### PR TITLE
make jacrev work w/ complex inputs, update errors

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -429,45 +429,35 @@ class APITest(jtu.JaxTestCase):
 
   def test_complex_grad_raises_error(self):
     self.assertRaises(TypeError, lambda: grad(lambda x: np.sin(x))(1 + 2j))
-    grad(lambda x: np.real(np.sin(x)))(1 + 2j)  # doesn't crash
 
-  # TODO(mattjj, dougalm): make this work if we can, and delete subsequent test
-  # def test_complex_jacfwd(self):
-  #   # code based on https://github.com/google/jax/issues/603
-  #   zs = 0.5j * onp.arange(5) + onp.arange(5)
+  def test_holomorphic_grad(self):
+    out = grad(lambda x: np.real(np.sin(x)))(1 + 2j)
+    expected = 2.0327230070196656 - 3.0518977991518j
+    self.assertAllClose(out, expected, check_dtypes=False)
 
-  #   def f(z):
-  #     return np.cos(np.linalg.norm(2 * z))
+  def test_complex_jacrev_raises_error(self):
+    self.assertRaises(TypeError, lambda: jacrev(lambda x: np.sin(x))(1 + 2j))
 
-  #   ans = jacfwd(f)(zs)
-  #   expected = grad(f)(zs)
-  #   self.assertAllClose(ans, expected, check_dtypes=True)
+  def test_holomorphic_jacrev(self):
+    # code based on https://github.com/google/jax/issues/603
+    zs = 0.5j * onp.arange(5) + onp.arange(5)
 
+    def f(z):
+      return np.cos(np.linalg.norm(2 * z))
+
+    ans = jacrev(f)(zs)
+    expected = grad(f)(zs)
+    self.assertAllClose(ans, expected, check_dtypes=True)
+
+  # TODO(mattjj,dougalm): can we make jacfwd act like jacrev with our
+  # differentiation convention here, modeling C->R as R^2->R, without rewriting
+  # the tangent jaxpr?
   def test_complex_jacfwd_raises_error(self):
     # code based on https://github.com/google/jax/issues/603
     zs = 0.5j * onp.arange(5) + onp.arange(5)
     def f(z):
       return np.cos(np.linalg.norm(2 * z))
     self.assertRaises(TypeError, lambda: jacfwd(f)(zs))
-
-  # TODO(mattjj, dougalm): make this work if we can, and delete subsequent test
-  # def test_complex_jacrev(self):
-  #   # code based on https://github.com/google/jax/issues/603
-  #   zs = 0.5j * onp.arange(5) + onp.arange(5)
-
-  #   def f(z):
-  #     return np.cos(np.linalg.norm(2 * z))
-
-  #   ans = jacrev(f)(zs)
-  #   expected = grad(f)(zs)
-  #   self.assertAllClose(ans, expected, check_dtypes=True)
-
-  def test_complex_jacrev_raises_error(self):
-    # code based on https://github.com/google/jax/issues/603
-    zs = 0.5j * onp.arange(5) + onp.arange(5)
-    def f(z):
-      return np.cos(np.linalg.norm(2 * z))
-    self.assertRaises(TypeError, lambda: jacrev(f)(zs))
 
 
 if __name__ == '__main__':

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -431,14 +431,28 @@ class APITest(jtu.JaxTestCase):
     self.assertRaises(TypeError, lambda: grad(lambda x: np.sin(x))(1 + 2j))
 
   def test_holomorphic_grad(self):
-    out = grad(lambda x: np.real(np.sin(x)))(1 + 2j)
+    out = grad(lambda x: np.sin(x), holomorphic=True)(1 + 2j)
     expected = 2.0327230070196656 - 3.0518977991518j
     self.assertAllClose(out, expected, check_dtypes=False)
 
-  def test_complex_jacrev_raises_error(self):
+  def test_nonholomorphic_grad(self):
+    zs = 0.5j * onp.arange(5) + onp.arange(5)
+
+    def f(z):
+      return np.sum(np.cos(np.abs(z)))
+
+    ans = grad(f)(zs)
+    expected = onp.array([ 0.        +0.j,
+                          -0.80430663+0.40215331j,
+                          -0.70368982+0.35184491j,
+                           0.1886467 -0.09432335j,
+                           0.86873727-0.43436864j])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_complex_output_jacrev_raises_error(self):
     self.assertRaises(TypeError, lambda: jacrev(lambda x: np.sin(x))(1 + 2j))
 
-  def test_holomorphic_jacrev(self):
+  def test_nonholomorphic_jacrev(self):
     # code based on https://github.com/google/jax/issues/603
     zs = 0.5j * onp.arange(5) + onp.arange(5)
 
@@ -449,15 +463,8 @@ class APITest(jtu.JaxTestCase):
     expected = grad(f)(zs)
     self.assertAllClose(ans, expected, check_dtypes=True)
 
-  # TODO(mattjj,dougalm): can we make jacfwd act like jacrev with our
-  # differentiation convention here, modeling C->R as R^2->R, without rewriting
-  # the tangent jaxpr?
-  def test_complex_jacfwd_raises_error(self):
-    # code based on https://github.com/google/jax/issues/603
-    zs = 0.5j * onp.arange(5) + onp.arange(5)
-    def f(z):
-      return np.cos(np.linalg.norm(2 * z))
-    self.assertRaises(TypeError, lambda: jacfwd(f)(zs))
+  def test_complex_input_jacfwd_raises_error(self):
+    self.assertRaises(TypeError, lambda: jacfwd(lambda x: np.sin(x))(1 + 2j))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to #603 (fixes the bug, leaving that issue open for more discussion).

This PR squashes some minor dtype bugs in api.py and also adds errors and tests to clarify our handling of functions involving complex numbers with `jacfwd` and `jacrev`.

Thanks to @dougalm for clarifying several things laid out below.

To explain the complex number handling conventions in `jacfwd` and `jacrev`, it's useful to keep in mind that the fundamental autodiff primitives are `jvp` and `vjp`. Those have no ambiguity in handling complex numbers because the user specifies the tangent or cotangent vector to push forward or pull back. The ambiguity arises in `grad`, `jacfwd`, and `jacrev` because these functions internally choose what tangents/cotangents to use. (`grad` can be considered a special case of `jacrev` here, so I'm going to focus on the Jacobian functions.)

The `jacfwd` function pushes forward a standard basis of real input tangent vectors, and so is meant to apply to functions with real inputs, like `R -> R` or `R -> C`. In the scalar-input case, that just means pushing forward the scalar `1.`. It is an error to evaluate `jacfwd(f)` on complex-valued inputs because the real standard basis it uses wouldn't make sense.

Symmetrically, the `jacrev` function pulls back a standard basis of real output cotangent vectors, and so applies to functions like `R -> R` or `C -> R`. In the scalar-output case (i.e. the `grad` case) that means pulling back the scalar `1.`. It's an error to evaluate `jacrev(f)` at a point where `f` has complex output.

Interestingly, for holomorphic functions like `C -> C`, we can compute the full Jacobian matrix just by pushing forward or pulling back a standard real basis. In particular, in the scalar-input scalar-ouptut case, the Jacobian of a holomorphic function is just a single complex scalar, and so it's clear that we need only multiply by a `1.` on either side to reveal it. Correspondingly, `jacfwd` and `jacrev` both work for holomorphic functions, and so this PR adds the option for the user to pass `holomorphic=True` to `jacfwd` and `jacrev`, which just prevent them from raising their corresponding errors on complex inputs or complex outputs, respectively. If the function to be differentiated is not actually holomorphic yet the user passes `holomorphic=True`, the user just gets the `jvp` or `vjp` of the function mapped over a standard real basis, but that result does not represent the full Jacobian of the function when the function has complex inputs or complex outputs, respectively.

What if we want to perform forward-accumulation for a `C -> R` function, or reverse-accumulation for an `R -> C` function? Or what if we want to compute all the derivative information for a non-holomorphic `C->C` function? In those cases, we just need to map over full bases of the input/output spaces, where we treat an n-dimensional complex vector space as a 2n-dimensional vector space over the reals. Concretely, we can do things like this to use forward-accumulation to get the full derivative of a `C -> R` function:

```python
In [1]: from jax import jvp, grad

In [2]: import jax.numpy as np

In [3]: print grad(lambda x: np.real(np.abs(x)))(2 + 0.5j)  # grad handles C -> R directly
(0.97014254-0.24253564j)

In [4]: print jvp(lambda x: np.real(np.abs(x)), (2 + 0.5j,), (1 + 0j,))[1]
0.97014254

In [5]: print jvp(lambda x: np.real(np.abs(x)), (2 + 0.5j,), (0 - 1j,))[1]
-0.24253564
```

To do that in a single pass, we can just `vmap` over another axis of size 2. It might be useful to add convenience functions to the API to do that, modeled after `jacfwd` and `jacrev` but which create the 2n-sized bases. PRs welcome :)