### PR TITLE
Improvements to jax_to_hlo genrule.

### DIFF
--- a/jax/tools/BUILD
+++ b/jax/tools/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "jax_to_hlo",
+    srcs = ["jax_to_hlo.py"],
+    deps = [
+        "//third_party/py/jax",
+    ],
+)


### PR DESCRIPTION
- Specify an explicit name for the genrule, rather than using the name
   of src.  You might have one src that produces multiple HLO
   computations (e.g. with different input sizes).

 - Allow jax_to_hlo genrule to depend on multiple libraries, not just
   one.

 - Silence warning when running jax_to_hlo genrule about no GPU/TPU
   being available.

CC @mattjj @skyewm