### PR TITLE
Change test tolerance logic not to choose tolerance values based on f…

### DIFF
--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -16,9 +16,12 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as onp
+
 from jax.abstract_arrays import ShapedArray
 from jax.core import Primitive
 from jax.interpreters import xla
+from .. import dtypes
 from ..interpreters import ad
 from ..interpreters import batching
 
@@ -37,6 +40,11 @@ def fft_impl(x, fft_type, fft_lengths):
   return xla.apply_primitive(fft_p, x, fft_type=fft_type, fft_lengths=fft_lengths)
 
 def fft_abstract_eval(x, fft_type, fft_lengths):
+  if not dtypes.issubdtype(x.dtype, onp.complexfloating):
+    raise TypeError("FFT requires complex inputs, got {}.".format(x.dtype.name))
+  if x.dtype != onp.complex64:
+    msg = "FFT is only implemented for complex64 types, got {}."
+    raise NotImplementedError(msg.format(x.dtype.name))
   return ShapedArray(x.shape, x.dtype)
 
 def fft_translation_rule(c, x, fft_type, fft_lengths):

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -104,8 +104,8 @@ def tolerance(dtype, tol=None):
   tol = {onp.dtype(key): value for key, value in tol.items()}
   default = (tpu_default_tolerance if device_under_test() == "tpu"
              else default_tolerance)
-  dtype = onp.dtype(dtype)
-  return tol.get(dtypes.canonicalize_dtype(dtype), default[dtype])
+  dtype = dtypes.canonicalize_dtype(onp.dtype(dtype))
+  return tol.get(dtype, default[dtype])
 
 def _assert_numpy_close(a, b, atol=None, rtol=None):
   assert a.shape == b.shape

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -546,7 +546,9 @@ class APITest(jtu.JaxTestCase):
                           -0.70368982+0.35184491j,
                            0.1886467 -0.09432335j,
                            0.86873727-0.43436864j])
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(ans, expected, check_dtypes=False,
+                        atol=jtu.default_gradient_tolerance,
+                        rtol=jtu.default_gradient_tolerance)
 
   def test_complex_output_jacrev_raises_error(self):
     self.assertRaises(TypeError, lambda: jacrev(lambda x: np.sin(x))(1 + 2j))

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -57,7 +57,9 @@ class BatchingTest(jtu.JaxTestCase):
 
     ans = matmat(A, B)
     expected = onp.dot(A, B)
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(
+        ans, expected, check_dtypes=False,
+        rtol={onp.float32:1e-2} if jtu.device_under_test() == "tpu" else None)
 
     jaxpr = make_jaxpr(matmat)(A, B)
     self.assertEqual(len(jaxpr.eqns), 1)
@@ -217,7 +219,9 @@ class BatchingTest(jtu.JaxTestCase):
           np.maximum(np.dot(W_t, np.transpose(x_ex)), 0.0), x_ex)
       expected_ans = np.transpose(expected_ans)
 
-      self.assertAllClose(ans[i], expected_ans, check_dtypes=False)
+      self.assertAllClose(
+          ans[i], expected_ans, check_dtypes=False,
+          atol={onp.float32:5e-2} if jtu.device_under_test() == "tpu" else None)
 
   def testDotGeneral(self):
     R = onp.random.RandomState(0).randn
@@ -566,7 +570,8 @@ class BatchingTest(jtu.JaxTestCase):
       per_example_direct += [
           np.reshape(g, (1,) + g.shape)]
     per_example_direct = np.concatenate(per_example_direct, axis=0)
-    self.assertAllClose(per_example, per_example_direct, check_dtypes=True)
+    self.assertAllClose(per_example, per_example_direct, check_dtypes=True,
+                        rtol=1e-5)
 
   def testCumProd(self):
    x = np.arange(9).reshape(3, 3) + 1
@@ -616,7 +621,7 @@ class BatchingTest(jtu.JaxTestCase):
 
     ans = vmap(lax_linalg.cholesky)(a)
     expected = onp.linalg.cholesky(a)
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(ans, expected, check_dtypes=False, rtol=1e-4)
 
     b = onp.random.RandomState(0).randn(10, 5, 5).astype(onp.float32)
     b = onp.matmul(b, onp.conj(onp.swapaxes(b, -1, -2)))
@@ -624,7 +629,7 @@ class BatchingTest(jtu.JaxTestCase):
 
     ans = vmap(lax_linalg.cholesky, in_axes=1, out_axes=0)(b_trans)
     expected = onp.linalg.cholesky(b)
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(ans, expected, check_dtypes=False, rtol=1e-4)
 
   def testLaxLinalgTriangularSolve(self):
     a = onp.random.RandomState(0).randn(4, 10, 4).astype(onp.float32)

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -172,7 +172,7 @@ class CoreTest(jtu.JaxTestCase):
 
   @parameterized.parameters(test_specs)
   def test_jit(self, f, args):
-    jtu.check_eq(jit(f)(*args), f(*args))
+    jtu.check_close(jit(f)(*args), f(*args))
 
   @parameterized.parameters(test_specs)
   def test_jvp(self, f, args):
@@ -192,7 +192,9 @@ class CoreTest(jtu.JaxTestCase):
 
   @parameterized.parameters(test_specs)
   def test_vjp(self, f, args):
-    jtu.check_vjp(f, partial(vjp, f), args)
+    jtu.check_vjp(f, partial(vjp, f), args,
+                  rtol={onp.float32: 1e-2, onp.float64: 1e-5},
+                  atol={onp.float32: 1e-2, onp.float64: 1e-5})
 
   def test_jvp_closure(self):
     def foo(x):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -193,7 +193,7 @@ class CoreTest(jtu.JaxTestCase):
   @parameterized.parameters(test_specs)
   def test_vjp(self, f, args):
     jtu.check_vjp(f, partial(vjp, f), args,
-                  rtol={onp.float32: 1e-2, onp.float64: 1e-5},
+                  rtol={onp.float32: 3e-2, onp.float64: 1e-5},
                   atol={onp.float32: 1e-2, onp.float64: 1e-5})
 
   def test_jvp_closure(self):

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -31,7 +31,9 @@ config.parse_flags_with_absl()
 
 
 float_dtypes = [onp.float32, onp.float64]
-complex_dtypes = [onp.complex64, onp.complex128]
+# TODO(b/144573940): onp.complex128 isn't supported by XLA, and the JAX
+# implementation casts to complex64.
+complex_dtypes = [onp.complex64]
 inexact_dtypes = float_dtypes + complex_dtypes
 int_dtypes = [onp.int32, onp.int64]
 bool_dtypes = [onp.bool_]
@@ -67,7 +69,8 @@ class FftTest(jtu.JaxTestCase):
     onp_op = onp.fft.ifftn if inverse else onp.fft.fftn
     np_fn = lambda a: np_op(a, axes=axes)
     onp_fn = lambda a: onp_op(a, axes=axes)
-    self._CheckAgainstNumpy(onp_fn, np_fn, args_maker, check_dtypes=True,
+    # Numpy promotes to complex128 aggressively.
+    self._CheckAgainstNumpy(onp_fn, np_fn, args_maker, check_dtypes=False,
                             tol=1e-4)
     self._CompileAndCheck(np_fn, args_maker, check_dtypes=True)
     # Test gradient for differentiable types.

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -39,7 +39,9 @@ class EinsumTest(jtu.JaxTestCase):
   def _check(self, s, *ops):
     a = onp.einsum(s, *ops)
     b = np.einsum(s, *ops)
-    self.assertAllClose(a, b, atol=1e-4, rtol=1e-4, check_dtypes=True)
+
+    atol = 2e-1 if jtu.device_under_test() == "tpu" else 1e-4
+    self.assertAllClose(a, b, atol=atol, rtol=1e-4, check_dtypes=True)
 
   def test_three_operands_1(self):
     r = rng()
@@ -311,8 +313,9 @@ class EinsumTest(jtu.JaxTestCase):
         L[n,c] = s
 
     path = np.einsum_path('ntk,kd,dc->nc', S, W, V, optimize='optimal')[0]
+    rtol = 1e-2 if jtu.device_under_test() == "tpu" else None
     self.assertAllClose(L, np.einsum('ntk,kd,dc->nc', S, W, V, optimize=path),
-                        check_dtypes=False)
+                        check_dtypes=False, rtol=rtol)
 
 
 if __name__ == '__main__':

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -150,7 +150,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype) + (d - 1) / 2.]
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol={onp.float32: 1e-3, onp.float64: 1e-14})
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   def testIssue980(self):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -98,7 +98,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(onp.linalg.det, np.linalg.det, args_maker,
                             check_dtypes=True, tol=1e-3)
-    self._CompileAndCheck(np.linalg.det, args_maker, check_dtypes=True)
+    self._CompileAndCheck(np.linalg.det, args_maker, check_dtypes=True,
+                          rtol={onp.float64: 1e-13})
 
   def testDetOfSingularMatrix(self):
     x = np.array([[-1., 3./2], [2./3, -1.]], dtype=onp.float32)
@@ -629,7 +630,9 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     x, = args_maker()
     p, l, u = jsp.linalg.lu(x)
-    self.assertAllClose(x, onp.matmul(p, onp.matmul(l, u)), check_dtypes=True)
+    self.assertAllClose(x, onp.matmul(p, onp.matmul(l, u)), check_dtypes=True,
+                        rtol={onp.float32: 1e-4, onp.float64:1e-12,
+                              onp.complex64: 1e-4, onp.complex128:1e-12})
     self._CompileAndCheck(jsp.linalg.lu, args_maker, check_dtypes=True)
 
   def testLuOfSingularMatrix(self):
@@ -691,7 +694,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     u = onp.triu(lu)
     for i in range(n):
       x[[i, piv[i]],] = x[[piv[i], i],]
-    self.assertAllClose(x, onp.matmul(l, u), check_dtypes=True, rtol=1e-3)
+    self.assertAllClose(x, onp.matmul(l, u), check_dtypes=True, rtol=1e-3,
+                        atol=1e-3)
     self._CompileAndCheck(jsp.linalg.lu_factor, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -813,7 +817,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
         l if lower else T(l), b, trans=1 if transpose_a else 0, lower=lower,
         unit_diagonal=unit_diagonal)
 
-    self.assertAllClose(onp_ans, ans, check_dtypes=True)
+    self.assertAllClose(onp_ans, ans, check_dtypes=True,
+                        rtol={onp.float32: 1e-4, onp.float64: 1e-11})
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -301,7 +301,9 @@ class MaskingTest(jtu.JaxTestCase):
     seqs_ = [xs[:t] for xs, t in zip(seqs, ts)]
     expected = grad(lambda W: rnn_reference(W, seqs_, ys).sum())(W)
 
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(
+        ans, expected, check_dtypes=False,
+        rtol={onp.float32:2e-2} if jtu.device_under_test() == "tpu" else None)
 
   def test_nesting(self):
     raise SkipTest("not yet implemented")

--- a/tests/multibackend_test.py
+++ b/tests/multibackend_test.py
@@ -55,7 +55,7 @@ class MultiBackendTest(jtu.JaxTestCase):
     y = npr.uniform(size=(10,10))
     z_host = onp.matmul(x, y)
     z = fun(x, y)
-    self.assertAllClose(z, z_host, check_dtypes=True)
+    self.assertAllClose(z, z_host, check_dtypes=True, rtol=1e-2)
     correct_platform = backend if backend else jtu.device_under_test()
     self.assertEqual(z.device_buffer.platform(), correct_platform)
 
@@ -77,7 +77,7 @@ class MultiBackendTest(jtu.JaxTestCase):
     y = npr.uniform(size=(10,10))
     z_host = onp.matmul(x, y) + onp.ones_like(x)
     z = fun(x, y)
-    self.assertAllClose(z, z_host, check_dtypes=True)
+    self.assertAllClose(z, z_host, check_dtypes=True, rtol=1e-2)
     correct_platform = outer if outer else jtu.device_under_test()
     self.assertEqual(z.device_buffer.platform(), correct_platform)
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -37,7 +37,8 @@ config.parse_flags_with_absl()
 class NNFunctionsTest(jtu.JaxTestCase):
 
   def testSoftplusGrad(self):
-    check_grads(nn.softplus, (1e-8,), 4)
+    check_grads(nn.softplus, (1e-8,), 4,
+                rtol=1e-2 if jtu.device_under_test() == "tpu" else None)
 
   def testSoftplusValue(self):
     val = nn.softplus(89.)

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -291,7 +291,7 @@ class OptimizerTests(jtu.JaxTestCase):
 
     J1 = jacrev(loss, argnums=(0,))(initial_params)
     J2 = jacfwd(loss, argnums=(0,))(initial_params)
-    self.assertAllClose(J1, J2, check_dtypes=True)
+    self.assertAllClose(J1, J2, check_dtypes=True, rtol=1e-6)
 
   def testUnpackPackRoundTrip(self):
     opt_init, _, _ = optimizers.momentum(0.1, mass=0.9)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -286,7 +286,8 @@ class LaxRandomTest(jtu.JaxTestCase):
     pdf = scipy.stats.gamma.pdf(z, alpha)
     expected_grad = -cdf_dot / pdf
 
-    self.assertAllClose(actual_grad, expected_grad, check_dtypes=True, rtol=0.0005)
+    self.assertAllClose(actual_grad, expected_grad, check_dtypes=True,
+                        rtol=2e-2 if jtu.device_under_test() == "tpu" else 5e-4)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -66,7 +66,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       return [k, mu, loc]
 
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
-                            tol=1e-4)
+                            tol=1e-3)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(3, jtu.rand_default)
@@ -97,8 +97,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       return [x, a, b, loc, scale]
 
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
-                            tol=1e-4)
-    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
+                            tol=1e-3)
+    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True, rtol=2e-5)
 
   @genNamedParametersNArgs(3, jtu.rand_default)
   def testCauchyLogPdf(self, rng_factory, shapes, dtypes):
@@ -112,7 +112,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(2, jtu.rand_positive)
@@ -128,7 +129,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       x = x / onp.sum(x, axis=-1, keepdims=True)
       return [x, alpha]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(3, jtu.rand_positive)
@@ -141,7 +143,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       x, loc, scale = map(rng, shapes, dtypes)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(4, jtu.rand_positive)
@@ -170,7 +173,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(scale, a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   @genNamedParametersNArgs(3, jtu.rand_default)
@@ -185,7 +189,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(scale, a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-6)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   # TODO: currently it ignores the argument "shapes" and only tests dim=4
@@ -218,7 +223,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-3)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
@@ -234,7 +240,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
@@ -250,7 +257,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [x, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-6)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
@@ -268,8 +276,9 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [q, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
-    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
+    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True, rtol=1e-5)
 
 
   @genNamedParametersNArgs(4, jtu.rand_positive)
@@ -282,7 +291,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       x, b, loc, scale = map(rng, shapes, dtypes)
       return [x, b, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-3)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
@@ -298,7 +308,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       scale = onp.clip(onp.abs(scale), a_min=0.1, a_max=None)
       return [x, df, loc, scale]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-3)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
 
@@ -312,7 +323,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
       x, loc, scale = map(rng, shapes, dtypes)
       return [x, loc, onp.abs(scale)]
 
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=True,
+                            tol=1e-4)
     self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
 
   def testIssue972(self):


### PR DESCRIPTION
…lags (in particular, --jax_enable_x64).

We would like to move away from having global flags to enable 64-bit mode. We therefore need other methods to select test tolerances. Instead, use a per-type default tolerance, and allow tests to override tolerances by passing per-type dictionaries of atol and rtol values. Fix up tolerances to make tests pass.

This change would allow further simplification of `lax_test.py` and `lax_numpy_test.py` since the common `test_util.py` now has logic for per-dtype tolerances.

Improve dtype rules for `fft` ops.