### PR TITLE
added jvp rule for eigh, tests

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -39,7 +39,10 @@ def cholesky(x, symmetrize_input=True):
     x = symmetrize(x)
   return cholesky_p.bind(x)
 
-def eigh(x, lower=True): return eigh_p.bind(x, lower=lower)
+def eigh(x, lower=True, symmetrize=True):
+  if symmetrize:
+    x = (x + _H(x)) / 2  # orthogonal projection onto self-adjoint matrices
+  return eigh_p.bind(x, lower=lower)
 
 def lu(x): return lu_p.bind(x)
 
@@ -146,10 +149,34 @@ def eigh_cpu_translation_rule(c, operand, lower):
     raise NotImplementedError(
         "Only unbatched eigendecomposition is implemented on CPU")
 
+def eigh_jvp_rule(primals, tangents, lower):
+  # Derivative for eigh in the simplest case of distinct eigenvalues.
+  # Simple case from https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+  # The general solution treating the case of degenerate eigenvalues is
+  # considerably more complicated. Ambitious readers may refer to the general
+  # methods at:
+  # https://www.win.tue.nl/analysis/reports/rana06-33.pdf and
+  # https://people.orie.cornell.edu/aslewis/publications/99-clarke.pdf
+  a, = primals
+  a_dot, = tangents
+  v, w = eigh_p.bind((a + _H(a)) / 2.0, lower=lower)
+  # for complex numbers we need eigenvalues to be full dtype of v, a:
+  w = w.astype(a.dtype)
+  eye_n = np.eye(a.shape[-1], dtype=a.dtype)
+  # carefully build reciprocal delta-eigenvalue matrix, avoiding NaNs.
+  Fmat = np.reciprocal(eye_n + w - w[..., np.newaxis]) - eye_n
+  # eigh impl doesn't support batch dims, but future-proof the grad.
+  dot = lax.dot if a.ndim == 2 else lax.batch_matmul
+  vdag_adot_v = dot(dot(_H(v), a_dot), v)
+  dv = dot(v, np.multiply(Fmat, vdag_adot_v))
+  dw = np.diagonal(np.multiply(eye_n, vdag_adot_v))
+  return core.pack((v, w)), core.pack((dv, dw))
+
 eigh_p = Primitive('eigh')
 eigh_p.def_impl(eigh_impl)
 eigh_p.def_abstract_eval(eigh_abstract_eval)
 xla.translations[eigh_p] = eigh_translation_rule
+ad.primitive_jvps[eigh_p] = eigh_jvp_rule
 xla.backend_specific_translations['Host'][eigh_p] = eigh_cpu_translation_rule
 
 

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -39,9 +39,9 @@ def cholesky(x, symmetrize_input=True):
     x = symmetrize(x)
   return cholesky_p.bind(x)
 
-def eigh(x, lower=True, symmetrize=True):
-  if symmetrize:
-    x = (x + _H(x)) / 2  # orthogonal projection onto self-adjoint matrices
+def eigh(x, lower=True, symmetrize_input=True):
+  if symmetrize_input:
+    x = symmetrize(x)
   return eigh_p.bind(x, lower=lower)
 
 def lu(x): return lu_p.bind(x)
@@ -151,10 +151,11 @@ def eigh_cpu_translation_rule(c, operand, lower):
 
 def eigh_jvp_rule(primals, tangents, lower):
   # Derivative for eigh in the simplest case of distinct eigenvalues.
-  # Simple case from https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+  # This is classic nondegenerate perurbation theory, but also see
+  # https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
   # The general solution treating the case of degenerate eigenvalues is
   # considerably more complicated. Ambitious readers may refer to the general
-  # methods at:
+  # methods below or refer to degenerate perturbation theory in physics.
   # https://www.win.tue.nl/analysis/reports/rana06-33.pdf and
   # https://people.orie.cornell.edu/aslewis/publications/99-clarke.pdf
   a, = primals

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -160,7 +160,7 @@ def eigh_jvp_rule(primals, tangents, lower):
   # https://people.orie.cornell.edu/aslewis/publications/99-clarke.pdf
   a, = primals
   a_dot, = tangents
-  v, w = eigh_p.bind((a + _H(a)) / 2.0, lower=lower)
+  v, w = eigh_p.bind(symmetrize(a), lower=lower)
   # for complex numbers we need eigenvalues to be full dtype of v, a:
   w = w.astype(a.dtype)
   eye_n = np.eye(a.shape[-1], dtype=a.dtype)

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -170,7 +170,7 @@ def eigh_jvp_rule(primals, tangents, lower):
   dot = lax.dot if a.ndim == 2 else lax.batch_matmul
   vdag_adot_v = dot(dot(_H(v), a_dot), v)
   dv = dot(v, np.multiply(Fmat, vdag_adot_v))
-  dw = np.diagonal(np.multiply(eye_n, vdag_adot_v))
+  dw = np.diagonal(vdag_adot_v)
   return core.pack((v, w)), core.pack((dv, dw))
 
 eigh_p = Primitive('eigh')

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -93,7 +93,7 @@ def det(a):
 
 
 @_wraps(onp.linalg.eigh)
-def eigh(a, UPLO=None, symmetrize=True):
+def eigh(a, UPLO=None, symmetrize_input=True):
   if UPLO is None or UPLO == "L":
     lower = True
   elif UPLO == "U":
@@ -103,7 +103,7 @@ def eigh(a, UPLO=None, symmetrize=True):
     raise ValueError(msg)
 
   a = _promote_arg_dtypes(np.asarray(a))
-  v, w = lax_linalg.eigh(a, lower=lower, symmetrize=symmetrize)
+  v, w = lax_linalg.eigh(a, lower=lower, symmetrize_input=symmetrize_input)
   return w, v
 
 

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -93,7 +93,7 @@ def det(a):
 
 
 @_wraps(onp.linalg.eigh)
-def eigh(a, UPLO=None):
+def eigh(a, UPLO=None, symmetrize=True):
   if UPLO is None or UPLO == "L":
     lower = True
   elif UPLO == "U":
@@ -103,7 +103,7 @@ def eigh(a, UPLO=None):
     raise ValueError(msg)
 
   a = _promote_arg_dtypes(np.asarray(a))
-  v, w = lax_linalg.eigh(a, lower=lower)
+  v, w = lax_linalg.eigh(a, lower=lower, symmetrize=symmetrize)
   return w, v
 
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -172,12 +172,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name":
        "_shape={}_lower={}".format(jtu.format_shape_dtype_string(shape, dtype),
                                    lower),
-       "shape": shape, "dtype": dtype, "rng": rng, "lower":lower}
+       "shape": shape, "dtype": dtype, "rng": rng, "lower":lower, "eps":eps}
       for shape in [(1, 1), (4, 4), (5, 5), (50, 50)]
       for dtype in complex_types()
       for rng in [jtu.rand_default()]
-      for lower in [True, False])
-      for eps in [1e-4])
+      for lower in [True, False]
+      for eps in [1e-4]))
   # TODO(phawkins): enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.skip_on_devices("gpu", "tpu")


### PR DESCRIPTION
This adds the jvp rule for the symmetric eigendecomposition eigh operator.  I followed Matthew's approach with the cholesky op of symmetrizing the input argument.  I'd be happy to change that up if it's not how we want to deal with symmetry-bound operators.