### PR TITLE
add erf_inv rule

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -249,6 +249,49 @@ def def_comp(prim, comp):
 
 def_comp(lax.erfc_p, lambda x: 1 - lax.erf(x))
 
+
+def _erf_inv_rule(primals_in, series_in):
+  x, = primals_in
+  series, = series_in
+
+  u = [x] + series
+  primal_out = lax.erf_inv(x)
+  v = [primal_out] + [None] * len(series)
+
+  # derivative on co-domain for caching purposes
+  deriv_const = np.sqrt(np.pi) / 2.
+  deriv_y = lambda y: lax.mul(deriv_const, lax.exp(lax.square(y)))
+
+  # manually propagate through deriv_y since we don't have lazy evaluation of sensitivities
+
+  c = [deriv_y(primal_out)] + [None] * (len(series) - 1)
+  tmp_sq = [lax.square(v[0])] + [None] * (len(series) - 1)
+  tmp_exp = [lax.exp(tmp_sq[0])] + [None] * (len(series) - 1)
+  for k in range(1, len(series)):
+    # we know c[:k], we compute c[k]
+
+    # propagate c to get v
+    v[k] = fact(k-1) * sum(_scale(k, j) * c[k-j] * u[j] for j in range(1, k + 1))
+
+    # propagate v to get next c
+
+    # square
+    tmp_sq[k] = fact(k) * sum(_scale2(k, j) * v[k-j] * v[j] for j in range(k + 1))
+
+    # exp
+    tmp_exp[k] = fact(k-1) * sum(_scale(k, j) * tmp_exp[k-j] * tmp_sq[j] for j in range(1, k + 1))
+
+    # const
+    c[k] = deriv_const * tmp_exp[k]
+
+  # we can't, and don't need, to compute c[k+1], just need to get the last v[k]
+  k = len(series)
+  v[k] = fact(k-1) * sum(_scale(k, j) * c[k-j] * u[j] for j in range(1, k + 1))
+
+  primal_out, *series_out = v
+  return primal_out, series_out
+jet_rules[lax.erf_inv_p] = _erf_inv_rule
+
 ### More complicated rules
 
 def fact(n):

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -226,6 +226,8 @@ class JetTest(jtu.JaxTestCase):
   def test_erf(self):        self.unary_check(lax.erf)
   @jtu.skip_on_devices("tpu")
   def test_erfc(self):       self.unary_check(lax.erfc)
+  @jtu.skip_on_devices("tpu")
+  def test_erf_inv(self):    self.unary_check(lax.erf_inv, lims=[-1, 1])
 
   @jtu.skip_on_devices("tpu")
   def test_div(self):   self.binary_check(lambda x, y: x / y, lims=[0.8, 4.0])


### PR DESCRIPTION
Addresses #2431. 

Adds rule for `erf_inv` using IFT and propagating through `deriv_erf`. Sensitivities need to be manually propagated through each primitive in `deriv_erf` so that they may be cached between orders.