### PR TITLE
Preserve precision config in dot_general transpose rule

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2088,7 +2088,8 @@ def _dot_general_transpose_lhs(g, y, dimension_numbers, precision,
   dims = ((ans_y, y_kept), (ans_batch, y_batch))
   x_contract_sorted_by_y = list(onp.take(x_contract, onp.argsort(y_contract)))
   out_axes = onp.argsort(list(x_batch) + x_kept + x_contract_sorted_by_y)
-  return transpose(dot_general(g, y, dims), tuple(out_axes))
+  return transpose(dot_general(g, y, dims, precision=precision),
+                   tuple(out_axes))
 
 def _dot_general_transpose_rhs(g, x, dimension_numbers, precision):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -400,6 +400,7 @@ def concatenate(operands, dimension):
                             operand_shapes=tuple(o.shape for o in operands))
 
 Precision = xla_client.PrecisionConfig.Precision
+Precision.__str__ = lambda precision: precision.name
 
 def conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation=None,
                          rhs_dilation=None, dimension_numbers=None,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1812,6 +1812,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     dot = partial(lax.dot, precision=lax.Precision.HIGHEST)
     check_grads_bilinear(dot, (lhs, rhs), order=2, modes=["fwd", "rev"],
                          atol=tol, rtol=tol)
+    # check that precision config is preserved
+    result, pullback = api.vjp(dot, lhs, rhs)
+    gresult = lax.zeros_like_array(result)
+    s = str(api.make_jaxpr(pullback)(gresult))
+    assert "precision=HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -1837,6 +1842,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                           precision=lax.Precision.HIGHEST)
     check_grads_bilinear(dot_general, (lhs, rhs), order=2, modes=["fwd", "rev"],
                          atol=tol, rtol=tol)
+    # check that precision config is preserved
+    result, pullback = api.vjp(dot_general, lhs, rhs)
+    gresult = lax.zeros_like_array(result)
+    s = str(api.make_jaxpr(pullback)(gresult))
+    assert "precision=HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}".format(


### PR DESCRIPTION
Removing `dot` revealed this latent bug in `dot_general`.