### PR TITLE
Add `jax.nn.one_hot(x, num_classes, dtype)`.

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -17,6 +17,7 @@
 
 import numpy as onp
 
+from jax import dtypes
 from jax import lax
 from jax import random
 from jax.scipy.special import expit
@@ -235,3 +236,31 @@ def normalize(x, axis=-1, mean=None, variance=None, epsilon=1e-5):
     # when used in neural network normalization layers
     variance = np.mean(x**2, axis, keepdims=True) - mean**2
   return (x - mean) * lax.rsqrt(variance + epsilon)
+
+def one_hot(x, num_classes, *, dtype=np.float64):
+  """One-hot encodes the given indicies.
+
+  Each index in the input ``x`` is encoded as a vector of zeros of length
+  ``num_classes`` with the element at ``index`` set to one::
+
+  >>> jax.nn.one_hot(np.array([0, 1, 2]), 3)
+  DeviceArray([[1., 0., 0.],
+               [0., 1., 0.],
+               [0., 0., 1.]], dtype=float32)
+
+  Indicies outside the range [0, num_classes) will be encoded as zeros::
+
+  >>> jax.nn.one_hot(np.array([-1, 3]), 3)
+  DeviceArray([[0., 0., 0.],
+               [0., 0., 0.]], dtype=float32)
+
+  Args:
+    x: A tensor of indices.
+    num_classes: Number of classes in the one-hot dimension.
+    dtype: optional, a float dtype for the returned values (default float64 if
+      jax_enable_x64 is true, otherwise float32).
+  """
+  dtype = dtypes.canonicalize_dtype(dtype)
+  x = np.asarray(x)
+  return np.array(x[..., np.newaxis] == np.arange(num_classes, dtype=x.dtype),
+                  dtype=dtype)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -61,6 +61,39 @@ class NNFunctionsTest(jtu.JaxTestCase):
     # see https://github.com/google/jax/pull/1640
     jax.make_jaxpr(nn.hard_tanh)(np.ones((10 ** 12,)))  # don't oom
 
+  def testOneHot(self):
+    actual = nn.one_hot(np.array([0, 1, 2]), 3)
+    expected = np.array([[1., 0., 0.],
+                         [0., 1., 0.],
+                         [0., 0., 1.]])
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+    actual = nn.one_hot(np.array([1, 2, 0]), 3)
+    expected = np.array([[0., 1., 0.],
+                         [0., 0., 1.],
+                         [1., 0., 0.]])
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+  def testOneHotOutOfBound(self):
+    actual = nn.one_hot(np.array([-1, 3]), 3)
+    expected = np.array([[0., 0., 0.],
+                         [0., 0., 0.]])
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+  def testOneHotNonArrayInput(self):
+    actual = nn.one_hot([0, 1, 2], 3)
+    expected = np.array([[1., 0., 0.],
+                         [0., 1., 0.],
+                         [0., 0., 1.]])
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+  def testOneHotCustomDtype(self):
+    actual = nn.one_hot(np.array([0, 1, 2]), 3, dtype=np.bool_)
+    expected = np.array([[True, False, False],
+                         [False, True, False],
+                         [False, False, True]])
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
 InitializerRecord = collections.namedtuple(
   "InitializerRecord",
   ["name", "initializer", "shapes"])


### PR DESCRIPTION
This is an extremely common function and I've seen it re-implemented in a bunch of places, I think it would be useful to have a standard implementation in `jax.nn`.

I've marked `dtype` as keyword only because I think we may want to add more parameters to this function in the future (e.g. axis, on/off value) and we may want to place these args before dtype in the list (e.g. axis first). I'm not sure if there is an established pattern in JAX for this already and would be open to suggestions if there are alternatives to consider.