### PR TITLE
Change implementation of negative log-likelihood in README toy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ def logistic_predictions(weights, inputs):
 # Training loss is the negative log-likelihood of the training labels.
 def loss(weights, inputs, targets):
     preds = logistic_predictions(weights, inputs)
-    label_probs = np.log(preds) * targets + np.log(1 - preds) * (1 - targets)
+    label_logprobs = np.log(preds) * targets + np.log(1 - preds) * (1 - targets)
     return -np.sum(label_probs)
 
 # Build a toy dataset.

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ def logistic_predictions(weights, inputs):
 # Training loss is the negative log-likelihood of the training labels.
 def loss(weights, inputs, targets):
     preds = logistic_predictions(weights, inputs)
-    label_probs = preds * targets + (1 - preds) * (1 - targets)
-    return -np.sum(np.log(label_probs))
+    label_probs = np.log(preds) * targets + np.log(1 - preds) * (1 - targets)
+    return -np.sum(label_probs)
 
 # Build a toy dataset.
 inputs = np.array([[0.52, 1.12,  0.77],


### PR DESCRIPTION
In the "[A brief tour](https://github.com/google/jax#a-brief-tour)" section of the [README](https://github.com/google/jax/blob/master/README.md), the function `loss` of the toy example is described as "the negative log-likelihood of the training labels". It is implemented as
```
def loss(weights, inputs, targets):
    preds = logistic_predictions(weights, inputs)
    label_probs = preds * targets + (1 - preds) * (1 - targets)
    return -np.sum(np.log(label_probs))
```
which works in the toy example because `targets` are boolean, but is not in fact the negative log-likelihood. I think beginners might be confused since the implementation is not general. It would not work with label smoothing, for example.