### PR TITLE
add lax.broadcast_in_dim shape check and test

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2367,6 +2367,13 @@ def _broadcast_in_dim_shape_rule(operand, shape, broadcast_dimensions):
     msg = ('broadcast_in_dim broadcast_dimensions must be a subset of output '
            'dimensions, got {} for operand ndim {} and shape {}.')
     raise TypeError(msg.format(broadcast_dimensions, operand.ndim, shape))
+  if any(operand.shape[i] != shape[broadcast_dimensions[i]]
+         for i in range(operand.ndim)):
+    msg = ('broadcast_in_dim operand dimension sizes must equal their '
+           'corresponding dimensions in the broadcasted-to shape; got '
+           'operand of shape {}, target broadcast shape {}, '
+           'broadcast_dimensions {} ')
+    raise TypeError(msg.format(operand.shape, shape, broadcast_dimensions))
   return shape
 
 def _broadcast_in_dim_transpose_rule(t, shape, broadcast_dimensions):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -831,6 +831,17 @@ class LaxTest(jtu.JaxTestCase):
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     self._CompileAndCheck(op, args_maker, check_dtypes=True)
 
+  def testBroadcastInDimShapeCheck(self):
+    rng = jtu.rand_default()
+    x = rng((6, 7), onp.float32)
+    def op(x):
+      lax.broadcast_in_dim(x, broadcast_dimensions=(1, 2), shape=(3, 4, 5))
+    self.assertRaisesRegex(
+      TypeError,
+      ("broadcast_in_dim operand dimension sizes must equal their "
+       "corresponding dimensions in the broadcasted-to shape;*"),
+      lambda: op(x))
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
           jtu.format_shape_dtype_string(inshape, dtype),

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -149,11 +149,17 @@ class MaskingTest(jtu.JaxTestCase):
       return api.device_put(x)
 
   def test_shapecheck_broadcast_in_dim(self):
-    x = np.zeros((7, 1))
-    lax.broadcast_in_dim(x, shape=(3, x.shape[0], 4), broadcast_dimensions=(1, 2))
-    @shapecheck(['(n, 1)'], '(3, n, 4)')
+    x = np.zeros(7)
+
+    @shapecheck(['(n,)'], '(3, n, 4)')
     def broadcast_in_dim(x):
-      return lax.broadcast_in_dim(x, shape=(3, x.shape[0], 4), broadcast_dimensions=(1, 2))
+      return lax.broadcast_in_dim(x, shape=(3, x.shape[0], 4), broadcast_dimensions=(1,))
+
+    x = np.zeros((7, 1))
+
+    @shapecheck(['(n, 1)'], '(3, n, 4, 1)')
+    def broadcast_in_dim(x):
+      return lax.broadcast_in_dim(x, shape=(3, x.shape[0], 4, x.shape[1]), broadcast_dimensions=(1, 3))
 
   def test_shapecheck_jit(self):
     @shapecheck(['n'], '2*n')


### PR DESCRIPTION
Operand dimensions must equal their corresponding dimensions in the broadcast shape.