### PR TITLE
Allow JVP for SVD when not computing singular vectors

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -776,7 +776,7 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
   dA, = tangents
   s, U, Vt = svd_p.bind(A, full_matrices=False, compute_uv=True)
 
-  if full_matrices:
+  if compute_uv and full_matrices:
     # TODO: implement full matrices case, documented here: https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
     raise NotImplementedError(
       "Singular value decomposition JVP not implemented for full matrices")

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -456,8 +456,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     self._CompileAndCheck(partial(np.linalg.svd, full_matrices=full_matrices, compute_uv=compute_uv),
                           args_maker, check_dtypes=True)
-    if not full_matrices:
-      svd = partial(np.linalg.svd, full_matrices=False)
+    if not (compute_uv and full_matrices):
+      svd = partial(np.linalg.svd, full_matrices=full_matrices, compute_uv=compute_uv)
       jtu.check_jvp(svd, partial(jvp, svd), (a,), rtol=1e-2, atol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/2011. Essentially, the `'nuc'`, `2` and `-2` norms from `np.linalg.norm` would fail due to the default argument `True` for `full_matrices` even if `compute_uv` was `False`.