### PR TITLE
Update JAX FAQ.rst, jax.device_put

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -64,7 +64,7 @@ and with ``jit`` it is::
     Result: 2
 
 For :func:`jax.jit`, the function is executed once using the Python interpreter, at which time the
-``Inside`` printing happens, and the first value of ``y`` is observed. Then the function
+``Inside`` printing happens, and the first value of ``y`` is observed. Then, the function
 is compiled and cached, and executed multiple times with different values of ``x``, but
 with the same first value of ``y``.
 
@@ -78,13 +78,12 @@ Additional reading:
 Controlling data and computation placement on devices
 -----------------------------------------------------
 
-We describe first the principles of data and computation placement
-in JAX.
+Let's first look at the principles of data and computation placement in JAX.
 
-In JAX the computation follows the data placement. JAX arrays
-have two placement properties: the device where the data resides,
-and whether it is **committed** to the device or not (we sometimes
-say that the data is *sticky* to the device).
+In JAX, the computation follows data placement. JAX arrays
+have two placement properties: 1) the device where the data resides;
+and 2) whether it is **committed** to the device or not (the data is sometimes 
+referred to as being *sticky* to the device).
 
 By default, JAX arrays are placed uncommitted on the default device
 (``jax.devices()[0]``).
@@ -97,29 +96,27 @@ Computations involving uncommitted data are performed on the default
 device and the results are uncommitted on the default device.
 
 Data can also be placed explicitly on a device using :func:`jax.device_put`
-with a ``device`` parameter, in which case if becomes **committed** to the device:
+with a ``device`` parameter, in which case it—the data—becomes **committed** to the device:
 
 >>> import jax
 >>> from jax import device_put
 >>> print(device_put(1, jax.devices()[2]).device_buffer.device())  # doctest: +SKIP
 gpu:2
 
-Computations involving some committed inputs, will happen on the
-committed device, and the result will be committed on the
-same device. It is an error to invoke an operation on
-arguments that are committed to more than one device.
+Computations involving some committed inputs will happen on the
+committed device and the result will be committed on the
+same device. You should not invoke an operation on
+arguments that are committed to more than one device—it will lead to errors.
 
-You can also use :func:`jax.device_put` without a ``device`` parameter,
-in which case the data is left as is if already on a device (whether
-committed or not), or a Python value that is not on any device is
-placed uncommitted on the default device.
+You can also use :func:`jax.device_put` without a ``device`` parameter. In this case
+the data is left as is if it's already on the device (committed or not), or a Python 
+value—that is not on any device—is placed uncommitted on the default device.
 
-Jitted functions behave as any other primitive operation
-(will follow the data and will error if invoked on data
-committed on more than one device).
+Jitted functions behave like any other primitive operations—they will follow the 
+data and will show errors if invoked on data committed on more than one device.
 
 (As of April 2020, :func:`jax.jit` has a `device` parameter
-that affects slightly the device placement. That parameter
+that affects the device placement slightly. That parameter
 is experimental, is likely to be removed or changed, and
 its use is not recommended.)
 
@@ -134,12 +131,12 @@ For a worked-out example, we recommend reading through
 
 If you are getting an error that a library function is called with
 *"Abstract tracer value encountered where concrete value is expected"*, you may need to
-change how you invoke JAX transformations. We give first an example, and
-a couple of solutions, and then we explain in more detail what is actually
+change how you invoke JAX transformations. Below, you'll first go over such example and then
+a couple of possible solutions. Then, you'll learn the details of what is actually
 happening, if you are curious or the simple solution does not work for you.
 
 Some library functions take arguments that specify shapes or axes,
-such as the 2nd and 3rd arguments for :func:`jax.numpy.split`::
+such as the second and third arguments for :func:`jax.numpy.split`::
 
   # def np.split(arr, num_sections: Union[int, Sequence[int]], axis: int):
   np.split(np.zeros(2), 2, 0)  # works
@@ -155,7 +152,7 @@ you will get the following error::
     See `https://jax.readthedocs.io/en/latest/faq.html#abstract-tracer-value-where-concrete-value-is-expected-error`.
     Encountered value: Traced<ShapedArray(int32[], weak_type=True):JaxprTrace(level=-1/1)>
 
-We must change the way we use :func:`jax.jit` to ensure that the ``num_sections``
+You must change the way you use :func:`jax.jit` to ensure that the ``num_sections``
 and ``axis`` arguments use their concrete values (``2`` and ``0`` respectively).
 The best mechanism is to use special transformation parameters
 to declare some arguments to be static, e.g., ``static_argnums`` for :func:`jax.jit`::
@@ -179,6 +176,7 @@ Different kinds of JAX values
 
 In the process of transforming functions, JAX replaces some function
 arguments with special tracer values.
+
 You could see this if you use a ``print`` statement::
 
   def func(x):

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -96,7 +96,7 @@ Computations involving uncommitted data are performed on the default
 device and the results are uncommitted on the default device.
 
 Data can also be placed explicitly on a device using :func:`jax.device_put`
-with a ``device`` parameter, in which case it—the data—becomes **committed** to the device:
+with a ``device`` parameter, in which case the data becomes **committed** to the device:
 
 >>> import jax
 >>> from jax import device_put
@@ -105,20 +105,20 @@ gpu:2
 
 Computations involving some committed inputs will happen on the
 committed device and the result will be committed on the
-same device. You should not invoke an operation on
-arguments that are committed to more than one device—it will lead to errors.
+same device. Invoking an operation on arguments that are committed 
+to more than one device will raise an error.
 
-You can also use :func:`jax.device_put` without a ``device`` parameter. In this case
-the data is left as is if it's already on the device (committed or not), or a Python 
-value—that is not on any device—is placed uncommitted on the default device.
+You can also use :func:`jax.device_put` without a ``device`` parameter. If the data 
+is already on a device (committed or not), it's left as-is. If the data isn't on any 
+device—that is, it's a regular Python or NumPy value—it's placed uncommitted on the default 
+device. You can also use :func:`jax.device_put` without a `device` parameter. 
 
 Jitted functions behave like any other primitive operations—they will follow the 
 data and will show errors if invoked on data committed on more than one device.
 
-(As of April 2020, :func:`jax.jit` has a `device` parameter
-that affects the device placement slightly. That parameter
-is experimental, is likely to be removed or changed, and
-its use is not recommended.)
+(As of April 2020, :func:`jax.jit` has a `device` parameter that affects the device 
+placement. That parameter is experimental, is likely to be removed or changed, 
+and its use is not recommended.)
 
 For a worked-out example, we recommend reading through
 ``test_computation_follows_data`` in
@@ -131,9 +131,9 @@ For a worked-out example, we recommend reading through
 
 If you are getting an error that a library function is called with
 *"Abstract tracer value encountered where concrete value is expected"*, you may need to
-change how you invoke JAX transformations. Below, you'll first go over such example and then
-a couple of possible solutions. Then, you'll learn the details of what is actually
-happening, if you are curious or the simple solution does not work for you.
+change how you invoke JAX transformations. Below is an example and a couple of possible 
+solutions, followed by the details of what is actually happening, if you are curious 
+or the simple solution does not work for you.
 
 Some library functions take arguments that specify shapes or axes,
 such as the second and third arguments for :func:`jax.numpy.split`::


### PR DESCRIPTION
Hey team, this PR creates a few minor changes to make JAX FAQ hopefully slightly better in terms of readability and UX. 
I was learning about data placement on devices with `jax.device_put` and decided to make some improvements by applying a few things, as I got slightly lost, hence:

```
Data can also be placed explicitly on a device using :func:`jax.device_put`
- with a ``device`` parameter, in which case if becomes **committed** to the device:
+ with a ``device`` parameter, in which case it—the data—becomes **committed** to the device:
```

Used the Google doc writing style guide here and other tech writing stuff. Cheers & thanks for your work