### PR TITLE
Remove 'backend' argument from device_put.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1333,8 +1333,8 @@ def make_jaxpr(fun):
   return jaxpr_maker
 
 
-def device_put(x, device=None, backend=None):
-  return tree_map(lambda y: xla.device_put_p.bind(y, device=device, backend=backend), x)
+def device_put(x, device=None):
+  return tree_map(lambda y: xla.device_put_p.bind(y, device=device), x)
 
 
 # TODO(mattjj): consider revising

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -145,6 +145,12 @@ def get_backend(platform=None):
     return backend(platform)
 
 
+def get_device_backend(device=None):
+  """Returns the Backend associated with `device`, or the default Backend."""
+  platform = device.platform if device else None
+  return get_backend(platform)
+
+
 def device_count(backend=None):
   """Returns the total number of devices.
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -306,6 +306,23 @@ class APITest(jtu.JaxTestCase):
     api.device_put(x)
     api.device_put(y)
 
+  @jtu.skip_on_devices("cpu")
+  def test_device_put_across_platforms(self):
+    default_device = jax.devices()[0]
+    cpu_device = jax.devices("cpu")[0]
+
+    onp_arr = onp.array([1,2,3])
+    scalar = 1
+    device_arr = np.array([1,2,3])
+    assert device_arr.device_buffer.device() is default_device
+
+    for val in [onp_arr, device_arr, scalar]:
+      x = api.device_put(val, device=cpu_device)
+      self.assertEqual(x.device_buffer.device(), cpu_device)
+
+    y = api.device_put(x)
+    self.assertEqual(y.device_buffer.device(), default_device)
+
   @jtu.skip_on_devices("tpu")
   def test_jacobian(self):
     R = onp.random.RandomState(0).randn


### PR DESCRIPTION
The appropriate Backend is instead inferred from the 'device' argument. This is a first step towards removing the 'backend' argument from more functions.