### PR TITLE
Make the C++ version of tree_multimap accept tree suffixes of the primary tree.

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -72,9 +72,8 @@ if pytree:
         corresponding leaves of the pytrees.
       tree: a pytree to be mapped over, with each leaf providing the first
         positional argument to `f`.
-      *rest: a tuple of pytrees, the structure of each of which must be a tree
-        suffix of `tree`.
-
+      *rest: a tuple of pytrees, each of which has the same structure as tree or
+        or has tree as a prefix.
     Returns:
       A new pytree with the same structure as `tree` but with the value at each
       leaf given by `f(x, *xs)` where `x` is the value at the corresponding leaf

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -48,6 +48,7 @@ from .util import unzip2, partial, safe_map
 # TODO(phawkins): use the first case unconditionally when the minimum Jaxlib
 # version has been increased to 0.1.23.
 if pytree:
+
   def tree_map(f, tree):
     """Map a function over a pytree to produce a new pytree.
 
@@ -63,7 +64,6 @@ if pytree:
     leaves, treedef = pytree.flatten(tree)
     return treedef.unflatten(map(f, leaves))
 
-
   def tree_multimap(f, tree, *rest):
     """Map a multi-input function over pytree args to produce a new pytree.
 
@@ -72,20 +72,17 @@ if pytree:
         corresponding leaves of the pytrees.
       tree: a pytree to be mapped over, with each leaf providing the first
         positional argument to `f`.
-      *rest: a tuple of pytrees, each with the same structure as `tree`.
+      *rest: a tuple of pytrees, the structure of each of which must be a tree
+        suffix of `tree`.
 
     Returns:
       A new pytree with the same structure as `tree` but with the value at each
       leaf given by `f(x, *xs)` where `x` is the value at the corresponding leaf
-      in `tree` and `xs` is the tuple of values at corresponding leaves in `rest`.
+      in `tree` and `xs` is the tuple of values at corresponding nodes in
+      `rest`.
     """
     leaves, treedef = pytree.flatten(tree)
-    all_leaves = [leaves]
-    for r in rest:
-      r_leaves, r_treedef = pytree.flatten(r)
-      if treedef != r_treedef:
-        raise TypeError("Mismatch pytrees: {} != {}".format(treedef, r_treedef))
-      all_leaves.append(r_leaves)
+    all_leaves = [leaves] + [treedef.flatten_up_to(r) for r in rest]
     return treedef.unflatten(f(*xs) for xs in zip(*all_leaves))
 
   def tree_leaves(tree):

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -49,7 +49,6 @@ tf_pybind_extension(
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/synchronization",
         "@pybind11",
     ],
 )

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -111,7 +111,7 @@ class PyTreeDef {
   // Flattens a Pytree into a list of leaves and a PyTreeDef.
   static std::pair<py::list, std::unique_ptr<PyTreeDef>> Flatten(py::handle x);
 
-  // Flattens a Pytree up to this PyTree. 'this' must be a tree prefix of
+  // Flattens a Pytree up to this PyTreeDef. 'this' must be a tree prefix of
   // the tree-structure of 'x'. For example, if we flatten a value
   // [(1, (2, 3)), {"foo": 4}] with a treedef [(*, *), *], the result is the
   // list of leaves [1, (2, 3), {"foo": 4}].
@@ -424,7 +424,8 @@ py::list PyTreeDef::FlattenUpTo(py::handle xs) const {
   while (!agenda.empty()) {
     if (it == traversal_.rend()) {
       throw std::invalid_argument(
-          "Tree structures did not match; reached end of tree.");
+          absl::StrFormat("Tree structures did not match: %s vs %s",
+                          py::repr(xs), ToString()));
     }
     const Node& node = *it;
     py::object object = agenda.back();
@@ -554,7 +555,9 @@ py::list PyTreeDef::FlattenUpTo(py::handle xs) const {
     }
   }
   if (it != traversal_.rend() || leaf != -1) {
-    throw std::invalid_argument("Tree structures did not match.");
+    throw std::invalid_argument(
+        absl::StrFormat("Tree structures did not match: %s vs %s",
+                        py::repr(xs), ToString()));
   }
   return leaves;
 }

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -27,7 +27,6 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/synchronization/mutex.h"
 #include "include/pybind11/pybind11.h"
 #include "include/pybind11/pytypes.h"
 #include "include/pybind11/stl.h"
@@ -68,10 +67,9 @@ class CustomNodeRegistry {
       return a.equal(b);
     }
   };
-  absl::Mutex mu_;
   absl::flat_hash_map<py::object, std::unique_ptr<Registration>, TypeHash,
                       TypeEq>
-      registrations_ GUARDED_BY(mu_);
+      registrations_;
 };
 
 /*static*/ CustomNodeRegistry* CustomNodeRegistry::Singleton() {
@@ -83,7 +81,6 @@ class CustomNodeRegistry {
                                              py::function to_iterable,
                                              py::function from_iterable) {
   CustomNodeRegistry* registry = Singleton();
-  absl::MutexLock lock(&registry->mu_);
   auto registration = absl::make_unique<Registration>();
   registration->type = type;
   registration->to_iterable = std::move(to_iterable);
@@ -99,7 +96,6 @@ class CustomNodeRegistry {
 /*static*/ const CustomNodeRegistry::Registration* CustomNodeRegistry::Lookup(
     py::handle type) {
   CustomNodeRegistry* registry = Singleton();
-  absl::MutexLock lock(&registry->mu_);
   auto it =
       registry->registrations_.find(py::reinterpret_borrow<py::object>(type));
   return it == registry->registrations_.end() ? nullptr : it->second.get();
@@ -114,6 +110,12 @@ class PyTreeDef {
 
   // Flattens a Pytree into a list of leaves and a PyTreeDef.
   static std::pair<py::list, std::unique_ptr<PyTreeDef>> Flatten(py::handle x);
+
+  // Flattens a Pytree up to this PyTree. 'this' must be a tree prefix of
+  // the tree-structure of 'x'. For example, if we flatten a value
+  // [(1, (2, 3)), {"foo": 4}] with a treedef [(*, *), *], the result is the
+  // list of leaves [1, (2, 3), {"foo": 4}].
+  py::list FlattenUpTo(py::handle x) const;
 
   // Returns an unflattened PyTree given an iterable of leaves and a PyTreeDef.
   py::object Unflatten(py::iterable leaves) const;
@@ -413,6 +415,150 @@ py::object PyTreeDef::Unflatten(py::iterable leaves) const {
   }
 }
 
+py::list PyTreeDef::FlattenUpTo(py::handle xs) const {
+  py::list leaves(num_leaves());
+  std::vector<py::object> agenda;
+  agenda.push_back(py::reinterpret_borrow<py::object>(xs));
+  auto it = traversal_.rbegin();
+  int leaf = num_leaves() - 1;
+  while (!agenda.empty()) {
+    if (it == traversal_.rend()) {
+      throw std::invalid_argument(
+          "Tree structures did not match; reached end of tree.");
+    }
+    const Node& node = *it;
+    py::object object = agenda.back();
+    agenda.pop_back();
+    ++it;
+
+    switch (node.kind) {
+      case Kind::kLeaf:
+        if (leaf < 0) {
+          throw std::logic_error("Leaf count mismatch.");
+        }
+        leaves[leaf] = py::reinterpret_borrow<py::object>(object);
+        --leaf;
+        break;
+
+      case Kind::kNone:
+        break;
+
+      case Kind::kTuple: {
+        if (!PyTuple_CheckExact(object.ptr())) {
+          throw std::invalid_argument(
+              absl::StrFormat("Expected tuple, got %s.", py::repr(object)));
+        }
+        py::tuple tuple = py::reinterpret_borrow<py::tuple>(object);
+        if (tuple.size() != node.arity) {
+          throw std::invalid_argument(
+              absl::StrFormat("Tuple arity mismatch: %d != %d; tuple: %s.",
+                              tuple.size(), node.arity, py::repr(object)));
+        }
+        for (py::handle entry : tuple) {
+          agenda.push_back(py::reinterpret_borrow<py::object>(entry));
+        }
+        break;
+      }
+
+      case Kind::kList: {
+        if (!PyList_CheckExact(object.ptr())) {
+          throw std::invalid_argument(
+              absl::StrFormat("Expected list, got %s.", py::repr(object)));
+        }
+        py::list list = py::reinterpret_borrow<py::list>(object);
+        if (list.size() != node.arity) {
+          throw std::invalid_argument(
+              absl::StrFormat("List arity mismatch: %d != %d; list: %s.",
+                              list.size(), node.arity, py::repr(object)));
+        }
+        for (py::handle entry : list) {
+          agenda.push_back(py::reinterpret_borrow<py::object>(entry));
+        }
+        break;
+      }
+
+      case Kind::kDict: {
+        if (!PyDict_CheckExact(object.ptr())) {
+          throw std::invalid_argument(
+              absl::StrFormat("Expected dict, got %s.", py::repr(object)));
+        }
+        py::dict dict = py::reinterpret_borrow<py::dict>(object);
+        py::list keys =
+            py::reinterpret_steal<py::list>(PyDict_Keys(dict.ptr()));
+        if (PyList_Sort(keys.ptr())) {
+          throw std::runtime_error("Dictionary key sort failed.");
+        }
+        if (keys.not_equal(node.node_data)) {
+          throw std::invalid_argument(
+              absl::StrFormat("Dict key mismatch; expected keys: %s; dict: %s.",
+                              py::repr(node.node_data), py::repr(object)));
+        }
+        for (py::handle key : keys) {
+          agenda.push_back(dict[key]);
+        }
+        break;
+      }
+
+      case Kind::kNamedTuple: {
+        if (!py::isinstance<py::tuple>(object) ||
+            !py::hasattr(object, "_fields")) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Expected named tuple, got %s.", py::repr(object)));
+        }
+        py::tuple tuple = py::reinterpret_borrow<py::tuple>(object);
+        if (tuple.size() != node.arity) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Named tuple arity mismatch: %d != %d; tuple: %s.", tuple.size(),
+              node.arity, py::repr(object)));
+        }
+        if (tuple.get_type().not_equal(node.node_data)) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Named tuple type mismatch: expected type: %s, tuple: %s.",
+              py::repr(node.node_data), py::repr(object)));
+        }
+        for (py::handle entry : tuple) {
+          agenda.push_back(py::reinterpret_borrow<py::object>(entry));
+        }
+        break;
+      }
+
+      case Kind::kCustom: {
+        auto* registration = CustomNodeRegistry::Lookup(object.get_type());
+        if (registration != node.custom) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Custom node type mismatch: expected type: %s, value: %s.",
+              py::repr(node.custom->type), py::repr(object)));
+        }
+        py::tuple out = py::cast<py::tuple>(node.custom->to_iterable(object));
+        if (out.size() != 2) {
+          throw std::runtime_error(
+              "PyTree custom to_iterable function should return a pair");
+        }
+        if (node.node_data.not_equal(out[1])) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Mismatch custom node data: %s != %s; value: %s.",
+              py::repr(node.node_data), py::repr(out[1]), py::repr(object)));
+        }
+        int arity = 0;
+        for (py::handle entry : py::cast<py::iterable>(out[0])) {
+          ++arity;
+          agenda.push_back(py::reinterpret_borrow<py::object>(entry));
+        }
+        if (arity != node.arity) {
+          throw std::invalid_argument(absl::StrFormat(
+              "Custom type arity mismatch: %d != %d; value: %s.", arity,
+              node.arity, py::repr(object)));
+        }
+        break;
+      }
+    }
+  }
+  if (it != traversal_.rend() || leaf != -1) {
+    throw std::invalid_argument("Tree structures did not match.");
+  }
+  return leaves;
+}
+
 py::object PyTreeDef::Walk(const py::function& f_node, py::handle f_leaf,
                            py::iterable leaves) const {
   std::vector<py::object> agenda;
@@ -601,6 +747,7 @@ PYBIND11_MODULE(pytree, m) {
 
   py::class_<PyTreeDef>(m, "PyTreeDef")
       .def("unflatten", &PyTreeDef::Unflatten)
+      .def("flatten_up_to", &PyTreeDef::FlattenUpTo)
       .def("compose", &PyTreeDef::Compose)
       .def("walk", &PyTreeDef::Walk)
       .def("from_iterable_tree", &PyTreeDef::FromIterableTree)

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -70,6 +70,15 @@ class TreeTest(jtu.JaxTestCase):
     actual = tree_util.tree_unflatten(tree, xs)
     self.assertEqual(actual, inputs)
 
+  @parameterized.parameters(*PYTREES)
+  def testRoundtripWithFlattenUpTo(self, inputs):
+    _, tree = tree_util.tree_flatten(inputs)
+    if not hasattr(tree, "flatten_up_to"):
+      self.skipTest("Test requires Jaxlib >= 0.1.23")
+    xs = tree.flatten_up_to(inputs)
+    actual = tree_util.tree_unflatten(tree, xs)
+    self.assertEqual(actual, inputs)
+
   @parameterized.parameters(
       (tree_util.Partial(_dummy_func),),
       (tree_util.Partial(_dummy_func, 1, 2),),
@@ -95,7 +104,25 @@ class TreeTest(jtu.JaxTestCase):
     _, tree = tree_util.tree_flatten(((1, 2, 3), (4,)))
     _, c0 = tree_util.tree_flatten((0, 0, 0))
     _, c1 = tree_util.tree_flatten((7,))
+    if not callable(tree.children):
+      self.skipTest("Test requires Jaxlib >= 0.1.23")
     self.assertEqual([c0, c1], tree.children())
+
+  def testFlattenUpTo(self):
+    _, tree = tree_util.tree_flatten([(1, 2), None, ATuple(foo=3, bar=7)])
+    if not hasattr(tree, "flatten_up_to"):
+      self.skipTest("Test requires Jaxlib >= 0.1.23")
+    out = tree.flatten_up_to([({
+        "foo": 7
+    }, (3, 4)), None, ATuple(foo=(11, 9), bar=None)])
+    self.assertEqual(out, [{"foo": 7}, (3, 4), (11, 9), None])
+
+  def testTreeMultimap(self):
+    x = ((1, 2), (3, 4, 5))
+    y = (([3], None), ({"foo": "bar"}, 7, [5, 6]))
+    out = tree_util.tree_multimap(lambda *xs: tuple(xs), x, y)
+    self.assertEqual(out, (((1, [3]), (2, None)),
+                           ((3, {"foo": "bar"}), (4, 7), (5, [5, 6]))))
 
 
 if __name__ == "__main__":

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -53,6 +53,9 @@ tree_util.register_pytree_node(AnObject, lambda o: ((o.x, o.y), o.z),
                                lambda z, xy: AnObject(xy[0], xy[1], z))
 
 PYTREES = [
+    ("foo",),
+    ((),),
+    (([()]),),
     ((1, 2),),
     (((1, "foo"), ["bar", (3, None, 7)]),),
     ([3],),


### PR DESCRIPTION
Document and test the `tree_multimap` behavior.
Add a pytreedef.flatten_up_to() method that flattens a PyTree only up to the structure of a PyTreeDef.
Remove unnecessary locking in custom node registry; we hold the GIL already so there's no point to the additional locking.