### PR TITLE
Minor fixes to docs related to jax.numpy.vectorize

### DIFF
--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -7,6 +7,5 @@ jax.experimental package
     jax.experimental.loops
     jax.experimental.optimizers
     jax.experimental.stax
-    jax.experimental.vectorize
 
 .. automodule:: jax.experimental

--- a/docs/jax.experimental.vectorize.rst
+++ b/docs/jax.experimental.vectorize.rst
@@ -1,6 +1,0 @@
-jax.experimental.vectorize module
-=================================
-
-.. automodule:: jax.experimental.vectorize
-    :members:
-    :show-inheritance:

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -51,7 +51,7 @@ Vectorization (:code:`vmap`)
 ----------------------------
 
 .. autofunction:: vmap
-.. autofunction:: numpy.vectorize
+.. autofunction:: jax.numpy.vectorize
 
 Parallelization (:code:`pmap`)
 ------------------------------

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -303,7 +303,7 @@ def update_numpydoc(docstr, fun, op):
   parameters = '\n'.join(param_list).replace('@@', '\n    ')
   return docstr[:begin_idx + 1] + parameters + docstr[end_idx - 2:]
 
-_numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$')
+_numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*\)$')
 
 def _wraps(fun, update_doc=True, lax_description=""):
   """Like functools.wraps but works with numpy.ufuncs.


### PR DESCRIPTION
- Show `numpy.jax.vectorize` explicitly in the JAX docs, rather than the
  original `numpy.vectorize.
- Updated regex for identifying function signatures in NumPy. This now correctly
  parses `np.vectorize` and `np.einsum`.
- Removed docs for `jax.experimental.vectorize`. There's still some good
  narrative content in the docstring but it should go somewhere else.