### PR TITLE
skip fori_loops with zero trip count

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -192,17 +192,24 @@ def fori_loop(lower, upper, body_fun, init_val):
            "got {} and {}")
     raise TypeError(msg.format(lower_dtype.name, upper_dtype.name))
 
-  # If we can specialize on the trip count, call scan instead of a while_loop
-  # to enable efficient reverse-mode differentiation.
   try:
     lower_ = int(lower)
     upper_ = int(upper)
   except TypeError:
-    use_scan = False
+    static_trip_count = False
   else:
-    use_scan = False  # TODO(mattjj): re-enable this
+    static_trip_count = True
 
-  if use_scan:
+  if static_trip_count and lower_ == upper_:
+    # When we know the trip count is zero, we skip the loop entirely. As one
+    # consequence, in this case like Python we allow `body_fun` to be any
+    # syntactically correct Python function, rather than requiring it pass our
+    # abstract evaluation type checking. See this issue as an example:
+    # https://github.com/google/jax/issues/3285.
+    result = init_val
+  elif static_trip_count and False:  # TODO(mattjj): re-enable this
+    # If we can specialize on the trip count, call scan instead of a while_loop
+    # to enable efficient reverse-mode differentiation.
     (_, _, result), _ = scan(_fori_scan_body_fun(body_fun),
                              (lower, upper, init_val), None,
                              length=upper_ - lower_)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2035,6 +2035,20 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertAllClose(result.second, np.array([0., 10., 30.]),
                         check_dtypes=False)
 
+  def test_zero_trip_count_fori_loop(self):
+    # https://github.com/google/jax/issues/3285
+    def loop_cumsum(vals):
+      def body_fun(i, state):
+        return state + vals[i]
+      init = vals.dtype.type(0)
+      return lax.fori_loop(0, len(vals), body_fun, init)
+
+    with api.disable_jit():
+      expected = loop_cumsum(jnp.arange(0))
+
+    ans = loop_cumsum(jnp.arange(0))  # doesn't crash
+    self.assertAllClose(expected, ans, check_dtypes=False)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #3285

See especially [this comment](https://github.com/google/jax/issues/3285#issuecomment-637655722) for an explanation.

Interestingly, we _can't_ make an analogous change to `lax.scan` because we need to infer the types of its scanned-over outputs (to produce outputs of the correct shape, even in the zero-iteration case), and to do that we need to run abstract interpretation on the scanned function anyway.

An alternative to this change is to close #3285 as "working as intended".