### PR TITLE
Changed api.make_jaxpr to return a TypedJaxpr

### DIFF
--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
@@ -177,7 +177,8 @@
     }
    ],
    "source": [
-    "def examine_jaxpr(jaxpr):\n",
+    "def examine_jaxpr(typed_jaxpr):\n",
+    "  jaxpr = typed_jaxpr.jaxpr\n",
     "  print(\"invars:\", jaxpr.invars)\n",
     "  print(\"outvars:\", jaxpr.outvars)\n",
     "  print(\"constvars:\", jaxpr.constvars)\n",

--- a/jax/api.py
+++ b/jax/api.py
@@ -1279,7 +1279,7 @@ def make_jaxpr(fun):
 
   Returns:
     A wrapped version of `fun` that when applied to example arguments returns a
-    jaxpr representation of `fun` on those arguments.
+    TypedJaxpr representation of `fun` on those arguments.
 
   A `jaxpr` is JAX's intermediate representation for program traces. The `jaxpr`
   language is based on the simply-typed first-order lambda calculus with
@@ -1299,20 +1299,16 @@ def make_jaxpr(fun):
   { lambda  ;  ; a.
     let b = cos a
         c = sin b
-    in c }
+    in [c] }
   >>> jax.make_jaxpr(jax.grad(f))(3.0)
-  { lambda b ;  ; a.
-    let c = pack a
-        (d) = id c
-        e = cos d
-        f = cos e
-        g = mul b f
-        h = neg g
-        i = sin d
-        j = mul h i
-        k = pack j
-        (l) = id k
-    in l }
+  { lambda  ;  ; a.
+    let b = cos a
+        c = cos b
+        d = mul 1.0 c
+        e = neg d
+        f = sin a
+        g = mul e f
+    in [g] }
   """
   _check_callable(fun)
 
@@ -1325,9 +1321,12 @@ def make_jaxpr(fun):
     wrapped = lu.wrap_init(fun)
     jax_args, in_tree = tree_flatten((args, kwargs))
     jaxtree_fun, out_tree = flatten_fun(wrapped, in_tree)
-    pvals = map(pv_like, jax_args)
-    jaxpr, _, _ = pe.trace_to_jaxpr(jaxtree_fun, pvals)
-    return jaxpr
+    in_pvals = map(pv_like, jax_args)
+    jaxpr, out_pvals, consts = pe.trace_to_jaxpr(jaxtree_fun, in_pvals, instantiate=True)
+    out_avals = map(raise_to_shaped, unzip2(out_pvals)[0])
+    in_avals = tuple(raise_to_shaped(in_aval) for in_aval, _ in in_pvals)
+    typed_jaxpr = core.TypedJaxpr(jaxpr, consts, in_avals, out_avals)
+    return typed_jaxpr
 
   jaxpr_maker.__name__ = "make_jaxpr({})".format(jaxpr_maker.__name__)
   return jaxpr_maker

--- a/jax/api.py
+++ b/jax/api.py
@@ -1322,7 +1322,8 @@ def make_jaxpr(fun):
     jax_args, in_tree = tree_flatten((args, kwargs))
     jaxtree_fun, out_tree = flatten_fun(wrapped, in_tree)
     in_pvals = map(pv_like, jax_args)
-    jaxpr, out_pvals, consts = pe.trace_to_jaxpr(jaxtree_fun, in_pvals, instantiate=True)
+    jaxpr, out_pvals, consts = pe.trace_to_jaxpr(jaxtree_fun, in_pvals,
+                                                 instantiate=True)
     out_avals = map(raise_to_shaped, unzip2(out_pvals)[0])
     in_avals = tuple(raise_to_shaped(in_aval) for in_aval, _ in in_pvals)
     typed_jaxpr = core.TypedJaxpr(jaxpr, consts, in_avals, out_avals)

--- a/jax/core.py
+++ b/jax/core.py
@@ -652,7 +652,7 @@ def pp_eqn(eqn):
           >> pp(' [ {} ; {} ]'.format(pp_vars(const_vars),
                                       pp_vars(bound_vars))))
   return (pp('{} = '.format(lhs)) >>
-          pp(eqn.primitive.name) >> pp_kv_pairs(eqn.params)
+          pp(eqn.primitive.name) >> pp_kv_pairs(sorted(eqn.params.items()))
           >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
 def pp_jaxpr(jaxpr):

--- a/jax/core.py
+++ b/jax/core.py
@@ -652,7 +652,7 @@ def pp_eqn(eqn):
           >> pp(' [ {} ; {} ]'.format(pp_vars(const_vars),
                                       pp_vars(bound_vars))))
   return (pp('{} = '.format(lhs)) >>
-          pp(eqn.primitive.name) >> pp_kv_pairs(eqn.params.items())
+          pp(eqn.primitive.name) >> pp_kv_pairs(eqn.params)
           >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
 def pp_jaxpr(jaxpr):

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -64,7 +64,7 @@ def vcat(ps):
 
 def pp_kv_pairs(kv_pairs):
   if kv_pairs:
-    kv_pairs = vcat([pp('{}='.format(k)) >> pp(v) for k, v in kv_pairs])
+    kv_pairs = vcat([pp('{}='.format(k)) >> pp(kv_pairs[k]) for k in sorted(kv_pairs)])
     return pp('[ ') >> kv_pairs >> pp(' ]')
   else:
     return pp('')

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -64,7 +64,7 @@ def vcat(ps):
 
 def pp_kv_pairs(kv_pairs):
   if kv_pairs:
-    kv_pairs = vcat([pp('{}='.format(k)) >> pp(kv_pairs[k]) for k in sorted(kv_pairs)])
+    kv_pairs = vcat([pp('{}='.format(k)) >> pp(v) for k, v in kv_pairs])
     return pp('[ ') >> kv_pairs >> pp(' ]')
   else:
     return pp('')

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -620,6 +620,14 @@ class JaxTestCase(parameterized.TestCase):
     else:
       raise TypeError((type(x), type(y)))
 
+  def assertEqualIgnoreWhitespace(self, expected, what):
+    """Asserts two strings are equal ignoring whitespace."""
+    ignore_space_re = re.compile(r"[\n\s]+")
+    expected_clean = re.sub(ignore_space_re, " ", expected).strip()
+    what_clean = re.sub(ignore_space_re, " ", what).strip()
+    if expected_clean != what_clean:
+      self.assertEqual(expected, what, "Checking " + what)  # For error msg
+
   def _CompileAndCheck(self, fun, args_maker, check_dtypes,
                        rtol=None, atol=None):
     """Helper method for running JAX compilation and allclose assertions."""

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -625,7 +625,8 @@ class JaxTestCase(parameterized.TestCase):
     ignore_space_re = re.compile(r'\s*\n\s*')
     expected_clean = re.sub(ignore_space_re, '\n', expected.strip())
     what_clean = re.sub(ignore_space_re, '\n', what.strip())
-    self.assertMultiLineEqual(expected_clean, what_clean)
+    self.assertMultiLineEqual(expected_clean, what_clean,
+                              msg="Expecting\n"+expected)
 
   def _CompileAndCheck(self, fun, args_maker, check_dtypes,
                        rtol=None, atol=None):

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -620,13 +620,12 @@ class JaxTestCase(parameterized.TestCase):
     else:
       raise TypeError((type(x), type(y)))
 
-  def assertEqualIgnoreWhitespace(self, expected, what):
-    """Asserts two strings are equal ignoring whitespace."""
-    ignore_space_re = re.compile(r"[\n\s]+")
-    expected_clean = re.sub(ignore_space_re, " ", expected).strip()
-    what_clean = re.sub(ignore_space_re, " ", what).strip()
-    if expected_clean != what_clean:
-      self.assertEqual(expected, what, "Checking " + what)  # For error msg
+  def assertMultiLineStrippedEqual(self, expected, what):
+    """Asserts two strings are equal, after stripping each line."""
+    ignore_space_re = re.compile(r'\s*\n\s*')
+    expected_clean = re.sub(ignore_space_re, '\n', expected.strip())
+    what_clean = re.sub(ignore_space_re, '\n', what.strip())
+    self.assertMultiLineEqual(expected_clean, what_clean)
 
   def _CompileAndCheck(self, fun, args_maker, check_dtypes,
                        rtol=None, atol=None):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1509,11 +1509,11 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     jaxpr = api.make_jaxpr(api.linearize(f_yesremat, 4.)[1])(1.)
-    scan_eqn, = jaxpr.eqns
+    scan_eqn, = jaxpr.jaxpr.eqns
     self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
     jaxpr = api.make_jaxpr(api.vjp(f_yesremat, 4.)[1])(1.)
-    scan_eqn, = jaxpr.eqns
+    scan_eqn, = jaxpr.jaxpr.eqns
     self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
   def test_remat_no_redundant_flops(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1295,8 +1295,8 @@ class JaxprTest(jtu.JaxTestCase):
       return (x, 1., np.zeros(1))
 
     jaxpr = api.make_jaxpr(fun)(0.)
-    self.assertEqualIgnoreWhitespace(str(jaxpr), """
-    { lambda  b ;  ; a.
+    self.assertMultiLineStrippedEqual(str(jaxpr), """
+    { lambda b ;  ; a.
         let
         in [a, 1.0, b] }
     """)
@@ -1309,7 +1309,7 @@ class JaxprTest(jtu.JaxTestCase):
                       x + 2.,
                       lambda xf: xf - x)
     jaxpr = api.make_jaxpr(f)(3.)
-    self.assertEqualIgnoreWhitespace(str(jaxpr), """
+    self.assertMultiLineStrippedEqual(str(jaxpr), """
     { lambda  ;  ; a.
         let b = ge a 0.0
             c = add a 1.0

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1311,18 +1311,18 @@ class JaxprTest(jtu.JaxTestCase):
     jaxpr = api.make_jaxpr(f)(3.)
     self.assertMultiLineStrippedEqual(str(jaxpr), """
     { lambda  ;  ; a.
-        let b = ge a 0.0
-            c = add a 1.0
-            d = add a 2.0
-            e = cond[ true_jaxpr={ lambda  ;  ; b a.
-                                   let c = add a b
-                                   in [c] }
-                      false_jaxpr={ lambda  ;  ; b a.
-                                    let c = sub a b
-                                    in [c] }
-                      true_nconsts=1
-                      false_nconsts=1 ] b a c a d
-        in [e] }
+      let b = ge a 0.0
+          c = add a 1.0
+          d = add a 2.0
+          e = cond[ false_jaxpr={ lambda  ;  ; b a.
+                                  let c = sub a b
+                                  in [c] }
+                    false_nconsts=1
+                    true_jaxpr={ lambda  ;  ; b a.
+                                 let c = add a b
+                                 in [c] }
+                    true_nconsts=1 ] b a c a d
+      in [e] }
         """)
 
 

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -62,7 +62,7 @@ class BatchingTest(jtu.JaxTestCase):
         rtol={onp.float32:1e-2} if jtu.device_under_test() == "tpu" else None)
 
     jaxpr = make_jaxpr(matmat)(A, B)
-    self.assertEqual(len(jaxpr.eqns), 1)
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
 
   def testPerExampleGradients(self):
     def predict(params, inputs):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 from collections import namedtuple
 import gc
 import operator
-from unittest import skip
 
 import numpy as onp
 from absl.testing import absltest
@@ -275,7 +274,6 @@ class CoreTest(jtu.JaxTestCase):
       self.assertEqual(gc.collect(), 0)
     finally:
       gc.set_debug(debug)
-
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -348,7 +348,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
   def testForiLoopBatchedIssue1190(self):
     f = lambda x: lax.fori_loop(0, 4, lambda _, x: x + 1, x)
     jaxpr = api.make_jaxpr(api.vmap(f))(np.arange(3))
-    eqn = jaxpr.eqns[0]
+    eqn = jaxpr.jaxpr.eqns[0]
     self.assertIs(eqn.primitive, lax.while_p)
     self.assertEqual(eqn.params['cond_jaxpr'].in_avals[0].shape, ())
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -741,7 +741,7 @@ class IndexingTest(jtu.JaxTestCase):
   def testTrivialGatherIsntGenerated(self):
     # https://github.com/google/jax/issues/1621
     jaxpr = api.make_jaxpr(lambda x: x[:, None])(onp.arange(4))
-    self.assertEqual(len(jaxpr.eqns), 1)
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
     self.assertNotIn('gather', str(jaxpr))
 
   def testBooleanIndexingWithEmptyResult(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2396,7 +2396,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testPrecision(self):
 
     def iter_eqns(jaxpr):
-      for eqn in jaxpr.eqns:
+      for eqn in jaxpr.jaxpr.eqns:
         yield eqn
         for subjaxpr, _, _ in eqn.bound_subjaxprs:
           for sub_eqn in iter_eqns(subjaxpr):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2396,7 +2396,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testPrecision(self):
 
     def iter_eqns(jaxpr):
-      for eqn in jaxpr.jaxpr.eqns:
+      for eqn in jaxpr.eqns:
         yield eqn
         for subjaxpr, _, _ in eqn.bound_subjaxprs:
           for sub_eqn in iter_eqns(subjaxpr):
@@ -2404,7 +2404,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     def assert_precision(expected, fun, *args):
       jaxpr = jax.make_jaxpr(fun)(*args)
-      precision, = [eqn.params['precision'] for eqn in iter_eqns(jaxpr)
+      precision, = [eqn.params['precision'] for eqn in iter_eqns(jaxpr.jaxpr)
                     if eqn.primitive == lax.dot_general_p]
       self.assertEqual(precision, expected)
 


### PR DESCRIPTION
Unfortunately, this is a breaking change for make_jaxpr. But I think that a TypedJaxpr is
more future-proof result for that function. 

* A TypedJaxpr contains more useful information (consts, types). Upcoming changes
  will improve the printing of TypedJaxpr, e.g. to include the constants and some types.
* Also forced the instantiation of constants when producing the jaxpr.
  Before:
  >>>print(api.make_jaxpr(lambda x: 1.)(0.))
     lambda ; ; a.
     let
     in [*]}
  After this change:
  >>>print(api.make_jaxpr(lambda x: 1.)(0.))
     lambda ; ; a.
     let
     in [1.0]}