### PR TITLE
refine population_count type check

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1971,6 +1971,7 @@ def _brcast_to(x, shape):
 _float = {np.floating}
 _complex = {np.complexfloating}
 _complex_elem_types = {np.float32, np.float64}
+_uint = {np.unsignedinteger}
 _int = {np.integer}
 _bool = {np.bool_}
 
@@ -2242,7 +2243,7 @@ ad.defjvp_zero(or_p)
 xor_p = standard_naryop([_bool_or_int, _bool_or_int], 'xor')
 ad.defjvp_zero(xor_p)
 
-population_count_p = standard_unop(_bool_or_int, 'population_count')
+population_count_p = standard_unop(_uint, 'population_count')
 
 def _add_transpose(t, x, y):
   # The following linearity assertion is morally true, but because in some cases we

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1971,7 +1971,6 @@ def _brcast_to(x, shape):
 _float = {np.floating}
 _complex = {np.complexfloating}
 _complex_elem_types = {np.float32, np.float64}
-_uint = {np.unsignedinteger}
 _int = {np.integer}
 _bool = {np.bool_}
 
@@ -2243,7 +2242,7 @@ ad.defjvp_zero(or_p)
 xor_p = standard_naryop([_bool_or_int, _bool_or_int], 'xor')
 ad.defjvp_zero(xor_p)
 
-population_count_p = standard_unop(_uint, 'population_count')
+population_count_p = standard_unop(_int, 'population_count')
 
 def _add_transpose(t, x, y):
   # The following linearity assertion is morally true, but because in some cases we

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -119,9 +119,14 @@ shift_right_arithmetic = np.right_shift
 # TODO shift_right_logical
 
 def population_count(x):
+  assert np.issubdtype(x.dtype, np.integer)
   dtype = x.dtype
-  if x.dtype in (np.uint8, np.uint16):
-    x = x.astype(np.uint32)
+  iinfo = np.iinfo(x.dtype)
+  if np.iinfo(x.dtype).bits < 32:
+    assert iinfo.kind in ('i', 'u')
+    x = x.astype(np.uint32 if iinfo.kind == 'u' else np.int32)
+  if iinfo.kind == 'i':
+    x = x.view(f"uint{np.iinfo(x.dtype).bits}")
   assert x.dtype in (np.uint32, np.uint64)
   m = [
       0x5555555555555555,  # binary: 0101...

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -137,7 +137,7 @@ LAX_OPS = [
     op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small),
     op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small),
     op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small),
-    op_record("population_count", 1, uint_dtypes, jtu.rand_int),
+    op_record("population_count", 1, int_dtypes, jtu.rand_int),
 
     op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small),
     op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1786,6 +1786,12 @@ class LaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "duplicate value in 'axes' .*"):
       lax.reduce(np.arange(3), 0, lax.add, (0, 0))
 
+  def test_population_count_booleans_not_supported(self):
+    # https://github.com/google/jax/issues/3886
+    msg = "population_count does not accept dtype bool"
+    with self.assertRaisesRegex(TypeError, msg):
+      lax.population_count(True)
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -137,7 +137,7 @@ LAX_OPS = [
     op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small),
     op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small),
     op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small),
-    op_record("population_count", 1, int_dtypes, jtu.rand_int),
+    op_record("population_count", 1, int_dtypes + uint_dtypes, jtu.rand_int),
 
     op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small),
     op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small),


### PR DESCRIPTION
fixes #3886

[Signed and unsigned integers are allowed](https://cs.opensource.google/tensorflow/tensorflow/+/master:tensorflow/compiler/xla/service/shape_inference.cc;l=314?q=xla%20f:shape_inference.cc), other types are not.