### PR TITLE
log1p insead of log in logsumexp

### DIFF
--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -82,7 +82,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
   dimadd = lambda x: lax.reshape(x, shape)
   amax = lax.reduce(a, _constant_like(a, -onp.inf), lax.max, dims)
   amax_singletons = dimadd(amax)
-  out = lax.add(lax.log(lax.reduce(lax.exp(lax.sub(a, amax_singletons)),
+  out = lax.add(lax.log1p(lax.reduce(lax.exp(lax.sub(a, amax_singletons)),
                                    _constant_like(a, 0), lax.add, dims)), amax)
   return dimadd(out) if keepdims else out
 


### PR DESCRIPTION
Fixes #1205 
Hey @mattjj !

I used log1p instead of log! However, I wasn't sure how to make in analogous to #1204 though. 


I couldn't figure out how to re-write the code for ```lax.reduce``` inside.

Is this what was required? 

Let me know if this needs any changes, and I'd be happy to do those!

Thanks! =) 