### PR TITLE
Allow `jnp.int32(tracer)` to work.

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -147,7 +147,7 @@ class _ScalarMeta(type):
     return not (self == other)
 
   def __call__(self, x):
-    return array(self.dtype.type(x), dtype=self.dtype)
+    return array(x, dtype=self.dtype)
 
 def _make_scalar_type(np_scalar_type):
   return _ScalarMeta(np_scalar_type.__name__, (object,),

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -173,5 +173,11 @@ class DtypesTest(jtu.JaxTestCase):
     np.testing.assert_equal(np.int32(101), np.int32(AnEnum.B))
     np.testing.assert_equal(jnp.int32(101), jnp.int32(AnEnum.B))
 
+  def testScalarCastInsideJitWorks(self):
+    # jnp.int32(tracer) should work.
+    self.assertEqual(jnp.int32(101),
+                     jax.jit(lambda x: jnp.int32(x))(jnp.float32(101.4)))
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Fixes #3180

(I don't entirely recall why I wrote things this way, but my recollection is that it related to JAX/TF interoperability inside TF Probability. I don't believe the problem reproduces any more.) 