### PR TITLE
Add switch and associative_scan to lax docs

### DIFF
--- a/docs/jax.lax.rst
+++ b/docs/jax.lax.rst
@@ -138,10 +138,12 @@ Control flow operators
 .. autosummary::
   :toctree: _autosummary
 
+    associative_scan
     cond
     fori_loop
     map
     scan
+    switch
     while_loop
 
 Custom gradient operators


### PR DESCRIPTION
These functions currently do not appear in the list of functions at https://jax.readthedocs.io/en/latest/jax.lax.html