### PR TITLE
Cleanup: remove some test interdependence

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -72,6 +72,11 @@ def _dtype(x):
           np.dtype(dtypes.python_scalar_dtypes.get(type(x), None)) or
           np.asarray(x).dtype)
 
+
+def num_float_bits(dtype):
+  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
+
+
 def is_sequence(x):
   try:
     iter(x)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -388,7 +388,7 @@ if numpy_version >= (1, 15):
       op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
   ]
 
-CombosWithReplacement = itertools.combinations_with_replacement
+itertools.combinations_with_replacement = itertools.combinations_with_replacement
 
 
 def _dtypes_are_compatible_for_bitwise_ops(args):
@@ -461,7 +461,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "inexact": rec.inexact}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in itertools.chain(JAX_ONE_TO_ONE_OP_RECORDS,
@@ -489,7 +489,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "tol": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_OPERATOR_OVERLOADS))
@@ -509,7 +509,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "op_tolerance": rec.tolerance}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in itertools.product(
           *(_valid_dtypes_for_shape(s, rec.dtypes) for s in shapes)))
       for rec in JAX_RIGHT_OPERATOR_OVERLOADS))
@@ -559,10 +559,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "np_op": getattr(np, rec.name), "jnp_op": getattr(jnp, rec.name)}
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(rec.shapes, rec.nargs))
+          itertools.combinations_with_replacement(rec.shapes, rec.nargs))
         for dtypes in filter(
           _dtypes_are_compatible_for_bitwise_ops,
-          CombosWithReplacement(rec.dtypes, rec.nargs)))
+          itertools.combinations_with_replacement(rec.dtypes, rec.nargs)))
       for rec in JAX_BITWISE_OP_RECORDS))
   def testBitwiseOp(self, np_op, jnp_op, rng_factory, shapes, dtypes):
     rng = rng_factory(self.rng())
@@ -774,7 +774,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 5, 2), (4, 5, 2), (-1, -1, 0, None)], # axisc should do nothing
           [(4, 5, 2), (4, 5, 2), (-1, -1, -1, None)] # same as before
       ]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
   def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -813,7 +813,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-matrix", (4, 3, 2), (2, 5)),
           ("matrix-tensor", (5, 2), (3, 2, 4)),
           ("tensor-tensor", (2, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
   def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -850,7 +850,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-matrix", (5, 2, 3), (3, 2)),
           ("tensor-tensor", (5, 3, 4), (5, 4, 1)),
           ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
   def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
     rng = rng_factory(self.rng())
     def np_fun(x, y):
@@ -881,7 +881,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(2, 3, 4), (5, 4, 3, 6), [[1, 2], [2, 1]]],
           [(1, 2, 3, 4), (4, 5, 3, 6), [[2, 3], [2, 0]]],
       ]
-      for lhs_dtype, rhs_dtype in CombosWithReplacement(number_dtypes, 2)))
+      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
   def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -1242,7 +1242,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
        "rng_factory": jtu.rand_default}
       for num_arrs in [3]
-      for arg_dtypes in CombosWithReplacement(default_dtypes, num_arrs)
+      for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, num_arrs)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
   def testConcatenate(self, axis, base_shape, arg_dtypes, rng_factory):
@@ -1275,7 +1275,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
        "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
        "rng_factory": jtu.rand_default}
-      for arg_dtypes in CombosWithReplacement(default_dtypes, 2)
+      for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, 2)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
   def testAppend(self, axis, base_shape, arg_dtypes, rng_factory):
@@ -1702,7 +1702,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         enumerate([jtu.rand_some_inf_and_nan, jtu.rand_some_zero])
       for x2_rng_factory in [partial(jtu.rand_int, low=-1075, high=1024)]
       for x1_shape, x2_shape in filter(_shapes_are_broadcast_compatible,
-                                       CombosWithReplacement(array_shapes, 2))
+                                       itertools.combinations_with_replacement(array_shapes, 2))
       for x1_dtype in default_dtypes))
   @jtu.skip_on_devices("tpu")  # TODO(b/153053081)
   def testLdexp(self, x1_shape, x1_dtype, x2_shape, x1_rng_factory, x2_rng_factory):
@@ -2744,7 +2744,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for x_shape, i_shape in filter(
         _shapes_are_equal_length,
         filter(_shapes_are_broadcast_compatible,
-               CombosWithReplacement(nonempty_nonscalar_array_shapes, 2)))
+               itertools.combinations_with_replacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1],
                                   [cast(Optional[int], None)])
       for dtype in default_dtypes
@@ -2976,8 +2976,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for shape, dtype in zip(shapes, dtypes))),
      "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
     for shapes in filter(_shapes_are_broadcast_compatible,
-                         CombosWithReplacement(all_shapes, 3))
-    for dtypes in CombosWithReplacement(all_dtypes, 3)))
+                         itertools.combinations_with_replacement(all_shapes, 3))
+    for dtypes in itertools.combinations_with_replacement(all_dtypes, 3)))
   def testWhereThreeArgument(self, rng_factory, shapes, dtypes):
     args_maker = self._GetArgsMaker(rng_factory(self.rng()), shapes, dtypes)
     def np_fun(cond, x, y):
@@ -2997,8 +2997,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for n in range(0, 3)
         for shapes in filter(
           _shapes_are_broadcast_compatible,
-          CombosWithReplacement(all_shapes, 2 * n + 1))
-        for dtypes in CombosWithReplacement(all_dtypes, n + 1)))
+          itertools.combinations_with_replacement(all_shapes, 2 * n + 1))
+        for dtypes in itertools.combinations_with_replacement(all_dtypes, n + 1)))
   def testSelect(self, rng_factory, shapes, dtypes):
     rng = rng_factory(self.rng())
     n = len(dtypes) - 1
@@ -3862,9 +3862,6 @@ GRAD_SPECIAL_VALUE_TEST_RECORDS = [
     GradSpecialValuesTestSpec(jnp.sinc, [0.], 1),
 ]
 
-def num_float_bits(dtype):
-  return jnp.finfo(dtypes.canonicalize_dtype(dtype)).bits
-
 class NumpyGradTests(jtu.JaxTestCase):
   @parameterized.named_parameters(itertools.chain.from_iterable(
       jtu.cases_from_list(
@@ -3872,7 +3869,7 @@ class NumpyGradTests(jtu.JaxTestCase):
             rec.name, shapes, itertools.repeat(dtype)),
          "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
          "order": rec.order, "tol": rec.tol}
-        for shapes in CombosWithReplacement(nonempty_shapes, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(nonempty_shapes, rec.nargs)
         for dtype in rec.dtypes)
       for rec in GRAD_TEST_RECORDS))
   def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -388,8 +388,6 @@ if numpy_version >= (1, 15):
       op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),
   ]
 
-itertools.combinations_with_replacement = itertools.combinations_with_replacement
-
 
 def _dtypes_are_compatible_for_bitwise_ops(args):
   if len(args) <= 1:

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -84,7 +84,7 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record("zeta", 2, float_dtypes, jtu.rand_positive, False),
 ]
 
-CombosWithReplacement = itertools.combinations_with_replacement
+itertools.combinations_with_replacement = itertools.combinations_with_replacement
 
 
 class LaxBackedScipyTests(jtu.JaxTestCase):
@@ -151,8 +151,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
          "nondiff_argnums": rec.nondiff_argnums,
          "scipy_op": getattr(osp_special, rec.name),
          "lax_op": getattr(lsp_special, rec.name)}
-        for shapes in CombosWithReplacement(all_shapes, rec.nargs)
-        for dtypes in (CombosWithReplacement(rec.dtypes, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(all_shapes, rec.nargs)
+        for dtypes in (itertools.combinations_with_replacement(rec.dtypes, rec.nargs)
           if isinstance(rec.dtypes, list) else itertools.product(*rec.dtypes)))
       for rec in JAX_SPECIAL_FUNCTION_RECORDS))
   def testScipySpecialFun(self, scipy_op, lax_op, rng_factory, shapes, dtypes,

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -84,8 +84,6 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
     op_record("zeta", 2, float_dtypes, jtu.rand_positive, False),
 ]
 
-itertools.combinations_with_replacement = itertools.combinations_with_replacement
-
 
 class LaxBackedScipyTests(jtu.JaxTestCase):
   """Tests for LAX-backed Scipy implementation."""

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -38,10 +38,6 @@ config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
 
-def num_float_bits(dtype):
-  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
-
-
 ### lax tests
 
 # For standard unops and binops, we can generate a large number of tests on
@@ -165,8 +161,6 @@ LAX_OPS = [
     op_record("lt", 2, default_dtypes, jtu.rand_small),
 ]
 
-CombosWithReplacement = itertools.combinations_with_replacement
-
 
 class LaxTest(jtu.JaxTestCase):
   """Numerical tests for LAX operations."""
@@ -178,7 +172,7 @@ class LaxTest(jtu.JaxTestCase):
          "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
   def testOp(self, op_name, rng_factory, shapes, dtype):
@@ -194,7 +188,7 @@ class LaxTest(jtu.JaxTestCase):
          "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype, "tol": rec.tol}
         for shape_group in compatible_shapes
-        for shapes in CombosWithReplacement(shape_group, rec.nargs)
+        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
   def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -18,7 +18,6 @@ from absl.testing import absltest
 import numpy as np
 
 import jax
-from jax import dtypes
 from jax import test_util as jtu
 import jax.numpy as jnp
 from jax.experimental.ode import odeint
@@ -28,10 +27,6 @@ import scipy.integrate as osp_integrate
 
 from jax.config import config
 config.parse_flags_with_absl()
-
-
-def num_float_bits(dtype):
-  return dtypes.finfo(dtypes.canonicalize_dtype(dtype)).bits
 
 
 class ODETest(jtu.JaxTestCase):
@@ -56,7 +51,7 @@ class ODETest(jtu.JaxTestCase):
     y0 = [np.pi - 0.1, 0.0]
     ts = np.linspace(0., 1., 11)
     args = (0.25, 9.8)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(pend, y0, ts, *args, tol=tol)
 
@@ -72,7 +67,7 @@ class ODETest(jtu.JaxTestCase):
 
     y0 = (np.array(-0.1), np.array([[[0.1]]]))
     ts = np.linspace(0., 1., 11)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     integrate = partial(odeint, dynamics)
     jtu.check_grads(integrate, (y0, ts), modes=["rev"], order=2,
@@ -86,7 +81,7 @@ class ODETest(jtu.JaxTestCase):
 
     y0 = [np.pi - 0.1, 0.0]
     ts = np.linspace(0., 1., 11)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(dynamics, y0, ts, tol=tol)
 
@@ -104,7 +99,7 @@ class ODETest(jtu.JaxTestCase):
     args = (rng.randn(3), rng.randn(3))
     y0 = rng.randn(3)
     ts = np.linspace(0.1, 0.2, 4)
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
     self.check_against_scipy(decay, y0, ts, *args, tol=tol)
 
@@ -118,7 +113,7 @@ class ODETest(jtu.JaxTestCase):
       return _np.array(y - _np.sin(t) - _np.cos(t) * arg1 + arg2)
 
     ts = np.array([0.1, 0.2])
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
     y0 = np.linspace(0.1, 0.9, 10)
     args = (0.1, 0.2)
 
@@ -134,7 +129,7 @@ class ODETest(jtu.JaxTestCase):
       return _np.array(y - _np.sin(t) - _np.cos(t) * arg1 + arg2)
 
     ts = np.array([0.1, 0.2])
-    tol = 1e-1 if num_float_bits(np.float64) == 32 else 1e-3
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
     big_y0 = np.linspace(1.1, 10.9, 10)
     args = (0.1, 0.3)
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -31,8 +31,6 @@ all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 
 float_dtypes = [onp.float32, onp.float64]
 
-itertools.combinations_with_replacement = itertools.combinations_with_replacement
-
 def genNamedParametersNArgs(n, rng_factory):
     return parameterized.named_parameters(
         jtu.cases_from_list(

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -31,15 +31,15 @@ all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 
 float_dtypes = [onp.float32, onp.float64]
 
-CombosWithReplacement = itertools.combinations_with_replacement
+itertools.combinations_with_replacement = itertools.combinations_with_replacement
 
 def genNamedParametersNArgs(n, rng_factory):
     return parameterized.named_parameters(
         jtu.cases_from_list(
           {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
             "rng_factory": rng_factory, "shapes": shapes, "dtypes": dtypes}
-          for shapes in CombosWithReplacement(all_shapes, n)
-          for dtypes in CombosWithReplacement(float_dtypes, n)))
+          for shapes in itertools.combinations_with_replacement(all_shapes, n)
+          for dtypes in itertools.combinations_with_replacement(float_dtypes, n)))
 
 
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
@@ -432,7 +432,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
           # [(5, 3, 2), (3, 2,), (5, 3, 2, 2)],
           # [(5, 3, 2), (3, 2,), (2, 2)],
       ]
-      for x_dtype, mean_dtype, cov_dtype in CombosWithReplacement(float_dtypes, 3)
+      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(float_dtypes, 3)
       if (mean_shape is not None or mean_dtype == onp.float32)
       and (cov_shape is not None or cov_dtype == onp.float32)
       for rng_factory in [jtu.rand_default]))


### PR DESCRIPTION
Why? Because tests are not within the package directory structure, imports between test files can be problematic. This is a first step toward removing those.

This does parts of #3561, without the problematic refactoring.