### PR TITLE
Add StaxLayer: tuple with properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ cd jax
 pip install scipy
 ```
 
+If you are building on Linux, make sure `libpythonX.X-dev` corresponding to your
+Python version is installed (e.g. `libpython3.6-dev`).
+
 If you are building on a Mac, make sure XCode and the XCode command line tools
 are installed.
 

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -135,6 +135,17 @@ class StaxTest(jtu.JaxTestCase):
     init_fun, apply_fun = stax.serial(*spec)
     _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)
 
+  def testStaxLayerProperties(self):
+    layers = [stax.Conv(3, (2, 2)), stax.Conv(3, (2, 2))]
+    serial = stax.serial(*layers)
+    [self.assertIs(l1, l2) for (l1, l2) in zip(layers, serial.layers)]
+    [self.assertIs(f1, f2) for (f1, f2) in zip(
+        (serial.init_fun, serial.apply_fun),
+        serial)]
+
+    parallel = stax.parallel(*layers)
+    [self.assertIs(l1, l2) for (l1, l2) in zip(layers, serial.layers)]
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_input_shape={}".format(input_shape),
        "input_shape": input_shape}
@@ -163,7 +174,7 @@ class StaxTest(jtu.JaxTestCase):
     init_fun, apply_fun = stax.FanInConcat(axis)
     _CheckShapeAgreement(self, init_fun, apply_fun, input_shapes)
 
-  def testIsuse182(self):
+  def testIssue182(self):
     init_fun, apply_fun = stax.Softmax
     input_shape = (10, 3)
     inputs = onp.arange(30.).astype("float32").reshape(input_shape)


### PR DESCRIPTION
This is a simple and stateless way of exposing properties of interest on `stax` layers.

Came about when thinking about `ppipe` and that it would be nice if the user could simply pass in a `stax.serial` model to split those layers across devices.

Also @levskaya's `Let` and `LetP` could use this to expose `params` and `values`.

This PR wraps `serial` and `parallel` outputs in `StaxLayer`, exposing the `layers` property.