### PR TITLE
fix binary promotion test

### DIFF
--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -104,7 +104,7 @@ class DtypesTest(jtu.JaxTestCase):
     op = jax.jit(operator.add) if jit else operator.add
     for x, y, dtype in testcases:
       x, y = (y, x) if swap else (x, y)
-      z = x + y
+      z = op(x, y)
       self.assertTrue(isinstance(z, jnp.ndarray), msg=(x, y, z))
       self.assertEqual(z.dtype, dtypes.canonicalize_dtype(dtype), msg=(x, y, z))
 


### PR DESCRIPTION
The jitted version of the test was not being run properly.

Found by running `$ pyflakes tests`