### PR TITLE
Disable the workaround to prevent expansion of type aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,25 +33,10 @@ import typing
 sys.path.insert(0, os.path.abspath('..'))
 
 
-# Workaround to avoid expanding type aliases. See:
+# Currently type aliases are expanded. We tried a workaround along the lines of:
 # https://github.com/sphinx-doc/sphinx/issues/6518#issuecomment-589613836
-
-# When building docs, enable `from __future__ import annotations` everywhere.
-def _rewrite(p):
-  with open(p) as f:
-    contents = f.read()
-  with open(p, 'w') as f:
-    f.write('from __future__ import annotations\n')
-    f.write(contents)
-
-if 'READTHEDOCS' in os.environ:
-  for path, dirs, files in os.walk('../jax/'):
-    for file in files:
-      if file.endswith('.py'):
-        _rewrite(os.path.abspath(os.path.join(path, file)))
-
-# Monkey patch for the typing module to prevent it from expanding type aliases.
-typing.get_type_hints = lambda obj, *unused: obj.__annotations__
+# Unfortunately, this workaround makes Sphinx drop module-level documentation.
+# See https://github.com/google/jax/issues/3452.
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,6 @@
 #
 import os
 import sys
-import typing
 
 sys.path.insert(0, os.path.abspath('..'))
 


### PR DESCRIPTION
Attempt to fix #3452. We can insert the `from __future__ import annotations` manually once we move to Python 3.7.

I tried also #3354, but it seems to be too complicated. 