### PR TITLE
Add a DeviceArray._unstack() method that unpacks an array along its m…

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -86,8 +86,15 @@ shard_arg_handlers[core.Unit] = \
 def _shard_array(x, ordinals, assignments, backend=None):
   nrep = len(ordinals)
   return (xla.device_put(x[assignments[r]], ordinals[r], backend=backend) for r in range(nrep))
-for _t in it.chain(array_types, [xla.DeviceArray]):
+for _t in array_types:
   shard_arg_handlers[_t] = _shard_array
+
+def _shard_device_array(x, ordinals, assignments, backend=None):
+  nrep = len(ordinals)
+  xs = x._unstack()
+  return (xla.device_put(xs[assignments[r]], ordinals[r], backend=backend)
+          for r in range(nrep))
+shard_arg_handlers[xla.DeviceArray] = _shard_device_array
 
 def shard_aval(size, aval):
   try:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3031,3 +3031,10 @@ setattr(ShapedArray, "split", core.aval_method(split))
 setattr(DeviceArray, "broadcast", lax.broadcast)
 setattr(DeviceArray, "broadcast_in_dim", lax.broadcast_in_dim)
 setattr(DeviceArray, "split", split)
+
+@jit
+def _unstack(x):
+  if x.ndim == 0:
+    raise ValueError("Argument to _unstack must be non-scalar")
+  return [lax.index_in_dim(x, i, keepdims=False) for i in range(x.shape[0])]
+setattr(DeviceArray, "_unstack", _unstack)


### PR DESCRIPTION
…ajor dimension.

Use it to implement pxla's shard_arg method for DeviceArrays; this is faster than slicing out each element one by one.