### PR TITLE
don't over-instantiate literals

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -36,19 +36,16 @@ def identity(x): return x
 
 # A partial value (pval) is modeled as a pair (pv, const), as per
 #   type PVal = (PV, Const)
-#   data PV = NonePV | AbstractPV AbstractValue
+#   data PV = Known | Unknown AbstractValue
 #   type Const = MaybeTraced JaxType
-# where the NonePV arm indicates a known (constant) value, the AbstractPV arm
-# indicates an unknown value.
+# where the Known arm indicates a known (constant) value (represented by a None
+# payload, and the Unknown arm indicates an unknown value.
 # Additionally, when the pv is an AbstractValue, then the const must be unit.
 
 
 class JaxprTrace(Trace):
   def pure(self, val):
-    if type(val) in core.literalable_types and onp.shape(val) == ():
-      return JaxprTracer(self, PartialVal((None, val)), Literal(val))
-    else:
-      return self.new_const(val)
+    return self.new_const(val)
 
   def lift(self, val):
     return self.new_const(val)
@@ -76,8 +73,8 @@ class JaxprTrace(Trace):
     if isinstance(pv, AbstractValue):
       return tracer
     elif pv is None:
-      if type(tracer.recipe) is Literal:
-        return self.new_instantiated_literal(tracer.recipe.val)
+      if type(const) in core.literalable_types and onp.shape(const) == ():
+        return self.new_instantiated_literal(const)
       else:
         return self.new_instantiated_const(const)
     else:
@@ -392,8 +389,7 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
   env_vars, env_vals = unzip2(env.items())
   const_vars, const_vals = unzip2(consts.items())
   jaxpr = Jaxpr(const_vars, env_vars, invars, list(map(var, out_tracers)), eqns)
-  # core.skip_checks or core.check_jaxpr(jaxpr)
-  core.check_jaxpr(jaxpr)
+  core.skip_checks or core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -38,9 +38,10 @@ def identity(x): return x
 #   type PVal = (PV, Const)
 #   data PV = Known | Unknown AbstractValue
 #   type Const = MaybeTraced JaxType
-# where the Known arm indicates a known (constant) value (represented by a None
-# payload, and the Unknown arm indicates an unknown value.
-# Additionally, when the pv is an AbstractValue, then the const must be unit.
+# where the Known arm, represented by a None, indicates a known (constant) value
+# and the Unknown arm, represented by an AbstractValue instance, indicates an
+# unknown value.
+# When the pv is an AbstractValue, then the const must be unit.
 
 
 class JaxprTrace(Trace):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -981,6 +981,17 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     key = random.PRNGKey(0)
     api.grad(lambda c: lax.scan(f, (c, key), onp.ones(3))[0][0])(0.)  # doesn't crash
 
+  def testIssue1361(self):
+    @api.jit
+    def jit_run_scan(x):
+      def fun(carry, _):
+        x, _ = carry
+        return (2 * x, 0.), None
+      (x, _), _ = lax.scan(fun, (x, 0.), np.arange(3))
+      return x
+
+    api.grad(lambda x: jit_run_scan(x))(0.)  # doesn't crash
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #1361

During partial evaluation, constants should only be instantiated in a jaxpr when necessary. Constants that are known during tracing time, like literals, shouldn't always be staged into the jaxpr. We were always putting literals in the staged-out jaxpr. As a consequence, we had a literal `0.0` appearing in both `jaxpr_1` and `jaxpr_2` of `_scan_partial_eval`, while exactly one of those should be a unit (in this case the latter).