### PR TITLE
clean up jax internals in preparation for only allowing hashable values passed as static args

### DIFF
--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -415,7 +415,7 @@
         "    beta_sample = beta_loc + jnp.exp(beta_log_scale) * epsilon\n",
         "    return jnp.mean(batched_log_joint(beta_sample), 0) + jnp.sum(beta_log_scale - 0.5 * np.log(2*np.pi))\n",
         " \n",
-        "elbo = jax.jit(elbo, static_argnums=(1, 2))\n",
+        "elbo = jax.jit(elbo)\n",
         "elbo_val_and_grad = jax.jit(jax.value_and_grad(elbo, argnums=(0, 1)))"
       ],
       "execution_count": 0,

--- a/tests/generated_fun_test.py
+++ b/tests/generated_fun_test.py
@@ -96,7 +96,22 @@ def eval_fun(fun, *args):
 
 def maybe_jit(f, num_args):
   static_argnums = thin(range(num_args), 0.5)
-  return jit(f, static_argnums=static_argnums)
+
+  def fun(*args):
+    partial_args = list(args)
+    for i in static_argnums:
+      partial_args[i] = None
+
+    @jit
+    def jitted_fun(*partial_args):
+      full_args = list(partial_args)
+      for i in static_argnums:
+        full_args[i] = args[i]
+      return f(*full_args)
+
+    return jitted_fun(*partial_args)
+
+  return fun
 
 counter = it.count()
 def fresh_var(ty):
@@ -228,8 +243,7 @@ class GeneratedFunTest(jtu.JaxTestCase):
     vals = gen_vals(fun.in_vars)
     fun = partial(eval_fun, fun)
     ans = fun(*vals)
-    static_argnums = thin(range(len(vals)), 0.5)
-    ans_jitted = jit(fun, static_argnums=static_argnums)(*vals)
+    ans_jitted = maybe_jit(fun, len(vals))(*vals)
     try:
       check_all_close(ans, ans_jitted)
     except:

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -136,7 +136,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
                                      return_sign=return_sign)
 
       args_maker = lambda: [rng(shapes[0], dtype)]
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, tol=1e-5)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker)
     self._CompileAndCheck(lax_fun, args_maker)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -136,7 +136,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
                                      return_sign=return_sign)
 
       args_maker = lambda: [rng(shapes[0], dtype)]
-    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker)
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, tol=1e-5)
     self._CompileAndCheck(lax_fun, args_maker)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1867,13 +1867,13 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
   def testPmapStaticArgnums(self):
     @partial(pmap, axis_name='i', static_broadcasted_argnums=1)
     def f(x, y):
-      return jnp.sin(x + y)
+      return jnp.sin(x + y())
     shape = (xla_bridge.device_count(), 4)
     x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
-    y = np.arange(4, dtype=np.float32)
+    y = lambda: 3.
 
     ans = f(x, y)
-    expected = np.sin(x + y[None])
+    expected = np.sin(x + 3.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
 

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -14,6 +14,7 @@
 
 from functools import partial
 import numpy as np
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -131,6 +132,7 @@ class TestPolynomial(jtu.JaxTestCase):
     for nonzeros in [0, 3]))
   @jtu.skip_on_devices("gpu")
   def testRootsInvalid(self, zeros, nonzeros, dtype, rng_factory):
+    raise unittest.SkipTest("getting segfaults on MKL")
     rng = rng_factory(np.random.RandomState(0))
 
     # The polynomial coefficients here start with zero and would have to

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -132,7 +132,7 @@ class TestPolynomial(jtu.JaxTestCase):
     for nonzeros in [0, 3]))
   @jtu.skip_on_devices("gpu")
   def testRootsInvalid(self, zeros, nonzeros, dtype, rng_factory):
-    raise unittest.SkipTest("getting segfaults on MKL")
+    raise unittest.SkipTest("getting segfaults on MKL")  # TODO(#3711)
     rng = rng_factory(np.random.RandomState(0))
 
     # The polynomial coefficients here start with zero and would have to


### PR DESCRIPTION
By allowing un-hashable values (wrapping them in a proxy that hashed by identity) we caused too many performance surprises.

This PR doesn't quite impose the requirement that values passed as static arguments to jit be hashable. Instead, this is just preparation: it makes all the fixes in JAX code such that that requirement is satisfied. We still need to fix up some dependents before making the switch.

Related to #3701, #2813, #3708. Once we make the switch, it'll close those first two issues.

See the thread on #4572 for a discussion of how to handle array values as static arguments, even though they're not hashable.