### PR TITLE
Add betaln, a wrapper for the Beta function (scipy.special.betaln).

### DIFF
--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -32,6 +32,12 @@ def gammaln(x):
   return lax.lgamma(x)
 
 
+@_wraps(osp_special.betaln)
+def betaln(x, y):
+  x, y = _promote_args_like(osp_special.betaln, x, y)
+  return lax.sub(lax.add(lax.lgamma(x), lax.lgamma(y)), lax.lgamma(x + y))
+
+
 @_wraps(osp_special.digamma, update_doc=False)
 def digamma(x):
   x, = _promote_args_like(osp_special.digamma, x)

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -35,7 +35,7 @@ def gammaln(x):
 @_wraps(osp_special.betaln)
 def betaln(x, y):
   x, y = _promote_args_like(osp_special.betaln, x, y)
-  return lax.sub(lax.add(lax.lgamma(x), lax.lgamma(y)), lax.lgamma(x + y))
+  return lax.lgamma(x) + lax.lgamma(y) - lax.lgamma(x + y)
 
 
 @_wraps(osp_special.digamma, update_doc=False)

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -22,15 +22,14 @@ import scipy.stats as osp_stats
 from ... import lax
 from ...numpy.lax_numpy import (_promote_args_like, _constant_like, _wraps,
                                 where, inf, logical_or)
-from ..special import gammaln
+from ..special import betaln
 
 
 @_wraps(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
   x, a, b, loc, scale = _promote_args_like(osp_stats.beta.logpdf, x, a, b, loc, scale)
   one = _constant_like(x, 1)
-  shape_term_tmp = lax.add(gammaln(a), gammaln(b))
-  shape_term = lax.sub(gammaln(lax.add(a, b)), shape_term_tmp)
+  shape_term = lax.neg(betaln(a, b))
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.add(lax.mul(lax.sub(a, one), lax.log(y)),
                             lax.mul(lax.sub(b, one), lax.log1p(lax.neg(y))))

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -59,6 +59,7 @@ def op_record(name, nargs, dtypes, rng_factory, test_grad, test_name=None):
 
 JAX_SPECIAL_FUNCTION_RECORDS = [
     # TODO: digamma has no JVP implemented.
+    op_record("betaln", 2, float_dtypes, jtu.rand_positive, False),
     op_record("digamma", 1, float_dtypes, jtu.rand_positive, False),
     op_record("erf", 1, float_dtypes, jtu.rand_small_positive, True),
     op_record("erfc", 1, float_dtypes, jtu.rand_small_positive, True),


### PR DESCRIPTION
This adds betaln as a wrapper for scipy.stats.betaln. This is a default implementation, which could be replaced with a more numerically stable XLA implementation in the future.