### PR TITLE
Add jax.numpy.vectorize

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -51,7 +51,7 @@ Vectorization (:code:`vmap`)
 ----------------------------
 
 .. autofunction:: vmap
-
+.. autofunction:: numpy.vectorize
 
 Parallelization (:code:`pmap`)
 ------------------------------

--- a/jax/experimental/vectorize.py
+++ b/jax/experimental/vectorize.py
@@ -97,6 +97,15 @@ from jax import grad, jit, vmap
 import jax.numpy as jnp
 import numpy as np
 import re
+import warnings
+
+
+warnings.warn(
+    "jax.experimental.vectorize is deprecated and will be removed soon. Use "
+    "jax.numpy.vectorize instead.",
+    FutureWarning,
+)
+
 
 # See http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
 _DIMENSION_NAME = r'\w+'

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -15,3 +15,4 @@
 from .lax_numpy import *
 from . import fft
 from . import linalg
+from .vectorize import vectorize

--- a/jax/numpy/vectorize.py
+++ b/jax/numpy/vectorize.py
@@ -1,0 +1,236 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+import re
+import textwrap
+from typing import Any, Callable, Dict, List, Set, Tuple
+
+import numpy as onp
+
+from .. import api
+from .. import lax
+from .. import linear_util as lu
+from . import lax_numpy as np
+from ..util import safe_map as map, safe_zip as zip
+from .lax_numpy import _wraps
+
+
+# See http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html
+_DIMENSION_NAME = r'\w+'
+_CORE_DIMENSION_LIST = '(?:{0:}(?:,{0:})*)?'.format(_DIMENSION_NAME)
+_ARGUMENT = r'\({}\)'.format(_CORE_DIMENSION_LIST)
+_ARGUMENT_LIST = '{0:}(?:,{0:})*'.format(_ARGUMENT)
+_SIGNATURE = '^{0:}->{0:}$'.format(_ARGUMENT_LIST)
+
+
+CoreDims = Tuple[str, ...]
+NDArray = Any
+
+
+def _parse_gufunc_signature(
+    signature: str,
+) -> Tuple[List[CoreDims], List[CoreDims]]:
+  """Parse string signatures for a generalized universal function.
+
+  Args:
+    signature: generalized universal function signature, e.g.,
+      ``(m,n),(n,p)->(m,p)`` for ``np.matmul``.
+
+  Returns:
+    Tuple of input and output core dimensions parsed from the signature.
+  """
+  if not re.match(_SIGNATURE, signature):
+    raise ValueError(
+        'not a valid gufunc signature: {}'.format(signature))
+  return tuple([tuple(re.findall(_DIMENSION_NAME, arg))
+                for arg in re.findall(_ARGUMENT, arg_list)]
+               for arg_list in signature.split('->'))
+
+
+def _update_dim_sizes(
+    dim_sizes: Dict[str, int],
+    shape: Tuple[int, ...],
+    core_dims: CoreDims,
+    error_context: str,
+    *,
+    is_input: bool,
+):
+  """Incrementally check and update core dimension sizes for a single argument.
+
+  Args:
+    dim_sizes: sizes of existing core dimensions. Will be updated in-place.
+    shape: shape of this argument.
+    core_dims: core dimensions for this argument.
+
+  """
+  num_core_dims = len(core_dims)
+  if is_input:
+    if len(shape) < num_core_dims:
+      raise ValueError(
+          'input with shape %r does not have enough dimensions for all core '
+          'dimensions %r %s' % (shape, core_dims, error_context))
+  else:
+    if len(shape) != num_core_dims:
+      raise ValueError(
+          'output shape %r does not match core dimensions %r %s'
+          % (shape, core_dims, error_context))
+
+  core_shape = shape[-num_core_dims:] if core_dims else ()
+  for dim, size in zip(core_dims, core_shape):
+    if dim not in dim_sizes:
+      dim_sizes[dim] = size
+    elif size != dim_sizes[dim]:
+      raise ValueError(
+          'inconsistent size for core dimension %r: %r vs %r %s'
+          % (dim, size, dim_sizes[dim], error_context))
+
+
+def _parse_input_dimensions(
+    args: Tuple[NDArray, ...],
+    input_core_dims: List[CoreDims],
+    error_context: str,
+) -> Tuple[Tuple[int, ...], Dict[str, int]]:
+  """Parse broadcast and core dimensions for vectorize with a signature.
+
+  Args:
+    args: tuple of input arguments to examine.
+    input_core_dims: list of core dimensions corresponding to each input.
+
+  Returns:
+    broadcast_shape: common shape to broadcast all non-core dimensions to.
+    dim_sizes: common sizes for named core dimensions.
+  """
+  shapes = []
+  dim_sizes = {}
+  for arg, core_dims in zip(args, input_core_dims):
+    _update_dim_sizes(dim_sizes, arg.shape, core_dims, error_context,
+                      is_input=True)
+    ndim = arg.ndim - len(core_dims)
+    shapes.append(arg.shape[:ndim])
+  broadcast_shape = lax.broadcast_shapes(*shapes)
+  return broadcast_shape, dim_sizes
+
+
+def _broadcast_with_core_dims(
+    args: Tuple[NDArray, ...],
+    input_core_dims: List[CoreDims],
+    error_context: str,
+) -> Tuple[Tuple[NDArray, ...], Dict[str, int]]:
+  if len(args) != len(input_core_dims):
+    raise TypeError(
+        'wrong number of positional arguments: expected %r, got %r %s'
+        % (len(input_core_dims), len(args), error_context))
+
+  broadcast_shape, dim_sizes = _parse_input_dimensions(
+      args, input_core_dims, error_context)
+  input_shapes = [broadcast_shape + tuple(dim_sizes[dim] for dim in core_dims)
+                  for core_dims in input_core_dims]
+  args = tuple(map(np.broadcast_to, args, input_shapes))
+  return args, dim_sizes
+
+
+def _check_output_dims(
+    func: Callable,
+    dim_sizes: Dict[str, int],
+    expected_output_core_dims: List[CoreDims],
+    error_context: str):
+  """Check that output core dimensions match the signature."""
+  def wrapped(*args):
+    out = func(*args)
+    out_shapes = map(np.shape, out if isinstance(out, tuple) else [out])
+
+    if expected_output_core_dims is None:
+      output_core_dims = [()] * len(out_shapes)
+    else:
+      output_core_dims = expected_output_core_dims
+      if len(output_core_dims) > 1 and not isinstance(out, tuple):
+        raise TypeError(
+            "output must be a tuple when multiple outputs are expected, "
+            "got: {!r}\n{}".format(out, error_context))
+      if len(out_shapes) != len(output_core_dims):
+        raise TypeError(
+            'wrong number of output arguments: expected %r, got %r %s'
+            % (len(output_core_dims), len(out_shapes), error_context))
+
+    sizes = dict(dim_sizes)
+    for shape, core_dims in zip(out_shapes, output_core_dims):
+      _update_dim_sizes(sizes, shape, core_dims, error_context,
+                        is_input=False)
+
+    return out
+  return wrapped
+
+
+def _apply_excluded(func, excluded, args):
+  if not excluded:
+    return func, args
+
+  if max(excluded) >= len(args):
+    raise ValueError("excluded={!r} is invalid for {!r} argument(s)"
+                     .format(excluded, len(args)))
+
+  dynamic_args = [arg for i, arg in enumerate(args) if i not in excluded]
+  static_args = [(i, args[i]) for i in sorted(excluded)]
+
+  def new_func(*args):
+    args = list(args)
+    for i, arg in static_args:
+      args.insert(i, arg)
+    return func(*args)
+
+  return new_func, dynamic_args
+
+
+@_wraps(onp.vectorize, lax_description=textwrap.dedent("""
+    JAX's implementation of vectorize should be considerably more efficient
+    than NumPy's, because it uses a batching transformation rather than an
+    explicit "for" loop.
+
+    Note that JAX only supports the optional ``excluded`` (integer only) and
+    ``signature`` arguments, both of which must be specified with keywords.
+    """))
+def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
+
+  if any(not isinstance(exclude, int) for exclude in excluded):
+    raise TypeError("jax.numpy.vectorize can only exclude integer arguments, "
+                    "but excluded={!r}".format(excluded))
+  if excluded and min(excluded) < 0:
+    raise ValueError("excluded={!r} contains negative numbers".format(excluded))
+
+  @functools.wraps(pyfunc)
+  def vectorized(*args):
+    error_context = ("on vectorized function with excluded={!r} and "
+                     "signature={!r}".format(excluded, signature))
+    excluded_func, args = _apply_excluded(pyfunc, excluded, args)
+    args = tuple(map(np.asarray, args))
+
+    if signature is not None:
+      input_core_dims, output_core_dims = _parse_gufunc_signature(signature)
+      broadcast_args, dim_sizes = _broadcast_with_core_dims(
+          args, input_core_dims, error_context)
+    else:
+      input_core_dims = [()] * len(args)
+      broadcast_args = np.broadcast_arrays(*args)
+      output_core_dims = None
+      dim_sizes = {}
+
+    checked_func = _check_output_dims(
+        excluded_func, dim_sizes, output_core_dims, error_context)
+
+    num_batch_dims = broadcast_args[0].ndim - len(input_core_dims[0])
+    vectorized_func = checked_func
+    for _ in range(num_batch_dims):
+      vectorized_func = api.vmap(vectorized_func)
+    return vectorized_func(*broadcast_args)
+  return vectorized

--- a/tests/lax_numpy_vectorize_test.py
+++ b/tests/lax_numpy_vectorize_test.py
@@ -1,0 +1,217 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import itertools
+import unittest
+
+import numpy as onp
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax
+from jax import lax
+from jax import numpy as np
+from jax import test_util as jtu
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+class VectorizeTest(jtu.JaxTestCase):
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_leftshape={}_rightshape={}".format(left_shape, right_shape),
+       "left_shape": left_shape, "right_shape": right_shape, "result_shape": result_shape}
+      for left_shape, right_shape, result_shape in [
+          ((2, 3), (3, 4), (2, 4)),
+          ((2, 3), (1, 3, 4), (1, 2, 4)),
+          ((5, 2, 3), (1, 3, 4), (5, 2, 4)),
+          ((6, 5, 2, 3), (3, 4), (6, 5, 2, 4)),
+      ]))
+  def test_matmat(self, left_shape, right_shape, result_shape):
+    matmat = np.vectorize(np.dot, signature='(n,m),(m,k)->(n,k)')
+    self.assertEqual(matmat(np.zeros(left_shape),
+                            np.zeros(right_shape)).shape, result_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_leftshape={}_rightshape={}".format(left_shape, right_shape),
+       "left_shape": left_shape, "right_shape": right_shape, "result_shape": result_shape}
+      for left_shape, right_shape, result_shape in [
+          ((2, 3), (3,), (2,)),
+          ((2, 3), (1, 3), (1, 2)),
+          ((4, 2, 3), (1, 3), (4, 2)),
+          ((5, 4, 2, 3), (1, 3), (5, 4, 2)),
+      ]))
+  def test_matvec(self, left_shape, right_shape, result_shape):
+    matvec = np.vectorize(np.dot, signature='(n,m),(m)->(n)')
+    self.assertEqual(matvec(np.zeros(left_shape),
+                            np.zeros(right_shape)).shape, result_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_leftshape={}_rightshape={}".format(left_shape, right_shape),
+       "left_shape": left_shape, "right_shape": right_shape, "result_shape": result_shape}
+      for left_shape, right_shape, result_shape in [
+          ((3,), (3,), ()),
+          ((2, 3), (3,), (2,)),
+          ((4, 2, 3), (3,), (4, 2)),
+      ]))
+  def test_vecmat(self, left_shape, right_shape, result_shape):
+    vecvec = np.vectorize(np.dot, signature='(m),(m)->()')
+    self.assertEqual(vecvec(np.zeros(left_shape),
+                            np.zeros(right_shape)).shape, result_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(shape),
+       "shape": shape, "result_shape": result_shape}
+      for shape, result_shape in [
+          ((3,), ()),
+          ((2, 3,), (2,)),
+          ((1, 2, 3,), (1, 2)),
+      ]))
+  def test_magnitude(self, shape, result_shape):
+    size = 1
+    for x in shape:
+        size *= x
+    inputs = np.arange(size).reshape(shape)
+
+    @partial(np.vectorize, signature='(n)->()')
+    def magnitude(x):
+      return np.dot(x, x)
+
+    self.assertEqual(magnitude(inputs).shape, result_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(shape),
+       "shape": shape, "result_shape": result_shape}
+      for shape, result_shape in [
+          ((3,), ()),
+          ((2, 3), (2,)),
+          ((1, 2, 3, 4), (1, 2, 3)),
+      ]))
+  def test_mean(self, shape, result_shape):
+    mean = np.vectorize(np.mean, signature='(n)->()')
+    self.assertEqual(mean(np.zeros(shape)).shape, result_shape)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(shape),
+       "shape": shape, "result_shape": result_shape}
+      for shape, result_shape in [
+          ((), (2,)),
+          ((3,), (3,2,)),
+      ]))
+  def test_stack_plus_minus(self, shape, result_shape):
+
+    @partial(np.vectorize, signature='()->(n)')
+    def stack_plus_minus(x):
+      return np.stack([x, -x])
+
+    self.assertEqual(stack_plus_minus(np.zeros(shape)).shape, result_shape)
+
+  def test_center(self):
+
+    @partial(np.vectorize, signature='(n)->(),(n)')
+    def center(array):
+      bias = np.mean(array)
+      debiased = array - bias
+      return bias, debiased
+
+    b, a = center(np.arange(3))
+    self.assertEqual(a.shape, (3,))
+    self.assertEqual(b.shape, ())
+    self.assertAllClose(1.0, b, check_dtypes=False)
+
+    b, a = center(np.arange(6).reshape(2, 3))
+    self.assertEqual(a.shape, (2, 3))
+    self.assertEqual(b.shape, (2,))
+    self.assertAllClose(np.array([1.0, 4.0]), b, check_dtypes=False)
+
+  def test_exclude_first(self):
+
+    @partial(np.vectorize, excluded={0})
+    def f(x, y):
+      assert x == 'foo'
+      assert y.ndim == 0
+      return y
+
+    x = np.arange(3)
+    self.assertAllClose(x, f('foo', x), check_dtypes=True)
+    self.assertAllClose(x, jax.jit(f, 0)('foo', x), check_dtypes=True)
+
+  def test_exclude_second(self):
+
+    @partial(np.vectorize, excluded={1})
+    def f(x, y):
+      assert x.ndim == 0
+      assert y == 'foo'
+      return x
+
+    x = np.arange(3)
+    self.assertAllClose(x, f(x, 'foo'), check_dtypes=True)
+    self.assertAllClose(x, jax.jit(f, 1)(x, 'foo'), check_dtypes=True)
+
+  def test_exclude_errors(self):
+    with self.assertRaisesRegex(
+        TypeError, "jax.numpy.vectorize can only exclude"):
+      np.vectorize(lambda x: x, excluded={'foo'})
+
+    with self.assertRaisesRegex(
+        ValueError, r"excluded=\{-1\} contains negative numbers"):
+      np.vectorize(lambda x: x, excluded={-1})
+
+    f = np.vectorize(lambda x: x, excluded={1})
+    with self.assertRaisesRegex(
+        ValueError, r"excluded=\{1\} is invalid for 1 argument\(s\)"):
+      f(1.0)
+
+  def test_bad_inputs(self):
+    matmat = np.vectorize(np.dot, signature='(n,m),(m,k)->(n,k)')
+    with self.assertRaisesRegex(
+        TypeError, "wrong number of positional arguments"):
+      matmat(np.zeros((3, 2)))
+    with self.assertRaisesRegex(
+        ValueError,
+        r"input with shape \(2,\) does not have enough dimensions"):
+      matmat(np.zeros((2,)), np.zeros((2, 2)))
+    with self.assertRaisesRegex(
+        ValueError, r"inconsistent size for core dimension 'm'"):
+      matmat(np.zeros((2, 3)), np.zeros((4, 5)))
+
+  def test_wrong_output_type(self):
+    f = np.vectorize(np.dot, signature='(n,m),(m,k)->(n,k),()')
+    with self.assertRaisesRegex(
+        TypeError, "output must be a tuple"):
+      f(np.zeros((2, 2)), np.zeros((2, 2)))
+
+  def test_wrong_num_outputs(self):
+    f = np.vectorize(lambda *args: args, signature='(),()->(),(),()')
+    with self.assertRaisesRegex(
+        TypeError, "wrong number of output arguments"):
+      f(1, 2)
+
+  def test_wrong_output_shape(self):
+    f = np.vectorize(np.dot, signature='(n,m),(m,k)->(n)')
+    with self.assertRaisesRegex(
+        ValueError, r"output shape \(2, 2\) does not match"):
+      f(np.zeros((2, 2)), np.zeros((2, 2)))
+
+  def test_inconsistent_output_size(self):
+    f = np.vectorize(np.dot, signature='(n,m),(m,k)->(n,n)')
+    with self.assertRaisesRegex(
+        ValueError, r"inconsistent size for core dimension 'n'"):
+      f(np.zeros((2, 3)), np.zeros((3, 4)))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This is basically a non-experimental version of the machinery in `jax.experimental.vectorize`, except:
- It adds the `excluded` argument from NumPy, which works just like `static_argnums` in `jax.jit`.
- It doesn't include the `axis` argument yet (which NumPy doesn't have, and which felt a little half-baked -- it is easy to explicitly use `moveaxis` is desired).

Eventually we might want want to consolidate the specification of signatures with signatures used by shape-checking machinery, but it's nice to emulate NumPy's existing interface, and this is already useful (e.g., for writing vectorized linear algebra routines).

I have added a deprecation warning when the `jax.experimental.vectorize` module
is imported warning that it will go away soon. To make the transition easier, I would vote for waiting for a month or two.