### PR TITLE
Make `assertAllClose` work with non-array types.

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -516,6 +516,8 @@ class JaxTestCase(parameterized.TestCase):
       x = onp.asarray(x)
       y = onp.asarray(y)
       self.assertArraysAllClose(x, y, check_dtypes, atol=atol, rtol=rtol)
+    elif x == y:
+        return
     else:
       raise TypeError((type(x), type(y)))
 


### PR DESCRIPTION
In our application this would make comparing trees with other entries like Nones and enums easier. I may be missing some other issues though, let me know if this change makes sense!