### PR TITLE
allow mask to return output logical shape

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -69,11 +69,11 @@ def extend_shape_envs(logical_env, padded_env):
 
 def shape_as_value(shape):
   assert is_tracing() or not is_polymorphic(shape)
-  return eval_polymorphic_shape(shape, shape_envs.logical)
+  return eval_poly_shape(shape, shape_envs.logical)
 
 def padded_shape_as_value(shape):
   assert is_tracing() or not is_polymorphic(shape)
-  return eval_polymorphic_shape(shape, shape_envs.padded)
+  return eval_poly_shape(shape, shape_envs.padded)
 
 def mask_fun(fun, logical_env, padded_env, in_vals, polymorphic_shapes):
   env_keys, padded_env_vals = unzip2(sorted(padded_env.items()))
@@ -101,7 +101,7 @@ def mask_subtrace(master, shapes, padded_env, *in_vals):
   out_vals, out_shapes = unzip2((t.val, t.polymorphic_shape) for t in out_tracers)
   yield out_vals, out_shapes
 
-def eval_polymorphic_shape(shape, values_dict):
+def eval_poly_shape(shape, values_dict):
   return tuple(eval_poly(dim, values_dict) for dim in shape)
 
 def eval_poly(poly, values_dict):

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -32,7 +32,7 @@ from jax.scipy.special import expit
 from jax import mask, vmap, jit, grad, shapecheck, make_jaxpr
 from jax.interpreters.masking import (
     shape_as_value, ShapeError, parse_spec, Poly, Mon, finalize_spec,
-    eval_polymorphic_shape, remap_ids, UniqueIds)
+    eval_poly_shape, remap_ids, UniqueIds)
 
 config.parse_flags_with_absl()
 
@@ -153,14 +153,14 @@ class MaskingTest(jtu.JaxTestCase):
     out_specs, _ = tree_flatten(out_shape)
     out_specs = map(parse_spec, out_specs)
     out_specs = map(finalize_spec, out_specs, map(np.shape, padded_outs))
-    logical_out_shapes = [eval_polymorphic_shape(s, logical_env)
+    logical_out_shapes = [eval_poly_shape(s, logical_env)
                           for s in out_specs]
     logical_out_slices = [tuple(map(slice, s)) for s in logical_out_shapes]
     logical_outs = [o[s] for o, s in zip(padded_outs, logical_out_slices)]
 
     in_specs = map(parse_spec, in_shapes)
     in_specs = map(finalize_spec, in_specs, padded_in_shapes)
-    logical_in_shapes = [eval_polymorphic_shape(s, logical_env)
+    logical_in_shapes = [eval_poly_shape(s, logical_env)
                          for s in in_specs]
     logical_in_slices = [tuple(map(slice, s)) for s in logical_in_shapes]
     logical_args = [a[s] for a, s in zip(padded_args, logical_in_slices)]
@@ -173,7 +173,6 @@ class MaskingTest(jtu.JaxTestCase):
     padded_outs_jit, _ = tree_flatten(jit(masked_fun)(padded_args, logical_env))
     self.assertAllClose(padded_outs_jit, padded_outs, check_dtypes=True,
                         atol=atol, rtol=rtol)
-
 
   def test_add(self):
     self.check(lax.add, ['n', ''], 'n', {'n': 3}, [(4,), ()], ['float_', 'float_'],
@@ -732,6 +731,18 @@ class MaskingTest(jtu.JaxTestCase):
     jaxpr = make_jaxpr(foo)([padded_x], dict(n=3))
     self.assertNotIn('mul', str(jaxpr))
     self.assertNotIn('add', str(jaxpr))
+
+  def test_return_shape_to_user(self):
+    @partial(mask, in_shapes=['n'])
+    def foo(x):
+      return [x, np.sum(x)]
+
+    out, out_shape = foo([np.arange(5)], dict(n=2))
+    self.assertIsInstance(out_shape, list)
+    self.assertLen(out_shape, 2)
+    a, b = out_shape
+    self.assertEqual(a.shape, (2,))
+    self.assertEqual(b.shape, ())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the `mask` argument `out_shape` is not provided, or when it has value `None`, return the output logical shape to the user.