### PR TITLE
Use get() rather than a try-catch block in memoized function lookup.

### DIFF
--- a/jax/util.py
+++ b/jax/util.py
@@ -126,20 +126,24 @@ def split_merge(predicate, xs):
   return lhs, rhs, merge
 
 
+class _MemoizeNoEntry(object):
+  pass
+
+_NO_MEMO_ENTRY = _MemoizeNoEntry
+
 def memoize(fun):
   cache = {}
   def memoized_fun(*args, **kwargs):
     key = (args, tuple(kwargs and sorted(kwargs.items())))
     try:
-      return cache[key]
-    except KeyError:
-      ans = cache[key] = fun(*args, **kwargs)
-      return ans
+      ans = cache.get(key, _NO_MEMO_ENTRY)
+      if ans != _NO_MEMO_ENTRY:
+        return ans
     except TypeError:
-      if allow_memoize_hash_failures:
-        return fun(*args, **kwargs)
-      else:
+      if not allow_memoize_hash_failures:
         raise
+    ans = cache[key] = fun(*args, **kwargs)
+    return ans
   return memoized_fun
 
 


### PR DESCRIPTION
Currently backtraces often look like this:
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/p/jax/jax/util.py in memoized_fun(*args, **kwargs)
    133     try:
--> 134       return cache[key]
    135     except KeyError:

KeyError: ((lu, ShapedArray(int32[2,2])), ())

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
~/p/jax/jax/util.py in memoized_fun(*args, **kwargs)
    133     try:
--> 134       return cache[key]
    135     except KeyError:

KeyError: ((lu, xla_client.Shape(_dtype=dtype('int32'), _dimensions=(2, 2), _is_tuple=False, _minor_to_major=None)), ())

During handling of the above exception, another exception occurred:

NotImplementedError                       Traceback (most recent call last)
<ipython-input-26-d6c00d50e3c9> in <module>
```

The "during handling of the above exception..." message is mostly a distraction for the user that occurs because we perform the memoized function evaluation inside a `catch` block. By performing the function evaluation outside the catch block, we can get better backtraces without the distraction of the KeyError exception.

```