### PR TITLE
Added pshuffle

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -113,6 +113,30 @@ def ppermute(x, axis_name, perm):
   """
   return ppermute_p.bind(x, axis_name=axis_name, perm=tuple(perm))
 
+def pshuffle(x, axis_name, perm):
+  """Perform a collective shuffle according to the permutation ``perm``.
+
+  This function is a simple wrapper around jax.lax.ppermute.
+
+  Args:
+    x: array with a mapped axis named ``axis_name``.
+    axis_name: hashable Python object used to name a pmapped axis (see the
+      ``pmap`` docstring for more details).
+    perm: list of of ints, representing the new order of the source indicies
+      that encode how the mapped axis named ``axis_name`` should be
+      shuffled. The integer values are treated as indices into the mapped axis
+      ``axis_name``. Every int between 0 and ``len(perm)-1`` should be included.
+
+  Returns:
+    An array with the same shape as ``x`` with slices along the axis
+    ``axis_name`` gathered from ``x`` according to the permutation ``perm``.
+  """
+  if set(perm) != set(range(len(perm))):
+    raise AssertionError(
+      "Perm {} does not represent a real permutation".format(perm))
+  return ppermute(x, axis_name, zip(perm, range(len(perm))))
+
+
 def pswapaxes(x, axis_name, axis):
   """Swap the pmapped axis ``axis_name`` with the unmapped axis ``axis``.
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -133,8 +133,8 @@ def pshuffle(x, axis_name, perm):
   """
   if set(perm) != set(range(len(perm))):
     raise AssertionError(
-      "Perm {} does not represent a real permutation".format(perm))
-  return ppermute(x, axis_name, zip(perm, range(len(perm))))
+      "Given `perm` does not represent a real permutation: {}".format(perm))
+  return ppermute(x, axis_name, list(zip(perm, range(len(perm)))))
 
 
 def pswapaxes(x, axis_name, axis):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -355,6 +355,31 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   @jtu.skip_on_devices("cpu", "gpu")
+  def testCollectivePermuteCyclicGradWithPShuffle(self):
+    device_count = xla_bridge.device_count()
+    shift_right = [(i - 1) % device_count for i in range(device_count)]
+    f = lambda x: lax.pshuffle(x, perm=shift_right, axis_name='i')
+    y = onp.pi + onp.arange(device_count, dtype=onp.float32)
+    g = lambda x: np.sum(y * pmap(f, 'i')(x))
+
+    x = onp.arange(device_count, dtype=onp.float32)
+    ans = grad(g)(x)
+    expected = onp.roll(onp.pi + onp.arange(device_count), 1)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  @jtu.skip_on_devices("cpu", "gpu")
+  def testPShuffleWithBadPerm(self):
+    device_count = xla_bridge.device_count()
+    bad_perm = list(range(device_count))
+    bad_perm[0] = 1
+    f = lambda x: lax.pshuffle(x, perm=bad_perm, axis_name='i')
+    g = lambda: pmap(f, "i")(onp.arange(device_count))
+    self.assertRaisesRegex(
+      AssertionError, 
+      "Given `perm` does not represent a real permutation: .*", 
+      g)
+
+  @jtu.skip_on_devices("cpu", "gpu")
   def testPpermuteWithZipObject(self):
     # https://github.com/google/jax/issues/1703
     num_devices = xla_bridge.device_count()

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -361,7 +361,6 @@ class PmapTest(jtu.JaxTestCase):
     f = lambda x: lax.pshuffle(x, perm=shift_right, axis_name='i')
     y = onp.pi + onp.arange(device_count, dtype=onp.float32)
     g = lambda x: np.sum(y * pmap(f, 'i')(x))
-
     x = onp.arange(device_count, dtype=onp.float32)
     ans = grad(g)(x)
     expected = onp.roll(onp.pi + onp.arange(device_count), 1)
@@ -376,7 +375,7 @@ class PmapTest(jtu.JaxTestCase):
     g = lambda: pmap(f, "i")(onp.arange(device_count))
     self.assertRaisesRegex(
       AssertionError, 
-      "Given `perm` does not represent a real permutation: .*", 
+      "Given `perm` does not represent a real permutation: {}".format(bad_perm), 
       g)
 
   @jtu.skip_on_devices("cpu", "gpu")

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -354,8 +354,8 @@ class PmapTest(jtu.JaxTestCase):
     expected = onp.roll(onp.pi + onp.arange(device_count), 1)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @jtu.skip_on_devices("cpu", "gpu")
-  def testCollectivePermuteCyclicGradWithPShuffle(self):
+  @jtu.skip_on_devices("cpu")
+  def testCollectivePermuteCyclicWithPShuffle(self):
     device_count = xla_bridge.device_count()
     values = onp.arange(device_count)
     shift_right = [(i - 1) % device_count for i in range(device_count)]
@@ -364,7 +364,7 @@ class PmapTest(jtu.JaxTestCase):
     ans = onp.asarray(pmap(f, "i")(values))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @jtu.skip_on_devices("cpu", "gpu")
+  @jtu.skip_on_devices("cpu")
   def testPShuffleWithBadPerm(self):
     device_count = xla_bridge.device_count()
     bad_perm = list(range(device_count))


### PR DESCRIPTION
I don't like how I need how I need to always use a list of tuples when doing a `ppermute`, and I end up using this `zip` trick every time. 

I am purposing a new `pshuffle` function as a simple wrapper to `ppermute` that uses the order of the integers as their implied destination index.