### PR TITLE
Fix a corner case in `repeat`.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2366,7 +2366,7 @@ def _repeat_scalar(a, repeats, axis=None):
   if not isscalar(repeats):
     raise NotImplementedError(
         "_repeat_scalar implementation only supports scalar repeats")
-  if axis is None or isscalar(a):
+  if axis is None or isscalar(a) or len(shape(a)) == 0:
     a = ravel(a)
     axis = 0
   a_shape = list(shape(a))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1114,7 +1114,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_default}
       for repeats in [0, 1, 2]
       for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
-      for axis in [None] + list(range(-len(shape), len(shape)))))
+      for axis in [None] + list(range(-len(shape), max(1, len(shape))))))
   def testRepeat(self, axis, shape, dtype, repeats, rng_factory):
     rng = rng_factory(self.rng())
     onp_fun = lambda arg: onp.repeat(arg, repeats=repeats, axis=axis)


### PR DESCRIPTION
`jnp.repeat(jnp.array(0), 1, axis=0)` throws an error whereas `np.repeat(np.array(0), 1, axis=0) => np.array([0])`.