### PR TITLE
Increase minimum Jaxlib version to 0.1.22.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -439,7 +439,7 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
   def copy_to_host_async(self):
     if self._npy_value is None:
       for buf in self.device_buffers:
-        xla._copy_to_host_async(buf)
+        buf.copy_to_host_async()
 
   def delete(self):
     for buf in self.device_buffers:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -145,12 +145,7 @@ def device_put(x, device_num=0):
     if x.device_buffer.device() == device_num:
       return x.device_buffer
     else:
-      # TODO(phawkins): remove after the minimum Jaxlib version is raised to
-      # 0.1.22
-      if hasattr(x.device_buffer, 'copy_to_device'):
-        return x.device_buffer.copy_to_device(device_num)
-      else:
-        return device_put(x.device_buffer.to_py(), device_num)
+      return x.device_buffer.copy_to_device(device_num)
   elif isinstance(x, DeviceConstant):
     return _instantiate_device_constant(x, device_num=device_num)
   elif isinstance(x, (DeviceArray, onp.ndarray)):
@@ -510,13 +505,6 @@ xb.register_constant_handler(DeviceTuple, _device_tuple_constant_handler)
 # TODO(mattjj): could jit-compile a computation here
 ad_util.jaxval_adders[DeviceTuple] = ad_util.add_jaxtuples
 
-# TODO(phawkins): after Jaxlib 0.1.17 has been released, bump the minimum
-# jaxlib version and change callers of this function to simply call
-# the copy_to_host_async method directly.
-def _copy_to_host_async(buffer):
-  if hasattr(buffer, "copy_to_host_async"):
-    buffer.copy_to_host_async()
-
 
 def _forward_method(attrname, self, fun, *args):
   return fun(getattr(self, attrname), *args)
@@ -550,7 +538,7 @@ class DeviceArray(DeviceValue):
     """Requests a copy of the buffer to the host."""
     self._check_if_deleted()
     if self._npy_value is None:
-      _copy_to_host_async(self.device_buffer)
+      self.device_buffer.copy_to_host_async()
 
   def delete(self):
     """Deletes the device array and any cached copy on the host.

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -34,7 +34,7 @@ import six
 
 import jaxlib
 
-_minimum_jaxlib_version = (0, 1, 14)
+_minimum_jaxlib_version = (0, 1, 22)
 try:
   from jaxlib import version as jaxlib_version
 except:
@@ -56,14 +56,6 @@ _check_jaxlib_version()
 
 from jaxlib import xla_client
 from jaxlib import xla_data_pb2
-
-# TODO(phawkins): This is a workaround for older jaxlib versions. Remove after a
-# jaxlib release.
-try:
-  from jaxlib import xrt
-except ImportError:
-  xrt = None
-
 
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_enable_x64',
@@ -130,8 +122,6 @@ def _get_xrt_backend():
   worker = "tpu_worker"
   tf_context = xrt.get_tf_context(FLAGS.jax_backend_target, worker)
   backend = xrt.XrtBackend(tf_context, tf_device_name)
-  #  TODO(phawkins) fix XrtBackend to set the following and remove this line.
-  backend.platform = "TPU"
   return backend
 
 


### PR DESCRIPTION
Remove code that preserves backward compatibility with older jaxlib versions.