### PR TITLE
avoid staging out some trivial convert_element_types

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -349,7 +349,7 @@ def convert_element_type(operand, new_dtype):
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
   new_dtype = xla_bridge.canonicalize_dtype(new_dtype)
-  old_dtype = _dtype(operand)
+  old_dtype = xla_bridge.canonicalize_dtype(_dtype(operand))
   if old_dtype != new_dtype:
     if (onp.issubdtype(old_dtype, onp.complexfloating) and
         not onp.issubdtype(new_dtype, onp.complexfloating)):


### PR DESCRIPTION
The reason this isn't needed even if, say, the operand is a float64 and we have JAX_ENABLE_X64=False, is that we do that kind of dtype conversion when dispatching computations (by calling `canonicalize_dtype` from `device_put` in xla.py).