### PR TITLE
[jax2tf] Fix error in sorting with TF graphs.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1104,9 +1104,9 @@ def _sort(*operand: TfVal, dimension: int, is_stable: bool, num_keys: int) -> Tu
     raise NotImplementedError("TODO: implement stable version of XlaSort")
   if dimension == len(operand[0].shape) - 1:
     if len(operand) == 2:
-      return tfxla.key_value_sort(operand[0], operand[1])
+      return tuple(tfxla.key_value_sort(operand[0], operand[1]))
     else:
-      return tfxla.sort(operand)
+      return (tfxla.sort(operand[0]),)
   else:
     raise NotImplementedError("TODO: implement XlaSort for all axes")
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -131,9 +131,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         not harness.params["is_stable"]):
       # TODO: fix the TF GPU test
       raise unittest.SkipTest("GPU tests are running TF on CPU")
-    # TODO: if we enable this test, we get the error
-    #  iterating over `tf.Tensor` is not allowed: AutoGraph is disabled in this function.
-    raise unittest.SkipTest("TODO: re-enable the sort test")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)


### PR DESCRIPTION
Because we are only sorting along the last dimension for now, the results of sorting for a Tensor of shape s were output as a Tensor of shape 1:s, which was then somehow interpreted as a tuple of Tensors of shape s, thus satisfying the "multiple_results" requirement.