### PR TITLE
Remove pe (partial_eval) from name_stack in XLA metadata.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -167,8 +167,6 @@ class JaxprTrace(Trace):
     if (self.master.trace_type is StagingJaxprTrace
         and call_primitive in staged_out_calls):
       tracers = map(self.instantiate_const_abstracted, tracers)
-    else:
-      name = wrap_name(name, 'pe')
     params = dict(params, name=name)
 
     if call_primitive in call_partial_eval_rules:

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -67,10 +67,10 @@ class MetadataTest(jtu.JaxTestCase):
     self.assertRegex(hlo, 'op_type="sin"')
     self.assertRegex(hlo, 'op_type="cos"')
     self.assertRegex(hlo, 'op_type="mul"')
-    self.assertRegex(hlo, 'op_name=".*jit\\(pe\\(jvp\\(foo\\)\\)\\)/sin"')
-    self.assertRegex(hlo, 'op_name=".*jit\\(pe\\(jvp\\(foo\\)\\)\\)/cos"')
+    self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/sin"')
+    self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/cos"')
     self.assertRegex(hlo, 'op_name=".*jit\\(transpose\\('
-                          'pe\\(jvp\\(foo\\)\\)\\)\\)/mul"')
+                          'jvp\\(foo\\)\\)\\)/mul"')
 
   def test_cond_metadata(self):
     def true_fun(x):


### PR DESCRIPTION
The `pe` is supposed to denote partial evaluation, however it is showing up in other places (eg. in the body of a pmap). Because you should only expect to see `pe` in the following sequence (in the context of AD): `transpose -> pe -> jvp`, we opted to drop the `pe` from the name stack.