### PR TITLE
Implement bernoulli logpmf

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -380,12 +380,12 @@ def _normal(key, shape, dtype):
   return onp.array(onp.sqrt(2), dtype) * lax.erf_inv(u)
 
 
-def bernoulli(key, mean=onp.float32(0.5), shape=()):
+def bernoulli(key, p=onp.float32(0.5), shape=()):
   """Sample Bernoulli random values with given shape and mean.
 
   Args:
     key: a PRNGKey used as the random key.
-    mean: optional, an array-like broadcastable to `shape` for the mean of the
+    p: optional, an array-like broadcastable to `shape` for the mean of the
       random variables (default 0.5).
     shape: optional, a tuple of nonnegative integers representing the shape
       (default scalar).
@@ -393,16 +393,16 @@ def bernoulli(key, mean=onp.float32(0.5), shape=()):
   Returns:
     A random array with the specified shape and boolean dtype.
   """
-  return _bernoulli(key, mean, shape)
+  return _bernoulli(key, p, shape)
 
 @partial(jit, static_argnums=(2,))
-def _bernoulli(key, mean, shape):
-  shape = shape or onp.shape(mean)
-  if not onp.issubdtype(lax.dtype(mean), onp.float32):
-    mean = lax.convert_element_type(mean, onp.float32)
-  if onp.shape(mean) != shape:
-    mean = np.broadcast_to(mean, shape)
-  return lax.lt(uniform(key, shape), mean)
+def _bernoulli(key, p, shape):
+  shape = shape or onp.shape(p)
+  if not onp.issubdtype(onp.float32, lax.dtype(p)):
+    p = lax.convert_element_type(p, onp.float32)
+  if onp.shape(p) != shape:
+    p = np.broadcast_to(p, shape)
+  return lax.lt(uniform(key, shape, lax.dtype(p)), p)
 
 
 def cauchy(key, shape=(), dtype=onp.float32):

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -23,7 +23,8 @@ from .. import lax
 from ..api import custom_transforms
 from ..interpreters import ad, batching
 from ..numpy import lax_numpy as np
-from ..numpy.lax_numpy import _wraps, asarray, _reduction_dims, _constant_like
+from ..numpy.lax_numpy import (_wraps, asarray, _reduction_dims, _constant_like,
+                               _promote_args_like)
 
 
 # need to create new functions because _wraps sets the __name__ attribute
@@ -65,6 +66,18 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
   out = lax.add(lax.log(lax.reduce(lax.exp(lax.sub(a, amax_singletons)),
                                    _constant_like(a, 0), lax.add, dims)), amax)
   return dimadd(out) if keepdims else out
+
+
+@_wraps(osp_special.xlogy)
+def xlogy(x, y):
+  x, y = _promote_args_like(osp_special.xlogy, x, y)
+  return lax._safe_mul(x, lax.log(y))
+
+
+@_wraps(osp_special.xlog1py)
+def xlog1py(x, y):
+  x, y = _promote_args_like(osp_special.xlog1py, x, y)
+  return lax._safe_mul(x, lax.log1p(y))
 
 
 # Normal distributions

--- a/jax/scipy/stats/__init__.py
+++ b/jax/scipy/stats/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+from . import bernoulli
 from . import beta
 from . import cauchy
 from . import expon

--- a/jax/scipy/stats/bernoulli.py
+++ b/jax/scipy/stats/bernoulli.py
@@ -1,0 +1,39 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as onp
+import scipy.stats as osp_stats
+
+from ... import lax
+from ...numpy.lax_numpy import (_promote_args_like, _constant_like, _wraps,
+                                where, inf, logical_or)
+from ..special import xlogy, xlog1py
+
+
+@_wraps(osp_stats.bernoulli.logpmf)
+def logpmf(k, p, loc=0):
+  k, p, loc = _promote_args_like(osp_stats.bernoulli.logpmf, k, p, loc)
+  zero = _constant_like(k, 0)
+  one = _constant_like(k, 1)
+  x = lax.sub(k, loc)
+  log_probs = xlogy(x, p) + xlog1py(lax.sub(one, x), -p)
+  return where(logical_or(lax.lt(x, zero), lax.gt(x, one)), -inf, log_probs)
+
+@_wraps(osp_stats.bernoulli.pmf)
+def pmf(k, p, loc=0):
+  return np.exp(pmf(k, p, loc))

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -27,6 +27,7 @@ from scipy.stats import random_correlation
 
 from jax import test_util as jtu
 from jax.scipy import stats as lsp_stats
+from jax.scipy.special import expit
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -48,6 +49,22 @@ def genNamedParametersNArgs(n, rng):
 
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
   """Tests for LAX-backed scipy.stats implementations"""
+
+  @genNamedParametersNArgs(3, jtu.rand_default())
+  def testBernoulliLogPmf(self, rng, shapes, dtypes):
+    scipy_fun = osp_stats.bernoulli.logpmf
+    lax_fun = lsp_stats.bernoulli.logpmf
+
+    def args_maker():
+      x, logit, loc = map(rng, shapes, dtypes)
+      x = onp.floor(x)
+      p = expit(logit)
+      loc = onp.floor(loc)
+      return [x, p, loc]
+
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
+    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(5, jtu.rand_positive())
   def testBetaLogPdf(self, rng, shapes, dtypes):


### PR DESCRIPTION
This PR also adds chi square test for discrete distributions and some convenience utilities `xlogy`, `xlog1py` which leverages `lax._safe_mul` to get correct behaviours.

In addition, I rename `mean` -> `p` to match scipy version. In addition, `mean` is not a conventional term IMO.

Pair code/review with @neerajprad