### PR TITLE
Remove special case for scan masking

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -33,7 +33,6 @@ from .. import linear_util as lu
 map = safe_map
 zip = safe_zip
 
-shape_parameterized_primitive_rules: Dict[core.Primitive, Callable] = {}
 masking_rules: Dict[core.Primitive, Callable] = {}
 
 def defvectorized(prim):
@@ -369,7 +368,7 @@ class MaskTracer(Tracer):
 
   @property
   def dtype(self):
-    return self.val.dtype
+    return self.val.dtype if hasattr(self.val, 'dtype') else type(self.val)
 
   def is_pure(self):
     return all(type(poly) is not Poly or poly.is_constant
@@ -393,24 +392,18 @@ class MaskTrace(Trace):
     return MaskTracer(self, val.val, val.polymorphic_shape)
 
   def process_primitive(self, primitive, tracers, params):
+    masking_rule = masking_rules.get(primitive)
+    if masking_rule is None:
+      raise NotImplementedError(
+        f'Masking rule for {primitive} not implemented yet.')
+    aout = primitive.abstract_eval(*(t.aval for t in tracers), **params)
     vals, polymorphic_shapes = unzip2((t.val, t.polymorphic_shape) for t in tracers)
-    if primitive in shape_parameterized_primitive_rules:
-      rule = shape_parameterized_primitive_rules[primitive]
-      out, out_shape = rule(shape_envs, vals, polymorphic_shapes, **params)
+    logical_shapes = map(shape_as_value, polymorphic_shapes)
+    out = masking_rule(vals, logical_shapes, **params)
+    if primitive.multiple_results:
+      return map(partial(MaskTracer, self), out, (o.shape for o in aout))
     else:
-      avals = [t.aval for t in tracers]
-      out = primitive.abstract_eval(*avals, **params)
-      out_shape = [o.shape for o in out] if primitive.multiple_results else out.shape
-      logical_shapes = map(shape_as_value, polymorphic_shapes)
-      masking_rule = masking_rules.get(primitive)
-      if masking_rule is None:
-        raise NotImplementedError(
-            'Masking rule for {} not implemented yet.'.format(primitive))
-      out = masking_rule(vals, logical_shapes, **params)
-    if not primitive.multiple_results:
-      return MaskTracer(self, out, out_shape)
-    else:
-      return map(partial(MaskTracer, self), out, out_shape)
+      return MaskTracer(self, out, aout.shape)
 
   def process_call(self, call_primitive, f, tracers, params):
     assert call_primitive.multiple_results

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -368,7 +368,7 @@ class MaskTracer(Tracer):
 
   @property
   def dtype(self):
-    return self.val.dtype if hasattr(self.val, 'dtype') else type(self.val)
+    return getattr(self.val, 'dtype', type(self.val))
 
   def is_pure(self):
     return all(type(poly) is not Poly or poly.is_constant

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1481,11 +1481,9 @@ def _scan_shape_rule(shapes, reverse, length, jaxpr,
   ys_shapes = [(length,) + tuple(y_aval.shape) for y_aval in y_avals]
   return init_shexprs + ys_shapes
 
-def _scan_masking_rule(shape_envs, padded_vals, shape_exprs, reverse, length,
+def _scan_masking_rule(padded_vals, logical_shapes, reverse, length,
                        jaxpr, num_consts, num_carry, linear):
-  out_shape = _scan_shape_rule(shape_exprs, reverse, length, jaxpr,
-                               num_consts, num_carry, linear)
-  dynamic_length = length.evaluate(shape_envs.logical)
+  dynamic_length, = masking.shape_as_value((length,))
   masked_jaxpr = _masked_scan_jaxpr(jaxpr, num_consts, num_carry)
   consts, init, xs = split_list(padded_vals, [num_consts, num_carry])
   max_length, = {x.shape[0] for x in xs}
@@ -1495,7 +1493,7 @@ def _scan_masking_rule(shape_envs, padded_vals, shape_exprs, reverse, length,
       reverse=reverse, length=max_length, jaxpr=masked_jaxpr,
       num_consts=1 + num_consts, num_carry=1 + num_carry,
       linear=tuple([False] + const_linear + [False] + init_linear + xs_linear))
-  return out_vals[1:], out_shape
+  return out_vals[1:]
 
 def _masked_scan_jaxpr(jaxpr, num_consts, num_carry):
   fun = core.jaxpr_as_fun(jaxpr)
@@ -1540,7 +1538,7 @@ pe.custom_partial_eval_rules[scan_p] = _scan_partial_eval
 xla.initial_style_translations[scan_p] = \
     xla.lower_fun_initial_style(_scan_impl)
 batching.primitive_batchers[scan_p] = _scan_batching_rule
-masking.shape_parameterized_primitive_rules[scan_p] = _scan_masking_rule
+masking.masking_rules[scan_p] = _scan_masking_rule
 
 
 def map(f, xs):

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1474,13 +1474,6 @@ def _scan_batching_rule(args, dims, reverse, length, jaxpr, num_consts,
   ys_bdims = [1 if b else batching.not_mapped for b in ys_batched]
   return outs, carry_bdims + ys_bdims
 
-def _scan_shape_rule(shapes, reverse, length, jaxpr,
-                     num_consts, num_carry, linear):
-  const_shexprs, init_shexprs, xs_shexprs = split_list(shapes, [num_consts, num_carry])
-  _, y_avals = split_list(jaxpr.out_avals, [num_carry])
-  ys_shapes = [(length,) + tuple(y_aval.shape) for y_aval in y_avals]
-  return init_shexprs + ys_shapes
-
 def _scan_masking_rule(padded_vals, logical_shapes, reverse, length,
                        jaxpr, num_consts, num_carry, linear):
   dynamic_length, = masking.shape_as_value((length,))


### PR DESCRIPTION
The scan masking rule is now simplified to a standard masking rule, and the special case handling in masking.py has been removed. Also removes the redundant scan shape rule and calls `abstract_eval` with polymorphic inputs instead, like for all other primitives.