### PR TITLE
Makes the `Tracer` object `weakref`-able

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -282,7 +282,7 @@ class Trace(object):
 
 class Tracer(object):
   __array_priority__ = 1000
-  __slots__ = ['trace']
+  __slots__ = ['trace', '__weakref__']
 
   def __array__(self):
     raise Exception("Tracer can't be used with raw numpy functions. "


### PR DESCRIPTION
Follow on to https://github.com/google/jax/pull/1180, which did this for `DeviceArray`.