### PR TITLE
Explicitly broadcast values in nn.one_hot and nn.initializers.orthogonal.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -665,6 +665,10 @@ def broadcast_in_dim(operand: Array, shape: Shape,
       operand, shape=tuple(shape),
       broadcast_dimensions=tuple(broadcast_dimensions))
 
+def broadcast_to_rank(x: Array, rank: int) -> Array:
+  """Adds leading dimensions of ``1`` to give ``x`` rank ``rank``."""
+  return broadcast(x, (1,) * (rank - x.ndim))
+
 def reshape(operand: Array, new_sizes: Shape,
             dimensions: Optional[Sequence[int]] = None) -> Array:
   """Wraps XLA's `Reshape

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -264,8 +264,9 @@ def one_hot(x, num_classes, *, dtype=np.float64):
   """
   dtype = dtypes.canonicalize_dtype(dtype)
   x = np.asarray(x)
-  return np.array(x[..., np.newaxis] == np.arange(num_classes, dtype=x.dtype),
-                  dtype=dtype)
+  lhs = x[..., np.newaxis]
+  rhs = lax.broadcast_to_rank(np.arange(num_classes, dtype=x.dtype), lhs.ndim)
+  return np.array(lhs == rhs, dtype=dtype)
 
 def relu6(x):
   r"""Rectified Linear Unit 6 activation function.

--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -89,7 +89,8 @@ def orthogonal(scale=1.0, column_axis=-1, dtype=np.float32):
     matrix_shape = (n_cols, n_rows) if n_rows < n_cols else (n_rows, n_cols)
     A = random.normal(key, matrix_shape, dtype)
     Q, R = np.linalg.qr(A)
-    Q *= np.sign(np.diag(R)) # needed for a uniform distribution
+    diag_sign = lax.broadcast_to_rank(np.sign(np.diag(R)), rank=Q.ndim)
+    Q *= diag_sign # needed for a uniform distribution
     if n_rows < n_cols: Q = Q.T
     Q = np.reshape(Q, tuple(onp.delete(shape, column_axis)) + (shape[column_axis],))
     Q = np.moveaxis(Q, -1, column_axis)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -32,7 +32,16 @@ import jax.numpy as np
 from jax.config import config
 config.parse_flags_with_absl()
 
+
 class NNFunctionsTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    config.update("jax_numpy_rank_promotion", "raise")
+
+  def tearDown(self):
+    super().tearDown()
+    config.update("jax_numpy_rank_promotion", "warn")
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSoftplusGrad(self):
@@ -157,6 +166,14 @@ INITIALIZER_RECS = [
 ]
 
 class NNInitializersTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    config.update("jax_numpy_rank_promotion", "raise")
+
+  def tearDown(self):
+    super().tearDown()
+    config.update("jax_numpy_rank_promotion", "warn")
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":


### PR DESCRIPTION
At head the following fails:

```python
>>> import jax
>>> import jax.numpy as jnp
>>> jax.config.update('jax_numpy_rank_promotion', 'raise')
>>> jax.nn.one_hot(jnp.ones([8]), 512)
...
ValueError: Operands could not be broadcast together for equal on shapes (8, 1) (512,) and with the config option jax_numpy_rank_promotion='raise'. For more information, see https://jax.readthedocs.io/en/latest/rank_promotion_warning.html.
```