### PR TITLE
Add a type check that verifies the lower and upper arguments to lax.f…

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -121,7 +121,13 @@ def fori_loop(lower, upper, body_fun, init_val):
   Returns:
     Loop value from the final iteration, of type ``a``.
   """
-  # TODO: perhaps do some type checking here, for better error messages
+  # TODO: perhaps do more type checking here, for better error messages.
+  lower_dtype = xb.canonicalize_dtype(lax.dtype(lower))
+  upper_dtype = xb.canonicalize_dtype(lax.dtype(upper))
+  if lower_dtype != upper_dtype:
+    msg = ("lower and upper arguments to fori_loop must have equal types, "
+           "got {} and {}")
+    raise TypeError(msg.format(lower_dtype.name, upper_dtype.name))
   _, _, result = while_loop(_fori_cond_fun, _fori_body_fun(body_fun),
                             (lower, upper, init_val))
   return result

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -321,6 +321,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = (onp.array([4, 3]), onp.array([1, 2]))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testForiLoopErrors(self):
+    """Test typing error messages for while."""
+    with self.assertRaisesRegex(
+      TypeError, "arguments to fori_loop must have equal types"):
+      lax.fori_loop(np.int16(0), np.int32(10), (lambda i, c: c), np.float32(7))
+
   def testForiLoopBatched(self):
     def body_fun(i, loop_carry):
       x, y = loop_carry
@@ -461,11 +467,11 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     def fun(pred):
       return lax.cond(pred, pred, lambda x: (True, x), pred, lambda x: (False, x))
-    
+
     @api.jit
     def cfun(pred):
       return fun(pred)
-    
+
     self.assertEqual(fun(0), cfun(0), (False,0))
     self.assertEqual(fun(0.), cfun(0.), (False,0.))
     self.assertEqual(fun(1), cfun(1), (True,1))
@@ -475,7 +481,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     for pred in ["abc", [], [1,2]]:
       for f in [fun, cfun]:
         self.assertRaises(TypeError, f, pred)
-    
+
   def testNestedCond(self):
     def fun(x):
       if x < 2:


### PR DESCRIPTION
…ori_loop have equal types.

Gives a better error (otherwise the `lax.lt` inside the loop condition reports a type mismatch).