### PR TITLE
Added better error messages.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -69,7 +69,7 @@ class UnshapedArray(core.AbstractValue):
       float, "Try using `value.astype(float)` instead.")
   _int     = concretization_function_error(
       int, "Try using `value.astype(int)` instead.")
-  _complex = concretization_function_error(complex,
+  _complex = concretization_function_error(
       complex, "Try using `value.astype(complex)` instead.")
   _hex     = concretization_function_error(hex)
   _oct     = concretization_function_error(oct)

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -24,7 +24,7 @@ from . import dtypes
 from . util import prod, partialmethod
 
 
-def concretization_err_msg(fun, context):
+def concretization_err_msg(fun, context=None):
   fname = getattr(fun, "__name__", fun)
   if context is None:
     context = ("The function to be transformed can't be traced at the required level "

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -221,6 +221,16 @@ class APITest(jtu.JaxTestCase):
     self.assertRaisesRegex(
       TypeError, "Incompatible shapes for dot: got \\(3L?,\\) and \\(4L?,\\).",
       lambda: grad(f)(onp.zeros(3), onp.zeros(4)))
+  
+  def test_abstract_error_message(self):
+    for castfun in [float, complex, int]:
+      def f(x):
+        return castfun(x)
+
+      self.assertRaisesRegex(
+          TypeError,
+          "Try using value.astype\({}\) instead".format(castfun.__name__),
+          lambda: jit(f)(1.0))
 
   def test_switch_value_jit(self):
     def f(x):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -229,7 +229,7 @@ class APITest(jtu.JaxTestCase):
 
       self.assertRaisesRegex(
           TypeError,
-          "Try using value.astype\({}\) instead".format(castfun.__name__),
+          "Try using `value.astype\({}\)` instead".format(castfun.__name__),
           lambda: jit(f)(1.0))
 
   def test_switch_value_jit(self):


### PR DESCRIPTION
#2057 

Added better error messages for when a user accidentally uses a python cast instead of a the `jax.numpy` casting.