### PR TITLE
Adjust tolerance for LaxTest.testConv0DIsDot.

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -496,7 +496,7 @@ class LaxTest(jtu.JaxTestCase):
     jnp_fun = partial(lax.conv_general_dilated, window_strides=(),
                       padding='VALID', dimension_numbers=('NC', 'IO', 'NC'))
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
-    self._CheckAgainstNumpy(jnp_fun, onp.dot, args_maker)
+    self._CheckAgainstNumpy(jnp_fun, onp.dot, args_maker, tol=.1)
 
 
   @staticmethod


### PR DESCRIPTION
This was failing on TPU.