### PR TITLE
BDF solver for stiff ODEs

### DIFF
--- a/jax/experimental/bdf/__init__.py
+++ b/jax/experimental/bdf/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa: F401
+from .bdf import bdf_solve

--- a/jax/experimental/bdf/bdf.py
+++ b/jax/experimental/bdf/bdf.py
@@ -369,7 +369,7 @@ def bdf_solve(ode_fn,
 class Results(
     collections.namedtuple(
         "Results",
-        ["times", "states", "diagnostics", "solver_internal_state"])):  #
+        ["times", "states", "diagnostics", "solver_internal_state"])):
   """
     namedtuple class to store results from ode solver
     """

--- a/jax/experimental/bdf/bdf.py
+++ b/jax/experimental/bdf/bdf.py
@@ -1,0 +1,476 @@
+import collections
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+from . import bdf_util
+
+#Adapted from tensorflow_probabilty
+#https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/math/ode/bdf.py
+#Accessed 2020-06-26
+
+
+def _get_coefficients(bdf_coefficients):
+  newton_coefficients = 1. / (
+      (1. - bdf_coefficients) * bdf_util.RECIPROCAL_SUMS)
+
+  error_coefficients = bdf_coefficients * bdf_util.RECIPROCAL_SUMS + 1. / (
+      bdf_util.ORDERS + 1)
+
+  return newton_coefficients, error_coefficients
+
+
+def _get_common_params_and_coefficients(
+    ode_fn, initial_time, initial_state, atol, rtol, min_step_size_factor,
+    max_step_size_factor, max_order, max_num_newton_iters, max_num_steps,
+    newton_tol_factor, newton_step_size_factor, safety_factor,
+    bdf_coefficients):
+  #convert everything to jnp arrays
+  atol, rtol = jnp.array(atol, dtype=jnp.float64), jnp.array(rtol,
+                                                             dtype=jnp.float64)
+  min_step_size_factor, max_step_size_factor = jnp.array(min_step_size_factor, dtype=jnp.float64),\
+                                               jnp.array(max_step_size_factor, dtype=jnp.float64)
+  max_order, max_num_newton_iters = jnp.array(max_order, dtype=jnp.int64),\
+                                    jnp.array(max_num_newton_iters, dtype=jnp.int64)
+  max_num_steps = jnp.array(max_num_steps, dtype=jnp.float64)
+  newton_tol_factor, newton_step_size_factor = jnp.array(newton_tol_factor, dtype=jnp.float64), \
+                                               jnp.array(newton_step_size_factor, dtype=jnp.float64)
+  safety_factor = jnp.array(safety_factor, dtype=jnp.float64)
+  bdf_coefficients = jnp.array(bdf_coefficients, dtype=jnp.float64)
+  initial_state_vec = initial_state.flatten()
+  ode_fn_vec = bdf_util.get_ode_fn_vec(ode_fn, initial_time, initial_state)
+  num_odes = jnp.shape(initial_state_vec)[0]
+
+  newton_coefficients, error_cofficients = _get_coefficients(bdf_coefficients)
+
+  _params = SolverParams(atol=atol,
+                         rtol=rtol,
+                         min_step_size_factor=min_step_size_factor,
+                         max_step_size_factor=max_step_size_factor,
+                         safety_factor=safety_factor,
+                         max_num_steps=max_num_steps,
+                         max_order=max_order,
+                         max_num_newton_iters=max_num_newton_iters,
+                         newton_tol_factor=newton_tol_factor,
+                         newton_step_size_factor=newton_step_size_factor,
+                         bdf_coefficients=bdf_coefficients,
+                         initial_state_vec=initial_state_vec,
+                         ode_fn_vec=ode_fn_vec,
+                         initial_time=initial_time,
+                         num_odes=num_odes)
+  _coefficients = Coefficients(newton_coefficients=newton_coefficients,
+                               error_coefficients=error_cofficients)
+
+  return _params, _coefficients
+
+
+def _initialize_solver_internal_state(
+    ode_fn, initial_time, initial_state, atol, rtol, min_step_size_factor,
+    max_step_size_factor, max_order, max_num_newton_iters, max_num_steps,
+    newton_tol_factor, newton_step_size_factor, safety_factor,
+    bdf_coefficients):
+
+  p, e = _get_common_params_and_coefficients(
+      ode_fn, initial_time, initial_state, atol, rtol, min_step_size_factor,
+      max_step_size_factor, max_order, max_num_newton_iters, max_num_steps,
+      newton_tol_factor, newton_step_size_factor, safety_factor,
+      bdf_coefficients)
+
+  first_step_size = bdf_util.first_step_size(
+      atol=atol,
+      first_order_error_coefficient=e.error_coefficients[1],
+      initial_state_vec=p.initial_state_vec,
+      initial_time=initial_time,
+      ode_fn_vec=p.ode_fn_vec,
+      rtol=rtol,
+      safety_factor=safety_factor)
+
+  first_order_backward_difference = p.ode_fn_vec(
+      initial_time, p.initial_state_vec) * first_step_size
+
+  backward_differences = jnp.concatenate([
+      p.initial_state_vec[jnp.newaxis, :],
+      first_order_backward_difference[jnp.newaxis, :],
+      jnp.zeros(
+          jnp.array(jnp.stack((bdf_util.MAX_ORDER + 1, p.num_odes)),
+                    dtype=jnp.int64))
+  ],
+                                         axis=0)
+  return _BDFSolverInternalState(backward_differences=backward_differences,
+                                 order=1,
+                                 step_size=first_step_size)
+
+
+def _solve(ode_fn, initial_time, initial_state, solution_times, jacobian_fn,
+           atol, rtol, min_step_size_factor, max_step_size_factor, max_order,
+           max_num_newton_iters, max_num_steps, newton_tol_factor,
+           newton_step_size_factor, safety_factor, bdf_coefficients):
+  def advance_to_solution_time(_states):
+    """Takes multiple steps to advance time to `solution_times[n]`."""
+    n, diagnostics, iterand, solver_internal_state, state_vec, times = _states
+
+    def step_cond(_states):
+      next_time, diagnostics, iterand, *_ = _states
+      return (iterand.time < next_time) & (jnp.equal(diagnostics.status, 0))
+
+    nth_solution_time = solution_times[n]
+
+    [_, diagnostics, iterand, solver_internal_state, state_vec,
+     times] = jax.lax.while_loop(step_cond, step, [
+         nth_solution_time, diagnostics, iterand, solver_internal_state,
+         state_vec, times
+     ])
+
+    state_vec = jax.ops.index_update(
+        state_vec, jax.ops.index[n],
+        solver_internal_state.backward_differences[0])
+    times = jax.ops.index_update(times, jax.ops.index[n], nth_solution_time)
+
+    return (n + 1, diagnostics, iterand, solver_internal_state, state_vec,
+            times)
+
+  def step(_states):
+    """Takes a single step."""
+    next_time, diagnostics, iterand, solver_internal_state, state_vec, times = _states
+    distance_to_next_time = next_time - iterand.time
+    overstepped = iterand.new_step_size > distance_to_next_time
+    iterand = iterand._replace(
+        new_step_size=jnp.where(overstepped, distance_to_next_time,
+                                iterand.new_step_size),
+        should_update_step_size=overstepped | iterand.should_update_step_size)
+    #lazy jacobian evaluation ?
+
+    diagnostics = diagnostics._replace(
+        num_jacobian_evaluations=diagnostics.num_jacobian_evaluations + 1)
+    iterand = iterand._replace(jacobian_mat=jacobian_fn(
+        iterand.time, solver_internal_state.backward_differences[0]),
+                               jacobian_is_up_to_date=True)
+
+    def maybe_step_cond(_states):
+      accepted, diagnostics, *_ = _states
+      return jnp.logical_not(accepted) & jnp.equal(diagnostics.status, 0)
+
+    _, diagnostics, iterand, solver_internal_state = jax.lax.while_loop(
+        maybe_step_cond, maybe_step,
+        (False, diagnostics, iterand, solver_internal_state))
+    return [
+        next_time, diagnostics, iterand, solver_internal_state, state_vec,
+        times
+    ]
+
+  def maybe_step(_states):
+    """Takes a single step only if the outcome has a low enough error."""
+    accepted, diagnostics, iterand, solver_internal_state = _states
+    [
+        num_jacobian_evaluations, num_matrix_factorizations,
+        num_ode_fn_evaluations, status
+    ] = diagnostics
+    [
+        jacobian_mat, jacobian_is_up_to_date, new_step_size, num_steps,
+        num_steps_same_size, should_update_jacobian, should_update_step_size,
+        time, unitary, upper
+    ] = iterand
+    [backward_differences, order, step_size] = solver_internal_state
+    status = jnp.where(jnp.equal(num_steps, max_num_steps), -1, 0)
+    backward_differences = jnp.where(
+        should_update_step_size,
+        bdf_util.interpolate_backward_differences(backward_differences, order,
+                                                  new_step_size / step_size),
+        backward_differences)
+    step_size = jnp.where(should_update_step_size, new_step_size, step_size)
+    should_update_factorization = should_update_step_size  #pylint: disable=unused-variable
+    num_steps_same_size = jnp.where(should_update_step_size, 0,
+                                    num_steps_same_size)
+
+    def update_factorization():
+      return bdf_util.newton_qr(jacobian_mat, e.newton_coefficients[order],
+                                step_size)
+
+    #lazy jacobian evaluation?
+    unitary, upper = update_factorization()
+    num_matrix_factorizations += 1
+
+    tol = p.atol + p.rtol * jnp.abs(backward_differences[0])
+    newton_tol = newton_tol_factor * jnp.linalg.norm(tol)
+
+    [
+        newton_converged, next_backward_difference, next_state_vec,
+        newton_num_iters
+    ] = bdf_util.newton(backward_differences, max_num_newton_iters,
+                        e.newton_coefficients[order], p.ode_fn_vec, order,
+                        step_size, time, newton_tol, unitary, upper)
+    num_steps += 1
+    num_ode_fn_evaluations += newton_num_iters
+
+    # If Newton's method failed and the Jacobian was up to date, decrease the
+    # step size.
+    newton_failed = jnp.logical_not(newton_converged)
+    should_update_step_size = newton_failed & jacobian_is_up_to_date
+    new_step_size = step_size * jnp.where(should_update_step_size,
+                                          newton_step_size_factor, 1.)
+
+    # If Newton's method failed and the Jacobian was NOT up to date, update
+    # the Jacobian.
+    should_update_jacobian = newton_failed & jnp.logical_not(
+        jacobian_is_up_to_date)
+
+    error_ratio = jnp.where(
+        newton_converged,
+        bdf_util.error_ratio(next_backward_difference,
+                             e.error_coefficients[order], tol), jnp.nan)
+    accepted = error_ratio < 1.
+    converged_and_rejected = newton_converged & jnp.logical_not(accepted)
+
+    # If Newton's method converged but the solution was NOT accepted, decrease
+    # the step size.
+    new_step_size = jnp.where(
+        converged_and_rejected,
+        bdf_util.next_step_size(step_size, order, error_ratio, p.safety_factor,
+                                p.min_step_size_factor,
+                                p.max_step_size_factor), new_step_size)
+    should_update_step_size = should_update_step_size | converged_and_rejected
+
+    # If Newton's method converged and the solution was accepted, update the
+    # matrix of backward differences.
+    time = jnp.where(accepted, time + step_size, time)
+    backward_differences = jnp.where(
+        accepted,
+        bdf_util.update_backward_differences(backward_differences,
+                                             next_backward_difference,
+                                             next_state_vec, order),
+        backward_differences)
+    jacobian_is_up_to_date = jacobian_is_up_to_date & jnp.logical_not(accepted)
+    num_steps_same_size = jnp.where(accepted, num_steps_same_size + 1,
+                                    num_steps_same_size)
+
+    # Order and step size are only updated if we have taken strictly more than
+    # order + 1 steps of the same size. This is to prevent the order from
+    # being throttled.
+    should_update_order_and_step_size = accepted & (num_steps_same_size >
+                                                    order + 1)
+    new_order = order
+    new_error_ratio = error_ratio
+    for offset in [-1, +1]:
+      proposed_order = jnp.clip(order + offset, 1, max_order)
+      proposed_error_ratio = bdf_util.error_ratio(
+          backward_differences[proposed_order + 1],
+          e.error_coefficients[proposed_order], tol)
+      proposed_error_ratio_is_lower = proposed_error_ratio < new_error_ratio
+      new_order = jnp.where(
+          should_update_order_and_step_size & proposed_error_ratio_is_lower,
+          proposed_order, new_order)
+      new_error_ratio = jnp.where(
+          should_update_order_and_step_size & proposed_error_ratio_is_lower,
+          proposed_error_ratio, new_error_ratio)
+    order = new_order
+    error_ratio = new_error_ratio
+
+    new_step_size = jnp.where(
+        should_update_order_and_step_size,
+        bdf_util.next_step_size(step_size, order, error_ratio, p.safety_factor,
+                                p.min_step_size_factor,
+                                p.max_step_size_factor), new_step_size)
+    should_update_step_size = (should_update_step_size
+                               | should_update_order_and_step_size)
+
+    diagnostics = _BDFDiagnostics(num_jacobian_evaluations,
+                                  num_matrix_factorizations,
+                                  num_ode_fn_evaluations, status)
+
+    iterand = _BDFIterand(jacobian_mat, jacobian_is_up_to_date, new_step_size,
+                          num_steps, num_steps_same_size,
+                          should_update_jacobian, should_update_step_size,
+                          time, unitary, upper)
+
+    solver_internal_state = _BDFSolverInternalState(backward_differences,
+                                                    order, step_size)
+    return accepted, diagnostics, iterand, solver_internal_state
+
+  solver_internal_state = _initialize_solver_internal_state(
+      ode_fn, initial_time, initial_state, atol, rtol, min_step_size_factor,
+      max_step_size_factor, max_order, max_num_newton_iters, max_num_steps,
+      newton_tol_factor, newton_step_size_factor, safety_factor,
+      bdf_coefficients)
+
+  p, e = _get_common_params_and_coefficients(
+      ode_fn, initial_time, initial_state, atol, rtol, min_step_size_factor,
+      max_step_size_factor, max_order, max_num_newton_iters, max_num_steps,
+      newton_tol_factor, newton_step_size_factor, safety_factor,
+      bdf_coefficients)
+
+  diagnostics = _BDFDiagnostics(num_jacobian_evaluations=0,
+                                num_matrix_factorizations=0,
+                                num_ode_fn_evaluations=0,
+                                status=0)
+
+  iterand = _BDFIterand(
+      jacobian_mat=jnp.zeros([p.num_odes, p.num_odes]),
+      jacobian_is_up_to_date=False,
+      new_step_size=solver_internal_state.step_size,
+      num_steps=0,
+      num_steps_same_size=0,
+      should_update_jacobian=True,
+      should_update_step_size=False,
+      time=p.initial_time,
+      unitary=jnp.zeros([p.num_odes, p.num_odes]),
+      upper=jnp.zeros([p.num_odes, p.num_odes]),
+  )
+
+  num_solution_times = jnp.shape(solution_times)[0]
+  state_vec_size = jnp.shape(initial_state)[0]
+  state_vec = jnp.zeros([num_solution_times, state_vec_size],
+                        dtype=jnp.float64)
+  times = jnp.zeros([num_solution_times], dtype=jnp.float64)
+
+  def advance_to_solution_time_cond(_states):
+    n, diagnostics, *_ = _states
+    return (n < num_solution_times) & (jnp.equal(diagnostics.status, 0))
+
+  [_, diagnostics, iterand,
+   solver_internal_state, state_vec, times] = jax.lax.while_loop(
+       advance_to_solution_time_cond, advance_to_solution_time,
+       (0, diagnostics, iterand, solver_internal_state, state_vec, times))
+  return Results(
+      times=times,
+      states=state_vec,
+      diagnostics=diagnostics,
+      solver_internal_state=solver_internal_state,
+  )
+
+
+@partial(jax.jit, static_argnums=(0, 4))
+def bdf_solve(ode_fn,
+              initial_time,
+              initial_state,
+              solution_times,
+              jacobian_fn,
+              atol=1e-6,
+              rtol=1e-3,
+              min_step_size_factor=0.1,
+              max_step_size_factor=10.,
+              max_order=bdf_util.MAX_ORDER,
+              max_num_newton_iters=4,
+              max_num_steps=jnp.inf,
+              newton_tol_factor=0.1,
+              newton_step_size_factor=0.5,
+              safety_factor=0.9,
+              bdf_coefficients=[0., 0.1850, -1. / 9., -0.0823, -0.0415, 0.]):
+
+  results = _solve(ode_fn, initial_time, initial_state, solution_times,
+                   jacobian_fn, atol, rtol, min_step_size_factor,
+                   max_step_size_factor, max_order, max_num_newton_iters,
+                   max_num_steps, newton_tol_factor, newton_step_size_factor,
+                   safety_factor, bdf_coefficients)
+
+  return results
+
+
+class Results(
+    collections.namedtuple(
+        "Results",
+        ["times", "states", "diagnostics", "solver_internal_state"])):  #
+  """
+    namedtuple class to store results from ode solver
+    """
+  def __new__(cls, times, states, diagnostics, solver_internal_state):
+    return super(Results, cls).__new__(cls, times, states, diagnostics,
+                                       solver_internal_state)
+
+
+bdf_util.register_pytree_namedtuple(Results)  #JAX pytree
+
+
+class _BDFDiagnostics(
+    collections.namedtuple('_BDFDiagnostics', [
+        'num_jacobian_evaluations',
+        'num_matrix_factorizations',
+        'num_ode_fn_evaluations',
+        'status',
+    ])):
+  """
+    namedtuple class to store diagnostics
+    """
+  def __new__(cls, num_jacobian_evaluations, num_matrix_factorizations,
+              num_ode_fn_evaluations, status):
+    return super(_BDFDiagnostics, cls).__new__(cls, num_jacobian_evaluations,
+                                               num_matrix_factorizations,
+                                               num_ode_fn_evaluations, status)
+
+
+bdf_util.register_pytree_namedtuple(_BDFDiagnostics)  #JAX pytree
+
+
+class _BDFIterand(
+    collections.namedtuple('_BDFIterand', [
+        'jacobian_mat', 'jacobian_is_up_to_date', 'new_step_size', 'num_steps',
+        'num_steps_same_size', 'should_update_jacobian',
+        'should_update_step_size', 'time', 'unitary', 'upper'
+    ])):
+  """
+    namedtuple class to store iterand state
+    """
+  def __new__(cls, jacobian_mat, jacobian_is_up_to_date, new_step_size,
+              num_steps, num_steps_same_size, should_update_jacobian,
+              should_update_step_size, time, unitary, upper):
+    return super(_BDFIterand,
+                 cls).__new__(cls, jacobian_mat, jacobian_is_up_to_date,
+                              new_step_size, num_steps, num_steps_same_size,
+                              should_update_jacobian, should_update_step_size,
+                              time, unitary, upper)
+
+
+bdf_util.register_pytree_namedtuple(_BDFIterand)  #JAX pytree
+
+
+class _BDFSolverInternalState(
+    collections.namedtuple('_BDFSolverInternalState', [
+        'backward_differences',
+        'order',
+        'step_size',
+    ])):
+  """
+    Returned by the solver to warm start future invocations
+    """
+  def __new__(cls, backward_differences, order, step_size):
+    return super(_BDFSolverInternalState,
+                 cls).__new__(cls, backward_differences, order, step_size)
+
+
+bdf_util.register_pytree_namedtuple(_BDFSolverInternalState)  #JAX pytree
+
+
+class SolverParams(
+    collections.namedtuple('SolverParams', [
+        "rtol", "atol", "safety_factor", "min_step_size_factor",
+        "max_step_size_factor", "max_num_steps", "max_order",
+        "max_num_newton_iters", "newton_tol_factor", "newton_step_size_factor",
+        "bdf_coefficients", "initial_state_vec", "ode_fn_vec", "initial_time",
+        "num_odes"
+    ])):
+  def __new__(cls, rtol, atol, safety_factor, min_step_size_factor,
+              max_step_size_factor, max_num_steps, max_order,
+              max_num_newton_iters, newton_tol_factor, newton_step_size_factor,
+              bdf_coefficients, initial_state_vec, ode_fn_vec, initial_time,
+              num_odes):
+    return super(SolverParams,
+                 cls).__new__(cls, rtol, atol, safety_factor,
+                              min_step_size_factor, max_step_size_factor,
+                              max_num_steps, max_order, max_num_newton_iters,
+                              newton_tol_factor, newton_step_size_factor,
+                              bdf_coefficients, initial_state_vec, ode_fn_vec,
+                              initial_time, num_odes)
+
+
+bdf_util.register_pytree_namedtuple(SolverParams)
+
+
+class Coefficients(
+    collections.namedtuple('Coefficients',
+                           ["newton_coefficients", "error_coefficients"])):
+  def __new__(cls, newton_coefficients, error_coefficients):
+    return super(Coefficients, cls).__new__(cls, newton_coefficients,
+                                            error_coefficients)
+
+
+bdf_util.register_pytree_namedtuple(Coefficients)

--- a/jax/experimental/bdf/bdf_util.py
+++ b/jax/experimental/bdf/bdf_util.py
@@ -1,8 +1,5 @@
 from collections import namedtuple
-from functools import partial
-from typing import Callable, Dict, List, Tuple, Union
-
-import numpy as np
+from typing import Callable, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -257,7 +254,7 @@ def update_backward_differences(backward_differences, next_backward_difference,
 def get_ode_fn_vec(ode_fn, initial_time, initial_state):
   initial_state_vec = initial_state.flatten()  #pylint: disable=unused-variable
 
-  def ode_fn_vec(inital_time, initial_state_vec):
+  def ode_fn_vec(initial_time, initial_state_vec):
     return ode_fn(initial_time, initial_state_vec)
 
   return ode_fn_vec

--- a/jax/experimental/bdf/bdf_util.py
+++ b/jax/experimental/bdf/bdf_util.py
@@ -251,8 +251,8 @@ def update_backward_differences(backward_differences, next_backward_difference,
   return new_backward_differences
 
 
-def get_ode_fn_vec(ode_fn, initial_time, initial_state):
-  initial_state_vec = initial_state.flatten()  #pylint: disable=unused-variable
+def get_ode_fn_vec(ode_fn, initial_time, initial_state): #pylint: disable=unused-variable
+  initial_state_vec = initial_state.flatten()  #noqa: F841 #pylint: disable=unused-variable 
 
   def ode_fn_vec(initial_time, initial_state_vec):
     return ode_fn(initial_time, initial_state_vec)

--- a/jax/experimental/bdf/bdf_util.py
+++ b/jax/experimental/bdf/bdf_util.py
@@ -1,0 +1,293 @@
+from collections import namedtuple
+from functools import partial
+from typing import Callable, Dict, List, Tuple, Union
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+
+#Adapted from tensorflow_probabilty at
+# https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/math/ode/bdf_util.py
+#Accessed 2020-06-24
+
+MAX_ORDER = 5
+ORDERS = jnp.arange(0, MAX_ORDER + 1)
+RECIPROCAL_SUMS = jnp.concatenate(
+    [jnp.array([jnp.nan]), jnp.cumsum(1. / ORDERS[1:])])
+
+
+def register_pytree_namedtuple(cls: object):
+  jax.tree_util.register_pytree_node(cls, lambda xs: (tuple(xs), None),
+                                     lambda _, xs: cls(*xs))
+
+
+def error_ratio(backward_difference: jnp.ndarray,
+                error_coefficient: jnp.ndarray,
+                tol: Union[jnp.ndarray, float]) -> jnp.ndarray:
+  """Computes the ratio of the error in the computed state to the tolerance."""
+  error_ratio_ = jnp.linalg.norm(error_coefficient * backward_difference / tol)
+  return error_ratio_
+
+
+def first_step_size(atol: Union[jnp.ndarray, float],
+                    first_order_error_coefficient: Union[jnp.ndarray, float],
+                    initial_state_vec: jnp.ndarray,
+                    initial_time: Union[jnp.ndarray, float],
+                    ode_fn_vec: Callable,
+                    rtol: Union[jnp.ndarray, float],
+                    safety_factor: Union[jnp.ndarray, float],
+                    epsilon: float = 1e-12,
+                    max_step_size: float = 1.,
+                    min_step_size: float = 1e-12) -> jnp.ndarray:
+  """Selects the first step size to use."""
+  next_time = initial_time + epsilon
+  first_derivative = ode_fn_vec(initial_time, initial_state_vec)
+  next_state_vec = initial_state_vec + first_derivative * epsilon
+  second_derivative = (ode_fn_vec(next_time, next_state_vec) -
+                       first_derivative) / epsilon
+  tol = atol + (rtol * jnp.abs(initial_state_vec))
+  # Local truncation error of an order one step is
+  # `err(step_size) = first_order_error_coefficient * second_derivative *
+  #                 * step_size**2`.
+  # Choose the largest `step_size` such that `norm(err(step_size) / tol) <= 1`.
+  norm = jnp.linalg.norm(first_order_error_coefficient * second_derivative /
+                         tol)
+  step_size = jax.lax.rsqrt(norm)
+  return jnp.clip(safety_factor * step_size, min_step_size, max_step_size)
+
+
+def interpolation_matrix(
+    order: Union[jnp.ndarray, int],
+    step_size_ratio: Union[jnp.ndarray, float, int]) -> jnp.ndarray:
+  """Creates the matrix used to interpolate backward differences."""
+  orders = jnp.arange(1, MAX_ORDER + 1)
+  i = orders[:, jnp.newaxis]
+  j = orders[jnp.newaxis, :]
+  # Matrix whose (i, j)-th entry (`1 <= i, j <= order`) is
+  # `1/j! (0 - i * step_size_ratio) * ... * ((j-1) - i * step_size_ratio)`.
+  full_interpolation_matrix = jnp.cumprod(((j - 1) - i * step_size_ratio) / j,
+                                          axis=1)
+  zeros_matrix = jnp.zeros_like(full_interpolation_matrix)
+  interpolation_matrix_ = jnp.where(
+      jnp.arange(1, MAX_ORDER + 1) <= order,
+      jnp.transpose(
+          jnp.where(
+              jnp.arange(1, MAX_ORDER + 1) <= order,
+              jnp.transpose(full_interpolation_matrix), zeros_matrix)),
+      zeros_matrix)
+  return interpolation_matrix_
+
+
+def interpolate_backward_differences(
+    backward_differences: jnp.ndarray, order: Union[jnp.ndarray, int],
+    step_size_ratio: Union[jnp.ndarray, float, int]) -> jnp.ndarray:
+  """Updates backward differences when a change in the step size occurs."""
+  interpolation_matrix_ = interpolation_matrix(order, step_size_ratio)
+  interpolation_matrix_unit_step_size_ratio = interpolation_matrix(order, 1.)
+  interpolated_backward_differences_orders_one_to_five = jnp.matmul(
+      interpolation_matrix_unit_step_size_ratio,
+      jnp.matmul(interpolation_matrix_, backward_differences[1:MAX_ORDER + 1]))
+  interpolated_backward_differences = jnp.concatenate([
+      backward_differences[0].reshape(1,
+                                      jnp.shape(backward_differences)[1]),
+      interpolated_backward_differences_orders_one_to_five,
+      jnp.zeros(
+          jnp.stack(
+              jnp.array([2, jnp.shape(backward_differences)[1]],
+                        dtype=jnp.int64)))
+  ],
+                                                      axis=0)
+  return interpolated_backward_differences
+
+
+class _NewtonIterand(
+    namedtuple("NewtonIterand", [
+        "converged", "finished", "next_backward_difference", "next_state_vec",
+        "num_iters", "prev_delta_norm"
+    ])):  #pylint: disable=inherit-non-class
+  """
+    namedtuple class to store Newton iterand
+    """
+  def __new__(cls, converged, finished, next_backward_difference,
+              next_state_vec, num_iters, prev_delta_norm):
+    return super(_NewtonIterand,
+                 cls).__new__(cls, converged, finished,
+                              next_backward_difference, next_state_vec,
+                              num_iters, prev_delta_norm)
+
+
+register_pytree_namedtuple(_NewtonIterand)  #JAX pytree
+
+
+def newton_qr(
+    jacobian_mat: jnp.ndarray, newton_coefficient: Union[jnp.ndarray, float,
+                                                         int],
+    step_size: Union[jnp.ndarray, float,
+                     int]) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  """QR factorizes the matrix used in each iteration of Newton's method."""
+  identity = jnp.eye(jnp.shape(jacobian_mat)[0], dtype=jacobian_mat.dtype)
+  newton_matrix = (identity - step_size * newton_coefficient * jacobian_mat)
+  q, r = jnp.linalg.qr(newton_matrix)
+  return q, r
+
+
+def newton(
+    backward_differences: jnp.ndarray, max_num_iters: Union[jnp.ndarray, float,
+                                                            int],
+    newton_coefficient: Union[jnp.ndarray, float, int], ode_fn_vec: Callable,
+    order: Union[jnp.ndarray, float,
+                 int], step_size: Union[jnp.ndarray, float,
+                                        int], time: Union[jnp.ndarray, float,
+                                                          int],
+    tol: Union[jnp.ndarray, float], unitary: jnp.ndarray, upper: jnp.ndarray
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+  """Runs Newton's method to solve the BDF equation."""
+  initial_guess = jnp.sum(jnp.where(
+      jnp.arange(MAX_ORDER + 1).reshape(-1, 1) <= order,
+      backward_differences[:MAX_ORDER + 1],
+      jnp.zeros_like(backward_differences)[:MAX_ORDER + 1]),
+                          axis=0)
+
+  rhs_constant_term = newton_coefficient * jnp.sum(jnp.where(
+      jnp.arange(1, MAX_ORDER + 1).reshape(-1, 1) <= order,
+      RECIPROCAL_SUMS[1:, jnp.newaxis] * backward_differences[1:MAX_ORDER + 1],
+      jnp.zeros_like(backward_differences)[1:MAX_ORDER + 1]),
+                                                   axis=0)
+
+  next_time = time + step_size
+
+  def newton_body(iterand):
+    """Performs one iteration of Newton's method."""
+    next_backward_difference = iterand.next_backward_difference
+    next_state_vec = iterand.next_state_vec
+
+    rhs = newton_coefficient * step_size * ode_fn_vec(
+        next_time,
+        next_state_vec) - rhs_constant_term - next_backward_difference
+    delta = jnp.squeeze(
+        jax.scipy.linalg.solve_triangular(upper,
+                                          jnp.matmul(jnp.transpose(unitary),
+                                                     rhs[:, jnp.newaxis]),
+                                          lower=False))
+    num_iters = iterand.num_iters + 1
+
+    next_backward_difference += delta
+    next_state_vec += delta
+
+    delta_norm = jnp.linalg.norm(delta)
+    lipschitz_const = delta_norm / iterand.prev_delta_norm
+
+    # Stop if method has converged.
+    approx_dist_to_sol = lipschitz_const / (1. - lipschitz_const) * delta_norm
+    close_to_sol = approx_dist_to_sol < tol
+    delta_norm_is_zero = jnp.equal(delta_norm, jnp.array(0.,
+                                                         dtype=jnp.float64))
+    converged = close_to_sol | delta_norm_is_zero
+    finished = converged
+
+    # Stop if any of the following conditions are met:
+    # (A) We have hit the maximum number of iterations.
+    # (B) The method is converging too slowly.
+    # (C) The method is not expected to converge.
+    too_slow = lipschitz_const > 1.
+    finished = finished | too_slow
+
+    too_many_iters = jnp.equal(num_iters, max_num_iters)
+    num_iters_left = max_num_iters - num_iters
+    wont_converge = (approx_dist_to_sol * lipschitz_const**num_iters_left >
+                     tol)
+    finished = finished | too_many_iters | wont_converge
+
+    return _NewtonIterand(converged=converged,
+                          finished=finished,
+                          next_backward_difference=next_backward_difference,
+                          next_state_vec=next_state_vec,
+                          num_iters=num_iters,
+                          prev_delta_norm=delta_norm)
+
+  iterand = _NewtonIterand(
+      converged=False,
+      finished=False,
+      next_backward_difference=jnp.zeros_like(initial_guess),
+      next_state_vec=initial_guess,
+      num_iters=0,
+      prev_delta_norm=(jnp.array(-0.)))
+  iterand = jax.lax.while_loop(
+      lambda iterand: jnp.logical_not(iterand.finished), newton_body, iterand)
+  return (iterand.converged, iterand.next_backward_difference,
+          iterand.next_state_vec, iterand.num_iters)
+
+
+def update_backward_differences(backward_differences, next_backward_difference,
+                                next_state_vec, order):
+  """Returns the backward differences for the next time."""
+  new_backward_differences_array = jnp.zeros(
+      (MAX_ORDER + 3, jnp.shape(next_backward_difference)[0]),
+      dtype=next_backward_difference.dtype)
+  new_backward_differences_array = jax.ops.index_update(
+      new_backward_differences_array, jax.ops.index[order + 2],
+      next_backward_difference - backward_differences[order + 1])
+  new_backward_differences_array = jax.ops.index_update(
+      new_backward_differences_array, jax.ops.index[order + 1],
+      next_backward_difference)
+
+  def body(vals):
+    k, new_backward_differences_array_ = vals
+    new_backward_differences_array_k = new_backward_differences_array_[
+        k + 1] + backward_differences[k]
+    new_backward_differences_array_ = jax.ops.index_update(
+        new_backward_differences_array_, jax.ops.index[k],
+        new_backward_differences_array_k)
+    return (k - 1, new_backward_differences_array_)
+
+  def body_cond(vals):
+    k, _ = vals
+    return k > 0
+
+  _, new_backward_differences_array = jax.lax.while_loop(
+      body_cond, body, (order, new_backward_differences_array))
+  new_backward_differences_array = jax.ops.index_update(
+      new_backward_differences_array, jax.ops.index[0], next_state_vec)
+
+  new_backward_differences = jnp.stack(new_backward_differences_array)
+  return new_backward_differences
+
+
+def get_ode_fn_vec(ode_fn, initial_time, initial_state):
+  initial_state_vec = initial_state.flatten()  #pylint: disable=unused-variable
+
+  def ode_fn_vec(inital_time, initial_state_vec):
+    return ode_fn(initial_time, initial_state_vec)
+
+  return ode_fn_vec
+
+
+def next_step_size(step_size, order, error_ratio, safety_factor,
+                   min_step_size_factor, max_step_size_factor):
+  """Computes the next step size to use.
+
+  Computes the next step size by applying a multiplicative factor to the current
+  step size. This factor is
+  ```none
+  factor_unclamped = error_ratio**(-1. / (order + 1)) * safety_factor
+  factor = clamp(factor_unclamped, min_step_size_factor, max_step_size_factor)
+  ```
+
+  Args:
+    step_size: Scalar float `Tensor` specifying the current step size.
+    order: Scalar integer `Tensor` specifying the order of the method.
+    error_ratio: Scalar float `Tensor` specifying the ratio of the error in the
+      computed state and the tolerance.
+    safety_factor: Scalar float `Tensor`.
+    min_step_size_factor: Scalar float `Tensor` specifying a lower bound on the
+      multiplicative factor.
+    max_step_size_factor: Scalar float `Tensor` specifying an upper bound on the
+      multiplicative factor.
+
+  Returns:
+    Scalar float `Tensor` specifying the next step size.
+  """
+  factor = error_ratio**(-1. / (order + 1.))
+  return step_size * jnp.clip(safety_factor * factor, min_step_size_factor,
+                              max_step_size_factor)

--- a/jax/experimental/bdf/bdf_util_test.py
+++ b/jax/experimental/bdf/bdf_util_test.py
@@ -1,0 +1,105 @@
+import numpy as np
+
+import jax.numpy as jnp
+
+#local imports
+from . import bdf_util
+
+#Adapted from tensorflow_probabilty at
+#https://github.com/tensorflow/probability/blob/master/tensorflow_probability/python/math/ode/bdf_util_test.py
+#Accessed 2020-06-24
+
+
+def test_first_step_size_is_large_when_ode_fn_is_constant():
+  initial_state_vec = jnp.array([1.], dtype=jnp.float64)
+  atol = jnp.array(1e-12, dtype=jnp.float64)
+  first_order_bdf_coefficient = -0.1850
+  first_order_error_coefficient = first_order_bdf_coefficient + 0.5
+  initial_time = jnp.array(0., dtype=jnp.float64)
+  ode_fn_vec = lambda time, state: 1.
+  rtol = jnp.array(1e-8, dtype=jnp.float64)
+  safety_factor = jnp.array(0.9, dtype=jnp.float64)
+  max_step_size = 1.
+  step_size = bdf_util.first_step_size(atol,
+                                       first_order_error_coefficient,
+                                       initial_state_vec,
+                                       initial_time,
+                                       ode_fn_vec,
+                                       rtol,
+                                       safety_factor,
+                                       max_step_size=max_step_size)
+  # Step size should be maximal.
+  np.testing.assert_allclose(np.asarray(max_step_size, dtype=np.float64),
+                             np.asarray(step_size, dtype=np.float64),
+                             err_msg='step size is not equal')
+
+
+def test_interpolation_matrix_unit_step_size_ratio():
+  order = jnp.array(bdf_util.MAX_ORDER, dtype=jnp.int32)
+  step_size_ratio = jnp.array(1., dtype=jnp.float64)
+  interpolation_matrix = bdf_util.interpolation_matrix(order, step_size_ratio)
+  np.testing.assert_allclose(
+      interpolation_matrix,
+      jnp.array([[-1., -0., -0., -0., -0.], [-2., 1., 0., 0., 0.],
+                 [-3., 3., -1., -0., -0.], [-4., 6., -4., 1., 0.],
+                 [-5., 10., -10., 5., -1.]],
+                dtype=jnp.float64),
+      err_msg='Interpolation matrices are not equal')
+
+
+def test_interpolate_backward_differences_zeroth_order_is_unchanged():
+  backward_differences = jnp.array(np.random.normal(size=((bdf_util.MAX_ORDER +
+                                                           3, 3))),
+                                   dtype=jnp.float64)
+  step_size_ratio = jnp.array(0.5, dtype=jnp.float64)
+  interpolated_backward_differences = (
+      bdf_util.interpolate_backward_differences(backward_differences,
+                                                bdf_util.MAX_ORDER,
+                                                step_size_ratio))
+  np.testing.assert_allclose(
+      backward_differences[0],
+      interpolated_backward_differences[0],
+      err_msg='Interpolated backward differences are not equal')
+
+
+def test_newton_order_one():
+  jacobian_mat = jnp.array([[-1.]], dtype=jnp.float64)
+  bdf_coefficient = jnp.array(-0.1850, dtype=jnp.float64)
+  first_order_newton_coefficient = 1. / (1. - bdf_coefficient)
+  step_size = jnp.array(0.01, dtype=jnp.float64)
+  unitary, upper = bdf_util.newton_qr(jacobian_mat,
+                                      first_order_newton_coefficient,
+                                      step_size)
+
+  backward_differences = jnp.array([[1.], [-1.], [0.], [0.], [0.], [0.]],
+                                   dtype=jnp.float64)
+  ode_fn_vec = lambda time, state: -state
+  order = jnp.array(1, dtype=jnp.int32)
+  time = jnp.array(0., dtype=jnp.float64)
+  tol = jnp.array(1e-6, dtype=jnp.float64)
+
+  # The equation we are trying to solve with Newton's method is linear.
+  # Therefore, we should observe exact convergence after one iteration. An
+  # additional iteration is required to obtain an accurate error estimate,
+  # making the total number of iterations 2.
+  max_num_newton_iters = 2
+
+  converged, next_backward_difference, next_state, _ = bdf_util.newton(
+      backward_differences, max_num_newton_iters,
+      first_order_newton_coefficient, ode_fn_vec, order, step_size, time, tol,
+      unitary, upper)
+  np.testing.assert_equal(np.asarray(converged), True)
+
+  state = backward_differences[0, :]
+  exact_next_state = ((1. - bdf_coefficient) * state +
+                      bdf_coefficient) / (1. + step_size - bdf_coefficient)
+
+  np.testing.assert_allclose(next_backward_difference, exact_next_state)
+  np.testing.assert_allclose(next_state, exact_next_state)
+
+
+if __name__ == "__main__":
+  test_first_step_size_is_large_when_ode_fn_is_constant()
+  test_interpolation_matrix_unit_step_size_ratio()
+  test_interpolate_backward_differences_zeroth_order_is_unchanged()
+  test_newton_order_one()


### PR DESCRIPTION
This PR addresses #3686 . 

Implements BDF solver with JAX control flow and JIT support using code from tensforflow_probability.  The current implementation is tested against SciPy's VODE wrapper with stiff chemical kinetics. 

To-Do:

- [ ] Adjoint sensitivities using `custom_vjp` 

- [ ] Lazy jacobian evaluation 

- [x] Automatically calculate jacobian using JAX's autodiff if user doesn't provide jacobian function 

- [ ] Automatically choose times if user only provides `end_time`

Comments and suggestions are welcome. @shoyer 
