### PR TITLE
Change dynamic-slice and dynamic-update-slice primitives to have one …

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2735,9 +2735,10 @@ def _dynamic_slice_jvp(primals, tangents, slice_sizes, operand_shape):
 def _dynamic_slice_transpose_rule(t, operand, *start_indices, slice_sizes=None,
                                   operand_shape=None):
   assert operand is None
+  assert all(s is not None for s in start_indices)
   zeros = full(operand_shape, tie_in(t, _zero(t)))
   return ([dynamic_update_slice(zeros, t, start_indices)] +
-          [ad_util.zero] * len(start_indices))
+          [None] * len(start_indices))
 
 def _batch_dynamic_slice_indices(indices, bdims):
   size = next((x.shape[i] for x, i in zip(indices, bdims) if i is not None), -1)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2744,8 +2744,10 @@ def _batch_dynamic_slice_indices(indices, bdims):
   if size < 0:
     return concatenate([reshape(i, [1]) for i in indices], 0), None
   indices = concatenate(
-    [broadcast_in_dim(x, (size, 1), broadcast_dimensions=(0,))
-     for x in indices], dimension=1)
+    [broadcast_in_dim(x, (size, 1),
+                      broadcast_dimensions=((0,) if i is not None else ()))
+     for x, i in zip(indices, bdims)],
+    dimension=1)
   return indices, 0
 
 def _dynamic_slice_batching_rule(batched_args, batch_dims, slice_sizes,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2740,12 +2740,12 @@ def _dynamic_slice_transpose_rule(t, operand, *start_indices, slice_sizes=None,
           [ad_util.zero] * len(start_indices))
 
 def _batch_dynamic_slice_indices(indices, bdims):
-  size = next((x.shape[i] for x, i in zip(indices, bdims)), -1)
-  if size >= 0:
-    return concatenate([reshape(i, [1]) for i in start_indices], 0), None
+  size = next((x.shape[i] for x, i in zip(indices, bdims) if i is not None), -1)
+  if size < 0:
+    return concatenate([reshape(i, [1]) for i in indices], 0), None
   indices = concatenate(
-    [broadcast_to(x, (size, 1), broadcast_dims=(0,)) for x in indices],
-    dimension=1)
+    [broadcast_in_dim(x, (size, 1), broadcast_dimensions=(0,))
+     for x in indices], dimension=1)
   return indices, 0
 
 def _dynamic_slice_batching_rule(batched_args, batch_dims, slice_sizes,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1278,15 +1278,14 @@ def index_in_dim(operand, index, axis=0, keepdims=True):
 
 def dynamic_slice_in_dim(operand, start_index, slice_size, axis=0):
   """Convenience wrapper around dynamic_slice applying to one dimension."""
-  start_indices = [onp.array([0], dtype=_dtype(start_index))] * operand.ndim
+  start_indices = [0] * operand.ndim
   slice_sizes = list(operand.shape)
 
   axis = int(axis)
   axis_size = _const(start_index, operand.shape[axis])
-  start_indices[axis] = reshape(rem(start_index, axis_size), [1])
+  start_indices[axis] = rem(start_index, axis_size)
   slice_sizes[axis] = int(slice_size)
 
-  start_indices = concatenate(start_indices, 0)
   return dynamic_slice(operand, start_indices, slice_sizes)
 
 


### PR DESCRIPTION
…argument per index, not a single array index.

XLA deprecated the single-array-of-indices form of dynamic-slices. It is preferable to use a list of scalar indices since it helps XLA generate more efficient code in the case that some indices are constant but others are not.