### PR TITLE
Generalize reduce-window padding to support (lo, hi) pairs.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -791,9 +791,6 @@ def _reduce_window(jax_f, reducer, init_val, operand, window_dimensions,
   # TODO(tomhennigan): tf2xla should have a shape inference function.
   out_shape = _reduce_window_shape(jax_f, operand, window_dimensions,
                                    window_strides, padding)
-  padding = lax.padtype_to_pads(_get_shape_from_tensor_or_array(operand),
-                                window_dimensions,
-                                window_strides, padding)
   a = tf.constant(0, operand.dtype)
   reducer_fn = reducer.get_concrete_function(a, a)
   out = tfxla.reduce_window(operand, tf.constant(init_val, operand.dtype),

--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -174,8 +174,10 @@ def _pooling_layer(reducer, init_val, rescaler=None):
       strides = strides[:i] + (1,) + strides[i:]
 
     def init_fun(rng, input_shape):
+      padding_vals = lax.padtype_to_pads(input_shape, window_shape,
+                                         strides, padding)
       out_shape = lax.reduce_window_shape_tuple(input_shape, window_shape,
-                                                strides, padding)
+                                                strides, padding_vals)
       return out_shape, ()
     def apply_fun(params, inputs, **kwargs):
       out = lax.reduce_window(inputs, init_val, reducer, window_shape,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4862,6 +4862,7 @@ def _select_and_gather_add_batching_rule(
   x = batching.bdim_at_front(x, x_bdim, size)
   window_dimensions = (1,) + window_dimensions
   window_strides = (1,) + window_strides
+  padding = ((0, 0),) + padding
   out = _select_and_gather_add(t, x, select_prim, window_dimensions,
                                window_strides, padding)
   return (out, 0)

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1116,7 +1116,7 @@ def _reduce_and(operand: Array, axes: Sequence[int]) -> Array:
 def reduce_window(operand: Array, init_value: Array, computation: Callable,
                   window_dimensions: Shape, window_strides: Sequence[int],
                   padding: Union[str, Sequence[Tuple[int, int]]]) -> Array:
-  """Wraps XLA's `ReduceWindow
+  """Wraps XLA's `ReduceWindowWithGeneralPadding
   <https://www.tensorflow.org/xla/operation_semantics#reducewindow>`_
   operator.
   """

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -566,8 +566,9 @@ class LaxVmapTest(jtu.JaxTestCase):
             [(1, 2, 2, 1), (1, 1, 1, 1)]))
 
     def fun(operand, tangents):
+      pads = lax.padtype_to_pads(operand.shape, dims, strides, padding)
       return lax._select_and_gather_add(operand, tangents, lax.ge_p, dims,
-                                        strides, padding)
+                                        strides, pads)
 
     for shape, dims, strides in all_configs:
       for bdims in all_bdims(shape, shape):


### PR DESCRIPTION
This matches the underlying XLA API, and it turns out to simplify the code slightly, too.