### PR TITLE
[jax2tf] Added special case for tf.pad.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -628,6 +628,10 @@ def _pad_shape(operand, padding_value, padding_config):
 
 def _pad(operand, padding_value, padding_config):
   low, high, interior = util.unzip3(padding_config)
+  if all(lo >= 0 and hi >= 0 and i == 0 for lo, hi, i in padding_config):
+    return tf.pad(operand, util.safe_zip(low, high),
+                  mode="CONSTANT", constant_values=padding_value)
+  # TODO(necula): implement shape inference for XlaPad
   out_shape = _pad_shape(operand, padding_value, padding_config)
   out = tfxla.pad(operand, padding_value, low, high, interior)
   out.set_shape(out_shape)

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -150,7 +150,7 @@ lax_pad = jtu.cases_from_list(
   for dtype in default_dtypes
   for pads in [
     [(0, 0, 0), (0, 0, 0)],  # no padding
-    [(1, 1, 0), (2, 2, 0)],  # edge padding
+    [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
     [(1, 2, 1), (0, 1, 0)],  # edge padding and interior padding
     [(0, 0, 0), (-1, -1, 0)],  # negative padding
     [(0, 0, 0), (-2, -2, 4)],  # add big dilation then remove from edges

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -154,13 +154,14 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_pad)
   def test_pad(self, harness: primitive_harness.Harness):
+    # TODO: figure out the bfloat16 story
     if harness.params["dtype"] is dtypes.bfloat16:
       raise unittest.SkipTest("bfloat16 not implemented")
-    # TODO: implement (or decide not to) pads with negative edge padding
+    # TODO: fix pad with negative padding in XLA (fixed on 06/16/2020)
     if any([lo < 0 or hi < 0 for lo, hi, mid in harness.params["pads"]]):
       raise unittest.SkipTest("pad with negative pad not supported")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           with_function=True)
+                           with_function=False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
     dict(testcase_name=f"_{f_jax.__name__}",

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -976,7 +976,14 @@ class LaxTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
       for dtype in default_dtypes
-      for pads in [[(1, 2, 1), (0, 1, 0)]]))
+      for pads in [
+        [(0, 0, 0), (0, 0, 0)],  # no padding
+        [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
+        [(1, 2, 1), (0, 1, 0)],  # edge padding and interior padding
+        [(0, 0, 0), (-1, -1, 0)],  # negative padding
+        [(0, 0, 0), (-2, -2, 4)],  # add big dilation then remove from edges
+        [(0, 0, 0), (-2, -3, 1)],  # remove everything in one dimension
+      ]))
   def testPadAgainstNumpy(self, shape, dtype, pads, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype)]


### PR DESCRIPTION
jax2tf.convert now recognizes the special cases when lax.pad can be implemented with tf.pad (75% dynamic usage count).


Fixed lax_reference.pad to handle lax.pad with negative edge padding.