### PR TITLE
tweak jnp.repeat not to use jnp on shapes

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2546,13 +2546,14 @@ def repeat(a, repeats, axis=None, *, total_repeat_length=None):
   # If total_repeat_length is not given, can't compile, use a default.
   if total_repeat_length is None:
     repeats = core.concrete_or_error(np.array, repeats, "jax.numpy.repeat")
+    repeats = np.ravel(repeats)
     if ndim(a) != 0:
       repeats = np.broadcast_to(repeats, [a.shape[axis]])
     total_repeat_length = np.sum(repeats)
   else:
+    repeats = ravel(repeats)
     if ndim(a) != 0:
       repeats = broadcast_to(repeats, [a.shape[axis]])
-    repeats = ravel(repeats)
 
   # Special case when a is a scalar.
   if ndim(a) == 0:


### PR DESCRIPTION
The main goal here is to avoid using `jax.numpy` for shape computations, since it's a performance bug now (doing small integer operations on an accelerator) and will become an error after #3370. I also removed a test utility function in favor of just calling `numpy.repeat` directly.