### PR TITLE
vmap improvements

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -572,12 +572,11 @@ def vmap(fun, in_axes=0, out_axes=0):
       length equal to the number of positional arguments to ``fun``. An integer
       or None indicates which array axis to map over for all arguments (with
       None indicating not to map any axis), and a tuple indicates which axis to
-      map for each corresponding positional argument. More generally, if the
-      positinal arguments to ``fun`` are container types, the corresponding
-      element of ``in_axes`` can itself be a matching container, so that
-      distinct array axes can be mapped for different container elements. The
-      constraint is that ``in_axes`` must be a container tree prefix of the
-      positional argument tuple passed to ``fun``.
+      map for each corresponding positional argument. If the positinal arguments
+      to ``fun`` are container types, the corresponding element of ``in_axes``
+      can itself be a matching container, so that distinct array axes can be
+      mapped for different container elements. ``in_axes`` must be a container
+      tree prefix of the positional argument tuple passed to ``fun``.
     out_axes: A nonnegative integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof indicating where the mapped axis should appear
       in the output.
@@ -623,19 +622,8 @@ def vmap(fun, in_axes=0, out_axes=0):
   >>> z = np.ones((C, D, K))
   >>> tree = (x, (y, z))
   >>> vfoo = vmap(foo, in_axes=((0, (1, 2)),))
-  >>> print(vfoo(tree))
-  [[[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]
-   [[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]
-   [[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]
-   [[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]
-   [[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]
-   [[12. 12. 12. 12. 12.]
-    [12. 12. 12. 12. 12.]]]
+  >>> print(vfoo(tree)).shape
+  (6, 2, 5)
   """
   docstr = ("Vectorized version of {fun}. Takes similar arguments as {fun} "
             "but with additional array axes over which {fun} is mapped.")
@@ -648,8 +636,9 @@ def vmap(fun, in_axes=0, out_axes=0):
     raise TypeError(msg.format(type(in_axes), type(out_axes)))
 
   def _check_axis_sizes(tree, vals, dims):
+    mapped_axis_sizes = {x.shape[d] for x, d in zip(vals, dims) if d is not None}
     try:
-      sizes, = {x.shape[d] for x, d in zip(vals, dims) if d is not None}
+      sizes, = mapped_axis_sizes
     except ValueError:
       msg = "vmap got inconsistent sizes for array axes to be mapped:\n{}"
       # we switch the error message based on whether args is a tuple of arrays,

--- a/jax/api.py
+++ b/jax/api.py
@@ -573,7 +573,7 @@ def vmap(fun, in_axes=0, out_axes=0):
       or None indicates which array axis to map over for all arguments (with
       None indicating not to map any axis), and a tuple indicates which axis to
       map for each corresponding positional argument. More generally, if the
-      positinal arguments to ``fun`` are container types, the corresponding
+      positional arguments to ``fun`` are container types, the corresponding
       element of ``in_axes`` can itself be a matching container, so that
       distinct array axes can be mapped for different container elements. The
       constraint is that ``in_axes`` must be a container tree prefix of the

--- a/jax/api.py
+++ b/jax/api.py
@@ -679,8 +679,12 @@ def vmap(fun, in_axes=0, out_axes=0):
 
   return batched_fun
 
-# TODO(mattjj,phawkins): improve this implementation
 def _flatten_axes(treedef, axis_tree):
+  # given an axis spec tree axis_tree (a pytree with integers and Nones at the
+  # leaves, i.e. the Nones are to be considered leaves) that is a tree prefix of
+  # the given treedef, build a complete axis spec tree with the same structure
+  # and return the flattened result
+  # TODO(mattjj,phawkins): improve this implementation
   proxy = object()
   dummy = tree_unflatten(treedef, [object()] * treedef.num_leaves)
   axes = []

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from .tree_util import (build_tree, process_pytree, tree_flatten,
-                        tree_unflatten, treedef_is_leaf)
+from .tree_util import (build_tree, tree_flatten, tree_unflatten,
+                        treedef_is_leaf)
 from .linear_util import transformation_with_aux
 from .util import safe_map, unzip2, partial, curry
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -25,7 +25,7 @@ from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like
                        zeros_like_p, zero, Zero)
 from ..abstract_arrays import raise_to_shaped
 from ..util import unzip2, unzip3, safe_map, safe_zip, partial, split_list
-from ..tree_util import process_pytree, build_tree, register_pytree_node, tree_map
+from ..tree_util import build_tree, register_pytree_node, tree_map
 from ..linear_util import thunk, staged, transformation, transformation_with_aux, wrap_init
 from ..api_util import flatten_fun, flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -52,7 +52,8 @@ def batch_fun(fun, in_vals, in_dims):
 @transformation_with_aux
 def batch_subtrace(master, in_dims, *in_vals):
   trace = BatchTrace(master, core.cur_sublevel())
-  in_tracers = map(partial(BatchTracer, trace), in_vals, in_dims)
+  in_tracers = [BatchTracer(trace, val, dim) if dim is not None else val
+                for val, dim in zip(in_vals, in_dims)]
   outs = yield in_tracers, {}
   out_tracers = map(trace.full_raise, outs)
   out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -38,8 +38,8 @@ map = safe_map
 
 
 def batch(fun, in_vals, in_dims, out_dim_dests):
-  out_vals, out_dims = batch_fun(fun, in_vals, in_dims)
   size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
+  out_vals, out_dims = batch_fun(fun, in_vals, in_dims)
   return map(partial(matchaxis, size), out_dims, out_dim_dests(), out_vals)
 
 def batch_fun(fun, in_vals, in_dims):
@@ -163,8 +163,8 @@ def get_primitive_batcher(p):
   try:
     return primitive_batchers[p]
   except KeyError:
-    raise NotImplementedError(
-        "Batching rule for '{}' not implemented".format(p))
+    msg = "Batching rule for '{}' not implemented"
+    raise NotImplementedError(msg.format(p))
 
 def defvectorized(prim):
   primitive_batchers[prim] = partial(vectorized_batcher, prim)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1093,6 +1093,12 @@ class APITest(jtu.JaxTestCase):
     b = np.dot(a + np.eye(a.shape[0]), real_x)
     print(gf(a, b))  # doesn't crash
 
+  def test_vmap_in_axes_tree_prefix_error(self):
+    # https://github.com/google/jax/issues/795
+    jtu.check_raises_regexp(
+        lambda: api.vmap(lambda x: x, in_axes=(0, 0))(np.ones(3)),
+        ValueError, "axes specification must be a tree prefix")
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1097,7 +1097,11 @@ class APITest(jtu.JaxTestCase):
     # https://github.com/google/jax/issues/795
     jtu.check_raises_regexp(
         lambda: api.vmap(lambda x: x, in_axes=(0, 0))(np.ones(3)),
-        ValueError, "axes specification must be a tree prefix")
+        ValueError,
+        "axes specification must be a tree prefix of the corresponding "
+        r"value, got specification \(0, 0\) for value "
+        r"PyTreeDef\(tuple, \[\*\]\)."
+    )
 
   def test_vmap_unbatched_object_passthrough_issue_183(self):
     # https://github.com/google/jax/issues/183

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1106,6 +1106,29 @@ class APITest(jtu.JaxTestCase):
     ans = vfun(lambda x: x + 1, np.arange(3))
     self.assertAllClose(ans, onp.arange(1, 4), check_dtypes=False)
 
+  def test_vmap_error_message_issue_705(self):
+    # https://github.com/google/jax/issues/705
+    def h(a, b):
+      return np.sum(a) + np.sum(b)
+
+    X = onp.random.randn(10, 4)
+    U = onp.random.randn(10, 2)
+    self.assertRaisesRegex(
+        ValueError,
+        "vmap got inconsistent sizes for array axes to be mapped:\n"
+        "arg 0 has shape \(10, 4\) and axis 0 is to be mapped\n"
+        "arg 1 has shape \(10, 2\) and axis 1 is to be mapped\n"
+        "so\n"
+        "arg 0 has an axis to be mapped of size 10\n"
+        "arg 1 has an axis to be mapped of size 2",
+        lambda: api.vmap(h, in_axes=(0, 1))(X, U))
+
+    self.assertRaisesRegex(
+        ValueError,
+        "vmap got inconsistent sizes for array axes to be mapped:\n"
+        "the tree of axis sizes is:\n",
+        lambda: api.vmap(h, in_axes=(0, 1))(X, [U, U]))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1099,14 +1099,14 @@ class APITest(jtu.JaxTestCase):
         lambda: api.vmap(lambda x: x, in_axes=(0, 0))(np.ones(3)),
         ValueError, "axes specification must be a tree prefix")
 
-  def test_vmap_objects_issue_183(self):
+  def test_vmap_unbatched_object_passthrough_issue_183(self):
     # https://github.com/google/jax/issues/183
     fun = lambda f, x: f(x)
     vfun = api.vmap(fun, (None, 0))
     ans = vfun(lambda x: x + 1, np.arange(3))
     self.assertAllClose(ans, onp.arange(1, 4), check_dtypes=False)
 
-  def test_vmap_error_message_issue_705(self):
+  def test_vmap_mismatched_axis_sizes_error_message_issue_705(self):
     # https://github.com/google/jax/issues/705
     def h(a, b):
       return np.sum(a) + np.sum(b)
@@ -1126,7 +1126,8 @@ class APITest(jtu.JaxTestCase):
     self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
-        "the tree of axis sizes is:\n",
+        "the tree of axis sizes is:\n"
+        "\(10, \[2, 2\]\)",
         lambda: api.vmap(h, in_axes=(0, 1))(X, [U, U]))
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1099,6 +1099,13 @@ class APITest(jtu.JaxTestCase):
         lambda: api.vmap(lambda x: x, in_axes=(0, 0))(np.ones(3)),
         ValueError, "axes specification must be a tree prefix")
 
+  def test_vmap_objects_issue_183(self):
+    # https://github.com/google/jax/issues/183
+    fun = lambda f, x: f(x)
+    vfun = api.vmap(fun, (None, 0))
+    ans = vfun(lambda x: x + 1, np.arange(3))
+    self.assertAllClose(ans, onp.arange(1, 4), check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1117,6 +1117,7 @@ class APITest(jtu.JaxTestCase):
 
     X = onp.random.randn(10, 4)
     U = onp.random.randn(10, 2)
+
     self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
@@ -1126,6 +1127,17 @@ class APITest(jtu.JaxTestCase):
         "arg 0 has an axis to be mapped of size 10\n"
         "arg 1 has an axis to be mapped of size 2",
         lambda: api.vmap(h, in_axes=(0, 1))(X, U))
+
+    self.assertRaisesRegex(
+        ValueError,
+        "vmap got inconsistent sizes for array axes to be mapped:\n"
+        r"arg 0 has shape \(10, 4\) and axis 0 is to be mapped" "\n"
+        r"arg 1 has shape \(10, 2\) and axis 1 is to be mapped" "\n"
+        r"arg 2 has shape \(10, 4\) and axis 0 is to be mapped" "\n"
+        "so\n"
+        "args 0, 2 have axes to be mapped of size 10\n"
+        "arg 1 has an axis to be mapped of size 2",
+        lambda: api.vmap(lambda x, y, z: None, in_axes=(0, 1, 0))(X, U, X))
 
     self.assertRaisesRegex(
         ValueError,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1116,8 +1116,8 @@ class APITest(jtu.JaxTestCase):
     self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
-        "arg 0 has shape \(10, 4\) and axis 0 is to be mapped\n"
-        "arg 1 has shape \(10, 2\) and axis 1 is to be mapped\n"
+        r"arg 0 has shape \(10, 4\) and axis 0 is to be mapped" "\n"
+        r"arg 1 has shape \(10, 2\) and axis 1 is to be mapped" "\n"
         "so\n"
         "arg 0 has an axis to be mapped of size 10\n"
         "arg 1 has an axis to be mapped of size 2",
@@ -1127,7 +1127,7 @@ class APITest(jtu.JaxTestCase):
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
         "the tree of axis sizes is:\n"
-        "\(10, \[2, 2\]\)",
+        r"\(10, \[2, 2\]\)",
         lambda: api.vmap(h, in_axes=(0, 1))(X, [U, U]))
 
 

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -369,20 +369,22 @@ class BatchingTest(jtu.JaxTestCase):
 
   def testDynamicSlice(self):
     # test dynamic_slice via numpy indexing syntax
-    x = onp.arange(30).reshape((10, 3))
+    # see https://github.com/google/jax/issues/1613 for an explanation of why we
+    # need to use np rather than onp to create x and idx
+    x = np.arange(30).reshape((10, 3))
 
     ans = vmap(lambda x, i: x[i], in_axes=(0, None))(x, 1)
     expected = x[:, 1]
     self.assertAllClose(ans, expected, check_dtypes=False)
 
 
-    idx = onp.array([0, 1, 2, 1, 0] * 2)
+    idx = np.array([0, 1, 2, 1, 0] * 2)
     ans = vmap(lambda x, i: x[i], in_axes=(0, 0))(x, idx)
     expected = x[onp.arange(10), idx]
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    x = onp.arange(3)
-    idx = onp.array([0, 1, 2, 1, 0] * 2)
+    x = np.arange(3)
+    idx = np.array([0, 1, 2, 1, 0] * 2)
     ans = vmap(lambda x, i: x[i], in_axes=(None, 0))(x, idx)
     expected = x[idx]
     self.assertAllClose(ans, expected, check_dtypes=False)

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -103,7 +103,7 @@ class TreeTest(jtu.JaxTestCase):
 
   @parameterized.parameters(*PYTREES)
   def testRoundtripViaBuild(self, inputs):
-    xs, tree = tree_util.process_pytree(tuple, inputs)
+    xs, tree = tree_util._process_pytree(tuple, inputs)
     actual = tree_util.build_tree(tree, xs)
     self.assertEqual(actual, inputs)
 


### PR DESCRIPTION
The aim here is to close #183 (a one-liner, after all this time!), close #705, and close #795.

Re: #183, we just had to replace this line:

```python
  in_tracers = map(partial(BatchTracer, trace), in_vals, in_dims)
```

with this one:

```python
  in_tracers = [BatchTracer(trace, val, dim) if dim is not None else val
                for val, dim in zip(in_vals, in_dims)]
```

Re: #705, the error printed out in that example case is now:

```python
import jax.numpy as np
from jax import api
import numpy as onp

def h(a, b):
  return np.sum(a) + np.sum(b)

X = onp.random.randn(10, 4)
U = onp.random.randn(10, 2)
api.vmap(h, in_axes=(0, 1))(X, U)
```

```
ValueError: vmap got inconsistent sizes for array axes to be mapped:
arg 0 has shape (10, 4) and axis 0 is to be mapped
arg 1 has shape (10, 2) and axis 1 is to be mapped
so
arg 0 has an axis to be mapped of size 10
arg 1 has an axis to be mapped of size 2
```

Or slightly more generally:

```python
vmap(lambda x, y, z: None, (0, 1, 0))(X, U, X)
```

```
ValueError: vmap got inconsistent sizes for array axes to be mapped:
arg 0 has shape (10, 4) and axis 0 is to be mapped
arg 1 has shape (10, 2) and axis 1 is to be mapped
arg 2 has shape (10, 4) and axis 0 is to be mapped
so
args 0, 2 have axes to be mapped of size 10
arg 1 has an axis to be mapped of size 2
```

There was a semi-interesting failure of `BatchingTest.testDynamicSlice` on eae47b2: because `vmap` now passes through un-mapped arguments unmolsted (to fix #183) that meant we couldn't write `x[i]` anymore when `x` would be a raw ndarray and `i` would be one of our Tracers. The fix was just to use `np` rather than `onp` in the test.