### PR TITLE
Fixes bug in `lax.con_shape_tuple` when using (None,) as part of an input shape.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3654,7 +3654,7 @@ def padtype_to_pads(in_shape, window_shape, window_strides, padding):
       raise RuntimeError(msg.format(padding))
 
   if padding == PaddingType.SAME:
-    out_shape = onp.ceil(onp.true_divide(in_shape, window_strides)).astype(int)
+    out_shape = onp.ceil(onp.true_divide(in_shape, window_strides).astype(float)).astype(int)
     pad_sizes = [_max((out_size - 1) * stride + window_shape - in_size, 0)
                  for out_size, stride, window_shape, in_size
                  in zip(out_shape, window_strides, window_shape, in_shape)]


### PR DESCRIPTION
I came across this bug this morning: https://gist.github.com/nirum/6f7f345bc6b46224f36cc40c73a8147c

The error is due to the dtype of the `lhs_shape` argument being 'object' instead of a numeric type, which causes `onp.ceil` to fail.

This fix casts the output of `true_divide` to float before the call to `onp.ceil`