### PR TITLE
[Draft] Fix lax.max grad

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1906,11 +1906,12 @@ def _minmax_translation_rule(c, x, y, minmax=None, cmp=None):
         x, y)
   return minmax(c)(x, y)
 
+
 max_p = standard_naryop([_any, _any], 'max', translation_rule=partial(
     _minmax_translation_rule, minmax=lambda c: c.Max, cmp=lambda c: c.Gt))
 ad.defjvp2(max_p,
-           lambda g, ans, x, y: mul(_brcast(g, y), _balanced_eq(x, ans, y)),
-           lambda g, ans, x, y: mul(_brcast(g, x), _balanced_eq(y, ans, x)))
+           lambda g, ans, x, y: mul(_brcast(g, y), _eq(ans, x)),
+           lambda g, ans, x, y: mul(_brcast(g, x), _eq(ans, y)))
 
 min_p = standard_naryop([_any, _any], 'min', translation_rule=partial(
     _minmax_translation_rule, minmax=lambda c: c.Min, cmp=lambda c: c.Lt))
@@ -4599,6 +4600,8 @@ def _balanced_eq(x, z, y):
   return div(select(_eq_meet(x, z), _ones(z), _zeros(z)),
              select(_eq_meet(y, z), _twos(z), _ones(z)))
 
+def _eq(x, z):
+  return select(_eq_meet(x, z), _ones(z), _zeros(z))
 
 def _eq_meet(a, b):
   a_dtype, b_dtype = _dtype(a), _dtype(b)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1910,8 +1910,8 @@ def _minmax_translation_rule(c, x, y, minmax=None, cmp=None):
 max_p = standard_naryop([_any, _any], 'max', translation_rule=partial(
     _minmax_translation_rule, minmax=lambda c: c.Max, cmp=lambda c: c.Gt))
 ad.defjvp2(max_p,
-           lambda g, ans, x, y: mul(_brcast(g, y), _eq(ans, x)),
-           lambda g, ans, x, y: mul(_brcast(g, x), _eq(ans, y)))
+           lambda g, ans, x, y: mul(_brcast(g, y), _eq(x, ans)),
+           lambda g, ans, x, y: mul(_brcast(g, x), _eq(y, ans)))
 
 min_p = standard_naryop([_any, _any], 'min', translation_rule=partial(
     _minmax_translation_rule, minmax=lambda c: c.Min, cmp=lambda c: c.Lt))

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -364,7 +364,7 @@ class BatchingTest(jtu.JaxTestCase):
     ans = hessian(lambda x: fun(x, 0.0))(x)
     expected = onp.array([[0., 0., 0., 0., 0.],
                           [0., 0., 0., 0., 0.],
-                          [0., 0.,0.5, 0., 0.],
+                          [0., 0., 2., 0., 0.],
                           [0., 0., 0., 2., 0.],
                           [0., 0., 0., 0., 2.]])
     self.assertAllClose(ans, expected, check_dtypes=False)


### PR DESCRIPTION
This solves both #2140 and #2107 

Here's the grad of softplus, using @shoyer 's code in #2107. 
![image](https://user-images.githubusercontent.com/13261989/74078583-95024280-4a6f-11ea-920c-b04dd92dd3bb.png)

Edit: Clarifying my PR, previously JAX considered `grad max(x,y) = 0.5`, when `x = y`. 
By using this [definition of max](https://math.stackexchange.com/questions/1237239/what-is-the-derivative-of-max-and-min-functions) and JAX's `grad abs(x - y) = 1`, when `x == y`, it makes sense for `grad max(x, y) = 1`, when `x == y`. 
Also by making the change we can solve both issues cited above