### PR TITLE
de-duplicate constants staged into jaxprs

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -119,7 +119,10 @@ class Literal(object):
     return self.val == other.val if self.hashable else self.val is other.val
 
   def __repr__(self):
-    return 'Literal(val={}, hashable={})'.format(self.val, self.hashable)
+    if self.hashable:
+      return '{}'.format(self.val)
+    else:
+      return 'Literal(val={}, hashable={})'.format(self.val, self.hashable)
 
 class Primitive(object):
   def __init__(self, name):

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -454,6 +454,7 @@ def tracers_to_jaxpr(in_tracers, out_tracer):
   eqns = []
   env = {}
   consts = {}
+  const_to_var = defaultdict(newvar)
   destructuring_vars = {}
   for t in sorted_tracers:
     recipe = t.recipe
@@ -464,7 +465,8 @@ def tracers_to_jaxpr(in_tracers, out_tracer):
     elif isinstance(recipe, FreeVar):
       env[var(t)] = recipe.val
     elif isinstance(recipe, ConstVar):
-      consts[var(t)] = recipe.val
+      v = t_to_var[id(t)] = const_to_var[id(recipe.val)]
+      consts[v] = recipe.val
     elif isinstance(recipe, Literal):
       t_to_var[id(t)] = recipe
     elif isinstance(recipe, Destructuring):


### PR DESCRIPTION
I ran the example in #824 and this seems to fix the memory blowup! (Though it's still very slow to compile the unrolled loop.)

Fixes #824 