### PR TITLE
[JAX] Change semantics of dtype promotion to just call numpy.result_type.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -152,8 +152,9 @@ def make_shaped_array(x):
   dtype = xla_bridge.canonicalize_dtype(onp.result_type(x))
   return ShapedArray(onp.shape(x), dtype)
 
-array_types = [onp.ndarray, onp.float64, onp.float32, onp.int64, onp.int32,
-               onp.bool_, onp.uint64, onp.uint32, float, int, bool]
+array_types = [onp.ndarray, onp.float64, onp.float32, onp.complex64,
+               onp.int64, onp.int32, onp.bool_, onp.uint64, onp.uint32, float,
+               int, bool]
 
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -126,10 +126,7 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    all_scalar = _all(isscalar(x) for x in args)
-    some_bools = _any(_dtype(x) == onp.dtype("bool") for x in args)
-    keep_all = all_scalar or some_bools
-    from_dtypes = (_dtype(x) for x in args if keep_all or not isscalar(x))
+    from_dtypes = (_dtype(x) for x in args)
     to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
     return [lax.convert_element_type(x, to_dtype)
             if _dtype(x) != to_dtype else x for x in args]

--- a/jax/random.py
+++ b/jax/random.py
@@ -187,7 +187,7 @@ def _random_bits(key, bit_width, shape):
   bits = threefry_2x32(key.keypair, onp.arange(max_count, dtype=onp.uint32))
   if bit_width == 64:
     bits = [lax.convert_element_type(x, onp.uint64) for x in np.split(bits, 2)]
-    bits = (bits[0] << 32) | bits[1]
+    bits = (bits[0] << onp.uint64(32)) | bits[1]
   return lax.reshape(bits, shape)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -39,8 +39,7 @@ all_shapes = [jtu.NUMPY_SCALAR_SHAPE] + array_shapes
 float_dtypes = [onp.float32, onp.float64]
 complex_dtypes = [onp.complex64]
 int_dtypes = [onp.int32, onp.int64]
-unsigned_dtypes = (
-    [onp.uint32, onp.uint64] if FLAGS.jax_enable_x64 else [onp.uint32])
+unsigned_dtypes = [onp.uint32, onp.uint64]
 bool_dtypes = [onp.bool_]
 default_dtypes = float_dtypes + int_dtypes
 numeric_dtypes = float_dtypes + complex_dtypes + int_dtypes
@@ -182,6 +181,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           _dtypes_are_compatible_for_bitwise_ops,
           CombosWithReplacement(rec.dtypes, rec.nargs)))
   def testBitwiseOp(self, onp_op, lnp_op, rng, shapes, dtypes):
+    if not FLAGS.jax_enable_x64 and any(
+        onp.iinfo(dtype).bits == 64 for dtype in dtypes):
+      self.skipTest("x64 types are disabled by jax_enable_x64")
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     self._CheckAgainstNumpy(onp_op, lnp_op, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=True)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -34,13 +34,13 @@ FLAGS = config.FLAGS
 
 array_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4), (2, 3, 4)]
 
-# TODO(b/120546360): add jtu.NUMPY_SCALAR_SHAPE when the coercion rules are
-# fixed so the tests pass.
-all_shapes = array_shapes
+all_shapes = [jtu.NUMPY_SCALAR_SHAPE] + array_shapes
 
 float_dtypes = [onp.float32, onp.float64]
 complex_dtypes = [onp.complex64]
 int_dtypes = [onp.int32, onp.int64]
+unsigned_dtypes = (
+    [onp.uint32, onp.uint64] if FLAGS.jax_enable_x64 else [onp.uint32])
 bool_dtypes = [onp.bool_]
 default_dtypes = float_dtypes + int_dtypes
 numeric_dtypes = float_dtypes + complex_dtypes + int_dtypes
@@ -57,10 +57,6 @@ def op_record(name, nargs, dtypes, rng, diff_modes, test_name=None):
 JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("abs", 1, default_dtypes, jtu.rand_default(), ["rev"]),
     op_record("add", 2, default_dtypes, jtu.rand_default(), ["rev"]),
-    op_record("bitwise_and", 2, int_dtypes, jtu.rand_bool(), []),
-    op_record("bitwise_not", 1, int_dtypes, jtu.rand_bool(), []),
-    op_record("bitwise_or", 2, int_dtypes, jtu.rand_bool(), []),
-    op_record("bitwise_xor", 2, int_dtypes, jtu.rand_bool(), []),
     op_record("ceil", 1, float_dtypes, jtu.rand_default(), []),
     op_record("conj", 1, numeric_dtypes, jtu.rand_default(), ["rev"]),
     op_record("conjugate", 1, numeric_dtypes, jtu.rand_default(), ["rev"]),
@@ -109,6 +105,17 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("where", 3, (onp.float32, onp.int64), jtu.rand_some_zero(), []),
 ]
 
+JAX_BITWISE_OP_RECORDS = [
+    op_record("bitwise_and", 2, int_dtypes + unsigned_dtypes,
+              jtu.rand_bool(), []),
+    op_record("bitwise_not", 1, int_dtypes + unsigned_dtypes,
+              jtu.rand_bool(), []),
+    op_record("bitwise_or", 2, int_dtypes + unsigned_dtypes,
+              jtu.rand_bool(), []),
+    op_record("bitwise_xor", 2, int_dtypes + unsigned_dtypes,
+              jtu.rand_bool(), []),
+]
+
 JAX_REDUCER_RECORDS = [
     op_record("all", 1, bool_dtypes, jtu.rand_default(), []),
     op_record("any", 1, bool_dtypes, jtu.rand_default(), []),
@@ -128,6 +135,22 @@ JAX_ARGMINMAX_RECORDS = [
 CombosWithReplacement = itertools.combinations_with_replacement
 
 
+def _dtypes_are_compatible_for_bitwise_ops(args):
+  if len(args) <= 1:
+    return True
+  is_signed = lambda dtype: onp.issubdtype(dtype, onp.signedinteger)
+  width = lambda dtype: onp.iinfo(dtype).bits
+  x, y = args
+  if width(x) > width(y):
+    x, y = y, x
+  # The following condition seems a little ad hoc, but seems to capture what
+  # numpy actually implements.
+  return (
+      is_signed(x) == is_signed(y)
+      or (width(x) == 32 and width(y) == 32)
+      or (width(x) == 32 and width(y) == 64 and is_signed(y)))
+
+
 class LaxBackedNumpyTests(jtu.JaxTestCase):
   """Tests for LAX-backed Numpy implementation."""
 
@@ -144,6 +167,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for shapes in CombosWithReplacement(all_shapes, rec.nargs)
       for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
   def testOp(self, onp_op, lnp_op, rng, shapes, dtypes):
+    args_maker = self._GetArgsMaker(rng, shapes, dtypes)
+    self._CheckAgainstNumpy(onp_op, lnp_op, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp_op, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(
+      {"testcase_name": jtu.format_test_name_suffix(rec.test_name, shapes,
+                                                    dtypes),
+       "rng": rec.rng, "shapes": shapes, "dtypes": dtypes,
+       "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name)}
+      for rec in JAX_BITWISE_OP_RECORDS
+      for shapes in CombosWithReplacement(all_shapes, rec.nargs)
+      for dtypes in filter(
+          _dtypes_are_compatible_for_bitwise_ops,
+          CombosWithReplacement(rec.dtypes, rec.nargs)))
+  def testBitwiseOp(self, onp_op, lnp_op, rng, shapes, dtypes):
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     self._CheckAgainstNumpy(onp_op, lnp_op, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=True)


### PR DESCRIPTION
* Enable tests for numpy scalars in lax_numpy_test.py.
* Fix invalid promotion in random.py.
* Split tests for bitwise ops into their own test case and test mixed signedness.
* Add complex64 to the set of types supported by abstractify.