### PR TITLE
Expand type support for random uniform() & randint()

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -77,6 +77,8 @@ _dtype_to_32bit_dtype = {
 @util.memoize
 def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on FLAGS.jax_enable_x64."""
+  if isinstance(dtype, str) and dtype == "bfloat16":
+    dtype = bfloat16
   dtype = np.dtype(dtype)
 
   if FLAGS.jax_enable_x64:
@@ -120,7 +122,8 @@ iinfo = np.iinfo
 def finfo(dtype):
   # Since NumPy doesn't consider bfloat16 a floating-point type, we have to
   # provide an alternative implementation of finfo that does so.
-  if np.result_type(dtype) == _bfloat16_dtype:
+  if ((isinstance(dtype, str) and dtype == "bfloat16") or
+      np.result_type(dtype) == _bfloat16_dtype):
     return _bfloat16_finfo
   else:
     return np.finfo(dtype)

--- a/jax/random.py
+++ b/jax/random.py
@@ -350,7 +350,7 @@ def _uniform(key, shape, dtype, minval, maxval):
   _check_shape("uniform", shape)
   if not np.issubdtype(dtype, onp.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
-  
+
   minval = lax.convert_element_type(minval, dtype)
   maxval = lax.convert_element_type(maxval, dtype)
   finfo = np.finfo(dtype)

--- a/jax/random.py
+++ b/jax/random.py
@@ -350,13 +350,13 @@ def _uniform(key, shape, dtype, minval, maxval):
   _check_shape("uniform", shape)
   if not np.issubdtype(dtype, onp.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
-
+  
   minval = lax.convert_element_type(minval, dtype)
   maxval = lax.convert_element_type(maxval, dtype)
   finfo = np.finfo(dtype)
   nbits, nmant = finfo.bits, finfo.nmant
 
-  if nbits not in (32, 64):
+  if nbits not in (16, 32, 64):
     raise TypeError("uniform only accepts 32- or 64-bit dtypes.")
 
   bits = _random_bits(key, nbits, shape)
@@ -367,7 +367,7 @@ def _uniform(key, shape, dtype, minval, maxval):
   # equivalent float representations, which might not be true on all platforms.
   float_bits = lax.bitwise_or(
       lax.shift_right_logical(bits, onp.array(nbits - nmant, lax.dtype(bits))),
-      onp.array(1., dtype).view(onp.uint32 if nbits == 32 else onp.uint64))
+      onp.array(1., dtype).view(_UINT_DTYPES[nbits]))
   floats = lax.bitcast_convert_type(float_bits, dtype) - onp.array(1., dtype)
   return lax.max(
       minval,
@@ -408,8 +408,8 @@ def _randint(key, shape, minval, maxval, dtype):
   maxval = lax.convert_element_type(maxval, dtype)
   nbits = np.iinfo(dtype).bits
 
-  if nbits not in (32, 64):
-    raise TypeError("randint only accepts 32- or 64-bit dtypes.")
+  if nbits not in (8, 16, 32, 64):
+    raise TypeError("randint only accepts 8-, 16-, 32-, or 64-bit dtypes.")
 
   # if we don't have minval < maxval, just always return minval
   # https://github.com/google/jax/issues/222
@@ -422,16 +422,15 @@ def _randint(key, shape, minval, maxval, dtype):
   rbits = lambda key: _random_bits(key, nbits, shape)
   higher_bits, lower_bits = rbits(k1), rbits(k2)
 
-  unsigned_dtype = onp.uint32 if nbits == 32 else onp.uint64
+  unsigned_dtype = _UINT_DTYPES[nbits]
   span = lax.convert_element_type(maxval - minval, unsigned_dtype)
 
   # To compute a remainder operation on an integer that might have twice as many
   # bits as we can represent in the native unsigned dtype, we compute a
-  # multiplier equal to 2**nbits % span (using that nbits is 32 or 64).
-  multiplier = lax.rem(onp.array(2**16, unsigned_dtype), span)
+  # multiplier equal to 2**nbits % span. To avoid overflow, we use the identity:
+  #  (a * b) % N = [(a % N) * (b % N)] % N
+  multiplier = lax.rem(lax._const(span, 2 ** (nbits // 2)), span)
   multiplier = lax.rem(lax.mul(multiplier, multiplier), span)
-  if nbits == 64:
-    multiplier = lax.rem(lax.mul(multiplier, multiplier), span)
 
   random_offset = lax.add(lax.mul(lax.rem(higher_bits, span), multiplier),
                           lax.rem(lower_bits, span))

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -38,6 +38,13 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
+def supported_dtypes(dtypes):
+  return [t for t in dtypes if t in jtu.supported_dtypes()]
+
+float_dtypes = supported_dtypes([jnp.bfloat16, np.float16, np.float32, np.float64])
+int_dtypes = supported_dtypes([np.int8, np.int16, np.int32, np.int64])
+uint_dtypes = supported_dtypes([np.uint8, np.uint16, np.uint32, np.uint64])
+
 class LaxRandomTest(jtu.JaxTestCase):
 
   def _CheckCollisions(self, samples, nbits):
@@ -157,7 +164,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
-      for dtype in [jnp.bfloat16, np.float16, np.float32, np.float64]))
+      for dtype in float_dtypes))
   def testRngUniform(self, dtype):
     key = random.PRNGKey(0)
     rand = lambda key: random.uniform(key, (10000,), dtype)
@@ -172,12 +179,8 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
-      for dtype in [np.int8, np.int16, np.int32, np.int64,
-                    np.uint8, np.uint16, np.uint32, np.uint64]))
+      for dtype in int_dtypes + uint_dtypes))
   def testRngRandint(self, dtype):
-    if dtype == np.int8 and jtu.device_under_test() == 'tpu':
-      raise SkipTest("8-bit inputs not supported on TPU")
-
     lo = 5
     hi = 10
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -166,6 +166,8 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
       for dtype in float_dtypes))
   def testRngUniform(self, dtype):
+    if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
+      raise SkipTest("rng.uniform() not supported on TPU for 16-bit types.")
     key = random.PRNGKey(0)
     rand = lambda key: random.uniform(key, (10000,), dtype)
     crand = api.jit(rand)
@@ -181,6 +183,8 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
       for dtype in int_dtypes + uint_dtypes))
   def testRngRandint(self, dtype):
+    if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
+      raise SkipTest("rng.randint() not supported on TPU for 8- or 16-bit types.")
     lo = 5
     hi = 10
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -167,7 +167,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       for dtype in float_dtypes))
   def testRngUniform(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
-      raise SkipTest("rng.uniform() not supported on TPU for 16-bit types.")
+      raise SkipTest("random.uniform() not supported on TPU for 16-bit types.")
     key = random.PRNGKey(0)
     rand = lambda key: random.uniform(key, (10000,), dtype)
     crand = api.jit(rand)
@@ -184,7 +184,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       for dtype in int_dtypes + uint_dtypes))
   def testRngRandint(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
-      raise SkipTest("rng.randint() not supported on TPU for 8- or 16-bit types.")
+      raise SkipTest("random.randint() not supported on TPU for 8- or 16-bit types.")
     lo = 5
     hi = 10
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -127,7 +127,6 @@ class LaxRandomTest(jtu.JaxTestCase):
       nbits = [32]
     rand_bits = [random._random_bits(key, n, (N * 64 // n,)) for n in nbits]
     rand_bits_32 = np.array([np.array(r).view(np.uint32) for r in rand_bits])
-    print(rand_bits_32)
     assert np.all(rand_bits_32 == rand_bits_32[0])
 
   def testRngRandomBits(self):
@@ -158,7 +157,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
-      for dtype in [np.float32, np.float64]))
+      for dtype in [jnp.bfloat16, np.float16, np.float32, np.float64]))
   def testRngUniform(self, dtype):
     key = random.PRNGKey(0)
     rand = lambda key: random.uniform(key, (10000,), dtype)
@@ -173,8 +172,12 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
-      for dtype in [np.int32, np.int64]))
+      for dtype in [np.int8, np.int16, np.int32, np.int64,
+                    np.uint8, np.uint16, np.uint32, np.uint64]))
   def testRngRandint(self, dtype):
+    if dtype == np.int8 and jtu.device_under_test() == 'tpu':
+      raise SkipTest("8-bit inputs not supported on TPU")
+
     lo = 5
     hi = 10
 


### PR DESCRIPTION
Adds `float16` and `bfloat16` support to `uniform()`, and `(u)int8` & `(u)int16` support to `randInt`