### PR TITLE
Add with_sharding_constraint method to be used within sharded_jit.

### DIFF
--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -346,7 +346,7 @@ def _sharding_constraint_impl(x, partitions):
       "with_sharding_constraint() should only be called inside sharded_jit()")
 
 def _sharding_constraint_translation_rule(c, x_node, partitions):
-  return xb.with_sharding_constraint(c, x_node, partitions)
+  return xb.set_sharding(c, x_node, partitions)
 
 sharding_constraint_p = core.Primitive("sharding_constraint")
 sharding_constraint_p.def_impl(_sharding_constraint_impl)

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -360,10 +360,18 @@ def set_sharding(x, partitions: Optional[PartitionSpec]):
   and may change without warning!
 
   This should only be called inside a function transformed by ``sharded_jit``.
-  It refines how ``f`` is sharded. ``partitions`` must correspond to the same
-  number of total partitions dictated by the outer ``sharded_jit`` and any other
-  ``set_sharding`` calls. In the case where only replication has been specified,
-  any ``partitions`` are valid.
+  It constrains how the function is sharded: regardless of any other specified
+  partitions, the compiler will make sure that ``x`` is sharded according to
+  ``partitions``.  Note that a ``set_sharding`` call doesn't necessarily
+  correspond to a reshard, since the compiler is free to achieve this sharding
+  as long as the constraint is met, e.g. it might insert a reshard earlier in
+  the computation. Another way to think of this is that the ``set_sharding``
+  call may flow "up" the function to preceeding operations as well as "down" to
+  subsequent ones.
+
+  ``partitions`` must correspond to the same number of total partitions dictated
+  by the outer ``sharded_jit`` and any other ``set_sharding`` calls. In the case
+  where only replication has been specified, any ``partitions`` are valid.
 
   Example usage:
     @partial(sharded_jit, in_parts=None, out_parts=None, num_shards=2

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -217,7 +217,7 @@ def get_num_partitions(*partitions):
 
 
 def _inner_partitions(jaxpr, expected_num_parts: Optional[int]):
-  """Returns the total number of partitions from PartitonSpecs inside `jaxpr`.
+  """Returns the total number of partitions from PartitionSpecs inside `jaxpr`.
 
   Also validates that this number matches `expected_num_parts` if provided.
   """

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -366,7 +366,7 @@ def set_sharding(x, partitions: Optional[PartitionSpec]):
   correspond to a reshard, since the compiler is free to achieve this sharding
   as long as the constraint is met, e.g. it might insert a reshard earlier in
   the computation. Another way to think of this is that the ``set_sharding``
-  call may flow "up" the function to preceeding operations as well as "down" to
+  call may flow "up" the function to preceding operations as well as "down" to
   subsequent ones.
 
   ``partitions`` must correspond to the same number of total partitions dictated

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -147,7 +147,7 @@ class ShardedJitTest(jtu.JaxTestCase):
       sharded_jit(f, in_parts=P(2,2), out_parts=P(2,2))(x)
 
     # Replicated sharded_jit
-    actual = sharded_jit(f, in_parts=None, out_parts=None)
+    actual = sharded_jit(f, in_parts=None, out_parts=None)(x)
     self.assertAllClose(actual, expected, check_dtypes=False)
     self.assertLen(actual.device_buffers, 2)
     self.assertAllClose(actual.device_buffers[0].to_py(),

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -140,10 +140,10 @@ class ShardedJitTest(jtu.JaxTestCase):
     # Mismatched sharded_jit partitions
     with self.assertRaisesRegex(
         ValueError,
-        "with_sharding_constraint with partitions=PartitionSpec\(1, 2\) "
-        "\(total partitions: 2\) doesn't match expected number of partitions: "
-        "4. If these partitions look right, check outer sharded_jit and/or "
-        "other with_sharding_constraint calls."):
+        r"with_sharding_constraint with partitions=PartitionSpec\(1, 2\) "
+        r"\(total partitions: 2\) doesn't match expected number of partitions: "
+        r"4. If these partitions look right, check outer sharded_jit and/or "
+        r"other with_sharding_constraint calls."):
       sharded_jit(f, in_parts=P(2,2), out_parts=P(2,2))(x)
 
     # Replicated sharded_jit


### PR DESCRIPTION
See the with_sharding_constraint docstring for a description of what this method does.

Depending on how we decide nested sharded_jits should work, an
alternative implementation for with_sharding_constraint could be:
```python
def with_sharding_constraint(x, partitions):
    return sharded_jit(lambda x: x, in_parts=partitions, out_parts=partitions)
```
In this case, we could get rid of the with_sharding_constraint primitive, and
possibly even the API. This implementation gets the job done for now
without committing to a nested sharded_jit behavior, and is also much
easier to take the gradient of than sharded_jit.
