### PR TITLE
Fixed issue with the 'compress' method of 'jnp.ndarray'

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4248,7 +4248,7 @@ _operators = {
 # These numpy.ndarray methods are just refs to an equivalent numpy function
 _nondiff_methods = ["all", "any", "argmax", "argmin", "argpartition", "argsort",
                     "nonzero", "searchsorted", "round"]
-_diff_methods = ["clip", "compress", "conj", "conjugate", "cumprod", "cumsum",
+_diff_methods = ["clip", "conj", "conjugate", "cumprod", "cumsum",
                  "diagonal", "dot", "max", "mean", "min", "prod", "ptp",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
                  "swapaxes", "take", "tile", "trace", "transpose", "var"]
@@ -4298,6 +4298,12 @@ setattr(ShapedArray, "split", core.aval_method(split))
 setattr(DeviceArray, "broadcast", lax.broadcast)
 setattr(DeviceArray, "broadcast_in_dim", lax.broadcast_in_dim)
 setattr(DeviceArray, "split", split)
+
+def _compress_method(a, condition, axis=None, out=None):
+  return compress(condition, a, axis, out)
+
+setattr(ShapedArray, "compress", _compress_method)
+setattr(DeviceArray, "compress", _compress_method)
 
 @partial(jit, static_argnums=(1,2,3))
 def _multi_slice(arr: DeviceArray,


### PR DESCRIPTION
The `compress` method of `jnp.ndarray` appears to be behaving differently than the free function `jax.numpy.compress`:

```python
m = jax.numpy.array([5, 8, 0, 0,
                     0, 0, 0, 0,
                     0, 0, 3, 0,
                     0, 6, 0, 0])
m.compress((m != 0).flatten())
>>> DeviceArray([ True,  True,  True,  True], dtype=bool)
jax.numpy.compress((m != 0).flatten(), m)
>>> DeviceArray([5, 8, 3, 6], dtype=int32)
```