### PR TITLE
Enable direct device-to-device copies on GPU and TPU.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,10 +23,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "665d9d0653a8a18b5aec5c27cac77af18933e4550a342ef9dd6a33b60802921b",
-    strip_prefix = "tensorflow-f4e64ca17ce392da2d3fa3959d3d8bdd27de2b39",
+    sha256 = "e76559e626477e662e1068df9788617fb0dd38ba65a1f196ff9cb65eb0b64cd2",
+    strip_prefix = "tensorflow-847a10f32d1948d6754632d29d67d5163cd2e1d7",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/f4e64ca17ce392da2d3fa3959d3d8bdd27de2b39.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/847a10f32d1948d6754632d29d67d5163cd2e1d7.tar.gz",
     ],
 )
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -129,9 +129,12 @@ def device_put(x, device_num=0):
     if x.device_buffer.device() == device_num:
       return x.device_buffer
     else:
-      # TODO(phawkins): perform a direct device-to-device copy rather than
-      # bouncing via the host.
-      return device_put(x.device_buffer.to_py(), device_num)
+      # TODO(phawkins): remove after the minimum Jaxlib version is raised to
+      # 0.1.22
+      if hasattr(x.device_buffer, 'copy_to_device'):
+        return DeviceArray(x.shape, x.device_buffer.copy_to_device(device_num))
+      else:
+        return device_put(x.device_buffer.to_py(), device_num)
   elif isinstance(x, DeviceConstant):
     return instantiate_device_constant(x, device_num=device_num)
   elif isinstance(x, (DeviceArray, onp.ndarray)):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1185,7 +1185,7 @@ def _pad(array, pad_width, mode, constant_values):
     return array
   elif mode in ("symmetric", "reflect", "wrap"):
     for i in xrange(nd):
-      if array.shape[i] == 0 :
+      if array.shape[i] == 0:
         if (pad_width[i, 0] > 0 or pad_width[i, 1] > 0):
           msg = "Cannot apply '{}' padding to empty axis"
           raise ValueError(msg.format(mode))


### PR DESCRIPTION
Update XLA to include device-to-device copies.