### PR TITLE
Fix mean behavior

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1522,6 +1522,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
   else:
     normalizer = onp.prod(onp.take(shape(a), axis))
   if dtype is None:
+    a = a if isinstance(a, ndarray) else asarray(a)
     if issubdtype(_dtype(a), bool_) or issubdtype(_dtype(a), integer):
       dtype = float_
     else:


### PR DESCRIPTION
Related to #3038 
Another way to make the API consistent would be to remove the ability of reductions to cast from list to array, but I don't think that's much of a good idea (always force the user to cast things by themselves), 
what do you guys think?
Pining @jakevdp since he was in #3038 discussion