### PR TITLE
Expand docstring for vmap with details about out_axes, and improve error checking

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -614,9 +614,15 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
       ``in_axes`` can itself be a matching container, so that distinct array
       axes can be mapped for different container elements. ``in_axes`` must be a
       container tree prefix of the positional argument tuple passed to ``fun``.
+
+      At least one positional argument must have `in_axes` not None. The sizes
+      of the mapped input axes for all mapped positional arguments must all
+      be equal.
+
     out_axes: A nonnegative integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof indicating where the mapped axis should appear
-      in the output.
+      in the output. All outputs with a mapped axis must have a non-None
+      `out_axes` specification.
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to
@@ -661,6 +667,23 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
   >>> vfoo = vmap(foo, in_axes=((0, (1, 2)),))
   >>> print(vfoo(tree)).shape
   (6, 2, 5)
+
+  The results of a vectorized function can be mapped or unmapped.
+  For example, the function below returns a pair with the first
+  element mapped and the second unmapped. Only for unmapped results
+  we can specify `out_axes` to be None (to keep it unmapped).
+
+  >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=(0, None))(np.arange(2.), 4.))
+  ([4., 5.], 8.)
+
+  If the `out_axes` is specified for an unmapped result, the result is broadcast
+  across the mapped axis:
+
+  >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=0)(np.arange(2.), 4.))
+  ([4., 5.], [8., 8.])
+
+  If the `out_axes` is specified for a mapped result, the result is
+  transposed accordingly.
   """
   docstr = ("Vectorized version of {fun}. Takes similar arguments as {fun} "
             "but with additional array axes over which {fun} is mapped.")
@@ -680,11 +703,20 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
            "or a (nested) tuple of those types, got {} and {} respectively.")
     raise TypeError(msg.format(type(in_axes), type(out_axes)))
 
-  def _check_axis_sizes(tree, vals, dims):
-    mapped_axis_sizes = {x.shape[d] for x, d in zip(vals, dims) if d is not None}
+  def _get_axis_size(i:int, shape: Tuple[int, ...], axis: int):
     try:
-      sizes, = mapped_axis_sizes
+      return shape[axis]
+    except (IndexError, TypeError) as e:
+      raise ValueError(f"vmap got arg {i} of rank {len(shape)} but axis to be mapped {axis}") from e
+
+  def _check_axis_sizes(tree, vals, dims):
+    mapped_axis_sizes = {_get_axis_size(i, onp.shape(x), d) for i, (x, d) in enumerate(zip(vals, dims))
+                         if d is not None}
+    try:
+      size, = mapped_axis_sizes
     except ValueError as e:
+      if not mapped_axis_sizes:
+        raise ValueError("vmap must have at least one non-None in_axes") from e
       msg = "vmap got inconsistent sizes for array axes to be mapped:\n{}"
       # we switch the error message based on whether args is a tuple of arrays,
       # in which case we can produce an error message based on argument indices,

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -59,7 +59,7 @@ def _batch_fun(sum_match, in_dims, out_dims_thunk, out_dim_dests, *in_vals, **pa
   out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
   out_dims = out_dims_thunk()
   for od, od_dest in zip(out_dims, out_dim_dests):
-    if od is not None and not isinstance(od_dest, int) and not od_dest is last:
+    if od is not None and not isinstance(od_dest, int) and not od_dest is last and not sum_match:
       msg = f"vmap has mapped output but out_axes is {od_dest}"
       raise ValueError(msg)
   out_vals = map(partial(matchaxis, size, sum_match=sum_match), out_dims, out_dim_dests, out_vals)


### PR DESCRIPTION
The newly added test cases used to raise the following kinds of exceptions:

AttributeError: 'float' object has no attribute 'shape'

ValueError: (0, None)

ValueError: vmap got inconsistent sizes for array axes to be mapped:
    arg 0 has shape (2,) and axis None is to be mapped
        so

TypeError: only integer scalar arrays can be converted to a scalar index.