### PR TITLE
thread through some debug metadata to XLA

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -85,6 +85,8 @@ def new_jaxpr_eqn(*args):
 JaxprEqn = namedtuple('JaxprEqn', ['eqn_id', 'invars', 'outvars', 'primitive',
                                    'bound_subjaxprs', 'params'])
 
+JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn))
+
 class Literal(object):
   __slots__ = ["val", "hash"]
 
@@ -616,26 +618,27 @@ def check_jaxpr(jaxpr):
   map(read, jaxpr.outvars)
 
 
-def pp_jaxpr(jaxpr):
-  def print_vars(vs):
+def pp_vars(vs):
     return ' '.join(map(str, vs))
 
-  def pp_eqn(eqn):
-    lhs = print_vars(eqn.outvars)
-    pp_subexpr = pp('')
-    if eqn.bound_subjaxprs:
-      for subjaxpr, const_vars, bound_vars in eqn.bound_subjaxprs:
-        pp_subexpr = pp_subexpr + (
-            pp_jaxpr(subjaxpr).indent(2)
-            >> pp(' [ {} ; {} ]'.format(print_vars(const_vars),
-                                        print_vars(bound_vars))))
-    return (pp('{} = '.format(lhs)) >>
-            pp(eqn.primitive.name) >> pp_kv_pairs(eqn.params.items())
-            >> pp(' ') >> pp(print_vars(eqn.invars))) + pp_subexpr
+def pp_eqn(eqn):
+  lhs = pp_vars(eqn.outvars)
+  pp_subexpr = pp('')
+  if eqn.bound_subjaxprs:
+    for subjaxpr, const_vars, bound_vars in eqn.bound_subjaxprs:
+      pp_subexpr = pp_subexpr + (
+          pp_jaxpr(subjaxpr).indent(2)
+          >> pp(' [ {} ; {} ]'.format(pp_vars(const_vars),
+                                      pp_vars(bound_vars))))
+  return (pp('{} = '.format(lhs)) >>
+          pp(eqn.primitive.name) >> pp_kv_pairs(eqn.params.items())
+          >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
-  return (pp('{{ lambda {} ; {} ; {}.'.format(print_vars(jaxpr.constvars),
-                                              print_vars(jaxpr.freevars),
-                                              print_vars(jaxpr.invars))) +
+def pp_jaxpr(jaxpr):
+
+  return (pp('{{ lambda {} ; {} ; {}.'.format(pp_vars(jaxpr.constvars),
+                                              pp_vars(jaxpr.freevars),
+                                              pp_vars(jaxpr.invars))) +
           ((pp('let ') >>
             vcat(map(pp_eqn, jaxpr.eqns))) +
            pp('in {} }}'.format(jaxpr.outvars))).indent(2))

--- a/jax/core.py
+++ b/jax/core.py
@@ -85,7 +85,7 @@ def new_jaxpr_eqn(*args):
 JaxprEqn = namedtuple('JaxprEqn', ['eqn_id', 'invars', 'outvars', 'primitive',
                                    'bound_subjaxprs', 'params'])
 
-JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn))
+JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn))[:-1]
 
 class Literal(object):
   __slots__ = ["val", "hash"]
@@ -635,7 +635,6 @@ def pp_eqn(eqn):
           >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
 def pp_jaxpr(jaxpr):
-
   return (pp('{{ lambda {} ; {} ; {}.'.format(pp_vars(jaxpr.constvars),
                                               pp_vars(jaxpr.freevars),
                                               pp_vars(jaxpr.invars))) +


### PR DESCRIPTION
Hopefully this makes our profiles prettier. Unclear how to test in the absence of `GetOpMetadata()` or `GetHloPrototxt()` methods, but I checked that the `op_type`, `op_name`, and source info fields seem to make sense. The `skip_frames` value is set such that:
- For a primitive computation, the reported source line will be the line where the lax op was called (this might be inside lax.numpy)
- For a `jit` computation, the reported source line will be the line where `jit` was called. Doing anything smarter (e.g. tracking source line for the function being jitted) would require threading debuginfo through the jaxprs themselves, which would be a lot more work.
- For the inner part of a nested `jit`, the source line won't be very useful.

Edit: not going to set the source info metadata for now, because @skye points out that caching makes it pretty useless.