### PR TITLE
DeviceArray.__iter__ returns DeviceArrays, without host sync

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5624,6 +5624,22 @@ def _multi_slice(arr,
 setattr(_DeviceArray, "_multi_slice", _multi_slice)
 setattr(_CppDeviceArray, "_multi_slice", _multi_slice)
 
+# The next two functions are related to iter(device_array), implemented here to
+# avoid circular imports.
+@jit
+def _unstack(x):
+  return [lax.index_in_dim(x, i, keepdims=False) for i in range(x.shape[0])]
+setattr(DeviceArray, "_unstack", _unstack)
+def _chunk_iter(x, size):
+  if size > x.shape[0]:
+    yield x
+  else:
+    num_chunks, tail = divmod(x.shape[0], size)
+    for i in range(num_chunks):
+      yield lax.dynamic_slice_in_dim(x, i * size, size)
+    if tail:
+      yield lax.dynamic_slice_in_dim(x, num_chunks * size, tail)
+setattr(DeviceArray, "_chunk_iter", _chunk_iter)
 
 # Syntactic sugar for scatter operations.
 class _IndexUpdateHelper:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -562,7 +562,19 @@ class ShardedDeviceArray(xla.DeviceArray):  # type: ignore
         buf = self.device_buffers[buf_idx]
         aval = ShapedArray(buf.xla_shape().dimensions(), self.aval.dtype)
         return xla.make_device_array(aval, None, buf)
-    return xla.DeviceArray.__getitem__(self, idx)
+    return super().__getitem__(idx)
+
+  def __iter__(self):
+    if self.ndim == 0:
+      raise TypeError("iteration over a 0-d array")  # same as numpy error
+    else:
+      return (self[i] for i in range(self.shape[0]))
+
+  def __reversed__(self):
+    if self.ndim == 0:
+      raise TypeError("iteration over a 0-d array")  # same as numpy error
+    else:
+      return (self[i] for i in range(self.shape[0] - 1, -1, -1))
 
 
 def _hashable_index(idx):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1986,7 +1986,7 @@ class APITest(jtu.JaxTestCase):
     self.assertStartsWith(repr(rep), "DeviceArray")
 
   def test_device_array_hash(self):
-    rep = jnp.ones(()) + 1.
+    rep = jnp.ones((1,)) + 1.
     self.assertIsInstance(rep, jax.interpreters.xla.DeviceArray)
     msg = "JAX DeviceArray, like numpy.ndarray, is not hashable."
     with self.assertRaisesRegex(TypeError, msg):
@@ -2569,6 +2569,11 @@ class APITest(jtu.JaxTestCase):
 
     jtu.check_grads(batched_scan_over_mul, (x_batch, coeff), order=2,
                     modes=['rev'])
+
+  def test_device_array_unpacking_1D_hashable(self):
+    xs = device_put(np.array([1, 1]))
+    x, _ = xs
+    hash(x)  # doesn't crash
 
 
 class RematTest(jtu.JaxTestCase):


### PR DESCRIPTION
cross-ref #1583 #3330 

The current (before this PR) implementation of `DeviceArray.__iter__` fom #965 pulls the array back to the host and does the slicing on the resulting NumPy array, effectively:

```python
# current implementation
class DeviceArray:
  def __iter__(self):
    return iter(self._value)  # self._value is the cached ndarray version of the array
```

There are three issues we want to address here:
1. `list(device_array)` shouldn't return a list of `numpy.ndaray`s, and instead should return a list of `DeviceArray`s, regardless of how those are computed (this issue came up in #1583 and in some JAX user chats recently);
2. `key, subkey = random.split(key)` in op-by-op mode shouldn't incur device synchronization, but it does curently because the we effectively call `random.split(key).__iter__()` (this issue came up in #3330 and in JAX chats);
3. from #965, we don't want expressions like `list(device_array)` or `list(jnp.arange(10000))` to be slow to evaluate, where before #965 there could be a several-second compilation time and relatively slow (~100ms) execution time.

To address (1) we could either keep the bounce via NumPy and add some device_puts, or keep all the operations on the device. To address (2) we want to keep all the operations on the device. Currently that means we need to compile and execute XLA computations (rather than just doing something in the runtime).

To address (3), i.e. to keep things performant, most importantly we don't want to incur big compilation times, which basically means we don't want to compile computations with large output arity. We also don't want to dispatch lots of XLA computations, to keep execution time reasonable. We can balance the two by chunking things, so that for chunk size C and array size N we end up compiling O(1) computations, none having output arity more than C, and dispatching about 2 N / C computations (for each chunk, one to slice it out of the original array and one to explode it).

I timed the current and new implementation this way:

```python
import time
import jax.numpy as jnp
from jax.interpreters import xla

def clear_caches():
  xla.xla_primitive_callable.cache_clear()
  xla._xla_callable.cache_clear()

def time_things(x):
  # time to grab the first element, nothing compiled
  times = []
  for _ in range(100):
    clear_caches()
    tic = time.time()
    next(iter(x))
    times.append(time.time() - tic)
  print(f"time to grab first element, uncompiled: {sum(times) / len(times) * 1000} ms")

  # time to grab first element, compiled
  times = []
  for _ in range(100):
    tic = time.time()
    next(iter(x))
    times.append(time.time() - tic)
  print(f"time to grab first element, compiled: {sum(times) / len(times) * 1000} ms")

  # time to grab the whole thing, nothing compiled
  times = []
  for _ in range(100):
    clear_caches()
    tic = time.time()
    list(x)
    times.append(time.time() - tic)
  print(f"total time to grab all elements, uncompiled: {sum(times) / len(times) * 1000} ms")
  print(f"average time to grab each element, uncompiled: {sum(times) / len(times) / x.shape[0] * 1000} ms")

  # time to grab the whole thing, compiled
  times = []
  for _ in range(100):
    tic = time.time()
    list(x)
    times.append(time.time() - tic)
  print(f"total time to grab all elements, compiled: {sum(times) / len(times) * 1000} ms")
  print(f"average time to grab each element, compiled: {sum(times) / len(times) / x.shape[0] * 1000} ms")

small = jnp.arange(10) + 1
big = jnp.arange(10000) + 1
```

Notice we are *not* calling `block_until_ready` and instead just looking at dispatch times. The numbers that come out are pretty noisy.

For the *current* implementation, on a TPUv3 internal colab we see this:

```
time_things(small)
time to grab first element, uncompiled: 0.001392364501953125 ms
time to grab first element, compiled: 0.001277923583984375 ms
total time to grab all elements, uncompiled: 0.003528594970703125 ms
average time to grab each element, uncompiled: 0.0003528594970703125 ms
total time to grab all elements, compiled: 0.0027894973754882812 ms
average time to grab each element, compiled: 0.0002789497375488281 ms

time_things(big)
time to grab first element, uncompiled: 0.0012826919555664062 ms
time to grab first element, compiled: 0.0011134147644042969 ms
total time to grab all elements, uncompiled: 0.7117271423339844 ms
average time to grab each element, uncompiled: 7.117271423339843e-05 ms
total time to grab all elements, compiled: 0.7156133651733398 ms
average time to grab each element, compiled: 7.156133651733398e-05 ms
```

For the *new* implementation with chunk_size=100, on a TPUv3 internal colab we see this:

```
time_things(small)
time to grab first element, uncompiled: 12.47842788696289 ms
time to grab first element, compiled: 0.1662755012512207 ms
total time to grab all elements, uncompiled: 12.541697025299072 ms
average time to grab each element, uncompiled: 1.2541697025299074 ms
total time to grab all elements, compiled: 0.16188859939575195 ms
average time to grab each element, compiled: 0.016188859939575195 ms

time_things(big)
time to grab first element, uncompiled: 88.96037578582764 ms
time to grab first element, compiled: 0.809943675994873 ms
total time to grab all elements, uncompiled: 182.55109786987305 ms
average time to grab each element, uncompiled: 0.018255109786987307 ms
total time to grab all elements, compiled: 80.00826835632324 ms
average time to grab each element, compiled: 0.008000826835632323 ms
```

I _think_ the ballparks here seem acceptable, and so meet desideratum (3) while avoiding the host sync per (2). Comparing to #965, we avoid any multi-second compile times even though we end up paying 80ms to compute `list(big)` rather than <1ms. I suspect these times will get better when we improve `jit` dispatch time, since a significant fraction of the trace is spent on Python overhead (anything that's not an Execute bar):

![image](https://user-images.githubusercontent.com/1458824/88247615-38789580-cc53-11ea-90cc-bbdb285624bb.png)

Here's one other benchmark:

```python
from jax import random 
import time

def time_things2():
  key = random.PRNGKey(0)
  key, _ = random.split(key)
  
  tic = time.time()
  for _ in range(1000):
    key, subkey = random.split(key)
  toc = time.time()
  print(f"{(toc - tic)} ms")
```

With the *current* implementation, on TPU we get:

```
time_things2()
0.27765631675720215 ms
```

With the *new* implementation, on TPU we get:

```
time_things2()
0.20100140571594238 ms
```

So perhaps we're saving something from avoiding the sync here, even though there's no other work going on here.

fixes #1583