### PR TITLE
Two more pmap optimizations:

### DIFF
--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -27,7 +27,7 @@ from six.moves import reduce
 from .. import core
 from .. import linear_util as lu
 from ..core import Trace, Tracer, Primitive, new_master
-from ..abstract_arrays import ShapedArray, ConcreteArray, make_shaped_array
+from ..abstract_arrays import ShapedArray, ConcreteArray
 from ..util import safe_zip, unzip2, unzip3, partialmethod, prod
 from ..lib import xla_bridge as xb
 from . import partial_eval as pe


### PR DESCRIPTION
* perform _shard_aval inside the memoized function not outside; this avoids work on the cache hit case.
* rather than sharding each argument individually and then transposing a large list of lists, use a single function to shard all arguments in the layout expected by the C++ binding code.

Remove a couple of unnecessary imports.