### PR TITLE
Add a more direct implementation of device_put.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -179,11 +179,11 @@ class _ResultArray(tuple): pass
 
 def result_handler(result_shape):
   if FLAGS.jax_device_values:
-    return _device_persistent_result_handler(result_shape)
+    return device_persistent_result_handler(result_shape)
   else:
     return _pyval_result_handler(result_shape)
 
-def _device_persistent_result_handler(result_shape):
+def device_persistent_result_handler(result_shape):
   t = type(result_shape)
   if t is _ResultArray:
     return partial(DeviceArray, result_shape)
@@ -416,7 +416,7 @@ class DeviceTuple(DeviceValue):
 
   def __iter__(self):
     bufs = self.device_buffer.destructure()
-    handlers = map(_device_persistent_result_handler, self.result_shapes)
+    handlers = map(device_persistent_result_handler, self.result_shapes)
     elts = [handler(buf) for handler, buf in zip(handlers, bufs)]
     return iter(elts)
 
@@ -632,7 +632,7 @@ def _xla_callable(fun, device_values, *abstract_args):
     compiled, result_shape = _compile_jaxpr(jaxpr, consts, *abstract_args)
     del master, consts, jaxpr, env
   if device_values:
-    handle_result = _device_persistent_result_handler(result_shape)
+    handle_result = device_persistent_result_handler(result_shape)
   else:
     handle_result = _pyval_result_handler(result_shape)
   return partial(_execute_compiled, compiled, pval, handle_result)


### PR DESCRIPTION
This implementation copies tensors to device without building an XLA computation. XLA compilation may take time superlinear in the number of arguments, but there's no good reason for us to build a computation at all, it was merely a convenient way to implement `device_put` for free. Instead, when the argument to `device_put` isn't a tracer, call `xla.device_put` directly. If it is a tracer, fall back to the old implementation.

Timing for benchmark in #947:
```
In [4]: %time x = jax.device_put([onp.random.randn(10,5) for _ in range(700)])
CPU times: user 45.3 ms, sys: 3.79 ms, total: 49.1 ms
Wall time: 33.8 ms
```
where the timing was previously 43.4s; i.e., this is 3 orders of magnitude faster.

Fixes #947.