### PR TITLE
lax.sort: allow any sequence of Arrays, not just tuples

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1188,13 +1188,13 @@ def cumprod(operand: Array, axis: int) -> Array:
   """Computes a cumulative product along `axis`."""
   return cumprod_p.bind(operand, axis=int(axis))
 
-def sort(operand: Union[Array, Tuple[Array, ...]], dimension: int = -1
+def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1
          ) -> Union[Array, Tuple[Array, ...]]:
   """Wraps XLA's `Sort
   <https://www.tensorflow.org/xla/operation_semantics#sort>`_
   operator.
   """
-  if isinstance(operand, tuple):
+  if isinstance(operand, Sequence):
     if len(operand) == 0:
       raise TypeError("Sort requires at least one operand")
     dimension = _canonicalize_axis(dimension, len(operand[0].shape))


### PR DESCRIPTION
Based on review of #3342.

Before:
```python
In [1]: from jax import lax                                                                                                           

In [2]: import jax.numpy as jnp                                                                                                       

In [3]: lax.sort([jnp.array([1, 3, 2, 4]), jnp.array([0, 1, 2, 3])])   
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-08ac0b675d83> in <module>
----> 1 lax.sort([jnp.array([1, 3, 2, 4]), jnp.array([0, 1, 2, 3])])

~/github/google/jax/jax/lax/lax.py in sort(operand, dimension)
   1201     return tuple(sort_p.bind(*operand, dimension=dimension))
   1202   else:
-> 1203     dimension = _canonicalize_axis(dimension, len(operand.shape))
   1204     return sort_p.bind(operand, dimension=dimension)[0]
   1205 

AttributeError: 'list' object has no attribute 'shape'
```
after:
```python
In [3]: lax.sort([jnp.array([1, 3, 2, 4]), jnp.array([0, 1, 2, 3])])
Out[3]: 
(DeviceArray([1, 2, 3, 4], dtype=int32),
 DeviceArray([0, 2, 1, 3], dtype=int32))
```