### PR TITLE
add a function for elementwise jacobian accumulation

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -353,6 +353,7 @@ def hessian(fun, argnums=0):
 def _std_basis(pytree):
   leaves, _ = tree_flatten(pytree)
   ndim = sum(map(onp.size, leaves))
+  # TODO(mattjj): use a symbolic identity matrix here
   return _unravel_array_into_pytree(pytree, 1, onp.eye(ndim))
 
 def _unravel_array_into_pytree(pytree, axis, arr):
@@ -734,3 +735,26 @@ def _primitive(fun):
   traceable.primitive = fun_p
 
   return traceable
+
+
+def _elementwise_std_basis(pytree):
+  leaves, _ = tree_flatten(pytree)
+  arity = len(leaves)
+  dims = map(onp.size, leaves)
+  # TODO(mattjj): use symbolic constants
+  basis_array = onp.stack(
+      [onp.concatenate([onp.ones(dims[j]) if i == j else onp.zeros(dims[j])
+                        for j in range(arity)]) for i in range(arity)])
+  return _unravel_array_into_pytree(pytree, 1, basis_array)
+
+def jarrett(fun):
+  new_fun = _primitive(fun)
+
+  def elementwise_jvp(primals, tangents):
+    pushfwd = partial(jvp, fun, primals)
+    y, jacs = vmap(pushfwd, out_axes=(None, 0))(_elementwise_std_basis(tangents))
+    out_tangent = sum([tangent * jac for tangent, jac in zip(tangents, jacs)])
+    return y, out_tangent
+
+  ad.primitive_jvps[new_fun.primitive] = elementwise_jvp
+  return new_fun

--- a/jax/api.py
+++ b/jax/api.py
@@ -717,7 +717,7 @@ def _check_scalar(x):
     raise TypeError(msg(x))
 
 
-def _primitive(fun):
+def custom_transforms(fun):
   name = getattr(fun, '__name__', '<unnamed user primitive>')
   fun_p = core.Primitive(name)
   fun_p.def_impl(fun)
@@ -748,7 +748,7 @@ def _elementwise_std_basis(pytree):
   return _unravel_array_into_pytree(pytree, 1, basis_array)
 
 def jarrett(fun):
-  new_fun = _primitive(fun)
+  new_fun = custom_transforms(fun)
 
   def elementwise_jvp(primals, tangents):
     pushfwd = partial(jvp, fun, primals)
@@ -756,6 +756,6 @@ def jarrett(fun):
     flat_tangents, _ = tree_flatten(tangents)
     out_tangent = sum([t * jac for t, jac in zip(flat_tangents, jacs)])
     return y, out_tangent
-
   ad.primitive_jvps[new_fun.primitive] = elementwise_jvp
+
   return new_fun

--- a/jax/api.py
+++ b/jax/api.py
@@ -753,7 +753,8 @@ def jarrett(fun):
   def elementwise_jvp(primals, tangents):
     pushfwd = partial(jvp, fun, primals)
     y, jacs = vmap(pushfwd, out_axes=(None, 0))(_elementwise_std_basis(tangents))
-    out_tangent = sum([tangent * jac for tangent, jac in zip(tangents, jacs)])
+    flat_tangents, _ = tree_flatten(tangents)
+    out_tangent = sum([t * jac for t, jac in zip(flat_tangents, jacs)])
     return y, out_tangent
 
   ad.primitive_jvps[new_fun.primitive] = elementwise_jvp

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -1707,7 +1707,7 @@ xor_p = standard_binop([_any, _any], 'xor')
 ad.defjvp_zero(xor_p)
 
 def _add_transpose(t, x, y):
-  assert x is None and y is None  # computation must be linear, not affine
+  # assert x is None and y is None  # computation must be linear, not affine
   return [t, t]
 
 add_p = standard_binop([_num, _num], 'add')

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -1732,8 +1732,8 @@ ad.defbilinear_broadcasting(_brcast, mul_p, mul, mul)  # TODO
 def _safe_mul_translation_rule(c, x, y):
   dtype = c.GetShape(x).numpy_dtype()
   zero = c.Constant(onp.array(0, dtype=dtype))
-  out_shape = tuple(onp.maximum(c.GetShape(x).dimensions(),
-                                c.GetShape(y).dimensions()))
+  out_shape = broadcast_shapes(c.GetShape(x).dimensions(),
+                               c.GetShape(y).dimensions())
   return c.Select(c.Or(c.Eq(x, zero), c.Eq(y, zero)),
                   c.Broadcast(zero, out_shape),
                   c.Mul(x, y))


### PR DESCRIPTION
This PR adds the `jarrett` function implementing [the optimization from Jarrett Revels et al. 2018 _Dynamic Automatic Differentiation of GPU Broadcast Kernels_](https://arxiv.org/abs/1810.08297).

Here's example code showing the usage and effect:

```python
from jax import jarrett, vjp, make_jaxpr
import jax.numpy as np

def f(x):
  return np.sin(np.sin(np.sin(x)))
f2 = jarrett(f)

print f(3)
print f2(3)
print

_, f_vjp = vjp(f, 3.)
_, f2_vjp = vjp(f2, 3.)
print f_vjp(1.)
print f2_vjp(1.)
print

print make_jaxpr(f_vjp)(1.)
print make_jaxpr(f2_vjp)(1.)
```

```
0.14018878
0.14018878

(array(-0.9704719, dtype=float32),)
(array(-0.9704719, dtype=float32),)

{ lambda e i g ;  ; a.
  let b = pack * a
      (c d) = id b
      f = mul d e
      h = mul f g
      j = mul h i
      k = pack j
      (l) = id k
      m = pack l
  in m }

{ lambda e ;  ; a.
  let b = pack * a
      (c d) = id b
      f = mul d e
      g = pack f
      (h) = id g
      i = pack h
  in i }
```

Notice that using `jarrett` only one constant is stored for the `vjp`, and only one `mul` occurs in the backward pass!

A more practical example where this provides significant memory savings is the `gelu` nonlinearity:

```python
def gelu(x):
    return 0.5 * x * (1 + np.tanh(np.sqrt( 2 / np.pi) * (x + 0.044715 * np.power(x, 3))))
```

Here are the VJP jaxprs for the gelu:

```
{ lambda m g p i r k e ;  ; a.
  let b = pack * a
      (c d) = id b
      f = mul d e
      h = div f g
      j = mul h i
      l = mul j k
      n = safe_mul l m
      o = add_any j n
      q = mul d p
      s = mul q r
      t = add_any o s
      u = pack t
      (v) = id u
      w = pack v
  in w }

{ lambda e ;  ; a.
  let b = pack * a
      (c d) = id b
      f = mul d e
      g = pack f
      (h) = id g
      i = pack h
  in i }
```

Over in d3f9e0a we attempted another version which could apply the optimization automagically but only to all chain compositions of elementwise *unary* primitives, without the need for any user annotation. That technique is somewhat orthogonal to this one, and we could decide to merge that commit too. But even though the two aren't mutually exclusive, here's a comparison:

Upsides to the technique in this PR:
1. many fewer lines of code, keeps standard JVP machinery simple and moreover doesn't edit it at all so there's no concern about unexpected new behavior in old code
2. handles not just unary, but binary and n-ary composite functions (so it can actually handle the `gelu` use case)
3. non-magical, user controls exactly where they want to use this technique (because for multi-arity functions, i.e. not just primitives but user functions being differentiated, there are tradeoffs and doing something automatic won't handle anything beyond unary well in all cases)
4. yet another killer story for compositionality!

Downsides to the technique in this PR:
1. non-magical, user has to annotate

Because upside 1 seems great, and downside 1 does not seem very costly, our current thinking is we'll just merge the technique in this PR and leave the other as an experiment.

One surprising effect of this change is that we had to remove an assert in `lax._add_transpose` because here we're using `vmap` to batch together several perturbations at once. The computation is still linear, but `_add_transpose` doesn't know that without checking for numerical zero values.

Got lots of input and advice from @dougalm on this one.