### PR TITLE
Don't keep primal arguments and results in the linearized jaxpr

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1476,9 +1476,7 @@ def _lift_linearized(jaxpr, primal_avals, consts, io_tree, out_pvals, *py_args):
         msg = ("linearized function called on tangent values inconsistent with "
                "the original primal values.")
         raise ValueError(msg) from e
-    dummy = (core.unit,) * len(tangents)
-    out = eval_jaxpr(jaxpr, consts, *(dummy + tangents))
-    tangents_out = out[len(out)//2:]
+    tangents_out = eval_jaxpr(jaxpr, consts, *tangents)
     return tuple(map(lambda out_pv, tan_out: out_pv.merge_with_known(tan_out),
                      out_pvals, tangents_out))
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -116,7 +116,11 @@ class JaxprTrace(Trace):
     return JaxprTracer(self, PartialVal.unknown(get_aval(val)), ConstVar(val))
 
   def new_arg(self, pval: PartialVal) -> 'JaxprTracer':
-    return JaxprTracer(self, pval, LambdaBinding())
+    const = pval.get_known()
+    if const is None:
+      return JaxprTracer(self, pval, LambdaBinding())
+    else:
+      return self.new_const(const)
 
   def instantiate_const(self, tracer) -> Tracer:
     const = tracer.pval.get_known()


### PR DESCRIPTION
Linearized functions are supposed to take tangent types to tangent
types, and so all primal arguments are unused and primal results get
replaced by units.

This is a retake of #2751, with the last commit fixing all the failures appearing there.

The rationale for the change in `partial_eval` is that it's weird that a known value appears in the staged out trace _if and only if_ it was an argument. This feels wrong because passing `x` to a call primitive uses the binder variable, while passing `x + 0` replaces the binder with a unit... This is due to the recipes of all arguments being `LambdaBinder` instances. With this change they're treated in the same way as all other known values.