### PR TITLE
Fix lax_reference implementation of round() to match lax.

### DIFF
--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -32,7 +32,7 @@ neg = onp.negative
 sign = onp.sign
 floor = onp.floor
 ceil = onp.ceil
-round = onp.round
+round = lambda x: onp.trunc(x + onp.copysign(.5, x))
 nextafter = onp.nextafter
 
 is_finite = onp.isfinite


### PR DESCRIPTION
lax.round() is documented to round half away from zero, but np.round() rounds to nearest even.