### PR TITLE
remove unused jax.numpy.array case (was typo)

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1160,6 +1160,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     else:
       return object
   elif hasattr(object, '__array__'):
+    # this case is for duck-typed handling of objects that implement `__array__`
     return array(object.__array__(), dtype)
   elif isinstance(object, (list, tuple)):
     if object:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1148,24 +1148,22 @@ def atleast_3d(*arys):
     return [atleast_3d(arr) for arr in arys]
 
 
-# TODO(mattjj): can this be simplified?
 @_wraps(onp.array)
 def array(object, dtype=None, copy=True, order="K", ndmin=0):
   del copy  # Unused.
   if ndmin != 0 or order != "K":
     raise NotImplementedError("Only implemented for order='K', ndmin=0.")
 
-  if hasattr(object, '__asarray__'):
-    return object.__asarray__(dtype)
-  elif isinstance(object, ndarray):
+  if isinstance(object, ndarray):
     if dtype and _dtype(object) != dtype:
       return lax.convert_element_type(object, dtype)
     else:
       return object
+  elif hasattr(object, '__array__'):
+    return array(object.__array__(), dtype)
   elif isinstance(object, (list, tuple)):
     if object:
-      subarrays = [expand_dims(array(elt, dtype=dtype), 0) for elt in object]
-      return concatenate(subarrays)
+      return stack([array(elt, dtype=dtype) for elt in object])
     else:
       return onp.array([], dtype)
   elif isscalar(object):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -942,9 +942,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp.array, lnp.array, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp.array, args_maker, check_dtypes=True)
 
-  def testArrayAsarrayMethod(self):
+  def testArrayMethod(self):
     class arraylike(object):
-      def __asarray__(self, dtype=None):
+      dtype = onp.float32
+      def __array__(self, dtype=None):
         return 3.
     a = arraylike()
     ans = lnp.array(a)


### PR DESCRIPTION
There are still likely performance improvements to be made to `jax.numpy.array` in some cases, as in  [the example](https://github.com/google/jax/pull/389#issuecomment-466014625) near the bottom of #389.