### PR TITLE
Move tuple_arguments onto Compile() instead of Execute().

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   # The jaxlib version should match the minimum jaxlib version in
   # jax/lib/__init__.py. This tests JAX PRs against the oldest permitted
   # jaxlib.
-  - pip install jaxlib==0.1.41
+  - pip install jaxlib==0.1.43
   - pip install -v .
   # The following are needed to test the Colab notebooks and the documentation building
   - if [ "$JAX_ONLY_DOCUMENTATION" = true ]; then

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -203,8 +203,7 @@ def _sharded_jit_translation_rule(c, axis_env, freevar_nodes,
 
 def _execute_spatially_partitioned(compiled, in_handler, out_handler, *args):
   input_bufs = in_handler(args)
-  out_bufs = compiled.ExecuteOnLocalDevices(
-      list(input_bufs), tuple_arguments=False)
+  out_bufs = compiled.ExecuteOnLocalDevices(list(input_bufs))
   return out_handler(out_bufs)
 
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -191,13 +191,14 @@ def xla_primitive_callable(prim, *arg_specs, **params):
       num_replicas=nreps,
       num_partitions=1,
       device_assignment=device and (device.id,))
+  options.tuple_arguments = tuple_args
   compiled = built_c.Compile(compile_options=options, backend=backend)
   if nreps == 1:
     return partial(_execute_compiled_primitive, prim, compiled, backend,
-                  tuple_args, handle_result)
+                   handle_result)
   else:
     return partial(_execute_replicated_primitive, prim, compiled, backend,
-                   tuple_args, handle_result)
+                   handle_result)
 
 def _device_from_arg_devices(devices):
   """Given devices of inputs, determine where to perform a computation.
@@ -249,22 +250,20 @@ def primitive_computation(prim, axis_env, backend, tuple_args, *avals, **params)
 def primitive_subcomputation(prim, *avals, **params):
   return primitive_computation(prim, AxisEnv(1), None, False, *avals, **params)
 
-def _execute_compiled_primitive(prim, compiled, backend, tuple_args,
-                                result_handler, *args):
+def _execute_compiled_primitive(prim, compiled, backend, result_handler, *args):
   device, = compiled.local_devices()
   input_bufs = [device_put(x, device) for x in args if x is not token]
-  out_bufs = compiled.Execute(input_bufs, tuple_arguments=tuple_args)
+  out_bufs = compiled.Execute(input_bufs)
   if FLAGS.jax_debug_nans:
     check_nans(prim, out_bufs)
   return result_handler(out_bufs if prim.multiple_results else out_bufs[0])
 
-def _execute_replicated_primitive(prim, compiled, backend, tuple_args,
-                                  result_handler, *args):
+def _execute_replicated_primitive(prim, compiled, backend, result_handler,
+                                  *args):
   input_bufs = [
       [device_put(x, device) for x in args if x is not token]
       for device in compiled.local_devices()]
-  out_buf = compiled.ExecuteOnLocalDevices(
-      input_bufs, tuple_arguments=tuple_args)[0]
+  out_buf = compiled.ExecuteOnLocalDevices(input_bufs)[0]
   if not prim.multiple_results:
     out_buf, = out_buf
   return result_handler(out_buf)
@@ -515,12 +514,13 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, *arg_specs):
       num_replicas=nreps,
       num_partitions=1,
       device_assignment=(device.id,) if device else None)
+  options.tuple_arguments = tuple_args
   compiled = built.Compile(compile_options=options, backend=xb.get_backend(backend))
 
   if nreps == 1:
-    return partial(_execute_compiled, compiled, backend, result_handlers, tuple_args)
+    return partial(_execute_compiled, compiled, backend, result_handlers)
   else:
-    return partial(_execute_replicated, compiled, backend, result_handlers, tuple_args)
+    return partial(_execute_replicated, compiled, backend, result_handlers)
 
 def _xla_callable_device(nreps, backend, device, arg_devices):
   if nreps > 1:
@@ -560,19 +560,18 @@ def _pval_to_result_handler(device, pval):
   else:
     return aval_to_result_handler(device, pv)
 
-def _execute_compiled(compiled, backend, handlers, tuple_args, *args):
+def _execute_compiled(compiled, backend, handlers, *args):
   device, = compiled.local_devices()
   input_bufs = [device_put(x, device) for x in args if x is not token]
-  out_bufs = compiled.Execute(input_bufs, tuple_arguments=tuple_args)
+  out_bufs = compiled.Execute(input_bufs)
   if FLAGS.jax_debug_nans: check_nans(xla_call_p, out_bufs)
   return [handler(out_buf) for handler, out_buf in zip(handlers, out_bufs)]
 
-def _execute_replicated(compiled, backend, handlers, tuple_args, *args):
+def _execute_replicated(compiled, backend, handlers, *args):
   input_bufs = [
       [device_put(x, device) for x in args if x is not token]
       for device in compiled.local_devices()]
-  out_bufs = compiled.ExecuteOnLocalDevices(
-      input_bufs, tuple_arguments=tuple_args)[0]
+  out_bufs = compiled.ExecuteOnLocalDevices(input_bufs)[0]
   if FLAGS.jax_debug_nans: check_nans(xla_call_p, out_bufs)
   return [handler(out_buf) for handler, out_buf in zip(handlers, out_bufs)]
 
@@ -955,10 +954,10 @@ def _lazy_force_computation(sticky, aval, device, lexpr) -> Callable[[DeviceArra
   force_fun: Callable[[DeviceValue], DeviceArray]
   if lazy.is_constant(lexpr):
     def force_fun(_):
-      return handler(compiled.Execute([], tuple_arguments=False)[0])
+      return handler(compiled.Execute([])[0])
   else:
     def force_fun(x):
-      return handler(compiled.Execute([x.device_buffer], tuple_arguments=False)[0])
+      return handler(compiled.Execute([x.device_buffer])[0])
   return force_fun
 
 

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -17,7 +17,7 @@
 
 import jaxlib
 
-_minimum_jaxlib_version = (0, 1, 41)
+_minimum_jaxlib_version = (0, 1, 43)
 try:
   from jaxlib import version as jaxlib_version
 except Exception as err:


### PR DESCRIPTION
Update minimum jaxlib version to 0.1.43.

This change is in preparation for an XLA:Python runtime refactoring.