### PR TITLE
Disable np.quantile test for old Numpy versions.

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1534,6 +1534,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for keepdims in [False, True]))
   def testQuantile(self, op, a_rng, q_rng, a_shape, a_dtype, q_shape, q_dtype,
                    axis, keepdims):
+    if op == "quantile" and numpy_version < (1, 15):
+      raise SkipTest("Numpy < 1.15 does not have np.quantile")
     args_maker = lambda: [a_rng(a_shape, a_dtype), q_rng(q_shape, q_dtype)]
     onp_fun = partial(getattr(onp, op), axis=axis, keepdims=keepdims)
     lnp_fun = partial(getattr(lnp, op), axis=axis, keepdims=keepdims)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2653,6 +2653,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       for bdims in all_bdims(shape)
       for fft_ndims in range(0, min(3, len(shape)) + 1)
       for rng in [jtu.rand_default()]))
+  @jtu.skip_on_devices("tpu")  # TODO(b/137993701): unimplemented cases.
   def testFft(self, fft_ndims, shape, bdims, rng):
     ndims = len(shape)
     axes = range(ndims - fft_ndims, ndims)


### PR DESCRIPTION
Disable FFT batching test on TPU.