### PR TITLE
Implement np.{cumsum,cumprod,nancumsum,nancumprod}.

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -370,6 +370,14 @@ def _reduce_window_sum(operand, window_dimensions, window_strides, padding):
       window_strides=tuple(window_strides), padding=padding,
       input_shape=operand.shape)
 
+def _reduce_window_prod(operand, window_dimensions, window_strides, padding):
+  init_value = _const(operand, 1)
+  jaxpr, consts = _reduction_jaxpr(mul, init_value)
+  return reduce_window_p.bind(
+      operand, init_value, jaxpr=jaxpr, consts=consts,
+      window_dimensions=tuple(window_dimensions),
+      window_strides=tuple(window_strides), padding=padding)
+
 def _reduce_window_max(operand, window_dimensions, window_strides, padding):
   return reduce_window_max_p.bind(
       operand, window_dimensions=tuple(window_dimensions),

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -917,7 +917,7 @@ def _make_cumulative_reduction(onp_reduction, window_reduce, init_val,
     window_dims = [1] * num_dims
     window_dims[axis] = a_shape[axis]
     return window_reduce(
-       a, window_dims, strides, xla_bridge.get_xla_client().PaddingType.VALID )
+       a, window_dims, strides, xla_bridge.get_xla_client().PaddingType.VALID)
 
   return cumulative_reduction
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -882,6 +882,56 @@ nanmax = _make_nan_reduction(onp.nanmax, max, -inf, nan_if_all_nan=True)
 nansum = _make_nan_reduction(onp.nansum, sum, 0, nan_if_all_nan=False)
 nanprod = _make_nan_reduction(onp.nanprod, prod, 1, nan_if_all_nan=False)
 
+
+def _make_cumulative_reduction(onp_reduction, window_reduce, init_val,
+                               squash_nan=False):
+  @_wraps(onp_reduction)
+  def cumulative_reduction(a, axis=None, dtype=None):
+    if axis is None or isscalar(a):
+      a = ravel(a)
+      axis = 0
+
+    a_shape = list(shape(a))
+    num_dims = len(a_shape)
+
+    if axis < 0:
+      axis = axis + num_dims
+    if axis < 0 or axis >= num_dims:
+      raise ValueError(
+          "axis {} is out of bounds for array of dimension {}".format(
+              axis, num_dims))
+
+    if squash_nan:
+      a = where(isnan(a), _constant_like(a, init_val), a)
+
+    if dtype:
+      a = lax.convert_element_type(a, dtype)
+
+    if a_shape[axis] == 0:
+      return a
+
+    padding = [(0, 0, 0)] * num_dims
+    padding[axis] = (a_shape[axis] - 1, 0, 0)
+    a = lax.pad(a, _constant_like(a, init_val), padding)
+    strides = [1] * num_dims
+    window_dims = [1] * num_dims
+    window_dims[axis] = a_shape[axis]
+    return window_reduce(
+       a, window_dims, strides, xla_bridge.get_xla_client().PaddingType.VALID )
+
+  return cumulative_reduction
+
+
+cumsum = _make_cumulative_reduction(
+  onp.cumsum, lax._reduce_window_sum, 0, squash_nan=False)
+cumprod = _make_cumulative_reduction(
+  onp.cumprod, lax._reduce_window_prod, 1, squash_nan=False)
+nancumsum = _make_cumulative_reduction(
+  onp.nancumsum, lax._reduce_window_sum, 0, squash_nan=True)
+nancumprod = _make_cumulative_reduction(
+  onp.nancumprod, lax._reduce_window_prod, 1, squash_nan=True)
+
+
 ### Array-creation functions
 
 @_wraps(onp.pad)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -530,6 +530,26 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
+          op, jtu.format_shape_dtype_string(shape, dtype), axis, out_dtype),
+       "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
+       "rng": jtu.rand_default(), "lnp_op": getattr(lnp, op),
+       "onp_op": getattr(onp, op)}
+      for op in ["cumsum", "cumprod"]
+      for dtype in default_dtypes
+      for out_dtype in default_dtypes
+      for shape in all_shapes
+      for axis in [None] + list(range(-len(shape), len(shape)))))
+  def testCumSum(self, axis, shape, dtype, out_dtype, onp_op, lnp_op, rng):
+    onp_fun = lambda arg: onp_op(arg, axis=axis, dtype=out_dtype)
+    lnp_fun = lambda arg: lnp_op(arg, axis=axis, dtype=out_dtype)
+
+    args_maker = lambda: [rng(shape, dtype)]
+
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}_m={}_n={}_k={}".format(
           onp.dtype(dtype).name, m, n, k),
        "m": m, "n": n, "k": k, "dtype": dtype, "rng": jtu.rand_default()}

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -536,11 +536,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rng": jtu.rand_default(), "lnp_op": getattr(lnp, op),
        "onp_op": getattr(onp, op)}
       for op in ["cumsum", "cumprod"]
-      for dtype in default_dtypes
-      for out_dtype in default_dtypes
+      # TODO(phawkins): replace both type lists with default_dtypes after a
+      # Jaxlib update includes
+      # https://github.com/google/jax/commit/86f5d189cf563b027c3cd00eea38072c003905c8
+      for dtype in [onp.float32, onp.int32]
+      for out_dtype in [onp.float32, onp.int32]
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testCumSum(self, axis, shape, dtype, out_dtype, onp_op, lnp_op, rng):
+  def testCumSumProd(self, axis, shape, dtype, out_dtype, onp_op, lnp_op, rng):
     onp_fun = lambda arg: onp_op(arg, axis=axis, dtype=out_dtype)
     lnp_fun = lambda arg: lnp_op(arg, axis=axis, dtype=out_dtype)
 


### PR DESCRIPTION
Fixes #296 .

No tests for the NaN variants until we resolve the question of CPU fast math semantics.