### PR TITLE
Upgrade bazel from 0.29.1 to 1.2.1

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -57,19 +57,19 @@ def get_python_bin_path(python_bin_path_flag):
 
 # Bazel
 
-BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/0.29.1/"
+BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/1.2.1/"
 BazelPackage = collections.namedtuple("BazelPackage", ["file", "sha256"])
 bazel_packages = {
     "Linux":
         BazelPackage(
-            file="bazel-0.29.1-linux-x86_64",
+            file="bazel-1.2.1-linux-x86_64",
             sha256=
-            "da3031d811f42f6208d24a87984b5b07e1c75afede184cad86eb02bef6c3b9b0"),
+            "f5e21d7448419d1596ad0c5bb71fb336a0af08c832587aec394970ea56701d88"),
     "Darwin":
         BazelPackage(
-            file="bazel-0.29.1-darwin-x86_64",
+            file="bazel-1.2.1-darwin-x86_64",
             sha256=
-            "34daae4caafbdb0952415ed6f97f47f03df84df9af146e9eb910ba65c073efdd"),
+            "6729be5a56e6eadf7a9112afd2d87ce348da8fca22077b882d9bb7a6f5d41d1c"),
 }
 
 


### PR DESCRIPTION
Bazel version `0.29.1` is not compatible with the latest TensorFlow/XLA. According to the [Bazel version flags](https://github.com/tensorflow/tensorflow/blob/073460df145807ce4968718db793d8e2675b9d7e/configure.py#L52-L53), it is better to upgrade the version of Bazel used in JAX to `1.2.1`. If not, issues due to incompatible Bazel version will and interrupt successful installation.