### PR TITLE
Fix undefined variable in jnp.pad(mode='edge')

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1919,7 +1919,7 @@ def _pad_edge(array, pad_width):
   nd = ndim(array)
   for i in range(nd):
     if array.shape[i] == 0:
-      _check_no_padding(pad_width[i], mode)
+      _check_no_padding(pad_width[i], "edge")
       continue
 
     n = array.shape[i]


### PR DESCRIPTION
Before:
```python
>>> import jax.numpy as jnp                                                                   
>>> jnp.pad(jnp.array([]), 4, mode='edge')
# ...
NameError: name 'mode' is not defined
```
After:
```python
>>> import jax.numpy as jnp                                                                   
>>> jnp.pad(jnp.array([]), 4, mode='edge')
# ...
ValueError: Cannot apply 'edge' padding to empty axis
```