### PR TITLE
enable array literals (not just scalars)

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -74,7 +74,7 @@ class JaxprTrace(Trace):
     if isinstance(pv, AbstractValue):
       return tracer
     elif pv is None:
-      if type(const) in core.literalable_types and onp.shape(const) == ():
+      if type(const) in core.literalable_types:
         return self.new_instantiated_literal(const)
       else:
         return self.new_instantiated_const(const)
@@ -159,6 +159,7 @@ class JaxprTrace(Trace):
     out_tracers = [JaxprTracer(self, PartialVal((out_pv, out_pv_const)), None)
                    for out_pv, out_pv_const in zip(out_pvs, out_pv_consts)]
     # The `jaxpr` already contains the env_vars at start of invars
+    # TODO(mattjj): avoid consts being broadcasted
     new_params = dict(params,
                       mapped_invars=tuple([True] * len(const_tracers) +
                                           [False] * len(env_tracers) +

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -466,7 +466,7 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
     jaxpr.invars = jaxpr.invars[1:]  # ignore dummy
     assert not env
     del master
-  out_pvs, out_consts = unzip2(out_pvals)
+  out_pvs, _ = unzip2(out_pvals)
 
   # TODO(skye,mattjj): allow more collectives on multi-host as we test them, but
   # for now raise an error

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -305,7 +305,10 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
 
   def read(v):
     if type(v) is Literal:
-      return c.Constant(canonicalize_dtype(v.val))
+      val = env.get(v, None)
+      if val is None:
+        env[v] = val = c.Constant(canonicalize_dtype(v.val))
+      return val
     else:
       return env[v]
 


### PR DESCRIPTION
Previously we only included scalars as literals in jaxprs. This PR removes that constraint, and allows arrays of any size to be included in jaxpr literals.

The reason for this change is to fix an old issue where array constants in pmapped computations were broadcasted to have a leading axis equal to the mapped axis size, e.g. from @hawkinsp:

```python
import jax
import jax.random
import numpy as np

x = jax.random.uniform(jax.random.PRNGKey(0), shape=(1000000, 10))
f = jax.pmap(lambda i: x[i])

print(jax.xla_computation(f)(np.arange(12)).GetHloText())
```

```
$ XLA_FLAGS="--xla_force_host_platform_device_count=12" python

ENTRY xla_computation_pmap__lambda___axis_name__axis_0x7fd36de1a2f0__.56 {
  ...
  constant.1 = f32[12,1000000,10]{2,1,0} constant({...})
  ...
```

The issue was that [we got consts for a staged-out pmap as outputs from a pmap bind](https://github.com/google/jax/blob/28e802c6f15d7ed87fee9bee6270137423b9967c/jax/interpreters/partial_eval.py#L151-L153), and outputs from a pmap always have a leading axis size equal to the mapped axis size (i.e. constants are broadcast). This PR changes it so that array constants aren't produced as outputs but instead immediately hoisted into the jaxpr being formed as literals. (An alternative solution would be to allow non-mapped outputs from a pmapped function, which we might want anyway, but this seems simpler for handling array constants.)

Since all JAX types are currently literalable types, I can't think of a way for the consts field to be populated now. I thought closing over outer tracers would do it, like this:

```python
@jit 
def f(x):
  @jit 
  def g():
    return x
  return g()
```

but that instead populates `env`, which means it now gets closure-converted into the formal parameters.

This choice can affect serialization, since jaxprs themselves may contain large array constants (without further processing).

TODO
- [ ] attempt to de-duplicate large literals with subjaxprs