### PR TITLE
Make PyTreeDef pickleable for Multiprocessing

### DIFF
--- a/jaxlib/pytree.cc
+++ b/jaxlib/pytree.cc
@@ -805,7 +805,7 @@ PYBIND11_MODULE(pytree, m) {
                [](const PyTreeDef &p) { return p.GetTraversal(); },
                // function 2: __setstate__ - build a new PyTreeDef from a tuple with a traversal_
                [](py::tuple t) {
-                   PyTreeDef p();
+                   PyTreeDef p;
                    p.SetTraversal(t);
                    return p;
                });)

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -14,6 +14,7 @@
 
 
 import collections
+import pickle
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -165,6 +166,14 @@ class TreeTest(jtu.JaxTestCase):
   @parameterized.parameters(*LEAVES)
   def testAllLeavesWithLeaves(self, leaf):
     self.assertTrue(tree_util.all_leaves([leaf]))
+
+  @parameterized.parameters(*TREES)
+  def testPickles(self, inputs):
+    xs, tree = tree_util.tree_flatten(inputs)
+    pickled_tree = pickle.dumps(tree)
+    unpickled_tree = pickle.loads(pickled_tree)
+    result = tree_util.tree_unflatten(unpickled_tree, xs)
+    self.assertEqual(result, inputs)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
To enable Jax Multiprocessing, it's necessary to pickle the treedefs (ex: Haiku params) That's supported by pybind (link below), but not implemented on the PyTreeDef class.

Can you take a look? It's the first C++ I've written in my life

Does traversal_ fully encode the tree, or is there other state? 

2 new public methods on PyTreeDef to get/set traversal_ (not sure about type casts)
```
        py::tuple GetTraversal() {return py::make_tuple(traversal_); } \\ <-- do we need to convert each Node?
        void SetTraversal(py::tuple t) { traversal_ = t.cast<std::vector<Node>>(); }
```
Then at the bottom in PYBIND11_MODULE, add pickling functions `__getstate__` and `__setstate__` 
```
            // make PyTreeDef pickleable to enable use with multiprocessing
            // https://pybind11.readthedocs.io/en/stable/advanced/classes.html#pickling-support
            // function 1: __getstate__ - return a tuple which fully encodes the state of the object
            // for PyTreeDef, the traversal_ vector of node structs fully encodes the tree (I think?)
            // function 2: __setstate__ - build a new PyTreeDef from a tuple with a traversal_
            .def(py::pickle(
                     [](const PyTreeDef &p) { return p.GetTraversal(); },
                     [](py::tuple t) {
                         PyTreeDef p;
                         p.SetTraversal(t);
                         return p;
                     }););
```