### PR TITLE
Make DeviceValue and subclasses weakref friendly

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -434,7 +434,7 @@ for _t in array_types:
 
 class DeviceValue(object):
   """A DeviceValue represents a value backed by device memory."""
-  __slots__ = ["aval", "device_buffer"]
+  __slots__ = ["aval", "device_buffer", "__weakref__"]
 
   def __init__(self, aval, device_buffer):
     self.aval = aval


### PR DESCRIPTION
Adds a `__weakref__` item to `__slots__` to make the class friendly to `weakref.ref`.

https://stackoverflow.com/questions/19526340/weakref-and-slots
