### PR TITLE
Support __cuda_array_interface__ on JAX DeviceArrays.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "46d17ceaae12196c1cb2e99ca0cf040e7cefdc45ae9eede60c3caf3c5aaf5e48",
-    strip_prefix = "tensorflow-93ccefd6d3b8d32f7afcc43568fc7e872e744767",
+    sha256 = "4ce0e08aa014fafa7a0e8fb3531bdc914bd8a49828e1f5c31bb8adfb751ad73d",
+    strip_prefix = "tensorflow-210649dd56d7c4b75e3e8e2a851b61c80ae13dbb",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/93ccefd6d3b8d32f7afcc43568fc7e872e744767.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/210649dd56d7c4b75e3e8e2a851b61c80ae13dbb.tar.gz",
     ],
 )
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -832,6 +832,10 @@ class DeviceArray(DeviceValue):
   def __array__(self, dtype=None, context=None):
     return onp.asarray(self._value, dtype=dtype)
 
+  @property
+  def __cuda_array_interface__(self):
+    return _force(self).device_buffer.__cuda_array_interface__
+
   __str__ = partialmethod(_forward_to_value, str)
   __bool__ = __nonzero__ = partialmethod(_forward_to_value, bool)
   def __float__(self): return self._value.__float__()


### PR DESCRIPTION
Allows exporting GPU device-resident arrays to other libraries, e.g., CuPy.

Fixes half of issue #1100 namely exporting GPU-resident arrays from JAX to other systems. The reverse direction (importing arrays into JAX) is yet to come.