### PR TITLE
Deprecate random.shuffle() and implement random.permutation() for multi-dim inputs

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -23,6 +23,7 @@ https://github.com/google/jax/blob/master/design_notes/prng.md
 
 from functools import partial
 from typing import Optional, Sequence, Union
+import warnings
 
 import numpy as onp
 
@@ -431,12 +432,18 @@ def shuffle(key: np.ndarray, x: np.ndarray, axis: int = 0) -> np.ndarray:
   Returns:
     A shuffled version of x.
   """
+  msg = ("jax.random.shuffle is deprecated and will be removed in a future release. "
+         "Use jax.random.permutation")
+  warnings.warn(msg, FutureWarning)
   return _shuffle(key, x, axis)
 
 
 def permutation(key, x):
   """
   Permute elements of an array along its first axis or return a permuted range.
+
+  If `x` is a multi-dimensional array, it is only shuffled along its
+  first index.
 
   Args:n
     key: a PRNGKey used as the random key.
@@ -454,9 +461,8 @@ def permutation(key, x):
   elif onp.ndim(x) == 1:
     return _shuffle(key, x, 0)
   else:
-    msg = ("permutation for >1d inputs x not yet implemented, see "
-           "https://github.com/google/jax/issues/2066 for updates.")
-    raise NotImplementedError(msg)
+    ind = _shuffle(key, np.arange(x.shape[0]), 0)
+    return x[ind]
 
 
 @partial(jit, static_argnums=(2,))


### PR DESCRIPTION
Addresses #2066. 

Motivation for deprecating `shuffle`:

- the numpy implementation shuffles in-place, which JAX cannot emulate
- numpy's ``permutation`` provides all the functionality of ``shuffle``, but returns a copy rather than shuffling in-place.

Once a few releases have passed, we should make shuffle() raise a NotImplementedError that points to permutation as a viable replacement.