### PR TITLE
Reset parameter replication default

### DIFF
--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -264,10 +264,12 @@ def _numpy_array_constant(builder, value, canonicalize_types=True):
     value = normalize_to_xla_dtypes(value)
   return xops.ConstantLiteral(builder, value)
 
-def parameter(builder, num, shape, name=None, replicated=False):
+def parameter(builder, num, shape, name=None, replicated=None):
   if name is None:
     name = ''
-  if isinstance(replicated, bool):
+  if replicated is None:
+    replicated = []
+  elif isinstance(replicated, bool):
     replicated = [replicated] * shape.leaf_count()
 
   return xops.Parameter(builder, num,


### PR DESCRIPTION
Reapplies https://github.com/tensorflow/tensorflow/commit/c044907cc85cdd5dd0c7ba58ea395fae59ef2e75 after XLA Python client change.

(XLA's replication analysis uses an empty std::vector to denote "no replication annotation," and only expects non-empty annotations on the parameters of the outermost computation.)