### PR TITLE
Fix shape rule for lax.pad for input dimensions of size 0.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2950,8 +2950,9 @@ def _pad_dtype_rule(operand, padding_value, *, padding_config):
 
 def _pad_shape_rule(operand, padding_value, *, padding_config):
   lo, hi, interior = zip(*padding_config)
-  out_shape = onp.add(onp.add(onp.add(lo, hi), operand.shape),
-                      onp.multiply(interior, onp.subtract(operand.shape, 1)))
+  out_shape = onp.add(
+    onp.add(onp.add(lo, hi), operand.shape),
+    onp.maximum(0, onp.multiply(interior, onp.subtract(operand.shape, 1))))
   return tuple(out_shape)
 
 def _pad_transpose(t, operand, padding_value, *, padding_config):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -955,7 +955,7 @@ class LaxTest(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_pads={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
-      for shape in [(2, 3)]
+      for shape in [(0, 2), (2, 3)]
       for dtype in default_dtypes
       for pads in [[(1, 2, 1), (0, 1, 0)]]))
   def testPad(self, shape, dtype, pads, rng_factory):


### PR DESCRIPTION
Fixes #3599 