### PR TITLE
iterate on computation-follows-data policy

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -360,7 +360,7 @@ class ShardedDeviceArray(ShardedDeviceValue, xla.DeviceArray):
       ids = self._ids()
       device_buffer = self.device_buffers[ids[idx]]
       aval = ShapedArray(self.aval.shape[1:], self.aval.dtype)
-      handler = xla.aval_to_result_handler(aval)
+      handler = xla.aval_to_result_handler(None, aval)
       return handler(device_buffer)
     else:
       return super(ShardedDeviceArray, self).__getitem__(idx)

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -79,8 +79,7 @@ class FftTest(jtu.JaxTestCase):
     self._CompileAndCheck(np_fn, args_maker, check_dtypes=True)
     # Test gradient for differentiable types.
     if dtype in inexact_dtypes:
-      # TODO(skye): can we be more precise?
-      tol = 1e-1
+      tol = 0.15  # TODO(skye): can we be more precise?
       jtu.check_grads(np_fn, args_maker(), order=1, atol=tol, rtol=tol)
       jtu.check_grads(np_fn, args_maker(), order=2, atol=tol, rtol=tol)
 

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -62,30 +62,77 @@ class MultiDeviceTest(jtu.JaxTestCase):
     if len(jax.devices()) < 2:
       raise SkipTest("test requires multiple devices")
 
+    # computation follows data explicitly placed on device 1
+    x = jax.device_put(1, jax.devices()[1])
+    y = x.reshape((1, 1))
+    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
+    z = y.reshape((1, 1))
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+
+    # multiple arguments explicitly placed on device 0 are compatible
     x = jax.device_put(1, jax.devices()[0])
     y = jax.device_put(2, jax.devices()[0])
     z = x + y
     self.assertEqual(z, 3)
     self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+    w = z + x
+    self.assertEqual(w.device_buffer.device(), jax.devices()[0])
 
+    f = jax.jit(lambda x: x + 1, device=jax.devices()[0])
+    z = f(1) + f(2)
+    self.assertEqual(z, 5)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+    w = z + z
+    self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+
+    # multiple arguments explicitly placed on device 1 are compatible
     x = jax.device_put(1, jax.devices()[1])
     y = jax.device_put(2, jax.devices()[1])
     z = x + y
     self.assertEqual(z, 3)
     self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    w = z + x
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
 
-    x = jax.device_put(1, jax.devices()[1])
-    y = 4
-    z = x + y
+    f = jax.jit(lambda x: x + 1, device=jax.devices()[1])
+    z = f(1) + f(2)
     self.assertEqual(z, 5)
     self.assertEqual(z.device_buffer.device(), jax.devices()[1])
-
-    x = jax.device_put(1, jax.devices()[1])
-    y = np.ones(3)
-    z = x + y
-    self.assertAllClose(z, 1 + onp.ones(3), check_dtypes=False)
+    w = z + z
     self.assertEqual(z.device_buffer.device(), jax.devices()[1])
 
+    # an argument explicitly placed on one device still works with values that
+    # aren't device-committed (and computaiton follows device-committed values)
+    z = jax.device_put(1., jax.devices()[1]) + 4
+    self.assertEqual(z, 5.)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    w = z + 3
+    self.assertEqual(w, 8.)
+    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+
+    z = jax.device_put(1., jax.devices()[1]) + np.ones(3)
+    self.assertAllClose(z, 1 + onp.ones(3), check_dtypes=False)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    w = z - 3
+    self.assertAllClose(w, 1 + onp.ones(3) - 3, check_dtypes=False)
+    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+
+    z = jax.device_put(1., jax.devices()[1]) + np.array([1, 2])
+    self.assertAllClose(z, 1 + onp.array([1, 2]), check_dtypes=False)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    w = z * 2
+    self.assertAllClose(w, (1 + onp.array([1, 2])) * 2, check_dtypes=False)
+    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+
+    z = jax.device_put(1., jax.devices()[1]) + jax.device_put(2)
+    self.assertAllClose(z, 3., check_dtypes=False)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+
+    z = jax.device_put(1., jax.devices()[1]) + jax.jit(lambda x: x + 1)(3)
+    self.assertAllClose(z, 5., check_dtypes=False)
+    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+
+    # multiple arguments explicitly placed on distinct devices cause errors
     x = jax.device_put(1, jax.devices()[0])
     y = jax.device_put(2, jax.devices()[1])
     self.assertRaisesRegex(
@@ -93,9 +140,12 @@ class MultiDeviceTest(jtu.JaxTestCase):
         "primitive arguments must be colocated on the same device",
         lambda: x + y)
 
-    x = jax.device_put(1, jax.devices()[1])
-    y = x.reshape((1, 1))
-    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
+    f = jax.jit(lambda x: x + 1, device=jax.devices()[0])
+    g = jax.jit(lambda x: x + 1, device=jax.devices()[1])
+    self.assertRaisesRegex(
+        ValueError,
+        "primitive arguments must be colocated on the same device",
+        lambda: f(1) + g(2))
 
   def test_primitive_compilation_cache(self):
     if len(jax.devices()) < 2:

--- a/tests/multibackend_test.py
+++ b/tests/multibackend_test.py
@@ -123,6 +123,22 @@ class MultiBackendTest(jtu.JaxTestCase):
     self.assertEqual(z.device_buffer.platform(), backend)
     self.assertEqual(w.device_buffer.platform(), backend)
 
+  @jtu.skip_on_devices("cpu")  # test can only fail with non-cpu backends
+  def testJitCpu(self):
+    @partial(api.jit, backend='cpu')
+    def get_arr(scale):
+      return scale + np.ones((2, 2))
+
+    x = get_arr(0.1)
+
+    a = x / x.shape[0]
+    b = x + np.ones_like(x)
+    c = x + np.eye(2)
+
+    self.assertEqual(a.device_buffer.device(), api.devices('cpu')[0])
+    self.assertEqual(b.device_buffer.device(), api.devices('cpu')[0])
+    self.assertEqual(c.device_buffer.device(), api.devices('cpu')[0])
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
improve computation-follows-data policy from #1884, fix #1914 (see also discussion thread there)

The new policy is that JAX's `DeviceArrays`, which are backed by device memory but potentially on different devices (like distinct GPUs, or CPU and GPU), can either be "stuck" to their device or not (i.e. "sticky" or not). A `DeviceArray` result is stuck to its device if

1. it was produced by a computation with an explicit user-provided device or backend label, i.e. a `jit` or `device_put` with an explicit device or backend argument, or
2. it was produced by a computation that consumed as an argument a sticky DeviceArray value.

If a computation without an explicit device/backend label is applied to all non-sticky arguments, the result is non-sticky. If a computation without an explicit device/backend label is applied to any sticky arguments, then if all the sticky device labels agree the result is sticky on the same device, and otherwise an error is raised. (A computation with an explicit device/backend label can consume any sticky or non-sticky values without error, regardless of their devices.)

Implementation-wise, every `DeviceArray` has an attribute `_device` (introduced in #1884, revised here) that set either to a value that represents a `Device` instance (actually stored as a `Device` class / int id pair), indicating that the `DeviceArray` is sticky on that device, or `None` indicating that the `DeviceArray` is not sticky. The value of the _device attribute for results of a computation is computed when the XLA executable is compiled and stored in the result handler (which packages up a raw device buffer into a `DeviceArray`).

I consider this policy still in flux! I want to bounce it off the rest of the JAX team after the holiday break, and we'll probably keep iterating with @romanngg (and anyone else interested) to get the policy right.