### PR TITLE
Fix missing type promotion accidentally removed by #2512.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2323,6 +2323,7 @@ def matmul(a, b, precision=None):  # pylint: disable=missing-docstring
   if shape(a)[0 if a_is_vec else -1] != shape(b)[0 if b_is_vec else -2]:
     msg = "matmul requires contracting dimension to match, got {} and {}"
     raise ValueError(msg.format(shape(a), shape(b)))
+  a, b = _promote_dtypes(a, b)
   if a_is_vec and b_is_vec:
     return lax.dot(a, b, precision=precision)
   elif a_is_vec:


### PR DESCRIPTION
This is in fact covered by the existing tests, but we were unlucky and didn't hit them in the set of generated tests we selected.