### PR TITLE
Avoid lexically capturing the train_images value in MNIST VAE example.

### DIFF
--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -24,6 +24,7 @@ import time
 
 import matplotlib.pyplot as plt
 
+import jax
 import jax.numpy as jnp
 from jax import jit, grad, lax, random
 from jax.experimental import optimizers
@@ -99,6 +100,9 @@ if __name__ == "__main__":
   init_params = init_encoder_params, init_decoder_params
 
   opt_init, opt_update, get_params = optimizers.momentum(step_size, mass=0.9)
+
+  train_images = jax.device_put(train_images)
+  test_images = jax.device_put(test_images)
 
   def binarize_batch(rng, i, images):
     i = i % num_batches

--- a/examples/mnist_vae.py
+++ b/examples/mnist_vae.py
@@ -106,10 +106,10 @@ if __name__ == "__main__":
     return random.bernoulli(rng, batch)
 
   @jit
-  def run_epoch(rng, opt_state):
+  def run_epoch(rng, opt_state, images):
     def body_fun(i, opt_state):
       elbo_rng, data_rng = random.split(random.fold_in(rng, i))
-      batch = binarize_batch(data_rng, i, train_images)
+      batch = binarize_batch(data_rng, i, images)
       loss = lambda params: -elbo(elbo_rng, params, batch) / batch_size
       g = grad(loss)(get_params(opt_state))
       return opt_update(i, g, opt_state)
@@ -127,7 +127,7 @@ if __name__ == "__main__":
   opt_state = opt_init(init_params)
   for epoch in range(num_epochs):
     tic = time.time()
-    opt_state = run_epoch(random.PRNGKey(epoch), opt_state)
+    opt_state = run_epoch(random.PRNGKey(epoch), opt_state, train_images)
     test_elbo, sampled_images = evaluate(opt_state, test_images)
     print("{: 3d} {} ({:.3f} sec)".format(epoch, test_elbo, time.time() - tic))
     plt.imsave(imfile.format(epoch), sampled_images, cmap=plt.cm.gray)


### PR DESCRIPTION
This has the effect of baking in the training dataset as a constant, something that LLVM does not like that much.

May help with #3891 