### PR TITLE
Add jnp vs np out of bounds indexing to Sharp Bits nb

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 0,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -133,7 +133,7 @@
     "id": "2AxeCufq4wAp",
     "outputId": "7013374b-041f-4270-db19-cfb4ab992f52",
     "tags": [
-     "raises-exception"
+       "raises-exception"
     ]
    },
    "outputs": [
@@ -317,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 🔪 Out of Bounds Indexing"
+    "## 🔪 Out-of-Bounds Indexing"
    ]
   },
   {
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -357,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -366,7 +366,7 @@
        "DeviceArray(9, dtype=int32)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 0,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2383,7 +2383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -133,7 +133,7 @@
     "id": "2AxeCufq4wAp",
     "outputId": "7013374b-041f-4270-db19-cfb4ab992f52",
     "tags": [
-        "raises-exception"
+     "raises-exception"
     ]
    },
    "outputs": [
@@ -311,6 +311,68 @@
     "new_jax_array = index_add(jax_array, index[::2, 3:], 7.)\n",
     "print(\"new array post-addition:\")\n",
     "print(new_jax_array)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 🔪 Out of Bounds Indexing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In Numpy, you are used to errors being thrown when you index an array outside of its bounds, like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IndexError",
+     "evalue": "index 11 is out of bounds for axis 0 with size 10",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-eac95ae2edf8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0monp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m11\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m: index 11 is out of bounds for axis 0 with size 10"
+     ]
+    }
+   ],
+   "source": [
+    "onp.arange(10)[11]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, raising an error on other accelerators can be more difficult. Therefore, JAX does not raise an error and instead returns the last value in the array. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray(9, dtype=int32)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.arange(10)[11]"
    ]
   },
   {
@@ -2321,7 +2383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added a section on the differences in out of bounds indexing to the 🔪 Sharp Bits notebook. 