### PR TITLE
Update jax_to_hlo .bzl file to use exec_tools instead of tools.

### DIFF
--- a/jax/tools/build_defs.bzl
+++ b/jax/tools/build_defs.bzl
@@ -153,7 +153,7 @@ EOF
     native.genrule(
         name = name + "_jax_to_hlo_genrule",
         outs = [name + ".pb", name + ".txt"],
-        tools = [runner],
+        exec_tools = [runner],
         cmd = """
         JAX_PLATFORM_NAME=cpu \
         '$(location {runner})' \


### PR DESCRIPTION
Fixes a Python 3 compatibility problem.