### PR TITLE
Add type check that indexers are integers or boolean values.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2843,6 +2843,12 @@ def _index_to_gather(x_shape, idx):
       y_axis += 1
       x_axis += 1
     else:
+      if (not issubdtype(abstract_i.dtype, integer)
+          and not issubdtype(abstract_i.dtype, bool_)):
+        msg = ("Indexer must have integer or boolean type, got indexer "
+               "with type {} at position {}, indexer value {}")
+        raise TypeError(msg.format(abstract_i.dtype.name, idx_pos, i))
+
       msg = "Indexing mode not yet supported. Open a feature request!\n{}"
       raise IndexError(msg.format(idx))
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -753,6 +753,9 @@ class IndexingTest(jtu.JaxTestCase):
     expected =  onp.array([-1])[onp.array([False])]
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testFloatIndexingError(self):
+    x = lnp.array([1, 2, 3])
+    self.assertRaises(TypeError, lambda: x[3.5])
 
 def _broadcastable_shapes(shape):
   """Returns all shapes that broadcast to `shape`."""


### PR DESCRIPTION
Improves error if, say, a float type is passed as an indexer.