### PR TITLE
Bump required numpy version to 1.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='JAX team',
     author_email='jax-dev@google.com',
     packages=find_packages(),
-    install_requires=['numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py',
+    install_requires=['numpy>=1.15', 'six', 'protobuf>=3.6.0', 'absl-py',
                       'opt_einsum'],
     url='https://github.com/google/jax',
     license='Apache-2.0',


### PR DESCRIPTION
lax uses `np.take_along_axis` which was introduced in numpy 1.15:
https://docs.scipy.org/doc/numpy/release.html?highlight=array#new-np-take-along-axis-and-np-put-along-axis-functions