### PR TITLE
Use repr of value for DeviceArray.__repr__

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -267,10 +267,6 @@ class DeviceArray(DeviceValue):
     """Returns an ndarray (backed by host memory, not device memory)."""
     return onp.asarray(self)
 
-  def __repr__(self):
-    shape_str = ",".join(map(str, self.shape))
-    return "DeviceArray{{{}[{}]}}".format(onp.dtype(self.dtype).name, shape_str)
-
   def __len__(self):
     try:
       return self.shape[0]
@@ -298,6 +294,7 @@ class DeviceArray(DeviceValue):
 
   __array__ = partialmethod(forward_to_value, onp.asarray)
   __str__ = partialmethod(forward_to_value, str)
+  __repr__ = partialmethod(forward_to_value, repr)
   __bool__ = __nonzero__ = partialmethod(forward_to_value, bool)
   __float__ = partialmethod(forward_to_value, float)
   __int__ = partialmethod(forward_to_value, int)


### PR DESCRIPTION
Currently, `DeviceArray.__repr__` returns the class name and the size of the object. This is inconsistent with `np.ndarray.__repr__` which produces code to reconstruct the array (including the contents, unless the contents are too long to print cleanly). This provides a strange reminder that we aren't using "real" numpy so it may be nicer to just use the standard numpy `__repr__` instead.