### PR TITLE
Improve numerics of abs jvp (and softplus)

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1636,9 +1636,14 @@ ad.primitive_jvps[conj_p] = partial(ad.linear_jvp, conj_p)
 ad.primitive_transposes[conj_p] = _conj_transpose_rule
 
 abs_p = unop(_complex_basetype, _num, 'abs')
-ad.defjvp2(abs_p,
-           lambda g, ans, x:
-           div(_maybe_real(mul(g, _maybe_conj(x))), _replace_zero(ans)))
+
+def _abs_jvp_rule(g, ans, x):
+  if _iscomplex(x):
+    return _maybe_real(mul(g, div(_maybe_conj(x),
+           _replace_zero(convert_element_type(ans, _dtype(x))))))
+  else:
+    return select(ge(x, _zero(x)), g, neg(g))
+ad.defjvp2(abs_p, _abs_jvp_rule)
 _maybe_conj = lambda x: conj(x) if _iscomplex(x) else x
 _maybe_real = lambda x: real(x) if _iscomplex(x) else x
 

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -28,7 +28,7 @@ from jax import jarrett
 # activations
 
 def relu(x): return np.maximum(x, 0)
-def softplus(x): return np.log1p(np.exp(x))
+def softplus(x): return np.logaddexp(x, 0)
 def soft_sign(x): return x / (np.abs(x) + 1)
 def sigmoid(x): return expit(x)
 def swish(x): return x * sigmoid(x)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -35,4 +35,4 @@ class NNTest(jtu.JaxTestCase):
     check_grads(nn.softplus, (1e-8,), 4)
   def testSoftplusValue(self):
     val = nn.softplus(89.)
-    self.assertAllClose(val, 89.)
+    self.assertAllClose(val, 89., check_dtypes=False)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,4 +35,4 @@ class NNTest(jtu.JaxTestCase):
     check_grads(nn.softplus, (1e-8,), 4)
   def testSoftplusValue(self):
     val = nn.softplus(89.)
-    self.assertEqual(val, 89.)
+    self.assertAllClose(val, 89.)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for nn module."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import numpy as onp
+
+from jax import test_util as jtu
+from jax.test_util import check_grads
+from jax import nn
+from jax import random
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+class NNTest(jtu.JaxTestCase):
+  def testSoftplusGrad(self):
+    check_grads(nn.softplus, (1e-8,), 4)
+  def testSoftplusValue(self):
+    val = nn.softplus(89.)
+    self.assertEqual(val, 89.)


### PR DESCRIPTION
After receiving reports of mysterious numerical issues with fourth-order grad of `softplus`, we merged #1315 as it seemed to resolve them, but didn't have a good story for what was actually going on.

Unfortunately, this led to a different numerical problem—the previous implementation of `softplus` as `np.logaddexp(x, 0)` was much better for large x, since it's implemented as `max(x, 0) + log1p(exp(-abs(x)))` (or, essentially, `select(x > 0, x + log1p(exp(-x)), log1p(exp(x)))`). But the version with `max` and `abs` wasn't behaving exactly like the one with `select`, since that had neither numerical issue while `max`+`abs` still had bad fourth-order grads.

Eventually I narrowed the grad issue down to the JVP rule for `abs`, which is `jvp(abs)(x, g) = real(g * conj(x)) / abs(x)`, i.e. multiplying and then dividing by a number that might be very large or small. Since that is only needed for the complex case, this PR switches to a simpler JVP implementation for reals and reverts `softplus` to the more numerically-stable `logaddexp`-based implementation.

So now we have both `grad(grad(grad(grad(nn.softplus))))(1e-8) = -0.125` and `nn.softplus(89.) = 89.0`.

CC @yasamanb @Sohl-Dickstein @mcoram