### PR TITLE
Add {float16,uint16,uint8,int16,int8} types to abstract_arrays.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -161,9 +161,11 @@ def zeros_like_array(x):
   dtype = xla_bridge.canonicalize_dtype(onp.result_type(x))
   return onp.broadcast_to(onp.array(0, dtype), onp.shape(x))
 
-array_types = [onp.ndarray, onp.float64, onp.float32, onp.complex64,
-               onp.complex128, onp.int64, onp.int32, onp.bool_, onp.uint64,
-               onp.uint32, complex, float, int, bool]
+array_types = [onp.ndarray, onp.float64, onp.float32, onp.float16,
+               onp.complex64, onp.complex128,
+               onp.int64, onp.int32, onp.int16, onp.int8,
+               onp.bool_, onp.uint64, onp.uint32, onp.uint16, onp.uint8,
+               complex, float, int, bool]
 
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray


### PR DESCRIPTION
In principle this allows these types to be used. They are as yet untested, however.

(Issue #75 )