### PR TITLE
change dtype promotion behavior for jit-invariance

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,14 +726,24 @@ code to compile and end-to-end optimize much bigger functions.
 
 ## Current gotchas
 
-For a survey of current gotchas, with examples and explanations, we highly recommend reading the [Gotchas Notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb).
+For a survey of current gotchas, with examples and explanations, we highly
+recommend reading the [Gotchas Notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb).
 
 Some stand-out gotchas that might surprise NumPy users:
-1. [`np.isnan` doesn't yet work](https://github.com/google/jax/issues/276), and in general nan semantics aren't preserved on some backends.
-2. In-place mutation of arrays isn't supported, though [there is an alternative](https://jax.readthedocs.io/en/latest/jax.ops.html). Generally JAX requires functional code.
-3. JAX enforces single-precision numbers (32-bit or `float32`) by default and to use double-precision (64-bit or
-`float64`), one needs to set the `jax_enable_x64` variable **at startup** (set environment variable `JAX_ENABLE_x64 = True` or for other ways, see [here](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb#scrollTo=YTktlwTTMgFl))
-4. PRNGs are different and can be awkward, though for [good reasons](https://github.com/google/jax/blob/master/design_notes/prng.md), and non-reuse (linearity) is not yet checked.
+1. JAX enforces single-precision (32-bit, e.g. `float32`) values by default, and
+   to enable double-precision (64-bit, e.g. `float64`) one needs to set the
+   `jax_enable_x64` variable **at startup** (or set the environment variable
+   `JAX_ENABLE_x64=True`, see [the Gotchas Notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb#scrollTo=YTktlwTTMgFl))
+2. Some of NumPy's dtype promotion semantics involving a mix of Python scalars
+   and NumPy types aren't preserved, namely `np.add(1, np.array([2],
+   np.float32)).dtype` is `float64` rather than `float32`.
+3. In-place mutation of arrays isn't supported, though [there is an
+   alternative](https://jax.readthedocs.io/en/latest/jax.ops.html). Generally
+   JAX requires functional code.
+4. PRNGs are different and can be awkward, though for [good
+   reasons](https://github.com/google/jax/blob/master/design_notes/prng.md), and
+   non-reuse (linearity) is not yet checked.
+5. NumPy's nan semantics aren't preserved on some backends
 
 See [the notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb) for much more information.
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -735,7 +735,8 @@ def _get_min_identity(dtype):
     return onp.array(True, onp.bool_)
 
 def _reduce_sum(operand, axes):
-  return reduce_sum_p.bind(operand, axes=tuple(axes), input_shape=operand.shape)
+  return reduce_sum_p.bind(operand, axes=tuple(axes),
+                           input_shape=onp.shape(operand))
 
 def _reduce_prod(operand, axes):
   return reduce_prod_p.bind(operand, axes=tuple(axes))

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -50,7 +50,7 @@ def expit(x):
   x = asarray(x)
   one = lax._const(x, 1)
   return lax.div(one, lax.add(one, lax.exp(lax.neg(x))))
-ad.defjvp2(expit.primitive, lambda g, ans, x: g * ans * (1 - ans))
+ad.defjvp2(expit.primitive, lambda g, ans, x: g * ans * (lax._const(ans, 1) - ans))
 batching.defvectorized(expit.primitive)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -20,6 +20,7 @@ import collections
 import functools
 from functools import partial
 import itertools
+import operator
 import unittest
 from unittest import SkipTest
 
@@ -43,7 +44,7 @@ nonempty_nonscalar_array_shapes = [(4,), (3, 4), (3, 1), (1, 4), (2, 1, 4), (2, 
 nonempty_array_shapes = [()] + nonempty_nonscalar_array_shapes
 empty_array_shapes = [(0,), (0, 4), (3, 0),]
 
-scalar_shapes = [jtu.NUMPY_SCALAR_SHAPE]
+scalar_shapes = [jtu.NUMPY_SCALAR_SHAPE, jtu.PYTHON_SCALAR_SHAPE]
 array_shapes = nonempty_array_shapes + empty_array_shapes
 nonzerodim_shapes = nonempty_nonscalar_array_shapes + empty_array_shapes
 nonempty_shapes = scalar_shapes + nonempty_array_shapes
@@ -201,25 +202,18 @@ JAX_ARGMINMAX_RECORDS = [
 
 JAX_OPERATOR_OVERLOADS = [
     op_record("__add__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__radd__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__sub__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__rsub__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__mul__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__rmul__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__eq__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__ne__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__lt__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__gt__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__ge__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__lt__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__gt__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__ge__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__neg__", 1, number_dtypes, all_shapes, jtu.rand_default(), []),
     op_record("__pow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive(), []),
-    op_record("__rpow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive(), []),
     op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__floordiv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__rfloordiv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__floordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
     op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
     op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default(), []),
     # TODO(mattjj): __invert__ fails on bool dtypes because ~True == -2
     op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default(), []),
@@ -231,8 +225,18 @@ JAX_OPERATOR_OVERLOADS = [
     # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
     # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
     # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    # # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
     # TODO(mattjj): lshift, rshift
+]
+
+JAX_RIGHT_OPERATOR_OVERLOADS = [
+    op_record("__radd__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__rsub__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__rmul__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__rpow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive(), []),
+    op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
 ]
 
 numpy_version = tuple(map(int, onp.version.version.split('.')))
@@ -249,6 +253,8 @@ if numpy_version >= (1, 15):
 if six.PY2:
   JAX_OPERATOR_OVERLOADS += [
     op_record("__div__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+  ]
+  JAX_RIGHT_OPERATOR_OVERLOADS += [
     op_record("__rdiv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
   ]
 
@@ -293,7 +299,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                                                       dtypes),
          "rng": rec.rng, "shapes": shapes, "dtypes": dtypes,
          "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
-          "check_dtypes": rec.check_dtypes}
+         "check_dtypes": rec.check_dtypes}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
@@ -302,8 +308,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                                  JAX_COMPOUND_OP_RECORDS)))
   def testOp(self, onp_op, lnp_op, rng, shapes, dtypes, check_dtypes):
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
+    py_scalar_arg = jtu.PYTHON_SCALAR_SHAPE in shapes
     self._CheckAgainstNumpy(onp_op, lnp_op, args_maker,
-                            check_dtypes=check_dtypes)
+                            check_dtypes=check_dtypes and not py_scalar_arg)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=check_dtypes)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
@@ -318,8 +325,27 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for rec in JAX_OPERATOR_OVERLOADS))
   def testOperatorOverload(self, name, rng, shapes, dtypes):
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
-    fun = lambda x, *xs: getattr(x, name)(*xs)
-    self._CompileAndCheck(fun, args_maker, check_dtypes=True)
+    fun = lambda *xs: getattr(operator, name.strip('_'))(*xs)
+    self._CompileAndCheck(fun, args_maker,
+                          check_dtypes=jtu.PYTHON_SCALAR_SHAPE not in shapes)
+
+  @parameterized.named_parameters(itertools.chain.from_iterable(
+      jtu.cases_from_list(
+        {"testcase_name": jtu.format_test_name_suffix(rec.test_name, shapes,
+                                                      dtypes),
+         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes, "name": rec.name}
+        for shapes in filter(
+          _shapes_are_broadcast_compatible,
+          CombosWithReplacement(rec.shapes, rec.nargs))
+        for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
+      for rec in JAX_RIGHT_OPERATOR_OVERLOADS))
+  def testRightOperatorOverload(self, name, rng, shapes, dtypes):
+    if shapes[1] is jtu.PYTHON_SCALAR_SHAPE:
+      raise SkipTest()  # TODO(mattjj): clean up
+    args_maker = self._GetArgsMaker(rng, shapes, dtypes)
+    fun = lambda fst, snd: getattr(snd, name)(fst)
+    self._CompileAndCheck(fun, args_maker,
+                          check_dtypes=jtu.PYTHON_SCALAR_SHAPE not in shapes)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
       jtu.cases_from_list(
@@ -339,7 +365,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         onp.iinfo(dtype).bits == 64 for dtype in dtypes):
       self.skipTest("x64 types are disabled by jax_enable_x64")
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
-    self._CheckAgainstNumpy(onp_op, lnp_op, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(onp_op, lnp_op, args_maker,
+                            check_dtypes=jtu.PYTHON_SCALAR_SHAPE not in shapes)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -1405,6 +1432,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(x[0, 0], 1)
 
   def testScalarDtypePromotion(self):
+    # disabled this test after https://github.com/google/jax/issues/732
+    msg = ("jax.numpy differs from numpy in promotion rules for Python scalars."
+           " See https://github.com/google/jax/issues/732.")
+    raise SkipTest(msg)
     orig_numpy_result = (1 + onp.eye(1, dtype=onp.float32)).dtype
     jax_numpy_result = (1 + lnp.eye(1, dtype=lnp.float32)).dtype
     self.assertEqual(orig_numpy_result, jax_numpy_result)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -219,13 +219,9 @@ JAX_OPERATOR_OVERLOADS = [
     op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default(), []),
     # TODO(mattjj): investigate these failures
     # op_record("__or__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
     # op_record("__and__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
     # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
     # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    # # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
     # TODO(mattjj): lshift, rshift
 ]
 
@@ -237,6 +233,10 @@ JAX_RIGHT_OPERATOR_OVERLOADS = [
     op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
     op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
     op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
+    # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
+    # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
+    # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
 ]
 
 numpy_version = tuple(map(int, onp.version.version.split('.')))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1364,7 +1364,10 @@ class DeviceConstantTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), dimension),
        "shape": shape, "dtype": dtype, "dimension": dimension}
       for dtype in default_dtypes
-      for shape in [(), (3,), (2, 3), (2, 3, 4), (1001, 1001), (101, 101, 101)]
+      for shape in [(), (3,), (2, 3), (2, 3, 4),
+                    # TODO(mattjj): re-enable
+                    # (1001, 1001), (101, 101, 101),
+                    ]
       for dimension in range(len(shape))))
   def testIotaConstant(self, dtype, shape, dimension):
     make_const = lambda: lax.broadcasted_iota(dtype, shape, dimension)


### PR DESCRIPTION
Here are two desiderata for jax.numpy dtype promotion behavior:
1. follow what NumPy does (or a cleaned-up version of it)
2. be invariant to `@jit`

The latter is much more important, so whenever the two are in tension we prefer the latter.

Issue #732 showed our code had a special behavior that essentially handled a case of the former desideratum but also broke the latter. #732 also showed us (again) that our tests really should cover Python scalars.

In summary, in this commit:
* revise jax.numpy dtype promotion behavior to be invariant to `@jit`, but not to follow NumPy behavior with Python scalars involved
* add Python scalar types to lax_numpy tests
* simplify and update kron implementation to fix dtype issues
* fix #732