### PR TITLE
Fix README typo, `JAX_ENABLE_x64` -> `JAX_ENABLE_X64`

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Some stand-out gotchas that might surprise NumPy users:
 1. JAX enforces single-precision (32-bit, e.g. `float32`) values by default, and
    to enable double-precision (64-bit, e.g. `float64`) one needs to set the
    `jax_enable_x64` variable **at startup** (or set the environment variable
-   `JAX_ENABLE_x64=True`, see [the Gotchas Notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb#scrollTo=YTktlwTTMgFl))
+   `JAX_ENABLE_X64=True`, see [the Gotchas Notebook](https://colab.research.google.com/github/google/jax/blob/master/notebooks/Common_Gotchas_in_JAX.ipynb#scrollTo=YTktlwTTMgFl))
 2. Some of NumPy's dtype promotion semantics involving a mix of Python scalars
    and NumPy types aren't preserved, namely `np.add(1, np.array([2],
    np.float32)).dtype` is `float64` rather than `float32`.


### PR DESCRIPTION
As title, fix a typo.