### PR TITLE
Add np.polyadd numpy function

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -210,6 +210,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     packbits
     pad
     percentile
+    polyadd
     polyval
     power
     positive

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -47,7 +47,7 @@ from .lax_numpy import (
     nanmax, nanmean, nanmin, nanprod, nanstd, nansum, nanvar, ndarray, ndim,
     negative, newaxis, nextafter, nonzero, not_equal, number, numpy_version,
     object_, ones, ones_like, operator_name, outer, packbits, pad, percentile,
-    pi, polyval, positive, power, prod, product, promote_types, ptp, quantile,
+    pi, polyadd, polyval, positive, power, prod, product, promote_types, ptp, quantile,
     rad2deg, radians, ravel, real, reciprocal, remainder, repeat, reshape,
     result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,
     save, savez, searchsorted, select, set_printoptions, shape, sign, signbit,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2609,6 +2609,19 @@ def polyval(p, x):
     y = y * x + p[i]
   return y
 
+@_wraps(np.polyadd)
+def polyadd(a, b):
+  a = asarray(a)
+  b = asarray(b)
+
+  shape_diff = a.shape[0] - b.shape[0]
+  if shape_diff > 0:
+    b = concatenate((np.zeros(shape_diff, dtype=b.dtype), b))
+  else:
+    a = concatenate((np.zeros(shape_diff, dtype=b.dtype), a))
+
+  return lax.add(a,b)
+
 
 @_wraps(np.append)
 def append(arr, values, axis=None):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1129,6 +1129,22 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, jnp.float32), rng(shape, dtype)]
     self._CheckAgainstNumpy(np.extract, jnp.extract, args_maker)
 
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}".format(
+          jtu.format_shape_dtype_string(shape, dtype)),
+       "dtype": dtype, "shape": shape}
+      for dtype in default_dtypes
+      for shape in one_dim_array_shapes))
+  def testPolyAdd(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    np_fun = lambda arg1, arg2: np.polyadd(arg1, arg2)
+    jnp_fun = lambda arg1, arg2: jnp.polyadd(arg1, arg2)
+    args_maker = lambda: [rng(shape, dtype), rng(shape, dtype)]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
+    self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
+
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),


### PR DESCRIPTION
Part of #70 

I'll add tests once I'm confident my current approach is correct. The PR implements `np.polyadd` for two one dimensional arrays or `np.poly1d` objects.