### PR TITLE
Add a primitive integer_pow() for values raised to a fixed integer scalar.

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -261,6 +261,15 @@ def _pow_taylor(primals_in, series_in):
   return primal_out, series_out
 jet_rules[lax.pow_p] = _pow_taylor
 
+def _integer_pow_taylor(primals_in, series_in, *, y):
+  if y == 2:
+    fn = lambda x: x * x
+  else:
+    fn = lambda x: lax.pow(x, onp.array(y, dtype=x.dtype))
+  return jet(fn, primals_in, series_in)
+jet_rules[lax.integer_pow_p] = _integer_pow_taylor
+
+
 def _expit_taylor(primals_in, series_in):
   x, = primals_in
   series, = series_in

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -144,6 +144,8 @@ from .lax import (
   index_take,
   infeed,
   infeed_p,
+  integer_pow,
+  integer_pow_p,
   iota,
   is_finite,
   is_finite_p,

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -182,8 +182,7 @@ def gelu(x):
   <https://arxiv.org/abs/1606.08415>`_, section 2.
   """
   sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)
-  x_cubed = lax.integer_pow(x, 3)
-  cdf = 0.5 * (1.0 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * x_cubed)))
+  cdf = 0.5 * (1.0 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * (x ** 3))))
   return x * cdf
 
 def glu(x, axis=-1):

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -182,9 +182,7 @@ def gelu(x):
   <https://arxiv.org/abs/1606.08415>`_, section 2.
   """
   sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)
-  # Does not use the power operator here.
-  # See https://github.com/google/jax/pull/3036
-  x_cubed = x * x * x
+  x_cubed = lax.integer_pow(x, 3)
   cdf = 0.5 * (1.0 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * x_cubed)))
   return x * cdf
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -528,16 +528,8 @@ def power(x1, x2):
   # Using lax.pow may be imprecise for floating-point values; the goal of this
   # code path is to make sure we end up with a precise output for the common
   # pattern ``x ** 2`` or similar.
-  if isinstance(x2, int) and 0 <= x2 <= 64:
-    x1 = asarray(x1)
-    acc = None
-    while x2 > 0:
-      if x2 & 1:
-        acc = x1 if acc is None else lax.mul(acc, x1)
-      x2 >>= 1
-      if x2 > 0:
-        x1 = lax.mul(x1, x1)
-    return ones_like(x1) if acc is None else acc
+  if isinstance(x2, int):
+    return lax.integer_pow(x1, x2)
 
   x1, x2 = _promote_args(np.power, x1, x2)
   dtype = _dtype(x1)
@@ -815,7 +807,7 @@ def cbrt(x):
 
 
 @_wraps(np.square)
-def square(x): return lax.mul(x, x)
+def square(x): return lax.integer_pow(x, 2)
 
 
 @_wraps(np.deg2rad)
@@ -888,7 +880,7 @@ def hypot(x1, x2):
 @_wraps(np.reciprocal)
 def reciprocal(x):
   x, = _promote_dtypes_inexact(x)
-  return lax.div(lax._const(x, 1), x)
+  return lax.integer_pow(x, -1)
 
 
 @_wraps(np.sinc, update_doc=False)

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -143,7 +143,7 @@ class HostCallbackTest(jtu.JaxTestCase):
                     func=_print
                     nr_untapped=1
                     what=y * 3 ] d c
-      g = mul f f
+      g = integer_pow[ y=2 ] f
   in (g,) }""", str(api.make_jaxpr(fun1)(5.)))
     self.assertEqual("", testing_stream.output)
 
@@ -731,7 +731,7 @@ what: x3
                     func=_print
                     nr_untapped=1
                     what=y * 3 ] e d
-      h = mul g g
+      h = integer_pow[ y=2 ] g
       i = mul b 2.00
       j k = id_tap[ arg_treedef=*
                     func=_print
@@ -744,10 +744,9 @@ what: x3
                       nr_untapped=2
                       transforms=('jvp',)
                       what=y * 3 ] l j f
-      p = mul n g
-      q = mul g n
-      r = add_any p q
-  in (h, r) }""",
+      p = mul 2.00 g
+      q = mul n p
+  in (h, q) }""",
                                  str(api.make_jaxpr(jvp_fun1)(jnp.float32(5.), jnp.float32(0.1))))
     with hcb.outfeed_receiver():
       res_primals, res_tangents = jvp_fun1(jnp.float32(5.), jnp.float32(0.1))
@@ -892,7 +891,7 @@ transforms: ('jvp', 'transpose') what: x * 2
                     nr_untapped=1
                     transforms=('batch',)
                     what=y * 3 ] d c
-      g = mul f f
+      g = integer_pow[ y=2 ] f
   in (g,) }""", str(api.make_jaxpr(vmap_fun1)(vargs)))
     with hcb.outfeed_receiver():
       res_vmap = vmap_fun1(vargs)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2668,6 +2668,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     tol = 1e-1 if num_float_bits(onp.float64) == 32 else 1e-3
     check_grads(lax.rem, (x, y), 2, ["fwd", "rev"], tol, tol)
 
+  def testHigherOrderGradientOfReciprocal(self):
+    # Regression test for https://github.com/google/jax/issues/3136
+    def inv(x):
+      # N.B.: intentionally written as 1/x, not x ** -1 or reciprocal(x)
+      return 1 / x
+    grad_fn = jax.grad(jax.grad(jax.grad(jax.grad(jax.grad(jax.grad(inv))))))
+    self.assertAllClose(onp.float32(0.0439453125), grad_fn(onp.float32(4.)),
+                        check_dtypes=True)
 
 def all_bdims(*shapes):
   bdims = (itertools.chain([cast(Optional[int], None)],


### PR DESCRIPTION
Use `integer_pow()` in the RHS JVP of `div()`. Also use it in `square()` and `reciprocal()`.

Fixes #3136

```
In [1]: from jax import grad, make_jaxpr
In [2]: def inv(x): return 1/x
In [3]: print(grad(grad(grad(grad(grad(grad(inv))))))(4.))
0.043945312

In [4]: make_jaxpr(grad(grad(grad(grad(grad(grad(inv)))))))(4.)
Out[4]:
{ lambda  ; a.
  let b = integer_pow[ y=-7 ] a
      c = mul -6.0 b
      d = mul -120.0 c
  in (d,) }

In [5]:
```