### PR TITLE
Remove missing PPA in Dockerfile.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,7 @@ FROM gcr.io/tensorflow-testing/nosla-cuda10.0-cudnn7-ubuntu16.04-manylinux2010
 LABEL maintainer "Matt Johnson <mattjj@google.com>"
 
 WORKDIR /
+RUN rm /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
 RUN apt-get update
 RUN apt-get install libffi-dev
 RUN git clone --branch v1.2.14 https://github.com/pyenv/pyenv.git /pyenv


### PR DESCRIPTION
This PPA has been removed by the owner: https://launchpad.net/~jonathonf/+archive/ubuntu/python-3.6
This causes `apt-get update` to fail when generating the Docker image. We don't seem to need this repository, so just remove it before calling `apt-get update`.