### PR TITLE
Allow zero tolerance for jax.test_util.tolerance

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -116,7 +116,7 @@ def _assert_numpy_allclose(a, b, atol=None, rtol=None):
   onp.testing.assert_allclose(a, b, **kw)
 
 def tolerance(dtype, tol=None):
-  tol = tol or {}
+  tol = {} if tol is None else tol
   if not isinstance(tol, dict):
     return tol
   tol = {onp.dtype(key): value for key, value in tol.items()}

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -199,6 +199,9 @@ class LaxTest(jtu.JaxTestCase):
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
   def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):
+    if op_name == "nextafter" and dtype == onp.float64:
+      raise SkipTest("nextafter inconsistent for float64: "
+                     "https://github.com/google/jax/issues/2403")
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
     op = getattr(lax, op_name)


### PR DESCRIPTION
Currently, if a user passes any falsy value to jax.test_util.tolerance,
it is changed to the default value. This makes sense when the value
passed is None, but not when the value passed is 0 (which indicates
a desired tolerance of exactly 0).