### PR TITLE
Expanded the error messages due to re-using tracers saved in global s…

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -280,6 +280,13 @@ class Trace(object):
     self.level = master.level
     self.sublevel = sublevel
 
+  def escaped_tracer_error(self, detail):
+    msg = ("Encountered an unexpected tracer. Perhaps this tracer escaped "
+           "through global state from a previously traced function.\n"
+           "The functions being transformed should not save traced values to "
+           "global state.\nDetails: {}.")
+    raise ValueError(msg.format(detail))
+
   def full_raise(self, val):
     if not isinstance(val, Tracer):
       return self.pure(val)
@@ -291,19 +298,18 @@ class Trace(object):
       elif val._trace.sublevel < sublevel:
         return self.sublift(val)
       else:
-        raise Exception("Can't lift sublevels {} to {}"
-                        .format(val._trace.sublevel, sublevel))
+        self.escaped_tracer_error(
+          "Can't lift sublevels {} to {}".format(val._trace.sublevel, sublevel))
     elif val._trace.level < level:
       if val._trace.sublevel > sublevel:
-        raise Exception("Incompatible sublevel: {}, {}"
-                        .format(val._trace, (level, sublevel)))
+        self.escaped_tracer_error(
+          "Incompatible sublevel: {}, {}".format(val._trace, (level, sublevel)))
       return self.lift(val)
     elif val._trace.level > level:
-      raise Exception("Can't lift {} to {}".format(val, self))
-    elif val._trace.level == self.level:
-      raise Exception("Different traces at same level: {}, {}".format(val, self))
-    else:
-      raise Exception("Can't lift {} to {}".format(val, self))
+      self.escaped_tracer_error(
+        "Can't lift level {} to {}".format(val, self))
+    else:  # val._trace.level == self.level:
+      self.escaped_tracer_error("Different traces at same level: {}, {}".format(val, self))
 
 
   def pure(self, val):

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -370,8 +370,8 @@ class _BodyTracer(object):
         in_tracers=in_tracers,
         out_tracers=body_out_tracers,
         trace=self.trace)
-    except AssertionError as e:
-      if "Encountered unexpected tracer" == str(e):
+    except ValueError as e:
+      if "Tracer not among input tracers" in str(e):
         raise ValueError("Body of cond_range or while_range should not use the "
                          "index variable returned by iterator.")
       raise


### PR DESCRIPTION
…tate.

Previously these errors were raising Exception (as other internal errors),
but these errors may arise out of mis-use of tracers.