### PR TITLE
Adding value_and_jac* functions

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -350,6 +350,20 @@ class APITest(jtu.JaxTestCase):
     assert onp.allclose(jacfwd(f)(x), jacrev(f)(x))
 
   @jtu.skip_on_devices("tpu")
+  def test_value_and_jacobian(self):
+    R = onp.random.RandomState(0).randn
+    A = R(4, 3)
+    x = R(3)
+
+    f = lambda x: np.dot(A, x)
+    y, jac = api.value_and_jacfwd(f)(x)
+    assert np.allclose(jac, A)
+    assert np.allclose(y, f(x))
+    y, jac = api.value_and_jacrev(f)(x)
+    assert np.allclose(jac, A)
+    assert np.allclose(y, f(x))
+
+  @jtu.skip_on_devices("tpu")
   def test_hessian(self):
     R = onp.random.RandomState(0).randn
     A = R(4, 4)


### PR DESCRIPTION
At the moment while the Jacobian functions returned by both `jacfwd` and `jacrev` calculate the value of the function evaluated at the passed arguments the Jacobian is being computed for, there is no way to access this value. Often the value of the function will be needed in conjunction with the Jacobian - for example in a when applying Newton's method to find a root of a vector-valued function we require both the Jacobian and value of the function on each iteration.

This pull-request adds an optional `return_value` argument to both `jacfwd` and `jacrev` which if True makes the returned function return a tuple `(jacobian, value)` where `jacobian` is the Jacobian evaluated at the passed arguments and `value` is the value of the function evaluated at the passed arguments. If `return_value` is False (the default), `jacfwd` and `jacrev` retain their current behaviour - i.e. they return a function which returns only the Jacobian.

There already exists a `value_and_grad` function which implements an analogous operator for the specific case of scalar-valued functions. It would be more consistent with this existing function to define `value_and_jacrev` and `value_and_jacfwd` functions rather than using an additional argument, however this seemed like it could end up producing a lot of code and documentation duplication. The design proposed here is also more in keeping with the `has_aux` optional argument to `grad` and `value_and_grad` which alter the return signature of the returned function.

The same idea could also be applied to `hessian` function to optionally return both the Jacobian and value of the function being differentiated in addition to the Hessian itself. This would be useful for example when using Newton's method in an optimisation setting, where the objective function would be scalar valued and we would need both the Hessian and Jacobian (gradient) for the Newton iteration, and the value objective function to monitor convergence. The current pull-request implements part of the necessary functionality to do this as `hessian` internally calls `jacfwd` on the output of a `jacrev` call, with respectively the Jacobian and value being computed as intermediate values during these calls. It seems the best way to plumb everything together however would be to add a similar `has_aux` optional argument to `jacfwd` to allow it to be applied to a function returned by `jacrev` which returns both the Jacobian and value of a function. Adding `has_aux` to `jacfwd` and `jacrev` was mentioned as a todo in PR #499 however it looks like that PR was closed without merging and the related issue #497 remains open, so I'm not sure if there is some issue with adding `has_aux` for forward-mode?