### PR TITLE
Add some type helpers to lax_numpy.

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -70,6 +70,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     blackman
     broadcast_arrays
     broadcast_to
+    can_cast
     ceil
     clip
     column_stack
@@ -137,6 +138,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     isneginf
     isposinf
     isreal
+    isscalar
     issubdtype
     issubsctype
     ix_
@@ -188,6 +190,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     positive
     prod
     product
+    promote_types
     ptp
     quantile
     rad2deg
@@ -198,6 +201,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     remainder
     repeat
     reshape
+    result_type
     right_shift
     roll
     rot90

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -127,7 +127,7 @@ batching.primitive_batchers[cholesky_p] = cholesky_batching_rule
 def _nan_like(c, operand):
   shape = c.GetShape(operand)
   dtype = shape.element_type()
-  if onp.issubdtype(dtype, onp.complexfloating):
+  if np.issubdtype(dtype, onp.complexfloating):
     nan = c.Constant(onp.array(onp.nan * (1. + 1j), dtype=dtype))
   else:
     nan = c.Constant(onp.array(onp.nan, dtype=dtype))

--- a/jax/random.py
+++ b/jax/random.py
@@ -73,7 +73,7 @@ def _is_prng_key(key):
 
 
 def _make_rotate_left(dtype):
-  if not onp.issubdtype(dtype, onp.integer):
+  if not np.issubdtype(dtype, onp.integer):
     raise TypeError("_rotate_left only accepts integer dtypes.")
   nbits = onp.array(onp.iinfo(dtype).bits, dtype)
 
@@ -276,7 +276,7 @@ def uniform(key, shape=(), dtype=onp.float64, minval=0., maxval=1.):
 @partial(jit, static_argnums=(1, 2))
 def _uniform(key, shape, dtype, minval, maxval):
   _check_shape("uniform", shape)
-  if not onp.issubdtype(dtype, onp.floating):
+  if not np.issubdtype(dtype, onp.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
 
   minval = lax.convert_element_type(minval, dtype)
@@ -324,7 +324,7 @@ def randint(key, shape, minval, maxval, dtype=onp.int64):
 @partial(jit, static_argnums=(1, 4))
 def _randint(key, shape, minval, maxval, dtype):
   _check_shape("randint", shape, minval.shape, maxval.shape)
-  if not onp.issubdtype(dtype, onp.integer):
+  if not np.issubdtype(dtype, onp.integer):
     raise TypeError("randint only accepts integer dtypes.")
 
   minval = lax.convert_element_type(minval, dtype)
@@ -509,7 +509,7 @@ def _truncated_normal(key, lower, upper, shape, dtype):
   sqrt2 = onp.array(onp.sqrt(2), dtype)
   a = lax.erf(lax.convert_element_type(lower, dtype) / sqrt2)
   b = lax.erf(lax.convert_element_type(upper, dtype) / sqrt2)
-  if not onp.issubdtype(dtype, onp.floating):
+  if not np.issubdtype(dtype, onp.floating):
     raise TypeError("truncated_normal only accepts floating point dtypes.")
   u = uniform(key, shape, dtype, minval=onp.finfo(dtype).tiny)
   return sqrt2 * lax.erf_inv(a + u * (b - a))
@@ -531,7 +531,7 @@ def bernoulli(key, p=onp.float32(0.5), shape=None):
     is not None, or else ``p.shape``.
   """
   dtype = xla_bridge.canonicalize_dtype(lax.dtype(p))
-  if not onp.issubdtype(dtype, onp.floating):
+  if not np.issubdtype(dtype, onp.floating):
     msg = "bernoulli probability `p` must have a floating dtype, got {}."
     raise TypeError(msg.format(dtype))
   p = lax.convert_element_type(p, dtype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -315,7 +315,7 @@ CombosWithReplacement = itertools.combinations_with_replacement
 def _dtypes_are_compatible_for_bitwise_ops(args):
   if len(args) <= 1:
     return True
-  is_signed = lambda dtype: onp.issubdtype(dtype, onp.signedinteger)
+  is_signed = lambda dtype: lnp.issubdtype(dtype, onp.signedinteger)
   width = lambda dtype: onp.iinfo(dtype).bits
   x, y = args
   if width(x) > width(y):
@@ -696,7 +696,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for shape in all_shapes for dtype in number_dtypes
       for decimals in [0, 1, -2]))
   def testRoundStaticDecimals(self, shape, dtype, decimals, rng):
-    if onp.issubdtype(dtype, onp.integer) and decimals < 0:
+    if lnp.issubdtype(dtype, onp.integer) and decimals < 0:
       self.skipTest("Integer rounding with decimals < 0 not implemented")
     onp_fun = lambda x: onp.round(x, decimals=decimals)
     lnp_fun = lambda x: lnp.round(x, decimals=decimals)
@@ -1850,8 +1850,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     lnp_op = getattr(lnp, op)
     dtype = onp.dtype(xla_bridge.canonicalize_dtype(dtype)).type
     for x in (onp.nan, -onp.inf, -100., -2. -1., 0., 1., 2., 100., onp.inf,
-              onp.finfo(dtype).max, onp.sqrt(onp.finfo(dtype).max),
-              onp.sqrt(onp.finfo(dtype).max) * 2.):
+              lnp.finfo(dtype).max, onp.sqrt(lnp.finfo(dtype).max),
+              onp.sqrt(lnp.finfo(dtype).max) * 2.):
       if onp.isnan(x) and op in ("sinh", "cosh", "expm1", "exp"):
         # TODO(b/133842876, b/133842870): these return wrong outputs on CPU for
         # NaN inputs.
@@ -2088,7 +2088,7 @@ GRAD_SPECIAL_VALUE_TEST_RECORDS = [
 ]
 
 def num_float_bits(dtype):
-  return onp.finfo(xla_bridge.canonicalize_dtype(dtype)).bits
+  return lnp.finfo(xla_bridge.canonicalize_dtype(dtype)).bits
 
 class NumpyGradTests(jtu.JaxTestCase):
   @parameterized.named_parameters(itertools.chain.from_iterable(

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -194,7 +194,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     _skip_if_unsupported_type(dtype)
     tol = 30
     if jtu.device_under_test() == "tpu":
-      if onp.issubdtype(dtype, onp.complexfloating):
+      if np.issubdtype(dtype, onp.complexfloating):
         raise unittest.SkipTest("No complex eigh on TPU")
       # TODO(phawkins): this tolerance is unpleasantly high.
       tol = 1500
@@ -295,7 +295,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   def testEighBatching(self, shape, dtype, rng):
     _skip_if_unsupported_type(dtype)
     if (jtu.device_under_test() == "tpu" and
-        onp.issubdtype(dtype, onp.complexfloating)):
+        np.issubdtype(dtype, onp.complexfloating)):
       raise unittest.SkipTest("No complex eigh on TPU")
     shape = (10,) + shape
     args = rng(shape, dtype)
@@ -408,7 +408,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for rng in [jtu.rand_default()]))
   def testQr(self, shape, dtype, full_matrices, rng):
     _skip_if_unsupported_type(dtype)
-    if (onp.issubdtype(dtype, onp.complexfloating) and
+    if (np.issubdtype(dtype, onp.complexfloating) and
         (jtu.device_under_test() == "tpu" or jax.lib.version <= (0, 1, 27))):
       raise unittest.SkipTest("No complex QR implementation")
     m, n = shape[-2:]
@@ -685,7 +685,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for rng in [jtu.rand_default()]))
   def testSolve(self, lhs_shape, rhs_shape, dtype, sym_pos, lower, rng):
     _skip_if_unsupported_type(dtype)
-    if (sym_pos and onp.issubdtype(dtype, onp.complexfloating) and
+    if (sym_pos and np.issubdtype(dtype, onp.complexfloating) and
         jtu.device_under_test() == "tpu"):
       raise unittest.SkipTest(
         "Complex Cholesky decomposition not implemented on TPU")
@@ -765,7 +765,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types
       for transpose_a in [False, True]
       for conjugate_a in (
-          [False] if onp.issubdtype(dtype, np.floating) else [False, True])
+          [False] if np.issubdtype(dtype, np.floating) else [False, True])
       for left_side, a_shape, b_shape in [
           (False, (4, 4), (1, 4,)),
           (False, (3, 3), (4, 3)),

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -64,7 +64,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
       for dtype in [onp.float32, onp.float64]))
   def testNumpyAndXLAAgreeOnFloatEndianness(self, dtype):
-    if not FLAGS.jax_enable_x64 and onp.issubdtype(dtype, onp.float64):
+    if not FLAGS.jax_enable_x64 and np.issubdtype(dtype, onp.float64):
       raise SkipTest("can't test float64 agreement")
 
     bits_dtype = onp.uint32 if onp.finfo(dtype).bits == 32 else onp.uint64


### PR DESCRIPTION
Prefer to use jax.numpy type helpers rather than numpy type helpers in various places.
Cleanup in preparation for adding bfloat16 support to jax.

No functional changes are expected from this change.