### PR TITLE
Update minimum jaxlib to 0.1.36.

### DIFF
--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -17,7 +17,7 @@
 
 import jaxlib
 
-_minimum_jaxlib_version = (0, 1, 31)
+_minimum_jaxlib_version = (0, 1, 36)
 try:
   from jaxlib import version as jaxlib_version
 except:


### PR DESCRIPTION
This is needed in part to pull in new Device.platform from Tensorflow.
See #1764.