### PR TITLE
Suppress pytype error

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -241,7 +241,7 @@ def _as_slice_indices(arr: xla.DeviceArray, idx: Index) -> Tuple[
       start_indices[dim] = sub_idx.start
       limit_indices[dim] = sub_idx.stop
 
-  return tuple(start_indices), tuple(limit_indices), tuple(removed_dims)
+  return tuple(start_indices), tuple(limit_indices), tuple(removed_dims) # type: ignore
 
 
 def shard_aval(size, aval):


### PR DESCRIPTION
pytype gets confused otherwise:
```
File ".../pxla.py", line 244, in _as_slice_indices: bad option in return type [bad-return-type]
           Expected: Tuple[Tuple[int, ...], Tuple[int, ...], Tuple[int, ...]]
  Actually returned: Tuple[Tuple[Union[Tuple[Union[int, slice], ...], slice], ...], tuple, Tuple[int, ...]]
```