### PR TITLE
Use a whitelist to limit visibility of exported names in jax.numpy.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,12 @@ jax 0.1.67 (unreleased)
 
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.1.66...master>`_.
 
+* Notable changes:
+
+  * The visibility of names exported from :py:module:`jax.numpy` has been
+    tightened. This may break code that was making use of names that were
+    previously exported accidentally.
+
 jax 0.1.66 (May 5, 2020)
 ---------------------------
 

--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -100,6 +100,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     dot
     dsplit
     dstack
+    ediff1d
     einsum
     equal
     empty
@@ -256,6 +257,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     triu_indices
     true_divide
     trunc
+    unique
     unpackbits
     unravel_index
     vander

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -753,6 +753,9 @@ class DeviceArray(DeviceValue):
   # but lax_numpy.py overrides isinstance behavior and attaches ndarray methods.
   __slots__ = ["_npy_value", "_device", "_lazy_expr"]
   __array_priority__ = 100
+
+  # DeviceArray has methods that are dynamically populated in lax_numpy.py,
+  # and this annotation is needed to make pytype happy.
   _HAS_DYNAMIC_ATTRIBUTES = True
 
   def __init__(self, aval: core.ShapedArray, device: Optional[Device],

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -753,6 +753,7 @@ class DeviceArray(DeviceValue):
   # but lax_numpy.py overrides isinstance behavior and attaches ndarray methods.
   __slots__ = ["_npy_value", "_device", "_lazy_expr"]
   __array_priority__ = 100
+  _HAS_DYNAMIC_ATTRIBUTES = True
 
   def __init__(self, aval: core.ShapedArray, device: Optional[Device],
                lazy_expr: lazy.LazyExpr, device_buffer: PyLocalBuffer):

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -53,8 +53,9 @@ from .lax_numpy import (
     sinh, size, sometrue, sort, split, sqrt, square, squeeze, stack, std,
     subtract, sum, swapaxes, take, take_along_axis, tan, tanh, tensordot, tile,
     trace, transpose, tri, tril, tril_indices, triu, triu_indices, true_divide,
-    trunc, uint16, uint32, uint64, uint8, unique, unpackbits, unsignedinteger,
-    vander, var, vdot, vsplit, vstack, where, zeros, zeros_like)
+    trunc, uint16, uint32, uint64, uint8, unique, unpackbits, unravel_index,
+    unsignedinteger, vander, var, vdot, vsplit, vstack, where, zeros,
+    zeros_like)
 
 from .polynomial import roots
 from .vectorize import vectorize

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -12,9 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .lax_numpy import *
-from .polynomial import *
 from . import fft
 from . import linalg
+
+from ..interpreters.xla import DeviceArray
+
+from .lax_numpy import (
+    ComplexWarning, NINF, NZERO, PZERO, abs, absolute, add, all, allclose,
+    alltrue, amax, amin, angle, any, append, arange, arccos, arccosh, arcsin,
+    arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, around, array,
+    array_equal, array_repr, array_str, asarray, atleast_1d, atleast_2d,
+    atleast_3d, average, bartlett, bfloat16, bitwise_and, bitwise_not,
+    bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays,
+    broadcast_to, can_cast, cbrt, cdouble, ceil, character, clip, column_stack,
+    complex128, complex64, complex_, complexfloating, concatenate, conj,
+    conjugate, convolve, copysign, corrcoef, correlate, cos, cosh,
+    count_nonzero, cov, cross, csingle, cumprod, cumproduct, cumsum, deg2rad,
+    degrees, diag, diag_indices, diagonal, diff, divide, divmod, dot, double,
+    dsplit, dstack, dtype, e, ediff1d, einsum, einsum_path, empty, empty_like,
+    equal, euler_gamma, exp, exp2, expand_dims, expm1, eye, fabs, finfo, fix,
+    flexible, flip, fliplr, flipud, float16, float32, float64, float_,
+    float_power, floating, floor, floor_divide, fmax, fmin, fmod, frexp, full,
+    full_like, function, gcd, geomspace, gradient, greater, greater_equal,
+    hamming, hanning, heaviside, hsplit, hstack, hypot, identity, iinfo, imag,
+    inexact, inf, inner, int16, int32, int64, int8, int_, integer, isclose,
+    iscomplex, iscomplexobj, isfinite, isinf, isnan, isneginf, isposinf, isreal,
+    isrealobj, isscalar, issubdtype, issubsctype, iterable, ix_, kaiser, kron,
+    lcm, ldexp, left_shift, less, less_equal, linspace, load, log, log10, log1p,
+    log2, logaddexp, logaddexp2, logical_and, logical_not, logical_or,
+    logical_xor, logspace, mask_indices, matmul, max, maximum, mean, median,
+    meshgrid, min, minimum, mod, moveaxis, msort, multiply, nan, nan_to_num,
+    nanargmax, nanargmin, nancumprod, nancumsum, nanmax, nanmean, nanmin,
+    nanprod, nansum, ndarray, ndim, negative, newaxis, nextafter, nonzero,
+    not_equal, number, numpy_version, object_, ones, ones_like, operator_name,
+    outer, packbits, pad, percentile, pi, polyval, positive, power, prod,
+    product, promote_types, ptp, quantile, rad2deg, radians, ravel, real,
+    reciprocal, remainder, repeat, reshape, result_type, right_shift, rint,
+    roll, rollaxis, rot90, round, row_stack, save, savez, searchsorted, select,
+    set_printoptions, shape, sign, signbit, signedinteger, sin, sinc, single,
+    sinh, size, sometrue, sort, split, sqrt, square, squeeze, stack, std,
+    subtract, sum, swapaxes, take, take_along_axis, tan, tanh, tensordot, tile,
+    trace, transpose, tri, tril, tril_indices, triu, triu_indices, true_divide,
+    trunc, uint16, uint32, uint64, uint8, unique, unpackbits, unsignedinteger,
+    vander, var, vdot, vsplit, vstack, where, zeros, zeros_like)
+
+from .polynomial import roots
 from .vectorize import vectorize
 from ._util import _wraps
+
+
+# Module initialization is encapsulated in a function to avoid accidental
+# namespace pollution.
+def _init():
+  import numpy as np
+  from . import lax_numpy
+  from .. import util
+  # Builds a set of all unimplemented NumPy functions.
+  for func in util.get_module_functions(np):
+    if func.__name__ not in globals():
+      globals()[func.__name__] = lax_numpy._not_implemented(func)
+
+_init()
+del _init

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -59,7 +59,6 @@ from .lax_numpy import (
 
 from .polynomial import roots
 from .vectorize import vectorize
-from ._util import _wraps
 
 
 # Module initialization is encapsulated in a function to avoid accidental

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3815,11 +3815,6 @@ def _not_implemented(fun):
     raise NotImplementedError(msg.format(fun))
   return wrapped
 
-# Build a set of all unimplemented NumPy functions.
-for func in get_module_functions(onp):
-  if func.__name__ not in globals():
-    globals()[func.__name__] = _not_implemented(func)
-
 
 ### add method and operator overloads to arraylike classes
 
@@ -3903,6 +3898,9 @@ _diff_methods = ["clip", "compress", "conj", "conjugate", "cumprod", "cumsum",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
                  "swapaxes", "take", "tile", "trace", "transpose", "var"]
 
+argpartition = _not_implemented(onp.argpartition)
+compress = _not_implemented(onp.compress)
+searchsorted = _not_implemented(onp.searchsorted)
 
 # Set up operator, method, and property forwarding on Tracer instances containing
 # ShapedArray avals by following the forwarding conventions for Tracer.

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3898,9 +3898,11 @@ _diff_methods = ["clip", "compress", "conj", "conjugate", "cumprod", "cumsum",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
                  "swapaxes", "take", "tile", "trace", "transpose", "var"]
 
+# These methods are mentioned explicitly by nondiff_methods, so we create
+# _not_implemented implementations of them here rather than in __init__.py.
+# TODO(phawkins): implement these.
 argpartition = _not_implemented(onp.argpartition)
 compress = _not_implemented(onp.compress)
-searchsorted = _not_implemented(onp.searchsorted)
 
 # Set up operator, method, and property forwarding on Tracer instances containing
 # ShapedArray avals by following the forwarding conventions for Tracer.


### PR DESCRIPTION
Prevents unintentional exports of non-public names in the API.

(This should replace #2417 )
