### PR TITLE
Improved the type checking for uses of scan.

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -460,7 +460,7 @@ def scan(f, init, xs):
   """
   init_flat, init_tree = tree_flatten(init)
   xs_flat, _ = tree_flatten(xs)
-  num_carry = len(init_flat[0])
+  num_carry = len(init_flat)
   in_flat, in_tree = tree_flatten((init, xs))
   try:
     length, = {x.shape[0] for x in xs_flat}

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -447,7 +447,8 @@ def scan(f, init, xs):
       the loop carry and the second represents a slice of the output.
     init: an initial loop carry value of type ``c``, which can be a scalar,
       array, or any pytree (nested Python tuple/list/dict) thereof, representing
-      the initial loop carry value.
+      the initial loop carry value. This value must have the same structure as
+      the first element of the pair returned by ``f``.
     xs: the value of type ``[a]`` over which to scan along the leading axis,
       where ``[a]`` can be an array or any pytree (nested Python
       tuple/list/dict) thereof with consistent leading axis sizes.
@@ -457,9 +458,10 @@ def scan(f, init, xs):
     loop carry value and the second element represents the stacked outputs of
     the second output of ``f`` when scanned over the leading axis of the inputs.
   """
-  num_carry = len(tree_flatten(init)[0])
+  init_flat, init_tree = tree_flatten(init)
+  xs_flat, _ = tree_flatten(xs)
+  num_carry = len(init_flat[0])
   in_flat, in_tree = tree_flatten((init, xs))
-  init_flat, xs_flat = in_flat[:num_carry], in_flat[num_carry:]
   try:
     length, = {x.shape[0] for x in xs_flat}
   except AttributeError:
@@ -474,10 +476,16 @@ def scan(f, init, xs):
   x_dtypes = [x.dtype for x in xs_flat]
   x_avals = tuple(_map(ShapedArray, x_shapes, x_dtypes))
   jaxpr, consts, out_tree = _initial_style_jaxpr(f, in_tree, carry_avals + x_avals)
-  carry_avals_out, y_avals = split_list(jaxpr.out_avals, [num_carry])
-  if tuple(carry_avals_out) != carry_avals:
+
+  out_tree_avals = tree_unflatten(out_tree, jaxpr.out_avals)
+  init_tree_avals = tree_unflatten(init_tree, carry_avals)
+  if not isinstance(out_tree_avals, tuple) or len(out_tree_avals) != 2:
+    msg = "scan body output must be a pair, got {}."
+    raise TypeError(msg.format(out_tree_avals))
+  if out_tree_avals[0] != init_tree_avals:
     msg = "scan carry output type must match carry input type, got {} and {}."
-    raise TypeError(msg.format(tuple(carry_avals_out), carry_avals))
+    raise TypeError(msg.format(out_tree_avals[0], init_tree_avals))
+
   out = scan_p.bind(*itertools.chain(consts, in_flat),
                     forward=True, length=length, jaxpr=jaxpr,
                     num_consts=len(consts), num_carry=num_carry,

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -708,7 +708,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     if jit_f:
       f = api.jit(f)
     if jit_scan:
-      scan = api.jit(lax.scan, (0,))
+      scan = api.jit(lax.scan, static_argnums=(0,))
     else:
       scan = lax.scan
 
@@ -823,7 +823,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     def plus_one(p, iter_idx):
       return Point(p.x+1, p.y+1), iter_idx
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         'scan got value with no leading axis to scan over.*',
         lambda: lax.scan(plus_one, p0, list(range(5))))
@@ -844,11 +844,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lax.scan(lambda c, x: (0, x), 1.0, a)
     with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
       lax.scan(lambda c, x: (0, x), (1, 2), np.arange(5))
-
-    # Carry input and output are tuples with different structure
-    self.assertRaisesRegex(TypeError,
-                           'scan carry output type must match carry input type',
-                           lambda: lax.scan(lambda c, x: ((0, 0, 0), x), (1, (2, 3)), a))
 
 
   def testScanHigherOrderDifferentiation(self):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -832,17 +832,22 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     """Test typing error messages for scan."""
     a = np.arange(5)
     # Body output not a tuple
-    with self.assertRaisesRegex(TypeError, 'scan body output must be a pair'):
+    with self.assertRaisesRegex(TypeError,
+        re.escape("scan body output must be a pair, got ShapedArray(int32[]).")):
       lax.scan(lambda c, x: 0, 0, a)
-    # Carry input and output are tuples with different structure
     with  self.assertRaisesRegex(TypeError,
-                                 'scan carry output type must match carry input type'):
+        re.escape("scan carry output and input must have same type structure, "
+                  "got PyTreeDef(tuple, [*,*,*]) and PyTreeDef(tuple, [*,PyTreeDef(tuple, [*,*])])")):
       lax.scan(lambda c, x: ((0, 0, 0), x), (1, (2, 3)), a)
-    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+    with self.assertRaisesRegex(TypeError,
+        re.escape("scan carry output and input must have same type structure, got * and PyTreeDef(None, []).")):
       lax.scan(lambda c, x: (0, x), None, a)
-    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+    with self.assertRaisesRegex(TypeError,
+        re.escape("scan carry output and input must have identical types, "
+                  "got ShapedArray(int32[]) and ShapedArray(float32[]).")):
       lax.scan(lambda c, x: (0, x), 1.0, a)
-    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+    with self.assertRaisesRegex(TypeError,
+        re.escape("scan carry output and input must have same type structure, got * and PyTreeDef(tuple, [*,*]).")):
       lax.scan(lambda c, x: (0, x), (1, 2), np.arange(5))
 
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -828,6 +828,29 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         'scan got value with no leading axis to scan over.*',
         lambda: lax.scan(plus_one, p0, list(range(5))))
 
+  def testScanTypeErrors(self):
+    """Test typing error messages for scan."""
+    a = np.arange(5)
+    # Body output not a tuple
+    with self.assertRaisesRegex(TypeError, 'scan body output must be a pair'):
+      lax.scan(lambda c, x: 0, 0, a)
+    # Carry input and output are tuples with different structure
+    with  self.assertRaisesRegex(TypeError,
+                                 'scan carry output type must match carry input type'):
+      lax.scan(lambda c, x: ((0, 0, 0), x), (1, (2, 3)), a)
+    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+      lax.scan(lambda c, x: (0, x), None, a)
+    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+      lax.scan(lambda c, x: (0, x), 1.0, a)
+    with self.assertRaisesRegex(TypeError, 'scan carry output type must match carry input type'):
+      lax.scan(lambda c, x: (0, x), (1, 2), np.arange(5))
+
+    # Carry input and output are tuples with different structure
+    self.assertRaisesRegex(TypeError,
+                           'scan carry output type must match carry input type',
+                           lambda: lax.scan(lambda c, x: ((0, 0, 0), x), (1, (2, 3)), a))
+
+
   def testScanHigherOrderDifferentiation(self):
     d = 0.75
     def f(c, a):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -828,6 +828,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         'scan got value with no leading axis to scan over.*',
         lambda: lax.scan(plus_one, p0, list(range(5))))
 
+  @jtu.skip_on_flag('jax_enable_x64', True)  # With float64 error messages are different; hard to check precisely
   def testScanTypeErrors(self):
     """Test typing error messages for scan."""
     a = np.arange(5)
@@ -1266,7 +1267,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     jtu.check_grads(loss, (a, b), atol=1e-5, order=2, modes=['fwd'])
 
-    with self.assertRaisesRegexp(TypeError, "transpose_solve required"):
+    with self.assertRaisesRegex(TypeError, "transpose_solve required"):
       api.grad(loss)(a, b)
 
   def test_custom_linear_solve_errors(self):


### PR DESCRIPTION
Previous way of checking was done after flattening and got
easily confused by tuples of different shapes, or None.

Relates to https://github.com/google/jax/issues/1534.