### PR TITLE
patch lax.axis_index, add warning about soft_pmap

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -888,6 +888,7 @@ class _TempAxisName(object):
 
 
 def soft_pmap(fun, axis_name=None, backend=None):
+  warn("soft_pmap is an experimental feature and probably has bugs!")
   _check_callable(fun)
   axis_name = _TempAxisName(fun) if axis_name is None else axis_name
 

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -76,7 +76,6 @@ class PapplyTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSelect(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     p = onp.arange(15).reshape((5, 3)) % 4 == 1
     f = onp.zeros((5, 3))
 
@@ -159,7 +158,6 @@ class ParallelizeTest(jtu.JaxTestCase):
     self.assertIn('psum', repr(jaxpr))
 
   def testAdd(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     x = onp.arange(10)
     y = 2 * onp.arange(10)
     def f(x): return x + y
@@ -168,7 +166,6 @@ class ParallelizeTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testAdd2(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     x = onp.arange(10)
     y = 2 * onp.arange(10)
     def f(y): return x + y

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -479,7 +479,6 @@ class PmapTest(jtu.JaxTestCase):
     self.assertEqual(c.ravel()[0], device_count * 1)
 
   def testAxisIndex(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     device_count = xla_bridge.device_count()
     f = pmap(lambda x: x + pxla.axis_index('i'), 'i')
     x = np.ones(device_count)
@@ -559,7 +558,6 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSoftPmapAxisIndex(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     n = 4 * xla_bridge.device_count()
     def f(x):
       return x * lax.axis_index('i')
@@ -576,7 +574,6 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSoftPmapNested(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     n = 4 * xla_bridge.device_count()
 
     @partial(soft_pmap, axis_name='i')
@@ -590,7 +587,6 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testGradOfSoftPmap(self):
-    raise SkipTest("buggy")  # TODO(mattjj): fix
     n = 4 * xla_bridge.device_count()
 
     @partial(soft_pmap, axis_name='i')


### PR DESCRIPTION
This PR makes `lax.axis_index` no longer raise a NotImplementedError, which we added in #1682. Also it adds back in a bunch of `soft_pmap` and `lax.axis_index` tests.

We don't have great CI tools to test the hard multi-device nested-pmap cases of `lax.axis_index`, but for posterity here's the kind of test I ran in colab:

```python
import jax
from jax import lax

def f(a):
  return jax.pmap(jax.pmap(lambda x: lax.axis_index('i'), 'j'), 'i')(a)
print(f(onp.ones((2, 2))))

def f(a):
  return jax.pmap(jax.pmap(lambda x: lax.axis_index('j'), 'j'), 'i')(a)
print(f(onp.ones((2, 2))))

def f(a):
  return jax.pmap(jax.pmap(jax.pmap(lambda x: lax.axis_index('i'), 'k'), 'j'), 'i')(a)
print(f(onp.ones((2, 2, 2))))

def f(a):
  return jax.pmap(jax.pmap(jax.pmap(lambda x: lax.axis_index('j'), 'k'), 'j'), 'i')(a)
print(f(onp.ones((2, 2, 2))))

def f(a):
  return jax.pmap(jax.pmap(jax.pmap(lambda x: lax.axis_index('k'), 'k'), 'j'), 'i')(a)
print(f(onp.ones((2, 2, 2))))
```