### PR TITLE
Fix lazy broadcast issue

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2776,7 +2776,8 @@ ad.deflinear(broadcast_p, lambda t, sizes: [_reduce_sum(t, range(len(sizes)))])
 batching.primitive_batchers[broadcast_p] = _broadcast_batch_rule
 
 def _broadcast_in_dim_impl(operand, *, shape, broadcast_dimensions):
-  if type(operand) is xla.DeviceArray:
+  if type(operand) is xla.DeviceArray and onp.all(
+      onp.equal(operand.shape, onp.take(shape, broadcast_dimensions))):
     shape = _broadcast_in_dim_shape_rule(
       operand, shape=shape, broadcast_dimensions=broadcast_dimensions)
     aval = ShapedArray(shape, _dtype(operand))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1787,6 +1787,13 @@ class LazyConstantTest(jtu.JaxTestCase):
     expected = onp.asarray(make_const())
     self._Check(make_const, expected)
 
+  def testBroadcastInDim(self):
+    arr = lax.full((2, 1), 1.) + 1.
+    arr_onp = onp.full((2, 1), 1.) + 1.
+    expected = lax_reference.broadcast_in_dim(arr_onp, (2, 1, 3), (0, 2))
+    make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
+    self._Check(make_const, expected)
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Lazy expression broadcast doesn't support broadcasting a size 1 dim to a size n dim, it only supports broadcasting to a new dimension of size n.