### PR TITLE
Fixes to type handling.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -811,7 +811,7 @@ def angle(z):
   dtype = _dtype(re)
   if not issubdtype(dtype, inexact) or (
       issubdtype(_dtype(z), floating) and ndim(z) == 0):
-    dtype = dtypes.canonicalize_dtype(float64)
+    dtype = dtypes.canonicalize_dtype(float_)
     re = lax.convert_element_type(re, dtype)
     im = lax.convert_element_type(im, dtype)
   return lax.atan2(im, re)
@@ -1254,52 +1254,51 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
 
 @_wraps(onp.average)
 def average(a, axis=None, weights=None, returned=False):
-    a = asarray(a)
+  a = asarray(a)
 
-    if weights is None: # Treat all weights as 1
-        avg = mean(a, axis=axis)
-        if axis is None:
-            weights_sum = full((), size(a), dtype=avg.dtype)
-        else:
-            weights_sum = full_like(avg, a.shape[axis], dtype=avg.dtype)
+  if weights is None: # Treat all weights as 1
+    avg = mean(a, axis=axis)
+    if axis is None:
+      weights_sum = full((), size(a), dtype=avg.dtype)
     else:
-        weights = asarray(weights)
+      weights_sum = full_like(avg, a.shape[axis], dtype=avg.dtype)
+  else:
+    weights = asarray(weights)
 
-        if issubdtype(a.dtype, integer) or issubdtype(a.dtype, bool_):
-            out_dtype = dtypes.canonicalize_dtype(result_type(a.dtype,
-                                                                  weights.dtype,
-                                                                  floating))
-        else:
-            out_dtype = dtypes.canonicalize_dtype(result_type(a.dtype, weights.dtype))
+    if issubdtype(a.dtype, inexact):
+      out_dtype = result_type(a.dtype, weights.dtype)
+    else:
+      out_dtype = result_type(a.dtype, weights.dtype, float_)
+    out_dtype = dtypes.canonicalize_dtype(out_dtype)
 
-        a_shape = shape(a)
-        a_ndim = len(a_shape)
-        weights_shape = shape(weights)
-        axis = None if axis is None else _canonicalize_axis(axis, a_ndim)
+    a_shape = shape(a)
+    a_ndim = len(a_shape)
+    weights_shape = shape(weights)
+    axis = None if axis is None else _canonicalize_axis(axis, a_ndim)
 
-        if a_shape != weights_shape:
-            # Make sure the dimensions work out
-            if axis is None:
-                raise ValueError("Axis must be specified when shapes of a and "
-                                 "weights differ.")
-            if len(weights_shape) != 1:
-                raise ValueError("1D weights expected when shapes of a and "
-                                 "weights differ.")
-            if weights_shape[0] != a_shape[axis]:
-                raise ValueError("Length of weights not "
-                                 "compatible with specified axis.")
+    if a_shape != weights_shape:
+      # Make sure the dimensions work out
+      if axis is None:
+        raise ValueError("Axis must be specified when shapes of a and "
+                         "weights differ.")
+      if len(weights_shape) != 1:
+        raise ValueError("1D weights expected when shapes of a and "
+                         "weights differ.")
+      if weights_shape[0] != a_shape[axis]:
+        raise ValueError("Length of weights not "
+                         "compatible with specified axis.")
 
-            weights = broadcast_to(weights, (a_ndim - 1) * (1,) + weights_shape)
-            weights = moveaxis(weights, -1, axis)
+      weights = broadcast_to(weights, (a_ndim - 1) * (1,) + weights_shape)
+      weights = moveaxis(weights, -1, axis)
 
-        weights_sum = sum(weights, axis=axis, dtype=out_dtype)
-        avg = sum(multiply(a, weights), axis=axis, dtype=out_dtype) / weights_sum
+    weights_sum = sum(weights, axis=axis, dtype=out_dtype)
+    avg = sum(multiply(a, weights), axis=axis, dtype=out_dtype) / weights_sum
 
-    if returned:
-        if avg.shape != weights_sum.shape:
-            weights_sum = broadcast_to(weights_sum, avg.shape)
-        return avg, weights_sum
-    return avg
+  if returned:
+    if avg.shape != weights_sum.shape:
+      weights_sum = broadcast_to(weights_sum, avg.shape)
+    return avg, weights_sum
+  return avg
 
 
 @_wraps(onp.var)
@@ -1661,7 +1660,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     if object:
       out = stack([array(elt, dtype=dtype) for elt in object])
     else:
-      out = onp.array([], dtype)
+      out = onp.array([], dtype or float_)
   else:
     try:
       view = memoryview(object)
@@ -1798,7 +1797,8 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
   lax._check_user_dtype_supported(dtype, "linspace")
   if num < 0:
     raise ValueError("Number of samples, %s, must be non-negative." % num)
-  dtype = dtype or result_type(start, stop, float(num))
+  dt = result_type(start, stop, float(num))
+  dtype = dtype or dt
   bounds_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
   broadcast_start = broadcast_to(start, bounds_shape)
   axis = len(bounds_shape) + axis + 1 if axis < 0 else axis
@@ -1807,9 +1807,9 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
   iota_shape[axis] = num
   div = (num - 1) if endpoint else num
   if num > 1:
-    delta = (stop - start) / div
+    delta = lax.convert_element_type(stop - start, dt) / div
     out = (reshape(broadcast_start, bounds_shape) +
-           reshape(lax.iota(dtype, num), iota_shape) *
+           reshape(lax.iota(dt, num), iota_shape) *
            reshape(delta, bounds_shape))
   elif num == 1:
     delta = nan
@@ -1818,7 +1818,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
     empty_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
     empty_shape.insert(axis, 0)
     delta = nan
-    out = reshape(array([]), empty_shape).astype(dtype)
+    out = reshape(array([], dtype=dt), empty_shape)
   if retstep:
     return lax.convert_element_type(out, dtype), delta
   else:
@@ -3050,8 +3050,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
   if m.ndim > 2:
     raise ValueError("m has more than 2 dimensions")  # same as numpy error
-  X = array(m, ndmin=2, dtype=dtypes.canonicalize_dtype(
-    result_type(m, onp.float64)), copy=False)
+  X = array(m, ndmin=2, dtype=dtypes.canonicalize_dtype(result_type(m, float_)))
   if not rowvar and X.shape[0] != 1:
     X = X.T
   if X.shape[0] == 0:

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -250,8 +250,8 @@ def device_under_test():
 
 def supported_dtypes():
   if device_under_test() == "tpu":
-    return {onp.bool_, onp.int32, onp.int64, onp.uint32, onp.uint64,
-            dtypes.bfloat16, onp.float32, onp.complex64}
+    return {onp.bool_, onp.int32, onp.uint32, dtypes.bfloat16, onp.float32,
+            onp.complex64}
   else:
     return {onp.bool_, onp.int8, onp.int16, onp.int32, onp.int64,
             onp.uint8, onp.uint16, onp.uint32, onp.uint64,
@@ -441,7 +441,9 @@ def rand_some_inf():
 
     if dtypes.issubdtype(dtype, onp.complexfloating):
       base_dtype = onp.real(onp.array(0, dtype=dtype)).dtype
-      return rand(shape, base_dtype) + 1j * rand(shape, base_dtype)
+      out = (rand(shape, base_dtype) +
+             onp.array(1j, dtype) * rand(shape, base_dtype))
+      return _cast_to_shape(out, shape, dtype)
 
     dims = _dims_of_shape(shape)
     posinf_flips = rng.rand(*dims) < 0.1
@@ -464,7 +466,9 @@ def rand_some_nan():
     """The random sampler function."""
     if dtypes.issubdtype(dtype, onp.complexfloating):
       base_dtype = onp.real(onp.array(0, dtype=dtype)).dtype
-      return rand(shape, base_dtype) + 1j * rand(shape, base_dtype)
+      out = (rand(shape, base_dtype) +
+             onp.array(1j, dtype) * rand(shape, base_dtype))
+      return _cast_to_shape(out, shape, dtype)
 
     if not dtypes.issubdtype(dtype, onp.floating):
       # only float types have inf
@@ -497,7 +501,9 @@ def rand_some_inf_and_nan():
 
     if dtypes.issubdtype(dtype, onp.complexfloating):
       base_dtype = onp.real(onp.array(0, dtype=dtype)).dtype
-      return rand(shape, base_dtype) + 1j * rand(shape, base_dtype)
+      out = (rand(shape, base_dtype) +
+             onp.array(1j, dtype) * rand(shape, base_dtype))
+      return _cast_to_shape(out, shape, dtype)
 
     dims = _dims_of_shape(shape)
     posinf_flips = rng.rand(*dims) < 0.1

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -56,9 +56,12 @@ def num_float_bits(dtype):
 
 float_dtypes = list(jtu.supported_dtypes().intersection(
   {dtypes.bfloat16, onp.float16, onp.float32, onp.float64}))
-complex_dtypes = [onp.complex64, onp.complex128]
+complex_elem_dtypes = list(jtu.supported_dtypes().intersection(
+    {onp.float32, onp.float64}))
+complex_dtypes = list(jtu.supported_dtypes().intersection(
+    {onp.complex64, onp.complex128}))
 inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [onp.int32, onp.int64]
+int_dtypes = list(jtu.supported_dtypes().intersection({onp.int32, onp.int64}))
 bool_dtypes = [onp.bool_]
 default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
@@ -124,8 +127,8 @@ LAX_OPS = [
 
     op_record("real", 1, complex_dtypes, jtu.rand_default),
     op_record("imag", 1, complex_dtypes, jtu.rand_default),
-    op_record("complex", 2, [onp.float32, onp.float64], jtu.rand_default),
-    op_record("conj", 1, [onp.float32, onp.float64] + complex_dtypes,
+    op_record("complex", 2, complex_elem_dtypes, jtu.rand_default),
+    op_record("conj", 1, complex_elem_dtypes + complex_dtypes,
               jtu.rand_default),
     op_record("abs", 1, default_dtypes + complex_dtypes, jtu.rand_default),
     op_record("pow", 2, float_dtypes + complex_dtypes, jtu.rand_positive),
@@ -1599,93 +1602,99 @@ def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
   return GradTestSpec(
       op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
+grad_float_dtypes = list(jtu.supported_dtypes().intersection(
+  {onp.float32, onp.float64}))
+grad_complex_dtypes = list(jtu.supported_dtypes().intersection(
+  {onp.complex64, onp.complex128}))
+grad_inexact_dtypes = grad_float_dtypes + grad_complex_dtypes
+
 LAX_GRAD_OPS = [
     grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.floor, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.ceil, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.round, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
 
     grad_test_spec(lax.exp, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.expm1, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.log, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.log1p, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.sinh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64], tol=1e-5),
+                   dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.cosh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64], tol=1e-5),
+                   dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.tanh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64], tol=1e-5),
+                   dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.sin, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.cos, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.tan, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
-                   dtypes=[onp.float64, onp.complex64], tol=1e-3),
+                   dtypes=grad_inexact_dtypes, tol=1e-3),
     grad_test_spec(lax.asin, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
-                   dtypes=[onp.float64], tol=1e-3),
+                   dtypes=grad_float_dtypes, tol=1e-3),
     grad_test_spec(lax.acos, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, -1.3, 1.3),
-                   dtypes=[onp.float64], tol=1e-3),
+                   dtypes=grad_float_dtypes, tol=1e-3),
     # TODO(proteneer): atan2 input is already a representation of a
     # complex number. Need to think harder about what this even means
     # if each input itself is a complex number.
     grad_test_spec(lax.atan2, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
 
     grad_test_spec(lax.erf, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.erfc, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.erf_inv, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     # grad_test_spec(lax.lgamma, nargs=1, order=2, rng_factory=jtu.rand_small,
-    #                dtypes=[onp.float64]),  # TODO(mattjj): enable
+    #                dtypes=grad_float_dtypes),  # TODO(mattjj): enable
     grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
 
     grad_test_spec(lax.real, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.complex64]),
+                   dtypes=grad_complex_dtypes),
     grad_test_spec(lax.imag, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.complex64]),
+                   dtypes=grad_complex_dtypes),
     grad_test_spec(lax.complex, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float32]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.conj, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float32, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.abs, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.pow, nargs=2, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
 
     grad_test_spec(lax.add, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.sub, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.mul, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.div, nargs=2, order=1, rng_factory=jtu.rand_not_small,
-                   dtypes=[onp.float64, onp.complex64]),
+                   dtypes=grad_inexact_dtypes),
 
     grad_test_spec(lax.max, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     grad_test_spec(lax.min, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=[onp.float64]),
+                   dtypes=grad_float_dtypes),
     # TODO(mattjj): make some-equal checks more robust, enable second-order
     # grad_test_spec(lax.max, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=[onp.float64], name="MaxSomeEqual"),
+    #                dtypes=grad_float_dtypes, name="MaxSomeEqual"),
     # grad_test_spec(lax.min, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=[onp.float64], name="MinSomeEqual"),
+    #                dtypes=grad_float_dtypes, name="MinSomeEqual"),
 ]
 
 GradSpecialValuesTestSpec = collections.namedtuple(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1627,7 +1627,7 @@ LAX_GRAD_OPS = [
     grad_test_spec(lax.log1p, nargs=1, order=2, rng_factory=jtu.rand_positive,
                    dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.sinh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes, tol=1e-5),
+                   dtypes=grad_float_dtypes + [onp.complex64], tol=1e-5),
     grad_test_spec(lax.cosh, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.tanh, nargs=1, order=2, rng_factory=jtu.rand_default,


### PR DESCRIPTION
* Specify exactly which types to test in lax_test.py, rather than relying on non-x64 mode to squash unsupported types.
* Fix some excessive promotions in jax.numpy.
* Fix some buggy RNGs that returned the wrong type for complex inputs.