### PR TITLE
Fix some test failures.

### DIFF
--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -83,7 +83,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       x, a, loc, scale = map(rng, shapes, dtypes)
       return [x, a, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=5e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(3, jtu.rand_positive())


### PR DESCRIPTION
Raise tolerance for gamma logpdf function.
np.angle apparently returns np.float64 in older numpy versions for a complex64 input but np.float32 in Numpy 1.16.1. Ignore its dtype for testing purposes; JAX follows the newer NumPy semantics.