### PR TITLE
No more tuples

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -193,10 +193,10 @@ def zeros_like_shaped_array(aval):
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
 def raise_to_shaped(aval):
-  if type(aval) is core.AbstractTuple:
-    return core.AbstractTuple(map(raise_to_shaped, aval))
-  elif isinstance(aval, ShapedArray):
+  if isinstance(aval, ShapedArray):
     return ShapedArray(aval.shape, aval.dtype)
+  elif aval is core.abstract_unit:
+    return core.abstract_unit
   else:
     raise TypeError(type(aval))
 

--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -16,20 +16,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .core import JaxTuple, lattice_join, Primitive, AbstractTuple
+from .core import lattice_join, Primitive
 from .tree_util import register_pytree_node
 from .util import safe_map
 
 map = safe_map
 
 jaxval_adders = {}
-
-def add_jaxtuples(xs, ys):
-  assert len(xs) == len(ys)
-  return JaxTuple(map(add_impl, xs, ys))
-
-jaxval_adders[JaxTuple] = add_jaxtuples
-
 
 def add_jaxvals(x, y):
   return add_jaxvals_p.bind(x, y)
@@ -49,17 +42,10 @@ def zeros_like_impl_jaxtuple(xs):
   return JaxTuple(map(zeros_like_impl, xs))
 
 jaxval_zeros_likers = {}
-jaxval_zeros_likers[JaxTuple] = zeros_like_impl_jaxtuple
-
 
 def zeros_like_aval(aval):
   return aval_zeros_likers[type(aval)](aval)
 aval_zeros_likers = {}
-
-def zeros_like_abstract_tuple(tup):
-  return JaxTuple(map(zeros_like_aval, tup))
-aval_zeros_likers[AbstractTuple] = zeros_like_abstract_tuple
-
 
 def zeros_like_jaxval(val):
   return zeros_like_p.bind(val)
@@ -71,7 +57,6 @@ def zeros_like_impl(example):
   return jaxval_zeros_likers[type(example)](example)
 
 zeros_like_p.def_abstract_eval(lambda x: x)
-
 
 class Zero(object):
   def __repr__(self):

--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -16,13 +16,14 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .core import lattice_join, Primitive
+from .core import lattice_join, Primitive, Unit, unit, AbstractUnit, abstract_unit
 from .tree_util import register_pytree_node
 from .util import safe_map
 
 map = safe_map
 
 jaxval_adders = {}
+jaxval_adders[Unit] = lambda _, __: unit
 
 def add_jaxvals(x, y):
   return add_jaxvals_p.bind(x, y)
@@ -45,7 +46,9 @@ jaxval_zeros_likers = {}
 
 def zeros_like_aval(aval):
   return aval_zeros_likers[type(aval)](aval)
+
 aval_zeros_likers = {}
+aval_zeros_likers[AbstractUnit] = lambda _: unit
 
 def zeros_like_jaxval(val):
   return zeros_like_p.bind(val)

--- a/jax/api.py
+++ b/jax/api.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import itertools
+import itertools as it
 import operator as op
 import os
 import threading
@@ -44,14 +44,14 @@ from . import core
 from . import linear_util as lu
 from . import ad_util
 from .core import eval_jaxpr
-from .api_util import (wraps, flatten_fun, abstract_tuple_tree_leaves, apply_flat_fun)
-from .tree_util import (process_pytree, node_types, build_tree, PyTreeDef,
-                        tree_map, tree_flatten, tree_unflatten, tree_structure,
-                        tree_transpose, leaf, tree_leaves)
+from .api_util import (wraps, flatten_fun, apply_flat_fun, flatten_fun_nokwargs,
+                       flatten_fun_nokwargs2, apply_flat_fun_nokwargs)
+from .tree_util import (tree_map, tree_flatten, tree_unflatten, tree_structure,
+                        tree_transpose, tree_leaves, tree_multimap)
 from .util import (unzip2, unzip3, curry, partial, safe_map, safe_zip,
-                   WrapHashably, Hashable, prod)
+                   WrapHashably, Hashable, prod, split_list)
 from .lib.xla_bridge import canonicalize_dtype, device_count
-from .abstract_arrays import ShapedArray
+from .abstract_arrays import ShapedArray, raise_to_shaped
 from .interpreters import partial_eval as pe
 from .interpreters import xla
 from .interpreters import pxla
@@ -118,9 +118,6 @@ def jit(fun, static_argnums=(), device_assignment=None):
   [-0.54485154  0.27744263 -0.29255125 -0.91421586 -0.62452525 -0.2474813
    -0.8574326  -0.7823267   0.7682731   0.59566754]
   """
-  return _jit(fun, static_argnums, device_assignment)
-
-def _jit(fun, static_argnums, device_assignment):
   _check_callable(fun)
   if isinstance(device_assignment, int):
     device_assignment = (device_assignment,)
@@ -332,14 +329,15 @@ def grad(fun, argnums=0, has_aux=False, holomorphic=False):
 
   @wraps(fun, docstr=docstr, argnums=argnums)
   def grad_f(*args, **kwargs):
-    if not has_aux:
-      _, g = value_and_grad_f(*args, **kwargs)
-      return g
-    else:
-      (_, aux), g = value_and_grad_f(*args, **kwargs)
-      return g, aux
+    _, g = value_and_grad_f(*args, **kwargs)
+    return g
 
-  return grad_f
+  @wraps(fun, docstr=docstr, argnums=argnums)
+  def grad_f_aux(*args, **kwargs):
+    (_, aux), g = value_and_grad_f(*args, **kwargs)
+    return g, aux
+
+  return grad_f_aux if has_aux else grad_f
 
 def value_and_grad(fun, argnums=0, has_aux=False, holomorphic=False):
   """Creates a function which evaluates both `fun` and the gradient of `fun`.
@@ -576,20 +574,20 @@ def vmap(fun, in_axes=0, out_axes=0):
   product:
 
   >>> vv = lambda x, y: np.vdot(x, y)  #  ([a], [a]) -> []
-  >>> mv1 = vmap(vv, (0, 0), 0)        #  ([b,a], [b,a]) -> [b]        (b is the new axis)
-  >>> mv2 = vmap(vv, (0, 1), 0)        #  ([b,a], [a,b]) -> [b]        (b is the new axis)
-  >>> mv3 = vmap(vv, (0, None), 0)     #  ([b,a], [a]) -> [b]          (b is the new axis)
-  >>> mm2 = vmap(mv2, (1, 1), 0)       #  ([b,c,a], [a,c,b]) -> [c,b]  (c is the new axis)
-  >>> mm3 = vmap(mv3, (None, 1), 1)    #  ([b,a], [a,c]) -> [b,c]      (c is the new axis)
+  >>> mv = vmap(vv, (0, None), 0)      #  ([b,a], [a]) -> [b]      (b is the mapped axis)
+  >>> mm = vmap(mv, (None, 1), 1)      #  ([b,a], [a,c]) -> [b,c]  (c is the mapped axis)
 
-  (here we use `[a,b]` to indicate an array with shape (a,b))
+  Here we use `[a,b]` to indicate an array with shape (a,b). Here are some
+  variants:
+
+  >>> mv1 = vmap(vv, (0, 0), 0)   #  ([b,a], [b,a]) -> [b]        (b is the mapped axis)
+  >>> mv2 = vmap(vv, (0, 1), 0)   #  ([b,a], [a,b]) -> [b]        (b is the mapped axis)
+  >>> mm2 = vmap(mv2, (1, 1), 0)  #  ([b,c,a], [a,c,b]) -> [c,b]  (c is the mapped axis)
   """
-
   docstr = ("Vectorized version of {fun}. Takes similar arguments as {fun} "
             "but with additional array axes over which {fun} is mapped.")
 
   _check_callable(fun)
-
   if (not isinstance(in_axes, (list, tuple, type(None), int))
       or not isinstance(out_axes, (list, tuple, type(None), int))):
     msg = ("vmap arguments in_axes and out_axes must each be an integer, None, "
@@ -597,19 +595,33 @@ def vmap(fun, in_axes=0, out_axes=0):
     raise TypeError(msg.format(type(in_axes), type(out_axes)))
 
   @wraps(fun, docstr=docstr)
-  def batched_fun(*args, **kwargs):
-    if kwargs:
-      msg = ("kwargs not yet supported for functions output by vmap. Please "
-             "+1 the issue https://github.com/google/jax/issues/912")
-      raise NotImplementedError(msg)
-    f = lu.wrap_init(fun, kwargs) if not isinstance(fun, lu.WrappedFun) else fun
-    in_axes_ = in_axes if isinstance(in_axes, (list, tuple)) else (in_axes,) * len(args)
-    in_flat, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-    jaxtree_fun, out_tree = pytree_fun_to_jaxtupletree_fun(f, in_trees)
-    out_flat = batching.batch(jaxtree_fun, in_flat, in_axes_, out_axes)
-    return build_tree(out_tree(), out_flat)
+  def batched_fun(*args):
+    args_flat, in_tree  = tree_flatten(args)
+    f = lu.wrap_init(fun)
+    flat_fun, out_tree = flatten_fun_nokwargs(f, in_tree)
+    out_flat = batching.batch(flat_fun, args_flat, _flatten_axes(in_tree, in_axes),
+                              lambda: _flatten_axes(out_tree(), out_axes))
+    return tree_unflatten(out_tree(), out_flat)
 
   return batched_fun
+
+def _flatten_axes(treedef, axis_tree):
+  dummy = tree_unflatten(treedef, [object()] * treedef.num_leaves)
+  axes = []
+  add_leaves = lambda i, x: axes.extend([i] * len(tree_flatten(x)[0]))
+  # TODO(mattjj): remove _replace_nones / list comp after jaxlib 0.1.25
+  tree_multimap(add_leaves, _replace_nones(axis_tree), dummy)
+  axes = [None if a is _none_proxy else a for a in axes]
+  return axes
+
+# TODO(mattjj): remove this when jaxlib is updated past 0.1.25
+def _replace_nones(tuptree):
+  if type(tuptree) is tuple:
+    return tuple(map(_replace_nones, tuptree))
+  else:
+    return tuptree if tuptree is not None else _none_proxy
+class _NoneProxy(object): pass
+_none_proxy = _NoneProxy()
 
 
 def pmap(fun, axis_name=None):
@@ -701,36 +713,31 @@ def pmap(fun, axis_name=None):
 
   @wraps(fun)
   def f_pmapped(*args, **kwargs):
-    axis_size = _pmap_axis_size((args, kwargs))
     f = lu.wrap_init(fun)
-    args_flat, in_tree = tree_flatten((args, kwargs))
-    flat_fun, out_tree = flatten_fun_leafout(f, in_tree)
-    out = pxla.xla_pmap(flat_fun, *args_flat,
-                        axis_name=axis_name, axis_size=axis_size)
-    return out if treedef_is_leaf(out_tree()) else tree_unflatten(out_tree(), out)
+    args, in_tree = tree_flatten((args, kwargs))
+    axis_size = _pmap_axis_size(args)
+    _check_args(args)
+    flat_fun, out_tree = flatten_fun(f, in_tree)
+    out = pxla.xla_pmap(flat_fun, *args, axis_name=axis_name, axis_size=axis_size)
+    return tree_unflatten(out_tree(), out)
 
   namestr = "pmap({}, axis_name={})".format
   f_pmapped.__name__ = namestr(f_pmapped.__name__, axis_name)
   return f_pmapped
 
+def _pmap_axis_size(xs):
+  for x in xs:
+    try:
+      return x.shape[0]
+    except AttributeError:
+      pass
+  else:
+    msg = "pmap got value with no leading axis to map over: {}."
+    raise ValueError(msg.format([x for x in xs if not hasattr(x, 'shape')]))
+
 class _TempAxisName(object):
   def __repr__(self):
     return '<axis {}>'.format(hex(id(self)))
-
-def _pmap_axis_size(args):
-  try:
-    return next(_axis_size(leaf) for arg in args for leaf in tree_leaves(arg))
-  except StopIteration:
-    raise ValueError("pmap requires a leading axis to map over.")
-
-def _axis_size(x):
-  try:
-    return x.shape[0]
-  except AttributeError:
-    aval = core.get_aval(x)
-    if type(aval) is core.AbstractTuple:
-      return next(leaf.shape[0] for leaf in abstract_tuple_tree_leaves(aval))
-  raise ValueError("could not get axis size of type: {}".format(x))
 
 
 def soft_pmap(fun, axis_name=None):
@@ -738,48 +745,47 @@ def soft_pmap(fun, axis_name=None):
   axis_name = _TempAxisName() if axis_name is None else axis_name
 
   @wraps(fun)
-  def f_pmapped(*args):
-    axis_size = _pmap_axis_size(args)
+  def f_pmapped(*args, **kwargs):
+    f = lu.wrap_init(fun)
+    args_flat, in_tree = tree_flatten((args, kwargs))
+    axis_size = _pmap_axis_size(args_flat)
+    _check_args(args_flat)
+    flat_fun, out_tree = flatten_fun(f, in_tree)
+
     chunk_size, leftover = divmod(axis_size, pxla.unmapped_device_count())
     if chunk_size == 0 and leftover:
       return pmap(fun, axis_name)(*args)  # can map directly onto hardware
     elif leftover:
-      raise ValueError
+      msg = ("soft_pmap mapped axis size must be divisble by the number of "
+             "XLA devices (or be less than or equal to that number), but got "
+             "an axis size of {} with {} devices.")
+      raise ValueError(msg.format(axis_size, pxla.pxla.unmapped_device_count()))
     num_chunks = axis_size // chunk_size
 
-    f = lu.wrap_init(fun)
-    in_flat, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-    jaxtree_fun, out_tree = pytree_fun_to_jaxtupletree_fun(f, in_trees)
-    reshaped_args = map(partial(_reshape_split, num_chunks), in_flat)
-    soft_mapped_fun = pxla.split_axis(jaxtree_fun, axis_name, chunk_size)
-    reshaped_out = pxla.xla_pmap(soft_mapped_fun, *reshaped_args,
-                                 axis_name=axis_name, axis_size=num_chunks)
-    return build_tree(out_tree(), _reshape_merge(reshaped_out))
+    reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]
+    soft_mapped_fun = pxla.split_axis(flat_fun, axis_name, chunk_size)
+    reshaped_outs = pxla.xla_pmap(soft_mapped_fun, *reshaped_args,
+                                  axis_name=axis_name, axis_size=num_chunks)
+    outs = [_reshape_merge(out) for out in reshaped_outs]
+    return tree_unflatten(out_tree(), outs)
 
   namestr = "soft_pmap({}, axis_name={})".format
   f_pmapped.__name__ = namestr(f_pmapped.__name__, axis_name)
   return f_pmapped
 
-def _reshape_split(num_chunks, arg):
-  def split(aval, arg):
-    t = type(aval)
-    if t is ShapedArray:
-      prefix = (num_chunks, arg.shape[0] // num_chunks)
-      return arg.reshape(prefix + arg.shape[1:])
-    else:
-      raise TypeError(aval)
+def _reshape_split(num_chunks, x):
+  aval = core.get_aval(x)
+  if aval is core.abstract_unit:
+    return x
+  else:
+    return x.reshape((num_chunks, x.shape[0] // num_chunks) + x.shape[1:])
 
-  return split(batching.get_aval(arg), arg)
-
-def _reshape_merge(ans):
-  def merge(aval, ans):
-    t = type(aval)
-    if t is ShapedArray:
-      return ans.reshape((-1,) + ans.shape[2:])
-    else:
-      raise TypeError(aval)
-
-  return merge(batching.get_aval(ans), ans)
+def _reshape_merge(x):
+  aval = core.get_aval(x)
+  if aval is core.abstract_unit:
+    return x
+  else:
+    return x.reshape((-1,) + x.shape[2:])
 
 
 def _papply(fun):
@@ -787,12 +793,12 @@ def _papply(fun):
   axis_name = _TempAxisName()
 
   def papply_fun(*args, **kwargs):
-    axis_size = _pmap_axis_size(args)
-    f = lu.wrap_init(fun, kwargs)
-    args_flat, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-    jaxtree_fun, out_tree = pytree_fun_to_jaxtupletree_fun(f, in_trees)
-    out_flat = parallel.papply(jaxtree_fun, axis_name, args_flat, axis_size)
-    return build_tree(out_tree(), out_flat)
+    f = lu.wrap_init(fun)
+    args_flat, in_tree = tree_flatten((args, kwargs))
+    flat_fun, out_tree = flatten_fun(f, in_tree)
+    axis_size = _pmap_axis_size(args_flat)
+    out_flat = parallel.papply(flat_fun, axis_name, args_flat, axis_size)
+    return tree_unflatten(out_tree(), out_flat)
 
   return papply_fun, axis_name
 
@@ -801,7 +807,11 @@ def _parallelize(fun):
   axis_name = _TempAxisName()
 
   def pfun(*args):
-    axis_size = _pmap_axis_size(args)
+    f = lu.wrap_init(fun)
+    args_flat, in_tree = tree_flatten(args)
+    f, out_tree = flatten_fun_nokwargs(f, in_tree)
+    axis_size = _pmap_axis_size(args_flat)
+
     chunk_size, leftover = divmod(axis_size, pxla.unmapped_device_count())
     if chunk_size == 0 and leftover:
       return pmap(fun, axis_name)(*args)  # can map directly onto hardware
@@ -809,15 +819,15 @@ def _parallelize(fun):
       raise ValueError
     num_chunks = axis_size // chunk_size
 
-    f = lu.wrap_init(fun)
-    args_flat, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-    args_flat = map(partial(_reshape_split, num_chunks), args_flat)
-    f, out_tree = pytree_fun_to_jaxtupletree_fun(f, in_trees)
-    f, out_axis = parallel.papply_transform(f, axis_name, axis_size)
+    reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]
+    f, out_axes = parallel.papply_transform(f, axis_name, axis_size)
     f = pxla.split_axis(f, axis_name, chunk_size)
-    out = pxla.xla_pmap(f, *args_flat, axis_name=axis_name, axis_size=num_chunks)
-    out = parallel.match_axis(0, out_axis(), _reshape_merge(out))
-    return build_tree(out_tree(), out)
+    outs = pxla.xla_pmap(f, *reshaped_args, axis_name=axis_name,
+                         axis_size=num_chunks)
+    outs = map(_reshape_merge, outs)
+    outs = [batching.matchaxis(axis_size, 0, dst, x)
+            for dst, x in zip(out_axes(), outs)]
+    return tree_unflatten(out_tree(), outs)
 
   return pfun
 
@@ -855,10 +865,10 @@ def jvp(fun, primals, tangents):
   if not isinstance(fun, lu.WrappedFun):
     fun = lu.wrap_init(fun)
 
-  ps_flat, tree_def = tree_flatten((primals, {}))
-  ts_flat, tree_def_2 = tree_flatten((tangents, {}))
+  ps_flat, tree_def = tree_flatten(primals)
+  ts_flat, tree_def_2 = tree_flatten(tangents)
   assert tree_def == tree_def_2, (tree_def, tree_def_2)
-  flat_fun, out_tree = flatten_fun(fun, tree_def)
+  flat_fun, out_tree = flatten_fun_nokwargs(fun, tree_def)
   out_primals, out_tangents = ad.jvp(flat_fun).call_wrapped(ps_flat, ts_flat)
   return (tree_unflatten(out_tree(), out_primals),
           tree_unflatten(out_tree(), out_tangents))
@@ -938,7 +948,7 @@ def lift_linearized(jaxpr, primal_avals, consts, io_tree, out_pvals, *py_args):
         msg = ("linearized function called on tangent values inconsistent with "
                "the original primal values.")
         raise ValueError(msg)
-    dummy = tangents
+    dummy = (core.unit,) * len(tangents)
     out = eval_jaxpr(jaxpr, consts, (), *(dummy + tangents))
     tangents_out = out[len(out)//2:]
     return tuple(map(pe.merge_pvals, tangents_out, out_pvals))
@@ -994,38 +1004,21 @@ def vjp(fun, *primals, **kwargs):
   primals_flat, in_tree = tree_flatten(primals)
   _check_args(primals_flat)
   tree_map(_check_inexact_input_vjp, primals)
-  jaxtree_fun, out_tree = flatten_fun(fun, in_tree)
   if not has_aux:
-    out_primal, out_vjp = ad.vjp(jaxtree_fun, primals_flat)
+    flat_fun, out_tree = flatten_fun_nokwargs(fun, in_tree)
+    out_primal, out_vjp = ad.vjp(flat_fun, primals_flat)
+    out_tree = out_tree()
   else:
-    out_primal, out_vjp, aux = ad.vjp(jaxtree_fun, primals_flat, has_aux=True)
-  out_tree = out_tree()
-  if has_aux:
-    out_tree, aux_tree = treedef_children(out_tree)
+    flat_fun, out_aux_trees = flatten_fun_nokwargs2(fun, in_tree)
+    out_primal, out_vjp, aux = ad.vjp(flat_fun, primals_flat, has_aux=True)
+    out_tree, aux_tree = out_aux_trees()
   out_primal_py = tree_unflatten(out_tree, out_primal)
-  ct_in_trees = [out_tree]
-  ct_out_tree = treedef_tuple(in_trees)
-  def out_vjp_packed(cotangent_in):
-    return out_vjp(cotangent_in)
-  vjp_py = partial(apply_jaxtree_fun, out_vjp_packed, (ct_in_trees, ct_out_tree))
+  vjp_py = partial(apply_flat_fun_nokwargs, out_vjp, (out_tree, in_tree))
   if not has_aux:
     return out_primal_py, vjp_py
   else:
     return out_primal_py, vjp_py, tree_unflatten(aux_tree, aux)
 
-
-def trace_to_jaxpr(traceable, py_pvals, **kwargs):
-  fun = lu.wrap_init(traceable, kwargs)
-  pvals, in_trees = unzip2(map(tree_to_pval_tuples, py_pvals))
-  jaxtree_fun, out_tree = pytree_fun_to_jaxtupletree_fun(fun, in_trees)
-  jaxpr, out_pval, consts = pe.trace_to_jaxpr(jaxtree_fun, pvals)
-  return jaxpr, consts, out_pval, (in_trees, out_tree())
-
-def lift_jaxpr(jaxpr, consts, io_tree, pvals, py_args):
-  def fun(*args):
-    ans = eval_jaxpr(jaxpr, consts, (), *args)
-    return pe.merge_pvals(ans, pvals)
-  return apply_jaxtree_fun(fun, io_tree, *py_args)
 
 def make_jaxpr(fun):
   """Creates a function that produces its jaxpr given example args.
@@ -1090,13 +1083,12 @@ def make_jaxpr(fun):
   jaxpr_maker.__name__ = "make_jaxpr({})".format(jaxpr_maker.__name__)
   return jaxpr_maker
 
-tree_to_pval_tuples = partial(process_pytree, pe.pack_pvals)
-
 
 def device_put(x, device_num=0):
   return tree_map(lambda y: xla.device_put_p.bind(y, device_num=device_num), x)
 
 
+# TODO(mattjj): consider revising
 def _device_get(x):
   if isinstance(x, core.Tracer):
     return x
@@ -1116,7 +1108,7 @@ def _argnums_partial(f, dyn_argnums, args):
     dyn_argnums = (dyn_argnums,)
   else:
     dyn_argnums = tuple(dyn_argnums)
-  fixed_args = tuple([None if i in dyn_argnums else _wrap_hashably(arg)
+  fixed_args = tuple([core.unit if i in dyn_argnums else _wrap_hashably(arg)
                       for i, arg in enumerate(args)])
   dyn_args = tuple(args[i] for i in dyn_argnums)
   return _argnums_partial_(f, dyn_argnums, fixed_args), dyn_args
@@ -1131,7 +1123,7 @@ def _wrap_hashably(arg):
 
 @lu.transformation
 def _argnums_partial_(dyn_argnums, fixed_args, *dyn_args, **kwargs):
-  args = [None if arg is None else arg.val for arg in fixed_args]
+  args = [None if arg is core.unit else arg.val for arg in fixed_args]
   for i, arg in zip(dyn_argnums, dyn_args):
     args[i] = arg
   ans = yield args, kwargs
@@ -1145,7 +1137,7 @@ def _check_args(args):
 
 def _valid_jaxtype(arg):
   try:
-    xla.abstractify(arg)
+    xla.abstractify(arg)  # faster than core.get_aval
   except TypeError:
     return False
   else:
@@ -1161,18 +1153,17 @@ class CustomTransformsFunction(object):
   def __repr__(self):
     return '<jax.custom_transforms function {fun}>'.format(fun=self.__name__)
 
-  def __call__(self, *args, **kwargs):
-    def pv_like(x):
-      return pe.PartialVal((batching.get_aval(x), core.unit))  # Use shaped aval
-    jax_args, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-    jax_kwargs, kwargs_tree = pytree_to_jaxtupletree(kwargs)
-    jaxtree_fun, out_tree = pytree_fun_to_jaxtupletree_fun2(
-        lu.wrap_init(self.fun), kwargs_tree, in_trees)
-    pvals_in = map(pv_like, (jax_kwargs,) + jax_args)
-    jaxpr, _, consts = pe.trace_to_jaxpr(jaxtree_fun, pvals_in, instantiate=True)
-    ans = self.prim.bind(core.pack(consts), jax_kwargs, *jax_args,
-                         in_trees=in_trees, jaxpr=jaxpr)
-    return build_tree(out_tree(), ans)
+  def __call__(self, *args):
+    # TODO(mattjj): instead of tracing to a jaxpr, use process_call
+    args_flat, in_tree = tree_flatten(args)
+    flat_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
+    in_pvals = [pe.PartialVal((raise_to_shaped(core.get_aval(x)), core.unit))
+                for x in args_flat]
+    jaxpr, _, consts = pe.trace_to_jaxpr(flat_fun, in_pvals, instantiate=True)
+    outs = self.prim.bind(*it.chain(consts, args_flat), jaxpr=jaxpr,
+                          in_tree=in_tree, out_tree=out_tree(),
+                          num_consts=len(consts))
+    return tree_unflatten(out_tree(), outs)
 
 def custom_transforms(fun):
   """Wraps a function so that its transformation behavior can be controlled.
@@ -1218,18 +1209,19 @@ def custom_transforms(fun):
   """
   name = getattr(fun, '__name__', '<unnamed custom_transforms primitive>')
   fun_p = core.Primitive(name)
+  fun_p.multiple_results = True
 
-  def fun_impl(consts, jax_kwargs, *jax_args, **params):
-    return core.eval_jaxpr(params['jaxpr'], consts, (), jax_kwargs, *jax_args)
+  def fun_impl(*args, **params):
+    consts, args = split_list(args, [params['num_consts']])
+    return core.eval_jaxpr(params['jaxpr'], consts, (), *args)
   fun_p.def_impl(fun_impl)
 
   def fun_jvp(primals, tangents, **params):
     return ad.jvp(lu.wrap_init(fun_impl, params)).call_wrapped(primals, tangents)
   ad.primitive_jvps[fun_p] = fun_jvp
 
-  def fun_batch(batched_args, batch_dims, **params):
-    out = batching.batch(lu.wrap_init(fun_impl, params), batched_args, batch_dims, 0)
-    return out, 0
+  def fun_batch(args, dims, **params):
+    return batching.batch_fun(lu.wrap_init(fun_impl, params), args, dims)
   batching.primitive_batchers[fun_p] = fun_batch
 
   def fun_abstract_eval(*avals, **params):
@@ -1301,29 +1293,23 @@ def defjvp_all(fun, custom_jvp):
   """
   _check_custom_transforms_type("defjvp_all", fun)
   def custom_transforms_jvp(primals, tangents, **params):
-    consts, jax_kwargs, jax_args = primals[0], primals[1], primals[2:]
-    consts_dot, _, jax_args_dot = tangents[0], tangents[1], tangents[2:]
-    if consts_dot is not ad_util.zero:
-      msg = (
-          "Detected differentiation w.r.t. variables from outside the scope of "
-          "{}, but defjvp and defjvp_all only support differentiation w.r.t. "
-          "positional arguments.")
-      raise ValueError(msg.format(str(fun)))
-    if jax_kwargs:
-      msg = ("defjvp_all requires the corresponding custom_transforms function "
-             "not to be called with keyword arguments.")
+    num_consts, in_tree = params['num_consts'], params['in_tree']
+    _, args_flat = split_list(primals, [num_consts])
+    consts_dot, args_dot_flat = split_list(tangents, [num_consts])
+    if not all(t is ad_util.zero for t in consts_dot):
+      msg = ("Detected differentiation with respect to closed-over values with "
+             "custom JVP rule, which isn't supported.")
       raise ValueError(msg)
-    in_trees = params['in_trees']
-    args = tuple(map(build_tree, in_trees, jax_args))
-    args_dot = tuple(map(build_tree, in_trees, jax_args_dot))
-    pytree_out, pytree_out_dot = custom_jvp(args, args_dot)
-    out, out_tree = pytree_to_jaxtupletree(pytree_out)
-    out_dot, out_tree2 = pytree_to_jaxtupletree(pytree_out_dot)
+    args = tree_unflatten(in_tree, args_flat)
+    args_dot = tree_unflatten(in_tree, args_dot_flat)
+    out, out_dot = custom_jvp(args, args_dot)
+    out_flat, out_tree = tree_flatten(out)
+    out_dot_flat, out_tree2 = tree_flatten(out_dot)
     if out_tree != out_tree2:
-      msg = ("custom jvp rule returned different tree structures for primals "
-             "and tangents, but they must be equal: {} vs {}.")
+      msg = ("Custom JVP rule returned different tree structures for primals "
+             "and tangents, but they must be equal: {} and {}.")
       raise TypeError(msg.format(out_tree, out_tree2))
-    return out, out_dot
+    return out_flat, out_dot_flat
   ad.primitive_jvps[fun.prim] = custom_transforms_jvp
 
 def defjvp(fun, *jvprules):
@@ -1447,31 +1433,20 @@ def defvjp_all(fun, custom_vjp):
   (4.0, 3.0)
   """
   _check_custom_transforms_type("defvjp_all", fun)
-  def custom_transforms_vjp(argnums, consts, jax_kwargs, *jax_args, **params):
-    if 0 in argnums:
-      msg = (
-          "Detected differentiation w.r.t. variables from outside the scope of "
-          "{}, but defvjp and defvjp_all only support differentiation w.r.t. "
-          "positional arguments.")
-      raise ValueError(msg.format(str(fun)))
-    if jax_kwargs:
-      msg = ("defvjp_all requires the corresponding custom_transforms function "
-             "not to be called with keyword arguments.")
-      raise ValueError(msg)
-    args = map(build_tree, params['in_trees'], jax_args)
-    pytree_out, vjp_pytree = custom_vjp(*args)
-    out, out_tree = pytree_to_jaxtupletree(pytree_out)
-    def vjp_pytree_(ct):
-      args_cts = tuple(vjp_pytree(ct))
-      if len(args_cts) != len(params['in_trees']):
-        msg = ("custom VJP function must return a tuple of length equal to the "
-               "number of positional arguments to the function being "
-               "differentiated: expected {}, got {}")
-        raise TypeError(msg.format(len(params['in_trees']), len(args_cts)))
-      return ((), {},) + args_cts
-    vjp, _ = pytree_fun_to_jaxtupletree_fun(lu.wrap_init(vjp_pytree_), (out_tree,))
-    return out, vjp.call_wrapped
-  ad.defvjp_argnums(fun.prim, custom_transforms_vjp)
+  def custom_transforms_vjp(*consts_and_args, **params):
+    num_consts, in_tree = params['num_consts'], params['in_tree']
+    consts, args_flat = split_list(consts_and_args, [num_consts])
+    args = tree_unflatten(params['in_tree'], args_flat)
+    out, vjp = custom_vjp(*args)
+    out_flat, out_tree = tree_flatten(out)
+    assert out_tree == params['out_tree']
+    def vjp_flat(*cts_flat):
+      cts = tree_unflatten(out_tree, cts_flat)
+      args_cts_flat, in_tree2 = tree_flatten(vjp(cts))
+      assert in_tree == in_tree2
+      return [None] * num_consts + list(args_cts_flat)
+    return out_flat, vjp_flat
+  ad.defvjp_all(fun.prim, custom_transforms_vjp)
 
 def defvjp(fun, *vjprules):
   """Define VJP rules for each argument separately.
@@ -1518,8 +1493,9 @@ def defvjp(fun, *vjprules):
   def custom_vjp(*primals):
     ans = fun(*primals)
     # TODO(mattjj): avoid instantiating zeros?
-    vjpfun = lambda ct: [vjp(ct, ans, *primals) if vjp else ad_util.zeros_like_jaxval(x)
-                         for x, vjp in zip(primals, vjprules)]
+    def vjpfun(ct):
+      return tuple(vjp(ct, ans, *primals) if vjp else ad_util.zeros_like_jaxval(x)
+                   for x, vjp in zip(primals, vjprules))
     return ans, vjpfun
   defvjp_all(fun, custom_vjp)
 
@@ -1642,7 +1618,7 @@ def _make_graphviz(fun):
     aval = xla.abstractify(x)
     return pe.PartialVal((aval, core.unit))
 
-  id_names = ("id{}".format(i) for i in itertools.count())
+  id_names = ("id{}".format(i) for i in it.count())
 
   def jaxpr_to_graphviz(jaxpr, consts):
     fragment = []
@@ -1728,14 +1704,10 @@ def eval_shape(fun, *args, **kwargs):
   """
   def abstractify(x):
     return ShapedArray(onp.shape(x), onp.result_type(x))
-
-  jax_args, in_trees = unzip2(map(pytree_to_jaxtupletree, args))
-  jax_kwargs, kwargs_tree = pytree_to_jaxtupletree(kwargs)
-  f, out_tree = pytree_fun_to_jaxtupletree_fun2(lu.wrap_init(fun), kwargs_tree, in_trees)
-  abstract_args = map(abstractify, (jax_kwargs,) + tuple(jax_args))
-  out = pe.abstract_eval_fun(f.call_wrapped, *abstract_args)
-  return tree_map(onp.shape, build_tree(out_tree(), out))
-
+  args_flat, in_tree =  tree_flatten((args, kwargs))
+  fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
+  out = pe.abstract_eval_fun(fun.call_wrapped, *map(abstractify, args_flat))
+  return tree_map(onp.shape, tree_unflatten(out_tree(), out))
 
 def _custom_implicit_solve(solve, tangent_solve):
   """Define gradients for a function that performs an implicit solve.
@@ -1770,7 +1742,7 @@ def _custom_implicit_solve(solve, tangent_solve):
     @custom_transforms
     def solve_impl(params):
       return solve(func, params)
- 
+
     @partial(defjvp_all, solve_impl)
     def solve_impl_jvp(primals, tangents):
       # F(u(m), m) = 0  # system of equations in m

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -44,6 +44,14 @@ def flatten_fun(in_tree, *args_flat):
   ans = yield py_args, py_kwargs
   yield tree_flatten(ans)
 
+def apply_flat_fun(fun, io_tree, *py_args):
+  in_tree_expected, out_tree = io_tree
+  args, in_tree = tree_flatten((py_args, {}))
+  if in_tree != in_tree_expected:
+      raise TypeError("Expected {}, got {}".format(in_tree_expected, in_tree))
+  ans = fun(*args)
+  return tree_unflatten(out_tree, ans)
+
 def abstract_tuple_tree_leaves(aval):
   if type(aval) is AbstractTuple:
     for elt in aval:

--- a/jax/core.py
+++ b/jax/core.py
@@ -172,9 +172,9 @@ def eval_jaxpr(jaxpr, consts, freevar_vals, *args):
 
   env = {}
   write(unitvar, unit)
-  pat_fmap(write, jaxpr.constvars, consts)
-  pat_fmap(write, jaxpr.invars, args)
-  pat_fmap(write, jaxpr.freevars, freevar_vals)
+  map(write, jaxpr.constvars, consts)
+  map(write, jaxpr.invars, args)
+  map(write, jaxpr.freevars, freevar_vals)
   for eqn in jaxpr.eqns:
     in_vals = map(read, eqn.invars)
     subfuns = [partial(eval_jaxpr, subjaxpr, map(read, const_bindings),
@@ -188,16 +188,6 @@ def eval_jaxpr(jaxpr, consts, freevar_vals, *args):
     else:
       write(eqn.outvars[0], ans)
   return map(read, jaxpr.outvars)
-
-
-def pat_fmap(f, v, *xs):
-  if type(v) in (tuple, list):
-    if len(xs) == 1 and xs[0] is None:
-      return tuple(map(partial(pat_fmap, f), v, [None] * len(v)))
-    else:
-      return tuple(map(partial(pat_fmap, f), v, *xs))
-  else:
-    return f(v, *xs)
 
 
 def full_lower(val):
@@ -612,9 +602,9 @@ def check_jaxpr(jaxpr):
   write = partial(write_env, env)
 
   write(unitvar)
-  pat_fmap(write, jaxpr.constvars)
-  pat_fmap(write, jaxpr.freevars)
-  pat_fmap(write, jaxpr.invars)
+  map(write, jaxpr.constvars)
+  map(write, jaxpr.freevars)
+  map(write, jaxpr.invars)
   for eqn in jaxpr.eqns:
     map(read, eqn.invars)
     for subjaxpr, constvars, freevars in eqn.bound_subjaxprs:

--- a/jax/core.py
+++ b/jax/core.py
@@ -105,8 +105,12 @@ def jaxpr_as_fun(typed_jaxpr, *args):
   return out
 
 
-JaxprEqn = namedtuple('JaxprEqn', ['invars', 'outvars', 'primitive',
+def new_jaxpr_eqn(*args):
+  return JaxprEqn(object(), *args)
+
+JaxprEqn = namedtuple('JaxprEqn', ['eqn_id', 'invars', 'outvars', 'primitive',
                                    'bound_subjaxprs', 'params'])
+
 class Literal(object):
   __slots__ = ["val", "hash"]
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -20,7 +20,7 @@ import itertools as it
 
 from . import partial_eval as pe
 from .. import core as core
-from ..core import JaxTuple, Trace, Tracer, new_master, get_aval, pack, call_p, Primitive, Literal
+from ..core import Trace, Tracer, new_master, get_aval, call_p, Primitive, Literal
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
                        zeros_like_p, zero, Zero)
 from ..abstract_arrays import raise_to_shaped
@@ -483,7 +483,6 @@ def zero_jvp(primitive, primals, tangents, **params):
 
 deflinear(zeros_like_p, lambda t: [zero])
 deflinear(core.identity_p, lambda t: (t,))
-deflinear(core.pack_p, lambda t: list(t) if t is not zero else zero)
 deflinear(add_jaxvals_p, lambda t: (t, t))
 
 
@@ -503,8 +502,6 @@ def instantiate_zeros_at(instantiate, example, tangent):
 def instantiate_zeros(example, tangent):
   if tangent is zero:
     return zeros_like_jaxval(example)
-  elif isinstance(tangent, TangentTuple):
-    return pack(map(instantiate_zeros, example, tangent))
   else:
     return tangent
 
@@ -622,5 +619,3 @@ def jvp_jaxpr(jaxpr, nonzeros, instantiate):
 
 
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
-
-tree_to_jaxtuples = partial(process_pytree, pack)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -24,10 +24,10 @@ from ..core import Trace, Tracer, new_master, get_aval, call_p, Primitive, Liter
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
                        zeros_like_p, zero, Zero)
 from ..abstract_arrays import raise_to_shaped
-from ..util import unzip2, unzip3, safe_map, safe_zip, partial
+from ..util import unzip2, unzip3, safe_map, safe_zip, partial, split_list
 from ..tree_util import process_pytree, build_tree, register_pytree_node, tree_map
 from ..linear_util import thunk, staged, transformation, transformation_with_aux, wrap_init
-from ..api_util import flatten_fun  # TODO: can we avoid this?
+from ..api_util import flatten_fun, flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten
 
 from six.moves import builtins, reduce
@@ -41,17 +41,19 @@ def jvp(fun, has_aux=False, instantiate=True):
   if not has_aux:
     return jvpfun(jvp_subtrace(fun), instantiate)
   else:
-    fun, aux = jvp_subtrace_aux(fun, instantiate)
+    fun, aux = jvp_subtrace_aux(fun)
     return jvpfun(fun, instantiate), aux
 
 @transformation
 def jvpfun(instantiate, primals, tangents):
   with new_master(JVPTrace) as master:
-    out_primal, out_tangent = yield (master, primals, tangents), {}
+    out_primals, out_tangents = yield (master, primals, tangents), {}
     del master
-  out_tangent = instantiate_zeros_at(instantiate, out_primal, out_tangent)
-  yield (out_primal, out_tangent)
-
+  if type(instantiate) is bool:
+    instantiate = [instantiate] * len(out_tangents)
+  out_tangents = [instantiate_zeros(x, t) if inst else t for x, t, inst
+                  in zip(out_primals, out_tangents, instantiate)]
+  yield out_primals, out_tangents
 
 @transformation
 def jvp_subtrace(master, primals, tangents):
@@ -65,24 +67,23 @@ def jvp_subtrace(master, primals, tangents):
                 for out_tracer in out_tracers])
 
 @transformation_with_aux
-def jvp_subtrace_aux(instantiate, master, primals, tangents):
+def jvp_subtrace_aux(master, primals, tangents):
   trace = JVPTrace(master, core.cur_sublevel())
   for x in list(primals) + list(tangents):
     if isinstance(x, Tracer):
       assert x.trace.level < trace.level
   ans, aux = yield map(partial(JVPTracer, trace), primals, tangents), {}
-  out_tracer, aux_tracer = map(trace.full_raise, (ans, aux))
-  out_primal, out_tangent = out_tracer.primal, out_tracer.tangent
-  aux = aux_tracer.primal  # ignore aux tangent
-  out_tangent = instantiate_zeros_at(instantiate, out_primal, out_tangent)
-  yield (out_primal, out_tangent), aux
+  ans_tracers = map(trace.full_raise, ans)
+  aux_tracers = map(trace.full_raise, aux)
+  out_primals, out_tangents = unzip2((t.primal, t.tangent) for t in ans_tracers)
+  aux_primals, _            = unzip2((t.primal, t.tangent) for t in aux_tracers)
+  yield (out_primals, out_tangents), aux_primals
 
 def linearize(traceable, *primals, **kwargs):
   has_aux = kwargs.pop('has_aux', False)
   if not has_aux:
     jvpfun = jvp(traceable)
   else:
-    assert False, "TODO"
     jvpfun, aux = jvp(traceable, has_aux=True)
 
   in_pvals = (tuple(pe.PartialVal((None, p)) for p in primals)
@@ -101,27 +102,26 @@ def linearize(traceable, *primals, **kwargs):
 
 def vjp(traceable, primals, has_aux=False):
   if not has_aux:
-    out_primal, pval, jaxpr, consts = linearize(traceable, *primals)
+    out_primals, pvals, jaxpr, consts = linearize(traceable, *primals)
   else:
-    out_primal, pval, jaxpr, consts, aux = linearize(traceable, *primals, has_aux=True)
-  def vjp_(ct):
-    ct = ignore_consts(ct, pval)
-    dummy_primal_and_ct = pack((core.unit, ct))
-    dummy_args = (None,) * len(jaxpr.invars)
-    _, arg_cts = backward_pass(jaxpr, consts, (), dummy_args, dummy_primal_and_ct)
-    return instantiate_zeros(pack(primals), arg_cts[1])
+    out_primals, pvals, jaxpr, consts, aux = linearize(traceable, *primals, has_aux=True)
+  def vjp_(*cts):
+    cts = tuple(map(ignore_consts, cts, pvals))
+    dummy_primals_and_cts = (core.unit,) * len(cts) + cts
+    dummy_args = (undefined_primal,) * len(jaxpr.invars)
+    _, arg_cts = backward_pass(jaxpr, consts, (), dummy_args, dummy_primals_and_cts)
+    arg_cts = arg_cts[len(primals):]
+    return map(instantiate_zeros, primals, arg_cts)
 
   if not has_aux:
-    return out_primal, vjp_
+    return out_primals, vjp_
   else:
-    return out_primal, vjp_, aux
+    return out_primals, vjp_, aux
 
 def ignore_consts(ct, pval):
   aval, const = pval
   if isinstance(aval, core.AbstractValue):
     return ct
-  elif isinstance(aval, pe.JaxprTracerTuple):
-    return pack(map(ignore_consts, ct, zip(aval, const)))
   elif aval is None:
     return core.unit
   else:
@@ -136,7 +136,7 @@ def unpair_pval(pval):
     aval_1, aval_2 = aval
     return (aval_1, const_1), (aval_2, const_2)
 
-def backward_pass(jaxpr, consts, freevar_vals, args, cotangent_in):
+def backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in):
   def write_cotangent(v, ct):
     # assert v not in primal_env
     if ct is not None:
@@ -149,71 +149,47 @@ def backward_pass(jaxpr, consts, freevar_vals, args, cotangent_in):
     if type(v) is Literal:
       return v.val
     else:
-      return primal_env.get(v)
+      return primal_env.get(v, undefined_primal)
 
   def write_primal(v, val):
-    if val is not None:
+    if val is not undefined_primal:
       primal_env[v] = val
 
   primal_env = {}
-  core.pat_fmap(write_primal, jaxpr.constvars, consts)
-  core.pat_fmap(write_primal, jaxpr.freevars, freevar_vals)
-  core.pat_fmap(write_primal, jaxpr.invars, args)
+  map(write_primal, jaxpr.constvars, consts)
+  map(write_primal, jaxpr.freevars, freevar_vals)
+  map(write_primal, jaxpr.invars, args)
 
-  ct_env = {jaxpr.outvar: cotangent_in}
+  ct_env = {}
+  map(write_cotangent, jaxpr.outvars, cotangents_in)
   for eqn in jaxpr.eqns[::-1]:
-    cts_in = map(read_cotangent, eqn.outvars)
-    ct_in = TangentTuple(cts_in) if eqn.destructure else cts_in[0]
-    if not eqn.restructure:
-      invals = map(read_primal, eqn.invars)
+    invals = map(read_primal, eqn.invars)
+    if eqn.primitive.multiple_results:
+      cts_in = map(read_cotangent, eqn.outvars)
     else:
-      invals = [tuple(map(read_primal, v)) if type(v) is tuple
-                else read_primal(v) for v in eqn.invars]
+      cts_in, = map(read_cotangent, eqn.outvars)
     if eqn.bound_subjaxprs:
-      subjaxprs, sub_consts, sub_freevar_vals = unzip3([
-          (subjaxpr,
-           map(read_primal, const_vars),
-           map(read_primal, bound_vars))
-          for subjaxpr, const_vars, bound_vars in eqn.bound_subjaxprs])
-      cts_out, ct_free_vars_out = get_primitive_transpose(eqn.primitive)(
-          eqn.params, subjaxprs, sub_consts, sub_freevar_vals, invals, ct_in)
-      # TODO(dougalm): support cases != 1
-      assert(len(eqn.bound_subjaxprs) == 1)
-      _, _, bound_vars = eqn.bound_subjaxprs[0]
+      (subjaxpr, const_vars, bound_vars), = eqn.bound_subjaxprs
+      sub_consts = map(read_primal, const_vars)
+      sub_freevar_vals = map(read_primal, bound_vars)
+      ct_free_vars_out, cts_out = get_primitive_transpose(eqn.primitive)(
+          eqn.params, subjaxpr, sub_consts, sub_freevar_vals, invals, cts_in)
       map(write_cotangent, bound_vars, ct_free_vars_out)
     else:
-      cts_out = get_primitive_transpose(eqn.primitive)(ct_in, *invals, **eqn.params)
+      cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
+    cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
+    map(write_cotangent, eqn.invars, cts_out)
 
-    if cts_out is zero:
-      cts_out = [zero for _ in eqn.invars]
-    if not eqn.restructure:
-      map(write_cotangent, eqn.invars, cts_out)
-    else:
-      [map(write_cotangent, v, ct) if type(v) is tuple
-       else write_cotangent(v, ct) for v, ct in zip(eqn.invars, cts_out)]
-
-  freevar_cts = core.pat_fmap(read_cotangent, jaxpr.freevars)
-  cotangents_out = core.pat_fmap(lambda v, _: read_cotangent(v), jaxpr.invars, None)
-  cotangents_out = tuple(map(pack_cotangents_like_caller, args, cotangents_out))
+  freevar_cts = map(read_cotangent, jaxpr.freevars)
+  cotangents_out = map(read_cotangent, jaxpr.invars)
   return freevar_cts, cotangents_out
 
-def pack_cotangents_like_caller(arg, ct):
-  if type(arg) is tuple:
-    return tuple(map(pack_cotangents_like_caller, arg, ct))
-  elif arg is None:
-    return recursively_pack(ct)
-  else:
-    return None
-
-def recursively_pack(ct):
-  if type(ct) is tuple:
-    ct = tuple(map(recursively_pack, ct))
-    if any(elt is zero or isinstance(elt, TangentTuple) for elt in ct):
-      return TangentTuple(ct)
-    else:
-      return pack(ct)
-  else:
-    return ct
+class UndefinedPrimal(object):
+  def __repr__(self): return  '_'
+undefined_primal = UndefinedPrimal()
+register_pytree_node(UndefinedPrimal,
+                     lambda z: ((), None),
+                     lambda *_: undefined_primal)
 
 def get_primitive_transpose(p):
   try:
@@ -221,12 +197,6 @@ def get_primitive_transpose(p):
   except KeyError:
     raise NotImplementedError(
       "Reverse-mode differentiation rule for '{}' not implemented".format(p))
-
-class TangentTuple(tuple):
-  pass
-
-register_pytree_node(
-    TangentTuple, lambda xs: (xs, None), lambda _, xs: TangentTuple(xs))
 
 class JVPTrace(Trace):
 
@@ -240,8 +210,7 @@ class JVPTrace(Trace):
     return JVPTracer(self, val.primal, val.tangent)
 
   def process_primitive(self, primitive, tracers, params):
-    primals_in = [t.primal for t in tracers]
-    tangents_in = [t.tangent for t in tracers]
+    primals_in, tangents_in = unzip2((t.primal, t.tangent) for t in tracers)
     try:
       jvp = primitive_jvps[primitive]
     except KeyError:
@@ -249,59 +218,43 @@ class JVPTrace(Trace):
           "Forward-mode differentiation rule for '{}' not implemented"
           .format(primitive))
     primal_out, tangent_out = jvp(primals_in, tangents_in, **params)
-    return JVPTracer(self, primal_out, tangent_out)
+    if primitive.multiple_results:
+      return [JVPTracer(self, x, t) for x, t in zip(primal_out, tangent_out)]
+    else:
+      return JVPTracer(self, primal_out, tangent_out)
 
   def process_call(self, call_primitive, f, tracers, params):
+    assert call_primitive.multiple_results
     primals = [t.primal for t in tracers]
     tangents = [t.tangent for t in tracers]
-    nonzero_tangents, in_tree_def = tree_to_jaxtuples(tangents)
-    f_jvp, out_tree_def = traceable(jvp_subtrace(f, self.master), in_tree_def)
-    result = call_primitive.bind(f_jvp, pack(primals), nonzero_tangents, **params)
-    primal_out, tangent_out = build_tree(out_tree_def(), result)
-    return JVPTracer(self, primal_out, tangent_out)
+    nonzero_tangents, in_tree_def = tree_flatten(tangents)
+    f_jvp, out_tree_def = traceable(jvp_subtrace(f, self.master), len(primals), in_tree_def)
+    result = call_primitive.bind(f_jvp, *(primals + nonzero_tangents), **params)
+    primal_out, tangent_out = tree_unflatten(out_tree_def(), result)
+    return [JVPTracer(self, p, t) for p, t in zip(primal_out, tangent_out)]
 
-  def post_process_call(self, call_primitive, out_tracer, params):
-    out_jtuple, tree_def = tree_to_jaxtuples((out_tracer.primal, out_tracer.tangent))
+  def post_process_call(self, call_primitive, out_tracers, params):
+    primals, tangents = unzip2((t.primal, t.tangent) for t in out_tracers)
+    out = primals + tangents
+    del primals, tangents
     master = self.master
     def todo(x):
+      n = len(x) // 2
+      primals, tangents = x[:n], x[n:]
       trace = JVPTrace(master, core.cur_sublevel())
-      return JVPTracer(trace, *build_tree(tree_def, x))
-
-    return out_jtuple, todo
+      return map(partial(JVPTracer, trace), primals, tangents)
+    return out, todo
 
   def join(self, xt, yt):
-    isfull = lambda t: t is not zero and not isinstance(t, TangentTuple)
-    if isfull(xt) and isfull(yt):
+    xz, yz = xt is zero, yt is zero
+    if xz == yz:
       return xt, yt
-    elif isfull(xt):
-      if yt is zero:
-        return xt, zeros_like_jaxval(xt)
-      elif isinstance(xt, TangentTuple):
-        return xt, JaxTuple(map(zeros_like_jaxval, xt))
-      else:
-        raise TypeError
-    elif isfull(yt):
-      if xt is zero:
-        return zeros_like_jaxval(yt), yt
-      elif isinstance(xt, TangentTuple):
-        return JaxTuple(map(zeros_like_jaxval, yt)), yt
-      else:
-        raise TypeError
-    elif isinstance(xt, TangentTuple) or isinstance(yt, TangentTuple):
-      if xt is zero:
-        xt = TangentTuple((zero,) * len(yt))
-      elif yt is zero:
-        yt = TangentTuple((zero,) * len(xt))
-      return TangentTuple(map(self.join, xt, yt))
-    elif xt is zero and yt is zero:
-      return xt, yt
+    elif yz and not xz:
+      return xt, zeros_like_jaxval(xt)
+    elif xz and not yz:
+      return zeros_like_jaxval(yt), yt
     else:
       raise TypeError((xt, yt))
-
-  def pack(self, tracers):
-    primals = pack(t.primal for t in tracers)
-    tangents = TangentTuple([t.tangent for t in tracers])
-    return JVPTracer(self, primals, tangents)
 
 
 class JVPTracer(Tracer):
@@ -319,12 +272,6 @@ class JVPTracer(Tracer):
     # TODO(dougalm): add epsilon ball
     return get_aval(self.primal)
 
-  def unpack(self):
-    if self.tangent is zero:
-      return self.full_lower()
-    else:
-      return map(partial(JVPTracer, self.trace), self.primal, self.tangent)
-
   def full_lower(self):
     if self.tangent is zero:
       return core.full_lower(self.primal)
@@ -332,10 +279,7 @@ class JVPTracer(Tracer):
       return self
 
 def _primal_tangent_shapes_match(primal, tangent):
-  if type(tangent) is TangentTuple:
-    for p, t in zip(primal, tangent):
-      _primal_tangent_shapes_match(p, t)
-  elif tangent is not zero:
+  if tangent is not zero:
     primal_aval = raise_to_shaped(get_aval(primal))
     tangent_aval = raise_to_shaped(get_aval(tangent))
     assert primal_aval == tangent_aval
@@ -395,47 +339,46 @@ def add_tangents(x, y):
     return add_jaxvals(x, y)
 
 
-def defvjp_argnums(prim, custom_vjp):
+def defvjp_all(prim, custom_vjp):
+  # see https://github.com/google/jax/pull/636
   name = prim.name
 
   def fun_jvp(xs, ts, **params):
-    params['vjp_argnums'] = tuple(i for i, t in enumerate(ts) if t is not zero)
-    ts = map(instantiate_zeros, xs, ts)  # TODO(mattjj): avoid instantiation?
-    primal_out, tangent_out = fun_jvp_p.bind(pack(xs), pack(ts), **params)
-    return primal_out, tangent_out
+    ts = map(instantiate_zeros, xs, ts)
+    primals_and_tangents = fun_jvp_p.bind(*it.chain(xs, ts), **params)
+    primals, tangents = split_list(primals_and_tangents, [len(primals_and_tangents) // 2])
+    if prim.multiple_results:
+      return primals, tangents
+    else:
+      primal, = primals
+      tangent, = tangents
+      return primal, tangent
   primitive_jvps[prim] = fun_jvp
 
   fun_jvp_p = core.Primitive('{name}_jvp'.format(name=name))
+  fun_jvp_p.multiple_results = True
   def fun_jvp_partial_eval(trace, *tracers, **params):
-    primals_tracer, tangents_tracer = tracers
-    argnums = params.pop('vjp_argnums')
-    primal_out, vjp_py = custom_vjp(argnums, *primals_tracer, **params)
-
-    in_aval = raise_to_shaped(get_aval(primal_out))
-    ct_pval = pe.PartialVal((in_aval, core.unit))
-    vjp_jaxpr, out_pval, residuals = pe.trace_unwrapped_to_jaxpr(
-        lambda ct: pack(vjp_py(ct)), (ct_pval,), instantiate=False)
-    out_pv, out_const = out_pval
-    tangent_out = fun_lin_p.bind(out_const, pack(residuals), tangents_tracer,
-                                 in_aval=in_aval, out_pv=out_pv, vjp_jaxpr=vjp_jaxpr)
-
-    return pack((primal_out, tangent_out))
+    primals, tangents = split_list(tracers, [len(tracers) // 2])
+    primals_out, vjp_py = custom_vjp(*primals, **params)
+    if not prim.multiple_results:
+      primals_out = [primals_out]
+    out_avals = [raise_to_shaped(get_aval(x)) for x in primals_out]
+    ct_pvals = [pe.PartialVal((aval, core.unit)) for aval in out_avals]
+    jaxpr, _, res = pe.trace_to_jaxpr(wrap_init(vjp_py), ct_pvals, instantiate=True)
+    tangents_out = fun_lin_p.bind(*it.chain(res, tangents), trans_jaxpr=jaxpr,
+                                  num_res=len(res), out_avals=out_avals)
+    return primals_out + tangents_out
   pe.custom_partial_eval_rules[fun_jvp_p] = fun_jvp_partial_eval
 
   fun_lin_p = core.Primitive('{name}_lin'.format(name=name))
-  fun_lin_p.def_abstract_eval(lambda c, r, ts, in_aval, out_pv, vjp_jaxpr: in_aval)
-  def fun_lin_transpose(ct, out_const, residuals, ts, in_aval, out_pv, vjp_jaxpr):
-    assert ts is None and out_const is not None and residuals is not None
-    ans = core.eval_jaxpr(vjp_jaxpr, residuals, (), ct)
-    out = pe.merge_pvals(ans, pe.PartialVal((out_pv, out_const)))
-    return [None, None, out]
+  fun_lin_p.multiple_results = True
+  fun_lin_p.def_abstract_eval(lambda *_, **kwargs: kwargs['out_avals'])
+  def fun_lin_transpose(cts, *args, **kwargs):
+    num_res, trans_jaxpr = kwargs['num_res'], kwargs['trans_jaxpr']
+    res, _ = split_list(args, [num_res])
+    outs = core.eval_jaxpr(trans_jaxpr, res, (), *cts)
+    return [None] * num_res + outs
   primitive_transposes[fun_lin_p] = fun_lin_transpose
-
-def defvjp_all(prim, custom_vjp):
-  # see https://github.com/google/jax/pull/636
-  def custom_vjp_(argnums, *args, **params):
-    return custom_vjp(*args, **params)
-  defvjp_argnums(prim, custom_vjp_)
 
 def defvjp(prim, *vjps):
   def vjpmaker(*primals):
@@ -463,8 +406,8 @@ def defbilinear_broadcasting(bcast, prim, lhs_rule, rhs_rule):
 defbilinear = partial(defbilinear_broadcasting, lambda g, x: g)
 
 def bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs):
-  assert (x is None) ^ (y is None)
-  if x is None:
+  assert (x is undefined_primal) ^ (y is undefined_primal)
+  if x is undefined_primal:
     out = zero if cotangent is zero else lhs_rule(cotangent, y, **kwargs)
     return out, None
   else:
@@ -484,20 +427,6 @@ deflinear(zeros_like_p, lambda t: [zero])
 deflinear(core.identity_p, lambda t: (t,))
 deflinear(add_jaxvals_p, lambda t: (t, t))
 
-
-def instantiate_zeros_at(instantiate, example, tangent):
-  t = type(instantiate)
-  if t is tuple:
-    # note to future selves: it wasn't clear whether to pack here
-    return TangentTuple(map(instantiate_zeros_at, instantiate, example, tangent))
-  elif t is bool:
-    if instantiate:
-      return instantiate_zeros(example, tangent)
-    else:
-      return tangent
-  else:
-    raise TypeError(t)
-
 def instantiate_zeros(example, tangent):
   if tangent is zero:
     return zeros_like_jaxval(example)
@@ -507,114 +436,78 @@ def instantiate_zeros(example, tangent):
 def instantiate_zeros_aval(aval, tangent):
   if tangent is zero:
     return zeros_like_aval(aval)
-  elif isinstance(tangent, TangentTuple):
-    return pack(map(instantiate_zeros_aval, aval, tangent))
   else:
     return tangent
 
 @transformation_with_aux
-def traceable(in_tree_def, new_primals, new_tangents):
-  new_tangents = build_tree(in_tree_def, new_tangents)
+def traceable(num_primals, in_tree_def, *primals_and_tangents):
+  new_primals  = primals_and_tangents[:num_primals]
+  new_tangents = primals_and_tangents[num_primals:]
+  new_tangents = tree_unflatten(in_tree_def, new_tangents)
   primal_out, tangent_out = yield (new_primals, new_tangents), {}
-  out_jtuple, tree_def = tree_to_jaxtuples((primal_out, tangent_out))
-  yield out_jtuple, tree_def
-
-@transformation_with_aux
-def transposed_fun(jaxpr, in_tree_def, args):
-  args, consts, freevar_vals, ct = args
-  args, ct, freevar_vals = build_tree(in_tree_def, (args, ct, freevar_vals))
-  freevar_cts, cotangents_out = yield (jaxpr, consts, freevar_vals, args, ct), {}
-  out_jtuple, tree_def = tree_to_jaxtuples((cotangents_out, freevar_cts))
-  yield out_jtuple, tree_def
+  out_flat, tree_def = tree_flatten((primal_out, tangent_out))
+  yield out_flat, tree_def
 
 def call_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
-  jaxpr, = jaxpr
-  consts, = consts
-  freevar_vals, = freevar_vals
-  assert isinstance(jaxpr, core.Jaxpr)
-  (args, ct, freevar_vals), in_tree_def = tree_to_jaxtuples((args, ct, freevar_vals))
-  fun = wrap_init(backward_pass)
-  fun, out_tree_def = transposed_fun(fun, jaxpr, in_tree_def)
-  all_args = pack((pack(args), pack(consts), pack(freevar_vals), ct))
-  # TODO(dougalm): consider signalling to bind that no traces in fun closure
-  ans = primitive.bind(fun, all_args, **params)
-  return build_tree(out_tree_def(), ans)
-
-@transformation_with_aux
-def transposed_mapped(jaxpr, in_tree_def, freevar_vals, args):
-  args, consts, ct = args
-  args, ct = build_tree(in_tree_def, (args, ct))
-  freevar_cts, cotangents_out = yield (jaxpr, consts, freevar_vals, args, ct), {}
-  out_jtuple, tree_def = tree_to_jaxtuples((cotangents_out, freevar_cts))
-  yield out_jtuple, tree_def
-
-def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
-  jaxpr, = jaxpr
-  consts, = consts
-  freevar_vals, = freevar_vals
-  (args, ct), in_tree_def = tree_to_jaxtuples((args, ct))
-  fun = wrap_init(backward_pass)
-  fun, out_tree_def = transposed_mapped(fun, jaxpr, in_tree_def, tuple(freevar_vals))
-  all_args = pack((pack(args), pack(consts), ct))
-  ans = primitive.bind(fun, all_args, **params)
-  cts_out, freevar_cts = build_tree(out_tree_def(), ans)
-  freevar_cts = tree_map(lambda x: x.sum(0), freevar_cts)
-  return cts_out, freevar_cts
-
-def get_nonzeros(tangent):
-  if tangent is zero:
-    return False
-  elif isinstance(tangent, TangentTuple):
-    return tuple(map(get_nonzeros, tangent))
-  else:
-    return True
-
-def put_zeros(pack, isnonzero, x):
-  if isnonzero is True:
-    return x
-  elif isnonzero is False:
-    return zero
-  else:
-    return pack(map(partial(put_zeros, pack), isnonzero, x))
-
-def strip_zeros(unit, pack, isnonzero, x):
-  if isnonzero is True:
-    return x
-  elif isnonzero is False:
-    return unit
-  else:
-    return pack(map(partial(strip_zeros, unit, pack), isnonzero, x))
-
-@transformation_with_aux
-def f_jvp_traceable(nonzero_components, *primal_tangent_pairs):
-  primals, tangents = unzip2(primal_tangent_pairs)
-  tangents_zeros = map(partial(put_zeros, TangentTuple), nonzero_components, tangents)
-  primal_out, tangent_out = yield (primals, tangents_zeros), {}
-  # TODO check output is tuple
-  nonzeros_out = get_nonzeros(tangent_out)
-  tangent_out_nonzero = strip_zeros(core.unit, pack, nonzeros_out, tangent_out)
-  primal_tangent_pairs_out = [pack((p, t)) for p, t in zip(primal_out, tangent_out_nonzero)]
-  yield pack(primal_tangent_pairs_out), nonzeros_out
-
-def jvp_jaxpr(jaxpr, nonzeros, instantiate):
-  # jaxpr :: d -> a -> b -> (c1, c2)
-  # avals = (d, a, b)
-  # f :: d -> a -> b -> (c1, c2)
-  f = wrap_init(core.jaxpr_as_fun(jaxpr))
-  f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate), nonzeros)
-  # f_jvp :: (d, d') -> (a, a') -> (b, b') -> ((c1, c1'), (c2, c2'))
-  tangent_avals = map(partial(strip_zeros, core.AbstractTuple(()), core.AbstractTuple),
-                      nonzeros, jaxpr.in_avals)
-  pt_pvals = [pe.PartialVal((core.AbstractTuple((p_aval, t_aval)), core.unit))
-              for p_aval, t_aval in zip(jaxpr.in_avals, tangent_avals)]
-  jaxpr_out, pval_out, literals_out = pe.trace_to_jaxpr(
-      f_jvp, pt_pvals, instantiate=True)
-  # jaxpr_out :: (d, d') -> (a, a') -> (b, b') -> ((c1, c1'), (c2, c2'))
-  # out_nonzeros :: (nonzeros(c1), nonzeros(c2))
-  in_avals = tuple(map(core.AbstractTuple, zip(jaxpr.in_avals, tangent_avals)))
-  out_aval, _ = pval_out
-  jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, in_avals, out_aval)
-  return jaxpr_out, out_nonzeros()
-
+  all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
+  fun = wrap_init(partial(backward_pass, jaxpr))
+  fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+  out_flat = primitive.bind(fun, *all_args, **params)
+  return tree_unflatten(out_tree(), out_flat)
 
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
+
+def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
+  all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
+  fun = wrap_init(partial(backward_pass, jaxpr))
+  fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+  out_flat = primitive.bind(fun, *all_args, **params)
+  freevar_cts, arg_cts = tree_unflatten(out_tree(), out_flat)
+  freevar_cts = [x.sum(0) if x is not zero else x for x in freevar_cts]
+  return freevar_cts, arg_cts
+
+
+def jvp_jaxpr(jaxpr, nonzeros, instantiate):
+  assert len(jaxpr.in_avals) == len(nonzeros)
+  f = wrap_init(core.jaxpr_as_fun(jaxpr))
+  f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate), nonzeros)
+  tangent_avals = [aval for aval, nz in zip(jaxpr.in_avals, nonzeros) if nz]
+  avals_in = list(it.chain(jaxpr.in_avals, tangent_avals))
+  pvals = [pe.PartialVal((aval, core.unit)) for aval in avals_in]
+  jaxpr_out, pvals_out, literals_out = pe.trace_to_jaxpr(f_jvp, pvals, instantiate=True)
+  avals_out, _ = unzip2(pvals_out)
+  jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, avals_in, avals_out)
+  return jaxpr_out, out_nonzeros()
+
+@transformation_with_aux
+def f_jvp_traceable(nonzeros, *primals_and_nztangents):
+  num_primals = len(nonzeros)
+  primals = list(primals_and_nztangents[:num_primals])
+  nonzero_tangents = iter(primals_and_nztangents[num_primals:])
+  tangents = [next(nonzero_tangents) if nz else zero for nz in nonzeros]
+  primals_out, tangents_out = yield (primals, tangents), {}
+  out_nonzeros = [t is not zero for t in tangents_out]
+  nonzero_tangents_out = [t for t in tangents_out if t is not zero]
+  yield list(primals_out) + nonzero_tangents_out, out_nonzeros
+
+def rearrange_binders(jaxpr, primals_in, tangents_in, primals_out, tangents_out):
+  new_invars = _perm(primals_in, tangents_in, jaxpr.jaxpr.invars)
+  new_outvars = _perm(primals_out, tangents_out, jaxpr.jaxpr.outvars)
+  new_jaxpr = core.Jaxpr(jaxpr.jaxpr.constvars, jaxpr.jaxpr.freevars,
+                         new_invars, new_outvars, jaxpr.jaxpr.eqns)
+  new_in_avals = _perm(primals_in, tangents_in, jaxpr.in_avals)
+  new_out_avals = _perm(primals_out, tangents_out, jaxpr.out_avals)
+  new_typed_jaxpr = core.TypedJaxpr(new_jaxpr, jaxpr.literals, new_in_avals,
+                                    new_out_avals)
+  return new_typed_jaxpr
+
+def _perm(primal_counts, tangent_counts, lst):
+  n = sum(primal_counts)
+  primals, tangents = lst[:n], lst[n:]
+  primal_groups = split_list(primals, primal_counts[:-1])
+  tangent_groups = split_list(tangents, tangent_counts[:-1])
+  return _interleave(primal_groups, tangent_groups)
+
+def _interleave(xs, ys):
+  assert len(xs) == len(ys)
+  return [e for pair in zip(xs, ys) for l in pair for e in l]

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -25,7 +25,7 @@ import numpy as onp
 from six.moves import reduce
 
 from .. import core
-from ..core import Trace, Tracer, new_master, pack, AbstractTuple, JaxTuple
+from ..core import Trace, Tracer, new_master
 from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
 from ..ad_util import add_jaxvals_p, zeros_like_p, zeros_like_jaxval
 from ..linear_util import transformation, transformation_with_aux, wrap_init
@@ -212,12 +212,6 @@ def add_batch_dim_to_aval(bdim, size, aval):
     raise TypeError(t)
 
 pytype_aval_mappings = {}
-
-def shaped_jaxtuple(xs):
-  return AbstractTuple(map(shaped_aval, xs))
-
-pytype_aval_mappings[JaxTuple] = shaped_jaxtuple
-pytype_aval_mappings[xla.DeviceTuple] = xla.pytype_aval_mappings[xla.DeviceTuple]
 
 for t in it.chain(array_types, [xla.DeviceArray]):
   pytype_aval_mappings[t] = make_shaped_array

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -22,12 +22,13 @@ import itertools as it
 
 import numpy as onp
 
+import six
 from six.moves import reduce
 
 from .. import core
 from ..core import Trace, Tracer, new_master
 from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
-from ..ad_util import add_jaxvals_p, zeros_like_p, zeros_like_jaxval
+from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
 from ..linear_util import transformation, transformation_with_aux, wrap_init
 from ..util import unzip2, partial, safe_map
 from . import xla
@@ -36,189 +37,123 @@ from . import partial_eval as pe
 map = safe_map
 
 
-def batch(fun, in_vals, in_dims, out_dim_dst):
-  sizes = reduce(set.union, map(dimsize, in_dims, in_vals))
-  if not sizes:
-    return fun.call_wrapped(*in_vals), None  # no mapped dimensions
-  elif len(sizes) == 1:
-    sz = sizes.pop()
-    return batch_transform(fun, sz, in_dims, out_dim_dst).call_wrapped(in_vals)
-  else:
-    raise TypeError("got inconsistent map dimension sizes: {}".format(sizes))
+def batch(fun, in_vals, in_dims, out_dim_dests):
+  out_vals, out_dims = batch_fun(fun, in_vals, in_dims)
+  size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
+  return map(partial(matchaxis, size), out_dims, out_dim_dests(), out_vals)
 
-
-@transformation
-def batch_transform(size, in_dims, out_dim_dst, vals):
+def batch_fun(fun, in_vals, in_dims):
   with new_master(BatchTrace) as master:
-    trace = BatchTrace(master, core.cur_sublevel())
-    in_tracers = map(partial(BatchTracer, trace), vals, in_dims)
-    ans = yield in_tracers, {}
-    out_tracer = trace.full_raise(ans)
-    out_val, out_dim = out_tracer.val, out_tracer.batch_dim
-    del master, out_tracer
-  yield moveaxis(size, out_dim_dst, out_dim, out_val)
-
+    fun, out_dims = batch_subtrace(fun, master, in_dims)
+    out_vals = fun.call_wrapped(*in_vals)
+    del master
+  return out_vals, out_dims()
 
 @transformation_with_aux
-def batch_subtrace(master, dims, *vals):
+def batch_subtrace(master, in_dims, *in_vals):
   trace = BatchTrace(master, core.cur_sublevel())
-  ans = yield map(partial(BatchTracer, trace), vals, dims), {}
-  out_tracer = trace.full_raise(ans)
-  out_val, out_dim = out_tracer.val, out_tracer.batch_dim
-  yield out_val, out_dim
+  in_tracers = map(partial(BatchTracer, trace), in_vals, in_dims)
+  outs = yield in_tracers, {}
+  out_tracers = map(trace.full_raise, outs)
+  out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
+  yield out_vals, out_dims
 
 
 ### tracer
 
+# TODO(mattjj): use a special sentinel type rather than None
+NotMapped = type(None)
+not_mapped = None
 
 class BatchTracer(Tracer):
   __slots__ = ['val', 'batch_dim']
 
   def __init__(self, trace, val, batch_dim):
-    assert core.skip_checks or type(batch_dim) in (int, tuple, type(None))
+    assert core.skip_checks or type(batch_dim) in (int, NotMapped)
     self.trace = trace
     self.val = val
     self.batch_dim = batch_dim
 
   @property
   def aval(self):
-    batched_aval = get_aval(self.val)
-    return remove_batch_dim_from_aval(self.batch_dim, batched_aval)
-
-  def unpack(self):
-    if self.batch_dim is None:
-      return tuple(self.val)
+    aval = raise_to_shaped(core.get_aval(self.val))
+    if self.batch_dim is not_mapped:
+      return aval
     else:
-      t = type(self.batch_dim)
-      if t is tuple:
-        dims = list(self.batch_dim)
-      elif t is int:
-        dims = [self.batch_dim] * len(self.val)
+      if aval is core.abstract_unit:
+        return aval
+      elif type(aval) is ShapedArray:
+        assert 0 <= self.batch_dim < aval.ndim
+        new_shape = tuple(onp.delete(aval.shape, self.batch_dim))
+        return ShapedArray(new_shape, aval.dtype)
       else:
-        raise TypeError(self.batch_dim)
-      return map(partial(BatchTracer, self.trace), self.val, dims)
+        raise TypeError(aval)
 
   def full_lower(self):
-    if self.batch_dim is None:
+    if self.batch_dim is not_mapped:
       return core.full_lower(self.val)
     else:
       return self
 
 class BatchTrace(Trace):
   def pure(self, val):
-    return BatchTracer(self, val, None)
+    return BatchTracer(self, val, not_mapped)
 
   def lift(self, val):
-    return BatchTracer(self, val, None)
+    return BatchTracer(self, val, not_mapped)
 
   def sublift(self, val):
     return BatchTracer(self, val.val, val.batch_dim)
 
   def process_primitive(self, primitive, tracers, params):
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
-    if all(bdim is None for bdim in dims_in):
+    if all(bdim is not_mapped for bdim in dims_in):
       return primitive.bind(*vals_in, **params)
     else:
       # TODO(mattjj,phawkins): if no rule implemented, could vmap-via-map here
       batched_primitive = get_primitive_batcher(primitive)
       val_out, dim_out = batched_primitive(vals_in, dims_in, **params)
-      return BatchTracer(self, val_out, dim_out)
+      if primitive.multiple_results:
+        return map(partial(BatchTracer, self), val_out, dim_out)
+      else:
+        return BatchTracer(self, val_out, dim_out)
 
   def process_call(self, call_primitive, f, tracers, params):
+    assert call_primitive.multiple_results
     if call_primitive in pe.map_primitives:
       return self.process_map(call_primitive, f, tracers, params)
     vals, dims = unzip2((t.val, t.batch_dim) for t in tracers)
-    if all(bdim is None for bdim in dims):
+    if all(bdim is not_mapped for bdim in dims):
       return call_primitive.bind(f, *vals, **params)
     else:
-      f, dim_out = batch_subtrace(f, self.master, dims)
-      val_out = call_primitive.bind(f, *vals, **params)
-      return BatchTracer(self, val_out, dim_out())
+      f, dims_out = batch_subtrace(f, self.master, dims)
+      vals_out = call_primitive.bind(f, *vals, **params)
+      return [BatchTracer(self, v, d) for v, d in zip(vals_out, dims_out())]
 
   def process_map(self, map_primitive, f, tracers, params):
     vals, dims = unzip2((t.val, t.batch_dim) for t in tracers)
-    if all(dim is None for dim in dims):
+    if all(dim is not_mapped for dim in dims):
       return map_primitive.bind(f, *vals, **params)
     else:
-      size, = reduce(set.union, map(dimsize, dims, vals))
-      is_batched = tuple(map(where_batched, dims))
-      vals = map(partial(instantiate_bdim, size, 1), is_batched, dims, vals)
-      dims = tuple(map(partial(bools_to_bdims, 0), is_batched))
-      f, dim_out = batch_subtrace(f, self.master, dims)
-      val_out = map_primitive.bind(f, *vals, **params)
-      return BatchTracer(self, val_out, increment_bdim(dim_out()))
+      size, = {x.shape[d] for x, d in zip(vals, dims) if d is not not_mapped}
+      is_batched = tuple(d is not not_mapped for d in dims)
+      vals = [moveaxis(x, d, 1) if d is not not_mapped and d != 1 else x
+              for x, d in zip(vals, dims)]
+      dims = tuple(not_mapped if d is not_mapped else 1 for d in dims)
+      f, dims_out = batch_subtrace(f, self.master, dims)
+      vals_out = map_primitive.bind(f, *vals, **params)
+      return [BatchTracer(self, v, d) for v, d in zip(vals_out, dims_out())]
 
-  def post_process_call(self, call_primitive, out_tracer, params):
-    val, dim = out_tracer.val, out_tracer.batch_dim
+  def post_process_call(self, call_primitive, out_tracers, params):
+    vals, dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
     master = self.master
     def todo(x):
       trace = BatchTrace(master, core.cur_sublevel())
-      return BatchTracer(trace, x, dim)
-    return val, todo
-
-  def pack(self, tracers):
-    vals, dims = unzip2((t.val, t.batch_dim) for t in tracers)
-    return BatchTracer(self, pack(vals), tuple(dims))
-
-
-### abstract values
-
-
-def get_aval(x):
-  if isinstance(x, Tracer):
-    return raise_to_shaped(x.aval)
-  else:
-    return shaped_aval(x)
-
-def shaped_aval(x):
-  try:
-    return pytype_aval_mappings[type(x)](x)
-  except KeyError:
-    raise TypeError("{} is not a valid type for batching".format(type(x)))
-
-def remove_batch_dim_from_aval(bdim, aval):
-  t = type(aval)
-  if t is AbstractTuple:
-    if type(bdim) is tuple:
-      return AbstractTuple(map(remove_batch_dim_from_aval, bdim, aval))
-    else:
-      return AbstractTuple(map(partial(remove_batch_dim_from_aval, bdim), aval))
-  elif t is ShapedArray:
-    if bdim is None:
-      return ShapedArray(aval.shape, aval.dtype)
-    else:
-      assert 0 <= bdim < aval.ndim
-      unbatched_shape = tuple(onp.delete(aval.shape, bdim))
-      return ShapedArray(unbatched_shape, aval.dtype)
-  else:
-    raise TypeError(t)
-
-def add_batch_dim_to_aval(bdim, size, aval):
-  t = type(aval)
-  if t is AbstractTuple:
-    if type(bdim) is tuple:
-      return AbstractTuple(map(add_batch_dim_to_aval, bdim, size, aval))
-    else:
-      return AbstractTuple(map(partial(add_batch_dim_to_aval, bdim, size), aval))
-  elif t is ShapedArray:
-    if bdim is None:
-      return ShapedArray(aval.shape, aval.dtype)
-    else:
-      assert 0 <= bdim <= aval.ndim
-      batched_shape = tuple(
-        onp.insert(onp.asarray(aval.shape, onp.intp), bdim, size))
-      return ShapedArray(batched_shape, aval.dtype)
-  else:
-    raise TypeError(t)
-
-pytype_aval_mappings = {}
-
-for t in it.chain(array_types, [xla.DeviceArray]):
-  pytype_aval_mappings[t] = make_shaped_array
+      return map(partial(BatchTracer, trace), x, dims)
+    return vals, todo
 
 
 ### primitives
-
 
 primitive_batchers = {}
 
@@ -239,11 +174,24 @@ def vectorized_batcher(prim, batched_args, batch_dims, **params):
 def defbroadcasting(prim):
   primitive_batchers[prim] = partial(broadcast_batcher, prim)
 
-def broadcast_batcher(prim, batched_args, batch_dims, **params):
-  args = map(bdim_at_front, batched_args, batch_dims)
-  ndim = max(map(onp.ndim, args))  # special case to handle scalar broadcasting
-  args = map(partial(handle_scalar_broadcasting, ndim), args, batch_dims)
-  return prim.bind(*args, **params), 0
+def broadcast_batcher(prim, args, dims, **params):
+  shapes = {(x.shape, d) for x, d in zip(args, dims) if onp.ndim(x)}
+  if len(shapes) == 1:
+    # if there's only agreeing batch dims and scalars, just call the primitive
+    d = next(d for d in dims if d is not not_mapped)
+    return prim.bind(*args, **params), d
+  else:
+    size, = {shape[d] for shape, d in shapes if d is not not_mapped}
+    args = [bdim_at_front(x, d, size) for x, d in zip(args, dims)]
+    ndim = max(onp.ndim(x) for x in args)  # special-case scalar broadcasting
+    args = [_handle_scalar_broadcasting(ndim, x, d) for x, d in zip(args, dims)]
+    return prim.bind(*args, **params), 0
+
+def _handle_scalar_broadcasting(nd, x, d):
+  if d is not_mapped or nd == onp.ndim(x):
+    return x
+  else:
+    return x.reshape(x.shape + (1,) * (nd - onp.ndim(x)))
 
 def defreducer(prim):
   primitive_batchers[prim] = partial(reducer_batcher, prim)
@@ -252,7 +200,7 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
   operand, = batched_args
   bdim, = batch_dims
   axes = tuple(onp.where(onp.less(axes, bdim), axes, onp.add(axes, 1)))
-  bdim_out = list(onp.delete(onp.arange(operand.ndim), axes)).index(bdim)
+  bdim_out = int(list(onp.delete(onp.arange(operand.ndim), axes)).index(bdim))
   if 'input_shape' in params:
     params = dict(params, input_shape=operand.shape)
   return prim.bind(operand, axes=axes, **params), bdim_out
@@ -262,15 +210,17 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
 def add_batched(batched_args, batch_dims):
   bdx, bdy = batch_dims
   x, y = batched_args
-  x_aval, y_aval = map(get_aval, batched_args)
-  assert core.skip_checks or x_aval == y_aval
-  if bdx == bdy or x_aval == AbstractTuple(()):
-    return add_jaxvals_p.bind(x, y), bdx
+  if bdx == bdy or core.get_aval(x) == core.abstract_unit:
+    return add_jaxvals(x, y), bdx
+  elif bdx is not_mapped:
+    x = broadcast(x, y.shape[bdy], bdy)
+    return add_jaxvals(x, y), bdy
+  elif bdy is not_mapped:
+    y = broadcast(y, x.shape[bdx], bdx)
+    return add_jaxvals(x, y), bdx
   else:
-    sz = (dimsize(bdx, x) | dimsize(bdy, y)).pop()
-    move_bdim = partial(bdim_at_front, broadcast_size=sz, force_broadcast=True)
-    x, y = map(move_bdim, batched_args, batch_dims)
-    return add_jaxvals_p.bind(x, y), 0
+    x = moveaxis(x, bdx, bdy)
+    return add_jaxvals(x, y), bdy
 primitive_batchers[add_jaxvals_p] = add_batched
 
 def zeros_like_batched(batched_args, batch_dims):
@@ -290,242 +240,77 @@ defvectorized(xla.device_put_p)
 # almost works, except for broadcast, for which raw numpy.ndarrays don't have a
 # method. To handle that case, the `broadcast` function uses a try/except.
 
-
-def bdim_at_front(x, bdim, broadcast_size=1, force_broadcast=False):
-  return moveaxis(broadcast_size, 0, bdim, x, force_broadcast=force_broadcast)
-
-def move_dim_to_front(x, dim):
-  assert dim is not None
-  return moveaxis(None, 0, dim, x)
-
-def dimsize(dim, x):
-  return _dimsize(dim, get_aval(x), x)
-
-def _dimsize(dim, aval, x):
-  if type(aval) is AbstractTuple:
-    if type(dim) is tuple:
-      return reduce(set.union, map(_dimsize, dim, aval, x), set())
-    elif type(dim) is int:
-      return reduce(set.union, map(partial(_dimsize, dim), aval, x), set())
-    elif dim is None:
-      return set()
-    else:
-      raise TypeError(type(dim))
+def broadcast(x, sz, axis):
+  if core.get_aval(x) is core.abstract_unit:
+    return core.unit
+  shape = list(onp.shape(x))
+  shape.insert(axis, sz)
+  if isinstance(x, onp.ndarray) or onp.isscalar(x):
+    return onp.broadcast_to(x, shape)
   else:
-    if type(dim) is int:
-      return {x.shape[dim]}
-    elif dim is None:
-      return set()
-    else:
-      raise TypeError(type(dim))
+    broadcast_dims = tuple(onp.delete(onp.arange(len(shape)), axis))
+    return x.broadcast_in_dim(shape, broadcast_dims)
 
-def moveaxis(sz, dst, src, x, force_broadcast=True):
-  return _moveaxis(force_broadcast, sz, dst, src, get_aval(x), x)
+def moveaxis(x, src, dst):
+  if core.get_aval(x) is core.abstract_unit:
+    return core.unit
+  src, dst = src % x.ndim, dst % x.ndim
+  perm = [i for i in range(onp.ndim(x)) if i != src]
+  perm.insert(dst, src)
+  return x.transpose(perm)
 
-def _moveaxis(force_bcast, sz, dst, src, aval, x):
-  if type(aval) is AbstractTuple:
-    if type(src) is tuple and type(dst) is tuple:
-      return pack(map(partial(_moveaxis, force_bcast, sz), dst, src, aval, x))
-    elif type(src) is tuple:
-      return pack(map(partial(_moveaxis, force_bcast, sz, dst), src, aval, x))
-    elif type(dst) is tuple:
-      srcs = (src,) * len(dst)
-      return pack(map(partial(_moveaxis, force_bcast, sz), dst, srcs, aval, x))
-    elif type(src) in (int, type(None)):
-      return pack(map(partial(_moveaxis, force_bcast, sz, dst, src), aval, x))
-    else:
-      raise TypeError(type(src))
-  elif isinstance(aval, ShapedArray):
-    dst_ = (dst % aval.ndim) if dst is not None and aval.ndim else dst
-    if src == dst_:
-      return x
-    else:
-      if src is None:
-        x = broadcast(x, sz, force_broadcast=force_bcast)
-        src = 0
-        dst_ = dst % (aval.ndim + 1)
-      elif src >= aval.ndim:
-        raise ValueError(
-          "cannot move axis {} in {}-dimensional array".format(src, aval.ndim))
-      if src == dst_:
-        return x
-      else:
-        perm = [i for i in range(onp.ndim(x)) if i != src]
-        perm.insert(dst_, src)
-        return x.transpose(perm)
-  else:
-    raise TypeError(type(aval))
-
-def broadcast(x, sz, force_broadcast=False):
-  return _broadcast(force_broadcast, sz, get_aval(x), x)
-
-def _broadcast(force_bcast, sz, aval, x):
-  if type(aval) is AbstractTuple:
-    return pack(map(partial(_broadcast, sz), aval, x))
-  elif isinstance(aval, ShapedArray):
-    # for scalars, maybe don't actually broadcast
-    if not onp.ndim(x) and not force_bcast:
-      return x
-
-    # see comment at the top of this section
-    if isinstance(x, onp.ndarray) or onp.isscalar(x):
-      return onp.broadcast_to(x, (sz,) + onp.shape(x))
-    else:
-      return x.broadcast((sz,))  # should be a JAX arraylike
-  else:
-    raise TypeError(type(x))
-
-def handle_scalar_broadcasting(nd, x, bdim):
-  assert isinstance(get_aval(x), ShapedArray)
-  if bdim is None or nd == onp.ndim(x):
-    return x
-  else:
-    return x.reshape(x.shape + (1,) * (nd - x.ndim))
-
-
-# TODO(mattjj): try to de-duplicate utility functions with above
-
-def _bdim_map(f, bdim):
-  t = type(bdim)
-  if t is tuple:
-    return tuple(map(partial(_bdim_map, f), bdim))
-  elif t in (int, type(None)):
-    return f(bdim)
-  else:
-    raise TypeError(t)
-where_batched = partial(_bdim_map, lambda x: x is not None)
-increment_bdim = partial(_bdim_map, lambda x: None if x is None else x + 1)
-
-def bools_to_bdims(bdim, batched_indicator_tree):
-  t = type(batched_indicator_tree)
-  if t is tuple:
-    return tuple(map(partial(bools_to_bdims, bdim), batched_indicator_tree))
-  elif t is bool:
-    return bdim if batched_indicator_tree else None
-  else:
-    raise TypeError(t)
-
-def instantiate_bdim(size, axis, instantiate, bdim, x):
-  """Instantiate or move a batch dimension to position `axis`.
-
-  Ensures that `x` is at least as high on the batched lattice as `instantiate`.
-
-  Args:
-    size: int, size of the axis to instantiate.
-    axis: int, where to instantiate or move the batch dimension.
-    instantiate: tuple-tree of booleans, where the tree structure is a prefix of
-      the tree structure in x, indicating whether to instantiate the batch
-      dimension at the corresponding subtree in x.
-    bdim: tuple-tree of ints or NoneTypes, with identical tree structure to
-      `instantiate`, indicating where the batch dimension exists in the
-      corresponding subtree of x.
-    x: JaxType value on which to instantiate or move batch dimensions.
-
-  Returns:
-    A new version of `x` with instantiated batch dimensions.
-  """
-  def _inst(instantiate, bdim, x):
-    if type(instantiate) is tuple:
-      if type(bdim) is tuple:
-        return core.pack(map(_inst, instantiate, bdim, x))
-      elif type(bdim) is int or bdim is None:
-        bdims = (bdim,) * len(instantiate)
-        return core.pack(map(_inst, instantiate, bdims, x))
-      else:
-        raise TypeError(type(bdim))
-    elif type(instantiate) is bool:
-      if bdim is None:
-        return broadcast2(size, axis, x) if instantiate else x
-      elif type(bdim) is int:
-        return moveaxis2(bdim, axis, x)
-      elif type(bdim) is tuple:
-        return pack(map(partial(_inst, instantiate), bdim, x))
-      else:
-        raise TypeError(type(bdim))
-    else:
-      raise TypeError(type(instantiate))
-
-  return _inst(instantiate, bdim, x)
-
-def moveaxis2(src, dst, x):
+def matchaxis(sz, src, dst, x):
+  if core.get_aval(x) is core.abstract_unit:
+    return core.unit
   if src == dst:
     return x
+  elif type(src) == type(dst) == int:
+    return moveaxis(x, src, dst)
+  elif src is not_mapped and dst is not not_mapped:
+    return broadcast(x, sz, dst)
   else:
-    return _moveaxis2(src, dst, x, get_aval(x))
+    raise ValueError((src, dst))
 
-def _moveaxis2(src, dst, x, aval):
-  if type(aval) is AbstractTuple:
-    return core.pack(map(partial(_moveaxis2, src, dst), x, aval))
+def bdim_at_front(x, bdim, size):
+  if core.get_aval(x) is core.abstract_unit:
+    return core.unit
+  if bdim is not_mapped:
+    return broadcast(x, size, 0)
   else:
-    perm = [i for i in range(onp.ndim(x)) if i != src]
-    perm.insert(dst, src)
-    return x.transpose(perm)
+    return moveaxis(x, bdim, 0)
 
-def broadcast2(size, axis, x):
-  return _broadcast2(size, axis, x, get_aval(x))
 
-def _broadcast2(size, axis, x, aval):
-  if type(aval) is AbstractTuple:
-    return core.pack(map(partial(_broadcast2, size, axis), x, aval))
+def _promote_aval_rank(sz, aval):
+  if aval is core.abstract_unit:
+    return core.abstract_unit
   else:
-    # see comment at the top of this section
-    if isinstance(x, onp.ndarray) or onp.isscalar(x):
-      return onp.broadcast_to(x, (size,) + onp.shape(x))
-    else:
-      return x.broadcast((size,))  # should be a JAX arraylike
+    return ShapedArray((sz,) + aval.shape, aval.dtype)
 
-def _promote_aval_rank(n, batched, aval):
-  assert isinstance(aval, core.AbstractValue)
-  if type(aval) is AbstractTuple:
-    t = type(batched)
-    if t is tuple:
-      return AbstractTuple(map(partial(_promote_aval_rank, n), batched, aval))
-    elif t is bool:
-      if batched:
-        return AbstractTuple(map(partial(_promote_aval_rank, n, batched), aval))
-      else:
-        return aval
-    else:
-      raise TypeError(t)
-  else:
-    if batched:
-      return ShapedArray((n,) + aval.shape, aval.dtype)
-    else:
-      return aval
-
-def batch_jaxpr(jaxpr, size, is_batched, instantiate):
+def batch_jaxpr(jaxpr, size, batched, instantiate):
   f = wrap_init(core.jaxpr_as_fun(jaxpr))
-  f_batched, where_out_batched = batched_traceable(f, size, is_batched, instantiate)
-  in_avals = tuple(map(partial(_promote_aval_rank, size), is_batched, jaxpr.in_avals))
-  in_pvals = [pe.PartialVal((aval, core.unit)) for aval in in_avals]
-  jaxpr_out, pval_out, literals_out = pe.trace_to_jaxpr(
-      f_batched, in_pvals, instantiate=True)
-  out_aval, _ = pval_out
-  jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, in_avals, out_aval)
-  return jaxpr_out, where_out_batched()
+  f, batched_out = batched_traceable(f, size, batched, instantiate)
+  avals_in = [_promote_aval_rank(size, a) if b else a
+              for a, b in zip(jaxpr.in_avals, batched)]
+  in_pvals = [pe.PartialVal((aval, core.unit)) for aval in avals_in]
+  jaxpr_out, pvals_out, consts_out = pe.trace_to_jaxpr(f, in_pvals, instantiate=True)
+  avals_out, _ = unzip2(pvals_out)
+  jaxpr_out = core.TypedJaxpr(jaxpr_out, consts_out, avals_in, avals_out)
+  return jaxpr_out, batched_out()
 
 @transformation_with_aux
-def batched_traceable(size, is_batched, instantiate, *vals):
-  in_dims = bools_to_bdims(0, is_batched)
+def batched_traceable(size, batched, instantiate, *vals):
+  in_dims = [0 if b else None for b in batched]
   with new_master(BatchTrace) as master:
     trace = BatchTrace(master, core.cur_sublevel())
-    in_tracers = map(partial(BatchTracer, trace), vals, in_dims)
-    ans = yield in_tracers, {}
-    out_tracer = trace.full_raise(ans)
-    out_val, out_dim = out_tracer.val, out_tracer.batch_dim
-    del master, out_tracer
-  out_val = instantiate_bdim(size, 0, instantiate, out_dim, out_val)
-  yield out_val, _binary_lattice_join(where_batched(out_dim), instantiate)
-
-def _binary_lattice_join(a, b):
-  t = (type(a), type(b))
-  if t == (tuple, tuple):
-    return tuple(map(_binary_lattice_join, a, b))
-  elif t == (tuple, bool):
-    return tuple(map(_binary_lattice_join, a, (b,) * len(a)))
-  elif t == (bool, tuple):
-    return tuple(map(_binary_lattice_join, (a,) * len(b), b))
-  elif t == (bool, bool):
-    return a or b
-  else:
-    raise TypeError((type(a), type(b)))
+    ans = yield map(partial(BatchTracer, trace), vals, in_dims), {}
+    out_tracers = map(trace.full_raise, ans)
+    out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
+    del master, out_tracers
+  if type(instantiate) is bool:
+    instantiate = [instantiate] * len(out_vals)
+  out_vals = [moveaxis(x, d, 0) if d is not not_mapped and d != 0
+              else broadcast(x, size, 0) if d is not_mapped and inst else x
+              for x, d, inst in zip(out_vals, out_dims, instantiate)]
+  out_batched = [d is not not_mapped or inst
+                 for d, inst in zip(out_dims, instantiate)]
+  yield out_vals, out_batched

--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -27,13 +27,14 @@ from six.moves import reduce
 from .. import core
 from .. import linear_util as lu
 from ..core import Trace, Tracer, Primitive, new_master
-from ..abstract_arrays import ShapedArray, ConcreteArray
-from ..util import safe_zip, unzip2, unzip3, partialmethod, prod
+from ..abstract_arrays import ShapedArray, ConcreteArray, raise_to_shaped
+from ..util import safe_map, safe_zip, unzip2, unzip3, partialmethod, prod
 from ..lib import xla_bridge as xb
 from . import partial_eval as pe
 from . import batching
 from . import pxla
 
+map = safe_map
 zip = safe_zip
 
 def identity(x): return x
@@ -51,44 +52,23 @@ def papply_transform(name, axis_size, *args):
   with new_master(PapplyTrace) as master:
     trace = PapplyTrace(master, core.cur_sublevel())
     in_tracers = map(partial(PapplyTracer, trace, name, axis_size, axis=0), args)
-    ans = yield in_tracers, {}
-    out_tracer = trace.full_raise(ans)
-    out_val, out_axis = out_tracer.val, out_tracer.axis
-    del master, out_tracer
-  yield out_val, out_axis
+    outs = yield in_tracers, {}
+    out_tracers = map(trace.full_raise, outs)
+    out_vals, out_axes = unzip2((t.val, t.axis) for t in out_tracers)
+    del master, out_tracers
+  yield out_vals, out_axes
 
 @lu.transformation_with_aux
 def papply_subtrace(master, name, axis_size, axes, *vals):
   trace = PapplyTrace(master, core.cur_sublevel())
-  ans = yield map(partial(PapplyTracer, trace, name, axis_size), vals, axes), {}
-  out_tracer = trace.full_raise(ans)
-  out_val, out_axis = out_tracer.val, out_tracer.axis
-  yield out_val, out_axis
+  outs = yield map(partial(PapplyTracer, trace, name, axis_size), vals, axes), {}
+  out_tracers = map(trace.full_raise, outs)
+  out_vals, out_axes = unzip2((t.val, t.axis) for t in out_tracers)
+  yield out_vals, out_axes
 
-def match_axis(src, dst, x):
-  assert type(src) is int
-  if src == dst:
-    return x
-  else:
-    return _match_axis(src, dst, x, core.get_aval(x))
-
-def _match_axis(src, dst, x, aval):
-  if type(aval) is core.AbstractTuple:
-    if type(dst) is tuple:
-      return core.pack(map(partial(_match_axis, src), dst, x, aval))
-    else:
-      return core.pack(map(partial(_match_axis, src, dst), x, aval))
-  elif isinstance(aval, ShapedArray):
-    if type(dst) is int:
-      perm = [i for i in range(x.ndim) if i != src]
-      perm.insert(dst, src)
-      return x.transpose(perm)
-    elif dst is None:
-      return x[src]
-    else:
-      raise TypeError(dst)
-  else:
-    raise TypeError(aval)
+# TODO(mattjj); use a special sentinel type rather than None
+NotSharded = type(None)
+not_sharded = None
 
 class PapplyTracer(Tracer):
   def __init__(self, trace, name, axis_size, val, axis):
@@ -100,32 +80,39 @@ class PapplyTracer(Tracer):
 
   @property
   def aval(self):
-    batched_aval = batching.get_aval(self.val)
-    return batching.add_batch_dim_to_aval(
-        self.axis, self.axis_size, batched_aval)
-
-  def unpack(self):
-    raise NotImplementedError  # TODO(mattjj,frostig)
+    aval = raise_to_shaped(core.get_aval(self.val))
+    if self.axis is not_sharded:
+      return aval
+    else:
+      if aval is core.abstract_unit:
+        return aval
+      elif type(aval) is ShapedArray:
+        assert 0 <= self.axis < aval.ndim + 1
+        new_shape = list(aval.shape)
+        new_shape.insert(self.axis, self.axis_size)
+        return ShapedArray(tuple(new_shape), aval.dtype)
+      else:
+        raise TypeError(aval)
 
   def full_lower(self):
-    if self.axis is None:
+    if self.axis is not_sharded:
       return core.full_lower(self.val)
     else:
       return self
 
 class PapplyTrace(Trace):
   def pure(self, val):
-    return PapplyTracer(self, None, None, val, None)
+    return PapplyTracer(self, None, None, val, not_sharded)
 
   def lift(self, val):
-    return PapplyTracer(self, None, None, val, None)
+    return PapplyTracer(self, None, None, val, not_sharded)
 
   def sublift(self, val):
     return PapplyTracer(self, val.name, val.axis_size, val.val, val.axis)
 
   def process_primitive(self, primitive, tracers, params):
     names, vals, axes = unzip3((t.name, t.val, t.axis) for t in tracers)
-    if all(axis is None for axis in axes):
+    if all(axis is not_sharded for axis in axes):
       return primitive.bind(*vals, **params)
     else:
       name, = {n for n in names if n is not None}
@@ -135,15 +122,18 @@ class PapplyTrace(Trace):
       return PapplyTracer(self, name, size, val_out, axis_out)
 
   def process_call(self, call_primitive, f, tracers, params):
+    if call_primitive in pe.map_primitives:
+      return self.process_map(call_primitive, f, tracers, params)
     names, vals, axes = unzip3((t.name, t.val, t.axis) for t in tracers)
-    if all(axis is None for axis in axes):
+    if all(axis is not_sharded for axis in axes):
       return call_primitive.bind(f, *vals, **params)
     else:
       name, = {n for n in names if n is not None}
       size, = {t.axis_size for t in tracers if t.axis_size is not None}
-      f_papply, axis_out = papply_subtrace(f, self.master, name, size, axes)
-      val_out = call_primitive.bind(f_papply, *vals, **params)
-      return PapplyTracer(self, name, size, val_out, axis_out())
+      f_papply, axes_out = papply_subtrace(f, self.master, name, size, axes)
+      vals_out = call_primitive.bind(f_papply, *vals, **params)
+      return [PapplyTracer(self, name, size, x, a)
+              for x, a in zip(vals_out, axes_out())]
 
   def post_process_call(self, call_primitive, out_tracer):
     t = out_tracer
@@ -154,12 +144,8 @@ class PapplyTrace(Trace):
       return PapplyTracer(trace, name, size, x, axis)
     return val, todo
 
-  def pack(self, tracers):
-    vals = core.pack([t.val for t in tracers])
-    axis = tuple(t.axis for t in tracers)
-    name = tuple(t.name for t in tracers)
-    size = tuple(t.axis_size for t in tracers)
-    return PapplyTracer(self, name, size, vals, axis)
+  def process_map(self, map_primitive, f, tracers, params):
+    raise NotImplementedError  # TODO(mattjj,frostig)
 
 
 papply_primitive_rules = {}

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -25,9 +25,9 @@ from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ShapedArray, ConcreteArray
 from ..linear_util import thunk, transformation, transformation_with_aux
-from ..util import unzip2, safe_zip, safe_map, toposort, partial
+from ..util import unzip2, safe_zip, safe_map, toposort, partial, split_list
 from ..core import (Trace, Tracer, new_master, Jaxpr, JaxprEqn, Literal,
-                    get_aval, AbstractValue, unit, unitvar,
+                    get_aval, AbstractValue, unit, unitvar, abstract_unit,
                     Primitive, call_p, TypedJaxpr, new_jaxpr_eqn)
 
 map = safe_map
@@ -36,11 +36,10 @@ def identity(x): return x
 
 # A partial value (pval) is modeled as a pair (pv, const), as per
 #   type PVal = (PV, Const)
-#   data PV = NonePV | AbstractPV AbstractValue | JaxprTracerTuple [PV]
+#   data PV = NonePV | AbstractPV AbstractValue
 #   type Const = MaybeTraced JaxType
 # where the NonePV arm indicates a known (constant) value, the AbstractPV arm
-# indicates an unknown value, and the JaxprTracerTuple indicates a finer-grained
-# representation that might be a mixture.
+# indicates an unknown value.
 # Additionally, when the pv is an AbstractValue, then the const must be unit.
 
 
@@ -76,8 +75,6 @@ class JaxprTrace(Trace):
     pv, const = tracer.pval
     if isinstance(pv, AbstractValue):
       return tracer
-    elif isinstance(pv, JaxprTracerTuple):
-      return pack(map(lambda t: self.instantiate_const(self.full_raise(t)), tracer))
     elif pv is None:
       if type(tracer.recipe) is Literal:
         return self.new_instantiated_literal(tracer.recipe.val)
@@ -88,9 +85,7 @@ class JaxprTrace(Trace):
 
   def process_primitive(self, primitive, tracers, params):
     if primitive in custom_partial_eval_rules:
-      assert False, "update to match new partial_eval"
-      partial_eval = custom_partial_eval_rules[primitive]
-      return partial_eval(self, *tracers, **params)
+      return custom_partial_eval_rules[primitive](self, *tracers, **params)
     else:
       pvs, consts = unzip2(t.pval for t in tracers)
       if all(pv is None for pv in pvs):
@@ -98,20 +93,26 @@ class JaxprTrace(Trace):
       tracers = map(self.instantiate_const, tracers)
       avals = [t.aval for t in tracers]
       out_aval = primitive.abstract_eval(*avals, **params)
-      out_tracer = JaxprTracer(self, PartialVal((out_aval, unit)), None)
       # TODO(dougalm): think about whether these ref cycles will leak memory
-      out_tracer.recipe = new_jaxpr_eqn(tracers, [out_tracer], primitive, (), params)
-      return out_tracer
+      if primitive.multiple_results:
+        out_tracers = [JaxprTracer(self, PartialVal((aval, unit)), None)
+                       for aval in out_aval]
+        eqn = new_jaxpr_eqn(tracers, out_tracers, primitive, (), params)
+        for t in out_tracers: t.recipe = eqn
+        return out_tracers
+      else:
+        out_tracer = JaxprTracer(self, PartialVal((out_aval, unit)), None)
+        out_tracer.recipe = new_jaxpr_eqn(tracers, [out_tracer], primitive, (), params)
+        return out_tracer
 
   def process_call(self, call_primitive, f, tracers, params):
     if call_primitive in map_primitives:
       return self.process_map(call_primitive, f, tracers, params)
     in_pvs, in_consts = unzip2([t.pval for t in tracers])
     fun, aux = partial_eval(f, self, in_pvs)
-    stuff = call_primitive.bind(fun, *in_consts, **params)
+    out_flat = call_primitive.bind(fun, *in_consts, **params)
     out_pvs, jaxpr, env = aux()
-    N = len(jaxpr.constvars)
-    out_pv_consts, consts = (stuff[-N:], stuff[:-N])
+    out_pv_consts, consts = split_list(out_flat, [len(out_flat)-len(jaxpr.constvars)])
     const_tracers = map(self.new_instantiated_const, consts)
     bound_subjaxpr = (jaxpr, const_tracers, map(self.full_raise, env))
     out_tracers = [JaxprTracer(self, PartialVal((out_pv, out_pv_const)), None)
@@ -123,77 +124,63 @@ class JaxprTrace(Trace):
 
   def process_map(self, map_primitive, f, tracers, params):
     in_pvs, in_consts = unzip2([t.pval for t in tracers])
-    reduced_pvs = map(remove_axis_from_pv, in_pvs)
+    reduced_pvs = [None if pv is None else _mapped_aval(pv) for pv in in_pvs]
     fun, aux = partial_eval(f, self, reduced_pvs)
-    out_const, consts = map_primitive.bind(fun, *in_consts, **params)
-    out_pv_reduced, jaxpr, env = aux()
-    out_pv = add_axis_to_pv(params['axis_size'], out_pv_reduced)
+    out_flat = map_primitive.bind(fun, *in_consts, **params)
+    out_pvs_reduced, jaxpr, env = aux()
+    out_pv_consts, consts = split_list(out_flat, [len(out_flat)-len(jaxpr.constvars)])
+    out_pvs = [None if pv is None else _unmapped_aval(params['axis_size'], pv)
+               for pv in out_pvs_reduced]
     const_tracers = map(self.new_instantiated_const, consts)
-    jaxpr_converted = jaxpr.copy()
-    jaxpr_converted.constvars = []
-    jaxpr_converted.invars = list(it.chain(jaxpr.constvars, jaxpr.invars))
-    invars = tuple(it.chain(const_tracers, tracers))
-    bound_subjaxpr = (jaxpr_converted, (), map(self.full_raise, env))
-    eqn = JaxprEqn(invars, None, map_primitive, (bound_subjaxpr,), params)
-    return JaxprTracer(self, PartialVal((out_pv, out_const)), eqn)
+    lifted_jaxpr = closure_convert_jaxpr(jaxpr)
+    bound_subjaxpr = (lifted_jaxpr, (), map(self.full_raise, env))
+    out_tracers = [JaxprTracer(self, PartialVal((out_pv, out_pv_const)), None)
+                   for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
+    eqn = new_jaxpr_eqn(tuple(it.chain(const_tracers, tracers)),
+                        out_tracers, map_primitive, (bound_subjaxpr,), params)
+    for t in out_tracers:
+      t.recipe = eqn
+    return out_tracers
 
-  def post_process_call(self, call_primitive, out_tracer, params):
-    raise NotImplementedError
-    # TODO(mattjj): post_process_map
-    jaxpr, consts, env = tracers_to_jaxpr([], out_tracer)
-    out_pv, out_pv_const = out_tracer.pval
-    out = pack((out_pv_const, pack(consts)))
+  def post_process_call(self, call_primitive, out_tracers, params):
+    jaxpr, consts, env = tracers_to_jaxpr([], out_tracers)
+    out_pvs, out_pv_consts = unzip2(t.pval for t in out_tracers)
+    out = out_pv_consts + consts
+    del consts, out_pv_consts
     master = self.master
     def todo(x):
-      out_pv_const, consts = x
+      n = len(jaxpr.outvars)
+      out_pv_consts, consts = x[:n], x[n:]
       trace = JaxprTrace(master, core.cur_sublevel())
       const_tracers = map(trace.new_instantiated_const, consts)
       env_tracers = map(trace.full_raise, env)
       bound_subjaxpr = (jaxpr, const_tracers, env_tracers)
-      eqn = JaxprEqn([], None, call_primitive, (bound_subjaxpr,), params)
-      return JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), eqn)
-
+      out_tracers = [JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), None)
+                     for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
+      eqn = new_jaxpr_eqn([], out_tracers, call_primitive, (bound_subjaxpr,), params)
+      for t in out_tracers:
+        t.recipe = eqn
+      return out_tracers
     return out, todo
 
-map_primitives = set()
-
-
-def remove_axis_from_pv(pv):
-  if pv is None:
-    return pv
-  elif isinstance(pv, AbstractValue):
-    return remove_axis_from_aval(pv)
-  elif type(pv) is JaxprTracerTuple:
-    return JaxprTracerTuple(map(remove_axis_from_pv, pv))
-  else:
-    raise TypeError(type(pv))
-
-def remove_axis_from_aval(aval):
-  if type(aval) is AbstractTuple:
-    return AbstractTuple(map(remove_axis_from_aval, aval))
+def _mapped_aval(aval):
+  if aval is core.abstract_unit:
+    return aval
   elif isinstance(aval, ShapedArray):
     # might be raising abstraction level from Concrete here
     return ShapedArray(aval.shape[1:], aval.dtype)
   else:
-    raise NotImplementedError  # TODO(mattjj)
+    raise TypeError(aval)
 
-def add_axis_to_pv(size, pv):
-  if pv is None:
-    return pv
-  elif isinstance(pv, AbstractValue):
-    return add_axis_to_aval(size, pv)
-  elif type(pv) is JaxprTracerTuple:
-    return JaxprTracerTuple(map(partial(add_axis_to_pv, size), pv))
-  else:
-    raise TypeError(type(pv))
-
-def add_axis_to_aval(size, aval):
-  if type(aval) is AbstractTuple:
-    return AbstractTuple(map(partial(add_axis_to_aval, size), aval))
+def _unmapped_aval(size, aval):
+  if aval is core.abstract_unit:
+    return aval
   elif isinstance(aval, ShapedArray):
     return ShapedArray((size,) + aval.shape, aval.dtype)
   else:
-    raise NotImplementedError  # TODO(mattjj)
+    raise TypeError(aval)
+
+map_primitives = set()
 
 
 def partial_eval(f, trace, pvs):
@@ -212,12 +199,11 @@ def partial_eval_wrapper(avals, *consts):
 
 def abstract_eval_fun(fun, *avals, **params):
   pvals_in = [PartialVal((a, unit)) for a in avals]
-  _, pval_outs, _ = trace_to_jaxpr(lu.wrap_init(fun, params), pvals_in,
+  _, pvals_out, _ = trace_to_jaxpr(lu.wrap_init(fun, params), pvals_in,
                                   instantiate=True)
-  avals_out, _ = unzip2(pval_out)
+  avals_out, _ = unzip2(pvals_out)
   for aval_out in avals_out:
     assert isinstance(aval_out, AbstractValue)  # instantiate=True
-  assert False, "Need callers to handle multiple avals_out now"
   return avals_out
 
 
@@ -252,7 +238,7 @@ class JaxprTracer(Tracer):
 
   def ispure(self):
     pv, _ = self.pval
-    return pv is None
+    return pv is None  # or pv is core.abstract_unit
 
   def full_lower(self):
     if self.ispure():
@@ -260,8 +246,6 @@ class JaxprTracer(Tracer):
       return core.full_lower(const)
     else:
       return self
-
-class JaxprTracerTuple(tuple): pass
 
 Destructuring = namedtuple('Destructuring', ['i', 'eqn', 'key'])
 
@@ -273,20 +257,16 @@ class PartialVal(tuple):
       assert isinstance(pv, valid_pv_types), xs
       assert isinstance(const, core.Tracer) or core.valid_jaxtype(const), xs
       # invariant checks
-      if type(pv) is JaxprTracerTuple:
-        assert len(pv) == len(const), xs
       if isinstance(pv, AbstractValue):
         assert const == core.unit, xs
     return tuple.__new__(cls, xs)
 
-valid_pv_types = (AbstractValue, JaxprTracerTuple, type(None))
+valid_pv_types = (AbstractValue, type(None))
 
 def merge_pvals(val, pval):
   pv, const = pval
   if isinstance(pv, AbstractValue):
     return val
-  elif isinstance(pv, JaxprTracerTuple):
-    return pack(map(merge_pvals, val, zip(pv, const)))
   elif pv is None:
     return const
   else:
@@ -312,26 +292,7 @@ def join_pvals(pval1, pval2):
     aval = core.lattice_join(pv1, pv2)
     return PartialVal((aval, unit))  # neither is known
   else:
-    # the pvals are tuples with some mixtures of known/unknown
-    assert isinstance(pv1, JaxprTracerTuple) or isinstance(pv2, JaxprTracerTuple)
-    def explode(pv, const):
-      if isinstance(pv, AbstractValue):
-        assert const == core.unit
-        const = [core.unit] * len(pv)
-      elif pv is None:
-        pv = [None] * len(const)
-      else:
-        assert isinstance(pv, JaxprTracerTuple)
-      return pv, const
-    pv1, const1 = explode(pv1, const1)
-    pv2, const2 = explode(pv2, const2)
-    pvals1, pvals2 = zip(pv1, const1), zip(pv2, const2)
-    join_pvs, join_consts = unzip2(map(join_pvals, pvals1, pvals2))
-    if all(isinstance(pv, AbstractValue) for pv in join_pvs):
-      assert all(const == core.unit for const in join_consts)
-      return PartialVal((AbstractTuple(join_pvs), core.unit))
-    else:
-      return PartialVal((JaxprTracerTuple(join_pvs), pack(join_consts)))
+    raise TypeError((pval1, pval2))
 
 def as_abstract_val(pv):
   if isinstance(pv, AbstractValue):
@@ -344,31 +305,10 @@ def as_abstract_val(pv):
 def partial_val_aval(pv, const):
   if isinstance(pv, AbstractValue):
     return pv
-  elif isinstance(pv, JaxprTracerTuple):
-    return AbstractTuple(map(partial_val_aval, pv, const))
   elif pv is None:
     return get_aval(const)
   else:
     raise TypeError(pv)
-
-def pack_pvals(pvals):
-  pvs, consts = unzip2(pvals)
-  if all(pv is None for pv in pvs):
-    return PartialVal((None, pack(consts)))
-  elif all(isinstance(pv, AbstractValue) for pv in pvs):
-    pv_out = AbstractTuple(pvs)
-    return PartialVal((pv_out, unit))
-  else:
-    pv_out = JaxprTracerTuple(pvs)
-    return PartialVal((pv_out, pack(consts)))
-
-
-def abstractify(x):
-  return PartialVal((core.concrete_aval(x), unit))
-
-def trace_unwrapped_to_jaxpr(fun, pvals, instantiate, **kwargs):
-  return trace_to_jaxpr(lu.wrap_init(fun, kwargs), pvals,
-                        instantiate=instantiate)
 
 def trace_to_jaxpr(fun, pvals, **kwargs):
   """Traces a function, given abstract inputs, to a jaxpr."""
@@ -387,24 +327,20 @@ def trace_to_subjaxpr(master, instantiate, pvals):
   trace = JaxprTrace(master, core.cur_sublevel())
   in_tracers = map(trace.new_arg, pvals)
   ans = yield in_tracers, {}
-  out_tracers = map(trace.full_raise, ans)
-  out_tracers = map(partial(instantiate_const_at, trace, instantiate), out_tracers)
+  instantiate = [instantiate] * len(ans) if type(instantiate) is bool else instantiate
+  out_tracers = map(trace.full_raise, map(core.full_lower, ans))
+  out_tracers = map(partial(instantiate_const_at, trace), instantiate, out_tracers)
   jaxpr, consts, env = tracers_to_jaxpr(in_tracers, out_tracers)
   out_pvals = [t.pval for t in out_tracers]
   del trace, in_tracers, out_tracers
   yield jaxpr, (out_pvals, consts, env)
 
 def instantiate_const_at(trace, instantiate, tracer):
-  t = type(instantiate)
-  if t is tuple:
-    return pack(map(partial(instantiate_const_at, trace), instantiate, tracer))
-  elif t is bool:
-    if instantiate:
-      return trace.instantiate_const(trace.full_raise(tracer))
-    else:
-      return tracer
+  assert type(instantiate) is bool
+  if instantiate:
+    return trace.instantiate_const(trace.full_raise(tracer))
   else:
-    raise TypeError(t)
+    return tracer
 
 
 FreeVar = namedtuple('FreeVar', ['val'])
@@ -456,7 +392,8 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
   env_vars, env_vals = unzip2(env.items())
   const_vars, const_vals = unzip2(consts.items())
   jaxpr = Jaxpr(const_vars, env_vars, invars, list(map(var, out_tracers)), eqns)
-  core.skip_checks or core.check_jaxpr(jaxpr)
+  # core.skip_checks or core.check_jaxpr(jaxpr)
+  core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
 
@@ -483,128 +420,54 @@ def eqn_parents(eqn):
   subjaxpr_tracers = [it.chain(c, f) for _, c, f in eqn.bound_subjaxprs]
   return list(it.chain(eqn.invars,  *subjaxpr_tracers))
 
-def unzip_tracer_tuple(pvals):
-  pvs, consts = unzip2(pvals)
-  return PartialVal((JaxprTracerTuple(pvs), pack(consts)))
-
-def as_pval(aval, is_unknown, val):
-  t = type(is_unknown)
-  if t is tuple:
-    return unzip_tracer_tuple(map(as_pval, aval, is_unknown, val))
-  elif t is bool:
-    if is_unknown:
-      return PartialVal((aval, core.unit))
-    else:
-      return PartialVal((None, val))
-  else:
-    raise TypeError(t)
-
-def as_pval2(aval, is_unknown):
-  t = type(is_unknown)
-  if t is tuple:
-    return unzip_tracer_tuple(map(as_pval2, aval, is_unknown))
-  elif t is bool:
-    if is_unknown:
-      return PartialVal((core.AbstractTuple(()), core.unit))
-    else:
-      return PartialVal((aval, core.unit))
-  else:
-    raise TypeError(t)
-
-def unknown(x):
-  if x is None:
-    return False
-  elif type(x) is JaxprTracerTuple:
-    return tuple(map(unknown, x))
-  elif isinstance(x, core.AbstractValue):
-    return True
-  else:
-    raise TypeError(type(x))
-
-def _closure_convert_jaxpr(jaxpr):
+def closure_convert_jaxpr(jaxpr):
   core.skip_checks or core.check_jaxpr(jaxpr)
-  lifted_jaxpr = jaxpr.copy()
-  lifted_jaxpr.constvars = ()
-  lifted_jaxpr.invars = [tuple(jaxpr.constvars)] + list(jaxpr.invars)
+  lifted_jaxpr = Jaxpr(constvars=(), freevars=jaxpr.freevars,
+                       invars=jaxpr.constvars + jaxpr.invars,
+                       outvars=jaxpr.outvars, eqns=jaxpr.eqns)
   core.skip_checks or core.check_jaxpr(lifted_jaxpr)
   return lifted_jaxpr
 
-def partial_eval_jaxpr(jaxpr, second_components, instantiate):
-  raise NotImplementedError
-  # jaxpr :: d -> c -> a -> (c, b)
+def partial_eval_jaxpr(jaxpr, unknowns, instantiate):
   f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
 
   cell = []
-  # we do some final-style output munging to place residuals
-  # fun :: d1 -> c1 -> a1 -> (c1, (b1, res))
   def fun(*vals):
-    pvals = map(as_pval, jaxpr.in_avals, second_components, vals)
-    jaxpr_2, out_pval, consts_2 = trace_to_jaxpr(f, pvals, instantiate=instantiate)
-    out_pv, out_const = out_pval
-    out_pv = (None, None) if out_pv is None else out_pv
-    out_const = (core.unit, core.unit) if out_const is core.unit else out_const
-    out_pv_c, out_pv_b = out_pv
-    out_const_c, out_const_b = out_const
-    cell.append((out_pv_c, out_pv_b, jaxpr_2))
-    return pack((out_const_c, pack((out_const_b, pack(consts_2)))))
+    pvals = [PartialVal((aval, unit)) if uk else PartialVal((None, val))
+             for aval, val, uk in zip(jaxpr.in_avals, vals, unknowns)]
+    jaxpr_2, out_pvals_2, consts_2 = trace_to_jaxpr(f, pvals, instantiate=instantiate)
+    out_pvs_2, out_consts_2 = unzip2(out_pvals_2)
+    cell.append((out_pvs_2, jaxpr_2, len(consts_2)))
+    return out_consts_2 + consts_2
 
-  pvals = map(as_pval2, jaxpr.in_avals, second_components)
-  jaxpr_1, out_pval, consts_1 = trace_to_jaxpr(
-      lu.wrap_init(fun), pvals, instantiate=True)
-  out_pv_c, out_pv_b, jaxpr_2 = cell[0]
+  pvals = [PartialVal((abstract_unit, unit)) if uk else PartialVal((aval, unit))
+           for aval, uk in zip(jaxpr.in_avals, unknowns)]
+  jaxpr_1, out_pvals, consts_1 = trace_to_jaxpr(lu.wrap_init(fun), pvals, instantiate=True)
+  (out_pvs_2, jaxpr_2, num_res), = cell
+  assert len(jaxpr_2.constvars) == num_res
 
-  #               jaxpr_1 :: d1 -> c1 -> a1 -> (c1, (b1, res))
-  #               jaxpr_2 :: res | d2 -> c2 -> a2 -> (c2, b2)
-  #        lifted_jaxpr_2 :: res -> d2 -> c2 -> a2 -> (c2, b2)
-  # doubly_lifted_jaxpr_2 :: d2 -> c2 -> (a2, res) -> (c2, b2)
-  lifted_jaxpr_2 = _closure_convert_jaxpr(jaxpr_2)
-  doubly_lifted_jaxpr_2 = _move_and_pair_arg(lifted_jaxpr_2)
-  sc_out = sc_c_out, sc_b_out = unknown(out_pv_c), unknown(out_pv_b)
+  #   jaxpr :: a -> b
+  # jaxpr_1 :: a1 -> [b1, res]
+  # jaxpr_2 :: res | a2 -> b2
+  # jaxpr_2 :: [a2, res] -> b2
+  jaxpr_2 = closure_convert_jaxpr(jaxpr_2)
+  jaxpr_2.invars = jaxpr_2.invars[num_res:] + jaxpr_2.invars[:num_res]
+  uk_out = [pv is not None for pv in out_pvs_2]
 
-  in_avals_1, in_avals_2 = unzip2(map(_split_avals, second_components,
-                                      jaxpr.in_avals))
-  out_aval_1, out_aval_2 = _split_avals(sc_out, jaxpr.out_aval)
+  in_avals_1, in_avals_2 = unzip2(map(_split_aval, unknowns, jaxpr.in_avals))
+  out_avals_1, out_avals_2 = unzip2(map(_split_aval, uk_out, jaxpr.out_avals))
+  # out_avals_1 and in_avals_2 need the residuals added
+  out_pvs, _ = unzip2(out_pvals)
+  res_avals = out_pvs[len(jaxpr.out_avals):]
+  assert len(res_avals) == num_res
+  out_avals_1 = out_avals_1 + res_avals
+  in_avals_2 = in_avals_2 + res_avals
 
-  # in_avals_1 is already (d1, c1, a1), and out_aval_2 is already (c2, b2), but
-  # we must munge:
-  # 1. form out_aval_1 to include the residuals as (c1, (b1, res))
-  # 2. form in_avals_2 to include the residuals as (d2, c2, (a2, res))
+  typed_jaxpr_1 = TypedJaxpr(jaxpr_1, consts_1, in_avals_1, out_avals_1)
+  typed_jaxpr_2 = TypedJaxpr(jaxpr_2, (), in_avals_2, out_avals_2)
+  return typed_jaxpr_1, typed_jaxpr_2, uk_out
 
-  out_pv, _ = out_pval
-  _, (_, res) = out_pv
-  assert isinstance(res, AbstractValue)
-
-  c1, b1 = out_aval_1
-  lifted_out_aval_1 = AbstractTuple((c1, AbstractTuple((b1, res))))
-
-  d2, c2, a2 = in_avals_2
-  lifted_in_avals_2 = (d2, c2, AbstractTuple((a2, res)))
-
-  typed_jaxpr_1 = TypedJaxpr(jaxpr_1, consts_1, in_avals_1, lifted_out_aval_1)
-  typed_jaxpr_2 = TypedJaxpr(doubly_lifted_jaxpr_2, (), lifted_in_avals_2,
-                             out_aval_2)
-  return typed_jaxpr_1, typed_jaxpr_2, sc_out
-
-def _move_and_pair_arg(jaxpr):
-  moved_jaxpr = jaxpr.copy()
-  res, d, c, a = jaxpr.invars
-  moved_jaxpr.invars = [d, c, (a, res)]
-  core.skip_checks or core.check_jaxpr(moved_jaxpr)
-  return moved_jaxpr
-
-def _split_avals(second_component, aval):
-  t = type(second_component)
-  if t is tuple:
-    assert type(aval) is AbstractTuple
-    avals1, avals2 = unzip2(map(_split_avals, second_component, aval))
-    return AbstractTuple(avals1), AbstractTuple(avals2)
-  elif t is bool:
-    if second_component:
-      return AbstractTuple(()), aval
-    else:
-      return aval, AbstractTuple(())
-  else:
-    raise TypeError(t)
-
+def _split_aval(unknown, aval):
+  return (abstract_unit, aval) if unknown else (aval, abstract_unit)
 
 custom_partial_eval_rules = {}

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -28,12 +28,13 @@ from six.moves import reduce
 
 from .. import core
 from .. import linear_util as lu
-from ..abstract_arrays import ConcreteArray, ShapedArray
+from ..abstract_arrays import (ConcreteArray, ShapedArray, array_types,
+                               raise_to_shaped)
 from ..util import partial, unzip2, concatenate, prod
 from ..lib import xla_bridge as xb
-from .xla import xla_shape, xla_destructure, aval_from_xla_shape
+from .xla import aval_to_xla_shape, xla_destructure
 from .partial_eval import trace_to_subjaxpr, merge_pvals, JaxprTrace, PartialVal
-from .batching import dimsize, broadcast
+from .batching import broadcast, not_mapped
 from . import batching
 from . import partial_eval as pe
 from . import xla
@@ -44,138 +45,74 @@ from . import ad
 
 def identity(x): return x
 
-# TODO(mattjj, phawkins): improve re-distribution not to copy to host
-def shard_args(device_ordinals, assignments, axis_size, nrep, args):
+def shard_args(device_ordinals, assignments, axis_size, args):
   """Shard an argument data array arg along its leading axis.
 
   Args:
     device_ordinals: list of integers of length num_replicas mapping a logical
       replica index to a physical device number.
-    assignments: replica to shard assignment
+    assignments: replica to shard assignment.
     axis_size: int, size of the axis to be sharded.
     args: a sequence of JaxTypes representing arguments to be sharded along
       their leading axes (or the leading axess of their leaves in the tuple
       case) and placed on the devices indicated by `device_ordinals`.
-    nrep: number of replicas
 
   Returns:
     A list of device buffers with the same length as `device_ordinals` indexed
     by replica number, so that the nth element is the argument to be passed to
     the nth replica.
   """
-  nargs = len(args)
-  buffers = [[None] * nargs  for _ in range(nrep)]
+  nargs, nrep = len(args), len(device_ordinals)
+  buffers = [[None] * nargs for _ in range(nrep)]
   for a, arg in enumerate(args):
-    arg_type = type(arg)
-    if ((arg_type == ShardedDeviceArray or arg_type == ShardedDeviceTuple)
-         and nrep == len(arg.device_buffers)):
-      for r in range(nrep):
-        buf = arg.device_buffers[r]
-        if buf.device() == device_ordinals[r]:
-          buffers[r][a] = buf
-        else:
-          i = assignments[r]
-          buffers[r][a] = xla.device_put(arg.device_buffers[i].to_py(),
-                                         device_ordinals[r])
+    # The shard_arg_handlers allow an extensible set of types to be sharded, but
+    # inline handling for ShardedDeviceArray as a special case for performance
+    if type(arg) is ShardedDeviceArray:
+      if nrep == len(arg.device_buffers):
+        for r, buf in enumerate(arg.device_buffers):
+          buffers[r][a] = (buf if buf.device() == device_ordinals[r]
+                           else buf.copy_to_device(device_ordinals[r]))
+      else:
+        for r, buf in enumerate(arg.device_buffers):
+          buffers[r][a] = xla.device_put(x[assignments[r]], ordinals[r])
     else:
-      for r in range(nrep):
-        v = _slice(arg, assignments[r])
-        buffers[r][a] = xla.device_put(v, device_ordinals[r])
+      bufs = shard_arg_handlers[type(arg)](arg, device_ordinals, assignments)
+      for r, buf in enumerate(bufs):
+        buffers[r][a] = buf
   return buffers
+shard_arg_handlers = {}
+shard_arg_handlers[core.Unit] = \
+    lambda x, ordinals, _: [xla.device_put(core.unit, d) for d in ordinals]
+def _shard_array(x, ordinals, assignments):
+  nrep = len(ordinals)
+  return (xla.device_put(x[assignments[r]], ordinals[r]) for r in range(nrep))
+for _t in it.chain(array_types, [xla.DeviceArray]):
+  shard_arg_handlers[_t] = _shard_array
 
-def _slice(x, i):
-  """Return the ith slice of an array."""
-  return x[i]
+def shard_aval(size, aval):
+  try:
+    return shard_aval_handlers[type(aval)](size, aval)
+  except KeyError:
+    raise TypeError("No shard_aval handler for type: {}".format(type(aval)))
+shard_aval_handlers = {}
+shard_aval_handlers[core.AbstractUnit] = lambda size, x: x
+def _shard_abstract_array(size, x):
+  assert x.shape[0] == size
+  return ShapedArray(x.shape[1:], x.dtype)
+shard_aval_handlers[ShapedArray] = _shard_abstract_array
 
-def xla_shard(c, sizes, x):
-  def _xla_shard(shape, x):
-    if shape.is_tuple():
-      elts = map(_xla_shard, shape.tuple_shapes(), xla_destructure(c, x))
-      return c.Tuple(*elts)
-    else:
-      return shard_array(shape, x)
-
-  def shard_array(shape, x):
-    dims = list(shape.dimensions())
-    assert dims[0] == sizes[-1]
-    start_indices = _xla_shard_start_indices(c, dims[0], len(dims))
-    return c.Reshape(c.DynamicSlice(x, start_indices, [1] + dims[1:]),
-                     None, dims[1:])
-
-  return _xla_shard(c.GetShape(x), x)
-
-# TODO(b/110096942): more efficient gather
-def xla_unshard(c, replica_groups, x):
-  def _xla_unshard(shape, x):
-    if shape.is_tuple():
-      elts = map(_xla_unshard, shape.tuple_shapes(), xla_destructure(c, x))
-      return c.Tuple(*elts)
-    else:
-      return unshard_array(shape, x)
-
-  def unshard_array(shape, x):
-    axis_size = len(replica_groups[0])
-    dims = list(shape.dimensions())
-    start_indices = _xla_shard_start_indices(c, axis_size, len(dims) + 1)
-    padded = c.Broadcast(c.Constant(onp.array(0, shape.numpy_dtype())),
-                         [axis_size] + dims)
-    padded = c.DynamicUpdateSlice(padded, c.Reshape(x, None, [1] + dims),
-                                  start_indices)
-    return c.CrossReplicaSum(padded, replica_groups)
-
-  return _xla_unshard(c.GetShape(x), x)
-
-
-# TODO(mattjj): plumb more ergonimic form of DynamicSlice / DynamicUpdateSlice
-def _xla_shard_start_indices(c, axis_size, ndim):
-  idx = c.Rem(c.ReplicaId(), c.Constant(onp.array(axis_size, onp.uint32)))
-  zero = onp.zeros(ndim - 1, onp.uint32)
-  return c.Concatenate([c.Reshape(idx, None, [1]), c.Constant(zero)], 0)
-
-
-def sharded_result_handler(axis_size, aval):
-  full_aval = add_axis_to_aval(axis_size, aval)
-  if type(aval) is core.AbstractTuple:
-    return partial(sharded_tuple_result_handler, axis_size, full_aval)
-  elif isinstance(aval, ShapedArray):
-    return partial(sharded_array_result_handler, full_aval)
-  else:
-    raise TypeError(type(aval))
-
-def sharded_array_result_handler(aval, replica_results):
-  t, = set(map(type, replica_results))
-  if t is xla.DeviceArray:
-    bufs = [r.device_buffer for r in replica_results]
-    return ShardedDeviceArray(aval, bufs)
-  else:
-    assignments = assign_shards_to_replicas(len(replica_results), aval.shape[0])
-    _, ids = onp.unique(assignments, return_index=True)
-    return onp.stack([replica_results[i] for i in ids])
-
-def sharded_tuple_result_handler(axis_size, aval, replica_results):
-  t, = set(map(type, replica_results))
-  if t is xla.DeviceTuple:
-    bufs = [r.device_buffer for r in replica_results]
-    return ShardedDeviceTuple(axis_size, aval, bufs)
-  else:
-    raise TypeError(t)
-
-
-def add_axis_to_aval(n, aval):
-  if type(aval) is core.AbstractTuple:
-    return core.AbstractTuple(map(partial(add_axis_to_aval, n), aval))
-  elif isinstance(aval, ShapedArray):
-    return ShapedArray((n,) + aval.shape, aval.dtype)
-  else:
-    raise TypeError(type(aval))
-
-def remove_axis_from_aval(aval):
-  if type(aval) is core.AbstractTuple:
-    return core.AbstractTuple(map(remove_axis_from_aval, aval))
-  elif isinstance(aval, ShapedArray):
-    return ShapedArray(aval.shape[1:], aval.dtype)
-  else:
-    raise TypeError(aval)
+def aval_to_result_handler(size, nrep, aval):
+  try:
+    return pxla_result_handlers[type(aval)](size, nrep, aval)
+  except KeyError:
+    raise TypeError("No pxla_result_handler for type: {}".format(type(aval)))
+pxla_result_handlers = {}
+pxla_result_handlers[core.AbstractUnit] = lambda *_: lambda _: core.unit
+def array_result_handler(size, nrep, aval):
+  full_aval = ShapedArray((size,) + aval.shape, aval.dtype)
+  return partial(ShardedDeviceArray, full_aval)
+pxla_result_handlers[ShapedArray] = array_result_handler
+pxla_result_handlers[ConcreteArray] = array_result_handler
 
 
 def assign_shards_to_replicas(nrep, size):
@@ -229,12 +166,11 @@ def compile_replicated(jaxpr, axis_name, axis_size, consts, *abstract_args):
            "devices are available")
     raise ValueError(msg.format(num_replicas, xb.device_count()))
   axis_env = xla.AxisEnv(num_replicas, [axis_name], [axis_size])
-  arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = xla._jaxpr_computation(jaxpr, axis_env, consts, (), *arg_shapes)
-  result_shape = aval_from_xla_shape(built_c.GetReturnValueShape())
+  arg_shapes = list(map(aval_to_xla_shape, abstract_args))
+  built_c = xla.jaxpr_computation(jaxpr, axis_env, consts, (), *arg_shapes)
   compiled = built_c.Compile(arg_shapes, xb.get_compile_options(num_replicas),
                              backend=xb.get_backend())
-  return compiled, num_replicas, result_shape
+  return compiled, num_replicas
 
 
 ### applying parallel primitives in op-by-op Python dispatch
@@ -324,8 +260,10 @@ def _axis_index_partial_eval(trace, _, **params):
   # during pmap lowering. It is like the standard JaxprTrace.process_primitive
   # rule except that we don't attempt to lower out of the trace.
   out_aval = ShapedArray((), onp.uint32)
-  eqn = pe.JaxprEqn([], None, axis_index_p, (), False, False, params)
-  return pe.JaxprTracer(trace, pe.PartialVal((out_aval, core.unit)), eqn)
+  out_tracer = pe.JaxprTracer(trace, pe.PartialVal((out_aval, core.unit)), None)
+  eqn = core.new_jaxpr_eqn([], [out_tracer], axis_index_p, (), params)
+  out_tracer.recipe = eqn
+  return out_tracer
 
 axis_index_p = core.Primitive('axis_index')
 xla.translations[axis_index_p] = lambda c, hard_size, soft_size, axis_name: \
@@ -412,14 +350,22 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
     else:
       return super(ShardedDeviceArray, self).__getitem__(idx)
 
-core.pytype_aval_mappings[ShardedDeviceArray] = ConcreteArray
-xla.pytype_aval_mappings[ShardedDeviceArray] = lambda x: x.aval
-batching.pytype_aval_mappings[ShardedDeviceArray] = lambda x: x.aval
-xla.canonicalize_dtype_handlers[ShardedDeviceArray] = \
-    xla.canonicalize_dtype_handlers[xla.DeviceArray]
+# This handler code is effectively dead because we in-lined it in shard_args for
+# performance reasons.
+def _shard_sharded_device_array(x, ordinals, assignments):
+  n = len(ordinals)
+  if n == len(x.device_buffers):
+    return (b if b.device() == ordinals[r] else b.copy_to_device(ordinals[r])
+            for r, b in enumerate(x.device_buffers))
+  else:
+    return (xla.device_put(x[assignments[r]], ordinals[r]) for r in range(n))
+shard_arg_handlers[ShardedDeviceArray] = _shard_sharded_device_array
 
-xb.register_constant_handler(ShardedDeviceArray,
-                             xla._device_array_constant_handler)
+core.pytype_aval_mappings[ShardedDeviceArray] = ConcreteArray
+xla.device_put_handlers[ShardedDeviceArray] = xla._device_put_array
+xla.pytype_aval_mappings[ShardedDeviceArray] = lambda x: x.aval
+xla.canonicalize_dtype_handlers[ShardedDeviceArray] = identity
+xb.register_constant_handler(ShardedDeviceArray, xla._device_array_constant_handler)
 
 
 class ChunkedDeviceArray(ShardedDeviceArray):
@@ -433,14 +379,12 @@ class ChunkedDeviceArray(ShardedDeviceArray):
   def __getitem__(self, idx):
     return xla.DeviceArray.__getitem__(self, idx)
 
-core.pytype_aval_mappings[ChunkedDeviceArray] = ConcreteArray
-xla.pytype_aval_mappings[ChunkedDeviceArray] = \
-    xla.pytype_aval_mappings[xla.DeviceArray]
-batching.pytype_aval_mappings[ChunkedDeviceArray] = \
-    batching.pytype_aval_mappings[xla.DeviceArray]
-xla.canonicalize_dtype_handlers[ChunkedDeviceArray] = \
-    xla.canonicalize_dtype_handlers[xla.DeviceArray]
+shard_arg_handlers[ChunkedDeviceArray] = _shard_array
 
+core.pytype_aval_mappings[ChunkedDeviceArray] = ConcreteArray
+xla.device_put_handlers[ChunkedDeviceArray] = xla._device_put_array
+xla.pytype_aval_mappings[ChunkedDeviceArray] = lambda x: x.aval
+xla.canonicalize_dtype_handlers[ChunkedDeviceArray] = identity
 xb.register_constant_handler(ChunkedDeviceArray,
                              xla._device_array_constant_handler)
 
@@ -455,20 +399,11 @@ def xla_pmap_impl(fun, *args, **params):
   compiled_fun = parallel_callable(fun, axis_name, axis_size, *abstract_args)
   return compiled_fun(*args)
 
-def _shard_aval(axis_size, aval):
-  if type(aval) is core.AbstractTuple:
-    return core.AbstractTuple(map(partial(_shard_aval, axis_size), aval))
-  elif type(aval) is ShapedArray:
-    assert aval.shape[0] == axis_size
-    return ShapedArray(aval.shape[1:], aval.dtype)
-  else:
-    raise TypeError(aval)
-
 @lu.cache
 def parallel_callable(fun, axis_name, axis_size, *avals):
-  avals = tuple(_shard_aval(axis_size, a) for a in avals)
+  avals = tuple(map(partial(shard_aval, axis_size), avals))
   pvals = [PartialVal((aval, core.unit)) for aval in avals]
-  pval = PartialVal((core.AbstractTuple(()), core.unit))  # dummy value
+  pval = PartialVal([core.abstract_unit, core.unit])  # dummy value
 
   @lu.wrap_init
   def dynamic_fun(dummy, *args):
@@ -476,54 +411,59 @@ def parallel_callable(fun, axis_name, axis_size, *avals):
       return fun.call_wrapped(*args)
 
   with core.new_master(JaxprTrace, True) as master:
-    jaxpr, (out_pval, consts, env) = \
+    jaxpr, (out_pvals, consts, env) = \
         trace_to_subjaxpr(dynamic_fun, master, False).call_wrapped([pval] + pvals)
     jaxpr.invars = jaxpr.invars[1:]  # ignore dummy
     assert not env
     del master
-  out_pv, out_const = out_pval
-  if out_pv is None:
+  out_pvs, out_consts = unzip2(out_pvals)
+  if all(pv is None for pv in out_pvs):
     # When the output doesn't depend on the input we don't need to compile an
     # XLA computation at all; we handle this as a special case so we can stage
     # out multi-replica XLA computations regardless of the hardware available.
-    result_handler = sharded_result_handler(axis_size, xla.abstractify(out_const))
-    return lambda *args: result_handler([out_const] * axis_size)
+    # The 'None' values here are just dummies we know will be ignored.
+    handlers = [_pval_to_result_handler(axis_size, None, pval) for pval in out_pvals]
+    results = [handler(None) for handler in handlers]
+    return lambda *_: results
   else:
-    out = compile_replicated(jaxpr, axis_name, axis_size, consts, *avals)
-    compiled, nrep, shard_result_shape = out
+    compiled, nrep = compile_replicated(jaxpr, axis_name, axis_size, consts, *avals)
     device_ordinals = compiled.DeviceOrdinals()
     assignments = assign_shards_to_replicas(nrep, axis_size)
-    handle_args = partial(shard_args, device_ordinals, assignments, axis_size,
-                          nrep)
-    handle_replica_result = xla.result_handler(shard_result_shape)
-    handle_full_result = sharded_result_handler(axis_size, merged_aval(out_pval))
-    return partial(execute_replicated, compiled, out_pval, nrep,
-                   handle_args, handle_replica_result, handle_full_result)
+    handle_args = partial(shard_args, device_ordinals, assignments, axis_size)
+    handle_outs = _pvals_to_results_handler(axis_size, nrep, out_pvals)
+    return partial(execute_replicated, compiled, nrep, handle_args, handle_outs)
 
-def merged_aval(pval):
+def _pvals_to_results_handler(size, nrep, out_pvals):
+  nouts = len(out_pvals)
+  handlers = [_pval_to_result_handler(size, nrep, pval) for pval in out_pvals]
+  def handler(out_bufs):
+    buffers = [[None] * nrep for _ in range(nouts)]
+    for r, tuple_buf in enumerate(out_bufs):
+      for i, buf in enumerate(tuple_buf.destructure()):
+        buffers[i][r] = buf
+    return [h(bufs) for h, bufs in zip(handlers, buffers)]
+  return handler
+
+def _pval_to_result_handler(size, nrep, pval):
   pv, const = pval
-  if isinstance(pv, core.AbstractValue):
-    return pv
-  elif isinstance(pv, pe.JaxprTracerTuple):
-    return core.AbstractTuple(map(merged_aval, zip(pv, const)))
-  elif pv is None:
-    return xla.abstractify(const)
+  if pv is None:
+    bcast_const = core.unit if const is core.unit else broadcast(const, size, 0)
+    return lambda _: bcast_const
   else:
-    raise TypeError(type(pv))
+    return aval_to_result_handler(size, nrep, pv)
 
-def execute_replicated(compiled, pval, nrep, handle_in,
-                       handle_replica_result, handle_full_result, *args):
+def execute_replicated(compiled, nrep, in_handler, out_handler, *args):
   if nrep > xb.device_count():
     msg = ("executing pmap computation that requires {} replicas, but only {} "
            "XLA devices are available")
     raise ValueError(msg.format(nrep, xb.device_count()))
-  input_bufs = handle_in(args)
+  input_bufs = in_handler(args)
   out_bufs = compiled.ExecutePerReplica(list(input_bufs))
-  results = [merge_pvals(handle_replica_result(buf), pval) for buf in out_bufs]
-  return handle_full_result(results)
+  return out_handler(out_bufs)
 
 
 xla_pmap_p = core.Primitive('xla_pmap')
+xla_pmap_p.multiple_results = True
 xla_pmap = partial(core.call_bind, xla_pmap_p)
 xla_pmap_p.def_custom_bind(xla_pmap)
 xla_pmap_p.def_impl(xla_pmap_impl)
@@ -531,15 +471,52 @@ xla_pmap_p.def_impl(xla_pmap_impl)
 def _xla_pmap_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
                                axis_name, axis_size):
   new_env = xla.extend_axis_env(axis_env, axis_name, axis_size)
-  in_nodes_sharded = list(map(partial(xla_shard, c, new_env.sizes), in_nodes))
-  subc = xla._jaxpr_computation(jaxpr, new_env, (),
-                                tuple(map(c.GetShape, env_nodes)),
-                                *map(c.GetShape, in_nodes_sharded))
+  in_nodes_sharded = list(map(partial(_xla_shard, c, new_env.sizes), in_nodes))
+  subc = xla.jaxpr_computation(jaxpr, new_env, (),
+                               tuple(map(c.GetShape, env_nodes)),
+                               *map(c.GetShape, in_nodes_sharded))
   sharded_result = c.Call(subc, env_nodes + in_nodes_sharded)
-  return xla_unshard(c, xla.axis_groups(new_env, axis_name), sharded_result)
+  sharded_results = xla.xla_destructure(c, sharded_result)
+  unsharded_results = [_xla_unshard(c, xla.axis_groups(new_env, axis_name), r)
+                       for r in sharded_results]
+  return c.Tuple(*unsharded_results)
 xla.call_translations[xla_pmap_p] = _xla_pmap_translation_rule
 ad.primitive_transposes[xla_pmap_p] = partial(ad.map_transpose, xla_pmap_p)
 pe.map_primitives.add(xla_pmap_p)
+
+def _xla_shard(c, sizes, x):
+  xla_shape = c.GetShape(x)
+  if xla_shape.is_tuple():
+    assert not xla_shape.tuple_shapes()
+    return x
+  else:
+    dims = list(xla_shape.dimensions())
+    assert dims[0] == sizes[-1]
+    start_indices = _xla_shard_start_indices(c, dims[0], len(dims))
+    return c.Reshape(c.DynamicSlice(x, start_indices, [1] + dims[1:]),
+                    None, dims[1:])
+
+# TODO(b/110096942): more efficient gather
+def _xla_unshard(c, replica_groups, x):
+  xla_shape = c.GetShape(x)
+  if xla_shape.is_tuple():
+    assert not xla_shape.tuple_shapes()
+    return x
+  else:
+    axis_size = len(replica_groups[0])
+    dims = list(xla_shape.dimensions())
+    start_indices = _xla_shard_start_indices(c, axis_size, len(dims) + 1)
+    padded = c.Broadcast(c.Constant(onp.array(0, xla_shape.numpy_dtype())),
+                        [axis_size] + dims)
+    padded = c.DynamicUpdateSlice(padded, c.Reshape(x, None, [1] + dims),
+                                  start_indices)
+    return c.CrossReplicaSum(padded, replica_groups)
+
+# TODO(mattjj): use more ergonimic form of DynamicUpdateSlice instead!
+def _xla_shard_start_indices(c, axis_size, ndim):
+  idx = c.Rem(c.ReplicaId(), c.Constant(onp.array(axis_size, onp.uint32)))
+  zero = onp.zeros(ndim - 1, onp.uint32)
+  return c.Concatenate([c.Reshape(idx, None, [1]), c.Constant(zero)], 0)
 
 
 ### soft_pmap axis split transformation
@@ -558,28 +535,23 @@ pe.map_primitives.add(xla_pmap_p)
 def split_axis(axis_name, chunk_size, *args):
   with core.new_master(SplitAxisTrace) as master:
     trace = SplitAxisTrace(master, core.cur_sublevel())
-    in_tracers = map(partial(SplitAxisTracer, trace, axis_name), args)
+    in_tracers = list(map(partial(SplitAxisTracer, trace, axis_name), args))
     with add_chunk_to_axis_env(axis_name, trace, chunk_size):
-      ans = yield in_tracers, {}
-    out_tracer = trace.full_raise(ans)
-    out_val, out_axis = out_tracer.val, out_tracer.axis_name
-    del master, out_tracer
-  if out_axis is not_mapped:
-    out_val = batching.broadcast2(chunk_size, 0, out_val)
-  yield out_val
+      outs = yield in_tracers, {}
+    out_tracers = list(map(trace.full_raise, outs))
+    out_vals, out_names = unzip2((t.val, t.axis_name) for t in out_tracers)
+    del master, out_tracers
+  out_vals = [broadcast(x, chunk_size, 0) if d is not_mapped else x
+              for x, d in zip(out_vals, out_names)]
+  yield out_vals
 
 @lu.transformation_with_aux
 def split_axis_subtrace(master, names, *vals):
   trace = SplitAxisTrace(master, core.cur_sublevel())
-  ans = yield map(partial(SplitAxisTracer, trace), names, vals), {}
-  out_tracer = trace.full_raise(ans)
-  out_val, out_name = out_tracer.val, out_tracer.axis_name
-  yield out_val, out_name
-
-class NotMapped(object): pass
-not_mapped = NotMapped
-
-class SplitAxisTuple(tuple): pass
+  outs = yield list(map(partial(SplitAxisTracer, trace), names, vals)), {}
+  out_tracers = list(map(trace.full_raise, outs))
+  out_vals, out_names = unzip2((t.val, t.axis_name) for t in out_tracers)
+  yield out_vals, out_names
 
 @contextmanager
 def add_chunk_to_axis_env(axis_name, soft_trace, soft_size):
@@ -598,21 +570,11 @@ class SplitAxisTracer(core.Tracer):
 
   @property
   def aval(self):
-    aval = batching.get_aval(self.val)
+    aval = raise_to_shaped(core.get_aval(self.val))
     if self.axis_name is not_mapped:
       return aval
     else:
-      return batching.remove_batch_dim_from_aval(0, aval)
-
-  def unpack(self):
-    if self.name is not_mapped:
-      return tuple(self.val)
-    else:
-      if type(self.name) is SplitAxisTuple:
-        names = list(self.name)
-      else:
-        names = [self.name] * len(self.val)
-      return map(partial(SplitAxisTracer, self.trace), names, self.val)
+      return ShapedArray(aval.shape[1:], aval.dtype)
 
   def full_lower(self):
     if self.axis_name is not_mapped:
@@ -661,15 +623,20 @@ class SplitAxisTrace(core.Trace):
       else:
         # if it's not a pmap collective primitive, act just like batching
         rule = batching.get_primitive_batcher(primitive)
-        axes_in = [None if n is not_mapped else 0 for n in names_in]
+        axes_in = [n if n is not_mapped else 0 for n in names_in]
         val_out, axis_out = rule(vals_in, axes_in, **params)
-        if axis_out is None:
-          return SplitAxisTracer(self, not_mapped, val_out)
+        def new_tracer(x, a):
+          if a is not_mapped:
+            return SplitAxisTracer(self, not_mapped, x)
+          else:
+            return SplitAxisTracer(self, name, batching.moveaxis(x, a, 0))
+        if primitive.multiple_results:
+          return [new_tracer(x, a) for x, a in zip(val_out, axis_out)]
         else:
-          val_out = batching.moveaxis2(axis_out, 0, val_out)
-          return SplitAxisTracer(self, name, val_out)
+          return new_tracer(val_out, axis_out)
 
   def process_call(self, call_primitive, f, tracers, params):
+    assert call_primitive.multiple_results
     if call_primitive in pe.map_primitives:
       return self.process_map(call_primitive, f, tracers, params)
     else:
@@ -677,9 +644,9 @@ class SplitAxisTrace(core.Trace):
       if all(name is not_mapped for name in names):
         return call_primitive.bind(f, *vals, **params)
       else:
-        f, name_out = split_axis_subtrace(f, self.master, names)
-        val_out = call_primitive.bind(f, *vals, **params)
-        return SplitAxisTracer(self, name_out(), val_out)
+        f, names_out = split_axis_subtrace(f, self.master, names)
+        vals_out = call_primitive.bind(f, *vals, **params)
+        return [SplitAxisTracer(self, a, x) for a, x in zip(names_out(), vals_out)]
 
   def process_map(self, map_primitive, f, tracers, params):
     vals, names = unzip2((t.val, t.axis_name) for t in tracers)
@@ -689,11 +656,13 @@ class SplitAxisTrace(core.Trace):
       # because the map primitive maps over leading axes, we need to transpose
       # the software-mapped axis on any mapped arguments to be the second axis;
       # then we call the map primitive and resume the trace under the call
-      vals_transposed = map(partial(transpose_mapped, 0, 1), names, vals)
-      f, name_out = split_axis_subtrace(f, self.master, names)
-      val_out_transposed = map_primitive.bind(f, *vals_transposed, **params)
-      val_out = transpose_mapped(1, 0, name_out(), val_out_transposed)
-      return SplitAxisTracer(self, name_out(), val_out)
+      vals_trans = [batching.moveaxis(x, 0, 1) if d is not not_mapped else x
+                    for x, d in zip(vals, names)]
+      f, names_out = split_axis_subtrace(f, self.master, names)
+      vals_out_trans = map_primitive.bind(f, *vals_trans, **params)
+      vals_out = [batching.moveaxis(x, 1, 0) if d is not not_mapped else x
+                  for x, d in zip(vals_out_trans, names_out())]
+      return [SplitAxisTracer(self, a, x) for a, x in zip(names_out(), vals_out)]
 
   def post_process_call(self, call_primitive, out_tracer, params):
     val, name = out_tracer.val, out_tracer.axis_name
@@ -702,20 +671,6 @@ class SplitAxisTrace(core.Trace):
       trace = SplitAxisTrace(master, core.cur_sublevel())
       return  SplitAxisTracer(trace, name, x)
     return  val, todo
-
-  def pack(self, tracers):
-    vals, names = unzip2((t.val, t.axis_name) for t in tracers)
-    return SplitAxisTracer(self, SplitAxisTuple(names), core.pack(vals))
-
-def transpose_mapped(src, dst, name, x):
-  def transpose(name, x):
-    if type(name) is SplitAxisTuple:
-      return core.pack(map(transpose, name, x))
-    elif name is not_mapped:
-      return x
-    else:
-      return batching.moveaxis2(src,  dst, x)
-  return transpose(name, x)
 
 
 split_axis_rules = {}

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -33,12 +33,14 @@ from .. import tree_util
 from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, make_shaped_array,
                                array_types)
-from ..core import AbstractTuple, JaxTuple, pack, valid_jaxtype, Literal
+from ..core import valid_jaxtype, Literal
 from ..util import partial, partialmethod, cache, concatenate, safe_map, prod
 from ..lib import xla_bridge as xb
 from ..lib import xla_client
 from . import partial_eval as pe
 from . import ad
+
+map = safe_map  # TODO: remove
 
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_debug_nans',
@@ -62,13 +64,12 @@ def _xla_primitive_callable(prim, *abstract_args, **params):
   return partial(_execute_compiled_primitive, prim.name, compiled, handle_result)
 
 def xla_shape(x):
+  if x is core.abstract_unit:
+    return xb.Shape.tuple_shape(())
   try:
     return xla_client.Shape.array_shape(x.dtype, x.shape)
   except AttributeError:
-    if type(x) in (core.AbstractTuple, core.JaxTuple):
-      return xla_client.Shape.tuple_shape(tuple(map(xla_shape, x)))
-    else:
-      raise TypeError(type(x))
+    raise TypeError(type(x))
 
 @cache()
 def primitive_computation(prim, *shapes, **params):
@@ -96,7 +97,8 @@ def primitive_computation(prim, *shapes, **params):
 
 def aval_from_xla_shape(shape):
   if shape.is_tuple():
-    return AbstractTuple(map(aval_from_xla_shape, shape.tuple_shapes()))
+    assert len(shape.tuple_shapes()) == 0
+    return core.abstract_unit
   else:
     return ShapedArray(shape.dimensions(), shape.element_type())
 
@@ -128,15 +130,14 @@ def device_put(x, device_num=0):
     1. the array-like types DeviceArray (which is already backed by device
     memory, though may be on the wrong device) and its subclass DeviceConstant
     (which represents a lazy value to be instantiated), and
-    2. the tuple-like types DeviceTuple (which is already backed by device
-    memory, though may be on the wrong device) and JaxTuple (which may have some
-    elements that are backed by device memory on the correct device).
+    2. the tuple-like type DeviceTuple (which is already backed by device
+    memory, though may be on the wrong device).
   In particular, this function avoids transferring data already placed on the
   correct device, and handles instantiating DeviceConstants.
 
   Args:
     x: a tuplelike-tree with arraylike leaves representing the value to be
-      transferred to the device, where tuplelike means a JaxTuple or
+      transferred to the device, where tuplelike means a
       DeviceTuple, and arraylike includes DeviceArray, DeviceConstant, and
       anything that has an '__array__' attr.
     device_num: an int representing the target physical device number.
@@ -146,7 +147,7 @@ def device_put(x, device_num=0):
   """
   x = _canonicalize_pyval_dtype(x)
   t = type(x)
-  if t is DeviceArray or t is DeviceTuple:
+  if t is DeviceArray:
     if x.device_buffer.device() == device_num:
       return x.device_buffer
     else:
@@ -154,11 +155,9 @@ def device_put(x, device_num=0):
   elif isinstance(x, DeviceConstant):
     return _instantiate_device_constant(x, device_num=device_num)
   elif isinstance(x, (DeviceArray, onp.ndarray)):
-    return xla_client.Buffer.from_pyval(x, device_num, backend=xb.get_backend())
-  elif isinstance(x, JaxTuple):
-    element_bufs = tuple(map(partial(device_put, device_num=device_num), x))
-    return xla_client.Buffer.make_tuple(element_bufs, device=device_num,
-                                        backend=xb.get_backend())
+    return xb.device_put(x, device_num)  # handle arraylikes
+  elif isinstance(x, (core.Unit)):
+    return xb.device_put((), device_num)
   else:
     raise TypeError(t)
 
@@ -166,7 +165,7 @@ def device_put(x, device_num=0):
 # When we execute an XLA computation, we get a raw device buffer back and need
 # to package it into a suitable Python object to return to the user. To avoid
 # unnecessary device-to-host transfers, we typically return a DeviceValue that
-# acts just like a familiar Python type (e.g. an ndarray or JaxTuple) but is
+# acts just like a familiar Python type (e.g. an ndarray) but is
 # lazy in that it only copies data back to the host as required. Since the same
 # DeviceValue type is formed on every execution of a compiled computation, at
 # compile time we set up result handler functions and thus avoid redoing some of
@@ -194,11 +193,12 @@ def _compile_jaxpr(jaxpr, device_assignment, axis_env, const_vals, *abstract_arg
     raise ValueError(msg.format(axis_env.nreps, xb.device_count()))
   arg_shapes = list(map(xla_shape, abstract_args))
   built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
-  result_shape = aval_from_xla_shape(built_c.GetReturnValueShape())
+  result_tuple = built_c.GetReturnValueShape()
+  result_shapes = tuple(map(xla_shape_to_result_shape, result_tuple.tuple_shapes()))
   compile_opts = xb.get_compile_options(num_replicas=axis_env.nreps,
                                         device_assignment=device_assignment)
   compiled_c = built_c.Compile(arg_shapes, compile_opts, backend=xb.get_backend())
-  return compiled_c, result_shape
+  return compiled_c, result_shapes
 
 def build_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
   arg_shapes = list(map(xla_shape, abstract_args))
@@ -250,12 +250,7 @@ def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
   _map(write, jaxpr.invars, map(c.ParameterWithShape, arg_shapes))
   _prefetch_jaxpr_literals(jaxpr)
   for eqn in jaxpr.eqns:
-    if not eqn.restructure:
-      in_nodes = list(map(read, eqn.invars))
-    else:
-      in_nodes = [xla_pack(c, map(read, invars)) if type(invars) is tuple
-                  else read(invars) for invars in eqn.invars]
-
+    in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
       rule = backend_specific_translations[platform][eqn.primitive]
       ans = rule(c, *in_nodes, **eqn.params)
@@ -279,9 +274,9 @@ def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
       raise NotImplementedError(msg.format(eqn.primitive.name))
 
     c.GetShape(ans)  # force xla to do shape error checking
-    out_nodes = xla_destructure(c, ans) if eqn.destructure else [ans]
+    out_nodes = xla_destructure(c, ans) if len(eqn.outvars) != 1 else [ans]
     _map(write, eqn.outvars, out_nodes)
-  return c.Build(read(jaxpr.outvar))
+  return c.Build(c.Tuple(*map(read, jaxpr.outvars)))
 
 def _map(f, *xs):
   return tuple(map(f, *xs))
@@ -292,10 +287,6 @@ def xla_destructure(c, ans):
 
 def xla_pack(c, xs):
   return c.Tuple(*xs)
-
-def _tuple_constant(c, val, canonicalize_types=True):
-  return c.Tuple(*map(c.Constant, val))
-xb.register_constant_handler(JaxTuple, _tuple_constant)
 
 AxisEnv = namedtuple("AxisEnv", ["nreps", "names", "sizes"])
 
@@ -365,7 +356,6 @@ initial_style_translations = {}
 call_translations = {}
 backend_specific_translations = defaultdict(dict)
 
-translations[core.pack_p] = lambda c, *xs: c.Tuple(*xs)
 translations[core.call_p] = lambda c, subc_a1, *a2: c.Call(subc_a1[0],
                                                            subc_a1[1] + a2)
 translations[core.identity_p] = lambda c, x: x
@@ -401,15 +391,13 @@ def _canonicalize_pyval_dtype(x):
 
 canonicalize_dtype_handlers = {}
 
-def _canonicalize_tuple_dtype(tup):
-  return JaxTuple(map(_canonicalize_pyval_dtype, tup))
-canonicalize_dtype_handlers[JaxTuple] = _canonicalize_tuple_dtype
-
 def _canonicalize_ndarray_dtype(x):
   return onp.asarray(x, xb.canonicalize_dtype(onp.result_type(x)))
 
 for _t in array_types:
   canonicalize_dtype_handlers[_t] = _canonicalize_ndarray_dtype
+
+canonicalize_dtype_handlers[core.Unit] = lambda x: x
 
 def _identity(x): return x
 
@@ -423,14 +411,9 @@ def abstractify(x):
 
 pytype_aval_mappings = {}
 
-def _abstractify_tuple(tup):
-  return AbstractTuple(map(abstractify, tup))
-pytype_aval_mappings[JaxTuple] = _abstractify_tuple
-pytype_aval_mappings[AbstractTuple] = _abstractify_tuple
-
 for _t in array_types:
   pytype_aval_mappings[_t] = make_shaped_array
-
+pytype_aval_mappings[core.Unit] = lambda _: core.abstract_unit
 
 class DeviceValue(object):
   """A DeviceValue represents a value backed by device memory."""
@@ -453,45 +436,6 @@ class DeviceValue(object):
     """
     self._check_if_deleted()
     self.device_buffer.block_host_until_ready()
-
-
-class DeviceTuple(DeviceValue):
-  """A DeviceTuple is a JaxTuple backed by a single device memory buffer."""
-  __slots__ = []
-
-  def __init__(self, aval, device_buffer):
-    self.aval = aval
-    self.device_buffer = device_buffer
-
-  def __iter__(self):
-    bufs = self.device_buffer.destructure()
-    handlers = map(result_handler, self.aval)
-    elts = [handler(buf) for handler, buf in zip(handlers, bufs)]
-    return iter(elts)
-
-  def __len__(self):
-    return len(self.aval)
-
-  def __repr__(self):
-    return 'DeviceTuple(len={length})'.format(length=len(self))
-
-  def __eq__(self, other):
-    return tuple(self) == tuple(other)
-
-
-# DeviceValues don't need to be dtype-canonicalized because we assume values on
-# the device have already been canonicalized.
-core.pytype_aval_mappings[DeviceTuple] = core.pytype_aval_mappings[JaxTuple]
-pytype_aval_mappings[DeviceTuple] = op.attrgetter('aval')
-canonicalize_dtype_handlers[DeviceTuple] = _identity
-
-def _device_tuple_constant_handler(c, val, canonicalize_types=True):
-  const = partial(c.Constant, canonicalize_types=canonicalize_types)
-  return c.Tuple(*map(const, val))
-xb.register_constant_handler(DeviceTuple, _device_tuple_constant_handler)
-
-# TODO(mattjj): could jit-compile a computation here
-ad_util.jaxval_adders[DeviceTuple] = ad_util.add_jaxtuples
 
 
 def _forward_method(attrname, self, fun, *args):
@@ -676,26 +620,38 @@ def _xla_call_impl(fun, *args, **params):
 def _xla_callable(fun, device_assignment, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
-    jaxpr, (pval, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
+    jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here (though cond might eventually need them)
     axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
-    compiled, result_shape = _compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
-                                            *abstract_args)
+    compiled, result_shapes = _compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
+                                             *abstract_args)
+    print(jaxpr)
     del master, consts, jaxpr, env
   handle_result = result_handler(result_shape)
   if axis_env.nreps == 1:
-    return partial(_execute_compiled, compiled, pval, handle_result)
+    return partial(_execute_compiled, compiled, pvals, handle_result)
   else:
-    return partial(_execute_replicated, compiled, pval, handle_result)
+    assert False, "update it"
+    return partial(_execute_replicated, compiled, pvals, handle_result)
 
-def _execute_compiled(compiled, pval, handle_result, *args):
+def _execute_compiled(compiled, pvals, handlers, *args):
   device_num, = compiled.DeviceOrdinals()
   input_bufs = [device_put(x, device_num) for x in args]
-  out_buf = compiled.Execute(input_bufs)
-  check_nans("jit-compiled computation", out_buf)
-  return pe.merge_pvals(handle_result(out_buf), pval)
+  out_bufs = compiled.Execute(input_bufs).destructure()
+  [check_nans("jit-compiled computation", out_buf) for out_buf in out_bufs]
+
+  # TODO: remove
+  pvals = tuple(pvals)
+  handlers = tuple(handlers)
+  out_bufs = tuple(out_bufs)
+  assert len(pvals) == len(handlers), (len(pvals), len(handlers))
+  assert len(pvals) == len(out_bufs)
+
+  return [pe.merge_pvals(handler(out_buf), pval)
+          for handler, out_buf, pval in zip(handlers, out_bufs, pvals)]
 
 def _execute_replicated(compiled, pval, handle_result, *args):
+  raise NotImplementedError
   input_bufs = [[device_put(x, i) for x in args] for i in compiled.DeviceOrdinals()]
   out_buf = compiled.ExecutePerReplica(input_bufs)[0]
   check_nans("jit-compiled computation", out_buf)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -34,49 +34,111 @@ from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, make_shaped_array,
                                array_types)
 from ..core import valid_jaxtype, Literal
-from ..util import partial, partialmethod, cache, concatenate, safe_map, prod
+from ..util import partial, partialmethod, cache, safe_map, prod, unzip2
 from ..lib import xla_bridge as xb
-from ..lib import xla_client
+from ..lib import xla_client as xc
 from . import partial_eval as pe
 from . import ad
-
-map = safe_map  # TODO: remove
 
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_debug_nans',
                   strtobool(os.getenv('JAX_DEBUG_NANS', "False")),
                   'Add nan checks to every operation.')
 
+def _map(f, *xs): return tuple(map(f, *xs))
+def identity(x): return x
+
+
+### handlers
+
+xb.register_constant_handler(core.Unit, lambda c, *_: c.Tuple())
+
+def aval_to_xla_shape(aval):
+  try:
+    return xla_shape_handlers[type(aval)](aval)
+  except KeyError:
+    raise TypeError("No xla_shape_handler for type: {}".format(type(aval)))
+xla_shape_handlers = {}
+xla_shape_handlers[core.AbstractUnit] = lambda _: xc.Shape.tuple_shape(())
+xla_shape_handlers[ShapedArray] = lambda a: xc.Shape.array_shape(a.dtype, a.shape)
+xla_shape_handlers[ConcreteArray] = lambda a: xc.Shape.array_shape(a.dtype, a.shape)
+
+def aval_to_result_handler(aval):
+  try:
+    return xla_result_handlers[type(aval)](aval)
+  except KeyError:
+    raise TypeError("No xla_result_handler for type: {}".format(type(aval)))
+xla_result_handlers = {}
+xla_result_handlers[core.AbstractUnit] = lambda _: lambda _: core.unit
+def array_result_handler(aval): return partial(DeviceArray, aval)
+xla_result_handlers[ShapedArray] = array_result_handler
+xla_result_handlers[ConcreteArray] = array_result_handler
+
+def device_put(x, device_num=0):
+  x = canonicalize_dtype(x)
+  try:
+    return device_put_handlers[type(x)](x, device_num)
+  except KeyError:
+    raise TypeError("No device_put handler for type: {}".format(type(x)))
+device_put_handlers = {}
+device_put_handlers[core.Unit] = \
+    lambda _, n: xc.Buffer.from_pyval((), n, backend=xb.get_backend())
+def _device_put_array(x, n):
+  return xc.Buffer.from_pyval(x, n, backend=xb.get_backend())
+for _t in array_types:
+  device_put_handlers[_t] = _device_put_array
+
+# TODO(mattjj): try to remove this canonicalize_dtype stuff
+def canonicalize_dtype(x):
+  try:
+    return canonicalize_dtype_handlers[type(x)](x)
+  except KeyError:
+    raise TypeError("No canonicalize_dtype handler for type: {}".format(type(x)))
+canonicalize_dtype_handlers = {}
+canonicalize_dtype_handlers[core.Unit] = identity
+def _canonicalize_ndarray_dtype(x):
+  return onp.asarray(x, xb.canonicalize_dtype(onp.result_type(x)))
+for _t in array_types:
+  canonicalize_dtype_handlers[_t] = _canonicalize_ndarray_dtype
+
+def abstractify(x):
+  try:
+    return pytype_aval_mappings[type(x)](x)
+  except KeyError:
+    raise TypeError("No abstraction handler for type: {}".format(type(x)))
+pytype_aval_mappings = {}
+pytype_aval_mappings[core.Unit] = lambda _: core.abstract_unit
+for _t in array_types:
+  pytype_aval_mappings[_t] = make_shaped_array
+
+
+### op-by-op execution
+
 def apply_primitive(prim, *args, **params):
   """Impl rule that compiles and runs a single primitive 'prim' using XLA."""
   abstract_args = map(abstractify, args)
-  compiled_fun = _xla_primitive_callable(prim, *abstract_args, **params)
+  compiled_fun = xla_primitive_callable(prim, *abstract_args, **params)
   return compiled_fun(*args)
 
 @cache()
-def _xla_primitive_callable(prim, *abstract_args, **params):
-  shapes = tuple(map(xla_shape, abstract_args))
-  built_c = primitive_computation(prim, *shapes, **params)
-  result_shape = aval_from_xla_shape(built_c.GetReturnValueShape())
-  handle_result = result_handler(result_shape)
-  compiled = built_c.Compile(shapes, xb.get_compile_options(),
+def xla_primitive_callable(prim, *abstract_args, **params):
+  aval_out = prim.abstract_eval(*abstract_args, **params)
+  if prim.multiple_results:
+    handlers = tuple(map(aval_to_result_handler, aval_out))
+    handle_result = lambda xs: tuple(h(x) for h, x in zip(handlers, xs.destructure()))
+  else:
+    handle_result = aval_to_result_handler(aval_out)
+  xla_shapes = tuple(map(aval_to_xla_shape, abstract_args))
+  built_c = primitive_computation(prim, *xla_shapes, **params)
+  compiled = built_c.Compile(xla_shapes, xb.get_compile_options(),
                              backend=xb.get_backend())
-  return partial(_execute_compiled_primitive, prim.name, compiled, handle_result)
-
-def xla_shape(x):
-  if x is core.abstract_unit:
-    return xb.Shape.tuple_shape(())
-  try:
-    return xla_client.Shape.array_shape(x.dtype, x.shape)
-  except AttributeError:
-    raise TypeError(type(x))
+  return partial(_execute_compiled_primitive, prim, compiled, handle_result)
 
 @cache()
-def primitive_computation(prim, *shapes, **params):
-  """Builds an XLA computation for `prim` with argument `shapes`."""
+def primitive_computation(prim, *xla_shapes, **params):
   c = xb.make_computation_builder("primitive_computation")
   platform = xb.get_backend().platform
-  xla_args = map(c.ParameterWithShape, shapes)
+  xla_args = map(c.ParameterWithShape, xla_shapes)
   if prim in backend_specific_translations[platform]:
     rule = backend_specific_translations[platform][prim]
     rule(c, *xla_args, **params)  # return val set as a side-effect on c
@@ -95,140 +157,83 @@ def primitive_computation(prim, *shapes, **params):
     prim.abstract_eval(*map(aval_from_xla_shape, shapes), **params)
     raise e
 
-def aval_from_xla_shape(shape):
-  if shape.is_tuple():
-    assert len(shape.tuple_shapes()) == 0
-    return core.abstract_unit
-  else:
-    return ShapedArray(shape.dimensions(), shape.element_type())
-
-def _execute_compiled_primitive(name, compiled, result_handler, *args):
+def _execute_compiled_primitive(prim, compiled, result_handler, *args):
   device_num, = compiled.DeviceOrdinals()
   input_bufs = [device_put(x, device_num) for x in args]
   out_buf = compiled.Execute(input_bufs)
-  check_nans(name, out_buf)
+  if FLAGS.jax_debug_nans: check_nans(prim, out_buf)
   return result_handler(out_buf)
 
-def check_nans(name, buf):
-  FLAGS.jax_debug_nans and _check_nans(name, buf.shape(), buf)
+def check_nans(prim, buf):
+  if prim.multiple_results:
+    shapes = buf.shape().tuple_shapes()
+    _map(partial(_check_nans, prim.name), shapes, buf.destructure())
+  else:
+    _check_nans(prim.name, buf.shape(), buf)
 
 def _check_nans(name, xla_shape, buf):
   if xla_shape.is_tuple():
-    _map(partial(_check_nans, name), xla_shape.tuple_shapes(), buf.destructure())
+    assert not xla_shape.tuple_shapes()
   else:
     if onp.issubdtype(xla_shape.element_type(), onp.floating):
-      pyval = buf.to_py()
-      if onp.any(onp.isnan(pyval)):
+      if onp.any(onp.isnan(buf.to_py())):
         msg = "invalid value (nan) encountered in {}"
         raise FloatingPointError(msg.format(name))
 
-def device_put(x, device_num=0):
-  """Place a Python value `x` on device number `device_num`.
 
-  This is a wrapper around xla_client.Buffer.from_pyval to handle
-  additional Python types, namely
-    1. the array-like types DeviceArray (which is already backed by device
-    memory, though may be on the wrong device) and its subclass DeviceConstant
-    (which represents a lazy value to be instantiated), and
-    2. the tuple-like type DeviceTuple (which is already backed by device
-    memory, though may be on the wrong device).
-  In particular, this function avoids transferring data already placed on the
-  correct device, and handles instantiating DeviceConstants.
+### compiling jaxprs
 
-  Args:
-    x: a tuplelike-tree with arraylike leaves representing the value to be
-      transferred to the device, where tuplelike means a
-      DeviceTuple, and arraylike includes DeviceArray, DeviceConstant, and
-      anything that has an '__array__' attr.
-    device_num: an int representing the target physical device number.
-
-  Returns:
-    A buffer representing the input `x` placed on the appropriate device.
-  """
-  x = _canonicalize_pyval_dtype(x)
-  t = type(x)
-  if t is DeviceArray:
-    if x.device_buffer.device() == device_num:
-      return x.device_buffer
-    else:
-      return x.device_buffer.copy_to_device(device_num)
-  elif isinstance(x, DeviceConstant):
-    return _instantiate_device_constant(x, device_num=device_num)
-  elif isinstance(x, (DeviceArray, onp.ndarray)):
-    return xb.device_put(x, device_num)  # handle arraylikes
-  elif isinstance(x, (core.Unit)):
-    return xb.device_put((), device_num)
-  else:
-    raise TypeError(t)
-
-
-# When we execute an XLA computation, we get a raw device buffer back and need
-# to package it into a suitable Python object to return to the user. To avoid
-# unnecessary device-to-host transfers, we typically return a DeviceValue that
-# acts just like a familiar Python type (e.g. an ndarray) but is
-# lazy in that it only copies data back to the host as required. Since the same
-# DeviceValue type is formed on every execution of a compiled computation, at
-# compile time we set up result handler functions and thus avoid redoing some of
-# the Python bookkeeping work on every execution. Since XLA shapes are slower to
-# manipulate than simple Python builtins, we store the metadata required for
-# forming the DeviceValue result in special _ResultArray / _ResultTuple classes.
-
-# Every JaxType needs to map to an XLA type. However this function's design is
-# based on the assumption that XLA types can be mapped uniquely back to a
-# JaxType, i.e. that the mapping is bijective. That assumption could be relaxed,
-# but it would mean we need to do a bit more bookkeping on the Python side to
-# track abstract values of outputs.
-
-def result_handler(aval):
-  if isinstance(aval, core.AbstractTuple):
-    return partial(DeviceTuple, aval)
-  else:
-    return partial(DeviceArray, aval)
-
-
-def _compile_jaxpr(jaxpr, device_assignment, axis_env, const_vals, *abstract_args):
+def compile_jaxpr(jaxpr, device_assignment, axis_env, const_vals, *abstract_args):
   if axis_env.nreps > xb.device_count():
     msg = ("compiling computation that requires {} replicas, but only {} XLA "
            "devices are available")
-    raise ValueError(msg.format(axis_env.nreps, xb.device_count()))
-  arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
-  result_tuple = built_c.GetReturnValueShape()
-  result_shapes = tuple(map(xla_shape_to_result_shape, result_tuple.tuple_shapes()))
+    raise ValueErrr(msg.format(axis_env.nreps, xb.device_count()))
+  arg_shapes = tuple(map(aval_to_xla_shape, abstract_args))
+  built_c = jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
   compile_opts = xb.get_compile_options(num_replicas=axis_env.nreps,
                                         device_assignment=device_assignment)
-  compiled_c = built_c.Compile(arg_shapes, compile_opts, backend=xb.get_backend())
-  return compiled_c, result_shapes
+  return built_c.Compile(arg_shapes, compile_opts, backend=xb.get_backend())
 
 def build_jaxpr(jaxpr, axis_env, const_vals, *abstract_args):
-  arg_shapes = list(map(xla_shape, abstract_args))
-  built_c = _jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
-  return built_c
+  arg_shapes = map(aval_to_xla_shape, abstract_args)
+  return jaxpr_computation(jaxpr, axis_env, const_vals, (), *arg_shapes)
 
+def prefetch(x):
+  if isinstance(x, DeviceArray):
+    x.copy_to_host_async()
+  return x
 
-def _prefetch_jaxpr_literals(jaxpr):
-  """Prefetches any DeviceArray values inside a jaxpr to the host."""
-  for eqn in jaxpr.eqns:
-    for v in eqn.invars:
-      if type(v) is core.Literal and isinstance(v.val, DeviceArray):
-        v.val.copy_to_host_async()
-    if eqn.bound_subjaxprs:
-      for subjaxpr, _const_bindings, _freevar_bindings in eqn.bound_subjaxprs:
-        _prefetch_jaxpr_literals(subjaxpr)
+def jaxpr_literals(jaxpr):
+  return it.chain.from_iterable(eqn_literals(eqn) for eqn in jaxpr.eqns)
 
+def eqn_literals(eqn):
+  if eqn.bound_subjaxprs:
+    (subjaxpr, _, _), = eqn.bound_subjaxprs
+    for literal in jaxpr_literals(subjaxpr):
+      yield literal
+  if eqn.primitive in initial_style_translations:
+    for param in eqn.params.values():
+      if type(param) in (core.Jaxpr, core.TypedJaxpr):
+        subjaxpr = param if type(param) is core.Jaxpr else param.jaxpr
+        for literal in jaxpr_literals(subjaxpr):
+          yield literal
+  for v in eqn.invars:
+    if type(v) is core.Literal:
+      yield v.val
 
-def jaxpr_computation(jaxpr, const_vals, freevar_shapes, *arg_shapes):
-  axis_env = AxisEnv(1, [], [])
-  return _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
+def jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes):
+  c, out_nodes = _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes,
+                                    *arg_shapes)
+  return c.Build(c.Tuple(*out_nodes))
 
 def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes):
-  assert not any(type(invar) in (tuple, list) for invar in jaxpr.invars)
   c = xb.make_computation_builder("jaxpr_computation")
   platform = xb.get_backend().platform
+  _map(prefetch, it.chain(jaxpr_literals(jaxpr), const_vals))
 
   def read(v):
     if type(v) is Literal:
-      return c.Constant(_canonicalize_pyval_dtype(v.val))
+      return c.Constant(canonicalize_dtype(v.val))
     else:
       return env[v]
 
@@ -239,16 +244,12 @@ def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
   env = {}
   write(core.unitvar, c.Tuple())
   if const_vals:
-    for val in const_vals:
-      if isinstance(val, DeviceArray):
-        val.copy_to_host_async()
     _map(write, jaxpr.constvars, map(c.Constant, const_vals))
     _map(write, jaxpr.freevars, map(c.ParameterWithShape, freevar_shapes))
   else:
     all_freevars = it.chain(jaxpr.constvars, jaxpr.freevars)
     _map(write, all_freevars, map(c.ParameterWithShape, freevar_shapes))
   _map(write, jaxpr.invars, map(c.ParameterWithShape, arg_shapes))
-  _prefetch_jaxpr_literals(jaxpr)
   for eqn in jaxpr.eqns:
     in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
@@ -274,19 +275,14 @@ def _jaxpr_computation(jaxpr, axis_env, const_vals, freevar_shapes, *arg_shapes)
       raise NotImplementedError(msg.format(eqn.primitive.name))
 
     c.GetShape(ans)  # force xla to do shape error checking
-    out_nodes = xla_destructure(c, ans) if len(eqn.outvars) != 1 else [ans]
+    out_nodes = xla_destructure(c, ans) if eqn.primitive.multiple_results else [ans]
     _map(write, eqn.outvars, out_nodes)
-  return c.Build(c.Tuple(*map(read, jaxpr.outvars)))
-
-def _map(f, *xs):
-  return tuple(map(f, *xs))
+  return c, _map(read, jaxpr.outvars)
 
 def xla_destructure(c, ans):
   num_elements = len(c.GetShape(ans).tuple_shapes())
   return [c.GetTupleElement(ans, i) for i in range(num_elements)]
 
-def xla_pack(c, xs):
-  return c.Tuple(*xs)
 
 AxisEnv = namedtuple("AxisEnv", ["nreps", "names", "sizes"])
 
@@ -329,26 +325,72 @@ def eqn_replicas(eqn):
     return 1
 
 
-def lower_fun(fun, instantiate=False, initial_style=False):
-  """Lowers a traceable function to an XLA function.
+### xla_call underlying jit
 
-  Useful for implementing translation rules for primitives in terms of the
-  higher-level lax or NumPy APIs.
-  """
-  def f(c, *args, **params):
-    if initial_style:
-      axis_env, xla_args = args[0], args[1:]
-    else:
-      axis_env, xla_args = AxisEnv(1, [], []), args
-    xla_shapes = tuple(map(c.GetShape, xla_args))
-    avals = map(aval_from_xla_shape, xla_shapes)
-    pvals = [pe.PartialVal((a, core.unit)) for a in avals]
-    jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(fun, pvals, instantiate,
-                                                   **params)
-    built_c = _jaxpr_computation(jaxpr, axis_env, consts, (), *xla_shapes)
-    return c.Call(built_c, xla_args)
-  return f
+def _xla_call_impl(fun, *args, **params):
+  device_assignment = params['device_assignment']
+  compiled_fun = _xla_callable(fun, device_assignment, *map(abstractify, args))
+  try:
+    return compiled_fun(*args)
+  except FloatingPointError:
+    print("Invalid value encountered in the output of a jit function. "
+          "Calling the de-optimized version.")
+    return fun.call_wrapped(*args)  # probably won't return
 
+@lu.cache
+def _xla_callable(fun, device_assignment, *abstract_args):
+  pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
+  with core.new_master(pe.JaxprTrace, True) as master:
+    jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
+    assert not env  # no subtraces here (though cond might eventually need them)
+    axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
+    compiled = compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
+                             *abstract_args)
+    del master, consts, jaxpr, env
+  result_handlers = tuple(map(_pval_to_result_handler, pvals))
+  if axis_env.nreps == 1:
+    return partial(_execute_compiled, compiled, result_handlers)
+  else:
+    return partial(_execute_replicated, compiled, result_handlers)
+
+def _pval_to_result_handler(pval):
+  pv, const = pval
+  if pv is None:
+    return lambda _: const
+  else:
+    return aval_to_result_handler(pv)
+
+def _execute_compiled(compiled, handlers, *args):
+  device_num, = compiled.DeviceOrdinals()
+  input_bufs = [device_put(x, device_num) for x in args]
+  out_bufs = compiled.Execute(input_bufs).destructure()
+  if FLAGS.jax_debug_nans: check_nans(xla_call_p, out_buf)
+  return [handler(out_buf) for handler, out_buf in zip(handlers, out_bufs)]
+
+def _execute_replicated(compiled, handlers, *args):
+  input_bufs = [[device_put(x, i) for x in args]
+                for i in compiled.DeviceOrdinals()]
+  out_bufs = compiled.ExecutePerReplica(input_bufs)[0].destructure()
+  if FLAGS.jax_debug_nans: check_nans(xla_call_p, out_buf)
+  return [handler(out_buf) for handler, out_buf in zip(handlers, out_bufs)]
+
+
+xla_call_p = core.Primitive('xla_call')
+xla_call_p.multiple_results = True
+xla_call = partial(core.call_bind, xla_call_p)
+xla_call_p.def_custom_bind(xla_call)
+xla_call_p.def_impl(_xla_call_impl)
+
+def _xla_call_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
+                               device_assignment):
+  del device_assignment  # Ignored.
+  subc = jaxpr_computation(jaxpr, axis_env, (), _map(c.GetShape, env_nodes),
+                           *map(c.GetShape, in_nodes))
+  return c.Call(subc, env_nodes + in_nodes)
+ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
+
+
+### translation tables
 
 translations = {}
 parallel_translations = {}
@@ -356,64 +398,52 @@ initial_style_translations = {}
 call_translations = {}
 backend_specific_translations = defaultdict(dict)
 
-translations[core.call_p] = lambda c, subc_a1, *a2: c.Call(subc_a1[0],
-                                                           subc_a1[1] + a2)
 translations[core.identity_p] = lambda c, x: x
+call_translations[xla_call_p] = _xla_call_translation_rule
 
-def _zeros_like_translation_rule(c, x):
-  def _zeros_like(shape):
-    if shape.is_tuple():
-      return c.Tuple(*(_zeros_like(x) for x in shape.tuple_shapes()))
-    else:
-      return c.Broadcast(c.Constant(onp.array(0, shape.element_type())),
-                         shape.dimensions())
-  return _zeros_like(c.GetShape(x))
+def zeros_like_translation_rule(c, x):
+  shape = c.GetShape(x)
+  if shape.is_tuple():
+    assert not shape.tuple_shapes()
+    return c.Tuple()
+  else:
+    zero = c.Constant(onp.array(0, shape.element_type()))
+    return c.Broadcast(zero, shape.dimensions())
+translations[ad_util.zeros_like_p] = zeros_like_translation_rule
 
-def _add_jaxvals_translation_rule(c, x, y):
-  x_shape, y_shape = map(c.GetShape, (x, y))
-  if x_shape.is_tuple() and y_shape.is_tuple():
-    xs = xla_destructure(c, x)
-    ys = xla_destructure(c, y)
-    return c.Tuple(*map(partial(_add_jaxvals_translation_rule, c), xs, ys))
+def add_jaxvals_translation_rule(c, x, y):
+  shape = c.GetShape(x)
+  if shape.is_tuple():
+    assert not shape.tuple_shapes()
+    return x
   else:
     return c.Add(x, y)
+translations[ad_util.add_jaxvals_p] = add_jaxvals_translation_rule
 
-translations[ad_util.zeros_like_p] = _zeros_like_translation_rule
-translations[ad_util.add_jaxvals_p] = _add_jaxvals_translation_rule
+def lower_fun(fun, instantiate=False, initial_style=False):
+  """Build a translation rule for a traceable function."""
+  def f(c, *args, **params):
+    if initial_style:
+      axis_env, xla_args = args[0], args[1:]
+    else:
+      axis_env, xla_args = AxisEnv(1, [], []), args
+    xla_shapes = tuple(map(c.GetShape, xla_args))
+    avals = map(_aval_from_xla_shape, xla_shapes)
+    pvals = [pe.PartialVal((a, core.unit)) for a in avals]
+    jaxpr, _, consts = pe.trace_to_jaxpr(
+        lu.wrap_init(fun, params), pvals, instantiate=True)
+    built_c = jaxpr_computation(jaxpr, axis_env, consts, (), *xla_shapes)
+    return c.Call(built_c, xla_args)
+  return f
+
+def _aval_from_xla_shape(xla_shape):
+  if xla_shape.is_tuple() and not xla_shape.tuple_shapes():
+    return core.abstract_unit
+  else:
+    return ShapedArray(xla_shape.dimensions(), xla_shape.element_type())
 
 
-def _canonicalize_pyval_dtype(x):
-  try:
-    return canonicalize_dtype_handlers[type(x)](x)
-  except KeyError:
-    msg = "No canonicalize handler registered for type: {}"
-    raise TypeError(msg.format(type(x)))
-
-canonicalize_dtype_handlers = {}
-
-def _canonicalize_ndarray_dtype(x):
-  return onp.asarray(x, xb.canonicalize_dtype(onp.result_type(x)))
-
-for _t in array_types:
-  canonicalize_dtype_handlers[_t] = _canonicalize_ndarray_dtype
-
-canonicalize_dtype_handlers[core.Unit] = lambda x: x
-
-def _identity(x): return x
-
-
-def abstractify(x):
-  aval_mapping = pytype_aval_mappings.get(type(x))
-  if aval_mapping is None:
-    raise TypeError("Value '{}' of type {} is not a valid JAX type"
-                    .format(x, type(x)))
-  return aval_mapping(x)
-
-pytype_aval_mappings = {}
-
-for _t in array_types:
-  pytype_aval_mappings[_t] = make_shaped_array
-pytype_aval_mappings[core.Unit] = lambda _: core.abstract_unit
+### device-persistent data
 
 class DeviceValue(object):
   """A DeviceValue represents a value backed by device memory."""
@@ -437,7 +467,6 @@ class DeviceValue(object):
     self._check_if_deleted()
     self.device_buffer.block_host_until_ready()
 
-
 def _forward_method(attrname, self, fun, *args):
   return fun(getattr(self, attrname), *args)
 _forward_to_value = partial(_forward_method, "_value")
@@ -453,6 +482,9 @@ class DeviceArray(DeviceValue):
     self.aval = aval
     self.device_buffer = device_buffer
     self._npy_value = None
+    if not core.skip_checks:
+      npy_value = self._value
+      assert npy_value.dtype == aval.dtype and npy_value.shape == aval.shape
 
   @property
   def _value(self):
@@ -567,109 +599,19 @@ class DeviceArray(DeviceValue):
     raise TypeError("JAX DeviceArray, like numpy.ndarray, is not hashable.")
 
 core.literalable_types.add(DeviceArray)
-
-
-# DeviceValues don't need to be canonicalized because we assume values on the
-# device have already been canonicalized.
 core.pytype_aval_mappings[DeviceArray] = ConcreteArray
 pytype_aval_mappings[DeviceArray] = lambda x: x.aval
-canonicalize_dtype_handlers[DeviceArray] = _identity
+canonicalize_dtype_handlers[DeviceArray] = identity
 
 def _device_array_constant_handler(c, val, canonicalize_types=True):
   return c.Constant(onp.asarray(val), canonicalize_types=canonicalize_types)
 xb.register_constant_handler(DeviceArray, _device_array_constant_handler)
-
-pytype_aval_mappings[ConcreteArray] = make_shaped_array
-pytype_aval_mappings[ShapedArray] = _identity
-
-
-class DeviceConstant(DeviceArray):
-  def copy_to_host_async(self): pass
-
-  @staticmethod
-  def constant_handler(c, constant_instance, canonicalize_types=True):
-    assert False
-
-def _instantiate_device_constant(const, cutoff=1e6, device_num=0):
-  # dispatch an XLA Computation to build the constant on the device if it's
-  # large, or alternatively build it on the host and transfer it if it's small
-  # TODO(mattjj): need a way to instantiate on a specific device
-  assert isinstance(const, DeviceConstant)
-  if const.size > cutoff and device_num == 0:
-    c = xb.make_computation_builder("constant_instantiating_computation")
-    xla_const = const.constant_handler(c, const)
-    compiled = c.Build(xla_const).Compile((), xb.get_compile_options(),
-                                          backend=xb.get_backend())
-    return compiled.Execute(())
+def _device_put_device_array(x, device_num):
+  if x.device_buffer.device() == device_num:
+    return x.device_buffer
   else:
-    return xla_client.Buffer.from_pyval(onp.asarray(const), device_num,
-                                        backend=xb.get_backend())
-
-def _xla_call_impl(fun, *args, **params):
-  device_assignment = params.pop('device_assignment')
-  compiled_fun = _xla_callable(fun, device_assignment,
-                               *map(abstractify, args))
-  try:
-    return compiled_fun(*args)
-  except FloatingPointError:
-    print("Invalid value encountered in the output of a jit function. "
-          "Calling the de-optimized version.")
-    return fun.call_wrapped(*args)  # probably won't return
-
-@lu.cache
-def _xla_callable(fun, device_assignment, *abstract_args):
-  pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
-  with core.new_master(pe.JaxprTrace, True) as master:
-    jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
-    assert not env  # no subtraces here (though cond might eventually need them)
-    axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
-    compiled, result_shapes = _compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
-                                             *abstract_args)
-    del master, consts, jaxpr, env
-  handle_result = result_handler(result_shape)
-  if axis_env.nreps == 1:
-    return partial(_execute_compiled, compiled, pvals, handle_result)
-  else:
-    assert False, "update it"
-    return partial(_execute_replicated, compiled, pvals, handle_result)
-
-def _execute_compiled(compiled, pvals, handlers, *args):
-  device_num, = compiled.DeviceOrdinals()
-  input_bufs = [device_put(x, device_num) for x in args]
-  out_bufs = compiled.Execute(input_bufs).destructure()
-  [check_nans("jit-compiled computation", out_buf) for out_buf in out_bufs]
-
-  # TODO: remove
-  pvals = tuple(pvals)
-  handlers = tuple(handlers)
-  out_bufs = tuple(out_bufs)
-  assert len(pvals) == len(handlers), (len(pvals), len(handlers))
-  assert len(pvals) == len(out_bufs)
-
-  return [pe.merge_pvals(handler(out_buf), pval)
-          for handler, out_buf, pval in zip(handlers, out_bufs, pvals)]
-
-def _execute_replicated(compiled, pval, handle_result, *args):
-  raise NotImplementedError
-  input_bufs = [[device_put(x, i) for x in args] for i in compiled.DeviceOrdinals()]
-  out_buf = compiled.ExecutePerReplica(input_bufs)[0]
-  check_nans("jit-compiled computation", out_buf)
-  return pe.merge_pvals(handle_result(out_buf), pval)
-
-
-xla_call_p = core.Primitive('xla_call')
-xla_call = partial(core.call_bind, xla_call_p)
-xla_call_p.def_custom_bind(xla_call)
-xla_call_p.def_impl(_xla_call_impl)
-
-def _xla_call_translation_rule(c, jaxpr, axis_env, env_nodes, in_nodes,
-                               device_assignment):
-  del device_assignment  # Unused.
-  subc = _jaxpr_computation(jaxpr, axis_env, (), _map(c.GetShape, env_nodes),
-                            *map(c.GetShape, in_nodes))
-  return c.Call(subc, env_nodes + in_nodes)
-call_translations[xla_call_p] = _xla_call_translation_rule
-ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
+    return x.device_buffer.copy_to_device(device_num)
+device_put_handlers[DeviceArray] = _device_put_device_array
 
 
 def _device_put_impl(x, device_num=0):
@@ -678,8 +620,7 @@ def _device_put_impl(x, device_num=0):
   except TypeError:
     raise TypeError("Argument '{}' of type {} is not a valid JAX type"
                     .format(x, type(x)))
-
-  handler = result_handler(a)
+  handler = aval_to_result_handler(a)
   return handler(device_put(x, device_num))
 
 device_put_p = core.Primitive('device_put')
@@ -687,3 +628,26 @@ device_put_p.def_impl(_device_put_impl)
 device_put_p.def_abstract_eval(lambda x, **kwargs: x)
 translations[device_put_p] = lambda c, x, **kwargs: x
 ad.deflinear(device_put_p, lambda cotangent, **kwargs: [cotangent])
+
+
+### lazy constants
+
+class DeviceConstant(DeviceArray):
+  def copy_to_host_async(self): pass
+
+  @staticmethod
+  def constant_handler(c, constant_instance, canonicalize_types=True):
+    assert False
+
+def _instantiate_device_constant(const, device_num=0, cutoff=1e6):
+  # dispatch an XLA Computation to build the constant on the device if it's
+  # large, or alternatively build it on the host and transfer it if it's small
+  assert isinstance(const, DeviceConstant)
+  if const.size > cutoff and device_num == 0:
+    c = xb.make_computation_builder("constant_instantiating_computation")
+    xla_const = const.constant_handler(c, const)
+    opts = xb.get_compile_options(device_assignment=(device_num,))
+    compiled = c.Build(xla_const).Compile((), opts, backend=xb.get_backend())
+    return compiled.Execute(())
+  else:
+    return xc.Buffer.from_pyval(onp.asarray(const), device_num)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -625,7 +625,6 @@ def _xla_callable(fun, device_assignment, *abstract_args):
     axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
     compiled, result_shapes = _compile_jaxpr(jaxpr, device_assignment, axis_env, consts,
                                              *abstract_args)
-    print(jaxpr)
     del master, consts, jaxpr, env
   handle_result = result_handler(result_shape)
   if axis_env.nreps == 1:

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -17,7 +17,7 @@ from .lax import *
 from .lax import (_reduce_sum, _reduce_max, _reduce_min, _reduce_or,
                   _reduce_and, _reduce_window_sum, _reduce_window_max,
                   _reduce_window_min, _reduce_window_prod, _float, _complex,
-                  _input_dtype, _const, _eq_meet, _safe_mul, _abstractify,
+                  _input_dtype, _const, _eq_meet, _safe_mul,
                   _broadcasting_select)
 from .lax_control_flow import *
 from .lax_fft import *

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -38,8 +38,6 @@ from ..config import flags
 from ..core import Primitive
 from ..abstract_arrays import (UnshapedArray, ShapedArray, ConcreteArray,
                                array_types, make_shaped_array, raise_to_shaped)
-from ..api_util import (pytree_fun_to_jaxtupletree_fun, pytree_to_jaxtupletree,
-                        pytree_fun_to_flatjaxtuple_fun, pytree_to_flatjaxtuple)
 from ..interpreters import partial_eval as pe
 from ..interpreters import xla
 from ..interpreters import pxla

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -710,7 +710,7 @@ def scatter_add(operand, scatter_indices, updates, dimension_numbers):
   Returns:
     An array containing the sum of `operand` and the scattered updates.
   """
-  jaxpr, consts = _reduction_jaxpr(add, _const(operand, 0))
+  jaxpr, consts = _reduction_jaxpr(add, _abstractify(_const(operand, 0)))
   return scatter_add_p.bind(
       operand, scatter_indices, updates, update_jaxpr=jaxpr,
       update_consts=consts, dimension_numbers=dimension_numbers,
@@ -737,7 +737,7 @@ def scatter_min(operand, scatter_indices, updates, dimension_numbers):
   Returns:
     An array containing the sum of `operand` and the scattered updates.
   """
-  jaxpr, consts = _reduction_jaxpr(min, _const(operand, 0))
+  jaxpr, consts = _reduction_jaxpr(min, _abstractify(_const(operand, 0)))
   return scatter_min_p.bind(
       operand, scatter_indices, updates, update_jaxpr=jaxpr,
       update_consts=consts, dimension_numbers=dimension_numbers,
@@ -764,7 +764,7 @@ def scatter_max(operand, scatter_indices, updates, dimension_numbers):
   Returns:
     An array containing the sum of `operand` and the scattered updates.
   """
-  jaxpr, consts = _reduction_jaxpr(max, _const(operand, 0))
+  jaxpr, consts = _reduction_jaxpr(max, _abstractify(_const(operand, 0)))
   return scatter_max_p.bind(
       operand, scatter_indices, updates, update_jaxpr=jaxpr,
       update_consts=consts, dimension_numbers=dimension_numbers,
@@ -794,7 +794,7 @@ def scatter(operand, scatter_indices, updates, dimension_numbers):
   Returns:
     An array containing the sum of `operand` and the scattered updates.
   """
-  jaxpr, consts = _reduction_jaxpr(lambda x, y: y, _const(operand, 0))
+  jaxpr, consts = _reduction_jaxpr(lambda x, y: y, _abstractify(_const(operand, 0)))
   return scatter_p.bind(
       operand, scatter_indices, updates, update_jaxpr=jaxpr,
       update_consts=consts, dimension_numbers=dimension_numbers,
@@ -834,14 +834,15 @@ def reduce(operand, init_value, computation, dimensions):
   if monoid_reducer:
     return monoid_reducer(operand, dimensions)
   else:
-    jaxpr, consts = _reduction_jaxpr(computation, init_value)
+    jaxpr, consts = _reduction_jaxpr(computation, _abstractify(init_value))
     return reduce_p.bind(operand, init_value, computation=computation,
                          jaxpr=jaxpr, consts=consts, dimensions=tuple(dimensions))
 
-def _reduction_jaxpr(computation, init_value):
-  pval = _abstractify(init_value)
-  jaxpr, _, consts = pe.trace_unwrapped_to_jaxpr(computation, (pval, pval),
-                                                 instantiate=False)
+@cache()
+def _reduction_jaxpr(computation, aval):
+  pval = pe.PartialVal((aval, core.unit))
+  comp = lu.wrap_init(lambda x, y: (computation(x, y),))
+  jaxpr, _, consts = pe.trace_to_jaxpr(comp, (pval, pval), instantiate=False)
   return jaxpr, consts
 
 def _get_monoid_reducer(monoid_op, x):
@@ -906,7 +907,7 @@ def reduce_window(operand, init_value, computation, window_dimensions,
   if monoid_reducer:
     return monoid_reducer(operand, window_dimensions, window_strides, padding)
   else:
-    jaxpr, consts = _reduction_jaxpr(computation, init_value)
+    jaxpr, consts = _reduction_jaxpr(computation, _abstractify(init_value))
     return reduce_window_p.bind(
         operand, init_value, jaxpr=jaxpr, consts=consts,
         window_dimensions=tuple(window_dimensions),
@@ -930,7 +931,7 @@ def _reduce_window_sum(operand, window_dimensions, window_strides, padding):
 
 def _reduce_window_prod(operand, window_dimensions, window_strides, padding):
   init_value = _const(operand, 1)
-  jaxpr, consts = _reduction_jaxpr(mul, init_value)
+  jaxpr, consts = _reduction_jaxpr(mul, _abstractify(init_value))
   return reduce_window_p.bind(
       operand, init_value, jaxpr=jaxpr, consts=consts,
       window_dimensions=tuple(window_dimensions),
@@ -948,8 +949,8 @@ def _reduce_window_min(operand, window_dimensions, window_strides, padding):
 
 def _select_and_scatter(operand, select, window_dimensions, window_strides,
                         padding, source, init_value, scatter):
-  select_jaxpr, select_consts = _reduction_jaxpr(select)
-  scatter_jaxpr, scatter_consts = _reduction_jaxpr(scatter)
+  select_jaxpr, select_consts = _reduction_jaxpr(select, _abstractify(init_value))
+  scatter_jaxpr, scatter_consts = _reduction_jaxpr(scatter, _abstractify(init_value))
   return select_and_scatter_p.bind(
       operand, source, init_value, select_jaxpr=select_jaxpr,
       select_consts=select_consts, scatter_jaxpr=scatter_jaxpr,
@@ -1641,7 +1642,7 @@ ad.deflinear(complex_p, lambda t: [real(t), imag(neg(t))])
 conj_p = unop(_complex_dtype, _float | _complex, 'conj')
 
 def _conj_transpose_rule(t, x, input_dtype):
-  assert x is None
+  assert x is ad.undefined_primal
   if onp.issubdtype(input_dtype, onp.complexfloating):
     return [conj(t)]
   else:
@@ -1688,7 +1689,7 @@ xor_p = standard_binop([_any, _any], 'xor')
 ad.defjvp_zero(xor_p)
 
 def _add_transpose(t, x, y):
-  # assert x is None and y is None  # computation must be linear, not affine
+  # assert x is ad.undefined_primal and y is ad.undefined_primal  # not affine
   return [t, t]
 
 add_p = standard_binop([_num, _num], 'add')
@@ -1697,7 +1698,7 @@ ad.primitive_transposes[add_p] = _add_transpose
 
 
 def _sub_transpose(t, x, y):
-  assert x is None and y is None  # computation must be linear, not affine
+  assert x is ad.undefined_primal and y is ad.undefined_primal  # not affine
   return [t, neg(t) if t is not ad_util.zero else ad_util.zero]
 
 sub_p = standard_binop([_num, _num], 'sub')
@@ -1725,7 +1726,7 @@ ad.defbilinear_broadcasting(_brcast, safe_mul_p, _safe_mul, _safe_mul)
 
 
 def _div_transpose_rule(cotangent, x, y):
-  assert x is None and y is not None
+  assert x is ad.undefined_primal and y is not ad.undefined_primal
   res = ad_util.zero if cotangent is ad_util.zero else div(cotangent, y)
   return res, None
 div_p = standard_binop([_num, _num], 'div')
@@ -2097,8 +2098,8 @@ def _dot_batch_rule(batched_args, batch_dims, precision=None):
 
     assert lbd is not None and rbd is not None
     assert lhs.ndim == rhs.ndim == 2  # dot only supports rank 1 and above
-    lhs = batching.move_dim_to_front(lhs, lbd)
-    rhs = batching.move_dim_to_front(rhs, rbd)
+    lhs = batching.moveaxis(lhs, lbd, 0)
+    rhs = batching.moveaxis(rhs, rbd, 0)
     out = dot_general(lhs, rhs, [((1,), (1,)), ((0,), (0,))],
                       precision=precision)
     return out, 0
@@ -2107,7 +2108,7 @@ def _dot_batch_rule(batched_args, batch_dims, precision=None):
     assert rbd is not None
     lhs = broadcast(lhs, (rhs.shape[rbd],))
   else:
-    lhs = batching.move_dim_to_front(lhs, lbd)
+    lhs = batching.moveaxis(lhs, lbd, 0)
   lhs_batch = (0,)
   lhs_contracting = (onp.ndim(lhs) - 1,)
 
@@ -2115,7 +2116,7 @@ def _dot_batch_rule(batched_args, batch_dims, precision=None):
     assert lbd is not None
     rhs = broadcast(rhs, (lhs.shape[0],))
   else:
-    rhs = batching.move_dim_to_front(rhs, rbd)
+    rhs = batching.moveaxis(rhs, rbd, 0)
   rhs_batch = (0,)
   rhs_contracting = (onp.arange(1, onp.ndim(rhs))[-2:][0],)
 
@@ -2213,7 +2214,7 @@ def _dot_general_batch_rule(batched_args, batch_dims, dimension_numbers,
 
   if lbd is not None:
     if lbd != 0:
-      lhs = batching.move_dim_to_front(lhs, lbd)
+      lhs = batching.moveaxis(lhs, lbd, 0)
       lbd = 0
   else:
     assert rbd is not None
@@ -2223,7 +2224,7 @@ def _dot_general_batch_rule(batched_args, batch_dims, dimension_numbers,
 
   if rbd is not None:
     if rbd != 0:
-      rhs = batching.move_dim_to_front(rhs, rbd)
+      rhs = batching.moveaxis(rhs, rbd, 0)
       rbd = 0
   else:
     assert lbd is not None
@@ -2286,7 +2287,7 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, shape,
                                  broadcast_dimensions):
   operand, = batched_args
   bdim, = batch_dims
-  new_operand = batching.move_dim_to_front(operand, bdim)
+  new_operand = batching.moveaxis(operand, bdim, 0)
   new_shape = (operand.shape[bdim],) + shape
   new_broadcast_dimensions = (0,) + tuple(onp.add(1, broadcast_dimensions))
   return broadcast_in_dim(new_operand, new_shape, new_broadcast_dimensions), 0
@@ -2360,7 +2361,7 @@ def _concatenate_transpose_rule(t, *operands, **kwargs):
   operand_shapes = kwargs.pop('operand_shapes')
 
   if t is ad_util.zero:
-    return [ad_util.zero if o is None else None for o in operands]
+    return [ad_util.zero if o is ad.undefined_primal else None for o in operands]
   else:
     limit_points = onp.cumsum([shape[dimension] for shape in operand_shapes])
     starts = onp.zeros((len(operands), t.ndim), dtype=int)
@@ -2368,13 +2369,13 @@ def _concatenate_transpose_rule(t, *operands, **kwargs):
     limits = onp.tile(t.shape, (len(operands), 1))
     limits[:, dimension] = limit_points
 
-    return [slice(t, start, limit) if o is None else None
+    return [slice(t, start, limit) if o is ad.undefined_primal else None
             for o, start, limit in zip(operands, starts, limits)]
 
 def _concatenate_batch_rule(batched_args, batch_dims, dimension, operand_shapes):
   size = next(op.shape[bdim] for op, bdim in zip(batched_args, batch_dims)
               if bdim is not None)
-  operands = [batching.move_dim_to_front(op, bdim) if bdim is not None
+  operands = [batching.moveaxis(op, bdim, 0) if bdim is not None
               else broadcast(op, (size,))
               for op, bdim in zip(batched_args, batch_dims)]
   return concatenate(operands, dimension + 1), 0
@@ -2399,8 +2400,8 @@ def _pad_shape_rule(operand, padding_value, padding_config):
 
 def _pad_transpose(t, operand, padding_value, padding_config):
   if t is ad_util.zero:
-    return [ad_util.zero if operand is None else None,
-            ad_util.zero if padding_value is None else None]
+    return [ad_util.zero if operand is ad.undefined_primal else None,
+            ad_util.zero if padding_value is ad.undefined_primal else None]
 
   lo, hi, interior = zip(*padding_config)
   total = lambda x: _reduce_sum(x, list(range(t.ndim)))
@@ -2410,8 +2411,8 @@ def _pad_transpose(t, operand, padding_value, padding_config):
     unpadded = pad(t, onp.array(0., t.dtype), unpad_config)
     return slice(unpadded, onp.zeros_like(lo), unpadded.shape, onp.add(interior, 1))
 
-  t_operand = t_op() if operand is None else None
-  t_padv = sub(total(t), total(t_operand)) if padding_value is None else None
+  t_operand = t_op() if operand is ad.undefined_primal else None
+  t_padv = sub(total(t), total(t_operand)) if padding_value is ad.undefined_primal else None
 
   return [t_operand, t_padv]
 
@@ -2485,7 +2486,7 @@ def _reshape_transpose_rule(t, new_sizes, dimensions, old_sizes):
 def _reshape_batch_rule(batched_args, batch_dims, new_sizes, dimensions, **unused):
   operand, = batched_args
   bdim, = batch_dims
-  operand = batching.move_dim_to_front(operand, bdim)
+  operand = batching.moveaxis(operand, bdim, 0)
   if dimensions is not None:
     raise NotImplementedError  # TODO(mattjj): handle reshape w/ dimensions
     dimensions = (0,) + tuple(onp.add(1, dimensions))
@@ -2561,16 +2562,16 @@ def _select_dtype_rule(pred, on_true, on_false):
   return on_true.dtype
 
 def _select_transpose_rule(t, pred, on_true, on_false):
-  assert pred is not None
+  assert pred is not ad.undefined_primal
   if t is ad_util.zero:
     return [None,
-            ad_util.zero if on_true is None else None,
-            ad_util.zero if on_false is None else None]
+            ad_util.zero if on_true is ad.undefined_primal else None,
+            ad_util.zero if on_false is ad.undefined_primal else None]
   else:
     zeros = full_like(t, 0)
     return [None,
-            select(pred, t, zeros) if on_true is None else None,
-            select(pred, zeros, t) if on_false is None else None]
+            select(pred, t, zeros) if on_true is ad.undefined_primal else None,
+            select(pred, zeros, t) if on_false is ad.undefined_primal else None]
 
 def _select_batch_rule(batched_args, batch_dims, **unused_kwargs):
   pred, on_true, on_false, = batched_args
@@ -2591,17 +2592,22 @@ def _select_batch_rule(batched_args, batch_dims, **unused_kwargs):
     if ot_bdim == of_bdim:
       return select(pred, on_true, on_false), ot_bdim
     elif onp.shape(on_true) == onp.shape(on_false):
-      on_false = batching.moveaxis(size, ot_bdim, of_bdim, on_false)
+      on_false = batching.moveaxis(on_false, of_bdim, ot_bdim)
       return select(pred, on_true, on_false), ot_bdim
 
-  pred = batching.bdim_at_front(pred, pred_bdim, size, force_broadcast=True)
-  on_true = batching.bdim_at_front(on_true, ot_bdim, size, force_broadcast=True)
-  on_false = batching.bdim_at_front(on_false, of_bdim, size, force_broadcast=True)
+  pred = batching.bdim_at_front(pred, pred_bdim, size) if onp.shape(pred) else pred
+  if not onp.shape(on_true) == onp.shape(on_false) == ():
+    on_true = batching.bdim_at_front(on_true, ot_bdim, size)
+    on_false = batching.bdim_at_front(on_false, of_bdim, size)
   assert onp.shape(on_true) == onp.shape(on_false)
   if 0 < onp.ndim(pred) < onp.ndim(on_true):
     # vmapped function had a scalar pred with nonscalar args
     assert onp.ndim(pred) == 1
     pred = broadcast_in_dim(pred, on_true.shape, [0])
+  if onp.ndim(pred) > onp.ndim(on_true):
+    assert onp.ndim(on_true) == 0
+    on_true = broadcast(on_true, pred.shape)
+    on_false = broadcast(on_false, pred.shape)
   return select(pred, on_true, on_false), 0
 
 select_p = standard_primitive(_select_shape_rule, _select_dtype_rule, 'select')
@@ -2729,8 +2735,8 @@ def _dynamic_slice_jvp(primals, tangents, slice_sizes, operand_shape):
 
 def _dynamic_slice_transpose_rule(t, operand, *start_indices, **kwargs):
   operand_shape = kwargs["operand_shape"]
-  assert operand is None
-  assert all(s is not None for s in start_indices)
+  assert operand is ad.undefined_primal
+  assert all(s is not ad.undefined_primal for s in start_indices)
   zeros = full(operand_shape, tie_in(t, _zero(t)))
   return ([dynamic_update_slice(zeros, t, start_indices)] +
           [None] * len(start_indices))
@@ -2805,12 +2811,12 @@ def _dynamic_update_slice_jvp(primals, tangents, update_shape):
 def _dynamic_update_slice_transpose_rule(t, operand, update, *start_indices,
                                          **kwargs):
   update_shape = kwargs["update_shape"]
-  assert all(x is not None for x in start_indices)
+  assert all(x is not ad.undefined_primal for x in start_indices)
   dus = dynamic_update_slice
   ds = dynamic_slice
   zeros = _zeros(t, shape=update_shape)
-  operand_t = dus(t, zeros, start_indices) if operand is None else None
-  update_t = ds(t, start_indices, update_shape) if update is None else None
+  operand_t = dus(t, zeros, start_indices) if operand is ad.undefined_primal else None
+  update_t = ds(t, start_indices, update_shape) if update is ad.undefined_primal else None
   return [operand_t, update_t] + [None] * len(start_indices)
 
 def _dynamic_update_slice_translation_rule(c, operand, update, *start_indices,
@@ -2912,7 +2918,7 @@ def _gather_jvp_rule(g, operand, start_indices, dimension_numbers, slice_sizes,
 
 def _gather_transpose_rule(t, operand, start_indices, dimension_numbers,
                           slice_sizes, operand_shape):
-  assert operand is None
+  assert operand is ad.undefined_primal
   if t is ad_util.zero:
     return [ad_util.zero, ad_util.zero]
   zeros = full(operand_shape, tie_in(t, _zero(t)))
@@ -2928,7 +2934,7 @@ def _gather_batching_rule(batched_args, batch_dims, dimension_numbers,
   operand_bdim, start_indices_bdim = batch_dims
 
   if operand_bdim is not None and start_indices_bdim is None:
-    operand = batching.move_dim_to_front(operand, operand_bdim)
+    operand = batching.moveaxis(operand, operand_bdim, 0)
     slice_sizes = (operand.shape[0],) + slice_sizes
     offset_dims = (0,) + tuple(onp.add(1, dimension_numbers.offset_dims))
     collapsed_slice_dims = tuple(onp.add(1, dimension_numbers.collapsed_slice_dims))
@@ -2941,7 +2947,7 @@ def _gather_batching_rule(batched_args, batch_dims, dimension_numbers,
                   slice_sizes=slice_sizes), 0
 
   elif operand_bdim is None and start_indices_bdim is not None:
-    start_indices = batching.move_dim_to_front(start_indices, start_indices_bdim)
+    start_indices = batching.moveaxis(start_indices, start_indices_bdim, 0)
     offset_dims = tuple(onp.add(1, dimension_numbers.offset_dims))
     dnums = GatherDimensionNumbers(
         offset_dims=offset_dims,
@@ -2952,8 +2958,8 @@ def _gather_batching_rule(batched_args, batch_dims, dimension_numbers,
 
   else:
     # move our batch dimensions to the front to preserve sanity
-    operand = batching.move_dim_to_front(operand, operand_bdim)
-    start_indices = batching.move_dim_to_front(start_indices, start_indices_bdim)
+    operand = batching.moveaxis(operand, operand_bdim, 0)
+    start_indices = batching.moveaxis(start_indices, start_indices_bdim, 0)
 
     # Example: user code had start_indices shape (3, 4, 5), and we have to deal
     # with start_indices shape (7, 3, 4, 5). We transform that to a
@@ -3063,15 +3069,15 @@ def _scatter_add_jvp(primals, tangents, update_jaxpr, update_consts,
 def _scatter_add_transpose_rule(t, operand, scatter_indices, updates,
                                 update_jaxpr, update_consts, dimension_numbers,
                                 updates_shape):
-  assert scatter_indices is not None
+  assert scatter_indices is not ad.undefined_primal
   if t is ad_util.zero:
     return [ad_util.zero, None, ad_util.zero]
 
   operand_t = update_t = None
-  if operand is None:
+  if operand is ad.undefined_primal:
     operand_t = t
 
-  if updates is None:
+  if updates is ad.undefined_primal:
     gather_dnums = GatherDimensionNumbers(
       offset_dims=dimension_numbers.update_window_dims,
       collapsed_slice_dims=dimension_numbers.inserted_window_dims,
@@ -3099,8 +3105,7 @@ def _scatter_batching_rule(
   # it at the front (so that we can scatter into it)
   size = next(x.shape[ax] for x, ax in zip(batched_args, batch_dims)
               if ax is not None)
-  operand = batching.bdim_at_front(operand, operand_bdim, broadcast_size=size,
-                                   force_broadcast=True)
+  operand = batching.bdim_at_front(operand, operand_bdim, size)
   operand_bdim = 0
 
   if scatter_indices_bdim is not None and updates_bdim is None:
@@ -3108,7 +3113,7 @@ def _scatter_batching_rule(
     updates_bdim = 0
 
   if scatter_indices_bdim is None and updates_bdim is not None:
-    updates = batching.move_dim_to_front(updates, updates_bdim)
+    updates = batching.moveaxis(updates, updates_bdim, 0)
     inserted_window_dims = tuple(onp.add(1, dimension_numbers.inserted_window_dims))
     update_window_dims = (0,) + tuple(onp.add(1, dimension_numbers.update_window_dims))
     scatter_dims_to_operand_dims = tuple(onp.add(1, dimension_numbers.scatter_dims_to_operand_dims))
@@ -3119,9 +3124,8 @@ def _scatter_batching_rule(
     return scatter_op(operand, scatter_indices, updates, dnums), 0
   else:
     # see the third case in _gather_batching_rule for comparison and comments
-    scatter_indices = batching.move_dim_to_front(scatter_indices,
-                                                 scatter_indices_bdim)
-    updates = batching.move_dim_to_front(updates, updates_bdim)
+    scatter_indices = batching.moveaxis(scatter_indices, scatter_indices_bdim, 0)
+    updates = batching.moveaxis(updates, updates_bdim, 0)
 
     count_shape = list(scatter_indices.shape)
     count_shape[-1] = 1
@@ -3276,14 +3280,16 @@ def _reduce_batch_rule(batched_args, batch_dims, computation, jaxpr, consts, dim
   if init_value_bdim is None:
     assert operand_bdim is not None
     new_dimensions = [d + bool(d >= operand_bdim) for d in dimensions]
-    new_operand_bdim = operand_bdim - onp.sum(onp.less(dimensions, operand_bdim))
+    new_operand_bdim = operand_bdim - int(onp.sum(onp.less(dimensions, operand_bdim)))
     return reduce(operand, init_value, computation, new_dimensions), new_operand_bdim
   else:
     raise NotImplementedError  # loop and stack
 
 def _reduction_computation(c, jaxpr, consts, init_value):
   shape = c.GetShape(init_value)
-  return xla.jaxpr_computation(jaxpr, consts, (), shape, shape)
+  axis_env = xla.AxisEnv(1, [], [])  # no parallel primitives inside reductions
+  c, (out,) = xla._jaxpr_computation(jaxpr, axis_env, consts, (), shape, shape)
+  return c.Build(out)
 
 reduce_p = standard_primitive(_reduce_shape_rule, _input_dtype, 'reduce',
                               _reduce_translation_rule)
@@ -3631,7 +3637,7 @@ def _select_and_scatter_add_jvp(
 def _select_and_scatter_add_transpose(
     t, source, operand, select_prim, window_dimensions, window_strides,
     padding):
-  assert source is None and operand is not None
+  assert source is ad.undefined_primal and operand is not ad.undefined_primal
   source_t = _select_and_gather_add(t, operand, select_prim, window_dimensions,
                                     window_strides, padding)
   return [source_t, None]
@@ -3642,8 +3648,8 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
 
   if s_bdims is not None and o_bdims is not None:
     #TODO(#212): use a map construct instead of unrolling.
-    source = batching.move_dim_to_front(source, s_bdims)
-    operand = batching.move_dim_to_front(operand, o_bdims)
+    source = batching.moveaxis(source, s_bdims, 0)
+    operand = batching.moveaxis(operand, o_bdims, 0)
     outputs = [
         _select_and_scatter_add(s, o, **kwargs) for s, o in zip(source, operand)]
     outputs = [reshape(out, (1,) + out.shape) for out in outputs]
@@ -3651,7 +3657,7 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
     return outputs, 0
   elif s_bdims is not None:
     #TODO(#212): use a map construct instead of unrolling.
-    source = batching.move_dim_to_front(source, s_bdims)
+    source = batching.moveaxis(source, s_bdims, 0)
     outputs = [
         _select_and_scatter_add(s, operand, **kwargs) for s in source]
     outputs = [reshape(out, (1,) + out.shape) for out in outputs]
@@ -3659,7 +3665,7 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
     return outputs, 0
   elif o_bdims is not None:
     #TODO(#212): use a map construct instead of unrolling.
-    operand = batching.move_dim_to_front(operand, o_bdims)
+    operand = batching.moveaxis(operand, o_bdims, 0)
     outputs = [
         _select_and_scatter_add(source, o, **kwargs) for o in operand]
     outputs = [reshape(out, (1,) + out.shape) for out in outputs]
@@ -3809,7 +3815,7 @@ def _select_and_gather_add_jvp(
 def _select_and_gather_add_transpose(
     t, tangents, operand, select_prim, window_dimensions, window_strides,
     padding):
-  assert tangents is None and operand is not None
+  assert tangents is ad.undefined_primal and operand is not ad.undefined_primal
   result = _select_and_scatter_add(t, operand, select_prim, window_dimensions,
                                    window_strides, padding)
   return [result, None]
@@ -3844,12 +3850,7 @@ batching.primitive_batchers[sort_p] = _sort_batch_rule
 
 
 def _sort_key_val_abstract_eval(keys, values, dimension):
-  return core.AbstractTuple((keys, values))
-
-def _sort_key_val_impl(keys, values, dimension):
-  out = xla.apply_primitive(sort_key_val_p, keys, values, dimension=dimension)
-  sorted_keys, sorted_values = out
-  return core.pack((sorted_keys, sorted_values))
+  return keys, values
 
 def _sort_key_val_jvp(primals, tangents, dimension):
   # NOTE(mattjj): this re-sorts three times, but if we had a variadic
@@ -3874,15 +3875,15 @@ def _sort_key_val_jvp(primals, tangents, dimension):
     values_tangents_out = _sort_jvp_rule(values_tangents, keys, dimension)
 
   tangents_out = keys_tangents_out, values_tangents_out
-  return core.pack(val_out), ad.TangentTuple(tangents_out)
+  return val_out, tangents_out
 
 def _sort_key_val_transpose_rule(t, keys, values, dimension):
   t_keys, t_values = t
   assert t_keys is ad_util.zero
   iota = broadcasted_iota(onp.int32, keys.shape, dimension % keys.ndim)
   _, perm = sort_key_val(keys, iota)
-  keys_result = ad_util.zero if keys is None else None
-  values_result = sort_key_val(perm, t_values)[1] if values is None else None
+  keys_result = ad_util.zero if keys is ad.undefined_primal else None
+  values_result = sort_key_val(perm, t_values)[1] if values is ad.undefined_primal else None
   return [keys_result, values_result]
 
 def _sort_key_val_batch_rule(batched_args, batch_dims, dimension):
@@ -3891,31 +3892,27 @@ def _sort_key_val_batch_rule(batched_args, batch_dims, dimension):
   assert keys_bdim is not None or values_bdim is not None
   if keys_bdim == values_bdim:
     new_dimension = dimension + (keys_bdim <= dimension)
-    out = sort_key_val(keys, values, new_dimension)
-    return core.pack(out), keys_bdim
+    return sort_key_val(keys, values, new_dimension), (keys_bdim, keys_bdim)
   elif keys_bdim is not None and values_bdim is not None:
-    keys_trans = batching.moveaxis(keys.shape[keys_bdim], values_bdim,
-                                   keys_bdim, keys)
+    keys_trans = batching.moveaxis(keys, keys_bdim, values_bdim)
     new_dimension = dimension + (values_bdim <= dimension)
-    out = sort_key_val(keys_trans, values, new_dimension)
-    return core.pack(out), values_bdim
+    return sort_key_val(keys_trans, values, new_dimension), (values_bdim, values_bdim)
   elif keys_bdim is None:
     broadcast_dimensions = onp.delete(onp.arange(values.ndim), values_bdim)
     new_keys = broadcast_in_dim(keys, values.shape, broadcast_dimensions)
     new_dimension = dimension + (values_bdim <= dimension)
-    out = sort_key_val(new_keys, values, new_dimension)
-    return core.pack(out), values_bdim
+    return sort_key_val(new_keys, values, new_dimension), (values_bdim, values_bdim)
   elif values_bdim is None:
     broadcast_dimensions = onp.delete(onp.arange(keys.ndim), keys_bdim)
     new_values = broadcast_in_dim(values, keys.shape, broadcast_dimensions)
     new_dimension = dimension + (keys_bdim <= dimension)
-    out = sort_key_val(keys, new_values, new_dimension)
-    return core.pack(out), keys_bdim
+    return sort_key_val(keys, new_values, new_dimension), (keys_bdim, keys_bdim)
   else:
     raise Exception  # unreachable
 
 sort_key_val_p = Primitive('sort_key_val')
-sort_key_val_p.def_impl(_sort_key_val_impl)
+sort_key_val_p.multiple_results = True
+sort_key_val_p.def_impl(partial(xla.apply_primitive, sort_key_val_p))
 sort_key_val_p.def_abstract_eval(_sort_key_val_abstract_eval)
 xla.translations[sort_key_val_p] = partial(standard_translate, 'sort_key_val')
 ad.primitive_jvps[sort_key_val_p] = _sort_key_val_jvp
@@ -4034,9 +4031,10 @@ class _EyeConstant(xla.DeviceConstant):
 for _t in [_FilledConstant, _IotaConstant, _EyeConstant]:
   xla_bridge.register_constant_handler(_t, _t.constant_handler)
   core.pytype_aval_mappings[_t] = ConcreteArray
-  xla.pytype_aval_mappings[_t] = xla.pytype_aval_mappings[xla.DeviceArray]
+  xla.pytype_aval_mappings[_t] = make_shaped_array
+  xla.device_put_handlers[_t] = xla._instantiate_device_constant
+  pxla.shard_arg_handlers[_t] = pxla._shard_array
   xla.canonicalize_dtype_handlers[_t] = _identity
-  batching.pytype_aval_mappings[_t] = make_shaped_array
   ad_util.jaxval_adders[_t] = add
   ad_util.jaxval_zeros_likers[_t] = zeros_like_array
 
@@ -4063,8 +4061,7 @@ batching.primitive_batchers[stop_gradient_p] = _stop_gradient_batch_rule
 
 ### util
 
-def _ndim(x):
-  return x.ndim
+_ndim = onp.ndim
 
 
 def _dilate_shape(shape, dilation):
@@ -4410,5 +4407,4 @@ def subvals(lst, replace):
 
 
 def _abstractify(x):
-  # used internally for initial-style higher-order primitives
-  return pe.PartialVal((raise_to_shaped(core.get_aval(x)), core.unit))
+  return raise_to_shaped(core.get_aval(x))

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -30,15 +30,13 @@ from jax.lax import lax
 from jax.lax import _abstractify
 from jax import linear_util as lu
 from jax.abstract_arrays import ConcreteArray, ShapedArray, UnshapedArray
-from jax.api_util import (
-    pytree_to_flatjaxtuple, pytree_fun_to_flatjaxtuple_fun,
-    pytree_to_jaxtupletree, pytree_fun_to_jaxtupletree_fun)
+from jax.api_util import flatten_fun
 from jax.interpreters import batching
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 from jax.interpreters import ad
 from jax.util import partial, unzip2, safe_map, safe_zip
-from jax.tree_util import build_tree, tree_unflatten, tree_map
+from jax.tree_util import build_tree, tree_unflatten, tree_map, tree_flatten
 from jax import ad_util
 
 _map = safe_map
@@ -262,7 +260,7 @@ batching.primitive_batchers[while_p] = _while_loop_batching_rule
 
 def cond(pred, true_operand, true_fun, false_operand, false_fun):
   def trace_jaxpr(fun, operand):
-    op_flat, in_tree = pytree_to_flatjaxtuple(operand)
+    op_flat, in_tree = tree_flatten(operand)
     fun_flat, out_tree = pytree_fun_to_flatjaxtuple_fun(lu.wrap_init(fun), (in_tree,))
     jaxpr, pvout, consts = pe.trace_to_jaxpr(fun_flat, (_abstractify(op_flat),))
     return op_flat, jaxpr, consts, pvout, out_tree

--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -48,7 +48,7 @@ def fft_transpose_rule(t, fft_type, fft_lengths):
 def fft_batching_rule(batched_args, batch_dims, fft_type, fft_lengths):
   x, = batched_args
   bd, = batch_dims
-  x = batching.bdim_at_front(x, bd)
+  x = batching.moveaxis(x, bd, 0)
   return fft(x, fft_type, fft_lengths), 0
 
 fft_p = Primitive('fft')

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2924,6 +2924,8 @@ setattr(DeviceArray, "astype", lax.convert_element_type)
 
 # Extra methods that are handy
 setattr(ShapedArray, "broadcast", core.aval_method(lax.broadcast))
+setattr(ShapedArray, "broadcast_in_dim", core.aval_method(lax.broadcast_in_dim))
 setattr(ShapedArray, "split", core.aval_method(split))
 setattr(DeviceArray, "broadcast", lax.broadcast)
+setattr(DeviceArray, "broadcast_in_dim", lax.broadcast_in_dim)
 setattr(DeviceArray, "split", split)

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -331,8 +331,6 @@ else:
   register_pytree_node(tuple, lambda xs: (xs, None), lambda _, xs: tuple(xs))
   register_pytree_node(list, lambda xs: (tuple(xs), None), lambda _, xs: list(xs))
   register_pytree_node(dict, dict_to_iterable, lambda keys, xs: dict(zip(keys, xs)))
-  register_pytree_node(type(None), lambda z: ((), None), lambda _, xs: None)
-
 
   # To handle namedtuples, we can't just use the standard table of node_types
   # because every namedtuple creates its own type and thus would require its own

--- a/jax/util.py
+++ b/jax/util.py
@@ -94,9 +94,10 @@ def curry(f):
   """
   return partial(partial, f)
 
-def toposort(end_node):
+def toposort(end_nodes):
+  # TODO: think about repeated objects in end_nodes
   child_counts = {}
-  stack = [end_node]
+  stack = list(end_nodes)
   while stack:
     node = stack.pop()
     if id(node) in child_counts:
@@ -106,7 +107,7 @@ def toposort(end_node):
       stack.extend(node.parents)
 
   sorted_nodes = []
-  childless_nodes = [end_node]
+  childless_nodes = list(end_nodes)
   while childless_nodes:
     node = childless_nodes.pop()
     sorted_nodes.append(node)

--- a/jax/util.py
+++ b/jax/util.py
@@ -31,14 +31,12 @@ def safe_zip(*args):
     assert len(arg) == n, 'length mismatch: {}'.format(list(map(len, args)))
   return list(zip(*args))
 
-
 def safe_map(f, *args):
   args = list(map(list, args))
   n = len(args[0])
   for arg in args[1:]:
     assert len(arg) == n, 'length mismatch: {}'.format(list(map(len, args)))
   return list(map(f, *args))
-
 
 def unzip2(xys):
   xs = []
@@ -47,7 +45,6 @@ def unzip2(xys):
     xs.append(x)
     ys.append(y)
   return tuple(xs), tuple(ys)
-
 
 def unzip3(xyzs):
   xs = []
@@ -59,10 +56,24 @@ def unzip3(xyzs):
     zs.append(z)
   return tuple(xs), tuple(ys), tuple(zs)
 
+def split_list(args, ns):
+  assert type(ns) is list
+  args = list(args)
+  lists = []
+  for n in ns:
+    lists.append(args[:n])
+    args = args[n:]
+  lists.append(args)
+  return lists
+
+def split_dict(dct, names):
+  dct = dict(dct)
+  lst = [dct.pop(name) for name in names]
+  assert not dct
+  return lst
 
 def concatenate(xs):
   return list(it.chain.from_iterable(xs))
-
 
 def partial(fun, *args, **kwargs):
   wrapped = functools.partial(fun, *args, **kwargs)
@@ -95,7 +106,8 @@ def curry(f):
   return partial(partial, f)
 
 def toposort(end_nodes):
-  # TODO: think about repeated objects in end_nodes
+  if not end_nodes: return []
+
   child_counts = {}
   stack = list(end_nodes)
   while stack:
@@ -105,9 +117,12 @@ def toposort(end_nodes):
     else:
       child_counts[id(node)] = 1
       stack.extend(node.parents)
+  for node in end_nodes:
+    child_counts[id(node)] -= 1
 
   sorted_nodes = []
-  childless_nodes = list(end_nodes)
+  childless_nodes = [node for node in end_nodes if child_counts[id(node)] == 0]
+  assert childless_nodes
   while childless_nodes:
     node = childless_nodes.pop()
     sorted_nodes.append(node)
@@ -117,8 +132,14 @@ def toposort(end_nodes):
       else:
         child_counts[id(parent)] -= 1
 
+  check_toposort(sorted_nodes[::-1])
   return sorted_nodes[::-1]
 
+def check_toposort(nodes):
+  visited = set()
+  for node in nodes:
+    assert all(id(parent) in visited for parent in node.parents)
+    visited.add(id(node))
 
 def split_merge(predicate, xs):
   sides = list(map(predicate, xs))
@@ -139,19 +160,16 @@ def split_merge(predicate, xs):
 
   return lhs, rhs, merge
 
-
 def cache(max_size=4096):
   return fastcache.clru_cache(maxsize=max_size)
 
 memoize = fastcache.clru_cache(maxsize=None)
-
 
 def prod(xs):
   out = 1
   for x in xs:
     out *= x
   return out
-
 
 class WrapHashably(object):
   __slots__ = ["val"]
@@ -177,7 +195,6 @@ class Hashable(object):
   def __eq__(self, other):
     return self.val == other.val
 
-
 def get_module_functions(module):
   """Finds functions in module.
   Args:
@@ -185,7 +202,6 @@ def get_module_functions(module):
   Returns:
     module_fns: A set of functions, builtins or ufuncs in `module`.
   """
-
   module_fns = set()
   for key in dir(module):
     attr = getattr(module, key)

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -159,7 +159,6 @@ class PyTreeDef {
  private:
   enum class Kind {
     kLeaf,        // An opaque leaf node
-    kNone,        // None.
     kTuple,       // A tuple
     kNamedTuple,  // A collections.namedtuple
     kList,        // A list
@@ -248,9 +247,7 @@ void PyTreeDef::FlattenHelper(py::handle handle, py::list* leaves,
   Node node;
   int start_num_nodes = tree->traversal_.size();
   int start_num_leaves = leaves->size();
-  if (py::isinstance<py::none>(handle)) {
-    node.kind = Kind::kNone;
-  } else if (PyTuple_CheckExact(handle.ptr())) {
+  if (PyTuple_CheckExact(handle.ptr())) {
     py::tuple tuple = py::reinterpret_borrow<py::tuple>(handle);
     node.kind = Kind::kTuple;
     node.arity = tuple.size();
@@ -337,7 +334,6 @@ py::object PyTreeDef::Unflatten(py::iterable leaves) const {
         ++leaf_count;
         break;
 
-      case Kind::kNone:
       case Kind::kTuple:
       case Kind::kNamedTuple:
       case Kind::kList:
@@ -371,9 +367,6 @@ py::object PyTreeDef::Unflatten(py::iterable leaves) const {
   switch (node.kind) {
     case Kind::kLeaf:
       throw std::logic_error("MakeNode not implemented for leaves.");
-
-    case Kind::kNone:
-      return py::none();
 
     case Kind::kTuple:
     case Kind::kNamedTuple: {
@@ -439,9 +432,6 @@ py::list PyTreeDef::FlattenUpTo(py::handle xs) const {
         }
         leaves[leaf] = py::reinterpret_borrow<py::object>(object);
         --leaf;
-        break;
-
-      case Kind::kNone:
         break;
 
       case Kind::kTuple: {
@@ -580,7 +570,6 @@ py::object PyTreeDef::Walk(const py::function& f_node, py::handle f_leaf,
         break;
       }
 
-      case Kind::kNone:
       case Kind::kTuple:
       case Kind::kNamedTuple:
       case Kind::kList:
@@ -705,9 +694,6 @@ std::string PyTreeDef::ToString() const {
       case Kind::kLeaf:
         agenda.push_back("*");
         continue;
-      case Kind::kNone:
-        kind = "None";
-        break;
       case Kind::kNamedTuple:
         kind = "namedtuple";
         break;

--- a/jaxlib/version.py
+++ b/jaxlib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.24"
+__version__ = "0.1.25"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -31,9 +31,9 @@ import jax
 import jax.numpy as np
 from jax import jit, grad, device_get, device_put, jacfwd, jacrev, hessian
 from jax import api, lax
-from jax.core import Primitive, pack, JaxTuple
+from jax.core import Primitive
 from jax.interpreters import ad
-from jax.interpreters.xla import DeviceArray, DeviceTuple
+from jax.interpreters.xla import DeviceArray
 from jax.abstract_arrays import concretization_err_msg
 from jax.lib import xla_bridge as xb
 from jax import test_util as jtu

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -26,7 +26,7 @@ from jax.abstract_arrays import ShapedArray
 from jax import lax
 from jax import lax_linalg
 from jax import random
-from jax.api import jit, grad, jvp, vjp, trace_to_jaxpr, jacfwd, jacrev, hessian
+from jax.api import jit, grad, jvp, vjp, make_jaxpr, jacfwd, jacrev, hessian
 from jax.api import vmap
 from jax.core import unit
 from jax.interpreters import partial_eval as pe
@@ -56,16 +56,7 @@ class BatchingTest(jtu.JaxTestCase):
     expected = onp.dot(A, B)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    # this is a crude check that we only call a single dot
-    def pv_like(x):
-      aval = ShapedArray(onp.shape(x), onp.result_type(x))
-      return pe.PartialVal((aval, unit))
-
-    def make_jaxpr(fun, example_args):
-      jaxpr, _, _, _ = trace_to_jaxpr(fun, map(pv_like, example_args))
-      return jaxpr
-
-    jaxpr = make_jaxpr(matmat, (A, B))
+    jaxpr = make_jaxpr(matmat)(A, B)
     self.assertEqual(len(jaxpr.eqns), 1)
 
   def testPerExampleGradients(self):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -76,8 +76,8 @@ def fun_with_nested_calls_2(x):
       q = call(lambda x: y, x)
       q = q + call(lambda: y)
       q = q + call(lambda y: w + y, y)
-      return call(lambda w: call(np.sin, x) * y, 1.0) + q
-      # return call(lambda w: call(error(np.sin), x) * y, 1.0) + q
+      q = call(lambda w: call(np.sin, x) * y, 1.0) + q
+      return q
     p, t = jvp(baz, (x + 1.0,), (y,))
     return t + (x * p)
   return call(bar, x)
@@ -141,37 +141,8 @@ def fwd_deriv(f):
 
   return df
 
-def check_trace_eval(f, pvals, vals, expected_out_pval):
-  jaxpr, consts, out_pval, _ = api.trace_to_jaxpr(f, pvals)
-  assert expected_out_pval == out_pval, (expected_out_pval, out_pval)
-  output_traced = core.eval_jaxpr(jaxpr, consts, (), *vals)
-  output_traced = pe.merge_pvals(output_traced, out_pval)
-  output_eval = f(*vals)
-  assert onp.allclose(output_traced, output_eval), \
-      '\neval:         {}\ntrace + eval: {}'.format(output_eval, output_traced)
-
 
 class CoreTest(jtu.JaxTestCase):
-
-  def test_pack_unpack(self):
-    # TODO(dougalm): figure out what jaxpr-tracing api to expose and re-enable
-    self.skipTest("disabled")
-    y = onp.array(1.0)
-    def foo(x):
-      x1, y1 = core.pack((x, y))
-      assert y1 is y, (y1, y)
-      return x1
-
-    pe.trace_to_jaxpr(foo, (_,))
-
-  def test_tup_add(self):
-    # TODO(mattjj,dougalm): put tup_add somewhere (was in array_type.py)
-    self.skipTest("disabled")
-    y = onp.array(1.0)
-    def foo(x):
-      return np.tup_add(core.pack((x, y)))
-
-    pe.trace_to_jaxpr(foo, (_,))
 
   def test_tree_multimap(self):
     xs = ({'a': 1}, [2, 3])
@@ -186,12 +157,6 @@ class CoreTest(jtu.JaxTestCase):
       assert False
     except (TypeError, ValueError):
       pass
-
-  def test_print_jaxpr_compound(self):
-    # TODO(dougalm): figure out what jaxpr-tracing api to expose and re-enable
-    self.skipTest("disabled")
-    pv = pe.PartialVal((ShapedArray((2, 3), onp.float32), core.unit))
-    print(pe.trace_to_jaxpr(fun_with_call_closure, (pv,))[0])
 
   def test_tree_flatten(self):
     flat, _ = tree_flatten(({'a': 1}, [2, 3], 4))
@@ -216,43 +181,10 @@ class CoreTest(jtu.JaxTestCase):
   def test_jvp_zeros(self):
     def foo(x):
       def bar(y):
-        x1, y1 = core.pack((x, y))
-        return np.sin(x1 * y1)
+        return np.sin(x * y)
       return jvp(bar, (3 * x,), (2 * x,))
 
     jtu.check_eq(jit(foo)(0.5), foo(0.5))
-
-  def test_dynamic_subfun_context(self):
-    def foo(x):
-      def bar(y):
-        return np.multiply(np.sin(x), y)
-      return call(bar, x)
-
-    api.trace_to_jaxpr(foo, (__,))
-
-  def test_nested_grad(self):
-    self.skipTest("disabled")  # TODO: re-enable this test.
-    def foo(x):
-      print(type(x), x)
-      def bar(y):
-        return np.cos(y) * x
-      print(x * x)
-      return call(bar, x*x)
-
-    print(api.trace_to_jaxpr(api.grad(foo), (__,)))
-
-  def test_nested(self):
-    def foo(x):
-      def bar(y):
-        def baz(w):
-          q = call(lambda x: y, x) + call(lambda: y)
-          return call(lambda w: call(np.sin, x) * y, 1.0) + q
-        p, t = jvp(baz, (x + 1.0,), (y,))
-        return t + (x * p)
-
-      return call(bar, x)
-
-    api.trace_to_jaxpr(foo, (__,))
 
   @parameterized.parameters(test_specs)
   def test_jvp_linearized(self, f, args):
@@ -277,17 +209,6 @@ class CoreTest(jtu.JaxTestCase):
         return x + y
       return bar(0.0)
     assert jvp(foo, (1.0,), (2.0,)) == (1.0, 2.0)
-
-  def test_simple_trace(self):
-    def foo(x):
-      return np.sin(x) + np.cos(x)
-    pval = pe.PartialVal((ShapedArray((3, 2), onp.float32), core.unit))
-    check_trace_eval(foo, (pval,), (onp.random.randn(3, 2),), pval)
-
-  def test_nullary_trace(self):
-    def foo():
-      return 1.2
-    check_trace_eval(foo, (), (), (None, 1.2))
 
   def test_simple_jit(self):
     def foo(x):

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -88,7 +88,7 @@ class PapplyTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testLogSoftmax(self):
-    return SkipTest("test doesn't pass yet")  # TODO(frostig)
+    raise SkipTest("test doesn't pass yet")  # TODO(frostig)
 
     def fun(x):
       return x - np.log(np.sum(np.exp(x)))
@@ -113,7 +113,7 @@ class PapplyTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testAddBroadcasting(self):
-    return SkipTest("test doesn't pass yet")  # TODO(frostig)
+    raise SkipTest("test doesn't pass yet")  # TODO(frostig)
 
     def fun(x):
       return x + 3
@@ -252,7 +252,7 @@ class ParallelizeTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testDot(self):
-    return SkipTest("known failure")  # TODO(frostig)
+    raise SkipTest("known failure")  # TODO(frostig)
     x = onp.reshape(onp.arange(4., dtype=onp.float32), (2, 2))
 
     def fun(x, y):
@@ -308,8 +308,8 @@ class ParallelizeTest(jtu.JaxTestCase):
         expected = fun(x, y)
         pfun, axis_name = _papply(fun)
         ans = soft_pmap(pfun, axis_name)(x, y)
-    except NotImplementedError as e:
-      return SkipTest(e)
+    except (NotImplementedError, TypeError) as e:
+      raise SkipTest(e)
 
     ans = self.dedup(ans, expected.ndim)
     self.assertAllClose(ans, expected, check_dtypes=False)

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -262,26 +262,6 @@ class PmapTest(jtu.JaxTestCase):
     self.assertEqual((tuple(sorted(groups[0])),),
                      ((0, 1, 2, 3, 4, 5, 6, 7,),))  # order doesn't matter
 
-  def testShardedDeviceTuple(self):
-    f = lambda x: core.pack((x, x))
-    f = pmap(f)
-
-    shape = (xla_bridge.device_count(), 4)
-    x = onp.arange(prod(shape), dtype=onp.float32).reshape(shape)
-
-    # test that we can pass in and out ShardedDeviceTuples (and unpack them)
-    y = f(x)
-    self.assertIsInstance(y, pxla.ShardedDeviceTuple)
-    self.assertIsInstance(y, core.JaxTuple)
-    self.assertAllClose(y, (x, x), check_dtypes=False)
-    z = f(y)
-    self.assertIsInstance(z, pxla.ShardedDeviceTuple)
-    self.assertAllClose(z, (y, y), check_dtypes=True)
-
-    # test that we can pass a ShardedDeviceTuple to a regular jit computation
-    w = jit(lambda x: list(x)[0])(y)
-    self.assertAllClose(w, x, check_dtypes=False)
-
   @jtu.skip_on_devices("cpu", "gpu")
   def testCollectivePermute(self):
     device_count = xla_bridge.device_count()


### PR DESCRIPTION
This PR removes tuples from the jaxpr language, and JaxTuples / AbstractTuples / DeviceTuples / ShardedDeviceTuples from the implementation. Instead of tuples, jaxprs and primitives have multiple outputs.

Here are the main reasons for removing tuples:
1. every tracer needed its own transparent tuple type (e.g. JaxprTracerTuple, TangentTuple) so that packing into a tuple with a traced value didn't irreversibly lift quantities into a trace (e.g. so that tuple pack/unpack didn't cause broadcasting of unmapped values for a vmap trace),
1. allowing jaxpr variables to be bound to tuples meant types (e.g. for linearity, both in the AD sense and the PRNG sense) and lattice representations (e.g. for the initial-style analog of the batched/unbatched problem above) were more complex and the logic dealing with them had recursions everywhere,
1. relatedly, to support `lax.scan`'s mixed linear/nonlinear extensive arguments we had to introduce `pat_fmap` pattern destructuring and `JaxprEqn.restructure`, which polluted all jaxprs and jaxpr interpreters,
1. tuple munging wasn't actually a good way to do bookkeeping in e.g. control flow primitives and was leading to extra jaxpr munging work,
1. tuples basically doubled the number of data types we had to support (e.g. with device-backed versions), including in things like dispatch logic,
1. no user ever wanted to see or learn about JaxTuples, yet it was one of the first things they would encounter in api.py.

So this PR gets rid of them! We also took the opportunity to:
* revise control flow (including a more conservative and efficient vmap-of-while rule, a simpler implementation of `cond`, a removal of all jaxpr eqn munging, better compilation caching, and more modular code)
* make xla.py and pxla.py support the introduction of user-defined types like the rest of the system (to be used in follow-up work on PRNG key linearity checking)
* a cleanup of batching.py utility functions
* de-register None as a pytree so that users can handle it as they like (and e.g. use it as their own sentinel value).

I checked for performance regressions on `pmap` using a benchmark from @hawkinsp and @ibab; in 2 out of my 3 runs it went from ~15.5ms to ~14.5ms, and in the third run they both were ~15ms, so I don't think this presents a significant performance regression (it may already be faster, and in any case I'm optimistic it opens up more opportunities for improvement).

Co-authored by @dougalm, particularly the hard control flow parts. @dougalm also got us started by de-tupling jaxprs and ad.py.

Two things that will probably come in smaller follow-up PRs:
1. look at optimizing the `jit` dispatch path like we did for the `pmap` path, specifically in special-casing the handling of `DeviceArray` as an inlined fast path
2. remove `Primitive.multiple_results` in favor of making all primitives return multiple results (unless there are performance implications, which seems unlikely).