### PR TITLE
add vmap-of-pmap

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -119,11 +119,11 @@ class JaxprTrace(Trace):
                    False, False, params)
     return JaxprTracer(self, PartialVal((out_pv, out_pv_const)), eqn)
 
-  def process_map(self, call_primitive, f, tracers, params):
+  def process_map(self, map_primitive, f, tracers, params):
     in_pvs, in_consts = unzip2([t.pval for t in tracers])
     reduced_pvs = map(remove_axis_from_pv, in_pvs)
     fun, aux = partial_eval(f, self, reduced_pvs)
-    out_const, consts = call_primitive.bind(fun, *in_consts, **params)
+    out_const, consts = map_primitive.bind(fun, *in_consts, **params)
     out_pv_reduced, jaxpr, env = aux()
     out_pv = add_axis_to_pv(params['axis_size'], out_pv_reduced)
     const_tracers = map(self.new_instantiated_const, consts)
@@ -133,7 +133,7 @@ class JaxprTrace(Trace):
     jaxpr_converted.invars = list(it.chain(jaxpr.constvars, jaxpr.invars))
     invars = tuple(it.chain(const_tracers, tracers))
     bound_subjaxpr = (jaxpr_converted, (), env)
-    eqn = JaxprEqn(invars, None, call_primitive, (bound_subjaxpr,),
+    eqn = JaxprEqn(invars, None, map_primitive, (bound_subjaxpr,),
                    False, False, params)
     return JaxprTracer(self, PartialVal((out_pv, out_const)), eqn)
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -459,6 +459,7 @@ def tuple_element_handler(axis_size, aval):
 
 core.pytype_aval_mappings[ShardedDeviceTuple] = core.pytype_aval_mappings[core.JaxTuple]
 xla.pytype_aval_mappings[ShardedDeviceTuple] = op.attrgetter('aval')
+batching.pytype_aval_mappings[ShardedDeviceTuple] = op.attrgetter('aval')
 xla.canonicalize_dtype_handlers[ShardedDeviceTuple] = \
     xla.canonicalize_dtype_handlers[xla.DeviceTuple]
 
@@ -524,6 +525,8 @@ class ShardedDeviceArray(xla.DeviceArray):
 core.pytype_aval_mappings[ShardedDeviceArray] = ConcreteArray
 xla.pytype_aval_mappings[ShardedDeviceArray] = \
     xla.pytype_aval_mappings[xla.DeviceArray]
+batching.pytype_aval_mappings[ShardedDeviceArray] = \
+    batching.pytype_aval_mappings[xla.DeviceArray]
 xla.canonicalize_dtype_handlers[ShardedDeviceArray] = \
     xla.canonicalize_dtype_handlers[xla.DeviceArray]
 

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -483,6 +483,42 @@ class PmapTest(jtu.JaxTestCase):
     expected = 1 + onp.arange(device_count)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testVmapOfPmap(self):
+    device_count = xla_bridge.device_count()
+    f0 = lambda x: x
+    f1 = pmap(f0, axis_name='i')
+    ax = onp.random.randn(2, device_count, 50, 60)
+    bx = vmap(f1)(ax)
+    self.assertAllClose(ax, bx, check_dtypes=False)
+
+  def testVmapOfPmapNonLeadingAxis(self):
+    device_count = xla_bridge.device_count()
+    f0 = lambda x: x
+    f1 = pmap(f0, axis_name='i')
+    ax = onp.random.randn(device_count, 2, 50, 60)
+    bx = vmap(f1, in_axes=2, out_axes=2)(ax)
+    self.assertAllClose(ax, bx, check_dtypes=False)
+
+  def testVmapOfPmapTuple(self):
+    device_count = xla_bridge.device_count()
+    f0 = lambda *x: x
+    f1 = pmap(f0, axis_name='i')
+
+    ax = onp.random.randn(device_count, 2, 50, 60)
+    ay = onp.random.randn(device_count, 30, 2)
+    az1 = onp.random.randn(device_count, 20)
+    az2 = onp.random.randn(2, device_count, 20)
+
+    bx, by, bz = vmap(f1, in_axes=(1, 2, (None, 0)), out_axes=(1, 2, 0))(ax, ay, (az1, az2))
+
+    self.assertAllClose(ax, bx, check_dtypes=False)
+    self.assertAllClose(ay, by, check_dtypes=False)
+
+    bz1, bz2 = bz
+    expected_bz1 = onp.broadcast_to(az1, (2,) + az1.shape)
+    self.assertAllClose(expected_bz1, bz1, check_dtypes=False)
+    self.assertAllClose(bz2, bz2, check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Because `pmap` (with the underlying primitive `xla_pmap`) works like `jit` (with the underlying primitive `xla_call`), i.e. both work roughly like a call, transforms need to handle it like they handle call, with the slight difference that an axis is being mapped over.

Some transforms, like differentiation, don't need to distinguish between a map and a call, and just easily transform the function being called/mapped. But the batching transform needs to distinguish the two because of the axis bookkeeping: we need to vmap the function being mapped while taking into account that the pmap itself will eliminate the leading axis.

This adds a `process_map` to the vmap transformation to handle the needed axis bookkeeping.

(Also some minor cleanup of batching.py utility functions.)