### PR TITLE
enable jit+pmap by merging pxla.py and xla.py

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -30,8 +30,7 @@ from .. import linear_util as lu
 from ..abstract_arrays import ConcreteArray, ShapedArray, make_shaped_array
 from ..util import partial, unzip2, concatenate, prod, memoize_unary
 from ..lib import xla_bridge as xb
-from .xla import (xla_shape, xla_destructure, translation_rule,
-                  xla_shape_to_result_shape, jaxpr_computation)
+from .xla import xla_shape, xla_destructure, xla_shape_to_result_shape
 from .partial_eval import trace_to_subjaxpr, merge_pvals, JaxprTrace, PartialVal
 from .batching import dimsize, broadcast
 from . import batching
@@ -81,6 +80,52 @@ def _slice(x, i):
     return core.pack(_slice(elt, i) for elt in x)
   else:
     return x[i]
+
+
+def xla_shard(c, sizes, x):
+  def _xla_shard(shape, x):
+    if shape.is_tuple():
+      elts = map(_xla_shard, shape.tuple_shapes(), xla_destructure(c, x))
+      return c.Tuple(*elts)
+    else:
+      return shard_array(shape, x)
+
+  def shard_array(shape, x):
+    dims = list(shape.dimensions())
+    assert dims[0] == sizes[-1]
+    start_indices = _xla_shard_start_indices(c, dims[0], len(dims))
+    return c.Reshape(c.DynamicSlice(x, start_indices, [1] + dims[1:]),
+                     None, dims[1:])
+
+  return _xla_shard(c.GetShape(x), x)
+
+# TODO(b/110096942): more efficient gather
+def xla_unshard(c, replica_groups, x):
+  def _xla_unshard(shape, x):
+    if shape.is_tuple():
+      elts = map(_xla_unshard, shape.tuple_shapes(), xla_destructure(c, x))
+      return c.Tuple(*elts)
+    else:
+      return unshard_array(shape, x)
+
+  def unshard_array(shape, x):
+    axis_size = len(replica_groups[0])
+    dims = list(shape.dimensions())
+    start_indices = _xla_shard_start_indices(c, axis_size, len(dims) + 1)
+    padded = c.Broadcast(c.Constant(onp.array(0, shape.numpy_dtype())),
+                         [axis_size] + dims)
+    padded = c.DynamicUpdateSlice(padded, c.Reshape(x, None, [1] + dims),
+                                  start_indices)
+    return c.CrossReplicaSum(padded, replica_groups)
+
+  return _xla_unshard(c.GetShape(x), x)
+
+
+# TODO(mattjj): plumb more ergonimic form of DynamicSlice / DynamicUpdateSlice
+def _xla_shard_start_indices(c, axis_size, ndim):
+  idx = c.Rem(c.ReplicaId(), c.Constant(onp.array(axis_size, onp.uint32)))
+  zero = onp.zeros(ndim - 1, onp.uint32)
+  return c.Concatenate([c.Reshape(idx, None, [1]), c.Constant(zero)], 0)
 
 
 def sharded_result_handler(axis_size, aval):
@@ -177,177 +222,28 @@ def replica_groups(nrep, mesh_spec, mesh_axes):
       (prod(onp.take(full_spec, mesh_axes)), -1))
   return tuple(map(tuple, groups.T))
 
-def xla_shard(c, sizes, x):
-  """Analog of shard_arg that performs sharding within an XLA computation."""
-
-  def _xla_shard(shape, x):
-    if shape.is_tuple():
-      elts = map(_xla_shard, shape.tuple_shapes(), xla_destructure(c, x))
-      return c.Tuple(*elts)
-    else:
-      return shard_array(shape, x)
-
-  def shard_array(shape, x):
-    dims = list(shape.dimensions())
-    assert dims[0] == sizes[-1]
-    start_indices = _xla_shard_start_indices(c, dims[0], len(dims))
-    return c.Reshape(c.DynamicSlice(x, start_indices, [1] + dims[1:]),
-                     None, dims[1:])
-
-  return _xla_shard(c.GetShape(x), x)
-
-# TODO(mattjj): plumb more ergonimic form of DynamicSlice / DynamicUpdateSlice
-def _xla_shard_start_indices(c, axis_size, ndim):
-  idx = c.Rem(c.ReplicaId(), c.Constant(onp.array(axis_size, onp.uint32)))
-  zero = onp.zeros(ndim - 1, onp.uint32)
-  return c.Concatenate([c.Reshape(idx, None, [1]), c.Constant(zero)], 0)
-
-# TODO(b/110096942): more efficient gather
-def xla_unshard(c, replica_groups, x):
-  """Analog of unshard_output that un-shards within an XLA computation."""
-
-  def _xla_unshard(shape, x):
-    if shape.is_tuple():
-      elts = map(_xla_unshard, shape.tuple_shapes(), xla_destructure(c, x))
-      return c.Tuple(*elts)
-    else:
-      return unshard_array(shape, x)
-
-  def unshard_array(shape, x):
-    axis_size = len(replica_groups[0])
-    dims = list(shape.dimensions())
-    start_indices = _xla_shard_start_indices(c, axis_size, len(dims) + 1)
-    padded = c.Broadcast(c.Constant(onp.array(0, shape.numpy_dtype())),
-                         [axis_size] + dims)
-    padded = c.DynamicUpdateSlice(padded, c.Reshape(x, None, [1] + dims),
-                                  start_indices)
-    return c.CrossReplicaSum(padded, replica_groups)
-
-  return _xla_unshard(c.GetShape(x), x)
-
 
 ### the main pmap machinery lowers SPMD jaxprs to multi-replica XLA computations
 
-class PmapPrimitive(core.Primitive): pass
-
-AxisEnv = namedtuple("AxisEnv", ["nreps", "names", "sizes"])
-
-def axis_read(axis_env, axis_name):
-  return max(i for i, name in enumerate(axis_env.names) if name == axis_name)
-
-def axis_groups(axis_env, name):
-  if isinstance(name, (list, tuple)):
-    mesh_axes = tuple(map(partial(axis_read, axis_env), name))
-  else:
-    mesh_axes = (axis_read(axis_env, name),)
-  return replica_groups(axis_env.nreps, axis_env.sizes, mesh_axes)
-
 def compile_replicated(jaxpr, axis_name, axis_size, consts, *abstract_args):
-  num_replicas = axis_size * jaxpr_replicas(jaxpr)
+  num_replicas = axis_size * xla.jaxpr_replicas(jaxpr)
   if num_replicas > xb.device_count():
-    msg = ("compiling pmap computation that requires {} replicas, but only {} "
-           "XLA devices are available")
+    msg = ("compiling computation that requires {} replicas, but only {} XLA "
+           "devices are available")
     raise ValueError(msg.format(num_replicas, xb.device_count()))
-  axis_env = AxisEnv(num_replicas, [axis_name], [axis_size])
+  axis_env = xla.AxisEnv(num_replicas, [axis_name], [axis_size])
   arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = replicated_comp(jaxpr, axis_env, consts, (), *arg_shapes)
+  built_c = xla._jaxpr_computation(jaxpr, axis_env, consts, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
   compiled = built_c.Compile(arg_shapes, xb.get_compile_options(num_replicas),
                              backend=xb.get_backend())
   return compiled, num_replicas, result_shape
 
-def jaxpr_replicas(jaxpr):
-  return _max(eqn.params['axis_size'] * jaxpr_replicas(eqn.bound_subjaxprs[0][0])
-              for eqn in jaxpr.eqns if eqn.primitive is xla_pmap_p)
-def _max(itr): return max(list(itr) or [1])
-
-def replicated_comp(jaxpr, ax_env, const_vals, freevar_shapes, *arg_shapes):
-  assert not any(type(invar) in (tuple, list) for invar in jaxpr.invars)
-  c = xb.make_computation_builder("replicated_computation")
-
-  def read(v):
-    if type(v) is core.Literal:
-      return c.Constant(v.val)
-    else:
-      return env[v]
-
-  def write(v, node):
-    assert node is not None
-    env[v] = node
-
-  def axis_env_extend(name, size):
-    return AxisEnv(ax_env.nreps, ax_env.names + [name], ax_env.sizes + [size])
-
-  env = {}
-  write(core.unitvar, c.Tuple())
-  if const_vals:
-    for val in const_vals:
-      if isinstance(val, xla.DeviceArray):
-        val.copy_to_host_async()
-    _map(write, jaxpr.constvars, map(c.Constant, const_vals))
-    _map(write, jaxpr.freevars, map(c.ParameterWithShape, freevar_shapes))
-  else:
-    all_freevars = it.chain(jaxpr.constvars, jaxpr.freevars)
-    _map(write, all_freevars, map(c.ParameterWithShape, freevar_shapes))
-  _map(write, jaxpr.invars, map(c.ParameterWithShape, arg_shapes))
-  xla._prefetch_jaxpr_literals(jaxpr)
-  for eqn in jaxpr.eqns:
-    if not eqn.restructure:
-      in_nodes = list(map(read, eqn.invars))
-    else:
-      in_nodes = [xla.xla_pack(c, map(read, invars)) if type(invars) is tuple
-                  else read(invars) for invars in eqn.invars]
-    if type(eqn.primitive) is PmapPrimitive:
-      name = eqn.params['axis_name']
-      params = {k: eqn.params[k] for k in eqn.params if k != 'axis_name'}
-      try:
-        rule = parallel_translation_rules[eqn.primitive]
-      except KeyError:
-        msg = 'XLA translation rule for parallel primitive {} not implemented.'
-        raise NotImplementedError(msg.format(eqn.primitive.name))
-      ans = rule(c, *in_nodes, replica_groups=axis_groups(ax_env, name), **params)
-    elif eqn.bound_subjaxprs:
-      if eqn.primitive is xla_pmap_p:
-        name, size = eqn.params['axis_name'], eqn.params['axis_size']
-        new_env = axis_env_extend(name, size)
-        in_shards = tuple(map(partial(xla_shard, c, new_env.sizes), in_nodes))
-        (subjaxpr, const_bindings, freevar_bindings), = eqn.bound_subjaxprs
-        subc = replicated_comp(
-            subjaxpr, new_env, (),
-            tuple(map(c.GetShape, map(read, const_bindings + freevar_bindings))),
-            *map(c.GetShape, in_shards))
-        subfun = (subc, tuple(map(read, const_bindings + freevar_bindings)))
-        sharded_result = xla.xla_call_translation_rule(c, subfun, *in_shards)
-        ans = xla_unshard(c, axis_groups(new_env, name), sharded_result)
-      else:
-        subcs = [
-            jaxpr_computation(
-                subjaxpr, (),
-                tuple(map(c.GetShape, map(read, const_bindings + freevar_bindings))),
-                *map(c.GetShape, in_nodes))
-            for subjaxpr, const_bindings, freevar_bindings in eqn.bound_subjaxprs]
-        subfuns = [(subc, tuple(map(read, const_bindings + freevar_bindings)))
-                    for subc, (_, const_bindings, freevar_bindings)
-                    in zip(subcs, eqn.bound_subjaxprs)]
-        ans = translation_rule(eqn.primitive)(c, *(subfuns + in_nodes), **eqn.params)
-    else:
-      ans = translation_rule(eqn.primitive)(c, *in_nodes, **eqn.params)
-
-    out_nodes = xla_destructure(c, ans) if eqn.destructure else [ans]
-    _map(write, eqn.outvars, out_nodes)
-  return c.Build(read(jaxpr.outvar))
-
-def _map(f, *xs):
-  return tuple(map(f, *xs))
-
-parallel_translation_rules = {}
-
 
 ### applying parallel primitives in op-by-op Python dispatch
 
 # There are at least two cases where we might want to evaluate a parallel
-# primitive dispatched from Python, rather than being part of a staged-out pmap
-# computation and handled by replicated_comp above:
+# primitive dispatched from Python, rather than being staged out:
 #   1. axis_size = psum(1, 'axis_name'),
 #   2. to enable an implicit outermost pmap-like context for multi-host
 #      multi-controller SPMD programs.
@@ -654,10 +550,19 @@ xla_pmap_p = core.Primitive('xla_pmap')
 xla_pmap = partial(core.call_bind, xla_pmap_p)
 xla_pmap_p.def_custom_bind(xla_pmap)
 xla_pmap_p.def_impl(xla_pmap_impl)
+
+def _xla_pmap_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
+                               axis_name, axis_size):
+  new_env = xla.extend_axis_env(axis_env, axis_name, axis_size)
+  in_nodes_sharded = list(map(partial(xla_shard, c, new_env.sizes), in_nodes))
+  subc = xla._jaxpr_computation(jaxpr, new_env, (),
+                                tuple(map(c.GetShape, env_nodes)),
+                                *map(c.GetShape, in_nodes_sharded))
+  sharded_result = c.Call(subc, env_nodes + in_nodes_sharded)
+  return xla_unshard(c, xla.axis_groups(new_env, axis_name), sharded_result)
+xla.call_translations[xla_pmap_p] = _xla_pmap_translation_rule
 ad.primitive_transposes[xla_pmap_p] = partial(ad.map_transpose, xla_pmap_p)
 pe.map_primitives.add(xla_pmap_p)
-# TODO(mattjj): enable pjit inside jit, maybe by merging xla_pmap and xla_call
-# xla.translations[xla_pmap_p] = xla.xla_call_translation_rule
 
 
 ### soft_pmap axis split transformation
@@ -758,7 +663,7 @@ class SplitAxisTrace(core.Trace):
       return primitive.bind(*vals_in, **params)
     else:
       name, = set(n for n in names_in if n is not not_mapped)
-      if type(primitive) is PmapPrimitive:
+      if primitive in xla.parallel_translations:
         # if it's a pmap collective primitive, do something special
         if name == params['axis_name']:
           # if the name matches this tracer's name, apply the split_axis rule

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -63,12 +63,26 @@ def _xla_primitive_callable(prim, *abstract_args, **params):
                              backend=xb.get_backend())
   return partial(_execute_compiled_primitive, prim.name, compiled, handle_result)
 
+def xla_shape(x):
+  try:
+    return xb.Shape.array_shape(x.dtype, x.shape)
+  except AttributeError:
+    if type(x) in (core.AbstractTuple, core.JaxTuple):
+      return xb.Shape.tuple_shape(tuple(map(xla_shape, x)))
+    else:
+      raise TypeError(type(x))
+
 @memoize
 def primitive_computation(prim, *shapes, **params):
   """Builds an XLA computation for `prim` with argument `shapes`."""
   c = xb.make_computation_builder("primitive_computation")
+  platform = xb.get_backend().platform
   xla_args = map(c.ParameterWithShape, shapes)
-  xla_result = translation_rule(prim)(c, *xla_args, **params)
+  try:
+    rule = backend_specific_translations[platform].get(prim) or translations[prim]
+  except KeyError:
+    raise NotImplementedError("XLA translation rule for {} not found".format(prim))
+  rule(c, *xla_args, **params)  # side-effect on c
   try:
     return c.Build()
   except RuntimeError as e:
@@ -202,16 +216,20 @@ def _pyval_result_handler(result_shape):
     return _tuple_to_jaxtuple(buf.to_py())
   return f
 
-def _compile_jaxpr(jaxpr, const_vals, *abstract_args):
+def _compile_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
+  if axis_env.nreps > xb.device_count():
+    msg = ("compiling computation that requires {} replicas, but only {} XLA "
+           "devices are available")
+    raise ValueErrr(msg.format(axis_env.nreps, xb.device_count()))
   arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = jaxpr_computation(jaxpr, const_vals, (), *arg_shapes)
+  built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
-  return built_c.Compile(arg_shapes, xb.get_compile_options(),
+  return built_c.Compile(arg_shapes, xb.get_compile_options(axis_env.nreps),
                          backend=xb.get_backend()), result_shape
 
-def build_jaxpr(jaxpr, const_vals, *abstract_args):
+def build_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = jaxpr_computation(jaxpr, const_vals, (), *arg_shapes)
+  built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
   return built_c
 
 
@@ -227,8 +245,13 @@ def _prefetch_jaxpr_literals(jaxpr):
 
 
 def jaxpr_computation(jaxpr, const_vals, freevar_shapes, *arg_shapes):
+  axis_env = AxisEnv(1, [], [])
+  return _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
+
+def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes):
   assert not any(type(invar) in (tuple, list) for invar in jaxpr.invars)
   c = xb.make_computation_builder("jaxpr_computation")
+  platform = xb.get_backend().platform
 
   def read(v):
     if type(v) is Literal:
@@ -259,17 +282,29 @@ def jaxpr_computation(jaxpr, const_vals, freevar_shapes, *arg_shapes):
     else:
       in_nodes = [xla_pack(c, map(read, invars)) if type(invars) is tuple
                   else read(invars) for invars in eqn.invars]
-    in_shapes = _map(c.GetShape, in_nodes)
-    subcs = [
-        jaxpr_computation(
-            subjaxpr, (),
-            _map(c.GetShape, map(read, const_bindings + freevar_bindings)),
-            *in_shapes)
-        for subjaxpr, const_bindings, freevar_bindings in eqn.bound_subjaxprs]
-    subfuns = [(subc, _map(read, const_bindings + freevar_bindings))
-               for subc, (_, const_bindings, freevar_bindings)
-               in zip(subcs, eqn.bound_subjaxprs)]
-    ans = translation_rule(eqn.primitive)(c, *(subfuns + in_nodes), **eqn.params)
+
+    if eqn.primitive in backend_specific_translations[platform]:
+      rule = backend_specific_translations[platform][eqn.primitive]
+      ans = rule(c, *in_nodes, **eqn.params)
+    elif eqn.primitive in translations:
+      ans = translations[eqn.primitive](c, *in_nodes, **eqn.params)
+    elif eqn.primitive in initial_style_translations:
+      rule = initial_style_translations[eqn.primitive]
+      ans = rule(c, axis_env, *in_nodes, **eqn.params)
+    elif eqn.primitive in parallel_translations:
+      replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
+      new_params = {k: eqn.params[k] for k in eqn.params if k != 'axis_name'}
+      rule = parallel_translations[eqn.primitive]
+      ans = rule(c, *in_nodes, replica_groups=replica_groups, **new_params)
+    elif eqn.primitive in call_translations:
+      (subjaxpr, const_bindings, freevar_bindings), = eqn.bound_subjaxprs
+      env_nodes = list(map(read, const_bindings + freevar_bindings))
+      rule = call_translations[eqn.primitive]
+      ans = rule(c, subjaxpr, axis_env, env_nodes, in_nodes, **eqn.params)
+    else:
+      msg = "XLA translation rule for primitive '{}' not found"
+      raise NotImplementedError(msg.format(eqn.primitive.name))
+
     c.GetShape(ans)  # force xla to do shape error checking
     out_nodes = xla_destructure(c, ans) if eqn.destructure else [ans]
     _map(write, eqn.outvars, out_nodes)
@@ -289,34 +324,65 @@ def _tuple_constant(c, val, canonicalize_types=True):
   return c.Tuple(*map(c.Constant, val))
 xb.register_constant_handler(JaxTuple, _tuple_constant)
 
-def translation_rule(p):
-  backend = xb.get_backend()
-  backend_specific_rule = backend_specific_translations[backend.platform].get(p)
-  try:
-    return backend_specific_rule or translations[p]
-  except KeyError:
-    raise NotImplementedError(
-        "XLA translation rule for '{}' not implemented".format(p))
+AxisEnv = namedtuple("AxisEnv", ["nreps", "names", "sizes"])
+
+def extend_axis_env(env, name, size):
+  return AxisEnv(env.nreps, env.names + [name], env.sizes + [size])
+
+def axis_read(axis_env, axis_name):
+  return max(i for i, name in enumerate(axis_env.names) if name == axis_name)
+
+def axis_groups(axis_env, name):
+  if isinstance(name, (list, tuple)):
+    mesh_axes = tuple(map(partial(axis_read, axis_env), name))
+  else:
+    mesh_axes = (axis_read(axis_env, name),)
+  return _axis_groups(axis_env.nreps, axis_env.sizes, mesh_axes)
+
+def _axis_groups(nrep, mesh_spec, mesh_axes):
+  trailing_size, ragged = divmod(nrep, prod(mesh_spec))
+  assert not ragged
+  full_spec = list(mesh_spec) + [trailing_size]
+  iota = onp.arange(prod(full_spec)).reshape(full_spec)
+  groups = onp.reshape(
+      onp.moveaxis(iota, mesh_axes, onp.arange(len(mesh_axes))),
+      (prod(onp.take(full_spec, mesh_axes)), -1))
+  return tuple(map(tuple, groups.T))
+
+def jaxpr_replicas(jaxpr):
+  nums = (eqn_replicas(eqn) for eqn in jaxpr.eqns if eqn.bound_subjaxprs)
+  return max(it.chain([1], nums))  # max(itr, default=1)
+
+def eqn_replicas(eqn):
+  (subjaxpr, _, _), = eqn.bound_subjaxprs
+  return eqn.params.get('axis_size', 1) * jaxpr_replicas(subjaxpr)
 
 
-def lower_fun(fun, instantiate=False):
+def lower_fun(fun, instantiate=False, initial_style=False):
   """Lowers a traceable function to an XLA function.
 
   Useful for implementing translation rules for primitives in terms of the
   higher-level lax or NumPy APIs.
   """
-  def f(c, *xla_args, **params):
+  def f(c, *args, **params):
+    if initial_style:
+      axis_env, xla_args = args[0], args[1:]
+    else:
+      axis_env, xla_args = AxisEnv(1, [], []), args
     xla_shapes = tuple(map(c.GetShape, xla_args))
     avals = map(_aval_from_xla_shape, xla_shapes)
     pvals = [pe.PartialVal((a, core.unit)) for a in avals]
     jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(fun, pvals, instantiate,
                                                    **params)
-    built_c = jaxpr_computation(jaxpr, consts, (), *xla_shapes)
+    built_c = _jaxpr_computation(jaxpr, axis_env, consts, (), *xla_shapes)
     return c.Call(built_c, xla_args)
   return f
 
 
 translations = {}
+parallel_translations = {}
+initial_style_translations = {}
+call_translations = {}
 backend_specific_translations = defaultdict(dict)
 
 translations[core.pack_p] = lambda c, *xs: c.Tuple(*xs)
@@ -602,16 +668,6 @@ def _instantiate_device_constant(const, cutoff=1e6, device_num=0):
     return xb.device_put(onp.asarray(const), device_num)
 
 
-def xla_shape(x):
-  try:
-    return xb.Shape.array_shape(x.dtype, x.shape)
-  except AttributeError:
-    if type(x) in (core.AbstractTuple, core.JaxTuple):
-      return xb.Shape.tuple_shape(tuple(map(xla_shape, x)))
-    else:
-      raise TypeError(type(x))
-
-
 def _xla_call_impl(fun, *args, **params):
   device_values = FLAGS.jax_device_values and params.pop('device_values')
   compiled_fun = _xla_callable(fun, device_values, *map(abstractify, args))
@@ -622,20 +678,23 @@ def _xla_call_impl(fun, *args, **params):
           "Calling the de-optimized version.")
     return fun.call_wrapped(*args)  # probably won't return
 
-
 @lu.memoize
 def _xla_callable(fun, device_values, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
     jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here (though cond might eventually need them)
-    compiled, result_shape = _compile_jaxpr(jaxpr, consts, *abstract_args)
+    axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
+    compiled, result_shape = _compile_jaxpr(jaxpr, axis_env, consts, *abstract_args)
     del master, consts, jaxpr, env
   if device_values:
     handle_result = _device_persistent_result_handler(result_shape)
   else:
     handle_result = _pyval_result_handler(result_shape)
-  return partial(_execute_compiled, compiled, pval, handle_result)
+  if axis_env.nreps == 1:
+    return partial(_execute_compiled, compiled, pval, handle_result)
+  else:
+    return partial(_execute_replicated, compiled, pval, handle_result)
 
 def _execute_compiled(compiled, pval, handle_result, *args):
   input_bufs = [device_put(x) for x in args]
@@ -643,17 +702,25 @@ def _execute_compiled(compiled, pval, handle_result, *args):
   check_nans("jit-compiled computation", out_buf)
   return pe.merge_pvals(handle_result(out_buf), pval)
 
+def _execute_replicated(compiled, pval, handle_result, *args):
+  input_bufs = [[device_put(x, i) for x in args] for i in compiled.DeviceOrdinals()]
+  out_buf = compiled.ExecutePerReplica(input_bufs)[0]
+  check_nans("jit-compiled computation", out_buf)
+  return pe.merge_pvals(handle_result(out_buf), pval)
 
-def xla_call_translation_rule(c, subc_a1, *a2, **params):
-  subc, a1 = subc_a1
-  return c.Call(subc, a1 + a2)
 
 xla_call_p = core.Primitive('xla_call')
 xla_call = partial(core.call_bind, xla_call_p)
 xla_call_p.def_custom_bind(xla_call)
 xla_call_p.def_impl(_xla_call_impl)
 
-translations[xla_call_p] = xla_call_translation_rule
+def _xla_call_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
+                               device_values):
+  del device_values  # Unused.
+  subc = _jaxpr_computation(jaxpr, axis_env, (), _map(c.GetShape, env_nodes),
+                            *map(c.GetShape, in_nodes))
+  return c.Call(subc, env_nodes + in_nodes)
+call_translations[xla_call_p] = _xla_call_translation_rule
 ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
 
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -24,6 +24,7 @@ from six.moves import xrange
 
 import numpy as onp
 
+from jax import core
 from jax import ad_util
 from jax.lax import lax
 from jax.abstract_arrays import ShapedArray
@@ -179,7 +180,7 @@ def pcollect(x, axis_name):
 ### parallel primitives
 
 def standard_pmap_primitive(name):
-  prim = pxla.PmapPrimitive(name)
+  prim = core.Primitive(name)
   prim.def_impl(partial(pxla.apply_parallel_primitive, prim))
   prim.def_abstract_eval(lambda x, *args, **params: x)
   return prim
@@ -199,21 +200,21 @@ def _allreduce_translation_rule(prim, c, val, replica_groups):
 psum_p = standard_pmap_primitive('psum')
 pxla.split_axis_rules[psum_p] = \
     partial(_allreduce_split_axis_rule, psum_p, lax._reduce_sum)
-pxla.parallel_translation_rules[psum_p] = \
+xla.parallel_translations[psum_p] = \
     partial(_allreduce_translation_rule, lax.add_p)
 pxla.parallel_pure_rules[psum_p] = lambda x, shape: x * prod(shape)
 ad.deflinear(psum_p, lambda t, axis_name: [t])
 
 
 pmax_p = standard_pmap_primitive('pmax')
-pxla.parallel_translation_rules[pmax_p] = \
+xla.parallel_translations[pmax_p] = \
     partial(_allreduce_translation_rule, lax.max_p)
 pxla.split_axis_rules[pmax_p] = \
     partial(_allreduce_split_axis_rule, pmax_p, lax._reduce_max)
 
 
 pmin_p = standard_pmap_primitive('pmin')
-pxla.parallel_translation_rules[pmin_p] = \
+xla.parallel_translations[pmin_p] = \
     partial(_allreduce_translation_rule, lax.min_p)
 pxla.split_axis_rules[pmin_p] = \
     partial(_allreduce_split_axis_rule, pmin_p, lax._reduce_min)
@@ -239,7 +240,7 @@ def _ppermute_transpose_rule(t, perm, axis_name):
 
 ppermute_p = standard_pmap_primitive('ppermute')
 ad.deflinear(ppermute_p, _ppermute_transpose_rule)
-pxla.parallel_translation_rules[ppermute_p] = _ppermute_translation_rule
+xla.parallel_translations[ppermute_p] = _ppermute_translation_rule
 
 
 def _all_to_all_translation_rule(c, x, split_axis, concat_axis, replica_groups):
@@ -263,7 +264,7 @@ def _moveaxis(src, dst, x):
   return lax.transpose(x, perm)
 
 all_to_all_p = standard_pmap_primitive('all_to_all')
-pxla.parallel_translation_rules[all_to_all_p] = _all_to_all_translation_rule
+xla.parallel_translations[all_to_all_p] = _all_to_all_translation_rule
 pxla.split_axis_rules[all_to_all_p] = _all_to_all_split_axis_rule
 
 


### PR DESCRIPTION
This change is essentially de-duplicating the XLA lowering logic between xla.py and pxla.py. Only the latter was capable of handling collectives (aka pmap primitives), which meant that these didn't work:

1. some compositions of jit and pmap, like jit-of-pmap
2. collectives inside initial-style control flow like scan
3. jax.xla_computation on a function involving collectives

By merging the logic into xla.py, now all the lowering machinery works with everything. Woo!

The pxla.py file still exists and contains mostly dynamic/runtime components for pmap and functions used only by pmap and collectives translations. In particular, pxla.py has

* the pmap impl, particularly the dispatching logic for top-level pmaps, including argument sharding and lazy sharded result persistence
* the ShardedDeviceArray / ShardedDeviceTuple classes
* the dynamic (trace-time) axis environment data structures and logic and the special axis_index primitive
* the split-axis transformation for soft_pmap
* PmapPrimitive (just a tagged version of Primitive)
* the static sharding/unsharding logic for pmap-inside-jit/pmap

These things moved over to xla.py:

* the logic for lowering pmap primitives, especially the static axis environment used during xla lowering

This change refactors the translation rule tables a bit. Instead of just having two tables, there are now five, and they contain rules with slightly different type signatures:
* the `translations` table has rules with the same signatures as always, i.e. `CompBuilder -> [XlaOperand] -> ParamsDict -> XlaOperandOut`
* the `backend_specific_translations` table is keyed by platform name strings and has dict values that each have the same type as `translations`
* the `parallel_translations` table is used for primitives modeling parallel collectives, and so it has rules with signature `CompBuilder -> [XlaOperand] -> ReplicaGroups -> ParamsDict -> XlaOpOut`
* the `initial_style_translations` table is for the initial-style control flow primitives (like `scan`), for which the translation rules themselves lower jaxprs to XLA computations and thus require the static axis env to be passed in; the rules there have signature `CompBuilder -> AxisEnv -> [XlaOperand] -> ParamsDict -> XlaOpOut`
* the `call_translations` table is used for `xla_call` and `xla_pmap`, i.e. the primitives underlying `jit` and `pmap` respectively, and has rules with signature `CompBuilder -> Jaxpr -> AxisEnv -> [XlaOp] -> [XlaOp] -> ParamsDict -> XlaOp`

Having these as separate tables is an uninteresting implementation detail. The lowering function `_jaxpr_computation` just does a case analysis on whether the primitive being translated has an entry in any table (where the `backend_specific_translations` table must be checked before the `translations` table, since some primitives may be entered in both).

This change fixes #804 also addresses #852, in that the lax control flow impls for those primitives are now based on Python-level jaxpr interpreters rather than XLA compilation, but we should probably wait to close the latter issue until we benchmark and improve things more. This change at least seems not to be a performance regression: on my machine the lax control flow tests go from running in ~20s to running in ~14s.

This change also adds a docstring for `jax.xla_computation` and some basic tests.