### PR TITLE
Add jax.devices() and friends, and add `devices` arg to pmap.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3297,7 +3297,7 @@ def _reduce_batch_rule(batched_args, batch_dims, computation, jaxpr, consts, dim
 
 def _reduction_computation(c, jaxpr, backend, consts, init_value):
   shape = c.GetShape(init_value)
-  axis_env = xla.AxisEnv(1, [], [])  # no parallel primitives inside reductions
+  axis_env = xla.AxisEnv()  # no parallel primitives inside reductions
   c, (out,) = xla._jaxpr_computation(jaxpr, backend, axis_env, consts, (), shape, shape)
   return c.Build(out)
 


### PR DESCRIPTION
This change adds the following APIs:
* jax.devices(). This returns a list of available Device subclass instances.
* jax.host_id(). Currently always 0, but will be useful on multi-host platforms.
* jax.local_device_count(). Currently always equal to jax.device_count(), but
    will be useful on multi-host platforms.
* Optional `devices` argument to pmap. This can be used to specify which devices
    should be used in the replicated computation.