### PR TITLE
Batching rule for custom_linear_solve

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1446,6 +1446,72 @@ def _linear_solve_transpose_rule(cotangent, *primals, **kwargs):
   return [None] * sum(const_lengths) + cotangent_b
 
 
+def _linear_solve_batching_rule(args, dims, **kwargs):
+  const_lengths, jaxprs, tree = split_dict(kwargs,
+                                           ["const_lengths", "jaxprs", "tree"])
+  orig_bat = [d is not batching.not_mapped for d in dims]
+  size, = {
+      a.shape[d] for a, d in zip(args, dims) if d is not batching.not_mapped
+  }
+
+  params, b = _split_linear_solve_args(args, const_lengths)
+  params_dims, b_dims = _split_linear_solve_args(dims, const_lengths)
+  params_bat, orig_b_bat = _split_linear_solve_args(orig_bat, const_lengths)
+
+  (matvec, vecmat, solve, solve_t) = jaxprs
+  (matvec_bat, vecmat_bat, solve_bat, solve_t_bat) = params_bat
+
+  # Fixpoint computation of which parts of x and b are batched; we need to
+  # ensure this is consistent between all four jaxprs
+  b_bat = orig_b_bat
+  x_bat = [False] * len(vecmat.out_avals)
+  for i in range(1 + len(orig_b_bat) + len(vecmat.out_avals)):
+    # Apply vecmat and solve -> new batched parts of x
+    vecmat_jaxpr_batched, vecmat_x_bat = batching.batch_jaxpr(
+        vecmat, size, vecmat_bat + b_bat, instantiate=x_bat)
+    solve_jaxpr_batched, solve_x_bat = batching.batch_jaxpr(
+        solve, size, solve_bat + b_bat, instantiate=x_bat)
+    x_bat_out = _map(operator.or_, vecmat_x_bat, solve_x_bat)
+    # Apply matvec and solve_t -> new batched parts of b
+    matvec_jaxpr_batched, matvec_b_bat = batching.batch_jaxpr(
+        matvec, size, matvec_bat + x_bat_out, instantiate=b_bat)
+    solve_t_jaxpr_batched, solve_t_b_bat = batching.batch_jaxpr(
+        solve_t, size, solve_t_bat + x_bat_out, instantiate=b_bat)
+    b_bat_out = _map(lambda m, s, o: m or s or o, matvec_b_bat, solve_t_b_bat,
+                     orig_b_bat)
+    if x_bat_out == x_bat and b_bat_out == b_bat:
+      break
+    else:
+      x_bat = x_bat_out
+      b_bat = b_bat_out
+  else:
+    assert False, "Fixedpoint not reached"
+
+  batched_jaxprs = _LinearSolveTuple(matvec_jaxpr_batched, vecmat_jaxpr_batched,
+                                     solve_jaxpr_batched, solve_t_jaxpr_batched)
+
+  # Move batched axes to the front
+  new_params = [
+      batching.moveaxis(x, d, 0)
+      if d is not batching.not_mapped and d != 0 else x
+      for x, d in zip(_flatten(params), _flatten(params_dims))
+  ]
+  # Broadcast out b if necessary
+  new_b = [
+      batching.broadcast(x, size, 0) if now_bat and not was_bat else
+      batching.moveaxis(x, d, 0) if now_bat and d != 0 else x
+      for x, d, was_bat, now_bat in zip(b, b_dims, orig_b_bat, b_bat)
+  ]
+
+  outs = linear_solve_p.bind(
+      *(new_params + new_b),
+      const_lengths=const_lengths,
+      jaxprs=batched_jaxprs,
+      tree=tree)
+  out_dims = [0 if batched else batching.not_mapped for batched in b_bat]
+  return outs, out_dims
+
+
 linear_solve_p = core.Primitive('custom_linear_solve')
 linear_solve_p.multiple_results = True
 linear_solve_p.def_impl(_custom_linear_solve_impl)
@@ -1454,4 +1520,4 @@ ad.primitive_jvps[linear_solve_p] = _custom_linear_solve_jvp
 xla.initial_style_translations[linear_solve_p] = xla.lower_fun(
     _custom_linear_solve_impl, initial_style=True)
 ad.primitive_transposes[linear_solve_p] = _linear_solve_transpose_rule
-# TODO(shoyer): write batching rule
+batching.primitive_batchers[linear_solve_p] = _linear_solve_batching_rule

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1371,11 +1371,10 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     actual = api.jit(linear_solve)(a, b)
     self.assertAllClose(expected, actual, check_dtypes=True)
 
-    # TODO(shoyer): reenable when batching works
-    # c = rng.randn(3, 2)
-    # expected = np.linalg.solve(a, c)
-    # actual = api.vmap(linear_solve, (None, 1), 1)(a, c)
-    # self.assertAllClose(expected, actual, check_dtypes=True)
+    c = rng.randn(3, 2)
+    expected = np.linalg.solve(a, c)
+    actual = api.vmap(linear_solve, (None, 1), 1)(a, c)
+    self.assertAllClose(expected, actual, check_dtypes=True)
 
   def test_custom_linear_solve_zeros(self):
     def explicit_jacobian_solve(matvec, b):
@@ -1424,10 +1423,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertAllClose(expected, actual, atol=1e-5, check_dtypes=True)
     jtu.check_grads(build_and_solve, (a, b), atol=1e-5, order=2, rtol=2e-3)
 
-    # TODO(shoyer): reenable when batching works
-    # a2 = rng.randn(1, 2, 2)
-    # b2 = rng.randn(1, 2, 2)
-    # jtu.check_grads(api.vmap(build_and_solve), (a2, b2), atol=1e-5, order=2)
+    # vmap across an empty dimension
+    jtu.check_grads(
+        api.vmap(build_and_solve), (a[None, :, :], b[None, :]),
+        atol=1e-5,
+        order=2,
+        rtol=2e-3)
 
   def test_custom_linear_solve_cholesky(self):
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1502,6 +1502,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     jtu.check_grads(loss, (a, b), order=2, modes=['fwd'],
                     atol={onp.float32: 2e-3, onp.float64: 1e-11})
+    jtu.check_grads(api.vmap(loss), (a[None,:,:], b[None,:]), order=2,
+                    modes=['fwd'], atol={onp.float32: 2e-3, onp.float64: 1e-11})
 
     with self.assertRaisesRegex(TypeError, "transpose_solve required"):
       api.grad(loss)(a, b)


### PR DESCRIPTION
This PR adds a batching rule for `custom_linear_solve` by batching each of the jaxprs stored in the underlying primitive. Conceptually, this corresponds to transforming the initial linear system into an implicit "block diagonal" system, where `matvec`/`vecmat` apply a linear operation to each part of the input, and `solve`/`transpose_solve` solve each block separately.

Note that the batching of the input and output must agree between all four jaxprs, since the `custom_linear_solve` JVP and transpose rules assume the shapes all match. In particular, the JVP passes the output of `solve` into (the JVP of) `matvec` and then that output back into `solve`, and the transpose rule causes the (cotangents for the) output of `solve` to be fed back into `solve_transpose`  (and then `vecmat` if there are higher dimensional derivatives). To ensure consistency we can do a fixed-point iteration to figure out whether each component of x and b are batched or not.

(This fixed point logic is really only relevant if the vector space we are operating over is a pytree with interesting dependency structures, since otherwise the output is almost certainly batched. I've added a test that does a matvec and a solve over Python lists of scalars to make sure this works as expected.)