### PR TITLE
Relax dimension ordering rules for dot_general.

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -682,16 +682,16 @@ def check_raises_regexp(thunk, err_type, pattern):
     assert re.match(pattern, str(e)), "{}\n\n{}\n".format(e, pattern)
 
 
-def _iter_eqns(jaxpr):
+def iter_eqns(jaxpr):
   # TODO(necula): why doesn't this search in params?
   for eqn in jaxpr.eqns:
     yield eqn
   for subjaxpr in core.subjaxprs(jaxpr):
-    yield from _iter_eqns(subjaxpr)
+    yield from iter_eqns(subjaxpr)
 
 def assert_dot_precision(expected_precision, fun, *args):
   jaxpr = api.make_jaxpr(fun)(*args)
-  precisions = [eqn.params['precision'] for eqn in _iter_eqns(jaxpr.jaxpr)
+  precisions = [eqn.params['precision'] for eqn in iter_eqns(jaxpr.jaxpr)
                 if eqn.primitive == lax.dot_general_p]
   for precision in precisions:
     msg = "Unexpected precision: {} != {}".format(expected_precision, precision)

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -295,6 +295,7 @@ class BatchingTest(jtu.JaxTestCase):
     f = vmap(partial(jnp.einsum, 'ij,j->i'), (None, 0))
     jaxpr = make_jaxpr(f)(jnp.zeros((1000, 1000)), jnp.zeros((1000, 1000)))
     assert "broadcast" not in str(jaxpr)
+    assert "transpose" not in str(jaxpr)
 
   def testPad(self):
     R = np.random.RandomState(0).randn

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -291,12 +291,6 @@ class BatchingTest(jtu.JaxTestCase):
     expected = np.einsum('ij,i->j', xs, ys)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def testDot5(self):
-    f = vmap(partial(jnp.einsum, 'ij,j->i'), (None, 0))
-    jaxpr = make_jaxpr(f)(jnp.zeros((1000, 1000)), jnp.zeros((1000, 1000)))
-    assert "broadcast" not in str(jaxpr)
-    assert "transpose" not in str(jaxpr)
-
   def testPad(self):
     R = np.random.RandomState(0).randn
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -416,6 +416,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           ((3, 5), (2, 5), (([1], [1]), ([], []))),
           ((5, 3), (5, 2), (([0], [0]), ([], []))),
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
+          ((3, 5, 2), (2, 4, 5), (([2], [0]), ([1], [2]))),
+          ((7, 3, 5, 2), (2, 2, 4, 5), (([3], [0]), ([2], [3]))),
       ]
       for dtype in float_dtypes))
   def testDotGeneralContractAndBatchGrads(self, lhs_shape, rhs_shape, dtype,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -743,10 +743,14 @@ class LaxTest(jtu.JaxTestCase):
        "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
        "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, lhs_contracting, rhs_contracting in [
+          [(5,), (5,), [0], [0]],
+          [(5, 7), (5,), [0], [0]],
+          [(7, 5), (5,), [1], [0]],
           [(3, 5), (2, 5), [1], [1]],
           [(5, 3), (5, 2), [0], [0]],
           [(5, 3, 2), (5, 2, 4), [0], [0]],
           [(5, 3, 2), (5, 2, 4), [0,2], [0,1]],
+          [(5, 3, 2), (3, 5, 2, 4), [0,2], [1,2]],
           [(1, 2, 2, 3), (1, 2, 3, 1), [1], [1]],
           [(3, 2), (2, 4), [1], [0]],
       ]
@@ -773,6 +777,7 @@ class LaxTest(jtu.JaxTestCase):
        "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
+          ((3, 3, 2), (2, 3, 4), (([2], [0]), ([0], [1]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for dtype in all_dtypes
@@ -797,6 +802,7 @@ class LaxTest(jtu.JaxTestCase):
        "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
+          ((3, 3, 2), (2, 3, 4), (([2], [0]), ([0], [1]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for dtype in all_dtypes

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -238,10 +238,14 @@ class LaxVmapTest(jtu.JaxTestCase):
        "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
        "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, lhs_contracting, rhs_contracting in [
+          [(5,), (5,), [0], [0]],
+          [(5, 7), (5,), [0], [0]],
+          [(7, 5), (5,), [1], [0]],
           [(3, 5), (2, 5), [1], [1]],
           [(5, 3), (5, 2), [0], [0]],
           [(5, 3, 2), (5, 2, 4), [0], [0]],
           [(5, 3, 2), (5, 2, 4), [0,2], [0,1]],
+          [(5, 3, 2), (3, 5, 2, 4), [0,2], [1,2]],
           [(1, 2, 2, 3), (1, 2, 3, 1), [1], [1]],
           [(3, 2), (2, 4), [1], [0]],
       ]
@@ -266,6 +270,7 @@ class LaxVmapTest(jtu.JaxTestCase):
        "dimension_numbers": dimension_numbers, "bdims": bdims, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
+          ((3, 3, 2), (2, 3, 4), (([2], [0]), ([0], [1]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
       for bdims in all_bdims(lhs_shape, rhs_shape)

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -283,6 +283,12 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(dot, 5, bdims, (lhs_shape, rhs_shape), (dtype, dtype),
                         rng)
 
+    # Checks that batching didn't introduce any transposes or broadcasts.
+    jaxpr = api.make_jaxpr(dot)(np.zeros(lhs_shape, dtype),
+                                np.zeros(rhs_shape, dtype))
+    for eqn in jtu.iter_eqns(jaxpr.jaxpr):
+      self.assertFalse(eqn.primitive in ["transpose", "broadcast"])
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}_bdims={}".format(
           shape, np.dtype(dtype).name, broadcast_sizes, bdims),


### PR DESCRIPTION
JAX currently requires that batch dimensions appear first and contiguously in the arguments to dot_general. However, XLA does not require this; relax JAX's checks so that it also allows batch dimensions in arbitrary positions.

Since batch dimensions are now allowed in arbitrary positions, it's not hard to
generalize the dot_general batching rule to avoid performing any transposes. Fixes #2972 .

In passing, also move the bool/int dot expansion into the XLA translation rule. The expansion inside the `lax.dot_general()` wrapper predated the existence of (or at least my knowledge of) `xla.lower_fun()`.