### PR TITLE
Add missing functions to autodoc lists

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -78,7 +78,10 @@ Not every function in NumPy is implemented; contributions are welcome!
     concatenate
     conj
     conjugate
+    convolve
+    copysign
     corrcoef
+    correlate
     cos
     cosh
     count_nonzero
@@ -210,6 +213,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     result_type
     right_shift
     roll
+    rollaxis
     roots
     rot90
     round
@@ -245,6 +249,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     triu
     triu_indices
     true_divide
+    trunc
     unpackbits
     vander
     var

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -37,6 +37,19 @@ jax.scipy.ndimage
 
    map_coordinates
 
+jax.scipy.signal
+----------------
+
+.. automodule:: jax.scipy.signal
+
+.. autosummary::
+  :toctree: _autosummary
+
+   convolve
+   convolve2d
+   correlate
+   correlate2d
+
 jax.scipy.sparse.linalg
 -----------------------
 


### PR DESCRIPTION
Forgotten in #2631, #2642, #2675, #2688, and #2695