### PR TITLE
Cleanup last use of msgpack.

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -107,6 +107,5 @@ pytype_library(
     srcs_version = "PY3",
     deps = [
         ":jax",
-        "//third_party/py/msgpack",
     ],
 )


### PR DESCRIPTION
This is not needed for the new host_calback runtime.