### PR TITLE
Fix grad(jit(custom_linear_solve)) encounters ad_util.Zero in backwars pass

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -354,8 +354,11 @@ def triangular_solve_transpose_rule(
   # Triangular solve is nonlinear in its first argument and linear in its second
   # argument, analogous to `div` but swapped.
   assert a is not ad.undefined_primal and b is ad.undefined_primal
-  cotangent_b = triangular_solve(a, cotangent, left_side, lower,
-                                 not transpose_a, conjugate_a, unit_diagonal)
+  if cotangent is ad_util.zero:
+    cotangent_b = ad_util.zero
+  else:
+    cotangent_b = triangular_solve(a, cotangent, left_side, lower,
+                                   not transpose_a, conjugate_a, unit_diagonal)
   return [None, cotangent_b]
 
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1227,6 +1227,9 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     jtu.check_grads(linear_solve, (a, b), order=2)
 
+    # regression test for https://github.com/google/jax/issues/1536
+    jtu.check_grads(api.jit(linear_solve), (a, b), order=2)
+
   def test_custom_linear_solve_without_transpose_solve(self):
 
     def explicit_jacobian_solve(matvec, b):


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/1536

I wrote a regression test, but I could not figure how to trigger this directly with triangular_solve alone.