### PR TITLE
[jax2tf] First draft of testing the QR conversion.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -358,7 +358,7 @@ tf_not_yet_impl = [
 
   lax.linear_solve_p,
   lax_linalg.cholesky_p, lax_linalg.eig_p, lax_linalg.eigh_p,
-  lax_linalg.lu_p, lax_linalg.qr_p, lax_linalg.svd_p,
+  lax_linalg.lu_p, lax_linalg.svd_p,
   lax_linalg.triangular_solve_p,
 
   lax_fft.fft_p, lax.igamma_grad_a_p,
@@ -1129,6 +1129,11 @@ def _sort(*operand: TfVal, dimension: int, is_stable: bool, num_keys: int) -> Tu
     raise NotImplementedError("TODO: implement XlaSort for all axes")
 
 tf_impl[lax.sort_p] = _sort
+
+def _qr(operand, full_matrices):
+  return tf.linalg.qr(operand, full_matrices=full_matrices)
+
+tf_impl[lax_linalg.qr_p] = _qr
 
 def _custom_jvp_call_jaxpr(*args: TfValOrUnit,
                            fun_jaxpr: core.TypedJaxpr,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -24,6 +24,7 @@ from absl import testing
 from jax import config
 from jax import test_util as jtu
 from jax import lax
+from jax import lax_linalg
 from jax import numpy as jnp
 
 import numpy as np
@@ -358,6 +359,17 @@ lax_sort = tuple( # one array, random data, all axes, all dtypes
   for is_stable in [False, True]
 )
 
+lax_linalg_qr = tuple(
+  Harness(f"multi_array_shape={jtu.format_shape_dtype_string(shape, dtype)}_fullmatrices={full_matrices}",
+          lax_linalg.qr,
+          [RandArg(shape, dtype), StaticArg(full_matrices)],
+          shape=shape,
+          dtype=dtype,
+          full_matrices=full_matrices)
+  for dtype in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128] # See jax.lib.lapack.geqrf
+  for shape in [(1, 1), (3, 3), (3, 4), (2, 10, 5), (2, 200, 100)]
+  for full_matrices in [False, True]
+)
 
 lax_slice = tuple(
   Harness(f"_shape={shape}_start_indices={start_indices}_limit_indices={limit_indices}_strides={strides}",  # type: ignore

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -366,7 +366,7 @@ lax_linalg_qr = tuple(
           shape=shape,
           dtype=dtype,
           full_matrices=full_matrices)
-  for dtype in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128] # See jax.lib.lapack.geqrf
+  for dtype in jtu.dtypes.all
   for shape in [(1, 1), (3, 3), (3, 4), (2, 10, 5), (2, 200, 100)]
   for full_matrices in [False, True]
 )

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -133,6 +133,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       raise unittest.SkipTest("GPU tests are running TF on CPU")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_linalg_qr)
+  def test_qr(self, harness: primitive_harness.Harness):
+    # TODO: figure out why check_compiled=True breaks for complex types.
+    # TODO: figure out why we need to adjust atol and rtol.
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           check_compiled=False, atol=1e-5, rtol=1e-5)
+
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):
     dtype = harness.params["dtype"]

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -142,7 +142,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     elif harness.params["dtype"] in [jnp.float32, jnp.float64]:
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                              atol=1e-5, rtol=1e-5)
-    else: # TODO: figure out why check_compiled=True breaks for complex types.
+    else:
+      # TODO: see https://github.com/google/jax/pull/3775#issuecomment-659407824.
+      # - check_compiled=True breaks for complex types;
+      # - for now, the performance of the HLO QR implementation called when
+      #   compiling with TF is expected to have worse performance than the
+      #   custom calls made in JAX.
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                              expect_tf_exceptions=True, atol=1e-5, rtol=1e-5)
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -137,7 +137,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_qr(self, harness: primitive_harness.Harness):
     # See jax.lib.lapack.geqrf for the list of compatible types
     if not harness.params["dtype"] in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]:
-      with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
+      expected_error = ValueError if jtu.device_under_test() == "gpu" else NotImplementedError
+      with self.assertRaisesRegex(expected_error, "Unsupported dtype"):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
     elif harness.params["dtype"] in [jnp.float32, jnp.float64]:
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -135,10 +135,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_qr)
   def test_qr(self, harness: primitive_harness.Harness):
-    # TODO: figure out why check_compiled=True breaks for complex types.
-    # TODO: figure out why we need to adjust atol and rtol.
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           check_compiled=False, atol=1e-5, rtol=1e-5)
+    if not harness.params["dtype"] in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]:
+      with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
+        harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
+    else: # See jax.lib.lapack.geqrf for the list of compatible types
+      # TODO: figure out why check_compiled=True breaks for complex types.
+      self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                             check_compiled=False, atol=1e-5, rtol=1e-5)
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -135,13 +135,16 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_qr)
   def test_qr(self, harness: primitive_harness.Harness):
+    # See jax.lib.lapack.geqrf for the list of compatible types
     if not harness.params["dtype"] in [jnp.float32, jnp.float64, jnp.complex64, jnp.complex128]:
       with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
-    else: # See jax.lib.lapack.geqrf for the list of compatible types
-      # TODO: figure out why check_compiled=True breaks for complex types.
+    elif harness.params["dtype"] in [jnp.float32, jnp.float64]:
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                             check_compiled=False, atol=1e-5, rtol=1e-5)
+                             atol=1e-5, rtol=1e-5)
+    else: # TODO: figure out why check_compiled=True breaks for complex types.
+      self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                             expect_tf_exceptions=True, atol=1e-5, rtol=1e-5)
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):


### PR DESCRIPTION
QR decomposition is off by over 1e-6 in some instances, requiring custom
atol and rtol values in testing code. There is an odd problem in which
experimental compilation fails for complex types, although they are in
principle supported.