### PR TITLE
Stabler expit and logit derivatives

### DIFF
--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -21,7 +21,7 @@ import scipy.special as osp_special
 
 from .. import lax
 from ..api import custom_transforms
-from ..interpreters import ad
+from ..interpreters import ad, batching
 from ..numpy import lax_numpy as np
 from ..numpy.lax_numpy import _wraps, asarray, _reduction_dims, _constant_like
 
@@ -40,6 +40,7 @@ def logit(x):
   x = asarray(x)
   return lax.log(lax.div(x, lax.sub(lax._const(x, 1), x)))
 ad.defjvp2(logit.primitive, lambda g, ans, x: g / (x * (1 - x)))
+batching.defvectorized(logit.primitive)
 
 
 @_wraps(osp_special.expit)
@@ -49,6 +50,7 @@ def expit(x):
   one = lax._const(x, 1)
   return lax.div(one, lax.add(one, lax.exp(lax.neg(x))))
 ad.defjvp2(expit.primitive, lambda g, ans, x: g * ans * (1 - ans))
+batching.defvectorized(expit.primitive)
 
 
 @_wraps(osp_special.logsumexp)

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -20,6 +20,8 @@ import numpy as onp
 import scipy.special as osp_special
 
 from .. import lax
+from ..api import custom_transforms
+from ..interpreters import ad
 from ..numpy import lax_numpy as np
 from ..numpy.lax_numpy import _wraps, asarray, _reduction_dims, _constant_like
 
@@ -33,16 +35,20 @@ erfinv = _wraps(osp_special.erfinv)(lambda x: lax.erf_inv(x))
 
 
 @_wraps(osp_special.logit)
+@custom_transforms
 def logit(x):
   x = asarray(x)
   return lax.log(lax.div(x, lax.sub(lax._const(x, 1), x)))
+ad.defjvp2(logit.primitive, lambda g, ans, x: g / (x * (1 - x)))
 
 
 @_wraps(osp_special.expit)
+@custom_transforms
 def expit(x):
   x = asarray(x)
   one = lax._const(x, 1)
   return lax.div(one, lax.add(one, lax.exp(lax.neg(x))))
+ad.defjvp2(expit.primitive, lambda g, ans, x: g * ans * (1 - ans))
 
 
 @_wraps(osp_special.logsumexp)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -66,7 +66,6 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record("expit", 1, float_dtypes, jtu.rand_small_positive(), True),
     # TODO: gammaln has slightly high error.
     op_record("gammaln", 1, float_dtypes, jtu.rand_positive(), False),
-    # TODO: NaNs in gradient for logit.
     op_record("logit", 1, float_dtypes, jtu.rand_small_positive(), False),
     op_record("log_ndtr", 1, float_dtypes, jtu.rand_small(), True),
     op_record("ndtri", 1, float_dtypes, jtu.rand_uniform(0., 1.), True),


### PR DESCRIPTION
You get NAN when you run
```python
from jax.scipy.special import expit
from jax import grad

grad(expit)(-90.)
```
on GPU.

The gradient really should be zero there, not NAN. On CPU you get zero - which is correct, but I believe that's only because of [this bug](https://github.com/google/jax/issues/469).

This pr fixes that, and also fixes similar instability in the gradient of logit, for values close to 1. I used the new `custom_transforms` to define the simplified derivatives.

I've also setup batching for the new primitives.

__Edit:__ note I've removed a TODO from lax_scipy_test.py which I think was referring to this instability.