### PR TITLE
fix travis by running `pytest -n 1` instead of `-n 2`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - conda config --add channels conda-forge
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip six protobuf>=3.6.0 absl-py opt_einsum numpy scipy pytest-xdist
-  - pip install jaxlib
+  - pip install jaxlib==0.1.15
   - pip install -v .
 script:
   - pytest -n 2 tests examples -W ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - conda config --add channels conda-forge
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pip six protobuf>=3.6.0 absl-py opt_einsum numpy scipy pytest-xdist
-  - pip install jaxlib==0.1.15
+  - pip install jaxlib
   - pip install -v .
 script:
-  - pytest -n 2 tests examples -W ignore
+  - pytest -n 1 tests examples -W ignore


### PR DESCRIPTION
The recently-released jaxlib 0.1.16 seems to crash Travis and other low-resource machines on process exit (yet we weren't able to reproduce locally except on a very low-resource cloud instance). We're still investigating, but as a temporary fix to make the build go green we can just run with one test process.