### PR TITLE
Improve JAX API docs.

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -17,6 +17,6 @@ Module contents
 ---------------
 
 .. automodule:: jax
-    :members: jit, grad, value_and_grad, vmap, jacfwd, jacrev, make_jaxpr
+    :members: jit, grad, value_and_grad, vmap, jacfwd, jacrev, hessian, make_jaxpr
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Add examples for `jax.jit`, `jax.jacfwd`, and `jax.jacrev`.
Document `jax.hessian`. Add `argnums` support to `jax.hessian`.

Issue #61 .