### PR TITLE
Update core.call_impl to use call_wrapped

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -668,7 +668,7 @@ def call_bind(primitive, f, *args, **params):
 
 
 def call_impl(f, *args, **params):
-  return f(*args, **params)
+  return f.call_wrapped(*args, **params)
 
 
 call_p = Primitive('call')


### PR DESCRIPTION
This fixes core.call, which I think had just not been updated to a more recent wrapping api.