### PR TITLE
New and improved _shard_device_array function.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -48,7 +48,8 @@ from ..interpreters.xla import DeviceArray
 from ..interpreters.masking import Poly
 from .. import lax
 from .. import ops
-from ..util import partial, get_module_functions, unzip2, prod as _prod, subvals
+from ..util import (partial, get_module_functions, unzip2, prod as _prod,
+                    subvals, safe_zip)
 from ..lib import pytree
 from ..lib import xla_client
 
@@ -390,7 +391,7 @@ def fmax(x1, x2):
   return where((x1 > x2) | isnan(x2), x1, x2)
 
 @_wraps(onp.finfo)
-def finfo(dtype): 
+def finfo(dtype):
   return dtypes.finfo(dtype)
 
 @_wraps(onp.issubdtype)
@@ -724,7 +725,7 @@ def _conv(x, y, mode, op, precision):
   if ndim(x) != 1 or ndim(y) != 1:
     raise ValueError(f"{op}() only support 1-dimensional inputs.")
   x, y = _promote_dtypes_inexact(x, y)
-  
+
   out_order = slice(None)
   if len(x) < len(y):
     x, y = y, x
@@ -3986,12 +3987,24 @@ setattr(DeviceArray, "broadcast", lax.broadcast)
 setattr(DeviceArray, "broadcast_in_dim", lax.broadcast_in_dim)
 setattr(DeviceArray, "split", split)
 
-@jit
-def _unstack(x):
-  if x.ndim == 0:
-    raise ValueError("Argument to _unstack must be non-scalar")
-  return [lax.index_in_dim(x, i, keepdims=False) for i in range(x.shape[0])]
-setattr(DeviceArray, "_unstack", _unstack)
+@partial(jit, static_argnums=(1,2,3))
+def _multi_slice(arr: DeviceArray,
+                 start_indices: Tuple[Tuple[int, ...]],
+                 limit_indices: Tuple[Tuple[int, ...]],
+                 removed_dims: Tuple[Tuple[int, ...]]):
+  """Extracts multiple slices from `arr`.
+
+  This is used to shard DeviceArray arguments to pmap. It's implemented as a
+  DeviceArray method here to avoid circular imports.
+  """
+  results = []
+  for starts, limits, removed in safe_zip(start_indices, limit_indices, removed_dims):
+    sliced = lax.slice(arr, starts, limits)
+    if removed_dims:
+      sliced = sliced.reshape(onp.delete(arr.shape, removed_dims))
+    results.append(sliced)
+  return results
+setattr(DeviceArray, "_multi_slice", _multi_slice)
 
 
 # Syntactic sugar for scatter operations.


### PR DESCRIPTION
This gets the performance of sharding DeviceArray arguments to pmap roughly back to what it was prior to https://github.com/google/jax/commit/07571ae4dd3fceee580aa49c4490f99ce7f6b6de. It does so by re-introducing a _shard_device_array function that can handle arbitrary array slices.

Benchmark results compared to https://github.com/google/jax/commit/87d959089f3406714c98e674c145b09156319ef3 (i.e. just prior to the regression):
```
---------Benchmark summary for pmap_shard_device_array---------
  nargs    nshards       mean      %std    relative    mean/baseline
-------  ---------  ---------  --------  ----------  ---------------
     10          8  0.0479975  12.0865      1                1.09631
    100          8  0.32916     5.7446      6.85786          1.10263
    500          8  1.5563      2.68041    32.4246           1.10066
    100          2  0.136431    8.33826     2.84245          1.15886
    100          4  0.198815    5.91716     4.1422           1.11409
    100          8  0.31788     4.80559     6.62285          1.06637
```

This still seems a bit slower than it was before, but gets most of the performance back. We can further optimize in future changes if needed.

Fixes https://github.com/google/jax/pull/2958 (hopefully)