### PR TITLE
Make jax.numpy.broadcast_to consistent with numpy.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -997,7 +997,7 @@ def broadcast_arrays(*args):
 
 def broadcast_to(arr, shape):
   """Like Numpy's broadcast_to but doesn't necessarily return views."""
-  arr = arr if isinstance(arr, ndarray) or isscalar(arr) else array(arr)
+  arr = arr if isinstance(arr, ndarray) else array(arr)
   shape = tuple(map(int, shape))  # check that shape is concrete
   arr_shape = _shape(arr)
   if arr_shape == shape:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2394,7 +2394,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         check_dtypes=False)
 
   def testBroadcastToOnScalar(self):
-    self.assertTrue(isinstance(lnp.broadcast_to(10.0, ()), lnp.ndarray))
+    self.assertIsInstance(lnp.broadcast_to(10.0, ()), lnp.ndarray)
+    self.assertIsInstance(onp.broadcast_to(10.0, ()), onp.ndarray)
 
   def testPrecision(self):
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2393,6 +2393,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(lnp.broadcast_to(1, (3, 2)), onp.ones((3, 2)),
                         check_dtypes=False)
 
+  def testBroadcastToOnScalar(self):
+    self.assertTrue(isinstance(lnp.broadcast_to(10.0, ()), lnp.ndarray))
+
   def testPrecision(self):
 
     def iter_eqns(jaxpr):


### PR DESCRIPTION
Repro:
In [1]: import jax.numpy as jnp
In [2]: jnp.broadcast_to(10.0, [])
Out[2]: 10.0
In [3]: jnp.broadcast_to(10.0, [1])
Out[3]: DeviceArray([10.], dtype=float32)
In [4]: import numpy as np
In [5]: np.broadcast_to(10.0, [])
Out[5]: array(10.)
In [6]: np.broadcast_to(10.0, [1])
Out[6]: array([10.])