### PR TITLE
Jet rule for `integer_pow`

### DIFF
--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -163,6 +163,12 @@ class JetTest(jtu.JaxTestCase):
 
     self.assertAllClose(terms, expected_terms, atol=atol, rtol=rtol)
 
+  @jtu.skip_on_devices("tpu")
+  def test_int_pow(self):
+    for p in range(2, 6):
+      self.unary_check(lambda x: x ** p, lims=[-2, 2])
+    self.unary_check(lambda x: x ** 10, lims=[0, 0])
+
 
   @jtu.skip_on_devices("tpu")
   def test_exp(self):        self.unary_check(jnp.exp)


### PR DESCRIPTION
Addresses #2431 and #3140.

I kept the special case for `y == 2` since the `jet` rule for `mul` is simpler and uses one less for loop.
I used `np.where` for the case when the base is `0`, not sure if there's a cleaner/more efficient approach.