### PR TITLE
Implement ndarray.tolist() on DeviceArray.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3445,6 +3445,7 @@ setattr(DeviceArray, "T", property(transpose))
 setattr(DeviceArray, "real", property(real))
 setattr(DeviceArray, "imag", property(imag))
 setattr(DeviceArray, "astype", _astype)
+setattr(DeviceArray, "tolist", lambda x: onp.array(x).tolist())
 
 
 # Extra methods that are handy


### PR DESCRIPTION
We could also possibly implement this on traced arrays, but it's already useful on `DeviceArray`s.