### PR TITLE
Fix signature of __array__ method.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -575,7 +575,9 @@ class DeviceArray(DeviceValue):
     else:
       return format(self._value, format_spec)
 
-  __array__ = partialmethod(forward_to_value, onp.asarray)
+  def __array__(self, dtype=None, context=None):
+    return onp.asarray(self._value, dtype=dtype)
+
   __str__ = partialmethod(forward_to_value, str)
   __bool__ = __nonzero__ = partialmethod(forward_to_value, bool)
   __float__ = partialmethod(forward_to_value, float)


### PR DESCRIPTION
Without this fix the test suite spews many instances of this message:
numeric.py:538: DeprecationWarning: Non-string object detected for the array ordering. Please pass in 'C', 'F', 'A', or 'K' instead
    return array(a, dtype, copy=False, order=order)

because we are passing a context  object as the order argument to onp.asarray().