### PR TITLE
Add test of jax.numpy vs numpy call signatures

### DIFF
--- a/jax/numpy/_util.py
+++ b/jax/numpy/_util.py
@@ -91,6 +91,7 @@ def _wraps(fun, update_doc=True, lax_description=""):
 
       op.__name__ = fun.__name__
       op.__doc__ = docstr
+      op.__np_wrapped__ = fun
     finally:
       return op
   return wrap

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3997,7 +3997,7 @@ class NumpyGradTests(jtu.JaxTestCase):
 
     for name, (jnp_fun, np_fun) in func_pairs.items():
       # Some signatures have changed; skip for older numpy versions.
-      if np.__version__ < "1.17" and name in ['einsum_path', 'gradient', 'isscalar']:
+      if np.__version__ < "1.19" and name in ['einsum_path', 'gradient', 'isscalar']:
         continue
       # Note: can't use inspect.getfullargspec due to numpy issue
       # https://github.com/numpy/numpy/issues/12225

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3912,7 +3912,8 @@ class NumpyGradTests(jtu.JaxTestCase):
     skip = {
       'allclose', 'amax', 'amin', 'angle', 'argmax', 'argmin', 'around', 'broadcast_to',
       'clip', 'convolve', 'corrcoef', 'correlate', 'cumprod', 'cumproduct', 'cumsum',
-      'diff', 'empty_like', 'eye', 'full', 'full_like', 'gradient', 'histogram',
+      'diff', 'empty_like', 'einsum', 'einsum_path',
+      'eye', 'full', 'full_like', 'gradient', 'histogram',
       'isposinf', 'isneginf', 'isscalar', 'max', 'min', 'nancumprod', 'nancumsum',
       'nanprod', 'nansum', 'ones', 'ones_like', 'pad', 'polyadd', 'polyder', 'polysub',
       'prod', 'product', 'round', 'stack', 'sum', 'tile', 'zeros_like'


### PR DESCRIPTION
It can be confusing when jax.numpy call signatures do not exactly match the wrapped numpy call signatures, because the numpy docstring is used directly on the jax function. This PR adds a test that identifies mismatches. Addresses #2988.

A number of extra parameter overrides will be able to be removed via renaming some input parameters; I plan to do that in followup PRs.