### PR TITLE
jit _rewriting_take

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3140,6 +3140,7 @@ def unique(ar, return_index=False, return_inverse=False,
 
 ### Indexing
 
+@partial(jit, static_argnums=(1,))
 def _rewriting_take(arr, idx):
   # Computes arr[idx].
   # All supported cases of indexing can be implemented as an XLA gather,


### PR DESCRIPTION
This speeds up sharding DeviceArrays, but it's still slower than it was prior to https://github.com/google/jax/commit/07571ae4dd3fceee580aa49c4490f99ce7f6b6de.

Benchmark results before this change:
```
---------Benchmark summary for pmap_shard_device_array---------
  nargs    nshards       mean     %std    relative    mean/baseline
-------  ---------  ---------  -------  ----------  ---------------
     10          8   0.591478  1.40474     1                13.2292
    100          8   5.46587   0           9.24104          16.6675
    500          8  26.7065    0          45.1522           18.237
    100          2   1.3446    1.03661     2.27329          11.5996
    100          4   2.76082   0           4.66767          15.2887
    100          8   5.17868   0           8.7555           17.9272
```

Benchmark results after this change:
```
---------Benchmark summary for pmap_shard_device_array---------
  nargs    nshards       mean     %std    relative    mean/baseline
-------  ---------  ---------  -------  ----------  ---------------
     10          8  0.0963601  7.20422     1                2.15522
    100          8  0.747664   5.35998     7.75907          2.27991
    500          8  3.47621    0          36.0752           2.37379
    100          2  0.177158   6.54806     1.8385           1.52831
    100          4  0.358899   5.9578      3.72457          1.9875
    100          8  0.714554   4.52672     7.41545          2.47359
```

So we're still off by a factor of 2, but a lot better than a factor of 10+.