### PR TITLE
Improve jax.numpy.arange to return a lazy iota even if an explicit dt…

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1449,20 +1449,15 @@ def identity(n, dtype=None):
 
 
 @_wraps(onp.arange)
-def arange(*args, **kwargs):
-  dtype = kwargs.get("dtype", None)
-  if not args:
-    raise TypeError("Required argument 'start' (pos 1) not found")  # same as numpy error
-
+def arange(start, stop=None, step=None, dtype=None):
   # If called like np.arange(N), we create a lazy lax._IotaConstant.
-  if len(args) == 1 and not kwargs:
-    stop, = args
-    dtype = dtype or _dtype(stop)
+  if stop is None and step is None:
+    dtype = dtype or _dtype(start)
     if onp.issubdtype(dtype, onp.integer):
-      return lax.iota(dtype, stop)  # avoids materializing
+      return lax.iota(dtype, start)  # avoids materializing
 
   # Fall back to instantiating an ndarray in host memory
-  return onp.arange(*args, **kwargs)
+  return onp.arange(start, stop=stop, step=step, dtype=dtype)
 
 linspace = onp.linspace
 logspace = onp.logspace

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1600,6 +1600,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertFalse(type(lnp.arange(77)) == type(onp.arange(77)))
     self.assertTrue(type(lnp.arange(77)) == type(lax.iota(onp.int32, 77)))
 
+    # test that lnp.arange(N, dtype=int32) doesn't instantiate an ndarray
+    self.assertFalse(type(lnp.arange(77, dtype=lnp.int32)) ==
+                    type(onp.arange(77, dtype=onp.int32)))
+    self.assertTrue(type(lnp.arange(77, dtype=lnp.int32)) ==
+                    type(lax.iota(onp.int32, 77)))
+
   def testIssue830(self):
     a = lnp.arange(4, dtype=lnp.complex64)
     self.assertEqual(a.dtype, lnp.complex64)


### PR DESCRIPTION
…ype is provided.