### PR TITLE
Fix lax_reference's round for edge case inputs

### DIFF
--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -32,7 +32,7 @@ neg = np.negative
 sign = np.sign
 floor = np.floor
 ceil = np.ceil
-round = lambda x: np.trunc(x + np.copysign(.5, x)).astype(x.dtype)
+round = lambda x: np.trunc(x + np.copysign(np.nextafter(.5, .0, dtype=x.dtype), x)).astype(x.dtype)
 nextafter = np.nextafter
 
 is_finite = np.isfinite

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -32,7 +32,13 @@ neg = np.negative
 sign = np.sign
 floor = np.floor
 ceil = np.ceil
-round = lambda x: np.trunc(x + np.copysign(np.nextafter(.5, .0, dtype=x.dtype), x)).astype(x.dtype)
+
+def round(x):
+  return np.trunc(
+    x + np.copysign(np.nextafter(np.array(.5, dtype=x.dtype),
+                                 np.array(0., dtype=x.dtype),
+                                 dtype=x.dtype), x)).astype(x.dtype)
+
 nextafter = np.nextafter
 
 is_finite = np.isfinite


### PR DESCRIPTION
- round(8388609) would compute trunc(8388609 + 0.5) == 8388610.
  Fix this by not modifying sufficiently inputs.
- round(0.499999970198) would compute trunc(0.499999970198 + 0.5) == 1.0
  Fix this by explicitly special casing the first float before 0.5.