### PR TITLE
fix ppermute test bugs

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -196,29 +196,26 @@ def ppermute(x, axis_name, perm):
       partial(ppermute_p.bind, axis_name=axis_name, perm=tuple(perm)), x)
 
 def pshuffle(x, axis_name, perm):
-  """Perform a collective shuffle according to the permutation ``perm``.
+  """Convenience wrapper of jax.lax.ppermute with alternate permutation encoding
 
   If ``x`` is a pytree then the result is equivalent to mapping this function to
   each leaf in the tree.
-
-  This function is a simple wrapper around jax.lax.ppermute.
 
   Args:
     x: array(s) with a mapped axis named ``axis_name``.
     axis_name: hashable Python object used to name a pmapped axis (see the
       :func:`jax.pmap` documentation for more details).
-    perm: list of of ints, representing the new order of the source indices
-      that encode how the mapped axis named ``axis_name`` should be
-      shuffled. The integer values are treated as indices into the mapped axis
-      ``axis_name``. Every int between 0 and ``len(perm)-1`` should be included.
+    perm: list of of ints encoding sources for the permutation to be applied to
+      the axis named ``axis_name``, so that the output at axis index i
+      comes from the input at axis index perm[i]. Every integer in [0, N) should
+      be included exactly once for axis size N.
 
   Returns:
     Array(s) with the same shape as ``x`` with slices along the axis
     ``axis_name`` gathered from ``x`` according to the permutation ``perm``.
   """
   if set(perm) != set(range(len(perm))):
-    raise AssertionError(
-      "Given `perm` does not represent a real permutation: {}".format(perm))
+    raise ValueError(f"`perm` does not represent a permutation: {perm}")
   return ppermute(x, axis_name, list(zip(perm, range(len(perm)))))
 
 


### PR DESCRIPTION
Our CI only tests on 2 accelerators (and ppermute isn't implemented on CPU) so we didn't notice that our tests were buggy. Luckily the code itself wasn't!

Also, clarify the docstring on lax.pshuffle. I don't think anyone is using that convenience wrapper, so we might want to delete it.