### PR TITLE
Implement NumPy argwhere/flatnonzero/extract

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -57,19 +57,19 @@ def get_python_bin_path(python_bin_path_flag):
 
 # Bazel
 
-BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/0.29.1/"
+BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/1.2.1/"
 BazelPackage = collections.namedtuple("BazelPackage", ["file", "sha256"])
 bazel_packages = {
     "Linux":
         BazelPackage(
-            file="bazel-0.29.1-linux-x86_64",
+            file="bazel-1.2.1-linux-x86_64",
             sha256=
-            "da3031d811f42f6208d24a87984b5b07e1c75afede184cad86eb02bef6c3b9b0"),
+            "f5e21d7448419d1596ad0c5bb71fb336a0af08c832587aec394970ea56701d88"),
     "Darwin":
         BazelPackage(
-            file="bazel-0.29.1-darwin-x86_64",
+            file="bazel-1.2.1-darwin-x86_64",
             sha256=
-            "34daae4caafbdb0952415ed6f97f47f03df84df9af146e9eb910ba65c073efdd"),
+            "6729be5a56e6eadf7a9112afd2d87ce348da8fca22077b882d9bb7a6f5d41d1c"),
 }
 
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2598,6 +2598,25 @@ def _argminmax(op, a, axis):
   return min(mask_idxs, axis)
 
 
+@_wraps(onp.argwhere)
+def argwhere(a):
+  nnz = nonzero(a)
+  ret = transpose(asarray(nnz))
+  if isscalar(a):
+    ret = ret.reshape((0, 0))
+  return ret
+
+
+@_wraps(onp.flatnonzero)
+def flatnonzero(a):
+  return nonzero(ravel(a))[0]
+
+
+@_wraps(onp.extract)
+def extract(cond, a):
+  return take(ravel(a), nonzero(ravel(cond))[0])
+
+
 @_wraps(onp.sort)
 def sort(a, axis=-1, kind='quicksort', order=None):
   if kind != 'quicksort':

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -638,6 +638,46 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(
+          jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype}
+      for shape in all_shapes for dtype in all_dtypes))
+  def testArgWhere(self, shape, dtype):
+    rng = jtu.rand_some_zero()
+    onp_fun = lambda x: onp.argwhere(x)
+    lnp_fun = lambda x: lnp.argwhere(x)
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(
+          jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype}
+      for shape in all_shapes for dtype in all_dtypes))
+  def testFlatNonzero(self, shape, dtype):
+    rng = jtu.rand_some_zero()
+    onp_fun = lambda x: onp.flatnonzero(x)
+    lnp_fun = lambda x: lnp.flatnonzero(x)
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=False)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": "_{}".format("_".join(
+        jtu.format_shape_dtype_string(shape, dtype)
+        for shape, dtype in zip(shapes, dtypes))),
+     "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
+    for shapes in filter(_shapes_are_broadcast_compatible,
+                         CombosWithReplacement(all_shapes, 2))
+    for dtypes in CombosWithReplacement(all_dtypes, 2)))
+  def testExtract(self, rng_factory, shapes, dtypes):
+    rng = rng_factory()
+    args_maker = self._GetArgsMaker(rng_factory(), shapes, dtypes)
+    def onp_fun(cond, x):
+      return _promote_like_lnp(partial(onp.extract, cond))(x)
+    self._CheckAgainstNumpy(onp_fun, lnp.extract, args_maker,
+                            check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "{}_inshape={}_axis={}".format(
           rec.test_name.capitalize(),
           jtu.format_shape_dtype_string(shape, dtype), axis),


### PR DESCRIPTION
This PR implements `argwhere`, `flatnonzero`, and `extract` as mentioned in #2080

The implementation basically follows what NumPy does. 


P.S. I'm just trying to understand how JAX works by implementing stuff in "good first" issues. Please do let me know if you do not prefer me doing so. 
