### PR TITLE
Faster gradient for scipy.linalg.solve with sym_pos=True

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -604,6 +604,10 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker,
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(jsp_fun, args_maker, check_dtypes=True)
+    if sym_pos:
+      a, b = args_maker()
+      jtu.check_grads(jsp_fun, (a, b), modes=["fwd", "rev"], order=2)
+
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":


### PR DESCRIPTION
By reusing the Cholesky factorization, taking gradients of solves is about
twice as fast.

This is *not* ready to merge yet. I encountered two issues:
- Forward gradients don't work yet. I get the error:
  `NotImplementedError: Evaluation rule for 'func_jvp' not implemented`.
  Possibly this a bug related to the use of `custom_transforms`? Otherwise I'm
  really not sure what this means.
- I don't have the right backwards gradient for complex numbers yet, or at
  least the tests don't pass yet. I copied the logic from TensorFlow, so either
  TF has a bug or maybe it uses a different convention:
  https://github.com/tensorflow/tensorflow/blob/v1.14.0/tensorflow/python/ops/linalg_grad.py#L192

There's also the minor usability issue that custom transforms don't appear to
allow for static argument, but that's easy enough to get around by using a
closure.