### PR TITLE
Add jit internally to a few slow routines in scatter_ops and linalg.

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import numpy as onp
 import warnings
 
+from jax import jit
 from .. import lax
 from .. import lax_linalg
 from .lax_numpy import _not_implemented
@@ -222,6 +223,7 @@ def qr(a, mode="reduced"):
   return q, r
 
 
+@jit
 @_wraps(onp.linalg.solve)
 def solve(a, b):
   a, b = _promote_arg_dtypes(np.asarray(a), np.asarray(b))

--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import numpy as onp
 
+from jax import jit
 from ..abstract_arrays import ShapedArray, ConcreteArray
 from .. import core
 from .. import lax
@@ -263,6 +264,7 @@ def index_add(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter_add)
 
+@jit
 def index_min(x, idx, y):
   """Pure equivalent of :code:`x[idx] = minimum(x[idx], y)`.
 
@@ -299,6 +301,7 @@ def index_min(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter_min)
 
+@jit
 def index_max(x, idx, y):
   """Pure equivalent of :code:`x[idx] = maximum(x[idx], y)`.
 
@@ -335,6 +338,7 @@ def index_max(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter_max)
 
+@jit
 def index_update(x, idx, y):
   """Pure equivalent of :code:`x[idx] = y`.
 


### PR DESCRIPTION
This makes these operations *much* faster when run outside of a jit context.