### PR TITLE
Fix np.clip broadcasting across a_min and a_max

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -986,11 +986,11 @@ def clip(a, a_min=None, a_max=None):
   if a_min is not None:
     if _dtype(a_min) != _dtype(a):
       a_min = lax.convert_element_type(a_min, _dtype(a))
-    a = lax.max(a_min, a)
+    a = maximum(a_min, a)
   if a_max is not None:
     if _dtype(a_max) != _dtype(a):
       a_max = lax.convert_element_type(a_max, _dtype(a))
-    a = lax.min(a_max, a)
+    a = minimum(a_max, a)
   return a
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -683,7 +683,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max,
        "rng": jtu.rand_default()}
       for shape in all_shapes for dtype in number_dtypes
-      for a_min, a_max in [(-1, None), (None, 1), (-1, 1)]))
+      for a_min, a_max in [(-1, None), (None, 1), (-1, 1),
+                           (-lnp.ones(1), None),
+                           (None, lnp.ones(1)),
+                           (-lnp.ones(1), lnp.ones(1))]))
   def testClipStaticBounds(self, shape, dtype, a_min, a_max, rng):
     onp_fun = lambda x: onp.clip(x, a_min=a_min, a_max=a_max)
     lnp_fun = lambda x: lnp.clip(x, a_min=a_min, a_max=a_max)


### PR DESCRIPTION
Currently, `np.clip` errors when passing `a_min`/`a_max` shapes that don't exactly match the input.

```python
import numpy as onp
import jax.numpy as np
onp.clip(onp.ones((10, 1)), onp.ones(1), onp.ones(1))  # Correctly broadcasts
np.clip(np.ones((10, 1)), np.ones(1), np.ones(1)) # Throws type error
```
This PR modifies `clip` to use `minimum`/`maximum`, which do broadcast correctly, instead of `lax.min` and `lax.max`.