### PR TITLE
Fix in pxla._inner_partitions

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -784,7 +784,7 @@ def _inner_partitions(jaxpr, expected_num_parts: Optional[int]):
   Also validates that this number matches `expected_num_parts` if provided.
   """
   for eqn in jaxpr.eqns:
-    if eqn.primitive == "sharding_constraint":
+    if eqn.primitive.name == "sharding_constraint":
       parts = eqn.params["partitions"]
       nparts = get_num_partitions(parts)
       if expected_num_parts is None:


### PR DESCRIPTION
In cb77f2a22de49e85da93f43b7dc448aa238d5207, I switched to looking for
sharding_constraint_p's name since sharding_constraint_p itself is
defined in sharded_jit.py, but didn't quite get the update right.