### PR TITLE
delay backend check for xla_computation

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -369,7 +369,10 @@ def jaxpr_literals(jaxpr):
 
 
 def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
-  platform = xb.get_backend(backend).platform
+  if backend not in ('cpu', 'gpu', 'tpu'):
+    platform = xb.get_backend(backend).platform  # canonicalize
+  else:
+    platform = backend
 
   def read(v):
     if type(v) is Literal:


### PR DESCRIPTION
This helps `xla_computation` generate HLO programs even for device types not available at build time.

Internal global test showed no issues here.