### PR TITLE
Simplify Gather and Scatter by removing the index_vector_dim.

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -2537,8 +2537,8 @@ def _gather_dimensions_proto(indices_shape, dimension_numbers):
   proto.offset_dims.extend(dimension_numbers.offset_dims)
   proto.collapsed_slice_dims.extend(dimension_numbers.collapsed_slice_dims)
   proto.start_index_map.extend(dimension_numbers.start_index_map)
-  assert len(indices_shape) > 0
-  proto.index_vector_dim = len(indices_shape) - 1
+  assert indices_shape.rank() > 0
+  proto.index_vector_dim = indices_shape.rank() - 1
   return proto
 
 def _gather_dtype_rule(operand, start_indices, **kwargs):
@@ -2688,8 +2688,8 @@ def _scatter_dimensions_proto(indices_shape, dimension_numbers):
   proto.inserted_window_dims.extend(dimension_numbers.inserted_window_dims)
   proto.scatter_dims_to_operand_dims.extend(
       dimension_numbers.scatter_dims_to_operand_dims)
-  assert len(indices_shape) > 0
-  proto.index_vector_dim = len(indices_shape) - 1
+  assert indices_shape.rank() > 0
+  proto.index_vector_dim = indices_shape.rank() - 1
   return proto
 
 def _scatter_dtype_rule(operand, scatter_indices, updates, **kwargs):

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -2633,7 +2633,7 @@ def _gather_batching_rule(batched_args, batch_dims, dimension_numbers,
     count_shape = list(start_indices.shape)
     count_shape[-1] = 1
     counts = broadcasted_iota(start_indices.dtype, tuple(count_shape), 0)
-    start_indices = concatenate([counts, start_indices], len(counts_shape) - 1)
+    start_indices = concatenate([counts, start_indices], len(count_shape) - 1)
 
     slice_sizes = (1,) + slice_sizes
     collapsed_slice_dims = (0,) + tuple(onp.add(1, dimension_numbers.collapsed_slice_dims))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1850,9 +1850,8 @@ def take(a, indices, axis=None, out=None, mode=None):
       list(range(axis)) +
       list(range(axis + index_dims, len(a.shape) + index_dims - 1))),
     collapsed_slice_dims=(axis,),
-    start_index_map=(axis,),
-    index_vector_dim=index_dims)
-  return lax.gather(a, indices, dimension_numbers=dnums,
+    start_index_map=(axis,))
+  return lax.gather(a, indices[..., None], dimension_numbers=dnums,
                     slice_sizes=tuple(slice_sizes))
 
 

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -554,18 +554,20 @@ class BatchingTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.int32]
       for axis, shape, idxs, dnums, slice_sizes in [
-          (0, (3, 5), onp.array([0, 2]), lax.GatherDimensionNumbers(
-            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1,)),
-          (1, (10, 3), onp.array([0, 0, 0]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-            index_vector_dim=1), (2,)),
-          (1, (10, 3, 5), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1, 3)),
-          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+          (0, (3, 5), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1,)),
+          (1, (10, 3), onp.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+            (2,)),
+          (1, (10, 3, 5), onp.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1, 3)),
+          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]),
+           lax.GatherDimensionNumbers(
+             offset_dims=(1,), collapsed_slice_dims=(0,),
+             start_index_map=(0, 1)),
+            (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -586,19 +588,20 @@ class BatchingTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.float64]
       for axis, shape, idxs, dnums, slice_sizes in [
-          (0, (3, 5), onp.array([0, 2]), lax.GatherDimensionNumbers(
-            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1,)),
-          (1, (10, 3), onp.array([0, 0, 0]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-            index_vector_dim=1), (2,)),
-          (1, (10, 3, 5), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1, 3)),
-          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
-      ]
+          (0, (3, 5), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1,)),
+          (1, (10, 3), onp.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+            (2,)),
+          (1, (10, 3, 5), onp.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1, 3)),
+          (2, (10, 5, 3), onp.array([[0, 2], [1, 0]]),
+           lax.GatherDimensionNumbers(
+             offset_dims=(1,), collapsed_slice_dims=(0,),
+             start_index_map=(0, 1)),
+            (1, 3)),      ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
   def testGatherGradBatchedOperand(self, axis, shape, dtype, idxs, dnums,
@@ -619,21 +622,17 @@ class BatchingTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.int32]
       for axis, shape, idxs, dnums, slice_sizes in [
-          (0, (5,), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
-              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-              index_vector_dim=1), (1,)),
-          (1, (10,), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+          (0, (5,), onp.array([[[0], [2]], [[1], [3]]]), lax.GatherDimensionNumbers(
+              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)), (1,)),
+          (1, (10,), onp.array([[0, 0, 0], [0, 2, 1]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-               index_vector_dim=1), (2,)),
-          (1, (10, 5), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)), (2,)),
+          (1, (10, 5), onp.array([[0, 2, 1], [0, 3, 3]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-               index_vector_dim=1), (1, 3)),
-          (0, (10, 5), onp.array([[[0, 2], [1, 0]],
-                                  [[1, 2], [0, 3]]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)), (1, 3)),
+          (0, (10, 5), onp.array([[[0, 1], [2, 0]],
+                                  [[1, 0], [2, 3]]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -654,21 +653,17 @@ class BatchingTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.float64]
       for axis, shape, idxs, dnums, slice_sizes in [
-          (0, (5,), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
-              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-              index_vector_dim=1), (1,)),
-          (1, (10,), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+          (0, (5,), onp.array([[[0], [2]], [[1], [3]]]), lax.GatherDimensionNumbers(
+              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)), (1,)),
+          (1, (10,), onp.array([[0, 0, 0], [0, 2, 1]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-               index_vector_dim=1), (2,)),
-          (1, (10, 5), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)), (2,)),
+          (1, (10, 5), onp.array([[0, 2, 1], [0, 3, 3]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-               index_vector_dim=1), (1, 3)),
-          (0, (10, 5), onp.array([[[0, 2], [1, 0]],
-                                  [[1, 2], [0, 3]]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)), (1, 3)),
+          (0, (10, 5), onp.array([[[0, 1], [2, 0]],
+                                  [[1, 0], [2, 3]]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)), (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -691,21 +686,23 @@ class BatchingTest(jtu.JaxTestCase):
        "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.int32]
       for op_axis, idxs_axis, shape, idxs, dnums, slice_sizes in [
-          (0, 0, (2, 5), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
-              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-              index_vector_dim=1), (1,)),
-          (1, 1, (10, 2), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+          (0, 0, (2, 5), onp.array([[[0], [2]], [[1], [3]]]),
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-               index_vector_dim=1), (2,)),
-          (0, 1, (2, 10, 5,), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+           (1,)),
+          (1, 1, (10, 2), onp.array([[0, 0, 0], [0, 2, 1]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-               index_vector_dim=1), (1, 3)),
+             offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+           (2,)),
+          (0, 1, (2, 10, 5,), onp.array([[[0, 2, 1], [0, 3, 3]]]).T,
+           lax.GatherDimensionNumbers(
+             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+           (1, 3)),
           (2, 0, (10, 5, 2), onp.array([[[0, 2], [1, 0]],
-                                        [[1, 0], [2, 0]]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+                                        [[1, 0], [2, 0]]]),
+          lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
+           (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])
@@ -729,21 +726,23 @@ class BatchingTest(jtu.JaxTestCase):
        "rng": rng, "rng_idx": rng_idx}
       for dtype in [onp.float32, onp.int32]
       for op_axis, idxs_axis, shape, idxs, dnums, slice_sizes in [
-          (0, 0, (2, 5), onp.array([[0, 2], [1, 3]]), lax.GatherDimensionNumbers(
-              offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-              index_vector_dim=1), (1,)),
-          (1, 1, (10, 2), onp.array([[0, 0, 0], [0, 2, 1]]).T,
+          (0, 0, (2, 5), onp.array([[[0], [2]], [[1], [3]]]),
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-               index_vector_dim=1), (2,)),
-          (0, 1, (2, 10, 5,), onp.array([[0, 2, 1], [0, 3, 3]]).T,
+             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+           (1,)),
+          (1, 1, (10, 2), onp.array([[0, 0, 0], [0, 2, 1]]).T[..., None],
            lax.GatherDimensionNumbers(
-               offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-               index_vector_dim=1), (1, 3)),
+             offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+           (2,)),
+          (0, 1, (2, 10, 5,), onp.array([[[0, 2, 1], [0, 3, 3]]]).T,
+           lax.GatherDimensionNumbers(
+             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+           (1, 3)),
           (2, 0, (10, 5, 2), onp.array([[[0, 2], [1, 0]],
-                                        [[1, 0], [2, 0]]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+                                        [[1, 0], [2, 0]]]),
+          lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
+           (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()])

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1387,18 +1387,18 @@ class LaxTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in all_dtypes
       for shape, idxs, dnums, slice_sizes in [
-          ((5,), onp.array([0, 2]), lax.GatherDimensionNumbers(
-            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1,)),
-          ((10,), onp.array([0, 0, 0]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-            index_vector_dim=1), (2,)),
-          ((10, 5,), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1, 3)),
+          ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1,)),
+          ((10,), onp.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+            (2,)),
+          ((10, 5,), onp.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1, 3)),
           ((10, 5), onp.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1),
-            index_vector_dim=1), (1, 3)),
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
+            (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()]))
@@ -1417,15 +1417,15 @@ class LaxTest(jtu.JaxTestCase):
        "rng_idx": rng_idx}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
-          ((5,), onp.array([0, 2]), (2,), lax.ScatterDimensionNumbers(
+          ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
-          ((10,), onp.array([0, 0, 0]), (3, 2), lax.ScatterDimensionNumbers(
+            scatter_dims_to_operand_dims=(0,))),
+          ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
-          ((10, 5,), onp.array([0, 2, 1]), (3, 3), lax.ScatterDimensionNumbers(
+            scatter_dims_to_operand_dims=(0,))),
+          ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
+            scatter_dims_to_operand_dims=(0,))),
       ]
       for rng_idx in [jtu.rand_int(max(arg_shape))]
       for rng in [jtu.rand_default()]))
@@ -2131,15 +2131,15 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
       for dtype in float_dtypes
       for shape, idxs, dnums, slice_sizes in [
-          ((5,), onp.array([0, 2]), lax.GatherDimensionNumbers(
-            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1,)),
-          ((10,), onp.array([0, 0, 0]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,),
-            index_vector_dim=1), (2,)),
-          ((10, 5,), onp.array([0, 2, 1]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,),
-            index_vector_dim=1), (1, 3)),
+          ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
+            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1,)),
+          ((10,), onp.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+            (2,)),
+          ((10, 5,), onp.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
+            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+            (1, 3)),
       ]
       for rng_idx in [jtu.rand_int(max(shape))]
       for rng in [jtu.rand_default()]))
@@ -2159,15 +2159,15 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "rng_idx": rng_idx}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
-          ((5,), onp.array([0, 2]), (2,), lax.ScatterDimensionNumbers(
+          ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
-          ((10,), onp.array([0, 0, 0]), (3, 2), lax.ScatterDimensionNumbers(
+            scatter_dims_to_operand_dims=(0,))),
+          ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
-          ((10, 5,), onp.array([0, 2, 1]), (3, 3), lax.ScatterDimensionNumbers(
+            scatter_dims_to_operand_dims=(0,))),
+          ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,), index_vector_dim=1)),
+            scatter_dims_to_operand_dims=(0,))),
       ]
       for rng_idx in [jtu.rand_int(max(arg_shape))]
       for rng in [jtu.rand_default()]))


### PR DESCRIPTION
Use a canonical choice of:
* there is always a vector index dimension
* it is always the last dimension in indices.