### PR TITLE
add batching rule for lax.while_loop

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -35,28 +35,27 @@ from ..util import unzip2, partial, safe_map
 map = safe_map
 
 
-def batch(fun, in_vals, in_dims, out_dim_target):
+def batch(fun, in_vals, in_dims, out_dim_dst):
   sizes = reduce(set.union, map(dimsize, in_dims, in_vals))
   if not sizes:
     return fun.call_wrapped(*in_vals), None  # no mapped dimensions
   elif len(sizes) == 1:
-    out_val, out_dim = batch_transform(fun).call_wrapped(in_vals, in_dims)
-    return moveaxis(sizes.pop(), out_dim_target, out_dim, out_val)
+    sz = sizes.pop()
+    return batch_transform(fun, sz, in_dims, out_dim_dst).call_wrapped(in_vals)
   else:
     raise TypeError("got inconsistent map dimension sizes: {}".format(sizes))
 
 
-# TODO(mattjj,dougalm): could call batch_subtrace here (a bit redundant)
 @transformation
-def batch_transform(vals, dims):
+def batch_transform(size, in_dims, out_dim_dst, vals):
   with new_master(BatchTrace) as master:
     trace = BatchTrace(master, core.cur_sublevel())
-    in_tracers = map(partial(BatchTracer, trace), vals, dims)
+    in_tracers = map(partial(BatchTracer, trace), vals, in_dims)
     out_tracer = yield in_tracers
     out_tracer = trace.full_raise(out_tracer)
     out_val, out_dim = out_tracer.val, out_tracer.batch_dim
     del master
-  yield (out_val, out_dim)
+  yield moveaxis(size, out_dim_dst, out_dim, out_val)
 
 
 @transformation_with_aux

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -307,13 +307,21 @@ def move_dim_to_front(x, dim):
 def dimsize(dim, x):
   aval = get_aval(x)
   if type(aval) is AbstractTuple:
-    return reduce(set.union, map(partial(dimsize, dim), x))
-  elif type(dim) is int:
-    return {x.shape[dim]}
-  elif dim is None:
-    return set()
+    if type(dim) is tuple:
+      return reduce(set.union, map(dimsize, dim, x))
+    elif type(dim) is int:
+      return reduce(set.union, map(partial(dimsize, dim), x))
+    elif dim is None:
+      return set()
+    else:
+      raise TypeError(type(dim))
   else:
-    raise TypeError(type(dim))
+    if type(dim) is int:
+      return {x.shape[dim]}
+    elif dim is None:
+      return set()
+    else:
+      raise TypeError(type(dim))
 
 def moveaxis(sz, dst, src, x):
   aval = get_aval(x)

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -3670,7 +3670,7 @@ def _while_loop_batching_rule(batched_args, batch_dims, aval_out, cond_jaxpr,
   # See https://github.com/google/jax/issues/441 for a discussion.
   # To batch a while_loop, we need to do some masking, since the elements of the
   # batch may run for different numbers of iterations. We perform that masking
-  # usnig lax.select, and keep the loop running so long as any of the batch
+  # using lax.select, and keep the loop running so long as any of the batch
   # elements need by effectively using an np.any(...) in the cond_fun.
   # The basic strategy here is to lift `cond_jaxpr` and `body_jaxpr` back into
   # traceable Python functions using `core.eval_jaxpr`. Then we can batch them

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -833,6 +833,19 @@ class BatchingTest(jtu.JaxTestCase):
 
     H = hessian(f)(R)  # don't crash on UnshapedArray
 
+  def testWhileLoop(self):
+    def fun(x):
+      return lax.while_loop(lambda x: x < 3, lambda x: x + 2, x)
+
+    ans = vmap(fun)(onp.array([0, 1, 2, 3]))
+    expected = onp.array([4, 3, 4, 3])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    fun = jit(fun)
+    ans = vmap(fun)(onp.array([0, 1, 2, 3]))
+    expected = onp.array([4, 3, 4, 3])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -846,6 +846,22 @@ class BatchingTest(jtu.JaxTestCase):
     expected = onp.array([4, 3, 4, 3])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testWhileLoopCondConstsBatched(self):
+    def fun(x, y):
+      return lax.while_loop(lambda x: x < y, lambda x: x + 2, x)
+
+    ans = vmap(fun, in_axes=(None, 0))(0, onp.array([2, 3]))
+    expected = onp.array([2, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def testWhileLoopBodyConstsBatched(self):
+    def fun(x, y):
+      return lax.while_loop(lambda x: x < 3, lambda x: x + y, x)
+
+    ans = vmap(fun, in_axes=(None, 0))(0, onp.array([2, 3]))
+    expected = onp.array([4, 3])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #441 

Only lightly tested at the moment.

As per the discussion in #441, to batch a `while_loop` we need to do some masking, since the elements of the batch may run for different numbers of iterations. This code performs that masking with `lax.select`, and keeps running so long as any of the constituent loops need.

The basic strategy here is to lift `cond_jaxpr` and `body_jaxpr` back into Python traceables by using `core.eval_jaxpr`. Then we can just use `batching.batch_transform` (the transform underlying `vmap`) on them. The code avoids broadcasting out `cond_consts` and `body_consts`.