### PR TITLE
odeint: don't hoist non-differentiable consts

### DIFF
--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -221,6 +221,19 @@ class ODETest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "can't apply forward-mode.*"):
       jax.jacfwd(f)(3.)
 
+  @jtu.skip_on_devices("tpu")
+  def test_closure_nondiff(self):
+    # https://github.com/google/jax/issues/3584
+
+    def dz_dt(z, t):
+      return jnp.stack([z[0], z[1]])
+
+    def f(z):
+      y = odeint(dz_dt, z, jnp.arange(10.))
+      return jnp.sum(y)
+
+    jax.grad(f)(jnp.ones(2))  # doesn't crash
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
fixes #3584

This could use further revision! Left a todo.

The issue is that in #3562 we started closure-converting the dynamics function (by tracing it to a jaxpr up-front) so as to handle closed-over constants with respect to which we want to differentiate the odeint call. But if the dynamics function closes over integer-valued constants, then we can no longer call `vjp` on the closure-converted function without getting an error.

One fix would be to support (trivial) differentiation with respect to integer-valued inputs. That would work if we supperss the error message for integer-valued inputs in `vjp` and add a trivial tangent space for integer-valued arrays. Since that's potentially a further-reaching change, this commit instead just applies a local fix to avoid adding integer-valued inputs to the dynamics function by adapting the closure-conversion code.