### PR TITLE
Correction of a typo in the period of the PRNG.

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -665,7 +665,7 @@
         "id": "ORMVVGZJgSVi"
       },
       "source": [
-        "Underneath the hood, numpy uses the [Mersenne Twister](https://en.wikipedia.org/wiki/Mersenne_Twister) PRNG to power its pseudorandom functions.  The PRNG has a period of $2^{19937-1}$ and at any point can be described by __624 32bit unsigned ints__ and a __position__ indicating how much of this  \"entropy\" has been used up."
+        "Underneath the hood, numpy uses the [Mersenne Twister](https://en.wikipedia.org/wiki/Mersenne_Twister) PRNG to power its pseudorandom functions.  The PRNG has a period of $2^{19937}-1$ and at any point can be described by __624 32bit unsigned ints__ and a __position__ indicating how much of this  \"entropy\" has been used up."
       ]
     },
     {


### PR DESCRIPTION
The period is 2^19937-1 and not 2^(19937-1).