### PR TITLE
fix indexing error after #1622 involving empty result

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2557,7 +2557,9 @@ def _gather(arr, treedef, static_idx, dynamic_idx):
   indexer = _index_to_gather(shape(arr), idx)  # shared with _scatter_update
   y = arr
 
-  if indexer.gather_indices.size:
+  # We avoid generating a gather when indexer.gather_indices.size is empty
+  # unless indexer.slice_shape also corresponds to an empty array.
+  if indexer.gather_indices.size or not prod(indexer.slice_shape):
     y = lax.gather(y, indexer.gather_indices, indexer.dnums,
                    indexer.gather_slice_shape)
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -736,6 +736,15 @@ class IndexingTest(jtu.JaxTestCase):
     self.assertEqual(len(jaxpr.eqns), 1)
     self.assertNotIn('gather', str(jaxpr))
 
+  def testBooleanIndexingWithEmptyResult(self):
+    # based on a TensorFlow Probability test that started failing after #1622
+    x = lnp.array([-1])
+    mask = lnp.array([False])
+    ans = x[mask]  # doesn't crash
+
+    expected =  onp.array([-1])[onp.array([False])]
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
 
 def _broadcastable_shapes(shape):
   """Returns all shapes that broadcast to `shape`."""


### PR DESCRIPTION
Given that our tests didn't catch this, I wonder if we're missing some test coverage around boolean indexing and/or empty results. 