### PR TITLE
[jax2tf] First draft of SVD conversion.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -371,7 +371,7 @@ tf_not_yet_impl = [
 
   lax.linear_solve_p,
   lax_linalg.cholesky_p, lax_linalg.eig_p, lax_linalg.eigh_p,
-  lax_linalg.lu_p, lax_linalg.svd_p,
+  lax_linalg.lu_p,
   lax_linalg.triangular_solve_p,
 
   lax.igamma_grad_a_p,
@@ -1214,6 +1214,17 @@ def _qr(operand, full_matrices):
   return tf.linalg.qr(operand, full_matrices=full_matrices)
 
 tf_impl[lax_linalg.qr_p] = _qr
+
+def _svd(operand, full_matrices, compute_uv):
+  if operand.dtype in [jnp.complex64, jnp.complex128]:
+    raise NotImplementedError("TODO: tf.linalg.svd does not support complex tensors")
+  result = tf.linalg.svd(operand, full_matrices, compute_uv)
+  if not compute_uv:
+    return result,
+  s, u, v = result
+  return s, u, tf.linalg.adjoint(v)
+
+tf_impl[lax_linalg.svd_p] = _svd
 
 def _custom_jvp_call_jaxpr(*args: TfValOrUnit,
                            fun_jaxpr: core.TypedJaxpr,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1216,8 +1216,6 @@ def _qr(operand, full_matrices):
 tf_impl[lax_linalg.qr_p] = _qr
 
 def _svd(operand, full_matrices, compute_uv):
-  if operand.dtype in [jnp.complex64, jnp.complex128]:
-    raise NotImplementedError("TODO: tf.linalg.svd does not support complex tensors")
   result = tf.linalg.svd(operand, full_matrices, compute_uv)
   if not compute_uv:
     return result,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -450,22 +450,10 @@ def _fft_harness_gen(nb_axes):
 lax_fft = tuple(_fft_harness_gen(1) + _fft_harness_gen(2) + _fft_harness_gen(3) +
                 _fft_harness_gen(4))
 
-def _linalg_svd_test(operand, full_matrices, compute_uv):
-  result = lax_linalg.svd_p.bind(operand, full_matrices=full_matrices,
-                                 compute_uv=compute_uv)
-  if compute_uv:
-    s, u, v = result
-    U = u[..., :s.shape[-1]]
-    V = v[..., :s.shape[-1], :]
-    S = s[..., None, :]
-    # Reconstructing operand as documented in numpy.linalg.svd
-    return jnp.matmul(U * S, V), s.shape, u.shape, v.shape
-  else:
-    return result
-
 lax_linalg_svd = tuple(
   Harness(f"shape={jtu.format_shape_dtype_string(shape, dtype)}_fullmatrices={full_matrices}_computeuv={compute_uv}",
-          lambda *args: _linalg_svd_test(*args),
+          lambda *args: lax_linalg.svd_p.bind(args[0], full_matrices=args[1],
+                                              compute_uv=args[2]),
           [RandArg(shape, dtype), StaticArg(full_matrices), StaticArg(compute_uv)],
           shape=shape,
           dtype=dtype,

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -236,7 +236,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     def _custom_assert(r_jax, r_tf, atol=1e-6, rtol=1e-6):
       def _reconstruct_operand(result, is_tf: bool):
-        # Reconstructing operand as documented in numpy.linalg.svd
+        # Reconstructing operand as documented in numpy.linalg.svd (see
+        # https://numpy.org/doc/stable/reference/generated/numpy.linalg.svd.html)
         s, u, v = result
         if is_tf:
           s = s.numpy()
@@ -261,7 +262,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            atol=tol, rtol=tol,
                            expect_tf_exceptions=expect_tf_exceptions,
-                           custom_assert=custom_assert)
+                           custom_assert=custom_assert,
+                           always_custom=True)
 
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -212,6 +212,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_svd)
   def test_svd(self, harness: primitive_harness.Harness):
+    if jtu.device_under_test() == "tpu":
+      raise unittest.SkipTest("TODO: test crashes the XLA compiler for some TPU variants")
     expect_tf_exceptions = False
     if harness.params["dtype"] in [jnp.float16, dtypes.bfloat16]:
       if jtu.device_under_test() == "tpu":
@@ -231,7 +233,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
           harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
         return
       else:
-        # TODO: on CPU and GPU "No registered 'Svd' OpKernel for XLA_CPU_JIT devices"
+        # TODO: on CPU and GPU "No registered 'Svd' OpKernel for XLA_CPU_JIT devices".
+        # Works on JAX because JAX uses a custom implementation.
         expect_tf_exceptions = True
 
     def _custom_assert(r_jax, r_tf, atol=1e-6, rtol=1e-6):
@@ -263,7 +266,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                            atol=tol, rtol=tol,
                            expect_tf_exceptions=expect_tf_exceptions,
                            custom_assert=custom_assert,
-                           always_custom=True)
+                           always_custom_assert=True)
 
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -18,6 +18,8 @@ import unittest
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from functools import partial
+
 import jax
 from jax import dtypes
 from jax import lax
@@ -210,20 +212,57 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_svd)
   def test_svd(self, harness: primitive_harness.Harness):
+    expect_tf_exceptions = False
+    if harness.params["dtype"] in [jnp.float16, dtypes.bfloat16]:
+      if jtu.device_under_test() == "tpu":
+        # TODO: SVD on TPU for bfloat16 seems to work for JAX but fails for TF
+        expect_tf_exceptions = True
+      else:
+        # Does not work in JAX
+        with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
+          harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
+        return
+
     if harness.params["dtype"] in [jnp.complex64, jnp.complex128]:
       if jtu.device_under_test() == "tpu":
-        raise unittest.SkipTest("No TPU implementation for SVD of complex numbers")
-        # TODO: the above should be replaced by an appropriate assertRaisesRegex to
-        # detect future possible breaking changes of the conversion.
-      else:
-        # TODO: tf.linalg.svd is not compatible with complex numbers.
-        raise unittest.SkipTest("Conversion is not implemented for complex numbers")
-    elif harness.params["dtype"] in [jnp.float16, dtypes.bfloat16]:
-      with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
+        # TODO: on JAX on TPU there is no SVD implementation for complex
+        with self.assertRaisesRegex(RuntimeError,
+                                    "Binary op compare with different element types"):
           harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
-    else:
-      self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                             atol=1e-4, rtol=1e-4)
+        return
+      else:
+        # TODO: on CPU and GPU "No registered 'Svd' OpKernel for XLA_CPU_JIT devices"
+        expect_tf_exceptions = True
+
+    def _custom_assert(r_jax, r_tf, atol=1e-6, rtol=1e-6):
+      def _reconstruct_operand(result, is_tf: bool):
+        # Reconstructing operand as documented in numpy.linalg.svd
+        s, u, v = result
+        if is_tf:
+          s = s.numpy()
+          u = u.numpy()
+          v = v.numpy()
+        U = u[..., :s.shape[-1]]
+        V = v[..., :s.shape[-1], :]
+        S = s[..., None, :]
+        return jnp.matmul(U * S, V), s.shape, u.shape, v.shape
+
+      if harness.params["compute_uv"]:
+        r_jax_reconstructed = _reconstruct_operand(r_jax, False)
+        r_tf_reconstructed = _reconstruct_operand(r_tf, True)
+        self.assertAllClose(r_jax_reconstructed, r_tf_reconstructed,
+                            atol=atol, rtol=rtol)
+      else:
+        self.assertAllClose(r_jax, r_tf, atol=atol, rtol=rtol)
+
+    tol = 1e-4
+    custom_assert = partial(_custom_assert, atol=tol, rtol=tol)
+
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           atol=tol, rtol=tol,
+                           expect_tf_exceptions=expect_tf_exceptions,
+                           custom_assert=custom_assert)
+
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -61,7 +61,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
 
   def ConvertAndCompare(self, func_jax: Callable, *args,
                         custom_assert: Optional[Callable] = None,
-                        always_custom: bool = False,
+                        always_custom_assert: bool = False,
                         expect_tf_exceptions: bool = False,
                         atol=None,
                         rtol=None) -> Tuple[Any, Any]:
@@ -79,8 +79,9 @@ class JaxToTfTestCase(jtu.JaxTestCase):
         results. Use this function when JAX and TF produce different results.
         This function is only used for "eager" and "graph" modes by default, not for
         the "compiled" mode, because in that case we expect the results to be equal.
-      always_custom: if True, custom_assert is also called in "compiled" mode. This is
-        useful in cases where JAX and TF produce different but equally valid results.
+      always_custom_assert: if True, custom_assert is also called in "compiled" mode.
+        This is useful in cases where JAX and TF produce different but equally valid
+        results.
       expect_tf_exceptions: if True, there may be exceptions in some evaluation
         modes; when there is no exception the result should be the same
         as in JAX.
@@ -112,14 +113,12 @@ class JaxToTfTestCase(jtu.JaxTestCase):
           print(f"Encountered expected exception for mode={mode}: {e}")
           continue
 
-      if custom_assert is not None and mode in ("eager", "graph"):
+      if custom_assert is not None and (mode in ("eager", "graph") or
+                                        always_custom_assert):
         custom_assert(result_jax, result_tf)
       else:
-        if always_custom and custom_assert is not None:
-          custom_assert(result_jax, result_tf)
-        else:
-          # In compiled mode we expect the same result as JAX by default
-          self.assertAllClose(result_jax, result_tf, atol=atol, rtol=rtol)
+        # In compiled mode we expect the same result as JAX by default
+        self.assertAllClose(result_jax, result_tf, atol=atol, rtol=rtol)
 
     return (result_jax, result_tf)
 


### PR DESCRIPTION
See the [numpy doc for svd](https://numpy.org/doc/stable/reference/generated/numpy.linalg.svd.html) for the explanation behind the testing code.

Limitation: this conversion does not work for complex numbers.