### PR TITLE
Add np.gradient

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -692,9 +692,13 @@ def _gradient_along_axis(a, axis):
 
 @_wraps(onp.gradient)
 def gradient(a, axis=None):
+  if min(a.shape) < 2:
+    raise ValueError(
+      "Shape of array too small to calculate a numerical gradient")
+
   if axis is None:
-    axis = list(range(a.ndim))
-  elif type(axis) is int:
+    axis = range(a.ndim)
+  elif isinstance(axis, int):
     axis = [axis]
 
   a_grad = stack([_gradient_along_axis(a, ax) for ax in axis], axis=0)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -680,6 +680,31 @@ def diff(a, n=1, axis=-1,):
   return a
 
 
+def _gradient_along_axis(a, axis):
+  a_swap = swapaxes(a, 0, axis)
+  a_grad = concatenate((
+    (a_swap[1]  - a_swap[0])[newaxis],
+    (a_swap[2:] - a_swap[:-2]) * 0.5,
+    (a_swap[-1] - a_swap[-2])[newaxis]
+    ), axis=0)
+  return swapaxes(a_grad, 0, axis)
+
+
+@_wraps(onp.gradient)
+def gradient(a, axis=None):
+  if axis is None:
+    axis = list(range(a.ndim))
+  elif type(axis) is int:
+    axis = [axis]
+
+  a_grad = stack([_gradient_along_axis(a, ax) for ax in axis], axis=0)
+
+  if len(axis) == 1:
+    a_grad = a_grad[0]
+
+  return a_grad
+
+
 @_wraps(onp.isrealobj)
 def isrealobj(a):
   return not iscomplexobj(a)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -169,6 +169,7 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero(), ["rev"]),
     op_record("where", 3, (onp.float32, onp.int64), all_shapes, jtu.rand_some_zero(), []),
     op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default(), ["rev"]),
+    op_record("gradient", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default(), []),
 ]
 
 JAX_BITWISE_OP_RECORDS = [


### PR DESCRIPTION
I added support for `numpy.gradient`. There are a couple of issues with this PR:

1. It only supports the `axis` keyword
2. Need for auxiliary function `_gradient_along_axis`
3. The tests don't succeed

I am interested in your opinion about 1 and 2. 

Concerning 3, I see two problems:
3.1 `onp.gradient` only accepts arrays where the regarding axes are at least of length 2. This is not the case in the existing testing shapes `nonempty_nonscalar_array_shapes`.
3.2 `onp.gradient` returns a list of arrays. Even if I change `nonempty_nonscalar_array_shapes` to be large enough everywhere, this causes `self.assertTrue(hasattr(y, '__array__') or onp.isscalar(y))` to fail. 

This snippet at least confirms the functionality of the code:

```python
import numpy as onp
import jax
import jax.numpy as np

x = onp.random.rand(20, 30, 10, 15).astype(onp.float32)
y = np.array(x)

for axis in [None, 0, 1, 2, -1, -2, (0, 1), (0, -1), (-2, -1), (1, 3), (3, 1)]:
    xg = onp.array(onp.gradient(x, axis=axis))
    yg = np.gradient(y, axis=axis)

    assert onp.allclose(xg, yg)
```