### PR TITLE
Add test case for concurrent device_get and device_put calls.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -28,7 +28,7 @@ from six.moves import reduce
 from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ConcreteArray, ShapedArray
-from ..util import partial, unzip2, concatenate, prod, memoize_unary
+from ..util import partial, unzip2, concatenate, prod
 from ..lib import xla_bridge as xb
 from .xla import xla_shape, xla_destructure, xla_shape_to_result_shape
 from .partial_eval import trace_to_subjaxpr, merge_pvals, JaxprTrace, PartialVal
@@ -525,7 +525,7 @@ def _shard_aval(axis_size, aval):
   else:
     raise TypeError(aval)
 
-@lu.memoize
+@lu.cache
 def parallel_callable(fun, axis_name, axis_size, *avals):
   avals = tuple(_shard_aval(axis_size, a) for a in avals)
   pvals = [PartialVal((aval, core.unit)) for aval in avals]

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -34,7 +34,7 @@ from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, make_shaped_array,
                                array_types)
 from ..core import AbstractTuple, JaxTuple, pack, valid_jaxtype, Literal
-from ..util import partial, partialmethod, memoize, concatenate, safe_map, prod
+from ..util import partial, partialmethod, cache, concatenate, safe_map, prod
 from ..lib import xla_bridge as xb
 from ..lib import xla_client
 from . import partial_eval as pe
@@ -54,7 +54,7 @@ def apply_primitive(prim, *args, **params):
   compiled_fun = _xla_primitive_callable(prim, *abstract_args, **params)
   return compiled_fun(*args)
 
-@memoize
+@cache()
 def _xla_primitive_callable(prim, *abstract_args, **params):
   shapes = tuple(map(xla_shape, abstract_args))
   built_c = primitive_computation(prim, *shapes, **params)
@@ -73,7 +73,7 @@ def xla_shape(x):
     else:
       raise TypeError(type(x))
 
-@memoize
+@cache()
 def primitive_computation(prim, *shapes, **params):
   """Builds an XLA computation for `prim` with argument `shapes`."""
   c = xb.make_computation_builder("primitive_computation")
@@ -695,7 +695,7 @@ def _xla_call_impl(fun, *args, **params):
           "Calling the de-optimized version.")
     return fun.call_wrapped(*args)  # probably won't return
 
-@lu.memoize
+@lu.cache
 def _xla_callable(fun, device_assignment, device_values, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -45,7 +45,7 @@ from ..interpreters import xla
 from ..interpreters import pxla
 from ..interpreters import ad
 from ..interpreters import batching
-from ..util import curry, memoize, safe_zip, unzip2, prod
+from ..util import curry, cache, safe_zip, unzip2, prod
 from ..tree_util import build_tree, tree_unflatten, tree_map
 from ..lib import xla_bridge
 from ..lib import xla_client
@@ -57,7 +57,7 @@ _min = builtins.max
 _reduce = six.moves.reduce
 
 
-@memoize
+@cache()
 def broadcast_shapes(*shapes):
   """Returns the shape that results from NumPy broadcasting of `shapes`."""
   if len(shapes) == 1:

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -123,18 +123,16 @@ register_backend('xla', _get_local_backend)
 register_backend('xrt', _get_xrt_backend)
 
 _backend_lock = threading.Lock()
+
 @util.memoize
 def get_backend():
-  global _backend_lock
-  try:
+  with _backend_lock:
     _backend_lock.acquire()
     backend = _backends.get(FLAGS.jax_xla_backend)
     if backend is None:
       msg = 'Unknown jax_xla_backend value "{}".'
       raise ValueError(msg.format(FLAGS.jax_xla_backend))
     return backend()
-  finally:
-    _backend_lock.release()
 
 
 def device_count():

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -82,12 +82,6 @@ def get_compile_options(num_replicas=None, device_assignment=None):
     compile_options.device_assignment = device_assignment
   return compile_options
 
-
-def memoize_thunk(func):
-  cached = []
-  return lambda: cached[0] if cached else (cached.append(func()) or cached[0])
-
-
 _backends = {}
 
 def register_backend(name, factory):
@@ -128,7 +122,7 @@ register_backend('xla', _get_local_backend)
 register_backend('xrt', _get_xrt_backend)
 
 
-@memoize_thunk
+@util.memoize
 def get_backend():
   backend = _backends.get(FLAGS.jax_xla_backend)
   if backend is None:
@@ -143,7 +137,7 @@ def device_count():
 
 ### utility functions
 
-@util.memoize_unary
+@util.memoize
 def dtype_to_etype(dtype):
   """Convert from dtype to canonical etype (reading FLAGS.jax_enable_x64)."""
   return xla_client.dtype_to_etype(canonicalize_dtype(dtype))
@@ -157,7 +151,7 @@ _dtype_to_32bit_dtype = {
 }
 
 
-@util.memoize_unary
+@util.memoize
 def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on FLAGS.jax_enable_x64."""
   dtype = onp.dtype(dtype)
@@ -168,7 +162,7 @@ def canonicalize_dtype(dtype):
     return _dtype_to_32bit_dtype.get(dtype, dtype)
 
 
-@memoize_thunk
+@util.memoize
 def supported_numpy_dtypes():
   return {canonicalize_dtype(dtype)
           for dtype in xla_client.XLA_ELEMENT_TYPE_TO_DTYPE.values()}

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -196,15 +196,15 @@ def wrap_init(f, params={}):
   return WrappedFun(f, [], params)
 
 
-def memoize(call, max_size=4096):
+def cache(call, max_size=4096):
   @fastcache.clru_cache(maxsize=max_size)
-  def memoized_fun_body(f, args):
+  def cached_fun_body(f, args):
     return call(f, *args), f
 
-  def memoized_fun(f, *args):
-    ans, f_prev = memoized_fun_body(f, args)
+  def cached_fun(f, *args):
+    ans, f_prev = cached_fun_body(f, args)
     if id(f_prev) != id(f):
       f.populate_stores(f_prev)
     return ans
 
-  return memoized_fun
+  return cached_fun

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -44,7 +44,7 @@ from .. import core
 from ..abstract_arrays import UnshapedArray, ShapedArray, ConcreteArray
 from ..interpreters.xla import DeviceArray
 from .. import lax
-from ..util import memoize, partial, get_module_functions, unzip2, prod as _prod
+from ..util import partial, get_module_functions, unzip2, prod as _prod
 from ..lib import xla_bridge
 from ..lib import xla_client
 

--- a/jax/util.py
+++ b/jax/util.py
@@ -139,15 +139,10 @@ def split_merge(predicate, xs):
   return lhs, rhs, merge
 
 
-def memoize(fun, max_size=4096):
-  return fastcache.clru_cache(maxsize=max_size)(fun)
+def cache(max_size=4096):
+  return fastcache.clru_cache(maxsize=max_size)
 
-def memoize_unary(func):
-  class memodict(dict):
-    def __missing__(self, key):
-      val = self[key] = func(key)
-      return val
-  return memodict().__getitem__
+memoize = fastcache.clru_cache(maxsize=None)
 
 
 def prod(xs):


### PR DESCRIPTION
Fix concurrency problems in memoize_... decorators.
Rename util.memoize to util.cache.
Remove util.memoize_unary and xla_bridge.memoize_thunk, replace with more general and thread-safe util.memoize that wraps fastcache.

Progress on issue #1037.
