### PR TITLE
Add NumPy backend

### DIFF
--- a/jax/interpreters/numpy_eval.py
+++ b/jax/interpreters/numpy_eval.py
@@ -1,0 +1,725 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import namedtuple
+from contextlib import contextmanager
+from typing import Any, Dict, Callable, Union, Sequence, Tuple, List
+import builtins
+import itertools
+import numpy as np
+from numpy import ndarray
+import opt_einsum
+import scipy.special
+
+from .. import core, config, dtypes, xla, util, ad_util, random, partial, curry
+from ..core import Primitive, Trace, Jaxpr, TypedJaxpr
+from ..lax import lax
+
+_slice = builtins.slice
+_min = builtins.min
+_map = builtins.map
+
+map = util.safe_map
+zip = util.safe_zip
+
+Array = Union[ndarray, xla.DeviceArray]
+
+np_impl: Dict[Primitive, Callable[..., Any]] = {}
+
+class NumpyEvalTrace(Trace):
+  def pure(self, x): return x
+  lift = sublift = pure
+
+  def process_primitive(self, primitive, tracers, params):
+    impl = np_impl.get(primitive)
+    if impl is None:
+      raise NotImplementedError("NumPy backend does not yet support the "
+                                f"'{primitive}' primitive.")
+    return impl(*tracers, **params)
+
+  def process_call(self, primitive, f, tracers, params):
+    return f.call_wrapped(*tracers)
+  process_map = process_call
+
+@contextmanager
+def numpy_eval():
+  """
+  Makes JAX code evaluate with NumPy instead of XLA.
+
+  >>> @numpy_eval()
+  ... def some_fun(...):
+  ...  # jax code
+
+  Inline:
+
+  >>> from jax.interpreters.numpy_eval import numpy_eval
+  ... with numpy_eval():
+  ...   # jax code
+
+  ``jit(numpy_eval()(some_fun))`` will collapse constant calculations using NumPy,
+  so that no operations are performed on the XLA device during compilation.
+
+  `numpy_eval` is thread-safe.
+  """
+  assert config.omnistaging_enabled, "The NumPy backend requires omnistaging."
+  with core.new_base_main(NumpyEvalTrace):
+    yield
+
+def _ensure_numpy(a: Array) -> ndarray:
+  return np.asarray(a) if isinstance(a, xla.DeviceArray) else a
+
+neg = np.negative
+np_impl[lax.neg_p] = neg
+
+sign = np.sign
+np_impl[lax.sign_p] = sign
+
+floor = np.floor
+np_impl[lax.floor_p] = floor
+
+ceil = np.ceil
+np_impl[lax.ceil_p] = ceil
+
+def round(x):
+  return np.trunc(
+    x + np.copysign(np.nextafter(np.array(.5, dtype=x.dtype),
+                                 np.array(0., dtype=x.dtype),
+                                 dtype=x.dtype), x)).astype(x.dtype)
+np_impl[lax.round_p] = round
+
+nextafter = np.nextafter
+np_impl[lax.nextafter_p] = nextafter
+
+is_finite = np.isfinite
+np_impl[lax.is_finite_p] = is_finite
+
+exp = np.exp
+np_impl[lax.exp_p] = exp
+
+expm1 = np.expm1
+np_impl[lax.expm1_p] = expm1
+
+log = np.log
+np_impl[lax.log_p] = log
+
+log1p = np.log1p
+np_impl[lax.log1p_p] = log1p
+
+tanh = np.tanh
+np_impl[lax.tanh_p] = tanh
+
+sin = np.sin
+np_impl[lax.sin_p] = sin
+
+cos = np.cos
+np_impl[lax.cos_p] = cos
+
+def atan2(x, x2): return np.arctan2(x, x2).astype(x.dtype)
+np_impl[lax.atan2_p] = atan2
+
+sqrt = np.sqrt
+np_impl[lax.sqrt_p] = sqrt
+
+def rsqrt(x): return np.ones_like(x) / np.sqrt(x)
+np_impl[lax.rsqrt_p] = rsqrt
+
+sinh = np.sinh
+np_impl[lax.sinh_p] = sinh
+
+cosh = np.cosh
+np_impl[lax.cosh_p] = cosh
+
+asinh = np.arcsinh
+np_impl[lax.asinh_p] = asinh
+
+acosh = np.arccosh
+np_impl[lax.acosh_p] = acosh
+
+atanh = np.arctanh
+np_impl[lax.atanh_p] = atanh
+
+def betainc(a, b, x): return scipy.special.betainc(a, b, x).astype(x.dtype)
+np_impl[lax.regularized_incomplete_beta_p] = betainc
+
+def lgamma(x): return scipy.special.gammaln(x).astype(x.dtype)
+np_impl[lax.lgamma_p] = lgamma
+
+def digamma(x): return scipy.special.digamma(x).astype(x.dtype)
+np_impl[lax.digamma_p] = digamma
+
+igamma = scipy.special.gammainc
+np_impl[lax.igamma_p] = igamma
+
+igammac = scipy.special.gammaincc
+np_impl[lax.igammac_p] = igammac
+
+# TODO lax.igamma_grad_a_p
+
+def erf(x): return scipy.special.erf(x).astype(x.dtype)
+np_impl[lax.erf_p] = erf
+
+def erfc(x): return scipy.special.erfc(x).astype(x.dtype)
+np_impl[lax.erfc_p] = erfc
+
+def erf_inv(x): return scipy.special.erfinv(x).astype(x.dtype)
+np_impl[lax.erf_inv_p] = erf_inv
+
+def bessel_i0e(x): return scipy.special.i0e(x).astype(x.dtype)
+np_impl[lax.bessel_i0e_p] = bessel_i0e
+
+def bessel_i1e(x): return scipy.special.i1e(x).astype(x.dtype)
+np_impl[lax.bessel_i1e_p] = bessel_i1e
+
+real = np.real
+np_impl[lax.real_p] = real
+
+imag = np.imag
+np_impl[lax.imag_p] = imag
+
+def conj(x, input_dtype=None): return np.conj(x) + np.complex64(0)
+np_impl[lax.conj_p] = conj
+
+def complex(x, y): return x + np.complex64(1j) * y
+np_impl[lax.complex_p] = complex
+
+abs = np.absolute
+np_impl[lax.abs_p] = abs
+
+pow = np.power
+np_impl[lax.pow_p] = pow
+
+def integer_pow(x, y): return np.asarray(pow(x, y)).astype(x.dtype)
+np_impl[lax.integer_pow_p] = integer_pow
+
+bitwise_not = np.bitwise_not
+np_impl[lax.not_p] = bitwise_not
+
+bitwise_and = np.bitwise_and
+np_impl[lax.and_p] = bitwise_and
+
+bitwise_or = np.bitwise_or
+np_impl[lax.or_p] = bitwise_or
+
+bitwise_xor = np.bitwise_xor
+np_impl[lax.xor_p] = bitwise_xor
+
+add = np.add
+np_impl[lax.add_p] = add
+
+sub = np.subtract
+np_impl[lax.sub_p] = sub
+
+mul = np.multiply
+np_impl[lax.mul_p] = mul
+
+def div(lhs, rhs):
+  if dtypes.issubdtype(dtypes.dtype(lhs), np.integer):
+    quotient = np.floor_divide(lhs, rhs)
+    select = np.logical_and(np.sign(lhs) != np.sign(rhs),
+                            np.remainder(lhs, rhs) != 0)
+    return np.where(select, quotient + 1, quotient)
+  else:
+    return np.divide(lhs, rhs)
+np_impl[lax.div_p] = div
+
+def rem(lhs, rhs): return np.sign(lhs) * np.remainder(np.abs(lhs), np.abs(rhs))
+np_impl[lax.rem_p] = rem
+
+max = np.maximum
+np_impl[lax.max_p] = max
+
+min = np.minimum
+np_impl[lax.min_p] = min
+
+shift_left = np.left_shift
+np_impl[lax.shift_left_p] = shift_left
+
+@curry
+def _shift_right(shift_types: Dict, x1, x2):
+  shift_type = shift_types[x1.dtype]
+  shifted = np.right_shift(x1.view(shift_type), x2.astype(shift_type))
+  return shifted.astype(shift_type).view(x1.dtype)
+
+_arithmetic_shift_types = {
+  np.dtype('int8'): np.int8,
+  np.dtype('int16'): np.int16,
+  np.dtype('int32'): np.int32,
+  np.dtype('int64'): np.int64,
+  # lax does arithmetic (signed) shift irrespective of the type:
+  np.dtype('uint8'): np.int8,
+  np.dtype('uint16'): np.int16,
+  np.dtype('uint32'): np.int32,
+  np.dtype('uint64'): np.int64,
+}
+
+shift_right_arithmetic = _shift_right(_arithmetic_shift_types)
+np_impl[lax.shift_right_arithmetic_p] = shift_right_arithmetic
+
+_logical_shift_types = {
+  np.dtype('int8'): np.uint8,
+  np.dtype('int16'): np.uint16,
+  np.dtype('int32'): np.uint32,
+  np.dtype('int64'): np.uint64,
+  np.dtype('uint8'): np.uint8,
+  np.dtype('uint16'): np.uint16,
+  np.dtype('uint32'): np.uint32,
+  np.dtype('uint64'): np.uint64,
+}
+
+shift_right_logical = _shift_right(_logical_shift_types)
+np_impl[lax.shift_right_logical_p] = shift_right_logical
+
+def population_count(x):
+  assert np.issubdtype(x.dtype, np.integer)
+  dtype = x.dtype
+  iinfo = np.iinfo(x.dtype)
+  if np.iinfo(x.dtype).bits < 32:
+    assert iinfo.kind in ('i', 'u')
+    x = x.astype(np.uint32 if iinfo.kind == 'u' else np.int32)
+  if iinfo.kind == 'i':
+    x = x.view(f"uint{np.iinfo(x.dtype).bits}")
+  assert x.dtype in (np.uint32, np.uint64)
+  m = [
+    0x5555555555555555,  # binary: 0101...
+    0x3333333333333333,  # binary: 00110011..
+    0x0f0f0f0f0f0f0f0f,  # binary:  4 zeros,  4 ones ...
+    0x00ff00ff00ff00ff,  # binary:  8 zeros,  8 ones ...
+    0x0000ffff0000ffff,  # binary: 16 zeros, 16 ones ...
+    0x00000000ffffffff,  # binary: 32 zeros, 32 ones
+  ]
+
+  if x.dtype == np.uint32:
+    m = list(_map(np.uint32, m[:-1]))
+  else:
+    m = list(_map(np.uint64, m))
+
+  x = (x & m[0]) + ((x >>  1) & m[0])  # put count of each  2 bits into those  2 bits
+  x = (x & m[1]) + ((x >>  2) & m[1])  # put count of each  4 bits into those  4 bits
+  x = (x & m[2]) + ((x >>  4) & m[2])  # put count of each  8 bits into those  8 bits
+  x = (x & m[3]) + ((x >>  8) & m[3])  # put count of each 16 bits into those 16 bits
+  x = (x & m[4]) + ((x >> 16) & m[4])  # put count of each 32 bits into those 32 bits
+  if x.dtype == np.uint64:
+    x = (x & m[5]) + ((x >> 32) & m[5])  # put count of each 64 bits into those 64 bits
+  return x.astype(dtype)
+np_impl[lax.population_count_p] = population_count
+
+eq = np.equal
+np_impl[lax.eq_p] = eq
+
+ne = np.not_equal
+np_impl[lax.ne_p] = ne
+
+ge = np.greater_equal
+np_impl[lax.ge_p] = ge
+
+gt = np.greater
+np_impl[lax.gt_p] = gt
+
+le = np.less_equal
+np_impl[lax.le_p] = le
+
+lt = np.less
+np_impl[lax.lt_p] = lt
+
+def convert_element_type(operand, new_dtype, old_dtype=None):
+  return np.asarray(operand, dtype=new_dtype)
+np_impl[lax.convert_element_type_p] = convert_element_type
+
+def bitcast_convert_type(operand, new_dtype):
+  return np.asarray(operand).view(new_dtype)
+np_impl[lax.bitcast_convert_type_p] = bitcast_convert_type
+
+def clamp(min, operand, max):
+  return np.clip(operand, np.clip(min, None, max), max).astype(operand.dtype)
+np_impl[lax.clamp_p] = clamp
+
+def concatenate(*operands, dimension):
+  return np.concatenate(operands, dimension)
+np_impl[lax.concatenate_p] = concatenate
+
+def conv_general_dilated(lhs, rhs, window_strides, padding,
+                         lhs_dilation, rhs_dilation, dimension_numbers,
+                         feature_group_count, batch_group_count, **_):
+  lhs_perm, rhs_perm, out_perm = dimension_numbers
+  lhs = np.transpose(lhs, lhs_perm)
+  rhs = np.transpose(rhs, rhs_perm)
+  batch_size, feature_size, *spatial_shape = lhs.shape
+  lhs = np.reshape(
+    lhs, (batch_group_count, batch_size // batch_group_count,
+          feature_group_count, feature_size // feature_group_count) +
+         tuple(spatial_shape)).swapaxes(1, 2)
+  feature_size, *sh = rhs.shape
+  rhs = np.reshape(
+    rhs, (batch_group_count, feature_group_count,
+          feature_size // batch_group_count // feature_group_count) + tuple(sh))
+  outs = [conv_with_general_padding(lhs, rhs, window_strides, padding,
+                                    lhs_dilation, rhs_dilation)
+          for lhs, rhs in zip(lhs, rhs) for lhs, rhs in zip(lhs, rhs)]
+  return np.transpose(np.concatenate(outs, axis=1), np.argsort(out_perm))
+np_impl[lax.conv_general_dilated_p] = conv_general_dilated
+
+def conv_with_general_padding(lhs, rhs, window_strides, padding, lhs_dilation,
+                              rhs_dilation, precision=None):
+  return _conv(_dilate(lhs, lhs_dilation), _dilate(rhs, rhs_dilation),
+               window_strides, padding)
+
+def _dilate(operand, factors, fill_value=0):
+  # this logic is like lax.pad, but with two leading dimensions, no edge
+  # padding, and factors are at least 1 (interior padding is at least 0)
+  outspace = lax._dilate_shape(operand.shape[2:], dilation=factors)
+  out = np.full(operand.shape[:2] + tuple(outspace), fill_value, operand.dtype)
+  lhs_slices = tuple(_slice(None, None, step) for step in factors)
+  out[(_slice(None),) * 2 + lhs_slices] = operand
+  return out
+
+def _conv(lhs, rhs, window_strides, pads):
+  view, view_axes, rhs_axes, out_axes = _conv_view(
+    lhs, rhs.shape, window_strides, pads, 0.)
+  return opt_einsum.contract(
+    view, view_axes, rhs, rhs_axes, out_axes, use_blas=True)
+
+def _conv_view(lhs, rhs_shape, window_strides, pads, pad_value):
+  """Compute the view (and its axes) of a convolution or window reduction."""
+  if (_min(lhs.ndim, len(rhs_shape)) < 2 or lhs.ndim != len(rhs_shape)
+          or lhs.shape[1] != rhs_shape[1]):
+    raise ValueError('Dimension mismatch')
+  if len(window_strides) != len(rhs_shape) - 2:
+    raise ValueError('Wrong number of strides for spatial dimensions')
+  if len(pads) != len(rhs_shape) - 2:
+    raise ValueError('Wrong number of pads for spatial dimensions')
+
+  lhs = _pad(lhs, [(0, 0)] * 2 + list(pads), pad_value)
+  in_shape = lhs.shape[2:]
+  filter_shape = rhs_shape[2:]
+  dim = len(filter_shape)  # number of 'spatial' dimensions in convolution
+
+  out_strides = np.multiply(window_strides, lhs.strides[2:])
+  view_strides = lhs.strides[:1] + tuple(out_strides) + lhs.strides[1:]
+
+  out_shape = np.maximum(
+    0, np.floor_divide(np.subtract(in_shape, filter_shape), window_strides) + 1)
+  view_shape = lhs.shape[:1] + tuple(out_shape) + rhs_shape[1:]
+
+  view = np.lib.stride_tricks.as_strided(lhs, view_shape, view_strides)
+
+  view_axes = list(range(view.ndim))
+  sum_axes = view_axes[-dim-1:]
+  rhs_axes = [view.ndim] + sum_axes
+  out_axes = [0, view.ndim] + list(range(1, dim+1))
+
+  return view, view_axes, rhs_axes, out_axes
+
+def _pad(arr, pads, pad_value):
+  out = np.pad(arr, np.maximum(0, pads), mode='constant',
+               constant_values=pad_value).astype(arr.dtype)
+  slices = tuple(_slice(abs(lo) if lo < 0 else 0, hi % dim if hi < 0 else None)
+                 for (lo, hi), dim in zip(pads, np.shape(arr)))
+  return out[slices]
+
+is_np_version_below_1_19 = np.lib.NumpyVersion(np.__version__) < np.lib.NumpyVersion('1.19.0')
+Ufunc = namedtuple('ufunc', ['reduce', 'identity'])
+ufunc = Union[np.ufunc, Ufunc]
+
+@curry
+def _reduce(reducer: ufunc, operand: Array, axes: Tuple[int, ...]) -> ndarray:
+  operand = np.asarray(operand)
+  dtype = operand.dtype
+  if dtype == dtypes.bfloat16:
+    operand = operand.astype(np.float32)
+  elif dtype == np.uint64 and not config.FLAGS.jax_enable_x64:
+    operand = operand.astype(np.uint32)
+  out = reducer.reduce(operand, axis=axes)
+  if dtype == dtypes.bfloat16 and out.dtype == np.object:
+    out = out.astype(np.float32)
+  return out.astype(dtype)
+np_impl[lax.reduce_sum_p] = _reduce(np.add)
+np_impl[lax.reduce_prod_p] = _reduce(np.multiply)
+np_impl[lax.reduce_max_p] = _reduce(np.maximum)
+np_impl[lax.reduce_min_p] = _reduce(np.minimum)
+np_impl[lax.reduce_or_p] = _reduce(np.logical_or)
+np_impl[lax.reduce_and_p] = _reduce(np.logical_and)
+
+def reduce(operand: Array, init_value: Array, computation: Callable,
+           jaxpr: Jaxpr, consts: Tuple[Any, ...],
+           dimensions: Tuple[int, ...]) -> ndarray:
+  reducer = _reducer(jaxpr, consts, init_value)
+  return _reduce(reducer)(operand, dimensions)
+np_impl[lax.reduce_p] = reduce
+
+def _reducer(jaxpr: Jaxpr, consts: Tuple[Any, ...], init_value: Array) -> ufunc:
+  aval = lax._abstractify(init_value)
+  fun = core.jaxpr_as_fun(TypedJaxpr(jaxpr, consts, (aval, aval), (aval,)))
+  @numpy_eval()
+  def binop(x, y):
+    out, = fun(x, y)
+    return out
+
+  binop_ = (lambda x, y: binop(np.array(x, np.uint64), np.array(y, np.uint64))
+            if dtypes.dtype(init_value) == np.uint64 else binop)
+
+  if dtypes.dtype(init_value) == dtypes.bfloat16:
+    init_value = np.asarray(init_value, dtype=np.float32)
+
+  if is_np_version_below_1_19:
+    # np.frompyfunc does not have identity parameter before NumPy version 1.19:
+    # https://numpy.org/doc/1.18/reference/generated/numpy.frompyfunc.html
+    def reduce(operand, axis=0):
+      axis = range(np.ndim(operand)) if axis is None else axis
+      result = np.full(np.delete(np.shape(operand), axis), init_value,
+                       dtype=dtypes.dtype(operand))
+      for idx, _ in np.ndenumerate(operand):
+        out_idx = tuple(np.delete(idx, axis))
+        result[out_idx] = binop_(result[out_idx], operand[idx])
+      return result
+    return Ufunc(reduce=reduce, identity=init_value)
+
+  return np.frompyfunc(binop_, nin=2, nout=1, identity=init_value)
+
+@curry
+def _reduce_window(reducer: ufunc, operand: Array,
+                   window_dimensions: Tuple[int, ...],
+                   window_strides: Tuple[int, ...],
+                   padding: Tuple[Tuple[int, int], ...],
+                   base_dilation: Tuple[int, ...],
+                   window_dilation: Tuple[int, ...]) -> ndarray:
+  operand = np.reshape(operand, (1, 1) + operand.shape)
+  dilated_window_shape = lax._dilate_shape(window_dimensions, window_dilation)
+  identity = _identity(reducer, operand.dtype)
+  if any(d != 1 for d in base_dilation):
+    operand = _dilate(operand, base_dilation, identity)
+  view, *_ = _conv_view(operand, (1, 1) + tuple(dilated_window_shape),
+                        window_strides, padding, pad_value=identity)
+  el: List[Any] = [...]
+  view = view[tuple(el + [_slice(None, None, d) for d in window_dilation])]
+  view = view.reshape(view.shape[1:1+len(window_dimensions)] + (-1,))
+  return _reduce(reducer)(view, axes=-1)
+np_impl[lax.reduce_window_max_p] = _reduce_window(np.maximum)
+np_impl[lax.reduce_window_min_p] = _reduce_window(np.minimum)
+np_impl[lax.reduce_window_sum_p] = _reduce_window(np.add)
+
+def _identity(reducer: ufunc, dtype: Any) -> ndarray:
+  if reducer is np.maximum or reducer is np.minimum:
+    ismin = reducer is np.minimum
+    if dtype == np.bool: return ismin
+    if dtypes.issubdtype(dtype, np.inexact): return np.inf if ismin else -np.inf
+    return np.iinfo(dtype).max if ismin else np.iinfo(dtype).min
+  return np.asarray(reducer.identity, dtype=dtype)
+
+def reduce_window(operand: Array, init_value: Array,
+                  jaxpr: Jaxpr, consts: Tuple[Any, ...],
+                  window_dimensions: Tuple[int, ...],
+                  window_strides: Tuple[int, ...],
+                  padding: Tuple[Tuple[int, int], ...],
+                  base_dilation: Tuple[int, ...],
+                  window_dilation: Tuple[int, ...]) -> ndarray:
+  reducer = _reducer(jaxpr, consts, init_value)
+  return _reduce_window(reducer)(operand, window_dimensions,
+                                 window_strides, padding,
+                                 base_dilation, window_dilation)
+np_impl[lax.reduce_window_p] = reduce_window
+
+def dot_general(lhs, rhs, dimension_numbers, precision=None):
+  (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
+  new_id = itertools.count()
+  lhs_axis_ids = [next(new_id) for _ in lhs.shape]
+  rhs_axis_ids = [next(new_id) for _ in rhs.shape]
+  lhs_out_axis_ids = lhs_axis_ids[:]
+  rhs_out_axis_ids = rhs_axis_ids[:]
+
+  for lhs_axis, rhs_axis in zip(lhs_contracting, rhs_contracting):
+    shared_id = next(new_id)
+    lhs_axis_ids[lhs_axis] = shared_id
+    rhs_axis_ids[rhs_axis] = shared_id
+    lhs_out_axis_ids[lhs_axis] = None
+    rhs_out_axis_ids[rhs_axis] = None
+
+  batch_ids = []
+  for lhs_axis, rhs_axis in zip(lhs_batch, rhs_batch):
+    shared_id = next(new_id)
+    lhs_axis_ids[lhs_axis] = shared_id
+    rhs_axis_ids[rhs_axis] = shared_id
+    lhs_out_axis_ids[lhs_axis] = None
+    rhs_out_axis_ids[rhs_axis] = None
+    batch_ids.append(shared_id)
+
+  not_none = lambda x: x is not None
+  out_axis_ids = filter(not_none,
+                        batch_ids + lhs_out_axis_ids + rhs_out_axis_ids)
+  assert lhs.dtype == rhs.dtype
+  dtype = np.float32 if lhs.dtype == dtypes.bfloat16 else None
+  out = np.einsum(lhs, lhs_axis_ids, rhs, rhs_axis_ids, out_axis_ids,
+                  dtype=dtype)
+  return out.astype(dtypes.bfloat16) if lhs.dtype == dtypes.bfloat16 else out
+np_impl[lax.dot_general_p] = dot_general
+
+def broadcast_in_dim(operand, shape, broadcast_dimensions):
+  in_reshape = np.ones(len(shape), dtype=np.int32)
+  for i, bd in enumerate(broadcast_dimensions):
+    in_reshape[bd] = operand.shape[i]
+  return np.broadcast_to(np.reshape(operand, in_reshape), shape)
+np_impl[lax.broadcast_in_dim_p] = broadcast_in_dim
+
+def squeeze(array, dimensions): return np.squeeze(array, dimensions)
+np_impl[lax.squeeze_p] = squeeze
+
+def reshape(operand, new_sizes, dimensions=None):
+  if dimensions is not None:
+    operand = np.transpose(operand, dimensions)
+  return np.reshape(_ensure_numpy(operand), new_sizes)
+np_impl[lax.reshape_p] = reshape
+
+def pad(operand, padding_value, padding_config):
+  # https://www.tensorflow.org/xla/operation_semantics#pad
+  lo, hi, interior = zip(*padding_config)
+  # Handle first the positive edge padding and interior
+  lo_pos, hi_pos = np.clip(lo, 0, None), np.clip(hi, 0, None)
+  outshape = np.add(
+    np.add(np.add(lo_pos, hi_pos), operand.shape),
+    np.maximum(0, np.multiply(interior, np.subtract(operand.shape, 1))))
+  out = np.full(outshape, padding_value, operand.dtype)
+  lhs_slices = tuple(_slice(l if l > 0 else 0, -h if h > 0 else None, step)
+                     for l, h, step in zip(lo_pos, hi_pos, np.add(1, interior)))
+  out[lhs_slices] = operand
+  trim_slices = tuple(_slice(-l if l < 0 else 0, h if h < 0 else None)
+                      for l, h in zip(lo, hi))
+  return out[trim_slices]
+np_impl[lax.pad_p] = pad
+
+def rev(operand, dimensions):
+  dimensions = frozenset(dimensions)
+  indexer = (_slice(None, None, -1) if d in dimensions else _slice(None)
+             for d in range(np.ndim(operand)))
+  return operand[tuple(indexer)]
+np_impl[lax.rev_p] = rev
+
+select = np.where
+np_impl[lax.select_p] = select
+
+def slice(operand, start_indices, limit_indices, strides=None):  # pylint: disable=redefined-builtin
+  if strides is None:
+    strides = np.ones(len(start_indices)).astype(int)
+  idx = tuple(map(_slice, start_indices, limit_indices, strides))
+  return _ensure_numpy(operand)[idx]
+np_impl[lax.slice_p] = slice
+
+def dynamic_slice(operand, *start_indices, slice_sizes):
+  out = np.zeros(slice_sizes, dtype=operand.dtype)
+  idx = tuple(_slice(start, start+size)
+              for start, size in zip(start_indices, slice_sizes))
+  section = _ensure_numpy(operand)[idx]
+  out[tuple(_slice(None, stop) for stop in section.shape)] = section
+  return out
+np_impl[lax.dynamic_slice_p] = dynamic_slice
+
+def dynamic_update_slice(operand, update, *start_indices):
+  slices = tuple(map(_slice, start_indices, np.add(start_indices, update.shape)))
+  updated_operand = np.copy(operand)
+  updated_operand[slices] = update
+  return updated_operand
+np_impl[lax.dynamic_update_slice_p] = dynamic_update_slice
+
+def transpose(operand: Array, permutation: Sequence[int]) -> ndarray:
+  return np.transpose(_ensure_numpy(operand), permutation)
+np_impl[lax.transpose_p] = transpose
+
+def sort(*operands, dimension, is_stable, num_keys):
+  if len(operands) == 1:
+    operand, = operands
+    return np.sort(operand, dimension, 'stable' if is_stable else 'quicksort'),
+  keys = operands[:num_keys][::-1]
+  indices = np.lexsort(keys, axis=dimension)
+  return tuple(np.take_along_axis(o, indices, axis=dimension) for o in operands)
+np_impl[lax.sort_p] = sort
+
+def sort_key_val(keys, values, dimension=-1, is_stable=True):
+  return sort(keys, values,
+              dimension=dimension, is_stable=is_stable, num_keys=1)
+
+def top_k(x, k):
+  bcast_idxs = np.broadcast_to(np.arange(x.shape[-1], dtype=np.int32), x.shape)
+  sorted_vals, sorted_idxs = sort_key_val(x, bcast_idxs)
+  return sorted_vals[..., :-k-1:-1], sorted_idxs[..., :-k-1:-1]
+np_impl[lax.top_k_p] = top_k
+
+def argmax(operand, axes, index_dtype):
+  axis, = axes
+  return np.argmax(operand, axis).astype(index_dtype)
+np_impl[lax.argmax_p] = argmax
+
+def argmin(operand, axes, index_dtype):
+  axis, = axes
+  return np.argmin(operand, axis).astype(index_dtype)
+np_impl[lax.argmin_p] = argmin
+
+cummin = np.minimum.accumulate
+np_impl[lax.cummin_p] = cummin
+
+cummax = np.maximum.accumulate
+np_impl[lax.cummax_p] = cummax
+
+def cumsum(x, axis): return np.cumsum(x, axis).astype(x.dtype)
+np_impl[lax.cumsum_p] = cumsum
+
+def cumprod(x, axis): return np.cumprod(x, axis).astype(x.dtype)
+np_impl[lax.cumprod_p] = cumprod
+
+def gather(operand: Array, start_indices: Array,
+           dimension_numbers: lax.GatherDimensionNumbers,
+           slice_sizes: lax.Shape) -> ndarray:
+  offset_dims, collapsed_slice_dims, axes = dimension_numbers
+  indices_shape = start_indices.shape[:-1]
+  single = np.prod(indices_shape) == 1
+  uncollapsed_slice_dims = [d for d in range(len(slice_sizes))
+                            if d in axes and d not in collapsed_slice_dims]
+  start_indices = _ensure_numpy(start_indices)
+  if not single:
+    start_indices = start_indices.reshape([1] * len(uncollapsed_slice_dims) +
+                                          list(start_indices.shape))
+  def index(dim: int, slice_size: int):
+    if dim not in axes:
+      return _slice(0, slice_size)
+    (start_dim_index,), = np.argwhere(np.equal(axes, dim))
+    starts = start_indices[..., start_dim_index]
+    # lax.gather_p rectifies start indices to avoid out-of-bound slice elements:
+    starts = np.minimum(starts, operand.shape[dim] - slice_size)
+    if dim in collapsed_slice_dims:
+      return starts
+    if single:
+      start = starts.flat[0]
+      return _slice(start, start + slice_size)
+
+    (udim_index,), = np.argwhere(np.equal(uncollapsed_slice_dims, dim))
+    starts = np.squeeze(starts, udim_index)
+    return np.linspace(starts, stop=starts + slice_size, num=slice_size,
+                       dtype=int, axis=udim_index, endpoint=False)
+  idx = tuple(map(index, range(len(operand.shape)), slice_sizes))
+  out = _ensure_numpy(operand)[idx]
+  if single:
+    return out.reshape(list(indices_shape) + list(out.shape))
+  uncollapsed_slice_output_dims = [
+    udim + len(indices_shape) - np.sum(np.less(collapsed_slice_dims, udim))
+    for udim in uncollapsed_slice_dims]
+  for udim_index, uoutdim in enumerate(reversed(uncollapsed_slice_output_dims)):
+    out = np.moveaxis(out, udim_index, uoutdim)
+  for rev_odim_index, odim in enumerate(reversed(offset_dims)):
+    out = np.moveaxis(out, -(rev_odim_index + 1), odim)
+  return out
+np_impl[lax.gather_p] = gather
+
+# TODO scatter[_add/mul/min/max]_p, select_and_scatter[_add]_p
+
+np_impl[random.threefry2x32_p] = numpy_eval()(partial(
+  random._threefry2x32_lowering, use_rolled_loops=False))
+np_impl[xla.device_put_p] = lambda x, device: x
+np_impl[ad_util.stop_gradient_p] = lambda x: x
+np_impl[ad_util.zeros_like_p] = lambda x: np.zeros(np.shape(x), dtypes.dtype(x))

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -487,7 +487,7 @@ def conv_general_dilated(
   padding: Union[str, Sequence[Tuple[int, int]]],
   lhs_dilation: Optional[Sequence[int]] = None,
   rhs_dilation: Optional[Sequence[int]] = None,
-  dimension_numbers: ConvGeneralDilatedDimensionNumbers  = None,
+  dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
   feature_group_count: int = 1, batch_group_count: int = 1,
   precision: Optional[PrecisionType] = None) -> Array:
   """General n-dimensional convolution operator, with optional dilation.
@@ -1399,8 +1399,18 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
     fill_value = xla.device_put_p.bind(fill_value)
   return broadcast(fill_value, shape)
 
+# TODO(mattjj) remove, we only need this function because _device_put_raw is
+#  used directly in jnp.array/full instead of device_put_p.bind
+def _is_numpy_eval_tracing():
+  if not config.omnistaging_enabled: return False
+  stack = core.thread_local_state.trace_state.trace_stack
+  # TODO(mattjj) improve:
+  trace_type = stack.stack[0].trace_type
+  # __name__ avoids cyclic dependency with numpy_eval:
+  return trace_type.__name__ == 'NumpyEvalTrace'
+
 def _device_put_raw(x):
-  if isinstance(x, xla.DeviceArray):
+  if isinstance(x, xla.DeviceArray) or _is_numpy_eval_tracing():
     return x
   else:
     aval = raise_to_shaped(core.get_aval(x))
@@ -5832,7 +5842,7 @@ def _dilate_shape(shape, dilation):
     msg = "All dilations must be positive, got {}."
     raise TypeError(msg.format(dilation))
   dilation = (1,) * (len(shape) - len(dilation)) + tuple(dilation)
-  return np.where(shape == 0, 0,
+  return np.where(np.equal(shape, 0), 0,
                    np.multiply(dilation, np.subtract(shape, 1)) + 1)
 
 def _ceil_divide(x1, x2):

--- a/jax/lax_reference.py
+++ b/jax/lax_reference.py
@@ -12,439 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import builtins
-import collections
-import itertools
+from typing import Sequence
 
 import numpy as np
-import opt_einsum
-import scipy.special
 
-from . import dtypes
+from . import dtypes, lax
+from .lax.lax import padtype_to_pads, DType, Shape
+# flake8: noqa: F401
+from .interpreters.numpy_eval import (
+  neg, sign, floor, ceil, round, nextafter, is_finite, exp, expm1, log, log1p,
+  tanh, sin, cos, atan2, sqrt, rsqrt, sinh, cosh, asinh, acosh, atanh, betainc,
+  lgamma, digamma, igamma, igammac, erf, erfc, erf_inv, bessel_i0e, bessel_i1e,
+  real, imag, conj, complex, abs, pow, integer_pow, bitwise_not, bitwise_and,
+  bitwise_or, bitwise_xor, add, sub, mul, div, rem, max, min, shift_left,
+  shift_right_arithmetic, shift_right_logical, population_count, eq, ne, ge, gt,
+  le, lt, convert_element_type, bitcast_convert_type, clamp,
+  conv_with_general_padding, dot_general, broadcast_in_dim, squeeze,
+  reshape, pad, rev, select, slice, transpose, sort_key_val, top_k, cummin,
+  cummax, cumsum, cumprod, gather, numpy_eval, _conv
+)
 
-_slice = builtins.slice
-_max = builtins.max
-_min = builtins.min
-_map = builtins.map
-
-neg = np.negative
-sign = np.sign
-floor = np.floor
-ceil = np.ceil
-
-def round(x):
-  return np.trunc(
-    x + np.copysign(np.nextafter(np.array(.5, dtype=x.dtype),
-                                 np.array(0., dtype=x.dtype),
-                                 dtype=x.dtype), x)).astype(x.dtype)
-
-nextafter = np.nextafter
-
-is_finite = np.isfinite
-
-exp = np.exp
-expm1 = np.expm1
-log = np.log
-log1p = np.log1p
-tanh = np.tanh
-sin = np.sin
-cos = np.cos
-atan2 = np.arctan2
-
-sqrt = np.sqrt
-rsqrt = lambda x: np.ones_like(x) / np.sqrt(x)
 square = np.square
 reciprocal = np.reciprocal
 tan = np.tan
 asin = np.arcsin
 acos = np.arccos
 atan = np.arctan
-sinh = np.sinh
-cosh = np.cosh
-asinh = np.arcsinh
-acosh = np.arccosh
-atanh = np.arctanh
+full = np.full
 
-def betainc(a, b, x): return scipy.special.betainc(a, b, x).astype(x.dtype)
-def lgamma(x): return scipy.special.gammaln(x).astype(x.dtype)
-def digamma(x): return scipy.special.digamma(x).astype(x.dtype)
-igamma = scipy.special.gammainc
-igammac = scipy.special.gammaincc
-def erf(x): return scipy.special.erf(x).astype(x.dtype)
-def erfc(x): return scipy.special.erfc(x).astype(x.dtype)
-def erf_inv(x): return scipy.special.erfinv(x).astype(x.dtype)
-
-def bessel_i0e(x): return scipy.special.i0e(x).astype(x.dtype)
-def bessel_i1e(x): return scipy.special.i1e(x).astype(x.dtype)
-
-real = np.real
-imag = np.imag
-
-def conj(x):
-  return np.conj(x) + np.complex64(0)
-
-def complex(x, y):
-  return x + np.complex64(1j) * y
-
-abs = np.absolute
-pow = np.power
-
-bitwise_not = np.bitwise_not
-bitwise_and = np.bitwise_and
-bitwise_or = np.bitwise_or
-bitwise_xor = np.bitwise_xor
-
-add = np.add
-sub = np.subtract
-mul = np.multiply
-
-def div(lhs, rhs):
-  if dtypes.issubdtype(dtypes.result_type(lhs), np.integer):
-    quotient = np.floor_divide(lhs, rhs)
-    select = np.logical_and(np.sign(lhs) != np.sign(rhs),
-                             np.remainder(lhs, rhs) != 0)
-    return np.where(select, quotient + 1, quotient)
-  else:
-    return np.divide(lhs, rhs)
-
-def rem(lhs, rhs):
-  return np.sign(lhs) * np.remainder(np.abs(lhs), np.abs(rhs))
-
-max = np.maximum
-min = np.minimum
-
-shift_left = np.left_shift
-shift_right_arithmetic = np.right_shift
-# TODO shift_right_logical
-
-def population_count(x):
-  assert np.issubdtype(x.dtype, np.integer)
-  dtype = x.dtype
-  iinfo = np.iinfo(x.dtype)
-  if np.iinfo(x.dtype).bits < 32:
-    assert iinfo.kind in ('i', 'u')
-    x = x.astype(np.uint32 if iinfo.kind == 'u' else np.int32)
-  if iinfo.kind == 'i':
-    x = x.view(f"uint{np.iinfo(x.dtype).bits}")
-  assert x.dtype in (np.uint32, np.uint64)
-  m = [
-      0x5555555555555555,  # binary: 0101...
-      0x3333333333333333,  # binary: 00110011..
-      0x0f0f0f0f0f0f0f0f,  # binary:  4 zeros,  4 ones ...
-      0x00ff00ff00ff00ff,  # binary:  8 zeros,  8 ones ...
-      0x0000ffff0000ffff,  # binary: 16 zeros, 16 ones ...
-      0x00000000ffffffff,  # binary: 32 zeros, 32 ones
-  ]
-
-  if x.dtype == np.uint32:
-    m = list(map(np.uint32, m[:-1]))
-  else:
-    m = list(map(np.uint64, m))
-
-  x = (x & m[0]) + ((x >>  1) & m[0])  # put count of each  2 bits into those  2 bits
-  x = (x & m[1]) + ((x >>  2) & m[1])  # put count of each  4 bits into those  4 bits
-  x = (x & m[2]) + ((x >>  4) & m[2])  # put count of each  8 bits into those  8 bits
-  x = (x & m[3]) + ((x >>  8) & m[3])  # put count of each 16 bits into those 16 bits
-  x = (x & m[4]) + ((x >> 16) & m[4])  # put count of each 32 bits into those 32 bits
-  if x.dtype == np.uint64:
-    x = (x & m[5]) + ((x >> 32) & m[5])  # put count of each 64 bits into those 64 bits
-  return x.astype(dtype)
-
-eq = np.equal
-ne = np.not_equal
-ge = np.greater_equal
-gt = np.greater
-le = np.less_equal
-lt = np.less
-
-def convert_element_type(operand, dtype):
-  return np.asarray(operand, dtype=dtype)
-
-def bitcast_convert_type(operand, dtype):
-  return np.asarray(operand).view(dtype)
-
-def clamp(min, operand, max):
-  return np.clip(operand, np.clip(min, None, max), max).astype(operand.dtype)
-
-def concatenate(operands, dimension):
-  return np.concatenate(operands, axis=dimension)
-
-def conv(lhs, rhs, window_strides, padding):
-  pads = padtype_to_pads(lhs.shape[2:], rhs.shape[2:], window_strides, padding)
-  return _conv(lhs, rhs, window_strides, pads)
-
-def conv_with_general_padding(
-    lhs, rhs, window_strides, padding, lhs_dilation, rhs_dilation):
-  return _conv(_dilate(lhs, lhs_dilation), _dilate(rhs, rhs_dilation),
-               window_strides, padding)
-
-def conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation,
-                         rhs_dilation, dimension_numbers):
-  lhs_perm, rhs_perm, out_perm = _conv_general_permutations(dimension_numbers)
-  if isinstance(padding, str):
-    padding = padtype_to_pads(np.take(lhs.shape, lhs_perm)[2:],
-                              np.take(rhs.shape, rhs_perm)[2:],
-                              window_strides, padding)
-  trans_lhs = transpose(lhs, lhs_perm)
-  trans_rhs = transpose(rhs, rhs_perm)
-  out = conv_with_general_padding(trans_lhs, trans_rhs, window_strides, padding,
-                                  lhs_dilation, rhs_dilation)
-  return transpose(out, np.argsort(out_perm))
-
-dot = np.dot
-
-def dot_general(lhs, rhs, dimension_numbers):
-  (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
-  new_id = itertools.count()
-  lhs_axis_ids = [next(new_id) for _ in lhs.shape]
-  rhs_axis_ids = [next(new_id) for _ in rhs.shape]
-  lhs_out_axis_ids = lhs_axis_ids[:]
-  rhs_out_axis_ids = rhs_axis_ids[:]
-
-  for lhs_axis, rhs_axis in zip(lhs_contracting, rhs_contracting):
-    shared_id = next(new_id)
-    lhs_axis_ids[lhs_axis] = shared_id
-    rhs_axis_ids[rhs_axis] = shared_id
-    lhs_out_axis_ids[lhs_axis] = None
-    rhs_out_axis_ids[rhs_axis] = None
-
-  batch_ids = []
-  for lhs_axis, rhs_axis in zip(lhs_batch, rhs_batch):
-    shared_id = next(new_id)
-    lhs_axis_ids[lhs_axis] = shared_id
-    rhs_axis_ids[rhs_axis] = shared_id
-    lhs_out_axis_ids[lhs_axis] = None
-    rhs_out_axis_ids[rhs_axis] = None
-    batch_ids.append(shared_id)
-
-  not_none = lambda x: x is not None
-  out_axis_ids = filter(not_none,
-                        batch_ids + lhs_out_axis_ids + rhs_out_axis_ids)
-  assert lhs.dtype == rhs.dtype
-  dtype = np.float32 if lhs.dtype == dtypes.bfloat16 else None
-  out = np.einsum(lhs, lhs_axis_ids, rhs, rhs_axis_ids, out_axis_ids,
-                   dtype=dtype)
-  return out.astype(dtypes.bfloat16) if lhs.dtype == dtypes.bfloat16 else out
+def dot(a, b, *, precision=None): return np.dot(a, b)
 
 def broadcast(operand, sizes):
   return np.broadcast_to(operand, sizes + np.shape(operand))
 
-def broadcast_in_dim(operand, shape, broadcast_dimensions):
-  in_reshape = np.ones(len(shape), dtype=np.int32)
-  for i, bd in enumerate(broadcast_dimensions):
-    in_reshape[bd] = operand.shape[i]
-  return np.broadcast_to(np.reshape(operand, in_reshape), shape)
+def conv(lhs, rhs, window_strides: Sequence[int], padding: str, precision=None):
+  pads = padtype_to_pads(lhs.shape[2:], rhs.shape[2:], window_strides, padding)
+  return _conv(lhs, rhs, window_strides, pads)
 
-sum = np.sum
+def broadcasted_iota(dtype: DType, shape: Shape, dimension: int):
+  arr = np.arange(shape[dimension], dtype=dtypes.canonicalize_dtype(dtype))
+  singleton_shape = [1] * len(shape)
+  singleton_shape[dimension] = shape[dimension]
+  return np.broadcast_to(arr.reshape(singleton_shape), shape)
 
-squeeze = np.squeeze
+def _delta(dtype: DType, shape: Shape, axes: Sequence[int]):
+  base = np.zeros(np.take(shape, axes), dtype=dtype)
+  base[np.diag_indices(np.min(base.shape), ndim=base.ndim)] = 1
+  broadcast_axes = [a for a in range(len(shape)) if a not in axes]
+  for a in broadcast_axes:
+    base = np.expand_dims(base, a)  # not all at once to support NumPy 1.16
+  return np.broadcast_to(base, shape)
 
-def reshape(operand, new_sizes, dimensions=None):
-  if dimensions is None:
-    dimensions = range(len(np.shape(operand)))
-  return np.reshape(np.transpose(operand, dimensions), new_sizes)
-
-def pad(operand, padding_value, padding_config):
-  # https://www.tensorflow.org/xla/operation_semantics#pad
-  lo, hi, interior = zip(*padding_config)
-  # Handle first the positive edge padding and interior
-  lo_pos, hi_pos = np.clip(lo, 0, None), np.clip(hi, 0, None)
-  outshape = np.add(np.add(np.add(lo_pos, hi_pos), operand.shape),
-                     np.multiply(interior, np.subtract(operand.shape, 1)))
-  out = np.full(outshape, padding_value, operand.dtype)
-  lhs_slices = tuple(_slice(l if l > 0 else 0, -h if h > 0 else None, step)
-                     for l, h, step in zip(lo_pos, hi_pos, np.add(1, interior)))
-  out[lhs_slices] = operand
-  trim_slices = tuple(_slice(-l if l < 0 else 0, h if h < 0 else None)
-                     for l, h in zip(lo, hi))
-  return out[trim_slices]
-
-def rev(operand, dimensions):
-  dimensions = frozenset(dimensions)
-  indexer = (_slice(None, None, -1) if d in dimensions else _slice(None)
-             for d in range(np.ndim(operand)))
-  return operand[tuple(indexer)]
-
-select = np.where
-
-def slice(operand, start_indices, limit_indices, strides=None):  # pylint: disable=redefined-builtin
-  if strides is None:
-    strides = np.ones(len(start_indices)).astype(int)
-  slices = tuple(_map(_slice, start_indices, limit_indices, strides))
-  return operand[slices]
-
-def dynamic_slice(operand, start_indices, slice_sizes):
-  out = np.zeros(slice_sizes, dtype=operand.dtype)
-  idx = tuple(_slice(start, start+size)
-              for start, size in zip(start_indices, slice_sizes))
-  section = operand[idx]
-  out[tuple(_slice(None, stop) for stop in section.shape)] = section
-  return out
-
-def dynamic_update_slice(operand, update, start_indices):
-  slices = tuple(_map(_slice, start_indices, np.add(start_indices, update.shape)))
-  updated_operand = np.copy(operand)
-  updated_operand[slices] = update
-  return updated_operand
-
-transpose = np.transpose
-
-def reduce(operand, init_value, computation, dimensions):  # pylint: disable=redefined-builtin
-  reducer = _make_reducer(computation, init_value)
-  return reducer(operand, tuple(dimensions)).astype(np.asarray(operand).dtype)
-
-def reduce_window(operand, init_value, computation, window_dimensions,
-                  window_strides, padding, base_dilation):
-  op, dims, strides = operand, window_dimensions, window_strides
-  if isinstance(padding, str):
-    pads = padtype_to_pads(op.shape, dims, strides, padding)
-  else:
-    pads = padding
-  op = op.reshape((1, 1) + op.shape)
-  if base_dilation:
-    op = _dilate(op, base_dilation, init_value)
-  view = _conv_view(op, (1, 1) + dims, strides, pads,
-                    pad_value=init_value)[0]
-  view = view.reshape(view.shape[1:1+len(dims)] + (-1,))
-  reducer = _make_reducer(computation, init_value)
-  return reducer(view, axis=-1)
-
-# TODO(mattjj): select_and_scatter
-
-sort = np.sort
-
-def sort_key_val(keys, values, dimension=-1):
-  idxs = list(np.ix_(*[np.arange(d) for d in keys.shape]))
-  idxs[dimension] = np.argsort(keys, axis=dimension)
-  return keys[tuple(idxs)], values[tuple(idxs)]
-
-### conv util
-
-def _conv(lhs, rhs, window_strides, pads):
-  view, view_axes, rhs_axes, out_axes = _conv_view(
-      lhs, rhs.shape, window_strides, pads, 0.)
-  return opt_einsum.contract(
-      view, view_axes, rhs, rhs_axes, out_axes, use_blas=True)
-
-def padtype_to_pads(in_shape, filter_shape, window_strides, padding):
-  if padding.upper() == 'SAME':
-    out_shape = np.ceil(np.true_divide(in_shape, window_strides)).astype(int)
-    pad_sizes = [_max((out_size - 1) * stride + filter_size - in_size, 0)
-                 for out_size, stride, filter_size, in_size
-                 in zip(out_shape, window_strides, filter_shape, in_shape)]
-    return [(pad_size // 2, pad_size - pad_size // 2) for pad_size in pad_sizes]
-  else:
-    return [(0, 0)] * len(in_shape)
-
-def _conv_view(lhs, rhs_shape, window_strides, pads, pad_value):
-  """Compute the view (and its axes) of a convolution or window reduction."""
-  if (_min(lhs.ndim, len(rhs_shape)) < 2 or lhs.ndim != len(rhs_shape)
-      or lhs.shape[1] != rhs_shape[1]):
-    raise ValueError('Dimension mismatch')
-  if len(window_strides) != len(rhs_shape) - 2:
-    raise ValueError('Wrong number of strides for spatial dimensions')
-  if len(pads) != len(rhs_shape) - 2:
-    raise ValueError('Wrong number of pads for spatial dimensions')
-
-  lhs = _pad(lhs, [(0, 0)] * 2 + list(pads), pad_value)
-  in_shape = lhs.shape[2:]
-  filter_shape = rhs_shape[2:]
-  dim = len(filter_shape)  # number of 'spatial' dimensions in convolution
-
-  out_strides = np.multiply(window_strides, lhs.strides[2:])
-  view_strides = lhs.strides[:1] + tuple(out_strides) + lhs.strides[1:]
-
-  out_shape = np.floor_divide(
-      np.subtract(in_shape, filter_shape), window_strides) + 1
-  view_shape = lhs.shape[:1] + tuple(out_shape) + rhs_shape[1:]
-
-  view = np.lib.stride_tricks.as_strided(lhs, view_shape, view_strides)
-
-  view_axes = list(range(view.ndim))
-  sum_axes = view_axes[-dim-1:]
-  rhs_axes = [view.ndim] + sum_axes
-  out_axes = [0, view.ndim] + list(range(1, dim+1))
-
-  return view, view_axes, rhs_axes, out_axes
-
-def _pad(arr, pads, pad_value):
-  out = np.pad(arr, np.maximum(0, pads), mode='constant',
-                constant_values=pad_value).astype(arr.dtype)
-  slices = tuple(_slice(abs(lo) if lo < 0 else 0, hi % dim if hi < 0 else None)
-                 for (lo, hi), dim in zip(pads, np.shape(arr)))
-  return out[slices]
-
-def _dilate(operand, factors, fill_value=0):
-  # this logic is like lax.pad, but with two leading dimensions, no edge
-  # padding, and factors are at least 1 (interior padding is at least 0)
-  outspace = np.add(operand.shape[2:],
-                     np.multiply(np.subtract(factors, 1),
-                                  np.subtract(operand.shape[2:], 1)))
-  out = np.full(operand.shape[:2] + tuple(outspace), fill_value, operand.dtype)
-  lhs_slices = tuple(_slice(None, None, step) for step in factors)
-  out[(_slice(None),) * 2 + lhs_slices] = operand
-  return out
-
-def _conv_general_permutations(dimension_numbers):
-  lhs_spec, rhs_spec, out_spec = dimension_numbers
-  rhs_perm = ((rhs_spec.index('O'), rhs_spec.index('I'))
-              + tuple(i for i, c in enumerate(rhs_spec) if c not in {'O', 'I'}))
-  lhs_perm = ((lhs_spec.index('N'), lhs_spec.index('C'))
-              + tuple(sorted((i for i, c in enumerate(lhs_spec)
-                              if c not in {'N', 'C'}),
-                             key=lambda i: rhs_spec.index(lhs_spec[i]))))
-  out_perm = ((out_spec.index('N'), out_spec.index('C'))
-              + tuple(sorted((i for i, c in enumerate(out_spec)
-                              if c not in {'N', 'C'}),
-                             key=lambda i: rhs_spec.index(out_spec[i]))))
-  return lhs_perm, rhs_perm, out_perm
-
-### reduce util
-
-def _make_reducer(py_binop, init_val):
-  """Make a reducer function given a Python binop and an initial value."""
-  # It's tempting to use np.ufunc.reduce (even with a ufunc generated by
-  # np.frompyfunc(py_binop)), but this may not agree with custom init_val.
-  # We make an attempt to uncover an underlying numpy ufunc (which might be
-  # wrapped by autograd or lax) and check its identity against init_val.
-  monoid_record = _monoids.get(getattr(py_binop, '__name__'))
-  if monoid_record:
-    reducer, monoid_identity = monoid_record
-    if init_val == monoid_identity(dtypes.result_type(init_val)):
-      return reducer
-  return _reducer_from_pyfunc(py_binop, init_val)
-
-def _get_max_identity(dt):
-  return -np.inf if dtypes.issubdtype(dt, np.floating) else np.iinfo(dt).min
-
-def _get_min_identity(dt):
-  return np.inf if dtypes.issubdtype(dt, np.floating) else np.iinfo(dt).max
-
-def _identity_getter(op):
-  return lambda dtype: np.asarray(op.identity, dtype=dtype)
-
-MonoidRecord = collections.namedtuple('MonoidRecord', ['reducer', 'identity'])
-_monoids = {
-    'max': MonoidRecord(np.maximum.reduce, _get_max_identity),
-    'min': MonoidRecord(np.minimum.reduce, _get_min_identity),
-    'add': MonoidRecord(np.add.reduce, _identity_getter(np.add)),
-    'mul': MonoidRecord(np.multiply.reduce, _identity_getter(np.multiply)),
-    'multiply': MonoidRecord(np.multiply.reduce,
-                             _identity_getter(np.multiply)),
-    'logical_and': MonoidRecord(np.logical_and.reduce,
-                                _identity_getter(np.logical_and)),
-    'logical_or': MonoidRecord(np.logical_or.reduce,
-                               _identity_getter(np.logical_or)),
-}
-
-def _reducer_from_pyfunc(py_binop, init_val):
-  def reducer(operand, axis=0):
-    axis = range(np.ndim(operand)) if axis is None else axis
-    result = np.full(np.delete(np.shape(operand), axis), init_val,
-                      dtype=np.asarray(operand).dtype)
-    for idx, _ in np.ndenumerate(operand):
-      out_idx = tuple(np.delete(idx, axis))
-      result[out_idx] = py_binop(result[out_idx], operand[idx])
-    return result
-  return reducer
+argmin = numpy_eval()(lax.argmin)
+argmax = numpy_eval()(lax.argmax)
+batch_matmul = numpy_eval()(lax.batch_matmul)
+concatenate = numpy_eval()(lax.concatenate)
+conv_general_dilated = numpy_eval()(lax.conv_general_dilated)
+dynamic_slice = numpy_eval()(lax.dynamic_slice)
+dynamic_update_slice = numpy_eval()(lax.dynamic_update_slice)
+expand_dims = numpy_eval()(lax.expand_dims)
+index_take = numpy_eval()(lax.index_take)
+reduce = numpy_eval()(lax.reduce)
+reduce_window = numpy_eval()(lax.reduce_window)
+sort = numpy_eval()(lax.sort)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -16,6 +16,7 @@
 import collections
 from functools import partial
 import itertools
+from typing import Callable, Any
 from unittest import SkipTest
 
 from absl.testing import absltest
@@ -30,6 +31,7 @@ from jax import dtypes
 from jax import lax
 from jax import test_util as jtu
 from jax import lax_reference
+from jax.interpreters.numpy_eval import numpy_eval
 from jax.test_util import check_grads
 import jax.util
 from jax.util import prod
@@ -52,7 +54,8 @@ int_dtypes = jtu.dtypes.all_integer
 uint_dtypes = jtu.dtypes.all_unsigned
 bool_dtypes = jtu.dtypes.boolean
 default_dtypes = float_dtypes + int_dtypes
-all_dtypes = float_dtypes + complex_dtypes + int_dtypes + bool_dtypes
+number_dtypes = default_dtypes + complex_dtypes
+all_dtypes = number_dtypes + bool_dtypes
 
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
@@ -64,201 +67,176 @@ def op_record(op, nargs, dtypes, rng_factory, tol=None):
   return OpRecord(op, nargs, dtypes, rng_factory, tol)
 
 LAX_OPS = [
-    op_record("neg", 1, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("sign", 1, default_dtypes + uint_dtypes, jtu.rand_small),
-    op_record("floor", 1, float_dtypes, jtu.rand_small),
-    op_record("ceil", 1, float_dtypes, jtu.rand_small),
-    op_record("round", 1, float_dtypes, jtu.rand_default),
-    op_record("nextafter", 2, [f for f in float_dtypes if f != dtypes.bfloat16],
+    op_record(lax.neg, 1, number_dtypes, jtu.rand_small),
+    op_record(lax.sign, 1, default_dtypes + uint_dtypes, jtu.rand_small),
+    op_record(lax.floor, 1, float_dtypes, jtu.rand_small),
+    op_record(lax.ceil, 1, float_dtypes, jtu.rand_small),
+    op_record(lax.round, 1, float_dtypes, jtu.rand_default),
+    op_record(lax.nextafter, 2, [f for f in float_dtypes if f != dtypes.bfloat16],
               jtu.rand_default, tol=0),
 
-    op_record("is_finite", 1, float_dtypes, jtu.rand_small),
+    op_record(lax.is_finite, 1, float_dtypes, jtu.rand_small),
 
-    op_record("exp", 1, float_dtypes + complex_dtypes, jtu.rand_small),
+    op_record(lax.exp, 1, inexact_dtypes, jtu.rand_small),
     # TODO(b/142975473): on CPU, expm1 for float64 is only accurate to ~float32
     # precision.
-    op_record("expm1", 1, float_dtypes + complex_dtypes, jtu.rand_small,
-              {np.float64: 1e-8}),
-    op_record("log", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("log1p", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record(lax.expm1, 1, inexact_dtypes, jtu.rand_small, {np.float64: 1e-8}),
+    op_record(lax.log, 1, inexact_dtypes, jtu.rand_positive),
+    op_record(lax.log1p, 1, inexact_dtypes, jtu.rand_positive),
     # TODO(b/142975473): on CPU, tanh for complex128 is only accurate to
     # ~float32 precision.
     # TODO(b/143135720): on GPU, tanh has only ~float32 precision.
-    op_record("tanh", 1, float_dtypes + complex_dtypes, jtu.rand_small,
+    op_record(lax.tanh, 1, inexact_dtypes, jtu.rand_small,
               {np.float64: 1e-9, np.complex128: 1e-7}),
-    op_record("sin", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("cos", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("atan2", 2, float_dtypes, jtu.rand_default),
+    op_record(lax.sin, 1, inexact_dtypes, jtu.rand_default),
+    op_record(lax.cos, 1, inexact_dtypes, jtu.rand_default),
+    op_record(lax.atan2, 2, float_dtypes, jtu.rand_default),
 
-    op_record("sqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("rsqrt", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("square", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("reciprocal", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
-    op_record("tan", 1, float_dtypes + complex_dtypes, jtu.rand_default, {np.float32: 3e-5}),
-    op_record("asin", 1, float_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("acos", 1, float_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("atan", 1, float_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("asinh", 1, float_dtypes + complex_dtypes, jtu.rand_default,
+    op_record(lax.sqrt, 1, inexact_dtypes, jtu.rand_positive),
+    op_record(lax.rsqrt, 1, inexact_dtypes, jtu.rand_positive),
+    op_record(lax.square, 1, inexact_dtypes, jtu.rand_default),
+    op_record(lax.reciprocal, 1, inexact_dtypes, jtu.rand_positive),
+    op_record(lax.tan, 1, inexact_dtypes, jtu.rand_default, {np.float32: 3e-5}),
+    op_record(lax.asin, 1, inexact_dtypes, jtu.rand_small),
+    op_record(lax.acos, 1, inexact_dtypes, jtu.rand_small),
+    op_record(lax.atan, 1, inexact_dtypes, jtu.rand_small),
+    op_record(lax.asinh, 1, inexact_dtypes, jtu.rand_default,
               tol={np.complex64: 1E-4, np.complex128: 1E-5}),
-    op_record("acosh", 1, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record(lax.acosh, 1, inexact_dtypes, jtu.rand_positive),
     # TODO(b/155331781): atanh has only ~float precision
-    op_record("atanh", 1, float_dtypes + complex_dtypes, jtu.rand_small, {np.float64: 1e-9}),
-    op_record("sinh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("cosh", 1, float_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("lgamma", 1, float_dtypes, jtu.rand_positive,
+    op_record(lax.atanh, 1, inexact_dtypes, jtu.rand_small, {np.float64: 1e-9}),
+    op_record(lax.sinh, 1, inexact_dtypes, jtu.rand_default),
+    op_record(lax.cosh, 1, inexact_dtypes, jtu.rand_default),
+    op_record(lax.lgamma, 1, float_dtypes, jtu.rand_positive,
               {np.float32: 1e-3 if jtu.device_under_test() == "tpu" else 1e-5,
                np.float64: 1e-14}),
-    op_record("digamma", 1, float_dtypes, jtu.rand_positive,
+    op_record(lax.digamma, 1, float_dtypes, jtu.rand_positive,
               {np.float64: 1e-14}),
-    op_record("betainc", 3, float_dtypes, jtu.rand_positive,
+    op_record(lax.betainc, 3, float_dtypes, jtu.rand_positive,
               {np.float64: 1e-14}),
-    op_record("igamma", 2,
+    op_record(lax.igamma, 2,
               [f for f in float_dtypes if f not in [dtypes.bfloat16, np.float16]],
               jtu.rand_positive, {np.float64: 1e-14}),
-    op_record("igammac", 2,
+    op_record(lax.igammac, 2,
               [f for f in float_dtypes if f not in [dtypes.bfloat16, np.float16]],
               jtu.rand_positive, {np.float64: 1e-14}),
-    op_record("erf", 1, float_dtypes, jtu.rand_small),
-    op_record("erfc", 1, float_dtypes, jtu.rand_small),
+    op_record(lax.erf, 1, float_dtypes, jtu.rand_small),
+    op_record(lax.erfc, 1, float_dtypes, jtu.rand_small),
     # TODO(b/142976030): the approximation of erfinf used by XLA is only
     # accurate to float32 precision.
-    op_record("erf_inv", 1, float_dtypes, jtu.rand_small,
+    op_record(lax.erf_inv, 1, float_dtypes, jtu.rand_small,
               {np.float64: 1e-9}),
-    op_record("bessel_i0e", 1, float_dtypes, jtu.rand_default),
-    op_record("bessel_i1e", 1, float_dtypes, jtu.rand_default),
+    op_record(lax.bessel_i0e, 1, float_dtypes, jtu.rand_default),
+    op_record(lax.bessel_i1e, 1, float_dtypes, jtu.rand_default),
 
-    op_record("real", 1, complex_dtypes, jtu.rand_default),
-    op_record("imag", 1, complex_dtypes, jtu.rand_default),
-    op_record("complex", 2, complex_elem_dtypes, jtu.rand_default),
-    op_record("conj", 1, complex_elem_dtypes + complex_dtypes,
+    op_record(lax.real, 1, complex_dtypes, jtu.rand_default),
+    op_record(lax.imag, 1, complex_dtypes, jtu.rand_default),
+    op_record(lax.complex, 2, complex_elem_dtypes, jtu.rand_default),
+    op_record(lax.conj, 1, complex_elem_dtypes + complex_dtypes,
               jtu.rand_default),
-    op_record("abs", 1, default_dtypes + complex_dtypes, jtu.rand_default),
-    op_record("pow", 2, float_dtypes + complex_dtypes, jtu.rand_positive),
+    op_record(lax.abs, 1, number_dtypes, jtu.rand_default),
+    op_record(lax.pow, 2, inexact_dtypes, jtu.rand_positive),
 
-    op_record("bitwise_and", 2, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_not", 1, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_or", 2, bool_dtypes, jtu.rand_small),
-    op_record("bitwise_xor", 2, bool_dtypes, jtu.rand_small),
-    op_record("population_count", 1, int_dtypes + uint_dtypes, jtu.rand_int),
+    op_record(lax.bitwise_and, 2, bool_dtypes, jtu.rand_small),
+    op_record(lax.bitwise_not, 1, bool_dtypes, jtu.rand_small),
+    op_record(lax.bitwise_or, 2, bool_dtypes, jtu.rand_small),
+    op_record(lax.bitwise_xor, 2, bool_dtypes, jtu.rand_small),
+    op_record(lax.population_count, 1, int_dtypes + uint_dtypes, jtu.rand_int),
 
-    op_record("add", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("sub", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("mul", 2, default_dtypes + complex_dtypes, jtu.rand_small),
-    op_record("div", 2, default_dtypes + complex_dtypes, jtu.rand_nonzero),
-    op_record("rem", 2, default_dtypes, jtu.rand_nonzero),
+    op_record(lax.add, 2, number_dtypes, jtu.rand_small),
+    op_record(lax.sub, 2, number_dtypes, jtu.rand_small),
+    op_record(lax.mul, 2, number_dtypes, jtu.rand_small),
+    op_record(lax.div, 2, number_dtypes, jtu.rand_nonzero),
+    op_record(lax.rem, 2, default_dtypes, jtu.rand_nonzero),
 
-    op_record("max", 2, all_dtypes, jtu.rand_small),
-    op_record("min", 2, all_dtypes, jtu.rand_small),
+    op_record(lax.max, 2, all_dtypes, jtu.rand_small),
+    op_record(lax.min, 2, all_dtypes, jtu.rand_small),
 
-    op_record("eq", 2, all_dtypes, jtu.rand_some_equal),
-    op_record("ne", 2, all_dtypes, jtu.rand_small),
-    op_record("ge", 2, default_dtypes, jtu.rand_small),
-    op_record("gt", 2, default_dtypes, jtu.rand_small),
-    op_record("le", 2, default_dtypes, jtu.rand_small),
-    op_record("lt", 2, default_dtypes, jtu.rand_small),
+    op_record(lax.eq, 2, all_dtypes, jtu.rand_some_equal),
+    op_record(lax.ne, 2, all_dtypes, jtu.rand_small),
+    op_record(lax.ge, 2, default_dtypes, jtu.rand_small),
+    op_record(lax.gt, 2, default_dtypes, jtu.rand_small),
+    op_record(lax.le, 2, default_dtypes, jtu.rand_small),
+    op_record(lax.lt, 2, default_dtypes, jtu.rand_small),
 ]
 
 
 class LaxTest(jtu.JaxTestCase):
   """Numerical tests for LAX operations."""
 
-  @parameterized.named_parameters(itertools.chain.from_iterable(
-      jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix(
-            rec.op, shapes, itertools.repeat(dtype)),
-         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
-         "dtype": dtype}
-        for shape_group in compatible_shapes
-        for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
-        for dtype in rec.dtypes)
-      for rec in LAX_OPS))
-  def testOp(self, op_name, rng_factory, shapes, dtype):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    op = getattr(lax, op_name)
-    self._CompileAndCheck(op, args_maker)
+  def _Check(self, lax_op: Callable[..., Any], args_maker: Callable[[], Any],
+             tol=None, **params):
+    """
+    Checks the given lax operation against its jit-compiled version,
+    its reference implementation and itself evaluated on the NumPy backend.
+    """
+    lax_fun = partial(lax_op, **params)
+    self._CompileAndCheck(lax_fun, args_maker)
+
+    if not config.omnistaging_enabled: return # required by lax_ref + numpy_eval
+
+    args = args_maker()
+    ans = lax_fun(*args)
+    ref_op = getattr(lax_reference, lax_op.__name__)
+    ref_ans = ref_op(*args, **params)
+    self.assertAllClose(ref_ans, ans, atol=tol)
+
+    # TODO move into _CompileAndCheck once NumPy backend is complete:
+    numpy_ans = numpy_eval()(lax_fun)(*args)
+    self.assertAllClose(numpy_ans, ans, atol=tol)
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
       jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(
-            rec.op, shapes, itertools.repeat(dtype)),
-         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
+            rec.op.__name__, shapes, itertools.repeat(dtype)),
+         "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype, "tol": rec.tol}
         for shape_group in compatible_shapes
         for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
-  def testOpAgainstNumpy(self, op_name, rng_factory, shapes, dtype, tol):
-    if (not FLAGS.jax_enable_x64 and op_name == "nextafter"
-        and dtype == np.float64):
-      raise SkipTest("64-bit mode disabled")
+  def testOp(self, op, rng_factory, shapes, dtype, tol):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    op = getattr(lax, op_name)
-    numpy_op = getattr(lax_reference, op_name)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker, tol=tol)
-
-  # TODO test shift_left, shift_right_arithmetic, shift_right_logical
+    self._Check(op, args_maker, tol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}".format(
-          from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
+    {"testcase_name":
+       f"_op={op.__name__}_dtype={dtype.__name__}_shapes={shapes}",
+     "op": op, "dtype": dtype, "shapes": shapes}
+    for op in [lax.shift_left,
+               lax.shift_right_arithmetic,
+               lax.shift_right_logical]
+    for dtype in int_dtypes + uint_dtypes
+    for shape_group in compatible_shapes
+    for shapes in itertools.combinations_with_replacement(shape_group, 2)))
+  def testShiftOp(self, op, shapes, dtype):
+    info = np.iinfo(dtype)
+    x_rng = jtu.rand_int(self.rng(), low=info.min, high=info.max + 1)
+    # XLA requires shifts to be non-negative and below the bit width:
+    shift_rng = jtu.rand_int(self.rng(), high=info.bits)
+    args_maker = lambda: (x_rng(shapes[0], dtype), shift_rng(shapes[1], dtype))
+    self._Check(op, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+         f"_op={op.__name__}_from_dtype={from_dtype}_to_dtype={to_dtype}",
+       "op": op, "from_dtype": from_dtype, "to_dtype": to_dtype,
+       "rng_factory": rng_factory}
+      for op in [lax.convert_element_type, lax.bitcast_convert_type]
       for from_dtype, to_dtype in itertools.product(
           [np.float32, np.int32, "float32", "int32"], repeat=2)
       for rng_factory in [jtu.rand_default]))
-  def testConvertElementType(self, from_dtype, to_dtype, rng_factory):
+  def testConvertOp(self, op, from_dtype, to_dtype, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.convert_element_type(x, to_dtype)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(op, args_maker, new_dtype=to_dtype)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}"
-       .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for rng_factory in [jtu.rand_default]))
-  def testConvertElementTypeAgainstNumpy(self, from_dtype, to_dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.convert_element_type(x, to_dtype)
-    numpy_op = lambda x: lax_reference.convert_element_type(x, to_dtype)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}"
-       .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for rng_factory in [jtu.rand_default]))
-  def testBitcastConvertType(self, from_dtype, to_dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.bitcast_convert_type(x, to_dtype)
-    self._CompileAndCheck(op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}"
-       .format(from_dtype, to_dtype),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "rng_factory": rng_factory}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for rng_factory in [jtu.rand_default]))
-  def testBitcastConvertTypeAgainstNumpy(self, from_dtype, to_dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.bitcast_convert_type(x, to_dtype)
-    numpy_op = lambda x: lax_reference.bitcast_convert_type(x, to_dtype)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_min_shape={}_operand_shape={}_max_shape={}".format(
-          jtu.format_shape_dtype_string(min_shape, dtype),
-          jtu.format_shape_dtype_string(operand_shape, dtype),
-          jtu.format_shape_dtype_string(max_shape, dtype)),
+      {"testcase_name":
+         f"_min_shape={jtu.format_shape_dtype_string(min_shape, dtype)}"
+         f"_operand_shape={jtu.format_shape_dtype_string(operand_shape, dtype)}"
+         f"_max_shape={jtu.format_shape_dtype_string(max_shape, dtype)}",
        "min_shape": min_shape, "operand_shape": operand_shape,
        "max_shape": max_shape, "dtype": dtype, "rng_factory": rng_factory}
       for min_shape, operand_shape, max_shape in [
@@ -273,34 +251,12 @@ class LaxTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     shapes = [min_shape, operand_shape, max_shape]
     args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    self._CompileAndCheck(lax.clamp, args_maker)
+    self._Check(lax.clamp, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_min_shape={}_operand_shape={}_max_shape={}".format(
-          jtu.format_shape_dtype_string(min_shape, dtype),
-          jtu.format_shape_dtype_string(operand_shape, dtype),
-          jtu.format_shape_dtype_string(max_shape, dtype)),
-       "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "rng_factory": rng_factory}
-      for min_shape, operand_shape, max_shape in [
-          [(), (2, 3), ()],
-          [(2, 3), (2, 3), ()],
-          [(), (2, 3), (2, 3)],
-          [(2, 3), (2, 3), (2, 3)],
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testClampAgainstNumpy(self, min_shape, operand_shape, max_shape, dtype,
-                            rng_factory):
-    rng = rng_factory(self.rng())
-    shapes = [min_shape, operand_shape, max_shape]
-    args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    self._CheckAgainstNumpy(lax_reference.clamp, lax.clamp, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dim={}_baseshape=[{}]_dtype={}_narrs={}".format(
-          dim, ",".join(str(d) for d in base_shape), np.dtype(dtype).name,
-          num_arrs),
+      {"testcase_name":
+         f"_dim={dim}_baseshape=[{','.join(str(d) for d in base_shape)}]"
+         f"_dtype={np.dtype(dtype).name}_narrs={num_arrs}",
        "dim": dim, "base_shape": base_shape, "dtype": dtype,
        "num_arrs": num_arrs, "rng_factory": rng_factory}
       for num_arrs in [3]
@@ -312,35 +268,14 @@ class LaxTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
-    args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    op = lambda *args: lax.concatenate(args, dim)
-    self._CompileAndCheck(op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dim={}_baseshape=[{}]_dtype={}_narrs={}".format(
-          dim, ",".join(str(d) for d in base_shape), np.dtype(dtype).name,
-          num_arrs),
-       "dim": dim, "base_shape": base_shape, "dtype": dtype,
-       "num_arrs": num_arrs, "rng_factory": rng_factory}
-      for num_arrs in [3]
-      for dtype in default_dtypes
-      for base_shape in [(4,), (3, 4), (2, 3, 4)]
-      for dim in range(len(base_shape))
-      for rng_factory in [jtu.rand_default]))
-  def testConcatenateAgainstNumpy(self, dim, base_shape, dtype, num_arrs, rng_factory):
-    rng = rng_factory(self.rng())
-    shapes = [base_shape[:dim] + (size,) + base_shape[dim+1:]
-              for size, _ in zip(itertools.cycle([3, 1, 4]), range(num_arrs))]
-    args_maker = lambda: [rng(shape, dtype) for shape in shapes]
-    op = lambda *args: lax.concatenate(args, dim)
-    numpy_op = lambda *args: lax_reference.concatenate(args, dim)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
+    args_maker = lambda: [[rng(shape, dtype) for shape in shapes]]
+    self._Check(lax.concatenate, args_maker, dimension=dim)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}",
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [
@@ -353,40 +288,14 @@ class LaxTest(jtu.JaxTestCase):
   def testConv(self, lhs_shape, rhs_shape, dtype, strides, padding, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-
-    def fun(lhs, rhs):
-      return lax.conv(lhs, rhs, strides, padding)
-
-    self._CompileAndCheck(fun, args_maker)
+    self._Check(lax.conv, args_maker, window_strides=strides, padding=padding)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding),
-          "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-          "strides": strides, "padding": padding, "rng_factory": rng_factory}
-      for lhs_shape, rhs_shape in [
-          ((b, i, 9, 10), (j, i, 4, 5))
-          for b, i, j in itertools.product([2, 3], repeat=3)]
-      for dtype in float_dtypes
-      for strides in [(1, 1), (1, 2), (2, 1)]
-      for padding in ["VALID", "SAME"]
-      for rng_factory in [jtu.rand_small]))
-  def testConvAgainstNumpy(self, lhs_shape, rhs_shape, dtype, strides, padding,
-                           rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-    op = lambda lhs, rhs: lax.conv(lhs, rhs, strides, padding)
-    numpy_op = lambda lhs, rhs: lax_reference.conv(lhs, rhs, strides, padding)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_strides={}_padding={}"
-       "_lhs_dilation={}_rhs_dilation={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype),
-           strides, padding, lhs_dilation, rhs_dilation),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}"
+         f"_lhs_dilation={lhs_dilation}_rhs_dilation={rhs_dilation}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
        "rhs_dilation": rhs_dilation, "rng_factory": rng_factory}
@@ -403,55 +312,17 @@ class LaxTest(jtu.JaxTestCase):
                                  padding, lhs_dilation, rhs_dilation, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-
-    def fun(lhs, rhs):
-      return lax.conv_with_general_padding(
-          lhs, rhs, strides, padding, lhs_dilation, rhs_dilation)
-
-    self._CompileAndCheck(fun, args_maker)
+    self._Check(lax.conv_with_general_padding, args_maker,
+                window_strides=strides, padding=padding,
+                lhs_dilation=lhs_dilation, rhs_dilation=rhs_dilation,
+                precision=lax.Precision.HIGHEST)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_strides={}_padding={}"
-       "_lhs_dilation={}_rhs_dilation={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype),
-           strides, padding, lhs_dilation, rhs_dilation),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
-       "rhs_dilation": rhs_dilation, "rng_factory": rng_factory}
-      for lhs_shape, rhs_shape in [
-          ((b, i, 9, 10), (j, i, 4, 5))
-          for b, i, j in itertools.product([1, 2, 3], repeat=3)]
-      for dtype in [np.float32] for strides in [(1, 1), (1, 2), (2, 1)]
-      for padding in [((0, 0), (0, 0)), ((1, 2), (2, 0))]
-      for lhs_dilation, rhs_dilation in itertools.product(
-          [(1, 1), (1, 2), (2, 2)], repeat=2)
-      for rng_factory in [jtu.rand_small]))
-  def testConvWithGeneralPaddingAgainstNumpy(
-      self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dilation,
-      rhs_dilation, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-
-    def fun(lhs, rhs):
-      return lax.conv_with_general_padding(
-          lhs, rhs, strides, padding, lhs_dilation, rhs_dilation,
-          precision=lax.Precision.HIGHEST)
-
-    def numpy_fun(lhs, rhs):
-      return lax_reference.conv_with_general_padding(
-          lhs, rhs, strides, padding, lhs_dilation, rhs_dilation)
-
-    self._CheckAgainstNumpy(numpy_fun, fun, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_strides={}_padding={}"
-       "_lhs_dilation={}_rhs_dilation={}"
-       "_dims={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype),
-           strides, padding, lhs_dilation, rhs_dilation,
-           ",".join(dim_nums)),
+      {"testcase_name":
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}_lhs_dilation={lhs_dilation}"
+         f"_rhs_dilation={rhs_dilation}_dims={','.join(dim_nums)}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
        "rhs_dilation": rhs_dilation, "dimension_numbers": dim_nums,
@@ -480,29 +351,22 @@ class LaxTest(jtu.JaxTestCase):
                              dimension_numbers, perms, rng_factory):
     rng = rng_factory(self.rng())
     lhs_perm, rhs_perm = perms  # permute to compatible shapes
-
-    def args_maker():
-      return [lax.transpose(rng(lhs_shape, dtype), lhs_perm),
-              lax.transpose(rng(rhs_shape, dtype), rhs_perm)]
-
-    def fun(lhs, rhs):
-      return lax.conv_general_dilated(
-          lhs, rhs, strides, padding, lhs_dilation, rhs_dilation,
-          dimension_numbers, feature_group_count=feature_group_count,
-          batch_group_count=batch_group_count)
-
-    self._CompileAndCheck(fun, args_maker)
-
-  # TODO(mattjj): test conv_general_dilated against numpy
+    args_maker = lambda: [lax.transpose(rng(lhs_shape, dtype), lhs_perm),
+                          lax.transpose(rng(rhs_shape, dtype), rhs_perm)]
+    self._Check(lax.conv_general_dilated, args_maker, window_strides=strides,
+                padding=padding, lhs_dilation=lhs_dilation,
+                rhs_dilation=rhs_dilation, dimension_numbers=dimension_numbers,
+                feature_group_count=feature_group_count,
+                batch_group_count=batch_group_count)
 
   def testConv0DIsDot(self):
     rng = jtu.rand_default(self.rng())
-    def args_maker():
-      return [rng((10, 5), np.float32), rng((5, 7), np.float32)]
-    jnp_fun = partial(lax.conv_general_dilated, window_strides=(),
-                      padding='VALID', dimension_numbers=('NC', 'IO', 'NC'))
-    self._CompileAndCheck(jnp_fun, args_maker)
-    self._CheckAgainstNumpy(np.dot, jnp_fun, args_maker, tol=.1)
+    args_maker = lambda: [rng((10, 5), np.float32), rng((5, 7), np.float32)]
+    params = dict(window_strides=(), padding='VALID',
+                  dimension_numbers=('NC', 'IO', 'NC'))
+    self._Check(lax.conv_general_dilated, args_maker, **params)
+    self._CheckAgainstNumpy(np.dot, partial(lax.conv_general_dilated, **params),
+                            args_maker, tol=.1)
 
 
   @staticmethod
@@ -547,9 +411,9 @@ class LaxTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_rhs_dilation={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding, rhs_dilation),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}_rhs_dilation={rhs_dilation}",
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rhs_dilation": rhs_dilation,
           "rng_factory": rng_factory, 'dspec': dspec}
@@ -586,9 +450,9 @@ class LaxTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_rhs_dilation={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding, rhs_dilation),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}_rhs_dilation={rhs_dilation}",
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rhs_dilation": rhs_dilation,
           "rng_factory": rng_factory, 'dspec': dspec}
@@ -624,9 +488,9 @@ class LaxTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_rhs_dilation={}".format(
-           jtu.format_shape_dtype_string(lhs_shape, dtype),
-           jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding, rhs_dilation),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}_rhs_dilation={rhs_dilation}",
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rhs_dilation": rhs_dilation,
           "rng_factory": rng_factory, 'dspec': dspec}
@@ -661,9 +525,9 @@ class LaxTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-        "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_rhs_dilation={}".format(
-            jtu.format_shape_dtype_string(lhs_shape, dtype),
-            jtu.format_shape_dtype_string(rhs_shape, dtype), strides, padding, rhs_dilation),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_strides={strides}_padding={padding}_rhs_dilation={rhs_dilation}",
           "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
           "strides": strides, "padding": padding, "rhs_dilation": rhs_dilation,
           "rng_factory": rng_factory, 'dspec': dspec}
@@ -697,10 +561,10 @@ class LaxTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(fun_via_grad, fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_precision={}".format(
-          jtu.format_shape_dtype_string(lhs_shape, dtype),
-          jtu.format_shape_dtype_string(rhs_shape, dtype),
-          precision),
+      {"testcase_name":
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_precision={precision}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "precision": precision, "rng_factory": rng_factory}
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
@@ -711,35 +575,20 @@ class LaxTest(jtu.JaxTestCase):
   def testDot(self, lhs_shape, rhs_shape, dtype, precision, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-    self._CompileAndCheck(partial(lax.dot, precision=precision), args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}".format(
-          jtu.format_shape_dtype_string(lhs_shape, dtype),
-          jtu.format_shape_dtype_string(rhs_shape, dtype)),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "rng_factory": rng_factory}
-      for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
-      for dtype in all_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testDotAgainstNumpy(self, lhs_shape, rhs_shape, dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     tol = {
       np.float16: 1e-2,
       np.float64: max(jtu.default_tolerance()[np.dtype(np.float64)], 1e-14),
       np.complex128: max(jtu.default_tolerance()[np.dtype(np.complex128)],
-                          1e-14)
-    }
-    lax_op = partial(lax.dot, precision=lax.Precision.HIGHEST)
-    self._CheckAgainstNumpy(lax_reference.dot, lax_op, args_maker, tol=tol)
+                         1e-14)
+    } if precision is lax.Precision.HIGHEST else {np.float16: 2e-2}
+    self._Check(lax.dot, args_maker, precision=precision, tol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_lhs_contracting={}_rhs_contracting={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               lhs_contracting, rhs_contracting),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_lhs_contracting={lhs_contracting}"
+         f"_rhs_contracting={rhs_contracting}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
        "rng_factory": rng_factory}
@@ -762,18 +611,14 @@ class LaxTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
     dimension_numbers = ((lhs_contracting, rhs_contracting), ([], []))
-
-    def fun(lhs, rhs):
-      return lax.dot_general(lhs, rhs, dimension_numbers)
-
-    self._CompileAndCheck(fun, args_maker, check_dtypes=False)
+    self._Check(lax.dot_general, args_maker,
+                dimension_numbers=dimension_numbers)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_dimension_numbers={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               dimension_numbers),
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}"
+         f"_dimension_numbers={dimension_numbers}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
       for lhs_shape, rhs_shape, dimension_numbers in [
@@ -783,42 +628,15 @@ class LaxTest(jtu.JaxTestCase):
       ]
       for dtype in all_dtypes
       for rng_factory in [jtu.rand_small]))
-  def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
-                                     dimension_numbers, rng_factory):
+  def testDotGeneral(self, lhs_shape, rhs_shape, dtype, dimension_numbers, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-
-    def fun(lhs, rhs):
-      return lax.dot_general(lhs, rhs, dimension_numbers)
-
-    self._CompileAndCheck(fun, args_maker, check_dtypes=False)
+    self._Check(lax.dot_general, args_maker,
+                dimension_numbers=dimension_numbers)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_dimension_numbers={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               dimension_numbers),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "rng_factory": rng_factory}
-      for lhs_shape, rhs_shape, dimension_numbers in [
-          ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
-          ((3, 3, 2), (2, 3, 4), (([2], [0]), ([0], [1]))),
-          ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
-      ]
-      for dtype in all_dtypes
-      for rng_factory in [jtu.rand_small]))
-  def testDotGeneralAgainstNumpy(self, lhs_shape, rhs_shape, dtype,
-                                 dimension_numbers, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-    op = lambda x, y: lax.dot_general(x, y, dimension_numbers)
-    numpy_op = lambda x, y: lax_reference.dot_general(x, y, dimension_numbers)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}".format(
-          shape, np.dtype(dtype).name, broadcast_sizes),
+      {"testcase_name": f"_shape={shape}_dtype={np.dtype(dtype).name}"
+                        f"_broadcast_sizes={broadcast_sizes}",
        "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
        "rng_factory": rng_factory}
       for shape in [(), (2, 3)]
@@ -828,29 +646,12 @@ class LaxTest(jtu.JaxTestCase):
   def testBroadcast(self, shape, dtype, broadcast_sizes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.broadcast(x, broadcast_sizes)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(lax.broadcast, args_maker, sizes=broadcast_sizes)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_broadcast_sizes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), broadcast_sizes),
-       "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "rng_factory": rng_factory}
-      for shape in [(), (2, 3)]
-      for dtype in default_dtypes
-      for broadcast_sizes in [(), (2,), (1, 2)]
-      for rng_factory in [jtu.rand_default]))
-  def testBroadcastAgainstNumpy(self, shape, dtype, broadcast_sizes, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.broadcast(x, broadcast_sizes)
-    numpy_op = lambda x: lax_reference.broadcast(x, broadcast_sizes)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
-          jtu.format_shape_dtype_string(inshape, dtype),
-          outshape, broadcast_dimensions),
+      {"testcase_name":
+         f"_inshape={jtu.format_shape_dtype_string(inshape, dtype)}"
+         f"_outshape={outshape}_bcdims={broadcast_dimensions}",
        "inshape": inshape, "dtype": dtype, "outshape": outshape,
        "dimensions": broadcast_dimensions, "rng_factory": rng_factory}
       for inshape, outshape, broadcast_dimensions in [
@@ -865,13 +666,13 @@ class LaxTest(jtu.JaxTestCase):
   def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(inshape, dtype)]
-    op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(lax.broadcast_in_dim, args_maker, shape=outshape,
+                broadcast_dimensions=dimensions)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
-      jtu.format_shape_dtype_string(inshape, np.float32),
-      outshape, broadcast_dimensions),
+    {"testcase_name":
+       f"_inshape={jtu.format_shape_dtype_string(inshape, np.float32)}"
+       f"_outshape={outshape}_bcdims={broadcast_dimensions}",
       "inshape": inshape, "outshape": outshape,
       "broadcast_dimensions": broadcast_dimensions, "err_msg": err_msg}
     for inshape, outshape, broadcast_dimensions, err_msg in [
@@ -891,33 +692,10 @@ class LaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, err_msg):
       lax.broadcast_in_dim(x, shape=outshape, broadcast_dimensions=broadcast_dimensions)
 
-
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
-          jtu.format_shape_dtype_string(inshape, dtype),
-          outshape, broadcast_dimensions),
-       "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "rng_factory": rng_factory}
-      for inshape, outshape, broadcast_dimensions in [
-          ([2], [2, 2], [0]),
-          ([2], [2, 2], [1]),
-          ([2], [2, 3], [0]),
-          ([], [2, 3], []),
-          ([1], [2, 3], [1]),
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testBroadcastInDimAgainstNumpy(self, inshape, dtype, outshape,
-                                     dimensions, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(inshape, dtype)]
-    op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
-    numpy_op = lambda x: lax_reference.broadcast_in_dim(x, outshape, dimensions)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_inshape={}_dimensions={}".format(
-      jtu.format_shape_dtype_string(inshape, np.float32), dimensions),
+    {"testcase_name":
+       f"_inshape={jtu.format_shape_dtype_string(inshape, np.float32)}"
+       f"_dimensions={dimensions}",
       "inshape": inshape, "dimensions": dimensions, "error_type": error_type,
       "err_msg": err_msg}
     for inshape, dimensions, error_type, err_msg in [
@@ -934,8 +712,9 @@ class LaxTest(jtu.JaxTestCase):
       lax.squeeze(x, dimensions=dimensions)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_dimensions={}".format(
-          jtu.format_shape_dtype_string(arg_shape, np.float32), dimensions),
+      {"testcase_name":
+         f"_inshape={jtu.format_shape_dtype_string(arg_shape, np.float32)}"
+         f"_dimensions={dimensions}",
        "arg_shape": arg_shape, "dimensions": dimensions,
        "rng_factory": rng_factory}
       for arg_shape, dimensions in [
@@ -950,16 +729,14 @@ class LaxTest(jtu.JaxTestCase):
   def testSqueeze(self, arg_shape, dimensions, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(arg_shape, np.float32)]
-    op = lambda x: lax.squeeze(x, dimensions)
-    numpy_op = lambda x: lax_reference.squeeze(x, dimensions)
-    self._CompileAndCheck(op, args_maker)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-    check_grads(op, args_maker(), 2, ["fwd", "rev"], eps=1.)
+    self._Check(lax.squeeze, args_maker, dimensions=dimensions)
+    check_grads(partial(lax.squeeze, dimensions=dimensions),
+                args_maker(), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype)),
+      {"testcase_name":
+         f"_inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}"
+         f"_outshape={jtu.format_shape_dtype_string(out_shape, dtype)}",
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
        "rng_factory": rng_factory}
       for dtype in default_dtypes
@@ -970,30 +747,11 @@ class LaxTest(jtu.JaxTestCase):
   def testReshape(self, arg_shape, out_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(arg_shape, dtype)]
-    op = lambda x: lax.reshape(x, out_shape)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(lax.reshape, args_maker, new_sizes=out_shape)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype)),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng_factory": rng_factory}
-      for dtype in default_dtypes
-      for arg_shape, out_shape in [
-          [(3, 4), (12,)], [(2, 1, 4), (8,)], [(2, 2, 4), (2, 8)]
-      ]
-      for rng_factory in [jtu.rand_default]))
-  def testReshapeAgainstNumpy(self, arg_shape, out_shape, dtype, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(arg_shape, dtype)]
-    op = lambda x: lax.reshape(x, out_shape)
-    numpy_op = lambda x: lax_reference.reshape(x, out_shape)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_pads={}"
-       .format(jtu.format_shape_dtype_string(shape, dtype), pads),
+      {"testcase_name":
+         f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}_pads={pads}",
        "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
       for dtype in default_dtypes
       for shape, pads in [
@@ -1016,53 +774,31 @@ class LaxTest(jtu.JaxTestCase):
     fun = lambda operand: lax.pad(operand, np.array(0, dtype), pads)
     self._CompileAndCheck(fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_pads={}"
-       .format(jtu.format_shape_dtype_string(shape, dtype), pads),
-       "shape": shape, "dtype": dtype, "pads": pads, "rng_factory": jtu.rand_small}
-      for shape in [(2, 3)]
-      for dtype in default_dtypes
-      for pads in [
-        [(0, 0, 0), (0, 0, 0)],  # no padding
-        [(1, 1, 0), (2, 2, 0)],  # only positive edge padding
-        [(1, 2, 1), (0, 1, 0)],  # edge padding and interior padding
-        [(0, 0, 0), (-1, -1, 0)],  # negative padding
-        [(0, 0, 0), (-2, -2, 4)],  # add big dilation then remove from edges
-        [(0, 0, 0), (-2, -3, 1)],  # remove everything in one dimension
-      ]))
-  def testPadAgainstNumpy(self, shape, dtype, pads, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.pad(x, np.array(0, dtype), pads)
-    numpy_op = lambda x: lax_reference.pad(x, np.array(0, dtype), pads)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
   def testPadErrors(self):
     with self.assertRaisesRegex(ValueError, "padding_config"):
       lax.pad(np.zeros(2), 0., [(0, 1, 0), (0, 1, 0)])
     with self.assertRaisesRegex(ValueError, "padding_config"):
       lax.pad(np.zeros(2), 0., [(0, 1, -1)])
 
-  def testReverse(self):
-    rev = api.jit(lambda operand: lax.rev(operand, dimensions))
-
-    dimensions = []
-    self.assertAllClose(np.array([0, 1, 2, 3]), rev(np.array([0, 1, 2, 3])),
-                        check_dtypes=False)
-
-    dimensions = [0]
-    self.assertAllClose(np.array([3, 2, 1]), rev(np.array([1, 2, 3])),
-                        check_dtypes=False)
-
-    dimensions = [0, 1]
-    self.assertAllClose(np.array([[6, 5, 4], [3, 2, 1]]),
-                        rev(np.array([[1, 2, 3], [4, 5, 6]])),
-                        check_dtypes=False)
+  @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}"
+                      f"_dimensions={dimensions}",
+     "dimensions": dimensions, "shape": shape, "dtype": dtype}
+    for dtype in default_dtypes
+    for shape, dimensions in [
+      ((4,), ()),
+      ((3,), (0,)),
+      ((2, 3), (0, 1)),
+    ]))
+  def testReverse(self, dimensions, shape, dtype):
+    rng = jtu.rand_small(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    self._Check(lax.rev, args_maker, dimensions=dimensions)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_predshape={}_argshapes={}".format(
-          jtu.format_shape_dtype_string(pred_shape, np.bool_),
-          jtu.format_shape_dtype_string(arg_shape, arg_dtype)),
+      {"testcase_name":
+         f"_predshape={jtu.format_shape_dtype_string(pred_shape, np.bool_)}"
+         f"_argshapes={jtu.format_shape_dtype_string(arg_shape, arg_dtype)}",
        "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
        "rng_factory": rng_factory}
       for arg_shape in [(), (3,), (2, 3)]
@@ -1070,34 +806,16 @@ class LaxTest(jtu.JaxTestCase):
       for arg_dtype in default_dtypes
       for rng_factory in [jtu.rand_default]))
   def testSelect(self, pred_shape, arg_shape, arg_dtype, rng_factory):
-    def args_maker():
-      return [rng(pred_shape, np.bool_), rng(arg_shape, arg_dtype),
-              rng(arg_shape, arg_dtype)]
+    args_maker = lambda: [rng(pred_shape, np.bool_), rng(arg_shape, arg_dtype),
+                          rng(arg_shape, arg_dtype)]
     rng = rng_factory(self.rng())
-    return self._CompileAndCheck(lax.select, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_predshape={}_argshapes={}".format(
-          jtu.format_shape_dtype_string(pred_shape, np.bool_),
-          jtu.format_shape_dtype_string(arg_shape, arg_dtype)),
-       "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
-       "rng_factory": rng_factory}
-      for arg_shape in [(), (3,), (2, 3)]
-      for pred_shape in ([(), arg_shape] if arg_shape else [()])
-      for arg_dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testSelectAgainstNumpy(self, pred_shape, arg_shape, arg_dtype, rng_factory):
-    def args_maker():
-      return [rng(pred_shape, np.bool_), rng(arg_shape, arg_dtype),
-              rng(arg_shape, arg_dtype)]
-    rng = rng_factory(self.rng())
-    return self._CheckAgainstNumpy(lax_reference.select, lax.select, args_maker)
+    self._Check(lax.select, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_shape={}_start_indices={}_limit_indices={}_strides={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, limit_indices, strides),
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_start_indices={start_indices}_limit_indices={limit_indices}"
+         f"_strides={strides}",
        "shape": shape, "dtype": dtype, "starts": start_indices,
        "limits": limit_indices, "strides": strides, "rng_factory": rng_factory}
       for shape, start_indices, limit_indices, strides in [
@@ -1116,44 +834,16 @@ class LaxTest(jtu.JaxTestCase):
   def testSlice(self, shape, dtype, starts, limits, strides, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.slice(x, starts, limits, strides)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(lax.slice, args_maker, start_indices=starts,
+                limit_indices=limits, strides=strides)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
-       "_shape={}_start_indices={}_limit_indices={}_strides={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, limit_indices, strides),
-       "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "rng_factory": rng_factory}
-      for shape, start_indices, limit_indices, strides in [
-        [(3,), (1,), (2,), None],
-        [(7,), (4,), (7,), None],
-        [(5,), (1,), (5,), (2,)],
-        [(8,), (1,), (6,), (2,)],
-        [(5, 3), (1, 1), (3, 2), None],
-        [(5, 3), (1, 1), (3, 1), None],
-        [(7, 5, 3), (4, 0, 1), (7, 1, 3), None],
-        [(5, 3), (1, 1), (2, 1), (1, 1)],
-        [(5, 3), (1, 1), (5, 3), (2, 1)],
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testSliceAgainstNumpy(self, shape, dtype, starts, limits,
-                            strides, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.slice(x, starts, limits, strides)
-    numpy_op = lambda x: lax_reference.slice(x, starts, limits, strides)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_start_indices={}_size_indices={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, size_indices),
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_start_indices={start_indices}_slice_sizes={slice_sizes}",
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "size_indices": size_indices, "rng_factory": rng_factory}
-      for shape, start_indices, size_indices in [
+       "slice_sizes": slice_sizes, "rng_factory": rng_factory}
+      for shape, start_indices, slice_sizes in [
         [(3,), np.array((1,)), (1,)],
         [(5, 3), (1, 1), (3, 1)],
         [(5, 3), np.array((1, 1)), (3, 1)],
@@ -1161,32 +851,10 @@ class LaxTest(jtu.JaxTestCase):
       ]
       for dtype in default_dtypes
       for rng_factory in [jtu.rand_default]))
-  def testDynamicSlice(self, shape, dtype, start_indices, size_indices, rng_factory):
+  def testDynamicSlice(self, shape, dtype, start_indices, slice_sizes, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype), np.array(start_indices)]
-    op = lambda x, starts: lax.dynamic_slice(x, starts, size_indices)
-    self._CompileAndCheck(op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_start_indices={}_size_indices={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, size_indices),
-       "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "size_indices": size_indices, "rng_factory": rng_factory}
-      for shape, start_indices, size_indices in [
-        [(3,), (1,), (1,)],
-        [(5, 3), (1, 1), (3, 1)],
-        [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testDynamicSliceAgainstNumpy(self, shape, dtype, start_indices,
-                                   size_indices, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype), np.array(start_indices)]
-    op = lambda x, s: lax.dynamic_slice(x, s, size_indices)
-    numpy_op = lambda x, s: lax_reference.dynamic_slice(x, s, size_indices)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
+    self._Check(lax.dynamic_slice, args_maker, slice_sizes=slice_sizes)
 
   def testDynamicSliceInDim(self):
     # Regression test for mixed type problem in dynamic_slice_in_dim.
@@ -1195,9 +863,9 @@ class LaxTest(jtu.JaxTestCase):
     np.testing.assert_equal(lax.dynamic_slice_in_dim(x, 2, 3), x[2:5])
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_start_indices={}_update_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, update_shape),
+      {"testcase_name":
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_start_indices={start_indices}_update_shape={update_shape}",
        "shape": shape, "dtype": dtype, "start_indices": start_indices,
        "update_shape": update_shape, "rng_factory": rng_factory}
       for shape, start_indices, update_shape in [
@@ -1210,40 +878,13 @@ class LaxTest(jtu.JaxTestCase):
   def testDynamicUpdateSlice(self, shape, dtype, start_indices, update_shape,
                              rng_factory):
     rng = rng_factory(self.rng())
-
-    def args_maker():
-      return [rng(shape, dtype), rng(update_shape, dtype),
-              np.array(start_indices)]
-
-    self._CompileAndCheck(lax.dynamic_update_slice, args_maker)
+    args_maker = lambda: [rng(shape, dtype), rng(update_shape, dtype),
+                          np.array(start_indices)]
+    self._Check(lax.dynamic_update_slice, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_start_indices={}_update_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, update_shape),
-       "shape": shape, "dtype": dtype, "start_indices": start_indices,
-       "update_shape": update_shape, "rng_factory": rng_factory}
-      for shape, start_indices, update_shape in [
-        [(3,), (1,), (1,)],
-        [(5, 3), (1, 1), (3, 1)],
-        [(7, 5, 3), (4, 1, 0), (2, 0, 1)],
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testDynamicUpdateSliceAgainstNumpy(self, shape, dtype, start_indices,
-                                         update_shape, rng_factory):
-    rng = rng_factory(self.rng())
-
-    def args_maker():
-      return [rng(shape, dtype), rng(update_shape, dtype),
-              np.array(start_indices)]
-
-    self._CheckAgainstNumpy(lax_reference.dynamic_update_slice,
-                            lax.dynamic_update_slice, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_perm={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), perm),
+      {"testcase_name":
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}_perm={perm}",
        "shape": shape, "dtype": dtype, "perm": perm, "rng_factory": rng_factory}
       for shape, perm in [
         [(3, 4), (1, 0)],
@@ -1256,48 +897,30 @@ class LaxTest(jtu.JaxTestCase):
   def testTranspose(self, shape, dtype, perm, rng_factory):
     rng = rng_factory(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.transpose(x, perm)
-    self._CompileAndCheck(op, args_maker)
+    self._Check(lax.transpose, args_maker, permutation=perm)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_perm={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), perm),
-       "shape": shape, "dtype": dtype, "perm": perm, "rng_factory": rng_factory}
-      for shape, perm in [
-        [(3, 4), (1, 0)],
-        [(3, 4), (0, 1)],
-        [(3, 4, 5), (2, 1, 0)],
-        [(3, 4, 5), (1, 0, 2)],
-      ]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testTransposeAgainstNumpy(self, shape, dtype, perm, rng_factory):
-    rng = rng_factory(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.transpose(x, perm)
-    numpy_op = lambda x: lax_reference.transpose(x, perm)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_inshape={}_reducedims={}_initval={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims,
-               init_val),
+      {"testcase_name":
+         f"_op={op.__name__}"
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_dims={dims}_initval={init_val}",
        "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
        "dims": dims, "rng_factory": rng_factory}
       for init_val, op, types in [
-          (0, lax.add, default_dtypes),
-          (1, lax.mul, default_dtypes),
-          (0, lax.max, all_dtypes), # non-monoidal
-          (-np.inf, lax.max, float_dtypes),
-          (dtypes.iinfo(np.int32).min, lax.max, [np.int32]),
-          # (dtypes.iinfo(np.int64).min, lax.max, [np.int64]),  # TODO fails
-          (dtypes.iinfo(np.uint32).min, lax.max, [np.uint32]),
-          (dtypes.iinfo(np.uint64).min, lax.max, [np.uint64]),
-          (np.inf, lax.min, float_dtypes),
-          (dtypes.iinfo(np.int32).max, lax.min, [np.int32]),
-          # (dtypes.iinfo(np.int64).max, lax.min, [np.int64]),  # TODO fails
-          (dtypes.iinfo(np.uint32).max, lax.min, [np.uint32]),
-          (dtypes.iinfo(np.uint64).max, lax.min, [np.uint64]),
+          (0, lax.add, number_dtypes + uint_dtypes),
+          (1, lax.mul, number_dtypes + uint_dtypes),
+          (0, lax.max, all_dtypes),  # non-monoidal max
+          (0, lax.min, all_dtypes),  # non-monoidal min
+          (-np.inf, lax.max, inexact_dtypes),
+          (np.iinfo(np.int32).min, lax.max, [np.int32]),
+          # (np.iinfo(np.int64).min, lax.max, [np.int64]),  # TODO fails
+          (np.iinfo(np.uint32).min, lax.max, [np.uint32]),
+          (np.iinfo(np.uint64).min, lax.max, [np.uint64]),
+          (np.inf, lax.min, inexact_dtypes),
+          (np.iinfo(np.int32).max, lax.min, [np.int32]),
+          # (np.iinfo(np.int64).max, lax.min, [np.int64]),  # TODO fails
+          (np.iinfo(np.uint32).max, lax.min, [np.uint32]),
+          (np.iinfo(np.uint64).max, lax.min, [np.uint64]),
       ]
       for dtype in types
       for shape, dims in [
@@ -1310,28 +933,36 @@ class LaxTest(jtu.JaxTestCase):
   def testReduce(self, op, init_val, shape, dtype, dims, rng_factory):
     rng = rng_factory(self.rng())
     init_val = np.asarray(init_val, dtype=dtype)
-    fun = lambda operand, init_val: lax.reduce(operand, init_val, op, dims)
     args_maker = lambda: [rng(shape, dtype), init_val]
-    self._CompileAndCheck(fun, args_maker)
-
-    # we separately test the version that uses a concrete init_val because it
-    # can hit different code paths
-    fun = lambda operand: lax.reduce(operand, init_val, op, dims)
-    args_maker = lambda: [rng(shape, dtype)]
-    self._CompileAndCheck(fun, args_maker)
+    self._Check(lax.reduce, args_maker, computation=op, dimensions=dims)
+    # Test different code path for concrete init_val:
+    self._Check(lax.reduce, lambda: [rng(shape, dtype)], init_value=init_val,
+                computation=op, dimensions=dims)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
-                         "_basedilation={}_windowdilation={}")
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype),
-               dims, strides, padding, base_dilation, window_dilation),
-       "op": op, "init_val": init_val, "dtype": dtype, "shape": shape,
+      {"testcase_name":
+         f"_op={op.__name__}"
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_dims={dims}_initval={init_val}_strides={strides}_padding={padding}"
+         f"_basedilation={base_dilation}_windowdilation={window_dilation}",
+       "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
        "dims": dims, "strides": strides, "padding": padding,
        "base_dilation": base_dilation, "window_dilation": window_dilation}
       for init_val, op, dtypes in [
-          (0, lax.add, [np.float32]),
-          (-np.inf, lax.max, [np.float32]),
-          (np.inf, lax.min, [np.float32]),
+        (0, lax.add, number_dtypes + uint_dtypes),
+        (1, lax.mul, number_dtypes + uint_dtypes),  # custom op
+        (0, lax.max, number_dtypes),  # non-monoidal max
+        (0, lax.min, number_dtypes),  # non-monoidal min
+        (-np.inf, lax.max, inexact_dtypes),
+        (np.iinfo(np.int32).min, lax.max, [np.int32]),
+        # (np.iinfo(np.int64).min, lax.max, [np.int64]),  # TODO fails
+        (np.iinfo(np.uint32).min, lax.max, [np.uint32]),
+        (np.iinfo(np.uint64).min, lax.max, [np.uint64]),
+        (np.inf, lax.min, inexact_dtypes),
+        (np.iinfo(np.int32).max, lax.min, [np.int32]),
+        # (np.iinfo(np.int64).max, lax.min, [np.int64]),  # TODO fails
+        (np.iinfo(np.uint32).max, lax.min, [np.uint32]),
+        (np.iinfo(np.uint64).max, lax.min, [np.uint64]),
       ]
       for shape, dims, strides, padding, base_dilation, window_dilation in (
         itertools.chain(
@@ -1349,32 +980,18 @@ class LaxTest(jtu.JaxTestCase):
             [(1, 1, 1, 1), (2, 1, 3, 2)],
             [(1, 1, 1, 1), (1, 2, 2, 1)])))
       for dtype in dtypes))
-  def testReduceWindow(self, op, init_val, dtype, shape, dims, strides, padding,
+  def testReduceWindow(self, op, init_val, shape, dtype, dims, strides, padding,
                        base_dilation, window_dilation):
     rng = jtu.rand_small(self.rng())
     init_val = np.asarray(init_val, dtype=dtype)
-
-    def fun(operand, init_val):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
-                               base_dilation, window_dilation)
-
-    def reference_fun(operand, init_val):
-      return lax_reference.reduce_window(operand, init_val, op, dims, strides,
-                                         padding, base_dilation)
-
+    params = dict(computation=op, window_dimensions=dims,
+                  window_strides=strides, padding=padding,
+                  base_dilation=base_dilation, window_dilation=window_dilation)
     args_maker = lambda: [rng(shape, dtype), init_val]
-    self._CompileAndCheck(fun, args_maker)
-    if all(d == 1 for d in window_dilation):
-      self._CheckAgainstNumpy(reference_fun, fun, args_maker)
-
-    # we separately test the version that uses a concrete init_val because it
-    # can hit different code paths
-    def fun(operand):
-      return lax.reduce_window(operand, init_val, op, dims, strides, padding,
-                               base_dilation, window_dilation)
-
-    args_maker = lambda: [rng(shape, dtype)]
-    self._CompileAndCheck(fun, args_maker)
+    self._Check(lax.reduce_window, args_maker, **params)
+    # Test different code path for concrete init_val:
+    self._Check(lax.reduce_window, lambda: [rng(shape, dtype)],
+                init_value=init_val, **params)
 
   def testReduceWindowFailures(self):
     def empty_window_test():
@@ -1419,84 +1036,65 @@ class LaxTest(jtu.JaxTestCase):
       self.assertEqual(shape, result.shape)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_shape={}_axis={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis),
-       "op": op, "np_op": np_op, "shape": shape, "dtype": dtype,
-       "axis": axis, "rng_factory": rng_factory}
-      for op, np_op, types in [
-          (lax.cumsum, np.cumsum, default_dtypes),
-          (lax.cumprod, np.cumprod, default_dtypes),
-          (lax.cummax, np.maximum.accumulate, default_dtypes),
-          (lax.cummin, np.minimum.accumulate, default_dtypes),
-      ]
-      for dtype in types
+      {"testcase_name": f"_op={op.__name__}"
+                        f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+                        f"_axis={axis}",
+       "op": op, "shape": shape, "dtype": dtype, "axis": axis,
+       "rng_factory": rng_factory}
+      for op in [lax.cumsum, lax.cumprod, lax.cummax, lax.cummin]
+      for dtype in default_dtypes
       for shape in [[10], [3, 4, 5]]
       for axis in range(len(shape))
       for rng_factory in [
           jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
           else jtu.rand_small]))
-  def testCumulativeReduce(self, op, np_op, shape, dtype, axis, rng_factory):
+  def testCumulativeReduce(self, op, shape, dtype, axis, rng_factory):
     rng = rng_factory(self.rng())
-    fun = partial(op, axis=axis)
-    np_fun = partial(np_op, axis=axis, dtype=dtype)
     args_maker = lambda: [rng(shape, dtype)]
-    self._CompileAndCheck(fun, args_maker)
-    self._CheckAgainstNumpy(np_fun, fun, args_maker)
+    self._Check(op, args_maker, axis=axis)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}_isstable={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, is_stable),
-       "shape": shape, "dtype": dtype, "axis": axis, "is_stable": is_stable}
-      for dtype in all_dtypes
-      for shape in [(5,), (5, 7)]
-      for axis in [-1, len(shape) - 1]
-      for is_stable in [False, True]))
-  def testSort(self, shape, dtype, axis, is_stable):
+    {"testcase_name": f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+                      f"_axis={axis}_isstable={is_stable}"
+                      f"_numoperands={num_operands}_numkeys={num_keys}",
+     "shape": shape, "dtype": dtype, "axis": axis, "is_stable": is_stable,
+     "num_operands": num_operands, "num_keys": num_keys}
+    for dtype in all_dtypes + uint_dtypes
+    for shape in [(5,), (5, 7)]
+    for axis in range(-len(shape) + 1, len(shape))
+    for is_stable in [False, True]
+    for num_operands in [1, 3]
+    for num_keys in range(1, num_operands + 1)))
+  def testSort(self, shape, dtype, axis, is_stable, num_operands, num_keys):
     # TODO(b/141131288): enable complex-valued sorts on TPU.
     if (np.issubdtype(dtype, np.complexfloating) and (
         (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
          jtu.device_under_test() == "tpu")):
       raise SkipTest("Complex-valued sort not implemented")
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    fun = lambda x: lax.sort(x, dimension=axis, is_stable=is_stable)
-    self._CompileAndCheck(fun, args_maker)
+    def unique_rng(shape, dtype):
+      return jtu.rand_unique_int(self.rng())(shape, dtype).astype(dtype)
+    num_values = num_operands - num_keys
+    # Order of values with tied keys may differ for unstable sort, avoid:
+    use_unique_keys = not is_stable and num_values > 0 and dtype != np.bool_
+    key_rng = unique_rng if use_unique_keys else rng
+    args_maker = lambda: [rng(shape, dtype) if num_operands == 1 else tuple(
+      [key_rng(shape, dtype) for _ in range(num_keys)] +
+      [rng(shape, dtype) for _ in range(num_values)])]
+    self._Check(lax.sort, args_maker,
+                dimension=axis, num_keys=num_keys, is_stable=is_stable)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}_isstable={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, is_stable),
-        "shape": shape, "dtype": dtype, "axis": axis, "is_stable": is_stable}
-      for dtype in all_dtypes
-      for shape in [(5,), (5, 7)]
-      for axis in [-1, len(shape) - 1]
-      for is_stable in [False, True]))
-  def testSortAgainstNumpy(self, shape, dtype, axis, is_stable):
-    # TODO(b/141131288): enable complex-valued sorts on TPU.
-    if (np.issubdtype(dtype, np.complexfloating) and (
-        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
-         jtu.device_under_test() == "tpu")):
-      raise SkipTest("Complex-valued sort not implemented")
-    rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    op = lambda x: lax.sort(x, dimension=axis, is_stable=is_stable)
-    def numpy_op(x):
-      if is_stable:
-        return lax_reference.sort(x, axis, kind='stable')
-      else:
-        return lax_reference.sort(x, axis)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_keyshape={}_valshape={}_axis={}_isstable={}".format(
-          jtu.format_shape_dtype_string(shape, key_dtype),
-          jtu.format_shape_dtype_string(shape, val_dtype),
-          axis, is_stable),
+      {"testcase_name":
+         f"_keyshape={jtu.format_shape_dtype_string(shape, key_dtype)}"
+         f"_valshape={jtu.format_shape_dtype_string(shape, val_dtype)}"
+         f"_axis={axis}_isstable={is_stable}",
        "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
        "axis": axis, "is_stable": is_stable}
-      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
-      for val_dtype in [np.float32, np.int32, np.uint32]
+      for key_dtype in all_dtypes + uint_dtypes
+      for val_dtype in all_dtypes + uint_dtypes
       for shape in [(3,), (5, 3)]
-      for axis in [-1, len(shape) - 1]
+      for axis in range(-len(shape) + 1, len(shape))
       for is_stable in [False, True]))
   def testSortKeyVal(self, shape, key_dtype, val_dtype, axis, is_stable):
     # TODO(b/141131288): enable complex-valued sorts on TPU.
@@ -1505,94 +1103,31 @@ class LaxTest(jtu.JaxTestCase):
          jtu.device_under_test() == "tpu")):
       raise SkipTest("Complex-valued sort not implemented")
     rng = jtu.rand_default(self.rng())
-    # This test relies on the property that wherever keys are tied, values are
-    # too, since we don't guarantee the same ordering of values with equal keys.
-    # To avoid that case, we generate unique keys (globally in the key array).
-    def args_maker():
-      flat_keys = np.arange(prod(shape), dtype=key_dtype)
-      keys = self.rng().permutation(flat_keys).reshape(shape)
-      values = rng(shape, val_dtype)
-      return keys, values
-
-    fun = lambda keys, values: lax.sort_key_val(keys, values, axis, is_stable)
-    self._CompileAndCheck(fun, args_maker)
+    def unique_rng(shape, dtype):
+      return jtu.rand_unique_int(self.rng())(shape, dtype).astype(dtype)
+    # Order of values with tied keys may differ for unstable sort, avoid:
+    use_unique_keys = not is_stable and key_dtype != np.bool_
+    key_rng = unique_rng if use_unique_keys else rng
+    args_maker = lambda: [key_rng(shape, key_dtype), rng(shape, val_dtype)]
+    self._Check(lax.sort_key_val, args_maker,
+                dimension=axis, is_stable=is_stable)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_num_keys={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), num_keys),
-       "shape": shape, "dtype": dtype, "num_keys": num_keys}
-      for dtype in all_dtypes
-      for shape in [(3, 5,), (4, 3)]
-      for num_keys in range(1, shape[0] + 1)))
-  def testSortNumKeys(self, shape, dtype, num_keys):
-    # TODO(b/141131288): enable complex-valued sorts on TPU.
-    if (np.issubdtype(dtype, np.complexfloating) and (
-        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
-         jtu.device_under_test() == "tpu")):
-      raise SkipTest("Complex-valued sort not implemented")
-    rng = jtu.rand_default(self.rng())
-    args_maker = lambda: [rng(shape, dtype)]
-    lax_fun = lambda x: lax.sort(tuple(x), num_keys=num_keys)
-    numpy_fun = lambda x: tuple(x[:, np.lexsort(x[:num_keys][::-1])])
-    # self._CompileAndCheck(lax_fun, args_maker)
-    self._CheckAgainstNumpy(numpy_fun, lax_fun, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_keyshape={}_valshape={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, key_dtype),
-          jtu.format_shape_dtype_string(shape, val_dtype),
-          axis),
-       "shape": shape, "key_dtype": key_dtype, "val_dtype": val_dtype,
-       "axis": axis}
-      for key_dtype in float_dtypes + complex_dtypes + int_dtypes + uint_dtypes
-      for val_dtype in [np.float32, np.int32, np.uint32]
-      for shape in [(3,), (5, 3)]
-      for axis in [-1, len(shape) - 1]))
-  def testSortKeyValAgainstNumpy(self, shape, key_dtype, val_dtype, axis):
-    # TODO(b/141131288): enable complex-valued sorts on TPU.
-    if (np.issubdtype(key_dtype, np.complexfloating) and (
-        (jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 47)) or
-         jtu.device_under_test() == "tpu")):
-      raise SkipTest("Complex-valued sort not implemented")
-    rng = jtu.rand_default(self.rng())
-    # This test relies on the property that wherever keys are tied, values are
-    # too, since we don't guarantee the same ordering of values with equal keys.
-    # To avoid that case, we generate unique keys (globally in the key array).
-    def args_maker():
-      flat_keys = np.arange(prod(shape), dtype=key_dtype)
-      keys = self.rng().permutation(flat_keys).reshape(shape)
-      values = rng(shape, val_dtype)
-      return keys, values
-
-    op = lambda ks, vs: lax.sort_key_val(ks, vs, axis)
-    numpy_op = lambda ks, vs: lax_reference.sort_key_val(ks, vs, axis)
-    self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_k={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), k),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "k": k}
+      {"testcase_name":
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}_k={k}",
+       "shape": shape, "dtype": dtype, "k": k}
       for dtype in [np.float32, np.int32, np.uint32]
       for shape in [(3,), (5, 3)]
-      for k in [1, 3]
-      for rng_factory in [jtu.rand_default]))
-  def testTopK(self, shape, dtype, k, rng_factory):
-    def args_maker():
-      flat_values = np.arange(prod(shape), dtype=dtype)
-      values = self.rng().permutation(flat_values).reshape(shape)
-      return [values]
-    def reference_top_k(x):
-      bcast_idxs = np.broadcast_to(np.arange(shape[-1], dtype=np.int32), shape)
-      sorted_vals, sorted_idxs = lax_reference.sort_key_val(x, bcast_idxs)
-      return sorted_vals[..., :-k-1:-1], sorted_idxs[..., :-k-1:-1]
-    op = lambda vs: lax.top_k(vs, k=k)
-    self._CheckAgainstNumpy(op, reference_top_k, args_maker)
-    self._CompileAndCheck(op, args_maker)
+      for k in [1, 3]))
+  def testTopK(self, shape, dtype, k):
+    flat_values = np.arange(prod(shape), dtype=dtype)
+    args_maker = lambda: [self.rng().permutation(flat_values).reshape(shape)]
+    self._Check(lax.top_k, args_maker, k=k)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype)),
+      {"testcase_name":
+         f"_lhs_shape={jtu.format_shape_dtype_string(lhs_shape, dtype)}"
+         f"_rhs_shape={jtu.format_shape_dtype_string(rhs_shape, dtype)}",
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
        "rng_factory": rng_factory}
       for lhs_shape, rhs_shape in [((3, 2), (2, 4)),
@@ -1603,7 +1138,7 @@ class LaxTest(jtu.JaxTestCase):
   def testBatchMatMul(self, lhs_shape, rhs_shape, dtype, rng_factory):
     rng = rng_factory(self.rng())
     arg_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
-    self._CompileAndCheck(lax.batch_matmul, arg_maker)
+    self._Check(lax.batch_matmul, arg_maker)
 
   def testCollapse(self):
 
@@ -1617,9 +1152,11 @@ class LaxTest(jtu.JaxTestCase):
                      collapse_first_two(np.zeros((1, 2, 3, 4))).shape)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_axes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), idxs, axes),
-       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes, "rng_factory": rng_factory}
+      {"testcase_name":
+         f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+         f"_idxs={idxs}_axes={axes}",
+       "shape": shape, "dtype": dtype, "idxs": idxs, "axes": axes,
+       "rng_factory": rng_factory}
       for dtype in all_dtypes
       for shape, idxs, axes in [
           [(3, 4, 5), (np.array([0, 2, 1]),), (0,)],
@@ -1632,102 +1169,104 @@ class LaxTest(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     rand_idxs = lambda: tuple(rng(e.shape, e.dtype) for e in idxs)
     args_maker = lambda: [rng(shape, dtype), rand_idxs()]
-    fun = lambda src, idxs: lax.index_take(src, idxs, axes)
-    self._CompileAndCheck(fun, args_maker)
+    self._Check(lax.index_take, args_maker, axes=axes)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_dnums={}_slice_sizes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), idxs, dnums,
-          slice_sizes),
-       "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "rng_factory": rng_factory,
-       "rng_idx_factory": rng_idx_factory}
-      for dtype in all_dtypes
-      for shape, idxs, dnums, slice_sizes in [
-          ((5,), np.array([[0], [2]]), lax.GatherDimensionNumbers(
-            offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
-            (1,)),
-          ((10,), np.array([[0], [0], [0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,)),
-            (2,)),
-          ((10, 5,), np.array([[0], [2], [1]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,)),
-            (1, 3)),
-          ((10, 5), np.array([[0, 2], [1, 0]]), lax.GatherDimensionNumbers(
-            offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
-            (1, 3)),
-      ]
-      for rng_idx_factory in [partial(jtu.rand_int, high=max(shape))]
-      for rng_factory in [jtu.rand_default]))
-  def testGather(self, shape, dtype, idxs, dnums, slice_sizes, rng_factory,
+    {"testcase_name":
+       f"_shape={jtu.format_shape_dtype_string(shape, dtype)}"
+       f"_idx_shape={idx_shape}_dnums={dnums}_slice_sizes={slice_sizes}",
+      "shape": shape, "dtype": dtype, "idx_shape": idx_shape, "dnums": dnums,
+      "slice_sizes": slice_sizes, "rng_factory": rng_factory,
+      "rng_idx_factory": rng_idx_factory}
+    for dtype in all_dtypes
+    for shape, idx_shape, slice_sizes, dnums in [
+      ((5,), (2, 1), (1,), lax.GatherDimensionNumbers(  # indices
+        offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))),
+      ((10,), (3, 1), (2,), lax.GatherDimensionNumbers(  # slices
+        offset_dims=(1,), collapsed_slice_dims=(), start_index_map=(0,))),
+      ((5,), (2, 1), (3,), lax.GatherDimensionNumbers(  # changed offset_dim
+        offset_dims=(0,), collapsed_slice_dims=(), start_index_map=(0,))),
+      ((10, 5), (2, 2), (1, 3), lax.GatherDimensionNumbers(  # slices into 2D
+        offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1))),
+      ((10, 5), (3, 1), (1, 3), lax.GatherDimensionNumbers(  # aligned slices
+        offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0,))),
+      ((5,), (1,), (2,), lax.GatherDimensionNumbers(  # 0D batch = single slice
+        offset_dims=(0,), collapsed_slice_dims=(), start_index_map=(0,))),
+      ((5,), (1, 2, 1), (1,), lax.GatherDimensionNumbers(  # 2D batch
+        offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))),
+    ]
+    for rng_factory in [jtu.rand_default]
+    # gather rectifies start indices to avoid out-of-bound errors, test for it:
+    for rng_idx_factory in [partial(jtu.rand_int, high=max(shape))]
+  ))
+  def testGather(self, shape, dtype, idx_shape, dnums, slice_sizes, rng_factory,
                  rng_idx_factory):
     rng = rng_factory(self.rng())
     rng_idx = rng_idx_factory(self.rng())
-    rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
-    args_maker = lambda: [rng(shape, dtype), rand_idxs()]
-    fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
-    self._CompileAndCheck(fun, args_maker)
+    args_maker = lambda: [rng(shape, dtype), rng_idx(idx_shape, np.int)]
+    self._Check(lax.gather, args_maker, dimension_numbers=dnums,
+                slice_sizes=slice_sizes)
 
   # These tests are adapted from the corresponding tests in
   # tensorflow/compiler/xla/service/shape_inference_test.cc with slight
   # variations to account for the implicit setting of index_vector_dim in JAX.
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_{testcase_name}", "operand_shape": operand_shape,
-       "start_indices_shape": start_indices_shape,
-       "dimension_numbers": lax.GatherDimensionNumbers(
-          offset_dims=offset_dims,
-          collapsed_slice_dims=collapsed_slice_dims,
-          start_index_map=start_index_map),
-       "slice_sizes": slice_sizes, "msg": msg}
-      for (testcase_name, operand_shape, start_indices_shape, offset_dims,
-           collapsed_slice_dims, start_index_map, slice_sizes, msg) in [
-        ("NonAscendingWindowIndices", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
-         (4, 5, 6, 8, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "offset_dims in gather op must be sorted"),
-        ("RepeatedWindowIndices", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
-         (4, 5, 6, 7, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "offset_dims in gather op must not repeat"),
-        ("WindowIndexOutOfBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
-         (4, 5, 100, 101, 102), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "Offset dimension 2 in gather op is out of bounds"),
-        ("WindowIndexBarelyOutOfBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
-         (4, 5, 6, 7, 9), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "Offset dimension 4 in gather op is out of bounds"),
-        ("MismatchingElidedWindowDims", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (4,), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "All components of the offset index in a gather op must either be a "
-         "offset dimension or explicitly collapsed"),
-        ("OutOfBoundsWindowToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (0, 1, 2, 3, 19), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "Invalid collapsed_slice_dims set in gather op; valid range is"),
-        ("RepeatedWindowToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (0, 1, 2, 3, 3), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "collapsed_slice_dims in gather op must not repeat"),
-        ("MismatchingGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (), (0, 1, 2, 3), (10, 9, 8, 7, 6),
-         "Gather op has 4 elements in start_index_map and the bound of "
-         "dimension index_vector_dim=4 of start_indices is 5. These two "
-         "numbers must be equal."),
-        ("OutOfBoundsGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (), (0, 1, 2, 3, 7), (10, 9, 8, 7, 6),
-         "Invalid start_index_map"),
-        ("RepeatedGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (), (0, 1, 2, 3, 3), (10, 9, 8, 7, 6),
-         "start_index_map in gather op must not repeat"),
-        ("NonAscendingElidedWindowDims", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7, 8), (2, 1), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "collapsed_slice_dims in gather op must be sorted"),
-        ("WindowBoundsTooLarge", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7), (2,), (0, 1, 2, 3, 4), (10, 9, 8, 100, 6),
-         "Slice size at index 3 in gather op is out of range"),
-        ("MismatchingNumberOfWindowBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7),
-         "Gather op must have one slice size for every input dimension"),
-        ("WindowBoundsNot1ForElidedDim", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
-         (4, 5, 6, 7), (1,), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
-         "Gather op can only collapse slice dims with bound 1 or 0, but bound "
-         "is 9 for index 1 at position 0.")
-      ]
+    {"testcase_name": f"_{testcase_name}", "operand_shape": operand_shape,
+     "start_indices_shape": start_indices_shape,
+     "dimension_numbers": lax.GatherDimensionNumbers(
+       offset_dims=offset_dims,
+       collapsed_slice_dims=collapsed_slice_dims,
+       start_index_map=start_index_map),
+     "slice_sizes": slice_sizes, "msg": msg}
+    for (testcase_name, operand_shape, start_indices_shape, offset_dims,
+         collapsed_slice_dims, start_index_map, slice_sizes, msg) in [
+      ("NonAscendingWindowIndices", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
+       (4, 5, 6, 8, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "offset_dims in gather op must be sorted"),
+      ("RepeatedWindowIndices", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
+       (4, 5, 6, 7, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "offset_dims in gather op must not repeat"),
+      ("WindowIndexOutOfBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
+       (4, 5, 100, 101, 102), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "Offset dimension 2 in gather op is out of bounds"),
+      ("WindowIndexBarelyOutOfBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 1),
+       (4, 5, 6, 7, 9), (), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "Offset dimension 4 in gather op is out of bounds"),
+      ("MismatchingElidedWindowDims", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (4,), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "All components of the offset index in a gather op must either be a "
+       "offset dimension or explicitly collapsed"),
+      ("OutOfBoundsWindowToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (0, 1, 2, 3, 19), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "Invalid collapsed_slice_dims set in gather op; valid range is"),
+      ("RepeatedWindowToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (0, 1, 2, 3, 3), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "collapsed_slice_dims in gather op must not repeat"),
+      ("MismatchingGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (), (0, 1, 2, 3), (10, 9, 8, 7, 6),
+       "Gather op has 4 elements in start_index_map and the bound of "
+       "dimension index_vector_dim=4 of start_indices is 5. These two "
+       "numbers must be equal."),
+      ("OutOfBoundsGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (), (0, 1, 2, 3, 7), (10, 9, 8, 7, 6),
+       "Invalid start_index_map"),
+      ("RepeatedGatherToInputMapping", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (), (0, 1, 2, 3, 3), (10, 9, 8, 7, 6),
+       "start_index_map in gather op must not repeat"),
+      ("NonAscendingElidedWindowDims", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7, 8), (2, 1), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "collapsed_slice_dims in gather op must be sorted"),
+      ("WindowBoundsTooLarge", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7), (2,), (0, 1, 2, 3, 4), (10, 9, 8, 100, 6),
+       "Slice size at index 3 in gather op is out of range"),
+      ("MismatchingNumberOfWindowBounds", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7), (), (0, 1, 2, 3, 4), (10, 9, 8, 7),
+       "Gather op must have one slice size for every input dimension"),
+      ("WindowBoundsNot1ForElidedDim", (10, 9, 8, 7, 6), (5, 4, 3, 2, 5),
+       (4, 5, 6, 7), (1,), (0, 1, 2, 3, 4), (10, 9, 8, 7, 6),
+       "Gather op can only collapse slice dims with bound 1 or 0, but bound "
+       "is 9 for index 1 at position 0.")
+    ]
   ))
   def testGatherShapeCheckingRule(self, operand_shape, start_indices_shape,
                                   dimension_numbers, slice_sizes, msg):
@@ -1738,128 +1277,37 @@ class LaxTest(jtu.JaxTestCase):
       lax.gather(operand, start_indices, dimension_numbers, slice_sizes)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums),
-       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums,
-       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
-          ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
-            update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-      ]
-      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
-      for rng_factory in [jtu.rand_default]))
-  def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums,
-                     rng_factory, rng_idx_factory):
+    {"testcase_name":
+       f"_op={op.__name__}"
+       f"_shape={jtu.format_shape_dtype_string(arg_shape, dtype)}"
+       f"_idxs={idxs}_update={update_shape}_dnums={dnums}",
+     "op": op, "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
+     "update_shape": update_shape, "dnums": dnums,
+     "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
+    for op in [lax.scatter, lax.scatter_add, lax.scatter_min, lax.scatter_max]
+    for dtype in float_dtypes
+    for arg_shape, idxs, update_shape, dnums in [
+      ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
+        update_window_dims=(), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))),
+      ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
+        update_window_dims=(1,), inserted_window_dims=(),
+        scatter_dims_to_operand_dims=(0,))),
+      ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
+        update_window_dims=(1,), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))),
+    ]
+    for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
+    for rng_factory in [jtu.rand_default]))
+  def testScatterOp(self, op, arg_shape, dtype, idxs, update_shape, dnums,
+                    rng_factory, rng_idx_factory):
     rng = rng_factory(self.rng())
     rng_idx = rng_idx_factory(self.rng())
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
-    fun = partial(lax.scatter_add, dimension_numbers=dnums)
-    self._CompileAndCheck(fun, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums),
-       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums,
-       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
-          ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
-            update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-      ]
-      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
-      for rng_factory in [jtu.rand_default]))
-  def testScatterMin(self, arg_shape, dtype, idxs, update_shape, dnums,
-                     rng_factory, rng_idx_factory):
-    rng = rng_factory(self.rng())
-    rng_idx = rng_idx_factory(self.rng())
-    rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
-    args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
-                          rng(update_shape, dtype)]
-    fun = partial(lax.scatter_min, dimension_numbers=dnums)
-    self._CompileAndCheck(fun, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums),
-       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums,
-       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
-          ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
-            update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-      ]
-      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
-      for rng_factory in [jtu.rand_default]))
-  def testScatterMax(self, arg_shape, dtype, idxs, update_shape, dnums,
-                     rng_factory, rng_idx_factory):
-    rng = rng_factory(self.rng())
-    rng_idx = rng_idx_factory(self.rng())
-    rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
-    args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
-                          rng(update_shape, dtype)]
-    fun = partial(lax.scatter_max, dimension_numbers=dnums)
-    self._CompileAndCheck(fun, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums),
-       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums,
-       "rng_factory": rng_factory, "rng_idx_factory": rng_idx_factory}
-      for dtype in float_dtypes
-      for arg_shape, idxs, update_shape, dnums in [
-          ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
-            update_window_dims=(), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(),
-            scatter_dims_to_operand_dims=(0,))),
-          ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
-            update_window_dims=(1,), inserted_window_dims=(0,),
-            scatter_dims_to_operand_dims=(0,))),
-      ]
-      for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
-      for rng_factory in [jtu.rand_default]))
-  def testScatter(self, arg_shape, dtype, idxs, update_shape, dnums,
-                  rng_factory, rng_idx_factory):
-    rng = rng_factory(self.rng())
-    rng_idx = rng_idx_factory(self.rng())
-    rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
-    args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
-                          rng(update_shape, dtype)]
-    fun = partial(lax.scatter, dimension_numbers=dnums)
-    self._CompileAndCheck(fun, args_maker)
+    # TODO complete + test against NumPy backend + reference implementation:
+    self._CompileAndCheck(partial(op, dimension_numbers=dnums), args_maker)
 
   # These tests are adapted from the corresponding tests in
   # tensorflow/compiler/xla/service/shape_inference_test.cc with slight
@@ -2019,56 +1467,47 @@ class LaxTest(jtu.JaxTestCase):
                                                  rhs_spec=(0, 1, 2),
                                                  out_spec=(0, 1, 2))
     kwargs = { 'window_strides': (1,)
-             , 'padding': ((0, 0),)
-             , 'lhs_dilation': (1,)
-             , 'rhs_dilation': (1,)
-             , 'dimension_numbers': dimension_numbers
-             , 'feature_group_count': 1
-             , 'batch_group_count': 1
-             , 'precision': None
-             }
+      , 'padding': ((0, 0),)
+      , 'lhs_dilation': (1,)
+      , 'rhs_dilation': (1,)
+      , 'dimension_numbers': dimension_numbers
+      , 'feature_group_count': 1
+      , 'batch_group_count': 1
+      , 'precision': None
+               }
     lhs, rhs = np.ones((1, 1, 1)), np.ones((1, 1, 1, 1))
     with self.assertRaisesRegex(ValueError, msg):
       lax.conv_general_dilated(lhs, rhs, **kwargs)
 
-
-class LazyConstantTest(jtu.JaxTestCase):
-  def _Check(self, make_const, expected):
-    # check casting to ndarray works
-    asarray_result = np.asarray(make_const())
-
-    # check passing as an argument works (should hit constant handler)
-    zero = np.array(0, expected.dtype)
-    argument_result = lax.add(zero, make_const())
-
-    # check looping into a compiled computation works
-    jit_result = api.jit(lambda x: lax.add(x, make_const()))(zero)
-
-    # ensure they're all the same
-    self.assertAllClose(asarray_result, expected)
-    self.assertAllClose(argument_result, expected)
-    self.assertAllClose(jit_result, expected)
-
-    # ensure repr doesn't crash
-    repr(make_const())
+  def _CheckConstantOp(self, lax_op, **params):
+    self._Check(lax_op, lambda: [], **params)
+    ans = lax_op(**params)
+    # check casting to ndarray:
+    self.assertAllClose(ans, np.asarray(ans))
+    # check passing as an argument (should hit constant handler):
+    zero = np.array(0, ans.dtype)
+    op = lambda x: lax.add(x, lax_op(**params))
+    self.assertAllClose(ans, op(zero))
+    # check looping into a compiled computation:
+    self.assertAllClose(ans, api.jit(op)(zero))
+    # ensure repr doesn't crash:
+    repr(ans)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_fill={}".format(
-          jtu.format_shape_dtype_string(shape, dtype) if dtype else shape,
-          fill_value),
+    {"testcase_name":
+       f"_{jtu.format_shape_dtype_string(shape, dtype) if dtype else shape}"
+       f"_fill={fill_value}",
        "shape": shape, "dtype": dtype, "fill_value": fill_value}
       for dtype in itertools.chain(default_dtypes, [None])
       for shape in [(), (3,), (2, 3), (2, 3, 4), (1001, 1001)]
       for fill_value in [0, 1, np.pi]))
-  def testFilledConstant(self, shape, fill_value, dtype):
-    make_const = lambda: lax.full(shape, fill_value, dtype)
-    expected = np.full(shape, fill_value,
-                        dtype or dtypes.result_type(fill_value))
-    self._Check(make_const, expected)
+  def testFull(self, shape, fill_value, dtype):
+    self._CheckConstantOp(lax.full,
+                          shape=shape, fill_value=fill_value, dtype=dtype)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_dim={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), dimension),
+      {"testcase_name":
+         f"_{jtu.format_shape_dtype_string(shape, dtype)}_dim={dimension}",
        "shape": shape, "dtype": dtype, "dimension": dimension}
       for dtype in default_dtypes
       for shape in [(), (3,), (2, 3), (2, 3, 4),
@@ -2076,19 +1515,13 @@ class LazyConstantTest(jtu.JaxTestCase):
                     # (1001, 1001), (101, 101, 101),
                     ]
       for dimension in range(len(shape))))
-  def testIotaConstant(self, dtype, shape, dimension):
-    make_const = lambda: lax.broadcasted_iota(dtype, shape, dimension)
-
-    arr = np.arange(shape[dimension], dtype=dtypes.canonicalize_dtype(dtype))
-    singleton_shape = [1] * len(shape)
-    singleton_shape[dimension] = shape[dimension]
-    expected = np.broadcast_to(arr.reshape(singleton_shape), shape)
-
-    self._Check(make_const, expected)
+  def testIota(self, shape, dtype, dimension):
+    self._CheckConstantOp(lax.broadcasted_iota,
+                          dtype=dtype, shape=shape, dimension=dimension)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axes),
+      {"testcase_name":
+         f"_{jtu.format_shape_dtype_string(shape, dtype)}_axes={axes}",
        "shape": shape, "dtype": dtype, "axes": axes}
       for dtype in default_dtypes
       for shape, axes in [
@@ -2102,19 +1535,8 @@ class LazyConstantTest(jtu.JaxTestCase):
           [(1001, 1001), (0, 1)],
       ]))
   @jtu.skip_on_devices("tpu")  # TODO(mattjj): investigate failure
-  def testDeltaConstant(self, dtype, shape, axes):
-    make_const = lambda: lax._delta(dtype, shape, axes)
-    # don't check the asarray case, just assume it's right
-    expected = np.asarray(make_const())
-    self._Check(make_const, expected)
-
-  def testBroadcastInDim(self):
-    arr = lax.full((2, 1), 1.) + 1.
-    arr_np = np.full((2, 1), 1.) + 1.
-    expected = lax_reference.broadcast_in_dim(arr_np, (2, 1, 3), (0, 2))
-    make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
-    self._Check(make_const, expected)
-
+  def testDelta(self, shape, dtype, axes):
+    self._CheckConstantOp(lax._delta, dtype=dtype, shape=shape, axes=axes)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -81,18 +81,17 @@ class LaxVmapTest(jtu.JaxTestCase):
   @parameterized.named_parameters(itertools.chain.from_iterable(
       jtu.cases_from_list(
         {"testcase_name": "{}_bdims={}".format(
-            jtu.format_test_name_suffix(rec.op, shapes,
+            jtu.format_test_name_suffix(rec.op.__name__, shapes,
                                         itertools.repeat(dtype)), bdims),
-         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
+         "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
          "dtype": dtype, "bdims": bdims, "tol": rec.tol}
         for shape_group in compatible_shapes
         for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
         for bdims in all_bdims(*shapes)
         for dtype in rec.dtypes)
       for rec in LAX_OPS))
-  def testOp(self, op_name, rng_factory, shapes, dtype, bdims, tol):
+  def testOp(self, op, rng_factory, shapes, dtype, bdims, tol):
     rng = rng_factory(self.rng())
-    op = getattr(lax, op_name)
     self._CheckBatching(op, 10, bdims, shapes, [dtype] * len(shapes), rng,
                         atol=tol, rtol=tol)
 

--- a/tests/numpy_eval_test.py
+++ b/tests/numpy_eval_test.py
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+
+from jax import (config, jit, test_util as jtu, numpy as jnp, lax, device_put,
+                 random, ad_util, tree_flatten)
+from jax.interpreters.numpy_eval import numpy_eval
+from jax.interpreters.xla import DeviceArray
+from tests.lax_test import all_dtypes
+
+config.parse_flags_with_absl()
+
+
+class NumpyEvalTest(jtu.JaxTestCase):
+  def check(self, lax_fun, *args, allow_device_array_output=False):
+    if not config.omnistaging_enabled: return
+    expected_flat, expected_tree = tree_flatten(lax_fun(*args))
+    with numpy_eval():
+      actual_flat, actual_tree = tree_flatten(lax_fun(*args))
+    assert expected_tree == actual_tree
+    for expected, actual in zip(expected_flat, actual_flat):
+      is_np = (type(actual) in {np.ndarray, np.int64}.union(all_dtypes).union(
+                 {DeviceArray} if allow_device_array_output else {}) or
+               type(actual).__name__ == 'int64')  # needed for NumPy 1.16.4
+      assert is_np, f"{type(actual).__name__} not a valid NumPy type."
+    self.assertAllClose(expected, actual)
+
+  def test_jit(self):
+    self.check(jit(lax.square), np.array(1))
+
+  def test_jit_of_numpy_eval(self):
+    if not config.omnistaging_enabled: return
+
+    @jit
+    @numpy_eval()
+    def f(v):
+      return jnp.full((), v)
+
+    a = f(1)
+    self.assertAllClose(np.full((), 1), a)
+
+  def test_lax_ops_on_device_arrays(self):
+    self.check(lambda: jnp.array(1))
+    self.check(lambda: jnp.full((), 1))
+    self.check(lambda: jnp.zeros(()))
+    self.check(lambda: jnp.ones(()))
+    self.check(lax.transpose, jnp.array([[1, 2]]), (1, 0))
+    self.check(lax.reshape, jnp.array([[1, 2]]), (2, 1, 1))
+    self.check(lax.slice, jnp.array([1, 2]), (0,), (1,))
+    self.check(lax.dynamic_slice, jnp.array([1, 2]), (0,), (1,))
+    self.check(lax.dynamic_update_slice, jnp.array([1, 2]), jnp.array([0]), [0])
+    self.check(lax.gather, jnp.arange(5,), jnp.array([[0], [2]]),
+               lax.GatherDimensionNumbers((1,), (), (0,)), (3,))
+    self.check(lax.sort, jnp.array([2, 3, 1]))
+    self.check(lax.reduce, jnp.array([2, 3, 1]), jnp.array(0), lax.add, (0,))
+    self.check(lax.broadcast_in_dim, jnp.array([1, 2]), (2, 2), (0,))
+    self.check(lax.conv_general_dilated, jnp.array([[1.]]), jnp.array([[1.]]),
+               (), 'VALID')
+
+  def test_random_ops(self):
+    self.check(random.PRNGKey, jnp.array(0))
+    self.check(random.threefry_2x32, random.PRNGKey(0), lax.iota(np.uint32, 4))
+    self.check(random.fold_in, random.PRNGKey(0), 0)
+    self.check(random.split, random.PRNGKey(0))
+    self.check(random.split, random.PRNGKey(0), 3)
+
+  def test_ad_ops(self):
+    self.check(ad_util.zeros_like_jaxval, jnp.array(0))
+    self.check(lax.stop_gradient, {'a': [jnp.array(0)], 'b': jnp.array(1)},
+               allow_device_array_output=True)
+
+  def test_xla_ops(self):
+    self.check(device_put, jnp.array(1), allow_device_array_output=True)


### PR DESCRIPTION
Allows evaluating JAX code with NumPy instead of XLA.

```python
@numpy_eval()
def some_fun(...):
    # jax code
```

Inline:

```python
with numpy_eval():
    # jax code
```

For now requires import `from jax.interpreters.numpy_eval import numpy_eval` ("internal API").

`numpy_eval()(jit(some_fun))` ignores `jit`. Decorate your main function with `@numpy_eval()` to evaluate all code in NumPy. `jit(numpy_eval()(some_fun))` collapses constants with NumPy, so that no device dispatch happens during compilation. 

Support for non-experimental `lax.py` and `random.py` primitives is complete except for `*scatter*_p` and `igamma_grad_a_p`.

### Use cases

`numpy_eval` shines when device dispatch dominates over the actual calculation in XLA.
- Applying `@numpy_eval()` resulted in a ~3x speedup over XLA on CPU when sampling from PixelCNN with https://github.com/j-towns/fastar, with a further tweak (https://github.com/j-towns/fastar/pull/23) ~5x.
- Lightweight + traceable/`vmap`-ready shape rules for https://github.com/google/jax/issues/3893 is another potential use case.

`numpy_eval` is also useful for testing, avoiding converted copies of `lax` functions for NumPy: This PR shortens `lax_reference.py` to ~100 lines. It would be ~300 without `numpy_eval()(lax.<some_fun>)`.

### Collateral improvements

Complete the `lax_reference.py` implementation:
- Add `gather`, `threefry2x32`, `shift_left`, `shift_right_arithmetic`, `shift_right_logical`, `full`, more
- Complete `reduce`: Support all datatypes, optimize non-monoidal/custom reductions, remove dependency on `computation` parameter, use `jaxpr`/`consts` instead (https://github.com/google/jax/issues/4109)
- Complete `reduce_window`: Support all datatypes, `window_dilation`, non-monoidal/custom reductions from `jaxpr`
- Complete `sort`: Support multiple operands, `is_stable` and `num_keys`
- Complete `conv_general_dilated`: Support batch and feature groups, fix bugs
- Fix `pad`, `sort_key_val`, various other

Add `lax` tests against all above-mentioned added/completed `lax_reference` functions. Further complete test coverage of `lax` against its jit-compiled version (as well as its NumPy-interpreted version and lax reference implementation) for:
- `shift_left`, `shift_right_arithmetic`, `shift_right_logical`
- `gather`: 0D/2D index batches, unusual `offset_dims`
- `reduce`: Unsigned and complex datatypes
- `reduce_window`: Most datatypes, non-monoidal/custom reductions
- `sort`: Unsigned datatypes, non-default `axis`, `is_stable=False` on multiple operands
- `sort_key_val`: Most datatypes for `values`, non-default `axis`, stability of `is_stable=True`
- `nextafter`: `np.float64` on `JAX_ENABLE_X64=False`

Deduplicate `lax_test.py`, shorten it by ~600 lines (even with new tests added):
- Merge `test<Op>AgainstNumpy` into `test<Op>`, standardize testing via `_Check`
- Merge duplicate tests for groups of similar operations: `scatter*`, `convert_element_type`/`bitcast_convert_type`
- Merge `testSortNumKeys` into `testSort`