### PR TITLE
array() was a noop on scalar types

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -85,6 +85,7 @@ shape = _shape = onp.shape
 ndim = _ndim = onp.ndim
 size = onp.size
 _dtype = lax._dtype
+dtype = onp.dtype
 
 uint32 = onp.uint32
 int32 = onp.int32
@@ -774,11 +775,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     else:
       return onp.array([], dtype)
   elif isscalar(object):
-    out = lax.reshape(object, ())
-    if dtype and _dtype(out) != dtype:
-      return lax.convert_element_type(out, dtype)
-    else:
-      return out
+    return lax.convert_element_type(object, dtype)
   else:
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 asarray = array


### PR DESCRIPTION
Also forwarding `onp.dtype`.

Fixes #121 