### PR TITLE
Fix implementation of ndarray.astype method, add a test.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1447,7 +1447,6 @@ def _swap_args(f):
   return lambda x, y: f(y, x)
 
 _operators = {
-    "astype": lax.convert_element_type,
     "getitem": _rewriting_take,
     "neg": negative,
     "eq": equal,
@@ -1507,6 +1506,7 @@ for method_name in _nondiff_methods + _diff_methods:
   setattr(ShapedArray, method_name, core.aval_method(globals()[method_name]))
 setattr(ShapedArray, "flatten", core.aval_method(ravel))
 setattr(ShapedArray, "T", core.aval_property(transpose))
+setattr(ShapedArray, "astype", core.aval_method(lax.convert_element_type))
 
 
 # Forward operators, methods, and properies on DeviceArray to lax_numpy
@@ -1517,6 +1517,7 @@ for method_name in _nondiff_methods + _diff_methods:
   setattr(DeviceArray, method_name, globals()[method_name])
 setattr(DeviceArray, "flatten", ravel)
 setattr(DeviceArray, "T", property(transpose))
+setattr(DeviceArray, "astype", lax.convert_element_type)
 
 
 # Extra methods that are handy

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -804,10 +804,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testRavel(self):
     # TODO(mattjj): support this method-based syntax?
-    self.skipTest("test disabled")
     rng = onp.random.RandomState(0)
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]
     self._CompileAndCheck(lambda x: x.ravel(), args_maker, check_dtypes=True)
+
+  def testAstype(self):
+    rng = onp.random.RandomState(0)
+    args_maker = lambda: [rng.randn(3, 4).astype("float32")]
+    op = lambda x: x.astype(lnp.int32)
+    self._CheckAgainstNumpy(op, op, args_maker, check_dtypes=True)
+    self._CompileAndCheck(op, args_maker, check_dtypes=True)
 
   # TODO(mattjj): test other ndarray-like method overrides
 


### PR DESCRIPTION
Previously we were creating an operator named `__astype__`, which isn't a thing in numpy.