### PR TITLE
Add support for buffer donation in `jit` and `pmap`.

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -430,6 +430,7 @@ computation should run. For example
                                      e = add a d
                                  in (e,) }
                     device=None
+                    donated_invars=(False, False, False)
                     name=inner ] b a c
       e = add a d
   in (e,) }
@@ -474,6 +475,7 @@ example
                                      g = div e f
                                  in (g,) }
                     devices=None
+                    donated_invars=(False, False, False)
                     global_axis_size=None
                     mapped_invars=(True, False, True)
                     name=inner ] c b a

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -14,10 +14,13 @@
 
 
 from .tree_util import (build_tree, tree_flatten, tree_unflatten,
-                        treedef_is_leaf, tree_multimap, _replace_nones)
+                        treedef_is_leaf, tree_multimap, _replace_nones,
+                        tree_structure)
 from . import linear_util as lu
 from .util import safe_map, unzip2, partial, curry, WrapHashably, Hashable
 from .core import unit
+
+from typing import Tuple
 
 map = safe_map
 
@@ -81,6 +84,49 @@ def argnums_partial(f, dyn_argnums, args):
                       for i, arg in enumerate(args)])
   dyn_args = tuple(args[i] for i in dyn_argnums)
   return _argnums_partial(f, dyn_argnums, fixed_args), dyn_args
+
+def donation_vector(donate_argnums, args, kwargs) -> Tuple[bool, ...]:
+  """Returns a tuple with a boolean value for each leaf in args."""
+  res = []
+  for i, arg in enumerate(args):
+    donate = bool(i in donate_argnums)
+    res.extend((donate,) * tree_structure(arg).num_leaves)
+  res.extend((False,) * tree_structure(kwargs).num_leaves)
+  return tuple(res)
+
+def rebase_donate_argnums(donate_argnums, static_argnums) -> Tuple[int, ...]:
+  """Shifts donate to account for static.
+
+  >>> rebase_donate_argnums((3, 4), (0, 1))
+  (1, 2)
+
+  Args:
+    donate_argnums: An iterable of ints.
+    static_argnums: An iterable of ints.
+
+  Returns:
+    A tuple of unique, sorted integer values based on donate_argnums with each
+    element offset to account for static_argnums.
+  """
+  if not (static_argnums or donate_argnums):
+    return tuple(sorted(donate_argnums))
+
+  static_argnums = sorted(set(static_argnums))
+  donate_argnums = sorted(set(donate_argnums))
+  i = j = o = 0
+  out = []
+  while j < len(donate_argnums):
+    if i < len(static_argnums) and static_argnums[i] == donate_argnums[j]:
+      raise ValueError(f"`static_argnums` {static_argnums} and "
+                       f"`donate_argnums` {donate_argnums} cannot intersect.")
+
+    if i < len(static_argnums) and static_argnums[i] < donate_argnums[j]:
+      o += 1
+      i += 1
+    else:
+      out.append(donate_argnums[j] - o)
+      j += 1
+  return tuple(out)
 
 def wrap_hashably(arg):
   try:

--- a/jax/core.py
+++ b/jax/core.py
@@ -1203,6 +1203,9 @@ def type_transfer(prim, invars, params):
       if "mapped_invars" not in params:
         raise TypeError(
             f"Map primitive {prim} missing 'mapped_invars' parameter")
+      if "donated_invars" not in params:
+        raise TypeError(
+            f"Map primitive {prim} missing 'donated_invars' parameter")
 
     call_jaxpr = params["call_jaxpr"]
     if len(invars) != len(call_jaxpr.invars):

--- a/tests/api_util_test.py
+++ b/tests/api_util_test.py
@@ -1,0 +1,71 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for jax.api_util."""
+
+import itertools as it
+from absl.testing import absltest
+from absl.testing import parameterized
+from jax import api_util
+from jax import numpy as jnp
+from jax import test_util as jtu
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+class ApiUtilTest(jtu.JaxTestCase):
+
+  def test_donation_vector(self):
+    params = {"a": jnp.ones([]), "b": jnp.ones([])}
+    state = {"c": jnp.ones([]), "d": jnp.ones([])}
+    x = jnp.ones([])
+    args = params, state, x
+
+    for size in range(4):
+      for donate_argnums in it.permutations((0, 1, 2), size):
+        for kwargs in ({}, {"a": x}):
+          expected = ()
+          expected += (True, True) if 0 in donate_argnums else (False, False)
+          expected += (True, True) if 1 in donate_argnums else (False, False)
+          expected += (True,) if 2 in donate_argnums else (False,)
+          if kwargs:
+            expected += (False,)
+          self.assertEqual(
+              expected, api_util.donation_vector(donate_argnums, args, kwargs))
+
+  @parameterized.parameters(
+      ((0,), (0,)),
+      ((0, 1), (1, 2)),
+      ((0, 1, 2), (0, 1, 2)),
+  )
+  def test_rebase_donate_argnums_rejects_overlapping(self, donate, static):
+    with self.assertRaisesRegex(ValueError, "cannot intersect"):
+      api_util.rebase_donate_argnums(donate, static)
+
+  @parameterized.parameters(
+      ((), (), ()),
+      ((), (1, 2, 3), ()),
+      ((0,), (2, 3), (0,)),
+      ((0, 1), (2, 3), (0, 1)),
+      ((2, 3), (0, 1), (0, 1)),
+      ((3, 2), (1, 0), (0, 1)),
+      ((3,), (0, 1), (1,)),
+      ((3, 3, 3,), (0, 1), (1,)),
+  )
+  def test_rebase_donate_argnums(self, donate, static, expected):
+    self.assertEqual(expected,
+                     api_util.rebase_donate_argnums(donate, static))
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -252,6 +252,7 @@ what: here
                                                    ] 42 a
                                  in (c,) }
                     device=None
+                    donated_invars=(False,)
                     name=func ] a
   in (b,) }""", str(api.make_jaxpr(api.jit(func))(5)))
     self.assertEqual("", testing_stream.output)


### PR DESCRIPTION
For a computation of the form:

    >>> f = lambda x: x ** 2
    >>> f = jax.jit(f)
    >>> while run:
    ...   x = f(x)

JAX must currently always have two copies of `x` in device memory since there
is no reliable way in Python to determine whether there will be future uses of
`x`. This causes two classes of problem:

  1. Users at the limit of available device are constrained by the additional
     copy of their parameters and other state while they typically only require
     one copy. This typically frees 100M+ of device memory and is a critical
     optimization for larger models to match state of the art performance in
     other frameworks.

  2. This constant alloc/free of the input/output buffers can cause memory
     fragmentation on some platforms (although having a reusing allocator and
     limiting run-ahead may be a better solution for this problem).

We propose fixing this by using input/output aliasing as supported by XLA. We
will support this in JAX by allowing certain arguments of jit/pmap decorated
functions to be donated and reused as outputs:

    >>> f = lambda x: x ** 2
    >>> f = jit(f, donate_argnums=0)
    >>> while run:
    ...   x = f(x)

JAX will determine that the donated input `x` can alias with the output of the
function and it will instruct XLA it _must_ write the result to this buffer.

If a user tries to reuse a buffer after it has been donated they get an error
that the buffer is invalid:

    >>> y = f(x)
    >>> jax.device_get(x)
    ...
    RuntimeError: Invalid argument: CopyToHostAsync() called on invalid buffer.

The semantics of `donate_argnums` follows that of `static_argnums`, namely that
it identifies positional arguments to the computation that are to be donated
to the computation and used as part of the output.

One feature that is also enabled by this is invalidating buffers that should
only be used once, for example PRNGKeys:

    >>> @partial(jit, donate_argnums=0)
    ... def move(x):
    ...   # Do something complex enough for JAX to just optimize it away.
    ...   return tree_map(lambda x: x + x - x, x)

    >>> def safe_eager_uniform(key, *a, **k):
    ...   assert hasattr(key, 'device_buffer'), "random must run eagerly"
    ...   key = move(key)
    ...   return jax.random.uniform(key, *a, **k)

This is not a complete answer to random safety since it is still possible to
reuse a key as part of a traced computation, however it can be used to support
this feature (somewhat inefficiently) in eager mode.