### PR TITLE
Initial implementation of np.linalg.lstsq() via SVD

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -313,7 +313,7 @@ jax.numpy.linalg
   eigvals
   eigvalsh
   inv
-  leastsq
+  lstsq
   matrix_power
   matrix_rank
   multi_dot

--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -313,6 +313,7 @@ jax.numpy.linalg
   eigvals
   eigvalsh
   inv
+  leastsq
   matrix_power
   matrix_rank
   multi_dot

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -494,6 +494,9 @@ for func in get_module_functions(np.linalg):
        solutions. Here, the residuals are returned in all cases, to make the function
        compatible with jit. The non-jit compatible numpy behavior can be recovered by
        passing numpy_resid=True.
+
+    The lstsq function does not currently have a custom JVP rule, so the gradient is
+    poorly behaved for some inputs, particularly for low-rank `a`.
     """))
 def lstsq(a, b, rcond=None, *, numpy_resid=False):
   # TODO: add lstsq to lax_linalg and implement this function via those wrappers.

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -497,6 +497,7 @@ for func in get_module_functions(np.linalg):
     """))
 def lstsq(a, b, rcond=None, *, numpy_resid=False):
   # TODO: add lstsq to lax_linalg and implement this function via those wrappers.
+  # TODO: add custom jvp rule for more robust lstsq differentiation
   a, b = _promote_arg_dtypes(a, b)
   if a.shape[0] != b.shape[0]:
     raise ValueError("Leading dimensions of input arrays must match")

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -862,20 +862,20 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # SVD not implemented on TPU.
   def testLstsq(self, lhs_shape, rhs_shape, dtype, lowrank, rcond, rng_factory):
-    rng = rng_factory()
+    rng = rng_factory(self.rng())
     _skip_if_unsupported_type(dtype)
-    onp_fun = partial(onp.linalg.lstsq, rcond=rcond)
-    jnp_fun = partial(np.linalg.lstsq, rcond=rcond)
-    jnp_fun_numpy = partial(np.linalg.lstsq, rcond=rcond, numpy_resid=True)
-    tol = {onp.float32: 1e-6, onp.float64: 1e-12,
-           onp.complex64: 1e-6, onp.complex128: 1e-12}
+    onp_fun = partial(np.linalg.lstsq, rcond=rcond)
+    jnp_fun = partial(jnp.linalg.lstsq, rcond=rcond)
+    jnp_fun_numpy_resid = partial(jnp.linalg.lstsq, rcond=rcond, numpy_resid=True)
+    tol = {np.float32: 1e-6, np.float64: 1e-12,
+           np.complex64: 1e-6, np.complex128: 1e-12}
     def args_maker():
       lhs = rng(lhs_shape, dtype)
       if lowrank and lhs_shape[1] > 1:
         lhs[:, -1] = lhs[:, :-1].mean(1)
       return [lhs, rng(rhs_shape, dtype)]
 
-    self._CheckAgainstNumpy(onp_fun, jnp_fun_numpy, args_maker, check_dtypes=False, tol=tol)
+    self._CheckAgainstNumpy(onp_fun, jnp_fun_numpy_resid, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True, atol=tol, rtol=tol)
 
     # Disabled because grad is flaky for low-rank inputs.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -877,7 +877,10 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(onp_fun, jnp_fun_numpy, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True, atol=tol, rtol=tol)
-    # jtu.check_grads(jnp_fun, args_maker(), order=2, atol=tol, rtol=tol)
+
+    if np.finfo(dtype).bits == 64:
+      # Only check grad for first argument:
+      jtu.check_grads(lambda *args: jnp_fun(*args)[0], args_maker(), order=2, atol=1e-2, rtol=1e-2)
 
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): No complex eigh implementation on TPU.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -878,9 +878,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, jnp_fun_numpy, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True, atol=tol, rtol=tol)
 
-    if np.finfo(dtype).bits == 64:
-      # Only check grad for first argument:
-      jtu.check_grads(lambda *args: jnp_fun(*args)[0], args_maker(), order=2, atol=1e-2, rtol=1e-2)
+    # Disabled because grad is flaky for low-rank inputs.
+    # TODO:
+    # jtu.check_grads(lambda *args: jnp_fun(*args)[0], args_maker(), order=2, atol=1e-2, rtol=1e-2)
 
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): No complex eigh implementation on TPU.

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -844,34 +844,40 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs={}_rhs={}_rcond={}".format(
+       "_lhs={}_rhs={}_lowrank={}_rcond={}".format(
            jtu.format_shape_dtype_string(lhs_shape, dtype),
            jtu.format_shape_dtype_string(rhs_shape, dtype),
-           rcond),
+           lowrank, rcond),
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rcond": rcond, "rng_factory": rng_factory}
+       "lowrank": lowrank, "rcond": rcond, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
           ((1, 1), (1, 1)),
           ((4, 6), (4,)),
           ((6, 6), (6, 1)),
           ((8, 6), (8, 4)),
       ]
+      for lowrank in [True, False]
       for rcond in [-1, None, 0.5]
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # SVD not implemented on TPU.
-  def testLstsq(self, lhs_shape, rhs_shape, dtype, rcond, rng_factory):
+  def testLstsq(self, lhs_shape, rhs_shape, dtype, lowrank, rcond, rng_factory):
     rng = rng_factory()
     _skip_if_unsupported_type(dtype)
     onp_fun = partial(onp.linalg.lstsq, rcond=rcond)
     jnp_fun = partial(np.linalg.lstsq, rcond=rcond)
     jnp_fun_numpy = partial(np.linalg.lstsq, rcond=rcond, numpy_resid=True)
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     tol = {onp.float32: 1e-6, onp.float64: 1e-12,
            onp.complex64: 1e-6, onp.complex128: 1e-12}
+    def args_maker():
+      lhs = rng(lhs_shape, dtype)
+      if lowrank and lhs_shape[1] > 1:
+        lhs[:, -1] = lhs[:, :-1].mean(1)
+      return [lhs, rng(rhs_shape, dtype)]
 
     self._CheckAgainstNumpy(onp_fun, jnp_fun_numpy, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True, atol=tol, rtol=tol)
+    # jtu.check_grads(jnp_fun, args_maker(), order=2, atol=tol, rtol=tol)
 
   # Regression test for incorrect type for eigenvalues of a complex matrix.
   @jtu.skip_on_devices("tpu")  # TODO(phawkins): No complex eigh implementation on TPU.


### PR DESCRIPTION
This is an initial implementation of ``np.linalg.lstsq`` based on the SVD. A full solution would involve adding wrappers for ``*gelsd`` to lax_linalg.py & cusolver.

I estimate this is about 2x slower than the full solution, based on performance of the relevant lapack code paths in numpy.

Addresses part of #1999