### PR TITLE
Try downloading bazel before using pre-installed bazel.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -125,11 +125,11 @@ def get_bazel_path(bazel_path_flag):
   if bazel_path_flag:
     return bazel_path_flag
 
-  bazel = which("bazel")
+  bazel = download_and_verify_bazel()
   if bazel:
     return bazel
 
-  bazel = download_and_verify_bazel()
+  bazel = which("bazel")
   if bazel:
     return bazel
 


### PR DESCRIPTION
This ensures we're using the right bazel version.