### PR TITLE
Add a common lax._canonicalize_shape method, use on methods that acce…

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -205,7 +205,8 @@ def add_batch_dim_to_aval(bdim, size, aval):
       return ShapedArray(aval.shape, aval.dtype)
     else:
       assert 0 <= bdim <= aval.ndim
-      batched_shape = tuple(onp.insert(aval.shape, bdim, size))
+      batched_shape = tuple(
+        onp.insert(onp.asarray(aval.shape, onp.intp), bdim, size))
       return ShapedArray(batched_shape, aval.dtype)
   else:
     raise TypeError(t)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -619,6 +619,7 @@ class DeviceArray(DeviceValue):
   __complex__ = partialmethod(_forward_to_value, complex)
   __hex__ = partialmethod(_forward_to_value, hex)
   __oct__ = partialmethod(_forward_to_value, oct)
+  __index__ = partialmethod(_forward_to_value, op.index)
 
   # pickle saves and loads just like an ndarray
   __reduce__ = partialmethod(_forward_to_value, op.methodcaller("__reduce__"))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1758,6 +1758,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
+  def testIssue967(self):
+    self.assertRaises(TypeError, lambda: lnp.zeros(1.5))
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2240,6 +2240,17 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     expected = onp.array(0.0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testReshapeWithUnusualShapes(self):
+    ans = lax.reshape(onp.ones((3,), onp.float32), (lax.add(1, 2), 1))
+    self.assertAllClose(ans, onp.ones((3, 1), onp.float32), check_dtypes=True)
+
+    jtu.check_raises_regexp(
+      lambda: lax.reshape(onp.ones(3,), (onp.array([3, 1]),)), TypeError,
+      "Shapes must be 1D sequences of concrete values of integer type.*")
+
+    jtu.check_raises_regexp(
+      lambda: lax.reshape(onp.ones(3,), (1.5, 2.0)), TypeError,
+      "Shapes must be 1D sequences of concrete values of integer type.*")
 
 def all_bdims(*shapes):
   bdims = (itertools.chain([None], range(len(shape) + 1)) for shape in shapes)


### PR DESCRIPTION
…pt shapes in lax.

Explicitly convert shape entries to integers using the Python __index__() method.
Implement __index__ on DeviceArrays so shapes like (1, DeviceArray(2)) work.

Fixes bug where np.full accepted floating point shapes; __index__() errors for non-integer inputs, where int() would silently cast and drop information.

Fix bug in batching `add_batch_dim_to_aval` rule that would sometimes cause shapes of abstract arrays to contain float values (when batching a scalar).

Fixes #967 