### PR TITLE
More informative error on trying to concatenate zero-dimensional arrays

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -633,6 +633,8 @@ def stack(arrays):
 def concatenate(arrays, axis=0):
   if not arrays:
     raise ValueError("Need at least one array to concatenate.")
+  if ndim(arrays[0]) == 0:
+    raise ValueError("Zero-dimensional arrays cannot be concatenated.")
   return lax.concatenate(_promote_dtypes(*arrays), axis % ndim(arrays[0]))
 
 


### PR DESCRIPTION
When trying to concatenate a sequence of zero-dimensional arrays a `ZeroDivisionError: integer division or modulo by zero` exception is raised due to the modulo operation performed on the `axis` argument by the number of dimensions of the first array in the sequence:

https://github.com/google/jax/blob/fc4afb409b071a9d93738730b15c675662dec711/jax/numpy/lax_numpy.py#L632-L636

In comparison in NumPy a more informative exception is raised when attempting an equivalent function call: `ValueError: zero-dimensional arrays cannot be concatenated`. This PR adds equivalent error-handling to the `jax.numpy.concatenate` implementation.
