### PR TITLE
Helper function for defining differentiable solves.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1786,7 +1786,7 @@ def custom_implicit_solve(solve, tangent_solve):
       params, = primals
       grad_params, = tangents
       solution = solve_impl(params)
-      _, f_jvp = vjp(func, params, solution)
+      unchecked_zeros, f_jvp = vjp(func, params, solution)
       grad_solution = tree_map(
           lambda x: -x,
           tangent_solve(lambda p: f_jvp(p)[1], f_jvp(grad_params)[0])

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -910,7 +910,7 @@ class APITest(jtu.JaxTestCase):
       def body(state):
         low, high = state
         midpoint = 0.5 * (low + high)
-        update_upper = func(params, midpoint) > 0
+        update_upper = func(midpoint, params) > 0
         low = np.where(update_upper, low, midpoint)
         high = np.where(update_upper, midpoint, high)
         return (low, high)
@@ -918,8 +918,8 @@ class APITest(jtu.JaxTestCase):
       solution, _ = lax.while_loop(cond, body, (low, high))
       return solution
 
-    binary_search = api.custom_implicit_solve(_binary_search, scalar_solve)
-    sqrt_cubed = lambda x, y: y ** 2 - x ** 3
+    binary_search = api._custom_implicit_solve(_binary_search, scalar_solve)
+    sqrt_cubed = lambda y, x: y ** 2 - x ** 3
     value, grad = api.value_and_grad(binary_search, argnums=1)(sqrt_cubed, 5.0)
     self.assertAllClose(value, 5 ** 1.5, check_dtypes=False)
     self.assertAllClose(grad, api.grad(pow)(5.0, 1.5), check_dtypes=False)
@@ -928,7 +928,7 @@ class APITest(jtu.JaxTestCase):
       y_1d = y[np.newaxis]
       return np.linalg.solve(api.jacobian(f)(y_1d), y_1d).squeeze()
 
-    binary_search = api.custom_implicit_solve(_binary_search, scalar_solve2)
+    binary_search = api._custom_implicit_solve(_binary_search, scalar_solve2)
     grad = api.grad(binary_search, argnums=1)(sqrt_cubed, 5.0)
     self.assertAllClose(grad, api.grad(pow)(5.0, 1.5), check_dtypes=False)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -922,7 +922,7 @@ class APITest(jtu.JaxTestCase):
     value, grad = api.value_and_grad(binary_search, argnums=1)(
         lambda x, y: y ** 2 - x, 5.0)
     self.assertAllClose(value, np.sqrt(5), check_dtypes=False)
-    self.assertAllClose(grad, 0.5 / np.sqrt(5), check_dtypes=False)
+    self.assertAllClose(grad, api.grad(np.sqrt)(5.0), check_dtypes=False)
 
     def scalar_solve2(f, y):
       y_1d = y[np.newaxis]
@@ -930,7 +930,7 @@ class APITest(jtu.JaxTestCase):
 
     binary_search = api.custom_implicit_solve(_binary_search, scalar_solve2)
     grad = api.grad(binary_search, argnums=1)(lambda x, y: y ** 2 - x, 5.0)
-    self.assertAllClose(grad, 0.5 / np.sqrt(5), check_dtypes=False)
+    self.assertAllClose(grad, api.grad(np.sqrt)(5.0), check_dtypes=False)
 
   def test_jit_device_assignment(self):
     device_num = xb.device_count() - 1

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -897,6 +897,41 @@ class APITest(jtu.JaxTestCase):
     xla_comp = api.xla_computation(f)
     xla_comp(np.arange(8)).GetHloText()  # doesn't crash
 
+  def test_custom_implicit_solve(self):
+
+    def scalar_solve(f, y):
+      return y / f(1.0)
+
+    def _binary_search(func, params, low=0.0, high=100.0, tolerance=1e-6):
+      def cond(state):
+        low, high = state
+        return high - low > tolerance
+
+      def body(state):
+        low, high = state
+        midpoint = 0.5 * (low + high)
+        update_upper = func(params, midpoint) > 0
+        low = np.where(update_upper, low, midpoint)
+        high = np.where(update_upper, midpoint, high)
+        return (low, high)
+
+      solution, _ = lax.while_loop(cond, body, (low, high))
+      return solution
+
+    binary_search = api.custom_implicit_solve(_binary_search, scalar_solve)
+    value, grad = api.value_and_grad(binary_search, argnums=1)(
+        lambda x, y: y ** 2 - x, 5.0)
+    self.assertAllClose(value, np.sqrt(5), check_dtypes=False)
+    self.assertAllClose(grad, 0.5 / np.sqrt(5), check_dtypes=False)
+
+    def scalar_solve2(f, y):
+      y_1d = y[np.newaxis]
+      return np.linalg.solve(api.jacobian(f)(y_1d), y_1d).squeeze()
+
+    binary_search = api.custom_implicit_solve(_binary_search, scalar_solve2)
+    grad = api.grad(binary_search, argnums=1)(lambda x, y: y ** 2 - x, 5.0)
+    self.assertAllClose(grad, 0.5 / np.sqrt(5), check_dtypes=False)
+
   def test_jit_device_assignment(self):
     device_num = xb.device_count() - 1
     x = api.jit(lambda x: x, device_assignment=device_num)(3.)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -919,18 +919,18 @@ class APITest(jtu.JaxTestCase):
       return solution
 
     binary_search = api.custom_implicit_solve(_binary_search, scalar_solve)
-    value, grad = api.value_and_grad(binary_search, argnums=1)(
-        lambda x, y: y ** 2 - x, 5.0)
-    self.assertAllClose(value, np.sqrt(5), check_dtypes=False)
-    self.assertAllClose(grad, api.grad(np.sqrt)(5.0), check_dtypes=False)
+    sqrt_cubed = lambda x, y: y ** 2 - x ** 3
+    value, grad = api.value_and_grad(binary_search, argnums=1)(sqrt_cubed, 5.0)
+    self.assertAllClose(value, 5 ** 1.5, check_dtypes=False)
+    self.assertAllClose(grad, api.grad(pow)(5.0, 1.5), check_dtypes=False)
 
     def scalar_solve2(f, y):
       y_1d = y[np.newaxis]
       return np.linalg.solve(api.jacobian(f)(y_1d), y_1d).squeeze()
 
     binary_search = api.custom_implicit_solve(_binary_search, scalar_solve2)
-    grad = api.grad(binary_search, argnums=1)(lambda x, y: y ** 2 - x, 5.0)
-    self.assertAllClose(grad, api.grad(np.sqrt)(5.0), check_dtypes=False)
+    grad = api.grad(binary_search, argnums=1)(sqrt_cubed, 5.0)
+    self.assertAllClose(grad, api.grad(pow)(5.0, 1.5), check_dtypes=False)
 
   def test_jit_device_assignment(self):
     device_num = xb.device_count() - 1


### PR DESCRIPTION
``custom_implicit_solve`` is a helper function designed help library authors (most notably for ``jax.scipy.optimize``) define derivatives for functions that perform an implicit solve.

See the tests for an example of intended usage, defining a differentiable version of binary search.

This will start to become actually useful once we define some (differentiable) functions for matrix-free linear solves.