### PR TITLE
Fixed the readthedocs documentation build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,8 @@
 jaxlib
 ipykernel
 nbsphinx
+# The next packages are for readthedocs
+matplotlib
+# Must install jax itself for notebook execution to work
+.
+


### PR DESCRIPTION
Had to extend the docs/requirements.txt file to install
matplotlb (needed by the Gotchas notebook) and ".",
needed by everything. This results in a reduction
of the sphinx warnings from 3300 to 1200!