### PR TITLE
Cleanup: move _wraps into jax.numpy._utils.

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -17,3 +17,4 @@ from .polynomial import *
 from . import fft
 from . import linalg
 from .vectorize import vectorize
+from ._util import _wraps

--- a/jax/numpy/_util.py
+++ b/jax/numpy/_util.py
@@ -1,0 +1,82 @@
+import re
+
+
+def update_numpydoc(docstr, fun, op):
+  '''Transforms the numpy docstring to remove references of
+     parameters that are supported by the numpy version but not the JAX version'''
+
+  #Some numpy functions have an extra tab at the beginning of each line,
+  #If this function is one of those we remove this extra tab from all the lines
+  if not hasattr(op, '__code__'):
+    return docstr
+  if docstr[:4] == '    ':
+    lines = docstr.split('\n')
+    for idx, line in enumerate(lines):
+      lines[idx] = line.replace('    ', '', 1)
+    docstr = '\n'.join(lines)
+
+  begin_idx = docstr.find("Parameters")
+  begin_idx = docstr.find("--\n", begin_idx) + 2
+  end_idx = docstr.find("Returns", begin_idx)
+
+  parameters = docstr[begin_idx:end_idx]
+  param_list = parameters.replace('\n    ', '@@').split('\n')
+  for idx, p in enumerate(param_list):
+    param = p[:p.find(' : ')].split(", ")[0]
+    if param not in op.__code__.co_varnames:
+      param_list[idx] = ''
+  param_list = [param for param in param_list if param != '']
+  parameters = '\n'.join(param_list).replace('@@', '\n    ')
+  return docstr[:begin_idx + 1] + parameters + docstr[end_idx - 2:]
+
+_numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*\)$')
+
+
+def _wraps(fun, update_doc=True, lax_description=""):
+  """Like functools.wraps but works with numpy.ufuncs.
+     It is important that when wrapping numpy functions the parameters names
+     in the original function and in the JAX version are the same
+    Parameters:
+      fun: The function being wrapped
+      update_doc: whether to transform the numpy docstring to remove references of
+      parameters that are supported by the numpy version but not the JAX version.
+      If False, include the numpy docstring verbatim.
+  """
+  def wrap(op):
+    if not hasattr(fun, '__doc__') or fun.__doc__ is None:
+      return op
+    try:
+      # Numpy doc comments have the form:
+      # fn(x, y, z)          (optional)
+      #
+      # A one-line summary
+      #
+      # ... everything else ...
+      # We (a) move the summary to the top, since it is what the Sphinx
+      # autosummary extension expects, and (b) add a comment below the summary
+      # to the effect that this is a LAX wrapper of a Numpy function.
+      sections = fun.__doc__.split("\n\n")
+
+      signatures = []
+      summary = None
+      for i in range(len(sections)):
+        if _numpy_signature_re.match(sections[i]):
+          signatures.append(sections[i])
+        else:
+          summary = sections[i].strip()
+          break
+      body = "\n\n".join(signatures + sections[i + 1:])
+      if update_doc:
+        body = update_numpydoc(body, fun, op)
+      desc = lax_description + "\n" if lax_description else ""
+      docstr = (
+          "{summary}\n\nLAX-backend implementation of :func:`{fun}`.\n"
+          "{lax_description}Original docstring below.\n\n{body}"
+          .format(summary=summary, lax_description=desc,
+                  fun=fun.__name__, body=body))
+
+      op.__name__ = fun.__name__
+      op.__doc__ = docstr
+    finally:
+      return op
+  return wrap

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -19,7 +19,7 @@ from .. import lax
 from ..lib import xla_client
 from ..util import get_module_functions
 from .lax_numpy import _not_implemented
-from .lax_numpy import _wraps
+from ._util import _wraps
 from . import lax_numpy as jnp
 from .. import ops as jaxops
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -40,6 +40,7 @@ import numpy as onp
 import opt_einsum
 
 from jax import jit, device_put, custom_jvp
+from ._util import _wraps
 from .. import core
 from .. import dtypes
 from ..abstract_arrays import UnshapedArray, ShapedArray, ConcreteArray, canonicalize_shape
@@ -288,86 +289,6 @@ def _promote_args_inexact(fun_name, *args):
 
 def _constant_like(x, const):
   return onp.array(const, dtype=_dtype(x))
-
-
-def update_numpydoc(docstr, fun, op):
-  '''Transforms the numpy docstring to remove references of
-     parameters that are supported by the numpy version but not the JAX version'''
-
-  #Some numpy functions have an extra tab at the beginning of each line,
-  #If this function is one of those we remove this extra tab from all the lines
-  if not hasattr(op, '__code__'):
-    return docstr
-  if docstr[:4] == '    ':
-    lines = docstr.split('\n')
-    for idx, line in enumerate(lines):
-      lines[idx] = line.replace('    ', '', 1)
-    docstr = '\n'.join(lines)
-
-  begin_idx = docstr.find("Parameters")
-  begin_idx = docstr.find("--\n", begin_idx) + 2
-  end_idx = docstr.find("Returns", begin_idx)
-
-  parameters = docstr[begin_idx:end_idx]
-  param_list = parameters.replace('\n    ', '@@').split('\n')
-  for idx, p in enumerate(param_list):
-    param = p[:p.find(' : ')].split(", ")[0]
-    if param not in op.__code__.co_varnames:
-      param_list[idx] = ''
-  param_list = [param for param in param_list if param != '']
-  parameters = '\n'.join(param_list).replace('@@', '\n    ')
-  return docstr[:begin_idx + 1] + parameters + docstr[end_idx - 2:]
-
-_numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*\)$')
-
-def _wraps(fun, update_doc=True, lax_description=""):
-  """Like functools.wraps but works with numpy.ufuncs.
-     It is important that when wrapping numpy functions the parameters names
-     in the original function and in the JAX version are the same
-    Parameters:
-      fun: The function being wrapped
-      update_doc: whether to transform the numpy docstring to remove references of
-      parameters that are supported by the numpy version but not the JAX version.
-      If False, include the numpy docstring verbatim.
-  """
-  def wrap(op):
-    if not hasattr(fun, '__doc__') or fun.__doc__ is None:
-      return op
-    try:
-      # Numpy doc comments have the form:
-      # fn(x, y, z)          (optional)
-      #
-      # A one-line summary
-      #
-      # ... everything else ...
-      # We (a) move the summary to the top, since it is what the Sphinx
-      # autosummary extension expects, and (b) add a comment below the summary
-      # to the effect that this is a LAX wrapper of a Numpy function.
-      sections = fun.__doc__.split("\n\n")
-
-      signatures = []
-      summary = None
-      for i in range(len(sections)):
-        if _numpy_signature_re.match(sections[i]):
-          signatures.append(sections[i])
-        else:
-          summary = sections[i].strip()
-          break
-      body = "\n\n".join(signatures + sections[i + 1:])
-      if update_doc:
-        body = update_numpydoc(body, fun, op)
-      desc = lax_description + "\n" if lax_description else ""
-      docstr = (
-          "{summary}\n\nLAX-backend implementation of :func:`{fun}`.\n"
-          "{lax_description}Original docstring below.\n\n{body}"
-          .format(summary=summary, lax_description=desc,
-                  fun=fun.__name__, body=body))
-
-      op.__name__ = fun.__name__
-      op.__doc__ = docstr
-    finally:
-      return op
-  return wrap
 
 def _canonicalize_axis(axis, num_dims):
   """Canonicalize an axis in (-num_dims, num_dims) to [0, num_dims)."""

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -26,7 +26,7 @@ from .. import ops
 from .. import lax_linalg
 from .. import dtypes
 from .lax_numpy import _not_implemented
-from .lax_numpy import _wraps
+from ._util import _wraps
 from .vectorize import vectorize
 from . import lax_numpy as jnp
 from ..util import get_module_functions

--- a/jax/numpy/polynomial.py
+++ b/jax/numpy/polynomial.py
@@ -18,7 +18,7 @@ from .. import lax
 from . import lax_numpy as jnp
 
 from jax import jit
-from .lax_numpy import _wraps
+from ._util import _wraps
 from .linalg import eigvals as _eigvals
 from .. import ops as jaxops
 

--- a/jax/numpy/vectorize.py
+++ b/jax/numpy/vectorize.py
@@ -20,7 +20,7 @@ from .. import api
 from .. import lax
 from . import lax_numpy as jnp
 from ..util import safe_map as map, safe_zip as zip
-from .lax_numpy import _wraps
+from ._util import _wraps
 
 
 # See http://docs.scipy.org/doc/numpy/reference/c-api.generalized-ufuncs.html

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -21,7 +21,7 @@ import textwrap
 from jax import jit, vmap
 from .. import lax
 from .. import lax_linalg
-from ..numpy.lax_numpy import _wraps
+from ..numpy._util import _wraps
 from ..numpy import lax_numpy as jnp
 from ..numpy import linalg as np_linalg
 

--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -22,7 +22,7 @@ import scipy.ndimage
 
 from .. import api
 from ..numpy import lax_numpy as jnp
-from ..numpy.lax_numpy import _wraps
+from ..numpy._util import _wraps
 from ..util import safe_zip as zip
 
 

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -17,7 +17,8 @@ import warnings
 
 from .. import lax
 from ..numpy import lax_numpy as jnp
-from ..numpy.lax_numpy import (_wraps, _promote_dtypes_inexact)
+from ..numpy.lax_numpy import _promote_dtypes_inexact
+from ..numpy._util import _wraps
 
 
 # Note: we do not re-use the code from jax.numpy.convolve here, because the handling

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -21,8 +21,9 @@ from .. import util
 from .. import lax
 from .. import api
 from ..numpy import lax_numpy as jnp
-from ..numpy.lax_numpy import (_wraps, asarray, _reduction_dims, _constant_like,
+from ..numpy.lax_numpy import (asarray, _reduction_dims, _constant_like,
                                _promote_args_inexact)
+from ..numpy._util import _wraps                        
 
 
 @_wraps(osp_special.gammaln)

--- a/jax/scipy/stats/bernoulli.py
+++ b/jax/scipy/stats/bernoulli.py
@@ -17,10 +17,11 @@ import scipy.stats as osp_stats
 
 from ... import lax
 from ...numpy import lax_numpy as jnp
+from ...numpy._util import _wraps
 from ..special import xlogy, xlog1py
 
 
-@jnp._wraps(osp_stats.bernoulli.logpmf, update_doc=False)
+@_wraps(osp_stats.bernoulli.logpmf, update_doc=False)
 def logpmf(k, p, loc=0):
   k, p, loc = jnp._promote_args_inexact("bernoulli.logpmf", k, p, loc)
   zero = jnp._constant_like(k, 0)
@@ -30,6 +31,6 @@ def logpmf(k, p, loc=0):
   return jnp.where(jnp.logical_or(lax.lt(x, zero), lax.gt(x, one)),
                   -jnp.inf, log_probs)
 
-@jnp._wraps(osp_stats.bernoulli.pmf, update_doc=False)
+@_wraps(osp_stats.bernoulli.pmf, update_doc=False)
 def pmf(k, p, loc=0):
   return jnp.exp(logpmf(k, p, loc))

--- a/jax/scipy/stats/beta.py
+++ b/jax/scipy/stats/beta.py
@@ -15,7 +15,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like, _wraps,
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like,
                                 where, inf, logical_or)
 from ..special import betaln
 

--- a/jax/scipy/stats/cauchy.py
+++ b/jax/scipy/stats/cauchy.py
@@ -17,7 +17,8 @@ import numpy as np
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, _constant_like
 
 
 @_wraps(osp_stats.cauchy.logpdf, update_doc=False)

--- a/jax/scipy/stats/dirichlet.py
+++ b/jax/scipy/stats/dirichlet.py
@@ -18,6 +18,7 @@ import scipy.stats as osp_stats
 
 from ... import lax
 from ...numpy import lax_numpy as jnp
+from ...numpy._util import _wraps
 from ..special import gammaln, xlogy
 
 
@@ -26,7 +27,7 @@ def _is_simplex(x):
     return jnp.all(x > 0, axis=-1) & (x_sum <= 1) & (x_sum > 1 - 1e-6)
 
 
-@jnp._wraps(osp_stats.dirichlet.logpdf, update_doc=False)
+@_wraps(osp_stats.dirichlet.logpdf, update_doc=False)
 def logpdf(x, alpha):
     args = (np.ones((0,), lax.dtype(x)), np.ones((1,), lax.dtype(alpha)))
     to_dtype = lax.dtype(osp_stats.dirichlet.logpdf(*args))
@@ -37,6 +38,6 @@ def logpdf(x, alpha):
     return jnp.where(_is_simplex(x), log_probs, -jnp.inf)
 
 
-@jnp._wraps(osp_stats.dirichlet.pdf, update_doc=False)
+@_wraps(osp_stats.dirichlet.pdf, update_doc=False)
 def pdf(x, alpha):
   return lax.exp(logpdf(x, alpha))

--- a/jax/scipy/stats/expon.py
+++ b/jax/scipy/stats/expon.py
@@ -15,7 +15,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _wraps, where, inf
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, where, inf
 
 
 @_wraps(osp_stats.expon.logpdf, update_doc=False)

--- a/jax/scipy/stats/gamma.py
+++ b/jax/scipy/stats/gamma.py
@@ -15,7 +15,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like, _wraps,
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import (_promote_args_inexact, _constant_like,
                                 where, inf)
 from ..special import gammaln
 

--- a/jax/scipy/stats/laplace.py
+++ b/jax/scipy/stats/laplace.py
@@ -15,7 +15,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, _constant_like
 
 
 @_wraps(osp_stats.laplace.logpdf, update_doc=False)

--- a/jax/scipy/stats/logistic.py
+++ b/jax/scipy/stats/logistic.py
@@ -16,7 +16,8 @@ import scipy.stats as osp_stats
 from jax.scipy.special import expit, logit
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact
 
 
 @_wraps(osp_stats.logistic.logpdf, update_doc=False)

--- a/jax/scipy/stats/multivariate_normal.py
+++ b/jax/scipy/stats/multivariate_normal.py
@@ -19,7 +19,8 @@ import scipy.stats as osp_stats
 from ... import lax
 from ...lax_linalg import cholesky, triangular_solve
 from ... import numpy as jnp
-from ...numpy.lax_numpy import _promote_dtypes_inexact, _constant_like, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_dtypes_inexact, _constant_like
 
 
 @_wraps(osp_stats.multivariate_normal.logpdf, update_doc=False)

--- a/jax/scipy/stats/norm.py
+++ b/jax/scipy/stats/norm.py
@@ -18,7 +18,8 @@ import scipy.stats as osp_stats
 
 from ... import lax
 from ...numpy import lax_numpy as jnp
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, _constant_like
 from .. import special
 
 @_wraps(osp_stats.norm.logpdf, update_doc=False)

--- a/jax/scipy/stats/pareto.py
+++ b/jax/scipy/stats/pareto.py
@@ -16,7 +16,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps, inf, where
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, inf, where
 
 
 @_wraps(osp_stats.pareto.logpdf, update_doc=False)

--- a/jax/scipy/stats/poisson.py
+++ b/jax/scipy/stats/poisson.py
@@ -16,11 +16,12 @@
 import scipy.stats as osp_stats
 
 from ... import lax
+from ...numpy._util import _wraps
 from ...numpy import lax_numpy as jnp
 from ..special import xlogy, gammaln
 
 
-@jnp._wraps(osp_stats.poisson.logpmf, update_doc=False)
+@_wraps(osp_stats.poisson.logpmf, update_doc=False)
 def logpmf(k, mu, loc=0):
   k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
   zero = jnp._constant_like(k, 0)
@@ -28,6 +29,6 @@ def logpmf(k, mu, loc=0):
   log_probs = xlogy(x, mu) - gammaln(x + 1) - mu
   return jnp.where(lax.lt(x, zero), -jnp.inf, log_probs)
 
-@jnp._wraps(osp_stats.poisson.pmf, update_doc=False)
+@_wraps(osp_stats.poisson.pmf, update_doc=False)
 def pmf(k, mu, loc=0):
   return jnp.exp(logpmf(k, mu, loc))

--- a/jax/scipy/stats/t.py
+++ b/jax/scipy/stats/t.py
@@ -17,7 +17,8 @@ import numpy as np
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import _promote_args_inexact, _constant_like, _wraps
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import _promote_args_inexact, _constant_like
 
 
 @_wraps(osp_stats.t.logpdf, update_doc=False)

--- a/jax/scipy/stats/uniform.py
+++ b/jax/scipy/stats/uniform.py
@@ -16,7 +16,8 @@
 import scipy.stats as osp_stats
 
 from ... import lax
-from ...numpy.lax_numpy import (_constant_like, _promote_args_inexact, _wraps,
+from ...numpy._util import _wraps
+from ...numpy.lax_numpy import (_constant_like, _promote_args_inexact,
                                 where, inf, logical_or)
 
 

--- a/jax/third_party/numpy/linalg.py
+++ b/jax/third_party/numpy/linalg.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from jax.numpy import lax_numpy as jnp
 from jax.numpy import linalg as la
-from jax.numpy.lax_numpy import _wraps
+from jax.numpy._util import _wraps
 
 
 def _isEmpty2d(arr):


### PR DESCRIPTION
Why? This prevents circular imports within the numpy submodule.

Necessary for https://github.com/google/jax/pull/2938#discussion_r420983186