### PR TITLE
Add a pure Python LU decomposition.

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -414,7 +414,7 @@ def defvjp_all(prim, custom_vjp):
     in_aval = raise_to_shaped(get_aval(primal_out))
     ct_pval = pe.PartialVal((in_aval, core.unit))
     vjp_jaxpr, out_pval, residuals = pe.trace_unwrapped_to_jaxpr(
-        lambda ct: pack(vjp_py(ct)), (ct_pval,))
+        lambda ct: pack(vjp_py(ct)), (ct_pval,), instantiate=False)
     out_pv, out_const = out_pval
     tangent_out = fun_lin_p.bind(out_const, pack(residuals), tangents_tracer,
                                  in_aval=in_aval, out_pv=out_pv, vjp_jaxpr=vjp_jaxpr)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -390,8 +390,9 @@ def pack_pvals(pvals):
 def abstractify(x):
   return PartialVal((core.concrete_aval(x), unit))
 
-def trace_unwrapped_to_jaxpr(fun, pvals, **kwargs):
-  return trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals)
+def trace_unwrapped_to_jaxpr(fun, pvals, instantiate, **kwargs):
+  return trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals,
+                        instantiate=instantiate)
 
 def trace_to_jaxpr(fun, pvals, **kwargs):
   """Traces a function, given abstract inputs, to a jaxpr."""

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -794,7 +794,8 @@ def reduce(operand, init_value, computation, dimensions):
 
 def _reduction_jaxpr(computation, init_value):
   pval = _abstractify(init_value)
-  jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(computation, (pval, pval))
+  jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(computation, (pval, pval),
+                                                 instantiate=False)
   return jaxpr, consts
 
 def _get_monoid_reducer(monoid_op, x):

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -866,5 +866,5 @@ scan_p.def_impl(_scan_impl)
 ad.primitive_jvps[scan_p] = _scan_jvp
 ad.primitive_transposes[scan_p] = _scan_transpose
 pe.custom_partial_eval_rules[scan_p] = _scan_partial_eval
-xla.translations[scan_p] = partial(xla.lower_fun, _scan_impl)
+xla.translations[scan_p] = xla.lower_fun(_scan_impl)
 batching.primitive_batchers[scan_p] = _scan_batching_rule

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -505,11 +505,15 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     a = rng(shape, dtype)
     jtu.check_grads(jsp.linalg.lu, (a,), 2, atol=5e-2, rtol=1e-1)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype, "rng": rng}
+      for shape in [(4, 5), (6, 5)]
+      for dtype in [np.float32]
+      for rng in [jtu.rand_default()]))
   @jtu.skip_on_devices("gpu", "tpu")
-  def testLuBatching(self):
-    shape = (4, 5)
-    dtype = np.float32
-    rng = jtu.rand_default()
+  def testLuBatching(self, shape, dtype, rng):
     args = [rng(shape, np.float32) for _ in range(10)]
     expected = list(osp.linalg.lu(x) for x in args)
     ps = onp.stack([out[0] for out in expected])


### PR DESCRIPTION
This implementation can be used on platforms where we don't have any other implementation.

Extend `partial_eval.trace_to_unwrapped_jaxpr` and `xla.lower_fun` to accept an `instantiate` argument for instantiating constants. 

Progress on issue #825.