### PR TITLE
Remove import of sparse in scipy.

### DIFF
--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -14,6 +14,5 @@
 
 from . import linalg
 from . import ndimage
-from . import sparse
 from . import special
 from . import stats


### PR DESCRIPTION
This import was added recently in #2621.
Filed b/153410493.