### PR TITLE
minor cleanups in xla.py

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -143,31 +143,23 @@ def xla_primitive_callable(prim, *abstract_args, **params):
 
 @cache()
 def primitive_computation(prim, *xla_shapes, **params):
-  backend = params.get('backend', None)
-  new_params = {k: params[k] for k in params if k != 'backend'}
   c = xb.make_computation_builder("primitive_computation_{}".format(prim.name))
-  newvar = core.gensym('')
-  c.SetOpMetadata(xc.OpMetadata(
-      op_type=prim.name,
-      op_name=str(core.new_jaxpr_eqn(
-          [newvar() for i in range(len(xla_shapes))],
-          [newvar()],
-          prim, (), params))
-  ))
+  c.SetOpMetadata(xc.OpMetadata(op_type=prim.name, op_name=str(params)))
+  backend = params.pop("backend", None)
   platform = xb.get_backend(backend).platform
   xla_args = (_parameter_or_create_token(c, shape) for shape in xla_shapes)
   if prim in backend_specific_translations[platform]:
     rule = backend_specific_translations[platform][prim]
-    rule(c, *xla_args, **new_params)  # return val set as a side-effect on c
+    rule(c, *xla_args, **params)  # return val set as a side-effect on c
   elif prim in translations:
     rule = translations[prim]
-    rule(c, *xla_args, **new_params)  # return val set as a side-effect on c
+    rule(c, *xla_args, **params)  # return val set as a side-effect on c
   elif prim in reduction_translations:
     rule = reduction_translations[prim]
-    rule(c, *xla_args, backend=backend, **new_params)  # return val set as a side-effect on c
+    rule(c, *xla_args, backend=backend, **params)  # return val set as a side-effect on c
   elif prim in initial_style_translations:
     rule = initial_style_translations[prim]
-    rule(c, AxisEnv(), *xla_args,  backend=backend, **new_params)  # side-effect on c
+    rule(c, AxisEnv(), *xla_args,  backend=backend, **params)  # side-effect on c
   else:
     raise NotImplementedError("XLA translation rule for {} not found".format(prim))
   c.ClearOpMetadata()
@@ -307,10 +299,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
   _map(write, jaxpr.freevars, freevars)
   _map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    c.SetOpMetadata(xc.OpMetadata(
-      op_type=eqn.primitive.name,
-      op_name=str(eqn)
-    ))
+    c.SetOpMetadata(xc.OpMetadata( op_type=eqn.primitive.name, op_name=str(eqn)))
     in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
       rule = backend_specific_translations[platform][eqn.primitive]
@@ -432,7 +421,7 @@ def _xla_callable(fun, device, backend, *abstract_args):
   tuple_args = len(abstract_args) > 100
   with core.new_master(pe.JaxprTrace, True) as master:
     jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
-    assert not env  # no subtraces here (though cond might eventually need them)
+    assert not env  # no subtraces here
     axis_env = AxisEnv(jaxpr_replicas(jaxpr), [], [])
     compiled = _compile_jaxpr(jaxpr, device, backend, axis_env, consts,
                               tuple_args, *abstract_args)
@@ -658,7 +647,7 @@ class DeviceArray(DeviceValue):
     self._npy_value = None
 
   def __repr__(self):
-    return onp.array_repr(self)
+    return onp.array_repr(self._value)
 
   def item(self):
     if onp.issubdtype(self.dtype, onp.complexfloating):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -106,19 +106,19 @@ def product_io_fun(x, y):
 
 
 R = onp.random.randn
-TestSpec = namedtuple('TestSpec', ['fun', 'args'])
+CallSpec = namedtuple('CallSpec', ['fun', 'args'])
 test_specs_base = [
-    TestSpec(simple_fun, (R(3, 2), R(3, 2))),
-    TestSpec(simple_fun_fanout, (R(3, 2), R(3, 2))),
-    TestSpec(product_io_fun, ({'a': R(2, 2), 'b': R(2, 2)},
+    CallSpec(simple_fun, (R(3, 2), R(3, 2))),
+    CallSpec(simple_fun_fanout, (R(3, 2), R(3, 2))),
+    CallSpec(product_io_fun, ({'a': R(2, 2), 'b': R(2, 2)},
                               (R(2, 2), (R(2, 2), R(2, 2))))),
-    TestSpec(fun_with_call, (R(3, 2),)),
-    TestSpec(fun_with_two_calls, (R(3, 2),)),
-    TestSpec(fun_with_call_closure, (R(3, 2),)),
-    TestSpec(fun_call_jitted, (R(1,),)),
-    TestSpec(fun_with_nested_calls, (R(),)),
-    TestSpec(fun_with_nested_calls, (R(3, 2),)),
-    TestSpec(fun_with_nested_calls_2, (R(1, 2),)),
+    CallSpec(fun_with_call, (R(3, 2),)),
+    CallSpec(fun_with_two_calls, (R(3, 2),)),
+    CallSpec(fun_with_call_closure, (R(3, 2),)),
+    CallSpec(fun_call_jitted, (R(1,),)),
+    CallSpec(fun_with_nested_calls, (R(),)),
+    CallSpec(fun_with_nested_calls, (R(3, 2),)),
+    CallSpec(fun_with_nested_calls_2, (R(1, 2),)),
 ]
 
 def jvp_unlinearized(f, primals, tangents):
@@ -128,10 +128,10 @@ def jvp_unlinearized(f, primals, tangents):
 test_specs = []
 for ts in test_specs_base:
   test_specs.append(ts)
-  test_specs.append(TestSpec(partial(jvp, ts.fun), (ts.args, ts.args)))
-  test_specs.append(TestSpec(jit(ts.fun), ts.args))
-  test_specs.append(TestSpec(jit(jit(ts.fun)), ts.args))
-  test_specs.append(TestSpec(partial(jvp_unlinearized, ts.fun),
+  test_specs.append(CallSpec(partial(jvp, ts.fun), (ts.args, ts.args)))
+  test_specs.append(CallSpec(jit(ts.fun), ts.args))
+  test_specs.append(CallSpec(jit(jit(ts.fun)), ts.args))
+  test_specs.append(CallSpec(partial(jvp_unlinearized, ts.fun),
                              (ts.args, ts.args)))
 
 


### PR DESCRIPTION
1. simplify XLA OpMetadata associated with primitive computations
1. replace `TestSpec` with `CallSpec` in core_test.py to avoid a warning about test collection
1. `DeviceArray.__repr__` should forward to numpy value (so we don't generate a bunch of gathers and do inefficient device communication)