### PR TITLE
jaxpr typechecking: custom rules and errors

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1024,21 +1024,60 @@ def _cond_transpose(cts, *args, branches, linear):
   assert next(out_iter, None) is None
   return [None] + out
 
+def _avals_short(avals):
+  to_str = lambda aval: getattr(aval, 'str_short', partial(str, aval))()
+  return ' '.join(_map(to_str, avals))
+
+def _cond_typecheck(*avals, branches, linear):
+  core.typecheck_assert(
+      len(branches) > 0,
+      'cond requires at least one branch function')
+  core.typecheck_assert(
+      len(linear) + 1 == len(avals),
+      f'cond called with {len(linear)} linear flags for '
+      f'{len(avals) - 1} non-predicate operands')
+
+  jaxpr0 = branches[0]
+  jaxpr0_in_avals_str = _avals_short(jaxpr0.in_avals)
+  jaxpr0_out_avals_str = _avals_short(jaxpr0.out_avals)
+
+  for i, jaxpr in enumerate(branches[1:]):
+    core.typecheck_assert(
+        len(jaxpr0.in_avals) == len(jaxpr.in_avals),
+        f'cond branch 0 takes {len(jaxpr0.in_avals)} inputs, '
+        f'branch {i+1} takes {len(jaxpr.in_avals)}')
+    core.typecheck_assert(
+        len(jaxpr0.out_avals) == len(jaxpr.out_avals),
+        f'cond branch 0 outputs {len(jaxpr0.out_avals)} values, '
+        f'branch {i+1} outputs {len(jaxpr.out_avals)}')
+    core.typecheck_assert(
+        all(_map(core.typematch, jaxpr0.in_avals, jaxpr.in_avals)),
+        f'cond branches 0 and {i+1} have mismatching input types: '
+        f'{jaxpr0_in_avals_str} vs {_avals_short(jaxpr.in_avals)}')
+    core.typecheck_assert(
+        all(_map(core.typematch, jaxpr0.out_avals, jaxpr.out_avals)),
+        f'cond branches 0 and {i+1} have mismatching output types: '
+        f'{jaxpr0_out_avals_str} vs {_avals_short(jaxpr.out_avals)}')
+
+  core.typecheck_assert(
+      len(avals) == 1 + len(jaxpr0.in_avals),
+      f'cond called with {len(avals) - 1} non-predicate operands, '
+      f'but branches take {len(jaxpr0.in_avals)} inputs')
+
+  index_aval, *op_avals = avals
+  core.typecheck_assert(
+      index_aval.dtype == onp.int32,
+      f'cond called with index of type {index_aval.dtype} instead of int32')
+  core.typecheck_assert(
+      all(_map(core.typecompat, jaxpr0.in_avals, op_avals)),
+      f'cond branches take input types {jaxpr0_in_avals_str}, '
+      f'called with operands of type {_avals_short(op_avals)}')
+
 def cond_bind(*args, branches, linear):
   if not core.skip_checks:
-    assert len(branches) > 0
-    assert len(linear) + 1 == len(args)
-    assert len(args) == 1 + len(branches[0].in_avals)
-    jaxpr0 = branches[0]
-    for jaxpr in branches[1:]:
-      assert len(jaxpr0.in_avals) == len(jaxpr.in_avals)
-      assert len(jaxpr0.out_avals) == len(jaxpr.out_avals)
-      assert all(_map(typematch, jaxpr0.in_avals, jaxpr.in_avals))
-      assert all(_map(typematch, jaxpr0.out_avals, jaxpr.out_avals))
-    index, *ops = args
-    assert dtypes.result_type(index) == onp.int32
+    avals = _map(core.get_aval, args)
+    _cond_typecheck(*avals, branches=branches, linear=linear)
     for jaxpr in branches:
-      assert all(_map(typecheck, jaxpr.in_avals, ops))
       core.check_jaxpr(jaxpr.jaxpr)
   return core.Primitive.bind(cond_p, *args, branches=branches, linear=linear)
 
@@ -1052,6 +1091,7 @@ ad.primitive_transposes[cond_p] = _cond_transpose
 pe.custom_partial_eval_rules[cond_p] = _cond_partial_eval
 batching.primitive_batchers[cond_p] = _cond_batching_rule
 xla.initial_style_translations[cond_p] = _cond_translation_rule
+core.custom_typechecks[cond_p] = _cond_typecheck
 
 
 ### scan
@@ -1543,19 +1583,41 @@ def _masked_scan_jaxpr(jaxpr, num_consts, num_carry):
   const_avals, carry_avals, x_avals = split_list(jaxpr.in_avals, [num_consts, num_carry])
   return _make_typed_jaxpr(masked, [aval] + const_avals + [aval] + carry_avals + x_avals)
 
-def scan_bind(*args, reverse, length, num_consts, num_carry, jaxpr, linear):
+def _scan_typecheck(*avals, reverse, length, num_consts, num_carry, jaxpr,
+                    linear):
+  core.typecheck_assert(
+      len(linear) == len(avals),
+      f'scan called with {len(linear)} linear flags for {len(avals)} operands')
+
+  const_avals, init_avals, x_avals = split_list(avals, [num_consts, num_carry])
+  const_avals_jaxpr, init_avals_jaxpr, x_avals_jaxpr = split_list(
+      jaxpr.in_avals, [num_consts, num_carry])
+  carry_avals_jaxpr, _ = split_list(jaxpr.out_avals, [num_carry])
+  x_avals_mapped = _map(partial(core.mapped_aval, length), x_avals)
+
+  core.typecheck_assert(
+      all(_map(core.typematch, init_avals_jaxpr, carry_avals_jaxpr)),
+      f'scan input carry input and output types mismatch: '
+      f'{_avals_short(init_avals_jaxpr)} vs {_avals_short(carry_avals_jaxpr)}')
+  core.typecheck_assert(
+      all(_map(core.typecompat, const_avals_jaxpr, const_avals)),
+      f'scan jaxpr takes input const types {_avals_short(const_avals_jaxpr)}, '
+      f'called with consts of type {_avals_short(const_avals)}')
+  core.typecheck_assert(
+      all(_map(core.typecompat, init_avals_jaxpr, init_avals)),
+      f'scan jaxpr takes input carry types {_avals_short(init_avals_jaxpr)}, '
+      f'called with initial carry of type {_avals_short(init_avals)}')
+  core.typecheck_assert(
+      all(_map(core.typecompat, x_avals_jaxpr, x_avals_mapped)),
+      f'scan jaxpr takes input sequence types {_avals_short(x_avals_jaxpr)}, '
+      f'called with sequence of type {_avals_short(x_avals)}')
+
+def scan_bind(*args, **params):
   if not core.skip_checks:
-    assert len(linear) == len(args)
-    consts, init, xs = split_list(args, [num_consts, num_carry])
-    consts_avals, init_avals, x_avals = split_list(jaxpr.in_avals, [num_consts, num_carry])
-    assert all(_map(typecheck, consts_avals, consts)), (consts, consts_avals)
-    assert all(_map(typecheck, init_avals, init))
-    carry_avals, _ = split_list(jaxpr.out_avals, [num_carry])
-    assert all(_map(typematch, init_avals, carry_avals))
-    core.check_jaxpr(jaxpr.jaxpr)
-  return core.Primitive.bind(scan_p, *args, reverse=reverse, length=length,
-                             jaxpr=jaxpr, num_consts=num_consts,
-                             num_carry=num_carry, linear=linear)
+    avals = _map(core.get_aval, args)
+    _scan_typecheck(*avals, **params)
+    core.check_jaxpr(params['jaxpr'].jaxpr)
+  return core.Primitive.bind(scan_p, *args, **params)
 
 scan_p = core.Primitive("scan")
 scan_p.multiple_results = True
@@ -1570,6 +1632,7 @@ xla.initial_style_translations[scan_p] = \
     xla.lower_fun_initial_style(_scan_impl)
 batching.primitive_batchers[scan_p] = _scan_batching_rule
 masking.masking_rules[scan_p] = _scan_masking_rule
+core.custom_typechecks[scan_p] = _scan_typecheck
 
 
 def map(f, xs):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -329,17 +329,19 @@ class CoreTest(jtu.JaxTestCase):
 
     jaxpr = new_jaxpr()
     jaxpr.eqns[0].outvars[0].aval = make_shaped_array(2)   # int, not float!
-    jtu.check_raises_regexp(
-        lambda: core.check_jaxpr(jaxpr),
-        TypeError, (r"Variable '.' inconsistently typed as ShapedArray(.*), "
-                    r"bound as ShapedArray(.*) in '. = sin .'"))
+    self.assertRaisesRegex(
+        core.JaxprTypeError,
+        r"Variable '.' inconsistently typed as ShapedArray(.*), "
+        r"bound as ShapedArray(.*)\n\nin equation:\n\n  . = sin .",
+        lambda: core.check_jaxpr(jaxpr))
 
     jaxpr = new_jaxpr()
     jaxpr.eqns[0].outvars[0].aval = make_shaped_array(np.ones((2, 3)))
-    jtu.check_raises_regexp(
-        lambda: core.check_jaxpr(jaxpr),
-        TypeError, (r"Variable '.' inconsistently typed as ShapedArray(.*), "
-                    r"bound as ShapedArray(.*) in '. = sin .'"))
+    self.assertRaisesRegex(
+        core.JaxprTypeError,
+        r"Variable '.' inconsistently typed as ShapedArray(.*), "
+        r"bound as ShapedArray(.*)\n\nin equation:\n\n  . = sin .",
+        lambda: core.check_jaxpr(jaxpr))
 
   def test_jaxpr_dropvar_from_jit_call(self):
     def inner(x):


### PR DESCRIPTION
Regarding errors, this PR introduces an exception type specific to the jaxpr typechecker, so that we can distinguish between errors detected by the typechecker vs. errors in the typechecker itself. When reporting a typechecker-detected error, messages are now always accompanied by a jaxpr equation and jaxpr for context.

Regarding typechecking rules: the jaxpr checker calls abstract evaluation rules to transfer types across jaxpr equations. Some primitives have more to check internally. This PR introduces a `custom_typechecks` table for those primitives and populates it for `cond` and `scan`. Both were previously issuing checks at bind time. Doing so was (a) redundant, and (b) not guaranteed to precede the typechecker's abstract evaluation, which may depend on those checks for correctness. Either way, typechecks should happen at typechecking time only.

While moving `cond` and `scan`'s checks over, I also gave them error messages, and I added a few more checks.