### PR TITLE
Initial version of vmap collectives

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -769,7 +769,7 @@ def _dtype(x):
   return dtypes.canonicalize_dtype(dtypes.result_type(x))
 
 
-def vmap(fun: Callable[..., T], in_axes=0, out_axes=0) -> Callable[..., T]:
+def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callable[..., T]:
   """Vectorizing map. Creates a function which maps ``fun`` over argument axes.
 
   Args:
@@ -877,6 +877,8 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0) -> Callable[..., T]:
     docstr += "\n\nOriginal documentation:\n\n"
     docstr += fun.__doc__
 
+  axis_name = _TempAxisName(fun) if axis_name is None else axis_name
+
   if isinstance(in_axes, list):
     # To be a tree prefix of the positional args tuple, in_axes can never be a
     # list: if in_axes is not a leaf, it must be a tuple of trees. However,
@@ -911,7 +913,8 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0) -> Callable[..., T]:
     _ = _mapped_axis_size(in_tree, args_flat, in_axes_flat, "vmap")
     out_flat = batching.batch(flat_fun, args_flat, in_axes_flat,
                               lambda: flatten_axes("vmap out_axes", out_tree(),
-                                                   out_axes))
+                                                   out_axes),
+                              axis_name=axis_name)
     return tree_unflatten(out_tree(), out_flat)
 
   return batched_fun

--- a/jax/core.py
+++ b/jax/core.py
@@ -641,7 +641,7 @@ class TraceStack:
     return new
 
 class Sublevel(int): pass
-AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size'])
+AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size', 'tag'])
 
 
 class TraceState:
@@ -1170,6 +1170,10 @@ class MapPrimitive(Primitive):
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_map(self, out_tracers, params)
 
+# This is a no-op with omnistaging disabled
+@contextmanager
+def extend_axis_env(axis_name, size: int, tag: Any):
+  yield
 
 # ------------------- Jaxpr checking -------------------
 
@@ -1562,8 +1566,8 @@ def omnistaging_enabler() -> None:
   Primitive.bind = bind
 
   @contextmanager
-  def extend_axis_env(axis_name, size: int):
-    frame = AxisEnvFrame(axis_name, size)
+  def extend_axis_env(axis_name, size: int, tag: Any):
+    frame = AxisEnvFrame(axis_name, size, tag)
     thread_local_state.trace_state.axis_env.append(frame)
     try:
       yield

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -584,7 +584,9 @@ def _custom_vjp_call_jaxpr_vmap(args, in_dims, *, fun_jaxpr, fwd_jaxpr_thunk,
 
   fwd_in_dims = [0 if b else not_mapped for b in in_batched]
   fwd_out_dims = lambda: out_dims2[0]
-  batched_bwd = batching.batch_fun(bwd, fwd_out_dims, fwd_in_dims, sum_match=True)
+  # TODO: Support collectives in custom_vjp?
+  batched_bwd = batching.batch_fun(bwd, fwd_out_dims, fwd_in_dims,
+                                   axis_name='__unused_axis_name', sum_match=True)
 
   batched_outs = custom_vjp_call_jaxpr_p.bind(
       *args, fun_jaxpr=batched_fun_jaxpr,

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -143,6 +143,8 @@ class BatchTrace(Trace):
             raise NotImplementedError("axis_index_groups not supported in vmap collectives")
           result = collective_rules[primitive](vals_in, dims_in, frame.size, **params)
           remaining_axes = axes_names[:i] + axes_names[(i+1):]
+          # TODO: This assumes that the collective always returns the same result for each
+          #       array element, which is not true for the ones that are not reductions!
           if remaining_axes:
             new_params = dict(params, axis_name=remaining_axes)
             return primitive.bind(*result, **new_params)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -29,9 +29,9 @@ from . import partial_eval as pe
 map = safe_map
 
 
-def batch(fun : lu.WrappedFun, in_vals, in_dims, out_dim_dests):
+def batch(fun: lu.WrappedFun, in_vals, in_dims, out_dim_dests, axis_name):
   # executes a batched version of `fun` following out_dim_dests
-  batched_fun = batch_fun(fun, in_dims, out_dim_dests)
+  batched_fun = batch_fun(fun, in_dims, out_dim_dests, axis_name=axis_name)
   return batched_fun.call_wrapped(*in_vals)
 
 @lu.transformation_with_aux
@@ -45,17 +45,20 @@ def batch_subtrace(master, in_dims, *in_vals, **params):
   yield out_vals, out_dims
 
 
-def batch_fun(fun : lu.WrappedFun, in_dims, out_dim_dests, sum_match=False):
+def batch_fun(fun : lu.WrappedFun, in_dims, out_dim_dests, axis_name,
+              sum_match=False):
   # transformation version of batch, which doesn't call the function
   fun, out_dims = batch_subtrace(fun)
-  return _batch_fun(fun, sum_match, in_dims, out_dims, out_dim_dests)
+  return _batch_fun(fun, axis_name, sum_match, in_dims, out_dims, out_dim_dests)
 
 @lu.transformation
-def _batch_fun(sum_match, in_dims, out_dims_thunk, out_dim_dests, *in_vals, **params):
+def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
+               *in_vals, **params):
   in_dims = in_dims() if callable(in_dims) else in_dims
   size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
   with core.new_master(BatchTrace) as master:
-    out_vals = yield (master, in_dims,) + in_vals, params
+    with core.extend_axis_env(axis_name, size, master):
+      out_vals = yield (master, in_dims,) + in_vals, params
     del master
   out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
   out_dims = out_dims_thunk()
@@ -129,14 +132,29 @@ class BatchTrace(Trace):
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
     if all(bdim is not_mapped for bdim in dims_in):
       return primitive.bind(*vals_in, **params)
+    elif config.omnistaging_enabled and primitive in collective_rules:
+      axes_names = params['axis_name']
+      if not isinstance(axes_names, (tuple, list)):
+        axes_names = (axes_names,)
+      for i, axis_name in enumerate(axes_names):
+        frame = core.axis_frame(axis_name)
+        if frame.tag is self.master:
+          if params['axis_index_groups'] is not None:
+            raise NotImplementedError("axis_index_groups not supported in vmap collectives")
+          result = collective_rules[primitive](vals_in, dims_in, frame.size, **params)
+          remaining_axes = axes_names[:i] + axes_names[(i+1):]
+          if remaining_axes:
+            new_params = dict(params, axis_name=remaining_axes)
+            return primitive.bind(*result, **new_params)
+          else:
+            return result
+    # TODO(mattjj,phawkins): if no rule implemented, could vmap-via-map here
+    batched_primitive = get_primitive_batcher(primitive)
+    val_out, dim_out = batched_primitive(vals_in, dims_in, **params)
+    if primitive.multiple_results:
+      return map(partial(BatchTracer, self), val_out, dim_out)
     else:
-      # TODO(mattjj,phawkins): if no rule implemented, could vmap-via-map here
-      batched_primitive = get_primitive_batcher(primitive)
-      val_out, dim_out = batched_primitive(vals_in, dims_in, **params)
-      if primitive.multiple_results:
-        return map(partial(BatchTracer, self), val_out, dim_out)
-      else:
-        return BatchTracer(self, val_out, dim_out)
+      return BatchTracer(self, val_out, dim_out)
 
   def process_call(self, call_primitive, f: lu.WrappedFun, tracers, params):
     assert call_primitive.multiple_results
@@ -197,7 +215,9 @@ class BatchTrace(Trace):
     in_vals, in_dims = unzip2((t.val, t.batch_dim) for t in tracers)
     fun, out_dims1 = batch_subtrace(fun, self.master, in_dims)
     fwd, out_dims2 = batch_subtrace(fwd, self.master, in_dims)
-    bwd = batch_fun(bwd, out_dims2, in_dims, sum_match=True)
+    # TODO: Support collectives in custom_vjp?
+    bwd = batch_fun(bwd, out_dims2, in_dims,
+                    axis_name='__unused_axis_name', sum_match=True)
     out_vals = prim.bind(fun, fwd, bwd, *in_vals, out_trees=out_trees)
     fst, out_dims = lu.merge_linear_aux(out_dims1, out_dims2)
     if not fst:
@@ -420,3 +440,11 @@ def omnistaging_enabler() -> None:
     jaxpr_out, avals_out, literals_out = pe.trace_to_jaxpr_dynamic(f, avals_in)
     jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, avals_in, avals_out)
     return jaxpr_out, batched_out()
+
+
+# It is assumed that all collectives specified below are commutative
+# and associative over axis names if they support tuples. That is,
+# they have to satisfy:
+#   collective(x, ('i', 'j')) == collective(x, ('j', 'i'))
+#                             == collective(collective(x, 'j'), 'i')
+collective_rules: Dict[core.Primitive, Callable] = {}

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1015,7 +1015,7 @@ class DynamicJaxprTrace(core.Trace):
     axis_name, axis_size = params['axis_name'], params['axis_size']
     reduced_in_avals = [core.mapped_aval(axis_size, a) if m else a
                         for m, a in zip(params['mapped_invars'], in_avals)]
-    with core.extend_axis_env(axis_name, axis_size):  # type: ignore
+    with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.master, reduced_in_avals)
     out_avals = [core.unmapped_aval(params['axis_size'], a) for a in reduced_out_avals]

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -696,7 +696,7 @@ def parallel_callable(fun, backend, axis_name, axis_size, global_axis_size,
   if config.omnistaging_enabled:
     sharded_avals = tuple(shard_aval(axis_size, aval) if m else aval
                           for m, aval in zip(mapped_invars, avals))
-    with core.extend_axis_env(axis_name, axis_size):  # type: ignore
+    with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, sharded_avals)
     jaxpr = xla.apply_outfeed_rewriter(jaxpr)
   else:
@@ -1211,7 +1211,7 @@ def soft_pmap_impl(fun: lu.WrappedFun, *args, axis_name, axis_size, mapped_invar
 def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
   mapped_avals = [core.mapped_aval(axis_size, aval) if m else aval
                   for m, aval in zip(mapped_invars, avals)]
-  with core.extend_axis_env(axis_name, axis_size):  # type: ignore
+  with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_avals)
   jaxpr = xla.apply_outfeed_rewriter(jaxpr)
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -29,6 +29,7 @@ from jax.interpreters import ad
 from jax.interpreters import parallel
 from jax.interpreters import xla
 from jax.interpreters import pxla
+from jax.interpreters import batching
 from jax.util import partial, unzip2, prod
 from jax.lib import xla_client as xc
 from jax.config import config
@@ -387,12 +388,19 @@ xla.parallel_translations[psum_p] = _psum_translation_rule
 pxla.parallel_pure_rules[psum_p] = lambda *args, shape: (x * prod(shape) for x in args)
 ad.deflinear(psum_p, _psum_transpose_rule)
 pxla.multi_host_supported_collectives.add(psum_p)
+batching.collective_rules[psum_p] = \
+    lambda vals, dims, axis_size, **_: [v.sum(d) if d is not batching.not_mapped else
+                                        axis_size * v
+                                        for v, d in zip(vals, dims)]
 
 
 pmax_p = core.Primitive('pmax')
 pmax_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
 xla.parallel_translations[pmax_p] = \
     partial(_allreduce_translation_rule, lax.max_p)
+batching.collective_rules[pmax_p] = \
+    lambda vals, dims, axis_size, **_: [v.max(d) if d is not batching.not_mapped else v
+                                        for v, d in zip(vals, dims)]
 # pxla.split_axis_rules[pmax_p] = \
 #     partial(_allreduce_split_axis_rule, pmax_p, lax._reduce_max)
 
@@ -401,6 +409,9 @@ pmin_p = core.Primitive('pmin')
 pmin_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
 xla.parallel_translations[pmin_p] = \
     partial(_allreduce_translation_rule, lax.min_p)
+batching.collective_rules[pmin_p] = \
+    lambda vals, dims, axis_size, **_: [v.min(d) if d is not batching.not_mapped else v
+                                        for v, d in zip(vals, dims)]
 # pxla.split_axis_rules[pmin_p] = \
 #     partial(_allreduce_split_axis_rule, pmin_p, lax._reduce_min)
 

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1432,6 +1432,22 @@ class VmapOfPmapTest(jtu.JaxTestCase):
     expected = np.stack([fun(*args_slice(i)) for i in range(vmapped_size)])
     self.assertAllClose(ans, expected)
 
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testCollectivesWithVmap(self):
+    def f(map1, map2):
+      @partial(map1, axis_name='i')
+      @partial(map2, axis_name='j')
+      def f(x, y):
+        return x + jax.lax.psum(x.dot(y), ('i', 'j'))
+      return f
+
+    x = jnp.ones((2, 2, 64, 64))
+    y = f(jax.pmap, jax.pmap)(x, x)
+    self.assertAllClose(f(jax.vmap, jax.vmap)(x, x), y)
+    self.assertAllClose(f(jax.pmap, jax.vmap)(x, x), y)
+    self.assertAllClose(f(jax.vmap, jax.pmap)(x, x), y)
+
 
 class PmapWithDevicesTest(jtu.JaxTestCase):
 
@@ -1782,22 +1798,6 @@ class ShardArgsTest(jtu.JaxTestCase):
     for buf, idx in zip(bufs, indices):
       self.assertEqual(len(buf), 1)
       self.assertAllClose(buf[0].to_py(), x[idx], check_dtypes=False)
-
-  @skipIf(not jax.config.omnistaging_enabled,
-          "vmap collectives only supported when omnistaging is enabled")
-  def testCollectivesWithVmap(self):
-    def f(map1, map2):
-      @partial(map1, axis_name='i')
-      @partial(map2, axis_name='j')
-      def f(x, y):
-        return x + jax.lax.psum(x.dot(y), ('i', 'j'))
-      return f
-
-    x = jnp.ones((2, 2, 64, 64))
-    y = f(jax.pmap, jax.pmap)(x, x)
-    self.assertAllClose(f(jax.vmap, jax.vmap)(x, x), y)
-    self.assertAllClose(f(jax.pmap, jax.vmap)(x, x), y)
-    self.assertAllClose(f(jax.vmap, jax.pmap)(x, x), y)
 
 
 if __name__ == '__main__':

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -20,7 +20,7 @@ import gc
 import os
 from random import shuffle
 from typing import Optional, cast
-from unittest import SkipTest
+from unittest import SkipTest, skipIf
 import warnings
 import weakref
 
@@ -1782,6 +1782,23 @@ class ShardArgsTest(jtu.JaxTestCase):
     for buf, idx in zip(bufs, indices):
       self.assertEqual(len(buf), 1)
       self.assertAllClose(buf[0].to_py(), x[idx], check_dtypes=False)
+
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testCollectivesWithVmap(self):
+    def f(map1, map2):
+      @partial(map1, axis_name='i')
+      @partial(map2, axis_name='j')
+      def f(x, y):
+        return x + jax.lax.psum(x.dot(y), ('i', 'j'))
+      return f
+
+    x = jnp.ones((2, 2, 64, 64))
+    y = f(jax.pmap, jax.pmap)(x, x)
+    self.assertAllClose(f(jax.vmap, jax.vmap)(x, x), y)
+    self.assertAllClose(f(jax.pmap, jax.vmap)(x, x), y)
+    self.assertAllClose(f(jax.vmap, jax.pmap)(x, x), y)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1442,6 +1442,8 @@ class VmapOfPmapTest(jtu.JaxTestCase):
         return x + jax.lax.psum(x.dot(y), ('i', 'j'))
       return f
 
+    if xla_bridge.device_count() < 4:
+      raise SkipTest("test requires at least four devices")
     x = jnp.ones((2, 2, 64, 64))
     y = f(jax.pmap, jax.pmap)(x, x)
     self.assertAllClose(f(jax.vmap, jax.vmap)(x, x), y)


### PR DESCRIPTION
This adds support for the basic (associative and commutative)
collectives to vmap. Supporting more complex collectives will
require some more complicated rules. Also, at the moment it is not
possible to use collectives inside `custom_vjp` rules which we might
want to fix in the future.

This feature is also omnistaging-only.

Co-authored-by: Matthew Johnson <mattjj@google.com>