### PR TITLE
Update grad of while_loop message.

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -479,8 +479,9 @@ def _while_partial_eval(trace: pe.JaxprTrace, *tracers: pe.Tracer, cond_nconsts:
   return out_tracers
 
 def _while_transpose_error(*_, **kwargs):
-  raise ValueError("Reverse-mode differentiation does not work for lax.while_loop. "
-                   "Try using lax.scan, or lax.fori_loop with constant bounds.")
+  raise ValueError("Reverse-mode differentiation does not work for "
+                   "lax.while_loop or lax.fori_loop. "
+                   "Try using lax.scan instead.")
 
 while_p = lax.Primitive('while')
 while_p.multiple_results = True


### PR DESCRIPTION
The previous error message was misleading as of https://github.com/google/jax/commit/ed8dbd254deee8f11f77e50ad6e70e2696fead51 (see https://github.com/google/jax/pull/2414#issuecomment-600183624 for context).

Partially addresses https://github.com/google/jax/issues/2956.