### PR TITLE
[jax2tf] Another attempt to work around the nested XLA compilation bug

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -496,6 +496,7 @@ lax_slice = tuple(
     [(5,), (5,), (6,), None],
     [(5,), (10,), (11,), None],
     [(5,), (0,), (100,), None],
+    [(5,), (3,), (6,), None]
   ]
   for dtype in [np.float32]
 )

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -418,15 +418,11 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     else:
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
-  @primitive_harness.parameterized(primitive_harness.lax_dynamic_slice,
-                                   one_containing="shape=(3,)_start_indices=(1,)_limit_indices=(2,)_strides=None")
+  @primitive_harness.parameterized(primitive_harness.lax_dynamic_slice)
   def test_dynamic_slice(self, harness):
     # JAX.dynamic_slice rejects slice sizes too big; check this, and skip jax2tf
     args = harness.dyn_args_maker(self.rng())
     expect_tf_exceptions = False
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): TPU "graph" mode throws "not compilable". See README.md
-      expect_tf_exceptions = True
     if any(li - si < 0 or li - si >= sh
            for sh, si, li in zip(harness.params["shape"],
                                  harness.params["start_indices"],
@@ -460,39 +456,23 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_squeeze(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
-  @primitive_harness.parameterized(primitive_harness.lax_gather,
-                                   one_containing="shape=(10, 5)_idxs_shape=(2, 2)_dnums=GatherDimensionNumbers(offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1))_slice_sizes=(1, 3)")
+  @primitive_harness.parameterized(primitive_harness.lax_gather)
   def test_gather(self, harness: primitive_harness.Harness):
-    expect_tf_exceptions = False
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): TPU "graph" mode throws "not compilable". See README.md
-      expect_tf_exceptions = True
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   def test_boolean_gather(self):
-    expect_tf_exceptions = False
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): TPU "graph" mode throws "not compilable". See README.md
-      expect_tf_exceptions = True
     values = np.array([[True, True], [False, True], [False, False]],
                       dtype=np.bool_)
     indices = np.array([0, 1], dtype=np.int32)
     for axis in [0, 1]:
       f_jax = jax.jit(lambda v, i: jnp.take(v, i, axis=axis))  # pylint: disable=cell-var-from-loop
-      self.ConvertAndCompare(f_jax, values, indices,
-                             expect_tf_exceptions=expect_tf_exceptions)
+      self.ConvertAndCompare(f_jax, values, indices)
 
   def test_gather_rank_change(self):
-    expect_tf_exceptions = False
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): TPU "graph" mode throws "not compilable". See README.md
-      expect_tf_exceptions = True
     params = jnp.array([[1.0, 1.5, 2.0], [2.0, 2.5, 3.0], [3.0, 3.5, 4.0]])
     indices = jnp.array([[1, 1, 2], [0, 1, 0]])
     f_jax = jax.jit(lambda i: params[i])
-    self.ConvertAndCompare(f_jax, indices,
-                          expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(f_jax, indices)
 
   @parameterized.named_parameters(jtu.cases_from_list(
     dict(testcase_name=f"_{f_jax.__name__}",
@@ -515,15 +495,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
          op=op)
     for op in INDEX))
   def test_scatter_static(self, op):
-    expect_tf_exceptions = False
-    if jtu.device_under_test() == "tpu":
-      # TODO(necula): TPU "graph" mode throws "not compilable". See README.md
-      expect_tf_exceptions = True
     values = np.ones((5, 6), dtype=np.float32)
     update = np.float32(6.)
     f_jax = jax.jit(lambda v, u: op(v, jax.ops.index[::2, 3:], u))
-    self.ConvertAndCompare(f_jax, values, update,
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(f_jax, values, update)
 
   @parameterized.named_parameters(jtu.cases_from_list(
     dict(testcase_name=f"_{f_jax.__name__}",

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -418,7 +418,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     else:
       self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
-  @primitive_harness.parameterized(primitive_harness.lax_dynamic_slice)
+  @primitive_harness.parameterized(primitive_harness.lax_dynamic_slice,
+                                   one_containing="shape=(3,)_start_indices=(1,)_limit_indices=(2,)_strides=None")
   def test_dynamic_slice(self, harness):
     # JAX.dynamic_slice rejects slice sizes too big; check this, and skip jax2tf
     args = harness.dyn_args_maker(self.rng())
@@ -459,7 +460,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_squeeze(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
-  @primitive_harness.parameterized(primitive_harness.lax_gather)
+  @primitive_harness.parameterized(primitive_harness.lax_gather,
+                                   one_containing="shape=(10, 5)_idxs_shape=(2, 2)_dnums=GatherDimensionNumbers(offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1))_slice_sizes=(1, 3)")
   def test_gather(self, harness: primitive_harness.Harness):
     expect_tf_exceptions = False
     if jtu.device_under_test() == "tpu":


### PR DESCRIPTION
This is the Nth attempted solution to the problem that the TF slice/gather ops have different semantics for 
index-out-of-bounds than JAX (and XLA). We have tried to force compilation, by wrapping into tf.xla.experimental.compile, 
or tf.function(experimental_compile=True), but those solutions are brittle because they do not work when 
nested into an outer compilation (see b/162814494 and b/163006262). They also do not survive well being put in a SavedModel. Hence, we now use TFXLA slicing and gather ops.
