### PR TITLE
Add jax changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+These are the release notes for JAX.
+
+## jax 0.1.58 (unreleased)
+
+### Breaking changes
+
+### New features
+
+- Forward AD of while loop (https://github.com/google/jax/pull/1980)
+
+### Notable bug fixes


### PR DESCRIPTION
I don't think we need one for jaxlib, since changes there usually aren't user-visible (except for bug fixes? We can add one later if we find the need for it).