### PR TITLE
Add some missing NumPy constants: euler_gamma, NZERO and PZERO.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -82,11 +82,15 @@ _min = builtins.min
 _sum = builtins.sum
 _divmod = builtins.divmod
 
-# We need some numpy scalars
+# NumPy constants
+
 pi = onp.pi
 e = onp.e
+euler_gamma = onp.euler_gamma
 inf = onp.inf
 NINF = onp.NINF
+PZERO = onp.PZERO
+NZERO = onp.NZERO
 nan = onp.nan
 
 # And some numpy utility functions


### PR DESCRIPTION
I avoided adding the deprecated aliases for inf and nan.