### PR TITLE
Instantiate zeros in jet.

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -22,7 +22,7 @@ from jax import core
 from jax.util import unzip2
 from jax import ad_util
 from jax.tree_util import (register_pytree_node, tree_structure,
-                           treedef_is_leaf, tree_flatten, tree_unflatten)
+                           treedef_is_leaf, tree_flatten, tree_unflatten, tree_map)
 import jax.linear_util as lu
 from jax.interpreters import xla
 from jax.lax import lax
@@ -59,6 +59,8 @@ def jet_fun(primals, series):
   with core.new_master(JetTrace) as master:
     out_primals, out_terms = yield (master, primals, series), {}
     del master
+  out_terms = [tree_map(lambda x: onp.zeros_like(x, dtype=onp.result_type(out_primals[0])), series[0])
+               if s is zero_series else s for s in out_terms]
   yield out_primals, out_terms
 
 @lu.transformation

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -61,10 +61,6 @@ class JetTest(jtu.JaxTestCase):
     self.assertAllClose(y, expected_y, atol=atol, rtol=rtol,
                         check_dtypes=check_dtypes)
 
-    # TODO(duvenaud): Lower zero_series to actual zeros automatically.
-    if terms == zero_series:
-      terms = tree_map(np.zeros_like, expected_terms)
-
     self.assertAllClose(terms, expected_terms, atol=atol, rtol=rtol,
                         check_dtypes=check_dtypes)
 
@@ -85,10 +81,6 @@ class JetTest(jtu.JaxTestCase):
 
     self.assertAllClose(y, expected_y, atol=atol, rtol=rtol,
                         check_dtypes=check_dtypes)
-
-    # TODO(duvenaud): Lower zero_series to actual zeros automatically.
-    if terms == zero_series:
-      terms = tree_map(np.zeros_like, expected_terms)
 
     self.assertAllClose(terms, expected_terms, atol=atol, rtol=rtol,
                         check_dtypes=check_dtypes)
@@ -290,6 +282,21 @@ class JetTest(jtu.JaxTestCase):
     terms_y = [rng.randn(*y.shape) for _ in range(order)]
     series_in = (terms_b, terms_x, terms_y)
     self.check_jet(np.where, primals, series_in)
+
+  def test_inst_zero(self):
+    def f(x):
+      return 2.
+    def g(x):
+      return 2. + 0 * x
+    x = np.ones(1)
+    order = 3
+    f_out_primals, f_out_series = jet(f, (x, ), ([np.ones_like(x) for _ in range(order)], ))
+    assert f_out_series is not zero_series
+
+    g_out_primals, g_out_series = jet(g, (x, ), ([np.ones_like(x) for _ in range(order)], ))
+
+    assert g_out_primals == f_out_primals
+    assert g_out_series == f_out_series
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #2923 .

Edit: We might not always want to instantiate these zeros. For example, if we're tracing `jet` through control flow (basing this off of the `instantiate` flag of `jvp` which appears to be turned off for creation of `cond`, `while`, and `scan` `jvp` rules). Leaving this for now as those `jet` rules hasn't been implemented yet and perhaps there are different approaches.

Edit 2: Oh, I think this addresses @duvenaud's TODO in `jet_test.py` cc @mattjj @jessebett I think there was some previous discussion about this issue, maybe with regards to efficiency when composing with `odeint` and `grad`?