### PR TITLE
Implement prototype for static keyword argument support while jitting

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -155,7 +155,6 @@ def jit(fun, static_argnums=(), device=None, backend=None):
       msg = ("Jitted function has static_argnums={} but was called with only {}"
              " arguments.")
       raise TypeError(msg.format(static_argnums, len(args)))
-
     f = lu.wrap_init(_fun)
     if static_argnums:
       dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]


### PR DESCRIPTION
Quick (pretty unoptimized) prototype for static keyword argument support for jitted functions.

Works by converting the inputted arguments to have no keyword arguments and treating everything else the same. Most of the work is done by reading the signature of the to-be-jitted function `fun` using the [`inspect`](https://docs.python.org/3/library/inspect.html) module and manipulating the `*args` and `**kwargs` such that everything is aligned.

There is one caveat that might make the implementation seem a bit off: the standard way would not support keyword-only arguments without diving deeper into the compilation of the function since the technique works by converting all arguments to positional arguments; instead, I create a surrogate function that emulates `fun` while having no keyword arguments.

So all-in-all here is what happens, for example, when trying to jit a function `f(x, y, *, z)` with `static_argnums=(1, 2)`:
- Function `_f(x, y, z) = _f(x, y, z=z)` is constructed.
- When calling the functions with some `args` and `kwargs` we project the arguments onto the parameters of the original `f` and extract a positional `args` representation of the union of `args` and `kwargs`.
- We jit `_f` instead of `f` with only positional arguments.

Still a few things that need to happen before this CL is ready to go:
- [ ] Profile the overhead of using all this extra stuff while jitting (i.e. `inspect`).
- [ ] Possibly explore other approaches such as modifying `linear_utils` to support keyword arguments.
- [ ] Write tests.
- [ ] Raise errors where the function signature is not sufficient to map keyword arguments to positional arguments.

Here is an example of its usage that would error previously:
```python
@functools.partial(jit, static_argnums=(1, 3, 5))
def f1(a1, a2, a3=100., a4=200., *, kw1=300., kw2=400.):
  return 10000.

print(f1(1., 2.))
print(f1(a1=1., a2=2.))
print(f1(1., 2., 3.))
print(f1(1., 2., 3., 4.))
print(f1(1., 2., a3=3., a4=4.))
print(f1(1., 2., a4=4.))
print(f1(1., 2., kw1=5.))
print(f1(1., 2., kw2=6.))
print(f1(1., 2., kw1=5., kw2=6.))
```

Possibly closes #1159 
Related to #1936 

Would love to hear what people think of this issue.