### PR TITLE
Expose functools.reduce initializer argument to tree_util.tree_reduce

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -231,12 +231,12 @@ def _replace_nones(sentinel, tree):
     else:
       return tree
 
-def tree_reduce(function, tree, *initializer):
-  if initializer:  # We need to differentiate between initializer explicitly passed or not.
-    initializer, = initializer
-    return functools.reduce(function, tree_leaves(tree), initializer)
+no_initializer = object()
+def tree_reduce(function, tree, initializer=no_initializer):
+  if initializer is no_initializer:
+    return functools.reduce(function, jax.tree_leaves(tree))
   else:
-    return functools.reduce(function, tree_leaves(tree))
+    return functools.reduce(function, jax.tree_leaves(tree), initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -231,13 +231,12 @@ def _replace_nones(sentinel, tree):
     else:
       return tree
 
-def tree_reduce(*args):
-  if len(args) == 2:
-    f, tree = args
-    return functools.reduce(f, tree_leaves(tree))
+def tree_reduce(function, tree, *initializer):
+  if initializer:  # We need to differentiate between initializer explicitly passed or not.
+    initializer, = initializer
+    return functools.reduce(function, jax.tree_leaves(tree), initializer)
   else:
-    f, tree, initializer = args
-    return functools.reduce(f, tree_leaves(tree), initializer)
+    return functools.reduce(function, jax.tree_leaves(tree))
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -231,10 +231,13 @@ def _replace_nones(sentinel, tree):
     else:
       return tree
 
-def tree_reduce(f, tree, initializer=None):
-  if initializer is not None:
-    return functools.reduce(f, tree_leaves(tree), initializer)
-  return functools.reduce(f, tree_leaves(tree))
+def tree_reduce(*args):
+  if len(args) == 2:
+    f, seq = args
+    return reduce(f, tree_leaves(seq))
+  else:
+    f, seq, initializer = args
+    return reduce(f, seq, initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -234,9 +234,9 @@ def _replace_nones(sentinel, tree):
 no_initializer = object()
 def tree_reduce(function, tree, initializer=no_initializer):
   if initializer is no_initializer:
-    return functools.reduce(function, jax.tree_leaves(tree))
+    return functools.reduce(function, tree_leaves(tree))
   else:
-    return functools.reduce(function, jax.tree_leaves(tree), initializer)
+    return functools.reduce(function, tree_leaves(tree), initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -233,11 +233,11 @@ def _replace_nones(sentinel, tree):
 
 def tree_reduce(*args):
   if len(args) == 2:
-    f, seq = args
-    return reduce(f, tree_leaves(seq))
+    f, tree = args
+    return reduce(f, tree_leaves(tree))
   else:
-    f, seq, initializer = args
-    return reduce(f, seq, initializer)
+    f, tree, initializer = args
+    return reduce(f, tree_leaves(tree), initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -234,9 +234,9 @@ def _replace_nones(sentinel, tree):
 def tree_reduce(function, tree, *initializer):
   if initializer:  # We need to differentiate between initializer explicitly passed or not.
     initializer, = initializer
-    return functools.reduce(function, jax.tree_leaves(tree), initializer)
+    return functools.reduce(function, tree_leaves(tree), initializer)
   else:
-    return functools.reduce(function, jax.tree_leaves(tree))
+    return functools.reduce(function, tree_leaves(tree))
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -234,10 +234,10 @@ def _replace_nones(sentinel, tree):
 def tree_reduce(*args):
   if len(args) == 2:
     f, tree = args
-    return reduce(f, tree_leaves(tree))
+    return functools.reduce(f, tree_leaves(tree))
   else:
     f, tree, initializer = args
-    return reduce(f, tree_leaves(tree), initializer)
+    return functools.reduce(f, tree_leaves(tree), initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -232,7 +232,9 @@ def _replace_nones(sentinel, tree):
       return tree
 
 def tree_reduce(f, tree, initializer=None):
-  return functools.reduce(f, tree_leaves(tree), initializer)
+  if initializer is not None:
+    return functools.reduce(f, tree_leaves(tree), initializer)
+  return functools.reduce(f, tree_leaves(tree))
 
 def tree_all(tree):
   return all(tree_leaves(tree))

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -231,8 +231,8 @@ def _replace_nones(sentinel, tree):
     else:
       return tree
 
-def tree_reduce(f, tree):
-  return functools.reduce(f, tree_leaves(tree))
+def tree_reduce(f, tree, initializer=None):
+  return functools.reduce(f, tree_leaves(tree), initializer)
 
 def tree_all(tree):
   return all(tree_leaves(tree))


### PR DESCRIPTION
`functools.reduce` takes an optional `initializer` argument (default=None) which is currently not exposed by `tree_reduce'. This can be useful e.g. for computing an L2 penalty, where you would initialize with 0., and then sum the L2 for each parameter.

Example:
```
def l2_sum(total, param):
  return total + jnp.sum(param**2)

tree_reduce(l2_sum, params, 0.)
```