### PR TITLE
Adding implementations for numpy alen, isscalar

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -624,6 +624,11 @@ def alen(a):
     return len(array(a, ndmin=1))
 
 
+@_wraps(onp.asscalar)
+def asscalar(a):
+  return a.item()
+
+
 @_wraps(onp.signbit)
 def signbit(x):
   x, = _promote_shapes("signbit", x)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -626,7 +626,10 @@ def alen(a):
 
 @_wraps(onp.asscalar)
 def asscalar(a):
-  return a.item()
+  if lax.prod(a.shape) > 1:
+    raise ValueError('can only convert an array of size 1 to a Python scalar')
+  zero_indices = (0,) * len(a.shape)
+  return a[zero_indices]
 
 
 @_wraps(onp.signbit)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -322,12 +322,12 @@ _numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$')
 
 def _wraps(fun, update_doc=True, lax_description=""):
   """Like functools.wraps but works with numpy.ufuncs.
-     It is important that when wrapping numpy functions the parameters names 
+     It is important that when wrapping numpy functions the parameters names
      in the original function and in the JAX version are the same
     Parameters:
       fun: The function being wrapped
       update_doc: whether to transform the numpy docstring to remove references of
-      parameters that are supported by the numpy version but not the JAX version. 
+      parameters that are supported by the numpy version but not the JAX version.
       If False, include the numpy docstring verbatim.
   """
   def wrap(op):
@@ -614,6 +614,14 @@ def log10(x):
 def exp2(x):
   x, = _promote_dtypes_inexact(x)
   return lax.exp(lax.mul(lax.log(_constant_like(x, 2)), x))
+
+
+@_wraps(onp.alen)
+def alen(a):
+  try:
+    return len(a)
+  except TypeError:
+    return len(array(a, ndmin=1))
 
 
 @_wraps(onp.signbit)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1029,8 +1029,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testALen(self, shape, dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)
-    self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=False)
+    self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1022,6 +1022,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       test_single(m_rect, args_maker, repeats, axis=1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_rank={}".format(rank), "rank": rank}
+      for rank in range(7))
+  def testALen(self, rank):
+    args_maker = lambda: []
+    self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), axis, out_dtype),
        "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1023,8 +1023,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}".format(shape, dtype),
-       "shape": shape, "dtype": default_dtypes,
-       "rng_factory": jtu.rand_default}
+       "shape": shape, "dtype": dtype, "rng_factory": jtu.rand_default}
       for shape in [(), (1), (2), (1, 10), (3, 4, 5)]
       for dtype in default_dtypes))
   def testALen(self, shape, dtype, rng_factory):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1024,7 +1024,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}".format(shape, dtype),
        "shape": shape, "dtype": dtype, "rng_factory": jtu.rand_default}
-      for shape in [(), (1,), (2), (1, 10), (3, 4, 5)]
+      for shape in [(), (1,), (2,), (1, 10), (3, 4, 5)]
       for dtype in default_dtypes))
   def testALen(self, shape, dtype, rng_factory):
     rng = rng_factory()

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1024,13 +1024,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}".format(shape, dtype),
        "shape": shape, "dtype": dtype, "rng_factory": jtu.rand_default}
-      for shape in [(), (1), (2), (1, 10), (3, 4, 5)]
+      for shape in [(), (1,), (2), (1, 10), (3, 4, 5)]
       for dtype in default_dtypes))
   def testALen(self, shape, dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=False)
-    self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=False)
+    self.assertAllClose(
+    self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1041,8 +1041,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = rng_factory()
     shape = (1, ) * ndim if ndim else ()
     args_maker = lambda: [rng(shape, dtype)]
+    # TODO(fedden): NumPy implementation returns a true Python scalar, whereas
+    #               the jax implementation returns a composite scalar type. The
+    #               jax implementation retains the original dtype, but the
+    #               numpy implementation will be a 64 byte int/float (if casted
+    #               to an array).`check_dtypes` is set to False to avoid it
+    #               throwing an error.
     self._CheckAgainstNumpy(
-      onp.asscalar, lnp.asscalar, args_maker, check_dtypes=True)
+      onp.asscalar, lnp.asscalar, args_maker, check_dtypes=False)
     self._CompileAndCheck(lnp.asscalar, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1022,10 +1022,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       test_single(m_rect, args_maker, repeats, axis=1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_rank={}".format(rank), "rank": rank}
-      for rank in range(7)))
-  def testALen(self, rank):
-    args_maker = lambda: []
+      {"testcase_name": "_shape={}_dtype={}".format(rank), "shape": shape,
+          "dtype": default_dtypes, "rng_factory": jtu.rand_default}
+      for shape in [(), (1), (2), (1, 10), (3, 4, 5)]))
+  def testALen(self, shape, dtype, rng_factory):
+    rng = rng_factory()
+    args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=True)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1023,7 +1023,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_rank={}".format(rank), "rank": rank}
-      for rank in range(7))
+      for rank in range(7)))
   def testALen(self, rank):
     args_maker = lambda: []
     self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1029,9 +1029,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testALen(self, shape, dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]
-    self.assertAllClose(
     self._CheckAgainstNumpy(onp.alen, lnp.alen, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp.alen, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_ndim={}_dtype={}".format(ndim, dtype), "ndim": ndim,
+       "dtype": dtype, "rng_factory": jtu.rand_default}
+      for ndim in range(7)
+      for dtype in default_dtypes))
+  def testAsScalar(self, ndim, dtype, rng_factory):
+    rng = rng_factory()
+    shape = (1, ) * ndim if ndim else ()
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(
+      onp.asscalar, lnp.asscalar, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lnp.asscalar, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1022,9 +1022,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       test_single(m_rect, args_maker, repeats, axis=1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_dtype={}".format(rank), "shape": shape,
-          "dtype": default_dtypes, "rng_factory": jtu.rand_default}
-      for shape in [(), (1), (2), (1, 10), (3, 4, 5)]))
+      {"testcase_name": "_shape={}_dtype={}".format(shape, dtype),
+       "shape": shape, "dtype": default_dtypes,
+       "rng_factory": jtu.rand_default}
+      for shape in [(), (1), (2), (1, 10), (3, 4, 5)]
+      for dtype in default_dtypes))
   def testALen(self, shape, dtype, rng_factory):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype)]


### PR DESCRIPTION
Hey folks,

I wanted to start getting familiar with this codebase and start contributing more regularly, as I think it's a fantastic project! 

Because of the above I have made a very simple PR to implement numpy alen, isscalar to understand the testing code that is used for jax a little better, aswell as to better understand both the repositories overall structure and the process used to contribute. [I found this op whilst looking at ops from this issue.](https://github.com/google/jax/issues/70#issuecomment-569535681)