### PR TITLE
prevent jit from treating kwargs as static

### DIFF
--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -39,11 +39,17 @@ def get_name(fun): return getattr(fun, "__name__", "<unnamed function>")
 def get_module(fun): return getattr(fun, "__module__", "<unknown module>")
 def get_doc(fun): return getattr(fun, "__doc__", "")
 
+@transformation_with_aux
+def pytree_fun_to_jaxtupletree_fun(args_trees, *args):
+  py_args = map(build_tree, args_trees, args)
+  ans = yield py_args, {}
+  yield pytree_to_jaxtupletree(ans)
 
 @transformation_with_aux
-def pytree_fun_to_jaxtupletree_fun(in_trees, *args):
-  py_args = map(build_tree, in_trees, args)
-  ans = yield py_args
+def pytree_fun_to_jaxtupletree_fun2(kwargs_tree, args_trees, kwargs, *args):
+  py_args = map(build_tree, args_trees, args)
+  py_kwargs = build_tree(kwargs_tree, kwargs)
+  ans = yield py_args, py_kwargs
   yield pytree_to_jaxtupletree(ans)
 
 def apply_jaxtree_fun(fun, io_tree, *py_args):
@@ -62,7 +68,7 @@ pytree_to_jaxtupletree = partial(process_pytree, pack)
 @transformation_with_aux
 def pytree_fun_to_flatjaxtuple_fun(in_trees, *args):
   py_args = map(tree_unflatten, in_trees, args)
-  ans = yield py_args
+  ans = yield py_args, {}
   yield pytree_to_flatjaxtuple(ans)
 
 def pytree_to_flatjaxtuple(pytree):

--- a/jax/core.py
+++ b/jax/core.py
@@ -525,7 +525,7 @@ def apply_todos(todos, x):
 
 @lu.transformation_with_aux
 def process_env_traces(primitive, level, *args):
-  ans = yield args
+  ans = yield args, {}
   todo = []
   while isinstance(ans, Tracer) and ans.trace.level > level:
     t = ans.trace

--- a/jax/flatten_util.py
+++ b/jax/flatten_util.py
@@ -39,5 +39,5 @@ def ravel_list(*lst):
 @transformation_with_aux
 def ravel_fun(unravel_inputs, flat_in, **kwargs):
   pytree_args = unravel_inputs(flat_in)
-  ans = yield pytree_args
+  ans = yield pytree_args, {}
   yield ravel_pytree(ans)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -51,7 +51,7 @@ def batch_transform(size, in_dims, out_dim_dst, vals):
   with new_master(BatchTrace) as master:
     trace = BatchTrace(master, core.cur_sublevel())
     in_tracers = map(partial(BatchTracer, trace), vals, in_dims)
-    out_tracer = yield in_tracers
+    out_tracer = yield in_tracers, {}
     out_tracer = trace.full_raise(out_tracer)
     out_val, out_dim = out_tracer.val, out_tracer.batch_dim
     del master
@@ -61,7 +61,7 @@ def batch_transform(size, in_dims, out_dim_dst, vals):
 @transformation_with_aux
 def batch_subtrace(master, dims, *vals):
   trace = BatchTrace(master, core.cur_sublevel())
-  ans = yield map(partial(BatchTracer, trace), vals, dims)
+  ans = yield map(partial(BatchTracer, trace), vals, dims), {}
   out_tracer = trace.full_raise(ans)
   out_val, out_dim = out_tracer.val, out_tracer.batch_dim
   yield out_val, out_dim

--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -56,7 +56,7 @@ def serial_pmap_transform(name, axes, *vals):
   with new_master(SerialPmapTrace) as master:
     trace = SerialPmapTrace(master, core.cur_sublevel())
     in_tracers = map(partial(SerialPmapTracer, trace, name), vals, axes)
-    ans = yield in_tracers
+    ans = yield in_tracers, {}
     out_tracer = trace.full_raise(ans)
     out_val, out_axis = out_tracer.val, out_tracer.axis
     del master, out_tracer
@@ -65,7 +65,7 @@ def serial_pmap_transform(name, axes, *vals):
 @lu.transformation_with_aux
 def serial_pmap_subtrace(master, name, axes, *vals):
   trace = SerialPmapTrace(master, core.cur_sublevel())
-  ans = yield map(partial(SerialPmapTracer, trace, name), vals, axes)
+  ans = yield map(partial(SerialPmapTracer, trace, name), vals, axes), {}
   out_tracer = trace.full_raise(ans)
   out_val, out_axis = out_tracer.val, out_tracer.axis
   yield out_val, out_axis
@@ -205,7 +205,7 @@ def papply_transform(name, args, axis_size, in_axes, out_axis):
   with new_master(PapplyTrace) as master:
     trace = PapplyTrace(master, core.cur_sublevel())
     in_tracers = map(partial(PapplyTracer, trace, name, axis_size), args, in_axes)
-    out_tracer = yield in_tracers
+    out_tracer = yield in_tracers, {}
     out_tracer = trace.full_raise(out_tracer)
     out_tracer = ensure_axis(out_axis, out_tracer.axis, out_tracer)
     out_val = out_tracer.val

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -170,8 +170,9 @@ def partial_eval(f, trace, pvs):
 
 
 @transformation_with_aux
-def partial_eval_wrapper(avals, *consts, **kwargs):
-  jaxpr, (out_pval, consts, env) = yield (map(PartialVal, zip(avals, consts)),)
+def partial_eval_wrapper(avals, *consts):
+  py_args = (map(PartialVal, zip(avals, consts)),)
+  jaxpr, (out_pval, consts, env) = yield py_args, {}
   out_pv, out_const = out_pval
   out = pack((out_const, pack(consts)))
   yield out, (out_pv, jaxpr, env)
@@ -334,13 +335,13 @@ def abstractify(x):
   return PartialVal((core.concrete_aval(x), unit))
 
 def trace_unwrapped_to_jaxpr(fun, pvals, **kwargs):
-  return trace_to_jaxpr(lu.wrap_init(fun), pvals, **kwargs)
+  return trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals)
 
-def trace_to_jaxpr(fun, pvals, **kwargs):
+def trace_to_jaxpr(fun, pvals):
   """Traces a function, given abstract inputs, to a jaxpr."""
   with new_master(JaxprTrace) as master:
     fun = trace_to_subjaxpr(fun, master)
-    jaxpr, (out_pval, consts, env) = fun.call_wrapped(pvals, **kwargs)
+    jaxpr, (out_pval, consts, env) = fun.call_wrapped(pvals)
     assert not env
     del master
 
@@ -351,7 +352,7 @@ def trace_to_subjaxpr(master, pvals):
   assert all([isinstance(pv, PartialVal) for pv in pvals]), pvals
   trace = JaxprTrace(master, core.cur_sublevel())
   in_tracers = map(trace.new_arg, pvals)
-  out_tracer = yield in_tracers
+  out_tracer = yield in_tracers, {}
   out_tracer = trace.full_raise(out_tracer)
   jaxpr, consts, env = tracers_to_jaxpr(in_tracers, out_tracer)
   out_pval = out_tracer.pval
@@ -464,7 +465,7 @@ def eval_jaxpr_raw(jaxpr, consts, freevar_vals, *args):
     map(write, eqn.outvars, outvals)
   return read(jaxpr.outvar)
 
-def compiled_call_impl(fun, *args, **kwargs):
+def compiled_call_impl(fun, *args):
   with new_master(JaxprTrace, True) as master:
     pvals = map(abstractify, args)
     jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master).call_wrapped(pvals)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -412,7 +412,7 @@ def xla_shape(x):
 @lu.transformation_with_aux
 def flatten_fun(in_trees, *flat_args):
   jtuple_trees = tuple(map(partial(build_tree, iter(flat_args)), in_trees))
-  ans = yield jtuple_trees
+  ans = yield jtuple_trees, {}
   aval = core.get_aval(ans)
   if type(aval) is AbstractTuple:
     ans_flat, out_tree = tree_flatten(ans)

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -120,15 +120,15 @@ class WrappedFun(object):
     f: the function to be transformed.
     transforms: a list of `(gen, gen_args, out_store)` tuples representing
       transformations to apply to `f.`
-    kwargs: keyword arguments to pass to `f`.
+    params: extra parameters to pass as keyword arguments to `f`.
   """
-  def __init__(self, f, transforms, kwargs):
+  def __init__(self, f, transforms, params):
     self.f = f
     self.transforms = transforms
-    self.kwargs = kwargs
+    self.params = params
 
   def wrap(self, *transformation):
-    return WrappedFun(self.f, [transformation] + self.transforms, self.kwargs)
+    return WrappedFun(self.f, [transformation] + self.transforms, self.params)
 
   def populate_stores(self, other):
     for (_, _, self_store), (_, _, other_store) in zip(self.transforms,
@@ -136,15 +136,16 @@ class WrappedFun(object):
       if self_store is not None:
         self_store.store(other_store.val)
 
-  def call_wrapped(self, *args):
+  def call_wrapped(self, *args, **kwargs):
     stack = []
     for gen, gen_args, out_store in self.transforms:
-      gen = gen(*(gen_args + tuple(args)))
-      args = next(gen)
+      gen = gen(*(gen_args + tuple(args)), **kwargs)
+      args, kwargs = next(gen)
+      assert type(args) in (tuple, list) and type(kwargs) is dict
       stack.append((gen, out_store))
 
     del gen
-    ans = self.f(*args, **self.kwargs)
+    ans = self.f(*args, **dict(self.params, **kwargs))
     del args
     while stack:
       gen, out_store = stack.pop()
@@ -165,7 +166,7 @@ class WrappedFun(object):
   def hashable_payload(self):
     return (self.f,
             tuple((gen, tuple(gen_args)) for gen, gen_args, _ in self.transforms),
-            tuple(sorted(self.kwargs.items())))
+            tuple(sorted(self.params.items())))
 
   def __hash__(self):
     return hash(self.hashable_payload())
@@ -189,9 +190,9 @@ def fun_name(f):
   except:
     return str(f)
 
-def wrap_init(f, kwargs={}):
+def wrap_init(f, params={}):
   """Wraps function `f` as a `WrappedFun`, suitable for transformation."""
-  return WrappedFun(f, [], kwargs)
+  return WrappedFun(f, [], params)
 
 
 def memoize(call, max_size=4096):

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -141,7 +141,6 @@ class WrappedFun(object):
     for gen, gen_args, out_store in self.transforms:
       gen = gen(*(gen_args + tuple(args)), **kwargs)
       args, kwargs = next(gen)
-      assert type(args) in (tuple, list) and type(kwargs) is dict
       stack.append((gen, out_store))
 
     del gen

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -62,28 +62,43 @@ class APITest(jtu.JaxTestCase):
       side.append(None)
       return 100*x + 10*y + z
 
-    f1 = jit(f)
-    assert f1(1, 2, 3, flag=True) == 123
+    f1 = jit(f, static_argnums=(3, 4))
+    assert f1(1, 2, 3, True, False) == 123
     assert len(side) == 1
-    assert f1(2, 1, 3, flag=True) == 213
+    assert f1(2, 1, 3, True, False) == 213
     assert len(side) == 1
-    assert f1(2, 1, 3, flag=True, flag2=True) == 213
+    assert f1(2, 1, 3, True, True) == 213
     assert len(side) == 2
 
     side[:] = []
-    f2 = jit(f, static_argnums=[0,2])
-    assert f2(1, 2, 3, flag=True) == 123
+    f2 = jit(f, static_argnums=(0, 2, 3, 4))
+    assert f2(1, 2, 3, True, False) == 123
     assert len(side) == 1
-    assert f2(1, 3, 3, flag=True) == 133
+    assert f2(1, 3, 3, True, False) == 133
     assert len(side) == 1
-    assert f2(2, 2, 3, flag=True) == 223
+    assert f2(2, 2, 3, True, False) == 223
     assert len(side) == 2
-    assert f2(2, 4, 3, flag=True) == 243
+    assert f2(2, 4, 3, True, False) == 243
     assert len(side) == 2
-    assert f2(2, 4, 3, flag=True, flag2=True) == 243
+    assert f2(2, 4, 3, True, True) == 243
     assert len(side) == 3
-    assert f2(2, 5, 3, flag=True, flag2=True) == 253
+    assert f2(2, 5, 3, True, True) == 253
     assert len(side) == 3
+
+  def test_jit_kwargs(self):
+    side = []
+
+    def f(x, y, z):
+      side.append(None)
+      return 100*x + 10*y + z
+
+    f1 = jit(f)
+    assert f(1, 2, 3) == 123
+    assert len(side) == 1
+    assert f(1, 2, z=3) == 123
+    # assert len(side) == 1  # actually recompiles
+
+    f(1, 2, z=onp.zeros(3))  # doesn't crash
 
   def test_grad_of_jit(self):
     side = []

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -93,12 +93,12 @@ class APITest(jtu.JaxTestCase):
       return 100*x + 10*y + z
 
     f1 = jit(f)
-    assert f(1, 2, 3) == 123
+    assert f1(1, 2, 3) == 123
     assert len(side) == 1
-    assert f(1, 2, z=3) == 123
+    assert f1(1, 2, z=3) == 123
     # assert len(side) == 1  # actually recompiles
 
-    f(1, 2, z=onp.zeros(3))  # doesn't crash
+    f1(1, 2, z=onp.zeros(3))  # doesn't crash
 
   def test_grad_of_jit(self):
     side = []

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -92,13 +92,18 @@ class APITest(jtu.JaxTestCase):
       side.append(None)
       return 100*x + 10*y + z
 
-    f1 = jit(f)
-    assert f1(1, 2, 3) == 123
+    f = jit(f)
+    assert f(1, 2, 3) == 123
     assert len(side) == 1
-    assert f1(1, 2, z=3) == 123
-    # assert len(side) == 1  # actually recompiles
+    assert f(1, 2, 3) == 123
+    assert len(side) == 1
 
-    f1(1, 2, z=onp.zeros(3))  # doesn't crash
+    assert f(1, 2, z=3) == 123
+    assert len(side) == 2  # actually recompiles from kwarg
+    assert f(1, 2, z=3) == 123
+    assert len(side) == 2  # but should still cache
+
+    f(1, 2, z=onp.zeros(3))  # doesn't crash
 
   def test_grad_of_jit(self):
     side = []

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -26,7 +26,7 @@ import jax.numpy as np
 from jax import test_util as jtu
 from jax import lax
 from jax import lax_parallel
-from jax.api import serial_pmap, papply, jit, make_jaxpr
+from jax.api import _serial_pmap, _papply, jit, make_jaxpr
 from jax.linear_util import wrap_init
 
 from jax.config import config
@@ -37,48 +37,48 @@ class SerialPmapTest(jtu.JaxTestCase):
 
   def testConstantFunction(self):
     f = lambda x: 3
-    ans = serial_pmap(f, axis_name='i')(onp.ones(4))
+    ans = _serial_pmap(f, axis_name='i')(onp.ones(4))
     expected = 3 * onp.ones(4)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testReduceSum(self):
     f = lambda x: lax_parallel.psum(x, 'i')
-    ans = serial_pmap(f, axis_name='i')(onp.ones(4))
+    ans = _serial_pmap(f, axis_name='i')(onp.ones(4))
     expected = 4 * onp.ones(4)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testReduceMax(self):
     f = lambda x: lax_parallel.pmax(x, 'i')
-    ans = serial_pmap(f, axis_name='i')(onp.arange(4))
+    ans = _serial_pmap(f, axis_name='i')(onp.arange(4))
     expected = 3 * onp.ones(4)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testPsplit(self):
     f = lambda x: lax_parallel.psplit(x, 'i', 2)
     arg = onp.arange(3 * 2 * 3 * 5).reshape(3, 2, 3, 5)
-    ans = serial_pmap(f, axis_name='i', out_axes=2)(arg)
+    ans = _serial_pmap(f, axis_name='i', out_axes=2)(arg)
     expected = arg
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testPsplitLike(self):
     f = lambda x, y: lax_parallel.psplit_like(x, y, 'i')
     arg = onp.arange(3 * 2 * 3 * 5).reshape(3, 2, 3, 5)
-    ans = serial_pmap(f, axis_name='i', in_axes=(None, 2), out_axes=2)(arg, arg)
+    ans = _serial_pmap(f, axis_name='i', in_axes=(None, 2), out_axes=2)(arg, arg)
     expected = arg
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testLogSoftmax(self):
     f = lambda x: x - np.log(lax_parallel.psum(np.exp(x), 'i'))
     x = onp.log(onp.arange(1., 10., dtype=onp.float32))
-    ans = serial_pmap(f, axis_name='i')(x)
+    ans = _serial_pmap(f, axis_name='i')(x)
     expected = x - onp.log(onp.sum(onp.exp(x)))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testNested(self):
     f = lambda x: lax_parallel.psum(lax_parallel.psum(x, 'i'), 'j')
     x = onp.ones((2, 2))
-    ans1 = serial_pmap(serial_pmap(f, 'i'), 'j')(x)
-    ans2 = serial_pmap(serial_pmap(f, 'j'), 'i')(x)
+    ans1 = _serial_pmap(_serial_pmap(f, 'i'), 'j')(x)
+    ans2 = _serial_pmap(_serial_pmap(f, 'j'), 'i')(x)
     expected = 4 * onp.ones((2, 2))
     self.assertAllClose(ans1, expected, check_dtypes=False)
     self.assertAllClose(ans2, expected, check_dtypes=False)
@@ -87,19 +87,19 @@ class SerialPmapTest(jtu.JaxTestCase):
 class PapplyTest(jtu.JaxTestCase):
 
   def testIdentity(self):
-    pfun, axis_name = papply(lambda x: x, 3)
+    pfun, axis_name = _papply(lambda x: x, 3)
     ans = pfun(onp.arange(3))
     expected = onp.arange(3)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testMap(self):
-    pfun, axis_name = papply(np.sin, 3)
+    pfun, axis_name = _papply(np.sin, 3)
     ans = pfun(onp.arange(3.))
     expected = onp.sin(onp.arange(3.))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSum(self):
-    pfun, axis_name = papply(lambda x: np.sum(x, axis=0), 5)
+    pfun, axis_name = _papply(lambda x: np.sum(x, axis=0), 5)
 
     jaxpr = make_jaxpr(pfun)(onp.ones(3))
     expected_jaxpr = make_jaxpr(
@@ -107,12 +107,12 @@ class PapplyTest(jtu.JaxTestCase):
     assert repr(jaxpr) == repr(expected_jaxpr)
 
     arg = onp.arange(15.).reshape((5, 3))
-    ans = serial_pmap(pfun, axis_name)(arg)[0]
+    ans = _serial_pmap(pfun, axis_name)(arg)[0]
     expected = onp.sum(arg, axis=0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testMax(self):
-    pfun, axis_name = papply(lambda x: np.max(x, axis=0), 5)
+    pfun, axis_name = _papply(lambda x: np.max(x, axis=0), 5)
 
     jaxpr = make_jaxpr(pfun)(onp.ones(3))
     expected_jaxpr = make_jaxpr(
@@ -120,12 +120,12 @@ class PapplyTest(jtu.JaxTestCase):
     assert repr(jaxpr) == repr(expected_jaxpr)
 
     arg = onp.arange(15.).reshape((5, 3))
-    ans = serial_pmap(pfun, axis_name)(arg)[0]
+    ans = _serial_pmap(pfun, axis_name)(arg)[0]
     expected = onp.max(arg, axis=0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSelect(self):
-    pfun, axis_name = papply(lax.select, 5,
+    pfun, axis_name = _papply(lax.select, 5,
                              in_axes=(None, 0, None))
 
     p = onp.arange(15).reshape((5, 3)) % 4 == 1
@@ -142,7 +142,7 @@ class PapplyTest(jtu.JaxTestCase):
     expected_jaxpr = make_jaxpr(expected_spmd)(p, t[0], f)
     assert repr(jaxpr) == repr(expected_jaxpr)
 
-    ans = serial_pmap(pfun, axis_name, in_axes=(None, 0, None))(p, t, f)
+    ans = _serial_pmap(pfun, axis_name, in_axes=(None, 0, None))(p, t, f)
     expected = lax.select(p, t, f)
     self.assertAllClose(ans, expected, check_dtypes=True)
 
@@ -152,14 +152,14 @@ class PapplyTest(jtu.JaxTestCase):
     def fun(x):
       return x - np.log(np.sum(np.exp(x)))
 
-    pfun, axis_name = papply(fun, 5)
+    pfun, axis_name = _papply(fun, 5)
 
     jaxpr = make_jaxpr(pfun)(onp.zeros(5))
     expected_jaxpr = make_jaxpr(
         lambda x: x - np.log(lax_parallel.psum(np.exp(x), axis_name)))(onp.zeros(5))
     assert repr(jaxpr) == repr(expected_jaxpr)
 
-    ans = serial_pmap(pfun, axis_name)(onp.arange(1., 5.))
+    ans = _serial_pmap(pfun, axis_name)(onp.arange(1., 5.))
     expected = fun(onp.arange(1., 5.))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -167,8 +167,8 @@ class PapplyTest(jtu.JaxTestCase):
     x = onp.array([[1, 2, 3], [4, 5, 6]])
     expected = x + x
 
-    pfun, axis_name = papply(np.add, 2)
-    ans = serial_pmap(pfun, axis_name)(x, x)
+    pfun, axis_name = _papply(np.add, 2)
+    ans = _serial_pmap(pfun, axis_name)(x, x)
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testAddBroadcasting(self):
@@ -180,8 +180,8 @@ class PapplyTest(jtu.JaxTestCase):
     x = onp.array([[1, 2], [3, 4]])
     expected = x + 3
 
-    pfun, axis_name = papply(fun, 2)
-    ans = serial_pmap(pfun, axis_name)(x)
+    pfun, axis_name = _papply(fun, 2)
+    ans = _serial_pmap(pfun, axis_name)(x)
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testTranspose(self):
@@ -195,8 +195,8 @@ class PapplyTest(jtu.JaxTestCase):
     ]
     for x in xs:
       expected = x.T
-      pfun, axis_name = papply(fun, x.shape[0])
-      ans = serial_pmap(pfun, axis_name)(x)
+      pfun, axis_name = _papply(fun, x.shape[0])
+      ans = _serial_pmap(pfun, axis_name)(x)
       self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testTransposeWithOddPermutation(self):
@@ -210,8 +210,8 @@ class PapplyTest(jtu.JaxTestCase):
     ]
     for x in xs:
       expected = np.transpose(x, (2, 0, 1))
-      pfun, axis_name = papply(fun, x.shape[0])
-      ans = serial_pmap(pfun, axis_name)(x)
+      pfun, axis_name = _papply(fun, x.shape[0])
+      ans = _serial_pmap(pfun, axis_name)(x)
       self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testTransposeAndAddRank2(self):
@@ -222,8 +222,8 @@ class PapplyTest(jtu.JaxTestCase):
     x = onp.reshape(onp.arange(4., dtype=onp.float32), (2, 2))
     expected = x + x.T
 
-    pfun, axis_name = papply(fun, 2)
-    ans = serial_pmap(pfun, axis_name)(x)
+    pfun, axis_name = _papply(fun, 2)
+    ans = _serial_pmap(pfun, axis_name)(x)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testTransposeAndAddRank3(self):
@@ -234,8 +234,8 @@ class PapplyTest(jtu.JaxTestCase):
     x = onp.reshape(onp.arange(8., dtype=onp.float32), (2, 2, 2))
     expected = x + x.T
 
-    pfun, axis_name = papply(fun, 2)
-    ans = serial_pmap(pfun, axis_name)(x)
+    pfun, axis_name = _papply(fun, 2)
+    ans = _serial_pmap(pfun, axis_name)(x)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testDot(self):
@@ -251,8 +251,8 @@ class PapplyTest(jtu.JaxTestCase):
     for in_axes in in_axes_combos:
       for x in xs:
         expected = fun(x, x)
-        pfun, axis_name = papply(fun, x.shape[0], in_axes=in_axes)
-        ans = serial_pmap(pfun, axis_name)(x, x)
+        pfun, axis_name = _papply(fun, x.shape[0], in_axes=in_axes)
+        ans = _serial_pmap(pfun, axis_name)(x, x)
         self.assertAllClose(ans, expected, check_dtypes=False)
 
 


### PR DESCRIPTION
fixes #523

It's tricky to reconcile handling arguments passed by the caller as keyword arguments with the `static_argnums` argument to `jit`. The issue is that we can't associate a keyword argument with the index of a formal parameter (or vice-versa) without inspecting the function signature, which is way too brittle (e.g. broken by decorators, `functools.partial`, etc). The approach here (suggested by @dougalm) is simply to raise an error if the caller passes fewer positional arguments than are indicated by `static_argnums`.

Another consequence of not canonicalizing `kwargs` to identify its entries with formal parameters is that these two lines correspond to different call signatures and hence the latter does not hit the compilation cache entry from the former:

```python
f = jit(lambda x, y: x + y)
f(1, 2)
f(1, y=2)  # doesn't hit the cache
```

Here's an extended version:

```python
f = jit(lambda x, y: x + y)
f(1, 2)
f(2, 3)  # cache hit
f(1, y=2)  # cache miss, re-compiles
f(3, y=4)  # cache hit
f(5, 6)  # cache hit
f(x=2, y=3)  # cache miss, re-compiles
f(y=4, x=8)  # cache hit
```

We don't guarantee cache hits in general, so while this behavior isn't ideal, it seems okay.

This PR also adds underscore prefixes to `_serial_pmap` and `_papply` so that they're not exposed as public symbols in `api.py` (though at least the latter will be later).