### PR TITLE
add jax.eval_shape, fixes #798

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -19,6 +19,6 @@ Module contents
 ---------------
 
 .. automodule:: jax
-    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr
+    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr, eval_shape
     :undoc-members:
     :show-inheritance:

--- a/jax/api.py
+++ b/jax/api.py
@@ -1083,21 +1083,26 @@ def eval_shape(fun, *args, **kwargs):
 
   Args:
     *args: a positional argument tuple of arrays, scalars, or (nested) standard
-      Python containers (pytrees) of those types. Since only the ``shape`` and
-      ``dtype`` attributes are accessed, only values that duck-type arrays are
-      required, rather than real ndarrays.
+      Python containers (tuples, lists, dicts, namedtuples, i.e. pytrees) of
+      those types. Since only the ``shape`` and ``dtype`` attributes are
+      accessed, only values that duck-type arrays are required, rather than real
+      ndarrays. The duck-typed objects cannot be namedtuples because those are
+      treated as standard Python containers. See the example below.
     **kwargs: a keyword argument dict of arrays, scalars, or (nested) standard
       Python containers (pytrees) of those types. As in ``args``, array values
       need only be duck-typed to have ``shape`` and ``dtype`` attributes.
 
   For example:
 
-  >>> f = lambda A, b, x: np.tanh(np.dot(A, x) + b)
-  >>> MyArgArray = collections.namedtuple("MyArgArray", ["shape", "dtype"])
+  >>> f = lambda A, x: np.tanh(np.dot(A, x))
+  >>> class MyArgArray(object):
+  ...   def __init__(self, shape, dtype):
+  ...     self.shape = shape
+  ...     self.dtype = dtype
+  ...
   >>> A = MyArgArray((2000, 3000), np.float32)
-  >>> b = MyArgArray((2000,), np.float32)
   >>> x = MyArgArray((3000, 1000), np.float32)
-  >>> out_shape = jax.eval_shape(f, A, b, x)  # no FLOPs performed
+  >>> out_shape = jax.eval_shape(f, A, x)  # no FLOPs performed
   >>> print(out_shape)
   (2000, 1000)
   """

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -635,12 +635,12 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(out_shape, (2,))
 
   def test_eval_shape_output_dict(self):
-    def fun4(x, y):
+    def fun(x, y):
       return {'hi': x[0] + x[1] + y}
 
     x = (np.ones(2), np.ones(2))
     y = 3.
-    out_shape = api.eval_shape(fun4, x, y)
+    out_shape = api.eval_shape(fun, x, y)
 
     self.assertEqual(out_shape, {'hi': (2,)})
 
@@ -652,6 +652,22 @@ class APITest(jtu.JaxTestCase):
     y = np.ones((4, 4))
 
     self.assertRaises(TypeError, lambda: api.eval_shape(fun, x, y))
+
+  def test_eval_shape_duck_typing(self):
+    def fun(A, b, x):
+      return np.dot(A, x) + b
+
+    class MyArgArray(object):
+      def __init__(self, shape, dtype):
+        self.shape = shape
+        self.dtype = dtype
+
+    A = MyArgArray((3, 4), np.float32)
+    b = MyArgArray((5,), np.float32)
+    x = MyArgArray((4, 5), np.float32)
+    out_shape = api.eval_shape(fun, A, b, x)
+
+    self.assertEqual(out_shape, (3, 5))
 
 
 if __name__ == '__main__':

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -593,5 +593,66 @@ class APITest(jtu.JaxTestCase):
     f_jit = api.jit(f)
     self.assertAllClose(f(pt), f_jit(pt), check_dtypes=False)
 
+  def test_eval_shape(self):
+    def fun(x, y):
+      return np.tanh(np.dot(x, y) + 3.)
+
+    x = np.ones((2, 3))
+    y = np.ones((3, 4))
+    out_shape = api.eval_shape(fun, x, y)
+
+    self.assertEqual(out_shape, (2, 4))
+
+  def test_eval_shape_constants(self):
+    def fun():
+      x = np.ones((2, 3))
+      y = np.ones((3, 4))
+      return np.tanh(np.dot(x, y) + 3.)
+
+    out_shape = api.eval_shape(fun)
+
+    self.assertEqual(out_shape, (2, 4))
+
+  def test_eval_shape_tuple_unpacking(self):
+    def fun(x, y):
+      a, b = x
+      return a + b + y
+
+    x = (np.ones(2), np.ones(2))
+    y = 3.
+    out_shape = api.eval_shape(fun, x, y)
+
+    self.assertEqual(out_shape, (2,))
+
+  def test_eval_shape_tuple_itemgetting(self):
+    def fun(x, y):
+      return x[0] + x[1] + y
+
+    x = (np.ones(2), np.ones(2))
+    y = 3.
+    out_shape = api.eval_shape(fun, x, y)
+
+    self.assertEqual(out_shape, (2,))
+
+  def test_eval_shape_output_dict(self):
+    def fun4(x, y):
+      return {'hi': x[0] + x[1] + y}
+
+    x = (np.ones(2), np.ones(2))
+    y = 3.
+    out_shape = api.eval_shape(fun4, x, y)
+
+    self.assertEqual(out_shape, {'hi': (2,)})
+
+  def test_eval_shape_shape_error(self):
+    def fun(x, y):
+      return np.tanh(np.dot(x, y) + 3.)
+
+    x = np.ones((3, 3))
+    y = np.ones((4, 4))
+
+    self.assertRaises(TypeError, lambda: api.eval_shape(fun, x, y))
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Add an `eval_shape` function to api.py, fixes #798.