### PR TITLE
Change scalar promotion rules to prefer array types over scalar types.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -242,3 +242,5 @@ def _make_concrete_python_scalar(x):
 for t in dtypes.python_scalar_dtypes.keys():
   core.pytype_aval_mappings[t] = _make_concrete_python_scalar
   ad_util.jaxval_zeros_likers[t] = _zeros_like_python_scalar
+
+core.literalable_types.update(dtypes.python_scalar_dtypes.keys())

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -41,7 +41,7 @@ def concretization_function_error(fun):
 
 class UnshapedArray(core.AbstractValue):
   __slots__ = ['dtype', 'weak_type']
-  array_abstraction_level = 1
+  array_abstraction_level = 2
 
   def __init__(self, dtype, weak_type=False):
     self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtype))

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -40,14 +40,16 @@ def concretization_function_error(fun):
 
 
 class UnshapedArray(core.AbstractValue):
-  __slots__ = ['dtype']
-  array_abstraction_level = 3
+  __slots__ = ['dtype', 'weak_type']
+  array_abstraction_level = 1
 
-  def __init__(self, dtype):
+  def __init__(self, dtype, weak_type=False):
     self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtype))
+    self.weak_type = weak_type
 
   def __eq__(self, other):
-    return type(self) is type(other) and self.dtype == other.dtype
+    return (type(self) is type(other) and self.dtype == other.dtype and
+            self.weak_type == other.weak_type)
 
   def __ne__(self, other):
     return not self == other
@@ -56,10 +58,11 @@ class UnshapedArray(core.AbstractValue):
     # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
     # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
     # the unique character code via hash(self.dtype.char)
-    return hash(self.dtype)
+    return hash((self.dtype, self.weak_type))
 
   def __repr__(self):
-    return '{}({})'.format(self.__class__.__name__, self.str_short())
+    return '{}({}{})'.format(self.__class__.__name__, self.str_short(),
+                             ", weak_type=True" if self.weak_type else "")
 
   _bool = _nonzero = concretization_function_error(bool)
   _float   = concretization_function_error(float)
@@ -75,20 +78,27 @@ class UnshapedArray(core.AbstractValue):
 
   def join(self, other):
     if self.dtype == other.dtype:
-      return self
+      if self.weak_type == other.weak_type:
+        return self
+      else:
+        return UnshapedArray(self.dtype, weak_type=False)
     else:
-      raise TypeError(other)
+      raise TypeError(self, other)
 
   def str_short(self):
     return self.dtype.name
 
+  def strip_weak_type(self):
+    """Returns a copy of the aval with weak_type=False."""
+    return UnshapedArray(self.dtype) if self.weak_type else self
+
 
 class ShapedArray(UnshapedArray):
   __slots__ = ['shape']
-  array_abstraction_level = 2
+  array_abstraction_level = 1
 
-  def __init__(self, shape, dtype):
-    self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtype))
+  def __init__(self, shape, dtype, weak_type=False):
+    super(ShapedArray, self).__init__(dtype, weak_type=weak_type)
     self.shape = shape
 
   ndim = property(lambda self: len(self.shape))
@@ -96,24 +106,28 @@ class ShapedArray(UnshapedArray):
 
   def __eq__(self, other):
     return (type(self) is type(other)
-            and self.dtype == other.dtype and self.shape == other.shape)
+            and self.dtype == other.dtype and self.shape == other.shape
+            and self.weak_type == other.weak_type)
 
   def __hash__(self):
     # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
     # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
     # the unique character code via hash(self.dtype.char)
-    return hash((self.shape, self.dtype))
+    return hash((self.shape, self.dtype, self.weak_type))
 
   def at_least_vspace(self):
     return self
 
   def join(self, other):
     if self.shape == other.shape and self.dtype == other.dtype:
-      return self
+      if self.weak_type == other.weak_type:
+        return self
+      else:
+        return ShapedArray(self.shape, self.dtype, weak_type=False)
     elif self.dtype == other.dtype:
       return UnshapedArray(self.dtype)
     else:
-      raise TypeError(other)
+      raise TypeError(self, other)
 
   def str_short(self):
     shapestr = ','.join(map(str, self.shape))
@@ -128,41 +142,48 @@ class ShapedArray(UnshapedArray):
   def _len(self, ignored_tracer):
     return len(self)
 
+  def strip_weak_type(self):
+    return ShapedArray(self.shape, self.dtype) if self.weak_type else self
 
 class ConcreteArray(ShapedArray):
   __slots__ = ['val']
   array_abstraction_level = 0
 
-  def __init__(self, val):
+  def __init__(self, val, weak_type=False):
+    super(ConcreteArray, self).__init__(onp.shape(val), onp.result_type(val),
+                                        weak_type=weak_type)
+    # Note: canonicalized self.dtype doesn't necessarily match self.val
     self.val = val
-    self.shape = onp.shape(val)
-    # canonicalized self.dtype doesn't necessarily match self.val
-    self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtypes.result_type(val)))
     assert self.dtype != onp.dtype('O')
 
   def __eq__(self, other):
     return (type(self) is type(other) and self.dtype == other.dtype
-            and self.shape == other.shape and onp.all(self.val == other.val))
+            and self.shape == other.shape and self.weak_type == other.weak_type
+            and onp.all(self.val == other.val))
 
   def __hash__(self):
     return id(self.val)
 
   def at_least_vspace(self):
-    return ShapedArray(self.shape, self.dtype)
+    return ShapedArray(self.shape, self.dtype, weak_type=self.weak_type)
 
   def join(self, other):
     if self == other:
       return self
     elif self.shape == other.shape and self.dtype == other.dtype:
-      return ShapedArray(self.shape, self.dtype)
+      return ShapedArray(self.shape, self.dtype,
+                         weak_type=self.weak_type and other.weak_type)
     elif self.dtype == other.dtype:
-      return UnshapedArray(self.dtype)
+      return UnshapedArray(self.dtype,
+                           weak_type=self.weak_type and other.weak_type)
     else:
-      raise TypeError(other)
+      raise TypeError(self, other)
 
   def str_short(self):
     return str(self.val)
 
+  def strip_weak_type(self):
+    return ConcreteArray(self.val) if self.weak_type else self
 
 class AbstractToken(core.AbstractValue): pass
 
@@ -181,10 +202,7 @@ array_types = {onp.ndarray, onp.float64, onp.float32, onp.float16,
                onp.complex64, onp.complex128,
                onp.int64, onp.int32, onp.int16, onp.int8,
                onp.bool_, onp.uint64, onp.uint32, onp.uint16, onp.uint8,
-               onp.longlong, complex, float, int, bool}
-
-if six.PY2:
-  array_types.add(long)  # noqa: F821
+               onp.longlong}
 
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray
@@ -208,3 +226,19 @@ def raise_to_shaped(aval):
     raise TypeError(type(aval))
 
 core.literalable_types.update(array_types)
+
+def make_abstract_python_scalar(x):
+  return ShapedArray((), dtypes.python_scalar_dtypes[type(x)],
+                     weak_type=True)
+
+def _zeros_like_python_scalar(x):
+  return onp.array(0, dtypes.python_scalar_dtypes[type(x)])
+
+def _make_concrete_python_scalar(x):
+  return ConcreteArray(
+    onp.array(x, dtype=dtypes.python_scalar_dtypes[type(x)]),
+    weak_type=True)
+
+for t in dtypes.python_scalar_dtypes.keys():
+  core.pytype_aval_mappings[t] = _make_concrete_python_scalar
+  ad_util.jaxval_zeros_likers[t] = _zeros_like_python_scalar

--- a/jax/core.py
+++ b/jax/core.py
@@ -282,7 +282,7 @@ class Tracer(object):
   __array_priority__ = 1000
   __slots__ = ['trace', '__weakref__']
 
-  def __array__(self):
+  def __array__(self, *args, **kw):
     raise Exception("Tracer can't be used with raw numpy functions. "
                     "You might have\n  import numpy as np\ninstead of\n  import jax.numpy as np")
 
@@ -491,6 +491,8 @@ class AbstractValue(object):
     except AttributeError:
       return self.__class__.__name__
 
+  def strip_weak_type(self):
+    return self
 
 class Bot(AbstractValue): pass
 

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -71,7 +71,7 @@ python_scalar_dtypes = {
 }
 
 if six.PY2:
-  python_scalar_dtypes[long] = int_  # noqa: F821
+  python_scalar_dtypes[long] = onp.dtype(int_)  # noqa: F821
 
 def scalar_type_of(x):
   typ = dtype(x)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -20,6 +20,7 @@ from distutils.util import strtobool
 import os
 
 import numpy as onp
+import six
 
 from .config import flags
 from . import util
@@ -29,14 +30,18 @@ flags.DEFINE_bool('jax_enable_x64',
                   strtobool(os.getenv('JAX_ENABLE_X64', 'False')),
                   'Enable 64-bit types to be used.')
 
-iinfo = onp.iinfo
-finfo = onp.finfo
 
-can_cast = onp.can_cast
-issubdtype = onp.issubdtype
-issubsctype = onp.issubsctype
-result_type = onp.result_type
-promote_types = onp.promote_types
+# Default types.
+
+bool_ = onp.bool_
+int_ = onp.int64
+float_ = onp.float64
+complex_ = onp.complex128
+
+# TODO(phawkins): change the above defaults to:
+# int_ = onp.int32
+# float_ = onp.float32
+# complex_ = onp.complex64
 
 
 _dtype_to_32bit_dtype = {
@@ -55,3 +60,82 @@ def canonicalize_dtype(dtype):
     return dtype
   else:
     return _dtype_to_32bit_dtype.get(dtype, dtype)
+
+
+# Default dtypes corresponding to Python scalars.
+python_scalar_dtypes = {
+  bool: onp.dtype(bool_),
+  int: onp.dtype(int_),
+  float: onp.dtype(float_),
+  complex: onp.dtype(complex_),
+}
+
+if six.PY2:
+  python_scalar_dtypes[long] = int_  # noqa: F821
+
+def scalar_type_of(x):
+  typ = dtype(x)
+  if onp.issubdtype(typ, onp.bool_):
+    return bool
+  elif onp.issubdtype(typ, onp.integer):
+    return int
+  elif onp.issubdtype(typ, onp.floating):
+    return float
+  elif onp.issubdtype(typ, onp.complexfloating):
+    return complex
+  else:
+    raise TypeError("Invalid scalar value {}".format(x))
+
+def coerce_to_array(x):
+  """Coreces a scalar or NumPy array to an onp.array.
+
+  Handles Python scalar type promotion according to JAX's rules, not NumPy's
+  rules.
+  """
+  dtype = python_scalar_dtypes.get(type(x), None)
+  return onp.array(x, dtype) if dtype else onp.array(x)
+
+iinfo = onp.iinfo
+finfo = onp.finfo
+
+can_cast = onp.can_cast
+issubdtype = onp.issubdtype
+issubsctype = onp.issubsctype
+promote_types = onp.promote_types
+
+
+def is_python_scalar(x):
+  try:
+    return x.aval.weak_type and onp.ndim(x) == 0
+  except AttributeError:
+    return type(x) in python_scalar_dtypes
+
+def _dtype_priority(dtype):
+  if issubdtype(dtype, onp.bool_):
+    return 0
+  elif issubdtype(dtype, onp.integer):
+    return 1
+  elif issubdtype(dtype, onp.floating):
+    return 2
+  elif issubdtype(dtype, onp.complexfloating):
+    return 3
+  else:
+    raise TypeError("Dtype {} is not supported by JAX".format(dtype))
+
+def dtype(x):
+  if type(x) in python_scalar_dtypes:
+    return python_scalar_dtypes[type(x)]
+  return onp.result_type(x)
+
+def result_type(*args):
+  """Convenience function to apply Numpy argument dtype promotion."""
+  # TODO(dougalm,mattjj): This is a performance bottleneck. Consider memoizing.
+  if len(args) < 2:
+    return dtype(args[0])
+  scalars = []
+  dtypes = []
+  for x in args:
+    (scalars if is_python_scalar(x) else dtypes).append(dtype(x))
+  array_priority = max(map(_dtype_priority, dtypes)) if dtypes else -1
+  dtypes += [x for x in scalars if _dtype_priority(x) > array_priority]
+  return canonicalize_dtype(onp.result_type(*dtypes))

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -26,6 +26,7 @@ import six
 from six.moves import reduce
 
 from .. import core
+from .. import dtypes
 from ..core import Trace, Tracer, new_master
 from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
 from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
@@ -253,7 +254,7 @@ def broadcast(x, sz, axis):
   shape = list(onp.shape(x))
   shape.insert(axis, sz)
   if isinstance(x, onp.ndarray) or onp.isscalar(x):
-    return onp.broadcast_to(x, shape)
+    return onp.broadcast_to(dtypes.coerce_to_array(x), shape)
   else:
     broadcast_dims = tuple(onp.delete(onp.arange(len(shape)), axis))
     return x.broadcast_in_dim(shape, broadcast_dims)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1449,7 +1449,7 @@ ShapedArray._iter = staticmethod(_iter)
 def zeros_like_array(x):
   return full_like(x, 0)
 
-for t in itertools.chain(dtypes.python_scalar_dtypes.key(), array_types,
+for t in itertools.chain(dtypes.python_scalar_dtypes.keys(), array_types,
                          [xla.DeviceArray]):
   ad_util.jaxval_adders[t] = add
 ad_util.jaxval_zeros_likers[xla.DeviceArray] = zeros_like_array

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1449,7 +1449,8 @@ ShapedArray._iter = staticmethod(_iter)
 def zeros_like_array(x):
   return full_like(x, 0)
 
-for t in itertools.chain(array_types, [xla.DeviceArray]):
+for t in itertools.chain(dtypes.python_scalar_dtypes.key(), array_types,
+                         [xla.DeviceArray]):
   ad_util.jaxval_adders[t] = add
 ad_util.jaxval_zeros_likers[xla.DeviceArray] = zeros_like_array
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1318,7 +1318,7 @@ def index_in_dim(operand, index, axis=0, keepdims=True):
 
 def dynamic_slice_in_dim(operand, start_index, slice_size, axis=0):
   """Convenience wrapper around dynamic_slice applying to one dimension."""
-  start_indices = [0] * operand.ndim
+  start_indices = [_zero(start_index)] * operand.ndim
   slice_sizes = list(operand.shape)
 
   axis = int(axis)
@@ -1338,7 +1338,7 @@ def dynamic_index_in_dim(operand, index, axis=0, keepdims=True):
 
 def dynamic_update_slice_in_dim(operand, update, start_index, axis):
   axis = int(axis)
-  start_indices = [0] * _ndim(operand)
+  start_indices = [_zero(start_index)] * _ndim(operand)
   start_indices[axis] = start_index
   return dynamic_update_slice(operand, update, start_indices)
 
@@ -4376,6 +4376,8 @@ def _dynamic_slice_indices(operand, start_indices):
 
 
 def _const(example, val):
+  if dtypes.is_python_scalar(example):
+    return dtypes.scalar_type_of(example)(val)
   return onp.array(val, _dtype(example))
 
 _zeros = partial(full_like, fill_value=0)

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from functools import partial
 import os
 import warnings
 
@@ -347,8 +348,11 @@ def _scalar_constant_handler(c, val, canonicalize_types=True):
 for scalar_type in [onp.int8, onp.int16, onp.int32, onp.int64,
                     onp.uint8, onp.uint16, onp.uint32, onp.uint64,
                     onp.float16, onp.float32, onp.float64, onp.float128,
-                    float, int, bool, onp.bool_, onp.longlong]:
+                    onp.bool_, onp.longlong]:
   register_constant_handler(scalar_type, _scalar_constant_handler)
 
-if six.PY2:
-  register_constant_handler(long, _scalar_constant_handler) # noqa: F821
+def _python_scalar_handler(dtype, c, val, canonicalize_dtypes=True):
+  return c.NumpyArrayConstant(dtype.type(val))
+
+for ptype, dtype in dtypes.python_scalar_dtypes.items():
+  register_constant_handler(ptype, partial(_python_scalar_handler, dtype))

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -38,7 +38,7 @@ _T = lambda x: np.swapaxes(x, -1, -2)
 def _promote_arg_dtypes(*args):
   """Promotes `args` to a common inexact type."""
   def _to_inexact_type(type):
-    return type if np.issubdtype(type, np.inexact) else np.float64
+    return type if np.issubdtype(type, np.inexact) else np.float_
   inexact_types = [_to_inexact_type(np._dtype(arg)) for arg in args]
   dtype = dtypes.canonicalize_dtype(np.result_type(*inexact_types))
   args = [lax.convert_element_type(arg, dtype) for arg in args]
@@ -181,8 +181,10 @@ def _norm(x, ord, axis, keepdims):
       # special case too.
       return np.sum(np.abs(x), axis=axis, keepdims=keepdims)
     else:
-      return np.power(np.sum(np.abs(x) ** ord, axis=axis, keepdims=keepdims),
-                      1. / ord)
+      abs_x = np.abs(x)
+      ord = lax._const(abs_x, ord)
+      out = np.sum(abs_x ** ord, axis=axis, keepdims=keepdims)
+      return np.power(out, 1. / ord)
 
   elif num_axes == 2:
     row_axis, col_axis = axis

--- a/jax/random.py
+++ b/jax/random.py
@@ -59,8 +59,8 @@ def PRNGKey(seed):
     # when jax_enable_x64=False and we don't want to drop the top 32 bits
     k1 = convert(onp.bitwise_and(onp.right_shift(seed, 32), 0xFFFFFFFF))
   else:
-    k1 = convert(lax.shift_right_logical(seed, 32))
-  k2 = convert(lax.bitwise_and(seed, 0xFFFFFFFF))
+    k1 = convert(lax.shift_right_logical(seed, lax._const(seed, 32)))
+  k2 = convert(np.bitwise_and(seed, 0xFFFFFFFF))
   return lax.concatenate([k1, k2], 0)
 
 def _is_prng_key(key):
@@ -823,7 +823,7 @@ def _gamma_grad_one(z, alpha):
 
     _, _, grad, flag = lax.while_loop(lambda zagf: (~zagf[3]) & (zagf[0] < 0.8),
                                       _case1,
-                                      (z, alpha, 0.0, False))
+                                      (z, alpha, lax._const(alpha, 0.0), False))
     _, _, grad, flag = lax.while_loop(_cond2, _case2, (z, alpha, grad, flag))
     _, _, grad, flag = lax.while_loop(_cond3, _case3, (z, alpha, grad, flag))
     _, _, grad, flag = lax.while_loop(lambda zagf: ~zagf[3], _case4, (z, alpha, grad, flag))

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -162,7 +162,7 @@ def _merge_tolerance(tol, default):
     return tol
   out = default.copy()
   for k, v in tol.items():
-    out[k] = v
+    out[onp.dtype(k)] = v
   return out
 
 def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS):

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -54,8 +54,10 @@ flags.DEFINE_integer(
 
 EPS = 1e-4
 
-_dtype = lambda x: getattr(x, 'dtype', None) or onp.asarray(x).dtype
-
+def _dtype(x):
+  return (getattr(x, 'dtype', None) or
+          onp.dtype(dtypes.python_scalar_dtypes.get(type(x), None)) or
+          onp.asarray(x).dtype)
 
 def is_sequence(x):
   try:
@@ -89,9 +91,9 @@ tpu_default_tolerance[onp.dtype(onp.complex64)] = 1e-3
 default_gradient_tolerance = {
   onp.dtype(onp.float16): 1e-2,
   onp.dtype(onp.float32): 2e-3,
-  onp.dtype(onp.float64): 1e-6,
+  onp.dtype(onp.float64): 1e-5,
   onp.dtype(onp.complex64): 1e-3,
-  onp.dtype(onp.complex128): 1e-6,
+  onp.dtype(onp.complex128): 1e-5,
 }
 
 def _assert_numpy_eq(x, y):
@@ -128,10 +130,9 @@ def inner_prod(xs, ys):
   return tree_reduce(onp.add, tree_multimap(contract, xs, ys))
 
 
-add = partial(tree_multimap, onp.add)
-sub = partial(tree_multimap, onp.subtract)
-conj = partial(tree_map, onp.conj)
-
+add = partial(tree_multimap, lambda x, y: onp.add(x, y, dtype=_dtype(x)))
+sub = partial(tree_multimap, lambda x, y: onp.subtract(x, y, dtype=_dtype(x)))
+conj = partial(tree_map, lambda x: onp.conj(x, dtype=_dtype(x)))
 
 def scalar_mul(xs, a):
   return tree_map(lambda x: onp.multiply(x, a, dtype=_dtype(x)), xs)
@@ -154,9 +155,19 @@ def numerical_jvp(f, primals, tangents, eps=EPS):
   return scalar_mul(sub(f_pos, f_neg), 0.5 / eps)
 
 
+def _merge_tolerance(tol, default):
+  if tol is None:
+    return default
+  if not isinstance(tol, dict):
+    return tol
+  out = default.copy()
+  for k, v in tol.items():
+    out[k] = v
+  return out
+
 def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS):
-  atol = atol or default_gradient_tolerance
-  rtol = rtol or default_gradient_tolerance
+  atol = _merge_tolerance(atol, default_gradient_tolerance)
+  rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   rng = onp.random.RandomState(0)
   tangent = tree_map(partial(rand_like, rng), args)
   v_out, t_out = f_jvp(args, tangent)
@@ -170,8 +181,8 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS):
 
 
 def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS):
-  atol = atol or default_gradient_tolerance
-  rtol = rtol or default_gradient_tolerance
+  atol = _merge_tolerance(atol, default_gradient_tolerance)
+  rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   _rand_like = partial(rand_like, onp.random.RandomState(0))
   v_out, vjpfun = f_vjp(*args)
   v_out_expected = f(*args)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1266,6 +1266,8 @@ class APITest(jtu.JaxTestCase):
         "positional arguments.",
         lambda: partial(df, x=0.)(y=1.))
 
+  def test_scalar_literals(self):
+    self.assertLen(api.make_jaxpr(lambda x: x + 2)(42).constvars, 0)
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -489,7 +489,8 @@ class BatchingTest(jtu.JaxTestCase):
       per_example_direct += [
           np.reshape(g, (1,) + g.shape)]
     per_example_direct = np.concatenate(per_example_direct, axis=0)
-    self.assertAllClose(per_example, per_example_direct, check_dtypes=True)
+    self.assertAllClose(per_example, per_example_direct, check_dtypes=True,
+                        rtol=2e-2)
 
   def testConvGeneralDilatedBatchNotMajor(self):
     W = np.array(onp.random.randn(3, 3, 1, 4), dtype=onp.float32)
@@ -540,7 +541,8 @@ class BatchingTest(jtu.JaxTestCase):
       per_example_direct += [
           np.reshape(g, (1,) + g.shape)]
     per_example_direct = np.concatenate(per_example_direct, axis=0)
-    self.assertAllClose(per_example, per_example_direct, check_dtypes=True)
+    self.assertAllClose(per_example, per_example_direct, check_dtypes=True,
+                        rtol=1e-3)
 
   def testSumPool(self):
     W = np.array(onp.random.randn(3, 3, 1, 5), dtype=onp.float32)
@@ -571,7 +573,7 @@ class BatchingTest(jtu.JaxTestCase):
           np.reshape(g, (1,) + g.shape)]
     per_example_direct = np.concatenate(per_example_direct, axis=0)
     self.assertAllClose(per_example, per_example_direct, check_dtypes=True,
-                        rtol=1e-5)
+                        rtol=1e-3)
 
   def testCumProd(self):
    x = np.arange(9).reshape(3, 3) + 1
@@ -936,7 +938,8 @@ class BatchingTest(jtu.JaxTestCase):
     scales = onp.array([[0.1], [0.2], [0.3], [0.4], [0.5]])
     ans = vmapped_f_grad(scales)  # don't crash!
     expected = onp.stack([grad(f)(scale) for scale in scales])
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    self.assertAllClose(ans, expected, check_dtypes=False,
+                        rtol=jtu.default_gradient_tolerance)
 
   def testIssue387(self):
     # https://github.com/google/jax/issues/387

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -576,7 +576,8 @@ class BatchingTest(jtu.JaxTestCase):
   def testCumProd(self):
    x = np.arange(9).reshape(3, 3) + 1
    y = vmap(lambda x: np.cumprod(x, axis=-1))(x)
-   self.assertAllClose(onp.cumprod(x, axis=1), y, check_dtypes=True)
+   self.assertAllClose(onp.cumprod(x, axis=1, dtype=np.int_), y,
+                       check_dtypes=True)
 
   def testSelect(self):
     pred = onp.array([True, False])
@@ -962,7 +963,8 @@ class BatchingTest(jtu.JaxTestCase):
         key, _ = random.split(key)
         return u, key
 
-      u, _ = lax.while_loop(lambda uk: uk[0] > 0.5, body_fn, (1., key))
+      u, _ = lax.while_loop(lambda uk: uk[0] > 0.5, body_fn,
+                            (np.float64(1.), key))
       return u
 
     print(vmap(f)(random.split(random.PRNGKey(0), 2)))  # no crash

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import operator
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+from jax import dtypes
+from jax import numpy as np
+from jax import test_util as jtu
+
+from jax.config import config
+config.parse_flags_with_absl()
+FLAGS = config.FLAGS
+
+
+class DtypesTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(
+    {"testcase_name": "_type={}".format(type.__name__), "type": type,
+     "dtype": dtype}
+    for type, dtype in [(bool, np.bool_), (int, np.int_), (float, np.float_),
+                        (complex, np.complex_)])
+  def testDefaultTypes(self, type, dtype):
+    for f in [np.array, jax.jit(np.array), jax.jit(lambda x: x)]:
+      y = f(type(0))
+      self.assertTrue(isinstance(y, np.ndarray), msg=(f, y))
+      self.assertEqual(y.dtype, dtypes.canonicalize_dtype(dtype), msg=(f, y))
+
+  @parameterized.named_parameters(
+    {"testcase_name": "_swap={}_jit={}".format(swap, jit),
+     "swap": swap, "jit": jit} 
+    for swap in [False, True] for jit in [False, True])
+  def testBinaryPromotion(self, swap, jit):
+    testcases = [
+      (np.array(1.), 0., np.float_),
+      (np.array(1.), np.array(0.), np.float_),
+      (np.array(1.), np.array(0., dtype=np.float16), np.float_),
+      (np.array(1.), np.array(0., dtype=np.float32), np.float_),
+      (np.array(1.), np.array(0., dtype=np.float64), np.float64),
+      (np.array(1., dtype=np.float16), 0., np.float16),
+      (np.array(1., dtype=np.float32), 0., np.float32),
+      (np.array(1., dtype=np.float64), 0., np.float64),
+      (np.array(1., dtype=np.float16), np.array(0., dtype=np.float16), np.float16),
+      (np.array(1., dtype=np.float16), np.array(0., dtype=np.float32), np.float32),
+      (np.array(1., dtype=np.float16), np.array(0., dtype=np.float64), np.float64),
+      (np.array(1., dtype=np.float32), np.array(0., dtype=np.float32), np.float32),
+      (np.array(1., dtype=np.float32), np.array(0., dtype=np.float64), np.float64),
+      (np.array(1., dtype=np.float64), np.array(0., dtype=np.float64), np.float64),
+      (np.array([1.]), 0., np.float_),
+      (np.array([1.]), np.array(0.), np.float_),
+      (np.array([1.]), np.array(0., dtype=np.float16), np.float_),
+      (np.array([1.]), np.array(0., dtype=np.float32), np.float_),
+      (np.array([1.]), np.array(0., dtype=np.float64), np.float64),
+      (np.array([1.], dtype=np.float32), np.array(0., dtype=np.float16), np.float32),
+      (np.array([1.], dtype=np.float16), np.array(0., dtype=np.float32), np.float32),
+      (np.array([1.], dtype=np.float16), 0., np.float16),
+    ]
+    op = jax.jit(operator.add) if jit else operator.add
+    for x, y, dtype in testcases:
+      x, y = (y, x) if swap else (x, y)
+      z = x + y
+      self.assertTrue(isinstance(z, np.ndarray), msg=(x, y, z))
+      self.assertEqual(z.dtype, dtypes.canonicalize_dtype(dtype), msg=(x, y, z))
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -271,7 +271,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return total
 
     cfun = api.jit(sum_first_n)
-    x = npr.RandomState(0).randn(10)
+    x = npr.RandomState(0).randn(10).astype(np.float_)
 
     for num in [0, 5, 10, 15]:
       self.assertAllClose(sum_first_n(x, num), onp.sum(x[:num]),
@@ -304,7 +304,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     def fun(x, y):
       return lax.while_loop(lambda x: x < 3, lambda x: x + y, x)
 
-    ans = api.vmap(fun, in_axes=(None, 0))(0, onp.array([2, 3]))
+    ans = api.vmap(fun, in_axes=(None, 0))(0, np.array([2, 3]))
     expected = onp.array([4, 3])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -393,7 +393,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return total
 
     cfun = api.jit(sum_first_n)
-    x = npr.RandomState(0).randn(10)
+    x = npr.RandomState(0).randn(10).astype(np.float_)
 
     for num in [0, 5, 10, 15]:
       self.assertAllClose(sum_first_n(x, num), onp.sum(x[:num]),
@@ -413,7 +413,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return out_val['total']
 
     cfun = api.jit(sum_first_n)
-    x = npr.RandomState(0).randn(10)
+    x = npr.RandomState(0).randn(10).astype(np.float_)
 
     for num in [0, 5, 10, 15]:
       self.assertAllClose(sum_first_n(x, num), onp.sum(x[:num]),
@@ -433,7 +433,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return tot
 
     cfun = api.jit(sum_first_n)
-    x = npr.RandomState(0).randn(10)
+    x = npr.RandomState(0).randn(10).astype(np.float_)
 
     for num in [0, 5, 10, 15]:
       self.assertAllClose(sum_first_n(x, num), onp.sum(x[:num]),
@@ -583,16 +583,16 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return lax.cond(pred, y, true_fun, z, false_fun)
 
     # these cases stay as cond
-    x = onp.array(2)
-    y = onp.array([1, 2])
-    z = onp.array([3, 4])
+    x = np.array(2)
+    y = np.array([1, 2])
+    z = np.array([3, 4])
     ans = api.vmap(fun, (None, 0, 0))(x, y, z)
     jaxpr = api.make_jaxpr(api.vmap(fun, (None, 0, 0)))(x, y, z)
     expected = onp.array([1, 2])
     self.assertAllClose(ans, expected, check_dtypes=False)
     assert "select" not in str(jaxpr)
 
-    x = onp.array(4)
+    x = np.array(4)
     ans = api.vmap(fun, (None, 0, 0))(x, y, z)
     jaxpr = api.make_jaxpr(api.vmap(fun, (None, 0, 0)))(x, y, z)
     expected = onp.array([-3, -4])
@@ -604,7 +604,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = onp.array([-3, -4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    z = onp.array(5)
+    z = np.array(5)
     ans = api.vmap(fun, (None, 0, None))(x, y, z)
     jaxpr = api.make_jaxpr(api.vmap(fun, (None, 0, None)))(x, y, z)
     expected = onp.array([-5, -5])
@@ -613,14 +613,14 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
 
     # these cases become select
-    x = onp.array([2, 4])
+    x = np.array([2, 4])
     ans = api.vmap(fun, (0, 0, None))(x, y, z)
     jaxpr = api.make_jaxpr(api.vmap(fun, (0, 0, None)))(x, y, z)
     expected = onp.array([1, -5])
     self.assertAllClose(ans, expected, check_dtypes=False)
     assert "select" in str(jaxpr)
 
-    z = onp.array([3, 4])
+    z = np.array([3, 4])
     ans = api.vmap(fun)(x, y, z)
     jaxpr = api.make_jaxpr(api.vmap(fun))(x, y, z)
     expected = onp.array([1, -4])
@@ -802,12 +802,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     n_out = 1
     length = 3
 
-    W_trans = r.randn(n_hid, n_hid + n_in)
-    W_out = r.randn(n_out, n_hid + n_in)
+    W_trans = r.randn(n_hid, n_hid + n_in).astype(np.float_)
+    W_out = r.randn(n_out, n_hid + n_in).astype(np.float_)
     params = W_trans, W_out
 
-    inputs = r.randn(length, n_in)
-    targets = r.randn(length, n_out)
+    inputs = r.randn(length, n_in).astype(np.float_)
+    targets = r.randn(length, n_out).astype(np.float_)
 
     def step(params, state, input):
       W_trans, W_out = params
@@ -850,8 +850,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     # we can vmap to batch things
     batch_size = 7
-    batched_inputs = r.randn(batch_size, length, n_in)
-    batched_targets = r.randn(batch_size, length, n_out)
+    batched_inputs = r.randn(batch_size, length, n_in).astype(np.float_)
+    batched_targets = r.randn(batch_size, length, n_out).astype(np.float_)
     batched_loss = api.vmap(lambda x, y: loss(params, x, y))
     losses = batched_loss(batched_inputs, batched_targets)
     expected = onp.stack(list(map(lambda x, y: loss(params, x, y),
@@ -1166,7 +1166,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return solution
 
     def sqrt_cubed(x, tangent_solve=scalar_solve):
-      f = lambda y: y ** 2 - x ** 3
+      f = lambda y: y ** 2. - np.array(x) ** 3.
       return lax.custom_root(f, 0.0, binary_search, tangent_solve)
 
     value, grad = api.value_and_grad(sqrt_cubed)(5.0)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -67,6 +67,21 @@ inexact_dtypes = float_dtypes + complex_dtypes
 number_dtypes = float_dtypes + complex_dtypes + int_dtypes
 all_dtypes = number_dtypes + bool_dtypes
 
+
+python_scalar_dtypes = [lnp.bool_, lnp.int_, lnp.float_, lnp.complex_]
+
+def _valid_dtypes_for_shape(shape, dtypes):
+  # Not all (shape, dtype) pairs are valid. In particular, Python scalars only
+  # have one type in each category (float, bool, etc.)
+  if shape is jtu.PYTHON_SCALAR_SHAPE:
+    return [t for t in dtypes if t in python_scalar_dtypes]
+  return dtypes
+
+def _shape_and_dtypes(shapes, dtypes):
+  for shape in shapes:
+    for dtype in _valid_dtypes_for_shape(shape, dtypes):
+      yield (shape, dtype)
+
 OpRecord = collections.namedtuple(
   "OpRecord",
   ["name", "nargs", "dtypes", "shapes", "rng_factory", "diff_modes",
@@ -191,7 +206,8 @@ JAX_COMPOUND_OP_RECORDS = [
               tolerance={onp.complex64: 1e-5}),
     op_record("square", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
-    op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              check_dtypes=False),
     op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
     op_record("where", 3, (onp.float32, onp.int64), all_shapes, jtu.rand_some_zero, []),
     op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
@@ -341,13 +357,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
-        for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
+        for dtypes in itertools.product(
+          *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in itertools.chain(JAX_ONE_TO_ONE_OP_RECORDS,
                                  JAX_COMPOUND_OP_RECORDS)))
   def testOp(self, onp_op, lnp_op, rng_factory, shapes, dtypes, check_dtypes,
              tol):
     rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
+    python_scalar = jtu.PYTHON_SCALAR_SHAPE in shapes
     scalar_arg = (jtu.PYTHON_SCALAR_SHAPE in shapes or
                   jtu.NUMPY_SCALAR_SHAPE in shapes or
                   () in shapes)
@@ -356,7 +374,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       onp_op, lnp_op, args_maker,
       check_dtypes=check_dtypes and not scalar_arg and not empty_shape,
       tol=tol)
-    self._CompileAndCheck(lnp_op, args_maker, check_dtypes=check_dtypes,
+    self._CompileAndCheck(lnp_op, args_maker,
+                          check_dtypes=check_dtypes and not python_scalar,
                           atol=tol, rtol=tol)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
@@ -368,7 +387,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
-        for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
+        for dtypes in itertools.product(
+          *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_OPERATOR_OVERLOADS))
   def testOperatorOverload(self, name, rng_factory, shapes, dtypes, tol):
     rng = rng_factory()
@@ -391,7 +411,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
-        for dtypes in CombosWithReplacement(rec.dtypes, rec.nargs))
+        for dtypes in itertools.product(
+          *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_RIGHT_OPERATOR_OVERLOADS))
   def testRightOperatorOverload(self, name, rng_factory, shapes, dtypes,
                                 op_tolerance):
@@ -500,7 +521,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
        "axis": axis}
       for rec in JAX_ARGMINMAX_RECORDS
-      for shape in rec.shapes for dtype in rec.dtypes
+      for shape, dtype in _shape_and_dtypes(rec.shapes, rec.dtypes)
       for axis in range(-len(shape), len(shape))))
   def testArgMinMax(self, onp_op, lnp_op, rng_factory, shape, dtype, axis):
     rng = rng_factory()
@@ -508,7 +529,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       raise unittest.SkipTest("complex128 reductions not supported on GPU")
 
     def onp_fun(array_to_reduce):
-      return onp_op(array_to_reduce, axis)
+      return onp_op(array_to_reduce, axis).astype(lnp.int_)
 
     def lnp_fun(array_to_reduce):
       return lnp_op(array_to_reduce, axis)
@@ -656,21 +677,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
        "rng_factory": jtu.rand_default}
       # TODO(phawkins): support integer dtypes too.
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(inexact_dtypes, 2)
-      for lhs_shape, rhs_shape in [
-        (l, r) for l, r in CombosWithReplacement(all_shapes, 2)
-        if len(jtu._dims_of_shape(l)) == 0
-        or len(jtu._dims_of_shape(r)) == 0
-        or l[-1] == r[-1]]))
+      for lhs_shape, lhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
+      for rhs_shape, rhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
+      if len(jtu._dims_of_shape(lhs_shape)) == 0
+      or len(jtu._dims_of_shape(rhs_shape)) == 0
+      or lhs_shape[-1] == rhs_shape[-1]))
   def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     onp_fun = lambda lhs, rhs: onp.inner(lhs, rhs)
     lnp_fun = lambda lhs, rhs: lnp.inner(lhs, rhs)
-    tol_spec = {onp.float64: 1e-13}
+    tol_spec = {onp.float16: 1e-2, onp.float64: 1e-13}
     if jtu.device_under_test() == "tpu":
       tol_spec[onp.float32] = 2e-1
-    tol = max(jtu.tolerance(lhs_dtype), jtu.tolerance(rhs_dtype))
+    tol = max(jtu.tolerance(lhs_dtype, tol_spec),
+              jtu.tolerance(rhs_dtype, tol_spec))
     # TODO(phawkins): there are float32/float64 disagreements for some inputs.
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False,
                             tol=tol)
@@ -701,7 +722,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), decimals),
        "shape": shape, "dtype": dtype, "decimals": decimals,
        "rng_factory": jtu.rand_default}
-      for shape in all_shapes for dtype in number_dtypes
+      for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)
       for decimals in [0, 1, -2]))
   def testRoundStaticDecimals(self, shape, dtype, decimals, rng_factory):
     rng = rng_factory()
@@ -711,10 +732,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     lnp_fun = lambda x: lnp.round(x, decimals=decimals)
     args_maker = lambda: [rng(shape, dtype)]
     tol = {onp.float16: 1e-2}
-    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True,
-                            tol=tol)
-    self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True, atol=tol,
-                          rtol=tol)
+    check_dtypes = shape is not jtu.PYTHON_SCALAR_SHAPE
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker,
+                            check_dtypes=check_dtypes, tol=tol)
+    self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=check_dtypes,
+                          atol=tol, rtol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_mode={}_rpadwidth={}_rconstantvalues={}".format(
@@ -733,7 +755,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ('reflect', None, nonempty_shapes),
         ('wrap', None, nonempty_shapes),
       ]
-      for shape in shapes for dtype in all_dtypes
+      for shape, dtype in _shape_and_dtypes(shapes, all_dtypes)
       for pad_width_rank in range(3)))
   def testPad(self, shape, dtype, mode, pad_width_rank, constant_values_rank,
               rng_factory, irng_factory):
@@ -754,7 +776,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [len(shape), 2][2 - constant_values_rank:], dtype)
       return rng(shape, dtype), kwargs
 
-    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker,
+                            check_dtypes=shape is not jtu.PYTHON_SCALAR_SHAPE)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -763,8 +786,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "reps": reps,
        "rng_factory": jtu.rand_default}
       for reps in [(), (2,), (3, 4), (2, 3, 4)]
-      for dtype in default_dtypes
-      for shape in all_shapes
+      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
       ))
   def testTile(self, shape, dtype, reps, rng_factory):
     rng = rng_factory()
@@ -773,7 +795,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     args_maker = lambda: [rng(shape, dtype)]
 
-    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker,
+                            check_dtypes=shape is not jtu.PYTHON_SCALAR_SHAPE)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -829,8 +852,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axis": axis, "shape": shape, "dtype": dtype, "repeats": repeats,
        "rng_factory": jtu.rand_default}
       for repeats in [0, 1, 2]
-      for dtype in default_dtypes
-      for shape in all_shapes
+      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
       for axis in [None] + list(range(-len(shape), len(shape)))))
   def testRepeat(self, axis, shape, dtype, repeats, rng_factory):
     rng = rng_factory()
@@ -1225,8 +1247,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           returned),
        "rng_factory": jtu.rand_default, "shape": shape, "dtype": dtype, "axis": axis,
        "weights_shape": weights_shape, "returned": returned}
-      for shape in nonempty_shapes
-      for dtype in number_dtypes
+      for shape, dtype in _shape_and_dtypes(nonempty_shapes, number_dtypes)
       for axis in set(range(-len(shape), len(shape))) | set([None])
       # `weights_shape` is either `None`, same as the averaged axis, or same as
       # that of the input
@@ -1244,33 +1265,39 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       lnp_fun = lambda x, weights: lnp.average(x, axis, weights, returned)
       args_maker = lambda: [rng(shape, dtype), rng(weights_shape, dtype)]
 
-    tol = jtu.tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-3,
-                                onp.float64: 1e-10, onp.complex64: 1e-3,
-                                onp.complex128: 1e-10})
+    tol = {onp.float16: 1e-1, onp.float32: 1e-3, onp.float64: 1e-10,
+           onp.complex64: 1e-3, onp.complex128: 1e-10}
+    check_dtypes = shape is not jtu.PYTHON_SCALAR_SHAPE
     try:
-        self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True,
-                                tol=tol)
+        self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker,
+                                check_dtypes=check_dtypes, tol=tol)
     except ZeroDivisionError:
         self.skipTest("don't support checking for ZeroDivisionError")
-    self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True, rtol=tol,
-                          atol=tol)
+    self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=check_dtypes,
+                          rtol=tol, atol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_arg{}_ndmin={}".format(i, ndmin),
-       "arg": arg, "ndmin": ndmin}
-      for i, arg in enumerate([
-          3., [1, 2, 3], [1., 2., 3.],
-          [[1, 2], [3, 4], [5, 6]], [[1, 2.], [3, 4], [5, 6]],
-          [[3, onp.array(2), 1], onp.arange(3.)],
+       "arg": arg, "ndmin": ndmin, "dtype": dtype}
+      for i, (arg, dtype) in enumerate([
+          ([True, False, True], lnp.bool_),
+          (3., lnp.float_),
+          ([1, 2, 3], lnp.int_),
+          ([1., 2., 3.], lnp.float_),
+          ([[1, 2], [3, 4], [5, 6]], lnp.int_),
+          ([[1, 2.], [3, 4], [5, 6]], lnp.float64),
+          ([[1., 2j], [3., 4.], [5., 6.]], lnp.complex_),
+          ([[3, onp.array(2), 1], onp.arange(3.)], onp.float_),
       ])
       for ndmin in [None, onp.ndim(arg), onp.ndim(arg) + 1, onp.ndim(arg) + 2]))
-  def testArray(self, arg, ndmin):
+  def testArray(self, arg, ndmin, dtype):
     args_maker = lambda: [arg]
+    dtype = dtypes.canonicalize_dtype(dtype)
     if ndmin is not None:
-      onp_fun = partial(onp.array, ndmin=ndmin)
+      onp_fun = partial(onp.array, ndmin=ndmin, dtype=dtype)
       lnp_fun = partial(lnp.array, ndmin=ndmin)
     else:
-      onp_fun = onp.array
+      onp_fun = partial(onp.array, dtype=dtype)
       lnp_fun = lnp.array
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
@@ -1494,13 +1521,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testOnpMean(self):
     # from https://github.com/google/jax/issues/125
-    x = lax.add(lnp.eye(3), 0.)
+    x = lax.add(lnp.eye(3, dtype=lnp.float_), 0.)
     ans = onp.mean(x)
     self.assertAllClose(ans, onp.array(1./3), check_dtypes=False)
 
   def testArangeOnFloats(self):
     # from https://github.com/google/jax/issues/145
-    expected = onp.arange(0.0, 1.0, 0.1)
+    expected = onp.arange(0.0, 1.0, 0.1, dtype=lnp.float_)
     ans = lnp.arange(0.0, 1.0, 0.1)
     self.assertAllClose(expected, ans, check_dtypes=True)
 
@@ -1672,9 +1699,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = rng_factory()
     dtype = onp.dtype(dtypes.canonicalize_dtype(dtype)).type
     args_maker = lambda: [rng(shape, dtype)]
+    check_dtypes = shape is not jtu.PYTHON_SCALAR_SHAPE
     self._CheckAgainstNumpy(onp.nan_to_num, lnp.nan_to_num, args_maker,
-                            check_dtypes=True)
-    self._CompileAndCheck(lnp.nan_to_num, args_maker, check_dtypes=True)
+                            check_dtypes=check_dtypes)
+    self._CompileAndCheck(lnp.nan_to_num, args_maker,
+                          check_dtypes=check_dtypes)
 
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix("ix_", shapes, dtypes),
@@ -1731,7 +1760,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # TODO(phawkins): we currently set dtype=False because we aren't as
     # aggressive about promoting to float64. It's not clear we want to mimic
     # Numpy here.
-    tol_spec = {onp.float32: 1e-5, onp.float64: 5e-6}
+    tol_spec = {onp.float16: 2e-2, onp.float32: 1e-5, onp.float64: 5e-6}
     tol = max(jtu.tolerance(a_dtype, tol_spec),
               jtu.tolerance(q_dtype, tol_spec))
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False,
@@ -1803,16 +1832,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_dtype={}".format(
-          op, {bool: "bool", int: "int", float: "float"}[dtype]),
-       "dtype": dtype, "op": op}
-      for dtype in [int, float, bool]
+      {"testcase_name": "_op={}_dtype={}".format(op, pytype.__name__),
+       "pytype": pytype, "dtype": dtype, "op": op}
+      for pytype, dtype in [(int, lnp.int_), (float, lnp.float_),
+                            (bool, lnp.bool_), (complex, lnp.complex_)]
       for op in ["atleast_1d", "atleast_2d", "atleast_3d"]))
-  def testAtLeastNdLiterals(self, dtype, op):
+  def testAtLeastNdLiterals(self, pytype, dtype, op):
     # Fixes: https://github.com/google/jax/issues/634
-    onp_fun = lambda arg: getattr(onp, op)(arg)
+    onp_fun = lambda arg: getattr(onp, op)(arg).astype(dtype)
     lnp_fun = lambda arg: getattr(lnp, op)(arg)
-    args_maker = lambda: [dtype(2)]
+    args_maker = lambda: [pytype(2)]
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
@@ -1825,13 +1854,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # test cases inspired by dask tests at
     # https://github.com/dask/dask/blob/master/dask/array/tests/test_creation.py#L92
     self.assertAllClose(lnp.arange(77),
-                        onp.arange(77), check_dtypes=True)
+                        onp.arange(77, dtype=lnp.int_), check_dtypes=True)
     self.assertAllClose(lnp.arange(2, 13),
-                        onp.arange(2, 13), check_dtypes=True)
+                        onp.arange(2, 13, dtype=lnp.int_), check_dtypes=True)
     self.assertAllClose(lnp.arange(4, 21, 9),
-                        onp.arange(4, 21, 9), check_dtypes=True)
+                        onp.arange(4, 21, 9, dtype=lnp.int_), check_dtypes=True)
     self.assertAllClose(lnp.arange(53, 5, -3),
-                        onp.arange(53, 5, -3), check_dtypes=True)
+                        onp.arange(53, 5, -3, dtype=lnp.int_),
+                        check_dtypes=True)
     # TODO(mattjj): make these tests work when jax_enable_x64=True
     # self.assertAllClose(lnp.arange(77, dtype=float),
     #                     onp.arange(77, dtype=float), check_dtypes=True)
@@ -1848,7 +1878,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     # test that lnp.arange(N, dtype=int32) doesn't instantiate an ndarray
     self.assertFalse(type(lnp.arange(77, dtype=lnp.int32)) ==
-                    type(onp.arange(77, dtype=onp.int32)))
+                     type(onp.arange(77, dtype=onp.int32)))
     self.assertTrue(type(lnp.arange(77, dtype=lnp.int32)) ==
                     type(lax.iota(onp.int32, 77)))
 
@@ -2117,8 +2147,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                               " doesn't exactly match other platforms.")
     rng = rng_factory()
     # relax default tolerances slightly
-    tol = {onp.float16: 2e-2, onp.float32: 1e-2, onp.float64: 1e-14,
-           onp.complex64: 1e-3, onp.complex128: 1e-14}
+    tol = {onp.float16: 2e-2, onp.float32: 1e-2, onp.float64: 1e-6,
+           onp.complex64: 1e-3, onp.complex128: 1e-6}
     args_maker = self._GetArgsMaker(rng,
                                     [start_shape, stop_shape],
                                     [dtype, dtype])
@@ -2161,7 +2191,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                     endpoint, dtype, rng_factory):
     rng = rng_factory()
     # relax default tolerances slightly
-    tol = {onp.float16: 2e-3, onp.float32: 2e-3, onp.complex128: 1e-14}
+    tol = {onp.float16: 4e-3, onp.float32: 2e-3, onp.complex128: 1e-14}
     def args_maker():
       """Test the set of inputs onp.geomspace is well-defined on."""
       start, stop = self._GetArgsMaker(rng,
@@ -2329,7 +2359,7 @@ class NumpyGradTests(jtu.JaxTestCase):
       for rec in GRAD_TEST_RECORDS))
   def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):
     rng = rng_factory()
-    tol = 1e-1 if num_float_bits(dtype) == 32 else tol
+    tol = {onp.float32: 1e-1, onp.complex64: 1e-1}
     args = tuple(rng(shape, dtype) for shape in shapes)
     check_grads(op, args, order, ["fwd", "rev"], tol, tol)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -689,7 +689,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     lnp_fun = lambda lhs, rhs: lnp.inner(lhs, rhs)
     tol_spec = {onp.float16: 1e-2, onp.float64: 1e-13}
     if jtu.device_under_test() == "tpu":
-      tol_spec[onp.float32] = 2e-1
+      tol_spec[onp.float32] = tol_spec[onp.complex64] = 2e-1
     tol = max(jtu.tolerance(lhs_dtype, tol_spec),
               jtu.tolerance(rhs_dtype, tol_spec))
     # TODO(phawkins): there are float32/float64 disagreements for some inputs.

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -31,6 +31,7 @@ import six
 
 from jax import api
 from jax import core
+from jax import dtypes
 from jax import lax
 from jax import test_util as jtu
 from jax import lax_reference
@@ -1561,7 +1562,8 @@ class DeviceConstantTest(jtu.JaxTestCase):
       for fill_value in [0, 1, onp.pi]))
   def testFilledConstant(self, shape, fill_value, dtype):
     make_const = lambda: lax.full(shape, fill_value, dtype)
-    expected = onp.full(shape, fill_value, dtype)
+    expected = onp.full(shape, fill_value,
+                        dtype or dtypes.result_type(fill_value))
     self._CheckDeviceConstant(make_const, expected)
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -234,8 +234,8 @@ class MaskingTest(jtu.JaxTestCase):
       return predicted
 
     rng = onp.random.RandomState(0)
-    W = onp.eye(n)
-    xs = rng.randn(10, n)
+    W = np.eye(n)
+    xs = rng.randn(10, n).astype(np.float_)
     ans = rnn([W, xs], dict(t=4))
     expected = xs[:4].sum(0)
     self.assertAllClose(ans, expected, check_dtypes=False)
@@ -252,9 +252,9 @@ class MaskingTest(jtu.JaxTestCase):
       return np.sum((predicted - target)**2)
 
     rng = onp.random.RandomState(0)
-    W = rng.randn(n, n)
-    xs = rng.randn(10, n)
-    y = rng.randn(n)
+    W = rng.randn(n, n).astype(np.float_)
+    xs = rng.randn(10, n).astype(np.float_)
+    y = rng.randn(n).astype(np.float_)
 
     ans = grad(lambda W: rnn([W, xs, y], dict(t=4)))(W)
 
@@ -281,8 +281,8 @@ class MaskingTest(jtu.JaxTestCase):
       return np.sum((predicted - target)**2)
 
     rng = onp.random.RandomState(0)
-    W = rng.randn(n, n)
-    seqs = rng.randn(3, 10, n)
+    W = rng.randn(n, n).astype(np.float_)
+    seqs = rng.randn(3, 10, n).astype(np.float_)
     ts = np.array([2, 5, 4])
     ys = rng.randn(3, n)
 

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -280,7 +280,7 @@ class OptimizerTests(jtu.JaxTestCase):
       assert trip == 75
       return opt_final
 
-    initial_params = 0.5
+    initial_params = np.float64(0.5)
     minimize_structure(initial_params)
 
     def loss(test_params):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -849,7 +849,7 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
 
     ndevices = xla_bridge.device_count()
     ans = foo(np.ones((ndevices, 1)))
-    expected = onp.ones((ndevices, 1)) * ndevices * 2
+    expected = onp.ones((ndevices, 1), dtype=np.float_) * ndevices * 2
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testPmapInJit(self):
@@ -862,7 +862,7 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
 
     ndevices = xla_bridge.device_count()
     ans = foo(np.ones((ndevices, 1)))
-    expected = onp.ones((ndevices, 1)) * ndevices
+    expected = onp.ones((ndevices, 1), dtype=np.float_) * ndevices
     self.assertAllClose(ans, expected, check_dtypes=True)
 
   def testGradBasic(self):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -340,7 +340,7 @@ class PmapTest(jtu.JaxTestCase):
       lambda x: lax.ppermute(x, "i", zip(range(num_devices), perm)), "i")
     result = f(np.arange(num_devices, dtype=np.float32))
     expected = np.asarray(perm, dtype=np.float32)
-    self.assertAllClose(result, expected)
+    self.assertAllClose(result, expected, check_dtypes=True)
 
   @jtu.skip_on_devices("cpu", "gpu")
   def testRule30(self):


### PR DESCRIPTION
Currently JAX does not treat Python scalars specially during type promotion. This means that, for example:
`1. + np.array([...], np.float32)`
ends up as an array of type np.float64. The `1.` is promoted to a default type (here np.float64), and the type promotion of a np.float64 and an np.float32 is an np.float64. This is unlike classic NumPy, which treats scalars specially during type promotion, in particular, preferring the type of an array over the type of a scalar.

This change adds a notion of weak_type to JAX avals. During type promotion, we prefer non-weak types, i.e., the type of the array in the example above, ignoring the type of the scalar.

In contexts where a Python scalar is to be promoted to a NumPy value, a default type is used (e.g., `np.float_`). This change also makes it possible to use 32-bit default types that differ from NumPy's default types. The JAX test suite passes with 32-bit default types. However, we do not yet enable this change or expose it in the API.
