### PR TITLE
Remove runtime tuple use from JAX.

### DIFF
--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -86,7 +86,7 @@ def _pvals_to_results_handler(nrep, npar, partitions, out_pvals):
     buffers = [[[None] * npar for _ in range(nrep)] for _ in range(nouts)]
     for raw_idx, tuple_buf in enumerate(out_bufs):
       r, p = onp.unravel_index(raw_idx, (nrep, npar))
-      for i, buf in enumerate(tuple_buf.destructure()):
+      for i, buf in enumerate(tuple_buf):
         buffers[i][r][p] = buf
     return [h(bufs) for h, bufs in zip(handlers, buffers)]
 
@@ -202,7 +202,8 @@ def _sharded_jit_translation_rule(c, axis_env, freevar_nodes,
 
 def _execute_spatially_partitioned(compiled, in_handler, out_handler, *args):
   input_bufs = in_handler(args)
-  out_bufs = compiled.ExecuteOnLocalDevices(list(input_bufs))
+  out_bufs = compiled.ExecuteOnLocalDevices(
+      list(input_bufs), tuple_arguments=False)
   return out_handler(out_bufs)
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -116,27 +116,12 @@ class APITest(jtu.JaxTestCase):
 
     f(1, 2, z=onp.zeros(3))  # doesn't crash
 
-  def test_jit_many_args_tuples(self):
+  def test_jit_with_many_args_works(self):
     @jit
     def f(args_list):
       return sum(args_list)
 
-    make_tuple = xla.make_tuple
-
-    counts = [0]
-    def make_tuple_and_count(*args, **kwargs):
-      counts[0] += 1
-      return make_tuple(*args, **kwargs)
-
-    try:
-      xla.make_tuple = make_tuple_and_count
-      ans = f(list(range(500)))
-    finally:
-      xla.make_tuple = make_tuple
-
-    expected = sum(range(500))
-    self.assertEqual(counts[0], 1)  # formed a tuple on dispatch
-    self.assertEqual(ans, expected)  # computed the correct result
+    self.assertEqual(f(list(range(500))), sum(range(500)))
 
   def test_grad_of_jit(self):
     side = []


### PR DESCRIPTION
Change in preparation for upcoming runtime changes related to buffer aliasing.