### PR TITLE
print warning when doing jit-of-pmap

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -169,8 +169,6 @@ def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
                        name=flat_fun.__name__, donated_invars=donated_invars)
     return tree_unflatten(out_tree(), out)
 
-  jitted_name = "jit({}, static_argnums={})"
-  f_jitted.__name__ = jitted_name.format(f_jitted.__name__, static_argnums)
   return f_jitted
 
 @contextmanager
@@ -1167,8 +1165,6 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
         donated_invars=tuple(donated_invars))
     return tree_unflatten(out_tree(), out)
 
-  namestr = "pmap({}, axis_name={})".format
-  f_pmapped.__name__ = namestr(f_pmapped.__name__, axis_name)
   return f_pmapped
 
 class _TempAxisName:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -249,6 +249,7 @@ def xla_primitive_callable(prim, *arg_specs: Tuple[core.AbstractValue,
     nreps = initial_style_primitive_replicas(params)
   else:
     nreps = 1
+
   if nreps > xb.device_count(backend):
     raise ValueError(
         f"compiling a primitive computation `{prim}` that requires {nreps} "
@@ -608,6 +609,14 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
 
   log_priority = logging.WARNING if FLAGS.jax_log_compiles else logging.DEBUG
   logging.log(log_priority, "Compiling %s for args %s.", fun.__name__, abstract_args)
+
+  if nreps > 1:
+    warn(f"The jitted function {fun.__name__} includes a pmap. Using "
+         "jit-of-pmap can lead to inefficient data movement, as the outer jit "
+         "does not preserve sharded data representations and instead collects "
+         "input and output arrays onto a single device. "
+         "Consider removing the outer jit unless you know what you're doing. "
+         "See https://github.com/google/jax/issues/2926.")
 
   if nreps > xb.device_count(backend):
     raise ValueError(


### PR DESCRIPTION
Print a warning when doing a jit-of-pmap. I used a regular "print" statement and not `warnings.warn` because (1) it's only printed once per compilation and (2) we might want to produce the warning for different functions, whereas AIUI `warnings.warn` on a given line will only print once during the Python process.

I wasn't sure how to add a test for a print statement to stdout, so I just skipped adding a test :)

I also removed some name munging that a user complained about. We could do that in a separate PR, but it made the warning message here look clearer!

```
$ env PYTHONPATH=. XLA_FLAGS=--xla_force_host_platform_device_count=8 ipython
In [1]: from jax import jit, pmap, numpy as jnp

In [2]: def foo(x): return x

In [3]: jit(pmap(foo))(jnp.arange(4))
The jitted function foo includes a pmap. Using jit-of-pmap can lead to inefficient data movement, as the outer jit does not preserve sharded data representations and instead collects input and output arrays onto a single device. Consider removing the outer jit unless you know what you're doing.
Out[3]: DeviceArray([0, 1, 2, 3], dtype=int32)
```

(Tangentially: should we be hard-wrapping exception messages?)