### PR TITLE
Use classic NumPy instead of JAX NumPy in multivariate random test

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -369,12 +369,12 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_mean={}_cov={}_{}".format(mean, cov, dtype),
         "mean": mean, "cov": cov, "dtype": dtype}
-      for mean in [0, 5, np.asarray([1, -2, 3]), np.asarray([[1]])]
-      for cov in [.1, 5, np.asarray([4, 5, 6]),
-        np.asarray([[4.60, 2.86, 2.33],
+      for mean in [0, 5, onp.asarray([1, -2, 3]), onp.asarray([[1]])]
+      for cov in [.1, 5, onp.asarray([4, 5, 6]),
+        onp.asarray([[4.60, 2.86, 2.33],
         [2.86, 3.04, 1.74],
         [2.33, 1.74, 1.83]]),
-        np.asarray([[[1]]])]
+        onp.asarray([[[1]]])]
       for dtype in [onp.float32, onp.float64]))
   def testMultivariateNormal(self, mean, cov, dtype):
     key = random.PRNGKey(0)


### PR DESCRIPTION
Avoids an initialization ordering problem.