### PR TITLE
Add a separate build matrix entry for documentation testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=25
 matrix:
   include:
-    - python: "3.0"
+    - python: "3.7"
       env: JAX_ENABLE_X64=1 JAX_ONLY_DOCUMENTATION=true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ python:
 env:
   - JAX_ENABLE_X64=0 JAX_NUM_GENERATED_CASES=25
   - JAX_ENABLE_X64=1 JAX_NUM_GENERATED_CASES=25
+matrix:
+  include:
+    - python: "3.0"
+      env: JAX_ENABLE_X64=1 JAX_ONLY_DOCUMENTATION=true
+
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -24,10 +29,13 @@ install:
   - pip install jaxlib
   - pip install -v .
   # The following are needed to test the Colab notebooks and the documentation building
-  - conda install --yes -c conda-forge pandoc ipykernel
-  - conda install --yes sphinx sphinx_rtd_theme nbsphinx jupyter_client matplotlib
+  - if [[ "$JAX_ONLY_DOCUMENTATION" != "" ]]; then
+      conda install --yes -c conda-forge pandoc ipykernel;
+      conda install --yes sphinx sphinx_rtd_theme nbsphinx jupyter_client matplotlib;
+    fi
 script:
-  - pytest -n 1 tests examples -W ignore
-  - if [[ "$TRAVIS_PYTHON_VERSION" > "3" ]]; then
-      sphinx-build -M html docs build;
+  - if [[ "$JAX_ONLY_DOCUMENTATION" == "" ]]; then
+      pytest -n 1 tests examples -W ignore ;
+    else
+      sphinx-build -b html -D nbsphinx_execute=always docs docs/build/html;
     fi


### PR DESCRIPTION
This way we parallelize the unit tests with the documentation tests.