### PR TITLE
Fix softplus grads at 0 v2

### DIFF
--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -46,7 +46,13 @@ def softplus(x):
   .. math::
     \mathrm{softplus}(x) = \log(1 + e^x)
   """
-  return np.logaddexp(x, 0)
+  # Get the smallest normal number.
+  # eps is too big and nextafter(0, 1) is denormal
+  dtype = np.result_type(x).type
+  if not issubclass(dtype, np.inexact):
+    dtype = np.float32
+  zero = np.finfo(dtype).tiny
+  return np.logaddexp(x, zero)
 
 def soft_sign(x):
   r"""Soft-sign activation function.

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -39,6 +39,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
     check_grads(nn.softplus, (1e-8,), order=4,
                 rtol=1e-2 if jtu.device_under_test() == "tpu" else None)
 
+  def testSoftplusGradZero(self):
+    check_grads(nn.softplus, (0.,), order=1,
+                rtol=1e-2 if jtu.device_under_test() == "tpu" else None)
+
   def testReluGrad(self):
     rtol = 1e-2 if jtu.device_under_test() == "tpu" else None
     check_grads(nn.relu, (1.,), order=3, rtol=rtol)


### PR DESCRIPTION
https://github.com/google/jax/issues/2107

I'm trying to see if XLA max implements:
- IEEE max: like fmax/fmaxf/fmaxl/std::fmax/std::fmaxf/std::fmaxl/np.maximum
- Python max: like std::max

Alternative implementation: https://github.com/google/jax/pull/2356