### PR TITLE
Add support for 8- and 16-bit output in _random_bits

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -276,8 +276,7 @@ def _random_bits(key, bit_width, shape):
   if bit_width not in (8, 16, 32, 64):
     raise TypeError("requires 8-, 16-, 32- or 64-bit field width.")
   size = onp.prod(shape)
-  bits = bit_width * size
-  max_count = (bits // 32) + (bits % 32)
+  max_count = int(onp.ceil(bit_width * size / 32))
   if max_count >= np.iinfo(onp.uint32).max:
     # TODO(mattjj): just split the key here
     raise TypeError("requesting more random bits than a single call provides.")

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -705,6 +705,12 @@ class JaxTestCase(parameterized.TestCase):
   def rng(self):
     return self._rng
 
+  def assertArraysEqual(self, x, y, check_dtypes):
+    """Assert that x and y arrays are exactly equal."""
+    if check_dtypes:
+      self.assertDtypesMatch(x, y)
+    np.testing.assert_equal(x, y)
+
   def assertArraysAllClose(self, x, y, check_dtypes, atol=None, rtol=None):
     """Assert that x and y are close (up to numerical tolerances)."""
     self.assertEqual(x.shape, y.shape)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -123,7 +123,8 @@ class LaxRandomTest(jtu.JaxTestCase):
     key = random.PRNGKey(1701)
     nbits = [8, 16, 32]
     if jtu.device_under_test() == "tpu":
-      nbits = [16, 32]
+      # U8 and U16 are not supported on TPU.
+      nbits = [32]
     rand_bits = [random._random_bits(key, n, (N * 64 // n,)) for n in nbits]
     rand_bits_32 = np.array([np.array(r).view(np.uint32) for r in rand_bits])
     print(rand_bits_32)
@@ -133,14 +134,15 @@ class LaxRandomTest(jtu.JaxTestCase):
     # Test specific outputs to ensure consistent random values between JAX versions.
     key = random.PRNGKey(1701)
 
+    # U8 and U16 are not supported on TPU.
     if jtu.device_under_test() != "tpu":
       bits8 = random._random_bits(key, 8, (3,))
       expected8 = np.array([216, 115,  43], dtype=np.uint8)
       self.assertArraysEqual(bits8, expected8, check_dtypes=True)
 
-    bits16 = random._random_bits(key, 16, (3,))
-    expected16 = np.array([41682,  1300, 55017], dtype=np.uint16)
-    self.assertArraysEqual(bits16, expected16, check_dtypes=True)
+      bits16 = random._random_bits(key, 16, (3,))
+      expected16 = np.array([41682,  1300, 55017], dtype=np.uint16)
+      self.assertArraysEqual(bits16, expected16, check_dtypes=True)
 
     bits32 = random._random_bits(key, 32, (3,))
     expected32 = np.array([56197195, 4200222568, 961309823], dtype=np.uint32)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -121,11 +121,11 @@ class LaxRandomTest(jtu.JaxTestCase):
     key = random.PRNGKey(1701)
 
     bits8 = random._random_bits(key, 8, (3,))
-    expected8 = np.array([193, 148, 117], dtype=np.uint8)
+    expected8 = np.array([216, 115,  43], dtype=np.uint8)
     self.assertArraysEqual(bits8, expected8, check_dtypes=True)
 
     bits16 = random._random_bits(key, 16, (3,))
-    expected16 = np.array([37450, 20880, 48825], dtype=np.uint16)
+    expected16 = np.array([41682, 55017, 1300], dtype=np.uint16)
     self.assertArraysEqual(bits16, expected16, check_dtypes=True)
 
     bits32 = random._random_bits(key, 32, (3,))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -116,6 +116,30 @@ class LaxRandomTest(jtu.JaxTestCase):
     np.testing.assert_equal(result[:n], np.full((n,), 0xc4923a9c, dtype=np.uint32))
     np.testing.assert_equal(result[n:], np.full((n,), 0x483df7a0, dtype=np.uint32))
 
+  def testRngRandomBits(self):
+    # Test specific outputs to ensure consistent random values between JAX versions.
+    key = random.PRNGKey(1701)
+
+    bits8 = random._random_bits(key, 8, (3,))
+    expected8 = np.array([193, 148, 117], dtype=np.uint8)
+    self.assertArraysEqual(bits8, expected8, check_dtypes=True)
+
+    bits16 = random._random_bits(key, 16, (3,))
+    expected16 = np.array([37450, 20880, 48825], dtype=np.uint16)
+    self.assertArraysEqual(bits16, expected16, check_dtypes=True)
+
+    bits32 = random._random_bits(key, 32, (3,))
+    expected32 = np.array([56197195, 4200222568, 961309823], dtype=np.uint32)
+    self.assertArraysEqual(bits32, expected32, check_dtypes=True)
+
+    bits64 = random._random_bits(key, 64, (3,))
+    if FLAGS.jax_enable_x64:
+      expected64 = np.array([3982329540505020460, 16822122385914693683,
+                             7882654074788531506], dtype=np.uint64)
+    else:
+      expected64 = np.array([676898860, 3164047411, 4010691890], dtype=np.uint32)
+    self.assertArraysEqual(bits64, expected64, check_dtypes=True)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
       for dtype in [np.float32, np.float64]))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -116,6 +116,18 @@ class LaxRandomTest(jtu.JaxTestCase):
     np.testing.assert_equal(result[:n], np.full((n,), 0xc4923a9c, dtype=np.uint32))
     np.testing.assert_equal(result[n:], np.full((n,), 0x483df7a0, dtype=np.uint32))
 
+  def testRngRandomBitsViewProperty(self):
+    # TODO: add 64-bit if it ever supports this property.
+    # TODO: will this property hold across endian-ness?
+    N = 10
+    key = random.PRNGKey(1701)
+    r32 = random._random_bits(key, 32, (N,))
+    r16 = random._random_bits(key, 16, (2 * N,))
+    r8 = random._random_bits(key, 8, (4 * N,))
+
+    self.assertArraysEqual(np.array(r32).view(np.uint8), np.array(r8), check_dtypes=True)
+    self.assertArraysEqual(np.array(r16).view(np.uint8), np.array(r8), check_dtypes=True)
+
   def testRngRandomBits(self):
     # Test specific outputs to ensure consistent random values between JAX versions.
     key = random.PRNGKey(1701)
@@ -125,7 +137,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     self.assertArraysEqual(bits8, expected8, check_dtypes=True)
 
     bits16 = random._random_bits(key, 16, (3,))
-    expected16 = np.array([41682, 55017, 1300], dtype=np.uint16)
+    expected16 = np.array([41682,  1300, 55017], dtype=np.uint16)
     self.assertArraysEqual(bits16, expected16, check_dtypes=True)
 
     bits32 = random._random_bits(key, 32, (3,))


### PR DESCRIPTION
Why? This will allow us to begin building-out support for more dtypes in the random functions that depend on `_random_bits` (see #3062).

Note that I avoided using ``bits.view()`` here for two reasons: (1) it is somewhat slower because of its generality, and (2) having lax.py depend on lax_numpy.py seems like a dependency in the wrong direction.