### PR TITLE
Make infeed_test and host_callback_test independent.

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -876,6 +876,8 @@ def _initialize_outfeed_receiver(
         max_callback_queue_size_bytes)
 
     def exit_handler():
+      # Prevent logging usage during compilation, gives errors under pytest
+      xla._on_exit = True
       logging.vlog(2, "Barrier wait atexit")
       barrier_wait()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,8 +10,5 @@ filterwarnings =
     ignore:can't resolve package from __spec__ or __package__:ImportWarning
     ignore:Using or importing the ABCs.*:DeprecationWarning
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
-addopts = --doctest-glob="*.rst"  --dist=loadfile
-# --dist=loadfile ensure that all the tests in one file are sent to the same runner. This is useful
-# for host_callback_test which start and then stop on teardown the C++ outfeed receiver
-# runtime. If we do not stop the receiver, other tests that use outfeed are going to fail.
+addopts = --doctest-glob="*.rst"
 

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -124,10 +124,6 @@ class HostCallbackTest(jtu.JaxTestCase):
       xla_bridge.get_backend.cache_clear()
     hcb.barrier_wait()
 
-  @classmethod
-  def tearDownClass(cls):
-    hcb.stop_outfeed_receiver()
-
   def helper_set_devices(self, nr_devices):
     flags_str = os.getenv("XLA_FLAGS", "")
     os.environ["XLA_FLAGS"] = (
@@ -962,6 +958,7 @@ what: x times i
     Check that we get the proper error from the runtime."""
     comp = xla_bridge.make_computation_builder(self._testMethodName)
     token = hcb.xops.CreateToken(comp)
+    hcb._initialize_outfeed_receiver()  # Needed if this is the sole test
     with self.assertRaisesRegex(RuntimeError,
                                 "Consumer ID cannot be a reserved value: 0"):
       hcb._outfeed_receiver.receiver.add_outfeed(
@@ -972,6 +969,7 @@ what: x times i
     """Try to register different shapes for the same consumer ID."""
     comp = xla_bridge.make_computation_builder(self._testMethodName)
     token = hcb.xops.CreateToken(comp)
+    hcb._initialize_outfeed_receiver()  # Needed if this is the sole test
     hcb._outfeed_receiver.receiver.add_outfeed(
         comp, token, 123,
         [xla_bridge.constant(comp, np.zeros((2, 3), dtype=np.float32))])


### PR DESCRIPTION
* the infeed_test will stop the outfeed receiver
* Remove the use of --dist=loadfile.