### PR TITLE
Cleanup: use test_util dtypes where possible

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -30,20 +30,6 @@ import numpy as np
 
 FLAGS = config.FLAGS
 
-# TODO: these are copied from tests/lax_test.py (make this source of truth)
-# Do not run int64 tests unless FLAGS.jax_enable_x64, otherwise we get a
-# mix of int32 and int64 operations.
-
-float_dtypes = jtu.dtypes.all_floating
-complex_elem_dtypes = jtu.dtypes.floating
-complex_dtypes = jtu.dtypes.complex
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = jtu.dtypes.all_integer
-uint_dtypes = jtu.dtypes.all_unsigned
-bool_dtypes = jtu.dtypes.boolean
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
-
 Rng = Any  # A random number generator
 
 class RandArg(NamedTuple):
@@ -189,7 +175,7 @@ lax_pad = jtu.cases_from_list(
           rng_factory=jtu.rand_small,
           arg_shape=arg_shape, dtype=dtype, pads=pads)
   for arg_shape in [(2, 3)]
-  for dtype in default_dtypes
+  for dtype in jtu.dtypes.all_floating + jtu.dtypes.all_integer
   for pads in [
     [(0, 0, 0), (0, 0, 0)],  # no padding
     [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
@@ -286,7 +272,7 @@ lax_squeeze = jtu.cases_from_list(
 
 shift_inputs = [
   (arg, dtype, shift_amount)
-  for dtype in uint_dtypes + int_dtypes
+  for dtype in jtu.dtypes.all_unsigned + jtu.dtypes.all_integer
   for arg in [
     np.array([-250, -1, 0, 1, 250], dtype=dtype),
   ]

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -30,13 +30,10 @@ config.parse_flags_with_absl()
 
 FLAGS = flags.FLAGS
 
-float_dtypes = [np.float32, np.float64]
-complex_dtypes = [np.complex64, np.complex128]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [np.int32, np.int64]
-bool_dtypes = [np.bool_]
-real_dtypes = float_dtypes + int_dtypes + bool_dtypes
-all_dtypes = real_dtypes + complex_dtypes
+float_dtypes = jtu.dtypes.floating
+inexact_dtypes = jtu.dtypes.inexact
+real_dtypes = float_dtypes + jtu.dtypes.integer + jtu.dtypes.bool
+all_dtypes = real_dtypes + jtu.dtypes.complex
 
 
 def _get_fftn_test_axes(shape):

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -32,7 +32,7 @@ FLAGS = flags.FLAGS
 
 float_dtypes = jtu.dtypes.floating
 inexact_dtypes = jtu.dtypes.inexact
-real_dtypes = float_dtypes + jtu.dtypes.integer + jtu.dtypes.bool
+real_dtypes = float_dtypes + jtu.dtypes.integer + jtu.dtypes.boolean
 all_dtypes = real_dtypes + jtu.dtypes.complex
 
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -39,11 +39,9 @@ FLAGS = config.FLAGS
 # pylint: disable=bad-continuation
 
 
-float_dtypes = [onp.float32, onp.float64]
-int_dtypes = [onp.int32, onp.int64]
-bool_types = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + int_dtypes + bool_types
+float_dtypes = jtu.dtypes.floating
+default_dtypes = float_dtypes + jtu.dtypes.integer
+all_dtypes = default_dtypes + jtu.dtypes.boolean
 
 IndexSpec = collections.namedtuple("IndexTest", ["shape", "indexer"])
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -906,9 +906,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     self._CompileAndCheck(jax_fn, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list({
-      "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}".format(
+      "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}_sugared={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
-          jtu.format_shape_dtype_string(update_shape, update_dtype), op.name),
+          jtu.format_shape_dtype_string(update_shape, update_dtype), op.name, sugared),
        "shape": shape, "dtype": dtype, "rng_factory": rng_factory, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op, "sugared": sugared

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -38,13 +38,8 @@ compatible_shapes = [[(), ()],
                      [(3, 1), (1, 4)],
                      [(2, 3, 4), (2, 1, 4)]]
 
-float_dtypes = [onp.float32, onp.float64]
-complex_dtypes = [onp.complex64]
-int_dtypes = [onp.int32, onp.int64]
-bool_dtypes = [onp.bool_]
-default_dtypes = float_dtypes + int_dtypes
-numeric_dtypes = float_dtypes + complex_dtypes + int_dtypes
-
+float_dtypes = jtu.dtypes.floating
+int_dtypes = jtu.dtypes.integer
 
 OpRecord = collections.namedtuple(
     "OpRecord",

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -25,13 +25,7 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
-float_dtypes = [np.float32, np.float64]
-# implementation casts to complex64.
-complex_dtypes = [np.complex64]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [np.int32, np.int64]
-real_dtypes = float_dtypes + int_dtypes
-all_dtypes = real_dtypes + complex_dtypes
+all_dtypes = jtu.dtypes.floating + jtu.dtypes.integer + jtu.dtypes.complex
 
 
 # TODO: these tests fail without fixed PRNG seeds.

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -30,12 +30,8 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
-float_dtypes = [onp.float32, onp.float64]
-complex_dtypes = [onp.complex64, onp.complex128]
-inexact_dtypes = float_dtypes + complex_dtypes
-int_dtypes = [onp.int32, onp.int64]
-bool_dtypes = [onp.bool_]
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+float_dtypes = jtu.dtypes.floating
+int_dtypes = jtu.dtypes.integer
 
 
 def _fixed_ref_map_coordinates(input, coordinates, order, mode, cval=0.0):


### PR DESCRIPTION
The benefit is that `jtu.dtypes` correctly selects the appropriate dtypes based on the backend and x64 mode.