### PR TITLE
Fix jax.checkpoint in API docs

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -92,6 +92,7 @@ Parallelization (:code:`pmap`)
 .. autofunction:: vjp
 .. autofunction:: custom_jvp
 .. autofunction:: custom_vjp
+.. autofunction:: checkpoint
 
 .. autofunction:: vmap
 .. autofunction:: jax.numpy.vectorize


### PR DESCRIPTION
On the index API doc page, it turns out functions need to be listed *twice* to
appear.