### PR TITLE
Update Docker build to produce manylinux2010 compliant wheels.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,21 +1,5 @@
-ARG CUDA_VERSION=9.2
-FROM nvidia/cuda:$CUDA_VERSION-cudnn7-devel-ubuntu16.04
+FROM gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010
 LABEL maintainer "Matt Johnson <mattjj@google.com>"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-            dh-autoreconf git curl \
-            build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
-            libsqlite3-dev wget llvm libncurses5-dev xz-utils tk-dev \
-            libxml2-dev libxmlsec1-dev libffi-dev openjdk-8-jdk curl \
-            bash-completion unzip python
-
-RUN wget "https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel_0.26.1-linux-x86_64.deb" && \
-    dpkg -i bazel_0.26.1-linux-x86_64.deb
-
-RUN git clone https://github.com/nixos/patchelf /tmp/patchelf
-WORKDIR /tmp/patchelf
-RUN bash bootstrap.sh && ./configure && make && make install && rm -r /tmp/patchelf
-
 
 WORKDIR /
 RUN git clone https://github.com/pyenv/pyenv.git /pyenv
@@ -30,6 +14,24 @@ RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 2.7.15 && pip in
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.5.6 && pip install numpy==1.15.4 scipy cython setuptools wheel
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.6.8 && pip install numpy==1.15.4 scipy cython setuptools wheel
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.7.2 && pip install numpy==1.15.4 scipy cython setuptools wheel
+
+# Change the CUDA version if it doesn't match the installed version.
+ARG JAX_CUDA_VERSION=10.0
+RUN /bin/bash -c 'if [[ ! "$CUDA_VERSION" =~ ^$JAX_CUDA_VERSION.*$ ]]; then \
+  apt-get update && \
+  apt-get remove -y --allow-change-held-packages cuda-license-10-0 libcudnn7 libnccl2 && \
+  apt-get install -y --no-install-recommends \
+      cuda-nvml-dev-$JAX_CUDA_VERSION \
+      cuda-command-line-tools-$JAX_CUDA_VERSION \
+      cuda-libraries-dev-$JAX_CUDA_VERSION \
+      cuda-minimal-build-$JAX_CUDA_VERSION \
+      libnccl2=$NCCL_VERSION-1+cuda$JAX_CUDA_VERSION \
+      libnccl-dev=$NCCL_VERSION-1+cuda$JAX_CUDA_VERSION \
+      libcudnn7=$CUDNN_VERSION-1+cuda$JAX_CUDA_VERSION \
+      libcudnn7-dev=$CUDNN_VERSION-1+cuda$JAX_CUDA_VERSION && \
+  rm -f /usr/local/cuda && \
+  ln -s /usr/local/cuda-$JAX_CUDA_VERSION /usr/local/cuda; \
+  fi'
 
 
 WORKDIR /

--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -14,16 +14,12 @@ do
   mkdir -p dist/nocuda/
   docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
   mv dist/*.whl dist/nocuda/
-  for I in $(find dist/nocuda/ -name "*linux_x86_64.whl")
-  do
-    mv $I $(echo $I | sed -e 's/linux_x86_64/manylinux1_x86_64/')
-  done
 done
 
 # build the cuda linux packages, tagging with linux_x86_64
 for CUDA_VERSION in $CUDA_VERSIONS
 do
-  docker build -t jaxbuild jax/build/ --build-arg CUDA_VERSION=$CUDA_VERSION
+  docker build -t jaxbuild jax/build/ --build-arg JAX_CUDA_VERSION=$CUDA_VERSION
   for PYTHON_VERSION in $PYTHON_VERSIONS
   do
     for CUDA_VARIANT in $CUDA_VARIANTS

--- a/build/build_wheel_docker_entrypoint.sh
+++ b/build/build_wheel_docker_entrypoint.sh
@@ -6,6 +6,7 @@ then
   exit 1
 fi
 
+export CC=/dt7/usr/bin/gcc
 export PYENV_ROOT="/pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
@@ -34,22 +35,26 @@ fi
 pyenv local "$PY_VERSION"
 
 PY_TAG=$(python -c "import wheel; import wheel.pep425tags as t; print(t.get_abbr_impl() + t.get_impl_ver())")
-echo "Python tag $PY_TAG"
+
+echo "Python tag: $PY_TAG"
 
 case $2 in
   cuda-included)
     python build.py --enable_cuda --bazel_startup_options="--output_user_root=/build/root"
     python include_cuda.py
+    PLAT_NAME="manylinux2010_x86_64"
     ;;
   cuda)
     python build.py --enable_cuda --bazel_startup_options="--output_user_root=/build/root"
+    PLAT_NAME="linux_x86_64"
     ;;
   nocuda)
     python build.py --bazel_startup_options="--output_user_root=/build/root"
+    PLAT_NAME="manylinux2010_x86_64"
     ;;
   *)
     usage
 esac
 
-python setup.py bdist_wheel --python-tag "$PY_TAG" --plat-name "linux_x86_64"
+python setup.py bdist_wheel --python-tag "$PY_TAG" --plat-name "$PLAT_NAME"
 cp -r dist/* /dist


### PR DESCRIPTION
Previously we lied and claimed our wheels were manylinux1 compliant but they weren't.

Uses a cross-compilation toolchain from the TF folks that builds manylinux2010 compliant wheels from a Ubuntu 16.04 VM.

The CUDA wheels still aren't manylinux2010 compliant because they depend on CUDA libraries from the system.