### PR TITLE
Change JAX type promotion to prefer inexact types.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ For an introduction to JAX, start at the
    gpu_memory_allocation
    profiling
    rank_promotion_warning
+   type_promotion
 
 .. toctree::
    :maxdepth: 2

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -9,7 +9,7 @@ following table, where, for example
 
 * "b1" means :code:`np.bool_`,
 * "s2" means :code:`np.int16`,
-* "u4" means :code:`np.int32`,
+* "u4" means :code:`np.uint32`,
 * "bf" means :code:`np.bfloat16`,
 * "f2" means :code:`np.float16`, and
 * "c8" means :code:`np.complex128`.

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -1,0 +1,86 @@
+.. _type-promotion:
+
+Type promotion semantics
+========================
+
+JAX's type promotion rules (i.e., the result of
+:func:`jax.numpy.promote_types` for each pair of types) are given by the
+following table, where, for example
+
+* "b1" means :code:`np.bool_`,
+* "s2" means :code:`np.int16`,
+* "u4" means :code:`np.int32`,
+* "bf" means :code:`np.bfloat16`,
+* "f2" means :code:`np.float16`, and
+* "c8" means :code:`np.complex128`.
+
+.. raw:: html
+
+    <style>
+        #types table {
+          border: 2px solid #aaa;
+        }
+
+        #types td, #types th {
+          border: 1px solid #ddd;
+          padding: 3px;
+        }
+        #types th {
+          border-bottom: 1px solid #aaa;
+        }
+        #types tr:nth-child(even){background-color: #f2f2f2;}
+        #types .d {
+          background-color: #ccf2cc;
+        }
+        #types td:first-child{
+          background-color: #f2f2f2;
+          border-right: 1px solid #aaa;
+          font-weight: bold;
+        }
+        #types tr:first-child{background-color: #f2f2f2;}
+    </style>
+
+    <table id="types">
+    <tr><th></th><th>b1</th><th>s1</th><th>s2</th><th>s4</th><th>s8</th><th>u1</th><th>u2</th><th>u4</th><th>u8</th><th>bf</th><th>f2</th><th>f4</th><th>f8</th><th>c4</th><th>c8</th></tr>
+    <tr><td>b1</td><td>b1</td><td>s1</td><td>s2</td><td>s4</td><td>s8</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>s1</td><td>s1</td]]><td>s1</td><td>s2</td><td>s4</td><td>s8</td><td>s2</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>s2</td><td>s2</td><td>s2</td><td>s2</td><td>s4</td><td>s8</td><td>s2</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>s4</td><td>s4</td><td>s4</td><td>s4</td><td>s4</td><td>s8</td><td>s4</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>u1</td><td>u1</td><td>s2</td><td>s2</td><td>s4</td><td>s8</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>u2</td><td>u2</td><td>s4</td><td>s4</td><td>s4</td><td>s8</td><td>u2</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>u4</td><td>u4</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>u4</td><td>u4</td><td>u4</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>u8</td><td>u8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr class="d"><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td class="d">bf</td><td>bf</td><td>f4</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>f2</td><td>f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f4</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>f4</td><td>f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">f8</td><td>f8</td><td>f8</td><td>f8</td><td>c8</td><td>c8</td></tr>
+    <tr><td>c4</td><td>c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td>c8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td class="d">c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td></tr>
+    </table><p>
+
+Jax's type promotion rules differ from those of NumPy, as given by
+:func:`numpy.promote_types`, in those cells highlighted with a green background
+in the table above. There are two key differences:
+
+* when promoting an integer or boolean type against a floating-point or complex
+  type, JAX always prefers the type of the floating-point or complex type.
+
+  Accelerator devices, such as GPUs and TPUs, either pay a significant
+  performance penalty to use 64-bit floating point types (GPUs) or do not
+  support 64-bit floating point types at all (TPUs). Classic NumPy's promotion
+  rules are too willing to overpromote to 64-bit types, which is problematic for
+  a system designed to run on accelerators.
+
+  JAX uses floating point promotion rules that are more suited to modern
+  accelerator devices and are less aggressive about promoting floating point
+  types. The promotion rules used by JAX for floating-point types are similar to
+  those used by PyTorch.
+
+* JAX supports the
+  `bfloat16 <https://en.wikipedia.org/wiki/Bfloat16_floating-point_format>`_
+  non-standard 16-bit floating point type
+  (:code:`jax.numpy.bfloat16`), which is useful for neural network training.
+  For a description of bfloat16, see details
+  The only notable promotion behavior is with respect to IEEE-754
+  :code:`float16`, which which :code:`bfloat16` promotes to a :code:`float32`.

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -41,23 +41,55 @@ following table, where, for example
     </style>
 
     <table id="types">
-    <tr><th></th><th>b1</th><th>s1</th><th>s2</th><th>s4</th><th>s8</th><th>u1</th><th>u2</th><th>u4</th><th>u8</th><th>bf</th><th>f2</th><th>f4</th><th>f8</th><th>c4</th><th>c8</th></tr>
-    <tr><td>b1</td><td>b1</td><td>s1</td><td>s2</td><td>s4</td><td>s8</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
-    <tr><td>s1</td><td>s1</td]]><td>s1</td><td>s2</td><td>s4</td><td>s8</td><td>s2</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
-    <tr><td>s2</td><td>s2</td><td>s2</td><td>s2</td><td>s4</td><td>s8</td><td>s2</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
-    <tr><td>s4</td><td>s4</td><td>s4</td><td>s4</td><td>s4</td><td>s8</td><td>s4</td><td>s4</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
-    <tr><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
-    <tr><td>u1</td><td>u1</td><td>s2</td><td>s2</td><td>s4</td><td>s8</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
-    <tr><td>u2</td><td>u2</td><td>s4</td><td>s4</td><td>s4</td><td>s8</td><td>u2</td><td>u2</td><td>u4</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
-    <tr><td>u4</td><td>u4</td><td>s8</td><td>s8</td><td>s8</td><td>s8</td><td>u4</td><td>u4</td><td>u4</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
-    <tr><td>u8</td><td>u8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
-    <tr class="d"><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td>bf</td><td class="d">bf</td><td>bf</td><td>f4</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><th></th><th>b1</th><th>u1</th><th>u2</th><th>u4</th><th>u8</th><th>i1</th><th>i2</th><th>i4</th><th>i8</th><th>bf</th><th>f2</th><th>f4</th><th>f8</th><th>c4</th><th>c8</th></tr>
+    <tr><td>b1</td><td>b1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>u1</td><td>u1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>u2</td><td>u2</td><td>u2</td><td>u2</td><td>u4</td><td>u8</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>i1</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td>f8</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>i2</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td>f8</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
+    <tr><td>i4</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td>f8</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td></tr>
+    <tr><td>bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">f4</td><td class="d">f4</td><td class="d">f8</td><td class="d">c4</td><td class="d">c8</td></tr>
     <tr><td>f2</td><td>f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f4</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
     <tr><td>f4</td><td>f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td></tr>
     <tr><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">f8</td><td>f8</td><td>f8</td><td>f8</td><td>c8</td><td>c8</td></tr>
     <tr><td>c4</td><td>c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td>c8</td><td>c4</td><td>c8</td></tr>
     <tr><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td class="d">c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td></tr>
     </table><p>
+
+.. The table above was generated by the following Python code.
+    import numpy as onp
+    from jax import numpy as np
+
+    types = [onp.bool_, onp.uint8, onp.uint16, onp.uint32, onp.uint64,
+             onp.int8, onp.int16, onp.int32, onp.int64,
+             np.bfloat16, onp.float16, onp.float32, onp.float64,
+             onp.complex64, onp.complex128]
+
+    def name(d):
+      d = onp.dtype(d)
+      if d == onp.dtype(np.bfloat16):
+        return "bf"
+      return "{}{}".format(
+        d.kind,
+        d.itemsize // 2 if onp.issubdtype(d, onp.complexfloating) else d.itemsize)
+
+    out = "<tr><th></th>"
+    for t in types:
+      out += "<th>{}</th>".format(name(t))
+    out += "</tr>\n"
+
+    for t1 in types:
+      out += "<tr><td>{}</td>".format(name(t1))
+      for t2 in types:
+        t = np.promote_types(t1, t2)
+        different = np.bfloat16 in (t1, t2) or t != onp.promote_types(t1, t2)
+        out += "<td{}>{}</td>".format(" class=\"d\"" if different else "", name(t))
+      out += "</tr>\n"
+
+    print(out)
 
 Jax's type promotion rules differ from those of NumPy, as given by
 :func:`numpy.promote_types`, in those cells highlighted with a green background
@@ -83,4 +115,3 @@ in the table above. There are two key differences:
   (:code:`jax.numpy.bfloat16`), which is useful for neural network training.
   The only notable promotion behavior is with respect to IEEE-754
   :code:`float16`, with which :code:`bfloat16` promotes to a :code:`float32`.
-  

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -81,7 +81,6 @@ in the table above. There are two key differences:
   `bfloat16 <https://en.wikipedia.org/wiki/Bfloat16_floating-point_format>`_
   non-standard 16-bit floating point type
   (:code:`jax.numpy.bfloat16`), which is useful for neural network training.
-  For a description of bfloat16, see details
   The only notable promotion behavior is with respect to IEEE-754
   :code:`float16`, with which :code:`bfloat16` promotes to a :code:`float32`.
   

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -83,4 +83,5 @@ in the table above. There are two key differences:
   (:code:`jax.numpy.bfloat16`), which is useful for neural network training.
   For a description of bfloat16, see details
   The only notable promotion behavior is with respect to IEEE-754
-  :code:`float16`, which which :code:`bfloat16` promotes to a :code:`float32`.
+  :code:`float16`, with which :code:`bfloat16` promotes to a :code:`float32`.
+  

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -146,14 +146,14 @@ issubsctype = onp.issubsctype
 # table.
 _jax_types = [
   onp.dtype('bool'),
-  onp.dtype('int8'),
-  onp.dtype('int16'),
-  onp.dtype('int32'),
-  onp.dtype('int64'),
   onp.dtype('uint8'),
   onp.dtype('uint16'),
   onp.dtype('uint32'),
   onp.dtype('uint64'),
+  onp.dtype('int8'),
+  onp.dtype('int16'),
+  onp.dtype('int32'),
+  onp.dtype('int64'),
   onp.dtype(bfloat16),
   onp.dtype('float16'),
   onp.dtype('float32'),
@@ -166,18 +166,18 @@ _jax_types = [
 _jax_type_nums = {t: i for i, t in enumerate(_jax_types)}
 
 def _make_type_promotion_table():
-  b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8 = _jax_types
-  #  b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8
+  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8 = _jax_types
+  #  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8
   return onp.array([
-    [b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # b1
-    [s1, s1, s2, s4, s8, s2, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s1
-    [s2, s2, s2, s4, s8, s2, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s2
-    [s4, s4, s4, s4, s8, s4, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s4
-    [s8, s8, s8, s8, s8, s8, s8, s8, f8, bf, f2, f4, f8, c4, c8],  # s8
-    [u1, s2, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # u1
-    [u2, s4, s4, s4, s8, u2, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # u2
-    [u4, s8, s8, s8, s8, u4, u4, u4, u8, bf, f2, f4, f8, c4, c8],  # u4
-    [u8, f8, f8, f8, f8, u8, u8, u8, u8, bf, f2, f4, f8, c4, c8],  # u8
+    [b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8],  # b1
+    [u1, u1, u2, u4, u8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8],  # u1
+    [u2, u2, u2, u4, u8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8],  # u2
+    [u4, u4, u4, u4, u8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8],  # u4
+    [u8, u8, u8, u8, u8, f8, f8, f8, f8, bf, f2, f4, f8, c4, c8],  # u8
+    [s1, s2, s4, s8, f8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8],  # s1
+    [s2, s2, s4, s8, f8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8],  # s2
+    [s4, s4, s4, s8, f8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8],  # s4
+    [s8, s8, s8, s8, f8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8],  # s8
     [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8],  # bf
     [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8],  # f2
     [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8],  # f4

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -141,38 +141,61 @@ def issubdtype(a, b):
 can_cast = onp.can_cast
 issubsctype = onp.issubsctype
 
-_bfloat16_type_promotions = {
-  onp.dtype('bool'): onp.dtype(bfloat16),
-  onp.dtype(bfloat16): onp.dtype(bfloat16),
-  onp.dtype('float16'): onp.dtype('float32'),
-  onp.dtype('float32'): onp.dtype('float32'),
-  onp.dtype('float64'): onp.dtype('float64'),
-  onp.dtype('complex64'): onp.dtype('complex64'),
-  onp.dtype('complex128'): onp.dtype('complex128'),
-  onp.dtype('int8'): onp.dtype(bfloat16),
-  onp.dtype('int16'): onp.dtype('float32'),
-  onp.dtype('int32'): onp.dtype('float64'),
-  onp.dtype('int64'): onp.dtype('float64'),
-  onp.dtype('uint8'): onp.dtype(bfloat16),
-  onp.dtype('uint16'): onp.dtype('float32'),
-  onp.dtype('uint32'): onp.dtype('float64'),
-  onp.dtype('uint64'): onp.dtype('float64'),
-}
+
+# List of all valid JAX dtypes, in the order they appear in the type promotion
+# table.
+_jax_types = [
+  onp.dtype('bool'),
+  onp.dtype('int8'),
+  onp.dtype('int16'),
+  onp.dtype('int32'),
+  onp.dtype('int64'),
+  onp.dtype('uint8'),
+  onp.dtype('uint16'),
+  onp.dtype('uint32'),
+  onp.dtype('uint64'),
+  onp.dtype(bfloat16),
+  onp.dtype('float16'),
+  onp.dtype('float32'),
+  onp.dtype('float64'),
+  onp.dtype('complex64'),
+  onp.dtype('complex128'),
+]
+
+# Mapping from types to their type numbers.
+_jax_type_nums = {t: i for i, t in enumerate(_jax_types)}
+
+def _make_type_promotion_table():
+  b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8 = _jax_types
+  #  b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8
+  return onp.array([
+    [b1, s1, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # b1
+    [s1, s1, s2, s4, s8, s2, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s1
+    [s2, s2, s2, s4, s8, s2, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s2
+    [s4, s4, s4, s4, s8, s4, s4, s8, f8, bf, f2, f4, f8, c4, c8],  # s4
+    [s8, s8, s8, s8, s8, s8, s8, s8, f8, bf, f2, f4, f8, c4, c8],  # s8
+    [u1, s2, s2, s4, s8, u1, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # u1
+    [u2, s4, s4, s4, s8, u2, u2, u4, u8, bf, f2, f4, f8, c4, c8],  # u2
+    [u4, s8, s8, s8, s8, u4, u4, u4, u8, bf, f2, f4, f8, c4, c8],  # u4
+    [u8, f8, f8, f8, f8, u8, u8, u8, u8, bf, f2, f4, f8, c4, c8],  # u8
+    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8],  # bf
+    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8],  # f2
+    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8],  # f4
+    [f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, c8, c8],  # f8
+    [c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c8, c4, c8],  # c4
+    [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8],  # c8
+  ])
+
+_type_promotion_table = _make_type_promotion_table()
 
 def promote_types(a, b):
   a = onp.dtype(a)
   b = onp.dtype(b)
-  if b == _bfloat16_dtype:
-    a, b = b, a
-
-  if a == _bfloat16_dtype:
-    try:
-      return _bfloat16_type_promotions[b]
-    except:
-      raise TypeError("invalid type promotion of bfloat16 type and {}"
-                      .format(b))
-
-  return onp.promote_types(a, b)
+  try:
+    return _type_promotion_table[_jax_type_nums[a], _jax_type_nums[b]]
+  except KeyError:
+    pass
+  raise TypeError("Invalid type promotion of {} and {}".format(a, b))
 
 
 def is_python_scalar(x):

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -189,6 +189,17 @@ def _make_type_promotion_table():
 _type_promotion_table = _make_type_promotion_table()
 
 def promote_types(a, b):
+  """Returns the type to which a binary operation should cast its arguments.
+
+  For details of JAX's type promotion semantics, see :ref:`type-promotion`.
+
+  Args:
+    a: a :class:`numpy.dtype` or a dtype specifier.
+    b: a :class:`numpy.dtype` or a dtype specifier.
+
+  Returns:
+    A :class:`numpy.dtype` object.
+  """
   a = onp.dtype(a)
   b = onp.dtype(b)
   try:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2369,6 +2369,7 @@ def inner(a, b, precision=None):
 def outer(a, b, out=None):
   if out:
     raise NotImplementedError("The 'out' argument to outer is not supported.")
+  a, b = _promote_dtypes(a, b)
   return ravel(a)[:, None] * ravel(b)
 
 @partial(jit, static_argnums=(2, 3, 4))


### PR DESCRIPTION
NumPy's type promotion rules tend to promote aggressively to `float64`, which isn't a very accelerator-friendly behavior when not all accelerators (e.g., TPUs) support 64-bit floating point types. Even on accelerators that support 64-bit floating point types (e.g., GPUs), promotion to a 64-bit type comes with a significant performance cost.

This change makes JAX type promotion between inexact and exact types closer to PyTorch's promotion semantics, which are a better fit for modern accelerators:
e.g.,
```
import numpy as onp
from jax import numpy as np

In [1]: onp.promote_types(onp.float32, onp.int32)   
Out[1]: dtype('float64')

In [2]: onp.promote_types(onp.float16, onp.int64)   
Out[2]: dtype('float64')

In [3]: np.promote_types(onp.float32, onp.int32)    
Out[3]: dtype('float32')

In [4]: np.promote_types(onp.float16, onp.int64)    
Out[4]: dtype('float16')
```

This change is in preparation for enabling x64 mode by default on all platforms.