### PR TITLE
Automated detection of unimplemented functions

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from .lax_numpy import *
+from . lax_numpy import *

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from . lax_numpy import *
+from .lax_numpy import *

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from six.moves import builtins
 
 import six
-import math
 import numpy as onp
 
 from .. import core
@@ -862,7 +861,6 @@ def _not_implemented(fun):
   return wrapped
 
 # Build a set of all unimplemented NumPy functions.
-# TODO(alexbw): deal with numpy.random
 UNIMPLEMENTED_FUNCS = get_module_functions(onp) - set(IMPLEMENTED_FUNCS)
 for func in UNIMPLEMENTED_FUNCS:
   if func.__name__ not in globals():
@@ -1125,4 +1123,3 @@ setattr(DeviceArray, "T", property(transpose))
 
 # Extra methods that are handy
 setattr(DeviceArray, "broadcast", lax.broadcast)
-

--- a/jax/util.py
+++ b/jax/util.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 import functools
 import itertools as it
 from operator import mul
+import types
+import numpy as onp
 
 allow_memoize_hash_failures = False
 
@@ -154,3 +156,21 @@ class WrapHashably(object):
 
   def __eq__(self, other):
     return self.val is other.val
+
+
+
+def get_module_functions(module):
+  """Finds functions in module.
+  Args:
+    module: A Python module.
+  Returns:
+    module_fns: A set of functions, builtins or ufuncs in `module`.
+  """
+
+  module_fns = set()
+  for key in dir(module):
+    attr = getattr(module, key)
+    if isinstance(
+        attr, (types.BuiltinFunctionType, types.FunctionType, onp.ufunc)):
+      module_fns.add(attr)
+  return module_fns


### PR DESCRIPTION
Proposed mechanism for automatically detecting unimplemented functions. If this makes sense, we can put it in empty files for numpy.fft, numpy.linalg, numpy.random, all scipy, etc.

This also gives us a way of automatically tracking what is and isn't implemented, which might be useful for 20%ers and github contributors..