### PR TITLE
Curry jit, grad, value_and_grad and vmap.

### DIFF
--- a/build/setup.py
+++ b/build/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.12', 'absl-py'],
+    install_requires=['scipy', 'numpy>=1.12', 'absl-py', 'toolz'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={'jaxlib': binary_libs},

--- a/examples/advi.py
+++ b/examples/advi.py
@@ -53,7 +53,7 @@ def batch_elbo(logprob, rng, params, num_samples):
 
 # ========= Helper function for plotting. =========
 
-@partial(jit, static_argnums=(0, 1, 2, 4))
+@jit(static_argnums=(0, 1, 2, 4))
 def _mesh_eval(func, x_limits, y_limits, params, num_ticks):
     # Evaluate func on a 2D grid defined by x_limits and y_limits.
     x = jnp.linspace(*x_limits, num=num_ticks)

--- a/jax/BUILD
+++ b/jax/BUILD
@@ -43,7 +43,10 @@ pytype_library(
         ],
     ),
     srcs_version = "PY3",
-    deps = ["@org_tensorflow//tensorflow/compiler/xla/python:xla_client"],
+    deps = [
+        "//third_party/py/toolz",
+        "@org_tensorflow//tensorflow/compiler/xla/python:xla_client",
+    ],
 )
 
 pytype_library(

--- a/jax/api.py
+++ b/jax/api.py
@@ -29,6 +29,7 @@ import functools
 import inspect
 import itertools as it
 import threading
+import toolz
 from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
 from warnings import warn
 
@@ -89,6 +90,7 @@ class _ThreadLocalState(threading.local):
 
 _thread_local_state = _ThreadLocalState()
 
+@toolz.curry
 def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
         device=None, backend: Optional[str] = None,
         donate_argnums: Union[int, Iterable[int]] = ()) -> Callable:
@@ -365,6 +367,7 @@ def xla_computation(fun: Callable,
     return c.build(xc.ops.Tuple(c, outs))
   return computation_maker
 
+@toolz.curry
 def grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
          has_aux: bool = False, holomorphic: bool = False) -> Callable:
   """Creates a function which evaluates the gradient of ``fun``.
@@ -420,6 +423,7 @@ def grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
 
   return grad_f_aux if has_aux else grad_f
 
+@toolz.curry
 def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
                    has_aux: bool = False, holomorphic: bool = False
                    ) -> Callable[..., Tuple[Any, Any]]:
@@ -734,7 +738,7 @@ def _split(x, indices, axis):
 def _dtype(x):
   return dtypes.canonicalize_dtype(dtypes.result_type(x))
 
-
+@toolz.curry
 def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
   """Vectorizing map. Creates a function which maps ``fun`` over argument axes.
 

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -206,7 +206,7 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
 
   return _odeint_wrapper(converted, rtol, atol, mxstep, y0, t, *consts, *args)
 
-@partial(jax.jit, static_argnums=(0, 1, 2, 3))
+@jax.jit(static_argnums=(0, 1, 2, 3))
 def _odeint_wrapper(func, rtol, atol, mxstep, y0, ts, *args):
   y0, unravel = ravel_pytree(y0)
   func = ravel_first_arg(func, unravel)

--- a/jax/image/scale.py
+++ b/jax/image/scale.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
 import enum
 import math
 from typing import Callable, Sequence, Tuple, Union
@@ -157,7 +156,7 @@ _kernels[ResizeMethod.LANCZOS5] = _lanczos_kernel(5.)
 _kernels[ResizeMethod.CUBIC] = _keys_cubic_kernel()
 
 
-@partial(jit, static_argnums=(1, 2, 3, 4))
+@jit(static_argnums=(1, 2, 3, 4))
 def _resize(image, shape: Sequence[int], method: Union[str, ResizeMethod],
             antialias: bool, precision):
   if len(shape) != image.ndim:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1695,19 +1695,19 @@ def _upcast_fp16_for_computation(f):
 
   return f_wrapped
 
-@api.jit
+@api.jit  # type: ignore
 @_upcast_fp16_for_computation
 def tan(x: Array) -> Array:
   r"""Elementwise tangent: :math:`\mathrm{tan}(x)`."""
   return div(sin(x), cos(x))
 
-@api.jit
+@api.jit  # type: ignore
 def asin(x: Array) -> Array:
   r"""Elementwise arc sine: :math:`\mathrm{asin}(x)`."""
   return mul(_const(x, 2),
              atan2(x, add(_const(x, 1), sqrt(sub(_const(x, 1), square(x))))))
 
-@api.jit
+@api.jit  # type: ignore
 def acos(x: Array) -> Array:
   r"""Elementwise arc cosine: :math:`\mathrm{acos}(x)`."""
   return select(

--- a/jax/lax/lax_fft.py
+++ b/jax/lax/lax_fft.py
@@ -92,7 +92,7 @@ def _naive_rfft(x, fft_lengths):
   n = fft_lengths[-1]
   return y[..., : n//2 + 1]
 
-@partial(jit, static_argnums=1)
+@jit(static_argnums=1)
 def _rfft_transpose(t, fft_lengths):
   # The transpose of RFFT can't be expressed only in terms of irfft. Instead of
   # manually building up larger twiddle matrices (which would increase the

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1008,7 +1008,7 @@ def ediff1d(ary, to_end=None, to_begin=None):
   return result
 
 
-@partial(jit, static_argnums=2)
+@jit(static_argnums=2)
 def _gradient(a, varargs, axis):
   def gradient_along_axis(a, h, axis):
     sliced = partial(lax.slice_in_dim, a, axis=axis)
@@ -1859,7 +1859,7 @@ def _make_cumulative_reduction(np_reduction, reduction, fill_nan=False, fill_val
   # avoid materializing the padded output.
   # Consider removing `jit` once again if reduce-window is generalized to
   # support arbitrary padding.
-  @partial(jit, static_argnums=(1, 2))
+  @jit(static_argnums=(1,2))
   def _cumulative_reduction(a, axis, dtype):
     if axis is None or isscalar(a):
       a = ravel(a)
@@ -2010,7 +2010,7 @@ def _pad_edge(array, pad_width):
   return array
 
 
-@partial(jit, static_argnums=(1, 2))
+@jit(static_argnums=(1,2))
 def _pad(array, pad_width, mode, constant_values):
   array = asarray(array)
   nd = ndim(array)
@@ -2899,7 +2899,7 @@ def einsum_path(subscripts, *operands, **kwargs):
 def _removechars(s, chars):
   return s.translate(str.maketrans(dict.fromkeys(chars)))
 
-@partial(jit, static_argnums=(1, 2))
+@jit(static_argnums=(1,2))
 def _einsum(operands: Sequence,
             contractions: Sequence[Tuple[Tuple[int, ...], Set[str], str]],
             precision):
@@ -3061,7 +3061,7 @@ def outer(a, b, out=None):
   a, b = _promote_dtypes(a, b)
   return ravel(a)[:, None] * ravel(b)
 
-@partial(jit, static_argnums=(2, 3, 4))
+@jit(static_argnums=(2, 3, 4))
 def _cross(a, b, axisa, axisb, axisc):
   a = moveaxis(a, axisa, -1)
   b = moveaxis(b, axisb, -1)
@@ -3208,7 +3208,7 @@ def msort(a):
   return sort(a, axis=0)
 
 
-@partial(jit, static_argnums=(2,))
+@jit(static_argnums=(2,))
 def _roll(a, shift, axis):
   a = asarray(a)
   a_shape = shape(a)
@@ -3341,7 +3341,7 @@ def _normalize_index(index, axis_size):
     lax.add(index, _constant_like(index, axis_size)),
     index)
 
-@partial(jit, static_argnums=(2,))
+@jit(static_argnums=(2,))
 def _take_along_axis(arr, indices, axis):
   if axis is None:
     if ndim(indices) != 1:
@@ -3415,7 +3415,7 @@ def take_along_axis(arr, indices, axis):
 
 ### SetOps
 
-@partial(jit, static_argnums=1)
+@jit(static_argnums=1)
 def _unique1d_sorted_mask(ar, optional_indices=False):
   """
   Helper function for unique which is jit-able
@@ -3494,7 +3494,7 @@ def _rewriting_take(arr, idx):
 
 # TODO(phawkins): re-enable jit after fixing excessive recompilation for
 # slice indexes (e.g., slice(0, 5, None), slice(10, 15, None), etc.).
-# @partial(jit, static_argnums=(1, 2))
+# @jit(static_argnums=(1, 2))
 def _gather(arr, treedef, static_idx, dynamic_idx):
   idx = _merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx)
   indexer = _index_to_gather(shape(arr), idx)  # shared with _scatter_update
@@ -4051,7 +4051,7 @@ def nanquantile(a, q, axis=None, out=None, overwrite_input=False,
   return _quantile(a, q, axis, interpolation, keepdims, True)
 
 
-@partial(jit, static_argnums=(2, 3, 4, 5))
+@jit(static_argnums=(2, 3, 4, 5))
 def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
   if interpolation not in ["linear", "lower", "higher", "midpoint", "nearest"]:
     raise ValueError("interpolation can only be 'linear', 'lower', 'higher', "
@@ -4150,7 +4150,7 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
   return lax.convert_element_type(result, a.dtype)
 
 
-@partial(jit, static_argnums=2)
+@jit(static_argnums=2)
 @partial(vectorize, excluded={0, 2})
 def _searchsorted(a, v, side):
   op = operator.le if side == 'left' else operator.lt
@@ -4410,7 +4410,7 @@ def _compress_method(a, condition, axis=None, out=None):
 setattr(ShapedArray, "compress", _compress_method)
 setattr(DeviceArray, "compress", _compress_method)
 
-@partial(jit, static_argnums=(1,2,3))
+@jit(static_argnums=(1, 2, 3))
 def _multi_slice(arr: DeviceArray,
                  start_indices: Tuple[Tuple[int, ...]],
                  limit_indices: Tuple[Tuple[int, ...]],

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -338,7 +338,7 @@ def inv(a):
     a, lax.broadcast(jnp.eye(a.shape[-1], dtype=lax.dtype(a)), a.shape[:-2]))
 
 
-@partial(jit, static_argnums=(1, 2, 3))
+@jit(static_argnums=(1, 2, 3))
 def _norm(x, ord, axis: Union[None, Tuple[int, ...], int], keepdims):
   x = _promote_arg_dtypes(jnp.asarray(x))
   x_shape = jnp.shape(x)

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -28,7 +28,7 @@ from ..numpy import linalg as np_linalg
 
 _T = lambda x: jnp.swapaxes(x, -1, -2)
 
-@partial(jit, static_argnums=(1,))
+@jit(static_argnums=(1,))
 def _cholesky(a, lower):
   a = np_linalg._promote_arg_dtypes(jnp.asarray(a))
   l = lax_linalg.cholesky(a if lower else jnp.conj(_T(a)), symmetrize_input=False)
@@ -43,7 +43,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
   return (cholesky(a, lower=lower), lower)
 
-@partial(jit, static_argnums=(2,))
+@jit(static_argnums=(2,))
 def _cho_solve(c, b, lower):
   c, b = np_linalg._promote_arg_dtypes(jnp.asarray(c), jnp.asarray(b))
   np_linalg._check_solve_shapes(c, b)
@@ -115,7 +115,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
   return lax_linalg.lu_solve(lu, pivots, b, trans)
 
 
-@partial(jit, static_argnums=(1,))
+@jit(static_argnums=(1,))
 def _lu(a, permute_l):
   a = np_linalg._promote_arg_dtypes(jnp.asarray(a))
   lu, pivots = lax_linalg.lu(a)
@@ -136,7 +136,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True):
   del overwrite_a, check_finite
   return _lu(a, permute_l)
 
-@partial(jit, static_argnums=(1, 2))
+@jit(static_argnums=(1, 2))
 def _qr(a, mode, pivoting):
   if pivoting:
     raise NotImplementedError(
@@ -160,7 +160,7 @@ def qr(a, overwrite_a=False, lwork=None, mode="full", pivoting=False,
   return _qr(a, mode, pivoting)
 
 
-@partial(jit, static_argnums=(2, 3))
+@jit(static_argnums=(2, 3))
 def _solve(a, b, sym_pos, lower):
   if not sym_pos:
     return np_linalg.solve(a, b)
@@ -190,7 +190,7 @@ def solve(a, b, sym_pos=False, lower=False, overwrite_a=False, overwrite_b=False
   del overwrite_a, overwrite_b, debug, check_finite
   return _solve(a, b, sym_pos, lower)
 
-@partial(jit, static_argnums=(2, 3, 4))
+@jit(static_argnums=(2, 3, 4))
 def _solve_triangular(a, b, trans, lower, unit_diagonal):
   if trans == 0 or trans == "N":
     transpose_a, conjugate_a = False, False

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,5 +10,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-scipy.*]
 ignore_missing_imports = True
+[mypy-toolz.*]
+ignore_missing_imports = True
 [mypy-jax.interpreters.autospmd]
 ignore_errors = True

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages(exclude=["examples"]),
     python_requires='>=3.6',
     install_requires=[
-        'numpy >=1.12', 'absl-py', 'opt_einsum'
+        'numpy >=1.12', 'absl-py', 'opt_einsum', 'toolz'
     ],
     url='https://github.com/google/jax',
     license='Apache-2.0',

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -43,7 +43,30 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
+
 class APITest(jtu.JaxTestCase):
+
+  def test_jit_curry_no_kwargs(self):
+    @jit
+    def f(x, y):
+      return x + y
+
+    @jit()
+    def g(x, y):
+      return x + y
+
+    assert f(1., 2.) == g(1., 2.)
+
+  def test_jit_curry_with_kwargs(self):
+    @partial(jit, static_argnums=(1,))
+    def f(x, y):
+      return x + y
+
+    @jit(static_argnums=(1,))
+    def g(x, y):
+      return x + y
+
+    assert f(1., 2.) == g(1., 2.)
 
   def test_grad_argnums(self):
     def f(x, y, z, flag=False):


### PR DESCRIPTION
Allows use as decorators with kwargs, e.g.:

`@jax.jit(static_argnums=(1,))
`
as opposed to the current, less pythonic:

`@functools.partial(jax.jit, static_argnums=(1,))
`
Also updates all internal usages.