### PR TITLE
map stop_gradient over data structure. otherwise it is silently a no-op

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -45,7 +45,7 @@ from ..interpreters import ad
 from ..interpreters import batching
 from ..interpreters import parallel
 from ..util import curry, memoize, safe_zip, unzip2, prod
-from ..tree_util import build_tree, tree_unflatten
+from ..tree_util import build_tree, tree_unflatten, tree_map
 from ..lib import xla_bridge
 from ..lib.xla_bridge import xla_client
 
@@ -971,7 +971,7 @@ def stop_gradient(x):
    >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
    array(0., dtype=float32)
    """
-  return stop_gradient_p.bind(x)
+  return tree_map(stop_gradient_p.bind, x)
 
 
 def _safe_mul(x, y): return safe_mul_p.bind(x, y)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2174,6 +2174,10 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     expected = api.grad(api.grad(f2))(x, x)
     self.assertAllClose(ans, expected, check_dtypes=True)
 
+    ans = api.grad(lambda x: lax.stop_gradient({'foo':x})['foo'])(3.)
+    expected = onp.array(0.0)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
 
 def slicer(x, bdim):
   if bdim is None:


### PR DESCRIPTION
Previous behavior:
```
jax.grad(lambda x: jax.lax.stop_gradient({'foo':x})['foo'])(3.) # returns array(1.0)
```
After the change, it returns `array(0.0)`.

It's useful to apply a network or sub-network but stop gradient on the parameters. 