### PR TITLE
Implement pmap of sharded_jit

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -748,6 +748,9 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
                        "but %s devices were specified" %
                        (num_global_shards, len(devices)))
 
+  # 'devices' may be 1D or 2D at this point (e.g.
+  # get_default_device_assignment() returns 2D assignment, caller may have
+  # provided 1D list of devices).
   device_assignment = tree_map(lambda d: d.id, devices)
   compile_options = xb.get_compile_options(
           num_replicas=num_global_replicas,
@@ -956,8 +959,8 @@ def _pval_to_result_handler(axis_size, nrep, npart, parts, pval, devices, backen
 
 def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
   if not mapped and npart > 1:
-    # TODO(skye): ShardingSpec assumes replication is treated as the innermost
-    # axis, but in this case, it needs to be the outer axis.
+    # TODO(skye, jekbradbury): ShardingSpec assumes replication is treated as
+    # the innermost axis, but in this case, it needs to be the outer axis.
     raise NotImplementedError(
         "Using pmap(in_axes=None) over sharded_jit not yet implemented.")
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -499,7 +499,7 @@ class ShardedDeviceArray(xla.DeviceArray):
       device_buffers = sharding_spec
       sharded_aval = ShapedArray(aval.shape[1:], aval.dtype)
       sharding_spec = _pmap_sharding_spec(aval.shape[0], aval.shape[0],
-                                          sharded_aval, True)
+                                          1, None, sharded_aval, True)
 
     # TODO(skye): assert invariants. Keep performance in mind though.
     if indices is None:
@@ -681,15 +681,21 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
     # XLA computation at all; we handle this as a special case so we can stage
     # out multi-replica XLA computations regardless of the hardware available.
     # The 'None' values here are just dummies we know will be ignored.
-    handlers = [_pval_to_result_handler(axis_size, None, pval, local_devices,
-                                        backend)
-                for pval in out_pvals]
+    handlers = [
+        _pval_to_result_handler(axis_size, None, None, None, pval, local_devices,
+                                backend) for pval in out_pvals
+    ]
     results = [handler(None) for handler in handlers]
     return lambda *_: results
 
   jaxpr_replicas = xla.jaxpr_replicas(jaxpr)
   num_local_replicas = axis_size * jaxpr_replicas
   num_global_replicas = global_axis_size * jaxpr_replicas
+  arg_parts, out_parts, num_partitions = _find_partitions(jaxpr)
+
+  num_local_shards = num_local_replicas * num_partitions
+  num_global_shards = num_global_replicas * num_partitions
+
   axis_env = xla.AxisEnv(num_global_replicas, (axis_name,), (global_axis_size,), devices)
 
   tuple_args = len(sharded_avals) > 100  # pass long arg lists as tuple for TPU
@@ -697,16 +703,23 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
   c = xb.make_computation_builder("pmap_{}".format(fun.__name__))
   xla_consts = _map(partial(xb.constant, c), consts)
   replicated = [not m for m in mapped_invars]
-  xla_args = xla._xla_callable_args(c, sharded_avals, tuple_args, replicated)
+  xla_args = xla._xla_callable_args(c, sharded_avals, tuple_args, replicated,
+                                    arg_parts)
   out_nodes = xla.jaxpr_subcomp(c, jaxpr, backend, axis_env, xla_consts,
                                 extend_name_stack(wrap_name(name, 'pmap')), *xla_args)
-  built = c.build(xops.Tuple(c, out_nodes))
+  build_out_tuple = partial(xops.Tuple, c, out_nodes)
+  if out_parts is not None:
+    out_tuple = xb.with_sharding(c, out_parts, build_out_tuple)
+  else:
+    out_tuple = build_out_tuple()
+  built = c.Build(out_tuple)
 
   if devices is None:
-    if num_global_replicas > xb.device_count(backend):
+    if num_global_shards > xb.device_count(backend):
       msg = ("compiling computation that requires {} replicas, but only {} XLA "
-             "devices are available")
-      raise ValueError(msg.format(num_global_replicas, xb.device_count(backend)))
+             "devices are available (num_replicas={}, num_partitions={})")
+      raise ValueError(msg.format(num_global_shards, xb.device_count(backend),
+                                  num_global_replicas, num_partitions))
 
     # On a single host, we use the platform's default device assignment to
     # potentially take advantage of device locality. On multiple hosts, the
@@ -721,44 +734,67 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
                  for d in xb.local_devices(host_id)]
     else:
       devices = xb.get_backend(backend).get_default_device_assignment(
-          num_global_replicas)
+          num_global_replicas, num_partitions)
   else:
-    if num_local_replicas != len(local_devices):
+    if num_local_shards != len(local_devices):
       local_devices_str = ", ".join(map(str, local_devices))
       raise ValueError(
           "Leading axis size of input to pmapped function must equal the "
           "number of local devices passed to pmap. Got axis_size=%d, "
           "num_local_devices=%d.\n(Local devices passed to pmap: %s)"
           % (axis_size, len(local_devices), local_devices_str))
-    if num_global_replicas != len(devices):
-      raise ValueError("compiling computation that requires %s replicas, "
-                       "but %s devices were specified"
-                       % (num_global_replicas, len(devices)))
+    if num_global_shards != len(devices):
+      raise ValueError("compiling computation that creates %s shards, "
+                       "but %s devices were specified" %
+                       (num_global_shards, len(devices)))
 
-  device_assignment = tuple(d.id for d in devices)
+  device_assignment = tree_map(lambda d: d.id, devices)
   compile_options = xb.get_compile_options(
           num_replicas=num_global_replicas,
-          num_partitions=1,
+          num_partitions=num_partitions,
           device_assignment=device_assignment)
   compile_options.parameter_is_tupled_arguments = tuple_args
   backend = xb.get_backend(backend)
   compiled = backend.compile(built, compile_options=compile_options)
 
-  input_sharding_specs = [_pmap_sharding_spec(num_local_replicas, axis_size,
-                                              aval, m)
-                          for m, aval in zip(mapped_invars, sharded_avals)]
+  input_sharding_specs = [
+      _pmap_sharding_spec(
+          num_local_replicas, axis_size, num_partitions, parts, aval, mapped)
+      for (aval, parts, mapped)
+      in safe_zip(sharded_avals, arg_parts or [None] * len(avals),
+                  mapped_invars)]
   input_indices = [spec_to_indices(aval.shape, spec)
                    if spec is not None else None
                    for aval, spec in zip(avals, input_sharding_specs)]
   handle_args = partial(shard_args, compiled.local_devices(), input_indices)
 
   handle_outs = _pvals_to_results_handler(axis_size, num_local_replicas,
+                                          num_partitions, out_parts,
                                           out_pvals, compiled.local_devices(),
                                           backend)
   return partial(execute_replicated, compiled, uses_outfeed, backend, handle_args,
                  handle_outs)
 
 multi_host_supported_collectives: Set[core.Primitive] = set()
+
+
+PartitionsOrReplicated = Optional[Tuple[int, ...]]
+
+def _find_partitions(jaxpr) -> Tuple[
+    Optional[Tuple[PartitionsOrReplicated, ...]],
+    Optional[Tuple[PartitionsOrReplicated, ...]],
+    int]:
+  """Returns (in_partitions, out_partitions, num_partitions)."""
+  for eqn in jaxpr.eqns:
+    if eqn.primitive.name == "sharded_call":
+      if len(jaxpr.eqns) > 1:
+        raise NotImplementedError(
+            "pmap of sharded_jit + non-sharded operations not yet implemented.")
+      num_partitions = reconcile_num_partitions(eqn.params["call_jaxpr"],
+                                                eqn.params["num_partitions"])
+      return (eqn.params["in_parts"], eqn.params["out_parts_thunk"](),
+              num_partitions)
+  return None, None, 1
 
 
 def reconcile_num_partitions(jaxpr, outer_num_parts: Optional[int]):
@@ -823,12 +859,21 @@ def get_num_partitions(*partitions):
 class ResultToPopulate(object): pass
 result_to_populate = ResultToPopulate()
 
-def _pvals_to_results_handler(size, nrep, out_pvals, devices, backend):
+def _pvals_to_results_handler(
+    size, nrep, npart,
+    out_parts: Optional[Tuple[PartitionsOrReplicated, ...]],
+    out_pvals, devices, backend):
   nouts = len(out_pvals)
-  handlers = [_pval_to_result_handler(size, nrep, pval, devices, backend)
-              for pval in out_pvals]
+  if out_parts is None:
+    out_parts = (None,) * len(out_pvals)
+  handlers = [
+      _pval_to_result_handler(size, nrep, npart, parts, pval, devices, backend)
+      for pval, parts in safe_zip(out_pvals, out_parts)
+  ]
+
   def handler(out_bufs):
-    buffers = [[result_to_populate] * nrep for _ in range(nouts)]
+    assert nrep * npart == len(out_bufs)
+    buffers = [[result_to_populate] * nrep * npart for _ in range(nouts)]
     for r, tuple_buf in enumerate(out_bufs):
       for i, buf in enumerate(tuple_buf):
         buffers[i][r] = buf
@@ -872,11 +917,13 @@ def replicate(val, axis_size, nrep, devices=None, backend=None):
   # TODO(jekbradbury): use ShardingSpec.replication_factor instead
   aval = xla.abstractify(val)  # type: ShapedArray
   replicated_aval = ShapedArray((axis_size,) + aval.shape, aval.dtype)
-  sharding_spec = _pmap_sharding_spec(nrep, axis_size, aval, True)
+  # TODO(skye): figure out how partitioning should work here
+  sharding_spec = _pmap_sharding_spec(nrep, axis_size, 1, None, aval, True)
   device_buffers = [xla.device_put(val, d) for d in devices]
   return ShardedDeviceArray(replicated_aval, sharding_spec, device_buffers)
 
-def _pval_to_result_handler(axis_size, nrep, pval, devices, backend):
+
+def _pval_to_result_handler(axis_size, nrep, npart, parts, pval, devices, backend):
   if devices:
     assert all(d.host_id == xb.host_id(backend) for d in devices)
   pv, const = pval
@@ -899,27 +946,37 @@ def _pval_to_result_handler(axis_size, nrep, pval, devices, backend):
   else:
     if pv is not core.abstract_unit:
       unsharded_aval = ShapedArray((axis_size,) + pv.shape, pv.dtype)
-      sharding_spec = _pmap_sharding_spec(nrep, axis_size, pv, True)
+      sharding_spec = _pmap_sharding_spec(nrep, axis_size, npart, parts, pv,
+                                          True)
       indices = spec_to_indices(unsharded_aval.shape, sharding_spec)
     else:
       sharding_spec = indices = None
       unsharded_aval = pv
     return aval_to_result_handler(sharding_spec, indices, unsharded_aval)
 
-def _pmap_sharding_spec(nrep, axis_size, sharded_aval, mapped):
+def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
+  if not mapped and npart > 1:
+    # TODO(skye): ShardingSpec assumes replication is treated as the innermost
+    # axis, but in this case, it needs to be the outer axis.
+    raise NotImplementedError(
+        "Using pmap(in_axes=None) over sharded_jit not yet implemented.")
+
   if sharded_aval is core.abstract_unit:
     return None
+
   replication_factor, ragged = divmod(nrep, axis_size)
   assert not ragged
+  shard_spec = partitioned_sharding_spec(npart, parts, sharded_aval)
+  assert shard_spec is not None  # hint for pytype
   if mapped:
     return ShardingSpec(
-        shards_per_axis=(axis_size,) + (1,) * len(sharded_aval.shape),
-        is_axis_materialized=(False,) + (True,) * len(sharded_aval.shape),
-        replication_factor=replication_factor)
+        shards_per_axis=(axis_size,) + shard_spec.shards_per_axis,
+        is_axis_materialized=(False,) + shard_spec.shards_per_axis,
+        replication_factor=replication_factor * shard_spec.replication_factor)
   else:
     return ShardingSpec(
-        shards_per_axis=(1,) * len(sharded_aval.shape),
-        is_axis_materialized=(True,) * len(sharded_aval.shape),
+        shards_per_axis=shard_spec.shards_per_axis,
+        is_axis_materialized=shard_spec.is_axis_materialized,
         replication_factor=replication_factor * axis_size)
 
 
@@ -930,8 +987,7 @@ def partitioned_sharding_spec(num_partitions: int,
 
   if partitions is None:
     return ShardingSpec(
-        # int(1) because pytype is confused by 1 (???)
-        shards_per_axis=(int(1),) * len(aval.shape),
+        shards_per_axis=(1,) * len(aval.shape),
         is_axis_materialized=(True,) * len(aval.shape),
         replication_factor=num_partitions)
   else:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -716,7 +716,7 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
 
   if devices is None:
     if num_global_shards > xb.device_count(backend):
-      msg = ("compiling computation that requires {} replicas, but only {} XLA "
+      msg = ("compiling computation that requires {} logical devices, but only {} XLA "
              "devices are available (num_replicas={}, num_partitions={})")
       raise ValueError(msg.format(num_global_shards, xb.device_count(backend),
                                   num_global_replicas, num_partitions))

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -74,8 +74,8 @@ def _pval_to_result_handler(npart, parts, pval):
 @lu.cache
 def _sharded_callable(
     fun: lu.WrappedFun, num_partitions: Optional[int],
-    in_parts: Tuple[Optional[Tuple[int, ...]], ...],
-    out_parts_thunk: Callable[[], Tuple[Optional[Tuple[int, ...]], ...]],
+    in_parts: Tuple[pxla.PartitionsOrReplicated, ...],
+    out_parts_thunk: Callable[[], Tuple[pxla.PartitionsOrReplicated, ...]],
     name: str, *abstract_args):
   nrep = 1
   in_pvals = [pe.PartialVal.unknown(aval) for aval in abstract_args]

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -34,7 +34,7 @@ from ..abstract_arrays import (ConcreteArray, ShapedArray, AbstractToken,
 from ..core import Literal, pp_eqn_compact
 from ..pprint_util import pp
 from ..util import (partial, partialmethod, cache, prod, unzip2, memoize,
-                    extend_name_stack, wrap_name)
+                    extend_name_stack, wrap_name, safe_zip)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from . import partial_eval as pe
@@ -601,26 +601,49 @@ def _xla_callable_device(nreps, backend, device, arg_devices):
     else:
       assert False  # Unreachable given the error check in _xla_callable
 
-def _xla_callable_args(c, avals, tuple_args, replicated=None):
+# Used within _xla_callable_args and _xla_param to distinguish between None (no
+# sharding annotation set) and replicated.
+_replicated_param = object()
+
+def _xla_callable_args(
+    c, avals, tuple_args, replicated=None,
+    partitions: Optional[Sequence[Optional[Tuple[int]]]] = None):
+  assert partitions is None or len(partitions) == len(avals)
   if not tuple_args:
     if replicated is None:
       replicated = [None] * len(avals)
-    xla_args = [xb.parameter(c, i, aval_to_xla_shape(a), replicated=r)
-                if a is not abstract_token else xops.CreateToken(c)
-                for i, (a, r) in enumerate(zip(avals, replicated))]
-    return xla_args
+    if partitions is None:
+      parts: List[object] = [None] * len(avals)
+    else:
+      parts = [_replicated_param if part is None else part
+               for part in partitions]
+    return [_xla_param(c, i, aval_to_xla_shape(a), r, p)
+            if a is not abstract_token else xops.CreateToken(c)
+            for i, (a, r, p)
+            in enumerate(safe_zip(avals, replicated, parts))]
   else:
     if replicated is not None:
       replicated = [r for a, r in zip(avals, replicated)
                     if a is not abstract_token]
+    tuple_parts = tuple(partitions) if partitions is not None else None
     tuple_shape = xc.Shape.tuple_shape(
         [aval_to_xla_shape(a) for a in avals if a is not abstract_token])
-    tuple_param = xb.parameter(c, 0, tuple_shape, replicated=replicated)
+    tuple_param = _xla_param(c, 0, tuple_shape, replicated, tuple_parts)
     xla_inputs = iter(xla_destructure(c, tuple_param))
     xla_args = [next(xla_inputs) if a is not abstract_token else
                 xops.CreateToken(c) for a in avals]
     assert next(xla_inputs, None) is None
     return xla_args
+
+def _xla_param(builder, param_num, xla_shape, replicated, partitions):
+  make_param = partial(xb.parameter, builder, param_num, xla_shape,
+                       replicated=replicated)
+  if partitions is None:
+    return make_param()
+  elif partitions is _replicated_param:
+    return xb.with_sharding(builder, None, make_param)
+  else:
+    return xb.with_sharding(builder, partitions, make_param)
 
 def _pval_to_result_handler(device, pval):
   pv, const = pval

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -607,7 +607,7 @@ _replicated_param = object()
 
 def _xla_callable_args(
     c, avals, tuple_args, replicated=None,
-    partitions: Optional[Sequence[Optional[Tuple[int]]]] = None):
+    partitions: Optional[Sequence[Optional[Sequence[int]]]] = None):
   assert partitions is None or len(partitions) == len(avals)
   if not tuple_args:
     if replicated is None:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2994,7 +2994,8 @@ def _reshape_sharded_device_array(array, new_sizes, old_sizes):
     if new_sizes[0] != split_axis_size: return None
     aval = ShapedArray(new_sizes, array.dtype)
     sharding_spec = pxla._pmap_sharding_spec(
-        new_sizes[0], new_sizes[0], ShapedArray(new_sizes[1:], array.dtype), True)
+        new_sizes[0], new_sizes[0], 1, None,
+        ShapedArray(new_sizes[1:], array.dtype), True)
     return pxla.ShardedDeviceArray(aval, sharding_spec, array.device_buffers)
 
   return None

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -21,10 +21,13 @@ from unittest import SkipTest
 
 import numpy as np
 from absl.testing import absltest
+from absl.testing import parameterized
 
 import jax
-from jax import vjp
+from jax import pmap, vjp
+from jax import lax
 from jax import test_util as jtu
+from jax import tree_util
 from jax.interpreters import pxla
 from jax.interpreters.sharded_jit import sharded_jit, with_sharding_constraint
 from jax.interpreters.sharded_jit import PartitionSpec as P
@@ -228,6 +231,187 @@ class ShardedJitTestNoTpu(jtu.JaxTestCase):
     self.assertIn("sharding={devices=[2,1]0,1}", hlo.as_hlo_text())
     # Annotation from sharded_jit
     self.assertIn("sharding={replicated}", hlo.as_hlo_text())
+
+class PmapOfShardedJitTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    if jtu.device_under_test() != "tpu":
+      raise SkipTest
+
+  # TODO(skye): make a similar version for ShardedJitTest and run the same tests
+  def _runTest(self, f, in_partitions, out_partitions, dtype=np.float32):
+    """Compares pmap(sharded_jit(f, ...)) to pmap(f)"""
+    shape = (2, 4, 4)
+    num_shards = shape[0] * np.prod(in_partitions[0])
+    if num_shards > jax.local_device_count():
+      raise SkipTest("requires %d devices" % num_shards)
+
+    x = np.arange(np.prod(shape, dtype=dtype)).reshape(shape)
+    y = x + 1
+    result = pmap(
+        sharded_jit(f, in_parts=in_partitions, out_parts=out_partitions))(x, y)
+    expected = pmap(f)(x, y)
+    self.assertAllClose(result, expected, check_dtypes=False)
+
+    flat_result = tree_util.tree_flatten(result)[0]
+    for r in flat_result:
+      self.assertTrue(isinstance(r, pxla.ShardedDeviceArray))
+      self.assertEqual(len(r.device_buffers), num_shards)
+
+  @parameterized.named_parameters({
+      "testcase_name":
+          "_in_parts={}_out_parts={}".format(in_partitions,
+                                             out_partitions).replace(" ", ""),
+      "in_partitions":
+          in_partitions,
+      "out_partitions":
+          out_partitions
+  } for in_partitions in [
+      (P(2, 1), P(2, 1)),
+      (P(2, 1), P(1, 2)),
+      (P(2, 2), P(2, 2)),
+      (P(4, 1), P(2, 2)),
+  ] for out_partitions in [in_partitions[0], None])
+  def testBasic(self, in_partitions, out_partitions):
+
+    def f(x, y):
+      return lax.dot(x, y)
+
+    self._runTest(f, in_partitions, out_partitions)
+
+  @parameterized.named_parameters({
+      "testcase_name":
+          "_in_parts={}_out_parts={}".format(in_partitions,
+                                             out_partitions).replace(" ", ""),
+      "in_partitions":
+          in_partitions,
+      "out_partitions":
+          out_partitions
+  } for in_partitions in [
+      (P(2, 1), P(2, 1)),
+      (P(2, 1), P(1, 2)),
+      (P(4, 1), P(2, 2))
+  ] for out_partitions in [(in_partitions[1], in_partitions[0], None),
+                           (None, None, None)])
+  def testMultipleOutputs(self, in_partitions, out_partitions):
+
+    def f(x, y):
+      a = lax.dot(x, y)
+      # TODO(skye): use these more interesting outputs once returning constants
+      # works
+      # return a, a + 1, 3
+      return a, a + x, x + y
+
+    self._runTest(f, in_partitions, out_partitions)
+
+  @parameterized.named_parameters({
+      "testcase_name":
+          "_in_parts={}_out_parts={}".format(in_partitions,
+                                             out_partitions).replace(" ", ""),
+      "in_partitions":
+          in_partitions,
+      "out_partitions":
+          out_partitions
+  } for in_partitions in [
+      (P(2, 1), P(2, 1)),
+      (P(2, 1), P(1, 2)),
+      (P(4, 1), P(2, 2))
+  ] for out_partitions in [in_partitions[0], None])
+  def testArrayConstants(self, in_partitions, out_partitions):
+
+    def f(x, y):
+      a = lax.dot(x, y)
+      b = a + jnp.ones(a.shape)
+      c = b + jnp.ones(a.shape[0])
+      return c
+
+    self._runTest(f, in_partitions, out_partitions)
+
+  def testPyTreeArgs(self):
+    if jax.local_device_count() < 4:
+      raise SkipTest("requires 4 devices")
+
+    def f(a, b, c):
+      a1, a2 = a
+      c1, (c2, c3) = c
+      return a1 + a2 + b + c1 + c2 + c3
+
+    def _make_arg(*shape):
+      return np.arange(np.prod(shape)).reshape(shape)
+
+    a = (_make_arg(2, 4, 4), _make_arg(2))
+    b = _make_arg(2, 4, 4)
+    c = (_make_arg(2), (_make_arg(2, 4, 4), _make_arg(2, 4, 4)))
+
+    in_parts = (None, P(2, 1), (None, P(2, 1)))
+    out_parts = P(2, 1)
+
+    result = pmap(sharded_jit(f, in_parts=in_parts, out_parts=out_parts))(a, b, c)
+    expected = pmap(f)(a, b, c)
+
+    self.assertAllClose(result, expected, check_dtypes=False)
+    self.assertTrue(isinstance(result, pxla.ShardedDeviceArray))
+    self.assertEqual(len(result.device_buffers), 4)
+
+  def testPyTreeOutputs(self):
+    if jax.local_device_count() < 4:
+      raise SkipTest("requires 4 devices")
+
+    def f(x):
+      return x + 1, ((x + 2, x + 3), x + 4)
+
+    shape = (2, 4, 4)
+    x = np.arange(np.prod(shape)).reshape(shape)
+    in_parts = (P(2, 1),)
+    out_parts = (P(2, 1), ((P(1, 2), None), P(2, 1)))
+
+    result = pmap(sharded_jit(f, in_parts=in_parts, out_parts=out_parts))(x)
+    expected = pmap(f)(x)
+
+    self.assertAllClose(result, expected, check_dtypes=False)
+
+  def testManyArgs(self):
+    if jax.local_device_count() < 4:
+      raise SkipTest("requires 4 devices")
+
+    num_args = 200
+
+    def f(*args):
+      return jnp.sum(args)
+
+    shape = (2, 4, 4)
+    args = [np.arange(np.prod(shape)).reshape(shape)] * num_args
+    in_partitions = (P(2, 1),) * num_args
+    out_partitions = None
+    result = pmap(sharded_jit(
+        f, in_parts=in_partitions, out_parts=out_partitions))(*args)
+    expected = pmap(f)(*args)
+
+    self.assertAllClose(result, expected, check_dtypes=False)
+    self.assertTrue(isinstance(result, pxla.ShardedDeviceArray))
+    self.assertEqual(len(result.device_buffers), 4)
+
+  def testShardingConstraint(self):
+    if jax.local_device_count() < 4:
+      raise SkipTest("requires 4 devices")
+
+    @partial(sharded_jit, in_parts=None, out_parts=None)
+    def f(x):
+      y = jnp.dot(x, x)
+      y = with_sharding_constraint(y, P(2,1))
+      return y * 2
+
+    def expected_f(x):
+      return jnp.dot(x, x) * 2
+
+    shape = (2, 8, 8)
+    x = np.arange(np.prod(shape)).reshape(shape)
+    result = pmap(f)(x)
+    expected = pmap(expected_f)(x)
+
+    self.assertAllClose(result, expected, check_dtypes=False)
+    self.assertIsInstance(result, pxla.ShardedDeviceArray)
+    self.assertLen(result.device_buffers, 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At a high level, we support `pmap` of `sharded_jit` by teaching `parallel_callable` about partitioning, and having it look at the traced jaxpr to see if it contains a `sharded_jit` call. This reuses much of the logic currently used by `_sharded_callable` to find any partitionings and derive the correct data sharding.

This PR only implements the `pmap(sharded_jit(f))` case; it raises an error if there are other operations being pmapped over. It also does not implement returning a constant value from `f` or multi-host `pmap` of `sharded_jit`.