### PR TITLE
when transposing a jaxpr, do a constant eval pass

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -663,3 +663,11 @@ def pp_jaxpr(jaxpr):
           ((pp('let ') >>
             vcat(map(pp_eqn, jaxpr.eqns))) +
            pp('in {} }}'.format(jaxpr.outvars))).indent(2))
+
+
+def tie_in(x, y):
+  return tie_in_p.bind(x, y)
+
+tie_in_p = Primitive('tie_in')
+tie_in_p.def_impl(lambda x, y: y)
+tie_in_p.def_abstract_eval(lambda x, y: y)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -763,3 +763,5 @@ def _instantiate_device_constant(const, device=None, backend=None, cutoff=1e6):
   else:
     return xc.Buffer.from_pyval(onp.asarray(const), device,
                                 backend=xb.get_backend(backend))
+
+translations[core.tie_in_p] = lambda c, x, y: y

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -414,7 +414,7 @@ _defbroadcasting(lax.shift_left_p)
 _defbroadcasting(lax.shift_right_arithmetic_p)
 _defbroadcasting(lax.shift_right_logical_p)
 
-_defidentity(lax.tie_in_p)
+_defidentity(core.tie_in_p)
 
 _defreducer(lax.reduce_sum_p, psum_p)
 _defreducer(lax.reduce_max_p, pmax_p)


### PR DESCRIPTION
This change includes #1715, plus the stuff described below.

Before this change, the jaxpr

```
{ lambda  ;  ; a.
  let b = add 2. 3.
      c = mul b a
  in [c] }
```

was not transposable, even though it is linear. The issue was that our transposition machinery assumed that in effect there were no constant subexpressions, and that constants appeared only as literals or as constvars. So this jaxpr would work:

```
{ lambda  ;  ; a.
  let b = mul 5. a
  in [b] }
```

However, as in #1715, using `tie_in` to control the parts of the computation that get staged out to jaxprs and hence xla (e.g. to avoid materializing large constants) could create jaxprs with constant subexpressions (indeed that's the point!).

This commit resolves the issue by adding a constant evaluation pass to `backward_pass` in ad.py. In the grad-of-jit case, this evaluation is staged out to XLA.

We thought about having `tie_in` not appear in jaxprs (as in #1647), but that would remove our ability to stage computations out to the backward pass (e.g. to avoid materializing a large constant in the backward pass).

The solution here is a stop-gap that we hope to be cleaned up a bit with #1677, which aims to provide an explicit embedding API to replace the use of `tie_in`.