### PR TITLE
Introduce framework for fixed-parameter `jax.scipy.stats` distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ docs/_autosummary
 .idea
 .vscode
 venv/
+.venv/
 jax.iml

--- a/jax/scipy/stats/_freezing.py
+++ b/jax/scipy/stats/_freezing.py
@@ -56,7 +56,7 @@ class FrozenDistribution:
         return f"{self.name}({self._get_assignment_str()}, funcs=[{self._get_func_str()}])"
 
     def _get_func_str(self):
-        return ', '.join(self.funcs.keys())
+        return ", ".join(self.funcs.keys())
 
     def _get_assignment_str(self):
         return ", ".join(f"{varname}={varvalue}" for varname, varvalue in self.assignment.items())

--- a/jax/scipy/stats/_freezing.py
+++ b/jax/scipy/stats/_freezing.py
@@ -1,0 +1,97 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import inspect
+import functools
+
+
+_required = type("_required", (object, ), {})()
+
+
+class FrozenDistribution:
+    """Fixed-parameter instantiation of an aribtrary distribution.
+
+    Wraps a collection of functions and binds some of their arguments to emulate
+    a fixed-parameter distribution. Note that this class does not expose the
+    functional API of the underlying distribution since everything is done at
+    run-time. Instead, we expose the wrapped functions in the `__getattr__`.
+    """
+    def __init__(self, name, raw_funcs, assignment):
+        self.name = name
+        self.assignment = assignment
+
+        self.funcs = {}
+        for raw_func in raw_funcs:
+            self.funcs[raw_func.__name__] = functools.partial(raw_func, **assignment)
+
+    def __getattr__(self, attr):
+        if attr in self.funcs:
+            return self.funcs[attr]
+        raise AttributeError(
+            f"distribution does not have attribute '{attr}', "
+            f"registered attributes are [{self._get_func_str()}]"
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, Frozen):
+            return False
+        return self.name == other.name and self.assignment == other.assignment
+
+    def __str__(self):
+        return f"{self.name}({self._get_assignment_str()})"
+
+    def __repr__(self):
+        return f"{self.name}({self._get_assignment_str()}, funcs=[{self._get_func_str()}])"
+
+    def _get_func_str(self):
+        return ', '.join(self.funcs.keys())
+
+    def _get_assignment_str(self):
+        return ", ".join(f"{varname}={varvalue}" for varname, varvalue in self.assignment.items())
+
+
+class Freezer:
+    """Facilitator of frozen distribution generation.
+
+    Keeps track of wrapped functions to pass through to distribution instantiations.
+    """
+    def __init__(self, name, **default_assignment):
+        self.name = name
+        self.default_assignment = default_assignment
+        self.argnames = default_assignment.keys()
+        self.funcs = []
+
+    def wrap(self, f):
+        parameters = inspect.signature(f).parameters
+        for argname in self.argnames:
+            if argname not in parameters:
+                raise TypeError(
+                    f"wrapped function `{self.name}.{f.__name__}` "
+                    f"is missing argument `{argname}`"
+                )
+        self.funcs.append(f)
+        return f
+
+    def __call__(self, **assignment):
+        for varname in assignment:
+            if varname not in self.argnames:
+                raise TypeError(f"got an unexpected keyword argument '{varname}'")
+
+        assignment = {**self.default_assignment, **assignment}
+        required = [f"'{name}'" for name in assignment if assignment[name] == _required]
+        if required:
+            raise TypeError(f"missing required arguments: {', '.join(required)}")
+
+        return FrozenDistribution(self.name, self.funcs, assignment)

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -12,27 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like, _wraps,
-                                where, inf, logical_or)
-from ..special import betaln
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy import special
+from jax.scipy.stats._freezing import Freezer, _required
 
 
-@_wraps(osp_stats.beta.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], a=_required, b=_required, loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
-  x, a, b, loc, scale = _promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
-  one = _constant_like(x, 1)
-  shape_term = lax.neg(betaln(a, b))
+  x, a, b, loc, scale = jnp._promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
+  one = jnp._constant_like(x, 1)
+  shape_term = lax.neg(special.betaln(a, b))
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.add(lax.mul(lax.sub(a, one), lax.log(y)),
                             lax.mul(lax.sub(b, one), lax.log1p(lax.neg(y))))
   log_probs = lax.sub(lax.add(shape_term, log_linear_term), lax.log(scale))
-  return where(logical_or(lax.gt(x, lax.add(loc, scale)),
-                          lax.lt(x, loc)), -inf, log_probs)
+  return jnp.where(jsp.logical_or(lax.gt(x, lax.add(loc, scale)),
+                                  lax.lt(x, loc)), -jnp.inf, log_probs)
 
-@_wraps(osp_stats.beta.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.beta.pdf, update_doc=False)
 def pdf(x, a, b, loc=0, scale=1):
   return lax.exp(logpdf(x, a, b, loc, scale))
-

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -34,7 +34,7 @@ def logpdf(x, a, b, loc=0, scale=1):
   log_linear_term = lax.add(lax.mul(lax.sub(a, one), lax.log(y)),
                             lax.mul(lax.sub(b, one), lax.log1p(lax.neg(y))))
   log_probs = lax.sub(lax.add(shape_term, log_linear_term), lax.log(scale))
-  return jnp.where(jsp.logical_or(lax.gt(x, lax.add(loc, scale)),
+  return jnp.where(jnp.logical_or(lax.gt(x, lax.add(loc, scale)),
                                   lax.lt(x, loc)), -jnp.inf, log_probs)
 
 

--- a/jax/scipy/stats/cauchy.py
+++ b/jax/scipy/stats/cauchy.py
@@ -16,19 +16,26 @@
 import numpy as np
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy.stats._freezing import Freezer
 
 
-@_wraps(osp_stats.cauchy.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.cauchy.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("cauchy.logpdf", x, loc, scale)
-  one = _constant_like(x, 1)
-  pi = _constant_like(x, np.pi)
+  x, loc, scale = jnp._promote_args_inexact("cauchy.logpdf", x, loc, scale)
+  one = jnp._constant_like(x, 1)
+  pi = jnp._constant_like(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.mul(pi, scale))
   return lax.neg(lax.add(normalize_term, lax.log1p(lax.mul(scaled_x, scaled_x))))
 
-@_wraps(osp_stats.cauchy.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.cauchy.pdf, update_doc=False)
 def pdf(x, loc=0, scale=1):
   return lax.exp(logpdf(x, loc, scale))

--- a/jax/scipy/stats/expon.py
+++ b/jax/scipy/stats/expon.py
@@ -12,20 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _wraps, where, inf
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy.stats._freezing import Freezer
 
 
-@_wraps(osp_stats.expon.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.expon.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("expon.logpdf", x, loc, scale)
+  x, loc, scale = jnp._promote_args_inexact("expon.logpdf", x, loc, scale)
   log_scale = lax.log(scale)
   linear_term = lax.div(lax.sub(x, loc), scale)
   log_probs = lax.neg(lax.add(linear_term, log_scale))
-  return where(lax.lt(x, loc), -inf, log_probs)
+  return jnp.where(lax.lt(x, loc), -jnp.inf, log_probs)
 
-@_wraps(osp_stats.expon.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.expon.pdf, update_doc=False)
 def pdf(x, loc=0, scale=1):
   return lax.exp(logpdf(x, loc, scale))

--- a/jax/scipy/stats/gamma.py
+++ b/jax/scipy/stats/gamma.py
@@ -12,24 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like, _wraps,
-                                where, inf)
-from ..special import gammaln
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy import special
+from jax.scipy.stats._freezing import Freezer, _required
 
 
-@_wraps(osp_stats.gamma.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], a=_required, loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.gamma.logpdf, update_doc=False)
 def logpdf(x, a, loc=0, scale=1):
-  x, a, loc, scale = _promote_args_inexact("gamma.logpdf", x, a, loc, scale)
-  one = _constant_like(x, 1)
+  x, a, loc, scale = jnp._promote_args_inexact("gamma.logpdf", x, a, loc, scale)
+  one = jnp._constant_like(x, 1)
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.sub(lax.mul(lax.sub(a, one), lax.log(y)), y)
-  shape_terms = lax.add(gammaln(a), lax.log(scale))
+  shape_terms = lax.add(special.gammaln(a), lax.log(scale))
   log_probs = lax.sub(log_linear_term, shape_terms)
-  return where(lax.lt(x, loc), -inf, log_probs)
+  return jnp.where(lax.lt(x, loc), -jnp.inf, log_probs)
 
-@_wraps(osp_stats.gamma.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.gamma.pdf, update_doc=False)
 def pdf(x, a, loc=0, scale=1):
   return lax.exp(logpdf(x, a, loc, scale))

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -12,29 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy.stats._freezing import Freezer
 
 
-@_wraps(osp_stats.laplace.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.laplace.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("laplace.logpdf", x, loc, scale)
-  two = _constant_like(x, 2)
+  x, loc, scale = jnp._promote_args_inexact("laplace.logpdf", x, loc, scale)
+  two = jnp._constant_like(x, 2)
   linear_term = lax.div(lax.abs(lax.sub(x, loc)), scale)
   return lax.neg(lax.add(linear_term, lax.log(lax.mul(two, scale))))
 
-@_wraps(osp_stats.laplace.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.laplace.pdf, update_doc=False)
 def pdf(x, loc=0, scale=1):
   return lax.exp(logpdf(x, loc, scale))
 
-@_wraps(osp_stats.laplace.cdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.laplace.cdf, update_doc=False)
 def cdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("laplace.cdf", x, loc, scale)
-  half = _constant_like(x, 0.5)
-  one = _constant_like(x, 1)
-  zero = _constant_like(x, 0)
+  x, loc, scale = jnp._promote_args_inexact("laplace.cdf", x, loc, scale)
+  half = jnp._constant_like(x, 0.5)
+  one = jnp._constant_like(x, 1)
+  zero = jnp._constant_like(x, 0)
   diff = lax.div(lax.sub(x, loc), scale)
   return lax.select(lax.le(diff, zero),
                     lax.mul(half, lax.exp(diff)),

--- a/jax/scipy/stats/logistic.py
+++ b/jax/scipy/stats/logistic.py
@@ -13,32 +13,47 @@
 # limitations under the License.
 
 import scipy.stats as osp_stats
-from jax.scipy.special import expit, logit
 
-from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _wraps
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy import special
+from jax.scipy.stats._freezing import Freezer
 
 
-@_wraps(osp_stats.logistic.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1])
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.logpdf, update_doc=False)
 def logpdf(x):
   return lax.neg(x) - 2. * lax.log1p(lax.exp(lax.neg(x)))
 
-@_wraps(osp_stats.logistic.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.pdf, update_doc=False)
 def pdf(x):
   return lax.exp(logpdf(x))
 
-@_wraps(osp_stats.logistic.ppf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.ppf, update_doc=False)
 def ppf(x):
-  return logit(x)
+  return special.logit(x)
 
-@_wraps(osp_stats.logistic.sf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.sf, update_doc=False)
 def sf(x):
-  return expit(lax.neg(x))
+  return special.expit(lax.neg(x))
 
-@_wraps(osp_stats.logistic.isf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.isf, update_doc=False)
 def isf(x):
-  return -logit(x)
+  return -special.logit(x)
 
-@_wraps(osp_stats.logistic.cdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.logistic.cdf, update_doc=False)
 def cdf(x):
-  return expit(x)
+  return special.expit(x)

--- a/jax/scipy/stats/norm.py
+++ b/jax/scipy/stats/norm.py
@@ -16,38 +16,47 @@
 import numpy as np
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy import lax_numpy as jnp
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
-from .. import special
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy import special
+from jax.scipy.stats._freezing import Freezer
 
-@_wraps(osp_stats.norm.logpdf, update_doc=False)
+
+freeze = Freezer(__name__.split(".")[-1], loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.norm.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("norm.logpdf", x, loc, scale)
-  two = _constant_like(x, 2)
+  x, loc, scale = jnp._promote_args_inexact("norm.logpdf", x, loc, scale)
+  two = jnp._constant_like(x, 2)
   scale_sqrd = lax.pow(scale, two)
-  log_normalizer = lax.log(lax.mul(_constant_like(x, 2 * np.pi), scale_sqrd))
+  log_normalizer = lax.log(lax.mul(jnp._constant_like(x, 2 * np.pi), scale_sqrd))
   quadratic = lax.div(lax.pow(lax.sub(x, loc), two), scale_sqrd)
   return lax.div(lax.neg(lax.add(log_normalizer, quadratic)), two)
 
 
-@_wraps(osp_stats.norm.pdf, update_doc=False)
+@freeze.wrap
+@jnp._wraps(osp_stats.norm.pdf, update_doc=False)
 def pdf(x, loc=0, scale=1):
   return lax.exp(logpdf(x, loc, scale))
 
 
-@_wraps(osp_stats.norm.cdf, update_doc=False)
+@freeze.wrap
+@jnp._wraps(osp_stats.norm.cdf, update_doc=False)
 def cdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("norm.cdf", x, loc, scale)
+  x, loc, scale = jnp._promote_args_inexact("norm.cdf", x, loc, scale)
   return special.ndtr(lax.div(lax.sub(x, loc), scale))
 
 
-@_wraps(osp_stats.norm.logcdf, update_doc=False)
+@freeze.wrap
+@jnp._wraps(osp_stats.norm.logcdf, update_doc=False)
 def logcdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("norm.logcdf", x, loc, scale)
+  x, loc, scale = jnp._promote_args_inexact("norm.logcdf", x, loc, scale)
   return special.log_ndtr(lax.div(lax.sub(x, loc), scale))
 
 
-@_wraps(osp_stats.norm.ppf, update_doc=False)
+@freeze.wrap
+@jnp._wraps(osp_stats.norm.ppf, update_doc=False)
 def ppf(q, loc=0, scale=1):
   return jnp.array(special.ndtri(q) * scale + loc, 'float64')

--- a/jax/scipy/stats/pareto.py
+++ b/jax/scipy/stats/pareto.py
@@ -15,19 +15,27 @@
 
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps, inf, where
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy import special
+from jax.scipy.stats._freezing import Freezer, _required
 
 
-@_wraps(osp_stats.pareto.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], b=_required, loc=0, scale=1)
+
+
+@freeze.wrap
+@jnp._wraps(osp_stats.pareto.logpdf, update_doc=False)
 def logpdf(x, b, loc=0, scale=1):
-  x, b, loc, scale = _promote_args_inexact("pareto.logpdf", x, b, loc, scale)
-  one = _constant_like(x, 1)
+  x, b, loc, scale = jnp._promote_args_inexact("pareto.logpdf", x, b, loc, scale)
+  one = jnp._constant_like(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.div(scale, b))
   log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))
-  return where(lax.lt(x, lax.add(loc, scale)), -inf, log_probs)
+  return jnp.where(lax.lt(x, lax.add(loc, scale)), -jnp.inf, log_probs)
 
-@_wraps(osp_stats.pareto.pdf, update_doc=False)
+
+@freeze.wrap
+@jnp._wraps(osp_stats.pareto.pdf, update_doc=False)
 def pdf(x, b, loc=0, scale=1):
   return lax.exp(logpdf(x, b, loc, scale))

--- a/jax/scipy/stats/uniform.py
+++ b/jax/scipy/stats/uniform.py
@@ -15,19 +15,22 @@
 
 import scipy.stats as osp_stats
 
-from ... import lax
-from ...numpy.lax_numpy import (_constant_like, _promote_args_inexact, _wraps,
-                                where, inf, logical_or)
+from jax import lax
+from jax.numpy import lax_numpy as jnp
+from jax.scipy.stats._freezing import Freezer
 
 
-@_wraps(osp_stats.uniform.logpdf, update_doc=False)
+freeze = Freezer(__name__.split(".")[-1], loc=0, scale=1)
+
+
+@jnp._wraps(osp_stats.uniform.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
-  x, loc, scale = _promote_args_inexact("uniform.logpdf", x, loc, scale)
+  x, loc, scale = jnp._promote_args_inexact("uniform.logpdf", x, loc, scale)
   log_probs = lax.neg(lax.log(scale))
-  return where(logical_or(lax.gt(x, lax.add(loc, scale)),
-                          lax.lt(x, loc)),
-               -inf, log_probs)
+  return jnp.where(jnp.logical_or(lax.gt(x, lax.add(loc, scale)),
+                                  lax.lt(x, loc)),
+                   -jnp.inf, log_probs)
 
-@_wraps(osp_stats.uniform.pdf, update_doc=False)
+@jnp._wraps(osp_stats.uniform.pdf, update_doc=False)
 def pdf(x, loc=0, scale=1):
   return lax.exp(logpdf(x, loc, scale))


### PR DESCRIPTION
Closes #2735.

This PR mainly introduces some rudimentary functionality for fixed-parameter or frozen distributions within JAX's `scipy.stats` implementation, but also cleans up and standardizes some of that code.

Existing functionality is unaffected.

Introduces two new classes `Freezer` and `FrozenDistribution` that respectively facilitate the binding of distribution parameters and the exporting of those bound functions to the user. An instance of `Freezer` is constructed per distribution family with the parameters to be fixed and the methods to be bound are wrapped with `Freezer.wrap`. The `Freezer` instance can then be called with a parameter assignment to produce a `FrozenDistribution` that inherits all the wrapped functions and binds the fixed parameters to them at run-time.

Couple things might be worth noting:
-  Current overhead of the wrapping seems to be negligible in my testing, but the calls to the `inspect` module might rack up if a lot of new distributions and respective suites of functions are introduced.
- Since everything is constructed at run-time, and bootstrapped from existing code, introspection into `FrozenDistribution` instances will not work properly. That is, since none of the functions are properly methods of the class, they will not show up when trying to check `__dir__` or other ways of accessing available functions of that distribution, even though they might be available. I tried to expose available functionality by way of the `__repr__`.