### PR TITLE
Add support for base dilation and window dilation to reduce window op…

### DIFF
--- a/jax/experimental/stax.py
+++ b/jax/experimental/stax.py
@@ -176,8 +176,9 @@ def _pooling_layer(reducer, init_val, rescaler=None):
     def init_fun(rng, input_shape):
       padding_vals = lax.padtype_to_pads(input_shape, window_shape,
                                          strides, padding)
-      out_shape = lax.reduce_window_shape_tuple(input_shape, window_shape,
-                                                strides, padding_vals)
+      ones = (1,) * len(window_shape)
+      out_shape = lax.reduce_window_shape_tuple(
+        input_shape, window_shape, strides, padding_vals, ones, ones)
       return out_shape, ()
     def apply_fun(params, inputs, **kwargs):
       out = lax.reduce_window(inputs, init_val, reducer, window_shape,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4697,9 +4697,12 @@ def _common_reduce_window_shape_rule(operand, window_dimensions,
                                    window_dilation)
 
 def reduce_window_shape_tuple(operand_shape, window_dimensions, window_strides,
-                              padding, base_dilation, window_dilation):
-  operand_shape = _dilate_shape(operand_shape, base_dilation)
-  window_dimensions = _dilate_shape(window_dimensions, window_dilation)
+                              padding, base_dilation=None,
+                              window_dilation=None):
+  if base_dilation is not None:
+    operand_shape = _dilate_shape(operand_shape, base_dilation)
+  if window_dilation is not None:
+    window_dimensions = _dilate_shape(window_dimensions, window_dilation)
   operand_padded = np.add(operand_shape, np.add(*zip(*padding)))
   t = np.floor_divide(
       np.subtract(operand_padded, window_dimensions), window_strides) + 1

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1132,8 +1132,12 @@ def _get_monoid_window_reducer(monoid_op: Callable, x: Array) -> Optional[Callab
 def _reduce_window_sum(operand: Array, window_dimensions: Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[Tuple[int, int]],
-                       base_dilation: Sequence[int],
-                       window_dilation: Sequence[int]) -> Array:
+                       base_dilation: Optional[Sequence[int]] = None,
+                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+  if base_dilation is None:
+    base_dilation = (1,) * len(window_dimensions)
+  if window_dilation is None:
+    window_dilation = (1,) * len(window_dimensions)
   return reduce_window_sum_p.bind(
       operand, window_dimensions=tuple(window_dimensions),
       window_strides=tuple(window_strides), padding=tuple(padding),
@@ -1143,10 +1147,14 @@ def _reduce_window_sum(operand: Array, window_dimensions: Shape,
 def _reduce_window_prod(operand: Array, window_dimensions: Shape,
                         window_strides: Sequence[int],
                         padding: Sequence[Tuple[int, int]],
-                        base_dilation: Sequence[int],
-                        window_dilation: Sequence[int]) -> Array:
+                        base_dilation: Optional[Sequence[int]] = None,
+                        window_dilation: Optional[Sequence[int]] = None) -> Array:
   init_value = _const(operand, 1)
   jaxpr, consts = _reduction_jaxpr(mul, _abstractify(init_value))
+  if base_dilation is None:
+    base_dilation = (1,) * len(window_dimensions)
+  if window_dilation is None:
+    window_dilation = (1,) * len(window_dimensions)
   return reduce_window_p.bind(
       operand, init_value, jaxpr=jaxpr, consts=consts,
       window_dimensions=tuple(window_dimensions),
@@ -1157,8 +1165,12 @@ def _reduce_window_prod(operand: Array, window_dimensions: Shape,
 def _reduce_window_max(operand: Array, window_dimensions: Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[Tuple[int, int]],
-                       base_dilation: Sequence[int],
-                       window_dilation: Sequence[int]) -> Array:
+                       base_dilation: Optional[Sequence[int]] = None,
+                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+  if base_dilation is None:
+    base_dilation = (1,) * len(window_dimensions)
+  if window_dilation is None:
+    window_dilation = (1,) * len(window_dimensions)
   return reduce_window_max_p.bind(
       operand, window_dimensions=tuple(window_dimensions),
       window_strides=tuple(window_strides), padding=tuple(padding),
@@ -1168,8 +1180,12 @@ def _reduce_window_max(operand: Array, window_dimensions: Shape,
 def _reduce_window_min(operand: Array, window_dimensions: Shape,
                        window_strides: Sequence[int],
                        padding: Sequence[Tuple[int, int]],
-                       base_dilation: Sequence[int],
-                       window_dilation: Sequence[int]) -> Array:
+                       base_dilation: Optional[Sequence[int]] = None,
+                       window_dilation: Optional[Sequence[int]] = None) -> Array:
+  if base_dilation is None:
+    base_dilation = (1,) * len(window_dimensions)
+  if window_dilation is None:
+    window_dilation = (1,) * len(window_dimensions)
   return reduce_window_min_p.bind(
       operand, window_dimensions=tuple(window_dimensions),
       window_strides=tuple(window_strides), padding=tuple(padding),

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -181,8 +181,15 @@ def inner_prod(xs, ys):
   return tree_reduce(np.add, tree_multimap(contract, xs, ys))
 
 
+def _safe_subtract(x, y, *, dtype):
+  """Subtraction that with `inf - inf == 0` semantics."""
+  with np.errstate(invalid='ignore'):
+    return np.where(np.equal(x, y), 0, np.subtract(x, y, dtype=dtype))
+
 add = partial(tree_multimap, lambda x, y: np.add(x, y, dtype=_dtype(x)))
 sub = partial(tree_multimap, lambda x, y: np.subtract(x, y, dtype=_dtype(x)))
+safe_sub = partial(tree_multimap,
+                   lambda x, y: _safe_subtract(x, y, dtype=_dtype(x)))
 conj = partial(tree_map, lambda x: np.conj(x, dtype=_dtype(x)))
 
 def scalar_mul(xs, a):
@@ -203,7 +210,7 @@ def numerical_jvp(f, primals, tangents, eps=EPS):
   delta = scalar_mul(tangents, eps)
   f_pos = f(*add(primals, delta))
   f_neg = f(*sub(primals, delta))
-  return scalar_mul(sub(f_pos, f_neg), 0.5 / eps)
+  return scalar_mul(safe_sub(f_pos, f_neg), 0.5 / eps)
 
 
 def _merge_tolerance(tol, default):

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -184,7 +184,8 @@ def inner_prod(xs, ys):
 def _safe_subtract(x, y, *, dtype):
   """Subtraction that with `inf - inf == 0` semantics."""
   with np.errstate(invalid='ignore'):
-    return np.where(np.equal(x, y), 0, np.subtract(x, y, dtype=dtype))
+    return np.where(np.equal(x, y), np.array(0, dtype),
+                    np.subtract(x, y, dtype=dtype))
 
 add = partial(tree_multimap, lambda x, y: np.add(x, y, dtype=_dtype(x)))
 sub = partial(tree_multimap, lambda x, y: np.subtract(x, y, dtype=_dtype(x)))

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -671,63 +671,74 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       check_grads(reduce, (operand,), 2, ["fwd", "rev"], tol, tol, eps)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_dtype={}_padding={}"
-       .format(op.__name__, np.dtype(dtype).name, padding),
-       "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
+      {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
+                         "_basedilation={}_windowdilation={}")
+       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims,
+               strides, padding, base_dilation, window_dilation),
+       "op": op, "init_val": init_val, "dtype": dtype, "shape": shape,
+       "dims": dims, "strides": strides, "padding": padding,
+       "base_dilation": base_dilation, "window_dilation": window_dilation,
        "rng_factory": rng_factory}
       for init_val, op, dtypes, rng_factory in [
           (0, lax.add, grad_float_dtypes, jtu.rand_small),
           (-np.inf, lax.max, grad_float_dtypes, jtu.rand_unique_int),
           (np.inf, lax.min, grad_float_dtypes, jtu.rand_unique_int),
       ]
-      for dtype in dtypes
-      for padding in ["VALID", "SAME"]))
-  @jtu.skip_on_flag("jax_skip_slow_tests", True)
+      for shape, dims, strides, padding, base_dilation, window_dilation in (
+        itertools.chain(
+          itertools.product(
+            [(4, 6)],
+            [(2, 1), (1, 2)],
+            [(1, 1), (2, 1), (1, 2)],
+            # TODO(b/161704903): explicit paddings segfault on CPU.
+            ["VALID", "SAME"], #, [(0, 3), (1, 2)]],
+            [(1, 1)] + ([(2, 3)] if op is lax.add else []),
+            [(1, 1)] + ([(1, 2)] if op is lax.add else [])),
+          itertools.product(
+            [(3, 2, 4, 6)],
+            [(1, 1, 2, 1), (2, 1, 2, 1)],
+            [(1, 2, 2, 1), (1, 1, 1, 1)],
+            # TODO(b/161704903): explicit paddings segfault on CPU.
+            ["VALID", "SAME"], # [(0, 1), (1, 0), (2, 3), (0, 2)]],
+            [(1, 1, 1, 1)] + ([(2, 1, 3, 2)] if op is lax.add else []),
+            [(1, 1, 1, 1)] + ([(1, 2, 2, 1)] if op is lax.add else []))))
+      for dtype in dtypes))
   @jtu.ignore_warning(category=UserWarning,
                       message="Using reduced precision for gradient.*")
-  def testReduceWindowGrad(self, op, init_val, dtype, padding, rng_factory):
+  def testReduceWindowGrad(
+      self, op, init_val, dtype, shape, dims, strides,
+      padding, base_dilation, window_dilation, rng_factory):
     rng = rng_factory(self.rng())
     init_val = np.asarray(init_val, dtype=dtype)
 
+    gradient_order = 3
     # We need this conditional and the corresponding loop logic to be in the
     # test method, rather than at the parameterized test level, because it
     # depends on FLAGS for the device under test.
     # TODO(b/31565929): enable when fixed.
     if jtu.device_under_test() == "tpu" and op is not lax.add:
-      all_configs = [((6, 5, 4, 3), (2, 2, 1, 1), (1, 2, 1, 1))]
+      if len(shape) != 4:
+        raise SkipTest("Only R4 SelectAndScatter implemented on TPU")
 
       # TODO(b/73062247): need variadic reduce-window for better precision.
       gradient_order = 1
-    else:
-      all_configs = itertools.chain(
-          itertools.product(
-              [(4, 6)],  # shapes
-              [(2, 1), (1, 2)],  # window_dimensions
-              [(1, 1), (2, 1), (1, 2)]  # strides
-          ),
-          itertools.product(
-              [(3, 2, 4, 6)],  # shapes
-              [(1, 1, 2, 1), (2, 1, 2, 1)],  # window_dimensions
-              [(1, 2, 2, 1), (1, 1, 1, 1)]),  # strides
-      )
-      gradient_order = 3
 
     def fun(operand):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding)
+      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
+                               base_dilation, window_dilation)
 
-    for shape, dims, strides in all_configs:
-      operand = rng(shape, dtype)
-      if op is lax.add:
-        eps = 1.
-        tol = None
-      else:
-        # this test can fail if there are duplicates in operand
-        self.assertEqual(np.unique(operand).size, operand.size,
-                         msg="test requires operand elements to be unique.")
-        eps = 1e-2
-        tol = {np.float16: 1e-1, np.float32: 6e-2, np.float64: 6e-2}
-      check_grads(fun, (operand,), gradient_order, ["fwd", "rev"], tol, tol,
-                  eps)
+    operand = rng(shape, dtype)
+    if op is lax.add:
+      eps = 1.
+      tol = None
+    else:
+      # this test can fail if there are duplicates in operand
+      self.assertEqual(np.unique(operand).size, operand.size,
+                       msg="test requires operand elements to be unique.")
+      eps = 1e-2
+      tol = {np.float16: 1e-1, np.float32: 6e-2, np.float64: 6e-2}
+    check_grads(fun, (operand,), gradient_order, ["fwd", "rev"], tol, tol,
+                eps)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}"

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -717,7 +717,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     # depends on FLAGS for the device under test.
     # TODO(b/31565929): enable when fixed.
     if jtu.device_under_test() == "tpu" and op is not lax.add:
-      if len(shape) != 4:
+      if len(shape) != 4 or dims != (1, 1, 2, 1):
         raise SkipTest("Only R4 SelectAndScatter implemented on TPU")
 
       # TODO(b/73062247): need variadic reduce-window for better precision.

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1302,56 +1302,60 @@ class LaxTest(jtu.JaxTestCase):
     self._CompileAndCheck(fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_dtype={}"
-       .format(op.__name__, np.dtype(dtype).name,),
-       "op": op, "init_val": init_val, "dtype": dtype,
-       "rng_factory": rng_factory}
+      {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
+                         "_basedilation={}_windowdilation={}")
+       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype),
+               dims, strides, padding, base_dilation, window_dilation),
+       "op": op, "init_val": init_val, "dtype": dtype, "shape": shape,
+       "dims": dims, "strides": strides, "padding": padding,
+       "base_dilation": base_dilation, "window_dilation": window_dilation}
       for init_val, op, dtypes in [
           (0, lax.add, [np.float32]),
           (-np.inf, lax.max, [np.float32]),
           (np.inf, lax.min, [np.float32]),
       ]
-      for dtype in dtypes
-      for rng_factory in [jtu.rand_small]))
-  def testReduceWindow(self, op, init_val, dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    init_val = np.asarray(init_val, dtype=dtype)
-
-    all_configs = list(itertools.chain(
-        itertools.product(
+      for shape, dims, strides, padding, base_dilation, window_dilation in (
+        itertools.chain(
+          itertools.product(
             [(4, 6)],
             [(2, 1), (1, 2)],
             [(1, 1), (2, 1), (1, 2)],
-            ["VALID", "SAME", [(0, 3), (1, 2)]]),
-        itertools.product(
+            ["VALID", "SAME", [(0, 3), (1, 2)]],
+            [(1, 1), (2, 3)],
+            [(1, 1), (1, 2)]),
+          itertools.product(
             [(3, 2, 4, 6)], [(1, 1, 2, 1), (2, 1, 2, 1)],
             [(1, 2, 2, 1), (1, 1, 1, 1)],
-            ["VALID", "SAME", [(0, 1), (1, 0), (2, 3), (0, 2)]])))
+            ["VALID", "SAME", [(0, 1), (1, 0), (2, 3), (0, 2)]],
+            [(1, 1, 1, 1), (2, 1, 3, 2)],
+            [(1, 1, 1, 1), (1, 2, 2, 1)])))
+      for dtype in dtypes))
+  def testReduceWindow(self, op, init_val, dtype, shape, dims, strides, padding,
+                       base_dilation, window_dilation):
+    rng = jtu.rand_small(self.rng())
+    init_val = np.asarray(init_val, dtype=dtype)
 
     def fun(operand, init_val):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding)
+      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
+                               base_dilation, window_dilation)
 
     def reference_fun(operand, init_val):
       return lax_reference.reduce_window(operand, init_val, op, dims, strides,
-                                         padding)
+                                         padding, base_dilation)
 
-    # pylint: disable=cell-var-from-loop
-    for shape, dims, strides, padding in all_configs:
-      args_maker = lambda: [rng(shape, dtype), init_val]
-      self._CompileAndCheck(fun, args_maker)
+    args_maker = lambda: [rng(shape, dtype), init_val]
+    self._CompileAndCheck(fun, args_maker)
+    if all(d == 1 for d in window_dilation):
       self._CheckAgainstNumpy(fun, reference_fun, args_maker)
-    # pylint: enable=cell-var-from-loop
 
     # we separately test the version that uses a concrete init_val because it
     # can hit different code paths
     def fun(operand):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding)
+      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
+                               base_dilation, window_dilation)
 
-    # pylint: disable=cell-var-from-loop
-    for shape, dims, strides, padding in all_configs:
-      args_maker = lambda: [rng(shape, dtype)]
-      self._CompileAndCheck(fun, args_maker)
-    # pylint: enable=cell-var-from-loop
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CompileAndCheck(fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}"

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -500,37 +500,45 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(fun, 5, bdims, (shape,), (dtype,), rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_dtype={}_padding={}"
-       .format(op.__name__, np.dtype(dtype).name, padding),
-       "op": op, "init_val": init_val, "dtype": dtype, "padding": padding,
-       "rng_factory": rng_factory}
+      {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
+                         "_basedilation={}_windowdilation={}")
+       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype),
+               dims, strides, padding, base_dilation, window_dilation),
+       "op": op, "init_val": init_val, "dtype": dtype, "shape": shape,
+       "dims": dims, "strides": strides, "padding": padding,
+       "base_dilation": base_dilation, "window_dilation": window_dilation}
       for init_val, op, dtypes in [
           (0, lax.add, [np.float32]),
           (-np.inf, lax.max, [np.float32]),
           (np.inf, lax.min, [np.float32]),
       ]
-      for dtype in dtypes
-      for padding in ["VALID", "SAME"]
-      for rng_factory in [jtu.rand_small]))
-  def testReduceWindow(self, op, init_val, dtype, padding, rng_factory):
-    rng = rng_factory(self.rng())
-    init_val = np.asarray(init_val, dtype=dtype)
-
-    all_configs = itertools.chain(
-        itertools.product(
+      for shape, dims, strides, padding, base_dilation, window_dilation in (
+        itertools.chain(
+          itertools.product(
             [(4, 6)],
             [(2, 1), (1, 2)],
-            [(1, 1), (2, 1), (1, 2)]),
-        itertools.product(
+            [(1, 1), (2, 1), (1, 2)],
+            ["VALID", "SAME", [(0, 3), (1, 2)]],
+            [(1, 1), (2, 3)],
+            [(1, 1), (1, 2)]),
+          itertools.product(
             [(3, 2, 4, 6)], [(1, 1, 2, 1), (2, 1, 2, 1)],
-            [(1, 2, 2, 1), (1, 1, 1, 1)]))
+            [(1, 2, 2, 1), (1, 1, 1, 1)],
+            ["VALID", "SAME", [(0, 1), (1, 0), (2, 3), (0, 2)]],
+            [(1, 1, 1, 1), (2, 1, 3, 2)],
+            [(1, 1, 1, 1), (1, 2, 2, 1)])))
+      for dtype in dtypes))
+  def testReduceWindow(self, op, init_val, dtype, shape, dims, strides, padding,
+                       base_dilation, window_dilation):
+    rng = jtu.rand_small(self.rng())
+    init_val = np.asarray(init_val, dtype=dtype)
 
     def fun(operand):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding)
+      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
+                               base_dilation, window_dilation)
 
-    for shape, dims, strides in all_configs:
-      for bdims in all_bdims(shape):
-        self._CheckBatching(fun, 3, bdims, (shape,), (dtype,), rng)
+    for bdims in all_bdims(shape):
+      self._CheckBatching(fun, 3, bdims, (shape,), (dtype,), rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}_bdims={}"

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -586,8 +586,9 @@ class LaxVmapTest(jtu.JaxTestCase):
 
     def fun(operand, tangents):
       pads = lax.padtype_to_pads(operand.shape, dims, strides, padding)
+      ones = (1,) * len(operand.shape)
       return lax._select_and_gather_add(operand, tangents, lax.ge_p, dims,
-                                        strides, pads)
+                                        strides, pads, ones, ones)
 
     for shape, dims, strides in all_configs:
       for bdims in all_bdims(shape, shape):


### PR DESCRIPTION
…erators.

Refactor reduce-window tests to use many generated cases instead of a single large test case with a loop.

Treat `inf - inf` as a zero difference in gradient tests.

Fixes #3793 