### PR TITLE
Update XLA.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,10 +23,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "d01c8cafd20c842b7e1af0eb15c45699c12aceb159e002a5cab56af187906d58",
-    strip_prefix = "tensorflow-84add98ff286a5b805d6b45d016f484b7c4f42ba",
+    sha256 = "516d4568ee2506f0df2b66d672124232a08fede139643d974d269676c16f5f3d",
+    strip_prefix = "tensorflow-d2318f541e51ac3afe573c5e7d91b93f8570d63d",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/84add98ff286a5b805d6b45d016f484b7c4f42ba.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/d2318f541e51ac3afe573c5e7d91b93f8570d63d.tar.gz",
     ],
 )
 

--- a/build/setup.py
+++ b/build/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib'],
     python_requires='>=3.5',
-    install_requires=['scipy', 'numpy>=1.12', 'six', 'absl-py'],
+    install_requires=['scipy', 'numpy>=1.12', 'absl-py'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={'jaxlib': binary_libs},


### PR DESCRIPTION
Drop six dependency from jaxlib, since xla_client.py no longer uses six.