### PR TITLE
Wrap optix rules in a namedtuple with init/apply

### DIFF
--- a/tests/optix_test.py
+++ b/tests/optix_test.py
@@ -53,10 +53,10 @@ class OptixTest(absltest.TestCase):
 
     # experimental/optix.py
     optix_params = self.init_params
-    opt_init, opt_update = optix.sgd(LR, 0.0)
-    state = opt_init(optix_params)
+    sgd = optix.sgd(LR, 0.0)
+    state = sgd.init(optix_params)
     for _ in range(STEPS):
-      updates, state = opt_update(self.per_step_updates, state)
+      updates, state = sgd.update(self.per_step_updates, state)
       optix_params = optix.apply_updates(optix_params, updates)
 
     # Check equivalence.
@@ -76,10 +76,10 @@ class OptixTest(absltest.TestCase):
 
     # experimental/optix.py
     optix_params = self.init_params
-    opt_init, opt_update = optix.adam(LR, b1, b2, eps)
-    state = opt_init(optix_params)
+    adam = optix.adam(LR, b1, b2, eps)
+    state = adam.init(optix_params)
     for _ in range(STEPS):
-      updates, state = opt_update(self.per_step_updates, state)
+      updates, state = adam.update(self.per_step_updates, state)
       optix_params = optix.apply_updates(optix_params, updates)
 
     # Check equivalence.
@@ -99,10 +99,10 @@ class OptixTest(absltest.TestCase):
 
     # experimental/optix.py
     optix_params = self.init_params
-    opt_init, opt_update = optix.rmsprop(LR, decay, eps)
-    state = opt_init(optix_params)
+    rmsprop = optix.rmsprop(LR, decay, eps)
+    state = rmsprop.init(optix_params)
     for _ in range(STEPS):
-      updates, state = opt_update(self.per_step_updates, state)
+      updates, state = rmsprop.update(self.per_step_updates, state)
       optix_params = optix.apply_updates(optix_params, updates)
 
     # Check equivalence.


### PR DESCRIPTION
Wrap optix rules in a namedtuple with init/update.

In general we've found it convenient to be able to keep track of pairs of functions as a single object. For example:

```python
# Init.
loss_fn = hk.transform(loss_fn)
optimizer = optix.sgd(...)

# Initial state.
params = loss_fn.init(rng, ...)
opt_state = optimizer.init(params)

# Step.
grads = jax.grad(loss_fn.apply)(params, ...)
updates, opt_state = optimizer.update(grads, opt_state)
params = optix.apply_update(params, updates)
```

PiperOrigin-RevId: 282633556