### PR TITLE
Add numpy and scipy convolution wrappers

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -659,6 +659,44 @@ def trunc(x):
   return where(lax.lt(x, lax._const(x, 0)), lax.ceil(x), lax.floor(x))
 
 
+def _conv(x, y, mode, op):
+  if issubdtype(x.dtype, complexfloating) or issubdtype(y.dtype, complexfloating):
+    raise NotImplementedError(f"{op}() does not support complex inputs")
+  if ndim(x) != 1 or ndim(y) != 1:
+    raise ValueError(f"{op}() only support 1-dimensional inputs.")
+  x, y = _promote_dtypes_inexact(x, y)
+  
+  out_order = slice(None)
+  if len(x) < len(y):
+    x, y = y, x
+    if op == "correlate":
+      out_order = slice(None, None, -1)
+  if op == 'convolve':
+    y = y[::-1]
+
+  if mode == 'valid':
+    padding = [(0, 0)]
+  elif mode == 'same':
+    padding = [(y.shape[0] // 2, y.shape[0] - y.shape[0] // 2 - 1)]
+  elif mode == 'full':
+    padding = [(y.shape[0] - 1, y.shape[0] - 1)]
+  else:
+    raise ValueError("mode must be one of ['full', 'same', 'valid']")
+
+  result = lax.conv_general_dilated(x[None, None, :], y[None, None, :], (1,), padding)
+  return result[0, 0, out_order]
+
+
+@_wraps(onp.convolve)
+def convolve(x, y, mode='full'):
+  return _conv(x, y, mode, 'convolve')
+
+
+@_wraps(onp.correlate)
+def correlate(x, y, mode='valid'):
+  return _conv(x, y, mode, 'correlate')
+
+
 def _normalize_float(x):
     info = finfo(_dtype(x))
     cond = lax.abs(x) < info.tiny

--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -14,6 +14,7 @@
 
 from . import linalg
 from . import ndimage
+from . import signal
 from . import sparse
 from . import special
 from . import stats

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -66,14 +66,10 @@ def convolve(in1, in2, mode='full', method='auto'):
 
 @_wraps(osp_signal.convolve2d)
 def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
-  if mode == 'same':
-    # TODO: correctly handle 'same' padding in convolve2d. Scipy handles this differently
-    # than the 1D case, and the results are difficult to replicate.
-    raise NotImplementedError("convolve2d(): mode='same' not implemented")
   if boundary != 'fill' or fillvalue != 0:
     raise NotImplementedError("convolve2d() only supports boundary='fill', fillvalue=0")
   if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
-    raise NotImplementedError("convolve() does not support complex inputs")
+    raise NotImplementedError("convolve2d() does not support complex inputs")
   if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
     raise ValueError(f"convolve2d() only supports 2-dimensional inputs.")
   return _convolve_nd(in1, in2, mode)
@@ -92,13 +88,10 @@ def correlate(in1, in2, mode='full', method='auto'):
 
 @_wraps(osp_signal.correlate)
 def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
-  if mode == 'same':
-    # Handling of padding in convolve2d mode='same' is difficult to replicate.
-    raise NotImplementedError("correlate2d(): mode='same' not implemented")
   if boundary != 'fill' or fillvalue != 0:
     raise NotImplementedError("correlate2d() only supports boundary='fill', fillvalue=0")
   if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
-    raise NotImplementedError("correlate() does not support complex inputs")
+    raise NotImplementedError("correlate2d() does not support complex inputs")
   if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
     raise ValueError("correlate2d() only supports {ndim}-dimensional inputs.")
-  return _convolve_nd(in1, in2[::-1, ::-1], mode)
+  return _convolve_nd(in1[::-1, ::-1], in2, mode)[::-1, ::-1]

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -1,0 +1,104 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.signal as osp_signal
+
+from .. import lax
+from ..numpy import lax_numpy as jnp
+from ..numpy.lax_numpy import (_wraps, _promote_dtypes_inexact)
+
+
+# Note: we do not re-use the code from jax.numpy.convolve here, because the handling
+# of padding differs slightly between the two implementations (particularly for
+# mode='same').
+def _convolve_nd(in1, in2, mode):
+  if mode not in ["full", "same", "valid"]:
+    raise ValueError("mode must be one of ['full', 'same', 'valid']")
+  if in1.ndim != in2.ndim:
+    raise ValueError("in1 and in2 must have the same number of dimensions")
+  in1, in2 = _promote_dtypes_inexact(in1, in2)
+
+  no_swap = all(s1 >= s2 for s1, s2 in zip(in1.shape, in2.shape))
+  swap = all(s1 <= s2 for s1, s2 in zip(in1.shape, in2.shape))
+  if not (no_swap or swap):
+    raise ValueError("One input must be smaller than the other in every dimension.")
+
+  shape_o = in2.shape
+  if swap:
+    in1, in2 = in2, in1
+  shape = in2.shape
+  in2 = in2[tuple(slice(None, None, -1) for s in shape)]
+
+  if mode == 'valid':
+    padding = [(0, 0) for s in shape]
+  elif mode == 'same':
+    padding = [(s - 1 - (s_o - 1) // 2, s - s_o + (s_o - 1) // 2)
+               for (s, s_o) in zip(shape, shape_o)]
+  elif mode == 'full':
+    padding = [(s - 1, s - 1) for s in shape]
+
+  strides = tuple(1 for s in shape)
+  result = lax.conv_general_dilated(in1[None, None], in2[None, None], strides, padding)
+  return result[0, 0]
+
+
+@_wraps(osp_signal.convolve)
+def convolve(in1, in2, mode='full', method='auto'):
+  if method != 'auto':
+    warnings.warn("convolve() ignores method argument")
+  if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
+    raise NotImplementedError("convolve() does not support complex inputs")
+  if jnp.ndim(in1) != 1 or jnp.ndim(in2) != 1:
+    raise ValueError(f"convolve() only supports 1-dimensional inputs.")
+  return _convolve_nd(in1, in2, mode)
+
+
+@_wraps(osp_signal.convolve2d)
+def convolve2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
+  if mode == 'same':
+    # TODO: correctly handle 'same' padding in convolve2d. Scipy handles this differently
+    # than the 1D case, and the results are difficult to replicate.
+    raise NotImplementedError("convolve2d(): mode='same' not implemented")
+  if boundary != 'fill' or fillvalue != 0:
+    raise NotImplementedError("convolve2d() only supports boundary='fill', fillvalue=0")
+  if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
+    raise NotImplementedError("convolve() does not support complex inputs")
+  if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
+    raise ValueError(f"convolve2d() only supports 2-dimensional inputs.")
+  return _convolve_nd(in1, in2, mode)
+
+
+@_wraps(osp_signal.correlate)
+def correlate(in1, in2, mode='full', method='auto'):
+  if method != 'auto':
+    warnings.warn("correlate() ignores method argument")
+  if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
+    raise NotImplementedError("correlate() does not support complex inputs")
+  if jnp.ndim(in1) != 1 or jnp.ndim(in2) != 1:
+    raise ValueError("correlate() only supports {ndim}-dimensional inputs.")
+  return _convolve_nd(in1, in2[::-1], mode)
+
+
+@_wraps(osp_signal.correlate)
+def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0):
+  if mode == 'same':
+    # Handling of padding in convolve2d mode='same' is difficult to replicate.
+    raise NotImplementedError("correlate2d(): mode='same' not implemented")
+  if boundary != 'fill' or fillvalue != 0:
+    raise NotImplementedError("correlate2d() only supports boundary='fill', fillvalue=0")
+  if jnp.issubdtype(in1.dtype, jnp.complexfloating) or jnp.issubdtype(in2.dtype, jnp.complexfloating):
+    raise NotImplementedError("correlate() does not support complex inputs")
+  if jnp.ndim(in1) != 2 or jnp.ndim(in2) != 2:
+    raise ValueError("correlate2d() only supports {ndim}-dimensional inputs.")
+  return _convolve_nd(in1, in2[::-1, ::-1], mode)

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -76,7 +76,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_default,
        "jsp_op": getattr(jsp_signal, op),
        "osp_op": getattr(osp_signal, op)}
-      for mode in ['full', 'valid']
+      for mode in ['full', 'same', 'valid']
       for op in ['convolve2d', 'correlate2d']
       for dtype in default_dtypes
       for xshape in twodim_shapes

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -1,0 +1,95 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from functools import partial
+
+from absl.testing import absltest, parameterized
+
+import numpy as onp
+
+from jax import test_util as jtu
+import jax.scipy.signal as jsp_signal
+import scipy.signal as osp_signal
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+onedim_shapes = [(1,), (2,), (5,), (10,)]
+twodim_shapes = [(1, 1), (2, 2), (2, 3), (3, 4), (4, 4)]
+
+
+def supported_dtypes(dtypes):
+  return [t for t in dtypes if t in jtu.supported_dtypes()]
+
+
+float_dtypes = supported_dtypes([onp.float32, onp.float64])
+int_dtypes = [onp.int32, onp.int64]
+default_dtypes = float_dtypes + int_dtypes
+
+
+class LaxBackedScipySignalTests(jtu.JaxTestCase):
+  """Tests for LAX-backed scipy.stats implementations"""
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "op={}_xshape=[{}]_yshape=[{}]_mode={}".format(
+          op,
+          jtu.format_shape_dtype_string(xshape, dtype),
+          jtu.format_shape_dtype_string(yshape, dtype),
+          mode),
+       "xshape": xshape, "yshape": yshape, "dtype": dtype, "mode": mode,
+       "rng_factory": jtu.rand_default,
+       "jsp_op": getattr(jsp_signal, op),
+       "osp_op": getattr(osp_signal, op)}
+      for mode in ['full', 'same', 'valid']
+      for op in ['convolve', 'correlate']
+      for dtype in default_dtypes
+      for xshape in onedim_shapes
+      for yshape in onedim_shapes))
+  def testConvolutions(self, xshape, yshape, dtype, mode, rng_factory, jsp_op, osp_op):
+    rng = rng_factory()
+    args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
+    osp_fun = partial(osp_op, mode=mode)
+    jsp_fun = partial(jsp_op, mode=mode)
+    tol = {onp.float16: 1e-2}
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False, tol=tol)
+    self._CompileAndCheck(jsp_fun, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "op={}_xshape=[{}]_yshape=[{}]_mode={}".format(
+          op,
+          jtu.format_shape_dtype_string(xshape, dtype),
+          jtu.format_shape_dtype_string(yshape, dtype),
+          mode),
+       "xshape": xshape, "yshape": yshape, "dtype": dtype, "mode": mode,
+       "rng_factory": jtu.rand_default,
+       "jsp_op": getattr(jsp_signal, op),
+       "osp_op": getattr(osp_signal, op)}
+      for mode in ['full', 'valid']
+      for op in ['convolve2d', 'correlate2d']
+      for dtype in default_dtypes
+      for xshape in twodim_shapes
+      for yshape in twodim_shapes))
+  def testConvolutions2D(self, xshape, yshape, dtype, mode, rng_factory, jsp_op, osp_op):
+    rng = rng_factory()
+    args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
+    osp_fun = partial(osp_op, mode=mode)
+    jsp_fun = partial(jsp_op, mode=mode)
+    tol = {onp.float16: 1e-2}
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, check_dtypes=False, tol=tol)
+    self._CompileAndCheck(jsp_fun, args_maker, check_dtypes=True)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Replaces #2662; incorporates some ideas from #1831 

I'm punting on ``mode='same'`` from scipy.signal.convolve2d, because I'm having trouble replicating the internal logic it uses to pad the inputs. In particular, the behavior is not internally consistent between 1d and 2d versions of the function:
```python
from scipy import signal                                                               
x = np.arange(1, 5) 
signal.correlate(x, x, mode='same')                                                   
# array([11, 20, 30, 20])
signal.correlate2d(x[None, :], x[None, :], mode='same')                                
# array([[20, 30, 20, 11]])
```
Edit: figured it out! All modes implemented!