### PR TITLE
Add numpy.vectorize to list of numpy fns in docs

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -292,6 +292,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     vander
     var
     vdot
+    vectorize
     vsplit
     vstack
     where


### PR DESCRIPTION
It's now both under "vectorization" and in the numpy page.  I guess that makes sense?