### PR TITLE
Support axis_index_groups in allreduce collectives

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,11 @@ jax 0.1.67 (unreleased)
 
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.1.66...master>`_.
 
+* New features:
+
+  * Support for reduction over subsets of a pmapped axis using ``axis_index_groups``
+    `#2382 <https://github.com/google/jax/pull/2382>`_.
+
 * Notable changes:
 
   * The visibility of names exported from :py:module:`jax.numpy` has been
@@ -25,11 +30,15 @@ jaxlib 0.1.47 (May 8, 2020)
 
 * Fixes crash for outfeed.
 
-
 jax 0.1.66 (May 5, 2020)
 ---------------------------
 
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.1.65...jax-v0.1.66>`_.
+
+* New features:
+
+  * Support for ``in_axes=None`` on :func:`pmap`
+    `#2896 <https://github.com/google/jax/pull/2896>`_.
 
 jaxlib 0.1.46 (May 5, 2020)
 ------------------------------

--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -472,7 +472,7 @@ example
                                  let c = add a b
                                      e = add c d
                                      f = psum[ axis_name=rows 
-                                               replica_groups=None ] a
+                                               axis_index_groups=None ] a
                                      g = div e f
                                  in (g,) }
                     devices=None

--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -471,7 +471,8 @@ example
                     call_jaxpr={ lambda  ; d b a.
                                  let c = add a b
                                      e = add c d
-                                     f = psum[ axis_name=rows ] a
+                                     f = psum[ axis_name=rows 
+                                               replica_groups=None ] a
                                      g = div e f
                                  in (g,) }
                     devices=None

--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -471,8 +471,8 @@ example
                     call_jaxpr={ lambda  ; d b a.
                                  let c = add a b
                                      e = add c d
-                                     f = psum[ axis_name=rows 
-                                               axis_index_groups=None ] a
+                                     f = psum[ axis_index_groups=None
+                                               axis_name=rows ] a
                                      g = div e f
                                  in (g,) }
                     devices=None

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -375,9 +375,9 @@ def apply_parallel_primitive(prim, *args, **params):
   # look up information in the dynamic axis env.
   dynamic_axis_env = _thread_local_state.dynamic_axis_env
   axis_name = params.pop('axis_name')
-  replica_groups = params.pop('replica_groups')
-  if replica_groups is not None:
-    shape = (len(replica_groups[0]),)
+  axis_index_groups = params.pop('axis_index_groups')
+  if axis_index_groups is not None:
+    shape = (len(axis_index_groups[0]),)
   else:
     logical_size = lambda frame: frame.hard_size * (frame.soft_size or 1)
     if isinstance(axis_name, (list, tuple)):

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -393,8 +393,11 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
       ans = rule(c, axis_env, extend_name_stack(name_stack, eqn.primitive.name),
                  map(aval, eqn.invars), backend, *in_nodes, **new_params)
     elif eqn.primitive in parallel_translations:
-      replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
-      new_params = {k: v for k, v in eqn.params.items() if k != 'axis_name'}
+      replica_groups = eqn.params.get('replica_groups', None)
+      if replica_groups is None:
+        replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
+      new_params = {k: v for k, v in eqn.params.items()
+                    if k not in ('axis_name', 'replica_groups')}
       rule = parallel_translations[eqn.primitive]
       ans = rule(c, *in_nodes, replica_groups=replica_groups, platform=platform,
                  **new_params)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -393,11 +393,14 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
       ans = rule(c, axis_env, extend_name_stack(name_stack, eqn.primitive.name),
                  map(aval, eqn.invars), backend, *in_nodes, **new_params)
     elif eqn.primitive in parallel_translations:
-      replica_groups = eqn.params.get('replica_groups', None)
-      if replica_groups is None:
-        replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
+      replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
+      axis_index_groups = eqn.params.get('axis_index_groups', None)
+      if axis_index_groups is not None:
+        replica_groups = [[axis_group[i] for i in axis_index_group]
+                          for axis_group in replica_groups
+                          for axis_index_group in axis_index_groups]
       new_params = {k: v for k, v in eqn.params.items()
-                    if k not in ('axis_name', 'replica_groups')}
+                    if k not in ('axis_name', 'axis_index_groups')}
       rule = parallel_translations[eqn.primitive]
       ans = rule(c, *in_nodes, replica_groups=replica_groups, platform=platform,
                  **new_params)

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -343,7 +343,7 @@ pxla.split_axis_rules[psum_p] = \
     partial(_allreduce_split_axis_rule, psum_p, lax._reduce_sum)
 xla.parallel_translations[psum_p] = _psum_translation_rule
 pxla.parallel_pure_rules[psum_p] = lambda *args, shape: (x * prod(shape) for x in args)
-ad.deflinear(psum_p, lambda *ts, axis_name, axis_index_groups: psum(
+ad.deflinear(psum_p, lambda ts, axis_name, axis_index_groups: psum_p.bind(
     *ts, axis_name=axis_name, axis_index_groups=axis_index_groups))
 pxla.multi_host_supported_collectives.add(psum_p)
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -147,6 +147,8 @@ def pmin(x, axis_name, *, axis_index_groups=None):
       pmin_p.bind, axis_name=axis_name, axis_index_groups=axis_index_groups), x)
 
 def _validate_axis_index_groups(axis_index_groups):
+  if axis_index_groups is None:
+    return
   len_0 = len(axis_index_groups[0])
   if any(len(g) != len_0 for g in axis_index_groups):
     raise ValueError("axis_index_groups must all be the same size")

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -50,7 +50,9 @@ def psum(x, axis_name, *, axis_index_groups=None):
       ``pmap`` docstring for more details).
     axis_index_groups: optional list of lists containing axis indices (e.g. for
       an axis of size 4, [[0, 1], [2, 3]] would perform psums over the first
-      two and last two replicas). All groups must be the same size.
+      two and last two replicas). Groups must cover all axis indices exactly
+      once, and all groups must be the same size.
+
 
   Returns:
     Array(s) with the same shape as ``x`` representing the result of an
@@ -83,7 +85,8 @@ def pmean(x, axis_name, *, axis_index_groups=None):
       ``pmap`` docstring for more details).
     axis_index_groups: optional list of lists containing axis indices (e.g. for
       an axis of size 4, [[0, 1], [2, 3]] would perform pmeans over the first
-      two and last two replicas). All groups must be the same size.
+      two and last two replicas). Groups must cover all axis indices exactly
+      once, and all groups must be the same size.
 
   Returns:
     Array(s) with the same shape as ``x`` representing the result of an
@@ -114,7 +117,8 @@ def pmax(x, axis_name, *, axis_index_groups=None):
       ``pmap`` docstring for more details).
     axis_index_groups: optional list of lists containing axis indices (e.g. for
       an axis of size 4, [[0, 1], [2, 3]] would perform pmaxes over the first
-      two and last two replicas). All groups must be the same size.
+      two and last two replicas). Groups must cover all axis indices exactly
+      once, and all groups must be the same size.
 
   Returns:
     Array(s) with the same shape as ``x`` representing the result of an
@@ -136,7 +140,8 @@ def pmin(x, axis_name, *, axis_index_groups=None):
       ``pmap`` docstring for more details).
     axis_index_groups: optional list of lists containing axis indices (e.g. for
       an axis of size 4, [[0, 1], [2, 3]] would perform pmins over the first
-      two and last two replicas). All groups must be the same size.
+      two and last two replicas). Groups must cover all axis indices exactly
+      once, and all groups must be the same size.
 
   Returns:
     Array(s) with the same shape as ``x`` representing the result of an
@@ -152,6 +157,9 @@ def _validate_axis_index_groups(axis_index_groups):
   len_0 = len(axis_index_groups[0])
   if any(len(g) != len_0 for g in axis_index_groups):
     raise ValueError("axis_index_groups must all be the same size")
+  axis_space = range(len_0 * len(axis_index_groups))
+  if set(i for g in axis_index_groups for i in g) != set(axis_space):
+    raise ValueError("axis_index_groups must cover all indices exactly once")
 
 def ppermute(x, axis_name, perm):
   """Perform a collective permutation according to the permutation ``perm``.

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -293,7 +293,8 @@ def standard_pmap_primitive(name, multiple_results=False):
 def _allreduce_split_axis_rule(prim, reducer, vals, which_mapped, axis_name,
                                axis_index_groups):
   assert tuple(which_mapped) == (True,)
-  assert axis_index_groups is None
+  if axis_index_groups is not None:
+    raise NotImplementedError("soft_pmap does not yet support axis_index_groups")
   vals = (reducer(x, [0]) for x in vals)
   return prim.bind(*vals, axis_name=axis_name), False
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -807,9 +807,9 @@ class APITest(jtu.JaxTestCase):
   def test_xla_computation(self):
     # these tests basically check the examples in the xla_computation docstring
 
-    def h(x):
+    def e(x):
       return jnp.sin(jnp.cos(x))
-    c = api.xla_computation(h)(2.)
+    c = api.xla_computation(e)(2.)
     self.assertIn('cosine', c.GetHloText())
     self.assertIn('sine', c.GetHloText())
 
@@ -831,6 +831,16 @@ class APITest(jtu.JaxTestCase):
     self.assertIn('replica_groups={{0,2,4,6},{1,3,5,7}}', c.GetHloText())
     self.assertIn('replica_groups={{0,1},{2,3},{4,5},{6,7}}', c.GetHloText())
     self.assertIn('replica_groups={{0,1,2,3,4,5,6,7}}', c.GetHloText())
+
+    def h(x):
+      rowsum = lax.psum(x, 'i', axis_index_groups=[[0, 1], [2, 3]])
+      colsum = lax.psum(x, 'j')
+      return rowsum, colsum
+    axis_env = [('i', 4), ('j', 2)]
+    c = api.xla_computation(h, axis_env=axis_env)(5.)
+    self.assertIn('all-reduce', c.GetHloText())
+    self.assertIn('replica_groups={{0,2},{4,6},{1,3},{5,7}}', c.GetHloText())
+    self.assertIn('replica_groups={{0,1},{2,3},{4,5},{6,7}}', c.GetHloText())
 
   def test_xla_computation_args(self):
     def foo(x, y, z):
@@ -1848,8 +1858,8 @@ class JaxprTest(jtu.JaxTestCase):
                     call_jaxpr={ lambda  ; d b a.
                                  let c = add a b
                                      e = add c d
-                                     f = psum[ axis_name=rows
-                                               replica_groups=None ] a
+                                     f = psum[ axis_index_groups=None
+                                               axis_name=rows ] a
                                      g = div e f
                                  in (g,) }
                     devices=None

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1848,7 +1848,8 @@ class JaxprTest(jtu.JaxTestCase):
                     call_jaxpr={ lambda  ; d b a.
                                  let c = add a b
                                      e = add c d
-                                     f = psum[ axis_name=rows ] a
+                                     f = psum[ axis_name=rows
+                                               replica_groups=None ] a
                                      g = div e f
                                  in (g,) }
                     devices=None


### PR DESCRIPTION
This lets users write collective operations that reduce over groups of axis indices within a pmapped axis rather than over the entire axis.
Example:

```python
def sum_with_groups(x):
  return psum(x, axis_name="i", axis_index_groups=[[0, 1], [2, 3]])
x = jnp.array([1., 2., 3., 4.])
y = pmap(sum_with_groups, axis_name="i")(x)  # [3., 3., 7., 7.]
```

Original motivation:
Even in the most composable and multihost-friendly nested-pmap world that we can come up with, I think we'll still want to be able to express collectives that operate over subsets of the pmap axis. In particular I think it's more natural, for example, for only the batchnorm layer to have to care about its distributed group size (whether to reduce over individual devices, neighboring pairs of devices, whole hosts, etc.), and keep the main pmap over the whole device axis, than for the entire model/training loop to need to know that (and use a pair of pmaps with separate axes).

Edit: this now operates at the level of JAX axis indices, so it works correctly with nested pmaps (they lower to XLA replica groups together).

Edit again, quoting from https://github.com/google/jax/pull/2382#issuecomment-625909818:

> I think the stronger version is to point to things we can't express even with nested pmaps (without requiring a sequence of separate pmap calls and some transposition). For example, with this proposal in a single pmap one can write axis_index_groups=[[0, 2], [1, 3]] and in another operation write axis_index_groups=[[0, 1], [2, 3]], right?