### PR TITLE
Actually use the user-provided epsilon value in tests.

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -114,10 +114,10 @@ def rand_like(rng, x):
 
 
 def numerical_jvp(f, primals, tangents, eps=EPS):
-  delta = scalar_mul(tangents, EPS)
+  delta = scalar_mul(tangents, eps)
   f_pos = f(*add(primals, delta))
   f_neg = f(*sub(primals, delta))
-  return scalar_mul(sub(f_pos, f_neg), 0.5 / EPS)
+  return scalar_mul(sub(f_pos, f_neg), 0.5 / eps)
 
 
 def check_jvp(f, f_jvp, args, atol=ATOL, rtol=RTOL, eps=EPS):
@@ -136,7 +136,7 @@ def check_vjp(f, f_vjp, args, atol=ATOL, rtol=RTOL, eps=EPS):
   v_out_expected = f(*args)
   check_eq(v_out, v_out_expected)
   tangent = tree_map(_rand_like, args)
-  tangent_out = numerical_jvp(f, args, tangent, eps=EPS)
+  tangent_out = numerical_jvp(f, args, tangent, eps=eps)
   cotangent = tree_map(_rand_like, v_out)
   cotangent_out = conj(vjpfun(conj(cotangent)))
   ip = inner_prod(tangent, cotangent_out)
@@ -155,7 +155,7 @@ def check_grads(f, args, order, atol=None, rtol=None, eps=None):
     default_tol = 1e-6 if FLAGS.jax_enable_x64 else 1e-2
     atol = atol or default_tol
     rtol = rtol or default_tol
-    eps = eps or default_tol
+    eps = eps or EPS
     check_jvp(f, partial(api.jvp, f), args, atol, rtol, eps)
     check_vjp(f, partial(api.vjp, f), args, atol, rtol, eps)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1619,7 +1619,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         return absltest.unittest.skip("pow grad imprecise on tpu")
     tol = 1e-1 if num_float_bits(dtype) == 32 else None
     args = tuple(rng(shape, dtype) for shape in shapes)
-    check_grads(op, args, order, tol, tol, tol)
+    check_grads(op, args, order, tol, tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}".format(
@@ -2025,7 +2025,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     operand = rng(shape, dtype)
     init_val = onp.asarray(init_val, dtype=dtype)
     reduce = lambda operand: lax.reduce(operand, init_val, op, dims)
-    check_grads(reduce, (operand,), 1, tol, tol, tol)
+    check_grads(reduce, (operand,), 1, tol, tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_dtype={}_padding={}"


### PR DESCRIPTION
Please in particular verify the changes to lax_test.py are sensible (lowering eps only). They seemed necessary to fix some test failures.