### PR TITLE
Faster test collection, second try

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -651,7 +651,8 @@ class BatchingTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
           slice_sizes),
        "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32, onp.int32]
       for axis, shape, idxs, dnums, slice_sizes in [
           (0, (3, 5), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
@@ -669,10 +670,12 @@ class BatchingTest(jtu.JaxTestCase):
              start_index_map=(0, 1)),
             (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherBatchedOperand(self, axis, shape, dtype, idxs, dnums,
-                               slice_sizes, rng, rng_idx):
+                               slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     operand = rng(shape, dtype)
     ans = vmap(fun, (axis, None))(operand, idxs)
@@ -685,7 +688,8 @@ class BatchingTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
           slice_sizes),
        "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32, onp.float64]
       for axis, shape, idxs, dnums, slice_sizes in [
           (0, (3, 5), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
@@ -702,10 +706,12 @@ class BatchingTest(jtu.JaxTestCase):
              offset_dims=(1,), collapsed_slice_dims=(0,),
              start_index_map=(0, 1)),
             (1, 3)),      ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherGradBatchedOperand(self, axis, shape, dtype, idxs, dnums,
-                                   slice_sizes, rng, rng_idx):
+                                   slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
     operand = rng(shape, dtype)
@@ -719,7 +725,8 @@ class BatchingTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
           slice_sizes),
        "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32, onp.int32]
       for axis, shape, idxs, dnums, slice_sizes in [
           (0, (5,), onp.array([[[0], [2]], [[1], [3]]]), lax.GatherDimensionNumbers(
@@ -734,10 +741,12 @@ class BatchingTest(jtu.JaxTestCase):
                                   [[1, 0], [2, 3]]]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)), (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherBatchedIndices(self, axis, shape, dtype, idxs, dnums,
-                               slice_sizes, rng, rng_idx):
+                               slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     operand = rng(shape, dtype)
     ans = vmap(fun, (None, axis))(operand, idxs)
@@ -750,7 +759,8 @@ class BatchingTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis, idxs, dnums,
           slice_sizes),
        "axis": axis, "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32, onp.float64]
       for axis, shape, idxs, dnums, slice_sizes in [
           (0, (5,), onp.array([[[0], [2]], [[1], [3]]]), lax.GatherDimensionNumbers(
@@ -765,10 +775,12 @@ class BatchingTest(jtu.JaxTestCase):
                                   [[1, 0], [2, 3]]]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)), (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherGradBatchedIndices(self, axis, shape, dtype, idxs, dnums,
-                                   slice_sizes, rng, rng_idx):
+                                   slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
     operand = rng(shape, dtype)
@@ -783,7 +795,7 @@ class BatchingTest(jtu.JaxTestCase):
           dnums, slice_sizes),
        "op_axis": op_axis, "idxs_axis": idxs_axis, "shape": shape, "dtype":
        dtype, "idxs": idxs, "dnums": dnums, "slice_sizes": slice_sizes,
-       "rng": rng, "rng_idx": rng_idx}
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32, onp.int32]
       for op_axis, idxs_axis, shape, idxs, dnums, slice_sizes in [
           (0, 0, (2, 5), onp.array([[[0], [2]], [[1], [3]]]),
@@ -804,10 +816,12 @@ class BatchingTest(jtu.JaxTestCase):
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
            (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherBatchedBoth(self, op_axis, idxs_axis, shape, dtype, idxs, dnums,
-                            slice_sizes, rng, rng_idx):
+                            slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     operand = rng(shape, dtype)
     assert operand.shape[op_axis] == idxs.shape[idxs_axis]
@@ -823,7 +837,7 @@ class BatchingTest(jtu.JaxTestCase):
           dnums, slice_sizes),
        "op_axis": op_axis, "idxs_axis": idxs_axis, "shape": shape, "dtype":
        dtype, "idxs": idxs, "dnums": dnums, "slice_sizes": slice_sizes,
-       "rng": rng, "rng_idx": rng_idx}
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in [onp.float32]
       for op_axis, idxs_axis, shape, idxs, dnums, slice_sizes in [
           (0, 0, (2, 5), onp.array([[[0], [2]], [[1], [3]]]),
@@ -844,10 +858,12 @@ class BatchingTest(jtu.JaxTestCase):
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
            (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()])
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default])
   def testGatherGradBatchedBoth(self, op_axis, idxs_axis, shape, dtype, idxs, dnums,
-                            slice_sizes, rng, rng_idx):
+                                slice_sizes, rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     gfun = grad(lambda x, idx: np.sum(np.sin(fun(x, idx))))
     operand = rng(shape, dtype)

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -53,14 +53,15 @@ class FftTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inverse={}_shape={}_axes={}".format(
           inverse, jtu.format_shape_dtype_string(shape, dtype), axes),
-       "axes": axes, "shape": shape, "dtype": dtype, "rng": rng,
+       "axes": axes, "shape": shape, "dtype": dtype, "rng_factory": rng_factory,
        "inverse": inverse}
       for inverse in [False, True]
-      for rng in [jtu.rand_default()]
+      for rng_factory in [jtu.rand_default]
       for dtype in all_dtypes
       for shape in [(10,), (10, 10), (2, 3, 4), (2, 3, 4, 5)]
       for axes in _get_fftn_test_axes(shape)))
-  def testFftn(self, inverse, shape, dtype, axes, rng):
+  def testFftn(self, inverse, shape, dtype, axes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: (rng(shape, dtype),)
     np_op = np.fft.ifftn if inverse else np.fft.fftn
     onp_op = onp.fft.ifftn if inverse else onp.fft.fftn

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -389,12 +389,13 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list({
       "testcase_name": "{}_inshape={}_indexer={}".format(
           name, jtu.format_shape_dtype_string( shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for dtype in all_dtypes
-    for rng in [jtu.rand_default()]))
-  def testStaticIndexing(self, shape, dtype, rng, indexer):
+    for rng_factory in [jtu.rand_default]))
+  def testStaticIndexing(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     fun = lambda x: x[indexer]
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)
@@ -404,12 +405,13 @@ class IndexingTest(jtu.JaxTestCase):
           "{}_inshape={}_indexer={}".format(name,
                                             jtu.format_shape_dtype_string(
                                                 shape, dtype), indexer),
-      "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer
+      "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_GRAD_TESTS
     for shape, indexer in index_specs
     for dtype in float_dtypes
-    for rng in [jtu.rand_default()])
-  def testStaticIndexingGrads(self, shape, dtype, rng, indexer):
+    for rng_factory in [jtu.rand_default])
+  def testStaticIndexingGrads(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     tol = 1e-2 if onp.finfo(dtype).bits == 32 else None
     arg = rng(shape, dtype)
     fun = lambda x: x[indexer]**2
@@ -434,7 +436,7 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in [
           ("OneSliceIndex",
            [IndexSpec(shape=(5,), indexer=slice(1, 3)),
@@ -454,8 +456,9 @@ class IndexingTest(jtu.JaxTestCase):
       ]
       for shape, indexer in index_specs
       for dtype in all_dtypes
-      for rng in [jtu.rand_default()])
-  def testDynamicIndexingWithSlicesErrors(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testDynamicIndexingWithSlicesErrors(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     unpacked_indexer, pack_indexer = self._ReplaceSlicesWithTuples(indexer)
 
     @api.jit
@@ -469,7 +472,7 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in [
           ("OneIntIndex",
            [IndexSpec(shape=(3,), indexer=1),
@@ -486,8 +489,9 @@ class IndexingTest(jtu.JaxTestCase):
       ]
       for shape, indexer in index_specs
       for dtype in all_dtypes
-      for rng in [jtu.rand_default()])
-  def testDynamicIndexingWithIntegers(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testDynamicIndexingWithIntegers(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     unpacked_indexer, pack_indexer = self._ReplaceSlicesWithTuples(indexer)
 
     def fun(x, unpacked_indexer):
@@ -500,7 +504,7 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in [
           ("OneIntIndex",
            [IndexSpec(shape=(3,), indexer=1),
@@ -519,8 +523,9 @@ class IndexingTest(jtu.JaxTestCase):
       ]
       for shape, indexer in index_specs
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()])
-  def testDynamicIndexingWithIntegersGrads(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testDynamicIndexingWithIntegersGrads(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     tol = 1e-2 if onp.finfo(dtype).bits == 32 else None
     unpacked_indexer, pack_indexer = self._ReplaceSlicesWithTuples(indexer)
 
@@ -535,12 +540,13 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
       for dtype in all_dtypes
-      for rng in [jtu.rand_default()])
-  def testAdvancedIntegerIndexing(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), indexer]
     fun = lambda x, idx: x[idx]
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)
@@ -548,7 +554,7 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in [
           ("One1DIntArrayIndex",
            [IndexSpec(shape=(3,), indexer=onp.array([0, 1])),
@@ -597,8 +603,9 @@ class IndexingTest(jtu.JaxTestCase):
       ]
       for shape, indexer in index_specs
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()])
-  def testAdvancedIntegerIndexingGrads(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testAdvancedIntegerIndexingGrads(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     tol = 1e-2 if onp.finfo(dtype).bits == 32 else None
     arg = rng(shape, dtype)
     fun = lambda x: x[indexer]**2
@@ -607,12 +614,13 @@ class IndexingTest(jtu.JaxTestCase):
   @parameterized.named_parameters(
       {"testcase_name": "{}_inshape={}_indexer={}"
        .format(name, jtu.format_shape_dtype_string(shape, dtype), indexer),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
       for dtype in all_dtypes
-      for rng in [jtu.rand_default()])
-  def testMixedAdvancedIntegerIndexing(self, shape, dtype, rng, indexer):
+      for rng_factory in [jtu.rand_default])
+  def testMixedAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
+    rng = rng_factory()
     indexer_with_dummies = [e if isinstance(e, onp.ndarray) else ()
                             for e in indexer]
     substitutes = [(i, e) for i, e in enumerate(indexer)
@@ -794,7 +802,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer,
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op
   } for name, index_specs in STATIC_INDEXING_TESTS
@@ -803,9 +811,10 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for rng in [jtu.rand_default()]))
+    for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, update_shape, update_dtype,
-                         rng, indexer, op):
+                         rng_factory, indexer, op):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
     jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
@@ -816,7 +825,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer,
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op
   } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS
@@ -825,9 +834,10 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for rng in [jtu.rand_default()]))
+    for rng_factory in [jtu.rand_default]))
   def testAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
-                           rng, indexer, op):
+                           rng_factory, indexer, op):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
     jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
@@ -838,7 +848,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer,
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op
   } for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS
@@ -847,9 +857,10 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for rng in [jtu.rand_default()]))
+    for rng_factory in [jtu.rand_default]))
   def testMixedAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
-                           rng, indexer, op):
+                           rng_factory, indexer, op):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
     jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
@@ -860,7 +871,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
-       "shape": shape, "dtype": dtype, "rng": rng, "indexer": indexer,
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op
   } for name, index_specs in STATIC_INDEXING_TESTS
@@ -869,10 +880,11 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     for dtype in float_dtypes
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else float_dtypes)
-    for rng in [jtu.rand_default()]))
+    for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj,phawkins): tpu issues
   def testStaticIndexingGrads(self, shape, dtype, update_shape, update_dtype,
-                              rng, indexer, op):
+                              rng_factory, indexer, op):
+    rng = rng_factory()
     jax_op = ops.index_update if op == UpdateOps.UPDATE else ops.index_add
     jax_fn = lambda x, y: jax_op(x, indexer, y)
     x = rng(shape, dtype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -69,8 +69,8 @@ all_dtypes = number_dtypes + bool_dtypes
 
 OpRecord = collections.namedtuple(
   "OpRecord",
-  ["name", "nargs", "dtypes", "shapes", "rng", "diff_modes", "test_name",
-   "check_dtypes", "tolerance"])
+  ["name", "nargs", "dtypes", "shapes", "rng_factory", "diff_modes",
+   "test_name", "check_dtypes", "tolerance"])
 
 default_tolerance = {
   onp.bool_: 0,
@@ -94,222 +94,222 @@ def tolerance(dtype, tol=None):
   return tol.get(dtype, default_tolerance[dtype])
 
 
-def op_record(name, nargs, dtypes, shapes, rng, diff_modes, test_name=None,
-              check_dtypes=True, tolerance=None):
+def op_record(name, nargs, dtypes, shapes, rng_factory, diff_modes,
+              test_name=None, check_dtypes=True, tolerance=None):
   test_name = test_name or name
-  return OpRecord(name, nargs, dtypes, shapes, rng, diff_modes, test_name,
-                  check_dtypes, tolerance)
+  return OpRecord(name, nargs, dtypes, shapes, rng_factory, diff_modes,
+                  test_name, check_dtypes, tolerance)
 
 JAX_ONE_TO_ONE_OP_RECORDS = [
-    op_record("abs", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("add", 2, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("conj", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal(), []),
-    op_record("exp", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("fabs", 1, float_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("float_power", 2, inexact_dtypes, all_shapes, jtu.rand_default(), ["rev"],
+    op_record("abs", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("add", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("conj", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("exp", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("fabs", 1, float_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("float_power", 2, inexact_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={onp.float32: 1e-5, onp.float64: 1e-12,
                          onp.complex64: 1e-5, onp.complex128: 1e-12}),
-    op_record("floor", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("greater", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), []),
-    op_record("greater_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), []),
-    op_record("less", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), []),
-    op_record("less_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), []),
-    op_record("log", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("logical_and", 2, all_dtypes, all_shapes, jtu.rand_bool(), []),
-    op_record("logical_not", 1, all_dtypes, all_shapes, jtu.rand_bool(), []),
-    op_record("logical_or", 2, all_dtypes, all_shapes, jtu.rand_bool(), []),
-    op_record("logical_xor", 2, all_dtypes, all_shapes, jtu.rand_bool(), []),
-    op_record("maximum", 2, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("minimum", 2, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("multiply", 2, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("negative", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("not_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), ["rev"]),
-    op_record("array_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal(), ["rev"]),
-    op_record("reciprocal", 1, inexact_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("subtract", 2, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("cos", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("tan", 1, number_dtypes, all_shapes, jtu.rand_uniform(-1.5, 1.5),
-              ["rev"]),
-    op_record("sinh", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("cosh", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
+    op_record("floor", 1, float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("greater", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("greater_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("less", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("less_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("log", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("logical_and", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_not", 1, all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_or", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_xor", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("maximum", 2, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("minimum", 2, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("multiply", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("negative", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("not_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
+    op_record("array_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
+    op_record("reciprocal", 1, inexact_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("subtract", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("cos", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("tan", 1, number_dtypes, all_shapes,
+              partial(jtu.rand_uniform, -1.5, 1.5), ["rev"]),
+    op_record("sinh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("cosh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
-    op_record("tanh", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"],
+    op_record("tanh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={onp.float64: 1e-7, onp.complex128: 1e-7}),
-    op_record("arcsin", 1, float_dtypes, all_shapes, jtu.rand_small(), ["rev"]),
-    op_record("arccos", 1, float_dtypes, all_shapes, jtu.rand_small(), ["rev"]),
-    op_record("arctan", 1, float_dtypes, all_shapes, jtu.rand_small(), ["rev"]),
-    op_record("arctan2", 2, float_dtypes, all_shapes, jtu.rand_small(), ["rev"]),
-    op_record("arcsinh", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("arccosh", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("arctanh", 1, number_dtypes, all_shapes, jtu.rand_small(), ["rev"]),
+    op_record("arcsin", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
+    op_record("arccos", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
+    op_record("arctan", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
+    op_record("arctan2", 2, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
+    op_record("arcsinh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("arccosh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("arctanh", 1, number_dtypes, all_shapes, jtu.rand_small, ["rev"]),
 ]
 
 JAX_COMPOUND_OP_RECORDS = [
     # angle has inconsistent 32/64-bit return types across numpy versions.
-    op_record("angle", 1, number_dtypes, all_shapes, jtu.rand_default(), [],
+    op_record("angle", 1, number_dtypes, all_shapes, jtu.rand_default, [],
               check_dtypes=False),
-    op_record("atleast_1d", 1, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("atleast_2d", 1, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("atleast_3d", 1, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("cbrt", 1, default_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("conjugate", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("deg2rad", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), ["rev"]),
+    op_record("atleast_1d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("atleast_2d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("atleast_3d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("cbrt", 1, default_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("conjugate", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("deg2rad", 1, float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
     op_record("divmod", 2, int_dtypes + float_dtypes, all_shapes,
-              jtu.rand_nonzero(), []),
-    op_record("exp2", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"],
+              jtu.rand_nonzero, []),
+    op_record("exp2", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={onp.float16: 1e-2}),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
-    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_positive(), [],
+    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
               test_name="expm1_large", tolerance={onp.float64: 1e-8}),
-    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive(),
+    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive,
               [], tolerance={onp.float64: 1e-8}),
-    op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), ["rev"]),
-    op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("kron", 2, number_dtypes, nonempty_shapes, jtu.rand_default(), []),
-    op_record("outer", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("imag", 1, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("iscomplex", 1, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("isfinite", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan(), []),
-    op_record("isinf", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan(), []),
-    op_record("isnan", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan(), []),
-    op_record("isneginf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan(), []),
-    op_record("isposinf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan(), []),
-    op_record("isreal", 1, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("isrealobj", 1, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("log2", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("log10", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_positive(), [],
+    op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
+    op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("kron", 2, number_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("outer", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("imag", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("iscomplex", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("isfinite", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isinf", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isnan", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isneginf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isposinf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isreal", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("isrealobj", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("log2", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("log10", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
               test_name="log1p_large", tolerance={onp.float64: 1e-12}),
-    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_small_positive(), [],
+    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_small_positive, [],
               tolerance={onp.float64: 1e-12}),
     op_record("logaddexp", 2, float_dtypes, all_shapes,
-              jtu.rand_some_inf_and_nan(), ["rev"],
+              jtu.rand_some_inf_and_nan, ["rev"],
               tolerance={onp.float64: 1e-12}),
     op_record("logaddexp2", 2, float_dtypes, all_shapes,
-              jtu.rand_some_inf_and_nan(), ["rev"],
+              jtu.rand_some_inf_and_nan, ["rev"],
               tolerance={onp.float16: 1e-2}),
     op_record("polyval", 2, number_dtypes, nonempty_nonscalar_array_shapes,
-              jtu.rand_default(), [], check_dtypes=False,
+              jtu.rand_default, [], check_dtypes=False,
               tolerance={onp.float16: 1e-2, onp.float64: 1e-12}),
-    op_record("positive", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("power", 2, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("rad2deg", 1, float_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("ravel", 1, all_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("real", 1, number_dtypes, all_shapes, jtu.rand_some_inf(), []),
-    op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), [],
+    op_record("positive", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("power", 2, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("rad2deg", 1, float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("ravel", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("real", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-2}),
-    op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("sinc", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"],
+    op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("sinc", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={onp.complex64: 1e-5}),
-    op_record("square", 1, number_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive(), ["rev"]),
-    op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default(), ["rev"]),
-    op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero(), ["rev"]),
-    op_record("where", 3, (onp.float32, onp.int64), all_shapes, jtu.rand_some_zero(), []),
-    op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default(), ["rev"]),
+    op_record("square", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
+    op_record("where", 3, (onp.float32, onp.int64), all_shapes, jtu.rand_some_zero, []),
+    op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
 ]
 
 JAX_BITWISE_OP_RECORDS = [
     op_record("bitwise_and", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool(), []),
+              jtu.rand_bool, []),
     op_record("bitwise_not", 1, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool(), []),
+              jtu.rand_bool, []),
     op_record("bitwise_or", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool(), []),
+              jtu.rand_bool, []),
     op_record("bitwise_xor", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool(), []),
+              jtu.rand_bool, []),
 ]
 
 JAX_REDUCER_RECORDS = [
-    op_record("mean", 1, number_dtypes, nonempty_shapes, jtu.rand_default(), []),
-    op_record("prod", 1, number_dtypes, all_shapes, jtu.rand_small_positive(), []),
-    op_record("sum", 1, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("var", 1, number_dtypes, nonempty_shapes, jtu.rand_default(), []),
-    op_record("std", 1, inexact_dtypes, nonempty_shapes, jtu.rand_default(), []),
-    op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan(), []),
-    op_record("nanprod", 1, inexact_dtypes, all_shapes, jtu.rand_some_nan(), []),
-    op_record("nansum", 1, number_dtypes, all_shapes, jtu.rand_some_nan(), []),
+    op_record("mean", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("prod", 1, number_dtypes, all_shapes, jtu.rand_small_positive, []),
+    op_record("sum", 1, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("var", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("std", 1, inexact_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("nanprod", 1, inexact_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("nansum", 1, number_dtypes, all_shapes, jtu.rand_some_nan, []),
 ]
 
 JAX_REDUCER_NO_DTYPE_RECORDS = [
-    op_record("all", 1, all_dtypes, all_shapes, jtu.rand_some_zero(), []),
-    op_record("any", 1, all_dtypes, all_shapes, jtu.rand_some_zero(), []),
-    op_record("max", 1, all_dtypes, nonempty_shapes, jtu.rand_default(), []),
-    op_record("min", 1, all_dtypes, nonempty_shapes, jtu.rand_default(), []),
+    op_record("all", 1, all_dtypes, all_shapes, jtu.rand_some_zero, []),
+    op_record("any", 1, all_dtypes, all_shapes, jtu.rand_some_zero, []),
+    op_record("max", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("min", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
 ]
 
 JAX_ARGMINMAX_RECORDS = [
-    op_record("argmin", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal(), []),
-    op_record("argmax", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal(), []),
+    op_record("argmin", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
+    op_record("argmax", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
 ]
 
 JAX_OPERATOR_OVERLOADS = [
-    op_record("__add__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__sub__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__mul__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__eq__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__ne__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__lt__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__gt__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__ge__", 2, default_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__neg__", 1, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__pow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive(), []),
-    op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), [],
+    op_record("__add__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__sub__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__mul__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__eq__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__ne__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__lt__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__gt__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__ge__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__neg__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__pow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive, []),
+    op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
-    op_record("__floordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__floordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
     # TODO(mattjj): __invert__ fails on bool dtypes because ~True == -2
-    op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default(), []),
+    op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default, []),
     # TODO(mattjj): investigate these failures
-    # op_record("__or__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__and__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    # op_record("__or__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__and__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
     # TODO(mattjj): lshift, rshift
 ]
 
 JAX_RIGHT_OPERATOR_OVERLOADS = [
-    op_record("__radd__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__rsub__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__rmul__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    op_record("__rpow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive(), []),
-    op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), [],
+    op_record("__radd__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rsub__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rmul__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rpow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive, []),
+    op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
-    op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
-    # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default(), []),
-    # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool(), []),
-    # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
+    # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
 ]
 
 numpy_version = tuple(map(int, onp.version.version.split('.')))
 if numpy_version >= (1, 15):
   JAX_COMPOUND_OP_RECORDS += [
-      op_record("isclose", 2, all_dtypes, all_shapes, jtu.rand_small_positive(), []),
-      op_record("gcd", 2, int_dtypes, all_shapes, jtu.rand_default(), []),
-      op_record("lcm", 2, int_dtypes, all_shapes, jtu.rand_default(), []),
+      op_record("isclose", 2, all_dtypes, all_shapes, jtu.rand_small_positive, []),
+      op_record("gcd", 2, int_dtypes, all_shapes, jtu.rand_default, []),
+      op_record("lcm", 2, int_dtypes, all_shapes, jtu.rand_default, []),
   ]
   JAX_REDUCER_NO_DTYPE_RECORDS += [
-      op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default(), []),
+      op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
   ]
 
 if six.PY2:
   JAX_OPERATOR_OVERLOADS += [
-    op_record("__div__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__div__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
   ]
   JAX_RIGHT_OPERATOR_OVERLOADS += [
-    op_record("__rdiv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero(), []),
+    op_record("__rdiv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
   ]
 
 
@@ -354,7 +354,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(rec.test_name, shapes,
                                                       dtypes),
-         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes,
+         "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes,
          "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
          "check_dtypes": rec.check_dtypes, "op_tolerance": rec.tolerance}
         for shapes in filter(
@@ -363,8 +363,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
       for rec in itertools.chain(JAX_ONE_TO_ONE_OP_RECORDS,
                                  JAX_COMPOUND_OP_RECORDS)))
-  def testOp(self, onp_op, lnp_op, rng, shapes, dtypes, check_dtypes,
+  def testOp(self, onp_op, lnp_op, rng_factory, shapes, dtypes, check_dtypes,
              op_tolerance):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     scalar_arg = (jtu.PYTHON_SCALAR_SHAPE in shapes or
                   jtu.NUMPY_SCALAR_SHAPE in shapes or
@@ -382,14 +383,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(rec.test_name, shapes,
                                                       dtypes),
-         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes, "name": rec.name,
+         "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes, "name": rec.name,
          "op_tolerance": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
         for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
       for rec in JAX_OPERATOR_OVERLOADS))
-  def testOperatorOverload(self, name, rng, shapes, dtypes, op_tolerance):
+  def testOperatorOverload(self, name, rng_factory, shapes, dtypes, op_tolerance):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     fun = lambda *xs: getattr(operator, name.strip('_'))(*xs)
     tol = max(tolerance(dtype, op_tolerance) for dtype in dtypes)
@@ -405,17 +407,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(rec.test_name, shapes,
                                                       dtypes),
-         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes, "name": rec.name,
+         "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes, "name": rec.name,
          "op_tolerance": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
         for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
       for rec in JAX_RIGHT_OPERATOR_OVERLOADS))
-  def testRightOperatorOverload(self, name, rng, shapes, dtypes,
+  def testRightOperatorOverload(self, name, rng_factory, shapes, dtypes,
                                 op_tolerance):
     if shapes[1] is jtu.PYTHON_SCALAR_SHAPE:
       raise SkipTest()  # TODO(mattjj): clean up
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     fun = lambda fst, snd: getattr(snd, name)(fst)
     tol = max(tolerance(dtype, op_tolerance) for dtype in dtypes)
@@ -431,7 +434,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.test_name, shapes, dtypes),
-         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes,
+         "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes,
          "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name)}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
@@ -440,7 +443,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           _dtypes_are_compatible_for_bitwise_ops,
           CombosWithReplacement(rec.dtypes, rec.nargs)))
       for rec in JAX_BITWISE_OP_RECORDS))
-  def testBitwiseOp(self, onp_op, lnp_op, rng, shapes, dtypes):
+  def testBitwiseOp(self, onp_op, lnp_op, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     if not FLAGS.jax_enable_x64 and any(
         onp.iinfo(dtype).bits == 64 for dtype in dtypes):
       self.skipTest("x64 types are disabled by jax_enable_x64")
@@ -454,7 +458,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           rec.test_name.capitalize(),
           jtu.format_shape_dtype_string(shape, dtype), axis,
           "None" if out_dtype is None else onp.dtype(out_dtype).name, keepdims),
-       "rng": rec.rng, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
+       "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
        "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
        "axis": axis, "keepdims": keepdims}
       for rec in JAX_REDUCER_RECORDS
@@ -462,7 +466,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for out_dtype in [None] + rec.dtypes
       for axis in set(range(-len(shape), len(shape))) | set([None])
       for keepdims in [False, True]))
-  def testReducer(self, onp_op, lnp_op, rng, shape, dtype, out_dtype, axis, keepdims):
+  def testReducer(self, onp_op, lnp_op, rng_factory, shape, dtype, out_dtype, axis, keepdims):
+    rng = rng_factory()
     onp_fun = lambda x: onp_op(x, axis, dtype=out_dtype, keepdims=keepdims)
     lnp_fun = lambda x: lnp_op(x, axis, dtype=out_dtype, keepdims=keepdims)
     args_maker = lambda: [rng(shape, dtype)]
@@ -479,14 +484,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "{}_inshape={}_axis={}_keepdims={}".format(
           rec.test_name.capitalize(),
           jtu.format_shape_dtype_string(shape, dtype), axis, keepdims),
-       "rng": rec.rng, "shape": shape, "dtype": dtype,
+       "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype,
        "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
        "axis": axis, "keepdims": keepdims}
       for rec in JAX_REDUCER_NO_DTYPE_RECORDS
       for shape in rec.shapes for dtype in rec.dtypes
       for axis in set(range(-len(shape), len(shape))) | set([None])
       for keepdims in [False, True]))
-  def testReducerNoDtype(self, onp_op, lnp_op, rng, shape, dtype, axis, keepdims):
+  def testReducerNoDtype(self, onp_op, lnp_op, rng_factory, shape, dtype, axis, keepdims):
+    rng = rng_factory()
     onp_fun = lambda x: onp_op(x, axis, keepdims=keepdims)
     lnp_fun = lambda x: lnp_op(x, axis, keepdims=keepdims)
     args_maker = lambda: [rng(shape, dtype)]
@@ -511,13 +517,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "{}_inshape={}_axis={}".format(
           rec.test_name.capitalize(),
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng": rec.rng, "shape": shape, "dtype": dtype,
+       "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype,
        "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
        "axis": axis}
       for rec in JAX_ARGMINMAX_RECORDS
       for shape in rec.shapes for dtype in rec.dtypes
       for axis in range(-len(shape), len(shape))))
-  def testArgMinMax(self, onp_op, lnp_op, rng, shape, dtype, axis):
+  def testArgMinMax(self, onp_op, lnp_op, rng_factory, shape, dtype, axis):
+    rng = rng_factory()
     if dtype == onp.complex128 and jtu.device_under_test() == "gpu":
       raise unittest.SkipTest("complex128 reductions not supported on GPU")
 
@@ -538,8 +545,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axes),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes, "rng": rng}
-      for rng in [jtu.rand_default()]
+       "axes": axes, "rng_factory": rng_factory}
+      for rng_factory in [jtu.rand_default]
       for lhs_shape, rhs_shape, axes in [
           [(2,), (2,), (-1, -1, -1, None)], # scalar output
           [(2, 4), (2, 4), (-1, -1, -1, 0)], # 2D vectors
@@ -553,7 +560,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 5, 2), (4, 5, 2), (-1, -1, -1, None)] # same as before
       ]
       for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
-  def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng):
+  def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     axisa, axisb, axisc, axis = axes
     lnp_fun = lambda a, b: lnp.cross(a, b, axisa, axisb, axisc, axis)
@@ -572,8 +580,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng": rng}
-      for rng in [jtu.rand_default()]
+       "rng_factory": rng_factory}
+      for rng_factory in [jtu.rand_default]
       for name, lhs_shape, rhs_shape in [
           ("matrix-scalar", (3, 3), ()),
           ("scalar-matrix", (), (3, 3)),
@@ -586,7 +594,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("matrix-tensor", (5, 2), (3, 2, 4)),
           ("tensor-tensor", (2, 3, 4), (5, 4, 1))]
       for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
-  def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng):
+  def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     tol_spec = {onp.float16: 1e-2}
     tol = max(tolerance(lhs_dtype, tol_spec), tolerance(rhs_dtype, tol_spec))
@@ -602,8 +611,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng": rng}
-      for rng in [jtu.rand_default()]
+       "rng_factory": rng_factory}
+      for rng_factory in [jtu.rand_default]
       for name, lhs_shape, rhs_shape in [
           ("vector-vector", (3,), (3,)),
           ("matrix-vector", (3, 3), (3,)),
@@ -616,7 +625,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-tensor", (5, 3, 4), (5, 4, 1)),
           ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]
       for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
-  def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng):
+  def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     tol_spec = {onp.float16: 1e-2, onp.float32: 1e-3, onp.float64: 1e-12}
     tol = max(tolerance(lhs_dtype, tol_spec), tolerance(rhs_dtype, tol_spec))
@@ -632,8 +642,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axes),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes, "rng": rng}
-      for rng in [jtu.rand_default()]
+       "axes": axes, "rng_factory": rng_factory}
+      for rng_factory in [jtu.rand_default]
       for lhs_shape, rhs_shape, axes in [
           [(2, 3, 4), (5, 6, 7), 0],  # from issue #740
           [(2, 3, 4), (3, 4, 5, 6), 2],
@@ -642,7 +652,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(1, 2, 3, 4), (4, 5, 3, 6), [[2, 3], [2, 0]]],
       ]
       for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
-  def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng):
+  def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     lnp_fun = lambda a, b: lnp.tensordot(a, b, axes)
     onp_fun = lambda a, b: onp.tensordot(a, b, axes)
@@ -658,7 +669,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       # TODO(phawkins): support integer dtypes too.
       for lhs_dtype, rhs_dtype in CombosWithReplacement(inexact_dtypes, 2)
       for lhs_shape, rhs_shape in [
@@ -666,7 +677,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         if len(jtu._dims_of_shape(l)) == 0
         or len(jtu._dims_of_shape(r)) == 0
         or l[-1] == r[-1]]))
-  def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng):
+  def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     onp_fun = lambda lhs, rhs: onp.inner(lhs, rhs)
     lnp_fun = lambda lhs, rhs: lnp.inner(lhs, rhs)
@@ -681,13 +693,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_amin={}_amax={}".format(
           jtu.format_shape_dtype_string(shape, dtype), a_min, a_max),
        "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for shape in all_shapes for dtype in number_dtypes
       for a_min, a_max in [(-1, None), (None, 1), (-1, 1),
                            (-lnp.ones(1), None),
                            (None, lnp.ones(1)),
                            (-lnp.ones(1), lnp.ones(1))]))
-  def testClipStaticBounds(self, shape, dtype, a_min, a_max, rng):
+  def testClipStaticBounds(self, shape, dtype, a_min, a_max, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.clip(x, a_min=a_min, a_max=a_max)
     lnp_fun = lambda x: lnp.clip(x, a_min=a_min, a_max=a_max)
     args_maker = lambda: [rng(shape, dtype)]
@@ -699,10 +712,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_decimals={}".format(
           jtu.format_shape_dtype_string(shape, dtype), decimals),
        "shape": shape, "dtype": dtype, "decimals": decimals,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for shape in all_shapes for dtype in number_dtypes
       for decimals in [0, 1, -2]))
-  def testRoundStaticDecimals(self, shape, dtype, decimals, rng):
+  def testRoundStaticDecimals(self, shape, dtype, decimals, rng_factory):
+    rng = rng_factory()
     if lnp.issubdtype(dtype, onp.integer) and decimals < 0:
       self.skipTest("Integer rounding with decimals < 0 not implemented")
     onp_fun = lambda x: onp.round(x, decimals=decimals)
@@ -720,8 +734,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           constant_values_rank),
        "shape": shape, "dtype": dtype, "mode": mode,
        "pad_width_rank": pad_width_rank,
-       "constant_values_rank": constant_values_rank, "rng": jtu.rand_default(),
-       "irng": jtu.rand_int(3)}
+       "constant_values_rank": constant_values_rank,
+       "rng_factory": jtu.rand_default,
+       "irng_factory": partial(jtu.rand_int, 3)}
       for mode, constant_values_rank, shapes in [
         ('constant', 0, all_shapes),
         ('constant', 1, all_shapes),
@@ -733,7 +748,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for shape in shapes for dtype in all_dtypes
       for pad_width_rank in range(3)))
   def testPad(self, shape, dtype, mode, pad_width_rank, constant_values_rank,
-              rng, irng):
+              rng_factory, irng_factory):
+    rng = rng_factory()
+    irng = irng_factory()
     pad_width = irng([len(shape), 2][2 - pad_width_rank:], onp.int32)
     def onp_fun(x, kwargs):
       if pad_width.size == 0:
@@ -756,12 +773,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape=[{}]_reps={}".format(
           jtu.format_shape_dtype_string(shape, dtype), reps),
        "shape": shape, "dtype": dtype, "reps": reps,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for reps in [(), (2,), (3, 4), (2, 3, 4)]
       for dtype in default_dtypes
       for shape in all_shapes
       ))
-  def testTile(self, shape, dtype, reps, rng):
+  def testTile(self, shape, dtype, reps, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.tile(arg, reps)
     lnp_fun = lambda arg: lnp.tile(arg, reps)
 
@@ -775,12 +793,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis, ",".join(str(d) for d in base_shape),
           ",".join(onp.dtype(dtype).name for dtype in dtypes)),
        "axis": axis, "base_shape": base_shape, "dtypes": dtypes,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for num_arrs in [3]
       for dtypes in CombosWithReplacement(default_dtypes, num_arrs)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
-  def testConcatenate(self, axis, base_shape, dtypes, rng):
+  def testConcatenate(self, axis, base_shape, dtypes, rng_factory):
+    rng = rng_factory()
     wrapped_axis = axis % len(base_shape)
     shapes = [base_shape[:wrapped_axis] + (size,) + base_shape[wrapped_axis+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), dtypes)]
@@ -798,11 +817,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis, ",".join(str(d) for d in base_shape),
           ",".join(onp.dtype(dtype).name for dtype in dtypes)),
        "axis": axis, "base_shape": base_shape, "dtypes": dtypes,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for dtypes in CombosWithReplacement(default_dtypes, 2)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
-  def testAppend(self, axis, base_shape, dtypes, rng):
+  def testAppend(self, axis, base_shape, dtypes, rng_factory):
+    rng = rng_factory()
     wrapped_axis = axis % len(base_shape)
     shapes = [base_shape[:wrapped_axis] + (size,) + base_shape[wrapped_axis+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), dtypes)]
@@ -819,12 +839,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape=[{}]_axis={}_repeats={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, repeats),
        "axis": axis, "shape": shape, "dtype": dtype, "repeats": repeats,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for repeats in [0, 1, 2]
       for dtype in default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testRepeat(self, axis, shape, dtype, repeats, rng):
+  def testRepeat(self, axis, shape, dtype, repeats, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.repeat(arg, repeats=repeats, axis=axis)
     lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=axis)
 
@@ -867,14 +888,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), axis, out_dtype),
        "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
-       "rng": jtu.rand_default(), "lnp_op": getattr(lnp, op),
+       "rng_factory": jtu.rand_default, "lnp_op": getattr(lnp, op),
        "onp_op": getattr(onp, op)}
       for op in ["cumsum", "cumprod"]
       for dtype in default_dtypes
       for out_dtype in default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testCumSumProd(self, axis, shape, dtype, out_dtype, onp_op, lnp_op, rng):
+  def testCumSumProd(self, axis, shape, dtype, out_dtype, onp_op, lnp_op, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp_op(arg, axis=axis, dtype=out_dtype)
     lnp_fun = lambda arg: lnp_op(arg, axis=axis, dtype=out_dtype)
 
@@ -888,12 +910,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}_m={}_n={}_k={}".format(
           onp.dtype(dtype).name, m, n, k),
-       "m": m, "n": n, "k": k, "dtype": dtype, "rng": jtu.rand_default()}
+       "m": m, "n": n, "k": k, "dtype": dtype, "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for n in [0, 4]
       for m in [None, 0, 1, 3, 4]
       for k in list(range(-4, 4))))
-  def testTri(self, m, n, k, dtype, rng):
+  def testTri(self, m, n, k, dtype, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda: onp.tri(n, M=m, k=k, dtype=dtype)
     lnp_fun = lambda: lnp.tri(n, M=m, k=k, dtype=dtype)
     args_maker = lambda: []
@@ -904,12 +927,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_op={}_shape={}_k={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), k),
        "dtype": dtype, "shape": shape, "op": op, "k": k,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for op in ["tril", "triu"]
       for k in list(range(-3, 3))))
-  def testTriLU(self, dtype, shape, op, k, rng):
+  def testTriLU(self, dtype, shape, op, k, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: getattr(onp, op)(arg, k=k)
     lnp_fun = lambda arg: getattr(lnp, op)(arg, k=k)
     args_maker = lambda: [rng(shape, dtype)]
@@ -919,11 +943,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_k={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "k": k, "rng": jtu.rand_default()}
+       "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) in (1, 2)]
       for k in list(range(-4, 4))))
-  def testDiag(self, shape, dtype, k, rng):
+  def testDiag(self, shape, dtype, k, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.diag(arg, k)
     lnp_fun = lambda arg: lnp.diag(arg, k)
     args_maker = lambda: [rng(shape, dtype)]
@@ -934,14 +959,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_offset={}_axis1={}_axis2={}".format(
           jtu.format_shape_dtype_string(shape, dtype), offset, axis1, axis2),
        "dtype": dtype, "shape": shape, "offset": offset, "axis1": axis1,
-       "axis2": axis2, "rng": jtu.rand_default()}
+       "axis2": axis2, "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in [a for a in range(-len(shape), len(shape))
                     if a % len(shape) != axis1 % len(shape)]
       for offset in list(range(-4, 4))))
-  def testDiagonal(self, shape, dtype, offset, axis1, axis2, rng):
+  def testDiagonal(self, shape, dtype, offset, axis1, axis2, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.diagonal(arg, offset, axis1, axis2)
     lnp_fun = lambda arg: lnp.diagonal(arg, offset, axis1, axis2)
     args_maker = lambda: [rng(shape, dtype)]
@@ -965,7 +991,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           out_dtype, offset, axis1, axis2),
        "dtype": dtype, "out_dtype": out_dtype, "shape": shape, "offset": offset,
-       "axis1": axis1, "axis2": axis2, "rng": jtu.rand_default()}
+       "axis1": axis1, "axis2": axis2, "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for out_dtype in [None] + number_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
@@ -973,7 +999,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for axis2 in range(-len(shape), len(shape))
       if (axis1 % len(shape)) != (axis2 % len(shape))
       for offset in list(range(-4, 4))))
-  def testTrace(self, shape, dtype, out_dtype, offset, axis1, axis2, rng):
+  def testTrace(self, shape, dtype, out_dtype, offset, axis1, axis2, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.trace(arg, offset, axis1, axis2, out_dtype)
     lnp_fun = lambda arg: lnp.trace(arg, offset, axis1, axis2, out_dtype)
     args_maker = lambda: [rng(shape, dtype)]
@@ -983,7 +1010,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), axis),
-       "shape": shape, "axis": axis, "dtypes": dtypes, "rng": rng}
+       "shape": shape, "axis": axis, "dtypes": dtypes, "rng_factory": rng_factory}
       for dtypes in [
         [onp.float32],
         [onp.float32, onp.float32],
@@ -993,8 +1020,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       ]
       for shape in [(), (2,), (3, 4), (1, 100)]
       for axis in range(-len(shape), len(shape) + 1)
-      for rng in [jtu.rand_default()]))
-  def testStack(self, shape, axis, dtypes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testStack(self, shape, axis, dtypes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [[rng(shape, dtype) for dtype in dtypes]]
     onp_fun = partial(onp.stack, axis=axis)
     lnp_fun = partial(lnp.stack, axis=axis)
@@ -1004,7 +1032,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_{}".format(
           op, jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes)),
-       "shape": shape, "op": op, "dtypes": dtypes, "rng": rng}
+       "shape": shape, "op": op, "dtypes": dtypes, "rng_factory": rng_factory}
       for op in ["hstack", "vstack", "dstack"]
       for dtypes in [
         [onp.float32],
@@ -1014,8 +1042,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         [onp.float32, onp.int32, onp.float64],
       ]
       for shape in [(), (2,), (3, 4), (1, 100), (2, 3, 4)]
-      for rng in [jtu.rand_default()]))
-  def testHVDStack(self, shape, op, dtypes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testHVDStack(self, shape, op, dtypes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [[rng(shape, dtype) for dtype in dtypes]]
     onp_fun = getattr(onp, op)
     lnp_fun = getattr(lnp, op)
@@ -1026,11 +1055,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, fill_value_dtype),
           onp.dtype(out_dtype).name if out_dtype else "None"),
        "shape": shape, "fill_value_dtype": fill_value_dtype,
-       "out_dtype": out_dtype, "rng": jtu.rand_default()}
+       "out_dtype": out_dtype, "rng_factory": jtu.rand_default}
       for shape in array_shapes
       for fill_value_dtype in default_dtypes
       for out_dtype in [None] + default_dtypes))
-  def testFull(self, shape, fill_value_dtype, out_dtype, rng):
+  def testFull(self, shape, fill_value_dtype, out_dtype, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda fill_value: onp.full(shape, fill_value, dtype=out_dtype)
     lnp_fun = lambda fill_value: lnp.full(shape, fill_value, dtype=out_dtype)
     args_maker = lambda: [rng((), fill_value_dtype)]
@@ -1044,12 +1074,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           onp.dtype(out_dtype).name),
        "shape": shape, "in_dtype": in_dtype,
        "fill_value_dtype": fill_value_dtype, "out_dtype": out_dtype,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for shape in array_shapes
       for in_dtype in default_dtypes
       for fill_value_dtype in default_dtypes
       for out_dtype in default_dtypes))
-  def testFullLike(self, shape, in_dtype, fill_value_dtype, out_dtype, rng):
+  def testFullLike(self, shape, in_dtype, fill_value_dtype, out_dtype, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x, fill_value: onp.full_like(x, fill_value, dtype=out_dtype)
     lnp_fun = lambda x, fill_value: lnp.full_like(x, fill_value, dtype=out_dtype)
     args_maker = lambda: [rng(shape, in_dtype), rng((), fill_value_dtype)]
@@ -1060,12 +1091,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}_{}sections".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
        "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype, "rng": jtu.rand_default()}
+       "dtype": dtype, "rng_factory": jtu.rand_default}
       for shape, axis, num_sections in [
           ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
       for dtype in default_dtypes))
-  def testSplitStaticInt(self, shape, num_sections, axis, dtype, rng):
+  def testSplitStaticInt(self, shape, num_sections, axis, dtype, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.split(x, num_sections, axis=axis)
     lnp_fun = lambda x: lnp.split(x, num_sections, axis=axis)
     args_maker = lambda: [rng(shape, dtype)]
@@ -1076,12 +1108,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}_{}sections".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
        "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype, "rng": jtu.rand_default()}
+       "dtype": dtype, "rng_factory": jtu.rand_default}
       for shape, axis, num_sections in [
           ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]
       for dtype in default_dtypes))
-  def testHVDSplit(self, shape, num_sections, axis, dtype, rng):
+  def testHVDSplit(self, shape, num_sections, axis, dtype, rng_factory):
+    rng = rng_factory()
     def fn(module, axis):
       if axis == 0:
         return module.vsplit
@@ -1103,7 +1136,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype),
           order),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "order": order, "rng": jtu.rand_default()}
+       "order": order, "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for order in ["C", "F"]
       for arg_shape, out_shape in [
@@ -1116,7 +1149,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
       ]))
-  def testReshape(self, arg_shape, out_shape, dtype, order, rng):
+  def testReshape(self, arg_shape, out_shape, dtype, order, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.reshape(x, out_shape, order=order)
     lnp_fun = lambda x: lnp.reshape(x, out_shape, order=order)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -1128,14 +1162,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for dtype in default_dtypes
       for arg_shape, out_shape in [
           ((7, 0), (0, 42, 101)),
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
       ]))
-  def testReshapeMethod(self, arg_shape, out_shape, dtype, rng):
+  def testReshapeMethod(self, arg_shape, out_shape, dtype, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.reshape(x, out_shape)
     lnp_fun = lambda x: x.reshape(*out_shape)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -1146,11 +1181,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_expanddim={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), dim),
        "arg_shape": arg_shape, "dtype": dtype, "dim": dim,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for arg_shape in [(), (3,), (3, 4)]
       for dtype in default_dtypes
       for dim in range(-len(arg_shape)+1, len(arg_shape))))
-  def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng):
+  def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.expand_dims(x, dim)
     lnp_fun = lambda x: lnp.expand_dims(x, dim)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -1161,12 +1197,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_axes=({},{})".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), ax1, ax2),
        "arg_shape": arg_shape, "dtype": dtype, "ax1": ax1, "ax2": ax2,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for arg_shape, ax1, ax2 in [
           ((3, 4), 0, 1), ((3, 4), 1, 0), ((3, 4, 5), 1, 2),
           ((3, 4, 5), -1, -2), ((3, 4, 5), 0, 1)]
       for dtype in default_dtypes))
-  def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2, rng):
+  def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.swapaxes(x, ax1, ax2)
     lnp_fun = lambda x: lnp.swapaxes(x, ax1, ax2)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -1177,14 +1214,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_axis={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), ax),
        "arg_shape": arg_shape, "dtype": dtype, "ax": ax,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for arg_shape, ax in [
           ((3, 1), None),
           ((3, 1), 1),
           ((1, 3, 1), (0, 2)),
           ((1, 4, 1), (0,))]
       for dtype in default_dtypes))
-  def testSqueeze(self, arg_shape, dtype, ax, rng):
+  def testSqueeze(self, arg_shape, dtype, ax, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda x: onp.squeeze(x, ax)
     lnp_fun = lambda x: lnp.squeeze(x, ax)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -1197,7 +1235,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis,
           (None if weights_shape is None else jtu.format_shape_dtype_string(weights_shape, dtype)),
           returned),
-       "rng": jtu.rand_default(), "shape": shape, "dtype": dtype, "axis": axis,
+       "rng_factory": jtu.rand_default, "shape": shape, "dtype": dtype, "axis": axis,
        "weights_shape": weights_shape, "returned": returned}
       for shape in nonempty_shapes
       for dtype in number_dtypes
@@ -1207,7 +1245,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for weights_shape in ([None, shape] if axis is None
                             else [None, (shape[axis],), shape])
       for returned in [False, True]))
-  def testAverage(self, shape, dtype, axis, weights_shape, returned, rng):
+  def testAverage(self, shape, dtype, axis, weights_shape, returned, rng_factory):
+    rng = rng_factory()
     if weights_shape is None:
       onp_fun = lambda x: onp.average(x, axis, returned=returned)
       lnp_fun = lambda x: lnp.average(x, axis, returned=returned)
@@ -1383,12 +1422,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng": rng, "shape": shape, "dtype": dtype, "axis": axis}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
       for shape in [(3,), (2, 3)]
       for dtype in default_dtypes
       for axis in range(-len(shape), len(shape))  # Test negative axes
-      for rng in [jtu.rand_default()]))
-  def testFlip(self, shape, dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testFlip(self, shape, dtype, axis, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     lnp_op = lambda x: lnp.flip(x, axis)
     onp_op = lambda x: onp.flip(x, axis)
@@ -1398,11 +1438,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
-       "rng": rng, "shape": shape, "dtype": dtype}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
       for shape in [(3,), (2, 3), (3, 2, 4)]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testFlipud(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testFlipud(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     lnp_op = lambda x: lnp.flipud(x)
     onp_op = lambda x: onp.flipud(x)
@@ -1413,11 +1454,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
-       "rng": rng, "shape": shape, "dtype": dtype}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
       for shape in [(3, 2), (2, 3), (3, 2, 4)]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testFliplr(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testFliplr(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     lnp_op = lambda x: lnp.fliplr(x)
     onp_op = lambda x: onp.fliplr(x)
@@ -1428,7 +1470,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_k={}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k, axes),
-       "rng": rng, "shape": shape, "dtype": dtype, "k": k, "axes": axes}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "k": k, "axes": axes}
       for shape, axes in [
           [(2, 3), (0, 1)],
           [(2, 3), (1, 0)],
@@ -1437,8 +1479,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       ]
       for k in range(-3, 4)
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testRot90(self, shape, dtype, k, axes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testRot90(self, shape, dtype, k, axes, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     lnp_op = lambda x: lnp.rot90(x, k, axes)
     onp_op = lambda x: onp.rot90(x, k, axes)
@@ -1525,7 +1568,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_shifts={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           shifts, axis),
-       "rng": rng, "shape": shape, "dtype": dtype, "shifts": shifts,
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "shifts": shifts,
        "axis": axis}
       for dtype in all_dtypes
       for shape in [(3, 4), (3, 4, 5), (7, 4, 0)]
@@ -1536,8 +1579,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ((-2,), (-2,)),
         ((1, 2), (0, -1))
       ]
-      for rng in [jtu.rand_default()]))
-  def testRoll(self, shape, dtype, shifts, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testRoll(self, shape, dtype, shifts, axis, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), onp.array(shifts)]
     lnp_op = partial(lnp.roll, axis=axis)
     onp_op = partial(onp.roll, axis=axis)
@@ -1549,24 +1593,26 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           jtu.format_shape_dtype_string(index_shape, index_dtype),
           axis, mode),
-       "rng": rng, "rng_indices": rng_indices, "shape": shape,
-       "index_shape": index_shape, "dtype": dtype, "index_dtype": index_dtype,
-       "axis": axis, "mode": mode}
+       "rng_factory": rng_factory, "rng_indices_factory": rng_indices_factory,
+       "shape": shape, "index_shape": index_shape, "dtype": dtype,
+       "index_dtype": index_dtype, "axis": axis, "mode": mode}
       for shape in [(3,), (3, 4), (3, 4, 5)]
       for index_shape in scalar_shapes + [(3,), (2, 1, 3)]
       for axis in itertools.chain(range(-len(shape), len(shape)), [None])
       for dtype in all_dtypes
       for index_dtype in int_dtypes
       for mode in ['wrap', 'clip']
-      for rng in [jtu.rand_default()]
-      for rng_indices in [jtu.rand_int(-5, 5)]))
-  def testTake(self, shape, dtype, index_shape, index_dtype, axis, mode, rng,
-               rng_indices):
+      for rng_factory in [jtu.rand_default]
+      for rng_indices_factory in [partial(jtu.rand_int, -5, 5)]))
+  def testTake(self, shape, dtype, index_shape, index_dtype, axis, mode,
+               rng_factory, rng_indices_factory):
     def args_maker():
       x = rng(shape, dtype)
       i = rng_indices(index_shape, index_dtype)
       return x, i
 
+    rng = rng_factory()
+    rng_indices = rng_indices_factory()
     lnp_op = lambda x, i: lnp.take(x, i, axis=axis, mode=mode)
     onp_op = lambda x, i: onp.take(x, i, axis=axis, mode=mode)
     self._CheckAgainstNumpy(lnp_op, onp_op, args_maker, check_dtypes=True)
@@ -1575,7 +1621,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_ishape={}_axis={}".format(
           jtu.format_shape_dtype_string(x_shape, dtype), i_shape, axis),
-       "rng": rng, "x_shape": x_shape, "i_shape": i_shape, "dtype": dtype,
+       "rng_factory": rng_factory, "x_shape": x_shape, "i_shape": i_shape, "dtype": dtype,
        "axis": axis}
       for x_shape, i_shape in filter(
         _shapes_are_equal_length,
@@ -1583,8 +1629,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                CombosWithReplacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1], [None])
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testTakeAlongAxis(self, x_shape, i_shape, dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testTakeAlongAxis(self, x_shape, i_shape, dtype, axis, rng_factory):
+    rng = rng_factory()
     i_shape = onp.array(i_shape)
     if axis is None:
       i_shape = [onp.prod(i_shape, dtype=onp.int64)]
@@ -1610,12 +1657,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string([shape], dtype),
           n, increasing),
        "dtype": dtype, "shape": shape, "n": n, "increasing": increasing,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for dtype in inexact_dtypes
       for shape in [0, 5]
       for n in [2, 4]
       for increasing in [False, True]))
-  def testVander(self, shape, dtype, n, increasing, rng):
+  def testVander(self, shape, dtype, n, increasing, rng_factory):
+    rng = rng_factory()
     onp_fun = lambda arg: onp.vander(arg, N=n, increasing=increasing)
     lnp_fun = lambda arg: lnp.vander(arg, N=n, increasing=increasing)
     args_maker = lambda: [rng([shape], dtype)]
@@ -1628,10 +1676,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix("nan_to_num", [shape],
                                                       [dtype]),
-         "rng": jtu.rand_some_inf_and_nan(), "shape": shape, "dtype": dtype}
+         "rng_factory": jtu.rand_some_inf_and_nan, "shape": shape,
+         "dtype": dtype}
         for shape in all_shapes
         for dtype in inexact_dtypes))
-  def testNanToNum(self, rng, shape, dtype):
+  def testNanToNum(self, rng_factory, shape, dtype):
+    rng = rng_factory()
     dtype = onp.dtype(xla_bridge.canonicalize_dtype(dtype)).type
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(onp.nan_to_num, lnp.nan_to_num, args_maker,
@@ -1640,14 +1690,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix("ix_", shapes, dtypes),
-         "rng": jtu.rand_default(), "shapes": shapes, "dtypes": dtypes}
+         "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
         for shapes, dtypes in (
           ((), ()),
           (((7,),), (onp.int32,)),
           (((3,), (4,)), (onp.int32, onp.int32)),
           (((3,), (1,), (4,)), (onp.int32, onp.int32, onp.int32)),
         )))
-  def testIx_(self, rng, shapes, dtypes):
+  def testIx_(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)
                           for shape, dtype in zip(shapes, dtypes)]
     self._CheckAgainstNumpy(onp.ix_, lnp.ix_, args_maker,
@@ -1698,13 +1749,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix("select", shapes,
                                                       (onp.bool_,) * n + dtypes),
-         "rng": jtu.rand_default(), "shapes": shapes, "dtypes": dtypes}
+         "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
         for n in range(0, 3)
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(all_shapes, 2 * n + 1))
         for dtypes in CombosWithReplacement(all_dtypes, n + 1)))
-  def test(self, rng, shapes, dtypes):
+  def test(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     n = len(dtypes) - 1
     def args_maker():
       condlist = [rng(shape, onp.bool_) for shape in shapes[:n]]
@@ -1898,15 +1950,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "_shape={}_dtype={}_out_dtype={}_axis={}_ddof={}_keepdims={}"
          .format(shape, dtype, out_dtype, axis, ddof, keepdims),
          "shape": shape, "dtype": dtype, "out_dtype": out_dtype, "axis": axis,
-         "ddof": ddof, "keepdims": keepdims, "rng": rng}
+         "ddof": ddof, "keepdims": keepdims, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5)]
         for dtype in all_dtypes
         for out_dtype in number_dtypes
         for axis in [None, 0, -1]
         for ddof in [0, 1, 2]
         for keepdims in [False, True]
-        for rng in [jtu.rand_default()]))
-  def testVar(self, shape, dtype, out_dtype, axis, ddof, keepdims, rng):
+        for rng_factory in [jtu.rand_default]))
+  def testVar(self, shape, dtype, out_dtype, axis, ddof, keepdims, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     onp_fun = partial(onp.var, dtype=out_dtype, axis=axis, ddof=ddof, keepdims=keepdims)
     lnp_fun = partial(lnp.var, dtype=out_dtype, axis=axis, ddof=ddof, keepdims=keepdims)
@@ -1921,15 +1974,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         {"testcase_name": "_shape={}_dtype={}_rowvar={}_ddof={}_bias={}".format(
             shape, dtype, rowvar, ddof, bias),
          "shape": shape, "dtype": dtype, "rowvar": rowvar, "ddof": ddof,
-         "bias": bias, "rng": rng}
+         "bias": bias, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5), (3, 10)]
         for dtype in all_dtypes
         for rowvar in [True, False]
         for bias in [True, False]
         for ddof in [None, 2, 3]
-        for rng in [jtu.rand_default()]))
+        for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("gpu")  # TODO(b/138003641): test fails on GPU.
-  def testCov(self, shape, dtype, rowvar, ddof, bias, rng):
+  def testCov(self, shape, dtype, rowvar, ddof, bias, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     onp_fun = partial(onp.cov, rowvar=rowvar, ddof=ddof, bias=bias)
     lnp_fun = partial(lnp.cov, rowvar=rowvar, ddof=ddof, bias=bias)
@@ -1944,14 +1998,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         {"testcase_name": "_shape={}_dtype={}_rowvar={}_ddof={}_bias={}".format(
             shape, dtype, rowvar, ddof, bias),
          "shape": shape, "dtype": dtype, "rowvar": rowvar, "ddof": ddof,
-         "bias": bias, "rng": rng}
+         "bias": bias, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5), (3, 10)]
         for dtype in number_dtypes
         for rowvar in [True, False]
         for bias in [True, False]
         for ddof in [None, 2, 3]
-        for rng in [jtu.rand_default()]))
-  def testCorrCoef(self, shape, dtype, rowvar, ddof, bias, rng):
+        for rng_factory in [jtu.rand_default]))
+  def testCorrCoef(self, shape, dtype, rowvar, ddof, bias, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     mat = onp.asarray([rng(shape, dtype)])
     onp_fun = partial(onp.corrcoef, rowvar=rowvar, ddof=ddof, bias=bias)
@@ -1965,13 +2020,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         {"testcase_name": "_shapes={}_dtype={}_indexing={}_sparse={}".format(
             shapes, dtype, indexing, sparse),
          "shapes": shapes, "dtype": dtype, "indexing": indexing,
-         "sparse": sparse, "rng": rng}
+         "sparse": sparse, "rng_factory": rng_factory}
         for shapes in [(), (5,), (5, 3)]
         for dtype in number_dtypes
         for indexing in ['xy', 'ij']
         for sparse in [True, False]
-        for rng in [jtu.rand_default()]))
-  def testMeshGrid(self, shapes, dtype, indexing, sparse, rng):
+        for rng_factory in [jtu.rand_default]))
+  def testMeshGrid(self, shapes, dtype, indexing, sparse, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [(x,) for x in shapes],
                                     [dtype] * len(shapes))
     onp_fun = partial(onp.meshgrid, indexing=indexing, sparse=sparse)
@@ -2044,15 +2100,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       {"testcase_name": "_from={}_to={}".format(from_shape, to_shape),
-       "rng": rng, "from_shape": from_shape, "to_shape": to_shape}
+       "rng_factory": rng_factory, "from_shape": from_shape, "to_shape": to_shape}
       for from_shape, to_shape in [
           [(1, 3), (4, 3)],
           [(3,), (2, 1, 3)],
           [(3,), (3, 3)],
           [(1,), (3,)],
       ]
-      for rng in [jtu.rand_default()])
-  def testBroadcastTo(self, from_shape, to_shape, rng):
+      for rng_factory in [jtu.rand_default])
+  def testBroadcastTo(self, from_shape, to_shape, rng_factory):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, [from_shape], [onp.float32])
     onp_op = lambda x: onp.broadcast_to(x, to_shape)
     lnp_op = lambda x: lnp.broadcast_to(x, to_shape)
@@ -2072,16 +2129,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 # as needed for e.g. particular compound ops of interest.
 
 GradTestSpec = collections.namedtuple(
-    "GradTestSpec", ["op", "nargs", "order", "rng", "dtypes", "name", "tol"])
-def grad_test_spec(op, nargs, order, rng, dtypes, name=None, tol=None):
-  return GradTestSpec(op, nargs, order, rng, dtypes, name or op.__name__, tol)
+    "GradTestSpec",
+    ["op", "nargs", "order", "rng_factory", "dtypes", "name", "tol"])
+def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
+  return GradTestSpec(
+      op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
 GRAD_TEST_RECORDS = [
-    grad_test_spec(lnp.arcsinh, nargs=1, order=2, rng=jtu.rand_positive(),
+    grad_test_spec(lnp.arcsinh, nargs=1, order=2,
+                   rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64], tol=1e-4),
-    grad_test_spec(lnp.arccosh, nargs=1, order=2, rng=jtu.rand_positive(),
+    grad_test_spec(lnp.arccosh, nargs=1, order=2,
+                   rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64], tol=1e-4),
-    grad_test_spec(lnp.arctanh, nargs=1, order=2, rng=jtu.rand_uniform(-0.9, 0.9),
+    grad_test_spec(lnp.arctanh, nargs=1, order=2,
+                   rng_factory=partial(jtu.rand_uniform, -0.9, 0.9),
                    dtypes=[onp.float64, onp.complex64], tol=1e-4),
 ]
 
@@ -2102,12 +2164,13 @@ class NumpyGradTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.name, shapes, itertools.repeat(dtype)),
-         "op": rec.op, "rng": rec.rng, "shapes": shapes, "dtype": dtype,
+         "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
          "order": rec.order, "tol": rec.tol}
         for shapes in CombosWithReplacement(nonempty_shapes, rec.nargs)
         for dtype in rec.dtypes)
       for rec in GRAD_TEST_RECORDS))
-  def testOpGrad(self, op, rng, shapes, dtype, order, tol):
+  def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):
+    rng = rng_factory()
     tol = 1e-1 if num_float_bits(dtype) == 32 else tol
     args = tuple(rng(shape, dtype) for shape in shapes)
     check_grads(op, args, order, ["fwd", "rev"], tol, tol)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import collections
 import functools
+from functools import partial
 import itertools
 import unittest
 
@@ -47,29 +48,31 @@ default_dtypes = float_dtypes + int_dtypes
 numeric_dtypes = float_dtypes + complex_dtypes + int_dtypes
 
 
-OpRecord = collections.namedtuple("OpRecord", ["name", "nargs", "dtypes", "rng",
-                                               "test_autodiff", "test_name"])
+OpRecord = collections.namedtuple(
+    "OpRecord",
+    ["name", "nargs", "dtypes", "rng_factory", "test_autodiff", "test_name"])
 
 
-def op_record(name, nargs, dtypes, rng, test_grad, test_name=None):
+def op_record(name, nargs, dtypes, rng_factory, test_grad, test_name=None):
   test_name = test_name or name
-  return OpRecord(name, nargs, dtypes, rng, test_grad, test_name)
+  return OpRecord(name, nargs, dtypes, rng_factory, test_grad, test_name)
 
 JAX_SPECIAL_FUNCTION_RECORDS = [
     # TODO: digamma has no JVP implemented.
-    op_record("digamma", 1, float_dtypes, jtu.rand_positive(), False),
-    op_record("erf", 1, float_dtypes, jtu.rand_small_positive(), True),
-    op_record("erfc", 1, float_dtypes, jtu.rand_small_positive(), True),
-    op_record("erfinv", 1, float_dtypes, jtu.rand_small_positive(), True),
-    op_record("expit", 1, float_dtypes, jtu.rand_small_positive(), True),
+    op_record("digamma", 1, float_dtypes, jtu.rand_positive, False),
+    op_record("erf", 1, float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfc", 1, float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfinv", 1, float_dtypes, jtu.rand_small_positive, True),
+    op_record("expit", 1, float_dtypes, jtu.rand_small_positive, True),
     # TODO: gammaln has slightly high error.
-    op_record("gammaln", 1, float_dtypes, jtu.rand_positive(), False),
-    op_record("logit", 1, float_dtypes, jtu.rand_small_positive(), False),
-    op_record("log_ndtr", 1, float_dtypes, jtu.rand_default(), True),
-    op_record("ndtri", 1, float_dtypes, jtu.rand_uniform(0.05, 0.95), True),
-    op_record("ndtr", 1, float_dtypes, jtu.rand_default(), True),
+    op_record("gammaln", 1, float_dtypes, jtu.rand_positive, False),
+    op_record("logit", 1, float_dtypes, jtu.rand_small_positive, False),
+    op_record("log_ndtr", 1, float_dtypes, jtu.rand_default, True),
+    op_record("ndtri", 1, float_dtypes, partial(jtu.rand_uniform, 0.05, 0.95),
+              True),
+    op_record("ndtr", 1, float_dtypes, jtu.rand_default, True),
     # TODO(phawkins): gradient of entr yields NaNs.
-    op_record("entr", 1, float_dtypes, jtu.rand_default(), False),
+    op_record("entr", 1, float_dtypes, jtu.rand_default, False),
 ]
 
 CombosWithReplacement = itertools.combinations_with_replacement
@@ -85,15 +88,17 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_axis={}_keepdims={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, keepdims),
        # TODO(b/133842870): re-enable when exp(nan) returns NaN on CPU.
-       "rng": jtu.rand_some_inf_and_nan() if jtu.device_under_test() != "cpu"
-              else jtu.rand_default(),
+       "rng_factory": jtu.rand_some_inf_and_nan
+                      if jtu.device_under_test() != "cpu"
+                      else jtu.rand_default,
        "shape": shape, "dtype": dtype,
        "axis": axis, "keepdims": keepdims}
       for shape in all_shapes for dtype in float_dtypes
       for axis in range(-len(shape), len(shape))
       for keepdims in [False, True]))
   @jtu.skip_on_flag("jax_xla_backend", "xrt")
-  def testLogSumExp(self, rng, shape, dtype, axis, keepdims):
+  def testLogSumExp(self, rng_factory, shape, dtype, axis, keepdims):
+    rng = rng_factory()
     # TODO(mattjj): test autodiff
     def scipy_fun(array_to_reduce):
       return osp_special.logsumexp(array_to_reduce, axis, keepdims=keepdims)
@@ -109,15 +114,16 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.test_name, shapes, dtypes),
-         "rng": rec.rng, "shapes": shapes, "dtypes": dtypes,
+         "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes,
          "test_autodiff": rec.test_autodiff,
          "scipy_op": getattr(osp_special, rec.name),
          "lax_op": getattr(lsp_special, rec.name)}
         for shapes in CombosWithReplacement(all_shapes, rec.nargs)
         for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
       for rec in JAX_SPECIAL_FUNCTION_RECORDS))
-  def testScipySpecialFun(self, scipy_op, lax_op, rng, shapes, dtypes,
+  def testScipySpecialFun(self, scipy_op, lax_op, rng_factory, shapes, dtypes,
                           test_autodiff):
+    rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     args = args_maker()
     self.assertAllClose(scipy_op(*args), lax_op(*args), atol=1e-3, rtol=1e-3,
@@ -130,17 +136,19 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_d={}".format(
           jtu.format_shape_dtype_string(shape, dtype), d),
-       "rng": jtu.rand_positive(), "shape": shape, "dtype": dtype, "d": d}
+       "rng_factory": jtu.rand_positive, "shape": shape, "dtype": dtype,
+       "d": d}
       for shape in all_shapes
       for dtype in float_dtypes
       for d in [1, 2, 5]))
-  def testMultigammaln(self, rng, shape, dtype, d):
+  def testMultigammaln(self, rng_factory, shape, dtype, d):
     def scipy_fun(a):
       return osp_special.multigammaln(a, d)
 
     def lax_fun(a):
       return lsp_special.multigammaln(a, d)
 
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype) + (d - 1) / 2.]
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -86,89 +86,89 @@ def tolerance(dtype, tol=None):
   return tol.get(dtype, default_tolerance[dtype])
 
 
-OpRecord = collections.namedtuple("OpRecord",
-                                  ["op", "nargs", "dtypes", "rng", "tol"])
+OpRecord = collections.namedtuple(
+    "OpRecord", ["op", "nargs", "dtypes", "rng_factory", "tol"])
 
-def op_record(op, nargs, dtypes, rng, tol=None):
-  return OpRecord(op, nargs, dtypes, rng, tol)
+def op_record(op, nargs, dtypes, rng_factory, tol=None):
+  return OpRecord(op, nargs, dtypes, rng_factory, tol)
 
 LAX_OPS = [
-    op_record("neg", 1, default_dtypes + complex_dtypes, jtu.rand_small()),
-    op_record("sign", 1, default_dtypes, jtu.rand_small()),
-    op_record("floor", 1, float_dtypes, jtu.rand_small()),
-    op_record("ceil", 1, float_dtypes, jtu.rand_small()),
-    op_record("round", 1, float_dtypes, jtu.rand_default()),
+    op_record("neg", 1, default_dtypes + complex_dtypes, jtu.rand_small),
+    op_record("sign", 1, default_dtypes, jtu.rand_small),
+    op_record("floor", 1, float_dtypes, jtu.rand_small),
+    op_record("ceil", 1, float_dtypes, jtu.rand_small),
+    op_record("round", 1, float_dtypes, jtu.rand_default),
 
-    op_record("is_finite", 1, float_dtypes, jtu.rand_small()),
+    op_record("is_finite", 1, float_dtypes, jtu.rand_small),
 
-    op_record("exp", 1, float_dtypes + complex_dtypes, jtu.rand_small()),
+    op_record("exp", 1, float_dtypes + complex_dtypes, jtu.rand_small),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
-    op_record("expm1", 1, float_dtypes + complex_dtypes, jtu.rand_small(),
+    op_record("expm1", 1, float_dtypes + complex_dtypes, jtu.rand_small,
               {onp.float64: 1e-8}),
-    op_record("log", 1, float_dtypes + complex_dtypes, jtu.rand_positive()),
-    op_record("log1p", 1, float_dtypes + complex_dtypes, jtu.rand_positive()),
+    op_record("log", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("log1p", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
-    op_record("tanh", 1, float_dtypes + complex_dtypes, jtu.rand_small(),
+    op_record("tanh", 1, float_dtypes + complex_dtypes, jtu.rand_small,
               {onp.float64: 1e-9, onp.complex128: 1e-7}),
-    op_record("sin", 1, float_dtypes + complex_dtypes, jtu.rand_default()),
-    op_record("cos", 1, float_dtypes + complex_dtypes, jtu.rand_default()),
-    op_record("atan2", 2, float_dtypes, jtu.rand_default()),
+    op_record("sin", 1, float_dtypes + complex_dtypes, jtu.rand_default),
+    op_record("cos", 1, float_dtypes + complex_dtypes, jtu.rand_default),
+    op_record("atan2", 2, float_dtypes, jtu.rand_default),
 
-    op_record("sqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive()),
-    op_record("rsqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive()),
-    op_record("square", 1, float_dtypes + complex_dtypes, jtu.rand_default()),
-    op_record("reciprocal", 1, float_dtypes + complex_dtypes, jtu.rand_positive()),
-    op_record("tan", 1, float_dtypes, jtu.rand_default(), {onp.float32: 1e-5}),
-    op_record("asin", 1, float_dtypes, jtu.rand_small()),
-    op_record("acos", 1, float_dtypes, jtu.rand_small()),
-    op_record("atan", 1, float_dtypes, jtu.rand_small()),
-    op_record("sinh", 1, float_dtypes + complex_dtypes, jtu.rand_default()),
-    op_record("cosh", 1, float_dtypes + complex_dtypes, jtu.rand_default()),
+    op_record("sqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("rsqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("square", 1, float_dtypes + complex_dtypes, jtu.rand_default),
+    op_record("reciprocal", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("tan", 1, float_dtypes, jtu.rand_default, {onp.float32: 1e-5}),
+    op_record("asin", 1, float_dtypes, jtu.rand_small),
+    op_record("acos", 1, float_dtypes, jtu.rand_small),
+    op_record("atan", 1, float_dtypes, jtu.rand_small),
+    op_record("sinh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
+    op_record("cosh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
 
-    op_record("lgamma", 1, float_dtypes, jtu.rand_positive(),
+    op_record("lgamma", 1, float_dtypes, jtu.rand_positive,
               {onp.float32: 1e-5, onp.float64: 1e-14}),
-    op_record("digamma", 1, float_dtypes, jtu.rand_positive(),
+    op_record("digamma", 1, float_dtypes, jtu.rand_positive,
               {onp.float64: 1e-14}),
-    op_record("erf", 1, float_dtypes, jtu.rand_small()),
-    op_record("erfc", 1, float_dtypes, jtu.rand_small()),
+    op_record("erf", 1, float_dtypes, jtu.rand_small),
+    op_record("erfc", 1, float_dtypes, jtu.rand_small),
     # TODO(b/142976030): the approximation of erfinf used by XLA is only
     # accurate to float32 precision.
-    op_record("erf_inv", 1, float_dtypes, jtu.rand_small(),
+    op_record("erf_inv", 1, float_dtypes, jtu.rand_small,
               {onp.float64: 1e-9}),
-    op_record("bessel_i0e", 1, float_dtypes, jtu.rand_default()),
-    op_record("bessel_i1e", 1, float_dtypes, jtu.rand_default()),
+    op_record("bessel_i0e", 1, float_dtypes, jtu.rand_default),
+    op_record("bessel_i1e", 1, float_dtypes, jtu.rand_default),
 
-    op_record("real", 1, complex_dtypes, jtu.rand_default()),
-    op_record("imag", 1, complex_dtypes, jtu.rand_default()),
-    op_record("complex", 2, [onp.float32, onp.float64], jtu.rand_default()),
+    op_record("real", 1, complex_dtypes, jtu.rand_default),
+    op_record("imag", 1, complex_dtypes, jtu.rand_default),
+    op_record("complex", 2, [onp.float32, onp.float64], jtu.rand_default),
     op_record("conj", 1, [onp.float32, onp.float64] + complex_dtypes,
-              jtu.rand_default()),
-    op_record("abs", 1, default_dtypes + complex_dtypes, jtu.rand_default()),
-    op_record("pow", 2, float_dtypes + complex_dtypes, jtu.rand_positive()),
+              jtu.rand_default),
+    op_record("abs", 1, default_dtypes + complex_dtypes, jtu.rand_default),
+    op_record("pow", 2, float_dtypes + complex_dtypes, jtu.rand_positive),
 
-    op_record("bitwise_and", 2, bool_dtypes, jtu.rand_small()),
-    op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small()),
-    op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small()),
-    op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small()),
+    op_record("bitwise_and", 2, bool_dtypes, jtu.rand_small),
+    op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small),
+    op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small),
+    op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small),
 
-    op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small()),
-    op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small()),
-    op_record("mul", 2, default_dtypes + complex_dtypes, jtu.rand_small()),
-    op_record("div", 2, default_dtypes + complex_dtypes, jtu.rand_nonzero()),
-    op_record("rem", 2, default_dtypes, jtu.rand_nonzero()),
+    op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small),
+    op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small),
+    op_record("mul", 2, default_dtypes + complex_dtypes, jtu.rand_small),
+    op_record("div", 2, default_dtypes + complex_dtypes, jtu.rand_nonzero),
+    op_record("rem", 2, default_dtypes, jtu.rand_nonzero),
 
-    op_record("max", 2, all_dtypes, jtu.rand_small()),
-    op_record("min", 2, all_dtypes, jtu.rand_small()),
+    op_record("max", 2, all_dtypes, jtu.rand_small),
+    op_record("min", 2, all_dtypes, jtu.rand_small),
 
-    op_record("eq", 2, all_dtypes, jtu.rand_some_equal()),
-    op_record("ne", 2, all_dtypes, jtu.rand_small()),
-    op_record("ge", 2, default_dtypes, jtu.rand_small()),
-    op_record("gt", 2, default_dtypes, jtu.rand_small()),
-    op_record("le", 2, default_dtypes, jtu.rand_small()),
-    op_record("lt", 2, default_dtypes, jtu.rand_small()),
+    op_record("eq", 2, all_dtypes, jtu.rand_some_equal),
+    op_record("ne", 2, all_dtypes, jtu.rand_small),
+    op_record("ge", 2, default_dtypes, jtu.rand_small),
+    op_record("gt", 2, default_dtypes, jtu.rand_small),
+    op_record("le", 2, default_dtypes, jtu.rand_small),
+    op_record("lt", 2, default_dtypes, jtu.rand_small),
 ]
 
 CombosWithReplacement = itertools.combinations_with_replacement
@@ -181,12 +181,14 @@ class LaxTest(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.op, shapes, itertools.repeat(dtype)),
-         "op_name": rec.op, "rng": rec.rng, "shapes": shapes, "dtype": dtype}
+         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
+         "dtype": dtype}
         for shape_group in compatible_shapes
         for shapes in CombosWithReplacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
-  def testOp(self, op_name, rng, shapes, dtype):
+  def testOp(self, op_name, rng_factory, shapes, dtype):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
     op = getattr(lax, op_name)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -195,13 +197,14 @@ class LaxTest(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.op, shapes, itertools.repeat(dtype)),
-         "op_name": rec.op, "rng": rec.rng, "shapes": shapes, "dtype": dtype,
-         "tol": rec.tol}
+         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
+         "dtype": dtype, "tol": rec.tol}
         for shape_group in compatible_shapes
         for shapes in CombosWithReplacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
-  def testOpAgainstNumpy(self, op_name, rng, shapes, dtype, tol):
+  def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
     op = getattr(lax, op_name)
     numpy_op = getattr(lax_reference, op_name)
@@ -212,11 +215,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}".format(
           from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng": rng}
+       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
-      for rng in [jtu.rand_default()]))
-  def testConvertElementType(self, from_dtype, to_dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConvertElementType(self, from_dtype, to_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng((2, 3), from_dtype)]
     op = lambda x: lax.convert_element_type(x, to_dtype)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -224,11 +228,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}"
        .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng": rng}
+       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
-      for rng in [jtu.rand_default()]))
-  def testConvertElementTypeAgainstNumpy(self, from_dtype, to_dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConvertElementTypeAgainstNumpy(self, from_dtype, to_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng((2, 3), from_dtype)]
     op = lambda x: lax.convert_element_type(x, to_dtype)
     numpy_op = lambda x: lax_reference.convert_element_type(x, to_dtype)
@@ -237,11 +242,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}"
        .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng": rng}
+       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
-      for rng in [jtu.rand_default()]))
-  def testBitcastConvertType(self, from_dtype, to_dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBitcastConvertType(self, from_dtype, to_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng((2, 3), from_dtype)]
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -249,11 +255,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}"
        .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng": rng}
+       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
-      for rng in [jtu.rand_default()]))
-  def testBitcastConvertTypeAgainstNumpy(self, from_dtype, to_dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBitcastConvertTypeAgainstNumpy(self, from_dtype, to_dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng((2, 3), from_dtype)]
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     numpy_op = lambda x: lax_reference.bitcast_convert_type(x, to_dtype)
@@ -265,7 +272,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(operand_shape, dtype),
           jtu.format_shape_dtype_string(max_shape, dtype)),
        "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "rng": rng}
+       "max_shape": max_shape, "dtype": dtype, "rng_factory": rng_factory}
       for min_shape, operand_shape, max_shape in [
           [(), (2, 3), ()],
           [(2, 3), (2, 3), ()],
@@ -273,8 +280,9 @@ class LaxTest(jtu.JaxTestCase):
           [(2, 3), (2, 3), (2, 3)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testClamp(self, min_shape, operand_shape, max_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testClamp(self, min_shape, operand_shape, max_shape, dtype, rng_factory):
+    rng = rng_factory()
     shapes = [min_shape, operand_shape, max_shape]
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
     self._CompileAndCheck(lax.clamp, args_maker, check_dtypes=True)
@@ -285,7 +293,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(operand_shape, dtype),
           jtu.format_shape_dtype_string(max_shape, dtype)),
        "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "rng": rng}
+       "max_shape": max_shape, "dtype": dtype, "rng_factory": rng_factory}
       for min_shape, operand_shape, max_shape in [
           [(), (2, 3), ()],
           [(2, 3), (2, 3), ()],
@@ -293,9 +301,10 @@ class LaxTest(jtu.JaxTestCase):
           [(2, 3), (2, 3), (2, 3)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testClampAgainstNumpy(self, min_shape, operand_shape, max_shape, dtype,
-                            rng):
+                            rng_factory):
+    rng = rng_factory()
     shapes = [min_shape, operand_shape, max_shape]
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
     self._CheckAgainstNumpy(lax.clamp, lax_reference.clamp, args_maker)
@@ -305,13 +314,14 @@ class LaxTest(jtu.JaxTestCase):
           dim, ",".join(str(d) for d in base_shape), onp.dtype(dtype).name,
           num_arrs),
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
-       "num_arrs": num_arrs, "rng": rng}
+       "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
       for dtype in default_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
-      for rng in [jtu.rand_default()]))
-  def testConcatenate(self, dim, base_shape, dtype, num_arrs, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConcatenate(self, dim, base_shape, dtype, num_arrs, rng_factory):
+    rng = rng_factory()
     shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
@@ -323,13 +333,14 @@ class LaxTest(jtu.JaxTestCase):
           dim, ",".join(str(d) for d in base_shape), onp.dtype(dtype).name,
           num_arrs),
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
-       "num_arrs": num_arrs, "rng": rng}
+       "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
       for dtype in default_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
-      for rng in [jtu.rand_default()]))
-  def testConcatenateAgainstNumpy(self, dim, base_shape, dtype, num_arrs, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConcatenateAgainstNumpy(self, dim, base_shape, dtype, num_arrs, rng_factory):
+    rng = rng_factory()
     shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
@@ -343,15 +354,16 @@ class LaxTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng": rng}
+          "strides": strides, "padding": padding, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([2, 3], repeat=3)]
       for dtype in float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1)]
       for padding in ["VALID", "SAME"]
-      for rng in [jtu.rand_small()]))
-  def testConv(self, lhs_shape, rhs_shape, dtype, strides, padding, rng):
+      for rng_factory in [jtu.rand_small]))
+  def testConv(self, lhs_shape, rhs_shape, dtype, strides, padding, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
@@ -365,16 +377,17 @@ class LaxTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng": rng}
+          "strides": strides, "padding": padding, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([2, 3], repeat=3)]
       for dtype in float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1)]
       for padding in ["VALID", "SAME"]
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testConvAgainstNumpy(self, lhs_shape, rhs_shape, dtype, strides, padding,
-                           rng):
+                           rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     op = lambda lhs, rhs: lax.conv(lhs, rhs, strides, padding)
     numpy_op = lambda lhs, rhs: lax_reference.conv(lhs, rhs, strides, padding)
@@ -388,7 +401,7 @@ class LaxTest(jtu.JaxTestCase):
            strides, padding, lhs_dilation, rhs_dilation),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
-       "rhs_dilation": rhs_dilation, "rng": rng}
+       "rhs_dilation": rhs_dilation, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([1, 2, 3], repeat=3)]
@@ -397,9 +410,10 @@ class LaxTest(jtu.JaxTestCase):
       for padding in [((0, 0), (0, 0)), ((1, 2), (2, 0))]
       for lhs_dilation, rhs_dilation in itertools.product(
           [(1, 1), (1, 2), (2, 2)], repeat=2)
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testConvWithGeneralPadding(self, lhs_shape, rhs_shape, dtype, strides,
-                                 padding, lhs_dilation, rhs_dilation, rng):
+                                 padding, lhs_dilation, rhs_dilation, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
@@ -416,7 +430,7 @@ class LaxTest(jtu.JaxTestCase):
            strides, padding, lhs_dilation, rhs_dilation),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
-       "rhs_dilation": rhs_dilation, "rng": rng}
+       "rhs_dilation": rhs_dilation, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([1, 2, 3], repeat=3)]
@@ -424,10 +438,11 @@ class LaxTest(jtu.JaxTestCase):
       for padding in [((0, 0), (0, 0)), ((1, 2), (2, 0))]
       for lhs_dilation, rhs_dilation in itertools.product(
           [(1, 1), (1, 2), (2, 2)], repeat=2)
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def DISABLED_testConvWithGeneralPaddingAgainstNumpy(
       self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dilation,
-      rhs_dilation, rng):
+      rhs_dilation, rng_factory):
+    rng = rng_factory()
     # TODO(mattjj): make this test pass
     raise SkipTest("this test is incomplete")
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
@@ -453,7 +468,7 @@ class LaxTest(jtu.JaxTestCase):
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
        "rhs_dilation": rhs_dilation, "dimension_numbers": dim_nums,
-       "perms": perms, "rng": rng}
+       "perms": perms, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([2, 3], repeat=3)]
@@ -461,7 +476,7 @@ class LaxTest(jtu.JaxTestCase):
       for padding in [((1, 2), (2, 0))]
       for lhs_dilation, rhs_dilation in itertools.product(
           [(1, 1), (1, 2)], repeat=2)
-      for rng in [jtu.rand_small()]
+      for rng_factory in [jtu.rand_small]
       for dim_nums, perms in [
         (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
         (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
@@ -469,7 +484,8 @@ class LaxTest(jtu.JaxTestCase):
       ]))
   def testConvGeneralDilated(self, lhs_shape, rhs_shape, dtype, strides,
                              padding, lhs_dilation, rhs_dilation,
-                             dimension_numbers, perms, rng):
+                             dimension_numbers, perms, rng_factory):
+    rng = rng_factory()
     lhs_perm, rhs_perm = perms  # permute to compatible shapes
 
     def args_maker():
@@ -529,7 +545,7 @@ class LaxTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
+          "strides": strides, "padding": padding, "rng_factory": rng_factory, 'dspec': dspec}
       for lhs_shape, rhs_shape in [
           ((b, 9, 10, i), (k, k, j, i))  # NB: i,j flipped in RHS for transpose
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
@@ -537,9 +553,10 @@ class LaxTest(jtu.JaxTestCase):
       for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHWC', 'HWIO', 'NHWC'),]
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testConvTranspose2DT(self, lhs_shape, rhs_shape, dtype, strides,
-                          padding, dspec, rng):
+                          padding, dspec, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     # NB: this test calculates conv_transpose performing identically to the
@@ -562,7 +579,7 @@ class LaxTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
+          "strides": strides, "padding": padding, "rng_factory": rng_factory, 'dspec': dspec}
       for lhs_shape, rhs_shape in [
           ((b, 9, 10, i), (k, k, i, j))
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
@@ -570,9 +587,10 @@ class LaxTest(jtu.JaxTestCase):
       for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHWC', 'HWIO', 'NHWC'),]
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testConvTranspose2D(self, lhs_shape, rhs_shape, dtype, strides,
-                          padding, dspec, rng):
+                          padding, dspec, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
@@ -594,7 +612,7 @@ class LaxTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng": rng, 'dspec': dspec}
+          "strides": strides, "padding": padding, "rng_factory": rng_factory, 'dspec': dspec}
       for lhs_shape, rhs_shape in [
           ((b, 10, i), (k, i, j))
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
@@ -602,9 +620,10 @@ class LaxTest(jtu.JaxTestCase):
       for strides in [(1,), (2,), (3,)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHC', 'HIO', 'NHC'),]
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testConvTranspose1D(self, lhs_shape, rhs_shape, dtype, strides,
-                          padding, dspec, rng):
+                          padding, dspec, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
@@ -626,13 +645,14 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(rhs_shape, dtype),
           precision),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "precision": precision, "rng": rng}
+       "precision": precision, "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
       for dtype in default_dtypes
       for precision in [None, lax.Precision.DEFAULT, lax.Precision.HIGH,
                         lax.Precision.HIGHEST]
-      for rng in [jtu.rand_default()]))
-  def testDot(self, lhs_shape, rhs_shape, dtype, precision, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testDot(self, lhs_shape, rhs_shape, dtype, precision, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     self._CompileAndCheck(partial(lax.dot, precision=precision), args_maker,
                           check_dtypes=True)
@@ -642,11 +662,12 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(lhs_shape, dtype),
           jtu.format_shape_dtype_string(rhs_shape, dtype)),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testDotAgainstNumpy(self, lhs_shape, rhs_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testDotAgainstNumpy(self, lhs_shape, rhs_shape, dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     tol = {onp.float16: 1e-2,
            onp.float64: max(default_tolerance[onp.float64], 1e-14)}
@@ -661,7 +682,7 @@ class LaxTest(jtu.JaxTestCase):
                lhs_contracting, rhs_contracting),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, lhs_contracting, rhs_contracting in [
           [(3, 5), (2, 5), [1], [1]],
           [(5, 3), (5, 2), [0], [0]],
@@ -671,9 +692,10 @@ class LaxTest(jtu.JaxTestCase):
           [(3, 2), (2, 4), [1], [0]],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractOnly(self, lhs_shape, rhs_shape, dtype,
-                                 lhs_contracting, rhs_contracting, rng):
+                                 lhs_contracting, rhs_contracting, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     dimension_numbers = ((lhs_contracting, rhs_contracting), ([], []))
 
@@ -689,15 +711,16 @@ class LaxTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                dimension_numbers),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "rng": rng}
+       "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
-                                     dimension_numbers, rng):
+                                     dimension_numbers, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     def fun(lhs, rhs):
@@ -712,15 +735,16 @@ class LaxTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                dimension_numbers),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "rng": rng}
+       "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testDotGeneralAgainstNumpy(self, lhs_shape, rhs_shape, dtype,
-                                 dimension_numbers, rng):
+                                 dimension_numbers, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     op = lambda x, y: lax.dot_general(x, y, dimension_numbers)
     numpy_op = lambda x, y: lax_reference.dot_general(x, y, dimension_numbers)
@@ -730,12 +754,13 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}".format(
           shape, onp.dtype(dtype).name, broadcast_sizes),
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
       for dtype in default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
-      for rng in [jtu.rand_default()]))
-  def testBroadcast(self, shape, dtype, broadcast_sizes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcast(self, shape, dtype, broadcast_sizes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.broadcast(x, broadcast_sizes)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -744,12 +769,13 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_broadcast_sizes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), broadcast_sizes),
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
       for dtype in default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
-      for rng in [jtu.rand_default()]))
-  def testBroadcastAgainstNumpy(self, shape, dtype, broadcast_sizes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcastAgainstNumpy(self, shape, dtype, broadcast_sizes, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.broadcast(x, broadcast_sizes)
     numpy_op = lambda x: lax_reference.broadcast(x, broadcast_sizes)
@@ -760,7 +786,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(inshape, dtype),
           outshape, broadcast_dimensions),
        "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "rng": rng}
+       "dimensions": broadcast_dimensions, "rng_factory": rng_factory}
       for inshape, outshape, broadcast_dimensions in [
           ([2], [2, 2], [0]),
           ([2], [2, 2], [1]),
@@ -768,8 +794,9 @@ class LaxTest(jtu.JaxTestCase):
           ([], [2, 3], []),
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(inshape, dtype)]
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -779,7 +806,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(inshape, dtype),
           outshape, broadcast_dimensions),
        "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "rng": rng}
+       "dimensions": broadcast_dimensions, "rng_factory": rng_factory}
       for inshape, outshape, broadcast_dimensions in [
           ([2], [2, 2], [0]),
           ([2], [2, 2], [1]),
@@ -787,9 +814,10 @@ class LaxTest(jtu.JaxTestCase):
           ([], [2, 3], []),
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testBroadcastInDimAgainstNumpy(self, inshape, dtype, outshape,
-                                     dimensions, rng):
+                                     dimensions, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(inshape, dtype)]
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     numpy_op = lambda x: lax_reference.broadcast_in_dim(x, outshape, dimensions)
@@ -800,13 +828,14 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for dtype in default_dtypes
       for arg_shape, out_shape in [
           [(3, 4), (12,)], [(2, 1, 4), (8,)], [(2, 2, 4), (2, 8)]
       ]
-      for rng in [jtu.rand_default()]))
-  def testReshape(self, arg_shape, out_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReshape(self, arg_shape, out_shape, dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(arg_shape, dtype)]
     op = lambda x: lax.reshape(x, out_shape)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -816,13 +845,14 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for dtype in default_dtypes
       for arg_shape, out_shape in [
           [(3, 4), (12,)], [(2, 1, 4), (8,)], [(2, 2, 4), (2, 8)]
       ]
-      for rng in [jtu.rand_default()]))
-  def testReshapeAgainstNumpy(self, arg_shape, out_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReshapeAgainstNumpy(self, arg_shape, out_shape, dtype, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(arg_shape, dtype)]
     op = lambda x: lax.reshape(x, out_shape)
     numpy_op = lambda x: lax_reference.reshape(x, out_shape)
@@ -831,11 +861,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_pads={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
-       "shape": shape, "dtype": dtype, "pads": pads, "rng": jtu.rand_small()}
+       "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
       for dtype in default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
-  def testPad(self, shape, dtype, pads, rng):
+  def testPad(self, shape, dtype, pads, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     fun = lambda operand: lax.pad(operand, onp.array(0, dtype), pads)
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)
@@ -843,11 +874,12 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_pads={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
-       "shape": shape, "dtype": dtype, "pads": pads, "rng": jtu.rand_small()}
+       "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
       for dtype in default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
-  def testPadAgainstNumpy(self, shape, dtype, pads, rng):
+  def testPadAgainstNumpy(self, shape, dtype, pads, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.pad(x, onp.array(0, dtype), pads)
     numpy_op = lambda x: lax_reference.pad(x, onp.array(0, dtype), pads)
@@ -870,17 +902,16 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(pred_shape, onp.bool_),
           jtu.format_shape_dtype_string(arg_shape, arg_dtype)),
        "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
       for arg_dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSelect(self, pred_shape, arg_shape, arg_dtype, rng):
-
+      for rng_factory in [jtu.rand_default]))
+  def testSelect(self, pred_shape, arg_shape, arg_dtype, rng_factory):
     def args_maker():
       return [rng(pred_shape, onp.bool_), rng(arg_shape, arg_dtype),
               rng(arg_shape, arg_dtype)]
-
+    rng = rng_factory()
     return self._CompileAndCheck(lax.select, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -888,17 +919,16 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(pred_shape, onp.bool_),
           jtu.format_shape_dtype_string(arg_shape, arg_dtype)),
        "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
       for arg_dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSelectAgainstNumpy(self, pred_shape, arg_shape, arg_dtype, rng):
-
+      for rng_factory in [jtu.rand_default]))
+  def testSelectAgainstNumpy(self, pred_shape, arg_shape, arg_dtype, rng_factory):
     def args_maker():
       return [rng(pred_shape, onp.bool_), rng(arg_shape, arg_dtype),
               rng(arg_shape, arg_dtype)]
-
+    rng = rng_factory()
     return self._CheckAgainstNumpy(lax.select, lax_reference.select, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -907,7 +937,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, limit_indices, strides),
        "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "rng": rng}
+       "limits": limit_indices, "strides": strides, "rng_factory": rng_factory}
       for shape, start_indices, limit_indices, strides in [
         [(3,), (1,), (2,), None],
         [(7,), (4,), (7,), None],
@@ -920,8 +950,9 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSlice(self, shape, dtype, starts, limits, strides, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSlice(self, shape, dtype, starts, limits, strides, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.slice(x, starts, limits, strides)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -932,7 +963,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, limit_indices, strides),
        "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "rng": rng}
+       "limits": limit_indices, "strides": strides, "rng_factory": rng_factory}
       for shape, start_indices, limit_indices, strides in [
         [(3,), (1,), (2,), None],
         [(7,), (4,), (7,), None],
@@ -945,9 +976,10 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testSliceAgainstNumpy(self, shape, dtype, starts, limits,
-                            strides, rng):
+                            strides, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.slice(x, starts, limits, strides)
     numpy_op = lambda x: lax_reference.slice(x, starts, limits, strides)
@@ -958,15 +990,16 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, size_indices),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "size_indices": size_indices, "rng": rng}
+       "size_indices": size_indices, "rng_factory": rng_factory}
       for shape, start_indices, size_indices in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testDynamicSlice(self, shape, dtype, start_indices, size_indices, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testDynamicSlice(self, shape, dtype, start_indices, size_indices, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), onp.array(start_indices)]
     op = lambda x, starts: lax.dynamic_slice(x, starts, size_indices)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -976,16 +1009,17 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, size_indices),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "size_indices": size_indices, "rng": rng}
+       "size_indices": size_indices, "rng_factory": rng_factory}
       for shape, start_indices, size_indices in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testDynamicSliceAgainstNumpy(self, shape, dtype, start_indices,
-                                   size_indices, rng):
+                                   size_indices, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), onp.array(start_indices)]
     op = lambda x, s: lax.dynamic_slice(x, s, size_indices)
     numpy_op = lambda x, s: lax_reference.dynamic_slice(x, s, size_indices)
@@ -996,16 +1030,17 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, update_shape),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "update_shape": update_shape, "rng": rng}
+       "update_shape": update_shape, "rng_factory": rng_factory}
       for shape, start_indices, update_shape in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSlice(self, shape, dtype, start_indices, update_shape,
-                             rng):
+                             rng_factory):
+    rng = rng_factory()
 
     def args_maker():
       return [rng(shape, dtype), rng(update_shape, dtype),
@@ -1019,16 +1054,17 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, update_shape),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "update_shape": update_shape, "rng": rng}
+       "update_shape": update_shape, "rng_factory": rng_factory}
       for shape, start_indices, update_shape in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSliceAgainstNumpy(self, shape, dtype, start_indices,
-                                         update_shape, rng):
+                                         update_shape, rng_factory):
+    rng = rng_factory()
 
     def args_maker():
       return [rng(shape, dtype), rng(update_shape, dtype),
@@ -1040,7 +1076,7 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_perm={}".format(
           jtu.format_shape_dtype_string(shape, dtype), perm),
-       "shape": shape, "dtype": dtype, "perm": perm, "rng": rng}
+       "shape": shape, "dtype": dtype, "perm": perm, "rng_factory": rng_factory}
       for shape, perm in [
         [(3, 4), (1, 0)],
         [(3, 4), (0, 1)],
@@ -1048,8 +1084,9 @@ class LaxTest(jtu.JaxTestCase):
         [(3, 4, 5), (1, 0, 2)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testTranspose(self, shape, dtype, perm, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testTranspose(self, shape, dtype, perm, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.transpose(x, perm)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
@@ -1057,7 +1094,7 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_perm={}".format(
           jtu.format_shape_dtype_string(shape, dtype), perm),
-       "shape": shape, "dtype": dtype, "perm": perm, "rng": rng}
+       "shape": shape, "dtype": dtype, "perm": perm, "rng_factory": rng_factory}
       for shape, perm in [
         [(3, 4), (1, 0)],
         [(3, 4), (0, 1)],
@@ -1065,8 +1102,9 @@ class LaxTest(jtu.JaxTestCase):
         [(3, 4, 5), (1, 0, 2)],
       ]
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testTransposeAgainstNumpy(self, shape, dtype, perm, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testTransposeAgainstNumpy(self, shape, dtype, perm, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.transpose(x, perm)
     numpy_op = lambda x: lax_reference.transpose(x, perm)
@@ -1077,7 +1115,7 @@ class LaxTest(jtu.JaxTestCase):
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims,
                init_val),
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
-       "dims": dims, "rng": rng}
+       "dims": dims, "rng_factory": rng_factory}
       for init_val, op, dtypes in [
           (0, lax.add, default_dtypes),
           (1, lax.mul, default_dtypes),
@@ -1098,9 +1136,11 @@ class LaxTest(jtu.JaxTestCase):
           [(3, 4, 5), (0,)], [(3, 4, 5), (1, 2)],
           [(3, 4, 5), (0, 2)], [(3, 4, 5), (0, 1, 2)]
       ]
-      for rng in [jtu.rand_default() if onp.issubdtype(dtype, onp.integer)
-                  else jtu.rand_small()]))
-  def testReduce(self, op, init_val, shape, dtype, dims, rng):
+      for rng_factory in [
+          jtu.rand_default if onp.issubdtype(dtype, onp.integer)
+          else jtu.rand_small]))
+  def testReduce(self, op, init_val, shape, dtype, dims, rng_factory):
+    rng = rng_factory()
     init_val = onp.asarray(init_val, dtype=dtype)
     fun = lambda operand, init_val: lax.reduce(operand, init_val, op, dims)
     args_maker = lambda: [rng(shape, dtype), init_val]
@@ -1116,7 +1156,7 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_op={}_dtype={}_padding={}"
        .format(op.__name__, onp.dtype(dtype).name, padding),
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for init_val, op, dtypes in [
           (0, lax.add, [onp.float32]),
           (-onp.inf, lax.max, [onp.float32]),
@@ -1124,8 +1164,9 @@ class LaxTest(jtu.JaxTestCase):
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]
-      for rng in [jtu.rand_small()]))
-  def testReduceWindow(self, op, init_val, dtype, padding, rng):
+      for rng_factory in [jtu.rand_small]))
+  def testReduceWindow(self, op, init_val, dtype, padding, rng_factory):
+    rng = rng_factory()
     init_val = onp.asarray(init_val, dtype=dtype)
 
     all_configs = itertools.chain(
@@ -1160,12 +1201,13 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng": rng, "shape": shape, "dtype": dtype, "axis": axis}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
       for dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSort(self, shape, dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSort(self, shape, dtype, axis, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     fun = lambda x: lax.sort(x, axis)
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)
@@ -1173,12 +1215,13 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng": rng, "shape": shape, "dtype": dtype, "axis": axis}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
       for dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSortAgainstNumpy(self, shape, dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSortAgainstNumpy(self, shape, dtype, axis, rng_factory):
+    rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.sort(x, axis)
     numpy_op = lambda x: lax_reference.sort(x, axis)
@@ -1189,14 +1232,15 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, key_dtype),
           jtu.format_shape_dtype_string(shape, val_dtype),
           axis),
-       "rng": rng, "shape": shape,
+       "rng_factory": rng_factory, "shape": shape,
        "key_dtype": key_dtype, "val_dtype": val_dtype, "axis": axis}
       for key_dtype in [onp.float32, onp.int32, onp.uint32]
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSortKeyVal(self, shape, key_dtype, val_dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSortKeyVal(self, shape, key_dtype, val_dtype, axis, rng_factory):
+    rng = rng_factory()
     # This test relies on the property that wherever keys are tied, values are
     # too, since we don't guarantee the same ordering of values with equal keys.
     # To avoid that case, we generate unique keys (globally in the key array).
@@ -1215,14 +1259,15 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, key_dtype),
           jtu.format_shape_dtype_string(shape, val_dtype),
           axis),
-       "rng": rng, "shape": shape,
+       "rng_factory": rng_factory, "shape": shape,
        "key_dtype": key_dtype, "val_dtype": val_dtype, "axis": axis}
       for key_dtype in [onp.float32, onp.int32, onp.uint32]
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSortKeyValAgainstNumpy(self, shape, key_dtype, val_dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSortKeyValAgainstNumpy(self, shape, key_dtype, val_dtype, axis, rng_factory):
+    rng = rng_factory()
     # This test relies on the property that wherever keys are tied, values are
     # too, since we don't guarantee the same ordering of values with equal keys.
     # To avoid that case, we generate unique keys (globally in the key array).
@@ -1242,13 +1287,14 @@ class LaxTest(jtu.JaxTestCase):
        .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
                jtu.format_shape_dtype_string(rhs_shape, dtype)),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [((3, 2), (2, 4)),
                                    ((5, 3, 2), (5, 2, 4)),
                                    ((1, 2, 2, 3), (1, 2, 3, 1))]
       for dtype in float_dtypes
-      for rng in [jtu.rand_small()]))
-  def testBatchMatMul(self, lhs_shape, rhs_shape, dtype, rng):
+      for rng_factory in [jtu.rand_small]))
+  def testBatchMatMul(self, lhs_shape, rhs_shape, dtype, rng_factory):
+    rng = rng_factory()
     arg_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     self._CompileAndCheck(lax.batch_matmul, arg_maker, check_dtypes=True)
 
@@ -1266,7 +1312,7 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_idxs={}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), idxs, axes),
-       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes, "rng": rng}
+       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes, "rng_factory": rng_factory}
       for dtype in all_dtypes
       for shape, idxs, axes in [
           [(3, 4, 5), (onp.array([0, 2, 1]),), (0,)],
@@ -1274,8 +1320,9 @@ class LaxTest(jtu.JaxTestCase):
           [(3, 4, 5), (onp.array([0, 2]), onp.array([1, 3])), (0, 1)],
           [(3, 4, 5), (onp.array([0, 2]), onp.array([1, 3])), (0, 2)],
       ]
-      for rng in [jtu.rand_default()]))
-  def testIndexTake(self, shape, dtype, idxs, axes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testIndexTake(self, shape, dtype, idxs, axes, rng_factory):
+    rng = rng_factory()
     rand_idxs = lambda: tuple(rng(e.shape, e.dtype) for e in idxs)
     args_maker = lambda: [rng(shape, dtype), rand_idxs()]
     fun = lambda src, idxs: lax.index_take(src, idxs, axes)
@@ -1286,7 +1333,8 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), idxs, dnums,
           slice_sizes),
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in all_dtypes
       for shape, idxs, dnums, slice_sizes in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
@@ -1302,9 +1350,12 @@ class LaxTest(jtu.JaxTestCase):
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
             (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()]))
-  def testGather(self, shape, dtype, idxs, dnums, slice_sizes, rng, rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testGather(self, shape, dtype, idxs, dnums, slice_sizes, rng_factory, 
+                 rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(shape, dtype), rand_idxs()]
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
@@ -1315,8 +1366,8 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -1329,10 +1380,12 @@ class LaxTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                     rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
@@ -1344,8 +1397,8 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -1358,10 +1411,12 @@ class LaxTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatterMin(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                     rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterMin(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
@@ -1373,8 +1428,8 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -1387,10 +1442,12 @@ class LaxTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatterMax(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                     rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterMax(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
@@ -1402,8 +1459,8 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -1416,10 +1473,12 @@ class LaxTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatter(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                  rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatter(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
@@ -1530,93 +1589,98 @@ class DeviceConstantTest(jtu.JaxTestCase):
 
 
 GradTestSpec = collections.namedtuple(
-    "GradTestSpec", ["op", "nargs", "order", "rng", "dtypes", "name", "tol"])
-def grad_test_spec(op, nargs, order, rng, dtypes, name=None, tol=None):
-  return GradTestSpec(op, nargs, order, rng, dtypes, name or op.__name__, tol)
+    "GradTestSpec",
+    ["op", "nargs", "order", "rng_factory", "dtypes", "name", "tol"])
+def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
+  return GradTestSpec(
+      op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
 LAX_GRAD_OPS = [
-    grad_test_spec(lax.neg, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.floor, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.floor, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.ceil, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.ceil, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.round, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.round, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
 
-    grad_test_spec(lax.exp, nargs=1, order=2, rng=jtu.rand_small(),
+    grad_test_spec(lax.exp, nargs=1, order=2, rng_factory=jtu.rand_small,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.expm1, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.expm1, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.log, nargs=1, order=2, rng=jtu.rand_positive(),
+    grad_test_spec(lax.log, nargs=1, order=2, rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.log1p, nargs=1, order=2, rng=jtu.rand_positive(),
+    grad_test_spec(lax.log1p, nargs=1, order=2, rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.sinh, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.sinh, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64], tol=1e-5),
-    grad_test_spec(lax.cosh, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.cosh, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64], tol=1e-5),
-    grad_test_spec(lax.tanh, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.tanh, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64], tol=1e-5),
-    grad_test_spec(lax.sin, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.sin, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.cos, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.cos, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.tan, nargs=1, order=2, rng=jtu.rand_uniform(-1.3, 1.3),
+    grad_test_spec(lax.tan, nargs=1, order=2,
+                   rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
                    dtypes=[onp.float64, onp.complex64], tol=1e-3),
-    grad_test_spec(lax.asin, nargs=1, order=2, rng=jtu.rand_uniform(-1., 1.),
+    grad_test_spec(lax.asin, nargs=1, order=2,
+                   rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
                    dtypes=[onp.float64], tol=1e-3),
-    grad_test_spec(lax.acos, nargs=1, order=2, rng=jtu.rand_uniform(-1., 1.),
+    grad_test_spec(lax.acos, nargs=1, order=2,
+                   rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
                    dtypes=[onp.float64], tol=1e-3),
     # TODO(proteneer): atan2 input is already a representation of a
     # complex number. Need to think harder about what this even means
     # if each input itself is a complex number.
-    grad_test_spec(lax.atan2, nargs=2, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.atan2, nargs=2, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
 
-    grad_test_spec(lax.erf, nargs=1, order=2, rng=jtu.rand_small(),
+    grad_test_spec(lax.erf, nargs=1, order=2, rng_factory=jtu.rand_small,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.erfc, nargs=1, order=2, rng=jtu.rand_small(),
+    grad_test_spec(lax.erfc, nargs=1, order=2, rng_factory=jtu.rand_small,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.erf_inv, nargs=1, order=2, rng=jtu.rand_small(),
+    grad_test_spec(lax.erf_inv, nargs=1, order=2, rng_factory=jtu.rand_small,
                    dtypes=[onp.float64]),
-    # grad_test_spec(lax.lgamma, nargs=1, order=2, rng=jtu.rand_small(),
+    # grad_test_spec(lax.lgamma, nargs=1, order=2, rng_factory=jtu.rand_small,
     #                dtypes=[onp.float64]),  # TODO(mattjj): enable
-    grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
 
-    grad_test_spec(lax.real, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.real, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.complex64]),
-    grad_test_spec(lax.imag, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.imag, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.complex64]),
-    grad_test_spec(lax.complex, nargs=2, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.complex, nargs=2, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float32]),
-    grad_test_spec(lax.conj, nargs=1, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.conj, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float32, onp.complex64]),
-    grad_test_spec(lax.abs, nargs=1, order=2, rng=jtu.rand_positive(),
+    grad_test_spec(lax.abs, nargs=1, order=2, rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.pow, nargs=2, order=2, rng=jtu.rand_positive(),
-                   dtypes=[onp.float64, onp.complex64]),
-
-    grad_test_spec(lax.add, nargs=2, order=2, rng=jtu.rand_default(),
-                   dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.sub, nargs=2, order=2, rng=jtu.rand_default(),
-                   dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.mul, nargs=2, order=2, rng=jtu.rand_default(),
-                   dtypes=[onp.float64, onp.complex64]),
-    grad_test_spec(lax.div, nargs=2, order=1, rng=jtu.rand_not_small(),
+    grad_test_spec(lax.pow, nargs=2, order=2, rng_factory=jtu.rand_positive,
                    dtypes=[onp.float64, onp.complex64]),
 
-    grad_test_spec(lax.max, nargs=2, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.add, nargs=2, order=2, rng_factory=jtu.rand_default,
+                   dtypes=[onp.float64, onp.complex64]),
+    grad_test_spec(lax.sub, nargs=2, order=2, rng_factory=jtu.rand_default,
+                   dtypes=[onp.float64, onp.complex64]),
+    grad_test_spec(lax.mul, nargs=2, order=2, rng_factory=jtu.rand_default,
+                   dtypes=[onp.float64, onp.complex64]),
+    grad_test_spec(lax.div, nargs=2, order=1, rng_factory=jtu.rand_not_small,
+                   dtypes=[onp.float64, onp.complex64]),
+
+    grad_test_spec(lax.max, nargs=2, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
-    grad_test_spec(lax.min, nargs=2, order=2, rng=jtu.rand_default(),
+    grad_test_spec(lax.min, nargs=2, order=2, rng_factory=jtu.rand_default,
                    dtypes=[onp.float64]),
     # TODO(mattjj): make some-equal checks more robust, enable second-order
-    # grad_test_spec(lax.max, nargs=2, order=1, rng=jtu.rand_some_equal(),
+    # grad_test_spec(lax.max, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
     #                dtypes=[onp.float64], name="MaxSomeEqual"),
-    # grad_test_spec(lax.min, nargs=2, order=1, rng=jtu.rand_some_equal(),
+    # grad_test_spec(lax.min, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
     #                dtypes=[onp.float64], name="MinSomeEqual"),
 ]
 
@@ -1674,13 +1738,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
             rec.name, shapes, itertools.repeat(dtype)),
-         "op": rec.op, "rng": rec.rng, "shapes": shapes, "dtype": dtype,
+         "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
          "order": rec.order, "tol": rec.tol}
         for shape_group in compatible_shapes
         for shapes in CombosWithReplacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_GRAD_OPS))
-  def testOpGrad(self, op, rng, shapes, dtype, order, tol):
+  def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):
+    rng = rng_factory()
     if jtu.device_under_test() == "tpu" and op is lax.pow:
       raise SkipTest("pow grad imprecise on tpu")
     tol = 1e-1 if num_float_bits(dtype) == 32 else tol
@@ -1699,11 +1764,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}".format(
           jtu.dtype_str(from_dtype), jtu.dtype_str(to_dtype)),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng": rng}
+       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           float_dtypes + complex_dtypes, repeat=2)
-      for rng in [jtu.rand_default()]))
-  def testConvertElementTypeGrad(self, from_dtype, to_dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConvertElementTypeGrad(self, from_dtype, to_dtype, rng_factory):
+    rng = rng_factory()
     tol = max(gradient_tolerance(to_dtype), gradient_tolerance(from_dtype))
     args = (rng((2, 3), from_dtype),)
     convert_element_type = lambda x: lax.convert_element_type(x, to_dtype)
@@ -1715,15 +1781,16 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(operand_shape, dtype),
           jtu.format_shape_dtype_string(max_shape, dtype)),
        "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "rng": rng}
+       "max_shape": max_shape, "dtype": dtype, "rng_factory": rng_factory}
       for min_shape, operand_shape, max_shape in [
           [(), (), ()],
           [(), (2, 3), ()],
           [(2, 3), (2, 3), (2, 3)],
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
-  def testClampGrad(self, min_shape, operand_shape, max_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testClampGrad(self, min_shape, operand_shape, max_shape, dtype, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-2})
     shapes = [min_shape, operand_shape, max_shape]
     min, operand, max = (rng(shape, dtype) for shape in shapes)
@@ -1737,13 +1804,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           dim, ",".join(str(d) for d in base_shape), onp.dtype(dtype).name,
           num_arrs),
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
-       "num_arrs": num_arrs, "rng": rng}
+       "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
       for dtype in float_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
-      for rng in [jtu.rand_default()]))
-  def testConcatenateGrad(self, dim, base_shape, dtype, num_arrs, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConcatenateGrad(self, dim, base_shape, dtype, num_arrs, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
@@ -1758,7 +1826,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                strides, padding),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "strides": strides, "padding": padding, "rng": rng,}
+       "strides": strides, "padding": padding, "rng_factory": rng_factory,}
        for lhs_shape, rhs_shape, all_strides in itertools.chain(
            [((b, i, 3, 4), (j, i, 1, 2), [(1, 1), (1, 2), (2, 1)])
             for b, i, j in itertools.product([2, 3], repeat=3)],
@@ -1766,8 +1834,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        for strides in all_strides
        for dtype in float_dtypes
        for padding in ["VALID", "SAME"]
-       for rng in [jtu.rand_small()]))
-  def testConvGrad(self, lhs_shape, rhs_shape, dtype, strides, padding, rng):
+       for rng_factory in [jtu.rand_small]))
+  def testConvGrad(self, lhs_shape, rhs_shape, dtype, strides, padding, rng_factory):
+    rng = rng_factory()
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
     conv = partial(lax.conv, window_strides=strides, padding=padding,
@@ -1784,7 +1853,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                strides, padding, lhs_dil, rhs_dil),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
-       "rhs_dil": rhs_dil, "rng": rng}
+       "rhs_dil": rhs_dil, "rng_factory": rng_factory}
        for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in
        itertools.chain(
            [((b, i, 3, 4), (j, i, 1, 2), [(1, 1), (1, 2), (2, 1)],
@@ -1798,9 +1867,10 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        for lhs_dil in lhs_dils
        for dtype in float_dtypes
        for padding in all_pads
-       for rng in [jtu.rand_small()]))
+       for rng_factory in [jtu.rand_small]))
   def testConvWithGeneralPaddingGrad(self, lhs_shape, rhs_shape, dtype, strides,
-                                     padding, lhs_dil, rhs_dil, rng):
+                                     padding, lhs_dil, rhs_dil, rng_factory):
+    rng = rng_factory()
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
     conv = partial(lax.conv_with_general_padding, window_strides=strides,
@@ -1819,7 +1889,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                feature_group_count),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
-       "rhs_dil": rhs_dil, "rng": rng, "dimension_numbers": dim_nums,
+       "rhs_dil": rhs_dil, "rng_factory": rng_factory, "dimension_numbers": dim_nums,
        "perms": perms, "feature_group_count": feature_group_count}
       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
           ((b, i, 6, 7),  # lhs_shape
@@ -1839,12 +1909,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
           (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
           (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))]
-      for rng in [jtu.rand_default()]
+      for rng_factory in [jtu.rand_default]
   ))
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): precision problems on TPU.
   def testConvGeneralDilatedGrad(self, lhs_shape, rhs_shape, dtype, strides,
                                  padding, lhs_dil, rhs_dil, dimension_numbers,
-                                 perms, feature_group_count, rng):
+                                 perms, feature_group_count, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype, {onp.float16: 5e-1, onp.float32: 1e-4})
 
     # permute shapes to match dim_spec, scale by feature_group_count
@@ -1870,10 +1941,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(lhs_shape, dtype),
           jtu.format_shape_dtype_string(rhs_shape, dtype)),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rng": jtu.rand_default()}
+       "rng_factory": jtu.rand_default}
       for lhs_shape in [(2,), (3, 2)] for rhs_shape in [(2,), (2, 4)]
       for dtype in float_dtypes))
-  def testDotGrad(self, lhs_shape, rhs_shape, dtype, rng):
+  def testDotGrad(self, lhs_shape, rhs_shape, dtype, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-4})
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
@@ -1893,7 +1965,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                dimension_numbers),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "rng": jtu.rand_small()}
+       "dimension_numbers": dimension_numbers, "rng_factory": jtu.rand_small}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 2), (2, 4), (([1], [0]), ([], []))),
           ((3, 5), (2, 5), (([1], [1]), ([], []))),
@@ -1902,7 +1974,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       ]
       for dtype in float_dtypes))
   def testDotGeneralContractAndBatchGrads(self, lhs_shape, rhs_shape, dtype,
-                                          dimension_numbers, rng):
+                                          dimension_numbers, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
@@ -1920,12 +1993,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}".format(
           shape, onp.dtype(dtype).name, broadcast_sizes),
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
       for dtype in float_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
-      for rng in [jtu.rand_default()]))
-  def testBroadcastGrad(self, shape, dtype, broadcast_sizes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcastGrad(self, shape, dtype, broadcast_sizes, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     args = (rng(shape, dtype),)
     broadcast = lambda x: lax.broadcast(x, broadcast_sizes)
@@ -1936,7 +2010,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(inshape, dtype),
           outshape, broadcast_dimensions),
        "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "rng": rng}
+       "dimensions": broadcast_dimensions, "rng_factory": rng_factory}
       for inshape, outshape, broadcast_dimensions in [
           ([2], [2, 2], [0]),
           ([2], [2, 2], [1]),
@@ -1944,8 +2018,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           ([], [2, 3], []),
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
-  def testBroadcastInDimGrad(self, inshape, dtype, outshape, dimensions, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcastInDimGrad(self, inshape, dtype, outshape, dimensions, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(inshape, dtype)
     broadcast_in_dim = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
@@ -1958,7 +2033,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype),
           permutation),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng": rng, "permutation": permutation}
+       "rng_factory": rng_factory, "permutation": permutation}
       for dtype in float_dtypes
       for arg_shape, out_shape, permutation in [
           [(3, 4), (12,), None],
@@ -1971,8 +2046,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           [(2, 2, 4), (2, 8), (0, 2, 1)],
           [(2, 2, 4), (2, 8), (2, 0, 1)],
       ]
-      for rng in [jtu.rand_default()]))
-  def testReshapeGrad(self, arg_shape, out_shape, permutation, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReshapeGrad(self, arg_shape, out_shape, permutation, dtype, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(arg_shape, dtype)
     reshape = lambda x: lax.reshape(x, out_shape, permutation)
@@ -1981,11 +2057,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_pads={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
-       "shape": shape, "dtype": dtype, "pads": pads, "rng": jtu.rand_small()}
+       "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
       for dtype in float_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)], [(-1, 0, 0), (-1, 0, 2)]]))
-  def testPadGrad(self, shape, dtype, pads, rng):
+  def testPadGrad(self, shape, dtype, pads, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
 
     operand = rng(shape, dtype)
@@ -2012,12 +2089,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(pred_shape, onp.bool_),
           jtu.format_shape_dtype_string(arg_shape, dtype)),
        "pred_shape": pred_shape, "arg_shape": arg_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSelectGrad(self, pred_shape, arg_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSelectGrad(self, pred_shape, arg_shape, dtype, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     pred = rng(pred_shape, onp.bool_)
     on_true = rng(arg_shape, dtype)
@@ -2032,7 +2110,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, limit_indices, strides),
        "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "rng": rng}
+       "limits": limit_indices, "strides": strides, "rng_factory": rng_factory}
       for shape, start_indices, limit_indices, strides in [
         [(3,), (1,), (2,), None],
         [(7,), (4,), (7,), None],
@@ -2045,8 +2123,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSliceGrad(self, shape, dtype, starts, limits, strides, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSliceGrad(self, shape, dtype, starts, limits, strides, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     slice = lambda x: lax.slice(x, starts, limits, strides)
@@ -2057,16 +2136,17 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, size_indices),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "size_indices": size_indices, "rng": rng}
+       "size_indices": size_indices, "rng_factory": rng_factory}
       for shape, start_indices, size_indices in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testDynamicSliceGrad(self, shape, dtype, start_indices, size_indices,
-                           rng):
+                           rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     dynamic_slice = lambda x: lax.dynamic_slice(x, start_indices, size_indices)
@@ -2077,16 +2157,17 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, update_shape),
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "update_shape": update_shape, "rng": rng}
+       "update_shape": update_shape, "rng_factory": rng_factory}
       for shape, start_indices, update_shape in [
         [(3,), (1,), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSliceGrad(self, shape, dtype, start_indices,
-                                 update_shape, rng):
+                                 update_shape, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     update = rng(update_shape, dtype)
@@ -2104,7 +2185,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_perm={}".format(
           jtu.format_shape_dtype_string(shape, dtype), perm),
-       "shape": shape, "dtype": dtype, "perm": perm, "rng": rng}
+       "shape": shape, "dtype": dtype, "perm": perm, "rng_factory": rng_factory}
       for shape, perm in [
         [(3, 4), (1, 0)],
         [(3, 4), (0, 1)],
@@ -2112,8 +2193,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(3, 4, 5), (1, 0, 2)],
       ]
       for dtype in float_dtypes
-      for rng in [jtu.rand_default()]))
-  def testTransposeGrad(self, shape, dtype, perm, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testTransposeGrad(self, shape, dtype, perm, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     transpose = lambda x: lax.transpose(x, perm)
@@ -2123,7 +2205,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       {"testcase_name": "_op={}_inshape={}_reducedims={}"
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims),
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
-       "dims": dims, "rng": rng}
+       "dims": dims, "rng_factory": rng_factory}
       for init_val, op, dtypes in [
           (0, lax.add, inexact_dtypes),
           # Precision problems for float16 tests.
@@ -2141,8 +2223,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           [(3, 4, 5), (0, 1, 2)],
           [(3, 1), (1,)],
       ]
-      for rng in [jtu.rand_default()]))
-  def testReduceGrad(self, op, init_val, shape, dtype, dims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReduceGrad(self, op, init_val, shape, dtype, dims, rng_factory):
+    rng = rng_factory()
     if jtu.device_under_test() == "tpu" and op is lax.mul:
       raise SkipTest("unimplemented case")
     tol = gradient_tolerance(
@@ -2158,16 +2241,17 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       {"testcase_name": "_op={}_dtype={}_padding={}"
        .format(op.__name__, onp.dtype(dtype).name, padding),
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for init_val, op, dtypes, rng in [
-          (0, lax.add, float_dtypes, jtu.rand_small()),
-          (-onp.inf, lax.max, [onp.float32], jtu.rand_default()),
-          (onp.inf, lax.min, [onp.float32], jtu.rand_default()),
+          (0, lax.add, float_dtypes, jtu.rand_small),
+          (-onp.inf, lax.max, [onp.float32], jtu.rand_default),
+          (onp.inf, lax.min, [onp.float32], jtu.rand_default),
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]
-      for rng in [jtu.rand_default()]))
-  def testReduceWindowGrad(self, op, init_val, dtype, padding, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReduceWindowGrad(self, op, init_val, dtype, padding, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-3})
     init_val = onp.asarray(init_val, dtype=dtype)
 
@@ -2213,12 +2297,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng": rng, "shape": shape, "dtype": dtype, "axis": axis}
+       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
       for dtype in [onp.float32]
       for shape in [(5,), (5, 7)]
       for axis in [len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSortGrad(self, shape, dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSortGrad(self, shape, dtype, axis, rng_factory):
+    rng = rng_factory()
     tol = gradient_tolerance(dtype, {onp.float32: 1e-3})
     operand = rng(shape, dtype)
     sort = lambda x: lax.sort(x, axis)
@@ -2230,14 +2315,15 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, key_dtype),
           jtu.format_shape_dtype_string(shape, val_dtype),
           axis),
-       "rng": rng, "shape": shape,
+       "rng_factory": rng_factory, "shape": shape,
        "key_dtype": key_dtype, "val_dtype": val_dtype, "axis": axis}
       for key_dtype in [onp.float32]
       for val_dtype in [onp.float32]
       for shape in [(3,), (5, 3)]
       for axis in [len(shape) - 1]
-      for rng in [jtu.rand_default()]))
-  def testSortKeyValGrad(self, shape, key_dtype, val_dtype, axis, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSortKeyValGrad(self, shape, key_dtype, val_dtype, axis, rng_factory):
+    rng = rng_factory()
     # This test relies on the property that wherever keys are tied, values are
     # too, since we don't guarantee the same ordering of values with equal keys.
     # To avoid that case, we generate unique keys (globally in the key array).
@@ -2255,7 +2341,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_idxs={}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), idxs, axes),
-       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes, "rng": rng}
+       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes,
+       "rng_factory": rng_factory}
       for dtype in float_dtypes
       for shape, idxs, axes in [
           [(3, 4, 5), (onp.array([0, 2, 1]),), (0,)],
@@ -2263,8 +2350,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           [(3, 4, 5), (onp.array([0, 2]), onp.array([1, 3])), (0, 1)],
           [(3, 4, 5), (onp.array([0, 2]), onp.array([1, 3])), (0, 2)],
       ]
-      for rng in [jtu.rand_default()]))
-  def testIndexTakeGrad(self, shape, dtype, idxs, axes, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testIndexTakeGrad(self, shape, dtype, idxs, axes, rng_factory):
+    rng = rng_factory()
     src = rng(shape, dtype)
     index_take = lambda src: lax.index_take(src, idxs, axes)
     check_grads(index_take, (src,), 2, ["fwd", "rev"], 1e-2, 1e-2, 1)
@@ -2274,7 +2362,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), idxs, dnums,
           slice_sizes),
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng": rng, "rng_idx": rng_idx}
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for shape, idxs, dnums, slice_sizes in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
@@ -2287,9 +2376,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
             (1, 3)),
       ]
-      for rng_idx in [jtu.rand_int(max(shape))]
-      for rng in [jtu.rand_default()]))
-  def testGatherGrad(self, shape, dtype, idxs, dnums, slice_sizes, rng, rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testGatherGrad(self, shape, dtype, idxs, dnums, slice_sizes, rng_factory,
+                     rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     idxs = rng_idx(idxs.shape, idxs.dtype)
     gather = lambda x: lax.gather(x, idxs, dimension_numbers=dnums,
                                   slice_sizes=slice_sizes)
@@ -2301,8 +2393,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -2315,10 +2407,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatterAddGrad(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                         rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterAddGrad(self, arg_shape, dtype, idxs, update_shape, dnums,
+                         rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     idxs = rng_idx(idxs.shape, idxs.dtype)
     scatter_add = lambda x, y: lax.scatter_add(x, idxs, y,
                                                dimension_numbers=dnums)
@@ -2331,8 +2425,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, dtype),
           idxs, update_shape, dnums),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "rng": rng,
-       "rng_idx": rng_idx}
+       "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
+       "rng_idx_factory": rng_idx_factory}
       for dtype in float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -2345,10 +2439,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for rng_idx in [jtu.rand_int(max(arg_shape))]
-      for rng in [jtu.rand_default()]))
-  def testScatterGrad(self, arg_shape, dtype, idxs, update_shape, dnums, rng,
-                         rng_idx):
+      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterGrad(self, arg_shape, dtype, idxs, update_shape, dnums,
+                      rng_factory, rng_idx_factory):
+    rng = rng_factory()
+    rng_idx = rng_idx_factory()
     idxs = rng_idx(idxs.shape, idxs.dtype)
     scatter = lambda x, y: lax.scatter(x, idxs, y, dimension_numbers=dnums)
     x = rng(arg_shape, dtype)
@@ -2428,14 +2524,15 @@ class LaxVmapTest(jtu.JaxTestCase):
         {"testcase_name": "{}_bdims={}".format(
             jtu.format_test_name_suffix(rec.op, shapes,
                                         itertools.repeat(dtype)), bdims),
-         "op_name": rec.op, "rng": rec.rng, "shapes": shapes, "dtype": dtype,
-         "bdims": bdims}
+         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
+         "dtype": dtype, "bdims": bdims}
         for shape_group in compatible_shapes
         for shapes in CombosWithReplacement(shape_group, rec.nargs)
         for bdims in all_bdims(*shapes)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
-  def testOp(self, op_name, rng, shapes, dtype, bdims):
+  def testOp(self, op_name, rng_factory, shapes, dtype, bdims):
+    rng = rng_factory()
     op = getattr(lax, op_name)
     tol = tolerance(dtype)
     self._CheckBatching(op, 10, bdims, shapes, dtype, rng, tol, tol)
@@ -2450,7 +2547,7 @@ class LaxVmapTest(jtu.JaxTestCase):
                feature_group_count, lhs_bdim, rhs_bdim),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
-       "rhs_dil": rhs_dil, "rng": rng, "dimension_numbers": dim_nums,
+       "rhs_dil": rhs_dil, "rng_factory": rng_factory, "dimension_numbers": dim_nums,
        "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim,
        "feature_group_count": feature_group_count}
       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
@@ -2474,13 +2571,14 @@ class LaxVmapTest(jtu.JaxTestCase):
       for lhs_bdim in itertools.chain([None], range(len(lhs_shape) + 1))
       for rhs_bdim in itertools.chain([None], range(len(rhs_shape) + 1))
       if (lhs_bdim, rhs_bdim) != (None, None)
-      for rng in [jtu.rand_default()]
+      for rng_factory in [jtu.rand_default]
   ))
   # TODO(mattjj): some cases fail on TPU just due to numerical tolerances
   @jtu.skip_on_devices("tpu")
   def testConvGeneralDilatedBatching(
       self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dil, rhs_dil,
-      dimension_numbers, perms, feature_group_count, lhs_bdim, rhs_bdim, rng):
+      dimension_numbers, perms, feature_group_count, lhs_bdim, rhs_bdim, rng_factory):
+    rng = rng_factory()
     tol = 1e-1 if onp.finfo(dtype).bits <= 32 else 1e-3
 
     # permute shapes to match dim_spec, scale by feature_group_count
@@ -2503,13 +2601,14 @@ class LaxVmapTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_from_dtype={}_to_dtype={}_bdims={}".format(
           shape, from_dtype, to_dtype, bdims),
        "shape": shape, "from_dtype": from_dtype, "to_dtype": to_dtype,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
       for shape in [(2, 3)]
       for bdims in all_bdims(shape)
-      for rng in [jtu.rand_default()]))
-  def testConvertElementType(self, shape, from_dtype, to_dtype, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testConvertElementType(self, shape, from_dtype, to_dtype, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.convert_element_type(x, to_dtype)
     self._CheckBatching(op, 10, bdims, (shape,), from_dtype, rng)
 
@@ -2517,13 +2616,14 @@ class LaxVmapTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_from_dtype={}_to_dtype={}_bdims={}".format(
           shape, from_dtype, to_dtype, bdims),
        "shape": shape, "from_dtype": from_dtype, "to_dtype": to_dtype,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
           [onp.float32, onp.int32, "float32", "int32"], repeat=2)
       for shape in [(2, 3)]
       for bdims in all_bdims(shape)
-      for rng in [jtu.rand_default()]))
-  def testBitcastElementType(self, shape, from_dtype, to_dtype, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBitcastElementType(self, shape, from_dtype, to_dtype, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     self._CheckBatching(op, 10, bdims, (shape,), from_dtype, rng)
 
@@ -2534,7 +2634,7 @@ class LaxVmapTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(max_shape, dtype),
                bdims),
        "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "bdims": bdims, "rng": rng}
+       "max_shape": max_shape, "dtype": dtype, "bdims": bdims, "rng_factory": rng_factory}
       for min_shape, operand_shape, max_shape in [
           [(), (2, 3), ()],
           [(2, 3), (2, 3), ()],
@@ -2543,8 +2643,9 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for dtype in default_dtypes
       for bdims in all_bdims(min_shape, operand_shape, max_shape)
-      for rng in [jtu.rand_default()]))
-  def testClamp(self, min_shape, operand_shape, max_shape, dtype, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testClamp(self, min_shape, operand_shape, max_shape, dtype, bdims, rng_factory):
+    rng = rng_factory()
     raise SkipTest("batching rule for clamp not implemented")  # TODO(mattj)
     shapes = [min_shape, operand_shape, max_shape]
     self._CheckBatching(lax.clamp, 10, bdims, shapes, dtype, rng)
@@ -2555,12 +2656,13 @@ class LaxVmapTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(rhs_shape, dtype),
           bdims),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
       for bdims in all_bdims(lhs_shape, rhs_shape)
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testDot(self, lhs_shape, rhs_shape, dtype, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testDot(self, lhs_shape, rhs_shape, dtype, bdims, rng_factory):
+    rng = rng_factory()
     self._CheckBatching(lax.dot, 5, bdims, (lhs_shape, rhs_shape), dtype, rng,
                         rtol=tolerance(dtype, {onp.float16: 5e-2}))
 
@@ -2572,7 +2674,7 @@ class LaxVmapTest(jtu.JaxTestCase):
                lhs_contracting, rhs_contracting, bdims),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, lhs_contracting, rhs_contracting in [
           [(3, 5), (2, 5), [1], [1]],
           [(5, 3), (5, 2), [0], [0]],
@@ -2583,9 +2685,10 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for bdims in all_bdims(lhs_shape, rhs_shape)
       for dtype in default_dtypes
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractOnly(self, lhs_shape, rhs_shape, dtype,
-                                 lhs_contracting, rhs_contracting, bdims, rng):
+                                 lhs_contracting, rhs_contracting, bdims, rng_factory):
+    rng = rng_factory()
     dimension_numbers = ((lhs_contracting, rhs_contracting), ([], []))
     dot = partial(lax.dot_general, dimension_numbers=dimension_numbers)
     self._CheckBatching(dot, 5, bdims, (lhs_shape, rhs_shape), dtype, rng)
@@ -2597,16 +2700,17 @@ class LaxVmapTest(jtu.JaxTestCase):
                jtu.format_shape_dtype_string(rhs_shape, dtype),
                dimension_numbers, bdims),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "bdims": bdims, "rng": rng}
+       "dimension_numbers": dimension_numbers, "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for bdims in all_bdims(lhs_shape, rhs_shape)
       for dtype in default_dtypes
-      for rng in [jtu.rand_small()]))
+      for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
-                                     dimension_numbers, bdims, rng):
+                                     dimension_numbers, bdims, rng_factory):
+    rng = rng_factory()
     dot = partial(lax.dot_general, dimension_numbers=dimension_numbers)
     self._CheckBatching(dot, 5, bdims, (lhs_shape, rhs_shape), dtype, rng)
 
@@ -2614,13 +2718,14 @@ class LaxVmapTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}_bdims={}".format(
           shape, onp.dtype(dtype).name, broadcast_sizes, bdims),
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
       for dtype in default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
       for bdims in all_bdims(shape)
-      for rng in [jtu.rand_default()]))
-  def testBroadcast(self, shape, dtype, broadcast_sizes, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcast(self, shape, dtype, broadcast_sizes, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.broadcast(x, broadcast_sizes)
     self._CheckBatching(op, 5, bdims, (shape,), dtype, rng)
 
@@ -2629,7 +2734,8 @@ class LaxVmapTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(inshape, dtype),
           outshape, broadcast_dimensions, bdims),
        "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "bdims": bdims, "rng": rng}
+       "dimensions": broadcast_dimensions, "bdims": bdims,
+       "rng_factory": rng_factory}
       for inshape, outshape, broadcast_dimensions in [
           ([2], [2, 2], [0]),
           ([2], [2, 2], [1]),
@@ -2638,8 +2744,9 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for dtype in default_dtypes
       for bdims in all_bdims(inshape)
-      for rng in [jtu.rand_default()]))
-  def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, bdims, rng_factory):
+    rng = rng_factory()
     raise SkipTest("this test has failures in some cases")  # TODO(mattjj)
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     self._CheckBatching(op, 5, bdims, (inshape,), dtype, rng)
@@ -2650,7 +2757,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype),
           dimensions, bdims),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "dimensions": dimensions, "bdims": bdims, "rng": rng}
+       "dimensions": dimensions, "bdims": bdims, "rng_factory": rng_factory}
       for dtype in default_dtypes
       for arg_shape, dimensions, out_shape in [
           [(3, 4), None, (12,)],
@@ -2661,21 +2768,23 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(2, 2, 4), (2, 1, 0), (4, 2, 2)]
       ]
       for bdims in all_bdims(arg_shape)
-      for rng in [jtu.rand_default()]))
-  def testReshape(self, arg_shape, out_shape, dtype, dimensions, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testReshape(self, arg_shape, out_shape, dtype, dimensions, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.reshape(x, out_shape, dimensions=dimensions)
     self._CheckBatching(op, 10, bdims, (arg_shape,), dtype, rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_pads={}_bdims={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads, bdims),
-       "shape": shape, "dtype": dtype, "pads": pads, "rng": jtu.rand_small(),
-       "bdims": bdims}
+       "shape": shape, "dtype": dtype, "pads": pads,
+       "rng_factory": jtu.rand_small, "bdims": bdims}
       for shape in [(2, 3)]
       for bdims in all_bdims(shape)
       for dtype in default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
-  def testPad(self, shape, dtype, pads, bdims, rng):
+  def testPad(self, shape, dtype, pads, bdims, rng_factory):
+    rng = rng_factory()
     fun = lambda operand: lax.pad(operand, onp.array(0, dtype), pads)
     self._CheckBatching(fun, 5, bdims, (shape,), dtype, rng)
 
@@ -2685,13 +2794,14 @@ class LaxVmapTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(arg_shape, arg_dtype),
           bdims),
        "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
-       "bdims": bdims, "rng": rng}
+       "bdims": bdims, "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
       for bdims in all_bdims(pred_shape, arg_shape, arg_shape)
       for arg_dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSelect(self, pred_shape, arg_shape, arg_dtype, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSelect(self, pred_shape, arg_shape, arg_dtype, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda c, x, y: lax.select(c < 0, x, y)
     self._CheckBatching(op, 5, bdims, (pred_shape, arg_shape, arg_shape,),
                         arg_dtype, rng)
@@ -2702,7 +2812,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           start_indices, limit_indices, strides, bdims),
        "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "bdims": bdims, "rng": rng}
+       "limits": limit_indices, "strides": strides, "bdims": bdims, "rng_factory": rng_factory}
       for shape, start_indices, limit_indices, strides in [
         [(3,), (1,), (2,), None],
         [(7,), (4,), (7,), None],
@@ -2716,15 +2826,16 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for bdims in all_bdims(shape)
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testSlice(self, shape, dtype, starts, limits, strides, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSlice(self, shape, dtype, starts, limits, strides, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.slice(x, starts, limits, strides)
     self._CheckBatching(op, 5, bdims, (shape,), dtype, rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_perm={}_bdims={}".format(
           jtu.format_shape_dtype_string(shape, dtype), perm, bdims),
-       "shape": shape, "dtype": dtype, "perm": perm, "bdims": bdims, "rng": rng}
+       "shape": shape, "dtype": dtype, "perm": perm, "bdims": bdims, "rng_factory": rng_factory}
       for shape, perm in [
         [(3, 4), (1, 0)],
         [(3, 4), (0, 1)],
@@ -2733,8 +2844,9 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for bdims in all_bdims(shape)
       for dtype in default_dtypes
-      for rng in [jtu.rand_default()]))
-  def testTranspose(self, shape, dtype, perm, bdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testTranspose(self, shape, dtype, perm, bdims, rng_factory):
+    rng = rng_factory()
     op = lambda x: lax.transpose(x, perm)
     self._CheckBatching(op, 5, bdims, (shape,), dtype, rng)
 
@@ -2743,7 +2855,7 @@ class LaxVmapTest(jtu.JaxTestCase):
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims,
                init_val, bdims),
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
-       "dims": dims, "bdims": bdims, "rng": rng}
+       "dims": dims, "bdims": bdims, "rng_factory": rng_factory}
       for init_val, op, dtypes in [
           (0, lax.add, default_dtypes),
           (1, lax.mul, default_dtypes),
@@ -2765,8 +2877,9 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(3, 4, 5), (0, 2)], [(3, 4, 5), (0, 1, 2)]
       ]
       for bdims in all_bdims(shape)
-      for rng in [jtu.rand_small()]))
-  def testReduce(self, op, init_val, shape, dtype, dims, bdims, rng):
+      for rng_factory in [jtu.rand_small]))
+  def testReduce(self, op, init_val, shape, dtype, dims, bdims, rng_factory):
+    rng = rng_factory()
     init_val = onp.asarray(init_val, dtype=dtype)
     fun = lambda operand: lax.reduce(operand, init_val, op, dims)
     self._CheckBatching(fun, 5, bdims, (shape,), dtype, rng)
@@ -2775,7 +2888,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       {"testcase_name": "_op={}_dtype={}_padding={}"
        .format(op.__name__, onp.dtype(dtype).name, padding),
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for init_val, op, dtypes in [
           (0, lax.add, [onp.float32]),
           (-onp.inf, lax.max, [onp.float32]),
@@ -2783,8 +2896,9 @@ class LaxVmapTest(jtu.JaxTestCase):
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]
-      for rng in [jtu.rand_small()]))
-  def testReduceWindow(self, op, init_val, dtype, padding, rng):
+      for rng_factory in [jtu.rand_small]))
+  def testReduceWindow(self, op, init_val, dtype, padding, rng_factory):
+    rng = rng_factory()
     init_val = onp.asarray(init_val, dtype=dtype)
 
     all_configs = itertools.chain(
@@ -2806,13 +2920,14 @@ class LaxVmapTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_bdims={}_fft_ndims={}"
        .format(shape, bdims, fft_ndims),
-       "shape": shape, "bdims": bdims, "fft_ndims": fft_ndims, "rng": rng}
+       "shape": shape, "bdims": bdims, "fft_ndims": fft_ndims, "rng_factory": rng_factory}
       for shape in [(5,), (3, 4, 5), (2, 3, 4, 5)]
       for bdims in all_bdims(shape)
       for fft_ndims in range(0, min(3, len(shape)) + 1)
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(b/137993701): unimplemented cases.
-  def testFft(self, fft_ndims, shape, bdims, rng):
+  def testFft(self, fft_ndims, shape, bdims, rng_factory):
+    rng = rng_factory()
     ndims = len(shape)
     axes = range(ndims - fft_ndims, ndims)
     fft_lengths = [shape[axis] for axis in axes]

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -61,11 +61,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (1000, 0, 0)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testCholesky(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testCholesky(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     def args_maker():
       factor_shape = shape[:-1] + (2 * shape[-1],)
@@ -86,11 +87,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
-       "n": n, "dtype": dtype, "rng": rng}
+       "n": n, "dtype": dtype, "rng_factory": rng_factory}
       for n in [0, 4, 5, 25]  # TODO(mattjj): complex64 unstable on large sizes?
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testDet(self, n, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testDet(self, n, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng((n, n), dtype)]
 
@@ -105,13 +107,14 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(0, 0), (1, 1), (3, 3), (4, 4), (10, 10), (200, 200),
                     (2, 2, 2), (2, 3, 3), (3, 2, 2)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")
-  def testSlogdet(self, shape, dtype, rng):
+  def testSlogdet(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
 
@@ -122,12 +125,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 4), (5, 5), (2, 7, 7)]
       for dtype in float_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")
-  def testSlogdetGrad(self, shape, dtype, rng):
+  def testSlogdetGrad(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     a = rng(shape, dtype)
     jtu.check_grads(np.linalg.slogdet, (a,), 2, atol=1e-1, rtol=1e-1)
@@ -142,14 +146,15 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}".format(
            jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(0, 0), (4, 4), (5, 5), (50, 50), (2, 6, 6)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   # TODO(phawkins): enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.skip_on_devices("gpu", "tpu")
-  def testEig(self, shape, dtype, rng):
+  def testEig(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     n = shape[-1]
     args_maker = lambda: [rng(shape, dtype)]
@@ -169,14 +174,15 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}".format(
            jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(4, 4), (5, 5), (50, 50)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   # TODO: enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.skip_on_devices("gpu", "tpu")
-  def testEigvals(self, shape, dtype, rng):
+  def testEigvals(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     n = shape[-1]
     args_maker = lambda: [rng(shape, dtype)]
@@ -188,12 +194,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 4), (5, 5)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("gpu", "tpu")
-  def testEigBatching(self, shape, dtype, rng):
+  def testEigBatching(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     shape = (10,) + shape
     args = rng(shape, dtype)
@@ -204,12 +211,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_n={}_lower={}".format(
            jtu.format_shape_dtype_string((n,n), dtype), lower),
-       "n": n, "dtype": dtype, "lower": lower, "rng": rng}
+       "n": n, "dtype": dtype, "lower": lower, "rng_factory": rng_factory}
       for n in [0, 4, 5, 50]
       for dtype in float_types + complex_types
       for lower in [False, True]
-      for rng in [jtu.rand_default()]))
-  def testEigh(self, n, dtype, lower, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testEigh(self, n, dtype, lower, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     tol = 30
     if jtu.device_under_test() == "tpu":
@@ -239,11 +247,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}".format(
            jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(4, 4), (5, 5), (50, 50)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testEigvalsh(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testEigvalsh(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if jtu.device_under_test() == "tpu":
       if np.issubdtype(dtype, np.complexfloating):
@@ -260,12 +269,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name":
        "_shape={}_lower={}".format(jtu.format_shape_dtype_string(shape, dtype),
                                    lower),
-       "shape": shape, "dtype": dtype, "rng": rng, "lower":lower}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "lower":lower}
       for shape in [(1, 1), (4, 4), (5, 5), (50, 50), (2, 10, 10)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]
+      for rng_factory in [jtu.rand_default]
       for lower in [True, False]))
-  def testEighGrad(self, shape, dtype, rng, lower):
+  def testEighGrad(self, shape, dtype, rng_factory, lower):
+    rng = rng_factory()
     self.skipTest("Test fails with numeric errors.")
     uplo = "L" if lower else "U"
     a = rng(shape, dtype)
@@ -285,16 +295,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name":
        "_shape={}_lower={}".format(jtu.format_shape_dtype_string(shape, dtype),
                                    lower),
-       "shape": shape, "dtype": dtype, "rng": rng, "lower":lower, "eps":eps}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "lower":lower, "eps":eps}
       for shape in [(1, 1), (4, 4), (5, 5), (50, 50)]
       for dtype in complex_types
-      for rng in [jtu.rand_default()]
+      for rng_factory in [jtu.rand_default]
       for lower in [True, False]
       for eps in [1e-4]))
   # TODO(phawkins): enable when there is a complex eigendecomposition
   # implementation for TPU.
   @jtu.skip_on_devices("tpu")
-  def testEighGradVectorComplex(self, shape, dtype, rng, lower, eps):
+  def testEighGradVectorComplex(self, shape, dtype, rng_factory, lower, eps):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     # Special case to test for complex eigenvector grad correctness.
     # Exact eigenvector coordinate gradients are hard to test numerically for complex
@@ -327,11 +338,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 4), (5, 5)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testEighBatching(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testEighBatching(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if (jtu.device_under_test() == "tpu" and
         np.issubdtype(dtype, onp.complexfloating)):
@@ -347,7 +359,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_ord={}_axis={}_keepdims={}".format(
          jtu.format_shape_dtype_string(shape, dtype), ord, axis, keepdims),
        "shape": shape, "dtype": dtype, "axis": axis, "keepdims": keepdims,
-       "ord": ord, "rng": rng}
+       "ord": ord, "rng_factory": rng_factory}
       for axis, shape in [
         (None, (1,)), (None, (7,)), (None, (5, 8)),
         (0, (9,)), (0, (4, 5)), ((1,), (10, 7, 3)), ((-2,), (4, 8)),
@@ -362,8 +374,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
              (isinstance(axis, tuple) and len(axis) == 1)
           else [None, 'fro', 1, 2, -1, -2, np.inf, -np.inf, 'nuc'])
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testNorm(self, shape, dtype, ord, axis, keepdims, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testNorm(self, shape, dtype, ord, axis, keepdims, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if (ord in ('nuc', 2, -2) and (
         jtu.device_under_test() != "cpu" or
@@ -384,16 +397,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(b + (m, n), dtype), full_matrices,
           compute_uv),
        "b": b, "m": m, "n": n, "dtype": dtype, "full_matrices": full_matrices,
-       "compute_uv": compute_uv, "rng": rng}
+       "compute_uv": compute_uv, "rng_factory": rng_factory}
       for b in [(), (3,), (2, 3)]
       for m in [2, 7, 29, 53]
       for n in [2, 7, 29, 53]
       for dtype in float_types + complex_types
       for full_matrices in [False, True]
       for compute_uv in [False, True]
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")
-  def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, rng):
+  def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if b != () and jax.lib.version <= (0, 1, 28):
       raise unittest.SkipTest("Batched SVD requires jaxlib 0.1.29")
@@ -440,12 +454,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_fullmatrices={}".format(
           jtu.format_shape_dtype_string(shape, dtype), full_matrices),
        "shape": shape, "dtype": dtype, "full_matrices": full_matrices,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for shape in [(1, 1), (3, 3), (3, 4), (2, 10, 5), (2, 200, 100)]
       for dtype in float_types + complex_types
       for full_matrices in [False, True]
-      for rng in [jtu.rand_default()]))
-  def testQr(self, shape, dtype, full_matrices, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testQr(self, shape, dtype, full_matrices, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if (np.issubdtype(dtype, onp.complexfloating) and
         (jtu.device_under_test() == "tpu" or jax.lib.version <= (0, 1, 27))):
@@ -499,11 +514,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for shape in [(10, 4, 5), (5, 3, 3), (7, 6, 4)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testQrBatching(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testQrBatching(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     args = rng(shape, np.float32)
     qs, rs = vmap(jsp.linalg.qr)(args)
     self.assertTrue(onp.all(onp.linalg.norm(args - onp.matmul(qs, rs)) < 1e-3))
@@ -514,7 +530,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype)),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rng": rng}
+       "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((1, 1), (1, 1)),
           ((4, 4), (4,)),
@@ -523,8 +539,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
           ((2, 1, 3, 3), (2, 4, 3, 4)),
       ]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testSolve(self, lhs_shape, rhs_shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSolve(self, lhs_shape, rhs_shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
@@ -535,11 +552,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (5, 5, 5)]
       for dtype in float_types
-      for rng in [jtu.rand_default()]))
-  def testInv(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testInv(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if jtu.device_under_test() == "gpu" and shape == (200, 200):
       raise unittest.SkipTest("Test is flaky on GPU")
@@ -601,11 +619,12 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 5), (10, 5), (50, 50)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testLu(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testLu(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     x, = args_maker()
@@ -621,12 +640,13 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(1, 1), (4, 5), (10, 5), (10, 10), (6, 7, 7)]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): precision problems on TPU.
-  def testLuGrad(self, shape, dtype, rng):
+  def testLuGrad(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     a = rng(shape, dtype)
     lu = vmap(jsp.linalg.lu) if len(shape) > 2 else jsp.linalg.lu
@@ -635,11 +655,12 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype, "rng": rng}
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
       for shape in [(4, 5), (6, 5)]
       for dtype in [np.float32]
-      for rng in [jtu.rand_default()]))
-  def testLuBatching(self, shape, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testLuBatching(self, shape, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args = [rng(shape, np.float32) for _ in range(10)]
     expected = list(osp.linalg.lu(x) for x in args)
@@ -655,11 +676,12 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
-       "n": n, "dtype": dtype, "rng": rng}
+       "n": n, "dtype": dtype, "rng_factory": rng_factory}
       for n in [1, 4, 5, 200]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testLuFactor(self, n, dtype, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testLuFactor(self, n, dtype, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng((n, n), dtype)]
 
@@ -679,7 +701,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(rhs_shape, dtype),
            trans),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "trans": trans, "rng": rng}
+       "trans": trans, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((1, 1), (1, 1)),
           ((4, 4), (4,)),
@@ -687,8 +709,9 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       ]
       for trans in [0, 1, 2]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testLuSolve(self, lhs_shape, rhs_shape, dtype, trans, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testLuSolve(self, lhs_shape, rhs_shape, dtype, trans, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     osp_fun = lambda lu, piv, rhs: osp.linalg.lu_solve((lu, piv), rhs, trans=trans)
     jsp_fun = lambda lu, piv, rhs: jsp.linalg.lu_solve((lu, piv), rhs, trans=trans)
@@ -709,7 +732,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
            jtu.format_shape_dtype_string(rhs_shape, dtype),
            sym_pos, lower),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "sym_pos": sym_pos, "lower": lower, "rng": rng}
+       "sym_pos": sym_pos, "lower": lower, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((1, 1), (1, 1)),
           ((4, 4), (4,)),
@@ -721,8 +744,9 @@ class ScipyLinalgTest(jtu.JaxTestCase):
         (True, True),
       ]
       for dtype in float_types + complex_types
-      for rng in [jtu.rand_default()]))
-  def testSolve(self, lhs_shape, rhs_shape, dtype, sym_pos, lower, rng):
+      for rng_factory in [jtu.rand_default]))
+  def testSolve(self, lhs_shape, rhs_shape, dtype, sym_pos, lower, rng_factory):
+    rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     if (sym_pos and np.issubdtype(dtype, onp.complexfloating) and
         jtu.device_under_test() == "tpu"):
@@ -750,7 +774,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
            lower, transpose_a, unit_diagonal),
        "lower": lower, "transpose_a": transpose_a,
        "unit_diagonal": unit_diagonal, "lhs_shape": lhs_shape,
-       "rhs_shape": rhs_shape, "dtype": dtype, "rng": rng}
+       "rhs_shape": rhs_shape, "dtype": dtype, "rng_factory": rng_factory}
       for lower in [False, True]
       for transpose_a in [False, True]
       for unit_diagonal in [False, True]
@@ -760,10 +784,11 @@ class ScipyLinalgTest(jtu.JaxTestCase):
           ((2, 8, 8), (2, 8, 10)),
       ]
       for dtype in float_types
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   def testSolveTriangular(self, lower, transpose_a, unit_diagonal, lhs_shape,
-                          rhs_shape, dtype, rng):
+                          rhs_shape, dtype, rng_factory):
     _skip_if_unsupported_type(dtype)
+    rng = rng_factory()
     k = rng(lhs_shape, dtype)
     l = onp.linalg.cholesky(onp.matmul(k, T(k))
                             + lhs_shape[-1] * onp.eye(lhs_shape[-1]))
@@ -798,7 +823,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
            lower, transpose_a, conjugate_a, unit_diagonal, left_side),
        "lower": lower, "transpose_a": transpose_a, "conjugate_a": conjugate_a,
        "unit_diagonal": unit_diagonal, "left_side": left_side,
-       "a_shape": a_shape, "b_shape": b_shape, "dtype": dtype, "rng": rng}
+       "a_shape": a_shape, "b_shape": b_shape, "dtype": dtype,
+       "rng_factory": rng_factory}
       for lower in [False, True]
       for unit_diagonal in [False, True]
       for dtype in float_types + complex_types
@@ -812,12 +838,13 @@ class ScipyLinalgTest(jtu.JaxTestCase):
           (True, (4, 4), (4, 3)),
           (True, (2, 8, 8), (2, 8, 10)),
       ]
-      for rng in [jtu.rand_default()]))
+      for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): Test fails on TPU.
   def testTriangularSolveGrad(
       self, lower, transpose_a, conjugate_a, unit_diagonal, left_side, a_shape,
-      b_shape, dtype, rng):
+      b_shape, dtype, rng_factory):
     _skip_if_unsupported_type(dtype)
+    rng = rng_factory()
     # Test lax_linalg.triangular_solve instead of scipy.linalg.solve_triangular
     # because it exposes more options.
     A = np.tril(rng(a_shape, dtype) + 5 * onp.eye(a_shape[-1], dtype=dtype))

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -39,11 +39,11 @@ float_dtypes = [onp.float32, onp.float64]
 
 CombosWithReplacement = itertools.combinations_with_replacement
 
-def genNamedParametersNArgs(n, rng):
+def genNamedParametersNArgs(n, rng_factory):
     return parameterized.named_parameters(
         jtu.cases_from_list(
           {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
-            "rng": rng, "shapes": shapes, "dtypes": dtypes}
+            "rng_factory": rng_factory, "shapes": shapes, "dtypes": dtypes}
           for shapes in CombosWithReplacement(all_shapes, n)
           for dtypes in CombosWithReplacement(float_dtypes, n)))
 
@@ -51,8 +51,9 @@ def genNamedParametersNArgs(n, rng):
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
   """Tests for LAX-backed scipy.stats implementations"""
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testPoissonLogPmf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testPoissonLogPmf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.poisson.logpmf
     lax_fun = lsp_stats.poisson.logpmf
 
@@ -68,8 +69,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testBernoulliLogPmf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testBernoulliLogPmf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.bernoulli.logpmf
     lax_fun = lsp_stats.bernoulli.logpmf
 
@@ -84,8 +86,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(5, jtu.rand_positive())
-  def testBetaLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(5, jtu.rand_positive)
+  def testBetaLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.beta.logpdf
     lax_fun = lsp_stats.beta.logpdf
 
@@ -97,8 +100,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testCauchyLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testCauchyLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.cauchy.logpdf
     lax_fun = lsp_stats.cauchy.logpdf
 
@@ -111,8 +115,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(2, jtu.rand_positive())
-  def testDirichletLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(2, jtu.rand_positive)
+  def testDirichletLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.cauchy.logpdf
     lax_fun = lsp_stats.cauchy.logpdf
     dim = 4
@@ -126,8 +131,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_positive())
-  def testExponLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_positive)
+  def testExponLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.expon.logpdf
     lax_fun = lsp_stats.expon.logpdf
 
@@ -138,8 +144,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(4, jtu.rand_positive())
-  def testGammaLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(4, jtu.rand_positive)
+  def testGammaLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.gamma.logpdf
     lax_fun = lsp_stats.gamma.logpdf
 
@@ -151,8 +158,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
                             tol=5e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_positive())
-  def testLaplaceLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_positive)
+  def testLaplaceLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.laplace.logpdf
     lax_fun = lsp_stats.laplace.logpdf
 
@@ -165,8 +173,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testLaplaceCdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testLaplaceCdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.laplace.cdf
     lax_fun = lsp_stats.laplace.cdf
 
@@ -180,8 +189,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   # TODO: currently it ignores the argument "shapes" and only tests dim=4
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testMultivariateNormalLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testMultivariateNormalLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.multivariate_normal.logpdf
     lax_fun = lsp_stats.multivariate_normal.logpdf
     dim = 4
@@ -196,8 +206,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testNormLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testNormLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.norm.logpdf
     lax_fun = lsp_stats.norm.logpdf
 
@@ -211,8 +222,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testNormLogCdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testNormLogCdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.norm.logcdf
     lax_fun = lsp_stats.norm.logcdf
 
@@ -226,8 +238,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testNormCdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testNormCdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.norm.cdf
     lax_fun = lsp_stats.norm.cdf
 
@@ -241,8 +254,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testNormPpf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testNormPpf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.norm.ppf
     lax_fun = lsp_stats.norm.ppf
 
@@ -258,8 +272,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(4, jtu.rand_positive())
-  def testParetoLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(4, jtu.rand_positive)
+  def testParetoLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.pareto.logpdf
     lax_fun = lsp_stats.pareto.logpdf
 
@@ -271,8 +286,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(4, jtu.rand_default())
-  def testTLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(4, jtu.rand_default)
+  def testTLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.t.logpdf
     lax_fun = lsp_stats.t.logpdf
 
@@ -286,8 +302,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
-  @genNamedParametersNArgs(3, jtu.rand_default())
-  def testUniformLogPdf(self, rng, shapes, dtypes):
+  @genNamedParametersNArgs(3, jtu.rand_default)
+  def testUniformLogPdf(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
     scipy_fun = osp_stats.uniform.logpdf
     lax_fun = lsp_stats.uniform.logpdf
 


### PR DESCRIPTION
Follows @hawkinsp's suggestion from #1632 to rewrite everything in terms of
RNG factories, creating actual RNG functions *inside* each test method instead
of when they are collected. This has the added bonus of making JAX's test suite
more reproducible, because you now get the same result regardless of how
many cases are run.

Also: use `onp.testing.assert_allclose` internally in jax.test_util, because it has
better error reporting than the existing helper functions.