### PR TITLE
Make pmap properly replicate closed-over constants.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   # The jaxlib version should match the minimum jaxlib version in
   # jax/lib/__init__.py. This tests JAX PRs against the oldest permitted
   # jaxlib.
-  - pip install jaxlib==0.1.36
+  - pip install jaxlib==0.1.37
   - pip install -v .
   # The following are needed to test the Colab notebooks and the documentation building
   - if [[ "$JAX_ONLY_DOCUMENTATION" != "" ]]; then

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -443,6 +443,12 @@ def parallel_callable(fun, backend, axis_name, axis_size, devices, *avals):
               "Compiling {} for {} devices with args {}.".format(
                   fun.__name__, global_axis_size, avals))
 
+  if devices:
+    local_devices = [d for d in devices if d.host_id == xb.host_id()]
+    assert len(local_devices) > 0
+  else:
+    local_devices = None
+
   @lu.wrap_init
   def dynamic_fun(dummy, *args):
     with extend_dynamic_axis_env(axis_name, dummy.trace, global_axis_size):
@@ -476,7 +482,9 @@ def parallel_callable(fun, backend, axis_name, axis_size, devices, *avals):
     # XLA computation at all; we handle this as a special case so we can stage
     # out multi-replica XLA computations regardless of the hardware available.
     # The 'None' values here are just dummies we know will be ignored.
-    handlers = [_pval_to_result_handler(axis_size, None, pval) for pval in out_pvals]
+    handlers = [_pval_to_result_handler(axis_size, None, pval, local_devices,
+                                        backend)
+                for pval in out_pvals]
     results = [handler(None) for handler in handlers]
     return lambda *_: results
 
@@ -500,9 +508,6 @@ def parallel_callable(fun, backend, axis_name, axis_size, devices, *avals):
       raise ValueError(msg.format(num_global_replicas, xb.device_count(backend)))
     device_assignment = None
   else:
-    assert any(d.host_id == xb.host_id() for d in devices)
-    local_devices = [d for d in devices if d.host_id == xb.host_id()]
-    assert len(local_devices) > 0
     if num_local_replicas != len(local_devices):
       local_devices_str = ", ".join(map(str, local_devices))
       raise ValueError(
@@ -522,7 +527,9 @@ def parallel_callable(fun, backend, axis_name, axis_size, devices, *avals):
   handle_args = partial(shard_args, backend, compiled.local_devices(),
                         assign_shards_to_replicas(num_local_replicas, axis_size),
                         axis_size, tuple_args)
-  handle_outs = _pvals_to_results_handler(axis_size, num_local_replicas, out_pvals)
+  handle_outs = _pvals_to_results_handler(axis_size, num_local_replicas,
+                                          out_pvals, compiled.local_devices(),
+                                          backend)
   return partial(execute_replicated, compiled, backend, num_local_replicas, handle_args, handle_outs)
 
 multi_host_supported_collectives = set()
@@ -530,9 +537,10 @@ multi_host_supported_collectives = set()
 class ResultToPopulate(object): pass
 result_to_populate = ResultToPopulate()
 
-def _pvals_to_results_handler(size, nrep, out_pvals):
+def _pvals_to_results_handler(size, nrep, out_pvals, devices, backend):
   nouts = len(out_pvals)
-  handlers = [_pval_to_result_handler(size, nrep, pval) for pval in out_pvals]
+  handlers = [_pval_to_result_handler(size, nrep, pval, devices, backend)
+              for pval in out_pvals]
   def handler(out_bufs):
     buffers = [[result_to_populate] * nrep for _ in range(nouts)]
     for r, tuple_buf in enumerate(out_bufs):
@@ -543,13 +551,65 @@ def _pvals_to_results_handler(size, nrep, out_pvals):
     return [h(bufs) for h, bufs in zip(handlers, buffers)]
   return handler
 
-def _pval_to_result_handler(size, nrep, pval):
+def replicate(val, axis_size, nrep, devices=None, backend=None):
+  """Replicates ``val`` across multiple devices.
+
+  Args:
+    val: the value to be replicated.
+    axis_size: the length of the output, i.e. the logical number of replicas to
+    create. Usually equal to `nrep`, but in the case of nested pmaps, `nrep` may
+    be a multiple of `axis_size`.
+    nrep: the number of replicas to create. If ``devices`` is set, must be equal
+      to ``len(devices)``.
+    devices: the devices to replicate across. If None, ``nrep`` will be used to
+      generate a default device assignment.
+    backend: string specifying which backend to use.
+
+  Returns:
+    A ShardedDeviceArray of length `axis_size` where each shard is equal to
+    ``val``.
+  """
+  device_count = (len(devices) if devices else xb.local_device_count())
+  if nrep > device_count:
+    msg = ("Cannot replicate across %d replicas because only %d local devices "
+           "are available." % (nrep, device_count))
+    if devices:
+      msg += (" (local devices = %s)"
+              % ", ".join(map(str, devices)) if devices else str(None))
+    raise ValueError(msg)
+
+  if devices is None:
+    assert nrep is not None
+    devices = xb.get_backend(backend).get_default_device_assignment(nrep)
+  assert nrep == len(devices)
+
+  aval = xla.abstractify(val)
+  aval = ShapedArray((axis_size,) + aval.shape, aval.dtype)
+  device_buffers = [xla.device_put(val, d) for d in devices]
+  return ShardedDeviceArray(aval, device_buffers)
+
+def _pval_to_result_handler(axis_size, nrep, pval, devices, backend):
+  if devices:
+    assert all(d.host_id == xb.host_id(backend) for d in devices)
   pv, const = pval
   if pv is None:
-    bcast_const = core.unit if const is core.unit else broadcast(const, size, 0)
+    if nrep is None:
+      nrep = axis_size
+      # If 'const' is a ShardedDeviceArray, it must have come from a pmap nested
+      # inside the one we're currently evaluating, and we should replicate
+      # 'const' across the total number of devices needed. We don't necessarily
+      # know the nested pmap's axis_size (e.g. the jaxpr for
+      # pmap(pmap(lambda x: 3)) is trivial, with no pmaps), but we can use the
+      # axis size of the output 'const'.
+      # TODO: we might be doing unnecessary device transfers in the inner pmap.
+      if isinstance(const, ShardedDeviceArray):
+        nrep *= len(const)
+
+    bcast_const = (core.unit if const is core.unit
+                   else replicate(const, axis_size, nrep, devices, backend))
     return lambda _: bcast_const
   else:
-    return aval_to_result_handler(size, nrep, pv)
+    return aval_to_result_handler(axis_size, nrep, pv)
 
 def execute_replicated(compiled, backend, nrep, in_handler, out_handler, *args):
   if nrep > xb.device_count(backend):

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -17,7 +17,7 @@
 
 import jaxlib
 
-_minimum_jaxlib_version = (0, 1, 36)
+_minimum_jaxlib_version = (0, 1, 37)
 try:
   from jaxlib import version as jaxlib_version
 except:


### PR DESCRIPTION
With this change, a value `x` can be replicated `nrep` times as follows:

```python
pmap(lambda _: x)(np.arange(nrep))
```

This will broadcast `x` into a ShardedDeviceArray suitable for passing into another pmap with the same input shape.

If `x` will be passed into a pmap with `devices` or a nested pmap, the replication pmap(s) should follow that structure. For example:

```python
# Replicates x across 8 devices.
x = pmap(pmap(lambda _: x))(np.ones(2, 4))

# x is already copied to the appropriate devices.
pmap(pmap(lambda i: i**2 + x))(np.ones(2, 4))
```
