### PR TITLE
Implementation of np.ldexp and np.frexp

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -451,8 +451,8 @@ def rand_small():
   return partial(_rand_dtype, randn, scale=1e-3)
 
 
-def rand_not_small():
-  post = lambda x: x + onp.where(x > 0, 10., -10.)
+def rand_not_small(offset=10.):
+  post = lambda x: x + onp.where(x > 0, offset, -offset)
   randn = npr.RandomState(0).randn
   return partial(_rand_dtype, randn, scale=3., post=post)
 


### PR DESCRIPTION
As per #70, add `ldexp` and its inverse function `frexp`.

Related links:
https://docs.scipy.org/doc/numpy/reference/generated/numpy.ldexp.html#numpy.ldexp
https://docs.scipy.org/doc/numpy/reference/generated/numpy.frexp.html#numpy.frexp
https://en.cppreference.com/w/cpp/numeric/math/frexp