### PR TITLE
Add pmap_benchmark.py

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,0 +1,109 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A simple Python microbenchmarking library."""
+
+from collections import OrderedDict
+from numbers import Number
+import os
+import time
+from typing import Any, Optional, Union, Callable, List, Dict
+
+import numpy as onp
+from tabulate import tabulate
+
+from jax.util import safe_zip
+
+
+def benchmark(f: Callable[[], Any], iters: Optional[int] = None,
+              warmup: Optional[int] = None, name: Optional[str] = None,
+              target_total_secs: Optional[Union[int, float]] = None):
+  """Benchmarks ``f``. Prints the results and returns the raw times.
+
+  Args:
+    f: The function to be benchmarked. Should take no arguments.
+    iters: The number of iterations to run for. If none, runs until
+      ``target_total_secs`` has elapsed.
+    warmup: The number of warmup (untimed) iterations to run for.
+    name: The name of the benchmark. Defaults to f.__name__.
+    target_total_secs: If ``iters`` isn't specified, the minimum number of
+      seconds to run for. Defaults to the env var TARGET_TOTAL_SECS or 10 if
+      not set.
+
+  Returns:
+    An ndarray containing the number of seconds each iteration ran for.
+  """
+  if target_total_secs is None:
+    target_total_secs = int(os.getenv("TARGET_TOTAL_SECS", "10"))
+
+  if warmup is None:
+    if iters is None:
+      warmup = 1
+    else:
+      warmup = onp.clip(1, iters // 10, 10)
+  for _ in range(warmup):
+    f()
+
+  times = []
+  count = 0
+  while (count < iters if iters is not None
+         else sum(times) < target_total_secs):
+    start = time.time()
+    f()
+    end = time.time()
+    times.append(end - start)
+    count += 1
+
+  times = onp.array(times)
+  print("---------Benchmark results for %s---------" % (name or f.__name__))
+  print("mean=%f std=%f %%std=%f total=%f" %
+        (times.mean(), times.std(), _pstd(times), times.sum()))
+  print("#iters=%d #warmup=%d" % (count, warmup))
+  print()
+  return times
+
+
+def benchmark_suite(prepare: Callable[..., Callable], params_list: List[Dict],
+                    name: str, target_total_secs: int = None):
+  """Benchmarks a function for several combinations of parameters.
+
+  Prints the summarized results in a table..
+
+  Args:
+    prepare: given kwargs returns a benchmark function specialized to the kwargs.
+    params_list: a list of kwargs on which to run the benchmark.
+    name: the name of this benchmark suite
+    target_total_secs: the ``target_total_secs`` to pass to ``benchmark``.
+ """
+  # Sort parameters alphabetically so benchmark results print consistently.
+  params_list = [OrderedDict(sorted(p.items())) for p in params_list]
+  assert all(p.keys() == params_list[0].keys() for p in params_list)
+
+  times = []
+  for params in params_list:
+    f = prepare(**params)
+    subname = name + "".join("_%s=%s" % (n, p) for n, p in params.items())
+    times.append(benchmark(f, name=subname,
+                           target_total_secs=target_total_secs))
+
+  print("---------Benchmark summary for %s---------" % name)
+  param_names = list(params_list[0].keys())
+  print(tabulate([tuple(params.values()) +
+                  (t.mean(), _pstd(t), t.mean() / times[0].mean())
+                  for params, t in safe_zip(params_list, times)],
+                 param_names + ["mean", "%std", "relative"]))
+  print()
+
+
+def _pstd(x):
+  return x.std() / x.mean() * 100

--- a/benchmarks/pmap_benchmark.py
+++ b/benchmarks/pmap_benchmark.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""To run on CPU with 500 CPU devices:
+
+CUDA_VISIBLE_DEVICES= XLA_FLAGS=--xla_force_host_platform_device_count=500 \
+python3 pmap_benchmark.py
+
+To make it run faster, set env var TARGET_TOTAL_SECS to a low number (e.g. 2).
+"""
+import numpy as onp
+
+from benchmark import benchmark_suite
+import jax
+import jax.numpy as np
+from jax import pmap
+
+
+def pmap_shard_args_benchmark():
+  """Pmap benchmark focusing on shard_args fast path.
+
+  This is intended to measure how long it takes to dispatch a correctly-sharded
+  ShardedDeviceArray to pmap.
+  """
+
+  def get_benchmark_fn(nargs, nshards):
+    pmap_fn = pmap(lambda *args: np.sum(args))
+    shape = (nshards, 4)
+    args = [onp.random.random(shape) for _ in range(nargs)]
+    sharded_args = pmap(lambda x: x)(args)
+    assert all(type(arg) == jax.pxla.ShardedDeviceArray for arg in sharded_args)
+    def benchmark_fn():
+      for _ in range(100):
+        pmap_fn(*sharded_args)
+    return benchmark_fn
+
+  params = []
+  for nargs in (10, 100, 101, 500):
+    nshards = min(4, jax.local_device_count())
+    params.append({"nargs": nargs, "nshards": nshards})
+  for nshards in (2, 4, 8, 100, 500):
+    if nshards > jax.local_device_count(): continue
+    params.append({"nargs": 10, "nshards": nshards})
+  benchmark_suite(get_benchmark_fn, params, "pmap_shard_args")
+
+
+def pmap_shard_outputs_benchmark():
+  """Pmap benchmark focusing on array_result_handler path.
+
+  This is intended to measure how long it takes to construct ShardedDeviceArrays
+  from pmap.
+  """
+  def get_benchmark_fn(nouts, nshards):
+    pmap_fn = pmap(lambda x: [x + i for i in range(nouts)])
+    shape = (nshards, 4)
+    arg = onp.random.random(shape)
+    def benchmark_fn():
+      for _ in range(100):
+        pmap_fn(arg)
+    return benchmark_fn
+
+  params = []
+  for nouts in (10, 100, 500):
+    nshards = min(4, jax.local_device_count())
+    params.append({"nouts": nouts, "nshards": nshards})
+  for nshards in (2, 4, 8, 100, 500):
+    if nshards > jax.local_device_count(): continue
+    params.append({"nouts": 10, "nshards": nshards})
+  benchmark_suite(get_benchmark_fn, params, "pmap_shard_outputs")
+
+
+def run_all_benchmarks():
+  pmap_shard_args_benchmark()
+  pmap_shard_outputs_benchmark()
+
+
+if __name__ == "__main__":
+  run_all_benchmarks()


### PR DESCRIPTION
Example output:

```
$ TARGET_TOTAL_SECS=2 CUDA_VISIBLE_DEVICES= XLA_FLAGS=--xla_force_host_platform_device_count=500 python3 benchmarks/pmap_benchmark.py
2020-03-12 15:46:35.903121: E external/org_tensorflow/tensorflow/stream_executor/cuda/cuda_driver.cc:313] failed call to cuInit: CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected
/usr/local/google/home/skyewm/jax/jax/lib/xla_bridge.py:122: UserWarning: No GPU/TPU found, falling back to CPU.
  warnings.warn('No GPU/TPU found, falling back to CPU.')
---------Benchmark results for pmap_shard_args_nargs=10_nshards=4---------
mean=0.034490 std=0.002890 %std=8.378140 total=2.000426
#iters=58 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=100_nshards=4---------
mean=0.091495 std=0.005935 %std=6.486871 total=2.012888
#iters=22 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=101_nshards=4---------
mean=0.113549 std=0.009080 %std=7.996712 total=2.043878
#iters=18 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=500_nshards=4---------
mean=0.356868 std=0.007960 %std=2.230518 total=2.141210
#iters=6 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=10_nshards=2---------
mean=0.022288 std=0.002946 %std=13.219607 total=2.005951
#iters=90 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=10_nshards=4---------
mean=0.035210 std=0.002024 %std=5.747389 total=2.006975
#iters=57 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=10_nshards=8---------
mean=0.048641 std=0.001578 %std=3.243398 total=2.042912
#iters=42 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=10_nshards=100---------
mean=0.257487 std=0.007190 %std=2.792452 total=2.059900
#iters=8 #warmup=1

---------Benchmark results for pmap_shard_args_nargs=10_nshards=500---------
mean=1.696294 std=0.005097 %std=0.300473 total=3.392588
#iters=2 #warmup=1

---------Benchmark summary for pmap_shard_args---------
  nargs    nshards       mean       %std    relative
-------  ---------  ---------  ---------  ----------
     10          4  0.0344901   8.37814     1
    100          4  0.0914949   6.48687     2.65279
    101          4  0.113549    7.99671     3.29221
    500          4  0.356868    2.23052    10.347
     10          2  0.0222883  13.2196      0.646224
     10          4  0.0352101   5.74739     1.02088
     10          8  0.0486408   3.2434      1.41028
     10        100  0.257487    2.79245     7.46555
     10        500  1.69629     0.300473   49.182

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=4---------
mean=0.061780 std=0.004737 %std=7.668032 total=2.038743
#iters=33 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=100_nshards=4---------
mean=0.123264 std=0.005980 %std=4.851385 total=2.095494
#iters=17 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=500_nshards=4---------
mean=0.471524 std=0.024051 %std=5.100792 total=2.357622
#iters=5 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=2---------
mean=0.041546 std=0.004446 %std=10.700256 total=2.035745
#iters=49 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=4---------
mean=0.063768 std=0.002756 %std=4.322039 total=2.040561
#iters=32 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=8---------
mean=0.087285 std=0.005343 %std=6.121320 total=2.007556
#iters=23 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=100---------
mean=0.623440 std=0.004038 %std=0.647725 total=2.493759
#iters=4 #warmup=1

---------Benchmark results for pmap_shard_outputs_nouts=10_nshards=500---------
mean=4.096676 std=0.000000 %std=0.000000 total=4.096676
#iters=1 #warmup=1

---------Benchmark summary for pmap_shard_outputs---------
  nouts    nshards       mean       %std    relative
-------  ---------  ---------  ---------  ----------
     10          4  0.0617801   7.66803     1
    100          4  0.123264    4.85139     1.99521
    500          4  0.471524    5.10079     7.6323
     10          2  0.0415458  10.7003      0.672479
     10          4  0.0637675   4.32204     1.03217
     10          8  0.087285    6.12132     1.41283
     10        100  0.62344     0.647725   10.0913
     10        500  4.09668     0          66.3106
```