### PR TITLE
Docstring typo

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -670,7 +670,7 @@ def _cauchy(key, shape, dtype):
 
 
 def dirichlet(key, alpha, shape=None, dtype=onp.float64):
-  """Sample Cauchy random values with given shape and float dtype.
+  """Sample Dirichlet random values with given shape and float dtype.
 
   Args:
     key: a PRNGKey used as the random key.


### PR DESCRIPTION
One word typo in the dirichlet documentation.