### PR TITLE
err on empty operand dimension in numpy argmin and argmax

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2865,7 +2865,7 @@ def nanargmin(a, axis=None):
 
 # TODO(mattjj): redo this lowering with a call to variadic lax.reduce
 def _argminmax(name, op, a, axis):
-  if size(a) == 0:
+  if a.shape[axis] == 0:
     raise ValueError("attempt to get {} of an empty sequence".format(name))
   shape = [1] * a.ndim
   shape[axis] = a.shape[axis]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -697,14 +697,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": rec.test_name.capitalize(),
-       "name": rec.name, "jnp_op": getattr(jnp, rec.name)}
+      {"testcase_name": rec.test_name.capitalize(), "name": rec.name,
+       "onp_op": getattr(onp, rec.name), "jnp_op": getattr(jnp, rec.name)}
       for rec in JAX_ARGMINMAX_RECORDS))
-  def testArgMinMaxEmpty(self, name, jnp_op):
+  def testArgMinMaxEmpty(self, name, onp_op, jnp_op):
     name = name[3:] if name.startswith("nan") else name
     msg = "attempt to get {} of an empty sequence".format(name)
     with self.assertRaises(ValueError, msg=msg):
       jnp_op(onp.array([]))
+    with self.assertRaises(ValueError, msg=msg):
+      jnp_op(onp.zeros((2, 0)), axis=1)
+    onp_fun = partial(onp_op, axis=0)
+    jnp_fun = partial(jnp_op, axis=0)
+    args_maker = lambda: [onp.zeros((2, 0))]
+    self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}_{}".format(


### PR DESCRIPTION
see #2899