### PR TITLE
Support mask of broadcast, consts (arange, zeros, ...)

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2417,9 +2417,9 @@ def arange(start, stop=None, step=None, dtype=None):
   require = partial(core.concrete_or_error, _np_asarray)
   msg = "It arose in jax.numpy.arange argument `{}`.".format
   if stop is None and step is None:
-    start = require(start, msg("stop"))
-    dtype = dtype or _dtype(start)
-    return lax.iota(dtype, np.ceil(start)) # avoids materializing
+    start_ = require(start, msg("stop"))
+    dtype = dtype or (int64 if type(start) is Poly else _dtype(start_))
+    return lax.iota(dtype, lax.lax._ceil(start_)) # avoids materializing
   else:
     start = require(start, msg("start"))
     stop = None if stop is None else require(stop, msg("stop"))

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -124,6 +124,11 @@ class PolyTest(jtu.JaxTestCase):
     assert -1 - n == -n - 1
 
 class MaskingTest(jtu.JaxTestCase):
+  def setUp(self):
+    super().setUp()
+    if not config.omnistaging_enabled:
+      raise SkipTest("Masking requires omnistaging.")
+
   def test_sum(self):
     @partial(mask, in_shapes=['n'], out_shape='')
     def padded_sum(x):
@@ -250,27 +255,19 @@ class MaskingTest(jtu.JaxTestCase):
     def times(x, y):
       return x * y
 
-    # TODO(shoyer): enable this check when broadcast_in_dim supports masking
-    with self.assertRaisesRegex(
-        NotImplementedError,
-        'Masking rule for broadcast_in_dim not implemented yet.'):
-      times([jnp.array([[1, 2], [3, 4], [5, 6]]), jnp.array([1, 2])],
-            dict(n=4, m=5))
-      # expected = np.array([[1, 2, 3], [8, 10, 12]])
-      # self.assertAllClose(ans, expected, check_dtypes=False)
+    ans = times([jnp.array([[1, 2], [3, 4], [5, 6]]), jnp.array([1, 2])],
+          dict(n=4, m=5))
+    expected = np.array([[1, 4], [3, 8], [5, 12]])
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
   def test_stack(self):
     @partial(mask, in_shapes=['n','n'], out_shape='(2, n)')
     def stack(x, y):
       return jnp.stack([x, y], 0)
 
-    # TODO(shoyer): enable this check when broadcast_in_dim supports masking
-    with self.assertRaisesRegex(
-        NotImplementedError,
-        'Masking rule for broadcast_in_dim not implemented yet.'):
-      stack([jnp.array([1, 2, 3]), jnp.array([4, 5, 6])], dict(n=10))
-      # expected = np.array([[1, 2, 3], [4, 5, 6]])
-      # self.assertAllClose(ans, expected, check_dtypes=False)
+    ans = stack([jnp.array([1, 2, 3]), jnp.array([4, 5, 6])], dict(n=10))
+    expected = np.array([[1, 2, 3], [4, 5, 6]])
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
   def test_monomorphic(self):
     @partial(mask, in_shapes=['(_, n)'], out_shape='')
@@ -644,6 +641,11 @@ class MaskingTest(jtu.JaxTestCase):
                ['(a, b, c)'], 'b, a, c', dict(a=2, b=3, c=4), [(3, 4, 5)],
                ['float_'], jtu.rand_default(self.rng()))
 
+  def test_squeeze(self):
+    self.check(lambda x: lax.squeeze(x, (0, 2)),
+               ['(1, n, 1)'], 'n', dict(n=2), [(1, 4, 1)],
+               ['float_'], jtu.rand_default(self.rng()))
+
   def test_sum_2d(self):
     self.check(jnp.sum, ['(m, n)'], '', dict(m=2, n=3), [(3, 4)], ['float_'],
                jtu.rand_default(self.rng()))
@@ -661,7 +663,12 @@ class MaskingTest(jtu.JaxTestCase):
     # TODO needs fix for https://github.com/google/jax/issues/2155
 
   def test_broadcast_in_dim(self):
-    raise SkipTest
+    self.check(lambda x: -lax.broadcast_in_dim(np.zeros((1, 1)), shape=(3, x.shape[0], 4), broadcast_dimensions=(1, 2)),
+               ['(n, 1)'], '(3, n, 4)', dict(n=2), [(5, 1)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_broadcast_to(self):
+    self.check(lambda x: -jnp.broadcast_to(0, x.shape), ['n'], 'n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
 
   def test_destructure(self):
     def d(key):
@@ -670,11 +677,60 @@ class MaskingTest(jtu.JaxTestCase):
 
     self.check(d, ['2'], '', {}, [(2,)], ['int_'], jtu.rand_int(self.rng(), 0, 10))
 
+  def test_select(self):
+    self.check(lambda x: lax.select(x < 0, x, 0. * x), ['n'], 'n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
   # TODO(mattjj,j-towns): fix test failure and reenable.
   @jtu.skip_on_devices("tpu")
   def test_where(self):
+    message = (
+      "mask(jit(broadcast_in_dim))) is not supported yet. "
+      "Consider using jit(mask(broadcast_in_dim)) instead."
+      "If you are using np.where, consider disabling jit on jax.lax._where or "
+      "manually broadcasting arguments to the same shape.")
+
+    self.assertRaisesWithLiteralMatch(
+      NotImplementedError, message,
+      lambda: self.check(lambda x: jnp.where(x < 0, x, 0.), ['n'], 'n',
+                         {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng())))
+    self.assertRaisesWithLiteralMatch(
+      NotImplementedError, message,
+      lambda: self.check(lambda x: jnp.where(x < 0, 0., x), ['n'], 'n',
+                         {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng())))
+    self.assertRaisesWithLiteralMatch(
+      NotImplementedError, message,
+      lambda: self.check(lambda x: jnp.where(x < 0, 0., 0.), ['n'], 'n',
+                         {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng())))
+
+    raise SkipTest("broken by omnistaging")  # TODO(mattjj): update
     self.check(lambda x: jnp.where(x < 0, x, 0. * x), ['n'], 'n',
                {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_zeros(self):
+    self.check(lambda x: -jnp.zeros(x.shape), ['n'], 'n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_ones(self):
+    self.check(lambda x: -jnp.ones(x.shape), ['n'], 'n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_arange(self):
+    self.check(lambda x: -jnp.arange(x.shape[0]), ['n'], 'n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_eye(self):
+    self.check(lambda x: -jnp.eye(x.shape[0], 2 * x.shape[0]), ['n'], 'n, 2*n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_tri(self):
+    self.check(lambda x: -jnp.tri(x.shape[0], 2 * x.shape[0]), ['n'], 'n, 2*n',
+               {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
+
+  def test_delta(self):
+    self.check(lambda x: -lax._delta(jnp.float32,
+      (x.shape[0], 2 * x.shape[0], 3 * x.shape[0]), axes=(0, 1)), ['n'],
+      'n, 2*n, 3*n', {'n': 2}, [(3,)], ['float_'], jtu.rand_default(self.rng()))
 
   def test_split(self):
     self.check(lambda x: jnp.split(x, 2), ['2*n'], ['n', 'n'], dict(n=4),


### PR DESCRIPTION
Adds support for `mask` of broadcast (fixing https://github.com/google/jax/issues/2769) and constant operations, as well as `mask(squeeze)` and preparations for `mask(where)`.

It introduces four new lax primitives (`iota_p`, `eye_p`, `delta_p`, `tri_p`), all without inputs (= constants). Together with `broadcast_in_dim_p`, each of these requires a target shape (or size) parameter. This shape can be polymorphic during masking. In that case, abstract evaluation of these primitives cannot return a `ConcreteArray`. To solve this, their `abstract_eval` function is modified to return a `ShapedArray` with polymorphic shape.

`mask` and `shapecheck` now require omnistaging, which is default since https://github.com/google/jax/pull/4038. @mattjj
Omnistaging broke `mask(jit)` and therefore `mask(where)` and `mask(pad)`, see TODOs in tests. Do you already have a plan to fix this?