### PR TITLE
Don't call _check_args in jit/pmap.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -135,7 +135,6 @@ def _jit(fun, static_argnums, device_assignment, device_values=True):
     dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
     f, dyn_args = _argnums_partial(f, dyn_argnums, args)
     args_flat, in_tree = tree_flatten((dyn_args, kwargs))
-    _check_args(args_flat)
     flat_fun, out_tree = flatten_fun_leafout(f, in_tree)
     out = xla.xla_call(flat_fun, *args_flat, device_values=device_values,
                        device_assignment=device_assignment)
@@ -702,7 +701,6 @@ def pmap(fun, axis_name=None):
     axis_size = _pmap_axis_size(args)
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten((args, kwargs))
-    _check_args(args_flat)
     flat_fun, out_tree = flatten_fun_leafout(f, in_tree)
     out = pxla.xla_pmap(flat_fun, *args_flat,
                         axis_name=axis_name, axis_size=axis_size)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -442,10 +442,11 @@ def _identity(x): return x
 
 
 def abstractify(x):
-  try:
-    return pytype_aval_mappings[type(x)](x)
-  except KeyError:
-    raise TypeError("No abstraction handler for type: {}".format(type(x)))
+  aval_mapping = pytype_aval_mappings.get(type(x))
+  if aval_mapping is None:
+    raise TypeError("Value '{}' of type {} is not a valid JAX type"
+                    .format(x, type(x)))
+  return aval_mapping(x)
 
 pytype_aval_mappings = {}
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -141,10 +141,10 @@ class APITest(jtu.JaxTestCase):
       return x
 
     jtu.check_raises_regexp(lambda: grad(f)("foo"), TypeError,
-                     "Argument 'foo' of type <.*'str'> is not a valid JAX type")
+                     ".* 'foo' of type <.*'str'> is not a valid JAX type")
 
     jtu.check_raises_regexp(lambda: jit(f)("foo"), TypeError,
-                     "Argument 'foo' of type <.*'str'> is not a valid JAX type")
+                     ".* 'foo' of type <.*'str'> is not a valid JAX type")
 
   # TODO(dougalm): enable when we remove 'None' from pytree nodes
   # def test_bad_output(self):


### PR DESCRIPTION
Instead, improve the error from xla.abstractify to match the one from _check_args.
This saves abstractifying values twice; `jit` and `pmap` have to abstractify their arguments as one of the first things they do anyway to build a JIT cache key.

Saves 5ms of 32ms on a pmap microbenchmark.