### PR TITLE
WIP: make standard abstract eval rules keep weak_type

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -100,7 +100,8 @@ def aval_to_result_handler(device: Optional[Device], aval: core.ShapedArray):
     raise TypeError(f"No xla_result_handler for type: {type(aval)}") from err
 
 def array_result_handler(device: Optional[Device], aval: core.ShapedArray):
-  return partial(DeviceArray, raise_to_shaped(aval), device, lazy.array(aval.shape))
+  return partial(DeviceArray, raise_to_shaped(aval, weak_type=aval.weak_type),
+                 device, lazy.array(aval.shape))
 
 xla_result_handlers: Dict[Type[core.AbstractValue], Callable[..., Callable]] = {
     core.AbstractUnit: lambda _, __: lambda _: core.unit,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1723,11 +1723,14 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
   least_specialized = _max(
       map(type, args), key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is ConcreteArray:
-    return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs))
+    return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs),
+                         weak_type=all(x.weak_type for x in args))
   elif least_specialized is ShapedArray:
-    return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs))
+    return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs),
+                       weak_type=all(x.weak_type for x in args))
   elif least_specialized is UnshapedArray:
-    return UnshapedArray(dtype_rule(*args, **kwargs))
+    return UnshapedArray(dtype_rule(*args, **kwargs),
+                         weak_type=all(x.weak_type for x in args))
   else:
     raise TypeError(args, least_specialized)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1706,6 +1706,23 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, msg):
       g(jnp.ones((1, 1)), b=1)
 
+  def test_weak_type_jit_caching(self):
+    # https://github.com/google/jax/issues/3163
+    my_fn_calls = 0
+
+    @jax.jit
+    def my_fn(x, y):
+        nonlocal my_fn_calls
+        my_fn_calls += 1
+        return x + y
+
+    x = 0
+    for i in range(10):
+        x = my_fn(x, i)
+
+    self.assertEqual(my_fn_calls, 1)
+
+
 class JaxprTest(jtu.JaxTestCase):
 
   def test_scalar_literals(self):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -104,7 +104,7 @@ class DtypesTest(jtu.JaxTestCase):
     op = jax.jit(operator.add) if jit else operator.add
     for x, y, dtype in testcases:
       x, y = (y, x) if swap else (x, y)
-      z = x + y
+      z = op(x, y)
       self.assertTrue(isinstance(z, jnp.ndarray), msg=(x, y, z))
       self.assertEqual(z.dtype, dtypes.canonicalize_dtype(dtype), msg=(x, y, z))
 


### PR DESCRIPTION
Attempting to fix #3163, but running into issues.

@hawkinsp can you share some wisdom, after reading #3163?