### PR TITLE
remove JaxTuples from optimizer states

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -24,7 +24,7 @@ from ..core import JaxTuple, Trace, Tracer, new_master, get_aval, pack, call_p, 
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval,
                        zeros_like_p, zero, Zero)
 from ..util import unzip2, unzip3, safe_map, safe_zip, partial
-from ..tree_util import process_pytree, build_tree, register_pytree_node, prune, tree_map
+from ..tree_util import process_pytree, build_tree, register_pytree_node, tree_map
 from ..linear_util import thunk, staged, transformation, transformation_with_aux, wrap_init
 
 from six.moves import builtins, reduce

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -74,7 +74,7 @@ def prefix_multimap(f, treedef, tree, *rest):
       all_children.append(other_children)
     all_children = zip(*all_children)
 
-    new_children = [tree_multimap_prefix(f, td, *xs)
+    new_children = [prefix_multimap(f, td, *xs)
                     for td, xs in zip(treedef.children, all_children)]
     return node_type.from_iterable(node_data, new_children)
 

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -67,8 +67,9 @@ def tree_multimap(f, tree, *rest):
     all_children = [children]
     for other_tree in rest:
       other_node_type = node_types.get(type(other_tree))
-      if node_type != other_node_type:
-        raise TypeError('Mismatch: {} != {}'.format(other_node_type, node_type))
+      # TODO(mattjj): enable this check
+      # if node_type != other_node_type:
+      #   raise TypeError('Mismatch: {} != {}'.format(other_node_type, node_type))
       other_children, other_node_data = node_type.to_iterable(other_tree)
       if other_node_data != node_spec:
         raise TypeError('Mismatch: {} != {}'.format(other_node_data, node_spec))


### PR DESCRIPTION
We formed JaxTuples in the optimizer states of experimental/optimizers.py so that we could reuse the pytree machinery without it mapping into those state tuples. But that caused a lot of headaches, e.g. when users wanted to serialize optimizer states (for saving to disk or doing distributed optimization) or when users attempted to pmap/vmap over optimizer states. (Really, JaxTuples should never be returned to users.)

Optimizer states include not just parameters but also things like velocities/momentum. The basic pattern before was that given a pytree of parameter arrays an optimizer state would be a pytree with the same structure but with each leaf as a JaxTuple instance that collected together a parameter vector with e.g. its corresponding velocity vector.

This PR contains a sequence of commits that tried out three different solutions for removing JaxTuples from optimizer states:
1. In 55a28b3 and 7be3649, instead of storing a pytree of JaxTuples we store optimizer states as a tuple of pytrees. We ultimately came back to this solution (plus a bit of refactoring).
1. In 04cfa11 we tried storing a pytree of regular Python tuples and using a `prefix_multimap` function that would only map down into a tree prefix (thus not mapping into the state tuples). This worked really well except for the `iterate`/`get_params` function, which didn't have the tree prefix information available. A solution would be to stash that information somewhere as a side-effect (maybe making optimizer instances into classes rather than plain Python tuples) and to return a `get_params` function (in addition to `init_fun` and `update_fun`), but that would also involve an API change for user code.
1. In 6fdf64d building on the previous solution we tried adding an `OptState` namedtuple class, with the advantage over the JaxTuple version being that it is registered as a proper pytree, and then stashing the prefix treedef information as node data. This worked well enough but still had the downsides of introducing a new type into optimizer states.

Ultimately in f94c206 we went back to the first solution pattern, but cleaned up the implementation by writing a `tree_mimomap` function.

This PR also added some docstrings to tree_util.py.