### PR TITLE
Add a regression test that runs the same computation on all devices t…

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -325,6 +325,15 @@ class APITest(jtu.JaxTestCase):
     y = api.device_put(x)
     self.assertEqual(y.device_buffer.device(), default_device)
 
+  def test_jit_on_all_devices(self):
+    # Verifies we can run the same computation on every device present, even
+    # if they are, for example, different models of GPU.
+    data = onp.random.rand(1000).astype(onp.float32)
+    f = api.jit(np.negative)
+    for device in jax.local_devices():
+      x = device_put(data, device=device)
+      onp.testing.assert_array_equal(-data, f(x))
+
   @jtu.skip_on_devices("tpu")
   def test_jacobian(self):
     R = onp.random.RandomState(0).randn


### PR DESCRIPTION
…hat are present.

Jaxlib 0.1.44 fixed #2721 and now we can compile for GPUs of different models. This PR adds a test, although it won't really catch the problem in any of our CI builds.

Fixes #2721 
Fixes one part of #1325 as well, although that issue has two separate problems in it.