### PR TITLE
Ensure ShapedArray.shape is always a tuple of builtins integers

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import operator
+
 import numpy as onp
 
 from . import core
@@ -96,7 +98,7 @@ class ShapedArray(UnshapedArray):
 
   def __init__(self, shape, dtype, weak_type=False):
     super(ShapedArray, self).__init__(dtype, weak_type=weak_type)
-    self.shape = shape
+    self.shape = tuple(map(operator.index, shape))
 
   ndim = property(lambda self: len(self.shape))
   size = property(lambda self: prod(self.shape))

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -91,16 +91,14 @@ class UnshapedArray(core.AbstractValue):
     """Returns a copy of the aval with weak_type=False."""
     return UnshapedArray(self.dtype) if self.weak_type else self
 
-
-_DIMENSION_TYPES = set()
+# Registry for valid dimension types. This is used by masking.Poly.
+_DIMENSION_TYPES = {int}
 
 def _canonicalize_dimension(dim):
-  try:
-    return operator.index(dim)
-  except TypeError:
-    if type(dim) not in _DIMENSION_TYPES:
-      raise
+  if type(dim) in _DIMENSION_TYPES:
     return dim
+  else:
+    return operator.index(dim)
 
 def _canonicalize_shape(shape):
   """Ensure shape is a tuple of int or registered _DIMENSION_TYPES."""

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -92,13 +92,19 @@ class UnshapedArray(core.AbstractValue):
     return UnshapedArray(self.dtype) if self.weak_type else self
 
 
+def _canonicalize_shape(shape):
+  """Ensure shape is a tuple of int or Poly objects."""
+  from .interpreters import masking
+  return tuple(map(masking.to_index, shape))
+
+
 class ShapedArray(UnshapedArray):
   __slots__ = ['shape']
   array_abstraction_level = 1
 
   def __init__(self, shape, dtype, weak_type=False):
     super(ShapedArray, self).__init__(dtype, weak_type=weak_type)
-    self.shape = tuple(map(operator.index, shape))
+    self.shape = _canonicalize_shape(shape)
 
   ndim = property(lambda self: len(self.shape))
   size = property(lambda self: prod(self.shape))

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -92,10 +92,19 @@ class UnshapedArray(core.AbstractValue):
     return UnshapedArray(self.dtype) if self.weak_type else self
 
 
+_DIMENSION_TYPES = set()
+
+def _canonicalize_dimension(dim):
+  try:
+    return operator.index(dim)
+  except TypeError:
+    if type(dim) not in _DIMENSION_TYPES:
+      raise
+    return dim
+
 def _canonicalize_shape(shape):
-  """Ensure shape is a tuple of int or Poly objects."""
-  from .interpreters import masking
-  return tuple(map(masking.to_index, shape))
+  """Ensure shape is a tuple of int or registered _DIMENSION_TYPES."""
+  return tuple(map(_canonicalize_dimension, shape))
 
 
 class ShapedArray(UnshapedArray):

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -24,6 +24,7 @@ import string
 
 import numpy as onp
 
+from .. import abstract_arrays
 from .. import core
 from ..core import Trace, Tracer
 from ..util import unzip2, safe_map, safe_zip, curry
@@ -87,11 +88,6 @@ def mask_subtrace(master, in_vals, shape_exprs):
   out_tracers = map(trace.full_raise, outs)
   out_vals, out_shapes = unzip2((t.val, t.shape_expr) for t in out_tracers)
   yield out_vals, out_shapes
-
-def to_index(x):
-  """Like operator.index, but allowing polymorphic dimensions."""
-  # not implemented as `Poly.__index__`, since operator.index only allows ints
-  return x if type(x) is Poly else op.index(x)
 
 def ensure_poly(p):
   if isinstance(p, Poly):
@@ -219,6 +215,9 @@ class Poly(Counter):
   @property
   def is_constant(self):
     return len(self) == 1 and next(iter(self)).degree == 0
+
+abstract_arrays._DIMENSION_TYPES.add(Poly)
+
 
 class Mon(Counter):  # type Mon = Map Id Int -- ids to degrees
   def __hash__(self):

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -88,6 +88,10 @@ def mask_subtrace(master, in_vals, shape_exprs):
   out_vals, out_shapes = unzip2((t.val, t.shape_expr) for t in out_tracers)
   yield out_vals, out_shapes
 
+def to_index(x):
+  """Like operator.index, but allowing polymorphic dimensions."""
+  # not implemented as `Poly.__index__`, since operator.index only allows ints
+  return x if type(x) is Poly else op.index(x)
 
 def ensure_poly(p):
   if isinstance(p, Poly):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3057,6 +3057,10 @@ class LaxVmapTest(jtu.JaxTestCase):
                         [dtype, idxs.dtype, dtype], jtu.rand_default(),
                         rtol={onp.float16: 5e-3})
 
+  def testShapeUsesBuiltinInt(self):
+    x = lax.iota(onp.int32, 3) + 1
+    self.assertIsInstance(x.shape[0], int)  # not np.int64
+
   # TODO Concatenate
   # TODO Reverse
   # TODO DynamicSlice


### PR DESCRIPTION
Currently, it can sometimes include elements of type int64, e.g.,

    In [1]: import jax.numpy as jnp

    In [2]: x = jnp.arange(3) + 1

    In [3]: x.shape  # looks fine at first glance
    Out[3]: (3,)

    In [4]: type(x.shape[0])  # yikes!
    Out[4]: numpy.int64

This confirms my hypothesis that NumPy's scalar types are the root of all evil.