### PR TITLE
Add gradients to the scatter_max and scatter_min operations.

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2629,6 +2629,68 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     check_grads(f, (rng((5, 5), onp.float32),), 2, ["fwd", "rev"], 1e-2, 1e-2,
                 1.)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
+          jtu.format_shape_dtype_string(arg_shape, dtype),
+          idxs, update_shape, dnums),
+       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
+      for dtype in grad_float_dtypes
+      for arg_shape, idxs, update_shape, dnums in [
+          ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
+            update_window_dims=(), inserted_window_dims=(0,),
+            scatter_dims_to_operand_dims=(0,))),
+          ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
+            update_window_dims=(1,), inserted_window_dims=(),
+            scatter_dims_to_operand_dims=(0,))),
+          ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
+            update_window_dims=(1,), inserted_window_dims=(0,),
+            scatter_dims_to_operand_dims=(0,))),
+      ]
+      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterMax(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory(self.rng())
+    rng_idx = rng_idx_factory(self.rng())
+    idxs = rng_idx(idxs.shape, idxs.dtype)
+    scatter_max = lambda x, y: lax.scatter_max(x, idxs, y, dnums)
+    x = rng(arg_shape, dtype)
+    y = rng(update_shape, dtype)
+    check_grads(scatter_max, (x, y), 2, ["fwd", "rev"], 1e-2, 1e-2)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
+          jtu.format_shape_dtype_string(arg_shape, dtype),
+          idxs, update_shape, dnums),
+       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
+       "update_shape": update_shape, "dnums": dnums,
+       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
+      for dtype in grad_float_dtypes
+      for arg_shape, idxs, update_shape, dnums in [
+          ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
+            update_window_dims=(), inserted_window_dims=(0,),
+            scatter_dims_to_operand_dims=(0,))),
+          ((10,), onp.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
+            update_window_dims=(1,), inserted_window_dims=(),
+            scatter_dims_to_operand_dims=(0,))),
+          ((10, 5,), onp.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
+            update_window_dims=(1,), inserted_window_dims=(0,),
+            scatter_dims_to_operand_dims=(0,))),
+      ]
+      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
+      for rng_factory in [jtu.rand_default]))
+  def testScatterMin(self, arg_shape, dtype, idxs, update_shape, dnums,
+                     rng_factory, rng_idx_factory):
+    rng = rng_factory(self.rng())
+    rng_idx = rng_idx_factory(self.rng())
+    idxs = rng_idx(idxs.shape, idxs.dtype)
+    scatter_min = lambda x, y: lax.scatter_min(x, idxs, y, dnums)
+    x = rng(arg_shape, dtype)
+    y = rng(update_shape, dtype)
+    check_grads(scatter_min, (x, y), 2, ["fwd", "rev"], 1e-2, 1e-2)
+
   def testStopGradient(self):
     def f(x):
       return lax.sin(x) * lax.cos(lax.stop_gradient(x))


### PR DESCRIPTION

This is being done to allow the creation of a differentiable segment_max. Segment_max is an important operation for GraphNets and is an open feature request at https://github.com/google/jax/issues/2255