### PR TITLE
broadcast arguments in jax.numpy.take_along_axis

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2411,6 +2411,7 @@ def _take_along_axis(arr, indices, axis):
   if rank != ndim(indices):
     msg = "indices and arr must have the same number of dimensions; {} vs. {}"
     raise ValueError(msg.format(ndim(indices), ndim(arr)))
+  arr, indices = broadcast_arrays(arr, indices)
   axis = _canonicalize_axis(axis, rank)
 
   arr_shape = list(shape(arr))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2405,20 +2405,27 @@ def _take_along_axis(arr, indices, axis):
   if axis is None:
     if ndim(indices) != 1:
       msg = "take_along_axis indices must be 1D if axis=None, got shape {}"
-      raise ValueError(msg.format(shape(indices)))
+      raise ValueError(msg.format(indices.shape))
     return take_along_axis(arr.ravel(), indices, 0)
   rank = ndim(arr)
   if rank != ndim(indices):
     msg = "indices and arr must have the same number of dimensions; {} vs. {}"
     raise ValueError(msg.format(ndim(indices), ndim(arr)))
-  arr, indices = broadcast_arrays(arr, indices)
   axis = _canonicalize_axis(axis, rank)
 
-  arr_shape = list(shape(arr))
-  axis_size = arr_shape[axis]
-  arr_shape[axis] = 1
-  idx_shape = shape(indices)
-  out_shape = lax.broadcast_shapes(idx_shape, tuple(arr_shape))
+  def replace(tup, val):
+    lst = list(tup)
+    lst[axis] = val
+    return tuple(lst)
+
+  bcast_shape = lax.broadcast_shapes(replace(arr.shape, 1), replace(indices.shape, 1))
+  indices = broadcast_to(indices, replace(bcast_shape, indices.shape[axis]))
+  arr     = broadcast_to(arr,     replace(bcast_shape, arr.shape[axis]))
+
+  axis_size = arr.shape[axis]
+  arr_shape = replace(arr.shape, 1)
+  idx_shape = indices.shape
+  out_shape = lax.broadcast_shapes(idx_shape, arr_shape)
 
   index_dims = [i for i, idx in enumerate(idx_shape) if i == axis or idx != 1]
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1985,6 +1985,16 @@ class NumpyGradTests(jtu.JaxTestCase):
   def testOpGradSpecialValue(self, op, special_value):
     check_grads(op, (special_value,), 2, ["fwd", "rev"])
 
+  def testTakeAlongAxisIssue1521(self):
+    # https://github.com/google/jax/issues/1521
+    idx = lnp.repeat(lnp.arange(3), 10).reshape((30, 1))
+
+    def f(x):
+      y = x * lnp.arange(3.).reshape((1, 3))
+      return lnp.take_along_axis(y, idx, -1).sum()
+
+    check_grads(f, (1.,), order=1)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2216,19 +2216,6 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     x = rng(shape, dtype)
     check_grads(gather, (x,), 2, ["fwd", "rev"], 1e-2, 1e-2, 1.)
 
-  def testGatherGradIssue1521(self):
-    gather_indices = onp.array([[[0, 0]],
-                                [[1, 1]]], onp.int32)
-    dnums = lax.GatherDimensionNumbers(offset_dims=(),
-                                       collapsed_slice_dims=(0, 1),
-                                       start_index_map=(0, 1))
-    slice_sizes = (1, 1)
-
-    def f(x):
-      return lax.gather(x, gather_indices, dnums, tuple(slice_sizes))
-    x = onp.array([[0., 1.]])
-    check_grads(f, (x,), 1, ["rev"])
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2216,6 +2216,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     x = rng(shape, dtype)
     check_grads(gather, (x,), 2, ["fwd", "rev"], 1e-2, 1e-2, 1.)
 
+  def testGatherGradIssue1521(self):
+    gather_indices = onp.array([[[0, 0]],
+                                [[1, 1]]], onp.int32)
+    dnums = lax.GatherDimensionNumbers(offset_dims=(),
+                                       collapsed_slice_dims=(0, 1),
+                                       start_index_map=(0, 1))
+    slice_sizes = (1, 1)
+
+    def f(x):
+      return lax.gather(x, gather_indices, dnums, tuple(slice_sizes))
+    x = onp.array([[0., 1.]])
+    check_grads(f, (x,), 1, ["rev"])
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype),


### PR DESCRIPTION
fixes #1521

The gather failure in the first test I wrote was misguided because I think it was doing out-of-bounds accessing. It was just a bad repro.

After reading #1521 more carefully, I realized it was just a broadcasting issue in our implementation of `take_along_axis`.