### PR TITLE
pin numpy version in setup.py to avoid warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["examples"]),
     python_requires='>=3.6',
     install_requires=[
-        'numpy>=1.12', 'absl-py', 'opt_einsum'
+        'numpy >=1.12, <1.19', 'absl-py', 'opt_einsum'
     ],
     url='https://github.com/google/jax',
     license='Apache-2.0',


### PR DESCRIPTION
Tests are red at HEAD due to a numpy 1.19 change that raises DeprecationWarnings like these:

```
   def issubdtype(a, b):
     if a == bfloat16:
       return b in [bfloat16, _bfloat16_dtype, np.floating, np.inexact,
                    np.number]
>       DeprecationWarning: Converting `np.complex` to a dtype is deprecated. The current result is `complex128`     which is not strictly correct.
```