### PR TITLE
fix XLA metadata for primitives with many args

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 from operator import attrgetter
 from contextlib import contextmanager
 from collections import namedtuple, Counter, defaultdict
+import itertools as it
 from weakref import ref
 import threading
 import types
@@ -86,6 +87,25 @@ JaxprEqn = namedtuple('JaxprEqn', ['eqn_id', 'invars', 'outvars', 'primitive',
                                    'bound_subjaxprs', 'params'])
 
 JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn))[:-1]
+
+class Var(object):
+  def __init__(self, count, suffix):
+    self.count = count
+    self.suffix = suffix
+
+  def __repr__(self):
+    rem = self.count
+    s = ''
+    while True:
+      rem, i = rem // 26, rem % 26
+      s = chr(97 + i % 26) + s
+      if not rem:
+        break
+    return s + self.suffix
+
+def gensym(suffix):
+  counter = it.count()
+  return lambda: Var(next(counter), suffix)
 
 class Literal(object):
   __slots__ = ["val", "hash"]

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -382,7 +382,7 @@ def eqn_tracer_to_var(var, eqn):
 
 
 def tracers_to_jaxpr(in_tracers, out_tracers):
-  newvar = gensym('')
+  newvar = core.gensym('')
   t_to_var = defaultdict(newvar)
   var = lambda t: t_to_var[id(t)]
   sorted_tracers = toposort(out_tracers)
@@ -420,25 +420,6 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
   core.skip_checks or core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
-
-def gensym(suffix):
-  counter = it.count()
-  return lambda: Var(next(counter), suffix)
-
-class Var(object):
-  def __init__(self, count, suffix):
-    self.count = count
-    self.suffix = suffix
-
-  def __repr__(self):
-    rem = self.count
-    s = ''
-    while True:
-      rem, i = rem // 26, rem % 26
-      s = chr(97 + i % 26) + s
-      if not rem:
-        break
-    return s + self.suffix
 
 def eqn_parents(eqn):
   subjaxpr_tracers = [it.chain(c, f) for _, c, f in eqn.bound_subjaxprs]

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -143,11 +143,12 @@ def primitive_computation(prim, *xla_shapes, **params):
   backend = params.get('backend', None)
   new_params = {k: params[k] for k in params if k != 'backend'}
   c = xb.make_computation_builder("primitive_computation_{}".format(prim.name))
+  newvar = core.gensym('')
   c.SetOpMetadata(xc.OpMetadata(
       op_type=prim.name,
       op_name=str(core.new_jaxpr_eqn(
-          [chr(ord('a') + i) for i in range(len(xla_shapes))],
-          [chr(ord('a') + len(xla_shapes))],
+          [newvar() for i in range(len(xla_shapes))],
+          [newvar()],
           prim, (), params))
   ))
   platform = xb.get_backend(backend).platform

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -72,6 +72,17 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertEqual(cloop(2), limit - 2)
     self.assertEqual(cloop(3), limit - 3)
 
+  def testWhileWithManyArgs(self):
+    nargs = 256
+
+    def loop_cond(state):
+      return lax.lt(state[0], 2)
+
+    def loop_body(state):
+      return tuple(lax.add(s, 1) for s in state)
+
+    _ = lax.while_loop(loop_cond, loop_body, (0,) * nargs)
+
   def testNestedWhile(self):
 
     def outer_loop(num):  # pylint: disable=missing-docstring


### PR DESCRIPTION
I forgot that control flow primitives can have arbitrarily many arguments, so this changes the metadata string to reuse the same infrastructure as partial_eval to gensym vars for the jaxpr equation. Also adds a test for the previously-failing case.