### PR TITLE
Use lax.full instead of broadcast in transpose rule for dynamic_slice.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2576,7 +2576,7 @@ def _dynamic_slice_jvp_rule(g, operand, start_indices, slice_sizes,
 def _dynamic_slice_transpose_rule(t, operand, start_indices, slice_sizes,
                                   operand_shape):
   assert operand is None
-  zeros = broadcast(_const(t, 0), operand_shape)
+  zeros = full(operand_shape, 0, dtype=t.dtype)
   return [dynamic_update_slice(zeros, t, start_indices), ad_util.zero]
 
 def _dynamic_slice_batching_rule(batched_args, batch_dims, slice_sizes,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2576,7 +2576,7 @@ def _dynamic_slice_jvp_rule(g, operand, start_indices, slice_sizes,
 def _dynamic_slice_transpose_rule(t, operand, start_indices, slice_sizes,
                                   operand_shape):
   assert operand is None
-  zeros = full(operand_shape, 0, dtype=t.dtype)
+  zeros = full(operand_shape, 0, dtype=_dtype(t))
   return [dynamic_update_slice(zeros, t, start_indices), ad_util.zero]
 
 def _dynamic_slice_batching_rule(batched_args, batch_dims, slice_sizes,


### PR DESCRIPTION
Helps with part of #824 (although there are more issues to fix).