### PR TITLE
fix lax.cond with non-zero true_consts

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -304,8 +304,9 @@ def cond(pred, true_operand, true_fun, false_operand, false_fun):
 def _cond_impl(pred, *args, **kwargs):
   true_jaxpr, false_jaxpr, true_nconsts, false_nconsts = split_dict(
       kwargs, ["true_jaxpr", "false_jaxpr", "true_nconsts", "false_nconsts"])
+  true_nops = len(true_jaxpr.in_avals) - true_nconsts
   true_consts, true_ops, false_consts, false_ops = split_list(
-      args, [true_nconsts, len(true_jaxpr.in_avals), false_nconsts])
+      args, [true_nconsts, true_nops, false_nconsts])
 
   if pred:
     return core.jaxpr_as_fun(true_jaxpr)(*(true_consts + true_ops))
@@ -319,7 +320,6 @@ def _cond_translation_rule(c, axis_env, pred, *args, **kwargs):
   true_jaxpr, false_jaxpr, true_nconsts, false_nconsts = split_dict(
       kwargs, ["true_jaxpr", "false_jaxpr", "true_nconsts", "false_nconsts"])
   true_nops = len(true_jaxpr.in_avals) - true_nconsts
-  false_nops = len(false_jaxpr.in_avals) - false_nconsts
   true_consts, true_ops, false_consts, false_ops = split_list(
       args, [true_nconsts, true_nops, false_nconsts])
 


### PR DESCRIPTION
As title, this PR fixes an issue of `lax.cond`. It would be great if some JAX devs add a regression test for this. I can't make a simple repro script for this issue. But I faced errors caused by this issue in some large scripts.