### PR TITLE
Custom derivative for np.linalg.det

### DIFF
--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -216,7 +216,7 @@ def _cofactor_solve(a, b):
   parity = np.count_nonzero(pivots != np.arange(a_shape[-1]), axis=-1)
   sign = np.array(-2 * (parity % 2) + 1, dtype=dtype)
   # partial_det[:, -1] contains the full determinant and
-  # partial_det[:, -2] contains U_{nn} / det{U}.
+  # partial_det[:, -2] contains det(u) / u_{nn}.
   partial_det = np.cumprod(diag, axis=-1) * sign[..., None]
   lu = ops.index_update(lu, ops.index[..., -1, -1], 1.0 / partial_det[..., -2])
   permutation = lax_linalg.lu_pivots_to_permutation(pivots, a_shape[-1])

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -199,11 +199,10 @@ def _cofactor_solve(a, b):
   permutation = np.broadcast_to(permutation, batch_dims + (a_shape[-1],))
   iotas = np.ix_(*(lax.iota(np.int32, b) for b in batch_dims + (1,)))
   x = x[iotas[:-1] + (permutation, slice(None))]
-  # TODO(pfau): return zero if the rank is less than n-1
   x = lax_linalg.triangular_solve(lu, x, left_side=True, lower=True,
                                   unit_diagonal=True)
-  x = ops.index_update(x, ops.index[..., :-1, :],
-                       x[..., :-1, :] * partial_det[..., -1, None, None])
+  x = np.concatenate((x[..., :-1, :] * partial_det[..., -1, None, None],
+                      x[..., -1:, :]), axis=-2)
   x = lax_linalg.triangular_solve(lu, x, left_side=True, lower=False)
   return partial_det[..., -1], np.where(np.isnan(x), np.zeros_like(x), x)
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -109,6 +109,36 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   def testDetOfSingularMatrix(self):
     x = np.array([[-1., 3./2], [2./3, -1.]], dtype=onp.float32)
     self.assertAllClose(onp.float32(0), jsp.linalg.det(x), check_dtypes=True)
+    
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
+      for shape in [(1, 1), (3, 3), (2, 4, 4)]
+      for dtype in float_types
+      for rng_factory in [jtu.rand_default]))
+  @jtu.skip_on_devices("tpu")
+  @jtu.skip_on_flag("jax_skip_slow_tests", True)
+  def testDetGrad(self, shape, dtype, rng_factory):
+    rng = rng_factory()
+    _skip_if_unsupported_type(dtype)
+    a = rng(shape, dtype)
+    jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
+    # make sure there are no NaNs when a matrix is zero
+    if len(shape) == 2:
+      jtu.check_grads(
+        np.linalg.det, (np.zeros_like(a),), 2, atol=1e-1, rtol=1e-1)
+    else:
+      a[0] = 0
+      jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
+
+  def testDetGradOfSingularMatrix(self):
+    # This matrix was known to lead to NaN gradients in previous version of det
+    a = np.array([[-0.00653029,  0.04353099, -0.00590861, -0.00494686],
+                  [-0.00245923,  0.08541009,  0.04338968, -0.01178439],
+                  [-0.01464201,  0.08210193,  0.07912003, -0.03005431],
+                  [ 0.01381988, -0.07361154, -0.06589139,  0.02652415]])
+    jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -126,19 +126,24 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
     # make sure there are no NaNs when a matrix is zero
     if len(shape) == 2:
+      pass
       jtu.check_grads(
-        np.linalg.det, (np.zeros_like(a),), 2, atol=1e-1, rtol=1e-1)
+        np.linalg.det, (np.zeros_like(a),), 1, atol=1e-1, rtol=1e-1)
     else:
       a[0] = 0
-      jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
+      jtu.check_grads(np.linalg.det, (a,), 1, atol=1e-1, rtol=1e-1)
 
   def testDetGradOfSingularMatrix(self):
-    # This matrix was known to lead to NaN gradients in previous version of det
-    a = np.array([[-0.00653029,  0.04353099, -0.00590861, -0.00494686],
-                  [-0.00245923,  0.08541009,  0.04338968, -0.01178439],
-                  [-0.01464201,  0.08210193,  0.07912003, -0.03005431],
-                  [ 0.01381988, -0.07361154, -0.06589139,  0.02652415]])
-    jtu.check_grads(np.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
+    # Rank 2 matrix with nonzero gradient
+    a = np.array([[ 50, -30,  45],
+                  [-30,  90, -81],
+                  [ 45, -81,  81]], dtype=np.float32)
+    # Rank 1 matrix with zero gradient
+    b = np.array([[ 36, -42,  18],
+                  [-42,  49, -21],
+                  [ 18, -21,   9]], dtype=np.float32)
+    jtu.check_grads(np.linalg.det, (a,), 1, atol=1e-1, rtol=1e-1)
+    jtu.check_grads(np.linalg.det, (b,), 1, atol=1e-1, rtol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":


### PR DESCRIPTION
This computes the cofactor matrix directly, instead of taking `det(x) * inv(x)` as the derivative of the determinant, avoiding NaNs when applied to singular matrices.

Closes issues #2756 and #2380.