### PR TITLE
relax the ndim>=1 condition of tensordot

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2321,9 +2321,6 @@ def tensordot(a, b, axes=2, precision=None):
   _check_arraylike("tensordot", a, b)
   a_ndim = ndim(a)
   b_ndim = ndim(b)
-  if a_ndim < 1 or b_ndim < 1:
-    msg = "tensordot requires a.ndim and b.dim to be at least 1, got {} and {}."
-    raise TypeError(msg.format(ndim(a), ndim(b)))
 
   a, b = _promote_dtypes(a, b)
   if type(axes) is int:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -785,6 +785,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axes": axes, "rng_factory": rng_factory}
       for rng_factory in [jtu.rand_default]
       for lhs_shape, rhs_shape, axes in [
+          [(3,), (), 0],
           [(2, 3, 4), (5, 6, 7), 0],  # from issue #740
           [(2, 3, 4), (3, 4, 5, 6), 2],
           [(2, 3, 4), (5, 4, 3, 6), [1, 2]],


### PR DESCRIPTION
This condition is not necessary. NumPy allows scalar inputs with axes=0. In my opinion, the check
```
if axes > _min(a_ndim, b_ndim):
```
in a few lines below is enough. Currently, `jax.numpy.tensordot(np.ones(3), 1., axes=0)` raise an error while `numpy.tensordot(np.ones(3), 1., axes=0)` returns `array([1., 1., 1.])`.