### PR TITLE
Improve type annotations for `jit` and `vmap`.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -945,11 +945,12 @@ def _mapped_axis_size(tree, vals, dims, name):
       sizes = tree_unflatten(tree, sizes)
       raise ValueError(msg.format("the tree of axis sizes is:\n{}".format(sizes))) from None
 
-def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
+def pmap(fun: Callable[..., T],
+         axis_name: Optional[AxisName] = None, *, in_axes=0,
          static_broadcasted_argnums: Union[int, Iterable[int]] = (),
          devices=None, backend: Optional[str] = None,
          axis_size: Optional[int] = None,
-         donate_argnums: Union[int, Iterable[int]] = ()) -> Callable:
+         donate_argnums: Union[int, Iterable[int]] = ()) -> Callable[..., T]:
   """Parallel map with support for collectives.
 
   The purpose of :py:func:`pmap` is to express single-program multiple-data (SPMD)

--- a/jax/api.py
+++ b/jax/api.py
@@ -895,7 +895,7 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0) -> Callable[..., T]:
     msg = "vmap in_axes leaves must be non-negative integers or None, but got {}."
     raise TypeError(msg.format(in_axes))
   if any(l < 0 for l in out_axes_ if l is not batching.last):
-    msg = "vmap in_axes leaves must be non-negative integers or None, but got {}."
+    msg = "vmap out_axes leaves must be non-negative integers or None, but got {}."
     raise TypeError(msg.format(out_axes))
   del in_axes_, out_axes_
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -29,7 +29,7 @@ import functools
 import inspect
 import itertools as it
 import threading
-from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, TypeVar, Union
 from warnings import warn
 
 import numpy as np
@@ -67,6 +67,7 @@ from .custom_derivatives import custom_jvp, custom_vjp
 from .config import flags, config, bool_env
 
 AxisName = Any
+T = TypeVar("T")
 
 map = safe_map
 zip = safe_zip
@@ -89,9 +90,11 @@ class _ThreadLocalState(threading.local):
 
 _thread_local_state = _ThreadLocalState()
 
-def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
-        device=None, backend: Optional[str] = None,
-        donate_argnums: Union[int, Iterable[int]] = ()) -> Callable:
+def jit(fun: Callable[..., T],
+        static_argnums: Union[int, Iterable[int]] = (),
+        device=None,
+        backend: Optional[str] = None,
+        donate_argnums: Union[int, Iterable[int]] = ()) -> Callable[..., T]:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:
@@ -753,7 +756,7 @@ def _dtype(x):
   return dtypes.canonicalize_dtype(dtypes.result_type(x))
 
 
-def vmap(fun: Callable, in_axes=0, out_axes=0) -> Callable:
+def vmap(fun: Callable[..., T], in_axes=0, out_axes=0) -> Callable[..., T]:
   """Vectorizing map. Creates a function which maps ``fun`` over argument axes.
 
   Args:

--- a/jax/api.py
+++ b/jax/api.py
@@ -67,6 +67,16 @@ from .custom_derivatives import custom_jvp, custom_vjp
 from .config import flags, config, bool_env
 
 AxisName = Any
+
+# This TypeVar is used below to express the fact that function call signatures
+# are invariant under the jit, vmap, and pmap transformations.
+# Specifically, we statically assert that the return type is invariant.
+# Until PEP-612 is implemented, we cannot express the same invariance for
+# function arguments.
+# Note that the return type annotations will generally not strictly hold
+# in JIT internals, as Tracer values are passed through the function.
+# Should this raise any type errors for the tracing code in future, we can disable
+# type checking in parts of the tracing code, or remove these annotations.
 T = TypeVar("T")
 
 map = safe_map

--- a/jax/random.py
+++ b/jax/random.py
@@ -264,7 +264,7 @@ def split(key: jnp.ndarray, num: int = 2) -> jnp.ndarray:
   Returns:
     An array with shape (num, 2) and dtype uint32 representing `num` new keys.
   """
-  return _split(key, int(num))
+  return _split(key, int(num))  # type: ignore
 
 @partial(jit, static_argnums=(1,))
 def _split(key, num) -> jnp.ndarray:
@@ -364,7 +364,7 @@ def uniform(key: jnp.ndarray,
                      f"got {dtype}")
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = abstract_arrays.canonicalize_shape(shape)
-  return _uniform(key, shape, dtype, minval, maxval)
+  return _uniform(key, shape, dtype, minval, maxval)  # type: ignore
 
 @partial(jit, static_argnums=(1, 2))
 def _uniform(key, shape, dtype, minval, maxval) -> jnp.ndarray:
@@ -473,7 +473,7 @@ def shuffle(key: jnp.ndarray, x: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
   msg = ("jax.random.shuffle is deprecated and will be removed in a future release. "
          "Use jax.random.permutation")
   warnings.warn(msg, FutureWarning)
-  return _shuffle(key, x, axis)
+  return _shuffle(key, x, axis)  # type: ignore
 
 
 def permutation(key, x):
@@ -606,7 +606,7 @@ def normal(key: jnp.ndarray,
                      f"got {dtype}")
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = abstract_arrays.canonicalize_shape(shape)
-  return _normal(key, shape, dtype)
+  return _normal(key, shape, dtype)  # type: ignore
 
 @partial(jit, static_argnums=(1, 2))
 def _normal(key, shape, dtype) -> jnp.ndarray:
@@ -648,7 +648,7 @@ def multivariate_normal(key: jnp.ndarray,
   dtype = dtypes.canonicalize_dtype(dtype)
   if shape is not None:
     shape = abstract_arrays.canonicalize_shape(shape)
-  return _multivariate_normal(key, mean, cov, shape, dtype)
+  return _multivariate_normal(key, mean, cov, shape, dtype)  # type: ignore
 
 @partial(jit, static_argnums=(3, 4))
 def _multivariate_normal(key, mean, cov, shape, dtype) -> jnp.ndarray:
@@ -704,7 +704,7 @@ def truncated_normal(key: jnp.ndarray,
   dtype = dtypes.canonicalize_dtype(dtype)
   if shape is not None:
     shape = abstract_arrays.canonicalize_shape(shape)
-  return _truncated_normal(key, lower, upper, shape, dtype)
+  return _truncated_normal(key, lower, upper, shape, dtype)  # type: ignore
 
 @partial(jit, static_argnums=(3, 4))
 def _truncated_normal(key, lower, upper, shape, dtype) -> jnp.ndarray:
@@ -746,7 +746,7 @@ def bernoulli(key: jnp.ndarray,
     msg = "bernoulli probability `p` must have a floating dtype, got {}."
     raise TypeError(msg.format(dtype))
   p = lax.convert_element_type(p, dtype)
-  return _bernoulli(key, p, shape)
+  return _bernoulli(key, p, shape)  # type: ignore
 
 @partial(jit, static_argnums=(2,))
 def _bernoulli(key, p, shape) -> jnp.ndarray:

--- a/jax/random.py
+++ b/jax/random.py
@@ -267,7 +267,7 @@ def split(key: jnp.ndarray, num: int = 2) -> jnp.ndarray:
   return _split(key, int(num))
 
 @partial(jit, static_argnums=(1,))
-def _split(key, num):
+def _split(key, num) -> jnp.ndarray:
   counts = lax.iota(np.uint32, num * 2)
   return lax.reshape(threefry_2x32(key, counts), (num, 2))
 
@@ -367,7 +367,7 @@ def uniform(key: jnp.ndarray,
   return _uniform(key, shape, dtype, minval, maxval)
 
 @partial(jit, static_argnums=(1, 2))
-def _uniform(key, shape, dtype, minval, maxval):
+def _uniform(key, shape, dtype, minval, maxval) -> jnp.ndarray:
   _check_shape("uniform", shape)
   if not jnp.issubdtype(dtype, np.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
@@ -504,7 +504,7 @@ def permutation(key, x):
 
 
 @partial(jit, static_argnums=(2,))
-def _shuffle(key, x, axis):
+def _shuffle(key, x, axis) -> jnp.ndarray:
   # On parallel architectures, Fisher-Yates is more expensive than doing
   # multiple sorts. This algorithm is based on one developed and analyzed by
   # tjablin@. We sort according to randomly-generated 32bit keys, but those keys
@@ -609,7 +609,7 @@ def normal(key: jnp.ndarray,
   return _normal(key, shape, dtype)
 
 @partial(jit, static_argnums=(1, 2))
-def _normal(key, shape, dtype):
+def _normal(key, shape, dtype) -> jnp.ndarray:
   _check_shape("normal", shape)
   lo = np.nextafter(np.array(-1., dtype), 0., dtype=dtype)
   hi = np.array(1., dtype)
@@ -651,7 +651,7 @@ def multivariate_normal(key: jnp.ndarray,
   return _multivariate_normal(key, mean, cov, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
-def _multivariate_normal(key, mean, cov, shape, dtype):
+def _multivariate_normal(key, mean, cov, shape, dtype) -> jnp.ndarray:
   if not np.ndim(mean) >= 1:
     msg = "multivariate_normal requires mean.ndim >= 1, got mean.ndim == {}"
     raise ValueError(msg.format(np.ndim(mean)))
@@ -707,7 +707,7 @@ def truncated_normal(key: jnp.ndarray,
   return _truncated_normal(key, lower, upper, shape, dtype)
 
 @partial(jit, static_argnums=(3, 4))
-def _truncated_normal(key, lower, upper, shape, dtype):
+def _truncated_normal(key, lower, upper, shape, dtype) -> jnp.ndarray:
   if shape is None:
     shape = lax.broadcast_shapes(np.shape(lower), np.shape(upper))
   else:
@@ -749,7 +749,7 @@ def bernoulli(key: jnp.ndarray,
   return _bernoulli(key, p, shape)
 
 @partial(jit, static_argnums=(2,))
-def _bernoulli(key, p, shape):
+def _bernoulli(key, p, shape) -> jnp.ndarray:
   if shape is None:
     shape = np.shape(p)
   else:


### PR DESCRIPTION
This change expresses the fact that function return type signatures are invariant under `jit` and `vmap` transformations.

Note that we can't (yet) express the fact that the argument signature is invariant since Python's type system doesn't have a way to express generic and variadic function types (although this will hopefully soon be supported; see PEP-612).