### PR TITLE
Replicating sort_complex functionality from np.sort_complex to jax.numpy

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -255,6 +255,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     sinh
     sometrue
     sort
+    sort_complex
     split
     sqrt
     square

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -53,7 +53,7 @@ from .lax_numpy import (
     rad2deg, radians, ravel, real, reciprocal, remainder, repeat, reshape,
     result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,
     save, savez, searchsorted, select, set_printoptions, shape, sign, signbit,
-    signedinteger, sin, sinc, single, sinh, size, sometrue, sort, split, sqrt,
+    signedinteger, sin, sinc, single, sinh, size, sometrue, sort, sort_complex, split, sqrt,
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,
     triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3240,7 +3240,7 @@ def sort(a, axis=-1, kind='quicksort', order=None):
 @_wraps(np.sort_complex)
 def sort_complex(a):
   a = lax.sort(a, dimension=0)
-  return lax.convert_element_type(a, result_type(a, complex64))
+  return lax.convert_element_type(a, result_type(a, complex_))
 
 @_wraps(np.lexsort)
 def lexsort(keys, axis=-1):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3237,6 +3237,11 @@ def sort(a, axis=-1, kind='quicksort', order=None):
   else:
     return lax.sort(a, dimension=_canonicalize_axis(axis, ndim(a)))
 
+@_wraps(np.sort_complex)
+def sort_complex(a):
+  a = lax.sort(a, dimension=0)
+  return lax.convert_element_type(a, result_type(a, complex64))
+
 @_wraps(np.lexsort)
 def lexsort(keys, axis=-1):
   keys = tuple(keys)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2652,7 +2652,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
         "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+      for dtype in python_scalar_dtypes
       for shape in one_dim_array_shapes
       for axis in [None]))
   def testSortComplex(self, dtype, shape, axis):
@@ -2662,13 +2662,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self.skipTest("complex sort not supported on TPU")
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    jnp_fun = jnp.sort_complex
-    np_fun = np.sort_complex
-    if axis is not None:
-      jnp_fun = partial(jnp_fun, axis=axis)
-      np_fun = partial(np_fun, axis=axis)
-    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
-    self._CompileAndCheck(jnp_fun, args_maker)
+    self._CheckAgainstNumpy(jnp.sort_complex, np.sort_complex, args_maker)
+    self._CompileAndCheck(jnp.sort_complex, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_input_type={}_axis={}".format(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2652,7 +2652,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
         "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in python_scalar_dtypes
+      for dtype in all_dtypes
       for shape in one_dim_array_shapes
       for axis in [None]))
   def testSortComplex(self, dtype, shape, axis):
@@ -2662,7 +2662,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self.skipTest("complex sort not supported on TPU")
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(jnp.sort_complex, np.sort_complex, args_maker)
+    self._CheckAgainstNumpy(jnp.sort_complex, np.sort_complex, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp.sort_complex, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2649,6 +2649,28 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_axis={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), axis),
+        "shape": shape, "dtype": dtype, "axis": axis}
+      for dtype in all_dtypes
+      for shape in one_dim_array_shapes
+      for axis in [None]))
+  def testSortComplex(self, dtype, shape, axis):
+    # TODO(b/141131288): enable test once complex sort is supported on TPU.
+    if (jnp.issubdtype(dtype, jnp.complexfloating)
+        and jtu.device_under_test() == "tpu"):
+      self.skipTest("complex sort not supported on TPU")
+    rng = jtu.rand_some_equal(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    jnp_fun = jnp.sort_complex
+    np_fun = np.sort_complex
+    if axis is not None:
+      jnp_fun = partial(jnp_fun, axis=axis)
+      np_fun = partial(np_fun, axis=axis)
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_input_type={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           input_type.__name__, axis),


### PR DESCRIPTION
Hi @hawkinsp & @jakevdp - Opening this new PR to replicate the changes from #3722 (as there were merge conflicts in that PR.
I have updated the code on the basis of changes suggested by both of you.

Discussion for your reference #2079 

Brief change-log:
1. Added sort_complex function
2. Added a test case testSortComplex (analogous to testSort)
3. Added a new entry for sort_complex to docs/jax.numpy.rst
4. Added the function entry to __init__.py

Please do let me know if this is alright, I'll go ahead and close the previous PR after your reponse.