### PR TITLE
improve cholesky jvp, misc other improvements (closes #354)

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -80,7 +80,7 @@ def cholesky_jvp_rule(primals, tangents):
   phi = lambda X: np.tril(X) / (1 + np.eye(x.shape[-1]))
   tmp = triangular_solve(L, sigma_dot,
                          left_side=False, transpose_a=True, lower=True)
-  L_dot = lax.dot(L, phi(triangular_solve(
+  L_dot = np.matmul(L, phi(triangular_solve(
       L, tmp, left_side=True, transpose_a=False, lower=True)))
   return L, L_dot
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -326,8 +326,8 @@ logical_xor = _logical_op(onp.logical_xor, lax.bitwise_xor)
 
 @_wraps(onp.true_divide)
 def true_divide(x1, x2):
-  x1, x2 = _promote_shapes(x1, x2)
   result_dtype = _result_dtype(onp.true_divide, x1, x2)
+  x1, x2 = _promote_shapes(x1, x2)
   return lax.div(lax.convert_element_type(x1, result_dtype),
                  lax.convert_element_type(x2, result_dtype))
 
@@ -390,7 +390,7 @@ def _float_divmod(x1, x2):
 
 @_wraps(onp.logaddexp)
 def logaddexp(x1, x2):
-  x1, x2 = _promote_to_result_dtype(onp.logaddexp, *_promote_shapes(x1, x2))
+  x1, x2 = _promote_shapes(*_promote_to_result_dtype(onp.logaddexp, x1, x2))
   amax = lax.max(x1, x2)
   return lax.add(amax, lax.log(lax.add(lax.exp(lax.sub(x1, amax)),
                                        lax.exp(lax.sub(x2, amax)))))
@@ -398,7 +398,7 @@ def logaddexp(x1, x2):
 
 @_wraps(onp.logaddexp2)
 def logaddexp2(x1, x2):
-  x1, x2 = _promote_to_result_dtype(onp.logaddexp2, *_promote_shapes(x1, x2))
+  x1, x2 = _promote_shapes(*_promote_to_result_dtype(onp.logaddexp2, x1, x2))
   amax = lax.max(x1, x2)
   return lax.add(amax, log2(lax.add(exp2(lax.sub(x1, amax)),
                                     exp2(lax.sub(x2, amax)))))

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -33,7 +33,6 @@ _EXPERIMENTAL_WARNING = "numpy.linalg support is experimental and may cause sile
 _T = lambda x: np.swapaxes(x, -1, -2)
 
 
-
 def _promote_arg_dtypes(*args):
   """Promotes `args` to a common inexact type."""
   def _to_inexact_type(type):
@@ -45,7 +44,6 @@ def _promote_arg_dtypes(*args):
     return args[0]
   else:
     return args
-
 
 
 @_wraps(onp.linalg.cholesky)

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -36,7 +36,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
   warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite
   a = np_linalg._promote_arg_dtypes(np.asarray(a))
-  l = lax_linalg.cholesky(a if lower else np.conj(_T(a)))
+  l = lax_linalg.cholesky(a if lower else np.conj(_T(a)), symmetrize_input=False)
   return l if lower else np.conj(_T(l))
 
 

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -793,6 +793,45 @@ class BatchingTest(jtu.JaxTestCase):
     expected = onp.transpose(x, (2, 1, 3, 0))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testIssue354(self):
+    psd_mat = onp.random.randn(20, 10)
+    psd_mat = psd_mat.T.dot(psd_mat)
+    vec = onp.random.randn(10)
+
+    def f(scale):
+      scaled_mat = scale * psd_mat
+      chol = np.linalg.cholesky(scaled_mat)
+      return -0.5 * np.sum((np.einsum('ij,j->i', chol, vec))**2)
+    vmapped_f = vmap(f)
+    vmapped_f_grad = grad(lambda x: np.sum(vmapped_f(x)))
+
+    scales = onp.array([[0.1], [0.2], [0.3], [0.4], [0.5]])
+    ans = vmapped_f_grad(scales)  # don't crash!
+    expected = onp.stack([grad(f)(scale) for scale in scales])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def testTranspose(self):
+    x = onp.arange(4 * 3 * 3).reshape((4, 3, 3))
+    ans = vmap(lambda x: x + x.T)(x)
+    expected = x + onp.swapaxes(x, -1, -2)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def testTransposePermutation(self):
+    x = onp.arange(6 * 3 * 4 * 5).reshape((6, 3, 4, 5))
+    ans = vmap(lambda x: np.transpose(x, (1, 0, 2)))(x)
+    expected = onp.transpose(x, (0, 2, 1, 3))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    x = onp.arange(6 * 3 * 4 * 5).reshape((6, 3, 4, 5))
+    ans = vmap(lambda x: np.transpose(x, (1, 2, 0)))(x)
+    expected = onp.transpose(x, (0, 2, 3, 1))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    x = onp.arange(6 * 3 * 4 * 5).reshape((3, 4, 6, 5))
+    ans = vmap(lambda x: np.transpose(x, (1, 2, 0)), in_axes=2)(x)
+    expected = onp.transpose(x, (2, 1, 3, 0))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -810,28 +810,6 @@ class BatchingTest(jtu.JaxTestCase):
     expected = onp.stack([grad(f)(scale) for scale in scales])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def testTranspose(self):
-    x = onp.arange(4 * 3 * 3).reshape((4, 3, 3))
-    ans = vmap(lambda x: x + x.T)(x)
-    expected = x + onp.swapaxes(x, -1, -2)
-    self.assertAllClose(ans, expected, check_dtypes=False)
-
-  def testTransposePermutation(self):
-    x = onp.arange(6 * 3 * 4 * 5).reshape((6, 3, 4, 5))
-    ans = vmap(lambda x: np.transpose(x, (1, 0, 2)))(x)
-    expected = onp.transpose(x, (0, 2, 1, 3))
-    self.assertAllClose(ans, expected, check_dtypes=False)
-
-    x = onp.arange(6 * 3 * 4 * 5).reshape((6, 3, 4, 5))
-    ans = vmap(lambda x: np.transpose(x, (1, 2, 0)))(x)
-    expected = onp.transpose(x, (0, 2, 3, 1))
-    self.assertAllClose(ans, expected, check_dtypes=False)
-
-    x = onp.arange(6 * 3 * 4 * 5).reshape((3, 4, 6, 5))
-    ans = vmap(lambda x: np.transpose(x, (1, 2, 0)), in_axes=2)(x)
-    expected = onp.transpose(x, (2, 1, 3, 0))
-    self.assertAllClose(ans, expected, check_dtypes=False)
-
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1215,6 +1215,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jax_numpy_result = (1 + lnp.eye(1, dtype=lnp.float32)).dtype
     self.assertEqual(orig_numpy_result, jax_numpy_result)
 
+  def testSymmetrizeDtypePromotion(self):
+    x = onp.eye(3, dtype=onp.float32)
+    orig_numpy_result = ((x + x.T) / 2).dtype
+
+    x = lnp.eye(3, dtype=lnp.float32)
+    jax_numpy_result = ((x + x.T) / 2).dtype
+    self.assertEqual(orig_numpy_result, jax_numpy_result)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -68,6 +68,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.cholesky, args_maker, check_dtypes=True)
 
+    jtu.check_grads(np.linalg.cholesky, args_maker(), 1, rtol=1e-1)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -61,14 +61,16 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for rng in [jtu.rand_default()]))
   def testCholesky(self, shape, dtype, rng):
     def args_maker():
-      a = rng(shape, dtype)
+      factor_shape = shape[:-1] + (2 * shape[-1],)
+      a = rng(factor_shape, dtype)
       return [onp.matmul(a, np.conj(T(a)))]
 
     self._CheckAgainstNumpy(onp.linalg.cholesky, np.linalg.cholesky, args_maker,
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.cholesky, args_maker, check_dtypes=True)
 
-    jtu.check_grads(np.linalg.cholesky, args_maker(), 1, rtol=1e-1)
+    if onp.finfo(dtype).bits == 64:
+      jtu.check_grads(np.linalg.cholesky, args_maker(), order=2)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -302,7 +304,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.solve, args_maker, check_dtypes=True)
 
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
@@ -376,7 +377,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                             args_maker, check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp.linalg.lu_factor, args_maker, check_dtypes=True)
 
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_lhs={}_rhs={}_sym_pos={}_lower={}".format(
@@ -415,7 +415,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp_fun, args_maker, check_dtypes=True)
-
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -483,6 +482,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     f = partial(jsp.linalg.solve_triangular, lower=lower,
                 trans=1 if transpose_a else 0)
     jtu.check_grads(f, (A, B), 2, rtol=1e-3)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
This PR:
- changes the cholesky jvp to handle leading dimensions like the underlying primitive does (thanks @hawkinsp)
- fixes other cholesky jvp issues by symmetrizing in the `cholesky` traceable by default (we're still discussing conventions on whether to follow the 'cholesky is a function on positive definite symmetric matrices' convention or the 'cholesky is a function on the lower triangular part of any matrix such that when you zero out the strict upper triangle and then symmetrize the result is positive definite ' convention by default)
- fixes logic in `lax._brcast` to handle zero-size arrays
- led to catching the bugs fixed in #368, #362, and #359 
- closes #354