### PR TITLE
make DeviceArray.__hash__ raise an error

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -937,7 +937,7 @@ def _wrap_hashably(arg):
   try:
     hash(arg)
   except TypeError:
-    return WrapHashably(arg)
+    return WrapHashably(arg)  # e.g. ndarrays, DeviceArrays
   else:
     return Hashable(arg)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -593,11 +593,7 @@ class DeviceArray(DeviceValue):
   def __eq__(self, other): return self._value == other
 
   def __hash__(self):
-    # TODO(mattjj): this is not semantically correct because it is possible
-    # __eq__ is true for values with unequal __hash__ values. However, the
-    # main use case at the moment is memoization for which false negatives are
-    # fine.
-    return id(self)
+    raise TypeError("JAX DeviceArray, like numpy.ndarray, is not hashable.")
 
 scalar_types.add(DeviceArray)
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1041,7 +1041,7 @@ def _conv_transpose_padding(k, s, padding):
     else:
       pad_a = int(onp.ceil(pad_len / 2))
   elif padding == 'VALID':
-    pad_len = k + s - 2 + max(k - s, 0)
+    pad_len = k + s - 2 + _max(k - s, 0)
     pad_a = k - 1
   else:
     raise ValueError('Padding mode must be `SAME` or `VALID`.')

--- a/jax/util.py
+++ b/jax/util.py
@@ -213,7 +213,6 @@ class Hashable(object):
     return self.val == other.val
 
 
-
 def get_module_functions(module):
   """Finds functions in module.
   Args:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1610,6 +1610,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       actual = lnp_op(x)
       self.assertAllClose(expected, actual, check_dtypes=True)
 
+  def testIssue883(self):
+    # from https://github.com/google/jax/issues/883
+
+    @partial(api.jit, static_argnums=(1,))
+    def f(x, v):
+      return x
+
+    x = lnp.ones((10, 10))
+    v = lnp.array([1, 2, 3])
+    first_call = f(x, v)
+    second_call = f(x, v)  # doesn't crash
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Fixes #883 by adjusting the caching logic we use not to rely on DeviceArray being hashable, also closing a long-standing TODO.

Also fixed a minor bug in lax.py which caused scalar DeviceArrays to appear in the padding params of  some convolutions (from using `max` instead of `_max` in lax.py).