### PR TITLE
Fix lax_reference implementations of erf_inv, conj, complex.

### DIFF
--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -62,16 +62,18 @@ lgamma = scipy.special.gammaln
 digamma = scipy.special.digamma
 erf = scipy.special.erf
 erfc = scipy.special.erfc
-erf_inv = scipy.special.erfi
+erf_inv = scipy.special.erfinv
+bessel_i0e = scipy.special.i0e
+bessel_i1e = scipy.special.i1e
 
 real = onp.real
 imag = onp.imag
 
 def conj(x):
-  return onp.asarray(onp.conj(x), dtype=onp.complex64)
+  return onp.conj(x) + onp.complex64(0)
 
 def complex(x, y):
-  return onp.asarray(x + 1j * y, dtype=onp.complex64)
+  return x + onp.complex64(1j) * y
 
 abs = onp.absolute
 pow = onp.power

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -70,8 +70,6 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record("ndtr", 1, float_dtypes, jtu.rand_default(), True),
     # TODO(phawkins): gradient of entr yields NaNs.
     op_record("entr", 1, float_dtypes, jtu.rand_default(), False),
-    op_record("i0e", 1, float_dtypes, jtu.rand_default(), True),
-    op_record("i1e", 1, float_dtypes, jtu.rand_default(), True),
 ]
 
 CombosWithReplacement = itertools.combinations_with_replacement

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -103,7 +103,9 @@ LAX_OPS = [
     op_record("digamma", 1, float_dtypes, jtu.rand_positive()),
     op_record("erf", 1, float_dtypes, jtu.rand_small()),
     op_record("erfc", 1, float_dtypes, jtu.rand_small()),
-    op_record("erf_inv", 1, float_dtypes, jtu.rand_small(), tol=1e-2),
+    op_record("erf_inv", 1, float_dtypes, jtu.rand_small()),
+    op_record("bessel_i0e", 1, float_dtypes, jtu.rand_small()),
+    op_record("bessel_i1e", 1, float_dtypes, jtu.rand_small()),
 
     op_record("real", 1, complex_dtypes, jtu.rand_default()),
     op_record("imag", 1, complex_dtypes, jtu.rand_default()),
@@ -1542,6 +1544,10 @@ LAX_GRAD_OPS = [
                    dtypes=[onp.float64]),
     # grad_test_spec(lax.lgamma, nargs=1, order=2, rng=jtu.rand_small(),
     #                dtypes=[onp.float64]),  # TODO(mattjj): enable
+    grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng=jtu.rand_default(),
+                   dtypes=[onp.float64]),
+    grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng=jtu.rand_default(),
+                   dtypes=[onp.float64]),
 
     grad_test_spec(lax.real, nargs=1, order=2, rng=jtu.rand_default(),
                    dtypes=[onp.complex64]),


### PR DESCRIPTION
It turns out you can set the tolerance for the `erf_inv` test much lower if you compare against the correct reference function... :-)

Move Bessel function tests into `lax_test.py` for consistency.