### PR TITLE
Tagging, take two

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -63,3 +63,10 @@ Parallelization (:code:`pmap`)
 .. autofunction:: device_count
 .. autofunction:: local_device_count
 .. autofunction:: host_count
+
+Tagging (:code:`collect` and :code:`inject`)
+------------------------------
+
+.. autofunction:: Scope
+.. autofunction:: collect
+.. autofunction:: inject

--- a/jax/api.py
+++ b/jax/api.py
@@ -915,7 +915,7 @@ def soft_pmap(fun, axis_name=None, backend=None):
       msg = ("soft_pmap mapped axis size must be divisble by the number of "
              "XLA devices (or be less than or equal to that number), but got "
              "an axis size of {} with {} devices.")
-      raise ValueError(msg.format(axis_size, pxla.pxla.unmapped_device_count()))
+      raise ValueError(msg.format(axis_size, pxla.unmapped_device_count()))
     num_chunks = axis_size // chunk_size
 
     reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]
@@ -945,9 +945,9 @@ def _reshape_merge(x):
     return x.reshape((-1,) + x.shape[2:])
 
 
-def _papply(fun):
+def _papply(fun, axis_name=None):
   # This function is for testing purposes.
-  axis_name = _TempAxisName(fun)
+  if axis_name is None: axis_name = _TempAxisName(fun)
 
   def papply_fun(*args, **kwargs):
     f = lu.wrap_init(fun)

--- a/jax/core.py
+++ b/jax/core.py
@@ -143,6 +143,7 @@ class Primitive(object):
     return '{}'.format(self.name)
 
   def bind(self, *args, **kwargs):
+    """Dispatch the primitive in the top trace's interpreter."""
     assert skip_checks or all(isinstance(arg, Tracer)
                               or valid_jaxtype(arg) for arg in args), args
     top_trace = find_top_trace(args)
@@ -211,6 +212,7 @@ def eval_jaxpr(jaxpr, consts, freevar_vals, *args):
 
 
 def full_lower(val):
+  """Drop any unneeded Tracer wrappers (e.g. batch tracers with no batch)."""
   if isinstance(val, Tracer):
     return val.full_lower()
   else:
@@ -224,7 +226,7 @@ def find_top_trace(xs):
  except ValueError:
    return None
  else:
-   return type(top_trace)(top_trace.master, cur_sublevel())
+   return top_trace.with_sublevel(cur_sublevel())
 
 
 # -------------------- tracing --------------------
@@ -235,6 +237,9 @@ class Trace(object):
     self.master = master
     self.level = master.level
     self.sublevel = sublevel
+
+  def with_sublevel(self, sublevel):
+    return type(self)(self.master, sublevel)
 
   def full_raise(self, val):
     if not isinstance(val, Tracer):

--- a/jax/dict_util.py
+++ b/jax/dict_util.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for working with nested dictionaries as path-indexed containers.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import itertools as it
+
+def maybe_set_dict(tree, path, val, accum_fn):
+  if len(path) == 0:
+    raise ValueError("cannot index nested dict with an empty path")
+  subtree = tree
+  for path_element in path[:-1]:
+    if path_element not in subtree:
+      if accum_fn is None:
+        subtree[path_element] = dict()
+      else:
+        return val
+    subtree = subtree[path_element]
+  if accum_fn is None: # storing, i.e. collect
+    if path[-1] in subtree:
+      # Some users might want `val = subtree[path[-1]]` here?
+      raise RuntimeError("cannot store multiple values to the same nested dict path")
+    else:
+      subtree[path[-1]] = val
+  elif path[-1] in subtree:
+    val = accum_fn(val, subtree[path[-1]])
+  return val
+
+def iterpaths(tree, prefix=()):
+  for key, val in tree.items():
+    path = prefix + (key,)
+    if isinstance(val, dict):
+      # TODO(jekbradbury): replace with `yield from` when Python 2 is dropped
+      for path2, val2 in iterpaths(val, path):
+        yield path2, val2
+    else:
+      yield path, val
+
+def as_dict(paths_and_values):
+  tree = dict()
+  for path, val in paths_and_values:
+    maybe_set_dict(tree, path, val, None)
+  return tree
+
+def dict_join(*trees):
+  """Union the contents of nested dictionaries.
+  
+  For example:
+
+  >>> dict_join({"a": 1, "b": {"c": 2}}, {"b": {"d": 3}})
+  {"a": 1, "b": {"c": 2, "d": 3}}
+  """
+  return as_dict(it.chain(*(iterpaths(tree) for tree in trees)))

--- a/jax/interpreters/tagging.py
+++ b/jax/interpreters/tagging.py
@@ -1,0 +1,159 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tracer for tagging and manipulating a computation's intermediate values.
+
+This relies on two features added to the jaxpr language. First, we introduce
+Scope, a new JAX type consisting entirely of compile-time Python metadata
+(a stack of namespaces/names), and a `push_scope` primitive to add a string
+or other Python value to this stack. Second, the `tag` primitive marks a value
+as a tagged intermediate with a name or nested scope; tge value can then be
+referenced and manipulated using this tag.
+
+The two primary public APIs for this functionality are `collect` and `inject`.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+
+import itertools as it
+
+import numpy as onp
+
+from .. import core
+from ..core import Trace, Tracer, new_master
+from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
+from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
+from ..linear_util import transformation, transformation_with_aux, wrap_init
+from ..dict_util import maybe_set_dict
+from ..util import unzip2, partial, safe_map
+from ..api_util import flatten_fun, flatten_fun_nokwargs
+from ..tree_util import tree_flatten, tree_unflatten
+from . import xla
+from . import partial_eval as pe
+
+map = safe_map
+tag_primitives = set()
+
+class Scope(object):
+  """Carries a path made of a stack of names/namespaces."""
+  __slots__ = ['path']
+  def __init__(self, path=()):
+    self.path = path
+
+class AbstractScope(core.AbstractValue):
+  __slots__ = ['path']
+  def __init__(self, path=()):
+    self.path = path
+
+core.pytype_aval_mappings[Scope] = lambda scope: AbstractScope(scope.path)
+xla.pytype_aval_mappings[Scope] = lambda scope: AbstractScope(scope.path)
+xla.xla_shape_handlers[AbstractScope] = xla.xla_shape_handlers[core.AbstractUnit]
+xla.canonicalize_dtype_handlers[Scope] = xla.identity
+xla.device_put_handlers[Scope] = xla.device_put_handlers[core.Unit]
+
+class TagTrace(core.Trace):
+
+  def __init__(self, master, sublevel, accum_fn, tree=None):
+    super(TagTrace, self).__init__(master, sublevel)
+    self.tree = dict() if tree is None else tree
+    self.accum_fn = accum_fn
+
+  def with_sublevel(self, sublevel):
+    return type(self)(self.master, sublevel, self.accum_fn, self.tree)
+
+  def pure(self, val):
+    return TagTracer(self, val)
+
+  def lift(self, val):
+    return TagTracer(self, val)
+
+  def sublift(self, val):
+    return TagTracer(self, val.val)
+
+  def maybe_set(self, path, val):
+    return maybe_set_dict(self.tree, path, val, self.accum_fn)
+
+  def process_primitive(self, primitive, tracers, params):
+    in_vals = [t.val for t in tracers]
+    out = primitive.bind(*in_vals, **params)
+    if primitive in tag_primitives:
+      path = in_vals[-1].path
+      out = self.maybe_set(path, out)
+    if primitive.multiple_results:
+      return [TagTracer(self, val) for val in out]
+    else:
+      return TagTracer(self, out)
+
+  def process_call(self, call_primitive, f, tracers, params):
+    in_vals = [t.val for t in tracers]
+    f_tag = tag_subtrace(f, self)
+    all_args, in_treedef = tree_flatten((in_vals, self.tree))
+    f_tag_flat, out_treedef = flatten_fun_nokwargs(f_tag, in_treedef)
+    out_flat = call_primitive.bind(f_tag_flat, *all_args, **params)
+    out_vals, out_tree = tree_unflatten(out_treedef(), out_flat)
+    self.tree.update(out_tree)
+    return [TagTracer(self, val) for val in out_vals]
+
+  def process_map(self, map_primitive, f, tracers, params):
+    raise NotImplementedError
+
+  def post_process_call(self, call_primitive, out_tracers, params):
+    raise NotImplementedError
+
+class TagTracer(core.Tracer):
+  __slots__ = ['trace', 'val']
+
+  def __init__(self, trace, val):
+    self.trace = trace
+    self.val = val
+
+  def __repr__(self):
+    return 'Traced<{}:{}>'.format(self.val, self.trace)
+
+  @property
+  def aval(self):
+    return core.get_aval(self.val)
+
+  def full_lower(self):
+    if isinstance(self.aval, AbstractScope):
+      return self
+    else:
+      return self.val
+
+
+@transformation
+def tag_subtrace(parent, in_vals, in_tree):
+  trace = parent.with_sublevel(core.cur_sublevel())
+  trace.tree = in_tree
+  in_tracers = [TagTracer(trace, val) for val in in_vals]
+  outs = yield in_tracers, {}
+  out_tracers = map(trace.full_raise, outs)
+  out_vals = [t.val for t in out_tracers]
+  out_tree = trace.tree
+  yield out_vals, out_tree
+
+def tag_fun(fun, in_vals, in_tree, accum_fn):
+  with core.new_master(TagTrace) as master:
+    trace = TagTrace(master, core.cur_sublevel(), accum_fn)
+    f_tag = tag_subtrace(fun, trace)
+    all_args, in_treedef = tree_flatten((in_vals, in_tree))
+    f_tag_flat, out_treedef = flatten_fun_nokwargs(f_tag, in_treedef)
+    out_flat = f_tag_flat.call_wrapped(*all_args)
+    out_vals, out_tree = tree_unflatten(out_treedef(), out_flat)
+    del master
+  return out_vals, out_tree

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1033,6 +1033,7 @@ def sort_key_val(keys, values, dimension=-1):
 
 
 def tie_in(x, y):
+  """Returns `y`, with data dependence on `x`."""
   return tie_in_p.bind(x, y)
 
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -251,13 +251,14 @@ def fold_in(key, data):
 
   Args:
     key: a PRNGKey (an array with shape (2,) and dtype uint32).
-    data: a 32bit integer representing data to be folded in to the key.
+    data: data to be folded into the key; will be hashed first if not an int.
 
   Returns:
     A new PRNGKey that is a deterministic function of the inputs and is
     statistically safe for producing a stream of new pseudo-random values.
   """
-  return _fold_in(key, data)
+  int_data = data if isinstance(data, int) else hash(data)
+  return _fold_in(key, int_data)
 
 @jit
 def _fold_in(key, data):

--- a/tests/tagging_test.py
+++ b/tests/tagging_test.py
@@ -1,0 +1,135 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from jax import test_util as jtu
+from jax import collect, inject, grad_intermediates, vmap, jit, grad, Scope
+from jax import lax, random
+import jax.numpy as np
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+class TaggingTest(jtu.JaxTestCase):
+
+  def test_collect(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val, tree = collect(foo)(scope, 2.)
+    self.assertAllClose(val, foo(scope, 2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+  
+  def test_collect_jit(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val, tree = collect(jit(foo))(scope, 2.)
+    self.assertAllClose(val, foo(scope, 2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+  
+  def test_jit_collect(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val, tree = jit(collect(foo))(scope, 2.)
+    self.assertAllClose(val, foo(scope, 2.), check_dtypes=True)
+    self.assertAllClose(tree, {"y": 4.}, check_dtypes=True)
+
+  def test_collect_nested(self):
+    def bar(scope, key, x):
+      scope, key = lax.push_scope(scope, "y"), random.fold_in(key, "y")
+      y = lax.tag(random.normal(key), scope)
+      return x + y
+    def baz(scope, key, x):
+      scope_1, key_1 = lax.push_scope(scope, 1), random.fold_in(key, 1)
+      a = bar(scope_1, key_1, x)
+      scope_2, key_2 = lax.push_scope(scope, 2), random.fold_in(key, 2)
+      b = bar(scope_2, key_2, x)
+      return a + b
+    scope = Scope()
+    key = random.PRNGKey(0)
+    val, tree = collect(baz)(scope, key, 2.)
+    self.assertAllClose(val, baz(scope, key, 2.), check_dtypes=True)
+    expected = {1: {"y": random.normal(random.fold_in(random.fold_in(key, 1), "y"))},
+                2: {"y": random.normal(random.fold_in(random.fold_in(key, 2), "y"))}}
+    self.assertAllClose(tree, expected, check_dtypes=True)
+
+  def test_inject(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val = inject(foo, {"y": 1.})(scope, 2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+
+  def test_inject_jit(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val = inject(jit(foo), {"y": 1.})(scope, 2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+  
+  def test_jit_inject(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope()
+    val = jit(inject(foo, {"y": 1.}))(scope, 2.)
+    self.assertAllClose(val, 2., check_dtypes=True)
+
+  def test_inject_nested(self):
+    def bar(scope, key, x):
+      scope, key = lax.push_scope(scope, "y"), random.fold_in(key, "y")
+      y = lax.tag(random.normal(key), scope)
+      return x + y
+    def baz(scope, key, x):
+      scope_1, key_1 = lax.push_scope(scope, 1), random.fold_in(key, 1)
+      a = bar(scope_1, key_1, x)
+      scope_2, key_2 = lax.push_scope(scope, 2), random.fold_in(key, 2)
+      b = bar(scope_2, key_2, x)
+      return a + b
+    scope = Scope()
+    key = random.PRNGKey(0)
+    val = inject(baz, {1: {"y": 0.3}, 2: {"y": 0.5}})(scope, key, 2.)
+    self.assertAllClose(val, 4.8, check_dtypes=True)
+
+  def test_grad_intermediates(self):
+    def foo(scope, x):
+      y = lax.tag(x ** 2, scope, "y")
+      z = y + 1
+      return z
+    scope = Scope() 
+    val = grad_intermediates(foo)(scope, 2.)
+    expected = {"y": 1.}
+    self.assertAllClose(val, expected, check_dtypes=True)
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This is a rewrite of #1660 that uses explicit scope arguments rather than conflating scopes with values. This leads to a simpler mental model that's also likely to be easier to build on top of (especially for Sonnet-like neural network libraries).

Here's an example of the more explicit API:
```python
def bar(scope, key, x):
  y = lax.tag(random.normal(key), scope, "y")
  return x + y
def baz(scope, key, x):
  key1, key2 = random.split(key)
  a = bar(lax.push_scope(scope, 1), key1, x)
  b = bar(lax.push_scope(scope, 2), key2, x)
  return a + b

collect(baz)(jax.Scope(), random.PRNGKey(0), 2.)
# (DeviceArray(2.8923516), {1: {'y': DeviceArray(0.14389044)}, 2: {'y': DeviceArray(-1.2515389)}})
```

This implementation is still able to support the PRNG-splitting-based approach to tag structure; we would just have to create a type that contains both a key and a scope and splits them together.