### PR TITLE
instantiate consts when tracing while's body_fun

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -477,7 +477,7 @@ def eval_jaxpr_raw(jaxpr, consts, freevar_vals, *args):
 def compiled_call_impl(fun, *args):
   with new_master(JaxprTrace, True) as master:
     pvals = map(abstractify, args)
-    jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master).call_wrapped(pvals)
+    jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     jaxpr_ans = eval_jaxpr_raw(jaxpr, consts, env, *args)
     ans = merge_pvals(jaxpr_ans, pval)
     del master, pvals, pval, consts, env, jaxpr_ans, jaxpr

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -169,7 +169,7 @@ def add_axis_to_aval(size, aval):
 
 
 def partial_eval(f, trace, pvs):
-  f = trace_to_subjaxpr(f, trace.master)
+  f = trace_to_subjaxpr(f, trace.master, False)
   return partial_eval_wrapper(f, tuple(pvs))
 
 
@@ -341,10 +341,11 @@ def abstractify(x):
 def trace_unwrapped_to_jaxpr(fun, pvals, **kwargs):
   return trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals)
 
-def trace_to_jaxpr(fun, pvals):
+def trace_to_jaxpr(fun, pvals, **kwargs):
   """Traces a function, given abstract inputs, to a jaxpr."""
+  instantiate = kwargs.pop('instantiate', False)
   with new_master(JaxprTrace) as master:
-    fun = trace_to_subjaxpr(fun, master)
+    fun = trace_to_subjaxpr(fun, master, instantiate)
     jaxpr, (out_pval, consts, env) = fun.call_wrapped(pvals)
     assert not env
     del master
@@ -352,12 +353,16 @@ def trace_to_jaxpr(fun, pvals):
   return jaxpr, out_pval, consts
 
 @transformation
-def trace_to_subjaxpr(master, pvals):
+def trace_to_subjaxpr(master, instantiate, pvals):
   assert all([isinstance(pv, PartialVal) for pv in pvals]), pvals
   trace = JaxprTrace(master, core.cur_sublevel())
   in_tracers = map(trace.new_arg, pvals)
   out_tracer = yield in_tracers, {}
   out_tracer = trace.full_raise(out_tracer)
+
+  if instantiate:
+    out_tracer = trace.instantiate_const(out_tracer)
+
   jaxpr, consts, env = tracers_to_jaxpr(in_tracers, out_tracer)
   out_pval = out_tracer.pval
   del trace, in_tracers, out_tracer

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -329,7 +329,7 @@ def _shard_aval(axis_size, aval):
 def parallel_callable(fun, axis_name, axis_size, *avals):
   pvals = [PartialVal((aval, core.unit)) for aval in avals]
   with core.new_master(JaxprTrace, True) as master:
-    jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master).call_wrapped(pvals)
+    jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env
     out = compile_replicated(jaxpr, axis_name, axis_size, consts, *avals)
     compiled, nrep, result_shape = out

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -516,7 +516,7 @@ def xla_call_impl(fun, *args):
 def xla_callable(fun, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
-    jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master).call_wrapped(pvals)
+    jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here (though cond might eventually need them)
     compiled, result_shape = compile_jaxpr(jaxpr, consts, *abstract_args)
     del master, consts, jaxpr, env

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -404,6 +404,20 @@ class LaxControlFlowTest(jtu.JaxTestCase):
             (0, 0), lambda x: (x[0], 0),
             (1, 1), lambda x: x)
 
+  def testIssue649(self):
+    from jax import lax
+
+    def body(x):
+      a, b = x
+      return (7, b + 1)
+
+    def cond(x):
+      a, b = x
+      return b < 10
+
+    out = lax.while_loop(cond, body, (33, 4))
+    self.assertEqual(out, (7, 10))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #649

Actually, all that was needed to fix #649 was the `instantiate=True` line in `while_loop`. This PR also adds some aval checking so that we can catch issues like this earlier.

The instantiate-consts logic in partial_eval.py is originally by @dougalm in 13fa383 (on the differentiable-scan branch).