### PR TITLE
Cleaned some test warnings.

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -157,11 +157,11 @@ class APITest(jtu.JaxTestCase):
     def f(x):
       return x
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError, ".* 'foo' of type <.*'str'> is not a valid JAX type",
       lambda: grad(f)("foo"))
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError, ".* 'foo' of type <.*'str'> is not a valid JAX type",
       lambda: jit(f)("foo"))
 
@@ -213,7 +213,7 @@ class APITest(jtu.JaxTestCase):
     def f(x, y):
       return np.dot(x, y)
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError, "Incompatible shapes for dot: got \\(3L?,\\) and \\(4L?,\\).",
       lambda: grad(f)(onp.zeros(3), onp.zeros(4)))
 
@@ -236,7 +236,7 @@ class APITest(jtu.JaxTestCase):
       return x
 
     assert jit(f, static_argnums=(1,))(0, 5) == 10
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         TypeError,
         "('JaxprTracer' object cannot be interpreted as an integer"
         "|Abstract value passed to .*)",
@@ -245,7 +245,7 @@ class APITest(jtu.JaxTestCase):
   def test_casts(self):
     for castfun in [float, complex, hex, oct] + list(six.integer_types):
       f = lambda x: castfun(x)
-      self.assertRaisesRegexp(
+      self.assertRaisesRegex(
           TypeError,
           "('JaxprTracer' object cannot be interpreted as an integer"
           "|Abstract value passed to .*)", lambda: jit(f)(0))
@@ -812,7 +812,7 @@ class APITest(jtu.JaxTestCase):
   def test_devicearray_delete(self):
     x = device_put(1.)
     x.delete()
-    self.assertRaisesRegexp(ValueError, "DeviceValue has been deleted.",
+    self.assertRaisesRegex(ValueError, "DeviceValue has been deleted.",
                             lambda: repr(x))
 
   def test_devicearray_block_until_ready(self):
@@ -964,7 +964,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_grad_of_int_errors(self):
     dfn = grad(lambda x: x ** 2)
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError,
       "Primal inputs to reverse-mode differentiation must be of float or "
       "complex type, got type int..", lambda: dfn(3))
@@ -1023,7 +1023,7 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(x.device_buffer.device(), device)
 
   def test_jit_of_noncallable(self):
-    self.assertRaisesRegexp(TypeError, "Expected a callable value.*",
+    self.assertRaisesRegex(TypeError, "Expected a callable value.*",
                             lambda: api.jit(3))
 
   def test_issue_1062(self):
@@ -1159,7 +1159,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_vmap_in_axes_tree_prefix_error(self):
     # https://github.com/google/jax/issues/795
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         "axes specification must be a tree prefix of the corresponding "
         r"value, got specification \(0, 0\) for value "
@@ -1295,7 +1295,7 @@ class APITest(jtu.JaxTestCase):
     # https://github.com/google/jax/issues/1696
     def f(x, y): return x + y
     df = api.grad(f, argnums=0)
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         TypeError,
         "differentiating with respect to argnums=0 requires at least 1 "
         "positional arguments to be passed by the caller, but got only 0 "

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -202,12 +202,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError,
         re.escape("body_fun output and input must have same type structure, got PyTreeDef(tuple, [*,*]) and *.")):
       lax.while_loop(lambda c: True, lambda c: (1., 1.), 0.)
-    with self.assertRaisesRegex(
+    with self.assertRaisesWithLiteralMatch(
         TypeError,
-        "body_fun output and input must have identical types, got\\n"
-        "ShapedArray\(bool\[\]\)\\n"
-        "and\\n"
-        "ShapedArray\(float32\[\]\)."):
+        "body_fun output and input must have identical types, got\n"
+        "ShapedArray(bool[])\n"
+        "and\n"
+        "ShapedArray(float32[])."):
       lax.while_loop(lambda c: True, lambda c: True, np.float32(0.))
 
   def testNestedWhileWithDynamicUpdateSlice(self):
@@ -530,12 +530,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         re.escape("true_fun and false_fun output must have same type structure, got * and PyTreeDef(tuple, [*,*]).")):
       lax.cond(True,
                1., lambda top: 1., 2., lambda fop: (2., 2.))
-    with self.assertRaisesRegex(
+    with self.assertRaisesWithLiteralMatch(
         TypeError,
         "true_fun and false_fun output must have identical types, got\n"
-        "ShapedArray\(float32\[1\]\)\n"
+        "ShapedArray(float32[1])\n"
         "and\n"
-        "ShapedArray\(float32\[\]\)."):
+        "ShapedArray(float32[])."):
       lax.cond(True,
                1., lambda top: np.array([1.], np.float32),
                2., lambda fop: np.float32(1.))
@@ -915,12 +915,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError,
         re.escape("scan carry output and input must have same type structure, got * and PyTreeDef(None, []).")):
       lax.scan(lambda c, x: (0, x), None, a)
-    with self.assertRaisesRegex(
+    with self.assertRaisesWithLiteralMatch(
         TypeError,
         "scan carry output and input must have identical types, got\n"
-        "ShapedArray\(int32\[\]\)\\n"
-        "and\\n"
-        "ShapedArray\(float32\[\]\)."):
+        "ShapedArray(int32[])\n"
+        "and\n"
+        "ShapedArray(float32[])."):
       lax.scan(lambda c, x: (np.int32(0), x), np.float32(1.0), a)
     with self.assertRaisesRegex(TypeError,
         re.escape("scan carry output and input must have same type structure, got * and PyTreeDef(tuple, [*,*]).")):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1485,19 +1485,19 @@ class LaxTest(jtu.JaxTestCase):
     ans = lax.reshape(onp.ones((3,), onp.float32), (lax.add(1, 2), 1))
     self.assertAllClose(ans, onp.ones((3, 1), onp.float32), check_dtypes=True)
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError,
       "Shapes must be 1D sequences of concrete values of integer type.*",
       lambda: lax.reshape(onp.ones(3,), (onp.array([3, 1]),)))
 
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError,
       "Shapes must be 1D sequences of concrete values of integer type.*",
       lambda: lax.reshape(onp.ones(3,), (1.5, 2.0)))
 
   @jtu.skip_on_devices("tpu")  # S16 not supported on TPU
   def testDynamicSliceTypeErrors(self):
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError,
       "index arguments to dynamic_slice must be integers of the same type",
       lambda: lax.dynamic_slice(onp.ones((3, 4), dtype=onp.float32),
@@ -1505,7 +1505,7 @@ class LaxTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices("tpu")  # S16 not supported on TPU
   def testDynamicUpdateSliceTypeErrors(self):
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
       TypeError,
       "index arguments to dynamic_update_slice must be integers of the same "
       "type",

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -95,7 +95,7 @@ class PmapTest(jtu.JaxTestCase):
   def testMismatchedAxisSizes(self):
     n = xla_bridge.device_count()
     f = pmap(lambda x, y: x + y)
-    self.assertRaisesRegexp(
+    self.assertRaisesRegex(
         ValueError,
         "Axis size .* does not match leading dimension of shape .*",
         lambda: f(onp.random.randn(n), onp.random.randn(n - 1)))


### PR DESCRIPTION
Specifically:
* lax_control_flow_test.py:...: DeprecationWarning: invalid escape sequence \(
* Deprecated assertRaisesRegexp, replace with assertRaisesRegex