### PR TITLE
Make LU gradient work for low-rank matrices

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -639,7 +639,7 @@ def _lu_jvp_rule(primals, tangents):
   # ==> [∂L_0, ∂L_1][U_0; 0] + [L_0, L_1][∂U_0; ∂U_1] = ∂A
   # ==> ∂L_0 U_0 + L_0 ∂U_0 + L_1 ∂U_1 = ∂A
   # ∂L_0 and ∂U_0 can be solved by the normal expression for ∂L and ∂U,
-  # while ∂U_1 can be solved from ∂L_0 and ∂U_0 as 
+  # while ∂U_1 can be solved from ∂L_0 and ∂U_0 as
   #     ∂U_1 = triu(inv(L) . (∂A - ∂L . U))[:-k]
   u_fix = la - triangular_solve(
       l, jnp.matmul(l_dot, u, precision=lax.Precision.HIGHEST),

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -633,7 +633,7 @@ def _lu_jvp_rule(primals, tangents):
   u_dot = jnp.matmul(jnp.triu(lau), u)
   # Correction for low-rank matrices
   u_fix = la - triangular_solve(
-      l, l_dot @ u,
+      l, jnp.matmul(l_dot, u, precision=lax.Precision.HIGHEST),
       left_side=True, transpose_a=False, lower=True, unit_diagonal=True)
   u_dot = jnp.where(mask, u_fix, u_dot)
   lu_dot = l_dot + u_dot

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -612,13 +612,29 @@ def _lu_jvp_rule(primals, tangents):
   u_padding[-2] = (0, n - k, 0)
   u = lax.pad(jnp.triu(lu[..., :k, :]), zero, u_padding) + u_eye
 
-  la = triangular_solve(l, x, left_side=True, transpose_a=False, lower=True,
-                        unit_diagonal=True)
-  lau = triangular_solve(u, la, left_side=False, transpose_a=False,
-                         lower=False)
+  # dummy calculation to figure out which matrices u are low-rank
+  d = triangular_solve(
+      u, jnp.ones(tuple(a_shape[:-2]) + (1, a_shape[-1])),
+      left_side=False, transpose_a=False, lower=False)
+  # TODO(pfau): make it so NaN/Inf due to low rank can be distinguished from
+  # NaN/Inf in the original data.
+  mask = jnp.tile(jnp.isinf(d) | jnp.isnan(d),
+                  (a.ndim-2)*[1] + [a_shape[-2], 1])
+
+  la = triangular_solve(
+      l, x, left_side=True, transpose_a=False, lower=True, unit_diagonal=True)
+  lau = triangular_solve(
+      u, la, left_side=False, transpose_a=False, lower=False)
+  lau = jnp.where(mask, 0.0, lau)
 
   l_dot = jnp.matmul(l, jnp.tril(lau, -1))
   u_dot = jnp.matmul(jnp.triu(lau), u)
+  # Correction for low-rank matrices
+  u_masked = jnp.where(jnp.swapaxes(mask, -1, -2), 0.0, u)
+  u_fix = la - triangular_solve(
+      l, l_dot @ u_masked,
+      left_side=True, transpose_a=False, lower=True, unit_diagonal=True)
+  u_dot = jnp.where(mask, u_fix, u_dot)
   lu_dot = l_dot + u_dot
   return (lu, pivots), (lu_dot, ad_util.Zero.from_value(pivots))
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -153,13 +153,14 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   def testDetGradOfSingularMatrixCorank1(self):
     # Rank 2 matrix with nonzero gradient
     a = singular_mats[0]
-    jtu.check_grads(jnp.linalg.det, (a,), 1, atol=1e-1, rtol=1e-1)
+    jtu.check_grads(jnp.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
 
   @jtu.skip_on_devices("tpu")  # TODO(mattjj,pfau): nan on tpu, investigate
   def testDetGradOfSingularMatrixCorank2(self):
     # Rank 1 matrix with zero gradient
     b = singular_mats[1]
     jtu.check_grads(jnp.linalg.det, (b,), 1, atol=1e-1, rtol=1e-1)
+    jtu.check_grads(jnp.linalg.det, (b,), 2, modes=["fwd"], atol=1e-1, rtol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -1002,7 +1003,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       return p, l[:, :-corank], u
     mat = singular_mats[corank-1]
     # Check forward mode gradients
-    jtu.check_grads(_lu, (mat,), 1, modes=['fwd'], atol=1e-1, rtol=1e-1)
+    jtu.check_grads(_lu, (mat,), 2, modes=['fwd'], atol=1e-1, rtol=1e-1)
     # Something is causing tests to fail for reverse-mode.
     # So let's just compare forward-mode and reverse-mode Jacobians
     jfwd = jax.jacfwd(jsp.linalg.lu)(mat)
@@ -1016,7 +1017,8 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")  # TODO(mattjj, pfau): fails on TPU.
   def testLuGradOfNonSquareSingularMatrix(self, matidx):
     mat = nonsquare_singular_mats[matidx]
-    jtu.check_grads(jsp.linalg.lu, (mat,), 1, modes=['fwd'], atol=1e-1, rtol=1e-1)
+    jtu.check_grads(jsp.linalg.lu, (mat,), 1, atol=1e-1, rtol=1e-1)
+    jtu.check_grads(jsp.linalg.lu, (mat,), 2, modes=["fwd"], atol=1e-1, rtol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -42,6 +42,29 @@ T = lambda x: np.swapaxes(x, -1, -2)
 float_types = [np.float32, np.float64]
 complex_types = [np.complex64, np.complex128]
 
+
+# Used in tests for det and lu
+singular_mats = [
+  jnp.array([[ 50, -30,  45],  # rank-2, corank-1
+             [-30,  90, -81],
+             [ 45, -81,  81]], dtype=jnp.float32),
+  jnp.array([[ 36, -42,  18],  # rank-1, corank-2
+             [-42,  49, -21],
+             [ 18, -21,   9]], dtype=jnp.float32),
+]
+
+
+nonsquare_singular_mats = [
+  jnp.array([[-35,   7,  27, -17],
+             [ 11, -13,  -9,  11],
+             [ 19, -11, -15,  13]], dtype=jnp.float32),
+  jnp.array([[-35,  11,  19],
+             [  7, -13, -11],
+             [ 27,  -9, -15],
+             [-17,  11,  13]], dtype=np.float32)
+]
+
+
 def _skip_if_unsupported_type(dtype):
   dtype = np.dtype(dtype)
   if (not FLAGS.jax_enable_x64 and
@@ -129,17 +152,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   def testDetGradOfSingularMatrixCorank1(self):
     # Rank 2 matrix with nonzero gradient
-    a = jnp.array([[ 50, -30,  45],
-                  [-30,  90, -81],
-                  [ 45, -81,  81]], dtype=jnp.float32)
+    a = singular_mats[0]
     jtu.check_grads(jnp.linalg.det, (a,), 1, atol=1e-1, rtol=1e-1)
 
   @jtu.skip_on_devices("tpu")  # TODO(mattjj,pfau): nan on tpu, investigate
   def testDetGradOfSingularMatrixCorank2(self):
     # Rank 1 matrix with zero gradient
-    b = jnp.array([[ 36, -42,  18],
-                  [-42,  49, -21],
-                  [ 18, -21,   9]], dtype=jnp.float32)
+    b = singular_mats[1]
     jtu.check_grads(jnp.linalg.det, (b,), 1, atol=1e-1, rtol=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -54,6 +54,17 @@ singular_mats = [
 ]
 
 
+nonsquare_singular_mats = [
+  jnp.array([[-35,   7,  27, -17],
+             [ 11, -13,  -9,  11],
+             [ 19, -11, -15,  13]], dtype=jnp.float32),
+  jnp.array([[-35,  11,  19],
+             [  7, -13, -11],
+             [ 27,  -9, -15],
+             [-17,  11,  13]], dtype=np.float32)
+]
+
+
 def _skip_if_unsupported_type(dtype):
   dtype = np.dtype(dtype)
   if (not FLAGS.jax_enable_x64 and
@@ -1000,22 +1011,12 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     for jf, jr in zip(jfwd, jrev):
       np.testing.assert_allclose(jf, jr)
 
-  self._nonsquare_singular_mats = [
-    jnp.array([[-35,   7,  27, -17],
-               [ 11, -13,  -9,  11],
-               [ 19, -11, -15,  13]], dtype=jnp.float32),
-    jnp.array([[-35,  11,  19],
-               [  7, -13, -11],
-               [ 27,  -9, -15],
-               [-17,  11,  13]], dtype=np.float32)
-  ]
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_matidx={}".format(matidx), "matidx": matidx}
       for matidx in range(2)))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj, pfau): fails on TPU.
   def testLuGradOfNonSquareSingularMatrix(self, matidx):
-    mat = self._nonsquare_singular_mats[matidx]
+    mat = nonsquare_singular_mats[matidx]
     jtu.check_grads(jsp.linalg.lu, (mat,), 1, atol=1e-1, rtol=1e-1)
     jtu.check_grads(jsp.linalg.lu, (mat,), 2, modes=["fwd"], atol=1e-1, rtol=1e-1)
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1000,7 +1000,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     for jf, jr in zip(jfwd, jrev):
       np.testing.assert_allclose(jf, jr)
 
-  nonsquare_singular_mats = [
+  self._nonsquare_singular_mats = [
     jnp.array([[-35,   7,  27, -17],
                [ 11, -13,  -9,  11],
                [ 19, -11, -15,  13]], dtype=jnp.float32),
@@ -1009,13 +1009,13 @@ class ScipyLinalgTest(jtu.JaxTestCase):
                [ 27,  -9, -15],
                [-17,  11,  13]], dtype=np.float32)
   ]
-  
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_matidx={}".format(matidx), "matidx": matidx}
       for matidx in range(2)))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj, pfau): fails on TPU.
   def testLuGradOfNonSquareSingularMatrix(self, matidx):
-    mat = nonsquare_singular_mats[matidx]
+    mat = self._nonsquare_singular_mats[matidx]
     jtu.check_grads(jsp.linalg.lu, (mat,), 1, atol=1e-1, rtol=1e-1)
     jtu.check_grads(jsp.linalg.lu, (mat,), 2, modes=["fwd"], atol=1e-1, rtol=1e-1)
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -54,17 +54,6 @@ singular_mats = [
 ]
 
 
-nonsquare_singular_mats = [
-  jnp.array([[-35,   7,  27, -17],
-             [ 11, -13,  -9,  11],
-             [ 19, -11, -15,  13]], dtype=jnp.float32),
-  jnp.array([[-35,  11,  19],
-             [  7, -13, -11],
-             [ 27,  -9, -15],
-             [-17,  11,  13]], dtype=np.float32)
-]
-
-
 def _skip_if_unsupported_type(dtype):
   dtype = np.dtype(dtype)
   if (not FLAGS.jax_enable_x64 and
@@ -1011,6 +1000,16 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     for jf, jr in zip(jfwd, jrev):
       np.testing.assert_allclose(jf, jr)
 
+  nonsquare_singular_mats = [
+    jnp.array([[-35,   7,  27, -17],
+               [ 11, -13,  -9,  11],
+               [ 19, -11, -15,  13]], dtype=jnp.float32),
+    jnp.array([[-35,  11,  19],
+               [  7, -13, -11],
+               [ 27,  -9, -15],
+               [-17,  11,  13]], dtype=np.float32)
+  ]
+  
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_matidx={}".format(matidx), "matidx": matidx}
       for matidx in range(2)))


### PR DESCRIPTION
This PR makes it so the gradient of the LU decomposition can be correctly computed for low-rank matrices. This introduces an additional computational overhead of one extra triangular_solve - each triangular_solve scales as O(n^2), while LU itself scales as O(n^3), so the additional overhead should be minimal.

This makes it so the second derivatives of the determinant of corank-1 matrices can be computed correctly. There are further issues with corank >1 matrices that this PR does not address.

One possible issue is that the behavior of the L term in the LU decomposition is not defined for low-rank matrices for columns greater than the rank of the matrix, and in fact behaves differently for different backends (certain terms that are 0 on CPU appear as 0.5 on GPU on the corank-2 matrix used in the tests, for instance). At the moment the behavior of the gradient of the L matrix for columns beyond the rank of the input matrix is not checked in the tests. As the LU decomposition is mainly used as an inner loop for matrix solves and determinants, we hope this will not introduce any undue confusion in the future.