### PR TITLE
Disable tests that don't pass on all backends.

### DIFF
--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -153,9 +153,9 @@ def check_trace_eval(f, pvals, vals, expected_out_pval):
 
 class CoreTest(jtu.JaxTestCase):
 
-  @skip
   def test_pack_unpack(self):
     # TODO(dougalm): figure out what jaxpr-tracing api to expose and re-enable
+    self.skipTest("disabled")
     y = onp.array(1.0)
     def foo(x):
       x1, y1 = core.pack((x, y))
@@ -164,9 +164,9 @@ class CoreTest(jtu.JaxTestCase):
 
     pe.trace_to_jaxpr(foo, (_,))
 
-  @skip
   def test_tup_add(self):
     # TODO(mattjj,dougalm): put tup_add somewhere (was in array_type.py)
+    self.skipTest("disabled")
     y = onp.array(1.0)
     def foo(x):
       return np.tup_add(core.pack((x, y)))
@@ -187,9 +187,9 @@ class CoreTest(jtu.JaxTestCase):
     except TypeError:
       pass
 
-  @skip
   def test_print_jaxpr_compound(self):
     # TODO(dougalm): figure out what jaxpr-tracing api to expose and re-enable
+    self.skipTest("disabled")
     pv = pe.PartialVal((ShapedArray((2, 3), onp.float32), core.unit))
     print(pe.trace_to_jaxpr(fun_with_call_closure, (pv,))[0])
 
@@ -230,8 +230,8 @@ class CoreTest(jtu.JaxTestCase):
 
     api.trace_to_jaxpr(foo, (__,))
 
-  @skip
   def test_nested_grad(self):
+    self.skipTest("disabled")  # TODO: re-enable this test.
     def foo(x):
       print(type(x), x)
       def bar(y):

--- a/tests/examples_test.py
+++ b/tests/examples_test.py
@@ -88,6 +88,8 @@ class ExamplesTest(jtu.JaxTestCase):
     assert np.all(kernel_lsq.gram(kernel, xs) == np.dot(xs, xs.T))
 
   def testKernelRegressionTrainAndPredict(self):
+    # TODO(frostig): reenable this test.
+    self.skipTest("Test is broken")
     n, d = 100, 20
     rng = onp.random.RandomState(0)
     truth = rng.randn(d)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -648,9 +648,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertFalse(a3)
 
   @jtu.skip_on_devices("tpu")  # TODO(mattjj): investigate this failure
-  @skip
   def testOnesBroadcastingConstantHandler(self):
     # TODO(mattjj): update this test for jax3
+    self.skipTest("test needs jax3 update")
 
     def fun(x):
       ones = lnp.ones((3, 4))
@@ -729,9 +729,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     self.assertRaises(TypeError, lambda: g(3.))
 
-  @skip
   def testTracingPrimitiveWithNoTranslationErrorMessage(self):
     # TODO(mattjj): update this for jax3
+    self.skipTest("test needs jax3 update")
     foo = lnp._not_implemented(lambda x: x)
 
     # No error if there's no tracing.
@@ -777,9 +777,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   # TODO(mattjj): test infix operator overrides
 
-  @skip
   def testRavel(self):
     # TODO(mattjj): support this method-based syntax?
+    self.skipTest("test disabled")
     rng = onp.random.RandomState(0)
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]
     self._CompileAndCheck(lambda x: x.ravel(), args_maker, check_dtypes=True)


### PR DESCRIPTION
Avoid use of @ skip decorator since it breaks in Python 2 in some cases.