### PR TITLE
Fix svd_p to stop returning garbage values of u/vt when compute_uv ==…

### DIFF
--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -854,9 +854,8 @@ xla.backend_specific_translations['gpu'][qr_p] = partial(
 # Singular value decomposition
 
 def svd_impl(operand, full_matrices, compute_uv):
-  result = xla.apply_primitive(svd_p, operand, full_matrices=full_matrices,
-                               compute_uv=compute_uv)
-  return result
+  return xla.apply_primitive(svd_p, operand, full_matrices=full_matrices,
+                             compute_uv=compute_uv)
 
 def svd_translation_rule(c, operand, full_matrices, compute_uv):
   shape = c.get_shape(operand).dimensions()

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -914,6 +914,9 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
   dU = jnp.matmul(U, F * (dSS + _T(dSS)))
   dV = jnp.matmul(V, F * (SdS + _T(SdS)))
 
+  if not compute_uv:
+    return (s,), (ds,)
+
   m, n = A.shape[-2:]
   if m > n:
     dU = dU + jnp.matmul(jnp.eye(m, dtype=A.dtype) - jnp.matmul(U, Ut), jnp.matmul(dA, V)) / s_dim

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -66,6 +66,12 @@ def qr(x, full_matrices=True):
   return q, r
 
 def svd(x, full_matrices=True, compute_uv=True):
+  """Singular value decomposition.
+
+  Returns the singular values if compute_uv is False, and a triple containing
+  the left singular vectors, the singular values and the adjoint of the right
+  singular vectors.
+  """
   result = svd_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
   if compute_uv:
     s, u, v = result

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -907,15 +907,16 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
   s_dim = s[..., None, :]
   dS = jnp.matmul(jnp.matmul(Ut, dA), V)
   ds = jnp.real(jnp.diagonal(dS, 0, -2, -1))
+
+  if not compute_uv:
+    return (s,), (ds,)
+
   F = 1 / (jnp.square(s_dim) - jnp.square(_T(s_dim)) + jnp.eye(k, dtype=A.dtype))
   F = F - jnp.eye(k, dtype=A.dtype)
   dSS = s_dim * dS
   SdS = _T(s_dim) * dS
   dU = jnp.matmul(U, F * (dSS + _T(dSS)))
   dV = jnp.matmul(V, F * (SdS + _T(SdS)))
-
-  if not compute_uv:
-    return (s,), (ds,)
 
   m, n = A.shape[-2:]
   if m > n:

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -68,9 +68,9 @@ def qr(x, full_matrices=True):
 def svd(x, full_matrices=True, compute_uv=True):
   """Singular value decomposition.
 
-  Returns the singular values if compute_uv is False, and a triple containing
-  the left singular vectors, the singular values and the adjoint of the right
-  singular vectors.
+  Returns the singular values if compute_uv is False, otherwise returns a triple
+  containing the left singular vectors, the singular values and the adjoint of
+  the right singular vectors.
   """
   result = svd_p.bind(x, full_matrices=full_matrices, compute_uv=compute_uv)
   if compute_uv:

--- a/jax/lax_linalg.py
+++ b/jax/lax_linalg.py
@@ -77,7 +77,8 @@ def svd(x, full_matrices=True, compute_uv=True):
     s, u, v = result
     return u, s, v
   else:
-    return result[0]
+    s, = result
+    return s
 
 def triangular_solve(a, b, left_side=False, lower=False, transpose_a=False,
                      conjugate_a=False, unit_diagonal=False):


### PR DESCRIPTION
… False.

The custom call made by svd_p does not compute u and vt when
compute_uv is set to False. Returning them using the primitive
means that it is up to the caller to throw away these values.