### PR TITLE
support x[[0, 2, 4], [0, 2, 4]] indexing, fix #187

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1510,7 +1510,7 @@ def _rewriting_take(arr, idx, axis=0):
   # Handle integer array indexing *without* ellipsis/slices/nones
   # https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#integer-array-indexing
   if _is_advanced_int_indexer_without_slices(idx):
-    if isinstance(idx, list):
+    if isinstance(idx, (tuple, list)):
       if _any(_shape(e) for e in idx):
         # At least one sequence element in the index list means broadcasting.
         idx = broadcast_arrays(*idx)
@@ -1521,7 +1521,7 @@ def _rewriting_take(arr, idx, axis=0):
       # The indexer is just a single integer array.
       idx = [idx]
 
-    flat_idx = tuple(mod(ravel(x), arr.shape[i]) for i, x in enumerate(idx))
+    flat_idx = tuple([mod(ravel(x), arr.shape[i]) for i, x in enumerate(idx)])
     out = lax.index_take(arr, flat_idx, tuple(range(len(idx))))
     return lax.reshape(out, idx[0].shape + _shape(arr)[len(idx):])
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -398,6 +398,10 @@ class IndexingTest(jtu.JaxTestCase):
            [IndexSpec(shape=(3, 4, 5), indexer=[[0, 1]]),
             IndexSpec(shape=(3, 4, 5), indexer=[[[0], [-1]], [[2, 3, 0, 3]]]),
             ]),
+          ("TupleOfListsOfPythonInts",
+           [IndexSpec(shape=(3, 4, 5), indexer=([0, 1])),
+            IndexSpec(shape=(3, 4, 5), indexer=([[0], [-1]], [[2, 3, 0, 3]])),
+            ]),
           ("ListOfPythonIntsAndIntArrays",
            [IndexSpec(shape=(3, 4, 5), indexer=[0, onp.array([0, 1])]),
             IndexSpec(shape=(3, 4, 5), indexer=[0, 1,
@@ -629,6 +633,15 @@ class IndexingTest(jtu.JaxTestCase):
     x = onp.zeros(3)
     i = onp.array([True, True, False])
     self.assertRaises(IndexError, lambda: api.jit(lambda x, i: x[i])(x, i))
+
+  def testIssue187(self):
+    x = lnp.ones((5, 5))
+    x[[0, 2, 4], [0, 2, 4]]  # doesn't crash
+
+    x = onp.arange(25).reshape((5, 5))
+    ans = api.jit(lambda x: x[[0, 2, 4], [0, 2, 4]])(x)
+    expected = x[[0, 2, 4], [0, 2, 4]]
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The issue was just an `isinstance(idx, list)` that should have been an `isisinstance(idx, (tuple, list))`. We had it right elsewhere, and in comments immediately above the offending line.