### PR TITLE
Enable buffer donation for GPU.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -795,7 +795,7 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
   else:
     out_tuple = build_out_tuple()
   backend = xb.get_backend(backend)
-  if backend.platform == "tpu":
+  if backend.platform in ("gpu", "tpu"):
     donated_invars = xla.set_up_aliases(c, xla_args, out_tuple, donated_invars, tuple_args)
   built = c.Build(out_tuple)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -648,7 +648,7 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
       extend_name_stack(wrap_name(name, 'jit')), *xla_args)
   out_tuple = xops.Tuple(c, out_nodes)
   backend = xb.get_backend(backend)
-  if backend.platform == "tpu":
+  if backend.platform in ("gpu", "tpu"):
     donated_invars = set_up_aliases(c, xla_args, out_tuple, donated_invars, tuple_args)
   if any(donated_invars):
     # TODO(tomhennigan): At call time we should mark these buffers as deleted.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3229,16 +3229,17 @@ class BufferDonationTest(jtu.JaxTestCase):
           "Some donated buffers were not usable: f32[2]{0}, s32[2]{0}",
           str(w[-1].message))
 
-  @jtu.skip_on_devices("cpu", "gpu")  # In/out aliasing only supported on TPU.
+  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
   def test_jit_donate_argnums_invalidates_input(self):
-    # We can't just use `lambda x: x` because JAX simplifies this away.
+    # We can't just use `lambda x: x` because JAX simplifies this away to an
+    # empty XLA computation.
     move = jit(lambda x: x + x - x, donate_argnums=0)
     x = jnp.ones([])
     y = move(x)
     self.assertDeleted(x)
     self.assertEqual(y, 1.)
 
-  @jtu.skip_on_devices("cpu", "gpu")  # In/out aliasing only supported on TPU.
+  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
   def test_jit_donate_argnums_static_argnums(self):
     jit_fun = jit(lambda a, b, c, d: ((a + b + c), (a + b + d)),
                   static_argnums=(0, 1), donate_argnums=(2, 3))
@@ -3284,7 +3285,7 @@ class BufferDonationTest(jtu.JaxTestCase):
 
   # === pmap ===
 
-  @jtu.skip_on_devices("cpu", "gpu")  # In/out aliasing only supported on TPU.
+  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
   def test_pmap_donate_argnums_invalidates_input(self):
     move = api.pmap(lambda x: x + x - x, donate_argnums=0)
     n = jax.local_device_count()


### PR DESCRIPTION
XLA:GPU now supports Jax buffer donation, this PR enables using `donate_argnums` to do buffer donation on GPU.