### PR TITLE
fix pmap test on GPU/TPU

### DIFF
--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -594,7 +594,7 @@ class PmapTest(jtu.JaxTestCase):
     g = lambda: pmap(f, "i")(np.arange(device_count))
     self.assertRaisesRegex(
       AssertionError,
-      "Given `perm` does not represent a real permutation: \\[1.*\\]", g)
+      "`perm` does not represent a permutation: \\[1.*\\]", g)
 
   @jtu.skip_on_devices("cpu", "gpu")
   def testPpermuteWithZipObject(self):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -593,7 +593,7 @@ class PmapTest(jtu.JaxTestCase):
     f = lambda x: lax.pshuffle(x, perm=bad_perm, axis_name='i')
     g = lambda: pmap(f, "i")(np.arange(device_count))
     self.assertRaisesRegex(
-      AssertionError,
+      ValueError,
       "`perm` does not represent a permutation: \\[1.*\\]", g)
 
   @jtu.skip_on_devices("cpu", "gpu")


### PR DESCRIPTION
This was broken by #3675, but not caught in github CI because the test only runs on GPU & TPU.