### PR TITLE
Fix typo in notebook JSON

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -131,9 +131,9 @@
     },
     "colab_type": "code",
     "id": "2AxeCufq4wAp",
-    "outputId": "7013374b-041f-4270-db19-cfb4ab992f52"
+    "outputId": "7013374b-041f-4270-db19-cfb4ab992f52",
     "tags": [
-        "raises-exception",
+        "raises-exception"
     ]
    },
    "outputs": [


### PR DESCRIPTION
Perhaps this is the reason why readthedocs does not show the link to the notebook?