### PR TITLE
Use expm1 in elu

### DIFF
--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -42,7 +42,7 @@ import jax.numpy as np
 def relu(x): return np.maximum(x, 0.)
 def softplus(x): return np.logaddexp(x, 0.)
 def sigmoid(x): return 1. / (1. + np.exp(-x))
-def elu(x): return np.where(x > 0, x, np.exp(x) - 1)
+def elu(x): return np.where(x > 0, x, np.expm1(x))
 def leaky_relu(x): return np.where(x >= 0, x, 0.01 * x)
 
 def logsoftmax(x, axis=-1):


### PR DESCRIPTION
expm1(x) is more accurate than exp(x) - 1 when x is nearly, but not
exactly, zero.

In the case of elu, we would compute exp(x) - 1 when x is <= 0. If x is
negative and has a very small magnitude, computing exp(x) - 1 would
round to zero.

For example, if x was -1.0E-8 then:
 exp(x) - 1 is 0 but expm1(x) is -1.0E-8