### PR TITLE
Explicit tuples are not valid function parameters in Python 3

### DIFF
--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -110,7 +110,8 @@ if __name__ == "__main__":
 
   @jit
   def run_epoch(rng, opt_state):
-    def body_fun(i, (rng, opt_state, images)):
+    def body_fun(i, rng__opt_state__images):
+      (rng, opt_state, images) = rng__opt_state__images
       rng, elbo_rng, data_rng = random.split(rng, 3)
       batch = binarize_batch(data_rng, i, images)
       loss = lambda params: -elbo(elbo_rng, params, batch) / batch_size


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google/jax on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/mnist_vae.py:113:21: E999 SyntaxError: invalid syntax
    def body_fun(i, (rng, opt_state, images)):
                    ^
1     E999 SyntaxError: invalid syntax
1
```