### PR TITLE
Make sure gather/scatter indices in lax gradient tests aren't out of …

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2526,19 +2526,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
        "slice_sizes": slice_sizes, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for shape, idxs, dnums, slice_sizes in [
+      for dtype in grad_float_dtypes
+      for shape, idxs, dnums, slice_sizes, max_idx in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
-            (1,)),
+            (1,), 5),
           ((10,), onp.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
-            (2,)),
+            (2,), 9),
           ((10, 5,), onp.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
-            (1, 3)),
+            (1, 3), 3),
       ]
-      for rng_idx_factory in [partial(jtu.rand_int, max(shape))]
+      for rng_idx_factory in [partial(jtu.rand_int, max_idx)]
       for rng_factory in [jtu.rand_default]))
   def testGatherGrad(self, shape, dtype, idxs, dnums, slice_sizes, rng_factory,
                      rng_idx_factory):
@@ -2557,19 +2557,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
+      for dtype in grad_float_dtypes
+      for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 4),
           ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 9),
           ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 3),
       ]
-      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_idx_factory in [partial(jtu.rand_int, max_idx)]
       for rng_factory in [jtu.rand_default]))
   def testScatterAddGrad(self, arg_shape, dtype, idxs, update_shape, dnums,
                          rng_factory, rng_idx_factory):
@@ -2589,19 +2589,19 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
+      for dtype in grad_float_dtypes
+      for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 4),
           ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 9),
           ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
+            scatter_dims_to_operand_dims=(0,)), 3),
       ]
-      for rng_idx_factory in [partial(jtu.rand_int, max(arg_shape))]
+      for rng_idx_factory in [partial(jtu.rand_int, max_idx)]
       for rng_factory in [jtu.rand_default]))
   def testScatterGrad(self, arg_shape, dtype, idxs, update_shape, dnums,
                       rng_factory, rng_idx_factory):


### PR DESCRIPTION
…bounds.

Out-of-bounds gathers are clamped by XLA to be in bounds, but out-of-bounds scatters are dropped by XLA entirely. This can cause gradient tests to fail because the two operations aren't duals of one another, as the gradient rules expect.

(NumPy-level indexing should probably return NaN for an out-of-bounds gather, but that isn't in scope for `lax`.)

Also restrict scatter/gather gradient tests to only test 32-bit or better types, as most of the gradient tests do, to avoid low-precision float failures.