### PR TITLE
Proofread documentation.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -73,6 +73,8 @@ Additional reading:
   * JAX_sharp_bits_
 
 
+.. _faq-data-placement:
+
 Controlling data and computation placement on devices
 -----------------------------------------------------
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -109,10 +109,11 @@ def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
       Defaults to ().
     device: This is an experimental feature and the API is likely to change.
       Optional, the Device the jitted function will run on. (Available devices
-      can be retrieved via ``jax.devices()``.) The default is inherited from
+      can be retrieved via :py:func:`jax.devices`.) The default is inherited from
       XLA's DeviceAssignment logic and is usually to use ``jax.devices()[0]``.
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu','gpu', or 'tpu'.
+      Optional, a string representing the XLA backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
     donate_argnums: Specify which arguments are "donated" to the computation.
       It is safe to donate arguments if you no longer need them once the
       computation has finished. In some cases XLA can make use of donated
@@ -172,17 +173,17 @@ def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
 
 @contextmanager
 def disable_jit():
-  """Context manager that disables ``jit`` behavior under its dynamic context.
+  """Context manager that disables :py:func:`jit` behavior under its dynamic context.
 
-  For debugging purposes, it is useful to have a mechanism that disables ``jit``
-  everywhere in a dynamic context.
+  For debugging purposes, it is useful to have a mechanism that disables
+  :py:func:`jit` everywhere in a dynamic context.
 
   Values that have a data dependence on the arguments to a jitted function are
-  traced and abstracted. For example, an abstract value may be a ShapedArray
-  instance, representing the set of all possible arrays with a given shape and
-  dtype, but not representing one concrete array with specific values. You might
-  notice those if you use a benign side-effecting operation in a jitted
-  function, like a print:
+  traced and abstracted. For example, an abstract value may be a
+  :py:class:`ShapedArray` instance, representing the set of all possible arrays
+  with a given shape and dtype, but not representing one concrete array with
+  specific values. You might notice those if you use a benign side-effecting
+  operation in a jitted function, like a print:
 
   >>> import jax
   >>>
@@ -196,10 +197,11 @@ def disable_jit():
   Value of y is Traced<ShapedArray(int32[3]):JaxprTrace(level=-1/1)>
   [5 7 9]
 
-  Here ``y`` has been abstracted by ``jit`` to a ``ShapedArray``, which
-  represents an array with a fixed shape and type but an arbitrary value. It's
-  also traced. If we want to see a concrete value while debugging, and avoid the
-  tracer too, we can use the ``disable_jit`` context manager:
+  Here ``y`` has been abstracted by :py:func:`jit` to a :py:class:`ShapedArray`,
+  which represents an array with a fixed shape and type but an arbitrary value.
+  The value of ``y`` is also traced. If we want to see a concrete value while
+  debugging, and avoid the tracer too, we can use the :py:func:`disable_jit`
+  context manager:
 
   >>> import jax.numpy as np
   >>>
@@ -230,25 +232,26 @@ def xla_computation(fun: Callable,
 
   Args:
     fun: Function from which to form XLA computations.
-    static_argnums: See the ``jax.jit`` docstring.
+    static_argnums: See the :py:func:`jax.jit` docstring.
     axis_env: Optional, a sequence of pairs where the first element is an axis
       name and the second element is a positive integer representing the size of
       the mapped axis with that name. This parameter is useful when lowering
       functions that involve parallel communication collectives, and it
       specifies the axis name/size environment that would be set up by
-      applications of ``jax.pmap``. See the examples below.
+      applications of :py:func:`jax.pmap`. See the examples below.
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu','gpu', or 'tpu'.
-    tuple_args: Optional bool, defaults to False. If True, the resulting XLA
-      computation will have a single tuple argument that is unpacked into the
-      specified function arguments.
-    instantiate_const_outputs: Optional bool, defaults to True. If False, then
-      ``xla_computation`` does not instantiate constant-valued outputs in the
-      XLA computation, and so the result is closer to the computation that
-      ``jax.jit`` produces and may be more useful for studying ``jit`` behavior.
-      If True, then constant-valued outputs are instantiated in the XLA
-      computation, which may be more useful for staging computations out of JAX
-      entirely.
+      Optional, a string representing the XLA backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
+    tuple_args: Optional bool, defaults to ``False``. If ``True``, the resulting
+      XLA computation will have a single tuple argument that is unpacked into
+      the specified function arguments.
+    instantiate_const_outputs: Optional bool, defaults to ``True``. If
+      ``False``, then :py:func:`xla_computation` does not instantiate
+      constant-valued outputs in the XLA computation, and so the result is
+      closer to the computation that :py:func:`jax.jit` produces and may be more
+      useful for studying :py:func:`jit` behavior. If ``True``, then
+      constant-valued outputs are instantiated in the XLA computation, which may
+      be more useful for staging computations out of JAX entirely.
 
   Returns:
     A wrapped version of ``fun`` that when applied to example arguments returns a
@@ -701,7 +704,7 @@ def hessian(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
   ``g`` example above. If ``fun(x)`` has shape ``(out1, out2, ...)`` and ``x``
   has shape ``(in1, in2, ...)`` then ``jax.hessian(fun)(x)`` has shape
   ``(out1, out2, ..., in1, in2, ..., in1, in2, ...)``. To flatten pytrees into
-  1D vectors, consider using ``jax.flatten_util.flatten_pytree``.
+  1D vectors, consider using :py:func:`jax.flatten_util.flatten_pytree`.
   """
   return jacfwd(jacrev(fun, argnums, holomorphic), argnums, holomorphic)
 
@@ -749,14 +752,14 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
       axes can be mapped for different container elements. ``in_axes`` must be a
       container tree prefix of the positional argument tuple passed to ``fun``.
 
-      At least one positional argument must have `in_axes` not None. The sizes
+      At least one positional argument must have ``in_axes`` not None. The sizes
       of the mapped input axes for all mapped positional arguments must all
       be equal.
 
     out_axes: A nonnegative integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof indicating where the mapped axis should appear
       in the output. All outputs with a mapped axis must have a non-None
-      `out_axes` specification.
+      ``out_axes`` specification.
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to
@@ -818,18 +821,18 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
   The results of a vectorized function can be mapped or unmapped.
   For example, the function below returns a pair with the first
   element mapped and the second unmapped. Only for unmapped results
-  we can specify `out_axes` to be None (to keep it unmapped).
+  we can specify ``out_axes`` to be ``None`` (to keep it unmapped).
 
   >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=(0, None))(np.arange(2.), 4.))
   (DeviceArray([4., 5.], dtype=float32), 8.0)
 
-  If the `out_axes` is specified for an unmapped result, the result is broadcast
+  If the ``out_axes`` is specified for an unmapped result, the result is broadcast
   across the mapped axis:
 
   >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=0)(np.arange(2.), 4.))
   (DeviceArray([4., 5.], dtype=float32), array([8., 8.]))
 
-  If the `out_axes` is specified for a mapped result, the result is
+  If the ``out_axes`` is specified for a mapped result, the result is
   transposed accordingly.
   """
   _check_callable(fun)
@@ -917,26 +920,26 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
          donate_argnums: Union[int, Iterable[int]] = ()) -> Callable:
   """Parallel map with support for collectives.
 
-  The purpose of ``pmap`` is to express single-program multiple-data (SPMD)
-  programs. Applying ``pmap`` to a function will compile the function with XLA
-  (similarly to ``jit``), then execute it in parallel on XLA devices, such as
+  The purpose of :py:func:`pmap` is to express single-program multiple-data (SPMD)
+  programs. Applying :py:func:`pmap` to a function will compile the function with XLA
+  (similarly to :py:func:`jit`), then execute it in parallel on XLA devices, such as
   multiple GPUs or multiple TPU cores. Semantically it is comparable to
-  ``vmap`` because both transformations map a function over array axes, but
-  where ``vmap`` vectorizes functions by pushing the mapped axis down into
-  primitive operations, ``pmap`` instead replicates the function and executes
+  :py:func:`vmap` because both transformations map a function over array axes, but
+  where :py:func:`vmap` vectorizes functions by pushing the mapped axis down into
+  primitive operations, :py:func:`pmap` instead replicates the function and executes
   each replica on its own XLA device in parallel.
 
-  Another key difference with ``vmap`` is that while ``vmap`` can only express
-  pure maps, ``pmap`` enables the use of parallel SPMD collective operations,
+  Another key difference with :py:func:`vmap` is that while :py:func:`vmap` can only express
+  pure maps, :py:func:`pmap` enables the use of parallel SPMD collective operations,
   like all-reduce sum.
 
   The mapped axis size must be less than or equal to the number of local XLA
-  devices available, as returned by ``jax.local_device_count()`` (unless
-  ``devices`` is specified, see below). For nested ``pmap`` calls, the product
+  devices available, as returned by :py:func:`jax.local_device_count()` (unless
+  ``devices`` is specified, see below). For nested :py:func:`pmap` calls, the product
   of the mapped axis sizes must be less than or equal to the number of XLA
   devices.
 
-  **Multi-host platforms:** On multi-host platforms such as TPU pods, ``pmap``
+  **Multi-host platforms:** On multi-host platforms such as TPU pods, :py:func:`pmap`
   is designed to be used in SPMD Python programs, where every host is running
   the same Python code such that all hosts run the same pmapped function in the
   same order. Each host should still call the pmapped function with mapped axis
@@ -958,7 +961,7 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
     axis_name: Optional, a hashable Python object used to identify the mapped
       axis so that parallel collectives can be applied.
     in_axes: A nonnegative integer, None, or nested Python container thereof
-      that specifies which axes in the input to map over (see ``vmap``).
+      that specifies which axes in the input to map over (see :py:func:`vmap`).
       Currently, only 0 and None are supported axes for pmap.
     static_broadcasted_argnums: An int or collection of ints specifying which
       positional arguments to treat as static (compile-time constant).
@@ -972,10 +975,11 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
       Optional, a sequence of Devices to map over. (Available devices can be
       retrieved via jax.devices()). If specified, the size of the mapped axis
       must be equal to the number of local devices in the sequence. Nested
-      ``pmap`` s with ``devices`` specified in either the inner or outer ``pmap``
+      :py:func:`pmap` s with ``devices`` specified in either the inner or outer :py:func:`pmap`
       are not yet supported.
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
+      Optional, a string representing the XLA backend. 'cpu', 'gpu', or 'tpu'.
+    axis_size: Optional; the size of the mapped axis.
     donate_argnums: Specify which arguments are "donated" to the computation.
       It is safe to donate arguments if you no longer need them once the
       computation has finished. In some cases XLA can make use of donated
@@ -990,7 +994,7 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
     and with output that has an additional leading array axis (with the same
     size).
 
-  For example, assuming 8 XLA devices are available, ``pmap`` can be used as a
+  For example, assuming 8 XLA devices are available, :py:func:`pmap` can be used as a
   map along a leading array axis:
 
   >>> import jax.numpy as np
@@ -1019,7 +1023,7 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
   >>> pmap(lambda x: x ** 2)(np.arange(9))  # doctest: +SKIP
   ValueError: ... requires 9 replicas, but only 8 XLA devices are available
 
-  As with ``vmap``, using ``None`` in ``in_axes`` indicates that an argument
+  As with :py:func:`vmap`, using ``None`` in ``in_axes`` indicates that an argument
   doesn't have an extra axis and should be broadcasted, rather than mapped,
   across the replicas:
 
@@ -1028,10 +1032,10 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
   >>> print(out)  # doctest: +SKIP
   ([4., 5.], [8., 8.])
 
-  Note that ``pmap`` always returns values mapped over their leading axis,
-  equivalent to using ``out_axes=0`` in ``vmap``.
+  Note that :py:func:`pmap` always returns values mapped over their leading axis,
+  equivalent to using ``out_axes=0`` in :py:func:`vmap`.
 
-  In addition to expressing pure maps, ``pmap`` can also be used to express
+  In addition to expressing pure maps, :py:func:`pmap` can also be used to express
   parallel single-program multiple-data (SPMD) programs that communicate via
   collective operations. For example:
 
@@ -1045,10 +1049,10 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
   In this example, ``axis_name`` is a string, but it can be any Python object
   with ``__hash__`` and ``__eq__`` defined.
 
-  The argument ``axis_name`` to ``pmap`` names the mapped axis so that
-  collective operations, like ``jax.lax.psum``, can refer to it. Axis names are
-  important particularly in the case of nested ``pmap`` functions, where
-  collectives can operate over distinct axes:
+  The argument ``axis_name`` to :py:func:`pmap` names the mapped axis so that
+  collective operations, like :func:`jax.lax.psum`, can refer to it. Axis names
+  are important particularly in the case of nested :py:func:`pmap` functions,
+  where collectives can operate over distinct axes:
 
   >>> from functools import partial
   >>> import jax
@@ -1393,7 +1397,7 @@ def _jvp(fun: lu.WrappedFun, primals, tangents):
           tree_unflatten(out_tree(), out_tangents))
 
 def linearize(fun: Callable, *primals) -> Tuple[Any, Callable]:
-  """Produce a linear approximation to ``fun`` using ``jvp`` and partial eval.
+  """Produces a linear approximation to ``fun`` using :py:func:`jvp` and partial eval.
 
   Args:
     fun: Function to be differentiated. Its arguments should be arrays, scalars,
@@ -1410,32 +1414,33 @@ def linearize(fun: Callable, *primals) -> Tuple[Any, Callable]:
     Jacobian-vector product of ``fun`` evaluated at ``primals`` without re-doing
     the linearization work.
 
-  In terms of values computed, ``linearize`` behaves much like a curried
-  ``jvp``, where these two code blocks compute the same values::
+  In terms of values computed, :py:func:`linearize` behaves much like a curried
+  :py:func:`jvp`, where these two code blocks compute the same values::
 
     y, out_tangent = jax.jvp(f, (x,), (in_tangent,))
 
     y, f_jvp = jax.linearize(f, x)
     out_tangent = f_jvp(in_tangent)
 
-  However, the difference is that ``linearize`` uses partial evaluation so that
-  the function ``f`` is not re-linearized on calls to ``f_jvp``. In general that
-  means the memory usage scales with the size of the computation, much like in
-  reverse-mode. (Indeed, ``linearize`` has a similar signature to ``vjp``!)
+  However, the difference is that :py:func:`linearize` uses partial evaluation
+  so that the function ``f`` is not re-linearized on calls to ``f_jvp``. In
+  general that means the memory usage scales with the size of the computation,
+  much like in reverse-mode. (Indeed, :py:func:`linearize` has a similar
+  signature to :py:func:`vjp`!)
 
   This function is mainly useful if you want to apply ``f_jvp`` multiple times,
   i.e. to evaluate a pushforward for many different input tangent vectors at the
   same linearization point. Moreover if all the input tangent vectors are known
-  at once, it can be more efficient to vectorize using ``vmap``, as in::
+  at once, it can be more efficient to vectorize using :py:func:`vmap`, as in::
 
     pushfwd = partial(jvp, f, (x,))
     y, out_tangents = vmap(pushfwd, out_axes=(None, 0))((in_tangents,))
 
-  By using ``vmap`` and ``jvp`` together like this we avoid the stored-linearization
+  By using :py:func:`vmap` and :py:func:`jvp` together like this we avoid the stored-linearization
   memory cost that scales with the depth of the computation, which is incurred
-  by both ``linearize`` and ``vjp``.
+  by both :py:func:`linearize` and :py:func:`vjp`.
 
-  Here's a more complete example of using ``linearize``:
+  Here's a more complete example of using :py:func:`linearize`:
 
   >>> import jax
   >>> import jax.numpy as np
@@ -1507,7 +1512,7 @@ def vjp(fun: Callable, *primals, **kwargs
         ) -> Union[Tuple[Any, Callable], Tuple[Any, Callable, Any]]:
   """Compute a (reverse-mode) vector-Jacobian product of ``fun``.
 
-  :py:func:``grad`` is implemented as a special case of :py:func:``vjp``.
+  :py:func:`grad` is implemented as a special case of :py:func:`vjp`.
 
   Args:
     fun: Function to be differentiated. Its arguments should be arrays, scalars,
@@ -1579,7 +1584,7 @@ def make_jaxpr(fun: Callable,
     fun: The function whose ``jaxpr`` is to be computed. Its positional
       arguments and return value should be arrays, scalars, or standard Python
       containers (tuple/list/dict) thereof.
-    static_argnums: See the ``jax.jit`` docstring.
+    static_argnums: See the :py:func:`jax.jit` docstring.
 
   Returns:
     A wrapped version of ``fun`` that when applied to example arguments returns
@@ -1587,10 +1592,10 @@ def make_jaxpr(fun: Callable,
 
   A ``jaxpr`` is JAX's intermediate representation for program traces. The
   ``jaxpr`` language is based on the simply-typed first-order lambda calculus
-  with let-bindings. ``make_jaxpr`` adapts a function to return its ``jaxpr``,
-  which we can inspect to understand what JAX is doing internally. The ``jaxpr``
-  returned is a trace of ``fun`` abstracted to ``ShapedArray`` level. Other
-  levels of abstraction exist internally.
+  with let-bindings. :py:func:`make_jaxpr` adapts a function to return its
+  ``jaxpr``, which we can inspect to understand what JAX is doing internally.
+  The ``jaxpr`` returned is a trace of ``fun`` abstracted to
+  :py:class:`ShapedArray` level. Other levels of abstraction exist internally.
 
   We do not describe the semantics of the ``jaxpr`` language in detail here, but
   instead give a few examples.
@@ -1647,15 +1652,16 @@ def device_put(x, device: Optional[xc.Device] = None):
   """Transfers ``x`` to ``device``.
 
   Args:
-    ``x``: An array, scalar, or (nested) standard Python container thereof.
-    ``device``: The (optional) ``Device`` to transfer ``x`` to.
-      If given, then the result is committed to the device.
+    x: An array, scalar, or (nested) standard Python container thereof.
+    device: The (optional) :py:class:`Device` to which ``x`` should be
+      transferred. If given, then the result is committed to the device.
 
   If the ``device`` parameter is ``None``, then this operation behaves like the
   identity function if the operand is on any device already, otherwise it
   transfers the data to the default device, uncommitted.
 
-  For more details on data placement see the https://jax.readthedocs.io/en/latest/faq.html#controlling-data-and-computation-placement-on-devices.
+  For more details on data placement see the
+  :ref:`FAQ on data placement <faq-data-placement>`.
 
   Returns:
     A copy of ``x`` that resides on ``device``.
@@ -1724,7 +1730,7 @@ class ShapeDtypeStruct(object):
     return hash((self.shape, self.dtype))
 
 def eval_shape(fun: Callable, *args, **kwargs):
-  """Compute the shape/dtype of ``fun(*args, **kwargs)`` without any FLOPs.
+  """Compute the shape/dtype of ``fun`` without any FLOPs.
 
   This utility function is useful for performing shape inference. Its
   input/output behavior is defined by::
@@ -1749,10 +1755,11 @@ def eval_shape(fun: Callable, *args, **kwargs):
   JAX's abstract interpretation machinery to evaluate the shapes without doing
   any FLOPs.
 
-  Using ``eval_shape`` can also catch shape errors, and will raise same shape
-  errors as evaluating ``fun(*args, **kwargs)``.
+  Using :py:func:`eval_shape` can also catch shape errors, and will raise same
+  shape errors as evaluating ``fun(*args, **kwargs)``.
 
   Args:
+    fun: The function whose output shape should be evaluated.
     *args: a positional argument tuple of arrays, scalars, or (nested) standard
       Python containers (tuples, lists, dicts, namedtuples, i.e. pytrees) of
       those types. Since only the ``shape`` and ``dtype`` attributes are
@@ -1829,7 +1836,7 @@ class CustomTransformsFunction(object):
     return tree_unflatten(out_tree(), outs)
 
 def custom_transforms(fun):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   name = getattr(fun, '__name__', '<unnamed custom_transforms primitive>')
   fun_p = core.Primitive(name)
@@ -1866,7 +1873,7 @@ def _check_custom_transforms_type(name, fun):
     raise TypeError(msg.format(name, type(fun)))
 
 def defjvp_all(fun, custom_jvp):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   _check_custom_transforms_type("defjvp_all", fun)
   def custom_transforms_jvp(primals, tangents, **params):
@@ -1891,7 +1898,7 @@ def defjvp_all(fun, custom_jvp):
   ad.primitive_jvps[fun.prim] = custom_transforms_jvp
 
 def defjvp(fun, *jvprules):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   _check_custom_transforms_type("defjvp", fun)
   def custom_jvp(primals, tangents):
@@ -1902,7 +1909,7 @@ def defjvp(fun, *jvprules):
   defjvp_all(fun, custom_jvp)
 
 def defvjp_all(fun, custom_vjp):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   _check_custom_transforms_type("defvjp_all", fun)
   def custom_transforms_vjp(*consts_and_args, **params):
@@ -1937,7 +1944,7 @@ def defvjp_all(fun, custom_vjp):
   ad.defvjp_all(fun.prim, custom_transforms_vjp)
 
 def defvjp(fun, *vjprules):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   _check_custom_transforms_type("defvjp", fun)
   def custom_vjp(*primals):
@@ -1950,7 +1957,7 @@ def defvjp(fun, *vjprules):
   defvjp_all(fun, custom_vjp)
 
 def custom_gradient(fun):
-  """This API is deprecated. See jax.custom_jvp and jax.custom_vjp instead."""
+  """This API is deprecated. See :py:func:`jax.custom_jvp` and :py:func:`jax.custom_vjp` instead."""
 
   def primal_fun(*args, **kwargs):
     ans, _ = fun(*args, **kwargs)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -99,7 +99,7 @@ class custom_jvp:
   This class is meant to be used as a function decorator. Instances are
   callables that behave similarly to the underlying function to which the
   decorator was applied, except when a differentiation transformation (like
-  ``jax.jvp`` or ``jax.grad``) is applied, in which case a custom user-supplied
+  :py:func:`jax.jvp` or :py:func:`jax.grad`) is applied, in which case a custom user-supplied
   JVP rule function is used instead of tracing into and performing automatic
   differentiation of the underlying function's implementation. There is a single
   instance method, ``defjvp``, which defines the custom JVP rule.
@@ -356,7 +356,7 @@ class custom_vjp:
   This class is meant to be used as a function decorator. Instances are
   callables that behave similarly to the underlying function to which the
   decorator was applied, except when a reverse-mode differentiation
-  transformation (like ``jax.grad``) is applied, in which case a custom
+  transformation (like :py:func:`jax.grad`) is applied, in which case a custom
   user-supplied VJP rule function is used instead of tracing into and performing
   automatic differentiation of the underlying function's implementation. There
   is a single instance method, ``defvjp``, which defines the custom VJP rule.

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -174,13 +174,14 @@ def get_device_backend(device=None):
 def device_count(backend: str = None):
   """Returns the total number of devices.
 
-  On most platforms, this is the same as ``local_device_count()``. However, on
-  multi-host platforms, this will return the total number of devices across all
-  hosts.
+  On most platforms, this is the same as :py:func:`jax.local_device_count`.
+  However, on multi-host platforms, this will return the total number of devices
+  across all hosts.
 
   Args:
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
+      Optional, a string representing the xla backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
 
   Returns:
     Number of devices.
@@ -196,17 +197,19 @@ def local_device_count(backend: str =None):
 def devices(backend: str = None):
   """Returns a list of all devices for a given backend.
 
-  Each device is represented by a subclass of ``Device`` (e.g. ``CpuDevice``,
-  ``GpuDevice``). The length of the returned list is equal to
-  ``device_count(backend)``. Local devices can be identified by comparing
-  ``Device.host_id`` to ``host_id()``.
+  Each device is represented by a subclass of :class:`Device` (e.g.
+  :class:`CpuDevice`, :class:`GpuDevice`). The length of the returned list is
+  equal to ``device_count(backend)``. Local devices can be identified by comparing
+  :meth:`Device.host_id` to the value returned by :py:func:`jax.host_id``.
 
   If ``backend`` is ``None``, returns all the devices from the default backend.
-  The default backend is generally 'gpu' or 'tpu' if available, otherwise 'cpu'.
+  The default backend is generally ``'gpu'`` or ``'tpu'`` if available,
+  otherwise ``'cpu'``.
 
   Args:
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
+      Optional, a string representing the xla backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
 
   Returns:
     List of Device subclasses.
@@ -215,15 +218,16 @@ def devices(backend: str = None):
 
 
 def local_devices(host_id: int = None, backend: str = None):
-  """Like ``devices``, but only returns devices local to a given host.
+  """Like :py:func:`jax.devices`, but only returns devices local to a given host.
 
   If ``host_id`` is ``None``, returns devices local to this host.
 
   Args:
     host_id: the integer ID of the host. Host IDs can be retrieved via
-      ``host_ids()``.
+      :py:func:`jax.host_ids`.
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
+      Optional, a string representing the xla backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
 
   Returns:
     List of Device subclasses.
@@ -243,7 +247,8 @@ def host_id(backend: str = None):
 
   Args:
     backend: This is an experimental feature and the API is likely to change.
-      Optional, a string representing the xla backend. 'cpu', 'gpu', or 'tpu'.
+      Optional, a string representing the xla backend: ``'cpu'``, ``'gpu'``, or
+      ``'tpu'``.
 
   Returns:
     Integer host ID.

--- a/jax/numpy/vectorize.py
+++ b/jax/numpy/vectorize.py
@@ -180,19 +180,21 @@ def _apply_excluded(func, excluded, args):
 def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
   """Define a vectorized function with broadcasting.
 
-  ``vectorize`` is a convenience wrapper for defining vectorized functions with
-  broadcasting, in the style of NumPy's `generalized universal functions <https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html>`_.
+  :func:`vectorize` is a convenience wrapper for defining vectorized
+  functions with broadcasting, in the style of NumPy's
+  `generalized universal functions <https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html>`_.
   It allows for defining functions that are automatically repeated across
   any leading dimensions, without the implementation of the function needing to
   be concerned about how to handle higher dimensional inputs.
 
-  ``jax.numpy.vectorize`` has the same interface as ``numpy.vectorize``, but it
-  is syntactic sugar for an auto-batching transformation (``vmap``) rather
-  than a Python loop. This should be considerably more efficient, but the
-  implementation must be written in terms of functions that act on JAX arrays.
+  :func:`jax.numpy.vectorize` has the same interface as
+  :class:`numpy.vectorize`, but it is syntactic sugar for an auto-batching
+  transformation (:func:`vmap`) rather than a Python loop. This should be
+  considerably more efficient, but the implementation must be written in terms
+  of functions that act on JAX arrays.
 
   Args:
-    pyfunc: vectorized function.
+    pyfunc: function to vectorize.
     excluded: optional set of integers representing positional arguments for
       which the function will not be vectorized. These will be passed directly
       to ``pyfunc`` unmodified.
@@ -206,7 +208,7 @@ def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
     Vectorized version of the given function.
 
   Here a few examples of how one could write vectorized linear algebra routines
-  using ``vectorize``::
+  using :func:`vectorize`::
 
     import jax.numpy as jnp
     from functools import partial


### PR DESCRIPTION
Use :func:, :class: and :meth: when referring to Python objects.
Use :ref: for hyperlinks.
Fix some bad formatting.