### PR TITLE
make jax.numpy.array(3) give 0D array, not scalar

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -514,7 +514,7 @@ def reshape(operand, new_sizes, dimensions=None):
   """
   same_shape = onp.shape(operand) == tuple(new_sizes)
   same_dims = dimensions is None or tuple(dimensions) == tuple(range(onp.ndim(operand)))
-  if same_shape and same_dims:
+  if onp.shape(operand) and same_shape and same_dims:
     return operand
   else:
     return reshape_p.bind(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1051,7 +1051,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_arg{}".format(i), "arg": arg}
       for i, arg in enumerate([
-          [1, 2, 3], [1., 2., 3.],
+          3., [1, 2, 3], [1., 2., 3.],
           [[1, 2], [3, 4], [5, 6]], [[1, 2.], [3, 4], [5, 6]],
           [[3, onp.array(2), 1], onp.arange(3.)],
       ])))
@@ -1059,6 +1059,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [arg]
     self._CheckAgainstNumpy(onp.array, lnp.array, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp.array, args_maker, check_dtypes=True)
+
+  def testIssue121(self):
+    assert not onp.isscalar(lnp.array(3))
 
   def testArrayMethod(self):
     class arraylike(object):


### PR DESCRIPTION
The mechanism is to use `lax.reshape` (which was already called in the definition of `np.array`) and avoid the optimization inside `lax.reshape` that skipped actually calling the primitive when the input and output shapes were equal (which in a sense misfired on scalars because scalars and 0D arrays have the same shape).

fixes #121