### PR TITLE
fix reference cycle in jaxpr tracing using weakrefs

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -80,13 +80,11 @@ def jaxpr_as_fun(typed_jaxpr, *args):
   return eval_jaxpr(typed_jaxpr.jaxpr, typed_jaxpr.literals, (), *args)
 
 
-def new_jaxpr_eqn(*args):
-  return JaxprEqn(object(), *args)
-
-JaxprEqn = namedtuple('JaxprEqn', ['eqn_id', 'invars', 'outvars', 'primitive',
+JaxprEqn = namedtuple('JaxprEqn', ['invars', 'outvars', 'primitive',
                                    'bound_subjaxprs', 'params'])
+JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn)).rstrip()
+new_jaxpr_eqn = JaxprEqn
 
-JaxprEqn.__repr__ = JaxprEqn.__str__ = lambda eqn: str(pp_eqn(eqn))[:-1]
 
 class Var(object):
   def __init__(self, count, suffix):

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -269,7 +269,7 @@ def _axis_index_partial_eval(trace, _, **params):
   # rule except that we don't attempt to lower out of the trace.
   out_aval = ShapedArray((), onp.int32)
   out_tracer = pe.JaxprTracer(trace, pe.PartialVal((out_aval, core.unit)), None)
-  eqn = core.new_jaxpr_eqn([], [out_tracer], axis_index_p, (), params)
+  eqn = pe.new_eqn_recipe([], [out_tracer], axis_index_p, (), params)
   out_tracer.recipe = eqn
   return out_tracer
 

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -704,11 +704,11 @@ def _scan_partial_eval(trace, *tracers, **kwargs):
   linear_2 = ([False] * len(int_res_tracers) +
               [lin or not uk for uk, lin in zip(unknowns, linear)] +
               [False] * len(ext_res_tracers))
-  eqn = pe.new_jaxpr_eqn(int_res_tracers + new_tracers + ext_res_tracers,
-                         out_tracers, scan_p, (),
-                         dict(forward=forward, length=length, jaxpr=jaxpr_2_opt,
-                              num_consts=num_consts_2,
-                              num_carry=num_carry, linear=linear_2))
+  eqn = pe.new_eqn_recipe(int_res_tracers + new_tracers + ext_res_tracers,
+                          out_tracers, scan_p, (),
+                          dict(forward=forward, length=length, jaxpr=jaxpr_2_opt,
+                               num_consts=num_consts_2,
+                               num_carry=num_carry, linear=linear_2))
   for t in out_tracers: t.recipe = eqn
   return out_tracers
 


### PR DESCRIPTION
As one step in tracing user code to a jaxpr using the machinery in partial_eval.py, we construct a bipartite graph made of JaxprTracer nodes, corresponding to values in the user code, and recipe nodes, particularly those corresponding to jaxpr equations, representing primitive operations. (This representation was put in place in #1224, since when primitives only had single outputs we could identify each primitive operation with the JaxprTracer value it produced.) This graph had reference cycles because each equation recipe points to both its input and output tracers (as a jaxpr eqn has both input and output vars) and a tracer must be able to point to the equation recipe that produced
it (for us to toposort the graph from in_tracers to out_tracers in tracers_to_jaxpr).

Those cycles caused memory leaks. This commit removes the strong reference cycle using weakrefs. In particular, equation recipes only hold weak references to their output tracers.

Before this change, we used the core.JaxprEqn struct both to represent equations in jaxprs (where invars and outvars are instances of the core.Var class) and to represent equation recipes (where invars and outvars are instances of the partial_eval.JaxprTracer class). That was a bit lazy. This commit distinguishes the two as separate JaxprEqn and JaxprEqnRecipe structs.

Bug find and test code from @trevorcai. Thanks!

Cross-ref the discussion on #1710.