### PR TITLE
Require opt_einsum version to be less than 3.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=find_packages(exclude=["examples"]),
     install_requires=[
-        'numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py', 'opt_einsum',
+        'numpy>=1.12', 'six', 'protobuf>=3.6.0', 'absl-py', 'opt_einsum<3',
         'fastcache'
     ],
     url='https://github.com/google/jax',


### PR DESCRIPTION
opt_einsum 3.0.0 adds a jax backend, which raises an exception on import.