### PR TITLE
Remove unnecessary code in colabs

### DIFF
--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -61,7 +61,6 @@
         "colab": {}
       },
       "source": [
-        "from __future__ import print_function, division, absolute_import\n",
         "import jax.numpy as np\n",
         "from jax import grad, jit, vmap\n",
         "from jax import random"

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -679,7 +679,7 @@
     "\n",
     "and so on.\n",
     "\n",
-    "To implement `hessian`, we could have used `jacrev(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \\mathbb{R}^n \\to \\mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\\nabla f : \\mathbb{R}^n \\to \\mathbb{R}^n$), which is where forward-mode wins out."
+    "To implement `hessian`, we could have used `jacfwd(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \\mathbb{R}^n \\to \\mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\\nabla f : \\mathbb{R}^n \\to \\mathbb{R}^n$), which is where forward-mode wins out."
    ]
   },
   {

--- a/docs/notebooks/neural_network_with_tfds_data.ipynb
+++ b/docs/notebooks/neural_network_with_tfds_data.ipynb
@@ -87,7 +87,6 @@
         "colab": {}
       },
       "source": [
-        "from __future__ import print_function, division, absolute_import\n",
         "import jax.numpy as np\n",
         "from jax import grad, jit, vmap\n",
         "from jax import random"
@@ -337,21 +336,6 @@
         "\n",
         "JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll use the `tensorflow/datasets` data loader."
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab_type": "code",
-        "id": "gEvWt8_u2pqG",
-        "colab": {}
-      },
-      "source": [
-        "# Install tensorflow-datasets\n",
-        "# TODO(rsepassi): Switch to stable version on release\n",
-        "!pip install -q --upgrade tfds-nightly tf-nightly"
-      ],
-      "execution_count": 0,
-      "outputs": []
     },
     {
       "cell_type": "code",

--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -48,10 +48,6 @@
         "colab": {}
       },
       "source": [
-        "from __future__ import absolute_import\n",
-        "from __future__ import division\n",
-        "from __future__ import print_function\n",
-        "\n",
         "import functools\n",
         "import itertools\n",
         "import re\n",


### PR DESCRIPTION
1. Fix a typo in the autodiff colab.
2. Remove unnecessary __future__ code.
3. remove `pip tf&tfds-nightly` version, as the colab has builtin versions, which I think works well in the tutorial.
