### PR TITLE
Add ValueError to jax.numpy.squeeze function.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -975,14 +975,9 @@ def squeeze(a, axis=None):
   if axis is None:
     newshape = [d for d in shape(a) if d != 1]
   else:
-    if isinstance(axis, int):
-      if shape(a)[axis] != 1:
-        raise ValueError(msg)
-      axis = (axis,)
-    elif isinstance(axis, tuple):
-      for x in axis:
-        if shape(a)[x] != 1:
-          raise ValueError(msg)
+    axis = (axis,) if isinstance(axis, int) else axis
+    if any(shape(a)[x] != 1 for x in axis):
+      raise ValueError(msg)
     axis = frozenset(_canonicalize_axis(i, ndim(a)) for i in axis)
     newshape = [d for i, d in enumerate(shape(a))
                 if d != 1 or i not in axis]

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -968,13 +968,21 @@ def ravel(a, order="C"):
 
 @_wraps(onp.squeeze)
 def squeeze(a, axis=None):
+  msg = "cannot select an axis to squeeze out " \
+            "which has size not equal to one"
   if 1 not in shape(a):
     return a
   if axis is None:
     newshape = [d for d in shape(a) if d != 1]
   else:
     if isinstance(axis, int):
+      if shape(a)[axis] != 1:
+        raise ValueError(msg)
       axis = (axis,)
+    elif isinstance(axis, tuple):
+      for x in axis:
+        if shape(a)[x] != 1:
+          raise ValueError(msg)
     axis = frozenset(_canonicalize_axis(i, ndim(a)) for i in axis)
     newshape = [d for i, d in enumerate(shape(a))
                 if d != 1 or i not in axis]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1448,6 +1448,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, lnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(lnp_fun, args_maker, check_dtypes=True)
 
+  def testAxisSizeNotOneError(self):
+    x = onp.array([[[0], [1], [2]]])
+    axis = 1 # axis 1 shape is 3
+    t_axis = (0,1)
+    self.assertRaises(ValueError, lambda: lnp.squeeze(x, axis=axis))
+    self.assertRaises(ValueError, lambda: api.jit(lnp.squeeze(x, axis=axis)))
+    self.assertRaises(ValueError, lambda: lnp.squeeze(x, axis=t_axis))
+    self.assertRaises(ValueError, lambda: api.jit(lnp.squeeze(x, axis=t_axis)))
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}_weights={}_returned={}".format(
           jtu.format_shape_dtype_string(shape, dtype),


### PR DESCRIPTION
Like numpy.squeeze function, if the value given to the axis is not equal to 1, it raises a ValueError.
Related issue: #2284