### PR TITLE
Instantiate symbolic zeros in the scatter-add transpose rule.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2804,12 +2804,14 @@ def _scatter_add_transpose_rule(t, operand, scatter_indices, updates,
                                 update_jaxpr, update_consts, dimension_numbers,
                                 updates_shape):
   assert scatter_indices is not None
+  if t is ad_util.zero:
+    return [ad_util.zero, None, ad_util.zero]
+
   operand_t = update_t = None
   if operand is None:
     operand_t = t
 
   if updates is None:
-    t = ad.instantiate_zeros(operand, t)
     gather_dnums = GatherDimensionNumbers(
       offset_dims=dimension_numbers.update_window_dims,
       collapsed_slice_dims=dimension_numbers.inserted_window_dims,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2809,6 +2809,7 @@ def _scatter_add_transpose_rule(t, operand, scatter_indices, updates,
     operand_t = t
 
   if updates is None:
+    t = ad.instantiate_zeros(operand, t)
     gather_dnums = GatherDimensionNumbers(
       offset_dims=dimension_numbers.update_window_dims,
       collapsed_slice_dims=dimension_numbers.inserted_window_dims,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -30,6 +30,7 @@ import six
 
 import numpy as onp
 
+import jax.ops
 from jax import api
 from jax import lax
 from jax import numpy as lnp
@@ -1551,6 +1552,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     expected = onp.array([3.71669453e-165, 4.72999108e-168, 6.01954653e-171,
                           7.66067839e-174], onp.float64)
     self.assertAllClose(f(x), expected, check_dtypes=False)
+
+  def testIssue776(self):
+    """Tests that the scatter-add transpose rule instantiates symbolic zeros."""
+    def f(u):
+      y = jax.ops.index_add(onp.ones(10,), [2, 4, 5], u)
+      # The transpose rule for lax.tie_in returns a symbolic zero for its first
+      # argument.
+      return lax.tie_in(y, 7.)
+
+    self.assertAllClose(onp.zeros(3,), api.grad(f)(onp.ones(3,)),
+                        check_dtypes=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #776.