### PR TITLE
Fix baby jax example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ from jax import grad, jit, vmap
 def predict(params, inputs):
   for W, b in params:
     outputs = np.dot(inputs, W) + b
-    inputs = np.tanh(outputs)
+    outputs = np.tanh(outputs)
   return outputs
 
 def logprob_fun(params, inputs, targets):


### PR DESCRIPTION
The `predict` function from the README's code example shadows the `inputs` variable with the output of `np.tanh`. The function is meant to give a simple example of a neural network's forward pass, in which case `outputs` should be shadowed instead.