### PR TITLE
WIP: Add bicgstab implementation

### DIFF
--- a/jax/scipy/sparse/linalg.py
+++ b/jax/scipy/sparse/linalg.py
@@ -37,11 +37,18 @@ def _vdot_real_part(x, y):
 
 # aliases for working with pytrees
 
-def _vdot_tree(x, y):
+def _vdot_tree_real(x, y):
   return sum(tree_leaves(tree_multimap(_vdot_real_part, x, y)))
+
+
+def _vdot_tree(x, y):
+  return sum(tree_leaves(tree_multimap(partial(
+    jnp.vdot, precision=lax.Precision.HIGHEST), x, y)))
+
 
 def _mul(scalar, tree):
   return tree_map(partial(operator.mul, scalar), tree)
+
 
 _add = partial(tree_multimap, operator.add)
 _sub = partial(tree_multimap, operator.sub)
@@ -54,32 +61,75 @@ def _identity(x):
 def _cg_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
 
   # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
-  bs = _vdot_tree(b, b)
+  bs = _vdot_tree_real(b, b)
   atol2 = jnp.maximum(jnp.square(tol) * bs, jnp.square(atol))
 
   # https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
 
   def cond_fun(value):
     x, r, gamma, p, k = value
-    rs = gamma if M is _identity else _vdot_tree(r, r)
+    rs = gamma if M is _identity else _vdot_tree_real(r, r)
     return (rs > atol2) & (k < maxiter)
 
   def body_fun(value):
     x, r, gamma, p, k = value
     Ap = A(p)
-    alpha = gamma / _vdot_tree(p, Ap)
+    alpha = gamma / _vdot_tree_real(p, Ap)
     x_ = _add(x, _mul(alpha, p))
     r_ = _sub(r, _mul(alpha, Ap))
     z_ = M(r_)
-    gamma_ = _vdot_tree(r_, z_)
+    gamma_ = _vdot_tree_real(r_, z_)
     beta_ = gamma_ / gamma
     p_ = _add(z_, _mul(beta_, p))
     return x_, r_, gamma_, p_, k + 1
 
   r0 = _sub(b, A(x0))
   p0 = z0 = M(r0)
-  gamma0 = _vdot_tree(r0, z0)
+  gamma0 = _vdot_tree_real(r0, z0)
   initial_value = (x0, r0, gamma0, p0, 0)
+
+  x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
+
+  return x_final
+
+
+def _bicgstab_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
+
+  # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.bicgstab
+  bs = _vdot_tree_real(b, b)
+  atol2 = jnp.maximum(jnp.square(tol) * bs, jnp.square(atol))
+
+  # https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method#Preconditioned_BiCGSTAB
+
+  def cond_fun(value):
+    x, r, *_, k = value
+    rs = _vdot_tree_real(r, r)
+    return (rs > atol2) & (k < maxiter)
+
+  def body_fun(value):
+    x, r, rhat, alpha, omega, rho, p, q, k = value
+    rho_ = _vdot_tree(jnp.conj(rhat), r)
+    beta = rho_ / rho * alpha / omega
+    p_ = _add(r, _mul(beta, _sub(p, _mul(omega, q))))
+    phat = M(p_)
+    q_ = A(p_)
+    alpha_ = rho_ / _vdot_tree(jnp.conj(rhat), q_)
+    s = _sub(r, _mul(alpha_, q_))
+    # TODO(sunilkpai): stop early?
+    #  It requires accessing cond_fun like this
+    #  if cond_fun((x, s, r0, alpha_, omega, rho_, p_, q_, k)):
+    #    x_ = _add(x, _mul(alpha_, phat))
+    #    return x_, s, rhat, alpha_, omega, rho_, p_, q, k
+    shat = M(s)
+    t = A(shat)
+    omega_ = _vdot_tree(jnp.conj(s), t) / _vdot_tree_real(t, t)
+    x_ = _add(x, _add(_mul(alpha_, phat), _mul(omega_, shat)))
+    r_ = _sub(s, _mul(omega_, t))
+    return x_, r_, rhat, alpha_, omega_, rho_, p_, q, k + 1
+
+  r0 = _sub(b, A(x0))
+  rho0 = alpha0 = omega0 = 1.0
+  initial_value = (x0, r0, r0, alpha0, omega0, rho0, r0, r0, 0)
 
   x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
 
@@ -88,6 +138,40 @@ def _cg_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
 
 def _shapes(pytree):
   return map(jnp.shape, tree_leaves(pytree))
+
+
+def isolve(_isolve, A, b, x0=None, *, tol=1e-5, atol=0.0,
+           maxiter=None, M=None):
+  if x0 is None:
+    x0 = tree_map(jnp.zeros_like, b)
+
+  b, x0 = device_put((b, x0))
+
+  if maxiter is None:
+    size = sum(bi.size for bi in tree_leaves(b))
+    maxiter = 10 * size  # copied from scipy
+
+  if M is None:
+    M = _identity
+
+  if tree_structure(x0) != tree_structure(b):
+    raise ValueError(
+        'x0 and b must have matching tree structure: '
+        f'{tree_structure(x0)} vs {tree_structure(b)}')
+
+  if _shapes(x0) != _shapes(b):
+    raise ValueError(
+        'arrays in x0 and b must have matching shapes: '
+        f'{_shapes(x0)} vs {_shapes(b)}')
+
+  isolve = partial(_isolve, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M)
+
+  real_valued = lambda x: not issubclass(x.dtype.type, np.complexfloating)
+  symmetric = all(map(real_valued, tree_leaves(b)))
+  x = lax.custom_linear_solve(
+    A, b, solve=isolve, transpose_solve=isolve, symmetric=symmetric)
+  info = None  # TODO(shoyer): return the real iteration count here
+  return x, info
 
 
 def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
@@ -143,34 +227,67 @@ def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
   scipy.sparse.linalg.cg
   jax.lax.custom_linear_solve
   """
-  if x0 is None:
-    x0 = tree_map(jnp.zeros_like, b)
 
-  b, x0 = device_put((b, x0))
+  return isolve(_cg_solve,
+                A=A, b=b, x0=x0, tol=tol, atol=atol,
+                maxiter=maxiter, M=M)
 
-  if maxiter is None:
-    size = sum(bi.size for bi in tree_leaves(b))
-    maxiter = 10 * size  # copied from scipy
 
-  if M is None:
-    M = _identity
+def bicgstab(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
+  """Use Bi-Conjugate Gradient Stable iteration to solve ``Ax = b``.
 
-  if tree_structure(x0) != tree_structure(b):
-    raise ValueError(
-        'x0 and b must have matching tree structure: '
-        f'{tree_structure(x0)} vs {tree_structure(b)}')
+  The numerics of JAX's ``bicgstab`` should exact match SciPy's
+  ``bicgstab`` (up to numerical precision), but note that the interface
+  is slightly different: you need to supply the linear operator ``A`` as
+  a function instead of a sparse matrix or ``LinearOperator``.
 
-  if _shapes(x0) != _shapes(b):
-    raise ValueError(
-        'arrays in x0 and b must have matching shapes: '
-        f'{_shapes(x0)} vs {_shapes(b)}')
+  Derivatives of ``bicgstab`` are implemented via implicit
+  differentiation with another ``bicgstab`` solve, rather than by
+  differentiating *through* the solver. They will be accurate only if
+  both solves converge.
 
-  cg_solve = partial(
-      _cg_solve, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M)
-  # real-valued positive-definite linear operators are symmetric
-  real_valued = lambda x: not issubclass(x.dtype.type, np.complexfloating)
-  symmetric = all(map(real_valued, tree_leaves(b)))
-  x = lax.custom_linear_solve(
-      A, b, solve=cg_solve, transpose_solve=cg_solve, symmetric=symmetric)
-  info = None  # TODO(shoyer): return the real iteration count here
-  return x, info
+  Parameters
+  ----------
+  A : function
+      Function that calculates the matrix-vector product ``Ax`` when called
+      like ``A(x)``. ``A`` must represent a hermitian, positive definite
+      matrix, and must return array(s) with the same structure and shape as its
+      argument.
+  b : array or tree of arrays
+      Right hand side of the linear system representing a single vector. Can be
+      stored as an array or Python container of array(s) with any shape.
+
+  Returns
+  -------
+  x : array or tree of arrays
+      The converged solution. Has the same structure as ``b``.
+  info : None
+      Placeholder for convergence information. In the future, JAX will report
+      the number of iterations when convergence is not achieved, like SciPy.
+
+  Other Parameters
+  ----------------
+  x0 : array
+      Starting guess for the solution. Must have the same structure as ``b``.
+  tol, atol : float, optional
+      Tolerances for convergence, ``norm(residual) <= max(tol*norm(b), atol)``.
+      We do not implement SciPy's "legacy" behavior, so JAX's tolerance will
+      differ from SciPy unless you explicitly pass ``atol`` to SciPy's ``cg``.
+  maxiter : integer
+      Maximum number of iterations.  Iteration will stop after maxiter
+      steps even if the specified tolerance has not been achieved.
+  M : function
+      Preconditioner for A.  The preconditioner should approximate the
+      inverse of A.  Effective preconditioning dramatically improves the
+      rate of convergence, which implies that fewer iterations are needed
+      to reach a given error tolerance.
+
+  See also
+  --------
+  scipy.sparse.linalg.cg
+  jax.lax.custom_linear_solve
+  """
+
+  return isolve(_bicgstab_solve,
+                A=A, b=b, x0=x0, tol=tol, atol=atol,
+                maxiter=maxiter, M=M)

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -28,6 +28,7 @@ import jax.scipy.sparse.linalg
 
 from jax.config import config
 config.parse_flags_with_absl()
+config.update("jax_enable_x64", True)
 
 float_types = [np.float32, np.float64]
 complex_types = [np.complex64, np.complex128]
@@ -54,23 +55,113 @@ def lax_bicgstab(A, b, M=None, rtol=1e-5, atol=0.0, **kwargs):
   A = partial(matmul_high_precision, A)
   if M is not None:
     M = partial(matmul_high_precision, M)
-  x, _ = jax.scipy.sparse.linalg.bicgstab(A, b, atol=atol, tol=rtol, M=M, **kwargs)
+  x, _ = jax.scipy.sparse.linalg.bicgstab(A, b, atol=atol, tol=rtol,
+                                          M=M, **kwargs)
   return x
 
 
 def scipy_cg(A, b, atol=0.0, **kwargs):
-  x, _ = scipy.sparse.linalg.cg(A, b, atol=atol, **kwargs)
+  x, info = scipy.sparse.linalg.cg(A, b, atol=atol, **kwargs)
   return x
 
 
 def scipy_bicgstab(A, b, atol=0.0, **kwargs):
-  x, _ = scipy.sparse.linalg.bicgstab(A, b, atol=atol, **kwargs)
+  x, info = scipy.sparse.linalg.bicgstab(A, b, atol=atol, **kwargs)
   return x
 
 
 def rand_sym_pos_def(rng, shape, dtype):
   matrix = np.eye(N=shape[0], dtype=dtype) + rng(shape, dtype)
   return matrix @ matrix.T.conj()
+
+
+def numpy_bicgstab(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=None):
+  A = partial(matmul_high_precision, A)
+  x0 = np.zeros_like(b) if x0 is None else x0
+  # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.bicgstab
+  bs = np.linalg.norm(b) ** 2
+  atol2 = jnp.maximum(np.square(tol) * bs, np.square(atol))
+
+  # https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method#Preconditioned_BiCGSTAB
+
+  _identity = (lambda x: x)
+  M = _identity if M is None else partial(matmul_high_precision, M)
+
+  def cond_fun(value):
+    x, r, *_, k = value
+    rs = np.vdot(r, r).real
+    return (rs > atol2) & (k < maxiter)
+
+  def body_fun(value):
+    x, r, rhat, alpha, omega, rho, p, q, k = value
+    rho_ = np.vdot(rhat, r)
+    beta = rho_ / rho * alpha / omega
+    p_ = r + beta * (p - (omega * q))
+    phat = M(p_)
+    q_ = A(phat)
+    alpha_ = rho_ / np.vdot(rhat, q_)
+    s = r - alpha_ * q_
+    if np.vdot(s, s).real < atol2:
+      return x + alpha_ * phat, s, rhat, alpha_, omega, rho_, p_, q_, k + 1
+    shat = M(s)
+    t = A(shat)
+    omega_ = np.vdot(t, s) / np.vdot(t, t)
+    x_ = x + alpha_ * phat + omega_ * shat
+    r_ = s - omega_ * t
+    return x_, r_, rhat, alpha_, omega_, rho_, p_, q_, k + 1
+
+  r0 = b - A(x0)
+  rho0 = alpha0 = omega0 = np.vdot(b, b) / np.vdot(b, b)
+  initial_value = (x0, r0, r0, alpha0, omega0, rho0, r0, r0, 0)
+
+  val = initial_value
+  while cond_fun(val):
+    val = body_fun(val)
+  x_final, *_ = val
+
+  return x_final
+
+
+def numpy_cg(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=None):
+  A = partial(matmul_high_precision, A)
+  x0 = np.zeros_like(b) if x0 is None else x0
+  # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
+  bs = np.linalg.norm(b) ** 2
+  atol2 = np.maximum(np.square(tol) * bs, np.square(atol))
+
+  # https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
+
+  _identity = (lambda x: x)
+  M = _identity if M is None else partial(matmul_high_precision, M)
+
+  def cond_fun(value):
+    x, r, gamma, p, k = value
+    rs = gamma if M is _identity else np.linalg.norm(r) ** 2
+    return (rs > atol2) & (k < maxiter)
+
+  def body_fun(value):
+    x, r, gamma, p, k = value
+    Ap = A(p)
+    alpha = gamma / np.vdot(p, Ap).real
+    x_ = x + alpha * p
+    r_ = r - alpha * Ap
+    z_ = M(r_)
+    gamma_ = np.vdot(r_, z_).real
+    beta_ = gamma_ / gamma
+    p_ = z_ + beta_ * p
+    return x_, r_, gamma_, p_, k + 1
+
+  r0 = b - A(x0)
+  p0 = z0 = M(r0)
+  gamma0 = np.vdot(r0, z0).real
+  initial_value = (x0, r0, gamma0, p0, 0)
+
+  val = initial_value
+  while cond_fun(val):
+    val = body_fun(val)
+  x_final, *_ = val
+
+  return x_final
 
 
 def poisson(shape, dtype):
@@ -87,18 +178,24 @@ def poisson(shape, dtype):
 class LaxBackedScipyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_shape={}_preconditioner={}".format(
+       "_shape={}_preconditioner={}_isolve={}".format(
             jtu.format_shape_dtype_string(shape, dtype),
-            preconditioner),
-       "shape": shape, "dtype": dtype, "preconditioner": preconditioner}
+            preconditioner, isolve[-1].__name__),
+       "shape": shape, "dtype": dtype, "preconditioner": preconditioner,
+        "isolve": isolve}
       for shape in [(4, 4), (7, 7), (32, 32)]
       for dtype in float_types + complex_types
-      for preconditioner in [None, 'identity', 'exact']))
+      for preconditioner in [None, 'identity', 'exact', 'random']
+      for isolve in [(scipy_bicgstab, lax_bicgstab), (scipy_cg, lax_cg)]))
   # TODO(#2951): reenable 'random' preconditioner.
-  def test_cg_against_scipy(self, shape, dtype, preconditioner):
+  def test_isolve_against_scipy(self, shape, dtype, preconditioner, isolve):
 
+    scipy_isolve, lax_isolve = isolve
     rng = jtu.rand_default(self.rng())
-    A = rand_sym_pos_def(rng, shape, dtype)
+    if lax_isolve == lax_cg:
+      A = rand_sym_pos_def(rng, shape, dtype)
+    else:
+      A = rng(shape, dtype)
     b = rng(shape[:1], dtype)
 
     if preconditioner == 'identity':
@@ -113,153 +210,124 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     def args_maker():
       return A, b
 
+    # sanity check with scipy first,
+    # then check against numpy if agree
+    # exposes some testing issues...
+    expected = np.linalg.solve(A, b)
+    scipy_result = scipy_isolve(A, b, M=M)
+    if np.allclose(expected, scipy_result, rtol=2e-2):
+      self._CheckAgainstNumpy(
+        np.linalg.solve,
+        partial(lax_isolve, M=M, atol=1e-6),
+        args_maker,
+        tol=2e-2)
+    else:
+      max_adiff = np.max(np.abs(expected - scipy_result))
+      max_rdiff = np.max(np.abs(expected - scipy_result) / np.abs(expected))
+      print(
+        'scipy/numpy differ abs: {}, rel: {}'.format(max_adiff, max_rdiff))
+
     self._CheckAgainstNumpy(
-        partial(scipy_cg, M=M, maxiter=1),
-        partial(lax_cg, M=M, maxiter=1),
+        partial(scipy_isolve, M=M, maxiter=1),
+        partial(lax_isolve, M=M, maxiter=1),
         args_maker,
         tol=1e-3)
 
     # TODO(shoyer,mattjj): I had to loosen the tolerance for complex64[7,7]
-    # with preconditioner=random
+    #  with preconditioner=random
     self._CheckAgainstNumpy(
-        partial(scipy_cg, M=M, maxiter=3),
-        partial(lax_cg, M=M, maxiter=3),
-        args_maker,
-        tol=3e-3)
-
-    self._CheckAgainstNumpy(
-        np.linalg.solve,
-        partial(lax_cg, M=M, atol=1e-6),
-        args_maker,
-        tol=2e-2)
+      partial(scipy_isolve, M=M, maxiter=3),
+      partial(lax_isolve, M=M, maxiter=3),
+      args_maker,
+      tol=3e-3)
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-          "_shape={}_preconditioner={}".format(
-              jtu.format_shape_dtype_string(shape, dtype),
-              preconditioner),
-          "shape": shape, "dtype": dtype, "preconditioner": preconditioner}
-      for shape in [(4, 4), (7, 7), (32, 32)]
-      for dtype in float_types + complex_types
-      for preconditioner in [None, 'identity', 'exact']))
-  def test_bicgstab_against_scipy(self, shape, dtype, preconditioner):
-
-    rng = jtu.rand_default(self.rng())
-    A = poisson(shape, dtype)  # use scipy's test to check bicgstab instead of random matrix
-    # A = rand_sym_pos_def(rng, shape, dtype)
-    b = rng(shape[:1], dtype)
-
-    if preconditioner == 'identity':
-      M = np.eye(shape[0], dtype=dtype)
-    elif preconditioner == 'exact':
-      M = np.linalg.inv(A)
-    else:
-      M = None
-
-    def args_maker():
-      return A, b
-
-    self._CheckAgainstNumpy(
-        partial(scipy_bicgstab, M=M, maxiter=1),
-        partial(lax_bicgstab, M=M, maxiter=1),
-        args_maker,
-        tol=1e-3)
-
-    self._CheckAgainstNumpy(
-        partial(scipy_bicgstab, M=M, maxiter=3),
-        partial(lax_bicgstab, M=M, maxiter=3),
-        args_maker,
-        tol=3e-3)
-
-    self._CheckAgainstNumpy(
-        np.linalg.solve,
-        partial(lax_bicgstab, M=M, atol=1e-6),
-        args_maker,
-        tol=2e-2)
-
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
+       "_shape={}_isolve={}".format(jtu.format_shape_dtype_string(shape, dtype),
+                                    isolve[1].__name__),
+       "shape": shape, "dtype": dtype, "isolve": isolve}
       for shape in [(2, 2)]
-      for dtype in float_types + complex_types))
-  def test_cg_as_solve(self, shape, dtype):
+      for dtype in float_types + complex_types
+      for isolve in [(scipy_bicgstab, lax_bicgstab), (scipy_cg, lax_cg)]))
+  def test_isolve_as_solve(self, shape, dtype, isolve):
     rng = jtu.rand_default(self.rng())
     a = rng(shape, dtype)
+    a = posify(a) if isolve[1] == lax_cg else a
     b = rng(shape[:1], dtype)
 
-    expected = np.linalg.solve(posify(a), b)
-    actual = lax_cg(posify(a), b)
-    self.assertAllClose(expected, actual)
+    scipy_isolve, lax_isolve = isolve
 
-    actual = jit(lax_cg)(posify(a), b)
-    self.assertAllClose(expected, actual)
+    expected = np.linalg.solve(a, b)
 
-    # numerical gradients are only well defined if ``a`` is guaranteed to be
-    # positive definite.
+    # test lax second to double check that it matches with scipy
+    actual = lax_isolve(a, b)
+    self.assertAllClose(expected, actual, rtol=1e-5)
+
+    # check jit compilation
+    actual = jit(lax_isolve)(a, b)
+    self.assertAllClose(expected, actual, rtol=1e-5)
+
     jtu.check_grads(
-        lambda x, y: lax_cg(posify(x), y),
-        (a, b), order=2, rtol=1e-2)
+        lambda x, y: lax_isolve(x, y),
+        (a, b), order=2, rtol=3e-2)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-          "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in [(2, 2)]
-      for dtype in float_types + complex_types))
-  def test_bicgstab_as_solve(self, shape, dtype):
-    rng = jtu.rand_default(self.rng())
-    a = poisson(shape, dtype)  # TODO(sunilkpai): random doesn't work (bicg numerics), so using poisson instead...
-    # a = rng(shape, dtype)
-    b = rng(shape[:1], dtype)
-
-    expected = np.linalg.solve(a, b)
-    actual = lax_bicgstab(a, b)
-    self.assertAllClose(expected, actual)
-
-    actual = jit(lax_bicgstab)(a, b)
-    self.assertAllClose(expected, actual)
-
-    jtu.check_grads(
-      lambda x, y: lax_bicgstab(a, y),
-      (a, b), order=2, rtol=3e-2)  # needed to loosen the tolerance here as well for complex128...
-
-  def test_cg_ndarray(self):
+           "isolve={}".format(isolve.__name__), "isolve": isolve}
+      for isolve in [jax.scipy.sparse.linalg.bicgstab,
+                     jax.scipy.sparse.linalg.cg]))
+  def test_isolve_ndarray(self, isolve):
     A = lambda x: 2 * x
     b = jnp.arange(9.0).reshape((3, 3))
     expected = b / 2
-    actual, _ = jax.scipy.sparse.linalg.cg(A, b)
+    actual, _ = isolve(A, b)
     self.assertAllClose(expected, actual)
 
-  def test_cg_pytree(self):
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+           "isolve={}".format(isolve.__name__), "isolve": isolve}
+      for isolve in [jax.scipy.sparse.linalg.bicgstab,
+                     jax.scipy.sparse.linalg.cg]))
+  def test_isolve_pytree(self, isolve):
     A = lambda x: {"a": x["a"] + 0.5 * x["b"], "b": 0.5 * x["a"] + x["b"]}
     b = {"a": 1.0, "b": -4.0}
     expected = {"a": 4.0, "b": -6.0}
-    actual, _ = jax.scipy.sparse.linalg.cg(A, b)
+    actual, _ = isolve(A, b)
     self.assertEqual(expected.keys(), actual.keys())
     self.assertAlmostEqual(expected["a"], actual["a"], places=6)
     self.assertAlmostEqual(expected["b"], actual["b"], places=6)
 
-  def test_cg_errors(self):
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+           "isolve={}".format(isolve.__name__), "isolve": isolve}
+      for isolve in [jax.scipy.sparse.linalg.bicgstab,
+                     jax.scipy.sparse.linalg.cg]))
+  def test_isolve_errors(self, isolve):
     A = lambda x: x
     b = jnp.zeros((2,))
     with self.assertRaisesRegex(
         ValueError, "x0 and b must have matching tree structure"):
-      jax.scipy.sparse.linalg.cg(A, {'x': b}, {'y': b})
+      isolve(A, {'x': b}, {'y': b})
     with self.assertRaisesRegex(
         ValueError, "x0 and b must have matching shape"):
-      jax.scipy.sparse.linalg.cg(A, b, b[:, np.newaxis])
+      isolve(A, b, b[:, np.newaxis])
 
-  def test_cg_without_pytree_equality(self):
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+           "isolve={}".format(isolve.__name__), "isolve": isolve}
+      for isolve in [jax.scipy.sparse.linalg.bicgstab,
+                     jax.scipy.sparse.linalg.cg]))
+  def test_isolve_without_pytree_equality(self, isolve):
 
     @register_pytree_node_class
     class MinimalPytree:
       def __init__(self, value):
         self.value = value
+
       def tree_flatten(self):
         return [self.value], None
+
       @classmethod
       def tree_unflatten(cls, aux_data, children):
         return cls(*children)
@@ -267,45 +335,9 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     A = lambda x: MinimalPytree(2 * x.value)
     b = MinimalPytree(jnp.arange(5.0))
     expected = b.value / 2
-    actual, _ = jax.scipy.sparse.linalg.cg(A, b)
+    actual, _ = isolve(A, b)
     self.assertAllClose(expected, actual.value)
 
-  def test_bicgstab_pytree(self):
-    A = lambda x: {"a": x["a"] + 0.5 * x["b"], "b": 0.5 * x["a"] + x["b"]}
-    b = {"a": 1.0, "b": -4.0}
-    expected = {"a": 4.0, "b": -6.0}
-    actual, _ = jax.scipy.sparse.linalg.bicgstab(A, b)
-    self.assertEqual(expected.keys(), actual.keys())
-    self.assertAlmostEqual(expected["a"], actual["a"], places=6)
-    self.assertAlmostEqual(expected["b"], actual["b"], places=6)
-
-  def test_bicgstab_errors(self):
-    A = lambda x: x
-    b = jnp.zeros((2,))
-    with self.assertRaisesRegex(
-        ValueError, "x0 and b must have matching tree structure"):
-      jax.scipy.sparse.linalg.bicgstab(A, {'x': b}, {'y': b})
-    with self.assertRaisesRegex(
-        ValueError, "x0 and b must have matching shape"):
-      jax.scipy.sparse.linalg.bicgstab(A, b, b[:, np.newaxis])
-
-  def test_bicgstab_without_pytree_equality(self):
-
-    @register_pytree_node_class
-    class MinimalPytree:
-      def __init__(self, value):
-        self.value = value
-      def tree_flatten(self):
-        return [self.value], None
-      @classmethod
-      def tree_unflatten(cls, aux_data, children):
-        return cls(*children)
-
-    A = lambda x: MinimalPytree(2 * x.value)
-    b = MinimalPytree(jnp.arange(5.0))
-    expected = b.value / 2
-    actual, _ = jax.scipy.sparse.linalg.bicgstab(A, b)
-    self.assertAllClose(expected, actual.value)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
I am working on the `bicgstab` implementation (using the current pytree convention in `cg`); I am most of the way there as the implementation was very similar to cg and the tests generally seem to work. This addresses one of the goals of #1531.

Before finalizing this PR, there are some points of confusion on the tests that have to do with numerical issues in iterative solvers. I would like some advice on this before proceeding.

1. If you use a iterative solver, you only get the correct answer up to some tolerance. This makes gradient checking harder and different from a lot of the other more predictable behaviors in `jax`. I noticed the biggest shape in the gradient tests `*_solve` is `(2, 2)`, and when I checked larger shapes, there was an error (depending on the type, either array not equal or grad check failure)! What is the general consensus on testing with respect to gradient checks, especially for these approximate solvers?
2. Mid-iteration convergence and breakdown checks may require some special implementation of loops. To truly match `scipy` for `cg` and `bicgstab` more generally, I think this will need to be implemented somehow. I have a TODO comment somewhere in this PR explaining how it would be implemented if `jit` were not a requirement.

I also want to make sure that the changes I made to `cg` to avoid code duplication are kosher.