### PR TITLE
Fixed a few places where device sticky-ness was lost. Added FAQ 

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -72,6 +72,54 @@ Additional reading:
 
   * JAX_sharp_bits_
 
+
+How can I control on which device the computation is executed?
+--------------------------------------------------------------
+
+We describe first the principles of data and computation placement
+in JAX.
+
+In JAX the computation follows the data placement. JAX arrays
+have two placement properties: the device where the data resides,
+and whether it is **committed** to the device or not (we sometimes
+say that the data is *sticky* to the device).
+
+By default, JAX arrays are placed uncommitted on the default device
+(``jax.devices()[0]``).
+
+>>> from jax import numpy as jnp
+>>> print(jnp.ones(3).device_buffer.device())
+gpu:0
+
+Computations involving uncommitted data are performed on the default
+device and the results are uncommitted on the default device.
+
+Data can also be placed explicitly on a device using :func:`jax.device_put`,
+in which case if becomes **committed** to the device:
+
+>>> from jax import device_put
+>>> print(device_put(1, jax.devices()[2]).device_buffer.device())
+gpu:2
+
+Computations involving some committed inputs, will happen on the
+committed device, and the result will be committed on the
+same device. It is an error to invoke an operation on
+arguments that are committed to more than one device.
+
+JAX also have a ``device`` parameter for :func:`jax.jit`.
+Jitted functions without a ``device`` parameter behave as any other
+primitive operation (will follow the data and will error
+if invoked on data committed on more than one device).
+
+Jitted computations that have a ``device`` parameter behave as
+if prior to the computation the arguments are ``device_put`` to
+the specified device. This means that the result is committed
+to the specified device.
+
+For a worked-out example, we recommend reading through
+``test_computation_follows_data`` in
+[multi_device_test.py](https://github.com/google/jax/blob/master/tests/multi_device_test.py).
+
 .. comment We refer to the anchor below in JAX error messages
 
 `Abstract tracer value encountered where concrete value is expected` error

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -73,8 +73,8 @@ Additional reading:
   * JAX_sharp_bits_
 
 
-How can I control on which device the computation is executed?
---------------------------------------------------------------
+Controlling data and computation placement on devices
+-----------------------------------------------------
 
 We describe first the principles of data and computation placement
 in JAX.
@@ -94,8 +94,8 @@ gpu:0
 Computations involving uncommitted data are performed on the default
 device and the results are uncommitted on the default device.
 
-Data can also be placed explicitly on a device using :func:`jax.device_put`,
-in which case if becomes **committed** to the device:
+Data can also be placed explicitly on a device using :func:`jax.device_put`
+with a ``device`` parameter, in which case if becomes **committed** to the device:
 
 >>> from jax import device_put
 >>> print(device_put(1, jax.devices()[2]).device_buffer.device())
@@ -106,15 +106,14 @@ committed device, and the result will be committed on the
 same device. It is an error to invoke an operation on
 arguments that are committed to more than one device.
 
-JAX also have a ``device`` parameter for :func:`jax.jit`.
-Jitted functions without a ``device`` parameter behave as any other
-primitive operation (will follow the data and will error
-if invoked on data committed on more than one device).
+Jitted functions behave as any other primitive operation
+(will follow the data and will error if invoked on data
+committed on more than one device).
 
-Jitted computations that have a ``device`` parameter behave as
-if prior to the computation the arguments are ``device_put`` to
-the specified device. This means that the result is committed
-to the specified device.
+(As of April 2020, :func:`jax.jit` has a `device` parameter
+that affects slightly the device placement. That parameter
+is experimental, is likely to be removed or changed, and
+its use is not recommended.)
 
 For a worked-out example, we recommend reading through
 ``test_computation_follows_data`` in

--- a/jax/api.py
+++ b/jax/api.py
@@ -1524,22 +1524,16 @@ def make_jaxpr(fun: Callable,
   return jaxpr_maker
 
 
-def device_put(x, device: Optional[xc.Device] = None):
+def device_put(x, device=None):
   """Transfers ``x`` to ``device``.
 
   Args:
     ``x``: An array, scalar, or (nested) standard Python container thereof.
-    ``device``: The (optional) ``Device`` to transfer ``x`` to.
-      If given, then the result is committed to the device.
-
-  If the ``device`` parameter is ``None``, then this operation behaves like the
-  identity function if the operand is on any device already, otherwise it
-  transfers the data to the default device, uncommitted.
-
-  For more details on data placement see the https://jax.readthedocs.io/en/latest/faq.html#controlling-data-and-computation-placement-on-devices.
+    ``device``: The ``Device`` to transfer ``x`` to.
 
   Returns:
-    A copy of ``x`` that resides on ``device``.
+    A copy of ``x`` that resides on ``device``. If ``x`` is already on
+    ``device``, returns ``x``.
   """
   return tree_map(lambda y: xla.device_put_p.bind(y, device=device), x)
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -1524,16 +1524,22 @@ def make_jaxpr(fun: Callable,
   return jaxpr_maker
 
 
-def device_put(x, device=None):
+def device_put(x, device: Optional[xc.Device] = None):
   """Transfers ``x`` to ``device``.
 
   Args:
     ``x``: An array, scalar, or (nested) standard Python container thereof.
-    ``device``: The ``Device`` to transfer ``x`` to.
+    ``device``: The (optional) ``Device`` to transfer ``x`` to.
+      If given, then the result is committed to the device.
+
+  If the ``device`` parameter is ``None``, then this operation behaves like the
+  identity function if the operand is on any device already, otherwise it
+  transfers the data to the default device, uncommitted.
+
+  For more details on data placement see the https://jax.readthedocs.io/en/latest/faq.html#controlling-data-and-computation-placement-on-devices.
 
   Returns:
-    A copy of ``x`` that resides on ``device``. If ``x`` is already on
-    ``device``, returns ``x``.
+    A copy of ``x`` that resides on ``device``.
   """
   return tree_map(lambda y: xla.device_put_p.bind(y, device=device), x)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -16,7 +16,11 @@
 from collections import defaultdict
 import itertools as it
 import operator as op
+<<<<<<< HEAD
 from typing import Any, Callable, Dict, Sequence, Type, Optional
+=======
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type
+>>>>>>> af1db4eb... Fixed a few places where device sitckyness was lost. Added FAQ for device
 
 from absl import logging
 import numpy as onp
@@ -42,6 +46,10 @@ from . import masking
 
 xe = xc._xla
 xops = xc._xla.ops
+
+# Types
+Backend = xc.LocalBackend
+Device = xc.Device
 
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_debug_nans',
@@ -82,13 +90,13 @@ xla_shape_handlers: Dict[Type[core.AbstractValue], Callable] = {
     ConcreteArray: _make_array_shape,
 }
 
-def aval_to_result_handler(device, aval):
+def aval_to_result_handler(device: Optional[Device], aval: Optional[Device]):
   try:
     return xla_result_handlers[type(aval)](device, aval)
   except KeyError as err:
     raise TypeError(f"No xla_result_handler for type: {type(aval)}") from err
 
-def array_result_handler(device, aval):
+def array_result_handler(device: Optional[Device], aval: Optional[Device]):
   return partial(DeviceArray, raise_to_shaped(aval), device, lazy.array(aval.shape))
 
 xla_result_handlers: Dict[Type[core.AbstractValue], Callable[..., Callable]] = {
@@ -97,21 +105,21 @@ xla_result_handlers: Dict[Type[core.AbstractValue], Callable[..., Callable]] = {
     ConcreteArray: array_result_handler,
 }
 
-def device_put(x, device=None):
+def device_put(x, device: Optional[Device] = None):
   x = canonicalize_dtype(x)
   try:
     return device_put_handlers[type(x)](x, device)
   except KeyError as err:
     raise TypeError(f"No device_put handler for type: {type(x)}") from err
 
-def _device_put_array(x, device):
+def _device_put_array(x, device: Optional[Device]):
   backend = xb.get_device_backend(device)
   return backend.buffer_from_pyval(x, device)
 
 def _device_put_scalar(x, device):
   return _device_put_array(dtypes.coerce_to_array(x), device)
 
-device_put_handlers: Dict[Any, Callable] = {core.Unit: _device_put_unit}
+device_put_handlers: Dict[Any, Callable[[Any, Optional[Device]], Any]] = {core.Unit: _device_put_unit}
 device_put_handlers.update((t, _device_put_array) for t in array_types)
 device_put_handlers.update((t, _device_put_scalar) for t in _scalar_types)
 
@@ -172,7 +180,8 @@ def apply_primitive(prim, *args, **params):
   return compiled_fun(*args)
 
 @cache()
-def xla_primitive_callable(prim, *arg_specs, **params):
+def xla_primitive_callable(prim, *arg_specs: Tuple[core.AbstractValue,
+                                                   Optional[Device]], **params):
   avals, arg_devices = unzip2(arg_specs)
   device = _device_from_arg_devices(arg_devices)
   backend = xb.get_device_backend(device)
@@ -205,7 +214,7 @@ def xla_primitive_callable(prim, *arg_specs, **params):
   else:
     return partial(_execute_replicated_primitive, prim, compiled, handle_result)
 
-def _device_from_arg_devices(devices):
+def _device_from_arg_devices(devices: Sequence[Optional[Device]]) -> Optional[Device]:
   """Given devices of inputs, determine where to perform a computation.
 
   Args:
@@ -749,7 +758,8 @@ class DeviceArray(DeviceValue):
   __slots__ = ["_npy_value", "_device", "_lazy_expr"]
   __array_priority__ = 100
 
-  def __init__(self, aval, device, lazy_expr, device_buffer):
+  def __init__(self, aval: core.AbstractValue, device: Optional[Device],
+               lazy_expr, device_buffer):
     self.aval = aval
     self.device_buffer = device_buffer
     self._device = device
@@ -760,6 +770,7 @@ class DeviceArray(DeviceValue):
       assert type(aval) is ShapedArray
       npy_value = self._value
       assert npy_value.dtype == aval.dtype and npy_value.shape == aval.shape
+      assert (device is None) or device is device_buffer.device()
 
   @property
   def _value(self):
@@ -915,12 +926,12 @@ def _device_array_constant_handler(c, val, canonicalize_types=True):
     return lazy.stage_lexpr(c, val._lazy_expr, base_val)
 xb.register_constant_handler(DeviceArray, _device_array_constant_handler)
 
-def _device_put_device_array(x, device):
+def _device_put_device_array(x: DeviceArray, device: Optional[Device]):
   x = _copy_device_array_to_device(x, device)
   return _force(x).device_buffer
 device_put_handlers[DeviceArray] = _device_put_device_array
 
-def _copy_device_array_to_device(x: DeviceArray, device: Optional[xc.Device]):
+def _copy_device_array_to_device(x: DeviceArray, device: Optional[xc.Device]) -> DeviceArray:
   if device is None:
     # no copying to be done because there's no target specified
     return x
@@ -932,6 +943,8 @@ def _copy_device_array_to_device(x: DeviceArray, device: Optional[xc.Device]):
     if x.device_buffer.device() == device:
       # no copying to be done because source equals target
       return x
+    elif x.device_buffer.device() == device:
+      moved_buf = x.device_buffer  # Perhaps we need to change stickyness
     else:
       # move the buffer with a device-to-device copy
       moved_buf = x.device_buffer.copy_to_device(device)
@@ -956,7 +969,9 @@ def _force(x: DeviceArray) -> DeviceArray:
     return force_fun(x)
 
 @cache()
-def _lazy_force_computation(sticky, aval, device, lexpr) -> Callable[[DeviceArray], DeviceArray]:
+def _lazy_force_computation(sticky: bool, aval: core.AbstractValue,
+                            device: Device, lexpr: lazy.LazyExpr
+                            ) -> Callable[[DeviceArray], DeviceArray]:
   c = xb.make_computation_builder("lazy_force")
   if lazy.is_constant(lexpr):
     param = None
@@ -969,7 +984,7 @@ def _lazy_force_computation(sticky, aval, device, lexpr) -> Callable[[DeviceArra
   xla_out = lazy.stage_lexpr(c, lexpr, param)
   built_c = c.Build(xla_out)
 
-  device = _device_from_arg_devices([device])
+  device: Optional[Device] = _device_from_arg_devices([device])
   options = xb.get_compile_options(
       num_replicas=1,
       num_partitions=1,
@@ -989,7 +1004,7 @@ def _lazy_force_computation(sticky, aval, device, lexpr) -> Callable[[DeviceArra
   return force_fun
 
 
-def _device_put_impl(x, device=None):
+def _device_put_impl(x, device: Optional[Device] = None):
   if type(x) is DeviceArray:
     return _copy_device_array_to_device(x, device)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -938,7 +938,7 @@ def _copy_device_array_to_device(x: DeviceArray, device: Optional[xc.Device]) ->
     # source and target platforms are the same
     if x.device_buffer.device() == device:
       # no copying to be done because source equals target
-      moved_buf = x.device_buffer  # Perhaps we need to change stickyness
+      return x
     else:
       # move the buffer with a device-to-device copy
       moved_buf = x.device_buffer.copy_to_device(device)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2635,7 +2635,7 @@ def _broadcast_in_dim_impl(operand, *, shape, broadcast_dimensions):
       operand, shape=shape, broadcast_dimensions=broadcast_dimensions)
     aval = ShapedArray(shape, _dtype(operand))
     lazy_expr = lazy.broadcast(operand._lazy_expr, shape, broadcast_dimensions)
-    return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
+    return xla.DeviceArray(aval, operand._device, lazy_expr, operand.device_buffer)
   else:
     return xla.apply_primitive(broadcast_in_dim_p, operand, shape=shape,
                                broadcast_dimensions=broadcast_dimensions)
@@ -2845,7 +2845,7 @@ def _reshape_impl(operand, *, new_sizes, dimensions):
     if bcast_dims is not None:
       aval = ShapedArray(new_sizes, operand.dtype)
       lazy_expr = lazy.broadcast(operand._lazy_expr, new_sizes, bcast_dims)
-      return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
+      return xla.DeviceArray(aval, operand._device, lazy_expr, operand.device_buffer)
 
   if type(operand) is pxla.ShardedDeviceArray and dimensions is None:
     array = _reshape_sharded_device_array(operand, new_sizes, old_sizes)
@@ -2999,7 +2999,7 @@ def _transpose_impl(operand, *, permutation):
   if type(operand) is xla.DeviceArray:
     lazy_expr = lazy.transpose(operand._lazy_expr, permutation)
     aval = ShapedArray(lazy_expr.shape, operand.dtype)
-    return xla.DeviceArray(aval, None, lazy_expr, operand.device_buffer)
+    return xla.DeviceArray(aval, operand._device, lazy_expr, operand.device_buffer)
   else:
     return xla.apply_primitive(transpose_p, operand, permutation=permutation)
 

--- a/jax/lazy.py
+++ b/jax/lazy.py
@@ -16,7 +16,7 @@
 from collections import namedtuple
 import functools
 import operator as op
-from typing import Any, Callable
+from typing import Any, Callable, Optional, Sequence, Tuple
 
 import numpy as onp
 
@@ -132,15 +132,15 @@ def broadcast(lexpr, shape, broadcast_dimensions):
     new_dims[d] = lexpr.dims[i]
   return LazyExpr(lexpr.input, shape, tuple(new_dims))
 
-def transpose(lexpr, perm):
+def transpose(lexpr: LazyExpr, perm: Sequence[int]):
   new_shape = tuple(lexpr.shape[i] for i in perm)
   new_dims = tuple(lexpr.dims[i] for i in perm)
   return LazyExpr(lexpr.input, new_shape, new_dims)
 
-def is_constant(lexpr):
+def is_constant(lexpr: Optional[LazyExpr]):
   return lexpr is not None and type(lexpr.input) is not ArrayVar
 
-def is_trivial(lexpr):
+def is_trivial(lexpr: LazyExpr) -> bool:
   return (type(lexpr.input) is ArrayVar and
           lexpr.dims == tuple(range(len(lexpr.shape))))
 
@@ -193,7 +193,7 @@ def eval_lexpr(lexpr, x):
   return x
 
 
-def stage_lexpr(c, lexpr, x):
+def stage_lexpr(c, lexpr: Optional[LazyExpr], x):
   """Stage a lazy expression into an XLA computation.
   Args:
     c: XLA ComputationBuilder into which to stage the expression.

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -55,142 +55,239 @@ def tearDownModule():
 
 class MultiDeviceTest(jtu.JaxTestCase):
 
-  def test_computation_follows_data(self):
+  def get_devices(self):
     if len(jax.devices()) < 2:
       raise SkipTest("test requires multiple devices")
+    return jax.devices()
+
+  def assert_committed_to_device(self, data, device):
+    """Asserts that the data is committed to the device."""
+    self.assertIsNotNone(data._device)
+    self.assertEqual(data.device_buffer.device(), device)
+
+  def assert_uncommitted_to_device(self, data, device):
+    """Asserts that the data is on the device but not committed to it."""
+    self.assertIsNone(data._device)
+    self.assertEqual(data.device_buffer.device(), device)
+
+  def test_computation_follows_data(self):
+    devices = self.get_devices()
+
+    # By default, computation is placed (uncommitted) on device 0
+    x = np.ones(2)
+    self.assert_uncommitted_to_device(x, devices[0])
+
+    # Computing only with uncommitted data, will perform the computation
+    # on the same device 0, and the result is uncommitted
+    y = np.sin(x + x * 1) + 2
+    self.assert_uncommitted_to_device(y, devices[0])
+
+    # We can use device_put to both place the data on the requested device,
+    # and to commit it there.
+    z = jax.device_put(1, devices[1])
+    self.assert_committed_to_device(z, devices[1])
+
+    # A computation with some committed inputs will happen on the committed
+    # device. Uncommitted data may be moved to the committed device.
+    u = z + x  # z is committed, and x is uncommitted
+    self.assert_committed_to_device(u, devices[1])
+
+    # A computation with inputs committed to multiple devices will result
+    # in an error
+    with self.assertRaisesRegex(ValueError,
+                                "primitive arguments must be colocated on the same device"):
+      jax.device_put(x, devices[2]) + jax.device_put(x, devices[3])
+
+    # A jitted-computation without a device specification behave like any
+    # other primitive
+    jit_add = jax.jit(lambda a, b: a + b)
+    self.assert_uncommitted_to_device(jit_add(1, 2), devices[0])
+    self.assert_committed_to_device(jit_add(1, jax.device_put(2, devices[2])),
+                                    devices[2])
+    with self.assertRaisesRegex(ValueError,
+                                "primitive arguments must be colocated on the same device"):
+      jit_add(jax.device_put(x, devices[2]), jax.device_put(x, devices[3]))
+
+    # A jitted computation with an device specification behaves as if the
+    # arguments are first device_put to the specified device. The result
+    # will be committed on the specified.
+    jit_add_on4 = jax.jit(lambda a, b: a + b, device=devices[4])
+    self.assert_committed_to_device(jit_add_on4(1, 2), devices[4])
+    self.assert_committed_to_device(jit_add_on4(1, jax.device_put(2, devices[2])),
+                                    devices[4])
+    self.assert_committed_to_device(jit_add_on4(jax.device_put(x, devices[2]),
+                                                jax.device_put(x, devices[3])),
+                                    devices[4])
+
+  def test_computation_follows_data_old(self):
+    devices = self.get_devices()
 
     # computation follows data explicitly placed on device 1
-    x = jax.device_put(1, jax.devices()[1])
+    x = jax.device_put(1, devices[1])
+    self.assert_committed_to_device(x, devices[1])
     y = x.reshape((1, 1))
-    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(y, devices[1])
     z = y.reshape((1, 1))
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
 
     # multiple arguments explicitly placed on device 0 are compatible
-    x = jax.device_put(1, jax.devices()[0])
-    y = jax.device_put(2, jax.devices()[0])
+    x = jax.device_put(1, devices[0])
+    y = jax.device_put(2, devices[0])
     z = x + y
     self.assertEqual(z, 3)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+    self.assert_committed_to_device(z, devices[0])
     w = z + x
-    self.assertEqual(w.device_buffer.device(), jax.devices()[0])
+    self.assert_committed_to_device(w, devices[0])
 
-    f = jax.jit(lambda x: x + 1, device=jax.devices()[0])
+    f = jax.jit(lambda x: x + 1, device=devices[0])
     z = f(1) + f(2)
     self.assertEqual(z, 5)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+    self.assert_committed_to_device(z, devices[0])
     w = z + z
-    self.assertEqual(z.device_buffer.device(), jax.devices()[0])
+    self.assert_committed_to_device(w, devices[0])
 
     # multiple arguments explicitly placed on device 1 are compatible
-    x = jax.device_put(1, jax.devices()[1])
-    y = jax.device_put(2, jax.devices()[1])
+    x = jax.device_put(1, devices[1])
+    y = jax.device_put(2, devices[1])
     z = x + y
     self.assertEqual(z, 3)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
     w = z + x
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(w, devices[1])
 
-    f = jax.jit(lambda x: x + 1, device=jax.devices()[1])
+    f = jax.jit(lambda x: x + 1, device=devices[1])
     z = f(1) + f(2)
     self.assertEqual(z, 5)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
     w = z + z
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(w, devices[1])
 
     # an argument explicitly placed on one device still works with values that
-    # aren't device-committed (and computaiton follows device-committed values)
-    z = jax.device_put(1., jax.devices()[1]) + 4
+    # aren't device-committed (and computation follows device-committed values)
+    z = jax.device_put(1., devices[1]) + 4
     self.assertEqual(z, 5.)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
     w = z + 3
     self.assertEqual(w, 8.)
-    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(w, devices[1])
 
-    z = jax.device_put(1., jax.devices()[1]) + np.ones(3)
-    self.assertAllClose(z, 1 + onp.ones(3), check_dtypes=False)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    z = jax.device_put(2., devices[1]) + np.ones(3)
+    self.assertAllClose(z, 2 + onp.ones(3), check_dtypes=False)
+    self.assert_committed_to_device(z, devices[1])
     w = z - 3
-    self.assertAllClose(w, 1 + onp.ones(3) - 3, check_dtypes=False)
-    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+    self.assertAllClose(w, 2 + onp.ones(3) - 3, check_dtypes=False)
+    self.assert_committed_to_device(w, devices[1])
 
-    z = jax.device_put(1., jax.devices()[1]) + np.array([1, 2])
+    z = jax.device_put(1., devices[1]) + np.array([1, 2])
     self.assertAllClose(z, 1 + onp.array([1, 2]), check_dtypes=False)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
     w = z * 2
     self.assertAllClose(w, (1 + onp.array([1, 2])) * 2, check_dtypes=False)
-    self.assertEqual(w.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(w, devices[1])
 
-    z = jax.device_put(1., jax.devices()[1]) + jax.device_put(2)
+    z = jax.device_put(1., devices[1]) + jax.device_put(2)
     self.assertAllClose(z, 3., check_dtypes=False)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
 
-    z = jax.device_put(1., jax.devices()[1]) + jax.jit(lambda x: x + 1)(3)
+    z = jax.device_put(1., devices[1]) + jax.jit(lambda x: x + 1)(3)
     self.assertAllClose(z, 5., check_dtypes=False)
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(z, devices[1])
 
     # multiple arguments explicitly placed on distinct devices cause errors
-    x = jax.device_put(1, jax.devices()[0])
-    y = jax.device_put(2, jax.devices()[1])
+    x = jax.device_put(1, devices[0])
+    y = jax.device_put(2, devices[1])
     self.assertRaisesRegex(
         ValueError,
         "primitive arguments must be colocated on the same device",
         lambda: x + y)
 
-    f = jax.jit(lambda x: x + 1, device=jax.devices()[0])
-    g = jax.jit(lambda x: x + 1, device=jax.devices()[1])
+    f = jax.jit(lambda x: x + 1, device=devices[0])
+    g = jax.jit(lambda x: x + 1, device=devices[1])
     self.assertRaisesRegex(
         ValueError,
         "primitive arguments must be colocated on the same device",
         lambda: f(1) + g(2))
 
   def test_primitive_compilation_cache(self):
-    if len(jax.devices()) < 2:
-      raise SkipTest("test requires multiple devices")
+    devices = self.get_devices()
 
-    x = jax.device_put(1, jax.devices()[1])
+    x = jax.device_put(1, devices[1])
 
     with jtu.count_primitive_compiles() as count:
       y = lax.add(x, x)
       z = lax.add(y, y)
 
     self.assertEqual(count[0], 1)
-    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
-    self.assertEqual(z.device_buffer.device(), jax.devices()[1])
+    self.assert_committed_to_device(y, devices[1])
+    self.assert_committed_to_device(z, devices[1])
 
   def test_device_put(self):
-    if len(jax.devices()) < 2:
-      raise SkipTest("test requires multiple devices")
+    devices = self.get_devices()
 
     # test device_put on regular values
-    x = jax.device_put(1, device=jax.devices()[0])
-    self.assertEqual(x.device_buffer.device(), jax.devices()[0])
+    x = jax.device_put(1, device=devices[0])
+    self.assert_committed_to_device(x, devices[0])
 
     # test device_put on its own output
-    y = jax.device_put(x, device=jax.devices()[1])
-    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
+    y = jax.device_put(x, device=devices[1])
+    self.assert_committed_to_device(y, devices[1])
 
     # test device_put on lazy values
-    x = jax.device_put(np.zeros(2), device=jax.devices()[0])
-    self.assertEqual(x.device_buffer.device(), jax.devices()[0])
+    x = jax.device_put(np.zeros(2), device=devices[0])
+    self.assert_committed_to_device(x, devices[0])
 
-    y = jax.device_put(x, device=jax.devices()[1])
-    self.assertEqual(y.device_buffer.device(), jax.devices()[1])
+    y = jax.device_put(x, device=devices[1])
+    self.assert_committed_to_device(y, devices[1])
 
-    x = jax.device_put(np.zeros(2), device=jax.devices()[1])
-    self.assertEqual(x.device_buffer.device(), jax.devices()[1])
+    x = jax.device_put(np.zeros(2), device=devices[1])
+    self.assert_committed_to_device(x, devices[1])
+
+    # device_put with device=None does not change placement
+    x = jax.device_put(np.zeros(2))
+    self.assert_uncommitted_to_device(x, devices[0])
+
+    x = jax.device_put(jax.device_put(2, device=devices[1]))
+    self.assert_committed_to_device(x, devices[1])
+
 
   def test_closed_over_values_device_placement(self):
     # see https://github.com/google/jax/issues/1431
-    if len(jax.devices()) < 2:
-      raise SkipTest("test requires multiple devices")
+    devices = self.get_devices()
 
     def f(): return lax.add(3., 4.)
     self.assertIsInstance(f(), xla.DeviceArray)
-    self.assertEqual(f().device_buffer.device(), jax.devices()[0])
-    self.assertEqual(jax.jit(f)().device_buffer.device(), jax.devices()[0])
-    self.assertEqual(jax.jit(f, device=jax.devices()[1])().device_buffer.device(),
-                     jax.devices()[1])
+    self.assert_uncommitted_to_device(f(), devices[0])
+    self.assert_uncommitted_to_device(jax.jit(f)(), devices[0])
+    self.assert_committed_to_device(jax.jit(f, device=devices[1])(),
+                                    devices[1])
+
+  def test_reshape(self):
+    devices = self.get_devices()
+    # computation follows data explicitly placed on device 1
+    x = jax.device_put(1, devices[1])
+    y = x.reshape((1, 1))
+    self.assert_committed_to_device(y, devices[1])
+    z = y.reshape((1, 1))
+    self.assert_committed_to_device(z, devices[1])
+
+  def test_broadcast(self):
+    devices = self.get_devices()
+
+    z = 1 + np.ones((2, 3))
+    self.assert_uncommitted_to_device(z, devices[0])
+    y = jax.device_put(1, devices[2]) + np.ones((2, 3))
+    self.assert_committed_to_device(y, devices[2])
+
+  def test_transpose(self):
+    devices = self.get_devices()
+
+    x = np.ones((2, 3))
+    self.assert_uncommitted_to_device(x, devices[0])
+
+    y = lax.transpose(x, (1, 0))
+    self.assert_uncommitted_to_device(y, devices[0])
+    z = lax.transpose(jax.device_put(x, devices[2]), (1, 0))
+    self.assert_committed_to_device(z, devices[2])
 
 
 if __name__ == '__main__':

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -111,6 +111,7 @@ class MultiDeviceTest(jtu.JaxTestCase):
     # A jitted computation with an device specification behaves as if the
     # arguments are first device_put to the specified device. The result
     # will be committed on the specified.
+    # The `device` parameter is experimental, and subject to change.
     jit_add_on4 = jax.jit(lambda a, b: a + b, device=devices[4])
     self.assert_committed_to_device(jit_add_on4(1, 2), devices[4])
     self.assert_committed_to_device(jit_add_on4(1, jax.device_put(2, devices[2])),


### PR DESCRIPTION

I have also added a new test (multi_device_test.test_computation_follows_data),
written more as part of the documentation. It is shorted than the
old test_computation_follows_data (which is still there, renamed
as test_computation_follows_data_old). I believe there is no
extra coverage in test_computation_follows_data_old w.r.t. all the
other tests we have.

Relates to #2564