### PR TITLE
make linspace, logspace, geomspace jittable and differentiable in start and stop args

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1677,6 +1677,7 @@ def arange(start, stop=None, step=None, dtype=None):
   # Fall back to instantiating an ndarray in host memory
   return onp.arange(start, stop=stop, step=step, dtype=dtype)
 
+
 def _wrap_numpy_nullary_function(f):
   """Adapts `f` to return a DeviceArray instead of an onp.ndarray.
 
@@ -1687,24 +1688,58 @@ def _wrap_numpy_nullary_function(f):
     return asarray(f(*args, **kwargs))
   return wrapper
 
+
+@_wraps(onp.linspace)
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
              axis=0):
+  """Implementation of linspace differentiable in start and stop args."""
   lax._check_user_dtype_supported(dtype, "linspace")
-  try:
-    out = onp.linspace(start, stop, num, endpoint, retstep, dtype, axis)
-    if retstep:
-      return asarray(out[0]), out[1]
-    else:
-      return asarray(out)
-  except TypeError:  # Old versions of onp may lack axis arg.
-    out = onp.linspace(start, stop, num, endpoint, retstep, dtype)
-    if retstep:
-      return moveaxis(asarray(out[0]), 0, axis), out[1]
-    else:
-      return moveaxis(asarray(out), 0, axis)
+  dtype = dtype or onp.result_type(start, stop, float(num))
+  bounds_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
+  broadcast_start = broadcast_to(start, bounds_shape)
+  axis = len(bounds_shape) + axis + 1 if axis < 0 else axis
+  bounds_shape.insert(axis, 1)
+  iota_shape = [1,] * len(bounds_shape)
+  iota_shape[axis] = num
+  if endpoint:
+    delta = (stop - start) / (num - 1)
+  else:
+    delta = (stop - start) / num
+  out = (reshape(broadcast_start, bounds_shape) +
+         reshape(lax.iota(dtype, num), iota_shape) *
+         reshape(delta, bounds_shape))
+  if retstep:
+    return lax.convert_element_type(out, dtype), delta
+  else:
+    return lax.convert_element_type(out, dtype)
 
-logspace = _wrap_numpy_nullary_function(onp.logspace)
-geomspace = _wrap_numpy_nullary_function(onp.geomspace)
+
+@_wraps(onp.logspace)
+def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, axis=0):
+  """Implementation of logspace differentiable in start and stop args."""
+  lin = linspace(start, stop, num,
+                 endpoint=endpoint, retstep=False, dtype=None, axis=axis)
+  if dtype is None:
+    return power(base, lin)
+  else:
+    return lax.convert_element_type(power(base, lin), dtype)
+
+
+@_wraps(onp.geomspace)
+def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
+  """Implementation of geomspace differentiable in start and stop args."""
+  dtype = dtype or onp.result_type(start, stop, float(num),
+                                   zeros((), dtype))
+  # follow the numpy geomspace convention for negative and complex endpoints
+  signflip = 1 - (1 - sign(real(start))) * (1 - sign(real(stop))) // 2
+  res = signflip * logspace(log10(signflip * start),
+                            log10(signflip * stop), num,
+                            endpoint=endpoint, base=10.0,
+                            dtype=dtype, axis=0)
+  if axis != 0:
+    res = moveaxis(res, 0, axis)
+  return lax.convert_element_type(res, dtype)
+
 
 @_wraps(onp.meshgrid)
 def meshgrid(*args, **kwargs):


### PR DESCRIPTION
Substitutes the previous simple onp wrapped versions of these functions with lax-lowered versions that can be used in jit and grad for derivatives in the start and stop args.  The only differences from the numpy reference functions concern the handling of denormal numbers in linspace and the cosmetic complex number rounding heuristic used in geomspace.  Fixes #1571 