### PR TITLE
Add support for multihost pmaps.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -51,7 +51,7 @@ from .tree_util import (tree_map, tree_flatten, tree_unflatten, tree_structure,
 from .util import (unzip2, unzip3, curry, partial, safe_map, safe_zip,
                    WrapHashably, Hashable, prod, split_list)
 from .lib.xla_bridge import (canonicalize_dtype, device_count,
-                             local_device_count, devices, host_id)
+                             local_device_count, devices, host_id, host_count)
 from .abstract_arrays import ShapedArray, raise_to_shaped
 from .interpreters import partial_eval as pe
 from .interpreters import xla
@@ -643,10 +643,23 @@ def pmap(fun, axis_name=None, devices=None, backend=None):
   pure maps, ``pmap`` enables the use of parallel SPMD collective operations,
   like all-reduce sum.
 
-  The mapped axis size must be less than or equal to the number of XLA devices
-  available (unless ``devices`` is specified, see below). For nested ``pmap``
-  calls, the product of the mapped axis sizes must be less than or equal to the
-  number of XLA devices.
+  The mapped axis size must be less than or equal to the number of local XLA
+  devices available, as returned by ``jax.local_device_count()`` (unless
+  ``devices`` is specified, see below). For nested ``pmap`` calls, the product
+  of the mapped axis sizes must be less than or equal to the number of XLA
+  devices.  TODO(skye): support < # local devices on multi-host platforms
+
+  **Multi-host platforms:** On multi-host platforms such as TPU pods, ``pmap``
+  is designed to be used in SPMD Python programs, where every host is running
+  the same Python code such that all hosts run the same pmapped function in the
+  same order. Each host should still call the pmapped function with mapped axis
+  size equal to the number of *local* devices (unless ``devices`` is specified,
+  see below), and an array of the same leading axis size will be returned as
+  usual. However, any collective operations in ``fun`` will be computed over
+  *all* participating devices, including those on other hosts, via
+  device-to-device communication.  Conceptually, this can be thought of as
+  running a pmap over a single array sharded across hosts, where each host
+  "sees" only its local shard of the input and output.
 
   Args:
     fun: Function to be mapped over argument axes.
@@ -654,12 +667,12 @@ def pmap(fun, axis_name=None, devices=None, backend=None):
       axis so that parallel collectives can be applied.
     devices: This is an experimental feature and the API is likely to change.
       Optional, a sequence of Devices to map over. (Available devices can be
-      retrieved via jax.devices()). If specified, the length of the sequence
-      must be equal to the size of the mapped axis. Nested ``pmap``s with
-      ``devices`` specified in either the inner or outer ``pmap`` are not yet
-      supported.
+      retrieved via jax.devices()). If specified, the size of the mapped axis
+      must be equal to the number of local devices in the sequence. Nested
+      ``pmap`` s with ``devices`` specified in either the inner or outer ``pmap``
+      are not yet supported.
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu','gpu', or 'tpu'.
+      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
 
   Returns:
     A parallelized version of ``fun`` with arguments that correspond to those of
@@ -721,10 +734,28 @@ def pmap(fun, axis_name=None, devices=None, backend=None):
   >>> print(doubly_normed.sum((0, 1)))
   1.0
 
+  On multi-host platforms, collective operations operate over all devices,
+  including those those on other hosts. For example, assuming the following code
+  runs on two hosts with 4 XLA devices each:
+
+  >>> f = lambda x: x + jax.lax.psum(x, axis_name='i')
+  >>> data = np.arange(4) if jax.host_id() == 0 else np.arange(4,8)
+  >>> out = pmap(f, axis_name='i')(data)
+  >>> print(out)
+  [28 29 30 31] # on host 0
+  [32 33 34 35] # on host 1
+
+  Each host passes in a different length-4 array, corresponding to its 4 local
+  devices, and the psum operates over all 8 values. Conceptually, the two
+  length-4 arrays can be thought of as sharded length-16 array (in this example
+  equivalent to np.arange(8)) that is mapped over, with the length-8 mapped axis
+  given name 'i'. The pmap call on each host then returns the corresponding
+  length-4 output shard.
+
   The ``devices`` argument can be used to specify exactly which devices are used
-  to run the parallel computation. For example, the following code defines
-  two parallel computations, one which runs on the first six devices and one on
-  the remaining two:
+  to run the parallel computation. For example, again assuming a single host
+  with 8 devices, the following code defines two parallel computations, one
+  which runs on the first six devices and one on the remaining two:
 
   >>> from functools import partial
   >>> @partial(pmap, axis_name='i', devices=jax.devices()[:6])

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -197,6 +197,10 @@ def host_id(backend=None):
   return get_backend(backend).host_id()
 
 
+def host_count():
+  return len(set(d.host_id for d in devices()))
+
+
 ### utility functions
 
 @util.memoize


### PR DESCRIPTION
All participating hosts are assumed to be running the same pmap code. Conceptually, this can be considered a single pmap over an array sharded on its leading pmapped dimension across the hosts. Each host passes its input shard to its pmapped function call, which returns the corresponding output shard (i.e. an array of the same leading dimension size). However, any collective operations will be run across the entire "global" array.

If the `devices` argument to pmap is None, the pmap is assumed to be running across all hosts visible to XLA (as returned by jax.host_count()). Each host can pass in an input array of leading dimension size equal to or less than the number of devices local to that host. Note that this doesn't change the current behavior for single-host platforms. If `devices` are specified, the participating hosts are dictated by the devices' host_ids, and each host must pass in an input array of leading dim size equal to the number of local participating devices.

Implementation-wise, each host independently compiles the computation, which we assume yields the same executable on all hosts (follow-up work will add more error checking). The hosts must know the global axis size of the sharded array, e.g. to provide the correct replica count to XLA. This is equal to the length of `devices` if specified, but if not, pmap is recursively called (with `devices` specified) to use `psum` to compute the global axis size.