### PR TITLE
Detect singular matrices during LU decomposition and return NaNs.

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -375,7 +375,7 @@ def _lu_unblocked(a):
   """Unblocked LU decomposition, as a rolled loop."""
   m, n = a.shape
   def body(k, state):
-    pivot, perm, a = state
+    pivot, perm, a, error = state
     m_idx = np.arange(m)
     n_idx = np.arange(n)
 
@@ -392,21 +392,24 @@ def _lu_unblocked(a):
     perm = ops.index_update(perm, ops.index[[i, k],], perm[[k, i],])
 
     # a[k+1:, k] /= a[k, k], adapted for loop-invariant shapes
+    x = a[k, k]
+    error = error | lax.eq(x, np._constant_like(a, 0))
     a = ops.index_update(a, ops.index[:, k],
-                         np.where(m_idx > k, a[:, k] / a[k, k], a[:, k]))
+                         np.where(m_idx > k, a[:, k] / x, a[:, k]))
 
     # a[k+1:, k+1:] -= np.outer(a[k+1:, k], a[k, k+1:])
     a = a - np.where((m_idx[:, None] > k) & (n_idx > k),
                      np.outer(a[:, k], a[k, :]), np.array(0, dtype=a.dtype))
-    return pivot, perm, a
+    return pivot, perm, a, error
 
   pivot = np.zeros((min(m, n),), dtype=np.int32)
   perm = np.arange(m, dtype=np.int32)
+  error = np.array(False, np.bool_)
   if m == 0 and n == 0:
     # If the array is empty, the loop body never executes but tracing it to a
     # jaxpr fails because the indexing cannot succeed.
-    return (pivot, perm, a)
-  return lax.fori_loop(0, min(m, n), body, (pivot, perm, a))
+    return (pivot, perm, a, error)
+  return lax.fori_loop(0, min(m, n), body, (pivot, perm, a, error))
 
 
 def _lu_blocked(a, block_size=32):
@@ -414,9 +417,11 @@ def _lu_blocked(a, block_size=32):
   m, n = a.shape
   r = min(m, n)
   pivot = np.zeros((r,), dtype=np.int32)
+  error = np.array(False, np.bool_)
   for k in range(0, r, block_size):
     b = min(r - k, block_size)
-    block_pivot, perm, lu_block = _lu_unblocked(a[k:, k:k+b])
+    block_pivot, perm, lu_block, block_error = _lu_unblocked(a[k:, k:k+b])
+    error = error | block_error
     a = ops.index_update(a, ops.index[k:, k:k+b], lu_block)
 
     a = ops.index_update(a, ops.index[k:, :k], a[perm + k, :k])
@@ -432,6 +437,7 @@ def _lu_blocked(a, block_size=32):
         a, ops.index[k+b:, k+b:],
         -lax.dot(a[k+b:, k:k+b], a[k:k+b, k+b:],
                  precision=lax.Precision.HIGHEST))
+  a = np.where(error, lax.full_like(a, np.nan), a)
   return pivot, a
 
 def _lu_python(x):
@@ -517,27 +523,26 @@ def _lu_batching_rule(batched_args, batch_dims):
   x = batching.bdim_at_front(x, bd)
   return lu_p.bind(x), 0
 
-def _lu_translation_rule(c, operand):
-  if xla.xb.get_backend().platform == "cpu":
-    shape = c.GetShape(operand)
-    batch_dims = shape.dimensions()[:-2]
-    getrf_out = lapack.jax_getrf(c, operand)
-    lu = c.GetTupleElement(getrf_out, 0)
-    # Subtract 1 from the pivot to get 0-based indices.
-    pivot = c.Sub(c.GetTupleElement(getrf_out, 1), c.ConstantS32Scalar(1))
-    ok = c.Eq(c.GetTupleElement(getrf_out, 2), c.ConstantS32Scalar(0))
-    lu = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), lu,
-                              _nan_like(c, lu))
-    return c.Tuple(lu, pivot)
-  else:
-    return xla.lower_fun(_lu_python, instantiate=True)(c, operand)
+def _lu_cpu_translation_rule(c, operand):
+  shape = c.GetShape(operand)
+  batch_dims = shape.dimensions()[:-2]
+  getrf_out = lapack.jax_getrf(c, operand)
+  lu = c.GetTupleElement(getrf_out, 0)
+  # Subtract 1 from the pivot to get 0-based indices.
+  pivot = c.Sub(c.GetTupleElement(getrf_out, 1), c.ConstantS32Scalar(1))
+  ok = c.Eq(c.GetTupleElement(getrf_out, 2), c.ConstantS32Scalar(0))
+  lu = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), lu,
+                            _nan_like(c, lu))
+  return c.Tuple(lu, pivot)
+
 
 lu_p = Primitive('lu')
 lu_p.def_impl(_lu_impl)
 lu_p.def_abstract_eval(_lu_abstract_eval)
-xla.translations[lu_p] = _lu_translation_rule
+xla.translations[lu_p] = xla.lower_fun(_lu_python, instantiate=True)
 ad.primitive_jvps[lu_p] = _lu_jvp_rule
 batching.primitive_batchers[lu_p] = _lu_batching_rule
+xla.backend_specific_translations['cpu'][lu_p] = _lu_cpu_translation_rule
 
 
 def lu_pivots_to_permutation(swaps, m):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -510,6 +510,11 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp.linalg.lu, args_maker, check_dtypes=True)
 
+  def testLuOfSingularMatrixReturnsNans(self):
+    xs = np.array([[-1., 3./2], [2./3, -1.]])
+    lu, _ = jsp.linalg.lu_factor(xs)
+    self.assertTrue(onp.all(onp.isnan(lu)))
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),


### PR DESCRIPTION
Use per-backend translation rule registration rather than an explicit if test.