### PR TITLE
Fix scalar type promotion of np.where.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -966,12 +966,9 @@ def where(condition, x=None, y=None):
     raise ValueError("Must use the three-argument form of where().")
   if not issubdtype(_dtype(condition), onp.bool_):
     condition = lax.ne(condition, zeros_like(condition))
+  x, y = _promote_dtypes(x, y)
   condition, x, y = broadcast_arrays(condition, x, y)
-  if not onp.size(x):
-    empty, _ = _promote_dtypes(x, y)
-    return empty
-  else:
-    return lax.select(condition, *_promote_dtypes(x, y))
+  return lax.select(condition, x, y) if onp.size(x) else x
 
 
 @_wraps(onp.select)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1862,13 +1862,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(x[0, 0], 1)
 
   def testScalarDtypePromotion(self):
-    # disabled this test after https://github.com/google/jax/issues/732
-    msg = ("jax.numpy differs from numpy in promotion rules for Python scalars."
-           " See https://github.com/google/jax/issues/732.")
-    raise SkipTest(msg)
     orig_numpy_result = (1 + onp.eye(1, dtype=onp.float32)).dtype
     jax_numpy_result = (1 + lnp.eye(1, dtype=lnp.float32)).dtype
     self.assertEqual(orig_numpy_result, jax_numpy_result)
+
+  def testWhereScalarPromotion(self):
+    x = lnp.where(lnp.array([True, False]), 3,
+                  lnp.ones((2,), dtype=lnp.float32))
+    self.assertEqual(x.dtype, onp.dtype(onp.float32))
 
   def testSymmetrizeDtypePromotion(self):
     x = onp.eye(3, dtype=onp.float32)


### PR DESCRIPTION
Broadcasting before promoting causes scalars to be promoted to the default type.

Also reenable a test for scalar promotion.