### PR TITLE
make custom_transforms handle pytrees, add api.defvjp

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -19,6 +19,6 @@ Module contents
 ---------------
 
 .. automodule:: jax
-    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr, eval_shape, custom_transforms
+    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr, eval_shape, custom_transforms, defjvp, defjvp2, defjvp_all, defvjp, defvjp2, defvjp_all, custom_gradient
     :undoc-members:
     :show-inheritance:

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -19,6 +19,6 @@ Module contents
 ---------------
 
 .. automodule:: jax
-    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr, eval_shape
+    :members: jit, disable_jit, grad, value_and_grad, vmap, pmap, jacfwd, jacrev, hessian, jvp, linearize, vjp, make_jaxpr, eval_shape, custom_transforms
     :undoc-members:
     :show-inheritance:

--- a/jax/api.py
+++ b/jax/api.py
@@ -1509,8 +1509,8 @@ def custom_gradient(fun):
   Returns:
     A Python callable with signature ``a -> b``, i.e. that returns the output
     value specified by the first element of ``fun``'s output pair. A side effect
-    is that under-the-hood ``jax.defvjp_all`` was called to set up the returned
-    Python callable to have the custom VJP rule specified by the second element
+    is that under-the-hood ``jax.defvjp_all`` is called to set up the returned
+    Python callable with the custom VJP rule specified by the second element
     of ``fun``'s output pair.
 
   For example:

--- a/jax/api.py
+++ b/jax/api.py
@@ -1326,6 +1326,14 @@ def custom_gradient(fun):
   If the function to be differentiated has type signature ``a -> b``, then the
   Python callable ``fun`` should have signature ``a -> (b, CT b -> CT a)`` where
   we use ``CT x`` to denote a cotangent type for ``x``. See the example below.
+  That is, ``fun`` should return a pair where the first element represents the
+  value of the function to be differentiated and the second element is a
+  function that represents the custom VJP rule.
+
+  The custom VJP function returned as the second element of the output of ``fun``
+  can close over intermediate values computed when evaluating the function to be
+  differentiated. That is, use lexical closure to share work between the forward
+  pass and the backward pass of reverse-mode automatic differentiation.
 
   Args:
     fun: a Python callable specifying both the function to be differentiated and

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -211,9 +211,10 @@ def partial_eval_wrapper(avals, *consts):
 
 
 def abstract_eval_fun(fun, *avals, **params):
-  pvs_in = [PartialVal((a, unit)) for a in avals]
-  _, pvout, _ = trace_to_jaxpr(lu.wrap_init(fun, params), pvs_in, instantiate=True)
-  aval_out, _ = pvout
+  pvals_in = [PartialVal((a, unit)) for a in avals]
+  _, pval_out, _ = trace_to_jaxpr(lu.wrap_init(fun, params), pvals_in,
+                                  instantiate=True)
+  aval_out, _ = pval_out
   assert isinstance(aval_out, AbstractValue)  # instantiate=True
   return aval_out
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -20,8 +20,7 @@ import numpy as onp
 import scipy.special as osp_special
 
 from .. import lax
-from ..api import custom_transforms
-from ..interpreters import ad, batching
+from ..api import custom_transforms, defjvp2
 from ..numpy import lax_numpy as np
 from ..numpy.lax_numpy import (_wraps, asarray, _reduction_dims, _constant_like,
                                _promote_args_like)
@@ -29,32 +28,32 @@ from ..numpy.lax_numpy import (_wraps, asarray, _reduction_dims, _constant_like,
 
 @_wraps(osp_special.gammaln)
 def gammaln(x):
-    x, = _promote_args_like(osp_special.gammaln, x)
-    return lax.lgamma(x)
+  x, = _promote_args_like(osp_special.gammaln, x)
+  return lax.lgamma(x)
 
 
 @_wraps(osp_special.digamma)
 def digamma(x):
-    x, = _promote_args_like(osp_special.digamma, x)
-    return lax.digamma(x)
+  x, = _promote_args_like(osp_special.digamma, x)
+  return lax.digamma(x)
 
 
 @_wraps(osp_special.erf)
 def erf(x):
-    x, = _promote_args_like(osp_special.erf, x)
-    return lax.erf(x)
+  x, = _promote_args_like(osp_special.erf, x)
+  return lax.erf(x)
 
 
 @_wraps(osp_special.erfc)
 def erfc(x):
-    x, = _promote_args_like(osp_special.erfc, x)
-    return lax.erfc(x)
+  x, = _promote_args_like(osp_special.erfc, x)
+  return lax.erfc(x)
 
 
 @_wraps(osp_special.erfinv)
 def erfinv(x):
-    x, = _promote_args_like(osp_special.erfinv, x)
-    return lax.erf_inv(x)
+  x, = _promote_args_like(osp_special.erfinv, x)
+  return lax.erf_inv(x)
 
 
 @_wraps(osp_special.logit)
@@ -62,8 +61,7 @@ def erfinv(x):
 def logit(x):
   x = asarray(x)
   return lax.log(lax.div(x, lax.sub(lax._const(x, 1), x)))
-ad.defjvp2(logit.primitive, lambda g, ans, x: g / (x * (1 - x)))
-batching.defvectorized(logit.primitive)
+defjvp2(logit, lambda g, ans, x: g / (x * (1 - x)))
 
 
 @_wraps(osp_special.expit)
@@ -72,8 +70,7 @@ def expit(x):
   x = asarray(x)
   one = lax._const(x, 1)
   return lax.div(one, lax.add(one, lax.exp(lax.neg(x))))
-ad.defjvp2(expit.primitive, lambda g, ans, x: g * ans * (lax._const(ans, 1) - ans))
-batching.defvectorized(expit.primitive)
+defjvp2(expit, lambda g, ans, x: g * ans * (lax._const(ans, 1) - ans))
 
 
 @_wraps(osp_special.logsumexp)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -612,6 +612,14 @@ class APITest(jtu.JaxTestCase):
     expected = {'hi': 2 * onp.arange(3), 'bye': 2 * onp.ones((3, 2))}
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def test_custom_gradient(self):
+    @api.custom_gradient
+    def f(x):
+      return x ** 2, lambda g: (g * x,)
+
+    self.assertEqual(f(3.), 9.)
+    self.assertEqual(api.grad(f)(3.), 3.)
+
   def test_devicetuple_iteration(self):
     tup = device_put(pack((1, 2)))
     self.assertIsInstance(tup, DeviceTuple)


### PR DESCRIPTION
Before this PR, using `custom_transforms` (from #419) with functions that took tuples/lists/dicts (i.e. pytrees) as arguments would silently fail. Moreover, defining custom rules that took as input or returned as output any pytree values wouldn't work. Finally, `custom_transforms` functions didn't automatically support vmap.

This PR fixes all that!

This PR also improves the API by adding `defjvp` and `defvjp` (cf. #636) functions (and their variants) to api.py, which can be called directly on a `custom_transforms` function rather than having to dig out a reference to the underlying primitive. There's also a `custom_gradient` convenience wrapper, which works like `tf.custom_gradient`.

This API will likely be the main mechanism by which users will define custom gradients.

TODO:
- [x] add docstrings

In the future we should add a tutorial explanation of how to do this in an .md file, like [in Autograd's tutorial](https://github.com/HIPS/autograd/blob/master/docs/tutorial.md#extend-autograd-by-defining-your-own-primitives), at which point we can finally close #116.

It would also be good to add more tests, especially for error messages.