### PR TITLE
add systematic tests for vmap-of-pmap

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -161,10 +161,12 @@ class BatchTrace(Trace):
     if all(dim is not_mapped for dim in dims):
       return map_primitive.bind(f, *vals, **params)
     else:
+      mapped_invars = params['mapped_invars']
       size, = {x.shape[d] for x, d in zip(vals, dims) if d is not not_mapped}
-      vals = [moveaxis(x, d, 1) if d is not not_mapped and d != 1 else x
-              for x, d in zip(vals, dims)]
-      dims = tuple(not_mapped if d is not_mapped else 0 for d in dims)
+      vals = [moveaxis(x, d, 1) if d == 0 and mapped_invar else x
+              for x, d, mapped_invar in zip(vals, dims, mapped_invars)]
+      dims = tuple(not_mapped if d is not_mapped else max(0, d - mapped_invar)
+                   for d, mapped_invar in zip(dims, mapped_invars))
       f, dims_out = batch_subtrace(f, self.master, dims)
       vals_out = map_primitive.bind(f, *vals, **params)
       dims_out = tuple(d + 1 if d is not not_mapped else d for d in dims_out())

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -23,7 +23,6 @@ from absl.testing import parameterized
 
 import numpy as onp
 
-import jax
 from jax import api
 from jax import dtypes
 from jax import lax


### PR DESCRIPTION
fixes #3440

Also re-applies the fix in #3439 (i.e it rolls-back the rollback PR #3448) because we're now confident it's correct (and some internal tests are buggy).