### PR TITLE
Remove unnecessary pip code

### DIFF
--- a/cloud_tpu_colabs/JAX_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_demo.ipynb
@@ -34,9 +34,6 @@
         "colab": {}
       },
       "source": [
-        "# Grab newest JAX version.\n",
-        "!pip install --upgrade -q jax==0.1.54 jaxlib==0.1.37\n",
-        "\n",
         "# Make sure the Colab Runtime is set to Accelerator: TPU.\n",
         "import requests\n",
         "import os\n",

--- a/cloud_tpu_colabs/Lorentz_ODE_Solver.ipynb
+++ b/cloud_tpu_colabs/Lorentz_ODE_Solver.ipynb
@@ -43,9 +43,6 @@
         "colab": {}
       },
       "source": [
-        "# Grab newest JAX version.\n",
-        "!pip install --upgrade -q jax==0.1.54 jaxlib==0.1.37\n",
-        "\n",
         "# Make sure the Colab Runtime is set to Accelerator: TPU.\n",
         "import requests\n",
         "import os\n",

--- a/cloud_tpu_colabs/Pmap_Cookbook.ipynb
+++ b/cloud_tpu_colabs/Pmap_Cookbook.ipynb
@@ -32,9 +32,6 @@
         "colab": {}
       },
       "source": [
-        "# Grab newest JAX version.\n",
-        "!pip install --upgrade -q jax==0.1.54 jaxlib==0.1.37\n",
-        "\n",
         "# Make sure the Colab Runtime is set to Accelerator: TPU.\n",
         "import requests\n",
         "import os\n",

--- a/cloud_tpu_colabs/Wave_Equation.ipynb
+++ b/cloud_tpu_colabs/Wave_Equation.ipynb
@@ -53,9 +53,6 @@
         "colab": {}
       },
       "source": [
-        "# Grab newest JAX version.\n",
-        "!pip install --upgrade -q jax==0.1.54 jaxlib==0.1.37\n",
-        "\n",
         "# Grab other packages for this demo.\n",
         "!pip install -U -q Pillow moviepy proglog\n",
         "\n",

--- a/examples/control.py
+++ b/examples/control.py
@@ -15,10 +15,6 @@
 Model-predictive non-linear control example.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 
 from jax import lax, grad, jacfwd, jacobian, vmap

--- a/examples/control_test.py
+++ b/examples/control_test.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from functools import partial
 from unittest import SkipTest
 

--- a/jax/scipy/stats/logistic.py
+++ b/jax/scipy/stats/logistic.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import scipy.stats as osp_stats
 from jax.scipy.special import expit, logit
 


### PR DESCRIPTION
The `pip install jax` in tpu colabs are not necessary, since the builtin Jax in colab is already 0.1.62 and 0.1.42 for jaxlib.

Since Jax now only supports python>=3.6, the `from __future__` code are also not necessary.