### PR TITLE
Improve error message when passing an invalid dtype.

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -79,7 +79,10 @@ def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on FLAGS.jax_enable_x64."""
   if isinstance(dtype, str) and dtype == "bfloat16":
     dtype = bfloat16
-  dtype = np.dtype(dtype)
+  try:
+    dtype = np.dtype(dtype)
+  except TypeError as e:
+    raise TypeError(f'dtype {dtype!r} not understood') from e
 
   if FLAGS.jax_enable_x64:
     return dtype

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -69,6 +69,10 @@ class DtypesTest(jtu.JaxTestCase):
       self.assertTrue(isinstance(y, jnp.ndarray), msg=(f, y))
       self.assertEqual(y.dtype, dtypes.canonicalize_dtype(dtype), msg=(f, y))
 
+  def testUnsupportedType(self):
+    with self.assertRaisesRegex(TypeError, "nonsense.* not understood"):
+      dtypes.canonicalize_dtype("nonsense")
+
   @parameterized.named_parameters(
     {"testcase_name": "_swap={}_jit={}".format(swap, jit),
      "swap": swap, "jit": jit}


### PR DESCRIPTION
I spotted this when debugging an issue like:

    self.assertEqual(x_jax, x_tf, check_dtypes=True)

The fix here is of course to use `x_tf.numpy()`, but it was not clear where the
error was from originally.