### PR TITLE
Extract JAX primitive test harness from lax_test.py.

### DIFF
--- a/jax/_test_utils/__init__.py
+++ b/jax/_test_utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/jax/_test_utils/primitive_harness.py
+++ b/jax/_test_utils/primitive_harness.py
@@ -1,0 +1,148 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines test inputs and invocations for JAX primitives.
+
+Used to test various implementations of JAX primitives, e.g., against
+NumPy (lax_reference) or TensorFlow.
+"""
+
+
+from typing import Any, Callable, Dict, Iterable, Optional, NamedTuple, Sequence, Tuple, Union, cast
+
+from absl import testing
+from jax import api
+from jax import test_util as jtu
+from jax import dtypes
+from jax import lax
+
+import numpy as onp
+
+# TODO: these are copied from tests/lax_test.py (make this source of truth)
+def supported_dtypes(dtypes):
+  return [t for t in dtypes if t in jtu.supported_dtypes()]
+
+float_dtypes = supported_dtypes([dtypes.bfloat16, onp.float16, onp.float32,
+                                 onp.float64])
+complex_elem_dtypes = supported_dtypes([onp.float32, onp.float64])
+complex_dtypes = supported_dtypes([onp.complex64, onp.complex128])
+inexact_dtypes = float_dtypes + complex_dtypes
+int_dtypes = supported_dtypes([onp.int32, onp.int64])
+uint_dtypes = supported_dtypes([onp.uint32, onp.uint64])
+bool_dtypes = [onp.bool_]
+default_dtypes = float_dtypes + int_dtypes
+all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+
+Rng = Any  # A random number generator
+
+class RandArg(NamedTuple):
+  """Descriptor for a randomly generated argument."""
+  shape: Tuple[int, ...]
+  dtype: onp.dtype
+
+class StaticArg(NamedTuple):
+  """Descriptor for a static argument."""
+  value: Any
+
+class Harness:
+  """Specifies inputs and callable for a primitive.
+
+  A primitive can take dynamic and static arguments. The dynamic arguments can
+  be generated using a RNG, are numeric (and appropriate for JIT).
+  """
+  # Descriptive name of the harness, used as a testcase_name. Unique in a group.
+  name: str
+  # The function taking all arguments (static and dynamic).
+  fun: Callable
+  arg_descriptors: Sequence[Union[RandArg, StaticArg, Any]]
+  rng_factory: Callable
+  params: Dict[str, Any]
+
+  def __init__(self, name, fun, arg_descriptors, *,
+               rng_factory=jtu.rand_default, **params):
+    self.name = name
+    self.fun = fun
+    self.arg_descriptors = arg_descriptors
+    self.rng_factory = rng_factory
+    self.params = params
+
+  def _arg_maker(self, arg_descriptor, rng: Rng):
+    if type(arg_descriptor) is StaticArg:
+      return arg_descriptor.value
+    if type(arg_descriptor) is RandArg:
+      return self.rng_factory(rng)(arg_descriptor.shape, arg_descriptor.dtype)
+    return arg_descriptor
+
+  def args_maker(self, rng: Rng) -> Sequence:
+    """All-argument maker, including the static ones."""
+    return [self._arg_maker(ad, rng) for ad in self.arg_descriptors]
+
+  def dyn_args_maker(self, rng: Rng) -> Sequence:
+    """A dynamic-argument maker, for use with `dyn_fun`."""
+    return [self._arg_maker(ad, rng) for ad in self.arg_descriptors
+            if type(ad) is not StaticArg]
+
+  def dyn_fun(self, *dyn_args):
+    """Invokes `fun` given just the dynamic arguments."""
+    all_args = self._args_from_dynargs(dyn_args)
+    return self.fun(*all_args)
+
+  def _args_from_dynargs(self, dyn_args: Sequence) -> Sequence:
+    """All arguments, including the static ones."""
+    next_dynamic_argnum = 0
+    all_args = []
+    for ad in self.arg_descriptors:
+      if type(ad) is StaticArg:
+        all_args.append(ad.value)
+      else:
+        all_args.append(dyn_args[next_dynamic_argnum])
+        next_dynamic_argnum += 1
+    return all_args
+
+
+def parameterized(harness_group: Iterable[Harness]):
+  return testing.parameterized.named_parameters(
+    dict(testcase_name=harness.name, harness=harness)
+    for harness in harness_group)
+
+
+lax_pad = jtu.cases_from_list(
+  Harness(f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}_pads={pads}",
+          lax.pad,
+          [RandArg(shape, dtype),
+           onp.array(0, dtype),
+           StaticArg(pads)],
+          rng_factory=jtu.rand_small)
+  for shape in [(2, 3)]
+  for dtype in default_dtypes
+  for pads in [[(1, 2, 1), (0, 1, 0)]]
+)
+
+lax_squeeze = jtu.cases_from_list(
+  Harness(f"_inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_dimensions={dimensions}",
+          lax.squeeze,
+          [RandArg(arg_shape, dtype),
+           StaticArg(dimensions)],
+          arg_shape=arg_shape, dtype=dtype)
+  for arg_shape, dimensions in [
+    [(1,), (0,)],
+    [(1,), (-1,)],
+    [(2, 1, 4), (1,)],
+    [(2, 1, 4), (-2,)],
+    [(2, 1, 3, 1), (1,)],
+    [(2, 1, 3, 1), (1, 3)],
+    [(2, 1, 3, 1), (3,)],
+    [(2, 1, 3, 1), (1, -1)],
+  ]
+  for dtype in [onp.float32]
+)

--- a/jax/_test_utils/primitive_harness.py
+++ b/jax/_test_utils/primitive_harness.py
@@ -26,20 +26,20 @@ from jax import test_util as jtu
 from jax import dtypes
 from jax import lax
 
-import numpy as onp
+import numpy as np
 
 # TODO: these are copied from tests/lax_test.py (make this source of truth)
 def supported_dtypes(dtypes):
   return [t for t in dtypes if t in jtu.supported_dtypes()]
 
-float_dtypes = supported_dtypes([dtypes.bfloat16, onp.float16, onp.float32,
-                                 onp.float64])
-complex_elem_dtypes = supported_dtypes([onp.float32, onp.float64])
-complex_dtypes = supported_dtypes([onp.complex64, onp.complex128])
+float_dtypes = supported_dtypes([dtypes.bfloat16, np.float16, np.float32,
+                                 np.float64])
+complex_elem_dtypes = supported_dtypes([np.float32, np.float64])
+complex_dtypes = supported_dtypes([np.complex64, np.complex128])
 inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([onp.int32, onp.int64])
-uint_dtypes = supported_dtypes([onp.uint32, onp.uint64])
-bool_dtypes = [onp.bool_]
+int_dtypes = supported_dtypes([np.int32, np.int64])
+uint_dtypes = supported_dtypes([np.uint32, np.uint64])
+bool_dtypes = [np.bool_]
 default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
 
@@ -48,7 +48,7 @@ Rng = Any  # A random number generator
 class RandArg(NamedTuple):
   """Descriptor for a randomly generated argument."""
   shape: Tuple[int, ...]
-  dtype: onp.dtype
+  dtype: np.dtype
 
 class StaticArg(NamedTuple):
   """Descriptor for a static argument."""
@@ -133,13 +133,12 @@ def parameterized(harness_group: Iterable[Harness],
 
 
 lax_pad = jtu.cases_from_list(
-  Harness(f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}_pads={pads}",
+  Harness(f"_inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_pads={pads}",
           lax.pad,
-          [RandArg(shape, dtype),
-           onp.array(0, dtype),
-           StaticArg(pads)],
-          rng_factory=jtu.rand_small)
-  for shape in [(2, 3)]
+          [RandArg(arg_shape, dtype), np.array(0, dtype), StaticArg(pads)],
+          rng_factory=jtu.rand_small,
+          arg_shape=arg_shape, dtype=dtype)
+  for arg_shape in [(2, 3)]
   for dtype in default_dtypes
   for pads in [
     [(0, 0, 0), (0, 0, 0)],  # no padding
@@ -151,8 +150,7 @@ lax_pad = jtu.cases_from_list(
 lax_squeeze = jtu.cases_from_list(
   Harness(f"_inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_dimensions={dimensions}",
           lax.squeeze,
-          [RandArg(arg_shape, dtype),
-           StaticArg(dimensions)],
+          [RandArg(arg_shape, dtype), StaticArg(dimensions)],
           arg_shape=arg_shape, dtype=dtype)
   for arg_shape, dimensions in [
     [(1,), (0,)],
@@ -164,5 +162,5 @@ lax_squeeze = jtu.cases_from_list(
     [(2, 1, 3, 1), (3,)],
     [(2, 1, 3, 1), (1, -1)],
   ]
-  for dtype in [onp.float32]
+  for dtype in [np.float32]
 )

--- a/jax/_test_utils/primitive_harness.py
+++ b/jax/_test_utils/primitive_harness.py
@@ -93,7 +93,7 @@ class Harness:
   def dyn_args_maker(self, rng: Rng) -> Sequence:
     """A dynamic-argument maker, for use with `dyn_fun`."""
     return [self._arg_maker(ad, rng) for ad in self.arg_descriptors
-            if isinstance(ad, StaticArg)]
+            if not isinstance(ad, StaticArg)]
 
   def dyn_fun(self, *dyn_args):
     """Invokes `fun` given just the dynamic arguments."""

--- a/jax/experimental/jax_to_tf/tests/tf_ops_test.py
+++ b/jax/experimental/jax_to_tf/tests/tf_ops_test.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 """Tests for the jax_to_tf transformation."""
 
+import unittest
+
 from absl.testing import absltest
 from absl.testing import parameterized
 from typing import Any, Callable, Sequence, Tuple
 
 import jax
+from jax import dtypes
 import jax.lax as lax
 import jax.numpy as jnp
 from jax import test_util as jtu
@@ -173,6 +176,8 @@ class TfOpsTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_pad)
   def test_pad(self, harness: primitive_harness.Harness):
+    if harness.params["dtype"] is dtypes.bfloat16:
+      raise unittest.SkipTest("bfloat16 not implemented")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            with_function=True)
 

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -232,19 +232,16 @@ def reshape(operand, new_sizes, dimensions=None):
   return np.reshape(np.transpose(operand, dimensions), new_sizes)
 
 def pad(operand, padding_value, padding_config):
-  # https://www.tensorflow.org/xla/operation_semantics#pad
   lo, hi, interior = zip(*padding_config)
-  # Handle first the positive edge padding and interior
-  lo_pos, hi_pos = np.clip(lo, 0, None), np.clip(hi, 0, None)
-  outshape = np.add(np.add(np.add(lo_pos, hi_pos), operand.shape),
+  outshape = np.add(np.add(np.add(lo, hi), operand.shape),
                      np.multiply(interior, np.subtract(operand.shape, 1)))
   out = np.full(outshape, padding_value, operand.dtype)
   lhs_slices = tuple(_slice(l if l > 0 else 0, -h if h > 0 else None, step)
-                     for l, h, step in zip(lo_pos, hi_pos, np.add(1, interior)))
-  out[lhs_slices] = operand
-  trim_slices = tuple(_slice(-l if l < 0 else 0, h if h < 0 else None)
+                     for l, h, step in zip(lo, hi, np.add(1, interior)))
+  rhs_slices = tuple(_slice(l if l < 0 else 0, -h if h < 0 else None)
                      for l, h in zip(lo, hi))
-  return out[trim_slices]
+  out[lhs_slices] = operand[rhs_slices]
+  return out
 
 def rev(operand, dimensions):
   dimensions = frozenset(dimensions)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -950,12 +950,14 @@ class LaxTest(jtu.JaxTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_pad)
   def testPad(self, harness: primitive_harness.Harness):
-    self._CompileAndCheck(harness.dyn_fun, harness.dyn_args_maker)
+    self._CompileAndCheck(harness.dyn_fun,
+                          lambda: harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_pad)
   def testPadAgainstNumpy(self,  harness: primitive_harness.Harness):
     self._CheckAgainstNumpy(lax_reference.pad,
-                            harness.fun, harness.args_maker)
+                            harness.fun,
+                            lambda: harness.args_maker(self.rng()))
 
   def testReverse(self):
     rev = api.jit(lambda operand: lax.rev(operand, dimensions))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -16,7 +16,7 @@
 import collections
 from functools import partial
 import itertools
-from typing import Any, Callable, Dict, Iterable, NamedTuple, Optional, Sequence, cast
+from typing import Optional, cast
 from unittest import SkipTest
 
 from absl.testing import absltest


### PR DESCRIPTION
The goal is to have a collection of test harnesses for the JAX primitives
to be able to test various implementation (JAX, NumPy, TensorFlow).

Put the primitive_harness.py in the main source tree, under _test_utils,
so that it can be imported from tests.

Demonstrate the use of the harness for lax.pad and lax.squeeze, both in
tf_ops_test and lax_test. The plan is to add support for more primitives
as we make progress testing jax_to_tf.