### PR TITLE
Add implementation of np.searchsorted

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -223,6 +223,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     rot90
     round
     row_stack
+    searchsorted
     select
     sign
     signbit

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -29,6 +29,7 @@ import builtins
 import collections
 from collections.abc import Sequence
 import itertools
+import operator
 import os
 import re
 import string
@@ -39,7 +40,7 @@ import warnings
 import numpy as onp
 import opt_einsum
 
-from jax import jit, device_put, custom_jvp
+from jax import jit, device_put, custom_jvp, vmap
 from ._util import _wraps
 from .. import core
 from .. import dtypes
@@ -3751,6 +3752,39 @@ def _quantile(a, q, axis, interpolation, keepdims):
     raise ValueError(f"interpolation={interpolation!r} not recognized")
 
   return lax.convert_element_type(result, a.dtype)
+
+
+@partial(jit, static_argnums=2)
+@partial(vmap, in_axes=(None, 0, None))
+def _searchsorted(a, v, side):
+  op = operator.le if side == 'left' else operator.lt
+
+  def cond_fun(state):
+    start, stop = state
+    return stop - start > 1
+
+  def body_fun(state):
+    start, stop = state
+    mid = (start + stop) // 2
+    return where(op(v, a[mid]), (start, mid), (mid, stop))
+
+  result = lax.while_loop(cond_fun, body_fun, array([0, a.shape[0]]))
+  return where(op(v, a[0]), 0, result[1])
+
+
+@_wraps(onp.searchsorted)
+def searchsorted(a, v, side='left', sorter=None):
+  assert side in ['left', 'right']
+  if sorter is not None:
+    raise NotImplementedError("sorter is not implemented")
+  a = asarray(a)
+  v = asarray(v)
+  if ndim(a) != 1:
+    raise ValueError("a should be 1-dimensional")
+  if size(a) == 0:
+    return zeros_like(v, dtype=int)
+  indices = _searchsorted(a, ravel(v), side)
+  return indices.reshape(v.shape)
 
 
 @_wraps(onp.percentile)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1424,7 +1424,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for rng_factory in [jtu.rand_default]
   ))
   def testSearchsorted(self, ashape, vshape, side, dtype, rng_factory):
-    rng = rng_factory()
+    rng = rng_factory(self.rng())
     args_maker = lambda: [jnp.sort(rng(ashape, dtype)), rng(vshape, dtype)]
     onp_fun = lambda a, v: onp.searchsorted(a, v, side=side)
     jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1412,6 +1412,26 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": "_a={}_v={}_side={}".format(
+      jtu.format_shape_dtype_string(ashape, dtype),
+      jtu.format_shape_dtype_string(vshape, dtype),
+      side), "ashape": ashape, "vshape": vshape, "side": side,
+     "dtype": dtype, "rng_factory": rng_factory}
+    for ashape in [(20,)]
+    for vshape in [(), (5,), (5, 5)]
+    for side in ['left', 'right']
+    for dtype in default_dtypes
+    for rng_factory in [jtu.rand_default]
+  ))
+  def testSearchsorted(self, ashape, vshape, side, dtype, rng_factory):
+    rng = rng_factory()
+    args_maker = lambda: [jnp.sort(rng(ashape, dtype)), rng(vshape, dtype)]
+    onp_fun = lambda a, v: onp.searchsorted(a, v, side=side)
+    jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side)
+    self._CheckAgainstNumpy(onp_fun, jnp_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), axis),
        "shape": shape, "axis": axis, "dtypes": dtypes, "rng_factory": rng_factory}


### PR DESCRIPTION
This is an implementation of np.searchsorted using ``lax_control_flow`` constructs.

Performance-wise, it's comparable to numpy on CPU for large inputs, with ~ms scale overhead dominating for smaller inputs. On GPU the crossover point is smaller

Here's the benchmark script I used:
```python
import jax.numpy as jnp
import numpy as onp
import pandas as pd
import altair as alt
import timeit

Nrange = (10 ** onp.linspace(1, 8, 20)).astype(int)
M = 10000

onp_times = []
jnp_times = []

def autotime(code, globals, repeat=3):
    timer = timeit.Timer(code, globals=globals)
    N, t = timer.autorange()
    return min([t / N] + [timer.timeit(N) for i in range(repeat - 1)])

data = jnp.arange(Nrange[-1])


for N in Nrange:
  x = data[:N]
  val = jnp.linspace(0, N, M).astype('int32')

  result1 = searchsorted(x, val)
  result2 = onp.searchsorted(onp.array(x), onp.array(val))
  assert onp.allclose(result1, result2), f"Failed for {N}"

  code = "searchsorted(x, val)"
  jnp_globals = {'searchsorted': jnp.searchsorted, 'x': x, 'val': val}
  onp_globals = {'searchsorted': onp.searchsorted, 'x': onp.array(x), 'val': onp.array(val)}

  jnp_times.append(autotime(code + ".block_until_ready()", jnp_globals))
  onp_times.append(autotime(code, onp_globals))

df = pd.DataFrame({
    'N': Nrange,
    'numpy': onp_times,
    'jax': jnp_times
})

alt.Chart(df).transform_fold(
    ['numpy', 'jax']
).mark_line().encode(
    x=alt.X('N:Q', scale=alt.Scale(type='log'), title='Length of array'),
    y=alt.Y('value:Q', scale=alt.Scale(type='log'), title='Time'),
    color='key:N'
)
```
Here is the result on a Colab CPU runtime:
![visualization - 2020-05-04T070717 147](https://user-images.githubusercontent.com/781659/80974697-ef444280-8dd5-11ea-9ac5-2806ad1a8909.png)
and a GPU runtime (P4):
![visualization - 2020-05-04T070722 612](https://user-images.githubusercontent.com/781659/80974705-f1a69c80-8dd5-11ea-9464-e3f6efa97578.png)
and a TPU runtime:
![visualization (2)](https://user-images.githubusercontent.com/781659/81235659-5a497100-8fb0-11ea-8e2e-84bfd8849395.png)
As you can see, it has the expected log(N) scaling, but has higher overhead at low-N, and is about an order of magnitude slower than numpy. I suspect there is room for improvement on performance, but I think this is useful as an initial implementation.

Also, TPU is currently ~5x slower than numpy even at the very large N end, which is probably to be expected with the iterative approach used here.