### PR TITLE
Fix jit with device placement on multi-backend setup

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -482,6 +482,7 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, *arg_specs):
 
   nreps = jaxpr_replicas(jaxpr)
   device = _xla_callable_device(nreps, backend, device, arg_devices)
+  backend = device.platform if device else backend
   result_handlers = tuple(map(partial(_pval_to_result_handler, device), pvals))
 
   # Computations that only produce constants and/or only rearrange their inputs,


### PR DESCRIPTION
In setups with multiple backends, a jit happens on the default
backend, unless we give a `backend` parameter. This is true
even if the inputs are committed to a device on the non-default
backend, or if we pass a `device` parameter to jit.

Inspired by #2851