### PR TITLE
Revert "Remove documentation presubmit action now that the RTD presubmit is enabled. (#3480)"

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -61,7 +61,7 @@ jobs:
       env:
         JAX_NUM_GENERATED_CASES: ${{ matrix.num_generated_cases }}
       run: |
-        [ ${{ matrix.enable-x64 }} = enable-x64 ] && JAX_ENABLE_X64=1 || JAX_ENABLE_X64=0 
+        [ ${{ matrix.enable-x64 }} = enable-x64 ] && JAX_ENABLE_X64=1 || JAX_ENABLE_X64=0
         pip install -e .
         echo "JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES"
         echo "JAX_ENABLE_X64=$JAX_ENABLE_X64"
@@ -89,7 +89,5 @@ jobs:
         pip install -r docs/requirements.txt
     - name: Build and test documentation
       run: |
-        sphinx-build -b html -D nbsphinx_execute=always docs docs/build/html
         pytest docs
         pytest --doctest-modules jax/api.py
-

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -61,7 +61,7 @@ jobs:
       env:
         JAX_NUM_GENERATED_CASES: ${{ matrix.num_generated_cases }}
       run: |
-        [ ${{ matrix.enable-x64 }} = enable-x64 ] && JAX_ENABLE_X64=1 || JAX_ENABLE_X64=0
+        [ ${{ matrix.enable-x64 }} = enable-x64 ] && JAX_ENABLE_X64=1 || JAX_ENABLE_X64=0 
         pip install -e .
         echo "JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES"
         echo "JAX_ENABLE_X64=$JAX_ENABLE_X64"
@@ -69,3 +69,27 @@ jobs:
           pytest -n auto jax/experimental/jax2tf/tests
         fi
         pytest -n auto tests examples
+
+
+  documentation:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt install -y pandoc
+        python -m pip install --upgrade pip
+        pip install -r docs/requirements.txt
+    - name: Build and test documentation
+      run: |
+        sphinx-build -b html -D nbsphinx_execute=always docs docs/build/html
+        pytest docs
+        pytest --doctest-modules jax/api.py
+

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -87,7 +87,7 @@ jobs:
         sudo apt install -y pandoc
         python -m pip install --upgrade pip
         pip install -r docs/requirements.txt
-    - name: Build and test documentation
+    - name: Test documentation
       run: |
         pytest docs
         pytest --doctest-modules jax/api.py


### PR DESCRIPTION
This (partially) reverts commit 68dcbdd1189cd938bf6023e4e1efaf64c71629aa.

@hawkinsp points out this was running doctest, which the RTD presubmit doesn't do AFAIK. We still don't build the docs here, as the RTD presubmit takes care of that.