### PR TITLE
improve the dtype promotion logic against Python scalars

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -571,7 +571,8 @@ def dynamic_slice_in_dim(operand, start_index, slice_size, axis=0):
   slice_sizes = list(operand.shape)
 
   axis = int(axis)
-  start_indices[axis] = reshape(rem(start_index, operand.shape[axis]), [1])
+  axis_size = onp.array(operand.shape[axis], start_index.dtype)
+  start_indices[axis] = reshape(rem(start_index, axis_size), [1])
   slice_sizes[axis] = int(slice_size)
 
   start_indices = concatenate(start_indices, 0)

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -571,7 +571,7 @@ def dynamic_slice_in_dim(operand, start_index, slice_size, axis=0):
   slice_sizes = list(operand.shape)
 
   axis = int(axis)
-  axis_size = onp.array(operand.shape[axis], start_index.dtype)
+  axis_size = _const(start_index, operand.shape[axis])
   start_indices[axis] = reshape(rem(start_index, axis_size), [1])
   slice_sizes[axis] = int(slice_size)
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -146,7 +146,8 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    from_dtypes = (x if type(x) in (int, float) else _dtype(x) for x in args)
+    from_dtypes = (x if type(x) in (int, float, long, complex) else _dtype(x)
+                   for x in args)
     to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
     return [lax.convert_element_type(x, to_dtype)
             if _dtype(x) != to_dtype else x for x in args]

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -146,11 +146,16 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    from_dtypes = (x if type(x) in (int, float, complex) else _dtype(x)
+    from_dtypes = (x if type(x) in _builtin_numeric_types else _dtype(x)
                    for x in args)
     to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
     return [lax.convert_element_type(x, to_dtype)
             if _dtype(x) != to_dtype else x for x in args]
+
+if six.PY3:
+  _builtin_numeric_types = (int, float, complex)
+else:
+  _builtin_numeric_types = (int, float, long, complex)
 
 def _promote_to_result_dtype(op, *args):
   """Convenience function to promote args directly to the op's result dtype."""

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -146,7 +146,7 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    from_dtypes = (x if type(x) in (int, float, long, complex) else _dtype(x)
+    from_dtypes = (x if type(x) in (int, float, complex) else _dtype(x)
                    for x in args)
     to_dtype = xla_bridge.canonicalize_dtype(result_type(*from_dtypes))
     return [lax.convert_element_type(x, to_dtype)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1775,7 +1775,7 @@ def take(a, indices, axis=None, out=None, mode=None):
     # TODO(phawkins): we have no way to report out of bounds errors yet.
     raise NotImplementedError("The 'raise' mode to np.take is not supported.")
   elif mode == "wrap":
-    indices = mod(indices, onp.array(a.shape[axis], _dtype(indices)))
+    indices = mod(indices, _constant_like(indices, a.shape[axis]))
   elif mode != "clip" and mode is not None:
     raise ValueError("Invalid mode '{}' for np.take".format(mode))
 
@@ -1834,7 +1834,7 @@ def _rewriting_take(arr, idx, axis=0):
   if isinstance(abstract_idx, ConcreteArray) and _int(abstract_idx):
     return lax.index_in_dim(arr, idx, axis, False)
   elif isinstance(abstract_idx, ShapedArray) and _int(abstract_idx):
-    idx = mod(idx, onp.array(arr.shape[axis], _dtype(idx)))
+    idx = mod(idx, _constant_like(idx, arr.shape[axis]))
     return lax.dynamic_index_in_dim(arr, idx, axis, False)
 
   # Handle slice index (only static, otherwise an error is raised)
@@ -1903,7 +1903,7 @@ def _rewriting_take(arr, idx, axis=0):
       # The indexer is just a single integer array.
       idx = [idx]
 
-    flat_idx = tuple([mod(ravel(x), onp.array(arr.shape[i], _dtype(x)))
+    flat_idx = tuple([mod(ravel(x), _constant_like(x, arr.shape[i]))
                       for i, x in enumerate(idx)])
     # TODO(mattjj): if we instead lower directly to lax.gather, we can probably
     # eliminate the reshape here.
@@ -1922,7 +1922,7 @@ def _rewriting_take(arr, idx, axis=0):
     idx_advanced, axes = zip(*advanced_pairs)
     idx_advanced = broadcast_arrays(*idx_advanced)
 
-    flat_idx = tuple(mod(ravel(x), onp.array(arr_sliced.shape[i], _dtype(x)))
+    flat_idx = tuple(mod(ravel(x), _constant_like(x, arr_sliced.shape[i]))
                      for i, x in zip(axes, idx_advanced))
     # TODO(mattjj): if we instead lower directly to lax.gather, we can probably
     # eliminate the reshape here.

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1210,6 +1210,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     x = lnp.full((1, 1), lnp.array([1])[0])  # doesn't crash
     self.assertEqual(x[0, 0], 1)
 
+  def testScalarDtypePromotion(self):
+    orig_numpy_result = (1 + onp.eye(1, dtype=onp.float32)).dtype
+    jax_numpy_result = (1 + lnp.eye(1, dtype=lnp.float32)).dtype
+    self.assertEqual(orig_numpy_result, jax_numpy_result)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Quoting from some @hawkinsp messages:


> numpy's type promotion rules are based on the *values* of scalars. so we can't possibly implement correct numpy promotion under a jit — we will sometimes promote too far.
> e.g. `onp.result_type(onp.float64(1), onp.ones((1), onp.complex64))` is `dtype('complex64')` but `onp.result_type(onp.float64, onp.ones((1), onp.complex64))` is `dtype('complex128')`
> jax always does the latter at the moment, not taking into account the value of the scalar.
> so it would seem we want a rule something like this for what to pass to result_type:
> * use concrete python values there wherever we have them (python values are always concrete, after all) but
> * always treat numpy values as if they were abstract (call lax._dtype on them), since if you do different things in the concrete/abstract case you will observe behavior differences from `@jit` ? In particular, we need to avoid numpy's value-dependent type promotion semantics for numpy scalars and numpy scalar arrays because we won't be able to implement it under `@jit` where we won't know the values.)

This PR implements that recommendation, and patches up a couple places where we called `lax.mod`/`lax.rem` and weren't handling the dtypes correctly.