### PR TITLE
Support subclass inheritance of pytree behavior

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -588,7 +588,7 @@ def vjp(fun, *primals, **kwargs):
     out_tree, aux_tree = out_tree.children
   out_primal_py = build_tree(out_tree, out_primal)
   ct_in_trees = [out_tree]
-  ct_out_tree = PyTreeDef(node_types[tuple], None, in_trees)
+  ct_out_tree = PyTreeDef(node_types[tuple], tuple, in_trees)
   def out_vjp_packed(cotangent_in):
     return out_vjp(cotangent_in)
   vjp_py = partial(apply_jaxtree_fun, out_vjp_packed, (ct_in_trees, ct_out_tree))

--- a/jax/core.py
+++ b/jax/core.py
@@ -26,6 +26,7 @@ import types
 from . import linear_util as lu
 from .util import unzip2, safe_zip, safe_map, partial
 from .pprint_util import pp, vcat, hcat, pp_kv_pairs
+from .tree_util import register_pytree_leaf
 
 # TODO(dougalm): the trace cache breaks the leak detector. Consisder solving.
 check_leaks = False
@@ -456,6 +457,8 @@ class JaxTuple(tuple):
       return unitvar
     else:
       return 'JaxTuple({})'.format(','.join(map(repr, self)))
+
+register_pytree_leaf(JaxTuple)
 
 
 class AbstractTuple(AbstractValue, tuple):

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -23,6 +23,7 @@ from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ShapedArray, ConcreteArray
 from ..linear_util import thunk, transformation, transformation_with_aux
+from ..tree_util import register_pytree_leaf
 from ..util import unzip2, safe_zip, safe_map, toposort, partial
 from ..core import (Trace, Tracer, new_master, Jaxpr, JaxprEqn, get_aval, pack,
                     AbstractValue, AbstractTuple, unit, unitvar, Primitive,
@@ -252,6 +253,8 @@ class PartialVal(tuple):
         and isinstance(xs[1], core.Tracer) or core.valid_jaxtype(xs[1])
     ), xs
     return tuple.__new__(cls, xs)
+
+register_pytree_leaf(PartialVal)
 
 valid_pv_types = (AbstractValue, JaxprTracerTuple, type(None))
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -174,10 +174,13 @@ class CoreTest(jtu.JaxTestCase):
     pe.trace_to_jaxpr(foo, (_,))
 
   def test_tree_multimap(self):
-    xs = ({'a': 1}, [2, 3])
-    ys = ({'a': 10}, [20, 30])
-    ys_bad = ({'a': 10, 'b': 10}, [20, 30])
-    zs = ({'a': 11}, [22, 33])
+    class MyDict(dict):
+      pass
+    MyNT = namedtuple('MyNT', ['a', 'b'])
+    xs = ({'a': 1}, [2, 3], MyDict({'c': 4}), MyNT(5, 6))
+    ys = ({'a': 10}, [20, 30], MyDict({'c': 40}), MyNT(50, 60))
+    ys_bad = ({'a': 10, 'b': 10}, [20, 30], MyDict({'c': 40}), MyNT(50, 60))
+    zs = ({'a': 11}, [22, 33], MyDict({'c': 44}), MyNT(55, 66))
 
     f = lambda x, y: x + y
     assert tree_multimap(f, xs, ys) == zs


### PR DESCRIPTION
I'm exploring some ideas around object-oriented layers, where it would be helpful if subclasses could inherit pytree registration from their base classes. This PR makes pytree behavior inheritable by default, but also lets subclasses override any inherited behavior and allows registering a superclass in a non-inheritable way.