### PR TITLE
Disable LU decomposition test for singular matrices.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 from functools import partial
 import itertools
-from unittest import SkipTest
+import unittest
 
 import numpy as onp
 import scipy as osp
@@ -49,12 +49,12 @@ def _skip_if_unsupported_type(dtype):
   dtype = onp.dtype(dtype)
   if (not FLAGS.jax_enable_x64 and
       dtype in (onp.dtype('float64'), onp.dtype('complex128'))):
-    raise SkipTest("--jax_enable_x64 is not set")
+    raise unittest.SkipTest("--jax_enable_x64 is not set")
   if FLAGS.jax_test_dut and FLAGS.jax_test_dut.startswith("gpu"):
     # TODO(b/129698548): enable complex128 tests when XLA/GPU has better
     # complex128 support.
     if dtype == onp.dtype('complex128'):
-      raise SkipTest("XLA/GPU complex128 support is incomplete.")
+      raise unittest.SkipTest("XLA/GPU complex128 support is incomplete.")
 
 
 numpy_version = tuple(map(int, onp.version.version.split('.')))
@@ -302,7 +302,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     if (ord in ('nuc', 2, -2) and (
         (not FLAGS.jax_test_dut or not FLAGS.jax_test_dut.startswith("cpu")) or
         (isinstance(axis, tuple) and len(axis) == 2))):
-      raise SkipTest("No adequate SVD implementation available")
+      raise unittest.SkipTest("No adequate SVD implementation available")
 
     args_maker = lambda: [rng(shape, dtype)]
     onp_fn = partial(onp.linalg.norm, ord=ord, axis=axis, keepdims=keepdims)
@@ -464,7 +464,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     _skip_if_unsupported_type(dtype)
     if (FLAGS.jax_test_dut and FLAGS.jax_test_dut.startswith("gpu") and
         shape == (200, 200)):
-      raise SkipTest("Test is flaky on GPU")
+      raise unittest.SkipTest("Test is flaky on GPU")
 
     def args_maker():
       invertible = False
@@ -510,6 +510,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp.linalg.lu, args_maker, check_dtypes=True)
 
+  # TODO(phawkins): figure out why this test fails on Travis and reenable.
+  @unittest.skip("Test fails on travis")
   def testLuOfSingularMatrixReturnsNans(self):
     xs = np.array([[-1., 3./2], [2./3, -1.]])
     lu, _ = jsp.linalg.lu_factor(xs)
@@ -587,7 +589,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     _skip_if_unsupported_type(dtype)
     if (sym_pos and onp.issubdtype(dtype, onp.complexfloating) and
        FLAGS.jax_test_dut and FLAGS.jax_test_dut.startswith("tpu")):
-      raise SkipTest("Complex Cholesky decomposition not implemented on TPU")
+      raise unittest.SkipTest(
+        "Complex Cholesky decomposition not implemented on TPU")
     osp_fun = lambda lhs, rhs: osp.linalg.solve(lhs, rhs, sym_pos=sym_pos, lower=lower)
     jsp_fun = lambda lhs, rhs: jsp.linalg.solve(lhs, rhs, sym_pos=sym_pos, lower=lower)
 


### PR DESCRIPTION
Import unittest rather than just unittest.SkipTest.