### PR TITLE
Support static valued scalar arrays in expand_dims/squeeze

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1538,7 +1538,7 @@ def _make_reduction(np_fun, op, init_val, preproc=None, bool_op=None,
 
 def _reduction_dims(a, axis):
   if axis is None:
-    return np.arange(ndim(a))
+    return tuple(range(ndim(a)))
   elif isinstance(axis, (np.ndarray, tuple, list)):
     return tuple(_canonicalize_axis(x, ndim(a)) for x in axis)
   elif isinstance(axis, int):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1145,19 +1145,16 @@ def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):
   if axis is None:
     a_shape = shape(a)
     axis = tuple(i for i, d in enumerate(a_shape) if d == 1)
-  elif isinstance(axis, int):
+  elif not isinstance(axis, tuple):
     axis = (axis,)
   return lax.squeeze(a, axis)
 
 
 @_wraps(np.expand_dims)
 def expand_dims(a, axis: Union[int, Tuple[int, ...]]):
-  # TODO(https://github.com/google/jax/issues/3243)
-  try:
-    axis = (int(axis),)  # type: ignore[arg-type]
-  except TypeError:
-    pass
-  return lax.expand_dims(a, axis)  # type: ignore[arg-type]
+  if not isinstance(axis, tuple):
+    axis = (axis,)
+  return lax.expand_dims(a, axis)
 
 
 @_wraps(np.swapaxes)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1884,14 +1884,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_expanddim={}".format(
+      {"testcase_name": "_inshape={}_expanddim={!r}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), dim),
        "arg_shape": arg_shape, "dtype": dtype, "dim": dim,
        "rng_factory": jtu.rand_default}
       for arg_shape in [(), (3,), (3, 4)]
       for dtype in default_dtypes
       for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
-                  + [(0,), (len(arg_shape), len(arg_shape) + 1)])))
+                  + [np.array(0), np.array(-1), (0,), (np.array(0),),
+                     (len(arg_shape), len(arg_shape) + 1)])))
   def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.expand_dims(x, dim)
@@ -1921,15 +1922,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_axis={}".format(
+      {"testcase_name": "_inshape={}_axis={!r}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), ax),
        "arg_shape": arg_shape, "dtype": dtype, "ax": ax,
        "rng_factory": jtu.rand_default}
       for arg_shape, ax in [
           ((3, 1), None),
           ((3, 1), 1),
+          ((3, 1), -1),
+          ((3, 1), np.array(1)),
           ((1, 3, 1), (0, 2)),
-          ((1, 4, 1), (0,))]
+          ((1, 3, 1), (0,)),
+          ((1, 4, 1), (np.array(0),))]
       for dtype in default_dtypes))
   def testSqueeze(self, arg_shape, dtype, ax, rng_factory):
     rng = rng_factory(self.rng())


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/3243