### PR TITLE
Prefer using broadcast_in_dim/squeeze instead of reshape

### DIFF
--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -69,6 +69,7 @@ Operators
     erfc
     erf_inv
     exp
+    expand_dims
     expm1
     fft
     floor

--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -121,6 +121,7 @@ Operators
     sort_key_val
     sqrt
     square
+    squeeze
     sub
     tan
     tie_in

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -286,7 +286,7 @@ from .lax import (_reduce_sum, _reduce_max, _reduce_min, _reduce_or,
                   _const, _eq_meet, _broadcasting_select,
                   _check_user_dtype_supported, _one, _const,
                   _upcast_fp16_for_computation, _broadcasting_shape_rule,
-                  _eye, _tri, _delta, _ones, _zeros)
+                  _eye, _tri, _delta, _ones, _zeros, _canonicalize_axis)
 from .lax_control_flow import (
   cond,
   cond_p,

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -254,6 +254,8 @@ from .lax import (
   sqrt,
   sqrt_p,
   square,
+  squeeze,
+  squeeze_p,
   standard_abstract_eval,
   standard_naryop,
   standard_primitive,

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -120,6 +120,7 @@ from .lax import (
   erfc_p,
   exp,
   exp_p,
+  expand_dims,
   expm1,
   expm1_p,
   floor,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1073,8 +1073,6 @@ def _get_min_identity(dtype: DType) -> Array:
     return onp.array(True, onp.bool_)
 
 def _reduce_sum(operand: Array, axes: Sequence[int]) -> Array:
-  if all(operand.shape[i] == 1 for i in axes):
-    return squeeze(operand, axes)
   return reduce_sum_p.bind(operand, axes=tuple(axes))
 
 def _reduce_prod(operand: Array, axes: Sequence[int]) -> Array:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2936,7 +2936,7 @@ batching.primitive_batchers[pad_p] = _pad_batch_rule
 # JAXpr is that we are reshaping from (1, 1) to (1,).
 # In constrast, squeeze[ dimensions=(0,) ] is unambiguous.
 
-def squeeze(array, dimensions: Tuple[int, ...]):
+def squeeze(array: Array, dimensions: Tuple[int, ...]) -> Array:
   """Squeeze any number of size 1 dimensions from an array."""
   ndim = onp.ndim(array)
   dimensions = tuple(sorted(_canonicalize_axis(i, ndim) for i in dimensions))
@@ -2983,7 +2983,7 @@ ad.deflinear2(squeeze_p, _squeeze_transpose_rule)
 batching.primitive_batchers[squeeze_p] = _squeeze_batch_rule
 
 
-def expand_dims(array, dimensions: Tuple[int, ...]):
+def expand_dims(array: Array, dimensions: Tuple[int, ...]) -> Array:
   """Insert any number of size 1 dimensions into an array."""
   ndim_out = onp.ndim(array) + len(dimensions)
   dims_set = frozenset(_canonicalize_axis(i, ndim_out) for i in dimensions)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -621,14 +621,15 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
                     lhs_batch_dims + lhs_noncontract_dims + lhs_contract_dims)
     rhs = transpose(rhs,
                     rhs_batch_dims + rhs_noncontract_dims + rhs_contract_dims)
-    new_lhs_shape = onp.insert(onp.array(onp.shape(lhs), dtype=onp.int64),
-                               len(lhs_batch_dims) + len(lhs_noncontract_dims),
-                               (1,) * len(rhs_noncontract_dims))
-    new_rhs_shape = onp.insert(onp.array(onp.shape(rhs), dtype=onp.int64),
-                               len(lhs_batch_dims),
-                               (1,) * len(lhs_noncontract_dims))
-    lhs = reshape(lhs, new_lhs_shape)
-    rhs = reshape(rhs, new_rhs_shape)
+
+    lhs_start_expand = len(lhs_batch_dims) + len(lhs_noncontract_dims)
+    lhs_end_expand = lhs_start_expand + len(rhs_noncontract_dims)
+    lhs = expand_dims(lhs, tuple(range(lhs_start_expand, lhs_end_expand)))
+
+    rhs_start_expand = len(lhs_batch_dims)
+    rhs_end_expand = rhs_start_expand + len(lhs_noncontract_dims)
+    rhs = expand_dims(rhs, tuple(range(rhs_start_expand, rhs_end_expand)))
+
     out_ndim = (len(lhs_batch_dims) + len(lhs_noncontract_dims) +
                 len(rhs_noncontract_dims))
     op_product = bitwise_and if lhs.dtype == onp.bool_ else mul
@@ -993,7 +994,7 @@ def scatter(operand: Array, scatter_indices:Array, updates: Array,
       update_consts=consts, dimension_numbers=dimension_numbers)
 
 def index_take(src: Array, idxs: Array, axes: Sequence[int]) -> Array:
-  indices = concatenate([reshape(i, [i.shape[0], 1]) for i in idxs], 1)
+  indices = concatenate([expand_dims(i, (1,)) for i in idxs], 1)
   indices = indices % onp.array([src.shape[ax] for ax in axes])
   slice_sizes = list(src.shape)
   for ax in axes:
@@ -1553,7 +1554,7 @@ def index_in_dim(operand: Array, index: int, axis: int = 0,
   if keepdims:
     return result
   else:
-    return reshape(result, onp.delete(operand.shape, axis))
+    return squeeze(result, (axis,))
 
 
 def dynamic_slice_in_dim(operand: Array, start_index: Array,
@@ -1575,7 +1576,7 @@ def dynamic_index_in_dim(operand: Array, index: Array, axis: int = 0,
   if keepdims:
     return result
   else:
-    return reshape(result, onp.delete(operand.shape, axis))
+    return squeeze(result, (axis,))
 
 
 def dynamic_update_slice_in_dim(operand: Array, update: Array,
@@ -1591,8 +1592,7 @@ def dynamic_update_index_in_dim(operand: Array, update: Array, index: Array,
   axis = int(axis)
   if _ndim(update) != _ndim(operand):
     assert _ndim(update) + 1 == _ndim(operand)
-    ax = axis % _ndim(operand)
-    update = reshape(update, operand.shape[:ax] + (1,) + operand.shape[ax+1:])
+    update = expand_dims(update, (axis,))
   return dynamic_update_slice_in_dim(operand, update, index, axis)
 
 
@@ -1845,8 +1845,8 @@ def _brcast_to(x, shape):
     assert len(x_shape) == len(shape)
     broadcast_dimensions, = onp.where(onp.equal(x_shape, shape))
     squeezed_dimensions, = onp.where(onp.not_equal(x_shape, shape))
-    inshape = onp.delete(x_shape, squeezed_dimensions)
-    return broadcast_in_dim(reshape(x, inshape), shape, broadcast_dimensions)
+    squeezed = squeeze(x, squeezed_dimensions)
+    return broadcast_in_dim(squeezed, shape, broadcast_dimensions)
   else:
     return broadcast(x, shape)
 
@@ -2927,7 +2927,8 @@ batching.primitive_batchers[pad_p] = _pad_batch_rule
 
 def squeeze(array, dimensions: Tuple[int, ...]):
   """Squeeze any number of size 1 dimensions from an array."""
-  dimensions = tuple(map(operator.index, dimensions))
+  ndim_out = onp.ndim(array) + len(dimensions)
+  dimensions = tuple(_canonicalize_axis(i, ndim_out) for i in dimensions)
   if not dimensions:
     return array
   return squeeze_p.bind(array, dimensions=dimensions)
@@ -2973,6 +2974,17 @@ squeeze_p = standard_primitive(_squeeze_shape_rule, _squeeze_dtype_rule,
                                'squeeze', _squeeze_translation_rule)
 ad.deflinear2(squeeze_p, _squeeze_transpose_rule)
 batching.primitive_batchers[squeeze_p] = _squeeze_batch_rule
+
+
+def expand_dims(array, dimensions: Tuple[int, ...]):
+  """Insert any number of size 1 dimensions into an array."""
+  ndim_out = onp.ndim(array) + len(dimensions)
+  dims_set = frozenset(_canonicalize_axis(i, ndim_out) for i in dimensions)
+  result_shape = list(onp.shape(array))
+  for i in sorted(dims_set):
+    result_shape.insert(i, 1)
+  broadcast_dims = [i for i in range(ndim_out) if i not in dims_set]
+  return broadcast_in_dim(array, result_shape, broadcast_dims)
 
 
 # We have a nonstandard reshape impl so that we can be lazy about data movement.
@@ -3372,7 +3384,7 @@ def _dynamic_slice_transpose_rule(t, operand, *start_indices, slice_sizes):
 def _batch_dynamic_slice_indices(indices, bdims):
   size = next((x.shape[i] for x, i in zip(indices, bdims) if i is not None), -1)
   if size < 0:
-    return concatenate([reshape(i, [1]) for i in indices], 0), None
+    return concatenate([broadcast(i, (1,)) for i in indices], 0), None
   indices = concatenate(
     [broadcast_in_dim(x, (size, 1),
                       broadcast_dimensions=((0,) if i is not None else ()))
@@ -4437,7 +4449,7 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
     operand = batching.moveaxis(operand, o_bdims, 0)
     outputs = [
         _select_and_scatter_add(s, o, **kwargs) for s, o in zip(source, operand)]
-    outputs = [reshape(out, (1,) + out.shape) for out in outputs]
+    outputs = [broadcast(out, (1,)) for out in outputs]
     outputs = concatenate(outputs, 0)
     return outputs, 0
   elif s_bdims is not None:
@@ -4445,7 +4457,7 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
     source = batching.moveaxis(source, s_bdims, 0)
     outputs = [
         _select_and_scatter_add(s, operand, **kwargs) for s in source]
-    outputs = [reshape(out, (1,) + out.shape) for out in outputs]
+    outputs = [broadcast(out, (1,)) for out in outputs]
     outputs = concatenate(outputs, 0)
     return outputs, 0
   elif o_bdims is not None:
@@ -4453,7 +4465,7 @@ def _select_and_scatter_add_batch_rule(batched_args, batch_dims, **kwargs):
     operand = batching.moveaxis(operand, o_bdims, 0)
     outputs = [
         _select_and_scatter_add(source, o, **kwargs) for o in operand]
-    outputs = [reshape(out, (1,) + out.shape) for out in outputs]
+    outputs = [broadcast(out, (1,)) for out in outputs]
     outputs = concatenate(outputs, 0)
     return outputs, 0
 
@@ -5239,7 +5251,7 @@ def _dynamic_slice_indices(operand, start_indices):
     if start_indices.ndim != 1:
       raise ValueError("Slice indices must be a 1D sequence, got {}"
                        .format(start_indices.shape))
-    start_indices = [reshape(slice(start_indices, [i], [i+1]), ())
+    start_indices = [squeeze(slice(start_indices, [i], [i+1]), dimensions=(0,))
                      for i in range(operand.ndim)]
   else:
     start_indices = [onp.asarray(i, dtype=dtypes.int_) if isinstance(i, int)
@@ -5444,7 +5456,7 @@ def _check_user_dtype_supported(dtype, fun_name=None):
 
 def _canonicalize_axis(axis, num_dims):
   """Canonicalize an axis in (-num_dims, num_dims) to [0, num_dims)."""
-  axis = int(axis)
+  axis = operator.index(axis)
   if axis < 0:
     axis = axis + num_dims
   if axis < 0 or axis >= num_dims:

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -223,6 +223,8 @@ def broadcast_in_dim(operand, shape, broadcast_dimensions):
 
 sum = np.sum
 
+squeeze = np.squeeze
+
 def reshape(operand, new_sizes, dimensions=None):
   if dimensions is None:
     dimensions = range(len(np.shape(operand)))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -293,7 +293,7 @@ def _constant_like(x, const):
 
 def _canonicalize_axis(axis, num_dims):
   """Canonicalize an axis in (-num_dims, num_dims) to [0, num_dims)."""
-  axis = int(axis)
+  axis = operator.index(axis)
   if axis < 0:
     axis = axis + num_dims
   if axis < 0 or axis >= num_dims:
@@ -1164,16 +1164,9 @@ def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):
 
 @_wraps(np.expand_dims)
 def expand_dims(a, axis: Union[int, Tuple[int, ...]]):
-  shape = _shape(a)
   if isinstance(axis, int):
     axis = (axis,)
-  ndim_out = ndim(a) + len(axis)
-  axis_set = frozenset(_canonicalize_axis(i, ndim_out) for i in axis)
-  result_shape = list(shape)
-  for i in sorted(axis_set):
-    result_shape.insert(i, 1)
-  broadcast_dims = [i for i in range(ndim_out) if i not in axis_set]
-  return lax.broadcast_in_dim(a, result_shape, broadcast_dims)
+  return lax.expand_dims(a, axis)
 
 
 @_wraps(np.swapaxes)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2662,11 +2662,8 @@ def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
   dim_numbers = (((ndim(a) - 1,), (ndim(b) - 2,)), (batch_dims, batch_dims))
   result = lax.dot_general(a, b, dim_numbers,  precision)
 
-  if a_is_vec or b_is_vec:
-    squeeze_dims = ((-2,) if a_is_vec else ()) + ((-1,) if b_is_vec else ())
-    return squeeze(result, squeeze_dims)
-  else:
-    return result
+  squeeze_dims = ((-2,) if a_is_vec else ()) + ((-1,) if b_is_vec else ())
+  return squeeze(result, squeeze_dims)
 
 
 @_wraps(np.vdot, lax_description=_PRECISION_DOC)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2153,7 +2153,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
   if ndmin > ndim(out):
-    out = broadcast_to(out, (1,) * (ndmin - ndim(out)) + shape(out))
+    out = lax.broadcast(out, (1,) * (ndmin - ndim(out)))
   return out
 
 @_wraps(np.asarray)
@@ -2396,7 +2396,7 @@ def ix_(*args):
       # Numpy uses an integer index type for empty arrays.
       output.append(lax.full(shape, np.zeros((), np.intp)))
     else:
-      output.append(lax.broadcast_in_dim(a, shape, [i]))
+      output.append(lax.broadcast_in_dim(a, shape, (i,)))
   return tuple(output)
 
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1155,21 +1155,11 @@ def unravel_index(indices, shape):
 def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):
   shape_a = shape(a)
   if axis is None:
-    if 1 not in shape_a:
-      return a
-    indices = tuple(0 if d == 1 else slice(None) for d in shape_a)
-  else:
-    if isinstance(axis, int):
-      axis = (axis,)
-    axis_set = frozenset(_canonicalize_axis(i, ndim(a)) for i in axis)
-    if not axis_set:
-      return a
-    if _any(shape_a[a] != 1 for a in axis_set):
-      raise ValueError("cannot select an axis to squeeze out which has size "
-                       "not equal to one")
-    indices = tuple(0 if i in axis_set else slice(None) for i in range(len(shape_a)))
-  # TODO: consider using lax.slice instead here?
-  return a[indices]
+    axis = tuple(i for i, d in enumerate(shape_a) if d == 1)
+  elif isinstance(axis, int):
+    axis = (axis,)
+  axis = tuple(_canonicalize_axis(i, ndim(a)) for i in axis)
+  return lax.squeeze(a, axis)
 
 
 @_wraps(np.expand_dims)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -218,8 +218,7 @@ def _promote_shapes(fun_name, *args):
       if FLAGS.jax_numpy_rank_promotion != "allow":
         _rank_promotion_warning_or_error(fun_name, shapes)
       result_rank = len(lax.broadcast_shapes(*shapes))
-      return [lax.reshape(arg, (1,) * (result_rank - len(shp)) + shp)
-              if shp and len(shp) != result_rank else arg
+      return [broadcast_to(arg, (1,) * (result_rank - len(shp)) + shp)
               for arg, shp in zip(args, shapes)]
 
 def _rank_promotion_warning_or_error(fun_name, shapes):
@@ -1153,29 +1152,38 @@ def unravel_index(indices, shape):
 
 
 @_wraps(np.squeeze)
-def squeeze(a, axis=None):
+def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):
   shape_a = shape(a)
   if axis is None:
     if 1 not in shape_a:
       return a
-    newshape = [d for d in shape_a if d != 1]
+    indices = tuple(0 if d == 1 else slice(None) for d in shape_a)
   else:
     if isinstance(axis, int):
       axis = (axis,)
-    axis = frozenset(_canonicalize_axis(i, ndim(a)) for i in axis)
-    if _any(shape_a[a] != 1 for a in axis):
+    axis_set = frozenset(_canonicalize_axis(i, ndim(a)) for i in axis)
+    if not axis_set:
+      return a
+    if _any(shape_a[a] != 1 for a in axis_set):
       raise ValueError("cannot select an axis to squeeze out which has size "
                        "not equal to one")
-    newshape = [d for i, d in enumerate(shape_a)
-                if d != 1 or i not in axis]
-  return lax.reshape(a, newshape)
+    indices = tuple(0 if i in axis_set else slice(None) for i in range(len(shape_a)))
+  # TODO: consider using lax.slice instead here?
+  return a[indices]
 
 
 @_wraps(np.expand_dims)
-def expand_dims(a, axis):
+def expand_dims(a, axis: Union[int, Tuple[int, ...]]):
   shape = _shape(a)
-  axis = _canonicalize_axis(axis, ndim(a) + 1)
-  return lax.reshape(a, shape[:axis] + (1,) + shape[axis:])
+  if isinstance(axis, int):
+    axis = (axis,)
+  ndim_out = ndim(a) + len(axis)
+  axis_set = frozenset(_canonicalize_axis(i, ndim_out) for i in axis)
+  result_shape = list(shape)
+  for i in sorted(axis_set):
+    result_shape.insert(i, 1)
+  broadcast_dims = [i for i in range(ndim_out) if i not in axis_set]
+  return lax.broadcast_in_dim(a, result_shape, broadcast_dims)
 
 
 @_wraps(np.swapaxes)
@@ -1372,7 +1380,7 @@ def broadcast_to(arr, shape):
     diff, = np.where(np.not_equal(shape[nlead:], arr_shape))
     new_dims = tuple(range(nlead)) + tuple(nlead + diff)
     kept_dims = tuple(np.delete(np.arange(len(shape)), new_dims))
-    return lax.broadcast_in_dim(squeeze(arr, diff), shape, kept_dims)
+    return lax.broadcast_in_dim(squeeze(arr, tuple(diff)), shape, kept_dims)
 
 
 @_wraps(np.split)
@@ -1552,8 +1560,7 @@ def _make_reduction(np_fun, op, init_val, preproc=None, bool_op=None,
     result = lax.reduce(a, _reduction_init_val(a, init_val),
                         op if computation_dtype != np.bool_ else bool_op, dims)
     if keepdims:
-      shape_with_singletons = subvals(shape(a), zip(dims, (1,) * len(dims)))
-      result = lax.reshape(result, shape_with_singletons)
+      result = expand_dims(result, dims)
     return lax.convert_element_type(result, dtype or result_dtype)
 
   return reduction
@@ -1989,13 +1996,11 @@ def stack(arrays, axis=0):
     raise ValueError("Need at least one array to stack.")
   shape0 = shape(arrays[0])
   axis = _canonicalize_axis(axis, len(shape0) + 1)
-  new_shape = list(shape0)
-  new_shape.insert(axis, 1)
   new_arrays = []
   for a in arrays:
     if shape(a) != shape0:
       raise ValueError("All input arrays must have the same shape.")
-    new_arrays.append(reshape(a, new_shape))
+    new_arrays.append(expand_dims(a, axis))
   return concatenate(new_arrays, axis=axis)
 
 @_wraps(np.tile)
@@ -2054,7 +2059,7 @@ def column_stack(tup):
   for v in tup:
     arr = array(v)
     if arr.ndim < 2:
-      arr = arr.reshape((-1, 1))
+      arr = expand_dims(arr, axis=0)
     arrays.append(arr)
   return concatenate(arrays, 1)
 
@@ -2099,7 +2104,12 @@ def atleast_1d(*arys):
 def atleast_2d(*arys):
   if len(arys) == 1:
     arr = array(arys[0])
-    return arr if ndim(arr) >= 2 else reshape(arr, (1, -1))
+    if ndim(arr) >= 2:
+      return arr
+    elif ndim(arr) == 1:
+      return expand_dims(arr, axis=0)
+    else:
+      return expand_dims(arr, axis=(0, 1))
   else:
     return [atleast_2d(arr) for arr in arys]
 
@@ -2108,10 +2118,12 @@ def atleast_2d(*arys):
 def atleast_3d(*arys):
   if len(arys) == 1:
     arr = array(arys[0])
-    if ndim(arr) <= 1:
-      arr = reshape(arr, (1, -1, 1))
+    if ndim(arr) == 0:
+      arr = expand_dims(arr, axis=(0, 1, 2))
+    elif ndim(arr) == 1:
+      arr = expand_dims(arr, axis=(0, 2))
     elif ndim(arr) == 2:
-      arr = reshape(arr, shape(arr) + (1,))
+      arr = expand_dims(arr, axis=2)
     return arr
   else:
     return [atleast_3d(arr) for arr in arys]
@@ -2151,7 +2163,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
   if ndmin > ndim(out):
-    out = lax.reshape(out, (1,) * (ndmin - ndim(out)) + shape(out))
+    out = broadcast_to(out, (1,) * (ndmin - ndim(out)) + shape(out))
   return out
 
 @_wraps(np.asarray)
@@ -2394,7 +2406,7 @@ def ix_(*args):
       # Numpy uses an integer index type for empty arrays.
       output.append(lax.full(shape, np.zeros((), np.intp)))
     else:
-      output.append(lax.reshape(a, shape))
+      output.append(lax.broadcast_in_dim(a, shape, [i]))
   return tuple(output)
 
 
@@ -2639,8 +2651,8 @@ def dot(a, b, *, precision=None):  # pylint: disable=missing-docstring
 def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
   _check_arraylike("matmul", a, b)
   a_is_vec, b_is_vec = (ndim(a) == 1), (ndim(b) == 1)
-  a = lax.reshape(a, (1,) + shape(a)) if a_is_vec else a
-  b = lax.reshape(b, shape(b) + (1,)) if b_is_vec else b
+  a = expand_dims(a, axis=0) if a_is_vec else a
+  b = expand_dims(b, axis=-1) if b_is_vec else b
 
   a, b = _promote_dtypes(a, b)
   batch_shape = lax.broadcast_shapes(shape(a)[:-2], shape(b)[:-2])
@@ -2651,10 +2663,8 @@ def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
   result = lax.dot_general(a, b, dim_numbers,  precision)
 
   if a_is_vec or b_is_vec:
-    m, n = shape(result)[-2:]
-    new_m = () if a_is_vec else (m,)
-    new_n = () if b_is_vec else (n,)
-    return lax.reshape(result, batch_shape + new_m + new_n)
+    squeeze_dims = ((-2,) if a_is_vec else ()) + ((-1,) if b_is_vec else ())
+    return squeeze(result, squeeze_dims)
   else:
     return result
 
@@ -3309,7 +3319,7 @@ def unique(ar, return_index=False, return_inverse=False,
 def _rewriting_take(arr, idx):
   # Computes arr[idx].
   # All supported cases of indexing can be implemented as an XLA gather,
-  # followed by an optional reverse and a reshape.
+  # followed by an optional reverse and broadcast_in_dim.
   arr = asarray(arr)
   treedef, static_idx, dynamic_idx = _split_index_for_jit(idx)
   return _gather(arr, treedef, static_idx, dynamic_idx)
@@ -3337,7 +3347,7 @@ def _gather(arr, treedef, static_idx, dynamic_idx):
     y = lax.rev(y, indexer.reversed_y_dims)
 
   # This adds np.newaxis/None dimensions.
-  return lax.reshape(y, indexer.slice_shape)
+  return expand_dims(y, indexer.newaxis_dims)
 
 _Indexer = collections.namedtuple("_Indexer", [
   # The expected shape of the slice output.
@@ -3356,9 +3366,8 @@ _Indexer = collections.namedtuple("_Indexer", [
   # the gather.
   "reversed_y_dims",
 
-  # For scatters, we must eliminate any axes created by `newaxis`, which
-  # are the following dimensions, which must be of size 1. For gathers, we
-  # simply reshape to `slice_shape` to introduce the new axes.
+  # Keep track of any axes created by `newaxis`. These must be inserted for
+  # gathers and eliminated for scatters.
   "newaxis_dims",
 ])
 

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -103,8 +103,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
   if b is not None or return_sign:
     raise NotImplementedError("Only implemented for b=None, return_sign=False")
   dims = _reduction_dims(a, axis)
-  shape = util.subvals(np.shape(a), zip(dims, (1,) * len(dims)))
-  dimadd = lambda x: lax.reshape(x, shape)
+  dimadd = lambda x: lax.expand_dims(x, dims)
   amax = lax.reduce(a, _constant_like(a, -np.inf), lax.max, dims)
   amax = lax.select(lax.is_finite(amax), amax, lax.full_like(amax, 0))
   amax_singletons = dimadd(amax)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1814,14 +1814,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
                   + [(0,), (len(arg_shape), len(arg_shape) + 1)])))
   def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng_factory):
-    if isinstance(dim, tuple) and numpy_version < (1, 18, 0):
-      raise SkipTest("support for multiple axes added in NumPy 1.18.0")
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.expand_dims(x, dim)
     jnp_fun = lambda x: jnp.expand_dims(x, dim)
     args_maker = lambda: [rng(arg_shape, dtype)]
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
+
+    if isinstance(dim, tuple) and numpy_version < (1, 18, 0):
+      raise SkipTest("support for multiple axes added in NumPy 1.18.0")
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_axes=({},{})".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1860,23 +1860,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_axis={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype), ax),
-       "arg_shape": arg_shape, "dtype": dtype, "ax": ax,
-       "rng_factory": jtu.rand_default}
-      for arg_shape, ax in [
-          ((3,), 0),
-          ((1, 3), 1),
-          ((1, 3, 1), (0, 1))]
-      for dtype in default_dtypes))
-  def testSqueezeFailsOnNonsingletonAxis(self, arg_shape, dtype, ax,
-                                         rng_factory):
-    rng = rng_factory(self.rng())
-    x = jnp.zeros(arg_shape, dtype=dtype)
-    fun = lambda: jnp.squeeze(x, ax)
-    self.assertRaisesRegex(ValueError, "cannot select an axis to squeeze", fun)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}_weights={}_returned={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           axis,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1811,8 +1811,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_default}
       for arg_shape in [(), (3,), (3, 4)]
       for dtype in default_dtypes
-      for dim in range(-len(arg_shape)+1, len(arg_shape))))
+      for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
+                  + [(0,), (len(arg_shape), len(arg_shape) + 1)])))
   def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng_factory):
+    if isinstance(dim, tuple) and numpy_version < (1, 18, 0):
+      raise SkipTest("support for multiple axes added in NumPy 1.18.0")
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.expand_dims(x, dim)
     jnp_fun = lambda x: jnp.expand_dims(x, dim)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -897,8 +897,8 @@ class LaxTest(jtu.JaxTestCase):
       "err_msg": err_msg}
     for inshape, dimensions, error_type, err_msg in [
       ((1, 2, 3), (0, 0), ValueError, 'dimensions are not unique'),
-      ((1, 2, 3), (3,), ValueError, 'dimensions outside range'),
-      ((1, 2, 3), (-1,), ValueError, 'dimensions outside range'),
+      ((1, 2, 3), (3,), ValueError, 'axis 3 is out of bounds'),
+      ((1, 2, 3), (-4,), ValueError, 'axis -4 is out of bounds'),
       ((1, 2, 3), (1,), ValueError, 'cannot select an axis to squeeze out'),
       ((1, 2, 3), (None,), TypeError, 'cannot be interpreted as an integer'),
     ]))
@@ -915,6 +915,7 @@ class LaxTest(jtu.JaxTestCase):
        "rng_factory": rng_factory}
       for arg_shape, dimensions in [
           [(1,), (0,)],
+          [(1,), (-1,)],
           [(2, 1, 4), (1,)],
           [(2, 1, 3, 1), (1,)],
           [(2, 1, 3, 1), (1, 3)],
@@ -3058,10 +3059,13 @@ class LaxVmapTest(jtu.JaxTestCase):
        "rng_factory": rng_factory}
       for arg_shape, dimensions in [
           [(1,), (0,)],
+          [(1,), (-1,)],
           [(2, 1, 4), (1,)],
+          [(2, 1, 4), (-2,)],
           [(2, 1, 3, 1), (1,)],
           [(2, 1, 3, 1), (1, 3)],
           [(2, 1, 3, 1), (3,)],
+          [(2, 1, 3, 1), (1, -1)],
       ]
       for bdims in all_bdims(arg_shape)
       for rng_factory in [jtu.rand_default]))

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -415,6 +415,29 @@ class MaskingTest(jtu.JaxTestCase):
     expected = 8 / 3
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def test_arithmetic(self):
+    @partial(mask, in_shapes=['(n, m)', 'm'], out_shape='(n, m)')
+    def times(x, y):
+      return x * y
+
+    # TODO(shoyer): enable this check when broadcast_in_dim supports masking
+    with self.assertRaisesRegex(KeyError, 'broadcast_in_dim'):
+      ans = times([jnp.array([[1, 2], [3, 4], [5, 6]]), jnp.array([1, 2])],
+                  dict(n=4, m=5))
+      # expected = np.array([[1, 2, 3], [8, 10, 12]])
+      # self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_stack(self):
+    @partial(mask, in_shapes=['n','n'], out_shape='(2, n)')
+    def stack(x, y):
+      return jnp.stack([x, y], 0)
+
+    # TODO(shoyer): enable this check when broadcast_in_dim supports masking
+    with self.assertRaisesRegex(KeyError, 'broadcast_in_dim'):
+      ans = stack([jnp.array([1, 2, 3]), jnp.array([4, 5, 6])], dict(n=10))
+      # expected = np.array([[1, 2, 3], [4, 5, 6]])
+      # self.assertAllClose(ans, expected, check_dtypes=False)
+
   def test_monomorphic(self):
     @partial(mask, in_shapes=['(_, n)'], out_shape='')
     def padded_sum(x):


### PR DESCRIPTION
`reshape()` is quite powerful, but does not necessarily preserve a notion of axis identity (particularly for axes of length 1). This is problematic for transformation rules that need to preserve a notion of axis identity, such as for masking and a new transformation rule I'm exploring for unraveling pytrees.

This PR adds a new `lax.squeeze` primitive, and rewrite functions from `lax_numpy.py` in terms of `lax.squeeze`/`lax.broadcast_in_dim`, whenever possible, to ensure a well-defined mapping between input and output axes. In particular, it updates: `matmul`, various `stack` functions, the `array` constructor, broadcasting arithmetic, array indexing, `squeeze` and reductions with `keepdims=True`.

I also implemented support for multiple axes in `jnp.expand_dims` (added in NumPy 1.18), since it was convenient for some of these other functions.

I considered trying to write a masking rule for broadcast_in_dim as well, but it was trickier than I expected and @JuliusKunze has probably already thought about it :)