### PR TITLE
add faster reshape utility function

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -885,10 +885,18 @@ def reshape(a, newshape, order="C"):
   except AttributeError:
     return _reshape(a, newshape, order=order)
 
-def _reshape(a, newshape, order="C"):
-  dummy_val = onp.broadcast_to(0, shape(a))  # zero strides
-  computed_newshape = onp.reshape(dummy_val, newshape).shape
+def _compute_newshape(a, newshape):
+  """Fixes a -1 value in newshape, if present."""
+  # other errors, like having more than one -1, are caught downstream
+  newsize = _prod(newshape)
+  if newsize < 0:
+    fix = a.size // -newsize
+    return [d if d != -1 else fix for d in newshape]
+  else:
+    return newshape
 
+def _reshape(a, newshape, order="C"):
+  computed_newshape = _compute_newshape(a, newshape)
   if order == "C":
     return lax.reshape(a, computed_newshape, None)
   elif order == "F":


### PR DESCRIPTION
The old implementation was kind of weird, and relied on creating a dummy onp array (with stride tricks so memory wasn't wasted).

Here's the old way:

```python
def _compute_newshape(a, newshape):
  dummy = onp.broadcast_to(0, a.shape)
  return onp.reshape(dummy, newshape).shape
```

```
In [1]: import numpy as np

In [2]: x = np.ones((2, 2))

In [3]: %timeit _compute_newshape(x, (2, 1, 2))
4.77 µs ± 203 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: %timeit _compute_newshape(x, (2, -1, 2))
4.52 µs ± 14.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

Here's the new way:

```python
def _compute_newshape(a, newshape):
  newsize = prod(newshape)
  if newsize < 0:
    fix = a.size // -newsize
    return [d if d != -1 else fix for d in newshape]
  else:
    return newshape
```

```
In [1]: import numpy as np

In [2]: x = np.ones((2, 2))

In [3]: %timeit _compute_newshape(x, (2, 1, 2))
218 ns ± 0.866 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [4]: %timeit _compute_newshape(x, (2, -1, 2))
467 ns ± 2.45 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```