### PR TITLE
Add CI tests for numpy 1.16.4

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -42,11 +42,18 @@ jobs:
           - python-version: 3.6
             os: ubuntu-latest
             enable-x64: disable-x64
+            numpy-version: "default"
             num_generated_cases: 25
           - python-version: 3.7
             os: ubuntu-latest
             enable-x64: enable-x64
+            numpy-version: "default"
             num_generated_cases: 25
+          - python-version: 3.7
+            os: ubuntu-latest
+            enable-x64: enable-x64
+            numpy-version: "1.16.4"
+            num_generated_cases: 10
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -57,6 +64,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r build/test-requirements.txt
+        if [ ${{ matrix.numpy-version }} != default ]; then
+          pip install numpy==${{ matrix.numpy-version }}
+        fi
+
     - name: Run tests
       env:
         JAX_NUM_GENERATED_CASES: ${{ matrix.num_generated_cases }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -42,17 +42,17 @@ jobs:
           - python-version: 3.6
             os: ubuntu-latest
             enable-x64: disable-x64
-            numpy-version: "default"
+            package-overrides: "none"
             num_generated_cases: 25
           - python-version: 3.7
             os: ubuntu-latest
             enable-x64: enable-x64
-            numpy-version: "default"
+            package-overrides: "none"
             num_generated_cases: 25
-          - python-version: 3.7
+          - python-version: 3.6
             os: ubuntu-latest
             enable-x64: enable-x64
-            numpy-version: "1.16.4"
+            package-overrides: "numpy==1.16.4"
             num_generated_cases: 10
     steps:
     - uses: actions/checkout@v2
@@ -64,8 +64,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r build/test-requirements.txt
-        if [ ${{ matrix.numpy-version }} != default ]; then
-          pip install numpy==${{ matrix.numpy-version }}
+        if [ ${{ matrix.package-overrides }} != none ]; then
+          pip install ${{ matrix.package-overrides }}
         fi
 
     - name: Run tests


### PR DESCRIPTION
This will allow us to catch some errors before pulldown. I set num_generated_cases to 10, so this should not affect overall CI time.