### PR TITLE
Support transforms along arbitrary axes with jax.numpy.fft

### DIFF
--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -61,10 +61,12 @@ def _fft_core(func_name, fft_type, a, s, axes, norm):
         "%s does not support repeated axes. Got axes %s." % (full_name, axes))
 
   if len(axes) > 3:
+    # XLA does not support FFTs over more than 3 dimensions
     raise ValueError(
         "%s only supports 1D, 2D, and 3D FFTs. "
         "Got axes %s with input rank %s." % (full_name, orig_axes, a.ndim))
 
+  # XLA only supports FFTs over the innermost axes, so rearrange if necessary.
   if orig_axes is not None:
     axes = tuple(range(a.ndim - len(axes), a.ndim))
     a = np.moveaxis(a, orig_axes, axes)

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -94,7 +94,8 @@ class FftTest(jtu.JaxTestCase):
     func = np.fft.ifftn if inverse else np.fft.fftn
     self.assertRaisesRegex(
         ValueError,
-        "jax.np.fft.{} only supports 1D, 2D, and 3D FFTs".format(name),
+        "jax.np.fft.{} only supports 1D, 2D, and 3D FFTs. "
+        "Got axes None with input rank 4.".format(name),
         lambda: func(rng([2, 3, 4, 5], dtype=onp.float64), axes=None))
     self.assertRaisesRegex(
         ValueError,

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import itertools
 import unittest
 
 import numpy as onp
@@ -44,9 +45,12 @@ def _get_fftn_test_axes(shape):
   axes = [[]]
   ndims = len(shape)
   # XLA's FFT op only supports up to 3 innermost dimensions.
-  if ndims <= 3: axes.append(None)
+  if ndims <= 3:
+    axes.append(None)
   for naxes in range(1, min(ndims, 3) + 1):
-    axes.append(range(ndims - naxes, ndims))
+    axes.extend(itertools.combinations(range(ndims), naxes))
+  for index in range(1, ndims + 1):
+    axes.append((-index,))
   return axes
 
 
@@ -90,20 +94,16 @@ class FftTest(jtu.JaxTestCase):
     func = np.fft.ifftn if inverse else np.fft.fftn
     self.assertRaisesRegex(
         ValueError,
-        "jax.np.fft.{} only supports 1D, 2D, and 3D FFTs over the innermost axes. "
-        "Got axes None with input rank 4.".format(name),
+        "jax.np.fft.{} only supports 1D, 2D, and 3D FFTs".format(name),
         lambda: func(rng([2, 3, 4, 5], dtype=onp.float64), axes=None))
-    self.assertRaisesRegex(
-        ValueError,
-        "jax.np.fft.{} only supports 1D, 2D, and 3D FFTs over the innermost axes. "
-        "Got axes \\[0\\] with input rank 4.".format(name),
-        lambda: func(rng([2, 3, 4, 5], dtype=onp.float64), axes=[0]))
     self.assertRaisesRegex(
         ValueError,
         "jax.np.fft.{} does not support repeated axes. Got axes \\[1, 1\\].".format(name),
         lambda: func(rng([2, 3], dtype=onp.float64), axes=[1, 1]))
     self.assertRaises(
-        IndexError, lambda: func(rng([2, 3], dtype=onp.float64), axes=[2]))
+        ValueError, lambda: func(rng([2, 3], dtype=onp.float64), axes=[2]))
+    self.assertRaises(
+        ValueError, lambda: func(rng([2, 3], dtype=onp.float64), axes=[-3]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes GH-1878

The logic that attempted to check for transformations along non-innermost axes
was broken.

Rather than fixing it, this PR adds support for these transformations by
transposing and untransposing arrays. This adds some overhead over the LAX
implementation, but it suspect it is minimal in most cases and it should be
worthwhile for the sake of completeness.