### PR TITLE
Address Issue 2330

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1721,10 +1721,13 @@ def concatenate(arrays, axis=0):
   # tree of concatenations as a workaround especially for op-by-op mode.
   # (https://github.com/google/jax/issues/653).
   k = 16
-  while len(arrays) > 1:
-    arrays = [lax.concatenate(arrays[i:i+k], axis)
-              for i in range(0, len(arrays), k)]
-  return arrays[0]
+  if len(arrays) == 1:
+    return array(arrays[0])
+  else:
+    while len(arrays) > 1:
+      arrays = [lax.concatenate(arrays[i:i+k], axis)
+                for i in range(0, len(arrays), k)]
+    return arrays[0]
 
 
 @_wraps(onp.vstack)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1080,7 +1080,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       x = [x]
       x = jnp.concatenate(x)
       x -= 1.
-    return x
+      return x
 
     np_input = np.ones((1))
     jnp_input = jnp.ones((1))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1078,22 +1078,22 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     '''
     def attempt_sideeffect(x):
       x = [x]
-      x = jnp.concatenate(x)
+      x = lnp.concatenate(x)
       x -= 1.
       return x
 
-    np_input = np.ones((1))
-    jnp_input = jnp.ones((1))
-    expected_np_input_after_call = np.ones((1))
-    expected_jnp_input_after_call = jnp.ones((1))
+    onp_input = onp.ones((1))
+    lnp_input = lnp.ones((1))
+    expected_onp_input_after_call = onp.ones((1))
+    expected_lnp_input_after_call = lnp.ones((1))
     
-    self.assertTrue(type(jnp.concatenate([np_input])) is jnp.DeviceArray)
+    self.assertTrue(type(lnp.concatenate([onp_input])) is lnp.DeviceArray)
     
-    attempt_sideeffect(np_input)
-    attempt_sideeffect(jnp_input)
+    attempt_sideeffect(onp_input)
+    attempt_sideeffect(lnp_input)
 
-    self.assertAllClose(np_input, expected_np_input_after_call, check_dtypes=True)
-    self.assertAllClose(jnp_input, expected_jnp_input_after_call, check_dtypes=True)
+    self.assertAllClose(onp_input, expected_onp_input_after_call, check_dtypes=True)
+    self.assertAllClose(lnp_input, expected_lnp_input_after_call, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1084,10 +1084,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     np_input = np.ones((1))
     jnp_input = jnp.ones((1))
+    expected_np_input_after_call = np.ones((1))
+    expected_jnp_input_after_call = jnp.ones((1))
+    
+    self.assertTrue(type(jnp.concatenate([np_input])) is jnp.DeviceArray)
+    
     attempt_sideeffect(np_input)
     attempt_sideeffect(jnp_input)
 
-    self.assertAllClose(np_input, jnp_input, check_dtypes=False)
+    self.assertAllClose(np_input, expected_np_input_after_call, check_dtypes=True)
+    self.assertAllClose(jnp_input, expected_jnp_input_after_call, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1072,6 +1072,23 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for repeats in [2, [1,3,2], [2], lnp.array([1,3,2]), lnp.array([2])]:
       test_single(m_rect, args_maker, repeats, axis=1)
 
+  def testIssue2330(self):
+    '''
+    Make sure return value of jnp.concatenate is a jax.ndarray and is side-effect save
+    '''
+    def attempt_sideeffect(x):
+      x = [x]
+      x = jnp.concatenate(x)
+      x -= 1.
+    return x
+
+    np_input = np.ones((1))
+    jnp_input = jnp.ones((1))
+    attempt_sideeffect(np_input)
+    attempt_sideeffect(jnp_input)
+
+    self.assertAllClose(np_input, jnp_input, check_dtypes=False)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), axis, out_dtype),


### PR DESCRIPTION
This PR addresses #2330 
When a list of length 1 is concatenated, it is wrapped into an `array` to ensure that there can be no side-effects on it