### PR TITLE
Give `Var`s an `aval`.

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -12,222 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import operator
-
 import numpy as onp
 
-from . import core
 from . import ad_util
+from . import core
 from . import dtypes
-from . util import prod, partialmethod
 
+_DIMENSION_TYPES = core._DIMENSION_TYPES
 
-def concretization_err_msg(fun, context=None):
-  fname = getattr(fun, "__name__", fun)
-  if context is None:
-    context = ("The function to be transformed can't be traced at the required level "
-        "of abstraction. If using `jit`, try using `static_argnums` or "
-        "applying `jit` to smaller subfunctions instead.")
-  msg = "Abstract value passed to `{}`, which requires a concrete value. {}"
-  return msg.format(fname, context)
-
-def concretization_function_error(fun, context=None):
-  def error(self, *args):
-    raise TypeError(concretization_err_msg(fun, context))
-  return error
-
-
-class UnshapedArray(core.AbstractValue):
-  __slots__ = ['dtype', 'weak_type']
-  array_abstraction_level = 2
-
-  def __init__(self, dtype, weak_type=False):
-    self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtype))
-    self.weak_type = weak_type
-
-  def __eq__(self, other):
-    return (type(self) is type(other) and self.dtype == other.dtype and
-            self.weak_type == other.weak_type)
-
-  def __ne__(self, other):
-    return not self == other
-
-  def __hash__(self):
-    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
-    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
-    # the unique character code via hash(self.dtype.char)
-    return hash((self.dtype, self.weak_type))
-
-  def __repr__(self):
-    return '{}({}{})'.format(self.__class__.__name__, self.str_short(),
-                             ", weak_type=True" if self.weak_type else "")
-
-  _bool = _nonzero = concretization_function_error(bool)
-  _float   = concretization_function_error(
-      float, "Try using `value.astype(float)` instead.")
-  _int     = concretization_function_error(
-      int, "Try using `value.astype(int)` instead.")
-  _complex = concretization_function_error(
-      complex, "Try using `value.astype(complex)` instead.")
-  _hex     = concretization_function_error(hex)
-  _oct     = concretization_function_error(oct)
-
-  def at_least_vspace(self):
-    return self
-
-  def join(self, other):
-    if self.dtype == other.dtype:
-      if self.weak_type == other.weak_type:
-        return self
-      else:
-        return UnshapedArray(self.dtype, weak_type=False)
-    else:
-      raise TypeError(self, other)
-
-  def str_short(self):
-    return self.dtype.name
-
-  def strip_weak_type(self):
-    """Returns a copy of the aval with weak_type=False."""
-    return UnshapedArray(self.dtype) if self.weak_type else self
-
-# Registry for valid dimension types. This is used by masking.Poly.
-_DIMENSION_TYPES = {int}
-
-def _canonicalize_dimension(dim):
-  if type(dim) in _DIMENSION_TYPES:
-    return dim
-  else:
-    return operator.index(dim)
-
-def canonicalize_shape(shape):
-  """Canonicalizes and checks for errors in a user-provided shape value.
-
-  Args:
-    shape: a Python value that represents a shape.
-
-  Returns:
-    A tuple of integers.
-  """
-  try:
-    return tuple(map(_canonicalize_dimension, shape))
-  except TypeError:
-    pass
-  msg = ("Shapes must be 1D sequences of concrete values of integer type, "
-         "got {}.")
-  if any(isinstance(x, core.Tracer) and isinstance(core.get_aval(x), ShapedArray)
-         and not isinstance(core.get_aval(x), ConcreteArray) for x in shape):
-    msg += ("\nIf using `jit`, try using `static_argnums` or applying `jit` to "
-            "smaller subfunctions.")
-  raise TypeError(msg.format(shape))
-
-
-class ShapedArray(UnshapedArray):
-  __slots__ = ['shape']
-  array_abstraction_level = 1
-
-  def __init__(self, shape, dtype, weak_type=False):
-    super(ShapedArray, self).__init__(dtype, weak_type=weak_type)
-    self.shape = canonicalize_shape(shape)
-
-  ndim = property(lambda self: len(self.shape))
-  size = property(lambda self: prod(self.shape))
-
-  def __eq__(self, other):
-    return (type(self) is type(other)
-            and self.dtype == other.dtype and self.shape == other.shape
-            and self.weak_type == other.weak_type)
-
-  def __hash__(self):
-    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
-    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
-    # the unique character code via hash(self.dtype.char)
-    return hash((self.shape, self.dtype, self.weak_type))
-
-  def at_least_vspace(self):
-    return self
-
-  def join(self, other):
-    if self.shape == other.shape and self.dtype == other.dtype:
-      if self.weak_type == other.weak_type:
-        return self
-      else:
-        return ShapedArray(self.shape, self.dtype, weak_type=False)
-    elif self.dtype == other.dtype:
-      return UnshapedArray(self.dtype)
-    else:
-      raise TypeError(self, other)
-
-  def str_short(self):
-    shapestr = ','.join(map(str, self.shape))
-    return '{}[{}]'.format(self.dtype.name, shapestr)
-
-  def __len__(self):
-    try:
-      return self.shape[0]
-    except IndexError:
-      raise TypeError("len() of unsized object")  # same as numpy error
-
-  def _len(self, ignored_tracer):
-    return len(self)
-
-  def strip_weak_type(self):
-    return ShapedArray(self.shape, self.dtype) if self.weak_type else self
-
-def _forward_to_value(self, fun, ignored_tracer, *args):
-  return fun(self.val, *args)
-
-class ConcreteArray(ShapedArray):
-  __slots__ = ['val']
-  array_abstraction_level = 0
-
-  def __init__(self, val, weak_type=False):
-    super(ConcreteArray, self).__init__(onp.shape(val), onp.result_type(val),
-                                        weak_type=weak_type)
-    # Note: canonicalized self.dtype doesn't necessarily match self.val
-    self.val = val
-    assert self.dtype != onp.dtype('O')
-
-  def __eq__(self, other):
-    return (type(self) is type(other) and self.dtype == other.dtype
-            and self.shape == other.shape and self.weak_type == other.weak_type
-            and onp.all(self.val == other.val))
-
-  def __hash__(self):
-    return id(self.val)
-
-  def at_least_vspace(self):
-    return ShapedArray(self.shape, self.dtype, weak_type=self.weak_type)
-
-  def join(self, other):
-    if self == other:
-      return self
-    elif self.shape == other.shape and self.dtype == other.dtype:
-      return ShapedArray(self.shape, self.dtype,
-                         weak_type=self.weak_type and other.weak_type)
-    elif self.dtype == other.dtype:
-      return UnshapedArray(self.dtype,
-                           weak_type=self.weak_type and other.weak_type)
-    else:
-      raise TypeError(self, other)
-
-  def str_short(self):
-    return str(self.val)
-
-  def strip_weak_type(self):
-    return ConcreteArray(self.val) if self.weak_type else self
-
-  _bool = _nonzero = partialmethod(_forward_to_value, bool)
-  _float   = partialmethod(_forward_to_value, float)
-  _int     = partialmethod(_forward_to_value, int)
-  _complex = partialmethod(_forward_to_value, complex)
-  _hex     = partialmethod(_forward_to_value, hex)
-  _oct     = partialmethod(_forward_to_value, oct)
-
-class AbstractToken(core.AbstractValue): pass
-
-abstract_token = AbstractToken()
+UnshapedArray = core.UnshapedArray
+ShapedArray = core.ShapedArray
+ConcreteArray = core.ConcreteArray
+AbstractToken = core.AbstractToken
+abstract_token = core.abstract_token
+canonicalize_shape = core.canonicalize_shape
+concretization_err_msg = core.concretization_err_msg
+raise_to_shaped = core.raise_to_shaped
 
 
 def make_shaped_array(x):
@@ -255,16 +55,6 @@ def zeros_like_shaped_array(aval):
   return onp.zeros(aval.shape, dtype=aval.dtype)
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
-
-def raise_to_shaped(aval, weak_type=False):
-  if isinstance(aval, ShapedArray):
-    return ShapedArray(aval.shape, aval.dtype, weak_type=weak_type)
-  elif aval is core.abstract_unit:
-    return core.abstract_unit
-  elif aval is abstract_token:
-    return abstract_token
-  else:
-    raise TypeError(type(aval))
 
 core.literalable_types.update(array_types)
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import operator
 from operator import attrgetter
 from contextlib import contextmanager
 from collections import namedtuple, Counter, defaultdict
@@ -22,8 +23,11 @@ from weakref import ref
 import threading
 import types
 
+import numpy as onp
+
+from . import dtypes
 from . import linear_util as lu
-from .util import safe_zip, safe_map, partial, curry
+from .util import safe_zip, safe_map, partial, curry, prod, partialmethod
 from .pprint_util import pp, vcat, hcat, pp_kv_pairs
 
 # TODO(dougalm): the trace cache breaks the leak detector. Consisder solving.
@@ -79,6 +83,14 @@ class TypedJaxpr(object):
     assert all(isinstance(aval, AbstractValue) for aval in in_avals)
     assert all(isinstance(aval, AbstractValue) for aval in out_avals)
 
+    if not skip_checks:
+      in_avals_raised = [raise_to_shaped(v) for v in in_avals]
+      out_avals_raised = [raise_to_shaped(v) for v in out_avals]
+      exp_in_avals = [v.aval for v in jaxpr.invars]
+      exp_out_avals = [v.aval for v in jaxpr.outvars]
+      assert in_avals_raised == exp_in_avals, f"expected: {exp_in_avals}, got: {in_avals_raised}"
+      assert out_avals_raised == exp_out_avals, f"expected: {exp_out_avals}, got: {out_avals_raised}"
+
     self.jaxpr = jaxpr
     self.literals = list(literals)
     self.in_avals = list(in_avals)
@@ -108,9 +120,10 @@ class Var(object):
   # TODO(frostig,mattjj): We don't override __eq__ or __hash__, so comparison is
   # by object id, but pretty printing might collide.
 
-  def __init__(self, count, suffix):
+  def __init__(self, count, suffix, aval):
     self.count = count
     self.suffix = suffix
+    self.aval = raise_to_shaped(aval)
 
   def __lt__(self, other):
     if not isinstance(other, Var):
@@ -130,7 +143,7 @@ class Var(object):
 
 def gensym(suffix):
   counter = it.count()
-  return lambda: Var(next(counter), suffix)
+  return lambda aval: Var(next(counter), suffix, aval)
 
 class Literal(object):
   __slots__ = ["val", "hash"]
@@ -145,6 +158,10 @@ class Literal(object):
           self.hash = hash((val.item(), val.dtype))
         except (TypeError, AttributeError):
           self.hash = None
+
+  @property
+  def aval(self):
+    return raise_to_shaped(get_aval(self.val))
 
   def __hash__(self):
     assert False
@@ -604,6 +621,8 @@ unit = Unit()
 literalable_types.add(Unit)
 
 class UnitVar(object):
+  @property
+  def aval(self): return abstract_unit
   def __repr__(self): return '*'
 unitvar = UnitVar()
 
@@ -612,6 +631,224 @@ pytype_aval_mappings[Unit] = lambda _: abstract_unit
 identity_p = Primitive('id')
 identity_p.def_impl(lambda x: x)
 identity_p.def_custom_bind(lambda x: x)
+
+def concretization_err_msg(fun, context=None):
+  fname = getattr(fun, "__name__", fun)
+  if context is None:
+    context = ("The function to be transformed can't be traced at the required level "
+               "of abstraction. If using `jit`, try using `static_argnums` or "
+               "applying `jit` to smaller subfunctions instead.")
+  msg = "Abstract value passed to `{}`, which requires a concrete value. {}"
+  return msg.format(fname, context)
+
+def concretization_function_error(fun, context=None):
+  def error(self, *args):
+    raise TypeError(concretization_err_msg(fun, context))
+  return error
+
+
+class UnshapedArray(AbstractValue):
+  __slots__ = ['dtype', 'weak_type']
+  array_abstraction_level = 2
+
+  def __init__(self, dtype, weak_type=False):
+    self.dtype = onp.dtype(dtypes.canonicalize_dtype(dtype))
+    self.weak_type = weak_type
+
+  def __eq__(self, other):
+    return (type(self) is type(other) and self.dtype == other.dtype and
+            self.weak_type == other.weak_type)
+
+  def __ne__(self, other):
+    return not self == other
+
+  def __hash__(self):
+    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
+    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
+    # the unique character code via hash(self.dtype.char)
+    return hash((self.dtype, self.weak_type))
+
+  def __repr__(self):
+    return '{}({}{})'.format(self.__class__.__name__, self.str_short(),
+                             ", weak_type=True" if self.weak_type else "")
+
+  _bool = _nonzero = concretization_function_error(bool)
+  _float   = concretization_function_error(
+      float, "Try using `value.astype(float)` instead.")
+  _int     = concretization_function_error(
+      int, "Try using `value.astype(int)` instead.")
+  _complex = concretization_function_error(
+      complex, "Try using `value.astype(complex)` instead.")
+  _hex     = concretization_function_error(hex)
+  _oct     = concretization_function_error(oct)
+
+  def at_least_vspace(self):
+    return self
+
+  def join(self, other):
+    if self.dtype == other.dtype:
+      if self.weak_type == other.weak_type:
+        return self
+      else:
+        return UnshapedArray(self.dtype, weak_type=False)
+    else:
+      raise TypeError(self, other)
+
+  def str_short(self):
+    return self.dtype.name
+
+  def strip_weak_type(self):
+    """Returns a copy of the aval with weak_type=False."""
+    return UnshapedArray(self.dtype) if self.weak_type else self
+
+class ShapedArray(UnshapedArray):
+  __slots__ = ['shape']
+  array_abstraction_level = 1
+
+  def __init__(self, shape, dtype, weak_type=False):
+    super(ShapedArray, self).__init__(dtype, weak_type=weak_type)
+    self.shape = canonicalize_shape(shape)
+
+  ndim = property(lambda self: len(self.shape))
+  size = property(lambda self: prod(self.shape))
+
+  def __eq__(self, other):
+    return (type(self) is type(other)
+            and self.dtype == other.dtype and self.shape == other.shape
+            and self.weak_type == other.weak_type)
+
+  def __hash__(self):
+    # can use hash(self.dtype) and rely on the fact that numpy reuses base dtype
+    # objects, e.g. `onp.zeros(3).dtype is onp.zeros(4).dtype`, or we can use
+    # the unique character code via hash(self.dtype.char)
+    return hash((self.shape, self.dtype, self.weak_type))
+
+  def at_least_vspace(self):
+    return self
+
+  def join(self, other):
+    if self.shape == other.shape and self.dtype == other.dtype:
+      if self.weak_type == other.weak_type:
+        return self
+      else:
+        return ShapedArray(self.shape, self.dtype, weak_type=False)
+    elif self.dtype == other.dtype:
+      return UnshapedArray(self.dtype)
+    else:
+      raise TypeError(self, other)
+
+  def str_short(self):
+    shapestr = ','.join(map(str, self.shape))
+    return '{}[{}]'.format(self.dtype.name, shapestr)
+
+  def __len__(self):
+    try:
+      return self.shape[0]
+    except IndexError:
+      raise TypeError("len() of unsized object")  # same as numpy error
+
+  def _len(self, ignored_tracer):
+    return len(self)
+
+  def strip_weak_type(self):
+    return ShapedArray(self.shape, self.dtype) if self.weak_type else self
+
+
+def _forward_to_value(self, fun, ignored_tracer, *args):
+  return fun(self.val, *args)
+
+class ConcreteArray(ShapedArray):
+  __slots__ = ['val']
+  array_abstraction_level = 0
+
+  def __init__(self, val, weak_type=False):
+    super(ConcreteArray, self).__init__(onp.shape(val), onp.result_type(val),
+                                        weak_type=weak_type)
+    # Note: canonicalized self.dtype doesn't necessarily match self.val
+    self.val = val
+    assert self.dtype != onp.dtype('O')
+
+  def __eq__(self, other):
+    return (type(self) is type(other) and self.dtype == other.dtype
+            and self.shape == other.shape and self.weak_type == other.weak_type
+            and onp.all(self.val == other.val))
+
+  def __hash__(self):
+    return id(self.val)
+
+  def at_least_vspace(self):
+    return ShapedArray(self.shape, self.dtype, weak_type=self.weak_type)
+
+  def join(self, other):
+    if self == other:
+      return self
+    elif self.shape == other.shape and self.dtype == other.dtype:
+      return ShapedArray(self.shape, self.dtype,
+                         weak_type=self.weak_type and other.weak_type)
+    elif self.dtype == other.dtype:
+      return UnshapedArray(self.dtype,
+                           weak_type=self.weak_type and other.weak_type)
+    else:
+      raise TypeError(self, other)
+
+  def str_short(self):
+    return str(self.val)
+
+  def strip_weak_type(self):
+    return ConcreteArray(self.val) if self.weak_type else self
+
+  _bool = _nonzero = partialmethod(_forward_to_value, bool)
+  _float   = partialmethod(_forward_to_value, float)
+  _int     = partialmethod(_forward_to_value, int)
+  _complex = partialmethod(_forward_to_value, complex)
+  _hex     = partialmethod(_forward_to_value, hex)
+  _oct     = partialmethod(_forward_to_value, oct)
+
+
+class AbstractToken(AbstractValue): pass
+
+abstract_token = AbstractToken()
+
+
+def raise_to_shaped(aval, weak_type=False):
+  if isinstance(aval, ShapedArray):
+    return ShapedArray(aval.shape, aval.dtype, weak_type=weak_type)
+  elif aval is abstract_unit:
+    return abstract_unit
+  elif aval is abstract_token:
+    return abstract_token
+  else:
+    raise TypeError(type(aval))
+
+# Registry for valid dimension types. This is used by masking.Poly.
+_DIMENSION_TYPES = {int}
+
+def _canonicalize_dimension(dim):
+  if type(dim) in _DIMENSION_TYPES:
+    return dim
+  else:
+    return operator.index(dim)
+
+def canonicalize_shape(shape):
+  """Canonicalizes and checks for errors in a user-provided shape value.
+
+  Args:
+    shape: a Python value that represents a shape.
+
+  Returns:
+    A tuple of integers.
+  """
+  try:
+    return tuple(map(_canonicalize_dimension, shape))
+  except TypeError:
+    pass
+  msg = ("Shapes must be 1D sequences of concrete values of integer type, "
+         "got {}.")
+  if any(isinstance(x, Tracer) and isinstance(get_aval(x), ShapedArray)
+         and not isinstance(get_aval(x), ConcreteArray) for x in shape):
+    msg += ("\nIf using `jit`, try using `static_argnums` or applying `jit` to "
+            "smaller subfunctions.")
+  raise TypeError(msg.format(shape))
 
 # ------------------- Call -------------------
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -423,20 +423,31 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
     `invars`.
   """
   newvar = core.gensym('')
-  t_to_var = defaultdict(newvar)
-  getvar = lambda t: t_to_var[id(t)]
+  t_to_var = {}
+  def getvar(t):
+    var = t_to_var.get(id(t))
+    if var is None:
+      var = newvar(partial_val_aval(*t.pval))
+      t_to_var[id(t)] = var
+    return var
   sorted_tracers = toposort(out_tracers)
   invars = map(getvar, in_tracers)
   eqns = []
   env = {}
   consts = {}
-  const_to_var = defaultdict(newvar)
+  const_to_var = {}
+  def getconstvar(c):
+    var = const_to_var.get(id(c))
+    if var is None:
+      var = newvar(get_aval(c))
+      const_to_var[id(c)] = var
+    return var
   processed_eqn_ids = set()
   for t in sorted_tracers:
     recipe = t.recipe
     if isinstance(recipe, JaxprEqnRecipe):
       if recipe.eqn_id not in processed_eqn_ids:
-        eqns.append(recipe_to_eqn(newvar, getvar, recipe))
+        eqns.append(recipe_to_eqn(lambda: newvar(core.abstract_unit), getvar, recipe))
         processed_eqn_ids.add(recipe.eqn_id)
     elif isinstance(recipe, LambdaBinding):
       if not any(t is in_tracer for in_tracer in in_tracers):
@@ -445,7 +456,7 @@ def tracers_to_jaxpr(in_tracers, out_tracers):
     elif isinstance(recipe, FreeVar):
       env[getvar(t)] = recipe.val
     elif isinstance(recipe, ConstVar):
-      v = t_to_var[id(t)] = const_to_var[id(recipe.val)]
+      v = t_to_var[id(t)] = getconstvar(recipe.val)
       consts[v] = recipe.val
     elif isinstance(recipe, Literal):
       t_to_var[id(t)] = recipe
@@ -495,6 +506,10 @@ def partial_eval_jaxpr(jaxpr, unknowns, instantiate):
   # jaxpr_2 :: [a2, res] -> b2
   jaxpr_2 = convert_constvars_jaxpr(jaxpr_2)
   jaxpr_2.invars = jaxpr_2.invars[num_res:] + jaxpr_2.invars[:num_res]
+  for var, unknown in zip(jaxpr_2.invars[:len(unknowns)], unknowns):
+    if not unknown:
+      var.aval = abstract_unit
+
   uk_out = [pv is not None for pv in out_pvs_2]
 
   in_avals_1, in_avals_2 = unzip2(map(_split_aval, unknowns, jaxpr.in_avals))

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -275,30 +275,32 @@ class CoreTest(jtu.JaxTestCase):
 
   def test_comparing_var(self):
     newsym = core.gensym('')
-    a = newsym()
-    b = newsym()
-    c = newsym()
+    a = newsym(core.abstract_unit)
+    b = newsym(core.abstract_unit)
+    c = newsym(core.abstract_unit)
     assert a < b < c
     assert c > b > a
     assert a != b and b != c and a != c
 
   def test_var_ordering(self):
     newsym = core.gensym('')
-    a = newsym()
-    b = newsym()
-    c = newsym()
+    a = newsym(core.abstract_unit)
+    b = newsym(core.abstract_unit)
+    c = newsym(core.abstract_unit)
     for ordering in it.permutations([a, b, c]):
       assert sorted(list(ordering)) == [a, b, c]
 
   def test_var_compared_by_identity(self):
-    a1 = core.gensym('')()
-    a2 = core.gensym('')()
+    a1 = core.gensym('')(core.abstract_unit)
+    a2 = core.gensym('')(core.abstract_unit)
     assert str(a1) == str(a2)
     assert a1 != a2
 
   def test_var_tree_flatten(self):
     newsym = core.gensym('')
-    a, b, c, d = newsym(), newsym(), newsym(), newsym()
+    a, b, c, d = (
+        newsym(core.abstract_unit), newsym(core.abstract_unit),
+        newsym(core.abstract_unit), newsym(core.abstract_unit))
     syms = {c: d, a: b}
     assert 'bd' == ''.join(map(str, tree_leaves(syms)))
 


### PR DESCRIPTION
For now, `TypedJaxpr` checks that the avals match the expected. I will remove the avals from `TypedJaxpr` in a follow-up (or possibly remove the class entirely, if literals are no longer needed).

It was necessary to move most of `abstract_arrays` into `core` to avoid circular dependency. I will remove `abstract_arrays` entirely in a follow-up.