### PR TITLE
Implement pareto logpdf and sampler

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -435,3 +435,26 @@ def laplace(key, shape=(), dtype=onp.float32):
   """
   u = uniform(key, shape, dtype, minval=-1., maxval=1.)
   return lax.mul(lax.sign(u), lax.log1p(lax.neg(lax.abs(u))))
+
+
+@partial(jit, static_argnums=(2, 3))
+def pareto(key, b, shape=(), dtype=onp.float32):
+  """Sample Pareto random values with given shape and float dtype.
+
+  Args:
+    key: a PRNGKey used as the random key.
+    b: an array-like broadcastable to `shape` and used as the shape parameter
+      of the random variables.
+    shape: optional, a tuple of nonnegative integers representing the shape
+      (default scalar).
+    dtype: optional, a float dtype for the returned values (default float32).
+
+  Returns:
+    A random array with the specified shape and dtype.
+  """
+  b = lax.convert_element_type(b, dtype)
+  shape = shape or onp.shape(b)
+  if onp.shape(b) != shape:
+    b = np.broadcast_to(b, shape)
+  e = exponential(key, shape, dtype)
+  return lax.exp(lax.div(e, b))

--- a/jax/scipy/stats/__init__.py
+++ b/jax/scipy/stats/__init__.py
@@ -20,5 +20,6 @@ from . import gamma
 from . import laplace
 from . import multivariate_normal
 from . import norm
+from . import pareto
 from . import t
 from . import uniform

--- a/jax/scipy/stats/pareto.py
+++ b/jax/scipy/stats/pareto.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as onp
+import scipy.stats as osp_stats
+
+from ... import lax
+from ...numpy.lax_numpy import _promote_args_like, _constant_like, _wraps, inf, where
+
+
+@_wraps(osp_stats.pareto.logpdf)
+def logpdf(x, b, loc=0, scale=1):
+  x, b, loc, scale = _promote_args_like(osp_stats.pareto.logpdf, x, b, loc, scale)
+  one = _constant_like(x, 1)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  normalize_term = lax.log(lax.div(scale, b))
+  log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))
+  return where(lax.lt(x, lax.add(loc, scale)), -inf, log_probs)
+
+@_wraps(osp_stats.pareto.pdf)
+def pdf(x, b, loc=0, scale=1):
+  return lax.exp(logpdf(x, b, loc, scale))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -151,7 +151,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     self.assertFalse(onp.all(perm1 == x))  # seems unlikely!
     self.assertTrue(onp.all(onp.sort(perm1) == x))
 
-  # TODO: add Kolmogorov-Smirnov test for Bernoulli
+  # TODO: add Chi-squared test for Bernoulli
   def testBernoulliShape(self):
     key = random.PRNGKey(0)
     x = random.bernoulli(key, onp.array([0.2, 0.3]), shape=(3, 2))

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -179,6 +179,19 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
+  @genNamedParametersNArgs(4, jtu.rand_positive())
+  def testParetoLogPdf(self, rng, shapes, dtypes):
+    scipy_fun = osp_stats.pareto.logpdf
+    lax_fun = lsp_stats.pareto.logpdf
+
+    def args_maker():
+      x, b, loc, scale = map(rng, shapes, dtypes)
+      return [x, b, loc, scale]
+
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
+
+
   @genNamedParametersNArgs(4, jtu.rand_default())
   def testTLogPdf(self, rng, shapes, dtypes):
     scipy_fun = osp_stats.t.logpdf


### PR DESCRIPTION
This PR adds pareto distribution to scipy.stats and random modules.

The design choice for random sampler follows a suggestion in #269 to make the API consistence: `jax.random.sampler(key, distribution parameters, shape, dtype)`.

The parameter name `b` follows scipy's implementation.