### PR TITLE
Prepare to switch default dtypes in JAX to be 32-bit types.

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -59,16 +59,12 @@ class _bfloat16_finfo(object):
   tiny = bfloat16(float.fromhex("0x1p-126"))
 
 # Default types.
-
+# Unlike classic NumPy, we use 32-bit default types. The goal is to be more
+# friendly to modern accelerator hardware.
 bool_ = onp.bool_
-int_ = onp.int64
-float_ = onp.float64
-complex_ = onp.complex128
-
-# TODO(phawkins): change the above defaults to:
-# int_ = onp.int32
-# float_ = onp.float32
-# complex_ = onp.complex64
+int_ = onp.int32
+float_ = onp.float32
+complex_ = onp.complex64
 
 
 _dtype_to_32bit_dtype = {

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -59,12 +59,16 @@ class _bfloat16_finfo(object):
   tiny = bfloat16(float.fromhex("0x1p-126"))
 
 # Default types.
-# Unlike classic NumPy, we use 32-bit default types. The goal is to be more
-# friendly to modern accelerator hardware.
+
 bool_ = onp.bool_
-int_ = onp.int32
-float_ = onp.float32
-complex_ = onp.complex64
+int_ = onp.int64
+float_ = onp.float64
+complex_ = onp.complex128
+
+# TODO(phawkins): change the above defaults to:
+# int_ = onp.int32
+# float_ = onp.float32
+# complex_ = onp.complex64
 
 
 _dtype_to_32bit_dtype = {

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -350,6 +350,11 @@ def convert_element_type(operand, new_dtype):
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
+  # Avoids dropping precision by casting Python scalars to the default Jax
+  # type. If we passed a Python scalar directly to the bind call below, it is
+  # cast to the default type as part of the calling convention.
+  if type(operand) in dtypes.python_scalar_dtypes:
+    operand = onp.asarray(operand, new_dtype)
   old_dtype = dtypes.canonicalize_dtype(_dtype(operand))
   if old_dtype == new_dtype:
     return operand

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -988,8 +988,9 @@ def select(condlist, choicelist, default=0):
     raise ValueError(msg.format(len(condlist), len(choicelist)))
   if len(condlist) == 0:
     raise ValueError("condlist must be non-empty")
-
-  output = default
+  choices = _promote_dtypes(default, *choicelist)
+  choicelist = choices[1:]
+  output = choices[0]
   for cond, choice in zip(condlist[::-1], choicelist[::-1]):
     output = where(cond, choice, output)
   return output

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -602,7 +602,7 @@ class JaxTestCase(parameterized.TestCase):
 
   def assertDtypesMatch(self, x, y):
     if FLAGS.jax_enable_x64:
-      self.assertEqual(onp.asarray(x).dtype, onp.asarray(y).dtype)
+      self.assertEqual(_dtype(x), _dtype(y))
 
   def assertAllClose(self, x, y, check_dtypes, atol=None, rtol=None):
     """Assert that x and y, either arrays or nested tuples/lists, are close."""
@@ -618,9 +618,11 @@ class JaxTestCase(parameterized.TestCase):
         self.assertAllClose(x_elt, y_elt, check_dtypes, atol=atol, rtol=rtol)
     elif hasattr(x, '__array__') or onp.isscalar(x):
       self.assertTrue(hasattr(y, '__array__') or onp.isscalar(y))
+      if check_dtypes:
+        self.assertDtypesMatch(x, y)
       x = onp.asarray(x)
       y = onp.asarray(y)
-      self.assertArraysAllClose(x, y, check_dtypes, atol=atol, rtol=rtol)
+      self.assertArraysAllClose(x, y, check_dtypes=False, atol=atol, rtol=rtol)
     elif x == y:
       return
     else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -447,7 +447,7 @@ class APITest(jtu.JaxTestCase):
   def test_grad_and_aux_basic(self):
     g, aux = grad(lambda x: (x**3, [x**2]), has_aux=True)(3.)
     self.assertAllClose(g, grad(lambda x: x**3)(3.), check_dtypes=True)
-    self.assertAllClose(aux, [9.], check_dtypes=True)
+    self.assertAllClose(aux, [9.], check_dtypes=False)
 
   def test_grad_and_aux_nested(self):
     def f(x):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -173,7 +173,7 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("conjugate", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("deg2rad", 1, float_dtypes, all_shapes, jtu.rand_default, []),
     op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"],
-              inexact=True),
+              inexact=six.PY3),
     op_record("divmod", 2, int_dtypes + float_dtypes, all_shapes,
               jtu.rand_nonzero, []),
     op_record("exp2", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -86,13 +86,13 @@ def _shape_and_dtypes(shapes, dtypes):
 OpRecord = collections.namedtuple(
   "OpRecord",
   ["name", "nargs", "dtypes", "shapes", "rng_factory", "diff_modes",
-   "test_name", "check_dtypes", "tolerance"])
+   "test_name", "check_dtypes", "tolerance", "inexact"])
 
 def op_record(name, nargs, dtypes, shapes, rng_factory, diff_modes,
-              test_name=None, check_dtypes=True, tolerance=None):
+              test_name=None, check_dtypes=True, tolerance=None, inexact=False):
   test_name = test_name or name
   return OpRecord(name, nargs, dtypes, shapes, rng_factory, diff_modes,
-                  test_name, check_dtypes, tolerance)
+                  test_name, check_dtypes, tolerance, inexact)
 
 JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("abs", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
@@ -100,7 +100,8 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default, []),
     op_record("conj", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("exp", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("exp", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
     op_record("fabs", 1, float_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("float_power", 2, inexact_dtypes, all_shapes,
               partial(jtu.rand_default, scale=1), ["rev"],
@@ -112,7 +113,8 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("greater_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
     op_record("less", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
     op_record("less_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("log", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("log", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
     op_record("logical_and", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
     op_record("logical_not", 1, all_dtypes, all_shapes, jtu.rand_bool, []),
     op_record("logical_or", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
@@ -127,51 +129,68 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("subtract", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("signbit", 1, default_dtypes + bool_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"]),
-    op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("cos", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
+    op_record("cos", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
     op_record("tan", 1, number_dtypes, all_shapes,
-              partial(jtu.rand_uniform, -1.5, 1.5), ["rev"]),
-    op_record("sinh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("cosh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+              partial(jtu.rand_uniform, -1.5, 1.5), ["rev"], inexact=True),
+    op_record("sinh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
+    op_record("cosh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
     op_record("tanh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
-              tolerance={onp.float64: 1e-7, onp.complex128: 1e-7}),
-    op_record("arcsin", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
-    op_record("arccos", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
-    op_record("arctan", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
-    op_record("arctan2", 2, float_dtypes, all_shapes, jtu.rand_small, ["rev"]),
-    op_record("arcsinh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
-    op_record("arccosh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
-    op_record("arctanh", 1, number_dtypes, all_shapes, jtu.rand_small, ["rev"]),
+              tolerance={onp.float64: 1e-7, onp.complex128: 1e-7},
+              inexact=True),
+    op_record("arcsin", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+              inexact=True),
+    op_record("arccos", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+              inexact=True),
+    op_record("arctan", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+              inexact=True),
+    op_record("arctan2", 2, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+              inexact=True),
+    op_record("arcsinh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
+    op_record("arccosh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
+    op_record("arctanh", 1, number_dtypes, all_shapes, jtu.rand_small, ["rev"],
+              inexact=True),
 ]
 
 JAX_COMPOUND_OP_RECORDS = [
     # angle has inconsistent 32/64-bit return types across numpy versions.
     op_record("angle", 1, number_dtypes, all_shapes, jtu.rand_default, [],
-              check_dtypes=False),
+              check_dtypes=False, inexact=True),
     op_record("atleast_1d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
     op_record("atleast_2d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
     op_record("atleast_3d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("cbrt", 1, default_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("cbrt", 1, default_dtypes, all_shapes, jtu.rand_default, ["rev"],
+              inexact=True),
     op_record("conjugate", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("deg2rad", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
+    op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"],
+              inexact=True),
     op_record("divmod", 2, int_dtypes + float_dtypes, all_shapes,
               jtu.rand_nonzero, []),
     op_record("exp2", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
-              tolerance={lnp.bfloat16: 2e-2, onp.float16: 1e-2}),
+              tolerance={lnp.bfloat16: 2e-2, onp.float16: 1e-2}, inexact=True),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
-              test_name="expm1_large", tolerance={onp.float64: 1e-8}),
+              test_name="expm1_large", tolerance={onp.float64: 1e-8}, inexact=True),
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive,
-              [], tolerance={onp.float64: 1e-8}),
+              [], tolerance={onp.float64: 1e-8}, inexact=True),
     op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
-    op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero,
+              ["rev"]),
+    op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default, [],
+              inexact=True),
+    op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default, [],
+              inexact=True),
     op_record("kron", 2, number_dtypes, nonempty_shapes, jtu.rand_default, []),
     op_record("outer", 2, number_dtypes, all_shapes, jtu.rand_default, []),
     op_record("imag", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
@@ -183,18 +202,21 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("isposinf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
     op_record("isreal", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
     op_record("isrealobj", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("log2", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
-    op_record("log10", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("log2", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
+    op_record("log10", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
     op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
-              test_name="log1p_large", tolerance={onp.float64: 1e-12}),
+              test_name="log1p_large", tolerance={onp.float64: 1e-12},
+              inexact=True),
     op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_small_positive, [],
-              tolerance={onp.float64: 1e-12}),
+              tolerance={onp.float64: 1e-12}, inexact=True),
     op_record("logaddexp", 2, float_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"],
-              tolerance={onp.float64: 1e-12}),
+              tolerance={onp.float64: 1e-12}, inexact=True),
     op_record("logaddexp2", 2, float_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"],
-              tolerance={onp.float16: 1e-2}),
+              tolerance={onp.float16: 1e-2}, inexact=True),
     op_record("polyval", 2, number_dtypes, nonempty_nonscalar_array_shapes,
               jtu.rand_default, [], check_dtypes=False,
               tolerance={onp.float16: 1e-2, onp.float64: 1e-12}),
@@ -209,12 +231,15 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
     op_record("sinc", 1, [t for t in number_dtypes if t != lnp.bfloat16],
               all_shapes, jtu.rand_default, ["rev"],
-              tolerance={onp.complex64: 1e-5}, check_dtypes=False),
+              tolerance={onp.complex64: 1e-5}, inexact=True,
+              check_dtypes=False),
     op_record("square", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"]),
+    op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+              inexact=True),
     op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"],
               check_dtypes=False),
-    op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero, ["rev"]),
+    op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero,
+              ["rev"], inexact=True),
     op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
 ]
 
@@ -230,10 +255,12 @@ JAX_BITWISE_OP_RECORDS = [
 ]
 
 JAX_REDUCER_RECORDS = [
-    op_record("mean", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("mean", 1, number_dtypes, nonempty_shapes, jtu.rand_default, [],
+              inexact=True),
     op_record("prod", 1, all_dtypes, all_shapes, jtu.rand_small_positive, []),
     op_record("sum", 1, all_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan,
+              [], inexact=True),
     op_record("nanprod", 1, inexact_dtypes, all_shapes, jtu.rand_some_nan, []),
     op_record("nansum", 1, number_dtypes, all_shapes, jtu.rand_some_nan, []),
 ]
@@ -243,8 +270,10 @@ JAX_REDUCER_NO_DTYPE_RECORDS = [
     op_record("any", 1, all_dtypes, all_shapes, jtu.rand_some_zero, []),
     op_record("max", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
     op_record("min", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
-    op_record("var", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
-    op_record("std", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("var", 1, all_dtypes, nonempty_shapes, jtu.rand_default, [],
+              inexact=True),
+    op_record("std", 1, all_dtypes, nonempty_shapes, jtu.rand_default, [],
+              inexact=True),
 ]
 
 JAX_ARGMINMAX_RECORDS = [
@@ -268,7 +297,8 @@ JAX_OPERATOR_OVERLOADS = [
     op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
     op_record("__floordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
+              inexact=True),
     op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
     # TODO(mattjj): __invert__ fails on bool dtypes because ~True == -2
     op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default, []),
@@ -289,7 +319,8 @@ JAX_RIGHT_OPERATOR_OVERLOADS = [
     op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
     op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
+              inexact=True),
     # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
     # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
     # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
@@ -348,7 +379,7 @@ def _shapes_are_equal_length(shapes):
   return all(len(shape) == len(shapes[0]) for shape in shapes[1:])
 
 
-def _promote_like_lnp(fun):
+def _promote_like_lnp(fun, inexact=False):
   """Decorator that promotes the arguments of `fun` to `lnp.result_type(*args)`.
 
   lnp and onp have different type promotion semantics; this decorator allows
@@ -356,17 +387,22 @@ def _promote_like_lnp(fun):
   implementation.
   """
   def wrapper(*args, **kw):
-    dtype = lnp.result_type(*tree_util.tree_leaves(args))
+    dtypes = [lnp.result_type(x) for x in tree_util.tree_leaves(args)]
+    if inexact and not any(lnp.issubdtype(dtype, lnp.inexact) for dtype in dtypes):
+      dtypes.append(lnp.float_)
+    dtype = lnp.result_type(*dtypes)
     args = tree_util.tree_map(lambda a: onp.asarray(a, dtype), args)
     return fun(*args, **kw)
   return wrapper
+
 
 class LaxBackedNumpyTests(jtu.JaxTestCase):
   """Tests for LAX-backed Numpy implementation."""
 
   def _GetArgsMaker(self, rng, shapes, dtypes, onp_arrays=True):
     def f():
-      out = [rng(shape, dtype) for shape, dtype in zip(shapes, dtypes)]
+      out = [rng(shape, dtype or lnp.float_)
+             for shape, dtype in zip(shapes, dtypes)]
       return out if onp_arrays else [lnp.asarray(a) for a in out]
     return f
 
@@ -376,7 +412,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                                                       dtypes),
          "rng_factory": rec.rng_factory, "shapes": shapes, "dtypes": dtypes,
          "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
-         "check_dtypes": rec.check_dtypes, "tolerance": rec.tolerance}
+         "check_dtypes": rec.check_dtypes, "tolerance": rec.tolerance,
+         "inexact": rec.inexact}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           CombosWithReplacement(rec.shapes, rec.nargs))
@@ -385,14 +422,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for rec in itertools.chain(JAX_ONE_TO_ONE_OP_RECORDS,
                                  JAX_COMPOUND_OP_RECORDS)))
   def testOp(self, onp_op, lnp_op, rng_factory, shapes, dtypes, check_dtypes,
-             tolerance):
+             tolerance, inexact):
     rng = rng_factory()
     args_maker = self._GetArgsMaker(rng, shapes, dtypes, onp_arrays=False)
     tol = max(jtu.tolerance(dtype, tolerance) for dtype in dtypes)
     tol = functools.reduce(jtu.join_tolerance,
                            [tolerance, tol, jtu.default_tolerance()])
-    self._CheckAgainstNumpy(_promote_like_lnp(onp_op), lnp_op, args_maker,
-                            check_dtypes=check_dtypes, tol=tol)
+    self._CheckAgainstNumpy(_promote_like_lnp(onp_op, inexact), lnp_op,
+                            args_maker, check_dtypes=check_dtypes, tol=tol)
     self._CompileAndCheck(lnp_op, args_maker, check_dtypes=check_dtypes,
                           atol=tol, rtol=tol)
 
@@ -481,18 +518,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
             "None" if out_dtype is None else onp.dtype(out_dtype).name, keepdims),
          "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
          "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
-         "axis": axis, "keepdims": keepdims}
+         "axis": axis, "keepdims": keepdims, "inexact": rec.inexact}
         for shape in rec.shapes for dtype in rec.dtypes
         for out_dtype in [None] + rec.dtypes
         for axis in set(range(-len(shape), len(shape))) | set([None])
         for keepdims in [False, True])
     for rec in JAX_REDUCER_RECORDS))
-  def testReducer(self, onp_op, lnp_op, rng_factory, shape, dtype, out_dtype, axis, keepdims):
+  def testReducer(self, onp_op, lnp_op, rng_factory, shape, dtype, out_dtype,
+                  axis, keepdims, inexact):
     rng = rng_factory()
     def onp_fun(x):
       x_cast = x if dtype != lnp.bfloat16 else x.astype(onp.float32)
       t = out_dtype if out_dtype != lnp.bfloat16 else onp.float32
       return onp_op(x_cast, axis, dtype=t, keepdims=keepdims)
+    onp_fun = _promote_like_lnp(onp_fun, inexact)
     lnp_fun = lambda x: lnp_op(x, axis, dtype=out_dtype, keepdims=keepdims)
     args_maker = lambda: [rng(shape, dtype)]
     tol_spec = {onp.float16: 1e-2, onp.float32: 1e-3, onp.complex64: 1e-3,
@@ -511,14 +550,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis, keepdims),
        "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype,
        "onp_op": getattr(onp, rec.name), "lnp_op": getattr(lnp, rec.name),
-       "axis": axis, "keepdims": keepdims}
+       "axis": axis, "keepdims": keepdims, "inexact": rec.inexact}
       for rec in JAX_REDUCER_NO_DTYPE_RECORDS
       for shape in rec.shapes for dtype in rec.dtypes
       for axis in set(range(-len(shape), len(shape))) | set([None])
       for keepdims in [False, True]))
-  def testReducerNoDtype(self, onp_op, lnp_op, rng_factory, shape, dtype, axis, keepdims):
+  def testReducerNoDtype(self, onp_op, lnp_op, rng_factory, shape, dtype, axis,
+                         keepdims, inexact):
     rng = rng_factory()
     onp_fun = lambda x: onp_op(x, axis, keepdims=keepdims)
+    onp_fun = _promote_like_lnp(onp_fun, inexact)
     lnp_fun = lambda x: lnp_op(x, axis, keepdims=keepdims)
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
@@ -535,7 +576,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     onp_fun = lambda x: onp.count_nonzero(x, axis)
     lnp_fun = lambda x: lnp.count_nonzero(x, axis)
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -911,6 +952,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testRepeat(self, axis, shape, dtype, repeats, rng_factory):
     rng = rng_factory()
     onp_fun = lambda arg: onp.repeat(arg, repeats=repeats, axis=axis)
+    onp_fun = _promote_like_lnp(onp_fun)
     lnp_fun = lambda arg: lnp.repeat(arg, repeats=repeats, axis=axis)
 
     args_maker = lambda: [rng(shape, dtype)]
@@ -1322,7 +1364,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       onp_fun = lambda x, weights: onp.average(x, axis, weights, returned)
       lnp_fun = lambda x, weights: lnp.average(x, axis, weights, returned)
       args_maker = lambda: [rng(shape, dtype), rng(weights_shape, dtype)]
-
+    onp_fun = _promote_like_lnp(onp_fun, inexact=True)
     tol = {lnp.bfloat16: 1e-1, onp.float16: 1e-1, onp.float32: 1e-3,
            onp.float64: 1e-10, onp.complex64: 1e-3, onp.complex128: 1e-10}
     check_dtypes = shape is not jtu.PYTHON_SCALAR_SHAPE
@@ -1343,9 +1385,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ([1, 2, 3], lnp.int_),
           ([1., 2., 3.], lnp.float_),
           ([[1, 2], [3, 4], [5, 6]], lnp.int_),
-          ([[1, 2.], [3, 4], [5, 6]], lnp.float64),
+          ([[1, 2.], [3, 4], [5, 6]], lnp.float_),
           ([[1., 2j], [3., 4.], [5., 6.]], lnp.complex_),
-          ([[3, onp.array(2), 1], onp.arange(3.)], onp.float_),
+          ([[3, onp.array(2, dtype=lnp.float_), 1],
+           onp.arange(3., dtype=lnp.float_)], lnp.float_),
       ])
       for ndmin in [None, onp.ndim(arg), onp.ndim(arg) + 1, onp.ndim(arg) + 2]))
   def testArray(self, arg, ndmin, dtype):
@@ -1890,7 +1933,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         onp.asarray(default, dtype=dtype))
     self._CheckAgainstNumpy(onp_fun, lnp.select, args_maker,
                             check_dtypes=False)
-    self._CompileAndCheck(lnp.select, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp.select, args_maker, check_dtypes=True,
+                          rtol={onp.float64: 1e-7, onp.complex128: 1e-7})
 
 
   def testIssue330(self):
@@ -1966,7 +2010,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # self.assertAllClose(lnp.arange(2, 13, dtype=int),
     #                     onp.arange(2, 13, dtype=int), check_dtypes=True)
     self.assertAllClose(lnp.arange(0, 1, -0.5),
-                        onp.arange(0, 1, -0.5), check_dtypes=True)
+                        onp.arange(0, 1, -0.5, dtype=lnp.float_),
+                        check_dtypes=True)
 
     self.assertRaises(TypeError, lambda: lnp.arange())
 
@@ -2115,7 +2160,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     tol = 7e-2 if jtu.device_under_test() == "tpu" else tol
     tol = jtu.join_tolerance(tol, jtu.tolerance(dtype))
     self._CheckAgainstNumpy(
-        onp_fun, lnp_fun, args_maker, check_dtypes=True, tol=tol)
+        onp_fun, lnp_fun, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True, atol=tol,
                           rtol=tol)
 
@@ -2142,7 +2187,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     lnp_fun = partial(lnp.corrcoef, rowvar=rowvar, ddof=ddof, bias=bias)
     if not onp.any(onp.isclose(onp.std(mat), 0.0)):
       self._CheckAgainstNumpy(
-          onp_fun, lnp_fun, args_maker, check_dtypes=True,
+          onp_fun, lnp_fun, args_maker, check_dtypes=False,
           tol=1e-2 if jtu.device_under_test() == "tpu" else None)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
@@ -2164,21 +2209,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     onp_fun = partial(onp.meshgrid, indexing=indexing, sparse=sparse)
     lnp_fun = partial(lnp.meshgrid, indexing=indexing, sparse=sparse)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
-
-  def assertDowncastDtypeEqual(self, x, y):
-    """Heuristic for comparing numpy and jax downcast dtypes."""
-    x_dt = jtu._dtype(x)
-    y_dt = jtu._dtype(y)
-    testing_tpu = jtu.device_under_test().startswith("tpu")
-    testing_x32 = not jax.config.read('jax_enable_x64')
-    to32dtype = {onp.int64: onp.int32, onp.uint64: onp.uint32,
-                 onp.float64: onp.float32, onp.float128: onp.float32,
-                 onp.complex128: onp.complex64, onp.complex256: onp.complex64}
-    to32dtype = {onp.dtype(k): onp.dtype(v) for k,v in to32dtype.items()}
-    if testing_tpu or testing_x32:
-      x_dt = to32dtype.get(x_dt, x_dt)
-      y_dt = to32dtype.get(y_dt, y_dt)
-    assert x_dt == y_dt, "truncated dtypes %s != %s" % (x_dt, y_dt)
 
   @parameterized.named_parameters(
       jtu.cases_from_list(
@@ -2214,13 +2244,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         endpoint=endpoint, retstep=retstep, dtype=dtype, axis=axis)
       self._CheckAgainstNumpy(onp_op, lnp_op, args_maker,
                               check_dtypes=False, tol=tol)
-      # Check dtype equivalence within expected 32bit downcasting.
-      a, b = lnp_op(start, stop), onp_op(start, stop)
-      if retstep:
-        self.assertDowncastDtypeEqual(a[0], b[0])
-        self.assertDowncastDtypeEqual(a[1], b[1])
-      else:
-        self.assertDowncastDtypeEqual(a, b)
       # floating-point compute between jitted platforms and non-jit + rounding
       # cause unavoidable variation in integer truncation for some inputs.
       if dtype in (inexact_dtypes + [None,]):
@@ -2267,9 +2290,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         start, stop, num, endpoint=endpoint, base=base, dtype=dtype, axis=axis)
       self._CheckAgainstNumpy(onp_op, lnp_op, args_maker,
                               check_dtypes=False, tol=tol)
-      # Check dtype equivalence within expected 32bit downcasting.
-      a, b = lnp_op(start, stop), onp_op(start, stop)
-      self.assertDowncastDtypeEqual(a, b)
       if dtype in (inexact_dtypes + [None,]):
         # Why do compiled and op-by-op float16 np.power numbers differ
         # slightly more than expected?
@@ -2327,9 +2347,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis=axis).astype(dtype)
       self._CheckAgainstNumpy(onp_op, lnp_op, args_maker,
                               check_dtypes=False, tol=tol)
-      # Check dtype equivalence within expected 32bit downcasting.
-      a, b = lnp_op(start, stop), onp_op(start, stop)
-      self.assertDowncastDtypeEqual(a, b)
       if dtype in (inexact_dtypes + [None,]):
         self._CompileAndCheck(lnp_op, args_maker,
                               check_dtypes=False, atol=tol, rtol=tol)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -387,10 +387,12 @@ def _promote_like_lnp(fun, inexact=False):
   implementation.
   """
   def wrapper(*args, **kw):
-    dtypes = [lnp.result_type(x) for x in tree_util.tree_leaves(args)]
-    if inexact and not any(lnp.issubdtype(dtype, lnp.inexact) for dtype in dtypes):
-      dtypes.append(lnp.float_)
-    dtype = lnp.result_type(*dtypes)
+    flat_args = tree_util.tree_leaves(args)
+    if inexact and not any(lnp.issubdtype(lnp.result_type(x), lnp.inexact)
+                           for x in flat_args):
+      dtype = lnp.result_type(lnp.float_, *flat_args)
+    else:
+      dtype = lnp.result_type(*flat_args)
     args = tree_util.tree_map(lambda a: onp.asarray(a, dtype), args)
     return fun(*args, **kw)
   return wrapper

--- a/tests/loops_test.py
+++ b/tests/loops_test.py
@@ -64,7 +64,8 @@ class LoopsTest(jtu.JaxTestCase):
     self.assertAllClose(5., api.grad(f_op)(2.), check_dtypes=True)
     self.assertAllClose(5., api.grad(f_op)(2.), check_dtypes=True)
     inc_batch = onp.arange(5, dtype=onp.float32)
-    self.assertAllClose(np.array([f_expected(inc) for inc in inc_batch]),
+    self.assertAllClose(np.array([f_expected(inc) for inc in inc_batch],
+                                 dtype=onp.float32),
                         api.vmap(f_op)(inc_batch), check_dtypes=True)
 
 
@@ -143,7 +144,7 @@ class LoopsTest(jtu.JaxTestCase):
   def test_example_doc(self):
     "The example from the module docstring."
     def f_expected():
-      arr = onp.zeros(5)
+      arr = onp.zeros(5, dtype=np.float_)
       for i in range(arr.shape[0]):
         arr[i] += 2.
         if i % 2 == 0:
@@ -151,7 +152,7 @@ class LoopsTest(jtu.JaxTestCase):
       return arr
 
     def f_op_jax():
-      arr = onp.zeros(5)
+      arr = np.zeros(5)
       def loop_body(i, acc_arr):
         arr1 = ops.index_update(acc_arr, i, acc_arr[i] + 2.)
         return lax.cond(i % 2 == 0,
@@ -380,8 +381,9 @@ class LoopsTest(jtu.JaxTestCase):
     self.assertAllClose(f_expected(2.), f_op(2.), check_dtypes=True)
     self.assertAllClose(f_expected(2.), api.jit(f_op)(2.), check_dtypes=True)
     self.assertAllClose(f_expected(1.), f_op(1.), check_dtypes=True)
-    init_batch = np.array([1., 2., 3.])
-    self.assertAllClose(np.array([f_expected(init) for init in init_batch]),
+    init_batch = onp.array([1., 2., 3.], dtype=onp.float32)
+    self.assertAllClose(onp.array([f_expected(init) for init in init_batch],
+                                  dtype=onp.float32),
                         api.vmap(f_op)(init_batch), check_dtypes=True)
 
   def test_error_while_cond_mutation(self):

--- a/tests/loops_test.py
+++ b/tests/loops_test.py
@@ -63,9 +63,9 @@ class LoopsTest(jtu.JaxTestCase):
     self.assertAllClose(f_expected(2.), api.jit(f_op)(2.), check_dtypes=True)
     self.assertAllClose(5., api.grad(f_op)(2.), check_dtypes=True)
     self.assertAllClose(5., api.grad(f_op)(2.), check_dtypes=True)
-    inc_batch = onp.arange(5, dtype=onp.float32)
+    inc_batch = onp.arange(5, dtype=np.float_)
     self.assertAllClose(np.array([f_expected(inc) for inc in inc_batch],
-                                 dtype=onp.float32),
+                                 dtype=np.float_),
                         api.vmap(f_op)(inc_batch), check_dtypes=True)
 
 


### PR DESCRIPTION
This PR prepares for switching the default types in JAX's NumPy to be 32-bit types. In particular, it makes the JAX tests pass in the event that `jax.numpy.int_`, `jax.numpy.float_`, and `jax.numpy.complex_` are defined to be 32-bit types instead of 64-bit types, but does not yet change the defaults.