### PR TITLE
Support unsigned types in jnp.gcd() & jnp.lcm()

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -4018,11 +4018,10 @@ def _gcd_body_fn(xs):
 def gcd(x1, x2):
   if (not issubdtype(_dtype(x1), integer) or
       not issubdtype(_dtype(x2), integer)):
-    raise ValueError("Arguments to gcd must be integers.")
+    raise ValueError("Arguments to jax.numpy.gcd must be integers.")
   x1, x2 = _promote_dtypes(x1, x2)
   x1, x2 = broadcast_arrays(x1, x2)
-  gcd, _ = lax.while_loop(_gcd_cond_fn, _gcd_body_fn,
-                          (lax.abs(x1), lax.abs(x2)))
+  gcd, _ = lax.while_loop(_gcd_cond_fn, _gcd_body_fn, (abs(x1), abs(x2)))
   return gcd
 
 
@@ -4031,7 +4030,7 @@ def lcm(x1, x2):
   x1, x2 = _promote_dtypes(x1, x2)
   d = gcd(x1, x2)
   return where(d == 0, lax._const(d, 0),
-               lax.div(lax.abs(multiply(x1, x2)), d))
+               abs(multiply(x1, floor_divide(x2, d))))
 
 
 @_wraps(np.extract)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -392,8 +392,11 @@ if numpy_version >= (1, 15):
   JAX_COMPOUND_OP_RECORDS += [
       op_record("isclose", 2, [t for t in all_dtypes if t != jnp.bfloat16],
                 all_shapes, jtu.rand_small_positive, []),
-      op_record("gcd", 2, int_dtypes, all_shapes, jtu.rand_default, []),
-      op_record("lcm", 2, int_dtypes, all_shapes, jtu.rand_default, []),
+      # uint64 is problematic because with any other int type it promotes to float.
+      op_record("gcd", 2, [d for d in int_dtypes + unsigned_dtypes if d != np.uint64],
+                all_shapes, jtu.rand_default, []),
+      op_record("lcm", 2, [d for d in int_dtypes + unsigned_dtypes if d != np.uint64],
+                all_shapes, jtu.rand_default, []),
   ]
   JAX_REDUCER_NO_DTYPE_RECORDS += [
       op_record("ptp", 1, number_dtypes, nonempty_shapes, jtu.rand_default, []),


### PR DESCRIPTION
Unblocked by support for unsigned ints in `jnp.abs`, added in #3914

Related to #3913 