### PR TITLE
Updates __eq__ for core.Literal to check type

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -132,6 +132,8 @@ class Literal(object):
     return id(self.val) if self.hash is None else self.hash
 
   def __eq__(self, other):
+    if not isinstance(other, Literal):
+      return False
     return self.val is other.val if self.hash is None else self.val == other.val
 
   def __repr__(self):


### PR DESCRIPTION
Currently, if you do an equality comparison between a `Literal` and a non-`Literal` (a `Var`, for example), it will likely error since `Literal.__eq__` calls `.val` on the object it's checking. This adds in a check to ensure the object it compares against is a `Literal`.