### PR TITLE
Make ad_util.zero a class that carries avals (similar to UndefinedPrimal)

### DIFF
--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -914,7 +914,7 @@
         "  # An alternative would be to check for Zero and perform algebraic \n",
         "  # simplification of the output tangent computation.\n",
         "  def make_zero(tan):\n",
-        "    return lax.zeros_like_array(x) if tan is ad.zero else tan  \n",
+        "    return lax.zeros_like_array(x) if type(tan) is ad.Zero else tan  \n",
         "  \n",
         "  output_tangent = multiply_add_prim(make_zero(xt), y, multiply_add_prim(x, make_zero(yt), make_zero(zt)))\n",
         "  return (primal_out, output_tangent)\n",

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -37,7 +37,7 @@ def make_shaped_array(x):
 
 def zeros_like_array(x):
   dtype = dtypes.canonicalize_dtype(dtypes.result_type(x))
-  return np.broadcast_to(np.array(0, dtype), np.shape(x))
+  return zeros_like_shaped_array(ShapedArray(np.shape(x), dtype))
 
 array_types = {np.ndarray, np.bool_,
                np.int8, np.int16, np.int32, np.int64,
@@ -53,7 +53,7 @@ for t in array_types:
 
 def zeros_like_shaped_array(aval):
   assert isinstance(aval, ShapedArray)
-  return np.zeros(aval.shape, dtype=aval.dtype)
+  return np.broadcast_to(np.array(0, aval.dtype), aval.shape)
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 

--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -14,7 +14,7 @@
 
 
 from .core import (lattice_join, Primitive, Unit, unit, AbstractUnit,
-                   valid_jaxtype)
+                   valid_jaxtype, raise_to_shaped, get_aval)
 from .tree_util import register_pytree_node
 from typing import Any, Dict
 from .util import safe_map
@@ -58,13 +58,17 @@ def zeros_like_impl(example):
 
 zeros_like_p.def_abstract_eval(lambda x: x)
 
-class Zero(object):
+class Zero:
+  __slots__ = ['aval']
+  def __init__(self, aval):
+    self.aval = aval
   def __repr__(self):
-    return "Zero"
+    return 'Zero({})'.format(self.aval)
+  @staticmethod
+  def from_value(val):
+    return Zero(raise_to_shaped(get_aval(val)))
 
-zero = Zero()
-
-register_pytree_node(Zero, lambda z: ((), None), lambda _, xs: zero)
+register_pytree_node(Zero, lambda z: ((), z.aval), lambda aval, _: Zero(aval))
 
 
 def _stop_gradient_impl(x):

--- a/jax/api.py
+++ b/jax/api.py
@@ -1877,7 +1877,7 @@ def defjvp_all(fun, custom_jvp):
     num_consts, in_tree = params['num_consts'], params['in_tree']
     _, args_flat = split_list(primals, [num_consts])
     consts_dot, args_dot_flat = split_list(tangents, [num_consts])
-    if not all(t is ad_util.zero for t in consts_dot):
+    if not all(type(t) is ad_util.Zero for t in consts_dot):
       msg = ("Detected differentiation with respect to closed-over values with "
              "custom JVP rule, which isn't supported.")
       raise ValueError(msg)
@@ -1901,7 +1901,7 @@ def defjvp(fun, *jvprules):
   def custom_jvp(primals, tangents):
     ans = fun(*primals)
     tangents_out = [rule(t, ans, *primals) for rule, t in zip(jvprules, tangents)
-                    if rule is not None and t is not ad_util.zero]
+                    if rule is not None and type(t) is not ad_util.Zero]
     return ans, functools.reduce(ad.add_tangents, tangents_out, ad_util.zero)
   defjvp_all(fun, custom_jvp)
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -1881,7 +1881,7 @@ def defjvp_all(fun, custom_jvp):
       msg = ("Detected differentiation with respect to closed-over values with "
              "custom JVP rule, which isn't supported.")
       raise ValueError(msg)
-    args_dot_flat = map(ad.instantiate_zeros, args_flat, args_dot_flat)
+    args_dot_flat = map(ad.instantiate_zeros, args_dot_flat)
     args = tree_unflatten(in_tree, args_flat)
     args_dot = tree_unflatten(in_tree, args_dot_flat)
     out, out_dot = custom_jvp(args, args_dot)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -24,7 +24,7 @@ from .tree_util import tree_flatten, tree_unflatten, tree_map, tree_multimap
 from .util import safe_zip, safe_map, unzip2, split_list, curry
 from .api_util import flatten_fun_nokwargs, argnums_partial, wrap_hashably
 from .abstract_arrays import raise_to_shaped
-from .ad_util import zero, stop_gradient_p
+from .ad_util import Zero, stop_gradient_p
 from .interpreters import partial_eval as pe
 from .interpreters import ad
 from .interpreters import batching
@@ -80,7 +80,7 @@ def sum_tangents(x, *xs):
   return reduce(ad.add_tangents, xs, x)
 
 def zeros_like_pytree(x):
-  return tree_map(lambda _: zero, x)
+  return tree_map(Zero.from_value, x)
 
 def stop_gradient(x):
   return tree_map(_stop_gradient, x)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -306,7 +306,7 @@ custom_jvp_call_jaxpr_p.def_abstract_eval(_custom_jvp_call_jaxpr_abstract_eval)
 
 def _custom_jvp_call_jaxpr_jvp(primals, tangents, *, fun_jaxpr, jvp_jaxpr_thunk):
   jvp_jaxpr = jvp_jaxpr_thunk()
-  tangents = map(ad.instantiate_zeros, primals, tangents)
+  tangents = map(ad.instantiate_zeros, tangents)
   outs = core.jaxpr_as_fun(jvp_jaxpr)(*primals, *tangents)
   return split_list(outs, [len(outs) // 2])
 ad.primitive_jvps[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_jvp
@@ -550,7 +550,7 @@ custom_vjp_call_jaxpr_p.def_abstract_eval(_custom_vjp_call_jaxpr_abstract_eval)
 
 def _custom_vjp_call_jaxpr_jvp(primals, tangents, *, fun_jaxpr, fwd_jaxpr_thunk,
                                bwd, out_trees):
-  tangents = map(ad.instantiate_zeros, primals, tangents)
+  tangents = map(ad.instantiate_zeros, tangents)
   fwd_jaxpr = fwd_jaxpr_thunk()
   out_tree, res_tree = out_trees()
   res_and_primals_out = core.jaxpr_as_fun(fwd_jaxpr)(*primals)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -389,7 +389,7 @@ id_tap_p.def_abstract_eval(_id_tap_abstract_eval)
 # The AttributeError is for regular values, the KeyError is for ConcreteArray
 def _instantiate_zeros(arg, tan):
   """Turn special ad.zero tangents into arrays of 0s."""
-  if tan is not ad.zero:
+  if type(tan) is not ad.Zero:
     return tan
 
   try:

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -262,7 +262,7 @@ class JVPTrace(Trace):
     if 'donated_invars' in new_params:
       new_donated_invars = (*params['donated_invars'],
                             *[m for m, t in zip(params['donated_invars'], tangents)
-                              if t is not zero])
+                              if type(t) is not Zero])
       new_params['donated_invars'] = tuple(new_donated_invars)
     result = call_primitive.bind(f_jvp, *primals, *nonzero_tangents, **new_params)
     primal_out, tangent_out = tree_unflatten(out_tree_def(), result)
@@ -492,7 +492,7 @@ def call_transpose(primitive, params, call_jaxpr, args, ct, _):
   if 'donated_invars' in params:
     new_donated_invars = (*[d for d, x in zip(params['donated_invars'], args)
                             if not is_undefined_primal(x)],
-                          *[False for x in ct if x is not zero])
+                          *[False for x in ct if type(x) is not Zero])
     params['donated_invars'] = tuple(new_donated_invars)
   out_flat = primitive.bind(fun, *all_args, **params)
   return tree_unflatten(out_tree(), out_flat)
@@ -536,10 +536,10 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   new_mapped_invars = (*[m for m, x in zip(params['mapped_invars'], args)
                          if not is_undefined_primal(x)],
-                       *[True for x in ct if type(x) is not zero])
+                       *[True for x in ct if type(x) is not Zero])
   new_donated_invars = (*[d for d, x in zip(params['donated_invars'], args)
                           if not is_undefined_primal(x)],
-                        *[False for x in ct if type(x) is not zero])
+                        *[False for x in ct if type(x) is not Zero])
   new_params = dict(params, name=wrap_name(params['name'], 'transpose'),
                     mapped_invars=tuple(new_mapped_invars),
                     donated_invars=tuple(new_donated_invars))

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -15,13 +15,13 @@
 
 import functools
 import itertools as it
-from typing import Any, Callable, Dict, Set, List
+from typing import Any, Callable, Dict, Set, List, Sequence, Optional
 
 from . import partial_eval as pe
 from .. import core as core
 from ..core import Trace, Tracer, new_master, get_aval, call_p, Primitive, Literal
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
-                       zeros_like_p, zero)
+                       zeros_like_p, Zero)
 from ..abstract_arrays import raise_to_shaped
 from ..util import unzip2, safe_map, safe_zip, partial, split_list, wrap_name
 from ..tree_util import register_pytree_node
@@ -59,7 +59,7 @@ def jvp_subtrace(master, primals, tangents):
   for x in list(primals) + list(tangents):
     if isinstance(x, Tracer):
       assert x._trace.level < trace.level
-  in_tracers = [JVPTracer(trace, x, t) if t is not zero else x
+  in_tracers = [JVPTracer(trace, x, t) if type(t) is not Zero else x
                 for x, t in zip(primals, tangents)]
   ans = yield in_tracers, {}
   out_tracers = map(trace.full_raise, ans)
@@ -139,19 +139,19 @@ def unpair_pval(pval):
 
 # NOTE: The FIXMEs below are caused by primal/tangent mixups (type errors if you will)
 def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
-  if all(ct is zero for ct in cotangents_in):
-    return [zero] * len(jaxpr.invars)
+  if all(type(ct) is Zero for ct in cotangents_in):
+    return map(lambda v: Zero(v.aval), jaxpr.invars)
 
   def write_cotangent(v, ct):
     # assert v not in primal_env
-    if ct is not None and type(v) is not Literal and ct is not zero:
+    if ct is not None and type(v) is not Literal and type(ct) is not Zero:
       ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
       if not core.skip_checks:
         ct_aval = core.get_aval(ct_env[v])
         assert v.aval == core.lattice_join(v.aval, ct_aval), (v.aval, ct_aval)
 
   def read_cotangent(v):
-    return ct_env.get(v, zero)
+    return ct_env.get(v, Zero(v.aval))
 
   def read_primal(v):
     if type(v) is Literal:
@@ -195,7 +195,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
           params, call_jaxpr, invals, cts_in, cts_in_avals)
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
-    cts_out = [zero] * len(eqn.invars) if cts_out is zero else cts_out
+    cts_out = map(lambda v: Zero(v.aval), eqn.invars) if cts_out is Zero else cts_out
     # FIXME: Some invars correspond to primals!
     map(write_cotangent, eqn.invars, cts_out)
     for var in to_drop:
@@ -229,10 +229,10 @@ def get_primitive_transpose(p):
 class JVPTrace(Trace):
 
   def pure(self, val):
-    return JVPTracer(self, val, zero)
+    return JVPTracer(self, val, Zero.from_value(val))
 
   def lift(self, val):
-    return JVPTracer(self, val, zero)
+    return JVPTracer(self, val, Zero.from_value(val))
 
   def sublift(self, val):
     return JVPTracer(self, val.primal, val.tangent)
@@ -291,10 +291,10 @@ class JVPTrace(Trace):
     new_name = wrap_name(params.get('name', f.__name__), 'jvp')
     new_mapped_invars = (*params['mapped_invars'],
                          *[m for m, t in zip(params['mapped_invars'], tangents)
-                           if t is not zero])
+                           if type(t) is not Zero])
     new_donated_invars = (*params['donated_invars'],
                           *[m for m, t in zip(params['donated_invars'], tangents)
-                            if t is not zero])
+                            if type(t) is not Zero])
     new_params = dict(params, name=new_name, mapped_invars=new_mapped_invars,
                       donated_invars=new_donated_invars)
     result = map_primitive.bind(f_jvp, *primals, *nonzero_tangents, **new_params)
@@ -323,7 +323,7 @@ class JVPTrace(Trace):
     return map(partial(JVPTracer, self), primals_out, tangents_out)
 
   def join(self, xt, yt):
-    xz, yz = xt is zero, yt is zero
+    xz, yz = type(xt) is Zero, type(yt) is Zero
     if xz == yz:
       return xt, yt
     elif yz and not xz:
@@ -350,13 +350,13 @@ class JVPTracer(Tracer):
     return get_aval(self.primal)
 
   def full_lower(self):
-    if self.tangent is zero:
+    if type(self.tangent) is Zero:
       return core.full_lower(self.primal)
     else:
       return self
 
 def _primal_tangent_shapes_match(primal, tangent):
-  if tangent is not zero:
+  if type(tangent) is not Zero:
     primal_aval = raise_to_shaped(get_aval(primal))
     tangent_aval = raise_to_shaped(get_aval(tangent))
     assert primal_aval == tangent_aval
@@ -375,14 +375,14 @@ def deflinear(primitive, transpose_rule):
 
 def linear_jvp(primitive, primals, tangents, **params):
   val_out = primitive.bind(*primals, **params)
-  if all(tangent is zero for tangent in tangents):
-    return val_out, zero
+  if all(type(tangent) is Zero for tangent in tangents):
+    return val_out, Zero.from_value(val_out)
   else:
     tangents = map(instantiate_zeros, primals, tangents)
     return val_out, primitive.bind(*tangents, **params)
 
 def linear_transpose(transpose_rule, cotangent, *args, **kwargs):
-  return zero if cotangent is zero else transpose_rule(cotangent, **kwargs)
+  return Zero if type(cotangent) is Zero else transpose_rule(cotangent, **kwargs)
 
 
 def deflinear2(primitive, transpose_rule):
@@ -390,34 +390,37 @@ def deflinear2(primitive, transpose_rule):
   primitive_transposes[primitive] = partial(linear_transpose2, transpose_rule)
 
 def linear_transpose2(transpose_rule, cotangent, *args, **kwargs):
-  return zero if cotangent is zero else transpose_rule(cotangent, *args, **kwargs)
+  return Zero if type(cotangent) is Zero else transpose_rule(cotangent, *args, **kwargs)
 
 
 def defjvp(primitive, *jvprules):
   assert isinstance(primitive, Primitive)
+  assert not primitive.multiple_results
   primitive_jvps[primitive] = partial(standard_jvp, jvprules, primitive)
 
 
 def standard_jvp(jvprules, primitive, primals, tangents, **params):
   val_out = primitive.bind(*primals, **params)
   tangents_out = [rule(t, *primals, **params) for rule, t in zip(jvprules, tangents)
-                  if rule is not None and t is not zero]
-  return val_out, functools.reduce(add_tangents, tangents_out, zero)
+                  if rule is not None and type(t) is not Zero]
+  return val_out, functools.reduce(add_tangents, tangents_out, Zero.from_value(val_out))
 
 def defjvp2(primitive, *jvprules):
   assert isinstance(primitive, Primitive)
+  assert not primitive.multiple_results
   primitive_jvps[primitive] = partial(standard_jvp2, jvprules, primitive)
 
 def standard_jvp2(jvprules, primitive, primals, tangents, **params):
   val_out = primitive.bind(*primals, **params)
   tangents_out = (rule(t, val_out, *primals, **params) for rule, t in zip(jvprules, tangents)
-                  if rule is not None and t is not zero)
-  return val_out, functools.reduce(add_tangents, tangents_out, zero)
+                  if rule is not None and type(t) is not Zero)
+  tangents_out = list(tangents_out)
+  return val_out, functools.reduce(add_tangents, tangents_out, Zero.from_value(val_out))
 
 def add_tangents(x, y):
-  if x is zero:
+  if type(x) is Zero:
     return y
-  elif y is zero:
+  elif type(y) is Zero:
     return x
   else:
     return add_jaxvals(x, y)
@@ -433,12 +436,14 @@ defbilinear = partial(defbilinear_broadcasting, lambda g, x: g)
 
 def bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs):
   assert is_undefined_primal(x) ^ is_undefined_primal(y)
+  if type(cotangent) is Zero:
+    return Zero
   if is_undefined_primal(x):
-    out = zero if cotangent is zero else lhs_rule(cotangent, y, **kwargs)
-    return out, None
+    out = lhs_rule(cotangent, y, **kwargs)
+    return Zero if out is Zero else (out, None)
   else:
-    out = zero if cotangent is zero else rhs_rule(cotangent, x, **kwargs)
-    return None, out
+    out = rhs_rule(cotangent, x, **kwargs)
+    return Zero if out is Zero else (None, out)
 
 
 def defjvp_zero(primitive):
@@ -446,21 +451,22 @@ def defjvp_zero(primitive):
   primitive_jvps[primitive] = partial(zero_jvp, primitive)
 
 def zero_jvp(primitive, primals, tangents, **params):
-  return primitive.bind(*primals, **params), zero
+  r = primitive.bind(*primals, **params)
+  return r, Zero.from_value(r)
 
 
-deflinear(zeros_like_p, lambda t: [zero])
+deflinear(zeros_like_p, lambda t: [Zero.from_value(t)])
 deflinear(core.identity_p, lambda t: (t,))
 deflinear(add_jaxvals_p, lambda t: (t, t))
 
 def instantiate_zeros(example, tangent):
-  if tangent is zero:
+  if type(tangent) is Zero:
     return zeros_like_jaxval(example)
   else:
     return tangent
 
 def instantiate_zeros_aval(aval, tangent):
-  if tangent is zero:
+  if type(tangent) is Zero:
     return zeros_like_aval(aval)
   else:
     return tangent
@@ -527,10 +533,10 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   new_mapped_invars = (*[m for m, x in zip(params['mapped_invars'], args)
                          if not is_undefined_primal(x)],
-                       *[True for x in ct if x is not zero])
+                       *[True for x in ct if type(x) is not zero])
   new_donated_invars = (*[d for d, x in zip(params['donated_invars'], args)
                           if not is_undefined_primal(x)],
-                        *[False for x in ct if x is not zero])
+                        *[False for x in ct if type(x) is not zero])
   new_params = dict(params, name=wrap_name(params['name'], 'transpose'),
                     mapped_invars=tuple(new_mapped_invars),
                     donated_invars=tuple(new_donated_invars))
@@ -541,7 +547,7 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   # The freevars are being fanned out (not mapped). During transpose the
   # dual of fan-out is fan-in-sum. We apply it to the unmapped invars.
   assert len(mapped_invars) == len(arg_cts)
-  arg_cts = (arg_ct if arg_mapped or arg_ct is zero else arg_ct.sum(0)
+  arg_cts = (arg_ct if arg_mapped or type(arg_ct) is Zero else arg_ct.sum(0)
              for arg_ct, arg_mapped in zip(arg_cts, mapped_invars))
 
   return arg_cts
@@ -564,10 +570,11 @@ def f_jvp_traceable(nonzeros, *primals_and_nztangents):
   num_primals = len(nonzeros)
   primals = list(primals_and_nztangents[:num_primals])
   nonzero_tangents = iter(primals_and_nztangents[num_primals:])
-  tangents = [next(nonzero_tangents) if nz else zero for nz in nonzeros]
+  tangents = [next(nonzero_tangents) if nz else Zero.from_value(p)
+	      for p, nz in zip(primals, nonzeros)]
   primals_out, tangents_out = yield (primals, tangents), {}
-  out_nonzeros = [t is not zero for t in tangents_out]
-  nonzero_tangents_out = [t for t in tangents_out if t is not zero]
+  out_nonzeros = [type(t) is not Zero for t in tangents_out]
+  nonzero_tangents_out = [t for t in tangents_out if type(t) is not Zero]
   yield list(primals_out) + nonzero_tangents_out, out_nonzeros
 
 def rearrange_binders(jaxpr: core.TypedJaxpr, primals_in, tangents_in, primals_out, tangents_out):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -63,7 +63,6 @@ def _batch_fun(sum_match, in_dims, out_dims_thunk, out_dim_dests, *in_vals, **pa
     if od is not None and not isinstance(od_dest, int) and not od_dest is last and not sum_match:
       msg = f"vmap has mapped output but out_axes is {od_dest}"
       raise ValueError(msg)
-  print(out_vals, out_dims, out_dim_dests, size, sum_match)
   out_vals = map(partial(matchaxis, size, sum_match=sum_match), out_dims, out_dim_dests, out_vals)
   yield out_vals
 
@@ -127,7 +126,6 @@ class BatchTrace(Trace):
     return BatchTracer(self, val.val, val.batch_dim)
 
   def process_primitive(self, primitive, tracers, params):
-    print(primitive)
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
     if all(bdim is not_mapped for bdim in dims_in):
       return primitive.bind(*vals_in, **params)
@@ -331,7 +329,6 @@ def moveaxis(x, src, dst):
   return x.transpose(perm)
 
 def matchaxis(sz, src, dst, x, sum_match=False):
-  print('>', src, dst)
   if core.get_aval(x) is core.abstract_unit:
     return core.unit
   if src == dst:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -25,7 +25,7 @@ import numpy as onp
 from .. import core
 from .. import linear_util as lu
 from ..abstract_arrays import ConcreteArray, raise_to_shaped
-from ..ad_util import zero
+from ..ad_util import Zero
 from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
                     wrap_name, cache, curry)
 from ..core import (Trace, Tracer, new_master, Jaxpr, Literal, get_aval,
@@ -50,7 +50,7 @@ class PartialVal(tuple):
     if not core.skip_checks:
       # type checks
       assert isinstance(pv, (AbstractValue, type(None))), xs
-      assert isinstance(const, core.Tracer) or const is zero or core.valid_jaxtype(const), xs
+      assert isinstance(const, core.Tracer) or type(const) is Zero or core.valid_jaxtype(const), xs
       # invariant checks
       if isinstance(pv, AbstractValue):
         assert const == core.unit, xs

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3521,8 +3521,8 @@ def _dynamic_update_slice_jvp(primals, tangents):
   if type(g_operand) is ad_util.Zero and type(g_update) is ad_util.Zero:
     tangent_out = ad_util.Zero.from_value(val_out)
   else:
-    g_operand = ad.instantiate_zeros(operand, g_operand)
-    g_update = ad.instantiate_zeros(update, g_update)
+    g_operand = ad.instantiate_zeros(g_operand)
+    g_update = ad.instantiate_zeros(g_update)
     tangent_out = dynamic_update_slice(g_operand, g_update, start_indices)
   return val_out, tangent_out
 
@@ -3727,8 +3727,8 @@ def _scatter_add_jvp(primals, tangents, *, update_jaxpr, update_consts,
   if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
     tangent_out = ad_util.Zero.from_value(val_out)
   else:
-    g_operand = ad.instantiate_zeros(operand, g_operand)
-    g_updates = ad.instantiate_zeros(updates, g_updates)
+    g_operand = ad.instantiate_zeros(g_operand)
+    g_updates = ad.instantiate_zeros(g_updates)
     tangent_out = scatter_add_p.bind(
         g_operand, scatter_indices, g_updates, update_jaxpr=update_jaxpr,
         update_consts=update_consts, dimension_numbers=dimension_numbers)
@@ -3884,8 +3884,8 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
   if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
     tangent_out = ad_util.Zero.from_value(val_out)
   else:
-    g_operand = ad.instantiate_zeros(operand, g_operand)
-    g_updates = ad.instantiate_zeros(updates, g_updates)
+    g_operand = ad.instantiate_zeros(g_operand)
+    g_updates = ad.instantiate_zeros(g_updates)
 
     # gather_dnums and slice_sizes define the gather op that is the inverse of
     # the scatter op specified by scatter_dnums
@@ -3989,8 +3989,8 @@ def _scatter_jvp(primals, tangents, *, update_jaxpr, update_consts,
       update_consts=update_consts, dimension_numbers=dnums)
     return val_out, ad_util.Zero.from_value(val_out)
 
-  g_operand = ad.instantiate_zeros(operand, g_operand)
-  g_updates = ad.instantiate_zeros(updates, g_updates)
+  g_operand = ad.instantiate_zeros(g_operand)
+  g_updates = ad.instantiate_zeros(g_updates)
 
   # If there are overlapping indices in the scatter, it is unspecified which
   # update "wins". So we use the following perhaps surprising scheme:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2131,7 +2131,7 @@ def _sub_transpose(t, x, y):
   # The following linearity assertion is morally true, but because in some cases
   # we instantiate zeros for convenience, it doesn't always hold.
   # assert ad.is_undefined_primal(x) and ad.is_undefined_primal(y)
-  return [t, neg(t) if t is not ad_util.zero else ad_util.zero]
+  return [t, neg(t) if type(t) is not ad_util.Zero else ad_util.Zero]
 
 sub_p = standard_naryop([_num, _num], 'sub')
 ad.defjvp(sub_p,
@@ -2145,7 +2145,7 @@ ad.defbilinear_broadcasting(_brcast, mul_p, mul, mul)
 
 def _div_transpose_rule(cotangent, x, y):
   assert ad.is_undefined_primal(x) and not ad.is_undefined_primal(y)
-  res = ad_util.zero if cotangent is ad_util.zero else div(cotangent, y)
+  res = ad_util.Zero if type(cotangent) is ad_util.Zero else div(cotangent, y)
   return res, None
 div_p = standard_naryop([_num, _num], 'div')
 ad.defjvp(div_p,
@@ -2401,7 +2401,7 @@ def _conv_general_dilated_transpose_rhs(
   assert type(dimension_numbers) is ConvDimensionNumbers
   if onp.size(g) == 0:
     # Avoids forming degenerate convolutions where the RHS has spatial size 0.
-    return ad_util.zero
+    return ad_util.Zero
   lhs_sdims, rhs_sdims, out_sdims = map(_conv_sdims, dimension_numbers)
   lhs_trans, rhs_trans, out_trans = map(_conv_spec_transpose, dimension_numbers)
   assert batch_group_count == 1 or feature_group_count == 1
@@ -2871,8 +2871,8 @@ def _concatenate_translation_rule(c, *operands, **kwargs):
 def _concatenate_transpose_rule(t, *operands, dimension):
   operand_shapes = [o.aval.shape if ad.is_undefined_primal(o) else o.shape
                     for o in operands]
-  if t is ad_util.zero:
-    return [ad_util.zero if ad.is_undefined_primal(o) else None for o in operands]
+  if t is ad_util.Zero:
+    return ad_util.Zero
   else:
     limit_points = onp.cumsum([shape[dimension] for shape in operand_shapes])
     starts = onp.zeros((len(operands), t.ndim), dtype=int)
@@ -2916,9 +2916,8 @@ def _pad_shape_rule(operand, padding_value, *, padding_config):
   return tuple(out_shape)
 
 def _pad_transpose(t, operand, padding_value, *, padding_config):
-  if t is ad_util.zero:
-    return [ad_util.zero if ad.is_undefined_primal(operand) else None,
-            ad_util.zero if ad.is_undefined_primal(padding_value) else None]
+  if t is ad_util.Zero:
+    return ad_util.Zero
 
   lo, hi, interior = zip(*padding_config)
   total = lambda x: _reduce_sum(x, list(range(t.ndim)))
@@ -3250,10 +3249,8 @@ def _select_dtype_rule(pred, on_true, on_false):
 
 def _select_transpose_rule(t, pred, on_true, on_false):
   assert not ad.is_undefined_primal(pred)
-  if t is ad_util.zero:
-    return [None,
-            ad_util.zero if ad.is_undefined_primal(on_true) else None,
-            ad_util.zero if ad.is_undefined_primal(on_false) else None]
+  if type(t) is ad_util.Zero:
+    return ad_util.Zero
   else:
     zeros = full_like(t, 0)
     return [None,
@@ -3442,9 +3439,9 @@ def _dynamic_slice_translation_rule(c, operand, *start_indices, slice_sizes):
   return xops.DynamicSlice(operand, start_indices, slice_sizes)
 
 def _dynamic_slice_jvp(primals, tangents, *, slice_sizes):
-  tangent_out = ad_util.zero
-  if tangents[0] is not ad_util.zero:
-    tangent_out = dynamic_slice(tangents[0], primals[1:], slice_sizes)
+  tangent_out = tangents[0]
+  if type(tangent_out) is not ad_util.Zero:
+    tangent_out = dynamic_slice(tangent_out, primals[1:], slice_sizes)
   return dynamic_slice(primals[0], primals[1:], slice_sizes), tangent_out
 
 def _dynamic_slice_transpose_rule(t, operand, *start_indices, slice_sizes):
@@ -3521,8 +3518,8 @@ def _dynamic_update_slice_jvp(primals, tangents):
   start_indices = primals[2:]
   g_operand, g_update = tangents[:2]
   val_out = dynamic_update_slice(operand, update, start_indices)
-  if g_operand is ad_util.zero and g_update is ad_util.zero:
-    tangent_out = ad_util.zero
+  if type(g_operand) is ad_util.Zero and type(g_update) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(val_out)
   else:
     g_operand = ad.instantiate_zeros(operand, g_operand)
     g_update = ad.instantiate_zeros(update, g_update)
@@ -3617,14 +3614,14 @@ def _gather_transpose_rule(t, operand, start_indices, *, dimension_numbers,
                           slice_sizes):
   assert ad.is_undefined_primal(operand)
   operand_shape = operand.aval.shape
-  if t is ad_util.zero:
-    return [ad_util.zero, ad_util.zero]
+  if type(t) is ad_util.Zero:
+    return ad_util.Zero
   zeros = full(operand_shape, tie_in(t, _zero(t)))
   scatter_dnums = ScatterDimensionNumbers(
     update_window_dims=dimension_numbers.offset_dims,
     inserted_window_dims=dimension_numbers.collapsed_slice_dims,
     scatter_dims_to_operand_dims=dimension_numbers.start_index_map)
-  return [scatter_add(zeros, start_indices, t, scatter_dnums), ad_util.zero]
+  return [scatter_add(zeros, start_indices, t, scatter_dnums), ad_util.Zero.from_value(start_indices)]
 
 def _gather_batching_rule(batched_args, batch_dims, *, dimension_numbers,
                           slice_sizes):
@@ -3727,8 +3724,8 @@ def _scatter_add_jvp(primals, tangents, *, update_jaxpr, update_consts,
   val_out = scatter_add_p.bind(
       operand, scatter_indices, updates, update_jaxpr=update_jaxpr,
       update_consts=update_consts, dimension_numbers=dimension_numbers)
-  if g_operand is ad_util.zero and g_updates is ad_util.zero:
-    tangent_out = ad_util.zero
+  if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(val_out)
   else:
     g_operand = ad.instantiate_zeros(operand, g_operand)
     g_updates = ad.instantiate_zeros(updates, g_updates)
@@ -3744,8 +3741,8 @@ def _scatter_add_transpose_rule(t, operand, scatter_indices, updates, *,
     updates_shape = updates.aval.shape
   else:
     updates_shape = updates.shape
-  if t is ad_util.zero:
-    return [ad_util.zero, None, ad_util.zero]
+  if type(t) is ad_util.Zero:
+    return ad_util.Zero
 
   operand_t = update_t = None
   if ad.is_undefined_primal(operand):
@@ -3775,8 +3772,8 @@ def _scatter_mul_transpose_rule(t, operand, scatter_indices, updates, *,
     updates_shape = updates.aval.shape
   else:
     updates_shape = updates.shape
-  if t is ad_util.zero:
-    return [ad_util.zero, None, ad_util.zero]
+  if type(t) is ad_util.Zero:
+    return ad_util.Zero
 
   operand_t = update_t = None
   if ad.is_undefined_primal(operand):
@@ -3884,8 +3881,8 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
       operand, scatter_indices, updates, update_jaxpr=update_jaxpr,
       update_consts=update_consts, dimension_numbers=scatter_dnums)
 
-  if g_operand is ad_util.zero and g_updates is ad_util.zero:
-    tangent_out = ad_util.zero
+  if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(val_out)
   else:
     g_operand = ad.instantiate_zeros(operand, g_operand)
     g_updates = ad.instantiate_zeros(updates, g_updates)
@@ -3986,12 +3983,11 @@ def _scatter_jvp(primals, tangents, *, update_jaxpr, update_consts,
   g_operand, g_scatter_indices, g_updates = tangents
   dnums = dimension_numbers
 
-  if g_operand is ad_util.zero and g_updates is ad_util.zero:
+  if type(g_operand) is ad_util.Zero and type(g_updates) is ad_util.Zero:
     val_out = scatter_p.bind(
       operand, scatter_indices, updates, update_jaxpr=update_jaxpr,
       update_consts=update_consts, dimension_numbers=dnums)
-    tangent_out = ad_util.zero
-    return val_out, tangent_out
+    return val_out, ad_util.Zero.from_value(val_out)
 
   g_operand = ad.instantiate_zeros(operand, g_operand)
   g_updates = ad.instantiate_zeros(updates, g_updates)
@@ -4507,8 +4503,8 @@ def _select_and_scatter_add_jvp(
       source, operand, select_prim, window_dimensions, window_strides,
       padding)
   del g_operand
-  if g_source is ad_util.zero:
-    tangent_out = ad_util.zero
+  if type(g_source) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(val_out)
   else:
     tangent_out = _select_and_scatter_add(
         g_source, operand, select_prim, window_dimensions,
@@ -4693,8 +4689,8 @@ def _select_and_gather_add_jvp(
       source, operand, select_prim, window_dimensions, window_strides,
       padding)
   del g_operand
-  if g_source is ad_util.zero:
-    tangent_out = ad_util.zero
+  if type(g_source) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(val_out)
   else:
     tangent_out = _select_and_gather_add(
         g_source, operand, select_prim, window_dimensions,
@@ -4932,8 +4928,7 @@ def _sort_jvp(primals, tangents, *, dimension):
   primals = sort_p.bind(*(primals + (iotas[dimension],)), dimension=dimension)
   idx = tuple(primals[-1] if i == dimension else iotas[i]
               for i in range(len(shape)))
-  tangents_out = tuple(ad_util.zero if t is ad_util.zero else t[idx]
-                       for t in tangents)
+  tangents_out = tuple(t if type(t) is ad_util.Zero else t[idx] for t in tangents)
   return tuple(primals[:-1]), tangents_out
 
 def _sort_batch_rule(batched_args, batch_dims, *, dimension):
@@ -4978,8 +4973,8 @@ def _top_k_jvp(primals, tangents, *, k):
   operand, = primals
   tangent, = tangents
   primals_out = top_k(operand, k)
-  if tangent is ad_util.zero:
-    tangents_out = (ad_util.zero, ad_util.zero)
+  if type(tangent) is ad_util.Zero:
+    tangent_out = ad_util.Zero.from_value(primals_out[0])
   else:
     _, k_idxs = primals_out
     idx_shape = k_idxs.shape
@@ -4998,9 +4993,8 @@ def _top_k_jvp(primals, tangents, *, k):
       offset_dims=(),
       collapsed_slice_dims=tuple(range(rank)),
       start_index_map=tuple(range(rank)))
-    tangents_out = (gather(tangent, gather_indices, dnums, slice_sizes),
-                    ad_util.zero)
-  return primals_out, tangents_out
+    tangent_out = gather(tangent, gather_indices, dnums, slice_sizes)
+  return primals_out, (tangent_out, ad_util.Zero.from_value(primals_out[1]))
 
 def _top_k_batch_rule(batched_args, batch_dims, *, k):
   operand, = batched_args
@@ -5022,8 +5016,12 @@ xla.translations[top_k_p] = partial(standard_translate, 'top_k')
 ad.primitive_jvps[top_k_p] = _top_k_jvp
 batching.primitive_batchers[top_k_p] = _top_k_batch_rule
 
-def _tie_in_transpose_rule(t):
-  return [ad_util.zero, t]
+def _tie_in_transpose_rule(t, x, y):
+  # TODO(apaszke): What to do about this?
+  if ad.is_undefined_primal(x):
+    return [ad_util.Zero(x.aval), t]
+  else:
+    return [ad_util.Zero.from_value(x), t]
 
 def _tie_in_batch_rule(batched_args, batch_dims):
   y = tie_in(*batched_args)
@@ -5039,7 +5037,7 @@ tie_in_p = Primitive('tie_in')
 tie_in_p.def_impl(_tie_in_impl)
 tie_in_p.def_abstract_eval(lambda x, y: raise_to_shaped(y))
 xla.translations[tie_in_p] = lambda c, x, y: y
-ad.deflinear(tie_in_p, _tie_in_transpose_rule)
+ad.deflinear2(tie_in_p, _tie_in_transpose_rule)
 batching.primitive_batchers[tie_in_p] = _tie_in_batch_rule
 masking.masking_rules[tie_in_p] = lambda vals, logical_shapes: vals[1]
 
@@ -5047,7 +5045,7 @@ masking.masking_rules[tie_in_p] = lambda vals, logical_shapes: vals[1]
 def _stop_gradient_jvp_rule(primals, tangents):
   # if we don't call stop_gradient here, we'd only peel off one autodiff tracer
   x, = primals
-  return stop_gradient(x), ad_util.zero
+  return stop_gradient(x), ad_util.Zero.from_value(x)
 
 def _stop_gradient_batch_rule(batched_args, batch_dims):
   x, = batched_args

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -409,8 +409,8 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
     assert False, "Fixpoint not reached"
 
   nonzeros = cconst_nz + body_nonzeros
-  tangents = [ad.instantiate_zeros(x, t) if type(t) is ad_util.Zero and nz else t
-              for x, t, nz in zip(primals, tangents, nonzeros)]
+  tangents = [ad.instantiate_zeros(t) if nz else t
+              for t, nz in zip(tangents, nonzeros)]
 
   cconst, bconst, init = split_list(primals, [cond_nconsts, body_nconsts])
   _, bconst_dot, init_dot = split_list(tangents, [cond_nconsts, body_nconsts])
@@ -1225,8 +1225,8 @@ def _scan_jvp(primals, tangents, reverse, length, jaxpr, num_consts, num_carry,
   else:
     assert False, "Fixpoint not reached"
 
-  tangents = [ad.instantiate_zeros(x, t) if type(t) is ad_util.Zero and nz else t
-              for x, t, nz in zip(primals, tangents, nonzeros)]
+  tangents = [ad.instantiate_zeros(t) if nz else t
+              for t, nz in zip(tangents, nonzeros)]
 
   consts, init, xs = split_list(primals, [num_consts, num_carry])
   all_tangents = split_list(tangents, [num_consts, num_carry])

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -368,8 +368,8 @@ def triangular_solve_transpose_rule(
   # Triangular solve is nonlinear in its first argument and linear in its second
   # argument, analogous to `div` but swapped.
   assert not ad.is_undefined_primal(a) and ad.is_undefined_primal(b)
-  if cotangent is ad_util.zero:
-    cotangent_b = ad_util.zero
+  if type(cotangent) is ad_util.Zero:
+    cotangent_b = ad_util.Zero(b.aval)
   else:
     cotangent_b = triangular_solve(a, cotangent, left_side, lower,
                                    not transpose_a, conjugate_a, unit_diagonal)
@@ -622,7 +622,7 @@ def _lu_jvp_rule(primals, tangents):
   l_dot = jnp.matmul(l, jnp.tril(lau, -1))
   u_dot = jnp.matmul(jnp.triu(lau), u)
   lu_dot = l_dot + u_dot
-  return (lu, pivots), (lu_dot, ad_util.zero)
+  return (lu, pivots), (lu_dot, ad_util.Zero.from_value(pivots))
 
 
 def _lu_batching_rule(batched_args, batch_dims):

--- a/jax/random.py
+++ b/jax/random.py
@@ -1028,7 +1028,7 @@ def _gamma_impl(key, a):
     samples = lax.map(lambda args: _gamma_one(*args), (keys, alphas))
   else:
     samples = vmap(_gamma_one)(keys, alphas)
-  return jnp.reshape(samples, a_shape),
+  return jnp.reshape(samples, a_shape)
 
 def _gamma_batching_rule(batched_args, batch_dims):
     k, a = batched_args
@@ -1036,14 +1036,13 @@ def _gamma_batching_rule(batched_args, batch_dims):
     size = next(t.shape[i] for t, i in zip(batched_args, batch_dims) if i is not None)
     k = batching.bdim_at_front(k, bk, size)
     a = batching.bdim_at_front(a, ba, size)
-    return random_gamma_p.bind(k, a), (0,)
+    return random_gamma_p.bind(k, a), 0
 
 random_gamma_p = core.Primitive('random_gamma')
-random_gamma_p.multiple_results = True
 random_gamma_p.def_impl(_gamma_impl)
-random_gamma_p.def_abstract_eval(lambda key, a: (abstract_arrays.raise_to_shaped(a),))
-ad.defjvp2(random_gamma_p, None, lambda tangent, ans, key, a: (tangent * _gamma_grad(ans[0], a),))
-xla.translations[random_gamma_p] = xla.lower_fun(_gamma_impl)
+random_gamma_p.def_abstract_eval(lambda key, a: abstract_arrays.raise_to_shaped(a))
+ad.defjvp2(random_gamma_p, None, lambda tangent, ans, key, a: tangent * _gamma_grad(ans, a))
+xla.translations[random_gamma_p] = xla.lower_fun(_gamma_impl, multiple_results=False)
 batching.primitive_batchers[random_gamma_p] = _gamma_batching_rule
 
 def gamma(key, a, shape=None, dtype=np.float64):
@@ -1081,7 +1080,7 @@ def _gamma(key, a, shape, dtype):
   a = lax.convert_element_type(a, dtype)
   if np.shape(a) != shape:
     a = jnp.broadcast_to(a, shape)
-  return random_gamma_p.bind(key, a)[0]
+  return random_gamma_p.bind(key, a)
 
 
 @partial(jit, static_argnums=(2, 3, 4))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1763,6 +1763,12 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, msg):
       g(jnp.ones((1, 1)), b=1)
 
+  def test_vmap_unmapped_last(self):
+    @partial(jax.vmap, out_axes=jax.interpreters.batching.last)
+    def f(x):
+      return np.zeros((2,))
+    f(np.zeros((5,)))
+
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This is useful for remat transpose rule submitted in #3162 and e.g.
allowed me to catch a slight overuse of defjvp2 for `random_gamma_p` (it
was unnecessarily declared as having multiple outputs).