### PR TITLE
Cleanup: define type lists in test_util & use in several test files.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -23,7 +23,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, NamedTuple, Sequence
 from absl import testing
 from jax import config
 from jax import test_util as jtu
-from jax import dtypes
 from jax import lax
 from jax import numpy as jnp
 
@@ -34,19 +33,14 @@ FLAGS = config.FLAGS
 # TODO: these are copied from tests/lax_test.py (make this source of truth)
 # Do not run int64 tests unless FLAGS.jax_enable_x64, otherwise we get a
 # mix of int32 and int64 operations.
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if
-          t in jtu.supported_dtypes() and
-          (FLAGS.jax_enable_x64 or np.dtype(t).itemsize != 8)]
 
-float_dtypes = supported_dtypes([dtypes.bfloat16, np.float16, np.float32,
-                                 np.float64])
-complex_elem_dtypes = supported_dtypes([np.float32, np.float64])
-complex_dtypes = supported_dtypes([np.complex64, np.complex128])
+float_dtypes = jtu.dtypes.all_floating
+complex_elem_dtypes = jtu.dtypes.floating
+complex_dtypes = jtu.dtypes.complex
 inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([np.int8, np.int16, np.int32, np.int64])
-uint_dtypes = supported_dtypes([np.uint8, np.uint16, np.uint32, np.uint64])
-bool_dtypes = [np.bool_]
+int_dtypes = jtu.dtypes.all_integer
+uint_dtypes = jtu.dtypes.all_unsigned
+bool_dtypes = jtu.dtypes.boolean
 default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
 
@@ -292,7 +286,7 @@ lax_squeeze = jtu.cases_from_list(
 
 shift_inputs = [
   (arg, dtype, shift_amount)
-  for dtype in supported_dtypes(uint_dtypes + int_dtypes)
+  for dtype in uint_dtypes + int_dtypes
   for arg in [
     np.array([-250, -1, 0, 1, 250], dtype=dtype),
   ]

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -40,7 +40,6 @@ except ImportError:
 dlpack_dtypes = [jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                    jnp.uint8, jnp.uint16, jnp.uint32, jnp.uint64,
                    jnp.float16, jnp.float32, jnp.float64]
-all_dtypes = dlpack_dtypes + [jnp.bool_, jnp.bfloat16]
 torch_dtypes = [jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                 jnp.uint8, jnp.float16, jnp.float32, jnp.float64]
 

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -41,15 +41,6 @@ config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
 
-def skip_if_jit_not_enabled():
-  if os.getenv("JAX_ENABLE_JIT_PRINT", "false") == "false":
-    raise SkipTest("print jit not enabled yet; use JAX_ENABLE_JIT_PRINT env.")
-
-
-def supported_dtypes():
-  return sorted(jtu.supported_dtypes(), key=lambda x: np.dtype(x).name)
-
-
 class _TestingOutputStream(object):
   """Use as `output_stream` for tests."""
 
@@ -520,7 +511,7 @@ where: 10
               dtype=dtype,
               nr_args=nr_args) for nr_args in [1, 2]
           for shape in [(), (2,), (2, 3), (2, 3, 4)]
-          for dtype in supported_dtypes()))
+          for dtype in jtu.dtypes.all))
   def test_jit_types(self, nr_args=2, dtype=jnp.int16, shape=(2,)):
     if dtype in (jnp.complex64, jnp.complex128, jnp.bool_):
       raise SkipTest(f"id_print jit not implemented for {dtype}.")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -43,17 +43,13 @@ FLAGS = config.FLAGS
 # For standard unops and binops, we can generate a large number of tests on
 # arguments of appropriate shapes and dtypes using the following table.
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([dtypes.bfloat16, onp.float16, onp.float32,
-                                 onp.float64])
-complex_elem_dtypes = supported_dtypes([onp.float32, onp.float64])
-complex_dtypes = supported_dtypes([onp.complex64, onp.complex128])
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([onp.int32, onp.int64])
-uint_dtypes = supported_dtypes([onp.uint32, onp.uint64])
-bool_dtypes = [onp.bool_]
+float_dtypes = jtu.dtypes.all_floating
+complex_elem_dtypes = jtu.dtypes.floating
+complex_dtypes = jtu.dtypes.complex
+inexact_dtypes = jtu.dtypes.all_inexact
+int_dtypes = jtu.dtypes.integer
+uint_dtypes = jtu.dtypes.unsigned
+bool_dtypes = jtu.dtypes.boolean
 default_dtypes = float_dtypes + int_dtypes
 all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
 

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -36,19 +36,9 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([dtypes.bfloat16, onp.float16, onp.float32,
-                                 onp.float64])
-complex_elem_dtypes = supported_dtypes([onp.float32, onp.float64])
-complex_dtypes = supported_dtypes([onp.complex64, onp.complex128])
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = supported_dtypes([onp.int32, onp.int64])
-uint_dtypes = supported_dtypes([onp.uint32, onp.uint64])
-bool_dtypes = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+float_dtypes = jtu.dtypes.all_floating
+default_dtypes = jtu.dtypes.all_floating + jtu.dtypes.integer
+all_dtypes = jtu.dtypes.all
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip
@@ -674,7 +664,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       # Note also that we chose 3 * 5 * 3 * 5 such that it fits in the range of
       # values a bfloat16 can represent exactly to avoid ties.
       for dtype, rng_factory in itertools.chain(
-        unsafe_zip(float_dtypes + int_dtypes, itertools.repeat(jtu.rand_unique_int)))))
+        unsafe_zip(default_dtypes, itertools.repeat(jtu.rand_unique_int)))))
   def testTopK(self, shape, dtype, k, bdims, rng_factory):
     rng = rng_factory(self.rng())
     # _CheckBatching doesn't work with tuple outputs, so test outputs separately.

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -38,12 +38,9 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-float_dtypes = supported_dtypes([jnp.bfloat16, np.float16, np.float32, np.float64])
-int_dtypes = supported_dtypes([np.int8, np.int16, np.int32, np.int64])
-uint_dtypes = supported_dtypes([np.uint8, np.uint16, np.uint32, np.uint64])
+float_dtypes = jtu.dtypes.all_floating
+int_dtypes = jtu.dtypes.all_integer
+uint_dtypes = jtu.dtypes.all_unsigned
 
 class LaxRandomTest(jtu.JaxTestCase):
 

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -31,13 +31,7 @@ onedim_shapes = [(1,), (2,), (5,), (10,)]
 twodim_shapes = [(1, 1), (2, 2), (2, 3), (3, 4), (4, 4)]
 
 
-def supported_dtypes(dtypes):
-  return [t for t in dtypes if t in jtu.supported_dtypes()]
-
-
-float_dtypes = supported_dtypes([onp.float32, onp.float64])
-int_dtypes = [onp.int32, onp.int64]
-default_dtypes = float_dtypes + int_dtypes
+default_dtypes = jtu.dtypes.floating + jtu.dtypes.integer
 
 
 class LaxBackedScipySignalTests(jtu.JaxTestCase):

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -29,7 +29,6 @@ config.parse_flags_with_absl()
 
 all_shapes = [(), (4,), (3, 4), (3, 1), (1, 4), (2, 1, 4)]
 
-float_dtypes = [onp.float32, onp.float64]
 
 def genNamedParametersNArgs(n, rng_factory):
     return parameterized.named_parameters(
@@ -37,7 +36,7 @@ def genNamedParametersNArgs(n, rng_factory):
           {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
             "rng_factory": rng_factory, "shapes": shapes, "dtypes": dtypes}
           for shapes in itertools.combinations_with_replacement(all_shapes, n)
-          for dtypes in itertools.combinations_with_replacement(float_dtypes, n)))
+          for dtypes in itertools.combinations_with_replacement(jtu.dtypes.floating, n)))
 
 
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
@@ -430,7 +429,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
           # [(5, 3, 2), (3, 2,), (5, 3, 2, 2)],
           # [(5, 3, 2), (3, 2,), (2, 2)],
       ]
-      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(float_dtypes, 3)
+      for x_dtype, mean_dtype, cov_dtype in itertools.combinations_with_replacement(jtu.dtypes.floating, 3)
       if (mean_shape is not None or mean_dtype == onp.float32)
       and (cov_shape is not None or cov_dtype == onp.float32)
       for rng_factory in [jtu.rand_default]))


### PR DESCRIPTION
Replaces #3561

In that PR, I tried defining type lists as module-level constants in `test_util.py`; that led to issues because the device is not always known yet when `jax/test_util` is imported. This replaces those constants with a simple lazy loading scheme.

The main benefit here is that it reduces duplication of dtype selection logic and puts it all in one place, preventing the temptation to have tests import from each other.

Still TODO is to use this new test utility in other test files; this PR starts with just those tests that replicate the `supported_dtypes` helper function.