### PR TITLE
Fix minor issue in conj_p translation rule.

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -1669,6 +1669,7 @@ def _conj_transpose_rule(t, x, input_dtype):
   else:
     return [real(t)]
 
+xla.translations[conj_p] = lambda c, x, **kwargs: c.Conj(x)
 ad.primitive_jvps[conj_p] = partial(ad.linear_jvp, conj_p)
 ad.primitive_transposes[conj_p] = _conj_transpose_rule
 


### PR DESCRIPTION
`conj_p` was forwarding its keyword arguments to the `ComputationBuilder.Conj()` method. The current implementation of `Conj()` ignores extra keyword arguments, but we shouldn't depend on this kind of implementation detail.