### PR TITLE
Implement jax_to_tf.scan

### DIFF
--- a/jax/experimental/jax_to_tf/__init__.py
+++ b/jax/experimental/jax_to_tf/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .jax_to_tf import enable_jit, convert
+from .jax_to_tf import convert

--- a/jax/experimental/jax_to_tf/jax_to_tf.py
+++ b/jax/experimental/jax_to_tf/jax_to_tf.py
@@ -29,6 +29,7 @@ from jax import numpy as jnp
 from jax import tree_util
 from jax import util
 from jax.api_util import flatten_fun
+from jax.lax import lax_control_flow
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 
@@ -44,27 +45,6 @@ from tensorflow.compiler.xla import xla_data_pb2  # type: ignore[import]
 # A value suitable in a TF tracing context: tf.Tensor, tf.Var, or
 # Python scalar or numpy.ndarray.
 TfVal = Any
-
-
-# TODO(necula): used for tests, until we handle all control-flow primitives
-class _JitState(threading.local):
-
-  def __init__(self):
-    super().__init__()
-    self.disable_jit = True
-
-_jit_state = _JitState()
-
-
-@contextlib.contextmanager
-def enable_jit():
-  """Temporarily allow JAX jit."""
-  old_state = _jit_state.disable_jit
-  _jit_state.disable_jit = False
-  try:
-    yield
-  finally:
-    _jit_state.disable_jit = old_state
 
 
 def disable_gradient(fun):
@@ -111,21 +91,11 @@ def convert(fun):
   """
   @disable_gradient
   def wrapped_fun(*args):
-    # TODO(necula): remove the jit disabling once we handle all control-flow.
-    # Disabling the jit helps to avoid some unsupported jax primitives.
-    # E.g. scan will be statically unrolled.
-    def doit():
-      f = lu.wrap_init(fun)
-      args_flat, in_tree = tree_util.tree_flatten((args, {}))
-      flat_fun, out_tree = flatten_fun(f, in_tree)
-      out_flat = _interpret_fun(flat_fun, args_flat)
-      return tree_util.tree_unflatten(out_tree(), out_flat)
-
-    if _jit_state.disable_jit:
-      with jax.disable_jit():
-        return doit()
-    else:
-      return doit()
+    f = lu.wrap_init(fun)
+    args_flat, in_tree = tree_util.tree_flatten((args, {}))
+    flat_fun, out_tree = flatten_fun(f, in_tree)
+    out_flat = _interpret_fun(flat_fun, args_flat)
+    return tree_util.tree_unflatten(out_tree(), out_flat)
 
   return wrapped_fun
 
@@ -844,6 +814,17 @@ def _batched_while(*args, cond_nconsts: int, cond_jaxpr: core.TypedJaxpr,
 
 tf_impl[lax.while_p] = _while
 
+
+def _scan(*tf_args : TfVal, **kwargs):
+  # We use the scan impl rule to rewrite in terms of while. We wrap it under
+  # _interpret_fun to abstract the TF values from scan_impl.
+  def func1(*jax_args):
+    return lax_control_flow._scan_impl(*jax_args, **kwargs)
+
+  return _interpret_fun(lu.wrap_init(func1), tf_args)
+
+tf_impl[lax.scan_p] = _scan
+
 # TODO: add_any
 # TODO: after_all
 # TODO: all_to_all
@@ -870,7 +851,6 @@ tf_impl[lax.while_p] = _while
 # TODO: reduce
 # TODO: reduce_window
 # TODO: rng_uniform
-# TODO: scan
 # TODO: select_and_gather_add
 # TODO: select_and_scatter
 # TODO: sort

--- a/jax/experimental/jax_to_tf/tests/tf_ops_test.py
+++ b/jax/experimental/jax_to_tf/tests/tf_ops_test.py
@@ -122,6 +122,11 @@ class TfOpsTest(jtu.JaxTestCase):
     f_tf = jax_to_tf.convert(f_jax)
     np.testing.assert_allclose(f_jax(0.7), f_tf(0.7))
 
+  def test_nested_jit(self):
+    f_jax = jax.jit(lambda x: jnp.sin(jax.jit(jnp.cos)(x)))
+    f_tf = jax_to_tf.convert(f_jax)
+    np.testing.assert_allclose(f_jax(0.7), f_tf(0.7))
+
   def test_converts_jax_arrays(self):
     f_tf = tf.function(lambda x: x)
     self.assertEqual(f_tf(jnp.zeros([])).numpy(), 0.)
@@ -349,29 +354,25 @@ class ControlFlowOpsTest(parameterized.TestCase):
 
   @parameterized.parameters(False, True)
   def test_cond(self, with_function=False):
-    with jax_to_tf.enable_jit():
+    def f_jax(pred, x):
+      return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
 
-      def f_jax(pred, x):
-        return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
-
-      f_tf = jax_to_tf.convert(f_jax)
-      if with_function:
-        f_tf = tf.function(f_tf)
-      np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
-      np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
+    f_tf = jax_to_tf.convert(f_jax)
+    if with_function:
+      f_tf = tf.function(f_tf)
+    np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
+    np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
 
   @parameterized.parameters(False, True)
   def test_cond_multiple_results(self, with_function=False):
-    with jax_to_tf.enable_jit():
+    def f_jax(pred, x):
+      return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
 
-      def f_jax(pred, x):
-        return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
-
-      f_tf = jax_to_tf.convert(f_jax)
-      if with_function:
-        f_tf = tf.function(f_tf)
-      np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
-      np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
+    f_tf = jax_to_tf.convert(f_jax)
+    if with_function:
+      f_tf = tf.function(f_tf)
+    np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
+    np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -380,59 +381,57 @@ class ControlFlowOpsTest(parameterized.TestCase):
     for with_function in [False, True]))
   def test_while_single_carry(self, with_function=False):
     """A while with a single carry"""
-    with jax_to_tf.enable_jit():
-      def func(x):
-        # Equivalent to:
-        #      for(i=x; i < 4; i++);
-        return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
+    def func(x):
+      # Equivalent to:
+      #      for(i=x; i < 4; i++);
+      return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
 
-      f_jax = func
-      f_tf = jax_to_tf.convert(f_jax)
-      if with_function:
-        f_tf = tf.function(f_tf)
-      res_jax = f_jax(0)
-      res_tf = f_tf(0)
-      np.testing.assert_allclose(res_jax, res_tf)
+    f_jax = func
+    f_tf = jax_to_tf.convert(f_jax)
+    if with_function:
+      f_tf = tf.function(f_tf)
+    res_jax = f_jax(0)
+    res_tf = f_tf(0)
+    np.testing.assert_allclose(res_jax, res_tf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
     dict(testcase_name=f"_function={with_function}",
          with_function=with_function)
     for with_function in [False, True]))
   def test_while(self, with_function=False):
-    with jax_to_tf.enable_jit():
-      # Some constants to capture in the conditional branches
-      cond_const = np.ones(3, dtype=np.float32)
-      body_const1 = np.full_like(cond_const, 1.)
-      body_const2 = np.full_like(cond_const, 2.)
+    # Some constants to capture in the conditional branches
+    cond_const = np.ones(3, dtype=np.float32)
+    body_const1 = np.full_like(cond_const, 1.)
+    body_const2 = np.full_like(cond_const, 2.)
 
-      def func(x):
-        # Equivalent to:
-        #      c = [1, 1, 1]
-        #      for(i=0; i < 3; i++)
-        #        c += [1, 1, 1] + [2, 2, 2]
-        #
-        # The function is set-up so that it captures constants in the
-        # body of the functionals. This covers some cases in the representation
-        # of the lax.while primitive.
-        def cond(idx_carry):
-          i, c = idx_carry
-          return i < jnp.sum(lax.tie_in(i, cond_const))  # Capture cond_const
+    def func(x):
+      # Equivalent to:
+      #      c = [1, 1, 1]
+      #      for(i=0; i < 3; i++)
+      #        c += [1, 1, 1] + [2, 2, 2]
+      #
+      # The function is set-up so that it captures constants in the
+      # body of the functionals. This covers some cases in the representation
+      # of the lax.while primitive.
+      def cond(idx_carry):
+        i, c = idx_carry
+        return i < jnp.sum(lax.tie_in(i, cond_const))  # Capture cond_const
 
-        def body(idx_carry):
-          i, c = idx_carry
-          return (i + 1, c + body_const1 + body_const2)
+      def body(idx_carry):
+        i, c = idx_carry
+        return (i + 1, c + body_const1 + body_const2)
 
-        return lax.while_loop(cond, body, (0, x))
+      return lax.while_loop(cond, body, (0, x))
 
-      f_jax = func
-      f_tf = jax_to_tf.convert(f_jax)
-      if with_function:
-        f_tf = tf.function(f_tf)
-      input = cond_const
-      res_jax = f_jax(input)
-      res_tf = f_tf(input)
-      for r_jax, r_tf in zip(res_jax, res_tf):
-        np.testing.assert_allclose(r_jax, r_tf)
+    f_jax = func
+    f_tf = jax_to_tf.convert(f_jax)
+    if with_function:
+      f_tf = tf.function(f_tf)
+    input = cond_const
+    res_jax = f_jax(input)
+    res_tf = f_tf(input)
+    for r_jax, r_tf in zip(res_jax, res_tf):
+      np.testing.assert_allclose(r_jax, r_tf)
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -441,45 +440,41 @@ class ControlFlowOpsTest(parameterized.TestCase):
     for with_function in [False, True]))
   def test_while_batched(self, with_function=True):
     """A while with a single carry"""
-    with jax_to_tf.enable_jit():
-      def product(x, y):
-        # Equivalent to "x * y" implemented as:
-        #      res = 0.
-        #      for(i=0; i < y; i++)
-        #         res += x
-        return lax.while_loop(lambda idx_carry: idx_carry[0] < y,
-                              lambda idx_carry: (idx_carry[0] + 1,
-                                                 idx_carry[1] + x),
-                              (0, 0.))
+    def product(x, y):
+      # Equivalent to "x * y" implemented as:
+      #      res = 0.
+      #      for(i=0; i < y; i++)
+      #         res += x
+      return lax.while_loop(lambda idx_carry: idx_carry[0] < y,
+                            lambda idx_carry: (idx_carry[0] + 1,
+                                               idx_carry[1] + x),
+                            (0, 0.))
 
-      # We use vmap to compute result[i, j] = i * j
-      xs = np.arange(4, dtype=np.int32)
-      ys = np.arange(5, dtype=np.int32)
+    # We use vmap to compute result[i, j] = i * j
+    xs = np.arange(4, dtype=np.int32)
+    ys = np.arange(5, dtype=np.int32)
 
-      def product_xs_y(xs, y):
-        return jax.vmap(product, in_axes=(0, None))(xs, y)
-      def product_xs_ys(xs, ys):
-        return jax.vmap(product_xs_y, in_axes=(None, 0))(xs, ys)
+    def product_xs_y(xs, y):
+      return jax.vmap(product, in_axes=(0, None))(xs, y)
+    def product_xs_ys(xs, ys):
+      return jax.vmap(product_xs_y, in_axes=(None, 0))(xs, ys)
 
-      f_jax = product_xs_ys
-      f_tf = jax_to_tf.convert(f_jax)
-      if with_function:
-        f_tf = tf.function(f_tf)
-      res_jax = f_jax(xs, ys)
-      res_tf = f_tf(xs, ys)
-      for r_tf, r_jax in zip(res_tf, res_jax):
-        np.testing.assert_allclose(r_tf, r_jax)
+    f_jax = product_xs_ys
+    f_tf = jax_to_tf.convert(f_jax)
+    if with_function:
+      f_tf = tf.function(f_tf)
+    res_jax = f_jax(xs, ys)
+    res_tf = f_tf(xs, ys)
+    for r_tf, r_jax in zip(res_tf, res_jax):
+      np.testing.assert_allclose(r_tf, r_jax)
 
   @parameterized.parameters(False, True)
   def test_scan(self, with_function=False):
     def f_jax(xs, ys):
-      # Equivalent to:
-      #    res = 0.
-      #    for x, y in zip(xs, ys):
-      #      res += x * y
-      def body(carry, inputs):
+      body_const = np.ones((2, ), dtype=np.float32)  # Test constant capture
+      def body(res0, inputs):
         x, y = inputs
-        return carry + x * y, carry
+        return res0 + x * y, body_const
       return lax.scan(body, 0., (xs, ys))
 
     f_tf = jax_to_tf.convert(f_jax)


### PR DESCRIPTION
Also removed the enable_jit, which was needed only
to work around the lack of control flow primitive support.