### PR TITLE
final-style unzipping for stax2 prototype

### DIFF
--- a/jax/experimental/stax2.py
+++ b/jax/experimental/stax2.py
@@ -1,0 +1,234 @@
+from __future__ import print_function
+
+import itertools as it
+import numpy as onp
+import operator as op
+
+import jax.numpy as np
+from jax import core
+from jax import random
+from jax.api_util import flatten_fun
+from jax.tree_util import tree_map, tree_flatten, tree_unflatten
+from jax.util import curry
+from jax.interpreters import partial_eval as pe
+from jax.abstract_arrays import ShapedArray
+from jax import linear_util as lu
+
+
+# The idea here is to have the user supply a function that describes both
+# initialization and application of a network, and to "unzip" that function into
+# its initialization part and its application part. The initialization part we
+# execute to produce initial parameters, and the application part we return as a
+# Python callable.
+
+# In types, we start with a user function,
+#
+#   user_fun :: Key -> a -> b
+#
+# and apply our unzip function to it, given a key and example arguments encoding
+# shapes,
+#
+#  unzip :: (Key -> a -> b) -> Key -> a -> (Params, Params -> a -> b)
+#
+# The second element of that tuple is the apply_fun.
+
+
+# First we set up prng splitting and sampling as new primitives so that we don't
+# just inline our prng hash function. We also use a variant of splitting based
+# on hashable name strings.
+
+def randn(key, shape):
+  return randn_p.bind(key, shape=shape)
+randn_p = core.Primitive('randn')
+randn_p.def_abstract_eval(lambda key, shape: ShapedArray(shape, onp.float32))
+
+def named_subkey(key, name):
+  return named_subkey_p.bind(key, name=name)
+named_subkey_p = core.Primitive('named_subkey')
+named_subkey_p.def_abstract_eval(lambda key, name: key)
+
+
+
+# Now we can write the unzip function, starting with unzip_jaxpr which applies
+# to a jaxpr before adding the boilerplate to handle Python callables and
+# pytrees. The unzip_jaxpr function looks like a jaxpr interpreter.
+
+def unzip_jaxpr(jaxpr):
+  key_invar, data_invars = jaxpr.invars[0], jaxpr.invars[1:]
+  params = {key_invar : Node()}
+  canonical_paramvars = {}
+  apply_eqns = []
+
+  for eqn in jaxpr.eqns:
+    if eqn.primitive is named_subkey_p:
+      parent_var, = eqn.invars
+      child_var, = eqn.outvars
+      name = eqn.params['name']
+      if name in params[parent_var].children:
+        params[child_var] = params[parent_var].children[name]
+      else:
+        params[child_var] = Node()
+        params[parent_var].children[name] = params[child_var]
+    elif eqn.primitive is randn_p:
+      parent_var, = eqn.invars
+      param_var, = eqn.outvars
+      shape = eqn.params['shape']
+      if hasattr(params[parent_var], "leaf"):
+        canonical_paramvars[param_var] = params[parent_var].leaf[1]
+      else:
+        params[parent_var].leaf = OpaqueTuple((onp.zeros(shape), param_var))
+    else:
+      canonical_invars = [canonical_paramvars.get(v, v) for v in eqn.invars]
+      apply_eqns.append(core.new_jaxpr_eqn(
+          canonical_invars, eqn.outvars, eqn.primitive, eqn.bound_subjaxprs,
+          eqn.params))
+
+  param_invar_tree = _strip_nodes(params[key_invar])
+  param_tree = tree_map(op.itemgetter(0), param_invar_tree)
+  invar_tree = tree_map(op.itemgetter(1), param_invar_tree)
+  param_invars, treedef = tree_flatten(invar_tree)
+
+  apply_jaxpr = core.Jaxpr(jaxpr.constvars, (),
+                           param_invars + data_invars,
+                           jaxpr.outvars, apply_eqns)
+  core.check_jaxpr(apply_jaxpr)
+  return param_tree, treedef, apply_jaxpr
+
+def unzip(fun, *example_args, **example_kwargs):
+  def abstractify(x):
+    return ShapedArray(onp.shape(x), onp.result_type(x))
+  args_flat, in_tree = tree_flatten((example_args, example_kwargs))
+  fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
+  pvals = [pe.PartialVal((abstractify(x), core.unit)) for x in args_flat]
+  jaxpr, _, consts = pe.trace_to_jaxpr(fun, pvals, instantiate=True)
+  param_tree, param_treedef, apply_jaxpr = unzip_jaxpr(jaxpr)
+
+  def apply_fun(params, *args, **kwargs):
+    args_flat, in_tree2 = tree_flatten(((core.unit,) + args, kwargs))
+    assert in_tree == in_tree2
+    params_flat, param_treedef2 = tree_flatten(params)
+    assert param_treedef == param_treedef2
+    out_flat = core.eval_jaxpr(apply_jaxpr, consts, (),
+                               *it.chain(params_flat, args_flat[1:]))
+    return tree_unflatten(out_tree(), out_flat)
+
+  return param_tree, apply_fun
+
+
+# These are just utility functions.
+
+def _strip_nodes(params):
+  assert type(params) is Node
+  if hasattr(params, "leaf"):
+    return params.leaf
+  else:
+    return {k : _strip_nodes(child) for k, child in params.children.items()}
+
+class Node(object):
+  __slots__ = ["leaf", "children"]  # only one!
+  def __init__(self):
+    self.children = {}
+  def __repr__(self):
+    if hasattr(self, "leaf"):
+      return repr(self.leaf)
+    else:
+      return repr(self.children)
+
+class OpaqueTuple(tuple): pass
+
+
+###
+
+### Example 1: The basics
+
+# f :: Key -> a -> b
+def f(key, x):
+  k1 = named_subkey(key, "Layer 1")
+  W = randn(named_subkey(k1, "W"), (4, 3))
+  b = randn(named_subkey(k1, "b"), (4,))
+  x = np.dot(W, x) + b
+
+  k2 = named_subkey(key, "Layer 2")
+  W = randn(named_subkey(k2, "W"), (2, 4))
+  b = randn(named_subkey(k2, "b"), (2,))
+  x = np.dot(W, x) + b
+
+  return x
+
+x = np.ones(3)
+key = random.PRNGKey(0)
+param_tree, apply_fun = unzip(f, key, x)
+print("Ex 1")
+print(param_tree)
+print(apply_fun(param_tree, x))
+
+
+# ### Example 2: writing point-free combinator libraries
+
+# type Layer = Key -> Array -> Array
+# Dense :: Int -> Layer
+# Serial :: [Layer] -> Layer
+
+@curry
+def Serial(layers, key, x):
+  for i, layer in enumerate(layers):
+    x = layer(named_subkey(key, i), x)
+  return x
+
+@curry
+def Dense(num_features_out, key, x):
+  num_features_in, = x.shape
+  W = randn(named_subkey(key, "W"), (num_features_out, num_features_in))
+  b = randn(named_subkey(key, "b"), (num_features_out,))
+  return np.dot(W, x) + b
+
+f = Serial([Dense(4), Dense(2)])
+
+x = np.ones(3)
+key = random.PRNGKey(0)
+param_tree, apply_fun = unzip(f, key, x)
+print("Ex 2")
+print(param_tree)
+print(apply_fun(param_tree, x))
+
+
+### Example 3: mixed pointy and point-free
+
+# Let's make a network with parameter sharing, using pointy fan-out of
+# parameters. One thing we could do is combine Ex 1 and Ex 2 and route
+# parameters themselves to express parameter reuse, but instead what we try here
+# is to handle parameter reuse by reusing keys. For that we use a slightly
+# different Serial combinator, the aptly-named Serial2.
+
+# type KeyedLayer = Array -> Array
+# Serial2 :: [KeyedLayer] -> KeyedLayer
+
+@curry
+def Serial2(layers, x):
+  for layer in layers:
+    x = layer(x)
+  return x
+
+def f(key, x):
+  layer_1 = Dense(2, named_subkey(key, 0))
+  layer_2 = Dense(x.shape[0], named_subkey(key, 1))
+  net = Serial2([layer_1, layer_2, layer_1])
+  return net(x)
+
+x = np.ones(3)
+key = random.PRNGKey(0)
+param_tree, apply_fun = unzip(f, key, x)
+print("Ex 3")
+print(param_tree)
+print(apply_fun(param_tree, x))
+
+
+# TODOs
+#   - actually have prng primitives, merge this with real prng splitting
+#   - pytree flattening stuff on data inputs/outputs
+#   - split with integers
+#   - figure out batch norm
+#   - we should only be capturing prng splits that derive from the input
+#     argument
+#   - recurse into subjaxprs, especially initial-style (scan!), not clear how to
+#     represent splits under a scan so maybe it's an error for now

--- a/jax/experimental/stax2.py
+++ b/jax/experimental/stax2.py
@@ -1,18 +1,13 @@
 from __future__ import print_function
 
-import itertools as it
 import numpy as onp
 import operator as op
 
+import jax
 import jax.numpy as np
 from jax import core
 from jax import random
-from jax.api_util import flatten_fun
-from jax.tree_util import tree_map, tree_flatten, tree_unflatten
-from jax.util import curry
-from jax.interpreters import partial_eval as pe
-from jax.abstract_arrays import ShapedArray
-from jax import linear_util as lu
+from jax.util import curry, partial
 
 
 # The idea here is to have the user supply a function that describes both
@@ -32,136 +27,160 @@ from jax import linear_util as lu
 #
 # The second element of that tuple is the apply_fun.
 
+# doesn't work yet because PRNGKey isn't a real type:
+# random.PRNGKey.__getitem__ = random.fold_in
 
-# First we set up prng splitting and sampling as new primitives so that we don't
-# just inline our prng hash function. We also use a variant of splitting based
-# on hashable name strings.
+uniform_p = random._uniform.prim
+normal_p = random._normal.prim
+fold_in_p = random._fold_in.prim
 
-def randn(key, shape):
-  return randn_p.bind(key, shape=shape)
-randn_p = core.Primitive('randn')
-randn_p.def_abstract_eval(lambda key, shape: ShapedArray(shape, onp.float32))
+class KeyTrace(core.Trace):
+  def pure(self, val):
+    return KeyTracer(self, val)
 
-def named_subkey(key, name):
-  return named_subkey_p.bind(key, name=name)
-named_subkey_p = core.Primitive('named_subkey')
-named_subkey_p.def_abstract_eval(lambda key, name: key)
+  def lift(self, val):
+    return KeyTracer(self, val)
 
+  def sublift(self, val):
+    raise NotImplementedError
 
-
-# Now we can write the unzip function, starting with unzip_jaxpr which applies
-# to a jaxpr before adding the boilerplate to handle Python callables and
-# pytrees. The unzip_jaxpr function looks like a jaxpr interpreter.
-
-def unzip_jaxpr(jaxpr):
-  key_invar, data_invars = jaxpr.invars[0], jaxpr.invars[1:]
-  params = {key_invar : Node()}
-  canonical_paramvars = {}
-  apply_eqns = []
-
-  for eqn in jaxpr.eqns:
-    if eqn.primitive is named_subkey_p:
-      parent_var, = eqn.invars
-      child_var, = eqn.outvars
-      name = eqn.params['name']
-      if name in params[parent_var].children:
-        params[child_var] = params[parent_var].children[name]
+  def process_primitive(self, primitive, tracers, params):
+    if primitive is fold_in_p:
+      assert len(tracers) == 1
+      key_tracer = tracers[0]
+      key, path, tree = key_tracer.val, key_tracer.path, key_tracer.tree
+      if key is None:
+        out = None
       else:
-        params[child_var] = Node()
-        params[parent_var].children[name] = params[child_var]
-    elif eqn.primitive is randn_p:
-      parent_var, = eqn.invars
-      param_var, = eqn.outvars
-      shape = eqn.params['shape']
-      if hasattr(params[parent_var], "leaf"):
-        canonical_paramvars[param_var] = params[parent_var].leaf[1]
+        out, = primitive.bind(key, **params)
+      return [KeyTracer(self, out, tree, path + [params['data']])]
+    elif primitive in [uniform_p, normal_p]:
+      key_tracer, args_tracers = tracers[0], tracers[1:]
+      key, path, tree = key_tracer.val, key_tracer.path, key_tracer.tree
+      assert all(len(tracer.path) == 0 for tracer in args_tracers[1:])
+      args = [tracer.val for tracer in args_tracers]
+      subtree = tree
+      for path_key in path[:-1]:
+        if path_key not in subtree:
+          subtree[path_key] = dict()
+        subtree = subtree[path_key]
+      if path[-1] in subtree:
+        out = subtree[path[-1]]
+        print("using provided sample", out)
       else:
-        params[parent_var].leaf = OpaqueTuple((onp.zeros(shape), param_var))
+        assert key is not None
+        out, = primitive.bind(key, *args, **params)
+        subtree[path[-1]] = out
+      return [KeyTracer(self, out, tree)]
     else:
-      canonical_invars = [canonical_paramvars.get(v, v) for v in eqn.invars]
-      apply_eqns.append(core.new_jaxpr_eqn(
-          canonical_invars, eqn.outvars, eqn.primitive, eqn.bound_subjaxprs,
-          eqn.params))
+      assert all(len(tracer.path) == 0 for tracer in tracers)
+      tree = tracers[0].tree
+      for tracer in tracers[1:]:
+        if tree == dict():
+          tree = tracer.tree
+        elif tracer.tree == dict():
+          continue
+        elif tree != tracer.tree:
+          raise AssertionError
+      args = [tracer.val for tracer in tracers]
+      out = primitive.bind(*args, **params)
+      if primitive.multiple_results:
+        return [KeyTracer(self, val, tree) for val in out]
+      else:
+        return KeyTracer(self, out, tree)
 
-  param_invar_tree = _strip_nodes(params[key_invar])
-  param_tree = tree_map(op.itemgetter(0), param_invar_tree)
-  invar_tree = tree_map(op.itemgetter(1), param_invar_tree)
-  param_invars, treedef = tree_flatten(invar_tree)
+  def process_call(self, call_primitive, f, tracers, params):
+    # let's inline it and see what happens
+    return f.call_wrapped(*tracers)
 
-  apply_jaxpr = core.Jaxpr(jaxpr.constvars, (),
-                           param_invars + data_invars,
-                           jaxpr.outvars, apply_eqns)
-  core.check_jaxpr(apply_jaxpr)
-  return param_tree, treedef, apply_jaxpr
+  def process_map(self, map_primitive, f, tracers, params):
+    raise NotImplementedError
 
-def unzip(fun, *example_args, **example_kwargs):
-  def abstractify(x):
-    return ShapedArray(onp.shape(x), onp.result_type(x))
-  args_flat, in_tree = tree_flatten((example_args, example_kwargs))
-  fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
-  pvals = [pe.PartialVal((abstractify(x), core.unit)) for x in args_flat]
-  jaxpr, _, consts = pe.trace_to_jaxpr(fun, pvals, instantiate=True)
-  param_tree, param_treedef, apply_jaxpr = unzip_jaxpr(jaxpr)
-
-  def apply_fun(params, *args, **kwargs):
-    args_flat, in_tree2 = tree_flatten(((core.unit,) + args, kwargs))
-    assert in_tree == in_tree2
-    params_flat, param_treedef2 = tree_flatten(params)
-    assert param_treedef == param_treedef2
-    out_flat = core.eval_jaxpr(apply_jaxpr, consts, (),
-                               *it.chain(params_flat, args_flat[1:]))
-    return tree_unflatten(out_tree(), out_flat)
-
-  return param_tree, apply_fun
+  def post_process_call(self, call_primitive, out_tracers, params):
+    raise NotImplementedError
 
 
-# These are just utility functions.
+class KeyTracer(core.Tracer):
+  __slots__ = ['trace', 'val', 'tree', 'path']
 
-def _strip_nodes(params):
-  assert type(params) is Node
-  if hasattr(params, "leaf"):
-    return params.leaf
-  else:
-    return {k : _strip_nodes(child) for k, child in params.children.items()}
+  def __init__(self, trace, val, tree=None, path=None):
+    self.trace = trace
+    self.val = val
+    self.tree = dict() if tree is None else tree
+    self.path = [] if path is None else path
 
-class Node(object):
-  __slots__ = ["leaf", "children"]  # only one!
-  def __init__(self):
-    self.children = {}
   def __repr__(self):
-    if hasattr(self, "leaf"):
-      return repr(self.leaf)
+    return 'Traced<{}:{}>'.format(self.val, self.trace)
+
+  @property
+  def aval(self):
+    return core.get_aval(self.val)
+
+  def full_lower(self):
+    if self.path is None:
+      return self.val
     else:
-      return repr(self.children)
+      return self
 
-class OpaqueTuple(tuple): pass
+random._uniform.overrides.add(KeyTrace)
+random._normal.overrides.add(KeyTrace)
+random._fold_in.overrides.add(KeyTrace)
 
+def unzip(f, key, *args):
+  def apply(tree, *args):
+    with core.new_master(KeyTrace) as master:
+      trace = KeyTrace(master, core.cur_sublevel())
+      args_tracers = [KeyTracer(trace, arg) for arg in args]
+      key_tracer = KeyTracer(trace, None, tree)
+      out_tracer = f(key_tracer, *args_tracers)
+      return out_tracer.val
+  with core.new_master(KeyTrace) as master:
+    trace = KeyTrace(master, core.cur_sublevel())
+    args_tracers = [KeyTracer(trace, arg) for arg in args]
+    key_tracer = KeyTracer(trace, key)
+    out_tracer = f(key_tracer, *args_tracers)
+    out_tree = out_tracer.tree
+  return out_tree, apply
 
-###
+### Example 0: Sanity check
+
+def e(key, x):
+  k = random.fold_in(key, "x")
+  return random.uniform(k, (3,)) + x
+
+x = np.ones(3)
+key = random.PRNGKey(0)
+
+param_tree, apply_fun = unzip(e, key, x)
+print("Ex 0")
+print(param_tree)
+print(apply_fun(param_tree, x))
 
 ### Example 1: The basics
 
 # f :: Key -> a -> b
 def f(key, x):
-  k1 = named_subkey(key, "Layer 1")
-  W = randn(named_subkey(k1, "W"), (4, 3))
-  b = randn(named_subkey(k1, "b"), (4,))
-  x = np.dot(W, x) + b
+  k1 = random.fold_in(key, 1)
+  W = random.uniform(random.fold_in(k1, "W"), (3, 4))
+  b = random.uniform(random.fold_in(k1, "b"), (4,))
+  x = np.dot(x, W) + b
 
-  k2 = named_subkey(key, "Layer 2")
-  W = randn(named_subkey(k2, "W"), (2, 4))
-  b = randn(named_subkey(k2, "b"), (2,))
-  x = np.dot(W, x) + b
+  k2 = random.fold_in(key, 2)
+  W = random.uniform(random.fold_in(k2, "W"), (4, 2))
+  b = random.uniform(random.fold_in(k2, "b"), (2,))
+  x = np.dot(x, W) + b
 
   return x
 
 x = np.ones(3)
 key = random.PRNGKey(0)
+# print(jax.make_jaxpr(f)(key, x))
+
 param_tree, apply_fun = unzip(f, key, x)
 print("Ex 1")
 print(param_tree)
 print(apply_fun(param_tree, x))
-
+print(jax.make_jaxpr(partial(apply_fun, param_tree))(x))
 
 # ### Example 2: writing point-free combinator libraries
 
@@ -172,14 +191,14 @@ print(apply_fun(param_tree, x))
 @curry
 def Serial(layers, key, x):
   for i, layer in enumerate(layers):
-    x = layer(named_subkey(key, i), x)
+    x = layer(random.fold_in(key, i), x)
   return x
 
 @curry
 def Dense(num_features_out, key, x):
   num_features_in, = x.shape
-  W = randn(named_subkey(key, "W"), (num_features_out, num_features_in))
-  b = randn(named_subkey(key, "b"), (num_features_out,))
+  W = random.normal(random.fold_in(key, "W"), (num_features_out, num_features_in))
+  b = random.normal(random.fold_in(key, "b"), (num_features_out,))
   return np.dot(W, x) + b
 
 f = Serial([Dense(4), Dense(2)])
@@ -190,7 +209,7 @@ param_tree, apply_fun = unzip(f, key, x)
 print("Ex 2")
 print(param_tree)
 print(apply_fun(param_tree, x))
-
+print(jax.make_jaxpr(partial(apply_fun, param_tree))(x))
 
 ### Example 3: mixed pointy and point-free
 
@@ -210,8 +229,8 @@ def Serial2(layers, x):
   return x
 
 def f(key, x):
-  layer_1 = Dense(2, named_subkey(key, 0))
-  layer_2 = Dense(x.shape[0], named_subkey(key, 1))
+  layer_1 = Dense(2, random.fold_in(key, 0))
+  layer_2 = Dense(x.shape[0], random.fold_in(key, 1))
   net = Serial2([layer_1, layer_2, layer_1])
   return net(x)
 
@@ -221,14 +240,9 @@ param_tree, apply_fun = unzip(f, key, x)
 print("Ex 3")
 print(param_tree)
 print(apply_fun(param_tree, x))
-
+print(jax.make_jaxpr(partial(apply_fun, param_tree))(x))
 
 # TODOs
-#   - actually have prng primitives, merge this with real prng splitting
-#   - pytree flattening stuff on data inputs/outputs
-#   - split with integers
 #   - figure out batch norm
-#   - we should only be capturing prng splits that derive from the input
-#     argument
 #   - recurse into subjaxprs, especially initial-style (scan!), not clear how to
 #     represent splits under a scan so maybe it's an error for now

--- a/jax/random.py
+++ b/jax/random.py
@@ -32,11 +32,14 @@ from . import lax
 from . import numpy as np
 from . import tree_util
 from .api import custom_transforms, defjvp, jit, vmap
+from .api_util import wraps
+from .util import safe_map
 from .numpy.lax_numpy import _constant_like, asarray, stack
 from jax.lib import xla_bridge
 from jax import core
 from jax.scipy.special import logit
 
+map = safe_map
 
 def PRNGKey(seed):
   """Create a pseudo-random number generator (PRNG) key given an integer seed.
@@ -66,6 +69,47 @@ def _is_prng_key(key):
     return key.shape == (2,) and key.dtype == onp.uint32
   except AttributeError:
     return False
+
+
+class SemiTransparentFunction(object):
+  def __init__(self, fun, prim):
+    self.fun = fun
+    self.prim = prim
+    self.overrides = set()
+    wraps(fun)(self)
+
+  def __repr__(self):
+    return '<jax.custom_transforms function {fun}>'.format(fun=self.__name__)
+
+  def __call__(self, *args, **kwargs):
+    out = self.prim.bind(*args, **kwargs)
+    return out[0]
+    
+
+def semi_transparent_primitive(fun):
+  """kinda similar to custom_transforms"""
+  name = getattr(fun, '__name__', '<unnamed semi-transparent primitive>')
+  fun_p = core.Primitive(name)
+  fun_p.multiple_results = True
+  f = SemiTransparentFunction(fun, fun_p)
+
+  def impl(*args, **kwargs):
+    return [fun(*args, **kwargs)]
+
+  def bind(*args, **kwargs):
+    top_trace = core.find_top_trace(args)
+    if top_trace is None or top_trace.__class__ not in f.overrides:
+      return impl(*args, **kwargs)
+    tracers = map(top_trace.full_raise, args)
+    out_tracers = top_trace.process_primitive(fun_p, tracers, kwargs)
+    return map(core.full_lower, out_tracers)
+  fun_p.def_custom_bind(bind)
+
+  def abstract_eval(*avals, **kwargs):
+    return abstract_eval_fun(impl, *avals, **kwargs)
+  fun_p.def_abstract_eval(abstract_eval)
+
+  return f
 
 
 ### utilities
@@ -168,16 +212,22 @@ def fold_in(key, data):
 
   Args:
     key: a PRNGKey (an array with shape (2,) and dtype uint32).
-    data: a 32bit integer representing data to be folded in to the key.
+    data: data to be folded into the key; will be hashed first if not an int.
 
   Returns:
     A new PRNGKey that is a deterministic function of the inputs and is
     statistically safe for producing a stream of new pseudo-random values.
   """
-  return _fold_in(key, data)
+  return _fold_in(key, data=data)
+
+@semi_transparent_primitive
+def _fold_in(key, data):
+  if not isinstance(data, int): # TODO do better
+    data = hash(data)
+  return __fold_in(key, data)
 
 @jit
-def _fold_in(key, data):
+def __fold_in(key, data):
   key2 = lax.tie_in(key, PRNGKey(data))
   return threefry_2x32(key, key2)
 
@@ -227,10 +277,14 @@ def uniform(key, shape=(), dtype=onp.float64, minval=0., maxval=1.):
     A random array with the specified shape and dtype.
   """
   dtype = xla_bridge.canonicalize_dtype(dtype)
-  return _uniform(key, shape, dtype, minval, maxval)
+  return _uniform(key, minval, maxval, shape=shape, dtype=dtype)
+
+@semi_transparent_primitive
+def _uniform(key, minval, maxval, shape, dtype):
+  return __uniform(key, shape, dtype, minval, maxval)
 
 @partial(jit, static_argnums=(1, 2))
-def _uniform(key, shape, dtype, minval, maxval):
+def __uniform(key, shape, dtype, minval, maxval):
   _check_shape("uniform", shape)
   if not onp.issubdtype(dtype, onp.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
@@ -372,10 +426,14 @@ def normal(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = xla_bridge.canonicalize_dtype(dtype)
-  return _normal(key, shape, dtype)
+  return _normal(key, shape=shape, dtype=dtype)
+
+@semi_transparent_primitive
+def _normal(key, shape, dtype):
+  return __normal(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
-def _normal(key, shape, dtype):
+def __normal(key, shape, dtype):
   _check_shape("normal", shape)
   lo = onp.nextafter(onp.array(-1., dtype), 0., dtype=dtype)
   hi = onp.array(1., dtype)


### PR DESCRIPTION
Builds on Dougal and Matt's existing staxperiments ideas+code :slightly_smiling_face: 

The main difference is that it's based on a final-style unzip transformation rather than one that operates on jaxprs; in general I'd rather our NN things didn't have the same limitations as `jit` if we can avoid it. This is a choice that should be questioned though! (e.g. it means that initialization "does flops" even when it doesn't necessarily have to; maybe we could try abstracting to shape level and back off if there's an error?).

Also includes an internally-oriented `custom_transforms`-like-thing that differs from `custom_transforms` in a couple ways that may or may not have been good ideas:
- it's completely transparent to interpreters that it doesn't overload, which means it can wrap functions 
that use Python control flow
- it doesn't support pytrees, but instead follows the JAX-internal convention that arguments called positionally are dynamic arguments while those called keywordically are static parameters (note that this clashes with `jit`'s `static_argnums` convention, leading to additional ugliness in random.py)
- I can't imagine it does the right thing with closed-over tracers, so let's say it doesn't support them