### PR TITLE
Fix time issues in odeint reverse mode

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -295,7 +295,17 @@ def pend_check_grads():
   check_grads(f, (y0, ts, *args), modes=["rev"], order=2,
               atol=1e-1, rtol=1e-1)
 
+def weird_time_pendulum_check_grads():
+  """Test that gradients are correct when the dynamics depend on t."""
+  def f(y0, ts):
+    return odeint(lambda y, t: np.array([y[1] * -t, -1 * y[1] - 9.8 * np.sin(y[0])]), y0, ts)
+
+  y0 = [np.pi - 0.1, 0.0]
+  ts = np.linspace(0., 1., 11)
+
+  check_grads(f, (y0, ts), modes=["rev"], order=2)
 
 if __name__ == '__main__':
   pend_benchmark_odeint()
   pend_check_grads()
+  weird_time_pendulum_check_grads()


### PR DESCRIPTION
This is an attempt at addressing the issues brought up in comments [here](https://github.com/google/jax/commit/7e480fa923097826febec8ac6b74222dca6189a3#r38709808) and [here](https://github.com/google/jax/commit/7e480fa923097826febec8ac6b74222dca6189a3#r38709906). This PR is intended to correct issues with the handling of time in the reverse-mode odeint solve.

Ideally we could write a regression test for this. Where would be the right place for such tests?