### PR TITLE
Travis CI: Use flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-sudo: false
-notifications:
-  email: false
 dist: xenial
 language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 env:
   - JAX_ENABLE_X64=0 JAX_NUM_GENERATED_CASES=100
   - JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=100
@@ -20,8 +18,13 @@ before_install:
   - conda update --yes conda
   - conda config --add channels conda-forge
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose six protobuf>=3.6.0 absl-py opt_einsum numpy scipy
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip nose six protobuf>=3.6.0 absl-py opt_einsum numpy scipy flake8
   - pip install jaxlib
   - pip install -v .
+before_script:
+  # fail the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script:
   - nosetests tests examples
+notifications:
+  email: false


### PR DESCRIPTION
Blocked by #317

Finds these kind of issues:
* https://github.com/google/jax/pulls?q=is%3Apr+author%3Acclauss+is%3Aclosed

Also:
* Add Python 3.7 to testing
* [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

[flake8](http://flake8.pycqa.org) testing of https://github.com/google/jax on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./jax/interpreters/parallel.py:249:38: F821 undefined name 'vals'
      return call_primitive.bind(f, *vals, **params)
                                     ^
./jax/interpreters/parallel.py:372:10: F821 undefined name '_scatter'
  return _scatter(source, target, target_axis, name)
         ^
./jax/interpreters/parallel.py:422:9: F821 undefined name 'rescatter'
    x = rescatter(x, ydim, name)
        ^
3     F821 undefined name 'vals'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
