### PR TITLE
Implemented np.fix

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -80,6 +80,7 @@ jax.numpy package
     expm1
     eye
     fabs
+    fix
     flip
     fliplr
     flipud

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -843,6 +843,14 @@ def round(a, decimals=0):
 around = round
 
 
+@_wraps(onp.fix)
+def fix(x, out=None):
+  if out is not None:
+    raise ValueError("fix does not support the `out` argument.")
+  zero = lax._const(x, 0)
+  return where(lax.ge(x, zero), lax.floor(x), lax.ceil(x))
+
+
 # Caution: If fast math mode is enabled, the semantics of inf and nan are not
 # preserved by XLA/LLVM, and the behavior of inf/nan values is unpredictable.
 # To disable fast math mode on CPU, set the environment variable

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -129,6 +129,7 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_positive(), [],
               test_name="expm1_large"),
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive(), []),
+    op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), ["rev"]),
     op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default(), []),


### PR DESCRIPTION
Implemented `np.fix` which was unimplemented in #70 
Here is the [Numpy documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.fix.html) and [their implementation](https://github.com/numpy/numpy/blob/master/numpy/lib/ufunclike.py#L65-L107). (I've not implemented it the exact way, since `np.asanyarray` is still unimplemented)