### PR TITLE
pmap(in_axes=None) of sharded_jit

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3051,7 +3051,7 @@ def _reshape_sharded_device_array(array, new_sizes, old_sizes):
     return None
 
   # TODO(skye): handle replicated buffers
-  if array.sharding_spec.replication_factor != 1:
+  if array.sharding_spec.replication_factors:
     return None
 
   # ShardedDevicesArrays require all buffers to have the same shape
@@ -3065,7 +3065,7 @@ def _reshape_sharded_device_array(array, new_sizes, old_sizes):
     sharding_spec = pxla.ShardingSpec(
         shards_per_axis=(num_chunks,) + (1,) * (len(new_sizes) - 1),
         is_axis_materialized=(True,) * len(new_sizes),
-        replication_factor=1)
+        replication_factors=[])
     return pxla.ShardedDeviceArray(aval, sharding_spec, array.device_buffers)
 
   if _is_axis_split(old_sizes, new_sizes):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -224,13 +224,13 @@ class PmapTest(jtu.JaxTestCase):
     # the output is actually replicated (has the same values in each device buffer)
     # but out_axes is implicitly 0, so we shouldn't have replication in the
     # sharding spec.
-    self.assertEqual(f_ans.sharding_spec.replication_factor, 1)
+    self.assertEmpty(f_ans.sharding_spec.replication_factors)
 
     g_expected = np.broadcast_to(x - np.sum(y, 0, keepdims=True), shape)
     g_ans = g(x, y)
     self.assertAllClose(g_ans, g_expected, check_dtypes=True)
     self.assertIsInstance(g_ans, pxla.ShardedDeviceArray)
-    self.assertEqual(g_ans.sharding_spec.replication_factor, 1)
+    self.assertEmpty(g_ans.sharding_spec.replication_factors)
 
   @parameterized.named_parameters(
       {"testcase_name": "_mesh={}".format(device_mesh_shape).replace(" ", ""),
@@ -909,7 +909,7 @@ class PmapTest(jtu.JaxTestCase):
     sharding_spec = pxla.ShardingSpec(
         shards_per_axis=(2, 2),
         is_axis_materialized=(True, True),
-        replication_factor=2)
+        replication_factors=[])
     arr = pxla.ShardedDeviceArray(aval, sharding_spec, bufs)
 
     r = pmap(lambda x: x + 1)(arr)
@@ -1382,7 +1382,7 @@ class SpecToIndicesTest(jtu.JaxTestCase):
     shape = (4, 8)
     spec = pxla.ShardingSpec(shards_per_axis=(2, 2),
                              is_axis_materialized=(True, True),
-                             replication_factor=1)
+                             replication_factors=[])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      ((slice(0,2), slice(0,4)),
                       (slice(0,2), slice(4,8)),
@@ -1393,7 +1393,7 @@ class SpecToIndicesTest(jtu.JaxTestCase):
     shape = (4, 8)
     spec = pxla.ShardingSpec(shards_per_axis=(2, 1),
                              is_axis_materialized=(True, True),
-                             replication_factor=1)
+                             replication_factors=[])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      (slice(0,2), (slice(2,4))))
 
@@ -1401,7 +1401,7 @@ class SpecToIndicesTest(jtu.JaxTestCase):
     shape = (4, 8)
     spec = pxla.ShardingSpec(shards_per_axis=(1, 1),
                              is_axis_materialized=(True, True),
-                             replication_factor=1)
+                             replication_factors=[])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      (slice(None),))
 
@@ -1409,31 +1409,83 @@ class SpecToIndicesTest(jtu.JaxTestCase):
     shape = (4, 8)
     spec = pxla.ShardingSpec(shards_per_axis=(4, 1),
                              is_axis_materialized=(False, True),
-                             replication_factor=1)
+                             replication_factors=[])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      (0, 1, 2, 3))
 
     shape = (2, 2)
     spec = pxla.ShardingSpec(shards_per_axis=(1, 2),
                              is_axis_materialized=(True, False),
-                             replication_factor=1)
+                             replication_factors=[])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      ((slice(None), 0),
                       (slice(None), 1)))
 
-  def testReplication(self):
+  def testReplicationAfterUnsharded(self):
     shape = (2, 8)
     spec = pxla.ShardingSpec(shards_per_axis=(2, 1),
                              is_axis_materialized=(False, True),
-                             replication_factor=3)
+                             replication_factors=[(3, 2)])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      (0, 0, 0, 1, 1, 1))
+
+  def testReplicationPosition2(self):
+    shape = (2, 8)
+    spec = pxla.ShardingSpec(shards_per_axis=(2, 2),
+                             is_axis_materialized=(False, True),
+                             replication_factors=[(3, 2)])
+    self.assertEqual(pxla.spec_to_indices(shape, spec),
+                     ((0, slice(0, 4)), (0, slice(0, 4)), (0, slice(0, 4)),
+                      (0, slice(4, 8)), (0, slice(4, 8)), (0, slice(4, 8)),
+                      (1, slice(0, 4)), (1, slice(0, 4)), (1, slice(0, 4)),
+                      (1, slice(4, 8)), (1, slice(4, 8)), (1, slice(4, 8))))
+
+  def testReplicationPosition1(self):
+    shape = (2, 8)
+    spec = pxla.ShardingSpec(shards_per_axis=(2, 2),
+                             is_axis_materialized=(False, True),
+                             replication_factors=[(3, 1)])
+    self.assertEqual(pxla.spec_to_indices(shape, spec),
+                     ((0, slice(0, 4)), (0, slice(4, 8)),
+                      (0, slice(0, 4)), (0, slice(4, 8)),
+                      (0, slice(0, 4)), (0, slice(4, 8)),
+                      (1, slice(0, 4)), (1, slice(4, 8)),
+                      (1, slice(0, 4)), (1, slice(4, 8)),
+                      (1, slice(0, 4)), (1, slice(4, 8))))
+
+  def testReplicationPosition0(self):
+    shape = (2, 8)
+    spec = pxla.ShardingSpec(shards_per_axis=(2, 1),
+                             is_axis_materialized=(False, True),
+                             replication_factors=[(3, 0)])
+    self.assertEqual(pxla.spec_to_indices(shape, spec),
+                     (0, 1, 0, 1, 0, 1))
+
+  def testMultipleReplications(self):
+    shape = (2, 7, 4)
+    spec = pxla.ShardingSpec(shards_per_axis=(2, 1, 2),
+                             is_axis_materialized=(False, True, True),
+                             replication_factors=[(3, 0), (2, 0), (2, 2)])
+    self.assertEqual(
+        pxla.spec_to_indices(shape, spec),
+        ((0, slice(None), slice(0, 2)), (0, slice(None), slice(2, 4)),
+         (0, slice(None), slice(0, 2)), (0, slice(None), slice(2, 4)),
+         (1, slice(None), slice(0, 2)), (1, slice(None), slice(2, 4)),
+         (1, slice(None), slice(0, 2)), (1, slice(None), slice(2, 4))) * 3 * 2)
+
+  def testReplicatedScalar(self):
+    shape = ()
+    spec = pxla.ShardingSpec(shards_per_axis=(),
+                             is_axis_materialized=(),
+                             replication_factors=[(3, 0)])
+    self.assertEqual(pxla.spec_to_indices(shape, spec),
+                     ((), (), ()))
 
 
 def _spec_str(spec):
   return (f"({spec.shards_per_axis},"
           f"{spec.is_axis_materialized},"
-          f"{spec.replication_factor})")
+          f"{spec.replication_factors})")
 
 
 class ShardArgsTest(jtu.JaxTestCase):
@@ -1455,36 +1507,44 @@ class ShardArgsTest(jtu.JaxTestCase):
       for shape, spec in [
           # pmap(in_axes=0)
           [(4, 8), pxla.ShardingSpec(shards_per_axis=(4, 1),
-                                    is_axis_materialized=(False, True),
-                                    replication_factor=1)],
+                                     is_axis_materialized=(False, True),
+                                     replication_factors=[])],
           # pmap(in_axes=1)
           [(2, 2), pxla.ShardingSpec(shards_per_axis=(1, 2),
-                                    is_axis_materialized=(True, False),
-                                    replication_factor=1)],
+                                     is_axis_materialized=(True, False),
+                                     replication_factors=[])],
           # unsharded
           [(4, 8), pxla.ShardingSpec(shards_per_axis=(1, 1),
-                                    is_axis_materialized=(True, True),
-                                    replication_factor=1)],
+                                     is_axis_materialized=(True, True),
+                                     replication_factors=[])],
           # partitioned, 1 axis
           [(4, 8), pxla.ShardingSpec(shards_per_axis=(2, 1),
-                                    is_axis_materialized=(True, True),
-                                    replication_factor=1)],
+                                     is_axis_materialized=(True, True),
+                                     replication_factors=[])],
           # partitioned, 2 axes
           [(4, 8), pxla.ShardingSpec(shards_per_axis=(2, 2),
-                                    is_axis_materialized=(True, True),
-                                    replication_factor=1)],
+                                     is_axis_materialized=(True, True),
+                                     replication_factors=[])],
           # partitioned + sharding
           [(2, 8), pxla.ShardingSpec(shards_per_axis=(2, 2),
                                      is_axis_materialized=(False, True),
-                                     replication_factor=1)],
+                                     replication_factors=[])],
           # replication + sharding
           [(2, 8), pxla.ShardingSpec(shards_per_axis=(2, 1),
-                                    is_axis_materialized=(False, True),
-                                    replication_factor=3)],
+                                     is_axis_materialized=(False, True),
+                                     replication_factors=[(3, 2)])],
           # replication, no sharding
           [(2, 8), pxla.ShardingSpec(shards_per_axis=(1, 1),
-                                    is_axis_materialized=(True, True),
-                                    replication_factor=3)],
+                                     is_axis_materialized=(True, True),
+                                     replication_factors=[(3, 2)])],
+          # multiple replicated axes
+          [(1, 8), pxla.ShardingSpec(shards_per_axis=(1, 2),
+                                     is_axis_materialized=(False, True),
+                                     replication_factors=[(2, 0), (2, 1)])],
+          # replicated scalar
+          [(), pxla.ShardingSpec(shards_per_axis=(),
+                                 is_axis_materialized=(),
+                                 replication_factors=[(2, 0), (3, 0)])]
       ])
   def testShardArgs(self, shape, spec, make_arg):
     indices = pxla.spec_to_indices(shape, spec)

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -258,6 +258,7 @@ class PmapOfShardedJitTest(jtu.JaxTestCase):
       self.assertTrue(isinstance(r, pxla.ShardedDeviceArray))
       self.assertEqual(len(r.device_buffers), num_shards)
 
+
   @parameterized.named_parameters({
       "testcase_name":
           "_in_parts={}_out_parts={}".format(in_partitions,
@@ -412,6 +413,27 @@ class PmapOfShardedJitTest(jtu.JaxTestCase):
     self.assertAllClose(result, expected, check_dtypes=False)
     self.assertIsInstance(result, pxla.ShardedDeviceArray)
     self.assertLen(result.device_buffers, 4)
+
+  def testInAxesNone(self):
+    shape = (4, 4)
+    replicas = 2
+    in_partitions = (P(2, 1), None, None)
+    out_partitions = P(2, 1)
+    in_axes = (None, None, 0)
+    x = y = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    dummy = np.arange(replicas, dtype=np.float32) + 1
+    num_shards = replicas * np.prod(in_partitions[0])
+    if num_shards > jax.local_device_count():
+      raise SkipTest("requires %d devices" % num_shards)
+
+    def f(x, y, _):
+      return x @ y
+
+    result = pmap(
+        sharded_jit(f, in_parts=in_partitions, out_parts=out_partitions),
+        in_axes=in_axes)(x, y, dummy)
+    expected = pmap(f, in_axes=in_axes)(x, y, dummy)
+    self.assertAllClose(result, expected, check_dtypes=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Sharded device arrays support "replication", meaning that the same values are present on different devices without adding extra logical axes to the array. We use this for two things: `pmap` with arguments that aren't mapped and `sharded_jit` with values that aren't sharded. But they need to be kept separate, because they map to physical devices in different ways (one corresponds to XLA replicas and the other to XLA partitions). This is essential for supporting `pmap(in_axes=None)` nested over `sharded_jit`.

This change modifies `ShardingSpec` to keep these two kinds of replication separate, and sets up sharded device arrays to represent more complex nesting in the future.