### PR TITLE
Thread precision through np.convolve & np.correlate

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1155,8 +1155,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = rng_factory()
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
     onp_fun = partial(onp_op, mode=mode)
-    jnp_fun = partial(jnp_op, mode=mode)
-    tol = 1e-2 if jtu.device_under_test() != "tpu" else 0.5
+    jnp_fun = partial(jnp_op, mode=mode, precision=lax.Precision.HIGHEST)
+    tol = 1e-2
     self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1154,8 +1154,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testConvolutions(self, xshape, yshape, dtype, mode, rng_factory, jnp_op, onp_op):
     rng = rng_factory()
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
+    precision = lax.Precision.HIGHEST if jtu.device_under_test() == "tpu" else None
     onp_fun = partial(onp_op, mode=mode)
-    jnp_fun = partial(jnp_op, mode=mode, precision=lax.Precision.HIGHEST)
+    jnp_fun = partial(jnp_op, mode=mode, precision=precision)
     tol = 1e-2
     self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)


### PR DESCRIPTION
This should alleviate TPU flakes without having to set the tolerance so high.