### PR TITLE
WIP: Print JAX arrays to full precision

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -940,6 +940,7 @@ class DeviceValue(object):
     return self
 
 def _forward_method(attrname, self, fun, *args):
+  print(attrname,fun,*args)
   return fun(getattr(self, attrname), *args)
 _forward_to_value = partial(_forward_method, "_value")
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3835,6 +3835,13 @@ class NumpyGradTests(jtu.JaxTestCase):
 
     check_grads(f, (1.,), order=1)
 
+  def testSetPrintOptions(self):
+    np.set_printoptions(floatmode="unique")
+    jnp.set_printoptions(floatmode="unique")
+    y = str(np.array(0.2 + 0.1))
+    z = str(jnp.array(0.2 + 0.1))
+
+    self.assertEqual(y,z)
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Hi! I made an attempt to implement print of JAX arrays to full precision using `jax.numpy.set_printoptions` as described in #3438. Now I am trying to figure out how to test the function. I have seen [some options](https://stackoverflow.com/questions/33767627/python-write-unittest-for-console-print) but they don't seem very adequate;