### PR TITLE
bazel CLI flags for test targets

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -16,6 +16,11 @@ licenses(["notice"])  # Apache 2
 
 load(":build_defs.bzl", "jax_test")
 
+config_setting(
+    name = "libjax_depend",
+    values = {"define": "libjax_depend=true"},
+)
+
 jax_test(
     name = "core_test",
     srcs = ["core_test.py"],

--- a/tests/build_defs.bzl
+++ b/tests/build_defs.bzl
@@ -31,9 +31,10 @@ def jax_test(
             fail("Only one test source file is currently supported.")
 
     # Deps that are linked into all test target variants.
-    all_test_deps = [
-        "//jax:libjax",
-    ]
+    all_test_deps = select({
+        ":libjax_depend": ["//jax:libjax"],
+        "//conditions:default": [],
+    })
     cpu_tags = ["jax_test_cpu"]
     gpu_tags = ["jax_test_gpu"]
     disabled_tags = ["manual", "notap", "disabled"]

--- a/tests/build_defs.bzl
+++ b/tests/build_defs.bzl
@@ -32,8 +32,10 @@ def jax_test(
 
     # Deps that are linked into all test target variants.
     all_test_deps = [
-        ":libjax",
+        "//jax:libjax",
     ]
+    cpu_tags = ["jax_test_cpu"]
+    gpu_tags = ["jax_test_gpu"]
     disabled_tags = ["manual", "notap", "disabled"]
     native.py_test(
         name = name + "_cpu",
@@ -43,7 +45,7 @@ def jax_test(
         deps = deps + all_test_deps,
         shard_count = shard_count.get("cpu") if shard_count else None,
         args = args + ["--jax_enable_x64=true --jax_test_dut=cpu --jax_platform_name=Host"],
-        tags = (disabled_tags if "cpu" in disable else []),
+        tags = cpu_tags + (disabled_tags if "cpu" in disable else []),
     )
     native.py_test(
         name = name + "_cpu_x32",
@@ -53,7 +55,7 @@ def jax_test(
         deps = deps + all_test_deps,
         shard_count = shard_count.get("cpu") if shard_count else None,
         args = args + ["--jax_enable_x64=false --jax_test_dut=cpu --jax_platform_name=Host"],
-        tags = (disabled_tags if "cpu" in disable else []),
+        tags = cpu_tags + (disabled_tags if "cpu" in disable else []),
     )
     native.py_test(
         name = name + "_gpu",
@@ -62,7 +64,7 @@ def jax_test(
         data = data,
         args = args + ["--jax_test_dut=gpu --jax_enable_x64=true --jax_platform_name=CUDA"],
         deps = deps + all_test_deps,
-        tags = ["requires-gpu-sm35"] + (disabled_tags if "gpu" in disable else []),
+        tags = gpu_tags + ["requires-gpu-sm35"] + (disabled_tags if "gpu" in disable else []),
         shard_count = shard_count.get("gpu") if shard_count else None,
     )
     native.py_test(
@@ -72,6 +74,6 @@ def jax_test(
         data = data,
         args = args + ["--jax_test_dut=gpu --jax_enable_x64=false --jax_platform_name=CUDA"],
         deps = deps + all_test_deps,
-        tags = ["requires-gpu-sm35"] + (disabled_tags if "gpu" in disable else []),
+        tags = gpu_tags + ["requires-gpu-sm35"] + (disabled_tags if "gpu" in disable else []),
         shard_count = shard_count.get("gpu") if shard_count else None,
     )


### PR DESCRIPTION
These changes add new tags to generated bazel test targets, so we can filter tests that get built and run using bazel's --test_tag_filters flag. For example:

    bazel test tests/... --test_tag_filters=-jax_test_gpu

builds and runs all targets except those generated to test jax compilation to GPU, and:

    bazel test tests/... --test_tag_filters=jax_test_cpu

builds and runs all targets generated to test CPU compilation.

Separately, generated test targets no longer build-depend on "//jax:libjax" by default. To require the dependency via CLI flag to bazel, use:

    bazel test tests/... --define libjax_depend=true