### PR TITLE
Implement np.sign for unsigned integers.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -415,7 +415,6 @@ fabs = _one_to_one_unop(onp.fabs, lax.abs, True)
 bitwise_not = _one_to_one_unop(onp.bitwise_not, lax.bitwise_not)
 negative = _one_to_one_unop(onp.negative, lax.neg)
 positive = _one_to_one_unop(onp.positive, lambda x: x)
-sign = _one_to_one_unop(onp.sign, lax.sign)
 
 floor = _one_to_one_unop(onp.floor, lax.floor, True)
 ceil = _one_to_one_unop(onp.ceil, lax.ceil, True)
@@ -484,6 +483,16 @@ logical_and = _logical_op(onp.logical_and, lax.bitwise_and)
 logical_not = _logical_op(onp.logical_not, lax.bitwise_not)
 logical_or = _logical_op(onp.logical_or, lax.bitwise_or)
 logical_xor = _logical_op(onp.logical_xor, lax.bitwise_xor)
+
+
+@_wraps(onp.sign)
+def sign(x):
+  dtype = _dtype(x)
+  if issubdtype(dtype, complexfloating):
+    re = lax.real(x)
+    return lax.complex(
+      lax.sign(where(re != 0, re, lax.imag(x))), _constant_like(re, 0))
+  return lax.sign(x)
 
 
 @_wraps(onp.true_divide)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -60,6 +60,7 @@ float_dtypes = list(jtu.supported_dtypes().intersection(
   {lnp.bfloat16, onp.float16, onp.float32, onp.float64}))
 complex_dtypes = [onp.complex64, onp.complex128]
 int_dtypes = [onp.int32, onp.int64]
+uint_dtypes = [onp.uint32, onp.uint64]
 unsigned_dtypes = [onp.uint32, onp.uint64]
 bool_dtypes = [onp.bool_]
 default_dtypes = float_dtypes + int_dtypes
@@ -188,6 +189,10 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
     op_record("floor_divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero,
               ["rev"]),
+    # TODO(phawkins): merge this with the preceding entry after the minimum
+    # Jaxlib version is increased to 0.1.38.
+    op_record("floor_divide", 2, uint_dtypes, all_shapes, jtu.rand_nonzero,
+              ["rev"]),
     op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default, [],
               inexact=True),
     op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default, [],
@@ -230,6 +235,8 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-2}),
     op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("sign", 1, number_dtypes + uint_dtypes, all_shapes,
+              jtu.rand_some_inf_and_nan, []),
     op_record("sinc", 1, [t for t in number_dtypes if t != lnp.bfloat16],
               all_shapes, jtu.rand_default, ["rev"],
               tolerance={onp.complex64: 1e-5}, inexact=True,
@@ -297,7 +304,8 @@ JAX_OPERATOR_OVERLOADS = [
               tolerance={onp.float32: 2e-4, onp.complex64: 2e-4, onp.complex128: 1e-14}),
     op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
-    op_record("__floordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__floordiv__", 2, default_dtypes, all_shapes,
+              jtu.rand_nonzero, []),
     op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
               inexact=True),
     op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
@@ -319,7 +327,8 @@ JAX_RIGHT_OPERATOR_OVERLOADS = [
               tolerance={onp.float32: 2e-4, onp.complex64: 1e-3}),
     op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-1}),
-    op_record("__rfloordiv__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("__rfloordiv__", 2, default_dtypes, all_shapes,
+              jtu.rand_nonzero, []),
     op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
               inexact=True),
     # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -62,6 +62,7 @@ complex_dtypes = list(jtu.supported_dtypes().intersection(
     {onp.complex64, onp.complex128}))
 inexact_dtypes = float_dtypes + complex_dtypes
 int_dtypes = list(jtu.supported_dtypes().intersection({onp.int32, onp.int64}))
+uint_dtypes = list(jtu.supported_dtypes().intersection({onp.uint32, onp.uint64}))
 bool_dtypes = [onp.bool_]
 default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
@@ -77,7 +78,7 @@ def op_record(op, nargs, dtypes, rng_factory, tol=None):
 
 LAX_OPS = [
     op_record("neg", 1, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("sign", 1, default_dtypes, jtu.rand_small),
+    op_record("sign", 1, default_dtypes + uint_dtypes, jtu.rand_small),
     op_record("floor", 1, float_dtypes, jtu.rand_small),
     op_record("ceil", 1, float_dtypes, jtu.rand_small),
     op_record("round", 1, float_dtypes, jtu.rand_default),


### PR DESCRIPTION
Fix definition of np.sign for complex numbers.
Document lax.sign better for non-float types.

Fixes #1933 