### PR TITLE
fix bug and improve error message for custom_jvp

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1075,7 +1075,8 @@ def process_env_traces(primitive: Union['CallPrimitive', 'MapPrimitive'],
   params = dict(params_tuple)
   todo = []
   while True:
-    tracers = [x for x in outs if isinstance(x, Tracer) and x._trace.level > level]
+    tracers = [x for x in outs if isinstance(x, Tracer)
+               and (level is None or x._trace.level > level)]
     if tracers:
       ans = max(tracers, key=lambda x: x._trace.level)
     else:

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -278,7 +278,11 @@ class CustomJVPCallPrimitive(core.CallPrimitive):
       outs = top_trace.process_custom_jvp_call(self, fun, jvp, tracers)
     _, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)
     if env_trace_todo:
-      raise core.UnexpectedTracerError
+      msg = ("Encountered an unexpected tracer in custom_jvp function "
+             f"{fun.__name__}. custom_jvp functions and their corresponding "
+             "differentiation rules must be defined at the top-level, i.e. "
+             "not within the body of another function to be transformed.")
+      raise core.UnexpectedTracerError(msg)
     return map(core.full_lower, outs)
 
   def impl(self, fun, _, *args):

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -280,7 +280,7 @@ class CustomJVPCallPrimitive(core.CallPrimitive):
     if env_trace_todo:
       msg = ("Encountered an unexpected tracer in custom_jvp function "
              f"{fun.__name__}. custom_jvp functions and their corresponding "
-             "differentiation rules must be defined at the top-level, i.e. "
+             "differentiation rules must be defined at the top level, "
              "not within the body of another function to be transformed.")
       raise core.UnexpectedTracerError(msg)
     return map(core.full_lower, outs)


### PR DESCRIPTION
fixes part of #3822, but we need a bit more to close that issue:
- [ ] add same checks to `custom_vjp`
- [ ] double-check and document top-level requirement for `custom_jvp`/`custom_vjp` and document it