### PR TITLE
Add lazy device-persistent JaxTuples (DeviceTuples)

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 """
-User-facing transformations.
+JAX user-facing transformations and utilities.
 
-These mostly wrap internal transformations, providing convenience flags to
-control behavior and handling Python containers (tuples/lists/dicts) of
-arguments and outputs.
+The transformations here mostly wrap internal transformations, providing
+convenience flags to control behavior and handling Python containers of
+arguments and outputs. The Python containers handled are pytrees (see
+tree_util.py), which include nested tuples/lists/dicts, where the leaves are
+arrays or JaxTuples.
 """
 
 from __future__ import absolute_import

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -74,3 +74,10 @@ def pytree_fun_to_flatjaxtuple_fun(in_trees, *args):
 def pytree_to_flatjaxtuple(pytree):
   flat_ans, out_tree = tree_flatten(pytree)
   return pack(flat_ans), out_tree
+
+
+@transformation_with_aux
+def flatten_fun(in_tree, *args_flat):
+  py_args, py_kwargs = tree_unflatten(in_tree, args_flat)
+  ans = yield py_args, py_kwargs
+  yield pytree_to_flatjaxtuple(ans)

--- a/jax/core.py
+++ b/jax/core.py
@@ -474,6 +474,12 @@ class JaxTuple(six.with_metaclass(_TupleMeta)):
 
 
 class AbstractTuple(AbstractValue, tuple):
+  def __new__(cls, xs=()):
+    if not skip_checks:
+      xs = tuple(xs)
+      assert all(isinstance(x, AbstractValue) for x in xs), xs
+    return tuple.__new__(cls, xs)
+
   @staticmethod
   def _iter(tracer):
     return map(full_lower, tracer.unpack())

--- a/jax/core.py
+++ b/jax/core.py
@@ -445,8 +445,7 @@ pytype_aval_mappings = {}
 # when slots are defined and multiple inheritance is necessary.
 class _TupleMeta(type(tuple)):
   def __instancecheck__(self, instance):
-    return type(instance) in tuple_types
-tuple_types = set()
+    return type(get_aval(instance)) is AbstractTuple
 
 class JaxTuple(six.with_metaclass(_TupleMeta)):
   __slots__ = ['xs']
@@ -467,7 +466,6 @@ class JaxTuple(six.with_metaclass(_TupleMeta)):
       return unitvar
     else:
       return 'JaxTuple({})'.format(','.join(map(repr, self)))
-tuple_types.add(JaxTuple)
 
 
 class AbstractTuple(AbstractValue, tuple):

--- a/jax/core.py
+++ b/jax/core.py
@@ -418,7 +418,11 @@ def lattice_join(x, y):
 
 
 def valid_jaxtype(x):
-  return type(x) in pytype_aval_mappings
+  try:
+    concrete_aval(x)
+  except TypeError:
+    return False
+  return True
 
 
 def concrete_aval(x):
@@ -440,9 +444,10 @@ pytype_aval_mappings = {}
 
 # ------------------- Products -------------------
 
-# We set up a registry of tuple types so that we can control the behavior of
-# isinstance(val, JaxTuple) without subclassing JaxTuple, which can be difficult
-# when slots are defined and multiple inheritance is necessary.
+# We override isinstance(x, JaxTuple) behavior (using a metaclass) because
+# defining __slots__ (for performance) is incompatible with multiple
+# inheritance, and both isinstance(x, JaxTuple) and isinstance(x, DeviceValue)
+# can be true.
 class _TupleMeta(type(tuple)):
   def __instancecheck__(self, instance):
     return type(get_aval(instance)) is AbstractTuple

--- a/jax/core.py
+++ b/jax/core.py
@@ -418,11 +418,7 @@ def lattice_join(x, y):
 
 
 def valid_jaxtype(x):
-  try:
-    concrete_aval(x)
-  except TypeError:
-    return False
-  return True
+  return type(x) in pytype_aval_mappings
 
 
 def concrete_aval(x):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -31,6 +31,7 @@ from ..ad_util import add_jaxvals_p, zeros_like_p, zeros_like_jaxval
 from ..linear_util import transformation, transformation_with_aux, wrap_init
 from ..tree_util import register_pytree_node
 from ..util import unzip2, partial, safe_map
+from . import xla
 
 map = safe_map
 
@@ -200,8 +201,9 @@ def shaped_jaxtuple(xs):
   return AbstractTuple(map(shaped_aval, xs))
 
 pytype_aval_mappings[JaxTuple] = shaped_jaxtuple
+pytype_aval_mappings[xla.DeviceTuple] = xla.abstractify_device_tuple
 
-for t in array_types:
+for t in it.chain(array_types, [xla.DeviceArray]):
   pytype_aval_mappings[t] = make_shaped_array
 
 

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -309,7 +309,7 @@ def _dimsize(dim, aval, x):
 def moveaxis(sz, dst, src, x, force_broadcast=True):
   return _moveaxis(sz, dst, src, get_aval(x), x, force_broadcast)
 
-# TODO(mattjj): not passing forece_broadcast recursively... intentional?
+# TODO(mattjj): not passing force_broadcast recursively... intentional?
 def _moveaxis(sz, dst, src, aval, x, force_broadcast=True):
   if type(aval) is AbstractTuple:
     if type(src) is tuple and type(dst) is tuple:
@@ -342,7 +342,7 @@ def _moveaxis(sz, dst, src, aval, x, force_broadcast=True):
 def broadcast(x, sz, force_broadcast=False):
   return _broadcast(sz, get_aval(x), x, force_broadcast)
 
-# TODO(mattjj): not passing forece_broadcast recursively... intentional?
+# TODO(mattjj): not passing force_broadcast recursively... intentional?
 def _broadcast(sz, aval, x, force_broadcast=False):
   if type(aval) is AbstractTuple:
     return pack(map(partial(_broadcast, sz), aval, x))

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -201,7 +201,7 @@ def shaped_jaxtuple(xs):
   return AbstractTuple(map(shaped_aval, xs))
 
 pytype_aval_mappings[JaxTuple] = shaped_jaxtuple
-pytype_aval_mappings[xla.DeviceTuple] = xla.abstractify_device_tuple
+pytype_aval_mappings[xla.DeviceTuple] = xla.pytype_aval_mappings[xla.DeviceTuple]
 
 for t in it.chain(array_types, [xla.DeviceArray]):
   pytype_aval_mappings[t] = make_shaped_array

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -301,9 +301,9 @@ def join_pvals(pval1, pval2):
     pvals1, pvals2 = zip(pv1, const1), zip(pv2, const2)
     join_pvs, join_consts = unzip2(map(join_pvals, pvals1, pvals2))
     if all(isinstance(pv, AbstractValue) for pv in join_pvs):
-      return PartialVal((AbstractTuple(join_pvs), tuple(join_consts)))
+      return PartialVal((AbstractTuple(join_pvs), pack(join_consts)))
     else:
-      return PartialVal((JaxprTracerTuple(join_pvs), tuple(join_consts)))
+      return PartialVal((JaxprTracerTuple(join_pvs), pack(join_consts)))
 
 def as_abstract_val(pv):
   if isinstance(pv, AbstractValue):

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -360,7 +360,7 @@ xla.canonicalize_dtype_handlers[ShardedDeviceTuple] = \
 class ShardedDeviceArray(xla.DeviceArray):
   """A ShardedDeviceArray is an ndarray sharded across devices.
 
-  The purposes of a ShardedDeviceArray is to reduce the number of transfers when
+  The purpose of a ShardedDeviceArray is to reduce the number of transfers when
   executing replicated computations, by allowing results to persist on the
   devices that produced them. That way dispatching a similarly replicated
   computation that consumes the same sharded memory layout does not incur any

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -371,7 +371,7 @@ def tuple_element_handler(axis_size, aval):
     raise TypeError(t)
 
 
-core.pytype_aval_mappings[ShardedDeviceTuple] = core.AbstractTuple
+core.pytype_aval_mappings[ShardedDeviceTuple] = core.pytype_aval_mappings[core.JaxTuple]
 xla.pytype_aval_mappings[ShardedDeviceTuple] = op.attrgetter('aval')
 xla.canonicalize_dtype_handlers[ShardedDeviceTuple] = \
     xla.canonicalize_dtype_handlers[xla.DeviceTuple]

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -341,6 +341,7 @@ class ShardedDeviceTuple(xla.DeviceTuple):
     all_bufs = zip(*[buf.destructure() for buf in self.device_buffers])
     elts = [_tuple_elt_handler(self.axis_size, bufs) for bufs in all_bufs]
     return iter(elts)
+core.tuple_types.add(ShardedDeviceTuple)
 
 def _tuple_elt_handler(axis_size, bufs):
   is_tuple = {buf.shape().is_tuple() for buf in bufs}

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -343,8 +343,8 @@ class ShardedDeviceArray(xla.DeviceArray):
     xla_shape = device_buffers[0].shape()
     self.shape = (axis_size,) + tuple(xla_shape.dimensions())
     self.dtype = xla_shape.element_type()
-    self.ndim = 1 + len(self.shape)
-    self.size = axis_size * prod(self.shape)
+    self.ndim = len(self.shape)
+    self.size = prod(self.shape)
     self._npy_value = None
 
   @property

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -442,6 +442,18 @@ class DeviceArray(DeviceValue):
   def __repr__(self):
     return onp.array_repr(self)
 
+  def item(self):
+    if onp.issubdtype(self.dtype, onp.complexfloating):
+      return complex(self)
+    elif onp.issubdtype(self.dtype, onp.floating):
+      return float(self)
+    elif onp.issubdtype(self.dtype, onp.integer):
+      return int(self)
+    elif onp.issubdtype(self.dtype, onp.bool_):
+      return bool(self)
+    else:
+      raise TypeError(self.dtype)
+
   def __len__(self):
     try:
       return self.shape[0]

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -403,6 +403,8 @@ def abstractify_device_tuple(tup):
 
 core.pytype_aval_mappings[DeviceTuple] = AbstractTuple
 pytype_aval_mappings[DeviceTuple] = abstractify_device_tuple
+# DeviceValues don't need to be canonicalized because we assume values on the
+# device have already been canonicalized.
 canonicalize_dtype_handlers[DeviceTuple] = identity
 
 
@@ -492,6 +494,8 @@ class DeviceArray(DeviceValue):
 
 core.pytype_aval_mappings[DeviceArray] = ConcreteArray
 pytype_aval_mappings[DeviceArray] = make_shaped_array
+# DeviceValues don't need to be canonicalized because we assume values on the
+# device have already been canonicalized.
 canonicalize_dtype_handlers[DeviceArray] = identity
 
 def _device_array_constant_handler(c, val, canonicalize_types=True):

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -365,13 +365,15 @@ for t in array_types:
 
 
 class DeviceValue(object):
+  """A DeviceValue represents a value backed by device memory."""
   __slots__ = ["device_buffer"]
   def __init__(self, device_buffer):
     self.device_buffer = device_buffer
 
-
 class DeviceTuple(DeviceValue):
+  """A DeviceTuple is a JaxTuple backed by a single device memory buffer."""
   __slots__ = ["elt_xla_shapes", "elt_handlers"]
+
   def __init__(self, device_buffer):
     self.device_buffer = device_buffer
     self.elt_xla_shapes = device_buffer.shape().tuple_shapes()
@@ -384,6 +386,10 @@ class DeviceTuple(DeviceValue):
 
   def __len__(self):
     return len(self.elt_xla_shapes)
+
+  def __repr__(self):
+    return 'DeviceTuple[{}]'.format(len(self.elt_xla_shapes))
+core.tuple_types.add(DeviceTuple)
 
 def _tuple_elt_handler(xla_shape):
   if xla_shape.is_tuple():
@@ -405,6 +411,9 @@ def forward_method(attrname, self, fun, *args):
 forward_to_value = partial(forward_method, "_value")
 
 class DeviceArray(DeviceValue):
+  """A DeviceArray is an ndarray backed by a single device memory buffer."""
+  # We don't subclass ndarray because that would open up a host of issues,
+  # but lax_numpy.py overrides isinstance behavior and attaches ndarray methods.
   __slots__ = ["shape", "dtype", "ndim", "size", "_npy_value"]
   __array_priority__ = 100.
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -84,6 +84,21 @@ def execute_compiled_primitive(compiled, result_handler, *args):
   return result_handler(compiled.Execute(input_bufs, not core.skip_checks))
 
 def device_put(x, device_num=0):
+  """Place a Python value `x` on device number `device_num`.
+
+  This is a wrapper around jax.lib.xla_bridge.device_put to handle
+  additional Python array types, namely DeviceArray (which is already backed by
+  device memory, though may be on the wrong device) and DeviceConstant. In
+  particular, it avoids transferring data already placed on the correct device,
+  and handles instantiating DeviceConstants.
+
+  Args:
+    x: an ndarray, DeviceArray, DeviceConstant, or JaxTuple to be transferred.
+    device_num: an int representing the target physical device number.
+
+  Returns:
+    A buffer representing the input `x` placed on the appropriate device.
+  """
   x = canonicalize_pyval_dtype(x)
   if type(x) is DeviceArray:
     if x.device_buffer.device() == device_num:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -136,9 +136,8 @@ def device_put(x, device_num=0):
   elif hasattr(x, '__array__'):
     return xb.device_put(x, device_num)  # handle arraylikes
   elif t is JaxTuple:
-    # TODO(mattjj, phawkins): for the JaxTuple case, this implementation can
-    # round-trip tuple elements already on the correct device; consider revising
-    return xb.device_put(x, device_num)
+    element_bufs = tuple(map(partial(device_put, device_num=device_num), x))
+    return xb.make_tuple(element_bufs, device_num)
   else:
     raise TypeError(t)
 
@@ -207,7 +206,7 @@ def pyval_result_handler(result_shape):
   if t is ResultArray:
     return lambda buf: buf.to_py()
   elif t is ResultTuple:
-    handlers = list(map(result_handler, result_shape))
+    handlers = list(map(pyval_result_handler, result_shape))
     return lambda buf: JaxTuple(h(b) for h, b in zip(handlers, buf.destructure()))
   else:
     raise TypeError(t)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -406,7 +406,7 @@ class DeviceTuple(DeviceValue):
 
 # DeviceValues don't need to be dtype-canonicalized because we assume values on
 # the device have already been canonicalized.
-core.pytype_aval_mappings[DeviceTuple] = AbstractTuple
+core.pytype_aval_mappings[DeviceTuple] = core.pytype_aval_mappings[JaxTuple]
 pytype_aval_mappings[DeviceTuple] = op.attrgetter('aval')
 canonicalize_dtype_handlers[DeviceTuple] = identity
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1265,8 +1265,6 @@ for t in itertools.chain(array_types, [xla.DeviceArray]):
   ad_util.jaxval_adders[t] = add
 ad_util.jaxval_zeros_likers[xla.DeviceArray] = zeros_like_array
 
-batching.pytype_aval_mappings[xla.DeviceArray] = make_shaped_array
-
 
 ### primitives
 

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -187,7 +187,8 @@ def device_put_many(pyvals_and_devices):
     return [device_put(pyval, device) for (pyval, device) in pyvals_and_devices]
 
 def make_tuple(bufs, device_num=0):
-  return xla_client.Buffer.make_tuple(bufs, device=device_num)
+  return xla_client.Buffer.make_tuple(bufs, device=device_num,
+                                      backend=get_backend())
 
 
 Shape = xla_client.Shape        # pylint: disable=invalid-name

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -186,6 +186,9 @@ def device_put_many(pyvals_and_devices):
   else:
     return [device_put(pyval, device) for (pyval, device) in pyvals_and_devices]
 
+def make_tuple(bufs, device_num=0):
+  return xla_client.Buffer.make_tuple(bufs, device=device_num)
+
 
 Shape = xla_client.Shape        # pylint: disable=invalid-name
 

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -12,6 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utilities for working with tree-like container data structures.
+
+The code here is independent of JAX. The only dependence is on jax.util, which
+itself has no JAX-specific code.
+
+This module provides a small set of utility functions for working with tree-like
+data structures, such as nested tuples, lists, and dicts. We call these
+structures pytrees. They are trees in that they are defined recursively (any
+non-pytree is a pytree, i.e. a leaf, and any pytree of pytrees is a pytree) and
+can be operated on recursively (object identity equivalence is not preserved by
+mapping operations, and the structures cannot contain reference cycles).
+
+The set of Python types that are considered pytree nodes (e.g. that can be
+mapped over, rather than treated as leaves) is extensible. There is a single
+module-level registry of types, and class hierarchy is ignored. By registering a
+new pytree node type, that type in effect becomes transparent to the utility
+functions in this file.
+"""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -542,10 +542,18 @@ class APITest(jtu.JaxTestCase):
     self.assertIsInstance(tup, DeviceTuple)
     self.assertEqual(tuple(tup), (1, 2))
 
+    tup = device_put(pack((1, pack((2, 3)))))
+    self.assertIsInstance(tup, DeviceTuple)
+    self.assertAllClose(tup, (1, (2, 3)), check_dtypes=False)
+
   def test_devicetuple_isinstance(self):
     tup = device_put(pack((1, 2)))
     self.assertIsInstance(tup, DeviceTuple)
     self.assertIsInstance(tup, JaxTuple)
+
+  def test_devicetuple_repr(self):
+    tup = device_put(pack((1, 2)))
+    self.assertEqual(repr(tup), 'DeviceTuple(len=2)')
 
 
 if __name__ == '__main__':

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -25,9 +25,9 @@ from jax import test_util as jtu
 import jax.numpy as np
 from jax import jit, grad, device_get, device_put, jacfwd, jacrev, hessian
 from jax import api
-from jax.core import Primitive
+from jax.core import Primitive, pack, JaxTuple
 from jax.interpreters.ad import defjvp, defvjp, defvjp2, defvjp_all
-from jax.interpreters.xla import DeviceArray
+from jax.interpreters.xla import DeviceArray, DeviceTuple
 from jax.abstract_arrays import concretization_err_msg
 
 from jax.config import config
@@ -536,6 +536,16 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(val_ans, onp.sin(3. * 4.), check_dtypes=False)
     self.assertAllClose(grad_ans, 3. * 4. + onp.cos(onp.sin(3. * 4)),
                         check_dtypes=False)
+
+  def test_devicetuple_iteration(self):
+    tup = device_put(pack((1, 2)))
+    self.assertIsInstance(tup, DeviceTuple)
+    self.assertEqual(tuple(tup), (1, 2))
+
+  def test_devicetuple_isinstance(self):
+    tup = device_put(pack((1, 2)))
+    self.assertIsInstance(tup, DeviceTuple)
+    self.assertIsInstance(tup, JaxTuple)
 
 
 if __name__ == '__main__':

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -555,6 +555,10 @@ class APITest(jtu.JaxTestCase):
     tup = device_put(pack((1, 2)))
     self.assertEqual(repr(tup), 'DeviceTuple(len=2)')
 
+  def test_legacy_devicearray_repr(self):
+    dx = device_put(3.)
+    str(dx.item())  # doesn't crash
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
The main purpose of this PR is to provide a mechanism to reduce container-traversing overheads that we pay on every dispatch to a jitted function, which are especially salient when running training on a stax/trax model with many parameters stored as a pytree (nested container) structure.

Here are two facts to unpack before explaining this PR in more detail.

### Fact 1

Python functions that are transformed using the transforms in api.py, like `jit` and `grad`, can accept arguments that are pytrees of JaxTypes.

Pytrees are recursive data types: a JaxType is a pytree, a tuple or list of pytrees is a pytree, and a dict with pytrees as values and sortable keys is a pytree. (Also [users can register new pytree types](https://github.com/google/jax/issues/244#issuecomment-454482916) and thus add custom container types that work with all the transforms in api.py, but we'll set those aside for concreteness.) A JaxType is an array or a `core.JaxTuple`, where an array is a `numpy.ndarray` or a `jax.interpreters.xla.DeviceArray`. A JaxType is a Python-embedded representation of a value in the jaxpr language. (The set of JaxTypes is also extensible, and includes some other array types, but let's keep things simple!)

In other words, a pytree is a container data structure like a nested list/tuple/dict, and its leaves are either arrays or JaxTuples. JaxTuples can themselves contain any JaxType, meaning arrays or nested JaxTuples, but they're just opaque leaves from a pytree point of view.

To avoid handling the variety of pytree types everywhere in JAX's codebase, api.py serves as a barrier to canonicalize pytrees into JaxTuple trees. That means that our XLA compilation and execution logic in xla.py need only know about JaxTuples and not, say, Python dicts or custom user pytree types. But that also means that on every dispatch to a jitted function we recurse (in Python) into pytree arguments and rebuild them into JaxTuples, and similarly we destructure the output and rebuild it into a pytree.

**User code doesn't usually form JaxTuples at all, so the arguments to transformed functions (like jitted functions) are almost always pytrees of arrays.** Pytree destructuring can take several milliseconds for large pytree arguments, and stax/trax (together with how optimizers.py) can generate large pytree arguments. That's too slow!

### Fact 2

On master, device persistence is handled only for arrays. That is, there are (essentially) two array JaxTypes, namely `numpy.ndarray` and `xla.DeviceArray`. The latter is effectively a subclass of the former that is backed by XLA device memory; it acts like a `numpy.ndarray` by lazily copying back to the host when needed.

When training a stax/trax neural network, the parameters (or more generally the optimizer state) is stored as a pytree of DeviceArrays. So we keep the arrays resident on the device, but we still have to traverse these pytree structures to dispatch computations on them.

**A consequence of this fact is that in xla.py we had to flatten/unflatten all the JaxTuple-tree inputs and outputs to XLA computations corresponding to jitted functions.** That also added overhead on every dispatch.

### Purpose of this PR

This PR adds a new JaxType called DeviceTuple. A DeviceTuple is to a JaxTuple what a DeviceArray is to a `numpy.ndarray`. That is, a DeviceTuple is a lazy-device-memory-backed JaxTuple.

In keeping with this analogy, DeviceTuples are only formed when a jitted user computation would return a JaxTuple. As mentioned in bolded text above, user computations don't usually return JaxTuples. So this change won't affect most (likely all) existing user computations. But it does provide a way to persist container-like structures on the device, in a way that doesn't require any destructuring when passed as an argument to a jitted function. Concretely, if an optimizer stores its state as a JaxTuple, then there won't be any pytree traversal when executing a computation on that optimizer state (it's a leaf).

In other words, this PR doesn't change any behavior in existing user code, but does add a new "fast path" for maintaining device persistence by using JaxTuples.

This change also allowed us to remove all the flatten/unflatten stuff in xla.py.

DeviceTuples weren't possible originally (at least with reasonable destructuring behavior on the Python side) because the XLA runtime didn't support reference counting and instead required unique ownership of buffers. But @hawkinsp recently fixed that!

We intend to follow up with a tweak to the optimizers.py implementation that will leverage this path that's optimized for device persistence. That update will only change how the optimizer state is stored; optimizer states are pretty much opaque to users (we've changed their representation a few times), and it won't add any restrictions to the parameters that can be handled by stax and the optimizers (they can still be any pytree of JaxTypes).