### PR TITLE
[jax2tf] First draft of conversion of population_count.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -364,7 +364,7 @@ for unexpected in [
 
 # Primitives that are not yet implemented must be explicitly declared here.
 tf_not_yet_impl = [
-  lax.population_count_p, lax.reduce_p, lax.reduce_window_p, lax.rng_uniform_p,
+  lax.reduce_p, lax.reduce_window_p, lax.rng_uniform_p,
   lax.select_and_gather_add_p, lax.select_and_scatter_p,
 
   lax.linear_solve_p,
@@ -399,6 +399,11 @@ tf_impl[lax.ceil_p] = tf.math.ceil
 tf_impl[lax.round_p] = tf.math.round
 tf_impl[lax.nextafter_p] = tf.math.nextafter
 
+def _population_count(x):
+  orig_dtype = x.dtype
+  return tf.bitcast(tf.raw_ops.PopulationCount(x=x), orig_dtype)
+
+tf_impl[lax.population_count_p] = _population_count
 tf_impl[lax.is_finite_p] = tf.math.is_finite
 
 tf_impl[lax.abs_p] = tf.math.abs

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -193,6 +193,17 @@ lax_bitwise_not = tuple(
   ]]
 )
 
+lax_population_count = tuple(
+  Harness(f"{jtu.dtype_str(dtype)}",
+          lax.population_count,
+          [arg],
+          dtype=dtype)
+  for dtype in jtu.dtypes.all_integer + jtu.dtypes.all_unsigned
+  for arg in [
+    np.array([-1, -2, 0, 1], dtype=dtype)
+  ]
+)
+
 _LAX_BINARY_ELEMENTWISE = (
   lax.add, lax.atan2, lax.div, lax.igamma, lax.igammac, lax.max, lax.min,
   lax.nextafter, lax.rem, lax.sub)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -244,6 +244,11 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_bitwise_not(self, harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_population_count)
+  def test_population_count(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           expect_tf_exceptions=True)
+
   @primitive_harness.parameterized(primitive_harness.lax_binary_elementwise)
   def test_binary_elementwise(self, harness):
     if harness.params["dtype"] is dtypes.bfloat16:


### PR DESCRIPTION
tf.raw_ops.PopulationCount returns a Tensor with elements of type
uint8. In JAX, the type of the result is the same as the type of
the input, hence the need to use tf.cast in the conversion
function.