### PR TITLE
Another small fix of the link rendering in the Autodiff Cookbook - vmap transformation

### DIFF
--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -1136,7 +1136,7 @@
       "source": [
         "### Jacobian-Matrix and Matrix-Jacobian products\n",
         "\n",
-        "Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's [`vmap` transformation](https://github.com/google/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products."
+        "Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's `vmap` [transformation](https://github.com/google/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products."
       ]
     },
     {


### PR DESCRIPTION
@shoyer Thanks for approving PR https://github.com/google/jax/pull/3501 - this one is similar. Backticks inside square brackets don't render well in Sphinx/ReadTheDocs for some reason when we add hyperlinks in markdown. (I am learning about auto-vectorization.)

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19637339/85233691-27442b00-b400-11ea-8002-8fd96d11ff96.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/19637339/85233714-5195e880-b400-11ea-9f61-d93cb285a60a.png">
