### PR TITLE
Switch jaxlib Python code to use the lower-level xla.ops API when bui…

### DIFF
--- a/jaxlib/cuda_prng.py
+++ b/jaxlib/cuda_prng.py
@@ -30,9 +30,14 @@ except ImportError:
 
 _prod = lambda xs: functools.reduce(operator.mul, xs, 1)
 
+# TODO(phawkins): remove after we no longer need to support old jax releases.
+def _unpack_builder(c):
+  # If `c` is a ComputationBuilder object, extracts the underlying XlaBuilder.
+  return getattr(c, "_builder", c)
 
 def threefry2x32(c, keys, data):
   """ThreeFry2x32 kernel for GPU."""
+  c = _unpack_builder(c)
   assert len(keys) == 2, keys
   assert len(data) == 2, data
   dims = c.GetShape(keys[0]).dimensions()
@@ -46,8 +51,8 @@ def threefry2x32(c, keys, data):
   opaque = cuda_prng_kernels.cuda_threefry2x32_descriptor(_prod(dims))
   layout = tuple(range(ndims - 1, -1, -1))
   shape = xla_client.Shape.array_shape(dtype, dims, layout)
-  return c.CustomCallWithLayout(
-      b"cuda_threefry2x32",
+  return xla_client.ops.CustomCallWithLayout(
+      c, b"cuda_threefry2x32",
       operands=(keys[0], keys[1], data[0], data[1]),
       shape_with_layout=xla_client.Shape.tuple_shape([shape, shape]),
       operand_shapes_with_layout=(shape,) * 4,


### PR DESCRIPTION
…lding XLA ops.

Change in preparation for deleting xla_client.ComputationBuilder.