### PR TITLE
revise optimizer api and implementation

### DIFF
--- a/examples/advi.py
+++ b/examples/advi.py
@@ -120,12 +120,12 @@ if __name__ == "__main__":
     init_mean = np.zeros(D)
     init_std  = np.zeros(D)
     init_params = (init_mean, init_std)
-    opt_init, opt_update = optimizers.momentum(step_size=0.1, mass=0.9)
+    opt_init, opt_update, get_params = optimizers.momentum(step_size=0.1, mass=0.9)
     opt_state = opt_init(init_params)
 
     @jit
     def update(i, opt_state):
-        params = optimizers.get_params(opt_state)
+        params = get_params(opt_state)
         gradient = grad(objective)(params, i)
         return opt_update(i, gradient, opt_state)
 
@@ -134,6 +134,6 @@ if __name__ == "__main__":
     print("Optimizing variational parameters...")
     for t in range(100):
         opt_state = update(t, opt_state)
-        params = optimizers.get_params(opt_state)
+        params = get_params(opt_state)
         callback(params, t)
     plt.show(block=True)

--- a/examples/differentially_private_sgd.py
+++ b/examples/differentially_private_sgd.py
@@ -204,16 +204,16 @@ def main(_):
 
   batches = data_stream()
 
-  opt_init, opt_update = optimizers.sgd(FLAGS.learning_rate)
+  opt_init, opt_update, get_params = optimizers.sgd(FLAGS.learning_rate)
 
   @jit
   def update(_, i, opt_state, batch):
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     return opt_update(i, grad(loss)(params, batch), opt_state)
 
   @jit
   def private_update(rng, i, opt_state, batch):
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     rng = random.fold_in(rng, i)  # get new key for new random numbers
     return opt_update(
         i,
@@ -243,7 +243,7 @@ def main(_):
     print('Epoch {} in {:0.2f} sec'.format(epoch, epoch_time))
 
     # evaluate test accuracy
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     test_acc = accuracy(params, shape_as_image(test_images, test_labels))
     test_loss = loss(params, shape_as_image(test_images, test_labels))
     print('Test set loss, accuracy (%): ({:.2f}, {:.2f})'.format(

--- a/examples/kernel_lsq.py
+++ b/examples/kernel_lsq.py
@@ -42,17 +42,17 @@ def gram(kernel, xs):
 
 
 def minimize(f, x, num_steps=10000, step_size=0.000001, mass=0.9):
-  opt_init, opt_update = optimizers.momentum(step_size, mass)
+  opt_init, opt_update, get_params = optimizers.momentum(step_size, mass)
 
   @jit
   def update(i, opt_state):
-    x = optimizers.get_params(opt_state)
+    x = get_params(opt_state)
     return opt_update(i, grad(f)(x), opt_state)
 
   opt_state = opt_init(x)
   for i in xrange(num_steps):
     opt_state = update(i, opt_state)
-  return optimizers.get_params(opt_state)
+  return get_params(opt_state)
 
 
 def train(kernel, xs, ys, regularization=0.01):

--- a/examples/mnist_classifier.py
+++ b/examples/mnist_classifier.py
@@ -72,11 +72,11 @@ if __name__ == "__main__":
         yield train_images[batch_idx], train_labels[batch_idx]
   batches = data_stream()
 
-  opt_init, opt_update = optimizers.momentum(step_size, mass=momentum_mass)
+  opt_init, opt_update, get_params = optimizers.momentum(step_size, mass=momentum_mass)
 
   @jit
   def update(i, opt_state, batch):
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     return opt_update(i, grad(loss)(params, batch), opt_state)
 
   _, init_params = init_random_params(rng, (-1, 28 * 28))
@@ -90,7 +90,7 @@ if __name__ == "__main__":
       opt_state = update(next(itercount), opt_state, next(batches))
     epoch_time = time.time() - start_time
 
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     train_acc = accuracy(params, (train_images, train_labels))
     test_acc = accuracy(params, (test_images, test_labels))
     print("Epoch {} in {:0.2f} sec".format(epoch, epoch_time))

--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
   _, init_decoder_params = decoder_init(dec_init_rng, (batch_size, 10))
   init_params = init_encoder_params, init_decoder_params
 
-  opt_init, opt_update = optimizers.momentum(step_size, mass=0.9)
+  opt_init, opt_update, get_params = optimizers.momentum(step_size, mass=0.9)
 
   def binarize_batch(rng, i, images):
     i = i % num_batches
@@ -115,13 +115,13 @@ if __name__ == "__main__":
       elbo_rng, data_rng = random.split(random.fold_in(rng, i))
       batch = binarize_batch(data_rng, i, train_images)
       loss = lambda params: -elbo(elbo_rng, params, batch) / batch_size
-      g = grad(loss)(optimizers.get_params(opt_state))
+      g = grad(loss)(get_params(opt_state))
       return opt_update(i, g, opt_state)
     return lax.fori_loop(0, num_batches, body_fun, opt_state)
 
   @jit
   def evaluate(opt_state, images):
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     elbo_rng, data_rng, image_rng = random.split(test_rng, 3)
     binarized_test = random.bernoulli(data_rng, images)
     test_elbo = elbo(elbo_rng, params, binarized_test) / images.shape[0]

--- a/examples/resnet50.py
+++ b/examples/resnet50.py
@@ -117,16 +117,16 @@ if __name__ == "__main__":
       onehot_labels = labels == np.arange(num_classes)
       yield images, onehot_labels
 
-  opt_init, opt_update = optimizers.momentum(step_size, mass=0.9)
+  opt_init, opt_update, get_params = optimizers.momentum(step_size, mass=0.9)
   batches = synth_batches()
 
   @jit
   def update(i, opt_state, batch):
-    params = optimizers.get_params(opt_state)
+    params = get_params(opt_state)
     return opt_update(i, grad(loss)(params, batch), opt_state)
 
   opt_state = opt_init(init_params)
   for i in xrange(num_steps):
     opt_state = update(i, opt_state, next(batches))
-  trained_params = optimizers.get_params(opt_state)
+  trained_params = get_params(opt_state)
 

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -172,14 +172,14 @@ def optimizer(opt_maker):
 
 @optimizer
 def sgd(step_size):
-  """Construct init and update step functions for stochastic gradient descent.
+  """Construct optimizer triple for stochastic gradient descent.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
       that maps the iteration index to positive scalar.
 
   Returns:
-    An (init, update) pair.
+    An (init_fun, update_fun, get_params) triple.
   """
   step_size = make_schedule(step_size)
   def init(x0):
@@ -192,14 +192,14 @@ def sgd(step_size):
 
 @optimizer
 def momentum(step_size, mass):
-  """Construct init and update step functions for SGD with Nesterov momentum.
+  """Construct optimizer triple for SGD with Nesterov momentum.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
       that maps the iteration index to positive scalar.
 
   Returns:
-    An (init, update) pair.
+    An (init_fun, update_fun, get_params) triple.
   """
   step_size = make_schedule(step_size)
   def init(x0):
@@ -217,14 +217,14 @@ def momentum(step_size, mass):
 
 @optimizer
 def rmsprop(step_size, gamma=0.9, eps=1e-8):
-  """Construct init and update step functions for RMSProp.
+  """Construct optimizer triple for RMSProp.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
       that maps the iteration index to positive scalar.
 
   Returns:
-    An (init, update) pair.
+    An (init_fun, update_fun, get_params) triple.
   """
   step_size = make_schedule(step_size)
   def init(x0):
@@ -242,7 +242,7 @@ def rmsprop(step_size, gamma=0.9, eps=1e-8):
 
 @optimizer
 def adam(step_size, b1=0.9, b2=0.999, eps=1e-8):
-  """Construct init and update step functions for Adam.
+  """Construct optimizer triple for Adam.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
@@ -255,7 +255,7 @@ def adam(step_size, b1=0.9, b2=0.999, eps=1e-8):
       numerical stability (default 1e-8).
 
   Returns:
-    An (init, update) pair.
+    An (init_fun, update_fun, get_params) triple.
   """
   step_size = make_schedule(step_size)
   def init(x0):

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -224,7 +224,7 @@ class JVPTrace(Trace):
     primal_out, tangent_out = build_tree(out_tree_def(), result)
     return JVPTracer(self, primal_out, tangent_out)
 
-  def post_process_call(self, _, out_tracer):
+  def post_process_call(self, call_primitive, out_tracer, params):
     out_jtuple, tree_def = tree_to_jaxtuples((out_tracer.primal, out_tracer.tangent))
     master = self.master
     def todo(x):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -131,7 +131,7 @@ class BatchTrace(Trace):
       val_out = call_primitive.bind(f, *vals, **params)
       return BatchTracer(self, val_out, dim_out())
 
-  def post_process_call(self, _, out_tracer):
+  def post_process_call(self, call_primitive, out_tracer, params):
     val, dim = out_tracer.val, out_tracer.batch_dim
     master = self.master
     def todo(x):

--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -145,7 +145,7 @@ class SerialPmapTrace(Trace):
       val_out = call_primitive.bind(f, *vals, **params)
       return SerialPmapTracer(self, name, val_out, axis_out())
 
-  def post_process_call(self, _, out_tracer):
+  def post_process_call(self, call_primitive, out_tracer, params):
     name, val, axis = out_tracer.name, out_tracer.val, out_tracer.axis
     master = self.master
     def todo(x):

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -111,7 +111,7 @@ class JaxprTrace(Trace):
     eqn = JaxprEqn(invars, None, call_primitive, (bound_subjaxpr,), False, params)
     return JaxprTracer(self, PartialVal((out_pv, out_const)), eqn)
 
-  def post_process_call(self, call_primitive, out_tracer):
+  def post_process_call(self, call_primitive, out_tracer, params):
     # TODO(mattjj): post_process_map
     jaxpr, consts, env = tracers_to_jaxpr([], out_tracer)
     out_pv, out_pv_const = out_tracer.pval
@@ -123,7 +123,7 @@ class JaxprTrace(Trace):
       const_tracers = map(trace.new_instantiated_const, consts)
       env_tracers = map(trace.full_raise, env)
       bound_subjaxpr = (jaxpr, const_tracers, env_tracers)
-      eqn = JaxprEqn([], None, call_primitive, (bound_subjaxpr,), False, {})
+      eqn = JaxprEqn([], None, call_primitive, (bound_subjaxpr,), False, params)
       return JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), eqn)
 
     return out, todo

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -152,6 +152,7 @@ def check_vjp(f, f_vjp, args, atol=ATOL, rtol=RTOL, eps=EPS):
 
 
 def check_grads(f, args, order, atol=None, rtol=None, eps=None):
+  args = tuple(args)
   if order > 1:
     def f_vjp(*args):
       out_primal_py, vjp_py = api.vjp(f, *args)

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -79,70 +79,23 @@ def tree_multimap(f, tree, *rest):
     leaf given by `f(x, *xs)` where `x` is the value at the corresponding leaf
     in `tree` and `xs` is the tuple of values at corresponding leaves in `rest`.
   """
-  # equivalent to prefix_multimap(f, tree_structure(tree), tree, *rest)
   node_type = node_types.get(type(tree))
   if node_type:
-    children, node_spec = node_type.to_iterable(tree)
+    children, aux_data = node_type.to_iterable(tree)
     all_children = [children]
     for other_tree in rest:
       other_node_type = node_types.get(type(other_tree))
-      # TODO(mattjj): enable this check
-      # if node_type != other_node_type:
-      #   raise TypeError('Mismatch: {} != {}'.format(other_node_type, node_type))
-      other_children, other_node_data = node_type.to_iterable(other_tree)
-      if other_node_data != node_spec:
-        raise TypeError('Mismatch: {} != {}'.format(other_node_data, node_spec))
+      if node_type != other_node_type:
+        raise TypeError('Mismatch: {} != {}'.format(other_node_type, node_type))
+      other_children, other_aux_data = node_type.to_iterable(other_tree)
+      if other_aux_data != aux_data:
+        raise TypeError('Mismatch: {} != {}'.format(other_aux_data, aux_data))
       all_children.append(other_children)
 
     new_children = [tree_multimap(f, *xs) for xs in zip(*all_children)]
-    return node_type.from_iterable(node_spec, new_children)
+    return node_type.from_iterable(aux_data, new_children)
   else:
     return f(tree, *rest)
-
-def prefix_multimap(f, treedef, tree, *rest):
-  """Like tree_multimap but only maps down through a tree prefix."""
-  if treedef is leaf:
-    return f(tree, *rest)
-  else:
-    node_type = node_types.get(type(tree))
-    if node_type != treedef.node_type:
-      raise TypeError('Mismatch: {} != {}'.format(treedef.node_type, node_type))
-    children, node_data = node_type.to_iterable(tree)
-    if node_data != treedef.node_data:
-      raise TypeError('Mismatch: {} != {}'.format(treedef.node_data, node_data))
-    all_children = [children]
-    for other_tree in rest:
-      other_children, other_node_data = node_type.to_iterable(other_tree)
-      if other_node_data != node_data:
-        raise TypeError('Mismatch: {} != {}'.format(other_node_data, node_data))
-      all_children.append(other_children)
-    all_children = zip(*all_children)
-
-    new_children = [prefix_multimap(f, td, *xs)
-                    for td, xs in zip(treedef.children, all_children)]
-    return node_type.from_iterable(node_data, new_children)
-
-def tree_mimomap(f, tree, *rest):
-  """Map a multi-input tuple-output over pytree args to form a tuple of pytrees.
-
-  Args:
-    f: function that takes `1 + len(rest)` arguments and returns a tuple, to be
-      applied at the corresponding leaves of the pytrees.
-    tree: a pytree to be mapped over, with each leaf providing the first
-      positional argument to `f`.
-    *rest: a tuple of pytrees, each with the same structure as `tree`.
-
-  Returns:
-    A tuple of pytrees with length given by the length of the output of `f` and
-    with each pytree element having the same structure as `tree`.
-  """
-  flat, treedef = tree_flatten(tree)
-  rest_flat, treedefs = unzip2(map(tree_flatten, rest))
-  if not all(td == treedef for td in treedefs):
-    td = next(td for td in treedefs if td != treedef)
-    raise TypeError('Mismatch: {} != {}'.format(treedef, td))
-  out_flat = zip(*map(f, flat, *rest_flat))
-  return tuple(map(partial(tree_unflatten, treedef), out_flat))
 
 
 def tree_reduce(f, tree):
@@ -269,6 +222,9 @@ class NodeType(object):
     self.name = name
     self.to_iterable = to_iterable
     self.from_iterable = from_iterable
+
+  def __repr__(self):
+    return self.name
 
 node_types = {}
 

--- a/notebooks/maml.ipynb
+++ b/notebooks/maml.ipynb
@@ -188,19 +188,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opt_init, opt_update = optimizers.adam(step_size=1e-2)\n",
+    "opt_init, opt_update, get_params = optimizers.adam(step_size=1e-2)\n",
     "opt_state = opt_init(net_params)\n",
     "\n",
     "# Define a compiled update step\n",
     "@jit\n",
     "def step(i, opt_state, x1, y1):\n",
-    "    p = optimizers.get_params(opt_state)\n",
+    "    p = get_params(opt_state)\n",
     "    g = grad(loss)(p, x1, y1)\n",
     "    return opt_update(i, g, opt_state)\n",
     "\n",
     "for i in range(100):\n",
     "    opt_state = step(i, opt_state, xrange_inputs, targets)\n",
-    "net_params = optimizers.get_params(opt_state)"
+    "net_params = get_params(opt_state)"
    ]
   },
   {

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -23,11 +23,15 @@ from absl.testing import absltest
 import jax.numpy as np
 import jax.test_util as jtu
 from jax import jit, grad
+from jax import core, tree_util
 from jax.experimental import optimizers
-from jax.lib import xla_bridge as xla
+from jax.interpreters import xla
 
 from jax.config import config
 config.parse_flags_with_absl()
+
+
+dummy_data = None
 
 class OptimizerTests(jtu.JaxTestCase):
 
@@ -36,29 +40,33 @@ class OptimizerTests(jtu.JaxTestCase):
     self._CheckRun(optimizer, loss, x0, num_steps, *args, **kwargs)
 
   def _CheckFuns(self, optimizer, loss, x0, *args):
-    init_fun, update_fun = optimizer(*args)
+    init_fun, update_fun, get_params_fun = optimizer(*args)
     opt_state = init_fun(x0)
-    update_fun(0, grad(loss)(x0, None), opt_state)  # doesn't crash
+    self.assertAllClose(x0, get_params_fun(opt_state), check_dtypes=True)
+    opt_state2 = update_fun(0, grad(loss)(x0, dummy_data), opt_state)  # doesn't crash
+    self.assertEqual(tree_util.tree_structure(opt_state),
+                     tree_util.tree_structure(opt_state2))
 
   @jtu.skip_on_devices('gpu')
   def _CheckRun(self, optimizer, loss, x0, num_steps, *args, **kwargs):
-    return # TODO(mattjj): bring back fax!
-    # num_repl = xla.get_replica_count()
-    # infeeder = fax.make_infeed_from_sequence(
-    #     [np.ones(1, dtype='float32')] * num_steps * num_repl,
-    #     with_pyvals=True)
+    init_fun, update_fun, get_params_fun = optimizer(*args)
 
-    # def op(infeed, x0):
-    #   opt_init, opt_update = optimizer(*args, **kwargs)
-    #   return optimizers.run_optimizer(loss, infeed, opt_update, opt_init(x0))
-    # cop = jit(op)
+    opt_state = init_fun(x0)
+    for i in range(num_steps):
+      x = get_params_fun(opt_state)
+      g = grad(loss)(x, dummy_data)
+      opt_state = update_fun(i, g, opt_state)
+    xstar = get_params_fun(opt_state)
+    self.assertLess(loss(xstar, dummy_data), 1e-2)
 
-    # a1, _ = op(infeeder(), x0)
-    # a2, _ = cop(infeeder(), x0)
-
-    # assert loss(a1, None) < 1e-3
-    # assert loss(a2, None) < 1e-3
-    # self.assertAllClose(a1, a2, check_dtypes=False)
+    update_fun_jitted = jit(update_fun)
+    opt_state = init_fun(x0)
+    for i in range(num_steps):
+      x = get_params_fun(opt_state)
+      g = grad(loss)(x, dummy_data)
+      opt_state = update_fun_jitted(i, g, opt_state)
+    xstar = get_params_fun(opt_state)
+    self.assertLess(loss(xstar, dummy_data), 1e-2)
 
   def testSgdScalar(self):
     def loss(x, _): return x**2
@@ -91,6 +99,14 @@ class OptimizerTests(jtu.JaxTestCase):
     mass = 0.
     self._CheckOptimizer(optimizers.momentum, loss, x0, num_iters, step_size, mass)
 
+  def testMomentumDict(self):
+    def loss(dct, _): return np.dot(dct['x'], dct['x'])
+    x0 = {'x': np.ones(2)}
+    num_iters = 100
+    step_size = 0.1
+    mass = 0.
+    self._CheckOptimizer(optimizers.momentum, loss, x0, num_iters, step_size, mass)
+
   def testRmspropVector(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
@@ -118,56 +134,75 @@ class OptimizerTests(jtu.JaxTestCase):
   def testSgdVectorExponentialDecaySchedule(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_schedule = optimizers.exponential_decay(0.1, 3, 2.)
-    self._CheckOptimizer(optimizers.sgd, loss, x0, num_iters, step_schedule)
+    self._CheckFuns(optimizers.sgd, loss, x0, step_schedule)
 
   def testSgdVectorInverseTimeDecaySchedule(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_schedule = optimizers.inverse_time_decay(0.1, 3, 2.)
-    self._CheckOptimizer(optimizers.sgd, loss, x0, num_iters, step_schedule)
+    self._CheckFuns(optimizers.sgd, loss, x0, step_schedule)
 
   def testAdamVectorInverseTimeDecaySchedule(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_schedule = optimizers.inverse_time_decay(0.1, 3, 2.)
-    self._CheckOptimizer(optimizers.adam, loss, x0, num_iters, step_schedule)
+    self._CheckFuns(optimizers.adam, loss, x0, step_schedule)
 
   def testMomentumVectorInverseTimeDecayStaircaseSchedule(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_sched = optimizers.inverse_time_decay(0.1, 3, 2., staircase=True)
     mass = 0.9
-    self._CheckOptimizer(optimizers.momentum, loss, x0, num_iters, step_sched, mass)
+    self._CheckFuns(optimizers.momentum, loss, x0, step_sched, mass)
 
   def testRmspropVectorPiecewiseConstantSchedule(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_schedule = optimizers.piecewise_constant([25, 75], [1.0, 0.5, 0.1])
-    self._CheckOptimizer(optimizers.rmsprop, loss, x0, num_iters, step_schedule)
+    self._CheckFuns(optimizers.rmsprop, loss, x0, step_schedule)
 
   def testTracedStepSize(self):
     def loss(x, _): return np.dot(x, x)
     x0 = np.ones(2)
-    num_iters = 100
     step_size = 0.1
 
-    init_fun, _ = optimizers.sgd(step_size)
+    init_fun, _, _ = optimizers.sgd(step_size)
     opt_state = init_fun(x0)
 
     @jit
     def update(opt_state, step_size):
-      _, update_fun = optimizers.sgd(step_size)
-      x = optimizers.get_params(opt_state)
+      _, update_fun, get_params = optimizers.sgd(step_size)
+      x = get_params(opt_state)
       g = grad(loss)(x, None)
       return update_fun(0, g, opt_state)
 
     update(opt_state, 0.9)  # doesn't crash
+
+  def testDeviceTupleState(self):
+    init_fun, update_fun, _ = optimizers.sgd(0.1)
+    opt_state = init_fun(np.zeros(3))
+    self.assertIsInstance(opt_state, optimizers.OptimizerState)
+    self.assertIsInstance(opt_state.packed_state, core.JaxTuple)
+    opt_state = jit(update_fun)(0, np.zeros(3), opt_state)
+    self.assertIsInstance(opt_state, optimizers.OptimizerState)
+    self.assertIsInstance(opt_state.packed_state, xla.DeviceTuple)
+
+  def testUpdateFunStructureMismatchErrorMessage(self):
+    @optimizers.optimizer
+    def opt_maker():
+      def init_fun(x0):
+        return {'x': x0}
+      def update_fun(i, g, opt_state):
+        x = opt_state['x']
+        return {'x': x - 0.1 * g, 'v': g}  # bug!
+      def get_params(opt_state):
+        return opt_state['x']
+      return init_fun, update_fun, get_params
+
+    init_fun, update_fun, get_params = opt_maker()
+    opt_state = init_fun(np.zeros(3))
+    self.assertRaises(TypeError, lambda: update_fun(opt_state))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This new optimizer API is more general, and in addition the new implementation is based on DeviceTuples (which themselves are implemented in #664; the commits are copied here so we'll merge that one first). This is pair work with @skye.

The design goals for the API are are:
1. JAX-compatible in that we can apply any JAX transformations to these functions, with the most important being the application jit and pmap to update_fun
2. Flexibility in optimizer state, particularly removing the current restriction that all parameters have the same flat tuple structure (of equal lengths) and instead allowing optimizer state to have any pytree structure (not just tree product)
3. Allow improved performance by using DeviceTuples, which can avoid pytree traversal overheads on each dispatch

We also updated our implementation of the API to realize the latter advantage.

In the new API, an optimizer is an `(init_fun, update_fun, get_params)` triple of functions, where the component functions have these signatures:

```
init_fun(params)

Args:
  params: pytree representing the initial parameters.

Returns:
  A pytree representing the initial optimizer state, which includes the initial
  parameters and may also include auxiliary values like initial momentum. The
  optimizer state pytree structure generally differs from that of `params`.
```

```
get_params(opt_state)

Args:
  opt_state: pytree representing an optimizer state.

Returns:
  A pytree representing the parameters extracted from `opt_state`, such that
  the invariant `params == get_params(init_params(params))` holds true.
```

```
update_fun(step, grads, opt_state)

Args:
  step: integer representing the step index.
  grads: a pytree with the same structure as `get_params(opt_state)` representing
    the gradients to be used in updating the optimizer state.
  opt_state: a pytree representing the optimizer state to be updated.

Returns:
  A pytree with the same structure as the `opt_state` argument representing the
  updated optimizer state.
```

Notice that an optimizer implementation has a lot of flexibility in the form of `opt_state`: it just has to be a pytree of JaxTypes (so that it can be passed to the JAX transforms defined in api.py) and it has to be consumable by `update_fun` and `get_params`.

The new implementation basically works by flattening pytrees. There are two levels of pytrees to think about: the pytree of `params`, which we can think of as defining an "outer pytree", and a pytree produced by applying `init_fun` to each leaf of the `params` pytree, which we can think of as the "inner pytrees". Since pytrees can be flattened, that structure is isomorphic to a list of lists.

The new optimizer implementation just reifies that list of lists. Moreover it represents the list-of-lists as a JaxTuple-of-JaxTuples so that we can store the entire optimizer state as a single DeviceTuple, and thus pay no tree traversal overhead when we dispatch to a `jit`-compiled `update_fun`. This JaxTuple-of-JaxTuples representing the full optimizer state is stored as the `packed_state` member of the `OptimizerState` namedtuple, which also includes the "outer pytree" definition and the "inner pytree" definitions.