### PR TITLE
improve jax.nn.relu differentiation

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -18,14 +18,15 @@
 import numpy as onp
 
 from jax import dtypes
+from jax import custom_transforms, defjvp
 from jax import lax
 from jax import random
 from jax.scipy.special import expit
 import jax.numpy as np
-from jax import jarrett
 
 # activations
 
+@custom_transforms
 def relu(x):
   r"""Rectified linear unit activation function.
 
@@ -35,6 +36,7 @@ def relu(x):
     \mathrm{relu}(x) = \max(x, 0)
   """
   return np.maximum(x, 0)
+defjvp(relu, lambda g, ans, x: lax.select(x > 0, g, lax.full_like(g, 0)))
 
 def softplus(x):
   r"""Softplus activation function.

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -36,8 +36,15 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSoftplusGrad(self):
-    check_grads(nn.softplus, (1e-8,), 4,
+    check_grads(nn.softplus, (1e-8,), order=4,
                 rtol=1e-2 if jtu.device_under_test() == "tpu" else None)
+
+  def testReluGrad(self):
+    rtol = 1e-2 if jtu.device_under_test() == "tpu" else None
+    check_grads(nn.relu, (1.,), order=3, rtol=rtol)
+    check_grads(nn.relu, (-1.,), order=3, rtol=rtol)
+    jaxpr = jax.make_jaxpr(jax.grad(nn.relu))(0.)
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 2)
 
   def testSoftplusValue(self):
     val = nn.softplus(89.)
@@ -45,7 +52,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testEluGrad(self):
-    check_grads(nn.elu, (1e4,), 4, eps=1.)
+    check_grads(nn.elu, (1e4,), order=4, eps=1.)
 
   def testEluValue(self):
     val = nn.elu(1e4)


### PR DESCRIPTION
Before:

```python
In [1]: from jax import make_jaxpr, grad

In [2]: from jax.nn import relu

In [3]: make_jaxpr(grad(relu))(0.)
Out[3]:
{ lambda  ; a.
  let b = max a 0.0
      c = eq a b
      d = tie_in b 1
      e = convert_element_type[ new_dtype=float32
                                old_dtype=int32 ] d
      f = tie_in b 0
      g = convert_element_type[ new_dtype=float32
                                old_dtype=int32 ] f
      h = select c e g
      i = eq 0.0 b
      j = tie_in b 2
      k = convert_element_type[ new_dtype=float32
                                old_dtype=int32 ] j
      l = tie_in b 1
      m = convert_element_type[ new_dtype=float32
                                old_dtype=int32 ] l
      n = select i k m
      o = div h n
      p = mul 1.0 o
  in p }
```

After:

```python
In [1]: from jax.nn import relu

In [2]: from jax import make_jaxpr, grad

In [3]: make_jaxpr(grad(relu))(0.)
Out[3]:
{ lambda  ; a.
  let b = gt a 0.0
      c = select b 1.0 0.0
  in c }
```

We define `grad(np.maximum, (0, 1))(3.14, 3.14) == (0.5, 0.5)` because of [an old Autograd convention](https://github.com/HIPS/autograd/pull/141) that seems reasonable due to symmetry. But even though `relu = lambda x: np.maximum(x, 0)`, we can define a cleaner derivative for it.

This PR intentionally changes the value of `grad(relu)(0.)`!

Before:

```python
In [1]: from jax import grad

In [2]: from jax.nn import relu

In [3]: grad(relu)(0.)
Out[3]: DeviceArray(0.5, dtype=float32)
```

After:

```python
In [1]: from jax import grad

In [2]: from jax.nn import relu

In [3]: grad(relu)(0.)
Out[3]: DeviceArray(0., dtype=float32)
```

This new behavior is less surprising, and is consistent with TF and PyTorch. A user requested that we make this change so as to make some results reproducible against a TensorFlow codebase:

```python
In [1]: import tensorflow as tf

In [2]: x = tf.constant(0.0)

In [3]: with tf.GradientTape() as g:
   ...:     g.watch(x)
   ...:     y = tf.nn.relu(x)
   ...: print(g.gradient(y, x))
tf.Tensor(0.0, shape=(), dtype=float32)
```