### PR TITLE
fix np.polyval complex128 dtype bug in x64=True mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - "2.7"
   - "3.6"
 env:
-  - DEPS="pip nose six protobuf>=3.6.0 absl-py opt_einsum numpy scipy"
+  - JAX_ENABLE_X64=0 JAX_NUM_GENERATED_CASES=100
+  - JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=100
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -19,8 +20,8 @@ before_install:
   - conda update --yes conda
   - conda config --add channels conda-forge
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION $DEPS
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose six protobuf>=3.6.0 absl-py opt_einsum numpy scipy
   - pip install jaxlib
   - pip install -v .
 script:
-  - JAX_NUM_GENERATED_CASES=100 nosetests tests examples
+  - nosetests tests examples

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -34,7 +34,9 @@ from jaxlib import xla_client
 
 
 FLAGS = flags.FLAGS
-flags.DEFINE_bool('jax_enable_x64', False, 'Enable 64-bit types to be used.')
+flags.DEFINE_bool('jax_enable_x64',
+                  os.getenv('JAX_ENABLE_X64', False),
+                  'Enable 64-bit types to be used.')
 flags.DEFINE_string('jax_dump_hlo_graph', None, 'Regexp of HLO graphs to dump.')
 flags.DEFINE_bool('jax_hlo_profile', False, 'Enables HLO profiling mode.')
 flags.DEFINE_string('jax_dump_hlo_unoptimized', None,
@@ -216,6 +218,11 @@ _dtype_to_32bit_dtype = {
 def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on FLAGS.jax_enable_x64."""
   dtype = onp.dtype(dtype)
+
+  # special rule for complex128, which XLA doesn't support
+  if dtype == onp.complex128:
+    dtype = onp.dtype('complex64')
+
   if FLAGS.jax_enable_x64:
     return str(dtype)
   else:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -149,8 +149,7 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    from_dtypes = (_dtype(x) for x in args)
-    to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
+    to_dtype = xla_bridge.canonicalize_dtype(result_type(*args))
     return [lax.convert_element_type(x, to_dtype)
             if _dtype(x) != to_dtype else x for x in args]
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -149,7 +149,8 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    to_dtype = xla_bridge.canonicalize_dtype(result_type(*args))
+    from_dtypes = (_dtype(x) for x in args)
+    to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
     return [lax.convert_element_type(x, to_dtype)
             if _dtype(x) != to_dtype else x for x in args]
 

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -408,8 +408,17 @@ class JaxTestCase(parameterized.TestCase):
       self.assertDtypesMatch(x, y)
 
   def assertDtypesMatch(self, x, y):
+    # special rule for complex128, which XLA doesn't support
+    def c128_to_c64(dtype):
+      if dtype == onp.complex128:
+        return onp.complex64
+      else:
+        return dtype
+
     if FLAGS.jax_enable_x64:
-      self.assertEqual(onp.asarray(x).dtype, onp.asarray(y).dtype)
+      x_dtype = c128_to_c64(onp.asarray(x).dtype)
+      y_dtype = c128_to_c64(onp.asarray(y).dtype)
+      self.assertEqual(x_dtype, y_dtype)
 
   def assertAllClose(self, x, y, check_dtypes, atol=None, rtol=None):
     """Assert that x and y, either arrays or nested tuples/lists, are close."""


### PR DESCRIPTION
Also enable JAX_ENABLE_X64=True tests on Travis to avoid future such issues. (Internal tests catch things like this, but we don't run those automatically.)