### PR TITLE
Remove option to skip checks on Execute().

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -480,7 +480,7 @@ def merged_aval(pval):
 def execute_replicated(compiled, pval, nrep, handle_in,
                        handle_replica_result, handle_full_result, *args):
   input_bufs = zip(*map(handle_in, args)) if args else [[]] * nrep
-  out_bufs = compiled.ExecutePerReplica(input_bufs)
+  out_bufs = compiled.ExecutePerReplica(list(input_bufs))
   results = [merge_pvals(handle_replica_result(buf), pval) for buf in out_bufs]
   return handle_full_result(results)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -81,7 +81,7 @@ def aval_from_xla_shape(shape):
 
 def execute_compiled_primitive(name, compiled, result_handler, *args):
   input_bufs = [device_put(x) for x in args]
-  out_buf = compiled.Execute(input_bufs, not core.skip_checks)
+  out_buf = compiled.Execute(input_bufs)
   check_nans(name, out_buf)
   return result_handler(out_buf)
 
@@ -613,7 +613,7 @@ def xla_callable(fun, device_values, *abstract_args):
 
 def execute_compiled(compiled, pval, handle_result, *args):
   input_bufs = [device_put(x) for x in args]
-  out_buf = compiled.Execute(input_bufs, not core.skip_checks)
+  out_buf = compiled.Execute(input_bufs)
   check_nans("jit-compiled computation", out_buf)
   return pe.merge_pvals(handle_result(out_buf), pval)
 


### PR DESCRIPTION
Ensure arguments to ExecuteReplicated() are a list instead of an iterator.

Change in preparation for removing Python wrappers around Executable.