### PR TITLE
Make DeviceArray.__iter__ and __reversed__ forward to _value.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -526,13 +526,13 @@ class DeviceArray(DeviceValue):
     if self.ndim == 0:
       raise TypeError("iteration over a 0-d array")  # same as numpy error
     else:
-      return (self[i] for i in xrange(self.shape[0]))
+      return self._value.__iter__()
 
   def __reversed__(self):
     if self.ndim == 0:
       raise TypeError("iteration over a 0-d array")
     else:
-      return (self[i] for i in xrange(self.shape[0] - 1, -1, -1))
+      return reversed(self._value)
 
   def __format__(self, format_spec):
     # Simulates behavior of https://github.com/numpy/numpy/pull/9883


### PR DESCRIPTION
This has the effect of transferring the entire array to the host and iterating over it in host memory, rather than slicing out individual elements in device memory one by one.

This is much faster for examples like `list(np.arange(10000))`; previously this took several seconds the first time due to compilation and 100ms+ subsequent times. With this change it takes < 1ms.

Fixes #946 .