### PR TITLE
Align momentum optimizer with conventional parameterization and add Nesterov

### DIFF
--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -200,8 +200,8 @@ def sgd(step_size):
   return init, update, get_params
 
 @optimizer
-def momentum(step_size, mass):
-  """Construct optimizer triple for SGD with Nesterov momentum.
+def momentum(step_size, mass, nesterov=False):
+  """Construct optimizer triple for SGD with (optionally) Nesterov momentum.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
@@ -216,8 +216,9 @@ def momentum(step_size, mass):
     return x0, v0
   def update(i, g, state):
     x, velocity = state
-    velocity = mass * velocity - (1. - mass) * g
-    x = x + step_size(i) * velocity
+    velocity = mass * velocity + g
+    d = mass * velocity + g if nesterov else velocity
+    x = x - step_size(i) * d
     return x, velocity
   def get_params(state):
     x, _ = state

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -200,12 +200,13 @@ def sgd(step_size):
   return init, update, get_params
 
 @optimizer
-def momentum(step_size, mass, nesterov=False):
-  """Construct optimizer triple for SGD with (optionally) Nesterov momentum.
+def momentum(step_size, mass):
+  """Construct optimizer triple for SGD with momentum.
 
   Args:
     step_size: positive scalar, or a callable representing a step size schedule
       that maps the iteration index to positive scalar.
+    mass: positive scalar representing the momentum coefficient.
 
   Returns:
     An (init_fun, update_fun, get_params) triple.
@@ -217,8 +218,34 @@ def momentum(step_size, mass, nesterov=False):
   def update(i, g, state):
     x, velocity = state
     velocity = mass * velocity + g
-    d = mass * velocity + g if nesterov else velocity
-    x = x - step_size(i) * d
+    x = x - step_size(i) * velocity
+    return x, velocity
+  def get_params(state):
+    x, _ = state
+    return x
+  return init, update, get_params
+
+
+@optimizer
+def nesterov(step_size, mass):
+  """Construct optimizer triple for SGD with Nesterov momentum.
+
+  Args:
+    step_size: positive scalar, or a callable representing a step size schedule
+      that maps the iteration index to positive scalar.
+    mass: positive scalar representing the momentum coefficient.
+
+  Returns:
+    An (init_fun, update_fun, get_params) triple.
+  """
+  step_size = make_schedule(step_size)
+  def init(x0):
+    v0 = np.zeros_like(x0)
+    return x0, v0
+  def update(i, g, state):
+    x, velocity = state
+    velocity = mass * velocity + g
+    x = x - step_size(i) * (mass * velocity + g)
     return x, velocity
   def get_params(state):
     x, _ = state


### PR DESCRIPTION
The implementation of SGD with momentum in optimizers.py was different from the typical parameterization. Thanks to @sschoenholz for noticing!

For background, there are two common parameterizations of ordinary momentum:
- Keras (and thus TF 2.X) use `v = mu * v - eta * g; x = x + v` (which expands to e.g. `x3 = x0 - (eta0*mu^2 + eta0*mu + eta0)*g0 - (eta1*mu + eta1)*g1 - eta2*g2`)
- PyTorch and Sonnet (and TF 1.X) use `v = mu * v + g; x = x - eta * v` (which expands to `x3 = x0 - (eta2*mu^2 + eta1*mu + eta0)*g0 - (eta2*mu + eta1)*g1 - eta2*g2`)

Other than their representation of internal state `v`, those expansions show that these two formulas only differ in how they're affected by changing learning rates. There are two analogous implementations for Nesterov momentum, again equivalent other than in the case of learning rate changes. The original papers describing momentum and Nesterov momentum assume constant learning rate, so they're ambiguous between the formulations.

The version of momentum in optimizers.py was different (related by a reparameterization of the learning rate hyperparameter). With this change, it exactly matches the formulas used by PyTorch (when `damping=0`) and Sonnet; we also add a Nesterov implementation.