### PR TITLE
indexed conditionals with multiple branches

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -14,6 +14,13 @@ jax 0.1.70 (Unreleased)
 
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.1.69...master>`_.
 
+* New features:
+
+  * ``lax.switch`` introduces indexed conditionals with multiple
+    branches, together with a generalization of the ``cond``
+    primitive
+    `#3318 <https://github.com/google/jax/pull/3318>`_.
+
 jax 0.1.69 (June 3, 2020)
 ---------------------------
 

--- a/jax/experimental/jax_to_tf/jax_to_tf.py
+++ b/jax/experimental/jax_to_tf/jax_to_tf.py
@@ -771,14 +771,14 @@ tf_impl[lax.scatter_mul_p] = functools.partial(_scatter, tf.math.multiply)
 tf_impl[lax.scatter_add_p] = functools.partial(_scatter, tf.math.add)
 
 
-def _cond(pred: TfVal, *operands: TfVal,
-          true_jaxpr: core.TypedJaxpr, false_jaxpr: core.TypedJaxpr,
+def _cond(index: TfVal, *operands: TfVal,
+          branches: Sequence[core.TypedJaxpr],
           linear: Sequence[bool]):
   del linear
   # tf.cond needs lambdas with no arguments.
-  true_tf_func = functools.partial(_interpret_jaxpr, true_jaxpr, *operands)
-  false_tf_func = functools.partial(_interpret_jaxpr, false_jaxpr, *operands)
-  return tf.cond(pred, true_tf_func, false_tf_func)
+  tf_branches = [functools.partial(_interpret_jaxpr, jaxpr, *operands)
+                 for jaxpr in branches]
+  return tf.switch_case(index, tf_branches)
 
 tf_impl[lax.cond_p] = _cond
 

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -298,6 +298,7 @@ from .lax_control_flow import (
   scan,
   scan_bind,
   scan_p,
+  switch,
   while_loop,
   while_p,
   associative_scan,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2841,6 +2841,7 @@ ad.defjvp(clamp_p,
                  g, _zeros(operand)),
           lambda g, min, operand, max:
           select(lt(max, operand), _brcast(g, operand), _zeros(operand)))
+batching.defbroadcasting(clamp_p)
 
 
 def _concatenate_shape_rule(*operands, **kwargs):

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -612,10 +612,12 @@ def _cond(pred, true_fun: Callable, false_fun: Callable, operand):
                         out_tree, true_jaxpr.out_avals,
                         false_out_tree, false_jaxpr.out_avals)
 
+  index = lax.convert_element_type(pred, onp.int32)
+
   linear = (False,) * (len(consts) + len(ops))
   out = cond_p.bind(
-      pred, *consts, *ops,
-      true_jaxpr=true_jaxpr, false_jaxpr=false_jaxpr, linear=linear)
+      index, *consts, *ops,
+      branches=(false_jaxpr, true_jaxpr), linear=linear)
   return tree_unflatten(out_tree, out)
 
 def _cond_with_per_branch_args(pred,
@@ -639,10 +641,10 @@ def _cond_with_per_branch_args(pred,
                (true_operand, false_operand))
 
 def _cond_abstract_eval(*args, **kwargs):
-  return _map(raise_to_shaped, kwargs["true_jaxpr"].out_avals)
+  return _map(raise_to_shaped, kwargs["branches"][0].out_avals)
 
 def _cond_translation_rule(c, axis_env, name_stack, avals, backend,
-                           pred, *args, true_jaxpr, false_jaxpr, linear):
+                           index, *args, branches, linear):
   del linear  # Unused.
 
   def make_computation(name, jaxpr, op_shape):
@@ -656,149 +658,152 @@ def _cond_translation_rule(c, axis_env, name_stack, avals, backend,
 
   op = xops.Tuple(c, args)
   op_shape = c.get_shape(op)
-  true_c = make_computation('true', true_jaxpr, op_shape)
-  false_c = make_computation('false', false_jaxpr, op_shape)
-  return xops.Conditional(pred, op, true_c, op, false_c)
+  branch_computations = [
+      make_computation(f'branch_{i}', jaxpr, op_shape)
+      for i, jaxpr in enumerate(branches)]
+  return xops.Conditional(index, branch_computations, [op] * len(branches))
 
-def _cond_pred_bcast_select(pred, x, y):
-  if core.get_aval(x) is core.get_aval(y) is core.abstract_unit:
-    return x
+def _select_tree(indices, branch_vals):
+  assert len(branch_vals) > 0
+  if len(branch_vals) == 1:
+    return branch_vals[0]
+  mid = len(branch_vals) // 2
+  mid = onp.array(mid, dtypes.canonicalize_dtype(lax.dtype(indices)))
+  return lax.select(lax.lt(indices, mid),
+                    _select_tree(indices, branch_vals[:mid]),
+                    _select_tree(indices, branch_vals[mid:]))
+
+def _cond_index_bcast_and_select_tree(indices, branch_vals):
+  if all(core.get_aval(x) is core.abstract_unit for x in branch_vals):
+    return branch_vals[0]
   else:
-    bcast_pred = lax.broadcast_in_dim(pred, onp.shape(x), list(range(onp.ndim(pred))))
-    return lax.select(bcast_pred, x, y)
+    bcast_indices = lax.broadcast_in_dim(
+        indices, onp.shape(branch_vals[0]), list(range(onp.ndim(indices))))
+    return _select_tree(bcast_indices, branch_vals)
 
-def _cond_batching_rule(args, dims, true_jaxpr, false_jaxpr, linear):
+def _cond_batching_rule(args, dims, branches, linear):
   # TODO: maybe avoid moving arg axes to front if we're promoting to select?
   size, = {x.shape[d] for x, d in zip(args, dims) if d is not batching.not_mapped}
   args = [batching.moveaxis(x, d, 0) if d is not batching.not_mapped and d != 0
           else x for x, d in zip(args, dims)]
   orig_bat = [d is not batching.not_mapped for d in dims]
   del dims
-  pred, *ops = args
-  pred_bat, *bat = orig_bat
+  index, *ops = args
+  index_bat, *bat = orig_bat
 
-  _, true_out_bat = batching.batch_jaxpr(true_jaxpr, size, bat, False)
-  _, false_out_bat = batching.batch_jaxpr(false_jaxpr, size, bat, False)
-  out_bat = [a or b for a, b in zip(true_out_bat, false_out_bat)]
+  branches_out_bat = [batching.batch_jaxpr(jaxpr, size, bat, False)[1]
+                      for jaxpr in branches]
+  out_bat = [any(bat) for bat in zip(*branches_out_bat)]
 
-  true_jaxpr_batched, _ = batching.batch_jaxpr(true_jaxpr, size, bat, out_bat)
-  false_jaxpr_batched, _ = batching.batch_jaxpr(false_jaxpr, size, bat, out_bat)
+  branches_batched = tuple(batching.batch_jaxpr(jaxpr, size, bat, out_bat)[0]
+                           for jaxpr in branches)
 
-  if pred_bat:
-    true_out = core.jaxpr_as_fun(true_jaxpr_batched)(*ops)
-    false_out = core.jaxpr_as_fun(false_jaxpr_batched)(*ops)
-    true_out = [batching.broadcast(x, size, 0) if not b else x
-                for x, b in zip(true_out, out_bat)]
-    false_out = [batching.broadcast(x, size, 0) if not b else x
-                 for x, b in zip(false_out, out_bat)]
-    return [_cond_pred_bcast_select(pred, t, f)
-            for t, f in zip(true_out, false_out)], [0] * len(true_out)
+  if index_bat:
+    branch_outs = []
+    for jaxpr in branches_batched:
+      out = core.jaxpr_as_fun(jaxpr)(*ops)
+      out = [batching.broadcast(x, size, 0) if not b else x
+             for x, b in zip(out, out_bat)]
+      branch_outs.append(out)
+    return [_cond_index_bcast_and_select_tree(index, outs)
+            for outs in zip(*branch_outs)], [0] * len(branch_outs[0])
   else:
     out_dims = [0 if b else batching.not_mapped for b in out_bat]
     out = cond_p.bind(
-        pred, *ops,
-        true_jaxpr=true_jaxpr_batched, false_jaxpr=false_jaxpr_batched,
-        linear=linear)
+        index, *ops, branches=branches_batched, linear=linear)
     return out, out_dims
 
-def _cond_jvp(primals, tangents, true_jaxpr, false_jaxpr, linear):
+def _cond_jvp(primals, tangents, branches, linear):
   nonzeros = [t is not ad_util.zero for t in tangents]
 
-  pred_nz, *ops_nz = nonzeros
-  assert pred_nz is False
+  index_nz, *ops_nz = nonzeros
+  assert index_nz is False
 
-  _, true_out_nz = ad.jvp_jaxpr(true_jaxpr, ops_nz, instantiate=False)
-  _, false_out_nz = ad.jvp_jaxpr(false_jaxpr, ops_nz, instantiate=False)
-  out_nz = [a or b for a, b in zip(true_out_nz, false_out_nz)]
+  branches_out_nz = [ad.jvp_jaxpr(jaxpr, ops_nz, instantiate=False)[1]
+                     for jaxpr in branches]
+  out_nz = [any(nz) for nz in zip(*branches_out_nz)]
 
-  true_jvp, _ = ad.jvp_jaxpr(true_jaxpr, ops_nz, instantiate=out_nz)
-  false_jvp, _ = ad.jvp_jaxpr(false_jaxpr, ops_nz, instantiate=out_nz)
+  branches_jvp = tuple(ad.jvp_jaxpr(jaxpr, ops_nz, instantiate=out_nz)[0]
+                       for jaxpr in branches)
 
-  pred, *ops = primals
+  index, *ops = primals
   _, *ops_dot = tangents
   ops_dot = _prune_zeros(ops_dot)
 
   ops_lin = tuple(linear)
   linear_jvp = ops_lin + (True,) * len(ops_dot)
   out = cond_p.bind(
-      pred, *ops, *ops_dot,
-      true_jaxpr=true_jvp, false_jaxpr=false_jvp, linear=linear_jvp)
+      index, *ops, *ops_dot, branches=branches_jvp, linear=linear_jvp)
   out_primals, out_tangents = split_list(out, [len(out_nz)])
   out_tangents_iter = iter(out_tangents)
   out_tangents = [
       next(out_tangents_iter) if nz else ad_util.zero for nz in out_nz]
   return out_primals, out_tangents
 
-def _cond_partial_eval(trace, *tracers, true_jaxpr, false_jaxpr, linear):
+def _cond_partial_eval(trace, *tracers, branches, linear):
   unknowns = [t.pval[0] is not None for t in tracers]
 
-  pred_uk, *ops_uk = unknowns
+  index_uk, *ops_uk = unknowns
 
-  if pred_uk:
-    # When the predicate is unknown, we stage out the whole cond.
-    params = dict(true_jaxpr=true_jaxpr, false_jaxpr=false_jaxpr, linear=linear)
+  if index_uk:
+    # When the branch index is unknown, we stage out the whole cond.
+    params = dict(branches=branches, linear=linear)
     return trace.default_process_primitive(cond_p, tracers, params)
 
-  _, _, t_out_uks = pe.partial_eval_jaxpr(true_jaxpr, ops_uk, instantiate=False,
+  branches_out_uks = []
+  for branch_jaxpr in branches:
+    _, _, out_uks = pe.partial_eval_jaxpr(branch_jaxpr, ops_uk,
+                                          instantiate=False,
                                           trace_type=trace.master.trace_type)
-  _, _, f_out_uks = pe.partial_eval_jaxpr(false_jaxpr, ops_uk, instantiate=False,
-                                          trace_type=trace.master.trace_type)
-  out_uks = [a or b for a, b in zip(t_out_uks, f_out_uks)]
+    branches_out_uks.append(out_uks)
+  out_uks = [any(uks) for uks in zip(*branches_out_uks)]
 
-  true_jaxpr_1, true_jaxpr_2, _ = pe.partial_eval_jaxpr(
-      true_jaxpr, ops_uk, instantiate=out_uks,
-      trace_type=trace.master.trace_type)
-  false_jaxpr_1, false_jaxpr_2, _ = pe.partial_eval_jaxpr(
-      false_jaxpr, ops_uk, instantiate=out_uks,
-      trace_type=trace.master.trace_type)
+  branches_1, branches_2, branch_res_avals = [], [], []
+  for branch_jaxpr in branches:
+    branch_jaxpr_1, branch_jaxpr_2, _ = pe.partial_eval_jaxpr(
+        branch_jaxpr, ops_uk, instantiate=out_uks,
+        trace_type=trace.master.trace_type)
+    branch_num_res = len(branch_jaxpr_1.out_avals) - len(out_uks)
 
-  num_t_res = len(true_jaxpr_1.out_avals) - len(out_uks)
-  num_f_res = len(false_jaxpr_1.out_avals) - len(out_uks)
+    # move residuals to the front
+    move = [False] * len(ops_uk) + [True] * branch_num_res
+    branch_jaxpr_2 = pe.move_binders_to_front(branch_jaxpr_2, move)
 
-  assert len(true_jaxpr.in_avals) == len(false_jaxpr.in_avals)
-  assert len(true_jaxpr.in_avals) == len(tracers) - 1
-  assert len(true_jaxpr.in_avals) == len(ops_uk)
+    # TODO(frostig,mattjj): pe.partial_eval_jaxpr should raise to shaped avals
+    res_avals = _map(
+        raise_to_shaped, branch_jaxpr_2.in_avals[:branch_num_res])
 
-  # Move the residuals to front
-  move = [False] * len(ops_uk) + [True] * num_t_res
-  true_jaxpr_2 = pe.move_binders_to_front(true_jaxpr_2, move)
-  move = [False] * len(ops_uk) + [True] * num_f_res
-  false_jaxpr_2 = pe.move_binders_to_front(false_jaxpr_2, move)
+    branches_1.append(branch_jaxpr_1)
+    branches_2.append(branch_jaxpr_2)
+    branch_res_avals.append(res_avals)
 
-  # TODO(frostig,mattjj): pe.partial_eval_jaxpr should raise to shaped avals
-  t_res_avals = _map(raise_to_shaped, true_jaxpr_2.in_avals[:num_t_res])
-  f_res_avals = _map(raise_to_shaped, false_jaxpr_2.in_avals[:num_f_res])
+  branches_1 = tuple(branches_1)
+  branches_2 = tuple(branches_2)
 
-  assert len(true_jaxpr_2.out_avals) == len(false_jaxpr_2.out_avals)
-  num_outs = len(true_jaxpr_2.out_avals)
+  for jaxpr in branches_2[1:]:
+    assert len(jaxpr.out_avals) == len(branches_2[0].out_avals)
 
-  # TODO(frostig): support joining a list of jaxpr/aval pairs rather than only a
-  # true/false pair special case, in preparation for switch
-  false_jaxpr_1 = _join_cond_outputs(
-      false_jaxpr_1, num_outs, t_res_avals, zeros_on_left=False)
-  true_jaxpr_1 = _join_cond_outputs(
-      true_jaxpr_1, num_outs, f_res_avals, zeros_on_left=True)
+  num_outs = len(branches_2[0].out_avals)
 
-  false_jaxpr_2, true_jaxpr_2 = _join_cond_pe_staged_jaxpr_inputs(
-      [false_jaxpr_2, true_jaxpr_2], [f_res_avals, t_res_avals])
+  branches_1 = _join_cond_outputs(branches_1, branch_res_avals, num_outs)
+  branches_2 = _join_cond_pe_staged_jaxpr_inputs(branches_2, branch_res_avals)
 
   # TODO(frostig,mattjj): reinstate this assertion once pe.partial_eval_jaxpr
   # raises to shaped avals
-  # assert true_jaxpr_1.out_avals == false_jaxpr_1.out_avals
-  num_res = num_t_res + num_f_res
+  # for j in branches_1[1:]:
+  #   assert j.out_avals == branches_1[0].out_avals
+  num_res = sum(_map(len, branch_res_avals))
 
   _, in_consts = unzip2([t.pval for t in tracers])
-  out_consts_res = cond_p.bind(
-      *in_consts, true_jaxpr=true_jaxpr_1, false_jaxpr=false_jaxpr_1,
-      linear=linear)
+  out_consts_res = cond_p.bind(*in_consts, branches=branches_1, linear=linear)
   out_consts, res = split_list(out_consts_res, [len(out_consts_res) - num_res])
 
   # TODO(frostig,mattjj): remove raised_to_shaped of avals once
   # pe.partial_eval_jaxpr handles it
-  out_avals = _map(raise_to_shaped, true_jaxpr_2.out_avals)
+  out_avals = _map(raise_to_shaped, branches_2[0].out_avals)
   out_pvs = [aval if uk else None for aval, uk in zip(out_avals, out_uks)]
 
-  pred_tracer = trace.instantiate_const(tracers[0])
+  index_tracer = trace.instantiate_const(tracers[0])
 
   ops_tracers = [trace.instantiate_const(t) if uk
                  else trace.new_instantiated_literal(core.unit)
@@ -810,35 +815,48 @@ def _cond_partial_eval(trace, *tracers, true_jaxpr, false_jaxpr, linear):
                  for pv, const in zip(out_pvs, out_consts)]
 
   linear_2 = (False,) * num_res + linear
-  params = dict(true_jaxpr=true_jaxpr_2, false_jaxpr=false_jaxpr_2,
-                linear=linear_2)
+  params = dict(branches=branches_2, linear=linear_2)
   eqn = pe.new_eqn_recipe(
-      [pred_tracer] + res_tracers + ops_tracers, out_tracers, cond_p, params)
+      [index_tracer] + res_tracers + ops_tracers, out_tracers, cond_p, params)
   for t in out_tracers: t.recipe = eqn
   return out_tracers
 
-def _join_cond_outputs(jaxpr, num_prefix, zeros_avals, zeros_on_left):
-  @lu.wrap_init
-  def f_aug(*args):
-    prefix_and_rest = core.jaxpr_as_fun(jaxpr)(*args)
-    prefix, rest = split_list(prefix_and_rest, [num_prefix])
-    zeros = [ad_util.zeros_like_aval(a) for a in zeros_avals]
-    if zeros_on_left:
-      return prefix + zeros + rest
-    else:
-      return prefix + rest + zeros
+# When partially evaluating conditionals, each branch produces residuals
+# depending on the computation carried out by the branch, and a corresponding
+# staged jaxpr that accepts those residuals as its first few inputs. The
+# residual-producing branches are staged as jaxprs and bound right away in a
+# conditional. The residual-consuming jaxprs are assembled together in a jaxpr
+# conditional. The following two helper functions are used to ensure that both
+# collections of jaxprs (those evaluated and those staged) are valid for joint
+# use under their respective conditionals.
 
-  return _make_typed_jaxpr(f_aug, jaxpr.in_avals)
+# Because every branch might produce different residuals, the branches' output
+# signatures might not match. But we need branch signatures to match in order to
+# bind them in a conditional. This function "joins" the residual outputs of the
+# branches by concatenation. Each augmented branch returns zero-filled values in
+# the place of all other branches' residuals.
+def _join_cond_outputs(jaxprs, res_avals_per_jaxpr, num_non_res_outputs):
+  def augment_jaxpr(i, jaxpr):
+    res_avals_prefix = util.concatenate(res_avals_per_jaxpr[:i])
+    res_avals_suffix = util.concatenate(res_avals_per_jaxpr[i+1:])
 
+    @lu.wrap_init
+    def f_aug(*args):
+      outs_and_residuals = core.jaxpr_as_fun(jaxpr)(*args)
+      outs, residuals = split_list(outs_and_residuals, [num_non_res_outputs])
+      zeros_prefix = _map(ad_util.zeros_like_aval, res_avals_prefix)
+      zeros_suffix = _map(ad_util.zeros_like_aval, res_avals_suffix)
+      return outs + zeros_prefix + residuals + zeros_suffix
+
+    return _make_typed_jaxpr(f_aug, jaxpr.in_avals)
+
+  return tuple(augment_jaxpr(i, jaxpr) for i, jaxpr in enumerate(jaxprs))
+
+# To use these staged jaxprs as the branches of another conditional, we need for
+# their (input) signatures to match. This function "joins" the staged jaxprs:
+# for each one, it makes another that accepts *all* residuals, but still only
+# uses those that it needs (dropping the rest).
 def _join_cond_pe_staged_jaxpr_inputs(jaxprs, res_avals_per_jaxpr):
-  # When partially evaluating conditionals, each branch produces residuals
-  # depending on the computation carried out by the branch, and a corresponding
-  # staged jaxpr that accepts those residuals as its first few inputs. To use
-  # these staged jaxprs as the branches of another conditional, we need for
-  # their (input) signatures to match. This function "joins" the staged jaxprs:
-  # for each one, it makes another that accepts *all* residuals, but still only
-  # uses those that it needs (dropping the rest).
-
   newvar = core.gensym([j.jaxpr for j in jaxprs], suffix='_')
   unused_res_vars = tuple(
       tuple(newvar(aval) for aval in res_avals)
@@ -866,7 +884,7 @@ def _join_cond_pe_staged_jaxpr_inputs(jaxprs, res_avals_per_jaxpr):
                                 jaxpr.out_avals)
     return jaxpr_aug
 
-  return [pad_jaxpr_res_avals(i, jaxpr) for i, jaxpr in enumerate(jaxprs)]
+  return tuple(pad_jaxpr_res_avals(i, jaxpr) for i, jaxpr in enumerate(jaxprs))
 
 def _transpose_cond_jaxpr(jaxpr, num_res):
   num_non_res = len(jaxpr.in_avals) - num_res
@@ -884,24 +902,23 @@ def _transpose_cond_jaxpr(jaxpr, num_res):
 
   return _make_typed_jaxpr(transposed, res_avals + jaxpr.out_avals)
 
-def _cond_transpose(cts, *args, true_jaxpr, false_jaxpr, linear):
-  pred, *ops = args
-  in_avals = _map(raise_to_shaped, true_jaxpr.in_avals)
+def _cond_transpose(cts, *args, branches, linear):
+  index, *ops = args
+  in_avals = _map(raise_to_shaped, branches[0].in_avals)
   num_res = len(ops) - sum(linear)
 
-  t_jaxpr_trans = _transpose_cond_jaxpr(true_jaxpr, num_res)
-  f_jaxpr_trans = _transpose_cond_jaxpr(false_jaxpr, num_res)
-  lin_in_avals = _map(raise_to_shaped, [a for a, l in zip(in_avals, linear) if l])
-  assert t_jaxpr_trans.out_avals == f_jaxpr_trans.out_avals == lin_in_avals
+  branches_trans = tuple(
+      _transpose_cond_jaxpr(jaxpr, num_res) for jaxpr in branches)
+  lin_in_avals = _map(
+      raise_to_shaped, [a for a, l in zip(in_avals, linear) if l])
+  assert all(jaxpr.out_avals == lin_in_avals for jaxpr in branches_trans)
 
   res = ops[:num_res]
-  cts = _map(ad.instantiate_zeros_aval, true_jaxpr.out_avals, cts)
+  cts = _map(ad.instantiate_zeros_aval, branches[0].out_avals, cts)
   linear_trans = (False,) * num_res + (True,) * len(cts)
 
   out = cond_p.bind(
-      pred, *res, *cts,
-      true_jaxpr=t_jaxpr_trans, false_jaxpr=f_jaxpr_trans,
-      linear=linear_trans)
+      index, *res, *cts, branches=branches_trans, linear=linear_trans)
   assert all(_map(typecheck, lin_in_avals, out))
 
   out_iter = iter(out)
@@ -909,21 +926,23 @@ def _cond_transpose(cts, *args, true_jaxpr, false_jaxpr, linear):
   assert next(out_iter, None) is None
   return [None] + out
 
-def cond_bind(*args, true_jaxpr, false_jaxpr, linear):
+def cond_bind(*args, branches, linear):
   if not core.skip_checks:
+    assert len(branches) > 0
     assert len(linear) + 1 == len(args)
-    assert len(args) == 1 + len(true_jaxpr.in_avals)
-    assert len(true_jaxpr.in_avals) == len(false_jaxpr.in_avals)
-    assert len(true_jaxpr.out_avals) == len(false_jaxpr.out_avals)
-    assert all(_map(typematch, true_jaxpr.in_avals, false_jaxpr.in_avals))
-    assert all(_map(typematch, true_jaxpr.out_avals, false_jaxpr.out_avals))
-    pred, *ops = args
-    assert all(_map(typecheck, true_jaxpr.in_avals, ops))
-    assert all(_map(typecheck, false_jaxpr.in_avals, ops))
-    core.check_jaxpr(true_jaxpr.jaxpr)
-    core.check_jaxpr(false_jaxpr.jaxpr)
-  return core.Primitive.bind(cond_p, *args, true_jaxpr=true_jaxpr,
-                             false_jaxpr=false_jaxpr, linear=linear)
+    assert len(args) == 1 + len(branches[0].in_avals)
+    jaxpr0 = branches[0]
+    for jaxpr in branches[1:]:
+      assert len(jaxpr0.in_avals) == len(jaxpr.in_avals)
+      assert len(jaxpr0.out_avals) == len(jaxpr.out_avals)
+      assert all(_map(typematch, jaxpr0.in_avals, jaxpr.in_avals))
+      assert all(_map(typematch, jaxpr0.out_avals, jaxpr.out_avals))
+    index, *ops = args
+    assert dtypes.result_type(index) == onp.int32
+    for jaxpr in branches:
+      assert all(_map(typecheck, jaxpr.in_avals, ops))
+      core.check_jaxpr(jaxpr.jaxpr)
+  return core.Primitive.bind(cond_p, *args, branches=branches, linear=linear)
 
 cond_p = lax.Primitive('cond')
 cond_p.multiple_results = True

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -61,13 +61,5 @@ def vcat(ps):
     return functools.reduce(lambda x, y: x + y, ps)
 
 
-def pp_kv_pairs(kv_pairs):
-  if kv_pairs:
-    kv_pairs = vcat([pp('{}='.format(k)) >> pp(v) for k, v in kv_pairs])
-    return pp('[ ') >> kv_pairs >> pp(' ]')
-  else:
-    return pp('')
-
-
 def print_list(xs):
   return ' '.join(map(str, xs))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1792,16 +1792,18 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertMultiLineStrippedEqual("""
 { lambda  ; a.
   let b = ge a 0.0
-      c = add a 1.0
-      d = add a 2.0
-      e = cond[ false_jaxpr={ lambda  ; e_ c a b.
-                              let d = sub b c
-                              in (d,) }
-                linear=(False, False, False, False)
-                true_jaxpr={ lambda  ; c f_ a b.
+      c = convert_element_type[ new_dtype=int32
+                                old_dtype=bool ] b
+      d = add a 1.0
+      e = add a 2.0
+      f = cond[ branches=( { lambda  ; e_ c a b.
+                             let d = sub b c
+                             in (d,) }
+                           { lambda  ; c f_ a b.
                              let d = add a c
-                             in (d,) } ] b a a c d
-  in (e,) }
+                             in (d,) } )
+                linear=(False, False, False, False) ] c a a d e
+  in (f,) }
         """, str(jaxpr))
 
   def test_make_jaxpr_static_argnums(self):

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -1091,18 +1091,20 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
       return lax.cond(z > 0, (1, 2), lambda a: (a[0], jnp.zeros(5)),
                       z, lambda a: (hcb.id_print(a), y))
     self.assertRewrite("""
-{ lambda d e ; a b h.
+{ lambda e f ; a b i.
   let c = gt b 0
-      f g i = cond[ false_jaxpr={ lambda  ; f_ e a b c g.
-                                  let d h = id_tap[ arg_treedef=*
-                                                    func=_print
-                                                     ] c g
-                                  in (d, e, h) }
-                    linear=(False, False, False, False, False, False)
-                    true_jaxpr={ lambda  ; d g_ a b c h.
+      d = convert_element_type[ new_dtype=int32
+                                old_dtype=bool ] c
+      g h j = cond[ branches=( { lambda  ; f_ e a b c g.
+                                 let d h = id_tap[ arg_treedef=*
+                                                   func=_print
+                                                   ] c g
+                                 in (d, e, h) }
+                               { lambda  ; d g_ a b c h.
                                  let
-                                 in (a, d, h) } ] c d e 1 2 b h
-  in (f, g, i) }""", func, [y, 5])
+                                 in (a, d, h) } )
+                    linear=(False, False, False, False, False, False) ] d e f 1 2 b i
+  in (g, h, j) }""", func, [y, 5])
 
   def test_while(self):
     ct_body = jnp.ones(5, np.float32)     # captured const for the body

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -80,10 +80,10 @@ class MetadataTest(jtu.JaxTestCase):
     hlo = jax.xla_computation(f)(1.).get_hlo_module().to_string()
     self.assertRegex(hlo, 'op_type="cond"')
     self.assertRegex(hlo, 'op_name=".*cond\\[ linear=\\(False, False\\) \\]"')
-    self.assertRegex(hlo, 'op_type="sin"')
-    self.assertRegex(hlo, 'op_name=".*cond/true_fun/sin"')
     self.assertRegex(hlo, 'op_type="cos"')
-    self.assertRegex(hlo, 'op_name=".*cond/false_fun/cos"')
+    self.assertRegex(hlo, 'op_name=".*cond/branch_0_fun/cos"')
+    self.assertRegex(hlo, 'op_type="sin"')
+    self.assertRegex(hlo, 'op_name=".*cond/branch_1_fun/sin"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:

* Rewrites our `cond` primitive to a more general form. Instead of a boolean predicate that selects one of two branch functions, it takes an integer index into a list of branch functions.
* Introduces `lax.switch` alongside the existing `lax.cond`, as an interface to the generalized primitive.

Where the batching rule for binary `cond` previously generated a binary `select`, the batching rule for the new n-ary `cond` now generates an inline tree-of-binary-select-expressions. In a future change, I'd like to factor this implementation of "n-ary select" out of the batching rule. We can use it (or any other implementation) to generalize the `select` primitive similarly to how this PR generalizes `cond`.

Fixes #2725 