### PR TITLE
Support pytrees in jax.scipy.linalg.cg

### DIFF
--- a/jax/scipy/sparse/linalg.py
+++ b/jax/scipy/sparse/linalg.py
@@ -13,17 +13,26 @@
 # limitations under the License.
 
 from functools import partial
+import operator
 import textwrap
 
 import scipy.sparse.linalg
-import jax.numpy as jnp
 import numpy as np
-from jax.numpy.lax_numpy import _wraps
-from jax import lax
+import jax.numpy as jnp
+from jax import lax, device_put
+from jax.tree_util import tree_leaves, tree_map, tree_multimap
 
 
+# aliases for working with pytrees
 def _vdot(x, y):
-  return jnp.vdot(x, y, precision=lax.Precision.HIGHEST)
+  f = partial(jnp.vdot, precision=lax.Precision.HIGHEST)
+  return sum(tree_leaves(tree_multimap(f, x, y)))
+
+def _mul(scalar, tree):
+  return tree_map(partial(operator.mul, scalar), tree)
+
+_add = partial(tree_multimap, operator.add)
+_sub = partial(tree_multimap, operator.sub)
 
 
 def _identity(x):
@@ -31,6 +40,7 @@ def _identity(x):
 
 
 def _cg_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
+
   # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
   bs = _vdot(b, b)
   atol2 = jnp.maximum(tol ** 2 * bs, atol ** 2)
@@ -46,15 +56,15 @@ def _cg_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
     x, r, gamma, p, k = value
     Ap = A(p)
     alpha = gamma / _vdot(p, Ap)
-    x_ = x + alpha * p
-    r_ = r - alpha * Ap
+    x_ = _add(x, _mul(alpha, p))
+    r_ = _sub(r, _mul(alpha, Ap))
     z_ = M(r_)
     gamma_ = _vdot(r_, z_)
     beta_ = gamma_ / gamma
-    p_ = z_ + beta_ * p
+    p_ = _add(z_, _mul(beta_, p))
     return x_, r_, gamma_, p_, k + 1
 
-  r0 = b - A(x0)
+  r0 = _sub(b, A(x0))
   p0 = z0 = M(r0)
   gamma0 = _vdot(r0, z0)
   initial_value = (x0, r0, gamma0, p0, 0)
@@ -77,14 +87,16 @@ def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
   A : function
       Function that calculates the matrix-vector product ``Ax`` when called
       like ``A(x)``. ``A`` must represent a hermitian, positive definite
-      matrix.
-  b : array
-      Right hand side of the linear system. Has shape (N,).
+      matrix, and must return array(s) with the same structure and shape as its
+      argument.
+  b : array or tree of arrays
+      Right hand side of the linear system representing a single vector. Can be
+      stored as an array or Python container of array(s) with any shape.
 
   Returns
   -------
-  x : array
-      The converged solution.
+  x : array or tree of arrays
+      The converged solution. Has the same structure as ``b``.
   info : None
       Placeholder for convergence information. In the future, JAX will report
       the number of iterations when convergence is not achieved, like SciPy.
@@ -92,7 +104,7 @@ def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
   Other Parameters
   ----------------
   x0 : array
-      Starting guess for the solution.
+      Starting guess for the solution. Must have the same structure as ``b``.
   tol, atol : float, optional
       Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
       We do not implement SciPy's "legacy" behavior, so JAX's tolerance will
@@ -111,20 +123,21 @@ def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
   scipy.sparse.linalg.cg
   """
   if x0 is None:
-    x0 = jnp.zeros_like(b)
+    x0 = tree_map(jnp.zeros_like, b)
+
+  b, x0 = device_put((b, x0))
 
   if maxiter is None:
-    maxiter = 10 * len(b)  # copied from scipy
+    size = sum(bi.size for bi in tree_leaves(b))
+    maxiter = 10 * size  # copied from scipy
 
   if M is None:
     M = _identity
 
-  if x0.shape != b.shape:
+  shape = partial(tree_map, lambda x: x.shape)
+  if shape(x0) != shape(b):
     raise ValueError(
-        f'x0 and b must have matching shape: {x0.shape} vs {b.shape}')
-  if b.ndim != 1:
-    raise ValueError(
-        f'b must be one-dimensional, but has shape {b.shape}')
+        f'x0 and b must have matching shape: {shape(x0)} vs {shape(b)}')
 
   cg_solve = partial(
       _cg_solve, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M)

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -146,7 +146,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     b = {"a": 1.0, "b": -4.0}
     expected = {"a": 4.0, "b": -6.0}
     actual, _ = jax.scipy.sparse.linalg.cg(A, b)
-    self.assertEqual(expected, actual)
+    self.assertEqual(expected.keys(), actual.keys())
+    self.assertAlmostEqual(expected["a"], actual["a"])
+    self.assertAlmostEqual(expected["b"], actual["b"])
 
   def test_cg_errors(self):
     A = lambda x: x

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -134,6 +134,28 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
         lambda x, y: lax_cg(posify(x), y),
         (a, b), order=2, rtol=1e-2)
 
+  def test_cg_ndarray(self):
+    A = lambda x: 2 * x
+    b = jnp.arange(9.0).reshape((3, 3))
+    expected = b / 2
+    actual, _ = jax.scipy.sparse.linalg.cg(A, b)
+    self.assertAllClose(expected, actual, check_dtypes=True)
+
+  def test_cg_pytree(self):
+    A = lambda x: {"a": x["a"] + 0.5 * x["b"], "b": 0.5 * x["a"] + x["b"]}
+    b = {"a": 1.0, "b": -4.0}
+    expected = {"a": 4.0, "b": -6.0}
+    actual, _ = jax.scipy.sparse.linalg.cg(A, b)
+    self.assertEqual(expected, actual)
+
+  def test_cg_errors(self):
+    A = lambda x: x
+    b = jnp.zeros((2, 1))
+    x0 = jnp.zeros((2,))
+    with self.assertRaisesRegexp(
+        ValueError, "x0 and b must have matching shape"):
+      jax.scipy.sparse.linalg.cg(A, b, x0)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Ideally there would be an cleaner way to write this, but for now this will do.