### PR TITLE
Import profiler in jax/__init__.py

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -87,6 +87,7 @@ from .version import __version__
 from . import image
 from . import lax
 from . import nn
+from . import profiler
 from . import random
 
 def _init():


### PR DESCRIPTION
At head the following fails:

```python
import jax
jax.profiler.$x
```

Requiring you to import the submodule directly:

```python
import jax.profiler
jax.profiler.$x
```

This change makes the first snippet work (in addition to the second).