### PR TITLE
Add experimental rematerialization decorator

### DIFF
--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -104,7 +104,6 @@ Operators
     scatter
     scatter_add
     select
-    shaped_identity
     shift_left
     shift_right_arithmetic
     shift_right_logical

--- a/jax/core.py
+++ b/jax/core.py
@@ -597,7 +597,8 @@ def call_bind(primitive, f, *args, **params):
 
 
 def call_impl(f, *args, **params):
-  return f.call_wrapped(*args, **params)
+  del params  # params parameterize the call primitive, not the function
+  return f.call_wrapped(*args)
 
 
 call_p = Primitive('call')

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -140,6 +140,9 @@ def unpair_pval(pval):
     return (aval_1, const_1), (aval_2, const_2)
 
 def backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in):
+  if all(ct is zero for ct in cotangents_in):
+    return [zero] * len(jaxpr.freevars), [zero] * len(jaxpr.invars)
+
   def write_cotangent(v, ct):
     # assert v not in primal_env
     if ct is not None:
@@ -159,13 +162,46 @@ def backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in):
       primal_env[v] = val
 
   primal_env = {}
+  write_primal(core.unitvar, core.unit)
   map(write_primal, jaxpr.constvars, consts)
   map(write_primal, jaxpr.freevars, freevar_vals)
   map(write_primal, jaxpr.invars, args)
 
+  def is_linear(var):
+    if type(var) is Literal:
+      return False
+    else:
+      return primal_env.get(var, undefined_primal) is undefined_primal
+
+  linear_eqns = []
+  for eqn in jaxpr.eqns:
+    if not eqn.bound_subjaxprs:
+      if any(is_linear(v) for v in eqn.invars):
+        linear_eqns.append(eqn)
+      else:
+        in_vals = map(read_primal, eqn.invars)
+        ans = eqn.primitive.bind(*in_vals, **eqn.params)
+        if eqn.primitive.multiple_results:
+          map(write_primal, eqn.outvars, ans)
+        else:
+          write_primal(eqn.outvars[0], ans)
+    else:
+      (subjaxpr, const_vars, bound_vars), = eqn.bound_subjaxprs
+      if any(is_linear(v) for v in it.chain(eqn.invars, const_vars, bound_vars)):
+        linear_eqns.append(eqn)
+      sub_consts = map(read_primal, const_vars)
+      sub_freevar_vals = map(read_primal, bound_vars)
+      in_vals = map(read_primal, eqn.invars)
+      all_args, in_tree_def = tree_flatten((sub_consts, sub_freevar_vals, in_vals))
+      fun = hashable_partial(wrap_init(_eval_primals), subjaxpr)
+      fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+      out_flat = eqn.primitive.bind(fun, *all_args, **eqn.params)
+      ans = tree_unflatten(out_tree(), out_flat)
+      map(write_primal, eqn.outvars, ans)
+
   ct_env = {}
   map(write_cotangent, jaxpr.outvars, cotangents_in)
-  for eqn in jaxpr.eqns[::-1]:
+  for eqn in linear_eqns[::-1]:
     invals = map(read_primal, eqn.invars)
     if eqn.primitive.multiple_results:
       cts_in = map(read_cotangent, eqn.outvars)
@@ -186,6 +222,51 @@ def backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in):
   freevar_cts = map(read_cotangent, jaxpr.freevars)
   cotangents_out = map(read_cotangent, jaxpr.invars)
   return freevar_cts, cotangents_out
+
+def _eval_primals(jaxpr, consts, freevar_vals, args):
+  primal_env = {}
+
+  def read_primal(v):
+    if type(v) is Literal:
+      return v.val
+    else:
+      return primal_env.get(v, undefined_primal)
+
+  def write_primal(v, val):
+    if val is not undefined_primal:
+      primal_env[v] = val
+
+  def is_linear(var):
+    if type(var) is Literal:
+      return False
+    else:
+      return primal_env.get(var, undefined_primal) is undefined_primal
+
+  write_primal(core.unitvar, core.unit)
+  map(write_primal, jaxpr.constvars, consts)
+  map(write_primal, jaxpr.freevars, freevar_vals)
+  map(write_primal, jaxpr.invars, args)
+  for eqn in jaxpr.eqns:
+    if not eqn.bound_subjaxprs:
+      if not any(is_linear(v) for v in eqn.invars):
+        in_vals = map(read_primal, eqn.invars)
+        ans = eqn.primitive.bind(*in_vals, **eqn.params)
+        if eqn.primitive.multiple_results:
+          map(write_primal, eqn.outvars, ans)
+        else:
+          write_primal(eqn.outvars[0], ans)
+    else:
+      (subjaxpr, const_vars, bound_vars), = eqn.bound_subjaxprs
+      sub_consts = map(read_primal, const_vars)
+      sub_freevar_vals = map(read_primal, bound_vars)
+      in_vals = map(read_primal, eqn.invars)
+      all_args, in_tree_def = tree_flatten((sub_consts, sub_freevar_vals, in_vals))
+      fun = hashable_partial(wrap_init(_eval_primals), subjaxpr)
+      fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+      out_flat = eqn.primitive.bind(fun, *all_args, **eqn.params)
+      ans = tree_unflatten(out_tree(), out_flat)
+      map(write_primal, eqn.outvars, ans)
+  return map(read_primal, jaxpr.outvars)
 
 class UndefinedPrimal(object):
   def __repr__(self): return  '_'
@@ -460,6 +541,7 @@ def call_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   out_flat = primitive.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
+primitive_transposes[pe.remat_call_p] = partial(call_transpose, pe.remat_call_p)
 
 def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1487,6 +1487,10 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
   least_specialized = _max(
       map(type, args), key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is ConcreteArray:
+    msg = ("If you see this error, please let us know by opening an issue at\n"
+           "https://github.com/google/jax/issues \n"
+           "since we thought this was unreachable!")
+    assert pe._thread_local_state.remat, msg
     return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs))
   elif least_specialized is ShapedArray:
     return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs))

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -675,7 +675,7 @@ def _scan_partial_eval(trace, *tracers, **kwargs):
   _, _, res_pvals = split_list(out_pvals_1, [num_carry, num_ys])
   intensive_residuals = [const for pv, const in res_pvals if pv is None]
   move = [False] * len(jaxpr_1.in_avals) + [pv is None for pv, _ in res_pvals]
-  jaxpr_2_opt = _move_binders_to_front(jaxpr_2, move)
+  jaxpr_2_opt = pe.move_binders_to_front(jaxpr_2, move)
   num_consts_2 = num_consts + len(intensive_residuals)
 
   in_consts = (list(consts_1) + [core.unit] * num_consts +
@@ -711,21 +711,6 @@ def _scan_partial_eval(trace, *tracers, **kwargs):
                                num_carry=num_carry, linear=linear_2))
   for t in out_tracers: t.recipe = eqn
   return out_tracers
-
-def _move_binders_to_front(typed_jaxpr, to_move):
-  assert not typed_jaxpr.jaxpr.constvars and not typed_jaxpr.jaxpr.freevars
-  assert len(typed_jaxpr.in_avals) == len(to_move)
-  new_invars = _move_to_front(typed_jaxpr.jaxpr.invars, to_move)
-  new_jaxpr = core.Jaxpr((), (), new_invars, typed_jaxpr.jaxpr.outvars,
-                         typed_jaxpr.jaxpr.eqns)
-  new_in_avals = _move_to_front(typed_jaxpr.in_avals, to_move)
-  new_typed_jaxpr = core.TypedJaxpr(new_jaxpr, typed_jaxpr.literals,
-                                    new_in_avals, typed_jaxpr.out_avals)
-  return new_typed_jaxpr
-
-def _move_to_front(lst, to_move):
-  return ([elt for elt, move in zip(lst, to_move) if move] +
-          [elt for elt, move in zip(lst, to_move) if not move])
 
 def _promote_aval_rank(sz, aval):
   if aval is core.abstract_unit:

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1084,7 +1084,7 @@ def custom_root(f, initial_guess, solve, tangent_solve):
 
 
 def _root_abstract_eval(*args, **kwargs):
-  return args[sum(kwargs['const_lengths']):]
+  return _map(raise_to_shaped, args[sum(kwargs['const_lengths']):])
 
 
 def _root_impl(*args, **kwargs):
@@ -1253,7 +1253,7 @@ def custom_linear_solve(
 
 
 def _linear_solve_abstract_eval(*args, **kwargs):
-  return args[sum(kwargs['const_lengths']):]
+  return _map(raise_to_shaped, args[sum(kwargs['const_lengths']):])
 
 
 def _custom_linear_solve_impl(*args, **kwargs):

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -148,8 +148,8 @@ class WrappedFun(object):
       gen = gen(*(gen_args + tuple(args)), **kwargs)
       args, kwargs = next(gen)
       stack.append((gen, out_store))
+    gen = None
 
-    del gen
     ans = self.f(*args, **dict(self.params, **kwargs))
     del args
     while stack:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1470,8 +1470,7 @@ class APITest(jtu.JaxTestCase):
 
     jaxpr = api.make_jaxpr(api.linearize(f_yesremat, 4.)[1])(1.)
     scan_eqn, = jaxpr.eqns
-    import ipdb; ipdb.set_trace()
-    self.assertIn(' sin ', str(scan_eqn.params['jaxpr']))
+    self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
     jaxpr = api.make_jaxpr(api.vjp(f_yesremat, 4.)[1])(1.)
     scan_eqn, = jaxpr.eqns


### PR DESCRIPTION
## The problem

We want to allow users to control how reverse-mode autodiff saves values from the forward pass. In particular, we want it to be easy to signal that a function shouldn't have any of its intermediate residuals stored for the backward pass, and instead those values should be recomputed from the function's saved inputs. This allows users greater control over the time/memory tradeoffs of their computations. (This feature is especially handy for accelerators on which memory access is much more expensive than FLOPs are.)

In JAX terms, since we implement reverse-mode as a composition of forward-mode, partial evaluation, and transposition, we want users to control how partial evaluation behaves.

This PR adds a `checkpoint` decorator (alias: `remat`) for this purpose.

Fixes #1732.

## API examples

### Example 1: grad-of-jit

Consider this grad-of-jit situation:

```python
import jax.numpy as np
from jax import jit, grad, remat

@remat
def g(x):
  return np.sin(np.sin(x))

@jit
def f(x):
  return g(x)

grad(f)(2.0)
```

If we run this _without_ the remat decorator, here are the jaxprs we end up lowering to XLA, one for the forward pass and one for the backward pass (by adding a `print(jaxpr)` to `xla._xla_callable`):

```
{ lambda  ;  ; a b.
  let c = sin a
      d = sin c
      e = cos a
      f = cos c
  in [d, *, e, f] }

{ lambda  ;  ; a b c.
  let d = mul c b
      e = mul d a
  in [e] }
```

Here's what we see _with_ the `remat` decorator:

```
{ lambda  ;  ; a b.
  let c = sin a
      d = sin c
  in [d, *, a] }

{ lambda  ;  ; a b.
  let c = remat_call a b
        { lambda  ;  ; a b.
          let c = sin a
              d = cos c
              e = mul b d
              f = cos a
              g = mul e f
          in [g] } [  ;  ]
  in [c] }
```

Notice how there are no residuals passed into the backward pass as constants, and we're computing `sin(2.0)` both in the forward pass and in the backward pass.


### Example 2: jit-of-grad

Here's a jit-of-grad situation:

```python
import jax.numpy as np
from jax import jit, value_and_grad, remat

@remat
def g(x):
  return np.sin(np.sin(x))

jit(grad(g))(2.0)
```

```
{ lambda  ;  ; a.
  let b = sin a
      c = sin b
      d = remat_call a 1.0
        { lambda  ;  ; a b.
          let c = sin a
              d = cos c
              e = mul b d
              f = cos a
              g = mul e f
          in [g] } [  ;  ]
  in [c, d] }
```

Again we're computing `sin(2.0)` twice. Not shown is the fact that the translation rule for lowering `remat_call` to XLA HLO includes some HLO widgets that will foil XLA's CSE optimization across `remat_call` boundaries, even though it's all being lowered to one computation here.

### Example 3: differentiating Python control flow under `remat`

```python
import jax.numpy as np
from jax import jit, grad, linearize, remat, make_jaxpr

@partial(remat, concrete=True)
def g(x):
  if x > 0.:
    return np.sin(np.sin(x))
  else:
    return np.cos(np.cos(x))

def f(x):
  x = 3. * x
  x = g(x)
  x = 4. * x
  return x

print(grad(f)(2.))
jaxpr = make_jaxpr(linearize(f, 2.)[1])(1.)
print(jaxpr)
```

```
11.075182

{ lambda  ;  ; a.
  let b = mul a 3.0
      c d = remat_call 6.0 b
        { lambda  ;  ; a b.
          let c = sin a
              d = sin c
              e = cos a
              f = mul b e
              g = cos c
              h = mul f g
          in [d, h] } [  ;  ]
      e = mul d 4.0
  in [e] }
```

Functions with `remat` can still support differentiating through Python control flow! At least, when you pass `concrete=True`. There's a tradeoff here: to handle Python control flow, in some cases involving `jit` we might end up doing redundant FLOPs, as in the [Three Sines Problem described below](https://github.com/google/jax/pull/1749#issuecomment-558267584), so we wanted to make this feature opt-in.

Notice that in this last jaxpr, the `remat_call` is applied to an argument that is a literal `6.0`. We've prevented that from being partially evaluated through the called jaxpr on the JAX side, and moreover the lowering of `remat_call` will prevent XLA from doing that constant folding as well.

### Example 4: scanning a `remat` function

```python
import jax.numpy as np
from jax import lax
from jax import vjp, remat, make_jaxpr

def f(c, x):
  return np.sin(c), None

def foo(x):
  y, _ = lax.scan(remat(f), x, np.arange(3.))
  return y

_, foo_vjp = vjp(foo, 4.)
foo_vjp(1.)  # added a `print(jaxpr)` in ad.backward_pass
```

```
{ lambda c d ;  ; a b.
  let e f = scan[ forward=True
                  length=3
                  jaxpr={ lambda  ;  ; a b c d e.
                          let f g = remat_call d e b
                                { lambda  ;  ; a b c.
                                  let d = sin a
                                      e = cos a
                                      f = mul c e
                                  in [d, f] } [  ;  ]
                          in [*, g] }
                  num_consts=0
                  num_carry=2
                  linear=[True, True, True, False, False] ] * b * c d
  in [*, f] }
```

Notice the `sin` and `cos` computation in the  scanned function! Compare to not using the `remat` decorator:

```
{ lambda c ;  ; a b.
  let d e = scan[ forward=True
                  length=3
                  jaxpr={ lambda  ;  ; a b c d.
                          let e = mul b d
                          in [*, e] }
                  num_consts=0
                  num_carry=2
                  linear=[True, True, True, False] ] * b * c
  in [*, e] }
```

### Example 5: recursive checkpointing

```python
def recursive_checkpoint(funs):
  if len(funs) == 1:
    return funs[0]
  elif len(funs) == 2:
    f1, f2 = funs
    return lambda x: f1(f2(x))
  else:
    f1 = recursive_checkpoint(funs[:len(funs)//2])
    f2 = recursive_checkpoint(funs[len(funs)//2:])
    return lambda x: f1(remat(f2)(x))

# forward pass
f = recursive_checkpoint([np.cos, np.sin, np.cos, np.sin])
print(make_jaxpr(f)(4.))

# forward and backward pass
f = recursive_checkpoint([np.sin, np.sin, np.sin, np.sin])
print(make_jaxpr(value_and_grad(f))(4.))

# longer forward pass
f = recursive_checkpoint([np.cos, np.sin, np.cos, np.sin,
                          np.cos, np.sin, np.cos, np.sin])
print(make_jaxpr(f)(4.))
```

```
# forward pass
{ lambda  ;  ; a.
  let b = remat_call[ concrete=False ] a
        { lambda  ;  ; a.
          let b = sin a
              c = cos b
          in [c] } [  ;  ]
      c = sin b
      d = cos c
  in [d] }

# forward and backward pass
{ lambda  ;  ; a.
  let b = sin a
      c = sin b
      d = sin c
      e = sin d
      f = cos d
      g = mul 1.0 f
      h = cos c
      i = mul g h
      j = remat_call[ concrete=False ] a i
        { lambda  ;  ; a b.
          let c = sin a
              d = cos c
              e = mul b d
              f = cos a
              g = mul e f
          in [g] } [  ;  ]
  in [e, j] }

# longer forward pass
{ lambda  ;  ; a.
  let b = remat_call[ concrete=False ] a
        { lambda  ;  ; a.
          let b = remat_call[ concrete=False ] a
                { lambda  ;  ; a.
                  let b = sin a
                      c = cos b
                  in [c] } [  ;  ]
              c = sin b
              d = cos c
          in [d] } [  ;  ]
      c = remat_call[ concrete=False ] b
        { lambda  ;  ; a.
          let b = sin a
              c = cos b
          in [c] } [  ;  ]
      d = sin c
      e = cos d
  in [e] }
```

## Implementation

The basic design here is to create a new call primitive, like `core.call_p` (which doesn't _necessarily_ raise the abstraction level of its inputs), that has a special partial evaluation rule: stage out the full computation, not just the parts that couldn't be partially evaluated. We call the new primitive `remat_call_p`.

The implementation of the partial evaluation rule has three main steps:

  1. trace the full jaxpr of the called function, treating all inputs as "unknown" (but potentially using concrete avals for the arguments which are actually "known", if `concrete=True`),
  1. process the full jaxpr to determine which outputs are meant to be "known"/"unknown", and to prune any extra computation,
  1. compute any "known" values we need (as an optimization, extract values from any concrete avals instead of re-evaluating them).

Otherwise, it looks a lot like the standard call partial evaluation rule, which is `JaxprTrace.process_call`.

To make `remat_call_p` transposable, we need to upgrade our `ad.backward_pass` code to do some nonlinear evaluation (to rematerialize the residuals needed).

To translate `remat_call_p` to XLA in a way that prevents XLA's CSE optimization from foiling our rematerialization plans, we use a special widget that (according to friendly XLA team members) will in effect force a false data dependence to avoid CSE.

This change also adjusts our abstract evaluation rules for concrete values not to promote to the shaped level. (It was a long time ago, but I think we had that policy only because we didn't have a use case for performing FLOPs while creating jaxprs.) To ensure that this change doesn't accidentally lead to more FLOPs in user code, I tried running the test suite with an `assert False` in the new concrete-evaluation path and checked that it was never hit except in the new `remat` tests.

The upgrade to ad.backward_pass was co-authored with @dougalm, and is essentially part of #1719.
