### PR TITLE
Fix some missing cases of broadcasting in np.einsum.

### DIFF
--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -315,6 +315,26 @@ class EinsumTest(jtu.JaxTestCase):
     self.assertAllClose(L, np.einsum('ntk,kd,dc->nc', S, W, V, optimize=path),
                         check_dtypes=False, rtol=rtol)
 
+  def test_contraction_broadcasting(self):
+    r = rng()
+    x = r.randn(3, 4, 5)
+    y = r.randn(3, 1, 6)
+    s = 'cij,cjk->cik'
+    self._check(s, x, y)
+
+  def test_batch_broadcasting(self):
+    r = rng()
+    x = r.randn(1, 4, 5)
+    y = r.randn(3, 5, 6)
+    s = 'cij,cjk->cik'
+    self._check(s, x, y)
+
+  def test_batch_and_contraction_broadcasting(self):
+    r = rng()
+    x = r.randn(1, 4, 5)
+    y = r.randn(3, 1, 6)
+    s = 'cij,cjk->cik'
+    self._check(s, x, y)
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -336,5 +336,13 @@ class EinsumTest(jtu.JaxTestCase):
     s = 'cij,cjk->cik'
     self._check(s, x, y)
 
+  def test_broadcasting_issue_2189(self):
+    r = rng()
+    x = r.randn(2, 1, 3, 3)
+    y = r.randn(2, 4, 3)
+    s = '...ij,...j'
+    self._check(s, x, y)
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
In particular, np.einsum allows one side of a batch or contracting dimension to have size 1 even if the other side has a non-1 size.

Implement np.matmul in terms of np.einsum. This allows us to reuse einsum's logic for performing broadcasting without explicitly broadcasting the LHS and RHS together.

Fixes #2189 