### PR TITLE
Fix minor bug in bernoulli.pmf

### DIFF
--- a/jax/scipy/stats/bernoulli.py
+++ b/jax/scipy/stats/bernoulli.py
@@ -33,4 +33,4 @@ def logpmf(k, p, loc=0):
 
 @np._wraps(osp_stats.bernoulli.pmf, update_doc=False)
 def pmf(k, p, loc=0):
-  return np.exp(pmf(k, p, loc))
+  return np.exp(logpmf(k, p, loc))


### PR DESCRIPTION
np.exp(pmf(...)) -> np.exp(logpmf(...))