### PR TITLE
add back a full_lower, dropped in #3491

### DIFF
--- a/jax/interpreters/invertible_ad.py
+++ b/jax/interpreters/invertible_ad.py
@@ -64,9 +64,6 @@ def _invertible_call_make_output_tracers(trace, in_tracers, out_tracers, params)
 pe.call_partial_eval_rules[invertible_call_p] = partial(
     pe._remat_partial_eval, _invertible_call_make_output_tracers)
 
-# TODO(mattjj): remove this when #3370 lands
-core.skip_check_primitives.add(invertible_call_p)
-
 @cache()
 def _append_invars(jaxpr, avals):
   newvar = core.gensym([jaxpr])


### PR DESCRIPTION
Fixes the one mysterious issue that popped up in #3491. Uncovered by an internal test that exercised a weird edge case (jitted functions returning compile-time-constant strings).