### PR TITLE
Fix experimental host callback on multi-host

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -849,8 +849,9 @@ def outfeed_receiver(*,
   """
   if not devices:
     backends = backends or xla_client._get_local_backends().keys()
-    devices = tuple(itertools.chain(*[api.local_devices(backend)
-                                      for backend in backends]))
+    devices = tuple(itertools.chain(
+        *[api.local_devices(api.host_id(backend), backend)
+          for backend in backends]))
   else:
     if backends:
       raise ValueError("At most one of `devices` or `backends` must be given.")

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -849,7 +849,7 @@ def outfeed_receiver(*,
   """
   if not devices:
     backends = backends or xla_client._get_local_backends().keys()
-    devices = tuple(itertools.chain(*[api.devices(backend)
+    devices = tuple(itertools.chain(*[api.local_devices(backend)
                                       for backend in backends]))
   else:
     if backends:


### PR DESCRIPTION
Hosts can only access the outfeed queue for local devices, while `api.devices` returns all devices in the system.