### PR TITLE
Fix large constants in activations

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -38,7 +38,6 @@ def elu(x, alpha=1.0):
   x = np.asarray(x)
   alpha = np.asarray(alpha, x.dtype)
   safe_x = lax.select(x > 0, np.zeros(onp.shape(x), x.dtype), x)
-  print(x.dtype, safe_x.dtype, np.expm1(safe_x).dtype, type(alpha), (alpha * np.expm1(safe_x)).dtype )
   return lax.select(x > 0, x, alpha * np.expm1(safe_x))
 
 def leaky_relu(x, negative_slope=1e-2):

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -35,18 +35,21 @@ def swish(x): return x * sigmoid(x)
 def log_sigmoid(x): return -softplus(-x)
 
 def elu(x, alpha=1.0):
-  safe_x = np.where(x > 0, 0., x)
-  return np.where(x > 0, x, alpha * np.expm1(safe_x))
+  safe_x = lax.select(x > 0, np.zeros(onp.shape(x)), x)
+  return lax.select(x > 0, x, alpha * np.expm1(safe_x))
 
 def leaky_relu(x, negative_slope=1e-2):
-  return np.where(x >= 0, x, negative_slope * x)
+  return lax.select(x >= 0, x, negative_slope * x)
 
 def hard_tanh(x):
-  return np.where(x > 1, 1, np.where(x < -1, -1, x))
+  shape = onp.shape(x)
+  ones = np.full(shape, 1.)
+  minus_ones = np.full(shape, -1.)
+  return lax.select(x > 1, ones, lax.select(x < -1, minus_ones, x))
 
 def celu(x, alpha=1.0):
   """Continuously-differentiable exponential linear unit activation"""
-  return np.where(x > 0, x, alpha * np.expm1(x / alpha))
+  return lax.select(x > 0, x, alpha * np.expm1(x / alpha))
 
 def selu(x):
   """Scaled exponential linear unit activation"""

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -35,26 +35,35 @@ def swish(x): return x * sigmoid(x)
 def log_sigmoid(x): return -softplus(-x)
 
 def elu(x, alpha=1.0):
-  safe_x = lax.select(x > 0, np.zeros(onp.shape(x)), x)
+  x = np.asarray(x)
+  alpha = np.asarray(alpha, x.dtype)
+  safe_x = lax.select(x > 0, np.zeros(onp.shape(x), x.dtype), x)
+  print(x.dtype, safe_x.dtype, np.expm1(safe_x).dtype, type(alpha), (alpha * np.expm1(safe_x)).dtype )
   return lax.select(x > 0, x, alpha * np.expm1(safe_x))
 
 def leaky_relu(x, negative_slope=1e-2):
+  x = np.asarray(x)
+  negative_slope = np.asarray(negative_slope, x.dtype)
   return lax.select(x >= 0, x, negative_slope * x)
 
 def hard_tanh(x):
+  x = np.asarray(x)
   shape = onp.shape(x)
-  ones = np.full(shape, 1.)
-  minus_ones = np.full(shape, -1.)
+  ones = np.full(shape, 1., x.dtype)
+  minus_ones = np.full(shape, -1., x.dtype)
   return lax.select(x > 1, ones, lax.select(x < -1, minus_ones, x))
 
 def celu(x, alpha=1.0):
   """Continuously-differentiable exponential linear unit activation"""
+  x = np.asarray(x)
+  alpha = np.asarray(alpha, x.dtype)
   return lax.select(x > 0, x, alpha * np.expm1(x / alpha))
 
 def selu(x):
   """Scaled exponential linear unit activation"""
-  alpha = 1.6732632423543772848170429916717
-  scale = 1.0507009873554804934193349852946
+  x = np.asarray(x)
+  alpha = onp.array(1.6732632423543772848170429916717, x.dtype)
+  scale = onp.array(1.0507009873554804934193349852946, x.dtype)
   return scale * elu(x, alpha)
 
 def gelu(x):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -30,6 +30,7 @@ from jax.test_util import check_grads
 from jax import nn
 from jax import random
 import jax
+import jax.numpy as np
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -49,6 +50,12 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testEluValue(self):
     val = nn.elu(1e4)
     self.assertAllClose(val, 1e4, check_dtypes=False)
+
+  def testEluMemory(self):
+      jax.make_jaxpr(nn.elu)(np.ones((10 ** 12,)))
+
+  def testHardTanhMemory(self):
+      jax.make_jaxpr(nn.hard_tanh)(np.ones((10 ** 12,)))
 
 InitializerRecord = collections.namedtuple(
   "InitializerRecord",


### PR DESCRIPTION
This fixes an issue where using the elu, selu, or tanh activation results in a constant as big as the input being created.

This PR also switches the use of np.where to lax.select for activation functions to avoid accidental broadcasting of scalars in the future.

I added a test that verifies that making the jaxpr does not produce constants that scale in size with the input.