### PR TITLE
Improve error message for indexing into an empty dimension

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3140,6 +3140,9 @@ def _index_to_gather(x_shape, idx):
     # Handle basic int indexes.
     if (isinstance(abstract_i, ConcreteArray) or
         isinstance(abstract_i, ShapedArray)) and _int(abstract_i):
+      if x_shape[x_axis] == 0:
+        # XLA gives error when indexing into an axis of size 0
+        raise IndexError(f"index is out of bounds for axis {x_axis} with size 0")
       i = _normalize_index(i, x_shape[x_axis])
       i = lax.convert_element_type(i, index_dtype)
       i = broadcast_to(i, tuple(gather_indices.shape[:-1]) + (1,))


### PR DESCRIPTION
It seems that JAX (and XLA) are a lot more forgiving for index-out-of-bounds,
except for the case when the dimension has size 0. In this case give a similar
IndexError message as numpy, instead of the current one:

   RuntimeError: Invalid argument: Slice size at index 0 in gather op is out
   of range, must be within [0, 1), got 1.:
   This is a bug in JAX's shape-checking rules; please report it!

Issue: #2671