### PR TITLE
Fix test flakiness in autodiff tests for min/max type functions

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2328,7 +2328,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           (0, lax.add, inexact_dtypes, jtu.rand_default),
           (-onp.inf, lax.max, grad_inexact_dtypes, jtu.rand_unique_int),
           (onp.inf, lax.min, grad_inexact_dtypes, jtu.rand_unique_int),
-          (1, lax.mul, grad_inexact_dtypes, partial(jtu.rand_default, scale=1)),
+          (1, lax.mul, grad_float_dtypes, partial(jtu.rand_default, scale=1)),
       ]
       for dtype in dtypes
       for shape, dims in [


### PR DESCRIPTION
We change tests to avoid computing numerical gradients in the neighborhood of nondifferentiable points where, for example, the maximum element in a reduce-max changes. The autodiff approximation is only valid within an epsilon ball around a point, and close to an inflection point the approximation may not be valid.