### PR TITLE
simplify cond by removing consts

### DIFF
--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -510,8 +510,7 @@ class _CondBuilder(_LoopBuilder):
     return lax_control_flow.cond_p.bind(
       *itertools.chain([self.pred], body_const_vals,
                        init_vals, false_body_const_vals, init_vals),
-      true_jaxpr=body_typed_jaxpr, false_jaxpr=false_body_typed_jaxpr,
-      true_nconsts=len(body_const_vals), false_nconsts=len(false_body_const_vals))
+      true_jaxpr=body_typed_jaxpr, false_jaxpr=false_body_typed_jaxpr)
 
 
 class _WhileBuilder(_LoopBuilder):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1697,11 +1697,9 @@ class JaxprTest(jtu.JaxTestCase):
           e = cond[ false_jaxpr={ lambda  ;  ; b a.
                                   let c = sub a b
                                   in [c] }
-                    false_nconsts=1
                     true_jaxpr={ lambda  ;  ; b a.
                                  let c = add a b
-                                 in [c] }
-                    true_nconsts=1 ] b a c a d
+                                 in [c] } ] b a c a d
       in [e] }
         """)
 

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -102,8 +102,7 @@ class MetadataTest(jtu.JaxTestCase):
       return jnp.cos(x)
     _ = jax.lax.cond(True, 1., true_fun, 1., false_fun)
     assert self.op_types[-3] == 'cond'
-    assert self.op_names[-3] == 'cond[ false_nconsts=0\n' \
-                                '      true_nconsts=0 ]'
+    assert self.op_names[-3] == 'cond'
     assert self.op_types[-2] == 'sin'
     assert self.op_names[-2] == 'cond/true_fun/sin'
     assert self.op_types[-1] == 'cos'


### PR DESCRIPTION
Some higher-order primitives, like 'scan' and 'while', benefit from distinguishing constants from other inputs to their closure-converted function arguments; the reason is that for those primitives constants act differently from the other inputs, which are loop carries or scanned-over values, and are handled differently by transformations. For example, they're used differently than loop carries in lattice fixed-point computations. As another example, in scan the constants in the forward computation are fanned out, so when transposing scan we generate an accumulate-add.

However, these considerations don't hold true for cond: since there's no looping going on (and hence no lattice fixed-points), constants are treated just like the other operands. So we don't need to carry around the distinction. That simplifies the cond rules a bit.