### PR TITLE
Rename Tracer.trace to Tracer._trace.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -228,7 +228,7 @@ def full_lower(val):
 
 def find_top_trace(xs):
  try:
-   top_trace = max((x.trace for x in xs if isinstance(x, Tracer)),
+   top_trace = max((x._trace for x in xs if isinstance(x, Tracer)),
                    key=attrgetter('level'))
  except ValueError:
    return None
@@ -250,22 +250,22 @@ class Trace(object):
       return self.pure(val)
     level = self.level
     sublevel = self.sublevel
-    if val.trace.master is self.master:
-      if val.trace.sublevel == sublevel:
+    if val._trace.master is self.master:
+      if val._trace.sublevel == sublevel:
         return val
-      elif val.trace.sublevel < sublevel:
+      elif val._trace.sublevel < sublevel:
         return self.sublift(val)
       else:
         raise Exception("Can't lift sublevels {} to {}"
-                        .format(val.trace.sublevel, sublevel))
-    elif val.trace.level < level:
-      if val.trace.sublevel > sublevel:
+                        .format(val._trace.sublevel, sublevel))
+    elif val._trace.level < level:
+      if val._trace.sublevel > sublevel:
         raise Exception("Incompatible sublevel: {}, {}"
-                        .format(val.trace, (level, sublevel)))
+                        .format(val._trace, (level, sublevel)))
       return self.lift(val)
-    elif val.trace.level > level:
+    elif val._trace.level > level:
       raise Exception("Can't lift {} to {}".format(val, self))
-    elif val.trace.level == self.level:
+    elif val._trace.level == self.level:
       raise Exception("Different traces at same level: {}, {}".format(val, self))
     else:
       raise Exception("Can't lift {} to {}".format(val, self))
@@ -287,14 +287,14 @@ class Trace(object):
 
 class Tracer(object):
   __array_priority__ = 1000
-  __slots__ = ['trace', '__weakref__']
+  __slots__ = ['_trace', '__weakref__']
 
   def __array__(self, *args, **kw):
     raise Exception("Tracer can't be used with raw numpy functions. "
                     "You might have\n  import numpy as np\ninstead of\n  import jax.numpy as np")
 
   def __init__(self, trace):
-    self.trace = trace
+    self._trace = trace
 
   def __iter__(self):
     return iter(self.aval._iter(self))
@@ -376,7 +376,7 @@ class Tracer(object):
         return attr
 
   def __repr__(self):
-    return 'Traced<{}>with<{}>'.format(self.aval, self.trace)
+    return 'Traced<{}>with<{}>'.format(self.aval, self._trace)
 
   def __copy__(self):
     return self
@@ -584,12 +584,12 @@ def process_env_traces(primitive, level, params_tuple, *args):
   params = dict(params_tuple)
   todo = []
   while True:
-    tracers = [x for x in outs if isinstance(x, Tracer) and x.trace.level > level]
+    tracers = [x for x in outs if isinstance(x, Tracer) and x._trace.level > level]
     if tracers:
-      ans = max(tracers, key=lambda x: x.trace.level)
+      ans = max(tracers, key=lambda x: x._trace.level)
     else:
       break
-    trace = type(ans.trace)(ans.trace.master, cur_sublevel())
+    trace = type(ans._trace)(ans._trace.master, cur_sublevel())
     outs = map(trace.full_raise, outs)
     outs, cur_todo = trace.post_process_call(primitive, outs, params)
     todo.append(cur_todo)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -61,7 +61,7 @@ def jvp_subtrace(master, primals, tangents):
   trace = JVPTrace(master, core.cur_sublevel())
   for x in list(primals) + list(tangents):
     if isinstance(x, Tracer):
-      assert x.trace.level < trace.level
+      assert x._trace.level < trace.level
   in_tracers = [JVPTracer(trace, x, t) if t is not zero else x
                 for x, t in zip(primals, tangents)]
   ans = yield in_tracers, {}
@@ -74,7 +74,7 @@ def jvp_subtrace_aux(master, primals, tangents):
   trace = JVPTrace(master, core.cur_sublevel())
   for x in list(primals) + list(tangents):
     if isinstance(x, Tracer):
-      assert x.trace.level < trace.level
+      assert x._trace.level < trace.level
   ans, aux = yield map(partial(JVPTracer, trace), primals, tangents), {}
   ans_tracers = map(trace.full_raise, ans)
   aux_tracers = map(trace.full_raise, aux)
@@ -360,7 +360,7 @@ class JVPTracer(Tracer):
   def __init__(self, trace, primal, tangent):
     if not core.skip_checks:
       _primal_tangent_shapes_match(primal, tangent)
-    self.trace = trace
+    self._trace = trace
     self.primal = primal
     self.tangent = tangent
 

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -69,7 +69,7 @@ class BatchTracer(Tracer):
 
   def __init__(self, trace, val, batch_dim):
     assert core.skip_checks or type(batch_dim) in (int, NotMapped)
-    self.trace = trace
+    self._trace = trace
     self.val = val
     self.batch_dim = batch_dim
 

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -343,7 +343,7 @@ class MaskTracer(Tracer):
   __slots__ = ["val", "shape_expr"]
 
   def __init__(self, trace, val, shape_expr):
-    self.trace = trace
+    self._trace = trace
     self.val = val
     self.shape_expr = shape_expr
 
@@ -430,7 +430,7 @@ class ShapeCheckTracer(Tracer):
   __slots__ = ["shape_expr"]
 
   def __init__(self, trace, shape_expr):
-    self.trace = trace
+    self._trace = trace
     self.shape_expr = shape_expr
 
   @property

--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -69,7 +69,7 @@ not_sharded = None
 
 class PapplyTracer(Tracer):
   def __init__(self, trace, name, axis_size, val, axis):
-    self.trace = trace
+    self._trace = trace
     self.name = name
     self.axis_size = axis_size
     self.val = val

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -58,7 +58,7 @@ class JaxprTrace(Trace):
     return JaxprTracer(self, val.pval, FreeVar(val))
 
   def new_const(self, val):
-    if isinstance(val, Tracer) and val.trace.level == self.level:
+    if isinstance(val, Tracer) and val._trace.level == self.level:
       raise Exception
     return JaxprTracer(self, PartialVal((None, val)), unit)
 
@@ -267,13 +267,13 @@ class JaxprTracer(Tracer):
     assert isinstance(pval, PartialVal)
     pv, const = pval
     if isinstance(const, Tracer):
-      assert const.trace.level < trace.level
-    self.trace = trace
+      assert const._trace.level < trace.level
+    self._trace = trace
     self.pval = pval
     self.recipe = recipe
 
   def __repr__(self):
-    return 'Traced<{}:{}>'.format(self.aval, self.trace)
+    return 'Traced<{}:{}>'.format(self.aval, self._trace)
 
   @property
   def aval(self):

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -456,7 +456,7 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
 
   @lu.wrap_init
   def dynamic_fun(dummy, *args):
-    with extend_dynamic_axis_env(axis_name, dummy.trace, global_axis_size):
+    with extend_dynamic_axis_env(axis_name, dummy._trace, global_axis_size):
       return fun.call_wrapped(*args)
 
   avals = tuple(map(partial(shard_aval, axis_size), avals))
@@ -742,7 +742,7 @@ def add_chunk_to_axis_env(axis_name, soft_trace, soft_size):
 
 class SplitAxisTracer(core.Tracer):
   def __init__(self, trace, axis_name, val):
-    self.trace = trace
+    self._trace = trace
     self.axis_name = axis_name
     self.val = val
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2656,6 +2656,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         "If using `jit`, try using `static_argnums` or applying `jit` to smaller subfunctions.",
         lambda: api.jit(lnp.zeros)(2))
 
+  def testTraceMethod(self):
+    x = onp.random.randn(3, 4).astype(lnp.float_)
+    self.assertAllClose(x.trace(), lnp.array(x).trace(), check_dtypes=True)
+    self.assertAllClose(x.trace(), api.jit(lambda y: y.trace())(x),
+                        check_dtypes=True)
+
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.
 


### PR DESCRIPTION
Makes the .trace() method work on arrays.

Fixes #2094 