### PR TITLE
implement James Bondbury caching heuristic

### DIFF
--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -204,7 +204,8 @@ def cache(call):
   seen_hashes = set()
   persistent_functions = set()
   def maybe_seen_before(f):
-    return len(seen_hashes) == (seen_hashes.add(hash(f)) or len(seen_hashes))
+    key = hash((f, getattr(f, '__name__', None), getattr(f, '__module__', None)))
+    return len(seen_hashes) == (seen_hashes.add(key) or len(seen_hashes))
 
   def memoized_fun(fun, *args):
     cache = fun_caches.setdefault(fun.f, {})


### PR DESCRIPTION
This is a follow-up to #1605 to address the issue of recompiling equal (but not identical) callables.

Python callables can be equal but not identical (in real use cases!), as we learned when we tried to pull #1605 down into Google and saw new test timeouts due to repeating big recompilations. Here's a stylized version of the issue:

```python
class partial(object):
  def __init__(self, f, *args):
    self.stuff = (f, args)
  def __hash__(self):
    return hash(self.stuff)
  def __eq__(self, other):
    return type(other) is partial and self.stuff == other.stuff
  def __call__(self, *rest):
    f, args = self.stuff
    return f(*(args + rest))

f = lambda x, y: x + y
assert partial(f, 2) == partial(f, 2)
assert partial(f, 2) is not partial(f, 2)

jit(partial(f, 2))(3)
jit(partial(f, 2))(5)  # cache hit or miss?
```

Before #1605, the last line would get a cache hit because the caching was based on equality (acting in effect as if the underlying callable itself was the cache key, ignoring the other components of the cache key for simplicity). After #1605, because the cache became a WeakKeyDictionary, when the first `partial(f, 2)` went out of scope the corresponding cache entry would be deleted.

This came up in a real use case, though it involved bound instance methods rather than partials. It relied on something like this at-first-surprising but sensible-in-retrospect Python behavior:

```python
class A:
  def foo(self): pass  # an instance method

a1, a2 = A(), A()
print(id(a1.foo), hash(a1.foo))
print(id(a2.foo), hash(a2.foo))  # different hashes!

class A:
  def foo(self): pass  # an instance method
  def __hash__(self): return 2
  def __eq__(self, other): type(other) is A

a1, a2 = A(), A()
print(id(a1.foo), hash(a1.foo))
print(id(a2.foo), hash(a2.foo))  # equal hashes!
```

```
140018977204896 4768
140018977204896 4796
140018977204896 8751184735374
140018977204896 8751184735374
```

Actually, what we observed were instance methods with _different_ ids but equal hashes (unlike the above for which the ids are all the same), though it involved threading.

So should we...
1. ...cache by putting the callables in a (strong-ref) dict, like pre-#1605, which means caching on value semantics? That means we'd get hits in the first example above, but it also means we can't delete cache entries when the corresponding callable objects go out of scope: what if someone creates a brand new but equal function later?
2. ...cache by putting the callables in a a WeakKeyDictionary, like post-#1605, which in terms of persistence is like caching on object identity? Then we'd be able to delete a cache entry when the corresponding callable object goes out of scope, solving the issue in #1605, but it also means we get cache misses in the above example, and in analogous real user code.

We don't know the answer yet. But at least as a stop-gap, or possibly a long-term solution if it works well, @jekbradbury proposed a heuristic: start from policy 2 using a WeakKeyDictionary, but keep around a list of callable hashes we've seen before. If we see the same hash again, then hang on to a strong reference to the callable, so as to keep it in the WeakKeyDictionary hash. (We called this the James Bondbury Heuristic because You Only Compile Twice.)

I verified:
  - [x] the internal tests pass rather than time out
  - [x] the memory leak version of the #1605 issue (with large constants) doesn't blow up
  - [x] the benchmark in #1605 is unaffected