### PR TITLE
Add jet rule for tanh

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -17,6 +17,7 @@ from functools import partial
 
 import numpy as onp
 
+import jax
 from jax import core
 from jax.util import unzip2
 from jax.tree_util import (register_pytree_node, tree_structure,
@@ -217,6 +218,9 @@ def fact(n):
 def _scale(k, j):
   return 1. / (fact(k - j) * fact(j - 1))
 
+def _scale2(k, j):
+  return 1. / (fact(k - j) * fact(j))
+
 def _exp_taylor(primals_in, series_in):
   x, = primals_in
   series, = series_in
@@ -253,6 +257,28 @@ def _pow_taylor(primals_in, series_in):
   return primal_out, series_out
 jet_rules[lax.pow_p] = _pow_taylor
 
+def _expit_taylor(primals_in, series_in):
+  x, = primals_in
+  series, = series_in
+  u = [x] + series
+  v = [jax.scipy.special.expit(x)] + [None] * len(series)
+  e = [v[0] * (1 - v[0])] + [None] * len(series)  # terms for sigmoid' = sigmoid * (1 - sigmoid)
+  for k in range(1, len(v)):
+    v[k] = fact(k-1) * sum([_scale(k, j) * e[k-j] * u[j] for j in range(1, k+1)])
+    e[k] = (1 - v[0]) * v[k] - fact(k) * sum([_scale2(k, j)* v[j] * v[k-j] for j in range(1, k+1)])
+
+  primal_out, *series_out = v
+  return primal_out, series_out
+
+def _tanh_taylor(primals_in, series_in):
+  x, = primals_in
+  series, = series_in
+  u = [2*x] + [2 * series_ for series_ in series]
+  primals_in, *series_in = u
+  primal_out, series_out = _expit_taylor((primals_in, ), (series_in, ))
+  series_out = [2 * series_ for series_ in series_out]
+  return 2 * primal_out - 1, series_out
+jet_rules[lax.tanh_p] = _tanh_taylor
 
 def _log_taylor(primals_in, series_in):
   x, = primals_in


### PR DESCRIPTION
Using `tanh(x)=2*expit(2*x) - 1` and the taylor rule for `expit` derived from the taylor rule for functions of first order ODEs.

<s>Numerically unstable when lims are wider than about `[-100, 100]`. Perhaps a comparison against `jet` through `tanh` as a composition of `lax` ops is needed, as this is how `expit` is implemented.</s>
Edit: Deriving a different rule for `expit` from its ODE makes it stable (see comment below)

@duvenaud @jessebett @mattjj 