### PR TITLE
Bump cell execution timeout

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ nbsphinx_execute = 'always'
 
 
 # Controls when a cell will time out (defaults to 30; use -1 for no timeout):
-nbsphinx_timeout = 90
+nbsphinx_timeout = 180
 
 # Default Pygments lexer for syntax highlighting in code cells:
 #nbsphinx_codecell_lexer = 'ipython3'


### PR DESCRIPTION
Looking at the recent [doc failures](https://readthedocs.org/projects/jax/builds/), a few are due to 

- Cell timeouts (which this tries to fix),
- Execution timeout (readthedocs gives 900seconds to build, total -- most of the time for jax is in executing the notebooks),
- Other somewhat random/inscrutable errors (and I could imagine a world in which one of the timeouts ends up triggering an inscrutable error in the execution).