### PR TITLE
Update XLA.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "1c803bce5ced83038dcca2581e99cf52536cdeeee397658c2a97617df91c7cfc",
-    strip_prefix = "tensorflow-9cf0314aeecaf11093eba3827ddbf29e7ea4d9de",
+    sha256 = "1db7390bd4c51be7526dc22d665b451109cdce56eb101f9e70996ed91dbdf746",
+    strip_prefix = "tensorflow-5e8df789cc30098d791475c14a623ec68b50b4ed",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/9cf0314aeecaf11093eba3827ddbf29e7ea4d9de.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/5e8df789cc30098d791475c14a623ec68b50b4ed.tar.gz",
     ],
 )
 

--- a/build/build.py
+++ b/build/build.py
@@ -60,19 +60,19 @@ def get_python_bin_path(python_bin_path_flag):
 
 # Bazel
 
-BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/0.22.0/"
+BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/0.24.0/"
 BazelPackage = collections.namedtuple("BazelPackage", ["file", "sha256"])
 bazel_packages = {
     "Linux":
         BazelPackage(
-            file="bazel-0.22.0-linux-x86_64",
+            file="bazel-0.24.0-linux-x86_64",
             sha256=
-            "8474ed28ed4998e2f5671ddf3a9a80ae9e484a5de3b8b70c8b654c017c65d363"),
+            "cf78da6f1b65e9e35f485eab421756c4b5188a705695276843759f3c3586bb0c"),
     "Darwin":
         BazelPackage(
-            file="bazel-0.22.0-darwin-x86_64",
+            file="bazel-0.24.0-darwin-x86_64",
             sha256=
-            "0fcd80d8a20b7c8b7b70ea9da4bea9b2ce3985c792d0cc7676a9e4c2f9600478"),
+            "adaacec710cae5a217dd967766fe489b8034aa9c0cb44d4eb06813d224489e01"),
 }
 
 
@@ -146,7 +146,7 @@ def check_bazel_version(bazel_path, min_version):
   match = re.search("Build label: *([0-9\\.]+)[^0-9\\.]", version_output)
   if match is None:
     print("Warning: bazel installation is not a release version. Make sure "
-          "bazel is at least 0.19.2")
+          "bazel is at least {}".format(min_version))
     return
   version = match.group(1)
   min_ints = [int(x) for x in min_version.split(".")]
@@ -179,6 +179,7 @@ build --define=no_gcp_support=true
 build --define=no_hdfs_support=true
 build --define=no_kafka_support=true
 build --define=no_ignite_support=true
+build --define=grpc_no_ares=true
 
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
@@ -277,7 +278,7 @@ def main():
 
   # Find a working Bazel.
   bazel_path = get_bazel_path(args.bazel_path)
-  check_bazel_version(bazel_path, "0.19.2")
+  check_bazel_version(bazel_path, "0.24.0")
   print("Bazel binary path: {}".format(bazel_path))
 
   python_bin_path = get_python_bin_path(args.python_bin_path)

--- a/build/install_xla_in_source_tree.sh
+++ b/build/install_xla_in_source_tree.sh
@@ -52,12 +52,16 @@ fi
 
 # Copy the XLA dependencies into jax/lib, fixing up some imports to point to the
 # new location.
-cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/pywrap_xla.py)" \
-  "${TARGET}/jaxlib"
-cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/_pywrap_xla.so)" \
-  "${TARGET}/jaxlib"
 cp -f "$(rlocation __main__/jaxlib/lapack.so)" "${TARGET}/jaxlib"
+cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/xla_extension.so)" \
+  "${TARGET}/jaxlib"
 sed \
-  -e 's/from tensorflow.compiler.xla.python import pywrap_xla as c_api/from . import pywrap_xla as c_api/' \
+  -e 's/from tensorflow.compiler.xla.python import xla_extension as _xla/from . import xla_extension as _xla/' \
+  -e 's/from tensorflow.compiler.xla.python.xla_extension import ops/from .xla_extension import ops/' \
   < "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/xla_client.py)" \
   > "${TARGET}/jaxlib/xla_client.py"
+sed \
+  -e 's/from tensorflow.compiler.xla.python import xla_client/from . import xla_client/' \
+  -e 's/from tensorflow.compiler.xla.python import xla_extension as _xla/from . import xla_extension as _xla/' \
+  < "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/xrt.py)" \
+  > "${TARGET}/jaxlib/xrt.py"

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -191,7 +191,8 @@ def compile_replicated(jaxpr, axis_name, axis_size, consts, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
   built_c = replicated_comp(jaxpr, axis_env, consts, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
-  compiled = built_c.Compile(arg_shapes, xb.get_compile_options(num_replicas))
+  compiled = built_c.Compile(arg_shapes, xb.get_compile_options(num_replicas),
+                             backend=xb.get_backend())
   return compiled, num_replicas, result_shape
 
 def jaxpr_replicas(jaxpr):

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -136,7 +136,8 @@ def compile_jaxpr(jaxpr, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
   built_c = jaxpr_computation(jaxpr, const_vals, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
-  return built_c.Compile(arg_shapes, xb.get_compile_options()), result_shape
+  return built_c.Compile(arg_shapes, xb.get_compile_options(),
+                         backend=xb.get_backend()), result_shape
 
 def build_jaxpr(jaxpr, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
@@ -377,7 +378,8 @@ def instantiate_device_constant(const, cutoff=1e6, device_num=0):
   if const.size > cutoff and device_num == 0:
     c = xb.make_computation_builder("constant_instantiating_computation")
     xla_const = const.constant_handler(c, const)
-    compiled = c.Build(xla_const).Compile((), xb.get_compile_options())
+    compiled = c.Build(xla_const).Compile((), xb.get_compile_options(),
+                                          backend=xb.get_backend())
     return compiled.Execute(())
   else:
     return xb.device_put(onp.asarray(const), device_num)

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -49,6 +49,7 @@ _check_jaxlib_version()
 
 from jaxlib import xla_client
 from jaxlib import xla_data_pb2
+from jaxlib import xrt
 
 
 FLAGS = flags.FLAGS
@@ -133,11 +134,20 @@ def _get_local_backend():
 
   return backend
 
+def _get_xrt_backend():
+  # TODO(phawkins): support non-TPU devices.
+  tf_device_name = "TPU"
+  worker = "tpu_worker"
+  tf_context = xrt.get_tf_context(FLAGS.jax_backend_target, worker)
+  backend = xrt.XrtBackend(tf_context, tf_device_name)
+  #  TODO(phawkins) fix XrtBackend to set the following and remove this line.
+  backend.platform = "TPU"
+  return backend
 
 
 register_backend('xla', _get_local_backend)
-register_backend('xrt',
-                 lambda: xla_client.XrtBackend(FLAGS.jax_backend_target))
+register_backend('xrt', _get_xrt_backend)
+
 
 @memoize_thunk
 def get_backend():

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -49,7 +49,12 @@ _check_jaxlib_version()
 
 from jaxlib import xla_client
 from jaxlib import xla_data_pb2
-from jaxlib import xrt
+
+# Workaround for older jaxlib versions. Remove after a jaxlib release.
+try:
+  from jaxlib import xrt
+except ImportError:
+  xrt = None
 
 
 FLAGS = flags.FLAGS

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -50,7 +50,8 @@ _check_jaxlib_version()
 from jaxlib import xla_client
 from jaxlib import xla_data_pb2
 
-# Workaround for older jaxlib versions. Remove after a jaxlib release.
+# TODO(phawkins): This is a workaround for older jaxlib versions. Remove after a
+# jaxlib release.
 try:
   from jaxlib import xrt
 except ImportError:


### PR DESCRIPTION
Switches XLA Python bindings to use pybind11.
Update XRT support to point to newer XRT client.
Update minimum bazel version to 0.24.0.

Fix missing backend argument to XLA Compile() calls.