### PR TITLE
Force a copy to device in jax.numpy.array() if copy=True.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1352,7 +1352,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 
 @_wraps(onp.asarray)
 def asarray(a, dtype=None, order=None):
-  return array(a, dtype=dtype, order=order)
+  return array(a, dtype=dtype, copy=False, order=order)
 
 
 @_wraps(onp.zeros_like)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -28,7 +28,7 @@ import opt_einsum
 import six
 from six.moves import builtins, xrange
 
-from jax import jit
+from jax import jit, device_put
 from .. import core
 from ..abstract_arrays import UnshapedArray, ShapedArray, ConcreteArray
 from ..interpreters.xla import DeviceArray
@@ -1322,13 +1322,15 @@ def atleast_3d(*arys):
 
 @_wraps(onp.array)
 def array(object, dtype=None, copy=True, order="K", ndmin=0):
-  del copy  # Unused.
-  if ndmin != 0 or order != "K":
+  if ndmin != 0 or (order is not None and order != "K"):
     raise NotImplementedError("Only implemented for order='K', ndmin=0.")
 
   if isinstance(object, ndarray):
     if dtype and _dtype(object) != dtype:
       return lax.convert_element_type(object, dtype)
+    elif copy:
+      # If a copy was requested, we must copy.
+      return device_put(object)
     else:
       return object
   elif hasattr(object, '__array__'):
@@ -1347,7 +1349,10 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
       return out
   else:
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
-asarray = array
+
+@_wraps(onp.asarray)
+def asarray(a, dtype=None, order=None):
+  return array(a, dtype=dtype, order=order)
 
 
 @_wraps(onp.zeros_like)


### PR DESCRIPTION
The motivation is the following example where the array is mutated after being passed to jax.numpy.array:
```
>>> a = np.array([42])
>>> b = jnp.array(a)
>>> a[0] = 24
>>> b
array([24])
```

Also fix up asarray() to have the precise signature of onp.asarray.