### PR TITLE
Fixes a fallthrough in the tensordot axes verification logic

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2455,6 +2455,9 @@ def tensordot(a, b, axes=2, precision=None):
         raise TypeError(msg.format(ax1, ax2))
       contracting_dims = (tuple(_canonicalize_axis(i, a_ndim) for i in ax1),
                           tuple(_canonicalize_axis(i, b_ndim) for i in ax2))
+    else:
+        msg = "tensordot requires both axes lists to be either ints, tuples or lists, got {} and {}"
+        raise TypeError(msg.format(ax1, ax2))
   else:
     msg = ("tensordot axes argument must be an int, a pair of ints, or a pair "
            "of lists/tuples of ints.")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -823,6 +823,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       TypeError, "Number of tensordot axes.*exceeds input ranks.*",
       lambda: jnp.tensordot(a, b, axes=2))
 
+    self.assertRaisesRegex(
+      TypeError, "tensordot requires axes lists to have equal length.*",
+      lambda: jnp.tensordot(a, b, axes=([0], [0, 1])))
+
+    self.assertRaisesRegex(
+      TypeError, "tensordot requires both axes lists to be either ints, tuples or lists.*",
+      lambda: jnp.tensordot(a, b, axes=('bad', 'axes')))
+
+    self.assertRaisesRegex(
+      TypeError, "tensordot axes argument must be an int, a pair of ints, or a pair of lists.*",
+      lambda: jnp.tensordot(a, b, axes='badaxes'))
+
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}".format(
           jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),


### PR DESCRIPTION
There's a fallthrough in the tensordot verification logic where if the axes aren't tuples or lists - if some dummy passes aranges for example - it'll fall through and end up throwing a confusing 

```NameError: name 'contracting_dims' is not defined ```

error. This PR adds the `else` clause needed to make the error informative.