### PR TITLE
Fix the handling of repeated vmap for id_tap

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -25,6 +25,12 @@ jax 0.1.68 (May 21, 2020)
     to both branches
     `#2993 <https://github.com/google/jax/pull/2993>`_.
 
+* Notable changes:
+
+  * The format of the `transforms` keyword for the `lax.experimental.host_callback.id_tap`
+    primitive has changed `#3132 <https://github.com/google/jax/pull/3132>`_.
+
+
 jax 0.1.67 (May 12, 2020)
 ---------------------------
 

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -71,30 +71,34 @@ following function definition::
      _, y = id_print(x, y, what="x,x^2")
      return y * x
 
+During JAX transformations the special parameters ``transforms`` is extended
+with a dictionary, containing the key ``name`` holding the name of the
+transformation and additional keys holding transformation parameters, if
+applicable.
 
-For :func:`jax.vmap` the arguments are batched, ``('batch', batch_dims)`` is
-appended to ``transforms``, where ``batch_dims`` specifies the tuple of
-batched dimensions::
+For :func:`jax.vmap` the arguments are batched, and ``transforms`` is extended
+with transformation name ``batch`` and ``batch_dims`` set to the the tuple of
+batched dimensions (one entry per argument, ``None`` denotes an argument that
+was broadcast)::
 
   jax.vmap(power3)(np.arange(3.))
-  # what=x,x^2 transforms=(batch, (0, 0)): ([0, 1, 2], [0, 1, 4])
-
+  # what=x,x^2 transforms=({name=batch, batch_dims=(0, 0)}): ([0, 1, 2], [0, 1, 4])
 
 For :func:`jax.jvp` there will be two callbacks, one with the values of
 the primals and one with the tangents::
 
   jax.jvp(power3, (3.,), (0.1,))
   # what=x,x^2: (3., 9.)
-  # what=x,x^2 transforms=(jvp): (0.1, 0.6)
+  # what=x,x^2 transforms={name=jvp}: (0.1, 0.6)
 
-For :func:`jax.vjp` or :func:`jax.grad` there will be one callback with the values of
-the adjoints for the arguments. You may also see a callback with the values of
-the primals from the forward pass, if those values are needed for the
-backward pass::
+For :func:`jax.vjp` or :func:`jax.grad` there will be one callback with the
+values of the adjoints for the arguments. You may also see a callback with
+the values of the primals from the forward pass, if those values are needed for
+the backward pass::
 
   jax.grad(power3)(3.)
   # what=x,x^2: (3., 9.)  # from forward pass, since y is needed in backward pass
-  # what=x,x^2 transforms=((jvp,), (transpose,)): (0., 3.)  # from backward pass, adjoints of _, y
+  # what=x,x^2 transforms=({name=jvp}, {name=transpose}): (0., 3.)  # from backward pass, adjoints of _, y
 
 See documentation for :func:`id_tap` and :func:`id_print`.
 For usage example, see tests/host_callback_test.py.
@@ -242,6 +246,23 @@ class _ConsumerCallable(NamedTuple):
   kwargs: Tuple[Tuple[str, Any], ...]
   arg_treedef: Any
 
+  def unpack_kwargs(self):
+    kwargs = dict(self.kwargs)
+    transforms = kwargs.get("transforms")
+    if transforms is None:
+      return kwargs
+    else:
+      def unpack_transform(name, *params):
+        if name == "batch":
+          return dict(name=name, batch_dims=params[0])
+        elif name == "mask":
+          return dict(name=name, logical_shapes=params[0])
+        else:
+          assert not params, f"{name}, {params}"
+          return dict(name=name)
+      return dict(kwargs,
+                  transforms=tuple([unpack_transform(*t) for t in transforms]))
+
 _consumer_registry: Dict[_ConsumerCallable, int] = dict()
 _consumer_registry_by_id: Dict[int, _ConsumerCallable] = dict()
 
@@ -311,7 +332,8 @@ positional arguments and parameters:
     element of the tuple is itself a tuple with the first element the name
     of the transform. The remaining elements depend on the transform. For 
     example, for `batch`, the parameters are the dimensions that have been 
-    batched, and for `mask` the logical shapes. 
+    batched, and for `mask` the logical shapes. These are unpacked by 
+    _ConsumerCallable before passing to the user function.
 
   * the remaining parameters are passed to the tap function.
 """
@@ -319,13 +341,16 @@ id_tap_p = core.Primitive("id_tap")
 id_tap_p.multiple_results = True
 xla.outfeed_primitives.add(id_tap_p)
 
-def _add_transform_name(params: Dict, transform: str,
-                        *transform_params) -> Dict:
-  """Adds the `transform` to the params["transforms"]."""
-  new_transform = (transform, *transform_params)
+def _add_transform(params: Dict, name: str,
+                   *transform_params) -> Dict:
+  """Adds the `transform` to the params["transforms"].
+
+  Uses a tuple representation internally, will be unpacked before the
+  callback by _ConsumerCallable.
+  """
+  new_transform = (name, *transform_params)
   return dict(params, transforms=(params.get("transforms", ())
                                   + (new_transform,)))
-
 
 def _id_tap_impl(*arrays, **params):
   # We use the jitted-version of the primitive even for eager execution, both
@@ -369,7 +394,7 @@ def _id_tap_jvp_rule(primals, tangents, *, func, nr_untapped=0, **params):
   tangent_zeros = tuple(map(_instantiate_zeros, primals, tangents))
   out_tangents_extra = id_tap_p.bind(*tangent_zeros, out_primals[0],
                                      func=func, nr_untapped=nr_untapped + 1,
-                                     **_add_transform_name(params, "jvp"))
+                                     **_add_transform(params, "jvp"))
   return tuple(out_primals), tuple(out_tangents_extra[:-1])
 
 ad.primitive_jvps[id_tap_p] = _id_tap_jvp_rule
@@ -379,14 +404,14 @@ def _id_tap_transpose_rule(cts, *args, func=None, nr_untapped=0, **params):
   assert len(cts) == len(args)
   cts_zeros = tuple(map(_instantiate_zeros, args, cts))
   ct_args = id_tap_p.bind(*cts_zeros, func=func, nr_untapped=nr_untapped,
-                          **_add_transform_name(params, "transpose"))
+                          **_add_transform(params, "transpose"))
   return ct_args
 
 ad.primitive_transposes[id_tap_p] = _id_tap_transpose_rule
 
 
 def _id_tap_batching_rule(batched_args, batch_dims, **params):
-  new_params = _add_transform_name(params, "batch", batch_dims)
+  new_params = _add_transform(params, "batch", batch_dims)
   res = id_tap_p.bind(*batched_args, **new_params)
   return res, batch_dims
 
@@ -399,8 +424,8 @@ batching.primitive_batchers[id_tap_p] = _id_tap_batching_rule
 # masking.shape_rules[id_tap_p] = _id_tap_shape_rule  # type: ignore[module-attr]
 
 def _id_tap_masking_rule(operands, operands_logical_shapes, **params):
-  new_params = _add_transform_name(params, "mask",
-                                   operands_logical_shapes)
+  new_params = _add_transform(params, "mask",
+                              operands_logical_shapes)
   return id_tap_p.bind(*operands, **new_params)
 
 masking.masking_rules[id_tap_p] = _id_tap_masking_rule
@@ -755,7 +780,7 @@ def outfeed_receiver(*,
         continue  # We need to read the entire outfeed
       try:
         arg = api.tree_unflatten(consumer.arg_treedef, arrays)
-        consumer.func(arg, **dict(consumer.kwargs))  # type: ignore[attribute-error]
+        consumer.func(arg, **consumer.unpack_kwargs())  # type: ignore[attribute-error]
       except Exception as e:
         logging.error(f"Postponing exception raised in tap function: {str(e)}\n{traceback.format_exc()}")
         count_tap_exceptions += 1

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -755,11 +755,11 @@ what: x3
     assertMultiLineStrippedEqual(self, """
 what: a * 2
 10.00
-transforms: (('jvp',),) what: a * 2
+transforms: ({'name': 'jvp'},) what: a * 2
 0.20
 what: y * 3
 30.00
-transforms: (('jvp',),) what: y * 3
+transforms: ({'name': 'jvp'},) what: y * 3
 0.60""", testing_stream.output)
     testing_stream.reset()
 
@@ -777,7 +777,7 @@ transforms: (('jvp',),) what: y * 3
 
     # Just making the Jaxpr invokes the id_print once
     assertMultiLineStrippedEqual(self, """
-transforms: (('jvp',), ('transpose',)) what: x * 3
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 3
 2.00""", testing_stream.output)
     testing_stream.reset()
     
@@ -788,7 +788,7 @@ transforms: (('jvp',), ('transpose',)) what: x * 3
     assertMultiLineStrippedEqual(self, """
 what: x * 3
 15.00
-transforms: (('jvp',), ('transpose',)) what: x * 3
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 3
 2.00""", testing_stream.output)
     testing_stream.reset()
 
@@ -834,9 +834,9 @@ what: x * 2
 10.00
 what: y * 3
 30.00
-transforms: (('jvp',), ('transpose',)) what: y * 3
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: y * 3
 5.00
-transforms: (('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 15.00""", testing_stream.output)
     testing_stream.reset()
 
@@ -853,9 +853,9 @@ transforms: (('jvp',), ('transpose',)) what: x * 2
   in (12.00,) }""", str(api.make_jaxpr(grad_func)(5.)))
       # Just making the Jaxpr invokes the id_print twiceonce
       assertMultiLineStrippedEqual(self, """
-transforms: (('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 3.00
-transforms: (('jvp',), ('transpose',), ('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}, {'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 2.00""", testing_stream.output)
       testing_stream.reset()
       res_grad = grad_func(jnp.float32(5.))
@@ -864,11 +864,11 @@ transforms: (('jvp',), ('transpose',), ('jvp',), ('transpose',)) what: x * 2
     assertMultiLineStrippedEqual(self, """
 what: x * 2
 10.00
-transforms: (('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 15.00
-transforms: (('jvp',), ('transpose',), ('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}, {'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 2.00
-transforms: (('jvp',), ('transpose',)) what: x * 2
+transforms: ({'name': 'jvp'}, {'name': 'transpose'}) what: x * 2
 3.00""", testing_stream.output)
     testing_stream.reset()
 
@@ -893,9 +893,9 @@ transforms: (('jvp',), ('transpose',)) what: x * 2
     with hcb.outfeed_receiver():
       res_vmap = vmap_fun1(vargs)
     assertMultiLineStrippedEqual(self, """
-transforms: (('batch', (0,)),) what: a * 2
+transforms: ({'name': 'batch', 'batch_dims': (0,)},) what: a * 2
 [ 8.00 10.00]
-transforms: (('batch', (0, 0)),) what: y * 3
+transforms: ({'name': 'batch', 'batch_dims': (0, 0)},) what: y * 3
 [24.00 30.00]""", testing_stream.output)
     testing_stream.reset()
 
@@ -918,10 +918,9 @@ transforms: (('batch', (0, 0)),) what: y * 3
     with hcb.outfeed_receiver():
       res_vmap = vmap_func(vargs)
     assertMultiLineStrippedEqual(self, """
-transforms: (('batch', (None, 0)),)
+transforms: ({'name': 'batch', 'batch_dims': (None, 0)},)
 [ 3.00
-  [4.00 5.00] ]
-   """, testing_stream.output)
+  [4.00 5.00] ]""", testing_stream.output)
     testing_stream.reset()
 
   def test_double_vmap(self):
@@ -949,7 +948,7 @@ transforms: (('batch', (None, 0)),)
     with hcb.outfeed_receiver():
       res_vmap = sum_all(xv, yv)
     assertMultiLineStrippedEqual(self, """
-transforms: (('batch', (0,)), ('batch', (0,)))
+transforms: ({'name': 'batch', 'batch_dims': (0,)}, {'name': 'batch', 'batch_dims': (0,)})
 [[0 1 2 3 4]
  [1 2 3 4 5]
  [2 3 4 5 6]]""", testing_stream.output)

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -736,13 +736,13 @@ what: x3
       j k = id_tap[ arg_treedef=*
                     func=_print
                     nr_untapped=1
-                    transforms=('jvp',)
+                    transforms=(('jvp',),)
                     what=a * 2 ] i d
       l = mul j 3.00
       m n o = id_tap[ arg_treedef=*
                       func=_print
                       nr_untapped=2
-                      transforms=('jvp',)
+                      transforms=(('jvp',),)
                       what=y * 3 ] l j f
       p = mul 2.00 g
       q = mul n p
@@ -755,11 +755,11 @@ what: x3
     assertMultiLineStrippedEqual(self, """
 what: a * 2
 10.00
-transforms: ('jvp',) what: a * 2
+transforms: (('jvp',),) what: a * 2
 0.20
 what: y * 3
 30.00
-transforms: ('jvp',) what: y * 3
+transforms: (('jvp',),) what: y * 3
 0.60""", testing_stream.output)
     testing_stream.reset()
 
@@ -777,7 +777,7 @@ transforms: ('jvp',) what: y * 3
 
     # Just making the Jaxpr invokes the id_print once
     assertMultiLineStrippedEqual(self, """
-transforms: ('jvp', 'transpose') what: x * 3
+transforms: (('jvp',), ('transpose',)) what: x * 3
 2.00""", testing_stream.output)
     testing_stream.reset()
     
@@ -788,7 +788,7 @@ transforms: ('jvp', 'transpose') what: x * 3
     assertMultiLineStrippedEqual(self, """
 what: x * 3
 15.00
-transforms: ('jvp', 'transpose') what: x * 3
+transforms: (('jvp',), ('transpose',)) what: x * 3
 2.00""", testing_stream.output)
     testing_stream.reset()
 
@@ -803,13 +803,13 @@ transforms: ('jvp', 'transpose') what: x * 3
       c d = id_tap[ arg_treedef=*
                     func=_print
                     nr_untapped=1
-                    transforms=('jvp', 'transpose')
+                    transforms=(('jvp',), ('transpose',))
                     what=y * 3 ] b 0.00
       e = mul c 3.00
       f g = id_tap[ arg_treedef=*
                     func=_print
                     nr_untapped=1
-                    transforms=('jvp', 'transpose')
+                    transforms=(('jvp',), ('transpose',))
                     what=x * 2 ] e 0.00
       h = mul f 2.00
       i = mul a 2.00
@@ -834,9 +834,9 @@ what: x * 2
 10.00
 what: y * 3
 30.00
-transforms: ('jvp', 'transpose') what: y * 3
+transforms: (('jvp',), ('transpose',)) what: y * 3
 5.00
-transforms: ('jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',)) what: x * 2
 15.00""", testing_stream.output)
     testing_stream.reset()
 
@@ -853,9 +853,9 @@ transforms: ('jvp', 'transpose') what: x * 2
   in (12.00,) }""", str(api.make_jaxpr(grad_func)(5.)))
       # Just making the Jaxpr invokes the id_print twiceonce
       assertMultiLineStrippedEqual(self, """
-transforms: ('jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',)) what: x * 2
 3.00
-transforms: ('jvp', 'transpose', 'jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',), ('jvp',), ('transpose',)) what: x * 2
 2.00""", testing_stream.output)
       testing_stream.reset()
       res_grad = grad_func(jnp.float32(5.))
@@ -864,11 +864,11 @@ transforms: ('jvp', 'transpose', 'jvp', 'transpose') what: x * 2
     assertMultiLineStrippedEqual(self, """
 what: x * 2
 10.00
-transforms: ('jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',)) what: x * 2
 15.00
-transforms: ('jvp', 'transpose', 'jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',), ('jvp',), ('transpose',)) what: x * 2
 2.00
-transforms: ('jvp', 'transpose') what: x * 2
+transforms: (('jvp',), ('transpose',)) what: x * 2
 3.00""", testing_stream.output)
     testing_stream.reset()
 


### PR DESCRIPTION
This is for #3126. 

Since for most transformations we don't have parameters, I am proposing that `transforms` is still a tuple of strings most of the time, except for `vmap` and `mask` where instead of a string we use a pair of `batch` and the batch dimensions.  