### PR TITLE
Add FIXMEs for AD type errors

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -137,7 +137,8 @@ def unpair_pval(pval):
     aval_1, aval_2 = aval
     return (aval_1, const_1), (aval_2, const_2)
 
-def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
+# NOTE: The FIXMEs below are caused by primal/tangent mixups (type errors if you will)
+def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
   if all(ct is zero for ct in cotangents_in):
     return [zero] * len(jaxpr.invars)
 
@@ -165,7 +166,9 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
   primal_env: Dict[Any, Any] = {}
   write_primal(core.unitvar, core.unit)
   map(write_primal, jaxpr.constvars, consts)
-  map(write_primal, jaxpr.invars, args)
+  # FIXME: invars can contain both primal and tangent values, and this line
+  #        forces primal_in to contain UndefinedPrimals for tangent values!
+  map(write_primal, jaxpr.invars, primals_in)
 
   def is_linear(var):
     if type(var) is Literal:
@@ -190,6 +193,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
       if any(is_linear(v) for v in eqn.invars):
         linear_eqns.append(eqn)
       if any(not is_linear(v) for v in eqn.invars):
+        # FIXME: Some invars correspond to tangents
         ans = _eval_subjaxpr_primals(eqn.primitive, call_jaxpr,
                                      map(read_primal, eqn.invars), params)
         map(write_primal, eqn.outvars, ans)
@@ -197,6 +201,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
   ct_env: Dict[Any, Any] = {}
   map(write_cotangent, jaxpr.outvars, cotangents_in)
   for eqn in linear_eqns[::-1]:
+    # FIXME: Some invars correspond to tangents
     invals = map(read_primal, eqn.invars)
     if eqn.primitive.multiple_results:
       cts_in = map(read_cotangent, eqn.outvars)
@@ -209,6 +214,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, args, cotangents_in):
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
     cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
+    # FIXME: Some invars correspond to primals!
     map(write_cotangent, eqn.invars, cts_out)
 
   cotangents_out = map(read_cotangent, jaxpr.invars)


### PR DESCRIPTION
Not sure if we actually want to merge this now, but putting it up at least to keep a more permanent reference somewhere. I've added a bunch of `FIXME`s in the places where I've noticed that AD mixes up tangent and primal values, variables or environments. Those should hopefully get cleaned up once linearity info is preserved in jaxprs.