### PR TITLE
Changes made to hack a build on a win10 machine.

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -25,7 +25,7 @@ sh_binary(
     srcs = ["install_xla_in_source_tree.sh"],
     data = [
         "@org_tensorflow//tensorflow/compiler/xla/python:xla_client",
-        "@org_tensorflow//tensorflow/compiler/xla/python/tpu_driver/client:py_tpu_client",
+        #"@org_tensorflow//tensorflow/compiler/xla/python/tpu_driver/client:py_tpu_client",
         "//jaxlib",
         "//jaxlib:lapack.so",
         "//jaxlib:pytree",

--- a/build/build.py
+++ b/build/build.py
@@ -179,15 +179,22 @@ BAZELRC_TEMPLATE = """
 # Flag to enable remote config
 common --experimental_repo_remote_exec
 
-build --repo_env PYTHON_BIN_PATH="{python_bin_path}"
-build --python_path="{python_bin_path}"
-build --repo_env TF_NEED_CUDA="{tf_need_cuda}"
+build --repo_env PYTHON_BIN_PATH="C:/Users/dom/AppData/Local/Programs/Python/Python37/python.exe"
+build --python_path="C:/Users/dom/AppData/Local/Programs/Python/Python37/python.exe"
+build --repo_env TF_NEED_CUDA="0"
 build --distinct_host_configuration=false
-build --copt=-Wno-sign-compare
+#build --copt=-Wno-sign-compare
+build --copt="/D_WINSOCKAPI_  /D_USE_MATH_DEFINES /DWIN32 /std:c++17" # /D_USE_MATH_DEFINES  does it lead to the definition of M_PI in 
+                                                                                                   #or do we need to explicitly define M_PI here or in code?
+                                                                                                   # /DM_PI=3.14159265358979323846
 build -c opt
 build:opt --copt=-march=native
 build:opt --host_copt=-march=native
 build:mkl_open_source_only --define=tensorflow_mkldnn_contraction_kernel=1
+
+
+build --local_cpu_resources=HOST_CPUS*.75 # added by djb  
+build --local_ram_resources=HOST_RAM*.75 # added by djb 
 
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
@@ -210,8 +217,10 @@ build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
 build --spawn_strategy=standalone
 build --strategy=Genrule=standalone
 
-build --cxxopt=-std=c++14
-build --host_cxxopt=-std=c++14
+#build --cxxopt=-std=latest                         # commented out by djb 
+#build --host_cxxopt=-std=--bazel_startup_options   # commented out by djb
+#build --cxxopt= /std:c++17                         # commented out by djb
+#build --host_cxxopt= /std:c++17                    # commented out by djb
 
 # Suppress all warning messages.
 build:short_logs --output_filter=DONT_MATCH_ANYTHING

--- a/build/install_xla_in_source_tree.sh
+++ b/build/install_xla_in_source_tree.sh
@@ -64,8 +64,8 @@ cp -f "$(rlocation __main__/jaxlib/cusolver.py)" "${TARGET}/jaxlib"
 cp -f "$(rlocation __main__/jaxlib/cuda_prng.py)" "${TARGET}/jaxlib"
 cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/xla_extension.so)" \
   "${TARGET}/jaxlib"
-cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/tpu_driver/client/tpu_client_extension.so)" \
-  "${TARGET}/jaxlib"
+#cp -f "$(rlocation org_tensorflow/tensorflow/compiler/xla/python/tpu_driver/client/tpu_client_extension.so)" \
+#  "${TARGET}/jaxlib"
 sed \
   -e 's/from tensorflow.compiler.xla.python import xla_extension as _xla/from . import xla_extension as _xla/' \
   -e 's/from tensorflow.compiler.xla.python.xla_extension import ops/from .xla_extension import ops/' \

--- a/djb_build_info.txt
+++ b/djb_build_info.txt
@@ -1,0 +1,63 @@
+Notes on hacking Jaxlib build process
+2 March 2020
+
+
+command line params give to the build.py script
+--bazel_options=-s --python_bin_path C:/Users/dom/AppData/Local/Programs/Python/Python37/python.exe
+
+resulting command line call that ran the build
+C:\Users\dom\tools\bazel.EXE run --verbose_failures=true -s --config=short_logs --config=mkl_open_source_only :install_xla_in_source_tree C:\Users\dom\libraries\durian888\jax\build
+
+
+Despite my efforts messing with defines in the .bazelrc file (and what I have done there is frankly speculative), to get things to compile I was forced to make the following changes in the code base pulled in by bazel. I'm guessing that this is "not how things should be done" (I'm visualizing you slapping your head and issuing comments about my mental functionality) and the changes will probably disappear should I do a bazel clean but needs must. I also suspect that a better build wizard than I would probably not have to resort to some or perhaps all of them by better command line parameter selection. Sadly I'm at a serious disadvantage since I am so new to bazel and its cunning ways.
+
+I assume that to develop Jax properly one needs the tensorflow source repo and I would do this if I could work out how to build jax from a local repo not one pulled in by bazal. However I fear to start down that hole - it may be a long time before I get back to the surface.  
+
+Here are the summary of the hacks I put in.
+
+I attempted to avoid the following problem with the /D_WINSOCKAPI_ in the bazelrc file
+build --copt="/D_WINSOCKAPI_ /D_USE_MATH_DEFINES /DWIN32 /std:c++17" but
+
+to stop the compiler complaining about a conflict between  both winsock.h and winsock2.h being pulled in I
+added
+
+#define _WINSOCKAPI_  
+line 17
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\platform\windows\error_windows.cc
+
+To deal with the repeated problem of M_PI not being defined I had to resort to adding
+#define M_PI 3.14159265358979323846
+in muliple files. I tried using the define /D_USE_MATH_DEFINES which some sources suggested would fix the problem but at least in my hands it failed to help.
+
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\lib\random\distribution_sampler.cc
+
+line15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\compiler\xla\python\bfloat16.cc
+
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\lib\random\random_distributions_test.cc
+
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\lib\random\simple_philox.cc
+
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\lib\random\weighted_picker.cc
+
+line 16
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\compiler\xla\client\lib\math.cc
+
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\core\lib\random\random_distributions.h
+
+Along the way I ended up with
+#include <utility>
+line 15
+C:\Users\dom\_bazel_dom\mo5isdhc\external\org_tensorflow\tensorflow\compiler\xla\client\lib\math.cc
+this may not be necessary - I can't now work out exactly why I put this in (sigh)
+
+I got the following weird error that seemed to be due to the use of the name small for a parameter - I'm scratching my head over this.
+
+external/org_tensorflow/tensorflow/compiler/xla/client/lib/math.cc(1600): error C2632: 'double' followed by 'char' is illegal
+
+as an experiment as I had a suspicion about the name "small" I renamed small to small_djb (djb are my initials - makes it easy for me to know if I made a change) through out the function that small appeared in and this and much to my surprise this change appeared to make the compiler happy and the build proceeded when I restarted bazel! If you have an explination about this stuff I would be very happy to hear it.

--- a/used_dot_bazelrc
+++ b/used_dot_bazelrc
@@ -1,0 +1,46 @@
+
+# Flag to enable remote config
+common --experimental_repo_remote_exec
+
+build --repo_env PYTHON_BIN_PATH="C:/Users/dom/AppData/Local/Programs/Python/Python37/python.exe"
+build --python_path="C:/Users/dom/AppData/Local/Programs/Python/Python37/python.exe"
+build --repo_env TF_NEED_CUDA="0"
+build --distinct_host_configuration=false
+#build --copt=-Wno-sign-compare
+build --copt="/D_WINSOCKAPI_ /D_USE_MATH_DEFINES /DWIN32 /std:c++17"                               # /D_USE_MATH_DEFINES  does it lead to the definition of M_PI in 
+                                                                                                   #or do we need to explicitly define M_PI here or in code?
+                                                                                                   # /DM_PI=3.14159265358979323846
+build -c opt
+build:opt --copt=-march=native
+build:opt --host_copt=-march=native
+build:mkl_open_source_only --define=tensorflow_mkldnn_contraction_kernel=1
+
+build --local_cpu_resources=HOST_CPUS*.75 # added by djb  
+build --local_ram_resources=HOST_RAM*.75 # added by djb 
+
+# Sets the default Apple platform to macOS.
+build --apple_platform_type=macos
+build --macos_minimum_os=10.9
+
+# Make Bazel print out all options from rc files.
+build --announce_rc
+
+# Disable enabled-by-default TensorFlow features that we don't care about.
+build --define=no_aws_support=true
+build --define=no_gcp_support=true
+build --define=no_hdfs_support=true
+build --define=no_kafka_support=true
+build --define=no_ignite_support=true
+build --define=grpc_no_ares=true
+
+build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
+build:cuda --define=using_cuda=true --define=using_cuda_nvcc=true
+
+build --spawn_strategy=standalone
+build --strategy=Genrule=standalone
+
+build --cxxopt="/D_WINSOCKAPI_  /D_USE_MATH_DEFINES /DWIN32 /std:c++17"                         
+build --host_cxxopt="/D_WINSOCKAPI_  /D_USE_MATH_DEFINES /DWIN32 /std:c++17"                         
+
+# Suppress all warning messages.
+build:short_logs --output_filter=DONT_MATCH_ANYTHING


### PR DESCRIPTION
As requested by Peter Hawkins <phawkins@google.com> in communication with djb@qvii.com aka durian888

Pull request  for hacks performed to make jaxlib on a win10 machine
summary of changes

djb_build_info.txt gives some details of what hacks were performed and why.
used_dot_bazelrc is a copy of the .bazelrc file that was used for the build.
Note the pulled in tensorflow code had to be hacked to make the build go through - and so are not in the repo proper
These changes are indicated in the djb_build_info.txt