### PR TITLE
Minor fix for compatibility with python>=3.7 and numpy>=1.18

### DIFF
--- a/jax/util.py
+++ b/jax/util.py
@@ -214,6 +214,10 @@ def get_module_functions(module):
   """
   module_fns = set()
   for key in dir(module):
+    # Omitting module level __getattr__, __dir__ which was added in Python 3.7
+    # https://www.python.org/dev/peps/pep-0562/
+    if key in ('__getattr__', '__dir__'):
+      continue
     attr = getattr(module, key)
     if isinstance(
         attr, (types.BuiltinFunctionType, types.FunctionType, onp.ufunc)):


### PR DESCRIPTION
Fixes #1912. Python 3.7 introduces module level [`__getattr__, __dir__`](https://www.python.org/dev/peps/pep-0562/) which is being utilized in numpy 1.18. This throws a `NotImplementedError` in `lax_numpy` since it is not overridden. An alternative to disregarding these functions in `get_module_functions` may be to filter for these after usage, but this seemed harmless. 

cc. @mattjj, @fehiepsi 