### PR TITLE
Implement DeviceArray.tobytes().

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1112,6 +1112,8 @@ class DeviceArray(DeviceValue):
   __hex__ = partialmethod(_forward_to_value, hex)
   __oct__ = partialmethod(_forward_to_value, oct)
   __index__ = partialmethod(_forward_to_value, op.index)
+  def tobytes(self, order='C'): return self._value.tobytes(order)
+  def tolist(self): return self._value.tolist()
 
   # pickle saves and loads just like an ndarray
   __reduce__ = partialmethod(_forward_to_value, op.methodcaller("__reduce__"))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4350,7 +4350,6 @@ setattr(DeviceArray, "T", property(transpose))
 setattr(DeviceArray, "real", property(real))
 setattr(DeviceArray, "imag", property(imag))
 setattr(DeviceArray, "astype", _astype)
-setattr(DeviceArray, "tolist", lambda x: np.array(x).tolist())
 setattr(DeviceArray, "view", _view)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3811,6 +3811,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self.assertAllClose(x.astype(jnp.float32) ** i, x ** i,
                           check_dtypes=False)
 
+  def testToBytes(self):
+    v = np.arange(12, dtype=np.int32).reshape(3, 4)
+    for order in ['C', 'F']:
+      self.assertEqual(jnp.asarray(v).tobytes(order), v.tobytes(order))
+
+  def testToList(self):
+    v = np.arange(12, dtype=np.int32).reshape(3, 4)
+    self.assertEqual(jnp.asarray(v).tolist(), v.tolist())
+
 
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.


### PR DESCRIPTION
Move tolist() implementation onto DeviceArray; there's no reason to populate it dynamically.

Fixes https://github.com/google/jax/issues/1791