### PR TITLE
Refactoring of jax_to_tf tests:

### DIFF
--- a/jax/experimental/jax_to_tf/tests/__init__.py
+++ b/jax/experimental/jax_to_tf/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/jax/experimental/jax_to_tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax_to_tf/tests/control_flow_ops_test.py
@@ -1,0 +1,145 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the jax_to_tf conversion for control-flow primitives."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from typing import Any, Callable, Sequence, Tuple
+
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+from jax import test_util as jtu
+import numpy as np
+
+from jax.experimental.jax_to_tf.tests import tf_test_util
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_cond(self, with_function=False):
+    def f_jax(pred, x):
+      return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
+
+    self.ConvertAndCompare(f_jax, True, 1., with_function=with_function)
+    self.ConvertAndCompare(f_jax, False, 1., with_function=with_function)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_cond_multiple_results(self, with_function=False):
+    def f_jax(pred, x):
+      return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
+
+    self.ConvertAndCompare(f_jax, True, 1., with_function=with_function)
+    self.ConvertAndCompare(f_jax, False, 1., with_function=with_function)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_while_single_carry(self, with_function=False):
+    """A while with a single carry"""
+    def func(x):
+      # Equivalent to:
+      #      for(i=x; i < 4; i++);
+      return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
+
+    self.ConvertAndCompare(func, 0, with_function=with_function)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_while(self, with_function=False):
+    # Some constants to capture in the conditional branches
+    cond_const = np.ones(3, dtype=np.float32)
+    body_const1 = np.full_like(cond_const, 1.)
+    body_const2 = np.full_like(cond_const, 2.)
+
+    def func(x):
+      # Equivalent to:
+      #      c = [1, 1, 1]
+      #      for(i=0; i < 3; i++)
+      #        c += [1, 1, 1] + [2, 2, 2]
+      #
+      # The function is set-up so that it captures constants in the
+      # body of the functionals. This covers some cases in the representation
+      # of the lax.while primitive.
+      def cond(idx_carry):
+        i, c = idx_carry
+        return i < jnp.sum(lax.tie_in(i, cond_const))  # Capture cond_const
+
+      def body(idx_carry):
+        i, c = idx_carry
+        return (i + 1, c + body_const1 + body_const2)
+
+      return lax.while_loop(cond, body, (0, x))
+
+    self.ConvertAndCompare(func, cond_const, with_function=with_function)
+
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_while_batched(self, with_function=True):
+    """A while with a single carry"""
+    def product(x, y):
+      # Equivalent to "x * y" implemented as:
+      #      res = 0.
+      #      for(i=0; i < y; i++)
+      #         res += x
+      return lax.while_loop(lambda idx_carry: idx_carry[0] < y,
+                            lambda idx_carry: (idx_carry[0] + 1,
+                                               idx_carry[1] + x),
+                            (0, 0.))
+
+    # We use vmap to compute result[i, j] = i * j
+    xs = np.arange(4, dtype=np.int32)
+    ys = np.arange(5, dtype=np.int32)
+
+    def product_xs_y(xs, y):
+      return jax.vmap(product, in_axes=(0, None))(xs, y)
+    def product_xs_ys(xs, ys):
+      return jax.vmap(product_xs_y, in_axes=(None, 0))(xs, ys)
+
+    self.ConvertAndCompare(product_xs_ys, xs, ys, with_function=with_function)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_function={with_function}",
+         with_function=with_function)
+    for with_function in [False, True]))
+  def test_scan(self, with_function=False):
+    def f_jax(xs, ys):
+      body_const = np.ones((2, ), dtype=np.float32)  # Test constant capture
+      def body(res0, inputs):
+        x, y = inputs
+        return res0 + x * y, body_const
+      return lax.scan(body, 0., (xs, ys))
+
+    arg = np.arange(10, dtype=np.float32)
+    self.ConvertAndCompare(f_jax, arg, arg, with_function=with_function)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/jax/experimental/jax_to_tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax_to_tf/tests/savedmodel_test.py
@@ -13,28 +13,22 @@
 # limitations under the License.
 
 import os
-import unittest
 
-import numpy as np
 from absl.testing import absltest
-from absl.testing import parameterized
-import jax
-from jax import test_util as jtu
-import jax.numpy as jnp
 
 import jax
-import jax.lax as lax
 import jax.numpy as jnp
 import numpy as np
-import tensorflow as tf
+import tensorflow as tf  # type: ignore[import]
 
 from jax.experimental import jax_to_tf
+from jax.experimental.jax_to_tf.tests import tf_test_util
 
 from jax.config import config
 config.parse_flags_with_absl()
 
 
-class SavedModelTest(jtu.JaxTestCase):
+class SavedModelTest(tf_test_util.JaxToTfTestCase):
 
   def testSavedModel(self):
     f_jax = jax.jit(lambda x: jnp.sin(jnp.cos(x)))
@@ -42,12 +36,13 @@ class SavedModelTest(jtu.JaxTestCase):
     model.f = tf.function(jax_to_tf.convert(f_jax),
                           input_signature=[tf.TensorSpec([], tf.float32)])
     x = np.array(0.7)
-    np.testing.assert_allclose(model.f(x), f_jax(x))
+    self.assertAllClose(model.f(x), f_jax(x))
     # Roundtrip through saved model on disk.
     model_dir = os.path.join(absltest.get_default_test_tmpdir(), str(id(model)))
     tf.saved_model.save(model, model_dir)
     restored_model = tf.saved_model.load(model_dir)
-    np.testing.assert_allclose(restored_model.f(x), f_jax(x))
+    self.assertAllClose(restored_model.f(x), f_jax(x))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/jax/experimental/jax_to_tf/tests/stax_test.py
+++ b/jax/experimental/jax_to_tf/tests/stax_test.py
@@ -20,7 +20,7 @@ import numpy as np
 import os
 import sys
 
-from jax.experimental import jax_to_tf
+from jax.experimental.jax_to_tf.tests import tf_test_util
 
 # Import ../../../../examples/resnet50.py
 def from_examples_import_resnet50():
@@ -30,7 +30,7 @@ def from_examples_import_resnet50():
   assert os.path.isfile(os.path.join(examples_dir, "resnet50.py"))
   try:
     sys.path.append(examples_dir)
-    import resnet50  # type: ignore[import-error]
+    import resnet50  # type: ignore
     return resnet50
   finally:
     sys.path.pop()
@@ -44,7 +44,7 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
-class StaxTest(jtu.JaxTestCase):
+class StaxTest(tf_test_util.JaxToTfTestCase):
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def test_res_net(self):
@@ -54,8 +54,7 @@ class StaxTest(jtu.JaxTestCase):
     _, params = init_fn(key, shape)
     infer = functools.partial(apply_fn, params)
     images = np.array(jax.random.normal(key, shape))
-    np.testing.assert_allclose(infer(images), jax_to_tf.convert(infer)(images),
-                               rtol=0.5)
+    self.ConvertAndCompare(infer, images, rtol=0.5)
 
 
 if __name__ == "__main__":

--- a/jax/experimental/jax_to_tf/tests/tf_ops_test.py
+++ b/jax/experimental/jax_to_tf/tests/tf_ops_test.py
@@ -15,7 +15,8 @@
 
 from absl.testing import absltest
 from absl.testing import parameterized
-import functools
+from typing import Any, Callable, Sequence, Tuple
+
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
@@ -24,6 +25,7 @@ import numpy as np
 import tensorflow as tf  # type: ignore[import]
 
 from jax.experimental import jax_to_tf
+from jax.experimental.jax_to_tf.tests import tf_test_util
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -102,25 +104,23 @@ INDEX = (
 )
 
 
-class TfOpsTest(jtu.JaxTestCase):
+class TfOpsTest(tf_test_util.JaxToTfTestCase):
 
   def test_basics(self):
     f_jax = lambda x: jnp.sin(jnp.cos(x))
-    f_tf = jax_to_tf.convert(f_jax)
-    self.assertIsInstance(f_tf(0.7), tf.Tensor)
-    np.testing.assert_allclose(f_jax(0.7), f_tf(0.7))
+    _, res_tf = self.ConvertAndCompare(f_jax, 0.7)
+    self.assertIsInstance(res_tf, tf.Tensor)
 
   def test_variable_input(self):
     f_jax = lambda x: jnp.sin(jnp.cos(x))
     f_tf = jax_to_tf.convert(f_jax)
     v = tf.Variable(0.7)
     self.assertIsInstance(f_tf(v), tf.Tensor)
-    np.testing.assert_allclose(f_jax(0.7), f_tf(v))
+    self.assertAllClose(f_jax(0.7), f_tf(v))
 
   def test_jit(self):
     f_jax = jax.jit(lambda x: jnp.sin(jnp.cos(x)))
-    f_tf = jax_to_tf.convert(f_jax)
-    np.testing.assert_allclose(f_jax(0.7), f_tf(0.7))
+    self.ConvertAndCompare(f_jax, 0.7)
 
   def test_nested_jit(self):
     f_jax = jax.jit(lambda x: jnp.sin(jax.jit(jnp.cos)(x)))
@@ -138,21 +138,23 @@ class TfOpsTest(jtu.JaxTestCase):
     n = jax.local_device_count()
     mk_sharded = lambda f: jax.pmap(lambda x: x)(f([n]))
     f_tf = tf.function(lambda x: x)
-    np.testing.assert_allclose(f_tf(mk_sharded(jnp.zeros)).numpy(),
-                               np.zeros([n]))
-    np.testing.assert_allclose(f_tf(mk_sharded(jnp.ones)).numpy(), np.ones([n]))
+    self.assertAllClose(f_tf(mk_sharded(jnp.zeros)).numpy(),
+                        np.zeros([n]))
+    self.assertAllClose(f_tf(mk_sharded(jnp.ones)).numpy(),
+                        np.ones([n]))
 
   def test_function(self):
     f_jax = jax.jit(lambda x: jnp.sin(jnp.cos(x)))
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(0.7), f_tf(0.7))
+    self.ConvertAndCompare(f_jax, 0.7, with_function=True)
 
-  @parameterized.parameters(jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
-                            jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
-                            jnp.greater_equal, jnp.not_equal, jnp.maximum,
-                            jnp.minimum)
-  def test_type_promotion(self, f_jax):
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
+                  jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
+                  jnp.greater_equal, jnp.not_equal, jnp.maximum,
+                  jnp.minimum]))
+  def test_type_promotion(self, f_jax=jnp.add):
     # We only test a few types here, as tensorflow does not support many
     # types like uint* or bool in binary ops.
     types = [np.int32, np.int64, np.float32]
@@ -160,33 +162,32 @@ class TfOpsTest(jtu.JaxTestCase):
       for y_dtype in types:
         x = np.array([1, 2], dtype=x_dtype)
         y = np.array([3, 4], dtype=y_dtype)
-        r_jax = f_jax(x, y)
-        r_tf = f_tf(x, y)
-        np.testing.assert_allclose(r_jax, r_tf)
+        self.ConvertAndCompare(f_jax, x, y, with_function=True)
 
   def test_concat(self):
     values = [np.array([1, 2], dtype=np.float32),
               np.array([1, 2], dtype=np.int32),
               np.array([1, 2], dtype=np.int8)]
     f_jax = jax.jit(lambda x: jnp.concatenate(x, axis=0))
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values), f_tf(values))
+    self.ConvertAndCompare(f_jax, values, with_function=True)
 
   def test_pad(self):
     values = np.array([1, 2], dtype=np.float32)
     f_jax = jax.jit(lambda x: jax.lax.pad(x, 0.0, [(3, 1, 2)]))
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values), f_tf(values))
+    self.ConvertAndCompare(f_jax, values, with_function=True)
 
-  @parameterized.parameters(*LAX_ELEMENTWISE_UNARY)
-  def test_unary_elementwise(self, f_jax):
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in LAX_ELEMENTWISE_UNARY))
+  def test_unary_elementwise(self, f_jax=lax.abs):
     x = np.array([-1.6, -1.4, -1.0, 0.0, 0.1, 0.2, 1, 1.4, 1.6],
                  dtype=np.float32)
     f_tf = tf.function(jax_to_tf.convert(f_jax))
     r_jax = f_jax(x)
     r_tf = f_tf(x)
-    np.testing.assert_allclose(r_jax[np.isfinite(r_jax)],
-                               r_tf[np.isfinite(r_tf)], atol=1e-4)
+    self.assertAllClose(r_jax[np.isfinite(r_jax)],
+                        r_tf[np.isfinite(r_tf)], atol=1e-4)
 
   def test_bitwise_not(self):
     x = np.array([-1, 3, -2, 0, 0, 2, 1, 3], dtype=np.int32)
@@ -194,11 +195,14 @@ class TfOpsTest(jtu.JaxTestCase):
     f_tf = tf.function(jax_to_tf.convert(f_jax))
     r_jax = f_jax(x)
     r_tf = f_tf(x)
-    np.testing.assert_allclose(r_jax[np.isfinite(r_jax)],
-                               r_tf[np.isfinite(r_tf)], atol=1e-4)
+    self.assertAllClose(r_jax[np.isfinite(r_jax)],
+                        r_tf[np.isfinite(r_tf)], atol=1e-4)
 
-  @parameterized.parameters(*LAX_ELEMENTWISE_BINARY)
-  def test_binary_elementwise(self, f_jax):
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in LAX_ELEMENTWISE_BINARY))
+  def test_binary_elementwise(self, f_jax=lax.add):
     a = np.array([-1.6, -1.4, -1.0, 0.0, 0.1, 0.2, 1, 1.4, 1.6],
                  dtype=np.float32)
     b = np.array([-1.6, 1.4, 1.0, 0.0, 0.1, 0.2, 1, 1.4, -1.6],
@@ -216,20 +220,26 @@ class TfOpsTest(jtu.JaxTestCase):
       r_tf = np.copy(r_tf)
       r_tf[r_tf == 0] = np.nan
       r_tf[r_tf == 1] = np.nan
-    np.testing.assert_allclose(r_jax[np.isfinite(r_jax)],
-                               r_tf[np.isfinite(r_tf)], atol=1e-4)
+    self.assertAllClose(r_jax[np.isfinite(r_jax)],
+                        r_tf[np.isfinite(r_tf)], atol=1e-4)
 
-  @parameterized.parameters(*LAX_LOGICAL_ELEMENTWISE_BINARY)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in LAX_LOGICAL_ELEMENTWISE_BINARY))
   def test_binary_logical_elementwise(self, f_jax):
     a = np.array([1, 3, 2, 0, 0, 2, 1, 3], dtype=np.uint32)
     b = np.array([1, 2, 3, 0, 1, 0, 2, 3], dtype=np.uint32)
     f_tf = tf.function(jax_to_tf.convert(f_jax))
     r_jax = f_jax(a, b)
     r_tf = f_tf(a, b)
-    np.testing.assert_allclose(r_jax[np.isfinite(r_jax)],
-                               r_tf[np.isfinite(r_tf)], atol=1e-4)
+    self.assertAllClose(r_jax[np.isfinite(r_jax)],
+                        r_tf[np.isfinite(r_tf)], atol=1e-4)
 
-  @parameterized.parameters((lax.betainc,))
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in (lax.betainc,)))
   def test_trinary_elementwise(self, f_jax):
     a = np.array([-1.6, -1.4, -1.0, 0.0, 0.1, 0.3, 1, 1.4, 1.6],
                  dtype=np.float32)
@@ -240,8 +250,8 @@ class TfOpsTest(jtu.JaxTestCase):
     f_tf = tf.function(jax_to_tf.convert(f_jax))
     r_jax = f_jax(a, b, c)
     r_tf = f_tf(a, b, c)
-    np.testing.assert_allclose(r_jax[np.isfinite(r_jax)],
-                               r_tf[np.isfinite(r_tf)], atol=1e-4)
+    self.assertAllClose(r_jax[np.isfinite(r_jax)],
+                        r_tf[np.isfinite(r_tf)], atol=1e-4)
 
   # TODO(necula): replace these tests with LAX reference tests
   def test_squeeze(self):
@@ -249,16 +259,14 @@ class TfOpsTest(jtu.JaxTestCase):
     values = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
     for squeeze_dims in ((1,), (3,), (1, 3,)):
       f_jax = jax.jit(lambda v: jnp.squeeze(v, axis=squeeze_dims))  # pylint: disable=cell-var-from-loop
-      f_tf = tf.function(jax_to_tf.convert(f_jax))
-      np.testing.assert_allclose(f_jax(values), f_tf(values))
+      self.ConvertAndCompare(f_jax, values, with_function=True)
 
   def test_gather(self):
     values = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.float32)
     indices = np.array([0, 1], dtype=np.int32)
     for axis in (0, 1):
       f_jax = jax.jit(lambda v, i: jnp.take(v, i, axis=axis))  # pylint: disable=cell-var-from-loop
-      f_tf = tf.function(jax_to_tf.convert(f_jax))
-      np.testing.assert_allclose(f_jax(values, indices), f_tf(values, indices))
+      self.ConvertAndCompare(f_jax, values, indices, with_function=True)
 
   def test_boolean_gather(self):
     values = np.array([[True, True], [False, True], [False, False]],
@@ -266,55 +274,57 @@ class TfOpsTest(jtu.JaxTestCase):
     indices = np.array([0, 1], dtype=np.int32)
     for axis in [0, 1]:
       f_jax = jax.jit(lambda v, i: jnp.take(v, i, axis=axis))  # pylint: disable=cell-var-from-loop
-      f_tf = tf.function(jax_to_tf.convert(f_jax))
-      np.testing.assert_allclose(f_jax(values, indices), f_tf(values, indices))
+      self.ConvertAndCompare(f_jax, values, indices, with_function=True)
 
-  @parameterized.parameters(*REDUCE)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in REDUCE))
   def test_reduce_ops_with_numerical_input(self, f_jax):
     values = [np.array([1, 2, 3], dtype=np.float32)]
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values), f_tf(values))
+    self.ConvertAndCompare(f_jax, values, with_function=True)
 
-  @parameterized.parameters(jnp.cumsum, jnp.cumprod)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in (jnp.cumsum, jnp.cumprod)))
   def test_cumulated_ops(self, f_jax):
     values = np.array([1, 2, 3], dtype=np.float32)
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values), f_tf(values))
+    self.ConvertAndCompare(f_jax, values, with_function=True)
 
-  @parameterized.parameters(*INDEX)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{op.__name__}",
+         op=op)
+    for op in INDEX))
   def test_scatter_static(self, op):
     values = np.ones((5, 6), dtype=np.float32)
     update = np.float32(6.)
     f_jax = jax.jit(lambda v, u: op(v, jax.ops.index[::2, 3:], u))
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values, update), f_tf(values, update))
+    self.ConvertAndCompare(f_jax, values, update, with_function=True)
 
-  @parameterized.parameters(*REDUCE)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in REDUCE))
   def test_reduce_ops_with_boolean_input(self, f_jax):
     values = [np.array([True, False, True], dtype=np.bool)]
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(values), f_tf(values))
+    self.ConvertAndCompare(f_jax, values, with_function=True)
 
   def test_gather_rank_change(self):
     params = jnp.array([[1.0, 1.5, 2.0], [2.0, 2.5, 3.0], [3.0, 3.5, 4.0]])
     indices = jnp.array([[1, 1, 2], [0, 1, 0]])
     f_jax = jax.jit(lambda i: params[i])
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
-    np.testing.assert_allclose(f_jax(indices), f_tf(indices))
+    self.ConvertAndCompare(f_jax, indices, with_function=True)
 
   def test_prngsplit(self):
     f_jax = jax.jit(lambda key: jax.random.split(key, 2))
-    f_tf = tf.function(jax_to_tf.convert(f_jax))
     for rng_key in [jax.random.PRNGKey(42),
                     np.array([0, 0], dtype=np.uint32),
                     np.array([0xFFFFFFFF, 0], dtype=np.uint32),
                     np.array([0, 0xFFFFFFFF], dtype=np.uint32),
                     np.array([0xFFFFFFFF, 0xFFFFFFFF], dtype=np.uint32)
                     ]:
-      jax_keys = f_jax(rng_key)
-      tf_keys = f_tf(rng_key)
-      for jax_key, tf_key in zip(jax_keys, tf_keys):
-        np.testing.assert_equal(jax_key, tf_key)
+      self.ConvertAndCompare(f_jax, rng_key, with_function=True)
 
   def test_gradients_disabled(self):
     f = jax_to_tf.convert(jnp.tan)
@@ -329,8 +339,7 @@ class TfOpsTest(jtu.JaxTestCase):
   def test_zeros_like(self):
     v = np.float32(2.)
     f_jax = jax.ad_util.zeros_like_jaxval
-    f_tf = jax_to_tf.convert(f_jax)
-    self.assertEqual(f_jax(v), f_tf(v))
+    self.ConvertAndCompare(f_jax, v)
 
   def test_stop_gradient(self):
     f = jax_to_tf.convert(lax.stop_gradient)
@@ -347,144 +356,6 @@ class TfOpsTest(jtu.JaxTestCase):
     self.assertLen(jax.tree_leaves(m.a), 2)
     self.assertLen(jax.tree_leaves(m.b), 2)
     self.assertLen(jax.tree_leaves(m.c), 2)
-
-
-# TODO(necula): move this to a separate file
-class ControlFlowOpsTest(parameterized.TestCase):
-
-  @parameterized.parameters(False, True)
-  def test_cond(self, with_function=False):
-    def f_jax(pred, x):
-      return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
-
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
-    np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
-
-  @parameterized.parameters(False, True)
-  def test_cond_multiple_results(self, with_function=False):
-    def f_jax(pred, x):
-      return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
-
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    np.testing.assert_allclose(f_tf(True, 1.), f_jax(True, 1.))
-    np.testing.assert_allclose(f_tf(False, 1.), f_jax(False, 1.))
-
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-    dict(testcase_name=f"_function={with_function}",
-         with_function=with_function)
-    for with_function in [False, True]))
-  def test_while_single_carry(self, with_function=False):
-    """A while with a single carry"""
-    def func(x):
-      # Equivalent to:
-      #      for(i=x; i < 4; i++);
-      return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
-
-    f_jax = func
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    res_jax = f_jax(0)
-    res_tf = f_tf(0)
-    np.testing.assert_allclose(res_jax, res_tf)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-    dict(testcase_name=f"_function={with_function}",
-         with_function=with_function)
-    for with_function in [False, True]))
-  def test_while(self, with_function=False):
-    # Some constants to capture in the conditional branches
-    cond_const = np.ones(3, dtype=np.float32)
-    body_const1 = np.full_like(cond_const, 1.)
-    body_const2 = np.full_like(cond_const, 2.)
-
-    def func(x):
-      # Equivalent to:
-      #      c = [1, 1, 1]
-      #      for(i=0; i < 3; i++)
-      #        c += [1, 1, 1] + [2, 2, 2]
-      #
-      # The function is set-up so that it captures constants in the
-      # body of the functionals. This covers some cases in the representation
-      # of the lax.while primitive.
-      def cond(idx_carry):
-        i, c = idx_carry
-        return i < jnp.sum(lax.tie_in(i, cond_const))  # Capture cond_const
-
-      def body(idx_carry):
-        i, c = idx_carry
-        return (i + 1, c + body_const1 + body_const2)
-
-      return lax.while_loop(cond, body, (0, x))
-
-    f_jax = func
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    input = cond_const
-    res_jax = f_jax(input)
-    res_tf = f_tf(input)
-    for r_jax, r_tf in zip(res_jax, res_tf):
-      np.testing.assert_allclose(r_jax, r_tf)
-
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-    dict(testcase_name=f"_function={with_function}",
-         with_function=with_function)
-    for with_function in [False, True]))
-  def test_while_batched(self, with_function=True):
-    """A while with a single carry"""
-    def product(x, y):
-      # Equivalent to "x * y" implemented as:
-      #      res = 0.
-      #      for(i=0; i < y; i++)
-      #         res += x
-      return lax.while_loop(lambda idx_carry: idx_carry[0] < y,
-                            lambda idx_carry: (idx_carry[0] + 1,
-                                               idx_carry[1] + x),
-                            (0, 0.))
-
-    # We use vmap to compute result[i, j] = i * j
-    xs = np.arange(4, dtype=np.int32)
-    ys = np.arange(5, dtype=np.int32)
-
-    def product_xs_y(xs, y):
-      return jax.vmap(product, in_axes=(0, None))(xs, y)
-    def product_xs_ys(xs, ys):
-      return jax.vmap(product_xs_y, in_axes=(None, 0))(xs, ys)
-
-    f_jax = product_xs_ys
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    res_jax = f_jax(xs, ys)
-    res_tf = f_tf(xs, ys)
-    for r_tf, r_jax in zip(res_tf, res_jax):
-      np.testing.assert_allclose(r_tf, r_jax)
-
-  @parameterized.parameters(False, True)
-  def test_scan(self, with_function=False):
-    def f_jax(xs, ys):
-      body_const = np.ones((2, ), dtype=np.float32)  # Test constant capture
-      def body(res0, inputs):
-        x, y = inputs
-        return res0 + x * y, body_const
-      return lax.scan(body, 0., (xs, ys))
-
-    f_tf = jax_to_tf.convert(f_jax)
-    if with_function:
-      f_tf = tf.function(f_tf)
-    arg = np.arange(10, dtype=np.float32)
-    res_jax = f_jax(arg, arg)
-    res_tf = f_tf(arg, arg)
-    for r_jax, r_tf in zip(res_jax, res_tf):
-      np.testing.assert_allclose(r_tf, r_jax)
 
 
 if __name__ == "__main__":

--- a/jax/experimental/jax_to_tf/tests/tf_test_util.py
+++ b/jax/experimental/jax_to_tf/tests/tf_test_util.py
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from typing import Any, Callable, Sequence, Tuple
+import tensorflow as tf  # type: ignore[import]
+
+from jax.config import config
+from jax import dtypes
+from jax.experimental import jax_to_tf
+from jax import test_util as jtu
+
+class JaxToTfTestCase(jtu.JaxTestCase):
+
+  def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
+    """Compares dtypes across JAX and TF dtypes. Overrides super method."""
+    def to_numpy_dtype(dt):
+      return dt if isinstance(dt, np.dtype) else dt.as_numpy_dtype
+
+    if not config.FLAGS.jax_enable_x64 and canonicalize_dtypes:
+      self.assertEqual(dtypes.canonicalize_dtype(to_numpy_dtype(jtu._dtype(x))),
+                       dtypes.canonicalize_dtype(to_numpy_dtype(jtu._dtype(y))))
+    else:
+      self.assertEqual(to_numpy_dtype(jtu._dtype(x)),
+                       to_numpy_dtype(jtu._dtype(y)))
+
+  def ConvertAndCompare(self, func_jax: Callable, *args,
+                        with_function: bool = False,
+                        atol=None,
+                        rtol=None) -> Tuple[Any, Any]:
+    """Compares jax_func(*args) with convert(jax_func)(*args)."""
+    func_tf = jax_to_tf.convert(func_jax)
+    if with_function:
+      func_tf = tf.function(func_tf)
+    res_jax = func_jax(*args)
+    res_tf = func_tf(*args)
+    self.assertAllClose(res_jax, res_tf, atol=atol, rtol=rtol)
+    return (res_jax, res_tf)
+


### PR DESCRIPTION
* Moved control-flow tests into their own file (more are coming)
* Used a helped function ConvertAndCompare
* Used self.assertAllClose instead of numpy.testing.assert_all_close because
  the former iterates over lists and tuples (and is standard in other JAX tests)
* Used @parameterized.named_parameters for parameterized tests, for nicer test
 names.