### PR TITLE
Remove usage of xla_client.{Computation,ComputationBuilder}.

### DIFF
--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -686,6 +686,7 @@
         "colab": {}
       },
       "source": [
+        "import jax.lib.xla_client\n",
         "@trace(\"multiply_add_xla_translation\")\n",
         "def multiply_add_xla_translation(c, xc, yc, zc):\n",
         "  \"\"\"The compilation to XLA of the primitive.\n",
@@ -695,7 +696,7 @@
         "\n",
         "  Does not need to be a JAX-traceable function.\n",
         "  \"\"\"\n",
-        "  return c.Add(c.Mul(xc, yc), zc)\n",
+        "  return xla_client.ops.Add(xla_client.ops.Mul(xc, yc), zc)\n",
         "\n",
         "# Now we register the XLA compilation rule with JAX\n",
         "# TODO: for GPU? and TPU?\n",

--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -686,7 +686,7 @@
         "colab": {}
       },
       "source": [
-        "import jax.lib.xla_client\n",
+        "from jax.lib import xla_client\n",
         "@trace(\"multiply_add_xla_translation\")\n",
         "def multiply_add_xla_translation(c, xc, yc, zc):\n",
         "  \"\"\"The compilation to XLA of the primitive.\n",

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -50,12 +50,16 @@ from ..abstract_arrays import (ConcreteArray, ShapedArray, array_types,
 from ..util import (partial, unzip2, prod, safe_map, safe_zip,
                     extend_name_stack, wrap_name)
 from ..lib import xla_bridge as xb
+from ..lib import xla_client as xc
 from ..tree_util import tree_map
 from .batching import broadcast, not_mapped
 from . import batching
 from . import partial_eval as pe
 from . import xla
 from . import ad
+
+
+xops = xc.ops
 
 FLAGS = flags.FLAGS
 
@@ -405,10 +409,10 @@ def _axis_index_partial_eval(trace, _, **params):
   return out_tracer
 
 def _axis_index_translation_rule(c, nreps, sizes, soft_size, axis_name):
-  div = c.Constant(onp.array(nreps // prod(sizes), dtype=onp.uint32))
-  mod = c.Constant(onp.array(sizes[-1], dtype=onp.uint32))
-  unsigned_index = c.Rem(c.Div(c.ReplicaId(), div), mod)
-  return c.ConvertElementType(unsigned_index, xb.dtype_to_etype(onp.int32))
+  div = xb.constant(c, onp.array(nreps // prod(sizes), dtype=onp.uint32))
+  mod = xb.constant(c, onp.array(sizes[-1], dtype=onp.uint32))
+  unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
+  return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(onp.int32))
 
 axis_index_p = core.Primitive('axis_index')
 xla.translations[axis_index_p] = _axis_index_translation_rule
@@ -542,7 +546,7 @@ def _shard_sharded_device_array_slow_path(x, devices, indices):
 shard_arg_handlers[ShardedDeviceArray] = _shard_sharded_device_array_slow_path
 
 def _sharded_device_array_constant_handler(c, val, canonicalize_types=True):
-  return c.Constant(onp.asarray(val), canonicalize_types=canonicalize_types)
+  return xb.constant(c, onp.asarray(val), canonicalize_types=canonicalize_types)
 xb.register_constant_handler(ShardedDeviceArray, _sharded_device_array_constant_handler)
 
 core.pytype_aval_mappings[ShardedDeviceArray] = ConcreteArray
@@ -649,11 +653,11 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
   tuple_args = len(sharded_avals) > 100  # pass long arg lists as tuple for TPU
 
   c = xb.make_computation_builder("pmap_{}".format(fun.__name__))
-  xla_consts = _map(c.Constant, consts)
+  xla_consts = _map(partial(xb.constant, c), consts)
   xla_args = xla._xla_callable_args(c, sharded_avals, tuple_args)
   out_nodes = xla.jaxpr_subcomp(c, jaxpr, backend, axis_env, xla_consts,
                                 extend_name_stack(wrap_name(name, 'pmap')), *xla_args)
-  built = c.Build(c.Tuple(*out_nodes))
+  built = c.Build(xops.Tuple(c, out_nodes))
 
   if devices is None:
     if num_global_replicas > xb.device_count(backend):
@@ -694,8 +698,8 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
           num_partitions=1,
           device_assignment=device_assignment)
   compile_options.tuple_arguments = tuple_args
-  compiled = built.Compile(compile_options=compile_options,
-                           backend=xb.get_backend(backend))
+  backend = xb.get_backend(backend)
+  compiled = backend.compile(built, compile_options=compile_options)
 
   input_sharding_specs = [_pmap_sharding_spec(num_local_replicas, axis_size,
                                               aval.shape)
@@ -843,7 +847,7 @@ def _pmap_translation_rule(c, axis_env,
   out_avals = [v.aval for v in call_jaxpr.outvars]
   outs = [_xla_unshard(c, aval, new_env, shard, backend=backend)
           for aval, shard in zip(out_avals, sharded_outs)]
-  return c.Tuple(*outs)
+  return xops.Tuple(c, outs)
 
 xla.call_translations[xla_pmap_p] = _pmap_translation_rule
 ad.primitive_transposes[xla_pmap_p] = partial(ad.map_transpose, xla_pmap_p)
@@ -853,9 +857,9 @@ def _xla_shard(c, aval, axis_env, x):
     return x
   elif isinstance(aval, ShapedArray):
     dims = list(c.GetShape(x).dimensions())
-    zero = c.Constant(onp.zeros((), dtype=onp.uint32))
+    zero = xb.constant(c, onp.zeros((), dtype=onp.uint32))
     idxs = [_unravel_index(c, axis_env)] + [zero] * (len(dims) - 1)
-    return c.Reshape(c.DynamicSlice(x, idxs, [1] + dims[1:]), None, dims[1:])
+    return xops.Reshape(xops.DynamicSlice(x, idxs, [1] + dims[1:]), dims[1:])
   else:
     raise TypeError((aval, c.GetShape(x)))
 
@@ -868,29 +872,31 @@ def _xla_unshard(c, aval, axis_env, x, backend):
     convert_bool = (onp.issubdtype(aval.dtype, onp.bool_)
                     and xb.get_backend(backend).platform in ('cpu', 'gpu'))
     if convert_bool:
-      x = c.ConvertElementType(x, xb.dtype_to_etype(onp.float32))
+      x = xops.ConvertElementType(x, xb.dtype_to_etype(onp.float32))
 
     xla_shape = c.GetShape(x)
     dims = list(xla_shape.dimensions())
-    padded = c.Broadcast(c.Constant(onp.array(0, xla_shape.numpy_dtype())),
+    padded = xops.Broadcast(xb.constant(c, onp.array(0, xla_shape.numpy_dtype())),
                          [axis_env.sizes[-1]] + dims)
-    zero = c.Constant(onp.zeros((), dtype=onp.uint32))
+    zero = xb.constant(c, onp.zeros((), dtype=onp.uint32))
     idxs = [_unravel_index(c, axis_env)] + [zero] * len(dims)
-    padded = c.DynamicUpdateSlice(padded, c.Reshape(x, None, [1] + dims), idxs)
-    out = c.CrossReplicaSum(padded, xla.axis_groups(axis_env, axis_env.names[-1]))
+    padded = xops.DynamicUpdateSlice(padded, xops.Reshape(x, [1] + dims), idxs)
+    replica_groups_protos = xc.make_replica_groups(
+      xla.axis_groups(axis_env, axis_env.names[-1]))
+    out = xops.CrossReplicaSum(padded, replica_groups_protos)
 
     # TODO(mattjj): remove this logic when AllReduce PRED supported on CPU / GPU
     if convert_bool:
-      nonzero = c.Ne(out, c.Constant(onp.array(0, dtype=onp.float32)))
-      out = c.ConvertElementType(nonzero, xb.dtype_to_etype(onp.bool_))
+      nonzero = xops.Ne(out, xb.constant(c, onp.array(0, dtype=onp.float32)))
+      out = xops.ConvertElementType(nonzero, xb.dtype_to_etype(onp.bool_))
     return out
   else:
     raise TypeError((aval, c.GetShape(x)))
 
 def _unravel_index(c, axis_env):
-  div = c.Constant(onp.array(axis_env.nreps // prod(axis_env.sizes), onp.uint32))
-  mod = c.Constant(onp.array(axis_env.sizes[-1], onp.uint32))
-  return c.Rem(c.Div(c.ReplicaId(), div), mod)
+  div = xb.constant(c, onp.array(axis_env.nreps // prod(axis_env.sizes), onp.uint32))
+  mod = xb.constant(c, onp.array(axis_env.sizes[-1], onp.uint32))
+  return xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
 
 
 ### soft_pmap axis split transformation

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -52,6 +52,10 @@ from ..lib import pytree
 from ..lib import xla_bridge
 from ..lib import xla_client
 
+xb = xla_bridge
+xc = xla_client
+xops = xla_client.ops
+
 FLAGS = flags.FLAGS
 
 _max = builtins.max
@@ -1705,7 +1709,7 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
 
 def standard_translate(name, c, *args, **kwargs):
   xla_opname = ''.join(term.capitalize() for term in name.split('_'))
-  return getattr(c, xla_opname)(*args, **kwargs)
+  return getattr(xops, xla_opname)(*args, **kwargs)
 
 
 def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
@@ -1815,18 +1819,19 @@ def _sign_translation_rule(c, x):
   shape = c.GetShape(x)
   dtype = shape.numpy_dtype()
   if dtypes.issubdtype(dtype, onp.unsignedinteger):
-    zero = c.Constant(onp.array(0, dtype=dtype))
+    zero = xb.constant(c, onp.array(0, dtype=dtype))
     dims = c.GetShape(x).dimensions()
-    return c.Select(c.Eq(x, zero), c.Broadcast(zero, dims),
-                    c.Broadcast(c.Constant(onp.array(1, dtype=dtype)), dims))
-  return c.Sign(x)
+    return xops.Select(xops.Eq(x, zero), xops.Broadcast(zero, dims),
+                       xops.Broadcast(xb.constant(c, onp.array(1, dtype=dtype)),
+                                      dims))
+  return xops.Sign(x)
 
 sign_p = standard_unop(_num, 'sign', translation_rule=_sign_translation_rule)
 ad.defjvp_zero(sign_p)
 
 nextafter_p = standard_naryop(
   [_float, _float], 'nextafter',
-  translation_rule=lambda c, x1, x2: c.NextAfter(x1, x2))
+  translation_rule=lambda c, x1, x2: xops.NextAfter(x1, x2))
 
 floor_p = standard_unop(_float, 'floor')
 ad.defjvp_zero(floor_p)
@@ -1971,7 +1976,7 @@ def _conj_transpose_rule(t, x, *, input_dtype):
   else:
     return [real(t)]
 
-xla.translations[conj_p] = lambda c, x, **kwargs: c.Conj(x)
+xla.translations[conj_p] = lambda c, x, **kwargs: xops.Conj(x)
 ad.primitive_jvps[conj_p] = partial(ad.linear_jvp, conj_p)
 ad.primitive_transposes[conj_p] = _conj_transpose_rule
 
@@ -2068,32 +2073,31 @@ def _broadcasting_select(c, which, x, y):
   out_shape = broadcast_shapes(which_shape, x_shape, y_shape)
   bcast_dims = lambda shape: tuple(range(len(out_shape) - len(shape),
                                          len(out_shape)))
-  which = c.BroadcastInDim(which, out_shape, bcast_dims(which_shape))
-  x = c.BroadcastInDim(x, out_shape, bcast_dims(x_shape))
-  y = c.BroadcastInDim(y, out_shape, bcast_dims(y_shape))
-  return c.Select(which, x, y)
+  which = xops.BroadcastInDim(which, out_shape, bcast_dims(which_shape))
+  x = xops.BroadcastInDim(x, out_shape, bcast_dims(x_shape))
+  y = xops.BroadcastInDim(y, out_shape, bcast_dims(y_shape))
+  return xops.Select(which, x, y)
 
 
 def _minmax_translation_rule(c, x, y, *, minmax=None, cmp=None):
   dtype = c.GetShape(x).numpy_dtype()
   if dtypes.issubdtype(dtype, onp.complexfloating):
-    comparator = cmp(c)
-    rx = c.Real(x)
-    ry = c.Real(y)
+    rx = xops.Real(x)
+    ry = xops.Real(y)
     return _broadcasting_select(
-        c, c.Select(c.Eq(rx, ry), comparator(c.Imag(x), c.Imag(y)),
-                    comparator(rx, ry)),
+        c, xops.Select(xops.Eq(rx, ry), cmp(xops.Imag(x), xops.Imag(y)),
+                       cmp(rx, ry)),
         x, y)
-  return minmax(c)(x, y)
+  return minmax(x, y)
 
 max_p = standard_naryop([_any, _any], 'max', translation_rule=partial(
-    _minmax_translation_rule, minmax=lambda c: c.Max, cmp=lambda c: c.Gt))
+    _minmax_translation_rule, minmax=xops.Max, cmp=xops.Gt))
 ad.defjvp2(max_p,
            lambda g, ans, x, y: mul(_brcast(g, y), _balanced_eq(x, ans, y)),
            lambda g, ans, x, y: mul(_brcast(g, x), _balanced_eq(y, ans, x)))
 
 min_p = standard_naryop([_any, _any], 'min', translation_rule=partial(
-    _minmax_translation_rule, minmax=lambda c: c.Min, cmp=lambda c: c.Lt))
+    _minmax_translation_rule, minmax=xops.Min, cmp=xops.Lt))
 ad.defjvp2(min_p,
            lambda g, ans, x, y: mul(_brcast(g, y), _balanced_eq(x, ans, y)),
            lambda g, ans, x, y: mul(_brcast(g, x), _balanced_eq(y, ans, x)))
@@ -2136,9 +2140,9 @@ def _convert_element_type_dtype_rule(operand, *, new_dtype, old_dtype):
 def _convert_element_type_translation_rule(c, operand, *, new_dtype, old_dtype):
   if (dtypes.issubdtype(old_dtype, onp.complexfloating) and
       not dtypes.issubdtype(new_dtype, onp.complexfloating)):
-    operand = c.Real(operand)
+    operand = xops.Real(operand)
   new_etype = xla_client.dtype_to_etype(new_dtype)
-  return c.ConvertElementType(operand, new_element_type=new_etype)
+  return xops.ConvertElementType(operand, new_element_type=new_etype)
 
 def _convert_element_type_transpose_rule(t, *, new_dtype, old_dtype):
   assert t.dtype == new_dtype, (t.dtype, new_dtype)
@@ -2161,7 +2165,7 @@ def _bitcast_convert_type_dtype_rule(operand, *, new_dtype):
 
 def _bitcast_convert_type_translation_rule(c, operand, *, new_dtype):
   new_etype = xla_bridge.dtype_to_etype(new_dtype)
-  return c.BitcastConvertType(operand, new_element_type=new_etype)
+  return xops.BitcastConvertType(operand, new_element_type=new_etype)
 
 bitcast_convert_type_p = standard_primitive(
     _bitcast_convert_type_shape_rule, _bitcast_convert_type_dtype_rule,
@@ -2331,10 +2335,10 @@ def _conv_general_dilated_translation_rule(
     **unused_kwargs):
   assert type(dimension_numbers) is ConvDimensionNumbers
   dimension_numbers = _conv_general_proto(dimension_numbers)
-  return c.ConvGeneralDilated(lhs, rhs, window_strides, padding, lhs_dilation,
-                              rhs_dilation, dimension_numbers,
-                              feature_group_count, batch_group_count,
-                              precision_config=_precision_config(precision))
+  return xops.ConvGeneralDilated(lhs, rhs, window_strides, padding, lhs_dilation,
+                                 rhs_dilation, dimension_numbers,
+                                 feature_group_count, batch_group_count,
+                                 precision_config=_precision_config(precision))
 
 def _conv_general_dilated_batch_rule(
     batched_args, batch_dims, *, window_strides, padding,
@@ -2569,8 +2573,9 @@ def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
   return batched_out, int(result_batch_dim)
 
 def _dot_general_translation_rule(c, lhs, rhs, *, dimension_numbers, precision):
-  return c.DotGeneral(lhs, rhs, dimension_numbers,
-                      precision_config=_precision_config(precision))
+  return xops.DotGeneral(lhs, rhs,
+                         xc.make_dot_dimension_numbers(dimension_numbers),
+                         precision_config=_precision_config(precision))
 
 def _dot_general_masking_rule(padded_vals, logical_shapes, *, dimension_numbers,
                               precision):
@@ -2734,7 +2739,7 @@ def _concatenate_dtype_rule(*operands, **kwargs):
 
 def _concatenate_translation_rule(c, *operands, **kwargs):
   dimension = kwargs.pop('dimension')
-  return c.Concatenate(operands, dimension=dimension)
+  return xops.ConcatInDim(c, operands, dimension)
 
 def _concatenate_transpose_rule(t, *operands, dimension):
   operand_shapes = [o.aval.shape if ad.is_undefined_primal(o) else o.shape
@@ -2812,7 +2817,12 @@ def _pad_batch_rule(batched_args, batch_dims, *, padding_config):
   else:
     raise NotImplementedError  # loop and stack
 
-pad_p = standard_primitive(_pad_shape_rule, _pad_dtype_rule, 'pad')
+def _pad_translation_rule(c, operand, padding_value, *, padding_config):
+  return xops.Pad(operand, padding_value,
+                  xc.make_padding_config(padding_config))
+
+pad_p = standard_primitive(_pad_shape_rule, _pad_dtype_rule, 'pad',
+                           translation_rule=_pad_translation_rule)
 ad.deflinear(pad_p, _pad_transpose)
 ad.primitive_transposes[pad_p] = _pad_transpose
 batching.primitive_batchers[pad_p] = _pad_batch_rule
@@ -2926,7 +2936,10 @@ def _reshape_dtype_rule(operand, *, new_sizes, dimensions):
   return operand.dtype
 
 def _reshape_translation_rule(c, operand, *, new_sizes, dimensions):
-  return c.Reshape(operand, new_sizes=new_sizes, dimensions=dimensions)
+  if dimensions is None:
+    return xops.Reshape(operand, new_sizes)
+  else:
+    return xops.Reshape(operand, dimensions, new_sizes)
 
 def _reshape_transpose_rule(t, operand, *, new_sizes, dimensions):
   assert ad.is_undefined_primal(operand)
@@ -3121,7 +3134,8 @@ def _slice_shape_rule(operand, *, start_indices, limit_indices, strides):
 
 def _slice_translation_rule(c, operand, *, start_indices, limit_indices,
                             strides):
-  return c.Slice(operand, start_indices, limit_indices, strides)
+  return xops.Slice(operand, start_indices, limit_indices,
+                    strides or [1] * len(start_indices))
 
 def _slice_transpose_rule(t, operand, *, start_indices, limit_indices, strides):
   assert ad.is_undefined_primal(operand)
@@ -3192,7 +3206,7 @@ def _dynamic_slice_dtype_rule(operand, *start_indices, slice_sizes):
   return operand.dtype
 
 def _dynamic_slice_translation_rule(c, operand, *start_indices, slice_sizes):
-  return c.DynamicSlice(operand, start_indices, slice_sizes)
+  return xops.DynamicSlice(operand, start_indices, slice_sizes)
 
 def _dynamic_slice_jvp(primals, tangents, *, slice_sizes):
   tangent_out = ad_util.zero
@@ -3296,7 +3310,7 @@ def _dynamic_update_slice_transpose_rule(t, operand, update, *start_indices):
   return [operand_t, update_t] + [None] * len(start_indices)
 
 def _dynamic_update_slice_translation_rule(c, operand, update, *start_indices):
-  return c.DynamicUpdateSlice(operand, update, start_indices)
+  return xops.DynamicUpdateSlice(operand, update, start_indices)
 
 def _dynamic_update_slice_batching_rule(batched_args, batch_dims):
   # A dynamic update slice is a special case of scatter; we can delegate to the
@@ -3357,9 +3371,10 @@ def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
 def _gather_translation_rule(c, operand, start_indices, *, dimension_numbers,
                              slice_sizes):
   indices_shape = c.GetShape(start_indices)
-  return c.Gather(
+  return xops.Gather(
     operand, start_indices,
-    _gather_dimensions_proto(indices_shape, dimension_numbers), slice_sizes)
+    _gather_dimensions_proto(indices_shape, dimension_numbers), slice_sizes,
+    indices_are_sorted=False)
 
 def _gather_jvp_rule(g, operand, start_indices, *, dimension_numbers,
                      slice_sizes):
@@ -3464,12 +3479,13 @@ def _scatter_shape_rule(operand, scatter_indices, updates, **kwargs):
 def _scatter_translation_rule(c, operand, scatter_indices, updates,
                               update_jaxpr, update_consts, dimension_numbers):
   dtype = c.GetShape(operand).numpy_dtype()
-  init_value = c.Constant(onp.array(0, dtype))
+  init_value = xb.constant(c, onp.array(0, dtype))
   update_computation = _reduction_computation(
       c, update_jaxpr, update_consts, init_value)
   indices_shape = c.GetShape(scatter_indices)
-  return c.Scatter(operand, scatter_indices, updates, update_computation,
-                  _scatter_dimensions_proto(indices_shape, dimension_numbers))
+  return xops.Scatter(operand, scatter_indices, updates, update_computation,
+                      _scatter_dimensions_proto(indices_shape, dimension_numbers),
+                      False, False)
 
 def _scatter_add_jvp(primals, tangents, *, update_jaxpr, update_consts,
                      dimension_numbers):
@@ -3747,7 +3763,7 @@ def _reduce_shape_rule(operand, init_value, *, computation, jaxpr, consts,
 def _reduce_translation_rule(c, operand, init_value, *, computation, jaxpr,
                              consts, dimensions):
   xla_computation = _reduction_computation(c, jaxpr, consts, init_value)
-  return c.Reduce(operand, init_value, xla_computation, dimensions)
+  return xops.Reduce(c, [operand], [init_value], xla_computation, dimensions)
 
 def _reduce_batch_rule(batched_args, batch_dims, *, computation, jaxpr, consts,
                        dimensions):
@@ -3766,7 +3782,7 @@ def _reduction_computation(c, jaxpr, consts, init_value):
   axis_env = xla.AxisEnv(1)  # no parallel primitives inside reductions
   subc = xla_bridge.make_computation_builder("reduction_computation")
   assert len(consts) == 0, "Reduction computations cannot have constants"
-  args = [subc.ParameterWithShape(shape), subc.ParameterWithShape(shape)]
+  args = [xb.parameter(subc, 0, shape), xb.parameter(subc, 1, shape)]
   out, = xla.jaxpr_subcomp(subc, jaxpr, None, axis_env, consts, '', *args)
   return subc.Build(out)
 
@@ -3800,9 +3816,9 @@ def _reduce_sum_shape_rule(operand, *, axes):
 def _reduce_sum_translation_rule(c, operand, *, axes):
   dtype = c.GetShape(operand).numpy_dtype()
   scalar = ShapedArray((), dtype)
-  return c.Reduce(operand, c.Constant(onp.array(0, dtype)),
-                  xla.primitive_subcomputation(add_p, scalar, scalar),
-                  axes)
+  return xops.Reduce(c, [operand], [xb.constant(c, onp.array(0, dtype))],
+                     xla.primitive_subcomputation(add_p, scalar, scalar),
+                     axes)
 
 def _reduce_sum_transpose_rule(cotangent, operand, *, axes):
   assert ad.is_undefined_primal(operand)
@@ -3827,8 +3843,8 @@ def _reduce_op_shape_rule(operand, *, axes):
 def _reduce_prod_translation_rule(c, operand, *, axes):
   dtype = c.GetShape(operand).numpy_dtype()
   scalar = ShapedArray((), dtype)
-  return c.Reduce(operand, c.Constant(onp.array(1, dtype)),
-                  xla.primitive_subcomputation(mul_p, scalar, scalar), axes)
+  return xops.Reduce(c, [operand], [xb.constant(c, onp.array(1, dtype))],
+                     xla.primitive_subcomputation(mul_p, scalar, scalar), axes)
 
 def _reduce_prod_jvp_rule(primals, tangents, *, axes):
   operand, = primals
@@ -3877,8 +3893,8 @@ def _reduce_chooser_shape_rule(operand, *, axes):
 def _reduce_chooser_translation_rule(prim, identity, c, operand, *, axes):
   dtype = c.GetShape(operand).numpy_dtype()
   scalar = ShapedArray((), dtype)
-  return c.Reduce(operand, c.Constant(identity(dtype)),
-                  xla.primitive_subcomputation(prim, scalar, scalar), axes)
+  return xops.Reduce(c, [operand], [xb.constant(c, identity(dtype))],
+                     xla.primitive_subcomputation(prim, scalar, scalar), axes)
 
 def _reduce_chooser_jvp_rule(g, ans, operand, *, axes):
   # TODO(mattjj): an alternative is to use variadic reduce to compute the chosen
@@ -3914,8 +3930,8 @@ def _reduce_logical_shape_rule(operand, *, axes):
 
 def _reduce_logical_translation_rule(prim, identity, c, operand, *, axes):
   scalar = ShapedArray((), onp.bool_)
-  return c.Reduce(operand, c.Constant(identity(onp.bool_)),
-                  xla.primitive_subcomputation(prim, scalar, scalar), axes)
+  return xops.Reduce(c, [operand], [xb.constant(c, identity(onp.bool_))],
+                     xla.primitive_subcomputation(prim, scalar, scalar), axes)
 
 _reduce_or_translation_rule = partial(_reduce_logical_translation_rule,
                                       or_p, _get_max_identity)
@@ -3942,8 +3958,12 @@ def _reduce_window_shape_rule(operand, init_value, *, jaxpr, consts,
 def _reduce_window_translation_rule(c, operand, init_value, *, jaxpr, consts,
                                     window_dimensions, window_strides, padding):
   xla_computation = _reduction_computation(c, jaxpr, consts, init_value)
-  return c.ReduceWindow(operand, init_value, xla_computation, window_dimensions,
-                        window_strides, padding)
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  return xops.ReduceWindowWithGeneralPadding(
+    operand, init_value, xla_computation, window_dimensions,
+    window_strides, (), (), pads)
 
 def _generic_reduce_window_batch_rule(
     batched_args, batch_dims, *, jaxpr, consts, window_dimensions,
@@ -3980,9 +4000,13 @@ def _reduce_window_sum_translation_rule(c, operand, *, window_dimensions,
                                         window_strides, padding):
   dtype = c.GetShape(operand).numpy_dtype()
   scalar = ShapedArray((), dtype)
-  return c.ReduceWindow(operand, c.Constant(onp.array(0, dtype)),
-                        xla.primitive_subcomputation(add_p, scalar, scalar),
-                        window_dimensions, window_strides, padding)
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  return xops.ReduceWindowWithGeneralPadding(
+    operand, xb.constant(c, onp.array(0, dtype)),
+    xla.primitive_subcomputation(add_p, scalar, scalar), window_dimensions,
+    window_strides, (), (), pads)
 
 def _reduce_window_sum_transpose_rule(cotangent, operand, *, window_dimensions,
                                       window_strides, padding):
@@ -4028,9 +4052,13 @@ def _reduce_window_chooser_translation_rule(
     prim, identity, c, operand, *, window_dimensions, window_strides, padding):
   dtype = c.GetShape(operand).numpy_dtype()
   scalar = ShapedArray((), dtype)
-  return c.ReduceWindow(operand, c.Constant(identity(dtype)),
-                        xla.primitive_subcomputation(prim, scalar, scalar),
-                        window_dimensions, window_strides, padding)
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  return xops.ReduceWindowWithGeneralPadding(
+    operand, xb.constant(c, identity(dtype)),
+    xla.primitive_subcomputation(prim, scalar, scalar), window_dimensions,
+    window_strides, (), (), pads)
 
 def _reduce_window_chooser_jvp_rule(prim, g, operand, *, window_dimensions,
                                     window_strides, padding):
@@ -4102,8 +4130,12 @@ def _select_and_scatter_translation(
   scatter_consts, window_dimensions, window_strides, padding):
   select = _reduction_computation(c, select_jaxpr, select_consts, init_value)
   scatter = _reduction_computation(c, scatter_jaxpr, scatter_consts, init_value)
-  return c.SelectAndScatter(operand, select, window_dimensions, window_strides,
-                            padding, source, init_value, scatter)
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  return xops.SelectAndScatterWithGeneralPadding(
+    operand, select, window_dimensions, window_strides, pads, source,
+    init_value, scatter)
 
 select_and_scatter_p = standard_primitive(
     _select_and_scatter_shape_rule, _input_dtype, 'select_and_scatter',
@@ -4122,9 +4154,13 @@ def _select_and_scatter_add_translation(
   scalar = ShapedArray((), dtype)
   select = xla.primitive_subcomputation(select_prim, scalar, scalar)
   scatter = xla.primitive_subcomputation(add_p, scalar, scalar)
-  zero = c.Constant(onp.array(0, dtype))
-  return c.SelectAndScatter(operand, select, window_dimensions, window_strides,
-                            padding, source, zero, scatter)
+  zero = xb.constant(c, onp.array(0, dtype))
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  return xops.SelectAndScatterWithGeneralPadding(
+    operand, select, window_dimensions, window_strides, pads, source, zero,
+    scatter)
 
 def _select_and_scatter_add_jvp(
     primals, tangents, *, select_prim, window_dimensions, window_strides,
@@ -4219,8 +4255,8 @@ def _select_and_gather_add_translation(
   assert nbits <= max_bits
   double_word_reduction = nbits * 2 <= max_bits
 
-  const = lambda c, dtype, x: c.Constant(onp.array(x, dtype=dtype),
-                                         canonicalize_types=False)
+  const = lambda c, dtype, x: xb.constant(c, onp.array(x, dtype=dtype),
+                                          canonicalize_types=False)
 
   if double_word_reduction:
     # TODO(b/73062247): XLA doesn't yet implement ReduceWindow on tuples, so
@@ -4233,21 +4269,21 @@ def _select_and_gather_add_translation(
 
     # Packs two values into a tuple.
     def pack(a, b):
-      a = c.BitcastConvertType(a, word_type)
-      b = c.BitcastConvertType(b, word_type)
-      a = c.ConvertElementType(a, double_word_type)
-      b = c.ConvertElementType(b, double_word_type)
-      a = c.ShiftLeft(a, const(c, double_word_dtype, nbits))
-      return c.Or(a, b)
+      a = xops.BitcastConvertType(a, word_type)
+      b = xops.BitcastConvertType(b, word_type)
+      a = xops.ConvertElementType(a, double_word_type)
+      b = xops.ConvertElementType(b, double_word_type)
+      a = xops.ShiftLeft(a, const(c, double_word_dtype, nbits))
+      return xops.Or(a, b)
 
     # Unpacks the first element of a tuple.
     def fst(c, t):
-      st = c.ShiftRightLogical(t, const(c, double_word_dtype, nbits))
-      return c.BitcastConvertType(c.ConvertElementType(st, word_type), etype)
+      st = xops.ShiftRightLogical(t, const(c, double_word_dtype, nbits))
+      return xops.BitcastConvertType(xops.ConvertElementType(st, word_type), etype)
 
     # Unpacks the second element of a tuple.
     def snd(t):
-      return c.BitcastConvertType(c.ConvertElementType(t, word_type), etype)
+      return xops.BitcastConvertType(xops.ConvertElementType(t, word_type), etype)
 
   else:
     # The double-word trick above only works if we have a sufficiently large
@@ -4268,41 +4304,43 @@ def _select_and_gather_add_translation(
 
     # Packs two values into a tuple.
     def pack(a, b):
-      a = c.ReducePrecision(a, exponent_bits=nexp, mantissa_bits=nmant)
-      b = c.ReducePrecision(b, exponent_bits=nexp, mantissa_bits=nmant)
-      a = c.BitcastConvertType(a, word_type)
-      b = c.BitcastConvertType(b, word_type)
-      b = c.ShiftRightLogical(b, const(c, word_dtype, r_nbits))
-      return c.Or(a, b)
+      a = xops.ReducePrecision(a, exponent_bits=nexp, mantissa_bits=nmant)
+      b = xops.ReducePrecision(b, exponent_bits=nexp, mantissa_bits=nmant)
+      a = xops.BitcastConvertType(a, word_type)
+      b = xops.BitcastConvertType(b, word_type)
+      b = xops.ShiftRightLogical(b, const(c, word_dtype, r_nbits))
+      return xops.Or(a, b)
 
     # Unpacks the first element of a tuple.
     def fst(c, t):
-      st = c.And(t, const(c, word_dtype, ((1 << r_nbits) - 1) << r_nbits))
-      return c.BitcastConvertType(st, etype)
+      st = xops.And(t, const(c, word_dtype, ((1 << r_nbits) - 1) << r_nbits))
+      return xops.BitcastConvertType(st, etype)
 
     # Unpacks the second element of a tuple.
     def snd(t):
-      return c.BitcastConvertType(c.ShiftLeft(t, const(c, word_dtype, r_nbits)),
+      return xops.BitcastConvertType(xops.ShiftLeft(t, const(c, word_dtype, r_nbits)),
                                   etype)
 
   def reducer():
     c = xla_bridge.make_computation_builder("select_and_gather_pair_reducer")
-    x = c.ParameterWithShape(
+    x = xb.parameter(c, 0,
       xla_client.Shape.array_shape(onp.dtype(double_word_dtype), ()))
-    y = c.ParameterWithShape(
+    y = xb.parameter(c, 1,
       xla_client.Shape.array_shape(onp.dtype(double_word_dtype), ()))
     assert select_prim is ge_p or select_prim is le_p
-    which = c.Ge if select_prim is ge_p else c.Le
-    c.Select(which(fst(c, x), fst(c, y)), x, y)
+    which = xops.Ge if select_prim is ge_p else xops.Le
+    xops.Select(which(fst(c, x), fst(c, y)), x, y)
     return c.Build()
 
 
   assert select_prim is ge_p or select_prim is le_p, select_prim
   init = -onp.inf if select_prim is ge_p else onp.inf
-  out = c.ReduceWindow(pack(operand, tangents),
-                       pack(const(c, dtype, init), const(c, dtype, 0)),
-                       reducer(), window_dimensions, window_strides,
-                       padding)
+  pads = xc.window_padding_type_to_pad_values(
+    padding, c.GetShape(operand).dimensions(), window_dimensions,
+    window_strides)
+  out = xops.ReduceWindowWithGeneralPadding(
+    pack(operand, tangents), pack(const(c, dtype, init), const(c, dtype, 0)),
+    reducer(), window_dimensions, window_strides, (), (), pads)
   return snd(out)
 
 def _select_and_gather_add_jvp(
@@ -4484,9 +4522,12 @@ def _sort_batch_rule(batched_args, batch_dims, *, dimension):
   new_dimension = dimension + (bdim <= dimension)
   return sort(operand, dimension=new_dimension), bdim
 
-sort_p = standard_primitive(sort_shape, _input_dtype, 'sort')
+def _sort_translation_rule(c, operand, *, dimension):
+  return xops.Sort(c, [operand], dimension=dimension, is_stable=True)
+
+sort_p = standard_primitive(sort_shape, _input_dtype, 'sort',
+                            translation_rule=_sort_translation_rule)
 ad.defjvp(sort_p, _sort_jvp_rule)
-xla.translations[sort_p] = partial(standard_translate, 'sort', is_stable=True)
 batching.primitive_batchers[sort_p] = _sort_batch_rule
 
 def _sort_key_val_abstract_eval(keys, values, *, dimension):
@@ -4551,12 +4592,14 @@ def _sort_key_val_batch_rule(batched_args, batch_dims, *, dimension):
   else:
     assert False  # unreachable
 
+def _sort_key_val_translation_rule(c, keys, values, *, dimension):
+  return xops.Sort(c, [keys, values], dimension=dimension, is_stable=True)
+
 sort_key_val_p = Primitive('sort_key_val')
 sort_key_val_p.multiple_results = True
 sort_key_val_p.def_impl(partial(xla.apply_primitive, sort_key_val_p))
 sort_key_val_p.def_abstract_eval(_sort_key_val_abstract_eval)
-xla.translations[sort_key_val_p] = partial(standard_translate, 'sort_key_val',
-                                           is_stable=True)
+xla.translations[sort_key_val_p] = _sort_key_val_translation_rule
 ad.primitive_jvps[sort_key_val_p] = _sort_key_val_jvp
 ad.primitive_transposes[sort_key_val_p] = _sort_key_val_transpose_rule
 batching.primitive_batchers[sort_key_val_p] = _sort_key_val_batch_rule
@@ -4640,7 +4683,7 @@ def create_token(x):
 create_token_p = Primitive("create_token")
 create_token_p.def_impl(partial(xla.apply_primitive, create_token_p))
 create_token_p.def_abstract_eval(lambda _: abstract_token)
-xla.translations[create_token_p] = lambda c, _: c.CreateToken()
+xla.translations[create_token_p] = lambda c, _: xops.CreateToken(c)
 
 def after_all(*operands):
   """Merges one or more XLA token values. Experimental.
@@ -4655,7 +4698,7 @@ def _after_all_abstract_eval(*operands):
 
 
 def _after_all_translation_rule(c, *operands):
-  return c.AfterAll(operands)
+  return xops.AfterAll(c, operands)
 
 after_all_p = Primitive("after_all")
 after_all_p.def_impl(partial(xla.apply_primitive, after_all_p))
@@ -4683,12 +4726,14 @@ def _infeed_abstract_eval(token, *, shapes):
 
 
 def _infeed_translation_rule(c, token, *, shapes):
-  shape = tuple(map(xla.aval_to_xla_shape, shapes))
-  xs_and_token = c.Infeed(xla_client.Shape.tuple_shape(shape), token)
-  xs = c.GetTupleElement(xs_and_token, 0)
-  token = c.GetTupleElement(xs_and_token, 1)
-  outs = [c.GetTupleElement(xs, i) for i in range(len(shapes))] + [token]
-  return c.Tuple(*outs)
+  shape = tuple(xla.aval_to_xla_shape(x).with_major_to_minor_layout_if_absent()
+                for x in shapes)
+  xs_and_token = xops.InfeedWithToken(token,
+                                      xla_client.Shape.tuple_shape(shape))
+  xs = xops.GetTupleElement(xs_and_token, 0)
+  token = xops.GetTupleElement(xs_and_token, 1)
+  outs = [xops.GetTupleElement(xs, i) for i in range(len(shapes))] + [token]
+  return xops.Tuple(c, outs)
 
 infeed_p = Primitive("infeed")
 infeed_p.multiple_results = True
@@ -4711,7 +4756,8 @@ def _outfeed_abstract_eval(token, *xs):
 
 
 def _outfeed_translation_rule(c, token, *xs):
-  return c.Outfeed(c.Tuple(*xs), token)
+  t = xops.Tuple(c, xs)
+  return xops.OutfeedWithToken(t, token, c.GetShape(t))
 
 outfeed_p = Primitive("outfeed")
 outfeed_p.def_impl(partial(xla.apply_primitive, outfeed_p))
@@ -4742,7 +4788,7 @@ def _rng_uniform_abstract_eval(a, b, *, shape):
   return ShapedArray(shape, a.dtype)
 
 def _rng_uniform_translation_rule(c, a, b, *, shape):
-  return c.RngUniform(a, b, shape)
+  return xops.RngUniform(a, b, shape)
 
 rng_uniform_p = Primitive("rng_uniform")
 rng_uniform_p.def_impl(partial(xla.apply_primitive, rng_uniform_p))

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -48,6 +48,8 @@ from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
                            tree_multimap)
 from jax import ad_util
 
+xops = xla_client.ops
+
 _map = safe_map
 zip = safe_zip
 _reduce = functools.reduce
@@ -258,40 +260,41 @@ def _while_loop_translation_rule(c, axis_env, name_stack, avals, backend, *args,
   # computation), we build XLA computations that handle the tuple munging before
   # generating a Call into the computations formed from the jaxprs.
 
-  init_carry = c.Tuple(*(cond_consts + body_consts + init_vals))
+  init_carry = xops.Tuple(c, cond_consts + body_consts + init_vals)
 
   cond_c = xb.make_computation_builder("cond_computation")
-  cond_carry = cond_c.ParameterWithShape(c.GetShape(init_carry))
-  cond_carry_elts = [cond_c.GetTupleElement(cond_carry, i) for i in range(len(args))]
+  cond_carry = xb.parameter(cond_c, 0, c.GetShape(init_carry))
+  cond_carry_elts = [xops.GetTupleElement(cond_carry, i) for i in range(len(args))]
   x, _, z = split_list(cond_carry_elts, [cond_nconsts, body_nconsts])
   pred, = xla.jaxpr_subcomp(cond_c, cond_jaxpr.jaxpr, backend, axis_env,
-                            _map(cond_c.Constant, cond_jaxpr.literals),
+                            _map(partial(xb.constant, cond_c),
+                                 cond_jaxpr.literals),
                             extend_name_stack(name_stack, 'cond'), *(x + z))
   if batched:
     scalar = ShapedArray((), onp.bool_)
     or_ = xla.primitive_subcomputation(lax.or_p, scalar, scalar)
-    pred = cond_c.Reduce(pred, cond_c.Constant(onp.array(False)), or_,
+    pred = xops.Reduce(cond_c, [pred], [xb.constant(cond_c, onp.array(False))], or_,
                          list(range(cond_jaxpr.out_avals[0].ndim)))
 
   body_c = xb.make_computation_builder("body_computation")
-  body_carry = body_c.ParameterWithShape(c.GetShape(init_carry))
-  body_carry_elts = [body_c.GetTupleElement(body_carry, i) for i in range(len(args))]
+  body_carry = xb.parameter(body_c, 0, c.GetShape(init_carry))
+  body_carry_elts = [xops.GetTupleElement(body_carry, i) for i in range(len(args))]
   x, y, z = split_list(body_carry_elts, [cond_nconsts, body_nconsts])
   new_z = xla.jaxpr_subcomp(body_c, body_jaxpr.jaxpr, backend, axis_env,
-                            _map(body_c.Constant, body_jaxpr.literals),
+                            _map(partial(xb.constant, body_c), body_jaxpr.literals),
                             extend_name_stack(name_stack, 'body'), *(y + z))
   if batched:
     body_pred, = xla.jaxpr_subcomp(body_c, cond_jaxpr.jaxpr, backend, axis_env,
-                                   _map(body_c.Constant, cond_jaxpr.literals),
+                                   _map(partial(xb.constant, body_c), cond_jaxpr.literals),
                                    extend_name_stack(name_stack, 'body_pred'), *(x + z))
     new_z = _map(partial(_pred_bcast_select, body_c, body_pred), new_z, z)
     assert _map(body_c.GetShape, new_z) == _map(body_c.GetShape, z) # no broadcast
-  new_carry = body_c.Tuple(*itertools.chain(x, y, new_z))
+  new_carry = xops.Tuple(body_c, list(itertools.chain(x, y, new_z)))
 
-  ans = c.While(cond_c.Build(pred), body_c.Build(new_carry), init_carry)
-  ans_elts = [c.GetTupleElement(ans, i) for i in range(len(args))]
+  ans = xops.While(cond_c.Build(pred), body_c.Build(new_carry), init_carry)
+  ans_elts = [xops.GetTupleElement(ans, i) for i in range(len(args))]
   _,  _, z = split_list(ans_elts, [cond_nconsts, body_nconsts])
-  return c.Tuple(*z)
+  return xops.Tuple(c, z)
 
 def _pred_bcast_select(c, pred, x, y):
   pred_shape = c.GetShape(pred).dimensions()
@@ -299,8 +302,8 @@ def _pred_bcast_select(c, pred, x, y):
   y_shape = c.GetShape(y).dimensions()
   assert x_shape == y_shape
   assert pred_shape == x_shape[:len(pred_shape)] == y_shape[:len(pred_shape)]
-  bcast_pred = c.BroadcastInDim(pred, x_shape, list(range(len(pred_shape))))
-  return c.Select(bcast_pred, x, y)
+  bcast_pred = xops.BroadcastInDim(pred, x_shape, list(range(len(pred_shape))))
+  return xops.Select(bcast_pred, x, y)
 
 def _while_loop_batching_rule(args, dims, cond_nconsts, cond_jaxpr,
                               body_nconsts, body_jaxpr):
@@ -555,20 +558,20 @@ def _cond_translation_rule(c, axis_env, name_stack, avals, backend,
 
   def make_computation(name, jaxpr, op_shape):
     c = xb.make_computation_builder(name + '_comp')
-    op = c.ParameterWithShape(op_shape)
-    ops = [c.GetTupleElement(op, i) for i in range(len(jaxpr.in_avals))]
+    op = xb.parameter(c, 0, op_shape)
+    ops = [xops.GetTupleElement(op, i) for i in range(len(jaxpr.in_avals))]
     outs = xla.jaxpr_subcomp(c, jaxpr.jaxpr, backend, axis_env,
-                             _map(c.Constant, jaxpr.literals),
+                             _map(partial(xb.constant, c), jaxpr.literals),
                              extend_name_stack(name_stack, name + '_fun'), *ops)
-    return c.Build(c.Tuple(*outs))
+    return c.Build(xops.Tuple(c, outs))
 
-  true_op = c.Tuple(*true_ops)
+  true_op = xops.Tuple(c, true_ops)
   true_c = make_computation('true', true_jaxpr, c.GetShape(true_op))
 
-  false_op = c.Tuple(*false_ops)
+  false_op = xops.Tuple(c, false_ops)
   false_c = make_computation('false', false_jaxpr, c.GetShape(false_op))
 
-  return c.Conditional(pred, true_op, true_c, false_op, false_c)
+  return xops.Conditional(pred, true_op, true_c, false_op, false_c)
 
 def _cond_pred_bcast_select(pred, x, y):
   if core.get_aval(x) is core.get_aval(y) is core.abstract_unit:

--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -23,9 +23,11 @@ from jax.core import Primitive
 from jax.interpreters import xla
 from jax.util import prod
 from . import dtypes, lax
-from ..lib.xla_bridge import xla_client
+from ..lib import xla_client
 from ..interpreters import ad
 from ..interpreters import batching
+
+xops = xla_client.ops
 
 __all__ = [
   "fft",
@@ -80,7 +82,7 @@ def fft_abstract_eval(x, fft_type, fft_lengths):
   return ShapedArray(shape, dtype)
 
 def fft_translation_rule(c, x, fft_type, fft_lengths):
-  return c.Fft(x, fft_type, fft_lengths)
+  return xops.Fft(x, fft_type, fft_lengths)
 
 def _naive_rfft(x, fft_lengths):
   y = fft(x, xla_client.FftType.FFT, fft_lengths)

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -30,10 +30,11 @@ from jax.interpreters import parallel
 from jax.interpreters import xla
 from jax.interpreters import pxla
 from jax.util import partial, unzip2, prod
-from jax.lib import xla_client
+from jax.lib import xla_client as xc
 
 from jax.interpreters.pxla import axis_index
 
+xops = xc.ops
 
 ### parallel traceables
 
@@ -265,7 +266,8 @@ def _allreduce_translation_rule(prim, c, val, replica_groups, platform=None):
   dtype = c.GetShape(val).numpy_dtype()
   scalar = ShapedArray((), dtype)
   computation = xla.primitive_subcomputation(prim, scalar, scalar)
-  return c.AllReduce(val, computation, replica_groups=replica_groups)
+  replica_groups_protos = xc.make_replica_groups(replica_groups)
+  return xops.AllReduce(val, computation, replica_groups_protos, None, None)
 
 # psum translation rule has special handling for complex dtypes
 def _psum_translation_rule(c, *args, replica_groups=None, platform=None):
@@ -282,24 +284,25 @@ def _psum_translation_rule(c, *args, replica_groups=None, platform=None):
 
   # The outputs, in the original argument order.
   out = [None] * len(args)
+  replica_groups_protos = xc.make_replica_groups(replica_groups)
   for dtype, (indices, dtype_args) in sorted(args_by_type.items()):
     is_complex = dtypes.issubdtype(dtype, onp.complexfloating)
     n = len(dtype_args)
     if is_complex:
-      dtype_args = ([c.Real(x) for x in dtype_args] +
-                    [c.Imag(x) for x in dtype_args])
+      dtype_args = ([xops.Real(x) for x in dtype_args] +
+                    [xops.Imag(x) for x in dtype_args])
     scalar = ShapedArray((), c.GetShape(dtype_args[0]).numpy_dtype())
     computation = xla.primitive_subcomputation(lax.add_p, scalar, scalar)
-    all_reduce = c.AllReduce(c.Tuple(*dtype_args), computation,
-                             replica_groups=replica_groups)
+    all_reduce = xops.AllReduce(xops.Tuple(c, dtype_args), computation,
+                                replica_groups_protos, None, None)
     if is_complex:
-      xs = [c.Complex(c.GetTupleElement(all_reduce, i),
-                      c.GetTupleElement(all_reduce, n + i)) for i in range(n)]
+      xs = [xops.Complex(xops.GetTupleElement(all_reduce, i),
+                         xops.GetTupleElement(all_reduce, n + i)) for i in range(n)]
     else:
-      xs = [c.GetTupleElement(all_reduce, i) for i in range(n)]
+      xs = [xops.GetTupleElement(all_reduce, i) for i in range(n)]
     for i, x in zip(indices, xs):
       out[i] = x
-  return c.Tuple(*out)
+  return xops.Tuple(*out)
 
 # TODO(b/150476027): CPU doesn't support tuple all-reduce correctly. But
 # fortunately we don't really need it in that case because CPU doesn't support
@@ -310,10 +313,10 @@ def _cpu_psum_translation_rule(c, *args, replica_groups):
                    replica_groups=replica_groups)
     dtype = c.GetShape(val).numpy_dtype()
     if dtypes.issubdtype(dtype, onp.complexfloating):
-      return c.Complex(psum(c.Real(val)), psum(c.Imag(val)))
+      return xops.Complex(psum(xops.Real(val)), psum(xops.Imag(val)))
     else:
       return psum(val)
-  return c.Tuple(*map(_translate, args))
+  return xops.Tuple(c, list(map(_translate, args)))
 
 psum_p = standard_pmap_primitive('psum', multiple_results=True)
 psum_p.def_abstract_eval(lambda *args, **params: map(raise_to_shaped, args))
@@ -350,7 +353,7 @@ def _ppermute_translation_rule(c, x, replica_groups, perm, platform=None):
   for grp in replica_groups:
     grp = list(sorted(grp))
     full_perm.extend((grp[src], grp[dst]) for src, dst in perm)
-  return c.CollectivePermute(x, full_perm)
+  return xops.CollectivePermute(x, full_perm)
 
 def _ppermute_transpose_rule(t, perm, axis_name):
   srcs, dsts = unzip2(perm)
@@ -365,7 +368,12 @@ pxla.multi_host_supported_collectives.add(ppermute_p)
 
 def _all_to_all_translation_rule(c, x, split_axis, concat_axis, replica_groups,
                                  platform=None):
-  return c.AllToAll(x, split_axis, concat_axis, replica_groups)
+  # Workaround for AllToAll not being implemented on CPU.
+  if len(replica_groups[0]) == 1:
+    return x
+  else:
+    replica_groups_protos = xc.make_replica_groups(replica_groups)
+    return xops.AllToAll(x, split_axis, concat_axis, replica_groups_protos)
 
 def _all_to_all_split_axis_rule(vals, which_mapped, split_axis, concat_axis,
                                 axis_name):

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -372,8 +372,12 @@ def _all_to_all_translation_rule(c, x, split_axis, concat_axis, replica_groups,
   if len(replica_groups[0]) == 1:
     return x
   else:
+    split_count = len(replica_groups[0])
+    if not all(split_count == len(g) for g in replica_groups):
+      raise ValueError('Replica groups must be equally sized')
     replica_groups_protos = xc.make_replica_groups(replica_groups)
-    return xops.AllToAll(x, split_axis, concat_axis, replica_groups_protos)
+    return xops.AllToAll(x, split_axis, concat_axis, split_count,
+                         replica_groups_protos)
 
 def _all_to_all_split_axis_rule(vals, which_mapped, split_axis, concat_axis,
                                 axis_name):

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -302,7 +302,7 @@ def _psum_translation_rule(c, *args, replica_groups=None, platform=None):
       xs = [xops.GetTupleElement(all_reduce, i) for i in range(n)]
     for i, x in zip(indices, xs):
       out[i] = x
-  return xops.Tuple(*out)
+  return xops.Tuple(c, out)
 
 # TODO(b/150476027): CPU doesn't support tuple all-reduce correctly. But
 # fortunately we don't really need it in that case because CPU doesn't support

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -404,9 +404,21 @@ def triangular_solve_batching_rule(batched_args, batch_dims, left_side,
                             transpose_a=transpose_a, conjugate_a=conjugate_a,
                             unit_diagonal=unit_diagonal), 0
 
+def _triangular_solve_translation_rule(
+    c, a, b, *, left_side, lower, transpose_a, conjugate_a, unit_diagonal):
+  if conjugate_a and not transpose_a:
+    a = xops.Conj(a)
+    conjugate_a = False
+  if not transpose_a:
+    transpose = xops.TriangularSolveOptions_Transpose.NO_TRANSPOSE
+  else:
+    transpose = (xops.TriangularSolveOptions_Transpose.ADJOINT if conjugate_a
+                 else xops.TriangularSolveOptions_Transpose.TRANSPOSE)
+  return xops.TriangularSolve(a, b, left_side, lower, unit_diagonal, transpose)
+
 triangular_solve_p = standard_primitive(
     triangular_solve_shape_rule, triangular_solve_dtype_rule,
-    'triangular_solve')
+    'triangular_solve', translation_rule=_triangular_solve_translation_rule)
 ad.defjvp2(triangular_solve_p,
            triangular_solve_jvp_rule_a,
            lambda g_b, _, a, b, **kws: triangular_solve(a, g_b, **kws))
@@ -460,7 +472,8 @@ def _triangular_solve_gpu_translation_rule(
     else:
       transpose = (xops.TriangularSolveOptions_Transpose.ADJOINT if conjugate_a
                    else xops.TriangularSolveOptions_Transpose.TRANSPOSE)
-    return ops.TriangularSolve(a, b, left_side, lower, unit_diagonal, transpose)
+    return xops.TriangularSolve(a, b, left_side, lower, unit_diagonal,
+                                transpose)
 
 xla.backend_specific_translations['gpu'][triangular_solve_p] = \
     _triangular_solve_gpu_translation_rule

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -34,6 +34,11 @@ from jax.lax import (standard_primitive, standard_unop, naryop_dtype_rule,
 from jax.lib import lapack
 from jax.lib import cusolver
 
+from jax.lib import xla_client
+from jax.lib import xla_bridge as xb
+
+xops = xla_client.ops
+
 
 # traceables
 
@@ -90,7 +95,7 @@ def symmetrize(x): return (x + _H(x)) / 2
 def _unpack_tuple(f, n):
   def g(c, *args, **kwargs):
     t = f(c, *args, **kwargs)
-    return (c.GetTupleElement(t, i) for i in range(n))
+    return (xops.GetTupleElement(t, i) for i in range(n))
   return g
 
 # primitives
@@ -131,19 +136,19 @@ def _nan_like(c, operand):
   shape = c.GetShape(operand)
   dtype = shape.element_type()
   if np.issubdtype(dtype, onp.complexfloating):
-    nan = c.Constant(onp.array(onp.nan * (1. + 1j), dtype=dtype))
+    nan = xb.constant(c, onp.array(onp.nan * (1. + 1j), dtype=dtype))
   else:
-    nan = c.Constant(onp.array(onp.nan, dtype=dtype))
-  return c.Broadcast(nan, shape.dimensions())
+    nan = xb.constant(c, onp.array(onp.nan, dtype=dtype))
+  return xops.Broadcast(nan, shape.dimensions())
 
 def _cholesky_cpu_gpu_translation_rule(potrf_impl, c, operand):
   shape = c.GetShape(operand)
   batch_dims = shape.dimensions()[:-2]
   dtype = shape.element_type().type
-  result, info = potrf_impl(c, operand, lower=True)
-  ok = c.Eq(info, c.ConstantS32Scalar(0))
+  result, info = potrf_impl(xb.computation_builder_shim(c), operand, lower=True)
+  ok = xops.Eq(info, xops.ConstantLiteral(c, onp.array(0, onp.int32)))
   return _broadcasting_select(c,
-                              c.Reshape(ok, None, batch_dims + (1, 1)), result,
+                              xops.Reshape(ok, batch_dims + (1, 1)), result,
                               _nan_like(c, result))
 
 xla.backend_specific_translations['cpu'][cholesky_p] = partial(
@@ -182,15 +187,15 @@ _cpu_geev = lapack.geev
 def eig_cpu_translation_rule(c, operand):
   shape = c.GetShape(operand)
   batch_dims = shape.dimensions()[:-2]
-  w, vl, vr, info = _cpu_geev(c, operand)
-  ok = c.Eq(info, c.ConstantS32Scalar(0))
-  w = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1,)), w,
+  w, vl, vr, info = _cpu_geev(xb.computation_builder_shim(c), operand)
+  ok = xops.Eq(info, xops.ConstantLiteral(c, onp.array(0, onp.int32)))
+  w = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), w,
                            _nan_like(c, w))
-  vl = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), vl,
+  vl = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vl,
                             _nan_like(c, vl))
-  vr = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), vr,
+  vr = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vr,
                             _nan_like(c, vr))
-  return c.Tuple(w, vl, vr)
+  return xops.Tuple(c, [w, vl, vr])
 
 def eig_batching_rule(batched_args, batch_dims):
   x, = batched_args
@@ -217,11 +222,11 @@ def eigh_translation_rule(c, operand, lower):
   shape = c.GetShape(operand)
   dims = shape.dimensions()
   if dims[-1] == 0:
-    return c.Tuple(operand, c.Reshape(operand, None, dims[:-1]))
+    return xops.Tuple(c, [operand, xops.Reshape(operand, dims[:-1])])
   if not lower:
     n = len(dims)
-    operand = c.Transpose(operand, list(range(n - 2)) + [n - 1, n - 2])
-  return c.Eigh(operand)
+    operand = xops.Transpose(operand, list(range(n - 2)) + [n - 1, n - 2])
+  return xops.Tuple(c, xops.Eigh(operand))
 
 def eigh_abstract_eval(operand, lower):
   if isinstance(operand, ShapedArray):
@@ -241,13 +246,13 @@ def eigh_abstract_eval(operand, lower):
 def _eigh_cpu_gpu_translation_rule(syevd_impl, c, operand, lower):
   shape = c.GetShape(operand)
   batch_dims = shape.dimensions()[:-2]
-  v, w, info = syevd_impl(c, operand, lower=lower)
-  ok = c.Eq(info, c.ConstantS32Scalar(0))
-  v = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), v,
+  v, w, info = syevd_impl(xb.computation_builder_shim(c), operand, lower=lower)
+  ok = xops.Eq(info, xops.ConstantLiteral(c, onp.array(0, onp.int32)))
+  v = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), v,
                            _nan_like(c, v))
-  w = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1,)), w,
+  w = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), w,
                            _nan_like(c, w))
-  return c.Tuple(v, w)
+  return xops.Tuple(c, [v, w])
 
 def eigh_jvp_rule(primals, tangents, lower):
   # Derivative for eigh in the simplest case of distinct eigenvalues.
@@ -414,18 +419,22 @@ def _triangular_solve_cpu_translation_rule(
   shape = c.GetShape(a)
   dtype = shape.element_type().type
 
+  if conjugate_a and not transpose_a:
+    a = xops.Conj(a)
+    conjugate_a = False
   if len(shape.dimensions()) == 2 and onp.dtype(dtype) in _cpu_lapack_types:
-    if conjugate_a and not transpose_a:
-      a = c.Conj(a)
-      conjugate_a = False
     return lapack.jax_trsm(
-      c, c.Constant(onp.array(1, dtype=dtype)), a, b, left_side, lower,
-                    transpose_a, conjugate_a, unit_diagonal)
+      xb.computation_builder_shim(c), xb.constant(c, onp.array(1, dtype=dtype)),
+      a, b, left_side, lower, transpose_a, conjugate_a, unit_diagonal)
   else:
     # Fall back to the HLO implementation for unsupported types or batching.
     # TODO: Consider swapping XLA for LAPACK in batched case
-    return c.TriangularSolve(a, b, left_side, lower, transpose_a, conjugate_a,
-                             unit_diagonal)
+    if not transpose_a:
+      transpose = xops.TriangularSolveOptions_Transpose.NO_TRANSPOSE
+    else:
+      transpose = (xops.TriangularSolveOptions_Transpose.ADJOINT if conjugate_a
+                   else xops.TriangularSolveOptions_Transpose.TRANSPOSE)
+    return xops.TriangularSolve(a, b, left_side, lower, unit_diagonal, transpose)
 
 xla.backend_specific_translations['cpu'][triangular_solve_p] = \
   _triangular_solve_cpu_translation_rule
@@ -437,16 +446,21 @@ def _triangular_solve_gpu_translation_rule(
   dims = shape.dimensions()
   m, n = dims[-2:]
   batch = prod(dims[:-2])
+  if conjugate_a and not transpose_a:
+    a = xops.Conj(a)
+    conjugate_a = False
   if batch > 1 and m <= 32 and n <= 32:
-    if conjugate_a and not transpose_a:
-      a = c.Conj(a)
-      conjugate_a = False
     return cusolver.trsm(
-      c, a, b, left_side, lower, transpose_a, conjugate_a, unit_diagonal)
+      xb.computation_builder_shim(c), a, b, left_side, lower, transpose_a,
+      conjugate_a, unit_diagonal)
   else:
     # Use the XLA implementation for unbatched triangular_solve.
-    return c.TriangularSolve(a, b, left_side, lower, transpose_a, conjugate_a,
-                             unit_diagonal)
+    if not transpose_a:
+      transpose = xops.TriangularSolveOptions_Transpose.NO_TRANSPOSE
+    else:
+      transpose = (xops.TriangularSolveOptions_Transpose.ADJOINT if conjugate_a
+                   else xops.TriangularSolveOptions_Transpose.TRANSPOSE)
+    return ops.TriangularSolve(a, b, left_side, lower, unit_diagonal, transpose)
 
 xla.backend_specific_translations['gpu'][triangular_solve_p] = \
     _triangular_solve_gpu_translation_rule
@@ -607,13 +621,13 @@ def _lu_batching_rule(batched_args, batch_dims):
 def _lu_cpu_gpu_translation_rule(getrf_impl, c, operand):
   shape = c.GetShape(operand)
   batch_dims = shape.dimensions()[:-2]
-  lu, pivot, info = getrf_impl(c, operand)
+  lu, pivot, info = getrf_impl(xb.computation_builder_shim(c), operand)
   # Subtract 1 from the pivot to get 0-based indices.
-  pivot = c.Sub(pivot, c.ConstantS32Scalar(1))
-  ok = c.Ge(info, c.ConstantS32Scalar(0))
-  lu = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), lu,
+  pivot = xops.Sub(pivot, xops.ConstantLiteral(c, onp.array(1, onp.int32)))
+  ok = xops.Ge(info, xops.ConstantLiteral(c, onp.array(0, onp.int32)))
+  lu = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), lu,
                             _nan_like(c, lu))
-  return c.Tuple(lu, pivot)
+  return xops.Tuple(c, [lu, pivot])
 
 
 lu_p = Primitive('lu')
@@ -730,7 +744,7 @@ def qr_impl(operand, full_matrices):
   return q, r
 
 def qr_translation_rule(c, operand, full_matrices):
-  return c.QR(operand, full_matrices=full_matrices)
+  return xops.Tuple(c, xops.QR(operand, full_matrices))
 
 def qr_abstract_eval(operand, full_matrices):
   if isinstance(operand, ShapedArray):
@@ -774,27 +788,31 @@ def _qr_cpu_gpu_translation_rule(geqrf_impl, orgqr_impl, c, operand,
   dims = shape.dimensions()
   m, n = dims[-2:]
   batch_dims = dims[:-2]
-  r, tau, info_geqrf = geqrf_impl(c, operand)
+  cs = xb.computation_builder_shim(c)
+  r, tau, info_geqrf = geqrf_impl(cs, operand)
   if m < n:
-    q = c.Slice(r, [0] * len(dims), list(batch_dims) + [m, m])
-    q, info_orgqr = orgqr_impl(c, q, tau)
+    q = xops.Slice(r, [0] * len(dims), list(batch_dims) + [m, m],
+                   [1] * len(dims))
+    q, info_orgqr = orgqr_impl(cs, q, tau)
   elif not full_matrices:
-    q, info_orgqr = orgqr_impl(c, r, tau)
-    r = c.Slice(r, [0] * len(dims), list(batch_dims) + [n, n])
+    q, info_orgqr = orgqr_impl(cs, r, tau)
+    r = xops.Slice(r, [0] * len(dims), list(batch_dims) + [n, n],
+                   [1] * len(dims))
   else:
     padding_config = [(0, 0, 0)] * len(dims)
     padding_config[-1] = (0, m - n, 0)
-    q = c.Pad(r, c.Constant(onp.array(0, dtype=shape.element_type())),
-              padding_config)
-    q, info_orgqr = orgqr_impl(c, q, tau)
+    q = xops.Pad(r, xops.Constant(c, onp.array(0, dtype=shape.element_type())),
+                 xla_client.make_padding_config(padding_config))
+    q, info_orgqr = orgqr_impl(cs, q, tau)
 
-  ok = c.And(c.Eq(info_geqrf, c.ConstantS32Scalar(0)),
-             c.Eq(info_orgqr, c.ConstantS32Scalar(0)))
-  q = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), q,
+  ok = xops.And(
+    xops.Eq(info_geqrf, xops.ConstantLiteral(c, onp.array(0, onp.int32))),
+    xops.Eq(info_orgqr, xops.ConstantLiteral(c, onp.array(0, onp.int32))))
+  q = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), q,
                            _nan_like(c, q))
-  r = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), r,
+  r = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), r,
                            _nan_like(c, r))
-  return c.Tuple(q, r)
+  return xops.Tuple(c, [q, r])
 
 qr_p = Primitive('qr')
 qr_p.multiple_results = True
@@ -870,16 +888,17 @@ def _svd_cpu_gpu_translation_rule(gesvd_impl, c, operand, full_matrices, compute
 
   shape = c.GetShape(operand)
   batch_dims = shape.dimensions()[:-2]
-  s, u, vt, info = gesvd_impl(c, operand, full_matrices=full_matrices,
+  s, u, vt, info = gesvd_impl(xb.computation_builder_shim(c), operand,
+                              full_matrices=full_matrices,
                               compute_uv=compute_uv)
-  ok = c.Eq(info, c.ConstantS32Scalar(0))
-  s = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1,)), s,
+  ok = xops.Eq(info, xops.ConstantLiteral(c, onp.array(0, onp.int32)))
+  s = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), s,
                            _nan_like(c, s))
-  u = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), u,
+  u = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), u,
                            _nan_like(c, u))
-  vt = _broadcasting_select(c, c.Reshape(ok, None, batch_dims + (1, 1)), vt,
+  vt = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vt,
                             _nan_like(c, vt))
-  return c.Tuple(s, u, vt)
+  return xops.Tuple(c, [s, u, vt])
 
 def svd_batching_rule(batched_args, batch_dims, full_matrices, compute_uv):
   x, = batched_args

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -50,6 +50,7 @@ try:
 except:
   tpu_client = None
 from jaxlib import xla_client
+from jaxlib import xla_extension as xe
 from jaxlib import lapack
 
 from jaxlib import pytree

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -50,7 +50,6 @@ try:
 except:
   tpu_client = None
 from jaxlib import xla_client
-from jaxlib import xla_extension as xe
 from jaxlib import lapack
 
 from jaxlib import pytree

--- a/jax/random.py
+++ b/jax/random.py
@@ -180,9 +180,10 @@ def _threefry2x32_gpu_translation_rule(c, k1, k2, x1, x2):
   rank = len(shape)
   def _broadcast(x):
     ndims = c.GetShape(x).rank()
-    return c.BroadcastInDim(x, shape, tuple(range(rank - ndims, rank)))
+    return xops.BroadcastInDim(x, shape, tuple(range(rank - ndims, rank)))
   return cuda_prng.threefry2x32(
-      c, (_broadcast(k1), _broadcast(k2)), (_broadcast(x1), _broadcast(x2)))
+      xla_bridge.computation_builder_shim(c),
+      (_broadcast(k1), _broadcast(k2)), (_broadcast(x1), _broadcast(x2)))
 
 threefry2x32_p = core.Primitive("threefry2x32")
 threefry2x32_p.multiple_results = True

--- a/jax/random.py
+++ b/jax/random.py
@@ -32,6 +32,7 @@ from . import dtypes
 from .api import jit, vmap
 from .numpy.lax_numpy import _constant_like, asarray
 from jax.lib import xla_bridge
+from jax.lib import xla_client
 from jax.lib import cuda_prng
 from jax import core
 from jax import abstract_arrays
@@ -180,7 +181,8 @@ def _threefry2x32_gpu_translation_rule(c, k1, k2, x1, x2):
   rank = len(shape)
   def _broadcast(x):
     ndims = c.GetShape(x).rank()
-    return xops.BroadcastInDim(x, shape, tuple(range(rank - ndims, rank)))
+    return xla_client.ops.BroadcastInDim(x, shape,
+                                         tuple(range(rank - ndims, rank)))
   return cuda_prng.threefry2x32(
       xla_bridge.computation_builder_shim(c),
       (_broadcast(k1), _broadcast(k2)), (_broadcast(x1), _broadcast(x2)))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -876,7 +876,7 @@ class APITest(jtu.JaxTestCase):
       return np.zeros((3, 4))
 
     xla_comp = api.xla_computation(f, instantiate_const_outputs=True)()
-    out_shape, = xla_comp.GetReturnValueShape().tuple_shapes()
+    out_shape, = xla_comp.GetProgramShape().result_shape().tuple_shapes()
     self.assertEqual(out_shape.dimensions(), (3, 4))
 
   def test_jit_device(self):

--- a/tests/infeed_test.py
+++ b/tests/infeed_test.py
@@ -41,8 +41,9 @@ class InfeedTest(jax.test_util.JaxTestCase):
     x = onp.float32(1.5)
     y = onp.reshape(onp.arange(12, dtype=onp.float32), (3, 4)) # onp.random.randn(3, 4).astype(onp.float32)
     z = onp.random.randn(3, 1, 1).astype(onp.float32)
-    xla_client.transfer_to_infeed((y,))
-    xla_client.transfer_to_infeed((z,))
+    device = jax.local_devices()[0]
+    device.TransferToInfeed((y,))
+    device.TransferToInfeed((z,))
     self.assertAllClose(f(x), x + y + z, check_dtypes=True)
 
   def testInfeedThenOutfeed(self):
@@ -58,8 +59,10 @@ class InfeedTest(jax.test_util.JaxTestCase):
     y = onp.random.randn(3, 4).astype(onp.float32)
     execution = threading.Thread(target=lambda: f(x))
     execution.start()
-    xla_client.transfer_to_infeed((y,))
-    out, = xla_client.transfer_from_outfeed(xla_client.shape_from_pyval((y,)))
+    device = jax.local_devices()[0]
+    device.TransferToInfeed((y,))
+    out, = device.TransferFromOutfeed(
+      xla_client.shape_from_pyval((y,)).with_major_to_minor_layout_if_absent())
     execution.join()
     self.assertAllClose(out, y + onp.float32(1), check_dtypes=True)
 
@@ -75,13 +78,15 @@ class InfeedTest(jax.test_util.JaxTestCase):
       token = lax.fori_loop(0, n, doubler, token)
       return lax.tie_in(token, n)
 
+    device = jax.local_devices()[0]
     n = 10
     execution = threading.Thread(target=lambda: f(n))
     execution.start()
     for _ in range(n):
       x = onp.random.randn(3, 4).astype(onp.float32)
-      xla_client.transfer_to_infeed((x,))
-      y, = xla_client.transfer_from_outfeed(xla_client.shape_from_pyval((x,)))
+      device.TransferToInfeed((x,))
+      y, = device.TransferFromOutfeed(xla_client.shape_from_pyval((x,))
+                                      .with_major_to_minor_layout_if_absent())
       self.assertAllClose(y, x * onp.float32(2), check_dtypes=True)
     execution.join()
 


### PR DESCRIPTION
ComputationBuilder is a fairly pointless wrapper class that mimics an outdated version of the the C++ XLA API. It dates back from when we used to have SWIG bindings and needed to write a non-trivial Python shim to keep the interface pleasant to use. Now that we have pybind11-based bindings that are reasonably ergonomic by themselves, we don't need the wrapper class. Instead, we can simply call the pybind11-wrapped C++ API directly, removing the impedance mismatch between the C++ and Python APIs and allowing us to delete the Python ComputationBuilder class.

Similarly we can delete xla_client.Computation for the same reasons; it doesn't do anything useful on top of the C++ API.