### PR TITLE
Add an empty line to JAX change log

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 .. PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 
 These are the release notes for JAX.
+
 jaxlib 0.1.51 (July 2, 2020)
 ------------------------------
 


### PR DESCRIPTION
Hi @gnecula, this is a super small change. Spotted a strange thing on the [change log](https://jax.readthedocs.io/en/latest/CHANGELOG.html).

```
These are the release notes for JAX. jaxlib 0.1.51 (July 2, 2020) ——————————
```

Added an empty line in the .rst file before the jaxlib 0.1.51 itemized list to make it render alright.

