### PR TITLE
Use precision=HIGHEST in expm repeated squaring

### DIFF
--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -296,7 +296,7 @@ def _solve_P_Q(P, Q, upper_triangular=False):
 def _squaring(R, n_squarings):
   # squaring step to undo scaling
   def my_body_fun(i,R):
-    return jnp.dot(R,R)
+    return jnp.dot(R,R,precision=lax.Precision.HIGHEST)
   lower = jnp.zeros(1, dtype=n_squarings.dtype)
   R = lax.fori_loop(lower[0], n_squarings, my_body_fun, R)
   return R
@@ -378,7 +378,6 @@ def _expm_frechet(A, E, method=None, compute_expm=True):
     expm_A, expm_frechet_AE = expm_frechet_algo_64(A, E)
   else:
     raise ValueError('only method=\'SPS\' is supported')
-  expm_A, expm_frechet_AE = expm_frechet_algo_64(A, E)
   if compute_expm:
     return expm_A, expm_frechet_AE
   else:
@@ -446,8 +445,8 @@ def expm_frechet_algo_64(A, E):
   # squaring
   def my_body_fun(i,my_arg):
     R, L = my_arg
-    L = jnp.dot(R, L) + jnp.dot(L, R)
-    R = jnp.dot(R, R)
+    L = jnp.dot(R, L, precision=lax.Precision.HIGHEST) + jnp.dot(L, R, precision=lax.Precision.HIGHEST)
+    R = jnp.dot(R, R, precision=lax.Precision.HIGHEST)
     return R, L
   lower = jnp.zeros(1, dtype=s.dtype)
   R, L = lax.fori_loop(lower[0], s, my_body_fun, (R, L))

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -293,7 +293,7 @@ def _solve_P_Q(P, Q, upper_triangular=False):
     return np_linalg.solve(Q, P)
 
 def _precise_dot(A, B):
-  return jnp.dot(A, B, precision=lax.Precision.HIGHEST)  
+  return jnp.dot(A, B, precision=lax.Precision.HIGHEST)
 
 @jit
 def _squaring(R, n_squarings):

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -500,7 +500,7 @@ def _diff_pade7(args):
   M4 = _precise_dot(A2, M2) + _precise_dot(M2, A2)
   A6 = _precise_dot(A2, A4)
   M6 = _precise_dot(A4, M2) + _precise_dot(M4, A2)
-  U = _precise_dot(A, dot(b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
+  U = _precise_dot(A, b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident)
   V = b[6]*A6 + b[4]*A4 + b[2]*A2 + b[0]*ident
   Lu = (_precise_dot(A, b[7]*M6 + b[5]*M4 + b[3]*M2) +
           _precise_dot(E, b[7]*A6 + b[5]*A4 + b[3]*A2 + b[1]*ident))


### PR DESCRIPTION
This will improve the output accuracy on TPUs, and doesn't currently affect other platforms.

Also remove a spurious duplicate line.