### PR TITLE
Remove unnecessary static_argnum in np.gradient

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1006,7 +1006,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
   return result
 
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=2)
 def _gradient(a, varargs, axis):
   def gradient_along_axis(a, h, axis):
     sliced = partial(lax.slice_in_dim, a, axis=axis)


### PR DESCRIPTION
The jit on `np.gradient` has an unnecessary static argnum on `varargs`. IIUC only ´axis` has to be static. 