### PR TITLE
Implement device_put as a primitive.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -989,24 +989,8 @@ def make_jaxpr(fun):
 tree_to_pval_tuples = partial(process_pytree, pe.pack_pvals)
 
 
-
-_traceable_device_put = jit(lambda x: x)
-
 def device_put(x, device_num=0):
-  def _device_put(x):
-    if isinstance(x, core.Tracer):
-      return _traceable_device_put(x)
-
-    try:
-      a = xla.abstractify(x)
-    except TypeError:
-      raise TypeError("Argument '{}' of type {} is not a valid JAX type"
-                      .format(x, type(x)))
-
-    result_shape = xla.xla_shape_to_result_shape(xla.xla_shape(a))
-    handler = xla.device_persistent_result_handler(result_shape)
-    return handler(xla.device_put(x, device_num))
-  return tree_map(_device_put, x)
+  return tree_map(lambda y: xla.device_put_p.bind(y, device_num=device_num), x)
 
 
 device_get = _jit(lambda x: x, (), device_values=False)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -238,7 +238,7 @@ def defvectorized(prim):
   primitive_batchers[prim] = partial(vectorized_batcher, prim)
 
 def vectorized_batcher(prim, batched_args, batch_dims, **params):
-  assert all(batch_dims[0] == bd for bd in batch_dims[1:])
+  assert all(batch_dims[0] == bd for bd in batch_dims[1:]), batch_dims
   return prim.bind(*batched_args, **params), batch_dims[0]
 
 def defbroadcasting(prim):
@@ -262,7 +262,7 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
     params = dict(params, input_shape=operand.shape)
   return prim.bind(operand, axes=axes, **params), bdim_out
 
-# set up primitive batches for ad_util primitives
+# sets up primitive batchers for ad_util and xla primitives
 
 def add_batched(batched_args, batch_dims):
   bdx, bdy = batch_dims
@@ -284,6 +284,7 @@ def zeros_like_batched(batched_args, batch_dims):
   return zeros_like_jaxval(val), bdim
 primitive_batchers[zeros_like_p] = zeros_like_batched
 
+defvectorized(xla.device_put_p)
 
 ### util
 


### PR DESCRIPTION
Uses the common dispatch logic rather than an explicit `isinstance(..., Tracer)` test.