### PR TITLE
Implement expon and laplace sampler

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -399,4 +399,39 @@ def cauchy(key, shape=(), dtype=onp.float32):
   """
   u = uniform(key, shape, dtype)
   pi = _constant_like(u, onp.pi)
-  return lax.tan(pi * lax.sub(u, _constant_like(u, 0.5)))
+  return lax.tan(lax.mul(pi, lax.sub(u, _constant_like(u, 0.5))))
+
+
+@partial(jit, static_argnums=(1, 2))
+def exponential(key, shape=(), dtype=onp.float32):
+  """Sample Exponential random values with given shape and float dtype.
+
+  Args:
+    key: a PRNGKey used as the random key.
+    shape: optional, a tuple of nonnegative integers representing the shape
+      (default scalar).
+    dtype: optional, a float dtype for the returned values (default float32).
+
+  Returns:
+    A random array with the specified shape and dtype.
+  """
+  u = uniform(key, shape, dtype)
+  # taking 1 - u to move the domain of log to (0, 1] instead of [0, 1)
+  return lax.neg(lax.log(lax.sub(_constant_like(u, 1), u)))
+
+
+@partial(jit, static_argnums=(1, 2))
+def laplace(key, shape=(), dtype=onp.float32):
+  """Sample Laplace random values with given shape and float dtype.
+
+  Args:
+    key: a PRNGKey used as the random key.
+    shape: optional, a tuple of nonnegative integers representing the shape
+      (default scalar).
+    dtype: optional, a float dtype for the returned values (default float32).
+
+  Returns:
+    A random array with the specified shape and dtype.
+  """
+  u = uniform(key, shape, dtype, minval=-1., maxval=1.)
+  return lax.mul(lax.sign(u), lax.log1p(lax.neg(lax.abs(u))))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -170,6 +170,34 @@ class LaxRandomTest(jtu.JaxTestCase):
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.cauchy().cdf)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
+      for dtype in [onp.float32, onp.float64]))
+  def testExponential(self, dtype):
+    key = random.PRNGKey(0)
+    rand = lambda key: random.exponential(key, (10000,), dtype)
+    crand = api.jit(rand)
+
+    uncompiled_samples = rand(key)
+    compiled_samples = crand(key)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.expon().cdf)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
+      for dtype in [onp.float32, onp.float64]))
+  def testLaplace(self, dtype):
+    key = random.PRNGKey(0)
+    rand = lambda key: random.laplace(key, (10000,), dtype)
+    crand = api.jit(rand)
+
+    uncompiled_samples = rand(key)
+    compiled_samples = crand(key)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.laplace().cdf)
+
   def testIssue222(self):
     x = random.randint(random.PRNGKey(10003), (), 0, 0)
     assert x == 0


### PR DESCRIPTION
This PR implements Expon and Laplace samplers whose already have logpdf/pdf methods implemented.

Reference for laplace sampler: https://en.wikipedia.org/wiki/Laplace_distribution#Generating_random_variables_according_to_the_Laplace_distribution where I have transformed U ->  - 2 * U to:
+ Reduce the number of operators involved
+ Match the behaviour of uniform sampler (which is [a, b) instead of (a, b])

Pair code/review with @neerajprad

