### PR TITLE
Refactor xla_bridge.py to do all backend caching itself.

### DIFF
--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -160,19 +160,17 @@ def get_backend(platform: Optional[str] = None) -> LocalClient:
 
   if platform is None:
     return list(_backends.values())[-1]
-
   if platform not in _backends:
     raise ValueError(f"Unknown backend '{platform}'")
-
   return _backends[platform]
 
 
 def _initialize_backends():
   global _backends
-  assert _backends is None, "_initialize_backends() should only called once!"
+  assert _backends is None, "_initialize_backends() should only be called once!"
   _backends = OrderedDict()
   for name, factory in _backend_factories.items():
-    logging.vlog(2, f"Initializing backend '{name}'")
+    logging.vlog(1, f"Initializing backend '{name}'")
     try:
       # TODO(skye): remove name parameter once all backend factories create a
       # single platform.

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -44,6 +44,9 @@ from . import xla_client
 
 xops = xla_client.ops
 
+# TODO(skye): expose in xla_client
+LocalClient = xla_client._xla.LocalClient
+
 FLAGS = flags.FLAGS
 
 flags.DEFINE_string(
@@ -113,7 +116,7 @@ def get_compile_options(num_replicas, num_partitions, device_assignment=None):
 
 _backend_factories = {}
 
-def register_backend(name: str, factory: Callable[[Optional[str]], xla_client.LocalBackend]):
+def register_backend(name: str, factory: Callable[[Optional[str]], LocalClient]):
   _backend_factories[name] = factory
 
 
@@ -144,7 +147,7 @@ _backends = None
 _backend_lock = threading.Lock()
 
 @util.memoize
-def get_backend(platform: Optional[str] = None) -> xla_client.LocalBackend:
+def get_backend(platform: Optional[str] = None) -> LocalClient:
   # TODO(mattjj,skyewm): remove this input polymorphism after we clean up how
   # 'backend' values are handled
   if not isinstance(platform, (type(None), str)):
@@ -157,6 +160,9 @@ def get_backend(platform: Optional[str] = None) -> xla_client.LocalBackend:
 
   if platform is None:
     return list(_backends.values())[-1]
+
+  if platform not in _backends:
+    raise ValueError(f"Unknown backend '{platform}'")
 
   return _backends[platform]
 

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -23,7 +23,7 @@ XLA. There are also a handful of related casting utilities.
 from collections import OrderedDict
 from functools import partial
 import os
-from typing import Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 import warnings
 
 from absl import logging
@@ -44,8 +44,7 @@ from . import xla_client
 
 xops = xla_client.ops
 
-# TODO(skye): expose in xla_client
-LocalClient = xla_client._xla.LocalClient
+LocalClient = Any # TODO(skye): should be xla_client._xla.LocalClient
 
 FLAGS = flags.FLAGS
 

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -52,7 +52,7 @@ class XlaBridgeTest(absltest.TestCase):
     self.assertNotEmpty(xb.local_devices())
     with self.assertRaisesRegex(ValueError, "Unknown host_id 100"):
       xb.local_devices(100)
-    with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
+    with self.assertRaisesRegex(ValueError, "Unknown backend 'foo'"):
       xb.local_devices(backend="foo")
 
 


### PR DESCRIPTION
This is working towards removing backend caching from the XLA client, making jax responsible for caching instead. This will ultimately simplify the backend creation and caching logic.

Prior to this change, each backend factory was expected to memoize its returned backends. `xla_bridge.get_backend()` was already memoized, but the extra caching layer was necessary to make `get_backend(None)` and `get_backend(<default backend string>)` return the same Backend object.

This change achieves the same effect in xla_bridge alone via the following changes:

1. Creating specific backend factories for every platform in xla_bridge, instead of the rough groupings denoted by the `--jax_xla_backend` flag. This allows us to move the default backend logic to xla_bridge.

2. Initializing all registered backends on the first get_backend() call. This allows xla_bridge to know which backends are available, to pick a default and warn if no GPU/TPU is available.