### PR TITLE
Add test for dtype coverage of jax.numpy ufuncs

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -19,7 +19,7 @@ from functools import partial
 import inspect
 import itertools
 import operator
-from typing import cast, Optional
+from typing import cast, Iterator, Optional, List, Tuple
 import unittest
 from unittest import SkipTest
 import warnings
@@ -4322,6 +4322,70 @@ class NumpySignaturesTest(jtu.JaxTestCase):
         mismatches[name] = {'np_params': list(np_params), 'jnp_params': list(jnp_params)}
 
     self.assertEqual(mismatches, {})
+
+
+_all_dtypes: List[str] = [
+  "bool_",
+  "uint8", "uint16", "uint32", "uint64",
+  "int8", "int16", "int32", "int64",
+  "float16", "float32", "float64",
+  "complex64", "complex128",
+]
+
+
+def _all_numpy_ufuncs() -> Iterator[str]:
+  """Generate the names of all ufuncs in the top-level numpy namespace."""
+  for name in dir(np):
+    f = getattr(np, name)
+    if isinstance(f, np.ufunc):
+      yield name
+
+
+def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:
+  """Generate valid dtypes of inputs to the given numpy ufunc."""
+  func = getattr(np, name)
+  for arg_dtypes in itertools.product(*(func.nin * (_all_dtypes,))):
+    args = (np.ones(1, dtype=dtype) for dtype in arg_dtypes)
+    try:
+      with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "divide by zero", RuntimeWarning)
+        _ = func(*args)
+    except TypeError:
+      pass
+    else:
+      yield arg_dtypes
+
+
+class NumpyUfuncTests(jtu.JaxTestCase):
+  @parameterized.named_parameters(
+    {"testcase_name": f"_{name}_{','.join(arg_dtypes)}",
+     "name": name, "arg_dtypes": arg_dtypes}
+    for name in _all_numpy_ufuncs()
+    for arg_dtypes in jtu.cases_from_list(_dtypes_for_ufunc(name)))
+  def testUfuncInputTypes(self, name, arg_dtypes):
+    if (name in ['copysign', 'divmod', 'floor_divide', 'fmod', 'gcd', 'left_shift',
+                 'mod', 'power', 'remainder', 'right_shift', 'rint', 'square']
+        and 'bool_' in arg_dtypes):
+      self.skipTest(f"jax.numpy does not support {name}{tuple(arg_dtypes)}")
+    if name == 'arctanh' and jnp.issubdtype(arg_dtypes[0], jnp.complexfloating):
+      self.skipTest("np.arctanh & jnp.arctanh have mismatched NaNs for complex input.")
+    for dtype in arg_dtypes:
+      jtu.skip_if_unsupported_type(dtype)
+
+    jnp_op = getattr(jnp, name)
+    np_op = getattr(np, name)
+    np_op = jtu.ignore_warning(category=RuntimeWarning,
+                               message="divide by zero.*")(np_op)
+    args_maker = lambda: tuple(np.ones(1, dtype=dtype) for dtype in arg_dtypes)
+
+    try:
+      jnp_op(*args_maker())
+    except NotImplementedError:
+      self.skipTest(f"jtu.{name} is not yet implemented.")
+
+    # large tol comes from the fact that numpy returns float16 in places
+    # that jnp returns float32. e.g. np.cos(np.uint8(0))
+    self._CheckAgainstNumpy(np_op, jnp_op, args_maker, check_dtypes=False, tol=1E-2)
 
 
 if __name__ == "__main__":

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4344,7 +4344,7 @@ def _all_numpy_ufuncs() -> Iterator[str]:
 def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:
   """Generate valid dtypes of inputs to the given numpy ufunc."""
   func = getattr(np, name)
-  for arg_dtypes in itertools.product(*(func.nin * (_all_dtypes,))):
+  for arg_dtypes in itertools.product(_all_dtypes, repeat=func.nin):
     args = (np.ones(1, dtype=dtype) for dtype in arg_dtypes)
     try:
       with warnings.catch_warnings():
@@ -4363,8 +4363,9 @@ class NumpyUfuncTests(jtu.JaxTestCase):
     for name in _all_numpy_ufuncs()
     for arg_dtypes in jtu.cases_from_list(_dtypes_for_ufunc(name)))
   def testUfuncInputTypes(self, name, arg_dtypes):
-    if (name in ['copysign', 'divmod', 'floor_divide', 'fmod', 'gcd', 'left_shift',
-                 'mod', 'power', 'remainder', 'right_shift', 'rint', 'square']
+    # TODO(jakevdp): fix following failures and remove from this exception list.
+    if (name in ['divmod', 'floor_divide', 'fmod', 'gcd', 'left_shift', 'mod',
+                 'power', 'remainder', 'right_shift', 'rint', 'square']
         and 'bool_' in arg_dtypes):
       self.skipTest(f"jax.numpy does not support {name}{tuple(arg_dtypes)}")
     if name == 'arctanh' and jnp.issubdtype(arg_dtypes[0], jnp.complexfloating):


### PR DESCRIPTION
Our current test suite for `jax.numpy` ufuncs is built on hand-defined `op_record` entries for all defined functions. This leaves some potential inputs untested, and in particular there are a number of dtypes supported by numpy but not supported by the corresponding jax function.

This PR adds an automatically generated set of tests to ensure dtype coverage for `jax.numpy` ports of top-level numpy ufuncs. The test extracts the list of ufuncs available in numpy's top-level namespace, generates a list of valid input dtypes for each, and uses these dtypes as inputs to the `jax.numpy` wrappers of the ufuncs.

This has already led to improved coverage of a number of wrapper functions (see linked PRs below). There are a few remaining known failures explicitly skipped in the test: primarily `bool` inputs which numpy casts to integers. It is not clear to me whether we should strive to support all of these in JAX, but I am leaving them as a TODO.