### PR TITLE
make jnp.array faster

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2134,16 +2134,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
             return np.array([], dtype=dtype)
     assert type(jnp.array(NDArrayLike())) == jax.interpreters.xla.DeviceArray
 
-    class DeviceArrayLike:
-        def __array__(self, dtype=None):
-            return jnp.array([], dtype=dtype)
-    assert type(jnp.array(DeviceArrayLike())) == jax.interpreters.xla.DeviceArray
+    # NOTE(mattjj): disabled b/c __array__ must produce ndarrays
+    # class DeviceArrayLike:
+    #     def __array__(self, dtype=None):
+    #         return jnp.array([], dtype=dtype)
+    # assert type(jnp.array(DeviceArrayLike())) == jax.interpreters.xla.DeviceArray
 
   def testArrayMethod(self):
     class arraylike(object):
       dtype = np.float32
       def __array__(self, dtype=None):
-        return 3.
+        return np.array(3., dtype=dtype)
     a = arraylike()
     ans = jnp.array(a)
     assert ans == 3.


### PR DESCRIPTION
fixes #2919

This turned out not to be so hard!

BEFORE (CPU):

```
In [1]: import numpy as np
   ...: import jax.numpy as jnp

In [2]: %timeit np.array([0] * int(1e5))
3.96 ms ± 2.46 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [2]: %timeit jnp.array([0] * int(1e5))
10.3 s ± 49.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

AFTER (CPU):

```
In [3]: %timeit jnp.array([0] * int(1e5))
21.9 ms ± 54.4 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

The example in #2919 actually used `1e6` rather than `1e5`:

BEFORE (CPU, copied from #2919):

```
import numpy as np
import jax.numpy as jnp

%%timeit
np.array([0] * int(1e6))
> 60.1 ms ± 578 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%%timeit
jnp.array([0] * int(1e6))
> 3min 12s ± 794 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

AFTER (CPU):

```
In [2]: %timeit jnp.array([0] * int(1e6))
224 ms ± 16.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Seems faster, I dno.