### PR TITLE
add support for returning aux data from grad

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -180,7 +180,7 @@ def grad(fun, argnums=0, has_aux=False):
     argnums: Optional, integer or tuple of integers. Specifies which positional
       argument(s) to differentiate with respect to (default 0).
     has_aux: Optional, bool. Indicates whether `fun` returns a pair where the
-     first element is considered the output of the mathematical functoin to be
+     first element is considered the output of the mathematical function to be
      differentiated and the second element is auxiliary data. Default False.
 
   Returns:
@@ -188,7 +188,8 @@ def grad(fun, argnums=0, has_aux=False):
     `fun`. If `argnums` is an integer then the gradient has the same shape and
     type as the positional argument indicated by that integer. If argnums is a
     tuple of integers, the gradient is a tuple of values with the same shapes
-    and types as the corresponding arguments.
+    and types as the corresponding arguments. If `has_aux` is True then a pair
+    of (gradient, auxiliary_data) is returned.
 
   For example:
 
@@ -226,7 +227,7 @@ def value_and_grad(fun, argnums=0, has_aux=False):
     argnums: Optional, integer or tuple of integers. Specifies which positional
       argument(s) to differentiate with respect to (default 0).
     has_aux: Optional, bool. Indicates whether `fun` returns a pair where the
-     first element is considered the output of the mathematical functoin to be
+     first element is considered the output of the mathematical function to be
      differentiated and the second element is auxiliary data. Default False.
 
   Returns:
@@ -559,7 +560,7 @@ def vjp(fun, *primals, **kwargs):
       of positional parameters to `fun`. Each primal value should be a tuple of
       arrays, scalar, or standard Python containers thereof.
     has_aux: Optional, bool. Indicates whether `fun` returns a pair where the
-     first element is considered the output of the mathematical functoin to be
+     first element is considered the output of the mathematical function to be
      differentiated and the second element is auxiliary data. Default False.
 
   Returns:

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -66,8 +66,8 @@ def jvp_subtrace_aux(master, primals, tangents):
   for x in list(primals) + list(tangents):
     if isinstance(x, Tracer):
       assert x.trace.level < trace.level
-  ans_and_aux = yield map(partial(JVPTracer, trace), primals, tangents)
-  out_tracer, aux_tracer = trace.full_raise(ans_and_aux)
+  ans, aux = yield map(partial(JVPTracer, trace), primals, tangents)
+  out_tracer, aux_tracer = map(trace.full_raise, (ans, aux))
   out_primal, out_tangent = out_tracer.primal, out_tracer.tangent
   aux = aux_tracer.primal  # ignore aux tangent
   yield (out_primal, out_tangent), aux

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -372,6 +372,10 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(g, grad(lambda x: x**3)(4.))
     self.assertEqual(aux, [4.])
 
+    g, aux = grad(lambda x: (x**3, [x**2, 4.]), has_aux=True)(4.)
+    self.assertEqual(g, grad(lambda x: x**3)(4.))
+    self.assertEqual(aux, [4.**2, 4.])
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -343,7 +343,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_grad_and_aux_basic(self):
     g, aux = grad(lambda x: (x**3, [x**2]), has_aux=True)(3.)
-    self.assertEqual(type(aux), list)
+    self.assertEqual(g, grad(lambda x: x**3)(3.))
     self.assertEqual(aux, [9.])
 
   def test_grad_and_aux_nested(self):
@@ -366,6 +366,11 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(grad(f)(4.), grad(f2)(4.))
     self.assertEqual(jit(grad(f))(4.), grad(f2)(4.))
     self.assertEqual(jit(grad(jit(f)))(4.), grad(f2)(4.))
+
+  def test_grad_and_aux_constant(self):
+    g, aux = grad(lambda x: (x**3, [4.]), has_aux=True)(4.)
+    self.assertEqual(g, grad(lambda x: x**3)(4.))
+    self.assertEqual(aux, [4.])
 
 
 if __name__ == '__main__':

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -341,6 +341,32 @@ class APITest(jtu.JaxTestCase):
     ans = jit(lambda x: 2 * x)(np.ones(int(2e6)))  # doesn't crash
     self.assertAllClose(ans, 2., check_dtypes=False)
 
+  def test_grad_and_aux_basic(self):
+    g, aux = grad(lambda x: (x**3, [x**2]), has_aux=True)(3.)
+    self.assertEqual(type(aux), list)
+    self.assertEqual(aux, [9.])
+
+  def test_grad_and_aux_nested(self):
+    def f(x):
+      g, aux = grad(lambda x: (x**3, [x**3]), has_aux=True)(x)
+      return aux[0]
+
+    f2 = lambda x: x**3
+
+    self.assertEqual(grad(f)(4.), grad(f2)(4.))
+    self.assertEqual(jit(grad(f))(4.), grad(f2)(4.))
+    self.assertEqual(jit(grad(jit(f)))(4.), grad(f2)(4.))
+
+    def f(x):
+      g, aux = grad(lambda x: (x**3, [x**3]), has_aux=True)(x)
+      return aux[0] * np.sin(x)
+
+    f2 = lambda x: x**3 * np.sin(x)
+
+    self.assertEqual(grad(f)(4.), grad(f2)(4.))
+    self.assertEqual(jit(grad(f))(4.), grad(f2)(4.))
+    self.assertEqual(jit(grad(jit(f)))(4.), grad(f2)(4.))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #366 and fixes #483 

The auxiliary data can be any pytree. Here's an example:

```python
from jax import grad

def f(x):
  val = x**2
  aux = [x**3, x**4]
  return val, aux

g, aux = grad(f, has_aux=True)(2.)
print(g)  # 4. == grad(lambda x: x**2)(2.)
print(aux)  # [8., 16.]
```

Thoughts on that API? An alternative would be to add more functions, like `grad_and_aux`, but then we might also need `val_and_grad_and_aux`. Ugh.

Also, suggestions welcome on how to tighten up the code.