### PR TITLE
sketch out all-gather primitive

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1179,7 +1179,7 @@ def _xla_unshard(c, aval, axis_env, x, backend):
     xla_shape = c.get_shape(x)
     dims = list(xla_shape.dimensions())
     padded = xops.Broadcast(xb.constant(c, onp.array(0, xla_shape.numpy_dtype())),
-                         [axis_env.sizes[-1]] + dims)
+                            [axis_env.sizes[-1]] + dims)
     zero = xb.constant(c, onp.zeros((), dtype=onp.uint32))
     idxs = [_unravel_index(c, axis_env)] + [zero] * len(dims)
     padded = xops.DynamicUpdateSlice(padded, xops.Reshape(x, [1] + dims), idxs)

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -489,7 +489,7 @@ def _all_gather_translation_rule(c, x, *, all_gather_dimension, axis_size,
   x_singleton = xops.BroadcastInDim(x, new_shape, broadcast_dimensions)
   return xops.AllGather(x_singleton, all_gather_dimension=all_gather_dimension,
                         shard_count=axis_size,
-                        replica_groups=replica_groups)
+                        replica_groups=xc.make_replica_groups(replica_groups))
 
 def _all_gather_abstract_eval(x, *, all_gather_dimension, axis_size, axis_name):
   shape, dtype = x.shape, x.dtype


### PR DESCRIPTION
We need:
1. either to gate this new version on jaxlib version, or else to push new jaxlib wheels and bump the minimum version;
2. to wait for #3370 's improvements to axis_index to make the transpose rule work; and
3. to handle pytrees.