### PR TITLE
Add support for scipy.ndimage.map_coordinates with order=0 and order=1

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -276,7 +276,7 @@ def update_numpydoc(docstr, fun, op):
 
 _numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$')
 
-def _wraps(fun, update_doc=True):
+def _wraps(fun, update_doc=True, lax_description=""):
   """Like functools.wraps but works with numpy.ufuncs.
      It is important that when wrapping numpy functions the parameters names 
      in the original function and in the JAX version are the same
@@ -310,11 +310,12 @@ def _wraps(fun, update_doc=True):
       body = "\n\n".join(signatures + sections[i + 1:])
       if update_doc:
         body = update_numpydoc(body, fun, op)
+      desc = lax_description + "\n" if lax_description else ""
       docstr = (
-        "{summary}\n\nLAX-backend implementation of :func:`{fun}`. "
-        "Original docstring below.\n\n{body}".format(
-          summary=summary, fun=fun.__name__, body=body))
-
+          "{summary}\n\nLAX-backend implementation of :func:`{fun}`.\n"
+          "{lax_description}Original docstring below.\n\n{body}"
+          .format(summary=summary, lax_description=desc,
+                  fun=fun.__name__, body=body))
 
       op.__name__ = fun.__name__
       op.__doc__ = docstr

--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -14,5 +14,6 @@
 
 from __future__ import absolute_import
 from . import linalg
+from . import ndimage
 from . import special
 from . import stats

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,6 +69,10 @@ def map_coordinates(
   input = np.asarray(input)
   coordinates = [np.asarray(c, input.dtype) for c in coordinates]
   cval = np.asarray(cval, input.dtype)
+
+  if len(coordinates) != input.ndim:
+    raise ValueError('coordinates must be a sequence of length input.ndim, but '
+                     '{} != {}'.format(len(coordinates), input.ndim))
 
   index_fixer = _INDEX_FIXERS.get(mode)
   if index_fixer is None:

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -1,0 +1,98 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import itertools
+import operator
+import textwrap
+
+import scipy.ndimage
+
+from ..numpy import lax_numpy as np
+from ..numpy.lax_numpy import _wraps
+
+
+_NOTE = '\n'.join(textwrap.wrap("""\
+Only linear interpolation (``order=1``) and modes ``'constant'``, ``'nearest'``
+and ``'wrap'`` are currently supported. Note that interpolation near boundaries
+differs from the scipy function, because we fixed an outstanding bug
+(https://github.com/scipy/scipy/issues/2640) -- this function interprets the
+``mode`` argument as documented by SciPy, but not as implemented by SciPy.
+""", width=72)) + "\n"
+
+
+def _prod(values):
+  out = 1
+  for value in values:
+    out *= value
+  return out
+
+
+# Note: these only hold for order=1
+_INDEX_FIXERS = {
+    'constant': lambda index, size: index,
+    'nearest': lambda index, size: np.clip(index, 0, size - 1),
+    'wrap': lambda index, size: index % size,
+}
+
+
+@_wraps(scipy.ndimage.map_coordinates, lax_description=_NOTE)
+def map_coordinates(
+    input, coordinates, order, mode='constant', cval=0.0,
+):
+  if order != 1:
+    raise NotImplementedError(
+        'jax.scipy.ndimage.map_coordinates currently requires order=1')
+
+  input = np.asarray(input)
+
+  index_fixer = _INDEX_FIXERS.get(mode)
+  if index_fixer is None:
+    raise NotImplementedError(
+        'jax.scipy.ndimage.map_coordinates does not yet support mode {}. '
+        'Currently supported modes are {}.'.format(mode, set(_INDEX_FIXERS)))
+
+  if mode == 'constant':
+    is_valid = lambda index, size: (0 <= index) & (index < size)
+  else:
+    is_valid = lambda index, size: True
+
+  all_indices_and_weights = []
+  for coordinate, size in zip(coordinates, input.shape):
+    lower = np.floor(coordinate)
+    upper = np.ceil(coordinate)
+    l_index = lower.astype(np.int32)
+    u_index = upper.astype(np.int32)
+    l_weight = 1 - (coordinate - lower)
+    u_weight = 1 - l_weight  # handles the edge case lower==upper
+    all_indices_and_weights.append(
+        [(index_fixer(l_index, size), is_valid(l_index, size), l_weight),
+         (index_fixer(u_index, size), is_valid(u_index, size), u_weight)]
+    )
+
+  outputs = []
+  for items in itertools.product(*all_indices_and_weights):
+    indices, validities, weights = zip(*items)
+    if any(valid is not True for valid in validities):
+      all_valid = functools.reduce(operator.and_, validities)
+      contribution = np.where(all_valid, input[indices], cval)
+    else:
+      contribution = input[indices]
+    outputs.append(_prod(weights) * contribution)
+  result = sum(outputs)
+  return result

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -27,15 +27,6 @@ from ..numpy import lax_numpy as np
 from ..numpy.lax_numpy import _wraps
 
 
-_NOTE = '\n'.join(textwrap.wrap("""\
-Only linear interpolation (``order=1``) and modes ``'constant'``, ``'nearest'``
-and ``'wrap'`` are currently supported. Note that interpolation near boundaries
-differs from the scipy function, because we fixed an outstanding bug
-(https://github.com/scipy/scipy/issues/2640) -- this function interprets the
-``mode`` argument as documented by SciPy, but not as implemented by SciPy.
-""", width=72)) + "\n"
-
-
 def _prod(values):
   out = 1
   for value in values:
@@ -51,7 +42,14 @@ _INDEX_FIXERS = {
 }
 
 
-@_wraps(scipy.ndimage.map_coordinates, lax_description=_NOTE)
+@_wraps(scipy.ndimage.map_coordinates, lax_description=textwrap.dedent("""\
+    Only linear interpolation (``order=1``) and modes ``'constant'``,
+    ``'nearest'`` and ``'wrap'`` are currently supported. Note that
+    interpolation near boundaries differs from the scipy function, because we
+    fixed an outstanding bug (https://github.com/scipy/scipy/issues/2640);
+    this function interprets the ``mode`` argument as documented by SciPy, but
+    not as implemented by SciPy.
+    """))
 def map_coordinates(
     input, coordinates, order, mode='constant', cval=0.0,
 ):

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -25,6 +25,7 @@ from absl.testing import parameterized
 import scipy.ndimage as osp_ndimage
 
 from jax import test_util as jtu
+from jax import dtypes
 from jax.scipy import ndimage as lsp_ndimage
 
 from jax.config import config
@@ -91,7 +92,8 @@ class NdimageTest(jtu.JaxTestCase):
     order = 1
     lsp_op = lambda x, c: lsp_ndimage.map_coordinates(x, c, order, mode, cval)
     osp_op = lambda x, c: _fixed_scipy_map_coordinates(x, c, order, mode, cval)
-    epsilon = max(onp.finfo(dtype).eps, onp.finfo(coords_dtype).eps)
+    epsilon = max([dtypes.finfo(dtypes.canonicalize_dtype(d)).eps
+                   for d in [dtype, coords_dtype]])
     self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, tol=10*epsilon,
                             check_dtypes=True)
 

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -40,9 +40,12 @@ bool_dtypes = [onp.bool_]
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
 
 
-def _fixed_scipy_map_coordinates(input, coordinates, order, mode, cval=0.0):
+def _fixed_ref_map_coordinates(input, coordinates, order, mode, cval=0.0):
+  # SciPy's implementation of map_coordinates handles boundaries incorrectly,
+  # unless mode='reflect'. For order=1, this only affects interpolation outside
+  # the bounds of the original array.
   # https://github.com/scipy/scipy/issues/2640
-  assert order == 1
+  assert order <= 1
   padding = [(max(-onp.floor(c.min()).astype(int) + 1, 0),
               max(onp.ceil(c.max()).astype(int) + 1 - size, 0))
              for c, size in zip(coordinates, input.shape)]
@@ -63,35 +66,42 @@ def _fixed_scipy_map_coordinates(input, coordinates, order, mode, cval=0.0):
 class NdimageTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_coordinates={}_mode={}_cval={}_round={}".format(
+      {"testcase_name": "_{}_coordinates={}_order={}_mode={}_cval={}_impl={}_round={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           jtu.format_shape_dtype_string(coords_shape, coords_dtype),
-          mode, cval, round_),
-       "rng_factory": rng_factory, "shape": shape, "coords_shape": coords_shape,
-       "dtype": dtype, "coords_dtype": coords_dtype, "mode": mode, "cval": cval,
-       "round_": round_}
+          order, mode, cval, impl, round_),
+       "rng_factory": rng_factory, "shape": shape,
+       "coords_shape": coords_shape, "dtype": dtype,
+       "coords_dtype": coords_dtype, "order": order, "mode": mode,
+       "cval": cval, "impl": impl, "round_": round_}
       for shape in [(5,), (3, 4), (3, 4, 5)]
       for coords_shape in [(7,), (2, 3, 4)]
       for dtype in float_dtypes
       for coords_dtype in float_dtypes
+      for order in [0, 1]
       for mode in ['wrap', 'constant', 'nearest']
       for cval in ([0, -1] if mode == 'constant' else [0])
-      for rng_factory in [partial(jtu.rand_uniform, -0.75, 1.75)]
+      for impl, rng_factory in [
+          ("original", partial(jtu.rand_uniform, 0, 1)),
+          ("fixed", partial(jtu.rand_uniform, -0.75, 1.75)),
+      ]
       for round_ in [True, False]))
-  def testMapCoordinates(self, shape, dtype, coords_shape, coords_dtype, mode,
-                         cval, round_, rng_factory):
+  def testMapCoordinates(self, shape, dtype, coords_shape, coords_dtype, order,
+                         mode, cval, impl, round_, rng_factory):
 
     def args_maker():
       x = onp.arange(onp.prod(shape), dtype=dtype).reshape(shape)
-      coords = [size * rng(coords_shape, coords_dtype) for size in shape]
+      coords = [(size - 1) * rng(coords_shape, coords_dtype) for size in shape]
       if round_:
         coords = [c.round().astype(int) for c in coords]
       return x, coords
 
     rng = rng_factory()
-    order = 1
-    lsp_op = lambda x, c: lsp_ndimage.map_coordinates(x, c, order, mode, cval)
-    osp_op = lambda x, c: _fixed_scipy_map_coordinates(x, c, order, mode, cval)
+    lsp_op = lambda x, c: lsp_ndimage.map_coordinates(
+        x, c, order=order, mode=mode, cval=cval)
+    impl_fun = (osp_ndimage.map_coordinates if impl == "original"
+                else _fixed_ref_map_coordinates)
+    osp_op = lambda x, c: impl_fun(x, c, order=order, mode=mode, cval=cval)
     epsilon = max([dtypes.finfo(dtypes.canonicalize_dtype(d)).eps
                    for d in [dtype, coords_dtype]])
     self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, tol=10*epsilon,

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -107,6 +107,17 @@ class NdimageTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, tol=10*epsilon,
                             check_dtypes=True)
 
+  def testMapCoordinatesErrors(self):
+    x = onp.arange(5.0)
+    c = [onp.linspace(0, 5, num=3)]
+    with self.assertRaisesRegex(NotImplementedError, 'requires order<=1'):
+      lsp_ndimage.map_coordinates(x, c, order=2)
+    with self.assertRaisesRegex(
+        NotImplementedError, 'does not yet support mode'):
+      lsp_ndimage.map_coordinates(x, c, order=1, mode='reflect')
+    with self.assertRaisesRegex(ValueError, 'sequence of length'):
+      lsp_ndimage.map_coordinates(x, [c, c], order=1)
+
   def testMapCoordinateDocstring(self):
     self.assertIn("Only linear interpolation",
                   lsp_ndimage.map_coordinates.__doc__)

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -1,0 +1,95 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+
+import numpy as onp
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import scipy.ndimage as osp_ndimage
+
+from jax import test_util as jtu
+from jax.scipy import ndimage as lsp_ndimage
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+float_dtypes = [onp.float32, onp.float64]
+complex_dtypes = [onp.complex64, onp.complex128]
+inexact_dtypes = float_dtypes + complex_dtypes
+int_dtypes = [onp.int32, onp.int64]
+bool_dtypes = [onp.bool_]
+all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+
+
+def _fixed_scipy_map_coordinates(input, coordinates, order, mode):
+  # https://github.com/scipy/scipy/issues/2640
+  assert order == 1
+  padding = [(max(-onp.floor(c.min()).astype(int) + 1, 0),
+              max(onp.ceil(c.max()).astype(int) + 1 - size, 0))
+             for c, size in zip(coordinates, input.shape)]
+  shifted_coords = [c + p[0] for p, c in zip(padding, coordinates)]
+  pad_mode = {
+      'nearest': 'edge', 'mirror': 'reflect', 'reflect': 'symmetric'
+  }.get(mode, mode)
+  padded = onp.pad(input, padding, mode=pad_mode)
+  return osp_ndimage.map_coordinates(
+      padded, shifted_coords, order=order, mode=mode)
+
+
+class NdimageTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_coordinates={}_mode={}_round={}".format(
+          jtu.format_shape_dtype_string(shape, dtype),
+          jtu.format_shape_dtype_string(coords_shape, coords_dtype),
+          mode, round_),
+       "rng_factory": rng_factory, "shape": shape,
+       "coords_shape": coords_shape, "dtype": dtype,
+       "coords_dtype": coords_dtype, "mode": mode, "round_": round_}
+      for shape in [(5,), (3, 4), (3, 4, 5)]
+      for coords_shape in [(7,), (2, 3, 4)]
+      for dtype in float_dtypes
+      for coords_dtype in float_dtypes
+      for mode in ['wrap', 'constant', 'nearest']
+      for rng_factory in [partial(jtu.rand_uniform, -0.75, 1.75)]
+      for round_ in [True, False]))
+  def testMapCoordinates(self, shape, dtype, coords_shape, coords_dtype, mode,
+                         round_, rng_factory):
+
+    def args_maker():
+      x = onp.arange(onp.prod(shape), dtype=dtype).reshape(shape)
+      coords = [size * rng(coords_shape, coords_dtype) for size in shape]
+      if round_:
+        coords = [c.round().astype(int) for c in coords]
+      return x, coords
+
+    rng = rng_factory()
+    lsp_op = lambda x, c: lsp_ndimage.map_coordinates(x, c, order=1, mode=mode)
+    osp_op = lambda x, c: _fixed_scipy_map_coordinates(x, c, order=1, mode=mode)
+    self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, check_dtypes=True)
+
+  def testMapCoordinateDocstring(self):
+    self.assertIn("Only linear interpolation",
+                  lsp_ndimage.map_coordinates.__doc__)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Higher dimensional interpolation will be a bit trickier, but this should already be useful.

~~Nearest neighbor interpolation with `order=0` could be added pretty easily, but that is basically want indexing already does.~~ Both `order=0` and `order=1` are supported.

Unfortunately SciPy's own `map_coordinates` has broken handling of boundary conditions (https://github.com/scipy/scipy/issues/2640). Rather than reproduce those bugs, they are fixed here.