### PR TITLE
Add support for in_axes=None (but not out_axes, or in_axes>0) to pmap

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1129,7 +1129,7 @@ def _papply(fun):
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten((args, kwargs))
     flat_fun, out_tree = flatten_fun(f, in_tree)
-    axis_size = _pmap_axis_size(args_flat)
+    axis_size = _mapped_axis_size(in_tree, args_flat, 0, "papply")
     out_flat = parallel.papply(flat_fun, axis_name, args_flat, axis_size)
     return tree_unflatten(out_tree(), out_flat)
 
@@ -1143,7 +1143,7 @@ def _parallelize(fun):
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten(args)
     f, out_tree = flatten_fun_nokwargs(f, in_tree)
-    axis_size = _pmap_axis_size(args_flat)
+    axis_size = _mapped_axis_size(in_tree, args_flat, 0, "parallelize")
 
     chunk_size, leftover = divmod(axis_size, pxla.unmapped_device_count())
     if chunk_size == 0 and leftover:

--- a/jax/api.py
+++ b/jax/api.py
@@ -1129,7 +1129,8 @@ def _papply(fun):
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten((args, kwargs))
     flat_fun, out_tree = flatten_fun(f, in_tree)
-    axis_size = _mapped_axis_size(in_tree, args_flat, 0, "papply")
+    axis_size = _mapped_axis_size(
+        in_tree, args_flat, (0,) * len(args_flat), "papply")
     out_flat = parallel.papply(flat_fun, axis_name, args_flat, axis_size)
     return tree_unflatten(out_tree(), out_flat)
 
@@ -1143,7 +1144,8 @@ def _parallelize(fun):
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten(args)
     f, out_tree = flatten_fun_nokwargs(f, in_tree)
-    axis_size = _mapped_axis_size(in_tree, args_flat, 0, "parallelize")
+    axis_size = _mapped_axis_size(
+        in_tree, args_flat, (0,) * len(args_flat), "parallelize")
 
     chunk_size, leftover = divmod(axis_size, pxla.unmapped_device_count())
     if chunk_size == 0 and leftover:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -141,10 +141,10 @@ def spec_to_indices(shape: Tuple[int, ...],
 
   # `product` will always return a sequence of tuples. Skip the tuples if each
   # index is a single element.
-  if len(indices_per_axis) > 1:
-    indices = list(product(*indices_per_axis))
-  else:
+  if len(indices_per_axis) == 1:
     indices = list(indices_per_axis[0])
+  else:
+    indices = list(product(*indices_per_axis))
 
   return tuple(i for i in indices
                for _ in range(sharding_spec.replication_factor))
@@ -196,6 +196,7 @@ def shard_args(devices: Sequence[xb.xla_client.Device],
         buffers[r][a] = (buf if buf.device() == devices[r]
                          else buf.copy_to_device(devices[r]))
     else:
+      arg = xla.canonicalize_dtype(arg)
       bufs = shard_arg_handlers[type(arg)](arg, devices, indices[a])
       for r, buf in enumerate(bufs):
         buffers[r][a] = buf
@@ -461,8 +462,9 @@ class ShardedDeviceArray(xla.DeviceArray):
     if device_buffers is None:
       assert isinstance(sharding_spec[0], xb.xla_client._xla.PyLocalBuffer)
       device_buffers = sharding_spec
+      sharded_aval = ShapedArray(aval.shape[1:], aval.dtype)
       sharding_spec = _pmap_sharding_spec(aval.shape[0], aval.shape[0],
-                                          aval.shape[1:])
+                                          sharded_aval, True)
 
     # TODO(skye): assert invariants. Keep performance in mind though.
     if indices is None:
@@ -563,12 +565,13 @@ def xla_pmap_impl(fun: lu.WrappedFun, *args, backend, axis_name, axis_size, glob
                   devices, name, mapped_invars):
   abstract_args = map(xla.abstractify, args)
   compiled_fun = parallel_callable(fun, backend, axis_name, axis_size,
-                                   global_axis_size, devices, name, *abstract_args)
+                                   global_axis_size, devices, name, mapped_invars,
+                                   *abstract_args)
   return compiled_fun(*args)
 
 @lu.cache
 def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
-                      devices, name, *avals):
+                      devices, name, mapped_invars, *avals):
   if devices is not None and len(devices) == 0:
     raise ValueError("'devices' argument to pmap must be non-empty, or None.")
 
@@ -614,9 +617,10 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
     with extend_dynamic_axis_env(axis_name, dummy._trace, global_axis_size):
       return fun.call_wrapped(*args)
 
-  sharded_avals = tuple(map(partial(shard_aval, axis_size), avals))
+  sharded_avals = tuple(shard_aval(axis_size, aval) if m else aval
+                        for m, aval in zip(mapped_invars, avals))
   pvals = [pe.PartialVal.unknown(aval) for aval in sharded_avals]
-  # We add a dummy first invar, to carry the trace details to `dynamic_fun`
+  # We add a dummy first invar, to carry the trace  details to `dynamic_fun`
   pval = pe.PartialVal.unknown(core.abstract_unit)  # dummy value for axis env
   jaxpr, out_pvals, consts = pe.trace_to_jaxpr(
       dynamic_fun, [pval] + pvals, instantiate=False, stage_out=True, bottom=True)
@@ -704,9 +708,8 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
   compiled = backend.compile(built, compile_options=compile_options)
 
   input_sharding_specs = [_pmap_sharding_spec(num_local_replicas, axis_size,
-                                              aval.shape)
-                          if aval is not core.abstract_unit else None
-                          for aval in sharded_avals]
+                                              aval, m)
+                          for m, aval in zip(mapped_invars, sharded_avals)]
   input_indices = [spec_to_indices(aval.shape, spec)
                    if spec is not None else None
                    for aval, spec in zip(avals, input_sharding_specs)]
@@ -772,7 +775,7 @@ def replicate(val, axis_size, nrep, devices=None, backend=None):
   # TODO(jekbradbury): use ShardingSpec.replication_factor instead
   aval = xla.abstractify(val)  # type: ShapedArray
   replicated_aval = ShapedArray((axis_size,) + aval.shape, aval.dtype)
-  sharding_spec = _pmap_sharding_spec(nrep, axis_size, aval.shape)
+  sharding_spec = _pmap_sharding_spec(nrep, axis_size, aval, True)
   device_buffers = [xla.device_put(val, d) for d in devices]
   return ShardedDeviceArray(replicated_aval, sharding_spec, device_buffers)
 
@@ -798,19 +801,27 @@ def _pval_to_result_handler(axis_size, nrep, pval, devices, backend):
     return lambda _: bcast_const
   else:
     if pv is not core.abstract_unit:
-      sharding_spec = _pmap_sharding_spec(nrep, axis_size, pv.shape)
+      sharding_spec = _pmap_sharding_spec(nrep, axis_size, pv, True)
       indices = spec_to_indices((axis_size,) + pv.shape, sharding_spec)
     else:
       sharding_spec = indices = None
     return aval_to_result_handler(axis_size, sharding_spec, indices, pv)
 
-def _pmap_sharding_spec(nrep, axis_size, sharded_shape):
+def _pmap_sharding_spec(nrep, axis_size, sharded_aval, mapped):
+  if sharded_aval is core.abstract_unit:
+    return None
   replication_factor, ragged = divmod(nrep, axis_size)
   assert not ragged
-  return ShardingSpec(
-      shards_per_axis=(axis_size,) + (1,) * len(sharded_shape),
-      is_axis_materialized=(False,) + (True,) * len(sharded_shape),
-      replication_factor=replication_factor)
+  if mapped:
+    return ShardingSpec(
+        shards_per_axis=(axis_size,) + (1,) * len(sharded_aval.shape),
+        is_axis_materialized=(False,) + (True,) * len(sharded_aval.shape),
+        replication_factor=replication_factor)
+  else:
+    return ShardingSpec(
+        shards_per_axis=(1,) * len(sharded_aval.shape),
+        is_axis_materialized=(True,) * len(sharded_aval.shape),
+        replication_factor=replication_factor * axis_size)
 
 
 def execute_replicated(compiled, backend, in_handler, out_handler, *args):

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2912,8 +2912,8 @@ def _reshape_sharded_device_array(array, new_sizes, old_sizes):
     if ragged: return None
     if new_sizes[0] != split_axis_size: return None
     aval = ShapedArray(new_sizes, array.dtype)
-    sharding_spec = pxla._pmap_sharding_spec(new_sizes[0], new_sizes[0],
-                                             new_sizes[1:])
+    sharding_spec = pxla._pmap_sharding_spec(
+        new_sizes[0], new_sizes[0], ShapedArray(new_sizes[1:], array.dtype), True)
     return pxla.ShardedDeviceArray(aval, sharding_spec, array.device_buffers)
 
   return None

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -187,7 +187,7 @@ class PmapTest(jtu.JaxTestCase):
     f = pmap(lambda x, y: x + y)
     self.assertRaisesRegex(
         ValueError,
-        "vmap or pmap got inconsistent sizes for array axes to be mapped",
+        "pmap got inconsistent sizes for array axes to be mapped",
         lambda: f(onp.random.randn(n), onp.random.randn(n - 1)))
 
   @parameterized.named_parameters(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -187,7 +187,7 @@ class PmapTest(jtu.JaxTestCase):
     f = pmap(lambda x, y: x + y)
     self.assertRaisesRegex(
         ValueError,
-        "Axis size .* does not match leading dimension of shape .*",
+        "vmap or pmap got inconsistent sizes for array axes to be mapped",
         lambda: f(onp.random.randn(n), onp.random.randn(n - 1)))
 
   @parameterized.named_parameters(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -209,15 +209,28 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testPartiallyMapped(self):
-    f = pmap(lambda x, y: x - lax.psum(y, 'i'), axis_name='i', in_axes=(None, 0))
+    f = pmap(lambda x, y: x, in_axes=(None, 0))
+    g = pmap(lambda x, y: x - lax.psum(y, 'i'), axis_name='i', in_axes=(None, 0))
 
-    shape = (xla_bridge.device_count(), 4)
-    x = 3.
+    mesh_shape = (xla_bridge.device_count(),)
+    shape = mesh_shape + (4,)
+    x = onp.array(3., dtype=onp.float32)
     y = onp.arange(prod(shape), dtype=onp.float32).reshape(shape)
-    expected = onp.broadcast_to(x - onp.sum(y, 0, keepdims=True), shape)
 
-    ans = f(x, y)
-    self.assertAllClose(ans, expected, check_dtypes=False)
+    f_expected = onp.broadcast_to(x, mesh_shape)
+    f_ans = f(x, y)
+    self.assertAllClose(f_ans, f_expected, check_dtypes=True)
+    self.assertIsInstance(f_ans, pxla.ShardedDeviceArray)
+    # the output is actually replicated (has the same values in each device buffer)
+    # but out_axes is implicitly 0, so we shouldn't have replication in the
+    # sharding spec.
+    self.assertEqual(f_ans.sharding_spec.replication_factor, 1)
+
+    g_expected = onp.broadcast_to(x - onp.sum(y, 0, keepdims=True), shape)
+    g_ans = g(x, y)
+    self.assertAllClose(g_ans, g_expected, check_dtypes=True)
+    self.assertIsInstance(g_ans, pxla.ShardedDeviceArray)
+    self.assertEqual(g_ans.sharding_spec.replication_factor, 1)
 
   @parameterized.named_parameters(
       {"testcase_name": "_mesh={}".format(device_mesh_shape).replace(" ", ""),

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -208,6 +208,17 @@ class PmapTest(jtu.JaxTestCase):
     self.assertEqual(ans.shape, expected.shape)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testPartiallyMapped(self):
+    f = pmap(lambda x, y: x - lax.psum(y, 'i'), axis_name='i', in_axes=(None, 0))
+
+    shape = (xla_bridge.device_count(), 4)
+    x = 3.
+    y = onp.arange(prod(shape), dtype=onp.float32).reshape(shape)
+    expected = onp.broadcast_to(x - onp.sum(y, 0), shape)
+
+    ans = f(x, y)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
   def testJvpAndPartialEval(self):
     @partial(pmap, axis_name='i')
     def f(x):


### PR DESCRIPTION
After trying a few different ways to give XLA information about when arguments to a pmap are the same across replicas (needed to trigger a strong-scaling optimization), this seems like a sweet spot:
- it can use the existing `mapped_invars` param, so there are no changes needed (yet) on the `xla_pmap` primitive or transformations
- it's (half of) the API I think we want in the long run, rather than an experimental keyword argument we'll delete later
- it's already useful for "normal" users (using `in_axes=None` for a replicated `DeviceArray` pmap input rather than manually broadcasting will avoid the relatively slow `DeviceArray` indexing path #2891 for that argument; this would help with #2871)

After this change, there are two ways to use pmap with replicated arguments that are also return values (e.g. neural network parameters in data-parallel training):
- most users should keep using `in_axes=0` (the default), leading to device persistent `ShardedDeviceArray`s that are sharded along their leading axis
- those of us who need the relevant XLA:TPU optimization can use `in_axes=None`, and manually adjust the `sharding_spec` of the returned `ShardedDeviceArray` to use `replication_factor` instead of leading-axis sharding (keeping this temporary/experimental/ugly code out of the core).

Later on, I also want to support `in_axes`>0 as well as `out_axes`. But there's a lot of implementation subtlety and choices related to `out_axes`, and I don't want to continue blocking things on that.

Once `out_axes=None` works, pmaps that use that will return replicated `ShardedDeviceArrays` with no leading replica axis, enabling the same kind of automatic device persistence behavior for `in_`/`out_axes=None` values that `in_`/`out_axes=0` values already have.