### PR TITLE
Better batching rule for triangular_solve

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -382,13 +382,28 @@ def triangular_solve_batching_rule(batched_args, batch_dims, left_side,
                                    unit_diagonal):
   x, y = batched_args
   bx, by = batch_dims
-  size = next(t.shape[i] for t, i in zip(batched_args, batch_dims)
-              if i is not None)
-  x = batching.bdim_at_front(x, bx, size)
-  y = batching.bdim_at_front(y, by, size)
-  return triangular_solve(x, y, left_side=left_side, lower=lower,
-                          transpose_a=transpose_a, conjugate_a=conjugate_a,
-                          unit_diagonal=unit_diagonal), 0
+  if bx is batching.not_mapped:
+    if left_side:
+      y = batching.moveaxis(y, by, -1)
+      y_flat = y.reshape(y.shape[:-2] + (y.shape[-2] * y.shape[-1],))
+      bdim_out = y.ndim - 1
+    else:
+      y = batching.moveaxis(y, by, 0)
+      y_flat = y.reshape((y.shape[0] * y.shape[1],) + y.shape[2:])
+      bdim_out = 0
+    out_flat = triangular_solve(
+        x, y_flat, left_side=left_side, lower=lower,
+        transpose_a=transpose_a, conjugate_a=conjugate_a,
+        unit_diagonal=unit_diagonal)
+    return out_flat.reshape(y.shape), bdim_out
+  else:
+    size = next(t.shape[i] for t, i in zip(batched_args, batch_dims)
+                if i is not None)
+    x = batching.bdim_at_front(x, bx, size)
+    y = batching.bdim_at_front(y, by, size)
+    return triangular_solve(x, y, left_side=left_side, lower=lower,
+                            transpose_a=transpose_a, conjugate_a=conjugate_a,
+                            unit_diagonal=unit_diagonal), 0
 
 triangular_solve_p = standard_primitive(
     triangular_solve_shape_rule, triangular_solve_dtype_rule,

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -388,9 +388,9 @@ def triangular_solve_batching_rule(batched_args, batch_dims, left_side,
       y_flat = y.reshape(y.shape[:-2] + (y.shape[-2] * y.shape[-1],))
       bdim_out = y.ndim - 1
     else:
-      y = batching.moveaxis(y, by, 0)
-      y_flat = y.reshape((y.shape[0] * y.shape[1],) + y.shape[2:])
-      bdim_out = 0
+      y = batching.moveaxis(y, by, -2)
+      y_flat = y.reshape(y.shape[:-3]  + (y.shape[-3] * y.shape[-2], y.shape[-1]))
+      bdim_out = y.ndim - 2
     out_flat = triangular_solve(
         x, y_flat, left_side=left_side, lower=lower,
         transpose_a=transpose_a, conjugate_a=conjugate_a,

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -318,6 +318,9 @@ def triangular_solve_shape_rule(a, b, left_side=False, **unused_kwargs):
   if a.ndim < 2:
     msg = "triangular_solve requires a.ndim to be at least 2, got {}."
     raise TypeError(msg.format(a.ndim))
+  if b.ndim < 2:
+    msg = "triangular_solve requires b.ndim to be at least 2, got {}."
+    raise TypeError(msg.format(b.ndim))
   if a.shape[-1] != a.shape[-2]:
     msg = ("triangular_solve requires the last two dimensions of a to be equal "
            "in size, got a.shape of {}.")

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -924,6 +924,30 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                 unit_diagonal=unit_diagonal, left_side=left_side)
     jtu.check_grads(f, (A, B), 2, rtol=4e-2, eps=1e-3)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_A={}_B={}_bdim={}_leftside={}".format(
+           a_shape, b_shape, bdims, left_side),
+       "left_side": left_side, "a_shape": a_shape, "b_shape": b_shape,
+       "bdims": bdims}
+      for left_side, a_shape, b_shape, bdims in [
+          (False, (4, 4), (2, 1, 4,), (None, 0)),
+          (False, (2, 4, 4), (1, 4,), (0, None)),
+          (False, (2, 4, 4), (2, 1, 4,), (0, 0)),
+          (True, (2, 4, 4), (2, 4, 1), (0, 0)),
+          (True, (1, 4, 4), (2, 1, 4, 3), (None, 0)),
+      ]))
+  def testTriangularSolveBatching(self, left_side, a_shape, b_shape, bdims):
+    rng = jtu.rand_default()
+    A = np.tril(rng(a_shape, onp.float32) + 5 * onp.eye(a_shape[-1]))
+    B = rng(b_shape, onp.float32)
+    f = partial(lax_linalg.triangular_solve, lower=True,
+                transpose_a=False, conjugate_a=False,
+                unit_diagonal=False, left_side=left_side)
+    x = vmap(f, bdims)(A, B)
+    actual = A @ x if left_side else x @ A
+    onp.testing.assert_allclose(actual - B, 0, atol=1e-5)
+
   def testTriangularSolveGradPrecision(self):
     rng = jtu.rand_default()
     a = np.tril(rng((3, 3), onp.float32))


### PR DESCRIPTION
Now, if only the right hand side argument `b` is batched, we leverage
triangular solve's builtin batching for handling multiple right-hand-side
vectors.

This makes the performance of `vmap` over only the second argument of linear
solves equivalent to relying on builtin batching::

    import numpy as onp
    import jax.numpy as np
    import jax
    rs = onp.random.RandomState(0)
    a = rs.randn(500, 500) + 0.1 * np.eye(500)
    b_mat = jax.device_put(rs.randn(500, 10))
    solve1 = jax.jit(np.linalg.solve)
    solve2 = jax.jit(jax.vmap(np.linalg.solve, in_axes=(None, 1), out_axes=1))

Before::

    In [6]: %timeit jax.device_get(solve1(a, b_mat))
    3.88 ms ± 293 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

    # 8x slower :(
    In [9]: %timeit jax.device_get(solve2(a, b_mat))
    23.5 ms ± 1.33 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

Now::

    In [2]: %timeit jax.device_get(solve1(a, b_mat))
    3.76 ms ± 304 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

    # same speed :)
    In [3]: %timeit jax.device_get(solve2(a, b_mat))
    3.72 ms ± 296 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)