### PR TITLE
give tie_in a custom partial-eval rule

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1224,6 +1224,17 @@ class APITest(jtu.JaxTestCase):
     python_should_be_executing = False
     api.pmap(f, 'i')(x)
 
+  def test_tie_in_jaxpr(self):
+    def f(x):
+      y = lax.tie_in(x, 1)
+      z = y + 2
+      return x + z
+
+    jaxpr = api.make_jaxpr(f)(0)
+    self.assertEqual(len(jaxpr.eqns), 2)
+    self.assertIs(jaxpr.eqns[0].primitive, lax.add_p)
+    self.assertIs(jaxpr.eqns[1].primitive, lax.add_p)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
The tie_in primitive (currently residing in lax.py even though it's really a core primitive) is about our tracing / embedding mechanism, and shouldn't show up in jaxprs.

```python
def f(x):
  y = lax.tie_in(x, 1)
  return y + 2
print(make_jaxpr(f)(0))
```

Before this change:
```
{ lambda  ;  ; a.
  let b = tie_in a 1
      c = add b 2
  in [c] }
```

After this change:
```
{ lambda  ;  ; a.
  let b = add 1 2
  in [b] }
```

More than just pretty-printing, since `tie_in` doesn't appear in jaxprs anymore, transformations on jaxprs ("initial-style" transformations) no longer need transformation rules for it. (Final-style rules still do, even though they're mostly just pass-throughs; the only nontrivial one is the partial-eval rule.)