### PR TITLE
[jax2tf] Change np.array dtype to jnp.float32 when target dtype is bfloat16.

### DIFF
--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert, safe_convert_to_tensor
+from .jax2tf import convert

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert
+from .jax2tf import convert, safe_convert_to_tensor

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -57,16 +57,16 @@ def _is_tfval(v: TfVal) -> bool:
   if isinstance(v, (tf.Tensor, tf.Variable)):
     return True
   try:
-    safe_convert_to_tensor(v)
+    # Note: this conversion is overkill and just intended as a type check; this code
+    # is in principle only run if core.skip_checks is False.
+    if hasattr(v, "dtype"):
+      tf.convert_to_tensor(np.array(v, jnp.float32) if v.dtype == jnp.bfloat16 else v,
+                           to_tf_dtype(v.dtype))
+    else:
+      tf.convert_to_tensor(v)
     return True
   except ValueError:
     return False
-
-def safe_convert_to_tensor(v):
-  if not hasattr(v, "dtype"):
-      return tf.convert_to_tensor(v)
-  return tf.convert_to_tensor(np.array(v, jnp.float32) if v.dtype == jnp.bfloat16
-                              else v, to_tf_dtype(v.dtype))
 
 # During JAX transformations we sometimes produce a Jaxpr that has arguments
 # of abstract value core.abstract_unit and results equal to core.unit.

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -57,10 +57,16 @@ def _is_tfval(v: TfVal) -> bool:
   if isinstance(v, (tf.Tensor, tf.Variable)):
     return True
   try:
-    tf.convert_to_tensor(v)
+    safe_convert_to_tensor(v)
     return True
   except ValueError:
     return False
+
+def safe_convert_to_tensor(v):
+  if not hasattr(v, "dtype"):
+      return tf.convert_to_tensor(v)
+  return tf.convert_to_tensor(np.array(v, jnp.float32) if v.dtype == jnp.bfloat16
+                              else v, to_tf_dtype(v.dtype))
 
 # During JAX transformations we sometimes produce a Jaxpr that has arguments
 # of abstract value core.abstract_unit and results equal to core.unit.

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -65,6 +65,17 @@ def _is_tfval(v: TfVal) -> bool:
     return False
 
 def _safe_convert_to_tensor(val, dtype=None):
+  """Converts val to a Tensor.
+
+  This method wraps TensorFlow's `convert_to_tensor
+  <https://www.tensorflow.org/api_docs/python/tf/convert_to_tensor>`_ operator with
+  special case handling for when `val` is an instance of `jnp.bfloat16` or has a
+  `jnp.bfloat16` dtype. Because this type is not supported in numpy and different
+  from `tf.bfloat16.as_numpy_dtype`, `tf.convert_to_tensor` runs into trouble when
+  trying to convert it. In such a case, we solve the problem by viewing val as a
+  `ndarray` with a `uint16` dtype, for which conversion is properly defined. Then, we
+  simply bitcast it back to `bfloat16`.
+  """
   dtype = dtype if dtype else (val.dtype if hasattr(val, "dtype") else None)
   if (dtype == jnp.bfloat16 or isinstance(val, jnp.bfloat16)):
     if not isinstance(val, jnp.ndarray):

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -244,7 +244,9 @@ class TensorFlowTracer(core.Tracer):
     else:  # Must be a numeric value
       assert core.skip_checks or _is_tfval(val), f"Non TfVal: {val}"
       aval = xla.abstractify(val)  # type: ignore
-      self.val = tf.convert_to_tensor(np.array(val, jnp.float32 if aval.dtype == jnp.bfloat16 else aval.dtype), dtype=to_tf_dtype(aval.dtype))  # type: ignore
+      source_array_dtype = jnp.float32 if aval.dtype == jnp.bfloat16 else aval.dtype
+      self.val = tf.convert_to_tensor(np.array(val, source_array_dtype),
+                                      dtype=to_tf_dtype(aval.dtype))  # type: ignore
       assert core.skip_checks or aval.strip_weak_type() == self.aval.strip_weak_type(), (
               f"Expected {aval}, got {self.aval}")
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -244,7 +244,10 @@ class TensorFlowTracer(core.Tracer):
     else:  # Must be a numeric value
       assert core.skip_checks or _is_tfval(val), f"Non TfVal: {val}"
       aval = xla.abstractify(val)  # type: ignore
-      self.val = tf.convert_to_tensor(np.array(val, aval.dtype), dtype=aval.dtype)  # type: ignore
+      source_array_dtype = aval.dtype
+      if aval.dtype == jnp.bfloat16:
+        source_array_dtype = jnp.float32
+      self.val = tf.convert_to_tensor(np.array(val, source_array_dtype), dtype=to_tf_dtype(aval.dtype))  # type: ignore
       assert core.skip_checks or aval.strip_weak_type() == self.aval.strip_weak_type(), (
               f"Expected {aval}, got {self.aval}")
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -244,10 +244,7 @@ class TensorFlowTracer(core.Tracer):
     else:  # Must be a numeric value
       assert core.skip_checks or _is_tfval(val), f"Non TfVal: {val}"
       aval = xla.abstractify(val)  # type: ignore
-      source_array_dtype = aval.dtype
-      if aval.dtype == jnp.bfloat16:
-        source_array_dtype = jnp.float32
-      self.val = tf.convert_to_tensor(np.array(val, source_array_dtype), dtype=to_tf_dtype(aval.dtype))  # type: ignore
+      self.val = tf.convert_to_tensor(np.array(val, jnp.float32 if aval.dtype == jnp.bfloat16 else aval.dtype), dtype=to_tf_dtype(aval.dtype))  # type: ignore
       assert core.skip_checks or aval.strip_weak_type() == self.aval.strip_weak_type(), (
               f"Expected {aval}, got {self.aval}")
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -557,10 +557,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       return x
 
     tf_fn_scalar = jax2tf.convert(jax_fn_scalar)
-    self.assertEqual(tf_fn_scalar(tf.convert_to_tensor(1.375)), 2.750)
+    self.assertAllClose(tf_fn_scalar(1.375).numpy(), jnp.bfloat16(2.750))
 
     tf_fn_array = jax2tf.convert(jax_fn_array)
-    self.assertAllClose(tf_fn_array(tf.convert_to_tensor([3, 4, 5])),
+    self.assertAllClose(tf_fn_array(np.array([3, 4, 5])),
                         np.array([4.5, 10, 17.5], jnp.bfloat16))
 
 if __name__ == "__main__":

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -543,8 +543,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     f = jax2tf.convert(lax.stop_gradient)
     self.assertEqual(f(tf.ones([])), 1.)
 
-  # test_bfloat16 checkes that https://github.com/google/jax/issues/3942 is fixed
-  def test_bfloat16(self):
+  # test_bfloat16_constant checks that https://github.com/google/jax/issues/3942 is
+  # fixed
+  def test_bfloat16_constant(self):
     def jax_fn(x):
       x = x.astype(jnp.bfloat16)
       x *= 2.
@@ -552,6 +553,16 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     tf_fn = jax2tf.convert(jax_fn)
     self.assertEqual(tf_fn(tf.convert_to_tensor(1.375)), 2.750)
+
+  def test_bfloat16_array(self):
+    def jax_fn(x):
+      x = x.astype(jnp.bfloat16)
+      x *= np.array([1.5, 2.5, 3.5], jnp.bfloat16)
+      return x
+
+    tf_fn = jax2tf.convert(jax_fn)
+    self.assertAllClose(tf_fn(tf.convert_to_tensor([3, 4, 5])),
+                        np.array([4.5, 10, 17.5], jnp.bfloat16))
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -551,7 +551,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       return x
 
     tf_fn = jax2tf.convert(jax_fn)
-    self.assertEqual(tf_fn(tf.convert_to_tensor(1.0)), 2.0)
+    self.assertEqual(tf_fn(tf.convert_to_tensor(1.375)), 2.750)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -546,22 +546,21 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   # test_bfloat16_constant checks that https://github.com/google/jax/issues/3942 is
   # fixed
   def test_bfloat16_constant(self):
-    def jax_fn(x):
+    def jax_fn_scalar(x):
       x = x.astype(jnp.bfloat16)
       x *= 2.
       return x
 
-    tf_fn = jax2tf.convert(jax_fn)
-    self.assertEqual(tf_fn(tf.convert_to_tensor(1.375)), 2.750)
-
-  def test_bfloat16_array(self):
-    def jax_fn(x):
+    def jax_fn_array(x):
       x = x.astype(jnp.bfloat16)
       x *= np.array([1.5, 2.5, 3.5], jnp.bfloat16)
       return x
 
-    tf_fn = jax2tf.convert(jax_fn)
-    self.assertAllClose(tf_fn(tf.convert_to_tensor([3, 4, 5])),
+    tf_fn_scalar = jax2tf.convert(jax_fn_scalar)
+    self.assertEqual(tf_fn_scalar(tf.convert_to_tensor(1.375)), 2.750)
+
+    tf_fn_array = jax2tf.convert(jax_fn_array)
+    self.assertAllClose(tf_fn_array(tf.convert_to_tensor([3, 4, 5])),
                         np.array([4.5, 10, 17.5], jnp.bfloat16))
 
 if __name__ == "__main__":

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -543,6 +543,15 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     f = jax2tf.convert(lax.stop_gradient)
     self.assertEqual(f(tf.ones([])), 1.)
 
+  # test_bfloat16 checkes that https://github.com/google/jax/issues/3942 is fixed
+  def test_bfloat16(self):
+    def jax_fn(x):
+      x = x.astype(jnp.bfloat16)
+      x *= 2.
+      return x
+
+    tf_fn = jax2tf.convert(jax_fn)
+    self.assertEqual(tf_fn(tf.convert_to_tensor(1.0)), 2.0)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -104,9 +104,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_pad)
   def test_pad(self, harness: primitive_harness.Harness):
-    # TODO: figure out the bfloat16 story
-    if harness.params["dtype"] is dtypes.bfloat16:
-      raise unittest.SkipTest("bfloat16 not implemented")
     # TODO: fix pad with negative padding in XLA (fixed on 06/16/2020)
     if any([lo < 0 or hi < 0 for lo, hi, mid in harness.params["pads"]]):
       raise unittest.SkipTest("pad with negative pad not supported")
@@ -118,9 +115,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         harness.params["k"] < 0):
       with self.assertRaisesRegex(ValueError, "k argument to top_k must be"):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
-    # TODO: figure out what's up with bfloat16
-    elif harness.params["dtype"] is dtypes.bfloat16:
-      raise unittest.SkipTest("bfloat16 support not implemented")
     elif harness.params["dtype"] in jtu.dtypes.complex:
       # TODO(necula): fix top_k complex bug on TPU
       if jtu.device_under_test() == "tpu":
@@ -135,9 +129,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_sort)
   def test_sort(self, harness: primitive_harness.Harness):
-    if harness.params["dtype"] is dtypes.bfloat16 or harness.params["dtype"] in jtu.dtypes.complex:
-      # TODO: implement bfloat16/complex support in XlaSort
-      raise unittest.SkipTest("bfloat16/complex support not implemented")
+    if harness.params["dtype"] in jtu.dtypes.complex:
+      # TODO: implement complex support in XlaSort
+      raise unittest.SkipTest("complex support not implemented")
     if harness.params["dtype"] is dtypes.bool_ and len(harness.arg_descriptors) == 4:
       # TODO: _sort uses tfxla.key_value_sort to handle 2 operandes, but the operation is not compatible with boolean keys.
       raise unittest.SkipTest("boolean key key value sort not implemented")

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -88,7 +88,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_type_promotion(self, f_jax=jnp.add):
     # We only test a few types here, as tensorflow does not support many
     # types like uint* or bool in binary ops.
-    types = [np.int32, np.int64, np.float32]
+    types = [dtypes.bfloat16, np.int32, np.int64, np.float32]
     for x_dtype in types:
       for y_dtype in types:
         x = np.array([1, 2], dtype=x_dtype)

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -92,7 +92,11 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     func_tf = jax2tf.convert(func_jax)
 
     def convert_if_bfloat16(v):
-      return jax2tf.safe_convert_to_tensor(v) if hasattr(v, "dtype") else v
+      if hasattr(v, "dtype"):
+        return tf.convert_to_tensor(np.array(v, jnp.float32) if
+                                      v.dtype == jnp.bfloat16 else v,
+                                    to_tf_dtype(v.dtype))
+      return v
 
     tf_args = tuple(map(convert_if_bfloat16, args))
 

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -95,7 +95,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
       if hasattr(v, "dtype"):
         return tf.convert_to_tensor(np.array(v, jnp.float32) if
                                       v.dtype == jnp.bfloat16 else v,
-                                    to_tf_dtype(v.dtype))
+                                    jax2tf.jax2tf.to_tf_dtype(v.dtype))
       return v
 
     tf_args = tuple(map(convert_if_bfloat16, args))

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -98,7 +98,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
 
     def run_tf(mode):
       if mode == "eager":
-        return func_tf(*args)
+        return func_tf(*tf_args)
       elif mode == "graph":
         return tf.function(func_tf, autograph=False)(*tf_args)
       elif mode == "compiled":

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -91,14 +91,19 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     # Run TF in all execution modes
     func_tf = jax2tf.convert(func_jax)
 
+    def convert_if_bfloat16(v):
+      return jax2tf.safe_convert_to_tensor(v) if hasattr(v, "dtype") else v
+
+    tf_args = tuple(map(convert_if_bfloat16, args))
+
     def run_tf(mode):
       if mode == "eager":
         return func_tf(*args)
       elif mode == "graph":
-        return tf.function(func_tf, autograph=False)(*args)
+        return tf.function(func_tf, autograph=False)(*tf_args)
       elif mode == "compiled":
         return tf.function(func_tf, autograph=False,
-                           experimental_compile=True)(*args)
+                           experimental_compile=True)(*tf_args)
       else:
         assert False
 


### PR DESCRIPTION
This ensures that the conversion for tf.convert_to_tensor is well
defined without losing precision.

Fixes google/jax#3942.