### PR TITLE
Fix list rendering in RTD for primitives.ipynb

### DIFF
--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -547,6 +547,7 @@
         "JAX first evaluates it abstractly using only the \n",
         "shape and type of the arguments. This abstract evaluation serves multiple\n",
         "purposes:\n",
+        "\n",
         "  * Gets the sequence of JAX primitives that are used in the computation. This \n",
         "  sequence will be compiled. \n",
         "  * Computes the shape and type of all vectors and operations used in the computation. \n",
@@ -976,6 +977,7 @@
       },
       "source": [
         "TO EXPLAIN: \n",
+        "\n",
         "  * Why is JAX using ConcreteArray in square_add_prim? There is no abstract evaluation going on here.\n",
         "  * Not sure how to explain that multiply_add_prim is invoked with ConcreteValue, yet\n",
         "  we do not call the multiply_add_abstract_eval.\n",


### PR DESCRIPTION
Colab doesn't require a newline before unordered list in Markdown; RTD
does.