### PR TITLE
Fix docstring for jax.random.beta ("Bernoulli" -> "Beta")

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -626,7 +626,7 @@ def beta(key: np.ndarray,
          b: Union[float, np.ndarray],
          shape: Optional[Sequence[int]] = None,
          dtype: onp.dtype = onp.float64) -> np.ndarray:
-  """Sample Bernoulli random values with given shape and mean.
+  """Sample Beta random values with given shape and float dtype.
 
   Args:
     key: a PRNGKey used as the random key.


### PR DESCRIPTION
The docs / docstring for [jax.random.beta](https://jax.readthedocs.io/en/latest/jax.random.html#jax.random.beta) say:

```
Sample Bernoulli random values...
```

It should say:
```
Sample Beta random values...
```

I chose to mimic [jax.random.dirichlet](https://jax.readthedocs.io/en/latest/jax.random.html#jax.random.dirichlet) and say:
```
Sample Beta random values with given shape and float dtype.
```
