### PR TITLE
Fix sphinx references in JAX docs

### DIFF
--- a/docs/async_dispatch.rst
+++ b/docs/async_dispatch.rst
@@ -25,10 +25,10 @@ DeviceArray([[258.01971436, 249.64862061, 257.13372803, ...,
 
 When an operation such as :code:`np.dot(x, x)` is executed, JAX does not wait
 for the operation to complete before returning control to the Python program.
-Instead, JAX returns a :class:`DeviceArray` value, which is a future, i.e., a
-value that will be produced in the future on an accelerator device but isn't
-necessarily available immediately. We can inspect the shape or type of a
-:class:`DeviceArray` without waiting for the computation that produced it to
+Instead, JAX returns a :class:`~jax.DeviceArray` value, which is a future,
+i.e., a value that will be produced in the future on an accelerator device but
+isn't necessarily available immediately. We can inspect the shape or type of a
+:class:`~jax.DeviceArray` without waiting for the computation that produced it to
 complete, and we can even pass it to another JAX computation, as we do with the
 addition operation here. Only if we actually inspect the value of the array from
 the host, for example by printing it or by converting it into a plain old
@@ -66,8 +66,9 @@ However it turns out that asynchronous dispatch is misleading us and we are not
 timing the execution of the matrix multiplication, only the time to dispatch
 the work. To measure the true cost of the operation we must either read the
 value on the host (e.g., convert it to a plain old host-side numpy array), or
-use the :func:`block_until_ready` method on a :class:`DeviceArray` value to wait
-for the computation that produced it to complete.
+use the :meth:`~jaxDeviceArray.block_until_ready` method on a
+:class:`DeviceArray` value to wait for the computation that produced it to
+complete.
 
 >>> %time onp.asarray(np.dot(x, x))
 CPU times: user 61.1 ms, sys: 0 ns, total: 61.1 ms

--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -6,12 +6,12 @@ JAX has some limited support for Python concurrency.
 Concurrency support is experimental and only lightly tested; please report any
 bugs.
 
-Clients may call JAX APIs (e.g., :fun:`jax.jit` or :fun:`jax.grad`) concurrently
-from separate Python threads.
+Clients may call JAX APIs (e.g., :func:`~jax.jit` or :func:`~jax.grad`)
+concurrently from separate Python threads.
 
 It is not permitted to manipulate JAX trace values concurrently from multiple
 threads. In other words, while it is permissible to call functions that use JAX
-tracing (e.g., :fun:`jax.jit`) from multiple threads, you must not use threading
-to manipulate JAX values inside the implementation of the function `f` that is
-passed to :fun:`jax.jit`. The most likely outcome if you do this is a mysterious
-error from JAX.
+tracing (e.g., :func:`~jax.jit`) from multiple threads, you must not use
+threading to manipulate JAX values inside the implementation of the function
+`f` that is passed to :func:`~jax.jit`. The most likely outcome if you do this
+is a mysterious error from JAX.


### PR DESCRIPTION
The links in `concurrency.rst` should work now.

The links in async_dispatch.rst don't work yet, but they will if
``DeviceArray`` ever ends up JAX's API docs.