### PR TITLE
Improved argument checking for lax.broadcast_in_dim

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -24,6 +24,8 @@ jax 0.1.60 (unreleased)
   * Added :py:func:`jax.nn.one_hot` utility function.
   * Added :py:module:`jax.experimental.jet` for exponentially faster
     higher-order automatic differentiation.
+  * Added more sanity checking to arguments of :py:func:`jax.lax.broadcast_in_dim`.
+
 * The minimum jaxlib version is now 0.1.40.
 
 jaxlib 0.1.40 (March 4, 2020)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2359,20 +2359,21 @@ def _broadcast_in_dim_shape_rule(operand, shape, broadcast_dimensions):
   _check_shapelike('broadcast_in_dim', 'shape', shape)
   _check_shapelike('broadcast_in_dim', 'broadcast_dimensions',
                    broadcast_dimensions)
-  if operand.ndim != len(broadcast_dimensions):
+  operand_ndim = onp.ndim(operand)
+  if operand_ndim != len(broadcast_dimensions):
     msg = ('broadcast_in_dim broadcast_dimensions must have length equal to '
            'operand ndim; got broadcast_dimensions {} for operand ndim {}.')
-    raise TypeError(msg.format(broadcast_dimensions, operand.ndim))
-  if len(shape) < operand.ndim:
+    raise TypeError(msg.format(broadcast_dimensions, operand_ndim))
+  if len(shape) < operand_ndim:
     msg = ('broadcast_in_dim target broadcast shape must have equal or higher rank '
            'to the operand shape; got operand ndim {} and target broadcast ndim {}.')
-    raise TypeError(msg.format(operand.ndim, len(shape)))
+    raise TypeError(msg.format(operand_ndim, len(shape)))
   if not set(broadcast_dimensions).issubset(set(range(len(shape)))):
     msg = ('broadcast_in_dim broadcast_dimensions must be a subset of output '
            'dimensions, got {} for operand ndim {} and shape {}.')
-    raise TypeError(msg.format(broadcast_dimensions, operand.ndim, shape))
+    raise TypeError(msg.format(broadcast_dimensions, operand_ndim, shape))
   if any(operand.shape[i] != 1 and operand.shape[i] != shape[broadcast_dimensions[i]]
-         for i in range(operand.ndim)):
+         for i in range(operand_ndim)):
       msg = ('broadcast_in_dim operand dimension sizes must either be 1, or be '
              'equal to their corresponding dimensions in the target broadcast shape; '
              'got operand of shape {}, target broadcast shape {}, '

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -188,9 +188,10 @@ def broadcast(operand, sizes):
   return onp.broadcast_to(operand, sizes + onp.shape(operand))
 
 def broadcast_in_dim(operand, shape, broadcast_dimensions):
-  inshape = tuple(1 if i not in broadcast_dimensions else d
-                  for i, d in enumerate(shape))
-  return onp.broadcast_to(onp.reshape(operand, inshape), shape)
+  in_reshape = onp.ones(len(shape), dtype=onp.int32)
+  for i, bd in enumerate(broadcast_dimensions):
+    in_reshape[bd] = operand.shape[i]
+  return onp.broadcast_to(onp.reshape(operand, in_reshape), shape)
 
 sum = onp.sum
 


### PR DESCRIPTION
* Added checking that the output shape has higher or equal rank to input
* Added checking that the broadcast_dims are sorted (required by XLA)
* Relaxed check that operand dimension size can be 1
* Added lax.broadcast_in_dim docstring