### PR TITLE
Update Random Numbers link in the JAX quickstart notebook

### DIFF
--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -61,7 +61,7 @@
         "id": "Xpy1dSgNqCP4"
       },
       "source": [
-        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the [README](../../README.md)."
+        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the [Common gotchas in JAX](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#🔪-Random-Numbers)."
       ]
     },
     {


### PR DESCRIPTION
This PR fixes the link in the JAX quickstart notebook in:

> "We’ll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the README." 

**Issue**: The README link originally took you to https://jax.readthedocs.io/en/README.md, which does not exist:

<center><img width="300" alt="image" src="https://user-images.githubusercontent.com/19637339/85051643-abdc4280-b18f-11ea-9467-bf5167ef3186.png"></center>

If you click on it in Colab, it also doesn't work (because of its form: `../../README.md`).

**Solution**: Perhaps a better way is to add a new link takes you to an explanation of how JAX random works (the Mersenne Twister PRNG) and its issues:

> For more details, see the [Common gotchas in JAX](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#🔪-Random-Numbers)."

The new link directs you straight to: `#🔪-Random-Numbers`.

Let me know what you think. Cheers!

(I'm working on adding `pmap` for the Quickstart, as discussed in https://github.com/google/jax/issues/3458.)