### PR TITLE
Remove `as_abstract_val`.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -316,12 +316,6 @@ def join_pvals(pval1, pval2):
   else:
     raise TypeError((pval1, pval2))
 
-def as_abstract_val(pv):
-  if isinstance(pv, AbstractValue):
-    return pv
-  else:
-    raise TypeError("{} is not abstract".format(pv))
-
 def partial_val_aval(pv, const):
   if isinstance(pv, AbstractValue):
     return pv

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -319,9 +319,7 @@ def join_pvals(pval1, pval2):
 def as_abstract_val(pv):
   if isinstance(pv, AbstractValue):
     return pv
-  elif isinstance(pv, JaxprTracerTuple):
-    return AbstractTuple(map(as_abstract_val, pv))
-  elif pv is None:
+  else:
     raise TypeError("{} is not abstract".format(pv))
 
 def partial_val_aval(pv, const):


### PR DESCRIPTION
The `JaxprTracerTuple` appears to no longer exist and the function could previously return `None` if `pv` was another type other than `AbstractValue`, instead of raising an error.