### PR TITLE
fixed TypeError caused by body_fun of foreach loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 .DS_Store
 build/
 dist/
+.mypy_cache/

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -622,7 +622,7 @@ def foreach_loop(sequence, body_fun, init_val):
   """
   _, result = fori_loop(
       0, len(sequence),
-      lambda i, seq_val: body_fun(seq_val[0][i], seq_val[1]),
+      lambda i, seq_val: (seq_val[0], body_fun(seq_val[0][i], seq_val[1])),
       (sequence, init_val))
   return result
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1281,6 +1281,24 @@ class LaxTest(jtu.JaxTestCase):
       self.assertAllClose(cfun(x, num), onp.sum(x[:num]), check_dtypes=False)
       self.assertAllClose(cfun(x, num), onp.sum(x[:num]), check_dtypes=False)
 
+  def testForeachLoopBasic(self):
+    def sum_squares(xs):
+        def body_fun(x, y):
+            return y + x * x
+        return lax.foreach_loop(xs, body_fun, 0)
+
+    sum_squares_jit = api.jit(sum_squares)
+
+    xs = np.array([1, 2, 3, 4])
+    self.assertEqual(sum_squares(xs[:1]), 1)
+    self.assertEqual(sum_squares(xs[:1]), sum_squares_jit(xs[:1]))
+    self.assertEqual(sum_squares(xs[:2]), 5)
+    self.assertEqual(sum_squares(xs[:2]), sum_squares_jit(xs[:2]))
+    self.assertEqual(sum_squares(xs[:3]), 14)
+    self.assertEqual(sum_squares(xs[:3]), sum_squares_jit(xs[:3]))
+    self.assertEqual(sum_squares(xs[:4]), 30)
+    self.assertEqual(sum_squares(xs[:4]), sum_squares_jit(xs[:4]))
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_lhs_shape={}_rhs_shape={}"
        .format(jtu.format_shape_dtype_string(lhs_shape, dtype),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1289,7 +1289,7 @@ class LaxTest(jtu.JaxTestCase):
 
     sum_squares_jit = api.jit(sum_squares)
 
-    xs = np.array([1, 2, 3, 4])
+    xs = onp.array([1, 2, 3, 4])
     self.assertEqual(sum_squares(xs[:1]), 1)
     self.assertEqual(sum_squares(xs[:1]), sum_squares_jit(xs[:1]))
     self.assertEqual(sum_squares(xs[:2]), 5)


### PR DESCRIPTION
This PR fixes the `body_fun` of the `foreach_loop`. Right now it causes a `TypeError`:

```python3
import jax.numpy as np
import jax
from jax import lax

@jax.jit
def sum_squares_foreach(xs):
    def body_fun(x, state):
        y = state
        y = y + x * x
        new_state = y
        return new_state

    init_val = 0
    final_state = lax.foreach_loop(xs, body_fun, init_val)
    y = final_state
    return y

xs = np.array([1, 2, 3, 4])
print(sum_squares_foreach(xs))
```

```
TypeError: body_fun input and output must have identical structure
```