### PR TITLE
[jax2tf] First draft for the conversion of FFTs.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -39,7 +39,7 @@ from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 from jax.interpreters import pxla
 
-from jaxlib.xla_client import FftType
+from jaxlib import xla_client
 
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
@@ -1192,15 +1192,19 @@ tf_impl[lax.sort_p] = _sort
 def _fft(x, fft_type, fft_lengths):
   shape = x.shape
   assert len(fft_lengths) <= len(shape)
-  if (fft_type == FftType.IRFFT and
-      fft_lengths != shape[-len(fft_lengths):-1] + ((shape[-1] - 1) * 2,) or
-      fft_type != FftType.IRFFT and
-      fft_lengths != shape[-len(fft_lengths):]):
+  if ((fft_type == xla_client.FftType.IRFFT and
+       fft_lengths != shape[-len(fft_lengths):-1] + ((shape[-1] - 1) * 2,)) or
+      (fft_type != xla_client.FftType.IRFFT and
+       fft_lengths != shape[-len(fft_lengths):])):
      raise NotImplementedError(f"Unsupported fft_lengths={fft_lengths} for fft_type={fft_type} of array with shape={shape}.")
-  tf_funcs = {FftType.FFT: [tf.signal.fft, tf.signal.fft2d, tf.signal.fft3d],
-              FftType.IFFT: [tf.signal.ifft, tf.signal.ifft2d, tf.signal.ifft3d],
-              FftType.RFFT: [tf.signal.rfft, tf.signal.rfft2d, tf.signal.rfft3d],
-              FftType.IRFFT: [tf.signal.irfft, tf.signal.irfft2d, tf.signal.irfft3d]}
+  tf_funcs = {xla_client.FftType.FFT: [tf.signal.fft, tf.signal.fft2d,
+                                       tf.signal.fft3d],
+              xla_client.FftType.IFFT: [tf.signal.ifft, tf.signal.ifft2d,
+                                        tf.signal.ifft3d],
+              xla_client.FftType.RFFT: [tf.signal.rfft, tf.signal.rfft2d,
+                                        tf.signal.rfft3d],
+              xla_client.FftType.IRFFT: [tf.signal.irfft, tf.signal.irfft2d,
+                                         tf.signal.irfft3d]}
 
   return tf_funcs[fft_type][len(fft_lengths) - 1](x)
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -39,6 +39,8 @@ from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 from jax.interpreters import pxla
 
+from jaxlib.xla_client import FftType
+
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
 
@@ -372,7 +374,7 @@ tf_not_yet_impl = [
   lax_linalg.lu_p, lax_linalg.svd_p,
   lax_linalg.triangular_solve_p,
 
-  lax_fft.fft_p, lax.igamma_grad_a_p,
+  lax.igamma_grad_a_p,
   random.random_gamma_p,
   lax.random_gamma_grad_p,
 
@@ -1186,6 +1188,16 @@ def _sort(*operand: TfVal, dimension: int, is_stable: bool, num_keys: int) -> Tu
     raise NotImplementedError("TODO: implement XlaSort for all axes")
 
 tf_impl[lax.sort_p] = _sort
+
+def _fft(x, fft_type, fft_lengths):
+  tf_funcs = {FftType.FFT: [tf.signal.fft, tf.signal.fft2d, tf.signal.fft3d],
+              FftType.IFFT: [tf.signal.ifft, tf.signal.ifft2d, tf.signal.ifft3d],
+              FftType.RFFT: [tf.signal.rfft, tf.signal.rfft2d, tf.signal.rfft3d],
+              FftType.IRFFT: [tf.signal.irfft, tf.signal.irfft2d, tf.signal.irfft3d]}
+
+  return tf_funcs[fft_type][len(fft_lengths) - 1](x)
+
+tf_impl[lax_fft.fft_p] = _fft
 
 def _qr(operand, full_matrices):
   return tf.linalg.qr(operand, full_matrices=full_matrices)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1190,6 +1190,13 @@ def _sort(*operand: TfVal, dimension: int, is_stable: bool, num_keys: int) -> Tu
 tf_impl[lax.sort_p] = _sort
 
 def _fft(x, fft_type, fft_lengths):
+  shape = x.shape
+  assert len(fft_lengths) <= len(shape)
+  if (fft_type == FftType.IRFFT and
+      fft_lengths != shape[-len(fft_lengths):-1] + ((shape[-1] - 1) * 2,) or
+      fft_type != FftType.IRFFT and
+      fft_lengths != shape[-len(fft_lengths):]):
+     raise NotImplementedError(f"Unsupported fft_lengths={fft_lengths} for fft_type={fft_type} of array with shape={shape}.")
   tf_funcs = {FftType.FFT: [tf.signal.fft, tf.signal.fft2d, tf.signal.fft3d],
               FftType.IFFT: [tf.signal.ifft, tf.signal.ifft2d, tf.signal.ifft3d],
               FftType.RFFT: [tf.signal.rfft, tf.signal.rfft2d, tf.signal.rfft3d],

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -27,7 +27,7 @@ from jax import lax
 from jax import lax_linalg
 from jax import numpy as jnp
 
-from jaxlib.xla_client import FftType
+from jaxlib import xla_client
 
 import numpy as np
 
@@ -430,12 +430,12 @@ lax_fft = tuple( # 1D tests
           fft_lengths=fft_lengths)
   for dtype in jtu.dtypes.all
   for shape in [(10,), (12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-1:]),
-                                (FftType.IFFT, shape[-1:]),
-                                (FftType.RFFT, shape[-1:]),
-                                (FftType.IRFFT, ((shape[-1] - 1) * 2,)),
-                                (FftType.IRFFT, [])]
-  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT) # No complex for RFFT!
+  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-1:]),
+                                (xla_client.FftType.IFFT, shape[-1:]),
+                                (xla_client.FftType.RFFT, shape[-1:]),
+                                (xla_client.FftType.IRFFT, ((shape[-1] - 1) * 2,)),
+                                (xla_client.FftType.IRFFT, [])]
+  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT) # No complex for RFFT!
 ) + tuple( # 2D tests
   Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
@@ -446,11 +446,12 @@ lax_fft = tuple( # 1D tests
           fft_lengths=fft_lengths)
   for dtype in jtu.dtypes.all
   for shape in [(12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-2:]),
-                                (FftType.IFFT, shape[-2:]),
-                                (FftType.RFFT, shape[-2:]),
-                                (FftType.IRFFT, shape[-2:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
+  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-2:]),
+                                (xla_client.FftType.IFFT, shape[-2:]),
+                                (xla_client.FftType.RFFT, shape[-2:]),
+                                (xla_client.FftType.IRFFT,
+                                 shape[-2:-1] + ((shape[-1] - 1) * 2,))]
+  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
 ) + tuple( # 3D tests
   Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
@@ -461,11 +462,12 @@ lax_fft = tuple( # 1D tests
           fft_lengths=fft_lengths)
   for dtype in jtu.dtypes.all
   for shape in [(14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-3:]),
-                                (FftType.IFFT, shape[-3:]),
-                                (FftType.RFFT, shape[-3:]),
-                                (FftType.IRFFT, shape[-3:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
+  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-3:]),
+                                (xla_client.FftType.IFFT, shape[-3:]),
+                                (xla_client.FftType.RFFT, shape[-3:]),
+                                (xla_client.FftType.IRFFT,
+                                 shape[-3:-1] + ((shape[-1] - 1) * 2,))]
+  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
 ) + tuple( # 4D tests
   Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
@@ -476,11 +478,12 @@ lax_fft = tuple( # 1D tests
           fft_lengths=fft_lengths)
   for dtype in jtu.dtypes.all
   for shape in [(14, 15, 16, 17)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape),
-                                (FftType.IFFT, shape),
-                                (FftType.RFFT, shape),
-                                (FftType.IRFFT, shape[:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
+  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape),
+                                (xla_client.FftType.IFFT, shape),
+                                (xla_client.FftType.RFFT, shape),
+                                (xla_client.FftType.IRFFT,
+                                 shape[:-1] + ((shape[-1] - 1) * 2,))]
+  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
 )
 
 lax_slice = tuple(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -418,83 +418,37 @@ lax_linalg_qr = tuple(
   for full_matrices in [False, True]
 )
 
-def _fft_rng_factory(dtype):
-  _all_integers = jtu.dtypes.all_integer + jtu.dtypes.all_unsigned + jtu.dtypes.boolean
-  # For integer types, use small values to keep the errors small
-  if dtype in _all_integers:
-    return jtu.rand_small
-  else:
-    return jtu.rand_default
+def _fft_harness_gen(nb_axes):
+  def _fft_rng_factory(dtype):
+    _all_integers = jtu.dtypes.all_integer + jtu.dtypes.all_unsigned + jtu.dtypes.boolean
+    # For integer types, use small values to keep the errors small
+    if dtype in _all_integers:
+      return jtu.rand_small
+    else:
+      return jtu.rand_default
 
-lax_fft = tuple( # 1D tests
-  Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          rng_factory=_fft_rng_factory(dtype),
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.all
-  for shape in [(10,), (12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-1:]),
-                                (xla_client.FftType.IFFT, shape[-1:]),
-                                (xla_client.FftType.RFFT, shape[-1:]),
-                                (xla_client.FftType.IRFFT, ((shape[-1] - 1) * 2,)),
-                                (xla_client.FftType.IRFFT, [])]
-  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT) # No complex for RFFT!
-) + tuple( # 2D tests
-  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          rng_factory=_fft_rng_factory(dtype),
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.all
-  for shape in [(12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-2:]),
-                                (xla_client.FftType.IFFT, shape[-2:]),
-                                (xla_client.FftType.RFFT, shape[-2:]),
-                                (xla_client.FftType.IRFFT,
-                                 shape[-2:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
-) + tuple( # 3D tests
-  Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          rng_factory=_fft_rng_factory(dtype),
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.all
-  for shape in [(14, 15, 16)]
-  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-3:]),
-                                (xla_client.FftType.IFFT, shape[-3:]),
-                                (xla_client.FftType.RFFT, shape[-3:]),
-                                (xla_client.FftType.IRFFT,
-                                 shape[-3:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
-) + tuple( # 4D tests
-  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          rng_factory=_fft_rng_factory(dtype),
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.all
-  for shape in [(14, 15, 16, 17)]
-  for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape),
-                                (xla_client.FftType.IFFT, shape),
-                                (xla_client.FftType.RFFT, shape),
-                                (xla_client.FftType.IRFFT,
-                                 shape[:-1] + ((shape[-1] - 1) * 2,))]
-  if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
-)
+  return tuple(
+    Harness(f"{nb_axes}d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+            lax.lax_fft.fft,
+            [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+            rng_factory=_fft_rng_factory(dtype),
+            shape=shape,
+            dtype=dtype,
+            fft_type=fft_type,
+            fft_lengths=fft_lengths)
+    for dtype in jtu.dtypes.all
+    for shape in filter(lambda x: len(x) >= nb_axes,
+                        [(10,), (12, 13), (14, 15, 16), (14, 15, 16, 17)])
+    for fft_type, fft_lengths in [(xla_client.FftType.FFT, shape[-nb_axes:]),
+                                  (xla_client.FftType.IFFT, shape[-nb_axes:]),
+                                  (xla_client.FftType.RFFT, shape[-nb_axes:]),
+                                  (xla_client.FftType.IRFFT,
+                                   shape[-nb_axes:-1] + ((shape[-1] - 1) * 2,))]
+    if not (dtype in jtu.dtypes.complex and fft_type == xla_client.FftType.RFFT)
+  )
+
+lax_fft = tuple(_fft_harness_gen(1) + _fft_harness_gen(2) + _fft_harness_gen(3) +
+                _fft_harness_gen(4))
 
 lax_slice = tuple(
   Harness(f"_shape={shape}_start_indices={start_indices}_limit_indices={limit_indices}_strides={strides}",  # type: ignore

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -27,6 +27,8 @@ from jax import lax
 from jax import lax_linalg
 from jax import numpy as jnp
 
+from jaxlib.xla_client import FftType
+
 import numpy as np
 
 FLAGS = config.FLAGS
@@ -414,6 +416,120 @@ lax_linalg_qr = tuple(
   for dtype in jtu.dtypes.all
   for shape in [(1, 1), (3, 3), (3, 4), (2, 10, 5), (2, 200, 100)]
   for full_matrices in [False, True]
+)
+
+
+
+lax_fft = tuple( # 1D tests, no complex
+  Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for shape in [(10,), (12, 13), (14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-1:]),
+                                (FftType.IFFT, shape[-1:]),
+                                (FftType.RFFT, shape[-1:]),
+                                (FftType.IRFFT, ((shape[-1] - 1) * 2,)),
+                                (FftType.IRFFT, [])]
+) + tuple( # 1D tests, complex
+  Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in jtu.dtypes.complex
+  for shape in [(10,), (12, 13), (14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-1:]),
+                                (FftType.IFFT, shape[-1:]),
+                                (FftType.IRFFT, ((shape[-1] - 1) * 2,)),
+                                (FftType.IRFFT, [])]
+) + tuple( # 2D tests, no complex
+  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for shape in [(12, 13), (14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-2:]),
+                                (FftType.IFFT, shape[-2:]),
+                                (FftType.RFFT, shape[-2:]),
+                                (FftType.IRFFT, shape[-2:-1] + ((shape[-1] - 1) * 2,))]
+) + tuple( # 2D tests, complex
+  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in jtu.dtypes.complex
+  for shape in [(12, 13), (14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-2:]),
+                                (FftType.IFFT, shape[-2:]),
+                                (FftType.IRFFT, shape[-2:-1] + ((shape[-1] - 1) * 2,))]
+) + tuple( # 3D tests, no complex
+  Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for shape in [(14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-3:]),
+                                (FftType.IFFT, shape[-3:]),
+                                (FftType.RFFT, shape[-3:]),
+                                (FftType.IRFFT, shape[-3:-1] + ((shape[-1] - 1) * 2,))]
+) + tuple( # 3D tests, complex
+  Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in jtu.dtypes.complex
+  for shape in [(14, 15, 16)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-3:]),
+                                (FftType.IFFT, shape[-3:]),
+                                (FftType.IRFFT, shape[-3:-1] + ((shape[-1] - 1) * 2,))]
+) + tuple( # 4D test, no complex, should error
+  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for shape in [(14, 15, 16, 17)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-4:]),
+                                (FftType.IFFT, shape[-4:]),
+                                (FftType.RFFT, shape[-4:]),
+                                (FftType.IRFFT, shape[-4:-1] + ((shape[-1] - 1) * 2,))]
+) + tuple( # 4D test, complex, should error
+  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
+          lax.lax_fft.fft,
+          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          shape=shape,
+          dtype=dtype,
+          fft_type=fft_type,
+          fft_lengths=fft_lengths)
+  for dtype in jtu.dtypes.complex
+  for shape in [(14, 15, 16, 17)]
+  for fft_type, fft_lengths in [(FftType.FFT, shape[-4:]),
+                                (FftType.IFFT, shape[-4:]),
+                                (FftType.IRFFT, shape[-4:-1] + ((shape[-1] - 1) * 2,))]
 )
 
 lax_slice = tuple(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -418,12 +418,19 @@ lax_linalg_qr = tuple(
   for full_matrices in [False, True]
 )
 
-
+def _fft_rng_factory(dtype):
+  _all_integers = jtu.dtypes.all_integer + jtu.dtypes.all_unsigned + jtu.dtypes.boolean
+  # For integer types, use small values to keep the errors small
+  if dtype in _all_integers:
+    return jtu.rand_small
+  else:
+    return jtu.rand_default
 
 lax_fft = tuple( # 1D tests
   Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          rng_factory=_fft_rng_factory(dtype),
           shape=shape,
           dtype=dtype,
           fft_type=fft_type,
@@ -440,6 +447,7 @@ lax_fft = tuple( # 1D tests
   Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          rng_factory=_fft_rng_factory(dtype),
           shape=shape,
           dtype=dtype,
           fft_type=fft_type,
@@ -456,6 +464,7 @@ lax_fft = tuple( # 1D tests
   Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          rng_factory=_fft_rng_factory(dtype),
           shape=shape,
           dtype=dtype,
           fft_type=fft_type,
@@ -472,6 +481,7 @@ lax_fft = tuple( # 1D tests
   Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
+          rng_factory=_fft_rng_factory(dtype),
           shape=shape,
           dtype=dtype,
           fft_type=fft_type,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -513,10 +513,10 @@ lax_fft = tuple( # 1D tests, no complex
           fft_lengths=fft_lengths)
   for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
   for shape in [(14, 15, 16, 17)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-4:]),
-                                (FftType.IFFT, shape[-4:]),
-                                (FftType.RFFT, shape[-4:]),
-                                (FftType.IRFFT, shape[-4:-1] + ((shape[-1] - 1) * 2,))]
+  for fft_type, fft_lengths in [(FftType.FFT, shape),
+                                (FftType.IFFT, shape),
+                                (FftType.RFFT, shape),
+                                (FftType.IRFFT, shape[:-1] + ((shape[-1] - 1) * 2,))]
 ) + tuple( # 4D test, complex, should error
   Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
@@ -527,9 +527,9 @@ lax_fft = tuple( # 1D tests, no complex
           fft_lengths=fft_lengths)
   for dtype in jtu.dtypes.complex
   for shape in [(14, 15, 16, 17)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-4:]),
-                                (FftType.IFFT, shape[-4:]),
-                                (FftType.IRFFT, shape[-4:-1] + ((shape[-1] - 1) * 2,))]
+  for fft_type, fft_lengths in [(FftType.FFT, shape),
+                                (FftType.IFFT, shape),
+                                (FftType.IRFFT, shape[:-1] + ((shape[-1] - 1) * 2,))]
 )
 
 lax_slice = tuple(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -420,7 +420,7 @@ lax_linalg_qr = tuple(
 
 
 
-lax_fft = tuple( # 1D tests, no complex
+lax_fft = tuple( # 1D tests
   Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
@@ -428,28 +428,15 @@ lax_fft = tuple( # 1D tests, no complex
           dtype=dtype,
           fft_type=fft_type,
           fft_lengths=fft_lengths)
-  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for dtype in jtu.dtypes.all
   for shape in [(10,), (12, 13), (14, 15, 16)]
   for fft_type, fft_lengths in [(FftType.FFT, shape[-1:]),
                                 (FftType.IFFT, shape[-1:]),
                                 (FftType.RFFT, shape[-1:]),
                                 (FftType.IRFFT, ((shape[-1] - 1) * 2,)),
                                 (FftType.IRFFT, [])]
-) + tuple( # 1D tests, complex
-  Harness(f"1d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.complex
-  for shape in [(10,), (12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-1:]),
-                                (FftType.IFFT, shape[-1:]),
-                                (FftType.IRFFT, ((shape[-1] - 1) * 2,)),
-                                (FftType.IRFFT, [])]
-) + tuple( # 2D tests, no complex
+  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT) # No complex for RFFT!
+) + tuple( # 2D tests
   Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
@@ -457,26 +444,14 @@ lax_fft = tuple( # 1D tests, no complex
           dtype=dtype,
           fft_type=fft_type,
           fft_lengths=fft_lengths)
-  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for dtype in jtu.dtypes.all
   for shape in [(12, 13), (14, 15, 16)]
   for fft_type, fft_lengths in [(FftType.FFT, shape[-2:]),
                                 (FftType.IFFT, shape[-2:]),
                                 (FftType.RFFT, shape[-2:]),
                                 (FftType.IRFFT, shape[-2:-1] + ((shape[-1] - 1) * 2,))]
-) + tuple( # 2D tests, complex
-  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.complex
-  for shape in [(12, 13), (14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-2:]),
-                                (FftType.IFFT, shape[-2:]),
-                                (FftType.IRFFT, shape[-2:-1] + ((shape[-1] - 1) * 2,))]
-) + tuple( # 3D tests, no complex
+  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
+) + tuple( # 3D tests
   Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
@@ -484,26 +459,14 @@ lax_fft = tuple( # 1D tests, no complex
           dtype=dtype,
           fft_type=fft_type,
           fft_lengths=fft_lengths)
-  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for dtype in jtu.dtypes.all
   for shape in [(14, 15, 16)]
   for fft_type, fft_lengths in [(FftType.FFT, shape[-3:]),
                                 (FftType.IFFT, shape[-3:]),
                                 (FftType.RFFT, shape[-3:]),
                                 (FftType.IRFFT, shape[-3:-1] + ((shape[-1] - 1) * 2,))]
-) + tuple( # 3D tests, complex
-  Harness(f"3d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.complex
-  for shape in [(14, 15, 16)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape[-3:]),
-                                (FftType.IFFT, shape[-3:]),
-                                (FftType.IRFFT, shape[-3:-1] + ((shape[-1] - 1) * 2,))]
-) + tuple( # 4D test, no complex, should error
+  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
+) + tuple( # 4D tests
   Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
           lax.lax_fft.fft,
           [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
@@ -511,25 +474,13 @@ lax_fft = tuple( # 1D tests, no complex
           dtype=dtype,
           fft_type=fft_type,
           fft_lengths=fft_lengths)
-  for dtype in [t for t in jtu.dtypes.all if t not in jtu.dtypes.complex]
+  for dtype in jtu.dtypes.all
   for shape in [(14, 15, 16, 17)]
   for fft_type, fft_lengths in [(FftType.FFT, shape),
                                 (FftType.IFFT, shape),
                                 (FftType.RFFT, shape),
                                 (FftType.IRFFT, shape[:-1] + ((shape[-1] - 1) * 2,))]
-) + tuple( # 4D test, complex, should error
-  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_ffttype={fft_type}_fftlengths={fft_lengths}",
-          lax.lax_fft.fft,
-          [RandArg(shape, dtype), StaticArg(fft_type), StaticArg(fft_lengths)],
-          shape=shape,
-          dtype=dtype,
-          fft_type=fft_type,
-          fft_lengths=fft_lengths)
-  for dtype in jtu.dtypes.complex
-  for shape in [(14, 15, 16, 17)]
-  for fft_type, fft_lengths in [(FftType.FFT, shape),
-                                (FftType.IFFT, shape),
-                                (FftType.IRFFT, shape[:-1] + ((shape[-1] - 1) * 2,))]
+  if not (dtype in jtu.dtypes.complex and fft_type == FftType.RFFT)
 )
 
 lax_slice = tuple(

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -157,7 +157,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_fft)
   def test_fft(self, harness: primitive_harness.Harness):
-    if len(harness.params["shape"]) > 3:
+    if len(harness.params["fft_lengths"]) > 3:
       with self.assertRaisesRegex(RuntimeError, "FFT only supports ranks 1-3"):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
     elif harness.params["dtype"] is dtypes.bfloat16:

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -27,6 +27,7 @@ from jax.config import config
 from jax.experimental import jax2tf
 from jax.experimental.jax2tf.tests import tf_test_util
 from jax.interpreters import xla
+
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
 
@@ -153,6 +154,16 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       # TODO: fix the TF GPU test
       raise unittest.SkipTest("GPU tests are running TF on CPU")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
+  @primitive_harness.parameterized(primitive_harness.lax_fft)
+  def test_fft(self, harness: primitive_harness.Harness):
+    if len(harness.params["shape"]) > 3:
+      with self.assertRaisesRegex(RuntimeError, "FFT only supports ranks 1-3"):
+        harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
+    elif harness.params["dtype"] is dtypes.bfloat16:
+      raise unittest.SkipTest("bfloat16 support not implemened")
+    else:
+      self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_qr)
   def test_qr(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -172,7 +172,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         if harness.params["dtype"] in jtu.dtypes.boolean:
           tol = 0.01
         else:
-          tol = 1e-4
+          tol = 1e-3
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                              atol=tol, rtol=tol)
 


### PR DESCRIPTION
Translation does not seem to cause any problem, however errors in
calls to lax.lax_fft are handled at a higher abstraction layer
(in jax.numpy.fft). Maybe it would thus make sense to make the
tests call jax.numpy.fft._fft_core instead of lax.lax_fft to ensure
the inputs are sanitized in the same way?