### PR TITLE
Simplify Jaxpr: remove the bound_subjaxpr field, all subjaxprs are in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ These are the release notes for JAX.
 ### Breaking changes
 
 * The minimum jaxlib version is now 0.1.38.
-* Simplified `Jaxpr` by removing the `Jaxpr.freevars` and changing the 
-  representation of `Jaxpr.bound_subjaxprs` to drop the environment values. 
+* Simplified `Jaxpr` by removing the `Jaxpr.freevars` and 
+  `Jaxpr.bound_subjaxprs`. The call primitives (`xla_call`, `xla_pmap`,
+   `sharded_call`, and `remat_call`) get a new parameter `call_jaxpr` with a
+   fully-closed (no `constvars`) JAXPR.  
 
 ### New features
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -172,7 +172,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
 
   linear_eqns = []
   for eqn in jaxpr.eqns:
-    if not eqn.bound_subjaxpr:
+    if not eqn.primitive.call_primitive:
       if any(is_linear(v) for v in eqn.invars):
         linear_eqns.append(eqn)
       else:
@@ -183,12 +183,12 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
         else:
           write_primal(eqn.outvars[0], ans)
     else:
-      subjaxpr = eqn.bound_subjaxpr
+      call_jaxpr = eqn.params["call_jaxpr"]
       if any(is_linear(v) for v in eqn.invars):
         linear_eqns.append(eqn)
       elif eqn.primitive is not pe.remat_call_p:
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr,
+            eqn.primitive, call_jaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
 
@@ -196,7 +196,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
       # nonlinear, so we always evaluate it even if it has a linear part
       if eqn.primitive is pe.remat_call_p:
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr,
+            eqn.primitive, call_jaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
 
@@ -208,10 +208,10 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
       cts_in = map(read_cotangent, eqn.outvars)
     else:
       cts_in, = map(read_cotangent, eqn.outvars)
-    if eqn.bound_subjaxpr:
-      subjaxpr = eqn.bound_subjaxpr
+    if eqn.primitive.call_primitive:
+      call_jaxpr, params = core.extract_call_jaxpr(eqn.primitive, eqn.params)
       cts_out = get_primitive_transpose(eqn.primitive)(
-          eqn.params, subjaxpr, invals, cts_in)
+          params, call_jaxpr, invals, cts_in)
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
     cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
@@ -251,7 +251,7 @@ def _eval_primals(jaxpr, args):
   assert not jaxpr.constvars
   map(write_primal, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    if not eqn.bound_subjaxpr:
+    if not eqn.primitive.call_primitive:
       if not any(is_linear(v) for v in eqn.invars):
         in_vals = map(read_primal, eqn.invars)
         ans = eqn.primitive.bind(*in_vals, **eqn.params)
@@ -260,11 +260,11 @@ def _eval_primals(jaxpr, args):
         else:
           write_primal(eqn.outvars[0], ans)
     else:
-      subjaxpr = eqn.bound_subjaxpr
+      call_jaxpr = eqn.params["call_jaxpr"]
       if (eqn.primitive is pe.remat_call_p or
           not any(is_linear(v) for v in eqn.invars)):
         ans = _eval_subjaxpr_primals(
-            eqn.primitive, subjaxpr,
+            eqn.primitive, call_jaxpr,
             map(read_primal, eqn.invars), eqn.params)
         map(write_primal, eqn.outvars, ans)
   return map(read_primal, jaxpr.outvars)
@@ -537,9 +537,9 @@ def traceable(num_primals, in_tree_def, *primals_and_tangents):
   yield out_flat, tree_def
 
 
-def call_transpose(primitive, params, jaxpr, args, ct):
+def call_transpose(primitive, params, call_jaxpr, args, ct):
   all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
-  fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
+  fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   params = dict(params, name=wrap_name(params['name'], 'transpose'))
   out_flat = primitive.bind(fun, *all_args, **params)
@@ -547,9 +547,9 @@ def call_transpose(primitive, params, jaxpr, args, ct):
 primitive_transposes[core.call_p] = partial(call_transpose, call_p)
 primitive_transposes[pe.remat_call_p] = partial(call_transpose, pe.remat_call_p)
 
-def map_transpose(primitive, params, jaxpr, args, ct):
+def map_transpose(primitive, params, call_jaxpr, args, ct):
   all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
-  fun = lu.hashable_partial(lu.wrap_init(backward_pass), jaxpr)
+  fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   params = dict(params, name=wrap_name(params['name'], 'transpose'))
   out_flat = primitive.bind(fun, *all_args, **params)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -136,10 +136,10 @@ class JaxprTrace(Trace):
     lifted_jaxpr = convert_constvars_jaxpr(jaxpr)
     out_tracers = [JaxprTracer(self, PartialVal((out_pv, out_pv_const)), None)
                    for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
+    new_params = dict(params, call_jaxpr=lifted_jaxpr)
     # The `jaxpr` already contains the env_vars at start of invars
     eqn = new_eqn_recipe(tuple(it.chain(const_tracers, env_tracers, tracers)),
-                         out_tracers, call_primitive, params,
-                         subjaxpr=lifted_jaxpr)
+                         out_tracers, call_primitive, new_params)
     for t in out_tracers:
       t.recipe = eqn
     return out_tracers
@@ -162,10 +162,10 @@ class JaxprTrace(Trace):
     new_params = dict(params,
                       mapped_invars=tuple([True] * len(const_tracers) +
                                           [False] * len(env_tracers) +
-                                          [True] * len(tracers)))
+                                          [True] * len(tracers)),
+                      call_jaxpr=lifted_jaxpr)
     eqn = new_eqn_recipe(tuple(it.chain(const_tracers, env_tracers, tracers)),
-                         out_tracers, map_primitive, new_params,
-                         subjaxpr=lifted_jaxpr)
+                         out_tracers, map_primitive, new_params)
     for t in out_tracers:
       t.recipe = eqn
     return out_tracers
@@ -187,10 +187,10 @@ class JaxprTrace(Trace):
       lifted_jaxpr = convert_constvars_jaxpr(jaxpr)
       out_tracers = [JaxprTracer(trace, PartialVal((out_pv, out_pv_const)), None)
                      for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
+      new_params = dict(params, call_jaxpr=lifted_jaxpr)
       # The `jaxpr` already contains the env_vars at start of invars
       eqn = new_eqn_recipe(tuple(it.chain(const_tracers, env_tracers)),
-                           out_tracers, call_primitive, params,
-                           subjaxpr=lifted_jaxpr)
+                           out_tracers, call_primitive, new_params)
       for t in out_tracers:
         t.recipe = eqn
       return out_tracers
@@ -215,11 +215,11 @@ class JaxprTrace(Trace):
                      for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
       new_params = dict(params,
                         mapped_invars=tuple([True] * len(const_tracers) +
-                                            [False] * len(env)))
+                                            [False] * len(env)),
+                        call_jaxpr=lifted_jaxpr)
       env_tracers = map(trace.full_raise, env)
       eqn = new_eqn_recipe(it.chain(const_tracers, env_tracers),
-                           out_tracers, map_primitive, new_params,
-                           subjaxpr=lifted_jaxpr)
+                           out_tracers, map_primitive, new_params)
       for t in out_tracers:
         t.recipe = eqn
       return out_tracers
@@ -383,12 +383,9 @@ FreeVar = namedtuple('FreeVar', ['val'])
 ConstVar = namedtuple('ConstVar', ['val'])
 LambdaBinding = namedtuple('LambdaBinding', [])
 JaxprEqnRecipe = namedtuple('JaxprEqnRecipe',
-                            ['eqn_id', 'invars', 'outvars', 'primitive',
-                             'bound_subjaxpr', 'params'])
+                            ['eqn_id', 'invars', 'outvars', 'primitive', 'params'])
 
-
-def new_eqn_recipe(invars, outvars, primitive, params,
-                   subjaxpr=None):
+def new_eqn_recipe(invars, outvars, primitive, params):
   """Constructs a new JaxEqnRecipe.
 
   Params:
@@ -396,25 +393,21 @@ def new_eqn_recipe(invars, outvars, primitive, params,
     outvars: the tracers for the primitive outputs.
     primitive: the primitive.
     params: the primitive params
-    subjaxpr: (optional) a sub-Jaxpr, used only for `xla_call` or `xla_pmap`.
-      If present, then `subjaxpr.invars` correspond to `invars.
   """
-  if subjaxpr is not None:
-    assert len(subjaxpr.constvars) == 0
-    assert len(subjaxpr.invars) == len(tuple(invars))
-    bound_subjaxpr = subjaxpr
-  else:
-    bound_subjaxpr = None
-
+  if primitive.call_primitive:
+    # TODO(necula): move these checks to core.check_jaxpr, and call it
+    # in more places.
+    assert "call_jaxpr" in params
   return JaxprEqnRecipe(object(), tuple(invars), map(ref, outvars), primitive,
-                        bound_subjaxpr, params)
+                        params)
+
 
 def recipe_to_eqn(unused_var, getvar, recipe):
-  _, in_tracers, out_tracer_refs, primitive, bound_subjaxpr, params = recipe
+  _, in_tracers, out_tracer_refs, primitive, params = recipe
   out_tracers = [t_ref() for t_ref in out_tracer_refs]
   invars  = [getvar(t) for t in in_tracers]
   outvars = [unused_var() if t is None else getvar(t) for t in out_tracers]
-  return new_jaxpr_eqn(invars, outvars, primitive, bound_subjaxpr, params)
+  return new_jaxpr_eqn(invars, outvars, primitive, params)
 
 def tracers_to_jaxpr(in_tracers, out_tracers):
   """Constructs Jaxpr given tracers for inputs and outputs.
@@ -520,6 +513,7 @@ def _split_aval(unknown, aval):
 
 
 remat_call_p = core.Primitive('remat_call')
+remat_call_p.call_primitive = True
 remat_call = partial(core.call_bind, remat_call_p)
 remat_call_p.def_custom_bind(remat_call)
 remat_call_p.def_impl(core.call_impl)
@@ -593,10 +587,9 @@ def _remat_partial_eval(trace, f, tracers, params):
   const_tracers = map(trace.new_instantiated_const, consts)
   lifted_jaxpr = convert_constvars_jaxpr(typed_jaxpr.jaxpr)
   out_tracers = [JaxprTracer(trace, out_pval, None) for out_pval in out_pvals]
+  new_params = dict(params, call_jaxpr=lifted_jaxpr)
   eqn = new_eqn_recipe(tuple(it.chain(const_tracers, instantiated_tracers)),
-                       out_tracers, remat_call_p,
-                       params,
-                       subjaxpr=lifted_jaxpr)
+                       out_tracers, remat_call_p, new_params)
   for t in out_tracers: t.recipe = eqn
   return out_tracers
 call_partial_eval_rules[remat_call_p] = _remat_partial_eval

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -284,21 +284,14 @@ def prefetch(x):
   return x
 
 def jaxpr_literals(jaxpr):
-  return it.chain.from_iterable(eqn_literals(eqn) for eqn in jaxpr.eqns)
+  """Generates all the literals inside a jaxpr, including nested subjaxprs."""
+  for eqn in jaxpr.eqns:
+    for v in eqn.invars:
+      if type(v) is core.Literal:
+        yield v.val
+  for subjaxpr in core.subjaxprs(jaxpr):
+    yield from jaxpr_literals(subjaxpr)
 
-def eqn_literals(eqn):
-  if eqn.bound_subjaxpr:
-    for literal in jaxpr_literals(eqn.bound_subjaxpr):
-      yield literal
-  if eqn.primitive in initial_style_translations:
-    for param in eqn.params.values():
-      if type(param) in (core.Jaxpr, core.TypedJaxpr):
-        subjaxpr = param if type(param) is core.Jaxpr else param.jaxpr
-        for literal in jaxpr_literals(subjaxpr):
-          yield literal
-  for v in eqn.invars:
-    if type(v) is core.Literal:
-      yield v.val
 
 def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
   platform = xb.get_backend(backend).platform
@@ -341,7 +334,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
     elif eqn.primitive in call_translations:
       new_params = check_backend_params(eqn.params, backend)
       rule = call_translations[eqn.primitive]
-      ans = rule(c, eqn.bound_subjaxpr, axis_env, in_nodes,
+      ans = rule(c, axis_env, in_nodes,
                  name_stack, backend=backend, **new_params)
     else:
       msg = "XLA translation rule for primitive '{}' not found"
@@ -402,13 +395,19 @@ def _axis_groups(nrep, mesh_spec, mesh_axes):
   return tuple(map(tuple, groups.T))
 
 def jaxpr_replicas(jaxpr):
+  """The number of replicas needed for a jaxpr.
+
+  For a eqn, multiply the `axis_size` with the `jaxpr_replicas` of the
+  subjaxprs. For a list of eqns, take the maximum number of replicas.
+  """
   return max(it.chain([1], (eqn_replicas(eqn) for eqn in jaxpr.eqns)))
 
 # TODO(mattjj): this function assumes that only pmap has a parameter named
 # axis_size, and that it corresponds to cross-replica mapping
 def eqn_replicas(eqn):
-  if eqn.bound_subjaxpr:
-    return eqn.params.get('axis_size', 1) * jaxpr_replicas(eqn.bound_subjaxpr)
+  call_jaxpr = eqn.params.get("call_jaxpr")
+  if call_jaxpr:
+    return eqn.params.get('axis_size', 1) * jaxpr_replicas(call_jaxpr)
   elif eqn.primitive in initial_style_translations:
     return initial_style_primitive_replicas(eqn.params)
   else:
@@ -424,37 +423,23 @@ def initial_style_primitive_replicas(params):
 # not-yet-supported features are used with multi-host programming
 
 def jaxpr_has_pmap(jaxpr):
-  return any(eqn_has_pmap(eqn) for eqn in jaxpr.eqns)
-
-def eqn_has_pmap(eqn):
-  if eqn.bound_subjaxpr:
-    return jaxpr_has_pmap(eqn.bound_subjaxpr)
-  elif eqn.primitive in initial_style_translations:
-    return any(jaxpr_has_pmap(param if type(param) is core.Jaxpr else param.jaxpr)
-               for param in eqn.params.values()
-               if type(param) in (core.Jaxpr, core.TypedJaxpr))
-  else:
-    return 'pmap' in eqn.primitive.name
+  """Whether there is an xla_pmap primitive anywhere inside a Jaxpr."""
+  for eqn in jaxpr.eqns:
+    if 'xla_pmap' in eqn.primitive.name:
+      return True
+  for subjaxpr in core.subjaxprs(jaxpr):
+    if jaxpr_has_pmap(subjaxpr):
+      return True
+  return False
 
 
 def jaxpr_collectives(jaxpr):
-  return it.chain.from_iterable(eqn_collectives(eqn) for eqn in jaxpr.eqns)
-
-def eqn_collectives(eqn):
-  if eqn.bound_subjaxpr:
-    for c in jaxpr_collectives(eqn.bound_subjaxpr):
-      yield c
-  elif eqn.primitive in initial_style_translations:
-    for param in eqn.params.values():
-      if type(param) is core.Jaxpr:
-        for c in jaxpr_collectives(param):
-          yield c
-      elif type(param) is core.TypedJaxpr:
-        for c in jaxpr_collectives(param.jaxpr):
-          yield c
-  else:
+  """Generates all the collective primitives anywhere inside a Jaxpr."""
+  for eqn in jaxpr.eqns:
     if eqn.primitive in parallel_translations:
       yield eqn.primitive
+  for subjaxpr in core.subjaxprs(jaxpr):
+    yield from jaxpr_collectives(subjaxpr)
 
 
 ### xla_call underlying jit
@@ -611,17 +596,19 @@ def _get_device(device, backend):
   return out
 
 xla_call_p = core.Primitive('xla_call')
+xla_call_p.call_primitive = True
 xla_call_p.multiple_results = True
 xla_call = partial(core.call_bind, xla_call_p)
 xla_call_p.def_custom_bind(xla_call)
 xla_call_p.def_impl(_xla_call_impl)
 
-def _xla_call_translation_rule(c, jaxpr, axis_env,
-                               in_nodes, name_stack, backend, name, device=None):
+def _xla_call_translation_rule(c, axis_env,
+                               in_nodes, name_stack, backend, name,
+                               call_jaxpr, device=None):
   del device  # Ignored.
   subc = xb.make_computation_builder("jit_{}".format(name))
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
-  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, (),
+  out_nodes = jaxpr_subcomp(subc, call_jaxpr, backend, axis_env, (),
                             extend_name_stack(name_stack, wrap_name(name, 'jit')), *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(in_nodes))
@@ -983,15 +970,16 @@ masking.shape_rules[device_put_p] = lambda x, **_: x.shape
 masking.defvectorized(device_put_p)
 
 
-def _remat_translation_rule(c, jaxpr, axis_env, in_nodes,
-                            name_stack, backend, name, device=None, concrete=None):
+def _remat_translation_rule(c, axis_env, in_nodes,
+                            name_stack, backend, name, call_jaxpr,
+                            device=None, concrete=None):
   # This looks a lot like _xla_call_translation_rule, except for a widget we use
   # to foil CSE.
   del device, concrete  # Unused.
   subc = xb.make_computation_builder("remat_call_subcomputation")
   args = [subc.ParameterWithShape(c.GetShape(n)) for n in in_nodes]
   args = [_foil_cse(subc, x) for x in args]
-  out_nodes = jaxpr_subcomp(subc, jaxpr, backend, axis_env, (),
+  out_nodes = jaxpr_subcomp(subc, call_jaxpr, backend, axis_env, (),
                             extend_name_stack(name_stack, wrap_name(name, 'remat')), *args)
   subc = subc.Build(subc.Tuple(*out_nodes))
   return c.Call(subc, list(in_nodes))

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -27,6 +27,7 @@ import numpy as onp
 import numpy.random as npr
 
 from . import api
+from . import core
 from . import dtypes
 from . import lax
 from .config import flags, bool_env
@@ -616,9 +617,8 @@ def _iter_eqns(jaxpr):
   # TODO(necula): why doesn't this search in params?
   for eqn in jaxpr.eqns:
     yield eqn
-    if eqn.bound_subjaxpr:
-      for sub_eqn in _iter_eqns(eqn.bound_subjaxpr):
-        yield sub_eqn
+  for subjaxpr in core.subjaxprs(jaxpr):
+    yield from _iter_eqns(subjaxpr)
 
 def assert_dot_precision(expected_precision, fun, *args):
   jaxpr = api.make_jaxpr(fun)(*args)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1003,8 +1003,8 @@ class APITest(jtu.JaxTestCase):
     c = onp.ones((2, 3, 3))
 
     jaxpr = api.make_jaxpr(lambda b, c: f(a, b, c))(b, c)
-    subjaxpr = next(eqn.bound_subjaxpr for eqn in jaxpr.jaxpr.eqns
-                    if eqn.bound_subjaxpr)
+    subjaxpr = next(eqn.params["call_jaxpr"] for eqn in jaxpr.jaxpr.eqns
+                    if "call_jaxpr" in eqn.params)
     self.assertEqual(len(subjaxpr.eqns), 1)
 
   def test_grad_of_int_errors(self):
@@ -1683,7 +1683,7 @@ class APITest(jtu.JaxTestCase):
 
     self.assertLen(outer_jaxpr.eqns, 1)
     self.assertEqual(outer_jaxpr.eqns[0].primitive.name, 'xla_call')
-    subjaxpr_1 = outer_jaxpr.eqns[0].bound_subjaxpr
+    subjaxpr_1 = outer_jaxpr.eqns[0].params["call_jaxpr"]
     self.assertEqual(str(subjaxpr_1), str(inner_jaxpr))
     self.assertLen(inner_jaxpr.eqns, 2)
     self.assertEqual(inner_jaxpr.eqns[0].primitive.name, 'mul')

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1126,6 +1126,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     for dtype in float_types + complex_types
   ))
   def testIssue2131(self, n, dtype):
+    _skip_on_mac_xla_bug()
     args_maker_zeros = lambda: [onp.zeros((n, n), dtype)]
     osp_fun = lambda a: osp.linalg.expm(a)
     jsp_fun = lambda a: jsp.linalg.expm(a)


### PR DESCRIPTION
… params.

The goal is to make the Jaxpr language more uniform: all higher-order
primitives carry sub-Jaxprs that are part of the parameters, and they
are all called xxx_jaxpr. As a side-effect, some code is simplified
(e.g., the code that searches for sub-jaxprs).

For now the code assumes that all the `call` (final-style) primitives
carry exactly one subjaxpr with the parameter name `call_jaxpr`. These
primitives are still processed differently in the internal code, but
there is no reason any external consumer of a Jaxpr needs to know this.