### PR TITLE
enable staging out more multi-replica computations

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -172,14 +172,14 @@ def zeros_like_array(x):
   dtype = xla_bridge.canonicalize_dtype(onp.result_type(x))
   return onp.broadcast_to(onp.array(0, dtype), onp.shape(x))
 
-array_types = [onp.ndarray, onp.float64, onp.float32, onp.float16,
+array_types = {onp.ndarray, onp.float64, onp.float32, onp.float16,
                onp.complex64, onp.complex128,
                onp.int64, onp.int32, onp.int16, onp.int8,
                onp.bool_, onp.uint64, onp.uint32, onp.uint16, onp.uint8,
-               onp.longlong, complex, float, int, bool]
+               onp.longlong, complex, float, int, bool}
 
 if six.PY2:
-  array_types.append(long)
+  array_types.add(long)
 
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -889,6 +889,12 @@ class APITest(jtu.JaxTestCase):
     self.assertIn('replica_groups={{0,1},{2,3},{4,5},{6,7}}', c.GetHloText())
     self.assertIn('replica_groups={{0,1,2,3,4,5,6,7}}', c.GetHloText())
 
+  def test_staging_out_multi_replica(self):
+    def f(x):
+      return api.pmap(np.mean)(x)
+    xla_comp = api.xla_computation(f)
+    xla_comp(np.arange(8)).GetHloText()  # doesn't crash
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -647,17 +647,17 @@ class PmapTest(jtu.JaxTestCase):
     make_jaxpr(f)(x)  # doesn't crash
 
   def testCompositionWithJitTwice(self):
-    raise SkipTest("issue 1000!")  # TODO(mattjj,frostig)
-
     @jit
     def f(x):
       y = 2 * x
+
       @jit
       def g(z):
         return pmap(lambda x: x * y)(z)
+
       return g(x)
 
-    f(onp.arange(1.).reshape((1, 1)))
+    f(onp.arange(1.).reshape((1, 1)))  # doesn't crash
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are two real changes here:

1. In api.py, improve the handling of the axis environment in `xla_computation` so that 
 xla_computation(pmap(lambda x: x))(x)` works, by checking for pmap's included in the jaxpr to be  taged out (analogous to how jit-of-pmap works).

2. In pxla.py, handle as a special case the pmapping of computations for which the output does not 
 epend on the input. The purpose here is to enable `xla_computation(pmap(lambda x: x))(x)` when `x = 
 p.arange(8)` yet only one XLA device is available. Evaluating that expression leads to the (partial) 
 valuation of a trivial pmap (unit / empty-tuple inputs and outputs), which would cause an error when we 
 ttempt to compile an XLA computation for more replicas than available hardware devices. We don't know the computation is trivial until after we've run the function, i.e. until we're in the xla_pmap impl, so this is the right place to do it.

The other changes are unrelated miscellania.