### PR TITLE
Initial implementation of DLPack support.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "d873d5cedbd91b44f5512fee2548c158f9d6ed5448e4a554264eca0800df1e6f",
-    strip_prefix = "tensorflow-e0d40be9f3db043787637c07ca342bd3ed1a2bee",
+    sha256 = "46d17ceaae12196c1cb2e99ca0cf040e7cefdc45ae9eede60c3caf3c5aaf5e48",
+    strip_prefix = "tensorflow-93ccefd6d3b8d32f7afcc43568fc7e872e744767",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/e0d40be9f3db043787637c07ca342bd3ed1a2bee.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/93ccefd6d3b8d32f7afcc43568fc7e872e744767.tar.gz",
     ],
 )
 

--- a/jax/dlpack.py
+++ b/jax/dlpack.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import lazy
+from .interpreters import xla
+from .lib import xla_client
+from .lib import xla_bridge
+
+def to_dlpack(x):
+  """Returns a DLPack tensor that encapsulates a DeviceArray `x`.
+
+  The DLPack shares memory with `x`.
+
+  Args:
+    x: a `DeviceArray`, on either CPU or GPU.
+  """
+  if not isinstance(x, xla.DeviceArray):
+    raise TypeError("Argument to to_dlpack must be a DeviceArray, got {}"
+                    .format(type(x)))
+  buf = xla._force(x).device_buffer
+  return xla_client._xla.BufferToDLPackManagedTensor(buf)
+
+def from_dlpack(dlpack, backend=None):
+  """Returns a `DeviceArray` representation of a DLPack tensor `dlpack`.
+
+  The returned `DeviceArray` shares memory with `dlpack`.
+
+  Args:
+    dlpack: a DLPack tensor, on either CPU or GPU.
+    backend: experimental, optional: the platform on which `dlpack` lives.
+  """
+  # TODO(phawkins): ideally the user wouldn't need to provide a backend and we
+  # would be able to figure it out from the DLPack.
+  backend = backend or xla_bridge.get_backend()
+  buf = xla_client._xla.DLPackManagedTensorToBuffer(dlpack, backend.client)
+  aval = xla._aval_from_xla_shape(buf.shape())
+  return xla.DeviceArray(aval, buf.device(), lazy.array(aval.shape), buf)

--- a/tests/dlpack_test.py
+++ b/tests/dlpack_test.py
@@ -60,8 +60,10 @@ class DLPackTest(jtu.JaxTestCase):
      "shape": shape, "dtype": dtype}
      for shape in all_shapes
      for dtype in scalar_types))
-  def testJaxRoundTrip(self):
-    x = jax.random.normal(jax.random.PRNGKey(42), (3, 1, 5))
+  def testJaxRoundTrip(self, shape, dtype):
+    rng = jtu.rand_default()
+    np = rng(shape, dtype)
+    x = jnp.array(np)
     dlpack = jax.dlpack.to_dlpack(x)
     y = jax.dlpack.from_dlpack(dlpack)
     self.assertAllClose(x, y, check_dtypes=True)
@@ -100,11 +102,8 @@ class DLPackTest(jtu.JaxTestCase):
     np = rng(shape, dtype)
     x = jnp.array(np)
     dlpack = jax.dlpack.to_dlpack(x)
-    print(dlpack)
     y = torch.utils.dlpack.from_dlpack(dlpack)
-    print(dlpack)
     self.assertAllClose(np, y.numpy(), check_dtypes=True)
-    print("ok")
 
 
 if __name__ == "__main__":

--- a/tests/dlpack_test.py
+++ b/tests/dlpack_test.py
@@ -1,0 +1,111 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from absl.testing import absltest, parameterized
+import numpy as np
+
+import jax
+from jax.config import config
+import jax.dlpack
+import jax.numpy as jnp
+from jax import test_util as jtu
+
+config.parse_flags_with_absl()
+
+try:
+  import torch
+  import torch.utils.dlpack
+except ImportError:
+  torch = None
+
+
+scalar_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
+                jnp.uint8, jnp.uint16, jnp.uint32, jnp.uint64,
+                jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64]
+torch_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
+                jnp.uint8, jnp.float16, jnp.float32, jnp.float64]
+
+nonempty_nonscalar_array_shapes = [(4,), (3, 4), (2, 3, 4)]
+empty_array_shapes = []
+# TODO(phawkins): size 0 and 1 dimensions are mishandled (with an error) when
+# being imported to JAX in jaxlib 0.1.38.
+if jax.lib.version > (0, 1, 38):
+  empty_array_shapes += [(0,), (0, 4), (3, 0),]
+  nonempty_nonscalar_array_shapes += [(3, 1), (1, 4), (2, 1, 4)]
+
+nonempty_array_shapes = [()] + nonempty_nonscalar_array_shapes
+all_shapes = nonempty_array_shapes + empty_array_shapes
+
+class DLPackTest(jtu.JaxTestCase):
+  def setUp(self):
+    if jtu.device_under_test() == "tpu":
+      self.skipTest("DLPack not supported on TPU")
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+     {"testcase_name": "_{}".format(
+        jtu.format_shape_dtype_string(shape, dtype)),
+     "shape": shape, "dtype": dtype}
+     for shape in all_shapes
+     for dtype in scalar_types))
+  def testJaxRoundTrip(self):
+    x = jax.random.normal(jax.random.PRNGKey(42), (3, 1, 5))
+    dlpack = jax.dlpack.to_dlpack(x)
+    y = jax.dlpack.from_dlpack(dlpack)
+    self.assertAllClose(x, y, check_dtypes=True)
+
+    self.assertRaisesRegex(RuntimeError,
+                           "DLPack tensor may be consumed at most once",
+                           lambda: jax.dlpack.from_dlpack(dlpack))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+     {"testcase_name": "_{}".format(
+        jtu.format_shape_dtype_string(shape, dtype)),
+     "shape": shape, "dtype": dtype}
+     for shape in all_shapes
+     for dtype in torch_types))
+  @unittest.skipIf(not torch, "Test requires PyTorch")
+  def testTorchToJax(self, shape, dtype):
+    rng = jtu.rand_default()
+    np = rng(shape, dtype)
+    x = torch.from_numpy(np)
+    x = x.cuda() if jtu.device_under_test() == "gpu" else x
+    dlpack = torch.utils.dlpack.to_dlpack(x)
+    y = jax.dlpack.from_dlpack(dlpack)
+    self.assertAllClose(np, y, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+     {"testcase_name": "_{}".format(
+        jtu.format_shape_dtype_string(shape, dtype)),
+     "shape": shape, "dtype": dtype}
+     for shape in all_shapes
+     for dtype in torch_types))
+  @unittest.skipIf(not torch or jax.lib.version <= (0, 1, 38),
+                   "Test requires PyTorch and jaxlib >= 0.1.39")
+  # TODO(phawkins): the dlpack destructor issues errors in jaxlib 0.1.38.
+  def testJaxToTorch(self, shape, dtype):
+    rng = jtu.rand_default()
+    np = rng(shape, dtype)
+    x = jnp.array(np)
+    dlpack = jax.dlpack.to_dlpack(x)
+    print(dlpack)
+    y = torch.utils.dlpack.from_dlpack(dlpack)
+    print(dlpack)
+    self.assertAllClose(np, y.numpy(), check_dtypes=True)
+    print("ok")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/dlpack_test.py
+++ b/tests/dlpack_test.py
@@ -35,8 +35,8 @@ except ImportError:
 scalar_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                 jnp.uint8, jnp.uint16, jnp.uint32, jnp.uint64,
                 jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64]
-torch_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
-                jnp.uint8, jnp.float16, jnp.float32, jnp.float64]
+torch_types = [jnp.int8, jnp.int16, jnp.int32, jnp.int64,
+               jnp.uint8, jnp.float16, jnp.float32, jnp.float64]
 
 nonempty_nonscalar_array_shapes = [(4,), (3, 4), (2, 3, 4)]
 empty_array_shapes = []


### PR DESCRIPTION
Unfortunately there are still a few bugs in the jaxlib DLPack support, so this code won't be ready to use until jaxlib 0.1.39.