### PR TITLE
Correct sign mistake in complex autodiff docs

### DIFF
--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -1399,6 +1399,7 @@
    },
    "source": [
     "This convention covers three important cases:\n",
+    "\n",
     "1. If `f` evaluates a holomorphic function, then we get the usual complex derivative, since $\\partial_0 u = \\partial_1 v$ and $\\partial_1 u = - \\partial_0 v$.\n",
     "2. If `f` is evaluates the real-valued loss function of a complex parameter `x`, then we get a result that we can use in gradient-based optimization by taking steps in the direction of the conjugate of `grad(f)(x)`.\n",
     "3. If `f` evaluates a real-to-real function, but its implementation uses complex primitives internally (some of which must be non-holomorphic, e.g. FFTs used in convolutions) then we get the same result that an implementation that only used real primitives would have given.\n",

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -1378,7 +1378,7 @@
    "source": [
     "def grad_f(z):\n",
     "    x, y = real(z), imag(z)\n",
-    "    return grad(u, 0)(x, y) + grad(u, 1)(x, y) * 1j"
+    "    return grad(u, 0)(x, y) - grad(u, 1)(x, y) * 1j"
    ]
   },
   {
@@ -1388,7 +1388,7 @@
     "id": "4j0F28bB8bgK"
    },
    "source": [
-    "In math symbols, that means we define $\\partial f(z) \\triangleq  \\partial_0 u(x, y) + \\partial_1 u(x, y)$. So we throw out $v$, ignoring the complex component function of $f$ entirely!"
+    "In math symbols, that means we define $\\partial f(z) \\triangleq  \\partial_0 u(x, y) - \\partial_1 u(x, y) i$. So we throw out $v$, ignoring the complex component function of $f$ entirely!"
    ]
   },
   {


### PR DESCRIPTION
The autodiff cookbook notebook had the wrong sign for the complex derivative and the imaginary i was missing in one place. The referenced [autograd docs](https://github.com/HIPS/autograd/blob/master/docs/tutorial.md#complex-numbers) had the right sign.