### PR TITLE
Make Jax buildable with the latest Bazel

### DIFF
--- a/build/WORKSPACE
+++ b/build/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "a38539c5b5c358548e75b44141b4ab637bba7c4dc02b46b1f62a96d6433f56ae",


### PR DESCRIPTION
Without this change build script fails with the following message: 

```
Encountered error while reading extension file 'tensorflow/workspace.bzl': no such package '@org_tensorflow//tensorflow': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
```

This PR simply implements the suggestion outlined in the error. I was able to successfully build against CUDA10 and latest cuDNN on Ubuntu 16.04, after applying this change.