### PR TITLE
Make the reverse operator work on empty list of dimensions

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2619,7 +2619,7 @@ def _rev_shape_rule(operand, dimensions):
   if len(set(dimensions)) != len(dimensions):
     msg = 'rev dimensions must be unique, got {}.'
     raise TypeError(msg.format(dimensions))
-  if not _max(dimensions) < operand.ndim:
+  if dimensions and not _max(dimensions) < operand.ndim:
     msg = ('rev dimensions must all be less than operand ndim, got dimensions '
            '{} for operand ndim {}.')
     raise TypeError(msg.format(dimensions, operand.ndim))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -913,6 +913,10 @@ class LaxTest(jtu.JaxTestCase):
   def testReverse(self):
     rev = api.jit(lambda operand: lax.rev(operand, dimensions))
 
+    dimensions = []
+    self.assertAllClose(onp.array([0, 1, 2, 3]), rev(onp.array([0, 1, 2, 3])),
+                        check_dtypes=False)
+
     dimensions = [0]
     self.assertAllClose(onp.array([3, 2, 1]), rev(onp.array([1, 2, 3])),
                         check_dtypes=False)


### PR DESCRIPTION
Example that this fixes:
```
from jax import lax
import jax.numpy as np
from jax.api import jacrev

x = np.ones((3, 5))

def f(x):
  return lax.conv_general_dilated(lhs=x, 
                                  rhs=np.ones((5, 2)), 
                                  window_strides=(), 
                                  padding='VALID', 
                                  dimension_numbers=('NC', 'IO', 'NC'))
  
jacrev(f)(x)
```
currently gives
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-136-2ad65e41f1de> in <module>()
     12                                   dimension_numbers=('NC', 'IO', 'NC'))
     13 
---> 14 jacrev(f)(x).shape

15 frames
google3/third_party/py/jax/api.py in jacfun(*args, **kwargs)
    514     y, pullback = vjp(f_partial, *dyn_args)
    515     holomorphic or tree_map(_check_real_output_jacrev, y)
--> 516     jac = vmap(pullback)(_std_basis(y))
    517     jac = jac[0] if isinstance(argnums, int) else jac
    518     example_args = dyn_args[0] if isinstance(argnums, int) else dyn_args

google3/third_party/py/jax/api.py in batched_fun(*args)
    692     _check_axis_sizes(in_tree, args_flat, in_axes_flat)
    693     out_flat = batching.batch(flat_fun, args_flat, in_axes_flat,
--> 694                               lambda: _flatten_axes(out_tree(), out_axes))
    695     return tree_unflatten(out_tree(), out_flat)
    696 

google3/third_party/py/jax/interpreters/batching.py in batch(fun, in_vals, in_dims, out_dim_dests)
     38 def batch(fun, in_vals, in_dims, out_dim_dests):
     39   size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
---> 40   out_vals, out_dims = batch_fun(fun, in_vals, in_dims)
     41   return map(partial(matchaxis, size), out_dims, out_dim_dests(), out_vals)
     42 

google3/third_party/py/jax/interpreters/batching.py in batch_fun(fun, in_vals, in_dims)
     44   with new_master(BatchTrace) as master:
     45     fun, out_dims = batch_subtrace(fun, master, in_dims)
---> 46     out_vals = fun.call_wrapped(*in_vals)
     47     del master
     48   return out_vals, out_dims()

google3/third_party/py/jax/linear_util.py in call_wrapped(self, *args, **kwargs)
    150     gen = None
    151 
--> 152     ans = self.f(*args, **dict(self.params, **kwargs))
    153     del args
    154     while stack:

google3/third_party/py/jax/api.py in _vjp_pullback_wrapper(fun, cotangent_dtypes, io_tree, py_args)
   1237              "match type of corresponding primal output ({})")
   1238       raise TypeError(msg.format(_dtype(a), dtype))
-> 1239   ans = fun(*args)
   1240   return tree_unflatten(out_tree, ans)
   1241 

google3/third_party/py/jax/interpreters/ad.py in vjp_(*cts)
    114     dummy_primals_and_cts = (core.unit,) * len(cts) + cts
    115     dummy_args = (undefined_primal,) * len(jaxpr.invars)
--> 116     _, arg_cts = backward_pass(jaxpr, consts, (), dummy_args, dummy_primals_and_cts)
    117     arg_cts = arg_cts[len(primals):]
    118     return map(instantiate_zeros, primals, arg_cts)

google3/third_party/py/jax/interpreters/ad.py in backward_pass(jaxpr, consts, freevar_vals, args, cotangents_in)
    222       map(write_cotangent, bound_vars, ct_free_vars_out)
    223     else:
--> 224       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
    225     cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
    226     map(write_cotangent, eqn.invars, cts_out)

google3/third_party/py/jax/interpreters/ad.py in bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs)
    505   assert (x is undefined_primal) ^ (y is undefined_primal)
    506   if x is undefined_primal:
--> 507     out = zero if cotangent is zero else lhs_rule(cotangent, y, **kwargs)
    508     return out, None
    509   else:

google3/third_party/py/jax/lax/lax.py in _conv_general_dilated_transpose_lhs(g, rhs, window_strides, padding, lhs_dilation, rhs_dilation, dimension_numbers, feature_group_count, lhs_shape, rhs_shape, precision)
   2042       window_strides, onp.take(g.shape, out_sdims), padding, lhs_dilation,
   2043       rhs_dilation)
-> 2044   revd_weights = rev(rhs, rhs_sdims)
   2045   return conv_general_dilated(
   2046       g, revd_weights, window_strides=lhs_dilation, padding=padding,

google3/third_party/py/jax/lax/lax.py in rev(operand, dimensions)
    671   operator.
    672   """
--> 673   return rev_p.bind(operand, dimensions=tuple(dimensions))
    674 
    675 def select(pred, on_true, on_false):

google3/third_party/py/jax/core.py in bind(self, *args, **kwargs)
    157     top_trace = find_top_trace(args)
    158     if top_trace is None:
--> 159       return self.impl(*args, **kwargs)
    160 
    161     tracers = map(top_trace.full_raise, args)

google3/third_party/py/jax/interpreters/xla.py in apply_primitive(prim, *args, **params)
    159 def apply_primitive(prim, *args, **params):
    160   """Impl rule that compiles and runs a single primitive 'prim' using XLA."""
--> 161   compiled_fun = xla_primitive_callable(prim, *map(arg_spec, args), **params)
    162   return compiled_fun(*args)
    163 

google3/third_party/py/jax/interpreters/xla.py in xla_primitive_callable(prim, *arg_specs, **params)
    167   device = _device_from_arg_devices(arg_devices)
    168   backend = xb.get_device_backend(device)
--> 169   aval_out = prim.abstract_eval(*avals, **params)
    170   if not prim.multiple_results:
    171     handle_result = aval_to_result_handler(device, aval_out)

google3/third_party/py/jax/lax/lax.py in standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs)
   1540     return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs))
   1541   elif least_specialized is ShapedArray:
-> 1542     return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs))
   1543   elif least_specialized is UnshapedArray:
   1544     return UnshapedArray(dtype_rule(*args, **kwargs))

google3/third_party/py/jax/lax/lax.py in _rev_shape_rule(operand, dimensions)
   2620     msg = 'rev dimensions must be unique, got {}.'
   2621     raise TypeError(msg.format(dimensions))
-> 2622   if not _max(dimensions) < operand.ndim:
   2623     msg = ('rev dimensions must all be less than operand ndim, got dimensions '
   2624            '{} for operand ndim {}.')

ValueError: max() arg is an empty sequence
```