### PR TITLE
make DeviceArray.__repr__ show it's not an ndarray

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -302,6 +302,10 @@ class DeviceArray(DeviceValue):
     """Returns an ndarray (backed by host memory, not device memory)."""
     return onp.asarray(self)
 
+  def __repr__(self):
+    shape_str = ",".join(map(str, self.shape))
+    return "DeviceArray{{{}[{}]}}".format(onp.dtype(self.dtype).name, shape_str)
+
   def __len__(self):
     try:
       return self.shape[0]
@@ -329,7 +333,6 @@ class DeviceArray(DeviceValue):
 
   __array__ = partialmethod(forward_to_value, onp.asarray)
   __str__ = partialmethod(forward_to_value, str)
-  __repr__ = partialmethod(forward_to_value, repr)
   __bool__ = __nonzero__ = partialmethod(forward_to_value, bool)
   __float__ = partialmethod(forward_to_value, float)
   __int__ = partialmethod(forward_to_value, int)


### PR DESCRIPTION
reverts 33bd02

We decided we didn't like this behavior, because it goes too far in obscuring that our device-memory-backed arrays are different from ndarrays. By keeping the repr different, it's easy enough to tell in a repl or debugger that lazy device persistence is going on, and we can still print things like ndarrays when we want to.