### PR TITLE
Improve speed of tracing dynamic_update_slice

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -5273,7 +5273,7 @@ def _dynamic_slice_indices(operand, start_indices):
                   add(start_indices, _const(start_indices, operand.shape)),
                   start_indices)
   else:
-    return [onp.asarray(i + d if i < 0 else i)
+    return [onp.asarray(i + d if i < 0 else i, getattr(i, 'dtype', dtypes.int_))
             if isinstance(i, (int, onp.integer))
             else select(lt(i, _const(i, 0)), add(i, _const(i, d)), i)
             for i, d in zip(start_indices, operand.shape)]

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -5259,22 +5259,24 @@ def _check_shapelike(fun_name, arg_name, obj):
 
 
 def _dynamic_slice_indices(operand, start_indices):
-  if not isinstance(start_indices, (tuple, list)):
-    if start_indices.ndim != 1:
-      raise ValueError("Slice indices must be a 1D sequence, got {}"
-                       .format(start_indices.shape))
-    start_indices = [squeeze(slice(start_indices, [i], [i+1]), dimensions=(0,))
-                     for i in range(operand.ndim)]
-  else:
-    start_indices = [onp.asarray(i, dtype=dtypes.int_) if isinstance(i, int)
-                     else i for i in start_indices]
   if len(start_indices) != operand.ndim:
     msg = ("Length of slice indices must match number of operand dimensions ({} "
           "vs {})")
     raise ValueError(msg.format(len(start_indices), operand.shape))
   # map int over operand.shape to raise any dynamic-shape errors
-  return [select(lt(i, _const(i, 0)), add(i, _const(i, int(d))), i)
-          for i, d in zip(start_indices, operand.shape)]
+  map(int, operand.shape)
+  if not isinstance(start_indices, (tuple, list)):
+    if start_indices.ndim != 1:
+      raise ValueError("Slice indices must be a 1D sequence, got {}"
+                       .format(start_indices.shape))
+    return select(lt(start_indices, _zeros(start_indices)),
+                  add(start_indices, _const(start_indices, operand.shape)),
+                  start_indices)
+  else:
+    return [onp.asarray(i + d if i < 0 else i)
+            if isinstance(i, (int, onp.integer))
+            else select(lt(i, _const(i, 0)), add(i, _const(i, d)), i)
+            for i, d in zip(start_indices, operand.shape)]
 
 
 

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -46,7 +46,7 @@ from ..interpreters import pxla
 from ..interpreters import ad
 from ..interpreters import batching
 from ..interpreters import masking
-from ..util import curry, cache, safe_zip, unzip2, prod
+from ..util import curry, cache, safe_zip, unzip2, prod, safe_map
 from ..tree_util import build_tree, tree_unflatten, tree_map
 from ..lib import pytree
 from ..lib import xla_bridge
@@ -5264,7 +5264,7 @@ def _dynamic_slice_indices(operand, start_indices):
           "vs {})")
     raise ValueError(msg.format(len(start_indices), operand.shape))
   # map int over operand.shape to raise any dynamic-shape errors
-  map(int, operand.shape)
+  safe_map(int, operand.shape)
   if not isinstance(start_indices, (tuple, list)):
     if start_indices.ndim != 1:
       raise ValueError("Slice indices must be a 1D sequence, got {}"


### PR DESCRIPTION
Take care only to use lax ops over ordinary numpy when necessary, and when possible use vectorized lax ops over scalar lax ops.

In my use case this reduced the time spent in _dynamic_slice_indices from 60s down to 0.2s.