### PR TITLE
Make lax.sort support tuple arguments using a variadic sort.

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -248,7 +248,6 @@ from .lax import (
   slice_p,
   sort,
   sort_key_val,
-  sort_key_val_p,
   sort_p,
   sqrt,
   sqrt_p,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1176,7 +1176,8 @@ def cumprod(operand: Array, axis: int) -> Array:
   """Computes a cumulative product along `axis`."""
   return cumprod_p.bind(operand, axis=int(axis))
 
-def sort(operand: Union[Array, Tuple[Array, ...]], dimension: int = -1) -> Array:
+def sort(operand: Union[Array, Tuple[Array, ...]], dimension: int = -1
+         ) -> Union[Array, Tuple[Array, ...]]:
   """Wraps XLA's `Sort
   <https://www.tensorflow.org/xla/operation_semantics#sort>`_
   operator.
@@ -1194,7 +1195,8 @@ def sort_key_val(keys: Array, values: Array,
                  dimension: int = -1) -> Tuple[Array, Array]:
   """Sorts ``keys`` along ``dimension`` and applies same permutation to ``values``."""
   dimension = _canonicalize_axis(dimension, len(keys.shape))
-  return tuple(sort_p.bind(keys, values, dimension=dimension))
+  k, v = sort_p.bind(keys, values, dimension=dimension)
+  return k, v
 
 def top_k(operand: Array, k: int) -> Tuple[Array, Array]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``."""

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2952,9 +2952,9 @@ def sort(a, axis=-1, kind='quicksort', order=None):
     raise ValueError("'order' argument to sort is not supported.")
 
   if axis is None:
-    return lax.sort(a.ravel(), 0)
+    return lax.sort(a.ravel(), dimension=0)
   else:
-    return lax.sort(a, _canonicalize_axis(axis, ndim(a)))
+    return lax.sort(a, dimension=_canonicalize_axis(axis, ndim(a)))
 
 
 @_wraps(np.argsort)


### PR DESCRIPTION
Change `_sort_jvp` to use a gather of ids to compute the JVP rather than another sort.
Remove `_sort_key_val_p`, since it is redundant with a variadic sort_p.
Add a batching test for `sort_p`.