### PR TITLE
Remove explicit broadcasts in vmap(dot_general)

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -291,6 +291,11 @@ class BatchingTest(jtu.JaxTestCase):
     ans = vmap(np.dot, in_axes=(1, None))(xs, ys)
     expected = onp.einsum('ij,i->j', xs, ys)
     self.assertAllClose(ans, expected, check_dtypes=False)
+  
+  def testDot5(self):
+    f = vmap(partial(np.einsum, 'ij,j->i'), (None, 0))
+    jaxpr = make_jaxpr(f)(np.zeros((1000, 1000)), np.zeros((1000, 1000)))
+    assert "broadcast" not in str(jaxpr)
 
   def testPad(self):
     R = onp.random.RandomState(0).randn


### PR DESCRIPTION
The general `Dot` HLO requires that the "batch dimensions" of its left-hand side and right-hand side match not just in size but in axis location; in order to satisfy this restriction we previously introduced broadcasts when batching dots in order to add the same batch dimensions to each operand. Unfortunately, this broadcast isn't being optimized away, at least on CPU/GPU, leading to a failure to pattern-match the dot into a matrix multiplication and poor performance as a result. An alternative approach, taken here, is to only use batch dimensions for their original purpose (batching of _both_ operands) and to introduce a new non-batch, non-contracting dimension as the _last_ dimension of the batched operand when there's only one (in order to avoid changing existing axis locations in that operand).
