### PR TITLE
Revert "add np.copy method to abstract arrays (#2257)"

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1383,10 +1383,11 @@ def device_put(x, device=None):
   return tree_map(lambda y: xla.device_put_p.bind(y, device=device), x)
 
 
+# TODO(mattjj): consider revising
 def _device_get(x):
   if isinstance(x, core.Tracer):
     return x
-  return onp.asarray(x)
+  return x.copy()
 
 def device_get(x):
   for y in tree_leaves(x):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1857,10 +1857,6 @@ def asarray(a, dtype=None, order=None):
   lax._check_user_dtype_supported(dtype, "asarray")
   return array(a, dtype=dtype, copy=False, order=order)
 
-@_wraps(onp.copy)
-def copy(a, order='K'):
-  return array(a, copy=True, order=order)
-
 
 @_wraps(onp.zeros_like)
 def zeros_like(x, dtype=None):
@@ -3481,8 +3477,7 @@ _nondiff_methods = ["all", "any", "argmax", "argmin", "argpartition", "argsort",
 _diff_methods = ["clip", "compress", "conj", "conjugate", "cumprod", "cumsum",
                  "diagonal", "dot", "max", "mean", "min", "prod", "ptp",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
-                 "swapaxes", "take", "tile", "trace", "transpose", "var",
-                 "copy"]
+                 "swapaxes", "take", "tile", "trace", "transpose", "var"]
 
 
 # Set up operator, method, and property forwarding on Tracer instances containing

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1826,9 +1826,6 @@ class APITest(jtu.JaxTestCase):
           re.DOTALL)):
       api.jit(func1)(2.)
 
-  def test_array_tracer_copy(self):
-    api.value_and_grad(lambda x: x.copy().sum())(np.ones(2))  # doesn't crash
-
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This reverts commit ae1214de74e9ec42da8ff813dab8577c6bd9231d.

This is only to test the internal pre-submits.