### PR TITLE
Support IntEnum values as arguments to JAX functions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - conda config --add channels conda-forge
   - conda update -q conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip six protobuf>=3.6.0 absl-py opt_einsum numpy scipy pytest-xdist fastcache
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip six protobuf>=3.6.0 absl-py opt_einsum numpy scipy pytest-xdist pytest-benchmark fastcache
   # The jaxlib version should match the minimum jaxlib version in
   # jax/lib/__init__.py. This tests JAX PRs against the oldest permitted
   # jaxlib.

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -73,7 +73,8 @@ Running the tests
 =================
 
 To run all the JAX tests, we recommend using ``pytest-xdist``, which can run tests in
-parallel. First, install ``pytest-xdist`` by running ``pip install pytest-xdist``.
+parallel. First, install ``pytest-xdist`` and ``pytest-benchmark`` by running
+``pip install pytest-xdist pytest-benchmark``.
 Then, from the repository root directory run
 
 .. code-block:: shell

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -240,10 +240,6 @@ def raise_to_shaped(aval):
 
 core.literalable_types.update(array_types)
 
-def make_abstract_python_scalar(x):
-  return ShapedArray((), dtypes.python_scalar_dtypes[type(x)],
-                     weak_type=True)
-
 def _zeros_like_python_scalar(x):
   return onp.array(0, dtypes.python_scalar_dtypes[type(x)])
 

--- a/tests/benchmarks/xla.py
+++ b/tests/benchmarks/xla.py
@@ -1,0 +1,48 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest
+import numpy as np
+import six
+
+import jax
+from jax import numpy as jnp
+from jax.interpreters import xla
+
+
+_abstractify_args = [
+  3,
+  3.5,
+  np.int32(3),
+  np.uint32(7),
+  np.random.randn(3, 4, 5, 6),
+  np.arange(100, dtype=np.float32),
+  jnp.int64(-3),
+  jnp.array([1, 2, 3])
+]
+
+if six.PY3:
+  import enum
+  class AnEnum(enum.IntEnum):
+    A = 123
+    B = 456
+  _abstractify_args.append(AnEnum.B)
+
+@pytest.mark.parametrize("arg", _abstractify_args)
+def test_abstractify(benchmark, arg):
+  benchmark(xla.abstractify, arg)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -18,6 +18,12 @@ from __future__ import print_function
 
 import itertools
 import operator
+import unittest
+
+import six
+
+if six.PY3:
+  import enum
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -132,6 +138,16 @@ class DtypesTest(jtu.JaxTestCase):
           self.assertEqual(onp.promote_types(t1, t2),
                            dtypes.promote_types(t1, t2))
 
+
+  @unittest.skipIf(six.PY2, "Test requires Python 3")
+  def testEnumPromotion(self):
+    class AnEnum(enum.IntEnum):
+      A = 42
+      B = 101
+    onp.testing.assert_equal(onp.array(42), onp.array(AnEnum.A))
+    onp.testing.assert_equal(np.array(42), np.array(AnEnum.A))
+    onp.testing.assert_equal(onp.int32(101), onp.int32(AnEnum.B))
+    onp.testing.assert_equal(np.int32(101), np.int32(AnEnum.B))
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
When abstractifying a Python value, search the method-resolution order (MRO) of the type rather than only looking at the value's own type. IntEnum instances are subclasses of int, so this allows us to correctly handle them as integers, much as NumPy itself does.