### PR TITLE
transposed convolution implementation

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -445,6 +445,44 @@ class LaxTest(jtu.JaxTestCase):
 
   # TODO(mattjj): test conv_general_dilated against numpy
 
+  @staticmethod
+  def _conv_transpose_via_grad(data, kernel, strides, padding,
+                               dimension_numbers=None):
+    """Helper method: calculates conv tranpose via grad for testing."""
+    assert len(data.shape) == len(kernel.shape)
+    nspatial = len(data.shape) - 2
+    one = (1,) * nspatial
+    dn = lax.conv_dimension_numbers(data.shape, kernel.shape,
+                                    dimension_numbers)
+    in_shape = onp.take(data.shape, dn.lhs_spec)
+    in_sdims = in_shape[2:]
+    k_shape = onp.take(kernel.shape, dn.rhs_spec)
+    k_sdims = k_shape[2:]
+    if padding == 'VALID':
+      o_sdims = [in_sdims[i]*strides[i] + max(k_sdims[i]-strides[i],0)
+                 for i in range(nspatial)]
+    elif padding == 'SAME':
+      o_sdims = [in_sdims[i]*strides[i] for i in range(nspatial)]
+    o_shape =  [in_shape[0], k_shape[1]] + o_sdims
+    out_spec_inv = [x[0] for x in
+                    sorted(enumerate(dn.out_spec), key=lambda x: x[1])]
+    o_layout = onp.take(onp.array(o_shape), out_spec_inv)
+    placeholder = onp.ones(o_layout, data.dtype)
+    conv = lambda x: lax.conv_general_dilated(x, kernel, strides, padding,
+                                              one, one, dn)
+    _, g = api.vjp(conv, placeholder)
+    return g(data)[0]
+
+  @staticmethod
+  def _transpose_conv_kernel(data, kernel, dimension_numbers):
+    dn = lax.conv_dimension_numbers(data.shape, kernel.shape,
+                                    dimension_numbers)
+    spatial_axes = onp.array(dn.rhs_spec)[2:]
+    for axis in spatial_axes:
+      kernel = onp.flip(kernel, axis)
+    kernel = onp.swapaxes(kernel, dn.rhs_spec[0], dn.rhs_spec[1])
+    return kernel
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_lhs_shape={}_rhs_shape={}_strides={}_padding={}".format(
@@ -453,57 +491,93 @@ class LaxTest(jtu.JaxTestCase):
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
       for lhs_shape, rhs_shape in [
-          ((b, 9, 10, i), (3, 3, i, j))
-          for b, i, j in itertools.product([2, 3], repeat=3)]
+          ((b, 9, 10, i), (k, k, j, i))  # NB: i,j flipped in RHS for transpose
+          for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
       for dtype in [onp.float32]
       for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHWC', 'HWIO', 'NHWC'),]
       for rng in [jtu.rand_small()]))
-  def testConvTranspose(self, lhs_shape, rhs_shape, dtype, strides,
-                        padding, dspec, rng):
-    def deconv_output_length(input_length, filter_size, padding, stride=0):
-      if padding.lower() == 'valid':
-        length = input_length * stride + max(filter_size - stride, 0)
-      elif padding.lower() == 'same':
-        length = input_length * stride
-      return length
-    def inv_permutation(p):
-      return [x[0] for x in sorted(enumerate(p), key=lambda x: x[1])]
-    def conv_transpose_via_grad(data, kernel, strides, padding,
-                                dimension_numbers=dspec):
-      assert len(data.shape) == len(kernel.shape)
-      ndims = len(data.shape)
-      nspatial = ndims - 2
-      one = (1,) * nspatial
-      dn = lax.conv_dimension_numbers(data.shape, kernel.shape,
-                                      dimension_numbers)
-      in_shape = onp.take(data.shape, dn.lhs_spec)
-      in_sdims = in_shape[2:]
-      k_shape = onp.take(kernel.shape, dn.rhs_spec)
-      k_sdims = k_shape[2:]
-      o_sdims = [deconv_output_length(in_sdims[i], k_sdims[i], padding,
-                                      stride=strides[i])
-                 for i in range(nspatial)]
-      o_shape =  [in_shape[0], k_shape[1]] + o_sdims
-      o_layout = onp.take(onp.array(o_shape), inv_permutation(dn.out_spec))
-      placeholder = onp.ones(o_layout, data.dtype)
-      conv = lambda x: lax.conv_general_dilated(x, kernel, strides, padding,
-                                                one, one, dn)
-      _, g = api.vjp(conv, placeholder)
-      return g(data)[0]
+  def testConvTranspose2DT(self, lhs_shape, rhs_shape, dtype, strides,
+                          padding, dspec, rng):
+    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
+    # NB: this test calculates conv_transpose performing identically to the
+    # lhs-grad of conv.
+    def fun(lhs, rhs):
+      return lax.conv_transpose(lhs, rhs, strides, padding,
+                                dimension_numbers=dspec,
+                                transpose_kernel=True)
+
+    def fun_via_grad(lhs, rhs):
+      return self._conv_transpose_via_grad(lhs, rhs, strides, padding,
+                                           dimension_numbers=dspec)
+
+    # NB: below just checks for agreement, we're not calling numpy.
+    self._CheckAgainstNumpy(fun, fun_via_grad, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}".format(
+           jtu.format_shape_dtype_string(lhs_shape, dtype),
+           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
+          "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
+          "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
+      for lhs_shape, rhs_shape in [
+          ((b, 9, 10, i), (k, k, i, j))
+          for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
+      for dtype in [onp.float32]
+      for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
+      for padding in ["VALID", "SAME"]
+      for dspec in [('NHWC', 'HWIO', 'NHWC'),]
+      for rng in [jtu.rand_small()]))
+  def testConvTranspose2D(self, lhs_shape, rhs_shape, dtype, strides,
+                          padding, dspec, rng):
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
       return lax.conv_transpose(lhs, rhs, strides, padding,
-                                dimension_numbers=dspec)
+                                dimension_numbers=dspec,
+                                transpose_kernel=False)
 
     def fun_via_grad(lhs, rhs):
-      return conv_transpose_via_grad(lhs, rhs, strides, padding,
-                                     dimension_numbers=dspec)
+      rhs_t = self._transpose_conv_kernel(lhs, rhs, dimension_numbers=dspec)
+      return self._conv_transpose_via_grad(lhs, rhs_t, strides, padding,
+                                           dimension_numbers=dspec)
 
-    # self._CompileAndCheck(fun, args_maker, check_dtypes=True)
+    # NB: below just checks for agreement, we're not calling numpy.
+    self._CheckAgainstNumpy(fun, fun_via_grad, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}".format(
+           jtu.format_shape_dtype_string(lhs_shape, dtype),
+           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
+          "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
+          "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
+      for lhs_shape, rhs_shape in [
+          ((b, 10, i), (k, i, j))
+          for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
+      for dtype in [onp.float32]
+      for strides in [(1,), (2,), (3,)]
+      for padding in ["VALID", "SAME"]
+      for dspec in [('NHC', 'HIO', 'NHC'),]
+      for rng in [jtu.rand_small()]))
+  def testConvTranspose1D(self, lhs_shape, rhs_shape, dtype, strides,
+                          padding, dspec, rng):
+    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
+
+    def fun(lhs, rhs):
+      return lax.conv_transpose(lhs, rhs, strides, padding,
+                                dimension_numbers=dspec,
+                                transpose_kernel=False)
+
+    def fun_via_grad(lhs, rhs):
+      rhs_t = self._transpose_conv_kernel(lhs, rhs, dimension_numbers=dspec)
+      return self._conv_transpose_via_grad(lhs, rhs_t, strides, padding,
+                                           dimension_numbers=dspec)
+
+    # NB: below just checks for agreement, we're not calling numpy.
     self._CheckAgainstNumpy(fun, fun_via_grad, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -84,6 +84,39 @@ class StaxTest(jtu.JaxTestCase):
     _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_channels={}_filter_shape={}_padding={}_strides={}_input_shape={}"
+       .format(channels, filter_shape, padding, strides, input_shape),
+       "channels": channels, "filter_shape": filter_shape, "padding": padding,
+       "strides": strides, "input_shape": input_shape}
+      for channels in [2, 3]
+      for filter_shape in [(1, 1), (2, 3), (3, 3)]
+      for padding in ["SAME", "VALID"]
+      for strides in [None, (2, 1), (2, 2)]
+      for input_shape in [(2, 10, 11, 1)]))
+  def testConvTransposeShape(self, channels, filter_shape, padding, strides,
+                               input_shape):
+    init_fun, apply_fun = stax.ConvTranspose(channels, filter_shape,
+                                               strides=strides, padding=padding)
+    _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_channels={}_filter_shape={}_padding={}_strides={}_input_shape={}"
+       .format(channels, filter_shape, padding, strides, input_shape),
+       "channels": channels, "filter_shape": filter_shape, "padding": padding,
+       "strides": strides, "input_shape": input_shape}
+      for channels in [2, 3]
+      for filter_shape in [(1,), (2,), (3,)]
+      for padding in ["SAME", "VALID"]
+      for strides in [None, (1,), (2,)]
+      for input_shape in [(2, 10, 1)]))
+  def testConv1DTransposeShape(self, channels, filter_shape, padding, strides,
+                               input_shape):
+    init_fun, apply_fun = stax.Conv1DTranspose(channels, filter_shape,
+                                               strides=strides, padding=padding)
+    _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_out_dim={}_input_shape={}"
                         .format(out_dim, input_shape),
        "out_dim": out_dim, "input_shape": input_shape}

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -96,7 +96,7 @@ class StaxTest(jtu.JaxTestCase):
       for input_shape in [(2, 10, 11, 1)]))
   def testConvTransposeShape(self, channels, filter_shape, padding, strides,
                                input_shape):
-    init_fun, apply_fun = stax.ConvTranspose(channels, filter_shape,
+    init_fun, apply_fun = stax.ConvTranspose(channels, filter_shape,  # 2D
                                                strides=strides, padding=padding)
     _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
This implements the upsampling 'transposed convolutions' in N-dimensions for any strides and for same, valid, or manually specified padding.  It was written to mimic the behavior of keras.layers.Conv2dTranspose and other similar grad-of-conv based transposed-convolutions as most people are familiar with these.  However, this implementation is __direct__, _not_ implemented in terms of a vjp of conv.

In fact, the default mode of operation is to calculate a 'fractionally-strided' conv w. LHS-dilation and __not__ to bother flipping and swapping the kernel (rhs) to mimic a true transpose, as this is just wasteful computationally, confuses input/output channels, and has no representational advantage for any use-case in neural nets.  True transposed-convs _can_ be calculated by passing `tranpose_kernel=True` to perfectly mimic the keras Conv2dTranspose applied to the given kernel if for some obscure reason you wanted to do that.  (e.g. I unit test against a vjp-of-conv.)

I retained the conv-transpose name only because most people call them that, but we could change that.