### PR TITLE
revise jaxpr pretty printing to old way of handling call primitives

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1027,8 +1027,11 @@ def pp_eqn(eqn: JaxprEqn) -> PrettyPrint:
 
 def pp_jaxpr(jaxpr) -> PrettyPrint:
   pp_outvars = str(tuple(jaxpr.outvars))
-  return (pp('{{ lambda {} ; {}.'.format(pp_vars(jaxpr.constvars),
-                                         pp_vars(jaxpr.invars))) +
+  if jaxpr.constvars:
+    pp_invars = '{} ; {}'.format(pp_vars(jaxpr.constvars), pp_vars(jaxpr.invars))
+  else:
+    pp_invars = pp_vars(jaxpr.invars)
+  return (pp('{{ lambda {}.'.format(pp_invars)) +
           ((pp('let ') >>
             vcat(map(pp_eqn, jaxpr.eqns))) +
            pp('in {} }}'.format(pp_outvars))).indent(2))

--- a/jax/core.py
+++ b/jax/core.py
@@ -1018,9 +1018,17 @@ def pp_eqn_compact(primitive_name: str, params: Dict) -> PrettyPrint:
 
 def pp_eqn(eqn: JaxprEqn) -> PrettyPrint:
   lhs = pp_vars(eqn.outvars)
-  pp_subexpr = pp('')
+  call_jaxpr, params = extract_call_jaxpr(eqn.primitive, eqn.params)
+  pp_subexpr = pp_jaxpr(call_jaxpr).indent(2) if call_jaxpr else pp('')
+  non_jaxpr_params = []
+  for name, val in sorted(params.items()):
+    if isinstance(val, (Jaxpr, TypedJaxpr)):
+      val = val if isinstance(val, Jaxpr) else val.jaxpr
+      pp_subexpr += (pp(name) + pp_jaxpr(val)).indent(2)
+    else:
+      non_jaxpr_params.append((name, val))
   return (pp('{} = '.format(lhs)) >>
-          pp(eqn.primitive.name) >> pp_kv_pairs(sorted(eqn.params.items()))
+          pp(eqn.primitive.name) >> pp_kv_pairs(non_jaxpr_params)
           >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -1020,15 +1020,8 @@ def pp_eqn(eqn: JaxprEqn) -> PrettyPrint:
   lhs = pp_vars(eqn.outvars)
   call_jaxpr, params = extract_call_jaxpr(eqn.primitive, eqn.params)
   pp_subexpr = pp_jaxpr(call_jaxpr).indent(2) if call_jaxpr else pp('')
-  non_jaxpr_params = []
-  for name, val in sorted(params.items()):
-    if isinstance(val, (Jaxpr, TypedJaxpr)):
-      val = val if isinstance(val, Jaxpr) else val.jaxpr
-      pp_subexpr += (pp(name) + pp_jaxpr(val)).indent(2)
-    else:
-      non_jaxpr_params.append((name, val))
   return (pp('{} = '.format(lhs)) >>
-          pp(eqn.primitive.name) >> pp_kv_pairs(non_jaxpr_params)
+          pp(eqn.primitive.name) >> pp_kv_pairs(sorted(params.items()))
           >> pp(' ') >> pp(pp_vars(eqn.invars))) + pp_subexpr
 
 

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-import functools
+from functools import partial, reduce
+import operator as op
 
 
 class PrettyPrint(object):
@@ -49,16 +50,8 @@ class PrettyPrint(object):
 def pp(s):
   return PrettyPrint([(0, line) for line in str(s).splitlines()])
 
-
-def hcat(ps):
-  return functools.reduce(lambda x, y: x >> y, ps)
-
-
-def vcat(ps):
-  if not ps:
-    return pp('')
-  else:
-    return functools.reduce(lambda x, y: x + y, ps)
+hcat = partial(reduce, op.rshift)
+def vcat(ps): return reduce(op.add, ps) if ps else pp('')
 
 
 def pp_kv_pairs(kv_pairs):

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from functools import partial, reduce
+import functools
 import operator as op
 
 
@@ -50,8 +50,13 @@ class PrettyPrint(object):
 def pp(s):
   return PrettyPrint([(0, line) for line in str(s).splitlines()])
 
-hcat = partial(reduce, op.rshift)
-def vcat(ps): return reduce(op.add, ps) if ps else pp('')
+
+def hcat(ps):
+  return functools.reduce(op.rshift, ps)
+
+
+def vcat(ps):
+  return functools.reduce(op.add, ps) if ps else pp('')
 
 
 def pp_kv_pairs(kv_pairs):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1763,12 +1763,12 @@ class JaxprTest(jtu.JaxTestCase):
 { lambda b ; a.
   let c = sub a 2.0
       d = xla_call[ backend=None
-                    call_jaxpr={ lambda  ; c b a.
-                                 let d = mul b c
-                                     e = add a d
-                                 in (e,) }
                     device=None
                     name=inner ] b a c
+          { lambda  ; c b a.
+            let d = mul b c
+                e = add a d
+            in (e,) }
       e = add a d
   in (e,) }
                             """, str(jaxpr))
@@ -1786,16 +1786,16 @@ class JaxprTest(jtu.JaxTestCase):
   let d = xla_pmap[ axis_name=rows
                     axis_size=1
                     backend=None
-                    call_jaxpr={ lambda  ; d b a.
-                                 let c = add a b
-                                     e = add c d
-                                     f = psum[ axis_name=rows ] a
-                                     g = div e f
-                                 in (g,) }
                     devices=None
                     global_axis_size=None
                     mapped_invars=(True, False, True)
                     name=inner ] c b a
+          { lambda  ; d b a.
+            let c = add a b
+                e = add c d
+                f = psum[ axis_name=rows ] a
+                g = div e f
+            in (g,) }
   in (d,) }
                               """, str(jaxpr))
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1613,15 +1613,15 @@ class JaxprTest(jtu.JaxTestCase):
                       lambda xf: xf - x)
     jaxpr = api.make_jaxpr(f)(3.)
     self.assertMultiLineStrippedEqual("""
-{ lambda  ; a.
+{ lambda a.
   let b = ge a 0.0
       c = add a 1.0
       d = add a 2.0
-      e = cond[ false_jaxpr={ lambda  ; b a.
+      e = cond[ false_jaxpr={ lambda b a.
                               let c = sub a b
                               in (c,) }
                 linear=(False, False, False, False)
-                true_jaxpr={ lambda  ; b a.
+                true_jaxpr={ lambda b a.
                              let c = add a b
                              in (c,) } ] b a c a d
   in (e,) }
@@ -1636,7 +1636,7 @@ class JaxprTest(jtu.JaxTestCase):
 
     jaxpr = jax.make_jaxpr(func1)(jnp.zeros(8), jnp.ones(8))
     self.assertMultiLineStrippedEqual("""
-{ lambda  ; a b.
+{ lambda a b.
   let c = sin b
       d = mul c 3.0
       e = add a d
@@ -1668,13 +1668,13 @@ class JaxprTest(jtu.JaxTestCase):
 
     jaxpr = api.make_jaxpr(func7)(5.)
     self.assertMultiLineStrippedEqual("""
-{ lambda  ; a.
+{ lambda a.
   let b = ge a 0.0
-      c = cond[ false_jaxpr={ lambda  ; a.
+      c = cond[ false_jaxpr={ lambda a.
                               let b = sub a 3.0
                               in (b,) }
                 linear=(False, False)
-                true_jaxpr={ lambda  ; a.
+                true_jaxpr={ lambda a.
                              let b = add a 3.0
                              in (b,) } ] b a a
   in (c,) }
@@ -1691,11 +1691,11 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertMultiLineStrippedEqual("""
 { lambda e ; a b c.
   let d = ge a 0.0
-      f = cond[ false_jaxpr={ lambda  ; c a b.
+      f = cond[ false_jaxpr={ lambda c a b.
                               let d = add c b
                               in (d,) }
                 linear=(False, False, False, False, False)
-                true_jaxpr={ lambda  ; a b.
+                true_jaxpr={ lambda a b.
                              let 
                              in (a,) } ] d b c e b c
   in (f,) }
@@ -1711,13 +1711,13 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertMultiLineStrippedEqual("""
 { lambda c d ; a b.
   let e = add a d
-      f g h = while[ body_jaxpr={ lambda  ; e g a b c.
+      f g h = while[ body_jaxpr={ lambda e g a b c.
                                   let d = add a 1
                                       f = add c e
                                       h = add f g
                                   in (d, b, h) }
                      body_nconsts=2
-                     cond_jaxpr={ lambda  ; a b c.
+                     cond_jaxpr={ lambda a b c.
                                   let d = lt a b
                                   in (d,) }
                      cond_nconsts=0 ] c a 0 b e
@@ -1739,7 +1739,7 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertMultiLineStrippedEqual("""
 { lambda c ; a b.
   let d e = scan[ forward=True
-                  jaxpr={ lambda  ; a b c d e.
+                  jaxpr={ lambda a b c d e.
                           let f = mul c e
                               g = add b f
                               h = add g a
@@ -1765,7 +1765,7 @@ class JaxprTest(jtu.JaxTestCase):
       d = xla_call[ backend=None
                     device=None
                     name=inner ] b a c
-          { lambda  ; c b a.
+          { lambda c b a.
             let d = mul b c
                 e = add a d
             in (e,) }
@@ -1790,7 +1790,7 @@ class JaxprTest(jtu.JaxTestCase):
                     global_axis_size=None
                     mapped_invars=(True, False, True)
                     name=inner ] c b a
-          { lambda  ; d b a.
+          { lambda d b a.
             let c = add a b
                 e = add c d
                 f = psum[ axis_name=rows ] a


### PR DESCRIPTION
```python
from jax import make_jaxpr, jit

@jit
def f(x):
  return x + 2
print(make_jaxpr(f)(3))
```

Before this PR:

```
{ lambda  ; a.
  let b = xla_call[ backend=None
                    call_jaxpr={ lambda  ; a.
                                 let b = add a 2
                                 in (b,) }
                    device=None
                    name=f ] a
  in (b,) }
```

After this PR:

```
{ lambda  ; a.
  let b = xla_call[ backend=None
                    device=None
                    name=f ] a
        { lambda a.
          let b = add a 2
          in (b,) }
  in (b,) }
```

This is in effect reviving the old way of pretty-printing (what were then) subjaxprs for calls. I like it better because otherwise there's too much indenting too quickly.

Also, I tweaked it so that when a jaxpr doesn't have constvars we avoid printing the semicolon and related spaces, so this:

```
lambda  ; a.
```

becomes this:

```
lambda a.
```

Since we cons-convert most jaxprs these days, it reduces the visual noise for the common case.