### PR TITLE
Convert int input to static_argnums to a tuple

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -112,7 +112,7 @@ def _jit(fun, static_argnums, device_values=True):
       return fun(*args, **kwargs)
     if isinstance(static_argnums, int):
       # static_argnums is a tuple of ints
-      static_argnums = tuple([static_argnums])
+      static_argnums = (static_argnums,)
     if static_argnums and max(static_argnums) >= len(args):
       msg = ("Jitted function has static_argnums={} but was called with only {}"
              " positional arguments.")

--- a/jax/api.py
+++ b/jax/api.py
@@ -110,6 +110,9 @@ def _jit(fun, static_argnums, device_values=True):
   def f_jitted(*args, **kwargs):
     if _jit_is_disabled or config.read('jax_disable_jit'):
       return fun(*args, **kwargs)
+    if isinstance(static_argnums, int):
+      # static_argnums is a tuple of ints
+      static_argnums = tuple([static_argnums])
     if static_argnums and max(static_argnums) >= len(args):
       msg = ("Jitted function has static_argnums={} but was called with only {}"
              " positional arguments.")


### PR DESCRIPTION
User could make mistake of passing an int to static_argnums, this helps to avoid unnecessary error.

Fix #969 