### PR TITLE
Remove xla.device_put_many.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -74,7 +74,7 @@ def shard_arg(device_ordinals, axis_size, arg):
   else:
     shards = [(_slice(arg, assignments[i]), device_ordinals[i])
               for i in range(len(assignments))]
-    return xla.device_put_many(shards)
+    return [xla.device_put(v, device) for v, device in shards]
 
 def _slice(x, i):
   """Return the ith slice of a JaxType (tuple or array)."""

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -142,53 +142,6 @@ def device_put(x, device_num=0):
   else:
     raise TypeError(t)
 
-def device_put_many(xs_and_devices):
-  """Place multiple Python values on multiple devices in parallel.
-
-  This is a wrapper around jax.lib.xla_bridge.device_put_many to handle
-  additional Python types. See the docstring for jax.interpreters.xla.device_put
-  for more information.
-
-  Args:
-    xs_and_devices: a sequence of (pyval, device_num) pairs in which  device_num
-      is an int representing the target physical device number and pyval is a
-      tuple-like tree with arraylike leaves (see the device_put docstring).
-
-  Returns:
-    A sequence of buffers representing the inputs placed on the corresponding
-    device numbers.
-  """
-  transfer_indices = []
-  transfers = []
-  outputs = [None] * len(xs_and_devices)
-  for i, (x, device_num) in enumerate(xs_and_devices):
-    x = canonicalize_pyval_dtype(x)
-    t = type(x)
-    if t is DeviceArray or t is DeviceTuple:
-      if x.device_buffer.device() == device_num:
-        outputs[i] = x.device_buffer
-      else:
-        transfer_indices.append(i)
-        # TODO(phawkins): perform a direct device-to-device copy rather than
-        # bouncing via the host.
-        transfers.append((x.device_buffer.to_py(), device_num))
-    elif isinstance(x, DeviceConstant):
-      outputs[i] = instantiate_device_constant(x, device_num=device_num)
-    elif hasattr(t, '__array__'):
-      transfer_indices.append(i)
-      transfers.append((x, device_num))  # handle arraylikes
-    elif t is JaxTuple:
-      # TODO(mattjj,phawkins): improve this to avoid device_put call
-      element_bufs = tuple(map(partial(device_put, device_num=device_num), x))
-      outputs[i] = xb.make_tuple(element_bufs, device_num)
-    else:
-      raise TypeError(t)
-
-  transfer_results = xb.device_put_many(transfers)
-  for i, result in zip(transfer_indices, transfer_results):
-    outputs[i] = result
-  return outputs
-
 
 # When we execute an XLA computation, we get a raw device buffer back and need
 # to package it into a suitable Python object to return to the user. To avoid

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -163,9 +163,6 @@ def device_put(pyval, device_num=0):
   return xla_client.LocalBuffer.from_pyval(pyval, device_num,
                                            backend=get_backend())
 
-def device_put_many(pyvals_and_devices):
-  return [device_put(pyval, device) for (pyval, device) in pyvals_and_devices]
-
 def make_tuple(bufs, device_num=0):
   return xla_client.Buffer.make_tuple(bufs, device=device_num,
                                       backend=get_backend())


### PR DESCRIPTION
We never actually hooked it up to the Jaxlib implementation, and since we now have asynchronous transfers, it's not clear we even need to. Remove it until we come up with a use case.