### PR TITLE
Switch to gelu approximation in jax.nn

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -54,10 +54,14 @@ def selu(x):
   scale = 1.0507009873554804934193349852946
   return scale * elu(x, alpha)
 
-@jarrett
 def gelu(x):
-  """Gaussian error linear unit activation"""
-  return x * (lax.erf(x / np.sqrt(2)) + 1) / 2
+  """GELU activation function.
+
+  We explicitly use the approximation rather than the exact formulation for
+  speed. See: https://arxiv.org/abs/1606.08415 Section 2.
+  """
+  cdf = 0.5 * (1.0 + np.tanh((np.sqrt(2 / np.pi) * (x + 0.044715 * x**3))))
+  return x * cdf
 
 def glu(x, axis=-1):
   """Gated linear unit activation"""


### PR DESCRIPTION
Approximate GELU is much faster than exact GELU.

The @jarrett annotation has been removed, as experiments indicate that
jax.grad(gelu) is faster tahn jax.grad(jax.jarrett(gelu)) on CPU.