### PR TITLE
Relax test tolerance for conv_general_dilated gradients.

### DIFF
--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -363,7 +363,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       raise SkipTest("float16 numerical issues")  # TODO(mattjj): resolve
 
     rng = rng_factory(self.rng())
-    tol = {dtypes.bfloat16: 1e-0, np.float16: 5e-1, np.float32: 2e-4}
+    tol = {dtypes.bfloat16: 1e-0, np.float16: 5e-1, np.float32: 1e-3}
 
     # permute shapes to match dim_spec, scale by feature_group_count
     lhs_perm, rhs_perm = perms


### PR DESCRIPTION
The new support for complex types leads to slightly higher errors.