### PR TITLE
Undefined name: 'value_and_grad' in ./tests/api_test.py

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -51,9 +51,9 @@ class APITest(jtu.JaxTestCase):
       return 1.0 * x + 2.0 * y + 3.0 * z
 
     y = f(1.0, 1.0, 1.0, flag=True)
-    assert value_and_grad(f)(1.0, 1.0, 1.0, flag=True) == (y, 1.0)
-    assert value_and_grad(f, argnums=1)(1.0, 1.0, 1.0, flag=True) == (y, 2.0)
-    assert value_and_grad(f, argnums=(2, 0))(1.0, 1.0, 1.0, flag=True) == (y, (3.0, 1.0))
+    assert api.value_and_grad(f)(1.0, 1.0, 1.0, flag=True) == (y, 1.0)
+    assert api.value_and_grad(f, argnums=1)(1.0, 1.0, 1.0, flag=True) == (y, 2.0)
+    assert api.value_and_grad(f, argnums=(2, 0))(1.0, 1.0, 1.0, flag=True) == (y, (3.0, 1.0))
 
   def test_jit_static_args(self):
     side = []


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google/jax on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/api_test.py:54:12: F821 undefined name 'value_and_grad'
    assert value_and_grad(f)(1.0, 1.0, 1.0, flag=True) == (y, 1.0)
           ^
./tests/api_test.py:55:12: F821 undefined name 'value_and_grad'
    assert value_and_grad(f, argnums=1)(1.0, 1.0, 1.0, flag=True) == (y, 2.0)
           ^
./tests/api_test.py:56:12: F821 undefined name 'value_and_grad'
    assert value_and_grad(f, argnums=(2, 0))(1.0, 1.0, 1.0, flag=True) == (y, (3.0, 1.0))
           ^
3     F821 undefined name 'value_and_grad'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree