### PR TITLE
Add jax.image.resize.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,6 +1,7 @@
 flake8
 jaxlib==0.1.51
 mypy==0.770
+pillow
 pytest-benchmark
 pytest-xdist
 # jax2tf needs some fixes that are not in latest tensorflow

--- a/docs/jax.image.rst
+++ b/docs/jax.image.rst
@@ -1,0 +1,16 @@
+jax.image package
+=================
+
+.. currentmodule:: jax.image
+
+.. automodule:: jax.image
+
+
+Image manipulation functions
+----------------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    resize
+

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -12,6 +12,7 @@ Subpackages
     jax.numpy
     jax.scipy
     jax.experimental
+    jax.image
     jax.lax
     jax.nn
     jax.ops

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -79,6 +79,7 @@ from .version import __version__
 
 # These submodules are separate because they are in an import cycle with
 # jax and rely on the names imported above.
+from . import image
 from . import lax
 from . import nn
 from . import random

--- a/jax/image/__init__.py
+++ b/jax/image/__init__.py
@@ -19,4 +19,3 @@ from .scale import (
   resize,
   ResizeMethod
 )
-del scale

--- a/jax/image/__init__.py
+++ b/jax/image/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common functions for neural network libraries."""
+
+# flake8: noqa: F401
+from .scale import (
+  resize,
+  ResizeMethod
+)
+del scale

--- a/jax/image/scale.py
+++ b/jax/image/scale.py
@@ -57,8 +57,6 @@ def _compute_spans(input_size: int, output_size: int,
                    antialias: bool) -> Tuple[np.ndarray, np.ndarray]:
   """
   Computes the locations and weights of the spans of a 1D input image.
-
-  input_size:
   Returns:
     A `(starts, weights)` tuple of ndarrays, where `starts` has shape
     `[output_size]` and `weights` has shape `[output_size, span_size]`.

--- a/jax/image/scale.py
+++ b/jax/image/scale.py
@@ -1,0 +1,197 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import enum
+import math
+import string
+from typing import Callable, Sequence, Tuple, Union
+
+from jax import lax
+from jax import numpy as jnp
+import numpy as np
+
+
+def _lanczos_kernel(radius: float):
+  def kernel(x: np.ndarray) -> np.ndarray:
+    x = np.abs(x)
+    y = radius * np.sin(np.pi * x) * np.sin(np.pi * x / radius)
+    with np.errstate(divide='ignore', invalid='ignore'):
+      out = y / (np.pi ** 2 * x ** 2)
+    out = np.where(x <= 1e-3, 1., out)
+    return np.where(x > radius, 0., out)
+
+  return radius, kernel
+
+
+def _triangle_kernel():
+  return 1., lambda x: np.maximum(0, 1 - np.abs(x))
+
+
+def _keys_cubic_kernel():
+  # http://ieeexplore.ieee.org/document/1163711/
+  # R. G. Keys. Cubic convolution interpolation for digital image processing.
+  # IEEE Transactions on Acoustics, Speech, and Signal Processing,
+  # 29(6):1153–1160, 1981.
+  def kernel(x: np.ndarray) -> np.ndarray:
+    x = np.abs(x)
+    out = ((1.5 * x - 2.5) * x) * x + 1.
+    out = np.where(x >= 1., ((-0.5* x + 2.5) * x - 4.) * x + 2., out)
+    return np.where(x >= 2., 0., out)
+  return 2., kernel
+
+
+def _compute_spans(input_size: int, output_size: int,
+                   scale: float, translate: float,
+                   kernel: Tuple[float, Callable[[np.ndarray], np.ndarray]],
+                   antialias: bool) -> Tuple[np.ndarray, np.ndarray]:
+  """
+  Computes the locations and weights of the spans of a 1D input image.
+
+  input_size:
+  Returns:
+    A `(starts, weights)` tuple of ndarrays, where `starts` has shape
+    `[output_size]` and `weights` has shape `[output_size, span_size]`.
+  """
+  radius, kernel_fn = kernel
+  inv_scale = 1. / scale
+  kernel_scale = max(inv_scale, 1.) if antialias else 1.
+  span_size = min(2 * int(math.ceil(radius * kernel_scale)) + 1, input_size)
+
+  sample_f = (np.arange(output_size) + 0.5) * inv_scale * (1. - translate)
+  span_start = np.ceil(sample_f - radius * kernel_scale - 0.5)
+  span_start = np.clip(span_start, 0, input_size - span_size)
+  kernel_pos = (span_start - sample_f)[:, None] + np.arange(span_size) + 0.5
+  weight = kernel_fn(kernel_pos / kernel_scale)
+  total_weight_sum = np.sum(weight, axis=1, keepdims=True)
+  weights = np.where(
+      np.abs(total_weight_sum) > 1000. * np.finfo(np.float32).min,
+      weight / total_weight_sum, 0)
+  return span_start.astype(np.int32), weights
+
+
+def _scale_and_translate(x, output_shape, scale, translate, kernel,
+                         antialias):
+  input_shape = x.shape
+  assert len(input_shape) == len(output_shape)
+  assert len(input_shape) == len(scale)
+  assert len(input_shape) == len(translate)
+  spatial_dims = np.nonzero(
+      np.not_equal(input_shape, output_shape) |
+      np.not_equal(scale, 1) |
+      np.not_equal(translate, 0))[0]
+  if len(spatial_dims) == 0:
+    return x
+  output_spatial_shape = tuple(np.array(output_shape)[spatial_dims])
+  indices = []
+  dim_weights = []
+  slice_shape = list(input_shape)
+  in_names = string.ascii_lowercase[:len(output_shape) + len(spatial_dims)]
+  out_names = list(string.ascii_lowercase[:len(output_shape)])
+  einstr = in_names
+  for i, d in enumerate(spatial_dims):
+    m = input_shape[d]
+    n = output_shape[d]
+    starts, weights = _compute_spans(m, n, scale[d], translate[d],
+                                     kernel, antialias=antialias)
+    starts = lax.broadcast_in_dim(starts, output_spatial_shape + (1,), (i,))
+    slice_shape[d] = weights.shape[1]
+    indices.append(starts.astype(np.int32))
+    dim_weights.append(weights.astype(x.dtype))
+    einstr += ",{}{}".format(in_names[len(output_shape) + i], in_names[d])
+    out_names[d] = in_names[len(output_shape) + i]
+  index = lax.concatenate(indices, len(output_spatial_shape))
+  dnums = lax.GatherDimensionNumbers(
+      offset_dims=tuple(range(len(output_shape))),
+      collapsed_slice_dims=(),
+      start_index_map=tuple(spatial_dims))
+  out = lax.gather(x, index, dnums, slice_shape)
+  return jnp.einsum("{}->{}".format(einstr, "".join(out_names)), out,
+                    *dim_weights, precision=lax.Precision.HIGHEST)
+
+
+class ResizeMethod(enum.Enum):
+  LINEAR = 1
+  LANCZOS3 = 2
+  LANCZOS5 = 3
+  CUBIC = 4
+  BOX = 5
+
+  @staticmethod
+  def from_string(s: str):
+    if s in ['linear', 'bilinear', 'trilinear']:
+      return ResizeMethod.LINEAR
+    elif s == 'lanczos3':
+      return ResizeMethod.LANCZOS3
+    elif s == 'lanczos5':
+      return ResizeMethod.LANCZOS5
+    elif s in ['cubic', 'bicubic', 'tricubic']:
+      return ResizeMethod.CUBIC
+    else:
+      raise ValueError(f'Unknown resize method "{s}"')
+
+_kernels = {}
+_kernels[ResizeMethod.LINEAR] = _triangle_kernel()
+_kernels[ResizeMethod.LANCZOS3] = _lanczos_kernel(3.)
+_kernels[ResizeMethod.LANCZOS5] = _lanczos_kernel(5.)
+_kernels[ResizeMethod.CUBIC] = _keys_cubic_kernel()
+
+
+def resize(image, shape: Sequence[int], method: Union[str, ResizeMethod],
+           antialias: bool = True):
+  """Image resize.
+
+  The ``method`` argument expects one of the following resize methods:
+
+  ``ResizeMethod.LINEAR``, ``"linear"``, ``"bilinear"``, ``"trilinear"``
+    `Linear interpolation`_. If ``antialias`` is ``True``, uses a triangular
+    filter when downsampling.
+
+  ``ResizeMethod.CUBIC``, ``"cubic"``, ``"bicubic"``, ``"tricubic"``
+    `Cubic interpolation`_, using the Keys cubic kernel.
+
+  ``ResizeMethod.LANCZOS3``, ``"lanczos3"``
+    `Lanczos resampling`_, using a kernel of radius 3.
+
+  ``ResizeMethod.LANCZOS5``, ``"lanczos5"``
+    `Lanczos resampling`_, using a kernel of radius 5.
+
+  .. _Linear interpolation: https://en.wikipedia.org/wiki/Bilinear_interpolation
+  .. _Cubic interpolation: https://en.wikipedia.org/wiki/Bicubic_interpolation
+  .. _Lanczos resampling: https://en.wikipedia.org/wiki/Lanczos_resampling
+
+  Args:
+    image: a JAX array.
+    shape: the output shape, as a sequence of integers with length equal to
+      the number of dimensions of `image`. Note that :func:`resize` does not
+      distinguish spatial dimensions from batch or channel dimensions, so this
+      includes all dimensions of the image. To represent a batch or a channel
+      dimension, simply leave that element of the shape unchanged.
+    method: the resizing method to use; either a ``ResizeMethod`` instance or a
+      string. Available methods are: LINEAR, LANCZOS3, LANCZOS5, CUBIC, BOX.
+    antialias: should an antialiasing filter be used when downsampling? Defaults
+      to ``True``. Has no effect when upsampling.
+  Returns:
+    The resized image.
+  """
+  if len(shape) != image.ndim:
+    msg = ('shape must have length equal to the number of dimensions of x; '
+           f' {shape} vs {image.shape}')
+    raise ValueError(msg)
+  kernel = _kernels[ResizeMethod.from_string(method) if isinstance(method, str)
+                    else method]
+  scale = [float(o) / i for o, i in zip(shape, image.shape)]
+  if not jnp.issubdtype(image.dtype, jnp.inexact):
+    image = lax.convert_element_type(image, jnp.result_type(image, jnp.float32))
+  return _scale_and_translate(image, shape, scale, [0.] * image.ndim, kernel,
+                              antialias)

--- a/jax/image/scale.py
+++ b/jax/image/scale.py
@@ -123,7 +123,6 @@ class ResizeMethod(enum.Enum):
   LANCZOS3 = 2
   LANCZOS5 = 3
   CUBIC = 4
-  BOX = 5
 
   @staticmethod
   def from_string(s: str):
@@ -176,7 +175,7 @@ def resize(image, shape: Sequence[int], method: Union[str, ResizeMethod],
       includes all dimensions of the image. To represent a batch or a channel
       dimension, simply leave that element of the shape unchanged.
     method: the resizing method to use; either a ``ResizeMethod`` instance or a
-      string. Available methods are: LINEAR, LANCZOS3, LANCZOS5, CUBIC, BOX.
+      string. Available methods are: LINEAR, LANCZOS3, LANCZOS5, CUBIC.
     antialias: should an antialiasing filter be used when downsampling? Defaults
       to ``True``. Has no effect when upsampling.
   Returns:

--- a/jax/image/scale.py
+++ b/jax/image/scale.py
@@ -62,6 +62,9 @@ def _compute_spans(input_size: int, output_size: int,
   """
   radius, kernel_fn = kernel
   inv_scale = 1. / scale
+  # When downsampling the kernel should be scaled since we want to low pass
+  # filter and interpolate, but when upsampling it should not be since we only
+  # want to interpolate.
   kernel_scale = max(inv_scale, 1.) if antialias else 1.
   span_size = min(2 * int(math.ceil(radius * kernel_scale)) + 1, input_size)
 
@@ -125,7 +128,7 @@ class ResizeMethod(enum.Enum):
 
   @staticmethod
   def from_string(s: str):
-    if s in ['linear', 'bilinear', 'trilinear']:
+    if s in ['linear', 'bilinear', 'trilinear', 'triangle']:
       return ResizeMethod.LINEAR
     elif s == 'lanczos3':
       return ResizeMethod.LANCZOS3
@@ -149,7 +152,7 @@ def resize(image, shape: Sequence[int], method: Union[str, ResizeMethod],
 
   The ``method`` argument expects one of the following resize methods:
 
-  ``ResizeMethod.LINEAR``, ``"linear"``, ``"bilinear"``, ``"trilinear"``
+  ``ResizeMethod.LINEAR``, ``"linear"``, ``"bilinear"``, ``"trilinear"``, ``"triangle"``
     `Linear interpolation`_. If ``antialias`` is ``True``, uses a triangular
     filter when downsampling.
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1,0 +1,158 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+import itertools
+import unittest
+
+import numpy as np
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from jax import image
+from jax import test_util as jtu
+
+from jax.config import config
+from jax.config import flags
+
+# We use TensorFlow and PIL as reference implementations.
+try:
+  import tensorflow as tf
+except ImportError:
+  tf = None
+
+try:
+  from PIL import Image as PIL_Image
+except ImportError:
+  PIL_Image = None
+
+config.parse_flags_with_absl()
+
+FLAGS = flags.FLAGS
+
+float_dtypes = jtu.dtypes.all_floating
+inexact_dtypes = jtu.dtypes.inexact
+
+class ImageTest(jtu.JaxTestCase):
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+       {"testcase_name": "_shape={}_target={}_method={}_antialias={}".format(
+          jtu.format_shape_dtype_string(image_shape, dtype),
+          jtu.format_shape_dtype_string(target_shape, dtype), method,
+          antialias),
+        "dtype": dtype, "image_shape": image_shape,
+        "target_shape": target_shape,
+        "method": method, "antialias": antialias}
+       for dtype in [np.float32]
+       for target_shape, image_shape in itertools.combinations_with_replacement(
+        [[2, 3, 2, 4], [2, 6, 4, 4], [2, 33, 17, 4], [2, 50, 38, 4]], 2)
+       for method in ["bilinear", "lanczos3", "lanczos5", "bicubic"]
+       for antialias in [False, True])) 
+  @unittest.skipIf(not tf, "Test requires TensorFlow")
+  def testResizeAgainstTensorFlow(self, dtype, image_shape, target_shape, method,
+                                  antialias):
+    # TODO(phawkins): debug this. There is a small mismatch between TF and JAX
+    # for some cases of non-antialiased bicubic downscaling; we would expect
+    # exact equality.
+    if method == "bicubic" and any(x < y for x, y in
+                                   zip(target_shape, image_shape)):
+      raise unittest.SkipTest("non-antialiased bicubic downscaling mismatch")
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: (rng(image_shape, dtype),)
+    def tf_fn(x):
+      out = tf.image.resize(x, tf.constant(target_shape[1:-1]), method=method,
+                             antialias=antialias).numpy()
+      print(out.dtype)
+      return out
+    jax_fn = partial(image.resize, shape=target_shape, method=method,
+                     antialias=antialias)
+    self._CheckAgainstNumpy(tf_fn, jax_fn, args_maker, check_dtypes=True,
+                            tol=1e-4)
+
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+       {"testcase_name": "_shape={}_target={}_method={}".format(
+          jtu.format_shape_dtype_string(image_shape, dtype),
+          jtu.format_shape_dtype_string(target_shape, dtype), method),
+        "dtype": dtype, "image_shape": image_shape,
+        "target_shape": target_shape,
+        "method": method}
+       for dtype in [np.float32]
+       for target_shape, image_shape in itertools.combinations_with_replacement(
+        [[3, 2], [6, 4], [33, 17], [50, 38]], 2)
+       for method in ["bilinear", "lanczos3", "bicubic"]))
+  @unittest.skipIf(not PIL_Image, "Test requires PIL")
+  def testResizeAgainstPIL(self, dtype, image_shape, target_shape, method):
+    rng = jtu.rand_uniform(self.rng())
+    args_maker = lambda: (rng(image_shape, dtype),)
+    def pil_fn(x):
+      pil_methods = {
+        "bilinear": PIL_Image.BILINEAR,
+        "bicubic": PIL_Image.BICUBIC,
+        "lanczos3": PIL_Image.LANCZOS,
+      }
+      img = PIL_Image.fromarray(x)
+      print(img, x.shape)
+      out = np.asarray(img.resize(target_shape[::-1], pil_methods[method]))
+      print(out.shape, target_shape)
+      return out
+    jax_fn = partial(image.resize, shape=target_shape, method=method,
+                     antialias=True)
+    self._CheckAgainstNumpy(pil_fn, jax_fn, args_maker, check_dtypes=True,
+                            tol=1e-4)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+       {"testcase_name": "_shape={}_target={}_method={}".format(
+          jtu.format_shape_dtype_string(image_shape, dtype),
+          jtu.format_shape_dtype_string(target_shape, dtype), method),
+        "dtype": dtype, "image_shape": image_shape, "target_shape": target_shape,
+        "method": method}
+       for dtype in inexact_dtypes
+       for image_shape, target_shape in [
+         ([3, 1, 2], [6, 1, 4]),
+         ([1, 3, 2, 1], [1, 6, 4, 1]),
+       ]
+       for method in ["linear", "lanczos3", "lanczos5", "cubic"]))
+  def testResizeUp(self, dtype, image_shape, target_shape, method):
+    data = [64, 32, 32, 64, 50, 100]
+    expected_data = {}
+    expected_data["linear"] = [
+        64.0, 56.0, 40.0, 32.0, 56.0, 52.0, 44.0, 40.0, 40.0, 44.0, 52.0, 56.0,
+        36.5, 45.625, 63.875, 73.0, 45.5, 56.875, 79.625, 91.0, 50.0, 62.5,
+        87.5, 100.0
+    ]
+    expected_data["lanczos3"] = [
+        75.8294, 59.6281, 38.4313, 22.23, 60.6851, 52.0037, 40.6454, 31.964,
+        35.8344, 41.0779, 47.9383, 53.1818, 24.6968, 43.0769, 67.1244, 85.5045,
+        35.7939, 56.4713, 83.5243, 104.2017, 44.8138, 65.1949, 91.8603, 112.2413
+    ]
+    expected_data["lanczos5"] = [
+        77.5699, 60.0223, 40.6694, 23.1219, 61.8253, 51.2369, 39.5593, 28.9709,
+        35.7438, 40.8875, 46.5604, 51.7041, 21.5942, 43.5299, 67.7223, 89.658,
+        32.1213, 56.784, 83.984, 108.6467, 44.5802, 66.183, 90.0082, 111.6109
+    ]
+    expected_data["cubic"] = [
+        70.1453, 59.0252, 36.9748, 25.8547, 59.3195, 53.3386, 41.4789, 35.4981,
+        36.383, 41.285, 51.0051, 55.9071, 30.2232, 42.151, 65.8032, 77.731,
+        41.6492, 55.823, 83.9288, 98.1026, 47.0363, 62.2744, 92.4903, 107.7284
+    ]
+    x = np.array(data, dtype=dtype).reshape(image_shape)
+    output = image.resize(x, target_shape, method)
+    expected = np.array(expected_data[method], dtype=dtype).reshape(target_shape)
+    self.assertAllClose(output, expected, atol=1e-04)
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -169,7 +169,7 @@ class ImageTest(jtu.JaxTestCase):
     args_maker = lambda: (rng(image_shape, dtype),)
     jax_fn = partial(image.resize, shape=target_shape, method=method,
                      antialias=antialias)
-    jtu.check_grads(jax_fn, args_maker(), order=1, rtol=1e-2)
+    jtu.check_grads(jax_fn, args_maker(), order=2, rtol=1e-2, eps=1.)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a port of tf.image.resize() and the ScaleAndTranslate operator.

While I don't expect this implementation to be particularly fast, it is a useful generic implementation to which we can add optimized special cases as the need arises.