### PR TITLE
Update automatic jaxlib install command to use nvidia-smi instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,10 +434,10 @@ for Python 3.6, 3.7, and 3.8; for anything else, you must build from
 source. Jax requires Python 3.6 or above. Jax does not support Python 2 any
 more.
 
-To try automatic detection of the correct version for your system, you can run: 
+To try automatic detection of the correct version for your system, you can run:
 
 ```bash
-pip install --upgrade https://storage.googleapis.com/jax-releases/`nvcc -V | sed -En "s/.* release ([0-9]*)\.([0-9]*),.*/cuda\1\2/p"`/jaxlib-0.1.44-`python3 -V | sed -En "s/Python ([0-9]*)\.([0-9]*).*/cp\1\2/p"`-none-linux_x86_64.whl jax
+pip install --upgrade https://storage.googleapis.com/jax-releases/`nvidia-smi | sed -En "s/.* CUDA Version: ([0-9]*)\.([0-9]*).*/cuda\1\2/p"`/jaxlib-0.1.44-`python3 -V | sed -En "s/Python ([0-9]*)\.([0-9]*).*/cp\1\2/p"`-none-linux_x86_64.whl jax
 ```
 
 Please let us know on [the issue tracker](https://github.com/google/jax/issues)


### PR DESCRIPTION
…nvcc.

This is just to get the CUDA version number, and nvidia-smi is more
commonly available.