### PR TITLE
Fix numpy version check that fails for development numpy versions.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -831,7 +831,7 @@ def isclose(a, b, rtol=1e-05, atol=1e-08):
   else:
     return lax.eq(a, b)
 
-numpy_version = tuple(map(int, onp.version.version.split('.')))
+numpy_version = tuple(map(int, onp.version.version.split('.')[:2]))
 if numpy_version < (1, 14):
   # see discussion at https://github.com/numpy/numpy/pull/9720
   def _maybe_numpy_1_13_isclose_behavior(a, out):


### PR DESCRIPTION
Numpy versions may contain strings if not a release build. Only look at the two major entries to avoid an exception.