### PR TITLE
Speedup JVP for triangular solve

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -319,18 +319,28 @@ def triangular_solve_jvp_rule_a(
     g_a, ans, a, b, left_side, lower, transpose_a, conjugate_a, unit_diagonal):
   if g_a is ad_util.zero:
     return ad_util.zero
+  m, n = b.shape[-2:]
   k = 1 if unit_diagonal else 0
   g_a = np.tril(g_a, k=-k) if lower else np.triu(g_a, k=k)
   g_a = lax.neg(g_a)
   g_a = np.swapaxes(g_a, -1, -2) if transpose_a else g_a
   g_a = np.conj(g_a) if conjugate_a else g_a
-  tmp = triangular_solve(a, g_a, left_side, lower, transpose_a, conjugate_a,
-                         unit_diagonal)
   dot = lax.dot if g_a.ndim == 2 else lax.batch_matmul
+
+  def a_inverse(rhs):
+    return triangular_solve(a, rhs, left_side, lower, transpose_a, conjugate_a,
+                            unit_diagonal)
+
   if left_side:
-    return dot(tmp, ans)
+    # triangular_solve is about the same cost as matrix multplication (~n^2
+    # FLOPs for matrix/vector inputs). So order these operations in whichever
+    # order is cheaper.
+    if m > n:
+      return a_inverse(dot(g_a, ans))
+    else:
+      return dot(a_inverse(g_a), ans)
   else:
-    return dot(ans, tmp)
+    return dot(ans, a_inverse(g_a))
 
 def triangular_solve_transpose_rule(
     cotangent, a, b, left_side, lower, transpose_a, conjugate_a,

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -332,13 +333,13 @@ def triangular_solve_jvp_rule_a(
                             unit_diagonal)
 
   if left_side:
-    # triangular_solve is about the same cost as matrix multplication (~n^2
-    # FLOPs for matrix/vector inputs). So order these operations in whichever
-    # order is cheaper.
+    # Note: triangular_solve is about the same cost as matrix multplication
+    # (~n^2 FLOPs for matrix/vector inputs). Order these operations in
+    # whichever order is cheaper.
     if m > n:
-      return a_inverse(dot(g_a, ans))
+      return a_inverse(dot(g_a, ans))  # A^{-1} (∂A X)
     else:
-      return dot(a_inverse(g_a), ans)
+      return dot(a_inverse(g_a), ans)  # (A^{-1} ∂A) X
   else:
     return dot(ans, a_inverse(g_a))
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -30,6 +30,7 @@ from absl.testing import parameterized
 import jax
 import jax.lib
 from jax import jit, grad, jvp, vmap
+from jax import lax_linalg
 from jax import numpy as np
 from jax import scipy as jsp
 from jax import test_util as jtu
@@ -750,33 +751,40 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs={}_rhs={}_lower={}_transposea={}_unit_diagonal={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype),
-           lower, transpose_a, unit_diagonal),
-       "lower": lower, "transpose_a": transpose_a,
-       "unit_diagonal": unit_diagonal, "lhs_shape": lhs_shape,
-       "rhs_shape": rhs_shape, "dtype": dtype, "rng": rng}
+       "_A={}_B={}_lower={}_transposea={}_conja={}_unitdiag={}_leftside={}".format(
+           jtu.format_shape_dtype_string(a_shape, dtype),
+           jtu.format_shape_dtype_string(b_shape, dtype),
+           lower, transpose_a, conjugate_a, unit_diagonal, left_side),
+       "lower": lower, "transpose_a": transpose_a, "conjugate_a": conjugate_a,
+       "unit_diagonal": unit_diagonal, "left_side": left_side,
+       "a_shape": a_shape, "b_shape": b_shape, "dtype": dtype, "rng": rng}
       for lower in [False, True]
       for unit_diagonal in [False, True]
       for dtype in float_types + complex_types
-      for transpose_a in (
-        [0, 1] if onp.issubdtype(dtype, np.floating) else [0, 1, 2])
-      for lhs_shape, rhs_shape in [
-          ((4, 4), (4,)),
-          ((4, 4), (4, 3)),
-          ((2, 8, 8), (2, 8, 10)),
+      for transpose_a in [False, True]
+      for conjugate_a in (
+          [False] if onp.issubdtype(dtype, np.floating) else [False, True])
+      for left_side, a_shape, b_shape in [
+          (False, (4, 4), (1, 4,)),
+          (False, (3, 3), (4, 3)),
+          (True, (4, 4), (4, 1)),
+          (True, (4, 4), (4, 3)),
+          (True, (2, 8, 8), (2, 8, 10)),
       ]
       for rng in [jtu.rand_default()]))
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): Test fails on TPU.
-  def testSolveTriangularGrad(self, lower, transpose_a, unit_diagonal,
-                              lhs_shape, rhs_shape, dtype, rng):
+  def testTriangularSolveGrad(
+      self, lower, transpose_a, conjugate_a, unit_diagonal, left_side, a_shape,
+      b_shape, dtype, rng):
     _skip_if_unsupported_type(dtype)
-    A = np.tril(rng(lhs_shape, dtype) + 5 * onp.eye(lhs_shape[-1], dtype=dtype))
+    # Test lax_linalg.triangular_solve instead of scipy.linalg.solve_triangular
+    # because it exposes more options.
+    A = np.tril(rng(a_shape, dtype) + 5 * onp.eye(a_shape[-1], dtype=dtype))
     A = A if lower else T(A)
-    B = rng(rhs_shape, dtype)
-    f = partial(jsp.linalg.solve_triangular, lower=lower, trans=transpose_a,
-                unit_diagonal=unit_diagonal)
+    B = rng(b_shape, dtype)
+    f = partial(lax_linalg.triangular_solve, lower=lower,
+                transpose_a=transpose_a, conjugate_a=conjugate_a,
+                unit_diagonal=unit_diagonal, left_side=left_side)
     jtu.check_grads(f, (A, B), 2, rtol=2e-2, eps=1e-3)
 
 


### PR DESCRIPTION
There is still room for improvement, e.g., by combining the currently separate
JVPs for a and b into a single expression (which will allow for saving an inner
triangular solve when both arguments are being differentiated), but this is
already significantly faster in the typical case of only solving a single
vector.

On my laptop's CPU, I measure 2.98 ms before vs 1.18 ms after on a 500x500 matrix (the forward pass is 527 µs):

    import numpy as onp
    import jax.numpy as np
    import jax
    rs = onp.random.RandomState(0)
    a = rs.randn(500, 500)
    b = rs.randn(500)

    @jax.jit
    def loss(a, b):
      return np.sum(jax.scipy.linalg.solve_triangular(a, b))
    grad = jax.jit(jax.grad(loss))

    %timeit jax.device_get(grad(a, b))