### PR TITLE
Change util.memoize and linear_util.memoize to be LRU caches with a default size of 64 entries.

### DIFF
--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -16,7 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .util import curry, partial
+from .util import curry, partial, OrderedDict
+
 
 def thunk(f):
   store = Store()
@@ -131,14 +132,17 @@ def wrap_init(f, kwargs={}):
   return WrappedFun(f, [], kwargs)
 
 
-def memoize(call):
-  cache = {}
+def memoize(call, max_size=64):
+  cache = OrderedDict()
   def memoized_fun(f, *args):
     key = (f, args)
     if key in cache:
       ans, f_prev = cache[key]
+      cache.move_to_end(key)
       f.populate_stores(f_prev)
     else:
+      if len(cache) > max_size:
+        cache.popitem(last=False)
       ans = call(f, *args)
       cache[key] = (ans, f)
     return ans

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -132,7 +132,7 @@ def wrap_init(f, kwargs={}):
   return WrappedFun(f, [], kwargs)
 
 
-def memoize(call, max_size=64):
+def memoize(call, max_size=4096):
   cache = OrderedDict()
   def memoized_fun(f, *args):
     key = (f, args)

--- a/jax/util.py
+++ b/jax/util.py
@@ -129,23 +129,27 @@ def split_merge(predicate, xs):
   return lhs, rhs, merge
 
 
+if six.PY3:
+  OrderedDict = collections.OrderedDict
+else:
+  # Retrofits a move_to_end method to OrderedDict in Python 2 mode.
+  class OrderedDict(collections.OrderedDict):
+    def move_to_end(self, key):
+      value = self[key]
+      del self[key]
+      self[key] = value
+
+
 _NO_MEMO_ENTRY = object()
 
 def memoize(fun, max_size=64):
-  cache = collections.OrderedDict()
-  if six.PY3:
-    move_to_end = lambda key, _: cache.move_to_end(key)
-  else:
-    def move_to_end(key, value):
-      del cache[key]
-      cache[key] = value
-
+  cache = OrderedDict()
   def memoized_fun(*args, **kwargs):
     key = (args, tuple(kwargs and sorted(kwargs.items())))
     try:
       ans = cache.get(key, _NO_MEMO_ENTRY)
       if ans != _NO_MEMO_ENTRY:
-        move_to_end(key, ans)
+        cache.move_to_end(key)
         return ans
     except TypeError:
       if not allow_memoize_hash_failures:

--- a/jax/util.py
+++ b/jax/util.py
@@ -142,7 +142,7 @@ else:
 
 _NO_MEMO_ENTRY = object()
 
-def memoize(fun, max_size=64):
+def memoize(fun, max_size=4096):
   cache = OrderedDict()
   def memoized_fun(*args, **kwargs):
     key = (args, tuple(kwargs and sorted(kwargs.items())))


### PR DESCRIPTION
The goal is to limit peak memory when running a large number of computations, e.g., the test suite.