### PR TITLE
tweak t logpdf tolerance for float64

### DIFF
--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -373,7 +373,8 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
                             tol=1e-3)
-    self._CompileAndCheck(lax_fun, args_maker)
+    self._CompileAndCheck(lax_fun, args_maker,
+                          rtol={onp.float64: 1e-14}, atol={onp.float64: 1e-14})
 
 
   @genNamedParametersNArgs(3, jtu.rand_default)


### PR DESCRIPTION
cc @srvasude 

This is for an upcoming numerics improvement to log1p in XLA which has uniformly better relative error, but made eager and jitted versions in this test disagree by an innocuous amount.