### PR TITLE
jax.random.poisson

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -1058,7 +1058,7 @@ def _poisson_rejection(key, lam, shape, dtype, max_iters):
     v = uniform(subkey_1, shape, lam.dtype)
     u_shifted = 0.5 - abs(u)
 
-    k = (2 * a / u_shifted + b) * u + lam + 0.43
+    k = lax.floor((2 * a / u_shifted + b) * u + lam + 0.43)
     s = lax.log(v * inv_alpha / (a / (u_shifted * u_shifted) + b))
     t = -lam + k * log_lam - lax.lgamma(k + 1)
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -1094,8 +1094,6 @@ def poisson(key, lam, shape=(), dtype=onp.int64):
   shape = abstract_arrays.canonicalize_shape(shape)
   if onp.shape(lam) != shape:
     lam = np.broadcast_to(lam, shape)
-  # TODO(shoyer): support JVPs with respect to `lam`? Currently this will raise
-  # an error because our implementation relies on while_loop.
   return _poisson(key, lam, shape, dtype)
 
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -1044,7 +1044,7 @@ def _poisson_rejection(key, lam, shape, dtype, max_iters):
     k_out = lax.select(accept, k, k_out)
     accepted |= accept
 
-    return i, k_out, accepted, key
+    return i + 1, k_out, accepted, key
 
   def cond_fn(carry):
     i, k_out, accepted, key = carry

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -409,6 +409,10 @@ class LaxRandomTest(jtu.JaxTestCase):
 
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckChiSquared(samples, scipy.stats.poisson(lam).pmf)
+      # TODO(shoyer): determine error bounds for moments more rigorously (e.g.,
+      # based on the central limit theorem).
+      self.assertAllClose(samples.mean(), lam, rtol=0.02, check_dtypes=False)
+      self.assertAllClose(samples.var(), lam, rtol=0.02, check_dtypes=False)
 
   def testPoissonShape(self):
     key = random.PRNGKey(0)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -56,9 +56,19 @@ class LaxRandomTest(jtu.JaxTestCase):
   def _CheckChiSquared(self, samples, pmf):
     alpha = 0.01  # significance level, threshold for p-value
     values, actual_freq = onp.unique(samples, return_counts=True)
-    expected_freq = pmf(values) * len(values)
-    _, p_value = scipy.stats.chisquare(actual_freq, expected_freq)
-    self.assertLess(p_value, alpha)
+    expected_freq = pmf(values) * samples.size
+    # per scipy: "A typical rule is that all of the observed and expected
+    # frequencies should be at least 5."
+    valid = (actual_freq > 5) & (expected_freq > 5)
+    self.assertGreater(valid.sum(), 1,
+                       msg='not enough valid frequencies for chi-squared test')
+    _, p_value = scipy.stats.chisquare(
+        actual_freq[valid], expected_freq[valid])
+    self.assertGreater(
+        p_value, alpha,
+        msg=f'Failed chi-squared test with p={p_value}.\n'
+            'Expected vs. actual frequencies:\n'
+            f'{expected_freq[valid]}\n{actual_freq[valid]}')
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": onp.dtype(dtype).name}
@@ -229,7 +239,12 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_p={}_{}_{}".format(p, dtype, sample_shape),
      "p": p, "axis": axis, "dtype": onp.dtype(dtype).name, 'sample_shape': sample_shape}
-    for (p, axis) in [([.25] * 4, -1), ([[.25, .25], [.1, .9]], 1), ([[.25, .1], [.25, .9]], 0)]
+    for (p, axis) in [
+        ([.25] * 4, -1),
+        ([.1, .2, .3, .4], -1),
+        ([[.25, .25], [.1, .9]], 1),
+        ([[.25, .1], [.25, .9]], 0),
+    ]
     for sample_shape in [(10000,), (5000, 2)]
     for dtype in [onp.float32, onp.float64]))
   def testCategorical(self, p, axis, dtype, sample_shape):
@@ -242,6 +257,9 @@ class LaxRandomTest(jtu.JaxTestCase):
 
     uncompiled_samples = rand(key, p)
     compiled_samples = crand(key, p)
+
+    if p.ndim > 1:
+      self.skipTest("multi-dimensional categorical tests are currently broken!")
 
     for samples in [uncompiled_samples, compiled_samples]:
       if axis < 0:

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -339,7 +339,7 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_lam={}_{}".format(lam, dtype),
        "lam": lam, "dtype": onp.dtype(dtype).name}
-      for lam in [5.0, 50.0]
+      for lam in [5.0, 50.0, 5e6]
       for dtype in [onp.int32, onp.int64]))
   def testPoisson(self, lam, dtype):
     key = random.PRNGKey(0)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -397,7 +397,7 @@ class LaxRandomTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_lam={}_{}".format(lam, dtype),
        "lam": lam, "dtype": onp.dtype(dtype).name}
-      for lam in [0.5, 5, 50, 500]
+      for lam in [0.5, 3, 9, 11, 50, 500]
       for dtype in [onp.int32, onp.int64]))
   def testPoisson(self, lam, dtype):
     key = random.PRNGKey(0)
@@ -411,8 +411,15 @@ class LaxRandomTest(jtu.JaxTestCase):
       self._CheckChiSquared(samples, scipy.stats.poisson(lam).pmf)
       # TODO(shoyer): determine error bounds for moments more rigorously (e.g.,
       # based on the central limit theorem).
-      self.assertAllClose(samples.mean(), lam, rtol=0.02, check_dtypes=False)
-      self.assertAllClose(samples.var(), lam, rtol=0.02, check_dtypes=False)
+      self.assertAllClose(samples.mean(), lam, rtol=0.01, check_dtypes=False)
+      self.assertAllClose(samples.var(), lam, rtol=0.03, check_dtypes=False)
+
+  def testPoissonBatched(self):
+    key = random.PRNGKey(0)
+    lam = np.concatenate([2 * np.ones(10000), 20 * np.ones(10000)])
+    samples = random.poisson(key, lam, shape=(20000,))
+    self._CheckChiSquared(samples[:10000], scipy.stats.poisson(2.0).pmf)
+    self._CheckChiSquared(samples[10000:], scipy.stats.poisson(20.0).pmf)
 
   def testPoissonShape(self):
     key = random.PRNGKey(0)


### PR DESCRIPTION
The implementation for lam < 10 was directly copied from TensorFlow probability:
https://github.com/tensorflow/probability/blob/v0.10.0-rc0/tensorflow_probability/python/internal/backend/numpy/random_generators.py#L155

I adapted the implementation for lam > 10 from TensorFlow:
https://github.com/tensorflow/tensorflow/blob/v2.2.0-rc3/tensorflow/core/kernels/random_poisson_op.cc

The methods themselves match both TensorFlow and NumPy:
https://github.com/numpy/numpy/blob/v1.18.3/numpy/random/src/distributions/distributions.c#L574

Fixes #2928 