### PR TITLE
Correct jax.numpy.pad signature

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1259,7 +1259,7 @@ def _pad(array, pad_width, mode, constant_values):
     raise NotImplementedError(msg.format(mode))
 
 @_wraps(onp.pad)
-def pad(array, pad_width, mode, constant_values=0):
+def pad(array, pad_width, mode='constant', constant_values=0):
   return _pad(array, pad_width, mode, constant_values)
 
 


### PR DESCRIPTION
See https://docs.scipy.org/doc/numpy/reference/generated/numpy.pad.html.