### PR TITLE
Update np.take_along_axis to avoid reshapes and materialization of large iotas.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2172,7 +2172,7 @@ def _take_along_axis(arr, indices, axis):
   j = 0
   for i in range(rank):
     if i == axis:
-      indices = indices % axis_size
+      indices = indices % _constant_like(indices, axis_size)
       gather_indices.append(lax.reshape(indices, gather_index_shape))
       slice_sizes.append(1)
       start_index_map.append(i)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1450,7 +1450,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     def args_maker():
       x = rng(x_shape, dtype)
       n = onp.prod(x_shape, dtype=onp.int32) if axis is None else x_shape[axis]
-      i = rng(i_shape, onp.int32) % n
+      i = rng(i_shape, onp.int32) % (2 * n - 1) - (n - 1)
       return x, i
 
     lnp_op = lambda x, i: lnp.take_along_axis(x, i, axis=axis)


### PR DESCRIPTION
Example:
```
In [1]: import jax.numpy as np; import jax
In [2]: indices = np.zeros((4,4,98304,1), np.int32)
In [3]: arr = np.zeros((4,4,512,32), dtype=np.float32)
In [4]: jax.make_jaxpr(np.take_along_axis)(arr, indices, axis=2)
```

Before:
```
{ lambda d l c j ;  ; a b.
  let e = reshape[ old_sizes=(4, 4, 98304, 1)
                   dimensions=None
                   new_sizes=(4, 4, 98304) ] b
      f = broadcast[ sizes=(32,) ] e
      g = transpose[ permutation=(1, 2, 3, 0) ] f
      h = reshape[ old_sizes=(4, 4, 98304, 32)
                   dimensions=None
                   new_sizes=(50331648,) ] g
      i = reshape[ old_sizes=(50331648,)
                   dimensions=None
                   new_sizes=(50331648, 1) ] h
      k = concatenate[ operand_shapes=((50331648L, 1L), (50331648L, 1L), (50331648, 1), (50331648L, 1L))
                       dimension=1 ] c d i j
      m = rem k l
      n = add m l
      o = rem n l
      p = gather[ dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0, 1, 2, 3), start_index_map=(0, 1, 2, 3))
                  slice_sizes=(1, 1, 1, 1)
                  operand_shape=(4, 4, 512, 32) ] a o
      q = reshape[ old_sizes=(50331648,)
                   dimensions=None
                   new_sizes=(4, 4, 98304, 32) ] p
  in q }
```

After:
```
Out[4]:
{ lambda c d ;  ; a b.
  let e = xla_call[ device_values=True ] a b
        { lambda c f ;  ; a b.
          let d = tie_in a c
              e = broadcast_in_dim[ shape=(4, 4, 98304, 1)
                                    broadcast_dimensions=(0,) ] d
              g = tie_in a f
              h = broadcast_in_dim[ shape=(4, 4, 98304, 1)
                                    broadcast_dimensions=(1,) ] g
              i = rem b 512
              j = add i 512
              k = rem j 512
              l = concatenate[ dimension=3
                               operand_shapes=((4, 4, 98304, 1), (4, 4, 98304, 1), (4, 4, 98304, 1)) ] e h k
              m = gather[ dimension_numbers=GatherDimensionNumbers(offset_dims=(3,), collapsed_slice_dims=(0, 1, 2), start_index_map=(0, 1, 2))
                          slice_sizes=(1, 1, 1, 32)
                          operand_shape=(4, 4, 512, 32) ] a l
          in m } [ c d ;  ]
  in e }
```