### PR TITLE
optimize scan with constant-across-time outputs

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -489,19 +489,42 @@ def _scan_impl(*args, **kwargs):
 
   consts, init, xs = split_list(args, [num_consts, num_carry])
   _, _, x_avals = split_list(jaxpr.in_avals, [num_consts, num_carry])
-  _, y_avals = split_list(jaxpr.out_avals, [num_carry])
+
+  # Some inputs to a scanned function are constant across time.
+  # Outputs that depend only on these constant inputs are also
+  # constant across time! As an optimization, we use partial_eval
+  # to identify these outputs and compute them outside the scan.
+  # This avoids slow and unnecessary slice updates inside the loop
+  # and may allow XLA to optimize out their time-axis broadcast.
+
+  uk_in = [False] * num_consts + [True] * (len(jaxpr.in_avals) - num_consts)
+  instantiate = [True] * num_carry + [False] * (len(jaxpr.out_avals) - num_carry)
+  const_jaxpr, step_jaxpr, uk_out = pe.partial_eval_jaxpr(jaxpr, uk_in, instantiate)
+
+  out_avals = [aval if uk else core.abstract_unit
+               for aval, uk in zip(jaxpr.out_avals, uk_out)]
+  _, y_avals = split_list(out_avals, [num_carry])
+
+  const_outs = core.jaxpr_as_fun(const_jaxpr)(
+      *(consts + [core.unit] * (len(jaxpr.in_avals) - num_consts)))
+  _, const_ys, residuals = split_list(
+      const_outs, [num_carry, len(jaxpr.out_avals) - num_carry])
 
   def body_fun(i, vals):
     i = i if forward else length - i - 1
     carry, ys = split_list(vals, [num_carry])
     x = _map(partial(_index_array, i), x_avals, xs)
-    out_flat = core.jaxpr_as_fun(jaxpr)(*(consts + carry + x))
+    out_flat = core.jaxpr_as_fun(step_jaxpr)(*(consts + carry + x + residuals))
     carry_out, y_updates = split_list(out_flat, [num_carry])
     ys_out = _map(partial(_update_array, i), y_avals, ys, y_updates)
     return carry_out + ys_out
 
   ys_init = _map(partial(_empty_array, length), y_avals)
-  return fori_loop(0, length, body_fun, init + ys_init)
+  nonconst_outs = fori_loop(0, length, body_fun, init + ys_init)
+  carry_out, nonconst_ys = split_list(nonconst_outs, [num_carry])
+  ys_out = [n if c is core.unit else c[None, ...]
+            for c, n in zip(const_ys, nonconst_ys)]
+  return carry_out + ys_out
 
 def _index_array(i, aval, x):
   if aval is core.abstract_unit:
@@ -578,7 +601,7 @@ def _scan_partial_eval(trace, *tracers, **kwargs):
   num_xs = len(jaxpr.in_avals) - num_carry - num_consts
   num_ys = len(jaxpr.out_avals) - num_carry
 
-  unknowns = original_unknowns = [t.pval[0] is not None for t in tracers]
+  unknowns = [t.pval[0] is not None for t in tracers]
   const_uk, init_uk, xs_uk = split_list(unknowns, [num_consts, num_carry])
 
   carry_uk = init_uk

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1010,6 +1010,20 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     api.grad(lambda x: jit_run_scan(x))(0.)  # doesn't crash
 
+  def testIssue810(self):
+    def loss(A):
+      def step(x, i):
+        return A @ x, None
+      init_x = np.zeros(A.shape[-1:])
+      last_x, _ = lax.scan(step, init_x, np.arange(10))
+      return np.sum(last_x)
+
+    A = np.zeros((3, 3))
+    # The second DUS was unnecessarily replicating A across time.
+    # We check XLA because _scan_impl is "underneath" the jaxpr language.
+    s = str(api.xla_computation(api.grad(loss))(A).GetHloText())
+    assert s.count("dynamic-update-slice(") < 2
+
   def test_root_scalar(self):
 
     def scalar_solve(f, y):


### PR DESCRIPTION
The `lax.scan` primitive has a notion of _inputs_ that are constant across time. But occasionally (typically in transformations) we create scans where the step function has one or more _outputs_ that are also constant across time. Currently, this leads to slow and unnecessary slicing/updates inside the loop which are essentially impossible for XLA to optimize away.

Instead, we can use partial_eval to identify these constant outputs and compute them once outside the scan. Although we still broadcast them across the time axis (since that's the semantics of scan), XLA is likely able to eliminate or fuse that broadcast in some cases.

This should improve the situation in #810 somewhat, though there are certainly more missing optimizations on both the JAX and XLA sides (and, beyond that, some unavoidable overheads of using a rolled loop).

Details of one case (present in #810) that now triggers this optimization, plus one thing that we're currently still missing:

Computing `grad(scan)` relies on partially evaluating `jvp(scan)`, itself a scan with some primal and some tangent inputs, in order to split it into two scans for the primal and tangent computations. But the primal values (aka linearization points or residuals) that are output from the primal scan and input to the tangent scan may include values that are constant across time, and those should ideally be evaluated only once, outside the primal scan, and passed as constant inputs to the tangent scan. With this optimization, they're evaluated once rather than many times, but then they're still replicated across the time axis and passed as  yet passed as constant inputs.

We may want to special-case `_scan_partial_eval` or modify the scan API in order to go all the way; I'm looking into that possibility now.