### PR TITLE
jet of pow using comp with exp, mul, log

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -239,6 +239,22 @@ def _expm1_taylor(primals_in, series_in):
   return lax.expm1(x), series_out
 jet_rules[lax.expm1_p] = _expm1_taylor
 
+def _pow_taylor(primals_in, series_in):
+  u_, r_ = primals_in
+  u_terms, r_terms = series_in
+  u = [u_] + u_terms
+  r = [r_] + r_terms
+
+  logu_, logu_terms = _log_taylor((u_, ), (u_terms, ))
+
+  v_, v_terms = _bilinear_taylor_rule(lax.mul_p, (logu_, r_), (logu_terms, r_terms))
+
+  v_, v_terms = _exp_taylor((v_, ), (v_terms, ))
+
+  return v_, v_terms
+jet_rules[lax.pow_p] = _pow_taylor
+
+
 def _log_taylor(primals_in, series_in):
   x, = primals_in
   series, = series_in

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -241,17 +241,16 @@ jet_rules[lax.expm1_p] = _expm1_taylor
 
 def _pow_taylor(primals_in, series_in):
   u_, r_ = primals_in
-  u_terms, r_terms = series_in
-  u = [u_] + u_terms
-  r = [r_] + r_terms
 
-  logu_, logu_terms = _log_taylor((u_, ), (u_terms, ))
+  x, series = jet(lambda x, y: lax.mul(y, lax.log(x)), primals_in, series_in)
 
-  v_, v_terms = _bilinear_taylor_rule(lax.mul_p, (logu_, r_), (logu_terms, r_terms))
+  u = [x] + series
+  v = [u_ ** r_] + [None] * len(series)
+  for k in range(1, len(v)):
+    v[k] = fact(k-1) * sum([_scale(k, j)* v[k-j] * u[j] for j in range(1, k+1)])
+  primal_out, *series_out = v
 
-  v_, v_terms = _exp_taylor((v_, ), (v_terms, ))
-
-  return v_, v_terms
+  return primal_out, series_out
 jet_rules[lax.pow_p] = _pow_taylor
 
 

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -56,6 +56,32 @@ class JetTest(jtu.JaxTestCase):
                 check_dtypes=True):
     y, terms = jet(fun, primals, series)
     expected_y, expected_terms = jvp_taylor(fun, primals, series)
+
+    self.assertAllClose(y, expected_y, atol=atol, rtol=rtol,
+                        check_dtypes=check_dtypes)
+
+    # TODO(duvenaud): Lower zero_series to actual zeros automatically.
+    if terms == zero_series:
+      terms = tree_map(np.zeros_like, expected_terms)
+
+    self.assertAllClose(terms, expected_terms, atol=atol, rtol=rtol,
+                        check_dtypes=check_dtypes)
+
+  def check_jet_finite(self, fun, primals, series, atol=1e-5, rtol=1e-5,
+                       check_dtypes=True):
+
+    y, terms = jet(fun, primals, series)
+    expected_y, expected_terms = jvp_taylor(fun, primals, series)
+
+    def _convert(x):
+      return np.where(np.isfinite(x), x, np.nan)
+
+    y = _convert(y)
+    expected_y = _convert(expected_y)
+
+    terms = _convert(np.asarray(terms))
+    expected_terms = _convert(np.asarray(expected_terms))
+
     self.assertAllClose(y, expected_y, atol=atol, rtol=rtol,
                         check_dtypes=check_dtypes)
 
@@ -111,14 +137,21 @@ class JetTest(jtu.JaxTestCase):
     terms_in = [rng.randn(*dims) for _ in range(order)]
     self.check_jet(fun, (primal_in,), (terms_in,), atol=1e-4, rtol=1e-4)
 
-  def binary_check(self, fun, lims=[-2, 2], order=3):
+  def binary_check(self, fun, lims=[-2, 2], order=3, finite=True):
     dims = 2, 3
     rng = onp.random.RandomState(0)
-    primal_in = (transform(lims, rng.rand(*dims)),
-                 transform(lims, rng.rand(*dims)))
+    if isinstance(lims, tuple):
+      x_lims, y_lims = lims
+    else:
+      x_lims, y_lims = lims, lims
+    primal_in = (transform(x_lims, rng.rand(*dims)),
+                 transform(y_lims, rng.rand(*dims)))
     series_in = ([rng.randn(*dims) for _ in range(order)],
                  [rng.randn(*dims) for _ in range(order)])
-    self.check_jet(fun, primal_in, series_in, atol=1e-4, rtol=1e-4)
+    if finite:
+      self.check_jet(fun, primal_in, series_in, atol=1e-4, rtol=1e-4)
+    else:
+      self.check_jet_finite(fun, primal_in, series_in, atol=1e-4, rtol=1e-4)
 
   @jtu.skip_on_devices("tpu")
   def test_exp(self):        self.unary_check(np.exp)
@@ -182,7 +215,7 @@ class JetTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")
   def test_xor(self):   self.binary_check(lambda x, y: np.logical_xor(x, y))
   @jtu.skip_on_devices("tpu")
-  def test_pow2(self):  self.binary_check(lambda x, y: x ** y, lims=[0.2, 15])
+  def test_pow(self):  self.binary_check(lambda x, y: x ** y, lims=([0.2, 500], [-500, 500]), finite=False)
 
   def test_process_call(self):
     def f(x):

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -181,6 +181,8 @@ class JetTest(jtu.JaxTestCase):
   def test_or(self):    self.binary_check(lambda x, y: np.logical_or(x, y))
   @jtu.skip_on_devices("tpu")
   def test_xor(self):   self.binary_check(lambda x, y: np.logical_xor(x, y))
+  @jtu.skip_on_devices("tpu")
+  def test_pow2(self):  self.binary_check(lambda x, y: x ** y, lims=[0.2, 15])
 
   def test_process_call(self):
     def f(x):


### PR DESCRIPTION
This implementation is numerically unstable (the test begins to fail when the upper limit is about 35), but it's unclear if there's another way to implement jet of pow easily.

Co-authored-by: Jesse Bettencourt <jessebett@cs.toronto.edu> (@jessebett)
Co-authored-by: David Duvenaud <duvenaud@cs.toronto.edu> (@duvenaud)