### PR TITLE
uses np.prod instead of jnp.prod for shapes

### DIFF
--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -554,7 +554,7 @@ where: 10
     if jtu.device_under_test() == "tpu":
       if dtype in (jnp.int16,):
         raise SkipTest(f"transfering {dtype} not supported on TPU")
-    args = [jnp.arange(jnp.prod(shape), dtype=dtype).reshape(shape)]
+    args = [jnp.arange(np.prod(shape), dtype=dtype).reshape(shape)]
     if nr_args > 1:
       args = args * nr_args
     jit_fun1 = api.jit(lambda xs: hcb.id_print(

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -238,7 +238,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       for shape in [100, (10, 10), (10, 5, 2)]))
   def testPermutationArray(self, dtype, shape):
     key = random.PRNGKey(0)
-    x = jnp.arange(jnp.prod(shape)).reshape(shape).astype(dtype)
+    x = jnp.arange(np.prod(shape)).reshape(shape).astype(dtype)
     rand = lambda key: random.permutation(key, x)
     crand = api.jit(rand)
 
@@ -249,7 +249,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     self.assertFalse(np.all(perm1 == x))  # seems unlikely!
     self.assertAllClose(np.sort(perm1.ravel()), x.ravel(), check_dtypes=False)
     self.assertArraysAllClose(
-      x, jnp.arange(jnp.prod(shape)).reshape(shape).astype(dtype),
+      x, jnp.arange(np.prod(shape)).reshape(shape).astype(dtype),
       check_dtypes=True)
 
   def testPermutationInteger(self):


### PR DESCRIPTION
Related to #3118, replaces `jnp.prod(shape)` for `np.prod(shape)` so we can stop supporting tuples in `jnp.prod`