### PR TITLE
Skip known invars and outvars in JaxprTrace.process_call

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -425,6 +425,9 @@ class MaskTrace(Trace):
       # Make padded_env hashable
       padded_env = (env_keys, padded_env_vals)
       f, shapes_out = mask_subtrace(f, self.master, shapes, padded_env)
+      if 'donated_invars' in params:
+        params = dict(params, donated_invars=((False,) * len(logical_env_vals) +
+                                              params['donated_invars']))
       vals_out = call_primitive.bind(f, *(logical_env_vals + vals), **params)
       return [MaskTracer(self, v, s) for v, s in zip(vals_out, shapes_out())]
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -27,7 +27,7 @@ from .. import linear_util as lu
 from ..abstract_arrays import ConcreteArray, raise_to_shaped
 from ..ad_util import Zero
 from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
-                    wrap_name, cache, curry)
+                    cache, curry)
 from ..core import (Trace, Tracer, new_master, Jaxpr, Literal, get_aval,
                     AbstractValue, unit, unitvar, abstract_unit,
                     TypedJaxpr, new_jaxpr_eqn)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -262,8 +262,7 @@ class JaxprTrace(Trace):
       return out_tracers
     return out, todo
 
-  def process_map(self, map_primitive, f: lu.WrappedFun, tracers, params):
-    return self.process_call(map_primitive, f, tracers, params)
+  process_map = process_call
 
   def post_process_map(self, map_primitive, out_tracers, params):
     jaxpr, consts, env = tracers_to_jaxpr([], out_tracers)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1099,6 +1099,7 @@ xla_pmap_p.multiple_results = True
 xla_pmap = partial(core.map_bind, xla_pmap_p)
 xla_pmap_p.def_custom_bind(xla_pmap)
 xla_pmap_p.def_impl(xla_pmap_impl)
+pe.staged_out_calls.add(xla_pmap_p)
 
 def _pmap_translation_rule(c, axis_env,
                            in_nodes, name_stack, axis_name, axis_size,


### PR DESCRIPTION
This is a proof of concept of a modification that would change the partial eval to more eagerly eliminate unit arguments and results while handling call primitives (if accepted, the same change would also apply to map primitives and `remat`). I haven't found any concrete arguments to support the current behavior, while there are a few good reasons when it comes to AD:
- Removing units makes the linearized jaxpr possible to type using a linear type system. In particular, an invariant which starts to hold after this change is that every non-constant variable should be used in the body of the jaxpr _exactly once_ (the same invariant doesn't necessarily propagate into call primitive bodies, because e.g. `remat` is linearized lazily, but it's something).
- It makes linearization "idempotent" (i.e. after every odd number of calls you get the same jaxpr, and similar with every even number of calls).

To verify the second claim you can use this script:
```py
import jax                   
import jax.numpy as jnp      
from functools import partial

call = lambda f: lambda *args: jax.core.call(jax.linear_util.wrap_init(lambda *args: [f(*args)]), *args)[0]
                                                                                                           
@call                                                                                                      
def sinsin(x):                                                                                             
    return jnp.sin(jnp.sin(x))                                                                             
                                                                                                           
def vjp_and_jaxpr(f, x, ct):                                                                               
    cell = [None]                                                                                          
    _, vjp = jax.vjp(f, x)                                                                                 
    print(jax.make_jaxpr(vjp)(ct))                                                                         
    return vjp                                                                                             
                                                                                                           
a = lambda x: jnp.array([x])                                                                                
vjp1 = vjp_and_jaxpr(sinsin, a(1.), a(2.))                                                                 
vjp2 = vjp_and_jaxpr(vjp1, a(3.), (a(4.),))                                                                
vjp3 = vjp_and_jaxpr(vjp2, (a(5.),), (a(6.),))                                                             
vjp4 = vjp_and_jaxpr(vjp3, (a(7.),), ((a(8.),),))                                                          
```

In master, you should see the following result, with numbers of dummy arguments and invars steadily growing with each `vjp` invocation:
```
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; d f a b c.
                             let e = mul c d
                                 g = mul e f
                             in (g,) }
                name=transpose(jvp(<lambda>)) ] b c * * a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; f h a b c d e.
                             let g = mul e f
                                 i = mul g h
                             in (i,) }
                name=transpose(jvp(transpose(jvp(<lambda>)))) ] b c * * * * a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; h j a b c d e f g.
                             let i = mul g h
                                 k = mul i j
                             in (k,) }
                name=transpose(jvp(transpose(jvp(transpose(jvp(<lambda>)))))) ] b c * * * * * * a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; j l a b c d e f g h i.
                             let k = mul i j
                                 m = mul k l
                             in (m,) }
                name=transpose(jvp(transpose(jvp(transpose(jvp(transpose(jvp(<lambda>)))))))) ] b c * * * * * * * * a
  in (d,) }
```
whereas with this patch, you should see this:
```
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; d f c.
                             let e = mul c d
                                 g = mul e f
                             in (g,) }
                name=transpose(jvp(<lambda>)) ] b c a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; d f c.
                             let e = mul c d
                                 g = mul e f
                             in (g,) }
                name=transpose(jvp(transpose(jvp(<lambda>)))) ] b c a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; d f c.
                             let e = mul c d
                                 g = mul e f
                             in (g,) }
                name=transpose(jvp(transpose(jvp(transpose(jvp(<lambda>)))))) ] b c a
  in (d,) }
{ lambda b c ; a.
  let d = call[ call_jaxpr={ lambda  ; d f c.
                             let e = mul c d
                                 g = mul e f
                             in (g,) }
                name=transpose(jvp(transpose(jvp(transpose(jvp(transpose(jvp(<lambda>)))))))) ] b c a
  in (d,) }
```

The jaxprs are equal in every other row, and the only thing that changes is the `name` param.