### PR TITLE
Use constant-time algorithm for static slice index calculation.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2343,11 +2343,7 @@ def _static_idx(idx, size):
   """Helper function to compute the static slice start/limit/stride values."""
   assert isinstance(idx, slice)
   start, stop, step = idx.indices(size)
-  if step < 0:
-    length = (start - stop - 1) // (-step) + 1 if stop < start else 0
-  else:
-    length = (stop - start - 1) // step + 1 if start < stop else 0
-  if length == 0:
+  if (step < 0 and stop >= start) or (step > 0 and start >= stop):
     return 0, 0, 1, False  # sliced to size zero
 
   if step > 0:


### PR DESCRIPTION
The current code was linear time in the size of the input array in some cases.

For the benchmark in https://github.com/google/jax/issues/927, compilation time improves from 18s to 0.2s on Mac. Interestingly the performance before this fix seems very different across platforms.

Improves the compilation time in #927; does not fix the nondetermistic segfault on exit on Mac.