### PR TITLE
Fix polyadd and expand test

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2611,13 +2611,11 @@ def polyadd(a, b):
   a = asarray(a)
   b = asarray(b)
 
-  shape_diff = a.shape[0] - b.shape[0]
-  if shape_diff > 0:
-    b = concatenate((np.zeros(shape_diff, dtype=b.dtype), b))
+  if b.shape[0] <= a.shape[0]:
+    return a.at[-b.shape[0]:].add(b)
   else:
-    a = concatenate((np.zeros(shape_diff, dtype=b.dtype), a))
+    return b.at[-a.shape[0]:].add(a)
 
-  return lax.add(a,b)
 
 def _trim_zeros(a):
   for i, v in enumerate(a):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1119,16 +1119,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "dtype": dtype, "shape": shape}
+      {"testcase_name": "a_shape={} , b_shape={}".format(
+          jtu.format_shape_dtype_string(a_shape, dtype),
+          jtu.format_shape_dtype_string(b_shape, dtype)),
+       "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
       for dtype in default_dtypes
-      for shape in one_dim_array_shapes))
-  def testPolyAdd(self, shape, dtype):
+      for a_shape in one_dim_array_shapes
+      for b_shape in one_dim_array_shapes))
+  def testPolyAdd(self, a_shape, b_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polyadd(arg1, arg2)
     jnp_fun = lambda arg1, arg2: jnp.polyadd(arg1, arg2)
-    args_maker = lambda: [rng(shape, dtype), rng(shape, dtype)]
+    args_maker = lambda: [rng(a_shape, dtype), rng(b_shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 


### PR DESCRIPTION
Upon further consideration (and based on the recent addition of np.polysub), I figured it'd be a good idea to make np.polyadd more clear and add test for different sized inputs. (Which wasn't implemented before).
