### PR TITLE
Add Cholesky, QR, and Triangular solve implementations.

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -1,0 +1,141 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as onp
+
+from jax.numpy import lax_numpy as np
+from jax import core
+from jax import lax
+from jax.interpreters import xla
+from jax.interpreters import ad
+from jax.util import partial
+from jax.abstract_arrays import ShapedArray
+from jax.core import Primitive
+from jax.lax import (standard_primitive, standard_unop, binop_dtype_rule,
+                     _float, _complex, _input_dtype)
+
+
+# traceables
+
+def cholesky(x): return cholesky_p.bind(x)
+
+def qr(x, full_matrices=True):
+  q, r = qr_p.bind(x, full_matrices=full_matrices)
+  return q, r
+
+def triangular_solve(a, b, left_side=False, lower=False, transpose_a=False,
+                     conjugate_a=False):
+  return triangular_solve_p.bind(
+      a, b, left_side=left_side, lower=lower, transpose_a=transpose_a,
+      conjugate_a=conjugate_a)
+
+
+# utilities
+
+def _T(x):
+  return np.swapaxes(x, -1, -2)
+
+
+# primitives
+
+
+def cholesky_jvp_rule(primals, tangents):
+  x, = primals
+  sigma_dot, = tangents
+  L = cholesky_p.bind(x)
+
+  # Forward-mode rule from https://arxiv.org/pdf/1602.07527.pdf
+  sigma_dot = (sigma_dot + _T(sigma_dot)) / 2
+  phi = lambda X: np.tril(X) / (1 + np.eye(x.shape[-1]))
+  tmp = triangular_solve(L, sigma_dot,
+                         left_side=False, transpose_a=True, lower=True)
+  L_dot = lax.dot(L, phi(triangular_solve(
+      L, tmp, left_side=True, transpose_a=False, lower=True)))
+  return L, L_dot
+
+cholesky_p = standard_unop(_float, 'cholesky')
+ad.primitive_jvps[cholesky_p] = cholesky_jvp_rule
+
+
+triangular_solve_dtype_rule = partial(
+    binop_dtype_rule, _input_dtype, (_float | _complex, _float | _complex),
+    'triangular_solve')
+
+def triangular_solve_shape_rule(a, b, left_side=False, **unused_kwargs):
+  if a.ndim < 2:
+    msg = "triangular_solve requires a.ndim to be at least 2, got {}."
+    raise TypeError(msg.format(a.ndim))
+  if a.shape[-1] != a.shape[-2]:
+    msg = ("triangular_solve requires the last two dimensions of a to be equal "
+           "in size, got a.shape of {}.")
+    raise TypeError(msg.format(a.shape))
+  if a.shape[:-2] != b.shape[:-2]:
+    msg = ("triangular_solve requires both arguments to have the same number "
+           "of dimensions and equal batch dimensions, got {} and {}.")
+    raise TypeError(msg.format(a.shape, b.shape))
+  common_dim = -2 if left_side else -1
+  if a.shape[-1] != b.shape[common_dim]:
+    msg = "Incompatible shapes for arguments to triangular_solve: {} and {}."
+    raise TypeError(msg.format(a.shape, b.shape))
+  return b.shape
+
+def triangular_solve_transpose_rule(
+    cotangent, a, b, left_side, lower, transpose_a, conjugate_a):
+  assert a is not None and b is None
+  cotangent_b = triangular_solve(a, cotangent, left_side, lower,
+                                 not transpose_a, conjugate_a)
+  return [None, cotangent_b]
+
+triangular_solve_p = standard_primitive(
+    triangular_solve_shape_rule, triangular_solve_dtype_rule,
+    'triangular_solve')
+ad.defjvp(triangular_solve_p,
+          None,
+          lambda g_b, a, b, **kwargs: triangular_solve(a, g_b, **kwargs))
+ad.primitive_transposes[triangular_solve_p] = triangular_solve_transpose_rule
+
+
+def qr_impl(operand, full_matrices):
+  q, r = xla.apply_primitive(qr_p, operand, full_matrices=full_matrices)
+  return core.pack((q, r))
+
+def qr_translation_rule(c, operand, full_matrices):
+  return c.QR(operand, full_matrices=full_matrices)
+
+def qr_abstract_eval(operand, full_matrices):
+  if isinstance(operand, ShapedArray):
+    if operand.ndim < 2:
+      raise ValueError("Argument to QR decomposition must have ndims >= 2")
+    batch_dims = operand.shape[:-2]
+    m = operand.shape[-2]
+    n = operand.shape[-1]
+    k = m if full_matrices else min(m, n)
+    q = ShapedArray(batch_dims + (m, k), operand.dtype)
+    r = ShapedArray(batch_dims + (k, n), operand.dtype)
+  else:
+    q = operand
+    r = operand
+  return core.AbstractTuple((q, r))
+
+def qr_dtype_rule(operand, full_matrices=True):
+  return operand.dtype
+
+qr_p = Primitive('qr')
+qr_p.def_impl(qr_impl)
+qr_p.def_abstract_eval(qr_abstract_eval)
+xla.translations[qr_p] = qr_translation_rule

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -16,11 +16,40 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+
 import numpy as onp
 
-from ..util import get_module_functions
+from .. import lax_linalg
 from .lax_numpy import _not_implemented
+from .lax_numpy import _wraps
 from .lax_numpy import IMPLEMENTED_FUNCS
+from . import lax_numpy as np
+from ..util import get_module_functions
+
+
+dot = np.dot
+matmul = np.matmul
+trace = np.trace
+
+
+@_wraps(onp.linalg.cholesky)
+def cholesky(a):
+  return lax_linalg.cholesky(a)
+
+
+@_wraps(onp.linalg.qr)
+def qr(a, mode="reduced"):
+  if mode in ("reduced", "r", "full"):
+    full_matrices = False
+  elif mode == "complete":
+    full_matrices = True
+  else:
+    raise ValueError("Unsupported QR decomposition mode '{}'".format(mode))
+  q, r = lax_linalg.qr(a, full_matrices)
+  if mode == "r":
+    return r
+  return q, r
+
 
 UNIMPLEMENTED_FUNCS = get_module_functions(onp.linalg) - set(IMPLEMENTED_FUNCS)
 for func in UNIMPLEMENTED_FUNCS:

--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from . import linalg
 from . import misc
 from . import special
 from . import stats

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import scipy.linalg
+
+from .. import lax_linalg
+from ..numpy.lax_numpy import _wraps
+from ..numpy import lax_numpy as np
+
+
+@_wraps(scipy.linalg.cholesky)
+def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
+  del overwrite_a, check_finite
+  if not lower:
+    raise NotImplementedError(
+        "The lower=False case of Cholesky is not implemented.")
+
+  return lax_linalg.cholesky(a)
+
+
+@_wraps(scipy.linalg.qr)
+def qr(a, overwrite_a=False, lwork=None, mode="full", pivoting=False,
+       check_finite=True):
+  del overwrite_a, lwork, check_finite
+  if pivoting:
+    raise NotImplementedError(
+        "The pivoting=True case of qr is not implemented.")
+  if mode in ("full", "r"):
+    full_matrices = True
+  elif mode == "economic":
+    full_matrices = True
+  else:
+    raise ValueError("Unsupported QR decomposition mode '{}'".format(mode))
+  q, r = lax_linalg.qr(a, full_matrices)
+  if mode == "r":
+    return r
+  return q, r
+
+
+@_wraps(scipy.linalg.solve_triangular)
+def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
+                     overwrite_b=False, debug=None, check_finite=True):
+  del overwrite_b, debug, check_finite
+
+  if unit_diagonal:
+    raise NotImplementedError("unit_diagonal=True is not implemented.")
+
+  if trans == 0 or trans == "N":
+    transpose_a, conjugate_a = False, False
+  elif trans == 1 or trans == "T":
+    transpose_a, conjugate_a = True, False
+  elif trans == 2 or trans == "C":
+    transpose_a, conjugate_a = True, True
+  else:
+    raise ValueError("Invalid 'trans' value {}".format(trans))
+
+  # lax_linalg.triangular_solve only supports matrix 'b's at the moment.
+  b_is_vector = np.ndim(a) == np.ndim(b) + 1
+  if b_is_vector:
+    b = b[..., None]
+  out = lax_linalg.triangular_solve(a, b, left_side=True, lower=lower,
+                                    transpose_a=transpose_a,
+                                    conjugate_a=conjugate_a)
+  if b_is_vector:
+    return out[..., 0]
+  else:
+    return out
+
+
+@_wraps(scipy.linalg.tril)
+def tril(m, k=0):
+  return np.tril(m, k)
+
+
+@_wraps(scipy.linalg.triu)
+def triu(m, k=0):
+  return np.triu(m, k)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -59,6 +59,14 @@ jax_test(
 )
 
 jax_test(
+    name = "linalg_test",
+    srcs = ["linalg_test.py"],
+    shard_count = {
+        "cpu": 2,
+    },
+)
+
+jax_test(
     name = "lax_scipy_test",
     srcs = ["lax_scipy_test.py"],
     shard_count = {

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1,0 +1,156 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LAPAX linear algebra module."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools
+
+import numpy as onp
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from jax import numpy as np
+from jax import scipy
+from jax import test_util as jtu
+from jax.lib import xla_bridge
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+T = lambda x: onp.swapaxes(x, -1, -2)
+
+
+def float_types():
+  return set(onp.dtype(xla_bridge.canonicalize_dtype(dtype))
+             for dtype in [onp.float32, onp.float64])
+
+
+class NumpyLinalgTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype, "rng": rng}
+      for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (1000, 0, 0)]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testCholesky(self, shape, dtype, rng):
+    def args_maker():
+      a = rng(shape, dtype)
+      return [onp.matmul(a, T(a))]
+
+    self._CheckAgainstNumpy(onp.linalg.cholesky, np.linalg.cholesky, args_maker,
+                            check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(np.linalg.cholesky, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}_fullmatrices={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), full_matrices),
+       "shape": shape, "dtype": dtype, "full_matrices": full_matrices,
+       "rng": rng}
+      for shape in [(1, 1), (3, 4), (2, 10, 5), (2, 200, 200)]
+      for dtype in float_types()
+      for full_matrices in [False, True]
+      for rng in [jtu.rand_default()]))
+  def testQr(self, shape, dtype, full_matrices, rng):
+    m, n = shape[-2:]
+
+    if full_matrices:
+      mode, k = "complete", m
+    else:
+      mode, k = "reduced", min(m, n)
+
+    a = rng(shape, dtype)
+    lq, lr = np.linalg.qr(a, mode=mode)
+
+    # onp.linalg.qr doesn't support broadcasting. But it seems like an
+    # inevitable extension so we support it in our version.
+    nq = onp.zeros(shape[:-2] + (m, k), dtype)
+    nr = onp.zeros(shape[:-2] + (k, n), dtype)
+    for index in onp.ndindex(*shape[:-2]):
+      nq[index], nr[index] = onp.linalg.qr(a[index], mode=mode)
+
+    max_rank = max(m, n)
+
+    # Norm, adjusted for dimension and type.
+    def norm(x):
+      n = onp.linalg.norm(x, axis=(-2, -1))
+      return n / (max_rank * onp.finfo(dtype).eps)
+
+    def compare_orthogonal(q1, q2):
+      # Q is unique up to sign, so normalize the sign first.
+      sum_of_ratios = onp.sum(onp.divide(q1, q2), axis=-2, keepdims=True)
+      phases = onp.divide(sum_of_ratios, onp.abs(sum_of_ratios))
+      q1 *= phases
+      self.assertTrue(onp.all(norm(q1 - q2) < 30))
+
+    # Check a ~= qr
+    self.assertTrue(onp.all(norm(a - onp.matmul(lq, lr)) < 30))
+
+    # Compare the first 'k' vectors of Q; the remainder form an arbitrary
+    # orthonormal basis for the null space.
+    compare_orthogonal(nq[..., :k], lq[..., :k])
+
+    # Check that q is close to unitary.
+    self.assertTrue(onp.all(norm(onp.eye(k) - onp.matmul(T(lq), lq)) < 5))
+
+
+class ScipyLinalgTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_lhs={}_rhs={}_lower={}_transposea={}".format(
+           jtu.format_shape_dtype_string(lhs_shape, dtype),
+           jtu.format_shape_dtype_string(rhs_shape, dtype),
+           lower, transpose_a),
+       "lower": lower, "transpose_a": transpose_a,
+       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
+       "rng": rng}
+      for lower, transpose_a in itertools.product([False, True], repeat=2)
+      for lhs_shape, rhs_shape in [
+          ((4, 4), (4,)),
+          ((4, 4), (4, 3)),
+          ((2, 8, 8), (2, 8, 10)),
+      ]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testSolveTriangularBlocked(self, lower, transpose_a, lhs_shape,
+                                 rhs_shape, dtype, rng):
+    k = rng(lhs_shape, dtype)
+    l = onp.linalg.cholesky(onp.matmul(k, T(k))
+                            + lhs_shape[-1] * onp.eye(lhs_shape[-1]))
+    l = l.astype(k.dtype)
+    b = rng(rhs_shape, dtype)
+
+    a = l if lower else T(l)
+    inv = onp.linalg.inv(T(a) if transpose_a else a).astype(a.dtype)
+    if len(lhs_shape) == len(rhs_shape):
+      onp_ans = onp.matmul(inv, b)
+    else:
+      onp_ans = onp.einsum("...ij,...j->...i", inv, b)
+
+    # The standard scipy.linalg.solve_triangular doesn't support broadcasting.
+    # But it seems like an inevitable extension so we support it.
+    ans = scipy.linalg.solve_triangular(
+        l if lower else T(l), b, trans=1 if transpose_a else 0, lower=lower)
+
+    self.assertAllClose(onp_ans, ans, check_dtypes=True)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
* Adds lax.{cholesky,triangular_solve,qr}. Adds a JVP for Cholesky.
* Adds a transpose rule for add_p, needed by the Cholesky JVP.
* Adds np.linalg.{cholesky,qr,dot,matmul,trace}.
* Adds scipy.linalg.{cholesky,qr,solve_triangular,tril,triu}.

Pair programmed with mattjj.

Partially addresses #44 