### PR TITLE
Add precision to jax.numpy functions that use lax.dot_general

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2033,7 +2033,14 @@ def append(arr, values, axis=None):
 ### Tensor contraction operations
 
 
-@_wraps(onp.dot)
+_PRECISION_DOC = """\
+In addition to the original NumPy arguments listed below, also supports
+``precision`` for extra control over matrix-multiplication precision
+on supported devices. See :py:func:`jax.lax.dot` for details.
+"""
+
+
+@_wraps(onp.dot, lax_description=_PRECISION_DOC)
 def dot(a, b, precision=None):  # pylint: disable=missing-docstring
   _check_arraylike("dot", a, b)
   a, b = _promote_dtypes(a, b)
@@ -2051,7 +2058,7 @@ def dot(a, b, precision=None):  # pylint: disable=missing-docstring
   return lax.dot_general(a, b, (contract_dims, batch_dims), precision)
 
 
-@_wraps(onp.matmul)
+@_wraps(onp.matmul, lax_description=_PRECISION_DOC)
 def matmul(a, b, precision=None):  # pylint: disable=missing-docstring
   _check_arraylike("matmul", a, b)
   a_is_vec, b_is_vec = (ndim(a) == 1), (ndim(b) == 1)
@@ -2075,14 +2082,14 @@ def matmul(a, b, precision=None):  # pylint: disable=missing-docstring
     return result
 
 
-@_wraps(onp.vdot)
+@_wraps(onp.vdot, lax_description=_PRECISION_DOC)
 def vdot(a, b, precision=None):
   if issubdtype(_dtype(a), onp.complexfloating):
     a = conj(a)
   return dot(a.ravel(), b.ravel(), precision=precision)
 
 
-@_wraps(onp.tensordot)
+@_wraps(onp.tensordot, lax_description=_PRECISION_DOC)
 def tensordot(a, b, axes=2, precision=None):
   _check_arraylike("tensordot", a, b)
   if not (ndim(a) >= 1 and ndim(b) >= 1):
@@ -2119,7 +2126,7 @@ def tensordot(a, b, axes=2, precision=None):
   raise TypeError(msg)
 
 
-@_wraps(onp.einsum)
+@_wraps(onp.einsum, lax_description=_PRECISION_DOC)
 def einsum(*operands, **kwargs):
   optimize = kwargs.pop('optimize', 'auto')
   optimize = 'greedy' if optimize is True else optimize
@@ -2311,7 +2318,7 @@ def _movechars(s, src, dst):
   return ''.join(chars)
 
 
-@_wraps(onp.inner)
+@_wraps(onp.inner, lax_description=_PRECISION_DOC)
 def inner(a, b, precision=None):
   if ndim(a) == 0 or ndim(b) == 0:
     return a * b

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2325,39 +2325,41 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       raise SkipTest("requires python 3 (for unittest.mock)")
 
     @contextlib.contextmanager
-    def assert_highest_precision():
+    def assert_precision(expected_precision):
       with unittest.mock.patch.object(
           lax.dot_general_p, 'bind', wraps=lax.dot_general_p.bind) as wrapper:
         yield
         (_, kwargs), = wrapper.call_args_list
-        precision = kwargs['precision']
-        self.assertEqual(precision, lax.Precision.HIGHEST)
+        actual_precision = kwargs['precision']
+        self.assertEqual(actual_precision, expected_precision)
 
     ones_1d = onp.ones((2,))
     ones_2d = onp.ones((2, 2))
     ones_3d = onp.ones((2, 2, 2))
 
-    with assert_highest_precision():
+    with assert_precision(None):
+      lnp.dot(ones_1d, ones_1d)
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.dot(ones_1d, ones_1d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.dot(ones_3d, ones_3d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.matmul(ones_2d, ones_2d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.vdot(ones_1d, ones_1d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.tensordot(ones_2d, ones_2d, axes=2, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.tensordot(
           ones_1d, ones_1d, axes=(0, 0), precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.tensordot(
           ones_1d, ones_1d, axes=((0,), (0,)), precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.einsum('i,i', ones_1d, ones_1d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.einsum('ij,ij', ones_2d, ones_2d, precision=lax.Precision.HIGHEST)
-    with assert_highest_precision():
+    with assert_precision(lax.Precision.HIGHEST):
       lnp.inner(ones_1d, ones_1d, precision=lax.Precision.HIGHEST)
 
 # Most grad tests are at the lax level (see lax_test.py), but we add some here


### PR DESCRIPTION
I suppose this needs tests, too.