### PR TITLE
handle numpy < 1.14 behavior of isclose

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -488,7 +488,7 @@ class JaxTestCase(parameterized.TestCase):
 
     self.assertAllClose(python_ans, compiled_ans, check_dtypes, rtol, atol)
 
-  def _CheckAgainstNumpy(self, lax_op, numpy_reference_op, args_maker,
+  def _CheckAgainstNumpy(self, numpy_reference_op, lax_op, args_maker,
                          check_dtypes=False, tol=1e-5):
     args = args_maker()
     numpy_ans = numpy_reference_op(*args)


### PR DESCRIPTION
I guess the alternative is not to behave like numpy in this case. But I'd rather get this change in and debate that separately, since it's the easier answer to say we agree with numpy, even version 1.13.3 (which is what our tests check).