### PR TITLE
Memoize TPU driver backend to be consistent with other XLA clients.

### DIFF
--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -122,7 +122,6 @@ def _get_local_backend(platform=None):
 
 register_backend('xla', _get_local_backend)
 
-
 # memoize the TPU driver to be consistent with xla_client behavior
 _tpu_backend = None
 


### PR DESCRIPTION
Jax backend behavior expects that the backend returned for `platform=None` is the same as that returned for `platform='tpu'` (when the TPU is set as the default platform).

The GPU and CPU backends support this implicitly, as `xla_client.get_backend` returns an already created value, but this breaks with the TPU driver support. This PR caches the value of the TPU backend call to mimic the existing behavior.