### PR TITLE
Support for non-scalar np.repeat arguments (fixes #1233)

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1735,21 +1735,21 @@ def repeat(a, repeats, axis=None):
       repeats_raveled.shape, n
     ))
 
-  # construct the total elements after repeat along the axis
+  # total elements after repeat along the axis
   total = sum(repeats_raveled)
 
-  # construct return array
   new_shape = a_shape.copy()
   new_shape[axis] = total
 
-  ret = ravel(onp.zeros(new_shape, a.dtype)) # use numpy array for in place update
-  # first we flatten the original array
+  ret = ravel(zeros(new_shape, a.dtype))
   a_flattened = ravel(a)
+
   # size of each chunk to copy
   chunk = 1
   for i in range(axis+1, ndim(a)):
     chunk *= a_shape[i]
-  # then we copy `chunk` until axis
+
+  # copy `chunk` until axis
   n_outer = 1
   for i in range(0, axis):
     n_outer *= a_shape[i]
@@ -1760,12 +1760,11 @@ def repeat(a, repeats, axis=None):
       tmp = repeats_raveled[j]
       for k in range(0, tmp):
         # copy `chunk` data
-        ret[new_data_ptr:new_data_ptr+chunk] = a_flattened[old_data_ptr:old_data_ptr+chunk]
+        ret = lax.dynamic_update_slice(ret, lax.dynamic_slice(a_flattened, [old_data_ptr], [chunk]), [new_data_ptr])
         new_data_ptr += chunk
       old_data_ptr += chunk
 
-  # then we reshape back to jax array
-  return reshape(array(ret), new_shape)
+  return reshape(ret, new_shape)
 
 @_wraps(onp.tri)
 def tri(N, M=None, k=0, dtype=None):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1738,7 +1738,7 @@ def repeat(a, repeats, axis=None):
   # total elements after repeat along the axis
   total = sum(repeats_raveled)
 
-  new_shape = a_shape.copy()
+  new_shape = a_shape[:]
   new_shape[axis] = total
 
   ret = ravel(zeros(new_shape, a.dtype))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -729,6 +729,37 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
+  def testIssue1233(self):
+    '''
+    Following numpy test suite at https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py `testRepeat`
+    '''
+    tol = 1e-5
+
+    m = [1,2,3,4,5,6]
+
+    for repeats in [2, [1,3,2,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
+      lax_ans = lnp.repeat(lnp.array(m), repeats)
+      numpy_ans = onp.repeat(onp.array(m), repeats)
+
+      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+
+    m_rect_lax = lnp.array(m).reshape((2,3))
+    m_rect_numpy = onp.array(m).reshape((2,3))
+
+    for repeats in [2, [2,1], [2], lnp.array([2,1]), lnp.array([2])]:
+      lax_ans = lnp.repeat(m_rect_lax, repeats, axis=0)
+      numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=0)
+
+      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+
+    for repeats in [2, [1,3,2], [2], lnp.array([1,3,2]), lnp.array([2])]:
+      lax_ans = lnp.repeat(m_rect_lax, repeats, axis=1)
+      numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=1)
+
+      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+
+    # TODO: test jit compile using self._CompileAndCheck
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), axis, out_dtype),

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -731,29 +731,28 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testIssue1233(self):
     '''
-    Following numpy test suite at https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py `testRepeat`
+    Following numpy test suite from `test_repeat` at https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py
     '''
     tol = 1e-5
 
-    m = [1,2,3,4,5,6]
-    args_maker = lambda: [lnp.array(m)]
+    m = lnp.array([1,2,3,4,5,6])
+    args_maker = lambda: [m]
 
     for repeats in [2, [1,3,2,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
-      lax_ans = lnp.repeat(lnp.array(m), repeats)
-      numpy_ans = onp.repeat(onp.array(m), repeats)
+      lax_ans = lnp.repeat(m, repeats)
+      numpy_ans = onp.repeat(m, repeats)
 
       self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
 
       lnp_fun = lambda arg: lnp.repeat(arg, repeats = repeats)
       self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
-    m_rect_lax = lnp.array(m).reshape((2,3))
-    m_rect_numpy = onp.array(m).reshape((2,3))
-    args_maker = lambda: [m_rect_lax]
+    m_rect = m.reshape((2,3))
+    args_maker = lambda: [m_rect]
 
     for repeats in [2, [2,1], [2], lnp.array([2,1]), lnp.array([2])]:
-      lax_ans = lnp.repeat(m_rect_lax, repeats, axis=0)
-      numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=0)
+      lax_ans = lnp.repeat(m_rect, repeats, axis=0)
+      numpy_ans = onp.repeat(m_rect, repeats, axis=0)
 
       lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=0)
 
@@ -761,8 +760,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
     for repeats in [2, [1,3,2], [2], lnp.array([1,3,2]), lnp.array([2])]:
-      lax_ans = lnp.repeat(m_rect_lax, repeats, axis=1)
-      numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=1)
+      lax_ans = lnp.repeat(m_rect, repeats, axis=1)
+      numpy_ans = onp.repeat(m_rect, repeats, axis=1)
 
       lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=1)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -736,6 +736,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     tol = 1e-5
 
     m = [1,2,3,4,5,6]
+    args_maker = lambda: [lnp.array(m)]
 
     for repeats in [2, [1,3,2,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
       lax_ans = lnp.repeat(lnp.array(m), repeats)
@@ -743,22 +744,30 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
       self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
 
+      lnp_fun = lambda arg: lnp.repeat(arg, repeats = repeats)
+      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+
     m_rect_lax = lnp.array(m).reshape((2,3))
     m_rect_numpy = onp.array(m).reshape((2,3))
+    args_maker = lambda: [m_rect_lax]
 
     for repeats in [2, [2,1], [2], lnp.array([2,1]), lnp.array([2])]:
       lax_ans = lnp.repeat(m_rect_lax, repeats, axis=0)
       numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=0)
 
+      lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=0)
+
       self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
     for repeats in [2, [1,3,2], [2], lnp.array([1,3,2]), lnp.array([2])]:
       lax_ans = lnp.repeat(m_rect_lax, repeats, axis=1)
       numpy_ans = onp.repeat(m_rect_numpy, repeats, axis=1)
 
-      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+      lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=1)
 
-    # TODO: test jit compile using self._CompileAndCheck
+      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -734,39 +734,30 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     Following numpy test suite from `test_repeat` at https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py
     '''
     tol = 1e-5
+    
+    def test_single(m, args_maker, repeats, axis):
+      lax_ans = lnp.repeat(m, repeats, axis)
+      numpy_ans = onp.repeat(m, repeats, axis)
+
+      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
+
+      lnp_fun = lambda arg: lnp.repeat(arg, repeats = repeats, axis=axis)
+      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
     m = lnp.array([1,2,3,4,5,6])
     args_maker = lambda: [m]
 
     for repeats in [2, [1,3,2,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
-      lax_ans = lnp.repeat(m, repeats)
-      numpy_ans = onp.repeat(m, repeats)
-
-      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
-
-      lnp_fun = lambda arg: lnp.repeat(arg, repeats = repeats)
-      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+      test_single(m, args_maker, repeats, None)
 
     m_rect = m.reshape((2,3))
     args_maker = lambda: [m_rect]
 
     for repeats in [2, [2,1], [2], lnp.array([2,1]), lnp.array([2])]:
-      lax_ans = lnp.repeat(m_rect, repeats, axis=0)
-      numpy_ans = onp.repeat(m_rect, repeats, axis=0)
-
-      lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=0)
-
-      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
-      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+      test_single(m_rect, args_maker, repeats, axis=0)
 
     for repeats in [2, [1,3,2], [2], lnp.array([1,3,2]), lnp.array([2])]:
-      lax_ans = lnp.repeat(m_rect, repeats, axis=1)
-      numpy_ans = onp.repeat(m_rect, repeats, axis=1)
-
-      lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=1)
-
-      self.assertAllClose(lax_ans, numpy_ans, check_dtypes=True, rtol=tol, atol=tol)
-      self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
+      test_single(m_rect, args_maker, repeats, axis=1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(


### PR DESCRIPTION
This PR fixes #1233 

It largely used the same logic and test suite from numpy. 

Tested with jit compile too. 