### PR TITLE
Revert support for building a non-GPU build with --config=cuda enabled.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -280,13 +280,6 @@ def main():
       parser,
       "enable_cuda",
       help_str="Should we build with CUDA enabled? Requires CUDA and CuDNN.")
-  add_boolean_argument(
-      parser,
-      "include_gpu_backend_if_cuda_enabled",
-      default=True,
-      help_str="If CUDA is enabled, should we build the GPU backend? This is "
-               "mostly useful to build a CPU-only build with a CUDA-enabled "
-               "toolchain.")
   parser.add_argument(
       "--cuda_path",
       default=None,
@@ -341,12 +334,12 @@ def main():
     config_args += ["--config=mkl_open_source_only"]
   if args.enable_cuda:
     config_args += ["--config=cuda"]
-    if args.include_gpu_backend_if_cuda_enabled:
-      config_args += ["--define=xla_python_enable_gpu=true"]
-  shell(
-    [bazel_path] + args.bazel_startup_options +
+    config_args += ["--define=xla_python_enable_gpu=true"]
+  command = ([bazel_path] + args.bazel_startup_options +
     ["run", "--verbose_failures=true"] + config_args +
     [":install_xla_in_source_tree", os.getcwd()])
+  print(" ".join(command))
+  shell(command)
   shell([bazel_path, "shutdown"])
 
 

--- a/build/build_wheel_docker_entrypoint.sh
+++ b/build/build_wheel_docker_entrypoint.sh
@@ -49,8 +49,7 @@ case $2 in
     PLAT_NAME="linux_x86_64"
     ;;
   nocuda)
-    python build.py --enable_cuda --include_gpu_backend_if_cuda_enabled=false \
-      --bazel_startup_options="--output_user_root=/build/root"
+    python build.py --bazel_startup_options="--output_user_root=/build/root"
     PLAT_NAME="manylinux2010_x86_64"
     ;;
   *)


### PR DESCRIPTION
It turns out there are implicit CUDA dependencies inside the TF libraries used by JAX, so the attempt to disable GPU dependencies conditionally didn't work.