### PR TITLE
[jax2tf] First draft of top_k conversion to tf.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1116,20 +1116,18 @@ tf_impl[lax.scan_p] = _scan
 def _top_k(operand: TfVal, k: int) -> Tuple[TfVal, TfVal]:
   # Some types originally incompatible with tf.math.top_k can be promoted
   # to a compatible type without loss of precision.
-  def promote_dtype(dtype):
-    if dtype in [jnp.bool_, jnp.uint8, jnp.uint16]:
-      return jnp.uint32
-    if dtype in [jnp.int8, jnp.int16]:
-      return jnp.int32
-    if dtype in [jnp.float16]:
-      return jnp.float32
-    if dtype in [jnp.bfloat16]:
-      return tf.bfloat16
+  def promote_tf_dtype(tf_dtype):
+    if tf_dtype in [tf.bool, tf.uint8, tf.uint16]:
+      return tf.uint32
+    if tf_dtype in [tf.int8, tf.int16]:
+      return tf.int32
+    if tf_dtype is tf.float16:
+      return tf.float32
     return None
 
-  conversion_dtype = promote_dtype(operand.dtype)
+  conversion_dtype = promote_tf_dtype(operand.dtype)
   if conversion_dtype:
-    values, indices = tf.math.top_k(tf.dtypes.cast(operand, to_tf_dtype(conversion_dtype)), k=k)
+    values, indices = tf.math.top_k(tf.dtypes.cast(operand, conversion_dtype), k=k)
     return tf.dtypes.cast(values, operand.dtype), indices
   else:
     return tf.math.top_k(operand, k=k)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1127,10 +1127,10 @@ def _top_k(operand: TfVal, k: int) -> Tuple[TfVal, TfVal]:
 
   conversion_dtype = promote_tf_dtype(operand.dtype)
   if conversion_dtype:
-    values, indices = tf.math.top_k(tf.dtypes.cast(operand, conversion_dtype), k=k)
+    values, indices = tf.math.top_k(tf.dtypes.cast(operand, conversion_dtype), k=k, sorted=True)
     return tf.dtypes.cast(values, operand.dtype), indices
   else:
-    return tf.math.top_k(operand, k=k)
+    return tf.math.top_k(operand, k=k, sorted=True)
 
 tf_impl[lax.top_k_p] = _top_k
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -319,6 +319,40 @@ lax_pad = tuple(
   ]
 )
 
+lax_top_k = tuple( # random testing
+  Harness(f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}_k={k}",
+          lax.top_k,
+          [RandArg(shape, dtype), StaticArg(k)],
+          shape=shape,
+          dtype=dtype,
+          k=k)
+  for dtype in jtu.dtypes.all #[np.float32, np.int32, np.uint32]
+  for shape in [(3,), (5, 3)]
+  for k in [-1, 1, 3, 4]
+  for rng_factory in [jtu.rand_default]
+) + tuple( # stability test
+  Harness(f"stability_inshape={jtu.format_shape_dtype_string(arr.shape, arr.dtype)}_k={k}",
+          lax.top_k,
+          [arr, StaticArg(k)],
+          shape=arr.shape,
+          dtype=arr.dtype,
+          k=k)
+  for arr in [
+      np.array([5, 7, 5, 8, 8, 5], dtype=np.int32)
+  ]
+  for k in [1, 3, 6]
+) + tuple( # nan/inf sorting test
+  Harness(f"nan_inshape={jtu.format_shape_dtype_string(arr.shape, arr.dtype)}_k={k}",
+          lax.top_k,
+          [arr, StaticArg(k)],
+          shape=arr.shape,
+          dtype=arr.dtype,
+          k=k)
+  for arr in [
+      np.array([+np.inf, np.nan, -np.nan, np.nan, -np.inf, 3], dtype=np.float32)
+  ]
+  for k in [1, 3, 6]
+)
 
 lax_sort = tuple( # one array, random data, all axes, all dtypes
   Harness(f"one_array_shape={jtu.format_shape_dtype_string(shape, dtype)}_axis={dimension}_isstable={is_stable}",

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -326,7 +326,7 @@ lax_top_k = tuple( # random testing
           shape=shape,
           dtype=dtype,
           k=k)
-  for dtype in jtu.dtypes.all #[np.float32, np.int32, np.uint32]
+  for dtype in jtu.dtypes.all
   for shape in [(3,), (5, 3)]
   for k in [-1, 1, 3, 4]
   for rng_factory in [jtu.rand_default]


### PR DESCRIPTION
We are able to use tf.math.top_k in most cases but:
- bfloat16 and complex numbers are unsupported
- tf.math.top_k works properly with args of type int32/64, uint32/64 and
  float32/64. Other flavors of uints/ints and bool can not be used with
  the operation by default, and they are thus promoted to their
  equivalent 32 bit representation, and the result is casted back to the
  original dtype.

A limitation right now is the handling of edge cases: TF and JAX order
np.inf and np.nan differently, resulting in inconsistencies in the case
where these values are present.