### PR TITLE
Perform division in `mean` using the target dtype

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -969,10 +969,9 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
     else:
       dtype = _dtype(a)
 
-  td = true_divide(
+  return lax.div(
       sum(a, axis, dtype=dtype, keepdims=keepdims),
       lax.convert_element_type(normalizer, dtype))
-  return lax.convert_element_type(td, dtype)
 
 
 @_wraps(onp.var)


### PR DESCRIPTION
Performing a `true_divide` and then casting back to `dtype` may lose precision, and a recent LLVM change caused tests to start failing because of it.