### PR TITLE
Improve jnp.sum's error messages for tuple inputs

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2184,8 +2184,12 @@ def _can_call_numpy_array(x):
 
 # TODO(mattjj): maybe move these two functions into xla.py
 def _device_put_raw(x):
-  return array_result_handler(None, abstractify(x))(device_put(x))
-
+  try:
+    result = array_result_handler(None, abstractify(x))(device_put(x))
+  except (RuntimeError, TypeError, ValueError):
+    raise TypeError("Unexpected input type for array: {}".format(type(x))) from None
+  else:
+    return result
 
 @_wraps(np.asarray)
 def asarray(a, dtype=None, order=None):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3268,6 +3268,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     x = jnp.ones((3, 4))
     self.assertRaises(ValueError, lambda: jnp.sum(x, axis=2))
 
+  @jtu.ignore_warning(category=FutureWarning, message="jax.numpy reductions won't accept lists and tuples in future versions, only scalars and ndarrays")
+  def testErrorMessageForTuples(self):
+    self.assertRaisesRegex(
+        TypeError, "Unexpected input type for array: <class 'numpy.ndarray'>",
+        lambda: jnp.sum((jnp.zeros(1), {})))
+
   def testIssue956(self):
     self.assertRaises(TypeError, lambda: jnp.ndarray((1, 1)))
 


### PR DESCRIPTION
For issue #3451 