### PR TITLE
Add build/ and dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 .bazelrc
 /tensorflow
 .DS_Store
+build/
+dist/


### PR DESCRIPTION
An alternative to installing `jax` using `pip install -e .` is to use `python setup.py`. This creates build/ and dist/ directories that should not be included in diffs since they are meant to be local.

This PR adds those entries to the .gitignore file