### PR TITLE
Use safe mul for exp jvp

### DIFF
--- a/jax/lax.py
+++ b/jax/lax.py
@@ -1611,7 +1611,7 @@ is_finite_p = unop(_fixed_dtype(onp.bool_), _float, 'is_finite')
 ad.defjvp_zero(is_finite_p)
 
 exp_p = standard_unop(_float | _complex, 'exp')
-ad.defjvp2(exp_p, lambda g, ans, x: mul(g, ans))
+ad.defjvp2(exp_p, lambda g, ans, x: _safe_mul(g, ans))
 
 log_p = standard_unop(_float | _complex, 'log')
 ad.defjvp(log_p, lambda g, x: div(g, x))


### PR DESCRIPTION
The justification for this is similar to https://github.com/google/jax/pull/383. We're using an 'ELU' (exponential linear unit), defined by:

```python
def elu(x):
    return np.where(x > 0, x, np.exp(x))
```

which can result in NANs in the backward pass of autodiff when zeros from the vjp of `np.where` are multiplied by infs from evaluating `np.exp` on non-small positive values of `x`.

I wonder whether there's a more robust solution to this problem, it seems a bit of a pain to have to specify safe_mul for all the ops that sometimes produce NANs or infs...