### PR TITLE
Update docs requirements.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,14 @@
-sphinx>=2.1
+# sphinx <3 is required by myst-parser[sphinx] v0.9.1, the latest version as of 2020-08-05
+sphinx >=2.1, <3
+
 sphinx_rtd_theme
+
+# sphinx-autodoc-typehints 1.11 requires sphinx >= 3, but we can't have that right now.
+sphinx-autodoc-typehints <1.11
+
 jaxlib
 ipykernel
 nbsphinx
-sphinx-autodoc-typehints
 myst-parser[sphinx]
 # The next packages are for notebooks
 matplotlib


### PR DESCRIPTION
We're in a bit of dependency hell, but at least this cleanly installs for me.

Note that I was not actually able to test this out e2e; I never ended up getting docs generation to work on my mac even when I used a pipenv, and docs generation worked on my Linux box even when this failed.  So I am only claiming that `pip install -r requirements.txt` now works.  :)