### PR TITLE
while_loop vmap init_val with mixed map/unmap dims

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -3683,12 +3683,11 @@ def _while_loop_batching_rule(batched_args, batch_dims, aval_out, cond_jaxpr,
   size = sizes.pop()
   assert not sizes
 
-  if init_val_bd is None:
-    # TODO(mattjj): if cond_consts_bd is also None, we could keep cond_fun
-    # unbatched and avoid the masking logic, but we ignore that optimiztaion
-    init_val = batching.bdim_at_front(init_val, init_val_bd, size,
-                                      force_broadcast=True)
-    init_val_bd = 0
+  # TODO(mattjj): if cond_consts_bd is also None, we could keep cond_fun
+  # unbatched and avoid the masking logic, but we ignore that optimiztaion
+  init_val = batching.bdim_at_front(init_val, init_val_bd, size,
+                                    force_broadcast=True)
+  init_val_bd = 0
 
   def batched_cond_fun(batched_loop_carry):
     @lu.wrap_init

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -913,6 +913,19 @@ class BatchingTest(jtu.JaxTestCase):
     expected = (onp.array([10, 11]), onp.array([20, 20]))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testIssue489(self):
+    def f(key):
+      def body_fn(uk):
+        key = uk[1]
+        u = random.uniform(key, ())
+        key, _ = random.split(key)
+        return u, key
+
+      u, _ = lax.while_loop(lambda uk: uk[0] > 0.5, body_fn, (1., key))
+      return u
+
+    print(vmap(f)(random.split(random.PRNGKey(0), 2)))  # no crash
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -917,7 +917,7 @@ class BatchingTest(jtu.JaxTestCase):
     def f(key):
       def body_fn(uk):
         key = uk[1]
-        u = random.uniform(key, ())
+        u = random.uniform(key, (), dtype=np.float64)
         key, _ = random.split(key)
         return u, key
 


### PR DESCRIPTION
When a while_loop init_val is not mapped/batched in a vmap, we need to broadcast it out since the result of the body_fun will be mapped. Since the init_val can be a tuple in general, we need to handle mixed mapped/unmapped tuple elements, i.e. handle a mixture of NoneType and int bdims for init_val.

This also let us delete some redundant code.

This bug was another case of me not thinking in terms of tuple-input/tuple-output primitives, since those are rare (and while_loop is one of them).

fixes #489