### PR TITLE
[jax2tf] Control on which TF device the TF converted code runs.

### DIFF
--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -76,9 +76,6 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     for with_function in [False, True]
     for dtype in [np.int64, np.float64]))
   def test_converts_64bit(self, dtype=np.int64, with_function=False):
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): fix and re-enable this test.
-      raise self.skipTest("Test is flaky on TPU")
     big_const = np.full((5,), 2 ** 33, dtype=dtype)
     self.ConvertAndCompare(jnp.sin, big_const)
     f_conv = jax2tf.convert(jnp.sin)

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -38,11 +38,11 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     if jtu.device_under_test() != "gpu":
       # TODO(necula): Change the build flags to ensure the GPU is seen by TF
       # It seems that we need --config=cuda build flag for this to work?
-      self.assertEquals(jtu.device_under_test().upper(),
-                        self.tf_default_device.device_type)
+      self.assertEqual(jtu.device_under_test().upper(),
+                       self.tf_default_device.device_type)
 
     with contextlib.ExitStack() as stack:
-      self._resource = stack.enter_context(tf.device(self.tf_default_device))
+      stack.enter_context(tf.device(self.tf_default_device))
       self.addCleanup(stack.pop_all().close)
 
   def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import logging
 import numpy as np
 from typing import Any, Callable, Tuple
 import tensorflow as tf  # type: ignore[import]
@@ -22,6 +24,26 @@ from jax.experimental import jax2tf
 from jax import test_util as jtu
 
 class JaxToTfTestCase(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    # Ensure that all TF ops are created on the proper device (TPU or GPU or CPU)
+    # TODO(necula): why doesn't TF do this automatically?
+    tf_preferred_devices = (
+        tf.config.list_logical_devices("TPU") +
+        tf.config.list_logical_devices("GPU") +
+        tf.config.list_logical_devices())
+    self.tf_default_device = tf_preferred_devices[0]
+    logging.info(f"Running jax2tf converted code on {self.tf_default_device}.")
+    if jtu.device_under_test() != "gpu":
+      # TODO(necula): Change the build flags to ensure the GPU is seen by TF
+      # It seems that we need --config=cuda build flag for this to work?
+      self.assertEquals(jtu.device_under_test().upper(),
+                        self.tf_default_device.device_type)
+
+    with contextlib.ExitStack() as stack:
+      self._resource = stack.enter_context(tf.device(self.tf_default_device))
+      self.addCleanup(stack.pop_all().close)
 
   def assertDtypesMatch(self, x, y, *, canonicalize_dtypes=True):
     """Compares dtypes across JAX and TF dtypes. Overrides super method."""
@@ -44,6 +66,8 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     if with_function:
       func_tf = tf.function(func_tf)
     res_jax = func_jax(*args)
+    #logging.info(f"res_jax is {res_jax} on {res_jax.device_buffer.device()}")
     res_tf = func_tf(*args)
+    #logging.info(f"res_tf is {res_tf} on {res_tf.backing_device}")
     self.assertAllClose(res_jax, res_tf, atol=atol, rtol=rtol)
     return (res_jax, res_tf)


### PR DESCRIPTION
The device should match the device on which the JAX code runs,
otherwise the numerical comparisons don't make sense.

* This code requires some build-file changes in Google3 to properly
  run on GPU and TPU.