### PR TITLE
Add tagging tracer and collect/inject transforms

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1971,7 +1971,7 @@ def collect(f, path_filter=lambda path: True, scope_argnum=0):
   ...   z = y + 1
   ...   return z
   >>> collect(foo)(2.)
-  (5., {"y": 4.})
+  (DeviceArray(5., dtype=float32), {'y': DeviceArray(4., dtype=float32)})
 
   >>> def bar(key, x):
   ...   y = lax.tag(random.normal(random.fold_in(key, "y")))
@@ -1981,7 +1981,8 @@ def collect(f, path_filter=lambda path: True, scope_argnum=0):
   ...   b = bar(random.fold_in(key, 2), x)
   ...   return a + b
   >>> collect(baz)(random.PRNGKey(0), 2.)
-  (4.2031232, {1: {"y": 0.723153976}, 2: {"y": 0.34818583}})
+  (DeviceArray(5.1561937, dtype=float32), {1: {'y': DeviceArray(0.2645052, dtype=float32)},
+  2: {'y': DeviceArray(0.8916887, dtype=float32)}})
   """
   fun = lu.wrap_init(f)
   def collect_fn(*args, **kwargs):
@@ -2019,7 +2020,7 @@ def inject(f, tree, accum_fn=lambda old, new: new, scope_argnum=0):
   ...   z = y + 1
   ...   return z
   >>> inject(foo, {"y": 1.})(2.)
-  2.
+  DeviceArray(2., dtype=float32)
 
   >>> def bar(key, x):
   ...   y = lax.tag(random.normal(random.fold_in(key, "y")))
@@ -2029,7 +2030,7 @@ def inject(f, tree, accum_fn=lambda old, new: new, scope_argnum=0):
   ...   b = bar(random.fold_in(key, 2), x)
   ...   return a + b
   >>> inject(baz, {1: {"y": 0.3}, 2: {"y": 0.5}})(random.PRNGKey(0), 2.)
-  4.8
+  DeviceArray(4.8, dtype=float32)
   """
   fun = lu.wrap_init(f)
   def inject_fn(*args, **kwargs):

--- a/jax/api.py
+++ b/jax/api.py
@@ -1989,7 +1989,7 @@ def collect(f, path_filter=lambda path: True, scope_argnum=0):
     flat_args, in_tree = tree_flatten((args, kwargs))
     flat_fun, out_tree = flatten_fun(fun, in_tree)
     paths = (None,) * scope_argnum + ((),) + (None,) * (len(flat_args) - scope_argnum - 1)
-    out_flat, _, tree = tagging.tag_fun(flat_fun, flat_args, paths, None, dict())
+    out_flat, tree = tagging.tag_fun(flat_fun, flat_args, paths, None, dict())
     tree = as_dict((path, val) for path, val in iterpaths(tree) if path_filter(path))
     return tree_unflatten(out_tree(), out_flat), tree
   return collect_fn
@@ -2037,7 +2037,7 @@ def inject(f, tree, accum_fn=lambda old, new: new, scope_argnum=0):
     flat_args, in_tree = tree_flatten((args, kwargs))
     flat_fun, out_tree = flatten_fun(fun, in_tree)
     paths = (None,) * scope_argnum + ((),) + (None,) * (len(flat_args) - scope_argnum - 1)
-    out_vals, _, _, = tagging.tag_fun(flat_fun, flat_args, paths, accum_fn, tree)
+    out_vals, _ = tagging.tag_fun(flat_fun, flat_args, paths, accum_fn, tree)
     return tree_unflatten(out_tree(), out_vals)
   return inject_fn
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -908,7 +908,7 @@ def soft_pmap(fun, axis_name=None, backend=None):
       msg = ("soft_pmap mapped axis size must be divisble by the number of "
              "XLA devices (or be less than or equal to that number), but got "
              "an axis size of {} with {} devices.")
-      raise ValueError(msg.format(axis_size, pxla.pxla.unmapped_device_count()))
+      raise ValueError(msg.format(axis_size, pxla.unmapped_device_count()))
     num_chunks = axis_size // chunk_size
 
     reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]

--- a/jax/dict_util.py
+++ b/jax/dict_util.py
@@ -1,0 +1,67 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for working with nested dictionaries as path-indexed containers.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools as it
+
+def maybe_set_dict(tree, path, val, accum_fn):
+  if len(path) == 0:
+    raise ValueError("cannot index nested dict with an empty path")
+  subtree = tree
+  for path_element in path[:-1]:
+    if path_element not in subtree:
+      if accum_fn is None:
+        subtree[path_element] = dict()
+      else:
+        return val
+    subtree = subtree[path_element]
+  if accum_fn is None: # storing, i.e. collect
+    if path[-1] in subtree:
+      raise RuntimeError("cannot store multiple values to the same nested dict path")
+    subtree[path[-1]] = val
+  elif path[-1] in subtree:
+    val = accum_fn(val, subtree[path[-1]])
+  return val
+
+def iterpaths(tree, prefix=()):
+  for key, val in tree.items():
+    path = prefix + (key,)
+    if isinstance(val, dict):
+      # TODO(jekbradbury): replace with `yield from` when Python 2 is dropped
+      for path2, val2 in iterpaths(val, path):
+        yield path2, val2
+    else:
+      yield path, val
+
+def as_dict(paths_and_values):
+  tree = dict()
+  for path, val in paths_and_values:
+    maybe_set_dict(tree, path, val, None)
+  return tree
+
+def dict_join(*trees):
+  """Union the contents of nested dictionaries.
+  
+  For example:
+
+  >>> dict_join({"a": 1, "b": {"c": 2}}, {"b": {"d": 3}})
+  {"a": 1, "b": {"c": 2, "d": 3}}
+  """
+  return as_dict(it.chain(*(iterpaths(tree) for tree in trees)))

--- a/jax/dict_util.py
+++ b/jax/dict_util.py
@@ -34,8 +34,10 @@ def maybe_set_dict(tree, path, val, accum_fn):
     subtree = subtree[path_element]
   if accum_fn is None: # storing, i.e. collect
     if path[-1] in subtree:
+      # Some users might want `val = subtree[path[-1]]` here?
       raise RuntimeError("cannot store multiple values to the same nested dict path")
-    subtree[path[-1]] = val
+    else:
+      subtree[path[-1]] = val
   elif path[-1] in subtree:
     val = accum_fn(val, subtree[path[-1]])
   return val

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -322,8 +322,6 @@ def join_pvals(pval1, pval2):
 def as_abstract_val(pv):
   if isinstance(pv, AbstractValue):
     return pv
-  elif isinstance(pv, JaxprTracerTuple):
-    return AbstractTuple(map(as_abstract_val, pv))
   elif pv is None:
     raise TypeError("{} is not abstract".format(pv))
 

--- a/jax/interpreters/tagging.py
+++ b/jax/interpreters/tagging.py
@@ -91,7 +91,7 @@ class TagTrace(core.Trace):
   def process_primitive(self, primitive, tracers, params):
     args, paths = unzip2((t.val, t.path) for t in tracers)
     tagging_rule = get_primitive_tagger(primitive)
-    out, out_path, is_sample = tagging_rule(args, paths)
+    out, out_path, is_sample = tagging_rule(args, paths, **params)
     if is_sample:
       assert not primitive.multiple_results
       out = self.maybe_set(out_path, out)

--- a/jax/interpreters/tagging.py
+++ b/jax/interpreters/tagging.py
@@ -1,0 +1,152 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tracer for tagging and manipulating a computation's intermediate values.
+
+This relies on two features added to the jaxpr language. First, JAX values can
+optionally carry a stack of tags as compile-time metadata, and the `push_tag`
+primitive can add a string or other Python value to this stack. Second, the
+`yield_value` primitive marks a value as a tagged intermediate that can be
+referenced and manipulated using its tag stack.
+
+Other primitives propagate their shortest argument path by default, except for 
+`tie_in`, which propagates the path of its first argument.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+
+import itertools as it
+
+import numpy as onp
+
+from .. import core
+from ..core import Trace, Tracer, new_master
+from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
+from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
+from ..linear_util import transformation, transformation_with_aux, wrap_init
+from ..dict_util import maybe_set_dict
+from ..util import unzip2, partial, safe_map
+from . import xla
+from . import partial_eval as pe
+
+map = safe_map
+
+yield_primitives = set()
+custom_tagging_rules = {}
+
+def _standard_tagging_rule(prim, args, paths, **params):
+  # propagate the shortest non-None path
+  paths = [path for path in paths if path is not None]
+  if len(paths) > 0:
+    out_path = min(paths, key=lambda path: len(path))
+  else:
+    out_path = None
+  out = prim.bind(*args, **params)
+  return out, out_path, (prim in yield_primitives)
+
+def get_primitive_tagger(p):
+  if p in custom_tagging_rules:
+    return custom_tagging_rules[p]
+  else:
+    return partial(_standard_tagging_rule, p)
+
+
+class TagTrace(core.Trace):
+
+  def __init__(self, master, sublevel, accum_fn, tree=None):
+    super(TagTrace, self).__init__(master, sublevel)
+    self.tree = dict() if tree is None else tree
+    self.accum_fn = accum_fn
+
+  def with_sublevel(self, sublevel):
+    return type(self)(self.master, sublevel, self.accum_fn, self.tree)
+
+  def pure(self, val):
+    return TagTracer(self, val, None)
+
+  def lift(self, val):
+    return TagTracer(self, val, None)
+
+  def sublift(self, val):
+    return TagTracer(self, val.val, val.path)
+
+  def maybe_set(self, path, val):
+    return maybe_set_dict(self.tree, path, val, self.accum_fn)
+
+  def process_primitive(self, primitive, tracers, params):
+    args, paths = unzip2((t.val, t.path) for t in tracers)
+    tagging_rule = get_primitive_tagger(primitive)
+    out, out_path, is_sample = tagging_rule(args, paths)
+    if is_sample:
+      assert not primitive.multiple_results
+      out = self.maybe_set(out_path, out)
+    if primitive.multiple_results:
+      return [TagTracer(self, val, out_path) for val in out]
+    else:
+      return TagTracer(self, out, out_path)
+
+  def process_call(self, call_primitive, f, tracers, params):
+    in_vals, in_paths = unzip2((t.val, t.path) for t in tracers)
+    f_key, out_paths = tag_subtrace(f, self, in_paths)
+    out_vals = call_primitive.bind(f_key, *in_vals, **params)
+    return [TagTracer(self, v, p) for v, p in zip(out_vals, out_paths())]
+
+  def process_map(self, map_primitive, f, tracers, params):
+    raise NotImplementedError
+
+  def post_process_call(self, call_primitive, out_tracers, params):
+    raise NotImplementedError
+
+class TagTracer(core.Tracer):
+  __slots__ = ['trace', 'val', 'path']
+
+  def __init__(self, trace, val, path):
+    self.trace = trace
+    self.val = val
+    self.path = path
+
+  def __repr__(self):
+    return 'Traced<{}:{}>'.format(self.val, self.trace)
+
+  @property
+  def aval(self):
+    return core.get_aval(self.val)
+
+  def full_lower(self):
+    if self.path is None:
+      return self.val
+    else:
+      return self
+
+
+@transformation_with_aux
+def tag_subtrace(parent, in_paths, *in_vals):
+  trace = parent.with_sublevel(core.cur_sublevel())
+  in_tracers = map(partial(TagTracer, trace), in_vals, in_paths)
+  outs = yield in_tracers, {}
+  out_tracers = map(trace.full_raise, outs)
+  out_vals, out_paths = unzip2((t.val, t.path) for t in out_tracers)
+  yield out_vals, out_paths
+
+def tag_fun(fun, in_vals, in_paths, accum_fn, in_tree):
+  with core.new_master(TagTrace) as master:
+    trace = TagTrace(master, core.cur_sublevel(), accum_fn, in_tree)
+    fun, out_paths = tag_subtrace(fun, trace, in_paths)
+    out_vals = fun.call_wrapped(*in_vals)
+    del master
+  return out_vals, out_paths(), trace.tree

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1458,7 +1458,7 @@ def _iter(tracer):
   else:
     n = tracer.shape[0]
     # return (index_in_dim(tracer, i, keepdims=False) for i in xrange(n))
-    return iter([index_in_dim(tracer, i, keepdims=False) for i in xrange(n)])
+    return iter([push_tag(index_in_dim(tracer, i, keepdims=False), i) for i in xrange(n)])
 ShapedArray._iter = staticmethod(_iter)
 
 # Add some ad handlers that use (or could use) lax primitives

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4019,7 +4019,7 @@ push_tag_p.def_abstract_eval(lambda x, name: x)
 xla.translations[push_tag_p] = lambda c, x, name: x
 ad.deflinear(push_tag_p, lambda t, name: [push_tag(t, name)])
 batching.primitive_batchers[push_tag_p] = \
-    lambda a, d, name: (push_tag(a[0]), d[0])
+    lambda a, d, name: (push_tag(a[0], name), d[0])
 tagging.custom_tagging_rules[push_tag_p] = _push_tag_tagging_rule
 
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3989,9 +3989,12 @@ def _tie_in_batch_rule(batched_args, batch_dims):
   _, bdim_y = batch_dims
   return y, bdim_y
 
-def _tie_in_tagging_rule(args, paths, **params):
-  out = tie_in_p.bind(*args, **params)
-  out_path = paths[0]
+def _tie_in_tagging_rule(args, paths):
+  if paths[0] is not None:
+    out_path = paths[0]
+  else:
+    out_path = paths[1]
+  out = tie_in_p.bind(*args)
   return out, out_path, False
 
 tie_in_p = Primitive('tie_in')

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4010,7 +4010,7 @@ tagging.custom_tagging_rules[tie_in_p] = _tie_in_tagging_rule
 
 def _push_tag_tagging_rule(args, paths, **params):
   out = push_tag_p.bind(*args, **params)
-  out_path = out_path + (params["name"],)
+  out_path = paths[0] + (params["name"],)
   return out, out_path, False
 
 push_tag_p = Primitive('push_tag')

--- a/jax/random.py
+++ b/jax/random.py
@@ -34,10 +34,8 @@ from . import tree_util
 from .api import custom_transforms, defjvp, jit, vmap
 from .numpy.lax_numpy import _constant_like, asarray, stack
 from jax.lib import xla_bridge
-from jax import core
 from jax.scipy.special import logit
 from jax.scipy.linalg import cholesky
-
 
 def PRNGKey(seed):
   """Create a pseudo-random number generator (PRNG) key given an integer seed.
@@ -204,13 +202,14 @@ def fold_in(key, data):
 
   Args:
     key: a PRNGKey (an array with shape (2,) and dtype uint32).
-    data: a 32bit integer representing data to be folded in to the key.
+    data: data to be folded into the key; will be hashed first if not an int.
 
   Returns:
     A new PRNGKey that is a deterministic function of the inputs and is
     statistically safe for producing a stream of new pseudo-random values.
   """
-  return _fold_in(key, data)
+  int_data = data if isinstance(data, int) else hash(data)
+  return lax.push_tag(_fold_in(key, int_data), data)
 
 @jit
 def _fold_in(key, data):

--- a/tests/tagging_test.py
+++ b/tests/tagging_test.py
@@ -1,0 +1,121 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from jax import test_util as jtu
+from jax import collect, inject, grad_intermediates, vmap, jit, grad
+from jax import lax, random
+import jax.numpy as np
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+class TaggingTest(jtu.JaxTestCase):
+
+  def test_collect(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val, tree = collect(foo)(2.)
+    self.assertAllClose(val, foo(2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+  
+  def test_collect_jit(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    self.skipTest("collect(jit) doesn't work yet")
+    val, tree = collect(jit(foo))(2.)
+    self.assertAllClose(val, foo(2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+  
+  def test_jit_collect(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val, tree = jit(collect(foo))(2.)
+    self.assertAllClose(val, foo(2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+
+  def test_collect_nested(self):
+    def bar(key, x):
+      y = lax.tag(random.normal(random.fold_in(key, "y")))
+      return x + y
+    def baz(key, x):
+      a = bar(random.fold_in(key, 1), x)
+      b = bar(random.fold_in(key, 2), x)
+      return a + b
+    key = random.PRNGKey(0)
+    val, tree = collect(baz)(key, 2.)
+    self.assertAllClose(val, baz(key, 2.), check_dtypes=True)
+    expected = {1: {"y": random.normal(random.fold_in(random.fold_in(key, 1), "y"))},
+                2: {"y": random.normal(random.fold_in(random.fold_in(key, 2), "y"))}}
+    self.assertAllClose(tree, expected, check_dtypes=True)
+
+  def test_inject(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val = inject(foo, {"y": 1.})(2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+
+  def test_inject_jit(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val = inject(jit(foo), {"y": 1.})(2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+  
+  def test_jit_inject(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val = jit(inject(foo, {"y": 1.}))(2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+
+  def test_inject_nested(self):
+    def bar(key, x):
+      y = lax.tag(random.normal(random.fold_in(key, "y")))
+      return x + y
+    def baz(key, x):
+      a = bar(random.fold_in(key, 1), x)
+      b = bar(random.fold_in(key, 2), x)
+      return a + b
+    key = random.PRNGKey(0)
+    val = inject(baz, {1: {"y": 0.3}, 2: {"y": 0.5}})(key, 2.)
+    self.assertAllClose(val, 4.8, check_dtypes=True)
+
+  def test_grad_intermediates(self):
+    def foo(x):
+      y = lax.tag(x ** 2, "y")
+      z = y + 1
+      return z
+    val = grad_intermediates(foo)(2.)
+    expected = {"y": 1.}
+    self.assertAllClose(val, expected, check_dtypes=True)
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/tagging_test.py
+++ b/tests/tagging_test.py
@@ -43,7 +43,6 @@ class TaggingTest(jtu.JaxTestCase):
       y = lax.tag(x ** 2, "y")
       z = y + 1
       return z
-    self.skipTest("collect(jit) doesn't work yet")
     val, tree = collect(jit(foo))(2.)
     self.assertAllClose(val, foo(2.), check_dtypes=True)
     self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)


### PR DESCRIPTION
## TL;DR:

This lets you name intermediate values in your computations, then extract and overwrite them using transformations. It can be used on its own—for example, to collect metrics or compute gradients of intermediate values—but also provides a JAX-native foundation for NN or PPL libraries that might compose better with other transforms or the JAX PRNG than similar functionality implemented at the Python level.

## Details:

First, we effectively augment the jaxpr language with two new (and in principle orthogonal) features:

1. A way (`lax.yield_value`) to mark that an intermediate value in a jaxpr is a yield point where evaluation can be "paused" and the value can be inspected or replaced from outside
2. A way (`lax.push_tag`) to accumulate stacks of compile-time metadata alongside values, and rules for propagating these metadata stacks through a computation's data flow

Together, these mechanisms give rise to a notion of _tagged intermediate values_ within computations: yield points whose metadata stacks each carry a name atop a stack of nested "namespaces" or "scopes". For instance, a yield point with the metadata stack ("foo", "bar") is a tagged intermediate value with the name `bar` inside a namespace `foo`.

Then, the new tagging tracer (`interpreters/tagging.py`) performs metadata stack propagation and handles yield points using their names and namespaces. When wrapped in a tagging transformation, a JAX function has an extra return value—a nested dict containing values collected at tagged intermediates—and an extra argument, a nested dict whose values will be used to replace tagged intermediates. The key paths to values in these dictionaries correspond to the names/namespaces in the metadata stacks of the tagged intermediates: for instance, the path to `1.` in `{"foo": {"bar": 1.}}` is the metadata stack `("foo", "bar")`.

The public API for the tagging tracer is a pair of function transformations, `collect` and `inject`, that respectively allow extracting and overwriting tagged intermediates. If we start with
```python
def foo(x):
  y = lax.tag(x ** 2, "y")
  z = y + 1
  return z
```
then `value, intermediates = collect(foo)(2.)` will give `intermediates = {"y": 4.}` (the value for `x**2`, the tagged intermediate named "y"), while `inject(foo, {"y": 1.})(2.)` will replace `x**2` with `1.` and return `2.`.

## Use cases:

**More convenient metrics and logging** using `collect` (avoids having to manually thread metric values out of potentially deeply nested functions)

**Gradients of intermediate values** can be obtained by injecting perturbations onto those intermediates, then differentiating with respect to the perturbations:
```python
def grad_intermediates(f):
  def grad_fun(*args, **kwargs):
    _, orig_tree = collect(f)(*args, **kwargs)
    def fun_for_grad(perturbation_tree):
      return inject(f, perturbation_tree, lambda old, new: old + new)(*args, **kwargs)
    return grad(fun_for_grad)(tree_map(np.zeros_like, orig_tree))
  return grad_fun
```
A version of this function is included as a public API.

A potential foundation for **probabilistic programming abstractions**: if sampling from distributions always takes place at a yield point, then arbitrary subsets of ancestral samples can be collected and replaced by inference algorithms.

Based on that, and along the lines of Dougal's PRNG key split tree idea (#1341), an unusual but (to me) compelling approach to **deep learning abstractions**. This involves representing a neural net architecture as a single function that initializes the network's parameters, tags them as intermediates with a namespaced structure, then uses them in a forward pass with the input data (so essentially a probabilistic program for a "Bayesian neural net").

The notion familiar from stax of a network architecture as a pair of `init` and `apply` functions can then be recovered by applying `collect` and `inject` respectively to the architecture function. Meanwhile, the namespaced structure can come from PRNG key `split` and `fold_in` operations (this is the stax2 idea, and the tagging tracer implements this behavior for PRNG key metadata stacks) or even from scopes maintained dynamically in Python (as in DeepMind's Sonnet library).

More to come on this front!

## Open questions:

The tagging tracer's use of **nested dictionaries** to represent values indexed by stacks of keys is essentially the same abstraction exposed in the `_with_path` functions in DeepMind's recently open-sourced [tree](https://github.com/deepmind/tree) library, albeit without support for lists. It might be reasonable to replace the hand-rolled helpers I added with a dependency on `tree` if we're willing to take one, or alternatively to build a notion of paths into JAX's existing pytree infrastructure.

**Composition** with semantics-preserving transformations (jit) or when nested inside semantics-non-preserving ones is well-defined (and seems to work), but there's a choice of what to do when nesting outside semantics-nonpreserving transformations like jvp and batching. For instance, should `collect(jvp(f))` only collect the primal values of named intermediates, or both the primals and tangents (and if the latter, how should they be returned)? Similarly, I think the right thing to do in inject/collect of vmap is to accept/return batched intermediate values with the batch dimension in the vmap's `out_dim`, but that might be a little surprising for `inject`. (The current behavior of this code is to collect only the primal values in a jvp trace and to collect the batching tracers themselves in batching traces).