### PR TITLE
fixed cross-entropy losses in mnist examples (fixes #1023)

### DIFF
--- a/examples/differentially_private_sgd.py
+++ b/examples/differentially_private_sgd.py
@@ -127,7 +127,7 @@ def loss(params, batch):
   inputs, targets = batch
   logits = predict(params, inputs)
   logits = stax.logsoftmax(logits)  # log normalize
-  return -np.mean(np.sum(logits * targets, 1))  # cross entropy loss
+  return -np.mean(np.sum(logits * targets, axis=1))  # cross entropy loss
 
 
 def accuracy(params, batch):

--- a/examples/mnist_classifier.py
+++ b/examples/mnist_classifier.py
@@ -40,7 +40,7 @@ from examples import datasets
 def loss(params, batch):
   inputs, targets = batch
   preds = predict(params, inputs)
-  return -np.mean(preds * targets)
+  return -np.mean(np.sum(preds * targets, axis=1))
 
 def accuracy(params, batch):
   inputs, targets = batch

--- a/examples/mnist_classifier_fromscratch.py
+++ b/examples/mnist_classifier_fromscratch.py
@@ -49,7 +49,7 @@ def predict(params, inputs):
 def loss(params, batch):
   inputs, targets = batch
   preds = predict(params, inputs)
-  return -np.mean(preds * targets)
+  return -np.mean(np.sum(preds * targets, axis=1))
 
 def accuracy(params, batch):
   inputs, targets = batch

--- a/examples/spmd_mnist_classifier_fromscratch.py
+++ b/examples/spmd_mnist_classifier_fromscratch.py
@@ -57,7 +57,7 @@ def predict(params, inputs):
 def loss(params, batch):
   inputs, targets = batch
   preds = predict(params, inputs)
-  return -np.mean(preds * targets)
+  return -np.mean(np.sum(preds * targets, axis=1))
 
 @jit
 def accuracy(params, batch):


### PR DESCRIPTION
fixes #1023

This also improves the training of the models a lot:

```
# mnist_classifer.py after 10 epochs

# before:
Training set accuracy 0.6450833678245544
Test set accuracy 0.643500030040741

# after:
Training set accuracy 0.8742333650588989
Test set accuracy 0.8819000124931335
```

```
# mnist_classifer_from_scratch.py after 10 epochs

# before:
Training set accuracy 0.7376999855041504
Test set accuracy 0.7508000135421753

# after:
Training set accuracy 0.9060333371162415
Test set accuracy 0.906000018119812
```

```
spmd_mnist_classifier_fromscratch.py after 10 epochs

# before:
Training set accuracy 0.7376999855041504
Test set accuracy 0.7507999539375305

# after:
Training set accuracy 0.9060333371162415
Test set accuracy 0.9059999585151672
```