### PR TITLE
Add regression tests for fast math issues.

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1644,6 +1644,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(onp.zeros(3,), api.grad(f)(onp.ones(3,)),
                         check_dtypes=True)
 
+  # TODO(phawkins): enable test after Jaxlib 0.1.22 is released.
+  @unittest.skip("Requires Jaxlib >= 0.1.22.")
+  def testIssue777(self):
+    x = lnp.linspace(-200, 0, 4, dtype=onp.float32)
+    f = api.grad(lambda x: lnp.sum(1 / (1 + lnp.exp(-x))))
+    self.assertAllClose(f(x), onp.array([0., 0., 0., 0.25], dtype=onp.float32),
+                        check_dtypes=True)
+
   @parameterized.named_parameters(
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(op, [()], [dtype]),

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import collections
 import functools
 import itertools
-from unittest import SkipTest
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -120,6 +120,13 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
     if test_autodiff:
       jtu.check_grads(lax_op, args, order=1, atol=1e-3, rtol=3e-3, eps=1e-3)
+
+  # TODO(phawkins): enable test after Jaxlib 0.1.22 is released.
+  @unittest.skip("Requires Jaxlib >= 0.1.22.")
+  def testIssue980(self):
+    x = onp.full((4,), -1e20, dtype=onp.float32)
+    self.assertAllClose(onp.zeros((4,), dtype=onp.float32),
+                        lsp_special.expit(x), check_dtypes=True)
 
 
 if __name__ == "__main__":

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import collections
 import itertools
+import unittest
 
 from absl.testing import absltest, parameterized
 
@@ -281,6 +282,15 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
+
+  # TODO(phawkins): enable test after Jaxlib 0.1.22 is released.
+  @unittest.skip("Requires Jaxlib >= 0.1.22.")
+  def testIssue972(self):
+    self.assertAllClose(
+      onp.ones((4,), onp.float32),
+      lsp_stats.norm.cdf(onp.full((4,), onp.inf, onp.float32)),
+      check_dtypes=False)
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
These tests are disabled until we release Jaxlib 0.1.22.

Issues: #777, #980, #972 