### PR TITLE
Rm duplicates from end_nodes in toposort

### DIFF
--- a/jax/util.py
+++ b/jax/util.py
@@ -107,6 +107,7 @@ def curry(f):
 
 def toposort(end_nodes):
   if not end_nodes: return []
+  end_nodes = _remove_duplicates(end_nodes)
 
   child_counts = {}
   stack = list(end_nodes)
@@ -140,6 +141,15 @@ def check_toposort(nodes):
   for node in nodes:
     assert all(id(parent) in visited for parent in node.parents)
     visited.add(id(node))
+
+def _remove_duplicates(node_list):
+  seen = set()
+  out = []
+  for n in node_list:
+    if id(n) not in seen:
+      seen.add(id(n))
+      out.append(n)
+  return out
 
 def split_merge(predicate, xs):
   sides = list(map(predicate, xs))


### PR DESCRIPTION
The `end_nodes` argument of `toposort` can contain duplicates, when a user jits a function with repeated outputs (something like `lambda x: (x, x)`). It seems toposort handles this situation badly, and the length of its return value can be (much) higher than the number of nodes in the original graph.

A simple repro:
```python
from jax.util import toposort
from collections import namedtuple

Node = namedtuple('Node', 'parents')

# Create a graph containing 11 nodes
n = Node([])
for i in range(10):
    n = Node([n])

print(len(toposort((n, n))))         # prints 22, should be 11
```
The length scales with the number of parents that `n` has and the number of times it is repeated. In my code this was causing serious performance issues (toposort was generating a list with ~80 million elements for a graph with ~3000 nodes).

This pr contains a straightforward fix, by removing duplicates from `end_nodes` at the start of `toposort`.