### PR TITLE
avoid some trival operations in mask computations

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -14,7 +14,7 @@
 
 from contextlib import contextmanager
 from collections import Counter, namedtuple
-from functools import partial
+from functools import partial, reduce
 from itertools import chain, product
 import operator as op
 import string
@@ -219,13 +219,32 @@ class Poly(dict):
     assert self.is_constant
     return op.index(next(iter(self.values())))
 
-  def evaluate(self, values_dict):
-    return sum(coeff * prod([values_dict[id] ** deg for id, deg in mon.items()])
-               for mon, coeff in self.items())
+  def evaluate(self, env):
+    prod = lambda xs: reduce(op.mul, xs) if xs else 1
+    terms = [mul(coeff, prod([pow(env[id], deg) for id, deg in mon.items()]))
+             for mon, coeff in self.items()]
+    return sum(terms) if len(terms) > 1 else terms[0]
 
   @property
   def is_constant(self):
     return len(self) == 1 and next(iter(self)).degree == 0
+
+def pow(x, deg):
+  try:
+    deg = int(deg)
+  except:
+    return x ** deg
+  else:
+    return 1 if deg == 0 else x if deg == 1 else x ** deg
+
+def mul(coeff, mon):
+  try:
+    coeff = int(coeff)
+  except:
+    return coeff * mon
+  else:
+    return  0 if coeff == 0 else mon if coeff == 1 else coeff * mon
+
 
 abstract_arrays._DIMENSION_TYPES.add(Poly)
 


### PR DESCRIPTION
I think #2800 accidentally removed `mul`, `pow`, and `prod` from mask.py, but those were there to avoid some trivial computations. In particular, on this program:

```python
@partial(mask, in_shapes=['n'], out_shape='')
def foo(x):
  return np.sum(x)

padded_x = np.array([0, 1, 2, 3, 999, 999])
print(make_jaxpr(foo)([padded_x], dict(n=3)))
```

after #2800 (and until this commit) we'd print

```
{ lambda c h ; a b.
  let d = mul b 1
      e = mul d 1
      f = add e 0
      g = let c f
      i = select g a h
      j = reduce_sum [ axes=(0,) ] i
  in (j,) }
```

but before #2800 (and after this commit) we print

```
{ lambda c e ; a b.
  let d = lt c b
      f = select d a e
      g = reduce_sum[ axes=(0,) ] f
  in (g,) }
```

This might save a tiny bit of work, but more importantly it means the `make_jaxpr` results are cleaner, and we like to show those!

@j-towns spotted the fix

cc @JuliusKunze

This PR also standardizes some imports in masking_test.py.