### PR TITLE
Add LU decomposition implementation backed by LAPACK on the CPU platform.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -213,6 +213,7 @@ pytype_aval_mappings = {}
 def abstractify_tuple(tup):
   return AbstractTuple(tuple(map(abstractify, tup)))
 pytype_aval_mappings[JaxTuple] = abstractify_tuple
+pytype_aval_mappings[AbstractTuple] = abstractify_tuple
 
 for t in array_types:
   pytype_aval_mappings[t] = make_shaped_array
@@ -320,6 +321,9 @@ pytype_aval_mappings[DeviceArray] = make_shaped_array
 canonicalize_dtype_handlers[DeviceArray] = identity
 xb.register_constant_handler(DeviceArray,
                              lambda c, val: c.Constant(onp.asarray(val)))
+
+pytype_aval_mappings[ConcreteArray] = make_shaped_array
+pytype_aval_mappings[ShapedArray] = lambda x: x
 
 
 class DeviceConstant(DeviceArray):

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -570,7 +570,8 @@ def fori_loop(lower, upper, body_fun, init_val):
   # The `lt` and `add` functions are added to the namespace programmatically.
   _, _, result = _while_loop(
       lambda upper_i_x: lt(upper_i_x[1], upper_i_x[0]),
-      lambda upper_i_x: (upper_i_x[0], add(upper_i_x[1], 1),
+      lambda upper_i_x: (upper_i_x[0],
+                         add(upper_i_x[1], onp.array(1, _dtype(upper_i_x[1]))),
                          body_fun(upper_i_x[1], upper_i_x[2])),
       (upper, lower, init_val))
   return result
@@ -2681,7 +2682,6 @@ def subvals(lst, replace):
 def _abstractify(x):
   # abstractify wrapper used internally for primitives like _while_loop
   if isinstance(x, core.Tracer):
-    # TODO(mattjj,dougalm): check that it's at least ShapedArray
-    return pe.PartialVal((x.aval, core.unit))
+    return pe.PartialVal((xla.abstractify(x.aval), core.unit))
   else:
     return pe.PartialVal((xla.abstractify(x), core.unit))

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -203,7 +203,10 @@ def lu_cpu_translation_rule(c, operand):
   else:
     raise NotImplementedError("Only unbatched LU decomposition is implemented")
 
-xla.backend_specific_translations['Host'][lu_p] = lu_cpu_translation_rule
+# TODO(phawkins): The hasattr() test here is to avoid incompatibilities between
+# jax and an older jaxlib. Remove after a jaxlib release includes jax_getrf.
+if hasattr(lapack, "jax_getrf"):
+  xla.backend_specific_translations['Host'][lu_p] = lu_cpu_translation_rule
 
 
 def lu_pivots_to_permutation(swaps, k):

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -28,11 +28,13 @@ from jax.abstract_arrays import ShapedArray
 from jax.core import Primitive
 from jax.lax import (standard_primitive, standard_unop, binop_dtype_rule,
                      _float, _complex, _input_dtype)
-import jaxlib
+from jaxlib import lapack
 
 # traceables
 
 def cholesky(x): return cholesky_p.bind(x)
+
+def lu(x): return lu_p.bind(x)
 
 def qr(x, full_matrices=True):
   q, r = qr_p.bind(x, full_matrices=full_matrices)
@@ -76,15 +78,14 @@ def cholesky_cpu_translation_rule(c, operand):
   shape = c.GetShape(operand)
   if len(shape.dimensions()) == 2 and (
     shape.element_type() == np.float32 or shape.element_type() == np.float64):
-    return c.GetTupleElement(jaxlib.lapack.jax_potrf(c, operand, lower=True), 0)
+    return c.GetTupleElement(lapack.jax_potrf(c, operand, lower=True), 0)
   else:
     # Fall back to the HLO implementation for batched Cholesky decomposition or
     # unsupported types.
     # TODO(phawkins): support LAPACK primitives in batched mode.
     return c.Cholesky(operand)
 
-if hasattr(jaxlib, "lapack"):
-  xla.backend_specific_translations['Host'][cholesky_p] = cholesky_cpu_translation_rule
+xla.backend_specific_translations['Host'][cholesky_p] = cholesky_cpu_translation_rule
 
 
 triangular_solve_dtype_rule = partial(
@@ -140,11 +141,11 @@ def triangular_solve_cpu_translation_rule(
     c, a, b, left_side, lower, transpose_a, conjugate_a):
   shape = c.GetShape(a)
   if len(shape.dimensions()) == 2 and shape.element_type() == np.float32:
-    return jaxlib.lapack.jax_trsm(
+    return lapack.jax_trsm(
       c, c.ConstantF32Scalar(1.0), a, b, left_side, lower, transpose_a,
       conjugate_a)
   elif len(shape.dimensions()) == 2 and shape.element_type() == np.float64:
-    return jaxlib.lapack.jax_trsm(
+    return lapack.jax_trsm(
       c, c.ConstantF64Scalar(1.0), a, b, left_side, lower, transpose_a,
       conjugate_a)
   else:
@@ -153,9 +154,78 @@ def triangular_solve_cpu_translation_rule(
     # TODO(phawkins): support BLAS primitives in batched mode.
     return c.TriangularSolve(a, b, left_side, lower, transpose_a, conjugate_a)
 
-if hasattr(jaxlib, "lapack"):
-  xla.backend_specific_translations['Host'][triangular_solve_p] = triangular_solve_cpu_translation_rule
+xla.backend_specific_translations['Host'][triangular_solve_p] = triangular_solve_cpu_translation_rule
 
+
+# LU decomposition
+
+# Computes a pivoted LU decomposition such that
+# PA = LU
+# In the style of LAPACK, LU are stored in the same matrix.
+# TODO(phawkins): add a mechanism to report errors for singular matrices.
+
+def lu_impl(operand):
+  lu, pivot = xla.apply_primitive(lu_p, operand)
+  return core.pack((lu, pivot))
+
+def lu_translation_rule(c, operand):
+  raise NotImplementedError(
+    "LU decomposition is only implemented on the CPU backend")
+
+def lu_abstract_eval(operand):
+  if isinstance(operand, ShapedArray):
+    if operand.ndim < 2:
+      raise ValueError("Argument to LU decomposition must have ndims >= 2")
+
+    batch_dims = operand.shape[:-2]
+    m = operand.shape[-2]
+    n = operand.shape[-1]
+    pivot = ShapedArray(batch_dims + (min(m, n),), np.int32)
+  else:
+    pivot = operand
+  return core.AbstractTuple((operand, pivot))
+
+lu_p = Primitive('lu')
+lu_p.def_impl(lu_impl)
+lu_p.def_abstract_eval(lu_abstract_eval)
+xla.translations[lu_p] = lu_translation_rule
+
+def lu_cpu_translation_rule(c, operand):
+  shape = c.GetShape(operand)
+  if len(shape.dimensions()) == 2 and (
+    shape.element_type() == np.float32 or shape.element_type() == np.float64):
+    out = lapack.jax_getrf(c, operand)
+    lu = c.GetTupleElement(out, 0)
+    # Subtract 1 from the pivot to get 0-based indices.
+    pivot = c.Sub(c.GetTupleElement(out, 1), c.ConstantS32Scalar(1))
+    # Throw away the `info` value, because we have no way to report errors.
+    return c.Tuple(lu, pivot)
+  else:
+    raise NotImplementedError("Only unbatched LU decomposition is implemented")
+
+xla.backend_specific_translations['Host'][lu_p] = lu_cpu_translation_rule
+
+
+def lu_pivots_to_permutation(swaps, k):
+  """Converts the pivots (row swaps) returned by LU to a permutation."""
+
+  def body_fn(i, loop_carry):
+    swaps, permutation = loop_carry
+    j = swaps[i]
+    x, y = np.ravel(permutation[i]), np.ravel(permutation[j])
+    permutation = lax.dynamic_update_index_in_dim(permutation, y, i, axis=0)
+    permutation = lax.dynamic_update_index_in_dim(permutation, x, j, axis=0)
+    return swaps, permutation
+
+  n, = np.shape(swaps)
+  permutation = np.arange(k)
+  _, permutation = lax.fori_loop(onp.array(0, onp.int32), onp.array(n, onp.int32),
+                                 body_fn, (swaps, permutation))
+  return permutation
+
+
+
+# QR decomposition
 
 def qr_impl(operand, full_matrices):
   q, r = xla.apply_primitive(qr_p, operand, full_matrices=full_matrices)
@@ -178,9 +248,6 @@ def qr_abstract_eval(operand, full_matrices):
     q = operand
     r = operand
   return core.AbstractTuple((q, r))
-
-def qr_dtype_rule(operand, full_matrices=True):
-  return operand.dtype
 
 def qr_jvp_rule(primals, tangents, full_matrices):
   # See j-towns.github.io/papers/qr-derivative.pdf for a terse derivation.

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import numpy as onp
 import warnings
 
+from .. import lax
 from .. import lax_linalg
 from .lax_numpy import _not_implemented
 from .lax_numpy import _wraps
@@ -34,6 +35,19 @@ _T = lambda x: np.swapaxes(x, -1, -2)
 def cholesky(a):
   warnings.warn(_EXPERIMENTAL_WARNING)
   return lax_linalg.cholesky(a)
+
+
+@_wraps(onp.linalg.det)
+def det(a):
+  dtype = lax._dtype(a)
+  a_shape = np.shape(a)
+  if len(a_shape) != 2 or a_shape[-1] != a_shape[-2]:
+    msg = "Argument to det() must be a square matrix, got {}"
+    raise ValueError(msg.format(a_shape))
+  lu, pivot = lax_linalg.lu(a)
+  parity = np.count_nonzero(pivot != np.arange(a_shape[-1])) % 2
+  return np.prod(np.diagonal(lu)) * np.array(-2 * parity + 1, dtype=dtype)
+
 
 @_wraps(onp.linalg.inv)
 def inv(a):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -63,6 +63,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.cholesky, args_maker, check_dtypes=True)
 
+  # TODO(phawkins): enable when there is an LU implementation for GPU/TPU.
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
@@ -70,7 +71,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for n in [0, 4, 5, 200]
       for dtype in float_types()
       for rng in [jtu.rand_default()]))
+  @jtu.skip_on_devices("gpu", "tpu")
   def testDet(self, n, dtype, rng):
+    if not hasattr(lapack, "jax_getrf"):
+      self.skipTest("No LU implementation available")
     args_maker = lambda: [rng((n, n), dtype)]
 
     self._CheckAgainstNumpy(onp.linalg.det, np.linalg.det, args_maker,
@@ -159,6 +163,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
 class ScipyLinalgTest(jtu.JaxTestCase):
 
+  # TODO(phawkins): enable when there is an LU implementation for GPU/TPU.
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
@@ -166,13 +171,18 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 5), (10, 5), (50, 50)]
       for dtype in float_types()
       for rng in [jtu.rand_default()]))
+  @jtu.skip_on_devices("gpu", "tpu")
   def testLu(self, shape, dtype, rng):
+    # TODO(phawkins): remove this after a jaxlib release.
+    if not hasattr(lapack, "jax_getrf"):
+      self.skipTest("No LU implementation available")
     args_maker = lambda: [rng(shape, dtype)]
 
     self._CheckAgainstNumpy(osp.linalg.lu, jsp.linalg.lu, args_maker,
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp.linalg.lu, args_maker, check_dtypes=True)
 
+  # TODO(phawkins): enable when there is an LU implementation for GPU/TPU.
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
@@ -180,7 +190,11 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for n in [1, 4, 5, 200]
       for dtype in float_types()
       for rng in [jtu.rand_default()]))
+  @jtu.skip_on_devices("gpu", "tpu")
   def testLuFactor(self, n, dtype, rng):
+    # TODO(phawkins): remove this after a jaxlib release.
+    if not hasattr(lapack, "jax_getrf"):
+      self.skipTest("No LU implementation available")
     args_maker = lambda: [rng((n, n), dtype)]
 
     self._CheckAgainstNumpy(osp.linalg.lu_factor, jsp.linalg.lu_factor,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -21,15 +21,18 @@ from functools import partial
 import itertools
 
 import numpy as onp
+import scipy as osp
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
 from jax import jvp
 from jax import numpy as np
-from jax import scipy
+from jax import scipy as jsp
 from jax import test_util as jtu
 from jax.lib import xla_bridge
+
+from jaxlib import lapack
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -59,6 +62,21 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp.linalg.cholesky, np.linalg.cholesky, args_maker,
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.cholesky, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
+       "n": n, "dtype": dtype, "rng": rng}
+      for n in [0, 4, 5, 200]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testDet(self, n, dtype, rng):
+    args_maker = lambda: [rng((n, n), dtype)]
+
+    self._CheckAgainstNumpy(onp.linalg.det, np.linalg.det, args_maker,
+                            check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(np.linalg.det, args_maker, check_dtypes=True)
+
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_fullmatrices={}".format(
@@ -143,6 +161,35 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
+       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype, "rng": rng}
+      for shape in [(1, 1), (4, 5), (10, 5), (50, 50)]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testLu(self, shape, dtype, rng):
+    args_maker = lambda: [rng(shape, dtype)]
+
+    self._CheckAgainstNumpy(osp.linalg.lu, jsp.linalg.lu, args_maker,
+                            check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(jsp.linalg.lu, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
+       "n": n, "dtype": dtype, "rng": rng}
+      for n in [1, 4, 5, 200]
+      for dtype in float_types()
+      for rng in [jtu.rand_default()]))
+  def testLuFactor(self, n, dtype, rng):
+    args_maker = lambda: [rng((n, n), dtype)]
+
+    self._CheckAgainstNumpy(osp.linalg.lu_factor, jsp.linalg.lu_factor,
+                            args_maker, check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(jsp.linalg.lu_factor, args_maker, check_dtypes=True)
+
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
        "_lhs={}_rhs={}_lower={}_transposea={}".format(
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype),
@@ -158,7 +205,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       ]
       for dtype in float_types()
       for rng in [jtu.rand_default()]))
-  def testSolveTriangularBlocked(self, lower, transpose_a, lhs_shape,
+  def testSolveTriangular(self, lower, transpose_a, lhs_shape,
                                  rhs_shape, dtype, rng):
     k = rng(lhs_shape, dtype)
     l = onp.linalg.cholesky(onp.matmul(k, T(k))
@@ -175,7 +222,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     # The standard scipy.linalg.solve_triangular doesn't support broadcasting.
     # But it seems like an inevitable extension so we support it.
-    ans = scipy.linalg.solve_triangular(
+    ans = jsp.linalg.solve_triangular(
         l if lower else T(l), b, trans=1 if transpose_a else 0, lower=lower)
 
     self.assertAllClose(onp_ans, ans, check_dtypes=True)
@@ -197,13 +244,13 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       ]
       for dtype in float_types()
       for rng in [jtu.rand_default()]))
-  def testSolveTriangularBlockedGrad(self, lower, transpose_a, lhs_shape,
+  def testSolveTriangularGrad(self, lower, transpose_a, lhs_shape,
                                      rhs_shape, dtype, rng):
     # TODO(frostig): change ensemble to support a bigger rtol
     A = np.tril(rng(lhs_shape, dtype) + 5 * onp.eye(lhs_shape[-1], dtype=dtype))
     A = A if lower else T(A)
     B = rng(rhs_shape, dtype)
-    f = partial(scipy.linalg.solve_triangular, lower=lower,
+    f = partial(jsp.linalg.solve_triangular, lower=lower,
                 trans=1 if transpose_a else 0)
     jtu.check_grads(f, (A, B), 2, rtol=1e-3)
 


### PR DESCRIPTION
Implement np.linalg.det, and scipy.linalg.{lu,lu_factor,det}.

Add missing abstractification to loop arguments.
Implement XLA abstractification rules for AbstractTuple, ConcreteArray, and ShapedArray.