### PR TITLE
Fix flaky generated_fun_test.py test

### DIFF
--- a/tests/generated_fun_test.py
+++ b/tests/generated_fun_test.py
@@ -186,7 +186,7 @@ def inner_prod(xs, ys):
   return sum(jnp.sum(x * y) for x, y in xys)
 
 def jvp_fd(fun, args, tangents):
-  EPS = 1e-4
+  EPS = 1e-3
   def eval_eps(eps):
     return fun(*[x if t is None else x + eps * t
                  for x, t in zip(args, tangents)])


### PR DESCRIPTION
Before this change, running
```
$ JAX_NUM_GENERATED_CASES=[number greater than 200] pytest -n auto tests/generated_fun_test.py
```
would consistently have one or more failures, after this change it consistently succeeds.