### PR TITLE
Implement __round__ on JAX arrays.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3238,9 +3238,7 @@ def _unimplemented_setitem(self, i, x):
 def _operator_round(number, ndigits=None):
   out = round(number, decimals=ndigits or 0)
   # If `ndigits` is None, for a builtin float round(7.5) returns an integer.
-  if ndigits is None:
-    out = out.astype(int_)
-  return out
+  return out.astype(int_) if ndigits is None else out
 
 _operators = {
     "getitem": _rewriting_take,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3235,6 +3235,13 @@ def _unimplemented_setitem(self, i, x):
          "jax.ops.index_add instead?")
   raise TypeError(msg.format(type(self)))
 
+def _operator_round(number, ndigits=None):
+  out = round(number, decimals=ndigits or 0)
+  # If `ndigits` is None, for a builtin float round(7.5) returns an integer.
+  if ndigits is None:
+    out = out.astype(int_)
+  return out
+
 _operators = {
     "getitem": _rewriting_take,
     "setitem": _unimplemented_setitem,
@@ -3276,6 +3283,7 @@ _operators = {
     "invert": bitwise_not,
     "lshift": left_shift,
     "rshift": right_shift,
+    "round": _operator_round,
 }
 
 # These numpy.ndarray methods are just refs to an equivalent numpy function

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -828,6 +828,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=check_dtypes,
                           atol=tol, rtol=tol)
 
+  def testOperatorRound(self):
+    self.assertAllClose(round(onp.float32(7.532), 1),
+                        round(lnp.float32(7.5), 1), check_dtypes=True)
+    self.assertAllClose(round(onp.float32(1.234), 2),
+                        round(lnp.float32(1.234), 2), check_dtypes=True)
+    self.assertAllClose(round(onp.float32(1.234)),
+                        round(lnp.float32(1.234)), check_dtypes=False)
+    self.assertAllClose(round(onp.float32(7.532), 1),
+                        round(lnp.array(7.5, lnp.float32), 1), check_dtypes=True)
+    self.assertAllClose(round(onp.float32(1.234), 2),
+                        round(lnp.array(1.234, lnp.float32), 2), check_dtypes=True)
+    self.assertAllClose(round(onp.float32(1.234)),
+                        round(lnp.array(1.234, lnp.float32)),
+                        check_dtypes=False)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_mode={}_rpadwidth={}_rconstantvalues={}".format(
           jtu.format_shape_dtype_string(shape, dtype), mode, pad_width_rank,


### PR DESCRIPTION
Avoids breakage from https://github.com/google/jax/pull/1836