### PR TITLE
Rename "NeurIPS 2019 JAX demo" to "JAX demo", as it's been presented …

### DIFF
--- a/cloud_tpu_colabs/JAX_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_demo.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "NeurIPS 2019 JAX demo.ipynb",
+      "name": "JAX demo.ipynb",
       "provenance": [],
       "collapsed_sections": [
         "AvXl1WDPKjmV"

--- a/cloud_tpu_colabs/README.md
+++ b/cloud_tpu_colabs/README.md
@@ -24,8 +24,8 @@ Solve the wave equation with `pmap`, and make cool movies! The spatial domain is
 
 ![](https://raw.githubusercontent.com/google/jax/master/cloud_tpu_colabs/images/wave_movie.gif)
 
-### [JAX Demo](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/NeurIPS_2019_JAX_demo.ipynb)
-An overview of JAX presented at the [Program Transformations for ML workshop at NeurIPS 2019](https://program-transformations.github.io/). Covers basic numpy usage, `grad`, `jit`, `vmap`, and `pmap`.
+### [JAX Demo](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/JAX_demo.ipynb)
+An overview of JAX presented at the [Program Transformations for ML workshop at NeurIPS 2019](https://program-transformations.github.io/) and the [Compilers for ML workshop at CGO 2020](https://www.c4ml.org/). Covers basic numpy usage, `grad`, `jit`, `vmap`, and `pmap`.
 
 ## Performance notes
 


### PR DESCRIPTION
…elsewhere.