### PR TITLE
Add a `jit` annotation around np.where.

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -759,7 +759,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "dtype": dtype, "shape": shape, "op": op, "k": k,
        "rng": jtu.rand_default()}
       for dtype in default_dtypes
-      for shape in [shape for shape in all_shapes if len(shape) >= 1]
+      for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for op in ["tril", "triu"]
       for k in list(range(-3, 3))))
   def testTriLU(self, dtype, shape, op, k, rng):


### PR DESCRIPTION
Avoids materializing broadcast scalars inside where in op-by-op mode.

Since np.tril appears in the linear part of the Cholesky JVP rule, change np.tril/triu to avoid where in favor of calling lax.select() directly. Ban 1D arguments to np.tril/triu, which aren't a documented behavior of the numpy implementation.

Fixes #850 