### PR TITLE
Make median() more efficient & handle infs correctly

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3481,7 +3481,7 @@ def percentile(a, q, axis=None, out=None, overwrite_input=False,
 def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     q = 0.5
     return quantile(a, q, axis=axis, out=out, overwrite_input=overwrite_input,
-                    keepdims=keepdims)
+                    keepdims=keepdims, interpolation='midpoint')
 
 def _astype(arr, dtype):
   lax._check_user_dtype_supported(dtype, "astype")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2139,7 +2139,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name":
-           "_op=median_a_shape={}_axis={}_keepdims={}".format(
+           "_a_shape={}_axis={}_keepdims={}".format(
              jtu.format_shape_dtype_string(a_shape, a_dtype),
              axis, keepdims),
          "a_rng": jtu.rand_default(), 


### PR DESCRIPTION
Fixes #2446 - the issue there was that linear interpolation involves multiplying values by weights, and in this case the value is infinity and the weight is zero. By shifting to `interpolation='midpoint'` we get the desired behavior with less computation required.