### PR TITLE
Fix README toy example incomplete `label_probs` var renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ def logistic_predictions(weights, inputs):
 def loss(weights, inputs, targets):
     preds = logistic_predictions(weights, inputs)
     label_logprobs = np.log(preds) * targets + np.log(1 - preds) * (1 - targets)
-    return -np.sum(label_probs)
+    return -np.sum(label_logprobs)
 
 # Build a toy dataset.
 inputs = np.array([[0.52, 1.12,  0.77],


### PR DESCRIPTION
Rename of `label_probs` into `label_logprobs` in the toy example was incomplete and, as a consequence, the toy example no longer worked. This renames `label_probs` completely and fixes the toy example.