### PR TITLE
Implement the invertible decorator in terms of custom_vjp

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -2024,7 +2024,7 @@ def custom_gradient(fun):
 def _ensure_tuple(x: Union[int, Iterable[int]]) -> Tuple[int, ...]:
   return (x,) if isinstance(x, int) else tuple(x)
 
-def invertible(fun: Callable, concrete: bool = False) -> Callable:
+def invertible(fun: Callable) -> Callable:
   """Asserts that the decorated function is invertible.
 
   Applying reverse-mode AD to a decorated function will use a more memory efficient
@@ -2034,13 +2034,5 @@ def invertible(fun: Callable, concrete: bool = False) -> Callable:
 
   Args:
     fun: The function assumed to be invertible.
-    concrete: See the documentation of checkpoint.
   """
-  @wraps(fun)
-  def fun_invertible(*args, **kwargs):
-    args_flat, in_tree = tree_flatten((args, kwargs))
-    flat_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
-    out_flat = iad.invertible_call(flat_fun, *args_flat, name=flat_fun.__name__,
-                                   concrete=concrete)
-    return tree_unflatten(out_tree(), out_flat)
-  return fun_invertible
+  return iad.invertible(fun)

--- a/jax/interpreters/invertible_ad.py
+++ b/jax/interpreters/invertible_ad.py
@@ -21,12 +21,10 @@ from jax import core
 from jax import linear_util as lu
 from . import ad
 from . import partial_eval as pe
-from .partial_eval import PartialVal, new_eqn_recipe, _partition_knowns
 from ..core import raise_to_shaped, get_aval, Literal, Jaxpr
 from ..api_util import flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten, register_pytree_node
-from ..util import safe_map, safe_zip, unzip2, split_list, cache
-from .. import source_info_util
+from ..util import safe_map, safe_zip, unzip2, split_list
 from .. import custom_derivatives
 from ..config import config
 
@@ -217,10 +215,10 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
       if config.omnistaging_enabled:
         # TODO: Actually we do know some of the inputs, because they might be literals!
         ivjp_jaxpr, out_pvals, _ = pe.trace_to_jaxpr(
-            complete_ivjp_flat, map(PartialVal.unknown, in_avals), instantiate=True)
+            complete_ivjp_flat, map(pe.PartialVal.unknown, in_avals), instantiate=True)
       else:
         ivjp_jaxpr, out_pvals, _ = pe.trace_to_jaxpr(
-          complete_ivjp_flat, map(PartialVal.unknown, in_avals),
+          complete_ivjp_flat, map(pe.PartialVal.unknown, in_avals),
           instantiate=True, stage_out=False)
       assert not ivjp_jaxpr.constvars  # That might happen some time, but don't bother until then
       out_avals = map(raise_to_shaped, unzip2(out_pvals)[0])

--- a/jax/interpreters/invertible_ad.py
+++ b/jax/interpreters/invertible_ad.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from functools import partial
 from typing import Dict, Any, Callable
 
@@ -23,7 +24,7 @@ from . import partial_eval as pe
 from .partial_eval import PartialVal, new_eqn_recipe, _partition_knowns
 from ..core import raise_to_shaped, get_aval, Literal, Jaxpr
 from ..api_util import flatten_fun_nokwargs
-from ..tree_util import tree_flatten, tree_unflatten
+from ..tree_util import tree_flatten, tree_unflatten, register_pytree_node
 from ..util import safe_map, safe_zip, unzip2, split_list, cache
 from .. import source_info_util
 from .. import custom_derivatives
@@ -36,68 +37,45 @@ zip = safe_zip
 # Reverse call primitive
 ################################################################################
 
-invertible_call_p = core.CallPrimitive('invertible_call')
-invertible_call = invertible_call_p.bind
-invertible_call_p.def_impl(core.call_impl)
+class DontFlatten:
+  def __init__(self, val):
+    self.val = val
 
-def _invertible_call_make_output_tracers(trace, in_tracers, out_tracers, params):
-  uks = [not t.pval.is_known() for t in out_tracers]
-  out_tracers_known, out_tracers_unknown = _partition_knowns(out_tracers, uks)
+register_pytree_node(DontFlatten,
+                     lambda x: ((), x.val),
+                     lambda val, _: DontFlatten(val))
 
-  # Add dummy arguments representing the outputs to the jaxpr. Those should
-  # remain unused if the expression is evaluated, but they make it well-formed.
-  out_known_avals = [raise_to_shaped(t.pval.get_aval()) for t in out_tracers_known]
-  out_consts = [trace.instantiate_const(t) for t in out_tracers_known]
-  new_jaxpr = _append_invars(params['call_jaxpr'], tuple(out_known_avals))
-  new_in_tracers = (*in_tracers, *out_consts)
+def get_concrete_array(aval):
+  assert isinstance(aval, core.ConcreteArray), aval
+  return aval.val
 
-  # Append dummy outputs that correspond to known outputs left in the call_jaxpr
-  dummy_outputs = [trace.new_const(t.pval.get_known()) for t in out_tracers_known]
-  new_out_tracers = (*dummy_outputs, *out_tracers_unknown)
+def invertible(fun):
+  # TODO: Avoid materializing zeros!
+  ifun = custom_derivatives.custom_vjp(fun)
 
-  eqn = new_eqn_recipe(new_in_tracers, new_out_tracers, invertible_call_p,
-                       dict(params, call_jaxpr=new_jaxpr),
-                       source_info_util.current())
-  for t in out_tracers_unknown: t.recipe = eqn
-  return new_out_tracers
+  def fwd(*args):
+    flat_args, in_tree = tree_flatten(args)
+    in_pvals = tuple(pe.PartialVal.unknown(raise_to_shaped(get_aval(arg))) for arg in flat_args)
+    fun_flat, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
+    jaxpr, out_pvals, consts = pe.trace_to_jaxpr(fun_flat, in_pvals)
+    # TODO: Don't warn if consts contain JVP tracers?
+    if consts:
+      warnings.warn("Values that an @invertible function closes over will not have their " +
+                    "gradients computed correctly (their uses inside this function will be ignored)!")
+    # TODO: This requires the body to be jittable, but this shouldn't be necessary.
+    #       Is there a way to trace a jaxpr while running it?
+    outs = core.eval_jaxpr(jaxpr, consts, *flat_args)
+    return tree_unflatten(out_tree(), outs), (args, outs, consts, DontFlatten((jaxpr, in_tree)))
 
-pe.call_partial_eval_rules[invertible_call_p] = partial(
-    pe._remat_partial_eval, _invertible_call_make_output_tracers)
+  def bwd(res, cts):
+    args, outs, consts, aux = res
+    jaxpr, in_tree = aux.val
+    flat_cts, _ = tree_flatten(cts)
+    return tree_unflatten(in_tree, inv_backward_pass(jaxpr, consts, args, outs, flat_cts))
 
-@cache()
-def _append_invars(jaxpr, avals):
-  newvar = core.gensym([jaxpr])
-  return core.Jaxpr(jaxpr.constvars, jaxpr.invars + map(newvar, avals),
-                    jaxpr.outvars, jaxpr.eqns)
+  ifun.defvjp(fwd, bwd)
 
-
-def _invertible_call_transpose(params, call_jaxpr, args, ct, _):
-  # TODO: Is the vjp invertible too? In principle yes, because the derivative is
-  #       a linear transform with coefficients derived from the primal, but do we
-  #       want to preserve this annotation?
-
-  # All this code is an awkward attempt to inverse engineer the structure of our
-  # arguments in a way that lets us separate primal arguments and constants from the
-  # primal outputs. We need to do that, because even though the jaxpr has arguments
-  # corresponding to the primal outputs, we need to fill them in in the primal environment
-  # under the names corresponding to the outvars of the jaxpr.
-  # The general idea here is that due to the way linearization works, all tangent
-  # arguments always come after all the primal args. Additionally, _inverse_partial_eval
-  # appends the constants corresponding to primal outputs as trailing arguments.
-  # In the end we expect is_tangent to be of the form:
-  #   [False, ..., False, True, ..., True, False, ..., False]
-  # where the first primal block gives us the constants and regular primal args,
-  # while the second block gives us the saved primal outputs.
-  is_tangent = map(ad.is_undefined_primal, args)
-  first_tangent = is_tangent.index(True)
-  last_tangent = (len(is_tangent) - 1) - is_tangent[::-1].index(True)
-  # Make sure that there are some primals before and after the tangent segment
-  assert first_tangent > 0 and last_tangent < len(is_tangent)
-  # Make sure that the tangents form a contiguous range
-  assert all(is_tangent[first_tangent:last_tangent + 1])
-  outputs = args[last_tangent + 1:]
-  return inv_backward_pass(call_jaxpr, (), args, outputs, ct)
-ad.primitive_transposes[invertible_call_p] = _invertible_call_transpose
+  return ifun
 
 ################################################################################
 # Custom inverse
@@ -114,7 +92,7 @@ class custom_ivjp:
 
   def __call__(self, *args, **kwargs):
     if self.ivjp is None:
-      msg = "No VJP defined for custom_vjp function {}. Did you forget to use defivjp?"
+      msg = "No IVJP defined for custom_vjp function {}. Did you forget to use defivjp?"
       raise AttributeError(msg.format(self.__name__))
     args = custom_derivatives._resolve_kwargs(self.fun, args, kwargs)
     # TODO: Support nondiff_argnums
@@ -176,7 +154,7 @@ ad.primitive_jvps[custom_ivjp_p] = _custom_ivjp_jvp
 
 def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotangents_in):
   if all(type(ct) is ad.Zero for ct in cotangents_in):
-    return zero_vars(jaxpr.invars)
+    return map(lambda v: ad.Zero(v.aval), jaxpr.invars)
 
   def write_cotangent(v, ct):
     # assert v not in primal_env
@@ -197,34 +175,15 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
       return
     primal_env.setdefault(v, val)
 
-  # Structure of arguments is [primal_invars, tangent_invars, unused_primal_outvar_placeholders]
-  primal_invars, tangent_invars = split(jaxpr.invars[:-len(primals_out)], parts=2)
-  primal_outvars, tangent_outvars = split(jaxpr.outvars, parts=2)
-
-  def is_tangent(var):
-    return type(var) is not Literal and var in tangent_vars
-
-  tangent_vars = set(tangent_invars)
-  primal_eqns = []
-  tangent_eqns = []
-  for eqn in jaxpr.eqns:
-    if not eqn.primitive.call_primitive:
-      if any(map(is_tangent, eqn.invars)):
-        tangent_eqns.append(eqn)
-        tangent_vars.update(eqn.outvars)
-      else:
-        primal_eqns.append(eqn)
-    else:
-      assert False
-
-  # Invert while computing the cotangents
+  # Invert while computing cotangents
   ct_env: Dict[Any, Any] = {}
   primal_env: Dict[Any, Any] = {}
   write_primal(core.unitvar, core.unit)
   map(write_primal, jaxpr.invars, primals_in)
-  map(write_primal, jaxpr.outvars[:len(primals_out)], primals_out)
-  map(write_cotangent, primal_outvars, split(cotangents_in, parts=2)[1])
-  for eqn in primal_eqns[::-1]:
+  map(write_primal, jaxpr.outvars, primals_out)
+  map(write_primal, jaxpr.constvars, consts)
+  map(write_cotangent, jaxpr.outvars, cotangents_in)
+  for eqn in jaxpr.eqns[::-1]:
     primals_in = map(read_primal, eqn.invars)
     primals_out = map(read_primal, eqn.outvars)
     cts_in = map(read_cotangent, eqn.outvars)
@@ -256,6 +215,7 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
 
       in_avals = map(abstract, primals_in + primals_out + primals_out)
       if config.omnistaging_enabled:
+        # TODO: Actually we do know some of the inputs, because they might be literals!
         ivjp_jaxpr, out_pvals, _ = pe.trace_to_jaxpr(
             complete_ivjp_flat, map(PartialVal.unknown, in_avals), instantiate=True)
       else:
@@ -284,8 +244,9 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
     # failing to compute cotangents later.
     assert not any(unknown_cotangents)
     # Remove residual outputs -- we won't be computing the unknown jaxpr anyway.
-    jaxpr_known.out_avals = jaxpr_known.out_avals[:num_inputs * 2]
-    jaxpr_known.jaxpr.outvars = jaxpr_known.jaxpr.outvars[:num_inputs * 2]
+    num_outputs = len(jaxpr_unknown.jaxpr.outvars)
+    jaxpr_known.out_avals = jaxpr_known.out_avals[:num_outputs]
+    jaxpr_known.jaxpr.outvars = jaxpr_known.jaxpr.outvars[:num_outputs]
     # TODO: We could drop the outputs that correspond to primals that we already know.
     #       This only matters in eager mode, so leaving it out for now...
     ivjp = core.jaxpr_as_fun(jaxpr_known)
@@ -297,15 +258,12 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
                       for prev, rec, unknown
                       in zip(primals_in, rec_primals_in, unknown_rec_primals_in)]
     map(write_primal, eqn.invars, rec_primals_in)
-    map(write_cotangent, eqn.invars, cts_out)
+    map(write_cotangent, [v for v in eqn.invars if type(v) is not Literal], cts_out)
 
   # NOTE: We keep the cotangents associated with primal variables, while the contract of a
   #       transpose is to return them in positions associated with tangent variables, which
   #       is what causes this whole confusion.
-  return zero_vars(primal_invars) + map(read_cotangent, primal_invars) + zero_vars(primals_out)
-
-def zero_vars(vs):
-  return map(lambda v: ad.Zero(v.aval), vs)
+  return map(read_cotangent, jaxpr.invars)
 
 primitive_ivjps: Dict[core.Primitive, Callable] = {}
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -656,12 +656,7 @@ remat_call_p = core.CallPrimitive('remat_call')
 remat_call = remat_call_p.bind
 remat_call_p.def_impl(core.call_impl)
 
-# We reuse the _remat_partial_eval function both for remat_call and for
-# invertible_call, both of which in a sense stage out operations to
-# rematerialize values. The two usages differ only in details of what jaxpr eqn
-# and output tracers are formed. As a result we parameterize _remat_partial_eval
-# by a `process_out` function.
-def _remat_partial_eval(process_out, trace, _, f, tracers, params):
+def _remat_partial_eval(trace, _, f, tracers, params):
   concrete = params['concrete']
 
   # Unlike JaxprTrace.process_call, we want to form a jaxpr for the entirety of
@@ -737,29 +732,18 @@ def _remat_partial_eval(process_out, trace, _, f, tracers, params):
   # Unknown outputs get wrapped in tracers with the appropriate recipe
   unknown_output_tracers = [JaxprTracer(trace, out_pval, None)
                             for out_pval in out_unknown_pvals]
-  out_tracers = _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
 
-  in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
-  new_params = dict(params, call_jaxpr=convert_constvars_jaxpr(typed_jaxpr.jaxpr))
-  return process_out(trace, in_tracers, out_tracers, new_params)
-
-def _remat_make_output_tracers(_, in_tracers, out_tracers, params):
   # dce jaxpr outputs
-  jaxpr = params['call_jaxpr']
-  out_unknowns = [not t.pval.is_known() for t in out_tracers]
-  typed_jaxpr = core.TypedJaxpr(jaxpr, (), [v.aval for v in jaxpr.invars],
-                                [v.aval for v in jaxpr.outvars])
   new_jaxpr = _dce_jaxpr(typed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
   new_params = dict(params, call_jaxpr=new_jaxpr)
 
   # set up eqn for unknown outputs
-  unknown_out_tracers = [t for t in out_tracers if not t.pval.is_known()]
-  eqn = new_eqn_recipe(in_tracers, unknown_out_tracers, remat_call_p, new_params,
+  in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
+  eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p, new_params,
                        source_info_util.current())
-  for t in unknown_out_tracers: t.recipe = eqn
-  return out_tracers
-call_partial_eval_rules[remat_call_p] = partial(
-    _remat_partial_eval, _remat_make_output_tracers)
+  for t in unknown_output_tracers: t.recipe = eqn
+  return _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
+call_partial_eval_rules[remat_call_p] = _remat_partial_eval
 
 def _partition_knowns(pvals, unknowns: Sequence[bool]):
   return ([e for e, unknown in zip(pvals, unknowns) if not unknown],


### PR DESCRIPTION
This simplifies the implementation significantly, as we can piggyback
off of all the logic for custom derivatives. For example, the previous
implementation didn't support differentiating with respect to a subset
of function parameters, but the new one does.