### PR TITLE
Add underscore prefixes to xla.py methods. Add some docstrings.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -48,22 +48,24 @@ flags.DEFINE_bool('jax_debug_nans',
                   'Add nan checks to every operation.')
 
 def apply_primitive(prim, *args, **params):
+  """Impl rule that compiles and runs a single primitive 'prim' using XLA."""
   abstract_args = map(abstractify, args)
-  compiled_fun = xla_primitive_callable(prim, *abstract_args, **params)
+  compiled_fun = _xla_primitive_callable(prim, *abstract_args, **params)
   return compiled_fun(*args)
 
 @memoize
-def xla_primitive_callable(prim, *abstract_args, **params):
+def _xla_primitive_callable(prim, *abstract_args, **params):
   shapes = tuple(map(xla_shape, abstract_args))
   built_c = primitive_computation(prim, *shapes, **params)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
   handle_result = result_handler(result_shape)
   compiled = built_c.Compile(shapes, xb.get_compile_options(),
                              backend=xb.get_backend())
-  return partial(execute_compiled_primitive, prim.name, compiled, handle_result)
+  return partial(_execute_compiled_primitive, prim.name, compiled, handle_result)
 
 @memoize
 def primitive_computation(prim, *shapes, **params):
+  """Builds an XLA computation for `prim` with argument `shapes`."""
   c = xb.make_computation_builder("primitive_computation")
   xla_args = map(c.ParameterWithShape, shapes)
   xla_result = translation_rule(prim)(c, *xla_args, **params)
@@ -71,16 +73,16 @@ def primitive_computation(prim, *shapes, **params):
     return c.Build()
   except RuntimeError as e:
     # try for a better error message by using the abstract_eval checks
-    prim.abstract_eval(*map(aval_from_xla_shape, shapes), **params)
+    prim.abstract_eval(*map(_aval_from_xla_shape, shapes), **params)
     raise e
 
-def aval_from_xla_shape(shape):
+def _aval_from_xla_shape(shape):
   if shape.is_tuple():
-    return AbstractTuple(map(aval_from_xla_shape, shape.tuple_shapes()))
+    return AbstractTuple(map(_aval_from_xla_shape, shape.tuple_shapes()))
   else:
     return ShapedArray(shape.dimensions(), shape.element_type())
 
-def execute_compiled_primitive(name, compiled, result_handler, *args):
+def _execute_compiled_primitive(name, compiled, result_handler, *args):
   input_bufs = [device_put(x) for x in args]
   out_buf = compiled.Execute(input_bufs)
   check_nans(name, out_buf)
@@ -123,7 +125,7 @@ def device_put(x, device_num=0):
   Returns:
     A buffer representing the input `x` placed on the appropriate device.
   """
-  x = canonicalize_pyval_dtype(x)
+  x = _canonicalize_pyval_dtype(x)
   t = type(x)
   if t is DeviceArray or t is DeviceTuple:
     if x.device_buffer.device() == device_num:
@@ -136,7 +138,7 @@ def device_put(x, device_num=0):
       else:
         return device_put(x.device_buffer.to_py(), device_num)
   elif isinstance(x, DeviceConstant):
-    return instantiate_device_constant(x, device_num=device_num)
+    return _instantiate_device_constant(x, device_num=device_num)
   elif isinstance(x, (DeviceArray, onp.ndarray)):
     return xb.device_put(x, device_num)  # handle arraylikes
   elif isinstance(x, JaxTuple):
@@ -155,7 +157,7 @@ def device_put(x, device_num=0):
 # compile time we set up result handler functions and thus avoid redoing some of
 # the Python bookkeeping work on every execution. Since XLA shapes are slower to
 # manipulate than simple Python builtins, we store the metadata required for
-# forming the DeviceValue result in special ResultArray / ResultTuple classes.
+# forming the DeviceValue result in special _ResultArray / _ResultTuple classes.
 
 # Every JaxType needs to map to an XLA type. However this function's design is
 # based on the assumption that XLA types can be mapped uniquely back to a
@@ -164,32 +166,33 @@ def device_put(x, device_num=0):
 # track abstract values of outputs.
 def xla_shape_to_result_shape(xla_shape):
   if xla_shape.is_tuple():
-    aval = aval_from_xla_shape(xla_shape)
+    aval = _aval_from_xla_shape(xla_shape)
     result_shapes = tuple(map(xla_shape_to_result_shape, xla_shape.tuple_shapes()))
-    return ResultTuple((aval, result_shapes))
+    return _ResultTuple((aval, result_shapes))
   else:
     shape, dtype = xla_shape.dimensions(), xla_shape.element_type()
     ndim, size = len(shape), prod(shape)
-    return ResultArray((shape, dtype, ndim, size))
-class ResultTuple(tuple): pass
-class ResultArray(tuple): pass
+    return _ResultArray((shape, dtype, ndim, size))
+
+class _ResultTuple(tuple): pass
+class _ResultArray(tuple): pass
 
 def result_handler(result_shape):
   if FLAGS.jax_device_values:
-    return device_persistent_result_handler(result_shape)
+    return _device_persistent_result_handler(result_shape)
   else:
-    return pyval_result_handler(result_shape)
+    return _pyval_result_handler(result_shape)
 
-def device_persistent_result_handler(result_shape):
+def _device_persistent_result_handler(result_shape):
   t = type(result_shape)
-  if t is ResultArray:
+  if t is _ResultArray:
     return partial(DeviceArray, result_shape)
-  elif t is ResultTuple:
+  elif t is _ResultTuple:
     return partial(DeviceTuple, result_shape)
   else:
     raise TypeError(t)
 
-def pyval_result_handler(result_shape):
+def _pyval_result_handler(result_shape):
   del result_shape
   def _tuple_to_jaxtuple(v):
     if isinstance(v, tuple):
@@ -199,7 +202,7 @@ def pyval_result_handler(result_shape):
     return _tuple_to_jaxtuple(buf.to_py())
   return f
 
-def compile_jaxpr(jaxpr, const_vals, *abstract_args):
+def _compile_jaxpr(jaxpr, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
   built_c = jaxpr_computation(jaxpr, const_vals, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
@@ -229,7 +232,7 @@ def jaxpr_computation(jaxpr, const_vals, freevar_shapes, *arg_shapes):
 
   def read(v):
     if type(v) is Literal:
-      return c.Constant(canonicalize_pyval_dtype(v.val))
+      return c.Constant(_canonicalize_pyval_dtype(v.val))
     else:
       return env[v]
 
@@ -282,9 +285,9 @@ def xla_destructure(c, ans):
 def xla_pack(c, xs):
   return c.Tuple(*xs)
 
-def tuple_constant(c, val, canonicalize_types=True):
+def _tuple_constant(c, val, canonicalize_types=True):
   return c.Tuple(*map(c.Constant, val))
-xb.register_constant_handler(JaxTuple, tuple_constant)
+xb.register_constant_handler(JaxTuple, _tuple_constant)
 
 def translation_rule(p):
   backend = xb.get_backend()
@@ -297,9 +300,14 @@ def translation_rule(p):
 
 
 def lower_fun(fun, instantiate=False):
+  """Lowers a traceable function to an XLA function.
+
+  Useful for implementing translation rules for primitives in terms of the
+  higher-level lax or NumPy APIs.
+  """
   def f(c, *xla_args, **params):
     xla_shapes = tuple(map(c.GetShape, xla_args))
-    avals = map(aval_from_xla_shape, xla_shapes)
+    avals = map(_aval_from_xla_shape, xla_shapes)
     pvals = [pe.PartialVal((a, core.unit)) for a in avals]
     jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(fun, pvals, instantiate,
                                                    **params)
@@ -316,7 +324,7 @@ translations[core.call_p] = lambda c, subc_a1, *a2: c.Call(subc_a1[0],
                                                            subc_a1[1] + a2)
 translations[core.identity_p] = lambda c, x: x
 
-def zeros_like_translation_rule(c, x):
+def _zeros_like_translation_rule(c, x):
   def _zeros_like(shape):
     if shape.is_tuple():
       return c.Tuple(*(_zeros_like(x) for x in shape.tuple_shapes()))
@@ -325,20 +333,20 @@ def zeros_like_translation_rule(c, x):
                          shape.dimensions())
   return _zeros_like(c.GetShape(x))
 
-def add_jaxvals_translation_rule(c, x, y):
+def _add_jaxvals_translation_rule(c, x, y):
   x_shape, y_shape = map(c.GetShape, (x, y))
   if x_shape.is_tuple() and y_shape.is_tuple():
     xs = xla_destructure(c, x)
     ys = xla_destructure(c, y)
-    return c.Tuple(*map(partial(add_jaxvals_translation_rule, c), xs, ys))
+    return c.Tuple(*map(partial(_add_jaxvals_translation_rule, c), xs, ys))
   else:
     return c.Add(x, y)
 
-translations[ad_util.zeros_like_p] = zeros_like_translation_rule
-translations[ad_util.add_jaxvals_p] = add_jaxvals_translation_rule
+translations[ad_util.zeros_like_p] = _zeros_like_translation_rule
+translations[ad_util.add_jaxvals_p] = _add_jaxvals_translation_rule
 
 
-def canonicalize_pyval_dtype(x):
+def _canonicalize_pyval_dtype(x):
   try:
     return canonicalize_dtype_handlers[type(x)](x)
   except KeyError:
@@ -347,17 +355,17 @@ def canonicalize_pyval_dtype(x):
 
 canonicalize_dtype_handlers = {}
 
-def canonicalize_tuple_dtype(tup):
-  return JaxTuple(map(canonicalize_pyval_dtype, tup))
-canonicalize_dtype_handlers[JaxTuple] = canonicalize_tuple_dtype
+def _canonicalize_tuple_dtype(tup):
+  return JaxTuple(map(_canonicalize_pyval_dtype, tup))
+canonicalize_dtype_handlers[JaxTuple] = _canonicalize_tuple_dtype
 
-def canonicalize_ndarray_dtype(x):
+def _canonicalize_ndarray_dtype(x):
   return onp.asarray(x, xb.canonicalize_dtype(onp.result_type(x)))
 
-for t in array_types:
-  canonicalize_dtype_handlers[t] = canonicalize_ndarray_dtype
+for _t in array_types:
+  canonicalize_dtype_handlers[_t] = _canonicalize_ndarray_dtype
 
-def identity(x): return x
+def _identity(x): return x
 
 
 def abstractify(x):
@@ -368,13 +376,13 @@ def abstractify(x):
 
 pytype_aval_mappings = {}
 
-def abstractify_tuple(tup):
+def _abstractify_tuple(tup):
   return AbstractTuple(map(abstractify, tup))
-pytype_aval_mappings[JaxTuple] = abstractify_tuple
-pytype_aval_mappings[AbstractTuple] = abstractify_tuple
+pytype_aval_mappings[JaxTuple] = _abstractify_tuple
+pytype_aval_mappings[AbstractTuple] = _abstractify_tuple
 
-for t in array_types:
-  pytype_aval_mappings[t] = make_shaped_array
+for _t in array_types:
+  pytype_aval_mappings[_t] = make_shaped_array
 
 
 class DeviceValue(object):
@@ -408,7 +416,7 @@ class DeviceTuple(DeviceValue):
 
   def __iter__(self):
     bufs = self.device_buffer.destructure()
-    handlers = map(device_persistent_result_handler, self.result_shapes)
+    handlers = map(_device_persistent_result_handler, self.result_shapes)
     elts = [handler(buf) for handler, buf in zip(handlers, bufs)]
     return iter(elts)
 
@@ -426,7 +434,7 @@ class DeviceTuple(DeviceValue):
 # the device have already been canonicalized.
 core.pytype_aval_mappings[DeviceTuple] = core.pytype_aval_mappings[JaxTuple]
 pytype_aval_mappings[DeviceTuple] = op.attrgetter('aval')
-canonicalize_dtype_handlers[DeviceTuple] = identity
+canonicalize_dtype_handlers[DeviceTuple] = _identity
 
 def _device_tuple_constant_handler(c, val, canonicalize_types=True):
   const = partial(c.Constant, canonicalize_types=canonicalize_types)
@@ -444,9 +452,9 @@ def _copy_to_host_async(buffer):
     buffer.copy_to_host_async()
 
 
-def forward_method(attrname, self, fun, *args):
+def _forward_method(attrname, self, fun, *args):
   return fun(getattr(self, attrname), *args)
-forward_to_value = partial(forward_method, "_value")
+_forward_to_value = partial(_forward_method, "_value")
 
 class DeviceArray(DeviceValue):
   """A DeviceArray is an ndarray backed by a single device memory buffer."""
@@ -536,18 +544,18 @@ class DeviceArray(DeviceValue):
   def __array__(self, dtype=None, context=None):
     return onp.asarray(self._value, dtype=dtype)
 
-  __str__ = partialmethod(forward_to_value, str)
-  __bool__ = __nonzero__ = partialmethod(forward_to_value, bool)
-  __float__ = partialmethod(forward_to_value, float)
-  __int__ = partialmethod(forward_to_value, int)
+  __str__ = partialmethod(_forward_to_value, str)
+  __bool__ = __nonzero__ = partialmethod(_forward_to_value, bool)
+  __float__ = partialmethod(_forward_to_value, float)
+  __int__ = partialmethod(_forward_to_value, int)
   if six.PY2:
-    __long__ = partialmethod(forward_to_value, long)  # noqa: F821
-  __complex__ = partialmethod(forward_to_value, complex)
-  __hex__ = partialmethod(forward_to_value, hex)
-  __oct__ = partialmethod(forward_to_value, oct)
+    __long__ = partialmethod(_forward_to_value, long)  # noqa: F821
+  __complex__ = partialmethod(_forward_to_value, complex)
+  __hex__ = partialmethod(_forward_to_value, hex)
+  __oct__ = partialmethod(_forward_to_value, oct)
 
   # pickle saves and loads just like an ndarray
-  __reduce__ = partialmethod(forward_to_value, op.methodcaller("__reduce__"))
+  __reduce__ = partialmethod(_forward_to_value, op.methodcaller("__reduce__"))
 
   # clobbered when jax.numpy is imported, but useful in tests
   def __eq__(self, other): return self._value == other
@@ -562,14 +570,14 @@ core.literalable_types.add(DeviceArray)
 # device have already been canonicalized.
 core.pytype_aval_mappings[DeviceArray] = ConcreteArray
 pytype_aval_mappings[DeviceArray] = make_shaped_array
-canonicalize_dtype_handlers[DeviceArray] = identity
+canonicalize_dtype_handlers[DeviceArray] = _identity
 
 def _device_array_constant_handler(c, val, canonicalize_types=True):
   return c.Constant(onp.asarray(val), canonicalize_types=canonicalize_types)
 xb.register_constant_handler(DeviceArray, _device_array_constant_handler)
 
 pytype_aval_mappings[ConcreteArray] = make_shaped_array
-pytype_aval_mappings[ShapedArray] = identity
+pytype_aval_mappings[ShapedArray] = _identity
 
 
 class DeviceConstant(DeviceArray):
@@ -579,7 +587,7 @@ class DeviceConstant(DeviceArray):
   def constant_handler(c, constant_instance, canonicalize_types=True):
     assert False
 
-def instantiate_device_constant(const, cutoff=1e6, device_num=0):
+def _instantiate_device_constant(const, cutoff=1e6, device_num=0):
   # dispatch an XLA Computation to build the constant on the device if it's
   # large, or alternatively build it on the host and transfer it if it's small
   # TODO(mattjj): need a way to instantiate on a specific device
@@ -604,9 +612,9 @@ def xla_shape(x):
       raise TypeError(type(x))
 
 
-def xla_call_impl(fun, *args, **params):
+def _xla_call_impl(fun, *args, **params):
   device_values = FLAGS.jax_device_values and params.pop('device_values')
-  compiled_fun = xla_callable(fun, device_values, *map(abstractify, args))
+  compiled_fun = _xla_callable(fun, device_values, *map(abstractify, args))
   try:
     return compiled_fun(*args)
   except FloatingPointError:
@@ -616,20 +624,20 @@ def xla_call_impl(fun, *args, **params):
 
 
 @lu.memoize
-def xla_callable(fun, device_values, *abstract_args):
+def _xla_callable(fun, device_values, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
     jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here (though cond might eventually need them)
-    compiled, result_shape = compile_jaxpr(jaxpr, consts, *abstract_args)
+    compiled, result_shape = _compile_jaxpr(jaxpr, consts, *abstract_args)
     del master, consts, jaxpr, env
   if device_values:
-    handle_result = device_persistent_result_handler(result_shape)
+    handle_result = _device_persistent_result_handler(result_shape)
   else:
-    handle_result = pyval_result_handler(result_shape)
-  return partial(execute_compiled, compiled, pval, handle_result)
+    handle_result = _pyval_result_handler(result_shape)
+  return partial(_execute_compiled, compiled, pval, handle_result)
 
-def execute_compiled(compiled, pval, handle_result, *args):
+def _execute_compiled(compiled, pval, handle_result, *args):
   input_bufs = [device_put(x) for x in args]
   out_buf = compiled.Execute(input_bufs)
   check_nans("jit-compiled computation", out_buf)
@@ -643,7 +651,7 @@ def xla_call_translation_rule(c, subc_a1, *a2, **params):
 xla_call_p = core.Primitive('xla_call')
 xla_call = partial(core.call_bind, xla_call_p)
 xla_call_p.def_custom_bind(xla_call)
-xla_call_p.def_impl(xla_call_impl)
+xla_call_p.def_impl(_xla_call_impl)
 
 translations[xla_call_p] = xla_call_translation_rule
 ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)


### PR DESCRIPTION
This PR does not take an opinion about which methods should be public, instead it attempts to codify the world as it is now by adding underscore prefixes to methods that are local to xla.py. It is frequently helpful to me to be able to identify which functions are API entry points and which are not.