### PR TITLE
Revert "Avoid re-flattening in jit() when no donate_argnums are prese…

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -164,10 +164,7 @@ def jit(fun: Callable, static_argnums: Union[int, Iterable[int]] = (),
     else:
       dyn_args = args
     args_flat, in_tree = tree_flatten((dyn_args, kwargs))
-    if donate_argnums:
-      donated_invars = donation_vector(donate_argnums, dyn_args, kwargs)
-    else:
-      donated_invars = (False,) * len(args_flat)
+    donated_invars = donation_vector(donate_argnums, dyn_args, kwargs)
     for arg in args_flat: _check_arg(arg)
     flat_fun, out_tree = flatten_fun(f, in_tree)
     out = xla.xla_call(flat_fun, *args_flat, device=device, backend=backend,
@@ -1183,10 +1180,7 @@ def pmap(fun: Callable, axis_name: Optional[AxisName] = None, *, in_axes=0,
     else:
       dyn_args, dyn_in_axes = args, in_axes
     args, in_tree = tree_flatten((dyn_args, kwargs))
-    if donate_argnums:
-      donated_invars = donation_vector(donate_tuple, dyn_args, kwargs)
-    else:
-      donated_invars = (False,) * len(args)
+    donated_invars = donation_vector(donate_tuple, dyn_args, kwargs)
     in_axes_flat = flatten_axes("pmap in_axes", in_tree, (dyn_in_axes, 0))
     local_axis_size = _mapped_axis_size(in_tree, args, in_axes_flat, "pmap")
     for arg in args: _check_arg(arg)


### PR DESCRIPTION
…nt. (#3945)"

This reverts commit 4e873f417ab4f3e68a102548167f2b0a005edfad.

See comments in #3945 about the failure.