### PR TITLE
pmap optimization: Don't precompute size and ndim on DeviceArrays.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -433,8 +433,8 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
     # return it unmodified.
     self.aval = aval
     self.device_buffers = device_buffers
-    self.shape, self.dtype = aval.shape, aval.dtype
-    self.ndim, self.size = len(aval.shape), prod(aval.shape)
+    self.shape = aval.shape
+    self.dtype = aval.dtype
     self.axis_size = aval.shape[0]
     self._npy_value = None
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3926,8 +3926,6 @@ class _FilledConstant(xla.DeviceConstant):
     assert type(fill_value) is onp.ndarray
     self.shape = shape
     self.dtype = _dtype(fill_value)
-    self.ndim = len(shape)
-    self.size = prod(shape)
     self._npy_value = None
 
     self.fill_value = fill_value
@@ -3949,8 +3947,6 @@ class _IotaConstant(xla.DeviceConstant):
   def __init__(self, dtype, shape, axis):
     self.shape = shape
     self.dtype = onp.dtype(dtype)
-    self.ndim = len(shape)
-    self.size = prod(shape)
     self._npy_value = None
 
     self.axis = axis
@@ -3978,8 +3974,6 @@ class _EyeConstant(xla.DeviceConstant):
   def __init__(self, shape, axes, dtype):
     self.shape = shape
     self.dtype = onp.dtype(dtype)
-    self.ndim = len(shape)
-    self.size = prod(shape)
     self._npy_value = None
 
     self.axes = axes


### PR DESCRIPTION
We don't even look at them most of the time, and they are in the critical path for running pmap code.

Saves ~1-2ms on a pmap microbenchmark.