### PR TITLE
Don't reuse SyntaxError in masking.py

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -114,6 +114,8 @@ def eval_dim_expr(env, poly):
 
 class ShapeError(Exception): pass
 
+class ShapeSyntaxError(Exception): pass
+
 # To denote some shape expressions (for annotations) we use a small language.
 #
 #   data Shape = Shape [Dim]
@@ -132,7 +134,7 @@ def parse_spec(spec=''):
   if not spec:
     return ShapeExpr(())
   if spec[0] == '(':
-    if spec[-1] != ')': raise SyntaxError(spec)
+    if spec[-1] != ')': raise ShapeSyntaxError(spec)
     spec = spec[1:-1]
   dims = map(parse_dim, spec.replace(' ', '').strip(',').split(','))
   return ShapeExpr(dims)
@@ -149,7 +151,7 @@ def parse_dim(spec):
   elif spec in identifiers:
     return parse_id(spec)
   else:
-    raise SyntaxError(spec)
+    raise ShapeSyntaxError(spec)
 digits = frozenset(string.digits)
 identifiers = frozenset(string.ascii_lowercase)
 


### PR DESCRIPTION
This exception type is really intended for errors in *Python* syntax. In
particular, IPython will add extra lines to the stack-trace to try to show
the original line of Python where the error came from.

Compare:

    In [2]: raise ValueError
    ---------------------------------------------------------------------------
    ValueError                                Traceback (most recent call last)
    <ipython-input-2-e4c8e09828d5> in <module>
    ----> 1 raise ValueError

    ValueError:

    In [3]: raise SyntaxError
    Traceback (most recent call last):

      File "/Users/shoyer/miniconda3/envs/jax-py37/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3326, in run_code
        exec(code_obj, self.user_global_ns, self.user_ns)

      File "<ipython-input-3-52c234f9b487>", line 1, in <module>
        raise SyntaxError

      File "<string>", line unknown
    SyntaxError

So I think it's better just to define our own `ShapeSyntaxError`.