### PR TITLE
Refactor handling of XLA backends.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -59,7 +59,8 @@ def xla_primitive_callable(prim, *abstract_args, **kwargs):
   built_c = primitive_computation(prim, *shapes, **kwargs)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
   handle_result = result_handler(result_shape)
-  compiled = built_c.Compile(shapes, xb.get_compile_options())
+  compiled = built_c.Compile(shapes, xb.get_compile_options(),
+                             backend=xb.get_backend())
   return partial(execute_compiled_primitive, compiled, handle_result)
 
 @memoize
@@ -188,7 +189,8 @@ def tuple_constant(c, val, canonicalize_types=True):
 xb.register_constant_handler(JaxTuple, tuple_constant)
 
 def translation_rule(p):
-  backend_specific_rule = backend_specific_translations[xb._platform_name].get(p)
+  backend = xb.get_backend()
+  backend_specific_rule = backend_specific_translations[backend.platform].get(p)
   try:
     return backend_specific_rule or translations[p]
   except KeyError:

--- a/jax/lax.py
+++ b/jax/lax.py
@@ -56,6 +56,7 @@ from .interpreters import parallel
 from .util import curry, memoize, safe_zip, unzip2, prod
 from .tree_util import build_tree, tree_unflatten
 from .lib import xla_bridge
+from .lib.xla_bridge import xla_client
 
 FLAGS = flags.FLAGS
 
@@ -3342,7 +3343,7 @@ def _reduce_window_sum_transpose_rule(cotangent, window_dimensions,
                     for (lo, hi), stride in zip(pads, window_strides)]
   pad_cotangent = pad(cotangent, _zero(cotangent), padding_config)
   result = _reduce_window_sum(pad_cotangent, window_dimensions, ones,
-                              xla_bridge.get_xla_client().PaddingType.VALID)
+                              xla_client.PaddingType.VALID)
   assert result.shape == input_shape
   return [result]
 
@@ -4121,7 +4122,7 @@ def _dilate_shape(shape, dilation):
 
 def padtype_to_pads(in_shape, window_shape, window_strides, padding):
   """Convert padding string to list of pairs of pad values."""
-  PaddingType = xla_bridge.get_xla_client().PaddingType
+  PaddingType = xla_client.PaddingType
 
   if isinstance(padding, str):
     mapping = {'VALID': PaddingType.VALID, 'SAME': PaddingType.SAME}

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -112,7 +112,7 @@ def cholesky_cpu_translation_rule(c, operand):
     # TODO(phawkins): support LAPACK primitives in batched mode.
     return c.Cholesky(operand)
 
-xla.backend_specific_translations['Host'][cholesky_p] = cholesky_cpu_translation_rule
+xla.backend_specific_translations['cpu'][cholesky_p] = cholesky_cpu_translation_rule
 
 
 # Symmetric/Hermitian eigendecomposition
@@ -178,7 +178,7 @@ eigh_p.def_impl(eigh_impl)
 eigh_p.def_abstract_eval(eigh_abstract_eval)
 xla.translations[eigh_p] = eigh_translation_rule
 ad.primitive_jvps[eigh_p] = eigh_jvp_rule
-xla.backend_specific_translations['Host'][eigh_p] = eigh_cpu_translation_rule
+xla.backend_specific_translations['cpu'][eigh_p] = eigh_cpu_translation_rule
 
 
 
@@ -261,7 +261,7 @@ def triangular_solve_cpu_translation_rule(
     # TODO(phawkins): support BLAS primitives in batched mode.
     return c.TriangularSolve(a, b, left_side, lower, transpose_a, conjugate_a)
 
-xla.backend_specific_translations['Host'][triangular_solve_p] = triangular_solve_cpu_translation_rule
+xla.backend_specific_translations['cpu'][triangular_solve_p] = triangular_solve_cpu_translation_rule
 
 
 # LU decomposition
@@ -360,7 +360,7 @@ def lu_cpu_translation_rule(c, operand):
 # TODO(phawkins): The hasattr() test here is to avoid incompatibilities between
 # jax and an older jaxlib. Remove after a jaxlib release includes jax_getrf.
 if hasattr(lapack, "jax_getrf"):
-  xla.backend_specific_translations['Host'][lu_p] = lu_cpu_translation_rule
+  xla.backend_specific_translations['cpu'][lu_p] = lu_cpu_translation_rule
 
 
 def lu_pivots_to_permutation(swaps, k):
@@ -471,4 +471,4 @@ svd_p = Primitive('svd')
 svd_p.def_impl(svd_impl)
 svd_p.def_abstract_eval(svd_abstract_eval)
 xla.translations[svd_p] = svd_translation_rule
-xla.backend_specific_translations['Host'][svd_p] = svd_cpu_translation_rule
+xla.backend_specific_translations['cpu'][svd_p] = svd_cpu_translation_rule

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -34,6 +34,7 @@ from ..interpreters.xla import DeviceArray
 from .. import lax
 from ..util import memoize, partial, get_module_functions, unzip2, prod as _prod
 from ..lib import xla_bridge
+from ..lib.xla_bridge import xla_client
 
 if six.PY3:
   def removechars(s, chars):
@@ -1027,7 +1028,7 @@ def _make_cumulative_reduction(onp_reduction, window_reduce, init_val,
     window_dims = [1] * num_dims
     window_dims[axis] = a_shape[axis]
     return window_reduce(
-       a, window_dims, strides, xla_bridge.get_xla_client().PaddingType.VALID)
+       a, window_dims, strides, xla_client.PaddingType.VALID)
 
   return cumulative_reduction
 


### PR DESCRIPTION
Use a new xla_client.get_local_backend() method if available, which will be available in a future Jaxlib release.
Use 'cpu', 'gpu' to name platforms instead of 'Host', and 'CUDA'.

Move logic to initialize backends into get_backend() instead of get_xla_client().
Remove xla_bridge.get_xla_client(). Just import xla_client.xla_bridge instead.

Remove _platform_name. Instead, ask the backend for its platform name.

Make `_JaxComputationBuilder` inherit directly from `xla_client.ComputationBuilder`.