### PR TITLE
fix broadcasting bug in rem jvp, fixes #1350

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1725,7 +1725,7 @@ ad.primitive_transposes[div_p] = _div_transpose_rule
 rem_p = standard_binop([_num, _num], 'rem')
 ad.defjvp(rem_p,
           lambda g, x, y: _brcast(g, y),
-          lambda g, x, y: mul(neg(g), floor(div(x, y))))
+          lambda g, x, y: mul(_brcast(neg(g), x), floor(div(x, y))))
 
 
 def _broadcasting_select(c, which, x, y):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1501,8 +1501,6 @@ LAX_GRAD_OPS = [
                    dtypes=[onp.float64]),
     grad_test_spec(lax.round, nargs=1, order=2, rng=jtu.rand_default(),
                    dtypes=[onp.float64]),
-    # grad_test_spec(lax.rem, nargs=2, order=2, rng=jtu.rand_default(),
-    #                dtypes=[onp.float64]),  # TODO(mattjj): enable
 
     grad_test_spec(lax.exp, nargs=1, order=2, rng=jtu.rand_small(),
                    dtypes=[onp.float64, onp.complex64]),
@@ -2286,6 +2284,22 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     ans = api.grad(lambda x: lax.stop_gradient({'foo':x})['foo'])(3.)
     expected = onp.array(0.0)
     self.assertAllClose(ans, expected, check_dtypes=False)
+
+  # TODO(mattjj): make this a more systematic test
+  def testRemainder(self):
+    rng = onp.random.RandomState(0)
+    x = rng.uniform(-0.9, 9, size=(3, 4))
+    y = rng.uniform(0.7, 1.9, size=(3, 1))
+    assert not set(onp.unique(x)) & set(onp.unique(y))
+    tol = 1e-1 if num_float_bits(onp.float64) == 32 else 1e-3
+    check_grads(lax.rem, (x, y), 2, ["fwd", "rev"], tol, tol)
+
+    rng = onp.random.RandomState(0)
+    x = rng.uniform(-0.9, 9, size=(1, 4))
+    y = rng.uniform(0.7, 1.9, size=(3, 4))
+    assert not set(onp.unique(x)) & set(onp.unique(y))
+    tol = 1e-1 if num_float_bits(onp.float64) == 32 else 1e-3
+    check_grads(lax.rem, (x, y), 2, ["fwd", "rev"], tol, tol)
 
 
 def all_bdims(*shapes):


### PR DESCRIPTION
See also [the comment around the `_brcast` implementation](https://github.com/google/jax/blob/b7b5328526d5cf624f308eabbb897b280ea8ef7c/jax/lax/lax.py#L1513-L1527).

There's an unfortunate implementation detail around broadcasting in JVPs for lax binops that bit us again here: XLA binops (like `add`, or `rem` here) do implicit broadcasting in the primitive (e.g. when applied to arguments of shapes `(3, 4)` and `(1, 4)`). When that broadcasting occurs, it means the transpose needs to include a reduce-sum. But to do that we need to know the original shape.

One solution is to make the implicit broadcasts explicit in the JVP rules. (That's why many JVP rules include calls to `_brcast`, and that's what this PR corrects in the `rem` JVP rule.) Another solution would be always to store shape information on the implicitly-broadcasting primitive itself, as some primitives have with `input_shape` parameters. (A cleaner version of the latter is to include concrete shapes in a jaxpr type system.)

The former solution would mean we can form jaxprs including these implicitly-broadcasting primitives when tracing on unshaped abstract values, but not do forward- or reverse-mode differentiation on them. The latter solution would mean we can't even form the jaxprs. In principle, we should only need these shapes to do reverse-mode differentiation.

Here's a table summarizing what we can do to programs including implicitly-broadcasting primitives on unshaped abstract values under each solution:

| Solution | form jaxpr | fwd-mode | rev-mode |
| --- | --- | --- | --- |
| shape-parameterized primitives | ❌  | ❌  | ❌  |
| explicit broadcast in JVP rules | ✅  | ❌  | ❌  |
| something smarter | ✅  | ✅  | ❌   |

We mostly went with row 2 for these implicitly-broadcasting primitives, but here (and once or twice before) missing a call to `_brcast` caused a silent error. We need a better solution, either row 1 (because tracing on unshaped values hasn't seen any application yet) or row 3.