### PR TITLE
Make pytest run over JAX tests warning clean, and error on warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ script:
       echo "===== Checking with mypy ====" &&
       time mypy --config-file=mypy.ini jax ;
     else
-      pytest tests examples -W ignore ;
+      pytest tests examples ;
     fi

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2114,6 +2114,7 @@ def _convert_element_type_translation_rule(c, operand, *, new_dtype, old_dtype):
   return c.ConvertElementType(operand, new_element_type=new_etype)
 
 def _convert_element_type_transpose_rule(t, *, new_dtype, old_dtype):
+  assert t.dtype == new_dtype, (t.dtype, new_dtype)
   return [convert_element_type_p.bind(t, new_dtype=old_dtype,
                                       old_dtype=new_dtype)]
 

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -266,7 +266,7 @@ sort = onp.sort
 def sort_key_val(keys, values, dimension=-1):
   idxs = list(onp.ix_(*[onp.arange(d) for d in keys.shape]))
   idxs[dimension] = onp.argsort(keys, axis=dimension)
-  return keys[idxs], values[idxs]
+  return keys[tuple(idxs)], values[tuple(idxs)]
 
 # TODO untake
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3378,7 +3378,7 @@ def cov(m, y=None, rowvar=True, bias=False, ddof=None, fweights=None,
 
 
 @_wraps(onp.corrcoef)
-def corrcoef(x, y=None, rowvar=True, bias=None, ddof=None):
+def corrcoef(x, y=None, rowvar=True):
   c = cov(x, y, rowvar)
   if len(shape(c)) == 0:
       # scalar - this should yield nan for values (nan/nan, inf/inf, 0/0), 1 otherwise

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings =
+    error
+    ignore:No GPU/TPU found, falling back to CPU.:UserWarning
+    ignore:Explicitly requested dtype.*is not available.*:UserWarning
+    ignore:jax.experimental.vectorize is deprecated.*:FutureWarning

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -212,7 +212,7 @@ class APITest(jtu.JaxTestCase):
 
       self.assertRaisesRegex(
           TypeError,
-          "Try using `x.astype\({}\)` instead.".format(castfun.__name__),
+          f"Try using `x.astype\\({castfun.__name__}\\)` instead.",
           lambda: jit(f)(1.0))
 
   def test_switch_value_jit(self):
@@ -1018,7 +1018,7 @@ class APITest(jtu.JaxTestCase):
     X = onp.random.randn(10, 4)
     U = onp.random.randn(10, 2)
 
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
         r"arg 0 has shape \(10, 4\) and axis 0 is to be mapped" "\n"
@@ -1028,7 +1028,7 @@ class APITest(jtu.JaxTestCase):
         "arg 1 has an axis to be mapped of size 2"):
       api.vmap(h, in_axes=(0, 1))(X, U)
 
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
         r"arg 0 has shape \(10, 4\) and axis 0 is to be mapped" "\n"
@@ -1039,32 +1039,38 @@ class APITest(jtu.JaxTestCase):
         "arg 1 has an axis to be mapped of size 2"):
       api.vmap(lambda x, y, z: None, in_axes=(0, 1, 0))(X, U, X)
 
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         ValueError,
         "vmap got inconsistent sizes for array axes to be mapped:\n"
         "the tree of axis sizes is:\n"
         r"\(10, \[2, 2\]\)"):
       api.vmap(h, in_axes=(0, 1))(X, [U, U])
 
-    with self.assertRaisesRegex(ValueError, "vmap got arg 0 of rank 0 but axis to be mapped 0"):
+    with self.assertRaisesRegex(
+        ValueError, "vmap got arg 0 of rank 0 but axis to be mapped 0"):
       # The mapped inputs cannot be scalars
       api.vmap(lambda x: x)(1.)
 
-    with self.assertRaisesRegexp(ValueError, re.escape("vmap got arg 0 of rank 1 but axis to be mapped [1. 2.]")):
+    with self.assertRaisesRegex(
+        ValueError, re.escape("vmap got arg 0 of rank 1 but axis to be mapped [1. 2.]")):
       api.vmap(lambda x: x, in_axes=(np.array([1., 2.]),))(np.array([1., 2.]))
 
-    with self.assertRaisesRegex(ValueError, "vmap must have at least one non-None in_axes"):
+    with self.assertRaisesRegex(
+        ValueError, "vmap must have at least one non-None in_axes"):
       # If the output is mapped, there must be a non-None in_axes
       api.vmap(lambda x: x, in_axes=None)(np.array([1., 2.]))
 
-    with self.assertRaisesRegexp(ValueError, "vmap got arg 0 of rank 1 but axis to be mapped 1"):
+    with self.assertRaisesRegex(
+        ValueError, "vmap got arg 0 of rank 1 but axis to be mapped 1"):
       api.vmap(lambda x: x, in_axes=1)(np.array([1., 2.]))
 
     # Error is: TypeError: only integer scalar arrays can be converted to a scalar index
-    with self.assertRaisesRegexp(ValueError, "axes specification must be a tree prefix of the corresponding value"):
+    with self.assertRaisesRegex(
+        ValueError, "axes specification must be a tree prefix of the corresponding value"):
       api.vmap(lambda x: x, in_axes=0, out_axes=(2, 3))(np.array([1., 2.]))
 
-    with self.assertRaisesRegexp(ValueError, "vmap has mapped output but out_axes is None"):
+    with self.assertRaisesRegex(
+        ValueError, "vmap has mapped output but out_axes is None"):
       # If the output is mapped, then there must be some out_axes specified
       api.vmap(lambda x: x, out_axes=None)(np.array([1., 2.]))
 

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -154,7 +154,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     A = lambda x: x
     b = jnp.zeros((2, 1))
     x0 = jnp.zeros((2,))
-    with self.assertRaisesRegexp(
+    with self.assertRaisesRegex(
         ValueError, "x0 and b must have matching shape"):
       jax.scipy.sparse.linalg.cg(A, b, x0)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1901,6 +1901,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
               jtu.tolerance(from_dtype, jtu.default_gradient_tolerance))
     args = (rng((2, 3), from_dtype),)
     convert_element_type = lambda x: lax.convert_element_type(x, to_dtype)
+    convert_element_type = jtu.ignore_warning(category=onp.ComplexWarning)(
+      convert_element_type)
     check_grads(convert_element_type, args, 2, ["fwd", "rev"], tol, tol, eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -3111,6 +3113,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       for padding in ["VALID", "SAME"]
       for rng_factory in [jtu.rand_small]))
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
+  @jtu.ignore_warning(message="Using reduced precision for gradient.*")
   def testSelectAndGatherAdd(self, dtype, padding, rng_factory):
     if jtu.device_under_test() == "tpu" and dtype == dtypes.bfloat16:
       raise SkipTest("bfloat16 _select_and_gather_add doesn't work on tpu")

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -62,6 +62,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (1000, 0, 0)]
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testCholesky(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
@@ -121,11 +122,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for nq in zip([2, 4, 6, 36], [(1, 2), (2, 2), (1, 2, 3), (3, 3, 1, 4)])
       for dtype in float_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testTensorsolve(self, m, nq, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if m == 23:
-      jtu.skip_on_mac_xla_bug()
     
     # According to numpy docs the shapes are as follows:
     # Coefficient tensor (a), of shape b.shape + Q. 
@@ -159,6 +159,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")
+  @jtu.skip_on_mac_linalg_bug()
   def testSlogdet(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
@@ -200,6 +201,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   # TODO(phawkins): enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.skip_on_devices("gpu", "tpu")
+  @jtu.skip_on_mac_linalg_bug()
   def testEig(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
@@ -228,11 +230,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   # TODO: enable when there is an eigendecomposition implementation
   # for GPU/TPU.
   @jtu.skip_on_devices("gpu", "tpu")
+  @jtu.skip_on_mac_linalg_bug()
   def testEigvals(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if shape == (50, 50) and dtype == onp.complex64:
-      jtu.skip_on_mac_xla_bug()
     n = shape[-1]
     args_maker = lambda: [rng(shape, dtype)]
     a, = args_maker()
@@ -615,10 +616,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 4), (200, 200), (7, 7, 7, 7)]
       for dtype in float_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testTensorinv(self, shape, dtype, rng_factory):
     _skip_if_unsupported_type(dtype)
-    if shape[0] > 100:
-      jtu.skip_on_mac_xla_bug()
     rng = rng_factory()
 
     def tensor_maker():
@@ -670,11 +670,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 4), (2, 5, 5), (200, 200), (5, 5, 5)]
       for dtype in float_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testInv(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if shape == (200, 200) and dtype == onp.float32:
-      jtu.skip_on_mac_xla_bug()
     if jtu.device_under_test() == "gpu" and shape == (200, 200):
       raise unittest.SkipTest("Test is flaky on GPU")
 
@@ -701,11 +700,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # SVD is not implemented on the TPU backend
+  @jtu.skip_on_mac_linalg_bug()
   def testPinv(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if shape == (7, 10000) and dtype in [onp.complex64, onp.float32]:
-      jtu.skip_on_mac_xla_bug()
     args_maker = lambda: [rng(shape, dtype)]
 
     self._CheckAgainstNumpy(onp.linalg.pinv, np.linalg.pinv, args_maker,
@@ -817,6 +815,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 5), (10, 5), (50, 50)]
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testLu(self, shape, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
@@ -877,11 +876,10 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for n in [1, 4, 5, 200]
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_mac_linalg_bug()
   def testLuFactor(self, n, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if n == 200 and dtype == onp.complex64:
-      jtu.skip_on_mac_xla_bug()
     args_maker = lambda: [rng((n, n), dtype)]
 
     x, = args_maker()
@@ -1102,11 +1100,10 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for n in [1, 4, 5, 20, 50, 100]
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_small]))
+  @jtu.skip_on_mac_linalg_bug()
   def testExpm(self, n, dtype, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
-    if n == 50 and dtype in [onp.complex64, onp.float32]:
-      jtu.skip_on_mac_xla_bug()
     args_maker = lambda: [rng((n, n), dtype)]
 
     osp_fun = lambda a: osp.linalg.expm(a)
@@ -1128,8 +1125,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     for n in [1, 4, 5, 20, 50, 100]
     for dtype in float_types + complex_types
   ))
+  @jtu.skip_on_mac_linalg_bug()
   def testIssue2131(self, n, dtype):
-    jtu.skip_on_mac_xla_bug()
     args_maker_zeros = lambda: [onp.zeros((n, n), dtype)]
     osp_fun = lambda a: osp.linalg.expm(a)
     jsp_fun = lambda a: jsp.linalg.expm(a)

--- a/tests/parallel_test.py
+++ b/tests/parallel_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import functools
 import itertools
 import unittest
 from unittest import SkipTest, skip
@@ -32,6 +32,9 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
+ignore_soft_pmap_warning = functools.partial(
+  jtu.ignore_warning, message="soft_pmap is an experimental.*")
+
 class PapplyTest(jtu.JaxTestCase):
 
   def testIdentity(self):
@@ -46,6 +49,7 @@ class PapplyTest(jtu.JaxTestCase):
     expected = onp.sin(onp.arange(3.))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSum(self):
     pfun, axis_name = _papply(lambda x: np.sum(x, axis=0))
 
@@ -59,6 +63,7 @@ class PapplyTest(jtu.JaxTestCase):
     expected = onp.sum(arg, axis=0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testMax(self):
     pfun, axis_name = _papply(lambda x: np.max(x, axis=0))
 
@@ -72,6 +77,7 @@ class PapplyTest(jtu.JaxTestCase):
     expected = onp.max(arg, axis=0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSelect(self):
     p = onp.arange(15).reshape((5, 3)) % 4 == 1
     f = onp.zeros((5, 3))
@@ -101,6 +107,7 @@ class PapplyTest(jtu.JaxTestCase):
     expected = fun(onp.arange(1., 5.))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testAdd(self):
     x = onp.array([[1, 2, 3], [4, 5, 6]])
     expected = x + x

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -61,6 +61,9 @@ def tearDownModule():
     os.environ["XLA_FLAGS"] = prev_xla_flags
   xla_bridge.get_backend.cache_clear()
 
+ignore_soft_pmap_warning = partial(
+  jtu.ignore_warning, message="soft_pmap is an experimental.*")
+
 
 class PmapTest(jtu.JaxTestCase):
   def _getMeshShape(self, device_mesh_shape):
@@ -434,7 +437,7 @@ class PmapTest(jtu.JaxTestCase):
     g = lambda: pmap(f, "i")(onp.arange(device_count))
     self.assertRaisesRegex(
       AssertionError,
-      "Given `perm` does not represent a real permutation: \[1.*\]", g)
+      "Given `perm` does not represent a real permutation: \\[1.*\\]", g)
 
   @jtu.skip_on_devices("cpu", "gpu")
   def testPpermuteWithZipObject(self):
@@ -772,6 +775,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = onp.swapaxes(x, 0, 2)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSoftPmapPsum(self):
     n = 4 * xla_bridge.device_count()
     def f(x):
@@ -780,6 +784,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = onp.ones(n) / n
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSoftPmapAxisIndex(self):
     n = 4 * xla_bridge.device_count()
     def f(x):
@@ -788,6 +793,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = 2 * onp.arange(n)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSoftPmapOfJit(self):
     n = 4 * xla_bridge.device_count()
     def f(x):
@@ -796,6 +802,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = 3 * onp.arange(n)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSoftPmapNested(self):
     n = 4 * xla_bridge.device_count()
 
@@ -809,6 +816,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = onp.arange(n ** 2).reshape(n, n).T
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testGradOfSoftPmap(self):
     n = 4 * xla_bridge.device_count()
 
@@ -820,6 +828,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = onp.repeat(onp.arange(n)[:, None], n, axis=1)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_soft_pmap_warning()
   def testSoftPmapDevicePersistence(self):
     device_count = xla_bridge.device_count()
     shape = (2 * 2 * device_count, 2, 3)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -175,7 +175,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       for p in [0.1, 0.5, 0.9]
       for dtype in [onp.float32, onp.float64]))
   def testBernoulli(self, p, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     p = onp.array(p, dtype=dtype)
     rand = lambda key, p: random.bernoulli(key, p, (10000,))
@@ -194,7 +193,6 @@ class LaxRandomTest(jtu.JaxTestCase):
     for sample_shape in [(10000,), (5000, 2)]
     for dtype in [onp.float32, onp.float64]))
   def testCategorical(self, p, axis, dtype, sample_shape):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     p = onp.array(p, dtype=dtype)
     logits = onp.log(p) - 42 # test unnormalized
@@ -245,7 +243,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
       for dtype in [onp.float32, onp.float64]))
   def testCauchy(self, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     rand = lambda key: random.cauchy(key, (10000,), dtype)
     crand = api.jit(rand)
@@ -264,7 +261,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       ]
       for dtype in [onp.float32, onp.float64]))
   def testDirichlet(self, alpha, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     rand = lambda key, alpha: random.dirichlet(key, alpha, (10000,), dtype)
     crand = api.jit(rand)
@@ -282,7 +278,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
       for dtype in [onp.float32, onp.float64]))
   def testExponential(self, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     rand = lambda key: random.exponential(key, (10000,), dtype)
     crand = api.jit(rand)
@@ -299,7 +294,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       for a in [0.1, 1., 10.]
       for dtype in [onp.float32, onp.float64]))
   def testGamma(self, a, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     rand = lambda key, a: random.gamma(key, a, (10000,), dtype)
     crand = api.jit(rand)
@@ -346,7 +340,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
       for dtype in [onp.float32, onp.float64]))
   def testGumbel(self, dtype):
-    jtu.skip_on_mac_xla_bug()
     key = random.PRNGKey(0)
     rand = lambda key: random.gumbel(key, (10000,), dtype)
     crand = api.jit(rand)
@@ -428,8 +421,8 @@ class LaxRandomTest(jtu.JaxTestCase):
        "dim": dim, "dtype": dtype}
       for dim in [1, 3, 5]
       for dtype in [onp.float32, onp.float64]))
+  @jtu.skip_on_mac_linalg_bug()
   def testMultivariateNormal(self, dim, dtype):
-    jtu.skip_on_mac_xla_bug()
     r = onp.random.RandomState(dim)
     mean = r.randn(dim)
     cov_factor = r.randn(dim, dim)
@@ -453,9 +446,9 @@ class LaxRandomTest(jtu.JaxTestCase):
       # eigenvectors follow a standard normal distribution.
       self._CheckKolmogorovSmirnovCDF(whitened.ravel(), scipy.stats.norm().cdf)
 
+  @jtu.skip_on_mac_linalg_bug()
   def testMultivariateNormalCovariance(self):
     # test code based on https://github.com/google/jax/issues/1869
-    jtu.skip_on_mac_xla_bug()
     N = 100000
     cov = np.array([[ 0.19,  0.00, -0.13,  0.00],
                    [  0.00,  0.29,  0.00, -0.23],

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -14,10 +14,12 @@
 
 
 import collections
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
+import jax.lib
 from jax import test_util as jtu
 from jax import tree_util
 
@@ -157,11 +159,13 @@ class TreeTest(jtu.JaxTestCase):
                            ((3, {"foo": "bar"}), (4, 7), (5, [5, 6]))))
 
   @parameterized.parameters(*TREES)
+  @unittest.skipIf(jax.lib.version < (0, 1, 44), "Jaxlib too old")
   def testAllLeavesWithTrees(self, tree):
     leaves = tree_util.tree_leaves(tree)
     self.assertTrue(tree_util.all_leaves(leaves))
     self.assertFalse(tree_util.all_leaves([tree]))
 
+  @unittest.skipIf(jax.lib.version < (0, 1, 44), "Jaxlib too old")
   @parameterized.parameters(*LEAVES)
   def testAllLeavesWithLeaves(self, leaf):
     self.assertTrue(tree_util.all_leaves([leaf]))


### PR DESCRIPTION
Remove global warning suppression in travis.yml. Instead add a pytest.ini that converts warnings to errors, with the exception of a whitelist.
Either fix or locally suppress warnings in tests.

Also fix crashes on Mac related to a preexisting linear algebra bug.

Fixes #1784