### PR TITLE
Syntactic sugar for indexed update functions.

### DIFF
--- a/docs/jax.ops.rst
+++ b/docs/jax.ops.rst
@@ -24,6 +24,27 @@ pure alternatives, namely :func:`jax.ops.index_update` and its relatives.
     index_min
     index_max
 
+
+Syntactic sugar for indexed update operators
+--------------------------------------------
+
+JAX also provides an alternate syntax for these indexed update operators.
+Specifically, JAX ndarray types have a property ``at``, which can be used as
+follows (where ``idx`` can be an arbitrary index expression).
+
+====================  ===================================================
+Alternate syntax      Equivalent expression
+====================  ===================================================
+``x.at[idx].set(y)``  ``jax.ops.index_update(x, jax.ops_index[idx], y)``
+``x.at[idx].add(y)``  ``jax.ops.index_add(x, jax.ops_index[idx], y)``
+``x.at[idx].mul(y)``  ``jax.ops.index_mul(x, jax.ops_index[idx], y)``
+``x.at[idx].min(y)``  ``jax.ops.index_min(x, jax.ops_index[idx], y)``
+``x.at[idx].max(y)``  ``jax.ops.index_max(x, jax.ops_index[idx], y)``
+====================  ===================================================
+
+Note that none of these expressions modify the original `x`; instead they return
+a modified copy of `x`.
+
 Other operators
 ---------------
 

--- a/docs/jax.ops.rst
+++ b/docs/jax.ops.rst
@@ -35,11 +35,11 @@ follows (where ``idx`` can be an arbitrary index expression).
 ====================  ===================================================
 Alternate syntax      Equivalent expression
 ====================  ===================================================
-``x.at[idx].set(y)``  ``jax.ops.index_update(x, jax.ops_index[idx], y)``
-``x.at[idx].add(y)``  ``jax.ops.index_add(x, jax.ops_index[idx], y)``
-``x.at[idx].mul(y)``  ``jax.ops.index_mul(x, jax.ops_index[idx], y)``
-``x.at[idx].min(y)``  ``jax.ops.index_min(x, jax.ops_index[idx], y)``
-``x.at[idx].max(y)``  ``jax.ops.index_max(x, jax.ops_index[idx], y)``
+``x.at[idx].set(y)``  ``jax.ops.index_update(x, jax.ops.index[idx], y)``
+``x.at[idx].add(y)``  ``jax.ops.index_add(x, jax.ops.index[idx], y)``
+``x.at[idx].mul(y)``  ``jax.ops.index_mul(x, jax.ops.index[idx], y)``
+``x.at[idx].min(y)``  ``jax.ops.index_min(x, jax.ops.index[idx], y)``
+``x.at[idx].max(y)``  ``jax.ops.index_max(x, jax.ops.index[idx], y)``
 ====================  ===================================================
 
 Note that none of these expressions modify the original `x`; instead they return

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3692,61 +3692,100 @@ def _unstack(x):
 setattr(DeviceArray, "_unstack", _unstack)
 
 
-# Syntactic sugar for scatter operations
+# Syntactic sugar for scatter operations.
 class IndexUpdateHelper(object):
-  """Helper object to call indexed update functions.
+  # Note: this docstring will appear as the docstring for the `at` property.
+  """Indexable helper object to call indexed update functions.
 
-  This makes it possible to do :code:`x.update[idx](y)` instead of
-  :code:`jax.ops.index_update(x, jax.ops.index[idx], y)`.
+  The `at` property is syntactic sugar for calling the indexed update functions
+  defined in :mod:`jax.ops`, and acts as a pure equivalent of in-place
+  modificatons.
+
+  In particular:
+  - :code:`x = x.at[idx].set(y)` is a pure equivalent of :code:`x[idx] = y`.
+  - :code:`x = x.at[idx].add(y)` is a pure equivalent of :code:`x[idx] += y`.
+  - :code:`x = x.at[idx].min(y)` is a pure equivalent of
+      :code:`x[idx] = minimum(x[idx], y)`.
+  - :code:`x = x.at[idx].max(y)` is a pure equivalent of
+      :code:`x[idx] = maximum(x[idx], y)`.
   """
-  __slots__ = ("index_method", "array")
+  __slots__ = ("array",)
 
-  def __init__(self, index_method, array):
-    self.index_method = index_method
+  def __init__(self, array):
     self.array = array
 
   def __getitem__(self, index):
-    return partial(self.index_method, self.array, index)
+    return IndexUpdateRef(self.array, index)
 
   def __repr__(self):
-    return f"IndexUpdateHelper({self.index_method}, {self.array})"
+    return f"IndexUpdateHelper({repr(self.array)})"
 
 
-def _make_index_update_property(property_name, numpy_equiv, method_fn):
-  fn = partial(IndexUpdateHelper, method_fn)
-  fn.__doc__ = textwrap.dedent(f"""\
-      Pure equivalent of :code:`{numpy_equiv}`.
+class IndexUpdateRef(object):
+  """Helper object to call indexed update functions for an (advanced) index.
 
-      :code:`x.{property_name}[idx](y)` is syntactic sugar for
-      :code:`jax.ops.{method_fn.__name__}(x, jax.ops.index[idx], y)`, and
-      returns the value of `x` that would result from the NumPy-style
-      :mod:`indexed assignment <numpy.doc.indexing>` :code:`{numpy_equiv}`.
+  This object references a source array and a specific indexer into that array.
+  Methods on this object return copies of the source array that have been
+  modified at the positions specified by the indexer.
+  """
+  __slots__ = ("array", "index")
 
-      See :mod:`jax.ops` for details.""")
-  return fn
+  def __init__(self, array, index):
+    self.array = array
+    self.index = index
 
+  def __repr__(self):
+    return f"IndexUpdateRef({repr(self.array)}, {repr(self.index)})"
 
-_update_helper = _make_index_update_property("update", "x[idx] = y",
-                                            ops.index_update)
-setattr(DeviceArray, "update", property(_update_helper))
-setattr(ShapedArray, "update", core.aval_property(_update_helper))
+  def set(self, values):
+    """Pure equivalent of :code:`x[idx] = y`.
 
-_add_helper = _make_index_update_property("add", "x[idx] += y", ops.index_add)
-setattr(DeviceArray, "add", property(_add_helper))
-setattr(ShapedArray, "add", core.aval_property(_add_helper))
+    :code:`x.at[idx].set(y)` is syntactic sugar for
+    :code:`jax.ops.index_update(x, jax.ops.index[idx], y)`, and
+    returns the value of `x` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] = y`.
 
-_update_add_helper = _make_index_update_property("update_add", "x[idx] += y",
-                                                ops.index_add)
-setattr(DeviceArray, "update_add", property(_update_add_helper))
-setattr(ShapedArray, "update_add", core.aval_property(_update_add_helper))
+    See :mod:`jax.ops` for details.
+    """
+    return ops.index_update(self.array, self.index, values)
 
-_update_min_helper = _make_index_update_property(
-    "update_min", "x[idx] = minimum(x[idx], y)", ops.index_min)
-setattr(DeviceArray, "update_min", property(_update_min_helper))
-setattr(ShapedArray, "update_min", core.aval_property(_update_min_helper))
+  def add(self, values):
+    """Pure equivalent of :code:`x[idx] += y`.
 
-_update_max_helper = _make_index_update_property(
-    "update_max", "x[idx] = maximum(x[idx], y)", ops.index_max)
-setattr(DeviceArray, "update_max", property(_update_max_helper))
-setattr(ShapedArray, "update_max", core.aval_property(_update_max_helper))
+    :code:`x.at[idx].add(y)` is syntactic sugar for
+    :code:`jax.ops.index_add(x, jax.ops.index[idx], y)`, and
+    returns the value of `x` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] += y`.
 
+    See :mod:`jax.ops` for details.
+    """
+    return ops.index_add(self.array, self.index, values)
+
+  def min(self, values):
+    """Pure equivalent of :code:`x[idx] = minimum(x[idx], y)`.
+
+    :code:`x.at[idx].min(y)` is syntactic sugar for
+    :code:`jax.ops.index_min(x, jax.ops.index[idx], y)`, and
+    returns the value of `x` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>`
+    :code:`x[idx] = minimum(x[idx], y)`.
+
+    See :mod:`jax.ops` for details.
+    """
+    return ops.index_min(self.array, self.index, values)
+
+  def max(self, values):
+    """Pure equivalent of :code:`x[idx] = maximum(x[idx], y)`.
+
+    :code:`x.at[idx].max(y)` is syntactic sugar for
+    :code:`jax.ops.index_max(x, jax.ops.index[idx], y)`, and
+    returns the value of `x` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>`
+    :code:`x[idx] = maximum(x[idx], y)`.
+
+    See :mod:`jax.ops` for details.
+    """
+    return ops.index_max(self.array, self.index, values)
+
+setattr(DeviceArray, "at", property(IndexUpdateHelper))
+setattr(ShapedArray, "at", core.aval_property(IndexUpdateHelper))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3791,7 +3791,7 @@ setattr(DeviceArray, "_unstack", _unstack)
 
 
 # Syntactic sugar for scatter operations.
-class IndexUpdateHelper(object):
+class _IndexUpdateHelper:
   # Note: this docstring will appear as the docstring for the `at` property.
   """Indexable helper object to call indexed update functions.
 
@@ -3800,13 +3800,13 @@ class IndexUpdateHelper(object):
   modificatons.
 
   In particular:
-  - :code:`x = x.at[idx].set(y)` is a pure equivalent of :code:`x[idx] = y`.
-  - :code:`x = x.at[idx].add(y)` is a pure equivalent of :code:`x[idx] += y`.
-  - :code:`x = x.at[idx].mul(y)` is a pure equivalent of :code:`x[idx] *= y`.
-  - :code:`x = x.at[idx].min(y)` is a pure equivalent of
-      :code:`x[idx] = minimum(x[idx], y)`.
-  - :code:`x = x.at[idx].max(y)` is a pure equivalent of
-      :code:`x[idx] = maximum(x[idx], y)`.
+  - ``x = x.at[idx].set(y)`` is a pure equivalent of ``x[idx] = y``.
+  - ``x = x.at[idx].add(y)`` is a pure equivalent of ``x[idx] += y``.
+  - ``x = x.at[idx].mul(y)`` is a pure equivalent of ``x[idx] *= y``.
+  - ``x = x.at[idx].min(y)`` is a pure equivalent of
+      ``x[idx] = minimum(x[idx], y)``.
+  - ``x = x.at[idx].max(y)`` is a pure equivalent of
+      ``x[idx] = maximum(x[idx], y)``.
   """
   __slots__ = ("array",)
 
@@ -3814,13 +3814,13 @@ class IndexUpdateHelper(object):
     self.array = array
 
   def __getitem__(self, index):
-    return IndexUpdateRef(self.array, index)
+    return _IndexUpdateRef(self.array, index)
 
   def __repr__(self):
-    return f"IndexUpdateHelper({repr(self.array)})"
+    return f"_IndexUpdateHelper({repr(self.array)})"
 
 
-class IndexUpdateRef(object):
+class _IndexUpdateRef:
   """Helper object to call indexed update functions for an (advanced) index.
 
   This object references a source array and a specific indexer into that array.
@@ -3834,69 +3834,69 @@ class IndexUpdateRef(object):
     self.index = index
 
   def __repr__(self):
-    return f"IndexUpdateRef({repr(self.array)}, {repr(self.index)})"
+    return f"_IndexUpdateRef({repr(self.array)}, {repr(self.index)})"
 
   def set(self, values):
-    """Pure equivalent of :code:`x[idx] = y`.
+    """Pure equivalent of ``x[idx] = y``.
 
-    :code:`x.at[idx].set(y)` is syntactic sugar for
-    :code:`jax.ops.index_update(x, jax.ops.index[idx], y)`, and
-    returns the value of `x` that would result from the NumPy-style
-    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] = y`.
+    ``x.at[idx].set(y)`` is syntactic sugar for
+    ``jax.ops.index_update(x, jax.ops.index[idx], y)``, and
+    returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] = y``.
 
     See :mod:`jax.ops` for details.
     """
     return ops.index_update(self.array, self.index, values)
 
   def add(self, values):
-    """Pure equivalent of :code:`x[idx] += y`.
+    """Pure equivalent of ``x[idx] += y``.
 
-    :code:`x.at[idx].add(y)` is syntactic sugar for
-    :code:`jax.ops.index_add(x, jax.ops.index[idx], y)`, and
-    returns the value of `x` that would result from the NumPy-style
-    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] += y`.
+    ``x.at[idx].add(y)`` is syntactic sugar for
+    ``jax.ops.index_add(x, jax.ops.index[idx], y)``, and
+    returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] += y``.
 
     See :mod:`jax.ops` for details.
     """
     return ops.index_add(self.array, self.index, values)
 
   def mul(self, values):
-    """Pure equivalent of :code:`x[idx] += y`.
+    """Pure equivalent of ``x[idx] += y``.
 
-    :code:`x.at[idx].mul(y)` is syntactic sugar for
-    :code:`jax.ops.index_mul(x, jax.ops.index[idx], y)`, and
-    returns the value of `x` that would result from the NumPy-style
-    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] *= y`.
+    ``x.at[idx].mul(y)`` is syntactic sugar for
+    ``jax.ops.index_mul(x, jax.ops.index[idx], y)``, and
+    returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] *= y``.
 
     See :mod:`jax.ops` for details.
     """
     return ops.index_mul(self.array, self.index, values)
 
   def min(self, values):
-    """Pure equivalent of :code:`x[idx] = minimum(x[idx], y)`.
+    """Pure equivalent of ``x[idx] = minimum(x[idx], y)``.
 
-    :code:`x.at[idx].min(y)` is syntactic sugar for
-    :code:`jax.ops.index_min(x, jax.ops.index[idx], y)`, and
-    returns the value of `x` that would result from the NumPy-style
-    :mod:`indexed assignment <numpy.doc.indexing>`
-    :code:`x[idx] = minimum(x[idx], y)`.
+    ``x.at[idx].min(y)`` is syntactic sugar for
+    ``jax.ops.index_min(x, jax.ops.index[idx], y)``, and
+    returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>`
+    ``x[idx] = minimum(x[idx], y)``.
 
     See :mod:`jax.ops` for details.
     """
     return ops.index_min(self.array, self.index, values)
 
   def max(self, values):
-    """Pure equivalent of :code:`x[idx] = maximum(x[idx], y)`.
+    """Pure equivalent of ``x[idx] = maximum(x[idx], y)``.
 
-    :code:`x.at[idx].max(y)` is syntactic sugar for
-    :code:`jax.ops.index_max(x, jax.ops.index[idx], y)`, and
-    returns the value of `x` that would result from the NumPy-style
-    :mod:`indexed assignment <numpy.doc.indexing>`
-    :code:`x[idx] = maximum(x[idx], y)`.
+    ``x.at[idx].max(y)`` is syntactic sugar for
+    ``jax.ops.index_max(x, jax.ops.index[idx], y)``, and
+    returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>`
+    ``x[idx] = maximum(x[idx], y)``.
 
     See :mod:`jax.ops` for details.
     """
     return ops.index_max(self.array, self.index, values)
 
-setattr(DeviceArray, "at", property(IndexUpdateHelper))
-setattr(ShapedArray, "at", core.aval_property(IndexUpdateHelper))
+setattr(DeviceArray, "at", property(_IndexUpdateHelper))
+setattr(ShapedArray, "at", core.aval_property(_IndexUpdateHelper))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3803,6 +3803,7 @@ class IndexUpdateHelper(object):
   In particular:
   - :code:`x = x.at[idx].set(y)` is a pure equivalent of :code:`x[idx] = y`.
   - :code:`x = x.at[idx].add(y)` is a pure equivalent of :code:`x[idx] += y`.
+  - :code:`x = x.at[idx].mul(y)` is a pure equivalent of :code:`x[idx] *= y`.
   - :code:`x = x.at[idx].min(y)` is a pure equivalent of
       :code:`x[idx] = minimum(x[idx], y)`.
   - :code:`x = x.at[idx].max(y)` is a pure equivalent of
@@ -3859,6 +3860,18 @@ class IndexUpdateRef(object):
     See :mod:`jax.ops` for details.
     """
     return ops.index_add(self.array, self.index, values)
+
+  def mul(self, values):
+    """Pure equivalent of :code:`x[idx] += y`.
+
+    :code:`x.at[idx].mul(y)` is syntactic sugar for
+    :code:`jax.ops.index_mul(x, jax.ops.index[idx], y)`, and
+    returns the value of `x` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>` :code:`x[idx] *= y`.
+
+    See :mod:`jax.ops` for details.
+    """
+    return ops.index_mul(self.array, self.index, values)
 
   def min(self, values):
     """Pure equivalent of :code:`x[idx] = minimum(x[idx], y)`.

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -32,7 +32,6 @@ import itertools
 import os
 import re
 import string
-import textwrap
 import types
 from typing import Tuple
 import warnings

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -846,6 +846,7 @@ class UpdateOps(enum.Enum):
     return {
       UpdateOps.UPDATE: x.at[indexer].set,
       UpdateOps.ADD: x.at[indexer].add,
+      UpdateOps.MUL: x.at[indexer].mul,
       UpdateOps.MIN: x.at[indexer].min,
       UpdateOps.MAX: x.at[indexer].max,
     }[op](y)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -831,52 +831,69 @@ class UpdateOps(enum.Enum):
       UpdateOps.MAX: ops.index_max,
     }[op](x, indexer, y)
 
+  def sugar_fn(op, indexer, x, y):
+    x = jnp.array(x)
+    return {
+      UpdateOps.UPDATE: x.update,
+      UpdateOps.ADD: x.update_add,
+      UpdateOps.MIN: x.update_min,
+      UpdateOps.MAX: x.update_max,
+    }[op][indexer](y)
+
 
 class IndexedUpdateTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list({
-      "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
+      "testcase_name": "{}_inshape={}_indexer={}_update={}_sugared={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
-          jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
+          jtu.format_shape_dtype_string(update_shape, update_dtype), sugared, op.name),
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
-       "op": op
+       "op": op, "sugared": sugared
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for op in UpdateOps
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, update_shape, update_dtype,
-                         rng_factory, indexer, op):
+                         rng_factory, indexer, sugared, op):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
-    jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
+    if sugared:
+      jax_fn = lambda x, y: UpdateOps.sugar_fn(op, indexer, x, y)
+    else:
+      jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
     self._CheckAgainstNumpy(onp_fn, jax_fn, args_maker, check_dtypes=True)
     self._CompileAndCheck(jax_fn, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list({
-      "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
+      "testcase_name": "{}_inshape={}_indexer={}_update={}_sugared={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
-          jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
+          jtu.format_shape_dtype_string(update_shape, update_dtype), sugared, op.name),
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
-       "op": op
+       "op": op, "sugared": sugared
   } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
-                           rng_factory, indexer, op):
+                           rng_factory, indexer, sugared, op):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
-    jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
+    if sugared:
+      jax_fn = lambda x, y: UpdateOps.sugar_fn(op, indexer, x, y)
+    else:
+      jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
     self._CheckAgainstNumpy(onp_fn, jax_fn, args_maker, check_dtypes=True)
     self._CompileAndCheck(jax_fn, args_maker, check_dtypes=True)
 
@@ -886,20 +903,24 @@ class IndexedUpdateTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
-       "op": op
+       "op": op, "sugared": sugared
   } for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
     for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
     for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testMixedAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
-                           rng_factory, indexer, op):
+                                rng_factory, indexer, sugared, op):
     rng = rng_factory()
     args_maker = lambda: [rng(shape, dtype), rng(update_shape, update_dtype)]
     onp_fn = lambda x, y: UpdateOps.onp_fn(op, indexer, x, y)
-    jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
+    if sugared:
+      jax_fn = lambda x, y: UpdateOps.sugar_fn(op, indexer, x, y)
+    else:
+      jax_fn = lambda x, y: UpdateOps.jax_fn(op, indexer, x, y)
     self._CheckAgainstNumpy(onp_fn, jax_fn, args_maker, check_dtypes=True)
     self._CompileAndCheck(jax_fn, args_maker, check_dtypes=True)
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -834,11 +834,11 @@ class UpdateOps(enum.Enum):
   def sugar_fn(op, indexer, x, y):
     x = jnp.array(x)
     return {
-      UpdateOps.UPDATE: x.update,
-      UpdateOps.ADD: x.update_add,
-      UpdateOps.MIN: x.update_min,
-      UpdateOps.MAX: x.update_max,
-    }[op][indexer](y)
+      UpdateOps.UPDATE: x.at[indexer].set,
+      UpdateOps.ADD: x.at[indexer].add,
+      UpdateOps.MIN: x.at[indexer].min,
+      UpdateOps.MAX: x.at[indexer].max,
+    }[op](y)
 
 
 class IndexedUpdateTest(jtu.JaxTestCase):


### PR DESCRIPTION
@dpfau suggested adding some syntactic sugar for `jax.ops.index_update` and related functions. This PR implements one option for that syntactic sugar: instead of
```python
x = jax.index_update(x, jax.ops.index[..., 1:3, :], y)
x = jax.index_add(x, jax.ops.index[..., 1:3, :], y)
x = jax.index_min(x, jax.ops.index[..., 1:3, :], y)
x = jax.index_max(x, jax.ops.index[..., 1:3, :], y)
```
you can write
```python
x = x.at[..., 1:3, :].set(y)
x = x.at[..., 1:3, :].add(y)
x = x.at[..., 1:3, :].min(y)
x = x.at[..., 1:3, :].max(y)
```

## Other possible options
Originally implemented by this PR:
```python
x = x.update[..., 1:3, :](y)
x = x.add[..., 1:3, :](y)  # or x = x.update_add[..., 1:3, :](y)
x = x.update_min[..., 1:3, :](y)
x = x.update_max[..., 1:3, :](y)
```
Other easy-to-implement options discussed:
```python
x = x.at[..., 1:3, :].update(y)
x = x.at[..., 1:3, :].add(y)
x = x.at[..., 1:3, :].min(y)
x = x.at[..., 1:3, :].max(y)
```

```python
x = x.update[..., 1:3, :].to(y)
x = x.update[..., 1:3, :].add(y)
x = x.update[..., 1:3, :].min(y)
x = x.update[..., 1:3, :].max(y)
```

Harder to implement (would require `x[idx]` to act both as an array itself and a slice reference to `x`):
```python
x = x[..., 1:3, :].update(y)
x = x[..., 1:3, :].update_add(y)
x = x[..., 1:3, :].update_min(y)
x = x[..., 1:3, :].update_max(y)
```

Even harder to implement (would require adding a layer of indirection)
```python
# x is an indirect wrapper of a device value,
# where __setattr__ changes the wrapped value
x[..., 1:3, :] = y
x[..., 1:3, :] += y
# (mutable) x now contains a different (immutable) wrapped value
```

I'd be interested to know which of these people prefer the best, and if there are other tradeoffs here I haven't thought of.
