### PR TITLE
Simplify bound_subjaxprs.

### DIFF
--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -430,7 +430,7 @@ class _BodyTracer(object):
     in_pvals = [t.pval for t in in_tracers]
     in_avals = tuple(safe_map(abstract_arrays.raise_to_shaped, unzip2(in_pvals)[0]))
 
-    typed_jaxpr = core.TypedJaxpr(pe.closure_convert_jaxpr(jaxpr),
+    typed_jaxpr = core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
                                   (), const_avals + in_avals, out_avals)
     return typed_jaxpr, consts
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -172,7 +172,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
 
   linear_eqns = []
   for eqn in jaxpr.eqns:
-    if not eqn.bound_subjaxprs:
+    if not eqn.bound_subjaxpr:
       if any(is_linear(v) for v in eqn.invars):
         linear_eqns.append(eqn)
       else:
@@ -183,13 +183,12 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
         else:
           write_primal(eqn.outvars[0], ans)
     else:
-      (subjaxpr, const_vars), = eqn.bound_subjaxprs
-      assert not any(is_linear(v) for v in const_vars)
+      subjaxpr = eqn.bound_subjaxpr
       if any(is_linear(v) for v in eqn.invars):
         linear_eqns.append(eqn)
       elif eqn.primitive is not pe.remat_call_p:
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr, map(read_primal, const_vars),
+            eqn.primitive, subjaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
 
@@ -197,7 +196,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
       # nonlinear, so we always evaluate it even if it has a linear part
       if eqn.primitive is pe.remat_call_p:
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr, map(read_primal, const_vars),
+            eqn.primitive, subjaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
 
@@ -209,11 +208,11 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
       cts_in = map(read_cotangent, eqn.outvars)
     else:
       cts_in, = map(read_cotangent, eqn.outvars)
-    if eqn.bound_subjaxprs:
-      (subjaxpr, const_vars), = eqn.bound_subjaxprs
-      sub_consts = map(read_primal, const_vars)
+    if eqn.bound_subjaxpr:
+      subjaxpr = eqn.bound_subjaxpr
+      # TODO(necula): clean this transpose
       cts_out = get_primitive_transpose(eqn.primitive)(
-          eqn.params, subjaxpr, sub_consts, invals, cts_in)
+          eqn.params, subjaxpr, (), invals, cts_in)
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
     cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
@@ -222,14 +221,15 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
   cotangents_out = map(read_cotangent, jaxpr.invars)
   return cotangents_out
 
-def _eval_subjaxpr_primals(prim, jaxpr, consts, in_vals, params):
-  all_args, in_tree_def = tree_flatten((consts, in_vals))
+def _eval_subjaxpr_primals(prim, jaxpr, in_vals, params):
+  assert not jaxpr.constvars
+  all_args, in_tree_def = tree_flatten((in_vals,))
   fun = lu.hashable_partial(lu.wrap_init(_eval_primals), jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   out_flat = prim.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
 
-def _eval_primals(jaxpr, consts, args):
+def _eval_primals(jaxpr, args):
   primal_env = {}
 
   def read_primal(v):
@@ -249,10 +249,10 @@ def _eval_primals(jaxpr, consts, args):
       return primal_env.get(var, undefined_primal) is undefined_primal
 
   write_primal(core.unitvar, core.unit)
-  map(write_primal, jaxpr.constvars, consts)
+  assert not jaxpr.constvars
   map(write_primal, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    if not eqn.bound_subjaxprs:
+    if not eqn.bound_subjaxpr:
       if not any(is_linear(v) for v in eqn.invars):
         in_vals = map(read_primal, eqn.invars)
         ans = eqn.primitive.bind(*in_vals, **eqn.params)
@@ -261,12 +261,11 @@ def _eval_primals(jaxpr, consts, args):
         else:
           write_primal(eqn.outvars[0], ans)
     else:
-      (subjaxpr, const_vars), = eqn.bound_subjaxprs
-      assert not any(is_linear(v) for v in const_vars)
+      subjaxpr = eqn.bound_subjaxpr
       if (eqn.primitive is pe.remat_call_p or
           not any(is_linear(v) for v in eqn.invars)):
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr, map(read_primal, const_vars),
+            eqn.primitive, subjaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
   return map(read_primal, jaxpr.outvars)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -25,7 +25,7 @@ from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ShapedArray, ConcreteArray, raise_to_shaped
 from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
-                    wrap_name)
+                    wrap_name, cache)
 from ..core import (Trace, Tracer, new_master, Jaxpr, Literal, get_aval,
                     AbstractValue, unit, unitvar, abstract_unit, Primitive,
                     call_p, TypedJaxpr, new_jaxpr_eqn)
@@ -466,6 +466,7 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
   core.skip_checks or core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
+@cache()
 def convert_constvars_jaxpr(jaxpr):
   """Moves the constvars to the start of invars."""
   core.skip_checks or core.check_jaxpr(jaxpr)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -159,12 +159,12 @@ class JaxprTrace(Trace):
     out_tracers = [JaxprTracer(self, PartialVal((out_pv, out_pv_const)), None)
                    for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
     # The `jaxpr` already contains the env_vars at start of invars
-    params = params.copy()
-    params["mapped_invars"] = tuple([True] * len(const_tracers) +
-                                    [False] * len(env_tracers) +
-                                    [True] * len(tracers))
+    new_params = dict(params,
+                      mapped_invars=tuple([True] * len(const_tracers) +
+                                          [False] * len(env_tracers) +
+                                          [True] * len(tracers)))
     eqn = new_eqn_recipe(tuple(it.chain(const_tracers, env_tracers, tracers)),
-                         out_tracers, map_primitive, params,
+                         out_tracers, map_primitive, new_params,
                          subjaxpr=lifted_jaxpr)
     for t in out_tracers:
       t.recipe = eqn
@@ -213,12 +213,12 @@ class JaxprTrace(Trace):
       lifted_jaxpr = convert_constvars_jaxpr(jaxpr)
       out_tracers = [JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), None)
                      for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
-      params = params.copy()
-      params["mapped_invars"] = tuple(([True] * len(const_tracers) +
-                                       [False] * len(env)))
+      new_params = dict(params,
+                        mapped_invars=tuple([True] * len(const_tracers) +
+                                            [False] * len(env)))
       env_tracers = map(trace.full_raise, env)
       eqn = new_eqn_recipe(it.chain(const_tracers, env_tracers),
-                           out_tracers, map_primitive, params,
+                           out_tracers, map_primitive, new_params,
                            subjaxpr=lifted_jaxpr)
       for t in out_tracers:
         t.recipe = eqn

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -645,7 +645,7 @@ xla_pmap = partial(core.call_bind, xla_pmap_p)
 xla_pmap_p.def_custom_bind(xla_pmap)
 xla_pmap_p.def_impl(xla_pmap_impl)
 
-def _pmap_translation_rule(c, jaxpr, axis_env, const_nodes,
+def _pmap_translation_rule(c, jaxpr, axis_env,
                            in_nodes, name_stack, axis_name, axis_size,
                            global_axis_size, devices, name, backend=None,
                            mapped_invars=None):
@@ -662,7 +662,7 @@ def _pmap_translation_rule(c, jaxpr, axis_env, const_nodes,
     for in_node, in_node_mapped in zip(in_nodes, mapped_invars))
 
   sharded_outs = xla.jaxpr_subcomp(
-      c, jaxpr, backend, new_env, const_nodes,
+      c, jaxpr, backend, new_env, (),
       extend_name_stack(name_stack, wrap_name(name, 'pmap')), *in_nodes_sharded)
   outs = [_xla_unshard(c, new_env, shard) for shard in sharded_outs]
   return c.Tuple(*outs)

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -58,7 +58,7 @@ def _initial_style_jaxpr(fun, in_tree, in_avals):
                                                stage_out_calls=True)
   out_avals = _map(raise_to_shaped, unzip2(out_pvals)[0])
   const_avals = tuple(raise_to_shaped(core.get_aval(c)) for c in consts)
-  typed_jaxpr = core.TypedJaxpr(pe.closure_convert_jaxpr(jaxpr),
+  typed_jaxpr = core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
                                 (), const_avals + in_avals, out_avals)
   return typed_jaxpr, consts, out_tree()
 
@@ -940,7 +940,7 @@ def _scan_partial_eval(trace, *tracers, **kwargs):
   const_avals_1 = [raise_to_shaped(core.get_aval(c)) for c in consts_1]
   in_avals_1 = [core.abstract_unit] * num_consts + jaxpr_1.in_avals[num_consts:]
   out_avals_1 = [core.abstract_unit if pv is None else pv for pv, c in out_pvals_1]
-  jaxpr_1_opt = pe.TypedJaxpr(pe.closure_convert_jaxpr(untyped_jaxpr_1),
+  jaxpr_1_opt = pe.TypedJaxpr(pe.convert_constvars_jaxpr(untyped_jaxpr_1),
                               (), const_avals_1 + in_avals_1, out_avals_1)
   num_consts_1 = num_consts + len(consts_1)
   # any now-known residuals are intensive, so we want to revise jaxpr_2 to take

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -606,10 +606,11 @@ def check_raises_regexp(thunk, err_type, pattern):
 
 
 def _iter_eqns(jaxpr):
+  # TODO(necula): why doesn't this search in params?
   for eqn in jaxpr.eqns:
     yield eqn
-    for subjaxpr, _ in eqn.bound_subjaxprs:
-      for sub_eqn in _iter_eqns(subjaxpr):
+    if eqn.bound_subjaxpr:
+      for sub_eqn in _iter_eqns(eqn.bound_subjaxpr):
         yield sub_eqn
 
 def assert_dot_precision(expected_precision, fun, *args):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1003,8 +1003,8 @@ class APITest(jtu.JaxTestCase):
     c = onp.ones((2, 3, 3))
 
     jaxpr = api.make_jaxpr(lambda b, c: f(a, b, c))(b, c)
-    subjaxpr = next(eqn.bound_subjaxprs[0][0] for eqn in jaxpr.jaxpr.eqns
-                    if eqn.bound_subjaxprs)
+    subjaxpr = next(eqn.bound_subjaxpr for eqn in jaxpr.jaxpr.eqns
+                    if eqn.bound_subjaxpr)
     self.assertEqual(len(subjaxpr.eqns), 1)
 
   def test_grad_of_int_errors(self):
@@ -1683,7 +1683,7 @@ class APITest(jtu.JaxTestCase):
 
     self.assertLen(outer_jaxpr.eqns, 1)
     self.assertEqual(outer_jaxpr.eqns[0].primitive.name, 'xla_call')
-    (subjaxpr_1, _), = outer_jaxpr.eqns[0].bound_subjaxprs
+    subjaxpr_1 = outer_jaxpr.eqns[0].bound_subjaxpr
     self.assertEqual(str(subjaxpr_1), str(inner_jaxpr))
     self.assertLen(inner_jaxpr.eqns, 2)
     self.assertEqual(inner_jaxpr.eqns[0].primitive.name, 'mul')


### PR DESCRIPTION
Before, bound_subjaxprs was a tuple (0 or 1 values) of
a pair of a Jaxpr and its constant values. Now we close up all such Jaxprs
such that they do not take constvars and their constant values are part of the
arguments.

We also rename bound_subjaxprs to bound_subjaxpr (an optional Jaxpr)

This is first part of a simplification. In a subsequent PR I will move
the bound_subjaxpr into params, as for most higher-order primitives.