### PR TITLE
Clarify docs on jax.lax.cond.

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -621,6 +621,17 @@ def cond(*args, **kwargs):
 
   Pred must be a scalar type.
 
+  Note that true_fun/false_fun may not need to refer to an `operand` to compute
+  their result, but one must still be provided to the `cond` call and be
+  accepted by both the branch functions, e.g.:
+
+      jax.lax.cond(
+          get_predicate_value(),
+          lambda _: 23,
+          lambda _: 42,
+          operand=None)
+
+
   Arguments:
     pred: Boolean scalar type, indicating which branch function to
       apply. Collections (list, tuple) are not supported.


### PR DESCRIPTION
Minor clarification on something that slightly threw me on my second day writing JAX. I had true_fn/false_fn that relied entirely on capturing variables in the outer scope so not needing an input.. Tom Hennigan has pointed out to me some potential performance issues with relying on captured variable input, so I didn't want to put that in the example, but just show very explicitly what to do if you don't "need" any arguments to your branch functions.