### PR TITLE
Cleanup: record names in get_module_functions

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -71,9 +71,9 @@ def _init():
   from . import lax_numpy
   from .. import util
   # Builds a set of all unimplemented NumPy functions.
-  for func in util.get_module_functions(np):
-    if func.__name__ not in globals():
-      globals()[func.__name__] = lax_numpy._not_implemented(func)
+  for name, func in util.get_module_functions(np).items():
+    if name not in globals():
+      globals()[name] = lax_numpy._not_implemented(func)
 
 _init()
 del _init

--- a/jax/numpy/fft.py
+++ b/jax/numpy/fft.py
@@ -236,6 +236,6 @@ def ifftshift(x, axes=None):
   return jnp.roll(x, shift, axes)
 
 
-for func in get_module_functions(np.fft):
-  if func.__name__ not in globals():
-    globals()[func.__name__] = _not_implemented(func)
+for name, func in get_module_functions(np.fft).items():
+  if name not in globals():
+    globals()[name] = _not_implemented(func)

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -479,9 +479,9 @@ def solve(a, b):
     return vmap(custom_solve, b.ndim - 1, max(a.ndim, b.ndim) - 1)(b)
 
 
-for func in get_module_functions(np.linalg):
-  if func.__name__ not in globals():
-    globals()[func.__name__] = _not_implemented(func)
+for name, func in get_module_functions(np.linalg).items():
+  if name not in globals():
+    globals()[name] = _not_implemented(func)
 
 
 @_wraps(np.linalg.lstsq, lax_description=textwrap.dedent("""\

--- a/jax/util.py
+++ b/jax/util.py
@@ -223,9 +223,9 @@ def get_module_functions(module):
   Args:
     module: A Python module.
   Returns:
-    module_fns: A set of functions, builtins or ufuncs in `module`.
+    module_fns: A dict of names mapped to functions, builtins or ufuncs in `module`.
   """
-  module_fns = set()
+  module_fns = {}
   for key in dir(module):
     # Omitting module level __getattr__, __dir__ which was added in Python 3.7
     # https://www.python.org/dev/peps/pep-0562/
@@ -234,7 +234,7 @@ def get_module_functions(module):
     attr = getattr(module, key)
     if isinstance(
         attr, (types.BuiltinFunctionType, types.FunctionType, onp.ufunc)):
-      module_fns.add(attr)
+      module_fns[key] = attr
   return module_fns
 
 def wrap_name(name, transform_name):


### PR DESCRIPTION
Why? In general, `__name__` attributes do not always match the name by which the object is exposed to the user.

For example, `jax.numpy` currently includes an attribute named `<lambda>`, which is not intended:
```python
>>> import jax.numpy
>>> getattr(jax.numpy, '<lambda>')
<function jax.numpy.lax_numpy._not_implemented.<locals>.wrapped>
```
This should fix the issue.