### PR TITLE
Fixes from pytype

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -614,7 +614,5 @@ def jvp_jaxpr(jaxpr, nonzeros, instantiate):
 
 
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
-primitive_transposes[pe.compiled_call_p] = partial(call_transpose, pe.compiled_call_p)
-
 
 tree_to_jaxtuples = partial(process_pytree, pack)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -293,7 +293,7 @@ class JVPTrace(Trace):
         xt = TangentTuple((zero,) * len(yt))
       elif yt is zero:
         yt = TangentTuple((zero,) * len(xt))
-      return TangentTuple(map(self.join), xt, yt)
+      return TangentTuple(map(self.join, xt, yt))
     elif xt is zero and yt is zero:
       return xt, yt
     else:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -517,21 +517,6 @@ def eqn_parents(eqn):
     return list(it.chain(invars, *subjaxpr_tracers))
 
 
-def compiled_call_impl(fun, *args):
-  with new_master(JaxprTrace, True) as master:
-    pvals = map(abstractify, args)
-    jaxpr, (pval, consts, env) = trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
-    jaxpr_ans = eval_jaxpr_raw(jaxpr, consts, env, *args)
-    ans = merge_pvals(jaxpr_ans, pval)
-    del master, pvals, pval, consts, env, jaxpr_ans, jaxpr
-    return ans
-
-compiled_call_p = Primitive('compiled_call')
-compiled_call = partial(core.call_bind, compiled_call_p)
-compiled_call_p.def_custom_bind(compiled_call)
-compiled_call_p.def_impl(compiled_call_impl)
-
-
 def unzip_tracer_tuple(pvals):
   pvs, consts = unzip2(pvals)
   return PartialVal((JaxprTracerTuple(pvs), pack(consts)))


### PR DESCRIPTION
Ran [pytype](https://github.com/google/pytype) over some files in the JAX core and found a few bugs. One of them was in code that @mattjj says we can drop completely, while another was in a rare AD case that we're not immediately sure how to come up with a test for.