### PR TITLE
fix degenerate case behavior of linspace

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1689,76 +1689,65 @@ def _wrap_numpy_nullary_function(f):
   return wrapper
 
 
-# TODO(mattjj,levskaya): use this version when we sort out test failure
-# @_wraps(onp.linspace)
-# def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
-#              axis=0):
-#   """Implementation of linspace differentiable in start and stop args."""
-#   lax._check_user_dtype_supported(dtype, "linspace")
-#   dtype = dtype or onp.result_type(start, stop, float(num))
-#   bounds_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
-#   broadcast_start = broadcast_to(start, bounds_shape)
-#   axis = len(bounds_shape) + axis + 1 if axis < 0 else axis
-#   bounds_shape.insert(axis, 1)
-#   iota_shape = [1,] * len(bounds_shape)
-#   iota_shape[axis] = num
-#   if endpoint:
-#     delta = (stop - start) / (num - 1)
-#   else:
-#     delta = (stop - start) / num
-#   out = (reshape(broadcast_start, bounds_shape) +
-#          reshape(lax.iota(dtype, num), iota_shape) *
-#          reshape(delta, bounds_shape))
-#   if retstep:
-#     return lax.convert_element_type(out, dtype), delta
-#   else:
-#     return lax.convert_element_type(out, dtype)
-#
-#
-# @_wraps(onp.logspace)
-# def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, axis=0):
-#   """Implementation of logspace differentiable in start and stop args."""
-#   lin = linspace(start, stop, num,
-#                  endpoint=endpoint, retstep=False, dtype=None, axis=axis)
-#   if dtype is None:
-#     return power(base, lin)
-#   else:
-#     return lax.convert_element_type(power(base, lin), dtype)
-#
-#
-# @_wraps(onp.geomspace)
-# def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
-#   """Implementation of geomspace differentiable in start and stop args."""
-#   dtype = dtype or onp.result_type(start, stop, float(num),
-#                                    zeros((), dtype))
-#   # follow the numpy geomspace convention for negative and complex endpoints
-#   signflip = 1 - (1 - sign(real(start))) * (1 - sign(real(stop))) // 2
-#   res = signflip * logspace(log10(signflip * start),
-#                             log10(signflip * stop), num,
-#                             endpoint=endpoint, base=10.0,
-#                             dtype=dtype, axis=0)
-#   if axis != 0:
-#     res = moveaxis(res, 0, axis)
-#   return lax.convert_element_type(res, dtype)
-
+@_wraps(onp.linspace)
 def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
              axis=0):
+  """Implementation of linspace differentiable in start and stop args."""
   lax._check_user_dtype_supported(dtype, "linspace")
-  try:
-    out = onp.linspace(start, stop, num, endpoint, retstep, dtype, axis)
-    if retstep:
-      return asarray(out[0]), out[1]
-    else:
-      return asarray(out)
-  except TypeError:  # Old versions of onp may lack axis arg.
-    out = onp.linspace(start, stop, num, endpoint, retstep, dtype)
-    if retstep:
-      return moveaxis(asarray(out[0]), 0, axis), out[1]
-    else:
-      return moveaxis(asarray(out), 0, axis)
+  if num < 0:
+    raise ValueError("Number of samples, %s, must be non-negative." % num)
+  dtype = dtype or onp.result_type(start, stop, float(num))
+  bounds_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
+  broadcast_start = broadcast_to(start, bounds_shape)
+  axis = len(bounds_shape) + axis + 1 if axis < 0 else axis
+  bounds_shape.insert(axis, 1)
+  iota_shape = [1,] * len(bounds_shape)
+  iota_shape[axis] = num
+  div = (num - 1) if endpoint else num
+  if num > 1:
+    delta = (stop - start) / div
+    out = (reshape(broadcast_start, bounds_shape) +
+           reshape(lax.iota(dtype, num), iota_shape) *
+           reshape(delta, bounds_shape))
+  elif num == 1:
+    delta = nan
+    out = reshape(broadcast_start, bounds_shape)
+  else: # num == 0 degenerate case, match onp behavior
+    empty_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
+    empty_shape.insert(axis, 0)
+    delta = nan
+    out = reshape(array([]), empty_shape).astype(dtype)
+  if retstep:
+    return lax.convert_element_type(out, dtype), delta
+  else:
+    return lax.convert_element_type(out, dtype)
 
-logspace = _wrap_numpy_nullary_function(onp.logspace)
-geomspace = _wrap_numpy_nullary_function(onp.geomspace)
+
+@_wraps(onp.logspace)
+def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None, axis=0):
+  """Implementation of logspace differentiable in start and stop args."""
+  lin = linspace(start, stop, num,
+                 endpoint=endpoint, retstep=False, dtype=None, axis=axis)
+  if dtype is None:
+    return power(base, lin)
+  else:
+    return lax.convert_element_type(power(base, lin), dtype)
+
+
+@_wraps(onp.geomspace)
+def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis=0):
+  """Implementation of geomspace differentiable in start and stop args."""
+  dtype = dtype or onp.result_type(start, stop, float(num),
+                                   zeros((), dtype))
+  # follow the numpy geomspace convention for negative and complex endpoints
+  signflip = 1 - (1 - sign(real(start))) * (1 - sign(real(stop))) // 2
+  res = signflip * logspace(log10(signflip * start),
+                            log10(signflip * stop), num,
+                            endpoint=endpoint, base=10.0,
+                            dtype=dtype, axis=0)
+  if axis != 0:
+    res = moveaxis(res, 0, axis)
+  return lax.convert_element_type(res, dtype)
 
 
 @_wraps(onp.meshgrid)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1242,7 +1242,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for axis in set(range(-len(shape), len(shape))) | set([None])
       # `weights_shape` is either `None`, same as the averaged axis, or same as
       # that of the input
-      for weights_shape in ([None, shape] if axis is None
+      for weights_shape in ([None, shape] if axis is None or len(shape) == 1
                             else [None, (shape[axis],), shape])
       for returned in [False, True]))
   def testAverage(self, shape, dtype, axis, weights_shape, returned, rng_factory):
@@ -2059,16 +2059,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "dtype": dtype, "rng_factory": rng_factory}
         for start_shape in [(), (2,), (2, 2)]
         for stop_shape in [(), (2,), (2, 2)]
-        for num in [5, 20]
+        for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for retstep in [True, False]
         for dtype in number_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testLinspace(self, start_shape, stop_shape, num, endpoint,
                    retstep, dtype, rng_factory):
-    # TODO(mattjj,levskaya): re-enable when test failure is sorted out
-    raise SkipTest("tfp test failures")
-
     rng = rng_factory()
     # relax default tolerances slightly
     tol = tolerance(dtype if dtype else onp.float32) * 10
@@ -2110,16 +2107,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "dtype": dtype, "rng_factory": rng_factory}
         for start_shape in [(), (2,), (2, 2)]
         for stop_shape in [(), (2,), (2, 2)]
-        for num in [5, 20]
+        for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for base in [10.0, 2, onp.e]
         for dtype in number_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testLogspace(self, start_shape, stop_shape, num,
                    endpoint, base, dtype, rng_factory):
-    # TODO(mattjj,levskaya): re-enable when test failure is sorted out
-    raise SkipTest("tfp test failures")
-
     if (dtype in int_dtypes and
         jtu.device_under_test() == "gpu" and
         not FLAGS.jax_enable_x64):
@@ -2161,16 +2155,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "dtype": dtype, "rng_factory": rng_factory}
         for start_shape in [(), (2,), (2, 2)]
         for stop_shape in [(), (2,), (2, 2)]
-        for num in [5, 20]
+        for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         # NB: numpy's geomspace gives nonsense results on integer types
         for dtype in inexact_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testGeomspace(self, start_shape, stop_shape, num,
                     endpoint, dtype, rng_factory):
-    # TODO(mattjj,levskaya): re-enable when test failure is sorted out
-    raise SkipTest("tfp test failures")
-
     rng = rng_factory()
     # relax default tolerances slightly
     tol = tolerance(dtype if dtype else onp.float32) * 10


### PR DESCRIPTION
Fixes the issue in num=1, num=0 cases that was breaking TFP tests.  Added test coverage for these degenerate cases.  Also fixed an unrelated bug in lax_numpy tests that was blocking larger JAX_NUM_GENERATED_CASES coverage option.