### PR TITLE
Delete cotangent references on their last use

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -196,16 +196,16 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
 
   # Find the last use of each cotangent so that they can be removed
   # as soon as possible.
-  drop_cts: Dict[int, Any] = {}
+  drop_cts = []
   seen_vars: Set[Any] = set(jaxpr.invars)
   for eqn in linear_eqns:
     read_set = set(eqn.outvars)  # NOTE: eqn is not transposed yet!
-    drop_cts[id(eqn)] = read_set - seen_vars
+    drop_cts.append(read_set - seen_vars)
     seen_vars |= read_set
 
   ct_env: Dict[Any, Any] = {}
   map(write_cotangent, jaxpr.outvars, cotangents_in)
-  for eqn in linear_eqns[::-1]:
+  for eqn, to_drop in zip(linear_eqns[::-1], drop_cts[::-1]):
     invals = map(read_primal, eqn.invars)
     if eqn.primitive.multiple_results:
       cts_in = map(read_cotangent, eqn.outvars)
@@ -217,10 +217,10 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
           params, call_jaxpr, invals, cts_in)
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
-    for var in drop_cts[id(eqn)]:
-      ct_env.pop(var, None)  # NB: Constant cotangents might be missing
     cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
     map(write_cotangent, eqn.invars, cts_out)
+    for var in to_drop:
+      ct_env.pop(var, None)  # NB: Constant cotangents might be missing
 
   cotangents_out = map(read_cotangent, jaxpr.invars)
   return cotangents_out

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -196,7 +196,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
 
   # Find the last use of each cotangent so that they can be removed
   # as soon as possible.
-  drop_cts = []
+  drop_cts: List[Set[Any]] = []
   seen_vars: Set[Any] = set(jaxpr.invars)
   for eqn in linear_eqns:
     read_set = set(eqn.outvars)  # NOTE: eqn is not transposed yet!

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -15,7 +15,7 @@
 
 import functools
 import itertools as it
-from typing import Any, Callable, Dict, Set
+from typing import Any, Callable, Dict, Set, List
 
 from . import partial_eval as pe
 from .. import core as core

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -15,7 +15,7 @@
 
 import functools
 import itertools as it
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Set
 
 from . import partial_eval as pe
 from .. import core as core


### PR DESCRIPTION
Current implementation of transposition may add a factor of 2x to
peak memory usage in real cases and _potentially an unbounded factor_
in pathological programs. The reason why this happens is because the
cotangents computed by the `backward_pass` are never evicted from the
environment until the whole transposition is complete. Other systems
(e.g. PyTorch) generally make use of refcounting or liveness analysis
to remove unnecessary references as soon as they are known to no
longer be needed.

A simple example that showcases this issue is this:
```python
def f(x):
  for i in range(1000):
    x = x * 4
  return x

x = np.ones(4)
vjp(f, x)[1](x)
```

Adding `print(len(ct_env))` at the end of `backward_pass` reveals that
the dictionary actually holds a thousand `DeviceArray`s, while both
forward and backward can be computed in constant memory. Of course this
is the pathological example I mentioned above, but one can easily see
that keeping the cotangents alive for the whole duration of differentiation
causes the memory cost to be approximately `fwd_coefs + all_fwd_intermediates`
instead of `fwd_memory + program_pathwidth` where:
* `fwd_coefs` is the amount of memory necessary to store all constant
  coefficients of the linearized function
* `all_fwd_intermediates` is the amount of memory necessary to
  store _all intermediates appearing in the forward program_.
* `program_pathwidth` is the maximum over amounts of memory necessary
  to store the live values over all transposed program locations

Note that usually we have that `all_fwd_intermediates > fwd_coefs >> program_pathwidth` (`>>` meaning that the RHS is usually significantly smaller).