### PR TITLE
fix a leak where compiled results lived too long

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -846,7 +846,7 @@ def pmap(fun, axis_name=None, devices=None, backend=None):
   [ 13.  13.]
   """
   _check_callable(fun)
-  axis_name = _TempAxisName() if axis_name is None else axis_name
+  axis_name = _TempAxisName(fun) if axis_name is None else axis_name
 
   @wraps(fun)
   def f_pmapped(*args, **kwargs):
@@ -875,13 +875,19 @@ def _pmap_axis_size(xs):
     raise ValueError(msg.format([x for x in xs if not hasattr(x, 'shape')]))
 
 class _TempAxisName(object):
+  def __init__(self, obj):
+    self.obj = obj
   def __repr__(self):
-    return '<axis {}>'.format(hex(id(self)))
+    return '<axis {}>'.format(hex(id(self.obj)))
+  def __hash__(self):
+    return hash(self.obj)
+  def __eq__(self, other):
+    return self.obj is other.obj
 
 
 def soft_pmap(fun, axis_name=None, backend=None):
   _check_callable(fun)
-  axis_name = _TempAxisName() if axis_name is None else axis_name
+  axis_name = _TempAxisName(fun) if axis_name is None else axis_name
 
   @wraps(fun)
   def f_pmapped(*args, **kwargs):
@@ -930,7 +936,7 @@ def _reshape_merge(x):
 
 def _papply(fun):
   # This function is for testing purposes.
-  axis_name = _TempAxisName()
+  axis_name = _TempAxisName(fun)
 
   def papply_fun(*args, **kwargs):
     f = lu.wrap_init(fun)
@@ -944,7 +950,7 @@ def _papply(fun):
 
 
 def _parallelize(fun):
-  axis_name = _TempAxisName()
+  axis_name = _TempAxisName(fun)
 
   def pfun(*args):
     f = lu.wrap_init(fun)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -26,7 +26,7 @@ from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like
 from ..abstract_arrays import raise_to_shaped
 from ..util import unzip2, unzip3, safe_map, safe_zip, partial, split_list
 from ..tree_util import build_tree, register_pytree_node, tree_map
-from ..linear_util import thunk, staged, transformation, transformation_with_aux, wrap_init
+from ..linear_util import thunk, transformation, transformation_with_aux, wrap_init
 from ..api_util import flatten_fun, flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten
 

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -197,15 +197,16 @@ def wrap_init(f, params={}):
 
 
 def cache(call):
-  caches = weakref.WeakKeyDictionary()
-  def memoized_fun(f, *args):
-    cache = caches.setdefault(f.f, {})
-    key = (f.transforms, f.params, args)
-    if key in cache:
-      ans, stores = cache[key]
-      f.populate_stores(stores)
+  fun_caches = weakref.WeakKeyDictionary()
+  def memoized_fun(fun, *args):
+    cache = fun_caches.setdefault(fun.f, {})
+    key = (fun.transforms, fun.params, args)
+    result = cache.get(key, None)
+    if result is not None:
+      ans, stores = result
+      fun.populate_stores(stores)
     else:
-      ans = call(f, *args)
-      cache[key] = (ans, f.stores)
+      ans = call(fun, *args)
+      cache[key] = (ans, fun.stores)
     return ans
   return memoized_fun

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -69,7 +69,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import fastcache
+import weakref
 
 from .util import curry, partial
 
@@ -112,18 +112,6 @@ class Store(object):
   __bool__ = __nonzero__
 
 
-@curry
-def staged(f, *init_args):
-  store = Store()
-  def f_partial(*rest):
-    ans, aux = f(*(init_args + rest))
-    store.store(aux)
-    return ans
-
-  f_partial.__name__ = f.__name__ + "_staged"
-  return f_partial, thunk(lambda: store.val)
-
-
 class WrappedFun(object):
   """Represents a function `f` to which `transforms` are to be applied.
 
@@ -149,8 +137,8 @@ class WrappedFun(object):
     return WrappedFun(self.f, ((gen, gen_args),) + self.transforms,
                       (out_store,) + self.stores, self.params)
 
-  def populate_stores(self, other):
-    for self_store, other_store in zip(self.stores, other.stores):
+  def populate_stores(self, stores):
+    for self_store, other_store in zip(self.stores, stores):
       if self_store is not None:
         self_store.store(other_store.val)
 
@@ -208,15 +196,16 @@ def wrap_init(f, params={}):
   return WrappedFun(f, (), (), tuple(sorted(params.items())))
 
 
-def cache(call, max_size=4096):
-  @fastcache.clru_cache(maxsize=max_size)
-  def cached_fun_body(f, args):
-    return call(f, *args), f
-
-  def cached_fun(f, *args):
-    ans, f_prev = cached_fun_body(f, args)
-    if id(f_prev) != id(f):
-      f.populate_stores(f_prev)
+def cache(call):
+  caches = weakref.WeakKeyDictionary()
+  def memoized_fun(f, *args):
+    cache = caches.setdefault(f.f, {})
+    key = (f.transforms, f.params, args)
+    if key in cache:
+      ans, stores = cache[key]
+      f.populate_stores(stores)
+    else:
+      ans = call(f, *args)
+      cache[key] = (ans, f.stores)
     return ans
-
-  return cached_fun
+  return memoized_fun


### PR DESCRIPTION
The original repro @levskaya showed us was essentially this OOM:

```python
for i in range(40):
  f = jit(lambda: 1. * np.ones((300, 1024, 1024)))
  f().block_until_ready()
```

Even though f was being rebound on every iteration, the cache entries corresponding to the previous iterations of the loop were sticking around.

Instead, if the user drops all references to a function, we want to clear the corresponding compilation cache entries (since they can never be used).

The fix here is to use a two-level cache for compiled code: the first level is a WeakKeyDictionary keyed by the raw Python callable underlying the WrappedFun, and the second level is a regular dictionary keyed by (transforms, params, args). Because this logic is now present in  linear_util.py:cache, the implementations of `WrappedFun.__eq__` and `WrappedFun.__hash__` may be superfluous now.

One unintended consequence is that this implementation now avoids using fastcache.crlu_cache for the jit and pmap compilation caches. It was easier to implement this logic in pure Python. We might want to revise this for performance reasons. ~*That means Travis might fail due to OOMs.*~ @hawkinsp points out that we have no way of knowing a priori if, say, some Google user's code is relying on the LRU behavior that this PR is removing (hopefully temporarily). If this change breaks someone in Google, I'll roll it back asap!

This change does not affect op-by-op execution; those caches use util.py:cache, which are still backed by fastcache.clru_cache. This change only affects jit and pmap caching because those are the only caches backed by linear_util.py:cache.

This PR also incidentally fixed #1600.

TODO:
- [x] run a micro-benchmark before/after, maybe the one mentioned in #1224 
- [x] address reviewer comments

As a micro-benchmark for cache hits, I used this script locally on CPU:

```python
from jax import jit
import time

N = 100_000

f = jit(lambda x: x)
f(2)  # warmup

# time with blocking
tic = time.time()
for _ in range(N):
  f(2).block_until_ready()
toc = time.time()
print((toc - tic) / N)

# time without blocking
tic = time.time()
x = 2
for _ in range(N-1):
  x = f(x)
f(x).block_until_ready()
toc = time.time()
print((toc - tic) / N)
```

```
# on master
0.00012189582347869873
4.287614107131958e-05

# on this pr
0.00011845468282699585
4.283436298370361e-05
```

(The timings are essentially identical if we instead use `f = jitlambda x: x + x)`.)

I think that's strong enough evidence that this isn't regressing our performance on the cache hit path.