### PR TITLE
Return error number in build.py on bad bazel version.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -151,13 +151,13 @@ def check_bazel_version(bazel_path, min_version, max_version):
   if min_ints > actual_ints:
     print("Outdated bazel revision (>= {} required, found {})".format(
         min_version, version))
-    sys.exit(0)
+    sys.exit(-1)
   if max_version is not None:
     max_ints = [int(x) for x in max_version.split(".")]
     if actual_ints >= max_ints:
       print("Please downgrade your bazel revision to build JAX (>= {} and < {}"
             " required, found {})".format(min_version, max_version, version))
-      sys.exit(0)
+      sys.exit(-1)
 
 
 BAZELRC_TEMPLATE = """


### PR DESCRIPTION
This prevents our build scripts from continuing on error.