### PR TITLE
`odeint(f)` fails when `f` has a custom jvp

### DIFF
--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -310,34 +310,34 @@ class JetTest(jtu.JaxTestCase):
     assert g_out_primals == f_out_primals
     assert g_out_series == f_out_series
 
-def test_odeint_jet_softplus(self):
-    # check if this composition fails
-    from jax.experimental.ode import odeint
-    import jax.numpy as jnp
+  def test_odeint_jet_softplus(self):
+      # check if this composition fails
+      from jax.experimental.ode import odeint
+      import jax.numpy as jnp
 
-    dims = (2, 3)
-    order = 3
+      dims = (2, 3)
+      order = 3
 
-    # explicitly broadcast zeros since current max rule doesn't do that
-    softplus_prim = lambda x: jnp.logaddexp(x, jnp.zeros_like(x))
+      # explicitly broadcast zeros since current max rule doesn't do that
+      softplus_prim = lambda x: jnp.logaddexp(x, jnp.zeros_like(x))
 
-    def dynamics_jet_expit(x, t):
-      primal_in = jnp.ones_like(x)
-      terms_in = [jnp.ones_like(x) for _ in range(order)]
-      primals = (primal_in, )
-      series = (terms_in, )
-      return jet(softplus_prim, primals, series)[1][-1]
+      def dynamics_jet_expit(x, t):
+        primal_in = jnp.ones_like(x)
+        terms_in = [jnp.ones_like(x) for _ in range(order)]
+        primals = (primal_in, )
+        series = (terms_in, )
+        return jet(softplus_prim, primals, series)[1][-1]
 
-    x0 = jnp.zeros(dims)
-    ts = jnp.array([0., 1.])
+      x0 = jnp.zeros(dims)
+      ts = jnp.array([0., 1.])
 
-    # fails due to primitive.multiple_results = True
-    # odeint(dynamics_jet_expit, x0, ts)
+      # fails due to primitive.multiple_results = True
+      # odeint(dynamics_jet_expit, x0, ts)
 
-    # also need to take gradients!
-    # TODO: check that it's a) numerically correct and b) numerically stable over large ranges
-    y_dot, vjpfun = jax.vjp(lambda _x0: odeint(dynamics_jet_expit, _x0, ts), x0)
-    vjpfun(y_dot)
+      # also need to take gradients!
+      # TODO: check that it's a) numerically correct and b) numerically stable over large ranges
+      y_dot, vjpfun = jax.vjp(lambda _x0: odeint(dynamics_jet_expit, _x0, ts), x0)
+      vjpfun(y_dot)
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -229,6 +229,10 @@ class JetTest(jtu.JaxTestCase):
   def test_erf(self):        self.unary_check(lax.erf)
   @jtu.skip_on_devices("tpu")
   def test_erfc(self):       self.unary_check(lax.erfc)
+  @jtu.skip_on_devices("tpu")
+  def test_softplus2(self):   self.unary_check(lambda x: jax.numpy.logaddexp(x, jax.numpy.zeros_like(x)),
+                                               lims=[-500, 500],
+                                               order=5)
 
   @jtu.skip_on_devices("tpu")
   def test_div(self):   self.binary_check(lambda x, y: x / y, lims=[0.8, 4.0])
@@ -261,6 +265,10 @@ class JetTest(jtu.JaxTestCase):
   def test_pow(self):  self.binary_check(lambda x, y: x ** y, lims=([0.2, 500], [-500, 500]), finite=False)
   @jtu.skip_on_devices("tpu")
   def test_atan2(self):      self.binary_check(lax.atan2, lims=[-40, 40])
+  @jtu.skip_on_devices("tpu")
+  def test_lax_max(self):    self.binary_check(lax.max)
+  @jtu.skip_on_devices("tpu")
+  def test_lax_min(self):    self.binary_check(lax.min)
 
   def test_process_call(self):
     def f(x):


### PR DESCRIPTION
@mattjj @jessebett @duvenaud 