### PR TITLE
Add boolean indexing function to jax.ops

### DIFF
--- a/jax/ops/__init__.py
+++ b/jax/ops/__init__.py
@@ -13,4 +13,11 @@
 # limitations under the License.
 
 
-from .scatter import index, index_add, index_update, index_min, index_max, segment_sum
+from .scatter import (
+        index,
+        index_add,
+        index_update,
+        index_min,
+        index_max,
+        segment_sum,
+        index_by_mask)

--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -130,6 +130,7 @@ def index_add(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter_add)
 
+
 def index_min(x, idx, y):
   """Pure equivalent of :code:`x[idx] = minimum(x[idx], y)`.
 
@@ -202,6 +203,7 @@ def index_max(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter_max)
 
+
 def index_update(x, idx, y):
   """Pure equivalent of :code:`x[idx] = y`.
 
@@ -239,6 +241,7 @@ def index_update(x, idx, y):
   """
   return _scatter_update(x, idx, y, lax.scatter)
 
+
 def segment_sum(data, segment_ids, num_segments=None):
   """Computes the sum within segments of an array.
 
@@ -267,3 +270,19 @@ def segment_sum(data, segment_ids, num_segments=None):
   out = np.zeros((num_segments,) + data.shape[1:], dtype=data.dtype)
   segment_ids = np.mod(segment_ids, num_segments)
   return index_add(out, segment_ids, data)
+
+
+def index_by_mask(x, boolean_mask, axis=0, pad_value=0):
+  """A version of NumPy's `x[boolean_mask]`, but with a static output shape.
+
+  Selects elements of `x` according to the boolean mask `boolean_mask`. The
+  output is padded with `pad_value` so that it has the same shape as `x`.
+
+  Args:
+    x: the array that should be indexed.
+    boolean_mask: boolean array with shape `(x.shape[axis],)`.
+    axis: The dimension of `x` that should be indexed.
+    pad_value: Value to pad the output with to make it statically shaped.
+  """
+  x = np.where(boolean_mask, x, pad_value)
+  return lax.sort_key_val(~boolean_mask, x, dimension=axis)[1]


### PR DESCRIPTION
We sometimes need to perform boolean indexing inside of `jax.jit`, and found that it's useful to have a function which does that while padding the output to the same shape as the original input.
I think that having this function will be useful, even if JAX gains better variable shape support in the future.

Some things I'm not sure about in this implementation:
 - Is `jax.lax.sort_key_val` going to do a stable sort? XLA exposes a parameter for setting the sort to stable, but this is not exposed in `jax.lax.sort*`. I'd be happy to add an additional argument or to default the sort to be stable.
 - I can get the code to throw an error saying "This is a bug in JAX's shape-checking rules; please report it!". How can I perform proper shape checking, or should I perhaps add the checks to `jax.sort*`?