### PR TITLE
Add AdaMax optimizer

### DIFF
--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -149,6 +149,13 @@ class OptimizerTests(jtu.JaxTestCase):
     x0 = (np.ones(2), np.ones((2, 2)))
     self._CheckOptimizer(optimizers.sm3, loss, x0, num_iters, step_size)
 
+  def testAdaMaxVector(self):
+    def loss(x): return np.dot(x, x)
+    x0 = np.ones(2)
+    num_iters = 100
+    step_size = 0.1
+    self._CheckOptimizer(optimizers.adamax, loss, x0, num_iters, step_size)
+
   def testSgdVectorExponentialDecaySchedule(self):
     def loss(x): return np.dot(x, x)
     x0 = np.ones(2)


### PR DESCRIPTION
Implements AdaMax, a variant of Adam under the infinity norm, as described in the original [paper](https://arxiv.org/abs/1412.6980).

Perhaps this is too niche and should be left out of core JAX, similar to as suggested in #1467. On the other hand AdaMax is available in [PyTorch](https://pytorch.org/docs/stable/optim.html#torch.optim.Adamax) and [TF](https://www.tensorflow.org/api_docs/python/tf/keras/optimizers/Adamax). Let me know what you think!