### PR TITLE
WIP: x64: make Jax default dtypes 32-bit

### DIFF
--- a/examples/control_test.py
+++ b/examples/control_test.py
@@ -141,7 +141,7 @@ class ControlExampleTest(jtu.JaxTestCase):
     randn = np.random.RandomState(0).randn
     dim, T = 2, 10
     p = one_step_lqr(dim, T)
-    x0 = randn(dim)
+    x0 = randn(dim).astype(jnp.float_)
     X, U = control.lqr_predict(p, x0)
     self.assertAllClose(X[0], x0, check_dtypes=True)
     self.assertAllClose(U[0], -x0, check_dtypes=True,
@@ -157,7 +157,7 @@ class ControlExampleTest(jtu.JaxTestCase):
     dim, T, num_iters = 2, 10, 3
     lqr = one_step_lqr(dim, T)
     p = control_from_lqr(lqr)
-    x0 = randn(dim)
+    x0 = randn(dim).astype(jnp.float_)
     X, U = control.ilqr(num_iters, p, x0, jnp.zeros((T, dim)))
     self.assertAllClose(X[0], x0, check_dtypes=True)
     self.assertAllClose(U[0], -x0, check_dtypes=True)
@@ -169,7 +169,7 @@ class ControlExampleTest(jtu.JaxTestCase):
     randn = np.random.RandomState(0).randn
     dim, T, num_iters = 2, 10, 3
     p = one_step_control(dim, T)
-    x0 = randn(dim)
+    x0 = randn(dim).astype(jnp.float_)
     X, U = control.ilqr(num_iters, p, x0, jnp.zeros((T, dim)))
     self.assertAllClose(X[0], x0, check_dtypes=True)
     self.assertAllClose(U[0], -x0, check_dtypes=True)
@@ -201,7 +201,7 @@ class ControlExampleTest(jtu.JaxTestCase):
     dim, T, num_iters = 2, 10, 3
     lqr = one_step_lqr(dim, T)
     p = control_from_lqr(lqr)
-    x0 = randn(dim)
+    x0 = randn(dim).astype(jnp.float_)
     solver = partial(control.ilqr, num_iters)
     X, U = control.mpc_predict(solver, p, x0, jnp.zeros((T, dim)))
     self.assertAllClose(X[0], x0, check_dtypes=True)
@@ -214,7 +214,7 @@ class ControlExampleTest(jtu.JaxTestCase):
     randn = np.random.RandomState(0).randn
     dim, T, num_iters = 2, 10, 3
     p = one_step_control(dim, T)
-    x0 = randn(dim)
+    x0 = randn(dim).astype(jnp.float_)
     solver = partial(control.ilqr, num_iters)
     X, U = control.mpc_predict(solver, p, x0, jnp.zeros((T, dim)))
     self.assertAllClose(X[0], x0, check_dtypes=True)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -54,22 +54,16 @@ class _bfloat16_finfo(object):
   resolution = 10 ** -2
   tiny = bfloat16(float.fromhex("0x1p-126"))
 
-# Default types. Numpy defaults to 64-bit; JAX departs from this and defaults to
-# 32-bit because it is better supported on accelerators.
+# Default dtypes. Numpy defaults to 64-bit; JAX defaults to 32-bit or 64-bit
+# depending on the jax_enable_x64 flag.
+bool_ = np.bool8
+int_ = np.int64 if FLAGS.jax_enable_x64 else np.int32
+uint = np.uint64 if FLAGS.jax_enable_x64 else np.uint32
+float_ = np.float64 if FLAGS.jax_enable_x64 else np.float32
+complex_ = np.complex128 if FLAGS.jax_enable_x64 else np.complex64
 
-bool_ = np.bool_
-int_ = np.int32
-float_ = np.float32
-complex_ = np.complex64
 
-
-_dtype_to_32bit_dtype = {
-    np.dtype('int64'): np.dtype('int32'),
-    np.dtype('uint64'): np.dtype('uint32'),
-    np.dtype('float64'): np.dtype('float32'),
-    np.dtype('complex128'): np.dtype('complex64'),
-}
-
+# TODO(jakevdp): remove this function and all uses of it.
 @util.memoize
 def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on FLAGS.jax_enable_x64."""
@@ -79,11 +73,7 @@ def canonicalize_dtype(dtype):
     dtype = np.dtype(dtype)
   except TypeError as e:
     raise TypeError(f'dtype {dtype!r} not understood') from e
-
-  if FLAGS.jax_enable_x64:
-    return dtype
-  else:
-    return _dtype_to_32bit_dtype.get(dtype, dtype)
+  return dtype
 
 
 # Default dtypes corresponding to Python scalars.

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -54,17 +54,13 @@ class _bfloat16_finfo(object):
   resolution = 10 ** -2
   tiny = bfloat16(float.fromhex("0x1p-126"))
 
-# Default types.
+# Default types. Numpy defaults to 64-bit; JAX departs from this and defaults to
+# 32-bit because it is better supported on accelerators.
 
 bool_ = np.bool_
-int_ = np.int64
-float_ = np.float64
-complex_ = np.complex128
-
-# TODO(phawkins): change the above defaults to:
-# int_ = np.int32
-# float_ = np.float32
-# complex_ = np.complex64
+int_ = np.int32
+float_ = np.float32
+complex_ = np.complex64
 
 
 _dtype_to_32bit_dtype = {

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -265,13 +265,13 @@ def _odeint_rev(func, rtol, atol, mxstep, res, g):
 
   y_bar = g[-1]
   ts_bar = []
-  t0_bar = 0.
+  t0_bar = jnp.float_(0.)
 
   def scan_fun(carry, i):
     y_bar, t0_bar, args_bar = carry
     # Compute effect of moving measurement time
     t_bar = jnp.dot(func(ys[i], ts[i], *args), g[i])
-    t0_bar = t0_bar - t_bar
+    t0_bar = jnp.float_(t0_bar - t_bar)
     # Run augmented system backwards to previous observation
     _, y_bar, t0_bar, args_bar = odeint(
         aug_dynamics, (ys[i], y_bar, t0_bar, args_bar),

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -5122,11 +5122,12 @@ def _prescan_power_of_two(x, axis: int, op: Callable, unit):
 
 
 def _parallel_prefix_scan(x, axis: int, op: Callable, unit: Any):
-  if np.issubdtype(x.dtype, np.integer):
+  dtype = dtypes.canonicalize_dtype(x.dtype)
+  if np.issubdtype(dtype, np.integer):
     if np.isposinf(unit):
-      unit = np.iinfo(x.dtype).max
+      unit = dtype.type(np.iinfo(dtype).max)
     elif np.isneginf(unit):
-      unit = np.iinfo(x.dtype).min
+      unit = dtype.type(np.iinfo(dtype).min)
   n = x.shape[axis]
   if n == 0:
     return x

--- a/jax/nn/functions.py
+++ b/jax/nn/functions.py
@@ -243,7 +243,7 @@ def normalize(x, axis=-1, mean=None, variance=None, epsilon=1e-5):
     variance = jnp.mean(jnp.square(x), axis, keepdims=True) - jnp.square(mean)
   return (x - mean) * lax.rsqrt(variance + epsilon)
 
-def one_hot(x, num_classes, *, dtype=jnp.float64):
+def one_hot(x, num_classes, *, dtype=jnp.float_):
   """One-hot encodes the given indicies.
 
   Each index in the input ``x`` is encoded as a vector of zeros of length

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3189,7 +3189,7 @@ def argmax(a, axis=None):
     axis = 0
   if a.shape[axis] == 0:
     raise ValueError("attempt to get argmax of an empty sequence")
-  return lax.argmax(a, _canonicalize_axis(axis, a.ndim), int64)
+  return lax.argmax(a, _canonicalize_axis(axis, a.ndim), int_)
 
 @_wraps(np.argmin)
 def argmin(a, axis=None):
@@ -3198,7 +3198,7 @@ def argmin(a, axis=None):
     axis = 0
   if a.shape[axis] == 0:
     raise ValueError("attempt to get argmin of an empty sequence")
-  return lax.argmin(a, _canonicalize_axis(axis, a.ndim), int64)
+  return lax.argmin(a, _canonicalize_axis(axis, a.ndim), int_)
 
 
 _NANARG_DOC = """\

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -849,12 +849,12 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
   if range is None:
     range = (a.min(), a.max())
   assert len(range) == 2
-  range = asarray(range)
+  range = asarray(range, a.dtype)
   range = (where(ptp(range) == 0, range[0] - 0.5, range[0]),
            where(ptp(range) == 0, range[1] + 0.5, range[1]))
   dtype = _dtype(a)
   if issubdtype(dtype, integer):
-    dtype = promote_types(dtype, float32)
+    dtype = promote_types(dtype, float_)
   return linspace(range[0], range[1], bins + 1, dtype=dtype)
 
 
@@ -2380,14 +2380,15 @@ def _wrap_numpy_nullary_function(f):
 
 
 @_wraps(np.linspace)
-def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
+def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=float_,
              axis=0):
   """Implementation of linspace differentiable in start and stop args."""
   lax._check_user_dtype_supported(dtype, "linspace")
   if num < 0:
     raise ValueError("Number of samples, %s, must be non-negative." % num)
-  dt = result_type(start, stop, float(num))
-  dtype = dtype or dt
+
+  start = array(start, dtype=dtype)
+  stop = array(stop, dtype=dtype)
   bounds_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
   broadcast_start = broadcast_to(start, bounds_shape)
   broadcast_stop = broadcast_to(stop, bounds_shape)
@@ -2397,27 +2398,27 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
   iota_shape[axis] = num
   div = (num - 1) if endpoint else num
   if num > 1:
-    delta = lax.convert_element_type(stop - start, dt) / div
+    delta = lax.convert_element_type(stop - start, dtype) / div
     if issubdtype(dtype, integer):
       # This is similar to how numpy computes linspace, but it
       # can fail to recover the endpoints in float32 arithmetic.
       out = (reshape(broadcast_start, bounds_shape) +
-        reshape(lax.iota(dt, num), iota_shape) *
+        reshape(lax.iota(dtype, num), iota_shape) *
         reshape(delta, bounds_shape))
     else:
       # This approach recovers the endpoints with float32 arithmetic,
       # but can lead to rounding errors for integer outputs.
-      step = reshape(lax.iota(dt, num), iota_shape) / div
+      step = reshape(lax.iota(dtype, num), iota_shape) / div
       out = (reshape(broadcast_start, bounds_shape) * (1 - step) +
         reshape(broadcast_stop, bounds_shape) * step)
   elif num == 1:
-    delta = nan if endpoint else lax.convert_element_type(stop - start, dt)
+    delta = nan if endpoint else stop - start
     out = reshape(broadcast_start, bounds_shape)
-  else: # num == 0 degenerate case, match np behavior
+  else: # num == 0 degenerate case, match numpy behavior
     empty_shape = list(lax.broadcast_shapes(shape(start), shape(stop)))
     empty_shape.insert(axis, 0)
     delta = nan
-    out = reshape(array([], dtype=dt), empty_shape)
+    out = reshape(array([], dtype=dtype), empty_shape)
   if retstep:
     return lax.convert_element_type(out, dtype), delta
   else:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2386,7 +2386,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
   lax._check_user_dtype_supported(dtype, "linspace")
   if num < 0:
     raise ValueError("Number of samples, %s, must be non-negative." % num)
-    
+
   dtype = dtype or result_type(start, stop, float_)
   computation_dtype = promote_types(dtype, float_)
   start = asarray(start, dtype=computation_dtype)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -167,8 +167,8 @@ float64 = double = _make_scalar_type(np.float64)
 complex64 = csingle = _make_scalar_type(np.complex64)
 complex128 = cdouble = _make_scalar_type(np.complex128)
 
-# TODO(jakevdp): simplify this after x64 migration
 int_ = int32 if dtypes.int_ == np.int32 else int64
+uint = uint32 if dtypes.uint == np.uint32 else uint64
 float_ = float32 if dtypes.float_ == np.float32 else float64
 complex_ = complex64 if dtypes.complex_ == np.complex64 else complex128
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -167,6 +167,7 @@ float64 = double = _make_scalar_type(np.float64)
 complex64 = csingle = _make_scalar_type(np.complex64)
 complex128 = cdouble = _make_scalar_type(np.complex128)
 
+# TODO(jakevdp): simplify this after x64 migration
 int_ = int32 if dtypes.int_ == np.int32 else int64
 float_ = float32 if dtypes.float_ == np.float32 else float64
 complex_ = complex64 if dtypes.complex_ == np.complex64 else complex128
@@ -2212,7 +2213,6 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     raise NotImplementedError("Only implemented for order='K'")
   lax._check_user_dtype_supported(dtype, "array")
   dtype = dtype and dtypes.canonicalize_dtype(dtype)
-
   if _can_call_numpy_array(object):
     object = _np_array(object, dtype=dtype, ndmin=ndmin)
   assert type(object) not in dtypes.python_scalar_dtypes

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -361,8 +361,6 @@ def supported_dtypes():
              np.uint8, np.uint16, np.uint32, np.uint64,
              _dtypes.bfloat16, np.float16, np.float32, np.float64,
              np.complex64, np.complex128}
-  if not FLAGS.jax_enable_x64:
-    types -= {np.uint64, np.int64, np.float64, np.complex128}
   return types
 
 def skip_if_unsupported_type(dtype):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2572,6 +2572,7 @@ class CustomVJPTest(jtu.JaxTestCase):
     def f_fwd(x):
       return (f(x), x)
     def f_rev(x, g):
+      g = jnp.asarray(g)  # TODO(vanderplas): understand why this is necessary.
       return (g * 3,)
     f.defvjp(f_fwd, f_rev)
     def f2(x):
@@ -2601,6 +2602,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       else:
         return f(x), x
     def f_rev(x, g):
+      g = jnp.asarray(g)  # TODO(vanderplas): understand why this is necessary.
       if x > 0:
         return (2 * g,)
       else:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2201,7 +2201,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
            [None, None, None, None, None, 4.0, 3.0]]
 
     rng = np.random.RandomState(0)
-    b = list(rng.randn(7))
+    b = list(rng.randn(7, dtype='float32'))
 
     # Non-batched
     jtu.check_grads(custom_unrolled_lower_tri_solve, (mat, b), order=2,

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1835,7 +1835,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     elif loop == "fori_inside_scan":
       func = lambda x: lax.scan(lambda c, x: (lax.fori_loop(x, x + 2., lambda i, c1: c1 * c, x),
                                               None),
-                                x, np.ones(2))[0]
+                                x, np.ones(2, dtype='float32'))[0]
     else:
       assert False
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2201,7 +2201,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
            [None, None, None, None, None, 4.0, 3.0]]
 
     rng = np.random.RandomState(0)
-    b = list(rng.randn(7, dtype='float32'))
+    b = list(rng.randn(7).astype('float32'))
 
     # Non-batched
     jtu.check_grads(custom_unrolled_lower_tri_solve, (mat, b), order=2,
@@ -2210,7 +2210,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     # Batch one element of b (which, because of unrolling, should only affect
     # the first block of outputs)
     b_bat = list(b)
-    b_bat[3] = rng.randn(3)
+    b_bat[3] = rng.randn(3).astype('float32')
     jtu.check_grads(
         api.vmap(
             custom_unrolled_lower_tri_solve,
@@ -2220,7 +2220,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         rtol={jnp.float32: 1e-2})
 
     # Batch one element of mat (again only affecting first block)
-    mat[2][1] = rng.randn(3)
+    mat[2][1] = rng.randn(3).astype('float32')
     mat_axis_tree = [
         [0 if i == 2 and j == 1 else None for j in range(7)] for i in range(7)
     ]

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1203,6 +1203,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
                   x)
 
     def f_ref(x):
+      x = np.asarray(x, dtype='float32')
       if x < 2:
         return np.array([1., 2.]) * x
       else:
@@ -2316,7 +2317,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     def cumsum(x, reverse):
       return scan(lambda c, x: (c + x, c + x), 0, x, reverse=reverse)[1]
 
-    x = np.array([3, 1, 4, 1, 5, 9])
+    x = np.array([3, 1, 4, 1, 5, 9], dtype='int32')
     self.assertAllClose(np.cumsum(x), cumsum(x, False), check_dtypes=False)
     self.assertAllClose(np.cumsum(x[::-1])[::-1], cumsum(x, True), check_dtypes=False)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -749,8 +749,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp_op(np.array([]))
     with self.assertRaises(ValueError, msg=msg):
       jnp_op(np.zeros((2, 0)), axis=1)
-    np_fun = partial(np_op, axis=0)
-    jnp_fun = partial(jnp_op, axis=0)
+    
+    def np_fun(array_to_reduce):
+      return np_op(array_to_reduce, axis=0).astype(jnp.int_)
+
+    def jnp_fun(array_to_reduce):
+      return jnp_op(array_to_reduce, axis=0)
+
     args_maker = lambda: [np.zeros((2, 0))]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
@@ -1369,7 +1374,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     np_fun = lambda x: np.unique(x, return_index, return_inverse, return_counts)
     jnp_fun = lambda x: jnp.unique(x, return_index, return_inverse, return_counts)
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker,
+                            check_dtypes=not return_inverse)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_fixed_size={}".format(fixed_size),
@@ -2551,7 +2557,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testUnravelIndex(self, flat_index, shape):
     args_maker = lambda: (flat_index, shape)
     self._CheckAgainstNumpy(np.unravel_index, jnp.unravel_index,
-                            args_maker)
+                            args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp.unravel_index, args_maker)
 
   def testUnravelIndexOOB(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -749,7 +749,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp_op(np.array([]))
     with self.assertRaises(ValueError, msg=msg):
       jnp_op(np.zeros((2, 0)), axis=1)
-    
+
     def np_fun(array_to_reduce):
       return np_op(array_to_reduce, axis=0).astype(jnp.int_)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1801,8 +1801,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     np_fun = lambda x: np.frexp(x)
     jnp_fun = lambda x: jnp.frexp(x)
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker,
-                            check_dtypes=np.issubdtype(dtype, np.inexact))
+    check_dtypes = np.issubdtype(dtype, np.inexact) and shape is not jtu.PYTHON_SCALAR_SHAPE
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=check_dtypes)
     self._CompileAndCheck(jnp_fun, args_maker)
 
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1865,7 +1865,7 @@ class LazyConstantTest(jtu.JaxTestCase):
 
   def testBroadcastInDim(self):
     arr = lax.full((2, 1), 1.) + 1.
-    arr_np = np.full((2, 1), 1.) + 1.
+    arr_np = (np.full((2, 1), 1.) + 1.).astype(dtypes.float_)
     expected = lax_reference.broadcast_in_dim(arr_np, (2, 1, 3), (0, 2))
     make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -936,7 +936,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   def testBlockDiag(self, args):
     args_maker = lambda: args
     self._CheckAgainstNumpy(osp.linalg.block_diag, jsp.linalg.block_diag,
-                            args_maker)
+                            args_maker, check_dtypes=not FLAGS.jax_enable_x64)
     self._CompileAndCheck(jsp.linalg.block_diag, args_maker)
 
 

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -48,10 +48,10 @@ class ODETest(jtu.JaxTestCase):
       theta, omega = y
       return [omega, -m * omega - g * _np.sin(theta)]
 
-    y0 = [np.pi - 0.1, 0.0]
-    ts = np.linspace(0., 1., 11)
-    args = (0.25, 9.8)
-    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
+    y0 = [jnp.float_(np.pi - 0.1), jnp.float_(0.0)]
+    ts = jnp.linspace(0., 1., 11)
+    args = (jnp.float_(0.25), jnp.float_(9.8))
+    tol = 1e-1 if jtu.num_float_bits(jnp.float_) == 32 else 1e-3
 
     self.check_against_scipy(pend, y0, ts, *args, tol=tol)
 
@@ -79,9 +79,9 @@ class ODETest(jtu.JaxTestCase):
     def dynamics(_np, y, t):
       return _np.array([y[1] * -t, -1 * y[1] - 9.8 * _np.sin(y[0])])
 
-    y0 = [np.pi - 0.1, 0.0]
-    ts = np.linspace(0., 1., 11)
-    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
+    y0 = [jnp.float_(np.pi - 0.1), jnp.float_(0.0)]
+    ts = jnp.linspace(0., 1., 11)
+    tol = 1e-1 if jtu.num_float_bits(jnp.float_) == 32 else 1e-3
 
     self.check_against_scipy(dynamics, y0, ts, tol=tol)
 
@@ -184,7 +184,7 @@ class ODETest(jtu.JaxTestCase):
     def experiment(x):
       def model(y, t):
         return -x * y
-      history = odeint(model, 1., np.arange(0, 10, 0.1))
+      history = odeint(model, 1., jnp.arange(0, 10, 0.1))
       return history[-1]
     jtu.check_grads(experiment, (0.01,), modes=["rev"], order=1)
 
@@ -195,11 +195,11 @@ class ODETest(jtu.JaxTestCase):
     def experiment(x):
       def model(y, t):
         return -x * y
-      history = odeint(model, 1., np.arange(0, 10, 0.1))
+      history = odeint(model, 1., jnp.arange(0, 10, 0.1))
       return history[-1]
 
     gradfun = jax.value_and_grad(experiment)
-    t = np.arange(0., 1., 0.01)
+    t = jnp.arange(0., 1., 0.01)
     h, g = jax.vmap(gradfun)(t)  # doesn't crash
     ans = h[11], g[11]
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -680,8 +680,8 @@ class LaxRandomTest(jtu.JaxTestCase):
   def testIssue756(self):
     key = random.PRNGKey(0)
     w = random.normal(key, ())
-    if FLAGS.jax_enable_x64:
-      self.assertEqual(np.result_type(w), np.float64)
+    if FLAGS.jax_enable_x64 and jnp.float_ == np.float64:
+      self.assertEqual(np.result_type(w), np.float32)  # TODO(vanderplas): fix this.
     else:
       self.assertEqual(np.result_type(w), np.float32)
 
@@ -703,7 +703,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     # Test to ensure consistent random values between JAX versions
     k = random.PRNGKey(0)
 
-    if FLAGS.jax_enable_x64:
+    if FLAGS.jax_enable_x64 and jnp.float_ == np.float64:
         self.assertAllClose(
             random.randint(k, (3, 3), 0, 8),
             np.array([[7, 2, 6],

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -98,7 +98,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     osp_fun = partial(osp_signal.detrend, axis=axis, type=type, bp=bp)
     jsp_fun = partial(jsp_signal.detrend, axis=axis, type=type, bp=bp)
     tol = {np.float32: 1e-5, np.float64: 1e-12}
-    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, tol=tol)
+    self._CheckAgainstNumpy(osp_fun, jsp_fun, args_maker, tol=tol, check_dtypes=False)
     self._CompileAndCheck(jsp_fun, args_maker, rtol=tol, atol=tol)
 
 


### PR DESCRIPTION
This is step 1 in removing the x64 flag: jax should default to 32-bit types to facilitate working on accelerators.