### PR TITLE
Minor fix to docs which mentions IOHW where it should be OIHW

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -1440,7 +1440,7 @@
    "source": [
     "These are the simple convenience functions for convolutions\n",
     "\n",
-    "️⚠️ The convenience `lax.conv`, `lax.conv_with_general_padding` helper function assume __NCHW__ images and __IOHW__ kernels."
+    "️⚠️ The convenience `lax.conv`, `lax.conv_with_general_padding` helper function assume __NCHW__ images and __OIHW__ kernels."
    ]
   },
   {
@@ -1479,7 +1479,7 @@
    ],
    "source": [
     "out = lax.conv(np.transpose(img,[0,3,1,2]),    # lhs = NCHW image tensor\n",
-    "               np.transpose(kernel,[2,3,0,1]), # rhs = IOHW conv kernel tensor\n",
+    "               np.transpose(kernel,[3,2,0,1]), # rhs = OIHW conv kernel tensor\n",
     "               (1, 1),  # window strides\n",
     "               'SAME') # padding mode\n",
     "print(\"out shape: \", out.shape)\n",


### PR DESCRIPTION
It appears the default kernel order is OIHW but this page in the docs claims it's IOHW.