### PR TITLE
Canonicalize the shape in the wrapper functions in random.py.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -104,16 +104,12 @@ def _canonicalize_dimension(dim):
 def canonicalize_shape(shape):
   """Canonicalizes and checks for errors in a user-provided shape value.
 
-  `None` shape is passed through as is.
-
   Args:
-    shape: a Python value that represents a shape, or None.
+    shape: a Python value that represents a shape.
 
   Returns:
-    A tuple of integers, or None.
+    A tuple of integers.
   """
-  if shape is None:
-    return None
   try:
     return tuple(map(_canonicalize_dimension, shape))
   except TypeError:

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -104,12 +104,16 @@ def _canonicalize_dimension(dim):
 def canonicalize_shape(shape):
   """Canonicalizes and checks for errors in a user-provided shape value.
 
+  `None` shape is passed through as is.
+
   Args:
-    shape: a Python value that represents a shape.
+    shape: a Python value that represents a shape, or None.
 
   Returns:
-    A tuple of integers.
+    A tuple of integers, or None.
   """
+  if shape is None:
+    return None
   try:
     return tuple(map(_canonicalize_dimension, shape))
   except TypeError:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -37,7 +37,7 @@ from ..config import flags
 from ..core import Primitive
 from ..abstract_arrays import (UnshapedArray, ShapedArray, ConcreteArray,
                                AbstractToken, array_types, make_shaped_array,
-                               raise_to_shaped, abstract_token)
+                               raise_to_shaped, abstract_token, canonicalize_shape)
 from ..interpreters import partial_eval as pe
 from ..interpreters import xla
 from ..interpreters import pxla
@@ -84,17 +84,7 @@ def _canonicalize_shape(shape):
   # TODO(mattjj): this next check is a temporary workaround for masking
   if (type(shape) is tuple and masking.is_polymorphic(shape)):
     return shape
-  try:
-    return tuple(map(operator.index, shape))
-  except TypeError:
-    pass
-  msg = ("Shapes must be 1D sequences of concrete values of integer type, "
-         "got {}.")
-  if any(isinstance(x, core.Tracer) and isinstance(core.get_aval(x), ShapedArray)
-         and not isinstance(core.get_aval(x), ConcreteArray) for x in shape):
-    msg += ("\nIf using `jit`, try using `static_argnums` or applying `jit` to "
-            "smaller subfunctions.")
-  raise TypeError(msg.format(shape))
+  return canonicalize_shape(shape)
 
 def _identity(x): return x
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -72,20 +72,6 @@ def broadcast_shapes(*shapes):
                      .format(tuple(map(tuple, shapes))))
   return tuple(result_shape)
 
-def _canonicalize_shape(shape):
-  """Canonicalizes and checks for errors in a user-provided shape value.
-
-  Args:
-    shape: a Python value that represents a shape.
-
-  Returns:
-    A tuple of integers.
-  """
-  # TODO(mattjj): this next check is a temporary workaround for masking
-  if (type(shape) is tuple and masking.is_polymorphic(shape)):
-    return shape
-  return canonicalize_shape(shape)
-
 def _identity(x): return x
 
 ### traceables
@@ -641,7 +627,7 @@ def reshape(operand, new_sizes, dimensions=None):
   <https://www.tensorflow.org/xla/operation_semantics#reshape>`_
   operator.
   """
-  new_sizes = _canonicalize_shape(new_sizes)  # TODO
+  new_sizes = canonicalize_shape(new_sizes)  # TODO
   new_sizes = tuple(new_sizes)
   same_shape = onp.shape(operand) == new_sizes
   same_dims = dimensions is None or tuple(dimensions) == tuple(range(onp.ndim(operand)))
@@ -749,7 +735,7 @@ def gather(operand, start_indices, dimension_numbers, slice_sizes):
   """
   return gather_p.bind(
       operand, start_indices, dimension_numbers=dimension_numbers,
-      slice_sizes=_canonicalize_shape(slice_sizes), operand_shape=operand.shape)
+      slice_sizes=canonicalize_shape(slice_sizes), operand_shape=operand.shape)
 
 def scatter_add(operand, scatter_indices, updates, dimension_numbers):
   """Scatter-add operator.
@@ -1064,7 +1050,7 @@ def full(shape, fill_value, dtype=None):
     dtype: the type of the output array, or `None`. If not `None`, `fill_value`
       will be cast to `dtype`.
   """
-  shape = _canonicalize_shape(shape)
+  shape = canonicalize_shape(shape)
   if onp.shape(fill_value):
     msg = "full must be called with scalar fill_value, got fill_value.shape {}."
     raise TypeError(msg.format(onp.shape(fill_value)))
@@ -1087,7 +1073,7 @@ def iota(dtype, size):
 def broadcasted_iota(dtype, shape, dimension):
   """Convenience wrapper around ``iota``."""
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = _canonicalize_shape(shape)
+  shape = canonicalize_shape(shape)
   dimension = int(dimension)
   return broadcast_in_dim(iota(dtype, shape[dimension]), shape, [dimension])
 
@@ -1314,7 +1300,7 @@ def full_like(x, fill_value, dtype=None, shape=None):
     An ndarray with the same shape as `x` with its entries set equal to
     `fill_value`, similar to the output of np.full.
   """
-  shape = onp.shape(x) if shape is None else _canonicalize_shape(shape)
+  shape = onp.shape(x) if shape is None else canonicalize_shape(shape)
   fill_value = tie_in(x, fill_value)
   return full(shape, fill_value, dtype or _dtype(x))
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -500,7 +500,8 @@ def multivariate_normal(key, mean, cov, shape=None, dtype=onp.float64):
     ``broadcast_shapes(mean.shape[:-1], cov.shape[:-2]) + mean.shape[-1:]``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _multivariate_normal(key, mean, cov, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
@@ -548,7 +549,8 @@ def truncated_normal(key, lower, upper, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by broadcasting ``lower`` and ``upper``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _truncated_normal(key, lower, upper, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
@@ -583,7 +585,8 @@ def bernoulli(key, p=onp.float32(0.5), shape=None):
     is not None, or else ``p.shape``.
   """
   dtype = dtypes.canonicalize_dtype(lax.dtype(p))
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   if not np.issubdtype(dtype, onp.floating):
     msg = "bernoulli probability `p` must have a floating dtype, got {}."
     raise TypeError(msg.format(dtype))
@@ -620,7 +623,8 @@ def beta(key, a, b, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by broadcasting ``a`` and ``b``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _beta(key, a, b, shape, dtype)
 
 def _beta(key, a, b, shape, dtype):
@@ -685,7 +689,8 @@ def dirichlet(key, alpha, shape=None, dtype=onp.float64):
     ``alpha.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _dirichlet(key, alpha, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))
@@ -943,7 +948,8 @@ def gamma(key, a, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by ``a.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _gamma(key, a, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))
@@ -1077,7 +1083,8 @@ def pareto(key, b, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by ``b.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
-  shape = abstract_arrays.canonicalize_shape(shape)
+  if shape is not None:
+    shape = abstract_arrays.canonicalize_shape(shape)
   return _pareto(key, b, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))

--- a/jax/random.py
+++ b/jax/random.py
@@ -318,6 +318,7 @@ def uniform(key, shape=(), dtype=onp.float64, minval=0., maxval=1.):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _uniform(key, shape, dtype, minval, maxval)
 
 @partial(jit, static_argnums=(1, 2))
@@ -366,6 +367,7 @@ def randint(key, shape, minval, maxval, dtype=onp.int64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _randint(key, shape, minval, maxval, dtype)
 
 @partial(jit, static_argnums=(1, 4))
@@ -464,6 +466,7 @@ def normal(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _normal(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -497,6 +500,7 @@ def multivariate_normal(key, mean, cov, shape=None, dtype=onp.float64):
     ``broadcast_shapes(mean.shape[:-1], cov.shape[:-2]) + mean.shape[-1:]``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _multivariate_normal(key, mean, cov, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
@@ -544,6 +548,7 @@ def truncated_normal(key, lower, upper, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by broadcasting ``lower`` and ``upper``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _truncated_normal(key, lower, upper, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
@@ -578,6 +583,7 @@ def bernoulli(key, p=onp.float32(0.5), shape=None):
     is not None, or else ``p.shape``.
   """
   dtype = dtypes.canonicalize_dtype(lax.dtype(p))
+  shape = abstract_arrays.canonicalize_shape(shape)
   if not np.issubdtype(dtype, onp.floating):
     msg = "bernoulli probability `p` must have a floating dtype, got {}."
     raise TypeError(msg.format(dtype))
@@ -614,6 +620,7 @@ def beta(key, a, b, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by broadcasting ``a`` and ``b``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _beta(key, a, b, shape, dtype)
 
 def _beta(key, a, b, shape, dtype):
@@ -646,6 +653,7 @@ def cauchy(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _cauchy(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -677,6 +685,7 @@ def dirichlet(key, alpha, shape=None, dtype=onp.float64):
     ``alpha.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _dirichlet(key, alpha, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))
@@ -709,6 +718,7 @@ def exponential(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _exponential(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -933,6 +943,7 @@ def gamma(key, a, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by ``a.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _gamma(key, a, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))
@@ -962,6 +973,7 @@ def gumbel(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _gumbel(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -1013,6 +1025,7 @@ def laplace(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _laplace(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -1037,6 +1050,7 @@ def logistic(key, shape=(), dtype=onp.float64):
     A random array with the specified shape and dtype.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _logistic(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
@@ -1063,6 +1077,7 @@ def pareto(key, b, shape=None, dtype=onp.float64):
     ``shape`` is not None, or else by ``b.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _pareto(key, b, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))
@@ -1095,6 +1110,7 @@ def t(key, df, shape=(), dtype=onp.float64):
     ``shape`` is not None, or else by ``df.shape``.
   """
   dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
   return _t(key, df, shape, dtype)
 
 @partial(jit, static_argnums=(2, 3))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -494,7 +494,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       phi = lambda x, t: np.sqrt(2.0 / d) * np.cos(np.matmul(W, x) + w*t + b)
       return phi
 
-    self.assertRaisesRegex(ValueError, '.*requires a concrete.*',
+    self.assertRaisesRegex(TypeError, 'Shapes must be 1D.*',
                            lambda: feature_map(5, 3))
 
   def testIssue756(self):


### PR DESCRIPTION
This lets the user be more sloppy in using numpy arrays and statically
known DeviceArrays for shapes, and still hit the jit cache. For cases when they
are not statically known, this change improves the error message.