### PR TITLE
Fix a number of flaky tests.

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -637,10 +637,10 @@ def rand_int(low, high=None):
     return randint(low, high=high, size=shape, dtype=dtype)
   return fn
 
-def rand_unique_int():
+def rand_unique_int(high=None):
   randchoice = npr.RandomState(0).choice
   def fn(shape, dtype):
-    return randchoice(onp.arange(onp.prod(shape), dtype=dtype),
+    return randchoice(onp.arange(high or onp.prod(shape), dtype=dtype),
                       size=shape, replace=False)
   return fn
 

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -75,7 +75,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
       for dtype in float_types + complex_types
       for rng_factory in [jtu.rand_default]
       for rng_factory in [jtu.rand_default]
-      for preconditioner in [None, 'random', 'identity', 'exact']))
+      for preconditioner in [None, 'identity', 'exact']))
+  # TODO(#2951): reenable 'random' preconditioner.
   def test_cg_against_scipy(self, shape, dtype, rng_factory, preconditioner):
 
     rng = rng_factory()
@@ -99,7 +100,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
         partial(lax_cg, M=M, maxiter=1),
         args_maker,
         check_dtypes=True,
-        tol=3e-5)
+        tol=2e-4)
 
     # TODO(shoyer,mattjj): I had to loosen the tolerance for complex64[7,7]
     # with preconditioner=random
@@ -115,7 +116,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
         partial(lax_cg, M=M, atol=1e-6),
         args_maker,
         check_dtypes=True,
-        tol=2e-4)
+        tol=1e-3)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -183,7 +183,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(onp.linalg.tensorsolve, 
                             np.linalg.tensorsolve, args_maker,
-                            check_dtypes=True, tol=1e-3)
+                            check_dtypes=True,
+                            tol={onp.float32: 1e-2, onp.float64: 1e-3})
     self._CompileAndCheck(np.linalg.tensorsolve, 
                           args_maker, check_dtypes=True,
                           rtol={onp.float64: 1e-13})
@@ -528,7 +529,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
               norm(a - onp.matmul(out[1][..., None, :] * out[0][..., :, :k], out[2])) < 350))
       else:
         self.assertTrue(onp.all(
-          norm(a - onp.matmul(out[1][..., None, :] * out[0], out[2])) < 300))
+          norm(a - onp.matmul(out[1][..., None, :] * out[0], out[2])) < 350))
 
       # Check the unitary properties of the singular vector matrices.
       self.assertTrue(onp.all(norm(onp.eye(out[0].shape[-1]) - onp.matmul(onp.conj(T(out[0])), out[0])) < 10))
@@ -754,7 +755,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             check_dtypes=True, tol=1e-2)
     self._CompileAndCheck(np.linalg.pinv, args_maker, check_dtypes=True)
     # TODO(phawkins): 1e-1 seems like a very loose tolerance.
-    jtu.check_grads(np.linalg.pinv, args_maker(), 2, rtol=1e-1)
+    jtu.check_grads(np.linalg.pinv, args_maker(), 2, rtol=1e-1, atol=2e-1)
 
   @jtu.skip_on_devices("tpu")  # SVD is not implemented on the TPU backend
   def testPinvGradIssue2792(self):

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -64,7 +64,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
                             tol=1e-3)
-    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(lax_fun, args_maker, check_dtypes=True,
+                          rtol={onp.float64: 1e-14})
 
   @genNamedParametersNArgs(3, jtu.rand_default)
   def testPoissonPmf(self, rng_factory, shapes, dtypes):


### PR DESCRIPTION
* relax some test tolerances.
* disable 'random' preconditioner in CG test (#2951).
* ensure that scatter and top-k tests don't create ties.