### PR TITLE
Fix bug in jax repeat which caused a value error for repeat arguments…

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1958,7 +1958,8 @@ def repeat(a, repeats, axis=None):
   for i, repeat in enumerate(repeats_tiled):
     if not isinstance(repeat, int):
       repeat = repeat.item()
-    ret = concatenate((ret, tile(a_splitted[i], repeat)))
+    if repeat != 0:
+      ret = concatenate((ret, tile(a_splitted[i], repeat)))
 
   return reshape(ret, new_shape)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -925,7 +925,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     m = lnp.array([1,2,3,4,5,6])
     args_maker = lambda: [m]
 
-    for repeats in [2, [1,3,2,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
+    for repeats in [2, [1,3,2,1,1,2], [1,3,0,1,1,2], [2], lnp.array([1,3,2,1,1,2]), lnp.array([2])]:
       test_single(m, args_maker, repeats, None)
 
     m_rect = m.reshape((2,3))


### PR DESCRIPTION
… containing 0.

Fixing https://github.com/google/jax/issues/1233