### PR TITLE
fix nan handling in pow jvp (fixes #347)

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -962,6 +962,9 @@ _maybe_real = lambda x: real(x) if _iscomplex(x) else x
 pow_p = standard_binop([_float | _complex, _float | _complex], 'pow')
 
 def pow_jvp_lhs(g, x, y):
+  # we call _safe_mul here so that we get the behavior 0*inf = 0, since when a
+  # coefficient in `g` is zero we want to keep it at zero, not produce a nan.
+  # see https://github.com/google/jax/pull/383
   jac = mul(y, pow(x, select(eq(y, _zeros(y)), _ones(y), sub(y, _ones(y)))))
   return _safe_mul(_brcast(g, y), jac)
 

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -348,7 +348,7 @@ class _JaxComputationBuilderBase(object):
 
   def ConstantLike(self, example_value, value, canonicalize_types=True):
     example_value = onp.asarray(example_value)
-    return self.Constant(onp.array(value).astype(example_value.dtype))
+    return self.Constant(onp.array(value, dtype=example_value.dtype))
 
   def Constant(self, py_val, canonicalize_types=True):
     """Translate constant `py_val` to a constant for this ComputationBuilder.

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1232,7 +1232,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       return lnp.sum(x)
 
     x = lnp.array([[1, 2], [3, 4], [0, 0]], dtype=lnp.float64)
-    result = grad(test_fail)(x)
+    result = api.grad(test_fail)(x)
     assert not onp.any(onp.isnan(result))
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1223,6 +1223,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jax_numpy_result = ((x + x.T) / 2).dtype
     self.assertEqual(orig_numpy_result, jax_numpy_result)
 
+  def testIssue347(self):
+    # https://github.com/google/jax/issues/347
+    def test_fail(x):
+      x = lnp.sqrt(lnp.sum(x ** 2, axis=1))
+      ones = lnp.ones_like(x)
+      x = lnp.where(x > 0.5, x, ones)
+      return lnp.sum(x)
+
+    x = lnp.array([[1, 2], [3, 4], [0, 0]], dtype=lnp.float64)
+    result = grad(test_fail)(x)
+    assert not onp.any(onp.isnan(result))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
See #347 for example code.

Interestingly, Autograd still has this issue:

```python
import autograd.numpy as np
from autograd import grad

def f(x):
  x = np.sqrt(np.sum(x**2, axis=1))
  return np.sum(np.where(x > 0.5, x, np.ones_like(x)))

x = np.array([[1, 2], [3, 4], [0, 0]], dtype=np.float64)
print grad(f)(x)

# [[0.4472136  0.89442719]
#  [0.6        0.8       ]
#  [       nan        nan]]
```

It comes down to the formula for the jvp of `sqrt(x)` being problematic at `x=0` when the gradient has coefficients that are also zero, since `g * x ** -0.5` is `0 * inf` there. In this case, the zero coefficients in the gradient arise from the `lax.select`/`np.where` call.

I think a zero in the gradient should win out over an inf in the Jacobian, and this PR implements that policy. I had trouble implementing it on top of the standard `lax.mul` primitive because of linearity constraints in the JVP rule, so instead I added a new `lax._safe_mul` that implements the `0*inf = 0` policy in its translation rule.