### PR TITLE
Fix NaNs in grad(jax.nn.elu) for large positive inputs.

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -35,7 +35,8 @@ def swish(x): return x * sigmoid(x)
 def log_sigmoid(x): return -softplus(-x)
 
 def elu(x, alpha=1.0):
-  return np.where(x > 0, x, alpha * np.expm1(x))
+  safe_x = np.where(x > 0, 0., x)
+  return np.where(x > 0, x, alpha * np.expm1(safe_x))
 
 def leaky_relu(x, negative_slope=1e-2):
   return np.where(x >= 0, x, negative_slope * x)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -29,6 +29,7 @@ from jax import test_util as jtu
 from jax.test_util import check_grads
 from jax import nn
 from jax import random
+import jax
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -41,6 +42,13 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testSoftplusValue(self):
     val = nn.softplus(89.)
     self.assertAllClose(val, 89., check_dtypes=False)
+
+  def testEluGrad(self):
+    check_grads(nn.elu, (1e4,), 4, eps=1.)
+
+  def testEluValue(self):
+    val = nn.elu(1e4)
+    self.assertAllClose(val, 1e4, check_dtypes=False)
 
 InitializerRecord = collections.namedtuple(
   "InitializerRecord",
@@ -80,3 +88,6 @@ class NNInitializersTest(jtu.JaxTestCase):
       for dtype in [onp.float32, onp.float64]))
   def testInitializer(self, initializer, rng, shape, dtype):
     val = initializer(rng, shape, dtype)
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
The gradient of np.where is not robust to NaNs in the unselected branch.
A double where trick makes sure that the `expm1` will not NaN.
I have added a check_grads test that NaNs with the original implementation.