### PR TITLE
Changes for compatibility with a upcoming Jaxlib update.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -175,6 +175,9 @@ array_types = [onp.ndarray, onp.float64, onp.float32, onp.float16,
                onp.bool_, onp.uint64, onp.uint32, onp.uint16, onp.uint8,
                onp.longlong, complex, float, int, bool]
 
+if six.PY2:
+  array_types.append(long)
+
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray
   ad_util.jaxval_zeros_likers[t] = zeros_like_array

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3124,7 +3124,7 @@ def _reduce_logical_shape_rule(operand, axes):
   return tuple(onp.delete(operand.shape, axes))
 
 def _reduce_logical_translation_rule(prim, identity, c, operand, axes):
-  scalar = xla_bridge.Shape.array_shape(onp.bool_, ())
+  scalar = xla_bridge.Shape.array_shape(onp.dtype(onp.bool_), ())
   return c.Reduce(operand, c.Constant(identity(onp.bool_)),
                   xla.primitive_computation(prim, scalar, scalar), axes)
 
@@ -3409,8 +3409,10 @@ def _select_and_gather_add_pair_reducer(dtype, select_prim):
   etype = xla_bridge.dtype_to_etype_exact(dtype)
 
   c = xla_bridge.make_computation_builder("select_and_gather_pair_reducer")
-  x = c.ParameterWithShape(xla_bridge.Shape.array_shape(pair_uint_dtype, ()))
-  y = c.ParameterWithShape(xla_bridge.Shape.array_shape(pair_uint_dtype, ()))
+  x = c.ParameterWithShape(
+    xla_bridge.Shape.array_shape(onp.dtype(pair_uint_dtype), ()))
+  y = c.ParameterWithShape(
+    xla_bridge.Shape.array_shape(onp.dtype(pair_uint_dtype), ()))
 
   bits_const = c.Constant(pair_uint_dtype(bits), canonicalize_types=False)
 

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -203,12 +203,12 @@ def jax_trsm(c, alpha, a, b, left_side=False, lower=False, trans_a=False,
         alpha, a, b),
       shape_with_layout=Shape.array_shape(dtype, b_shape.dimensions(), (0, 1)),
       operand_shapes_with_layout=(
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(dtype, (), ()),
           Shape.array_shape(dtype, a_shape.dimensions(), (0, 1)),
           Shape.array_shape(dtype, b_shape.dimensions(), (0, 1)),
@@ -342,16 +342,16 @@ def jax_getrf(c, a):
             batch_dims + (m, n),
             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))),
           Shape.array_shape(
-            np.int32,
+            np.dtype(np.int32),
             batch_dims + (min(m, n),),
             tuple(range(num_bd, -1, -1))),
-          Shape.array_shape(np.int32, batch_dims,
+          Shape.array_shape(np.dtype(np.int32), batch_dims,
             tuple(range(num_bd - 1, -1, -1))),
       )),
       operand_shapes_with_layout=(
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(
             dtype,
             batch_dims + (m, n),
@@ -452,11 +452,11 @@ def jax_potrf(c, a, lower=False):
       operands=(c.ConstantS32Scalar(int(lower)), c.ConstantS32Scalar(n), a),
       shape_with_layout=Shape.tuple_shape((
           Shape.array_shape(dtype, (n, n), (0, 1)),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
       )),
       operand_shapes_with_layout=(
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(dtype, (n, n), (0, 1)),
       ))
 
@@ -675,21 +675,29 @@ def jax_gesdd(c, a, full_matrices=True, compute_uv=True):
   if dtype == np.float32:
     fn = b"lapack_sgesdd"
     singular_vals_dtype = np.float32
-    workspace = (Shape.array_shape(np.int32, (gesdd_iwork_size(m, n),), (0,)),)
+    workspace = (Shape.array_shape(np.dtype(np.int32),
+                                   (gesdd_iwork_size(m, n),), (0,)),)
   elif dtype == np.float64:
     fn = b"lapack_dgesdd"
     singular_vals_dtype = np.float64
-    workspace = (Shape.array_shape(np.int32, (gesdd_iwork_size(m, n),), (0,)),)
+    workspace = (Shape.array_shape(np.dtype(np.int32),
+                                   (gesdd_iwork_size(m, n),), (0,)),)
   elif dtype == np.complex64:
     fn = b"lapack_cgesdd"
     singular_vals_dtype = np.float32
-    workspace = (Shape.array_shape(np.int32, (gesdd_iwork_size(m, n),), (0,)),
-                 Shape.array_shape(np.float32, (cgesdd_rwork_size(m, n, int(compute_uv)),), (0,)))
+    workspace = (Shape.array_shape(np.dtype(np.int32),
+                                   (gesdd_iwork_size(m, n),), (0,)),
+                 Shape.array_shape(np.dtype(np.float32),
+                                   (cgesdd_rwork_size(m, n, int(compute_uv)),),
+                                   (0,)))
   elif dtype == np.complex128:
     fn = b"lapack_zgesdd"
     singular_vals_dtype = np.float64
-    workspace = (Shape.array_shape(np.int32, (gesdd_iwork_size(m, n),), (0,)),
-                 Shape.array_shape(np.float64, (cgesdd_rwork_size(m, n, int(compute_uv)),), (0,)))
+    workspace = (Shape.array_shape(np.dtype(np.int32),
+                                   (gesdd_iwork_size(m, n),), (0,)),
+                 Shape.array_shape(np.dtype(np.float64),
+                                   (cgesdd_rwork_size(m, n, int(compute_uv)),),
+                                   (0,)))
   else:
     raise NotImplementedError("Unsupported dtype {}".format(dtype))
 
@@ -699,16 +707,16 @@ def jax_gesdd(c, a, full_matrices=True, compute_uv=True):
                 c.ConstantS32Scalar(m), c.ConstantS32Scalar(n), a),
       shape_with_layout=Shape.tuple_shape((
           Shape.array_shape(dtype, (m, n), (0, 1)),
-          Shape.array_shape(singular_vals_dtype, (min(m, n),), (0,)),
+          Shape.array_shape(np.dtype(singular_vals_dtype), (min(m, n),), (0,)),
           Shape.array_shape(dtype, (m, m if full_matrices else min(m, n)), (0, 1)),
           Shape.array_shape(dtype, (n if full_matrices else min(m, n), n), (0, 1)),
-          Shape.array_shape(np.int32, (), ())) + workspace
+          Shape.array_shape(np.dtype(np.int32), (), ())) + workspace
       ),
       operand_shapes_with_layout=(
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(dtype, (m, n), (0, 1)),
       ))
   return c.Tuple(c.GetTupleElement(out, 1), c.GetTupleElement(out, 2),
@@ -843,24 +851,30 @@ def jax_syevd(c, a, lower=False):
     fn = b"lapack_ssyevd"
     eigvals_type = np.float32
     workspace = (Shape.array_shape(dtype, (syevd_work_size(n),), (0,)),
-                 Shape.array_shape(np.int32, (syevd_iwork_size(n),), (0,)))
+                 Shape.array_shape(np.dtype(np.int32)
+                                   (syevd_iwork_size(n),), (0,)))
   elif dtype == np.float64:
     fn = b"lapack_dsyevd"
     eigvals_type = np.float64
     workspace = (Shape.array_shape(dtype, (syevd_work_size(n),), (0,)),
-                 Shape.array_shape(np.int32, (syevd_iwork_size(n),), (0,)))
+                 Shape.array_shape(np.dtype(np.int32),
+                                   (syevd_iwork_size(n),), (0,)))
   elif dtype == np.complex64:
     fn = b"lapack_cheevd"
     eigvals_type = np.float32
     workspace = (Shape.array_shape(dtype, (heevd_work_size(n),), (0,)),
-                 Shape.array_shape(np.float32, (heevd_rwork_size(n),), (0,)),
-                 Shape.array_shape(np.int32, (syevd_iwork_size(n),), (0,)))
+                 Shape.array_shape(np.dtype(np.float32)
+                                   (heevd_rwork_size(n),), (0,)),
+                 Shape.array_shape(np.dtype(np.int32),
+                                   (syevd_iwork_size(n),), (0,)))
   elif dtype == np.complex128:
     fn = b"lapack_zheevd"
     eigvals_type = np.float64
     workspace = (Shape.array_shape(dtype, (heevd_work_size(n),), (0,)),
-                 Shape.array_shape(np.float64, (heevd_rwork_size(n),), (0,)),
-                 Shape.array_shape(np.int32, (syevd_iwork_size(n),), (0,)))
+                 Shape.array_shape(np.dtype(np.float64),
+                                   (heevd_rwork_size(n),), (0,)),
+                 Shape.array_shape(np.dtype(np.int32),
+                                   (syevd_iwork_size(n),), (0,)))
   else:
     raise NotImplementedError("Unsupported dtype {}".format(dtype))
 
@@ -871,12 +885,12 @@ def jax_syevd(c, a, lower=False):
                 a),
       shape_with_layout=Shape.tuple_shape((
           Shape.array_shape(dtype, (n, n), (0, 1)),
-          Shape.array_shape(eigvals_type, (n,), (0,)),
-          Shape.array_shape(np.int32, (), ())) + workspace
+          Shape.array_shape(np.dtype(eigvals_type), (n,), (0,)),
+          Shape.array_shape(np.dtype(np.int32), (), ())) + workspace
       ),
       operand_shapes_with_layout=(
-          Shape.array_shape(np.int32, (), ()),
-          Shape.array_shape(np.int32, (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(dtype, (n, n), (0, 1)),
       ))
   return c.Tuple(c.GetTupleElement(out, 0), c.GetTupleElement(out, 1),

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -185,9 +185,9 @@ class APITest(jtu.JaxTestCase):
     def f(x, y):
       return np.dot(x, y)
 
-    jtu.check_raises(lambda: grad(f)(onp.zeros(3), onp.zeros(4)),
-                     TypeError,
-                     "Incompatible shapes for dot: got (3,) and (4,).")
+    jtu.check_raises_regexp(
+        lambda: grad(f)(onp.zeros(3), onp.zeros(4)), TypeError,
+        "Incompatible shapes for dot: got \\(3L?,\\) and \\(4L?,\\).")
 
   def test_switch_value_jit(self):
     def f(x):


### PR DESCRIPTION
Shape.array_shape will only accept dtypes, not scalar type objects.
Add long to the set of types known to abstract_arrays in Python 2.
Make api_test.py accepting of long values in shapes.