### PR TITLE
Faster gradient rules for {numpy,scipy}.linalg.solve

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -27,6 +27,7 @@ from .. import lax_linalg
 from .. import dtypes
 from .lax_numpy import _not_implemented
 from .lax_numpy import _wraps
+from .vectorize import vectorize
 from . import lax_numpy as np
 from ..api import custom_transforms, defjvp
 from ..util import get_module_functions
@@ -328,16 +329,38 @@ def qr(a, mode="reduced"):
   return q, r
 
 
-@_wraps(onp.linalg.solve)
-@jit
-def solve(a, b):
-  a, b = _promote_arg_dtypes(np.asarray(a), np.asarray(b))
+def _check_solve_shapes(a, b):
   if not (a.ndim >= 2 and a.shape[-1] == a.shape[-2] and b.ndim >= 1):
     msg = ("The arguments to solve must have shapes a=[..., m, m] and "
            "b=[..., m, k] or b=[..., m]; got a={} and b={}")
     raise ValueError(msg.format(a.shape, b.shape))
-  lu, pivots = lax_linalg.lu(a)
-  return lax_linalg.lu_solve(lu, pivots, b, trans=0)
+
+
+@partial(vectorize, signature='(n,m),(m)->(n)')
+def _matvec_multiply(a, b):
+  return np.dot(a, b, precision=lax.Precision.HIGHEST)
+
+
+@_wraps(onp.linalg.solve)
+@jit
+def solve(a, b):
+  a, b = _promote_arg_dtypes(np.asarray(a), np.asarray(b))
+  _check_solve_shapes(a, b)
+
+  # With custom_linear_solve, we can reuse the same factorization when
+  # computing sensitivities. This is considerably faster.
+  lu, pivots = lax.stop_gradient(lax_linalg.lu)(a)
+  custom_solve = partial(
+      lax.custom_linear_solve,
+      lambda x: _matvec_multiply(a, x),
+      solve=lambda _, x: lax_linalg.lu_solve(lu, pivots, x, trans=0),
+      transpose_solve=lambda _, x: lax_linalg.lu_solve(lu, pivots, x, trans=1))
+  if a.ndim == b.ndim + 1:
+    # b.shape == [..., m]
+    return custom_solve(b)
+  else:
+    # b.shape == [..., m, k]
+    return vmap(custom_solve, b.ndim - 1, max(a.ndim, b.ndim) - 1)(b)
 
 
 for func in get_module_functions(onp.linalg):

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -18,7 +18,7 @@ from functools import partial
 import scipy.linalg
 import textwrap
 
-from jax import jit
+from jax import jit, vmap
 from .. import lax
 from .. import lax_linalg
 from ..numpy.lax_numpy import _wraps
@@ -45,24 +45,16 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 @partial(jit, static_argnums=(2,))
 def _cho_solve(c, b, lower):
   c, b = np_linalg._promote_arg_dtypes(np.asarray(c), np.asarray(b))
-  c_shape = np.shape(c)
-  b_shape = np.shape(b)
-  c_ndims = len(c_shape)
-  b_ndims = len(b_shape)
-  if not (c_ndims >= 2 and c_shape[-1] == c_shape[-2] and
-          (c_ndims == b_ndims or c_ndims == b_ndims + 1)):
-    msg = ("The arguments to solve must have shapes a=[..., m, m] and "
-           "b=[..., m, k] or b=[..., m]; got a={} and b={}")
-    raise ValueError(msg.format(c_shape, b_shape))
-
+  np_linalg._check_solve_shapes(c, b)
   # TODO(phawkins): triangular_solve only supports matrices on the RHS, so we
   # add a dummy dimension. Extend it to support vectors and simplify this.
-  b = b if c_ndims == b_ndims else b[..., None]
+  rhs_vector = c.ndim == b.ndim + 1
+  b = b[..., np.newaxis] if rhs_vector else b
   b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
                                   transpose_a=not lower, conjugate_a=not lower)
   b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
                                   transpose_a=lower, conjugate_a=lower)
-  return b[..., 0] if c_ndims != b_ndims else b
+  return b[..., 0] if rhs_vector else b
 
 @_wraps(scipy.linalg.cho_solve, update_doc=False)
 def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
@@ -170,13 +162,30 @@ def qr(a, overwrite_a=False, lwork=None, mode="full", pivoting=False,
   del overwrite_a, lwork, check_finite
   return _qr(a, mode, pivoting)
 
+
 @partial(jit, static_argnums=(2, 3))
 def _solve(a, b, sym_pos, lower):
   if not sym_pos:
     return np_linalg.solve(a, b)
 
   a, b = np_linalg._promote_arg_dtypes(np.asarray(a), np.asarray(b))
-  return cho_solve(cho_factor(a, lower=lower), b)
+  np_linalg._check_solve_shapes(a, b)
+
+  # With custom_linear_solve, we can reuse the same factorization when
+  # computing sensitivities. This is considerably faster.
+  factors = lax.stop_gradient(cho_factor)(a, lower=lower)
+  custom_solve = partial(
+      lax.custom_linear_solve,
+      lambda x: np_linalg._matvec_multiply(a, x),
+      solve=lambda _, x: cho_solve(factors, x),
+      symmetric=True)
+  if a.ndim == b.ndim + 1:
+    # b.shape == [..., m]
+    return custom_solve(b)
+  else:
+    # b.shape == [..., m, k]
+    return vmap(custom_solve, b.ndim - 1, max(a.ndim, b.ndim) - 1)(b)
+
 
 @_wraps(scipy.linalg.solve)
 def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False,


### PR DESCRIPTION
Fixes #1747

The implicit function theorem (via `lax.custom_linear_solve`) lets us _directly_ define gradients for linear solves, in contrast to the current implementations of gradient for `solve` which rely upon differentiating matrix factorization.

In **theory**, JVPs of `cholesky` and `lu` involve the equivalent of ~3 dense matrix-matrix multiplications, which makes them rather expensive: time `O(n**3)`. In contrast, with `custom_linear_solve` we don't need to differentiate the factorization. The JVP and VJP rules for linear solve (for a single right-hand-side vector) now only use matrix-vector products and triangular solves, which is time `O(n**2)`. We should also have reduced memory usage, because we don't need to save any intermediate outputs.

In **practice**, these new gradient rules seem to make linear solves with large arrays ~3x faster, e.g.,

    from functools import partial
    import jax.scipy as jsp
    from jax import lax
    import jax.numpy as np
    import numpy as onp
    import jax

    def loss(solve):
      def f(a, b):
        return solve(a, b).sum()
      return f

    rs = onp.random.RandomState(0)
    N = 500
    K = 1
    a = rs.randn(N, N)
    a = jax.device_put(a.T @ a + 0.1 * np.eye(N))
    b = jax.device_put(rs.randn(N, K))

    # general matrix solve
    grad = jax.jit(jax.grad(loss(np.linalg.solve)))
    grad(a, b).block_until_ready()
    %timeit grad(a, b).block_until_ready()
    # N=500, K=1: 11.4 ms -> 3.63 ms

    # positive definite solve
    grad = jax.jit(jax.grad(loss(partial(jsp.linalg.solve, sym_pos=True))))
    grad(a, b).block_until_ready()
    %timeit grad(a, b).block_until_ready()
    # N=500, K=1: 9.22 ms -> 2.83 ms