### PR TITLE
Remove a deprecated reference to testExamplesJaxprDoc in Understanding Jaxpr

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -3,9 +3,6 @@ Understanding Jaxprs
 
 Updated: May 3, 2020 (for commit f1a46fe).
 
-(Note: the code examples in this file can be seed also in
-``jax/tests/api_test::JaxprTest.testExamplesJaxprDoc``.)
-
 Conceptually, one can think of JAX transformations as first tracing the Python
 function to be transformed into a small and well-behaved intermediate form,
 the jaxpr, that is then transformed accordingly, and ultimately compiled and executed.


### PR DESCRIPTION
This PR removes a deprecated reference to `JaxprTest.testExamplesJaxprDoc` in the Understanding Jaxpr guide.

See:
- https://github.com/google/jax/pull/2994#issuecomment-625490111
- https://github.com/google/jax/issues/3678

<center><img src="https://user-images.githubusercontent.com/19637339/86822360-71294400-c083-11ea-9e5f-f9c49de2b9ce.png" width="500"></center>

Thanks @j-towns