### PR TITLE
Fix bug with caching in presence of JVP and JIT

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -567,8 +567,9 @@ identity_p.def_custom_bind(lambda x: x)
 
 
 def apply_todos(todos, outs):
-  while todos:
-    outs = map(full_lower, todos.pop()(outs))
+  todos_list = list(todos)
+  while todos_list:
+    outs = map(full_lower, todos_list.pop()(outs))
   return outs
 
 @lu.transformation_with_aux
@@ -586,7 +587,7 @@ def process_env_traces(primitive, level, params_tuple, *args):
     outs = map(trace.full_raise, outs)
     outs, cur_todo = trace.post_process_call(primitive, outs, params)
     todo.append(cur_todo)
-  yield outs, todo
+  yield outs, tuple(todo)  # Ensure the aux output is immutable
 
 def call_bind(primitive, f, *args, **params):
   top_trace = find_top_trace(args)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -567,6 +567,21 @@ class APITest(jtu.JaxTestCase):
       # jaxpr2 = api.make_jaxpr(f2_vjp)(y)
       # assert len(jaxpr2.constvars) == 2
 
+  def test_jvp_jit_cached(self):
+    """Bug in caching in presence of JVP and JIT."""
+
+    def func(x):
+      def inner(y):
+        return y * x
+
+      # Must have two calls to the inner jit (the second one hits the cache)
+      res1 = api.jit(inner)(4.)
+      res2 = api.jit(inner)(5.)
+      return res1 + res2
+
+    self.assertAllClose((45., 9.), api.jvp(func, (5.,), (1.,)), check_dtypes=True)
+
+
   def test_complex_grad_raises_error(self):
     self.assertRaises(TypeError, lambda: grad(lambda x: np.sin(x))(1 + 2j))
 


### PR DESCRIPTION
The bug was that the auxiliary output of the process_env_traces
was mutated before the next cache hit, so the cache content changed.

Fixes: #1945