### PR TITLE
Fix arr.view() on TPU

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3977,12 +3977,14 @@ def _view(arr, dtype=None, type=None):
   if dtype is None:
     return arr
   arr_dtype = _dtype(arr)
+  if arr_dtype == dtype:
+    return arr
+  nbits_in = 8 * arr_dtype.itemsize
+  nbits_out = 8 * _dtype(dtype).itemsize
   # bool is implemented as lax:PRED, which is not compatible with lax.bitcast_convert_type.
   # We work around this by casting bool to uint8.
   if arr_dtype == bool_:
     arr = arr.astype(uint8)
-  nbits_in = 8 * arr_dtype.itemsize
-  nbits_out = 8 * _dtype(dtype).itemsize
   if nbits_in == nbits_out:
     if dtype == bool_:
       return lax.bitcast_convert_type(arr, uint8).astype(dtype)
@@ -3995,17 +3997,15 @@ def _view(arr, dtype=None, type=None):
     raise NotImplementedError(f"arr.view() for arr.dtype={arr_dtype}")
   if nbits_out not in byte_dtypes:
     raise NotImplementedError(f"arr.view(dtype) for dtype={dtype}")
-  shifts_in = arange(0, nbits_in, 8, dtype=np.uint8)
-  shifts_out = arange(0, nbits_out, 8, dtype=byte_dtypes[nbits_out])
-  # Cast input to like-size bytes:
   arr_bytes = lax.bitcast_convert_type(arr, byte_dtypes[nbits_in])
-  # Extract uint8
-  arr_bytes = ((arr_bytes[..., newaxis] >> shifts_in) & 255).astype(np.uint8)
-  # Reshape for output bytes
-  arr_bytes = arr_bytes.reshape(arr.shape[:-1] + (-1, nbits_out // 8)).astype(byte_dtypes[nbits_out])
-  # Convert to output bytes
-  arr_bytes = (arr_bytes << shifts_out).sum(-1).astype(byte_dtypes[nbits_out])
-  # Cast to output dtype
+  if nbits_in < nbits_out:
+    shifts = arange(0, nbits_out, nbits_in, dtype=byte_dtypes[nbits_out])
+    arr_bytes = arr_bytes.reshape(arr.shape[:-1] + (-1, nbits_out // nbits_in)).astype(byte_dtypes[nbits_out])
+    arr_bytes = (arr_bytes << shifts).sum(-1).astype(byte_dtypes[nbits_out])
+  else:
+    shifts = arange(0, nbits_in, nbits_out, dtype=byte_dtypes[nbits_in])
+    arr_bytes = ((arr_bytes[..., newaxis] >> shifts) & iinfo(byte_dtypes[nbits_out]).max).astype(byte_dtypes[nbits_out])
+    arr_bytes = arr_bytes.reshape(arr_bytes.shape[:-2] + (-1,))
   if dtype == bool_:
     return lax.bitcast_convert_type(arr_bytes, uint8).astype(dtype)
   return lax.bitcast_convert_type(arr_bytes, dtype)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -462,6 +462,15 @@ def _rand_dtype(rand, shape, dtype, scale=1., post=lambda x: x):
     vals = r()
   return _cast_to_shape(np.asarray(post(vals), dtype), shape, dtype)
 
+def rand_fullrange(rng):
+  """Random numbers that span the full range of available bits."""
+  def gen(shape, dtype, post=lambda x: x):
+    dtype = np.dtype(dtype)
+    size = dtype.itemsize * np.prod(_dims_of_shape(shape))
+    vals = rng.randint(0, np.iinfo(np.uint8).max, size=size, dtype=np.uint8)
+    vals = post(vals).view(dtype).reshape(shape)
+    return _cast_to_shape(post(vals), shape, dtype)
+  return gen
 
 def rand_default(rng, scale=3):
   return partial(_rand_dtype, rng.randn, scale=scale)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -462,15 +462,20 @@ def _rand_dtype(rand, shape, dtype, scale=1., post=lambda x: x):
     vals = r()
   return _cast_to_shape(np.asarray(post(vals), dtype), shape, dtype)
 
-def rand_fullrange(rng):
+
+def rand_fullrange(rng, standardize_nans=True):
   """Random numbers that span the full range of available bits."""
   def gen(shape, dtype, post=lambda x: x):
     dtype = np.dtype(dtype)
     size = dtype.itemsize * np.prod(_dims_of_shape(shape))
     vals = rng.randint(0, np.iinfo(np.uint8).max, size=size, dtype=np.uint8)
     vals = post(vals).view(dtype).reshape(shape)
-    return _cast_to_shape(post(vals), shape, dtype)
+    # Non-standard NaNs cause errors in numpy equality assertions.
+    if standardize_nans and np.issubdtype(dtype, np.floating):
+      vals[np.isnan(vals)] = np.nan
+    return _cast_to_shape(vals, shape, dtype)
   return gen
+
 
 def rand_default(rng, scale=3):
   return partial(_rand_dtype, rng.randn, scale=scale)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -725,11 +725,20 @@ class JaxTestCase(parameterized.TestCase):
       self.assertDtypesMatch(x, y)
     np.testing.assert_equal(x, y)
 
-  def assertArraysAllClose(self, x, y, check_dtypes, atol=None, rtol=None):
+  def assertArraysAllClose(self, x, y, check_dtypes, atol=None, rtol=None,
+                           standardize_nans=False):
     """Assert that x and y are close (up to numerical tolerances)."""
     self.assertEqual(x.shape, y.shape)
     atol = max(tolerance(_dtype(x), atol), tolerance(_dtype(y), atol))
     rtol = max(tolerance(_dtype(x), rtol), tolerance(_dtype(y), rtol))
+
+    if standardize_nans:
+      if np.issubdtype(_dtype(x), np.floating) and np.any(np.isnan(x)):
+        x = np.copy(x)
+        x[np.isnan(x)] = np.nan
+      if np.issubdtype(_dtype(y), np.floating) and np.any(np.isnan(y)):
+        y = np.copy(y)
+        y[np.isnan(y)] == np.nan
 
     _assert_numpy_allclose(x, y, atol=atol, rtol=rtol)
 
@@ -740,18 +749,20 @@ class JaxTestCase(parameterized.TestCase):
     if FLAGS.jax_enable_x64:
       self.assertEqual(_dtype(x), _dtype(y))
 
-  def assertAllClose(self, x, y, check_dtypes, atol=None, rtol=None):
+  def assertAllClose(self, x, y, check_dtypes, atol=None, rtol=None, standardize_nans=False):
     """Assert that x and y, either arrays or nested tuples/lists, are close."""
     if isinstance(x, dict):
       self.assertIsInstance(y, dict)
       self.assertEqual(set(x.keys()), set(y.keys()))
       for k in x.keys():
-        self.assertAllClose(x[k], y[k], check_dtypes, atol=atol, rtol=rtol)
+        self.assertAllClose(x[k], y[k], check_dtypes, atol=atol, rtol=rtol,
+                            standardize_nans=standardize_nans)
     elif is_sequence(x) and not hasattr(x, '__array__'):
       self.assertTrue(is_sequence(y) and not hasattr(y, '__array__'))
       self.assertEqual(len(x), len(y))
       for x_elt, y_elt in zip(x, y):
-        self.assertAllClose(x_elt, y_elt, check_dtypes, atol=atol, rtol=rtol)
+        self.assertAllClose(x_elt, y_elt, check_dtypes, atol=atol, rtol=rtol,
+                            standardize_nans=standardize_nans)
     elif hasattr(x, '__array__') or np.isscalar(x):
       self.assertTrue(hasattr(y, '__array__') or np.isscalar(y))
       if check_dtypes:
@@ -773,7 +784,7 @@ class JaxTestCase(parameterized.TestCase):
                               msg="Found\n{}\nExpecting\n{}".format(what, expected))
 
   def _CompileAndCheck(self, fun, args_maker, check_dtypes,
-                       rtol=None, atol=None):
+                       rtol=None, atol=None, standardize_nans=False):
     """Helper method for running JAX compilation and allclose assertions."""
     args = args_maker()
 
@@ -802,8 +813,10 @@ class JaxTestCase(parameterized.TestCase):
     python_should_be_executing = False
     compiled_ans = cfun(*args)
 
-    self.assertAllClose(python_ans, monitored_ans, check_dtypes, atol, rtol)
-    self.assertAllClose(python_ans, compiled_ans, check_dtypes, atol, rtol)
+    self.assertAllClose(python_ans, monitored_ans, check_dtypes, atol, rtol,
+                        standardize_nans=standardize_nans)
+    self.assertAllClose(python_ans, compiled_ans, check_dtypes, atol, rtol,
+                        standardize_nans=standardize_nans)
 
     args = args_maker()
 
@@ -813,15 +826,17 @@ class JaxTestCase(parameterized.TestCase):
     python_should_be_executing = False
     compiled_ans = cfun(*args)
 
-    self.assertAllClose(python_ans, compiled_ans, check_dtypes, atol, rtol)
+    self.assertAllClose(python_ans, compiled_ans, check_dtypes, atol, rtol,
+                        standardize_nans=standardize_nans)
 
   def _CheckAgainstNumpy(self, numpy_reference_op, lax_op, args_maker,
-                         check_dtypes=False, tol=None):
+                         check_dtypes=False, tol=None, standardize_nans=False):
     args = args_maker()
     lax_ans = lax_op(*args)
     numpy_ans = numpy_reference_op(*args)
+
     self.assertAllClose(numpy_ans, lax_ans, check_dtypes=check_dtypes,
-                        atol=tol, rtol=tol)
+                        atol=tol, rtol=tol, standardize_nans=standardize_nans)
 
 
 @contextmanager

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2233,11 +2233,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, a_dtype)]
     np_op = lambda x: np.asarray(x).view(dtype)
     jnp_op = lambda x: jnp.asarray(x).view(dtype)
-    self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True, standardize_nans=True)
-    self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True, standardize_nans=True)
+    self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True)
+    self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True)
 
-  def testViewSpecialFloats(self):
-    vals = np.array([
+  def testPathologicalFloats(self):
+    args_maker = lamnda: [np.array([
       0b_0111_1111_1000_0000_0000_0000_0000_0000, # inf
       0b_1111_1111_1000_0000_0000_0000_0000_0000, # -inf
       0b_0111_1111_1100_0000_0000_0000_0000_0000, # qnan
@@ -2248,11 +2248,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       0b_1111_1111_1000_0000_0000_1100_0000_0000, # -nonstandard nan
       0b_0000_0000_0000_0000_0000_0000_0000_0000, # zero
       0b_1000_0000_0000_0000_0000_0000_0000_0000, # -zero
-    ], dtype='uint32').view('float32')
+    ], dtype='uint32')]
 
-    args_maker = lambda: [vals]
-    np_op = lambda x: np.asarray(x).view('uint32')
-    jnp_op = lambda x: jnp.asarray(x).view('uint32')
+    np_op = lambda x: np.asarray(x).view('float32').view('uint32')
+    jnp_op = lambda x: jnp.asarray(x).view('float32').view('uint32')
 
     self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True)
     self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2223,18 +2223,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for a_dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)
       for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
   def testView(self, shape, a_dtype, dtype):
-    def _itemsize(dtype):
-      if dtype == jnp.bool_:
-        return 8
-      elif jnp.issubdtype(dtype, jnp.integer):
-        return jnp.iinfo(dtype).bits
-      else:
-        return jnp.finfo(dtype).bits
     if jtu.device_under_test() == 'tpu':
-      if _itemsize(a_dtype) in [8, 16] or _itemsize(dtype) in [8, 16]:
-        self.skipTest("arr.view() not supported on TPU for 8-bit or 16-bit types.")
+      if jnp.dtype(a_dtype).itemsize in [8, 16] or jnp.dtype(dtype).itemsize in [8, 16]:
+        self.skipTest("arr.view() not supported on TPU for 8- or 16-bit types.")
     if not FLAGS.jax_enable_x64:
-      if _itemsize(a_dtype) == 64 or _itemsize(dtype) == 64:
+      if jnp.dtype(a_dtype).itemsize == 64 or jnp.dtype(dtype).itemsize == 64:
         self.skipTest("x64 types are disabled by jax_enable_x64")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, a_dtype)]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -85,12 +85,6 @@ def _shape_and_dtypes(shapes, dtypes):
     for dtype in _valid_dtypes_for_shape(shape, dtypes):
       yield (shape, dtype)
 
-def _dtype_info(dtype):
-  """Helper function for to get dtype info needed for clipping."""
-  if jnp.issubdtype(dtype, jnp.integer):
-    return jnp.iinfo(dtype)
-  return jnp.finfo(dtype)
-
 OpRecord = collections.namedtuple(
   "OpRecord",
   ["name", "nargs", "dtypes", "shapes", "rng_factory", "diff_modes",
@@ -2229,13 +2223,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for a_dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)
       for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
   def testView(self, shape, a_dtype, dtype):
+    def _itemsize(dtype):
+      if dtype == jnp.bool_:
+        return 8
+      elif jnp.issubdtype(dtype, jnp.integer):
+        return jnp.iinfo(dtype).bits
+      else:
+        return jnp.finfo(dtype).bits
     if jtu.device_under_test() == 'tpu':
-      if (a_dtype == onp.bool_ or dtype == onp.bool_
-          or _dtype_info(a_dtype).bits in [8, 16]
-          or _dtype_info(dtype).bits in [8, 16]):
-        self.skipTest("arr.view() not supported on TPU for 8-bit or 16-bit inputs.")
-    if not FLAGS.jax_enable_x64 and a_dtype == onp.float64 or dtype == onp.float64:
-      self.skipTest("x64 types are disabled by jax_enable_x64")
+      if _itemsize(a_dtype) in [8, 16] or _itemsize(dtype) in [8, 16]:
+        self.skipTest("arr.view() not supported on TPU for 8-bit or 16-bit types.")
+    if not FLAGS.jax_enable_x64:
+      if _itemsize(a_dtype) == 64 or _itemsize(dtype) == 64:
+        self.skipTest("x64 types are disabled by jax_enable_x64")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, a_dtype)]
     np_op = lambda x: np.asarray(x).view(dtype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2229,7 +2229,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     if not FLAGS.jax_enable_x64:
       if jnp.dtype(a_dtype).itemsize == 8 or jnp.dtype(dtype).itemsize == 8:
         self.skipTest("x64 types are disabled by jax_enable_x64")
-    rng = jtu.rand_default(self.rng())
+    rng = jtu.rand_fullrange(self.rng())
     args_maker = lambda: [rng(shape, a_dtype)]
     np_op = lambda x: np.asarray(x).view(dtype)
     jnp_op = lambda x: jnp.asarray(x).view(dtype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2237,7 +2237,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True)
 
   def testPathologicalFloats(self):
-    args_maker = lamnda: [np.array([
+    args_maker = lambda: [np.array([
       0b_0111_1111_1000_0000_0000_0000_0000_0000, # inf
       0b_1111_1111_1000_0000_0000_0000_0000_0000, # -inf
       0b_0111_1111_1100_0000_0000_0000_0000_0000, # qnan

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2236,6 +2236,27 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True, standardize_nans=True)
     self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True, standardize_nans=True)
 
+  def testViewSpecialFloats(self):
+    vals = np.array([
+      0b_0111_1111_1000_0000_0000_0000_0000_0000, # inf
+      0b_1111_1111_1000_0000_0000_0000_0000_0000, # -inf
+      0b_0111_1111_1100_0000_0000_0000_0000_0000, # qnan
+      0b_1111_1111_1100_0000_0000_0000_0000_0000, # -qnan
+      0b_0111_1111_1000_0000_0000_0000_0000_0001, # snan
+      0b_1111_1111_1000_0000_0000_0000_0000_0001, # -snan
+      0b_0111_1111_1000_0000_0000_1100_0000_0000, # nonstandard nan
+      0b_1111_1111_1000_0000_0000_1100_0000_0000, # -nonstandard nan
+      0b_0000_0000_0000_0000_0000_0000_0000_0000, # zero
+      0b_1000_0000_0000_0000_0000_0000_0000_0000, # -zero
+    ], dtype='uint32').view('float32')
+
+    args_maker = lambda: [vals]
+    np_op = lambda x: np.asarray(x).view('uint32')
+    jnp_op = lambda x: jnp.asarray(x).view('uint32')
+
+    self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True)
+    self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True)
+
   # TODO(mattjj): test other ndarray-like method overrides
 
   def testNpMean(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2220,9 +2220,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, a_dtype), dtype),
       "shape": shape, "a_dtype": a_dtype, "dtype": dtype}
       for shape in [(8,), (3, 8)]  # last dim = 8 to ensure shape compatibility
-      for a_dtype in [np.bool_, np.uint8, np.float16, np.int32, np.float64]
-      for dtype in [np.bool_, np.int8, np.int16, np.float32, np.float64]))
-  @jtu.skip_on_devices("tpu")
+      for a_dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)
+      for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
   def testView(self, shape, a_dtype, dtype):
     if not FLAGS.jax_enable_x64 and a_dtype == np.float64 or dtype == np.float64:
       self.skipTest("x64 types are disabled by jax_enable_x64")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2233,8 +2233,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, a_dtype)]
     np_op = lambda x: np.asarray(x).view(dtype)
     jnp_op = lambda x: jnp.asarray(x).view(dtype)
-    self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True)
-    self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(jnp_op, np_op, args_maker, check_dtypes=True, standardize_nans=True)
+    self._CompileAndCheck(jnp_op, args_maker, check_dtypes=True, standardize_nans=True)
 
   # TODO(mattjj): test other ndarray-like method overrides
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2224,10 +2224,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
   def testView(self, shape, a_dtype, dtype):
     if jtu.device_under_test() == 'tpu':
-      if jnp.dtype(a_dtype).itemsize in [8, 16] or jnp.dtype(dtype).itemsize in [8, 16]:
+      if jnp.dtype(a_dtype).itemsize in [1, 2] or jnp.dtype(dtype).itemsize in [1, 2]:
         self.skipTest("arr.view() not supported on TPU for 8- or 16-bit types.")
     if not FLAGS.jax_enable_x64:
-      if jnp.dtype(a_dtype).itemsize == 64 or jnp.dtype(dtype).itemsize == 64:
+      if jnp.dtype(a_dtype).itemsize == 8 or jnp.dtype(dtype).itemsize == 8:
         self.skipTest("x64 types are disabled by jax_enable_x64")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, a_dtype)]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2229,7 +2229,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     if not FLAGS.jax_enable_x64:
       if jnp.dtype(a_dtype).itemsize == 8 or jnp.dtype(dtype).itemsize == 8:
         self.skipTest("x64 types are disabled by jax_enable_x64")
-    rng = jtu.rand_fullrange(self.rng())
+    rng = jtu.rand_fullrange(self.rng(), standardize_nans=True)
     args_maker = lambda: [rng(shape, a_dtype)]
     np_op = lambda x: np.asarray(x).view(dtype)
     jnp_op = lambda x: jnp.asarray(x).view(dtype)


### PR DESCRIPTION
Rather than passing through uint8, arr.view() now goes directly from the input bitwidth to output bitwidth.