### PR TITLE
Improve behavior of a number of math functions for extreme inputs.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -274,6 +274,7 @@ tanh = _one_to_one_unop(onp.tanh, lax.tanh, True)
 arcsinh = _one_to_one_unop(onp.arcsinh, lax.asinh, True)
 arccosh = _one_to_one_unop(onp.arccosh, lax.acosh, True)
 arctanh = _one_to_one_unop(onp.arctanh, lax.atanh, True)
+sqrt = _one_to_one_unop(onp.sqrt, lax.sqrt, True)
 
 
 add = _one_to_one_binop(onp.add, lax.add)
@@ -458,12 +459,6 @@ fmod = _wraps(onp.fmod)(lambda x, y: lax.rem(x, y))
 def cbrt(x):
   x, = _promote_to_result_dtype(onp.cbrt, x)
   return lax.sign(x) * power(lax.abs(x), _constant_like(x, 1. / 3.))
-
-
-@_wraps(onp.sqrt)
-def sqrt(x):
-  x, = _promote_to_result_dtype(onp.sqrt, x)
-  return power(x, _constant_like(x, 0.5))
 
 
 @_wraps(onp.square)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1580,7 +1580,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
               onp.finfo(dtype).max, onp.sqrt(onp.finfo(dtype).max),
               onp.sqrt(onp.finfo(dtype).max) * 2.):
       if onp.isnan(x) and op in ("cosh", "expm1", "exp"):
-        # TODO(b/133842876, b/)133842870: these return wrong outputs on CPU for
+        # TODO(b/133842876, b/133842870): these return wrong outputs on CPU for
         # NaN inputs.
         continue
       x = dtype(x)


### PR DESCRIPTION
Call XLA's sqrt instead of defining sqrt to be x**0.5. The two have different behaviors for infinite inputs.

Incorporate improvements to acos, sinh, cosh, asinh, and acosh that have previously been made to the versions in the XLA C++ client libraries.