### PR TITLE
Fix type error in partial_eval.py.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -214,7 +214,7 @@ class JaxprTrace(Trace):
       out_tracers = [JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), None)
                      for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
       params = params.copy()
-      params["mapped_invars"] = tuple(([True] * len(const_tracers),
+      params["mapped_invars"] = tuple(([True] * len(const_tracers) +
                                        [False] * len(env)))
       env_tracers = map(trace.full_raise, env)
       eqn = new_eqn_recipe(it.chain(const_tracers, env_tracers),

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -214,8 +214,8 @@ class JaxprTrace(Trace):
       out_tracers = [JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), None)
                      for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
       params = params.copy()
-      params["mapped_invars"] = tuple([True] * len(const_tracers),
-                                      [False] * len(env))
+      params["mapped_invars"] = tuple(([True] * len(const_tracers),
+                                       [False] * len(env)))
       env_tracers = map(trace.full_raise, env)
       eqn = new_eqn_recipe(it.chain(const_tracers, env_tracers),
                            out_tracers, map_primitive, params,


### PR DESCRIPTION
The tuple constructor takes a single iterable argument.

@gnecula this was introduced in https://github.com/google/jax/commit/862a1d594b67845f480bba7b342afb134ffc1a14 and caught via pytype. Are we missing some test coverage?