### PR TITLE
Don't serialize jaxpr equations into XLA metadata.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -300,7 +300,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
   _map(write, jaxpr.freevars, freevars)
   _map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    c.SetOpMetadata(xc.OpMetadata( op_type=eqn.primitive.name, op_name=str(eqn)))
+    c.SetOpMetadata(xc.OpMetadata(op_type=eqn.primitive.name))
     in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
       rule = backend_specific_translations[platform][eqn.primitive]


### PR DESCRIPTION
Equations can be quite large, e.g. if it's some kind of call primitive. This can result in using many GB of host memory just to create the HLO module.

Fixes at least part of #1911.