### PR TITLE
add tuple simplification logic

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -260,6 +260,9 @@ class JaxprTracer(Tracer):
       return self
 
   def unpack(self):
+    if type(self.recipe) is JaxprEqn and self.recipe.primitive is core.pack_p:
+      return tuple(self.recipe.invars)
+
     pv, const = self.pval
     if isinstance(pv, (AbstractValue, JaxprTracerTuple)):
       n = len(pv)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -774,6 +774,16 @@ class APITest(jtu.JaxTestCase):
 
     self.assertEqual(out_shape, (3, 5))
 
+  def test_detuplification(self):
+    def fun(x):
+      y = pack((x, x))
+      z = pack((y, x))
+      y1, _ = z
+      y2, _ = y1
+      return y2
+
+    assert len(api.make_jaxpr(fun)(1).eqns) == 0
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
An example, taken from real user code involving `scan`! Before:

```
{ lambda e g h d cn f cm co ;  ; a b c.
  let (i j) = id c
      (k l) = id i
      m = pack k *
      (n o p q r s t u v w x y z ba bb bc) = id j
      bd = pack * * * * * s t * * * x * * * bb *
      be = pack m bd
      (bf bg) = id be
      (bh bi bj bk bl bm bn bo bp bq br bs bt bu bv bw) = id bg
      bx = pack * * * bm * * bv *
      by = pack * bx
      bz = pack * by
      (ca cb) = id bz
      (cc cd) = id cb
      (ce cf cg ch ci cj ck cl) = id cd
      cp = pack f g h ch cm cn ck co
      cq = pack e cp
      cr = pack d cq
  in cr }
```

After:

```
{ lambda d ;  ; a b c.
  let
  in d }
```

Say goodbye to your tuples!