### PR TITLE
moved check_jaxpr code around to match eval_jaxpr

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1131,33 +1131,6 @@ def typematch(aval1: UnshapedArray, aval2: UnshapedArray) -> bool:
   return (raise_to_shaped(aval1).strip_weak_type() ==
           raise_to_shaped(aval2).strip_weak_type())
 
-# For use in Jaxpr typechecking (under `check_jaxpr`)
-class _JaxprTypeEnvironment(object):
-  __slots__ = ["env"]
-
-  def __init__(self):
-    self.env: Dict[Var, AbstractValue] = {}
-
-  def read(self, v: Var):
-    env = self.env
-    if type(v) is not Literal:
-      if v not in env:
-        raise TypeError(
-            "Variable '{}' not defined".format(v))
-      if v.aval != env[v]:
-        raise TypeError(
-            "Variable '{}' inconsistently typed as {}, bound as {}".format(
-                v, v.aval, env[v]))
-    return v
-
-  def write(self, v: Var):
-    env = self.env
-    if v in env:
-      raise TypeError(
-          "Variable {} already bound".format(v))
-    env[v] = v.aval
-    return v
-
 def check_jaxpr(jaxpr: Jaxpr):
   """Checks well-formedness of a jaxpr.
 
@@ -1169,7 +1142,7 @@ def check_jaxpr(jaxpr: Jaxpr):
   Raises `TypeError` if `jaxpr` is determined invalid. Returns `None` otherwise.
   """
   try:
-    _check_jaxpr(jaxpr)
+    _check_jaxpr(jaxpr, [v.aval for v in jaxpr.invars])
   except Exception as e:
     exception_type = type(e)
     msg_context = f"while checking jaxpr:\n\n{jaxpr}\n"
@@ -1180,90 +1153,105 @@ def check_jaxpr(jaxpr: Jaxpr):
       exception_args = [msg, *e.args[1:]]
     raise exception_type(*exception_args) from e
 
-def _check_jaxpr(jaxpr: Jaxpr):
-  env = _JaxprTypeEnvironment()
+def _check_jaxpr(jaxpr: Jaxpr, in_avals: Sequence[AbstractValue]):
 
-  env.write(unitvar)
-  map(env.write, jaxpr.constvars)
-  map(env.write, jaxpr.invars)
+  def read(v: Atom) -> AbstractValue:
+    if isinstance(v, Literal):
+      return get_aval(v.val)
+    else:
+      if v not in env:
+        raise TypeError(f"Variable '{v}' not defined")
+      return env[v]
+
+  def write(v: Var, a: AbstractValue) -> None:
+    if v in env:
+      raise TypeError(f"Variable '{v}' already bound")
+    # TODO(frostig): we'd rather check equality or just typecompat here, but
+    # partial_eval.tracers_to_jaxpr types eqn outvars as abstract_unit if the
+    # outvars are unused
+    if not typecompat(v.aval, a) and v.aval is not abstract_unit:
+      raise TypeError(f"Variable '{v}' inconsistently typed as {a}, "
+                      f"bound as {v.aval}")
+    env[v] = a
+
+  env : Dict[Var, AbstractValue] = {}
+
+  write(unitvar, abstract_unit)
+  map(write, jaxpr.constvars, [v.aval for v in jaxpr.constvars])
+  map(write, jaxpr.invars, in_avals)
 
   for eqn in jaxpr.eqns:
-    check_jaxpr_eqn(env, eqn)
+    in_avals = map(read, eqn.invars)
+    if eqn.primitive.call_primitive:
+      out_avals = check_call(eqn.primitive, in_avals, eqn.params)
+    elif eqn.primitive.map_primitive:
+      out_avals = check_map(eqn.primitive, in_avals, eqn.params)
+    else:
+      out_avals = check_eqn(eqn.primitive, in_avals, eqn.params)
+    try:
+      map(write, eqn.outvars, out_avals)
+    except TypeError as e:
+      msg, = e.args
+      raise TypeError(msg + f" in '{eqn}'") from None
 
-  for subjaxpr in subjaxprs(jaxpr):
-    _check_jaxpr(subjaxpr)
+  map(read, jaxpr.outvars)
 
-  map(env.read, jaxpr.outvars)
-
-def _valid_eqn_assignment(dst_aval: UnshapedArray,
-                          src_aval: UnshapedArray) -> bool:
-  # TODO(frostig): we'd rather this check simply be `typecompat` and not allow
-  # assignment to an AbstractUnit, but partial_eval.tracers_to_jaxpr types eqn
-  # outvars as AbstractUnit if the outvars are unused.
-  return dst_aval is abstract_unit or typecompat(dst_aval, src_aval)
-
-def check_jaxpr_eqn(env: _JaxprTypeEnvironment, eqn: JaxprEqn):
-  invars = map(env.read, eqn.invars)
-  inferred_out_avals = type_transfer(eqn.primitive, invars, eqn.params)
-  outvars = map(env.write, eqn.outvars)
-
-  for outvar, inferred_out_aval in zip(outvars, inferred_out_avals):
-    if not _valid_eqn_assignment(outvar.aval, inferred_out_aval):
-      raise TypeError(
-          f"Jaxpr equation LHS {outvar} is {outvar.aval}, "
-          f"RHS is inferred as {inferred_out_aval}, in '{eqn}'")
-
-def type_transfer(prim: Primitive, invars: Sequence[Var],
-                  params: Dict[str, Any]) -> List[AbstractValue]:
-  in_avals = [v.aval for v in invars]
-
-  if prim.call_primitive or prim.map_primitive:
-    if "call_jaxpr" not in params:
-      raise TypeError(
-          f"Call primitive {prim} missing 'call_jaxpr' parameter")
-
-    if prim.map_primitive:
-      if "axis_size" not in params:
-        raise TypeError(
-            f"Map primitive {prim} missing 'axis_size' parameter")
-      if "mapped_invars" not in params:
-        raise TypeError(
-            f"Map primitive {prim} missing 'mapped_invars' parameter")
-      if "donated_invars" not in params:
-        raise TypeError(
-            f"Map primitive {prim} missing 'donated_invars' parameter")
-
-    call_jaxpr = params["call_jaxpr"]
-    if len(invars) != len(call_jaxpr.invars):
-      raise TypeError(
-          f"Call primitive {prim} with {len(invars)} operands "
-          f"cannot call jaxpr with {len(call_jaxpr.invars)} invars")
-
-    binder_avals = [v.aval for v in call_jaxpr.invars]
-
-    if prim.map_primitive:
-      axis_size = params["axis_size"]
-      mapped_invars = params["mapped_invars"]
-      binder_avals = [unmapped_aval(axis_size, aval) if mapped else aval
-                      for aval, mapped in zip(binder_avals, mapped_invars)]
-
-    for binder_aval, in_aval in zip(binder_avals, in_avals):
-      if not typecompat(binder_aval, in_aval):
-        raise TypeError(
-            f"Call primitive {prim} passes operand {in_aval} "
-            f"to jaxpr expecting {binder_aval}")
-
-    out_avals = [v.aval for v in call_jaxpr.outvars]
-
-    if prim.map_primitive:
-      axis_size = params["axis_size"]
-      out_avals = [unmapped_aval(axis_size, aval) for aval in out_avals]
-  else:
-    out_avals = prim.abstract_eval(*in_avals, **params)
-
+def check_eqn(prim, in_avals, params):
+  for param in params.values():
+    if isinstance(param, Jaxpr):
+      check_jaxpr(param)
+    elif isinstance(param, TypedJaxpr):
+      check_jaxpr(param.jaxpr)
+  out_avals = prim.abstract_eval(*in_avals, **params)
   if not prim.multiple_results:
     out_avals = [out_avals]
+  return out_avals
 
+def check_call(prim, in_avals, params):
+  if "call_jaxpr" not in params:
+    raise TypeError(f"Call primitive {prim} missing 'call_jaxpr' parameter")
+  call_jaxpr = params["call_jaxpr"]
+
+  # These checks also happen in recursive call, but give better errors here.
+  if len(in_avals) != len(call_jaxpr.invars):
+    raise TypeError(f"Call primitive {prim} with {len(invars)} operands "
+                    f"cannot call jaxpr with {len(call_jaxpr.invars)} inputs")
+  binder_avals = [v.aval for v in call_jaxpr.invars]
+  for binder_aval, in_aval in zip(binder_avals, in_avals):
+    if not typecompat(binder_aval, in_aval):
+      raise TypeError(
+          f"Call primitive {prim} passes operand {in_aval} "
+          f"to jaxpr expecting {binder_aval}")
+
+  _check_jaxpr(call_jaxpr, in_avals)
+
+  out_avals = [v.aval for v in call_jaxpr.outvars]
+  return out_avals
+
+def check_map(prim, in_avals, params):
+  if "call_jaxpr" not in params:
+    raise TypeError(f"Map primitive {prim} missing 'call_jaxpr' parameter")
+  call_jaxpr = params["call_jaxpr"]
+  if "axis_size" not in params:
+    raise TypeError(f"Map primitive {prim} missing 'axis_size' parameter")
+  axis_size = params["axis_size"]
+  if "mapped_invars" not in params:
+    raise TypeError(f"Map primitive {prim} missing 'mapped_invars' parameter")
+  mapped_invars = params["mapped_invars"]
+
+  binder_avals = [unmapped_aval(axis_size, v.aval) if mapped else v.aval
+                  for v, mapped in zip(call_jaxpr.invars, mapped_invars)]
+  for binder_aval, in_aval in zip(binder_avals, in_avals):
+    if not typecompat(binder_aval, in_aval):
+      raise TypeError(f"Call primitive {prim} passes operand {in_aval} "
+                      f"to jaxpr expecting {binder_aval}")
+
+  mapped_avals = [mapped_aval(axis_size, aval) if mapped else aval
+                  for aval, mapped in zip(in_avals, mapped_invars)]
+  _check_jaxpr(call_jaxpr, mapped_avals)
+
+  mapped_out_avals = [v.aval for v in call_jaxpr.outvars]
+  out_avals = [unmapped_aval(axis_size, aval) for aval in mapped_out_avals]
   return out_avals
 
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -330,15 +330,15 @@ class CoreTest(jtu.JaxTestCase):
     jaxpr.eqns[0].outvars[0].aval = make_shaped_array(2)   # int, not float!
     jtu.check_raises_regexp(
         lambda: core.check_jaxpr(jaxpr),
-        TypeError, ("Jaxpr equation LHS .* is ShapedArray(.*), "
-                    "RHS is inferred as ShapedArray(.*), in '.* = sin .*'"))
+        TypeError, (r"Variable '.' inconsistently typed as ShapedArray(.*), "
+                    r"bound as ShapedArray(.*) in '. = sin .'"))
 
     jaxpr = new_jaxpr()
     jaxpr.eqns[0].outvars[0].aval = make_shaped_array(np.ones((2, 3)))
     jtu.check_raises_regexp(
         lambda: core.check_jaxpr(jaxpr),
-        TypeError, ("Jaxpr equation LHS .* is ShapedArray(.*), "
-                    "RHS is inferred as ShapedArray(.*), in '.* = sin .*'"))
+        TypeError, (r"Variable '.' inconsistently typed as ShapedArray(.*), "
+                    r"bound as ShapedArray(.*) in '. = sin .'"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change is mostly stylistic; it brings `check_jaxpr` closer to `eval_jaxpr` (and the other jaxpr interpreters) in organization. There's a slight tweak to an error message which lets us save some slightly redundant code.