### PR TITLE
Adjust test tolerances for TPU.

### DIFF
--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -137,8 +137,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
     if test_autodiff:
       jtu.check_grads(lax_op, args, order=1,
-                      atol=jtu.if_device_under_test("tpu", 2e-3, 1e-3),
-                      rtol=2e-2, eps=1e-3)
+                      atol=jtu.if_device_under_test("tpu", .02, 1e-3),
+                      rtol=jtu.if_device_under_test("tpu", .01, .02),
+                      eps=1e-3)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_d={}".format(


### PR DESCRIPTION
Ideally this is temporary, as the tolerances are getting high.