### PR TITLE
Fix typo in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def predict(params, inputs):
   for W, b in params:
     outputs = np.dot(inputs, W) + b
     inputs = np.tanh(outputs)
-  return outputs
+  return inputs
 
 def logprob_fun(params, inputs, targets):
   preds = predict(params, inputs)


### PR DESCRIPTION
I could be wrong, but this looks like a typo to me. The layer activations are assigned to `inputs` which then feeds back into the `np.dot` expression in the next iteration. But then `outputs` is returned so the activation on the last layer has no effect.