### PR TITLE
Remove "from __future__" uses from JAX.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -16,9 +16,6 @@
 #
 # Helper script for building JAX's libjax easily.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import argparse
 import collections

--- a/examples/advi.py
+++ b/examples/advi.py
@@ -18,8 +18,6 @@ This demo fits a Gaussian approximation to an intractable, unnormalized
 density, by differentiating through a Monte Carlo estimate of the
 variational evidence lower bound (ELBO)."""
 
-from __future__ import absolute_import
-from __future__ import print_function
 
 from functools import partial
 import matplotlib.pyplot as plt

--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -14,9 +14,6 @@
 
 """Datasets used in examples."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import array
 import gzip

--- a/examples/differentially_private_sgd.py
+++ b/examples/differentially_private_sgd.py
@@ -63,9 +63,6 @@ Example invocations:
    --epochs=45 \
    --learning_rate=.25 \
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools
 import time

--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import sys

--- a/examples/gaussian_process_regression.py
+++ b/examples/gaussian_process_regression.py
@@ -15,9 +15,6 @@
 """A basic example demonstrating using JAX to do Gaussian process regression.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 from absl import app
 from absl import flags
 from functools import partial

--- a/examples/kernel_lsq.py
+++ b/examples/kernel_lsq.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/examples/mnist_classifier.py
+++ b/examples/mnist_classifier.py
@@ -19,9 +19,6 @@ the mini-library jax.experimental.optimizers is for first-order stochastic
 optimization.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import time
 import itertools

--- a/examples/mnist_classifier_fromscratch.py
+++ b/examples/mnist_classifier_fromscratch.py
@@ -17,9 +17,6 @@
 The primary aim here is simplicity and minimal dependencies.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import time
 

--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -18,9 +18,6 @@ This file uses the stax network definition library and the optimizers
 optimization library.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import time

--- a/examples/onnx2xla.py
+++ b/examples/onnx2xla.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """An ONNX to XLA compiler by JAX-tracing a Numpy-backed ONNX interpreter."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from cStringIO import StringIO
 from functools import partial

--- a/examples/resnet50.py
+++ b/examples/resnet50.py
@@ -17,9 +17,6 @@
 This file uses the stax neural network definition library and the optimizers
 optimization library.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy.random as npr
 

--- a/examples/spmd_mnist_classifier_fromscratch.py
+++ b/examples/spmd_mnist_classifier_fromscratch.py
@@ -20,9 +20,6 @@ minimizing dependencies by avoiding the use of higher-level layers and
 optimizers libraries.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import time

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 

--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .core import lattice_join, Primitive, Unit, unit, AbstractUnit, abstract_unit
 from .tree_util import register_pytree_node

--- a/jax/api.py
+++ b/jax/api.py
@@ -23,9 +23,6 @@ tree_util.py), which include nested tuples/lists/dicts, where the leaves are
 arrays.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .tree_util import (build_tree, tree_flatten, tree_unflatten,
                         treedef_is_leaf)

--- a/jax/core.py
+++ b/jax/core.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from operator import attrgetter
 from contextlib import contextmanager

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -19,9 +19,6 @@
 # b) the set of supported types (e.g., bfloat16),
 # so we need our own implementation that deviates from NumPy in places.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from distutils.util import strtobool
 import functools

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -103,9 +103,6 @@ Transformations:
 For usage example, see tests/loops_test.py.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import copy
 from functools import partial

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -22,9 +22,6 @@ stepsize integration methods.
 Adjoint algorithm based on Appendix C of https://arxiv.org/pdf/1806.07366.pdf
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import time

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -66,9 +66,6 @@ the JAX transforms defined in api.py) and it has to be consumable by update_fun
 and get_params.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 import functools

--- a/jax/experimental/optix.py
+++ b/jax/experimental/optix.py
@@ -38,9 +38,6 @@ Many popular optimizers can be implemented using `optix` as one-liners, and,
 for convenience, we provide aliases for some of the most popular ones.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -17,9 +17,6 @@
 For an example of its use, see examples/resnet50.py.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import itertools

--- a/jax/flatten_util.py
+++ b/jax/flatten_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .tree_util import tree_flatten, tree_unflatten
 from . import linear_util as lu

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import itertools as it

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 
 from contextlib import contextmanager
 from collections import defaultdict, Counter, namedtuple

--- a/jax/interpreters/parallel.py
+++ b/jax/interpreters/parallel.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import warnings

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools as it
 from collections import namedtuple, Counter, defaultdict

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple, defaultdict
 from contextlib import contextmanager

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple, defaultdict
 from distutils.util import strtobool

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from .lax import *
 from .lax import (_reduce_sum, _reduce_max, _reduce_min, _reduce_or,
                   _reduce_and, _reduce_window_sum, _reduce_window_max,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import builtins
 import collections

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -16,9 +16,6 @@
 Control flow primitives.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -15,9 +15,6 @@
 Parallelization primitives.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import numpy as onp

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import builtins
 import collections

--- a/jax/lazy.py
+++ b/jax/lazy.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 import functools

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -19,9 +19,6 @@ and provide some automatic type mapping logic for converting between Numpy and
 XLA. There are also a handful of related casting utilities.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import os

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -62,9 +62,6 @@ dynamic positional arguments for the generators, and also the auxiliary output
 data must be immutable, because it will be stored in function memoization tables.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import weakref
 

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -14,8 +14,6 @@
 
 """Shared neural network activations and other functions."""
 
-from __future__ import absolute_import
-from __future__ import division
 
 import numpy as onp
 

--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -17,8 +17,6 @@ Common neural network layer initializers, consistent with definitions
 used in Keras and Sonnet.
 """
 
-from __future__ import absolute_import
-from __future__ import division
 
 from functools import partial
 

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from .lax_numpy import *
 from . import fft
 from . import linalg

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -24,9 +24,6 @@ transformations for NumPy primitives can be derived from the transformation
 rules for the underlying :code:`lax` primitives.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from distutils.util import strtobool
 import builtins

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/jax/ops/__init__.py
+++ b/jax/ops/__init__.py
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 
 from .scatter import index, index_add, index_update, index_min, index_max, segment_sum

--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -14,9 +14,6 @@
 
 # Helpers for indexed updates.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 from functools import partial

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -20,9 +20,6 @@ The JAX PRNG system is based on "Parallel random numbers: as easy as 1, 2, 3"
 https://github.com/google/jax/blob/master/design_notes/prng.md
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import itertools

--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from . import linalg
 from . import ndimage
 from . import special

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import itertools

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.special as osp_special

--- a/jax/scipy/stats/__init__.py
+++ b/jax/scipy/stats/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from . import bernoulli
 from . import poisson
 from . import beta

--- a/jax/scipy/stats/bernoulli.py
+++ b/jax/scipy/stats/bernoulli.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/cauchy.py
+++ b/jax/scipy/stats/cauchy.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/dirichlet.py
+++ b/jax/scipy/stats/dirichlet.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/expon.py
+++ b/jax/scipy/stats/expon.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/gamma.py
+++ b/jax/scipy/stats/gamma.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/multivariate_normal.py
+++ b/jax/scipy/stats/multivariate_normal.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/norm.py
+++ b/jax/scipy/stats/norm.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/pareto.py
+++ b/jax/scipy/stats/pareto.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/poisson.py
+++ b/jax/scipy/stats/poisson.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import scipy.stats as osp_stats
 

--- a/jax/scipy/stats/t.py
+++ b/jax/scipy/stats/t.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 import scipy.stats as osp_stats

--- a/jax/scipy/stats/uniform.py
+++ b/jax/scipy/stats/uniform.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import scipy.stats as osp_stats
 

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from contextlib import contextmanager
 import functools

--- a/jax/tools/jax_to_hlo.py
+++ b/jax/tools/jax_to_hlo.py
@@ -63,9 +63,6 @@ Implementation note: This script must be python2 compatible for now, because
 Google's genrules still run with python2, b/66712815.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from ast import literal_eval
 import importlib

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -35,9 +35,6 @@ See the `JAX pytrees notebook <https://jax.readthedocs.io/en/latest/notebooks/JA
 for examples.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import collections

--- a/jax/util.py
+++ b/jax/util.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/jaxlib/cuda_prng.py
+++ b/jaxlib/cuda_prng.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import itertools

--- a/jaxlib/cusolver.py
+++ b/jaxlib/cusolver.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 import operator

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 from contextlib import contextmanager

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import numpy as onp
 from absl.testing import absltest

--- a/tests/benchmarks/xla.py
+++ b/tests/benchmarks/xla.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import enum
 import pytest

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 import gc

--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for --debug_nans."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import enum
 import itertools

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools
 import unittest

--- a/tests/generated_fun_test.py
+++ b/tests/generated_fun_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 from functools import partial

--- a/tests/infeed_test.py
+++ b/tests/infeed_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import threading
 

--- a/tests/jax_to_hlo_test.py
+++ b/tests/jax_to_hlo_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 import jax.numpy as np

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 from functools import partial

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import defaultdict
 import itertools

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import enum

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import functools

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for the LAPAX linear algebra module."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import itertools

--- a/tests/loops_test.py
+++ b/tests/loops_test.py
@@ -14,9 +14,6 @@
 
 """Tests for the experimental/loops."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 import numpy as onp

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 from unittest import SkipTest

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from jax import test_util as jtu

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 from unittest import SkipTest

--- a/tests/multibackend_test.py
+++ b/tests/multibackend_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for nn module."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import itertools

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for the optimizers module."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import functools
 

--- a/tests/optix_test.py
+++ b/tests/optix_test.py
@@ -14,9 +14,6 @@
 
 """Tests for the optix module."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from jax import numpy as jnp

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import itertools
 import unittest

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 import os

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 from unittest import SkipTest

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from functools import partial
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import itertools

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for Stax library."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import jax
 import jax.numpy as np

--- a/tests/vectorize_test.py
+++ b/tests/vectorize_test.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 """Tests for Vectorize library."""
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from absl.testing import absltest
 from jax.lib import xla_bridge as xb


### PR DESCRIPTION
The future (Python 3) has arrived; no need to request it explicitly.