### PR TITLE
Update WORKSPACE to setup upstream dependencies.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,3 +49,27 @@ tf_workspace(
 )
 
 tf_bind()
+
+# Required for TensorFlow dependency on @com_github_grpc_grpc
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
+load("@upb//bazel:repository_defs.bzl", "bazel_version_repository")
+
+bazel_version_repository(name = "bazel_version")


### PR DESCRIPTION
This is necessary as of https://github.com/tensorflow/tensorflow/commit/f396035891b0938364ea247a7dd243a147930c6e.

Many thanks to @lezh for this fix!

Co-authored-by: Oliver Le Zhuang <izhuangle@gmail.com>