### PR TITLE
Remove jax.lax.xla_bridge, which was an accidental export.

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -319,6 +319,3 @@ from .lax_parallel import (
   pswapaxes,
   standard_pmap_primitive,
 )
-
-# TODO(phawkins): remove this import after fixing users.
-from ..lib import xla_bridge


### PR DESCRIPTION
All known users have been updated.