### PR TITLE
rewrite axis_index implementation, use custom bind

### DIFF
--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1037,6 +1037,17 @@ class PmapTest(jtu.JaxTestCase):
     tol = 1e-1 if jtu.device_under_test() == "tpu" else 1e-3
     self.assertAllClose(result, expected, check_dtypes=False, atol=tol, rtol=tol)
 
+  def testAxisIndexRemat(self):
+    # https://github.com/google/jax/issues/2716
+    n = len(jax.devices())
+
+    def f(key):
+      key = random.fold_in(key, jax.lax.axis_index('i'))
+      return random.bernoulli(key, p=0.5)
+
+    keys = random.split(random.PRNGKey(0), n)
+    jax.pmap(jax.remat(f), axis_name='i')(keys)
+
 
 class PmapWithDevicesTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
fixes #2716

`lax.axis_index` is an odd duck because by construction it never has any data dependence on Tracers, yet its corresponding computation must be staged out to XLA's `ReplicaId`. Instead we rely on the global trace state context for its behavior.

However, it was implemented in a weird way, and #2716 even exposed this approach was buggy. The weird thing was that instead of writing a custom bind rule, since the standard bind only works on data dependence and we wanted to do something different, instead I wrote it so that the dynamic context logic was in the "traceable" function `axis_index`, and that logic set up a lifted dummy arg so that the standard data-dependence bind rule would work.

#2716 showed us that this breaks round-trippability through `eval_jaxpr` (needed by e.g. `remat`) because `eval_jaxpr` calls the bind rule directly and does not call the traceable function wrapper.

The solution was just to get rid of this indirect way of using the standard bind and just implement `axis_index` in terms of a custom bind rule which inspects the dynamic trace context as needed.

(We also realized that `axis_index` won't work in custom jvp/vjp rules in some casees because of how the dynamic axis index environment is not included in the trace state copied during thunkification. But we want to move axis index stuff into core.py so that we can reuse it for vmap anyway. Follow-up todo for me!)