### PR TITLE
Add support for sorting complex values, defaulting to a NumPy-style l…

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4599,6 +4599,8 @@ def _float_to_int_for_sort(x):
 # -NaN < -infinity < ... < -0 < 0 < ... < infinity < NaN.
 # For complex types, the (real, imag) pairs are sorted lexicographically
 # (following NumPy's semantics).
+# See also:
+# https://github.com/tensorflow/tensorflow/blob/ba43780830f09da72081fe5061c436f1c6203a92/tensorflow/compiler/xla/client/lib/comparators.h#L33
 def _sort_lt_comparator(*operands):
   assert len(operands) >= 2 and len(operands) % 2 == 0, operands
   x, y = operands[:2]

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4595,6 +4595,10 @@ def _float_to_int_for_sort(x):
   return select(lt(signed, _zero(signed)), flipped, signed)
 
 # Default comparator that sorts the operands only on their first arguments.
+# For floating point types, a total order is created where
+# -NaN < -infinity < ... < -0 < 0 < ... < infinity < NaN.
+# For complex types, the (real, imag) pairs are sorted lexicographically
+# (following NumPy's semantics).
 def _sort_lt_comparator(*operands):
   assert len(operands) >= 2 and len(operands) % 2 == 0, operands
   x, y = operands[:2]

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4599,7 +4599,7 @@ def _float_to_int_for_sort(x):
 # -NaN < -infinity < ... < -0 < 0 < ... < infinity < NaN.
 # For complex types, the (real, imag) pairs are sorted lexicographically
 # (following NumPy's semantics).
-# See also:
+# This code adds complex-number support to the algorithm from:
 # https://github.com/tensorflow/tensorflow/blob/ba43780830f09da72081fe5061c436f1c6203a92/tensorflow/compiler/xla/client/lib/comparators.h#L33
 def _sort_lt_comparator(*operands):
   assert len(operands) >= 2 and len(operands) % 2 == 0, operands

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4289,6 +4289,11 @@ _UINT_DTYPES = {
   64: onp.uint64,
 }
 
+_INT_DTYPES = {
+  16: onp.int16,
+  32: onp.int32,
+  64: onp.int64,
+}
 
 def _select_and_gather_add_translation(
     c, tangents, operand, *, select_prim, window_dimensions, window_strides,
@@ -4563,8 +4568,63 @@ def _sort_abstract_eval(*args, **kwargs):
     raise TypeError(f"Arguments to sort must have equal shapes, got: {shapes}")
   return args
 
+
+def _float_to_int_for_sort(x):
+  # Switch from a floating point value to a integer value in such a way that
+  # when using the integer value to compare, we get the same result for normal
+  # values, and -nan is treated as the smallest value, and nan is treated as
+  # the largest value.
+  # If f is a float, and
+  # x = bit_cast<int32>(f);
+  # y = x < 0 ? int32_max - x : x;
+  # then y is ordered as an int32 such that finite values have the obvious
+  # order, -0 is ordered before 0, and -NaN and NaN appear at the beginning
+  # and end of the ordering.
+  # Note that in order to avoid -x to overflow, we calculate
+  # int32_max - x as unsigned, and then convert back to signed.
+  if x.dtype == dtypes.bfloat16:
+    x = convert_element_type(x, onp.float32)
+  nbits = onp.finfo(x).bits
+  signed_dtype = _INT_DTYPES[nbits]
+  unsigned_dtype = _UINT_DTYPES[nbits]
+
+  signed = bitcast_convert_type(x, signed_dtype)
+  unsigned = bitcast_convert_type(x, unsigned_dtype)
+  flipped = bitcast_convert_type(
+    sub(unsigned_dtype(onp.iinfo(signed_dtype).max), unsigned), signed_dtype)
+  return select(lt(signed, _zero(signed)), flipped, signed)
+
+# Default comparator that sorts the operands only on their first arguments.
+def _sort_lt_comparator(*operands):
+  assert len(operands) >= 2 and len(operands) % 2 == 0, operands
+  x, y = operands[:2]
+  assert x.dtype == y.dtype, (x.dtype, y.dtype)
+  if onp.issubdtype(x.dtype, onp.complexfloating):
+    x_keys = [_float_to_int_for_sort(real(x)), _float_to_int_for_sort(imag(x))]
+    y_keys = [_float_to_int_for_sort(real(y)), _float_to_int_for_sort(imag(y))]
+  elif onp.issubdtype(x.dtype, onp.floating):
+    x_keys = [_float_to_int_for_sort(x)]
+    y_keys = [_float_to_int_for_sort(y)]
+  else:
+    x_keys = [x]
+    y_keys = [y]
+
+  p = None
+  for xk, yk in zip(x_keys[::-1], y_keys[::-1]):
+    p = (bitwise_or(lt(xk, yk), bitwise_and(eq(xk, yk), p)) if p is not None
+         else lt(xk, yk))
+  return p
+
 def _sort_translation_rule(c, *operands, dimension):
-  out = xops.Sort(c, operands, dimension=dimension, is_stable=True)
+  types = [c.get_shape(x).xla_element_type() for x in operands]
+  subc = xla_bridge.make_computation_builder("sort_lt_comparator")
+  params = [xb.parameter(subc, 2 * i + j, xc.Shape.array_shape(typ, ()))
+            for i, typ in enumerate(types) for j in range(2)]
+  result = xla.lower_fun(_sort_lt_comparator,
+                         multiple_results=False)(subc, *params)
+  comparator = subc.build(result)
+  out = xops.Sort(c, operands, dimension=dimension, is_stable=True,
+                  comparator=comparator)
   return out if len(operands) != 1 else xops.Tuple(c, [out])
 
 def _sort_jvp(primals, tangents, *, dimension):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1307,9 +1307,10 @@ class LaxTest(jtu.JaxTestCase):
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSort(self, shape, dtype, axis):
-    if (jtu.device_under_test() == "cpu" and
-        onp.issubdtype(dtype, onp.complexfloating)):
-      raise SkipTest("Complex sort not implemented on CPU")
+    if (onp.issubdtype(dtype, onp.complexfloating) and (
+        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
+         jtu.device_under_test() == "tpu")):
+      raise SkipTest("Complex-valued sort not implemented")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     fun = lambda x: lax.sort(x, dimension=axis)
@@ -1323,9 +1324,10 @@ class LaxTest(jtu.JaxTestCase):
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSortAgainstNumpy(self, shape, dtype, axis):
-    if (jtu.device_under_test() == "cpu" and
-        onp.issubdtype(dtype, onp.complexfloating)):
-      raise SkipTest("Complex sort not implemented on CPU")
+    if (onp.issubdtype(dtype, onp.complexfloating) and (
+        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
+         jtu.device_under_test() == "tpu")):
+      raise SkipTest("Complex-valued sort not implemented")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.sort(x, dimension=axis)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1302,13 +1302,15 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in [onp.float32, onp.int32, onp.uint32]
+       "shape": shape, "dtype": dtype, "axis": axis}
+      for dtype in all_dtypes
       for shape in [(5,), (5, 7)]
-      for axis in [-1, len(shape) - 1]
-      for rng_factory in [jtu.rand_default]))
-  def testSort(self, shape, dtype, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      for axis in [-1, len(shape) - 1]))
+  def testSort(self, shape, dtype, axis):
+    if (jtu.device_under_test() == "cpu" and
+        onp.issubdtype(dtype, onp.complexfloating)):
+      raise SkipTest("Complex sort not implemented on CPU")
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     fun = lambda x: lax.sort(x, dimension=axis)
     self._CompileAndCheck(fun, args_maker, check_dtypes=True)
@@ -1316,13 +1318,15 @@ class LaxTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in [onp.float32, onp.int32, onp.uint32]
+        "shape": shape, "dtype": dtype, "axis": axis}
+      for dtype in all_dtypes
       for shape in [(5,), (5, 7)]
-      for axis in [-1, len(shape) - 1]
-      for rng_factory in [jtu.rand_default]))
-  def testSortAgainstNumpy(self, shape, dtype, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      for axis in [-1, len(shape) - 1]))
+  def testSortAgainstNumpy(self, shape, dtype, axis):
+    if (jtu.device_under_test() == "cpu" and
+        onp.issubdtype(dtype, onp.complexfloating)):
+      raise SkipTest("Complex sort not implemented on CPU")
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     op = lambda x: lax.sort(x, dimension=axis)
     numpy_op = lambda x: lax_reference.sort(x, axis)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1307,6 +1307,7 @@ class LaxTest(jtu.JaxTestCase):
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSort(self, shape, dtype, axis):
+    # TODO(b/141131288): enable complex-valued sorts on TPU.
     if (onp.issubdtype(dtype, onp.complexfloating) and (
         (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
          jtu.device_under_test() == "tpu")):
@@ -1324,6 +1325,7 @@ class LaxTest(jtu.JaxTestCase):
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSortAgainstNumpy(self, shape, dtype, axis):
+    # TODO(b/141131288): enable complex-valued sorts on TPU.
     if (onp.issubdtype(dtype, onp.complexfloating) and (
         (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
          jtu.device_under_test() == "tpu")):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1343,7 +1343,7 @@ class LaxTest(jtu.JaxTestCase):
           axis),
        "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
        "axis": axis}
-      for key_dtype in all_dtypes
+      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]))
@@ -1373,7 +1373,7 @@ class LaxTest(jtu.JaxTestCase):
           axis),
        "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
        "axis": axis}
-      for key_dtype in all_dtypes
+      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1341,15 +1341,19 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, key_dtype),
           jtu.format_shape_dtype_string(shape, val_dtype),
           axis),
-       "rng_factory": rng_factory, "shape": shape,
-       "key_dtype": key_dtype, "val_dtype": val_dtype, "axis": axis}
-      for key_dtype in [onp.float32, onp.int32, onp.uint32]
+       "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
+       "axis": axis}
+      for key_dtype in all_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
-      for axis in [-1, len(shape) - 1]
-      for rng_factory in [jtu.rand_default]))
-  def testSortKeyVal(self, shape, key_dtype, val_dtype, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      for axis in [-1, len(shape) - 1]))
+  def testSortKeyVal(self, shape, key_dtype, val_dtype, axis):
+    # TODO(b/141131288): enable complex-valued sorts on TPU.
+    if (onp.issubdtype(key_dtype, onp.complexfloating) and (
+        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
+         jtu.device_under_test() == "tpu")):
+      raise SkipTest("Complex-valued sort not implemented")
+    rng = jtu.rand_default(self.rng())
     # This test relies on the property that wherever keys are tied, values are
     # too, since we don't guarantee the same ordering of values with equal keys.
     # To avoid that case, we generate unique keys (globally in the key array).
@@ -1367,15 +1371,19 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, key_dtype),
           jtu.format_shape_dtype_string(shape, val_dtype),
           axis),
-       "rng_factory": rng_factory, "shape": shape,
-       "key_dtype": key_dtype, "val_dtype": val_dtype, "axis": axis}
-      for key_dtype in [onp.float32, onp.int32, onp.uint32]
+       "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
+       "axis": axis}
+      for key_dtype in all_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
-      for axis in [-1, len(shape) - 1]
-      for rng_factory in [jtu.rand_default]))
-  def testSortKeyValAgainstNumpy(self, shape, key_dtype, val_dtype, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      for axis in [-1, len(shape) - 1]))
+  def testSortKeyValAgainstNumpy(self, shape, key_dtype, val_dtype, axis):
+    # TODO(b/141131288): enable complex-valued sorts on TPU.
+    if (onp.issubdtype(key_dtype, onp.complexfloating) and (
+        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
+         jtu.device_under_test() == "tpu")):
+      raise SkipTest("Complex-valued sort not implemented")
+    rng = jtu.rand_default(self.rng())
     # This test relies on the property that wherever keys are tied, values are
     # too, since we don't guarantee the same ordering of values with equal keys.
     # To avoid that case, we generate unique keys (globally in the key array).


### PR DESCRIPTION
…exicographic ordering.

Implemented using a custom comparator, since the XLA-level default comparator doesn't impose an ordering for complex values.

Fixes #3074