### PR TITLE
[jax2tf] Add special case for translation of lax.gather to tf.gather.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -902,19 +902,58 @@ def _gather_shape(operand, start_indices, dimension_numbers, slice_sizes):
   return out.shape
 
 
+def _try_tf_gather(operand, start_indices, dimension_numbers, slice_sizes):
+  # Handle only the case when batch_dims=0.
+
+  # Find axis to match the tf.gather semantics
+  # Let I = len(indices_shape)
+  # let O = len(op_shape)
+  # slice_sizes == op_shape[:axis] + (1,) + op_shape[axis+1:]
+  # collapsed_slice_dims == (axis,)
+  # start_index_map == (axis,)
+  # offset_dims == (0, 1, ..., axis - 1, axis + I, ..., O + I - 1)
+  op_shape = np.shape(operand)
+  assert len(op_shape) == len(slice_sizes)
+  if not (len(op_shape) >= 1 and
+          len(dimension_numbers.start_index_map) == 1 and
+          len(dimension_numbers.collapsed_slice_dims) == 1 and
+          dimension_numbers.collapsed_slice_dims[0] == dimension_numbers.start_index_map[0] and
+          len(dimension_numbers.offset_dims) == len(op_shape) - 1):
+    return None
+  # We added a trailing dimension of size 1
+  if start_indices.shape[-1] != 1:
+    return None
+  # Guess the axis
+  axis = dimension_numbers.collapsed_slice_dims[0]
+  index_dims = len(np.shape(start_indices)) - 1
+  expected_offset_dims = tuple(
+      list(range(axis)) +
+      list(range(axis + index_dims, len(op_shape) + index_dims - 1)))
+  if dimension_numbers.offset_dims != expected_offset_dims:
+    return None
+  expected_slice_sizes = op_shape[:axis] + (1,) + op_shape[axis + 1:]
+  if slice_sizes != expected_slice_sizes:
+    return None
+  # TODO: should we allow ourselves to add a reshape, or should we strictly
+  #  convert 1:1, or go to TFXLA when not possible?
+  start_indices = tf.reshape(start_indices, start_indices.shape[0:-1])
+  return tf.gather(operand, start_indices, axis=axis, batch_dims=0)
+
+
 @functools.partial(bool_to_int8, argnums=0)
-def _gather(operand, start_indices, dimension_numbers, slice_sizes,
-            indices_are_sorted=False):
+def _gather(operand, start_indices, dimension_numbers, slice_sizes):
   """Tensorflow implementation of gather."""
+  res = _try_tf_gather(operand, start_indices, dimension_numbers, slice_sizes)
+  if res is not None:
+    return res
   out_shape = _gather_shape(
       operand, start_indices, dimension_numbers, slice_sizes)
   proto = _gather_dimensions_proto(start_indices.shape, dimension_numbers)
   out, = tf.xla.experimental.compile(
-      lambda o, s: tfxla.gather(o, s, proto, slice_sizes, indices_are_sorted),
+      lambda o, s: tfxla.gather(o, s, proto, slice_sizes, False),
       [operand, start_indices])
   out.set_shape(out_shape)
   return out
-
 tf_impl[lax.gather_p] = _gather
 
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -25,6 +25,7 @@ from jax import config
 from jax import test_util as jtu
 from jax import dtypes
 from jax import lax
+from jax import numpy as jnp
 
 import numpy as np
 
@@ -136,8 +137,52 @@ def parameterized(harness_group: Iterable[Harness],
     for harness in harness_group
     if one_containing is None or one_containing in harness.name)
   if one_containing is not None:
+    if not cases:
+      raise ValueError(f"Cannot find test case with name containing {one_containing}."
+                       "Names are:"
+                       "\n".join([harness.name for harness in harness_group]))
     cases = cases[0:1]
   return testing.parameterized.named_parameters(*cases)
+
+
+_gather_input = np.arange(1000, dtype=np.float32).reshape((10, 10, 10))
+lax_gather = jtu.cases_from_list(
+  # Construct gather harnesses using take
+  [Harness(f"from_take_indices_shape={indices.shape}_axis={axis}",
+           lambda a, i, axis: jnp.take(a, i, axis=axis),
+           [_gather_input,
+            indices,
+            StaticArg(axis)])
+   for indices in [
+     np.array(2, dtype=np.int32),
+     np.array([2], dtype=np.int32),
+     np.array([2, 4], dtype=np.int32),
+     np.array([[2, 4], [5, 6]], dtype=np.int32)
+   ]
+   for axis in [0, 1, 2]] +
+
+  # Directly from lax.gather in lax_test.py.
+  [Harness(
+    f"_shape={shape}_idxs_shape={idxs.shape}_dnums={dnums}_slice_sizes={slice_sizes}",
+    lambda op, idxs, dnums, slice_sizes: lax.gather(op, idxs, dimension_numbers=dnums, slice_sizes=slice_sizes),
+    [RandArg(shape, np.float32),
+     idxs, StaticArg(dnums), StaticArg(slice_sizes)])
+    for shape, idxs, dnums, slice_sizes in [
+    ((5,), np.array([[0], [2]]), lax.GatherDimensionNumbers(
+      offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
+     (1,)),
+    ((10,), np.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
+      offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
+     (2,)),
+    ((10, 5,), np.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
+      offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
+     (1, 3)),
+    ((10, 5), np.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
+      offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
+     (1, 3)),
+    ]
+  ]
+)
 
 
 lax_pad = jtu.cases_from_list(


### PR DESCRIPTION
Also adds more tests for conversion for gather.

The detection is non-trivial, may not be worth having it. This covers 50% of uses of gather. 