### PR TITLE
Update Jaxlib docker build.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,18 +7,12 @@ RUN apt-get update
 RUN apt-get install libffi-dev
 RUN git clone --branch v1.2.14 https://github.com/pyenv/pyenv.git /pyenv
 ENV PYENV_ROOT /pyenv
-RUN /pyenv/bin/pyenv install 2.7.15
 RUN /pyenv/bin/pyenv install 3.5.6
 RUN /pyenv/bin/pyenv install 3.6.8
 RUN /pyenv/bin/pyenv install 3.7.2
 RUN /pyenv/bin/pyenv install 3.8.0
 
-# Install build-dependencies of scipy.
-# TODO(phawkins): remove when there are scipy wheels for Python 3.8.
-RUN apt-get update && apt-get install -y libopenblas-dev gfortran
-
 # We pin numpy to a version < 1.16 to avoid version compatibility issues.
-RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 2.7.15 && pip install numpy==1.15.4 scipy cython setuptools wheel future six
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.5.6 && pip install numpy==1.15.4 scipy cython setuptools wheel six
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.6.8 && pip install numpy==1.15.4 scipy cython setuptools wheel six
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.7.2 && pip install numpy==1.15.4 scipy cython setuptools wheel six

--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -2,7 +2,7 @@
 set -xev
 
 PYTHON_VERSIONS="3.5.6 3.6.8 3.7.2 3.8.0"
-CUDA_VERSIONS="9.0 9.2 10.0 10.1"
+CUDA_VERSIONS="9.2 10.0 10.1"
 CUDA_VARIANTS="cuda" # "cuda-included"
 
 mkdir -p dist

--- a/build/build_wheel_docker_entrypoint.sh
+++ b/build/build_wheel_docker_entrypoint.sh
@@ -38,6 +38,9 @@ PY_TAG=$(python -c "import wheel; import wheel.pep425tags as t; print(t.get_abbr
 
 echo "Python tag: $PY_TAG"
 
+# Workaround for https://github.com/bazelbuild/bazel/issues/9254
+export BAZEL_LINKLIBS="-lstdc++"
+
 case $2 in
   cuda-included)
     python build.py --enable_cuda --bazel_startup_options="--output_user_root=/build/root"


### PR DESCRIPTION
* work around https://github.com/bazelbuild/bazel/issues/9254 by setting BAZEL_LINKLIBS=-lstdc++
* drop CUDA 9.0 support, since we use a batched kernel only present in CUDA 9.2 or later.
* drop Python 2.7 support.