### PR TITLE
Update JAX Quickstart with parallelization (`pmap`), other changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ napolean_use_rtype = False
 
 # Execute notebooks before conversion: 'always', 'never', 'auto' (default)
 # We execute all notebooks, exclude the slow ones using 'exclude_patterns'
-nbsphinx_execute = 'always'
+nbsphinx_execute = 'never'
 
 # Use this kernel instead of the one stored in the notebook metadata:
 #nbsphinx_kernel_name = 'python3'

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -25,24 +25,55 @@
       "source": [
         "# JAX Quickstart\n",
         "\n",
-        "**JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance machine learning research.**\n",
+        "**JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance general numerical computing and machine learning research.**\n",
         "\n",
-        "With its updated version of [Autograd](https://github.com/hips/autograd), JAX\n",
+        "It is an extensible system for composable function transformations using Python and NumPy. JAX is fast, easy to use, and uses a functional programming model, which aligns well with mathematics.\n",
+        "\n",
+        "With an updated version of **[Autograd](https://github.com/hips/autograd)**, JAX\n",
         "can automatically differentiate native Python and NumPy code. It can\n",
-        "differentiate through a large subset of Python’s features, including loops, ifs,\n",
-        "recursion, and closures, and it can even take derivatives of derivatives of\n",
-        "derivatives. It supports reverse-mode as well as forward-mode differentiation, and the two can be composed arbitrarily\n",
-        "to any order.\n",
+        "differentiate through a large subset of Python’s features, including loops, if statements, recursions, and closures. \n",
+        "\n",
+        "JAX can even **take derivatives of derivatives of\n",
+        "derivatives**. It supports **reverse-mode and forward-mode differentiation** and the two can be composed arbitrarily to any order.\n",
         "\n",
         "What’s new is that JAX uses\n",
-        "[XLA](https://www.tensorflow.org/xla)\n",
-        "to compile and run your NumPy code on accelerators, like GPUs and TPUs.\n",
-        "Compilation happens under the hood by default, with library calls getting\n",
-        "just-in-time compiled and executed. But JAX even lets you just-in-time compile\n",
-        "your own Python functions into XLA-optimized kernels using a one-function API.\n",
-        "Compilation and automatic differentiation can be composed arbitrarily, so you\n",
-        "can express sophisticated algorithms and get maximal performance without having\n",
-        "to leave Python.\n"
+        "**[XLA](https://www.tensorflow.org/xla)** to compile and run your NumPy code on accelerators, like GPUs and TPUs. Compilation happens under the hood by default, with library calls getting just-in-time compiled and executed. But JAX even lets you **just-in-time (JIT) compile** your own Python functions into XLA-optimized kernels using a one-function API. Since all computations are compiled with JIT, there are almost no handwritten kernels. And JIT gives you an almost \"eager-mode\" performance.\n",
+        "\n",
+        "Compilation and automatic differentiation (autodiff) can be composed arbitrarily, so you\n",
+        "can express sophisticated algorithms and get maximal performance without having to leave Python.\n",
+        "\n",
+        "JAX is much more than just an accelerator-backed NumPy. It comes with a few key _program transformations_ (transforms) that are useful when writing numerical code. \n",
+        "\n",
+        "In this quickstart, you'll be focusing on the following transforms:\n",
+        "\n",
+        " - [jit()](https://jax.readthedocs.io/en/latest/jax.html#jax.jit): for speeding up your code\n",
+        " - [grad()](https://jax.readthedocs.io/en/latest/jax.html#jax.grad): for taking derivatives\n",
+        " - [vmap()](https://jax.readthedocs.io/en/latest/jax.html#vectorization-vmap): for automatic vectorization or batching\n",
+        " - [pmap()](https://jax.readthedocs.io/en/latest/jax.html#parallelization-pmap): for executing functions on multiple accelerators in parallel (on multiple GPU or even TPU cores)\n",
+        "\n",
+        "The general API is Pythonic and user-friendly—you pass a function into a transform and get a function out. You'll see it in the examples below.\n",
+        "\n",
+        "Since JAX is still being developed, do check out the [Common Gotchas in JAX](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) notebook."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DrX0V8NyIe7F",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Import the libraries"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "n_gdgjRVIj1U",
+        "colab_type": "text"
+      },
+      "source": [
+        "- Import `grad`, `jit`, `vmap`, and `pmap` as the transforms covered in this quickstart, `jax.random`—for random initialization, and `jax.numpy`—as the accelerator-backed NumPy:"
       ]
     },
     {
@@ -53,7 +84,8 @@
         "colab": {}
       },
       "source": [
-        "import jax.numpy as np\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
         "from jax import grad, jit, vmap\n",
         "from jax import random"
       ],
@@ -77,7 +109,23 @@
         "id": "Xpy1dSgNqCP4"
       },
       "source": [
-        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the [README](../../README.md)."
+        "First, let's look at how to do N-dimensional array (NDArray) multiplication in JAX, which should be as easy as in NumPy.\n",
+        "\n",
+        "Note that one big difference between NumPy and JAX is how you generate random numbers with JAX's [pseudo-random number generator (PRNG)](https://github.com/google/jax/blob/master/design_notes/prng.md). \n",
+        "\n",
+        "JAX PRNG = threefry counter PRNG + a functional array-oriented splitting model. "
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "gL1VcaPYJUqp",
+        "colab_type": "text"
+      },
+      "source": [
+        "Let's look at some examples:\n",
+        "\n",
+        "- Generate a random array with [jax.random()](https://jax.readthedocs.io/en/latest/jax.random.html):"
       ]
     },
     {
@@ -88,8 +136,13 @@
         "colab": {}
       },
       "source": [
+        "# Create a PRNG key (seed set to 0)\n",
         "key = random.PRNGKey(0)\n",
+        "\n",
+        "# Create a Normally-distributed 10-element NDArray with the PRNG key\n",
         "x = random.normal(key, (10,))\n",
+        "\n",
+        "# Print the new array\n",
         "print(x)"
       ],
       "execution_count": null,
@@ -102,7 +155,7 @@
         "id": "hDJF0UPKnuqB"
       },
       "source": [
-        "Let's dive right in and multiply two big matrices."
+        "- Multiply two matrices and measure the compute time:"
       ]
     },
     {
@@ -113,9 +166,14 @@
         "colab": {}
       },
       "source": [
+        "# Set a matrix size to 3000\n",
         "size = 3000\n",
-        "x = random.normal(key, (size, size), dtype=np.float32)\n",
-        "%timeit np.dot(x, x.T).block_until_ready()  # runs on the GPU"
+        "\n",
+        "# Instantiate a Normal matrix as JAX NumPy dtype `float32` with the PRNG key\n",
+        "x = random.normal(key, (size, size), dtype=jnp.float32)\n",
+        "\n",
+        "# Multiply the matrix by its transpose, measure the time it takes to compute\n",
+        "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
       "execution_count": null,
       "outputs": []
@@ -127,9 +185,11 @@
         "id": "0AlN7EbonyaR"
       },
       "source": [
-        "We added that `block_until_ready` because [JAX uses asynchronous execution by default](https://jax.readthedocs.io/en/latest/async_dispatch.html).\n",
+        "The NumPy calculation runs on the accelerator! Notice how much time it took to carry out the matrix multiply with JAX NumPy.\n",
         "\n",
-        "JAX NumPy functions work on regular NumPy arrays. "
+        "Note that when measuring the true cost of the operation, you add `block_until_ready()` to wait until the computation is complete. Read more about how [JAX uses asynchronous execution by default](https://jax.readthedocs.io/en/latest/async_dispatch.html). \n",
+        "\n",
+        "- The next example shows how you can use JAX NumPy functions to work on regular NumPy arrays:"
       ]
     },
     {
@@ -140,9 +200,14 @@
         "colab": {}
       },
       "source": [
-        "import numpy as onp  # original CPU-backed NumPy\n",
+        "# Import the original CPU-backed NumPy\n",
+        "import numpy as onp\n",
+        "\n",
+        "# Create a Normal matrix of dtype `float32` with ordinary NumPy \n",
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
-        "%timeit np.dot(x, x.T).block_until_ready()"
+        "\n",
+        "# Dot multiply again with JAX NumPy, measure the compute time\n",
+        "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
       "execution_count": null,
       "outputs": []
@@ -154,7 +219,11 @@
         "id": "_SrcB2IurUuE"
       },
       "source": [
-        "That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using `device_put`."
+        "This is slower than before because the computation follows the data placement without staying on the CPU, GPU or TPU. The kernels are dispatched to the accelerator one operation at a time.\n",
+        "\n",
+        "With JAX, however, you can explicitly place data, such as your NDArray, on the device. You can read more on data and computation placement [here](https://jax.readthedocs.io/en/latest/faq.html#faq-data-placement).\n",
+        "\n",
+        "- Ensure that an NDArray is backed by device memory by using [jax.device_put()](https://jax.readthedocs.io/en/latest/jax.html?highlight=device_put#jax.device_put):"
       ]
     },
     {
@@ -167,9 +236,14 @@
       "source": [
         "from jax import device_put\n",
         "\n",
+        "# As before, create a Normal matrix with ordinary NumPy and dtype `float32`\n",
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
+        "\n",
+        "# Transfer NDArray to device\n",
         "x = device_put(x)\n",
-        "%timeit np.dot(x, x.T).block_until_ready()"
+        "\n",
+        "# As before, dot multiply with JAX NumPy, measure the compute time \n",
+        "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
       "execution_count": null,
       "outputs": []
@@ -181,7 +255,11 @@
         "id": "clO9djnen8qi"
       },
       "source": [
-        "The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster."
+        "Notice the time improvement here.\n",
+        "\n",
+        "The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. \n",
+        "\n",
+        "Note that the behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's _faster_."
       ]
     },
     {
@@ -191,7 +269,9 @@
         "id": "ghkfKNQttDpg"
       },
       "source": [
-        "If you have a GPU (or TPU!) these calls run on the accelerator and have the potential to be much faster than on CPU."
+        "If you have a GPU (or TPU!), these calls run on the accelerator and have the potential to be much faster than on CPU.\n",
+        "\n",
+        "- Run the dot multiply again using ordinary NumPy instead of JAX NumPy:"
       ]
     },
     {
@@ -202,7 +282,11 @@
         "colab": {}
       },
       "source": [
+        "# As before, create a Normal matrix with ordinary NumPy and dtype `float32`\n",
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
+        "\n",
+        "# Create a dot product with ordinary NumPy instead of JAX\n",
+        "# and measure the time it takes to compute\n",
         "%timeit onp.dot(x, x.T)"
       ],
       "execution_count": null,
@@ -215,13 +299,9 @@
         "id": "iOzp0P_GoJhb"
       },
       "source": [
-        "JAX is much more than just a GPU-backed NumPy. It also comes with a few program transformations that are useful when writing numerical code. For now, there's three main ones:\n",
+        "This was just an introduction on how to multiply matrices with JAX.\n",
         "\n",
-        " - `jit`, for speeding up your code\n",
-        " - `grad`, for taking derivatives\n",
-        " - `vmap`, for automatic vectorization or batching.\n",
-        "\n",
-        "Let's go over these, one-by-one. We'll also end up composing these in interesting ways."
+        "Let's go over each of JAX's key program transforms—`jit`, `grad`, `vmap`, and `pmap`. You'll also be composing these program transformations in interesting ways!"
       ]
     },
     {
@@ -241,7 +321,21 @@
         "id": "YrqE32mvE3b7"
       },
       "source": [
-        "JAX runs transparently on the GPU (or CPU, if you don't have one, and TPU coming soon!). However, in the above example, JAX is dispatching kernels to the GPU one operation at a time. If we have a sequence of operations, we can use the `@jit` decorator to compile multiple operations together using [XLA](https://www.tensorflow.org/xla). Let's try that."
+        "JAX runs transparently on the GPU/TPU (or CPU, if you don't have one).\n",
+        "\n",
+        "However, in the above examples, JAX is dispatching kernels to the GPU one operation at a time. Overall, JAX NumPy can be sometimes slower than ordinary NumPy—especially on the CPU. So, if you have a sequence of operations, to speed your calculation you can use the @[jit](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) decorator to compile multiple operations together using [XLA](https://www.tensorflow.org/xla). \n",
+        "\n",
+        "Let's try that."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "433jT-kAKIXb",
+        "colab_type": "text"
+      },
+      "source": [
+        "- In the example below, you'll define a Scaled Exponential Linear Unit (SELU) activation function (which you may be familiar with from the world of deep learning). Then, you'll apply SELU on a large array and check how fast the computation is with JAX NumPy:"
       ]
     },
     {
@@ -252,10 +346,14 @@
         "colab": {}
       },
       "source": [
+        "# Define a SELU activation function\n",
         "def selu(x, alpha=1.67, lmbda=1.05):\n",
-        "  return lmbda * np.where(x > 0, x, alpha * np.exp(x) - alpha)\n",
+        "  return lmbda * jnp.where(x > 0, x, alpha * jnp.exp(x) - alpha)\n",
         "\n",
+        "# Instantiate a Normally-distributed NDArray with 1 million elements\n",
         "x = random.normal(key, (1000000,))\n",
+        "\n",
+        "# Call SELU and measure the computation once the computation is complete\n",
         "%timeit selu(x).block_until_ready()"
       ],
       "execution_count": null,
@@ -268,7 +366,7 @@
         "id": "a_V8SruVHrD_"
       },
       "source": [
-        "We can speed it up with `@jit`, which will jit-compile the first time `selu` is called and will be cached thereafter."
+        "- You can speed up the calculation with `jit`, which will JIT-compile the first time `selu` is called (and it will be cached thereafter):"
       ]
     },
     {
@@ -279,7 +377,10 @@
         "colab": {}
       },
       "source": [
+        "# Apply `jit()` on the SELU function\n",
         "selu_jit = jit(selu)\n",
+        "\n",
+        "# Call jitted SELU, measure the compute time again\n",
         "%timeit selu_jit(x).block_until_ready()"
       ],
       "execution_count": null,
@@ -288,13 +389,45 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "ZJdx45U_KU4m",
+        "colab_type": "text"
+      },
+      "source": [
+        "Notice how much faster it is when you JIT-compile."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "colab_type": "text",
         "id": "HxpBc4WmfsEU"
       },
       "source": [
-        "## Taking derivatives with `grad`\n",
+        "## Taking derivatives with `grad`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IgsZK32DKZCB",
+        "colab_type": "text"
+      },
+      "source": [
+        "In addition to evaluating numerical functions, you can also transform them. One such transformation is [autodiff](https://en.wikipedia.org/wiki/Automatic_differentiation). \n",
         "\n",
-        "In addition to evaluating numerical functions, we also want to transform them. One transformation is [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation). In JAX, just like in [Autograd](https://github.com/HIPS/autograd), you can compute gradients with the `grad` function."
+        "Just like in [Autograd](https://github.com/HIPS/autograd), you can compute gradients with the [grad()](https://jax.readthedocs.io/en/latest/jax.html#jax.grad) function in JAX. \n",
+        "\n",
+        "Taking derivatives is as easy as calling `grad`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "H-zr129jKbTW",
+        "colab_type": "text"
+      },
+      "source": [
+        "- Let's explore autodiff with a logistic regression example below where you first use `jit` on a function and then calculate the gradient:"
       ]
     },
     {
@@ -305,10 +438,14 @@
         "colab": {}
       },
       "source": [
+        "# Define a logistic regression function with JAX NumPy\n",
         "def sum_logistic(x):\n",
-        "  return np.sum(1.0 / (1.0 + np.exp(-x)))\n",
+        "  return jnp.sum(1.0 / (1.0 + jnp.exp(-x)))\n",
         "\n",
-        "x_small = np.arange(3.)\n",
+        "# Create an array with spaced elements\n",
+        "x_small = jnp.arange(3.)\n",
+        "\n",
+        "# JIT the logistic regression function, take its derivative\n",
         "derivative_fn = grad(sum_logistic)\n",
         "print(derivative_fn(x_small))"
       ],
@@ -322,7 +459,7 @@
         "id": "PtNs881Ohioc"
       },
       "source": [
-        "Let's verify with finite differences that our result is correct."
+        "- Let's verify that your result is correct with finite differences:"
       ]
     },
     {
@@ -335,9 +472,8 @@
       "source": [
         "def first_finite_differences(f, x):\n",
         "  eps = 1e-3\n",
-        "  return np.array([(f(x + eps * v) - f(x - eps * v)) / (2 * eps)\n",
-        "                   for v in np.eye(len(x))])\n",
-        "\n",
+        "  return jnp.array([(f(x + eps * v) - f(x - eps * v)) / (2 * eps)\n",
+        "                   for v in jnp.eye(len(x))])\n",
         "\n",
         "print(first_finite_differences(sum_logistic, x_small))"
       ],
@@ -351,7 +487,11 @@
         "id": "Q2CUZjOWNZ-3"
       },
       "source": [
-        "Taking derivatives is as easy as calling `grad`. `grad` and `jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:"
+        " Note how close the results are. \n",
+        "\n",
+        "`grad` and `jit` compose and you can mix them arbitrarily. In the above example, you jitted `sum_logistic` and then took its derivative. You can go even further and take as many gradients of gradients as you want.\n",
+        "\n",
+        "- Invoke `grad` and `jit` multiple times:"
       ]
     },
     {
@@ -374,7 +514,11 @@
         "id": "yCJ5feKvhnBJ"
       },
       "source": [
-        "For more advanced autodiff, you can use `jax.vjp` for reverse-mode vector-Jacobian products and `jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:"
+        "For more advanced autodiff, you can use JAX's primitive [vjp()](https://jax.readthedocs.io/en/latest/jax.html?highlight=jax.vjp#jax.vjp) (vector-Jacobian products) for reverse-mode vector-Jacobian products and [jvp()](https://jax.readthedocs.io/en/latest/jax.html?highlight=jax.jvp#jax.jvp) (Jacobian-vector products) for forward-mode Jacobian-vector products. These transforms return functions to push-forward or pull-back single vectors. (Reverse-mode differentiation is often referred to as backpropagation or backprop in machine learning.)\n",
+        "\n",
+        "They can also be composed arbitrarily with one another, and with other JAX transformations, such as `jit`. \n",
+        "\n",
+        "- Below is a simple example of a function that efficiently computes full Hessian matrices with [jax.hessian()](https://jax.readthedocs.io/en/latest/_modules/jax/api.html#hessian). You can mix `jit` with full Jacobian matrices using JAX's [jacfwd()](https://jax.readthedocs.io/en/latest/jax.html#jax.jacfwd) and [jacrev()](https://jax.readthedocs.io/en/latest/jax.html#jax.jacrev)."
       ]
     },
     {
@@ -386,11 +530,38 @@
       },
       "source": [
         "from jax import jacfwd, jacrev\n",
+        "\n",
+        "# Define some small random arrays with the PRNG key\n",
+        "size = 5\n",
+        "x = random.normal(key, (size, ), dtype=jnp.float32)\n",
+        "y = random.normal(key, (size, size), dtype=jnp.float32)\n",
+        "\n",
+        "# Define a simple dot product multiply with JAX NumPy\n",
+        "def fun(x):\n",
+        "    return jnp.dot(jnp.dot(x, y), x)\n",
+        "\n",
+        "# This is a Hessian function\n",
         "def hessian(fun):\n",
-        "  return jit(jacfwd(jacrev(fun)))"
+        "  return jit(jacfwd(jacrev(fun)))\n",
+        "\n",
+        "# Define the Hessian computation\n",
+        "hess = hessian(fun)\n",
+        "\n",
+        "# Compute and show the output\n",
+        "print(hess(x))"
       ],
       "execution_count": null,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bZAde_wBRutv",
+        "colab_type": "text"
+      },
+      "source": [
+        "Hope you get the taste of what you can do with JAX's autodiff system. To learn more, check out [The Autodiff Cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html)."
+      ]
     },
     {
       "cell_type": "markdown",
@@ -409,7 +580,11 @@
         "id": "PcxkONy5aius"
       },
       "source": [
-        "JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand."
+        "JAX has another transformation in its API that you might find useful: [vmap()](https://jax.readthedocs.io/en/latest/jax.html#jax.vmap). The vectorizing map promotes matrix-on-vector multiplies into matrix-on-matrix multiplies. It achieves that by adding a batch dimension to every primitive operation in the function. Using `vmap` can save you from having to carry around batch dimensions in your code. Compared to manual vectorization, this transform is more practical and faster particularly when building more complex neural networks.\n",
+        "\n",
+        "`vmap` has the familiar semantics of mapping a function along array axes. It works a lot like a regular Python `map`. But, instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. \n",
+        "\n",
+        "When composed with `jit`, it can be just as fast as adding the batch dimensions by hand."
       ]
     },
     {
@@ -419,7 +594,9 @@
         "id": "TPiX4y-bWLFS"
       },
       "source": [
-        "We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using `vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions."
+        "You're going to work with a simple example of executing matrix-on-matrix multiplications by hand, which is easy to do by hand here. The same technique can apply to more complicated functions.\n",
+        "\n",
+        "- Set up a simple dot product of matrices:"
       ]
     },
     {
@@ -430,11 +607,15 @@
         "colab": {}
       },
       "source": [
+        "# Define a matrix - a random 150x100 NDArray with the PRNG key, as before\n",
         "mat = random.normal(key, (150, 100))\n",
+        "\n",
+        "# Define batched inputs - a random 10x100 NDArray\n",
         "batched_x = random.normal(key, (10, 100))\n",
         "\n",
+        "# Define a dot product of a matrix on vector\n",
         "def apply_matrix(v):\n",
-        "  return np.dot(mat, v)"
+        "  return jnp.dot(mat, v)"
       ],
       "execution_count": null,
       "outputs": []
@@ -446,7 +627,7 @@
         "colab_type": "text"
       },
       "source": [
-        "Given a function such as `apply_matrix`, we can loop over a batch dimension in Python, but usually the performance of doing so is poor."
+        "- Given a function such as `apply_matrix`, you can loop over a batch dimension in Python (but, usually, the performance of doing so is poor):"
       ]
     },
     {
@@ -457,9 +638,11 @@
         "colab": {}
       },
       "source": [
+        "# Define a naively batched dot product\n",
         "def naively_batched_apply_matrix(v_batched):\n",
-        "  return np.stack([apply_matrix(v) for v in v_batched])\n",
+        "  return jnp.stack([apply_matrix(v) for v in v_batched])\n",
         "\n",
+        "# Measure the time to perform the computation, use `block_until_ready()`, as before\n",
         "print('Naively batched')\n",
         "%timeit naively_batched_apply_matrix(batched_x).block_until_ready()"
       ],
@@ -473,7 +656,7 @@
         "colab_type": "text"
       },
       "source": [
-        "We know how to batch this operation manually. In this case, `np.dot` handles extra batch dimensions transparently."
+        "- You probably know how to batch this operation manually. In this case, `jnp.dot` handles extra batch dimensions transparently as follows:"
       ]
     },
     {
@@ -484,10 +667,12 @@
         "colab": {}
       },
       "source": [
+        "# Apply the @jit decorator to compile normal dot product ops with XLA\n",
         "@jit\n",
         "def batched_apply_matrix(v_batched):\n",
-        "  return np.dot(v_batched, mat.T)\n",
+        "  return jnp.dot(v_batched, mat.T)\n",
         "\n",
+        "# Check how much time it takes to compute\n",
         "print('Manually batched')\n",
         "%timeit batched_apply_matrix(batched_x).block_until_ready()"
       ],
@@ -501,7 +686,7 @@
         "colab_type": "text"
       },
       "source": [
-        "However, suppose we had a more complicated function without batching support. We can use `vmap` to add batching support automatically."
+        "- However, suppose you had a more complicated function without batching support. You can use `vmap` to add batching support automatically:"
       ]
     },
     {
@@ -512,10 +697,12 @@
         "colab": {}
       },
       "source": [
+        "# Apply the @jit decorator to compile auto-vectorized ops with XLA\n",
         "@jit\n",
         "def vmap_batched_apply_matrix(v_batched):\n",
         "  return vmap(apply_matrix)(v_batched)\n",
         "\n",
+        "# Check how much time it takes to compute\n",
         "print('Auto-vectorized with vmap')\n",
         "%timeit vmap_batched_apply_matrix(batched_x).block_until_ready()"
       ],
@@ -529,7 +716,7 @@
         "id": "pYVl3Z2nbZhO"
       },
       "source": [
-        "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation."
+        "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, forward- and reverse-mode autodiff for fast Jacobian (`jax.jacfwd` and `jax.jacrev`) and Hessian (`jax.hessian`) matrix calculations, and any other JAX transformation."
       ]
     },
     {

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -13,7 +13,7 @@
       "language": "python",
       "name": "python3"
     },
-    "accelerator": "GPU"
+    "accelerator": "TPU"
   },
   "cells": [
     {
@@ -89,7 +89,7 @@
         "from jax import grad, jit, vmap\n",
         "from jax import random"
       ],
-      "execution_count": null,
+      "execution_count": 1,
       "outputs": []
     },
     {
@@ -133,7 +133,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "u0nseKZNqOoH",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "3e8e1242-9071-4ee4-fff0-dfb30679d637"
       },
       "source": [
         "# Create a PRNG key (seed set to 0)\n",
@@ -145,8 +149,17 @@
         "# Print the new array\n",
         "print(x)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[-0.3721109   0.26423115 -0.18252768 -0.7368197  -0.44030377 -0.1521442\n",
+            " -0.67135346 -0.5908641   0.73168886  0.5673026 ]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -163,7 +176,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "eXn8GUl6CG5N",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "492ca6ef-e494-4efd-82c0-44e482a43a01"
       },
       "source": [
         "# Set a matrix size to 3000\n",
@@ -175,8 +192,17 @@
         "# Multiply the matrix by its transpose, measure the time it takes to compute\n",
         "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "The slowest run took 48.82 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "1 loop, best of 3: 30.2 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -197,7 +223,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "ZPl0MuwYrM7t",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "08191fbf-a5a2-4275-8820-eafec6707957"
       },
       "source": [
         "# Import the original CPU-backed NumPy\n",
@@ -209,8 +239,16 @@
         "# Dot multiply again with JAX NumPy, measure the compute time\n",
         "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "10 loops, best of 3: 82.5 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -231,7 +269,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "Jj7M7zyRskF0",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "f1430722-ec4a-4aa2-acd5-c1daf04668c7"
       },
       "source": [
         "from jax import device_put\n",
@@ -245,8 +287,16 @@
         "# As before, dot multiply with JAX NumPy, measure the compute time \n",
         "%timeit jnp.dot(x, x.T).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "10 loops, best of 3: 26 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -279,7 +329,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "RzXK8GnIs7VV",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "8c68a679-c0d4-4b28-fcf3-7cb4b3e97fde"
       },
       "source": [
         "# As before, create a Normal matrix with ordinary NumPy and dtype `float32`\n",
@@ -289,8 +343,16 @@
         "# and measure the time it takes to compute\n",
         "%timeit onp.dot(x, x.T)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1 loop, best of 3: 510 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -343,7 +405,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "qLGdCtFKFLOR",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "537cfdbc-e8fa-450b-c34b-3ffb5ae6b9fe"
       },
       "source": [
         "# Define a SELU activation function\n",
@@ -356,8 +422,17 @@
         "# Call SELU and measure the computation once the computation is complete\n",
         "%timeit selu(x).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "The slowest run took 171.08 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "1 loop, best of 3: 2.43 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -374,7 +449,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "fh4w_3NpFYTp",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "fc18bb10-d66e-4a9e-ebd7-b06ce42ab0ee"
       },
       "source": [
         "# Apply `jit()` on the SELU function\n",
@@ -383,8 +462,17 @@
         "# Call jitted SELU, measure the compute time again\n",
         "%timeit selu_jit(x).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "The slowest run took 368.33 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "1000 loops, best of 3: 337 µs per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -435,7 +523,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "IMAgNJaMJwPD",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "fd1eacf5-0651-4241-90e5-051a07ac3fa7"
       },
       "source": [
         "# Define a logistic regression function with JAX NumPy\n",
@@ -449,8 +541,16 @@
         "derivative_fn = grad(sum_logistic)\n",
         "print(derivative_fn(x_small))"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[0.25       0.19661197 0.10499357]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -467,7 +567,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "JXI7_OZuKZVO",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "3cb94d90-a0f5-4652-d48a-d53504c263ca"
       },
       "source": [
         "def first_finite_differences(f, x):\n",
@@ -477,8 +581,16 @@
         "\n",
         "print(first_finite_differences(sum_logistic, x_small))"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[0.24998187 0.1965761  0.10502338]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -499,13 +611,25 @@
       "metadata": {
         "colab_type": "code",
         "id": "TO4g8ny-OEi4",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "1ae24242-cca2-4b23-94d5-ac847af67583"
       },
       "source": [
         "print(grad(jit(grad(jit(grad(sum_logistic)))))(1.0))"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "-0.035325605\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -526,7 +650,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "Z-JxbiNyhxEW",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 102
+        },
+        "outputId": "2af9e7df-f3e2-48f0-c807-64055120432b"
       },
       "source": [
         "from jax import jacfwd, jacrev\n",
@@ -550,8 +678,20 @@
         "# Compute and show the output\n",
         "print(hess(x))"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[[ 5.032702   -1.9991791   0.4032886   2.2227669  -1.073147  ]\n",
+            " [-1.9991791   3.8138     -0.30260596 -2.7868059  -1.4474283 ]\n",
+            " [ 0.4032886  -0.30260596 -2.5324054  -0.3041943   0.16804928]\n",
+            " [ 2.2227669  -2.7868059  -0.3041943  -0.2903153  -0.03739795]\n",
+            " [-1.073147   -1.4474283   0.16804928 -0.03739795 -0.69874346]]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -617,7 +757,7 @@
         "def apply_matrix(v):\n",
         "  return jnp.dot(mat, v)"
       ],
-      "execution_count": null,
+      "execution_count": 13,
       "outputs": []
     },
     {
@@ -635,7 +775,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "KWVc9BsZv0Ki",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        },
+        "outputId": "2fe00219-8436-4bb3-d24e-4cd3508ac716"
       },
       "source": [
         "# Define a naively batched dot product\n",
@@ -646,8 +790,18 @@
         "print('Naively batched')\n",
         "%timeit naively_batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Naively batched\n",
+            "The slowest run took 24.02 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "100 loops, best of 3: 6.81 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -664,7 +818,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "ipei6l8nvrzH",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        },
+        "outputId": "c0d0393a-7d69-4186-87a2-4a469bade616"
       },
       "source": [
         "# Apply the @jit decorator to compile normal dot product ops with XLA\n",
@@ -676,8 +834,18 @@
         "print('Manually batched')\n",
         "%timeit batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Manually batched\n",
+            "The slowest run took 253.88 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "1000 loops, best of 3: 285 µs per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -694,7 +862,11 @@
       "metadata": {
         "colab_type": "code",
         "id": "67Oeknf5vuCl",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        },
+        "outputId": "0eb3ee04-2dfb-44d6-f27a-0eea7aacb170"
       },
       "source": [
         "# Apply the @jit decorator to compile auto-vectorized ops with XLA\n",
@@ -706,8 +878,18 @@
         "print('Auto-vectorized with vmap')\n",
         "%timeit vmap_batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Auto-vectorized with vmap\n",
+            "The slowest run took 235.19 times longer than the fastest. This could mean that an intermediate result is being cached.\n",
+            "1000 loops, best of 3: 312 µs per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -776,7 +958,11 @@
       "metadata": {
         "id": "lI1x7ol_GUnr",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "154c2748-f6cc-4172-dcae-afe23e0e9205"
       },
       "source": [
         "# Run this cell inside Google Colab with TPUs enabled\n",
@@ -799,8 +985,16 @@
         "config.FLAGS.jax_backend_target = \"grpc://\" + os.environ['COLAB_TPU_ADDR']\n",
         "print(config.FLAGS.jax_backend_target)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "grpc://10.107.144.26:8470\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -827,13 +1021,30 @@
       "metadata": {
         "id": "XnqzwBcgGp7f",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "8dcd50f8-4302-466c-b798-d8bacffffdbf"
       },
       "source": [
         "jax.devices"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<function jax.lib.xla_bridge.devices>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 2
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -862,15 +1073,27 @@
       "metadata": {
         "id": "GCVRSahjG2mI",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "35895a71-63fa-4874-8120-5832c64b24ef"
       },
       "source": [
         "y = pmap(lambda x: x ** 2)(jnp.arange(8))\n",
         "\n",
         "print(y)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[ 0  1  4  9 16 25 36 49]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -887,7 +1110,11 @@
       "metadata": {
         "id": "yASda37nG6Jr",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "faa3ff6d-65dc-415c-f945-c89016822cce"
       },
       "source": [
         "# Create a PRNG key and split it into 8 new ones\n",
@@ -903,8 +1130,17 @@
         "# Return the mean of the result and show the output\n",
         "print(pmap(jnp.mean)(result))"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[-0.00515623  0.01026373 -0.00641113 -0.01368965 -0.00786617 -0.01982933\n",
+            " -0.00123709 -0.01034036]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -921,13 +1157,25 @@
       "metadata": {
         "id": "F3yYESbEG8gL",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "0466e34b-fd12-4fe1-a790-7b80845249be"
       },
       "source": [
         "timeit -n 5 -r 5 pmap(jnp.dot)(matrices, matrices).block_until_ready()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "5 loops, best of 5: 15.6 ms per loop\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -944,7 +1192,11 @@
       "metadata": {
         "id": "E7NjrJabHDNf",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        },
+        "outputId": "a305b109-573f-488f-a682-c20fb39c3cec"
       },
       "source": [
         "# Define an arbitrary array and reshape it\n",
@@ -962,8 +1214,24 @@
         "\n",
         "f(x)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "ShardedDeviceArray([[ 0.        , -0.7170853 ],\n",
+              "                    [-3.1085174 , -0.4824318 ],\n",
+              "                    [10.366636  , 13.135289  ],\n",
+              "                    [ 0.22163185, -0.52112055]], dtype=float32)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 6
+        }
+      ]
     },
     {
       "cell_type": "markdown",

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -1,4 +1,20 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "JAX Quickstart.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "accelerator": "GPU"
+  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -41,7 +57,7 @@
         "from jax import grad, jit, vmap\n",
         "from jax import random"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -76,7 +92,7 @@
         "x = random.normal(key, (10,))\n",
         "print(x)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -101,7 +117,7 @@
         "x = random.normal(key, (size, size), dtype=np.float32)\n",
         "%timeit np.dot(x, x.T).block_until_ready()  # runs on the GPU"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -128,7 +144,7 @@
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
         "%timeit np.dot(x, x.T).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -155,7 +171,7 @@
         "x = device_put(x)\n",
         "%timeit np.dot(x, x.T).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -189,7 +205,7 @@
         "x = onp.random.normal(size=(size, size)).astype(onp.float32)\n",
         "%timeit onp.dot(x, x.T)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -242,7 +258,7 @@
         "x = random.normal(key, (1000000,))\n",
         "%timeit selu(x).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -266,7 +282,7 @@
         "selu_jit = jit(selu)\n",
         "%timeit selu_jit(x).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -296,7 +312,7 @@
         "derivative_fn = grad(sum_logistic)\n",
         "print(derivative_fn(x_small))"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -325,7 +341,7 @@
         "\n",
         "print(first_finite_differences(sum_logistic, x_small))"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -348,7 +364,7 @@
       "source": [
         "print(grad(jit(grad(jit(grad(sum_logistic)))))(1.0))"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -373,7 +389,7 @@
         "def hessian(fun):\n",
         "  return jit(jacfwd(jacrev(fun)))"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -420,7 +436,7 @@
         "def apply_matrix(v):\n",
         "  return np.dot(mat, v)"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -447,7 +463,7 @@
         "print('Naively batched')\n",
         "%timeit naively_batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -475,7 +491,7 @@
         "print('Manually batched')\n",
         "%timeit batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -503,7 +519,7 @@
         "print('Auto-vectorized with vmap')\n",
         "%timeit vmap_batched_apply_matrix(batched_x).block_until_ready()"
       ],
-      "execution_count": 0,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -519,6 +535,262 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "TZfecIXaGFoj",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Parallelization with `pmap`"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4PN9M-RyGJJF",
+        "colab_type": "text"
+      },
+      "source": [
+        "Suppose you want to run your computations on multiple XLA accelerators—GPUs or TPUs. JAX has an API for that called [pmap()](https://jax.readthedocs.io/en/latest/jax.html#jax.pmap) that lets you write single-program multiple-data (SPMD) programs. Google Cloud TPU pods are multi-host platforms and you can utilize them with this transform.\n",
+        "\n",
+        "Similar to `jit`, when you apply `pmap` to a function, you compile with XLA. Then, you execute it in parallel on multiple devices.\n",
+        "\n",
+        "Like `vmap`, this transform maps a function over array axes. But, unlike `vmap`, `pmap` replicates the function and executes each replica on its own XLA device in parallel. \n",
+        "\n",
+        "The transform also allows you to use all-reduce sum and other parallel SPMD collective operations."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TFAQqLfVGL4H",
+        "colab_type": "text"
+      },
+      "source": [
+        "### Enable Cloud TPUs in Google Colab"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "TttxraN5GMXF",
+        "colab_type": "text"
+      },
+      "source": [
+        "To take advantage of JAX's `pmap`, you'll be using Cloud TPUs in Google Colab:\n",
+        "\n",
+        "- Change your Google Colab runtime by clicking **Edit** > **Notebook settings**\n",
+        "- Select **Hardware acceleration: TPU**\n",
+        "- If it says \"Unable to connect to the runtime\", click on the **Reconnect** button in the top right corner and wait until it has a green check mark (✓)\n",
+        "\n",
+        "Then, run the cell below to further configure the TPU support:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "lI1x7ol_GUnr",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Run this cell inside Google Colab with TPUs enabled\n",
+        "import requests\n",
+        "import os\n",
+        "\n",
+        "# Import JAX libraries again, just in case (runtime switching resets the state)\n",
+        "import jax\n",
+        "import jax.numpy as jnp\n",
+        "from jax import grad, jit, vmap, pmap, random\n",
+        "\n",
+        "if 'TPU_DRIVER_MODE' not in globals():\n",
+        "  url = 'http://' + os.environ['COLAB_TPU_ADDR'].split(':')[0] + ':8475/requestversion/tpu_driver0.1-dev20191206'\n",
+        "  resp = requests.post(url)\n",
+        "  TPU_DRIVER_MODE = 1\n",
+        "\n",
+        "# This is required to use TPU Driver as JAX's backend\n",
+        "from jax.config import config\n",
+        "config.FLAGS.jax_xla_backend = \"tpu_driver\"\n",
+        "config.FLAGS.jax_backend_target = \"grpc://\" + os.environ['COLAB_TPU_ADDR']\n",
+        "print(config.FLAGS.jax_backend_target)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "AoJbFTqtGl2k",
+        "colab_type": "text"
+      },
+      "source": [
+        "Your output should have the Colab TPU IP address (gRPC) and port number."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f10Tw5PZGoKG",
+        "colab_type": "text"
+      },
+      "source": [
+        "- To list available devices for the backend, use [jax.devices()](https://jax.readthedocs.io/en/latest/jax.html#jax.devices):"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "XnqzwBcgGp7f",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "jax.devices"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pwhHa4LrGsmN",
+        "colab_type": "text"
+      },
+      "source": [
+        "(The default backend is 'gpu' or 'tpu', if available. Otherwise it's 'cpu'.)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ewx4DCImGxMf",
+        "colab_type": "text"
+      },
+      "source": [
+        "Let's go over some `pmap` examples.\n",
+        "\n",
+        "- For a number of XLA devices available (e.g. 8), you can use `pmap` to map along a leading array axis:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "GCVRSahjG2mI",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "y = pmap(lambda x: x ** 2)(jnp.arange(8))\n",
+        "\n",
+        "print(y)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9tpdh-ehG4he",
+        "colab_type": "text"
+      },
+      "source": [
+        "- Run a dot product multiply on several devices:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "yASda37nG6Jr",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Create a PRNG key and split it into 8 new ones\n",
+        "keys = random.split(random.PRNGKey(0), 8)\n",
+        "\n",
+        "# Complile a new 5000x5000 matrix with `pmap`\n",
+        "size = 5000\n",
+        "matrices = pmap(lambda key: random.normal(key, (size, size)))(keys)\n",
+        "\n",
+        "# Run the dot product of two matrices in parallel on XLA accelerators\n",
+        "result = pmap(jnp.dot)(matrices, matrices)\n",
+        "\n",
+        "# Return the mean of the result and show the output\n",
+        "print(pmap(jnp.mean)(result))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i2H12vPQG8HO",
+        "colab_type": "text"
+      },
+      "source": [
+        "- Measure the compute time:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "F3yYESbEG8gL",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "timeit -n 5 -r 5 pmap(jnp.dot)(matrices, matrices).block_until_ready()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "_nOu6JrxHA2q",
+        "colab_type": "text"
+      },
+      "source": [
+        "- Compose autodiff (`grad`) with `pmap`:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "E7NjrJabHDNf",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Define an arbitrary array and reshape it\n",
+        "x = jnp.arange(8.).reshape((4, 2))\n",
+        "\n",
+        "# Apply the @pmap decorator to run calculations across devices\n",
+        "@pmap\n",
+        "def f(x):\n",
+        "  y = jnp.sin(x)\n",
+        "  @pmap\n",
+        "  def g(z):\n",
+        "    return jnp.cos(z) * jnp.tan(y.sum()) * jnp.tanh(x).sum()\n",
+        "  # Call `grad`!\n",
+        "  return grad(lambda w: jnp.sum(g(w)))(x)\n",
+        "\n",
+        "f(x)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XMIC2JUYHFn7",
+        "colab_type": "text"
+      },
+      "source": [
+        "The code here is simple. For a neural network example where you can do some data-parallel neural network training, check out [the SPMD MNIST example](https://github.com/google/jax/blob/master/examples/spmd_mnist_classifier_fromscratch.py) or the much more capable [Trax library](https://github.com/google/trax/)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "WwNnjaI4th_8",
         "colab_type": "text"
       },
@@ -526,22 +798,5 @@
         "This is just a taste of what JAX can do. We're really excited to see what you do with it!"
       ]
     }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "JAX Quickstart.ipynb",
-      "version": "0.3.2",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "accelerator": "GPU"
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }


### PR DESCRIPTION
PR ref: https://github.com/google/jax/issues/3458

- Added a section covering `pmap` (using accelerators in parallel) with the material from @skye NeurIPS 2019 demo, main JAX GitHub README, `pmap` API docs
- Added annotation to code examples to help new users
- Added that JAX is a system for general numerical computing, since it's not just for machine learning research (ref: NeurIPS 2019 demo)
- Expanded the Hessian example for the vectorized map (`vmap`) - please check if it's fine
- Added more info on the fwd/reverse-mode Jacobian matrices, using The Autodiff Cookbook as a reference (also fixed two small links in that notebook as a result)
- Changed importing JAX NumPy to `as jnp` instead of `np` in line with other examples (we have ordinary NumPy as `onp`, so it may be confusing otherwise for new users)
- Mentioned, just in case, that `vmap` is a lot like a regular Python `map` (but...)
- Added links to source code/APIs (e.g. `device_put`, `vjp`, `@jit` etc etc
- Expanded the intro, some other paragraphs included a small "table of contents" thing
- Added that "JAX is fast, easy to use, and uses a functional programming model..."
- Added more info about JIT (almost no handwritten kernels, you get almost "eager-mode" performance)
- Added a sentence about how user-friendly the API is ("pass a function into a transform and get a function out...")
- Made other minor changes using Google's doc style guide (addressing the user as "you" instead of "we", and other stuff)

Most of these are just UX improvement suggestions. Feel free to rip them apart/propose new changes/propose to keep the old stuff.

cc @mattjj @shoyer

Thanks for your work 👍