### PR TITLE
Implement batched singular value decomposition.

### DIFF
--- a/jaxlib/cusolver.py
+++ b/jaxlib/cusolver.py
@@ -271,27 +271,64 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
   """Singular value decomposition."""
 
   a_shape = c.GetShape(a)
+  dims = a_shape.dimensions()
   dtype = a_shape.element_type()
-  b = 1
-  m, n = a_shape.dimensions()
-  singular_vals_dtype = _real_type(dtype)
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  b = _prod(batch_dims)
+  singular_vals_dtype = np.dtype(_real_type(dtype))
 
-  if m < n:
+  if m < 32 and n < 32:
+    lwork, opaque = cusolver_kernels.build_gesvdj_descriptor(
+        np.dtype(dtype), b, m, n, compute_uv)
+    scalar_layout = tuple(range(num_bd - 1, -1, -1))
+    vector_layout = (num_bd,) + scalar_layout
+    matrix_layout = (num_bd, num_bd + 1) + scalar_layout
+    out = c.CustomCall(
+        b"cusolver_gesvdj",
+        operands=(a,),
+        shape_with_layout=_Shape.tuple_shape((
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n),),
+                               vector_layout),
+            _Shape.array_shape(dtype, batch_dims + (m, m), matrix_layout),
+            _Shape.array_shape(dtype, batch_dims + (n, n), matrix_layout),
+            _Shape.array_shape(np.dtype(np.int32), batch_dims, scalar_layout),
+            _Shape.array_shape(dtype, (lwork,), (0,)),
+        )),
+        operand_shapes_with_layout=(
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
+        ),
+        opaque=opaque)
+    s = c.GetTupleElement(out, 1)
+    u = c.GetTupleElement(out, 2)
+    v = c.GetTupleElement(out, 3)
+    info = c.GetTupleElement(out, 4)
+    vt = c.Transpose(v, tuple(range(num_bd)) + (num_bd + 1, num_bd))
+    if np.issubdtype(dtype, np.complexfloating):
+      vt = c.Conj(vt)
+  elif m < n:
     lwork, opaque = cusolver_kernels.build_gesvd_descriptor(
         np.dtype(dtype), b, n, m, compute_uv, full_matrices)
+    scalar_layout = tuple(range(num_bd - 1, -1, -1))
+    vector_layout = (num_bd,) + scalar_layout
+    matrix_layout = (num_bd + 1, num_bd) + scalar_layout
     out = c.CustomCall(
         b"cusolver_gesvd",
         operands=(a,),
         shape_with_layout=_Shape.tuple_shape((
-            _Shape.array_shape(dtype, (m, n), (1, 0)),
-            _Shape.array_shape(np.dtype(singular_vals_dtype), (min(m, n),), (0,)),
-            _Shape.array_shape(dtype, (n, n), (1, 0)),
-            _Shape.array_shape(dtype, (m, m), (1, 0)),
-            _Shape.array_shape(np.dtype(np.int32), (), ()),
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n),),
+                               vector_layout),
+            _Shape.array_shape(dtype, batch_dims + (n, n), matrix_layout),
+            _Shape.array_shape(dtype, batch_dims + (m, m), matrix_layout),
+            _Shape.array_shape(np.dtype(np.int32), batch_dims, scalar_layout),
             _Shape.array_shape(dtype, (lwork,), (0,)),
         )),
         operand_shapes_with_layout=(
-            _Shape.array_shape(dtype, (m, n), (1, 0)),
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
         ),
         opaque=opaque)
     s = c.GetTupleElement(out, 1)
@@ -302,19 +339,23 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
     lwork, opaque = cusolver_kernels.build_gesvd_descriptor(
         np.dtype(dtype), b, m, n, compute_uv, full_matrices)
 
+    scalar_layout = tuple(range(num_bd - 1, -1, -1))
+    vector_layout = (num_bd,) + scalar_layout
+    matrix_layout = (num_bd, num_bd + 1) + scalar_layout
     out = c.CustomCall(
         b"cusolver_gesvd",
         operands=(a,),
         shape_with_layout=_Shape.tuple_shape((
-            _Shape.array_shape(dtype, (m, n), (0, 1)),
-            _Shape.array_shape(np.dtype(singular_vals_dtype), (min(m, n),), (0,)),
-            _Shape.array_shape(dtype, (m, m), (0, 1)),
-            _Shape.array_shape(dtype, (n, n), (0, 1)),
-            _Shape.array_shape(np.dtype(np.int32), (), ()),
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n),),
+                               vector_layout),
+            _Shape.array_shape(dtype, batch_dims + (m, m), matrix_layout),
+            _Shape.array_shape(dtype, batch_dims + (n, n), matrix_layout),
+            _Shape.array_shape(np.dtype(np.int32), batch_dims, scalar_layout),
             _Shape.array_shape(dtype, (lwork,), (0,)),
         )),
         operand_shapes_with_layout=(
-            _Shape.array_shape(dtype, (m, n), (0, 1)),
+            _Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
         ),
         opaque=opaque)
     s = c.GetTupleElement(out, 1)
@@ -322,6 +363,6 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
     vt = c.GetTupleElement(out, 3)
     info = c.GetTupleElement(out, 4)
   if not full_matrices:
-    u = c.Slice(u, (0, 0), (m, min(m, n)))
-    vt = c.Slice(vt, (0, 0), (min(m, n), n))
+    u = c.Slice(u, (0,) * len(dims), batch_dims + (m, min(m, n)))
+    vt = c.Slice(vt, (0,) * len(dims), batch_dims + (min(m, n), n))
   return s, u, vt, info

--- a/jaxlib/lapack.pyx
+++ b/jaxlib/lapack.pyx
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
+# cython: language_level=2
 # distutils: language = c++
 
 # Shims that allow the XLA CPU backend to call scipy-provided LAPACK kernels
@@ -22,6 +23,7 @@ from __future__ import print_function
 from libc.stdlib cimport malloc, free
 from libc.stdint cimport int32_t
 from libc.string cimport memcpy
+from libcpp cimport bool as bool_t
 from libcpp.string cimport string
 from cpython.pycapsule cimport PyCapsule_New
 
@@ -872,12 +874,36 @@ cdef int cgesdd_rwork_size(int m, int n, int compute_uv) nogil:
   cdef int mx = max(m, n)
   return max(5 * mn * mn + 5 * mn, 2 * mx * mn + 2 * mn * mn + mn)
 
+cdef char gesdd_jobz(bool_t job_opt_compute_uv,
+                     bool_t job_opt_full_matrices) nogil:
+  # define appropriate job code
+  cdef char jobz = 'A'
+  if job_opt_compute_uv == 0:
+    jobz = 'N'
+  else:
+    if job_opt_full_matrices == 0:
+      jobz = 'S'
+  return jobz
+
+cdef int sgesdd_work_size(int m, int n, bool_t job_opt_compute_uv,
+                          bool_t job_opt_full_matrices):
+  cdef float work
+  cdef int lwork = -1
+  cdef int info
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
+  sgesdd(&jobz, &m, &n, NULL, &m, NULL, NULL, &m, NULL, &ldvt, &work,
+         &lwork, NULL, &info)
+  return <int>(work) if info == 0 else -1
+
 cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
   cdef int32_t job_opt_full_matrices = (<int32_t*>(data[0]))[0]
   cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
-  cdef int m = (<int32_t*>(data[2]))[0]
-  cdef int n = (<int32_t*>(data[3]))[0]
-  cdef float* a_in = <float*>(data[4])
+  cdef int b = (<int32_t*>(data[2]))[0]
+  cdef int m = (<int32_t*>(data[3]))[0]
+  cdef int n = (<int32_t*>(data[4]))[0]
+  cdef int lwork = (<int32_t*>(data[5]))[0]
+  cdef float* a_in = <float*>(data[6])
 
   cdef void** out = <void**>(out_tuple)
   cdef float* a_out = <float*>(out[0])
@@ -886,46 +912,49 @@ cdef void lapack_sgesdd(void* out_tuple, void** data) nogil:
   cdef float* vt = <float*>(out[3])
   cdef int* info = <int*>(out[4])
   cdef int* iwork = <int*>(out[5])
+  cdef float* work = <float*>(out[6])
 
   if a_out != a_in:
-    memcpy(a_out, a_in, m * n * sizeof(float))
+    memcpy(a_out, a_in, b * m * n * sizeof(float))
 
-  # define appropriate job code
-  cdef char jobz = 'A'
-  if job_opt_compute_uv == 0:
-    jobz = 'N'
-  else:
-    if job_opt_full_matrices == 0:
-      jobz = 'S'
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
 
   cdef int lda = m
   cdef int ldu = m
-  cdef int ldvt = n
-  if job_opt_full_matrices == 0:
-    ldvt = min(m, n)
+  cdef int tdu = min(m, n) if job_opt_full_matrices == 0 else m
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
 
-  # First perform a workspace query to get the optimal lwork
-  # NB: We perform a workspace query with malloc and free for the work array, 
-  # because it is officially recommended in the LAPACK documentation
-  cdef float wkopt = 0
-  cdef int lwork = -1
-  sgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, iwork, info)
-  lwork = <int> wkopt
-
-  # Now get the actual SVD
-  cdef float* work = <float *> malloc(lwork * sizeof(float))
-  sgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, iwork, info)
-  free(work)
+  for i in range(b):
+    sgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork,
+           iwork, info)
+    a_out += m * n
+    s += min(m, n)
+    u += m * tdu
+    vt += ldvt * n
+    info += 1
 
 register_cpu_custom_call_target(b"lapack_sgesdd", <void*>(lapack_sgesdd))
 
 
+cdef int dgesdd_work_size(int m, int n, bool_t job_opt_compute_uv,
+                          bool_t job_opt_full_matrices):
+  cdef double work
+  cdef int lwork = -1
+  cdef int info
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
+  dgesdd(&jobz, &m, &n, NULL, &m, NULL, NULL, &m, NULL, &ldvt, &work,
+         &lwork, NULL, &info)
+  return <int>(work) if info == 0 else -1
+
 cdef void lapack_dgesdd(void* out_tuple, void** data) nogil:
   cdef int32_t job_opt_full_matrices = (<int32_t*>(data[0]))[0]
   cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
-  cdef int m = (<int32_t*>(data[2]))[0]
-  cdef int n = (<int32_t*>(data[3]))[0]
-  cdef double* a_in = <double*>(data[4])
+  cdef int b = (<int32_t*>(data[2]))[0]
+  cdef int m = (<int32_t*>(data[3]))[0]
+  cdef int n = (<int32_t*>(data[4]))[0]
+  cdef int lwork = (<int32_t*>(data[5]))[0]
+  cdef double* a_in = <double*>(data[6])
 
   cdef void** out = <void**>(out_tuple)
   cdef double* a_out = <double*>(out[0])
@@ -934,46 +963,48 @@ cdef void lapack_dgesdd(void* out_tuple, void** data) nogil:
   cdef double* vt = <double*>(out[3])
   cdef int* info = <int*>(out[4])
   cdef int* iwork = <int*>(out[5])
+  cdef double* work = <double*>(out[6])
 
   if a_out != a_in:
-    memcpy(a_out, a_in, m * n * sizeof(double))
+    memcpy(a_out, a_in, b * m * n * sizeof(double))
 
-  # define appropriate job code
-  cdef char jobz = 'A'
-  if job_opt_compute_uv == 0:
-    jobz = 'N'
-  else:
-    if job_opt_full_matrices == 0:
-      jobz = 'S'
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
 
   cdef int lda = m
   cdef int ldu = m
-  cdef int ldvt = n
-  if job_opt_full_matrices == 0:
-    ldvt = min(m, n)
+  cdef int tdu = min(m, n) if job_opt_full_matrices == 0 else m
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
 
-  # First perform a workspace query to get the optimal lwork
-  # NB: We perform a workspace query with malloc and free for the work array,
-  # because it is officially recommended in the LAPACK documentation
-  cdef double wkopt = 0
-  cdef int lwork = -1
-  dgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, iwork, info)
-  lwork = <int> wkopt
-
-  # Now get the actual SVD
-  cdef double* work = <double *> malloc(lwork * sizeof(double))
-  dgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, iwork, info)
-  free(work)
+  for i in range(b):
+    dgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork,
+           iwork, info)
+    a_out += m * n
+    s += min(m, n)
+    u += m * tdu
+    vt += ldvt * n
+    info += 1
 
 register_cpu_custom_call_target(b"lapack_dgesdd", <void*>(lapack_dgesdd))
 
+cdef int cgesdd_work_size(int m, int n, bool_t job_opt_compute_uv,
+                          bool_t job_opt_full_matrices):
+  cdef float complex work
+  cdef int lwork = -1
+  cdef int info
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
+  cgesdd(&jobz, &m, &n, NULL, &m, NULL, NULL, &m, NULL, &ldvt, &work,
+         &lwork, NULL, NULL, &info)
+  return <int>(work.real) if info == 0 else -1
 
 cdef void lapack_cgesdd(void* out_tuple, void** data) nogil:
   cdef int32_t job_opt_full_matrices = (<int32_t*>(data[0]))[0]
   cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
-  cdef int m = (<int32_t*>(data[2]))[0]
-  cdef int n = (<int32_t*>(data[3]))[0]
-  cdef float complex* a_in = <float complex*>(data[4])
+  cdef int b = (<int32_t*>(data[2]))[0]
+  cdef int m = (<int32_t*>(data[3]))[0]
+  cdef int n = (<int32_t*>(data[4]))[0]
+  cdef int lwork = (<int32_t*>(data[5]))[0]
+  cdef float complex* a_in = <float complex*>(data[6])
 
   cdef void** out = <void**>(out_tuple)
   cdef float complex* a_out = <float complex*>(out[0])
@@ -983,46 +1014,49 @@ cdef void lapack_cgesdd(void* out_tuple, void** data) nogil:
   cdef int* info = <int*>(out[4])
   cdef int* iwork = <int*>(out[5])
   cdef float* rwork = <float*>(out[6])
+  cdef float complex* work = <float complex*>(out[7])
 
   if a_out != a_in:
-    memcpy(a_out, a_in, m * n * sizeof(float complex))
+    memcpy(a_out, a_in, b * m * n * sizeof(float complex))
 
-  # define appropriate job code
-  cdef char jobz = 'A'
-  if job_opt_compute_uv == 0:
-    jobz = 'N'
-  else:
-    if job_opt_full_matrices == 0:
-      jobz = 'S'
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
 
   cdef int lda = m
   cdef int ldu = m
-  cdef int ldvt = n
-  if job_opt_full_matrices == 0:
-    ldvt = min(m, n)
+  cdef int tdu = min(m, n) if job_opt_full_matrices == 0 else m
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
 
-  # First perform a workspace query to get the optimal lwork
-  # NB: We perform a workspace query with malloc and free for the work array,
-  # because it is officially recommended in the LAPACK documentation
-  cdef float complex wkopt = 0
-  cdef int lwork = -1
-  cgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, rwork, iwork, info)
-  lwork = <int>(wkopt.real)
-
-  # Now get the actual SVD
-  cdef float complex* work = <float complex*> malloc(lwork * sizeof(float complex))
-  cgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, rwork, iwork, info)
-  free(work)
+  for i in range(b):
+    cgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork,
+           rwork, iwork, info)
+    a_out += m * n
+    s += min(m, n)
+    u += m * tdu
+    vt += ldvt * n
+    info += 1
 
 register_cpu_custom_call_target(b"lapack_cgesdd", <void*>(lapack_cgesdd))
 
 
+cdef int zgesdd_work_size(int m, int n, bool_t job_opt_compute_uv,
+                          bool_t job_opt_full_matrices):
+  cdef double complex work
+  cdef int lwork = -1
+  cdef int info
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
+  zgesdd(&jobz, &m, &n, NULL, &m, NULL, NULL, &m, NULL, &ldvt, &work,
+         &lwork, NULL, NULL, &info)
+  return <int>(work.real) if info == 0 else -1
+
 cdef void lapack_zgesdd(void* out_tuple, void** data) nogil:
   cdef int32_t job_opt_full_matrices = (<int32_t*>(data[0]))[0]
   cdef int32_t job_opt_compute_uv = (<int32_t*>(data[1]))[0]
-  cdef int m = (<int32_t*>(data[2]))[0]
-  cdef int n = (<int32_t*>(data[3]))[0]
-  cdef double complex* a_in = <double complex*>(data[4])
+  cdef int b = (<int32_t*>(data[2]))[0]
+  cdef int m = (<int32_t*>(data[3]))[0]
+  cdef int n = (<int32_t*>(data[4]))[0]
+  cdef int lwork = (<int32_t*>(data[5]))[0]
+  cdef double complex* a_in = <double complex*>(data[6])
 
   cdef void** out = <void**>(out_tuple)
   cdef double complex* a_out = <double complex*>(out[0])
@@ -1032,36 +1066,26 @@ cdef void lapack_zgesdd(void* out_tuple, void** data) nogil:
   cdef int* info = <int*>(out[4])
   cdef int* iwork = <int*>(out[5])
   cdef double* rwork = <double*>(out[6])
+  cdef double complex* work = <double complex*>(out[7])
 
   if a_out != a_in:
-    memcpy(a_out, a_in, m * n * sizeof(double complex))
+    memcpy(a_out, a_in, b * m * n * sizeof(double complex))
 
-  # define appropriate job code
-  cdef char jobz = 'A'
-  if job_opt_compute_uv == 0:
-    jobz = 'N'
-  else:
-    if job_opt_full_matrices == 0:
-      jobz = 'S'
+  cdef char jobz = gesdd_jobz(job_opt_compute_uv, job_opt_full_matrices)
 
   cdef int lda = m
   cdef int ldu = m
-  cdef int ldvt = n
-  if job_opt_full_matrices == 0:
-    ldvt = min(m, n)
+  cdef int tdu = min(m, n) if job_opt_full_matrices == 0 else m
+  cdef int ldvt = min(m, n) if job_opt_full_matrices == 0 else n
 
-  # First perform a workspace query to get the optimal lwork
-  # NB: We perform a workspace query with malloc and free for the work array,
-  # because it is officially recommended in the LAPACK documentation
-  cdef double complex wkopt = 0
-  cdef int lwork = -1
-  zgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, &wkopt, &lwork, rwork, iwork, info)
-  lwork = <int>(wkopt.real)
-
-  # Now get the actual SVD
-  cdef double complex* work = <double complex*> malloc(lwork * sizeof(double complex))
-  zgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, rwork, iwork, info)
-  free(work)
+  for i in range(b):
+    zgesdd(&jobz, &m, &n, a_out, &lda, s, u, &ldu, vt, &ldvt, work, &lwork,
+           rwork, iwork, info)
+    a_out += m * n
+    s += min(m, n)
+    u += m * tdu
+    vt += ldvt * n
+    info += 1
 
 register_cpu_custom_call_target(b"lapack_zgesdd", <void*>(lapack_zgesdd))
 
@@ -1070,53 +1094,85 @@ def gesdd(c, a, full_matrices=True, compute_uv=True):
 
   a_shape = c.GetShape(a)
   dtype = a_shape.element_type()
-  m, n = a_shape.dimensions()
+  dims = a_shape.dimensions()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  b = 1
+  for d in batch_dims:
+    b *= d
+
   if dtype == np.float32:
     fn = b"lapack_sgesdd"
     singular_vals_dtype = np.float32
-    workspace = (Shape.array_shape(np.dtype(np.int32),
-                                   (gesdd_iwork_size(m, n),), (0,)),)
+    lwork = sgesdd_work_size(m, n, compute_uv, full_matrices)
+    workspace = (
+      Shape.array_shape(np.dtype(np.int32), (gesdd_iwork_size(m, n),), (0,)),
+      Shape.array_shape(dtype, (lwork,), (0,)),
+    )
   elif dtype == np.float64:
     fn = b"lapack_dgesdd"
     singular_vals_dtype = np.float64
-    workspace = (Shape.array_shape(np.dtype(np.int32),
-                                   (gesdd_iwork_size(m, n),), (0,)),)
+    lwork = dgesdd_work_size(m, n, compute_uv, full_matrices)
+    workspace = (
+      Shape.array_shape(np.dtype(np.int32), (gesdd_iwork_size(m, n),), (0,)),
+      Shape.array_shape(dtype, (lwork,), (0,)),
+    )
   elif dtype == np.complex64:
     fn = b"lapack_cgesdd"
     singular_vals_dtype = np.float32
-    workspace = (Shape.array_shape(np.dtype(np.int32),
-                                   (gesdd_iwork_size(m, n),), (0,)),
-                 Shape.array_shape(np.dtype(np.float32),
-                                   (cgesdd_rwork_size(m, n, int(compute_uv)),),
-                                   (0,)))
+    lwork = cgesdd_work_size(m, n, compute_uv, full_matrices)
+    workspace = (
+      Shape.array_shape(np.dtype(np.int32), (gesdd_iwork_size(m, n),), (0,)),
+      Shape.array_shape(np.dtype(np.float32),
+                        (cgesdd_rwork_size(m, n, int(compute_uv)),), (0,)),
+      Shape.array_shape(dtype, (lwork,), (0,)),
+    )
   elif dtype == np.complex128:
     fn = b"lapack_zgesdd"
     singular_vals_dtype = np.float64
-    workspace = (Shape.array_shape(np.dtype(np.int32),
-                                   (gesdd_iwork_size(m, n),), (0,)),
-                 Shape.array_shape(np.dtype(np.float64),
-                                   (cgesdd_rwork_size(m, n, int(compute_uv)),),
-                                   (0,)))
+    lwork = zgesdd_work_size(m, n, compute_uv, full_matrices)
+    workspace = (
+      Shape.array_shape(np.dtype(np.int32), (gesdd_iwork_size(m, n),), (0,)),
+      Shape.array_shape(np.dtype(np.float64),
+                        (cgesdd_rwork_size(m, n, int(compute_uv)),), (0,)),
+      Shape.array_shape(dtype, (lwork,), (0,)),
+    )
   else:
     raise NotImplementedError("Unsupported dtype {}".format(dtype))
 
+  scalar_layout = tuple(range(num_bd - 1, -1, -1))
+  vector_layout = (num_bd,) + scalar_layout
+  matrix_layout = (num_bd, num_bd + 1) + scalar_layout
   out = c.CustomCall(
       fn,
-      operands=(c.ConstantS32Scalar(int(full_matrices)), c.ConstantS32Scalar(int(compute_uv)),
-                c.ConstantS32Scalar(m), c.ConstantS32Scalar(n), a),
+      operands=(c.ConstantS32Scalar(int(full_matrices)),
+                c.ConstantS32Scalar(int(compute_uv)),
+                c.ConstantS32Scalar(b),
+                c.ConstantS32Scalar(m), c.ConstantS32Scalar(n),
+                c.ConstantS32Scalar(lwork), a),
       shape_with_layout=Shape.tuple_shape((
-          Shape.array_shape(dtype, (m, n), (0, 1)),
-          Shape.array_shape(np.dtype(singular_vals_dtype), (min(m, n),), (0,)),
-          Shape.array_shape(dtype, (m, m if full_matrices else min(m, n)), (0, 1)),
-          Shape.array_shape(dtype, (n if full_matrices else min(m, n), n), (0, 1)),
-          Shape.array_shape(np.dtype(np.int32), (), ())) + workspace
+          Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
+          Shape.array_shape(np.dtype(singular_vals_dtype),
+                            batch_dims + (min(m, n),), vector_layout),
+          Shape.array_shape(dtype,
+                            batch_dims + (m, m if full_matrices else min(m, n)),
+                            matrix_layout),
+          Shape.array_shape(dtype,
+                            batch_dims + (n if full_matrices else min(m, n), n),
+                            matrix_layout),
+          Shape.array_shape(np.dtype(np.int32), batch_dims, scalar_layout),
+        ) + workspace
       ),
       operand_shapes_with_layout=(
           Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(np.dtype(np.int32), (), ()),
           Shape.array_shape(np.dtype(np.int32), (), ()),
-          Shape.array_shape(dtype, (m, n), (0, 1)),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(np.dtype(np.int32), (), ()),
+          Shape.array_shape(dtype, batch_dims + (m, n), matrix_layout),
       ))
   return (c.GetTupleElement(out, 1), c.GetTupleElement(out, 2),
           c.GetTupleElement(out, 3), c.GetTupleElement(out, 4))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -326,6 +326,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")
   def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, rng):
     _skip_if_unsupported_type(dtype)
+    if b != () and jax.lib.version <= (0, 1, 28):
+      raise unittest.SkipTest("Batched SVD requires jaxlib 0.1.29")
     args_maker = lambda: [rng(b + (m, n), dtype)]
 
     # Norm, adjusted for dimension and type.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -312,9 +312,11 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_n={}_full_matrices={}_compute_uv={}".format(
-          jtu.format_shape_dtype_string((m, n), dtype), full_matrices, compute_uv),
-       "m": m, "n": n, "dtype": dtype, "full_matrices": full_matrices,
+          jtu.format_shape_dtype_string(b + (m, n), dtype), full_matrices,
+          compute_uv),
+       "b": b, "m": m, "n": n, "dtype": dtype, "full_matrices": full_matrices,
        "compute_uv": compute_uv, "rng": rng}
+      for b in [(), (3,), (2, 3)]
       for m in [2, 7, 29, 53]
       for n in [2, 7, 29, 53]
       for dtype in float_types + complex_types
@@ -322,9 +324,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for compute_uv in [False, True]
       for rng in [jtu.rand_default()]))
   @jtu.skip_on_devices("tpu")
-  def testSVD(self, m, n, dtype, full_matrices, compute_uv, rng):
+  def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, rng):
     _skip_if_unsupported_type(dtype)
-    args_maker = lambda: [rng((m, n), dtype)]
+    args_maker = lambda: [rng(b + (m, n), dtype)]
 
     # Norm, adjusted for dimension and type.
     def norm(x):
@@ -333,24 +335,26 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     a, = args_maker()
     out = np.linalg.svd(a, full_matrices=full_matrices, compute_uv=compute_uv)
-
     if compute_uv:
       # Check the reconstructed matrices
       if full_matrices:
         k = min(m, n)
         if m < n:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2][:k, :])) < 50))
+          self.assertTrue(onp.all(
+              norm(a - onp.matmul(out[1][..., None, :] * out[0], out[2][..., :k, :])) < 50))
         else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0][:, :k], out[2])) < 50))
+          self.assertTrue(onp.all(
+              norm(a - onp.matmul(out[1][..., None, :] * out[0][..., :, :k], out[2])) < 350))
       else:
-          self.assertTrue(onp.all(norm(a - onp.matmul(out[1] * out[0], out[2])) < 50))
+        self.assertTrue(onp.all(
+          norm(a - onp.matmul(out[1][..., None, :] * out[0], out[2])) < 300))
 
       # Check the unitary properties of the singular vector matrices.
-      self.assertTrue(onp.all(norm(onp.eye(out[0].shape[1]) - onp.matmul(onp.conj(T(out[0])), out[0])) < 10))
+      self.assertTrue(onp.all(norm(onp.eye(out[0].shape[-1]) - onp.matmul(onp.conj(T(out[0])), out[0])) < 10))
       if m >= n:
-        self.assertTrue(onp.all(norm(onp.eye(out[2].shape[1]) - onp.matmul(onp.conj(T(out[2])), out[2])) < 10))
+        self.assertTrue(onp.all(norm(onp.eye(out[2].shape[-1]) - onp.matmul(onp.conj(T(out[2])), out[2])) < 10))
       else:
-        self.assertTrue(onp.all(norm(onp.eye(out[2].shape[0]) - onp.matmul(out[2], onp.conj(T(out[2])))) < 20))
+        self.assertTrue(onp.all(norm(onp.eye(out[2].shape[-2]) - onp.matmul(out[2], onp.conj(T(out[2])))) < 20))
 
     else:
       self.assertTrue(onp.allclose(onp.linalg.svd(a, compute_uv=False), onp.asarray(out), atol=1e-4, rtol=1e-4))
@@ -359,7 +363,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                           args_maker, check_dtypes=True)
     if not full_matrices:
       svd = partial(np.linalg.svd, full_matrices=False)
-      jtu.check_jvp(svd, partial(jvp, svd), (a,), atol=1e-1 if FLAGS.jax_enable_x64 else jtu.ATOL)
+      jtu.check_jvp(svd, partial(jvp, svd), (a,), rtol=1e-2, atol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_fullmatrices={}".format(


### PR DESCRIPTION
On GPU, switch to using the Jacobi implementation of SVD for matrices smaller than 32x32. The Jacobi implementation has an efficient implementation for batches of small matrices.

Partially addresses issue #1259 