### PR TITLE
Better error message for indexing with floats

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3032,8 +3032,8 @@ def _index_to_gather(x_shape, idx):
       y_axis += 1
       x_axis += 1
     else:
-      if abstract_i and not (issubdtype(abstract_i.dtype, integer) or
-                             issubdtype(abstract_i.dtype, bool_)):
+      if (abstract_i is not None and
+          not (issubdtype(abstract_i.dtype, integer) or issubdtype(abstract_i.dtype, bool_))):
         msg = ("Indexer must have integer or boolean type, got indexer "
                "with type {} at position {}, indexer value {}")
         raise TypeError(msg.format(abstract_i.dtype.name, idx_pos, i))

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -754,8 +754,20 @@ class IndexingTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testFloatIndexingError(self):
-    x = jnp.array([1, 2, 3])
-    self.assertRaises(TypeError, lambda: x[3.5])
+    BAD_INDEX_TYPE_ERROR = "Indexer must have integer or boolean type, got indexer with type"
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      jnp.zeros(2)[0.]
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      jnp.zeros((2, 2))[(0, 0.)]
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      jnp.zeros((2, 2))[(0, 0.)]
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      api.jit(lambda idx: jnp.zeros((2, 2))[idx])((0, 0.))
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      ops.index_add(jnp.zeros(2), 0., 1.)
+    with self.assertRaisesRegex(TypeError, BAD_INDEX_TYPE_ERROR):
+      ops.index_update(jnp.zeros(2), 0., 1.)
+
 
   def testIndexOutOfBounds(self):  # https://github.com/google/jax/issues/2245
     array = jnp.ones(5)


### PR DESCRIPTION
Now the error message is 'Indexer must have integer or boolean type'.
Before it was 'len() of unsized object'

Fixes: #2495