### PR TITLE
Raise an error if stop_gradient is called on non-arrays

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1275,23 +1275,23 @@ def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
 def stop_gradient(x):
   """Stops gradient computation.
 
-   Operationally `stop_gradient` is the identity function, that is, it returns
-   argument `x` unchanged. However, `stop_gradient` prevents the flow of
-   gradients during forward or reverse-mode automatic differentiation. If there
-   are multiple nested gradient computations, `stop_gradient` stops gradients
-   for all of them.
+  Operationally `stop_gradient` is the identity function, that is, it returns
+  argument `x` unchanged. However, `stop_gradient` prevents the flow of
+  gradients during forward or reverse-mode automatic differentiation. If there
+  are multiple nested gradient computations, `stop_gradient` stops gradients
+  for all of them.
 
-   For example:
+  For example:
 
-   >>> jax.grad(lambda x: x**2)(3.)
-   array(6., dtype=float32)
-   >>> jax.grad(lambda x: jax.lax.stop_gradient(x)**2)(3.)
-   array(0., dtype=float32)
-   >>> jax.grad(jax.grad(lambda x: x**2))(3.)
-   array(2., dtype=float32)
-   >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
-   array(0., dtype=float32)
-   """
+  >>> jax.grad(lambda x: x**2)(3.)
+  array(6., dtype=float32)
+  >>> jax.grad(lambda x: jax.lax.stop_gradient(x)**2)(3.)
+  array(0., dtype=float32)
+  >>> jax.grad(jax.grad(lambda x: x**2))(3.)
+  array(2., dtype=float32)
+  >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
+  array(0., dtype=float32)
+  """
   return tree_map(stop_gradient_p.bind, x)
 
 
@@ -4608,6 +4608,12 @@ masking.masking_rules[tie_in_p] = lambda vals, logical_shapes: vals[1]
 
 ### stop-gradient
 
+def _stop_gradient_impl(x):
+  if not core.valid_jaxtype(x):
+    raise TypeError("stop_gradient only works on valid JAX arrays, but "
+                    f"input argument is: {x}")
+  return x
+
 def _stop_gradient_jvp_rule(primals, tangents):
   # if we don't call stop_gradient here, we'd only peel off one autodiff tracer
   x, = primals
@@ -4619,7 +4625,7 @@ def _stop_gradient_batch_rule(batched_args, batch_dims):
   return stop_gradient(x), dim
 
 stop_gradient_p = Primitive('stop_gradient')
-stop_gradient_p.def_impl(_identity)
+stop_gradient_p.def_impl(_stop_gradient_impl)
 stop_gradient_p.def_abstract_eval(_identity)
 xla.translations[stop_gradient_p] = lambda c, x: x
 ad.primitive_jvps[stop_gradient_p] = _stop_gradient_jvp_rule

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -350,7 +350,7 @@ def solve(a, b):
 
   # With custom_linear_solve, we can reuse the same factorization when
   # computing sensitivities. This is considerably faster.
-  lu, pivots = lax.stop_gradient(lax_linalg.lu)(a)
+  lu, pivots = lax_linalg.lu(lax.stop_gradient(a))
   custom_solve = partial(
       lax.custom_linear_solve,
       lambda x: _matvec_multiply(a, x),

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -169,7 +169,7 @@ def _solve(a, b, sym_pos, lower):
 
   # With custom_linear_solve, we can reuse the same factorization when
   # computing sensitivities. This is considerably faster.
-  factors = lax.stop_gradient(cho_factor)(a, lower=lower)
+  factors = cho_factor(lax.stop_gradient(a), lower=lower)
   custom_solve = partial(
       lax.custom_linear_solve,
       lambda x: np_linalg._matvec_multiply(a, x),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2626,6 +2626,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     expected = onp.array(0.0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    with self.assertRaises(TypeError):
+      lax.stop_gradient(lambda x: x)
+
   # TODO(mattjj): make this a more systematic test
   def testRemainder(self):
     rng = onp.random.RandomState(0)


### PR DESCRIPTION
Also fixes some incorrect uses where `lax.stop_gradient()` was called on functions instead of arrays, inside `np.linalg.solve`.