### PR TITLE
Add batching rule for lax.sort

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3796,8 +3796,16 @@ def _sort_jvp_rule(g, operand, dimension):
   _, g_out = sort_key_val(operand, g, dimension)
   return g_out
 
+def _sort_batch_rule(batched_args, batch_dims, dimension):
+  operand, = batched_args
+  bdim, = batch_dims
+  dimension = dimension % (operand.ndim - 1)
+  new_dimension = dimension + (bdim <= dimension)
+  return sort(operand, dimension=new_dimension), bdim
+
 sort_p = standard_primitive(sort_shape, _input_dtype, 'sort')
 ad.defjvp(sort_p, _sort_jvp_rule)
+batching.primitive_batchers[sort_p] = _sort_batch_rule
 
 
 def _sort_key_val_abstract_eval(keys, values, dimension):

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -409,6 +409,21 @@ class BatchingTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
     assert len(onp.unique(ans)) == 10 * 3 * 2
 
+  def testSort(self):
+    v = onp.arange(12)[::-1].reshape(3, 4)
+
+    sv = vmap(partial(lax.sort, dimension=0), (0,))(v)
+    self.assertAllClose(sv, v[:, ::-1], check_dtypes=True)
+
+    sv = vmap(partial(lax.sort, dimension=-1), (0,))(v)
+    self.assertAllClose(sv, v[:, ::-1], check_dtypes=True)
+
+    sv = vmap(partial(lax.sort, dimension=0), (1,))(v)
+    self.assertAllClose(sv, v[::-1, :].T, check_dtypes=True)
+
+    sv = vmap(partial(lax.sort, dimension=0), (1,), 1)(v)
+    self.assertAllClose(sv, v[::-1, :], check_dtypes=True)
+
   def testSortKeyVal(self):
     k = onp.arange(12)[::-1].reshape(3, 4)
     v = onp.random.RandomState(0).permutation(12).reshape(3, 4)


### PR DESCRIPTION
This rule is important for some numpy utilities such as `np.quantile` or `np.percentile`.