### PR TITLE
Support all types for higher derivatives of reduce-window-min/max.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3660,14 +3660,13 @@ def _select_and_gather_add_translation(
                   "min/max operator. This is likely from a second or "
                   "higher derivative of a max-pooling operation and is to work"
                   "around a missing XLA support for pair-reductions.")
-    if etype == xla_client.PrimitiveType.F32:
-      nexp, nmant = 8, 7  # bfloat16 precision.
-    elif etype == xla_client.PrimitiveType.F64:
-      nexp, nmant = onp.finfo(onp.float32).nexp, onp.finfo(onp.float32).nmant
+    r_nbits = nbits // 2
+    # Drop/round the bottom mantissa bits.
+    nexp = onp.finfo(dtype).nexp
+    nmant = r_nbits - nexp - 1
 
     double_word_dtype = word_dtype = _UINT_DTYPES[nbits]
     word_type = xla_bridge.dtype_to_etype_exact(word_dtype)
-    r_nbits = nbits // 2
 
     # Packs two values into a tuple.
     def pack(a, b):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2030,8 +2030,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "rng": rng}
       for init_val, op, dtypes, rng in [
           (0, lax.add, float_dtypes, jtu.rand_small()),
-          (-onp.inf, lax.max, float_dtypes, jtu.rand_default()),
-          (onp.inf, lax.min, float_dtypes, jtu.rand_default()),
+          (-onp.inf, lax.max, [onp.float32], jtu.rand_default()),
+          (onp.inf, lax.min, [onp.float32], jtu.rand_default()),
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2045,7 +2045,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     # TODO(b/31565929): enable when fixed.
     if FLAGS.jax_test_dut == "tpu" and op is not lax.add:
       all_configs = [((6, 5, 4, 3), (2, 2, 1, 1), (1, 2, 1, 1))]
-      test_gradients = True  # TODO(b/73062247): need variadic reduce-window.
+
+      # TODO(b/73062247): need variadic reduce-window for better precision.
+      gradient_order = 1
     else:
       all_configs = itertools.chain(
           itertools.product(
@@ -2058,22 +2060,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
               [(1, 1, 2, 1), (2, 1, 2, 1)],  # window_dimensions
               [(1, 2, 2, 1), (1, 1, 1, 1)]),  # strides
       )
-      test_gradients = True
+      gradient_order = 3
 
     def fun(operand):
       return lax.reduce_window(operand, init_val, op, dims, strides, padding)
 
-    # pylint: disable=cell-var-from-loop
     for shape, dims, strides in all_configs:
       operand = rng(shape, dtype)
       if op is not lax.add:
         # this test can fail if there are duplicates in operand
         self.assertEqual(onp.unique(operand).size, operand.size,
                          msg="test requires operand elements to be unique.")
-      jtu.check_vjp(fun, partial(api.vjp, fun), (operand,), 1e-2, 1e-2, 1e-2)
-      if test_gradients:
-        check_grads(fun, (operand,), 3, ["fwd", "rev"], 1e-2, 1e-2, 1e-2)
-    # pylint: enable=cell-var-from-loop
+      check_grads(fun, (operand,), gradient_order, ["fwd", "rev"], 1e-2, 1e-2,
+                  1e-2)
 
   # TODO(b/205052657): enable more tests when supported
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2029,9 +2029,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
        "rng": rng}
       for init_val, op, dtypes, rng in [
-          (0, lax.add, [onp.float32], jtu.rand_small()),
-          (-onp.inf, lax.max, [onp.float32], jtu.rand_default()),
-          (onp.inf, lax.min, [onp.float32], jtu.rand_default()),
+          (0, lax.add, float_dtypes, jtu.rand_small()),
+          (-onp.inf, lax.max, float_dtypes, jtu.rand_default()),
+          (onp.inf, lax.min, float_dtypes, jtu.rand_default()),
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]
@@ -2045,7 +2045,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     # TODO(b/31565929): enable when fixed.
     if FLAGS.jax_test_dut == "tpu" and op is not lax.add:
       all_configs = [((6, 5, 4, 3), (2, 2, 1, 1), (1, 2, 1, 1))]
-      test_gradients = False  # TODO(b/73062247): need variadic reduce-window.
+      test_gradients = True  # TODO(b/73062247): need variadic reduce-window.
     else:
       all_configs = itertools.chain(
           itertools.product(


### PR DESCRIPTION
On CPU/GPU this means support for float64 derivatives, and on TPU this means support for float32 derivatives. However, we implement this by downcasting to the largest available type (float32 on cpu/gpu and bfloat16 on TPU) until XLA adds variadic reduce-window support.

Warn if we are forced to be imprecise.