### PR TITLE
allow stax apply_fns to take general kwargs, not just rng

### DIFF
--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -43,7 +43,7 @@ def _CheckShapeAgreement(test_case, init_fun, apply_fun, input_shape):
   result_shape, params = init_fun(input_shape)
   inputs = random_inputs(onp.random.RandomState(0), input_shape)
   rng_key = random.PRNGKey(0)
-  result = apply_fun(params, inputs, rng_key)
+  result = apply_fun(params, inputs, rng=rng_key)
   test_case.assertEqual(result.shape, result_shape)
 
 


### PR DESCRIPTION
Implementation of an idea from @craffel that simplifies future improvements.  Because stax's Dropout signature for rng is different for every other function in stax (it's an arg not a kwarg there) there's a small chance this could effect some end-users code if they _directly_ called Dropout's apply_fn, otherwise it shouldn't affect end-user code.  I think the flexibility provided by this change is more than worth that trouble.