### PR TITLE
implemented fftfreq

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -262,6 +262,7 @@ jax.numpy.fft
   ifft
   fft2
   ifft2
+  fftfreq
 
 jax.numpy.linalg
 ----------------

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -24,6 +24,7 @@ from ..util import get_module_functions
 from .lax_numpy import _not_implemented
 from .lax_numpy import _wraps
 from . import lax_numpy as np
+from .. import ops as jaxops
 
 
 def _promote_to_complex(arg):
@@ -80,6 +81,44 @@ def _fft_core(func_name, fft_type, a, s, axes, norm):
   if orig_axes is not None:
     transformed = np.moveaxis(transformed, axes, orig_axes)
   return transformed
+
+
+@_wraps(onp.fft.fftfreq)
+def fftfreq(n, d=1.0):
+  if isinstance(n, list) or isinstance(n, tuple):
+    raise ValueError(
+          "The n argument of jax.np.fft.fftfreq only takes an int. "
+          "Got n = %s." % list(n))
+
+  elif isinstance(d, list) or isinstance(d, tuple):
+    raise ValueError(
+          "The d argument of jax.np.fft.fftfreq only takes a single value. "
+          "Got d = %s." % list(d))
+
+  k = np.zeros(n)
+  if n % 2 == 0:
+    # k[0: n // 2 - 1] = np.arange(0, n // 2 - 1)
+    k = jaxops.index_update(k,
+                        jaxops.index[0: n // 2],
+                        np.arange(0, n // 2))
+
+    # k[n // 2:] = np.arange(-n // 2, -1)
+    k = jaxops.index_update(k,
+                        jaxops.index[n // 2:],
+                        np.arange(-n // 2, 0))
+
+  else:
+    # k[0: (n - 1) // 2] = np.arange(0, (n - 1) // 2)
+    k = jaxops.index_update(k,
+                        jaxops.index[0: (n - 1) // 2 + 1],
+                        np.arange(0, (n - 1) // 2 + 1))
+
+    # k[(n - 1) // 2 + 1:] = np.arange(-(n - 1) // 2, -1)
+    k = jaxops.index_update(k,
+                        jaxops.index[(n - 1) // 2 + 1:],
+                        np.arange(-(n - 1) // 2, 0))
+
+  return k / (d * n)
 
 
 @_wraps(onp.fft.fftn)


### PR DESCRIPTION
Please see https://github.com/google/jax/issues/1877

There could be more type-checking done for `n` and `d` but I think `np.arange` should catch many of those as well.

@shoyer, let me know what you think!