### PR TITLE
Improve searchsorted implementation

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -36,7 +36,6 @@ import numpy as np
 import opt_einsum
 
 from jax import jit, custom_jvp
-from .vectorize import vectorize
 from ._util import _wraps
 from .. import core
 from .. import dtypes

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4246,6 +4246,7 @@ def _searchsorted(a, v, side='left'):
 
   return high.reshape(v_shape)
 
+@_wraps(np.searchsorted)
 def searchsorted(a, v, side='left', sorter=None):
   if side not in ['left', 'right']:
     raise ValueError(f"{side!r} is an invalid value for keyword 'side'")
@@ -4256,7 +4257,7 @@ def searchsorted(a, v, side='left', sorter=None):
   if ndim(a) != 1:
     raise ValueError("a should be 1-dimensional")
   if size(a) == 0 or size(v) == 0:
-    return zeros_like(v, dtype=int)
+    return zeros_like(v, dtype=int_)
   return _searchsorted(a, v, side)
 
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4225,8 +4225,8 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
 
 
 @partial(jit, static_argnums=2)
-def _searchsorted(a, v, side='left'):
-  op = operator.lt if side == "right" else operator.le
+def _searchsorted(a, v, side):
+  op = operator.le if side == 'left' else operator.lt
 
   def body_fun(i, state):
     low, high = state

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4252,8 +4252,6 @@ def searchsorted(a, v, side='left', sorter=None):
   v = asarray(v)
   if ndim(a) != 1:
     raise ValueError("a should be 1-dimensional")
-  if size(a) == 0 or size(v) == 0:
-    return zeros_like(v, dtype=int_)
   return _searchsorted(a, ravel(v), side).reshape(shape(v))
 
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4236,8 +4236,8 @@ def _searchsorted(a, v, side='left'):
     high = where(mask, mid, high)
     return (low, high), x
 
-  low = zeros(len(v), dtype=int_)
-  high = full(len(v), len(a), dtype=int_)
+  low = zeros(len(v), dtype=dtypes.canonicalize_dtype(int_))
+  high = full(len(v), len(a), dtype=dtypes.canonicalize_dtype(int_))
   n_levels = int(np.ceil(np.log2(len(a) + 1)))
   (low, high), _ = lax.scan(fscan, (low, high), None, length=n_levels)
   return high

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4228,13 +4228,13 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
 def _searchsorted(a, v, side='left'):
   op = operator.lt if side == "right" else operator.le
 
-  def fscan(carry, x):
+  def fscan(carry, _):
     low, high = carry
     mid = (low + high) // 2
     mask = op(v, a[mid])
     low = where(mask, low, mid)
     high = where(mask, mid, high)
-    return (low, high), x
+    return (low, high), None
 
   low = zeros(len(v), dtype=dtypes.canonicalize_dtype(int_))
   high = full(len(v), len(a), dtype=dtypes.canonicalize_dtype(int_))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1831,7 +1831,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(vshape, dtype),
       side), "ashape": ashape, "vshape": vshape, "side": side,
      "dtype": dtype, "rng_factory": rng_factory}
-    for ashape in [(20,)]
+    for ashape in [(15,), (16,), (17,)]
     for vshape in [(), (5,), (5, 5)]
     for side in ['left', 'right']
     for dtype in default_dtypes
@@ -1839,7 +1839,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   ))
   def testSearchsorted(self, ashape, vshape, side, dtype, rng_factory):
     rng = rng_factory(self.rng())
-    args_maker = lambda: [jnp.sort(rng(ashape, dtype)), rng(vshape, dtype)]
+    args_maker = lambda: [np.sort(rng(ashape, dtype)), rng(vshape, dtype)]
     np_fun = lambda a, v: np.searchsorted(a, v, side=side)
     jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)


### PR DESCRIPTION
This replaces a vectorized `lax.while_loop` with a single fixed-size `lax.scan`. The performance on CPU and TPU are similar, but it is an improvement on GPU. For smaller arrays (< 100 elements), the performance is roughly equivalent to the current algorithm. For larger arrays (100,000 elements), it is up to 30% faster on GPU for large arrays.

Here are some quick benchmarks comparing the old and new algorithm on CPU and GPU ([notebook here](http://go/colabx-drive/1HT3huWM6OA7K8S9MzXly1vwK184_mh5z)):
![cpu-bench](https://user-images.githubusercontent.com/781659/88593197-0b8dff00-d014-11ea-9f1c-dd1615f2d9cd.png)
![gpu-bench](https://user-images.githubusercontent.com/781659/88593201-0d57c280-d014-11ea-95a0-32aefdcbc0aa.png)
![tpu-bench](https://user-images.githubusercontent.com/781659/88597446-12b90b00-d01c-11ea-98bf-569582719f92.png)

It appears that the main benefit of this approach is that it allows XLA GPU to take better advantage of parallel computation, as evidenced by the flat curve for the size of the query array across five orders of magnitude.
