### PR TITLE
Fix LHS transpose rule for conv_general_dilated.

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -4452,9 +4452,10 @@ def _conv_general_vjp_lhs_padding(
     in_shape, window_dimensions, window_strides, out_shape, padding,
     lhs_dilation, rhs_dilation):
   lhs_dilated_shape = _dilate_shape(in_shape, lhs_dilation)
+  rhs_dilated_shape = _dilate_shape(window_dimensions, rhs_dilation)
   out_dilated_shape = _dilate_shape(out_shape, window_strides)
-  pad_before = onp.subtract(window_dimensions, [lo for lo, _ in padding]) - 1
-  pad_after = (onp.add(lhs_dilated_shape, window_dimensions) - 1
+  pad_before = onp.subtract(rhs_dilated_shape, [lo for lo, _ in padding]) - 1
+  pad_after = (onp.add(lhs_dilated_shape, rhs_dilated_shape) - 1
                - out_dilated_shape - pad_before)
   return zip(pad_before, pad_after)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1890,7 +1890,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
            [(1, 1), (1, 2), (2, 1)],  # strides
            [((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],  # pads
            [(1, 1), (2, 1)],  # lhs_dils
-           [(1, 1)])  # rhs_dils
+           [(1, 1), (2, 2)])  # rhs_dils
           for b, i, j in itertools.product([1, 2], repeat=3)]
       for strides in all_strides
       for rhs_dil in rhs_dils


### PR DESCRIPTION
Fixes the case where rhs_dilation is > 1.

Addresses one of the two problems in issue #563.