### PR TITLE
Fix Kolmogorov-Smirnov hypothesis test

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -51,8 +51,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   def _CheckKolmogorovSmirnovCDF(self, samples, cdf):
     fail_prob = 0.01  # conservative bound on statistical fail prob by Kolmo CDF
-    statistic = scipy.stats.kstest(samples, cdf).statistic
-    self.assertLess(1. - scipy.special.kolmogorov(statistic), fail_prob)
+    self.assertGreater(scipy.stats.kstest(samples, cdf).pvalue, fail_prob)
 
   def _CheckChiSquared(self, samples, pmf):
     alpha = 0.01  # significance level, threshold for p-value
@@ -128,7 +127,6 @@ class LaxRandomTest(jtu.JaxTestCase):
     for samples in [uncompiled_samples, compiled_samples]:
       self.assertTrue(onp.all(lo <= samples))
       self.assertTrue(onp.all(samples < hi))
-      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.randint(lo, hi).cdf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}


### PR DESCRIPTION
I noticed that the random tests for continuous distributions were passing even with incorrect cdfs. Thankfully I haven't had to study hypthesis testing for a long time, but helpfully [Wikipedia explains](https://en.wikipedia.org/wiki/Statistical_hypothesis_testing#Interpretation) that

>If the p-value is less than the chosen significance threshold [...], then we say the null hypothesis is rejected at the chosen level of significance.

After correcting the hypothesis test the randint k-s test was failing, presumably because the test is only valid for continuous distributions.