### PR TITLE
Add np.unwrap

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -56,7 +56,7 @@ from .lax_numpy import (
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,
     triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,
-    unpackbits, unravel_index, unsignedinteger, vander, var, vdot, vsplit,
+    unpackbits, unravel_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
     vstack, where, zeros, zeros_like)
 
 from .polynomial import roots

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1844,6 +1844,22 @@ nancumprod = _make_cumulative_reduction(np.nancumprod, lax.cumprod,
                                         fill_nan=True, fill_value=1)
 
 
+@_wraps(np.unwrap)
+def unwrap(p, discont=pi, axis=-1):
+  dd = diff(p, axis=axis)
+  ddmod = mod(dd + pi, 2 * pi) - pi
+  ddmod = where(isclose(ddmod, -pi) & (dd > 0), pi, ddmod)
+
+  ph_correct = where(abs(dd) < discont, 0, ddmod - dd)
+
+  up = concatenate((
+    lax.slice_in_dim(p, 0, 1, axis=axis),
+    lax.slice_in_dim(p, 1, None, axis=axis) + cumsum(ph_correct, axis=axis)
+  ), axis=axis)
+
+  return up
+
+
 ### Array-creation functions
 
 def _check_no_padding(axis_padding, mode):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1848,7 +1848,7 @@ nancumprod = _make_cumulative_reduction(np.nancumprod, lax.cumprod,
 def unwrap(p, discont=pi, axis=-1):
   dd = diff(p, axis=axis)
   ddmod = mod(dd + pi, 2 * pi) - pi
-  ddmod = where(isclose(ddmod, -pi) & (dd > 0), pi, ddmod)
+  ddmod = where((ddmod == -pi) & (dd > 0), pi, ddmod)
 
   ph_correct = where(abs(dd) < discont, 0, ddmod - dd)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -262,8 +262,8 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("ediff1d", 3, [np.int32], all_shapes, jtu.rand_default, []),
     op_record("unwrap", 1, float_dtypes, nonempty_nonscalar_array_shapes,
               jtu.rand_default, ["rev"],
-              # numpy.unwrap always returns float64 
-              check_dtypes=False, 
+              # numpy.unwrap always returns float64
+              check_dtypes=False,
               # numpy cumsum is inaccurate, see issue #3517
               tolerance={dtypes.bfloat16: 1e-1, np.float16: 1e-1})
 ]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -260,6 +260,12 @@ JAX_COMPOUND_OP_RECORDS = [
               ["rev"], inexact=True),
     op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
     op_record("ediff1d", 3, [np.int32], all_shapes, jtu.rand_default, []),
+    op_record("unwrap", 1, float_dtypes, nonempty_nonscalar_array_shapes,
+              jtu.rand_default, ["rev"],
+              # numpy.unwrap always returns float64 
+              check_dtypes=False, 
+              # numpy cumsum is inaccurate, see issue #3517
+              tolerance={dtypes.bfloat16: 1e-1, np.float16: 1e-1})
 ]
 
 JAX_BITWISE_OP_RECORDS = [


### PR DESCRIPTION
Concerning the test, see issue https://github.com/google/jax/issues/3517 for discussion of accuracy differences between jax and numpy. In this case, numpy seems to be the more inexact one.
For the small test shapes of `nonempty_nonscalar_array_shapes`, the inaccuracy of cumsum is only a problem for float16. 

Apart from that, should I write a custom test

* testing for larger arrays?
* varying also the `discont` and `axis` parameters?

I disregarded the latter, as the test of `np.diff` also doesn't seem to vary `axis`.

Looking forward to your insights!