### PR TITLE
Remove unnecessary zero checks from JVP rules in lax_linalg

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -103,9 +103,6 @@ def cholesky_jvp_rule(primals, tangents):
   sigma_dot, = tangents
   L = np.tril(cholesky_p.bind(x))
 
-  if sigma_dot is ad_util.zero:
-    return L, ad_util.zero
-
   # Forward-mode rule from https://arxiv.org/pdf/1602.07527.pdf
   def phi(X):
     l = np.tril(X)
@@ -262,9 +259,6 @@ def eigh_jvp_rule(primals, tangents, lower):
 
   v, w = eigh_p.bind(symmetrize(a), lower=lower)
 
-  if a_dot is ad_util.zero:
-    return core.pack((v, w)), ad.TangentTuple(ad_util.zero, ad_util.zero)
-
   # for complex numbers we need eigenvalues to be full dtype of v, a:
   w = w.astype(a.dtype)
   eye_n = np.eye(a.shape[-1], dtype=a.dtype)
@@ -326,8 +320,6 @@ def triangular_solve_shape_rule(a, b, left_side=False, **unused_kwargs):
 
 def triangular_solve_jvp_rule_a(
     g_a, ans, a, b, left_side, lower, transpose_a, conjugate_a, unit_diagonal):
-  if g_a is ad_util.zero:
-    return ad_util.zero
   m, n = b.shape[-2:]
   k = 1 if unit_diagonal else 0
   g_a = np.tril(g_a, k=-k) if lower else np.triu(g_a, k=k)
@@ -537,10 +529,6 @@ def _lu_jvp_rule(primals, tangents):
   a_dot, = tangents
   lu, pivots = lu_p.bind(a)
 
-  if a_dot is ad_util.zero:
-    return (core.pack((lu, pivots)),
-            ad.TangentTuple((ad_util.zero, ad_util.zero)))
-
   a_shape = np.shape(a)
   m, n = a_shape[-2:]
   dtype = lax.dtype(a)
@@ -680,8 +668,6 @@ def qr_jvp_rule(primals, tangents, full_matrices):
   x, = primals
   dx, = tangents
   q, r = qr_p.bind(x, full_matrices=False)
-  if dx is ad_util.zero:
-    return core.pack((q, r)), ad.TangentTuple(ad_util.zero, ad_util.zero)
   if full_matrices or np.shape(x)[-2] < np.shape(x)[-1]:
     raise NotImplementedError
   dx_rinv = triangular_solve(r, dx)  # Right side solve by default
@@ -777,9 +763,6 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
   A, = primals
   dA, = tangents
   s, U, Vt = svd_p.bind(A, full_matrices=False, compute_uv=True)
-
-  if dA is ad_util.zero:
-    return ((s, U, Vt), (ad_util.zero, ad_util.zero, ad_util.zero))
 
   if full_matrices:
     # TODO: implement full matrices case, documented here: https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf


### PR DESCRIPTION
I'm pretty sure all of these are dead code that can no longer be triggered, e.g., as evidenced by their use of no longer existing `core.pack` and `ad.TangentTuple`.