### PR TITLE
try simplifying random.multivariate_normal api

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -371,6 +371,7 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}D_{}".format(dim, onp.dtype(dtype).name),
        "dim": dim, "dtype": dtype}
+      for dim in [1, 3, 5]
       for dtype in [onp.float32, onp.float64]))
   def testMultivariateNormal(self, dim, dtype):
     r = onp.random.RandomState(dim)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -218,7 +218,9 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_alpha={}_{}".format(alpha, dtype),
        "alpha": alpha, "dtype": onp.dtype(dtype).name}
-      for alpha in [[0.2, 1., 5.]]
+      for alpha in [
+          onp.array([0.2, 1., 5.]),
+      ]
       for dtype in [onp.float32, onp.float64]))
   def testDirichlet(self, alpha, dtype):
     key = random.PRNGKey(0)
@@ -275,8 +277,8 @@ class LaxRandomTest(jtu.JaxTestCase):
   def testGammaGrad(self, alpha):
     rng = random.PRNGKey(0)
     alphas = onp.full((100,), alpha)
-    z = random.gamma(rng, alphas)
-    actual_grad = api.grad(lambda x: (random.gamma(rng, x)).sum())(alphas)
+    z = random.gamma(rng, alphas, shape=(100,))
+    actual_grad = api.grad(lambda x: random.gamma(rng, x, shape=(100,)).sum())(alphas)
 
     eps = 0.01 * alpha / (1.0 + onp.sqrt(alpha))
     cdf_dot = (scipy.stats.gamma.cdf(z, alpha + eps)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from functools import partial
 from unittest import SkipTest
-import re
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -367,35 +367,32 @@ class LaxRandomTest(jtu.JaxTestCase):
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.t(df).cdf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_mean={}_cov={}_{}".format(mean, cov, dtype),
-        "mean": mean, "cov": cov, "dtype": dtype}
-      for mean in [0, 5, np.asarray([1, -2, 3]), np.asarray([[1]])]
-      for cov in [.1, 5, np.asarray([4, 5, 6]),
-        np.asarray([[4.60, 2.86, 2.33],
-        [2.86, 3.04, 1.74],
-        [2.33, 1.74, 1.83]]),
-        np.asarray([[[1]]])]
+      {"testcase_name": "_{}D_{}".format(dim, onp.dtype(dtype).name),
+       "dim": dim, "dtype": dtype}
+      for dim in [1, 3, 5]
       for dtype in [onp.float32, onp.float64]))
-  def testMultivariateNormal(self, mean, cov, dtype):
-    key = random.PRNGKey(0)
-    rand = lambda key, mean, cov: random.multivariate_normal(key, mean, cov, (1000,), dtype)
-    crand = api.jit(rand)
-    if hasattr(cov, "shape") and cov.ndim > 2 or hasattr(mean, "shape") and mean.ndim > 1:
-      self.assertRaises(ValueError, lambda: rand(key, mean, cov))
-      self.assertRaises(ValueError, lambda: crand(key, mean, cov))
-      return
+  def testMultivariateNormal(self, dim, dtype):
+    r = onp.random.RandomState(dim)
+    mean = r.randn(dim)
+    cov_factor = r.randn(dim, dim)
+    cov = onp.dot(cov_factor, cov_factor.T) + dim * onp.eye(dim)
 
-    uncompiled_samples = rand(key, mean, cov)
-    compiled_samples = crand(key, mean, cov)
-    if hasattr(cov, "shape") and cov.ndim == 2:
-      inv_scale = scipy.linalg.lapack.dtrtri(onp.linalg.cholesky(cov), lower=True)[0]
-      rescale = lambda x: onp.tensordot(x, inv_scale, axes=(-1, 1))
-    else:
-      rescale = lambda x: x / np.sqrt(cov)
+    keys = random.split(random.PRNGKey(0), 1000)
+    rand = api.vmap(partial(random.multivariate_normal, mean=mean, cov=cov))
+    crand = api.jit(rand)
+
+    uncompiled_samples = rand(keys)
+    compiled_samples = crand(keys)
+
+    # This is a quick-and-dirty multivariate normality check that tests that a
+    # uniform mixture of the marginals along the covariance matrix's
+    # eigenvectors follow a standard normal distribution.
+    # TODO(mattjj); check for correlations, maybe use a more sophisticated test.
+    inv_scale = scipy.linalg.lapack.dtrtri(onp.linalg.cholesky(cov), lower=True)[0]
     for samples in [uncompiled_samples, compiled_samples]:
-      self._CheckKolmogorovSmirnovCDF(
-          rescale(samples - mean).reshape(-1),
-          scipy.stats.norm().cdf)
+      centered = samples - mean
+      whitened = onp.einsum('nj,ij->ni', centered, inv_scale)
+      self._CheckKolmogorovSmirnovCDF(whitened.ravel(), scipy.stats.norm().cdf)
 
   def testIssue222(self):
     x = random.randint(random.PRNGKey(10003), (), 0, 0)
@@ -417,7 +414,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       phi = lambda x, t: np.sqrt(2.0 / d) * np.cos(np.matmul(W, x) + w*t + b)
       return phi
 
-    self.assertRaisesRegex(ValueError, re.compile(r'.*requires a concrete.*'),
+    self.assertRaisesRegex(ValueError, '.*requires a concrete.*',
                            lambda: feature_map(5, 3))
 
   def testIssue756(self):


### PR DESCRIPTION
Standardize the behavior of `shape` arguments in `jax.random`. Also simplify the rank-polymorphic behavior of `jax.random.multivariate_normal`.

The basic idea is that, [following NumPy](https://docs.scipy.org/doc/numpy/reference/random/generated/numpy.random.Generator.normal.html) and my own guesses as to what's least surprising, the shape of a randomly-sampled array is determined by either the `shape` argument to the sampler function or the shape of any parameter arrays. (If the `shape` argument is provided and the parameters have non-scalar shapes, then they must be consistent.)

Some sampler functions don't take any parameters: `uniform`, `normal`, `cauchy`, `exponential`, `gumbel`, `laplace`, `logistic`. (We're following the convention of not including scale parameters.) For these, the `shape` argument determines the result shape and has a default value of `()`.

Other sampler functions _corresponding to random variables with a scalar range_ take one or two parameter arguments (`bernoulli`, `beta`, `gamma`, `pareto`, `t`). We could require these arguments to be scalars, and require users to `vmap` (over key arrays, parameter arrays, or combinations of the two) to produce vectors or arrays of samples. **But I chose not to require using `vmap` because that makes the common use case less practical.** As a result of that choice, we need to fix a convention for how the shapes of array parameters affect the result shape, especially if a `shape` argument is specified. [Following NumPy](https://docs.scipy.org/doc/numpy/reference/random/generated/numpy.random.Generator.normal.html), I implemented this convention: the default value of `shape` is `None` and that indicates that the result shape is computed by broadcasting together the parameter shapes. If a non-`None` value of `shape` is provided, then it determines the result shape (and parameter shapes must be broadcast-compatible with it).

One more detail needs to be worked out, which is how to handle the case of random variables with vector ranges (`dirichlet` and `multivariate_normal`). In particular: does `shape` specify the batch shape or the full result shape? Concretely, to sample 100 times from a 3D multivariate normal, do we write `random.multivariate_normal(key, mu, cov, shape=(100,))` or `random.multivariate_normal(key, mu, cov, shape=(100, 3))`? [Following NumPy](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.random.multivariate_normal.html) (and TensorFlow, and Pyro, and convenience) I followed the former: the `shape` argument specifies the _batch shape_.

_Original comment:_

@jekbradbury @aeftimia @fehiepsi  Building directly on #1419, this is an experiment in simplifying `random.multivariate_normal`, basically to remove all the rank-polymorphic behavior (which can be implemented using `vmap` instead).

Thoughts?

fixes #1384 