### PR TITLE
Fix compilation bug in histogram_bin_edges

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -825,6 +825,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
   if range is None:
     range = (a.min(), a.max())
   assert len(range) == 2
+  range = asarray(range)
   range = (where(ptp(range) == 0, range[0] - 0.5, range[0]),
            where(ptp(range) == 0, range[1] + 0.5, range[1]))
   dtype = _dtype(a)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -823,10 +823,10 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
   if b.ndim == 1:
     return b
   if range is None:
-    range = (where(a.ptp() == 0, a.min() - 0.5, a.min()),
-             where(a.ptp() == 0, a.max() + 0.5, a.max()))
-  elif range[0] == range[1]:
-    range = (range[0] - 0.5, range[1] + 0.5)
+    range = (a.min(), a.max())
+  assert len(range) == 2
+  range = (where(ptp(range) == 0, range[0] - 0.5, range[0]),
+           where(ptp(range) == 0, range[1] + 0.5, range[1]))
   dtype = _dtype(a)
   if issubdtype(dtype, integer):
     dtype = promote_types(dtype, float32)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -823,9 +823,10 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
   if b.ndim == 1:
     return b
   if range is None:
-    range = a.min(), a.max()
-  if not isinstance(a, core.Tracer) and range[0] == range[1]:
-    range = range[0] - 0.5, range[0] + 0.5
+    range = (where(a.ptp() == 0, a.min() - 0.5, a.min()),
+             where(a.ptp() == 0, a.max() + 0.5, a.max()))
+  elif range[0] == range[1]:
+    range = (range[0] - 0.5, range[1] + 0.5)
   dtype = _dtype(a)
   if issubdtype(dtype, integer):
     dtype = promote_types(dtype, float32)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2010,11 +2010,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testHistogramBinEdges(self, shape, dtype, bins, range, weights):
     rng = jtu.rand_default(self.rng())
     _weights = lambda w: abs(w) if weights else None
-    np_fun = lambda a, w: np.histogram_bin_edges(a, bins=bins, range=range,
-                                                   weights=_weights(w))
-    jnp_fun = lambda a, w: jnp.histogram_bin_edges(a, bins=bins, range=range,
-                                                   weights=_weights(w))
-    args_maker = lambda: [rng(shape, dtype), rng(shape, dtype)]
+    np_fun = lambda a, w, r: np.histogram_bin_edges(a, bins=bins, range=r,
+                                                    weights=_weights(w))
+    jnp_fun = lambda a, w, r: jnp.histogram_bin_edges(a, bins=bins, range=r,
+                                                      weights=_weights(w))
+    args_maker = lambda: [rng(shape, dtype), rng(shape, dtype), range]
     tol = {jnp.bfloat16: 2E-2, np.float16: 1E-2}
     # linspace() compares poorly to numpy when using bfloat16
     if dtype != jnp.bfloat16:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2004,7 +2004,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for shape in [(5,), (5, 5)]
     for dtype in number_dtypes
     for bins in [10, np.arange(-5, 6), [-5, 0, 3]]
-    for range in [None, (0, 10)]
+    for range in [None, (0, 0), (0, 10)]
     for weights in [True, False]
   ))
   def testHistogramBinEdges(self, shape, dtype, bins, range, weights):


### PR DESCRIPTION
Previously the logic was incorrect with a range of span zero when jit compiled.