### PR TITLE
Use np.eye instead of onp.eye in quickstart notebook.

### DIFF
--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -385,7 +385,7 @@
         "def first_finite_differences(f, x):\n",
         "  eps = 1e-3\n",
         "  return np.array([(f(x + eps * v) - f(x - eps * v)) / (2 * eps)\n",
-        "                   for v in onp.eye(len(x))])\n",
+        "                   for v in np.eye(len(x))])\n",
         "\n",
         "\n",
         "print(first_finite_differences(sum_logistic, x_small))"


### PR DESCRIPTION
JAX supports np.eye, so no need to fall back to onp.