### PR TITLE
Fixed a few more places where device commitment was lost.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -106,6 +106,11 @@ committed device, and the result will be committed on the
 same device. It is an error to invoke an operation on
 arguments that are committed to more than one device.
 
+You can also use :func:`jax.device_put` without a ``device`` parameter,
+in which case the data is left as is if already on a device (whether
+committed or not), or a Python value that is not on any device is
+placed uncommitted on the default device.
+
 Jitted functions behave as any other primitive operation
 (will follow the data and will error if invoked on data
 committed on more than one device).

--- a/jax/api.py
+++ b/jax/api.py
@@ -1539,16 +1539,22 @@ def make_jaxpr(fun: Callable,
   return jaxpr_maker
 
 
-def device_put(x, device=None):
+def device_put(x, device: Optional[xc.Device] = None):
   """Transfers ``x`` to ``device``.
 
   Args:
     ``x``: An array, scalar, or (nested) standard Python container thereof.
-    ``device``: The ``Device`` to transfer ``x`` to.
+    ``device``: The (optional) ``Device`` to transfer ``x`` to.
+      If given, then the result is committed to the device.
+
+  If the ``device`` parameter is ``None``, then this operation behaves like the
+  identity function if the operand is on any device already, otherwise it
+  transfers the data to the default device, uncommitted.
+
+  For more details on data placement see the https://jax.readthedocs.io/en/latest/faq.html#controlling-data-and-computation-placement-on-devices.
 
   Returns:
-    A copy of ``x`` that resides on ``device``. If ``x`` is already on
-    ``device``, returns ``x``.
+    A copy of ``x`` that resides on ``device``.
   """
   return tree_map(lambda y: xla.device_put_p.bind(y, device=device), x)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2043,7 +2043,7 @@ class LazyTest(jtu.JaxTestCase):
       x = np.ones(3) + np.zeros(3)
       y = np.ones(3) + np.ones(3)
 
-    self.assertEqual(count[0], 1)
+    self.assertEqual(1, count[0])
     self.assertAllClose(x, onp.ones(3), check_dtypes=False)
     self.assertAllClose(y, onp.ones(3) + onp.ones(3), check_dtypes=False)
 


### PR DESCRIPTION
* trivial jit computations were forcing commitment to the default device
* a device_put with a device specification would not set the commitment
  if the data was already (uncommitted) on the specified device.
* added tests for the above
* once the above were fixed the LaztTest.test_zeros_ones_compilation
  stated to fail because the `sticky` parameter to lazy_force_computation
  was changing. Fixed this by removing stickyness from the compilation key.
* Expanded docstring for jax.device_put; expanded the
  device placement FAQ entry.


Follow-up to #2882