### PR TITLE
Update scipy.ndimage.map_coordinates docstring

### DIFF
--- a/jax/scipy/ndimage.py
+++ b/jax/scipy/ndimage.py
@@ -111,10 +111,10 @@ def _map_coordinates(input, coordinates, order, mode, cval):
 
 
 @_wraps(scipy.ndimage.map_coordinates, lax_description=textwrap.dedent("""\
-    Only linear interpolation (``order=1``) and modes ``'constant'``,
-    ``'nearest'`` and ``'wrap'`` are currently supported. Note that
-    interpolation near boundaries differs from the scipy function, because we
-    fixed an outstanding bug (https://github.com/scipy/scipy/issues/2640);
+    Only nearest neighbor (``order=0``), linear interpolation (``order=1``) and
+    modes ``'constant'``, ``'nearest'`` and ``'wrap'`` are currently supported.
+    Note that interpolation near boundaries differs from the scipy function,
+    because we fixed an outstanding bug (https://github.com/scipy/scipy/issues/2640);
     this function interprets the ``mode`` argument as documented by SciPy, but
     not as implemented by SciPy.
     """))

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -114,7 +114,7 @@ class NdimageTest(jtu.JaxTestCase):
       lsp_ndimage.map_coordinates(x, [c, c], order=1)
 
   def testMapCoordinateDocstring(self):
-    self.assertIn("Only linear interpolation",
+    self.assertIn("Only nearest neighbor",
                   lsp_ndimage.map_coordinates.__doc__)
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
This PR updates the documentation of `scipy.ndimage.map_coordinates`, including details of nearest neighbor (`order=0`) interpolation as a possible input argument.