### PR TITLE
Scatter batching rule (closes #350)

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -2238,6 +2238,8 @@ def _scatter_batching_rule(batched_args, batch_dims, update_jaxpr,
   operand_bdim, scatter_indices_bdim, updates_bdim = batch_dims
   del update_jaxpr, update_consts, updates_shape  # Unused.
 
+  # move the operand batch dim to the front if it is not None, otherwise create
+  # it at the front (so that we can scatter into it)
   size = next(x.shape[ax] for x, ax in zip(batched_args, batch_dims)
               if ax is not None)
   operand = batching.bdim_at_front(operand, operand_bdim, broadcast_size=size,

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -2267,7 +2267,9 @@ def _scatter_batching_rule(batched_args, batch_dims, update_jaxpr,
     updates = batching.move_dim_to_front(updates, updates_bdim)
 
     index_vector_dim = dimension_numbers.index_vector_dim + 1
-    counts = broadcasted_iota(scatter_indices.dtype, scatter_indices.shape, 0)
+    count_shape = list(scatter_indices.shape)
+    count_shape[index_vector_dim] = 1
+    counts = broadcasted_iota(scatter_indices.dtype, tuple(count_shape), 0)
     scatter_indices = concatenate([counts, scatter_indices], index_vector_dim)
 
     update_window_dims = tuple(onp.add(1, dimension_numbers.update_window_dims))

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -556,6 +556,9 @@ class BatchingTest(jtu.JaxTestCase):
           (1, (10, 3, 5), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
             index_vector_dim=1), (1, 3)),
+          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
+            index_vector_dim=1), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -651,10 +654,14 @@ class BatchingTest(jtu.JaxTestCase):
            lax.GatherDimensionNumbers(
                offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
                index_vector_dim=1), (2,)),
-          (1, (10, 5,), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+          (1, (10, 5), onp.array([[0, 2, 1], [0, 3, 3]]).T,
            lax.GatherDimensionNumbers(
                offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
                index_vector_dim=1), (1, 3)),
+          (0, (10, 5), onp.array([[[0, 2], [1, 0]],
+                                  [[1, 2], [0, 3]]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
+            index_vector_dim=1), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -726,6 +733,10 @@ class BatchingTest(jtu.JaxTestCase):
            lax.GatherDimensionNumbers(
                offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
                index_vector_dim=1), (1, 3)),
+          (2, 0, (10, 5, 2), onp.array([[[0, 2], [1, 0]],
+                                        [[1, 0], [2, 0]]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
+            index_vector_dim=1), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -556,9 +556,6 @@ class BatchingTest(jtu.JaxTestCase):
           (1, (10, 3, 5), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
             index_vector_dim=1), (1, 3)),
-          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -568,6 +565,39 @@ class BatchingTest(jtu.JaxTestCase):
     operand = rng(shape, dtype)
     ans = vmap(fun, (axis, None))(operand, idxs)
     expected = onp.stack([fun(operand[(slice(None),) * axis + (i,)], idxs)
+                          for i in range(operand.shape[axis])])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  @parameterized.named_parameters(
+      {"testcase_name": "_shape={}_axis={}_idxs={}_dnums={}_slice_sizes={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
+          slice_sizes),
+       "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
+       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+      for dtype in [onp.float32, onp.float64]
+      for axis, shape, idxs, dnums, slice_sizes in [
+          (0, (3, 5), onp.array([0, 2]), lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
+            index_vector_dim=1), (1,)),
+          (1, (10, 3), onp.array([0, 0, 0]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
+            index_vector_dim=1), (2,)),
+          (1, (10, 3, 5), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
+            index_vector_dim=1), (1, 3)),
+          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
+            index_vector_dim=1), (1, 3)),
+      ]
+      for rng_idx in [jtu.rand_int(max(shape))]
+      for rng in [jtu.rand_default()])
+  def testGatherGradBatchedOperand(self, axis, shape, dtype, idxs, dnums,
+                                   slice_sizes, rng, rng_idx):
+    fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
+    gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
+    operand = rng(shape, dtype)
+    ans = vmap(gfun, (axis, None))(operand, idxs)
+    expected = onp.stack([gfun(operand[(slice(None),) * axis + (i,)], idxs)
                           for i in range(operand.shape[axis])])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -607,6 +637,38 @@ class BatchingTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   @parameterized.named_parameters(
+      {"testcase_name": "_shape={}_axis={}_idxs={}_dnums={}_slice_sizes={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
+          slice_sizes),
+       "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
+       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+      for dtype in [onp.float32, onp.float64]
+      for axis, shape, idxs, dnums, slice_sizes in [
+          (0, (5,), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
+              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
+              index_vector_dim=1), (1,)),
+          (1, (10,), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+           lax.GatherDimensionNumbers(
+               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
+               index_vector_dim=1), (2,)),
+          (1, (10, 5,), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+           lax.GatherDimensionNumbers(
+               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
+               index_vector_dim=1), (1, 3)),
+      ]
+      for rng_idx in [jtu.rand_int(max(shape))]
+      for rng in [jtu.rand_default()])
+  def testGatherGradBatchedIndices(self, axis, shape, dtype, idxs, dnums,
+                                   slice_sizes, rng, rng_idx):
+    fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
+    gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
+    operand = rng(shape, dtype)
+    ans = vmap(gfun, (None, axis))(operand, idxs)
+    expected = onp.stack([gfun(operand, idxs[(slice(None),) * axis + (i,)])
+                          for i in range(idxs.shape[axis])])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  @parameterized.named_parameters(
       {"testcase_name": "_shape={}_op_axis={}_idxs_axis={}_idxs={}_dnums={}_slice_sizes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), op_axis, idxs_axis, idxs,
           dnums, slice_sizes),
@@ -640,6 +702,41 @@ class BatchingTest(jtu.JaxTestCase):
     assert operand.shape[op_axis] == idxs.shape[idxs_axis]
     ans = vmap(fun, (op_axis, idxs_axis))(operand, idxs)
     expected = onp.stack([fun(operand[(slice(None),) * op_axis + (i,)],
+                              idxs[(slice(None),) * idxs_axis + (i,)])
+                          for i in range(idxs.shape[idxs_axis])])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  @parameterized.named_parameters(
+      {"testcase_name": "_shape={}_op_axis={}_idxs_axis={}_idxs={}_dnums={}_slice_sizes={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), op_axis, idxs_axis, idxs,
+          dnums, slice_sizes),
+       "op_axis": op_axis, "idxs_axis": idxs_axis, "shape": shape, "dtype":
+       dtype, "idxs": idxs, "dnums": dnums, "slice_sizes": slice_sizes,
+       "rng": rng, "rng_idx": rng_idx}
+      for dtype in [onp.float32, onp.int32]
+      for op_axis, idxs_axis, shape, idxs, dnums, slice_sizes in [
+          (0, 0, (2, 5), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
+              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
+              index_vector_dim=1), (1,)),
+          (1, 1, (10, 2), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+           lax.GatherDimensionNumbers(
+               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
+               index_vector_dim=1), (2,)),
+          (0, 1, (2, 10, 5,), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+           lax.GatherDimensionNumbers(
+               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
+               index_vector_dim=1), (1, 3)),
+      ]
+      for rng_idx in [jtu.rand_int(max(shape))]
+      for rng in [jtu.rand_default()])
+  def testGatherGradBatchedBoth(self, op_axis, idxs_axis, shape, dtype, idxs, dnums,
+                            slice_sizes, rng, rng_idx):
+    fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
+    gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
+    operand = rng(shape, dtype)
+    assert operand.shape[op_axis] == idxs.shape[idxs_axis]
+    ans = vmap(gfun, (op_axis, idxs_axis))(operand, idxs)
+    expected = onp.stack([gfun(operand[(slice(None),) * op_axis + (i,)],
                               idxs[(slice(None),) * idxs_axis + (i,)])
                           for i in range(idxs.shape[idxs_axis])])
     self.assertAllClose(ans, expected, check_dtypes=False)


### PR DESCRIPTION
This PR includes commits from #351, but those will get squashed away when we merge #351.

The main use case is vmap(grad(indexing_fun)).