### PR TITLE
make nested jit stage out full inner jit bodies

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -228,9 +228,9 @@ def zeros_like_shaped_array(aval):
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
-def raise_to_shaped(aval):
+def raise_to_shaped(aval, weak_type=False):
   if isinstance(aval, ShapedArray):
-    return ShapedArray(aval.shape, aval.dtype)
+    return ShapedArray(aval.shape, aval.dtype, weak_type=weak_type)
   elif aval is core.abstract_unit:
     return core.abstract_unit
   elif aval is abstract_token:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -89,7 +89,7 @@ class JaxprTrace(Trace):
     if isinstance(pv, AbstractValue):
       return tracer
     elif pv is None:
-      aval = raise_to_shaped(get_aval(const))
+      aval = raise_to_shaped(get_aval(const), onp.isscalar(const))
       return JaxprTracer(self, PartialVal((aval, unit)), ConstVar(const))
     else:
       raise TypeError(pv)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -419,7 +419,7 @@ def _xla_call_impl(fun, *args, **params):
 @lu.cache
 def _xla_callable(fun, device, backend, *abstract_args):
   pvals = [pe.PartialVal((aval, core.unit)) for aval in abstract_args]
-  with core.new_master(pe.JaxprTrace, True) as master:
+  with core.new_master(pe.StagingJaxprTrace, True) as master:
     jaxpr, (pvals, consts, env) = pe.trace_to_subjaxpr(fun, master, False).call_wrapped(pvals)
     assert not env  # no subtraces here
     del master, env


### PR DESCRIPTION
Before this change, inner jitted functions wouldn't necessarily be fully staged out into an outer-jit trace; instead, as much as possible would be hoisted out of the inner jit. That led to extra constants getting materialized in #1640.

For example:

```python
@jit
def f(x, y):
    z = 2 * x
    return y + z

@jit
def g(x):
    return f(2, x)

g(3)
```

would lead to these **two** XLA computations being compiled and executed:

```
HloModule jit_f.7

ENTRY jit_f.7 {
  parameter.2 = () parameter(1)
  tuple.3 = () tuple()
  parameter.1 = s32[] parameter(0)
  constant.4 = s32[] constant(2)
  multiply.5 = s32[] multiply(parameter.1, constant.4)
  ROOT tuple.6 = ((), s32[]) tuple(tuple.3, multiply.5)
}
```
```
HloModule jit_g.14

jaxpr_subcomputation.4 {
  parameter.6 = () parameter(1)
  tuple.8 = () tuple()
  parameter.7 = s32[] parameter(2)
  parameter.5 = s32[] parameter(0)
  add.9 = s32[] add(parameter.7, parameter.5)
  ROOT tuple.10 = (s32[]) tuple(add.9)
}

ENTRY jit_g.14 {
  constant.1 = s32[] constant(4)
  tuple.3 = () tuple()
  parameter.2 = s32[] parameter(0)
  call.11 = (s32[]) call(constant.1, tuple.3, parameter.2), to_apply=jaxpr_subcomputation.4
  get-tuple-element.12 = s32[] get-tuple-element(call.11), index=0
  ROOT tuple.13 = (s32[]) tuple(get-tuple-element.12)
}
```

Notice that the `multiply` is separated out from the `add`, and in particular the XLA computation underlying `g` only has the `add` in it.

This behavior was desirable when using partial evaluation for reverse-mode autodiff, since in that case we want to partially evaluate all the primal values underneath a call while staging out a jaxpr for the tangent values. But it was undesirable for the other use of partial evaluation, namely forming jaxprs under `jit` (and `pmap`).

The solution was just to tag jaxpr traces differently in the two cases.

After this PR, we instead get only this computation compiled and/or executed:

```
HloModule jit_g.15

jaxpr_subcomputation.4 {
  tuple.7 = () tuple()
  parameter.6 = s32[] parameter(1)
  parameter.5 = s32[] parameter(0)
  constant.8 = s32[] constant(2)
  multiply.9 = s32[] multiply(parameter.5, constant.8)
  add.10 = s32[] add(parameter.6, multiply.9)
  ROOT tuple.11 = (s32[]) tuple(add.10)
}

ENTRY jit_g.15 {
  tuple.3 = () tuple()
  constant.1 = s32[] constant(2)
  parameter.2 = s32[] parameter(0)
  call.12 = (s32[]) call(constant.1, parameter.2), to_apply=jaxpr_subcomputation.4
  get-tuple-element.13 = s32[] get-tuple-element(call.12), index=0
  ROOT tuple.14 = (s32[]) tuple(get-tuple-element.13)
}
```

(This relies on #1818 as well.)