### PR TITLE
Remove check comparing shift/axis and input dimensions in np.roll

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2678,8 +2678,6 @@ def roll(a, shift, axis=None):
   if len(b_shape) != 1:
     msg = "'shift' and 'axis' arguments to roll must be scalars or 1D arrays"
     raise ValueError(msg)
-  if b_shape[0] > a_ndim:
-    raise ValueError("More shifts/axes than dimensions of input to roll.")
 
   for x, i in zip(broadcast_to(shift, b_shape),
                   onp.broadcast_to(axis, b_shape)):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1802,7 +1802,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         (1, 1),
         ((3,), (0,)),
         ((-2,), (-2,)),
-        ((1, 2), (0, -1))
+        ((1, 2), (0, -1)),
+        ((4, 2, 5, 5, 2, 4), None),
+        (100, None),
       ]
       for rng_factory in [jtu.rand_default]))
   def testRoll(self, shape, dtype, shifts, axis, rng_factory):


### PR DESCRIPTION
Previously, `jax.numpy` checked that the number of shifts and/or axes was fewer than the number of dimensions of input. However, `numpy` doesn't make this check.

As a simple example, the following call will trigger a `ValueError`:
```python
import jax.numpy as np
np.roll([2, 3, 4, 5], (1, 0, 1))
```

However, `numpy` will treat a `shift` of `(1, 0, 1)` as though it were `np.sum(1, 0, 1)`.

We make the following changes:
1. Remove the dimensional check
2. Add two tests:
    a. Check when shift has high dimensionality
    b. Check that shift "overflow" works correctly (not really related to the issue at hand, but in the name of coverage)