### PR TITLE
fix einsum tensor product logic (fixes #37)

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1155,14 +1155,16 @@ def _einsum(operands, contractions):
         if lhs_batch != rhs_batch:
           rhs = moveaxis(rhs, rhs_batch, lhs_batch)
         batch_names = ''.join(lhs_names[i] for i in lhs_batch)
+        nbatch = len(batch_names)
 
-        names = batch_names + lhs_names + rhs_names
+        assert len(lhs_names) == lhs.ndim and len(rhs_names) == rhs.ndim
+        assert lhs_names.startswith(batch_names) and rhs_names.startswith(batch_names)
+
+        names = batch_names + lhs_names[nbatch:] + rhs_names[nbatch:]
         lhs_shape = iter(lhs.shape)
-        lhs_shape = [next(lhs_shape) if n in batch_names + lhs_names else 1
-                     for n in names]
+        lhs_shape = [next(lhs_shape) if n in lhs_names else 1 for n in names]
         rhs_shape = iter(rhs.shape)
-        rhs_shape = [next(rhs_shape) if n in batch_names + rhs_names else 1
-                     for n in names]
+        rhs_shape = [next(rhs_shape) if n in rhs_names else 1 for n in names]
         operand = lax.reshape(lhs, lhs_shape) * lax.reshape(rhs, rhs_shape)
 
     else:

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -81,6 +81,13 @@ class EinsumTest(jtu.JaxTestCase):
     s = 'nij,jk->nik'
     check(s, x, y)
 
+  def test_two_operands_6(self):
+    # based on https://github.com/google/jax/issues/37#issuecomment-448572187
+    x = rng().randn(2, 1)
+    y = rng().randn(2, 3, 4)
+    s = 'sa,shb->shab'
+    check(s, x, y)
+
   def test_one_operand_1(self):
     x = rng().randn(3, 4, 5)
     s = 'ijk->j'


### PR DESCRIPTION
The error was that `lhs_names` and `rhs_names` included `batch_names` as
prefixes, but the reshaping logic was written as if they did not include
batch_names (and so batch_names had to be prepended).