### PR TITLE
Compare treedefs by `num_leaves` not `traversal_` in `tree_transpose`.

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -194,12 +194,11 @@ def build_tree(treedef, xs):
 
 def tree_transpose(outer_treedef, inner_treedef, pytree_to_transpose):
   flat, treedef = tree_flatten(pytree_to_transpose)
-  expected_treedef = outer_treedef.compose(inner_treedef)
-  if treedef != expected_treedef:
-    raise TypeError("Mismatch\n{}\n != \n{}".format(treedef, expected_treedef))
-
   inner_size = inner_treedef.num_leaves
   outer_size = outer_treedef.num_leaves
+  if treedef.num_leaves != (inner_size * outer_size):
+    expected_treedef = outer_treedef.compose(inner_treedef)
+    raise TypeError(f"Mismatch\n{treedef}\n != \n{expected_treedef}")
   flat = iter(flat)
   lol = [[next(flat) for _ in range(inner_size)] for __ in range(outer_size)]
   transposed_lol = zip(*lol)

--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -682,6 +682,13 @@ std::unique_ptr<PyTreeDef> PyTreeDef::Compose(const PyTreeDef& inner) const {
       out->traversal_.push_back(n);
     }
   }
+  const auto& root = traversal_.back();
+  const auto& inner_root = inner.traversal_.back();
+  // TODO(tomhennigan): This should update all nodes in the traversal.
+  auto& out_root = out->traversal_.back();
+  out_root.num_nodes = (root.num_nodes - root.num_leaves) +
+                       (inner_root.num_nodes * root.num_leaves);
+  out_root.num_leaves *= inner_root.num_leaves;
   return out;
 }
 


### PR DESCRIPTION
In general for a `kCustom` node it is not guaranteed that `a.compose(b)` will
have the same `traversal_` as some structure `c` (which is the composition of
`a+b`). We have a real world example in deepmind/dm-haiku with our FlatMapping
type and I've put a simpler example in `tree_util_tests.py`.

Since this test seems largely to be for input validation I've changed this to
compute the expected number of leaves (which is cheaper than using compose as
the previous implementation did) which will catch common errors and is
guaranteed to work for any well formed pytree (additionally I had to fix the
leaf and node count for composed pytrees which were wrong at HEAD).