### PR TITLE
Set default odeint tol appropriately for float32

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -24,6 +24,7 @@ Adjoint algorithm based on Appendix C of https://arxiv.org/pdf/1806.07366.pdf
 
 
 from functools import partial
+import math
 import operator as op
 
 import jax
@@ -133,7 +134,7 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
                       jnp.minimum(err_ratio**(1.0 / order) / safety, 1.0 / dfactor))
   return jnp.where(mean_error_ratio == 0, last_step * ifactor, last_step / factor)
 
-def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
+def odeint(func, y0, t, *args, rtol=None, atol=None, mxstep=jnp.inf):
   """Adaptive stepsize (Dormand-Prince) Runge-Kutta odeint implementation.
 
   Args:
@@ -165,6 +166,12 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
 @partial(jax.jit, static_argnums=(0, 1, 2, 3))
 def _odeint_wrapper(func, rtol, atol, mxstep, y0, ts, *args):
   y0, unravel = ravel_pytree(y0)
+  if rtol is None or atol is None:
+    default_tol = math.sqrt(jnp.finfo(y0.dtype).eps)
+    if rtol is None:
+      rtol = default_tol
+    if atol is None:
+      atol = default_tol
   func = ravel_first_arg(func, unravel)
   out = _odeint(func, rtol, atol, mxstep, y0, ts, *args)
   return jax.vmap(unravel)(out)


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/3437

The default of `1.4e-8` matches `scipy.integrate.odeint`'s default of `sqrt(finfo(float64).eps) = 1.49012e-8`. The natural generalization for float32 would be `sqrt(finfo(float32).eps) = 3.45e-4`.

The other defensible choice would be `rtol=1e-3` and `atol=1e-6`, which matches SciPy's newer `solve_ivp` interface: https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.solve_ivp.html