### PR TITLE
Update XLA.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "e96c727cca782ddbcff9b0cabba0d80852ab87c4e7b1672068a81b4f504b0809",
-    strip_prefix = "tensorflow-d9ef9c47200625165ad38338b2468e9c4c629b3a",
+    sha256 = "996a31e99e802232aa49ed5add9e2be8a83d31e633180c436806ae325993bc8d",
+    strip_prefix = "tensorflow-25b0e7d995050c85a56d787a6aac4e1a7423902e",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/d9ef9c47200625165ad38338b2468e9c4c629b3a.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/25b0e7d995050c85a56d787a6aac4e1a7423902e.tar.gz",
     ],
 )
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -18,6 +18,8 @@ jaxlib 0.1.46 (unreleased)
 ------------------------------
 
 * Fixes crash for linear algebra functions on Mac OS X (#432).
+* Fixes an illegal instruction crash caused by using AVX512 instructions when
+  an operating system or hypervisor disabled them (#2906).
 
 jax 0.1.65 (April 30, 2020)
 ---------------------------


### PR DESCRIPTION
Mention illegal instruction fix in changelog.

Fixes linear algebra crashes due to too small a thread stack size on Linux.