### PR TITLE
python performance improvements

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -50,7 +50,7 @@ class UnshapedArray(core.AbstractValue):
     return type(self) is type(other) and self.dtype == other.dtype
 
   def __hash__(self):
-    return hash(str(self.dtype))
+    return hash(self.dtype)
 
   def __repr__(self):
     return '{}({})'.format(self.__class__.__name__, self.str_short())
@@ -93,7 +93,7 @@ class ShapedArray(UnshapedArray):
             and self.dtype == other.dtype and self.shape == other.shape)
 
   def __hash__(self):
-    return hash((self.shape, str(self.dtype)))
+    return hash((self.shape, self.dtype))
 
   def at_least_vspace(self):
     return self

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -53,7 +53,7 @@ class UnshapedArray(core.AbstractValue):
     # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
     # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
     # the unique character code via hash(self.dtype.char)
-    return hash(self.dtype)
+    return hash(self.dtype.char)
 
   def __repr__(self):
     return '{}({})'.format(self.__class__.__name__, self.str_short())
@@ -99,7 +99,7 @@ class ShapedArray(UnshapedArray):
     # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
     # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
     # the unique character code via hash(self.dtype.char)
-    return hash((self.shape, self.dtype))
+    return hash((self.shape, self.dtype.char))
 
   def at_least_vspace(self):
     return self

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -44,12 +44,15 @@ class UnshapedArray(core.AbstractValue):
   array_abstraction_level = 3
 
   def __init__(self, dtype):
-    self.dtype = dtype
+    self.dtype = onp.dtype(xla_bridge.canonicalize_dtype(dtype))
 
   def __eq__(self, other):
     return type(self) is type(other) and self.dtype == other.dtype
 
   def __hash__(self):
+    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
+    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
+    # the unique character code via hash(self.dtype.char)
     return hash(self.dtype)
 
   def __repr__(self):
@@ -74,7 +77,7 @@ class UnshapedArray(core.AbstractValue):
       raise TypeError(other)
 
   def str_short(self):
-    return onp.dtype(self.dtype).name
+    return self.dtype.name
 
 
 class ShapedArray(UnshapedArray):
@@ -93,6 +96,9 @@ class ShapedArray(UnshapedArray):
             and self.dtype == other.dtype and self.shape == other.shape)
 
   def __hash__(self):
+    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
+    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
+    # the unique character code via hash(self.dtype.char)
     return hash((self.shape, self.dtype))
 
   def at_least_vspace(self):
@@ -107,9 +113,8 @@ class ShapedArray(UnshapedArray):
       raise TypeError(other)
 
   def str_short(self):
-    dtypestr = onp.dtype(self.dtype).name
     shapestr = ','.join(map(str, self.shape))
-    return '{}[{}]'.format(dtypestr, shapestr)
+    return '{}[{}]'.format(self.dtype.name, shapestr)
 
   def __len__(self):
     try:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -28,7 +28,7 @@ from .. import ad_util
 from .. import tree_util
 from .. import linear_util as lu
 from ..abstract_arrays import ConcreteArray, ShapedArray
-from ..util import partial, unzip2, concatenate, safe_map, prod, memoize_unary
+from ..util import partial, concatenate, prod, memoize_unary, unzip2
 from ..lib import xla_bridge as xb
 from .xla import (xla_shape, xla_destructure, translation_rule,
                   xla_shape_to_result_shape, jaxpr_computation)
@@ -38,8 +38,6 @@ from . import partial_eval as pe
 from . import parallel
 from . import xla
 from . import ad
-
-map = safe_map
 
 
 ### util


### PR DESCRIPTION
The current test failure is just a Python 3 map object thing to take care of.

See below for a quick profiling script.

Before:
```
     ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     427773    0.822    0.000    3.353    0.000 jax/abstract_arrays.py:95(__hash__)
108697/2073    0.132    0.000    2.665    0.001 jax/interpreters/xla.py:423(tree_flatten)
```

After:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   427773    0.096    0.000    0.124    0.000 jax/abstract_arrays.py:95(__hash__)
     2073    0.002    0.000    0.959    0.000 jax/interpreters/xla.py:421(tree_flatten)
```

```python
# Copyright 2018 Google LLC
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     https://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

"""A mock-up showing a ResNet50 network with training on synthetic data.

This file uses the stax neural network definition library and the optimizers
optimization library.
"""
from __future__ import absolute_import
from __future__ import division
from __future__ import print_function

import numpy.random as npr

from six.moves import xrange

import jax.numpy as np
from jax.config import config
from jax import jit, grad, random
from jax.experimental import optimizers
from jax.experimental import stax
from jax.experimental.stax import (AvgPool, BatchNorm, Conv, Dense, FanInSum,
                                   FanOut, Flatten, GeneralConv, Identity,
                                   MaxPool, Relu, LogSoftmax)


# ResNet blocks compose other layers

def ConvBlock(kernel_size, filters, strides=(2, 2)):
  ks = kernel_size
  filters1, filters2, filters3 = filters
  Main = stax.serial(
      Conv(filters1, (1, 1), strides), BatchNorm(), Relu,
      Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
      Conv(filters3, (1, 1)), BatchNorm())
  Shortcut = stax.serial(Conv(filters3, (1, 1), strides), BatchNorm())
  return stax.serial(FanOut(2), stax.parallel(Main, Shortcut), FanInSum, Relu)


def IdentityBlock(kernel_size, filters):
  ks = kernel_size
  filters1, filters2 = filters
  def make_main(input_shape):
    # the number of output channels depends on the number of input channels
    return stax.serial(
        Conv(filters1, (1, 1)), BatchNorm(), Relu,
        Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
        Conv(input_shape[3], (1, 1)), BatchNorm())
  Main = stax.shape_dependent(make_main)
  return stax.serial(FanOut(2), stax.parallel(Main, Identity), FanInSum, Relu)


# ResNet architectures compose layers and ResNet blocks

def ResNet50(num_classes):
  return stax.serial(
      GeneralConv(('HWCN', 'OIHW', 'NHWC'), 64, (7, 7), (2, 2), 'SAME'),
      BatchNorm(), Relu, MaxPool((3, 3), strides=(2, 2)),
      ConvBlock(3, [64, 64, 256], strides=(1, 1)),
      IdentityBlock(3, [64, 64]),
      IdentityBlock(3, [64, 64]),
      ConvBlock(3, [128, 128, 512]),
      IdentityBlock(3, [128, 128]),
      IdentityBlock(3, [128, 128]),
      IdentityBlock(3, [128, 128]),
      ConvBlock(3, [256, 256, 1024]),
      IdentityBlock(3, [256, 256]),
      IdentityBlock(3, [256, 256]),
      IdentityBlock(3, [256, 256]),
      IdentityBlock(3, [256, 256]),
      IdentityBlock(3, [256, 256]),
      ConvBlock(3, [512, 512, 2048]),
      IdentityBlock(3, [512, 512]),
      IdentityBlock(3, [512, 512]),
      AvgPool((7, 7)), Flatten, Dense(num_classes), LogSoftmax)


if __name__ == "__main__":
  rng_key = random.PRNGKey(0)

  batch_size = 8
  num_classes = 1001
  input_shape = (224, 224, 3, batch_size)
  step_size = 0.1
  num_steps = 100

  init_fun, predict_fun = ResNet50(num_classes)
  _, init_params = init_fun(rng_key, input_shape)

  def loss(params, batch):
    inputs, targets = batch
    logits = predict_fun(params, inputs)
    return np.sum(logits * targets)

  def accuracy(params, batch):
    inputs, targets = batch
    target_class = np.argmax(targets, axis=-1)
    predicted_class = np.argmax(predict_fun(params, inputs), axis=-1)
    return np.mean(predicted_class == target_class)

  def synth_batches():
    rng = npr.RandomState(0)
    while True:
      images = rng.rand(*input_shape).astype('float32')
      labels = rng.randint(num_classes, size=(batch_size, 1))
      onehot_labels = labels == np.arange(num_classes)
      yield images, onehot_labels

  opt_init, opt_update = optimizers.momentum(step_size, mass=0.9)
  batches = synth_batches()

  @jit
  def update(i, opt_state, batch):
    return opt_state

  opt_state = opt_init(init_params)
  for i in xrange(num_steps):
    opt_state = update(i, opt_state, next(batches))
  trained_params = optimizers.get_params(opt_state)
```