### PR TITLE
Migrate initializers and activation functions to jax.nn

### DIFF
--- a/docs/jax.nn.initializers.rst
+++ b/docs/jax.nn.initializers.rst
@@ -1,0 +1,29 @@
+
+jax.nn.initializers package
+===========================
+
+.. currentmodule:: jax.nn.initializers
+
+.. automodule:: jax.nn.initializers
+
+
+Initializers
+------------
+
+This module provides common neural network layer initializers,
+consistent with definitions used in Keras and Sonnet.
+
+.. autosummary::
+  :toctree: _autosummary
+
+    zeros
+    ones
+    uniform
+    normal
+    variance_scaling
+    glorot_uniform
+    glorot_normal
+    lecun_uniform
+    lecun_normal
+    he_uniform
+    he_normal

--- a/docs/jax.nn.rst
+++ b/docs/jax.nn.rst
@@ -1,0 +1,42 @@
+
+jax.nn package
+=================
+
+.. currentmodule:: jax.nn
+
+.. toctree::
+    :maxdepth: 1
+
+    jax.nn.initializers
+
+.. automodule:: jax.nn
+
+
+Activation functions
+------------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    relu
+    sigmoid
+    softplus
+    soft_sign
+    swish
+    log_sigmoid
+    leaky_relu
+    hard_tanh
+    elu
+    celu
+    selu
+    gelu
+
+Other functions
+---------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    softmax
+    log_softmax
+    normalize

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -13,6 +13,7 @@ Subpackages
     jax.scipy
     jax.experimental
     jax.lax
+    jax.nn
     jax.ops
     jax.random
     jax.tree_util

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -30,59 +30,19 @@ from six.moves import reduce
 
 from jax import lax
 from jax import random
-from jax.scipy.special import logsumexp, expit
 import jax.numpy as np
 
+from jax.nn import *
+
+# aliases for backwards compatibility
+glorot = initializers.glorot_normal
+randn = initializers.normal
+zeros = initializers.zeros
+ones = initializers.ones
 
 # Following the convention used in Keras and tf.layers, we use CamelCase for the
 # names of layer constructors, like Conv and Relu, while using snake_case for
 # other functions, like lax.conv and relu.
-
-
-def relu(x): return np.maximum(x, 0.)
-def softplus(x): return np.logaddexp(x, 0.)
-def sigmoid(x): return expit(x)
-def elu(x): return np.where(x > 0, x, np.expm1(x))
-def leaky_relu(x): return np.where(x >= 0, x, 0.01 * x)
-
-def logsoftmax(x, axis=-1):
-  """Apply log softmax to an array of logits, log-normalizing along an axis."""
-  return x - logsumexp(x, axis, keepdims=True)
-
-def softmax(x, axis=-1):
-  """Apply softmax to an array of logits, exponentiating and normalizing along an axis."""
-  unnormalized = np.exp(x - x.max(axis, keepdims=True))
-  return unnormalized / unnormalized.sum(axis, keepdims=True)
-
-def fastvar(x, axis, keepdims):
-  """A fast but less numerically-stable variance calculation than np.var."""
-  return np.mean(x**2, axis, keepdims=keepdims) - np.mean(x, axis, keepdims=keepdims)**2
-
-
-# Initializers
-
-def randn(stddev=1e-2):
-  """An initializer function for random normal coefficients."""
-  def init(rng, shape):
-    std = lax.convert_element_type(stddev, np.float32)
-    return std * random.normal(rng, shape, dtype=np.float32)
-  return init
-
-def glorot(out_axis=0, in_axis=1, scale=onp.sqrt(2)):
-  """An initializer function for random Glorot-scaled coefficients."""
-  def init(rng, shape):
-    fan_in, fan_out = shape[in_axis], shape[out_axis]
-    size = onp.prod(onp.delete(shape, [in_axis, out_axis]))
-    std = scale / np.sqrt((fan_in + fan_out) / 2. * size)
-    std = lax.convert_element_type(std, np.float32)
-    return std * random.normal(rng, shape, dtype=np.float32)
-  return init
-
-zeros = lambda rng, shape: np.zeros(shape, dtype='float32')
-ones = lambda rng, shape: np.ones(shape, dtype='float32')
-
-
-# Layers
 
 # Each layer constructor function returns an (init_fun, apply_fun) pair, where
 #   init_fun: takes an rng key and an input shape and returns an
@@ -90,7 +50,7 @@ ones = lambda rng, shape: np.ones(shape, dtype='float32')
 #   apply_fun: takes params, inputs, and an rng key and applies the layer.
 
 
-def Dense(out_dim, W_init=glorot(), b_init=randn()):
+def Dense(out_dim, W_init=initializers.glorot_normal(), b_init=initializers.normal()):
   """Layer constructor function for a dense (fully-connected) layer."""
   def init_fun(rng, input_shape):
     output_shape = input_shape[:-1] + (out_dim,)
@@ -104,12 +64,14 @@ def Dense(out_dim, W_init=glorot(), b_init=randn()):
 
 
 def GeneralConv(dimension_numbers, out_chan, filter_shape,
-                strides=None, padding='VALID', W_init=None, b_init=randn(1e-6)):
+                strides=None, padding='VALID', W_init=None,
+                b_init=initializers.normal(1e-6)):
   """Layer construction function for a general convolution layer."""
   lhs_spec, rhs_spec, out_spec = dimension_numbers
   one = (1,) * len(filter_shape)
   strides = strides or one
-  W_init = W_init or glorot(rhs_spec.index('O'), rhs_spec.index('I'))
+  W_init = W_init or initializers.glorot_normal(rhs_spec.index('I'),
+                                                rhs_spec.index('O'))
   def init_fun(rng, input_shape):
     filter_shape_iter = iter(filter_shape)
     kernel_shape = [out_chan if c == 'O' else
@@ -132,7 +94,7 @@ Conv = functools.partial(GeneralConv, ('NHWC', 'HWIO', 'NHWC'))
 
 def GeneralConvTranspose(dimension_numbers, out_chan, filter_shape,
                          strides=None, padding='VALID', W_init=None,
-                         b_init=randn(1e-6)):
+                         b_init=initializers.normal(1e-6)):
   """Layer construction function for a general transposed-convolution layer."""
   lhs_spec, rhs_spec, out_spec = dimension_numbers
   one = (1,) * len(filter_shape)
@@ -178,8 +140,7 @@ def BatchNorm(axis=(0, 1, 2), epsilon=1e-5, center=True, scale=True,
     ed = tuple(None if i in axis else slice(None) for i in range(np.ndim(x)))
     beta = beta[ed]
     gamma = gamma[ed]
-    mean, var = np.mean(x, axis, keepdims=True), fastvar(x, axis, keepdims=True)
-    z = (x - mean) / np.sqrt(var + epsilon)
+    z = normalize(x, axis, epsilon=epsilon)
     if center and scale: return gamma * z + beta
     if center: return z + beta
     if scale: return gamma * z
@@ -195,12 +156,14 @@ def elementwise(fun, **fun_kwargs):
 Tanh = elementwise(np.tanh)
 Relu = elementwise(relu)
 Exp = elementwise(np.exp)
-LogSoftmax = elementwise(logsoftmax, axis=-1)
+LogSoftmax = elementwise(log_softmax, axis=-1)
 Softmax = elementwise(softmax, axis=-1)
 Softplus = elementwise(softplus)
 Sigmoid = elementwise(sigmoid)
 Elu = elementwise(elu)
 LeakyRelu = elementwise(leaky_relu)
+Selu = elementwise(selu)
+Gelu = elementwise(gelu)
 
 
 def _pooling_layer(reducer, init_val, rescaler=None):

--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,78 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common neural network activations and other functions."""
-
-from __future__ import absolute_import
-from __future__ import division
-
-import numpy as onp
-
-from jax import lax
-from jax import random
-from jax.scipy.special import expit
-import jax.numpy as np
-from jax import jarrett
+"""Common functions for neural network libraries."""
 
 from . import initializers
-
-# activations
-
-def relu(x): return np.maximum(x, 0)
-def softplus(x): return np.logaddexp(x, 0)
-def soft_sign(x): return x / (np.abs(x) + 1)
-def sigmoid(x): return expit(x)
-def swish(x): return x * sigmoid(x)
-def log_sigmoid(x): return -softplus(-x)
-
-def elu(x, alpha=1.0):
-  return np.where(x > 0, x, alpha * np.expm1(x))
-
-def leaky_relu(x, negative_slope=1e-2):
-  return np.where(x >= 0, x, negative_slope * x)
-
-def hard_tanh(x):
-  return np.where(x > 1, 1, np.where(x < -1, -1, x))
-
-def celu(x, alpha=1.0):
-  """Continuously-differentiable exponential linear unit activation"""
-  return np.where(x > 0, x, alpha * np.expm1(x / alpha))
-
-def selu(x):
-  """Scaled exponential linear unit activation"""
-  alpha = 1.6732632423543772848170429916717
-  scale = 1.0507009873554804934193349852946
-  return scale * leaky_relu(x, alpha)
-
-@jarrett
-def gelu(x):
-  """Gaussian error linear unit activation"""
-  return x * (lax.erf(x / np.sqrt(2)) + 1) / 2
-
-def glu(x, axis=-1):
-  """Gated linear unit activation"""
-  size = x.shape[axis]
-  assert size % 2 == 0, "axis size must be divisible by 2"
-  return x[..., :size] * sigmoid(x[..., size:])
-
-# other functions
-
-def log_softmax(x, axis=-1):
-  shifted = x - x.max(axis, keepdims=True)
-  return shifted - np.log(np.sum(np.exp(shifted), axis, keepdims=True))
-
-def softmax(x, axis=-1):
-  unnormalized = np.exp(x - x.max(axis, keepdims=True))
-  return unnormalized / unnormalized.sum(axis, keepdims=True)
-
-def normalize(x, axis=-1, mean=None, variance=None, epsilon=1e-5):
-  """Normalize an array by subtracting mean and dividing by sqrt(var)."""
-  if mean is None:
-    mean = np.mean(x, axis, keepdims=True)
-  if variance is None:
-    # this definition is traditionally seen as less accurate than np.var's
-    # mean((x - mean(x))**2) but may be faster and even, given typical
-    # activation distributions and low-precision arithmetic, more accurate
-    # when used in neural network normalization layers
-    variance = np.mean(x**2, axis, keepdims=True) - mean**2
-  return (x - mean) * lax.rsqrt(variance + epsilon)
+from .functions import *

--- a/jax/nn/__init__.py
+++ b/jax/nn/__init__.py
@@ -1,0 +1,89 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common neural network activations and other functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+
+import numpy as onp
+
+from jax import lax
+from jax import random
+from jax.scipy.special import expit
+import jax.numpy as np
+from jax import jarrett
+
+from . import initializers
+
+# activations
+
+def relu(x): return np.maximum(x, 0)
+def softplus(x): return np.logaddexp(x, 0)
+def soft_sign(x): return x / (np.abs(x) + 1)
+def sigmoid(x): return expit(x)
+def swish(x): return x * sigmoid(x)
+def log_sigmoid(x): return -softplus(-x)
+
+def elu(x, alpha=1.0):
+  return np.where(x > 0, x, alpha * np.expm1(x))
+
+def leaky_relu(x, negative_slope=1e-2):
+  return np.where(x >= 0, x, negative_slope * x)
+
+def hard_tanh(x):
+  return np.where(x > 1, 1, np.where(x < -1, -1, x))
+
+def celu(x, alpha=1.0):
+  """Continuously-differentiable exponential linear unit activation"""
+  return np.where(x > 0, x, alpha * np.expm1(x / alpha))
+
+def selu(x):
+  """Scaled exponential linear unit activation"""
+  alpha = 1.6732632423543772848170429916717
+  scale = 1.0507009873554804934193349852946
+  return scale * leaky_relu(x, alpha)
+
+@jarrett
+def gelu(x):
+  """Gaussian error linear unit activation"""
+  return x * (lax.erf(x / np.sqrt(2)) + 1) / 2
+
+def glu(x, axis=-1):
+  """Gated linear unit activation"""
+  size = x.shape[axis]
+  assert size % 2 == 0, "axis size must be divisible by 2"
+  return x[..., :size] * sigmoid(x[..., size:])
+
+# other functions
+
+def log_softmax(x, axis=-1):
+  shifted = x - x.max(axis, keepdims=True)
+  return shifted - np.log(np.sum(np.exp(shifted), axis, keepdims=True))
+
+def softmax(x, axis=-1):
+  unnormalized = np.exp(x - x.max(axis, keepdims=True))
+  return unnormalized / unnormalized.sum(axis, keepdims=True)
+
+def normalize(x, axis=-1, mean=None, variance=None, epsilon=1e-5):
+  """Normalize an array by subtracting mean and dividing by sqrt(var)."""
+  if mean is None:
+    mean = np.mean(x, axis, keepdims=True)
+  if variance is None:
+    # this definition is traditionally seen as less accurate than np.var's
+    # mean((x - mean(x))**2) but may be faster and even, given typical
+    # activation distributions and low-precision arithmetic, more accurate
+    # when used in neural network normalization layers
+    variance = np.mean(x**2, axis, keepdims=True) - mean**2
+  return (x - mean) * lax.rsqrt(variance + epsilon)

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -1,0 +1,87 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared neural network activations and other functions."""
+
+from __future__ import absolute_import
+from __future__ import division
+
+import numpy as onp
+
+from jax import lax
+from jax import random
+from jax.scipy.special import expit
+import jax.numpy as np
+from jax import jarrett
+
+# activations
+
+def relu(x): return np.maximum(x, 0)
+def softplus(x): return np.logaddexp(x, 0)
+def soft_sign(x): return x / (np.abs(x) + 1)
+def sigmoid(x): return expit(x)
+def swish(x): return x * sigmoid(x)
+def log_sigmoid(x): return -softplus(-x)
+
+def elu(x, alpha=1.0):
+  return np.where(x > 0, x, alpha * np.expm1(x))
+
+def leaky_relu(x, negative_slope=1e-2):
+  return np.where(x >= 0, x, negative_slope * x)
+
+def hard_tanh(x):
+  return np.where(x > 1, 1, np.where(x < -1, -1, x))
+
+def celu(x, alpha=1.0):
+  """Continuously-differentiable exponential linear unit activation"""
+  return np.where(x > 0, x, alpha * np.expm1(x / alpha))
+
+def selu(x):
+  """Scaled exponential linear unit activation"""
+  alpha = 1.6732632423543772848170429916717
+  scale = 1.0507009873554804934193349852946
+  return scale * leaky_relu(x, alpha)
+
+@jarrett
+def gelu(x):
+  """Gaussian error linear unit activation"""
+  return x * (lax.erf(x / np.sqrt(2)) + 1) / 2
+
+def glu(x, axis=-1):
+  """Gated linear unit activation"""
+  size = x.shape[axis]
+  assert size % 2 == 0, "axis size must be divisible by 2"
+  return x[..., :size] * sigmoid(x[..., size:])
+
+# other functions
+
+def log_softmax(x, axis=-1):
+  shifted = x - x.max(axis, keepdims=True)
+  return shifted - np.log(np.sum(np.exp(shifted), axis, keepdims=True))
+
+def softmax(x, axis=-1):
+  unnormalized = np.exp(x - x.max(axis, keepdims=True))
+  return unnormalized / unnormalized.sum(axis, keepdims=True)
+
+def normalize(x, axis=-1, mean=None, variance=None, epsilon=1e-5):
+  """Normalize an array by subtracting mean and dividing by sqrt(var)."""
+  if mean is None:
+    mean = np.mean(x, axis, keepdims=True)
+  if variance is None:
+    # this definition is traditionally seen as less accurate than np.var's
+    # mean((x - mean(x))**2) but may be faster and even, given typical
+    # activation distributions and low-precision arithmetic, more accurate
+    # when used in neural network normalization layers
+    variance = np.mean(x**2, axis, keepdims=True) - mean**2
+  return (x - mean) * lax.rsqrt(variance + epsilon)

--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -1,0 +1,74 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common neural network layer initializers, consistent with definitions
+used in Keras and Sonnet.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+
+from functools import partial
+
+import numpy as onp
+
+from jax import lax
+from jax import random
+import jax.numpy as np
+
+def zeros(key, shape, dtype=np.float32): return np.zeros(shape, dtype)
+def ones(key, shape, dtype=np.float32): return np.ones(shape, dtype)
+
+def uniform(scale=1e-2):
+  def init(key, shape, dtype=np.float32):
+    return random.uniform(key, shape, dtype) * scale
+  return init
+
+def normal(stddev=1e-2):
+  def init(key, shape, dtype=np.float32):
+    return random.normal(key, shape, dtype) * stddev
+  return init
+
+def _compute_fans(shape, in_axis=-2, out_axis=-1):
+  receptive_field_size = onp.prod(shape) / shape[in_axis] / shape[out_axis]
+  fan_in = shape[in_axis] * receptive_field_size
+  fan_out = shape[out_axis] * receptive_field_size
+  return fan_in, fan_out
+
+def variance_scaling(scale, mode, distribution, in_axis=-2, out_axis=-1):
+  def init(key, shape, dtype=np.float32):
+    variance = scale
+    fan_in, fan_out = _compute_fans(shape, in_axis, out_axis)
+    if mode == "fan_in": variance /= fan_in
+    elif mode == "fan_out": variance /= fan_out
+    elif mode == "fan_avg": variance /= (fan_in + fan_out) / 2
+    else: raise ValueError("invalid mode for variance scaling initializer")
+    if distribution == "truncated_normal":
+      # constant is stddev of standard normal truncated to (-2, 2)
+      stddev = onp.sqrt(variance) / .87962566103423978
+      return random.truncated_normal(key, -2, 2, shape, dtype) * stddev
+    elif distribution == "normal":
+      return random.normal(key, shape, dtype) * onp.sqrt(variance)
+    elif distribution == "uniform":
+      return random.uniform(key, shape, dtype, -1) * onp.sqrt(3 * variance)
+    else:
+      raise ValueError("invalid distribution for variance scaling initializer")
+  return init
+
+glorot_uniform = partial(variance_scaling, 1.0, "fan_avg", "uniform")
+glorot_normal = partial(variance_scaling, 1.0, "fan_avg", "truncated_normal")
+lecun_uniform = partial(variance_scaling, 1.0, "fan_in", "uniform")
+lecun_normal = partial(variance_scaling, 1.0, "fan_in", "truncated_normal")
+kaiming_uniform = he_uniform = partial(variance_scaling, 2.0, "fan_in", "uniform")
+kaiming_normal = he_normal = partial(variance_scaling, 2.0, "fan_in", "truncated_normal")

--- a/jax/random.py
+++ b/jax/random.py
@@ -383,6 +383,34 @@ def _normal(key, shape, dtype):
   return onp.array(onp.sqrt(2), dtype) * lax.erf_inv(u)
 
 
+def truncated_normal(key, lower, upper, shape=(), dtype=onp.float64):
+  """Sample truncated standard normal random values with given shape and float
+  dtype.
+
+  Args:
+    key: a PRNGKey used as the random key.
+    lower: a lower bound for truncation.
+    upper: an upper bound for truncation.
+    shape: a tuple of nonnegative integers representing the shape.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+
+  Returns:
+    A random array with the specified shape and dtype.
+  """
+  dtype = xla_bridge.canonicalize_dtype(dtype)
+  return _truncated_normal(key, lower, upper, shape, dtype)
+
+@partial(jit, static_argnums=(3, 4))
+def _truncated_normal(key, lower, upper, shape, dtype):
+  _check_shape("truncated_normal", shape)
+  sqrt2 = onp.sqrt(2)
+  a = lax.erf(lower / sqrt2)
+  b = lax.erf(upper / sqrt2)
+  u = uniform(key, shape, dtype)
+  return sqrt2 * lax.erf_inv(a + u * (b - a))
+
+
 def bernoulli(key, p=onp.float32(0.5), shape=()):
   """Sample Bernoulli random values with given shape and mean.
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -384,13 +384,12 @@ def _normal(key, shape, dtype):
 
 
 def truncated_normal(key, lower, upper, shape=(), dtype=onp.float64):
-  """Sample truncated standard normal random values with given shape and float
-  dtype.
+  """Sample truncated standard normal random values with given shape and dtype.
 
   Args:
     key: a PRNGKey used as the random key.
-    lower: a lower bound for truncation.
-    upper: an upper bound for truncation.
+    lower: a floating-point lower bound for truncation.
+    upper: a floating-point upper bound for truncation.
     shape: a tuple of nonnegative integers representing the shape.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
@@ -404,9 +403,9 @@ def truncated_normal(key, lower, upper, shape=(), dtype=onp.float64):
 @partial(jit, static_argnums=(3, 4))
 def _truncated_normal(key, lower, upper, shape, dtype):
   _check_shape("truncated_normal", shape)
-  sqrt2 = onp.sqrt(2)
-  a = lax.erf(lower / sqrt2)
-  b = lax.erf(upper / sqrt2)
+  sqrt2 = onp.array(onp.sqrt(2), dtype)
+  a = lax.erf(lax.convert_element_type(lower, dtype) / sqrt2)
+  b = lax.erf(lax.convert_element_type(upper, dtype) / sqrt2)
   u = uniform(key, shape, dtype)
   return sqrt2 * lax.erf_inv(a + u * (b - a))
 


### PR DESCRIPTION
This PR does a few things:

- Adds a simple truncated normal sampler, which I've manually verified does the right thing for inputs in the regime relevant to neural net initialization (I'm still a little afraid that the special cases I've seen in other truncated normal implementations are important, but I'm fairly confident that they're not needed for initializers).
- Adds a `jax.nn` namespace to centralize/official-ize the location of shared neural net-related functions.
- Puts implementations of standard initializers, activation functions, and a couple other things there. The goal is to have one place with reliable semantics and numerics; I'm not yet sure what kinds of tests to add to make sure that stays the case.
- Updates the `log_softmax` implementation to fix a numerical issue seen internally.
- Updates stax to use `jax.nn`, hopefully without breaking users.
- Adds docs for `jax.nn`.

Closes #1194 and #1195, re-closes #985. 