### PR TITLE
Added support for creating arrays via the buffer interface

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1382,6 +1382,13 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     if dtype and _dtype(out) != xla_bridge.canonicalize_dtype(dtype):
       out = lax.convert_element_type(out, dtype)
   else:
+    try:
+      view = memoryview(object)
+    except TypeError:
+      pass  # `object` does not support the buffer interface.
+    else:
+      return array(onp.asarray(view), dtype, copy)
+
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
   if ndmin > ndim(out):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1115,6 +1115,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     ans = lnp.array(a)
     assert ans == 3.
 
+  def testMemoryview(self):
+    ans = lnp.array(bytearray(b'\x2a'))
+    self.assertAllClose(
+        ans,
+        onp.array([0x2a], dtype=onp.uint8),
+        check_dtypes=True)
+
   def testAllClose(self):
     rng = onp.random.RandomState(0)
     x = rng.randn(2, 2)


### PR DESCRIPTION
This allows to call `jax.numpy.array` on objects which do not expose
the `__array__` attribute, but can be viewed as an array through
`memoryview`.