### PR TITLE
Require protobuf 3.6.0 or later

### DIFF
--- a/build/setup.py
+++ b/build/setup.py
@@ -25,7 +25,7 @@ setup(
     author='JAX team',
     author_email='jax-dev@google.com',
     packages=['jaxlib'],
-    install_requires=['numpy>=1.12', 'six', 'protobuf', 'absl-py'],
+    install_requires=['numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={'jaxlib': binary_libs},

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jax', 'jax.lib', 'jax.interpreters', 'jax.numpy', 'jax.scipy',
               'jax.scipy.stats', 'jax.experimental'],
-    install_requires=['numpy>=1.12', 'six', 'protobuf', 'absl-py',
+    install_requires=['numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py',
                       'opt_einsum'],
     url='https://github.com/google/jax',
     license='Apache-2.0',


### PR DESCRIPTION
Installing from PIP, I got an error on import that `protobuf.descriptor.FileDescriptor`'s `__init__` method had no `serialized_options` argument. It looks like this argument was added in https://github.com/protocolbuffers/protobuf/commit/0400cca3236de1ca303af38bf81eab332d042b7c which appeared first in `protobuf` version 3.6.0. I had `protobuf` 3.5.0 on my system, which satisfies `jax`'s currently listed requirement of `protobuf` (with no version number) This updates the setup.py and build.py to require `protobuf>=3.6.0`.