### PR TITLE
Add sharded_jit translation rule.

### DIFF
--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -120,6 +120,21 @@ class ShardedJitTest(jtu.JaxTestCase):
 
 # TODO(skye): add error tests
 
+# Tests that don't need a TPU to run.
+class ShardedJitTestNoTpu(jtu.JaxTestCase):
+
+  def testTranslationRule(self):
+    @partial(sharded_jit, in_parts=(P(2, 1), P(2, 1)), out_parts=None)
+    def f(x, y):
+      return x + y
+
+    # Test that the translation rule runs without error and produces the
+    # OpShardings we expect somewhere.
+    shape = (8, 8)
+    hlo = jax.xla_computation(f)(np.ones(shape), np.ones(shape))
+    self.assertIn("sharding={devices=[2,1]0,1}", hlo.as_hlo_text())
+    self.assertIn("sharding={replicated}", hlo.as_hlo_text())
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
This is potentially dangerous, because it lets sharded_jit() be called
inside other calls primitives (e.g. jit, pmap) which isn't supported
yet. I'm adding it now because I'm planning to implement
pmap-of-sharded_jit soon, and it will help with testing a set_sharding
API I'm also planning to add soon.