### PR TITLE
Generate type hints for parameters, even if the parameters aren't doc…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,3 +295,7 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+
+# Tell sphinx-autodoc-typehints to generate stub parameter annotations including
+# types, even if the parameters aren't explicitly documented.
+always_document_param_types = True


### PR DESCRIPTION
…umented.

This change tells sphinx-autodoc-typehint to generate stub parameter documentation for arguments that have type hints.