### PR TITLE
Small fix of the link rendering in the Autodiff Cookbook that refers to Autograd's reverse-mode Jacobian

### DIFF
--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -1319,7 +1319,7 @@
         "id": "7r5_m9Y68bf_"
       },
       "source": [
-        "Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation of reverse-mode `jacobian` in Autograd](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`."
+        "Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) of reverse-mode `jacobian` in Autograd had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`."
       ]
     },
     {


### PR DESCRIPTION
Markdown stuff - hopefully this fixes the rendering in Sphinx/ReadTheDocs of a link that refers to Autograd's reverse-mode Jacobian method. 

I was learning about mixing `jit` with full Jacobian with `jacfwd` and `jacrev` noticed the following:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19637339/85228627-4f219780-b3dc-11ea-8d27-92b3fe080b33.png">

And in another browser (with extensions off):

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19637339/85228638-6496c180-b3dc-11ea-91f6-f4972776ffb8.png">

PS I assume the link was referring to:

```python
@unary_to_nary
def jacobian(fun, x):
  
  vjp, ans = _make_vjp(fun, x)
  ...
```