### PR TITLE
Remove `dot` primitive in favor of reusing `dot_general`

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -411,11 +411,6 @@ _defreducer(lax.reduce_max_p, pmax_p)
 _defreducer(lax.reduce_min_p, pmin_p)
 
 
-def _dot_papply_rule(name, size, vals, dims, precision):
-  x, _ = vals
-  dim_nums = [((x.ndim,), (0,)), ((), ())]
-  return _dot_general_papply_rule(name, size, vals, dims, dim_nums, precision)
-
 def _dot_general_papply_rule(name, size, vals, dims, dimension_numbers,
                              precision):
   x, y = vals
@@ -700,7 +695,6 @@ def _gather_papply_rule(
     raise NotImplementedError
 
 
-parallel.papply_primitive_rules[lax.dot_p] = _dot_papply_rule
 parallel.papply_primitive_rules[lax.dot_general_p] = _dot_general_papply_rule
 parallel.papply_primitive_rules[lax.reshape_p] = _reshape_papply_rule
 parallel.papply_primitive_rules[lax.transpose_p] = _transpose_papply_rule

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -233,7 +233,6 @@ class BatchingTest(jtu.JaxTestCase):
     y = R(3, 10, 5, 6)
     fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     ans = vmap(fun, in_axes=(2, 1))(x, y)
-    fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     expected = onp.stack([fun(x[..., i, :], y[:, i, ...]) for i in range(10)])
     self.assertAllClose(ans, expected, check_dtypes=True)
 
@@ -241,7 +240,6 @@ class BatchingTest(jtu.JaxTestCase):
     y = R(3, 5, 6)
     fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     ans = vmap(fun, in_axes=(3, None))(x, y)
-    fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     expected = onp.stack([fun(x[..., i], y) for i in range(10)])
     self.assertAllClose(ans, expected, check_dtypes=True)
 
@@ -249,8 +247,14 @@ class BatchingTest(jtu.JaxTestCase):
     y = R(3, 5, 10, 6)
     fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     ans = vmap(fun, in_axes=(None, 2))(x, y)
-    fun = lambda x, y: lax.dot_general(x, y, [((2,), (1,)), ((0,), (0,))])
     expected = onp.stack([fun(x, y[..., i, :]) for i in range(10)])
+    self.assertAllClose(ans, expected, check_dtypes=True)
+
+    x = R(4)
+    y = R(4, 10)
+    fun = lambda x, y: lax.dot_general(x, y, [((0,), (0,)), ((), ())])
+    ans = vmap(fun, in_axes=(None, 1))(x, y)
+    expected = onp.stack([fun(x, y[..., i]) for i in range(10)])
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testDot(self):

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -64,7 +64,7 @@ class MaskingTest(jtu.JaxTestCase):
     def thunk():
       @shapecheck(['(m, n)', 'n'], 'm')
       def matvec(A, b):
-        return np.dot(b, A)
+        return lax.dot_general(A, b, [((0,), (0,)), ((), ())])
     self.assertRaisesRegex(ShapeError, "", thunk)
 
   def test_flatten_shape_checking(self):


### PR DESCRIPTION
There's only one underlying `dot` HLO, so this shouldn't change anything for XLA.

Also beefs up the dot_general batch rule to add a missing optimization that was needed for a test.