### PR TITLE
ensure DeviceArray.aval is ShapedArray

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -476,6 +476,7 @@ bot = Bot()
 
 class AbstractUnit(AbstractValue):
   def join(self, other): return self
+  def _eq(self, self_traced, other): return get_aval(other) is self
 
 abstract_unit = AbstractUnit()
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -308,12 +308,14 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
   _collect = staticmethod(onp.stack)
 
   def __init__(self, aval, device_buffers):
-    # aval must be a ShapedArray instance, because the aval_mapping rules
-    # return it unmodified.
     self.aval = aval
     self.device_buffers = device_buffers
     self.axis_size = aval.shape[0]
     self._npy_value = None
+    if not core.skip_checks:
+      assert type(aval) is ShapedArray
+      npy_value = self._value
+      assert npy_value.dtype == aval.dtype and npy_value.shape == aval.shape
 
   def _ids(self):
     num_bufs = len(self.device_buffers)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -314,8 +314,6 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
     self._npy_value = None
     if not core.skip_checks:
       assert type(aval) is ShapedArray
-      npy_value = self._value
-      assert npy_value.dtype == aval.dtype and npy_value.shape == aval.shape
 
   def _ids(self):
     num_bufs = len(self.device_buffers)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -44,6 +44,9 @@ FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_debug_nans',
                   strtobool(os.getenv('JAX_DEBUG_NANS', "False")),
                   'Add nan checks to every operation.')
+flags.DEFINE_bool('jax_log_compiles',
+                  strtobool(os.getenv('JAX_LOG_COMPILES', "False")),
+                  'Print a message each time a `jit` computation is compiled.')
 
 def _map(f, *xs): return tuple(map(f, *xs))
 def identity(x): return x
@@ -339,6 +342,8 @@ def _xla_call_impl(fun, *args, **params):
 
 @lu.cache
 def _xla_callable(fun, device_assignment, *abstract_args):
+  if FLAGS.jax_log_compiles:
+    print("Compiling {} for args {}.".format(fun.__name__, abstract_args))
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
   with core.new_master(pe.JaxprTrace, True) as master:
     jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -32,7 +32,7 @@ from .. import ad_util
 from .. import tree_util
 from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, make_shaped_array,
-                               array_types)
+                               array_types, raise_to_shaped)
 from ..core import valid_jaxtype, Literal
 from ..util import partial, partialmethod, cache, safe_map, prod, unzip2
 from ..lib import xla_bridge as xb
@@ -70,7 +70,7 @@ def aval_to_result_handler(aval):
     raise TypeError("No xla_result_handler for type: {}".format(type(aval)))
 xla_result_handlers = {}
 xla_result_handlers[core.AbstractUnit] = lambda _: lambda _: core.unit
-def array_result_handler(aval): return partial(DeviceArray, aval)
+def array_result_handler(aval): return partial(DeviceArray, raise_to_shaped(aval))
 xla_result_handlers[ShapedArray] = array_result_handler
 xla_result_handlers[ConcreteArray] = array_result_handler
 
@@ -483,6 +483,7 @@ class DeviceArray(DeviceValue):
     self.device_buffer = device_buffer
     self._npy_value = None
     if not core.skip_checks:
+      assert type(aval) is ShapedArray
       npy_value = self._value
       assert npy_value.dtype == aval.dtype and npy_value.shape == aval.shape
 

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -141,6 +141,10 @@ class WrappedFun(object):
     self.stores = stores
     self.params = params
 
+  @property
+  def __name__(self):
+    return getattr(self.f, '__name__', '<unnamed wrapped function>')
+
   def wrap(self, gen, gen_args, out_store):
     return WrappedFun(self.f, ((gen, gen_args),) + self.transforms,
                       (out_store,) + self.stores, self.params)


### PR DESCRIPTION
Fixes #1239, which was caused by DeviceArray.aval, and hence xla.abstractify(device_array), being a ConcreteArray, leading to compilation cache misses all the time because those are necessarily cached on id.

This PR also adds the `jax_log_compiles` flag (and the corresponding `JAX_LOG_COMPILES` environment variable) to help us quickly identify these recompile issues in the future.