### PR TITLE
Remove experimental warning from linalg routines.

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -28,7 +28,6 @@ from . import lax_numpy as np
 from ..util import get_module_functions
 from ..lib import xla_bridge
 
-_EXPERIMENTAL_WARNING = "numpy.linalg support is experimental and may cause silent failures or wrong outputs"
 
 _T = lambda x: np.swapaxes(x, -1, -2)
 
@@ -48,14 +47,12 @@ def _promote_arg_dtypes(*args):
 
 @_wraps(onp.linalg.cholesky)
 def cholesky(a):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   a = _promote_arg_dtypes(np.asarray(a))
   return lax_linalg.cholesky(a)
 
 
 @_wraps(onp.linalg.svd)
 def svd(a, full_matrices=True, compute_uv=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   a = _promote_arg_dtypes(np.asarray(a))
   return lax_linalg.svd(a, full_matrices, compute_uv)
 
@@ -116,7 +113,6 @@ def eigh(a, UPLO=None, symmetrize_input=True):
 
 @_wraps(onp.linalg.inv)
 def inv(a):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   if np.ndim(a) < 2 or a.shape[-1] != a.shape[-2]:
     raise ValueError("Argument to inv must have shape [..., n, n], got {}."
       .format(np.shape(a)))
@@ -208,7 +204,6 @@ def norm(x, ord=None, axis=None, keepdims=False):
 
 @_wraps(onp.linalg.qr)
 def qr(a, mode="reduced"):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   if mode in ("reduced", "r", "full"):
     full_matrices = False
   elif mode == "complete":

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -27,13 +27,10 @@ from ..numpy import lax_numpy as np
 from ..numpy import linalg as np_linalg
 
 
-_EXPERIMENTAL_WARNING = "scipy.linalg support is experimental and may cause silent failures or wrong outputs"
-
 _T = lambda x: np.swapaxes(x, -1, -2)
 
 @_wraps(scipy.linalg.cholesky)
 def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite
   a = np_linalg._promote_arg_dtypes(np.asarray(a))
   l = lax_linalg.cholesky(a if lower else np.conj(_T(a)), symmetrize_input=False)
@@ -74,7 +71,6 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
 @_wraps(scipy.linalg.svd)
 def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         check_finite=True, lapack_driver='gesdd'):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite, lapack_driver
   a = np_linalg._promote_arg_dtypes(np.asarray(a))
   return lax_linalg.svd(a, full_matrices, compute_uv)
@@ -82,7 +78,6 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
 
 @_wraps(scipy.linalg.det)
 def det(a, overwrite_a=False, check_finite=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite
   return np_linalg.det(a)
 
@@ -112,7 +107,6 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
 
 @_wraps(scipy.linalg.inv)
 def inv(a, overwrite_a=False, check_finite=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, check_finite
   return np_linalg.inv(a)
 
@@ -145,7 +139,6 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
 @_wraps(scipy.linalg.qr)
 def qr(a, overwrite_a=False, lwork=None, mode="full", pivoting=False,
        check_finite=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_a, lwork, check_finite
   if pivoting:
     raise NotImplementedError(
@@ -176,7 +169,6 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
 @_wraps(scipy.linalg.solve_triangular)
 def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
                      overwrite_b=False, debug=None, check_finite=True):
-  warnings.warn(_EXPERIMENTAL_WARNING)
   del overwrite_b, debug, check_finite
 
   if trans == 0 or trans == "N":


### PR DESCRIPTION
There's no particular reason to scare people with the experimental warning any longer; we don't know of any bugs here.