### PR TITLE
Make JAX tracer state thread-local. 

### DIFF
--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -1,0 +1,17 @@
+Concurrency
+===========
+
+JAX has some limited support for Python concurrency.
+
+Concurrency support is experimental and only lightly tested; please report any
+bugs.
+
+Clients may call JAX APIs (e.g., :fun:`jax.jit` or :fun:`jax.grad`) concurrently
+from separate Python threads.
+
+It is not permitted to manipulate JAX trace values concurrently from multiple
+threads. In other words, while it is permissible to call functions that use JAX
+tracing (e.g., :fun:`jax.jit`) from multiple threads, you must not use threading
+to manipulate JAX values inside the implementation of the function `f` that is
+passed to :fun:`jax.jit`. The most likely outcome if you do this is a mysterious
+error from JAX.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ For an introduction to JAX, start at the
    :caption: Notes
 
    async_dispatch
+   concurrency
    gpu_memory_allocation
    profiling
 

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -127,7 +127,6 @@ _backend_lock = threading.Lock()
 @util.memoize
 def get_backend():
   with _backend_lock:
-    _backend_lock.acquire()
     backend = _backends.get(FLAGS.jax_xla_backend)
     if backend is None:
       msg = 'Unknown jax_xla_backend value "{}".'

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -947,6 +947,19 @@ class APITest(jtu.JaxTestCase):
     for x, y in zip(xs, ys):
       self.assertAllClose(x, y, check_dtypes=True)
 
+  @unittest.skipIf(six.PY2, "Test requires Python 3")
+  def test_concurrent_jit(self):
+    @jit
+    def f(x):
+      return x + x - 3.
+
+    xs = [onp.random.randn(i) for i in range(10)]
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+      futures = [executor.submit(partial(f, x)) for x in xs]
+      ys = [f.result() for f in futures]
+    for x, y in zip(xs, ys):
+      self.assertAllClose(x * 2 - 3., y, check_dtypes=True)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Allows tracing in separate threads (e.g., call `jit(f)` concurrently).

Using threading within a traced context still won't work, but that is perhaps less important than the ability to call JIT-ted computations from separate threads.

This change does not yet add any logic to attach thread IDs to tracers to ensure tracer/thread hygiene; that would be a sensible safety measure for a future change.

Revives https://github.com/google/jax/pull/734. Changes since last time:
* the LRU caches are now using `fastcache` which is thread safe.
* subclasses `threading.local`.

Fixes #1037 