### PR TITLE
Add unit_diagonal option to lax_linalg.solve_triangular.

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -251,10 +251,8 @@ def solve(a, b):
   iotas = np.ix_(*(lax.iota(np.int32, b) for b in batch_dims + (1,)))
   x = x[iotas[:-1] + (permutation, slice(None))]
 
-  # TODO(phawkins): add unit_diagonal support to triangular_solve, use it here
-  # instead of explicit masking of l.
-  l = np.tril(lu, -1)[..., :, :m] + np.eye(m, m, dtype=dtype)
-  x = lax_linalg.triangular_solve(l, x, left_side=True, lower=True)
+  x = lax_linalg.triangular_solve(lu, x, left_side=True, lower=True,
+                                  unit_diagonal=True)
   x = lax_linalg.triangular_solve(lu, x, left_side=True, lower=False)
 
   return x[..., 0] if a_ndims == b_ndims + 1 else x

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -179,9 +179,6 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
   warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_b, debug, check_finite
 
-  if unit_diagonal:
-    raise NotImplementedError("unit_diagonal=True is not implemented.")
-
   if trans == 0 or trans == "N":
     transpose_a, conjugate_a = False, False
   elif trans == 1 or trans == "T":
@@ -193,15 +190,14 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
 
   a, b = np_linalg._promote_arg_dtypes(np.asarray(a), np.asarray(b))
 
-  a = np.tril(a) if lower else np.triu(a)
-
   # lax_linalg.triangular_solve only supports matrix 'b's at the moment.
   b_is_vector = np.ndim(a) == np.ndim(b) + 1
   if b_is_vector:
     b = b[..., None]
   out = lax_linalg.triangular_solve(a, b, left_side=True, lower=lower,
                                     transpose_a=transpose_a,
-                                    conjugate_a=conjugate_a)
+                                    conjugate_a=conjugate_a,
+                                    unit_diagonal=unit_diagonal)
   if b_is_vector:
     return out[..., 0]
   else:


### PR DESCRIPTION
LAPACK and cuBLAS both support treating the diagonal of a triangular matrix as 1 and ignoring the actual matrix contents. Plumb this ability through to lax and use it a few places that were explicitly masking diagonals.

In addition, move logic to mask tangents to triangular solve into the JVP rule instead of relying on the caller to do it.
