### PR TITLE
don't hardcode array size in test

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -185,6 +185,11 @@ def xla_primitive_callable(prim, *arg_specs, **params):
     nreps = initial_style_primitive_replicas(params)
   else:
     nreps = 1
+  if nreps > xb.device_count(backend):
+    msg = ("compiling a primitive computation `{}` that requires {} replicas, "
+           "but only {} XLA devices are available on backend {}.")
+    raise ValueError(msg.format(prim, nreps, xb.device_count(backend),
+                                backend.platform))
   built_c = primitive_computation(prim, AxisEnv(nreps), backend, tuple_args,
                                   *avals, **params)
   options = xb.get_compile_options(

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1816,22 +1816,21 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = onp.arange(10)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @jtu.skip_on_devices("tpu", "gpu", "cpu")# TODO(mattjj): follow up w/ xla
-  # Issue #2554
   def test_while_loop_of_pmap(self):
     # code from jsnoek@
+
     def body(i, x):
       result = api.pmap(lambda z: lax.psum(np.sin(z), 'i'), axis_name='i')(x)
       return result + x
     f_loop = lambda x: lax.fori_loop(0, 3, body, x)
-    ans = f_loop(np.ones(8))
+    ans = f_loop(np.ones(api.device_count()))
     del body, f_loop
 
     def body2(i, x):
       result = np.broadcast_to(np.sin(x).sum(), x.shape)
       return result + x
     g_loop = lambda x: lax.fori_loop(0, 3, body2, x)
-    expected = g_loop(np.ones(8))
+    expected = g_loop(np.ones(api.device_count()))
 
     self.assertAllClose(ans, expected, check_dtypes=False)
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1834,6 +1834,23 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def test_while_loop_of_pmap_error_message(self):
+
+    def body(i, x):
+      result = api.pmap(lambda z: lax.psum(np.sin(z), 'i'), axis_name='i')(x)
+      return result + x
+    f_loop = lambda x: lax.fori_loop(0, 3, body, x)
+
+    too_big = 2 * api.device_count()
+
+    self.assertRaisesRegex(
+        ValueError,
+        re.escape(
+            "compiling a primitive computation `while` that requires {} "
+            "replicas, but only {} XLA devices are available on backend {}."
+            .format(too_big, api.device_count(), jtu.device_under_test())),
+        lambda: f_loop(np.ones(too_big)))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Fixes #2554

Internal tests pass!

Added an error message, which looks like this:

ValueError: compiling a primitive computation `while` that requires 2 replicas, but only 1 XLA devices are available on backend cpu.