### PR TITLE
Wrap pad_widths in a tuple to avoid cache misses

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1681,7 +1681,9 @@ def _pad(array, pad_width, mode, constant_values):
 
 @_wraps(onp.pad)
 def pad(array, pad_width, mode='constant', constant_values=0):
-  return _pad(array, tuple(pad_width), mode, constant_values)
+  if isinstance(pad_width, list):
+    pad_width = tuple(pad_width)
+  return _pad(array, pad_width, mode, constant_values)
 
 
 @_wraps(onp.stack)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1681,7 +1681,7 @@ def _pad(array, pad_width, mode, constant_values):
 
 @_wraps(onp.pad)
 def pad(array, pad_width, mode='constant', constant_values=0):
-  return _pad(array, pad_width, mode, constant_values)
+  return _pad(array, tuple(pad_width), mode, constant_values)
 
 
 @_wraps(onp.stack)


### PR DESCRIPTION
Previously `jnp.pad(x, pad_widths, ...)` recompiled every time if `pad_widths` was a list whose object id wasn't constant. Wrap it in a tuple so that the jit cache on `_pad` can correctly hash it by value.