### PR TITLE
fix lax_numpy array/asarray performance bug

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1132,8 +1132,8 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   if ndmin != 0 or order != "K":
     raise NotImplementedError("Only implemented for order='K', ndmin=0.")
 
-  if hasattr(object, '__asarray__'):
-    return object.__asarray__(dtype)
+  if hasattr(object, '__array__'):
+    return object.__array__(dtype)
   elif isinstance(object, ndarray):
     if dtype and _dtype(object) != dtype:
       return lax.convert_element_type(object, dtype)


### PR DESCRIPTION
The issue is that `jax.numpy.array(some_array)` doesn't have a fast path, and instead it does the very slow thing of unpacking the leading axis and packing it back together. That performance bug originates from a [typo in `jax.numpy.array`](https://github.com/google/jax/blob/471c8eba990201eb9f626aef860de06ba09e4681/jax/numpy/lax_numpy.py#L1135-L1136) where `__asarray__` was written instead of `__array__`.