### PR TITLE
[WIP] Implement np.ediff1d

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -628,6 +628,32 @@ def diff(a, n=1, axis=-1,):
 
   return a
 
+@_wraps(onp.ediff1d)
+def ediff1d(array, to_end=None, to_begin=None):
+    array = ravel(asarray(array))
+
+    difference = array[1:] - array[:-1]
+
+    difference_dtype = difference.dtype
+
+    if to_begin is not None:
+        _to_begin = asarray(to_begin, dtype=difference_dtype)
+        if not all(ravel(equal(to_begin, _to_begin))):
+            raise ValueError("cannot convert 'to_begin' to array with dtype {} "
+                             "as required for input array".format(difference_dtype))
+        to_begin = ravel(_to_begin)
+        difference = concatenate((to_begin, difference))
+
+    if to_end is not None:
+        _to_end = asarray(to_end, dtype=difference_dtype)
+        if not equal(to_end, _to_end).all():
+            raise ValueError("cannot convert 'to_end' to array with dtype {} "
+                             "as required for input array".format(difference_dtype))
+        to_end = ravel(_to_end)
+        difference = concatenate((difference, to_end))
+
+    return difference
+
 
 @_wraps(onp.isrealobj)
 def isrealobj(a):
@@ -1086,7 +1112,6 @@ nancumsum = _make_cumulative_reduction(
   onp.nancumsum, lax._reduce_window_sum, 0, squash_nan=True)
 nancumprod = _make_cumulative_reduction(
   onp.nancumprod, lax._reduce_window_prod, 1, squash_nan=True)
-
 
 ### Array-creation functions
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -687,6 +687,27 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_{}_{}".format(
+          jtu.format_shape_dtype_string(shape, dtype),
+          "None" if end_dtype is None else onp.dtype(end_dtype).name,
+          "None" if begin_dtype is None else onp.dtype(begin_dtype).name,),
+       "shape": shape, "dtype": dtype, "end_dtype": end_dtype,
+       "begin_dtype": begin_dtype, "rng": jtu.rand_default()}
+      for dtype in number_dtypes
+      for end_dtype in [None] + number_dtypes
+      for begin_dtype in [None] + number_dtypes
+      for shape in all_shapes))
+  def testEDiff1d(self, shape, dtype, end_dtype, begin_dtype, rng):
+    args_maker = lambda: [rng(shape, dtype),
+                          (None if end_dtype is None else rng(shape, end_dtype)),
+                          (None if begin_dtype is None else rng(shape, begin_dtype))]
+    onp_fun = lambda x, to_end, to_begin: onp.ediff1d(x, to_end, to_begin)
+    lnp_fun = lambda x, to_end, to_begin: lnp.ediff1d(x, to_end, to_begin)
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
+    # TODO(avaidya): re-enable once it's JITtable
+    #self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}_m={}_n={}_k={}".format(
           onp.dtype(dtype).name, m, n, k),
        "m": m, "n": n, "k": k, "dtype": dtype, "rng": jtu.rand_default()}


### PR DESCRIPTION
`ediff1d` isn't implemented, as per #70.

Here's [Numpy's documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ediff1d.html). I'm running into two issues related to dtypes:

1. Numpy checks that `to_end` and `to_begin` can be safely converted to `x`'s dtype by converting them, then checking equality with the original. JITting this fails, since there's control flow based on this comparison. I'm not sure how to get around this. See: [jax/lax_numpy.py:643](https://github.com/kroq-gar78/jax/blob/ediff1d/jax/numpy/lax_numpy.py#L643)

2. Numpy throws a `ValueError` when they aren't equal. Some test cases fail because of this (i.e. the dtypes are incompatble), usually when there's a loss of precision, like `float64` to `complex64`. Is there a "nice" way to detect this already, just for picking dtypes for testing?

   Another question on this: I don't see simple way yet to assert for exceptions in the JAX implementation if Numpy throws one. If there's no function to do this already, I could add a case at [jax/test_util.py:490](https://github.com/google/jax/blob/master/jax/test_util.py#L490) under `JaxTestCase._CheckAgainstNumpy` that checks we're raising the same same exception type as Numpy, if any.