### PR TITLE
Lazy sublanguage

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -32,6 +32,7 @@ from .. import core
 from .. import ad_util
 from .. import tree_util
 from .. import dtypes
+from .. import lazy
 from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, AbstractToken,
                                make_shaped_array, array_types, raise_to_shaped,
@@ -78,7 +79,7 @@ def aval_to_result_handler(device, aval):
 xla_result_handlers = {}
 xla_result_handlers[core.AbstractUnit] = lambda _, __: lambda _: core.unit
 def array_result_handler(device, aval):
-  return partial(DeviceArray, raise_to_shaped(aval), device)
+  return partial(DeviceArray, raise_to_shaped(aval), device, lazy.array(aval.shape))
 xla_result_handlers[ShapedArray] = array_result_handler
 xla_result_handlers[ConcreteArray] = array_result_handler
 
@@ -145,6 +146,7 @@ def _make_abstract_python_scalar(typ, _):
 
 for _t in dtypes.python_scalar_dtypes.keys():
   pytype_aval_mappings[_t] = partial(_make_abstract_python_scalar, _t)
+
 
 ### op-by-op execution
 
@@ -536,6 +538,7 @@ def _xla_callable_args(c, avals, tuple_args):
 def _pval_to_result_handler(device, pval):
   pv, const = pval
   if pv is None:
+    const = _device_put_impl(const, device) if device else const
     return lambda _: const
   else:
     return aval_to_result_handler(device, pv)
@@ -566,8 +569,8 @@ def _execute_trivial(jaxpr, device, consts, handlers, *args):
   _map(env.setdefault, jaxpr.constvars, consts)
   outs = [canonicalize_dtype(v.val) if type(v) is Literal else env[v]
           for v in jaxpr.outvars]
-  return [x if type(x) is DeviceArray else handler(device_put(x, device))
-          for handler, x in zip(handlers, outs)]
+  return [_copy_device_array_to_device(x, device) if type(x) is DeviceArray
+          else h(device_put(x, device)) for h, x in zip(handlers, outs)]
 
 def make_tuple(bufs, device, backend):
   return xb.get_backend(backend).make_tuple(bufs, device)
@@ -678,7 +681,7 @@ class DeviceValue(object):
     self.device_buffer = device_buffer
 
   def _check_if_deleted(self):
-    if self.device_buffer is None:
+    if self.device_buffer is deleted_buffer:
       raise ValueError("DeviceValue has been deleted.")
 
   def block_until_ready(self):
@@ -702,13 +705,14 @@ class DeviceArray(DeviceValue):
   """A DeviceArray is an ndarray backed by a single device memory buffer."""
   # We don't subclass ndarray because that would open up a host of issues,
   # but lax_numpy.py overrides isinstance behavior and attaches ndarray methods.
-  __slots__ = ["_npy_value", "_device"]
+  __slots__ = ["_npy_value", "_device", "_lazy_expr"]
   __array_priority__ = 100
 
-  def __init__(self, aval, device, device_buffer):
+  def __init__(self, aval, device, lazy_expr, device_buffer):
     self.aval = aval
     self.device_buffer = device_buffer
     self._device = device and (type(device), device.id)
+    self._lazy_expr = lazy_expr
 
     self._npy_value = None
     if not core.skip_checks:
@@ -720,7 +724,10 @@ class DeviceArray(DeviceValue):
   def _value(self):
     self._check_if_deleted()
     if self._npy_value is None:
-      self._npy_value = self.device_buffer.to_py()
+      if is_device_constant(self):
+        self._npy_value = lazy.eval_lexpr(self._lazy_expr, None)
+      else:
+        self._npy_value = _force(self).device_buffer.to_py()
       self._npy_value.flags.writeable = False
     return self._npy_value
 
@@ -747,7 +754,7 @@ class DeviceArray(DeviceValue):
   def copy_to_host_async(self):
     """Requests a copy of the buffer to the host."""
     self._check_if_deleted()
-    if self._npy_value is None:
+    if self._npy_value is None and not is_device_constant(self):
       self.device_buffer.copy_to_host_async()
 
   def delete(self):
@@ -762,7 +769,7 @@ class DeviceArray(DeviceValue):
     time of deletion.
     """
     self.device_buffer.delete()
-    self.device_buffer = None
+    self.device_buffer = deleted_buffer
     self._npy_value = None
 
   def __repr__(self):
@@ -837,31 +844,97 @@ class DeviceArray(DeviceValue):
   def __hash__(self):
     raise TypeError("JAX DeviceArray, like numpy.ndarray, is not hashable.")
 
+class DeletedBuffer(object): pass
+deleted_buffer = DeletedBuffer()
+
+class DeviceConstant(object):
+  __slots__ = ["_device"]
+  def __init__(self, device=None): self._device = device
+  def device(self): return self._device
+  def to_py(self): return None
+
+def is_device_constant(x):
+  return type(x) is DeviceArray and type(x.device_buffer) is DeviceConstant
+
 core.literalable_types.add(DeviceArray)
 core.pytype_aval_mappings[DeviceArray] = ConcreteArray
-pytype_aval_mappings[DeviceArray] = lambda x: x.aval
+pytype_aval_mappings[DeviceArray] = op.attrgetter('aval')
 canonicalize_dtype_handlers[DeviceArray] = identity
 
 def _device_array_constant_handler(c, val, canonicalize_types=True):
-  return c.Constant(onp.asarray(val), canonicalize_types=canonicalize_types)
+  if is_device_constant(val):
+    return lazy.stage_lexpr(c, val._lazy_expr, None)
+  else:
+    base_val = c.Constant(val.device_buffer.to_py())
+    return lazy.stage_lexpr(c, val._lazy_expr, base_val)
 xb.register_constant_handler(DeviceArray, _device_array_constant_handler)
 
 def _device_put_device_array(x, device):
-  # TODO(skye): we're assuming the DeviceBuffers without "platform" are
-  # XrtBuffers. Figure out a less risky way to deal with XrtBuffers.
-  if (not hasattr(x.device_buffer, "platform") or
-      xb.get_device_backend(device).platform == x.device_buffer.platform()):
-    if device is None or x.device_buffer.device() == device:
-      return x.device_buffer
-    else:
-      return x.device_buffer.copy_to_device(device)
-  else:
-   # Buffers from different XLA backends are passed through the host.
-   return xc.Buffer.from_pyval(x, device, backend=xb.get_device_backend(device))
+  x = _copy_device_array_to_device(x, device)
+  return _force(x).device_buffer
 device_put_handlers[DeviceArray] = _device_put_device_array
+
+def _copy_device_array_to_device(x, device):
+  if is_device_constant(x):
+    return DeviceArray(x.aval, device, x._lazy_expr, DeviceConstant(device))
+  elif xb.get_device_backend(device).platform == x.device_buffer.platform():
+    if device is None or x.device_buffer.device() == device:
+      return x
+    else:
+      moved_buf = x.device_buffer.copy_to_device(device)
+  else:
+    # Buffers from different XLA backends are passed through the host.
+    moved_buf = xc.Buffer.from_pyval(x.device_buffer.to_py(), device,
+                                     backend=xb.get_device_backend(device))
+  return DeviceArray(x.aval, device, x._lazy_expr, moved_buf)
+
+def _force(x):
+  if lazy.is_trivial(x._lazy_expr):
+    return x
+  else:
+    # force x on the device where it lives, but preserve stickiness on result
+    if x._device:
+      device = x._device
+      sticky = True
+    else:
+      d = x.device_buffer.device()
+      device = d and (type(d), d.id)
+      sticky = False
+    force_fun = _lazy_force_computation(sticky, x.aval, device, x._lazy_expr)
+    return force_fun(x)
+
+@cache()
+def _lazy_force_computation(sticky, aval, device, lexpr):
+  c = xb.make_computation_builder("lazy_force")
+  if lazy.is_constant(lexpr):
+    param = None
+  else:
+    idxs = [(src, dst) for dst, src in enumerate(lexpr.dims) if src is not None]
+    param_shape = [None] * len(idxs)
+    for src, dst in idxs:
+      param_shape[src] = aval.shape[dst]
+    param = c.ParameterWithShape(xc.Shape.array_shape(aval.dtype, param_shape))
+  xla_out = lazy.stage_lexpr(c, lexpr, param)
+  built_c = c.Build(xla_out)
+
+  device = _device_from_arg_devices([device])
+  options = xb.get_compile_options(device_assignment=device and (device.id,))
+  backend = xb.get_device_backend(device)
+  compiled = built_c.Compile(compile_options=options, backend=backend)
+
+  result_device = device if sticky else None
+  handler = partial(DeviceArray, aval, result_device, lazy.array(aval.shape))
+  if lazy.is_constant(lexpr):
+    force_fun = lambda _: handler(compiled.Execute([]))
+  else:
+    force_fun = lambda x: handler(compiled.Execute([x.device_buffer]))
+  return force_fun
 
 
 def _device_put_impl(x, device=None):
+  if type(x) is DeviceArray:
+    return _copy_device_array_to_device(x, device)
+
   try:
     a = abstractify(x)
   except TypeError:
@@ -904,28 +977,3 @@ def _foil_cse(c, x):
     shape, dtype = xla_shape.dimensions(), xla_shape.numpy_dtype()
     zero = c.Broadcast(c.Constant(onp.array(0, dtype=dtype)), shape)
     return c.Select(pred, x, zero)
-
-
-### lazy constants
-
-class DeviceConstant(DeviceArray):
-  def copy_to_host_async(self): pass
-
-  @staticmethod
-  def constant_handler(c, constant_instance, canonicalize_types=True):
-    assert False
-
-def _instantiate_device_constant(const, device=None, backend=None, cutoff=1e6):
-  # dispatch an XLA Computation to build the constant on the device if it's
-  # large, or alternatively build it on the host and transfer it if it's small
-  assert isinstance(const, DeviceConstant)
-  backend = xb.get_backend(device.platform) if device else xb.get_backend(backend)
-  if const.size > cutoff:
-    c = xb.make_computation_builder("constant_instantiating_computation")
-    xla_const = const.constant_handler(c, const)
-    device_assignment = (device.id,) if device else None
-    opts = xb.get_compile_options(device_assignment=device_assignment)
-    compiled = c.Build(xla_const).Compile((), opts, backend=backend)
-    return compiled.Execute(())
-  else:
-    return xc.Buffer.from_pyval(onp.asarray(const), device, backend=backend)

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -21,7 +21,7 @@ from .lax import (_reduce_sum, _reduce_max, _reduce_min, _reduce_or,
                   _input_dtype, _const, _eq_meet, _safe_mul,
                   _broadcasting_select, _check_user_dtype_supported,
                   _one, _const, _upcast_fp16_for_computation,
-                  _broadcasting_shape_rule)
+                  _broadcasting_shape_rule, _eye, _tri, _delta)
 from .lax_control_flow import *
 from .lax_fft import *
 from .lax_parallel import *

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -36,6 +36,7 @@ from .. import ad_util
 from .. import api
 from .. import linear_util as lu
 from .. import dtypes
+from .. import lazy
 from ..config import flags
 from ..core import Primitive
 from ..abstract_arrays import (UnshapedArray, ShapedArray, ConcreteArray,
@@ -615,15 +616,12 @@ def broadcast(operand, sizes):
   Returns:
     An array containing the result.
   """
-  return broadcast_p.bind(operand, sizes=tuple(sizes))
+  dims = tuple(range(len(sizes), len(sizes) + onp.ndim(operand)))
+  return broadcast_in_dim(operand, tuple(sizes) + onp.shape(operand), dims)
 
 def broadcast_in_dim(operand, shape, broadcast_dimensions):
   if onp.ndim(operand) == len(shape) and not len(broadcast_dimensions):
     return operand
-  if any(x < 0 or x >= len(shape) for x in broadcast_dimensions):
-    msg = ("broadcast dimensions must be >= 0 and < ndim(shape), got {} for "
-           "shape {}")
-    raise ValueError(msg.format(broadcast_dimensions, shape))
   return broadcast_in_dim_p.bind(
       operand, shape=tuple(shape),
       broadcast_dimensions=tuple(broadcast_dimensions))
@@ -1060,47 +1058,64 @@ def full(shape, fill_value, dtype=None):
   if onp.shape(fill_value):
     msg = "full must be called with scalar fill_value, got fill_value.shape {}."
     raise TypeError(msg.format(onp.shape(fill_value)))
-  dtype = dtype or _dtype(fill_value)
-  dtype = dtypes.canonicalize_dtype(dtype)
-
-  # For constants (defined as Python scalars, raw ndarrays, or DeviceValues),
-  # create a _FilledConstant value, otherwise just call broadcast.
-  if onp.isscalar(fill_value) or type(fill_value) is onp.ndarray:
-    return _FilledConstant(onp.asarray(fill_value, dtype), shape)
-  elif isinstance(fill_value, xla.DeviceValue):
-    val = onp.asarray(fill_value, dtype)
-    return _FilledConstant(val, shape)
-  else:
-    return broadcast(convert_element_type(fill_value, dtype), shape)
+  dtype = dtypes.canonicalize_dtype(dtype or _dtype(fill_value))
+  # TODO(mattjj): remove device_put when dtype conversion produces DeviceArray
+  fill_value = xla.device_put_p.bind(convert_element_type(fill_value, dtype))
+  return broadcast(fill_value, shape)
 
 def iota(dtype, size):
   """Wraps XLA's `Iota
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
   operator.
   """
-  return broadcasted_iota(dtype, (int(size),), 0)
+  size = int(size)
+  dtype = dtypes.canonicalize_dtype(dtype)
+  lazy_expr = lazy.iota(dtype, size)
+  aval = ShapedArray((size,), dtype)
+  return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
 
 def broadcasted_iota(dtype, shape, dimension):
-  """Wraps XLA's `Iota
-  <https://www.tensorflow.org/xla/operation_semantics#iota>`_
-  operator.
-  """
+  """Convenience wrapper around ``iota``."""
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = _canonicalize_shape(shape)
   dimension = int(dimension)
-  return _IotaConstant(dtype, shape, dimension)
+  return broadcast_in_dim(iota(dtype, shape[dimension]), shape, [dimension])
 
-def eye(dtype, size):
-  return broadcasted_eye(dtype, (size, size), (0, 1))
+def _eye(dtype, shape, offset):
+  """Like numpy.eye, create a 2D array with ones on a diagonal.
 
-def broadcasted_eye(dtype, shape, axes):
-  if not isinstance(axes, (list, tuple)) or not len(axes) >= 2:
-    raise TypeError("make_diagonal `axes` must be a tuple with len at least 2.")
+  This function exists for creating lazy identity matrices; that is,
+  materialization of the array is delayed and it may be fused into consumers to
+  avoid materialization at all."""
+  N, M = tuple(map(int, shape))
+  offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = _canonicalize_shape(shape)
-  axes = tuple(map(int, axes))
-  return _EyeConstant(shape, axes, dtype)
+  lazy_expr = lazy.eye(dtype, (N, M), offset)
+  aval = ShapedArray((N, M), dtype)
+  return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
 
+def _delta(dtype, shape, axes):
+  """This function exists for creating lazy Kronecker delta arrays, particularly
+  for use in jax.numpy.einsum to express traces. It differs from ``eye`` in that
+  it can create arrays of any rank, but doesn't allow offsets."""
+  shape = tuple(map(int, shape))
+  axes = tuple(map(int, axes))
+  dtype = dtypes.canonicalize_dtype(dtype)
+  base_shape = tuple(onp.take(shape, axes))
+  lazy_expr = lazy.broadcast(lazy.delta(dtype, base_shape), shape, axes)
+  aval = ShapedArray(shape, dtype)
+  return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
+
+def _tri(dtype, shape, offset):
+  """Like numpy.tri, create a 2D array with ones below a diagonal.
+  This function exists for creating lazy triangular matrices, particularly for
+  use in jax.numpy.tri."""
+  N, M = tuple(map(int, shape))
+  offset = int(offset)
+  dtype = dtypes.canonicalize_dtype(dtype)
+  lazy_expr = lazy.tri(dtype, (N, M), offset)
+  aval = ShapedArray((N, M), dtype)
+  return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
 
 def stop_gradient(x):
   """Stops gradient computation.
@@ -2288,11 +2303,23 @@ broadcast_p = standard_primitive(
 ad.deflinear(broadcast_p, lambda t, sizes: [_reduce_sum(t, range(len(sizes)))])
 batching.primitive_batchers[broadcast_p] = _broadcast_batch_rule
 
+def _broadcast_in_dim_impl(operand, shape, broadcast_dimensions):
+  if type(operand) is xla.DeviceArray:
+    aval = ShapedArray(shape, _dtype(operand))
+    lazy_expr = lazy.broadcast(operand._lazy_expr, shape, broadcast_dimensions)
+    return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
+  else:
+    return xla.apply_primitive(broadcast_in_dim_p, operand, shape=shape,
+                               broadcast_dimensions=broadcast_dimensions)
 
 def _broadcast_in_dim_shape_rule(operand, shape, broadcast_dimensions):
   _check_shapelike('broadcast_in_dim', 'shape', shape)
   _check_shapelike('broadcast_in_dim', 'broadcast_dimensions',
                    broadcast_dimensions)
+  if any(x >= len(shape) for x in broadcast_dimensions):
+    msg = ("broadcast_in_dim broadcast dimensions must be less than "
+           "ndim(shape), got {} for shape {}.")
+    raise ValueError(msg.format(broadcast_dimensions, shape))
   if operand.ndim != len(broadcast_dimensions):
     msg = ('broadcast_in_dim broadcast_dimensions must have length equal to '
            'operand ndim, got broadcast_dimensions {} for operand ndim {}.')
@@ -2319,6 +2346,7 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, shape,
 
 broadcast_in_dim_p = standard_primitive(
     _broadcast_in_dim_shape_rule, _input_dtype, 'broadcast_in_dim')
+broadcast_in_dim_p.def_impl(_broadcast_in_dim_impl)
 ad.deflinear(broadcast_in_dim_p, _broadcast_in_dim_transpose_rule)
 batching.primitive_batchers[broadcast_in_dim_p] = _broadcast_in_dim_batch_rule
 
@@ -2466,9 +2494,14 @@ ad.primitive_transposes[pad_p] = _pad_transpose
 batching.primitive_batchers[pad_p] = _pad_batch_rule
 
 
-# We have a nonstandard reshape impl so that we can be lazy about data movement
-# for specific types, particularly ShardedDeviceArrays / ChunkedDeviceArrays
+# We have a nonstandard reshape impl so that we can be lazy about data movement.
 def _reshape_impl(operand, new_sizes, dimensions, old_sizes):
+  if type(operand) is xla.DeviceArray and dimensions is None:
+    bcast_dims = _is_singleton_reshape(old_sizes, new_sizes)
+    if bcast_dims is not None:
+      aval = ShapedArray(new_sizes, operand.dtype)
+      lazy_expr = lazy.broadcast(operand._lazy_expr, new_sizes, bcast_dims)
+      return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
   if (type(operand) is pxla.ShardedDeviceArray and dimensions is None
       and _is_axis_merge(old_sizes, new_sizes)):
     aval = ShapedArray(new_sizes, operand.dtype)
@@ -2481,6 +2514,26 @@ def _reshape_impl(operand, new_sizes, dimensions, old_sizes):
   else:
     return xla.apply_primitive(reshape_p, operand, new_sizes=new_sizes,
                                dimensions=dimensions, old_sizes=old_sizes)
+
+def _is_singleton_reshape(old, new):
+  # A singleton reshape is one where only singleton dimensions are added. We
+  # want to detect them because they can be expressed as (lazy) broadcasts.
+  old, new = iter(old), iter(new)
+  d1, d2 = next(old, None), next(new, None)
+  bcast_dims = []
+  i = 0
+  while True:
+    if d1 is d2 is None:
+      return bcast_dims
+    elif d1 == d2:
+      bcast_dims.append(i)
+      i += 1
+      d1, d2 = next(old, None), next(new, None)
+    elif d2 == 1:
+      i += 1
+      d2 = next(new, None)
+    else:
+      return None
 
 def _is_axis_merge(s1, s2):
   return s1[2:] == s2[1:] and s1[0] * s1[1] == s2[0]
@@ -2560,6 +2613,14 @@ ad.deflinear(rev_p, lambda t, dimensions: [rev(t, dimensions)])
 batching.primitive_batchers[rev_p] = _rev_batch_rule
 
 
+def _transpose_impl(operand, permutation):
+  if type(operand) is xla.DeviceArray:
+    lazy_expr = lazy.transpose(operand._lazy_expr, permutation)
+    aval = ShapedArray(lazy_expr.shape, operand.dtype)
+    return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
+  else:
+    return xla.apply_primitive(transpose_p, operand, permutation=permutation)
+
 def _transpose_shape_rule(operand, permutation):
   if not isinstance(permutation, (tuple, list, onp.ndarray)):
     msg = "transpose permutation must be a tuple/list/ndarray, got {}."
@@ -2578,6 +2639,7 @@ def _transpose_batch_rule(batched_args, batch_dims, permutation):
 
 transpose_p = standard_primitive(_transpose_shape_rule, _input_dtype,
                                  'transpose')
+transpose_p.def_impl(_transpose_impl)
 ad.deflinear(transpose_p,
              lambda t, permutation: [transpose(t, onp.argsort(permutation))])
 batching.primitive_batchers[transpose_p] = _transpose_batch_rule
@@ -4037,100 +4099,6 @@ masking.shape_rules[tie_in_p] = lambda shape_exprs: shape_exprs[1]
 masking.masking_rules[tie_in_p] = lambda vals, logical_shapes: vals[1]
 
 
-### constants
-
-
-class _FilledConstant(xla.DeviceConstant):
-  __slots__ = ["fill_value"]
-
-  def __init__(self, fill_value, shape):
-    assert type(fill_value) is onp.ndarray
-    self.aval = ShapedArray(shape, _dtype(fill_value))
-    self._npy_value = None
-
-    self.fill_value = fill_value
-
-  @property
-  def _value(self):
-    return onp.full(self.shape, self.fill_value)
-
-  @staticmethod
-  def constant_handler(c, filled_const, canonicalize_types=True):
-    return c.Broadcast(
-      c.NumpyArrayConstant(filled_const.fill_value, canonicalize_types),
-      filled_const.shape)
-
-
-class _IotaConstant(xla.DeviceConstant):
-  __slots__ = ["axis"]
-
-  def __init__(self, dtype, shape, axis):
-    self.aval = ShapedArray(shape, onp.dtype(dtype))
-    self._npy_value = None
-
-    self.axis = axis
-
-  @property
-  def _value(self):
-    if self._npy_value is None:
-      iota = onp.arange(self.shape[self.axis], dtype=self.dtype)
-      iota = iota.reshape([self.shape[self.axis] if i == self.axis else 1
-                           for i in range(self.ndim)])
-      self._npy_value = onp.broadcast_to(iota, self.shape)
-    return self._npy_value
-
-  @staticmethod
-  def constant_handler(c, iota_constant, canonicalize_types=True):
-    dtype = iota_constant.dtype
-    if canonicalize_types:
-      dtype = dtypes.canonicalize_dtype(dtype)
-    return c.BroadcastedIota(dtype, iota_constant.shape, iota_constant.axis)
-
-
-class _EyeConstant(xla.DeviceConstant):
-  __slots__ = ["axes"]
-
-  def __init__(self, shape, axes, dtype):
-    self.aval = ShapedArray(shape, onp.dtype(dtype))
-    self._npy_value = None
-
-    self.axes = axes
-
-  @property
-  def _value(self):
-    if self._npy_value is None:
-      ones = [1] * self.ndim
-      iotas = [onp.arange(self.shape[axis]).reshape(subvals(ones, [(axis, -1)]))
-               for axis in self.axes]
-      eyes = [i1 == i2 for i1, i2 in zip(iotas[:-1], iotas[1:])]
-      result = onp.asarray(_reduce(operator.and_, eyes), self.dtype)
-      self._npy_value = onp.broadcast_to(result, self.shape)
-    return self._npy_value
-
-  @staticmethod
-  def constant_handler(c, diag_const, canonicalize_types=True):
-    if canonicalize_types:
-      etype = xla_bridge.dtype_to_etype(diag_const.dtype)
-    else:
-      etype = xla_client.dtype_to_etype(diag_const.dtype)
-    etype = xla_bridge.dtype_to_etype(diag_const.dtype)
-    iotas = [c.BroadcastedIota(onp.uint32, diag_const.shape, axis)
-             for axis in diag_const.axes]
-    eyes = [c.Eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    return c.ConvertElementType(_reduce(c.And, eyes), etype)
-
-
-for _t in [_FilledConstant, _IotaConstant, _EyeConstant]:
-  xla_bridge.register_constant_handler(_t, _t.constant_handler)
-  core.pytype_aval_mappings[_t] = ConcreteArray
-  xla.pytype_aval_mappings[_t] = make_shaped_array
-  xla.device_put_handlers[_t] = xla._instantiate_device_constant
-  pxla.shard_arg_handlers[_t] = pxla._shard_array
-  xla.canonicalize_dtype_handlers[_t] = _identity
-  ad_util.jaxval_adders[_t] = add
-  ad_util.jaxval_zeros_likers[_t] = zeros_like_array
-
-
 ### stop-gradient
 
 def _stop_gradient_jvp_rule(primals, tangents):
@@ -4587,13 +4555,6 @@ def _eq_meet(a, b):
     else:
       b = convert_element_type(b, a_dtype)
   return eq(a, b)
-
-
-def subvals(lst, replace):
-  lst = list(lst)
-  for i, v in replace:
-    lst[i] = v
-  return tuple(lst)
 
 
 def _abstractify(x):

--- a/jax/lazy.py
+++ b/jax/lazy.py
@@ -1,0 +1,244 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+import operator as op
+
+import numpy as onp
+from six.moves import reduce
+
+from .util import safe_map, safe_zip, unzip2, subvals
+from .lib import xla_bridge as xb
+
+map = safe_map
+zip = safe_zip
+
+
+### util
+
+# TODO(mattjj): replace with dataclass when Python 2 support is removed
+def taggedtuple(name, fields):
+  """Lightweight version of namedtuple where equality depends on the type."""
+  def __new__(cls, *xs):
+    return tuple.__new__(cls, (cls,) + xs)
+  def __str__(self):
+    return '{}{}'.format(name, tuple.__str__(self[1:]))
+  class_namespace = {'__new__' : __new__, '__str__': __str__}
+  for i, f in enumerate(fields):
+    class_namespace[f] = property(op.itemgetter(i+1))
+  return type(name, (tuple,), class_namespace)
+
+
+### lazy sublanguage
+
+# There are two components to a LazyExpr: an input and a reindexing
+# specification. The input represents a base array to which the reindexing
+# specification is applied.
+#
+# An input can represent an array constructor (Iota, Eye, etc.) or it can be an
+# ArrayVar which encodes that the base array is some exogenous array value (from
+# an environment with only a single value in it). These LazyExprs are attached
+# to DeviceArrays, so when the input part of the expression is ArrayVar that
+# basically means the associated device buffer represents the input, while if
+# the input is an array constructor then the associated device_buffer field of
+# the DeviceArray should be set to a DeviceConstant sentinel value. For the
+# array constructor expressions:
+#   * Iota builds a 1D sequence [0, 1, ..., N-1],
+#   * Eye builds a 2D array with ones on a (possibly offset) diagonal and zeros
+#     elsewhere (like numpy.eye),
+#   * Tri builds a triangular matrix with ones on and below a diagonal and zeros
+#     elsewhere (like numpy.tri), and
+#   * Delta builds a Kronecker delta array with ones along its multidimensional
+#     main diagonal and zeros elsewhere (for use in tensor contractions).
+#
+# The reindexing specification encodes the shape of the final result and a list
+# of dimensions, which are integers or Nones. The integer entries take on values
+# 0, 1, ..., R-1 where R is the rank of the input array, and encode where the
+# axes of the input array are to be mapped in the final output. When an entry is
+# None that indicates that the corresponding axis of the result is a broadcasted
+# one.
+#
+# Here are some examples of lazy expressions and the arrays they represent:
+#
+# LazyExpr(input=Iota(dtype=dtype('float32'), size=3),
+#          shape=(3, 4), dims=(0, None))
+# DeviceArray([[0., 0., 0., 0.],
+#              [1., 1., 1., 1.],
+#              [2., 2., 2., 2.]], dtype=float32)
+#
+# LazyExpr(input=Iota(dtype=dtype('float32'), size=3),
+#          shape=(4, 3), dims=(None, 0))
+# DeviceArray([[0., 1., 2.],
+#              [0., 1., 2.],
+#              [0., 1., 2.],
+#              [0., 1., 2.]], dtype=float32)
+#
+# For performance, some functions on lazy expressions accept None as an input to
+# stand for the identity lazy expression.
+#
+# We use the `taggedtuple` class constructor, rather than standard namedtuples,
+# because two namedtuple instances of different types but equal elements hash to
+# the same value, e.g.
+#   A = namedtuple('A', ['x', 'y'])
+#   B = namedtuple('B', ['x', 'y'])
+#   hash(A(1, 2)) == hash(B(1, 2))   # True
+# but we want hashes to be sensitive to the type tag (while still being fast).
+
+LazyExpr = namedtuple('LazyExpr', ['input', 'shape', 'dims'])
+ArrayVar = taggedtuple('ArrayVar', [])
+Iota = taggedtuple('Iota', ['dtype', 'size'])           # like np.arange(N)
+Eye = taggedtuple('Eye', ['dtype', 'shape', 'offset'])  # like np.eye
+Tri = taggedtuple('Tri', ['dtype', 'shape', 'offset'])  # like np.tri
+Delta = taggedtuple('Delta', ['dtype', 'shape'])  # kronecker delta arrays
+
+def array(shape):
+  return LazyExpr(ArrayVar(), shape, tuple(range(len(shape))))
+
+def iota(dtype, size):
+  return LazyExpr(Iota(dtype, size), (size,), (0,))
+
+def eye(dtype, shape, offset):
+  assert len(shape) == 2
+  return LazyExpr(Eye(dtype, shape, offset), shape, (0, 1))
+
+def tri(dtype, shape, offset):
+  assert len(shape) == 2
+  return LazyExpr(Tri(dtype, shape, offset), shape, (0, 1))
+
+def delta(dtype, shape):
+  return LazyExpr(Delta(dtype, shape), shape, tuple(range(len(shape))))
+
+def broadcast(lexpr, shape, broadcast_dimensions):
+  new_dims = [None] * len(shape)
+  for i, d in enumerate(broadcast_dimensions):
+    new_dims[d] = lexpr.dims[i]
+  return LazyExpr(lexpr.input, shape, tuple(new_dims))
+
+def transpose(lexpr, perm):
+  new_shape = tuple(lexpr.shape[i] for i in perm)
+  new_dims = tuple(lexpr.dims[i] for i in perm)
+  return LazyExpr(lexpr.input, new_shape, new_dims)
+
+def is_constant(lexpr):
+  return lexpr is not None and type(lexpr.input) is not ArrayVar
+
+def is_trivial(lexpr):
+  return (type(lexpr.input) is ArrayVar and
+          lexpr.dims == tuple(range(len(lexpr.shape))))
+
+
+def eval_lexpr(lexpr, x):
+  """Evaluate a lazy expression using NumPy.
+  Args:
+    lexpr: the LazyExpr to evaluate.
+    x: ndarray or None, representing the value of ArrayVar if present.
+  Returns:
+    An ndarray representing the value of the lazy expression.
+  """
+  if is_trivial(lexpr):
+    return x
+
+  input_, shape, dims = lexpr
+
+  # first create a starting ndarray from input_
+  t = type(input_)
+  if t is ArrayVar:
+    assert x is not None and type(x) is onp.ndarray
+  elif t is Iota:
+    assert x is None
+    x = onp.arange(input_.size, dtype=input_.dtype)
+  elif t is Eye:
+    assert x is None
+    N, M = input_.shape
+    x = onp.eye(N, M, dtype=input_.dtype, k=input_.offset)
+  elif t is Tri:
+    assert x is None
+    N, M = input_.shape
+    x = onp.tri(N, M, dtype=input_.dtype, k=input_.offset)
+  elif t is Delta:
+    ones = [1] * len(input_.shape)
+    iotas = [onp.arange(d).reshape(subvals(ones, [(i, -1)]))
+             for i, d in enumerate(input_.shape)]
+    eyes = [i1 == i2 for i1, i2 in zip(iotas[:-1], iotas[1:])]
+    x = onp.asarray(reduce(op.and_, eyes), input_.dtype)
+  else:
+    assert False
+
+  # then apply the reindexing operation
+  perm = [d for d in dims if d is not None]
+  if perm != list(range(len(perm))):
+    x = onp.transpose(x, perm)
+  if shape != x.shape:
+    in_shape = [1 if d is None else s for d, s in zip(dims, shape)]
+    x = onp.broadcast_to(onp.reshape(x, in_shape), shape)
+
+  return x
+
+
+def stage_lexpr(c, lexpr, x):
+  """Stage a lazy expression into an XLA computation.
+  Args:
+    c: XLA ComputationBuilder into which to stage the expression.
+    lexpr: a LazyExpr to evaluate (or None for the identity expression).
+    x: XlaOp or None, representing the value of ArrayVar if present.
+  Returns:
+    An XlaOp representing the value of the lazy expression.
+  """
+  if lexpr is None or is_trivial(lexpr):
+    return x
+
+  input_, shape, dims = lexpr
+
+  # first create a starting XlaOp from input_
+  t = type(input_)
+  if t is ArrayVar:
+    assert x is not None
+  elif t is Iota:
+    assert x is None
+    x = c.Iota(input_.dtype, input_.size)
+  elif t is Eye:
+    assert x is None
+    N, M = input_.shape
+    bool_eye = c.Eq(c.Add(c.BroadcastedIota(onp.int32, (N, M), 0),
+                          c.Constant(onp.array(input_.offset, onp.int32))),
+                    c.BroadcastedIota(onp.int32, (N, M), 1))
+    x = c.ConvertElementType(bool_eye, xb.dtype_to_etype(input_.dtype))
+  elif t is Tri:
+    assert x is None
+    N, M = input_.shape
+    bool_tri = c.Ge(c.Add(c.BroadcastedIota(onp.int32, (N, M), 0),
+                          c.Constant(onp.array(input_.offset, onp.int32))),
+                    c.BroadcastedIota(onp.int32, (N, M), 1))
+    x = c.ConvertElementType(bool_tri, xb.dtype_to_etype(input_.dtype))
+  elif t is Delta:
+    etype = xb.dtype_to_etype(input_.dtype)
+    iotas = [c.BroadcastedIota(onp.uint32, input_.shape, i)
+             for i in range(len(input_.shape))]
+    eyes = [c.Eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
+    x = c.ConvertElementType(reduce(c.And, eyes), etype)
+  else:
+    assert False
+
+  # then apply the operations encoded in reindex
+  bcast_dims, perm = unzip2((i, d) for i, d in enumerate(dims) if d is not None)
+  if tuple(perm) != tuple(range(len(perm))):
+    x = c.Transpose(x, perm)
+  if shape != c.GetShape(x).dimensions():
+    x = c.BroadcastInDim(x, shape, bcast_dims)
+
+  return x

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -20,6 +20,7 @@ import numpy as onp
 import scipy.special as osp_special
 
 from .. import lax
+from .. import util
 from ..api import custom_transforms, defjvp
 from ..numpy import lax_numpy as np
 from ..numpy.lax_numpy import (_wraps, asarray, _reduction_dims, _constant_like,
@@ -84,7 +85,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
   if b is not None or return_sign:
     raise NotImplementedError("Only implemented for b=None, return_sign=False")
   dims = _reduction_dims(a, axis)
-  shape = lax.subvals(onp.shape(a), zip(dims, (1,) * len(dims)))
+  shape = util.subvals(onp.shape(a), zip(dims, (1,) * len(dims)))
   dimadd = lambda x: lax.reshape(x, shape)
   amax = lax.reduce(a, _constant_like(a, -onp.inf), lax.max, dims)
   amax = lax.select(lax.is_finite(amax), amax, lax.full_like(amax, 0))

--- a/jax/util.py
+++ b/jax/util.py
@@ -56,6 +56,12 @@ def unzip3(xyzs):
     zs.append(z)
   return tuple(xs), tuple(ys), tuple(zs)
 
+def subvals(lst, replace):
+  lst = list(lst)
+  for i, v in replace:
+    lst[i] = v
+  return tuple(lst)
+
 def split_list(args, ns):
   assert type(ns) is list
   args = list(args)

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -299,7 +299,7 @@ class BatchingTest(jtu.JaxTestCase):
     ans = vmap(np.dot, in_axes=(1, None))(xs, ys)
     expected = onp.einsum('ij,i->j', xs, ys)
     self.assertAllClose(ans, expected, check_dtypes=False)
-  
+
   def testDot5(self):
     f = vmap(partial(np.einsum, 'ij,j->i'), (None, 0))
     jaxpr = make_jaxpr(f)(np.zeros((1000, 1000)), np.zeros((1000, 1000)))

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -32,6 +32,7 @@ from jax import lax
 from jax import numpy as lnp
 from jax import ops
 from jax import test_util as jtu
+from jax import util
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -426,8 +427,8 @@ class IndexingTest(jtu.JaxTestCase):
       isnone = [i for i, elt in enumerate(triple) if elt is None]
       zeros = itertools.repeat(0)
       nones = itertools.repeat(None)
-      out = lax.subvals(triple, zip(isnone, zeros))
-      return out, lambda out: slice(*lax.subvals(out, zip(isnone, nones)))
+      out = util.subvals(triple, zip(isnone, zeros))
+      return out, lambda out: slice(*util.subvals(out, zip(isnone, nones)))
     elif isinstance(idx, (tuple, list)) and idx:
       t = type(idx)
       elts, packs = zip(*map(self._ReplaceSlicesWithTuples, idx))
@@ -630,7 +631,7 @@ class IndexingTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype), indexer_with_dummies]
 
     def fun(x, indexer_with_dummies):
-      idx = type(indexer)(lax.subvals(indexer_with_dummies, substitutes))
+      idx = type(indexer)(util.subvals(indexer_with_dummies, substitutes))
       return x[idx]
 
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -40,7 +40,7 @@ from jax import numpy as lnp
 from jax import test_util as jtu
 from jax import dtypes
 from jax import tree_util
-from jax.interpreters import partial_eval
+from jax.interpreters import partial_eval, xla
 from jax.test_util import check_grads
 
 from jax.config import config
@@ -2074,11 +2074,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(lnp.arange(53, 5, -3),
                         onp.arange(53, 5, -3, dtype=lnp.int_),
                         check_dtypes=True)
-    # TODO(mattjj): make these tests work when jax_enable_x64=True
-    # self.assertAllClose(lnp.arange(77, dtype=float),
-    #                     onp.arange(77, dtype=float), check_dtypes=True)
-    # self.assertAllClose(lnp.arange(2, 13, dtype=int),
-    #                     onp.arange(2, 13, dtype=int), check_dtypes=True)
+    self.assertAllClose(lnp.arange(77, dtype=float),
+                        onp.arange(77, dtype=float), check_dtypes=True)
+    self.assertAllClose(lnp.arange(2, 13, dtype=int),
+                        onp.arange(2, 13, dtype=int), check_dtypes=True)
     self.assertAllClose(lnp.arange(0, 1, -0.5),
                         onp.arange(0, 1, -0.5, dtype=lnp.float_),
                         check_dtypes=True)
@@ -2094,6 +2093,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                      type(onp.arange(77, dtype=onp.int32)))
     self.assertTrue(type(lnp.arange(77, dtype=lnp.int32)) ==
                     type(lax.iota(onp.int32, 77)))
+
+    # test laziness for int dtypes
+    self.assertTrue(xla.is_device_constant(lnp.arange(77)))
+    self.assertTrue(xla.is_device_constant(lnp.arange(77, dtype=lnp.int32)))
 
   def testIssue830(self):
     a = lnp.arange(4, dtype=lnp.complex64)

--- a/tests/multibackend_test.py
+++ b/tests/multibackend_test.py
@@ -139,6 +139,18 @@ class MultiBackendTest(jtu.JaxTestCase):
     self.assertEqual(b.device_buffer.device(), api.devices('cpu')[0])
     self.assertEqual(c.device_buffer.device(), api.devices('cpu')[0])
 
+  @jtu.skip_on_devices("cpu")  # test can only fail with non-cpu backends
+  def test_closed_over_values_device_placement(self):
+    # see https://github.com/google/jax/issues/1431
+    if len(jax.devices()) < 2:
+      raise SkipTest("test requires multiple devices")
+
+    def f(): return lax.add(3., 4.)
+    self.assertNotEqual(jax.jit(f)().device_buffer.device(),
+                        api.devices('cpu')[0])
+    self.assertEqual(jax.jit(f, backend='cpu')().device_buffer.device(),
+                     api.devices('cpu')[0])
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -483,6 +483,7 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     f = pmap(lambda x: (x, 3))
+    x = onp.arange(device_count)
     with jtu.count_jit_and_pmap_compiles() as count:
       _, ans = f(x)
     self.assertEqual(count[0], 1)


### PR DESCRIPTION
**TLDR**

Before this commit, this computation would avoid materializing the iota (`np.arange`) array at trace time:

```python
@jit
def f(x):
  m, n = x.shape
  return x + np.arange(n)
```

But this one would materialize the iota array at trace time and stage it into the computation as a potentially large array constant:

```python
@jit
def f(x):
  m, n = x.shape
  return x + np.arange(m)[:, None]
```
The difference is that previously operations like broadcasts, transposes, and singleton-dimension-adding reshapes (as above) would force otherwise lazy values to be materialized, while after this commit broadcasts, transposes, and those reshapes are all lazy operations that only update metadata and reuse the same device buffer as their input rather than compiling and executing XLA computations and producing new buffers.

Also, `np.eye` and `np.tri` become lazy (in addition to `np.zeros`, `np.ones`, `np.full`).

Finally, this PR replaces the ad-hoc "lazy device constant" system.

In an earlier version of this PR, I had also included the feature that lazy expressions would be fused into eager mode op-by-op compiled computations. After thinking it through with @hawkinsp we decided to split that functionality out into a follow-up PR, if we decide to include it at all.

**TODO**
- [x] add a way to make identities and triangular matrices
- [x] systematic tests
- [x] make `jit` force its arguments (see [comment below](https://github.com/google/jax/pull/1668#issuecomment-561699616))
- [x] microbenchmarks
- [x] write implementation notes below

**Follow-up work** for subsequent PRs
- [x] check that this resolves the issues underlying #1640 (or tweak it to resolve them) [EDIT: actually it's already fixed by #1848]
- [ ] fuse lazy expressions into eager op-by-op computations
- [ ] consider adding dtype conversion to the lazy language
- [ ] remove use of `lax.tie_in` in as many places as possible
- [ ] leverage laziness in `pmap` dispatch
- [ ] also handle reshapes that remove singleton dimensions

## Design idea

The basic idea is to introduce a kind of lazy sublanguage. Each DeviceArray carries an expression in this lazy sublanguage, and when we apply certain operations we'll produce a result that refers to the same underlying buffer as the input but has an updated expression (rather than compiling and executing an XLA computation to produce a new result buffer). Only when we apply functions to the array that don't exist in the lazy sublanguage will we compile and execute an XLA computation (taking into account the any lazy expressions on the inputs).

We want a proper _sub_-language rather than, say, modeling the full jaxpr language, because that way we sidestep a tough tradeoff: if the lazy sublanguage can only express "cheap" operations, meaning operations we're happy to stage separately into multiple downstream consumers (and hence could be evaluated multiple times), then we don't need to worry about work sharing. If instead we had expensive computations, which we might not want to evaluate more than once, then we would need a more complex system that attempted to share work between evaluations of lazy expressions. (It gets complex because when we evaluate a lazy subexpression we'd need to decide which of its intermediates to materialize, and then update all equivalent lazy subexpressions in the system with the materialized values we computed.) Unfortunately "cheap" is hard to define precisely without understanding XLA better (on all backends), but the kinds of operations outlined above are ones that we expect can be fused into consumers, and so are "cheap" because the values of these expressions may never be materialized at all.

Because we're attaching expressions to DeviceArrays, this design operates "underneath" all the tracing logic: it sits under the impl rules. In other words, as the toy model below makes clear, it's something one can do in any numerical library, and all of JAX's tracing and transformation machinery sits on top unmodified.

## Lazy sublanguage

Other than being able to express the broadcasts, reshapes, and transposes we want, some design criteria for the language are:
1. cheap expressions (e.g. expressions XLA fuses into consumers, avoiding direct evaluation)
2. fixed-size canonical representation (i.e. it doesn't grow as we apply more broadcast/reshape/transpose operations) so to get more cache hits and for fast expression manipulation

Here's the abstract syntax in terms of AST constructors:

```haskell
data LazyExpr = LazyExpr Input Shape Dims
data Input = ArrayVar
           | Iota Dtype Size
           | Eye Dtype Shape Offset
           | Tri Dtype Shape Offset
           | Delta Shape Axes

type Shape = [Int]
type Dims = [Maybe Int]
type Size = Int
type Offset = Int
type Axes = [Int]
```

There are two components to a LazyExpr: an input and a reindexing specification. The input represents a base array to which the reindexing specification is applied.

An input can represent an array constructor (`Iota`, `Eye`, etc) or it can be an `ArrayVar` which encodes that the base array is some exogenous array value. (These LazyExprs are attached to DeviceArrays, so when the input part of the expression is `ArrayVar` that basically means the associated device buffer is the input, while if the input is an array constructor than the associated `device_buffer` field of the DeviceArray should be set to the sentinel value `xla.device_constant`.)

The reindexing specification encodes the shape of the final result and a list of dimensions, which are integers or Nones. The integer entries take on values 0, 1, ..., N-1 where N is the rank of the input array, and encode where the axes of the input array are to be mapped in the final output. When an entry is None that indicates that the corresponding axis of the result is a broadcasted one.

The corresponding AST constructors in Python look like

```python
LazyExpr = namedtuple('LazyExpr', ['input', 'shape', 'dims'])
LazyArrayVar = namedtuple('ArrayVar', [])
LazyIota = namedtuple('Iota', ['dtype', 'size'])
LazyEye = namedtuple('Eye', ['dtype', 'shape', 'offset'])
LazyTri = namedtuple('Tri', ['dtype', 'shape', 'offset'])
LazyDelta = namedtuple('Delta', ['dtype', 'shape', 'axes'])
```

Here are some examples of lazy expressions and the arrays they represent:

```python
LazyExpr(input=Iota(dtype=dtype('float32'), size=3), shape=(3, 4), dims=(0, None))
DeviceArray([[0., 0., 0., 0.],
             [1., 1., 1., 1.],
             [2., 2., 2., 2.]], dtype=float32)

LazyExpr(input=Iota(dtype=dtype('float32'), size=3), shape=(4, 3), dims=(None, 0))
DeviceArray([[0., 1., 2.],
             [0., 1., 2.],
             [0., 1., 2.],
             [0., 1., 2.]], dtype=float32)
```

See xla.py for a numpy-based interpreter of this language.

## Toy model

Here's a model showing the main idea (except for the changes to op-by-op and jit/pmap logic in xla.py).

```python
from collections import namedtuple
from functools import partial
import itertools as it

import numpy as onp
from jax.util import unzip2

LazyExpr = namedtuple('LazyExpr', ['input', 'shape', 'dims'])
ArrayVar = namedtuple('ArrayVar', [])
Iota = namedtuple('Iota', ['dtype', 'size'])


class Array(object):
  __slots__ = ['buf', 'lexpr']
  def __init__(self, buf, lexpr):
    self.buf = buf
    self.lexpr = lexpr

def materialize(arr):
  input_, shape, dims = arr.lexpr

  t = type(input_)
  if t is ArrayVar:
    x = arr.buf
  elif t is Iota:
    assert arr.buf is None
    x = onp.arange(input_.size, dtype=input_.dtype)
  else:
    assert False

  bcast_dims, perm = unzip2((i, d) for i, d in enumerate(dims) if d is not None)
  transposed = onp.transpose(x, perm)
  out = _broadcast_in_dim(transposed, shape, bcast_dims)

  return out

# NumPy implementation of lax.broadcast_in_dim (from lax_reference.py)
def _broadcast_in_dim(operand, shape, bcast_dims):
  inshape = tuple(1 if i not in bcast_dims else d for i, d in enumerate(shape))
  return onp.broadcast_to(onp.reshape(operand, inshape), shape)


# making an array (with a trivial identity reindex expression)
def make_array(buf):
  lazy_expr = LazyExpr(ArrayVar(), buf.shape, tuple(range(buf.ndim)))
  return Array(buf, lazy_expr)

# making an iota
def make_iota(dtype, size):
  lazy_expr = LazyExpr(Iota(dtype, size), (size,), (0,))
  return Array(None, lazy_expr)

# now for operations! first, a lazy broadcasting operation, modeling XLA's.
def lazy_broadcast(arr, shape, bcast_dims):
  lazy_expr = arr.lexpr
  new_dims = [None] * len(shape)
  for i, d in enumerate(bcast_dims):
    new_dims[d] = lazy_expr.dims[i]
  new_lazy_expr = LazyExpr(lazy_expr.input, shape, new_dims)
  return Array(arr.buf, new_lazy_expr)

# second, a transpose (HLO transpose uses "where it comes from" encoding)
def lazy_transpose(arr, perm):
  lazy_expr = arr.lexpr
  new_shape = [lazy_expr.shape[i] for i in perm]
  new_dims = [lazy_expr.dims[i] for i in perm]
  new_lazy_expr = LazyExpr(lazy_expr.input, new_shape, new_dims)
  return Array(arr.buf, new_lazy_expr)
```

## Micro-benchmarks

This PR adds some work to the op-by-op dispatch path, so we want to check that there isn't a significant performance regression. In the absence of proper performance regression tests, I just did some quick checks by hand.

On master (CPU):
```
In [1]: from jax import lax
In [2]: timeit -r 100 -n 1000 lax.add(1, 1).block_until_ready()
92.9 µs ± 8.3 µs per loop (mean ± std. dev. of 100 runs, 1000 loops each)
In [3]: x = lax.add(1, 1)
In [4]: timeit -r 100 -n 1000 lax.add(x, x).block_until_ready()
46.4 µs ± 5.11 µs per loop (mean ± std. dev. of 100 runs, 1000 loops each)
```

On branch (CPU):
```
In [1]: from jax import lax
In [2]: timeit -r 100 -n 1000 lax.add(1, 1).block_until_ready()
94.2 µs ± 9.03 µs per loop (mean ± std. dev. of 100 runs, 1000 loops each)
In [3]: x = lax.add(1, 1)
In [4]: timeit -r 100 -n 1000 lax.add(x, x).block_until_ready()
47.1 µs ± 5.36 µs per loop (mean ± std. dev. of 100 runs, 1000 loops each)
```

I did something similar with `jit(lax.add)` and there wasn't any movement there either.

## Implementation  notes

- The lazy language itself (namely the AST constructor namedtuples, a NumPy-based evaluator `eval_lexpr`, and an XLA-based interpreter `stage_lexpr`) is added in lazy.py.
- The impl rules of relevant primitives are updated in lax.py, so that e.g. a broadcast on a DeviceArray only updates metadata (as in the toy model above).
- The DeviceArray class in xla.py is updated to keep a `_lazy_expr` attribute.
- I made a couple explicit sentinels, like `device_constant`, rather than using `None` in some places.
- DeviceConstant, FIlledConstant, IotaConstant, EyeConstant are all removed.

Fixes #1909, and incidentally fixes #1431 because I happened to be updating that code.