### PR TITLE
Implement np.linalg.inv using a QR decomposition.

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -30,10 +30,18 @@ dot = np.dot
 matmul = np.matmul
 trace = np.trace
 
+_T = lambda x: np.swapaxes(x, -1, -2)
 
 @_wraps(onp.linalg.cholesky)
 def cholesky(a):
   return lax_linalg.cholesky(a)
+
+@_wraps(onp.linalg.inv)
+def inv(a):
+  if np.ndim(a) < 2 or a.shape[-1] != a.shape[-2]:
+    raise ValueError("Argument to inv must have shape [..., n, n].")
+  q, r = qr(a, mode="complete")
+  return lax_linalg.triangular_solve(r, _T(q), lower=False, left_side=True)
 
 
 @_wraps(onp.linalg.qr)

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -39,8 +39,9 @@ def cholesky(a):
 @_wraps(onp.linalg.inv)
 def inv(a):
   if np.ndim(a) < 2 or a.shape[-1] != a.shape[-2]:
-    raise ValueError("Argument to inv must have shape [..., n, n].")
-  q, r = qr(a, mode="complete")
+    raise ValueError("Argument to inv must have shape [..., n, n], got {}."
+      .format(np.shape(a)))
+  q, r = qr(a)
   return lax_linalg.triangular_solve(r, _T(q), lower=False, left_side=True)
 
 

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -21,6 +21,7 @@ import scipy.linalg
 from .. import lax_linalg
 from ..numpy.lax_numpy import _wraps
 from ..numpy import lax_numpy as np
+from ..numpy import linalg as np_linalg
 
 
 @_wraps(scipy.linalg.cholesky)
@@ -31,6 +32,12 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
         "The lower=False case of Cholesky is not implemented.")
 
   return lax_linalg.cholesky(a)
+
+
+@_wraps(scipy.linalg.inv)
+def inv(a, overwrite_a=False, check_finite=True):
+  del overwrite_a, check_finite
+  return np_linalg.inv(a)
 
 
 @_wraps(scipy.linalg.qr)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -109,6 +109,27 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     # Check that q is close to unitary.
     self.assertTrue(onp.all(norm(onp.eye(k) - onp.matmul(T(lq), lq)) < 5))
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype, "rng": rng}
+      for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (5, 5, 5)]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testInv(self, shape, dtype, rng):
+    def args_maker():
+      a = rng(shape, dtype)
+      try:
+        onp.linalg.inv(a)
+        invertible = True
+      except onp.linalg.LinAlgError:
+        pass
+      return [a]
+
+    self._CheckAgainstNumpy(onp.linalg.inv, np.linalg.inv, args_maker,
+                            check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(np.linalg.inv, args_maker, check_dtypes=True)
+
 
 class ScipyLinalgTest(jtu.JaxTestCase):
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -118,12 +118,14 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for rng in [jtu.rand_default()]))
   def testInv(self, shape, dtype, rng):
     def args_maker():
-      a = rng(shape, dtype)
-      try:
-        onp.linalg.inv(a)
-        invertible = True
-      except onp.linalg.LinAlgError:
-        pass
+      invertible = False
+      while not invertible:
+        a = rng(shape, dtype)
+        try:
+          onp.linalg.inv(a)
+          invertible = True
+        except onp.linalg.LinAlgError:
+          pass
       return [a]
 
     self._CheckAgainstNumpy(onp.linalg.inv, np.linalg.inv, args_maker,


### PR DESCRIPTION
An LU decomposition would probably be preferable; we can switch the implementation when we have an LU decomposition.

Fixes #44.