### PR TITLE
Added some more documentation to the linear_util module

### DIFF
--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 
 from .tree_util import (build_tree, tree_flatten, tree_unflatten,
                         treedef_is_leaf)
-from .linear_util import transformation_with_aux
+from . import linear_util as lu
 from .util import safe_map, unzip2, partial, curry
 
 map = safe_map
@@ -38,7 +38,7 @@ def get_name(fun): return getattr(fun, "__name__", "<unnamed function>")
 def get_module(fun): return getattr(fun, "__module__", "<unknown module>")
 def get_doc(fun): return getattr(fun, "__doc__", "")
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def flatten_fun(in_tree, *args_flat):
   py_args, py_kwargs = tree_unflatten(in_tree, args_flat)
   ans = yield py_args, py_kwargs
@@ -52,7 +52,7 @@ def apply_flat_fun(fun, io_tree, *py_args):
   ans = fun(*args)
   return tree_unflatten(out_tree, ans)
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def flatten_fun_nokwargs(in_tree, *args_flat):
   py_args = tree_unflatten(in_tree, args_flat)
   ans = yield py_args, {}
@@ -66,7 +66,7 @@ def apply_flat_fun_nokwargs(fun, io_tree, py_args):
   ans = fun(*args)
   return tree_unflatten(out_tree, ans)
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def flatten_fun_nokwargs2(in_tree, *args_flat):
   py_args = tree_unflatten(in_tree, args_flat)
   ans, aux = yield py_args, {}

--- a/jax/flatten_util.py
+++ b/jax/flatten_util.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 from .tree_util import tree_flatten, tree_unflatten
-from .linear_util import transformation_with_aux
+from . import linear_util as lu
 from .util import safe_zip
 
 import jax.numpy as np
@@ -36,7 +36,7 @@ def ravel_list(*lst):
   return np.concatenate([np.ravel(elt) for elt in lst]) if lst else np.array([])
 
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def ravel_fun(unravel_inputs, flat_in, **kwargs):
   pytree_args = unravel_inputs(flat_in)
   ans = yield pytree_args, {}

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -22,16 +22,15 @@ from . import partial_eval as pe
 from .. import core as core
 from ..core import Trace, Tracer, new_master, get_aval, call_p, Primitive, Literal
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
-                       zeros_like_p, zero, Zero)
+                       zeros_like_p, zero)
 from ..abstract_arrays import raise_to_shaped
-from ..util import unzip2, unzip3, safe_map, safe_zip, partial, split_list
-from ..tree_util import build_tree, register_pytree_node, tree_map
-from ..linear_util import (thunk, transformation, transformation_with_aux,
-                           wrap_init, hashable_partial)
+from ..util import unzip2, safe_map, safe_zip, partial, split_list
+from ..tree_util import register_pytree_node
+from .. import linear_util as lu
 from ..api_util import flatten_fun, flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten
 
-from six.moves import builtins, reduce
+from six.moves import reduce
 
 zip = safe_zip
 map = safe_map
@@ -45,7 +44,7 @@ def jvp(fun, has_aux=False, instantiate=True):
     fun, aux = jvp_subtrace_aux(fun)
     return jvpfun(fun, instantiate), aux
 
-@transformation
+@lu.transformation
 def jvpfun(instantiate, primals, tangents):
   with new_master(JVPTrace) as master:
     out_primals, out_tangents = yield (master, primals, tangents), {}
@@ -56,7 +55,7 @@ def jvpfun(instantiate, primals, tangents):
                   in zip(out_primals, out_tangents, instantiate)]
   yield out_primals, out_tangents
 
-@transformation
+@lu.transformation
 def jvp_subtrace(master, primals, tangents):
   trace = JVPTrace(master, core.cur_sublevel())
   for x in list(primals) + list(tangents):
@@ -69,7 +68,7 @@ def jvp_subtrace(master, primals, tangents):
   yield unzip2([(out_tracer.primal, out_tracer.tangent)
                 for out_tracer in out_tracers])
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def jvp_subtrace_aux(master, primals, tangents):
   trace = JVPTrace(master, core.cur_sublevel())
   for x in list(primals) + list(tangents):
@@ -230,7 +229,7 @@ def backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in):
 
 def _eval_subjaxpr_primals(prim, jaxpr, consts, freevar_vals, in_vals, params):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, in_vals))
-  fun = hashable_partial(wrap_init(_eval_primals), jaxpr)
+  fun = lu.hashable_partial(lu.wrap_init(_eval_primals), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   out_flat = prim.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
@@ -458,7 +457,7 @@ def defvjp_all(prim, custom_vjp):
       primals_out = [primals_out]
     out_avals = [raise_to_shaped(get_aval(x)) for x in primals_out]
     ct_pvals = [pe.PartialVal((aval, core.unit)) for aval in out_avals]
-    jaxpr, _, res = pe.trace_to_jaxpr(wrap_init(vjp_py), ct_pvals, instantiate=True)
+    jaxpr, _, res = pe.trace_to_jaxpr(lu.wrap_init(vjp_py), ct_pvals, instantiate=True)
     tangents_out = fun_lin_p.bind(*it.chain(res, tangents), trans_jaxpr=jaxpr,
                                   num_res=len(res), out_avals=out_avals)
     return primals_out + tangents_out
@@ -534,7 +533,7 @@ def instantiate_zeros_aval(aval, tangent):
   else:
     return tangent
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def traceable(num_primals, in_tree_def, *primals_and_tangents):
   new_primals  = primals_and_tangents[:num_primals]
   new_tangents = primals_and_tangents[num_primals:]
@@ -546,7 +545,7 @@ def traceable(num_primals, in_tree_def, *primals_and_tangents):
 
 def call_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
-  fun = hashable_partial(wrap_init(backward_pass), jaxpr)
+  fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   out_flat = primitive.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
@@ -555,7 +554,7 @@ primitive_transposes[pe.remat_call_p] = partial(call_transpose, pe.remat_call_p)
 
 def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
-  fun = hashable_partial(wrap_init(backward_pass), jaxpr)
+  fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   out_flat = primitive.bind(fun, *all_args, **params)
   freevar_cts, arg_cts = tree_unflatten(out_tree(), out_flat)
@@ -565,7 +564,7 @@ def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
 
 def jvp_jaxpr(jaxpr, nonzeros, instantiate):
   assert len(jaxpr.in_avals) == len(nonzeros)
-  f = wrap_init(core.jaxpr_as_fun(jaxpr))
+  f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
   f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate), nonzeros)
   tangent_avals = [aval for aval, nz in zip(jaxpr.in_avals, nonzeros) if nz]
   avals_in = list(it.chain(jaxpr.in_avals, tangent_avals))
@@ -575,7 +574,7 @@ def jvp_jaxpr(jaxpr, nonzeros, instantiate):
   jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, avals_in, avals_out)
   return jaxpr_out, out_nonzeros()
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def f_jvp_traceable(nonzeros, *primals_and_nztangents):
   num_primals = len(nonzeros)
   primals = list(primals_and_nztangents[:num_primals])

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -27,7 +27,6 @@ import numpy as onp
 from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ShapedArray, ConcreteArray, raise_to_shaped
-from ..linear_util import thunk, transformation, transformation_with_aux
 from ..util import unzip2, safe_zip, safe_map, toposort, partial, split_list
 from ..core import (Trace, Tracer, new_master, Jaxpr, Literal, get_aval,
                     AbstractValue, unit, unitvar, abstract_unit, Primitive,
@@ -237,7 +236,7 @@ def partial_eval(f, trace, pvs):
   return partial_eval_wrapper(f, tuple(pvs))
 
 
-@transformation_with_aux
+@lu.transformation_with_aux
 def partial_eval_wrapper(avals, *consts):
   py_args = (map(PartialVal, zip(avals, consts)),)
   jaxpr, (out_pvals, consts, env) = yield py_args, {}
@@ -336,7 +335,7 @@ def trace_to_jaxpr(fun, pvals, instantiate=False, stage_out_calls=False):
 
   return jaxpr, out_pvals, consts
 
-@transformation
+@lu.transformation
 def trace_to_subjaxpr(master, instantiate, pvals):
   assert all([isinstance(pv, PartialVal) for pv in pvals]), pvals
   trace = JaxprTrace(master, core.cur_sublevel())

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -13,56 +13,53 @@
 # limitations under the License.
 
 """
-Utilities for defining linear functions composed with transformations.
+Utilities for defining functions composed with transformations.
 
-"Linear" here is meant in the sense of linear types; that is, a linear function
-may be called at most once.
+For example,
 
-For example:
+   from jax import linear_util as lu
 
-from jax import linear_util as lu
+   wf = lu.wrap_init(f)  # Produce a WrappedFun for applying transformations on `f`
 
-# A transformation that scales its argument down and its result up.
-@lu.transformation
-def scale_transformer(scale, x):
-  ans = yield (x / scale,)
-  yield x * scale
-
-def f(x):
-  return x + 1
-
-g = lu.wrap_init(f)  # Wraps `f` as a `WrappedFun`.
-g = scale_transformer(g, 2.0)  # Scale inputs/outputs by 2.0
-g = scale_transformer(g, 0.7)  # Scale inputs/outputs further by 0.7.
-print(g.call_wrapped(3.))  # Call the transformed function.
-
-
-A `WrappedFun` object represents a function `f`, together with a
-sequence of nested transformations that are to be applied to the positional
+A `WrappedFun` object represents a function `f`, together with a sequence of
+nested transformations that are to be applied to the positional and keyword
 arguments at call time and function return values at return time.
+A transformation can take some static positional arguments that are given
+at the wrapping time, and may also return some auxiliary output:
+
+    wf, aux_out_thunk = trans1(wf, static_arg)
+
+We can call the transformed function. First, the transformation is applied
+to the dynamic args and keyword args to produce new dynamic and keyword args.
+Then the underlying function is called and the transformation is applied to
+the results.
+If there are multiple transformations, they form a stack. The arguments are
+transformed first with the last applied transformation; the results are
+transformed first with the first applied transformation.
+
+    res = wf.call_wrapped(dynamic_args, kwargs)
+    # Now `aux_out_thunk()` is the auxiliary output.
+
+A transformation is written as a generator function that takes zero or more
+static positional arguments (given when the transformation is instantiated),
+along with positional and keyword arguments to be transformed.
+The generator will yield twice:
+
+    @lu.transformation_with_aux
+    def trans1(static_arg, *dynamic_args, **kwargs):
+      ...
+      # First yield: pair of transformed (args, kwargs). Get back the results.
+      results = yield (new_dynamic_args, new_kwargs)
+      ...
+      # Second yield: pair of (transformed results, and auxiliary output)
+      yield new_results, auxiliary_output
+
+
 `WrappedFun` objects explicitly represent the set of transformations so that
 they can be used as dictionary keys for memoization. `WrappedFun` objects
-compare as equal only if they compute the same function.
-
-Transformations are implemented as generators to save call stack frames.
-A transformation's generator takes arguments `gen args + args`, and yields
-a tuple of transformed arguments that should be passed to the wrapped
-function. The result of the wrapped function is passed back to the generator
-using `gen.send()`, and the generator yields the transformed results to pass
-back to the caller.
-
-Transformations can also return auxiliary data using the `transform_with_aux`
-decorator. For example:
-
-@lu.transformation_with_aux
-def scale_transformer_aux(scale, x):
-  ans = yield (x / scale,)
-  yield (x * scale, "Auxiliary data: {}".format(x))
-
-g = lu.wrap_init(f)  # Wraps `f` as a `WrappedFun`.
-g, aux_thunk = scale_transformer_aux(g, 2.0)  # Scale inputs/outputs by 2.0
-print(g.call_wrapped(3.))  # Call the transformed function.
-print(aux_thunk()) # Retrieves the auxiliary data computed during evaluation.
+compare as equal only if they compute the same function. The static and the
+dynamic positional arguments for the generators, and also the auxiliary output
+data must be immutable, because it will be stored in function memoization tables.
 """
 
 from __future__ import absolute_import
@@ -71,18 +68,7 @@ from __future__ import print_function
 
 import weakref
 
-from .util import curry, partial
-
-
-def thunk(f):
-  store = Store()
-  def f_memoized():
-    if not store:
-      # TODO(dougalm): save/restore relevant environment state too
-      store.store(f())
-    return store.val
-
-  return f_memoized
+from .util import curry
 
 class StoreException(Exception): pass
 
@@ -91,6 +77,7 @@ class EmptyStoreValue(object): pass
 _EMPTY_STORE_VALUE = EmptyStoreValue()
 
 class Store(object):
+  """Storage for a value, with checks for overwriting or reading empty store."""
   __slots__ = ("_val",)
 
   def __init__(self):
@@ -117,9 +104,14 @@ class WrappedFun(object):
 
   Arguments:
     f: the function to be transformed.
-    transforms: a list of `(gen, gen_args, out_store)` tuples representing
-      transformations to apply to `f.`
-    params: extra parameters to pass as keyword arguments to `f`.
+    transforms: a list of `(gen, gen_static_args)` tuples representing
+      transformations to apply to `f.` Here `gen` is a generator function
+      and `gen_static_args` is a tuple of static arguments for the generator. See
+      description at the start of this module for the expected behavior of the
+      generator.
+    stores: a list of out_store for the auxiliary output of the `transforms`.
+    params: extra parameters to pass as keyword arguments to `f`, along with the
+      transformed keyword arguments.
   """
   __slots__ = ("f", "transforms", "stores", "params")
 
@@ -133,19 +125,26 @@ class WrappedFun(object):
   def __name__(self):
     return getattr(self.f, '__name__', '<unnamed wrapped function>')
 
-  def wrap(self, gen, gen_args, out_store):
-    return WrappedFun(self.f, ((gen, gen_args),) + self.transforms,
+  def wrap(self, gen, gen_static_args, out_store):
+    """Add another transform and its store."""
+    return WrappedFun(self.f, ((gen, gen_static_args),) + self.transforms,
                       (out_store,) + self.stores, self.params)
 
   def populate_stores(self, stores):
+    """Copy the values from the `stores` into `self.stores`."""
     for self_store, other_store in zip(self.stores, stores):
       if self_store is not None:
         self_store.store(other_store.val)
 
   def call_wrapped(self, *args, **kwargs):
+    """Calls the underlying function, applying the transforms.
+
+    The positional `args` and keyword `kwargs` are passed to the first
+    transformation generator.
+    """
     stack = []
-    for (gen, gen_args), out_store in zip(self.transforms, self.stores):
-      gen = gen(*(gen_args + tuple(args)), **kwargs)
+    for (gen, gen_static_args), out_store in zip(self.transforms, self.stores):
+      gen = gen(*(gen_static_args + tuple(args)), **kwargs)
       args, kwargs = next(gen)
       stack.append((gen, out_store))
     gen = None
@@ -176,14 +175,21 @@ class WrappedFun(object):
             self.params == other.params)
 
 @curry
-def transformation(gen, fun, *transformation_args):
-  return fun.wrap(gen, transformation_args, None)
+def transformation(gen, fun, *gen_static_args):
+  """Adds one more transformation to a WrappedFun.
+  Args:
+    gen: the transformation generator function
+    fun: a WrappedFun on which to apply the transformation
+    gen_static_args: static args for the generator function
+  """
+  return fun.wrap(gen, gen_static_args, None)
 
 @curry
-def transformation_with_aux(gen, fun, *transformation_args):
+def transformation_with_aux(gen, fun, *gen_static_args):
+  """Adds one more transformation with auxiliary output to a WrappedFun."""
   out_store = Store()
   out_thunk = lambda: out_store.val
-  return fun.wrap(gen, transformation_args, out_store), out_thunk
+  return fun.wrap(gen, gen_static_args, out_store), out_thunk
 
 def fun_name(f):
   try:
@@ -197,6 +203,13 @@ def wrap_init(f, params={}):
 
 
 def cache(call):
+  """Cache decorator for WrappedFun calls.
+  Args:
+    call: a function that takes a WrappedFun as a first argument
+
+  Returns:
+     the memoized `call` function.
+  """
   fun_caches = weakref.WeakKeyDictionary()
 
   def memoized_fun(fun, *args):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+from functools import partial
+import unittest
+import warnings
+import weakref
+
+from absl import logging
+from absl.testing import absltest
+import numpy as onp
+import six
+
+if six.PY3:
+  import concurrent.futures
+
+import jax
+import jax.numpy as np
+from jax import jit, grad, device_put, jacfwd, jacrev, hessian
+from jax import api, lax
+from jax.core import Primitive
+from jax.interpreters import ad
+from jax.interpreters.xla import DeviceArray
+from jax.abstract_arrays import concretization_err_msg
+from jax.lib import xla_bridge as xb
+from jax import linear_util as lu
+from jax import test_util as jtu
+from jax import tree_util
+
+from jax.config import config
+config.parse_flags_with_absl()
+FLAGS = config.FLAGS
+
+class UtilTest(jtu.JaxTestCase):
+
+  def test_wrapped_fun_transforms(self):
+    """Test a combination of transforms."""
+
+    def f(*args, factor=2):
+      """The function to be transformed.
+      Scales the positional arguments by a factor.
+      Takes only one keyword argument, the factor to scale by."""
+      return tuple(a * factor for a in args)
+
+    @lu.transformation_with_aux
+    def kw_to_positional(factor, *args, **kwargs):
+      """A transformation with auxiliary output.
+      Turns all keyword parameters into positional ones.
+
+      On entry, append the values of the keyword arguments to the positional
+      arguments. On exit, take a list of results and recreate a dictionary
+      from the tail of the results. The auxiliary output is the list of
+      keyword keys.
+      """
+      kwargs_keys = kwargs.keys()
+      new_args = tuple(kwargs[k] for k in kwargs_keys)
+      new_kwargs = dict(factor=factor)
+      results = yield args + new_args, new_kwargs  # Yield transformed (args, kwargs)
+      # Assume results correspond 1:1 to the args + new_args
+      assert len(results) == len(args) + len(new_args)
+      aux_output = len(new_args)
+      yield (results[0:len(args)],
+             dict(zip(kwargs_keys, results[len(args):]))), aux_output
+
+
+    wf = lu.wrap_init(f)  # Wraps `f` as a `WrappedFun`.
+    wf, out_thunk = kw_to_positional(wf, 2)
+    # Call the transformed function.
+    scaled_positional, scaled_kwargs = wf.call_wrapped(1, 2, three=3, four=4)
+    self.assertEqual((2, 4), scaled_positional)
+    self.assertEqual(dict(three=6, four=8), scaled_kwargs)
+    self.assertEqual(2, out_thunk())

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -16,29 +16,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
-from functools import partial
-import unittest
-import warnings
-import weakref
-
-from absl import logging
-from absl.testing import absltest
-import numpy as onp
-import six
-
-if six.PY3:
-  import concurrent.futures
-
 import jax
 import jax.numpy as np
-from jax import jit, grad, device_put, jacfwd, jacrev, hessian
 from jax import api, lax
-from jax.core import Primitive
-from jax.interpreters import ad
-from jax.interpreters.xla import DeviceArray
-from jax.abstract_arrays import concretization_err_msg
-from jax.lib import xla_bridge as xb
 from jax import linear_util as lu
 from jax import test_util as jtu
 from jax import tree_util

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -32,10 +32,12 @@ class UtilTest(jtu.JaxTestCase):
   def test_wrapped_fun_transforms(self):
     """Test a combination of transforms."""
 
-    def f(*args, factor=2):
+    def f(*args, **kwargs):
       """The function to be transformed.
       Scales the positional arguments by a factor.
       Takes only one keyword argument, the factor to scale by."""
+      factor = kwargs.pop('factor', 2)  # For PY2
+      assert not kwargs
       return tuple(a * factor for a in args)
 
     @lu.transformation_with_aux


### PR DESCRIPTION
Also cleaned up the inconsistent way of importing the module.
Prefer importing with qualified name 'lu.transformation' rather
than just 'transformation'.

I found the need for such documentation while trying to understand how WrappedFun caching works for #1945.