### PR TITLE
DOC: add a table of contents for top level API docs

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -23,15 +23,61 @@ Subpackages
 Just-in-time compilation (:code:`jit`)
 --------------------------------------
 
+.. autosummary::
+
+    jit
+    disable_jit
+    xla_computation
+    make_jaxpr
+    eval_shape
+    device_put
+
+Automatic differentiation
+-------------------------
+
+.. autosummary::
+
+    grad
+    value_and_grad
+    jacfwd
+    jacrev
+    hessian
+    jvp
+    linearize
+    vjp
+    custom_jvp
+    custom_vjp
+
+
+Vectorization (:code:`vmap`)
+----------------------------
+
+.. autosummary::
+
+    vmap
+    jax.numpy.vectorize
+
+Parallelization (:code:`pmap`)
+------------------------------
+
+.. autosummary::
+
+    pmap
+    devices
+    local_devices
+    host_id
+    host_ids
+    device_count
+    local_device_count
+    host_count
+
+
 .. autofunction:: jit
 .. autofunction:: disable_jit
 .. autofunction:: xla_computation
 .. autofunction:: make_jaxpr
 .. autofunction:: eval_shape
 .. autofunction:: device_put
-
-Automatic differentiation
--------------------------
 
 .. autofunction:: grad
 .. autofunction:: value_and_grad
@@ -44,15 +90,8 @@ Automatic differentiation
 .. autofunction:: custom_jvp
 .. autofunction:: custom_vjp
 
-
-Vectorization (:code:`vmap`)
-----------------------------
-
 .. autofunction:: vmap
 .. autofunction:: jax.numpy.vectorize
-
-Parallelization (:code:`pmap`)
-------------------------------
 
 .. autofunction:: pmap
 .. autofunction:: devices


### PR DESCRIPTION
This makes them easier to scan. The links in the table of contents link to the entries lower in the page, so it's still possible to read them all the docstrings sequentially if desired.

# Before

![image](https://user-images.githubusercontent.com/1217238/80942137-e4b78800-8d98-11ea-9cde-715c7c426b85.png)

# After

![image](https://user-images.githubusercontent.com/1217238/80942155-eda85980-8d98-11ea-96f0-4988ff1b24f9.png)
![image](https://user-images.githubusercontent.com/1217238/80942171-fa2cb200-8d98-11ea-9710-2048a5ce9dcd.png)
