### PR TITLE
WIP: use jaxprs for custom_implicit_solve

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1852,9 +1852,9 @@ def _custom_implicit_solve(solve, tangent_solve):
       # return tree_unflatten(solution_tree, f_jvp(*args)[-len(solution):])
       return f_jvp(*args)[-len(solution):]
 
-    grad_func_wrt_params = f_jvp(*tangents)[:-len(solution)]
+    grad_wrt_params = f_jvp(*tangents)[:-len(solution)]
     grad_solution, _ = tree_flatten(tree_map(
-        op.neg, tangent_solve(calc_grad_wrt_solution, grad_func_wrt_params),
+        op.neg, tangent_solve(calc_grad_wrt_solution, grad_wrt_params),
     ))
     return solution, grad_solution
 
@@ -1864,4 +1864,3 @@ def _custom_implicit_solve(solve, tangent_solve):
   ad.primitive_jvps[solve_p] = _wrapped_solve_jvp
 
   return wrapped_solve
-

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -165,7 +165,7 @@ def while_loop(cond_fun, body_fun, init_val):
   if cond_jaxpr.out_avals != [ShapedArray((), onp.bool_)]:
     msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
     raise TypeError(msg.format(cond_jaxpr.out_avals))
-  if not treedef_children(in_tree) == [body_tree]:
+  if not list(treedef_children(in_tree)) == [body_tree]:
     msg = "body_fun output pytree structure must match init_val, got {} and {}."
     raise TypeError(msg.format(body_tree, treedef_children(in_tree)[0]))
   outs = while_p.bind(*itertools.chain(cond_consts, body_consts, init_vals),

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -48,7 +48,7 @@ from .util import unzip2, partial, safe_map
 
 # TODO(phawkins): use the first case unconditionally when the minimum Jaxlib
 # version has been increased to 0.1.23.
-if pytree:
+if False:
 
   def tree_map(f, tree):
     """Map a function over a pytree to produce a new pytree.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -887,7 +887,7 @@ class APITest(jtu.JaxTestCase):
   def test_custom_implicit_solve(self):
 
     def scalar_solve(f, y):
-      return y / f(1.0)
+      return y[0] / f(1.0)[0]
 
     def _binary_search(func, params, low=0.0, high=100.0, tolerance=1e-6):
       def cond(state):
@@ -907,6 +907,9 @@ class APITest(jtu.JaxTestCase):
 
     binary_search = api._custom_implicit_solve(_binary_search, scalar_solve)
     sqrt_cubed = lambda y, x: y ** 2 - x ** 3
+    value = binary_search(sqrt_cubed, 5.0)
+    self.assertAllClose(value, 5 ** 1.5, check_dtypes=False)
+
     value, grad = api.value_and_grad(binary_search, argnums=1)(sqrt_cubed, 5.0)
     self.assertAllClose(value, 5 ** 1.5, check_dtypes=False)
     self.assertAllClose(grad, api.grad(pow)(5.0, 1.5), check_dtypes=False)


### PR DESCRIPTION
Note: this currently fails with a core dump:
```
tests/api_test.py Fatal Python error: Aborted

Current thread 0x00000001199415c0 (most recent call first):
  File "/Users/shoyer/dev/jax/jax/tree_util.py", line 104 in tree_unflatten
  File "/Users/shoyer/dev/jax/jax/api.py", line 1833 in wrapped_solve
  File "/Users/shoyer/dev/jax/jax/linear_util.py", line 165 in call_wrapped
  File "/Users/shoyer/dev/jax/jax/interpreters/partial_eval.py", line 318 in trace_to_jaxpr
  File "/Users/shoyer/dev/jax/jax/interpreters/ad.py", line 94 in linearize
  File "/Users/shoyer/dev/jax/jax/interpreters/ad.py", line 105 in vjp
  File "/Users/shoyer/dev/jax/jax/api.py", line 1047 in vjp
  File "/Users/shoyer/dev/jax/jax/api.py", line 387 in value_and_grad_f
  File "/Users/shoyer/dev/jax/tests/api_test.py", line 913 in test_custom_implicit_solve
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/unittest/case.py", line 615 in run
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/unittest/case.py", line 663 in __call__
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/unittest.py", line 207 in runtest
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 117 in pytest_runtest_call
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 192 in <lambda>
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 220 in from_call
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 192 in call_runtest_hook
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 167 in call_and_report
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 87 in runtestprotocol
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/runner.py", line 72 in pytest_runtest_protocol
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/main.py", line 256 in pytest_runtestloop
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/main.py", line 235 in _main
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/main.py", line 191 in wrap_session
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/main.py", line 228 in pytest_cmdline_main
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 81 in <lambda>
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/manager.py", line 87 in _hookexec
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/pluggy/hooks.py", line 289 in __call__
  File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/_pytest/config/__init__.py", line 77 in main
  File "/Users/shoyer/miniconda3/envs/jax-py37/bin/pytest", line 11 in <module>
Aborted (core dumped)
```

This appears to be bug in the C++ implementation of pytree. If I disable the C++ pytree, I get instead:
```
====================================================== FAILURES ======================================================
_________________________________________ APITest.test_custom_implicit_solve _________________________________________

self = <api_test.APITest testMethod=test_custom_implicit_solve>

    def test_custom_implicit_solve(self):

      def scalar_solve(f, y):
        return y[0] / f(1.0)[0]

      def _binary_search(func, params, low=0.0, high=100.0, tolerance=1e-6):
        def cond(state):
          low, high = state
          return high - low > tolerance

        def body(state):
          low, high = state
          midpoint = 0.5 * (low + high)
          update_upper = func(midpoint, params) > 0
          low = np.where(update_upper, low, midpoint)
          high = np.where(update_upper, midpoint, high)
          return (low, high)

        solution, _ = lax.while_loop(cond, body, (low, high))
        return solution

      binary_search = api._custom_implicit_solve(_binary_search, scalar_solve)
      sqrt_cubed = lambda y, x: y ** 2 - x ** 3
>     value = binary_search(sqrt_cubed, 5.0)

tests/api_test.py:910:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
jax/api.py:1816: in wrapped_solve
    partial(solve, func_from_params_flat), params_tree, params_avals,
jax/lax/lax_control_flow.py:56: in _initial_style_jaxpr
    jaxpr, out_pvals, consts = pe.trace_to_jaxpr(fun, in_pvals, instantiate=True)
jax/interpreters/partial_eval.py:318: in trace_to_jaxpr
    jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
jax/linear_util.py:165: in call_wrapped
    ans = self.f(*args, **dict(self.params, **kwargs))
tests/api_test.py:905: in _binary_search
    solution, _ = lax.while_loop(cond, body, (low, high))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cond_fun = <function APITest.test_custom_implicit_solve.<locals>._binary_search.<locals>.cond at 0x11b4670d0>
body_fun = <function APITest.test_custom_implicit_solve.<locals>._binary_search.<locals>.body at 0x11b467158>
init_val = (0.0, 100.0)

    def while_loop(cond_fun, body_fun, init_val):
      """Call ``body_fun`` repeatedly in a loop while ``cond_fun`` is True.

      The type signature in brief is

      .. code-block:: haskell

        while_loop :: (a -> Bool) -> (a -> a) -> a -> a

      The semantics of ``while_loop`` are given by this Python implementation::

        def while_loop(cond_fun, body_fun, init_val):
          val = init_val
          while cond_fun(val):
            val = body_fun(val)
          return val

      Unlike that Python version, ``while_loop`` is a JAX primitive and is lowered
      to a single XLA While HLO. That makes it useful for reducing compilation times
      for jit-compiled functions, since native Python loop constructs in an ``@jit``
      function are unrolled, leading to large XLA computations.

      Another difference from using Python-native loop constructs is that
      ``while_loop`` is not reverse-mode differentiable because XLA computations
      require static bounds on memory requirements.

      Args:
        cond_fun: function of type ``a -> Bool``.
        body_fun: function of type ``a -> a``.
        init_val: value of type ``a``, a type that can be a scalar, array, or any
          pytree (nested Python tuple/list/dict) thereof, representing the initial
          loop carry value.

      Returns:
        The output from the final iteration of body_fun, of type ``a``.
      """
      init_vals, in_tree = tree_flatten((init_val,))
      init_avals = tuple(_map(_abstractify, init_vals))
      cond_jaxpr, cond_consts, cond_tree = _initial_style_jaxpr(cond_fun, in_tree, init_avals)
      body_jaxpr, body_consts, body_tree = _initial_style_jaxpr(body_fun, in_tree, init_avals)
      if not treedef_is_leaf(cond_tree):
        msg = "cond_fun must return a boolean scalar, but got pytree {}."
        raise TypeError(msg.format(cond_tree))
      if cond_jaxpr.out_avals != [ShapedArray((), onp.bool_)]:
        msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
        raise TypeError(msg.format(cond_jaxpr.out_avals))
      if not treedef_children(in_tree) == [body_tree]:
        msg = "body_fun output pytree structure must match init_val, got {} and {}."
>       raise TypeError(msg.format(body_tree, treedef_children(in_tree)[0]))
E       TypeError: body_fun output pytree structure must match init_val, got PyTree(<class 'tuple'>, [*,*]) and PyTree(<class 'tuple'>, [*,*]).

jax/lax/lax_control_flow.py:170: TypeError
```