### PR TITLE
Update XLA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 *.pyc
 *.so
-/jax/lib/pywrap_xla.py
-/jax/lib/xla_client.py
-/jax/lib/xla_data_pb2.py
 *.egg-info
 .ipynb_checkpoints
 /bazel-*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
    name = "org_tensorflow",
-   sha256 = "96ef8a03a602e1f8b2cf4b1bc89974cfc2754235d545691547651b9b437bdcc9",
-   strip_prefix = "tensorflow-9f9efff916ed427b24216a739465842a09a8e136",
+   sha256 = "ba253da211d3d22255ca6afa204eedd8348cae4a1e3a726684eb76e18de90df6",
+   strip_prefix = "tensorflow-00afc7bb81d6d36a0f619c08c011abe08965a25b",
    urls = [
-       "https://github.com/tensorflow/tensorflow/archive/9f9efff916ed427b24216a739465842a09a8e136.tar.gz",
+       "https://github.com/tensorflow/tensorflow/archive/00afc7bb81d6d36a0f619c08c011abe08965a25b.tar.gz",
    ],
 )
 

--- a/build/install_xla_in_source_tree.sh
+++ b/build/install_xla_in_source_tree.sh
@@ -52,8 +52,6 @@ fi
 
 # Copy the XLA dependencies into jax/lib, fixing up some imports to point to the
 # new location.
-cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/xla_data_pb2.py)" \
-  "${TARGET}/jaxlib"
 cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/pywrap_xla.py)" \
   "${TARGET}/jaxlib"
 cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/_pywrap_xla.so)" \
@@ -61,7 +59,5 @@ cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/_pywrap_xla.so)
 cp -f "$(rlocation __main__/jaxlib/lapack.so)" "${TARGET}/jaxlib"
 sed \
   -e 's/from tensorflow.compiler.xla.python import pywrap_xla as c_api/from . import pywrap_xla as c_api/' \
-  -e 's/from tensorflow.compiler.xla import xla_data_pb2/from . import xla_data_pb2/' \
-  -e '/from tensorflow.compiler.xla.service import hlo_pb2/d' \
   < "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/xla_client.py)" \
   > "${TARGET}/jaxlib/xla_client.py"

--- a/build/jaxlib/__init__.py
+++ b/build/jaxlib/__init__.py
@@ -11,3 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from . import xla_client
+from .version import __version__
+
+class xla_data_pb2(object):
+  """Compatibility shim for supporting Jax versions 0.1.20 or older.
+
+  Delete when we next break Jaxlib backward compatibility."""
+  GatherDimensionNumbers = xla_client.GatherDimensionNumbers
+  ScatterDimensionNumbers = xla_client.ScatterDimensionNumbers
+  ConvolutionDimensionNumbers = xla_client.ConvolutionDimensionNumbers
+  DotDimensionNumbers = xla_client.DotDimensionNumbers
+
+for name, value in xla_client.PrimitiveType.__members__.items():
+  setattr(xla_data_pb2, name, value)

--- a/build/jaxlib/version.py
+++ b/build/jaxlib/version.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup, find_packages
-
-with open('jax/version.py') as f:
-  exec(f.read(), globals())
-
-setup(
-    name='jax',
-    version=__version__,
-    description='Differentiate, compile, and transform Numpy code.',
-    author='JAX team',
-    author_email='jax-dev@google.com',
-    packages=find_packages(),
-    install_requires=[
-        'numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py', 'opt_einsum'
-    ],
-    url='https://github.com/google/jax',
-    license='Apache-2.0',
-)
+__version__ = "0.1.10"

--- a/build/setup.py
+++ b/build/setup.py
@@ -16,11 +16,14 @@ from setuptools import setup
 from glob import glob
 import os
 
+with open('jaxlib/version.py') as f:
+  exec(f.read(), globals())
+
 binary_libs = [os.path.basename(f) for f in glob('jaxlib/*.so*')]
 
 setup(
     name='jaxlib',
-    version='0.1.9',
+    version=__version__,
     description='XLA library for JAX',
     author='JAX team',
     author_email='jax-dev@google.com',


### PR DESCRIPTION
Updates XLA to https://github.com/tensorflow/tensorflow/commit/00afc7bb81d6d36a0f619c08c011abe08965a25b.

The new XLA release removes the use of protocol buffers from the XLA client. Fixes #349.
Add backward compatibility shims to jaxlib to allow older jax releases to still work on an up to date jaxlib.

The new XLA release also incorporates a fix that avoids a host-device copy for every iteration of a `lax.fori_loop()` on GPU. Fixes #402.

Add a new `jaxlib.__version__` field, change jax/jaxlib compatibility logic to check for it.