### PR TITLE
Add jnp.unravel_index

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1163,11 +1163,11 @@ def unravel_index(flat_index, shape):
   flat_index = asarray(flat_index)
   sizes = pad(shape, (0, 1), constant_values=1)
   cumulative_sizes = cumprod(sizes[::-1])[::-1]
-  # Add enough trailing dims to avoid conflict with flat_index
-  cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * flat_index.ndim)
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior
   clipped_index = clip(flat_index, -total_size, total_size - 1)
+  # Add enough trailing dims to avoid conflict with flat_index
+  cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * flat_index.ndim)
   idx = clipped_index % cumulative_sizes[:-1] // cumulative_sizes[1:]
   return tuple(idx)
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1159,16 +1159,16 @@ and out-of-bounds indices are clipped.
 """
 
 @_wraps(onp.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
-def unravel_index(flat_index, shape):
-  flat_index = asarray(flat_index)
+def unravel_index(indices, shape):
+  indices = asarray(indices)
   sizes = pad(shape, (0, 1), constant_values=1)
   cumulative_sizes = cumprod(sizes[::-1])[::-1]
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior
-  clipped_index = clip(flat_index, -total_size, total_size - 1)
+  clipped_indices = clip(indices, -total_size, total_size - 1)
   # Add enough trailing dims to avoid conflict with flat_index
-  cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * flat_index.ndim)
-  idx = clipped_index % cumulative_sizes[:-1] // cumulative_sizes[1:]
+  cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * indices.ndim)
+  idx = clipped_indices % cumulative_sizes[:-1] // cumulative_sizes[1:]
   return tuple(idx)
 
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1160,13 +1160,13 @@ and out-of-bounds indices are clipped.
 
 @_wraps(onp.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(flat_index, shape):
-    sizes = pad(shape, (0, 1), constant_values=1)
-    cumulative_sizes = cumprod(sizes[::-1])[::-1]
-    total_size = cumulative_sizes[0]
-    # Clip so raveling and unraveling an oob index will not change the behavior
-    clipped_index = clip(flat_index, -total_size, total_size - 1)
-    idx = clipped_index % cumulative_sizes[:-1] // cumulative_sizes[1:]
-    return tuple(idx)
+  sizes = pad(shape, (0, 1), constant_values=1)
+  cumulative_sizes = cumprod(sizes[::-1])[::-1]
+  total_size = cumulative_sizes[0]
+  # Clip so raveling and unraveling an oob index will not change the behavior
+  clipped_index = clip(flat_index, -total_size, total_size - 1)
+  idx = clipped_index % cumulative_sizes[:-1] // cumulative_sizes[1:]
+  return tuple(idx)
 
 
 @_wraps(onp.squeeze)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -390,7 +390,7 @@ def fmax(x1, x2):
   return where((x1 > x2) | isnan(x2), x1, x2)
 
 @_wraps(onp.finfo)
-def finfo(dtype): 
+def finfo(dtype):
   return dtypes.finfo(dtype)
 
 @_wraps(onp.issubdtype)
@@ -724,7 +724,7 @@ def _conv(x, y, mode, op, precision):
   if ndim(x) != 1 or ndim(y) != 1:
     raise ValueError(f"{op}() only support 1-dimensional inputs.")
   x, y = _promote_dtypes_inexact(x, y)
-  
+
   out_order = slice(None)
   if len(x) < len(y):
     x, y = y, x
@@ -1151,6 +1151,17 @@ def ravel(a, order="C"):
   if order == "K":
     raise NotImplementedError("Ravel not implemented for order='K'.")
   return reshape(a, (size(a),), order)
+
+
+@_wraps(onp.unravel_index)
+def unravel_index(flat_index, shape):
+    sizes = pad(shape, (0, 1), constant_values=1)
+    cumulative_sizes = cumprod(sizes[::-1])[::-1]
+    total_size = cumulative_sizes[0]
+    # Clip so raveling and unraveling an oob index will not change the behavior
+    clipped_index = clip(flat_index, -total_size, total_size - 1)
+    idx = clipped_index % cumulative_sizes[:-1] // cumulative_sizes[1:]
+    return tuple(idx)
 
 
 @_wraps(onp.squeeze)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1160,8 +1160,11 @@ and out-of-bounds indices are clipped.
 
 @_wraps(onp.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(flat_index, shape):
+  flat_index = asarray(flat_index)
   sizes = pad(shape, (0, 1), constant_values=1)
   cumulative_sizes = cumprod(sizes[::-1])[::-1]
+  # Add enough trailing dims to avoid conflict with flat_index
+  cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * flat_index.ndim)
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior
   clipped_index = clip(flat_index, -total_size, total_size - 1)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1153,7 +1153,12 @@ def ravel(a, order="C"):
   return reshape(a, (size(a),), order)
 
 
-@_wraps(onp.unravel_index)
+_UNRAVEL_INDEX_DOC = """\
+Unlike numpy's implementation of unravel_index, negative indices are accepted
+and out-of-bounds indices are clipped.
+"""
+
+@_wraps(onp.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(flat_index, shape):
     sizes = pad(shape, (0, 1), constant_values=1)
     cumulative_sizes = cumprod(sizes[::-1])[::-1]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1995,7 +1995,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.parameters(
     (0, (2, 1, 3)),
     (5, (2, 1, 3)),
-    (0, ()))
+    (0, ()),
+    ([0, 1, 2], (2, 2)),
+    ([[[0, 1], [2, 3]]], (2, 2)))
   def testUnravelIndex(self, flat_index, shape):
     self._CheckAgainstNumpy(
       onp.unravel_index,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1992,6 +1992,23 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]
     self._CompileAndCheck(lambda x: x.ravel(), args_maker, check_dtypes=True)
 
+  @parameterized.parameters(
+    (0, (2, 1, 3)),
+    (5, (2, 1, 3)),
+    (0, ()))
+  def testUnravelIndex(self, flat_index, shape):
+    self._CheckAgainstNumpy(
+      onp.unravel_index,
+      jnp.unravel_index,
+      lambda: (flat_index, shape),
+      check_dtypes=True
+    )
+
+  def testUnravelIndexOOB(self):
+    self.assertEqual(jnp.unravel_index(2, (2,)), (1,))
+    self.assertEqual(jnp.unravel_index(-2, (2, 1, 3,)), (1, 0, 1))
+    self.assertEqual(jnp.unravel_index(-3, (2,)), (0,))
+
   def testAstype(self):
     rng = onp.random.RandomState(0)
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]


### PR DESCRIPTION
To maximize consistency with indexing a raveled array, negative indices are tolerated, even though `onp.unravel_index` would raise an exception. Out-of-bounds indices are clipped. 

Closes #2889