### PR TITLE
Move some sharded_jit functionality into pxla.py

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -51,7 +51,7 @@ from ..util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,
                     extend_name_stack, wrap_name)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
-from ..tree_util import tree_map
+from ..tree_util import tree_flatten, tree_map
 from .batching import broadcast, not_mapped
 from . import batching
 from . import partial_eval as pe
@@ -759,6 +759,66 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
                  handle_outs)
 
 multi_host_supported_collectives: Set[core.Primitive] = set()
+
+
+def reconcile_num_partitions(jaxpr, outer_num_parts: Optional[int]):
+  """Returns the total number of partitions to use.
+
+  Validates that any inner partitioning matches outer_num_parts if provided, and
+  returns the number of partitions to use based on outer_num_parts and any inner
+  partitioning.
+  """
+  inner_num_parts = _inner_partitions(jaxpr, outer_num_parts)
+  if outer_num_parts is None and inner_num_parts is None:
+    # No partitions specified anywhere, everything is replicated.
+    return 1
+  if outer_num_parts is None:
+    return inner_num_parts
+  return outer_num_parts
+
+
+
+def _inner_partitions(jaxpr, expected_num_parts: Optional[int]):
+  """Returns the total number of partitions from PartitionSpecs inside `jaxpr`.
+
+  Also validates that this number matches `expected_num_parts` if provided.
+  """
+  for eqn in jaxpr.eqns:
+    if eqn.primitive == "sharding_constraint":
+      parts = eqn.params["partitions"]
+      nparts = get_num_partitions(parts)
+      if expected_num_parts is None:
+        expected_num_parts = nparts
+      elif nparts != expected_num_parts:
+        # TODO(skye): raise this error as we trace the jaxpr
+        raise ValueError(
+            f"with_sharding_constraint with partitions={parts} "
+            f"(total partitions: {nparts}) doesn't match expected number of "
+            f"partitions: {expected_num_parts}. If these partitions look "
+            f"right, check outer sharded_jit and/or other "
+            f"with_sharding_constraint calls.")
+      elif eqn.primitive.call_primitive:
+        expected_num_parts = _inner_partitions(eqn.params["call_jaxpr"],
+                                               expected_num_parts)
+      # TODO(skye): control flow
+  return expected_num_parts
+
+
+def get_num_partitions(*partitions):
+  partition_specs = tree_flatten(partitions)[0]
+  if len(partition_specs) == 0:
+    # Everything is specified as replicated (all Nones).
+    return None
+  num_partitions_set = set(onp.prod(spec) for spec in partition_specs)
+  if len(num_partitions_set) > 1:
+    raise ValueError(
+        f"All partition specs must use the same number of total partitions, "
+        f"got {partitions}, with distinct number of partitions "
+        f"{num_partitions_set} (the total number of partitions is the product "
+        f"of a partition spec)")
+  assert len(num_partitions_set) == 1
+  return num_partitions_set.pop()
+
 
 class ResultToPopulate(object): pass
 result_to_populate = ResultToPopulate()

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -923,6 +923,25 @@ def _pmap_sharding_spec(nrep, axis_size, sharded_aval, mapped):
         replication_factor=replication_factor * axis_size)
 
 
+def partitioned_sharding_spec(num_partitions: int,
+                              partitions: Optional[Sequence[int]], aval):
+  if aval is core.abstract_unit:
+    return None
+
+  if partitions is None:
+    return ShardingSpec(
+        # int(1) because pytype is confused by 1 (???)
+        shards_per_axis=(int(1),) * len(aval.shape),
+        is_axis_materialized=(True,) * len(aval.shape),
+        replication_factor=num_partitions)
+  else:
+    assert len(partitions) == len(aval.shape)
+    return ShardingSpec(
+        shards_per_axis=tuple(partitions),
+        is_axis_materialized=(True,) * len(aval.shape),
+        replication_factor=1)
+
+
 def execute_replicated(compiled,
                        uses_outfeed, backend, in_handler, out_handler, *args):
   xla.check_before_outfeed_execution(uses_outfeed)

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -92,14 +92,7 @@ def _sharded_callable(
     # TODO(skye): fall back to regular jit?
     raise ValueError("sharded_jit only works on TPU!")
 
-  num_inner_parts = _inner_partitions(jaxpr, num_partitions)
-  if num_partitions is None:
-    num_partitions = num_inner_parts
-  assert num_partitions == num_inner_parts
-  if num_partitions is None:
-    # No partitions specified anywhere, everything is replicated.
-    num_partitions = 1
-
+  num_partitions = pxla.reconcile_num_partitions(jaxpr, num_partitions)
   out_parts = out_parts_thunk()
 
   c = xb.make_computation_builder("spjit_{}".format(fun.__name__))
@@ -200,47 +193,6 @@ def _xla_sharded_args(c, avals, in_parts):
   return xla_args
 
 
-def get_num_partitions(*partitions):
-  partition_specs = tree_flatten(partitions)[0]
-  if len(partition_specs) == 0:
-    # Everything is specified as replicated (all Nones).
-    return None
-  num_partitions_set = set(np.prod(spec) for spec in partition_specs)
-  if len(num_partitions_set) > 1:
-    raise ValueError(
-        f"All partition specs must use the same number of total partitions, "
-        f"got {partitions}, with distinct number of partitions "
-        f"{num_partitions_set} (the total number of partitions is the product "
-        f"of a partition spec)")
-  assert len(num_partitions_set) == 1
-  return num_partitions_set.pop()
-
-
-def _inner_partitions(jaxpr, expected_num_parts: Optional[int]):
-  """Returns the total number of partitions from PartitionSpecs inside `jaxpr`.
-
-  Also validates that this number matches `expected_num_parts` if provided.
-  """
-  for eqn in jaxpr.eqns:
-    if eqn.primitive == sharding_constraint_p:
-      parts = eqn.params["partitions"]
-      nparts = get_num_partitions(parts)
-      if expected_num_parts is None:
-        expected_num_parts = nparts
-      elif nparts != expected_num_parts:
-        # TODO(skye): raise this error as we trace the jaxpr
-        raise ValueError(
-            f"with_sharding_constraint with partitions={parts} "
-            f"(total partitions: {nparts}) doesn't match expected number of "
-            f"partitions: {expected_num_parts}. If these partitions look "
-            f"right, check outer sharded_jit and/or other "
-            f"with_sharding_constraint calls.")
-      elif eqn.primitive.call_primitive:
-        expected_num_parts = _inner_partitions(eqn.params["call_jaxpr"],
-                                               expected_num_parts)
-      # TODO(skye): control flow
-  return expected_num_parts
-
 def _sharded_call_impl(fun, *args, num_partitions, in_parts, out_parts_thunk,
                        name):
   compiled_fun = _sharded_callable(fun, num_partitions, in_parts,
@@ -315,7 +267,7 @@ def sharded_jit(fun: Callable, in_parts, out_parts):
   Returns:
     A version of ``fun`` that will be distributed across multiple devices.
   """
-  num_parts = get_num_partitions(in_parts, out_parts)
+  num_parts = pxla.get_num_partitions(in_parts, out_parts)
 
   def wrapped(*args, **kwargs):
     if kwargs:


### PR DESCRIPTION
Specifically:
* Move `_inner_partitions`
* Move `get_num_partitions`
* Move and slightly modify the logic for finding and validating inner
  partitions to a new function, `reconcile_num_partitions`
* Move `_partitioned_sharding_spec` and rename to `partitioned_sharding_spec`

This is in preparation for enabling pmap-of-sharded_jit, since pmap
will need access to this functionality as well.