### PR TITLE
speed up pmap axis-size getting

### DIFF
--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .core import pack
+from .core import pack, AbstractTuple
 from .tree_util import (build_tree, process_pytree, tree_flatten,
                         tree_unflatten, leaf)
 from .linear_util import transformation_with_aux
@@ -92,3 +92,13 @@ def flatten_fun_leafout(in_tree, *args_flat):
     yield ans, out_tree
   else:
     yield pack(flat_ans), out_tree
+
+
+def abstract_tuple_tree_leaves(aval):
+  if type(aval) is AbstractTuple:
+    for elt in aval:
+      # TODO(mattjj,phawkins): use 'yield from' when PY2 is dropped
+      for a in abstract_tuple_tree_leaves(elt):
+        yield a
+  else:
+    yield aval


### PR DESCRIPTION
For tree_flatten, we also tried these implementations:

```python
def tree_flatten(tree):
  leaves = []
  def f(tree):
    node_type = _get_node_type(tree)
    if node_type:
      children, node_spec = node_type.to_iterable(tree)
      child_specs = tuple(map(f, children))
      return PyTreeDef(node_type, node_spec, child_specs)
    else:
      leaves.append(tree)
      return leaf
  return leaves, f(tree)

def tree_flatten(tree):
  leaves = []
  _, treedef = walk_pytree(lambda node: None, leaves.append, tree)
  return leaves, treedef
```

and surprisingly the version in this PR was slightly faster. We only tried on flattening this pytree though:

```python
pytree = [[(np.zeros(10), (), np.zeros(10), ()) for _ in range(20)] for _ in range(20)]
```

The change in this PR made `api._pmap_axis_size(pytree)` on the above `pytree` go from 5.3ms to 3.24us (notice ms and us!), and `tree_util.tree_flatten(pytree)` go from 3.5ms to 2.5ms.