### PR TITLE
Add SVD to jax/numpy/linalg, jax/scipy/linalg

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -40,6 +40,13 @@ def qr(x, full_matrices=True):
   q, r = qr_p.bind(x, full_matrices=full_matrices)
   return q, r
 
+def svd(x, full_matrices=True, compute_uv=True):
+  s, u, v = qr_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
+  if compute_uv:
+    return s, u, v
+  else:
+    return s
+
 def triangular_solve(a, b, left_side=False, lower=False, transpose_a=False,
                      conjugate_a=False):
   return triangular_solve_p.bind(
@@ -271,3 +278,36 @@ qr_p.def_impl(qr_impl)
 qr_p.def_abstract_eval(qr_abstract_eval)
 xla.translations[qr_p] = qr_translation_rule
 ad.primitive_jvps[qr_p] = qr_jvp_rule
+
+
+# SVD decomposition
+
+def svd_impl(operand, full_matrices, compute_uv):
+  s, u, vt = xla.apply_primitive(svd_p, operand, full_matrices=full_matrices, compute_uv=compute_uv)
+  return core.pack((s, u, vt))
+
+def svd_translation_rule(c, operand):
+  raise NotImplementedError(
+    "SVD is only implemented on the CPU backend")
+
+def svd_abstract_eval(operand, full_matrices, compute_uv):
+  if isinstance(operand, ShapedArray):
+    if operand.ndim < 2:
+      raise ValueError("Argument to SVD must have ndims >= 2")
+
+    batch_dims = operand.shape[:-2]
+    m = operand.shape[-2]
+    n = operand.shape[-1]
+    s = ShapedArray(batch_dims + (min(m, n),), operand.dtype)
+    u = ShapedArray(batch_dims + (m, m if full_matrices else min(m, n)), operand.dtype)
+    vt = ShapedArray(batch_dims + (n if full_matrices else min(m, n), n), operand.dtype)
+  else:
+    s = operand
+    u = operand
+    vt = operand
+  return core.AbstractTuple((s, u, vt))
+
+svd_p = Primitive('svd')
+svd_p.def_impl(svd_impl)
+svd_p.def_abstract_eval(svd_abstract_eval)
+xla.translations[svd_p] = svd_translation_rule

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -45,7 +45,7 @@ def qr(x, full_matrices=True):
 def svd(x, full_matrices=True, compute_uv=True):
   s, u, v = svd_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
   if compute_uv:
-    return s, u, v
+    return u, s, v
   else:
     return s
 
@@ -325,7 +325,7 @@ xla.translations[qr_p] = qr_translation_rule
 ad.primitive_jvps[qr_p] = qr_jvp_rule
 
 
-# SVD decomposition
+# Singular value decomposition
 
 def svd_impl(operand, full_matrices, compute_uv):
   s, u, vt = xla.apply_primitive(svd_p, operand, full_matrices=full_matrices, compute_uv=compute_uv)

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -41,7 +41,7 @@ def qr(x, full_matrices=True):
   return q, r
 
 def svd(x, full_matrices=True, compute_uv=True):
-  s, u, v = qr_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
+  s, u, v = svd_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
   if compute_uv:
     return s, u, v
   else:
@@ -286,14 +286,14 @@ def svd_impl(operand, full_matrices, compute_uv):
   s, u, vt = xla.apply_primitive(svd_p, operand, full_matrices=full_matrices, compute_uv=compute_uv)
   return core.pack((s, u, vt))
 
-def svd_translation_rule(c, operand):
+def svd_translation_rule(c, operand, full_matrices, compute_uv):
   raise NotImplementedError(
-    "SVD is only implemented on the CPU backend")
+    "Singular value decomposition is only implemented on the CPU backend")
 
 def svd_abstract_eval(operand, full_matrices, compute_uv):
   if isinstance(operand, ShapedArray):
     if operand.ndim < 2:
-      raise ValueError("Argument to SVD must have ndims >= 2")
+      raise ValueError("Argument to singular value decomposition must have ndims >= 2")
 
     batch_dims = operand.shape[:-2]
     m = operand.shape[-2]
@@ -307,7 +307,20 @@ def svd_abstract_eval(operand, full_matrices, compute_uv):
     vt = operand
   return core.AbstractTuple((s, u, vt))
 
+def svd_cpu_translation_rule(c, operand, full_matrices, compute_uv):
+  shape = c.GetShape(operand)
+  dtype = shape.element_type().type
+  if len(shape.dimensions()) == 2 and dtype in {np.float32, np.float64}:
+    out = lapack.jax_gesdd(c, operand, full_matrices=full_matrices, compute_uv=compute_uv)
+    return c.Tuple(c.GetTupleElement(out, 0),
+                   c.GetTupleElement(out, 1),
+                   c.GetTupleElement(out, 2))
+  else:
+    raise NotImplementedError(
+        "Only unbatched singular value decomposition for real matrices is implemented on CPU")
+
 svd_p = Primitive('svd')
 svd_p.def_impl(svd_impl)
 svd_p.def_abstract_eval(svd_abstract_eval)
 xla.translations[svd_p] = svd_translation_rule
+xla.backend_specific_translations['Host'][svd_p] = svd_cpu_translation_rule

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -40,6 +40,7 @@ def cholesky(a):
 @_wraps(onp.linalg.svd)
 def svd(a, full_matrices=True, compute_uv=True):
   warnings.warn(_EXPERIMENTAL_WARNING)
+  a = _promote_arg_dtypes(np.asarray(a))
   return lax_linalg.svd(a, full_matrices, compute_uv)
 
 

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -37,6 +37,12 @@ def cholesky(a):
   return lax_linalg.cholesky(a)
 
 
+@_wraps(onp.linalg.svd)
+def svd(a, full_matrices=True, compute_uv=True):
+  warnings.warn(_EXPERIMENTAL_WARNING)
+  return lax_linalg.svd(a, full_matrices, compute_uv)
+
+
 @_wraps(onp.linalg.slogdet)
 def slogdet(a):
   dtype = lax._dtype(a)

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -39,6 +39,13 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
   return l if lower else np.conj(l.T)
 
 
+@_wraps(scipy.linalg.svd)
+def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False, check_finite=True, lapack_driver='gesdd'):
+  warnings.warn(_EXPERIMENTAL_WARNING)
+  del overwrite_a, check_finite, lapack_driver
+  return lax_linalg.svd(a)
+
+
 @_wraps(scipy.linalg.det)
 def det(a, overwrite_a=False, check_finite=True):
   warnings.warn(_EXPERIMENTAL_WARNING)

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -43,7 +43,8 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False, check_finite=True, lapack_driver='gesdd'):
   warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite, lapack_driver
-  return lax_linalg.svd(a)
+  a = np_linalg._promote_arg_dtypes(np.asarray(a))
+  return lax_linalg.svd(a, full_matrices, compute_uv)
 
 
 @_wraps(scipy.linalg.det)

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -28,7 +28,7 @@ from cpython.pycapsule cimport PyCapsule_New
 from scipy.linalg.cython_blas cimport strsm, dtrsm, ctrsm
 from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf
 from scipy.linalg.cython_lapack cimport spotrf, dpotrf, cpotrf
-from scipy.linalg.cython_lapack cimport sgesdd, dgesdd, cgesdd
+from scipy.linalg.cython_lapack cimport sgesdd, dgesdd
 from scipy.linalg.cython_lapack cimport ssyevd, dsyevd, cheevd
 
 import numpy as np
@@ -388,7 +388,7 @@ def jax_potrf(c, a, lower=False):
       ))
 
 
-# ?gesdd: SVD decomposition
+# ?gesdd: Singular value decomposition
 
 cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
   cdef int32_t job_opt_full_matrices = (<int32_t*>(data[0]))[0]

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -421,7 +421,7 @@ cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
   if job_opt_full_matrices == 0:
     ldvt = min(m, n)
 
-  cdef int* iwork = <int *> malloc(min(m, n) * sizeof(int))
+  cdef int* iwork = <int *> malloc(8 * min(m, n) * sizeof(int))
 
   # First perform a workspace query to get the optimal lwork
   # NB: We perform a workspace query with malloc and free for the work array, 
@@ -471,7 +471,7 @@ cdef void lapack_dgesdd(void* out_tuple, void** data) nogil:
   if job_opt_full_matrices == 0:
     ldvt = min(m, n)
 
-  cdef int* iwork = <int *> malloc(min(m, n) * sizeof(int))
+  cdef int* iwork = <int *> malloc(8 * min(m, n) * sizeof(int))
 
   # First perform a workspace query to get the optimal lwork
   # NB: We perform a workspace query with malloc and free for the work array, 

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -19,6 +19,7 @@
 
 from __future__ import print_function
 
+from libc.stdlib cimport malloc, free
 from libc.stdint cimport int32_t
 from libc.string cimport memcpy
 from libcpp.string cimport string
@@ -390,10 +391,11 @@ def jax_potrf(c, a, lower=False):
 # ?gesdd: SVD decomposition
 
 cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
-  cdef int32_t job_opt = (<int32_t*>(data[0]))[0]
-  cdef int m = (<int32_t*>(data[1]))[0]
-  cdef int n = (<int32_t*>(data[2]))[0]
-  cdef float* a_in = <float*>(data[3])
+  cdef int32_t job_opt_some = (<int32_t*>(data[0]))[0]
+  cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
+  cdef int m = (<int32_t*>(data[2]))[0]
+  cdef int n = (<int32_t*>(data[3]))[0]
+  cdef float* a_in = <float*>(data[4])
 
   cdef void** out = <void**>(out_tuple)
   cdef float* a_out = <float*>(out[0])
@@ -490,7 +492,7 @@ def jax_gesdd(c, a, full_matrices=True, compute_uv=True):
 
   return c.CustomCall(
       fn,
-      operands=(c.ConstantS32Scalar(int(full_matrices)), c.ConstantS32Scalar(int(compute_uv)),
+      operands=(c.ConstantS32Scalar(int(not full_matrices)), c.ConstantS32Scalar(int(compute_uv)),
                 c.ConstantS32Scalar(m), c.ConstantS32Scalar(n), a),
       shape_with_layout=Shape.tuple_shape((
           Shape.array_shape(dtype, (m, n), (0, 1)),

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -27,6 +27,7 @@ from cpython.pycapsule cimport PyCapsule_New
 from scipy.linalg.cython_blas cimport strsm, dtrsm, ctrsm
 from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf
 from scipy.linalg.cython_lapack cimport spotrf, dpotrf, cpotrf
+from scipy.linalg.cython_lapack cimport sgesdd, dgesdd, cgesdd
 
 import numpy as np
 from jaxlib import xla_client
@@ -382,4 +383,126 @@ def jax_potrf(c, a, lower=False):
           Shape.array_shape(np.int32, (), ()),
           Shape.array_shape(np.int32, (), ()),
           Shape.array_shape(dtype, (n, n), (0, 1)),
+      ))
+
+
+
+# ?gesdd: SVD decomposition
+
+cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
+  cdef int32_t job_opt = (<int32_t*>(data[0]))[0]
+  cdef int m = (<int32_t*>(data[1]))[0]
+  cdef int n = (<int32_t*>(data[2]))[0]
+  cdef float* a_in = <float*>(data[3])
+
+  cdef void** out = <void**>(out_tuple)
+  cdef float* a_out = <float*>(out[0])
+  cdef float* s = <float*>(out[1])
+  cdef float* u = <float*>(out[2])
+  cdef float* vt = <float*>(out[3])
+  cdef int* info = <int*>(out[4])
+
+  if a_out != a_in:
+    memcpy(a_out, a_in, m * n * sizeof(float))
+
+  # define appropriate job code
+  cdef char jobz = 'A'
+  if job_opt_compute_uv == 0:
+    jobz = 'N'
+  else:
+    if job_opt_some == 1:
+      jobz = 'S'
+
+  cdef int lda = m
+  cdef int ldu = m
+  cdef int ldvt = n
+
+  cdef int* iwork = <int *> malloc(min(m, n) * sizeof(int))
+
+  # First perform a workspace query to get the optimal lwork
+  cdef float wkopt = 0
+  cdef int lwork = -1
+  sgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, iwork, info)
+  lwork = <int> wkopt
+
+  # Now get the actual SVD
+  cdef work = <float *> malloc(lwork * sizeof(float))
+  sgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, iwork, info)
+
+register_cpu_custom_call_target(b"lapack_sgesdd", <void*>(lapack_sgesdd))
+
+
+cdef void lapack_dgesdd(void* out_tuple, void** data) nogil:
+  cdef int32_t job_opt_some = (<int32_t*>(data[0]))[0]
+  cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
+  cdef int m = (<int32_t*>(data[2]))[0]
+  cdef int n = (<int32_t*>(data[3]))[0]
+  cdef double* a_in = <double*>(data[4])
+
+  cdef void** out = <void**>(out_tuple)
+  cdef double* a_out = <double*>(out[0])
+  cdef double* s = <double*>(out[1])
+  cdef double* u = <double*>(out[2])
+  cdef double* vt = <double*>(out[3])
+  cdef int* info = <int*>(out[4])
+
+  if a_out != a_in:
+    memcpy(a_out, a_in, m * n * sizeof(double))
+
+  # define appropriate job code
+  cdef char jobz = 'A'
+  if job_opt_compute_uv == 0:
+    jobz = 'N'
+  else:
+    if job_opt_some == 1:
+      jobz = 'S'
+
+  cdef int lda = m
+  cdef int ldu = m
+  cdef int ldvt = n
+
+  cdef int* iwork = <int *> malloc(min(m, n) * sizeof(int))
+
+  # First perform a workspace query to get the optimal lwork
+  cdef double wkopt = 0
+  cdef int lwork = -1
+  dgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, iwork, info)
+  lwork = <int> wkopt
+
+  # Now get the actual SVD
+  cdef work = <double *> malloc(lwork * sizeof(double))
+  dgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, iwork, info)
+
+register_cpu_custom_call_target(b"lapack_dgesdd", <void*>(lapack_dgesdd))
+
+def jax_gesdd(c, a, full_matrices=True, compute_uv=True):
+  assert sizeof(int32_t) == sizeof(int)
+
+  a_shape = c.GetShape(a)
+  dtype = a_shape.element_type()
+  m, n = a_shape.dimensions()
+  if dtype == np.float32:
+    fn = b"lapack_sgesdd"
+  elif dtype == np.float64:
+    fn = b"lapack_dgesdd"
+  else:
+    raise NotImplementedError("Unsupported dtype {}".format(dtype))
+
+  return c.CustomCall(
+      fn,
+      operands=(c.ConstantS32Scalar(int(full_matrices)), c.ConstantS32Scalar(int(compute_uv)),
+                c.ConstantS32Scalar(m), c.ConstantS32Scalar(n), a),
+      shape_with_layout=Shape.tuple_shape((
+          Shape.array_shape(dtype, (m, n), (0, 1)),
+          Shape.array_shape(dtype, (min(m, n),), (0,)),
+          Shape.array_shape(dtype, (m, m if full_matrices else min(m, n)), (0, 1)),
+          Shape.array_shape(dtype, (n if full_matrices else min(m, n), n), (0, 1)),
+          Shape.array_shape(np.int32, (), ()),
+      )),
+      operand_shapes_with_layout=(
+          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(dtype, (m, n), (0, 1)),
       ))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -164,11 +164,11 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       if full_matrices:
         k = min(m, n)
         if m < n:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2][:k, :])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2][:k, :])) < 50))
         else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0][:, :k], out[2])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0][:, :k], out[2])) < 50))
       else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2])) < 50))
 
       # Check the unitary properties of the singular vector matrices.
       self.assertTrue(onp.all(norm(onp.eye(out[0].shape[1]) - onp.matmul(T(out[0]), out[0])) < 5))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -164,18 +164,21 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       if full_matrices:
         k = min(m, n)
         if m < n:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[0] * out[1], out[2][:k, :])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2][:k, :])) < 30))
         else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[0] * out[1][:, :k], out[2])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0][:, :k], out[2])) < 30))
       else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[0] * out[1], out[2])) < 30))
+          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2])) < 30))
 
       # Check the unitary properties of the singular vector matrices.
-      self.assertTrue(onp.all(norm(onp.eye(out[1].shape[1]) - onp.matmul(T(out[1]), out[1])) < 5))
+      self.assertTrue(onp.all(norm(onp.eye(out[0].shape[1]) - onp.matmul(T(out[0]), out[0])) < 5))
       if m >= n:
         self.assertTrue(onp.all(norm(onp.eye(out[2].shape[1]) - onp.matmul(T(out[2]), out[2])) < 5))
       else:
         self.assertTrue(onp.all(norm(onp.eye(out[2].shape[0]) - onp.matmul(out[2], T(out[2]))) < 5))
+
+    else:
+      self.assertTrue(onp.allclose(onp.linalg.svd(a, compute_uv=False), onp.asarray(out)))
 
     self._CompileAndCheck(partial(np.linalg.svd, full_matrices=full_matrices, compute_uv=compute_uv),
                           args_maker, check_dtypes=True)


### PR DESCRIPTION
This pull request consists of a crude implementation of SVD for `jax/numpy/linalg` and `jax/scipy/linalg`.

So far, this supports single precision and double precision real inputs. I haven't tested this yet.

Closes #180 