### PR TITLE
fix np.eye(N) bug for N > 1000, fix DeviceConstant repr bug, add tests

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3646,7 +3646,7 @@ class _IotaConstant(xla.DeviceConstant):
 
   def __init__(self, dtype, shape, axis):
     self.shape = shape
-    self.dtype = dtype
+    self.dtype = onp.dtype(dtype)
     self.ndim = len(shape)
     self.size = prod(shape)
     self._npy_value = None
@@ -3675,7 +3675,7 @@ class _EyeConstant(xla.DeviceConstant):
 
   def __init__(self, shape, axes, dtype):
     self.shape = shape
-    self.dtype = dtype
+    self.dtype = onp.dtype(dtype)
     self.ndim = len(shape)
     self.size = prod(shape)
     self._npy_value = None

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3700,7 +3700,7 @@ class _EyeConstant(xla.DeviceConstant):
     else:
       etype = xla_bridge.dtype_to_etype_exact(diag_const.dtype)
     etype = xla_bridge.dtype_to_etype(diag_const.dtype)
-    iotas = [c.BroadcastedIota(onp.bool_, diag_const.shape, axis)
+    iotas = [c.BroadcastedIota(onp.uint32, diag_const.shape, axis)
              for axis in diag_const.axes]
     eyes = [c.Eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
     return c.ConvertElementType(_reduce(c.And, eyes), etype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1481,6 +1481,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertFalse(type(lnp.arange(77)) == type(onp.arange(77)))
     self.assertTrue(type(lnp.arange(77)) == type(lax.iota(onp.int32, 77)))
 
+  def testIssue728(self):
+    assert lnp.allclose(lnp.eye(5000), onp.eye(5000))
+    self.assertEqual(0, onp.sum(lnp.eye(1050) - onp.eye(1050)))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1352,7 +1352,7 @@ class DeviceConstantTest(jtu.JaxTestCase):
           fill_value),
        "shape": shape, "dtype": dtype, "fill_value": fill_value}
       for dtype in itertools.chain(default_dtypes, [None])
-      for shape in [(), (3,), (2, 3), (2, 3, 4)]
+      for shape in [(), (3,), (2, 3), (2, 3, 4), (1001, 1001)]
       for fill_value in [0, 1, onp.pi]))
   def testFilledConstant(self, shape, fill_value, dtype):
     make_const = lambda: lax.full(shape, fill_value, dtype)
@@ -1364,7 +1364,7 @@ class DeviceConstantTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), dimension),
        "shape": shape, "dtype": dtype, "dimension": dimension}
       for dtype in default_dtypes
-      for shape in [(), (3,), (2, 3), (2, 3, 4)]
+      for shape in [(), (3,), (2, 3), (2, 3, 4), (1001, 1001), (101, 101, 101)]
       for dimension in range(len(shape))))
   def testIotaConstant(self, dtype, shape, dimension):
     make_const = lambda: lax.broadcasted_iota(dtype, shape, dimension)
@@ -1389,6 +1389,7 @@ class DeviceConstantTest(jtu.JaxTestCase):
           [(2, 3, 4), (0, 1, 2)],
           [(2, 3, 4, 2), (0, 1, 2)],
           [(2, 3, 4, 2), (0, 2, 3)],
+          [(1001, 1001), (0, 1)],
       ]))
   def testEyeConstant(self, dtype, shape, axes):
     make_const = lambda: lax.broadcasted_eye(dtype, shape, axes)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1343,6 +1343,9 @@ class DeviceConstantTest(jtu.JaxTestCase):
     self.assertAllClose(argument_result, expected, check_dtypes=True)
     self.assertAllClose(jit_result, expected, check_dtypes=True)
 
+    # ensure repr doesn't crash
+    repr(make_const())
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_fill={}".format(
           jtu.format_shape_dtype_string(shape, dtype) if dtype else shape,


### PR DESCRIPTION
When creating a constant with `jax.numpy.eye(N)` with N > 1000 passing that constant as an argument to an XLA computation (rather than, say, converting it directly to an ndarray), or otherwise just staging any `jax.numpy.eye`-created constant into an XLA computation, the constant was not being correctly formed. This has been a bug for a while, though since the previous code may have generated undefined behavior, it's possible these effects emerged recently.