### PR TITLE
Add optional `tuple_args` argument to xla_computation.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -194,7 +194,8 @@ def disable_jit():
     _thread_local_state.jit_is_disabled = prev_val
 
 
-def xla_computation(fun, static_argnums=(), axis_env=None, backend=None):
+def xla_computation(fun, static_argnums=(), axis_env=None, backend=None,
+                    tuple_args=False):
   """Creates a function that produces its XLA computation given example args.
 
   Args:
@@ -208,6 +209,9 @@ def xla_computation(fun, static_argnums=(), axis_env=None, backend=None):
       applications of ``jax.pmap``. See the examples below.
     backend: This is an experimental feature and the API is likely to change.
       Optional, a string representing the xla backend. 'cpu','gpu', or 'tpu'.
+    tuple_args: Optional, defaults to False. If True, the resulting XLA
+      computation will have a single tuple argument that is unpacked into the
+      specified function arguments.
 
   Returns:
     A wrapped version of ``fun`` that when applied to example arguments returns a
@@ -291,7 +295,7 @@ def xla_computation(fun, static_argnums=(), axis_env=None, backend=None):
     pvals = map(pv_like, jax_args)
     jaxpr, _, consts = pe.trace_to_jaxpr(jaxtree_fun, pvals)
     axis_env_ = make_axis_env(xla.jaxpr_replicas(jaxpr))
-    return xla.build_jaxpr(jaxpr, backend, axis_env_, consts,
+    return xla.build_jaxpr(jaxpr, backend, axis_env_, consts, tuple_args,
                            *map(xla.abstractify, jax_args))
   return computation_maker
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -207,9 +207,10 @@ def compile_jaxpr(jaxpr, device, backend, axis_env, const_vals, tuple_args,
   return built_c.Compile(compile_options=compile_opts,
                          backend=xb.get_backend(backend))
 
-def build_jaxpr(jaxpr, backend, axis_env, const_vals, *abstract_args):
+def build_jaxpr(jaxpr, backend, axis_env, const_vals, tuple_args, *abstract_args):
   arg_shapes = map(aval_to_xla_shape, abstract_args)
-  return jaxpr_computation(jaxpr, backend, axis_env, const_vals, (), arg_shapes)
+  return jaxpr_computation(jaxpr, backend, axis_env, const_vals, (), arg_shapes,
+                           tuple_args=tuple_args)
 
 def prefetch(x):
   if isinstance(x, DeviceArray):
@@ -240,7 +241,8 @@ def jaxpr_computation(jaxpr, backend, axis_env, const_vals, freevar_shapes,
   _map(prefetch, it.chain(const_vals, jaxpr_literals(jaxpr)))
   consts = _map(c.Constant, const_vals)
   if tuple_args:
-    tuple_shape = xc.Shape.tuple_shape(list(freevar_shapes) + list(arg_shapes))
+    freevar_shapes, arg_shapes = list(freevar_shapes), list(arg_shapes)
+    tuple_shape = xc.Shape.tuple_shape(freevar_shapes + arg_shapes)
     tuple_arg = c.ParameterWithShape(tuple_shape)
     nfreevars, nargs = len(freevar_shapes), len(arg_shapes)
     freevars = [c.GetTupleElement(tuple_arg, i) for i in range(nfreevars)]


### PR DESCRIPTION
This is useful when using JAX to create an HLO module that is compiled
and executed elsewhere.