### PR TITLE
restore the behavior that Nones are pytrees

### DIFF
--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -57,10 +57,10 @@ PYTREES = [
     ((),),
     (([()]),),
     ((1, 2),),
-    (((1, "foo"), ["bar", (3, (), 7)]),),
+    (((1, "foo"), ["bar", (3, None, 7)]),),
     ([3],),
-    ([3, ATuple(foo=(3, ATuple(foo=3, bar=())), bar={"baz": 34})],),
-    ([AnObject(3, (), [4, "foo"])],),
+    ([3, ATuple(foo=(3, ATuple(foo=3, bar=None)), bar={"baz": 34})],),
+    ([AnObject(3, None, [4, "foo"])],),
     ({"a": 1, "b": 2},),
 ]
 
@@ -112,19 +112,19 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual([c0, c1], tree.children())
 
   def testFlattenUpTo(self):
-    _, tree = tree_util.tree_flatten([(1, 2), (), ATuple(foo=3, bar=7)])
+    _, tree = tree_util.tree_flatten([(1, 2), None, ATuple(foo=3, bar=7)])
     if not hasattr(tree, "flatten_up_to"):
       self.skipTest("Test requires Jaxlib >= 0.1.23")
     out = tree.flatten_up_to([({
         "foo": 7
-    }, (3, 4)), (), ATuple(foo=(11, 9), bar=())])
-    self.assertEqual(out, [{"foo": 7}, (3, 4), (11, 9), ()])
+    }, (3, 4)), None, ATuple(foo=(11, 9), bar=None)])
+    self.assertEqual(out, [{"foo": 7}, (3, 4), (11, 9), None])
 
   def testTreeMultimap(self):
     x = ((1, 2), (3, 4, 5))
-    y = (([3], ()), ({"foo": "bar"}, 7, [5, 6]))
+    y = (([3], None), ({"foo": "bar"}, 7, [5, 6]))
     out = tree_util.tree_multimap(lambda *xs: tuple(xs), x, y)
-    self.assertEqual(out, (((1, [3]), (2, ())),
+    self.assertEqual(out, (((1, [3]), (2, None)),
                            ((3, {"foo": "bar"}), (4, 7), (5, [5, 6]))))
 
 


### PR DESCRIPTION
We recently (in #1224) changed pytrees so that Nones were no longer considered empty pytrees (containers) by default. The idea was that users could then use Nones as they see fit. Specifically, a user wanted to reuse our tree-flattening utilities to do things like `tree_flatten((1, (None, 2))` and get `[1, None, 2]` rather than `[1, 2]`. 

But this ended up causing pain for users, for example with code like this:

```python
@jit
def f(x, y=None):
  ...
```

Previously, with Nones registered as pytrees, that would just work as expected because the None (a common sentinel for "optional argument" in Python) would be whisked away by the pytree flattening code used in all our API functions. But when not treating None as an empty pytree, this code results in an error:

```
TypeError: Argument 'None' of type <class 'NoneType'> is not a valid JAX type
```

Basically, not treating Nones as pytrees made a common JAX use case stop working in a surprising way. And the only reason not to treat Nones as pytrees was so that our tree utilities could be reused in other ways. But JAX isn't a pytree library anyway.

This PR reverts the change in #1224  and makes Nones behave as pytrees by default.

(The reason this particular change was included in #1224 is that #1224 removed all of the JAX core's dependence on Nones being pytrees. But while the core doesn't need Nones as pytrees anymore, now we have the above user code reason to make Nones into pytrees!)