### PR TITLE
improve prng compile times with loop rolling

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -32,7 +32,7 @@ from . import lax
 from . import numpy as np
 from . import tree_util
 from .api import custom_transforms, defjvp, jit, vmap
-from .numpy.lax_numpy import _constant_like, asarray
+from .numpy.lax_numpy import _constant_like, asarray, stack
 from jax.lib import xla_bridge
 from jax import core
 from jax.scipy.special import logit
@@ -123,18 +123,21 @@ def threefry_2x32(keypair, count):
   else:
     x = list(np.split(count.ravel(), 2))
 
-  rotations = asarray([[13, 15, 26, 6], [17, 29, 16, 24]], dtype="uint32")
-  ks = asarray([key1, key2, key1 ^ key2 ^ onp.uint32(0x1BD11BDA)], dtype="uint32")
-  idxs = asarray([[1, 2], [2, 0], [0, 1], [1, 2], [2, 0]])
+  rotations = onp.array([[13, 15, 26, 6], [17, 29, 16, 24]], dtype=onp.uint32)
+  ks = stack([key1, key2, key1 ^ key2 ^ onp.uint32(0x1BD11BDA)])
+  idxs = onp.array([[1, 2], [2, 0], [0, 1], [1, 2], [2, 0]])
 
   x[0] = x[0] + ks[0]
   x[1] = x[1] + ks[1]
 
+  get = partial(lax.dynamic_index_in_dim, keepdims=False)
+
   def step(i, x):
-    for r in rotations[i % 2]:
+    for r in get(rotations, i % 2):
       x = apply_round(x, r)
-    i0, i1 = idxs[i]
-    return [x[0] + ks[i0], x[1] + ks[i1] + asarray(i + 1, dtype="uint32")]
+    i0, i1 = get(idxs, i)
+    return [x[0] + ks[i0],
+            x[1] + ks[i1] + asarray(i + 1, dtype=onp.uint32)]
   out = np.concatenate(lax.fori_loop(0, 5, step, x))
   assert out.dtype == onp.uint32
   return lax.reshape(out[:-1] if odd_size else out, count.shape)

--- a/jax/random.py
+++ b/jax/random.py
@@ -123,34 +123,29 @@ def threefry_2x32(keypair, count):
   else:
     x = list(np.split(count.ravel(), 2))
 
-  rotations = onp.uint32([13, 15, 26, 6, 17, 29, 16, 24])
+  rotations = asarray([13, 15, 26, 6, 17, 29, 16, 24], dtype="uint32")
   ks = [key1, key2, key1 ^ key2 ^ onp.uint32(0x1BD11BDA)]
 
   x[0] = x[0] + ks[0]
   x[1] = x[1] + ks[1]
 
-  for r in rotations[:4]:
-    x = apply_round(x, r)
+  x = lax.fori_loop(0, 4, lambda i, x: apply_round(x, rotations[i]), x)
   x[0] = x[0] + ks[1]
   x[1] = x[1] + ks[2] + onp.uint32(1)
 
-  for r in rotations[4:]:
-    x = apply_round(x, r)
+  x = lax.fori_loop(4, 8, lambda i, x: apply_round(x, rotations[i]), x)
   x[0] = x[0] + ks[2]
   x[1] = x[1] + ks[0] + onp.uint32(2)
 
-  for r in rotations[:4]:
-    x = apply_round(x, r)
+  x = lax.fori_loop(0, 4, lambda i, x: apply_round(x, rotations[i]), x)
   x[0] = x[0] + ks[0]
   x[1] = x[1] + ks[1] + onp.uint32(3)
 
-  for r in rotations[4:]:
-    x = apply_round(x, r)
+  x = lax.fori_loop(4, 8, lambda i, x: apply_round(x, rotations[i]), x)
   x[0] = x[0] + ks[1]
   x[1] = x[1] + ks[2] + onp.uint32(4)
 
-  for r in rotations[:4]:
-    x = apply_round(x, r)
+  x = lax.fori_loop(0, 4, lambda i, x: apply_round(x, rotations[i]), x)
   x[0] = x[0] + ks[2]
   x[1] = x[1] + ks[0] + onp.uint32(5)
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -398,6 +398,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       self.assertEqual(onp.result_type(w), onp.float32)
 
   def testNoOpByOpUnderHash(self):
+    raise SkipTest()  # TODO(mattjj): re-enable this test
     def fail(): assert False
     apply_primitive, xla.apply_primitive = xla.apply_primitive, fail
     out = random.threefry_2x32(onp.zeros(2, onp.uint32), onp.arange(10, dtype=onp.uint32))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -398,11 +398,12 @@ class LaxRandomTest(jtu.JaxTestCase):
       self.assertEqual(onp.result_type(w), onp.float32)
 
   def testNoOpByOpUnderHash(self):
-    raise SkipTest()  # TODO(mattjj): re-enable this test
-    def fail(): assert False
+    def fail(*args, **kwargs): assert False
     apply_primitive, xla.apply_primitive = xla.apply_primitive, fail
-    out = random.threefry_2x32(onp.zeros(2, onp.uint32), onp.arange(10, dtype=onp.uint32))
-    xla.apply_primitive = apply_primitive
+    try:
+      out = random.threefry_2x32(onp.zeros(2, onp.uint32), onp.arange(10, dtype=onp.uint32))
+    finally:
+      xla.apply_primitive = apply_primitive
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes #1172

Code from #1172:

```python
from jax import jit, random
from jax.config import config; config.update("jax_platform_name", "cpu")
import time

def f(key, i):
    for _ in range(i):
        _, key = random.split(key)
    return key

for i in range(17):
    t = time.time()
    key = jit(f, static_argnums=(1,))(random.PRNGKey(0), i).copy()
    print("split {} times takes {}".format(i, time.time() - t))
```

Before (CPU backend):
```
split 0 times takes 0.0584418773651
split 1 times takes 0.0834980010986
split 2 times takes 0.159592151642
split 3 times takes 0.304208993912
split 4 times takes 0.499366998672
split 5 times takes 0.925127029419
split 6 times takes 1.68947792053
split 7 times takes 2.74465990067
split 8 times takes 4.27907800674
split 9 times takes 6.66637420654
split 10 times takes 9.77492880821
split 11 times takes 14.9957740307
split 12 times takes 19.7543628216
split 13 times takes 26.9135191441
split 14 times takes 33.8859760761
split 15 times takes 43.9121148586
split 16 times takes 52.6436569691
```


After 275bf9d, rolling the inner loop (CPU backend):
```
split 0 times takes 0.0326280593872
split 1 times takes 0.174847126007
split 2 times takes 0.271623849869
split 3 times takes 0.443490028381
split 4 times takes 0.658795118332
split 5 times takes 0.810074090958
split 6 times takes 1.0533349514
split 7 times takes 1.34268808365
split 8 times takes 1.60742712021
split 9 times takes 1.83798694611
split 10 times takes 2.12129998207
split 11 times takes 2.35916495323
split 12 times takes 2.70749402046
split 13 times takes 3.08042216301
split 14 times takes 3.3945119381
split 15 times takes 3.67894697189
split 16 times takes 4.16872882843
```

After d857d3f, rolling the outer loop (CPU backend):
```
split 0 times takes 0.0505750179291
split 1 times takes 0.179420948029
split 2 times takes 0.194557905197
split 3 times takes 0.23614692688
split 4 times takes 0.312750101089
split 5 times takes 0.394812107086
split 6 times takes 0.473638772964
split 7 times takes 0.554468870163
split 8 times takes 0.63796877861
split 9 times takes 0.721169948578
split 10 times takes 0.809171199799
split 11 times takes 0.899457931519
split 12 times takes 0.995654821396
split 13 times takes 1.09211206436
split 14 times takes 1.17162895203
split 15 times takes 1.27369189262
split 16 times takes 1.34894180298
```

Not only should compile times be faster in rolling the outer loop, but also it should provide faster execution than rolling the inner loop.

Execution time maybe took a slight hit compared to unrolling everything on master:

```
# on master
In [1]: from jax import random
In [2]: key = random.PRNGKey(0)
jax/lib/xla_bridge.py:109: UserWarning: No GPU/TPU found, falling back to CPU.
  warnings.warn('No GPU/TPU found, falling back to CPU.')
In [3]: timeit random.normal(key, (1000, 1000)).block_until_ready()
The slowest run took 56.75 times longer than the fastest. This could mean that an intermediate result is being cached.
1 loop, best of 3: 5.81 ms per loop
In [4]: timeit random.normal(key, (1000, 1000)).block_until_ready()
100 loops, best of 3: 5.86 ms per loop

# on d857d3f
In [1]: from jax import random
In [2]: key = random.PRNGKey(0)
jax/lib/xla_bridge.py:109: UserWarning: No GPU/TPU found, falling back to CPU.
  warnings.warn('No GPU/TPU found, falling back to CPU.')
In [3]: timeit random.normal(key, (1000, 1000)).block_until_ready()
The slowest run took 44.97 times longer than the fastest. This could mean that an intermediate result is being cached.
1 loop, best of 3: 6.93 ms per loop
In [4]: timeit random.normal(key, (1000, 1000)).block_until_ready()
100 loops, best of 3: 7.45 ms per loop
```

@fehiepsi unless this execution time cost seems onerous (which we can trade off against compile time by doing more unrolling), this seems like a net win to me! Maybe XLA can learn to optimize loops better to close the execution time gap.

If you can make a benchmark for us and the XLA team, we can make it fast!