### PR TITLE
Add scalar python types to array-like types

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -104,7 +104,7 @@ set_printoptions = onp.set_printoptions
 #
 # Note that scalar python types are included to have consistent isinstance
 # behavior when using JIT. This is different from numpy which treats scalars
-# differently (i.e. isintance(1, onp.ndarray) == False).
+# differently (i.e. isinstance(1, onp.ndarray) == False).
 _arraylike_types = (onp.ndarray, UnshapedArray, DeviceArray,
                     bool, float, complex) + six.integer_types
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -101,7 +101,12 @@ set_printoptions = onp.set_printoptions
 # array base class). We can override the isinstance behavior directly, without
 # having the complexity of multiple inheritance on those classes, by defining
 # the ndarray class to have a metaclass with special __instancecheck__ behavior.
-_arraylike_types = (onp.ndarray, UnshapedArray, DeviceArray)
+#
+# Note that scalar python types are included to have consistent isinstance
+# behavior when using JIT. This is different from numpy which treats scalars
+# differently (i.e. isintance(1, onp.ndarray) == False).
+_arraylike_types = (onp.ndarray, UnshapedArray, DeviceArray,
+                    bool, int, float, complex)
 
 class _ArrayMeta(type(onp.ndarray)):
   """Metaclass for overriding ndarray isinstance checks."""

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -106,7 +106,7 @@ set_printoptions = onp.set_printoptions
 # behavior when using JIT. This is different from numpy which treats scalars
 # differently (i.e. isintance(1, onp.ndarray) == False).
 _arraylike_types = (onp.ndarray, UnshapedArray, DeviceArray,
-                    bool, int, float, complex)
+                    bool, float, complex) + six.integer_types
 
 class _ArrayMeta(type(onp.ndarray)):
   """Metaclass for overriding ndarray isinstance checks."""


### PR DESCRIPTION
This will make `isinstance` called on scalars return True for both jitted and non-jitted JAX programs. Note that
`isinstance(x, onp.ndarray)` is False for these types, so it breaks this correspondence.

#1080 