### PR TITLE
add make_hlo to api for printing XLA HLO

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -54,6 +54,7 @@ from .api import (
   local_device_count,
   local_devices,
   linearize,
+  make_hlo,
   make_jaxpr,
   mask,
   partial,  # TODO(phawkins): update callers to use functools.partial.


### PR DESCRIPTION
This adds a function much like make_jaxpr that makes it easy to print the unoptimized JAX-emitted HLO for a jitted function, as well as the XLA-compiled and optimized HLO for the function.