### PR TITLE
minor fixes from #3222

### DIFF
--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -1264,7 +1264,7 @@
         "\n",
         "  In our case, multiply_add is not a linear primitive. However, it is used linearly \n",
         "  w.r.t. tangents in multiply_add_value_and_jvp:\n",
-        "       output_tangent(xt, yt, zt) = multiply_add_prim(xt, y, multiply_add_prim(x, yt, zt)\n",
+        "       output_tangent(xt, yt, zt) = multiply_add_prim(xt, y, multiply_add_prim(x, yt, zt))\n",
         "  \n",
         "  Always one of the first two multiplicative arguments are constants.\n",
         "\n",
@@ -1280,7 +1280,7 @@
         "  if not ad.is_undefined_primal(x):\n",
         "    # This use of multiply_add is with a constant \"x\"\n",
         "    assert ad.is_undefined_primal(y)\n",
-        "    ct_y = ad.zero if ct is ad.zero else multiply_add_prim(x, ct, lax.zeros_like_array(x))\n",
+        "    ct_y = ad.Zero(y.aval) if type(ct) is ad.Zero else multiply_add_prim(x, ct, lax.zeros_like_array(x))
         "    res = None, ct_y, ct\n",
         "  else:\n",
         "    # This use of multiply_add is with a constant \"y\"\n",

--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -1285,7 +1285,7 @@
         "  else:\n",
         "    # This use of multiply_add is with a constant \"y\"\n",
         "    assert ad.is_undefined_primal(x)\n",
-        "    ct_x = ad.zero if ct is ad.zero else multiply_add_prim(ct, y, lax.zeros_like_array(y))\n",
+        "    ct_x = ad.Zero(x.aval) if type(ct) is ad.Zero else multiply_add_prim(ct, y, lax.zeros_like_array(y))\n",
         "    res = ct_x, None, ct\n",
         "  return res\n",
         "\n",

--- a/jax/api.py
+++ b/jax/api.py
@@ -830,7 +830,7 @@ def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
   across the mapped axis:
 
   >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=0)(np.arange(2.), 4.))
-  (DeviceArray([4., 5.], dtype=float32), array([8., 8.]))
+  (DeviceArray([4., 5.], dtype=float32), DeviceArray([8., 8.], dtype=float32))
 
   If the ``out_axes`` is specified for a mapped result, the result is
   transposed accordingly.

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -74,10 +74,10 @@ def jvp_subtrace_aux(master, primals, tangents):
       assert x._trace.level < trace.level
   ans, aux = yield map(partial(JVPTracer, trace), primals, tangents), {}
   ans_tracers = map(trace.full_raise, ans)
-  aux_tracers = map(trace.full_raise, aux)
   out_primals, out_tangents = unzip2((t.primal, t.tangent) for t in ans_tracers)
-  aux_primals, _            = unzip2((t.primal, t.tangent) for t in aux_tracers)
-  aux_primals = map(core.full_lower, aux_primals)
+  aux_primals = [core.full_lower(x.primal)
+                 if isinstance(x, JVPTracer) and x._trace.level == trace.level
+                 else x for x in aux]
   yield (out_primals, out_tangents), aux_primals
 
 def linearize(traceable, *primals, **kwargs):

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -144,7 +144,8 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
 
   def write_cotangent(v, ct):
     # assert v not in primal_env
-    if ct is not None and type(v) is not Literal and type(ct) is not Zero:
+    if (ct is not None and type(v) is not Literal and
+        type(ct) is not Zero and ct is not Zero):
       ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
       if not core.skip_checks:
         ct_aval = core.get_aval(ct_env[v])
@@ -195,7 +196,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
           params, call_jaxpr, invals, cts_in, cts_in_avals)
     else:
       cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals, **eqn.params)
-    cts_out = map(lambda v: Zero(v.aval), eqn.invars) if cts_out is Zero else cts_out
+    cts_out = [Zero(v.aval) for v in eqn.invars] if cts_out is Zero else cts_out
     # FIXME: Some invars correspond to primals!
     map(write_cotangent, eqn.invars, cts_out)
     for var in to_drop:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2871,7 +2871,7 @@ def _concatenate_translation_rule(c, *operands, **kwargs):
 def _concatenate_transpose_rule(t, *operands, dimension):
   operand_shapes = [o.aval.shape if ad.is_undefined_primal(o) else o.shape
                     for o in operands]
-  if t is ad_util.Zero:
+  if type(t) is ad_util.Zero:
     return ad_util.Zero
   else:
     limit_points = onp.cumsum([shape[dimension] for shape in operand_shapes])
@@ -2916,7 +2916,7 @@ def _pad_shape_rule(operand, padding_value, *, padding_config):
   return tuple(out_shape)
 
 def _pad_transpose(t, operand, padding_value, *, padding_config):
-  if t is ad_util.Zero:
+  if type(t) is ad_util.Zero:
     return ad_util.Zero
 
   lo, hi, interior = zip(*padding_config)

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1589,7 +1589,7 @@ def _memcpy(axis, num, src, dst, offset):
     return lax.dynamic_update_index_in_dim(dst, update, i + offset, axis)
   return fori_loop(0, num, body, dst)
 
-masking.masking_rules[lax.concatenate_p] = _concat_masking_rule
+masking.masking_rules[lax.concatenate_p] = _concat_masking_rule  # type: ignore
 
 
 def _check_tree(func_name, expected_name, actual_tree, expected_tree):


### PR DESCRIPTION
Two fixes related to #3222.

First, the way `jvp_subtrace_aux` in ad.py used to handle aux, we might do something crazy like`JVPTracer(trace, object(), zero)`, but the changes from #3222, which in effect propagates more type-like information, wasn't happy about that. (This is an old bug / issue, but #3222 exposed it.)

Second, the transpose rule for `div` might return `[ad_util.Zero, None]`, where the convention introduced in #3222 is that the class `Zero` there stands for a zero cotangent of any shape, since the caller, `backward_pass`, has all the avals needed to instantiate the `Zero` class at the right aval. But the caller wasn't instantiating it; the logic in `backward_pass` would create instances of `Zero` only when transpose rules returned a `Zero`, rather than a sequence containing `Zero`. (In addition to `div`, this happened in other `div`-like cases, like `triangular_solve_transpose_rule`.)

The latter issue suggests we don't have great test coverage for symbolic zero cotangents...

There were a couple other tiny tweaks too.