### PR TITLE
Import tpu_driver after xla_client

### DIFF
--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -45,10 +45,6 @@ def _check_jaxlib_version():
 _check_jaxlib_version()
 
 
-try:
-  from jaxlib import tpu_client  # pytype: disable=import-error
-except:
-  tpu_client = None
 from jaxlib import xla_client
 from jaxlib import lapack
 
@@ -58,3 +54,8 @@ try:
   from jaxlib import cuda_prng
 except ImportError:
   cuda_prng = None
+
+try:
+  from jaxlib import tpu_client  # pytype: disable=import-error
+except:
+  tpu_client = None


### PR DESCRIPTION
This is a workaround until we build a new jaxlib with https://github.com/tensorflow/tensorflow/commit/f4628678066c72309d3fd121af1aaf54d9905ca3