### PR TITLE
Import nn in jax/__init__.py.

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -17,5 +17,6 @@ os.environ.setdefault('TF_CPP_MIN_LOG_LEVEL', '1')
 
 from jax.version import __version__
 from jax.api import *
+from jax import nn
 from jax import random
 import jax.numpy as np  # side-effecting import sets up operator overloads


### PR DESCRIPTION
Not sure when this changed, but last week `jax.nn.softmax` (et al) would work.