### PR TITLE
Add numpy.rint to lax numpy

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -214,6 +214,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     reshape
     result_type
     right_shift
+    rint
     roll
     rollaxis
     roots

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -498,6 +498,18 @@ logical_or = _logical_op(onp.logical_or, lax.bitwise_or)
 logical_xor = _logical_op(onp.logical_xor, lax.bitwise_xor)
 
 
+@_wraps(onp.rint)
+def rint(x):
+  if issubdtype(_dtype(x), complexfloating):
+    return lax.complex(rint(lax.real(x)), rint(lax.imag(x)))
+  y = floor(x)
+  r = x - y
+
+  # Tie break by rounding to nearest even
+  y_is_odd = lax.convert_element_type(y % 2, bool_)
+  return where((r > 0.5) | ((r == 0.5) & y_is_odd), y + 1, y)
+
+
 @_wraps(onp.sign)
 def sign(x):
   dtype = _dtype(x)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -500,14 +500,12 @@ logical_xor = _logical_op(onp.logical_xor, lax.bitwise_xor)
 
 @_wraps(onp.rint)
 def rint(x):
-  if issubdtype(_dtype(x), complexfloating):
+  dtype = _dtype(x)
+  if issubdtype(dtype, integer):
+    return x
+  if issubdtype(dtype, complexfloating):
     return lax.complex(rint(lax.real(x)), rint(lax.imag(x)))
-  y = floor(x)
-  r = x - y
-
-  # Tie break by rounding to nearest even
-  y_is_odd = lax.convert_element_type(y % 2, bool_)
-  return where((r > 0.5) | ((r == 0.5) & y_is_odd), y + 1, y)
+  return _round_to_nearest_even(x)
 
 
 @_wraps(onp.sign)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -502,7 +502,7 @@ logical_xor = _logical_op(onp.logical_xor, lax.bitwise_xor)
 def rint(x):
   dtype = _dtype(x)
   if issubdtype(dtype, integer):
-    return x
+    return lax.convert_element_type(x, float_)
   if issubdtype(dtype, complexfloating):
     return lax.complex(rint(lax.real(x)), rint(lax.imag(x)))
   return _round_to_nearest_even(x)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -238,6 +238,8 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-2}),
     op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("rint", 1, all_dtypes + uint_dtypes, all_shapes,
+              jtu.rand_some_inf_and_nan, []),
     op_record("sign", 1, number_dtypes + uint_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, []),
     op_record('copysign', 2, default_dtypes, all_shapes, jtu.rand_some_inf_and_nan, [],

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -238,7 +238,7 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={onp.float16: 1e-2}),
     op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("rint", 1, all_dtypes + uint_dtypes, all_shapes,
+    op_record("rint", 1, number_dtypes + uint_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, []),
     op_record("sign", 1, number_dtypes + uint_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, []),


### PR DESCRIPTION
Aside: I noticed that the [`all_dtypes`](https://github.com/google/jax/blob/8fa707af9834f778f7e1c2953645455b02a78c97/tests/lax_numpy_test.py#L71) list in lax_numpy_tests.py doesn't include the uint dtypes, is this intended?