### PR TITLE
Fix implementation of cumsum/cumprod for boolean inputs.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3627,6 +3627,9 @@ batching.primitive_batchers[reduce_window_p] = _generic_reduce_window_batch_rule
 
 def _reduce_window_sum_shape_rule(operand, window_dimensions, window_strides,
                                   padding, input_shape):
+  if not dtypes.issubdtype(operand.dtype, onp.number):
+    msg = "operand to reduce_window_sum must have a number dtype, got {}"
+    raise TypeError(msg.format(onp.dtype(operand.dtype).name))
   return _common_reduce_window_shape_rule(operand, window_dimensions,
                                          window_strides, padding)
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1534,6 +1534,8 @@ def _make_cumulative_reduction(onp_reduction, window_reduce, init_val,
     if squash_nan:
       a = where(isnan(a), _constant_like(a, init_val), a)
 
+    if not dtype and _dtype(a) == bool_:
+      dtype = int_
     if dtype:
       a = lax.convert_element_type(a, dtype)
 
@@ -1553,7 +1555,6 @@ def _make_cumulative_reduction(onp_reduction, window_reduce, init_val,
   def cumulative_reduction(a, axis=None, dtype=None):
     # jit doesn't support kwargs as static_args.
     return _cumulative_reduction(a, axis, dtype)
-
   return cumulative_reduction
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1075,7 +1075,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_default, "lnp_op": getattr(lnp, op),
        "onp_op": getattr(onp, op)}
       for op in ["cumsum", "cumprod"]
-      for dtype in default_dtypes
+      for dtype in all_dtypes
       for out_dtype in default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))


### PR DESCRIPTION
Check for number inputs in the reduce_window_sum dtype rule.

Fixes #2105 