### PR TITLE
Implement np.unique

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3063,6 +3063,7 @@ def take_along_axis(arr, indices, axis):
 
 ### SetOps
 
+@partial(jit, static_argnums=1)
 def _unique1d_sorted_mask(ar, optional_indices=False):
   """
   Helper function for unique which is jit-able

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3114,6 +3114,11 @@ def _unique1d(ar, return_index=False, return_inverse=False,
 @_wraps(onp.unique)
 def unique(ar, return_index=False, return_inverse=False,
            return_counts=False, axis=None):
+
+  if iscomplexobj(ar):
+    raise NotImplementedError(
+          "np.unique is not implemented for complex valued arrays")
+
   if axis is None:
     ret = _unique1d(ar, return_index, return_inverse, return_counts)
     if len(ret) == 1:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3103,7 +3103,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
     ret += (perm[mask],)
   if return_inverse:
     imask = cumsum(mask) - 1
-    inv_idx = zeros(mask.shape, dtype=int32)
+    inv_idx = zeros(mask.shape, dtype=int_)
     inv_idx = ops.index_update(inv_idx, perm, imask)
     ret += (inv_idx,)
   if return_counts:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1083,6 +1083,24 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_ind={}_inv={}_count={}".format(
+          jtu.format_shape_dtype_string(shape, dtype),
+          return_index, return_inverse, return_counts),
+       "shape": shape, "dtype": dtype,
+       "return_index": return_index, "return_inverse": return_inverse,
+       "return_counts": return_counts, "rng": jtu.rand_default()}
+      for dtype in number_dtypes
+      for shape in all_shapes
+      for return_index in [False, True]
+      for return_inverse in [False, True]
+      for return_counts in [False, True]))
+  def testUnique(self, shape, dtype, return_index, return_inverse, return_counts, rng):
+    args_maker = lambda: [rng(shape, dtype)]
+    onp_fun = lambda x: onp.unique(x, return_index, return_inverse, return_counts)
+    jnp_fun = lambda x: jnp.unique(x, return_index, return_inverse, return_counts)
+    self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=True)
+
   def testIssue1233(self):
     '''
     Following numpy test suite from `test_repeat` at https://github.com/numpy/numpy/blob/master/numpy/core/tests/test_multiarray.py

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1090,7 +1090,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype,
        "return_index": return_index, "return_inverse": return_inverse,
        "return_counts": return_counts, "rng": jtu.rand_default()}
-      for dtype in number_dtypes
+      for dtype in default_dtypes
       for shape in all_shapes
       for return_index in [False, True]
       for return_inverse in [False, True]


### PR DESCRIPTION
This is an implementation of [np.unique](https://docs.scipy.org/doc/numpy/reference/generated/numpy.unique.html) from issue #70 (and #2078 ) . It follows the same structure as the original implementation with changes for Jax compatibility. 

The axis argument has not yet been implemented since it requires a [np.view](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.view.html) function, with the structured array dtype. This is in order to view each sub-tensor along the axis as its own element. Another way to achieve this would be by using pure python and sets, but it seems like that would be too slow. Either way, np.unique is still useful without it. 

np.unique is intrinsically hard to make jit-compatible since its output shape depends on the values in the array. I've added a helper function called `_unique1d_sorted_mask` which is compatible with jit. This is so that a function like "computing the number of unique elements in a jit-compatible way" could easily be implemented in the future. 

The test checks all default types and all shapes. It also tests all input arguments but axis. The test does not compile with jit since unique is not compatible with it. 