### PR TITLE
Implement np.linalg.matrix_power

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -284,6 +284,7 @@ jax.numpy.linalg
   eig
   eigh
   inv
+  matrix_power
   norm
   qr
   slogdet

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -65,9 +65,12 @@ def svd(a, full_matrices=True, compute_uv=True):
 @_wraps(onp.linalg.matrix_power)
 def matrix_power(a, n):
   a = _promote_arg_dtypes(np.asarray(a))
-  # _assertRankAtLeast2(a)
-  # _assertNdSquareness(a)
 
+  if a.ndim < 2:
+    raise TypeError("%d-dimensional array given. Array must be at least "
+                    "two-dimensional" % a.ndim)
+  if a.shape[-2] != a.shape[-1]:
+    raise TypeError("Last 2 dimensions of the array must be square")
   try:
     n = operator.index(n)
   except TypeError:

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -68,19 +68,17 @@ def matrix_power(a, n):
   a = _promote_arg_dtypes(np.asarray(a))
 
   if a.ndim < 2:
-    raise TypeError("%d-dimensional array given. Array must be at least "
-                    "two-dimensional" % a.ndim)
+    raise TypeError("{}-dimensional array given. Array must be at least "
+                    "two-dimensional".format(a.ndim))
   if a.shape[-2] != a.shape[-1]:
     raise TypeError("Last 2 dimensions of the array must be square")
   try:
     n = operator.index(n)
   except TypeError:
-    raise TypeError("exponent must be an integer")
+    raise TypeError("exponent must be an integer, got {}".format(n))
 
   if n == 0:
-    a = np.empty_like(a)
-    a = ops.index_update(a, ..., np.eye(a.shape[-2], dtype=a.dtype))
-    return a
+    return np.broadcast_to(np.eye(a.shape[-2], dtype=a.dtype), a.shape)
   elif n < 0:
     a = inv(a)
     n = np.abs(n)

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -77,14 +77,6 @@ def matrix_power(a, n):
   except TypeError:
     raise TypeError("exponent must be an integer")
 
-  if a.dtype != object:
-    fmatmul = np.matmul
-  elif a.ndim == 2:
-    fmatmul = np.dot
-  else:
-    raise NotImplementedError(
-        "matrix_power not supported for stacks of object arrays")
-
   if n == 0:
     a = np.empty_like(a)
     a = ops.index_update(a, ..., np.eye(a.shape[-2], dtype=a.dtype))
@@ -96,16 +88,16 @@ def matrix_power(a, n):
   if n == 1:
     return a
   elif n == 2:
-    return fmatmul(a, a)
+    return a @ a
   elif n == 3:
-    return fmatmul(fmatmul(a, a), a)
+    return (a @ a) @ a
 
   z = result = None
   while n > 0:
-    z = a if z is None else fmatmul(z, z)
+    z = a if z is None else (z @ z)
     n, bit = divmod(n, 2)
     if bit:
-      result = z if result is None else fmatmul(result, z)
+      result = z if result is None else (result @ z)
 
   return result
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -604,6 +604,25 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-3)
     self._CompileAndCheck(np.linalg.pinv, args_maker, check_dtypes=True)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}_n={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), n),
+       "shape": shape, "dtype": dtype, "n": n, "rng_factory": rng_factory}
+      for shape in [(1, 1), (2, 2), (4, 4), (5, 5),
+                    (1, 2, 2), (2, 3, 3), (2, 5, 5)]
+      for dtype in float_types + complex_types
+      for n in [-5, -2, -1, 0, 1, 2, 3, 4, 5, 10, 15]
+      for rng_factory in [jtu.rand_default]))
+  def testMatrixPower(self, shape, dtype, n, rng_factory):
+    rng = rng_factory()
+    _skip_if_unsupported_type(dtype)
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(partial(onp.linalg.matrix_power, n=n),
+                            partial(np.linalg.matrix_power, n=n),
+                            args_maker, check_dtypes=True, tol=1e-3)
+    self._CompileAndCheck(partial(np.linalg.matrix_power, n=n), args_maker,
+                          check_dtypes=True, rtol=1e-3)
+
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): No complex eigh implementation on TPU.
   def testIssue669(self):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -611,7 +611,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (2, 2), (4, 4), (5, 5),
                     (1, 2, 2), (2, 3, 3), (2, 5, 5)]
       for dtype in float_types + complex_types
-      for n in [-5, -2, -1, 0, 1, 2, 3, 4, 5, 10, 15]
+      for n in [-5, -2, -1, 0, 1, 2, 3, 4, 5, 10]
       for rng_factory in [jtu.rand_default]))
   def testMatrixPower(self, shape, dtype, n, rng_factory):
     rng = rng_factory()


### PR DESCRIPTION
Implements [`np.linalg.matrix_rank`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.matrix_power.html).

Implementation is heavily based on [the NumPy implementation](https://github.com/numpy/numpy/blob/v1.17.0/numpy/linalg/linalg.py#L559-L672) with some tweaks to ensure JAX and JIT compatibility.

Related to #1999