### PR TITLE
Clean up jax.numpy.__init__

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -732,6 +732,9 @@ class DeviceArray(DeviceValue):
   __slots__ = ["_npy_value", "_device", "_lazy_expr"]
   __array_priority__ = 100
 
+  # We dynamically add numpy methods in jax/numpy/__init__.py.
+  _HAS_DYNAMIC_ATTRIBUTES = True
+
   def __init__(self, aval, device, lazy_expr, device_buffer):
     self.aval = aval
     self.device_buffer = device_buffer

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -16,6 +16,8 @@ from . import fft
 from . import linalg
 from .vectorize import vectorize
 
+from ..interpreters.xla import DeviceArray
+
 from .lax_numpy import (
     ComplexWarning, NINF, NZERO, PZERO, abs, absolute, add, all, allclose,
     alltrue, amax, amin, angle, any, append, arange, arccos, arccosh, arcsin,
@@ -56,3 +58,25 @@ from .lax_numpy import (
 
 from .lax_numpy import _unimplemented_numpy_fns
 globals().update(_unimplemented_numpy_fns)
+
+# Forward operators, methods, and properties on DeviceArray to lax_numpy
+# functions (with no Tracers involved; this forwarding is direct)
+from .lax_numpy import (_operators, _nondiff_methods, _diff_methods, _reshape_method,
+                        _astype)
+import numpy as _np
+from .. import lax as _lax
+
+for operator_name, function in _operators.items():
+  setattr(DeviceArray, "__{}__".format(operator_name), function)
+for method_name in _nondiff_methods + _diff_methods:
+  setattr(DeviceArray, method_name, globals()[method_name])
+setattr(DeviceArray, "reshape", _reshape_method)
+setattr(DeviceArray, "flatten", ravel)
+setattr(DeviceArray, "T", property(transpose))
+setattr(DeviceArray, "real", property(real))
+setattr(DeviceArray, "imag", property(imag))
+setattr(DeviceArray, "astype", _astype)
+setattr(DeviceArray, "tolist", lambda x: _np.array(x).tolist())
+setattr(DeviceArray, "broadcast", _lax.broadcast)
+setattr(DeviceArray, "broadcast_in_dim", _lax.broadcast_in_dim)
+setattr(DeviceArray, "split", split)

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -12,7 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .lax_numpy import *
 from . import fft
 from . import linalg
 from .vectorize import vectorize
+
+from .lax_numpy import (
+    ComplexWarning, NINF, NZERO, PZERO, abs, absolute, add, all, allclose,
+    alltrue, amax, amin, angle, any, append, arange, arccos, arccosh, arcsin,
+    arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, around, array,
+    array_equal, array_repr, array_str, asarray, atleast_1d, atleast_2d,
+    atleast_3d, average, bartlett, bfloat16, bitwise_and, bitwise_not,
+    bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays,
+    broadcast_to, can_cast, cbrt, cdouble, ceil, character, clip, column_stack,
+    complex128, complex64, complex_, complexfloating, concatenate, conj,
+    conjugate, corrcoef, cos, cosh, count_nonzero, cov, cross, csingle,
+    cumprod, cumproduct, cumsum, deg2rad, degrees, diag, diag_indices,
+    diagonal, diff, divide, divmod, dot, double, dsplit, dstack, dtype, e,
+    einsum, einsum_path, empty, empty_like, equal, euler_gamma, exp, exp2,
+    expand_dims, expm1, eye, fabs, finfo, fix, flexible, flip, fliplr, flipud,
+    float16, float32, float64, float_, float_power, floating, floor,
+    floor_divide, fmod, full, full_like, function, gcd, geomspace, gradient,
+    greater, greater_equal, hamming, hanning, heaviside, hsplit, hstack, hypot,
+    identity, iinfo, imag, inexact, inf, inner, int16, int32, int64, int8,
+    int_, integer, isclose, iscomplex, iscomplexobj, isfinite, isinf, isnan,
+    isneginf, isposinf, isreal, isrealobj, isscalar, issubdtype, issubsctype,
+    iterable, ix_, kaiser, kron, lcm, left_shift, less, less_equal, linspace,
+    load, log, log10, log1p, log2, logaddexp, logaddexp2, logical_and,
+    logical_not, logical_or, logical_xor, logspace, mask_indices, matmul, max,
+    maximum, mean, median, meshgrid, min, minimum, mod, moveaxis, msort,
+    multiply, nan, nan_to_num, nancumprod, nancumsum, nanmax, nanmean, nanmin,
+    nanprod, nansum, ndarray, ndim, negative, newaxis, nextafter, nonzero,
+    not_equal, number, numpy_version, object_, ones, ones_like, operator_name,
+    outer, pad, percentile, pi, polyval, positive, power, prod, product,
+    promote_types, ptp, quantile, rad2deg, radians, ravel, real, reciprocal,
+    remainder, repeat, reshape, result_type, right_shift, roll, rot90, round,
+    row_stack, save, savez, select, set_printoptions, shape, sign, signbit,
+    signedinteger, sin, sinc, single, sinh, size, sometrue, sort, split, sqrt,
+    square, squeeze, stack, std, subtract, sum, swapaxes, take,
+    take_along_axis, tan, tanh, tensordot, tile, trace, transpose, tri, tril,
+    tril_indices, triu, triu_indices, true_divide, uint16, uint32, uint64,
+    uint8, unsignedinteger, vander, var, vdot, vsplit, vstack, where, zeros,
+    zeros_like)
+
+from .lax_numpy import _unimplemented_numpy_fns
+globals().update(_unimplemented_numpy_fns)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3596,28 +3596,10 @@ setattr(ShapedArray, "imag", core.aval_property(imag))
 setattr(ShapedArray, "astype", core.aval_method(_astype))
 
 
-# Forward operators, methods, and properties on DeviceArray to lax_numpy
-# functions (with no Tracers involved; this forwarding is direct)
-for operator_name, function in _operators.items():
-  setattr(DeviceArray, "__{}__".format(operator_name), function)
-for method_name in _nondiff_methods + _diff_methods:
-  setattr(DeviceArray, method_name, globals()[method_name])
-setattr(DeviceArray, "reshape", _reshape_method)
-setattr(DeviceArray, "flatten", ravel)
-setattr(DeviceArray, "T", property(transpose))
-setattr(DeviceArray, "real", property(real))
-setattr(DeviceArray, "imag", property(imag))
-setattr(DeviceArray, "astype", _astype)
-setattr(DeviceArray, "tolist", lambda x: onp.array(x).tolist())
-
-
 # Extra methods that are handy
 setattr(ShapedArray, "broadcast", core.aval_method(lax.broadcast))
 setattr(ShapedArray, "broadcast_in_dim", core.aval_method(lax.broadcast_in_dim))
 setattr(ShapedArray, "split", core.aval_method(split))
-setattr(DeviceArray, "broadcast", lax.broadcast)
-setattr(DeviceArray, "broadcast_in_dim", lax.broadcast_in_dim)
-setattr(DeviceArray, "split", split)
 
 @jit
 def _unstack(x):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1093,9 +1093,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_input = jnp.ones((1))
     expected_onp_input_after_call = onp.ones((1))
     expected_jnp_input_after_call = jnp.ones((1))
-    
-    self.assertIs(type(jnp.concatenate([onp_input])), jnp.DeviceArray)
-    
+
+    self.assertIs(type(jnp.concatenate([onp_input])), xla.DeviceArray)
+
     attempt_sideeffect(onp_input)
     attempt_sideeffect(jnp_input)
 
@@ -2801,7 +2801,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "axis": axis,
          "dtype": dtype, "rng_factory": rng_factory}
         for shape in [(10,), (10, 15), (10, 15, 20)]
-        for _num_axes in range(len(shape)) 
+        for _num_axes in range(len(shape))
         for axis in itertools.combinations(range(len(shape)), _num_axes)
         for dtype in inexact_dtypes
         for rng_factory in [jtu.rand_default]))


### PR DESCRIPTION
This is hopefully the first of several commits to clean up the symbols we export.