### PR TITLE
make np.arange(N) create lazy const, add arange tests

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1264,14 +1264,14 @@ def arange(*args, **kwargs):
   if not args:
     raise TypeError("Required argument 'start' (pos 1) not found")  # same as numpy error
 
-  # if called like np.arange(N) we create a lazy lax._IotaConstant
+  # If called like np.arange(N), we create a lazy lax._IotaConstant.
   if len(args) == 1 and not kwargs:
     stop, = args
     dtype = dtype or _dtype(stop)
     if onp.issubdtype(dtype, onp.integer):
       return lax.iota(dtype, stop)  # avoids materializing
 
-  # fall back to instantiating an ndarray in host memory
+  # Fall back to instantiating an ndarray in host memory
   return onp.arange(*args, **kwargs)
 
 linspace = onp.linspace

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1260,16 +1260,18 @@ def identity(n, dtype=None):
 
 @_wraps(onp.arange)
 def arange(*args, **kwargs):
-  # attempt to generate a lazy IotaConstant, otherwise fall back to raw numpy
-  # TODO(mattjj): add tests for this function, then re-enable
-  # dtype = kwargs.pop("dtype", None)
-  # if not args:
-  #   raise TypeError("Required argument 'start' (pos 1) not found")  # same as numpy error
-  # elif len(args) == 1 and not kwargs:
-  #   stop, = args
-  #   dtype = dtype or _dtype(stop)
-  #   if onp.issubdtype(dtype, onp.integer):
-  #     return lax.iota(dtype, stop)  # avoids materializing
+  dtype = kwargs.pop("dtype", None)
+  if not args:
+    raise TypeError("Required argument 'start' (pos 1) not found")  # same as numpy error
+
+  # if called like np.arange(N) we create a lazy lax._IotaConstant
+  if len(args) == 1 and not kwargs:
+    stop, = args
+    dtype = dtype or _dtype(stop)
+    if onp.issubdtype(dtype, onp.integer):
+      return lax.iota(dtype, stop)  # avoids materializing
+
+  # fall back to instantiating an ndarray in host memory
   return onp.arange(*args, **kwargs)
 
 linspace = onp.linspace

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1187,7 +1187,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     ans = onp.mean(x)
     self.assertAllClose(ans, onp.array(1./3), check_dtypes=False)
 
-  # TODO(mattjj): more exhaustive arange tests
   def testArangeOnFloats(self):
     # from https://github.com/google/jax/issues/145
     expected = onp.arange(0.0, 1.0, 0.1)
@@ -1374,6 +1373,30 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testLongLong(self):
     self.assertAllClose(onp.int64(7), api.jit(lambda x: x)(onp.longlong(7)),
                         check_dtypes=True)
+
+  def testArange(self):
+    # test cases inspired by dask tests at
+    # https://github.com/dask/dask/blob/master/dask/array/tests/test_creation.py#L92
+    self.assertAllClose(lnp.arange(77),
+                        onp.arange(77), check_dtypes=True)
+    self.assertAllClose(lnp.arange(2, 13),
+                        onp.arange(2, 13), check_dtypes=True)
+    self.assertAllClose(lnp.arange(4, 21, 9),
+                        onp.arange(4, 21, 9), check_dtypes=True)
+    self.assertAllClose(lnp.arange(53, 5, -3),
+                        onp.arange(53, 5, -3), check_dtypes=True)
+    self.assertAllClose(lnp.arange(77, dtype=float),
+                        onp.arange(77, dtype=float), check_dtypes=True)
+    self.assertAllClose(lnp.arange(2, 13, dtype=int),
+                        onp.arange(2, 13, dtype=int), check_dtypes=True)
+    self.assertAllClose(lnp.arange(0, 1, -0.5),
+                        onp.arange(0, 1, -0.5), check_dtypes=True)
+
+    self.assertRaises(TypeError, lambda: lnp.arange())
+
+    # test that lnp.arange(N) doesn't instantiate an ndarray
+    self.assertFalse(type(lnp.arange(77)) == type(onp.arange(77)))
+    self.assertTrue(type(lnp.arange(77)) == type(lax.iota(onp.int32, 77)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This helps #553, and resolves the specific code in that example, but it doesn't solve cases like

```python
@jit
def fun(x):
  return np.arange(10, -1, -1)[x]
```

because we don't always return a DeviceArray from `np.arange` and hence we don't hit our own indexing in this case.