### PR TITLE
Fix eigh JVP to ensure that both the primal and tangents of the eigen…

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -265,10 +265,10 @@ def eigh_jvp_rule(primals, tangents, lower):
   a, = primals
   a_dot, = tangents
 
-  v, w = eigh_p.bind(symmetrize(a), lower=lower)
+  v, w_real = eigh_p.bind(symmetrize(a), lower=lower)
 
   # for complex numbers we need eigenvalues to be full dtype of v, a:
-  w = w.astype(a.dtype)
+  w = w_real.astype(a.dtype)
   eye_n = jnp.eye(a.shape[-1], dtype=a.dtype)
   # carefully build reciprocal delta-eigenvalue matrix, avoiding NaNs.
   Fmat = jnp.reciprocal(eye_n + w[..., jnp.newaxis, :] - w[..., jnp.newaxis]) - eye_n
@@ -277,8 +277,8 @@ def eigh_jvp_rule(primals, tangents, lower):
                 precision=lax.Precision.HIGHEST)
   vdag_adot_v = dot(dot(_H(v), a_dot), v)
   dv = dot(v, jnp.multiply(Fmat, vdag_adot_v))
-  dw = jnp.diagonal(vdag_adot_v, axis1=-2, axis2=-1)
-  return (v, w), (dv, dw)
+  dw = jnp.real(jnp.diagonal(vdag_adot_v, axis1=-2, axis2=-1))
+  return (v, w_real), (dv, dw)
 
 def eigh_batching_rule(batched_args, batch_dims, lower):
   x, = batched_args

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -418,7 +418,7 @@ class IndexingTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     tol = 1e-2 if jnp.finfo(dtype).bits == 32 else None
     arg = rng(shape, dtype)
-    fun = lambda x: x[indexer]**2
+    fun = lambda x: jnp.asarray(x)[indexer]**2
     check_grads(fun, (arg,), 2, tol, tol, tol)
 
   def _ReplaceSlicesWithTuples(self, idx):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -405,6 +405,8 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     # evaluate eigenvector gradient and groundtruth eigensystem for perturbed input matrix
     f = partial(jnp.linalg.eigh, UPLO=uplo)
     (w, v), (dw, dv) = jvp(f, primals=(a,), tangents=(a_dot,))
+    self.assertTrue(jnp.issubdtype(w.dtype, jnp.floating))
+    self.assertTrue(jnp.issubdtype(dw.dtype, jnp.floating))
     new_a = a + a_dot
     new_w, new_v = f(new_a)
     new_a = (new_a + np.conj(new_a.T)) / 2


### PR DESCRIPTION
…values are real.

Add test to jax.test_util.check_jvp that ensure the primals and both the primals and tangents produced by a JVP rule have identical types.

Fixes #2325