### PR TITLE
Add bfloat16 support to JAX.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -198,10 +198,11 @@ def zeros_like_array(x):
   dtype = dtypes.canonicalize_dtype(dtypes.result_type(x))
   return onp.broadcast_to(onp.array(0, dtype), onp.shape(x))
 
-array_types = {onp.ndarray, onp.float64, onp.float32, onp.float16,
+array_types = {onp.ndarray, onp.bool_,
+               onp.int8, onp.int16, onp.int32, onp.int64,
+               onp.uint8, onp.uint16, onp.uint32, onp.uint64,
+               dtypes.bfloat16, onp.float16, onp.float32, onp.float64,
                onp.complex64, onp.complex128,
-               onp.int64, onp.int32, onp.int16, onp.int8,
-               onp.bool_, onp.uint64, onp.uint32, onp.uint16, onp.uint8,
                onp.longlong}
 
 for t in array_types:

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -133,7 +133,6 @@ def issubdtype(a, b):
 
 can_cast = onp.can_cast
 issubsctype = onp.issubsctype
-promote_types = onp.promote_types
 
 _bfloat16_type_promotions = {
   onp.dtype('bool'): onp.dtype(bfloat16),

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Array type functions.
+#
+# JAX dtypes differ from NumPy in both:
+# a) their type promotion rules, and
+# b) the set of supported types (e.g., bfloat16),
+# so we need our own implementation that deviates from NumPy in places.
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1750,11 +1750,7 @@ def _add_transpose(t, x, y):
   # assert x is ad.undefined_primal and y is ad.undefined_primal  # not affine
   return [t, t]
 
-def _add_translation_rule(c, x, y):
-  return (c.Add if c.GetShape(x).numpy_dtype() != onp.bool_ else c.Or)(x, y)
-
-add_p = standard_binop([_num, _num], 'add',
-                       translation_rule=_add_translation_rule)
+add_p = standard_binop([_num, _num], 'add')
 ad.defjvp(add_p, lambda g, x, y: _brcast(g, y), lambda g, x, y: _brcast(g, x))
 ad.primitive_transposes[add_p] = _add_transpose
 
@@ -1769,10 +1765,7 @@ ad.defjvp(sub_p,
           lambda g, x, y: _brcast(neg(g), x))
 ad.primitive_transposes[sub_p] = _sub_transpose
 
-def _mul_translation_rule(c, x, y):
-  return (c.Mul if c.GetShape(x).numpy_dtype() != onp.bool_ else c.And)(x, y)
-mul_p = standard_binop([_num, _num], 'mul',
-                       translation_rule=_mul_translation_rule)
+mul_p = standard_binop([_num, _num], 'mul')
 ad.defbilinear_broadcasting(_brcast, mul_p, mul, mul)
 
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1750,7 +1750,11 @@ def _add_transpose(t, x, y):
   # assert x is ad.undefined_primal and y is ad.undefined_primal  # not affine
   return [t, t]
 
-add_p = standard_binop([_num, _num], 'add')
+def _add_translation_rule(c, x, y):
+  return (c.Add if c.GetShape(x).numpy_dtype() != onp.bool_ else c.Or)(x, y)
+
+add_p = standard_binop([_num, _num], 'add',
+                       translation_rule=_add_translation_rule)
 ad.defjvp(add_p, lambda g, x, y: _brcast(g, y), lambda g, x, y: _brcast(g, x))
 ad.primitive_transposes[add_p] = _add_transpose
 
@@ -1765,7 +1769,10 @@ ad.defjvp(sub_p,
           lambda g, x, y: _brcast(neg(g), x))
 ad.primitive_transposes[sub_p] = _sub_transpose
 
-mul_p = standard_binop([_num, _num], 'mul')
+def _mul_translation_rule(c, x, y):
+  return (c.Mul if c.GetShape(x).numpy_dtype() != onp.bool_ else c.And)(x, y)
+mul_p = standard_binop([_num, _num], 'mul',
+                       translation_rule=_mul_translation_rule)
 ad.defbilinear_broadcasting(_brcast, mul_p, mul, mul)
 
 

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -25,6 +25,8 @@ import scipy.special
 
 from six.moves import builtins
 
+from . import dtypes
+
 _slice = builtins.slice
 _max = builtins.max
 _min = builtins.min
@@ -88,7 +90,7 @@ sub = onp.subtract
 mul = onp.multiply
 
 def div(lhs, rhs):
-  if onp.issubdtype(onp.result_type(lhs), onp.integer):
+  if dtypes.issubdtype(dtypes.result_type(lhs), onp.integer):
     quotient = onp.floor_divide(lhs, rhs)
     select = onp.logical_and(onp.sign(lhs) != onp.sign(rhs),
                              onp.remainder(lhs, rhs) != 0)
@@ -176,7 +178,11 @@ def dot_general(lhs, rhs, dimension_numbers):
   not_none = lambda x: x is not None
   out_axis_ids = filter(not_none,
                         batch_ids + lhs_out_axis_ids + rhs_out_axis_ids)
-  return onp.einsum(lhs, lhs_axis_ids, rhs, rhs_axis_ids, out_axis_ids)
+  assert lhs.dtype == rhs.dtype
+  dtype = onp.float32 if lhs.dtype == dtypes.bfloat16 else None
+  out = onp.einsum(lhs, lhs_axis_ids, rhs, rhs_axis_ids, out_axis_ids,
+                   dtype=dtype)
+  return out.astype(dtypes.bfloat16) if lhs.dtype == dtypes.bfloat16 else out
 
 def broadcast(operand, sizes):
   return onp.broadcast_to(operand, sizes + onp.shape(operand))
@@ -352,15 +358,15 @@ def _make_reducer(py_binop, init_val):
   monoid_record = _monoids.get(getattr(py_binop, '__name__'))
   if monoid_record:
     reducer, monoid_identity = monoid_record
-    if init_val == monoid_identity(onp.result_type(init_val)):
+    if init_val == monoid_identity(dtypes.result_type(init_val)):
       return reducer
   return _reducer_from_pyfunc(py_binop, init_val)
 
 def _get_max_identity(dt):
-  return -onp.inf if onp.issubdtype(dt, onp.floating) else onp.iinfo(dt).min
+  return -onp.inf if dtypes.issubdtype(dt, onp.floating) else onp.iinfo(dt).min
 
 def _get_min_identity(dt):
-  return onp.inf if onp.issubdtype(dt, onp.floating) else onp.iinfo(dt).max
+  return onp.inf if dtypes.issubdtype(dt, onp.floating) else onp.iinfo(dt).max
 
 def _identity_getter(op):
   return lambda dtype: onp.asarray(op.identity, dtype=dtype)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -116,6 +116,21 @@ def tolerance(dtype, tol=None):
   dtype = dtypes.canonicalize_dtype(onp.dtype(dtype))
   return tol.get(dtype, default[dtype])
 
+def _normalize_tolerance(tol):
+  tol = tol or 0
+  if isinstance(tol, dict):
+    return {onp.dtype(k): v for k, v in tol.items()}
+  else:
+    return {k: tol for k in default_tolerance.keys()}
+
+def join_tolerance(tol1, tol2):
+  tol1 = _normalize_tolerance(tol1)
+  tol2 = _normalize_tolerance(tol2)
+  out = tol1
+  for k, v in tol2.items():
+    out[k] = max(v, tol1.get(k, 0))
+  return out
+
 def _assert_numpy_close(a, b, atol=None, rtol=None):
   assert a.shape == b.shape
   atol = max(tolerance(a.dtype, atol), tolerance(b.dtype, atol))

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -77,6 +77,7 @@ default_tolerance = {
   onp.dtype(onp.uint16): 0,
   onp.dtype(onp.uint32): 0,
   onp.dtype(onp.uint64): 0,
+  onp.dtype(dtypes.bfloat16): 1e-2,
   onp.dtype(onp.float16): 1e-3,
   onp.dtype(onp.float32): 1e-6,
   onp.dtype(onp.float64): 1e-15,
@@ -89,6 +90,7 @@ tpu_default_tolerance[onp.dtype(onp.float32)] = 1e-3
 tpu_default_tolerance[onp.dtype(onp.complex64)] = 1e-3
 
 default_gradient_tolerance = {
+  onp.dtype(dtypes.bfloat16): 1e-1,
   onp.dtype(onp.float16): 1e-2,
   onp.dtype(onp.float32): 2e-3,
   onp.dtype(onp.float64): 1e-5,
@@ -96,8 +98,10 @@ default_gradient_tolerance = {
   onp.dtype(onp.complex128): 1e-5,
 }
 
-def _assert_numpy_eq(x, y):
-  onp.testing.assert_allclose(x, y)
+def _assert_numpy_allclose(a, b, atol=None, rtol=None):
+  a = a.astype(onp.float32) if a.dtype == dtypes.bfloat16 else a
+  b = b.astype(onp.float32) if b.dtype == dtypes.bfloat16 else b
+  onp.testing.assert_allclose(a, b, atol=atol, rtol=rtol)
 
 def tolerance(dtype, tol=None):
   tol = tol or {}
@@ -113,11 +117,11 @@ def _assert_numpy_close(a, b, atol=None, rtol=None):
   assert a.shape == b.shape
   atol = max(tolerance(a.dtype, atol), tolerance(b.dtype, atol))
   rtol = max(tolerance(a.dtype, rtol), tolerance(b.dtype, rtol))
-  onp.testing.assert_allclose(a, b, atol=atol * a.size, rtol=rtol * b.size)
+  _assert_numpy_allclose(a, b, atol=atol * a.size, rtol=rtol * b.size)
 
 
 def check_eq(xs, ys):
-  tree_all(tree_multimap(_assert_numpy_eq, xs, ys))
+  tree_all(tree_multimap(_assert_numpy_allclose, xs, ys))
 
 
 def check_close(xs, ys, atol=None, rtol=None):
@@ -126,7 +130,8 @@ def check_close(xs, ys, atol=None, rtol=None):
 
 
 def inner_prod(xs, ys):
-  contract = lambda x, y: onp.real(onp.vdot(x, y))
+  def contract(x, y):
+    return onp.real(onp.dot(onp.conj(x).reshape(-1), y.reshape(-1)))
   return tree_reduce(onp.add, tree_multimap(contract, xs, ys))
 
 
@@ -226,12 +231,12 @@ def device_under_test():
 def supported_dtypes():
   if device_under_test() == "tpu":
     return {onp.bool_, onp.int32, onp.int64, onp.uint32, onp.uint64,
-            onp.float32, onp.complex64}
+            dtypes.bfloat16, onp.float32, onp.complex64}
   else:
     return {onp.bool_, onp.int8, onp.int16, onp.int32, onp.int64,
             onp.uint8, onp.uint16, onp.uint32, onp.uint64,
-            onp.float16, onp.float32, onp.float64, onp.complex64,
-            onp.complex128}
+            dtypes.bfloat16, onp.float16, onp.float32, onp.float64,
+            onp.complex64, onp.complex128}
 
 def skip_on_devices(*disabled_devices):
   """A decorator for test methods to skip the test on certain devices."""
@@ -352,7 +357,7 @@ def rand_default():
 
 
 def rand_nonzero():
-  post = lambda x: onp.where(x == 0, 1, x)
+  post = lambda x: onp.where(x == 0, onp.array(1, dtype=x.dtype), x)
   randn = npr.RandomState(0).randn
   return partial(_rand_dtype, randn, scale=3, post=post)
 
@@ -423,8 +428,8 @@ def rand_some_inf():
     neginf_flips = rng.rand(*dims) < 0.1
 
     vals = base_rand(shape, dtype)
-    vals = onp.where(posinf_flips, onp.inf, vals)
-    vals = onp.where(neginf_flips, -onp.inf, vals)
+    vals = onp.where(posinf_flips, onp.array(onp.inf, dtype=dtype), vals)
+    vals = onp.where(neginf_flips, onp.array(-onp.inf, dtype=dtype), vals)
 
     return _cast_to_shape(onp.asarray(vals, dtype=dtype), shape, dtype)
 
@@ -449,7 +454,7 @@ def rand_some_nan():
     nan_flips = rng.rand(*dims) < 0.1
 
     vals = base_rand(shape, dtype)
-    vals = onp.where(nan_flips, onp.nan, vals)
+    vals = onp.where(nan_flips, onp.array(onp.nan, dtype=dtype), vals)
 
     return _cast_to_shape(onp.asarray(vals, dtype=dtype), shape, dtype)
 
@@ -480,9 +485,9 @@ def rand_some_inf_and_nan():
     nan_flips = rng.rand(*dims) < 0.1
 
     vals = base_rand(shape, dtype)
-    vals = onp.where(posinf_flips, onp.inf, vals)
-    vals = onp.where(neginf_flips, -onp.inf, vals)
-    vals = onp.where(nan_flips, onp.nan, vals)
+    vals = onp.where(posinf_flips, onp.array(onp.inf, dtype=dtype), vals)
+    vals = onp.where(neginf_flips, onp.array(-onp.inf, dtype=dtype), vals)
+    vals = onp.where(nan_flips, onp.array(onp.nan, dtype=dtype), vals)
 
     return _cast_to_shape(onp.asarray(vals, dtype=dtype), shape, dtype)
 
@@ -500,7 +505,7 @@ def rand_some_zero():
     zeros = rng.rand(*dims) < 0.5
 
     vals = base_rand(shape, dtype)
-    vals = onp.where(zeros, 0, vals)
+    vals = onp.where(zeros, onp.array(0, dtype=dtype), vals)
 
     return _cast_to_shape(onp.asarray(vals, dtype=dtype), shape, dtype)
 
@@ -564,7 +569,7 @@ class JaxTestCase(parameterized.TestCase):
     atol = max(tolerance(_dtype(x), atol), tolerance(_dtype(y), atol))
     rtol = max(tolerance(_dtype(x), rtol), tolerance(_dtype(y), rtol))
 
-    onp.testing.assert_allclose(x, y, atol=atol, rtol=rtol)
+    _assert_numpy_allclose(x, y, atol=atol, rtol=rtol)
 
     if check_dtypes:
       self.assertDtypesMatch(x, y)
@@ -639,5 +644,5 @@ class JaxTestCase(parameterized.TestCase):
     args = args_maker()
     numpy_ans = numpy_reference_op(*args)
     lax_ans = lax_op(*args)
-    self.assertAllClose(lax_ans, numpy_ans, check_dtypes=check_dtypes,
+    self.assertAllClose(numpy_ans, lax_ans, check_dtypes=check_dtypes,
                         atol=tol, rtol=tol)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -101,7 +101,10 @@ default_gradient_tolerance = {
 def _assert_numpy_allclose(a, b, atol=None, rtol=None):
   a = a.astype(onp.float32) if a.dtype == dtypes.bfloat16 else a
   b = b.astype(onp.float32) if b.dtype == dtypes.bfloat16 else b
-  onp.testing.assert_allclose(a, b, atol=atol, rtol=rtol)
+  kw = {}
+  if atol: kw["atol"] = atol
+  if rtol: kw["rtol"] = rtol
+  onp.testing.assert_allclose(a, b, **kw)
 
 def tolerance(dtype, tol=None):
   tol = tol or {}

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -374,8 +374,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                   jtu.NUMPY_SCALAR_SHAPE in shapes or
                   () in shapes)
     empty_shape = any(isinstance(s, tuple) and 0 in s for s in shapes)
-    tol_dtypes = list(dtypes) + [lnp.result_type(*dtypes)]
-    tol = max(jtu.tolerance(dtype, tolerance) for dtype in tol_dtypes)
+    tol = max(jtu.tolerance(dtype, tolerance) for dtype in dtypes)
+    tol = functools.reduce(jtu.join_tolerance,
+                           [tolerance, tol, jtu.default_tolerance])
     self._CheckAgainstNumpy(
       onp_op, lnp_op, args_maker,
       check_dtypes=check_dtypes and not scalar_arg and not empty_shape,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -376,7 +376,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     empty_shape = any(isinstance(s, tuple) and 0 in s for s in shapes)
     tol = max(jtu.tolerance(dtype, tolerance) for dtype in dtypes)
     tol = functools.reduce(jtu.join_tolerance,
-                           [tolerance, tol, jtu.default_tolerance])
+                           [tolerance, tol, jtu.default_tolerance()])
     self._CheckAgainstNumpy(
       onp_op, lnp_op, args_maker,
       check_dtypes=check_dtypes and not scalar_arg and not empty_shape,
@@ -1057,10 +1057,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         return onp.trace(arg, offset, axis1, axis2, onp.float32).astype(lnp.bfloat16)
       else:
         return onp.trace(arg, offset, axis1, axis2, out_dtype)
-    #   t = out_dtype if out_dtype != lnp.bfloat16 else onp.float32
-    #   out = onp.trace(arg, offset, axis1, axis2, t)
-    #   return out.astype(out_t) if out_dtype else out
-    # onp_fun = lambda arg: onp.trace(arg, offset, axis1, axis2, out_dtype)
     lnp_fun = lambda arg: lnp.trace(arg, offset, axis1, axis2, out_dtype)
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2210,7 +2210,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     init_val = onp.asarray(init_val, dtype=dtype)
     reduce = lambda operand: lax.reduce(operand, init_val, op, dims)
     eps = (1.0 if dtypes.finfo(dtype).bits == 16 and op is lax.add else
-           5e-1 if dtype == dtypes.bfloat16 and op is lax.mul else
+           2e-0 if dtype == dtypes.bfloat16 and op is lax.mul else
            1e-1 if dtype == dtypes.bfloat16 else
            1e-2 if dtypes.finfo(dtype).bits == 32 else None)
     check_grads(reduce, (operand,), 1, ["fwd", "rev"], tol, tol, eps)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -652,7 +652,7 @@ class LaxTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     tol = {
       onp.float16: 1e-2,
-      onp.float64: max(jtu.default_tolerance[onp.dtype(onp.float64)], 1e-14)
+      onp.float64: max(jtu.default_tolerance()[onp.dtype(onp.float64)], 1e-14)
     }
     lax_op = partial(lax.dot, precision=lax.Precision.HIGHEST)
     self._CheckAgainstNumpy(lax_op, lax_reference.dot, args_maker, tol=tol)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -55,7 +55,7 @@ def num_float_bits(dtype):
 # arguments of appropriate shapes and dtypes using the following table.
 
 float_dtypes = list(jtu.supported_dtypes().intersection(
-  {onp.float16, onp.float32, onp.float64}))
+  {dtypes.bfloat16, onp.float16, onp.float32, onp.float64}))
 complex_dtypes = [onp.complex64, onp.complex128]
 inexact_dtypes = float_dtypes + complex_dtypes
 int_dtypes = [onp.int32, onp.int64]
@@ -64,27 +64,6 @@ default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
 
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
-
-default_tolerance = {
-  onp.bool_: 0,
-  onp.int16: 0,
-  onp.int32: 0,
-  onp.int64: 0,
-  onp.float16: 1e-3,
-  onp.float32: 1e-6,
-  onp.float64: 1e-15,
-  onp.complex64: 1e-6,
-  onp.complex128: 1e-15,
-}
-
-def tolerance(dtype, tol=None):
-  if not FLAGS.jax_enable_x64:
-    if dtype == onp.float64:
-      dtype = onp.float32
-    elif dtype == onp.complex128:
-      dtype = onp.complex64
-  tol = tol or {}
-  return tol.get(dtype, default_tolerance[dtype])
 
 
 OpRecord = collections.namedtuple(
@@ -671,8 +650,10 @@ class LaxTest(jtu.JaxTestCase):
   def testDotAgainstNumpy(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-    tol = {onp.float16: 1e-2,
-           onp.float64: max(default_tolerance[onp.float64], 1e-14)}
+    tol = {
+      onp.float16: 1e-2,
+      onp.float64: max(jtu.default_tolerance[onp.dtype(onp.float64)], 1e-14)
+    }
     lax_op = partial(lax.dot, precision=lax.Precision.HIGHEST)
     self._CheckAgainstNumpy(lax_op, lax_reference.dot, args_maker, tol=tol)
 
@@ -1740,26 +1721,6 @@ def check_grads_bilinear(f, args, order,
   check_grads(lambda rhs: f(lhs, rhs), (rhs,), order,
               modes=modes, atol=atol, rtol=rtol, eps=1.)
 
-
-default_gradient_tolerance = {
-  onp.float16: 1e-2,
-  onp.float32: 1e-6,
-  onp.float64: 1e-10,
-  onp.complex64: 1e-6,
-  onp.complex128: 1e-10,
-}
-
-def gradient_tolerance(dtype, tol=None):
-  if dtype == onp.complex64:
-    dtype = onp.float32
-  elif dtype == onp.complex128:
-    dtype = onp.float64
-  if not FLAGS.jax_enable_x64 and dtype == onp.float64:
-    dtype = onp.float32
-  tol = tol or {}
-  return tol.get(dtype, default_gradient_tolerance[dtype])
-
-
 class LaxAutodiffTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
@@ -1798,7 +1759,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testConvertElementTypeGrad(self, from_dtype, to_dtype, rng_factory):
     rng = rng_factory()
-    tol = max(gradient_tolerance(to_dtype), gradient_tolerance(from_dtype))
+    tol = max(jtu.tolerance(to_dtype, jtu.default_gradient_tolerance),
+              jtu.tolerance(from_dtype, jtu.default_gradient_tolerance))
     args = (rng((2, 3), from_dtype),)
     convert_element_type = lambda x: lax.convert_element_type(x, to_dtype)
     check_grads(convert_element_type, args, 2, ["fwd", "rev"], tol, tol, eps=1.)
@@ -1815,15 +1777,16 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           [(), (2, 3), ()],
           [(2, 3), (2, 3), (2, 3)],
       ]
-      for dtype in float_dtypes
+      # TODO(phawkins): this test fails for bfloat16.
+      for dtype in [t for t in float_dtypes if t != dtypes.bfloat16]
       for rng_factory in [jtu.rand_default]))
   def testClampGrad(self, min_shape, operand_shape, max_shape, dtype, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-2})
+    tol = {dtypes.bfloat16: 1e-1, onp.float16: 1e-1, onp.float32: 1e-2}
     shapes = [min_shape, operand_shape, max_shape]
     min, operand, max = (rng(shape, dtype) for shape in shapes)
     min, max = onp.minimum(min, max), onp.maximum(min, max)  # broadcast
-    eps = 1e-1 if dtype == onp.float16 else 1e-2
+    eps = 1e-1 if dtypes.finfo(dtype).bits == 16 else 1e-2
     check_grads(lax.clamp, (min, operand, max), 2, ["fwd", "rev"], tol, tol,
                 eps=eps)
 
@@ -1840,12 +1803,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testConcatenateGrad(self, dim, base_shape, dtype, num_arrs, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
     operands = tuple(rng(shape, dtype) for shape in shapes)
     concatenate = lambda *args: lax.concatenate(args, dim)
-    check_grads(concatenate, operands, 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(concatenate, operands, 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -1944,7 +1906,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                                  padding, lhs_dil, rhs_dil, dimension_numbers,
                                  perms, feature_group_count, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype, {onp.float16: 5e-1, onp.float32: 1e-4})
+    tol = {dtypes.bfloat16: 3e-1, onp.float16: 5e-1, onp.float32: 1e-4}
 
     # permute shapes to match dim_spec, scale by feature_group_count
     lhs_perm, rhs_perm = perms
@@ -1974,7 +1936,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for dtype in float_dtypes))
   def testDotGrad(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-4})
+    tol = {onp.float16: 1e-1, onp.float32: 1e-4}
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
     dot = partial(lax.dot, precision=lax.Precision.HIGHEST)
@@ -2004,13 +1966,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   def testDotGeneralContractAndBatchGrads(self, lhs_shape, rhs_shape, dtype,
                                           dimension_numbers, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)
     dot_general = partial(lax.dot_general, dimension_numbers=dimension_numbers,
                           precision=lax.Precision.HIGHEST)
-    check_grads_bilinear(dot_general, (lhs, rhs), order=2, modes=["fwd", "rev"],
-                         atol=tol, rtol=tol)
+    check_grads_bilinear(dot_general, (lhs, rhs), order=2, modes=["fwd", "rev"])
     # check that precision config is preserved
     result, pullback = api.vjp(dot_general, lhs, rhs)
     gresult = lax.zeros_like_array(result)
@@ -2028,10 +1988,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testBroadcastGrad(self, shape, dtype, broadcast_sizes, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     args = (rng(shape, dtype),)
     broadcast = lambda x: lax.broadcast(x, broadcast_sizes)
-    check_grads(broadcast, args, 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(broadcast, args, 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
@@ -2049,11 +2008,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testBroadcastInDimGrad(self, inshape, dtype, outshape, dimensions, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(inshape, dtype)
     broadcast_in_dim = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
-    check_grads(broadcast_in_dim, (operand,), 2, ["fwd", "rev"], tol, tol,
-                eps=1.)
+    check_grads(broadcast_in_dim, (operand,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_outshape={}_perm={}".format(
@@ -2077,10 +2034,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testReshapeGrad(self, arg_shape, out_shape, permutation, dtype, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(arg_shape, dtype)
     reshape = lambda x: lax.reshape(x, out_shape, permutation)
-    check_grads(reshape, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(reshape, (operand,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_pads={}"
@@ -2091,17 +2047,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for pads in [[(1, 2, 1), (0, 1, 0)], [(-1, 0, 0), (-1, 0, 2)]]))
   def testPadGrad(self, shape, dtype, pads, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
-
     operand = rng(shape, dtype)
     pad = lambda operand: lax.pad(operand, onp.array(0, dtype), pads)
-    check_grads(pad, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(pad, (operand,), 2, ["fwd", "rev"], eps=1.)
 
     operand = rng(shape, dtype)
     padding_value = onp.array(0., dtype)
     pad = lambda operand, padding_value: lax.pad(operand, padding_value, pads)
-    check_grads(pad, (operand, padding_value), 2, ["fwd", "rev"], tol, tol,
-                eps=1.)
+    check_grads(pad, (operand, padding_value), 2, ["fwd", "rev"], eps=1.)
 
   def testReverseGrad(self):
     rev = lambda operand: lax.rev(operand, dimensions)
@@ -2125,13 +2078,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testSelectGrad(self, pred_shape, arg_shape, dtype, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     pred = rng(pred_shape, onp.bool_)
     on_true = rng(arg_shape, dtype)
     on_false = rng(arg_shape, dtype)
     select = lambda on_true, on_false: lax.select(pred, on_true, on_false)
-    check_grads(select, (on_true, on_false), 2, ["fwd", "rev"], tol, tol,
-                eps=1.)
+    check_grads(select, (on_true, on_false), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -2155,10 +2106,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testSliceGrad(self, shape, dtype, starts, limits, strides, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     slice = lambda x: lax.slice(x, starts, limits, strides)
-    check_grads(slice, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(slice, (operand,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_start_indices={}_size_indices={}".format(
@@ -2176,10 +2126,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   def testDynamicSliceGrad(self, shape, dtype, start_indices, size_indices,
                            rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     dynamic_slice = lambda x: lax.dynamic_slice(x, start_indices, size_indices)
-    check_grads(dynamic_slice, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(dynamic_slice, (operand,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_start_indices={}_update_shape={}".format(
@@ -2197,19 +2146,18 @@ class LaxAutodiffTest(jtu.JaxTestCase):
   def testDynamicUpdateSliceGrad(self, shape, dtype, start_indices,
                                  update_shape, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     update = rng(update_shape, dtype)
     start_indices = onp.array(start_indices)
 
     dus = lambda x, y: lax.dynamic_update_slice(x, y, start_indices)
-    check_grads(dus, (operand, update), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(dus, (operand, update), 2, ["fwd", "rev"], eps=1.)
 
     dus = lambda x: lax.dynamic_update_slice(x, update, start_indices)
-    check_grads(dus, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(dus, (operand,), 2, ["fwd", "rev"], eps=1.)
 
     dus = lambda y: lax.dynamic_update_slice(operand, y, start_indices)
-    check_grads(dus, (update,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(dus, (update,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_perm={}".format(
@@ -2225,10 +2173,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testTransposeGrad(self, shape, dtype, perm, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype)
     operand = rng(shape, dtype)
     transpose = lambda x: lax.transpose(x, perm)
-    check_grads(transpose, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1.)
+    check_grads(transpose, (operand,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_inshape={}_reducedims={}"
@@ -2257,12 +2204,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     rng = rng_factory()
     if jtu.device_under_test() == "tpu" and op is lax.mul:
       raise SkipTest("unimplemented case")
-    tol = gradient_tolerance(
-      dtype, {onp.float16: 1e-1, onp.float32: 4e-2, onp.float64: 1e-3})
+    tol = {dtypes.bfloat16: 1e-1, onp.float16: 1e-1, onp.float32: 4e-2,
+           onp.float64: 1e-3, onp.complex64: 1e-2}
     operand = rng(shape, dtype)
     init_val = onp.asarray(init_val, dtype=dtype)
     reduce = lambda operand: lax.reduce(operand, init_val, op, dims)
     eps = (1.0 if dtypes.finfo(dtype).bits == 16 and op is lax.add else
+           1e-1 if dtype == dtypes.bfloat16 else
            1e-2 if dtypes.finfo(dtype).bits == 32 else None)
     check_grads(reduce, (operand,), 1, ["fwd", "rev"], tol, tol, eps)
 
@@ -2281,7 +2229,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testReduceWindowGrad(self, op, init_val, dtype, padding, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype, {onp.float16: 1e-1, onp.float32: 1e-3})
+    tol = {onp.float16: 1e-1, onp.float32: 1e-3}
     init_val = onp.asarray(init_val, dtype=dtype)
 
     # We need this conditional and the corresponding loop logic to be in the
@@ -2333,10 +2281,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   def testSortGrad(self, shape, dtype, axis, rng_factory):
     rng = rng_factory()
-    tol = gradient_tolerance(dtype, {onp.float32: 1e-3})
     operand = rng(shape, dtype)
     sort = lambda x: lax.sort(x, axis)
-    check_grads(sort, (operand,), 2, ["fwd", "rev"], tol, tol, eps=1e-2)
+    check_grads(sort, (operand,), 2, ["fwd", "rev"], eps=1e-2)
 
   # TODO(b/205052657): enable more tests when supported
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -2384,7 +2331,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     rng = rng_factory()
     src = rng(shape, dtype)
     index_take = lambda src: lax.index_take(src, idxs, axes)
-    check_grads(index_take, (src,), 2, ["fwd", "rev"], 1e-2, 1e-2, 1)
+    check_grads(index_take, (src,), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_idxs={}_dnums={}_slice_sizes={}".format(
@@ -2563,8 +2510,7 @@ class LaxVmapTest(jtu.JaxTestCase):
   def testOp(self, op_name, rng_factory, shapes, dtype, bdims):
     rng = rng_factory()
     op = getattr(lax, op_name)
-    tol = tolerance(dtype)
-    self._CheckBatching(op, 10, bdims, shapes, dtype, rng, tol, tol)
+    self._CheckBatching(op, 10, bdims, shapes, dtype, rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -2694,7 +2640,7 @@ class LaxVmapTest(jtu.JaxTestCase):
     rng = rng_factory()
     op = partial(lax.dot, precision=lax.Precision.HIGHEST)
     self._CheckBatching(op, 5, bdims, (lhs_shape, rhs_shape), dtype, rng,
-                        rtol=tolerance(dtype, {onp.float16: 5e-2}))
+                        rtol={onp.float16: 5e-2})
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2210,6 +2210,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     init_val = onp.asarray(init_val, dtype=dtype)
     reduce = lambda operand: lax.reduce(operand, init_val, op, dims)
     eps = (1.0 if dtypes.finfo(dtype).bits == 16 and op is lax.add else
+           5e-1 if dtype == dtypes.bfloat16 and op is lax.mul else
            1e-1 if dtype == dtypes.bfloat16 else
            1e-2 if dtypes.finfo(dtype).bits == 32 else None)
     check_grads(reduce, (operand,), 1, ["fwd", "rev"], tol, tol, eps)


### PR DESCRIPTION
bfloat16 support is still immature, but this PR adds some initial support.

Fixes #76, at least enough that we can declare it fixed and open specific issues for specific bfloat16 problems.

The main awkwardness that this change deals with is that classic NumPy doesn't understand bfloat16 promotion rules, so we must:
* implement our own type promotion operators that understand bfloat16 types
* wrap a number of the reference implementations in tests to temporarily cast to float32 for computation.