### PR TITLE
Mark instances of 'long' with # noqa

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -179,7 +179,7 @@ array_types = {onp.ndarray, onp.float64, onp.float32, onp.float16,
                onp.longlong, complex, float, int, bool}
 
 if six.PY2:
-  array_types.add(long)
+  array_types.add(long)  # noqa: F821
 
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -311,4 +311,4 @@ for scalar_type in [onp.int8, onp.int16, onp.int32, onp.int64,
   register_constant_handler(scalar_type, _scalar_constant_handler)
 
 if six.PY2:
-  register_constant_handler(long, _scalar_constant_handler)
+  register_constant_handler(long, _scalar_constant_handler) # noqa: F821

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1388,7 +1388,7 @@ class LaxTest(jtu.JaxTestCase):
   def testLongConstantHandling(self):
     if six.PY3:
       self.skipTest("Test is Python 2 specific")
-    self.assertTrue(api.jit(lambda x: lax.lt(x, long(10)))(long(3)))
+    self.assertTrue(api.jit(lambda x: lax.lt(x, long(10)))(long(3)))  # noqa: F821
 
   def testIssue831(self):
     # Tests the DeviceTuple constant handler


### PR DESCRIPTION
As discussed in #315 and #317 this linter directive forces the linter to overlook _undefined names_ like __long__ in Python 3.