### PR TITLE
Improve error when zero-sized arrays passed to convolve

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -652,7 +652,7 @@ def _conv(x, y, mode, op, precision):
     raise ValueError(f"{op}() only support 1-dimensional inputs.")
   x, y = _promote_dtypes_inexact(x, y)
   if len(x) == 0 or len(y) == 0:
-    raise ValueError(f"{op}(): inputs cannot be empty.")
+    raise ValueError(f"{op}: inputs cannot be empty, got shapes {x.shape} and {y.shape}.")
 
   out_order = slice(None)
   if len(x) < len(y):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -651,6 +651,8 @@ def _conv(x, y, mode, op, precision):
   if ndim(x) != 1 or ndim(y) != 1:
     raise ValueError(f"{op}() only support 1-dimensional inputs.")
   x, y = _promote_dtypes_inexact(x, y)
+  if len(x) == 0 or len(y) == 0:
+    raise ValueError(f"{op}(): inputs cannot be empty.")
 
   out_order = slice(None)
   if len(x) < len(y):

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -29,6 +29,8 @@ def _convolve_nd(in1, in2, mode, *, precision):
     raise ValueError("mode must be one of ['full', 'same', 'valid']")
   if in1.ndim != in2.ndim:
     raise ValueError("in1 and in2 must have the same number of dimensions")
+  if in1.size == 0 or in2.size == 0:
+    raise ValueError("zero-size arrays not supported in convolutions.")
   in1, in2 = _promote_dtypes_inexact(in1, in2)
 
   no_swap = all(s1 >= s2 for s1, s2 in zip(in1.shape, in2.shape))

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -30,7 +30,7 @@ def _convolve_nd(in1, in2, mode, *, precision):
   if in1.ndim != in2.ndim:
     raise ValueError("in1 and in2 must have the same number of dimensions")
   if in1.size == 0 or in2.size == 0:
-    raise ValueError("zero-size arrays not supported in convolutions.")
+    raise ValueError(f"zero-size arrays not supported in convolutions, got shapes {in1.shape} and {in2.shape}.")
   in1, in2 = _promote_dtypes_inexact(in1, in2)
 
   no_swap = all(s1 >= s2 for s1, s2 in zip(in1.shape, in2.shape))


### PR DESCRIPTION
Previously, the error looked like this:
```pytb
RuntimeError: Invalid argument: Window dimensions {
  stride: 1
  padding_low: -1
  padding_high: -1
  window_dilation: 1
  base_dilation: 1
}
dimensions {
  size: 1
  stride: 1
  window_dilation: 1
  base_dilation: 1
}
 has a non-positive dimension.: 
This is a bug in JAX's shape-checking rules; please report it!
https://github.com/google/jax/issues
```
After:
```
ValueError: convolve: inputs cannot be empty, got shapes (4,) and (0,)
```