### PR TITLE
enable soft_pmap device persistence

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -82,7 +82,7 @@ def primitive_computation(prim, *shapes, **params):
     rule = backend_specific_translations[platform].get(prim) or translations[prim]
   except KeyError:
     raise NotImplementedError("XLA translation rule for {} not found".format(prim))
-  rule(c, *xla_args, **params)  # side-effect on c
+  rule(c, *xla_args, **params)  # return val set as a side-effect on c
   try:
     return c.Build()
   except RuntimeError as e:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -644,7 +644,7 @@ def isrealobj(a):
 @_wraps(onp.reshape)
 def reshape(a, newshape, order="C"):
   try:
-    return a.reshape(newshape, order=order)
+    return a.reshape(newshape, order=order)  # forward to method for ndarrays
   except AttributeError:
     return _reshape(a, newshape, order=order)
 


### PR DESCRIPTION
Previously soft_pmap didn't allow for sharded device persistence because it performs reshapes on the input and output of the underlying pmap computation corrseponding to splitting out and merging together the hardware-mapped and software-mapped axes, resepectively. These reshapes forced the ShardedDeviceArray produced by the pmap computation to be collected into a (single-device-backed) DeviceArray.

The approach in this commit is to make the lax.reshape impl smarter about ShardedDeviceArrays so that axis-merging logical reshapes don't force collection (i.e. don't force re-layout). Instead they now produce a new ShardedDeviceArray subclass called a ChunkedDeviceArray, which represents the same logical reshape result but without data movement.

One way to think about the key difference between ShardedDeviceArray and ChunkedDeviceArray is that when forced the former collects its shards together using onp.stack while the latter collects its shards with onp.concatenate. The leading letter of each name is meant to remind us of that difference (s for stack, c for concatenate). Another way to think about it is that for ShardedDeviceArray the distributed logical axis is fully mapped (i.e. isn't identified with any axis on the underlying buffers) while for ChunkedDeviceArray the distributed logical axis is identified with the leading axis of the underlying buffers.

ChunkedDeviceArrays can be turned back into ShardedDeviceArrays under particular reshapes, namely reshapes that split the hardware-mapped axis back out into the leading dimension. This way a sequence of soft_pmapped computations can maintain device persistence (i.e. not force collection). Every other operation forces collcetion, just like it does for ShardedDeviceArrays.