### PR TITLE
first cut at jit device placement api

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -90,9 +90,10 @@ def jit(fun, static_argnums=(), device_assignment=None):
       different values for these constants will trigger recompilation. If the
       jitted function is called with fewer positional arguments than indicated
       by `static_argnums` then an error is raised. Defaults to ().
-    device_assignment: Optional, an int specifying the device ordinal for which
-      to compile the function. The default is inherited from XLA's
-      DeviceAssignment logic and is usually to use device 0.
+    device_assignment: This is an experimental feature and the API is likely to
+      change. Optional, an int specifying the device ordinal for which to compile the
+      function. The default is inherited from XLA's DeviceAssignment logic and is
+      usually to use device 0.
 
   Returns:
     A wrapped version of `fun`, set up for just-in-time compilation.

--- a/jax/api.py
+++ b/jax/api.py
@@ -90,6 +90,9 @@ def jit(fun, static_argnums=(), device_assignment=None):
       different values for these constants will trigger recompilation. If the
       jitted function is called with fewer positional arguments than indicated
       by `static_argnums` then an error is raised. Defaults to ().
+    device_assignment: Optional, an int specifying the device ordinal for which
+      to compile the function. The default is inherited from XLA's
+      DeviceAssignment logic and is usually to use device 0.
 
   Returns:
     A wrapped version of `fun`, set up for just-in-time compilation.
@@ -111,6 +114,8 @@ def jit(fun, static_argnums=(), device_assignment=None):
 
 def _jit(fun, static_argnums, device_assignment, device_values=True):
   _check_callable(fun)
+  if isinstance(device_assignment, int):
+    device_assignment = (device_assignment,)
   if isinstance(static_argnums, int):
     static_argnums = (static_argnums,)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -97,7 +97,8 @@ def _aval_from_xla_shape(shape):
     return ShapedArray(shape.dimensions(), shape.element_type())
 
 def _execute_compiled_primitive(name, compiled, result_handler, *args):
-  input_bufs = [device_put(x) for x in args]
+  device_num, = compiled.DeviceOrdinals()
+  input_bufs = [device_put(x, device_num) for x in args]
   out_buf = compiled.Execute(input_bufs)
   check_nans(name, out_buf)
   return result_handler(out_buf)
@@ -216,7 +217,7 @@ def _pyval_result_handler(result_shape):
     return _tuple_to_jaxtuple(buf.to_py())
   return f
 
-def _compile_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
+def _compile_jaxpr(jaxpr, device_assignment, axis_env, const_vals, *abstract_args):
   if axis_env.nreps > xb.device_count():
     msg = ("compiling computation that requires {} replicas, but only {} XLA "
            "devices are available")
@@ -224,8 +225,10 @@ def _compile_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
   built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
   result_shape = xla_shape_to_result_shape(built_c.GetReturnValueShape())
-  return built_c.Compile(arg_shapes, xb.get_compile_options(axis_env.nreps),
-                         backend=xb.get_backend()), result_shape
+  compile_opts = xb.get_compile_options(num_replicas=axis_env.nreps,
+                                        device_assignment=device_assignment)
+  compiled_c = built_c.Compile(arg_shapes, compile_opts, backend=xb.get_backend())
+  return compiled_c, result_shape
 
 def build_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
@@ -670,7 +673,9 @@ def _instantiate_device_constant(const, cutoff=1e6, device_num=0):
 
 def _xla_call_impl(fun, *args, **params):
   device_values = FLAGS.jax_device_values and params.pop('device_values')
-  compiled_fun = _xla_callable(fun, device_values, *map(abstractify, args))
+  device_assignment = params.pop('device_assignment')
+  compiled_fun = _xla_callable(fun, device_assignment, device_values,
+                               *map(abstractify, args))
   try:
     return compiled_fun(*args)
   except FloatingPointError:
@@ -679,13 +684,14 @@ def _xla_call_impl(fun, *args, **params):
     return fun.call_wrapped(*args)  # probably won't return
 
 @lu.memoize
-def _xla_callable(fun, device_values, *abstract_args):
+def _xla_callable(fun, device_assignment, device_values, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
     jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here (though cond might eventually need them)
     axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
-    compiled, result_shape = _compile_jaxpr(jaxpr, axis_env, consts, *abstract_args)
+    compiled, result_shape = _compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
+                                            *abstract_args)
     del master, consts, jaxpr, env
   if device_values:
     handle_result = _device_persistent_result_handler(result_shape)
@@ -697,7 +703,8 @@ def _xla_callable(fun, device_values, *abstract_args):
     return partial(_execute_replicated, compiled, pval, handle_result)
 
 def _execute_compiled(compiled, pval, handle_result, *args):
-  input_bufs = [device_put(x) for x in args]
+  device_num, = compiled.DeviceOrdinals()
+  input_bufs = [device_put(x, device_num) for x in args]
   out_buf = compiled.Execute(input_bufs)
   check_nans("jit-compiled computation", out_buf)
   return pe.merge_pvals(handle_result(out_buf), pval)
@@ -715,8 +722,8 @@ xla_call_p.def_custom_bind(xla_call)
 xla_call_p.def_impl(_xla_call_impl)
 
 def _xla_call_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
-                               device_values):
-  del device_values  # Unused.
+                               device_values, device_assignment):
+  del device_values, device_assignment  # Unused.
   subc = _jaxpr_computation(jaxpr, axis_env, (), _map(c.GetShape, env_nodes),
                             *map(c.GetShape, in_nodes))
   return c.Call(subc, env_nodes + in_nodes)

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -160,7 +160,7 @@ def get_backend():
 
 
 def device_count():
-  return get_backend().device_count()
+  return int(get_backend().device_count())
 
 
 def device_put(pyval, device_num=0):

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -82,12 +82,33 @@ flags.DEFINE_string(
     'pass "cpu" for CPU or "gpu" for GPU.')
 
 
-def get_compile_options(num_replicas=None):
-  """Returns the compile options to use, as derived from flag values."""
+def get_compile_options(num_replicas=None, device_assignment=None):
+  """Returns the compile options to use, as derived from flag values.
+
+  Args:
+    num_replicas: Optional int indicating the number of replicas for which to
+      compile (default inherited from xla_client.CompileOptions).
+    device_assignment: Optional tuple of integers indicating the assignment of
+      logical replicas to physical devices (default inherited from
+      xla_client.CompileOptions). Must be consistent with `num_replicas`.
+  """
   compile_options = None
   if num_replicas is not None:
     compile_options = compile_options or xla_client.CompileOptions()
     compile_options.num_replicas = num_replicas
+  if device_assignment is not None:
+    # NOTE(mattjj): xla_client.DeviceAssignment.create expects a 2D ndarray
+    # indexed by replica number and computation per replica, respectively, while
+    # here we currently assume only one computation per replica, hence the
+    # second axis is always trivial.
+    if num_replicas is not None and num_replicas != len(device_assignment):
+      msg = "device_assignment does not match num_replicas: {} vs {}."
+      raise ValueError(msg.format(device_assignment, num_replicas))
+    compile_options = compile_options or xla_client.CompileOptions()
+    device_assignment = onp.array(device_assignment)[:, None]
+    device_assignment = xla_client.DeviceAssignment.create(device_assignment)
+    assert num_replicas is None or device_assignment.replica_count() == num_replicas
+    compile_options.device_assignment = device_assignment
   return compile_options
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -898,7 +898,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_jit_device_assignment(self):
     device_num = xb.device_count() - 1
-    x = api._jit(lambda x: x, (), device_assignment=(device_num,))(3.)
+    x = api.jit(lambda x: x, device_assignment=device_num)(3.)
     self.assertIsInstance(x, DeviceArray)
     self.assertEqual(x.device_buffer.device(), device_num)
 


### PR DESCRIPTION
cf. #1009

The idea is that we want to associate compiled computations (both `pmap` and `jit` ones, though this PR is just starting with `jit`) with physical device numbers so that we can control where things are executed (and as a consequence where the results are produced and lazily persisted). The API here is just to provide an optional `device_assignment` argument to `jit` that closely follows [the XLA DeviceAssignment API](https://github.com/tensorflow/tensorflow/blob/2522738eba2be57e524b48ad40c15f88f5464b3f/tensorflow/compiler/xla/python/xla_client.py#L431-L449). In particular, to assign a computation to physical device 1 we could write something like

```python
@partial(jit, device_assignment=1)
def foo(x, y, z):
  ...
```