### PR TITLE
avoid materializing some special constants

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -27,9 +27,11 @@ from .lib import xla_bridge
 
 def concretization_err_msg(fun):
   fname = getattr(fun, "__name__", fun)
-  return ("Abstract value passed to function {} that requires a concrete value. "
-          "Possibly tracing Python control flow using abstract values. "
-          "If so, try using lax.cond or lax.while instead.").format(fname)
+  msg = ("Abstract value passed to `{}`, which requires a concrete value. "
+         "The function to be transformed can't be traced at the required level "
+         "of abstraction. If using `jit`, try using `static_argnums` or "
+         "applying `jit` to smaller subfunctions instead.")
+  return msg.format(fname)
 
 def concretization_function_error(fun):
   def error(self, *args):

--- a/jax/core.py
+++ b/jax/core.py
@@ -249,6 +249,8 @@ class Tracer(object):
   def __hex__(self): return self.aval._hex(self)
   def __oct__(self): return self.aval._oct(self)
 
+  def __setitem__(self, idx, val):
+    raise TypeError("JAX 'Tracer' objects do not support item assignment")
 
   def __getattr__(self, name):
     # if the aval property raises an AttributeError, gets caught here

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -340,12 +340,6 @@ def instantiate_device_constant(const, cutoff=1000000):
   else:
     return xb.device_put(onp.asarray(const))
 
-def register_device_constant(cls):
-  pytype_aval_mappings[cls] = pytype_aval_mappings[DeviceArray]
-  canonicalize_dtype_handlers[cls] = identity
-  core.pytype_aval_mappings[cls] = ConcreteArray
-  xb.register_constant_handler(cls, cls.constant_handler)
-
 
 def xla_shape(x):
   try:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -328,7 +328,7 @@ class DeviceConstant(DeviceArray):
     assert False
 
 # TODO(mattjj): tune cutoff
-def instantiate_device_constant(const, cutoff=1000000):
+def instantiate_device_constant(const, cutoff=0):
   # dispatch an XLA Computation to build the constant on the device if it's
   # large, or alternatively build it on the host and transfer it if it's small
   assert isinstance(const, DeviceConstant)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -327,8 +327,7 @@ class DeviceConstant(DeviceArray):
   def constant_handler(c, constant_instance):
     assert False
 
-# TODO(mattjj): tune cutoff
-def instantiate_device_constant(const, cutoff=0):
+def instantiate_device_constant(const, cutoff=1e6):
   # dispatch an XLA Computation to build the constant on the device if it's
   # large, or alternatively build it on the host and transfer it if it's small
   assert isinstance(const, DeviceConstant)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -263,7 +263,7 @@ class DeviceArray(DeviceValue):
 
   def __repr__(self):
     shape_str = ",".join(map(str, self.shape))
-    return "DeviceArray{{{}[{}]}}".format(self.dtype.name, shape_str)
+    return "DeviceArray{{{}[{}]}}".format(onp.dtype(self.dtype).name, shape_str)
 
   def __len__(self):
     try:

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -417,14 +417,14 @@ opaque_param_ids = itertools.count()
 def tie_in(x, y):
   return tie_in_p.bind(x, y)
 
-def full(shape, fill_value, dtype=None):
+def full(shape, fill_value, dtype):
   if onp.shape(fill_value):
     msg = "full must be called with scalar fill_value, got fill_value.shape {}."
     raise TypeError(msg.format(onp.shape(fill_value)))
+  dtype = xla_bridge.canonicalize_dtype(dtype)
 
   # For constants (defined as Python scalars, raw ndarrays, or DeviceValues),
   # create a FilledConstant value, otherwise just call broadcast.
-  dtype = dtype and xla_bridge.canonicalize_dtype(dtype)
   if onp.isscalar(fill_value) or type(fill_value) is onp.ndarray:
     return FilledConstant(onp.asarray(fill_value, dtype), shape)
   elif isinstance(fill_value, xla.DeviceValue):

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -355,6 +355,7 @@ def _ndarray_constant_handler(c, val):
     An XLA ComputationDataHandle / XlaOp representing the constant ndarray
     staged into the XLA Computation.
   """
+  # TODO(mattjj): revise this to use c.BroadcastInDim rather than Transpose
   if onp.any(onp.equal(0, val.strides)) and val.size > 0:
     zero_stride_axes, = onp.where(onp.equal(0, val.strides))
     other_axes, = onp.where(onp.not_equal(0, val.strides))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -794,33 +794,27 @@ asarray = array
 
 @_wraps(onp.zeros_like)
 def zeros_like(x, dtype=None):
-  return zeros(_shape(x), dtype or _dtype(x))
+  return lax.full_like(x, 0, dtype)
 
 
 @_wraps(onp.ones_like)
 def ones_like(x, dtype=None):
-  return ones(_shape(x), dtype or _dtype(x))
+  return lax.full_like(x, 1, dtype)
 
 
-@_wraps(onp.full)
-def full(shape, fill_value, dtype=None):
-  if dtype:
-    fill_value = lax.convert_element_type(fill_value, dtype)
-  return lax.broadcast(fill_value, tuple(shape))
+full = _wraps(onp.full)(lax.full)
 
 
 @_wraps(onp.zeros)
 def zeros(shape, dtype=onp.dtype("float64")):
   shape = (shape,) if onp.isscalar(shape) else shape
-  dtype = xla_bridge.canonicalize_dtype(dtype)
-  return onp.broadcast_to(onp.zeros((), dtype), tuple(shape))
+  return lax.full(shape, 0, dtype)
 
 
 @_wraps(onp.ones)
 def ones(shape, dtype=onp.dtype("float64")):
   shape = (shape,) if onp.isscalar(shape) else shape
-  dtype = xla_bridge.canonicalize_dtype(dtype)
-  return onp.broadcast_to(onp.ones((), dtype), tuple(shape))
+  return lax.full(shape, 1, dtype)
 
 
 @_wraps(onp.repeat)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -697,10 +697,6 @@ def allclose(a, b, rtol=1e-05, atol=1e-08):
 ### Array-creation functions
 
 
-arange = onp.arange
-eye = onp.eye
-
-
 @_wraps(onp.stack)
 def stack(arrays):
   if not arrays:
@@ -815,6 +811,48 @@ def zeros(shape, dtype=onp.dtype("float64")):
 def ones(shape, dtype=onp.dtype("float64")):
   shape = (shape,) if onp.isscalar(shape) else shape
   return lax.full(shape, 1, dtype)
+
+
+@_wraps(onp.eye)
+def eye(N, M=None, k=None, dtype=onp.dtype("float64")):
+  M = N if M is None else M
+  if k is None:
+    return lax.broadcasted_eye(dtype, (N, M), (0, 1))
+  else:
+    k_dtype = _dtype(k)
+    if not onp.issubdtype(k_dtype, onp.integer):
+      msg = "eye argument `k` must be of integer dtype, got {}"
+      raise TypeError(msg.format(k_dtype))
+    rows = k + lax.broadcasted_iota(k_dtype, (N, M), 0)
+    cols = lax.broadcasted_iota(k_dtype, (N, M), 1)
+    return lax.convert_element_type(lax.eq(rows, cols), dtype)
+
+
+@_wraps(onp.arange)
+def arange(*args, **kwargs):
+  nargs = len(args)
+  start, step = 0, 1
+  dtype = kwargs.pop("dtype", None)
+  if kwargs:
+    raise TypeError("arange only accepts 'dtype' kwarg, got {}".format(kwargs))
+  if nargs == 0:
+    raise TypeError("Required argument 'start' (pos 1) not found")  # same as numpy error
+  elif nargs == 1:
+    stop, = args
+    dtype = dtype or _dtype(stop)
+    return lax.iota(dtype, stop)  # avoids materializing
+  elif nargs == 2:
+    start, stop = args
+    dtype = dtype or onp.result_type(start, stop)
+  elif nargs == 3:
+    start, stop, step = args
+    dtype = dtype or onp.result_type(start, stop, step)
+  elif nargs == 4:
+    start, stop, step, dtype = args
+    dtype = dtype or onp.result_type(start, stop, step)
+
+  size = (stop - start - 1) // step + 1
+  return start + step * lax.iota(dtype, size)
 
 
 @_wraps(onp.repeat)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -798,7 +798,9 @@ def ones_like(x, dtype=None):
   return lax.full_like(x, 1, dtype)
 
 
-full = _wraps(onp.full)(lax.full)
+@_wraps(onp.full)
+def full(shape, fill_value, dtype=None):
+  return lax.full(shape, fill_value, dtype)
 
 
 @_wraps(onp.zeros)

--- a/jax/random.py
+++ b/jax/random.py
@@ -168,7 +168,7 @@ def split(key, num=2):
   Returns:
     A tuple of length `num` of new PRNGKey instances.
   """
-  counts = onp.arange(num * 2, dtype=onp.uint32)
+  counts = lax.iota(onp.uint32, num * 2)
   bits = lax.reshape(threefry_2x32(key.keypair, counts), (num, 2))
   keypairs = (lax.index_in_dim(bits, i, keepdims=False) for i in range(num))
   return tuple(PRNGKey.from_keypair((kp[0], kp[1])) for kp in keypairs)
@@ -183,7 +183,7 @@ def _random_bits(key, bit_width, shape):
     # TODO(mattjj): just split the key here
     raise TypeError("requesting more random bits than a single call provides.")
 
-  bits = threefry_2x32(key.keypair, onp.arange(max_count, dtype=onp.uint32))
+  bits = threefry_2x32(key.keypair, lax.iota(onp.uint32, max_count))
   if bit_width == 64:
     bits = [lax.convert_element_type(x, onp.uint64) for x in np.split(bits, 2)]
     bits = (bits[0] << onp.uint64(32)) | bits[1]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -180,17 +180,13 @@ class APITest(jtu.JaxTestCase):
 
     assert jit(f, static_argnums=(1,))(0, 5) == 10
     jtu.check_raises_regexp(
-        lambda: jit(f)(0, 5), TypeError,
-        "('JaxprTracer' object cannot be interpreted as an integer"
-        "|Abstract value passed to function.*)")
+        lambda: jit(f)(0, 5), TypeError, "Abstract value passed to .*")
 
   def test_casts(self):
     for castfun in [float, complex, hex, oct] + list(six.integer_types):
       f = lambda x: castfun(x)
       jtu.check_raises_regexp(
-          lambda: jit(f)(0), TypeError,
-          "('JaxprTracer' object cannot be interpreted as an integer"
-          "|Abstract value passed to function.*)")
+          lambda: jit(f)(0), TypeError, "Abstract value passed to .*")
 
   def test_unimplemented_interpreter_rules(self):
     foo_p = Primitive('foo')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -180,13 +180,17 @@ class APITest(jtu.JaxTestCase):
 
     assert jit(f, static_argnums=(1,))(0, 5) == 10
     jtu.check_raises_regexp(
-        lambda: jit(f)(0, 5), TypeError, "Abstract value passed to .*")
+        lambda: jit(f)(0, 5), TypeError,
+        "('JaxprTracer' object cannot be interpreted as an integer"
+        "|Abstract value passed to .*)")
 
   def test_casts(self):
     for castfun in [float, complex, hex, oct] + list(six.integer_types):
       f = lambda x: castfun(x)
       jtu.check_raises_regexp(
-          lambda: jit(f)(0), TypeError, "Abstract value passed to .*")
+          lambda: jit(f)(0), TypeError,
+          "('JaxprTracer' object cannot be interpreted as an integer"
+          "|Abstract value passed to .*)")
 
   def test_unimplemented_interpreter_rules(self):
     foo_p = Primitive('foo')


### PR DESCRIPTION
Whether using `@jit` or op-by-op mode, the fact that we're evaluating Python means that we might end up materializing some large regularly-structured constants, like the outputs of `np.arange` or `np.eye`. (We have a separate strategy for dealing with `np.zeros`, `np.ones`, and `np.full` based on creating zero-stride ndarrays and treating them in a special way, though this PR unifies their treatment.) That can be wasteful and make both compile- and run-times slower.

Instead, when using `@jit` we'd like code for generating these constants to be staged into the computation, and when calling functions op-by-op in many cases we'd probably like to execute code to generate the constant in device memory rather than materializing the constant on the host and transferring it.

A key motivating example is PRNG. Our count-based PRNG design means to generate 1e7 random values we map a hash function over a count vector of size 1e7. In the master branch, that means we create an array of length `1e7` on the CPU by calling `onp.arange(1e7)`, then we ship that to the device for the actual computation. Pretty dumb!

To avoid that, all we need is a bit of laziness. If we create lazy constant values, rather than materializing the constants outright, they have a chance to persist in their un-materialized form until they encounter a `jit` trace (or, for op-by-op mode, a computation to be applied on the device).

This PR adds lazy constant values as well as a `lax.tie_in` primitive for ensuring that constant values are hooked into the staged computation. It also updates the PRNG code to take advantage of these lazy constants, avoiding the pathology described above.

TODO:
  - [x] do some simple benchmarking [done](https://github.com/google/jax/pull/140#issuecomment-448350974)
  - [x] add unit tests
  - [x] tune the cutoff in xla.py instantiate_device_constant for when to materialize-and-transfer vs when to build-on-device for lazy constant arguments passed to computations [done](https://github.com/google/jax/pull/140#issuecomment-448433620)

Note for reviewer: a few commits up I experimented with making `lax.full` a primitive, but I didn't like the power:weight and so in bdc9e92f I opted for some type-testing in the traceable instead. Feedback welcome.