### PR TITLE
improve efficiency of conv batching rules (i.e. vmap rules)

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -507,6 +507,7 @@ class JaxTestCase(parameterized.TestCase):
       for k in x.keys():
         self.assertAllClose(x[k], y[k], check_dtypes, atol=atol, rtol=rtol)
     elif is_sequence(x) and not hasattr(x, '__array__'):
+      import ipdb; ipdb.set_trace()
       self.assertTrue(is_sequence(y) and not hasattr(y, '__array__'))
       self.assertEqual(len(x), len(y))
       for x_elt, y_elt in zip(x, y):

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -507,7 +507,6 @@ class JaxTestCase(parameterized.TestCase):
       for k in x.keys():
         self.assertAllClose(x[k], y[k], check_dtypes, atol=atol, rtol=rtol)
     elif is_sequence(x) and not hasattr(x, '__array__'):
-      import ipdb; ipdb.set_trace()
       self.assertTrue(is_sequence(y) and not hasattr(y, '__array__'))
       self.assertEqual(len(x), len(y))
       for x_elt, y_elt in zip(x, y):

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -485,7 +485,6 @@ class BatchingTest(jtu.JaxTestCase):
                                          (5, 21, 5, 1)))
     self.assertAllClose(per_example, per_example_direct, check_dtypes=True)
 
-
   def testMaxPool(self):
     W = np.array(onp.random.randn(3, 3, 1, 5), dtype=onp.float32)
     X = np.array(onp.random.randn(10, 5, 5, 1), dtype=onp.float32)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1635,14 +1635,15 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_lhs_dilation={}_"
-       "rhs_dilation={}_dims={}"
+       "rhs_dilation={}_dims={}_feature_group_count={}"
        .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
                jtu.format_shape_dtype_string(rhs_shape, dtype),
-               strides, padding, lhs_dil, rhs_dil, ",".join(dim_nums)),
+               strides, padding, lhs_dil, rhs_dil, ",".join(dim_nums),
+               feature_group_count),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
        "rhs_dil": rhs_dil, "rng": rng, "dimension_numbers": dim_nums,
-       "perms": perms}
+       "perms": perms, "feature_group_count": feature_group_count}
       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
           ((b, i, 6, 7),  # lhs_shape
            (j, i, 1, 2),  # rhs_shape
@@ -1651,6 +1652,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
            [(1, 1), (2, 1)],  # lhs_dils
            [(1, 1), (2, 2)])  # rhs_dils
           for b, i, j in itertools.product([1, 2], repeat=3)]
+      for feature_group_count in [1]  # TODO(mattjj): feature_group_count=2
       for strides in all_strides
       for rhs_dil in rhs_dils
       for lhs_dil in lhs_dils
@@ -1665,14 +1667,23 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")
   def testConvGeneralDilatedGrad(self, lhs_shape, rhs_shape, dtype, strides,
                                  padding, lhs_dil, rhs_dil, dimension_numbers,
-                                 perms, rng):
+                                 perms, feature_group_count, rng):
     tol = 1e-1 if onp.finfo(dtype).bits == 32 else 1e-3
-    lhs_perm, rhs_perm = perms  # permute to compatible shapes
-    lhs = onp.transpose(rng(lhs_shape, dtype), lhs_perm)
-    rhs = onp.transpose(rng(rhs_shape, dtype), rhs_perm)
+
+    # permute shapes to match dim_spec, scale by feature_group_count
+    lhs_perm, rhs_perm = perms
+    lhs_shape = list(onp.take(lhs_shape, lhs_perm))
+    rhs_shape = list(onp.take(rhs_shape, rhs_perm))
+    dim_spec = lax.conv_dimension_numbers(lhs_shape, rhs_shape, dimension_numbers)
+    lhs_shape[dim_spec.lhs_spec[1]] *= feature_group_count
+    rhs_shape[dim_spec.rhs_spec[0]] *= feature_group_count
+
+    lhs = rng(lhs_shape, dtype)
+    rhs = rng(rhs_shape, dtype)
     conv = partial(lax.conv_general_dilated, window_strides=strides,
                    padding=padding, lhs_dilation=lhs_dil, rhs_dilation=rhs_dil,
-                   dimension_numbers=dimension_numbers)
+                   dimension_numbers=dimension_numbers,
+                   feature_group_count=feature_group_count)
     check_grads_bilinear(conv, (lhs, rhs), order=2, modes=["fwd", "rev"],
                          atol=tol, rtol=tol)
 
@@ -2164,15 +2175,16 @@ class LaxVmapTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_lhs_dilation={}_"
-       "rhs_dilation={}_dims={}_lhs_bdim={}_rhs_bdim={}"
+       "rhs_dilation={}_dims={}_feature_group_count={}_lhs_bdim={}_rhs_bdim={}"
        .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                strides, padding, lhs_dil, rhs_dil, ",".join(dim_nums),
-               lhs_bdim, rhs_bdim),
+               feature_group_count, lhs_bdim, rhs_bdim),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
        "rhs_dil": rhs_dil, "rng": rng, "dimension_numbers": dim_nums,
-       "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim}
+       "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim,
+       "feature_group_count": feature_group_count}
       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
           ((b, i, 6, 7),  # lhs_shape
            (j, i, 1, 2),  # rhs_shape
@@ -2181,6 +2193,7 @@ class LaxVmapTest(jtu.JaxTestCase):
            [(1, 1), (2, 1)],  # lhs_dils
            [(1, 1), (2, 2)])  # rhs_dils
           for b, i, j in itertools.product([1, 2], repeat=3)]
+      for feature_group_count in [1, 2]
       for strides in all_strides
       for rhs_dil in rhs_dils
       for lhs_dil in lhs_dils
@@ -2197,14 +2210,17 @@ class LaxVmapTest(jtu.JaxTestCase):
   ))
   def testConvGeneralDilatedBatching(
       self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dil, rhs_dil,
-      dimension_numbers, perms, lhs_bdim, rhs_bdim, rng):
+      dimension_numbers, perms, feature_group_count, lhs_bdim, rhs_bdim, rng):
     tol = 1e-1 if onp.finfo(dtype).bits == 32 else 1e-3
     bdim_size = 10
 
-    # permute shapes to match dimension_numbers
+    # permute shapes to match dim_spec, scale by feature_group_count
     lhs_perm, rhs_perm = perms
     lhs_shape = list(onp.take(lhs_shape, lhs_perm))
     rhs_shape = list(onp.take(rhs_shape, rhs_perm))
+    dim_spec = lax.conv_dimension_numbers(lhs_shape, rhs_shape, dimension_numbers)
+    lhs_shape[dim_spec.lhs_spec[1]] *= feature_group_count
+    rhs_shape[dim_spec.rhs_spec[0]] *= feature_group_count
 
     # add batch dimension
     if lhs_bdim is not None:
@@ -2220,10 +2236,11 @@ class LaxVmapTest(jtu.JaxTestCase):
 
     conv = partial(lax.conv_general_dilated, window_strides=strides,
                    padding=padding, lhs_dilation=lhs_dil, rhs_dilation=rhs_dil,
-                   dimension_numbers=dimension_numbers)
+                   dimension_numbers=dimension_numbers,
+                   feature_group_count=feature_group_count)
     ans = api.vmap(conv, (lhs_bdim, rhs_bdim))(lhs, rhs)
     expected = onp.stack([conv(lhs_slice(i), rhs_slice(i)) for i in range(bdim_size)])
-    self.assertAllClose(ans, expected, check_dtypes=True)
+    self.assertAllClose(ans, expected, True, tol, tol)
 
 
 if __name__ == '__main__':

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1656,12 +1656,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for lhs_dil in lhs_dils
       for dtype in [onp.float32]
       for padding in all_pads
-      for rng in [jtu.rand_default()]
       for dim_nums, perms in [
           (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
           (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
-          (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))
-      ]))
+          (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))]
+      for rng in [jtu.rand_default()]
+  ))
   @jtu.skip_on_devices("tpu")
   def testConvGeneralDilatedGrad(self, lhs_shape, rhs_shape, dtype, strides,
                                  padding, lhs_dil, rhs_dil, dimension_numbers,
@@ -2150,6 +2150,79 @@ class LaxAutodiffTest(jtu.JaxTestCase):
 
     ans = api.grad(api.grad(f))(x)
     expected = api.grad(api.grad(f2))(x, x)
+    self.assertAllClose(ans, expected, check_dtypes=True)
+
+
+def slicer(x, bdim):
+  if bdim is None:
+    return lambda _: x
+  else:
+    return lambda i: lax.index_in_dim(x, i, bdim, keepdims=False)
+
+class LaxVmapTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_lhs_dilation={}_"
+       "rhs_dilation={}_dims={}_lhs_bdim={}_rhs_bdim={}"
+       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
+               jtu.format_shape_dtype_string(rhs_shape, dtype),
+               strides, padding, lhs_dil, rhs_dil, ",".join(dim_nums),
+               lhs_bdim, rhs_bdim),
+       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
+       "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
+       "rhs_dil": rhs_dil, "rng": rng, "dimension_numbers": dim_nums,
+       "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim}
+      for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
+          ((b, i, 6, 7),  # lhs_shape
+           (j, i, 1, 2),  # rhs_shape
+           [(1, 1), (1, 2), (2, 1)],  # strides
+           [((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],  # pads
+           [(1, 1), (2, 1)],  # lhs_dils
+           [(1, 1), (2, 2)])  # rhs_dils
+          for b, i, j in itertools.product([1, 2], repeat=3)]
+      for strides in all_strides
+      for rhs_dil in rhs_dils
+      for lhs_dil in lhs_dils
+      for dtype in [onp.float32]
+      for padding in all_pads
+      for dim_nums, perms in [
+          (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
+          (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
+          (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))]
+      for lhs_bdim in itertools.chain([None], range(len(lhs_shape) + 1))
+      for rhs_bdim in itertools.chain([None], range(len(rhs_shape) + 1))
+      if (lhs_bdim, rhs_bdim) != (None, None)
+      for rng in [jtu.rand_default()]
+  ))
+  def testConvGeneralDilatedBatching(
+      self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dil, rhs_dil,
+      dimension_numbers, perms, lhs_bdim, rhs_bdim, rng):
+    tol = 1e-1 if onp.finfo(dtype).bits == 32 else 1e-3
+    bdim_size = 10
+
+    # permute shapes to match dimension_numbers
+    lhs_perm, rhs_perm = perms
+    lhs_shape = list(onp.take(lhs_shape, lhs_perm))
+    rhs_shape = list(onp.take(rhs_shape, rhs_perm))
+
+    # add batch dimension
+    if lhs_bdim is not None:
+      lhs_shape.insert(lhs_bdim, bdim_size)
+    if rhs_bdim is not None:
+      rhs_shape.insert(rhs_bdim, bdim_size)
+
+    # create arg values and sliced versions
+    lhs = rng(lhs_shape, dtype)
+    rhs = rng(rhs_shape, dtype)
+    lhs_slice = slicer(lhs, lhs_bdim)
+    rhs_slice = slicer(rhs, rhs_bdim)
+
+    conv = partial(lax.conv_general_dilated, window_strides=strides,
+                   padding=padding, lhs_dilation=lhs_dil, rhs_dilation=rhs_dil,
+                   dimension_numbers=dimension_numbers)
+    ans = api.vmap(conv, (lhs_bdim, rhs_bdim))(lhs, rhs)
+    expected = onp.stack([conv(lhs_slice(i), rhs_slice(i)) for i in range(bdim_size)])
     self.assertAllClose(ans, expected, check_dtypes=True)
 
 


### PR DESCRIPTION
Our vmap rules for `conv_general_dilated` involving a batch dimension on the `rhs` argument were inefficient because they generated a loop over the batch dimension with one `conv_general_dilated` call per iteration. @michaelisard pointed out that we can generate a single `conv_general_dilated` call if we use `rhs`'s output feature dimension, since it corresponds to a universally quantified index.

This PR also set up a systematic test for the `conv_general_dilated` vmap rule in lax_test.py, in a pattern that we should probably reuse to make systematic tests for all vmap rules.

This PR is in a sense incomplete because now `vmap` + `conv_general_dilated` will generate calls with `feature_group_count > 1`, but I didn't finish generalizing the `conv_general_dilated` transpose rules to handle `feature_group_count > 1`. I'm going to hold off on that because I think @jheek may have already done some or all of that work, and we will coordinate our PRs on Monday.

That is, I won't merge this until I sort out the transpose rule with @jheek's upcoming PR #859.

cc @jheek would you mind reviewing this on Monday?
cc @sschoenholz for FYI and optional review