### PR TITLE
ResBlock combinator in stax

### DIFF
--- a/examples/resnet50.py
+++ b/examples/resnet50.py
@@ -45,7 +45,7 @@ def ConvBlock(kernel_size, filters, strides=(2, 2)):
       Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
       Conv(filters3, (1, 1)), BatchNorm())
   Shortcut = stax.serial(Conv(filters3, (1, 1), strides), BatchNorm())
-  return ResBlock(Main, Shortcut)
+  return ResBlock(Main, Shortcut, tail=Relu)
 
 
 def IdentityBlock(kernel_size, filters):
@@ -58,7 +58,7 @@ def IdentityBlock(kernel_size, filters):
         Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
         Conv(input_shape[3], (1, 1)), BatchNorm())
   Main = stax.shape_dependent(make_main)
-  return ResBlock(Main, Identity)
+  return ResBlock(Main, Identity, tail=Relu)
 
 
 # ResNet architectures compose layers and ResNet blocks

--- a/examples/resnet50.py
+++ b/examples/resnet50.py
@@ -30,9 +30,9 @@ from jax.config import config
 from jax import jit, grad, random
 from jax.experimental import optimizers
 from jax.experimental import stax
-from jax.experimental.stax import (AvgPool, BatchNorm, Conv, Dense, FanInSum,
-                                   FanOut, Flatten, GeneralConv, Identity,
-                                   MaxPool, Relu, LogSoftmax)
+from jax.experimental.stax import (AvgPool, BatchNorm, Conv, Dense,
+                                   Flatten, GeneralConv, Identity,
+                                   MaxPool, Relu, ResBlock, LogSoftmax)
 
 
 # ResNet blocks compose other layers
@@ -45,7 +45,7 @@ def ConvBlock(kernel_size, filters, strides=(2, 2)):
       Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
       Conv(filters3, (1, 1)), BatchNorm())
   Shortcut = stax.serial(Conv(filters3, (1, 1), strides), BatchNorm())
-  return stax.serial(FanOut(2), stax.parallel(Main, Shortcut), FanInSum, Relu)
+  return ResBlock(Main, Shortcut)
 
 
 def IdentityBlock(kernel_size, filters):
@@ -58,7 +58,7 @@ def IdentityBlock(kernel_size, filters):
         Conv(filters2, (ks, ks), padding='SAME'), BatchNorm(), Relu,
         Conv(input_shape[3], (1, 1)), BatchNorm())
   Main = stax.shape_dependent(make_main)
-  return stax.serial(FanOut(2), stax.parallel(Main, Identity), FanInSum, Relu)
+  return ResBlock(Main, Identity)
 
 
 # ResNet architectures compose layers and ResNet blocks

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -260,7 +260,7 @@ def Dropout(rate, mode='train'):
   return init_fun, apply_fun
 
 
-def ResBlock(*layers, fan_in=FanInSum, tail=Identity):
+def ResBlock(*layers, **kwargs):
   """Split input, feed it through one or more layers in parallel,
   recombine them with a fan-in, apply a trailing layer (i.e. an activation)
 
@@ -273,6 +273,13 @@ def ResBlock(*layers, fan_in=FanInSum, tail=Identity):
     A new layer, meaning an (init_fun, apply_fun) pair, representing the
     parallel composition of the given sequence of layers fed into fan_in and then tail.
   """
+  # TODO(aeftimia): change signature to
+  # def ResBlock(*layers, fan_in=FanInSum, tail=Identity):
+  # when Python 2 support expires
+  default_args = {'fan_in': FanInSum, 'tail': Identity}
+  default_args.update(kwargs)
+  fan_in = default_args['fan_in']
+  tail = default_args['tail']
   return serial(FanOut(len(layers)), parallel(*layers), fan_in, tail)
 
 

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -260,6 +260,22 @@ def Dropout(rate, mode='train'):
   return init_fun, apply_fun
 
 
+def ResBlock(*layers, fan_in=FanInSum, tail=Relu):
+  """Split input, feed it through one or more layers in parallel,
+  recombine them with a fan-in, apply a trailing layer (i.e. an activation)
+
+  Args:
+    *layers: a sequence of layers, each an (init_fun, apply_fun) pair.
+    fan_in, optional: a fan-in to recombine the outputs of each layer
+    tail, optional: a final layer to apply after recombination
+
+  Returns:
+    A new layer, meaning an (init_fun, apply_fun) pair, representing the
+    parallel composition of the given sequence of layers fed into fan_in and then tail.
+  """
+  return serial(FanOut(len(layers)), parallel(*layers), fan_in, tail)
+
+
 # Composing layers via combinators
 
 

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -260,7 +260,7 @@ def Dropout(rate, mode='train'):
   return init_fun, apply_fun
 
 
-def ResBlock(*layers, fan_in=FanInSum, tail=Relu):
+def ResBlock(*layers, fan_in=FanInSum, tail=Identity):
   """Split input, feed it through one or more layers in parallel,
   recombine them with a fan-in, apply a trailing layer (i.e. an activation)
 


### PR DESCRIPTION
I have seen (and used) the ResNet-style "split, apply, combine" design pattern enough that I thought it might be nice to have it built in. This may be trivial, but I thought it made code a little cleaner and could potentially clean up `import` statements for architectures with residual connections.

I confirmed the resnet50 example exhibited identical losses for each update with and without the new `ResBlock` call.

Please let me know if you like the idea, but would prefer some other function name and/or signature--I would be happy to modify it to suite maintainer preferences.