### PR TITLE
Use log1p when computing log(1 + x) or log(1 - x)

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -516,7 +516,7 @@ def _exponential(key, shape, dtype):
   _check_shape("exponential", shape)
   u = uniform(key, shape, dtype)
   # taking 1 - u to move the domain of log to (0, 1] instead of [0, 1)
-  return lax.neg(lax.log(lax.sub(_constant_like(u, 1), u)))
+  return lax.neg(lax.log1p(lax.neg(u)))
 
 
 def _gamma_one(key, alpha):

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -33,7 +33,7 @@ def logpdf(x, a, b, loc=0, scale=1):
   shape_term = lax.sub(gammaln(lax.add(a, b)), shape_term_tmp)
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.add(lax.mul(lax.sub(a, one), lax.log(y)),
-                            lax.mul(lax.sub(b, one), lax.log(lax.sub(one, y))))
+                            lax.mul(lax.sub(b, one), lax.log1p(lax.neg(y))))
   log_probs = lax.sub(lax.add(shape_term, log_linear_term), lax.log(scale))
   return where(logical_or(lax.gt(x, lax.add(loc, scale)),
                           lax.lt(x, loc)), -inf, log_probs)

--- a/jax/scipy/stats/cauchy.py
+++ b/jax/scipy/stats/cauchy.py
@@ -30,7 +30,7 @@ def logpdf(x, loc=0, scale=1):
   pi = _constant_like(x, onp.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.mul(pi, scale))
-  return lax.neg(lax.add(normalize_term, lax.log(one + lax.mul(scaled_x, scaled_x))))
+  return lax.neg(lax.add(normalize_term, lax.log1p(lax.mul(scaled_x, scaled_x))))
 
 @_wraps(osp_stats.cauchy.pdf)
 def pdf(x, loc=0, scale=1):


### PR DESCRIPTION
log(1 + x) is less accurate when its input is near zero whereas log1p
can compute the result without excessive accuracy loss.