### PR TITLE
Fix type promotion for real FFTs.

### DIFF
--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -44,7 +44,7 @@ def _promote_to_complex(arg):
   return lax.convert_element_type(arg, dtype)
 
 def _promote_to_real(arg):
-  dtype = dtypes.result_type(arg, onp.float64)
+  dtype = dtypes.result_type(arg, onp.float32)
   # XLA's FFT op only supports F32.
   # TODO(phawkins): remove when minimum jaxlib version is 0.1.48 or newer.
   if lib.version <= (0, 1, 47) and dtype == onp.float64:

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -26,8 +26,10 @@ from jax import numpy as jnp
 from jax import test_util as jtu
 
 from jax.config import config
+from jax.config import flags
 config.parse_flags_with_absl()
 
+FLAGS = flags.FLAGS
 
 float_dtypes = [np.float32, np.float64]
 complex_dtypes = [np.complex64, np.complex128]
@@ -110,7 +112,8 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if dtype in (float_dtypes if real and not inverse else inexact_dtypes):
+    if (FLAGS.jax_enable_x64 and
+        dtype in (float_dtypes if real and not inverse else inexact_dtypes)):
       # TODO(skye): can we be more precise?
       tol = 0.15
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)


### PR DESCRIPTION
Only enable gradient test in x64 mode.