### PR TITLE
add a "last" symbol for vmap axis specs, use it in `api.jacfwd`

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -357,6 +357,41 @@ class APITest(jtu.JaxTestCase):
                 (onp.array([0., 0.]), onp.array([0., 2.])))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @jtu.skip_on_devices("tpu")
+  def test_issue1372(self):
+    def quad(x):
+      return np.dot(x, x)
+
+    def f(x, u):
+      return quad(x) + quad(u)
+
+    x, u = np.ones(5), np.ones(2)
+
+    rev = jacrev
+    fwd = jacfwd
+
+    # Diagonal entries
+    self.assertEqual(rev(rev(f, 0), 0)(x, u).shape, (5, 5))
+    self.assertEqual(rev(fwd(f, 0), 0)(x, u).shape, (5, 5))
+    self.assertEqual(fwd(rev(f, 0), 0)(x, u).shape, (5, 5))
+    self.assertEqual(fwd(fwd(f, 0), 0)(x, u).shape, (5, 5))
+    self.assertEqual(rev(rev(f, 1), 1)(x, u).shape, (2, 2))
+    self.assertEqual(rev(fwd(f, 1), 1)(x, u).shape, (2, 2))
+    self.assertEqual(fwd(rev(f, 1), 1)(x, u).shape, (2, 2))
+    self.assertEqual(fwd(fwd(f, 1), 1)(x, u).shape, (2, 2))
+
+    # Off-diagonal entries by reverse-mode on the outside
+    self.assertEqual(rev(rev(f, 1), 0)(x, u).shape, (2, 5))
+    self.assertEqual(rev(fwd(f, 1), 0)(x, u).shape, (2, 5))
+    self.assertEqual(rev(rev(f, 0), 1)(x, u).shape, (5, 2))
+    self.assertEqual(rev(fwd(f, 0), 1)(x, u).shape, (5, 2))
+
+    # Off-diagonal entries by forward-mode on the outside
+    self.assertEqual(fwd(rev(f, 1), 0)(x, u).shape, (2, 5))
+    self.assertEqual(fwd(fwd(f, 1), 0)(x, u).shape, (2, 5))
+    self.assertEqual(fwd(rev(f, 0), 1)(x, u).shape, (5, 2))
+    self.assertEqual(fwd(fwd(f, 0), 1)(x, u).shape, (5, 2))
+
   def test_disable_jit(self):
     effects = []
 


### PR DESCRIPTION
Extending the vmap API in this way resolves ambiguity in how to specify the final dimension as the batched axis.