### PR TITLE
attempt to fix CI failure (from #3845 test?)

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2534,13 +2534,17 @@ class CustomJVPTest(jtu.JaxTestCase):
     def run():
       return jax.grad(unroll)(jnp.array(1.0), jnp.array([1.0]))
 
+    expected = run()
+
     # we just don't want this to crash
     n_workers = 20
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_workers) as e:
       futures = []
       for _ in range(n_workers):
         futures.append(e.submit(run))
-      _ = [f.result() for f in futures]
+      results = [f.result() for f in futures]
+    for ans in results:
+      self.assertAllClose(ans, expected)
 
 
 class CustomVJPTest(jtu.JaxTestCase):


### PR DESCRIPTION
There was [a CI failure](https://github.com/google/jax/actions/runs/180653313) after #3845, which was in an unrelated test but seemed like it could've been caused by some threading issue. I think the threads should all have shut down when the test from #3845 exits (because the ThreadPoolExecutor context manager should block until the threads are done), but perhaps async dispatch is biting us since we weren't reading the numerical result. So this PR attempts a fix by reading checking the result!