### PR TITLE
Fix minor typo in cell

### DIFF
--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -899,7 +899,7 @@
    "outputs": [],
    "source": [
     "def hvp(f, x, v):\n",
-    "    return grad(lambda x: np.vdot(grad(f)(x), v))"
+    "    return grad(lambda x: np.vdot(grad(f)(x), v))(x)"
    ]
   },
   {

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -462,7 +462,7 @@
    "outputs": [],
    "source": [
     "def hvp(f, x, v):\n",
-    "    return grad(lambda x: np.vdot(grad(f)(x), v))"
+    "    return grad(lambda x: np.vdot(grad(f)(x), v))(x)"
    ]
   },
   {


### PR DESCRIPTION
One of the arguments to `hvp` wasn't being used, which made the example slightly confusing.