### PR TITLE
Fix duplicated test name

### DIFF
--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1119,7 +1119,7 @@ class PmapTest(jtu.JaxTestCase):
                         jnp.array([sum(vals)] * ndevices),
                         check_dtypes=True)
 
-  def testPostProcessMap(self):
+  def testPostProcessMap2(self):
     # code from https://github.com/google/jax/issues/2787
     def vv(x, y):
       """Vector-vector multiply"""


### PR DESCRIPTION
The first of these tests was previously never run, because it was overwritten by the second test with a duplicate name.

Found via `$ pyflakes tests/`