### PR TITLE
[odeint] check step size is greater than zero

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -171,8 +171,8 @@ def _odeint(func, rtol, atol, mxstep, y0, ts, *args):
   def scan_fun(carry, target_t):
 
     def cond_fun(state):
-      i, _, _, t, _, _, _ = state
-      return (t < target_t) & (i < mxstep)
+      i, _, _, t, dt, _, _ = state
+      return (t < target_t) & (i < mxstep) & (dt > 0)
 
     def body_fun(state):
       i, y, f, t, dt, last_t, interp_coeff = state

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2863,7 +2863,10 @@ class CustomVJPTest(jtu.JaxTestCase):
 
     ans = jax.grad(g)(2.)  # don't crash
     expected = jax.grad(f, 0)(2., 0.1) + jax.grad(f, 0)(2., 0.2)
-    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    atol = {onp.float64: 5e-15}
+    rtol = {onp.float64: 2e-15}
+    self.assertAllClose(ans, expected, check_dtypes=False, atol=atol, rtol=rtol)
 
   def test_lowering_out_of_traces(self):
     # https://github.com/google/jax/issues/2578


### PR DESCRIPTION
In case the system being solved is stiff, it might make more sense for `odeint` to return an inaccurate solution rather than getting stuck in an infinite loop. IIUC this is at least part of the purpose for `mxstep` as well.

Ideally this wouldn't be a silent failure, but I guess such info would have to be part of other auxiliary info returned by `odeint`. (see #2628)

WDYT?