### PR TITLE
Add a jax.numpy.__init__ method that throws a TypeError if called.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -82,7 +82,10 @@ class _ArrayMeta(type(onp.ndarray)):
 
 # pylint: disable=invalid-name
 class ndarray(six.with_metaclass(_ArrayMeta, onp.ndarray)):
-  pass
+  def __init__(shape, dtype=None, buffer=None, offset=0, strides=None,
+               order=None):
+    raise TypeError("jax.numpy.ndarray() should not be instantiated explicitly."
+                    " Use jax.numpy.array, or jax.numpy.zeros instead.")
 # pylint: enable=invalid-name
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1679,6 +1679,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     x = lnp.ones((3, 4))
     self.assertRaises(ValueError, lambda: lnp.sum(x, axis=2))
 
+  def testIssue956(self):
+    self.assertRaises(TypeError, lambda: lnp.ndarray((1, 1)))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Improves the error message for #956, where np.ndarray was called explicitly.

Fixes #956 