### PR TITLE
Drop fastcache dependency, which isn't necessary on Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - conda config --add channels conda-forge
   - conda update -q conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip six protobuf>=3.6.0 absl-py opt_einsum numpy scipy pytest-xdist pytest-benchmark fastcache
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip absl-py opt_einsum numpy scipy pytest-xdist pytest-benchmark
   # The jaxlib version should match the minimum jaxlib version in
   # jax/lib/__init__.py. This tests JAX PRs against the oldest permitted
   # jaxlib.

--- a/jax/util.py
+++ b/jax/util.py
@@ -21,7 +21,6 @@ import functools
 import itertools as it
 import types
 
-import fastcache
 import numpy as onp
 
 
@@ -177,9 +176,9 @@ def split_merge(predicate, xs):
   return lhs, rhs, merge
 
 def cache(max_size=4096):
-  return fastcache.clru_cache(maxsize=max_size)
+  return functools.lru_cache(maxsize=max_size)
 
-memoize = fastcache.clru_cache(maxsize=None)
+memoize = functools.lru_cache(maxsize=None)
 
 def prod(xs):
   out = 1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["examples"]),
     python_requires='>=3.5',
     install_requires=[
-        'numpy>=1.12', 'absl-py', 'opt_einsum', 'fastcache'
+        'numpy>=1.12', 'absl-py', 'opt_einsum'
     ],
     url='https://github.com/google/jax',
     license='Apache-2.0',


### PR DESCRIPTION
Drop protobuf and six dependencies from travis configuration.