### PR TITLE
Added dtype arg for NN initializer factory methods

### DIFF
--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -113,7 +113,7 @@ def delta_orthogonal(scale=1.0, column_axis=-1, dtype=np.float32):
       raise ValueError("`fan_in` must be less or equal than `fan_out`. ")
     ortho_init = orthogonal(scale=scale, column_axis=column_axis, dtype=dtype)
     ortho_matrix = ortho_init(key, shape[-2:])
-    W = np.zeros(shape)
+    W = np.zeros(shape, dtype=dtype)
     if len(shape) == 3:
       k = shape[0]
       return ops.index_update(W, ops.index[(k-1)//2, ...], ortho_matrix)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -83,7 +83,7 @@ INITIALIZER_RECS = [
     initializer_record("lecun_normal", nn.initializers.lecun_normal),
     initializer_record("lecun_uniform", nn.initializers.lecun_uniform),
     initializer_record("orthogonal", nn.initializers.orthogonal, 2, 2),
-    initializer_record("orthogonal", nn.initializers.delta_orthogonal, 4, 4)
+    initializer_record("delta_orthogonal", nn.initializers.delta_orthogonal, 4, 4)
 ]
 
 class NNInitializersTest(jtu.JaxTestCase):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -74,16 +74,16 @@ def initializer_record(name, initializer, min_dims=2, max_dims=4):
   return InitializerRecord(name, initializer, shapes)
 
 INITIALIZER_RECS = [
-    initializer_record("uniform", nn.initializers.uniform(), 1),
-    initializer_record("normal", nn.initializers.normal(), 1),
-    initializer_record("he_normal", nn.initializers.he_normal()),
-    initializer_record("he_uniform", nn.initializers.he_uniform()),
-    initializer_record("glorot_normal", nn.initializers.glorot_normal()),
-    initializer_record("glorot_uniform", nn.initializers.glorot_uniform()),
-    initializer_record("lecun_normal", nn.initializers.lecun_normal()),
-    initializer_record("lecun_uniform", nn.initializers.lecun_uniform()),
-    initializer_record("orthogonal", nn.initializers.orthogonal(), 2, 2),
-    initializer_record("orthogonal", nn.initializers.delta_orthogonal(), 4, 4)
+    initializer_record("uniform", nn.initializers.uniform, 1),
+    initializer_record("normal", nn.initializers.normal, 1),
+    initializer_record("he_normal", nn.initializers.he_normal),
+    initializer_record("he_uniform", nn.initializers.he_uniform),
+    initializer_record("glorot_normal", nn.initializers.glorot_normal),
+    initializer_record("glorot_uniform", nn.initializers.glorot_uniform),
+    initializer_record("lecun_normal", nn.initializers.lecun_normal),
+    initializer_record("lecun_uniform", nn.initializers.lecun_uniform),
+    initializer_record("orthogonal", nn.initializers.orthogonal, 2, 2),
+    initializer_record("orthogonal", nn.initializers.delta_orthogonal, 4, 4)
 ]
 
 class NNInitializersTest(jtu.JaxTestCase):
@@ -93,7 +93,7 @@ class NNInitializersTest(jtu.JaxTestCase):
        "_{}_{}".format(
            rec.name,
            jtu.format_shape_dtype_string(shape, dtype)),
-       "initializer": rec.initializer,
+       "initializer": rec.initializer(),
        "shape": shape, "dtype": dtype}
       for rec in INITIALIZER_RECS
       for shape in rec.shapes
@@ -101,6 +101,27 @@ class NNInitializersTest(jtu.JaxTestCase):
   def testInitializer(self, initializer, shape, dtype):
     rng = random.PRNGKey(0)
     val = initializer(rng, shape, dtype)
+    self.assertEqual(shape, np.shape(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), np.dtype(val))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_{}_{}".format(
+           rec.name,
+           jtu.format_shape_dtype_string(shape, dtype)),
+       "initializer_provider": rec.initializer,
+       "shape": shape, "dtype": dtype}
+      for rec in INITIALIZER_RECS
+      for shape in rec.shapes
+      for dtype in [onp.float32, onp.float64]))
+  def testInitializerProvider(self, initializer_provider, shape, dtype):
+    rng = random.PRNGKey(0)
+    initializer = initializer_provider(dtype=dtype)
+    val = initializer(rng, shape)
+
+    self.assertEqual(shape, np.shape(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), np.dtype(val))
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Initializer factories in jax/nn/initializers.py (such as uniform(), normal(), glorot_normal(), etc) now have an optional `dtype` argument.
The value passed in that argument becomes the default value for the same `dtype` argument of the initializer function returned by the factory.

Closes #2003  