### PR TITLE
Cleanups to xla_bridge.py

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -33,7 +33,7 @@ from jax.interpreters import parallel
 from jax.interpreters import xla
 from jax.interpreters import pxla
 from jax.util import partial, unzip2, prod
-from jax.lib import xla_bridge
+from jax.lib import xla_client
 
 from jax.interpreters.pxla import axis_index
 
@@ -189,7 +189,7 @@ def _allreduce_split_axis_rule(prim, reducer, vals, which_mapped, axis_name):
 
 def _allreduce_translation_rule(prim, c, val, replica_groups):
   dtype = c.GetShape(val).numpy_dtype()
-  scalar = xla_bridge.Shape.array_shape(dtype, ())
+  scalar = xla_client.Shape.array_shape(dtype, ())
   computation = xla.primitive_computation(prim, scalar, scalar)
   return c.AllReduce(val, computation, replica_groups=replica_groups)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -37,6 +37,7 @@ from jax import lax_reference
 from jax.test_util import check_grads
 from jax.interpreters import xla
 from jax.lib import xla_bridge
+from jax.lib import xla_client
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -2667,7 +2668,7 @@ class LaxVmapTest(jtu.JaxTestCase):
     ndims = len(shape)
     axes = range(ndims - fft_ndims, ndims)
     fft_lengths = [shape[axis] for axis in axes]
-    op = lambda x: lax.fft(x, xla_bridge.xla_client.FftType.FFT, fft_lengths)
+    op = lambda x: lax.fft(x, xla_client.FftType.FFT, fft_lengths)
     self._CheckBatching(op, 5, bdims, [shape], onp.complex64, rng)
 
   # TODO Concatenate


### PR DESCRIPTION
Remove stringification of dtypes. The NumPy dtype handling bug has to do with types with different hashes comparing as equal. This does not happen between two np.dtype objects; it is sufficient to ensure we actually have an np.dtype rather than something dtype-like (e.g., a string or NumPy type object).
Remove xla_bridge.infeed_put, which is unused.
Remove xla_bridge.Shape (use xla_client.Shape instead).
Remove xla_bridge.dtype_to_etype_exact (use xla_client.dtype_to_etype instead).
Remove xla_bridge.device_put (inlined the definition into its callers).
Remove xla_bridge.make_tuple (inlined the definition into its callers).