### PR TITLE
Fix formatting in the custom derivatives notebook

### DIFF
--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -53,7 +53,7 @@
         "colab_type": "text"
       },
       "source": [
-        "#### Custom JVPs with `jax.custom_jvp`"
+        "### Custom JVPs with `jax.custom_jvp`"
       ]
     },
     {
@@ -175,7 +175,7 @@
         "colab_type": "text"
       },
       "source": [
-        "#### Custom VJPs with `jax.custom_vjp`"
+        "### Custom VJPs with `jax.custom_vjp`"
       ]
     },
     {
@@ -249,8 +249,6 @@
         "colab_type": "text"
       },
       "source": [
-        "\n",
-        "\n",
         "### Numerical stability\n",
         "\n",
         "One application of `jax.custom_jvp` is to improve the numerical stability of differentiation."


### PR DESCRIPTION
Sphinx is apparently quite picky about consistent use of headers: you can't
skip a header level. We were getting warnings like "WARNING: Title level
inconsistent" in the docs build, and sub-headers weren't showing up on this
page after the first section.