### PR TITLE
Fix __repr__ for ShapeDtypeStruct

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -2019,7 +2019,7 @@ class ShapeDtypeStruct(object):
 
   def __repr__(self):
     return "{}(shape={}, dtype={})".format(
-        type(self).__name__, self.shape, self.dtype.dtype.name)
+        type(self).__name__, self.shape, onp.dtype(self.dtype).name)
 
   __str__ = __repr__
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -892,9 +892,12 @@ class APITest(jtu.JaxTestCase):
     g = api.grad(f)(pt)
     self.assertIsInstance(pt, ZeroPoint)
 
-  @parameterized.parameters(1, 2, 3)
-  def test_shape_dtype_struct(self, i):
-    s = api.ShapeDtypeStruct(shape=(i, 2, 3), dtype=np.float32)
+  @parameterized.parameters(
+      (i, dtype)
+      for i in (1, 2, 3)
+      for dtype in (np.float32, onp.float32, np.dtype("float32")))
+  def test_shape_dtype_struct(self, i, dtype):
+    s = api.ShapeDtypeStruct(shape=(i, 2, 3), dtype=dtype)
     self.assertEqual(s.shape, (i, 2, 3))
     self.assertEqual(s.dtype, np.float32)
     self.assertEqual(s.ndim, 3)


### PR DESCRIPTION
The `__repr__` function for ShapeDtypeStruct works when the dtype is an instance of `_ScalarMeta`. However, before this change it fails when the dtype is something else, in particular when it is a numpy scalar type (i.e. `onp.float32`) or a regular dtype (i.e. `np.dtype("float32")`). Practically, this means that `jax.eval_shape` sometimes produces ShapeDtypeStruct values that can't be printed.

This PR fixes the issue by first converting the dtype into a common form, then taking the name. This also adds a few more test cases to check the behavior with different dtypes.