### PR TITLE
Remove DeviceValue.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1379,7 +1379,7 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
   return broadcast(fill_value, shape)
 
 def _device_put_raw(x):
-  if isinstance(x, xla.DeviceValue):
+  if isinstance(x, xla.DeviceArray):
     return x
   else:
     aval = raise_to_shaped(core.get_aval(x))

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -42,7 +42,7 @@ from .. import core
 from .. import dtypes
 from ..abstract_arrays import UnshapedArray, ShapedArray, ConcreteArray, canonicalize_shape
 from ..config import flags, config
-from ..interpreters.xla import DeviceArray, DeviceValue
+from ..interpreters.xla import DeviceArray
 from ..interpreters.masking import Poly
 from .. import lax
 from ..lax.lax import _device_put_raw
@@ -2246,7 +2246,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   if type(object) is np.ndarray:
     out = _device_put_raw(object)
     if dtype: assert _dtype(out) == dtype
-  elif isinstance(object, (DeviceValue, core.Tracer)):
+  elif isinstance(object, (DeviceArray, core.Tracer)):
     if isinstance(object, DeviceArray) and copy:
       # We perform a copy by bouncing back to the host
       # TODO(phawkins): add a device runtime function to copy a buffer
@@ -2276,7 +2276,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   return out
 
 def _can_call_numpy_array(x):
-  return _all(not isinstance(l, (core.Tracer, DeviceValue))
+  return _all(not isinstance(l, (core.Tracer, DeviceArray))
               for l in tree_leaves(x))
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -618,7 +618,7 @@ class APITest(jtu.JaxTestCase):
   def test_devicearray_delete(self):
     x = device_put(1.)
     x.delete()
-    self.assertRaisesRegex(ValueError, "DeviceValue has been deleted.",
+    self.assertRaisesRegex(ValueError, "DeviceArray has been deleted.",
                             lambda: repr(x))
 
   def test_devicearray_block_until_ready(self):


### PR DESCRIPTION
It is currently only extended by DeviceArray, thus there is no need for 2 objects when we can have a single one.

This is updating #3940. I am still testing out the script to export from google3 to github. It seems it delete+recreate the branch, thus it means every change must lead to a new PR. 
I guess I will need to fix the script to not be that disruptive.