### PR TITLE
Add `block_until_ready` to quickstart colab for accurate timing.

### DIFF
--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -18,11 +18,11 @@
   },
   "cells": [
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "logZcM_HEnve",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "##### Copyright 2018 Google LLC.\n",
         "\n",
@@ -30,11 +30,11 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "QwN47xiBEsKz",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "you may not use this file except in compliance with the License.\n",
@@ -50,11 +50,11 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "xtWX4x9DCF5_"
       },
-      "cell_type": "markdown",
       "source": [
         "# JAX Quickstart\n",
         "Dougal Maclaurin, Peter Hawkins, Matthew Johnson, Roy Frostig, Alex Wiltschko, Chris Leary\n",
@@ -82,12 +82,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "PaW85yP_BrCF",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "!pip install --upgrade -q https://storage.googleapis.com/jax-wheels/cuda$(echo $CUDA_VERSION | sed -e 's/\\.//' -e 's/\\..*//')/jaxlib-0.1.21-cp36-none-linux_x86_64.whl\n",
         "!pip install --upgrade -q jax"
@@ -96,12 +96,12 @@
       "outputs": []
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "SY8mDvEvCGqk",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "from __future__ import print_function, division\n",
         "import jax.numpy as np\n",
@@ -112,32 +112,32 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "FQ89jHCYfhpg"
       },
-      "cell_type": "markdown",
       "source": [
         "### Multiplying Matrices"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Xpy1dSgNqCP4"
       },
-      "cell_type": "markdown",
       "source": [
         "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the readme."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "u0nseKZNqOoH",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "key = random.PRNGKey(0)\n",
         "x = random.normal(key, (10,))\n",
@@ -147,109 +147,109 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "hDJF0UPKnuqB"
       },
-      "cell_type": "markdown",
       "source": [
         "Let's dive right in and multiply two big matrices."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "eXn8GUl6CG5N",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "size = 3000\n",
         "x = random.normal(key, (size, size), dtype=np.float32)\n",
-        "%timeit np.dot(x, x.T)  # runs on the GPU"
+        "%timeit np.dot(x, x.T).block_until_ready()  # runs on the GPU"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "0AlN7EbonyaR"
       },
-      "cell_type": "markdown",
       "source": [
         "JAX NumPy functions work on regular NumPy arrays."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "ZPl0MuwYrM7t",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "import numpy as onp  # original CPU-backed NumPy\n",
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
-        "%timeit np.dot(x, x.T)"
+        "%timeit np.dot(x, x.T).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "_SrcB2IurUuE"
       },
-      "cell_type": "markdown",
       "source": [
         "That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using `device_put`."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "Jj7M7zyRskF0",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "from jax import device_put\n",
         "\n",
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
         "x = device_put(x)\n",
-        "%timeit np.dot(x, x.T)"
+        "%timeit np.dot(x, x.T).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "clO9djnen8qi"
       },
-      "cell_type": "markdown",
       "source": [
         "The output of `device_put` still acts like an NDArray. By the way, the [implementation](https://github.com/google/jax/blob/c8f93511ecb977d02fa5b0eee17075706fd6fd93/jax/api.py#L162) of `device_put` is just `device_put = jit(lambda x: x)`."
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "ghkfKNQttDpg"
       },
-      "cell_type": "markdown",
       "source": [
         "If you have a GPU (or TPU!) these calls run on the accelerator and have the potential to be much faster than on CPU."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "RzXK8GnIs7VV",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
         "%timeit onp.dot(x, x.T)"
@@ -258,11 +258,11 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "iOzp0P_GoJhb"
       },
-      "cell_type": "markdown",
       "source": [
         "JAX is much more than just a GPU-backed NumPy. It also comes with a few program transformations that are useful when writing numerical code. For now, there's three main ones:\n",
         "\n",
@@ -274,72 +274,72 @@
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "bTTrTbWvgLUK"
       },
-      "cell_type": "markdown",
       "source": [
         "### Using `jit` to speed up functions"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "YrqE32mvE3b7"
       },
-      "cell_type": "markdown",
       "source": [
         "JAX runs transparently on the GPU (or CPU, if you don't have one, and TPU coming soon!). However, in the above example, JAX is dispatching kernels to the GPU one operation at a time. If we have a sequence of operations, we can use the `@jit` decorator to compile multiple operations together using [XLA](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/g3doc/overview.md). Let's try that."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "qLGdCtFKFLOR",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "def selu(x, alpha=1.67, lmbda=1.05):\n",
         "  return lmbda * np.where(x > 0, x, alpha * np.exp(x) - alpha)\n",
         "\n",
         "x = random.normal(key, (1000000,))\n",
-        "%timeit selu(x)"
+        "%timeit selu(x).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "a_V8SruVHrD_"
       },
-      "cell_type": "markdown",
       "source": [
         "We can speed it up with `@jit`, which will jit-compile the first time `selu` is called and will be cached thereafter."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "fh4w_3NpFYTp",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "selu_jit = jit(selu)\n",
-        "%timeit selu_jit(x)"
+        "%timeit selu_jit(x).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "HxpBc4WmfsEU"
       },
-      "cell_type": "markdown",
       "source": [
         "### Taking derivatives with `grad`\n",
         "\n",
@@ -347,12 +347,12 @@
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "IMAgNJaMJwPD",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "def sum_logistic(x):\n",
         "  return np.sum(1.0 / (1.0 + np.exp(-x)))\n",
@@ -365,22 +365,22 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "PtNs881Ohioc"
       },
-      "cell_type": "markdown",
       "source": [
         "Let's verify with finite differences that our result is correct."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "JXI7_OZuKZVO",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "def first_finite_differences(f, x):\n",
         "  eps = 1e-3\n",
@@ -394,22 +394,22 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "Q2CUZjOWNZ-3"
       },
-      "cell_type": "markdown",
       "source": [
         "Taking derivatives is as easy as calling `grad`. `grad` and `jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:"
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "TO4g8ny-OEi4",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "print(grad(jit(grad(jit(grad(sum_logistic)))))(1.0))"
       ],
@@ -417,22 +417,22 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "yCJ5feKvhnBJ"
       },
-      "cell_type": "markdown",
       "source": [
         "For more advanced autodiff, you can use `jax.vjp` for reverse-mode vector-Jacobian products and `jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:"
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "Z-JxbiNyhxEW",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "from jax import jacfwd, jacrev\n",
         "def hessian(fun):\n",
@@ -442,42 +442,42 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "TI4nPsGafxbL"
       },
-      "cell_type": "markdown",
       "source": [
         "### Auto-vectorization with `vmap`"
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "PcxkONy5aius"
       },
-      "cell_type": "markdown",
       "source": [
         "JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand."
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "TPiX4y-bWLFS"
       },
-      "cell_type": "markdown",
       "source": [
         "We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using `vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "8w0Gpsn8WYYj",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "mat = random.normal(key, (150, 100))\n",
         "batched_x = random.normal(key, (10, 100))\n",
@@ -489,104 +489,104 @@
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "0zWsc0RisQWx",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "Given a function such as `apply_matrix`, we can loop over a batch dimension in Python, but usually the performance of doing so is poor."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "KWVc9BsZv0Ki",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "def naively_batched_apply_matrix(v_batched):\n",
         "  return np.stack([apply_matrix(v) for v in v_batched])\n",
         "\n",
         "print('Naively batched')\n",
-        "%timeit naively_batched_apply_matrix(batched_x)"
+        "%timeit naively_batched_apply_matrix(batched_x).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "qHfKaLE9stbA",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "We know how to batch this operation manually. In this case, `np.dot` handles extra batch dimensions transparently."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "ipei6l8nvrzH",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "@jit\n",
         "def batched_apply_matrix(v_batched):\n",
         "  return np.dot(v_batched, mat.T)\n",
         "\n",
         "print('Manually batched')\n",
-        "%timeit batched_apply_matrix(batched_x)"
+        "%timeit batched_apply_matrix(batched_x).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "1eF8Nhb-szAb",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "However, suppose we had a more complicated function without batching support. We can use `vmap` to add batching support automatically."
       ]
     },
     {
+      "cell_type": "code",
       "metadata": {
         "colab_type": "code",
         "id": "67Oeknf5vuCl",
         "colab": {}
       },
-      "cell_type": "code",
       "source": [
         "@jit\n",
-        "def vmap_batched_apply_matrix(batched_x):\n",
-        "  return vmap(apply_matrix)(batched_x)\n",
+        "def vmap_batched_apply_matrix(v_batched):\n",
+        "  return vmap(apply_matrix)(v_batched)\n",
         "\n",
         "print('Auto-vectorized with vmap')\n",
-        "%timeit vmap_batched_apply_matrix(batched_x)"
+        "%timeit vmap_batched_apply_matrix(batched_x).block_until_ready()"
       ],
       "execution_count": 0,
       "outputs": []
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
         "id": "pYVl3Z2nbZhO"
       },
-      "cell_type": "markdown",
       "source": [
         "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation."
       ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "WwNnjaI4th_8",
         "colab_type": "text"
       },
-      "cell_type": "markdown",
       "source": [
         "This is just a taste of what JAX can do. We're really excited to see what you do with it!"
       ]


### PR DESCRIPTION
Also changes name of vmap argument to reduce confusion.
Other formatting changes made by Colab. I can revert them by hand if needed.