### PR TITLE
Fix broadcast_shapes for polymorphic dims (#3216)

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -69,8 +69,7 @@ Shape = Sequence[int]
 def _try_broadcast_shapes(shapes):
   # Replace 1 with 0 to avoid inconclusive comparisons for polymorphic dims:
   out_shape = onp.max(onp.where(shapes == 1, 0, shapes), axis=0)
-  out_shape = onp.where(onp.all(shapes == 1, 0), 1, out_shape)
-  out_shape = onp.where(onp.any(shapes == 0, 0), 0, out_shape)
+  out_shape = onp.where(onp.all(shapes == 1, axis=0), 1, out_shape)
   if not onp.all((shapes == out_shape) | (shapes == 1)):
     return None
   return canonicalize_shape(out_shape)

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -101,6 +101,7 @@ class ShapesTest(jtu.JaxTestCase):
     assert -1 - n == -n - 1
 
   def test_add_broadcast(self):
+    @shapecheck(['n', '(m, n)'], '(m, n)')
     @shapecheck(['(m, n)', 'n'], '(m, n)')
     @shapecheck(['n', ''], 'n')
     def add(a, b):


### PR DESCRIPTION
Allowing polymorphic dimensions results in some restrictions for writing comparisons within shape rules, i. e. `1>=m` (called within `onp.max`) is inconclusive in #3216. `broadcast_shapes` now avoids this by preprocessing out `1`s, and use comparisons of the form `0>=m` instead. This works since polynomials are assumed to be positive by default, allowing usage of many existing shape rules with only minor modifications.