### PR TITLE
include call stack + transforms in XLA metadata

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -946,10 +946,10 @@ def soft_pmap(fun, axis_name=None, backend=None):
 
     reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]
     soft_mapped_fun = pxla.split_axis(flat_fun, axis_name, chunk_size)
-    reshaped_outs = pxla.xla_pmap(soft_mapped_fun, *reshaped_args,
+    reshaped_outs = pxla.xla_pmap(soft_mapped_fun, *reshaped_args, backend=backend,
                                   axis_name=axis_name, axis_size=num_chunks,
                                   global_axis_size=None, devices=None,
-                                  backend=backend)
+                                  name=soft_mapped_fun.__name__)
     outs = [_reshape_merge(out) for out in reshaped_outs]
     return tree_unflatten(out_tree(), outs)
 
@@ -1006,9 +1006,9 @@ def _parallelize(fun):
     reshaped_args = [_reshape_split(num_chunks, x) for x in args_flat]
     f, out_axes = parallel.papply_transform(f, axis_name, axis_size)
     f = pxla.split_axis(f, axis_name, chunk_size)
-    outs = pxla.xla_pmap(f, *reshaped_args, axis_name=axis_name,
+    outs = pxla.xla_pmap(f, *reshaped_args, backend=None, axis_name=axis_name,
                          axis_size=num_chunks, global_axis_size=None,
-                         devices=None, backend=None)
+                         devices=None, name=f.__name__)
     outs = map(_reshape_merge, outs)
     outs = [batching.matchaxis(axis_size, 0, dst, x)
             for dst, x in zip(out_axes(), outs)]

--- a/jax/api.py
+++ b/jax/api.py
@@ -50,7 +50,7 @@ from .tree_util import (tree_map, tree_flatten, tree_unflatten, tree_structure,
                         tree_transpose, tree_leaves, tree_multimap,
                         _replace_nones)
 from .util import (unzip2, unzip3, curry, partial, safe_map, safe_zip,
-                   WrapHashably, Hashable, prod, split_list)
+                   WrapHashably, Hashable, prod, split_list, extend_name_stack, wrap_name)
 from .lib import xla_bridge as xb
 from .lib.xla_bridge import (device_count, local_device_count, devices, local_devices,
                              host_id, host_ids, host_count)
@@ -307,8 +307,9 @@ def xla_computation(fun, static_argnums=(), axis_env=None, backend=None,
     c = xb.make_computation_builder('xla_computation_{}'.format(fun_name))
     xla_consts = map(c.Constant, consts)
     xla_args = xla._xla_callable_args(c, avals, tuple_args)
-    outs = xla.jaxpr_subcomp(c, jaxpr, backend, axis_env_, xla_consts, (),
-                             'xla_computation(' + fun_name + ')/', *xla_args)
+    outs = xla.jaxpr_subcomp(
+        c, jaxpr, backend, axis_env_, xla_consts, (),
+        extend_name_stack(wrap_name(fun_name, 'xla_computation')), *xla_args)
     return c.Build(c.Tuple(*outs))
   return computation_maker
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -656,6 +656,11 @@ def check_jaxpr(jaxpr):
 def pp_vars(vs):
     return ' '.join(map(str, vs))
 
+def pp_eqn_compact(primitive_name, params):
+  filtered_params = {k: v for k, v in params.items()
+                     if not isinstance(v, (Jaxpr, TypedJaxpr))}
+  return pp(primitive_name) >> pp_kv_pairs(sorted(filtered_params.items()))
+
 def pp_eqn(eqn):
   lhs = pp_vars(eqn.outvars)
   pp_subexpr = pp('')

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -324,6 +324,8 @@ class JVPTrace(Trace):
     tangents = [t.tangent for t in tracers]
     nonzero_tangents, in_tree_def = tree_flatten(tangents)
     f_jvp, out_tree_def = traceable(jvp_subtrace(f, self.master), len(primals), in_tree_def)
+    name = params.get('name', f.__name__)
+    params = dict(params, name='jvp(' + name + ')')
     result = call_primitive.bind(f_jvp, *(primals + nonzero_tangents), **params)
     primal_out, tangent_out = tree_unflatten(out_tree_def(), result)
     return [JVPTracer(self, p, t) for p, t in zip(primal_out, tangent_out)]
@@ -549,6 +551,7 @@ def call_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+  params = dict(params, name='transpose(' + params['name'] + ')')
   out_flat = primitive.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
@@ -558,6 +561,7 @@ def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
+  params = dict(params, name='transpose(' + params['name'] + ')')
   out_flat = primitive.bind(fun, *all_args, **params)
   freevar_cts, arg_cts = tree_unflatten(out_tree(), out_flat)
   freevar_cts = [x.sum(0) if x is not zero else x for x in freevar_cts]

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -26,7 +26,7 @@ from ..core import Trace, Tracer, new_master, get_aval, call_p, Primitive, Liter
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
                        zeros_like_p, zero)
 from ..abstract_arrays import raise_to_shaped
-from ..util import unzip2, safe_map, safe_zip, partial, split_list
+from ..util import unzip2, safe_map, safe_zip, partial, split_list, wrap_name
 from ..tree_util import register_pytree_node
 from .. import linear_util as lu
 from ..api_util import flatten_fun, flatten_fun_nokwargs
@@ -325,7 +325,7 @@ class JVPTrace(Trace):
     nonzero_tangents, in_tree_def = tree_flatten(tangents)
     f_jvp, out_tree_def = traceable(jvp_subtrace(f, self.master), len(primals), in_tree_def)
     name = params.get('name', f.__name__)
-    params = dict(params, name='jvp(' + name + ')')
+    params = dict(params, name=wrap_name(name, 'jvp'))
     result = call_primitive.bind(f_jvp, *(primals + nonzero_tangents), **params)
     primal_out, tangent_out = tree_unflatten(out_tree_def(), result)
     return [JVPTracer(self, p, t) for p, t in zip(primal_out, tangent_out)]
@@ -551,7 +551,7 @@ def call_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
-  params = dict(params, name='transpose(' + params['name'] + ')')
+  params = dict(params, name=wrap_name(params['name'], 'transpose'))
   out_flat = primitive.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
@@ -561,7 +561,7 @@ def map_transpose(primitive, params, jaxpr, consts, freevar_vals, args, ct):
   all_args, in_tree_def = tree_flatten((consts, freevar_vals, args, ct))
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
-  params = dict(params, name='transpose(' + params['name'] + ')')
+  params = dict(params, name=wrap_name(params['name'], 'transpose'))
   out_flat = primitive.bind(fun, *all_args, **params)
   freevar_cts, arg_cts = tree_unflatten(out_tree(), out_flat)
   freevar_cts = [x.sum(0) if x is not zero else x for x in freevar_cts]

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -119,6 +119,8 @@ class BatchTrace(Trace):
 
   def process_call(self, call_primitive, f, tracers, params):
     assert call_primitive.multiple_results
+    name = params.get('name', f.__name__)
+    params = dict(params, name='vmap(' + name + ')')
     if call_primitive in pe.map_primitives:
       return self.process_map(call_primitive, f, tracers, params)
     vals, dims = unzip2((t.val, t.batch_dim) for t in tracers)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -28,7 +28,7 @@ from ..core import Trace, Tracer, new_master
 from ..abstract_arrays import ShapedArray, make_shaped_array, array_types, raise_to_shaped
 from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
 from .. import linear_util as lu
-from ..util import unzip2, partial, safe_map
+from ..util import unzip2, partial, safe_map, wrap_name
 from . import xla
 from . import partial_eval as pe
 
@@ -120,7 +120,7 @@ class BatchTrace(Trace):
   def process_call(self, call_primitive, f, tracers, params):
     assert call_primitive.multiple_results
     name = params.get('name', f.__name__)
-    params = dict(params, name='vmap(' + name + ')')
+    params = dict(params, name=wrap_name(name, 'vmap'))
     if call_primitive in pe.map_primitives:
       return self.process_map(call_primitive, f, tracers, params)
     vals, dims = unzip2((t.val, t.batch_dim) for t in tracers)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -27,7 +27,8 @@ import numpy as onp
 from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ShapedArray, ConcreteArray, raise_to_shaped
-from ..util import unzip2, safe_zip, safe_map, toposort, partial, split_list
+from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
+                    wrap_name)
 from ..core import (Trace, Tracer, new_master, Jaxpr, Literal, get_aval,
                     AbstractValue, unit, unitvar, abstract_unit, Primitive,
                     call_p, TypedJaxpr, new_jaxpr_eqn)
@@ -119,7 +120,7 @@ class JaxprTrace(Trace):
     if self.master.trace_type is StagingJaxprTrace:
       tracers = map(self.instantiate_const_abstracted, tracers)
     else:
-      name = 'pe(' + name + ')'
+      name = wrap_name(name, 'pe')
     params = dict(params, name=name)
     if call_primitive in call_partial_eval_rules:
       return call_partial_eval_rules[call_primitive](self, f, tracers, params)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -115,8 +115,12 @@ class JaxprTrace(Trace):
         return out_tracer
 
   def process_call(self, call_primitive, f, tracers, params):
+    name = params.get('name', f.__name__)
     if self.master.trace_type is StagingJaxprTrace:
       tracers = map(self.instantiate_const_abstracted, tracers)
+    else:
+      name = 'pe(' + name + ')'
+    params = dict(params, name=name)
     if call_primitive in call_partial_eval_rules:
       return call_partial_eval_rules[call_primitive](self, f, tracers, params)
     if call_primitive in map_primitives:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -35,7 +35,8 @@ from .. import linear_util as lu
 from ..abstract_arrays import (ConcreteArray, ShapedArray, AbstractToken,
                                make_shaped_array, array_types, raise_to_shaped,
                                abstract_token)
-from ..core import valid_jaxtype, Literal
+from ..core import valid_jaxtype, Literal, pp_eqn_compact
+from ..pprint_util import pp
 from ..util import (partial, partialmethod, cache, safe_map, prod, unzip2,
                     memoize)
 from ..lib import xla_bridge as xb
@@ -204,7 +205,9 @@ def _device_from_arg_devices(devices):
 @cache()
 def primitive_computation(prim, backend, tuple_args, *avals, **params):
   c = xb.make_computation_builder("primitive_computation_{}".format(prim.name))
-  c.SetOpMetadata(xc.OpMetadata(op_type=prim.name, op_name=str(params)))
+  c.SetOpMetadata(xc.OpMetadata(
+      op_type=prim.name,
+      op_name=str(pp_eqn_compact(prim.name, params))))
   platform = xb.get_backend(backend).platform
   xla_args = _xla_callable_args(c, avals, tuple_args)
   if prim in backend_specific_translations[platform]:
@@ -215,7 +218,7 @@ def primitive_computation(prim, backend, tuple_args, *avals, **params):
     rule(c, *xla_args, **params)  # return val set as a side-effect on c
   elif prim in initial_style_translations:
     rule = initial_style_translations[prim]
-    rule(c, AxisEnv(), *xla_args, backend=backend, **params)  # side-effect on c
+    rule(c, AxisEnv(), '', *xla_args, backend=backend, **params)  # side-effect on c
   else:
     raise NotImplementedError("XLA translation rule for {} not found".format(prim))
   c.ClearOpMetadata()
@@ -282,7 +285,7 @@ def eqn_literals(eqn):
     if type(v) is core.Literal:
       yield v.val
 
-def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
+def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, call_stack, *args):
   platform = xb.get_backend(backend).platform
 
   def read(v):
@@ -301,7 +304,10 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
   _map(write, jaxpr.freevars, freevars)
   _map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    c.SetOpMetadata(xc.OpMetadata(op_type=eqn.primitive.name))
+    c.SetOpMetadata(xc.OpMetadata(
+        op_type=eqn.primitive.name,
+        op_name=str(pp(call_stack) >> pp_eqn_compact(
+            eqn.primitive.name, eqn.params))))
     in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
       rule = backend_specific_translations[platform][eqn.primitive]
@@ -311,7 +317,8 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
     elif eqn.primitive in initial_style_translations:
       new_params = check_backend_params(eqn.params, backend)
       rule = initial_style_translations[eqn.primitive]
-      ans = rule(c, axis_env, *in_nodes, backend=backend, **new_params)
+      ans = rule(c, axis_env, call_stack + eqn.primitive.name + '/', *in_nodes,
+                 backend=backend, **new_params)
     elif eqn.primitive in parallel_translations:
       replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
       new_params = {k: v for k, v in eqn.params.items() if k != 'axis_name'}
@@ -324,7 +331,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, *args):
       freevar_nodes = _map(read, freevar_bindings)
       rule = call_translations[eqn.primitive]
       ans = rule(c, subjaxpr, axis_env, const_nodes, freevar_nodes, in_nodes,
-                 backend=backend, **new_params)
+                 call_stack, backend=backend, **new_params)
     else:
       msg = "XLA translation rule for primitive '{}' not found"
       raise NotImplementedError(msg.format(eqn.primitive.name))
@@ -437,10 +444,8 @@ def eqn_collectives(eqn):
 
 ### xla_call underlying jit
 
-def _xla_call_impl(fun, *args, **params):
-  device = params['device']
-  backend = params['backend']
-  compiled_fun = _xla_callable(fun, device, backend, *map(arg_spec, args))
+def _xla_call_impl(fun, *args, device, backend, name):
+  compiled_fun = _xla_callable(fun, device, backend, name, *map(arg_spec, args))
   try:
     return compiled_fun(*args)
   except FloatingPointError:
@@ -449,7 +454,7 @@ def _xla_call_impl(fun, *args, **params):
     return fun.call_wrapped(*args)  # probably won't return
 
 @lu.cache
-def _xla_callable(fun, device, backend, *arg_specs):
+def _xla_callable(fun, device, backend, name, *arg_specs):
   if device is not None and backend is not None:
     raise ValueError("can't specify both a device and a backend for jit, "
                      "got device={} and backend={}".format(device, backend))
@@ -492,7 +497,7 @@ def _xla_callable(fun, device, backend, *arg_specs):
   xla_consts = _map(c.Constant, consts)
   xla_args = _xla_callable_args(c, abstract_args, tuple_args)
   out_nodes = jaxpr_subcomp(c, jaxpr, backend, AxisEnv(nreps, [], []),
-                            xla_consts, (), *xla_args)
+                            xla_consts, (), 'jit(' + name + ')/', *xla_args)
   built = c.Build(c.Tuple(*out_nodes))
 
   options = xb.get_compile_options(
@@ -592,13 +597,14 @@ xla_call_p.def_custom_bind(xla_call)
 xla_call_p.def_impl(_xla_call_impl)
 
 def _xla_call_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes,
-                               in_nodes, backend, device=None):
+                               in_nodes, call_stack, backend, name, device=None):
   del device  # Ignored.
-  subc = xb.make_computation_builder("jaxpr_subcomputation")  # TODO(mattjj): name
+  subc = xb.make_computation_builder("jit_{}".format(name))
   consts = [subc.ParameterWithShape(c.GetShape(n)) for n in const_nodes]
   freevars = [subc.ParameterWithShape(c.GetShape(n)) for n in freevar_nodes]
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
-  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars, *args)
+  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars,
+                            call_stack + 'jit(' + name + ')/', *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(const_nodes) + list(freevar_nodes) + list(in_nodes))
 ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
@@ -639,16 +645,17 @@ def lower_fun(fun, instantiate=False, initial_style=False):
   def f(c, *args, **params):
     backend = params.pop('backend', None)
     if initial_style:
-      axis_env, xla_args = args[0], args[1:]
+      axis_env, call_stack, xla_args = args[0], args[1], args[2:]
     else:
-      axis_env, xla_args = AxisEnv(), args
+      axis_env, call_stack, xla_args = AxisEnv(), '', args
     xla_shapes = tuple(map(c.GetShape, xla_args))
     avals = map(_aval_from_xla_shape, xla_shapes)
     pvals = [pe.PartialVal((a, core.unit)) for a in avals]
     jaxpr, _, consts = pe.trace_to_jaxpr(
         lu.wrap_init(fun, params), pvals, instantiate=True)
     consts = _map(c.Constant, consts)
-    outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, (), *xla_args)
+    outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, (),
+                         call_stack, *xla_args)
     return c.Tuple(*outs)
   return f
 
@@ -952,7 +959,7 @@ masking.defvectorized(device_put_p)
 
 
 def _remat_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes, in_nodes,
-                            backend, device=None, concrete=None):
+                            call_stack, backend, name, device=None, concrete=None):
   # This looks a lot like _xla_call_translation_rule, except for a widget we use
   # to foil CSE.
   del device, concrete  # Unused.
@@ -961,7 +968,8 @@ def _remat_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes, in_n
   freevars = [subc.ParameterWithShape(c.GetShape(n)) for n in freevar_nodes]
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
   args = [_foil_cse(subc, x) for x in args]
-  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars, *args)
+  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars,
+                            call_stack + 'remat(' + name + ')/', *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(const_nodes) + list(freevar_nodes) + list(in_nodes))
 call_translations[pe.remat_call_p] = _remat_translation_rule

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -38,7 +38,7 @@ from ..abstract_arrays import (ConcreteArray, ShapedArray, AbstractToken,
 from ..core import valid_jaxtype, Literal, pp_eqn_compact
 from ..pprint_util import pp
 from ..util import (partial, partialmethod, cache, safe_map, prod, unzip2,
-                    memoize)
+                    memoize, extend_name_stack, wrap_name)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from . import partial_eval as pe
@@ -210,15 +210,16 @@ def primitive_computation(prim, backend, tuple_args, *avals, **params):
       op_name=str(pp_eqn_compact(prim.name, params))))
   platform = xb.get_backend(backend).platform
   xla_args = _xla_callable_args(c, avals, tuple_args)
+  # return val always set as a side-effect on c
   if prim in backend_specific_translations[platform]:
     rule = backend_specific_translations[platform][prim]
-    rule(c, *xla_args, **params)  # return val set as a side-effect on c
+    rule(c, *xla_args, **params)  
   elif prim in translations:
     rule = translations[prim]
-    rule(c, *xla_args, **params)  # return val set as a side-effect on c
+    rule(c, *xla_args, **params)
   elif prim in initial_style_translations:
     rule = initial_style_translations[prim]
-    rule(c, AxisEnv(), '', *xla_args, backend=backend, **params)  # side-effect on c
+    rule(c, AxisEnv(), extend_name_stack(prim.name), *xla_args, backend=backend, **params)
   else:
     raise NotImplementedError("XLA translation rule for {} not found".format(prim))
   c.ClearOpMetadata()
@@ -285,7 +286,7 @@ def eqn_literals(eqn):
     if type(v) is core.Literal:
       yield v.val
 
-def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, call_stack, *args):
+def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, name_stack, *args):
   platform = xb.get_backend(backend).platform
 
   def read(v):
@@ -306,7 +307,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, call_stack, *ar
   for eqn in jaxpr.eqns:
     c.SetOpMetadata(xc.OpMetadata(
         op_type=eqn.primitive.name,
-        op_name=str(pp(call_stack) >> pp_eqn_compact(
+        op_name=str(pp(name_stack) >> pp_eqn_compact(
             eqn.primitive.name, eqn.params))))
     in_nodes = list(map(read, eqn.invars))
     if eqn.primitive in backend_specific_translations[platform]:
@@ -317,8 +318,8 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, call_stack, *ar
     elif eqn.primitive in initial_style_translations:
       new_params = check_backend_params(eqn.params, backend)
       rule = initial_style_translations[eqn.primitive]
-      ans = rule(c, axis_env, call_stack + eqn.primitive.name + '/', *in_nodes,
-                 backend=backend, **new_params)
+      ans = rule(c, axis_env, extend_name_stack(name_stack, eqn.primitive.name),
+                 *in_nodes, backend=backend, **new_params)
     elif eqn.primitive in parallel_translations:
       replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
       new_params = {k: v for k, v in eqn.params.items() if k != 'axis_name'}
@@ -331,7 +332,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, freevars, call_stack, *ar
       freevar_nodes = _map(read, freevar_bindings)
       rule = call_translations[eqn.primitive]
       ans = rule(c, subjaxpr, axis_env, const_nodes, freevar_nodes, in_nodes,
-                 call_stack, backend=backend, **new_params)
+                 name_stack, backend=backend, **new_params)
     else:
       msg = "XLA translation rule for primitive '{}' not found"
       raise NotImplementedError(msg.format(eqn.primitive.name))
@@ -496,8 +497,9 @@ def _xla_callable(fun, device, backend, name, *arg_specs):
   c = xb.make_computation_builder("jit_{}".format(fun.__name__))
   xla_consts = _map(c.Constant, consts)
   xla_args = _xla_callable_args(c, abstract_args, tuple_args)
-  out_nodes = jaxpr_subcomp(c, jaxpr, backend, AxisEnv(nreps, [], []),
-                            xla_consts, (), 'jit(' + name + ')/', *xla_args)
+  out_nodes = jaxpr_subcomp(
+      c, jaxpr, backend, AxisEnv(nreps, [], []), xla_consts, (),
+      extend_name_stack(wrap_name(name, 'jit')), *xla_args)
   built = c.Build(c.Tuple(*out_nodes))
 
   options = xb.get_compile_options(
@@ -597,14 +599,14 @@ xla_call_p.def_custom_bind(xla_call)
 xla_call_p.def_impl(_xla_call_impl)
 
 def _xla_call_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes,
-                               in_nodes, call_stack, backend, name, device=None):
+                               in_nodes, name_stack, backend, name, device=None):
   del device  # Ignored.
   subc = xb.make_computation_builder("jit_{}".format(name))
   consts = [subc.ParameterWithShape(c.GetShape(n)) for n in const_nodes]
   freevars = [subc.ParameterWithShape(c.GetShape(n)) for n in freevar_nodes]
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
   out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars,
-                            call_stack + 'jit(' + name + ')/', *args)
+                            extend_name_stack(name_stack, wrap_name(name, 'jit')), *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(const_nodes) + list(freevar_nodes) + list(in_nodes))
 ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
@@ -645,9 +647,9 @@ def lower_fun(fun, instantiate=False, initial_style=False):
   def f(c, *args, **params):
     backend = params.pop('backend', None)
     if initial_style:
-      axis_env, call_stack, xla_args = args[0], args[1], args[2:]
+      axis_env, name_stack, xla_args = args[0], args[1], args[2:]
     else:
-      axis_env, call_stack, xla_args = AxisEnv(), '', args
+      axis_env, name_stack, xla_args = AxisEnv(), '', args
     xla_shapes = tuple(map(c.GetShape, xla_args))
     avals = map(_aval_from_xla_shape, xla_shapes)
     pvals = [pe.PartialVal((a, core.unit)) for a in avals]
@@ -655,7 +657,7 @@ def lower_fun(fun, instantiate=False, initial_style=False):
         lu.wrap_init(fun, params), pvals, instantiate=True)
     consts = _map(c.Constant, consts)
     outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, (),
-                         call_stack, *xla_args)
+                         name_stack, *xla_args)
     return c.Tuple(*outs)
   return f
 
@@ -959,7 +961,7 @@ masking.defvectorized(device_put_p)
 
 
 def _remat_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes, in_nodes,
-                            call_stack, backend, name, device=None, concrete=None):
+                            name_stack, backend, name, device=None, concrete=None):
   # This looks a lot like _xla_call_translation_rule, except for a widget we use
   # to foil CSE.
   del device, concrete  # Unused.
@@ -969,7 +971,7 @@ def _remat_translation_rule(c, jaxpr, axis_env, const_nodes, freevar_nodes, in_n
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
   args = [_foil_cse(subc, x) for x in args]
   out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, consts, freevars,
-                            call_stack + 'remat(' + name + ')/', *args)
+                            extend_name_stack(name_stack, wrap_name(name, 'remat')), *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(const_nodes) + list(freevar_nodes) + list(in_nodes))
 call_translations[pe.remat_call_p] = _remat_translation_rule

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3427,7 +3427,7 @@ def _reduction_computation(c, jaxpr, consts, init_value):
   subc = xla_bridge.make_computation_builder("reduction_computation")
   consts = [subc.ParameterWithShape(const) for const in consts]
   args = [subc.ParameterWithShape(shape), subc.ParameterWithShape(shape)]
-  out, = xla.jaxpr_subcomp(subc, jaxpr, None, axis_env, consts, (), *args)
+  out, = xla.jaxpr_subcomp(subc, jaxpr, None, axis_env, consts, (), None, *args)
   return subc.Build(out)
 
 def _masking_defreducer(prim, identity):

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3427,7 +3427,7 @@ def _reduction_computation(c, jaxpr, consts, init_value):
   subc = xla_bridge.make_computation_builder("reduction_computation")
   consts = [subc.ParameterWithShape(const) for const in consts]
   args = [subc.ParameterWithShape(shape), subc.ParameterWithShape(shape)]
-  out, = xla.jaxpr_subcomp(subc, jaxpr, None, axis_env, consts, (), None, *args)
+  out, = xla.jaxpr_subcomp(subc, jaxpr, None, axis_env, consts, (), '', *args)
   return subc.Build(out)
 
 def _masking_defreducer(prim, identity):

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -43,7 +43,7 @@ from jax.interpreters import masking
 from jax.lib import xla_bridge as xb
 from jax.lib import xla_client
 from jax.util import (partial, unzip2, safe_map, safe_zip, split_list,
-                      split_dict, cache)
+                      split_dict, cache, extend_name_stack)
 from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
                            treedef_children, treedef_tuple)
 from jax import ad_util
@@ -213,7 +213,7 @@ def while_loop(cond_fun, body_fun, init_val):
 def _while_loop_abstract_eval(*args, **kwargs):
   return _map(raise_to_shaped, kwargs["body_jaxpr"].out_avals)
 
-def _while_loop_translation_rule(c, axis_env, call_stack, *args, **kwargs):
+def _while_loop_translation_rule(c, axis_env, name_stack, *args, **kwargs):
   backend = kwargs.pop('backend')
   cond_jaxpr, body_jaxpr, cond_nconsts, body_nconsts = split_dict(
       kwargs, ["cond_jaxpr", "body_jaxpr", "cond_nconsts", "body_nconsts"])
@@ -234,7 +234,7 @@ def _while_loop_translation_rule(c, axis_env, call_stack, *args, **kwargs):
   x, _, z = split_list(cond_carry_elts, [cond_nconsts, body_nconsts])
   pred, = xla.jaxpr_subcomp(cond_c, cond_jaxpr.jaxpr, backend, axis_env,
                             _map(cond_c.Constant, cond_jaxpr.literals), (),
-                            call_stack + 'cond/', *(x + z))
+                            extend_name_stack(name_stack, 'cond'), *(x + z))
   if batched:
     scalar = ShapedArray((), onp.bool_)
     or_ = xla.primitive_subcomputation(lax.or_p, scalar, scalar)
@@ -247,11 +247,11 @@ def _while_loop_translation_rule(c, axis_env, call_stack, *args, **kwargs):
   x, y, z = split_list(body_carry_elts, [cond_nconsts, body_nconsts])
   new_z = xla.jaxpr_subcomp(body_c, body_jaxpr.jaxpr, backend, axis_env,
                             _map(body_c.Constant, body_jaxpr.literals), (),
-                            call_stack + 'body/', *(y + z))
+                            extend_name_stack(name_stack, 'body'), *(y + z))
   if batched:
     body_pred, = xla.jaxpr_subcomp(body_c, cond_jaxpr.jaxpr, backend, axis_env,
                                    _map(body_c.Constant, cond_jaxpr.literals), (),
-                                   call_stack + 'body_pred/', *(x + z))
+                                   extend_name_stack(name_stack, 'body_pred'), *(x + z))
     new_z = _map(partial(_pred_bcast_select, body_c, body_pred), new_z, z)
     assert _map(body_c.GetShape, new_z) == _map(body_c.GetShape, z) # no broadcast
   new_carry = body_c.Tuple(*itertools.chain(x, y, new_z))
@@ -429,7 +429,7 @@ def cond(pred, true_operand, true_fun, false_operand, false_fun):
 def _cond_abstract_eval(*args, **kwargs):
   return _map(raise_to_shaped, kwargs["true_jaxpr"].out_avals)
 
-def _cond_translation_rule(c, axis_env, call_stack, pred, *args, **kwargs):
+def _cond_translation_rule(c, axis_env, name_stack, pred, *args, **kwargs):
   backend = kwargs.pop("backend", None)
   true_jaxpr, false_jaxpr, true_nconsts, false_nconsts = split_dict(
       kwargs, ["true_jaxpr", "false_jaxpr", "true_nconsts", "false_nconsts"])
@@ -438,19 +438,19 @@ def _cond_translation_rule(c, axis_env, call_stack, pred, *args, **kwargs):
       args, [true_nconsts, true_nops, false_nconsts])
 
   def make_computation(name, jaxpr, op_shape):
-    c = xb.make_computation_builder(name)
+    c = xb.make_computation_builder(name + '_comp')
     op = c.ParameterWithShape(op_shape)
     ops = [c.GetTupleElement(op, i) for i in range(len(jaxpr.in_avals))]
     outs = xla.jaxpr_subcomp(c, jaxpr.jaxpr, backend, axis_env,
                              _map(c.Constant, jaxpr.literals), (),
-                             call_stack + name + '/', *ops)
+                             extend_name_stack(name_stack, name + '_fun'), *ops)
     return c.Build(c.Tuple(*outs))
 
   true_op = c.Tuple(*(true_consts + true_ops))
-  true_c = make_computation("true_comp", true_jaxpr, c.GetShape(true_op))
+  true_c = make_computation('true', true_jaxpr, c.GetShape(true_op))
 
   false_op = c.Tuple(*(false_consts + false_ops))
-  false_c = make_computation("false_comp", false_jaxpr, c.GetShape(false_op))
+  false_c = make_computation('false', false_jaxpr, c.GetShape(false_op))
 
   return c.Conditional(pred, true_op, true_c, false_op, false_c)
 

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -213,7 +213,7 @@ def while_loop(cond_fun, body_fun, init_val):
 def _while_loop_abstract_eval(*args, **kwargs):
   return _map(raise_to_shaped, kwargs["body_jaxpr"].out_avals)
 
-def _while_loop_translation_rule(c, axis_env, *args, **kwargs):
+def _while_loop_translation_rule(c, axis_env, call_stack, *args, **kwargs):
   backend = kwargs.pop('backend')
   cond_jaxpr, body_jaxpr, cond_nconsts, body_nconsts = split_dict(
       kwargs, ["cond_jaxpr", "body_jaxpr", "cond_nconsts", "body_nconsts"])
@@ -233,7 +233,8 @@ def _while_loop_translation_rule(c, axis_env, *args, **kwargs):
   cond_carry_elts = [cond_c.GetTupleElement(cond_carry, i) for i in range(len(args))]
   x, _, z = split_list(cond_carry_elts, [cond_nconsts, body_nconsts])
   pred, = xla.jaxpr_subcomp(cond_c, cond_jaxpr.jaxpr, backend, axis_env,
-                            _map(cond_c.Constant, cond_jaxpr.literals), (), *(x + z))
+                            _map(cond_c.Constant, cond_jaxpr.literals), (),
+                            call_stack + 'cond/', *(x + z))
   if batched:
     scalar = ShapedArray((), onp.bool_)
     or_ = xla.primitive_subcomputation(lax.or_p, scalar, scalar)
@@ -245,10 +246,12 @@ def _while_loop_translation_rule(c, axis_env, *args, **kwargs):
   body_carry_elts = [body_c.GetTupleElement(body_carry, i) for i in range(len(args))]
   x, y, z = split_list(body_carry_elts, [cond_nconsts, body_nconsts])
   new_z = xla.jaxpr_subcomp(body_c, body_jaxpr.jaxpr, backend, axis_env,
-                            _map(body_c.Constant, body_jaxpr.literals), (), *(y + z))
+                            _map(body_c.Constant, body_jaxpr.literals), (),
+                            call_stack + 'body/', *(y + z))
   if batched:
     body_pred, = xla.jaxpr_subcomp(body_c, cond_jaxpr.jaxpr, backend, axis_env,
-                                   _map(body_c.Constant, cond_jaxpr.literals), (), *(x + z))
+                                   _map(body_c.Constant, cond_jaxpr.literals), (),
+                                   call_stack + 'body_pred/', *(x + z))
     new_z = _map(partial(_pred_bcast_select, body_c, body_pred), new_z, z)
     assert _map(body_c.GetShape, new_z) == _map(body_c.GetShape, z) # no broadcast
   new_carry = body_c.Tuple(*itertools.chain(x, y, new_z))
@@ -426,7 +429,7 @@ def cond(pred, true_operand, true_fun, false_operand, false_fun):
 def _cond_abstract_eval(*args, **kwargs):
   return _map(raise_to_shaped, kwargs["true_jaxpr"].out_avals)
 
-def _cond_translation_rule(c, axis_env, pred, *args, **kwargs):
+def _cond_translation_rule(c, axis_env, call_stack, pred, *args, **kwargs):
   backend = kwargs.pop("backend", None)
   true_jaxpr, false_jaxpr, true_nconsts, false_nconsts = split_dict(
       kwargs, ["true_jaxpr", "false_jaxpr", "true_nconsts", "false_nconsts"])
@@ -439,7 +442,8 @@ def _cond_translation_rule(c, axis_env, pred, *args, **kwargs):
     op = c.ParameterWithShape(op_shape)
     ops = [c.GetTupleElement(op, i) for i in range(len(jaxpr.in_avals))]
     outs = xla.jaxpr_subcomp(c, jaxpr.jaxpr, backend, axis_env,
-                             _map(c.Constant, jaxpr.literals), (), *ops)
+                             _map(c.Constant, jaxpr.literals), (),
+                             call_stack + name + '/', *ops)
     return c.Build(c.Tuple(*outs))
 
   true_op = c.Tuple(*(true_consts + true_ops))

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -35,6 +35,8 @@ class PrettyPrint(object):
   def __rshift__(self, rhs):
     if not rhs.lines:
       return self
+    if not self.lines:
+      return rhs
 
     indent, s = self.lines[-1]
     indented_block = rhs.indent(indent + len(s))
@@ -44,7 +46,7 @@ class PrettyPrint(object):
                        + indented_block.lines[1:])
 
   def __str__(self):
-    return '\n'.join(' ' * indent + s for indent, s in self.lines) + '\n'
+    return '\n'.join(' ' * indent + s for indent, s in self.lines)
 
 
 def pp(s):

--- a/jax/util.py
+++ b/jax/util.py
@@ -228,3 +228,9 @@ def get_module_functions(module):
         attr, (types.BuiltinFunctionType, types.FunctionType, onp.ufunc)):
       module_fns.add(attr)
   return module_fns
+
+def wrap_name(name, transform_name):
+  return transform_name + '(' + name + ')'
+
+def extend_name_stack(stack, name=''):
+  return stack + name + '/'

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -1,0 +1,99 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from absl.testing import absltest
+from jax import test_util as jtu
+from jax.lib import xla_bridge as xb
+import jax
+from jax import numpy as jnp
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+class MetadataTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    self.op_names = []
+    self.op_types = []
+    def SetOpMetadata(builder, metadata):
+      self.op_names.append(metadata.op_name)
+      self.op_types.append(metadata.op_type)
+      return super(xb._JaxComputationBuilder, builder).SetOpMetadata(metadata)
+    xb._JaxComputationBuilder.SetOpMetadata = SetOpMetadata
+
+  def tearDown(self):
+    self.op_names = []
+    self.op_types = []
+    del xb._JaxComputationBuilder.SetOpMetadata
+
+  def test_primitive_metadata(self):
+    _ = jnp.sin(1.)
+    assert self.op_types[-1] == 'sin'
+    assert self.op_names[-1] == 'sin'
+    _ = jnp.reshape(1., (1,))
+    assert self.op_types[-1] == 'reshape'
+    assert self.op_names[-1] == 'reshape[ dimensions=None\n' \
+                                '         new_sizes=(1,)\n' \
+                                '         old_sizes=() ]'
+
+  def test_jit_metadata(self):
+    _ = jax.jit(jnp.sin)(1.)
+    assert self.op_types[-1] == 'sin'
+    assert self.op_names[-1] == 'jit(sin)/sin'
+    def foo(x):
+      return jnp.sin(x)
+    _ = jax.jit(foo)(1.)
+    assert self.op_types[-1] == 'sin'
+    assert self.op_names[-1] == 'jit(foo)/sin'
+
+  def test_nested_jit_metadata(self):
+    @jax.jit
+    def foo(x):
+      return jnp.sin(x)
+    def bar(x):
+      return jnp.cos(foo(x))
+    _ = bar(1.)
+    assert self.op_types[-2] == 'sin'
+    assert self.op_names[-2] == 'jit(foo)/sin'
+    assert self.op_types[-1] == 'cos'
+    assert self.op_names[-1] == 'cos'
+    _ = jax.jit(bar)(1.)
+    assert self.op_types[-3] == 'xla_call'
+    assert self.op_names[-3] == 'jit(bar)/xla_call[ backend=None\n' \
+                                '                   device=None\n' \
+                                '                   name=foo ]'
+    assert self.op_types[-2] == 'sin'
+    assert self.op_names[-2] == 'jit(bar)/jit(foo)/sin'
+    assert self.op_types[-1] == 'cos'
+    assert self.op_names[-1] == 'jit(bar)/cos'
+
+  def test_grad_jit_metadata(self):
+    @jax.jit
+    def foo(x):
+      return jnp.sin(x)
+    _ = jax.grad(foo)(1.)
+    assert self.op_types[-3] == 'sin'
+    assert self.op_names[-3] == 'jit(pe(jvp(foo)))/sin'
+    assert self.op_types[-2] == 'cos'
+    assert self.op_names[-2] == 'jit(pe(jvp(foo)))/cos'
+    assert self.op_types[-1] == 'mul'
+    assert self.op_names[-1] == 'jit(transpose(pe(jvp(foo))))/mul'
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -94,6 +94,20 @@ class MetadataTest(jtu.JaxTestCase):
     assert self.op_types[-1] == 'mul'
     assert self.op_names[-1] == 'jit(transpose(pe(jvp(foo))))/mul'
 
+  def test_cond_metadata(self):
+    def true_fun(x):
+      return jnp.sin(x)
+    def false_fun(x):
+      return jnp.cos(x)
+    _ = jax.lax.cond(True, 1., true_fun, 1., false_fun)
+    assert self.op_types[-3] == 'cond'
+    assert self.op_names[-3] == 'cond[ false_nconsts=0\n' \
+                                '      true_nconsts=0 ]'
+    assert self.op_types[-2] == 'sin'
+    assert self.op_names[-2] == 'cond/true_fun/sin'
+    assert self.op_types[-1] == 'cos'
+    assert self.op_names[-1] == 'cond/false_fun/cos'
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
An important part of performance debugging is relating metadata/traces collected by profilers to the structure of the user program, in order to (for instance) understand what parts are slow. This PR is a step towards improving that experience. Where we might previously have had
```
|----------|-------------|---------------|
 XLA op 1     XLA op 2        XLA op 3
```
we'd eventually like to see traces along the lines of
```
|----------|-------------|---------------|
 XLA op 1     XLA op 2        XLA op 3
|------------------------|---------------|
          layer1            grad(layer1)
```
(Or perhaps the more accurate, if verbose, `pe(jvp(layer1))` and `transpose(pe(jvp(layer1)))` implemented here.)
In order to do that, we add a param called `name` to call primitives (including the primitive that backs `jit`), and optionally wrap that name with transformation descriptions in the corresponding call-handling transformation rules (`process_call` etc.). During XLA translation, we maintain a lexical call stack consisting of these names, and pass that stack as part of the metadata for each XLA op we create.