### PR TITLE
change the XLA representation of JAX's unit

### DIFF
--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -29,7 +29,6 @@ add_jaxvals_p = Primitive('add_any')
 
 @add_jaxvals_p.def_impl
 def add_impl(xs, ys):
-  # assert type(xs) == type(ys), (xs, ys)
   return jaxval_adders[type(xs)](xs, ys)
 
 @add_jaxvals_p.def_abstract_eval

--- a/jax/api.py
+++ b/jax/api.py
@@ -1559,7 +1559,7 @@ def custom_transforms(fun):
   fun_p.def_abstract_eval(fun_abstract_eval)
 
   def fun_translation(c, *xla_args, **params):
-    return xla.lower_fun(fun_impl, True)(c, *xla_args, **params)
+    return xla.lower_fun(fun_impl)(c, *xla_args, **params)
   xla.translations[fun_p] = fun_translation
 
   return CustomTransformsFunction(fun, fun_p)

--- a/jax/dlpack.py
+++ b/jax/dlpack.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import core
 from . import lazy
 from .interpreters import xla
 from .lib import xla_client
@@ -44,5 +45,7 @@ def from_dlpack(dlpack, backend=None):
   # would be able to figure it out from the DLPack.
   backend = backend or xla_bridge.get_backend()
   buf = xla_client._xla.DLPackManagedTensorToBuffer(dlpack, backend.client)
-  aval = xla._aval_from_xla_shape(buf.shape())
+  xla_shape = buf.shape()
+  assert not xla_shape.is_tuple()
+  aval = core.ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
   return xla.DeviceArray(aval, buf.device(), lazy.array(aval.shape), buf)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -651,7 +651,13 @@ def add_jaxvals_translation_rule(c, x, y):
 translations[ad_util.add_jaxvals_p] = add_jaxvals_translation_rule
 
 def lower_fun(fun):
-  """Build a translation rule for a traceable function."""
+  # This function can only be used to lower functions that take JAX array types
+  # as arguments (and e.g. don't accept unit values), because it assumes it can
+  # map from XLA types to JAX types. In general that mapping is not possible (as
+  # the mapping from JAX types to XLA types is not invertible), but for now at
+  # least we assume that the mapping from JAX *array* types to XLA array types
+  # is invertible. This assumption is unchecked!
+  # TODO(mattjj): remove assumption can map XLA array types to JAX array types
   def f(c, *xla_args, **params):
     # TODO(mattjj): revise this 'calling convention'
     avals = [_array_aval_from_xla_shape(c.GetShape(x)) for x in xla_args]
@@ -664,6 +670,9 @@ def lower_fun(fun):
   return f
 
 def _array_aval_from_xla_shape(xla_shape):
+  # This function instantiates the assumption that we can map fro XLA array
+  # types to JAX array types.
+  # TODO(mattjj): remove assumption can map XLA array types to JAX array types
   assert not xla_shape.is_tuple()
   return ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -51,9 +51,17 @@ def _map(f, *xs): return tuple(map(f, *xs))
 def identity(x): return x
 
 
+# unit representation
+def _make_unit(c): return c.Constant(onp.zeros((), dtype=onp.dtype('bool')))
+def _make_abstract_unit(_): return xc.Shape.array_shape(onp.dtype('bool'), ())
+def _device_put_unit(_, device):
+  return xc.Buffer.from_pyval(onp.zeros((), dtype=onp.dtype('bool')),
+                              backend=xb.get_device_backend(device))
+
+
 ### handlers
 
-xb.register_constant_handler(core.Unit, lambda c, *_: c.Tuple())
+xb.register_constant_handler(core.Unit, lambda c, *_: _make_unit(c))
 
 def aval_to_xla_shape(aval):
   try:
@@ -62,7 +70,7 @@ def aval_to_xla_shape(aval):
     raise TypeError("No xla_shape_handler for type: {}".format(type(aval))
                     ) from err
 xla_shape_handlers = {}
-xla_shape_handlers[core.AbstractUnit] = lambda _: xc.Shape.tuple_shape(())
+xla_shape_handlers[core.AbstractUnit] = _make_abstract_unit
 xla_shape_handlers[ShapedArray] = lambda a: xc.Shape.array_shape(a.dtype, a.shape)
 xla_shape_handlers[ConcreteArray] = lambda a: xc.Shape.array_shape(a.dtype, a.shape)
 
@@ -88,9 +96,7 @@ def device_put(x, device=None):
                     ) from err
 
 device_put_handlers = {}
-device_put_handlers[core.Unit] = \
-    lambda _, device: xc.Buffer.make_tuple(
-        (), device, backend=xb.get_device_backend(device))
+device_put_handlers[core.Unit] = _device_put_unit
 def _device_put_array(x, device):
   return xc.Buffer.from_pyval(x, device, backend=xb.get_device_backend(device))
 for _t in array_types:
@@ -223,7 +229,8 @@ def primitive_computation(prim, axis_env, backend, tuple_args, *avals, **params)
     rule(c, *xla_args, **params)
   elif prim in initial_style_translations:
     rule = initial_style_translations[prim]
-    rule(c, axis_env, extend_name_stack(prim.name), *xla_args, backend=backend, **params)
+    rule(c, axis_env, extend_name_stack(prim.name), avals, backend,
+         *xla_args, **params)
   else:
     raise NotImplementedError("XLA translation rule for {} not found".format(prim))
   c.ClearOpMetadata()
@@ -268,13 +275,11 @@ def check_nans(prim, bufs):
     _check_nans(prim.name, bufs.shape(), bufs)
 
 def _check_nans(name, xla_shape, buf):
-  if xla_shape.is_tuple():
-    assert not xla_shape.tuple_shapes()
-  else:
-    if dtypes.issubdtype(xla_shape.element_type(), onp.floating):
-      if onp.any(onp.isnan(buf.to_py())):
-        msg = "invalid value (nan) encountered in {}"
-        raise FloatingPointError(msg.format(name))
+  assert not xla_shape.is_tuple()
+  if dtypes.issubdtype(xla_shape.element_type(), onp.floating):
+    if onp.any(onp.isnan(buf.to_py())):
+      msg = "invalid value (nan) encountered in {}"
+      raise FloatingPointError(msg.format(name))
 
 ### compiling jaxprs
 
@@ -302,12 +307,18 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
     else:
       return env[v]
 
+  def aval(v):
+    if type(v) is Literal:
+      return abstractify(v.val)
+    else:
+      return v.aval
+
   def write(v, node):
     assert node is not None
     env[v] = node
 
   env = {}
-  write(core.unitvar, c.Tuple())
+  write(core.unitvar, _make_unit(c))
   _map(write, jaxpr.constvars, consts)
   _map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
@@ -325,7 +336,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
       new_params = check_backend_params(eqn.params, backend)
       rule = initial_style_translations[eqn.primitive]
       ans = rule(c, axis_env, extend_name_stack(name_stack, eqn.primitive.name),
-                 *in_nodes, backend=backend, **new_params)
+                 map(aval, eqn.invars), backend, *in_nodes, **new_params)
     elif eqn.primitive in parallel_translations:
       replica_groups = axis_groups(axis_env, eqn.params['axis_name'])
       new_params = {k: v for k, v in eqn.params.items() if k != 'axis_name'}
@@ -586,7 +597,7 @@ def make_tuple(bufs, device, backend):
 def _get_device(device, backend):
   # TODO(mattjj): after jaxlib update, avoid compile here, just to get device
   c = xb.make_computation_builder("get_device")
-  built = c.Build(c.Tuple())
+  built = c.Build(_make_unit(c))
   options = xb.get_compile_options(
       num_replicas=1,
       num_partitions=1,
@@ -628,48 +639,44 @@ call_translations[xla_call_p] = _xla_call_translation_rule
 
 def zeros_like_translation_rule(c, x):
   shape = c.GetShape(x)
-  if shape.is_tuple():
-    assert not shape.tuple_shapes()
-    return c.Tuple()
-  else:
-    zero = c.Constant(onp.array(0, shape.element_type()))
-    return c.Broadcast(zero, shape.dimensions())
+  assert not shape.is_tuple()
+  zero = c.Constant(onp.array(0, shape.element_type()))
+  return c.Broadcast(zero, shape.dimensions())
 translations[ad_util.zeros_like_p] = zeros_like_translation_rule
 
 def add_jaxvals_translation_rule(c, x, y):
   shape = c.GetShape(x)
-  if shape.is_tuple():
-    assert not shape.tuple_shapes()
-    return x
-  else:
-    return c.Add(x, y)
+  assert not shape.is_tuple()
+  return c.Add(x, y)
 translations[ad_util.add_jaxvals_p] = add_jaxvals_translation_rule
 
-def lower_fun(fun, instantiate=False, initial_style=False):
+def lower_fun(fun):
   """Build a translation rule for a traceable function."""
-  def f(c, *args, **params):
-    backend = params.pop('backend', None)
+  def f(c, *xla_args, **params):
     # TODO(mattjj): revise this 'calling convention'
-    if initial_style:
-      axis_env, name_stack, xla_args = args[0], args[1], args[2:]
-    else:
-      axis_env, name_stack, xla_args = AxisEnv(1), '', args
-    xla_shapes = tuple(map(c.GetShape, xla_args))
-    avals = map(_aval_from_xla_shape, xla_shapes)
+    avals = [_array_aval_from_xla_shape(c.GetShape(x)) for x in xla_args]
     pvals = [pe.PartialVal((a, core.unit)) for a in avals]
     jaxpr, _, consts = pe.trace_to_jaxpr(
         lu.wrap_init(fun, params), pvals, instantiate=True)
     consts = _map(c.Constant, consts)
-    outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, consts,
-                         name_stack, *xla_args)
+    outs = jaxpr_subcomp(c, jaxpr, None, AxisEnv(1), consts, '', *xla_args)
     return c.Tuple(*outs)
   return f
 
-def _aval_from_xla_shape(xla_shape):
-  if xla_shape.is_tuple() and not xla_shape.tuple_shapes():
-    return core.abstract_unit
-  else:
-    return ShapedArray(xla_shape.dimensions(), xla_shape.element_type())
+def _array_aval_from_xla_shape(xla_shape):
+  assert not xla_shape.is_tuple()
+  return ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
+
+def lower_fun_initial_style(fun):
+  def f(c, axis_env, name_stack, avals, backend, *xla_args, **params):
+    pvals = [pe.PartialVal((a, core.unit)) for a in avals]
+    jaxpr, _, consts = pe.trace_to_jaxpr(
+        lu.wrap_init(fun, params), pvals, instantiate=True)
+    consts = _map(c.Constant, consts)
+    outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack,
+                         *xla_args)
+    return c.Tuple(*outs)
+  return f
 
 
 ### device-persistent data

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -616,7 +616,7 @@ lu_p = Primitive('lu')
 lu_p.multiple_results = True
 lu_p.def_impl(_lu_impl)
 lu_p.def_abstract_eval(_lu_abstract_eval)
-xla.translations[lu_p] = xla.lower_fun(_lu_python, instantiate=True)
+xla.translations[lu_p] = xla.lower_fun(_lu_python)
 ad.primitive_jvps[lu_p] = _lu_jvp_rule
 batching.primitive_batchers[lu_p] = _lu_batching_rule
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -192,9 +192,9 @@ threefry2x32_p.def_impl(partial(xla.apply_primitive, threefry2x32_p))
 threefry2x32_p.def_abstract_eval(_threefry2x32_abstract_eval)
 batching.defbroadcasting(threefry2x32_p)
 xla.translations[threefry2x32_p] = xla.lower_fun(
-    partial(_threefry2x32_lowering, use_rolled_loops=False), instantiate=True)
+    partial(_threefry2x32_lowering, use_rolled_loops=False))
 xla.backend_specific_translations['cpu'][threefry2x32_p] = xla.lower_fun(
-    partial(_threefry2x32_lowering, use_rolled_loops=True), instantiate=True)
+    partial(_threefry2x32_lowering, use_rolled_loops=True))
 if cuda_prng:
   xla.backend_specific_translations['gpu'][threefry2x32_p] = \
       _threefry2x32_gpu_translation_rule
@@ -927,7 +927,7 @@ random_gamma_p.multiple_results = True
 random_gamma_p.def_impl(_gamma_impl)
 random_gamma_p.def_abstract_eval(lambda key, a: (abstract_arrays.raise_to_shaped(a),))
 ad.defjvp2(random_gamma_p, None, lambda tangent, ans, key, a: (tangent * _gamma_grad(ans[0], a),))
-xla.translations[random_gamma_p] = xla.lower_fun(_gamma_impl, instantiate=True)
+xla.translations[random_gamma_p] = xla.lower_fun(_gamma_impl)
 batching.primitive_batchers[random_gamma_p] = _gamma_batching_rule
 
 def gamma(key, a, shape=None, dtype=onp.float64):


### PR DESCRIPTION
Previously the representation of JAX's unit value (a sentinel / placeholder) was an empty tuple, but by changing the representation to something else we can further reduce our dependence on runtime tuples.

This commit makes the representation fairly easy to change. There are three functions in xla.py that define the representation. Here are versions that would keep the old XLA representation as an empty tuple:

```python
def _make_unit(c): return c.Tuple()
def _make_abstract_unit(_): return xc.Shape.tuple_shape(())
def _device_put_unit(_, device):
  return xc.Buffer.make_tuple((), device, backend=xb.get_device_backend(device))
```

The new representation is as a trivial array. An alternative representation would be nothing at all: we don't need to generate XLA computations that have representations of JAX units. While that alternative is probably the best choice, it seemed like it would require a bit more refactoring/bookkeeping (e.g. to allow XLA computations to have a smaller number of outputs than the corresponding JAX function), and would also mean the XLA representation would be a step further removed from the jaxpr representation. So I stuck with a trivial array for now.

The mapping from JAX types to XLA types need not be invertible. However, XLA translation rules currently don't take as arguments the corresponding JAX types (abstract values), and there were a few cases where we relied on checking whether an argument's XLA type was that of an empty tuple so as to determine if we were effectively operating on a JAX unit.

In particular, the AD-related primitive `add_jaxvals_p` could in principle add two units, and get lowered to an XLA addition on the unit representation. Previously, the translation rule for `add_jaxvals_p` checked the XLA type so that adding two empty tuples didn't produce any XLA operation; now it adds its inputs, and so if unit is represented as a trivial array we could be inserting trivial scalar adds where we had none before. However, if that case is ever possible, it doesn't come up in our tests (which I checked by keeping the representation as an empty tuple and then asserting an XLA tuple type is never seen by that translation rule).

Another place there's a potential gap is in `xla.lower_fun`. Here's a comment I added to that function:

```
  # This function can only be used to lower functions that take JAX array types
  # as arguments (and e.g. don't accept unit values), because it assumes it can
  # map from XLA types to JAX types. In general that mapping is not possible (as
  # the mapping from JAX types to XLA types is not invertible), but for now at
  # least we assume that the mapping from JAX *array* types to XLA array types
  # is invertible. This assumption is unchecked!
  # TODO(mattjj): remove assumption can map XLA array types to JAX array types
```

If we refactor all translation rules to take avals as arguments, we can avoid this kind of assumption. But since `xla.lower_fun` is just an internal tool, this seems reasonable.

@hawkinsp FYI there's a similar assumption in dlpack, since we map from a dlpack array to a JAX DeviceArray and associated it with an aval.