### PR TITLE
Disable gradients of custom_linear_solve for complex dtypes

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1612,7 +1612,7 @@ def _custom_linear_solve_jvp(primals, tangents, const_lengths, jaxprs, tree):
   kwargs = dict(const_lengths=const_lengths, jaxprs=jaxprs, tree=tree)
   x = linear_solve_p.bind(*primals, **kwargs)
 
-  if any(issubclass(xi.dtype.type, onp.complexfloating) for xi in x):
+  if any(issubclass(dtypes.dtype(xi).type, onp.complexfloating) for xi in x):
     raise NotImplementedError(
         "gradients of complex values are not yet supported in "
         "custom_linear_solve: https://github.com/google/jax/issues/2572")

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1612,6 +1612,11 @@ def _custom_linear_solve_jvp(primals, tangents, const_lengths, jaxprs, tree):
   kwargs = dict(const_lengths=const_lengths, jaxprs=jaxprs, tree=tree)
   x = linear_solve_p.bind(*primals, **kwargs)
 
+  if any(issubclass(xi.dtype.type, onp.complexfloating) for xi in x):
+    raise NotImplementedError(
+        "gradients of complex values are not yet supported in "
+        "custom_linear_solve: https://github.com/google/jax/issues/2572")
+
   params, _ = _split_linear_solve_args(primals, const_lengths)
   params_dot, b_dot = _split_linear_solve_args(tangents, const_lengths)
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -59,6 +59,10 @@ def high_precision_dot(a, b):
   return lax.dot(a, b, precision=lax.Precision.HIGHEST)
 
 
+def posify(matrix):
+  return high_precision_dot(matrix, matrix.T.conj())
+
+
 class LaxControlFlowTest(jtu.JaxTestCase):
 
   def testWhileWithTuple(self):
@@ -1636,17 +1640,38 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     a = rng.randn(2, 2)
     b = rng.randn(2)
 
-    expected = np.linalg.solve(high_precision_dot(a, a.T), b)
-    actual = positive_definite_solve(high_precision_dot(a, a.T), b)
+    expected = np.linalg.solve(onp.asarray(posify(a)), b)
+    actual = positive_definite_solve(posify(a), b)
     self.assertAllClose(expected, actual, check_dtypes=True)
 
-    actual = api.jit(positive_definite_solve)(high_precision_dot(a, a.T), b)
+    actual = api.jit(positive_definite_solve)(posify(a), b)
     self.assertAllClose(expected, actual, check_dtypes=True)
 
     # numerical gradients are only well defined if ``a`` is guaranteed to be
     # positive definite.
     jtu.check_grads(
-        lambda x, y: positive_definite_solve(high_precision_dot(x, x.T), y),
+        lambda x, y: positive_definite_solve(posify(x), y),
+        (a, b), order=2, rtol=1e-2)
+
+  def test_custom_linear_solve_complex(self):
+    raise SkipTest("known failure: https://github.com/google/jax/issues/2572")
+
+    def positive_definite_solve(a, b):
+      def solve(matvec, x):
+        return jsp.linalg.solve(a, x)
+      matvec = partial(high_precision_dot, a)
+      return lax.custom_linear_solve(matvec, b, solve, symmetric=True)
+
+    rng = onp.random.RandomState(0)
+    a = 0.5 * rng.randn(2, 2) + 0.5j * rng.randn(2, 2)
+    b = 0.5 * rng.randn(2) + 0.5j * rng.randn(2)
+
+    expected = np.linalg.solve(posify(a), b)
+    actual = positive_definite_solve(posify(a), b)
+    self.assertAllClose(expected, actual, check_dtypes=True)
+
+    jtu.check_grads(
+        lambda x, y: positive_definite_solve(posify(x), y),
         (a, b), order=2, rtol=1e-2)
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1654,7 +1654,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         (a, b), order=2, rtol=1e-2)
 
   def test_custom_linear_solve_complex(self):
-    raise SkipTest("known failure: https://github.com/google/jax/issues/2572")
 
     def positive_definite_solve(a, b):
       def solve(matvec, x):
@@ -1670,9 +1669,11 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     actual = positive_definite_solve(posify(a), b)
     self.assertAllClose(expected, actual, check_dtypes=True)
 
-    jtu.check_grads(
-        lambda x, y: positive_definite_solve(posify(x), y),
-        (a, b), order=2, rtol=1e-2)
+    # TODO(shoyer): remove this error when complex values work 
+    with self.assertRaises(NotImplementedError):
+      jtu.check_grads(
+          lambda x, y: positive_definite_solve(posify(x), y),
+          (a, b), order=2, rtol=1e-2)
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def test_custom_linear_solve_lu(self):


### PR DESCRIPTION
Gradients are currently broken: https://github.com/google/jax/issues/2572