### PR TITLE
Prototype an explicit embedding API

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4195,6 +4195,12 @@ outfeed_p.def_impl(partial(xla.apply_primitive, outfeed_p))
 outfeed_p.def_abstract_eval(_outfeed_abstract_eval)
 xla.translations[outfeed_p] = _outfeed_translation_rule
 
+
+iota_p = core.Primitive("iota")
+iota_p.def_abstract_eval(lambda dtype, size: ShapedArray((size,), dtype))
+xla.translations[iota_p] = lambda c, dtype, size: c.Iota(dtype, size)
+
+
 ### util
 
 _ndim = onp.ndim

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -144,6 +144,7 @@ class WrappedFun(object):
 
   def call_wrapped(self, *args, **kwargs):
     stack = []
+    gen = None
     for (gen, gen_args), out_store in zip(self.transforms, self.stores):
       gen = gen(*(gen_args + tuple(args)), **kwargs)
       args, kwargs = next(gen)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -901,7 +901,7 @@ else:
 # `np.where(np.zeros(1000), 7, 4)`. In op-by-op mode, we don't want to
 # materialize the broadcast forms of scalar arguments.
 @_wraps(onp.where, update_doc=False)
-@jit
+# @jit
 def where(condition, x=None, y=None):
   if x is None or y is None:
     raise ValueError("Must use the three-argument form of where().")


### PR DESCRIPTION
Consider this program:

```python
import jax.numpy as np

@jit
def foo(x):
  M, N = x.shape
  mask =  np.arange(M)[:, None] < np.arange(N)[None, :]
  return lax.select(mask, x, 0)
```

What gets staged out to XLA? You might be surprised! The jaxpr seen by the tracing machinery is essentially this:

```
{ lambda b c ;  ; a.
  let d = select b a c
  in [d] }
```

The creation of `mask` doesn't get staged out at all: instead, all those operations (iota, reshape, less-than) are executed eagerly (op-by-op), building the large constant in memory before building it into the jaxpr as a constant (`b` in the jaxpr). That's a shame, because if XLA got to see the whole computation corresponding to `foo`'s body, it might not need to materialize `mask` at all, fusing its construction into the `lax.select` operation. Instead, the current behavior and its resulting memory inefficiency has surprised users and prevented them from expressing the XLA computations they want.

(More laziness, like #1668, can help, but has limits unless we make everything lazy, which opens up complicated tradeoffs. And even if we end up with full laziness someday, it should be a magical convenience layer on top of a more explicit API underneath.)

The crux of the issue is data dependence: `mask` has no data dependence on the argument `x` (depending on shape information doesn't count as a data dependence). All of JAX's embedding (i.e. tracing) machinery works by data dependence, and while there are other mechanisms possible (not detailed here), relying on data dependence avoids a lot of complexity and other nasty surprises. In particular, it makes compositionality much easier. An unfortunate result is that here we're not able to stage out what we want, at least not without a new API. (The `lax.tie_in` primitive is a way to force a data dependence. and it's used specifically for this issue. But we're not happy with it because it requires a weird mental model and makes programs awkward.)

One way to think about the issue is in terms of embedding: we've embedded the jaxpr language (essentially XLA HLO) in Python in a way that looks like regular Python+NumPy, but as in this case it's sometimes unclear what jaxpr is being expressed, and sometimes hard or impossible to express exactly the jaxpr you want. We've optimized for convenience but sacrificed some expressiveness and clarity.

One solution is to provide an explicit variant of the embedding with which users can express any jaxpr, at the cost of some convenience. This PR is a prototype in that direction.

The basic proposal is to introduce a `jit` variant called `pure_jit` that enables more explicit embeddings.

**So far, we've implemented `pure_jaxpr`, which is like the explicit analogue of `make_jaxpr`. That is, `pure_jaxpr` is to `make_jaxpr` roughly like `pure_jit` is to `jit`.**

Here are some examples:

```python
import jax.numpy as np
from jax import lax
from jax import pure_jaxpr

def f(pure):
  x = pure.lit(1)
  y = np.broadcast_to(x, (1000,))
  return y
print(pure_jaxpr(f))  # pure_jaxpr is to make_jaxpr as pure_jit is to jit
```
```
{ lambda  ;  ; .
  let a = broadcast_in_dim[ shape=(1000,)
                            broadcast_dimensions=() ] 1
  in [a] }
```

```python
def g(pure, y):
  x = pure.app(lax.iota_p, dtype=np.int32, size=10)
  return x + y
print(pure_jaxpr(g, 3))
```

```
{ lambda  ;  ; a.
  let b = iota[ dtype=<class 'numpy.int32'>
                size=10 ]
      c = add b a
  in [c] }
```

The basic idea is that `pure_jit` (and here `pure_jaxpr`) provide an additional argument to the function being called. That additional argument can be used to ensure values, including constants, get staged out (`pure.lit`), and to ensure that primitive applications are staged out (`pure.app`).

To be super explicit, a user could write every primitive application with `pure.app`. But usually these things are only needed in special places, particularly creating constants.

Here's what the original program `foo` could look like:

```python
from jax import lax

@pure_jit
def foo(pure, x):
  a = pure.app(lax.iota_p, size=x.shape[0], dtype=np.int32)
  b = pure.app(lax.iota_p, size=x.shape[1], dtype=np.int32)
  mask =  a[:, None] < b[None, :]
  return lax.select(mask, x, 0)
```

We could imagine providing some convenience methods, like have a `pure.iota` and `pure.zeros` etc., but the fundamental components are `pure.lit` and `pure.app`. (In fact, if we have an identity primitive, we only need `pure.app`. See also [`kyapply` from Autograd's early history](https://github.com/HIPS/autograd/commit/06394705bff11cf285d0b62d9296f97cc0362aef).)

TODO:
- [ ] iterate on the API
- [ ] check the behavior under partial evaluation (i.e. grad): does grad-of-jit cause these things to be executed in an op-by-op way?
- [ ] add `pure_jit`
- [ ] if needed, generalize our notion of jaxpr linearity (cf [this comment](https://github.com/google/jax/pull/1647#issuecomment-552067418))