### PR TITLE
add support for custom VJP definitions

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -178,3 +178,12 @@ array_types = [onp.ndarray, onp.float64, onp.float32, onp.float16,
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray
   ad_util.jaxval_zeros_likers[t] = zeros_like_array
+
+
+def raise_to_shaped(aval):
+  if type(aval) is core.AbstractTuple:
+    return core.AbstractTuple(map(raise_to_shaped, aval))
+  elif isinstance(aval, ShapedArray):
+    return ShapedArray(aval.shape, aval.dtype)
+  else:
+    raise TypeError(type(aval))

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -23,6 +23,7 @@ from .. import core as core
 from ..core import JaxTuple, Trace, Tracer, new_master, get_aval, pack, call_p, Primitive
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval,
                        zeros_like_p, zero, Zero)
+from ..abstract_arrays import raise_to_shaped
 from ..util import unzip2, unzip3, safe_map, safe_zip, partial
 from ..tree_util import process_pytree, build_tree, register_pytree_node, tree_map
 from ..linear_util import thunk, staged, transformation, transformation_with_aux, wrap_init
@@ -307,7 +308,6 @@ def deflinear(primitive, transpose_rule):
   primitive_jvps[primitive] = partial(linear_jvp, primitive)
   primitive_transposes[primitive] = partial(linear_transpose, transpose_rule)
 
-
 def linear_jvp(primitive, primals, tangents, **params):
   val_out = primitive.bind(*primals, **params)
   if all(tangent is zero for tangent in tangents):
@@ -315,7 +315,6 @@ def linear_jvp(primitive, primals, tangents, **params):
   else:
     tangents = map(instantiate_zeros, primals, tangents)
     return val_out, primitive.bind(*tangents, **params)
-
 
 def linear_transpose(transpose_rule, cotangent, *args, **kwargs):
   return zero if cotangent is zero else transpose_rule(cotangent, **kwargs)
@@ -332,18 +331,15 @@ def standard_jvp(jvprules, primitive, primals, tangents, **params):
                   if rule is not None and t is not zero]
   return val_out, reduce(add_tangents, tangents_out, zero)
 
-
 def defjvp2(primitive, *jvprules):
   assert isinstance(primitive, Primitive)
   primitive_jvps[primitive] = partial(standard_jvp2, jvprules, primitive)
-
 
 def standard_jvp2(jvprules, primitive, primals, tangents, **params):
   val_out = primitive.bind(*primals, **params)
   tangents_out = (rule(t, val_out, *primals, **params) for rule, t in zip(jvprules, tangents)
                   if rule is not None and t is not zero)
   return val_out, reduce(add_tangents, tangents_out, zero)
-
 
 def add_tangents(x, y):
   if x is zero:
@@ -354,6 +350,57 @@ def add_tangents(x, y):
     return add_jaxvals(x, y)
 
 
+def defvjp_all(prim, custom_vjp):
+  name = prim.name
+
+  def fun_jvp(xs, ts):
+    ts = map(instantiate_zeros, xs, ts)  # TODO(mattjj): avoid instantiation?
+    primal_out, tangent_out = fun_jvp_p.bind(pack(xs), pack(ts))
+    return primal_out, tangent_out
+  primitive_jvps[prim] = fun_jvp
+
+  fun_jvp_p = core.Primitive('{name}_jvp'.format(name=name))
+  def fun_jvp_partial_eval(trace, *tracers):
+    primals_tracer, tangents_tracer = tracers
+    primal_out, vjp_py = custom_vjp(*primals_tracer)
+
+    in_aval = raise_to_shaped(get_aval(primal_out))
+    ct_pval = pe.PartialVal((in_aval, core.unit))
+    vjp_jaxpr, out_pval, residuals = pe.trace_unwrapped_to_jaxpr(
+        lambda ct: pack(vjp_py(ct)), (ct_pval,))
+    out_pv, out_const = out_pval
+    tangent_out = fun_lin_p.bind(out_const, pack(residuals), tangents_tracer,
+                                 in_aval=in_aval, out_pv=out_pv, vjp_jaxpr=vjp_jaxpr)
+
+    return pack((primal_out, tangent_out))
+  pe.custom_partial_eval_rules[fun_jvp_p] = fun_jvp_partial_eval
+
+  fun_lin_p = core.Primitive('{name}_lin'.format(name=name))
+  fun_lin_p.def_abstract_eval(lambda c, r, ts, in_aval, out_pv, vjp_jaxpr: in_aval)
+  def fun_lin_transpose(ct, out_const, residuals, ts, in_aval, out_pv, vjp_jaxpr):
+    assert ts is None and out_const is not None and residuals is not None
+    ans = core.eval_jaxpr(vjp_jaxpr, residuals, (), ct)
+    out = pe.merge_pvals(ans, pe.PartialVal((out_pv, out_const)))
+    return [None, None, out]
+  primitive_transposes[fun_lin_p] = fun_lin_transpose
+
+def defvjp(prim, *vjps):
+  def vjpmaker(*primals):
+    ans = prim.bind(*primals)
+    vjpfun = lambda ct: [vjp(ct, *primals) if vjp else zeros_like_jaxval(x)
+                         for x, vjp in zip(primals, vjps)]
+    return ans, vjpfun
+  defvjp_all(prim, vjpmaker)
+
+def defvjp2(prim, *vjps):
+  def vjpmaker(*primals):
+    ans = prim.bind(*primals)
+    vjpfun = lambda ct: [vjp(ct, ans, *primals) if vjp else zeros_like_jaxval(x)
+                         for x, vjp in zip(primals, vjps)]
+    return ans, vjpfun
+  defvjp_all(prim, vjpmaker)
+
+
 def defbilinear_broadcasting(bcast, prim, lhs_rule, rhs_rule):
   assert isinstance(prim, Primitive)
   lhs_jvp = lambda g, x, y, **kwargs: prim.bind(bcast(g, y), y, **kwargs)
@@ -361,7 +408,6 @@ def defbilinear_broadcasting(bcast, prim, lhs_rule, rhs_rule):
   defjvp(prim, lhs_jvp, rhs_jvp)
   primitive_transposes[prim] = partial(bilinear_transpose, lhs_rule, rhs_rule)
 defbilinear = partial(defbilinear_broadcasting, lambda g, x: g)
-
 
 def bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs):
   assert (x is None) ^ (y is None)
@@ -376,7 +422,6 @@ def bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs):
 def defjvp_zero(primitive):
   assert isinstance(primitive, Primitive)
   primitive_jvps[primitive] = partial(zero_jvp, primitive)
-
 
 def zero_jvp(primitive, primals, tangents, **params):
   return primitive.bind(*primals, **params), zero

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -26,7 +26,7 @@ from six.moves import reduce
 
 from .. import core
 from ..core import Trace, Tracer, new_master, pack, AbstractTuple, JaxTuple
-from ..abstract_arrays import ShapedArray, make_shaped_array, array_types
+from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
 from ..ad_util import add_jaxvals_p, zeros_like_p, zeros_like_jaxval
 from ..linear_util import transformation, transformation_with_aux, wrap_init
 from ..tree_util import register_pytree_node
@@ -159,14 +159,6 @@ def shaped_aval(x):
     return pytype_aval_mappings[type(x)](x)
   except KeyError:
     raise TypeError("{} is not a valid type for batching".format(type(x)))
-
-def raise_to_shaped(aval):
-  if type(aval) is AbstractTuple:
-    return AbstractTuple(map(raise_to_shaped, aval))
-  elif isinstance(aval, ShapedArray):
-    return ShapedArray(aval.shape, aval.dtype)
-  else:
-    raise TypeError(type(aval))
 
 def remove_batch_dim_from_aval(bdim, aval):
   t = type(aval)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -247,7 +247,7 @@ def lower_fun(fun, c, *xla_args, **params):
   xla_shapes = tuple(map(c.GetShape, xla_args))
   avals = map(aval_from_xla_shape, xla_shapes)
   pvals = [pe.PartialVal((a, core.unit)) for a in avals]
-  jaxpr, pvout, consts = pe.trace_unwrapped_to_jaxpr(fun, pvals, **params)
+  jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(fun, pvals, **params)
   built_c = jaxpr_computation(jaxpr, consts, (), *xla_shapes)
   return c.Call(built_c, xla_args)
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -36,7 +36,7 @@ from .. import linear_util as lu
 from ..config import flags
 from ..core import Primitive
 from ..abstract_arrays import (UnshapedArray, ShapedArray, ConcreteArray,
-                               array_types, make_shaped_array)
+                               array_types, make_shaped_array, raise_to_shaped)
 from ..api_util import (pytree_fun_to_jaxtupletree_fun, pytree_to_jaxtupletree,
                         pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple)
 from ..interpreters import partial_eval as pe
@@ -3951,8 +3951,5 @@ def subvals(lst, replace):
 
 
 def _abstractify(x):
-  # abstractify wrapper used internally for primitives like while_loop
-  if isinstance(x, core.Tracer):
-    return pe.PartialVal((xla.abstractify(x.aval), core.unit))
-  else:
-    return pe.PartialVal((xla.abstractify(x), core.unit))
+  # used internally for initial-style higher-order primitives
+  return pe.PartialVal((raise_to_shaped(core.get_aval(x)), core.unit))


### PR DESCRIPTION
cross-ref #116, though we can't close that until we document `@custom_transforms` and `defvjp`.

cc @duvenaud 

The motivation is that for a function `fun :: a -> b`, we want to allow the user to specify a custom VJP of the form `custom_vjp :: a -> (b, CT b -> CT a)`, where as usual we use `CT x` to mean "cotangent type for the type `x`". Values computed on the forward pass can be reused on the backward pass via lexical closure.

This PR adds a `defvjp_all` function, which can be used together with `@custom_transforms` to get the desired effect. It also adds a couple convenience functions `defvjp` and `defvjp2`.

The rest of this comment is to explain some implementation details.

Since JAX derives reverse-mode by composing forward-mode, partial evaluation, and transposition transformations, to define a VJP rule directly requires coordinating across all three of those stages.


Consider a jaxpr containing a primitive `fun`, perhaps arising from a user decorating a Python function with `@custom_transforms`:

```
{ lambda  ; ; a.
  let b = fun a
      c = negative b
  in c }
```

We want the JVP to look like this:
```
{ lambda  ; ; a b.
  let c = fun_jvp a b
      (d, e) = id c
      f = negative d
      g = negative e
      h = pack f g
  in h }
```
Notice the new primitive `fun_jvp`. This primitive is a "dummy" in that it will only be produced as an intermediate in a jvp-peval-transpose composition of transforms, and we only need a partial-eval rule for it.

Here's what happens when we partial-eval out the primal values:
```
{ lambda r ; ; a.
  let b = fun_lin [...] r a
      c = negative b
  in c }
```
Yet another primitive, `fun_lin`, appears. This primitive is another "dummy" in that it will only be produced as an intermediate and only has a transpose rule.

An important detail at the partial-eval stage is how we get the residuals `r` out of the user-supplied Python traceable for `CT b -> CT a`. Basically we turn that Python traceable into a jaxpr during partial evaluation, and in so doing wring out all the residuals that it might close over. As a result, the `[...]` in the above really contains the jaxpr version of the `CT b -> CT a` function.

Finally, the transposed jaxpr will look like
```
The transposed jaxpr2 will look like:
{ lambda r ; ; a.
  let b = negative a
      c = fun_lin_transpose [...] r b
  in c }
```
where `fun_lin_transpose` is a primitive for which the impl evaluates the VJP jaxpr CT b -> CT a (including residuals as consts).

To summarize, we introduce dummy primitives to rig up this process:
`fun_p` --JVP--> `fun_jvp_p` --PEval--> `fun_lin_p` --Trans--> `fun_lin_transpose_p`
where `fun_lin_transpose_p` effectively corresponds to the user-supplied `CT b -> CT a` function, and the PEval step forms a jaxpr of the `CT b -> CT a` Python traceable to get the residuals out.