### PR TITLE
guard np.take_along_axis test in case of old numpy

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -201,13 +201,13 @@ def _constant_like(x, const):
 
 def _wraps(fun):
   """Like functools.wraps but works with numpy.ufuncs."""
-  docstr = """
-  LAX-backed implementation of {fun}. Original docstring below.
-
-  {np_doc}
-  """.format(fun=fun.__name__, np_doc=fun.__doc__)
   def wrap(op):
     try:
+      docstr = """
+      LAX-backed implementation of {fun}. Original docstring below.
+
+      {np_doc}
+      """.format(fun=fun.__name__, np_doc=fun.__doc__)
       op.__name__ = fun.__name__
       op.__doc__ = docstr
     finally:
@@ -1553,7 +1553,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     return perm
 
 
-@_wraps(onp.take_along_axis)
+@_wraps(getattr(onp, "take_along_axis", None))
 def take_along_axis(arr, indices, axis):
   if axis is None and ndim(arr) != 1:
     return take_along_axis(arr.ravel(), indices.ravel(), 0)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1023,8 +1023,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       return x, i
 
     lnp_op = lambda x, i: lnp.take_along_axis(x, i, axis=axis)
-    onp_op = lambda x, i: onp.take_along_axis(x, i, axis=axis)
-    self._CheckAgainstNumpy(lnp_op, onp_op, args_maker, check_dtypes=True)
+
+    if hasattr(onp, "take_along_axis"):
+      onp_op = lambda x, i: onp.take_along_axis(x, i, axis=axis)
+      self._CheckAgainstNumpy(lnp_op, onp_op, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=True)
 
 


### PR DESCRIPTION
c.f. #239 (thanks for catching this, @craffel!)