### PR TITLE
make tuple unpacking cause a full_lower

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -449,7 +449,7 @@ class JaxTuple(tuple):
 class AbstractTuple(AbstractValue, tuple):
   @staticmethod
   def _iter(tracer):
-    return tracer.unpack()
+    return map(full_lower, tracer.unpack())
 
   def _len(self, ignored_tracer):
     return len(self)  # tuples have a known length

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -247,10 +247,9 @@ class JVPTracer(Tracer):
 
   def unpack(self):
     if self.tangent is zero:
-      tangent = [zero] * len(self.primal)
+      return self.full_lower()
     else:
-      tangent = self.tangent
-    return map(partial(JVPTracer, self.trace), self.primal, tangent)
+      return map(partial(JVPTracer, self.trace), self.primal, self.tangent)
 
   def full_lower(self):
     if self.tangent is zero:


### PR DESCRIPTION
This can help with tuple-output primitives that have a non-differentiable element.