### PR TITLE
actually fix nondeterminism in einsum

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1399,8 +1399,8 @@ def _einsum(operands, contractions):
 
       contracted_names = contracted_names & (set(lhs_names) | set(rhs_names))
       batch_names = (set(lhs_names) & set(rhs_names)) - contracted_names
-      lhs_batch = [i for i,l in enumerate(lhs_names) if l in batch_names]
-      rhs_batch = [i for i,r in enumerate(rhs_names) if r in batch_names]
+      lhs_batch, rhs_batch = unzip2((lhs_names.find(n), rhs_names.find(n))
+                                    for n in batch_names)
       
       # NOTE(mattjj): this can fail non-deterministically in python3, maybe
       # due to opt_einsum
@@ -1418,7 +1418,8 @@ def _einsum(operands, contractions):
         batch_names = ''.join(batch_names)
       else:
         batch_dims = tuple(lhs_batch)
-        batch_names = ''.join(lhs_names[i] for i in batch_dims)
+        batch_names = ''.join(lhs_names[i] for i in range(len(lhs_names))
+                              if i in batch_dims)
 
       if contracted_names:
         # contract using lax.dot_general

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1399,9 +1399,9 @@ def _einsum(operands, contractions):
 
       contracted_names = contracted_names & (set(lhs_names) | set(rhs_names))
       batch_names = (set(lhs_names) & set(rhs_names)) - contracted_names
-      lhs_batch, rhs_batch = unzip2((lhs_names.find(n), rhs_names.find(n))
-                                    for n in batch_names)
-
+      lhs_batch = [i for i,l in enumerate(lhs_names) if l in batch_names]
+      rhs_batch = [i for i,r in enumerate(rhs_names) if r in batch_names]
+      
       # NOTE(mattjj): this can fail non-deterministically in python3, maybe
       # due to opt_einsum
       assert _all(name in lhs_names and name in rhs_names and

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -276,6 +276,11 @@ class EinsumTest(jtu.JaxTestCase):
 
     check(einstr, *operands)
 
+  def test_ordered_front_batch_dim_case(self):
+    x = onp.ones((1,8,20,4))
+    y = onp.ones((1,8,20,4))
+    s = 'ijkl,ijml->ijkm'
+    check(s, x, y)
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes nondeterministic failure in case of already-front, already-ordered batchdims in 2-operand einsum.