### PR TITLE
Refactor tests to define common functionality in test_util

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -30,25 +30,6 @@ import numpy as np
 
 FLAGS = config.FLAGS
 
-# TODO: these are copied from tests/lax_test.py (make this source of truth)
-# Do not run int64 tests unless FLAGS.jax_enable_x64, otherwise we get a
-# mix of int32 and int64 operations.
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if
-          t in jtu.supported_dtypes() and
-          (FLAGS.jax_enable_x64 or np.dtype(t).itemsize != 8)]
-
-float_dtypes = supported_dtypes([dtypes.bfloat16, np.float16, np.float32,
-                                 np.float64])
-complex_elem_dtypes = supported_dtypes([np.float32, np.float64])
-complex_dtypes = supported_dtypes([np.complex64, np.complex128])
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([np.int8, np.int16, np.int32, np.int64])
-uint_dtypes = supported_dtypes([np.uint8, np.uint16, np.uint32, np.uint64])
-bool_dtypes = [np.bool_]
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
-
 Rng = Any  # A random number generator
 
 class RandArg(NamedTuple):
@@ -147,7 +128,7 @@ lax_pad = jtu.cases_from_list(
           rng_factory=jtu.rand_small,
           arg_shape=arg_shape, dtype=dtype, pads=pads)
   for arg_shape in [(2, 3)]
-  for dtype in default_dtypes
+  for dtype in jtu.default_dtypes
   for pads in [
     [(0, 0, 0), (0, 0, 0)],  # no padding
     [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
@@ -231,7 +212,7 @@ lax_squeeze = jtu.cases_from_list(
 
 shift_inputs = [
   (arg, dtype, shift_amount)
-  for dtype in supported_dtypes(uint_dtypes + int_dtypes)
+  for dtype in (jtu.uint_dtypes + jtu.int_dtypes)
   for arg in [
     np.array([-250, -1, 0, 1, 250], dtype=dtype),
   ]

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -23,7 +23,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, NamedTuple, Sequence
 from absl import testing
 from jax import config
 from jax import test_util as jtu
-from jax import dtypes
 from jax import lax
 
 import numpy as np

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -349,6 +349,7 @@ def supported_dtypes():
 def _supported(dtypes):
   return [t for t in dtypes if t in supported_dtypes()]
 
+basic_float_dtypes = _supported([np.float32, np.float64])
 float_dtypes = _supported([dtypes.bfloat16, np.float16, np.float32, np.float64])
 complex_elem_dtypes = _supported([np.float32, np.float64])
 complex_dtypes = _supported([np.complex64, np.complex128])

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -188,6 +188,10 @@ def rand_like(rng, x):
     return randn()
 
 
+def num_float_bits(dtype):
+  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
+
+
 def numerical_jvp(f, primals, tangents, eps=EPS):
   delta = scalar_mul(tangents, eps)
   f_pos = f(*add(primals, delta))

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -335,13 +335,34 @@ def if_device_under_test(device_type: Union[str, Sequence[str]],
 
 def supported_dtypes():
   if device_under_test() == "tpu":
-    return {np.bool_, np.int32, np.uint32, dtypes.bfloat16, np.float32,
-            np.complex64}
+    types = {np.bool_, np.int32, np.uint32, dtypes.bfloat16, np.float32,
+             np.complex64}
   else:
-    return {np.bool_, np.int8, np.int16, np.int32, np.int64,
-            np.uint8, np.uint16, np.uint32, np.uint64,
-            dtypes.bfloat16, np.float16, np.float32, np.float64,
-            np.complex64, np.complex128}
+    types = {np.bool_, np.int8, np.int16, np.int32, np.int64,
+             np.uint8, np.uint16, np.uint32, np.uint64,
+             dtypes.bfloat16, np.float16, np.float32, np.float64,
+             np.complex64, np.complex128}
+  if not FLAGS.jax_enable_x64:
+    types -= {np.uint64, np.int64, np.float64, np.complex128}
+  return types
+
+def _supported(dtypes):
+  return [t for t in dtypes if t in supported_dtypes()]
+
+float_dtypes = _supported([dtypes.bfloat16, np.float16, np.float32, np.float64])
+complex_elem_dtypes = _supported([np.float32, np.float64])
+complex_dtypes = _supported([np.complex64, np.complex128])
+inexact_dtypes = float_dtypes + complex_dtypes
+int_dtypes = _supported([np.int32, np.int64])
+all_int_dtypes = _supported([np.int8, np.int16, np.int32, np.int64])
+uint_dtypes = _supported([np.uint32, np.uint64])
+all_uint_dtypes = _supported([np.uint8, np.uint16, np.uint32, np.uint64])
+bool_dtypes = _supported([np.bool_])
+default_dtypes = float_dtypes + int_dtypes
+real_dtypes = float_dtypes + int_dtypes + uint_dtypes
+number_dtypes = float_dtypes + complex_dtypes + int_dtypes
+all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+python_scalar_dtypes = [np.bool_, np.int_, np.float_, np.complex_]
 
 def skip_if_unsupported_type(dtype):
   if dtype not in supported_dtypes():

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -88,7 +88,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
       for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
       for axes in _get_fftn_test_axes(shape)))
   def testFftn(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -144,7 +144,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
       for shape in [(10,)]
       for axis in [-1, 0]))
   def testFft(self, inverse, real, shape, dtype, axis, rng_factory):
@@ -205,7 +205,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
       for shape in [(16, 8, 4, 8), (16, 8, 4, 8, 4)]
       for axes in [(-2, -1), (0, 1), (1, 3), (-1, 2)]))
   def testFft2(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -259,7 +259,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.int_dtypes
+    for dtype in jtu.all_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testFftfreq(self, size, d, dtype, rng_factory):
@@ -303,7 +303,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.int_dtypes
+    for dtype in jtu.all_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testRfftfreq(self, size, d, dtype, rng_factory):
@@ -347,7 +347,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.int_dtypes
+    for dtype in jtu.all_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testFftshift(self, shape, dtype, rng_factory, axes):
@@ -362,7 +362,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.int_dtypes
+    for dtype in jtu.all_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testIfftshift(self, shape, dtype, rng_factory, axes):

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -30,6 +30,11 @@ config.parse_flags_with_absl()
 
 FLAGS = flags.FLAGS
 
+float_dtypes = jtu.basic_float_dtypes
+inexact_dtypes = float_dtypes + jtu.complex_dtypes
+real_dtypes = float_dtypes + jtu.int_dtypes + jtu.bool_dtypes
+all_dtypes = real_dtypes + jtu.complex_dtypes
+
 
 def _get_fftn_test_axes(shape):
   axes = [[]]
@@ -88,7 +93,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
+      for dtype in (real_dtypes if real and not inverse else all_dtypes)
       for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
       for axes in _get_fftn_test_axes(shape)))
   def testFftn(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -104,7 +109,7 @@ class FftTest(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
     if (FLAGS.jax_enable_x64 and
-        dtype in (jtu.float_dtypes if real and not inverse else jtu.inexact_dtypes)):
+        dtype in (float_dtypes if real and not inverse else inexact_dtypes)):
       # TODO(skye): can we be more precise?
       tol = 0.15
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
@@ -144,7 +149,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
+      for dtype in (real_dtypes if real and not inverse else all_dtypes)
       for shape in [(10,)]
       for axis in [-1, 0]))
   def testFft(self, inverse, real, shape, dtype, axis, rng_factory):
@@ -205,7 +210,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (jtu.real_dtypes if real and not inverse else jtu.all_dtypes)
+      for dtype in (real_dtypes if real and not inverse else all_dtypes)
       for shape in [(16, 8, 4, 8), (16, 8, 4, 8, 4)]
       for axes in [(-2, -1), (0, 1), (1, 3), (-1, 2)]))
   def testFft2(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -259,7 +264,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.all_dtypes
+    for dtype in all_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testFftfreq(self, size, d, dtype, rng_factory):
@@ -274,7 +279,7 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if dtype in jtu.inexact_dtypes:
+    if dtype in inexact_dtypes:
       tol = 0.15  # TODO(skye): can we be more precise?
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
 
@@ -303,7 +308,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.all_dtypes
+    for dtype in all_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testRfftfreq(self, size, d, dtype, rng_factory):
@@ -318,7 +323,7 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if dtype in jtu.inexact_dtypes:
+    if dtype in inexact_dtypes:
       tol = 0.15  # TODO(skye): can we be more precise?
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
 
@@ -347,7 +352,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.all_dtypes
+    for dtype in all_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testFftshift(self, shape, dtype, rng_factory, axes):
@@ -362,7 +367,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in jtu.all_dtypes
+    for dtype in all_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testIfftshift(self, shape, dtype, rng_factory, axes):

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -30,14 +30,6 @@ config.parse_flags_with_absl()
 
 FLAGS = flags.FLAGS
 
-float_dtypes = [np.float32, np.float64]
-complex_dtypes = [np.complex64, np.complex128]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [np.int32, np.int64]
-bool_dtypes = [np.bool_]
-real_dtypes = float_dtypes + int_dtypes + bool_dtypes
-all_dtypes = real_dtypes + complex_dtypes
-
 
 def _get_fftn_test_axes(shape):
   axes = [[]]
@@ -96,7 +88,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (real_dtypes if real and not inverse else all_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
       for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
       for axes in _get_fftn_test_axes(shape)))
   def testFftn(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -112,7 +104,7 @@ class FftTest(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
     if (FLAGS.jax_enable_x64 and
-        dtype in (float_dtypes if real and not inverse else inexact_dtypes)):
+        dtype in (jtu.float_dtypes if real and not inverse else jtu.inexact_dtypes)):
       # TODO(skye): can we be more precise?
       tol = 0.15
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
@@ -152,7 +144,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (real_dtypes if real and not inverse else all_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
       for shape in [(10,)]
       for axis in [-1, 0]))
   def testFft(self, inverse, real, shape, dtype, axis, rng_factory):
@@ -213,7 +205,7 @@ class FftTest(jtu.JaxTestCase):
       for inverse in [False, True]
       for real in [False, True]
       for rng_factory in [jtu.rand_default]
-      for dtype in (real_dtypes if real and not inverse else all_dtypes)
+      for dtype in (jtu.real_dtypes if real and not inverse else jtu.int_dtypes)
       for shape in [(16, 8, 4, 8), (16, 8, 4, 8, 4)]
       for axes in [(-2, -1), (0, 1), (1, 3), (-1, 2)]))
   def testFft2(self, inverse, real, shape, dtype, axes, rng_factory):
@@ -267,7 +259,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in all_dtypes
+    for dtype in jtu.int_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testFftfreq(self, size, d, dtype, rng_factory):
@@ -282,7 +274,7 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if dtype in inexact_dtypes:
+    if dtype in jtu.inexact_dtypes:
       tol = 0.15  # TODO(skye): can we be more precise?
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
 
@@ -311,7 +303,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string([size], dtype), d),
       "dtype": dtype, "size": size, "rng_factory": rng_factory, "d": d}
     for rng_factory in [jtu.rand_default]
-    for dtype in all_dtypes
+    for dtype in jtu.int_dtypes
     for size in [9, 10, 101, 102]
     for d in [0.1, 2.]))
   def testRfftfreq(self, size, d, dtype, rng_factory):
@@ -326,7 +318,7 @@ class FftTest(jtu.JaxTestCase):
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker)
     # Test gradient for differentiable types.
-    if dtype in inexact_dtypes:
+    if dtype in jtu.inexact_dtypes:
       tol = 0.15  # TODO(skye): can we be more precise?
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
 
@@ -355,7 +347,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in all_dtypes
+    for dtype in jtu.int_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testFftshift(self, shape, dtype, rng_factory, axes):
@@ -370,7 +362,7 @@ class FftTest(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(shape, dtype), axes),
       "dtype": dtype, "shape": shape, "rng_factory": rng_factory, "axes": axes}
     for rng_factory in [jtu.rand_default]
-    for dtype in all_dtypes
+    for dtype in jtu.int_dtypes
     for shape in [[9], [10], [101], [102], [3, 5], [3, 17], [5, 7, 11]]
     for axes in _get_fftn_test_axes(shape)))
   def testIfftshift(self, shape, dtype, rng_factory, axes):

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -31,7 +31,7 @@ from jax import lax
 from jax import test_util as jtu
 from jax.test_util import check_grads
 
-from tests.lax_test import num_float_bits, compatible_shapes
+from tests.lax_test import compatible_shapes, num_float_bits
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -45,97 +45,98 @@ def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
   return GradTestSpec(
       op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
+grad_inexact_dtypes = jtu.basic_float_dtypes + jtu.complex_dtypes
 
 LAX_GRAD_OPS = [
     grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.floor, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.ceil, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.round, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
 
     grad_test_spec(lax.exp, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.expm1, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.log, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.log1p, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.sinh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes + [onp.complex64], tol=1e-5),
+                   dtypes=jtu.basic_float_dtypes + [onp.complex64], tol=1e-5),
     grad_test_spec(lax.cosh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes, tol=1e-5),
+                   dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.tanh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes, tol=1e-5),
+                   dtypes=grad_inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.sin, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes, tol={onp.float32: 5e-1}),
+                   dtypes=grad_inexact_dtypes, tol={onp.float32: 5e-1}),
     grad_test_spec(lax.cos, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.tan, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=jtu.inexact_dtypes, tol=1e-3),
+                   dtypes=grad_inexact_dtypes, tol=1e-3),
     grad_test_spec(lax.asin, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=jtu.float_dtypes, tol=1e-3),
+                   dtypes=jtu.basic_float_dtypes, tol=1e-3),
     grad_test_spec(lax.acos, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=jtu.float_dtypes, tol=2e-2),
+                   dtypes=jtu.basic_float_dtypes, tol=2e-2),
     # TODO(proteneer): atan2 input is already a representation of a
     # complex number. Need to think harder about what this even means
     # if each input itself is a complex number.
     grad_test_spec(lax.atan2, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
 
     grad_test_spec(lax.erf, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.erfc, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.erf_inv, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     # grad_test_spec(lax.lgamma, nargs=1, order=2, rng_factory=jtu.rand_small,
-    #                dtypes=jtu.float_dtypes),  # TODO(mattjj): enable
+    #                dtypes=jtu.basic_float_dtypes),  # TODO(mattjj): enable
     grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
 
     grad_test_spec(lax.real, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=jtu.complex_dtypes),
     grad_test_spec(lax.imag, nargs=1, order=2, rng_factory=jtu.rand_default,
                    dtypes=jtu.complex_dtypes),
     grad_test_spec(lax.complex, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.conj, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.abs, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.pow, nargs=2, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=jtu.inexact_dtypes, tol={onp.float32: 3e-1}),
+                   dtypes=grad_inexact_dtypes, tol={onp.float32: 3e-1}),
 
     grad_test_spec(lax.add, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.sub, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.mul, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
     grad_test_spec(lax.div, nargs=2, order=1, rng_factory=jtu.rand_not_small,
-                   dtypes=jtu.inexact_dtypes),
+                   dtypes=grad_inexact_dtypes),
 
     grad_test_spec(lax.max, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     grad_test_spec(lax.min, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=jtu.float_dtypes),
+                   dtypes=jtu.basic_float_dtypes),
     # TODO(mattjj): make some-equal checks more robust, enable second-order
     # grad_test_spec(lax.max, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=jtu.float_dtypes, name="MaxSomeEqual"),
+    #                dtypes=jtu.basic_float_dtypes, name="MaxSomeEqual"),
     # grad_test_spec(lax.min, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=jtu.float_dtypes, name="MinSomeEqual"),
+    #                dtypes=jtu.basic_float_dtypes, name="MinSomeEqual"),
 ]
 
 GradSpecialValuesTestSpec = collections.namedtuple(
@@ -224,7 +225,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testClampGrad(self, shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -341,7 +342,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for strides in all_strides
       for rhs_dil in rhs_dils
       for lhs_dil in lhs_dils
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for padding in ([((0, 0), (0, 0)), ((1, 0), (0, 1))] +
         ([((0, -1), (0, 0))] if lhs_shape[2] != 0 else []))
       for dim_nums, perms in [
@@ -634,9 +635,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "dims": dims, "rng_factory": rng_factory}
       for init_val, op, dtypes, rng_factory in [
           (0, lax.add, jtu.inexact_dtypes, jtu.rand_default),
-          (-onp.inf, lax.max, jtu.inexact_dtypes, jtu.rand_unique_int),
-          (onp.inf, lax.min, jtu.inexact_dtypes, jtu.rand_unique_int),
-          (1, lax.mul, jtu.float_dtypes, partial(jtu.rand_default, scale=1)),
+          (-onp.inf, lax.max, grad_inexact_dtypes, jtu.rand_unique_int),
+          (onp.inf, lax.min, grad_inexact_dtypes, jtu.rand_unique_int),
+          (1, lax.mul, jtu.basic_float_dtypes, partial(jtu.rand_default, scale=1)),
       ]
       for dtype in dtypes
       for shape, dims in [
@@ -667,9 +668,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
        "rng_factory": rng_factory}
       for init_val, op, dtypes, rng_factory in [
-          (0, lax.add, jtu.float_dtypes, jtu.rand_small),
-          (-onp.inf, lax.max, jtu.float_dtypes, jtu.rand_unique_int),
-          (onp.inf, lax.min, jtu.float_dtypes, jtu.rand_unique_int),
+          (0, lax.add, jtu.basic_float_dtypes, jtu.rand_small),
+          (-onp.inf, lax.max, jtu.basic_float_dtypes, jtu.rand_unique_int),
+          (onp.inf, lax.min, jtu.basic_float_dtypes, jtu.rand_unique_int),
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]))
@@ -823,7 +824,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
        "slice_sizes": slice_sizes, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for shape, idxs, dnums, slice_sizes, max_idx in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
@@ -854,7 +855,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -886,7 +887,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -929,7 +930,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -960,7 +961,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -31,9 +31,7 @@ from jax import lax
 from jax import test_util as jtu
 from jax.test_util import check_grads
 
-from tests.lax_test import (CombosWithReplacement, compatible_shapes,
-                            complex_dtypes, float_dtypes, inexact_dtypes,
-                            num_float_bits)
+from tests.lax_test import num_float_bits, compatible_shapes
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -47,102 +45,102 @@ def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
   return GradTestSpec(
       op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
-grad_float_dtypes = list(jtu.supported_dtypes().intersection(
+jtu.float_dtypes = list(jtu.supported_dtypes().intersection(
   {onp.float32, onp.float64}))
-grad_complex_dtypes = list(jtu.supported_dtypes().intersection(
+jtu.complex_dtypes = list(jtu.supported_dtypes().intersection(
   {onp.complex64, onp.complex128}))
-grad_inexact_dtypes = grad_float_dtypes + grad_complex_dtypes
+jtu.inexact_dtypes = jtu.float_dtypes + jtu.complex_dtypes
 
 LAX_GRAD_OPS = [
     grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.floor, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.ceil, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.round, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=0.1, high=0.4),
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
 
     grad_test_spec(lax.exp, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.expm1, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.log, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.log1p, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.sinh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes + [onp.complex64], tol=1e-5),
+                   dtypes=jtu.float_dtypes + [onp.complex64], tol=1e-5),
     grad_test_spec(lax.cosh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes, tol=1e-5),
+                   dtypes=jtu.inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.tanh, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes, tol=1e-5),
+                   dtypes=jtu.inexact_dtypes, tol=1e-5),
     grad_test_spec(lax.sin, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes, tol={onp.float32: 5e-1}),
+                   dtypes=jtu.inexact_dtypes, tol={onp.float32: 5e-1}),
     grad_test_spec(lax.cos, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.tan, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=grad_inexact_dtypes, tol=1e-3),
+                   dtypes=jtu.inexact_dtypes, tol=1e-3),
     grad_test_spec(lax.asin, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=grad_float_dtypes, tol=1e-3),
+                   dtypes=jtu.float_dtypes, tol=1e-3),
     grad_test_spec(lax.acos, nargs=1, order=2,
                    rng_factory=partial(jtu.rand_uniform, low=-1.3, high=1.3),
-                   dtypes=grad_float_dtypes, tol=2e-2),
+                   dtypes=jtu.float_dtypes, tol=2e-2),
     # TODO(proteneer): atan2 input is already a representation of a
     # complex number. Need to think harder about what this even means
     # if each input itself is a complex number.
     grad_test_spec(lax.atan2, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
 
     grad_test_spec(lax.erf, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.erfc, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.erf_inv, nargs=1, order=2, rng_factory=jtu.rand_small,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     # grad_test_spec(lax.lgamma, nargs=1, order=2, rng_factory=jtu.rand_small,
-    #                dtypes=grad_float_dtypes),  # TODO(mattjj): enable
+    #                dtypes=jtu.float_dtypes),  # TODO(mattjj): enable
     grad_test_spec(lax.bessel_i0e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.bessel_i1e, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
 
     grad_test_spec(lax.real, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_complex_dtypes),
+                   dtypes=jtu.complex_dtypes),
     grad_test_spec(lax.imag, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_complex_dtypes),
+                   dtypes=jtu.complex_dtypes),
     grad_test_spec(lax.complex, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.conj, nargs=1, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.abs, nargs=1, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.pow, nargs=2, order=2, rng_factory=jtu.rand_positive,
-                   dtypes=grad_inexact_dtypes, tol={onp.float32: 3e-1}),
+                   dtypes=jtu.inexact_dtypes, tol={onp.float32: 3e-1}),
 
     grad_test_spec(lax.add, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.sub, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.mul, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
     grad_test_spec(lax.div, nargs=2, order=1, rng_factory=jtu.rand_not_small,
-                   dtypes=grad_inexact_dtypes),
+                   dtypes=jtu.inexact_dtypes),
 
     grad_test_spec(lax.max, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     grad_test_spec(lax.min, nargs=2, order=2, rng_factory=jtu.rand_default,
-                   dtypes=grad_float_dtypes),
+                   dtypes=jtu.float_dtypes),
     # TODO(mattjj): make some-equal checks more robust, enable second-order
     # grad_test_spec(lax.max, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=grad_float_dtypes, name="MaxSomeEqual"),
+    #                dtypes=jtu.float_dtypes, name="MaxSomeEqual"),
     # grad_test_spec(lax.min, nargs=2, order=1, rng_factory=jtu.rand_some_equal,
-    #                dtypes=grad_float_dtypes, name="MinSomeEqual"),
+    #                dtypes=jtu.float_dtypes, name="MinSomeEqual"),
 ]
 
 GradSpecialValuesTestSpec = collections.namedtuple(
@@ -188,7 +186,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
          "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
          "order": rec.order, "tol": rec.tol}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_GRAD_OPS))
   def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):
@@ -213,7 +211,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.dtype_str(from_dtype), jtu.dtype_str(to_dtype)),
        "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
       for from_dtype, to_dtype in itertools.product(
-          float_dtypes + complex_dtypes, repeat=2)
+          jtu.float_dtypes + jtu.complex_dtypes, repeat=2)
       for rng_factory in [jtu.rand_default]))
   def testConvertElementTypeGrad(self, from_dtype, to_dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -231,7 +229,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testClampGrad(self, shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -250,7 +248,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
        "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
       for rng_factory in [jtu.rand_default]))
@@ -275,7 +273,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
             for b, i, j in itertools.product([2, 3], repeat=3)],
            [((4, 2, 1), (3, 2, 1), [(1,)])])
        for strides in all_strides
-       for dtype in float_dtypes
+       for dtype in jtu.float_dtypes
        for padding in ["VALID", "SAME"]
        for rng_factory in [jtu.rand_small]))
   def testConvGrad(self, lhs_shape, rhs_shape, dtype, strides, padding, rng_factory):
@@ -308,7 +306,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        for strides in all_strides
        for rhs_dil in rhs_dils
        for lhs_dil in lhs_dils
-       for dtype in float_dtypes
+       for dtype in jtu.float_dtypes
        for padding in all_pads
        for rng_factory in [jtu.rand_small]))
   def testConvWithGeneralPaddingGrad(self, lhs_shape, rhs_shape, dtype, strides,
@@ -348,7 +346,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for strides in all_strides
       for rhs_dil in rhs_dils
       for lhs_dil in lhs_dils
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for padding in ([((0, 0), (0, 0)), ((1, 0), (0, 1))] +
         ([((0, -1), (0, 0))] if lhs_shape[2] != 0 else []))
       for dim_nums, perms in [
@@ -390,7 +388,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "rng_factory": jtu.rand_default}
       for lhs_shape in [(2,), (3, 2)] for rhs_shape in [(2,), (2, 4)]
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testDotGrad(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
     tol = {onp.float16: 1e-1, onp.float32: 1e-4}
@@ -419,7 +417,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           ((5, 3), (5, 2), (([0], [0]), ([], []))),
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
       ]
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testDotGeneralContractAndBatchGrads(self, lhs_shape, rhs_shape, dtype,
                                           dimension_numbers, rng_factory):
     rng = rng_factory(self.rng())
@@ -440,7 +438,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
       for rng_factory in [jtu.rand_default]))
   def testBroadcastGrad(self, shape, dtype, broadcast_sizes, rng_factory):
@@ -461,7 +459,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           ([2], [2, 3], [0]),
           ([], [2, 3], []),
       ]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testBroadcastInDimGrad(self, inshape, dtype, outshape, dimensions, rng_factory):
     rng = rng_factory(self.rng())
@@ -476,7 +474,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           permutation),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "rng_factory": rng_factory, "permutation": permutation}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, out_shape, permutation in [
           [(3, 4), (12,), None],
           [(2, 1, 4), (8,), None],
@@ -500,7 +498,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)], [(-1, 0, 0), (-1, 0, 2)]]))
   def testPadGrad(self, shape, dtype, pads, rng_factory):
     rng = rng_factory(self.rng())
@@ -531,7 +529,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSelectGrad(self, pred_shape, arg_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -559,7 +557,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (2, 1), (1, 1)],
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSliceGrad(self, shape, dtype, starts, limits, strides, rng_factory):
     rng = rng_factory(self.rng())
@@ -578,7 +576,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicSliceGrad(self, shape, dtype, start_indices, size_indices,
                            rng_factory):
@@ -598,7 +596,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSliceGrad(self, shape, dtype, start_indices,
                                  update_shape, rng_factory):
@@ -626,7 +624,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
         [(3, 4, 5), (2, 1, 0)],
         [(3, 4, 5), (1, 0, 2)],
       ]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default]))
   def testTransposeGrad(self, shape, dtype, perm, rng_factory):
     rng = rng_factory(self.rng())
@@ -640,10 +638,10 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
        "dims": dims, "rng_factory": rng_factory}
       for init_val, op, dtypes, rng_factory in [
-          (0, lax.add, inexact_dtypes, jtu.rand_default),
-          (-onp.inf, lax.max, grad_inexact_dtypes, jtu.rand_unique_int),
-          (onp.inf, lax.min, grad_inexact_dtypes, jtu.rand_unique_int),
-          (1, lax.mul, grad_float_dtypes, partial(jtu.rand_default, scale=1)),
+          (0, lax.add, jtu.inexact_dtypes, jtu.rand_default),
+          (-onp.inf, lax.max, jtu.inexact_dtypes, jtu.rand_unique_int),
+          (onp.inf, lax.min, jtu.inexact_dtypes, jtu.rand_unique_int),
+          (1, lax.mul, jtu.float_dtypes, partial(jtu.rand_default, scale=1)),
       ]
       for dtype in dtypes
       for shape, dims in [
@@ -674,9 +672,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
        "rng_factory": rng_factory}
       for init_val, op, dtypes, rng_factory in [
-          (0, lax.add, grad_float_dtypes, jtu.rand_small),
-          (-onp.inf, lax.max, grad_float_dtypes, jtu.rand_unique_int),
-          (onp.inf, lax.min, grad_float_dtypes, jtu.rand_unique_int),
+          (0, lax.add, jtu.float_dtypes, jtu.rand_small),
+          (-onp.inf, lax.max, jtu.float_dtypes, jtu.rand_unique_int),
+          (onp.inf, lax.min, jtu.float_dtypes, jtu.rand_unique_int),
       ]
       for dtype in dtypes
       for padding in ["VALID", "SAME"]))
@@ -809,7 +807,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), idxs, axes),
        "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes,
        "rng_factory": rng_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for shape, idxs, axes in [
           [(3, 4, 5), (onp.array([0, 2, 1]),), (0,)],
           [(3, 4, 5), (onp.array([-1, -2]),), (0,)],
@@ -830,7 +828,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
        "slice_sizes": slice_sizes, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for shape, idxs, dnums, slice_sizes, max_idx in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
@@ -861,7 +859,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -893,7 +891,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums, max_idx in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -936,7 +934,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -967,7 +965,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in grad_float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -45,11 +45,6 @@ def grad_test_spec(op, nargs, order, rng_factory, dtypes, name=None, tol=None):
   return GradTestSpec(
       op, nargs, order, rng_factory, dtypes, name or op.__name__, tol)
 
-jtu.float_dtypes = list(jtu.supported_dtypes().intersection(
-  {onp.float32, onp.float64}))
-jtu.complex_dtypes = list(jtu.supported_dtypes().intersection(
-  {onp.complex64, onp.complex128}))
-jtu.inexact_dtypes = jtu.float_dtypes + jtu.complex_dtypes
 
 LAX_GRAD_OPS = [
     grad_test_spec(lax.neg, nargs=1, order=2, rng_factory=jtu.rand_default,

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -31,7 +31,7 @@ from jax import lax
 from jax import test_util as jtu
 from jax.test_util import check_grads
 
-from tests.lax_test import compatible_shapes, num_float_bits
+from tests.lax_test import compatible_shapes
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -189,7 +189,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     if jtu.device_under_test() == "tpu" and op is lax.pow:
       raise SkipTest("pow grad imprecise on tpu")
-    tol = jtu.join_tolerance(1e-1, tol) if num_float_bits(dtype) == 32 else tol
+    tol = jtu.join_tolerance(1e-1, tol) if jtu.num_float_bits(dtype) == 32 else tol
     args = tuple(rng(shape, dtype) for shape in shapes)
     check_grads(op, args, order, ["fwd", "rev"], tol, tol)
 
@@ -1015,14 +1015,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     x = rng.uniform(-0.9, 9, size=(3, 4))
     y = rng.uniform(0.7, 1.9, size=(3, 1))
     assert not set(onp.unique(x)) & set(onp.unique(y))
-    tol = 1e-1 if num_float_bits(onp.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(onp.float64) == 32 else 1e-3
     check_grads(lax.rem, (x, y), 2, ["fwd", "rev"], tol, tol)
 
     rng = onp.random.RandomState(0)
     x = rng.uniform(-0.9, 9, size=(1, 4))
     y = rng.uniform(0.7, 1.9, size=(3, 4))
     assert not set(onp.unique(x)) & set(onp.unique(y))
-    tol = 1e-1 if num_float_bits(onp.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(onp.float64) == 32 else 1e-3
     check_grads(lax.rem, (x, y), 2, ["fwd", "rev"], tol, tol)
 
   def testHigherOrderGradientOfReciprocal(self):

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -38,13 +38,6 @@ FLAGS = config.FLAGS
 # makes the test name formatting unwieldy.
 # pylint: disable=bad-continuation
 
-
-float_dtypes = [onp.float32, onp.float64]
-int_dtypes = [onp.int32, onp.int64]
-bool_types = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + int_dtypes + bool_types
-
 IndexSpec = collections.namedtuple("IndexTest", ["shape", "indexer"])
 
 
@@ -396,7 +389,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
-    for dtype in all_dtypes
+    for dtype in jtu.all_dtypes
     for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -412,7 +405,7 @@ class IndexingTest(jtu.JaxTestCase):
       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_GRAD_TESTS
     for shape, indexer in index_specs
-    for dtype in float_dtypes
+    for dtype in jtu.float_dtypes
     for rng_factory in [jtu.rand_default])
   def testStaticIndexingGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -459,7 +452,7 @@ class IndexingTest(jtu.JaxTestCase):
           ]),
       ]
       for shape, indexer in index_specs
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithSlicesErrors(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -492,7 +485,7 @@ class IndexingTest(jtu.JaxTestCase):
            [IndexSpec((3, 4, 5), indexer=(1, 2, 3))]),
       ]
       for shape, indexer in index_specs
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithIntegers(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -526,7 +519,7 @@ class IndexingTest(jtu.JaxTestCase):
            [IndexSpec((3, 4, 5), indexer=(1, 2, 3))]),
       ]
       for shape, indexer in index_specs
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithIntegersGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -547,7 +540,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_default])
   def testAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -606,7 +599,7 @@ class IndexingTest(jtu.JaxTestCase):
             ]),
       ]
       for shape, indexer in index_specs
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_default])
   def testAdvancedIntegerIndexingGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -621,7 +614,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_default])
   def testMixedAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -863,9 +856,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -890,9 +883,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -917,9 +910,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testMixedAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -944,9 +937,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for op in [UpdateOps.ADD, UpdateOps.MUL, UpdateOps.UPDATE]
-    for dtype in float_dtypes
+    for dtype in jtu.float_dtypes
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else float_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.float_dtypes)
     for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj,phawkins): tpu issues
   def testStaticIndexingGrads(self, shape, dtype, update_shape, update_dtype,

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -38,6 +38,10 @@ FLAGS = config.FLAGS
 # makes the test name formatting unwieldy.
 # pylint: disable=bad-continuation
 
+
+default_dtypes = jtu.basic_float_dtypes + jtu.int_dtypes
+all_dtypes = jtu.basic_float_dtypes + jtu.int_dtypes + jtu.bool_dtypes
+
 IndexSpec = collections.namedtuple("IndexTest", ["shape", "indexer"])
 
 
@@ -389,7 +393,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
-    for dtype in jtu.all_dtypes
+    for dtype in all_dtypes
     for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -405,7 +409,7 @@ class IndexingTest(jtu.JaxTestCase):
       "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer
   } for name, index_specs in STATIC_INDEXING_GRAD_TESTS
     for shape, indexer in index_specs
-    for dtype in jtu.float_dtypes
+    for dtype in jtu.basic_float_dtypes
     for rng_factory in [jtu.rand_default])
   def testStaticIndexingGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -452,7 +456,7 @@ class IndexingTest(jtu.JaxTestCase):
           ]),
       ]
       for shape, indexer in index_specs
-      for dtype in jtu.all_dtypes
+      for dtype in all_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithSlicesErrors(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -485,7 +489,7 @@ class IndexingTest(jtu.JaxTestCase):
            [IndexSpec((3, 4, 5), indexer=(1, 2, 3))]),
       ]
       for shape, indexer in index_specs
-      for dtype in jtu.all_dtypes
+      for dtype in all_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithIntegers(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -519,7 +523,7 @@ class IndexingTest(jtu.JaxTestCase):
            [IndexSpec((3, 4, 5), indexer=(1, 2, 3))]),
       ]
       for shape, indexer in index_specs
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for rng_factory in [jtu.rand_default])
   def testDynamicIndexingWithIntegersGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -540,7 +544,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
-      for dtype in jtu.all_dtypes
+      for dtype in all_dtypes
       for rng_factory in [jtu.rand_default])
   def testAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -599,7 +603,7 @@ class IndexingTest(jtu.JaxTestCase):
             ]),
       ]
       for shape, indexer in index_specs
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for rng_factory in [jtu.rand_default])
   def testAdvancedIntegerIndexingGrads(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -614,7 +618,7 @@ class IndexingTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer}
       for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS
       for shape, indexer in index_specs
-      for dtype in jtu.all_dtypes
+      for dtype in all_dtypes
       for rng_factory in [jtu.rand_default])
   def testMixedAdvancedIntegerIndexing(self, shape, dtype, rng_factory, indexer):
     rng = rng_factory(self.rng())
@@ -856,9 +860,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
+    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testStaticIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -883,9 +887,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
+    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -910,9 +914,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS
     for shape, indexer in index_specs
     for op in UpdateOps
-    for dtype in (jtu.all_dtypes if op == UpdateOps.UPDATE else jtu.default_dtypes)
+    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.all_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
     for sugared in [True, False]
     for rng_factory in [jtu.rand_default]))
   def testMixedAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
@@ -937,9 +941,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
   } for name, index_specs in STATIC_INDEXING_TESTS
     for shape, indexer in index_specs
     for op in [UpdateOps.ADD, UpdateOps.MUL, UpdateOps.UPDATE]
-    for dtype in jtu.float_dtypes
+    for dtype in jtu.basic_float_dtypes
     for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.float_dtypes)
+    for update_dtype in ([dtype] if op == UpdateOps.ADD else jtu.basic_float_dtypes)
     for rng_factory in [jtu.rand_default]))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj,phawkins): tpu issues
   def testStaticIndexingGrads(self, shape, dtype, update_shape, update_dtype,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -55,29 +55,12 @@ nonzerodim_shapes = nonempty_nonscalar_array_shapes + empty_array_shapes
 nonempty_shapes = scalar_shapes + nonempty_array_shapes
 all_shapes =  scalar_shapes + array_shapes
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([jnp.bfloat16, np.float16, np.float32,
-                                 np.float64])
-complex_dtypes = [np.complex64, np.complex128]
-int_dtypes = [np.int32, np.int64]
-uint_dtypes = [np.uint32, np.uint64]
-unsigned_dtypes = [np.uint32, np.uint64]
-bool_dtypes = [np.bool_]
-default_dtypes = float_dtypes + int_dtypes
-inexact_dtypes = float_dtypes + complex_dtypes
-number_dtypes = float_dtypes + complex_dtypes + int_dtypes
-all_dtypes = number_dtypes + bool_dtypes
-
-
-python_scalar_dtypes = [jnp.bool_, jnp.int_, jnp.float_, jnp.complex_]
 
 def _valid_dtypes_for_shape(shape, dtypes):
   # Not all (shape, dtype) pairs are valid. In particular, Python scalars only
   # have one type in each category (float, bool, etc.)
   if shape is jtu.PYTHON_SCALAR_SHAPE:
-    return [t for t in dtypes if t in python_scalar_dtypes]
+    return [t for t in dtypes if t in jtu.python_scalar_dtypes]
   return dtypes
 
 def _shape_and_dtypes(shapes, dtypes):
@@ -98,169 +81,169 @@ def op_record(name, nargs, dtypes, shapes, rng_factory, diff_modes,
                   test_name, check_dtypes, tolerance, inexact)
 
 JAX_ONE_TO_ONE_OP_RECORDS = [
-    op_record("abs", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("add", 2, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("conj", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("exp", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("abs", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("add", 2, jtu.all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("ceil", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("conj", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("equal", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("exp", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
-    op_record("fabs", 1, float_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("float_power", 2, inexact_dtypes, all_shapes,
+    op_record("fabs", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("float_power", 2, jtu.inexact_dtypes, all_shapes,
               partial(jtu.rand_default, scale=1), ["rev"],
               tolerance={jnp.bfloat16: 1e-2, np.float32: 1e-3,
                          np.float64: 1e-12, np.complex64: 2e-4,
                          np.complex128: 1e-12}, check_dtypes=False),
-    op_record("floor", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("greater", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("greater_equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("less", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("less_equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
-    op_record("log", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("floor", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("greater", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("greater_equal", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("less", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("less_equal", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, []),
+    op_record("log", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("logical_and", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
-    op_record("logical_not", 1, all_dtypes, all_shapes, jtu.rand_bool, []),
-    op_record("logical_or", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
-    op_record("logical_xor", 2, all_dtypes, all_shapes, jtu.rand_bool, []),
-    op_record("maximum", 2, all_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("minimum", 2, all_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("multiply", 2, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("negative", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("nextafter", 2, [f for f in float_dtypes if f != jnp.bfloat16],
+    op_record("logical_and", 2, jtu.all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_not", 1, jtu.all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_or", 2, jtu.all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("logical_xor", 2, jtu.all_dtypes, all_shapes, jtu.rand_bool, []),
+    op_record("maximum", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("minimum", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("multiply", 2, jtu.all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("negative", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("nextafter", 2, [f for f in jtu.float_dtypes if f != jnp.bfloat16],
               all_shapes, jtu.rand_default, ["rev"], inexact=True, tolerance=0),
-    op_record("not_equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
-    op_record("array_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
-    op_record("reciprocal", 1, inexact_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("subtract", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("signbit", 1, default_dtypes + bool_dtypes, all_shapes,
+    op_record("not_equal", 2, jtu.all_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
+    op_record("array_equal", 2, jtu.number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
+    op_record("reciprocal", 1, jtu.inexact_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("subtract", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("signbit", 1, jtu.default_dtypes + jtu.bool_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"]),
-    op_record("trunc", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("trunc", 1, jtu.float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("sin", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
-    op_record("cos", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("cos", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
-    op_record("tan", 1, number_dtypes, all_shapes,
+    op_record("tan", 1, jtu.number_dtypes, all_shapes,
               partial(jtu.rand_uniform, low=-1.5, high=1.5), ["rev"],
               inexact=True),
-    op_record("sinh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("sinh", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
-    op_record("cosh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("cosh", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
-    op_record("tanh", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("tanh", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={np.float64: 1e-7, np.complex128: 1e-7},
               inexact=True),
-    op_record("arcsin", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+    op_record("arcsin", 1, jtu.float_dtypes, all_shapes, jtu.rand_small, ["rev"],
               inexact=True),
-    op_record("arccos", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+    op_record("arccos", 1, jtu.float_dtypes, all_shapes, jtu.rand_small, ["rev"],
               inexact=True),
-    op_record("arctan", 1, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+    op_record("arctan", 1, jtu.float_dtypes, all_shapes, jtu.rand_small, ["rev"],
               inexact=True),
-    op_record("arctan2", 2, float_dtypes, all_shapes, jtu.rand_small, ["rev"],
+    op_record("arctan2", 2, jtu.float_dtypes, all_shapes, jtu.rand_small, ["rev"],
               inexact=True),
-    op_record("arcsinh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("arcsinh", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("arccosh", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("arccosh", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("arctanh", 1, number_dtypes, all_shapes, jtu.rand_small, ["rev"],
+    op_record("arctanh", 1, jtu.number_dtypes, all_shapes, jtu.rand_small, ["rev"],
               inexact=True, tolerance={np.float64: 1e-9}),
 ]
 
 JAX_COMPOUND_OP_RECORDS = [
     # angle has inconsistent 32/64-bit return types across numpy versions.
-    op_record("angle", 1, number_dtypes, all_shapes, jtu.rand_default, [],
+    op_record("angle", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, [],
               check_dtypes=False, inexact=True),
-    op_record("atleast_1d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("atleast_2d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("atleast_3d", 1, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("cbrt", 1, default_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("atleast_1d", 1, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("atleast_2d", 1, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("atleast_3d", 1, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("cbrt", 1, jtu.default_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
-    op_record("conjugate", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("deg2rad", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("divide", 2, number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"],
+    op_record("conjugate", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("deg2rad", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("divide", 2, jtu.number_dtypes, all_shapes, jtu.rand_nonzero, ["rev"],
               inexact=True),
-    op_record("divmod", 2, int_dtypes + float_dtypes, all_shapes,
+    op_record("divmod", 2, jtu.int_dtypes + jtu.float_dtypes, all_shapes,
               jtu.rand_nonzero, []),
-    op_record("exp2", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("exp2", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               tolerance={jnp.bfloat16: 4e-2, np.float16: 1e-2}, inexact=True),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
-    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
+    op_record("expm1", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, [],
               test_name="expm1_large", tolerance={np.float64: 1e-8}, inexact=True),
-    op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive,
+    op_record("expm1", 1, jtu.number_dtypes, all_shapes, jtu.rand_small_positive,
               [], tolerance={np.float64: 1e-8}, inexact=True),
-    op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("floor_divide", 2, number_dtypes, all_shapes,
+    op_record("fix", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("floor_divide", 2, jtu.number_dtypes, all_shapes,
               jtu.rand_nonzero, ["rev"]),
-    op_record("floor_divide", 2, uint_dtypes, all_shapes,
+    op_record("floor_divide", 2, jtu.uint_dtypes, all_shapes,
               jtu.rand_nonzero, ["rev"]),
-    op_record("fmin", 2, number_dtypes, all_shapes, jtu.rand_some_nan, []),
-    op_record("fmax", 2, number_dtypes, all_shapes, jtu.rand_some_nan, []),
-    op_record("heaviside", 2, default_dtypes, all_shapes, jtu.rand_default, [],
+    op_record("fmin", 2, jtu.number_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("fmax", 2, jtu.number_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("heaviside", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("hypot", 2, default_dtypes, all_shapes, jtu.rand_default, [],
+    op_record("hypot", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("kron", 2, number_dtypes, nonempty_shapes, jtu.rand_default, []),
-    op_record("outer", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("imag", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("iscomplex", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("isfinite", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("isinf", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("isnan", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("isneginf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("isposinf", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("isreal", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("isrealobj", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("log2", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("kron", 2, jtu.number_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("outer", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("imag", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("iscomplex", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("isfinite", 1, jtu.inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isinf", 1, jtu.inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isnan", 1, jtu.inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isneginf", 1, jtu.float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isposinf", 1, jtu.float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
+    op_record("isreal", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("isrealobj", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("log2", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("log10", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("log10", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_positive, [],
+    op_record("log1p", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, [],
               test_name="log1p_large", tolerance={np.float64: 1e-12},
               inexact=True),
-    op_record("log1p", 1, number_dtypes, all_shapes, jtu.rand_small_positive, [],
+    op_record("log1p", 1, jtu.number_dtypes, all_shapes, jtu.rand_small_positive, [],
               tolerance={np.float64: 1e-12}, inexact=True),
-    op_record("logaddexp", 2, float_dtypes, all_shapes,
+    op_record("logaddexp", 2, jtu.float_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"],
               tolerance={np.float64: 1e-12}, inexact=True),
-    op_record("logaddexp2", 2, float_dtypes, all_shapes,
+    op_record("logaddexp2", 2, jtu.float_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"],
               tolerance={np.float16: 1e-2, np.float64: 2e-14}, inexact=True),
-    op_record("polyval", 2, number_dtypes, nonempty_nonscalar_array_shapes,
+    op_record("polyval", 2, jtu.number_dtypes, nonempty_nonscalar_array_shapes,
               jtu.rand_default, [], check_dtypes=False,
               tolerance={dtypes.bfloat16: 4e-2, np.float16: 1e-2,
                          np.float64: 1e-12}),
-    op_record("positive", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("power", 2, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("positive", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("power", 2, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               tolerance={np.complex128: 1e-14}),
-    op_record("rad2deg", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("ravel", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("real", 1, number_dtypes, all_shapes, jtu.rand_some_inf, []),
-    op_record("remainder", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
+    op_record("rad2deg", 1, jtu.float_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("ravel", 1, jtu.all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("real", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_inf, []),
+    op_record("remainder", 2, jtu.default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={np.float16: 1e-2}),
-    op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("rint", 1, number_dtypes + uint_dtypes, all_shapes,
+    op_record("mod", 2, jtu.default_dtypes, all_shapes, jtu.rand_nonzero, []),
+    op_record("rint", 1, jtu.number_dtypes + jtu.uint_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, []),
-    op_record("sign", 1, supported_dtypes(number_dtypes + uint_dtypes),
+    op_record("sign", 1, jtu.number_dtypes + jtu.uint_dtypes,
               all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record('copysign', 2, default_dtypes, all_shapes, jtu.rand_some_inf_and_nan, [],
+    op_record('copysign', 2, jtu.default_dtypes, all_shapes, jtu.rand_some_inf_and_nan, [],
               check_dtypes=False),
-    op_record("sinc", 1, [t for t in number_dtypes if t != jnp.bfloat16],
+    op_record("sinc", 1, [t for t in jtu.number_dtypes if t != jnp.bfloat16],
               all_shapes, jtu.rand_default, ["rev"],
               tolerance={np.complex64: 1e-5}, inexact=True,
               check_dtypes=False),
-    op_record("square", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
-    op_record("sqrt", 1, number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
+    op_record("square", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
+    op_record("sqrt", 1, jtu.number_dtypes, all_shapes, jtu.rand_positive, ["rev"],
               inexact=True),
-    op_record("transpose", 1, all_dtypes, all_shapes, jtu.rand_default, ["rev"],
+    op_record("transpose", 1, jtu.all_dtypes, all_shapes, jtu.rand_default, ["rev"],
               check_dtypes=False),
-    op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero,
+    op_record("true_divide", 2, jtu.all_dtypes, all_shapes, jtu.rand_nonzero,
               ["rev"], inexact=True),
-    op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
+    op_record("diff", 1, jtu.number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
     op_record("ediff1d", 3, [np.int32], all_shapes, jtu.rand_default, []),
-    op_record("unwrap", 1, float_dtypes, nonempty_nonscalar_array_shapes,
+    op_record("unwrap", 1, jtu.float_dtypes, nonempty_nonscalar_array_shapes,
               jtu.rand_default, ["rev"],
               # numpy.unwrap always returns float64
               check_dtypes=False,
@@ -269,96 +252,96 @@ JAX_COMPOUND_OP_RECORDS = [
 ]
 
 JAX_BITWISE_OP_RECORDS = [
-    op_record("bitwise_and", 2, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("bitwise_and", 2, jtu.int_dtypes + jtu.uint_dtypes, all_shapes,
               jtu.rand_bool, []),
-    op_record("bitwise_not", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("bitwise_not", 1, jtu.int_dtypes + jtu.uint_dtypes, all_shapes,
               jtu.rand_bool, []),
-    op_record("bitwise_or", 2, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("bitwise_or", 2, jtu.int_dtypes + jtu.uint_dtypes, all_shapes,
               jtu.rand_bool, []),
-    op_record("bitwise_xor", 2, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("bitwise_xor", 2, jtu.int_dtypes + jtu.uint_dtypes, all_shapes,
               jtu.rand_bool, []),
 ]
 
 JAX_REDUCER_RECORDS = [
-    op_record("mean", 1, number_dtypes, nonempty_shapes, jtu.rand_default, [],
+    op_record("mean", 1, jtu.number_dtypes, nonempty_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("prod", 1, all_dtypes, all_shapes, jtu.rand_small_positive, []),
-    op_record("sum", 1, all_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan,
+    op_record("prod", 1, jtu.all_dtypes, all_shapes, jtu.rand_small_positive, []),
+    op_record("sum", 1, jtu.all_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("nanmean", 1, jtu.inexact_dtypes, nonempty_shapes, jtu.rand_some_nan,
               [], inexact=True),
-    op_record("nanprod", 1, inexact_dtypes, all_shapes, jtu.rand_some_nan, []),
-    op_record("nansum", 1, number_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("nanprod", 1, jtu.inexact_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("nansum", 1, jtu.number_dtypes, all_shapes, jtu.rand_some_nan, []),
 ]
 
 JAX_REDUCER_NO_DTYPE_RECORDS = [
-    op_record("all", 1, all_dtypes, all_shapes, jtu.rand_some_zero, []),
-    op_record("any", 1, all_dtypes, all_shapes, jtu.rand_some_zero, []),
-    op_record("max", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
-    op_record("min", 1, all_dtypes, nonempty_shapes, jtu.rand_default, []),
-    op_record("var", 1, all_dtypes, nonempty_shapes, jtu.rand_default, [],
+    op_record("all", 1, jtu.all_dtypes, all_shapes, jtu.rand_some_zero, []),
+    op_record("any", 1, jtu.all_dtypes, all_shapes, jtu.rand_some_zero, []),
+    op_record("max", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("min", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_default, []),
+    op_record("var", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("std", 1, all_dtypes, nonempty_shapes, jtu.rand_default, [],
+    op_record("std", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("nanvar", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan,
+    op_record("nanvar", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_nan,
               [], inexact=True),
-    op_record("nanstd", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan,
+    op_record("nanstd", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_nan,
               [], inexact=True),
 ]
 
 JAX_ARGMINMAX_RECORDS = [
-    op_record("argmin", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
-    op_record("argmax", 1, all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
-    op_record("nanargmin", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
-    op_record("nanargmax", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("argmin", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
+    op_record("argmax", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_equal, []),
+    op_record("nanargmin", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("nanargmax", 1, jtu.all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
 ]
 
 JAX_OPERATOR_OVERLOADS = [
-    op_record("__add__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__sub__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__mul__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__eq__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__ne__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__lt__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__le__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__gt__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__ge__", 2, default_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__pos__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__neg__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__pow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive, [],
+    op_record("__add__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__sub__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__mul__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__eq__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__ne__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__lt__", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__le__", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__gt__", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__ge__", 2, jtu.default_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__pos__", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__neg__", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__pow__", 2, jtu.inexact_dtypes, all_shapes, jtu.rand_positive, [],
               tolerance={np.float32: 2e-4, np.complex64: 2e-4, np.complex128: 1e-14}),
-    op_record("__mod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
+    op_record("__mod__", 2, jtu.default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={np.float16: 1e-1}),
-    op_record("__floordiv__", 2, default_dtypes, all_shapes,
+    op_record("__floordiv__", 2, jtu.default_dtypes, all_shapes,
               jtu.rand_nonzero, []),
-    op_record("__truediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
+    op_record("__truediv__", 2, jtu.number_dtypes, all_shapes, jtu.rand_nonzero, [],
               inexact=True),
-    op_record("__abs__", 1, number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__abs__", 1, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
     # TODO(mattjj): __invert__ fails on bool dtypes because ~True == -2
-    op_record("__invert__", 1, int_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__invert__", 1, jtu.int_dtypes, all_shapes, jtu.rand_default, []),
     # TODO(mattjj): investigate these failures
-    # op_record("__or__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
-    # op_record("__and__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
-    # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    # op_record("__or__", 2, jtu.number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__and__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    # op_record("__xor__", 2, jtu.number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__divmod__", 2, jtu.number_dtypes, all_shapes, jtu.rand_nonzero, []),
     # TODO(mattjj): lshift, rshift
 ]
 
 JAX_RIGHT_OPERATOR_OVERLOADS = [
-    op_record("__radd__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__rsub__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__rmul__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("__rpow__", 2, inexact_dtypes, all_shapes, jtu.rand_positive, [],
+    op_record("__radd__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rsub__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rmul__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    op_record("__rpow__", 2, jtu.inexact_dtypes, all_shapes, jtu.rand_positive, [],
               tolerance={np.float32: 2e-4, np.complex64: 1e-3}),
-    op_record("__rmod__", 2, default_dtypes, all_shapes, jtu.rand_nonzero, [],
+    op_record("__rmod__", 2, jtu.default_dtypes, all_shapes, jtu.rand_nonzero, [],
               tolerance={np.float16: 1e-1}),
-    op_record("__rfloordiv__", 2, default_dtypes, all_shapes,
+    op_record("__rfloordiv__", 2, jtu.default_dtypes, all_shapes,
               jtu.rand_nonzero, []),
-    op_record("__rtruediv__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, [],
+    op_record("__rtruediv__", 2, jtu.number_dtypes, all_shapes, jtu.rand_nonzero, [],
               inexact=True),
-    # op_record("__ror__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
-    # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
-    # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
-    # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
+    # op_record("__ror__", 2, jtu.number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__rand__", 2, jtu.number_dtypes, all_shapes, jtu.rand_default, []),
+    # op_record("__rxor__", 2, jtu.number_dtypes, all_shapes, jtu.rand_bool, []),
+    # op_record("__rdivmod__", 2, jtu.number_dtypes, all_shapes, jtu.rand_nonzero, []),
 ]
 
 class _OverrideEverything(object):
@@ -379,16 +362,14 @@ for rec in JAX_OPERATOR_OVERLOADS + JAX_RIGHT_OPERATOR_OVERLOADS:
 numpy_version = tuple(map(int, np.version.version.split('.')))
 if numpy_version >= (1, 15):
   JAX_COMPOUND_OP_RECORDS += [
-      op_record("isclose", 2, [t for t in all_dtypes if t != jnp.bfloat16],
+      op_record("isclose", 2, [t for t in jtu.all_dtypes if t != jnp.bfloat16],
                 all_shapes, jtu.rand_small_positive, []),
-      op_record("gcd", 2, int_dtypes, all_shapes, jtu.rand_default, []),
-      op_record("lcm", 2, int_dtypes, all_shapes, jtu.rand_default, []),
+      op_record("gcd", 2, jtu.int_dtypes, all_shapes, jtu.rand_default, []),
+      op_record("lcm", 2, jtu.int_dtypes, all_shapes, jtu.rand_default, []),
   ]
   JAX_REDUCER_NO_DTYPE_RECORDS += [
-      op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
+      op_record("ptp", 1, jtu.number_dtypes, nonempty_shapes, jtu.rand_default, []),
   ]
-
-CombosWithReplacement = itertools.combinations_with_replacement
 
 
 def _dtypes_are_compatible_for_bitwise_ops(args):
@@ -461,7 +442,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "inexact": rec.inexact}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in itertools.chain(JAX_ONE_TO_ONE_OP_RECORDS,
@@ -489,7 +470,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "tol": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_OPERATOR_OVERLOADS))
@@ -509,7 +490,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "op_tolerance": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_RIGHT_OPERATOR_OVERLOADS))
@@ -559,10 +540,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "np_op": getattr(np, rec.name), "jnp_op": getattr(jnp, rec.name)}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in filter(
           _dtypes_are_compatible_for_bitwise_ops,
-          CombosWithReplacement(rec.dtypes, rec.nargs)))
+          itertools.combinations_with_replacement(rec.dtypes, rec.nargs)))
       for rec in JAX_BITWISE_OP_RECORDS))
   def testBitwiseOp(self, np_op, jnp_op, rng_factory, shapes, dtypes):
     rng = rng_factory(self.rng())
@@ -648,7 +629,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "shape": shape, "dtype": dtype, "axis": axis}
-      for shape in all_shapes for dtype in all_dtypes
+      for shape in all_shapes for dtype in jtu.all_dtypes
       for axis in list(range(-len(shape), len(shape))) + [None]))
   def testCountNonzero(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
@@ -662,7 +643,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+      for shape in all_shapes for dtype in jtu.all_dtypes))
   def testNonzero(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda x: np.nonzero(x)
@@ -677,7 +658,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+      for shape in all_shapes for dtype in jtu.all_dtypes))
   def testFlatNonzero(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = jtu.ignore_warning(
@@ -691,7 +672,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+      for shape in all_shapes for dtype in jtu.all_dtypes))
   def testArgWhere(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = jtu.ignore_warning(
@@ -774,7 +755,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 5, 2), (4, 5, 2), (-1, -1, 0, None)], # axisc should do nothing
           [(4, 5, 2), (4, 5, 2), (-1, -1, -1, None)] # same as before
       ]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(jtu.number_dtypes, 2)))
   def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -813,7 +794,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-matrix", (4, 3, 2), (2, 5)),
           ("matrix-tensor", (5, 2), (3, 2, 4)),
           ("tensor-tensor", (2, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(jtu.number_dtypes, 2)))
   def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -850,7 +831,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-matrix", (5, 2, 3), (3, 2)),
           ("tensor-tensor", (5, 3, 4), (5, 4, 1)),
           ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(jtu.number_dtypes, 2)))
   def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
     rng = rng_factory(self.rng())
     def np_fun(x, y):
@@ -881,7 +862,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(2, 3, 4), (5, 4, 3, 6), [[1, 2], [2, 1]]],
           [(1, 2, 3, 4), (4, 5, 3, 6), [[2, 3], [2, 0]]],
       ]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(jtu.number_dtypes, 2)))
   def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -927,7 +908,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "dtype": dtype, "invert": invert}
       for element_shape in all_shapes
       for test_shape in all_shapes
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for invert in [True, False]))
   def testIsin(self, element_shape, test_shape, dtype, invert):
     rng = jtu.rand_default(self.rng())
@@ -946,7 +927,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "dtype": dtype, "invert": invert}
       for element_shape in all_shapes
       for test_shape in all_shapes
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for invert in [True, False]))
   def testIn1d(self, element_shape, test_shape, dtype, invert):
     rng = jtu.rand_default(self.rng())
@@ -965,8 +946,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
        "rng_factory": jtu.rand_default}
       # TODO(phawkins): support integer dtypes too.
-      for lhs_shape, lhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
-      for rhs_shape, rhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
+      for lhs_shape, lhs_dtype in _shape_and_dtypes(all_shapes, jtu.inexact_dtypes)
+      for rhs_shape, rhs_dtype in _shape_and_dtypes(all_shapes, jtu.inexact_dtypes)
       if len(jtu._dims_of_shape(lhs_shape)) == 0
       or len(jtu._dims_of_shape(rhs_shape)) == 0
       or lhs_shape[-1] == rhs_shape[-1]))
@@ -996,7 +977,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), a_min, a_max),
        "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max,
        "rng_factory": jtu.rand_default}
-      for shape in all_shapes for dtype in number_dtypes
+      for shape in all_shapes for dtype in jtu.number_dtypes
       for a_min, a_max in [(-1, None), (None, 1), (-1, 1),
                            (-np.ones(1), None),
                            (None, np.ones(1)),
@@ -1019,7 +1000,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), decimals),
        "shape": shape, "dtype": dtype, "decimals": decimals,
        "rng_factory": jtu.rand_default}
-      for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)
+      for shape, dtype in _shape_and_dtypes(all_shapes, jtu.number_dtypes)
       for decimals in [0, 1, -2]))
   def testRoundStaticDecimals(self, shape, dtype, decimals, rng_factory):
     rng = rng_factory(self.rng())
@@ -1068,7 +1049,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ('wrap', None, nonempty_shapes),
         ('edge', None, nonempty_shapes),
       ]
-      for shape, dtype in _shape_and_dtypes(shapes, all_dtypes)
+      for shape, dtype in _shape_and_dtypes(shapes, jtu.all_dtypes)
       for pad_width_rank in range(3)))
   def testPad(self, shape, dtype, mode, pad_width_rank, constant_values_rank,
               rng_factory, irng_factory):
@@ -1099,7 +1080,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "reps": reps,
        "rng_factory": jtu.rand_default}
       for reps in [(), (2,), (3, 4), (2, 3, 4)]
-      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
+      for shape, dtype in _shape_and_dtypes(all_shapes, jtu.default_dtypes)
       ))
   def testTile(self, shape, dtype, reps, rng_factory):
     rng = rng_factory(self.rng())
@@ -1117,7 +1098,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype}
       for shape in all_shapes
-      for dtype in all_dtypes))
+      for dtype in jtu.all_dtypes))
   def testExtract(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, jnp.float32), rng(shape, dtype)]
@@ -1129,7 +1110,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(a_shape, dtype),
           jtu.format_shape_dtype_string(b_shape, dtype)),
        "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for a_shape in one_dim_array_shapes
       for b_shape in one_dim_array_shapes))
   def testPolyAdd(self, a_shape, b_shape, dtype):
@@ -1146,7 +1127,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(a_shape, dtype),
           jtu.format_shape_dtype_string(b_shape, dtype)),
        "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for a_shape in one_dim_array_shapes
       for b_shape in one_dim_array_shapes))
   def testPolySub(self, a_shape, b_shape, dtype):
@@ -1163,7 +1144,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(a_shape, dtype),
           order),
        "dtype": dtype, "a_shape": a_shape, "order" : order}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for a_shape in one_dim_array_shapes
       for order in range(5)))
   def testPolyDer(self, a_shape, order, dtype):
@@ -1180,7 +1161,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "shape": shape, "dtype": dtype, "axis": axis}
       for shape in all_shapes
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for axis in [None] + list(range(len(shape)))))
   def testCompress(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
@@ -1202,7 +1183,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), len(condition), axis),
        "shape": shape, "dtype": dtype, "condition": condition, "axis": axis}
       for shape in [(2, 3)]
-      for dtype in int_dtypes
+      for dtype in jtu.int_dtypes
       # condition entries beyond axis size must be zero.
       for condition in [[1], [1, 0, 0, 0, 0, 0, 0]]
       for axis in [None, 0, 1]))
@@ -1218,7 +1199,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "shape": shape, "dtype": dtype, "axis": axis}
       for shape in array_shapes
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for axis in [None] + list(range(len(shape)))))
   def testCompressMethod(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
@@ -1242,7 +1223,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
        "rng_factory": jtu.rand_default}
       for num_arrs in [3]
-      for arg_dtypes in CombosWithReplacement(default_dtypes, num_arrs)
+      for arg_dtypes in itertools.combinations_with_replacement(jtu.default_dtypes, num_arrs)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
   def testConcatenate(self, axis, base_shape, arg_dtypes, rng_factory):
@@ -1275,7 +1256,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
        "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
        "rng_factory": jtu.rand_default}
-      for arg_dtypes in CombosWithReplacement(default_dtypes, 2)
+      for arg_dtypes in itertools.combinations_with_replacement(jtu.default_dtypes, 2)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
   def testAppend(self, axis, base_shape, arg_dtypes, rng_factory):
@@ -1303,7 +1284,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axis": axis, "shape": shape, "dtype": dtype, "repeats": repeats,
        "rng_factory": jtu.rand_default}
       for repeats in [0, 1, 2]
-      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
+      for shape, dtype in _shape_and_dtypes(all_shapes, jtu.default_dtypes)
       for axis in [None] + list(range(-len(shape), max(1, len(shape))))))
   def testRepeat(self, axis, shape, dtype, repeats, rng_factory):
     rng = rng_factory(self.rng())
@@ -1323,7 +1304,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype,
        "return_index": return_index, "return_inverse": return_inverse,
        "return_counts": return_counts}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in all_shapes
       for return_index in [False, True]
       for return_inverse in [False, True]
@@ -1401,7 +1382,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "np_op": getattr(np, op)}
       for mode in ['full', 'same', 'valid']
       for op in ['convolve', 'correlate']
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for xshape in one_dim_array_shapes
       for yshape in one_dim_array_shapes))
   def testConvolutions(self, xshape, yshape, dtype, mode, rng_factory, jnp_op, np_op):
@@ -1422,8 +1403,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_default, "jnp_op": getattr(jnp, op),
        "np_op": getattr(np, op)}
       for op in ["cumsum", "cumprod"]
-      for dtype in all_dtypes
-      for out_dtype in default_dtypes
+      for dtype in jtu.all_dtypes
+      for out_dtype in jtu.default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
   def testCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op, rng_factory):
@@ -1449,8 +1430,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
        "jnp_op": getattr(jnp, op), "np_op": getattr(np, op)}
       for op in ["nancumsum", "nancumprod"]
-      for dtype in all_dtypes
-      for out_dtype in default_dtypes
+      for dtype in jtu.all_dtypes
+      for out_dtype in jtu.default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
   def testNanCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op):
@@ -1478,7 +1459,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         jtu.format_shape_dtype_string(xshape, dtype) if xshape is not None else None,
         dx, axis),
         "yshape": yshape, "xshape": xshape, "dtype": dtype, "dx": dx, "axis": axis}
-        for dtype in default_dtypes
+        for dtype in jtu.default_dtypes
         for yshape, xshape, dx, axis in [
           ((10,), None, 1.0, -1),
           ((3, 10), None, 2.0, -1),
@@ -1504,7 +1485,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_dtype={}_m={}_n={}_k={}".format(
           np.dtype(dtype).name, m, n, k),
        "m": m, "n": n, "k": k, "dtype": dtype}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for n in [0, 4]
       for m in [None, 0, 1, 3, 4]
       for k in list(range(-4, 4))))
@@ -1520,7 +1501,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           op, jtu.format_shape_dtype_string(shape, dtype), k),
        "dtype": dtype, "shape": shape, "op": op, "k": k,
        "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for op in ["tril", "triu"]
       for k in list(range(-3, 3))))
@@ -1560,7 +1541,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     {"testcase_name": "_shape={}_k={}".format(
       jtu.format_shape_dtype_string(shape, dtype), k),
       "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
-    for dtype in default_dtypes
+    for dtype in jtu.default_dtypes
     for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
     for k in [-1, 0, 1]))
   def testTriuIndicesFrom(self, shape, dtype, k, rng_factory):
@@ -1574,7 +1555,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     {"testcase_name": "_shape={}_k={}".format(
       jtu.format_shape_dtype_string(shape, dtype), k),
       "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
-    for dtype in default_dtypes
+    for dtype in jtu.default_dtypes
     for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
     for k in [-1, 0, 1]))
   def testTrilIndicesFrom(self, shape, dtype, k, rng_factory):
@@ -1598,7 +1579,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         jtu.format_shape_dtype_string(shape, dtype)
       ),
        "dtype": dtype, "shape": shape}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in [(1,1), (2,2), (3,3), (4,4), (5,5)]))
   def testDiagIndicesFrom(self, dtype, shape):
     rng = jtu.rand_default(self.rng())
@@ -1612,7 +1593,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_k={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k),
        "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) in (1, 2)]
       for k in list(range(-4, 4))))
   def testDiag(self, shape, dtype, k, rng_factory):
@@ -1627,7 +1608,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_k={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k),
        "dtype": dtype, "shape": shape, "k": k}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in all_shapes
       for k in range(-4, 4)))
   def testDiagFlat(self, shape, dtype, k):
@@ -1646,7 +1627,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(a1_shape, dtype),
           jtu.format_shape_dtype_string(a2_shape, dtype)),
        "dtype": dtype, "a1_shape": a1_shape, "a2_shape": a2_shape}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for a1_shape in one_dim_array_shapes
       for a2_shape in one_dim_array_shapes))
   def testPolyMul(self, a1_shape, a2_shape, dtype):
@@ -1664,7 +1645,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), offset, axis1, axis2),
        "dtype": dtype, "shape": shape, "offset": offset, "axis1": axis1,
        "axis2": axis2, "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in [a for a in range(-len(shape), len(shape))
@@ -1681,7 +1662,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_n={}".format(np.dtype(dtype).name, n),
        "dtype": dtype, "n": n}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for n in list(range(4))))
   def testIdentity(self, n, dtype):
     np_fun = lambda: np.identity(n, dtype)
@@ -1702,8 +1683,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         enumerate([jtu.rand_some_inf_and_nan, jtu.rand_some_zero])
       for x2_rng_factory in [partial(jtu.rand_int, low=-1075, high=1024)]
       for x1_shape, x2_shape in filter(_shapes_are_broadcast_compatible,
-                                       CombosWithReplacement(array_shapes, 2))
-      for x1_dtype in default_dtypes))
+                                       itertools.combinations_with_replacement(array_shapes, 2))
+      for x1_dtype in jtu.default_dtypes))
   @jtu.skip_on_devices("tpu")  # TODO(b/153053081)
   def testLdexp(self, x1_shape, x1_dtype, x2_shape, x1_rng_factory, x2_rng_factory):
     # integer types are converted to float64 in numpy's implementation
@@ -1731,7 +1712,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           partial(jtu.rand_not_small, offset=1e8),
       ])
       for shape in all_shapes
-      for dtype in default_dtypes))
+      for dtype in jtu.default_dtypes))
   @jtu.skip_on_devices("tpu")
   def testFrexp(self, shape, dtype, rng_factory):
     # integer types are converted to float64 in numpy's implementation
@@ -1752,8 +1733,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           out_dtype, offset, axis1, axis2),
        "dtype": dtype, "out_dtype": out_dtype, "shape": shape, "offset": offset,
        "axis1": axis1, "axis2": axis2, "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
-      for out_dtype in [None] + number_dtypes
+      for dtype in jtu.default_dtypes
+      for out_dtype in [None] + jtu.number_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in range(-len(shape), len(shape))
@@ -1780,7 +1761,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for ashape in [(20,)]
     for vshape in [(), (5,), (5, 5)]
     for side in ['left', 'right']
-    for dtype in default_dtypes
+    for dtype in jtu.default_dtypes
     for rng_factory in [jtu.rand_default]
   ))
   def testSearchsorted(self, ashape, vshape, side, dtype, rng_factory):
@@ -1801,7 +1782,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for binshape in [(1,), (5,)]
     for right in [True, False]
     for reverse in [True, False]
-    for dtype in default_dtypes
+    for dtype in jtu.default_dtypes
     for rng_factory in [jtu.rand_default]
   ))
   def testDigitize(self, xshape, binshape, right, reverse, dtype, rng_factory):
@@ -1883,8 +1864,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "fill_value_dtype": fill_value_dtype,
        "out_dtype": out_dtype, "rng_factory": jtu.rand_default}
       for shape in array_shapes + [3, np.array(7, dtype=np.int32)]
-      for fill_value_dtype in default_dtypes
-      for out_dtype in [None] + default_dtypes))
+      for fill_value_dtype in jtu.default_dtypes
+      for out_dtype in [None] + jtu.default_dtypes))
   def testFull(self, shape, fill_value_dtype, out_dtype, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda fill_value: np.full(shape, fill_value, dtype=out_dtype)
@@ -1901,7 +1882,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for op in ["zeros", "ones"]
       for shape in [2, (), (2,), (3, 0), np.array((4, 5, 6), dtype=np.int32),
                     np.array(4, dtype=np.int32)]
-      for dtype in all_dtypes))
+      for dtype in jtu.all_dtypes))
   def testZerosOnes(self, np_op, jnp_op, shape, dtype):
     args_maker = lambda: []
     np_op = partial(np_op, shape, dtype)
@@ -1922,9 +1903,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "fill_value_dtype": fill_value_dtype, "out_dtype": out_dtype,
        "rng_factory": jtu.rand_default}
       for shape in array_shapes
-      for in_dtype in default_dtypes
-      for fill_value_dtype in default_dtypes
-      for out_dtype in default_dtypes))
+      for in_dtype in jtu.default_dtypes
+      for fill_value_dtype in jtu.default_dtypes
+      for out_dtype in jtu.default_dtypes))
   def testFullLike(self, shape, in_dtype, fill_value_dtype, out_dtype, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda x, fill_value: np.full_like(x, fill_value, dtype=out_dtype)
@@ -1941,7 +1922,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for shape, axis, num_sections in [
           ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
-      for dtype in default_dtypes))
+      for dtype in jtu.default_dtypes))
   def testSplitStaticInt(self, shape, num_sections, axis, dtype, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.split(x, num_sections, axis=axis)
@@ -1979,7 +1960,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       "weights": weights,
     }
     for shape in [(5,), (5, 5)]
-    for dtype in number_dtypes
+    for dtype in jtu.number_dtypes
     for bins in [10, np.arange(-5, 6), [-5, 0, 3]]
     for range in [None, (0, 10)]
     for weights in [True, False]
@@ -2009,7 +1990,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       "weights": weights,
     }
     for shape in [(5,), (5, 5)]
-    for dtype in default_dtypes
+    for dtype in jtu.default_dtypes
     # We only test explicit integer-valued bin edges beause in other cases
     # rounding errors lead to flaky tests.
     for bins in [np.arange(-5, 6), [-5, 0, 3]]
@@ -2040,7 +2021,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for shape, axis, num_sections in [
           ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]
-      for dtype in default_dtypes))
+      for dtype in jtu.default_dtypes))
   def testHVDSplit(self, shape, num_sections, axis, dtype, rng_factory):
     rng = rng_factory(self.rng())
     def fn(module, axis):
@@ -2065,7 +2046,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           order),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "order": order, "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for order in ["C", "F"]
       for arg_shape, out_shape in [
           (jtu.NUMPY_SCALAR_SHAPE, (1, 1, 1)),
@@ -2091,7 +2072,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "rng_factory": jtu.rand_default}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for arg_shape, out_shape in [
           ((7, 0), (0, 42, 101)),
           ((2, 1, 4), (-1,)),
@@ -2111,7 +2092,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "dim": dim,
        "rng_factory": jtu.rand_default}
       for arg_shape in [(), (3,), (3, 4)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
                   + [np.array(0), np.array(-1), (0,), (np.array(0),),
                      (len(arg_shape), len(arg_shape) + 1)])))
@@ -2134,7 +2115,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for arg_shape, ax1, ax2 in [
           ((3, 4), 0, 1), ((3, 4), 1, 0), ((3, 4, 5), 1, 2),
           ((3, 4, 5), -1, -2), ((3, 4, 5), 0, 1)]
-      for dtype in default_dtypes))
+      for dtype in jtu.default_dtypes))
   def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.swapaxes(x, ax1, ax2)
@@ -2156,7 +2137,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((1, 3, 1), (0, 2)),
           ((1, 3, 1), (0,)),
           ((1, 4, 1), (np.array(0),))]
-      for dtype in default_dtypes))
+      for dtype in jtu.default_dtypes))
   def testSqueeze(self, arg_shape, dtype, ax, rng_factory):
     rng = rng_factory(self.rng())
     np_fun = lambda x: np.squeeze(x, ax)
@@ -2173,7 +2154,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           returned),
        "rng_factory": jtu.rand_default, "shape": shape, "dtype": dtype, "axis": axis,
        "weights_shape": weights_shape, "returned": returned}
-      for shape, dtype in _shape_and_dtypes(nonempty_shapes, number_dtypes)
+      for shape, dtype in _shape_and_dtypes(nonempty_shapes, jtu.number_dtypes)
       for axis in list(range(-len(shape), len(shape))) + [None]
       # `weights_shape` is either `None`, same as the averaged axis, or same as
       # that of the input
@@ -2207,16 +2188,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        f"_arg{i}_ndmin={ndmin}_dtype={np.dtype(dtype) if dtype else None}",
        "arg": arg, "ndmin": ndmin, "dtype": dtype}
       for i, (arg, dtypes) in enumerate([
-          ([True, False, True], all_dtypes),
-          (3., all_dtypes),
-          ([1, 2, 3], all_dtypes),
-          (np.array([1, 2, 3], dtype=np.int64), all_dtypes),
-          ([1., 2., 3.], all_dtypes),
-          ([[1, 2], [3, 4], [5, 6]], all_dtypes),
-          ([[1, 2.], [3, 4], [5, 6]], all_dtypes),
-          ([[1., 2j], [3., 4.], [5., 6.]], complex_dtypes),
+          ([True, False, True], jtu.all_dtypes),
+          (3., jtu.all_dtypes),
+          ([1, 2, 3], jtu.all_dtypes),
+          (np.array([1, 2, 3], dtype=np.int64), jtu.all_dtypes),
+          ([1., 2., 3.], jtu.all_dtypes),
+          ([[1, 2], [3, 4], [5, 6]], jtu.all_dtypes),
+          ([[1, 2.], [3, 4], [5, 6]], jtu.all_dtypes),
+          ([[1., 2j], [3., 4.], [5., 6.]], jtu.complex_dtypes),
           ([[3, np.array(2, dtype=jnp.float_), 1],
-           np.arange(3., dtype=jnp.float_)], all_dtypes),
+           np.arange(3., dtype=jnp.float_)], jtu.all_dtypes),
       ])
       for dtype in [None] + dtypes
       for ndmin in [None, np.ndim(arg), np.ndim(arg) + 1, np.ndim(arg) + 2]))
@@ -2416,7 +2397,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
       for shape in [(3,), (2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for axis in list(range(-len(shape), len(shape))) + [None]  # Test negative axes
       for rng_factory in [jtu.rand_default]))
   def testFlip(self, shape, dtype, axis, rng_factory):
@@ -2432,7 +2413,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype)),
        "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
       for shape in [(3,), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testFlipud(self, shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -2448,7 +2429,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype)),
        "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
       for shape in [(3, 2), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testFliplr(self, shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -2470,7 +2451,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 3, 2), (2, 1)],
       ]
       for k in range(-3, 4)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testRot90(self, shape, dtype, k, axes, rng_factory):
     rng = rng_factory(self.rng())
@@ -2515,8 +2496,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, a_dtype), dtype),
       "shape": shape, "a_dtype": a_dtype, "dtype": dtype}
       for shape in [(8,), (3, 8)]  # last dim = 8 to ensure shape compatibility
-      for a_dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)
-      for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
+      for a_dtype in (jtu.default_dtypes + jtu.uint_dtypes + jtu.bool_dtypes)
+      for dtype in (jtu.default_dtypes + jtu.uint_dtypes + jtu.bool_dtypes)))
   def testView(self, shape, a_dtype, dtype):
     if jtu.device_under_test() == 'tpu':
       if jnp.dtype(a_dtype).itemsize in [1, 2] or jnp.dtype(dtype).itemsize in [1, 2]:
@@ -2630,7 +2611,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           shifts, axis),
        "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "shifts": shifts,
        "axis": axis}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape in [(3, 4), (3, 4, 5), (7, 4, 0)]
       for shifts, axis in [
         (3, None),
@@ -2656,7 +2637,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis, start),
        "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis,
        "start": start}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape in [(1, 2, 3, 4)]
       for axis in [-3, 0, 2, 3]
       for start in [-4, -1, 2, 4]
@@ -2720,8 +2701,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for index_shape in scalar_shapes + [(3,), (2, 1, 3)]
       for axis in itertools.chain(range(-len(shape), len(shape)),
                                   [cast(Optional[int], None)])
-      for dtype in all_dtypes
-      for index_dtype in int_dtypes
+      for dtype in jtu.all_dtypes
+      for index_dtype in jtu.int_dtypes
       for mode in ['wrap', 'clip']))
   def testTake(self, shape, dtype, index_shape, index_dtype, axis, mode):
     def args_maker():
@@ -2744,10 +2725,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for x_shape, i_shape in filter(
         _shapes_are_equal_length,
         filter(_shapes_are_broadcast_compatible,
-               CombosWithReplacement(nonempty_nonscalar_array_shapes, 2)))
+               itertools.combinations_with_replacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1],
                                   [cast(Optional[int], None)])
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testTakeAlongAxis(self, x_shape, i_shape, dtype, axis, rng_factory):
     rng = rng_factory(self.rng())
@@ -2777,7 +2758,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           n, increasing),
        "dtype": dtype, "shape": shape, "n": n, "increasing": increasing,
        "rng_factory": jtu.rand_default}
-      for dtype in inexact_dtypes
+      for dtype in jtu.inexact_dtypes
       for shape in [0, 5]
       for n in [2, 4]
       for increasing in [False, True]))
@@ -2800,7 +2781,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "rng_factory": jtu.rand_some_inf_and_nan, "shape": shape,
          "dtype": dtype}
         for shape in array_shapes
-        for dtype in inexact_dtypes))
+        for dtype in jtu.inexact_dtypes))
   def testNanToNum(self, rng_factory, shape, dtype):
     rng = rng_factory(self.rng())
     dtype = np.dtype(dtypes.canonicalize_dtype(dtype)).type
@@ -2842,7 +2823,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
             dimensions, dtype, sparse),
          "dimensions": dimensions, "dtype": dtype, "sparse": sparse}
         for dimensions in [(), (2,), (3, 0), (4, 5, 6)]
-        for dtype in number_dtypes
+        for dtype in jtu.number_dtypes
         for sparse in [True, False]))
   def testIndices(self, dimensions, dtype, sparse):
     def args_maker(): return []
@@ -2878,7 +2859,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("nanpercentile", partial(jtu.rand_uniform, low=0., high=100.)),
           ("nanquantile", partial(jtu.rand_uniform, low=0., high=1.)),
         )
-        for a_dtype in default_dtypes
+        for a_dtype in jtu.default_dtypes
         for a_shape, axis in (
           ((7,), None),
           ((47, 7), 0),
@@ -2926,7 +2907,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "op": op, "a_shape": a_shape, "a_dtype": a_dtype,
          "axis": axis,
          "keepdims": keepdims}
-        for a_dtype in default_dtypes
+        for a_dtype in jtu.default_dtypes
         for a_shape, axis in (
           ((7,), None),
           ((47, 7), 0),
@@ -2959,7 +2940,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
        "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+      for shape in all_shapes for dtype in jtu.all_dtypes))
   def testWhereOneArgument(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda x: np.where(x)
@@ -2976,8 +2957,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for shape, dtype in zip(shapes, dtypes))),
      "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
     for shapes in filter(_shapes_are_broadcast_compatible,
-                         CombosWithReplacement(all_shapes, 3))
-    for dtypes in CombosWithReplacement(all_dtypes, 3)))
+                         itertools.combinations_with_replacement(all_shapes, 3))
+    for dtypes in itertools.combinations_with_replacement(jtu.all_dtypes, 3)))
   def testWhereThreeArgument(self, rng_factory, shapes, dtypes):
     args_maker = self._GetArgsMaker(rng_factory(self.rng()), shapes, dtypes)
     def np_fun(cond, x, y):
@@ -2997,8 +2978,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for n in range(0, 3)
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(all_shapes, 2 * n + 1))
-        for dtypes in CombosWithReplacement(all_dtypes, n + 1)))
+          itertools.combinations_with_replacement(all_shapes, 2 * n + 1))
+        for dtypes in itertools.combinations_with_replacement(jtu.all_dtypes, n + 1)))
   def testSelect(self, rng_factory, shapes, dtypes):
     rng = rng_factory(self.rng())
     n = len(dtypes) - 1
@@ -3087,7 +3068,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       "length": length,
       "rng_factory": rng_factory}
     for shape in [(5,), (10,)]
-    for dtype in int_dtypes
+    for dtype in jtu.int_dtypes
     for weights in [True, False]
     for minlength in [0, 20]
     for length in [None, 10]
@@ -3223,7 +3204,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(op, [()], [dtype]),
          "dtype": dtype, "op": op}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for op in ("sqrt", "arccos", "arcsin", "arctan", "sin", "cos", "tan",
                  "sinh", "cosh", "tanh", "arccosh", "arcsinh", "arctanh", "exp",
                  "log", "expm1", "log1p")))
@@ -3278,8 +3259,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "shape": shape, "dtype": dtype, "out_dtype": out_dtype, "axis": axis,
          "ddof": ddof, "keepdims": keepdims, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5)]
-        for dtype in all_dtypes
-        for out_dtype in inexact_dtypes
+        for dtype in jtu.all_dtypes
+        for out_dtype in jtu.inexact_dtypes
         for axis in [None, 0, -1]
         for ddof in [0, 1, 2]
         for keepdims in [False, True]
@@ -3313,8 +3294,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "shape": shape, "dtype": dtype, "out_dtype": out_dtype, "axis": axis,
          "ddof": ddof, "keepdims": keepdims, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5)]
-        for dtype in all_dtypes
-        for out_dtype in inexact_dtypes
+        for dtype in jtu.all_dtypes
+        for out_dtype in jtu.inexact_dtypes
         for axis in [None, 0, -1]
         for ddof in [0, 1, 2]
         for keepdims in [False, True]
@@ -3347,7 +3328,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "shape": shape, "dtype": dtype, "rowvar": rowvar, "ddof": ddof,
          "bias": bias, "rng_factory": rng_factory}
         for shape in [(5,), (10, 5), (5, 10)]
-        for dtype in all_dtypes
+        for dtype in jtu.all_dtypes
         for rowvar in [True, False]
         for bias in [True, False]
         for ddof in [None, 2, 3]
@@ -3375,7 +3356,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
             shape, dtype.__name__, rowvar),
          "shape": shape, "dtype": dtype, "rowvar": rowvar}
         for shape in [(5,), (10, 5), (3, 10)]
-        for dtype in number_dtypes
+        for dtype in jtu.number_dtypes
         for rowvar in [True, False]))
   def testCorrCoef(self, shape, dtype, rowvar):
     rng = jtu.rand_default(self.rng())
@@ -3401,7 +3382,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "end_shape": end_shape,
        "end_dtype": end_dtype, "begin_shape": begin_shape,
        "begin_dtype": begin_dtype}
-      for dtype in number_dtypes
+      for dtype in jtu.number_dtypes
       for end_dtype in [None] + [dtype]
       for begin_dtype in [None] + [dtype]
       for shape in [s for s in all_shapes if s != jtu.PYTHON_SCALAR_SHAPE]
@@ -3440,7 +3421,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "shapes": shapes, "dtype": dtype, "indexing": indexing,
          "sparse": sparse, "rng_factory": rng_factory}
         for shapes in [(), (5,), (5, 3)]
-        for dtype in number_dtypes
+        for dtype in jtu.number_dtypes
         for indexing in ['xy', 'ij']
         for sparse in [True, False]
         for rng_factory in [jtu.rand_default]))
@@ -3466,7 +3447,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for retstep in [True, False]
-        for dtype in number_dtypes + [None,]
+        for dtype in jtu.number_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testLinspace(self, start_shape, stop_shape, num, endpoint,
                    retstep, dtype, rng_factory):
@@ -3491,7 +3472,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                               check_dtypes=False, tol=tol)
       # floating-point compute between jitted platforms and non-jit + rounding
       # cause unavoidable variation in integer truncation for some inputs.
-      if dtype in (inexact_dtypes + [None,]):
+      if dtype in (jtu.inexact_dtypes + [None,]):
         self._CompileAndCheck(jnp_op, args_maker,
                               check_dtypes=False, atol=tol, rtol=tol)
 
@@ -3500,7 +3481,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         {"testcase_name": "_dtype={}".format(dtype),
          "dtype": dtype,
          "rng_factory": rng_factory}
-        for dtype in number_dtypes
+        for dtype in jtu.number_dtypes
         for rng_factory in [jtu.rand_default]))
   def testLinspaceEndpoints(self, dtype, rng_factory):
     """Regression test for Issue #3014."""
@@ -3524,11 +3505,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for base in [10.0, 2, np.e]
-        for dtype in inexact_dtypes + [None,]
+        for dtype in jtu.inexact_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testLogspace(self, start_shape, stop_shape, num,
                    endpoint, base, dtype, rng_factory):
-    if (dtype in int_dtypes and
+    if (dtype in jtu.int_dtypes and
         jtu.device_under_test() in ("gpu", "tpu") and
         not FLAGS.jax_enable_x64):
       raise unittest.SkipTest("GPUx32 truncated exponentiation"
@@ -3549,7 +3530,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         start, stop, num, endpoint=endpoint, base=base, dtype=dtype, axis=axis)
       self._CheckAgainstNumpy(np_op, jnp_op, args_maker,
                               check_dtypes=False, tol=tol)
-      if dtype in (inexact_dtypes + [None,]):
+      if dtype in (jtu.inexact_dtypes + [None,]):
         # Why do compiled and op-by-op float16 np.power numbers differ
         # slightly more than expected?
         atol = {np.float16: 1e-2}
@@ -3570,7 +3551,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         # NB: numpy's geomspace gives nonsense results on integer types
-        for dtype in inexact_dtypes + [None,]
+        for dtype in jtu.inexact_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testGeomspace(self, start_shape, stop_shape, num,
                     endpoint, dtype, rng_factory):
@@ -3586,7 +3567,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       # np.geomspace can't handle differently ranked tensors
       # w. negative numbers!
       start, stop = jnp.broadcast_arrays(start, stop)
-      if dtype in complex_dtypes:
+      if dtype in jtu.complex_dtypes:
         return start, stop
       # to avoid NaNs, non-complex start and stop cannot
       # differ in sign, elementwise
@@ -3607,7 +3588,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis=axis).astype(dtype)
       self._CheckAgainstNumpy(np_op, jnp_op, args_maker,
                               check_dtypes=False, tol=tol)
-      if dtype in (inexact_dtypes + [None,]):
+      if dtype in (jtu.inexact_dtypes + [None,]):
         self._CompileAndCheck(jnp_op, args_maker,
                               check_dtypes=False, atol=tol, rtol=tol)
 
@@ -3766,7 +3747,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for _num_axes in range(len(shape))
         for varargs in itertools.combinations(range(1, len(shape) + 1), _num_axes)
         for axis in itertools.combinations(range(len(shape)), _num_axes)
-        for dtype in inexact_dtypes
+        for dtype in jtu.inexact_dtypes
         for rng_factory in [jtu.rand_default]))
   def testGradient(self, shape, varargs, axis, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -3863,7 +3844,7 @@ class NumpyGradTests(jtu.JaxTestCase):
             rec.name, shapes, itertools.repeat(dtype)),
          "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
          "order": rec.order, "tol": rec.tol}
-        for shapes in CombosWithReplacement(nonempty_shapes, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(nonempty_shapes, rec.nargs)
         for dtype in rec.dtypes)
       for rec in GRAD_TEST_RECORDS))
   def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3834,8 +3834,6 @@ GRAD_SPECIAL_VALUE_TEST_RECORDS = [
     GradSpecialValuesTestSpec(jnp.sinc, [0.], 1),
 ]
 
-def num_float_bits(dtype):
-  return jnp.finfo(dtypes.canonicalize_dtype(dtype)).bits
 
 class NumpyGradTests(jtu.JaxTestCase):
   @parameterized.named_parameters(itertools.chain.from_iterable(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3505,7 +3505,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for base in [10.0, 2, np.e]
-        for dtype in jtu.inexact_dtypes + [None,]
+        for dtype in jtu.basic_float_dtypes + jtu.complex_dtypes + [None,]
         for rng_factory in [jtu.rand_default]))
   def testLogspace(self, start_shape, stop_shape, num,
                    endpoint, base, dtype, rng_factory):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -122,6 +122,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
       args_maker = lambda: [rng(shapes[0], dtype), rng(shapes[1], dtype)]
     else:
+      axis = int(onp.clip(axis, -len(shapes[0]), len(shapes[0]) - 1))
       def scipy_fun(array_to_reduce):
         return osp_special.logsumexp(array_to_reduce, axis, keepdims=keepdims,
                                      return_sign=return_sign)
@@ -131,8 +132,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
                                      return_sign=return_sign)
 
       args_maker = lambda: [rng(shapes[0], dtype)]
+    tol = {onp.float32: 1E-5}
     self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker)
-    self._CompileAndCheck(lax_fun, args_maker)
+    self._CompileAndCheck(lax_fun, args_maker, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
     jtu.cases_from_list(

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -50,31 +50,31 @@ def op_record(name, nargs, dtypes, rng_factory, test_grad, nondiff_argnums=(), t
   return OpRecord(name, nargs, dtypes, rng_factory, test_grad, nondiff_argnums, test_name)
 
 JAX_SPECIAL_FUNCTION_RECORDS = [
-    op_record("betaln", 2, jtu.float_dtypes, jtu.rand_positive, False),
-    op_record("betainc", 3, jtu.float_dtypes, jtu.rand_positive, False),
-    op_record("digamma", 1, jtu.float_dtypes, jtu.rand_positive, True),
-    op_record("gammainc", 2, jtu.float_dtypes, jtu.rand_positive, True),
-    op_record("gammaincc", 2, jtu.float_dtypes, jtu.rand_positive, True),
-    op_record("erf", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
-    op_record("erfc", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
-    op_record("erfinv", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
-    op_record("expit", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
+    op_record("betaln", 2, jtu.basic_float_dtypes, jtu.rand_positive, False),
+    op_record("betainc", 3, jtu.basic_float_dtypes, jtu.rand_positive, False),
+    op_record("digamma", 1, jtu.basic_float_dtypes, jtu.rand_positive, True),
+    op_record("gammainc", 2, jtu.basic_float_dtypes, jtu.rand_positive, True),
+    op_record("gammaincc", 2, jtu.basic_float_dtypes, jtu.rand_positive, True),
+    op_record("erf", 1, jtu.basic_float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfc", 1, jtu.basic_float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfinv", 1, jtu.basic_float_dtypes, jtu.rand_small_positive, True),
+    op_record("expit", 1, jtu.basic_float_dtypes, jtu.rand_small_positive, True),
     # TODO: gammaln has slightly high error.
-    op_record("gammaln", 1, jtu.float_dtypes, jtu.rand_positive, False),
-    op_record("logit", 1, jtu.float_dtypes, jtu.rand_uniform, True),
-    op_record("log_ndtr", 1, jtu.float_dtypes, jtu.rand_default, True),
-    op_record("ndtri", 1, jtu.float_dtypes, partial(jtu.rand_uniform, low=0.05,
+    op_record("gammaln", 1, jtu.basic_float_dtypes, jtu.rand_positive, False),
+    op_record("logit", 1, jtu.basic_float_dtypes, jtu.rand_uniform, True),
+    op_record("log_ndtr", 1, jtu.basic_float_dtypes, jtu.rand_default, True),
+    op_record("ndtri", 1, jtu.basic_float_dtypes, partial(jtu.rand_uniform, low=0.05,
                                                 high=0.95),
               True),
-    op_record("ndtr", 1, jtu.float_dtypes, jtu.rand_default, True),
+    op_record("ndtr", 1, jtu.basic_float_dtypes, jtu.rand_default, True),
     # TODO(phawkins): gradient of entr yields NaNs.
-    op_record("entr", 1, jtu.float_dtypes, jtu.rand_default, False),
-    op_record("polygamma", 2, (jtu.int_dtypes, jtu.float_dtypes), jtu.rand_positive, True, (0,)),
-    op_record("xlogy", 2, jtu.float_dtypes, jtu.rand_default, True),
-    op_record("xlog1py", 2, jtu.float_dtypes, jtu.rand_default, True),
+    op_record("entr", 1, jtu.basic_float_dtypes, jtu.rand_default, False),
+    op_record("polygamma", 2, (jtu.int_dtypes, jtu.basic_float_dtypes), jtu.rand_positive, True, (0,)),
+    op_record("xlogy", 2, jtu.basic_float_dtypes, jtu.rand_default, True),
+    op_record("xlog1py", 2, jtu.basic_float_dtypes, jtu.rand_default, True),
     # TODO: enable gradient test for zeta by restricting the domain of
     # of inputs to some reasonable intervals
-    op_record("zeta", 2, jtu.float_dtypes, jtu.rand_positive, False),
+    op_record("zeta", 2, jtu.basic_float_dtypes, jtu.rand_positive, False),
 ]
 
 
@@ -175,7 +175,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_positive, "shape": shape, "dtype": dtype,
        "d": d}
       for shape in all_shapes
-      for dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes
       for d in [1, 2, 5]))
   def testMultigammaln(self, rng_factory, shape, dtype, d):
     def scipy_fun(a):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -133,7 +133,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
       args_maker = lambda: [rng(shapes[0], dtype)]
     tol = {onp.float32: 1E-5}
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, tol=tol)
     self._CompileAndCheck(lax_fun, args_maker, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -38,13 +38,6 @@ compatible_shapes = [[(), ()],
                      [(3, 1), (1, 4)],
                      [(2, 3, 4), (2, 1, 4)]]
 
-float_dtypes = [onp.float32, onp.float64]
-complex_dtypes = [onp.complex64]
-int_dtypes = [onp.int32, onp.int64]
-bool_dtypes = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-numeric_dtypes = float_dtypes + complex_dtypes + int_dtypes
-
 
 OpRecord = collections.namedtuple(
     "OpRecord",
@@ -57,34 +50,32 @@ def op_record(name, nargs, dtypes, rng_factory, test_grad, nondiff_argnums=(), t
   return OpRecord(name, nargs, dtypes, rng_factory, test_grad, nondiff_argnums, test_name)
 
 JAX_SPECIAL_FUNCTION_RECORDS = [
-    op_record("betaln", 2, float_dtypes, jtu.rand_positive, False),
-    op_record("betainc", 3, float_dtypes, jtu.rand_positive, False),
-    op_record("digamma", 1, float_dtypes, jtu.rand_positive, True),
-    op_record("gammainc", 2, float_dtypes, jtu.rand_positive, True),
-    op_record("gammaincc", 2, float_dtypes, jtu.rand_positive, True),
-    op_record("erf", 1, float_dtypes, jtu.rand_small_positive, True),
-    op_record("erfc", 1, float_dtypes, jtu.rand_small_positive, True),
-    op_record("erfinv", 1, float_dtypes, jtu.rand_small_positive, True),
-    op_record("expit", 1, float_dtypes, jtu.rand_small_positive, True),
+    op_record("betaln", 2, jtu.float_dtypes, jtu.rand_positive, False),
+    op_record("betainc", 3, jtu.float_dtypes, jtu.rand_positive, False),
+    op_record("digamma", 1, jtu.float_dtypes, jtu.rand_positive, True),
+    op_record("gammainc", 2, jtu.float_dtypes, jtu.rand_positive, True),
+    op_record("gammaincc", 2, jtu.float_dtypes, jtu.rand_positive, True),
+    op_record("erf", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfc", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
+    op_record("erfinv", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
+    op_record("expit", 1, jtu.float_dtypes, jtu.rand_small_positive, True),
     # TODO: gammaln has slightly high error.
-    op_record("gammaln", 1, float_dtypes, jtu.rand_positive, False),
-    op_record("logit", 1, float_dtypes, jtu.rand_uniform, True),
-    op_record("log_ndtr", 1, float_dtypes, jtu.rand_default, True),
-    op_record("ndtri", 1, float_dtypes, partial(jtu.rand_uniform, low=0.05,
+    op_record("gammaln", 1, jtu.float_dtypes, jtu.rand_positive, False),
+    op_record("logit", 1, jtu.float_dtypes, jtu.rand_uniform, True),
+    op_record("log_ndtr", 1, jtu.float_dtypes, jtu.rand_default, True),
+    op_record("ndtri", 1, jtu.float_dtypes, partial(jtu.rand_uniform, low=0.05,
                                                 high=0.95),
               True),
-    op_record("ndtr", 1, float_dtypes, jtu.rand_default, True),
+    op_record("ndtr", 1, jtu.float_dtypes, jtu.rand_default, True),
     # TODO(phawkins): gradient of entr yields NaNs.
-    op_record("entr", 1, float_dtypes, jtu.rand_default, False),
-    op_record("polygamma", 2, (int_dtypes, float_dtypes), jtu.rand_positive, True, (0,)),
-    op_record("xlogy", 2, float_dtypes, jtu.rand_default, True),
-    op_record("xlog1py", 2, float_dtypes, jtu.rand_default, True),
+    op_record("entr", 1, jtu.float_dtypes, jtu.rand_default, False),
+    op_record("polygamma", 2, (jtu.int_dtypes, jtu.float_dtypes), jtu.rand_positive, True, (0,)),
+    op_record("xlogy", 2, jtu.float_dtypes, jtu.rand_default, True),
+    op_record("xlog1py", 2, jtu.float_dtypes, jtu.rand_default, True),
     # TODO: enable gradient test for zeta by restricting the domain of
     # of inputs to some reasonable intervals
-    op_record("zeta", 2, float_dtypes, jtu.rand_positive, False),
+    op_record("zeta", 2, jtu.float_dtypes, jtu.rand_positive, False),
 ]
-
-CombosWithReplacement = itertools.combinations_with_replacement
 
 
 class LaxBackedScipyTests(jtu.JaxTestCase):
@@ -152,8 +143,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
          "nondiff_argnums": rec.nondiff_argnums,
          "scipy_op": getattr(osp_special, rec.name),
          "lax_op": getattr(lsp_special, rec.name)}
-        for shapes in CombosWithReplacement(all_shapes, rec.nargs)
-        for dtypes in (CombosWithReplacement(rec.dtypes, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(all_shapes, rec.nargs)
+        for dtypes in (itertools.combinations_with_replacement(rec.dtypes, rec.nargs)
           if isinstance(rec.dtypes, list) else itertools.product(*rec.dtypes)))
       for rec in JAX_SPECIAL_FUNCTION_RECORDS))
   def testScipySpecialFun(self, scipy_op, lax_op, rng_factory, shapes, dtypes,
@@ -184,7 +175,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
        "rng_factory": jtu.rand_positive, "shape": shape, "dtype": dtype,
        "d": d}
       for shape in all_shapes
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for d in [1, 2, 5]))
   def testMultigammaln(self, rng_factory, shape, dtype, d):
     def scipy_fun(a):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -93,7 +93,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
        "shapes": shapes, "dtype": dtype,
        "axis": axis, "keepdims": keepdims,
        "return_sign": return_sign, "use_b": use_b}
-      for shape_group in compatible_shapes for dtype in float_dtypes
+      for shape_group in compatible_shapes for dtype in jtu.basic_float_dtypes
       for use_b in [False, True]
       for shapes in itertools.product(*(
         (shape_group, shape_group) if use_b else (shape_group,)))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -38,10 +38,6 @@ config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
 
-def num_float_bits(dtype):
-  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
-
-
 ### lax tests
 
 # For standard unops and binops, we can generate a large number of tests on

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -47,20 +47,6 @@ def num_float_bits(dtype):
 # For standard unops and binops, we can generate a large number of tests on
 # arguments of appropriate shapes and dtypes using the following table.
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([dtypes.bfloat16, onp.float16, onp.float32,
-                                 onp.float64])
-complex_elem_dtypes = supported_dtypes([onp.float32, onp.float64])
-complex_dtypes = supported_dtypes([onp.complex64, onp.complex128])
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([onp.int32, onp.int64])
-uint_dtypes = supported_dtypes([onp.uint32, onp.uint64])
-bool_dtypes = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
-
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
 
@@ -71,101 +57,99 @@ def op_record(op, nargs, dtypes, rng_factory, tol=None):
   return OpRecord(op, nargs, dtypes, rng_factory, tol)
 
 LAX_OPS = [
-    op_record("neg", 1, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("sign", 1, default_dtypes + uint_dtypes, jtu.rand_small),
-    op_record("floor", 1, float_dtypes, jtu.rand_small),
-    op_record("ceil", 1, float_dtypes, jtu.rand_small),
-    op_record("round", 1, float_dtypes, jtu.rand_default),
-    op_record("nextafter", 2, [f for f in float_dtypes if f != dtypes.bfloat16],
+    op_record("neg", 1, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_small),
+    op_record("sign", 1, jtu.default_dtypes + jtu.uint_dtypes, jtu.rand_small),
+    op_record("floor", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("ceil", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("round", 1, jtu.float_dtypes, jtu.rand_default),
+    op_record("nextafter", 2, [f for f in jtu.float_dtypes if f != dtypes.bfloat16],
               jtu.rand_default, tol=0),
 
-    op_record("is_finite", 1, float_dtypes, jtu.rand_small),
+    op_record("is_finite", 1, jtu.float_dtypes, jtu.rand_small),
 
-    op_record("exp", 1, float_dtypes + complex_dtypes, jtu.rand_small),
+    op_record("exp", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_small),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
-    op_record("expm1", 1, float_dtypes + complex_dtypes, jtu.rand_small,
+    op_record("expm1", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_small,
               {onp.float64: 1e-8}),
-    op_record("log", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("log1p", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("log", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
+    op_record("log1p", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
-    op_record("tanh", 1, float_dtypes + complex_dtypes, jtu.rand_small,
+    op_record("tanh", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_small,
               {onp.float64: 1e-9, onp.complex128: 1e-7}),
-    op_record("sin", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("cos", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("atan2", 2, float_dtypes, jtu.rand_default),
+    op_record("sin", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("cos", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("atan2", 2, jtu.float_dtypes, jtu.rand_default),
 
-    op_record("sqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("rsqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("square", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("reciprocal", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("tan", 1, float_dtypes, jtu.rand_default, {onp.float32: 3e-5}),
-    op_record("asin", 1, float_dtypes, jtu.rand_small),
-    op_record("acos", 1, float_dtypes, jtu.rand_small),
-    op_record("atan", 1, float_dtypes, jtu.rand_small),
-    op_record("asinh", 1, float_dtypes, jtu.rand_default),
-    op_record("acosh", 1, float_dtypes, jtu.rand_positive),
+    op_record("sqrt", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
+    op_record("rsqrt", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
+    op_record("square", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("reciprocal", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
+    op_record("tan", 1, jtu.float_dtypes, jtu.rand_default, {onp.float32: 3e-5}),
+    op_record("asin", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("acos", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("atan", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("asinh", 1, jtu.float_dtypes, jtu.rand_default),
+    op_record("acosh", 1, jtu.float_dtypes, jtu.rand_positive),
     # TODO(b/155331781): atanh has only ~float precision
-    op_record("atanh", 1, float_dtypes, jtu.rand_small, {onp.float64: 1e-9}),
-    op_record("sinh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("cosh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("lgamma", 1, float_dtypes, jtu.rand_positive,
+    op_record("atanh", 1, jtu.float_dtypes, jtu.rand_small, {onp.float64: 1e-9}),
+    op_record("sinh", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("cosh", 1, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("lgamma", 1, jtu.float_dtypes, jtu.rand_positive,
               {onp.float32: 1e-3 if jtu.device_under_test() == "tpu" else 1e-5,
                onp.float64: 1e-14}),
-    op_record("digamma", 1, float_dtypes, jtu.rand_positive,
+    op_record("digamma", 1, jtu.float_dtypes, jtu.rand_positive,
               {onp.float64: 1e-14}),
-    op_record("betainc", 3, float_dtypes, jtu.rand_positive,
+    op_record("betainc", 3, jtu.float_dtypes, jtu.rand_positive,
               {onp.float64: 1e-14}),
     op_record("igamma", 2,
-              [f for f in float_dtypes if f not in [dtypes.bfloat16, onp.float16]],
+              [f for f in jtu.float_dtypes if f not in [dtypes.bfloat16, onp.float16]],
               jtu.rand_positive, {onp.float64: 1e-14}),
     op_record("igammac", 2,
-              [f for f in float_dtypes if f not in [dtypes.bfloat16, onp.float16]],
+              [f for f in jtu.float_dtypes if f not in [dtypes.bfloat16, onp.float16]],
               jtu.rand_positive, {onp.float64: 1e-14}),
-    op_record("erf", 1, float_dtypes, jtu.rand_small),
-    op_record("erfc", 1, float_dtypes, jtu.rand_small),
+    op_record("erf", 1, jtu.float_dtypes, jtu.rand_small),
+    op_record("erfc", 1, jtu.float_dtypes, jtu.rand_small),
     # TODO(b/142976030): the approximation of erfinf used by XLA is only
     # accurate to float32 precision.
-    op_record("erf_inv", 1, float_dtypes, jtu.rand_small,
+    op_record("erf_inv", 1, jtu.float_dtypes, jtu.rand_small,
               {onp.float64: 1e-9}),
-    op_record("bessel_i0e", 1, float_dtypes, jtu.rand_default),
-    op_record("bessel_i1e", 1, float_dtypes, jtu.rand_default),
+    op_record("bessel_i0e", 1, jtu.float_dtypes, jtu.rand_default),
+    op_record("bessel_i1e", 1, jtu.float_dtypes, jtu.rand_default),
 
-    op_record("real", 1, complex_dtypes, jtu.rand_default),
-    op_record("imag", 1, complex_dtypes, jtu.rand_default),
-    op_record("complex", 2, complex_elem_dtypes, jtu.rand_default),
-    op_record("conj", 1, complex_elem_dtypes + complex_dtypes,
+    op_record("real", 1, jtu.complex_dtypes, jtu.rand_default),
+    op_record("imag", 1, jtu.complex_dtypes, jtu.rand_default),
+    op_record("complex", 2, jtu.complex_elem_dtypes, jtu.rand_default),
+    op_record("conj", 1, jtu.complex_elem_dtypes + jtu.complex_dtypes,
               jtu.rand_default),
-    op_record("abs", 1, default_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("pow", 2, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record("abs", 1, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_default),
+    op_record("pow", 2, jtu.float_dtypes + jtu.complex_dtypes, jtu.rand_positive),
 
-    op_record("bitwise_and", 2, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small),
-    op_record("population_count", 1, uint_dtypes, partial(jtu.rand_int,
+    op_record("bitwise_and", 2, jtu.bool_dtypes, jtu.rand_small),
+    op_record("bitwise_not", 1, jtu.bool_dtypes, jtu.rand_small),
+    op_record("bitwise_or", 2, jtu.bool_dtypes, jtu.rand_small),
+    op_record("bitwise_xor", 2, jtu.bool_dtypes, jtu.rand_small),
+    op_record("population_count", 1, jtu.uint_dtypes, partial(jtu.rand_int,
                                                           high=1 << 32)),
 
-    op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("mul", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("div", 2, default_dtypes + complex_dtypes, jtu.rand_nonzero),
-    op_record("rem", 2, default_dtypes, jtu.rand_nonzero),
+    op_record("add", 2, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_small),
+    op_record("sub", 2, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_small),
+    op_record("mul", 2, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_small),
+    op_record("div", 2, jtu.default_dtypes + jtu.complex_dtypes, jtu.rand_nonzero),
+    op_record("rem", 2, jtu.default_dtypes, jtu.rand_nonzero),
 
-    op_record("max", 2, all_dtypes, jtu.rand_small),
-    op_record("min", 2, all_dtypes, jtu.rand_small),
+    op_record("max", 2, jtu.all_dtypes, jtu.rand_small),
+    op_record("min", 2, jtu.all_dtypes, jtu.rand_small),
 
-    op_record("eq", 2, all_dtypes, jtu.rand_some_equal),
-    op_record("ne", 2, all_dtypes, jtu.rand_small),
-    op_record("ge", 2, default_dtypes, jtu.rand_small),
-    op_record("gt", 2, default_dtypes, jtu.rand_small),
-    op_record("le", 2, default_dtypes, jtu.rand_small),
-    op_record("lt", 2, default_dtypes, jtu.rand_small),
+    op_record("eq", 2, jtu.all_dtypes, jtu.rand_some_equal),
+    op_record("ne", 2, jtu.all_dtypes, jtu.rand_small),
+    op_record("ge", 2, jtu.default_dtypes, jtu.rand_small),
+    op_record("gt", 2, jtu.default_dtypes, jtu.rand_small),
+    op_record("le", 2, jtu.default_dtypes, jtu.rand_small),
+    op_record("lt", 2, jtu.default_dtypes, jtu.rand_small),
 ]
-
-CombosWithReplacement = itertools.combinations_with_replacement
 
 
 class LaxTest(jtu.JaxTestCase):
@@ -178,7 +162,7 @@ class LaxTest(jtu.JaxTestCase):
          "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
   def testOp(self, op_name, rng_factory, shapes, dtype):
@@ -194,7 +178,7 @@ class LaxTest(jtu.JaxTestCase):
          "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype, "tol": rec.tol}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
   def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):
@@ -276,7 +260,7 @@ class LaxTest(jtu.JaxTestCase):
           [(), (2, 3), (2, 3)],
           [(2, 3), (2, 3), (2, 3)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testClamp(self, min_shape, operand_shape, max_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -297,7 +281,7 @@ class LaxTest(jtu.JaxTestCase):
           [(), (2, 3), (2, 3)],
           [(2, 3), (2, 3), (2, 3)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testClampAgainstNumpy(self, min_shape, operand_shape, max_shape, dtype,
                             rng_factory):
@@ -313,7 +297,7 @@ class LaxTest(jtu.JaxTestCase):
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
        "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
       for rng_factory in [jtu.rand_default]))
@@ -332,7 +316,7 @@ class LaxTest(jtu.JaxTestCase):
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
        "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for dim in range(len(base_shape))
       for rng_factory in [jtu.rand_default]))
@@ -355,7 +339,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([2, 3], repeat=3)]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1)]
       for padding in ["VALID", "SAME"]
       for rng_factory in [jtu.rand_small]))
@@ -378,7 +362,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([2, 3], repeat=3)]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1)]
       for padding in ["VALID", "SAME"]
       for rng_factory in [jtu.rand_small]))
@@ -402,7 +386,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, i, 9, 10), (j, i, 4, 5))
           for b, i, j in itertools.product([1, 2, 3], repeat=3)]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1)]
       for padding in [((0, 0), (0, 0)), ((1, 2), (2, 0))]
       for lhs_dilation, rhs_dilation in itertools.product(
@@ -473,7 +457,7 @@ class LaxTest(jtu.JaxTestCase):
            (j * feature_group_count * batch_group_count, i, 4, 5))
           for w in [0, 10]
           for b, i, j in itertools.product([2, 3], repeat=3)]
-      for dtype in float_dtypes for strides in [(1, 1), (2, 1)]
+      for dtype in jtu.float_dtypes for strides in [(1, 1), (2, 1)]
       for padding in [((1, 2), (2, 0)), ((10, 8), (7, 13))]
       for lhs_dilation, rhs_dilation in itertools.product(
           [(1, 1), (1, 2), (1, 4)], repeat=2)
@@ -565,7 +549,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, 9, 10, i), (k, k, j, i))  # NB: i,j flipped in RHS for transpose
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHWC', 'HWIO', 'NHWC'),]
@@ -604,7 +588,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, 9, 10, i), (k, k, i, j))
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1, 1), (1, 2), (2, 1), (2, 2), (3, 3)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHWC', 'HWIO', 'NHWC'),]
@@ -642,7 +626,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [
           ((b, 10, i), (k, i, j))
           for b, i, j, k in itertools.product([2,3],[2,3],[2,3],[3,4,5])]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for strides in [(1,), (2,), (3,)]
       for padding in ["VALID", "SAME"]
       for dspec in [('NHC', 'HIO', 'NHC'),]
@@ -676,7 +660,7 @@ class LaxTest(jtu.JaxTestCase):
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "precision": precision, "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for precision in [None, lax.Precision.DEFAULT, lax.Precision.HIGH,
                         lax.Precision.HIGHEST]
       for rng_factory in [jtu.rand_default]))
@@ -692,7 +676,7 @@ class LaxTest(jtu.JaxTestCase):
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDotAgainstNumpy(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -723,7 +707,7 @@ class LaxTest(jtu.JaxTestCase):
           [(1, 2, 2, 3), (1, 2, 3, 1), [1], [1]],
           [(3, 2), (2, 4), [1], [0]],
       ]
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractOnly(self, lhs_shape, rhs_shape, dtype,
                                  lhs_contracting, rhs_contracting, rng_factory):
@@ -748,7 +732,7 @@ class LaxTest(jtu.JaxTestCase):
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
                                      dimension_numbers, rng_factory):
@@ -772,7 +756,7 @@ class LaxTest(jtu.JaxTestCase):
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for rng_factory in [jtu.rand_small]))
   def testDotGeneralAgainstNumpy(self, lhs_shape, rhs_shape, dtype,
                                  dimension_numbers, rng_factory):
@@ -788,7 +772,7 @@ class LaxTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
       for rng_factory in [jtu.rand_default]))
   def testBroadcast(self, shape, dtype, broadcast_sizes, rng_factory):
@@ -803,7 +787,7 @@ class LaxTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
       for rng_factory in [jtu.rand_default]))
   def testBroadcastAgainstNumpy(self, shape, dtype, broadcast_sizes, rng_factory):
@@ -826,7 +810,7 @@ class LaxTest(jtu.JaxTestCase):
           ([], [2, 3], []),
           ([1], [2, 3], [1]),
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, rng_factory):
     rng = rng_factory(self.rng())
@@ -871,7 +855,7 @@ class LaxTest(jtu.JaxTestCase):
           ([], [2, 3], []),
           ([1], [2, 3], [1]),
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testBroadcastInDimAgainstNumpy(self, inshape, dtype, outshape,
                                      dimensions, rng_factory):
@@ -928,7 +912,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "rng_factory": rng_factory}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for arg_shape, out_shape in [
           [(3, 4), (12,)], [(2, 1, 4), (8,)], [(2, 2, 4), (2, 8)]
       ]
@@ -945,7 +929,7 @@ class LaxTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype)),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "rng_factory": rng_factory}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for arg_shape, out_shape in [
           [(3, 4), (12,)], [(2, 1, 4), (8,)], [(2, 2, 4), (2, 8)]
       ]
@@ -962,7 +946,7 @@ class LaxTest(jtu.JaxTestCase):
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
   def testPad(self, shape, dtype, pads, rng_factory):
     rng = rng_factory(self.rng())
@@ -975,7 +959,7 @@ class LaxTest(jtu.JaxTestCase):
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for shape in [(2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for pads in [
         [(0, 0, 0), (0, 0, 0)],  # no padding
         [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
@@ -1015,7 +999,7 @@ class LaxTest(jtu.JaxTestCase):
        "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
-      for arg_dtype in default_dtypes
+      for arg_dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSelect(self, pred_shape, arg_shape, arg_dtype, rng_factory):
     def args_maker():
@@ -1032,7 +1016,7 @@ class LaxTest(jtu.JaxTestCase):
        "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
-      for arg_dtype in default_dtypes
+      for arg_dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSelectAgainstNumpy(self, pred_shape, arg_shape, arg_dtype, rng_factory):
     def args_maker():
@@ -1059,7 +1043,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (2, 1), (1, 1)],
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSlice(self, shape, dtype, starts, limits, strides, rng_factory):
     rng = rng_factory(self.rng())
@@ -1085,7 +1069,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (2, 1), (1, 1)],
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSliceAgainstNumpy(self, shape, dtype, starts, limits,
                             strides, rng_factory):
@@ -1107,7 +1091,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), onp.array((1, 1)), (3, 1)],
         [(7, 5, 3), onp.array((4, 1, 0)), (2, 0, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicSlice(self, shape, dtype, start_indices, size_indices, rng_factory):
     rng = rng_factory(self.rng())
@@ -1126,7 +1110,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicSliceAgainstNumpy(self, shape, dtype, start_indices,
                                    size_indices, rng_factory):
@@ -1153,7 +1137,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSlice(self, shape, dtype, start_indices, update_shape,
                              rng_factory):
@@ -1176,7 +1160,7 @@ class LaxTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (3, 1)],
         [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDynamicUpdateSliceAgainstNumpy(self, shape, dtype, start_indices,
                                          update_shape, rng_factory):
@@ -1199,7 +1183,7 @@ class LaxTest(jtu.JaxTestCase):
         [(3, 4, 5), (2, 1, 0)],
         [(3, 4, 5), (1, 0, 2)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testTranspose(self, shape, dtype, perm, rng_factory):
     rng = rng_factory(self.rng())
@@ -1217,7 +1201,7 @@ class LaxTest(jtu.JaxTestCase):
         [(3, 4, 5), (2, 1, 0)],
         [(3, 4, 5), (1, 0, 2)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testTransposeAgainstNumpy(self, shape, dtype, perm, rng_factory):
     rng = rng_factory(self.rng())
@@ -1233,15 +1217,15 @@ class LaxTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
        "dims": dims, "rng_factory": rng_factory}
       for init_val, op, types in [
-          (0, lax.add, default_dtypes),
-          (1, lax.mul, default_dtypes),
-          (0, lax.max, all_dtypes), # non-monoidal
-          (-onp.inf, lax.max, float_dtypes),
+          (0, lax.add, jtu.default_dtypes),
+          (1, lax.mul, jtu.default_dtypes),
+          (0, lax.max, jtu.all_dtypes), # non-monoidal
+          (-onp.inf, lax.max, jtu.float_dtypes),
           (dtypes.iinfo(onp.int32).min, lax.max, [onp.int32]),
           # (dtypes.iinfo(onp.int64).min, lax.max, [onp.int64]),  # TODO fails
           (dtypes.iinfo(onp.uint32).min, lax.max, [onp.uint32]),
           (dtypes.iinfo(onp.uint64).min, lax.max, [onp.uint64]),
-          (onp.inf, lax.min, float_dtypes),
+          (onp.inf, lax.min, jtu.float_dtypes),
           (dtypes.iinfo(onp.int32).max, lax.min, [onp.int32]),
           # (dtypes.iinfo(onp.int64).max, lax.min, [onp.int64]),  # TODO fails
           (dtypes.iinfo(onp.uint32).max, lax.min, [onp.uint32]),
@@ -1320,8 +1304,8 @@ class LaxTest(jtu.JaxTestCase):
        "op": op, "onp_op": onp_op, "shape": shape, "dtype": dtype,
        "axis": axis, "rng_factory": rng_factory}
       for op, onp_op, types in [
-          (lax.cumsum, onp.cumsum, default_dtypes),
-          (lax.cumprod, onp.cumprod, default_dtypes),
+          (lax.cumsum, onp.cumsum, jtu.default_dtypes),
+          (lax.cumprod, onp.cumprod, jtu.default_dtypes),
       ]
       for dtype in types
       for shape in [[10], [3, 4, 5]]
@@ -1341,7 +1325,7 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSort(self, shape, dtype, axis):
@@ -1359,7 +1343,7 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
         "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape in [(5,), (5, 7)]
       for axis in [-1, len(shape) - 1]))
   def testSortAgainstNumpy(self, shape, dtype, axis):
@@ -1381,7 +1365,7 @@ class LaxTest(jtu.JaxTestCase):
           axis),
        "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
        "axis": axis}
-      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
+      for key_dtype in jtu.float_dtypes + jtu.complex_dtypes + jtu.int_dtypes + jtu.uint_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]))
@@ -1411,7 +1395,7 @@ class LaxTest(jtu.JaxTestCase):
           axis),
        "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
        "axis": axis}
-      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
+      for key_dtype in jtu.float_dtypes + jtu.complex_dtypes + jtu.int_dtypes + jtu.uint_dtypes
       for val_dtype in [onp.float32, onp.int32, onp.uint32]
       for shape in [(3,), (5, 3)]
       for axis in [-1, len(shape) - 1]))
@@ -1465,7 +1449,7 @@ class LaxTest(jtu.JaxTestCase):
       for lhs_shape, rhs_shape in [((3, 2), (2, 4)),
                                    ((5, 3, 2), (5, 2, 4)),
                                    ((1, 2, 2, 3), (1, 2, 3, 1))]
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for rng_factory in [jtu.rand_small]))
   def testBatchMatMul(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
@@ -1487,7 +1471,7 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_idxs={}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), idxs, axes),
        "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes, "rng_factory": rng_factory}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape, idxs, axes in [
           [(3, 4, 5), (onp.array([0, 2, 1]),), (0,)],
           [(3, 4, 5), (onp.array([-1, -2]),), (0,)],
@@ -1509,7 +1493,7 @@ class LaxTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
        "slice_sizes": slice_sizes, "rng_factory": rng_factory,
        "rng_idx_factory": rng_idx_factory}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape, idxs, dnums, slice_sizes in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
@@ -1542,7 +1526,7 @@ class LaxTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -1573,7 +1557,7 @@ class LaxTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -1604,7 +1588,7 @@ class LaxTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -1635,7 +1619,7 @@ class LaxTest(jtu.JaxTestCase):
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums,
        "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -1736,7 +1720,7 @@ class LazyConstantTest(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype) if dtype else shape,
           fill_value),
        "shape": shape, "dtype": dtype, "fill_value": fill_value}
-      for dtype in itertools.chain(default_dtypes, [None])
+      for dtype in itertools.chain(jtu.default_dtypes, [None])
       for shape in [(), (3,), (2, 3), (2, 3, 4), (1001, 1001)]
       for fill_value in [0, 1, onp.pi]))
   def testFilledConstant(self, shape, fill_value, dtype):
@@ -1749,7 +1733,7 @@ class LazyConstantTest(jtu.JaxTestCase):
       {"testcase_name": "_{}_dim={}".format(
           jtu.format_shape_dtype_string(shape, dtype), dimension),
        "shape": shape, "dtype": dtype, "dimension": dimension}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape in [(), (3,), (2, 3), (2, 3, 4),
                     # TODO(mattjj): re-enable
                     # (1001, 1001), (101, 101, 101),
@@ -1769,7 +1753,7 @@ class LazyConstantTest(jtu.JaxTestCase):
       {"testcase_name": "_{}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axes),
        "shape": shape, "dtype": dtype, "axes": axes}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for shape, axes in [
           [(2, 3), (0, 1)],
           [(2, 3, 4), (0, 1)],
@@ -1785,13 +1769,6 @@ class LazyConstantTest(jtu.JaxTestCase):
     make_const = lambda: lax._delta(dtype, shape, axes)
     # don't check the asarray case, just assume it's right
     expected = onp.asarray(make_const())
-    self._Check(make_const, expected)
-
-  def testBroadcastInDim(self):
-    arr = lax.full((2, 1), 1.) + 1.
-    arr_onp = onp.full((2, 1), 1.) + 1.
-    expected = lax_reference.broadcast_in_dim(arr_onp, (2, 1, 3), (0, 2))
-    make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)
 
 

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -30,9 +30,7 @@ from jax import test_util as jtu
 from jax.lib import xla_client
 from jax.util import safe_map, safe_zip
 
-from tests.lax_test import (all_dtypes, CombosWithReplacement,
-                            compatible_shapes, default_dtypes, float_dtypes,
-                            int_dtypes, LAX_OPS)
+from tests.lax_test import LAX_OPS
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -40,6 +38,8 @@ FLAGS = config.FLAGS
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
+
+compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
 
 def all_bdims(*shapes):
@@ -82,7 +82,7 @@ class LaxVmapTest(jtu.JaxTestCase):
          "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype, "bdims": bdims, "tol": rec.tol}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for bdims in all_bdims(*shapes)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
@@ -198,7 +198,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(), (2, 3), (2, 3)],
           [(2, 3), (2, 3), (2, 3)],
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for bdims in all_bdims(min_shape, operand_shape, max_shape)
       for rng_factory in [jtu.rand_default]))
   def testClamp(self, min_shape, operand_shape, max_shape, dtype, bdims, rng_factory):
@@ -216,7 +216,7 @@ class LaxVmapTest(jtu.JaxTestCase):
        "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
       for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testDot(self, lhs_shape, rhs_shape, dtype, bdims, rng_factory):
     rng = rng_factory(self.rng())
@@ -242,7 +242,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(3, 2), (2, 4), [1], [0]],
       ]
       for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractOnly(self, lhs_shape, rhs_shape, dtype,
                                  lhs_contracting, rhs_contracting, bdims, rng_factory):
@@ -265,7 +265,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_small]))
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
                                      dimension_numbers, bdims, rng_factory):
@@ -280,7 +280,7 @@ class LaxVmapTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
        "bdims": bdims, "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for broadcast_sizes in [(), (2,), (1, 2)]
       for bdims in all_bdims(shape)
       for rng_factory in [jtu.rand_default]))
@@ -302,7 +302,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           ([2], [2, 3], [0]),
           ([], [2, 3], []),
       ]
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for bdims in all_bdims(inshape)
       for rng_factory in [jtu.rand_default]))
   def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, bdims, rng_factory):
@@ -342,7 +342,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           dimensions, bdims),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "dimensions": dimensions, "bdims": bdims, "rng_factory": rng_factory}
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for arg_shape, dimensions, out_shape in [
           [(3, 4), None, (12,)],
           [(2, 1, 4), None, (8,)],
@@ -365,7 +365,7 @@ class LaxVmapTest(jtu.JaxTestCase):
        "rng_factory": jtu.rand_small, "bdims": bdims}
       for shape in [(2, 3)]
       for bdims in all_bdims(shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
   def testPad(self, shape, dtype, pads, bdims, rng_factory):
     rng = rng_factory(self.rng())
@@ -382,7 +382,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
       for bdims in all_bdims(pred_shape, arg_shape, arg_shape)
-      for arg_dtype in default_dtypes
+      for arg_dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSelect(self, pred_shape, arg_shape, arg_dtype, bdims, rng_factory):
     rng = rng_factory(self.rng())
@@ -409,7 +409,7 @@ class LaxVmapTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
       for bdims in all_bdims(shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSlice(self, shape, dtype, starts, limits, strides, bdims, rng_factory):
     rng = rng_factory(self.rng())
@@ -427,7 +427,7 @@ class LaxVmapTest(jtu.JaxTestCase):
         [(3, 4, 5), (1, 0, 2)],
       ]
       for bdims in all_bdims(shape)
-      for dtype in default_dtypes
+      for dtype in jtu.default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testTranspose(self, shape, dtype, perm, bdims, rng_factory):
     rng = rng_factory(self.rng())
@@ -441,15 +441,15 @@ class LaxVmapTest(jtu.JaxTestCase):
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
        "dims": dims, "bdims": bdims, "rng_factory": rng_factory}
       for init_val, op, dtypes in [
-          (0, lax.add, default_dtypes),
-          (1, lax.mul, default_dtypes),
-          (0, lax.max, all_dtypes), # non-monoidal
-          (-onp.inf, lax.max, float_dtypes),
+          (0, lax.add, jtu.default_dtypes),
+          (1, lax.mul, jtu.default_dtypes),
+          (0, lax.max, jtu.all_dtypes), # non-monoidal
+          (-onp.inf, lax.max, jtu.float_dtypes),
           (dtypes.iinfo(onp.int32).min, lax.max, [onp.int32]),
           (dtypes.iinfo(onp.int64).min, lax.max, [onp.int64]),
           (dtypes.iinfo(onp.uint32).min, lax.max, [onp.uint32]),
           (dtypes.iinfo(onp.uint64).min, lax.max, [onp.uint64]),
-          (onp.inf, lax.min, float_dtypes),
+          (onp.inf, lax.min, jtu.float_dtypes),
           (dtypes.iinfo(onp.int32).max, lax.min, [onp.int32]),
           (dtypes.iinfo(onp.int64).max, lax.min, [onp.int64]),
           (dtypes.iinfo(onp.uint32).max, lax.min, [onp.uint32]),
@@ -527,7 +527,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       {"testcase_name": "_dtype={}_padding={}".format(onp.dtype(dtype).name,
                                                       padding),
        "dtype": dtype, "padding": padding, "rng_factory": rng_factory}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for padding in ["VALID", "SAME"]
       for rng_factory in [jtu.rand_small]))
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
@@ -576,7 +576,7 @@ class LaxVmapTest(jtu.JaxTestCase):
                slice_sizes, bdims),
        "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
        "slice_sizes": slice_sizes, "bdims": bdims}
-      for dtype in all_dtypes
+      for dtype in jtu.all_dtypes
       for shape, idxs, dnums, slice_sizes in [
           ((5,), onp.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
@@ -603,7 +603,7 @@ class LaxVmapTest(jtu.JaxTestCase):
           idxs, update_shape, dnums, bdims),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
        "update_shape": update_shape, "dnums": dnums, "bdims": bdims}
-      for dtype in float_dtypes
+      for dtype in jtu.float_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), onp.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -640,11 +640,11 @@ class LaxVmapTest(jtu.JaxTestCase):
       for bdims in all_bdims(shape)
       # TODO(b/155170120): test with repeats once the XLA:CPU stable top_k bug is fixed:
       # The top_k indices for integer arrays with identical entries won't match between
-      # vmap'd version and manual reference, so only test unique integer arrays for int_dtypes.
+      # vmap'd version and manual reference, so only test unique integer arrays for jtu.int_dtypes.
       # Note also that we chose 3 * 5 * 3 * 5 such that it fits in the range of
       # values a bfloat16 can represent exactly to avoid ties.
       for dtype, rng_factory in itertools.chain(
-        unsafe_zip(float_dtypes + int_dtypes, itertools.repeat(jtu.rand_unique_int)))))
+        unsafe_zip(jtu.float_dtypes + jtu.int_dtypes, itertools.repeat(jtu.rand_unique_int)))))
   def testTopK(self, shape, dtype, k, bdims, rng_factory):
     rng = rng_factory(self.rng())
     # _CheckBatching doesn't work with tuple outputs, so test outputs separately.

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -18,7 +18,6 @@ from absl.testing import absltest
 import numpy as np
 
 import jax
-from jax import dtypes
 from jax import test_util as jtu
 import jax.numpy as jnp
 from jax.experimental.ode import odeint
@@ -28,10 +27,6 @@ import scipy.integrate as osp_integrate
 
 from jax.config import config
 config.parse_flags_with_absl()
-
-
-def num_float_bits(dtype):
-  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
 
 
 class ODETest(jtu.JaxTestCase):
@@ -56,7 +51,7 @@ class ODETest(jtu.JaxTestCase):
     y0 = [np.pi - 0.1, 0.0]
     ts = np.linspace(0., 1., 11)
     args = (0.25, 9.8)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(pend, y0, ts, *args, tol=tol)
 
@@ -72,7 +67,7 @@ class ODETest(jtu.JaxTestCase):
 
     y0 = (np.array(-0.1), np.array([[[0.1]]]))
     ts = np.linspace(0., 1., 11)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     integrate = partial(odeint, dynamics)
     jtu.check_grads(integrate, (y0, ts), modes=["rev"], order=2,
@@ -86,7 +81,7 @@ class ODETest(jtu.JaxTestCase):
 
     y0 = [np.pi - 0.1, 0.0]
     ts = np.linspace(0., 1., 11)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(dynamics, y0, ts, tol=tol)
 
@@ -104,7 +99,7 @@ class ODETest(jtu.JaxTestCase):
     args = (rng.randn(3), rng.randn(3))
     y0 = rng.randn(3)
     ts = np.linspace(0.1, 0.2, 4)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(decay, y0, ts, *args, tol=tol)
 
@@ -118,7 +113,7 @@ class ODETest(jtu.JaxTestCase):
       return _np.array(y - _np.sin(t) - _np.cos(t) * arg1 + arg2)
 
     ts = np.array([0.1, 0.2])
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
     y0 = np.linspace(0.1, 0.9, 10)
     args = (0.1, 0.2)
 
@@ -134,7 +129,7 @@ class ODETest(jtu.JaxTestCase):
       return _np.array(y - _np.sin(t) - _np.cos(t) * arg1 + arg2)
 
     ts = np.array([0.1, 0.2])
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
     big_y0 = np.linspace(1.1, 10.9, 10)
     args = (0.1, 0.3)
 

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -24,16 +24,7 @@ from jax import test_util as jtu, jit
 from jax.config import config
 config.parse_flags_with_absl()
 
-
-float_dtypes = [np.float32, np.float64]
-# implementation casts to complex64.
-complex_dtypes = [np.complex64]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [np.int32, np.int64]
-real_dtypes = float_dtypes + int_dtypes
-all_dtypes = real_dtypes + complex_dtypes
-
-
+all_dtypes = [t for t in jtu.all_dtypes if t not in (jnp.bfloat16, np.float16, np.bool_)]
 # TODO: these tests fail without fixed PRNG seeds.
 
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -38,12 +38,6 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([jnp.bfloat16, np.float16, np.float32, np.float64])
-int_dtypes = supported_dtypes([np.int8, np.int16, np.int32, np.int64])
-uint_dtypes = supported_dtypes([np.uint8, np.uint16, np.uint32, np.uint64])
 
 class LaxRandomTest(jtu.JaxTestCase):
 
@@ -164,7 +158,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype)}
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testRngUniform(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.uniform() not supported on TPU for 16-bit types.")
@@ -181,7 +175,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype).name}
-      for dtype in int_dtypes + uint_dtypes))
+      for dtype in jtu.int_dtypes + jtu.uint_dtypes))
   def testRngRandint(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.randint() not supported on TPU for 8- or 16-bit types.")
@@ -418,7 +412,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype)}
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testExponential(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.exponential() not supported on TPU for 16-bit types.")
@@ -530,7 +524,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype)}
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testLaplace(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.laplace() not supported on TPU for 16-bit types.")
@@ -546,7 +540,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(dtype), "dtype": np.dtype(dtype)}
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testLogistic(self, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.logistic() not supported on TPU for 16-bit types.")
@@ -602,7 +596,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"testcase_name": "_{}D_{}".format(dim, np.dtype(dtype)),
        "dim": dim, "dtype": dtype}
       for dim in [1, 3, 5]
-      for dtype in float_dtypes))
+      for dtype in jtu.float_dtypes))
   def testMultivariateNormal(self, dim, dtype):
     if jtu.device_under_test() == "tpu" and jnp.dtype(dtype).itemsize < 3:
       raise SkipTest("random.multivariate_normal() not supported on TPU for 16-bit types.")

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -30,14 +30,6 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
-float_dtypes = [onp.float32, onp.float64]
-complex_dtypes = [onp.complex64, onp.complex128]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [onp.int32, onp.int64]
-bool_dtypes = [onp.bool_]
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
-
-
 def _fixed_ref_map_coordinates(input, coordinates, order, mode, cval=0.0):
   # SciPy's implementation of map_coordinates handles boundaries incorrectly,
   # unless mode='reflect'. For order=1, this only affects interpolation outside
@@ -73,8 +65,8 @@ class NdimageTest(jtu.JaxTestCase):
        "cval": cval, "impl": impl, "round_": round_}
       for shape in [(5,), (3, 4), (3, 4, 5)]
       for coords_shape in [(7,), (2, 3, 4)]
-      for dtype in float_dtypes + int_dtypes
-      for coords_dtype in float_dtypes
+      for dtype in jtu.float_dtypes + jtu.int_dtypes
+      for coords_dtype in jtu.float_dtypes
       for order in [0, 1]
       for mode in ['wrap', 'constant', 'nearest']
       for cval in ([0, -1] if mode == 'constant' else [0])
@@ -99,7 +91,7 @@ class NdimageTest(jtu.JaxTestCase):
     impl_fun = (osp_ndimage.map_coordinates if impl == "original"
                 else _fixed_ref_map_coordinates)
     osp_op = lambda x, c: impl_fun(x, c, order=order, mode=mode, cval=cval)
-    if dtype in float_dtypes:
+    if dtype in jtu.float_dtypes:
       epsilon = max([dtypes.finfo(dtypes.canonicalize_dtype(d)).eps
                      for d in [dtype, coords_dtype]])
       self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, tol=100*epsilon)
@@ -124,7 +116,7 @@ class NdimageTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_order={}".format(onp.dtype(dtype), order),
        "dtype": dtype, "order": order}
-      for dtype in float_dtypes + int_dtypes
+      for dtype in jtu.float_dtypes + jtu.int_dtypes
       for order in [0, 1]))
   def testMapCoordinatesRoundHalf(self, dtype, order):
     x = onp.arange(-3, 3, dtype=dtype)

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -65,8 +65,8 @@ class NdimageTest(jtu.JaxTestCase):
        "cval": cval, "impl": impl, "round_": round_}
       for shape in [(5,), (3, 4), (3, 4, 5)]
       for coords_shape in [(7,), (2, 3, 4)]
-      for dtype in jtu.float_dtypes + jtu.int_dtypes
-      for coords_dtype in jtu.float_dtypes
+      for dtype in jtu.basic_float_dtypes + jtu.int_dtypes
+      for coords_dtype in jtu.basic_float_dtypes
       for order in [0, 1]
       for mode in ['wrap', 'constant', 'nearest']
       for cval in ([0, -1] if mode == 'constant' else [0])
@@ -91,7 +91,7 @@ class NdimageTest(jtu.JaxTestCase):
     impl_fun = (osp_ndimage.map_coordinates if impl == "original"
                 else _fixed_ref_map_coordinates)
     osp_op = lambda x, c: impl_fun(x, c, order=order, mode=mode, cval=cval)
-    if dtype in jtu.float_dtypes:
+    if dtype in jtu.basic_float_dtypes:
       epsilon = max([dtypes.finfo(dtypes.canonicalize_dtype(d)).eps
                      for d in [dtype, coords_dtype]])
       self._CheckAgainstNumpy(lsp_op, osp_op, args_maker, tol=100*epsilon)
@@ -116,7 +116,7 @@ class NdimageTest(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_order={}".format(onp.dtype(dtype), order),
        "dtype": dtype, "order": order}
-      for dtype in jtu.float_dtypes + jtu.int_dtypes
+      for dtype in jtu.basic_float_dtypes + jtu.int_dtypes
       for order in [0, 1]))
   def testMapCoordinatesRoundHalf(self, dtype, order):
     x = onp.arange(-3, 3, dtype=dtype)

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -19,6 +19,7 @@ from absl.testing import absltest, parameterized
 
 import numpy as onp
 
+import jax.numpy as jnp
 from jax import lax
 from jax import test_util as jtu
 import jax.scipy.signal as jsp_signal
@@ -29,16 +30,7 @@ config.parse_flags_with_absl()
 
 onedim_shapes = [(1,), (2,), (5,), (10,)]
 twodim_shapes = [(1, 1), (2, 2), (2, 3), (3, 4), (4, 4)]
-
-
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-
-float_dtypes = supported_dtypes([onp.float32, onp.float64])
-int_dtypes = [onp.int32, onp.int64]
-default_dtypes = float_dtypes + int_dtypes
-
+default_dtypes = set(jtu.default_dtypes) - {jnp.float16, jnp.bfloat16}
 
 class LaxBackedScipySignalTests(jtu.JaxTestCase):
   """Tests for LAX-backed scipy.stats implementations"""

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -29,17 +29,14 @@ config.parse_flags_with_absl()
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 
-float_dtypes = [onp.float32, onp.float64]
-
-CombosWithReplacement = itertools.combinations_with_replacement
 
 def genNamedParametersNArgs(n, rng_factory):
     return parameterized.named_parameters(
         jtu.cases_from_list(
           {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
             "rng_factory": rng_factory, "shapes": shapes, "dtypes": dtypes}
-          for shapes in CombosWithReplacement(all_shapes, n)
-          for dtypes in CombosWithReplacement(float_dtypes, n)))
+          for shapes in itertools.combinations_with_replacement(all_shapes, n)
+          for dtypes in itertools.combinations_with_replacement(jtu.float_dtypes, n)))
 
 
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
@@ -432,7 +429,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
           # [(5, 3, 2), (3, 2,), (5, 3, 2, 2)],
           # [(5, 3, 2), (3, 2,), (2, 2)],
       ]
-      for x_dtype, mean_dtype, cov_dtype in CombosWithReplacement(float_dtypes, 3)
+      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(jtu.float_dtypes, 3)
       if (mean_shape is not None or mean_dtype == onp.float32)
       and (cov_shape is not None or cov_dtype == onp.float32)
       for rng_factory in [jtu.rand_default]))

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -36,7 +36,7 @@ def genNamedParametersNArgs(n, rng_factory):
           {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
             "rng_factory": rng_factory, "shapes": shapes, "dtypes": dtypes}
           for shapes in itertools.combinations_with_replacement(all_shapes, n)
-          for dtypes in itertools.combinations_with_replacement(jtu.float_dtypes, n)))
+          for dtypes in itertools.combinations_with_replacement(jtu.basic_float_dtypes, n)))
 
 
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
@@ -429,7 +429,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
           # [(5, 3, 2), (3, 2,), (5, 3, 2, 2)],
           # [(5, 3, 2), (3, 2,), (2, 2)],
       ]
-      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(jtu.float_dtypes, 3)
+      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(jtu.basic_float_dtypes, 3)
       if (mean_shape is not None or mean_dtype == onp.float32)
       and (cov_shape is not None or cov_dtype == onp.float32)
       for rng_factory in [jtu.rand_default]))


### PR DESCRIPTION
This is a step toward the goal of not having test files depend on importing each other, which will clean up our cross-platform testing strategy.