### PR TITLE
Make `JVPTracer` and `BatchTracer` `weakref`-able.

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -306,7 +306,7 @@ class JVPTrace(Trace):
 
 
 class JVPTracer(Tracer):
-  __slots__ = ['primal', 'tangent']
+  __slots__ = ['primal', 'tangent', '__weakref__']
 
   def __init__(self, trace, primal, tangent):
     if not core.skip_checks:

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -72,7 +72,7 @@ def batch_subtrace(master, dims, *vals):
 
 
 class BatchTracer(Tracer):
-  __slots__ = ['val', 'batch_dim']
+  __slots__ = ['val', 'batch_dim', '__weakref__']
 
   def __init__(self, trace, val, batch_dim):
     assert core.skip_checks or type(batch_dim) in (int, tuple, type(None))


### PR DESCRIPTION
In the spirit of #1180 and #1202 this helps with `jax.grad` compatibility for TensorFlow Probability.