### PR TITLE
fix custom_jvp/vjp closure issues, and nondiff_argnums too!

### DIFF
--- a/docs/custom_vjp_update.md
+++ b/docs/custom_vjp_update.md
@@ -1,0 +1,129 @@
+# `custom_vjp` and `nondiff_argnums` update guide
+_mattjj@_
+_Oct 14 2020_
+
+This doc assumes familiarity with `jax.custom_vjp`, as described in the [Custom
+derivative rules for JAX-transformable Python
+functions](https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html)
+notebook.
+
+### What to update
+
+After JAX [PR #4008](https://github.com/google/jax/pull/4008), the arguments
+passed into a `custom_vjp` function's `nondiff_argnums` can't be `Tracer`s (or
+containers of `Tracer`s), which basically means to allow for
+arbitrarily-transformable code `nondiff_argnums` shouldn't be used for
+array-valued arguments. Instead, `nondiff_argnums` should be used only for
+non-array values, like Python callables or shape tuples or strings.
+
+Wherever we used to use `nondiff_argnums` for array values, we should just pass
+those as regular arguments. In the `bwd` rule, we need to produce values for them,
+but we can just produce `None` values to indicate there's no corresponding
+gradient value.
+
+For example, here's the **old** way to write `clip_gradient`, which won't work
+when `hi` and/or `lo` are `Tracer`s from some JAX transformation.
+
+```python
+from functools import partial
+import jax
+
+@partial(jax.custom_vjp, nondiff_argnums=(0, 1))
+def clip_gradient(lo, hi, x):
+  return x  # identity function
+
+def clip_gradient_fwd(lo, hi, x):
+  return x, None  # no residual values to save
+
+def clip_gradient_bwd(lo, hi, _, g):
+  return (jnp.clip(g, lo, hi),)
+
+clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
+```
+
+Here's the **new**, awesome way, which supports arbitrary transformations:
+
+```python
+import jax
+
+@jax.custom_vjp  # no nondiff_argnums!
+def clip_gradient(lo, hi, x):
+  return x  # identity function
+
+def clip_gradient_fwd(lo, hi, x):
+  return x, (lo, hi)  # save lo and hi values as residuals
+
+def clip_gradient_bwd(res, g):
+  lo, hi = res
+  return (None, None, jnp.clip(g, lo, hi))  # return None for lo and hi
+
+clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
+```
+
+If you use the old way instead of the new way, you'll get a loud error in any
+case where something might go wrong (namely when there's a `Tracer` passed into
+a `nondiff_argnums` argument).
+
+Here's a case where we actually need `nondiff_argnums` with `custom_vjp`:
+
+```python
+from functools import partial
+import jax
+
+@partial(jax.custom_vjp, nondiff_argnums)
+def skip_app(f, x):
+  return f(x)
+
+def skip_app_fwd(f, x):
+  return skip_bwd(f, x), None
+
+def skip_app_bwd(f, _, g):
+  return (g,)
+
+skip_app.defvjp(skip_app_fwd, skip_app_bwd)
+```
+
+
+### Explanation
+
+Passing `Tracer`s into `nondiff_argnums` arguments was always buggy. While there
+were some cases which worked correctly, others would lead to complex and
+confusing error messages.
+
+The essence of the bug was that `nondiff_argnums` was implemented in a way that
+acted very much like lexical closure. But lexical closure over `Tracer`s wasn't
+at the time intended to work with `custom_jvp`/`custom_vjp`. Implementing
+`nondiff_argnums` that way was a mistake!
+
+**[PR #4008](https://github.com/google/jax/pull/4008) fixes all lexical closure
+issues with `custom_jvp` and `custom_vjp`.** Woohoo! That is, now `custom_jvp`
+and `custom_vjp` functions and rules can close over `Tracer`s to our hearts'
+content. For all non-autodiff transformations, things will Just Work. For
+autodiff transformations, we'll get a clear error message about why we can't
+differentiate with respect to values over which a `custom_jvp` or `custom_vjp`
+closes:
+
+> Detected differentiation of a custom_jvp function with respect to a closed-over
+value. That isn't supported because the custom JVP rule only specifies how to
+differentiate the custom_jvp function with respect to explicit input parameters.
+>
+> Try passing the closed-over value into the custom_jvp function as an argument,
+and adapting the custom_jvp rule.
+
+In tightening up and robustifying `custom_jvp` and `custom_vjp` in this way, we
+found that allowing `custom_vjp` to accept `Tracer`s in its `nondiff_argnums`
+would take a significant amount of bookkeeping: we'd need to rewrite the user's
+`fwd` function to return the values as residuals, and rewrite the user's `bwd`
+function to accept them as normal residuals (rather than accepting them as
+special leading arguments, as happens with `nondiff_argnums`). This seems maybe
+manageable, until you think through how we have to handle arbitrary pytrees!
+Moreover, that complexity isn't necessary: if user code treats array-like
+non-differentiable arguments just like regular arguments and residuals,
+everything already works. (Before
+[#4039](https://github.com/google/jax/pull/4039) JAX might've complained about
+involving integer-valued inputs and outputs in autodiff, but after
+[#4039](https://github.com/google/jax/pull/4039) those will just work!)
+
+Unlike `custom_vjp`, it was easy to make `custom_jvp` work with
+`nondiff_argnums` arguments that were `Tracer`s. So these updates only need to
+happen with `custom_vjp`.

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -18,13 +18,12 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "LqiaKasFjH82",
-        "colab_type": "text"
+        "id": "LqiaKasFjH82"
       },
       "source": [
         "# Custom derivative rules for JAX-transformable Python functions\n",
         "\n",
-        "*mattjj@ Mar 19 2020, last updated Mar 30 2020*\n",
+        "*mattjj@ Mar 19 2020, last updated Oct 14 2020*\n",
         "\n",
         "There are two ways to define differentiation rules in JAX:\n",
         "\n",
@@ -39,8 +38,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9Fg3NFNY-2RY",
-        "colab_type": "text"
+        "id": "9Fg3NFNY-2RY"
       },
       "source": [
         "## TL;DR"
@@ -49,8 +47,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ZgMNRtXyWIW8",
-        "colab_type": "text"
+        "id": "ZgMNRtXyWIW8"
       },
       "source": [
         "### Custom JVPs with `jax.custom_jvp`"
@@ -59,9 +56,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "zXic8tr--1PK",
-        "colab_type": "code",
-        "colab": {}
+        "id": "zXic8tr--1PK"
       },
       "source": [
         "import jax.numpy as jnp\n",
@@ -79,18 +74,16 @@
         "  tangent_out = jnp.cos(x) * x_dot * y + jnp.sin(x) * y_dot\n",
         "  return primal_out, tangent_out"
       ],
-      "execution_count": 0,
+      "execution_count": 2,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "RrNf588X_kJF",
-        "colab_type": "code",
-        "outputId": "33bc1c36-b720-442f-b385-8ebe025319e3",
+        "outputId": "b962bafb-e8a3-4b0d-ddf4-202e088231c3",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -102,7 +95,7 @@
         "print(y_dot)\n",
         "print(grad(f)(2., 3.))"
       ],
-      "execution_count": 2,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
@@ -119,9 +112,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "1kHd3cKOWQgB",
-        "colab_type": "code",
-        "colab": {}
+        "id": "1kHd3cKOWQgB"
       },
       "source": [
         "# Equivalent alternative using the defjvps convenience wrapper\n",
@@ -133,19 +124,17 @@
         "f.defjvps(lambda x_dot, primal_out, x, y: jnp.cos(x) * x_dot * y,\n",
         "          lambda y_dot, primal_out, x, y: jnp.sin(x) * y_dot)"
       ],
-      "execution_count": 0,
+      "execution_count": 4,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "Zn81cHeYWVOw",
-        "colab_type": "code",
+        "outputId": "bf29b66c-897b-485e-c0a0-ee0fbd729a95",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "outputId": "fb5e7e94-488f-4c30-a851-5e7c0a8173bf"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(f(2., 3.))\n",
@@ -154,7 +143,7 @@
         "print(y_dot)\n",
         "print(grad(f)(2., 3.))"
       ],
-      "execution_count": 4,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
@@ -171,8 +160,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "N2DOGCREWXFj",
-        "colab_type": "text"
+        "id": "N2DOGCREWXFj"
       },
       "source": [
         "### Custom VJPs with `jax.custom_vjp`"
@@ -181,9 +169,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "35ScHqhrBwPh",
-        "colab_type": "code",
-        "colab": {}
+        "id": "35ScHqhrBwPh"
       },
       "source": [
         "from jax import custom_vjp\n",
@@ -202,24 +188,22 @@
         "\n",
         "f.defvjp(f_fwd, f_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 6,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "HpSozxKUCXgp",
-        "colab_type": "code",
-        "outputId": "e515914b-a65b-49ba-a746-c343308451e7",
+        "outputId": "57277102-7bdb-41f0-c805-a27fcf9fb1ae",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(2., 3.))"
       ],
-      "execution_count": 6,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
@@ -233,8 +217,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "p5ypWA7XlZpu",
-        "colab_type": "text"
+        "id": "p5ypWA7XlZpu"
       },
       "source": [
         "## Example problems\n",
@@ -246,8 +229,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "AR02eyd1GQhC",
-        "colab_type": "text"
+        "id": "AR02eyd1GQhC"
       },
       "source": [
         "### Numerical stability\n",
@@ -258,8 +240,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GksPXslaGPaW",
-        "colab_type": "text"
+        "id": "GksPXslaGPaW"
       },
       "source": [
         "\n",
@@ -270,11 +251,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "6lWbTvs40ET-",
-        "colab_type": "code",
-        "outputId": "739b4df9-7c64-4fb4-c0ce-c04fa7d86db4",
+        "outputId": "8caff99e-add1-4c70-ace3-212c0c5c6f4e",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -285,7 +264,7 @@
         "\n",
         "log1pexp(3.)"
       ],
-      "execution_count": 7,
+      "execution_count": 8,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -297,15 +276,14 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 7
+          "execution_count": 8
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "PL36r_cD0oE8",
-        "colab_type": "text"
+        "id": "PL36r_cD0oE8"
       },
       "source": [
         "Since it's written in terms of `jax.numpy`, it's JAX-transformable:"
@@ -315,11 +293,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "XgtGKFld02UD",
-        "colab_type": "code",
-        "outputId": "a2722ad0-00d6-48d9-f5fa-cc87779bbe53",
+        "outputId": "809d399d-8eca-401e-b969-810e46648571",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -329,7 +305,7 @@
         "print(jit(grad(log1pexp))(3.))\n",
         "print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))"
       ],
-      "execution_count": 8,
+      "execution_count": 9,
       "outputs": [
         {
           "output_type": "stream",
@@ -345,8 +321,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "o56Nr3V61PKS",
-        "colab_type": "text"
+        "id": "o56Nr3V61PKS"
       },
       "source": [
         "But there's a numerical stability problem lurking here:"
@@ -356,17 +331,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "sVM6iwIO22sB",
-        "colab_type": "code",
-        "outputId": "1a1624bc-15fa-43c0-a9d0-ac17c80e8097",
+        "outputId": "9c935ee8-f174-475a-ca01-fc80949199e5",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(log1pexp)(100.))"
       ],
-      "execution_count": 9,
+      "execution_count": 10,
       "outputs": [
         {
           "output_type": "stream",
@@ -380,8 +353,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Zu9sR2I73wuO",
-        "colab_type": "text"
+        "id": "Zu9sR2I73wuO"
       },
       "source": [
         "That doesn't seem right! After all, the derivative of $x \\mapsto \\log (1 + e^x)$ is $x \\mapsto \\frac{e^x}{1 + e^x}$, and so for large values of $x$ we'd expect the value to be about 1.\n",
@@ -393,11 +365,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "dO6uZlYR4TVp",
-        "colab_type": "code",
-        "outputId": "36835248-669f-4025-8931-783072bed9f9",
+        "outputId": "61e06b1e-14cd-4030-f330-a949be185df8",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 119
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -405,7 +375,7 @@
         "\n",
         "make_jaxpr(grad(log1pexp))(100.)"
       ],
-      "execution_count": 10,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "execute_result",
@@ -414,6 +384,7 @@
               "{ lambda  ; a.\n",
               "  let b = exp a\n",
               "      c = add b 1.0\n",
+              "      _ = log c\n",
               "      d = div 1.0 c\n",
               "      e = mul d b\n",
               "  in (e,) }"
@@ -422,15 +393,14 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 10
+          "execution_count": 11
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "52HR5EW26PEt",
-        "colab_type": "text"
+        "id": "52HR5EW26PEt"
       },
       "source": [
         "Stepping through how the jaxpr would be evaluated, we can see that the last line would involve multiplying values that floating point math will round to 0 and $\\infty$, respectively, which is never a good idea. That is, we're effectively evaluating `lambda x: (1 / (1 + jnp.exp(x))) * jnp.exp(x)` for large `x`, which effectively turns into `0. * jnp.inf`.\n",
@@ -447,9 +417,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "XQt6MAuTJewG",
-        "colab_type": "code",
-        "colab": {}
+        "id": "XQt6MAuTJewG"
       },
       "source": [
         "from jax import custom_jvp\n",
@@ -466,24 +434,22 @@
         "  ans_dot = (1 - 1/(1 + jnp.exp(x))) * x_dot\n",
         "  return ans, ans_dot"
       ],
-      "execution_count": 0,
+      "execution_count": 12,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "rhiMHulfKBIF",
-        "colab_type": "code",
-        "outputId": "45256c6b-19fd-4bac-baf8-4892298048bd",
+        "outputId": "883bc4d2-3a1b-48d3-b205-c500f77d229c",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(log1pexp)(100.))"
       ],
-      "execution_count": 12,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "stream",
@@ -498,11 +464,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "9cLDuAo6KGUu",
-        "colab_type": "code",
-        "outputId": "c8194a60-7e48-4fb2-d78d-569b38841b42",
+        "outputId": "59984494-6124-4540-84fd-608ad4fc6bc6",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -510,7 +474,7 @@
         "print(jit(grad(log1pexp))(3.))\n",
         "print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))"
       ],
-      "execution_count": 13,
+      "execution_count": 14,
       "outputs": [
         {
           "output_type": "stream",
@@ -526,8 +490,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9sVUGbGkUOqO",
-        "colab_type": "text"
+        "id": "9sVUGbGkUOqO"
       },
       "source": [
         "Here's a `defjvps` convenience wrapper to express the same thing:"
@@ -536,9 +499,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "xfQTp8F7USEM",
-        "colab_type": "code",
-        "colab": {}
+        "id": "xfQTp8F7USEM"
       },
       "source": [
         "@custom_jvp\n",
@@ -547,19 +508,17 @@
         "\n",
         "log1pexp.defjvps(lambda t, ans, x: (1 - 1/(1 + jnp.exp(x))) * t)"
       ],
-      "execution_count": 0,
+      "execution_count": 15,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "dtdh-PLaUsvw",
-        "colab_type": "code",
+        "outputId": "aa36aec6-15af-4397-fc55-8b9fb7e607d8",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "outputId": "588a0619-0b5c-42ed-b2cf-955255b0f7a7"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(grad(log1pexp)(100.))\n",
@@ -567,7 +526,7 @@
         "print(jit(grad(log1pexp))(3.))\n",
         "print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))"
       ],
-      "execution_count": 15,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "stream",
@@ -584,8 +543,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "V9tHAfrSF1N-",
-        "colab_type": "text"
+        "id": "V9tHAfrSF1N-"
       },
       "source": [
         "### Enforcing a differentiation convention\n",
@@ -596,8 +554,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "l_6tdb-QGK-H",
-        "colab_type": "text"
+        "id": "l_6tdb-QGK-H"
       },
       "source": [
         "\n",
@@ -607,22 +564,19 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "AfF5P7x_GaSe",
-        "colab_type": "code",
-        "colab": {}
+        "id": "AfF5P7x_GaSe"
       },
       "source": [
         "def f(x):\n",
         "  return x / (1 + jnp.sqrt(x))"
       ],
-      "execution_count": 0,
+      "execution_count": 17,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BVcEkF3ZGgv1",
-        "colab_type": "text"
+        "id": "BVcEkF3ZGgv1"
       },
       "source": [
         "As a mathematical function on $\\mathbb{R}$ (the full real line), $f$ is not differentiable at zero (because the limit defining the derivative doesn't exist from the left). Correspondingly, autodiff produces a `nan` value:"
@@ -632,17 +586,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "piI0u5MiHhQh",
-        "colab_type": "code",
-        "outputId": "35bdee7d-41d7-44ed-b326-43d494cf71fa",
+        "outputId": "c045308f-2f3b-4c22-ebb2-b9ee582b4d25",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(0.))"
       ],
-      "execution_count": 17,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "stream",
@@ -656,8 +608,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "IP0H2b7ZHkzD",
-        "colab_type": "text"
+        "id": "IP0H2b7ZHkzD"
       },
       "source": [
         "But mathematically if we think of $f$ as a function on $\\mathbb{R}_+$ then it is differentiable at 0 [Rudin's Principles of Mathematical Analysis Definition 5.1, or Tao's Analysis I 3rd ed. Definition 10.1.1 and Example 10.1.6]. Alternatively, we might say as a convention we want to consider the directional derivative from the right. So there is a sensible value for the Python function `grad(f)` to return at `0.0`, namely `1.0`. By default, JAX's machinery for differentiation assumes all functions are defined over $\\mathbb{R}$ and thus doesn't produce `1.0` here.\n",
@@ -668,9 +619,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "ksHmCkcSKQJr",
-        "colab_type": "code",
-        "colab": {}
+        "id": "ksHmCkcSKQJr"
       },
       "source": [
         "@custom_jvp\n",
@@ -685,24 +634,22 @@
         "  ans_dot = ((jnp.sqrt(x) + 2) / (2 * (jnp.sqrt(x) + 1)**2)) * x_dot\n",
         "  return ans, ans_dot"
       ],
-      "execution_count": 0,
+      "execution_count": 19,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "Gsh9ZvMTKi1O",
-        "colab_type": "code",
-        "outputId": "fb288478-eb53-4362-aa46-24ea18003bec",
+        "outputId": "a3076175-6542-4210-ce4a-d0d82e0051c6",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(0.))"
       ],
-      "execution_count": 19,
+      "execution_count": 20,
       "outputs": [
         {
           "output_type": "stream",
@@ -716,8 +663,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Usbp_gxaVVea",
-        "colab_type": "text"
+        "id": "Usbp_gxaVVea"
       },
       "source": [
         "Here's the convenience wrapper version:"
@@ -726,9 +672,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "qXnrxIfaVYCs",
-        "colab_type": "code",
-        "colab": {}
+        "id": "qXnrxIfaVYCs"
       },
       "source": [
         "@custom_jvp\n",
@@ -737,24 +681,22 @@
         "\n",
         "f.defjvps(lambda t, ans, x: ((jnp.sqrt(x) + 2) / (2 * (jnp.sqrt(x) + 1)**2)) * t)"
       ],
-      "execution_count": 0,
+      "execution_count": 21,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "uUU5qRmEViK1",
-        "colab_type": "code",
+        "outputId": "ea7dc2c4-a100-48f4-a74a-859070daf994",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "109052a3-2176-4d7f-b63a-09d86898ce8b"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(grad(f)(0.))"
       ],
-      "execution_count": 21,
+      "execution_count": 22,
       "outputs": [
         {
           "output_type": "stream",
@@ -768,8 +710,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "7J2A85wbSAmF",
-        "colab_type": "text"
+        "id": "7J2A85wbSAmF"
       },
       "source": [
         "### Gradient clipping\n",
@@ -782,39 +723,37 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "8jfjSanIW_tJ",
-        "colab_type": "code",
-        "colab": {}
+        "id": "8jfjSanIW_tJ"
       },
       "source": [
         "from functools import partial\n",
         "from jax import custom_vjp\n",
         "\n",
-        "@partial(custom_vjp, nondiff_argnums=(0, 1))\n",
+        "@custom_vjp\n",
         "def clip_gradient(lo, hi, x):\n",
         "  return x  # identity function\n",
         "\n",
         "def clip_gradient_fwd(lo, hi, x):\n",
-        "  return x, None  # no residual values to save\n",
+        "  return x, (lo, hi)  # save bounds as residuals\n",
         "\n",
-        "def clip_gradient_bwd(lo, hi, _, g):\n",
-        "  return (jnp.clip(g, lo, hi),)\n",
+        "def clip_gradient_bwd(res, g):\n",
+        "  lo, hi = res\n",
+        "  return (None, None, jnp.clip(g, lo, hi))  # use None to indicate zero cotangents for lo and hi\n",
         "\n",
         "clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 23,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "4OLU_vf8Xw2J",
-        "colab_type": "code",
+        "outputId": "5a51ff2c-79c2-41ba-eead-53679b4eddbc",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 282
-        },
-        "outputId": "36b37747-6330-4990-a056-04780c218d79"
+        }
       },
       "source": [
         "import matplotlib.pyplot as plt\n",
@@ -825,60 +764,13 @@
         "plt.plot(jnp.sin(t))\n",
         "plt.plot(vmap(grad(jnp.sin))(t))"
       ],
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fe986788d68>]"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 23
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOydd3ic1ZX/P3fUe2+WZEuWZau6W8YG\nbHARtmVjOpgUE5KQRrKbZLMhm0I2CfmRbDakbDYbIBBCB2PAxh1jbGNwkauqLVlu6rJk9S7d3x93\nBMJIlkZT3nk17+d55tHMW7+Yeefce8655wgpJQYGBgYGrotJawEGBgYGBtpiGAIDAwMDF8cwBAYG\nBgYujmEIDAwMDFwcwxAYGBgYuDjuWgsYC+Hh4TIhIUFrGQYGBga64ujRo5ellBFXb9elIUhISCA3\nN1drGQYGBga6QghxYajthmvIwMDAwMUxDIGBgYGBi2MYAgMDAwMXxzAEBgYGBi6OYQgMDAwMXByb\nGAIhxDNCiFohRP4w+4UQ4k9CiFIhxCkhxOxB+9YLIUrMr/W20GNgYGBgMHpsNSP4B7DiGvtXAsnm\n10PAXwGEEKHAo8B8IAt4VAgRYiNNBgYGBgajwCbrCKSU+4QQCdc4ZC3wT6lqXh8UQgQLIWKAm4Bd\nUsoGACHELpRBedkWuj7DyVegqRz8o2DCLIhMA5Nze8d6+vopqGymoLKJxvYehIAJQT7MnhjCxDBf\nreUZODtNFVCRC1cuQG8X+IZCxDSIywJ3T63VXRMpJWfr2siraKS6qYvevn6iAr1JjQkkfUIgJpPQ\nWuK4wVELymKBS4M+l5u3Dbf9MwghHkLNJpg4ceLYVORvhJIdn3wOmACzvwjzv6YeECeiprmTp/aV\n8ebxCurbuoc8JjnSny8umMTdc+Px9nBzsEIDp6W/D/LfgCNPw6VDQx/j6Q8Zd8KChyFiqmP1jUBH\ndx8vHLzAK0cucraubchjwv29uHdeHOsXJhAZ4O1gheMPYavGNOYZwTtSyowh9r0DPC6l/MD8eTfw\nQ9SMwFtK+Svz9p8CHVLK313rXnPnzpVjXlnc0wHNlXDpsHpYSt8F70C4+ccw76uazxB6+vr53z1n\n+eveUnr7JMvToliVGcPM+GAiA73o65dcbGjn4Nl6Nh6v4FR5E3EhPvx8TTrL0qI01W7gBJTnwqZv\nQ20hhE+DmesgcRGEJYOHD7TWQtUJOL0V8jZAXzdkfQ1u/g/1HGjMllNV/OfmAmpbupiXEMLambFk\nJYYSH+KLyQTVTZ0cu3iFrXnVvFtUg6+HG99dPpUHFibg7ubcs3tnQAhxVEo59zPbHWQI/ga8L6V8\n2fz5NMoI3ATcJKX82lDHDYdVhuBqaotg+4+gbA8kLYU7ngS/cNtc20IqGzv4xgtHOVneRM70GH54\nS8o13T9SSj46W8/PNxdwpqaV9Qsm8R85qXi5G7MDl0NK2Pc7eP/Xaqab/UtIu+3aA5u2y7DnMch9\nFkInwz3/hOjPPL4OobOnj//YmMfG4xVMjwviJzlpZCVee5ZeVtfKL98pZM/pOq6bHMqf1s0yZgcj\noLUhyAEeBlahAsN/klJmmYPFR4GBLKJjwJyBmMFw2NQQgHqIcv8OO34MgbHwhY0QkmC764+C/Iom\nHvzHETq6+/jNXdNZlRkz6nO7e/v57fZinv7gHPMTQ3l6/VwCvD3sqNbAqejtUrOAU69C5t2Q89/g\nHTT6888fgA0PQlcz3Ps8TFlmP61DUN/axVf/mcuxi438y9Jkvr1kyqhH91JKNh6r4Mdv5RHi68nz\nX57PlEh/OyvWL3Y1BEKIl1Gj+3CgBpUJ5AEgpfw/IYQA/gcVCG4HviSlzDWf+yDwH+ZLPSalfHak\n+9ncEAxw8RC8dA+4ecID76igmgM4dvEKX3j6EMG+njzzwDymRQeM6TpvHa/g314/SWpMIP98MIsQ\nP+cOBhrYgN4ueOVzULoLlvwUbvw+iDEEUVtq4MU7obYY7noG0m61vdYhuNzaxb1/+4jyKx384d6Z\nrLRgADSYgsom1j9zBCklzz2YRUasBYbQhbD7jMCR2M0QANSdhn+sBjcPeHAHBMfb5z5mCiqbWPfk\nQUL8PHntawuICrRuavtecQ1ff+EY6RMCeekr1+HjabiJxi19vbDhASjaDGv+CHMesO56HY1qIFRx\nFD73OiQtsYXKYWls72bdU4c4d7mV576UxfzJYVZd79zlNj7/9CE6evrY+I2FJIT72Ujp+GE4Q2BE\nV64mYppyDXW1wvO3Q8cVu92qqqmDB549gr+XOy9+Zb7VRgBgSUoUf7pvFicvNfLwS8fo7eu3gVID\np2T7I8oIrPiN9UYAwCdYGYDwafDqF6DqpPXXHIaevn6+/sJRzta28tQX51ptBAASw/14/stZSClZ\n/+xhLrd22UCpa2AYgqGIzoT7X4Er52Hj16Df9j+mnT19fP35o7R39fKPB7OIC7HdmoAVGdH8563p\n7C6u5b93nbHZdQ2ciKP/gCNPwcJvw3Vft911vYPg8xvAOxhevh/arxmuGzO/2FzIwbIGfnNXJjcm\nf6ZPypiZHOHP3x+YR01zJ9980RgIjRbDEAzHpIWw4v+pdQf7fmvzyz/6dgEny5t44t6ZTI0aW0zg\nWnxhQQLrsuL56/tn2VVYY/PrG2hIxTHY8m8qy23Zf9r++oET4L4XoK0WNn7V5gOhDUfLef7gBb62\naDK3z4qz6bUBZk8M4de3Z3L4XAO/22kMhEaDYQiuxbyvwIx1sPc3cPGgzS67Pb+KV3Mv8c2bkshO\nj7bZda/m0TXpZMQG8v3XTlDV1GG3+xg4kO429ePsHwl3/R1MdooBTZgFK3+j1tkceMJml71Y386j\nb+czPzGUf1+RYrPrXs0ds+O4f/5E/m/vWfacrrXbfcYLhiG4FkLAqv+CoHh48+sqbmAltc2d/Ghj\nHpmxQXx3uX1XdHp7uPE/62bT0yd55I089JgYYHAVO38C9Wfh9v8DHzuX5ZrzJbUWYc//g5pCqy/X\n29fPv756HJNJ8Pt7Z+Jm5xIRP1udxrSoAB554xRN7T12vZfeMQzBSHgFwG1/VfGCXT+16lJSSn74\nxik6evp44t6ZeDhgJWRCuB+PrExh75k6Xsu9NPIJBs5L6buQ+4yKCyQusv/9hPhkTcJb34A+635M\nn9xfxrGLjfzqtgxig31sJHJ4vD3c+N3dM7jc2s0v3rHekI1nDEMwGhKuhwXfUg/hhQ/HfJlt+dXs\nOV3HD25Jceiily9cN4nrJofyy3eKqG7qdNh9DWxITwe88z1VKmLJTxx3X79wWP17VZbiwB/HfJmL\n9e388d0SVqRHs3bmkOXE7EJmXBDfWJzEG8fKea/YiJUNh2EIRsvN/6FcRFv+TeVvW0hLZw//ubmA\ntJhA1i+YZAeBw2MyCX575wx6+vr59dYih97bwEbs+x00XoDVT4C7l2PvnbZWvfb9DhovWny6lJKf\nbcrH3SR49NY0Owi8Nt9eOoUpkf78fFMhnT19Dr+/HjAMwWjx9FNZRLUFcPhJi09/YlcJtS1dPHZ7\nhibFsSaG+fK1xUlsOlnJwbJ6h9/fwArqTqvR+Ix1kHijNhqyH1N/d/zY4lO351fz/uk6vpc9jZgg\n+7uErsbL3Y2fr0nnYkM7T+0rc/j99YBhCCwhZTVMWQ57fq2W5I+S0tpWnvvoPPfNm8isidr13fnG\n4iRig3149O0CI79aT+z8CXj4wvJfaqchOF6VryjaBGXvj/q0rt4+HttaREp0gMNnwoO5ITmcFenR\n/OX9UiobjQy6qzEMgSUIoVLqejssWlvw2+3FeLub+H62tnXffTzd+OnqVE7XtPDyESNwrAvK9kLJ\nTlj0ffC33cKrMbHw26oY4/YfqZ4Ho+D5jy5QfqWDn+SkaV4m+sc5qUgJj28r1lSHM2IYAksJS1LL\n+Y/+Q6XxjUDu+QZ2Ftbw9cVJhPs72Lc7BLekRzN3Ugh/3l1CR7fhL3Vq+vth189UbCrra1qrAQ9v\nWPqo6nWQ9/qIhze19/Dn90pZNDWCG5K1Ke0+mPhQXx68IZFNJysprGzWWo5TYRiCsbD4h+DmBbt/\ncc3DpJT8emsRkQFefPnGRAeJuzZCCP59RQq1LV3848PzWssxuBYFG1W2zpKfqB9hZyDtNoiertyj\nvUN3zhvgf98vpbmzh0fsuHDMUr6+KIlAb3d+t/O01lKcCsMQjAX/SDVNLnxLVWochp2FNRy72Mj3\nlk/F19NRXUFHJisxlJumRfDX90uNhTbOSl8PvPdLiMqEzHu0VvMJJpOaFTRegGPPDXtYdVMnz354\nnttnxZI2QfvOZwME+XrwtcVJvFdcS+55+9RR0iOGIRgrCx9WKzv3/teQu6WU/Gl3CQlhvtw1x/b1\nVKzlB7dMo7mzl7/tG9m9ZaABp15TixiX/Fjz9qmfYcpSmHQ97P2tKnkxBP+39yx9/ZLvLnOufsgA\nX7o+gXB/L367/bSx2t6Mk33DdIRXAFz3LTizbchyve8V11JQ2cw3bx59tyVHkj4hiJzpMTz34Xlj\nVuBs9PXC/t8pF8zUFVqr+SxCwNKfqaJ0R//xmd21LZ28fPgid8yKJT7UdlV1bYWvpzvfXjKFw+cb\n+MhIpQZsZAiEECuEEKeFEKVCiEeG2P+EEOKE+XVGCNE4aF/foH2bbKHHYcx/CLyCYN+nZwVSSv70\nXilxIT7cPstxqygt5eGbp9DW3cdzH53XWorBYPLfgIYyFYsaS7cxRzDxOki4ET78s+qSNoin9pXR\n2y95eMkUjcSNzL3z4gn39+Kv7xszYrCBIRBCuAF/AVYCacA6IcSnlg9KKb8rpZwppZwJ/BnYOGh3\nx8A+KaVj+uPZCu8gVQu+aDPUFHy8eX/JZU5eauSbN01xSD2hsZIaE8jSlEieOXCOti7LV0sb2IH+\nPjWwiEyHaau0VnNtbvwetFTByVc+3nS5tYsXDl5k7cwJTApz3g5h3h5ufOXGxI+fVVfHFr9SWUCp\nlLJMStkNvAKsvcbx64CXbXBf52D+18HTH/b/98eb/ue9UmKCvLlzjvPOBgb45s1TaGzv4eXDlpcO\nMLADRZugvgQW/ZvzxQauZvLNqlz1B098XHbl2QPn6Ozt41s3O+9sYIDPzZ9IoLc7//t+qdZSNMcW\n37RYYPDqpHLzts8ghJgEJALvDdrsLYTIFUIcFELcNtxNhBAPmY/Lraurs4FsG+EbCnMfhIK3oPEi\nJy41cvh8A1++IREvd+fvFzxnUggLJofx5L4yunqNdQWa89FfIHSyqu3j7AihVhtfOQeFb9He3csL\nBy9yS1o0SRGOK6o4VgK8PXhgYQI7CmooqWnRWo6mOHrIcR+wQUo5+BdnkrmZ8v3AH4QQSUOdKKV8\nUko5V0o5NyJC4xWWVzPfvNjn0N/4+wfnCPBy59559m16b0u+eXMStS1dbDpRqbUU1+bSYSg/Atd9\n034NZ2zNtBzV4/jDP/FG7iWaOnr46iLnWDMzGh64PhEfDzeedPEaRLYwBBXA4F+9OPO2obiPq9xC\nUsoK898y4H1glg00OZagOEi/jf6jz7E3r4z7suIJ8PbQWtWouWFKOFOj/Hn2wHkjnU5LPvof1St4\n5v1aKxk9JpOKk1Wd5PC+rcyMD2a2hvW0LCXUz5M7Zsfy9slK6l242b0tDMERIFkIkSiE8ET92H8m\n+0cIkQKEAB8N2hYihPAyvw8Hrgf02UHium9h6m7hbtP7rF+YoLUaixBC8KXrEymsaubwOWORjSZc\nOa+SDuZ+SVW61RPT76PHM4iVbW/xlRsTEc6a6TQMDyxMoLu336XjZFYbAillL/AwsAMoAl6TUhYI\nIX4hhBicBXQf8Ir89JAzFcgVQpwE9gCPSyl1aQhaI2ZwTE7jGz67iAvSvqaQpdw2M5ZgXw+ePXBe\naymuycH/A2GCrIe0VmI5nr5s9cjmFrdcVsReu+yEM5IcFcCNyeE8f/ACPS5aldcmMQIp5VYp5VQp\nZZKU8jHztp9JKTcNOubnUspHrjrvQyllppRyhvnv322hRwtez73E33pWEt5TBcVbtJZjMT6ebtyf\nNZGdhdVcamjXWo5r0dkMx5+HjDshcILWaiwmv6KJ39TfiBAC96P6fIS/dH0CNc1dbM2r0lqKJjh5\nfpo+kFLy/MELXI5dCkET4chTWksaE19YMAkhBP/86LzWUlyLU69Cd6tzVBgdAy8cvMAVjyh6p65W\n9YeGKTvhzNw0NZLEcD+XnREbhsAGHCxroKyujXXXTYY56+HcPrhcorUsi4kJ8mFlRjSvHLlklKh2\nFFJC7rMQMwNiZ2utxmKaO3t4+0Qlt86YgOf134TOJmXYdIbJJFi/YBInLjVywgUXmBmGwAa8eOgC\ngd7urJ4eA7O/CCZ39XDrkM9fN4mWzl62uOgU2eFcOqzan879svOWk7gGbx2voKOnj89dNxHi50NU\nxpD1h/TAnXPi8PFw4+VDrhc0NgyBldS1dLGjoJq75sTj7eGmSlSnroETL0KP/lrizU8MZXKEn0tn\nUDiU3GfAK1DFB3SGlJIXDl5gelwQ0+OClSGb84Aqwlh5XGt5FhPg7cGtMyaw6WQlLZ2uVYjRMARW\n8vrRS/T0Se6fP/GTjXMfhM5GtdpYZwghuD9rIkcvXOF0tWuvtrQ77Q1Q8CZMvxe8nH8l7tXkXrjC\nmZpWPjf4u595N7j76HZWsG7+RDp6+njbxRZXGobACvr7JS8dush1k0OZEjnoQU64EcKSIVefGRR3\nzI7D081kzArszYkXoa9LDRx0yIsHLxDg7c6aGYMynXyCIeMOyNsAXfobSMyICyI1JpCXDl10qcWV\nhiGwgn0ldZRf6eBz8yd9eocQ6uEuPwLVedqIs4JQP09WZESz8Vg5nT1G0Ngu9PerONLEBRCVNvLx\nTkZDWzdb86q5c3bcZ7vvzXlAZUHlv6GJNmtQM+J4Cquayato0lqOwzAMgRW8cvgSYX6e3JIe/dmd\nM+4DN084/qLjhdmAdVkTae7sZcspI2hsFy5+CA1n1Y+mDnnzeAXdff2sy5r42Z1x8yAyTbfuobWz\nYvH2cK0ZsWEIxkhDWze7i2u4fVYsnu5D/DP6hqp68nmvjdjk2xm5bnIok8P9eMmFHgaHcuIl8AyA\nVH214Bhgw9FyZsQFMS064LM7B4LGlceh8oTDtVlLoLcHa6ZP4O0TlbS6SJ8OwxCMkU0nKujpk9x5\nrX7EMz8H7fVwZrvjhNkIIQT3zovn6IUrlNW1ai1nfNHVqhIJMm4HT+dr5TgSBZVNFFU1X7sX9/R7\nwN0bjr/gOGE25L6sibR397HllGsEjQ1DMEY2HCsnIzaQ1JjA4Q9KWgL+0SooqENunxWLScDGY8MV\nkzUYE0WboKdNDRR0yIaj5Xi6mbh1xjUaL/mEqBlx/gZdzohnTwxmcrgfb7jId98wBGOgqKqZ/Ipm\n7pp9jRERgJu7ihWU7IKWGseIsyGRgd7cmBzBm8cr6O93nQwKu3PiJQhNUguwdEZ3bz9vn6hkeXoU\nQb4jlFqfsQ46rkDJTseIsyFCCO6cE8fhcw0uUXvLMARj4I2j5Xi4CW6dOYpWlLM+D7IPTr0y8rFO\nyB2zY6lo7ODguXqtpYwPGs7B+f2q54AOVxK/V1xLQ1v3td1CAyQtAb9IOKnPzrS3zYpFuMiM2DAE\nFtLT189bJypYmhJFqJ/nyCeEJ0Nclsoe0mFe8i3p0QR4ufPG0fH/MDiEk68AQs0UdciGo+VEBnhx\n45TwkQ92c1exgjM7oE1/A4nYYB8WTA5j4/Hycb+mwDAEFrL3dB2XW0c5Ihpg1ufg8mmoOGY/YXbC\n28ONnOkxbMuvor3bNTIo7EZ/P5x8CSbfpLra6Yy6li72nK7l9tmxuLuN8qdjxjro74GCjfYVZyfu\nmB3Hhfp2jl64orUUu2IYAgvZcLSccH9PFk+zoG9y+u3g5qVSSXXIHbPjaO/uY3t+tdZS9M2FA9B4\nUbdB4rdPVNDXL0eOjQ0mOgOiMlVcRIesyIjGx8Nt3AeNbWIIhBArhBCnhRClQohHhtj/gBCiTghx\nwvz6yqB964UQJebXelvosRdN7T3sLq5h7cxYPEY7IgLwDoKp2WqlZZ/+RtXzEkKID/XhjWPlWkvR\nN6deBU9/SMnRWsmYeOtEBdPjgkiOGmLtwLWYuQ4qj0HdafsIsyP+Xu6szIjmnVOV43qVvdWGQAjh\nBvwFWAmkAeuEEEOtmX9VSjnT/HrafG4o8CgwH8gCHhVCOG3n6235VfT0SW4bTZD4ajLvgbY6OLfX\n9sLsjBCCO2bF8eHZeiob9VdR1Sno7YLCTaoyrQ7XDpTWtpJf0czaMX337wbhZo6P6I87ZsfR0tnL\nu0X6y/wbLbaYEWQBpVLKMillN/AKsHaU594C7JJSNkgprwC7gBU20GQX3j5RSWK4Hxmx11g7MBzJ\n2eAVBHmv216YA7hjdixSwuaTrrHAxuaU7IKuJsi4S2slY2LTyUqEQPXcsBT/SJiyFE69puIkOmNB\nUhgxQd68OY7dQ7YwBLHApUGfy83bruZOIcQpIcQGIUS8hecihHhICJErhMitq6uzgWzLqGnu5OC5\nem6dMQExlrQ/D29IWwNFm3XZp2BSmB8z4oPZZBiCsZG/AXzDYfJirZVYjJSSzScrWTA5jKhA77Fd\nJPNuaC6H8sO2FecA3EyC1dNj2FdSR2O7/hbHjQZHBYs3AwlSyumoUf9zll5ASvmklHKulHJuRIQF\ngVobsflkJVLCrTOtaC6eeY+qynh6m+2EOZA102MoqGzmrFFywjK6WtT/8/TbwW2ERVhOSF5FE+cu\nt3HrDCu++9NWqpITOqxICnDrjFh6+iQ7CsZnwoQtDEEFED/oc5x528dIKeullF3mj08Dc0Z7rrOw\n+WQl6RMCSYqwooFIwg0QEKNb99Dq6RMQwnAPWUzxVujthEyduoVOVOLhJliZMQa30ABeATB1hWrE\no8OEiYzYQBLCfMftjNgWhuAIkCyESBRCeAL3AZsGHyCEGPwNuhUoMr/fAWQLIULMQeJs8zan4vzl\nNk6WN7HWmtkAgMlNtSQs2aW6U+mM6CBvshJCzbOj8b3AxqbkvQ5BE9XCQp3R1y/ZfKqSxVMjRy4p\nMRIZd6qEifP7bSPOgQghWDNjAh+drae2pVNrOTbHakMgpewFHkb9gBcBr0kpC4QQvxBCDNTY/Y4Q\nokAIcRL4DvCA+dwG4JcoY3IE+IV5m1MxMApYPd1KQwDKV9rfA4VvW38tDbh15gTO1rVRVKW/7lOa\n0HYZzr6nunaZ9Lds5/C5Bmqau6wfBAEkL1elt3XrHppAv4RteePPPWSTb6aUcquUcqqUMklK+Zh5\n28+klJvM738kpUyXUs6QUt4spSwedO4zUsop5tezttBjS6SUvH2igqyEUCYE+1h/wZgZqo2lTh+G\nlRkxuJvEuJ0i25zCt1Stqcy7tVYyJjadrMDX041lqVHWX8zDR62hKNqk0ml1RnJUACnRAePyu6+/\nIYqDKaxq5mxdm3VB4sEIoYKGFw5Aa61trulAQv08uSE53HAPjZa8NyAiBaLStVZiMd29/WzNqyY7\nLQofTzfbXDTzLuhsUrMkHbJmxgSOXrhC+ZXxVZHUMAQjsOlkJe4mwapMKwJlV5N+G8h+NTLSIWum\nT6CisYNjFxu1luLcNFWolpQZd+my0uj+kjqaOnpsNwgCVWfJJ0S3M+I1ZvfweGvhahiCayClZGte\nFQunhI+u0uhoiUyD8KmqS5UOyU6PwtPdZGQPjcSAoc+4Q1sdY2RrXjWB3u7cMMWG6dpuHpC2VmVS\ndetvVD0xzJcZ8cFsHmedywxDcA0KKpu51NBBTuYQzemtQQhIu0237qEAbw+WTItkS14VfUbDmuEp\nfFsVXAtL0lqJxXT39rOrsJrladFD9+S2hoy7VIe2M/pdT5Nf0TyuWrgahuAabM2rws0kWJ5mY0MA\nKk6gY/dQzvQY6lq6xn153jHTXAUXD6rRrw45cPYyzZ29rLL1IAhg0kLVsEanmXMD2YNb88aPe8gw\nBMMw4BZaMDnMtm6hASJTde0eujklEi9307h6GGxK0WZA6tYQbMurwt/LnRuSR9GAxlJMbqr4Xsku\nXbqHooO8mT0xmG3jqCy7YQiGobi6hfP17ay0x4gIdJ895O/lzqKpEWzPrzb6GQ9F4dsQkQoRU7VW\nYjE9ff3sLKxhWWokXu42yha6mrS10NMOpe/a5/p2ZlWmKrdysV5/hmwoDEMwDNvyqjAJ1arRbqTp\nO3toVWY01c2dnCg3soc+RWutMvDpt2mtZEwcLKunsb3HtplyVzPpevAJ1a17aOB3YVv++JgRG4Zg\nGLbmVzM/MYxwfy/73SQyFcKn6dY9tDQ1Cg83wTbDPfRpijahZ7fQ1rwq/DzdWDTVjsUd3dwhdbXq\nZ9yjv5IN8aG+TI8LYus4cQ8ZhmAIztS0UFrbap9A2WCEUKPGCwegRX9NLwK9PbhhSjhb86qNxWWD\nKXxbxX8iUrRWYjG9ff3sKKhhSWoU3h52cgsNkLoWulugbI9972MnVmREc/JSIxXjoFmTYQiGYGte\nFcLebqEBdO4eWpkZQ0VjB/kVzVpLcQ7aLsP5D9RsQIeLyA6fa6ChrZtVGQ747icuUm1cC3X63TdX\nYx0PvbwNQzAE2/KqmTcplMixNuGwhIHsIZ0aguy0KNxNgq3jxFdqNcXvKMOeps/4wJa8Knw83Lhp\nWqT9b+buCdNWwekt0Ku/hi+J4X6kRAewfRx89w1DcBWlta2crmmxX7bQ1QgBKavh/AFdlqYO9vVk\nQVIY2/KqDPcQqHhPaJIuawv19avGK0tSIm1XW2gk0taq2kPn9jnmfjZmVWYMuReuUNusvzjHYAxD\ncBUD1t2qJhyWkrpGVag8s91x97QhKzNiOF/fTnG1i5embm9QP2g6dQsdOd/A5dZuxw2CACbfrEpT\nF+kze2hVZjRSovvOZYYhuIqtedXMmRRCdJAD3EIDTJgFgXHmRUj6Izs9CpPAyB4q3qIMuk6zhbbl\nVeHlbuJmR7iFBvDwhqm3QNE7uuxcNiUygCmR/mzVeY8CmxgCIcQKIcRpIUSpEOKRIfZ/TwhRaG5e\nv1sIMWnQvj4hxAnzS1NH+WVonfcAACAASURBVIX6NgqrmlnpiEDZYIRQddrPvgfdbY69tw0I9/ci\nKzF03KTSjZmiTRA8SfWc0Bn9/ZLtBdXcNC0CPy93x948bS10NKjsOR2yKiOaQ+fqqW/VX4+FAaw2\nBEIIN+AvwEogDVgnhEi76rDjwFxz8/oNwG8H7euQUs40v25FQ3YWqBROh2QLXU3qGtXXVscrLUtr\nWympcVH3UFcLlL2v/j/q0C10qqKJmuYubb77U5aBh69uF5etyIihX8LOQv2lgA9gixlBFlAqpSyT\nUnYDrwCfmhtLKfdIKQfWYh9ENal3OnYWVpMWE0h8qK/jbz5xgVppqVf3kLkwn54fBqsofRf6ulXg\nX4fsLKjGzSRYkuJAt9AAnr7KGBRvgf5+x9/fSlJjApgU5qvrOIEtDEEscGnQ53LztuH4MjC4/qy3\nECJXCHFQCDFszp0Q4iHzcbl1dXXWKR6Cy61d5F64Qna6DVryjQU3d5VKd2anLlPpooO8mREfzE4d\nPwxWUbwFfMMhXn8N6kEZ8PmJoQT72qHA4mhIWQ2t1VB5TJv7W4EQguy0KD4sraels0drOWPCocFi\nIcTngbnAfw3aPElKORe4H/iDEGLI4u1SyiellHOllHMjImy/9H13UQ1SfjKy1YTUNdDVBOf1mUqX\nnRbFyfImqpr0v9LSInq7lQGftlJV1tQZZXWtlNa2kp2m0SAIYGo2mNzVOgwdkp0eTXdfP3vP2H6Q\n6ghsYQgqgPhBn+PM2z6FEGIZ8GPgVinlx1EVKWWF+W8Z8D4wywaaLGZnQQ2xwT6kxgRocXvF5JvA\n01+37qEB//K7ruYeuvCBMuA6dQvtMv//Wq5FfGAAnxBIuEFlD+mQ2RNDCPf3/DjOqDdsYQiOAMlC\niEQhhCdwH/Cp7B8hxCzgbygjUDtoe4gQwsv8Phy4Hii0gSaLaOvqZX/pZbLToxBaBvo8vM2+0q3Q\n36edjjEyJdKfyRF+7NDpwzBmireAhx9MXqy1kjGxs7CGjNhAYoN9tBWSshrqS6DujLY6xoCbSbAs\nNYo9xbV09+ovzmG1IZBS9gIPAzuAIuA1KWWBEOIXQoiBLKD/AvyB169KE00FcoUQJ4E9wONSSocb\ngn1n6uju7dfWLTRA6hpoq4XyI1orGRPZadEcLKunqV2fvlKL6e9XhnvKUvDQ+Id0DNS2dHLs4hWW\npzrBd3/aSvVXt+6hKFq6evmorF5rKRZjkxiBlHKrlHKqlDJJSvmYedvPpJSbzO+XSSmjrk4TlVJ+\nKKXMlFLOMP/9uy30WMquwhqCfT2YlxCixe0/TXI2uHnq1j2UnR5Fb79kz2n9NdsZE1XHoaVSt26h\n3UW1KjamVZLEYILi1OLK4i1aKxkTC5PC8fV002XChMuvLO7p62d3cS1LU6Jwd3OCfw7vQEhcrAyB\nDmv3zIwLJiLAi52F+nsYxkTxFhBuKtipQ3YWVBMf6kNKtIaxscGk5EBFrur5rDO8Pdy4aVoEuwpr\ndNe1zwl++bTlyLkGmjp6nGNENEDqGmi8ADX5WiuxGJNJsDwtivdP19HZo784h8UUb4GE61WwU2e0\ndvVyoLSe7LRobWNjg0lZo/6e3qqtjjGSnRZNbUsXJ3XWtc/lDcHOwhq8PUwsSrZjNyZLmbYKhEm/\n7qG0KNq7+/jw7GWtpdiXy6VQV6xbt9C+M3V09/VrmzZ6NRHTVPVWncYJbp4WibtJ6G5hpUsbAikl\nOwuquTE5wnFld0eDfwTEX6fbVLoFSWH4e7nrNpVu1Az8WE1bpa2OMbKzoJpQP0/mTHKi2cxA3a1z\n+6BDX6NqgCBfD66bHKa7OIFLG4KCymYqmzqda0Q0QOpqqC2AhnNaK7EYL3c3bk6JZFdhDX0685Va\nRPEWVWAuOH7kY52MT2Jjkc4RGxtMymro79Vt3a3s9CjO1rVRWtuqtZRR42TfAMeys6Aak1BN2J2O\nlBz1V6cZFNlpUdS3dXPs4hWtpdiHlmqV4qtTt9ChsgZaOntZ7oyDoLi54BepW/fQMvPvyS4duYdc\n2xAU1jA3IZRQP43qq1yLkASIytStIbhpWgQebkJ3U+RRc3obID8x2DpjZ2E13h4mbnSm2NgAJje1\npqBkF/Tqr7TzhGAfpscF6SpzzmUNwUVzRy2ndAsNkJIDFz+CVv3VLwnw9mBhUjg7C2vGZwvL4i3K\nWEdeXXHd+ZFSsquwhkXOFhsbTOoa6G7VbQvL7LQojl9spEYnLSxd1hAMWGunWE08HCk5gIQz20Y8\n1BnJTo/iQn07Z2r04ysdFZ3NcG6vcgs5S9qlBeRXNFPV1Em2lrWFRiJxka7rbg382+rFPeTChqCG\nlOgAJoZp0HtgtERnQtBE3bqHlpt9pePOPfRx7wH9uoVMApZq0XtgtLh7QfJytZ5Ah3W3kiP9SQjz\n1U0aqUsagvrWLnLPNzj3iAjUaDN1NZzdozpg6YzIQG9mTQzWzcMwaoq3gG8YxM/XWsmY2FlQQ1Zi\nKCHOGBsbTMpqaKuD8lytlViMEILs9Gg+OnuZZh30KHBJQ7C7uJZ+iXPHBwZIyYG+LijdrbWSMZGd\nFk1eRRMVjeOkR0FvN5Tot/fA+cttnK5pcW6X6ADJy8HkAcU6dQ+lRdHTJ3n/tPPH+FzSEAz0Hkif\nEKi1lJGJv061sNSpe2igdMe46VFwfj90Nes2bfTj3gN6GAR5B0Hijeq7r8OEg1nmHgV6aGHpcoag\no7uPD0rrWJ6mce+B0fJxC8sd0Of8U8yrSYrwJynCT1epdNekeItqtD75Jq2VjImdhdWkatWXeyyk\n5EBDGdSd1lqJxQz0KNh7uo6uXueOc7icIdhXUkdnj5PVVxmJlBxzC8v9WisZE9np0Rwsa9B/j4L+\nfhW81GnvgcutXRy9cEVf3/2B8h2n9Tsjbu3q5aOzzt2jwOUMwc6CGoJ8PJiXGKq1lNGTdLMaherV\nPZQWRV+/5L3TOncPVR6HlirduoXeKzLHxpyp0u5IBE6A2Dm6/e4P9Chw9jRSmxgCIcQKIcRpIUSp\nEOKRIfZ7CSFeNe8/JIRIGLTvR+btp4UQt9hCz3D09vWzu7iGpSmReDhbfZVr4eGjRqHFW9WoVGfM\niAsmMsDL6R+GESl+R/UeSNZp74HCamKDfUiL0UFsbDDTVkHFUWiu1FqJxXh7uLF4qvP3KLD611AI\n4Qb8BVgJpAHrhBBXL7f8MnBFSjkFeAL4jfncNFSP43RgBfC/5uvZhSPnr9DY7mS9B0ZLymrVCavy\nuNZKLMZkEiwbDz0KTm+FSQvBV0ezSTNtXb3sK3GCvtxjYWAGptceBelRTt+jwBbD4iygVEpZJqXs\nBl4B1l51zFrgOfP7DcBSob6Na4FXpJRdUspzQKn5enZhZ2E1Xu4mFk11wvoqI5GcrUajOi3Epfse\nBfVndd17YH+JE/XltpSPexTo0z20ZFoUbk7eo8AWhiAWuDToc7l525DHmJvdNwFhozwXACHEQ0KI\nXCFEbl3d2PJyu3v7WZYaha+n+5jO1xTfUEi4QbcPg+57FAz8u6fotfeAE/XltpSPexTsh84mrdVY\nTJCvB/MTQ53aNaobR7mU8kkp5Vwp5dyIiLGN6B+7PZP/uX+WjZU5kJTVcPk0XC7RWonFeLmrfq7v\nFum0R0HxFlXyI3ii1kosptfce2CJM/YeGC0pq6G/R1Uk1SHZaVGU1rZyts45627Z4ltRAQzuzBFn\n3jbkMUIIdyAIqB/luTZFd/7RwQyMRvXqHkqP5nJrNycu6axHQWsdXDoE0/RZW+jweXNfbj26hQaI\nmwt+EbqdES938iJ0tjAER4BkIUSiEMITFfzddNUxm4D15vd3Ae9JVZt4E3CfOasoEUgGDttA0/gk\nKA4mzNLtw/BJjwLnfBiG5cx2VO8B/bqFVGwsXGspY0fnPQpig33IiA102gKMVhsCs8//YWAHUAS8\nJqUsEEL8Qghxq/mwvwNhQohS4HvAI+ZzC4DXgEJgO/AtKaWO00ocQEqO6ozVXKW1EosJ9Fb9XHcU\nVOurR0HxFgiKh+jpWiuxmIHeAzcmh+szNjaYlNXQ3aJiBTokOy2a45caqW1xvh4FNnEYSim3Simn\nSimTpJSPmbf9TEq5yfy+U0p5t5RyipQyS0pZNujcx8znTZNS6rPwviPRfSpdNOfr2/XTz7W7Dcr2\nqFx2HboVC6uaqWjs0LdbaIDExeDhp1vX6PK0KKSE3UW1Wkv5DDqNHLkwESm6TqX7uEeBk/pKP8PZ\nPdDbqd/eAwU1CAFLUp2498Bo8fCG5GWqTagOF1amRAcQH+rjlO4hwxDojY9T6fbpMpUuOsibGfE6\n6lFQvEVVwZy0UGslY2JXYQ1zJ4UQ7u+ltRTbkLIaWquh8pjWSixGCEF2WjQHSutp7erVWs6nMAyB\nHhkHqXQnLzVS3eR8vtJP0derAsXJt4Cbh9ZqLOZSQzuFVc3jwy00QPJy3S+s7O7rZ6+T9SgwDIEe\niZsHfpG6fRhuMZf42FXk5LOCSweho0G3biFd9R4YLT4hul5YOWdSCCG+HuxysrLshiHQIyaTSmXU\naSpdUoQ/ieF+Tukr/RTFW8HNUxX80yG7CmuYGuVPQrif1lJsS8pquHwG6s5orcRi3N1MLE2NYndx\nLT19zhPnMAyBXklZDd2tULZXayUWo3ylURwsq3fefq5Sqhr4k28CrwCt1VjMlbZuDp9vGF9uoQFS\ndN6jIC2Kls5eDpU1aC3lYwxDoFcSF4FngG7dQ9npTt7PtbYQrpz/pDGKznivuJa+fjm+3EIDBMVB\nzEw1Y9MhNyZH4O1hcqqufYYh0CvuXipwdnor9OtvDd7MeJXJ4rTuoYEfmWkrtdUxRnYV1hAd6E1m\nbJDWUuxDymq1sLLFSb8/18DH041FyapHgbMsrDQMgZ5JyYG2OvVA6Aw3k2B5WiTvO2s/19NbVFA+\nQH+ulc6ePvaeUX25TSb9LYIbFSmrAKnWFOiQ5WlRVDV1kl/RrLUUwDAE+iZ5OZg8dOseWp7mpP1c\nmypUAyCduoU+KLlMR0/f+HQLDRCZBiEJus0eWpoahUngNO4hwxDoGe8gmLwYit5RwU2d4bT9XAfK\nd+i0Cc2uwhoCvNy5bnKY1lLshxDq/8+5vdDVorUaiwn182ReQqjTFGA0DIHeScmBK+egtkhrJRbj\n7aF6FDhdP9fiLRA2BSKmaq3EYvr6Je8W1XBTSiSe7uP88U7Jgb5uKH1XayVjIjs9mtM1LVyob9Na\nimEIdM+0VYDQ7RQ5Oy3aufq5djbB+Q906xY6dvEK9W3dZI9nt9AA8fPBN0zH333zwkonmBEbhkDv\nBESroKZO4wQ3T4vE3Zn6uZbsUuU7dOwW8nAT3DRNh325LcXkBlNXwpmd0NuttRqLiQ/1JSU6wCnc\nQ4YhGA+k5EDVCWi8NPKxTkaQr+pR4DRppMVbVCesuLlaK7EYKSU7CqpZkBROgLf+aiONiZQc6GqC\nCx9orWRMZKdHk3uhgcut2lYIMAzBeEDnPQqWp0Vxtq5N+36uvV1qRjB1hRpt6oyS2lYu1Le7hlto\ngKSbwcNX1+6hfgnvadyjwCpDIIQIFULsEkKUmP+GDHHMTCHER0KIAiHEKSHEvYP2/UMIcU4IccL8\nmmmNHpclfIrqU6BT99ByZ/GVlu1VHbDS1mqrY4yMyyJzI+HhA0lL1AJAHWbOpU8IJDbYR3PXqLUz\ngkeA3VLKZGC3+fPVtANflFKmAyuAPwghggft/4GUcqb5dcJKPa5LSg6cPwDtzlO/ZLRMCPYhMzZI\ne/dQ0dvgFajKd+iQ7fnVzIgPJirQW2spjiVlNbRUqrUfOkMIwfK0KPaX1NHerV2PAmsNwVrgOfP7\n54Dbrj5ASnlGSllifl8J1AIuEMlyMCk5IPvgzA6tlYyJ7LQo1c+1WaMeBX29alQ59RZVvkNnlF9p\nJ6+iiZUZ+lsJbTVTbzH3KNCve6irt599Zy5rpsFaQxAlpRzool4NXHNOKoTIAjyBs4M2P2Z2GT0h\nhBj2CRRCPCSEyBVC5NbVOWmhMi2JmQUBE3TrHspOj0ZKeFcrX+nFD1XvgdRbtbm/lWzPV7MplzQE\nvqGqg5xODcG8xFCCfDw0XWU8oiEQQrwrhMgf4vUpR6pU1ZOGddIJIWKA54EvSSkHCnH/CEgB5gGh\nwA+HO19K+aSUcq6Ucm5EhDGh+Awmk5oVlO6G7nat1VjM1Ch/JoX5atewo3ATuPvotvfA9vxqUmMC\nmRQ2znoPjJaUHKgrgvqzIx/rZHi4mViaEsl7xbX0atSjYERDIKVcJqXMGOL1NlBj/oEf+KEfcjgn\nhAgEtgA/llIeHHTtKqnoAp4FsmzxH+WypORAbweU7dFaicUIIVieGqVNP9f+fjWTSl4Gnvr7Ia1t\n7uToxSuuORsYYGABoE5nBdnpUTS293Dk/BVN7m+ta2gTsN78fj3w9tUHCCE8gTeBf0opN1y1b8CI\nCFR8Id9KPa5Nwg2q/pBuH4Zobfq5VuRCS5Vu3UI7CqqR0kXdQgOETILoTN1+929MjsDT3cQOjRIm\nrDUEjwPLhRAlwDLzZ4QQc4UQT5uPuQdYBDwwRJroi0KIPCAPCAd+ZaUe18bNQ+XAn96mgp86Y86k\nEML8PNnu6IehaJOq4jr1Fsfe10Zsy69mcoQfUyL9tZaiLSmr4dIhaNU2J38s+Hm5syg5gu351ZrU\n3bLKEEgp66WUS6WUyWYXUoN5e66U8ivm9y9IKT0GpYh+nCYqpVwipcw0u5o+L6XUeEXROCAlRwU9\nL36ktRKLcTMJstOjea+ohs4eB/UokBKKNquWlN76a+LS0NbNoXMNrMyIRk2sXZjUNYBUhl2H5EyP\nprq5k+OXHF93y1hZPN5IWgpuXrqdIudkxtDWrRqrOITqPNWSMk2fbqFdhdX09UtWZsRoLUV7ItMg\nLBkKP+Oh1gVLU6PwdDOxNa9q5INtjGEIxhte/uaVllt0udLyusmhhPh6OO5hKNoMwqTbaqPb8quJ\nC/EhfUKg1lK0RwhIv01Vj23VX4p5oLcHNyaHsy2vyuHuIcMQjEdScqDpIlSf0lqJxbi7mbglPZrd\nRbWOcQ8VbYJJ14NfuP3vZWOaOno4UHrZcAsNJm0tyH4o3qy1kjGxKjOGyqZOh5dlNwzBeGTaSjXK\n1al7aFVmDK1dveyzt3uo7gzUFes2W2hPcS09fZIVhlvoE6IyIDQJCt7SWsmYWJYWhYebcLh7yDAE\n4xG/cJi4QLeGYEFSGMGOcA8NBBVTcux7HzuxLb+KqEAvZsUHj3ywq/Cxe2g/tGlXsmGsBPl4cMOU\ncLbmVSMd6No1DMF4JSUHavKhoUxrJRbj4WbilrRo3rW3e6jgTdXlKijWfvewE+3dvew9U8eK9GhM\nJsMt9CnSbjO7h/RZbmVVZgwVjR2cKm9y2D0NQzBeSV2j/up0irxqunIP7S+x06iu7owylOl32Of6\ndua94lo6e/oNt9BQRGdCSKJuv/vL06JwNznWPWQYgvFK8ETVwjJ/o9ZKxsTCpDCCfOzoHirYCAjd\n9h5452QVEQFeZCWGai3F+RhwD53bB231WquxmGBfT66fEs7W/CqHuYcMQzCeybgTavLU6FdneLiZ\nyE6L4t3CGrp6beweklIZyEnXQ6D+RtQtnT3sOV1LTmYMboZbaGjSblNl2XXqHsrJjOFSQwf5Fc0O\nuZ9hCMYzabcBwjz61R+rpsfQ0tXLB7Z2D9UWwuXTkHG7ba/rIN4tqqGrt581M/RnxBxGzAwISYBC\n/bqH3EyCLQ5yDxmGYDwTGKNGvfkbdbm47PqkcAK93W3/MORvVOm1qfp0C20+WUVssA+z4j/TGdZg\nACHUQKhsry679oX4ebIwKYxtDnIPGYZgvJNxuxr91hZqrcRiPN1NZKdHs8uW7iEp1QwpcRH466+v\nRWN7N/tL6siZHmNkC41E2lrlHirS7+KyC/XtFFTa3z1kGILxTupaNfrNf0NrJWMiZ3oMLZ29tmvj\nV3VSpdTqNFtoR0E1PX2S1dMNt9CITJgFoZMhf8PIxzohK9Kj8XATvH2iwu73MgzBeMc/AhIX69Y9\ndMOUcEL9PG33MBRsBJP7J+m1OuOdU1VMCvMlM1Z/lVIdjhCQeTec2w/Nji/kZi0hfp4snhrBppOV\n9Nm59pBhCFyBjDvgyjmoPK61EovxcDORkxnDu0U11ncuk1ItIpt8k+pzqzMut3ZxoPQyq6fHGLWF\nRkvm3YDUbcLErTNjqWnu4vA5+8Y5rDIEQohQIcQuIUSJ+e+Q0SshRN+gpjSbBm1PFEIcEkKUCiFe\nNXczM7A1KatV4xWdPgxrZ06gs6efndY2rKk4Bo0XdesW2pZfTb+ENTMmaC1FP4QnQ8xMyHtdayVj\nYllqJL6ebmw6aV/3kLUzgkeA3VLKZGC3+fNQdAxqSjO4wtdvgCeklFOAK8CXrdRjMBS+oao0dcFb\nqj+vzpgzKYS4EB/ePlFp3YXyXgc3T93WFtp8spIpkf5MiwrQWoq+yLxbzYYvl2qtxGJ8Pd3JToti\na1617dfTDMJaQ7AWeM78/jlU3+FRYe5TvAQYiORYdL6BhWTcCU2XVCs/nSGE4NYZE/ig9DKXW7vG\ndpG+XhU0nLoCfPRXpK2isYPD5xq4dcYEwy1kKRl3AEK3QeO1M2Np6uixXcLEEFhrCKKklANRmGog\napjjvIUQuUKIg0KIgR/7MKBRSjng+C0Hhq3+JYR4yHyN3Lo6/TWd0JyUHPDwhVOvaK1kTNw2K5a+\nfsmWU2MM+pXtgbY6mH6vbYU5iLeOK9fA7bP0VyBPcwInQMINakaox4SJZJUw8ZYds4dGNARCiHeF\nEPlDvD61GkeqVQ/D/StPklLOBe4H/iCESLJUqJTySSnlXCnl3IgI/eV/a46Xv8qUyX8Tejq1VmMx\nU6MCSIkOGPvDcPIV8AmB5GzbCnMAUkrePF7BvIQQ4kN9tZajTzLvhvpSqDqhtRKL+ThhotAGCRPD\nMKIhMDelzxji9TZQI4SIATD/rR3mGhXmv2XA+8AsoB4IFkK4mw+LA+yfMOvKzLgPuprgzHatlYyJ\n22bFcvxiIxfr2y07satF9WZIvwPc9ZePkF/RTGltK7fPitNain5Ju1XFh/L06h6aQFevDRImhsFa\n19AmYL35/XrgM12jhRAhQggv8/tw4Hqg0DyD2APcda3zDWxI4mIIiFGjYx0ykC1jcQZF4Sbo7dCt\nW+iNY+V4mkeFBmNkYDaY/wb0O6AFqo2ZPTGE2GAf3rI2YWIYrDUEjwPLhRAlwDLzZ4QQc4UQT5uP\nSQVyhRAnUT/8j0spB+od/BD4nhCiFBUz+LuVegyuhckNMu+C0l267N4UG+xDVkIoG49XWFZ/5dSr\nqj59fJb9xNmJnr5+Np+sZGlqJEG+HlrL0TfT74GWKhUv0hkmk2DtzAl8UFJHbYvtXbtWGQIpZb2U\ncqmUMtnsQmowb8+VUn7F/P5DKWWmlHKG+e/fB51fJqXMklJOkVLeLaUcY0qIwaiZsQ76e3VbcuLO\nObGU1bVx7OIom3s3Vai69NPvVStNdcb+kjrq27q5Y7bhFrKaqSvUzOD4i1orGRN3zI7jrjlx9PTZ\nPuBtrCx2NaLSISpTt+6hnOkT8PFwY8PRS6M7Ie91QKrRoA7ZeKyCEF8PFk81EiSsxt0LMu9R8aKO\nK1qrsZgpkf789q4ZxAb72PzahiFwRWbcB5XHdNmwxt/LnVWZMWw+WUV79wgZFFIqgxc3D8IsTlTT\nnObOHnYV1rBmxgQ83Y1H1SbM+hz0dek2aGwvjG+XK5J5t6pIevIlrZWMiXvmxtHa1cv2/BEyKMpz\noa4IZn3eMcJszDsnq+jq7TfWDtiSmBlqRnxCn999e2EYAlckIEplUJx4Cfp6tFZjMVmJoUwK8+W1\n3BHcQ8f/CR5+alW1Dnn1yEWmRQUwM15/K6Gdmpn3qxlxbZHWSpwGwxC4KrPXQ2sNnNmhtRKLEUJw\n95w4DpY1DL+moKsF8t6A9NvBS3+1eQormzlZ3sR9WfFGSQlbM/0eVYr8+AtaK3EaDEPgqiRng380\nHHtu5GOdkDtmxyEEwweNC96EnjaY/UXHCrMRrx65iKe7yXAL2QO/cJVBdOpVXc6I7YFhCFwVN3cV\nOCt9F5rKtVZjMROCfbgxOYINR8uHbtpx7HkIn6bLtQOdPX28ebyClRnRBPvqbyW0Lpj1eVV7qmSn\n1kqcAsMQuDKzvgCyX7d51ffMjaOyqZN9JVcVIawtgvLDajagQ7fKtvwqmjt7uXdevNZSxi9TlqtV\n9rnPaK3EKTAMgSsTmqi6dR1/XpfL7rPTogn39+TFgxc+vePY86oRz4z7tBFmJa8cvkRCmC8LJodp\nLWX84uau4mSlu1UPaxfHMASuzuwvqj4FZ/W37N7T3cR98yayu7iWSw3moHFPh0qLTVmlfME6o6yu\nlUPnGrhnnhEktjtz1qs06txntVaiOYYhcHVSVoNvmG6nyOvmT0QALx++qDbkv6FWjc77qqa6xsrz\nBy/gbhLcNccoKWF3AieoAcPxF3RZmt2WGIbA1XH3gjkPwJltcOW81mosJjbYh6WpUbx65BJdPb1w\n6G8QkaoakeiMtq5eNuSWsyozhsgAb63luAZzvwwdDVDo2oWPDUNgoB4GBBx5esRDnZEvXDeJ+rZu\nDu3fAdWnIOurugwSbzxWTktXL+sXJmgtxXVIXAxhU3T73bcVhiEwgKBY1b3s2PPQbWHTFyfghinh\nJIT5Ig4/CV6Buuw7IKXkuY8ukBkbxOyJxkpih2EywdwHVZZZ1Smt1WiGYQgMFPO/Bp2NkPea1kos\nxmQSfHWWH/M79lOffJdqy6kzDpTWU1rbyvqFCUaQ2NHMvF/18z70N62VaIZhCAwUExdAdKZ6GHTY\n4PtOuQtP0cff2pdoLWVM/OPD84T6ebJ6utGFzOH4hMDMz6mVxi32aQXp7FhlCIQQoUKIXUKIEvPf\nkCGOuVkIcWLQq1MIGuYrZQAAEV5JREFUcZt53z+EEOcG7ZtpjR4DKxAC5n8dagtVIxc90dOB9/G/\nUxK4kGeK3ahs7NBakUWcv9zG7uIa1mXF4+3hprUc1+S6b6iGTYef1FqJJlg7I3gE2C2lTAZ2mz9/\nCinlHinlTCnlTGAJ0A4MXtf9g4H9UsoTVuoxsIaMu8AvEg78QWsllnHiRWivJ2j595HAswfOaa3I\nIp7cX4aHm4n1CxK0luK6hCVB6mo48nfoatVajcOx1hCsBQaqlj0H3DbC8XcB26SU+otIugIe3rDg\nm3D2Pag8rrWa0dHfBx/+GWLnEJmxlJzMGF4+fInmTn0UE6tt6WTD0XLunB1HZKCRMqopC7+j4mQn\n9FlyxRqsNQRRUsoq8/tqIGqE4+8DXr5q22NCiFNCiCeEEF7DnSiEeEgIkSuEyK2rqxvuMANrmfug\nyrz5QCezgqJNav3D9f8CQvDQosm0dvXy8qGLWisbFc8eOE9PXz8PLZqstRSD+CyIy4KP/qLLkivW\nMKIhEEK8K4TIH+K1dvBxUkoJDBtlFELEAJnA4AL4PwJSgHlAKPDD4c6XUj4ppZwrpZwbEWH0b7Ub\n3kEw7ytqgc3lUq3VXBsp4cCfIHSyWiENZMQGsTApjGcOnKOr17kf5pbOHl44eIGVGdEkhvtpLccA\nYOG3ofEC5G/UWolDGdEQSCmXSSkzhni9DdSYf+AHfuhrr3Gpe4A3pZQfz9mllFVS0QU8C+ivZvB4\n5LpvqBXHH/5RayXXpnS36jS18Dtg+iTI+q2bp1DT3MWrR0bZ4F4jXjh4kZbOXr6+WH/9lMctKash\nMg32/salZgXWuoY2AevN79cD11qnvY6r3EKDjIhAxRfyrdRjYAv8I1W99hMvQ6OT/phKCXseg6CJ\nKvVvEAuTwpiXEMJf9pTS2eOcD3NLZw9P7jvL4qkRTI8zFpA5DSYTLP4h1Je41KzAWkPwOLBcCFEC\nLDN/RggxVwjx8ZptIUQCEA/sver8F4UQeUAeEA78yko9Brbihu+qlNK9v9FaydCc2aFmA4t/AO6f\nbt4ihOC7y6ZS09zFK4edM1bw7IHzXGnv4fvZU7WWYnA1qbeqWcG+37rMrMAqQyClrJdSLpVSJptd\nSA3m7blSyq8MOu68lDJWStl/1flLpJSZZlfT56WUrpe35awExalYwYkX4XKJ1mo+zcBsICQBZqwb\n8pAFSWFkJYbyv++fdbpZQVN7D0/tL2N5WpQxG3BGTCZY/O9w+YzLzAqMlcUGw3PD98DdR/3oOhPF\n76jicov+Hdw8hjxkYFZQ29LF8x9dGPIYrXhqfxktnb18b7kxG3BaUtdCZDrs+RX0dmmtxu4YhsBg\nePwj1LqCgjeh6qTWahS93bDrUQifOmJxuQVJYSyeGsGf3iuhoa3bQQKvTU1zJ88cOEfO9BhSYwK1\nlmMwHCYTZP9CpSYffkprNZ9gp/IvhiEwuDYLHla1WHb82DlqEB15GhrOQvavVLvBEfhJTirt3X38\n8d0zDhA3Mr/dfprePsm/3zJNaykGIzFlGSQtUbGC9gat1UB1Hjy91C5p3YYhMLg2PsGw5Cdwfr/2\nzTvaG2Dv4zD5ZkjOHtUpyVEBrMuK54VDFymt1TYEdaq8kTeOlfOlGxKYFGasG9AF2b+CrhbY91/a\n6pAStv0QGs6Bb6jNL28YAoORmfMliMqEnT/Rtl/BnsfUQ3nLYxY1nvnXZVPx9XDjV1sKkRrNaqSU\n/GJzIeH+njx88xRNNBiMgah0lZ58+CmoLdZOR/4bcOEALP2ZYQgMNMLkBit/o5rcf/CENhouHVYF\nweZ9VT2cFhDu78W/LEvm/dN1bMmrGvkEO/DKkUvkXrjCD26ZRoD30AFuAydl6aOqx8Xmf4H+/pGP\ntzUdjWoQFjMDZn/RLrcwDIHB6Ei4XgVnP/i98lU6kt5u9RAGToClPx3TJR5YmEBmbBA/31RIU7tj\nC9LVNHfy661FzE8M5e458Q69t4EN8I9QLqJLB+HYcyMfb2t2/RRaa2D1Hz61gt6WGIbAYPSseBx8\nQuGtb0KfA39MP/yj6pOQ89/gFTCmS7i7mXj8zkyutHfz2NZCGwscHiklP30rn+7efh6/czomk9F9\nTJfM/Bwk3Kgy1porHXffs3vg2D9VDaTY2Xa7jWEIDEaPbyis/r3K4d//e8fcs+IovP84pN8B01Za\ndan0CUE8tGgyr+WWs6PAMZ2o3jxewc7CGv512VSjsJyeEQLW/BH6e2DjQ45ZcdzZBJu/A2FT4KYf\n2fVWhiEwsIzUNZB5t8reObffvvfqaoE3vgL+0coA2YDvLptKZmwQ/77hFBV27mRWVtfKT97KJysx\nlK/emGjXexk4gLAkWPlblUF3wM4FGaWETd+Gpgq47a/g4WPX2xmGwMByVj8BoUmw4UFoqbHPPaSE\nTd9RC3rufEqtZbABnu4m/rxuFr19/fzLy8fp6bNP8K+ju4+HXzqOp7uJP943E3c341EbF8z6PKTf\nrjLYLh60332OPK3StZc9qvok2Bnj22lgOV4BcM8/obsVXn/APkvw9/8OCjbCkp/CpIU2vXRCuB+/\nviOT3AtX+Olb+TZPKe3vl3z/9RMUVTfz+3tmEBNk39GcgQMRQgVtgyfBK5+DK3YoX3J2z/9v78yD\npC6uOP75usshoByCyH3ERUUUBYKgJvFAQI2gAaMQAyoUlTLGM4kYE4+USUXjgZqI4lkSFRDRUGhA\nQFETUwSIyn0saGQ3IkcQKoiG4+WP7oWRw3V2hhl2fu9T9St+/X5dPf3mzfJ+3f26H0wdCSV9oOdP\nst/+PnBH4FSNph2h/x/go3eyP2e6YCK8fmeIUjr9+uy1m0L/k1pw9ZlHM27Oah55c1VW2/79a8t4\ndcEafnHucZx1bGVJ+5xqx6ENYPCEsF7w3CXZ3XW8dglMGBKOUBnwWDjqIge4I3CqTqcB0Ps3sPhl\neOWG7MRYL54cHEub0+CCB9PaOJYuN5zTgQs6N+euqUt58q/ZSXg/asZyRs9ayaDurRnu6wKFS+Oj\n4ftjw3EnYy+ErRszb3PdMnimf1gPGDwhZAvMEe4InMw49Wr41o0w72mYNDzE/FeV98eHdYcWXWHw\neKhxYJO5H3KIuPfizvQ9/ih+PWUxD88qrfI00c6dxt1TlzJqxgoGdm3JnRd2QgfQiTkHAe2/A5c8\nG97in+mfWVjpx/PhqfPC/ZDJ0CC3+03cETiZc/at0OuOsA3+mX4h0iEddmyDGbfDSyOgdQ+4bGKV\n9wukS83iQ3ho8Mn069ycu6cu45px7/HZ/7an1camrdu46tl/8vCslQzq3oq7BpxIke8XSAYdegdn\nsL4UxpwJq+ek38aCifBE75Ae9vJX4chjs9/PSsjIEUi6WNIiSTsldfuKen0lLZNUKmlkirydpNlR\nPl5Szf214RzknH4dDHgivNk8cloYIXyddYOyufB4r3B0RdfL4bJJOR0SA9QoCpE9P+tzDFPm/5u+\no97mzeXrKh0dmBnTFq2hz/1vMX3JJ/zy/OP47UUnuBNIGh16w/Dp4T/yJ/vA9FtD6HNlbCoP6wEv\nDoPmJ8GIWWHKKQ8ok4gJSccBO4FHgZ+a2dx91CkClgPnAGXAHGCQmS2WNAGYZGbjJD0CvG9moyv7\n3G7dutncuXt9lHMwsH5FOA7iX38LG2G+ORw69IFG7XfX2boRPngL3v0TrHgN6jaB8++Djv3y1+/I\n31du4JaXFrBq/Ra6tG7A4FPacMYxTWhcr9auOms3f86MJWsZN+cj5pdtouTIetxzcWc6t/JsY4lm\n60Z47Vfw7lio3QC6XRFCTZt22n00xPYvQtjpghdg/nhAcMZNcOo1+02ylE0kzTOzvV7aM3IEKY3P\nYv+OoCdwu5n1ieWKLXK/A9YBR5nZ9j3rfRXuCA5yzEIM9DsPQXm0U63Doc4RsO2zcG4KwGHNoNuV\n0OOqcKjXQcLn23YwYe5qHnt7Fav/EzadNaxTg3q1i9nyxY5dSW7aN6nLj779Db7XpYXvE3B2Uz4P\n3roXlv8FbCcU1YLDmoa/i83lQVZ8KHS+NETFNWyTs67tzxFUntkjc1oAq1PKZcApwBHAp2a2PUXe\nYn+NSBoBjABo3br1gempkx0kOP7CcK1fAatmwYZS2LIeatYJuYZbdg/7Aw7QIVqZULtGEUN6tuWH\nPdqwsHwz76xcz4cbPuPzbTuoXaOIkiPr0b1dI45vfrgvCDt706IrDHou/N5LZ8Ani+C/a8PfRf1W\n0OzEkPCm5sFz5EiljkDSDOCofTy6xcxylqnEzMYAYyCMCHL1uU6GNC4JVzVEEie0rM8JLXO7ZuEU\nCHUbh7f+akCljsDMemX4GeVAaixUyyjbADSQVBxHBRVyx3EcJ4fkYmJzDlASI4RqApcCky0sTrwB\nDIz1hgJ5zoXoOI6TPDINH71IUhnQE3hF0rQoby7pVYD4tn81MA1YAkwws0WxiZuAGySVEtYMnsik\nP47jOE76ZCVqKNd41JDjOE767C9qyGPeHMdxEo47AsdxnITjjsBxHCfhuCNwHMdJONVysVjSOqCq\nqYEaA+uz2J3qgOucDFznZJCJzm3MrMmewmrpCDJB0tx9rZoXMq5zMnCdk8GB0NmnhhzHcRKOOwLH\ncZyEk0RHMCbfHcgDrnMycJ2TQdZ1TtwageM4jvNlkjgicBzHcVJwR+A4jpNwEuUIJPWVtExSqaSR\n+e5PNpDUStIbkhZLWiTp2ihvJGm6pBXx34ZRLkkPxu9gvqQu+dWg6kgqkvSupCmx3E7S7Kjb+Hjs\nOZJqxXJpfN42n/2uKpIaSJooaamkJZJ6FrqdJV0ff9cLJT0vqXah2VnSk5LWSlqYIkvbrpKGxvor\nJA1Npw+JcQSSioA/AucCHYFBkjrmt1dZYTtwo5l1BHoAP456jQRmmlkJMDOWIehfEq8RwOjcdzlr\nXEs42ryCu4D7zexoYCMwLMqHARuj/P5YrzryADDVzI4FOhN0L1g7S2oBXAN0M7NOQBEhn0mh2flp\noO8esrTsKqkRcBshDXB34LYK5/G1MLNEXIScCdNSyjcDN+e7XwdAzz8D5wDLgGZR1gxYFu8fBQal\n1N9VrzpdhIx2M4GzgCmACLsti/e0NyEXRs94XxzrKd86pKlvfeCDPftdyHZmd77zRtFuU4A+hWhn\noC2wsKp2BQYBj6bIv1SvsisxIwJ2/6gqKIuygiEOhU8GZgNNzezj+GgN0DTeF8r3MAr4ObAzlo8A\nPrWQCAm+rNcunePzTbF+daIdsA54Kk6HPS6pLgVsZzMrB+4BPgI+JthtHoVt5wrStWtG9k6SIyho\nJNUDXgSuM7PNqc8svCIUTJywpO8Ca81sXr77kkOKgS7AaDM7GdjC7ukCoCDt3BDoT3CCzYG67D2F\nUvDkwq5JcgTlQKuUcssoq/ZIqkFwAs+a2aQo/kRSs/i8GbA2ygvhezgN6CfpQ2AcYXroAaCBpOJY\nJ1WvXTrH5/WBDbnscBYoA8rMbHYsTyQ4hkK2cy/gAzNbZ2bbgEkE2xeynStI164Z2TtJjmAOUBIj\nDmoSFp0m57lPGSNJhFzPS8zsvpRHk4GKyIGhhLWDCvmQGH3QA9iUMgStFpjZzWbW0szaEuz4upn9\nAHgDGBir7alzxXcxMNavVm/OZrYGWC3pmCg6G1hMAduZMCXUQ1Kd+Duv0Llg7ZxCunadBvSW1DCO\npHpH2dcj34skOV6QOQ9YDqwEbsl3f7Kk0+mEYeN84L14nUeYG50JrABmAI1ifRGip1YCCwgRGXnX\nIwP9zwCmxPv2wD+AUuAFoFaU147l0vi8fb77XUVdTwLmRlu/DDQsdDsDdwBLgYXAWKBWodkZeJ6w\nBrKNMPIbVhW7AldG3UuBK9Lpgx8x4TiOk3CSNDXkOI7j7AN3BI7jOAnHHYHjOE7CcUfgOI6TcNwR\nOI7jJBx3BI7jOAnHHYHjOE7C+T/DH/uANkYtegAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          }
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "iS8nRuBZYLcD",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 282
-        },
-        "outputId": "a22b17bc-df65-4531-9427-40d9ce834d38"
-      },
-      "source": [
-        "def clip_sin(x):\n",
-        "  x = clip_gradient(-0.75, 0.75, x)\n",
-        "  return jnp.sin(x)\n",
-        "\n",
-        "plt.plot(clip_sin(t))\n",
-        "plt.plot(vmap(grad(clip_sin))(t))"
-      ],
       "execution_count": 24,
       "outputs": [
         {
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "[<matplotlib.lines.Line2D at 0x7fe9862444e0>]"
+              "[<matplotlib.lines.Line2D at 0x7efe2c206b70>]"
             ]
           },
           "metadata": {
@@ -889,13 +781,61 @@
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0\ndHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOy9d3hU55n3/7lHvSAJFdRBAgQqCFFl\ng7sNMs1gYzs2TrI4G69Td7NJfrvrvMkm2WyyV5LdfZPNJvEbpziOE3c7BptiMBjj2KaIqgoIUdWR\nQAWh/vz+OCNHxsLS1DNn5vlc11yaOXNm5juaOXOf537u5/6KUgqNRqPRBC42swVoNBqNxlx0INBo\nNJoARwcCjUajCXB0INBoNJoARwcCjUajCXCCzRbgDImJiSorK8tsGRqNRmMpDhw4cEEplXT1dksG\ngqysLEpLS82WodFoNJZCRM6Mtl2nhjQajSbA0YFAo9FoAhwdCDQajSbA0YFAo9FoAhwdCDQajSbA\ncUsgEJHfiUiziJRf434RkZ+JSI2IHBWReSPuWy8iJ+yX9e7Qo9FoNJrx464Rwe+BZR9z/3Igx355\nFHgcQETige8A1wHFwHdEZKKbNGk0Go1mHLhlHYFSareIZH3MLmuAPyij5/UeEYkTkVTgVmC7UqoN\nQES2YwSUZ92hyx/oHxyior6Divp2LnX3IwJpsRHMmzyRyQmRZsvTaDyGUoqTLZcpq7tEY3svA4ND\nJMeEk5caQ0FaDDabmC3Rb/DWgrJ04NyI2+ft2661/SOIyKMYowkmT57sGZU+RFNHD7/eXcufD9XR\nerlv1H1yJkXzN4umcP+CTMJDgrysUKPxDFf6BvnjnjM8t/8sJ1suj7pPYnQYDyzMYP3iLCZNCPey\nQv/DMiuLlVJPAE8ALFiwwG/ddPoHh/jlWyd5/O0aBgYVS/OTWVGYypzMOCbFhDE4pDjb1s2ek628\ncqiOf91Qwa921/LduwpYkp9stnyNxiU2HW3g316roLmzl4VZE/nMDdkUZ8eTOTESmw0a23s4ePYi\nm8sa+eWuk/z+3dN8dekMHl6cRXCQrn1xFm8Fgjogc8TtDPu2Ooz00Mjtu7ykyeeov3SFL/zxAEfO\nt7Nydir/cmfuqOmf3JQYclNiWL84i/dPtvLd1yp45A+lrF80hf+zMo+wYD060FiLnv5B/s8rZbxy\nqI7ZGbH8/KF5FGfHf2S/KQlRTEmI4p65GdS2dPHvr1fy/U1VvFnVxM/WzdWjAycRd1lV2ucIXldK\nzRrlvpXAl4EVGBPDP1NKFdsniw8Aw1VEB4H5w3MG12LBggXK33oNlde187e/38+VvkF+dN9sVhSm\njvuxfQND/HhrNb/5yymuy47nN+sXMCE8xINqNRr30drVy9/9oZSDZy/xlTty+Pvbp4/77F4pxSsH\n6/jmq2VMjAzl6c9ex/RJ0R5WbF1E5IBSasHV291VPvos8D4wU0TOi8hnReTzIvJ5+y6bgVqgBvg1\n8EUA+w/+vwP77ZfvjRUE/JGDZy/ywK/eJyTIxktfWOxQEAAIDbbxrVX5/PSBORw4c5GHfr2Xi9eY\nV9BofIkLXb184lfvU1HfweOfnMdXl85wKMUjItw7P4OXv7CY/kHFA796n/K6dg8q9k/cNiLwJv40\nIqiob2fdE3uYGBXKC59bRHKMa0PbndVNfP6PBylIi+GZR64nIlSniTS+yaXuPtb9ei+nLnTx1GeK\nuW5qgkvPd+rCZT71m71c6R/klS8sJisxyk1K/QePjgg0ztHQfoWHn9xPdFgwf3rkOpeDAMDtucn8\n7MG5HDl3iS8/c5CBwSE3KNVo3Ev/4BCf/+MBTjZ38eu/WeByEADITozi6c8Wo5Ri/ZP7uNDV6wal\ngYEOBCbR0z/I558+QHfvAL//22IyJrpvTcCyWSn82+oCdlQ389/bj7vteTUad/G91yrZU9vGj+4r\n5Kacj/ikOM3UpGh++/BCmjp6+OKf9InQeNGBwCS+s6GCI+fb+ckDc5iRPMHtz//pRVmsK87k8V0n\n2V7Z5Pbn12ic5aUD53l6zxk+d/NU7pmb4fbnnzd5Iv9xTyH7TrXxX9v0idB40IHABLaWN/B86Tm+\neOs0SgpSPPY637mrgFnpMXz9hcM0tF/x2OtoNOPlbGs339lQznXZ8fzzslyPvc7aeRk8dN1k/t/b\nJ3nrWLPHXsdf0IHAyzR39PCNV8ooTI/lq0tnePS1wkOC+Pm6efQPKh57uQwrFgZo/IeBwSH+8flD\n2GzC/31gDkEebhHx7VX5zEyewGMvH6W9u9+jr2V1dCDwIkop/uXlo1zpH+QnD8whxAsrIbMSo3hs\neS5vH2/hhdJzYz9Ao/EQT7xTy8Gzl/j+3bNIj4vw+OuFhwTxX/cXcaGrj++9Xunx17MyOhB4kS3l\njbx1rIV/ujPXq4tePn39FK6fGs+/v15FY3uP115XoxnmbGs3//PmCZYVpLBmzqjtxDxCYUYsX7hl\nGi8fPM/Oaj1Xdi10IPASnT39/NtrFeSnxrB+0RSvvrbNJvz43iL6B4f4j81VXn1tjUYpxbc3lhNs\nE76zOt/rr//3d0xn+qRovruxkp7+Qa+/vhXQgcBL/GT7CZo7e/nBPbNMaY41OSGSz90yjY1H6tlT\n2+r119cELlvLG9l1rIWvlcwkNdbzKaGrCQsO4rt3FXC2rZtf7671+utbAR0IvEBNcxdPvX+aBxdO\nZu5k83x3vnDLNNLjIvjOhgpdX63xCr0Dg/xgcxW5KRO8PhIeyY05iSwrSOEXu2qov6Qr6K5GBwIv\n8OOt1YQH2/h6iWerhMYiIjSIf12Vx7GmTp7dryeONZ7n6ffPcP7iFb61Mt/0NtHfXJmHUvDDLdWm\n6vBFdCDwMKWn29hW2cTnb5lGYnSY2XK4syCFBVMm8r87TnClT+dLNZ6jvbuf/91Zw80zkrgxJ9Fs\nOWTGR/K3N2az8Ug9lfUdZsvxKXQg8CBKKf5jcxWTJoTx2ZuyzZYDGN0a/3lZLs2dvfz+vdNmy9H4\nMb/cVUNHTz+PeXDhmKN8/uZpxIQH81/bjpktxafQgcCDbKts4uDZS3xt6QwiQ33HDK44O55bZybx\n+K4avdBG4xEa23t48r3T3DM3nfy0GLPlfEBsZAifu2UaO6ubKT0dcB3vr4kOBB5CKcXPdpwgKyGS\n++a7v5+Kq/zTnTPp6BngV7tPmi1F44f8v7dPMjik+OoSc+fFRuMzN2SRGB3Gj7ce06vt7ehA4CF2\nVjdTUd/BF28bv9uSNylIi2Xl7FSeeu+0HhVo3EpzZw/P7jvL2rnpZMa7r6uuu4gMDebvb5/OvtNt\nvK9LqQH3OZQtE5FjIlIjIo+Ncv9PROSw/XJcRC6NuG9wxH0b3aHHbJRS/GxnDRkTI7hnrvdWUTrK\nl2+bzuW+QZ56/7TZUjR+xK931zIwpPjy7dPNlnJNHliYSWJ0GI/v0iNicEMgEJEg4BfAciAfWCci\nH1o+qJT6qlJqjlJqDvC/wCsj7r4yfJ9SarWrenyBd05c4Mi5S3zx1ule6SfkLHmpMdyRO4nfvXuK\ny70DZsvR+AEXunr5456zrJmTxpQE33UICw8J4pGbsj84VgMdd8xgFgM1SqlaABF5DlgDXKvL0zrg\nO254XcfZ8i9wdo9nnrvgbrjxqwD8fGcNqbHh3Dvfd0cDw3zxtunc+/h7PLvvLI/cNNVsOZq6A/DG\nt6C/27gtIzt0ipPbRtzn8Dauvd/w7QlpsPpnEBTCk++eomdgkC/d5rujgWE+ed1kfvlWDb/cVcOv\nPv0R98aAwh2BIB0YuTrpPHDdaDuKyBQgG9g5YnO4iJQCA8APlVKvXuOxjwKPAkyePNk5peFxEJ3s\n3GM/jvZzsPMHULCWw12x7DvdxrdW5hEW7Pt+wfOnTGTR1ASe2F3LpxdNsYRmv0Up2PR1aDkOWTcC\n6sP3GVeuve1DE5/j3fYxzzWe1xzogdpdkLOE7hlr+OOes9yZn8K0JO81VXSWCeEhPLw4i5/trOFE\nUyc5HjCIsgrerml8EHhJKTVyJdMUpVSdiEwFdopImVLqI4k7pdQTwBNgmNc79eq3fcOph41Jex38\nz2zY8zi/vfQAE8KCeWBhpmdeywN88bZpfPq3+9h4uJ77F1hHt99xdg/UH4KV/w0LHzFbzfgYGoKf\nL4D3f8HLHfNov9LP393sG2tmxsPDN2Tz63dO8cTuWv7z/iKz5ZiGOxLYdcDIX48M+7bReBB4duQG\npVSd/W8tsAuY6wZN3iU2HQrWMnToaXaXneTB4kwmhIeYrWrc3Dg9kRnJ0Tz57mldTmcme34BEROh\naJ3ZSsaPzQbXfwHqDrBn91bmZMYxz8R+Wo4SHxXK2nnpbDhST2sAm927IxDsB3JEJFtEQjF+7D9S\n/SMiucBE4P0R2yaKSJj9eiJwA9eeW/Btrv88tr4u7rO9zfrFWWarcQgR4TM3ZFPZ0MG+U3qRjSm0\nnYLqTTD/MxDqu5OsozLnIfpDY1l5+RUeuSkbGW1+wYd5eHEWfQNDPLvvrNlSTMPlQKCUGgC+DLwB\nVAEvKKUqROR7IjKyCuhB4Dn14VPOPKBURI4Ab2HMEVgyEHQlFnFIzeTzEW+SEWt+TyFHuXtOOnGR\nITz57mmzpQQme38FEgTFj5qtxHFCo3g95E7uDCplWZr1zqpzkidwU04iT+85Q3+AduV1S22jUmqz\nUmqGUmqaUuoH9m3fVkptHLHPd5VSj131uPeUUoVKqSL739+6Q48ZvFh6jt/030lSfz0cf8NsOQ4T\nERrEQ8WT2VbZyLm2brPlBBY9HXDoaZi1FmJSzVbjMOV17fyw9WZEbASXPmG2HKf4zA1ZNHX0srms\nwWwppuC7Re4WQinF03vO0Ji+FGIyYO/jZktyik8vmoKI8If3T5stJbAoewH6uqD4c2YrcYo/7jlD\nR0gSA7mr4dCfoO+y2ZIc5tYZk8hOjArYEbEOBG5gT20btS2XWXf9VCh+BE7thmbrWUKmxkawfFYK\nz+0/p1tUewulYP/vILUI0ueZrcZhOnr62XC4ntVFaYRe/yj0tkP5K2M/0Mew2YT1i6Zw+NwlDgfg\nAjMdCNzAn/aeISY8mFWzU2HOp8AWAgeeMluWU3zq+il09gywKUCHyF7n3D5oroAFnx19EZeP8+qh\nOq70D/LJ6yfD5OshKQ9Kf2e2LKe4d34GESFBPLs38CaNdSBwkZbOXt6oaOS++ZmEhwRBdBLk3QVH\nnoV+61niXZcdz9SkqICuoPAqpb+DsBiYda/ZShxGKcUf95xhdkYsszPijEC24G+h/qCxHsJiTAgP\nYXVRGhuP1NPZE1iNGHUgcJEXD5yjf1Dx0HUjVjvPfxh6LkGl9XroiQgPFU/mwJmLHGvsNFuOf9Pd\nBhV/htkPQJjvr8S9mtIzFzne1MUnR373ix6AkEjLjgrWXTeZK/2DbDhcb7YUr6IDgQsMDSme2XuW\n66fGM33SiAM56yaInwoHnjRPnAusnZdBaJBNjwo8zeE/wWCvcRZtQf605wwTwoO5qyjtrxvDY6Hw\nPih7CXrazRPnJEUZseSlxvDM3rMBtbhSBwIX2H2ihfMXr/DJ66Z8+A6bDeath7PvQ7P1jLLjo0JZ\nNiuFVw6ep6dfTxp7hKEhKH0SJi+C5Pyx9/cx2i73sbmskXvnZXzUfW/B3xpN846+YI44FzBGxJlU\nNnRQVme9QOYsOhC4wHP7zpEQFcqdBSkfvXPOJ41J44PWnDReVzyZjp4BNh3Vk8Ye4ex70HbSSCNa\nkD8fqqNvcIh1xaM0gEybCymzjbURFmTN3HTCQwJrRKwDgZO0Xe5jR3UT98xNJzR4lH9jdBLkrYLD\nz0B/j/cFusj1U+OZmhjFMwF0MHiVw89A6ATIs6YFx0sHzlOUEcvMlGt07Jz7KWg4Ao3l3hXmBmLC\nQ7hrdhobDtfTFSA+HToQOMnGw3X0Dyru/Tg/4nl/Y0waH9vsPWFuQkR4YGEmB85cpLaly2w5/kVv\nF1S8CrPugVDfs3Ici4r6dqoaOj7ei7vwfggKNeZBLMiDxZPp7htk09HAmDTWgcBJXjp4nlnpMeSl\nxlx7p+xbDNOOI89eex8f5p656dgEXjl4rWayGqeo2gj9l430oQV56cB5QoNsrC76GOOlyHiYuRyO\nPg8Dfd4T5ybmTY5jamIULwfId18HAieoauigvK6D++Z9zBkRgC3IKKer2QGdTd4R50YmxYRzU04S\nfz5Ux9BQ4FRQeJzDz0D8NMgc1b/Jp+kbGGLD4XqWFiQTGzlGq/U5n4TuVjixzTvi3IiIcO/8DPad\naguI3ls6EDjBywfOExIkrJ4zDivKonWgBqHsRc8L8wBr56VTd+kKe061mi3FP2g7BaffgTkPWXIl\n8c7qZtou9318WmiYaXcYjoAWTQ/dPTcdCZARsQ4EDtI/OMSrh+u4IzeZ+KjQsR+QNBPS5sGR5zwv\nzgPcWZDChLBgXj7g/weDVzjyHCBQ9KDZSpzipQPnmTQhjJumJ469c1CwsVju+BvQ1ex5cW4mPS6C\nRVMTeOXQeb9fU6ADgYO8fayFC13jPCMaZs5D0FQGjWWeE+YhwkOCWDk7lS3lDXT3BUYFhccYGoIj\nz8DUWyHWge+Pj9DS2ctbx5q5Z146wUHj/OmY+yljRHz0ec+K8xBr52VwprWbA2cumi3Fo+hA4CAv\nHThPYnQot8xMGv+DZt1rrCmw6Khg7bwMuvsG2VreaLYUa3PmXbh01rKTxBsO1zE4pMaeGxvJ8IjY\ngovLAJbNSiEiJMjvJ43dEghEZJmIHBORGhF5bJT7HxaRFhE5bL88MuK+9SJywn5Z7w49nqK9u58d\n1U2smZNOyHjPiMBeQbHMOBgGrXdWvTBrIpnxEbx88LzZUqzN0echNBpyV5qtxClePVzH7IxYcpKv\nsXbgWsz+BDQehZZjnhHmQaLDglk+K4XXj9b79Sp7lwOBiAQBvwCWA/nAOhEZbc3880qpOfbLb+yP\njQe+A1wHFAPfERGfdb7eUt5A/6Di7vFMEl9N0Tq43Awnd7hfmIcREdbOzeC9k63UX7JeR1WfYKDX\naEKYd5cl1w7UNHdRXtfBGme++wVrQWwWLpjIoLNngDerrFf5N17cMSIoBmqUUrVKqT7gOWDNOB97\nJ7BdKdWmlLoIbAeWuUGTR9hwuJ7sxChmpX/M2oFrkVMCEfEWPhjSUQpeOxIYC2zczonthmnLrPvM\nVuIUG4/UI4LhueEoE5KNNTVlLxpGPBZj0bQEUmPD+bMfp4fcEQjSgXMjbp+3b7uae0XkqIi8JCKZ\nDj4WEXlUREpFpLSlpcUNsh2jqaOHPadaWV2UhjhT9hcUAvlroHoz9FmvLnlKQhRFmXFs1IHAOcpf\ngshEmHqL2UocRinFa0fqWTQ1geSYcOeepPB+uHgazpe6VZs3CLIJq2ansvtEC5e6rbc4bjx4a7L4\nNSBLKTUb46zf4U5sSqknlFILlFILkpIcmKh1E68dqUcpWD0nbeydr8Wse40Vpce3uk+YF7lrdioV\n9R2c1C0nHKO3E45tgYJ7jBMCi1FW186pC5dZXeTCdz/vLggKM/yZLcjqonT6BxVvVPhnwYQ7AkEd\nkDnidoZ92wcopVqVUr32m78B5o/3sb7Ca0fqKUiLYVqSCwYiUxZDdAqUv+w+YV5k1ew0RHR6yGGq\nN8NAj9Gn34JsPFxPSJCwfJYTaaFhwmOMgonyVyxZMDErPYashEi/HRG7IxDsB3JEJFtEQoEHgQ9Z\nc4nIyG/QamDY2f0NoEREJtoniUvs23yK0xcuc+R8O2tcGQ2A0XJi1lpjyb0FTTtSYsMpzoq3j46s\nl+s1jbIXIXYyZBSbrcRhBocUrx2t55YZk8ZuKTEWhZ+A7gtwapdbtHkTEeGuojTeP9lKc6f1ugmP\nhcuBQCk1AHwZ4we8CnhBKVUhIt8TkeEeu/8gIhUicgT4B+Bh+2PbgH/HCCb7ge/Zt/kUw2cBq2a7\nGAjASA8N9kHV664/lwmsnpPGyZbLVDVoG8txcfkCnNxpnADYrLdsZ9+pNpo6el0/CQLIWWo4mB21\nZsHE6qI0hhRsKfO/9JBbvplKqc1KqRlKqWlKqR/Yt31bKbXRfv0bSqkCpVSRUuo2pVT1iMf+Tik1\n3X7xOW9HpRQbDtdRnBVPWlyE60+YPh/iplg2PbR8VirBNvHbIbLbqXzVWFlbeL/ZSpxi45E6IkOD\nWJKX7PqTBYfZCyZeh37rlSHnJE8gN2WCX373rXeK4mUqGzo42XLZtUnikYgYo4LaXcbZosWIjwrl\nxpxEnR4aL2UvQ1IuJBeYrcRh+gaG2FzWSEl+MhGhQe550oJ7oK8Lat50z/N5mbuK0jhw5iLnL1qv\n8u/j0IFgDDYeqSfYJqwodGGi7Gpm3WucJVa+6r7n9CJ3zU6j7tIVDp69ZLYU36a9zrCknHWfJTuN\nvnOihfYr/e47CQLIutlYT1Nh3e8+4HcWrjoQfAxKKTaXNbB4euL4Oo2Ol+QC4yyx/BX3PacXKSlI\nJjTYpquHxqLKXjMxa625Opxkc1kjMeHB3DjdjeXaQcFGKenxrZZMD01OiKQoM47X/My5TAeCj6Gi\nvoNzbVdYWTiKOb0rDKeHzrxrnDVajAnhIdw+cxKbyhoY1IY116ZyAyQXQsI0s5U4TN/AENsrG1ma\nnzK6J7crFNxt7fTQ7FTK6zr8ysJVB4KPYXNZA0E2YWm+mwMBGLlSMCbOLMjK2am0dPb6fXtep+lo\ngLN7jMlRC/LuyQt09Aywwt0nQWD59NBw9eDmMv9JD+lAcA2G00KLpia4Ny00TGIOTMo3zhotyG25\nkwgLtvnVweBWql4DlGUDwZayBqLDgrkxZxwGNI5i8fRQSmw48ybHscWP2rLrQHANqhs7Od3azXJP\nnBENk78GzrxnST/j6LBgbp6RxNbyRu1nPBqVGyApD5JmmK3EYfoHh9hW2cSSvEmEBbupWuhqLJ4e\nWlFotFs52+of1UM6EFyDLWUN2MSwavQYeasBZdn00IrCFBo7ejh8XlcPfYiuZmP+p+Bus5U4xZ7a\nVi5197u3Uu5qLJ4eGv5d2FLuHyNiHQiuwebyRq7LTiAxOsxzLzIpDxJyLJseuiMvmZAgYYtOD32Y\nqo1YOS20uayBqNAgbp7hweaOFk8PZcZHMjsjls1+kh7SgWAUjjd1UtPc5ZmJspGIGD8Wp/9iycVl\nMeEh3Dg9kc1ljXpx2UgqN0DiDKNE2GIMDA7xRkUTt+clEx7iobTQMBZPDy2blcKRc5eo8wOzJh0I\nRmFzWQPi6bTQMPlrjMVl1Zs8/1oeYHlhKnWXrlBe12G2FN/g8gUjsOevseQisn2n2mi73MeKWV74\n7ls8PTTcjdUfvLx1IBiFLWWNLJwSzyRnTTgcIaUQJmb9dfGRxSjJTybYJmz2k1ypy1S/DmoI8q05\nP7CprIGIkCBunTnJ8y/2ofSQ9Tp6ZidGkZsyga1+8N3XgeAqapq7ONbU6dlqoZEMp4dqd8EV69Xk\nx0WGsmhaAlvKGnR6CIyz2/hpluwtNDhkGK/cnjvJfb2FxiJvtZEeOvW2d17PzawoTKX0zEWaO6wX\nyEaiA8FVDEd3l0w4HCV/DQwNGC5WFmT5rFROt3ZT3Rjgram72+DUbsumhfafbuNCV5/3ToIAsm+G\nsBjLjohXFKagFJZ3LtOB4Co2lzUyf8pEUmK9kBYaJm0exGZCpTUPhpKCZGyCrh6q3mTM91i0WmhL\nWQNhwTZu80ZaaJjgUMgpMU6CLOhcNn3SBKZPimazxT0K3BIIRGSZiBwTkRoReWyU+78mIpV28/od\nIjJlxH2DInLYfjH1l/BM62UqGzpY7o2JspGIGEPkkzugx3qTronRYRRnx/tNKZ3TVG00vCZSi8xW\n4jBDQ4qtFY3cOjOJqLBg77543l3Q3Qrn9nj3dd3Eilkp7D3VSmtX79g7+yguBwIRCQJ+ASwH8oF1\nIpJ/1W6HgAV28/qXgB+PuO+KUmqO/bIaE9lWYazw9Uq10NXkrzGcy477nFPnuFhRmEpNcxcnmgI0\nPdTbaczz5N1lybTQ0bp2mjp6zfnuT19iGNtb1LVv2axUhhRsq7Reh4Bh3DEiKAZqlFK1Sqk+4Dng\nQ2NjpdRbSqnhtdh7MEzqfY5tlY3kp8aQGR/p/RfPWAjRyZZdZVxib8xn5YPBJWreNAJ57iqzlTjF\ntopGgmzC7bleTAsNExYN0263V1xZr+AgL3UCUxIiLT1P4I5AkA6cG3H7vH3btfgsMHJWNFxESkVk\nj4hcs+ZORB6171fa0tLimuJRuNDVS+mZi5QUuMGSzxlsNpi5wvhBsWApXUpsOEWZcWyz8MHgEtWb\nIDIRMq1nUA9GAL8uO564SA80WBwPeaug/Rw0HDbn9V1ARCjJT+a9mlY6e/rNluMUXp0sFpFPAQuA\n/xyxeYpSagHwEPBTERm1ebtS6gml1AKl1IKkJPcvfd9R1YRSfz2zNYXcVfZSut3maXCBkvxkjpxv\np6Hd+istHWKgD45vg5nLwealsks3UtvSRU1zFyX5Jp0EAcxYDhJk2fRQSUEKfYNDvH3c/Sep3sAd\ngaAOyBxxO8O+7UOIyBLgm8BqpdQHsypKqTr731pgFzDXDZocZltFE+lxEeSlTjDj5Q2GS+mqXzNP\ngwsM55ffDLT00Jm/QG+7ZdNC2+2f11Iz5geGiUqAKYstmxqdN3kiidGhH8wzWg13BIL9QI6IZItI\nKPAg8KHqHxGZC/wKIwg0j9g+UUTC7NcTgRuASjdocojLvQO8U3OBkoJkxMyJvuBQyFlqlNINDZqn\nw0mmT4pmalIUb1j0YHCa6k0QEgVTbzFbiVNsq2xiVnoM6XER5grJuwtaquHCCXN1OEGQTViSl8xb\n1c30DQyZLcdhXA4ESqkB4MvAG0AV8IJSqkJEviciw1VA/wlEAy9eVSaaB5SKyBHgLeCHSimvB4Ld\nx1voGxgyNy00TO5KuNwC5/ebrcQpSvJT2FPbSnu3NXOlDjM0BNWbYfodEGLyD6kTNHf2cPDsRZbm\n+ch3H+ymPtajpCCZzt4B3q9tNVuKw7hljkAptVkpNUMpNU0p9QP7tm8rpTbary9RSiVfXSaqlHpP\nKVWolCqy//2tO/Q4yvbKJuNb1wYAACAASURBVOIiQ1iYNdGMl/8w05eCLcSyQ+SSgmQGhhRvHWse\ne2d/oOEQdNZbNi20o6rZmBszq0hiJLEZxuJKi373F09LJDI0yJIFEwG/srh/cIgd1c3ckZtMcJAP\n/DvCY4wUQ5U1S+nmZMSRNCGMbZXWOxiconqTMck5o8RsJU6xraKRzPgIclNMnBsbSd4qqDsA7R+Z\nZvR5wkOCuHVmEtsrmyzn2ucDv3zmsv9UG+1X+n3jjGiY3JVw8RQ0V5mtxGFsNmFpfjK7jrXQ02+9\neQ6Hqd4EWTdAhA+MJh2kq3eAd2taKclPMXdubCS5dxl/LdqWvSQ/hebOXo5YzLUv4APBtsomwkNs\n3JzjQTcmR5m5AhALHwzJdPcN8t5J65ntOMSFGmNy06Jpod3HW+gbHDK3bPRqkmZA4kzLVs7dNnMS\nwTax3MLKgA4ESim2VTRyU06S99rujocJKcZKY4vmShdNSyA6LNiypXTjZvjzmbnCXB1Osq2ikfio\nUOZP8bHRTN4qOP2u0c3VYsRGhnD91ATLzRMEdCCoqO+gvr3Ht86IhsldaayybD9vthKHCQsO4rbc\nSWyvbGLQYrlSh6jeZDSYi8sce18f469zY5N8Y25sJLmrjC6uFu27VVKQzMmWy9Q0d5ktZdz42DfA\nu2yraMQmhgm7zzGcbqjebK4OJynJT6b1ch8Hz1rPbGdcdDYaJb4WTQvtrW2js2eApb54EpQ2Fyak\nWXZEvMT+e7LdQumhwA4ElU0syIonPsqk/iofR+J0S+dKb52ZREiQWG6IPG6ObQHUX2vfLca2ykbC\nQ2zc5EtzY8OIGP/Xmh3Q1z32/j5GWlwEszNiLVU5F7CB4KzdUcsn00LD5K60bK50QngIi6clsq2y\nyT8tLKs3GV7Tk67uuO77KKXYXtnEzb42NzaSvFUwcAVq3zJbiVOU5Cdz6OwlmixiYRmwgWA4WvvE\nauJrMZwrPbHNbCVOUVKQzJnWbo43WSdXOi56OgyP3dxVlvQeKK/roKG9hxIzewuNxZQbIDzWupVz\n9v+tVdJDARwImshNmcDkBBO8B8ZL2lyYkGrZXOlSe67U79JDH3gPWDctZBO4wwzvgfESFAIzllnW\nwjJnUjRZCZGWKSMNyEDQ2tVL6ek23z4jghEeBTug33qtnSfFhDN3cpxlDoZxU70JIhMg8zqzlTjF\ntoomirPjmeiLc2MjyV0JV9rg7PtmK3EYEaGkIIX3T16gwwIeBQEZCHZUNzOk8O35gWHyVkF/N5y0\naq40hbK6duouWS+QjcpAn5Gqs6j3wOkLlznW1OnbKdFhpi+B4HDrpofyk+kfVOw65vseBQEZCIa9\nBwrSYsyWMjZTbjQ8Co5Z9GCwt+7wG4+C0+9Ab4dly0Y/8B6wwklQaBRMvc0IBBYsOJhr9yiwgoVl\nwAWCK32D/KWmhaX5JnsPjJfgUMgpsaxHwbSkaKYlRVmqlO5jqd4EIZEw9VazlTjFtspG8szy5XaG\n3JXQfhYay8xW4jDDHgVvH2uhd8C3j92ACwS7T7TQ0+9j/VXGIncldLfCub1mK3GKkoIU9tS2Wd+j\nYGgIjlnXe+BCVy8Hzly01nd/5nIQm2ULJkoKkunqHeD9k77tURBwgWBbRROxESEszI43W8r4mb4E\ngkItnSsdHFLsPGbx9FD9IehssGxaaGeVfW7MlzrtjkVUIkxeZNnv/rBHga+XkbolEIjIMhE5JiI1\nIvLYKPeHicjz9vv3ikjWiPu+Yd9+TETudIeeazEwOMSO6ibuyJ1EiK/1V/k4wmMg+xbL5kqLMuKY\nNCHM5w+GMal+3fAeyLGo90BlI+lxEeSnWmBubCS5K6GpHNpOma3EYcJDgrhlhu97FLj8aygiQcAv\ngOVAPrBORK5ebvlZ4KJSajrwE+BH9sfmY3gcFwDLgF/an88j7D99kUvdPuY9MF5yV1jao2CJP3gU\nHNtsGKxHWmg0aedy7wC7T/iAL7czDHd3PWbRvlsFyT7vUeCO0+JioEYpVauU6gOeA9Zctc8a4Cn7\n9ZeAO8T4Nq4BnlNK9SqlTgE19ufzCNsqGwkLtnHzDB/srzIWwweDRYfIlvcoaD1pae+Bd074kC+3\no8RnQ/Isw7XPgtw+M5kgH/cocEcgSAfOjbh93r5t1H3sZvftQMI4HwuAiDwqIqUiUtrS4lxdbt/A\nEEvykokMDXbq8aaiPQrMZTgA51rVe8CHfLmdIXcVnNsDXb5fk381sZEhXJcd79OpUcskypVSTyil\nFiilFiQlOXdG/4N7Cvn5Q3PdrMyLWNyj4NaZSbxZZVGPgupNkFIIcZPNVuIwA3bvgdt90XtgvOSu\nBDUEx7earcQpSvKTqWnu4mSLb/bdcse3og4Y6cyRYd826j4iEgzEAq3jfKxbsVx+dCQz7b1tjm0x\nV4eTlBSkcKGrj8PnLOZR0NVilO7OtGZvoX2n7b7cVkwLDZNSCLGTLZsaXerjTejcEQj2Azkiki0i\noRiTvxuv2mcjsN5+/T5gpzJ6E28EHrRXFWUDOcA+N2jyT5JmQEKOZdNDf/Uo8M2D4Zoc34rhPWDd\ntJAxN5ZothTnGfYoOLkTen3zrPrjSI+LYFZ6jM82YHQ5ENhz/l8G3gCqgBeUUhUi8j0RWW3f7bdA\ngojUAF8DHrM/tgJ4AagEtgJfUkpZuKzEC+SuhNN/gSsWO6sGYsINP9c3Khqt5VFQvQliMyFlttlK\nHGbYe+CmnERrzo2NJG8VDPbCyR1mK3GKkvwUDp27RHOn73kUuCVhqJTarJSaoZSappT6gX3bt5VS\nG+3Xe5RS9yulpiulipVStSMe+wP742YqpayZ8/AmuatgaABObDdbiVOUFKRwurXbOn6ufZcNc5SZ\nKyzpPVDZ0EHdpSvWTgsNk3k9RMRbNz2Un4xSsKOq2WwpH8GiM0cBTPp8iE627sEw7FHgo7nSj3Dy\nLRjosa73QEUTInB7ng97D4yXoGCj5cTxrTBovXYluSkTyIyP8Mn0kA4EVsNmMw6Gmjeh3/eGmGOR\nEhtOUaaFPAqqNxlOWVMWm63EKbZXNrFgykQSo8PMluIecldCT7uRHrUYIkJJfgrv1rTS1etbZjs6\nEFiR3FXQ1wWndputxClK8pM5cu4Sje0+HsgGB4yzz5w7Dccsi3GurZvKhg7/SAsNM+12o/urRUfE\nJfnJ9A0O8baPeRToQGBFsm+G0GjLVg/daW/xsb3Kx0cF5/YYDlkWTQtZyntgvIREGMHAon235k+Z\nyMTIELb7WFt2HQisSHAY5Cy1exQMma3GYaYlRZOdGOWTudIPUb3Z6Po6/Q6zlTjF9somZiRHk5UY\nZbYU95K7Cjrrof6g2UocJjjIxh15yeyobqZ/0HeOXR0IrEruKrjcDHWlZitxGCNXmsye2lbf9XNV\nynCFm3orhE0wW43DXLzcx77Tbf6VFhpmxp1GF1gLp4c6ewbYW9tmtpQP0IHAqkxfArZgy6aHSgp8\n3M+1uRIunv5rsz+LsbO6mcEh5V9poWEi4yHrBssGgptykggPsfmUa58OBFYlIg6ybjI6MlowVzon\n06hk8dn0ULW95fHM5ebqcJLtlU2kxIRTmB5rthTPkLvK6AZ7ocZsJQ4TERrEzTmGR4GvLKzUgcDK\n5K6EtpNw4bjZShwmyCYszZ/ELl/1cz22yej2OsF6qZWe/kHePm74ctts1lsENy4+aMtuzRHx0vxk\nGtp7KK/rMFsKoAOBtfGDg8En/Vzb6wxbSoumhf5y4gJX+gf9My00TFwmpBZZNj10R14yNsFn0kM6\nEFiZ2HRIm/vXNIbF8Fk/12EnLIua0GyvbGJCWDDXT00wW4pnyb0Lzu+HTt/4MXWE+KhQFmbF+0wD\nRh0IrE7uSqNyqKPBbCUOEx5ieBT4nJ9r9SZImG50e7UYg0OKN6uauDV3EqHBfn54564ElKXbsh9r\n6uRM62WzpehAYHmGz1qt6uean+Jbfq7D7QssmhY6ePYirZf7KPHntNAwk/JgYrZlU6PDn5EvjIh1\nILA6SbkQP9WyudLbZk4i2Jf8XE9sh6F+S6eFQoKEW2da0JfbUYY9Cmrfhh7fmHR1hMz4SHJTJvhE\nekgHAqszfDCc2m2czVqM2EjDo8BnykirN0FUEmQsMFuJwyileKOikUXTEpkQbr3eSE6Rd5cRuGus\n25a99EwbF7p6TdWhA4E/MHOl/WB402wlTrE0P5mTLZfN93Md6DVGBDOWgS3IXC1OcKK5izOt3YGR\nFhomY6ERuC06Ii7JT2ZIwU6TPQpcCgQiEi8i20XkhP3vxFH2mSMi74tIhYgcFZEHRtz3exE5JSKH\n7Zc5rugJWDKLITLRsgfDUl/Jlda+DX2dkL/GXB1O4pdN5sbCFmT3KNhmBHKLUZAWQ3pchOmpUVdH\nBI8BO5RSOcAO++2r6Qb+RilVACwDfioicSPu/yel1Bz75bCLegITix8MaXERFKbHmp8eqtoAYTFG\nd1cLsrW8kaLMOJJjws2W4l1yVxkB/NQ7ZitxGBFhaX4y75xoobvPPI8CVwPBGuAp+/WngLuv3kEp\ndVwpdcJ+vR5oBgJgJsvLDB8Mp613MIAxRD507hLNHSZ5FAwOGOsxZtxpdHe1GOcvdlNW187yWdZb\nCe0y2bdYui17SX4yvQND7D5+wTQNrgaCZKXUcAF7I/CxY1IRKQZCgZMjNv/AnjL6iYhc8wgUkUdF\npFRESltafLRRmZlMvQVCoiybHiopSEEpeNOsXOnZ9wzvgbzV5ry+i2wtN0ZTARkIQsKNJozHNluy\nLfvC7HhiI0JMXWU8ZiAQkTdFpHyUy4cSqcronnTNVUEikgo8DXxGKTX8aX0DyAUWAvHAv1zr8Uqp\nJ5RSC5RSC5KS9IDiI4REwPTbLetRMCM5mikJkeYZdlRuhOAIy3oPbC1vJC81hikJfuY9MF5yV0FX\nkyXbsocE2bgjdxI7q5sZMMmjYMxAoJRaopSaNcplA9Bk/4Ef/qEf9XRORGKATcA3lVJ7Rjx3gzLo\nBZ4Eit3xpgKW3FXQ2WD0ybEYIsLSvGRz/FyHhoy0Qs4SCLXeD2lzRw8Hzl4MzNHAMDlLLd+W/VJ3\nP/tPXzTl9V1NDW0E1tuvrwc2XL2DiIQCfwb+oJR66ar7hoOIYMwvlLuoJ7DJKbEbdlj1YEgxx8+1\nrtQIoBZNC71R0YhSAZoWGiYizpjkt2hb9ptykggNtvGGSQUTrgaCHwJLReQEsMR+GxFZICK/se/z\nCeBm4OFRykT/JCJlQBmQCHzfRT2BzbBhR9VrljwY5k+ZSEJUKFu9fTBUbQRbiDFRbEG2lDcyNSmK\n6ZOizZZiLsNt2VuOma3EYaLCgrk5J4mt5Y2m9N1yKRAopVqVUncopXLsKaQ2+/ZSpdQj9ut/VEqF\njCgR/aBMVCl1u1Kq0J5q+pRSyuQVRX5A/hpoPWE4bFmMIJtQUpDCzqomevq95FGglBE4p94K4dYz\ncWm73MfeU20sn5WCMbAOYCzeln3l7BQaO3o4dM77fbf0ymJ/I281IFD5kSydJVhZmMrlPsNYxSs0\nlhmWlPnWTAttr2xkcEixfFaq2VLMJyYN0udbtnLujrxkQoNsbC7zfidhHQj8jehJMOUGqHjVbCVO\ncf3UeCZGhnjvYKh6DcRm2W6jW8obyZgYQUFajNlSfIPcVVB/0DAXshgx4SHclJPIlrIGr6eHdCDw\nRwruhgvHoLnKbCUOExxk486CFHZUNXsnPVS10QicUYmefy03036ln3drLui00Egs3pZ9RWEq9e09\nXm/LrgOBPzKcHrLoqGBFYSpdvQPs9nR6qOW4YYBu0Wqht6qb6R9ULNNpob+SNAMSciw7T7AkP5mQ\nIPF6ekgHAn9kQjJMWQyV1gwEi6YlEOeN9FDVRuNv7krPvo6H2FLeQHJMGHMz48beOZDIW2WYC10x\npybfFWIjQrhxeiKbyxpRXqz804HAX8m/2zjbba42W4nDhATZuDM/hTc9nR6q+DNkXmd4P1uM7r4B\n3j7ewrKCFGw2nRb6ELl3wdCAZS0sVxSmUnfpCkfPe89fRAcCfyXvLozqIWuOClbMNtJD75zwUCOu\nluPQVA4Faz3z/B5mZ3UzPf1DOi00GunzIG4ylL9ithKnWJqfTLDNu+khHQj8lZhUmHy9ZctIF09L\nIDbCg+mhilcAsaz3wOtHGkiaEEZxdrzZUnwPESi4B2rfgu42s9U4TFxkKDdMT2RzeYPX0kM6EPgz\n+XcbC8tajputxGFCgmyU5CfzZmUTvQNuTg8pZZwtTrnBCJgWo7Onn7eONbOyMJUgnRYanYK1Rnpo\neB7IYqwsTOVc2xXK67zjxawDgT8zvEjKwumhzt4B/uLu9FBzpVFeO+se9z6vl3izqonegSHuKrJe\nEPMaqUUQP9XS6aEgm7DJS+khHQj8mZg0yLzesmWkN0xLJCY82P0HQ/krxiKyPGumhV470kB6XARz\nMz/iDKsZRgRm3WsYNXWZ6wfsDBOjQlk8LYEtXkoP6UDg7xTcDc0VcOGE2UocJjTYRklBCtvdmR5S\nypgfyL4Zoq3na3Gpu493TrSwcnaqrhYai4K1oIYsO0+2ojCVM63dVNR7Pj2kA4G/k78GECh/2Wwl\nTrFydiqdPQPus/FrOAJttZatFnqjopH+QcWq2TotNCbJ+ZCUa5QJW5BlBSmEBAkbDnu+XYYOBP5O\nTBpk3QhlL1qyNfWN0xOJjwp138FQ8YphYJJ3l3uez8u8frSBKQmRFKZbr1OqKRSshTPvQYf3G7m5\nysSoUG6ZkcTGI/UMerj3kA4EgUDhfdBaAw2HzVbiMCFBNlYWpvJmVZPrzmVKGWeHU281vBssxoWu\nXt6tucCq2am6t9B4mbUWUJYtmFg9J52mjl72nfJsGaxLgUBE4kVku4icsP8ddfZKRAZHmNJsHLE9\nW0T2ikiNiDxvdzPTuJv8NYbxytEXzVbiFGvmpNHTP8Q2Vw1r6g7CpbOWTQttKW9kSMFdRWlmS7EO\niTmQXGjZ1OiSvElEhgax8Yhn00OujggeA3YopXKAHfbbo3FlhCnNyA5fPwJ+opSaDlwEPuuiHs1o\nREw0bCzLX4YhLxm+uJH5UyaSMTGCDYfrXXuishchKNSyvYVeO1LP9EnRzEyeYLYUazHrHji/Hy6e\nMVuJw0SGBlOSn8zmskb3r6cZgauBYA3wlP36Uxi+w+PC7lN8OzDsY+zQ4zUOMvt+6Go0yukshoiw\nuiiNv9Rc4EJXr3NPMjgA5S/BjGWGv63FqLt0hX2n2lhdlKbTQo4y6z7jb5lVR8TptF/pd1/BxCi4\nGgiSlVLDszCNQPI19gsXkVIR2SMiwz/2CcAlpdRw4vc8cM3uXyLyqP05SltavGxu7g/MWAahEyx7\nMNw9N53BIcWmo05O+tW+BZdbYPYD7hXmJV49ZKQG7plrvQZ5pjNxCkxeDEeft2bBRI5RMPGqB6uH\nxgwEIvKmiJSPcvnQahxlrHq41n95ilJqAfAQ8FMRmeaoUKXUE0qpBUqpBUlJ1qv/Np2QCKNSpvI1\n6O8xW43DzEieQG7KBOcPhiPP/TVFZjGUUvz5UB0LsyaSGR9pthxrUvQAXDhuuJdZjA8KJirdUDBx\nDcYMBHZT+lmjXDYATSKSCmD/O+oSPqVUnf1vLbALmAu0AnEiEmzfLQOwnr+clSi8D3rb4cQ2s5U4\nxd1z0zl09hJnW7sde2Bvp+FjW7AWgq1Xj1Be10FNcxf3zM0wW4p1yb8bgsLgyPNmK3GKNXPS6B1w\nQ8HENXA1NbQRWG+/vh74yBI+EZkoImH264nADUClfQTxFnDfxz1e40ayb4GoSZZNDw1XyzhcQVG5\nEQauWDYt9PLB84Tazwo1ThIRBzOXGQUTg/1mq3GYeZMnkh4XwauuFkxcA1cDwQ+BpSJyAlhiv42I\nLBCR39j3yQNKReQIxg//D5VSlfb7/gX4mojUYMwZ/NZFPZqPIyjYqKs+/oYl3ZvS4yIozornlUN1\njvVfOfo8TMyGzGLPifMQ/YNDvHaknjvyJhEbGWK2HGsz+0HovgA1O8xW4jA2m7BmThp/OdFCc6f7\nU7suBQKlVKtS6g6lVI49hdRm316qlHrEfv09pVShUqrI/ve3Ix5fq5QqVkpNV0rdr5RysiREM27m\nPASDvVD20tj7+iD3zk+ntuUyB8+O09y7vQ5O7TZGAxastnnnRAutl/tYO0+nhVxm+hKIiIejz5mt\nxCnWzsvgvvkZ9A+6f8JbrywONFKLjAU2h/9kthKnWDk7jYiQIF46cG58Dyh7EVAw+xMe1eUpXjlY\nx8TIEG6ZoQskXCY41OhIWr0ZerxnA+kupk+K5sf3FZEeF+H259aBIBCZ+0moPwRNFWYrcZjosGBW\nFKby2pEGuvvGqKBQyqgWylgICQ4XqplOR08/2yubuKsojdBgfai6haIHjRGxRVuzewr97QpECj9h\ntJw4ZM1RwScWZNDVO8DW8jEqKM6XQksVzP2Ud4S5mdePNNA7MKTXDriT9PmQkGPZEbGn0IEgEIlK\ngJnLjUlUC1ZQFGfHMyUhkhdKx0gPHfoDhERatrfQ8/vPMjN5AnMyrbcS2mcRgXl/A+f2QnO12Wp8\nBh0IApW5nzIqKI6/YbYShxER7p+fwZ7atmuvKejthLKXjSAQHuNdgW6gsr6DI+fbebA4U7eUcDdF\n64xW5IeeNluJz6ADQaAy7Q6IToFDfzRbiVOsnZeBCNeeNK74M/RfNs7+LMjz+88SGmzTaSFPEJ0E\nM1fAkWdhQBcqgg4EgUtQsLHs/sQ26GwyW43DpMVFcFNOEi8dOD+6acfBpyFxpiXXDvT0D/LnQ3Us\nn5VCXKT1VkJbgnnrobvVWHGu0YEgoJn7aVCDcNiao4JPLMigvr2H3SeuakLYXAXn98G8T1ty7cCW\n8gY6egZ4YGGm2VL8l2m3QWwmHPyD2Up8Ah0IApnEHMi6CUp/b0mfgpL8FBKjQ/nTnqv6zB982qiK\nmv2gOcJc5Ll958hKiGTR1ASzpfgvtiBjnqz2Lbh42mw1pqMDQaCz8BFoPwsntputxGFCg208uHAy\nO6qbOddmnzTuvwJHnjGqoqKttwirtqWLvafa+MRCPUnsceZ8EhDjxCHA0YEg0MldaUwa7//N2Pv6\nIOuum4wAz+47a2wof9noo1T8d6bqcpan95wh2CbcN1+3lPA4cZlGW/KDTwX8pLEOBIFOUAjMfxhq\n3oS2WrPVOEx6XAR35CXz/P5z9PYPwN5fQVKekfKyGJd7B3ip9DwrClOZNCHcbDmBwXWPGoZFlYHd\n+FgHAo0RCMQGpU+arcQpPn39FFov97H3nTeg8agxGrBgWuWVg+fp7B1g/eIss6UEDlNvh4TpxglE\nAKMDgQZiUiFvlbHApv+K2Woc5sbpiWQlRCL7noCwGEv6DiileOr9MxSmxzJvsl5J7DVsNlj4d1BX\nCnUHzFZjGjoQaAwWPmLk1stfMVuJw9hswt/NjeK6K+/QmnMfhEWbLclh3q1ppaa5i/WLs/QksbeZ\n8xCERsPeJ8xWYho6EGgMsm6CSQWw55eWNPi+lzcJlUF+1X272VKc4vfvnSY+KpRVs7ULmdcJjzHa\nTlS8Al0tY+/vh7gUCEQkXkS2i8gJ+9+Jo+xzm4gcHnHpEZG77ff9XkROjbhvjit6NC4gAou+BE3l\nULvLbDWO0X+F8IO/5UTMYn5XHUT9JWult05fuMyO6ibWFWcSHhJktpzApPhRGOyD0sA0SXR1RPAY\nsEMplQPssN/+EEqpt5RSc5RSc4DbgW5gpHv6Pw3fr5Q67KIejSsU3gfRyfD+z81W4hhHnoXuC8Qt\n/ToKePLdU2Yrcogn3qklJMjG+kVZZksJXJJmQM6dsO8JS86TuUqwi49fA9xqv/4UsAvDh/ha3Ads\nUUpdo2WkxlSCw4yKm53fhw1fgoiPDPB8k4pXIW0uSbPuYGXhYZ7dd46/vyOHmHDf9/ht7uzhpQPn\nuXdeBpNidMmoqdzwD/D7lfDiw8aqe19l8VfcvljS1UCQrJRqsF9vBJLH2P9B4P9ete0HIvJt7COK\na/kWi8ijwKMAkydPdl6x5uMpftRoxGWlSWNbMKz8bxDh0ZunsvFIPc/uPcvnbvF9V7In3z1N/+AQ\nj9481Wwpmik3GBVnVa8ZPte+yrz1bg8EosaYGBSRN4GUUe76JvCUUipuxL4XlVKjnkaKSCpwFEhT\nSvWP2NYIhAJPACeVUt8bS/SCBQtUaWnpWLtpApSHfr2Hky1d7P7n2wgL9t2ce2dPP4t/uJObchL5\n5Sfnmy1HEwCIyAGl1IKrt485R6CUWqKUmjXKZQPQZP8xH/5Rb/6Yp/oE8OfhIGB/7gZl0As8CViv\nZ7DG5/jSbdNp6ujl+f3jNLg3iT/uOUtnzwCft8DIRePfuDpZvBFYb7++Hvi4ddrrgGdHbhgRRAS4\nGyh3UY9Gw+JpCSzMmsgv3qqhp983u6p29vTzxO6T3DIjidkZegGZxlxcDQQ/BJaKyAlgif02IrJA\nRD7oYiYiWUAm8PZVj/+TiJQBZUAi8H0X9Wg0iAhfXTKDpo5enhtuRudjPPnuaS529/P1khlmS9Fo\nXJssVkq1AneMsr0UeGTE7dPARzz3lFLWXP2j8XkWTUugODueX+46yYPFk32qPr+9u59fv1PL0vxk\nPRrQ+AR6ZbHGLxkeFTR39vL0+2fGfoAX+fU7tXT2DPC1pXo0oPENdCDQ+C2LpiVwy4wkfrbzBG2X\n+8yWA0BTRw+/e/cUK2enkpcaY7YcjQbQgUDj53xrZR7dfYP8z5vHzZYCwI+3HmNgUPHPd840W4pG\n8wE6EGj8mpzkCawrzuSPe89S09xlqpaj5y/x8sHzfObGLKYkRJmqRaMZiQ4EGr/nH5fMIDIkiO9v\nqmSsBZSeQinF916rJDE6lC/fNt0UDRrNtdCBQOP3JEaH8ZUlOew61sKmsoaxH+ABntt/jtIzF/mn\nO2cywQI9kDSBhQ4E5oA7TgAACKZJREFUmoDg4cVZFKbH8t2NlbR394/9ADfS1NHDf2yu4rrseO6f\nn+nV19ZoxoMOBJqAIDjIxg/vLeRidx8/2FzptddVSvGvr5bTNzDED++djc2m3cc0vocOBJqAoSAt\nlkdvnsoLped5o6LRK6/550N1bKts4h+XzCA7UU8Qa3wTHQg0AcVXl8ygMD2Wf37pKHUedjKrbeni\nW6+WU5wdz9/dlO3R19JoXEEHAk1AERps43/XzWVgcIivPHuI/sEhj7zOlb5BvvzMIUKDbfzPg3MI\nDtKHmsZ30d9OTcCRlRjFf6wtpPTMRf711XK3l5QODSm+/uJhqho7+L+fKCI1NsKtz6/RuBtXHco0\nGkuyZk46J5q6+PlbNUxJiOILt7rPE+A/tx1jc1kj31yRx+25Y5n2aTTmowOBJmD52tIZnGnr5kdb\nqwkLtvG3N7qex//pm8d5fNdJ1hVP5hE9L6CxCDoQaAIWm0347/uL6B8Y4nuvV9IzMMgXbpmG4ZPk\nGENDiv/adoxf7jrJffMz+P7ds5x6Ho3GDPQcgSagCQ228b8PzWV1URo/3nqMf3juMN19Aw49R/uV\nfr74p4P8ctdJ1hVn8qN7ZxOk1wtoLIRLgUBE7heRChEZEpGPGCKP2G+ZiBwTkRoReWzE9mwR2Wvf\n/ryIhLqiR6NxhpAgo7Lnn+6cyetH61n203d4+3jLmJPISineqGjkzp/sZntVE99amcd/3FOog4DG\ncrg6IigH1gK7r7WDiAQBvwCWA/nAOhHJt9/9I+AnSqnpwEXgsy7q0WicQkT40m3TeeaR6wm2Cet/\nt497H3+Plw6c50JX74f2be7o4Zm9Z1nzi3f53NMHmBAezCtfWMwjN03V6SCNJXHVqrIKGOvLXwzU\nKKVq7fs+B6wRkSrgduAh+35PAd8FHndFk0bjCoumJbD5KzfxQuk5fv1OLf/fi0cAmBgZQnR4MJd7\nBz8wuZmaFMWP753NPfPSCdHrBDQWxhuTxenAuRG3zwPXAQnAJaXUwIjtH/E1HkZEHgUeBZg8ebJn\nlGo0QHhIEH+zKItPXz+F8roO3jt5gdOt3fT0DxIeEkTOpGiKs+MpSIvRIwCNXzBmIBCRN4GUUe76\nplJqg/sljY5S6gngCYAFCxaY01ReE1CICIUZsRRmxJotRaPxKGMGAqXUEhdfow4Y2Xs3w76tFYgT\nkWD7qGB4u0aj0Wi8iDcSm/uBHHuFUCjwILBRGSUZbwH32fdbD3hthKHRaDQaA1fLR+8RkfPAImCT\niLxh354mIpsB7Gf7XwbeAKqAF5RSFfan+BfgayJSgzFn8FtX9Gg0Go3GccQsD1dXWLBggSotLTVb\nhkaj0VgKETmglPrImi9d86bRaDQBjg4EGo1GE+DoQKDRaDQBjg4EGo1GE+BYcrJYRFqAM04+PBG4\n4EY5VkC/58BAv+fAwJX3PEUplXT1RksGAlcQkdLRZs39Gf2eAwP9ngMDT7xnnRrSaDSaAEcHAo1G\nowlwAjEQPGG2ABPQ7zkw0O85MHD7ew64OQKNRqPRfJhAHBFoNBqNZgQ6EGg0Gk2AE1CBQESWicgx\nEakRkcfM1uMORCRTRN4SkUoRqRCRr9i3x4vIdhE5Yf870b5dRORn9v/BURGZZ+47cB4RCRKRQyLy\nuv12tojstb+35+1tzxGRMPvtGvv9WWbqdhYRiRORl0SkWkSqRGSRv3/OIvJV+/e6XESeFZFwf/uc\nReR3ItIsIuUjtjn8uYrIevv+J0RkvSMaAiYQiEgQ8AtgOZAPrBORfHNVuYUB4OtKqXzgeuBL9vf1\nGLBDKZUD7LDfBuP959gvj2Jtj+ivYLQ2H+ZHwE+UUtOBi8Bn7ds/C1y0b/+JfT8r8j/AVqVULlCE\n8d799nMWkXTgH4AFSqlZQBCGn4m/fc6/B5Zdtc2hz1VE4oHvYNgAFwPfGQ4e40IpFRAXDM+EN0bc\n/gbwDbN1eeB9bgCWAseAVPu2VOCY/fqvgHUj9v9gPytdMBztdgC3A68DgrHaMvjqzxvDC2OR/Xqw\nfT8x+z04+H5jgVNX6/bnz5m/+p3H2z+314E7/fFzBrKAcmc/V2Ad8KsR2z+031iXgBkR8Ncv1TDn\n7dv8BvtQeC6wF0hWSjXY72oEku3X/eX/8FPgn4Eh++0E4JIyjJDgw+/rg/dsv7/dvr+VyAZagCft\n6bDfiEgUfvw5K6XqgP8CzgINGJ/bAfz7cx7G0c/Vpc87kAKBXyMi0cDLwD8qpTpG3qeMUwS/qRMW\nkVVAs1LqgNlavEgwMA94XCk1F7j8/7d39qxRBVEYfg4kJphC1y6yQgiIrWVAC0FJkcI06QRDkl8h\nVv4Bwd8goqAECTaCH7UfhZgQQ9wQwQSikiJ1imMx5+pFLdxs2MvOvA8s7JyZ4pz7Lrw7Z4ZdfrcL\ngCx1bgGzJBM8C4zxdwsle/qha0lGsAucq43bERt4zGyYZAIP3H05wt/MbDzmx4HvEc/hOVwCrpvZ\nF+ARqT10DzhtZkOxpl7Xr5pj/hSw38+Ej4EdYMfd38T4CckYctb5GrDt7j/c/RBYJmmfs84V3era\nk94lGcE74HzcODhBOnRaaTinnjEzI/3X8yd3v1ubWgGqmwPzpLODKn4zbh9MAQe1LehA4O633L3t\n7hMkHV+5+w3gNTAXy/6suXoWc7F+oL45u/se8NXMLkToKrBOxjqTWkJTZnYyPudVzdnqXKNbXZ8D\n02bWip3UdMT+j6YPSfp8IDMDbAJbwO2m8zmmmi6Tto0fgQ/xmiH1Rl8Cn4EXwJlYb6TbU1vAKulG\nRuN19FD/FeBZvJ8E3gId4DEwEvHRGHdifrLpvI9Y60XgfWj9FGjlrjNwB9gA1oD7wEhuOgMPSWcg\nh6Sd39JRdAUWo/YOsNBNDvqJCSGEKJySWkNCCCH+gYxACCEKR0YghBCFIyMQQojCkREIIUThyAiE\nEKJwZARCCFE4PwFp3KDASZ1MQAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydd3ic1ZX/P3fUe2+WZEuWZau6Wy5gDC7CFdPBpJiQhDSS3SSbhGwK2STkR7LZJWWz2QCBEDoYg23cMcY2Bhe5qtqS5aYuS1bv0v39cUcgjGRpNOWdV/N+nmcezbz1i5l3zr3nnHuOkFJiYGBgYOC6mLQWYGBgYGCgLYYhMDAwMHBxDENgYGBg4OIYhsDAwMDAxTEMgYGBgYGL4661gNEQHh4uExIStJZhYGBgoCuOHTt2RUoZce12XRqChIQEcnJytJZhYGBgoCuEEBcH2264hgwMDAxcHMMQGBgYGLg4hiEwMDAwcHEMQ2BgYGDg4hiGwMDAwMDFsYkhEEI8K4SoEULkDbFfCCH+JIQoEUKcFkLMHLBvvRCi2Pxabws9BgYGBgYjx1Yzgn8Ay6+zfwWQbH49DPwVQAgRCjwGzAWygMeEECE20mRgYGBgMAJsso5ASrlfCJFwnUPWAv+Uqub1ISFEsBAiBrgZ2C2lrAcQQuxGGZRXbKHrM5x6FRrLwD8Kxs2AyDQwObd3rLu3j/yKJvIrGmlo60YIGBfkw8zxIYwP89VanoGz01gO5Tlw9SL0dIJvKERMgbgscPfUWt11kVJyrraV3PIGqho76entIyrQm9SYQNLHBWIyCa0ljhkctaAsFrg84HOZedtQ2z+DEOJh1GyC8ePHj05F3kYo3vnJ54BxMPOLMPdr6gFxIqqbOnh6fylvnSinrrVr0GOSI/354vwJ3DM7Hm8PNwcrNHBa+noh7004+gxcPjz4MZ7+kHEXzH8EIiY7Vt8wtHf18uKhi7x69BLnalsHPSbc34v75sSxfkECkQHeDlY49hC2akxjnhG8I6XMGGTfO8ATUsoPzJ/3AD9CzQi8pZS/Nm//GdAupfz99e41e/ZsOeqVxd3t0FQBl4+oh6XkXfAOhFt+AnO+qvkMobu3j//de46/7iuhp1eyLC2KlZkxTI8PJjLQi94+yaX6Ng6dq2PjiXJOlzUSF+LDL9akszQtSlPtBk5AWQ5s/jbUFED4FJi+DhJvgrBk8PCBlhqoPAlntkHuBujtgqyvwS3/rp4Djdl6upL/2JJPTXMncxJCWDs9lqzEUOJDfDGZoKqxg+OXrrItt4p3C6vx9XDju8sm8+CCBNzdnHt27wwIIY5JKWd/ZruDDMHfgPellK+YP59BGYGbgZullF8b7LihsMoQXEtNIez4MZTuhaQlcOdT4Bdum2tbSEVDO9948RinyhpZNTWGH92acl33j5SSj87V8Yst+ZytbmH9/An8+6pUvNyN2YHLISXs/z28/xs1083+FaTdfv2BTesV2Ps45DwHoRPh3n9C9GceX4fQ0d3Lv2/MZeOJcqbGBfHTVWlkJV5/ll5a28Kv3ilg75la5k0M5U/rZhizg2HQ2hCsAh4BVqICw3+SUmaZg8XHgP4souPArP6YwVDY1BCAeohy/g47fwKBsfCFjRCSYLvrj4C88kYe+sdR2rt6+e3dU1mZGTPic7t6+vjdjiKe+eA8cxNDeWb9bAK8Peyo1sCp6OlUs4DTr0HmPbDqv8A7aOTnXzgIGx6Czia47wWYtNR+WgehrqWTr/4zh+OXGviXJcl8e/GkEY/upZRsPF7OT97OJcTXkxe+PJdJkf52Vqxf7GoIhBCvoEb34UA1KhPIA0BK+X9CCAH8DyoQ3AZ8SUqZYz73IeDfzZd6XEr53HD3s7kh6OfSYXj5XnDzhAffUUE1B3D80lW+8Mxhgn09efbBOUyJDhjVdd4+Uc6/vXGK1JhA/vlQFiF+zh0MNLABPZ3w6uegZDcs/hks/D6IUQRRm6vhpbugpgjufhbSbrO91kG40tLJfX/7iLKr7fzhvumssGAANJD8ikbWP3sUKSXPP5RFRqwFhtCFsPuMwJHYzRAA1J6Bf6wGNw94aCcEx9vnPmbyKxpZ99QhQvw8ef1r84kKtG5q+15RNV9/8Tjp4wJ5+Svz8PE03ERjlt4e2PAgFG6BNX+EWQ9ad732BjUQKj8Gn3sDkhbbQuWQNLR1se7pw5y/0sLzX8pi7sQwq653/korn3/mMO3dvWz8xgISwv1spHTsMJQhMKIr1xIxRbmGOlvghTug/ardblXZ2M6Dzx3F38udl74y12ojALA4JYo/3T+DU5cbeOTl4/T09tlAqYFTsuNRZQSW/9Z6IwDgE6wMQPgUeO0LUHnK+msOQXdvH19/8Rjnalp4+ouzrTYCAInhfrzw5SyklKx/7ghXWjptoNQ1MAzBYERnwgOvwtULsPFr0Gf7H9OO7l6+/sIx2jp7+MdDWcSF2G5NwPKMaP7jtnT2FNXwX7vP2uy6Bk7EsX/A0adhwbdh3tdtd13vIPj8BvAOhlcegLbrhutGzS+3FHCotJ7f3p3JwuTP9EkZNRMj/Pn7g3Ooburgmy8ZA6GRYhiCoZiwAJb/P7XuYP/vbH75xzblc6qskSfvm87kqNHFBK7HF+YnsC4rnr++f47dBdU2v76BhpQfh63/prLclv6H7a8fOA7ufxFaa2DjV20+ENpwrIwXDl3kazdN5I4ZcTa9NsDM8SH85o5Mjpyv5/e7jIHQSDAMwfWY8xWYtg72/RYuHbLZZXfkVfJazmW+eXMS2enRNrvutTy2Jp2M2EC+//pJKhvb7XYfAwfS1ap+nP0j4e6/g8lOMaBxM2DFb9U6m4NP2uyyl+raeGxTHnMTQ/nh8hSbXfda7pwZxwNzx/N/+86x90yN3e4zVjAMwfUQAlb+JwTFw1tfV3EDK6lp6uDHG3PJjA3iu8vsu6LT28ON/1k3k+5eyaNv5qLHxACDa9j1U6g7B3f8H/jYuSzXrC+ptQh7/x9UF1h9uZ7ePv71tROYTIL/vm86bnYuEfHz1WlMiQrg0TdP09jWbdd76R3DEAyHVwDc/lcVL9j9M6suJaXkR2+epr27lyfvm46HA1ZCJoT78eiKFPadreX1nMvDn2DgvJS8CznPqrhA4k32v58Qn6xJePsb0Gvdj+lTB0o5fqmBX9+eQWywj41EDo23hxu/v2caV1q6+OU71huysYxhCEZCwg0w/1vqIbz44agvsz2vir1navnBrSkOXfTyhXkTmDcxlF+9U0hVY4fD7mtgQ7rb4Z3vqVIRi3/quPv6hcPq/1ZlKQ7+cdSXuVTXxh/fLWZ5ejRrpw9aTswuZMYF8Y1FSbx5vIz3ioxY2VAYhmCk3PLvykW09d9U/raFNHd08x9b8kmLCWT9/Al2EDg0JpPgd3dNo7u3j99sK3TovQ1sxP7fQ8NFWP0kuHs59t5pa9Vr/++h4ZLFp0sp+fnmPNxNgsduS7ODwOvz7SWTmBTpzy82F9DR3evw++sBwxCMFE8/lUVUkw9HnrL49Cd3F1PT3Mnjd2RoUhxrfJgvX1uUxOZTFRwqrXP4/Q2soPaMGo1PWweJC7XRkP24+rvzJxafuiOvivfP1PK97CnEBNnfJXQtXu5u/GJNOpfq23h6f6nD768HDENgCSmrYdIy2PsbtSR/hJTUtPD8Rxe4f854ZozXru/ONxYlERvsw2Ob8o38aj2x66fg4QvLfqWdhuB4Vb6icDOUvj/i0zp7enl8WyEp0QEOnwkP5MbkcJanR/OX90uoaDAy6K7FMASWIIRKqetpt2htwe92FOHtbuL72drWfffxdONnq1M5U93MK0eNwLEuKN0Hxbvgpu+Dv+0WXo2KBd9WxRh3/Fj1PBgBL3x0kbKr7fx0VZrmZaJ/sioVKeGJ7UWa6nBGDENgKWFJajn/sX+oNL5hyLlQz66Car6+KIlwfwf7dgfh1vRoZk8I4c97imnvMvylTk1fH+z+uYpNZX1NazXg4Q1LHlO9DnLfGPbwxrZu/vxeCTdNjuDGZG1Kuw8kPtSXh25MZPOpCgoqmrSW41QYhmA0LPoRuHnBnl9e9zApJb/ZVkhkgBdfXpjoIHHXRwjBD5enUNPcyT8+vKC1HIPrkb9RZess/qn6EXYG0m6H6KnKPdozeOe8fv73/RKaOrp51I4Lxyzl6zclEejtzu93ndFailNhGILR4B+ppskFb6tKjUOwq6Ca45ca+N6yyfh6Oqor6PBkJYZy85QI/vp+ibHQxlnp7Yb3fgVRmZB5r9ZqPsFkUrOChotw/PkhD6tq7OC5Dy9wx4xY0sZp3/msnyBfD762KIn3imrIuWCfOkp6xDAEo2XBI2pl577/HHS3lJI/7SkmIcyXu2fZvp6Ktfzg1ik0dfTwt/3Du7cMNOD062oR4+KfaN4+9TNMWgITboB9v1MlLwbh//ado7dP8t2lztUPGeBLNyQQ7u/F73acMVbbm3Gyb5iO8AqAed+Cs9sHLdf7XlEN+RVNfPOWkXdbciTp44JYNTWG5z+8YMwKnI3eHjjwe+WCmbxcazWfRQhY8nNVlO7YPz6zu6a5g1eOXOLOGbHEh9quqq6t8PV059uLJ3HkQj0fGanUgI0MgRBiuRDijBCiRAjx6CD7nxRCnDS/zgohGgbs6x2wb7Mt9DiMuQ+DVxDs//SsQErJn94rIS7EhztmOG4VpaU8csskWrt6ef6jC1pLMRhI3ptQX6piUaPpNuYIxs+DhIXw4Z9Vl7QBPL2/lJ4+ySOLJ2kkbnjumxNPuL8Xf33fmBGDDQyBEMIN+AuwAkgD1gkhPrV8UEr5XSnldCnldODPwMYBu9v790kpHdMfz1Z4B6la8IVboDr/480Hiq9w6nID37x5kkPqCY2W1JhAlqRE8uzB87R2Wr5a2sAO9PWqgUVkOkxZqbWa67Pwe9BcCade/XjTlZZOXjx0ibXTxzEhzHk7hHl7uPGVhYkfP6uuji1+pbKAEillqZSyC3gVWHud49cBr9jgvs7B3K+Dpz8c+K+PN/3PeyXEBHlz1yznnQ30881bJtHQ1s0rRywvHWBgBwo3Q10x3PRvzhcbuJaJt6hy1R88+XHZlecOnqejp5dv3eK8s4F+Pjd3PIHe7vzv+yVaS9EcW3zTYoGBq5PKzNs+gxBiApAIvDdgs7cQIkcIcUgIcftQNxFCPGw+Lqe2ttYGsm2EbyjMfgjy34aGS5y83MCRC/V8+cZEvNydv1/wrAkhzJ8YxlP7S+nsMdYVaM5Hf4HQiaq2j7MjhFptfPU8FLxNW1cPLx66xK1p0SRFOK6o4mgJ8PbgwQUJ7Myvpri6WWs5muLoIcf9wAYp5cBfnAnmZsoPAH8QQiQNdqKU8ikp5Wwp5eyICI1XWF7LXPNin8N/4+8fnCfAy5375ti36b0t+eYtSdQ0d7L5ZIXWUlyby0eg7CjM+6b9Gs7YmimrVI/jD//EmzmXaWzv5qs3OceamZHw4A2J+Hi48ZSL1yCyhSEoBwb+6sWZtw3G/VzjFpJSlpv/lgLvAzNsoMmxBMVB+u30HXuefbml3J8VT4C3h9aqRsyNk8KZHOXPcwcvGOl0WvLR/6hewdMf0FrJyDGZVJys8hRH9m9jenwwMzWsp2UpoX6e3Dkzlk2nKqhz4Wb3tjAER4FkIUSiEMIT9WP/mewfIUQKEAJ8NGBbiBDCy/w+HLgB0GcHiXnfwtTVzD2m91m/IEFrNRYhhOBLNyRSUNnEkfPGIhtNuHpBJR3M/pKqdKsnpt5Pt2cQK1rf5isLExHOmuk0BA8uSKCrp8+l42RWGwIpZQ/wCLATKARel1LmCyF+KYQYmAV0P/Cq/PSQMxXIEUKcAvYCT0gpdWkIWiKmcVxO4Rs+u4kL0r6mkKXcPj2WYF8Pnjt4QWsprsmh/wNhgqyHtVZiOZ6+bPPI5la3HJbHXr/shDOSHBXAwuRwXjh0kW4XrcprkxiBlHKblHKylDJJSvm4edvPpZSbBxzzCynlo9ec96GUMlNKOc389++20KMFb+Rc5m/dKwjvroSirVrLsRgfTzceyBrProIqLte3aS3HtehoghMvQMZdEDhOazUWk1feyG/rFiKEwP2YPh/hL92QQHVTJ9tyK7WWoglOnp+mD6SUvHDoIldil0DQeDj6tNaSRsUX5k9ACME/P7qgtRTX4vRr0NXiHBVGR8GLhy5y1SOKnsmrVf2hIcpOODM3T44kMdzPZWfEhiGwAYdK6ymtbWXdvIkwaz2c3w9XirWWZTExQT6syIjm1aOXjRLVjkJKyHkOYqZB7Eyt1VhMU0c3m05WcNu0cXje8E3oaFSGTWeYTIL18ydw8nIDJ11wgZlhCGzAS4cvEujtzuqpMTDzi2ByVw+3Dvn8vAk0d/Sw1UWnyA7n8hHV/nT2l523nMR1ePtEOe3dvXxu3niInwtRGYPWH9IDd82Kw8fDjVcOu17Q2DAEVlLb3MnO/CrunhWPt4ebKlGdugZOvgTd+muJNzcxlIkRfi6dQeFQcp4Fr0AVH9AZUkpePHSRqXFBTI0LVoZs1oOqCGPFCa3lWUyAtwe3TRvH5lMVNHe4ViFGwxBYyRvHLtPdK3lg7vhPNs5+CDoa1GpjnSGE4IGs8Ry7eJUzVa692tLutNVD/lsw9T7wcv6VuNeSc/EqZ6tb+NzA737mPeDuo9tZwbq542nv7mWTiy2uNAyBFfT1SV4+fIl5E0OZFDngQU5YCGHJkKPPDIo7Z8bh6WYyZgX25uRL0NupBg465KVDFwnwdmfNtAGZTj7BkHEn5G6ATv0NJKbFBZEaE8jLhy+51OJKwxBYwf7iWsqutvO5uRM+vUMI9XCXHYWqXG3EWUGonyfLM6LZeLyMjm4jaGwX+vpUHGn8fIhKG/54J6O+tYttuVXcNTPus933Zj2osqDy3tREmzWoGXE8BZVN5JY3ai3HYRiGwApePXKZMD9Pbk2P/uzOafeDmyeceMnxwmzAuqzxNHX0sPW0ETS2C5c+hPpz6kdTh7x1opyu3j7WZY3/7M64ORCZplv30NoZsXh7uNaM2DAEo6S+tYs9RdXcMSMWT/dB/hl9Q1U9+dzXh23y7YzMmxjKxHA/Xnahh8GhnHwZPAMgVV8tOPrZcKyMaXFBTIkO+OzO/qBxxQmoOOlwbdYS6O3Bmqnj2HSyghYX6dNhGIJRsvlkOd29kruu1494+uegrQ7O7nCcMBshhOC+OfEcu3iV0toWreWMLTpbVCJBxh3g6XytHIcjv6KRwsqm6/finnovuHvDiRcdJ8yG3J81nrauXraedo2gsWEIRsmG42VkxAaSGhM49EFJi8E/WgUFdcgdM2IxCdh4fKhisgajonAzdLeqgYIO2XCsDE83E7dNu07jJZ8QNSPO26DLGfHM8cFMDPfjTRf57huGYBQUVjaRV97E3TOvMyICcHNXsYLi3dBc7RhxNiQy0JuFyRG8daKcvj7XyaCwOydfhtAktQBLZ3T19LHpZAXL0qMI8h2m1Pq0ddB+FYp3OUacDRFCcNesOI6cr3eJ2luGIRgFbx4rw8NNcNv0EbSinPF5kL1w+tXhj3VC7pwZS3lDO4fO12ktZWxQfx4uHFA9B3S4kvi9ohrqW7uu7xbqJ2kx+EXCKX12pr19RizCRWbEhiGwkO7ePt4+Wc6SlChC/TyHPyE8GeKyVPaQDvOSb02PJsDLnTePjf2HwSGcehUQaqaoQzYcKyMywIuFk8KHP9jNXcUKzu6EVv0NJGKDfZg/MYyNJ8rG/JoCwxBYyL4ztVxpGeGIqJ8Zn4MrZ6D8uP2E2QlvDzdWTY1he14lbV2ukUFhN/r64NTLMPFm1dVOZ9Q2d7L3TA13zIzF3W2EPx3T1kFfN+RvtK84O3HnzDgu1rVx7OJVraXYFcMQWMiGY2WE+3uyaIoFfZPT7wA3L5VKqkPunBlHW1cvO/KqtJaiby4ehIZLug0SbzpZTm+fHD42NpDoDIjKVHERHbI8IxofD7cxHzS2iSEQQiwXQpwRQpQIIR4dZP+DQohaIcRJ8+srA/atF0IUm1/rbaHHXjS2dbOnqJq102PxGOmICMA7CCZnq5WWvfobVc9JCCE+1Ic3j5dpLUXfnH4NPP0hZZXWSkbF2yfLmRoXRHLUIGsHrsf0dVBxHGrP2EeYHfH3cmdFRjTvnK4Y06vsrTYEQgg34C/ACiANWCeEGGzN/GtSyunm1zPmc0OBx4C5QBbwmBDCaTtfb8+rpLtXcvtIgsTXknkvtNbC+X22F2ZnhBDcOSOOD8/VUdGgv4qqTkFPJxRsVpVpdbh2oKSmhbzyJtaO6rt/Dwg3c3xEf9w5M47mjh7eLdRf5t9IscWMIAsokVKWSim7gFeBtSM891Zgt5SyXkp5FdgNLLeBJruw6WQFieF+ZMReZ+3AUCRng1cQ5L5he2EO4M6ZsUgJW065xgIbm1O8GzobIeNurZWMis2nKhAC1XPDUvwjYdISOP26ipPojPlJYcQEefPWGHYP2cIQxAKXB3wuM2+7lruEEKeFEBuEEPEWnosQ4mEhRI4QIqe2ttYGsi2juqmDQ+fruG3aOMRo0v48vCFtDRRu0WWfgglhfkyLD2azYQhGR94G8A2HiYu0VmIxUkq2nKpg/sQwogK9R3eRzHugqQzKjthWnANwMwlWT41hf3EtDW36Wxw3EhwVLN4CJEgpp6JG/c9begEp5VNSytlSytkRERYEam3EllMVSAm3TbeiuXjmvaoq45ntthPmQNZMjSG/oolzRskJy+hsVv/P0+8At2EWYTkhueWNnL/Sym3TrPjuT1mhSk7osCIpwG3TYunulezMH5sJE7YwBOVA/IDPceZtHyOlrJNSdpo/PgPMGum5zsKWUxWkjwskKcKKBiIJN0JAjG7dQ6unjkMIwz1kMUXboKcDMnXqFjpZgYebYEXGKNxC/XgFwOTlqhGPDhMmMmIDSQjzHbMzYlsYgqNAshAiUQjhCdwPbB54gBBi4DfoNqDQ/H4nkC2ECDEHibPN25yKC1daOVXWyFprZgMAJjfVkrB4t+pOpTOig7zJSgg1z47G9gIbm5L7BgSNVwsLdUZvn2TL6QoWTY4cvqTEcGTcpRImLhywjTgHIoRgzbRxfHSujprmDq3l2ByrDYGUsgd4BPUDXgi8LqXMF0L8UgjRX2P3O0KIfCHEKeA7wIPmc+uBX6GMyVHgl+ZtTkX/KGD1VCsNAShfaV83FGyy/loacNv0cZyrbaWwUn/dpzSh9Qqce0917TLpb9nOkfP1VDd1Wj8IAkhepkpv69Y9NI4+Cdtzx557yCbfTCnlNinlZCllkpTycfO2n0spN5vf/1hKmS6lnCalvEVKWTTg3GellJPMr+dsoceWSCnZdLKcrIRQxgX7WH/BmGmqjaVOH4YVGTG4m8SYnSLbnIK3Va2pzHu0VjIqNp8qx9fTjaWpUdZfzMNHraEo3KzSaXVGclQAKdEBY/K7r78hioMpqGziXG2rdUHigQihgoYXD0JLjW2u6UBC/Ty5MTnccA+NlNw3ISIFotK1VmIxXT19bMutIjstCh9PN9tcNPNu6GhUsyQdsmbaOI5dvErZ1bFVkdQwBMOw+VQF7ibBykwrAmXXkn47yD41MtIha6aOo7yhneOXGrSW4tw0lquWlBl367LS6IHiWhrbu203CAJVZ8knRLcz4jVm9/BYa+FqGILrIKVkW24lCyaFj6zS6EiJTIPwyapLlQ7JTo/C091kZA8NR7+hz7hTWx2jZFtuFYHe7tw4yYbp2m4ekLZWZVJ16W9UPT7Ml2nxwWwZY53LDENwHfIrmrhc386qzEGa01uDEJB2u27dQwHeHiyeEsnW3Ep6jYY1Q1OwSRVcC0vSWonFdPX0sbugimVp0YP35LaGjLtVh7az+l1Pk1feNKZauBqG4Dpsy63EzSRYlmZjQwAqTqBj99CqqTHUNneO+fK8o6apEi4dUqNfHXLw3BWaOnpYaetBEMCEBaphjU4z5/qzB7fljh33kGEIhqDfLTR/Ypht3UL9RKbq2j10S0okXu6mMfUw2JTCLYDUrSHYnluJv5c7NyaPoAGNpZjcVPG94t26dA9FB3kzc3ww28dQWXbDEAxBUVUzF+raWGGPERHoPnvI38udmyZHsCOvyuhnPBgFmyAiFSIma63EYrp7+9hVUM3S1Ei83G2ULXQtaWuhuw1K3rXP9e3MykxVbuVSnf4M2WAYhmAItudWYhKqVaPdSNN39tDKzGiqmjo4WWZkD32Klhpl4NNv11rJqDhUWkdDW7dtM+WuZcIN4BOqW/dQ/+/C9ryxMSM2DMEQbMurYm5iGOH+Xva7SWQqhE/RrXtoSWoUHm6C7YZ76NMUbkbPbqFtuZX4ebpx02Q7Fnd0c4fU1aqfcbf+SjbEh/oyNS6IbWPEPWQYgkE4W91MSU2LfQJlAxFCjRovHoRm/TW9CPT24MZJ4WzLrTIWlw2kYJOK/0SkaK3EYnp6+9iZX83i1Ci8PezkFuondS10NUPpXvvex04sz4jm1OUGysdAsybDEAzCttxKhL3dQv3o3D20IjOG8oZ28sqbtJbiHLRegQsfqNmADheRHTlfT31rFyszHPDdT7xJtXEt0Ol331yNdSz08jYMwSBsz61izoRQIkfbhMMS+rOHdGoIstOicDcJto0RX6nVFL2jDHuaPuMDW3Mr8fFw4+Ypkfa/mbsnTFkJZ7ZCj/4aviSG+5ESHcCOMfDdNwzBNZTUtHCmutl+2ULXIgSkrIYLB3VZmjrY15P5SWFsz6003EOg4j2hSbqsLdTbpxqvLE6JtF1toeFIW6tqD53f75j72ZiVmTHkXLxKTZP+4hwDMQzBNfRbd6uacFhK6hpVofLsDsfd04asyIjhQl0bRVUuXpq6rV79oOnULXT0Qj1XWrocNwgCmHiLKk1dqM/soZWZ0UiJ7juXGYbgGrblVjFrQgjRQQ5wC/UzbgYExpkXIemP7PQoTAIje6hoqzLoOs0W2p5biZe7iVsc4Rbqx8MbJt8Khe/osnPZpMgAJkX6s03nPQpsYgiEEMuFEGeEECVCiEcH2f89IUSBuXn9HiHEhAH7eoUQJ80vTR3lF+taKbq/0P0AACAASURBVKhsYoUjAmUDEULVaT/3HnS1OvbeNiDc34usxNAxk0o3ago3Q/AE1XNCZ/T1SXbkV3HzlAj8vNwde/O0tdBer7LndMjKjGgOn6+jrkV/PRb6sdoQCCHcgL8AK4A0YJ0QIu2aw04As83N6zcAvxuwr11KOd38ug0N2ZWvUjgdki10LalrVF9bHa+0LKlpobjaRd1Dnc1Q+r76/6hDt9Dp8kaqmzq1+e5PWgoevrpdXLY8I4Y+CbsK9JcC3o8tZgRZQImUslRK2QW8Cnxqbiyl3Cul7F+LfQjVpN7p2FVQRVpMIPGhvo6/+fj5aqWlXt1D5sJ8en4YrKLkXejtUjM7HbIrvwo3k2BxigPdQv14+ipjULQV+vocf38rSY0JYEKYr67jBLYwBLHA5QGfy8zbhuLLwMD6s95CiBwhxCEhxJA5d0KIh83H5dTW1lqneBCutHSSc/Eq2ek2aMk3GtzcVSrd2V26TKWLDvJmWnwwu3T8MFhF0VbwDYP4uVorGRW7CqqZmxhKsK8dCiyOhJTV0FIFFce1ub8VCCHIToviw5I6mju6tZYzKhwaLBZCfB6YDfzngM0TpJSzgQeAPwghBi3eLqV8Sko5W0o5OyLC9kvf9xRWI+UnI1tNSF0DnY1wQZ+pdNlpUZwqa6SyUf8rLS2ip0sZ8CkrVGVNnVFa20JJTQvZaRoNggAmZ4PJXa3D0CHZ6dF09fax76ztB6mOwBaGoByIH/A5zrztUwghlgI/AW6TUn4cVZFSlpv/lgLvAzNsoMliduVXExvsQ2pMgBa3V0y8GTz9dese6vcvv+tq7qGLHygDnrJaayWjYrf5/9cyLeID/fiEQMKNKntIh8wcH0K4v+fHcUa9YQtDcBRIFkIkCiE8gfuBT2X/CCFmAH9DGYGaAdtDhBBe5vfhwA1AgQ00WURrZw8HSq6QnR6F0DLQ5+Ft9pVug75e7XSMkkmR/kyM8GOnTh+GUVO0VQU7J96stZJRsaugmozYQGKDfbQVkrIa6oqh9qy2OkaBm0mwNDWKvUU1dPXoL85htSGQUvYAjwA7gULgdSllvhDil0KI/iyg/wT8gTeuSRNNBXKEEKeAvcATUkqHG4L9Z2vp6unT1i3UT+oaaK2BsqNaKxkV2WnRHCqto7FNn75Si5FSGe5JS8BD4x/SUVDT3MHxS1dZluoE3/0pK9Rf3bqHomju7OGj0jqtpViMTWIEUsptUsrJUsokKeXj5m0/l1JuNr9fKqWMujZNVEr5oZQyU0o5zfz377bQYym7C6oJ9vVgTkKIFrf/NMnZ4OapW/dQdnoUPX2SvWf012xnVFScgOYK3bqF9hTWqNiYVkkSAwmKU4sri7ZqrWRULEgKx9fTTZcJEy6/sri7t489RTUsSYnC3c0J/jm8AyFxkTIEOqzdMz0umIgAL3YV6O9hGBVFW0G4KQOuQ3blVxEf6kNKtIaxsYGkrILyHNXzWWd4e7hx85QIdhdU665rnxP88mnL0fP1NLZ3O8eIqJ/UNdBwEarztFZiMSaTYFlaFO+fqaWjW39xDosp2qqasfuGaq3EYlo6ezhYUkd2WrS2sbGBpKxRf89s01bHKMlOi6amuZNTOuva5/KGYFdBNd4eJm5KtmM3JkuZshKESb/uobQo2rp6+fDcFa2l2Je6c1BbqFu30P6ztXT19mmbNnotEVNU9VadxglumRKJu0nobmGlSxsCKSW78qtYmBzhuLK7I8E/AuLn6TaVbn5SGP5e7rpNpRsx/b7slJXa6hglu/KrCPXzZNYEJ4iN9dNfd+v8fmjX16gaIMjXg3kTw3QXJ3BpQ5Bf0URFY4dzjYj6SV0NNflQf15rJRbj5e7GLSmR7C6opldnvlKLKNoK0VMheLzWSizmk9hYpHPExgaSshr6enRbdys7PYpzta2U1LRoLWXEONk3wLHsyq/CJFQTdqejv2aNTjMostOiqGvt4vilq1pLsQ8tNXD5sG7dQodL62nu6GGZMw6C4maDX6Ru3UNLzb8nu3XkHnJtQ1BQzeyEUEL9NKqvcj1CEiAqU7eG4OYpEXi4Cd1NkUfMme2A1K9bqKAKbw8TC50pNtaPyU2tKSjeDT36K+08LtiHqXFBusqcc1lDcMncUcsp3UL9pKyCSx9Bi/7qlwR4e7AgKZxdBdVjs4Vl0VblEorK0FqJxUgp2V1QzU3OFhsbSOoa6GrRbQvL7LQoTlxqoFonLSxd1hD0W2unWE08FCmrAAlntw97qDOSnR7Fxbo2zlbrx1c6IjpbVO+BlNW67D2QV95EZWMH2VrWFhqOxJt0XXer/99WL+4hFzYE1aREBzA+TIPeAyMlOhOCxuvWPbTM7Csdc+6hc3ugt1O/vQcKzLExLXoPjBR3L0heptYT6LDuVnKkPwlhvrpJI3VJQ1DX0knOhXrnHhGBGm2mroZze1UHLJ0RGejNjPHBunkYRkzRVtVEKH6e1kpGxa78arISQwlxxtjYQFJWQ2stlOVorcRihBBkp0fz0bkrNOmgR4FLGoI9RTX0SZw7PtBPyio1+izZo7WSUZGdFk1ueSPlDWOkR0FvN5zdoYKZbg7u7WsDLlxp5Ux1s3O7RPtJXgYmDyjSqXsoLYruXsn7Z5w/xueShqC/90D6uECtpQxP/Dw1+tSpe6i/dMeY6VFw8SB0NOrWLfRx7wE9DIK8gyBxofru6zDhYIa5R4EeWli6nCFo7+rlg5JalqVp3HtgpHzcwnKnGo3qjKQIf5Ii/HSVSnddiraCuw9MvEVrJaNiV0EVqVr15R4NKaugvhRqz2itxGL6exTsO1NLZ49zxzlczhDsL66lo9vJ6qsMR8oqcwvLA1orGRXZ6dEcKq3Xf48CKZUhSFqsGq7rjCstnRy7eFVf3/0p5nUaZ/Q7I27p7OGjc87do8DlDMGu/GqCfDyYk6ijapFJt6gOWHp1D6VF0dsnee+Mzt1DlSehqVy3bqH3Cs2xMWeqtDscgeMgdpZuv/v9PQqcPY3UJoZACLFcCHFGCFEihHh0kP1eQojXzPsPCyESBuz7sXn7GSHErbbQMxQ9vX3sKapmSUokHs5WX+V6ePioDlhF26BPf23wpsUFExng5fQPw7AUbVVVYScv11rJqNhVUEVssA9pMTqIjQ1kykooPwZNFVorsRhvDzcWTXb+HgVW/xoKIdyAvwArgDRgnRAi7ZrDvgxclVJOAp4Efms+Nw3V4zgdWA78r/l6duHohas0tDlZ74GRkrJadcKqOKG1EosxmQRLx0KPgqJtMH4B+IVprcRiWjt72F/sBH25R0N/PSe99ihIj3L6HgW2GBZnASVSylIpZRfwKrD2mmPWAs+b328Algj1bVwLvCql7JRSngdKzNezC7sKqvByN3HTZCesrzIcydmqE5ZOC3HpvkdBfamqBqtTt9CBYifqy20pH/co0Kd7aPGUKNycvEeBLQxBLHB5wOcy87ZBjzE3u28EwkZ4LgBCiIeFEDlCiJza2tHl5Xb19LE0NQpfT/3lf+MbCgk36vZh0H2PgiLzaFSvRebynagvt6V83KPggErd1RlBvh7MTQx1ateobhzlUsqnpJSzpZSzIyJGN6J//I5M/ueBGTZW5kBSVsOVM3ClWGslFuPlrvq5vluo0x4FRVtVgbmQBK2VWEyPuffAYmfsPTBSUlZDX7eqSKpDstOiKKlp4Vytc9bdssW3ohyIH/A5zrxt0GOEEO5AEFA3wnNtiu78owPpH43q1T2UHs2Vli5OXtZZj4LWK3D5kG7dQkcumPty69Et1E/cbPCL0O2MeJmTF6GzhSE4CiQLIRKFEJ6o4O/ma47ZDKw3v78beE+q2sSbgfvNWUWJQDJwxAaaxiZBcTBuhm4fhk96FDjnwzAkZ3eA7Pskp11n7MqvNsfGwrWWMnp03qMgNtiHjNhApy3AaLUhMPv8HwF2AoXA61LKfCHEL4UQt5kP+zsQJoQoAb4HPGo+Nx94HSgAdgDfklLqOK3EAaSsgrKj0FSptRKLCfRW/Vx35lfpq0dB0VYIjIOYaVorsZj+3gMLk8P1GRsbSMpq6GpWsQIdkp0WzYnLDdQ0O1+PAps4DKWU26SUk6WUSVLKx83bfi6l3Gx+3yGlvEdKOUlKmSWlLB1w7uPm86ZIKfVZeN+R6D6VLpoLdW366efa1aaqv6as1GXvgYLKJsob2vXtFuoncRF4+OnWNbosLQopYU9hjdZSPoNOI0cuTESKrlPpPu5R4KS+0s9w7j3oaddtfGBXfjVCwOJUJ+49MFI8vCF5qWoTqsOFlSnRAcSH+jile8gwBHrj41S6/bpMpYsO8mZavI56FJzZpqpgTrhBayWjYndBNbMnhBDu76W1FNuQshpaqqDiuNZKLEYIQXZaNAdL6mjp7NFazqcwDIEeGQOpdKcuN1DV6Hy+0k/R26NGn8m3gpuH1mos5nJ9GwWVTWPDLdRP8jLdL6zs6u1jn5P1KDAMgR6JmwN+kbp9GG41l/jYXejks4LLh6G9XreLyHTVe2Ck+IToemHlrAkhhPh6sNvJyrIbhkCPmEzqx0mnqXRJEf4khvs5pa/0UxRtBTdPmLRUayWjYndBNZOj/EkI99Naim1JWQ1XzkLtWa2VWIy7m4klqVHsKaqhu9d54hyGIdArKauhqwVK92mtxGKUrzSKQ6V1ztvPVUpVAz9xEXgFaK3GYq62dnHkQv3Ycgv1k6LzHgVpUTR39HC4tF5rKR9jGAK9kngTeAbo1j2Une7k/VxrCuDqBd1mC71XVENvnxxbbqF+guIgZvon9Z90xsLkCLw9TE7Vtc8wBHrF3UsFzs5sgz79rcGbHq8yWZzWPVS0DRC6XU28u6Ca6EBvMmODtJZiH1JWq4WVzU76/bkOPp5u3JSsehQ4y8JKwxDomZRV0FqrHgid4WYSLEuL5H1n7eda9I6qbxOgvxF1R3cv+86qvtwmk/4WwY2IlJWAVFldOmRZWhSVjR3klTdpLQUwDIG+SV4GJg/duoeWpTlpP9fGMtWWUqduoQ+Kr9De3Ts23UL9RKapSrA6zR5akhqFSeA07iHDEOgZ7yCYuAgK31HBTZ3htP1c+0eZU/RpCHYXVBPg5c68ifrrpDZihFDuofP7oLNZazUWE+rnyZyEUKcpwGgYAr2TsgqunoeaQq2VWIy3h+pR4HT9XIu2QlgyREzWWonF9PZJ3i2s5uaUSDzdx/jjnbIKerug5F2tlYyK7PRozlQ3c7GuVWsphiHQPVNWAkK3U+TstGjn6ufa3gAXDuh2EdnxS1epa+0ieyy7hfqJnwu+YTr+7psXVjrBjNgwBHonIFqtNNZpnOCWKZG4O1M/15J3oa/nkyqvOmN3QTUeboKbp+iwL7elmNxg8go4uwt6urRWYzHxob6kRAc4hXvIMARjgZRVKrjZcHn4Y52MIF/Vo8Bp0kiL3lHlO2Jna63EYqSU7MyvYn5SOAHe+quNNCpSVkFnI1z8QGsloyI7PZqci/VcadG2QoBhCMYCOu9RsCwtinO1rdr3c+3phOJ3VScsk/4ejeKaFi7WtbmGW6ifpFvAw1fX7qE+Ce9p3KPAqm+7ECJUCLFbCFFs/hsyyDHThRAfCSHyhRCnhRD3Ddj3DyHEeSHESfNrujV6XJbwSapPgU7dQ8ucxVd6fr/qgKXTtNExWWRuODx8IGmxWgCow8y59HGBxAb7aO4atXbY8yiwR0qZDOwxf76WNuCLUsp0YDnwByFE8ID9P5BSTje/Tlqpx3VJWQUXDkKb89QvGSnjgn3IjA3S3j1UsEmV7Zh4s7Y6RsmOvCqmxQcTFeittRTHkrIamiug4oTWSixGCMGytCgOFNfS1qVdjwJrDcFa4Hnz++eB2689QEp5VkpZbH5fAdQALhDJcjApq0D2wtmdWisZFdlpUaqfa5NGPQp6e5RrbfKtqnyHzii72kZueSMrMsZgkbnhmHyruUeBft1DnT197D97RTMN1hqCKCllfxf1KuC6c1IhRBbgCZwbsPlxs8voSSHEkE+gEOJhIUSOECKnttZJC5VpScwMCBinW/dQdno0UsK7WvlKL30IbXWQdps297eSHXlqNuWShsA3FCYs0K0hmJMYSpCPh6arjIc1BEKId4UQeYO81g48TqrqSUM66YQQMcALwJeklP2FuH8MpABzgFDgR0OdL6V8Sko5W0o5OyLCmFB8BpNJzQpK9qiG6zpjcpQ/E8J8tWvYUbAZ3H1023tgR14VqTGBTAgbY70HRkrKKqgthLpzwx/rZHi4mViSEsl7RTX0aNSjYFhDIKVcKqXMGOS1Cag2/8D3/9APOpwTQgQCW4GfSCkPDbh2pVR0As8BWbb4j3JZUlapRuule7VWYjFCCJalRmnTz7WvT82kJi0BT/39kNY0dXDs0lXXnA30018lVqezguz0KBraujl64aom97fWNbQZWG9+vx7YdO0BQghP4C3gn1LKDdfs6zciAhVfyLNSj2uTcKOqP6TbhyFam36u5TnQXAlpa4c/1gnZmV+FlC7qFuonZAJEZ+r2u78wOQJPdxM7NUqYsNYQPAEsE0IUA0vNnxFCzBZCPGM+5l7gJuDBQdJEXxJC5AK5QDjwayv1uDZuHjB5uSqa1qtdBsJomTUhhDA/T3Y4+mEo2KSquE6+1bH3tRHb86qYGOHHpEh/raVoS8pq1We6Rduc/NHg5+XOTckR7Mir0qTullWGQEpZJ6VcIqVMNruQ6s3bc6SUXzG/f1FK6TEgRfTjNFEp5WIpZabZ1fR5KaXGK4rGACmrVMP1Sx9prcRi3EyC7PRo3iuspqPbQT0KpITCLSpl1Ft/TVzqW7s4fL6eFRnRqIm1C5O6BpBQuFlrJaNi1dRoqpo6OHHZ8XW39Ld80uD6JC0BNy/dTpFXZcbQ2qUaqziEqtPQcFG32UK7C6ro7ZOsyIjRWor2RKapqrEFn/FQ64IlqVF4upnYlls5/ME2xjAEYw0vf/NKy626XGk5b2IoIb4ejnsYCjarHHSd9h7YnldFXIgP6eMCtZaiPUJA+u1w4QNo0V+KeaC3BwuTw9meW+lw95BhCMYiKaug8ZIa7eoMdzcTt6ZHs6ewxjHuocItkHAD+OmviUtjezcHS64YbqGBpK0F2QdFW7RWMipWZsZQ0djh8LLshiEYi0xZAcKkW/fQyswYWjp72G9v91DtGbhyBlL16RbaW1RDd69kueEW+oSoDAhNgvy3tVYyKpamReHhJhzuHjIMwVjELxzGz9etIZifFEawI9xDBeagok57D2zPqyQq0IsZ8cHDH+wqfOweOgCt2pVsGC1BPh7cOCmcbblVSAe6dg1DMFZJWQXVeVBfqrUSi/FwM3FrWjTv2ts9VLgJ4rIgUH8j6rauHvadrWV5ejQmk+EW+hRpt5vdQ/ost7IyM4byhnZOlzU67J6GIRirpK5Rf3U6RV45VbmHDhTbaVR3pQSqciH9Dvtc3868V1RDR3ef4RYajOhMCEnU7Xd/WVoU7ibHuocMQzBWCR6vWljmbdRayahYkBRGkI8d3UP5GwGzG0GHvHOqkogAL7ISQ7WW4nz0u4fO74fWOq3VWEywryc3TApnW16lw9xDhiEYy2TcBdW5UHtWayUW4+FmIjstincLqunssYN7KO9NFUcJHGf7a9uZ5o5u9p6pYVVmDG6GW2hw0m5XZdl16h5alRnD5fp28sqbHHI/wxCMZdJuB4R59Ks/Vk6Nobmzhw9s7R6qLoDaIsi407bXdRDvFlbT2dPHmmmGW2hIYqZBSAIU6Nc95GYSbHWQe8gwBGOZwBiYcINyD+lwcdkNSeEEervb/mHI36jSa3VaZG7LqUpig32YEf+ZzrAG/QihBkKl+3TZtS/Ez5MFSWFsd5B7yDAEY52MO1SufE2B1kosxtPdRHZ6NLtt6R6SUhnGhIXgH2mbazqQhrYuDhTXsmpqjJEtNBxpa5V7qFC/i8su1rWRX2F/95BhCMY6qWvV6DfvTa2VjIpVU2No7uixXRu/qtNQf063bqGd+VV090pWTzXcQsMybgaEToS8DcMf64QsT4/Gw02w6WS53e9lGIKxjn8EJC7SrXvoxknhhPp52u5hyNsIJnfdriZ+53QlE8J8yYzVX6VUhyMEZN4D5w9Ak+MLuVlLiJ8niyZHsPlUBb12rj1kGAJXIONOuHoeKk5orcRiPNxMrMqM4d3Caus7l0mp4gMTb1Z9bnXGlZZODpZcYfXUGKO20EjJvAeQuk2YuG16LNVNnRw5b984h1WGQAgRKoTYLYQoNv8dNHolhOgd0JRm84DtiUKIw0KIEiHEa+ZuZga2JmW1aryi04dh7fRxdHT3scvahjXlx6HhEqTr0y20Pa+KPglrpukv5VUzwpMhZjrkvqG1klGxNDUSX083Np+yr3vI2hnBo8AeKWUysMf8eTDaBzSlGTgn/y3wpJRyEnAV+LKVegwGwzdUlabOf1v159UZsyaEEBfiw6aTFdZdKPcNcPNU5Td0yJZTFUyK9GdKVIDWUvRF5j1qNnylRGslFuPr6U52WhTbcqvss57GjLWGYC3wvPn986i+wyPC3Kd4MdAfybHofAMLybgLGi+rVn46QwjBbdPG8UHJFa60dI7uIr09Kmg4eTn46K9IW3lDO0fO13PbtHGGW8hSMu4EhG6Dxmunx9LY3m27hIlBsNYQREkp+6MwVUDUEMd5CyFyhBCHhBD9P/ZhQIOUst/xWwbEDnUjIcTD5mvk1Nbqr+mE5qSsAg9fOP2q1kpGxe0zYuntk2w9PcqgX+leaK2FqffZVpiDePuEcg3cMWPIR8RgKALHQcKNakaox4SJZJUw8bYds4eGNQRCiHeFEHmDvD61GkeqVQ9D/StPkFLOBh4A/iCESLJUqJTyKSnlbCnl7IiICEtPN/DyV4Xo8t6C7g6t1VjM5KgAUqIDRv8wnHoVfEIgOdu2whyAlJK3TpQzJyGE+FBfreXok8x7oK4EKk9qrcRiPk6YKLBBwsQQDGsIzE3pMwZ5bQKqhRAxAOa/NUNco9z8txR4H5gB1AHBQgh382FxgP0TZl2ZafdDZyOc3aG1klFx+4xYTlxq4FJdm2Undjar3gzpd4K7/vIR8sqbKKlp4Y4ZcVpL0S9pt6n4UK5e3UPj6OyxQcLEEFjrGtoMrDe/Xw98pmu0ECJECOFlfh8O3AAUmGcQe4G7r3e+gQ1JXAQBMWp0rEP6s2UszqAo2Aw97bp1C715vAxP86jQYJT0zwbz3oQ+B7RAtTEzx4cQG+zD29YmTAyBtYbgCWCZEKIYWGr+jBBithDiGfMxqUCOEOIU6of/CSllf72DHwHfE0KUoGIGf7dSj8H1MLlB5t1QsluX3Ztig33ISghl44lyy+qvnH5N1aePz7KfODvR3dvHllMVLEmNJMjXQ2s5+mbqvdBcqeJFOsNkEqydPo4Pimupaba9a9cqQyClrJNSLpFSJptdSPXm7TlSyq+Y338opcyUUk4z//37gPNLpZRZUspJUsp7pJSjTAkxGDHT1kFfj25LTtw1K5bS2laOXxphc+/GclWXfup9aqWpzjhQXEtdaxd3zjTcQlYzebmaGZx4SWslo+LOmXHcPSuO7l7bB7yNlcWuRlQ6RGXq1j20auo4fDzc2HDs8shOyH0DkGo0qEM2Hi8nxNeDRZONBAmrcfeCzHtVvKj9qtZqLGZSpD+/u3sascE+Nr+2YQhckWn3Q8VxXTas8fdyZ2VmDFtOVdLWNUwGhZTK4MXNgTCLE9U0p6mjm90F1ayZNg5Pd+NRtQkzPge9nboNGtsL49vlimTeoyqSnnpZayWj4t7ZcbR09rAjb5gMirIcqC2EGZ93jDAb886pSjp7+oy1A7YkZpqaEZ/U53ffXhiGwBUJiFIZFCdfht5urdVYTFZiKBPCfHk9Zxj30Il/goefWlWtQ147eokpUQFMj9ffSminZvoDakZcU6i1EqfBMASuysz10FINZ3dqrcRihBDcMyuOQ6X1Q68p6GyG3Dch/Q7w0l9tnoKKJk6VNXJ/VrxRUsLWTL1XlSI/8aLWSpwGwxC4KsnZ4B8Nx58f/lgn5M6ZcQjB0EHj/LeguxVmftGxwmzEa0cv4eluMtxC9sAvXGUQnX5NlzNie2AYAlfFzV0FzkrehcYyrdVYzLhgHxYmR7DhWNngTTuOvwDhU3S5dqCju5e3TpSzIiOaYF/9rYTWBTM+r2pPFe/SWolTYBgCV2bGF0D26Tav+t7ZcVQ0drC/+JoihDWFUHZEzQZ06FbZnldJU0cP982J11rK2GXSMrXKPudZrZU4BYYhcGVCE1W3rhMv6HLZfXZaNOH+nrx06OKndxx/QTXimXa/NsKs5NUjl0kI82X+xDCtpYxd3NxVnKxkD9SXaq1GcwxD4OrM/KLqU3BOf8vuPd1N3D9nPHuKarhcbw4ad7ertNiUlcoXrDNKa1s4fL6ee+cYQWK7M2u9SqPOeU5rJZpjGAJXJ2U1+Ibpdoq8bu54BPDKkUtqQ96batXonK9qqmu0vHDoIu4mwd2zjJISdidwnBownHhRl6XZbYlhCFwddy+Y9SCc3Q5XL2itxmJig31YkhrFa0cv09ndA4f/BhGpqhGJzmjt7GFDThkrM2OIDPDWWo5rMPvL0F4PBa5d+NgwBAbqYUDA0WeGPdQZ+cK8CdS1dnH4wE6oOg1ZX9VlkHjj8TKaO3tYvyBBaymuQ+IiCJuk2+++rTAMgQEExaruZcdfgC4Lm744ATdOCichzBdx5CnwCtRl3wEpJc9/dJHM2CBmjjdWEjsMkwlmP6SyzCpPa61GMwxDYKCY+zXoaIDc17VWYjEmk+CrM/yY236AuuS7VVtOnXGwpI6SmhbWL0gwgsSOZvoDqp/34b9prUQzDENgoBg/H6Iz1cOgwwbfd8ndeIpe/ta2WGspo+IfH14g1M+T1VONLmQOxycEpn9OrTRudXECXgAAEYJJREFUtk8rSGfHKkMghAgVQuwWQhSb/4YMcswtQoiTA14dQojbzfv+IYQ4P2DfdGv0GFiBEDD361BToBq56InudrxP/J3iwAU8W+RGRUO71oos4sKVVvYUVbMuKx5vDzet5bgm876hGjYdeUprJZpg7YzgUWCPlDIZ2GP+/CmklHullNOllNOBxUAbMHBd9w/690spT1qpx8AaMu4Gv0g4+AetlVjGyZegrY6gZd9HAs8dPK+1Iot46kApHm4m1s9P0FqK6xKWBKmr4ejfobNFazUOx1pDsBbor1r2PHD7MMffDWyXUuovIukKeHjD/G/Cufeg4oTWakZGXy98+GeInUVkxhJWZcbwypHLNHXoo5hYTXMHG46VcdfMOCIDjZRRTVnwHRUnO6nPkivWYK0hiJJSVprfVwFRwxx/P/DKNdseF0KcFkI8KYTwGupEIcTDQogcIURObW3tUIcZWMvsh1TmzQc6mRUUblbrH274FxCCh2+aSEtnD68cvqS1shHx3MELdPf28fBNE7WWYhCfBXFZ8NFfdFlyxRqGNQRCiHeFEHmDvNYOPE5KKYEho4xCiBggExhYAP/HQAowBwgFfjTU+VLKp6SUs6WUsyMijP6tdsM7COZ8RS2wuVKitZrrIyUc/BOETlQrpIGM2CAWJIXx7MHzdPY498Pc3NHNi4cusiIjmsRwP63lGAAs+DY0XIS8jVorcSjDGgIp5VIpZcYgr01AtfkHvv+HvuY6l7oXeEtK+fGcXUpZKRWdwHOA/moGj0XmfUOtOP7wj1oruT4le1SnqQXfAdMnQdZv3TKJ6qZOXjs6wgb3GvHioUs0d/Tw9UX666c8ZklZDZFpsO+3LjUrsNY1tBlYb36/HrjeOu11XOMWGmBEBCq+kGelHgNb4B+p6rWffAUanPTHVErY+zgEjVepfwNYkBTGnIQQ/rK3hI5u53yYmzu6eWr/ORZNjmBqnLGAzGkwmWDRj6Cu2KVmBdYagieAZUKIYmCp+TNCiNlCiI/XbAshEoB4YN81578khMgFcoFw4NdW6jGwFTd+V6WU7vut1koG5+xONRtY9ANw/3TzFiEE3106meqmTl494pyxgucOXuBqWzffz56stRSDa0m9Tc0K9v/OZWYFVhkCKWWdlHKJlDLZ7EKqN2/PkVJ+ZcBxF6SUsVLKvmvOXyylzDS7mj4vpXS9vC1nJShOxQpOvgRXirVW82n6ZwMhCTBt3aCHzE8KIysxlP99/5zTzQoa27p5+kApy9KijNmAM2IywaIfwpWzLjMrMFYWGwzNjd8Ddx/1o+tMFL2jisvd9ENw8xj0kP5ZQU1zJy98dHHQY7Ti6QOlNHf08L1lxmzAaUldC5HpsPfX0NOptRq7YxgCg6Hxj1DrCvLfgspTWqtR9HTB7scgfPKwxeXmJ4WxaHIEf3qvmPrWLgcJvD7VTR08e/A8q6bGkBoTqLUcg6EwmSD7lyo1+cjTWqv5BDuVfzEMgcH1mf+IqsWy8yfOUYPo6DNQfw6yf63aDQ7DT1el0tbVyx/fPesAccPzux1n6OmV/PDWKVpLMRiOSUshabGKFbTVa60GqnLhmSV2Ses2DIHB9fEJhsU/hQsHtG/e0VYP+56AibdAcvaITkmOCmBdVjwvHr5ESY22IajTZQ28ebyML92YwIQwY92ALsj+NXQ2w/7/1FaHlLD9R1B/HnxDbX55wxAYDM+sL0FUJuz6qbb9CvY+rh7KWx+3qPHMvy6djK+HG7/eWoDUaFYjpeSXWwoI9/fkkVsmaaLBYBREpav05CNPQ02Rdjry3oSLB2HJzw1DYKARJjdY8VvV5P6DJ7XRcPmIKgg256vq4bSAcH8v/mVpMu+fqWVrbuXwJ9iBV49eJufiVX5w6xQCvAcPcBs4KUseUz0utvwL9PUNf7ytaW9Qg7CYaTDzi3a5hWEIDEZGwg0qOPvBfytfpSPp6VIPYeA4WPKzUV3iwQUJZMYG8YvNBTS2ObYgXXVTB7/ZVsjcxFDumRXv0Hsb2AD/COUiunwIjj8//PG2ZvfPoKUaVv/hUyvobYlhCAxGzvInwCcU3v4m9Drwx/TDP6o+Cav+C7wCRnUJdzcTT9yVydW2Lh7fVmBjgUMjpeRnb+fR1dPHE3dNxWQyuo/pkumfg4SFKmOtqcJx9z23F47/U9VAip1pt9sYhsBg5PiGwur/Vjn8B/7bMfcsPwbvPwHpd8KUFVZdKn1cEA/fNJHXc8rYme+YTlRvnShnV0E1/7p0slFYTs8IAWv+CH3dsPFhx6w47miELd+BsElw84/teivDEBhYRuoayLxHZe+cP2Dfe3U2w5tfAf9oZYBswHeXTiYzNogfbjhNuZ07mZXWtvDTt/PISgzlqwsT7XovAwcQlgQrfqcy6A7auSCjlLD529BYDrf/FTx87Ho7wxAYWM7qJyE0CTY8BM3V9rmHlLD5O2pBz11Pq7UMNsDT3cSf182gp7ePf3nlBN299gn+tXf18sjLJ/B0N/HH+6fj7mY8amOCGZ+H9DtUBtulQ/a7z9FnVLr20sdUnwQ7Y3w7DSzHKwDu/Sd0tcAbD9pnCf6B30P+Rlj8M5iwwKaX/v/tnXtw1cUVxz9fEx4CSkAQIbxrUBGMAkVQ26IiQa2ggg/QggrDdKz12Vas9dWxTrU+UFtRfI5UBUS0DFqQIKitHUqoyitAAj5IKgZohCmiDWT7x27gysN4c2/uJfd3PjO/4bfnt7N3zz03nN/unt3TtU1z7rmwN0WfVHLbayuSHlJaXe246eUPKN64jQcvzqd9y/p9mzNSiOQXbXO6wLTLoLIeji9ZtxDmToS8Ahj48+S3vx/MERh1o11PGP5H+PS95M+ZLp8Jb93to5ROuyF57cYw/MRcrjn9aKYt2cDjb69Patt/eHMNbyzfyK/PPo4zjq0taZ/R4Dg0B0bP8OsFL16S3F3HFcUwY4w/QmXEk/6oixRgjsCoO71GwJDfwarX4PUbkxNjvWq2dyxdToXzHolr41i83HhWD87L78C9c1fzzN+Sk/B+UuFaJi9ax6j+nRlv6wKZS5uj4eKp/riTqefDjsrE29y0Bp4f7tcDRs/w2QJThDkCIzFOuQZ+cBMsfQ5mjfcx/3Xlw+l+3SG3L4yeDo3qN5n7IYeIBy7KZ+jxR/HbOat4bFFpnaeJqqsd981dzaTCEkb27cjd5/dC9ejEjIOA7j+CS17wb/HPD08srPSzZfDsOf5+zGzISe1+E3MERuKceTsMvstvg39+mI90iIddVVB4J7w6AToPgMtn1nm/QLw0zj6ER0efxLD8Dtw3dw3XTvuAL/+3M642tu6o4uoX/sVji9Yxqn8n7h1xAlm2XyAa9BjincHmUphyOmxYEn8by2fC00N8etgr3oAjj01+P2shIUcg6SJJKyVVS+r3LfWGSlojqVTSxBh5N0mLg3y6pMYHasM4yDntehjxtH+zefxUP0L4LusGZUXw1GB/dEXfK+DyWSkdEgM0yvKRPb8sOIY5y/7N0Env8vbaTbWODpxzzFu5kYKH3mF+8ef85tzjuOeC3uYEokaPITB+vv+P/JkCmH+7D32uja3lfj3glXHQ4USYsMhPOaUBJRIxIek4oBp4AviFc65oP3WygLXAWUAZsAQY5ZxbJWkGMMs5N03S48CHzrnJtX1uv379XFHRPh9lHAxsLvHHQXzyd78R5vvjoUcBtO6+p86OSvjoHXj/z1DyJjRvC+c+CD2Hpa/fgX+s28Ktry5n/ebt9Omcw+iTuzDomLa0adFkd52KbV9RWFzBtCWfsqxsK3lHtuD+i/LJ72TZxiLNjkp48zZ4fyo0zYF+V/pQ03a99hwNsfNrH3a6/GVYNh0QDLoZTrn2gEmWkomkpc65fV7aE3IEMY0v4sCOYCBwp3OuIJRrtsj9HtgEHOWc27l3vW/DHMFBjnM+Bvq9R6E82KnJ4dDsCKj60p+bAnBYe+h3FQy42h/qdZDwVdUuZhRt4Ml317PhP37TWatmjWjRNJvtX+/aneSme9vm/PSH3+PCPrm2T8DYQ/lSeOcBWPtXcNWQ1QQOa+f/LraVe1n2oZB/qY+Ka9UlZV07kCOoPbNH4uQCG2LKZcDJwBHAF865nTHy3AM1ImkCMAGgc+fO9dNTIzlIcPz5/tpcAusXwZZS2L4ZGjfzuYY79vf7A+rpEK1EaNooizEDu/KTAV1YUb6N99Zt5uMtX/JV1S6aNsoi78gW9O/WmuM7HG4Lwsa+5PaFUS/633tpIXy+Ev5b4f8uWnaC9if4hDeND54jR2p1BJIKgaP28+hW51zKMpU456YAU8CPCFL1uUaCtMnzVwNEEr07tqR3x9SuWRgZQvM2/q2/AVCrI3DODU7wM8qB2FiojkG2BciRlB1GBTVywzAMI4WkYmJzCZAXIoQaA5cCs51fnFgIjAz1xgJpzoVoGIYRPRINH71AUhkwEHhd0rwg7yDpDYDwtn8NMA8oBmY451aGJm4GbpRUil8zeDqR/hiGYRjxk5SooVRjUUOGYRjxc6CoIYt5MwzDiDjmCAzDMCKOOQLDMIyIY47AMAwj4jTIxWJJm4C6pgZqA2xOYncaAqZzNDCdo0EiOndxzrXdW9ggHUEiSCra36p5JmM6RwPTORrUh842NWQYhhFxzBEYhmFEnCg6ginp7kAaMJ2jgekcDZKuc+TWCAzDMIxvEsURgWEYhhGDOQLDMIyIEylHIGmopDWSSiVNTHd/koGkTpIWSlolaaWk64K8taT5kkrCv62CXJIeCd/BMkl90qtB3ZGUJel9SXNCuZukxUG36eHYcyQ1CeXS8LxrOvtdVyTlSJopabWkYkkDM93Okm4Iv+sVkl6S1DTT7CzpGUkVklbEyOK2q6SxoX6JpLHx9CEyjkBSFvAn4GygJzBKUs/09iop7ARucs71BAYAPwt6TQQWOOfygAWhDF7/vHBNACanvstJ4zr80eY13As85Jw7GqgExgX5OKAyyB8K9RoiDwNznXPHAvl43TPWzpJygWuBfs65XkAWPp9Jptn5OWDoXrK47CqpNXAHPg1wf+COGufxnXDOReLC50yYF1O+Bbgl3f2qBz3/ApwFrAHaB1l7YE24fwIYFVN/d72GdOEz2i0AzgDmAMLvtsze2974XBgDw312qKd06xCnvi2Bj/budybbmT35zlsHu80BCjLRzkBXYEVd7QqMAp6IkX+jXm1XZEYE7PlR1VAWZBlDGAqfBCwG2jnnPguPNgLtwn2mfA+TgF8B1aF8BPCF84mQ4Jt67dY5PN8a6jckugGbgGfDdNhTkpqTwXZ2zpUD9wOfAp/h7baUzLZzDfHaNSF7R8kRZDSSWgCvANc757bFPnP+FSFj4oQl/RiocM4tTXdfUkg20AeY7Jw7CdjOnukCICPt3AoYjneCHYDm7DuFkvGkwq5RcgTlQKeYcscga/BIaoR3Ai8452YF8eeS2ofn7YGKIM+E7+FUYJikj4Fp+Omhh4EcSdmhTqxeu3UOz1sCW1LZ4SRQBpQ55xaH8ky8Y8hkOw8GPnLObXLOVQGz8LbPZDvXEK9dE7J3lBzBEiAvRBw0xi86zU5znxJGkvC5noudcw/GPJoN1EQOjMWvHdTIx4TogwHA1pghaIPAOXeLc66jc64r3o5vOecuAxYCI0O1vXWu+S5GhvoN6s3ZObcR2CDpmCA6E1hFBtsZPyU0QFKz8Duv0Tlj7RxDvHadBwyR1CqMpIYE2Xcj3YskKV6QOQdYC6wDbk13f5Kk02n4YeMy4INwnYOfG10AlACFQOtQX/joqXXAcnxERtr1SED/QcCccN8d+CdQCrwMNAnypqFcGp53T3e/66jriUBRsPVrQKtMtzNwF7AaWAFMBZpkmp2Bl/BrIFX4kd+4utgVuCroXgpcGU8f7IgJwzCMiBOlqSHDMAxjP5gjMAzDiDjmCAzDMCKOOQLDMIyIY47AMAwj4pgjMAzDiDjmCAzDMCLO/wHIWvqAaYANKQAAAABJRU5ErkJggg==\n",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "iS8nRuBZYLcD",
+        "outputId": "299dc977-ff2f-43a4-c0d2-9fa6c7eaeeb2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 282
+        }
+      },
+      "source": [
+        "def clip_sin(x):\n",
+        "  x = clip_gradient(-0.75, 0.75, x)\n",
+        "  return jnp.sin(x)\n",
+        "\n",
+        "plt.plot(clip_sin(t))\n",
+        "plt.plot(vmap(grad(clip_sin))(t))"
+      ],
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "[<matplotlib.lines.Line2D at 0x7efe2c233cf8>]"
+            ]
+          },
+          "metadata": {
             "tags": []
+          },
+          "execution_count": 25
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9d3yU15X//z6jXpCECuogAQIVRBWywd0GmWawsR0bp+AkjlN3s0l+yTrfZJNsNskrye5+k82mfOMUx3HibsdgU0wzxrFNEVUFAUJUdSSQEEL9/v54Ro6MJUtTn3lm7vv1mpdm7tM+o5lnzr3nnnuOKKXQaDQaTeBiM1uARqPRaMxFGwKNRqMJcLQh0Gg0mgBHGwKNRqMJcLQh0Gg0mgAn2GwBzpCYmKiysrLMlqHRaDSWYv/+/ReUUknXtlvSEGRlZVFaWmq2DI1Go7EUInJmuHbtGtJoNJoARxsCjUajCXC0IdBoNJoARxsCjUajCXC0IdBoNJoAxy2GQET+KCJNIlI+wnYRkV+ISLWIHBGRuUO2rRWRE/bHWnfo0Wg0Gs3YcdeI4E/Akg/ZvhTIsT8eBX4DICLxwHeB64Bi4LsiMt5NmjQajUYzBtyyjkAptUtEsj5kl1XAn5WR83q3iMSJSCpwK7BVKdUKICJbMQzKM+7Q5Q/09g9QUddORV0blzp7EYG02AjmThzPxIRIs+VpNB5DKcXJ5iuU1V6ioa2bvv4BkmPCyUuNoSAtBptNzJboN3hrQVk6cG7I6/P2tpHaP4CIPIoxmmDixImeUelDNLZ38btdNfztYC0tV3qG3SdnQjSfWDCJ+4syCQ8J8rJCjcYzXO3p5y+7z/DsvrOcbL4y7D6J0WE8MD+DtQuzmDAu3MsK/Q/LrCxWSj0OPA5QVFTkt9V0evsH+PUbJ/nNm9X09SsW5yezrDCV2ZlxTIgJo39Acba1k90nW3j5YC3/tq6C3+6q4Xt3FbAoP9ls+RqNS2w4Us+/v1pB0+Vu5meN55M3ZFOcHU/m+EhsNmho6+LA2YtsLGvg1ztP8qe3T/OVxdN4eGEWwUE69sVZvGUIaoHMIa8z7G21GO6hoe07vaTJ56i7dJXP/2U/h8+3sXxmKv96Z+6w7p/clBhyU2JYuzCLd0+28L1XK3jkz6WsXTCJ/7M8j7BgPTrQWIuu3n7+z8tlvHywlpkZsfzyobkUZ8d/YL9JCVFMSojinjkZ1DR38B+vVfKDDUfZdrSRX6yZo0cHTiLuKlVpnyN4TSk1Y5hty4EvAcswJoZ/oZQqtk8W7wcGo4gOAPMG5wxGoqioSPlbrqHy2jY+9ad9XO3p5yf3zWRZYeqYj+3pG+Cnm6v4/d9PcV12PL9fW8S48BAPqtVo3EdLRzef+XMpB85e4st35PBPt08dc+9eKcXLB2r51itljI8M5alPX8fUCdEeVmxdRGS/Uqro2nZ3hY8+A7wLTBeR8yLyaRH5nIh8zr7LRqAGqAZ+B3wBwP6D/x/APvvj+6MZAX/kwNmLPPDbdwkJsvHi5xc6ZAQAQoNtfHtFPj9/YDb7z1zkod/t4eII8woajS9xoaObj/z2XSrq2vnNR+fylcXTHHLxiAj3zsvgpc8vpLdf8cBv36W8ts2Div0Tt40IvIk/jQgq6tpY8/huxkeF8vxnF5Ac49rQdkdVI5/7ywEK0mJ4+pHriQjVbiKNb3Kps4c1v9vDqQsdPPnJYq6bnODS+U5duMLHfr+Hq739vPz5hWQlRrlJqf/g0RGBxjnq267y8BP7iA4L5q+PXOeyEQC4PTeZXzw4h8PnLvGlpw/Q1z/gBqUajXvp7R/gc3/Zz8mmDn73iSKXjQBAdmIUT326GKUUa5/Yy4WObjcoDQy0ITCJrt5+PvfUfjq7+/jTp4rJGO++NQFLZqTw7ysL2F7VxH9vPe6282o07uL7r1ayu6aVn9xXyE05H6iT4jSTk6L5w8PzaWzv4gt/1R2hsaINgUl8d10Fh8+38bMHZjMteZzbz//xBVmsKc7kNztPsrWy0e3n12ic5cX953lq9xk+e/Nk7pmT4fbzz504nh/dU8jeU6381xbdERoL2hCYwObyep4rPccXbp1CSUGKx67z3bsKmJEew9eeP0R921WPXUejGStnWzr57rpyrsuO5xtLcj12ndVzM3jouon8vzdP8saxJo9dx1/QhsDLNLV38c2XyyhMj+Uri6d59FrhIUH8cs1cevsVj71UhhUDAzT+Q1//AP/y3EFsNuH/PjCbIA+niPjOinymJ4/jsZeO0NbZ69FrWR1tCLyIUop/fekIV3v7+dkDswnxwkrIrMQoHluay5vHm3m+9NzoB2g0HuLxt2o4cPYSP7h7BulxER6/XnhIEP91/ywudPTw/dcqPX49K6MNgRfZVN7AG8ea+fqduV5d9PLx6ydx/eR4/uO1ozS0dXntuhrNIGdbOvmfbSdYUpDCqtnDphPzCIUZsXz+lim8dOA8O6r0XNlIaEPgJS539fLvr1aQnxrD2gWTvHptm0346b2z6O0f4Ecbj3r12hqNUorvrC8n2CZ8d2W+16//T3dMZeqEaL63vpKu3n6vX98KaEPgJX629QRNl7v54T0zTEmONTEhks/eMoX1h+vYXdPi9etrApfN5Q3sPNbMV0umkxrreZfQtYQFB/G9uwo429rJ73bVeP36VkAbAi9Q3dTBk++e5sH5E5kz0by6O5+/ZQrpcRF8d12Fjq/WeIXuvn5+uPEouSnjvD4SHsqNOYksKUjhVzurqbukI+iuRRsCL/DTzVWEB9v4Wolno4RGIyI0iH9bkcexxss8s09PHGs8z1PvnuH8xat8e3m+6Wmiv7U8D6Xgx5uqTNXhi2hD4GFKT7eypbKRz90yhcToMLPlcGdBCkWTxvO/209wtUf7SzWeo62zl//dUc3N05K4MSfRbDlkxkfyqRuzWX+4jsq6drPl+BTaEHgQpRQ/2niUCePC+PRN2WbLAYxsjd9YkkvT5W7+9M5ps+Vo/Jhf76ymvauXxzy4cMxRPnfzFGLCg/mvLcfMluJTaEPgQbZUNnLg7CW+ungakaG+UwyuODueW6cn8Zud1XqhjcYjNLR18cQ7p7lnTjr5aTFmy3mP2MgQPnvLFHZUNVF6OuAy3o+INgQeQinFL7afICshkvvmuT+fiqt8/c7ptHf18dtdJ82WovFD/t+bJ+kfUHxlkbnzYsPxyRuySIwO46ebj+nV9na0IfAQO6qaqKhr5wu3jb3akjcpSItl+cxUnnzntB4VaNxK0+Uuntl7ltVz0smMd19WXXcRGRrMP90+lb2nW3lXh1ID7qtQtkREjolItYg8Nsz2n4nIIfvjuIhcGrKtf8i29e7QYzZKKX6xo5qM8RHcM8d7qygd5Uu3TeVKTz9PvnvabCkaP+J3u2roG1B86fapZksZkQfmZ5IYHcZvduoRMbjBEIhIEPArYCmQD6wRkfctH1RKfUUpNVspNRv4X+DlIZuvDm5TSq10VY8v8NaJCxw+d4kv3DrVK/mEnCUvNYY7cifwx7dPcaW7z2w5Gj/gQkc3f9l9llWz05iU4LsVwsJDgnjkpuz37tVAxx0zmMVAtVKqBkBEngVWASNleVoDfNcN13WcTf8KZ3d75twFd8ONXwHglzuqSY0N5955vjsaGOQLt03l3t+8wzN7z/LITZPNlqOp3Q+vfxt6O43XMjRDpzjZNmSbw22MvN/g63FpsPIXEBTCE2+foquvny/e5rujgUE+et1Efv1GNb/eWc1vP/6B6o0BhTsMQTowdHXSeeC64XYUkUlANrBjSHO4iJQCfcCPlVKvjHDso8CjABMnTnROaXgcRCc7d+yH0XYOdvwQClZzqCOWvadb+fbyPMKCfb9e8LxJ41kwOYHHd9Xw8QWTLKHZb1EKNnwNmo9D1o2Aev8248nIbe+b+Bxr24ecayzX7OuCmp2Qs4jOaav4y+6z3JmfwpQk7yVVdJZx4SE8vDCLX+yo5kTjZXI8UCDKKng7pvFB4EWl1NCVTJOUUrUiMhnYISJlSqkPOO6UUo8Dj4NRvN6pq9/2TacOG5W2WvifmbD7N/zh0gOMCwvmgfmZnrmWB/jCbVP4+B/2sv5QHfcXWUe333F2N9QdhOX/DfMfMVvN2BgYgF8Wwbu/4qX2ubRd7eUzN/vGmpmx8PAN2fzurVM8vquG/7x/ltlyTMMdDuxaYOivR4a9bTgeBJ4Z2qCUqrX/rQF2AnPcoMm7xKZDwWoGDj7FrrKTPFicybjwELNVjZkbpyYyLTmaJ94+rcPpzGT3ryBiPMxaY7aSsWOzwfWfh9r97N61mdmZccw1MZ+Wo8RHhbJ6bjrrDtfREsDF7t1hCPYBOSKSLSKhGD/2H4j+EZFcYDzw7pC28SISZn+eCNzAyHMLvs31n8PW08F9tjdZuzDLbDUOISJ88oZsKuvb2XtKL7IxhdZTULUB5n0SQn13knVYZj9Eb2gsy6+8zCM3ZSPDzS/4MA8vzKKnb4Bn9p41W4ppuGwIlFJ9wJeA14GjwPNKqQoR+b6IDI0CehB4Vr2/y5kHlIrIYeANjDkCSxqCjsRZHFTT+VzENjJizc8p5Ch3z04nLjKEJ94+bbaUwGTPb0GCoPhRs5U4TmgUr4XcyZ1BpSxJs16vOid5HDflJPLU7jP0BmhWXrfENiqlNiqlpimlpiilfmhv+45Sav2Qfb6nlHrsmuPeUUoVKqVm2f/+wR16zOCF0nP8vvdOknrr4PjrZstxmIjQIB4qnsiWygbOtXaaLSew6GqHg0/BjNUQk2q2Gocpr23jxy03I2IjuPRxs+U4xSdvyKKxvZuNZfVmSzEF3w1ytxBKKZ7afYaG9MUQkwF7fmO2JKf4+IJJiAh/fve02VICi7LnoacDij9rthKn+MvuM7SHJNGXuxIO/hV6rpgtyWFunTaB7MSogB0Ra0PgBnbXtFLTfIU110+G4kfg1C5osl5JyNTYCJbOSOHZfed0impvoRTs+yOkzoL0uWarcZj2rl7WHapj5aw0Qq9/FLrboPzl0Q/0MWw2Ye2CSRw6d4lDAbjATBsCN/DXPWeICQ9mxcxUmP0xsIXA/ifNluUUH7t+Epe7+tgQoENkr3NuLzRVQNGnh1/E5eO8crCWq739fPT6iTDxekjKg9I/mi3LKe6dl0FESBDP7Am8SWNtCFyk+XI3r1c0cN+8TMJDgiA6CfLugsPPQK/1SuJdlx3P5KSogI6g8Cqlf4SwGJhxr9lKHEYpxV92n2FmRiwzM+IMQ1b0Kag7YKyHsBjjwkNYOSuN9YfruNwVWIkYtSFwkRf2n6O3X/HQdUNWO897GLouQaX1cuiJCA8VT2T/mYsca7hsthz/prMVKv4GMx+AMN9fiXstpWcucryxg48O/e7PegBCIi07Klhz3USu9vaz7lCd2VK8ijYELjAwoHh6z1munxzP1AlDbuSsmyB+Mux/wjxxLrB6bgahQTY9KvA0h/4K/d1GL9qC/HX3GcaFB3PXrLR/NIbHQuF9UPYidLWZJ85JZmXEkpcaw9N7zgbU4kptCFxg14lmzl+8ykevm/T+DTYbzF0LZ9+FJusVyo6PCmXJjBRePnCerl49aewRBgag9AmYuACS80ff38dovdLDxrIG7p2b8cHqe0WfMpLmHXneHHEuYIyIM6msb6es1nqGzFm0IXCBZ/eeIyEqlDsLUj64cfZHjUnjA9acNF5TPJH2rj42HNGTxh7h7DvQetJwI1qQvx2spad/gDXFwySATJsDKTONtREWZNWcdMJDAmtErA2Bk7Re6WF7VSP3zEknNHiYf2N0EuStgENPQ2+X9wW6yPWT45mcGMXTAXQzeJVDT0PoOMizZgmOF/efZ1ZGLNNTRsjYOedjUH8YGsq9K8wNxISHcNfMNNYdqqMjQOp0aEPgJOsP1dLbr7j3w+oRz/2EMWl8bKP3hLkJEeGB+ZnsP3ORmuYOs+X4F90dUPEKzLgHQn2vlONoVNS1cbS+/cNrcRfeD0GhxjyIBXmweCKdPf1sOBIYk8baEDjJiwfOMyM9hrzUmJF3yr7FKNpx+JmR9/Fh7pmTjk3g5QMjJZPVOMXR9dB7xXAfWpAX958nNMjGylkfUngpMh6mL4Ujz0Ffj/fEuYm5E+OYnBjFSwHy3deGwAmO1rdTXtvOfXM/pEcEYAsywumqt8PlRu+IcyMTYsK5KSeJvx2sZWAgcCIoPM6hpyF+CmQOW7/Jp+npG2DdoToWFyQTGzlKqvXZH4XOFjixxTvi3IiIcO+8DPaeag2I3FvaEDjBS/vPExIkrJw9hlKUs9aA6oeyFzwvzAOsnptO7aWr7D7VYrYU/6D1FJx+C2Y/ZMmVxDuqmmi90vPhbqFBptxhVAS0qHvo7jnpSICMiLUhcJDe/gFeOVTLHbnJxEeFjn5A0nRImwuHn/W8OA9wZ0EK48KCeWm//98MXuHws4DArAfNVuIUL+4/z4RxYdw0NXH0nYOCjcVyx1+HjibPi3Mz6XERLJicwMsHz/v9mgJtCBzkzWPNXOgYY49okNkPQWMZNJR5TpiHCA8JYvnMVDaV19PZExgRFB5jYAAOPw2Tb4VYB74/PkLz5W7eONbEPXPTCQ4a40/HnI8ZI+Ijz3lWnIdYPTeDMy2d7D9z0WwpHkUbAgd5cf95EqNDuWV60tgPmnGvsabAoqOC1XMz6OzpZ3N5g9lSrM2Zt+HSWctOEq87VEv/gBp9bmwogyNiCy4uA1gyI4WIkCC/nzR2iyEQkSUickxEqkXksWG2PywizSJyyP54ZMi2tSJywv5Y6w49nqKts5ftVY2smp1OyFh7RGCPoFhi3Az91utVz88aT2Z8BC8dOG+2FGtz5DkIjYbc5WYrcYpXDtUyMyOWnOQR1g6MxMyPQMMRaD7mGWEeJDosmKUzUnjtSJ1fr7J32RCISBDwK2ApkA+sEZHh1sw/p5SabX/83n5sPPBd4DqgGPiuiPhs5etN5fX09ivuHssk8bXMWgNXmuDkdvcL8zAiwuo5GbxzsoW6S9bLqOoT9HUbSQjz7rLk2oHqpg7Ka9tZ5cx3v2A1iM3CARMZXO7qY9tR60X+jRV3jAiKgWqlVI1Sqgd4Flg1xmPvBLYqpVqVUheBrcASN2jyCOsO1ZGdGMWM9A9ZOzASOSUQEW/hmyEdpeDVw4GxwMbtnNhqFG2ZcZ/ZSpxi/eE6RDBqbjjKuGRjTU3ZC0YhHouxYEoCqbHh/M2P3UPuMATpwLkhr8/b267lXhE5IiIvikimg8ciIo+KSKmIlDY3N7tBtmM0tnex+1QLK2elIc6E/QWFQP4qqNoIPdaLS56UEMWszDjWa0PgHOUvQmQiTL7FbCUOo5Ti1cN1LJicQHJMuHMnKbwfLp6G86Vu1eYNgmzCipmp7DrRzKVO6y2OGwvemix+FchSSs3E6PU7nIlNKfW4UqpIKVWUlOTARK2bePVwHUrBytlpo+88EjPuNVaUHt/sPmFe5K6ZqVTUtXNSp5xwjO7LcGwTFNxjdAgsRlltG6cuXGHlLBe++3l3QVCYUZ/ZgqyclU5vv+L1Cv8MmHCHIagFMoe8zrC3vYdSqkUp1W1/+Xtg3liP9RVePVxHQVoMU5JcKCAyaSFEp0D5S+4T5kVWzExDRLuHHKZqI/R1GXn6Lcj6Q3WEBAlLZzjhFhokPMYImCh/2ZIBEzPSY8hKiPTbEbE7DME+IEdEskUkFHgQeF9pLhEZ+g1aCQxWdn8dKBGR8fZJ4hJ7m09x+sIVDp9vY5UrowEwUk7MWG0subdg0Y6U2HCKs+LtoyPr+XpNo+wFiJ0IGcVmK3GY/gHFq0fquGXahNFTSoxG4Ueg8wKc2ukWbd5ERLhrVhrvnmyh6bL1sgmPhsuGQCnVB3wJ4wf8KPC8UqpCRL4vIoM5dv9ZRCpE5DDwz8DD9mNbgf/AMCb7gO/b23yKwV7AipkuGgIw3EP9PXD0NdfPZQIrZ6dxsvkKR+t1GcsxceUCnNxhdABs1lu2s/dUK43t3a53ggByFhsVzI5YM2Bi5aw0BhRsKvM/95BbvplKqY1KqWlKqSlKqR/a276jlFpvf/5NpVSBUmqWUuo2pVTVkGP/qJSaan/4XG1HpRTrDtVSnBVPWlyE6ydMnwdxkyzrHlo6I5Vgm/jtENntVL5irKwtvN9sJU6x/nAtkaFBLMpLdv1kwWH2gInXoNd6Ycg5yePITRnnl99963VRvExlfTsnm6+4Nkk8FBFjVFCz0+gtWoz4qFBuzEnU7qGxUvYSJOVCcoHZShymp2+AjWUNlOQnExEa5J6TFtwDPR1Qvc095/Myd81KY/+Zi5y/aL3Ivw9DG4JRWH+4jmCbsKzQhYmya5lxr9FLrHzFfef0InfNTKP20lUOnL1kthTfpq3WKEk54z5LZhp960QzbVd73dcJAsi62VhPU2Hd7z7gdyVctSH4EJRSbCyrZ+HUxLFlGh0ryQVGL7H8Zfed04uUFCQTGmzT0UOjcdQeMzFjtbk6nGRjWQMx4cHcONWN4dpBwUYo6fHNlnQPTUyIZFZmHK/6WeUybQg+hIq6ds61XmV54TDF6V1h0D105m2j12gxxoWHcPv0CWwoq6dfF6wZmcp1kFwICVPMVuIwPX0DbK1sYHF+yvA1uV2h4G5ru4dmplJe2+5XJVy1IfgQNpbVE2QTFue72RCA4SsFY+LMgiyfmUrz5W6/T8/rNO31cHa3MTlqQd4+eYH2rj6WubsTBJZ3Dw1GD24s8x/3kDYEIzDoFlowOcG9bqFBEnNgQr7Ra7Qgt+VOICzY5lc3g1s5+iqgLGsINpXVEx0WzI05YyhA4ygWdw+lxIYzd2Icm/woLbs2BCNQ1XCZ0y2dLPVEj2iQ/FVw5h1L1jOODgvm5mlJbC5v0PWMh6NyHSTlQdI0s5U4TG//AFsqG1mUN4GwYDdFC12Lxd1DywqNdCtnW/wjekgbghHYVFaPTYxSjR4jbyWgLOseWlaYQkN7F4fO6+ih99HRZMz/FNxtthKn2F3TwqXOXvdGyl2Lxd1Dg78Lm8r9Y0SsDcEIbCxv4LrsBBKjwzx3kQl5kJBjWffQHXnJhAQJm7R76P0cXY+V3UIby+qJCg3i5mkeTO5ocfdQZnwkMzNi2egn7iFtCIbheONlqps6PDNRNhQR48fi9N8tubgsJjyEG6cmsrGsQS8uG0rlOkicZoQIW4y+/gFer2jk9rxkwkM85BYaxOLuoSUzUjh87hK1flCsSRuCYdhYVo942i00SP4qY3FZ1QbPX8sDLC1MpfbSVcpr282W4htcuWAY9vxVllxEtvdUK61Xelg2wwvffYu7hwazsfpDLW9tCIZhU1kD8yfFM8HZIhyOkFII47P+sfjIYpTkJxNsEzb6ia/UZapeAzUA+dacH9hQVk9ESBC3Tp/g+Yu9zz1kvYye2YlR5KaMY7MffPe1IbiG6qYOjjVe9my00FAG3UM1O+Gq9WLy4yJDWTAlgU1l9do9BEbvNn6KJXML9Q8YhVduz53gvtxCo5G30nAPnXrTO9dzM8sKUyk9c5GmdusZsqFoQ3ANg9bdpSIcjpK/Cgb6jCpWFmTpjFROt3RS1RDgqak7W+HULsu6hfadbuVCR4/3OkEA2TdDWIxlR8TLClNQCstXLtOG4Bo2ljUwb9J4UmK94BYaJG0uxGZCpTVvhpKCZGyCjh6q2mDM91g0WmhTWT1hwTZu84ZbaJDgUMgpMTpBFqxcNnXCOKZOiGajxWsUuMUQiMgSETkmItUi8tgw278qIpX24vXbRWTSkG39InLI/jD1l/BMyxUq69tZ6o2JsqGIGEPkk9uhy3qTronRYRRnx/tNKJ3THF1v1JpInWW2EocZGFBsrmjg1ulJRIUFe/fieXdBZwuc2+3d67qJZTNS2HOqhZaO7tF39lFcNgQiEgT8ClgK5ANrRCT/mt0OAkX24vUvAj8dsu2qUmq2/bESE9lSYazw9Uq00LXkrzIqlx33uUqdY2JZYSrVTR2caAxQ91D3ZWOeJ+8uS7qFjtS20djebc53f+oio7C9Rav2LZmRyoCCLZXWyxAwiDtGBMVAtVKqRinVAzwLvG9srJR6Qyk1uBZ7N0aRep9jS2UD+akxZMZHev/iGfMhOtmyq4xL7In5rHwzuET1NsOQ5y43W4lTbKloIMgm3J7rRbfQIGHRMOV2e8SV9QIO8lLHMSkh0tLzBO4wBOnAuSGvz9vbRuLTwNBZ0XARKRWR3SIyYsydiDxq36+0ubnZNcXDcKGjm9IzFykpcENJPmew2WD6MuMHxYKhdCmx4czKjGOLhW8Gl6jaAJEJkHmd2UqcYktlI9dlxxMX6YEEi2MhbwW0nYP6Q+Zc3wVEhJL8ZN6pbuFyV6/ZcpzCq5PFIvIxoAj4zyHNk5RSRcBDwM9FZNjk7Uqpx5VSRUqpoqQk9y993360EaX+0bM1hdwV9lC6XeZpcIGS/GQOn2+jvs36Ky0doq8Hjm+B6UvB5qWwSzdS09xBdVMHJfkmdYIApi0FCbKse6ikIIWe/gHePO7+Tqo3cIchqAUyh7zOsLe9DxFZBHwLWKmUem9WRSlVa/9bA+wE5rhBk8NsqWgkPS6CvNRxZlzeYDCUrupV8zS4wKB/eVuguYfO/B262wxDbkG22j+vxWbMDwwSlQCTFlrWNTp34ngSo0Pfm2e0Gu4wBPuAHBHJFpFQ4EHgfdE/IjIH+C2GEWga0j5eRMLszxOBG4BKN2hyiCvdfbxVfYGSgmTEzIm+4FDIWWyE0g30m6fDSaZOiGZyUhSvW/RmcJqqDRASCZNvNVuJU2ypbGRGegzpcRHmCsm7C5qr4MIJc3U4QZBNWJSXzBtVTfT0DZgtx2FcNgRKqT7gS8DrwFHgeaVUhYh8X0QGo4D+E4gGXrgmTDQPKBWRw8AbwI+VUl43BLuON9PTN2CuW2iQ3OVwpRnO7zNbiVOU5Kewu6aFtk5r+kodRimo2ghT74AQk39InaDpchcHzl5kcZ6PfPfBXtTHepQUJHO5u493a1rMluIwbpkjUEptVEpNU0pNUUr90N72HaXUevvzRUqp5GvDRJVS7yilCpVSs+x//+AOPY6ytbKRuMgQ5meNN6TrJEwAACAASURBVOPy72fqYrCFWHaIXFKQTN+A4o1jTaPv7A/UHYTLdZZ1C20/2mTMjZkVJDGU2AxjcaVFv/sLpyQSGRpkyYCJgF9Z3Ns/wPaqJu7ITSY4yAf+HeExMPkWY9LMgqF0szPiSBoXxpZK690MTlG1wZjkzCkxW4lTbKloIDM+gtwUE+fGhpK3Amr3Q9sHphl9nvCQIG6dnsTWykbLVe3zgV8+c9l3qpW2q72+0SMaJHc5XDwFTUfNVuIwNpuwOD+Zncea6eq13jyHw1RtMCY5I+PNVuIwHd19vF3dQkl+irlzY0PJvcv4a9G07CX5KTRd7uawxar2Bbwh2FLZSHiIjZtzPFiNyVGmLwPEwjdDMp09/bxz0nrFdhyi5SQ0H7WsW2jX8WZ6+gfMDRu9lqRpkDjdspFzt02fQLBNLLewMqANgVKKLRUN3JST5L20u2NhXIqx0tiivtIFUxKIDgu2bCjdmBk01LnLzNXhJFsqGoiPCmXeJB+YGxtK3go4/baRzdVixEaGcP3kBMvNEwS0Iaioa6eurcu3ekSD5C43Vlm2nTdbicOEBQdxW+4EtlY20m8xX6lDVG2AlJkQN9FsJQ7zj7mxCb4xNzaU3BVGFleL5t0qKUjmZPMVqps6zJYyZnzsG+BdtlQ0YBOjCLvPMehuqNporg4nKclPpuVKDwfOWq/YzpjoaIJzeyzrFtpT08rlrj4W+2InKG0OjEuz7Ih4kf33ZKuF3EOBbQgqGynKiic+yqT8Kh9G4lRL+0pvnZ5ESJBYbog8Zo5tApR13UKVDYSH2LjJl+bGBhExRsTV26Gnc/T9fYy0uAhmZsRaKnIuYA3BWXtFLZ90Cw2Su9yyvtJx4SEsnJLIlspG/yxhWbXBcAklzzBbicMopdha2cjNvjY3NpS8FdB3FWreMFuJU5TkJ3Pw7CUaLVLCMmANwaC19onVxCMx6Cs9scVsJU5RUpDMmZZOjjdax1c6Jro7jNoDuSssWXugvLad+rYuSszMLTQak26A8FjrRs7Z/7dWcQ8FsCFoJDdlHBMTTKg9MFbS5sC4VMv6ShfbfaV+5x46uR36u61be6DSPjdmRu2BsRIUAtOWWLaEZc6EaLISIi0TRhqQhqClo5vS062+3SOCITUKtkOv9VI7T4gJZ87EOMvcDGOmagNExEPm9WYrcYotFY0UZ8cz3hfnxoaSuxyutsLZd81W4jAiQklBCu+evEC7BWoUBKQh2F7VxIDCt+cHBslbAb2dcNKqvtIUymrbqL1kPUM2LP29cHyzUXsgyMu1fd3A6QtXONZ42bddooNMXQTB4dZ1D+Un09uv2HnM92sUBKQhGKw9UJAWY7aU0Zl0o1Gj4JhFbwZ76g6/qVFw5m3oarOsW+i92gNW6ASFRsHk2wxDYMGAgzn2GgVWKGEZcIbgak8/f69uZnG+ybUHxkpwqJHQzKI1CqYkRTMlKcpSoXQfStUGCI4wfqAsyJbKBvLMqsvtDLnLoe0sNJSZrcRhBmsUvHmsme4+3753A84Q7DrRTFevj+VXGY3c5dDZYixgsiAlBSnsrmm1fo0CpQxDMOV2CLXID+kQLnR0s//MRWt996cvBbFZNmCipCCZju4+3j3p2zUKAs4QbKloJDYihPnZFsoWOXURBIVa2lfaP6DYcczi7qH6Q9Bea1m30I6j9rkxX8q0OxpRiTBxgWW/+4M1Cnw9jNQthkBElojIMRGpFpHHhtkeJiLP2bfvEZGsIdu+aW8/JiJ3ukPPSPT1D7C9qpE7cicQ4mv5VT6M8BjIvsWyvtJZGXFMGBfm8zfDqFRtMHqn05aYrcQptlQ2kB4XQX6qBebGhpK7HBrLofWU2UocJjwkiFum+X6NApd/DUUkCPgVsBTIB9aISP41u30auKiUmgr8DPiJ/dh8jBrHBcAS4Nf283mEfacvcqnTx2oPjJXcZZauUbDIH2oUVG2EiQuNQusW40p3H7tO+EBdbmeYbk/jccyiebcKkn2+RoE7usXFQLVSqkYp1QM8C6y6Zp9VwJP25y8Cd4jxbVwFPKuU6lZKnQKq7efzCFsqGwgLtnHzNB/MrzIagzeDRYfIlq9R0FoDTRWWdQu9dcKH6nI7Sny2kcrjqDXnCW6fnkyQj9cocIchSAfODXl93t427D72YvdtQMIYjwVARB4VkVIRKW1udi4ut6dvgEV5yUSGWi/+W9coMJnBLLBWTTJX4UN1uZ0hdwWc2w0dvh+Tfy2xkSFclx3v065RyzjKlVKPK6WKlFJFSUnO9eh/eE8hv3xojpuVeRGL1yi4dXoS245atEZB1QajVzo+y2wlDtNnrz1wuy/WHhgructBDRiL+SxISX4y1U0dnGz2zbxb7vhW1AKZQ15n2NuG3UdEgoFYoGWMx7oVy/lHhzLd7pY4tslcHU5SUpDChY4eDp2zWI2CKxeM3qhF3UJ7T9vrclvRLTRISiHETrSsa3Sxjyehc4ch2AfkiEi2iIRiTP6uv2af9cBa+/P7gB3KyE28HnjQHlWUDeQAe92gyT9JmgYJOZZ1D/2jRoFv3gwjcnyz0Rudbl23kDE3lmi2FOcZrFFwcoeR/dVipMdFMCM9xmcTMLpsCOw+/y8BrwNHgeeVUhUi8n0RWWnf7Q9AgohUA18FHrMfWwE8D1QCm4EvKqUsHFbiBXKXw+m/w1WL9aqBmHCjnuvrFQ3WqlFQtQFiMiB1ltlKHGaw9sBNOYnWnBsbSt4KI+vrye1mK3GKkvwUDp67RNNl36tR4BaHoVJqo1JqmlJqilLqh/a27yil1tufdyml7ldKTVVKFSulaoYc+0P7cdOVUtb0eXiT3BUw0AcntpqtxClKClI43dJpnXquPfaEf7nLLFl7oLK+ndpLV63tFhok83oj66tV3UP5ySgF2482mS3lA1h05iiASZ8H0cnWvRkGaxT4qK/0A5zcYVTKsuj8wJaKRkTg9jwfrj0wVoKCjZQTxzcbWWAtRm7KODLjI3zSPaQNgdWw2YyboXob9PreEHM0UmLDmZVpoRoFxzYalbIm3WC2EqfYWtlI0aTxJEaHmS3FPeQuN7K/nv672UocRkQoyU/h7eoWOrp9q9iONgRWJHcF9HTAqV1mK3GKkvxkDp+7REObjxuy/j4jQivnTqNilsU419pJZX27f7iFBplyO4REWnZEXJKfTE//AG/6WI0CbQisSPbNEBpt2eihO+0pPrYe9fFRwbk9RoUsiy4is1TtgbESEmEYA4vm3Zo3aTzjI0PY6mNp2bUhsCLBYZCz2F6jYMBsNQ4zJSma7MQon/SVvo+qDUbW16mLzFbiFFsrG5mWHE1WYpTZUtxL7gq4XAd1B8xW4jDBQTbuyEtme1UTvf2+c+9qQ2BVclfAlSaoLTVbicMYvtJkdte0+G49V6WMqnDZt0DYOLPVOMzFKz3sPd3qX26hQabdCRJkaffQ5a4+9tS0mi3lPbQhsCpTF4Et2LLuoZICH6/n2lQJF09bNlpoR1UT/QPKv9xCg0TGQ9YNljUEN+UkER5i86mqfdoQWJWIOMi6ycjIaEFf6exMI5LFZ91DVRsBsexq4q2VjaTEhFOYHmu2FM+QuwKaq+BCtdlKHCYiNIibc4waBb6ysFIbAiuTuxxaT8KF42YrcZggm7A4fwI7fbWea9VrkFEE46zXo+7q7efN40ZdbpvNeovgxsR7admtOSJenJ9MfVsX5bXtZksBtCGwNn5wM/hkPde280aWV4u6hf5+4gJXe/v90y00SFymkfLDou6hO/KSsQk+4x7ShsDKxKZD2px/5Mq3GD5bz3Uwu+t0axqCrZWNjAsL5vrJ1quk5hC5d8H5fXDZN35MHSE+KpT5WfE+k4BRGwKrk7vciBxqrzdbicOEhxg1CnyunmvVBiPLa9I0s5U4TP+AYtvRRm7NnUBosJ/f3rnLAWXptOzHGi9zpuWK2VK0IbA8uSuMv1at55qf4lv1XK9egtNvWXYR2YGzF2m50kOJP7uFBpmQB+OzLesaHfyMfGFErA2B1UnKhfjJlvWV3jZ9AsG+VM+1epuR3XXQwFqMrZWNhAQJt063YF1uRxmsUVDzJnT5xqSrI2TGR5KbMs4n3EPaEFidwZvh1C4jGZfFiI00ahT4TBhp1WsQNQHSi8xW4jBKKV6vaGDBlETGhVsvN5JT5N0FA71Qbd207KVnWrnQ0W2qDm0I/IHpy+03wzazlTjF4vxkTjZfMb+ea183nNhmZHe1We/WONHUwZmWzsBwCw2SMR+ikiw7Ii7JT2ZAwQ6TaxS49G0XkXgR2SoiJ+x/xw+zz2wReVdEKkTkiIg8MGTbn0TklIgcsj9mu6InYMkshshEy94Mi33FV3pqF/RctmzYqF8mmRsNW5C9RsEWw5BbjIK0GNLjIkx3jbra7XkM2K6UygG2219fSyfwCaVUAbAE+LmIxA3Z/nWl1Gz745CLegITi98MaXERFKbHmu8eqlwHoeNg8q3m6nCSzeUNzMqMIzkm3Gwp3iV3hWHAT71lthKHEREW5yfz1olmOnvMq1HgqiFYBTxpf/4kcPe1OyiljiulTtif1wFNQADMZHmZwZvhtPVuBjCGyAfPXaKp3aQaBf19RuTVtDuN7K4W4/zFTspq21g6ww+TzI1G9i2WTstekp9Md98Au45fME2Dq4YgWSk1GMDeAHzomFREioFQ4OSQ5h/aXUY/E5ER70AReVRESkWktLnZRxOVmcnkWyAkyrLuoZKCFJSCbWb5Ss++A50tkL/SnOu7yOZyYzQVkIYgJNxIwnhsoyXTss/Pjic2IsTUVcajGgIR2SYi5cM8Vg3dTxnZk0ZcFSQiqcBTwCeVUoOf1jeBXGA+EA/860jHK6UeV0oVKaWKkpL0gOIDhETA1NstW6NgWnI0kxIizSvYUbkegiMsW3tgc3kDeakxTErws9oDYyV3BXQ0WjIte0iQjTtyJ7Cjqok+k2oUjGoIlFKLlFIzhnmsAxrtP/CDP/TDdudEJAbYAHxLKbV7yLnrlUE38ARQ7I43FbDkroDL9VB30GwlDiMiLM5LNqee68CA4VaYegeEWu+HtKm9i/1nLwbmaGCQnMWWT8t+qbOXfacvmnJ9V11D64G19udrgXXX7iAiocDfgD8rpV68ZtugERGM+YVyF/UENjkl9oIdVr0ZUsyp51pbahjQ/FWj7+uDvF7RgFIB6hYaJCLOKOFq0bTsN+UkERps43WTAiZcNQQ/BhaLyAlgkf01IlIkIr+37/MR4Gbg4WHCRP8qImVAGZAI/MBFPYHNYMGOo69a8maYN2k8CVGhbPb2zVC5DmwhxkSxBdlU3sDkpCimTog2W4q5DKZlbz5mthKHiQoL5uacJDaXN5iSd8slQ6CUalFK3aGUyrG7kFrt7aVKqUfsz/+ilAoZEiL6XpioUup2pVSh3dX0MaWUySuK/ID8VdBywqiwZTGCbEJJQQo7jjbS1eulGgVKGYZz8q0Qbr0iLq1XethzqpWlM1IwBtYBjMXTsi+fmUJDexcHz3k/75b1lk9qPpy8lYAYvVwLsrwwlSs9RmEVr9BwBC6dsWy00NbKBvoHFEtnpJotxXxi0iB9nmUj5+7ISyY0yMbGMu9nEtaGwN+IngCTboCKV8xW4hTXT45nfGSI926GyvXGvIpFaw9sKm8gY3wEBWkxZkvxDXJXQN0BaKs1W4nDxISHcFNOIpvK6r3uHtKGwB8puBsuHIOmo2YrcZjgIBt3FqSw/WiTd9xDR1815lWirFfEpe1qL29XX9BuoaFYPC37ssJU6tq6vJ6WXRsCf2TQPWTRUcGywlQ6uvvY5Wn3UPMxw2DmWdMt9EZVE739iiXaLfQPkqYZRYUsOk+wKD+ZkCDxuntIGwJ/ZFwyTFoIldY0BAumJBDnDfdQ5Xrjr0VrD2wqryc5Jow5mXGj7xxI5K2A03+Hq+bE5LtCbEQIN05NZGNZA8qLkX/aEPgr+XdDcxU0VZmtxGFCgmzcmZ/CNk+7h46ug4xiiLFej7qzp483jzezpCAFm027hd5H7l1GcSGLlrBcVphK7aWrHDnvvfoi2hD4K3l3YUQPWXNUsGym4R5664SHEnFdqIaGMii4xzPn9zA7qpro6h3QbqHhSJ8LcROh/GWzlTjF4vxkgm3edQ9pQ+CvxKTCxOstG0a6cEoCsREedA9VvAyIMbFuQV47XE/SuDCKs+PNluJ7iBgGvuYN6Gw1W43DxEWGcsPURDaW13vNPaQNgT+Tf7exsKz5uNlKHCYkyEZJfjLbKhvp7vOAe6j8JZi4wIg9txiXu3p541gTywtTCdJuoeEpWG24h46uN1uJUywvTOVc61XKa71Ti1kbAn9mcJGUhd1Dl7v7+Lu73UONlcb8yYzV7j2vl9h2tJHuvgHumqXdQiOSOgviJ1vaPRRkEzZ4yT2kDYE/E5MGmddbNoz0himJxIQHu/9mqHgZxGbZJHOvHq4nPS6COZkfqAyrGUQEZtxrFGrqMLcesDOMjwpl4ZQENnnJPaQNgb9TcDc0VcCFE2YrcZjQYBslBSlsdad7SCmjl5h1k7EK22Jc6uzhrRPNLJ+ZqqOFRqNgNagBy86TLStM5UxLJxV1nncPaUPg7+SvAsTwiVuQ5TNTudzV574yfg1HjAyVFnULvV7RQG+/YsVM7RYaleR8SMqFir+ZrcQplhSkEBIkrDvk+XQZ2hD4OzFpkHUjlL1gydTUN05NJD4q1H03Q/nLRgETi64mfu1IPZMSIilMt16mVFMoWA1n3oF27ydyc5XxUaHcMi2J9Yfr6Pdw7iFtCAKBwvugpRrqD5mtxGFCgmwsL0xl29FG1yuXKWXMD0y+1ajdYDEudHTzdvUFVsxM1bmFxsqM1YCybMDEytnpNLZ3s/eUZ8NgXTIEIhIvIltF5IT977CzVyLSP6Qozfoh7dkiskdEqkXkOXs1M427yV9lFF458oLZSpxi1ew0unoH2OJqwZraA3DprNFLtCCbyhsYUHDXLOuFvJpGYg4kF1rWNboobwKRoUGsP+xZ95CrI4LHgO1KqRxgu/31cFwdUpRm6Jj8J8DPlFJTgYvAp13UoxmOiPFGGcvyl2DASwVf3Mi8SePJGB/BukN1rp2o7AUICjUqWVmQVw/XMXVCNNOTx5ktxVrMuAfO74OLZ8xW4jCRocGU5CezsazBM+tp7LhqCFYBT9qfP4lRd3hM2OsU3w4M1jF26HiNg8y8HzoajHA6iyEirJyVxt+rL3Cho9u5k/T3QfmLMG2JUd/WYtReusreU62snJWm3UKOMuM+42+ZVUfE6bRd7XVfwMQwuGoIkpVSg7MwDUDyCPuFi0ipiOwWkcEf+wTgklJq0PF7Hkgf6UIi8qj9HKXNzV4ubu4PTFsCoeMsezPcPSed/gHFhiNOTvrVvAFXmmHmA+4V5iVeOWi4Bu6ZM+ItohmJ8ZNg4kI48pw1AyZyjICJVzwYPTSqIRCRbSJSPszjfatxlLHqYaT/8iSlVBHwEPBzEZniqFCl1ONKqSKlVFFSUpKjh2tCIoxEdJWvQm+X2WocZlryOHJTxjl/Mxx+9h8uMouhlOJvB2uZnzWezPhIs+VYk1kPwIXjRvUyi/FewESlGwImRmBUQ2AvSj9jmMc6oFFEUgHsf4ddwqeUqrX/rQF2AnOAFiBORILtu2UA1qsvZyUK74PuNjixxWwlTnH3nHQOnr3E2ZZOxw7svmzUsS1YDcHWi0cor22nuqmDe+ZkmC3FuuTfDUFhcPg5s5U4xarZaXT3uSFgYgRcdQ2tB9ban68FPrCET0TGi0iY/XkicANQaR9BvAHc92HHa9xI9i0QNcGy7qHBaBmHIygq10PfVcu6hV46cJ5Qe69Q4yQRcTB9iREw0d9rthqHmTtxPOlxEbziasDECLhqCH4MLBaRE8Ai+2tEpEhEfm/fJw8oFZHDGD/8P1ZKVdq3/SvwVRGpxpgz+IOLejQfRlCwEVd9/HVLVm9Kj4ugOCuelw/WOpZ/5chzMD4bMos9J85D9PYP8OrhOu7Im0BsZIjZcqzNzAeh8wJUbzdbicPYbMKq2Wn8/UQzTZfd79p1yRAopVqUUncopXLsLqRWe3upUuoR+/N3lFKFSqlZ9r9/GHJ8jVKqWCk1VSl1v1LKyZAQzZiZ/RD0d0PZi6Pv64PcOy+dmuYrHDg7xuLebbVwapcxGrBgtM1bJ5ppudLD6rnaLeQyUxdBRDwcedZsJU6xem4G983LoLff/RPeemVxoJE6y1hgc+ivZitxiuUz04gICeLF/efGdkDZC4CCmR/xqC5P8fKBWsZHhnDLNB0g4TLBoUZG0qqN0OW9MpDuYuqEaH563yzS4yLcfm5tCAKROR+FuoPQWGG2EoeJDgtmWWEqrx6up7NnlAgKpYxooYz5kOBwoJrptHf1srWykbtmpREarG9VtzDrQWNEbNHU7J5Cf7sCkcKPGCknDlpzVPCRogw6uvvYXD5KBMX5Umg+CnM+5h1hbua1w/V09w3otQPuJH0eJORYdkTsKbQhCESiEmD6UmMS1YIRFMXZ8UxKiOT50lHcQwf/DCGRls0t9Ny+s0xPHsfsTOuthPZZRGDuJ+DcHmiqMluNz6ANQaAy52NGBMXx181W4jAiwv3zMthd0zrymoLuy1D2kmEEwmO8K9ANVNa1c/h8Gw8WZ+qUEu5m1hojFfnBp8xW4jNoQxCoTLkDolPg4F/MVuIUq+dmIMLIk8YVf4PeK0bvz4I8t+8socE27RbyBNFJMH0ZHH4G+nSgImhDELgEBRvL7k9sgcuNZqtxmLS4CG7KSeLF/eeHL9px4ClInG7JtQNdvf387WAtS2ekEBdpvZXQlmDuWuhsMVaca7QhCGjmfBxUPxyy5qjgI0UZ1LV1sevENUkIm47C+b0w9+OWXDuwqbye9q4+HpifabYU/2XKbRCbCQf+bLYSn0AbgkAmMcco4l76J0vWKSjJTyExOpS/7r4mz/yBp4yoqJkPmiPMRZ7de46shEgWTE4wW4r/Ygsy5slq3oCLp81WYzraEAQ68x+BtrNwYqvZShwmNNjGg/Mnsr2qiXOt9knj3qtw+GkjKiraeouwapo72HOqlY/M15PEHmf2RwExOg4BjjYEgU7ucmPSeN/vR9/XB1lz3UQEeGbvWaOh/CUjj1LxZ0zV5SxP7T5DsE24b55OKeFx4jKNtOQHngz4SWNtCAKdoBCY9zBUb4PWGrPVOEx6XAR35CXz3L5zdPf2wZ7fQlKe4fKyGFe6+3ix9DzLClOZMC7cbDmBwXWPGgWLKgM78bE2BBrDEIgNSp8wW4lTfPz6SbRc6WHPW69DwxFjNGBBt8rLB85zubuPtQuzzJYSOEy+HRKmGh2IAEYbAg3EpELeCmOBTe9Vs9U4zI1TE8lKiET2Pg5hMZasO6CU4sl3z1CYHsvciXolsdew2WD+Z6C2FGr3m63GNLQh0BjMf8TwrZe/bLYSh7HZhM/MieK6q2/RknMfhEWbLclh3q5uobqpg7ULs/QksbeZ/RCERsOex81WYhraEGgMsm6CCQWw+9eWLPB9L9sIlX5+23m72VKc4k/vnCY+KpQVM3UVMq8THmOknah4GTqaR9/fD3HJEIhIvIhsFZET9r/jh9nnNhE5NOTRJSJ327f9SURODdk22xU9GhcQgQVfhMZyqNlpthrH6L1K+IE/cCJmIX+sCqLukrXcW6cvXGF7VSNrijMJDwkyW05gUvwo9PdAaWAWSXR1RPAYsF0plQNst79+H0qpN5RSs5VSs4HbgU5gaPX0rw9uV0odclGPxhUK74PoZHj3l2YrcYzDz0DnBeIWfw0FPPH2KbMVOcTjb9UQEmRj7YIss6UELknTIOdO2Pu4JefJXCXYxeNXAbfanz8J7MSoQzwS9wGblFIjpIzUmEpwmBFxs+MHsO6LEPGBAZ5vUvEKpM0hacYdLC88xDN7z/FPd+QQE+77NX6bLnfx4v7z3Ds3gwkxOmTUVG74Z/jTcnjhYWPVva+y8MtuXyzpqiFIVkrV2583AMmj7P8g8H+vafuhiHwH+4hipLrFIvIo8CjAxIkTnVes+XCKHzUScVlp0tgWDMv/G0R49ObJrD9cxzN7zvLZW3y/KtkTb5+mt3+AR2+ebLYUzaQbjIizo68ada59lblr3W4IRI0yMSgi24CUYTZ9C3hSKRU3ZN+LSqlhu5EikgocAdKUUr1D2hqAUOBx4KRS6vujiS4qKlKlpaWj7aYJUB763W5ONnew6xu3ERbsuz73y129LPzxDm7KSeTXH51nthxNACAi+5VSRde2jzpHoJRapJSaMcxjHdBo/zEf/FFv+pBTfQT426ARsJ+7Xhl0A08A1ssZrPE5vnjbVBrbu3lu3xgL3JvEX3af5XJXH5+zwMhF49+4Olm8Hlhrf74W+LB12muAZ4Y2DDEiAtwNlLuoR6Nh4ZQE5meN51dvVNPV65tZVS939fL4rpPcMi2JmRl6AZnGXFw1BD8GFovICWCR/TUiUiQi72UxE5EsIBN485rj/yoiZUAZkAj8wEU9Gg0iwlcWTaOxvZtnB5PR+RhPvH2ai529fK1kmtlSNBrXJouVUi3AHcO0lwKPDHl9GvhAzT2llDVX/2h8ngVTEijOjufXO0/yYPFEn4rPb+vs5Xdv1bA4P1mPBjQ+gV5ZrPFLBkcFTZe7eerdM6Mf4EV+91YNl7v6+OpiPRrQ+AbaEGj8lgVTErhlWhK/2HGC1is9ZssBoLG9iz++fYrlM1PJS40xW45GA2hDoPFzvr08j86efv5n23GzpQDw083H6OtXfOPO6WZL0WjeQxsCjV+TkzyONcWZ/GXPWaqbOkzVcuT8JV46cJ5P3pjFpIQoU7VoNEPRhkDj9/zLomlEhgTxgw2VjLaA0lMopfj+q5UkRofypdummqJBoxkJbQg0fk9idBhfXpTDzmPNbCirH/0AD/DsvnOUJ1agrwAACLVJREFUnrnI1++czjgL5EDSBBbaEGgCgocXZlGYHsv31lfS1tk7+gFupLG9ix9tPMp12fHcPy/Tq9fWaMaCNgSagCA4yMaP7y3kYmcPP9xY6bXrKqX4t1fK6ekb4Mf3zsRm09XHNL6HNgSagKEgLZZHb57M86Xneb2iwSvX/NvBWrZUNvIvi6aRnagniDW+iTYEmoDiK4umUZgeyzdePEKthyuZ1TR38O1XyinOjuczN2V79FoajStoQ6AJKEKDbfzvmjn09Q/w5WcO0ts/4JHrXO3p50tPHyQ02Mb/PDib4CB9q2l8F/3t1AQcWYlR/Gh1IaVnLvJvr5S7PaR0YEDxtRcOcbShnf/7kVmkxka49fwajbtxtUKZRmNJVs1O50RjB798o5pJCVF8/lb31QT4zy3H2FjWwLeW5XF77mhF+zQa89GGQBOwfHXxNM60dvKTzVWEBdv41I2u+/F/vu04v9l5kjXFE3lEzwtoLII2BJqAxWYT/vv+WfT2DfD91yrp6uvn87dMwaiT5BgDA4r/2nKMX+88yX3zMvjB3TOcOo9GYwZ6jkAT0IQG2/jfh+awclYaP918jH9+9hCdPX0OnaPtai9f+OsBfr3zJGuKM/nJvTMJ0usFNBbCJUMgIveLSIWIDIjIBwoiD9lviYgcE5FqEXlsSHu2iOyxtz8nIqGu6NFonCEkyIjs+fqd03ntSB1Lfv4Wbx5vHnUSWSnF6xUN3PmzXWw92si3l+fxo3sKtRHQWA5XRwTlwGpg10g7iEgQ8CtgKZAPrBGRfPvmnwA/U0pNBS4Cn3ZRj0bjFCLCF2+bytOPXE+wTVj7x73c+5t3eHH/eS50dL9v36b2Lp7ec5ZVv3qbzz61n3Hhwbz8+YU8ctNk7Q7SWBJXS1UeBUb78hcD1UqpGvu+zwKrROQocDvwkH2/J4HvAb9xRZNG4woLpiSw8cs38XzpOX73Vg3/3wuHARgfGUJ0eDBXuvvfK3IzOSmKn947k3vmphOi1wloLIw3JovTgXNDXp8HrgMSgEtKqb4h7R+oazyIiDwKPAowceJEzyjVaIDwkCA+sSCLj18/ifLadt45eYHTLZ109fYTHhJEzoRoirPjKUiL0SMAjV8wqiEQkW1AyjCbvqWUWud+ScOjlHoceBygqKjInKTymoBCRCjMiKUwI9ZsKRqNRxnVECilFrl4jVpgaO7dDHtbCxAnIsH2UcFgu0aj0Wi8iDccm/uAHHuEUCjwILBeGSEZbwD32fdbC3hthKHRaDQaA1fDR+8RkfPAAmCDiLxub08TkY0A9t7+l4DXgaPA80qpCvsp/hX4qohUY8wZ/MEVPRqNRqNxHDGrhqsrFBUVqdLSUrNlaDQajaUQkf1KqQ+s+dIxbxqNRhPgaEOg0Wg0AY42BBqNRhPgaEOg0Wg0AY4lJ4tFpBk44+ThicAFN8qxAvo9Bwb6PQcGrrznSUqppGsbLWkIXEFESoebNfdn9HsODPR7Dgw88Z61a0ij0WgCHG0INBqNJsAJREPwuNkCTEC/58BAv+fAwO3vOeDmCDQajUbzfgJxRKDRaDSaIWhDoNFoNAFOQBkCEVkiIsdEpFpEHjNbjzsQkUwReUNEKkWkQkS+bG+PF5GtInLC/ne8vV1E5Bf2/8EREZlr7jtwHhEJEpGDIvKa/XW2iOyxv7fn7GnPEZEw++tq+/YsM3U7i4jEiciLIlIlIkdFZIG/f84i8hX797pcRJ4RkXB/+5xF5I8i0iQi5UPaHP5cRWStff8TIrLWEQ0BYwhEJAj4FbAUyAfWiEi+uarcQh/wNaVUPnA98EX7+3oM2K6UygG221+D8f5z7I9HsXaN6C9jpDYf5CfAz5RSU4GLwKft7Z8GLtrbf2bfz4r8D7BZKZULzMJ47377OYtIOvDPQJFSagYQhFHPxN8+5z8BS65pc+hzFZF44LsYZYCLge8OGo8xoZQKiAdGzYTXh7z+JvBNs3V54H2uAxYDx4BUe1sqcMz+/LfAmiH7v7eflR4YFe22A7cDrwGCsdoy+NrPG6MWxgL782D7fmL2e3Dw/cYCp67V7c+fM/+odx5v/9xeA+70x88ZyALKnf1cgTXAb4e0v2+/0R4BMyLgH1+qQc7b2/wG+1B4DrAHSFZK1ds3NQDJ9uf+8n/4OfANYMD+OgG4pIxCSPD+9/Xee7Zvb7PvbyWygWbgCbs77PciEoUff85KqVrgv4CzQD3G57Yf//6cB3H0c3Xp8w4kQ+DXiEg08BLwL0qp9qHblNFF8Js4YRFZ8f+3d/asUQVRGH4ORCOxMGsXiRACkjaxCmghKClSxCadEFF/haTKHxCs/AEiCkqQYCP4URsNiEoU3aBgBI1YpLBKcVLMuXpRCzcb9rIz7wMLO2emOOe+C+/OmWEX2HL3taZz6SEDwEnghrtPAT/53S4AstS5BZwnmeAx4DB/t1Cypxe6lmQEX4DjtfFoxPoeMztAMoFb7r4c4W9mNhLzI8BWxHN4DqeAOTP7BNwhtYeuA8NmNhBr6nX9qjnmjwA/epnwPrAJbLr7sxjfIxlDzjqfAz66+3d33wGWSdrnrHNFp7p2pXdJRvAcOBE3Dg6SDp1WGs6pa8zMSP/1/Nbdr9WmVoDq5sBF0tlBFV+I2wfTwHZtC9oXuPtVdx919zGSjk/c/QLwFJiPZX/WXD2L+VjfV9+c3f0r8NnMJiJ0FlgnY51JLaFpMxuKz3lVc7Y61+hU14fAjJm1Yic1E7H/o+lDkh4fyMwC74ENYLHpfPapptOkbeMr4GW8Zkm90cfAB+ARcDTWG+n21AbwmnQjo/E6uqj/DPAg3o8Dq0AbuAsMRvxQjNsxP9503nusdRJ4EVrfB1q56wwsAe+AN8BNYDA3nYHbpDOQHdLO78pedAUuR+1t4FInOegnJoQQonBKag0JIYT4BzICIYQoHBmBEEIUjoxACCEKR0YghBCFIyMQQojCkREIIUTh7AJvF5/AQFxS3QAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
           }
         }
       ]
@@ -903,7 +843,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
         "id": "CICQuI86WK4_"
       },
       "source": [
@@ -915,8 +854,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "cgxMjNTrGjJn",
-        "colab_type": "text"
+        "id": "cgxMjNTrGjJn"
       },
       "source": [
         "\n",
@@ -928,8 +866,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "IC7tEcr1-Fc5",
-        "colab_type": "text"
+        "id": "IC7tEcr1-Fc5"
       },
       "source": [
         "### Implicit function differentiation of iterative implementations\n",
@@ -940,8 +877,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "szAt97t80hew",
-        "colab_type": "text"
+        "id": "szAt97t80hew"
       },
       "source": [
         "Another application for `jax.custom_vjp` is reverse-mode differentiation of functions that are JAX-transformable (by `jit`, `vmap`, ...) but not efficiently JAX-differentiable for some reason, perhaps because they involve `lax.while_loop`. (It's not possible to produce an XLA HLO program that efficiently computes the reverse-mode derivative of an XLA HLO While loop because that would require a program with unbounded memory use, which isn't possible to express in XLA HLO, at least without side-effecting interactions through infeed/outfeed.)\n",
@@ -952,9 +888,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "2uA8X2izXH2b",
-        "colab_type": "code",
-        "colab": {}
+        "id": "2uA8X2izXH2b"
       },
       "source": [
         "from jax.lax import while_loop\n",
@@ -971,14 +905,13 @@
         "  _, x_star = while_loop(cond_fun, body_fun, (x_guess, f(a, x_guess)))\n",
         "  return x_star"
       ],
-      "execution_count": 0,
+      "execution_count": 26,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "p2xFQAte19sF",
-        "colab_type": "text"
+        "id": "p2xFQAte19sF"
       },
       "source": [
         "This is an iterative procedure for numerically solving the equation $x = f(a, x)$ for $x$, by iterating $x_{t+1} = f(a, x_t)$ until $x_{t+1}$ is sufficiently close to $x_t$. The result $x^*$ depends on the parameters $a$, and so we can think of there being a function $a \\mapsto x^*(a)$ that is implicity defined by equation $x = f(a, x)$.\n",
@@ -989,33 +922,29 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "rDDwM8bYYzRT",
-        "colab_type": "code",
-        "colab": {}
+        "id": "rDDwM8bYYzRT"
       },
       "source": [
         "def newton_sqrt(a):\n",
         "  update = lambda a, x: 0.5 * (x + a / x)\n",
         "  return fixed_point(update, a, a)"
       ],
-      "execution_count": 0,
+      "execution_count": 27,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "42Ydd7_6aLXU",
-        "colab_type": "code",
-        "outputId": "a8b367eb-0701-4a22-b4a5-7074abd375a0",
+        "outputId": "c576dc92-33df-42b9-b2e8-ad54119514b1",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(newton_sqrt(2.))"
       ],
-      "execution_count": 27,
+      "execution_count": 28,
       "outputs": [
         {
           "output_type": "stream",
@@ -1029,8 +958,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-yFtYWH13QWm",
-        "colab_type": "text"
+        "id": "-yFtYWH13QWm"
       },
       "source": [
         "We can `vmap` or `jit` the function as well:"
@@ -1040,17 +968,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "t_YSXieT3Yyk",
-        "colab_type": "code",
-        "outputId": "796b9153-b5d7-4503-d496-480d9773cad7",
+        "outputId": "76483e18-81f3-47a8-e8aa-e81535c01fe2",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(jit(vmap(newton_sqrt))(jnp.array([1., 2., 3., 4.])))"
       ],
-      "execution_count": 28,
+      "execution_count": 29,
       "outputs": [
         {
           "output_type": "stream",
@@ -1064,8 +990,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "emwWIt3d3h1T",
-        "colab_type": "text"
+        "id": "emwWIt3d3h1T"
       },
       "source": [
         "We can't apply reverse-mode automatic differentiation because of the `while_loop`, but it turns out we wouldn't want to anyway: instead of differentiating through the implementation of `fixed_point` and all its iterations, we can exploit the mathematical structure to do something that is much more memory-efficient (and FLOP-efficient in this case, too!). We can instead use the implicit function theorem [Prop A.25 of Bertsekas's Nonlinear Programming, 2nd ed.], which guarantees (under some conditions) the existence of the mathematical objects we're about to use. In essence, we linearize at the solution and solve those linear equations iteratively to compute the derivatives we want.\n",
@@ -1096,9 +1021,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "g4jo-xlvdiym",
-        "colab_type": "code",
-        "colab": {}
+        "id": "g4jo-xlvdiym"
       },
       "source": [
         "from jax import vjp\n",
@@ -1135,24 +1058,22 @@
         "\n",
         "fixed_point.defvjp(fixed_point_fwd, fixed_point_rev)"
       ],
-      "execution_count": 0,
+      "execution_count": 30,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "iKzfT6d_mEoB",
-        "colab_type": "code",
-        "outputId": "31b93e63-6487-484b-e9a7-4b75c216fc01",
+        "outputId": "5d04c4a0-61dd-42de-ffa4-101b71d15a57",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(newton_sqrt(2.))"
       ],
-      "execution_count": 30,
+      "execution_count": 31,
       "outputs": [
         {
           "output_type": "stream",
@@ -1167,18 +1088,16 @@
       "cell_type": "code",
       "metadata": {
         "id": "Hmcpjr6gmtkO",
-        "colab_type": "code",
-        "outputId": "7f7c5025-11bb-48f1-e1df-9b30e05b6a19",
+        "outputId": "9c4a406c-0144-4d5f-e789-a7a4c850a3cc",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(newton_sqrt)(2.))\n",
         "print(grad(grad(newton_sqrt))(2.))"
       ],
-      "execution_count": 31,
+      "execution_count": 32,
       "outputs": [
         {
           "output_type": "stream",
@@ -1193,8 +1112,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "DvVmlaPD7W-4",
-        "colab_type": "text"
+        "id": "DvVmlaPD7W-4"
       },
       "source": [
         "We can check our answers by differentiating `jnp.sqrt`, which uses a totally different implementation:"
@@ -1204,18 +1122,16 @@
       "cell_type": "code",
       "metadata": {
         "id": "jj_JnI9Pm4jg",
-        "colab_type": "code",
-        "outputId": "0efc9081-980f-47cd-95a2-476024545692",
+        "outputId": "6eb3e158-209b-41f2-865c-376a1d07624b",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(jnp.sqrt)(2.))\n",
         "print(grad(grad(jnp.sqrt))(2.))"
       ],
-      "execution_count": 32,
+      "execution_count": 33,
       "outputs": [
         {
           "output_type": "stream",
@@ -1230,8 +1146,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "HowvqayEuy-H",
-        "colab_type": "text"
+        "id": "HowvqayEuy-H"
       },
       "source": [
         "A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API."
@@ -1240,8 +1155,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Dr0aNkBslfQf",
-        "colab_type": "text"
+        "id": "Dr0aNkBslfQf"
       },
       "source": [
         "## Basic usage of `jax.custom_jvp` and `jax.custom_vjp` APIs\n"
@@ -1250,8 +1164,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "MojTOg4tmQNT",
-        "colab_type": "text"
+        "id": "MojTOg4tmQNT"
       },
       "source": [
         "\n",
@@ -1263,9 +1176,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "nVkhbIFAOGZk",
-        "colab_type": "code",
-        "colab": {}
+        "id": "nVkhbIFAOGZk"
       },
       "source": [
         "from jax import custom_jvp\n",
@@ -1284,18 +1195,16 @@
         "\n",
         "f.defjvp(f_jvp)"
       ],
-      "execution_count": 0,
+      "execution_count": 34,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "fxhlECvW7Krj",
-        "colab_type": "code",
-        "outputId": "a727d3c5-ab82-4c0c-f77f-ac0500e84f5c",
+        "outputId": "30dc5e8b-d157-4ae2-cd17-145d4e1ba47b",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -1307,7 +1216,7 @@
         "print(y)\n",
         "print(y_dot)"
       ],
-      "execution_count": 34,
+      "execution_count": 35,
       "outputs": [
         {
           "output_type": "stream",
@@ -1323,8 +1232,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "JaoQVRzSQ9Qd",
-        "colab_type": "text"
+        "id": "JaoQVRzSQ9Qd"
       },
       "source": [
         "In words, we start with a a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it a JVP rule function `f_jvp` that takes a pair of inputs representing the primal inputs of type `a` and the corresponding tangent inputs of type `T a`, and produces a pair of outputs representing the primal outputs of type `b` and tangent outputs of type `T b`. The tangent outputs should be a linear function of the tangent inputs."
@@ -1333,8 +1241,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "1xGky7yMOavq",
-        "colab_type": "text"
+        "id": "1xGky7yMOavq"
       },
       "source": [
         "You can also use `f.defjvp` as a decorator, as in\n",
@@ -1353,8 +1260,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "e9R-ppvdQIOC",
-        "colab_type": "text"
+        "id": "e9R-ppvdQIOC"
       },
       "source": [
         "Even though we defined only a JVP rule and no VJP rule, we can use both forward- and reverse-mode differentiation on `f`. JAX will automatically transpose the linear computation on tangent values from our custom JVP rule, computing the VJP as efficiently as if we had written the rule by hand:"
@@ -1364,11 +1270,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "hl9Io86pQD6s",
-        "colab_type": "code",
-        "outputId": "e8794287-da8f-47e8-a1ce-eaa41831a591",
+        "outputId": "a9ef39aa-4df0-459f-ee1d-64b648cabcc4",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -1377,7 +1281,7 @@
         "print(grad(f)(3.))\n",
         "print(grad(grad(f))(3.))"
       ],
-      "execution_count": 35,
+      "execution_count": 36,
       "outputs": [
         {
           "output_type": "stream",
@@ -1392,8 +1296,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "MRlKe5D90svj",
-        "colab_type": "text"
+        "id": "MRlKe5D90svj"
       },
       "source": [
         "For automatic transposition to work, the JVP rule's output tangents must be linear as a function of the input tangents. Otherwise a transposition error is raised."
@@ -1402,8 +1305,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GRu-0yg96lXE",
-        "colab_type": "text"
+        "id": "GRu-0yg96lXE"
       },
       "source": [
         "Multiple arguments work like this:"
@@ -1412,9 +1314,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "JFLXlXuq6pRf",
-        "colab_type": "code",
-        "colab": {}
+        "id": "JFLXlXuq6pRf"
       },
       "source": [
         "@custom_jvp\n",
@@ -1429,24 +1329,22 @@
         "  tangent_out = 2 * x * y * x_dot + x ** 2 * y_dot\n",
         "  return primal_out, tangent_out"
       ],
-      "execution_count": 0,
+      "execution_count": 37,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "QpKwA0oA8DfE",
-        "colab_type": "code",
-        "outputId": "44aba2b3-200c-4cb7-f275-4cd9404d4068",
+        "outputId": "80855f56-04a5-4179-fd8b-199ea7eba476",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(2., 3.))"
       ],
-      "execution_count": 37,
+      "execution_count": 38,
       "outputs": [
         {
           "output_type": "stream",
@@ -1460,8 +1358,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YPsPS3rdaGo2",
-        "colab_type": "text"
+        "id": "YPsPS3rdaGo2"
       },
       "source": [
         "The `defjvps` convenience wrapper lets us define a JVP for each argument separately, and the results are computed separately then summed:\n",
@@ -1471,9 +1368,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "CsQIUhUkajua",
-        "colab_type": "code",
-        "colab": {}
+        "id": "CsQIUhUkajua"
       },
       "source": [
         "@custom_jvp\n",
@@ -1482,24 +1377,22 @@
         "\n",
         "f.defjvps(lambda t, ans, x: jnp.cos(x) * t)"
       ],
-      "execution_count": 0,
+      "execution_count": 39,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "zfSgXrPEap-i",
-        "colab_type": "code",
+        "outputId": "bf552090-a60d-4c2a-fc91-603396df94cd",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
-        },
-        "outputId": "b9401e3a-cbce-4aca-bad6-490524cfce7e"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(grad(f)(3.))"
       ],
-      "execution_count": 39,
+      "execution_count": 40,
       "outputs": [
         {
           "output_type": "stream",
@@ -1513,8 +1406,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "iYUCLJghbPiP",
-        "colab_type": "text"
+        "id": "iYUCLJghbPiP"
       },
       "source": [
         "Here's a `defjvps` example with multiple arguments:"
@@ -1523,9 +1415,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "Vx4Jv9s9bCi1",
-        "colab_type": "code",
-        "colab": {}
+        "id": "Vx4Jv9s9bCi1"
       },
       "source": [
         "@custom_jvp\n",
@@ -1535,26 +1425,24 @@
         "f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,\n",
         "          lambda y_dot, primal_out, x, y: x ** 2 * y_dot)"
       ],
-      "execution_count": 0,
+      "execution_count": 41,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "o9ezUYsjbbvC",
-        "colab_type": "code",
+        "outputId": "f60f4941-d5e3-49c3-920f-76fd92414697",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
-        },
-        "outputId": "67a9f25d-89ad-4abc-908b-8a97062da239"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(grad(f)(2., 3.))\n",
         "print(grad(f, 0)(2., 3.))  # same as above\n",
         "print(grad(f, 1)(2., 3.))"
       ],
-      "execution_count": 41,
+      "execution_count": 42,
       "outputs": [
         {
           "output_type": "stream",
@@ -1570,8 +1458,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "nuIUkaxibVfD",
-        "colab_type": "text"
+        "id": "nuIUkaxibVfD"
       },
       "source": [
         "As a shorthand, with `defjvps` you can pass a `None` value to indicate that the JVP for a particular argument is zero:"
@@ -1580,9 +1467,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "z4z3esdZbTzQ",
-        "colab_type": "code",
-        "colab": {}
+        "id": "z4z3esdZbTzQ"
       },
       "source": [
         "@custom_jvp\n",
@@ -1592,26 +1477,24 @@
         "f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,\n",
         "          None)"
       ],
-      "execution_count": 0,
+      "execution_count": 43,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "jOtQfp-5btSo",
-        "colab_type": "code",
+        "outputId": "b60aa797-4c1e-4421-826d-691ba418bc1d",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
-        },
-        "outputId": "ded61c3a-14a1-4965-b988-7a7c94eeaf53"
+          "base_uri": "https://localhost:8080/"
+        }
       },
       "source": [
         "print(grad(f)(2., 3.))\n",
         "print(grad(f, 0)(2., 3.))  # same as above\n",
         "print(grad(f, 1)(2., 3.))"
       ],
-      "execution_count": 43,
+      "execution_count": 44,
       "outputs": [
         {
           "output_type": "stream",
@@ -1627,8 +1510,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "kZ0yc-Ihoezk",
-        "colab_type": "text"
+        "id": "kZ0yc-Ihoezk"
       },
       "source": [
         "Calling a `jax.custom_jvp` function with keyword arguments, or writing a `jax.custom_jvp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism."
@@ -1637,8 +1519,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "3FGwfT67PDs9",
-        "colab_type": "text"
+        "id": "3FGwfT67PDs9"
       },
       "source": [
         "When you're not performing differentiation, the function `f` is called just as if it weren't decorated by `jax.custom_jvp`:"
@@ -1647,9 +1528,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "b-tB3xCHPRFt",
-        "colab_type": "code",
-        "colab": {}
+        "id": "b-tB3xCHPRFt"
       },
       "source": [
         "@custom_jvp\n",
@@ -1664,18 +1543,16 @@
         "  t, = tangents\n",
         "  return f(x), jnp.cos(x) * t"
       ],
-      "execution_count": 0,
+      "execution_count": 45,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "xAlRea95PjA5",
-        "colab_type": "code",
-        "outputId": "b20e8a49-1ba3-4be0-dcb7-83b2b7cca0d5",
+        "outputId": "10b4db9e-3192-415e-ac1c-0dc57c7dc086",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -1683,7 +1560,7 @@
         "\n",
         "print(f(3.))"
       ],
-      "execution_count": 45,
+      "execution_count": 46,
       "outputs": [
         {
           "output_type": "stream",
@@ -1699,18 +1576,16 @@
       "cell_type": "code",
       "metadata": {
         "id": "dyD2ow4NmpI-",
-        "colab_type": "code",
-        "outputId": "19081712-d417-4678-ba19-d60f8a86bd78",
+        "outputId": "1d66b67f-c1b4-4a9d-d6ed-12d88767842c",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(vmap(f)(jnp.arange(3.)))\n",
         "print(jit(f)(3.))"
       ],
-      "execution_count": 46,
+      "execution_count": 47,
       "outputs": [
         {
           "output_type": "stream",
@@ -1727,8 +1602,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "EzB75KZ5Pz7m",
-        "colab_type": "text"
+        "id": "EzB75KZ5Pz7m"
       },
       "source": [
         "The custom JVP rule is invoked during differentiation, whether forward or reverse:"
@@ -1738,18 +1612,16 @@
       "cell_type": "code",
       "metadata": {
         "id": "hKF0xyAxPyLZ",
-        "colab_type": "code",
-        "outputId": "7919ce76-d1a0-478b-a9d4-cf6050250c97",
+        "outputId": "214cc5a7-a992-41c8-aa01-8ea4b2b3b4d6",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "y, y_dot = jvp(f, (3.,), (1.,))\n",
         "print(y_dot)"
       ],
-      "execution_count": 47,
+      "execution_count": 48,
       "outputs": [
         {
           "output_type": "stream",
@@ -1766,17 +1638,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "Z1KaEgA58MEG",
-        "colab_type": "code",
-        "outputId": "3554eb34-a95d-48b4-e291-f7aa0885c02f",
+        "outputId": "86263d76-5a98-4d96-f5c2-9146bcf1b6fd",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(3.))"
       ],
-      "execution_count": 48,
+      "execution_count": 49,
       "outputs": [
         {
           "output_type": "stream",
@@ -1792,8 +1662,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "o8JFxk3lQhOs",
-        "colab_type": "text"
+        "id": "o8JFxk3lQhOs"
       },
       "source": [
         "Notice that `f_jvp` calls `f` to compute the primal outputs. In the context of higher-order differentiation, each application of a differentiation transform will use the custom JVP rule if and only if the rule calls the original `f` to compute the primal outputs. (This represents a kind of fundamental tradeoff, where we can't make use of intermediate values from the evaluation of `f` in our rule _and also_ have the rule apply in all orders of higher-order differentiation.)"
@@ -1803,17 +1672,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "B6PLJooTQgVp",
-        "colab_type": "code",
-        "outputId": "f53dba7d-fa93-4419-98b9-8c6568ac4741",
+        "outputId": "0d7ac628-656e-4b67-d285-f810155b6b9c",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "grad(grad(f))(3.)"
       ],
-      "execution_count": 49,
+      "execution_count": 50,
       "outputs": [
         {
           "output_type": "stream",
@@ -1834,15 +1701,14 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 49
+          "execution_count": 50
         }
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XNxAmFSsaaro",
-        "colab_type": "text"
+        "id": "XNxAmFSsaaro"
       },
       "source": [
         "You can use Python control flow with `jax.custom_jvp`:"
@@ -1851,9 +1717,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "kkXlSJL6adU2",
-        "colab_type": "code",
-        "colab": {}
+        "id": "kkXlSJL6adU2"
       },
       "source": [
         "@custom_jvp\n",
@@ -1873,25 +1737,23 @@
         "  else:\n",
         "    return ans, 3 * x_dot"
       ],
-      "execution_count": 0,
+      "execution_count": 51,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "QCHmJ56Na2G3",
-        "colab_type": "code",
-        "outputId": "fcc3fd07-6a14-47eb-e86a-a820c9917a16",
+        "outputId": "1772d3b4-44ef-4745-edd3-553c6312c553",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(1.))\n",
         "print(grad(f)(-1.))"
       ],
-      "execution_count": 51,
+      "execution_count": 52,
       "outputs": [
         {
           "output_type": "stream",
@@ -1906,8 +1768,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9cVdgR7ilt8l",
-        "colab_type": "text"
+        "id": "9cVdgR7ilt8l"
       },
       "source": [
         "### Use `jax.custom_vjp` to define custom reverse-mode-only rules\n",
@@ -1918,9 +1779,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "zAZk1n3dUw76",
-        "colab_type": "code",
-        "colab": {}
+        "id": "zAZk1n3dUw76"
       },
       "source": [
         "from jax import custom_vjp\n",
@@ -1941,18 +1800,16 @@
         "\n",
         "f.defvjp(f_fwd, f_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 53,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "E8W-H2S0Ngdr",
-        "colab_type": "code",
-        "outputId": "62e3afa0-d10f-4e72-e567-9ee9b8dd7c3d",
+        "outputId": "cd0dc221-e779-436d-f3b4-21e799f40620",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -1961,7 +1818,7 @@
         "print(f(3.))\n",
         "print(grad(f)(3.))"
       ],
-      "execution_count": 53,
+      "execution_count": 54,
       "outputs": [
         {
           "output_type": "stream",
@@ -1976,8 +1833,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "yLING7qEVGGN",
-        "colab_type": "text"
+        "id": "yLING7qEVGGN"
       },
       "source": [
         "In words, we again start with a a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it two functions, `f_fwd` and `f_bwd`, which describe how to perform the forward- and backward-passes of reverse-mode autodiff, respectively.\n",
@@ -1990,8 +1846,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "d1b5v67Oncfz",
-        "colab_type": "text"
+        "id": "d1b5v67Oncfz"
       },
       "source": [
         "So multiple arguments work like this:"
@@ -2000,9 +1855,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "IhMb64gkngAt",
-        "colab_type": "code",
-        "colab": {}
+        "id": "IhMb64gkngAt"
       },
       "source": [
         "from jax import custom_vjp\n",
@@ -2020,24 +1873,22 @@
         "\n",
         "f.defvjp(f_fwd, f_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 55,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "EnRtIhhLnkry",
-        "colab_type": "code",
-        "outputId": "4d28ce02-26e5-4d04-fb4a-767892844c88",
+        "outputId": "e03907ec-463a-4f3c-ae8e-feecb4394b2b",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(2., 3.))"
       ],
-      "execution_count": 55,
+      "execution_count": 56,
       "outputs": [
         {
           "output_type": "stream",
@@ -2051,8 +1902,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "GwC26P9kn8qw",
-        "colab_type": "text"
+        "id": "GwC26P9kn8qw"
       },
       "source": [
         "Calling a `jax.custom_vjp` function with keyword arguments, or writing a `jax.custom_vjp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism."
@@ -2061,8 +1911,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "XfH-ae8bYt6-",
-        "colab_type": "text"
+        "id": "XfH-ae8bYt6-"
       },
       "source": [
         "As with `jax.custom_jvp`, the custom VJP rule comprised by `f_fwd` and `f_bwd` is not invoked if differentiation is not applied. If function is evaluated, or transformed with `jit`, `vmap`, or other non-differentiation transformations, then only `f` is called."
@@ -2071,9 +1920,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "s-_Dbqi-N5Ij",
-        "colab_type": "code",
-        "colab": {}
+        "id": "s-_Dbqi-N5Ij"
       },
       "source": [
         "@custom_vjp\n",
@@ -2091,24 +1938,22 @@
         "\n",
         "f.defvjp(f_fwd, f_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 57,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "r0aZ79OmOAR5",
-        "colab_type": "code",
-        "outputId": "e62fd6d9-ec63-4a41-c4cd-5be2c8095818",
+        "outputId": "9cf16d9e-ca96-4987-e01a-dc0e22405576",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(f(3.))"
       ],
-      "execution_count": 57,
+      "execution_count": 58,
       "outputs": [
         {
           "output_type": "stream",
@@ -2124,17 +1969,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "7ToB9BYlm6uN",
-        "colab_type": "code",
-        "outputId": "6835b89c-847a-4b82-ac19-1e19a7b9858c",
+        "outputId": "aa9f3e3f-e6c3-4ee4-b87a-4526074f43aa",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(f)(3.))"
       ],
-      "execution_count": 58,
+      "execution_count": 59,
       "outputs": [
         {
           "output_type": "stream",
@@ -2152,11 +1995,9 @@
       "cell_type": "code",
       "metadata": {
         "id": "s1Pn_qCIODcF",
-        "colab_type": "code",
-        "outputId": "991797e7-ec9d-45b8-b88c-1548d9919334",
+        "outputId": "423d34e0-35b8-4b57-e89d-f70f20e28ea9",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -2165,7 +2006,7 @@
         "y, f_vjp = vjp(f, 3.)\n",
         "print(y)"
       ],
-      "execution_count": 59,
+      "execution_count": 60,
       "outputs": [
         {
           "output_type": "stream",
@@ -2182,17 +2023,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "dvgQtDHaOHuo",
-        "colab_type": "code",
-        "outputId": "02447bcd-2885-4883-cc09-a2b352ee3864",
+        "outputId": "d92649c5-0aab-49a9-9158-f7ddc5fccb9b",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 51
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(f_vjp(1.))"
       ],
-      "execution_count": 60,
+      "execution_count": 61,
       "outputs": [
         {
           "output_type": "stream",
@@ -2207,22 +2046,19 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "qFIIpkFcZCNP",
-        "colab_type": "text"
+        "id": "qFIIpkFcZCNP"
       },
       "source": [
-        "**Forward-mode autodiff cannot be used on the `jax.custom_vjp` function** and will raise an error:"
+        "**Forward-mode autodiff cannot be used on the** `jax.custom_vjp` **function** and will raise an error:"
       ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "3RGQRbI_OSEX",
-        "colab_type": "code",
-        "outputId": "f971d7d3-b323-4467-bbc2-3157f3381b64",
+        "outputId": "6385a024-7a10-445a-8380-b2eef722e597",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 68
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -2233,7 +2069,7 @@
         "except TypeError as e:\n",
         "  print('ERROR! {}'.format(e))"
       ],
-      "execution_count": 61,
+      "execution_count": 62,
       "outputs": [
         {
           "output_type": "stream",
@@ -2249,8 +2085,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "u04I9j2dntAU",
-        "colab_type": "text"
+        "id": "u04I9j2dntAU"
       },
       "source": [
         "If you want to use both forward- and reverse-mode, use `jax.custom_jvp` instead."
@@ -2259,8 +2094,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "YN97y7LEZbWV",
-        "colab_type": "text"
+        "id": "YN97y7LEZbWV"
       },
       "source": [
         "We can use `jax.custom_vjp` together with `pdb` to insert a debugger trace in the backward pass:"
@@ -2269,9 +2103,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "-DvRKsHPZk_g",
-        "colab_type": "code",
-        "colab": {}
+        "id": "-DvRKsHPZk_g"
       },
       "source": [
         "import pdb\n",
@@ -2289,15 +2121,13 @@
         "\n",
         "debug.defvjp(debug_fwd, debug_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 63,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
-        "id": "49GdkP4pZ2IV",
-        "colab_type": "code",
-        "colab": {}
+        "id": "49GdkP4pZ2IV"
       },
       "source": [
         "def foo(x):\n",
@@ -2305,14 +2135,13 @@
         "  y = debug(y)  # insert pdb in corresponding backward pass step\n",
         "  return jnp.sin(y)"
       ],
-      "execution_count": 0,
+      "execution_count": 64,
       "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "sGLnRcPwaKoX",
-        "colab_type": "text"
+        "id": "sGLnRcPwaKoX"
       },
       "source": [
         "```python\n",
@@ -2331,8 +2160,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "DaTfAJLAl1Lb",
-        "colab_type": "text"
+        "id": "DaTfAJLAl1Lb"
       },
       "source": [
         "## More features and details\n"
@@ -2341,8 +2169,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "LQF_UDApl_UV",
-        "colab_type": "text"
+        "id": "LQF_UDApl_UV"
       },
       "source": [
         "### Working with `list` / `tuple` / `dict` containers (and other pytrees)\n",
@@ -2355,9 +2182,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "6sDLZ3dAn3P2",
-        "colab_type": "code",
-        "colab": {}
+        "id": "6sDLZ3dAn3P2"
       },
       "source": [
         "from collections import namedtuple\n",
@@ -2382,18 +2207,16 @@
         "  dct = f(pt)\n",
         "  return dct['a'] + dct['b'][0]"
       ],
-      "execution_count": 0,
+      "execution_count": 65,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "My8pbOlPppJj",
-        "colab_type": "code",
-        "outputId": "8430db76-7c94-412d-d261-60614dff2dbc",
+        "outputId": "04cc1129-d0fb-4018-bec1-2ccf8b7906e3",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -2401,7 +2224,7 @@
         "\n",
         "print(f(pt))"
       ],
-      "execution_count": 65,
+      "execution_count": 66,
       "outputs": [
         {
           "output_type": "stream",
@@ -2416,22 +2239,20 @@
       "cell_type": "code",
       "metadata": {
         "id": "a9qyiCAhqLd3",
-        "colab_type": "code",
-        "outputId": "4184570b-a4b1-4297-da32-746b80bfb63f",
+        "outputId": "08bd0615-7c35-44ff-f90b-c175618c2c40",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(fun)(pt))"
       ],
-      "execution_count": 66,
+      "execution_count": 67,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "Point(x=DeviceArray(2.5403023, dtype=float32), y=array(0.))\n"
+            "Point(x=DeviceArray(2.5403023, dtype=float32), y=array(0., dtype=float32))\n"
           ],
           "name": "stdout"
         }
@@ -2440,8 +2261,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BWLN9tu4qWQd",
-        "colab_type": "text"
+        "id": "BWLN9tu4qWQd"
       },
       "source": [
         "And an analogous contrived example with `jax.custom_vjp`:"
@@ -2450,9 +2270,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "QkdbwGkJqS3J",
-        "colab_type": "code",
-        "colab": {}
+        "id": "QkdbwGkJqS3J"
       },
       "source": [
         "@custom_vjp\n",
@@ -2476,18 +2294,16 @@
         "  dct = f(pt)\n",
         "  return dct['a'] + dct['b'][0]"
       ],
-      "execution_count": 0,
+      "execution_count": 68,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "3onW7t6nrJ4E",
-        "colab_type": "code",
-        "outputId": "75910cfc-dee5-461c-a646-2f9dcba8f674",
+        "outputId": "ac455ab0-cac0-41fc-aea3-034931316053",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
@@ -2495,7 +2311,7 @@
         "\n",
         "print(f(pt))"
       ],
-      "execution_count": 68,
+      "execution_count": 69,
       "outputs": [
         {
           "output_type": "stream",
@@ -2510,17 +2326,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "ryyeKIXtrNpd",
-        "colab_type": "code",
-        "outputId": "e707a38e-f72f-40a6-ece4-499d21c9e5cb",
+        "outputId": "1780f738-ffd8-4ed7-ffbe-71d84bd62709",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(fun)(pt))"
       ],
-      "execution_count": 69,
+      "execution_count": 70,
       "outputs": [
         {
           "output_type": "stream",
@@ -2534,8 +2348,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "JKTNivxbmKWO",
-        "colab_type": "text"
+        "id": "JKTNivxbmKWO"
       },
       "source": [
         "### Handling  non-differentiable arguments"
@@ -2544,18 +2357,16 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "7g9sXSp_uc36",
-        "colab_type": "text"
+        "id": "7g9sXSp_uc36"
       },
       "source": [
-        "Some use cases, like the final example problem, call for non-differentiable arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`.\n"
+        "Some use cases, like the final example problem, call for non-differentiable arguments like function-valued arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`.\n"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "9yNIOzyBCvE5",
-        "colab_type": "text"
+        "id": "9yNIOzyBCvE5"
       },
       "source": [
         "#### `jax.custom_jvp` with `nondiff_argnums`\n",
@@ -2566,9 +2377,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "b3YMxxTBvy0I",
-        "colab_type": "code",
-        "colab": {}
+        "id": "b3YMxxTBvy0I"
       },
       "source": [
         "from functools import partial\n",
@@ -2583,24 +2392,22 @@
         "  x_dot, = tangents\n",
         "  return f(x), 2. * x_dot"
       ],
-      "execution_count": 0,
+      "execution_count": 71,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "5W-yEw9IB34S",
-        "colab_type": "code",
-        "outputId": "0a0d493c-a1fd-4f76-8cec-f18522aa5774",
+        "outputId": "a2c1444a-9cc7-43ee-cb52-6c5d1cec02f1",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(app(lambda x: x ** 3, 3.))"
       ],
-      "execution_count": 71,
+      "execution_count": 72,
       "outputs": [
         {
           "output_type": "stream",
@@ -2615,17 +2422,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "zbVIlOmqB7_O",
-        "colab_type": "code",
-        "outputId": "280d4b0a-e68b-4996-dd50-d66d129c8eec",
+        "outputId": "a0174f54-89b0-4957-9362-c05af922f974",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(app, 1)(lambda x: x ** 3, 3.))"
       ],
-      "execution_count": 72,
+      "execution_count": 73,
       "outputs": [
         {
           "output_type": "stream",
@@ -2639,8 +2444,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "-b_B_4WaBI2D",
-        "colab_type": "text"
+        "id": "-b_B_4WaBI2D"
       },
       "source": [
         "Notice the gotcha here: no matter where in the argument list these parameters appear, they're placed at the *start* of the signature of the corresponding JVP rule. Here's another example:"
@@ -2649,9 +2453,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "9hokWmyHBgKK",
-        "colab_type": "code",
-        "colab": {}
+        "id": "9hokWmyHBgKK"
       },
       "source": [
         "@partial(custom_jvp, nondiff_argnums=(0, 2))\n",
@@ -2664,24 +2466,22 @@
         "  x_dot, = tangents\n",
         "  return f(g(x)), 3. * x_dot"
       ],
-      "execution_count": 0,
+      "execution_count": 74,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "J7GsvJTgCfS0",
-        "colab_type": "code",
-        "outputId": "6963fd03-c952-467d-c117-39a53253b2b9",
+        "outputId": "43dd6a02-2e4e-449e-924a-d1a03fe622fe",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(app2(lambda x: x ** 3, 3., lambda y: 5 * y))"
       ],
-      "execution_count": 74,
+      "execution_count": 75,
       "outputs": [
         {
           "output_type": "stream",
@@ -2696,17 +2496,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "kPP8Jt1CCb1X",
-        "colab_type": "code",
-        "outputId": "77f7d0a0-951b-44df-fb44-540a0e968072",
+        "outputId": "6eff9aae-8d6e-4998-92ed-56272c32d6e8",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(app2, 1)(lambda x: x ** 3, 3., lambda y: 5 * y))"
       ],
-      "execution_count": 75,
+      "execution_count": 76,
       "outputs": [
         {
           "output_type": "stream",
@@ -2720,8 +2518,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "ECbalHIkC4ts",
-        "colab_type": "text"
+        "id": "ECbalHIkC4ts"
       },
       "source": [
         "#### `jax.custom_vjp` with `nondiff_argnums`"
@@ -2730,8 +2527,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "0u0jn4aWC8k1",
-        "colab_type": "text"
+        "id": "0u0jn4aWC8k1"
       },
       "source": [
         "A similar option exists for `jax.custom_vjp`, and similarly the convention is that the non-differentiable arguments are passed as the first arguments to the rules, no matter where they appear in the original function's signature. Here's an example:"
@@ -2740,9 +2536,7 @@
     {
       "cell_type": "code",
       "metadata": {
-        "id": "yCdu-_9GClWs",
-        "colab_type": "code",
-        "colab": {}
+        "id": "yCdu-_9GClWs"
       },
       "source": [
         "@partial(custom_vjp, nondiff_argnums=(0,))\n",
@@ -2757,24 +2551,22 @@
         "\n",
         "app.defvjp(app_fwd, app_bwd)"
       ],
-      "execution_count": 0,
+      "execution_count": 77,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "id": "qSgcWa1eDj4r",
-        "colab_type": "code",
-        "outputId": "6c34436a-1bdb-49db-a57f-b50f053c0cd4",
+        "outputId": "43939686-f857-47ea-9f85-53f440ef12ee",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(app(lambda x: x ** 2, 4.))"
       ],
-      "execution_count": 77,
+      "execution_count": 78,
       "outputs": [
         {
           "output_type": "stream",
@@ -2789,17 +2581,15 @@
       "cell_type": "code",
       "metadata": {
         "id": "tccagflcDmaz",
-        "colab_type": "code",
-        "outputId": "d28015b9-47a9-4adc-e643-3fea37ac1d46",
+        "outputId": "c75ca70b-2431-493b-e335-4f4d340902f1",
         "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 34
+          "base_uri": "https://localhost:8080/"
         }
       },
       "source": [
         "print(grad(app, 1)(lambda x: x ** 2, 4.))"
       ],
-      "execution_count": 78,
+      "execution_count": 79,
       "outputs": [
         {
           "output_type": "stream",
@@ -2813,11 +2603,12 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "BTEnNTk5D0sM",
-        "colab_type": "text"
+        "id": "BTEnNTk5D0sM"
       },
       "source": [
-        "See `clip_gradient` and `fixed_point` above for other usage examples."
+        "See `fixed_point` above for another usage example.\n",
+        "\n",
+        "**You don't need to use** `nondiff_argnums` **with array-valued arguments**, for example ones with integer dtype. Instead, `nondiff_argnums` should only be used for argument values that don't correspond to JAX types (essentially don't correspond to array types), like Python callables or strings. If JAX detects that an argument indicated by `nondiff_argnums` contains a JAX Tracer, then an error is raised. The `clip_gradient` function above is a good example of not using `nondiff_argnums` for integer-dtype array arguments."
       ]
     }
   ]

--- a/jax/core.py
+++ b/jax/core.py
@@ -393,23 +393,24 @@ class Trace:
         self.__class__.__name__, self.level, self.sublevel)
 
   def process_call(self, call_primitive, f, tracers, params):
-    raise NotImplementedError("must override to handle call-like primitives")
+    msg = (f"{type(self)} must override process_call to handle call-like "
+           "primitives")
+    raise NotImplementedError(msg)
 
   def process_map(self, call_primitive, f, tracers, params):
-    raise NotImplementedError("must override to handle map-like primitives")
+    msg = (f"{type(self)} must override process_map to handle map-like "
+           "primitives")
+    raise NotImplementedError(msg)
 
   def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
-    # As a default implementation, drop the custom differentiation rule. This
-    # behavior is desirable when staging out of the JAX system, but not when
-    # there are further differentiation transformations to be applied. Override
-    # this method to allow differentiation to be performed downstream.
-    del primitive, jvp  # Unused.
-    return fun.call_wrapped(*tracers)
+    msg = (f"{type(self)} must override process_custom_jvp_call "
+           "to handle custom_jvp primitives")
+    raise NotImplementedError(msg)
 
   def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, out_trees):
-    # See comment in the above process_custom_jvp_call method.
-    del primitive, fwd, bwd, out_trees  # Unused.
-    return fun.call_wrapped(*tracers)
+    msg = (f"{type(self)} must override process_custom_vjp_call "
+           "to handle custom_vjp primitives")
+    raise NotImplementedError(msg)
 
 def escaped_tracer_error(detail=None):
   msg = ("Encountered an unexpected tracer. Perhaps this tracer escaped "
@@ -574,6 +575,14 @@ class EvalTrace(Trace):
   def process_call(self, primitive, f, tracers, params):
     return primitive.impl(f, *tracers, **params)
   process_map = process_call
+
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
+    del primitive, jvp  # Unused.
+    return fun.call_wrapped(*tracers)
+
+  def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, out_trees):
+    del primitive, fwd, bwd, out_trees  # Unused.
+    return fun.call_wrapped(*tracers)
 
 
 class MainTrace:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -560,6 +560,26 @@ class TensorFlowTrace(core.Trace):
   def post_process_map(self, map_primitive, out_tracers, params):
     raise NotImplementedError("post_process_map")
 
+  def process_custom_jvp_call(self, prim, fun, jvp, tracers):
+    # Drop the custom differentiation rule and act like a call primitive. This
+    # behavior is desirable because jax2tf stages code out of the JAX system, so
+    # there are no more JAX differentiation transformations to be applied.
+    del jvp  # Unused.
+    return self.process_call(core.call_p, fun, tracers, {})
+
+  def post_process_custom_jvp_call(self, out_tracers, params):
+    assert False  # unreachable assuming jax2tf runs with clean trace state
+
+  def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees):
+    # Drop the custom differentiation rule and act like a call primitive. This
+    # behavior is desirable because jax2tf stages code out of the JAX system, so
+    # there are no more JAX differentiation transformations to be applied.
+    del fwd, bwd, out_trees  # Unused.
+    return self.process_call(core.call_p, fun, tracers, {})
+
+  def post_process_custom_vjp_call(self, out_tracers, params):
+    assert False  # unreachable assuming jax2tf runs with clean trace state
+
   def get_primitive_impl(self, p: core.Primitive) -> Tuple[Callable, bool]:
     # Returns the primitive implementation and whether the implementation
     # takes abstract values (see definition of tf_impl_with_avals)
@@ -1786,7 +1806,8 @@ tf_impl[lax_linalg.eigh_p] = _eigh
 
 def _custom_jvp_call_jaxpr(*args: TfVal,
                            fun_jaxpr: core.ClosedJaxpr,
-                           jvp_jaxpr_thunk: Callable) -> Sequence[TfVal]:
+                           jvp_jaxpr_thunk: Callable,
+                           num_consts: int) -> Sequence[TfVal]:
   # TODO(necula): ensure that there is no AD transformation in scope
   return _interpret_jaxpr(fun_jaxpr, *args)
 

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -153,8 +153,14 @@ class JetTrace(core.Trace):
       return map(partial(JetTracer, trace), primals, series)
     return out, todo
 
-  def join(self, xt, yt):
-    assert False  # TODO?
+  def process_custom_jvp_call(self, primitive, fun, jvp, tracers):
+    # TODO(mattjj): don't just ignore custom jvp rules?
+    del primitive, jvp  # Unused.
+    return fun.call_wrapped(*tracers)
+
+  def process_custom_vjp_call(self, primitive, fun, fwd, bwd, tracers, out_trees):
+    del primitive, fwd, bwd, out_trees  # Unused.
+    return fun.call_wrapped(*tracers)
 
 
 class ZeroTerm(object): pass

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -146,16 +146,17 @@ def unpair_pval(pval):
     aval_1, aval_2 = aval
     return (aval_1, const_1), (aval_2, const_2)
 
-def replace_float0s(primals, tangents):
-  return [core.zeros_like_float0(tangent, dtype(primal))
-          if dtype(tangent) is float0 else tangent
-          for primal, tangent in zip(primals, tangents)]
+def replace_float0s(primal, tangent):
+  if dtype(tangent) is float0:
+    return core.zeros_like_float0(tangent, dtype(primal))
+  else:
+    return tangent
 
-def recast_to_float0(primals, tangents):
-  return [Zero(get_aval(primal).at_least_vspace())
-          if core.primal_dtype_to_tangent_dtype(dtype(primal)) == float0
-          else tangent
-          for primal, tangent in zip(primals, tangents)]
+def recast_to_float0(primal, tangent):
+  if core.primal_dtype_to_tangent_dtype(dtype(primal)) == float0:
+    return Zero(get_aval(primal).at_least_vspace())
+  else:
+    return tangent
 
 # NOTE: The FIXMEs below are caused by primal/tangent mixups (type errors if you will)
 def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
@@ -314,11 +315,14 @@ class JVPTrace(Trace):
     tangents_in = map(instantiate_zeros, tangents_in)
     # Cast float0 to zeros with the primal dtype because custom jvp rules don't
     # currently handle float0s
-    tangents_in = replace_float0s(primals_in, tangents_in)
+    tangents_in = map(replace_float0s, primals_in, tangents_in)
     outs = f_jvp.call_wrapped(*it.chain(primals_in, tangents_in))
     primals_out, tangents_out = split_list(outs, [len(outs) // 2])
-    tangents_out = recast_to_float0(primals_out, tangents_out)
+    tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
+
+  def post_process_custom_jvp_call(self, out_tracers, params):
+    raise CustomJVPException()
 
   def process_custom_vjp_call(self, _, __, fwd, bwd, tracers, *, out_trees):
     primals_in, tangents_in = unzip2((t.primal, t.tangent) for t in tracers)
@@ -330,8 +334,11 @@ class JVPTrace(Trace):
     tangents_out = custom_lin_p.bind(
         *res, *tangents_in, num_res=res_tree.num_leaves, bwd=bwd,
         avals_out=avals_out)
-    tangents_out = recast_to_float0(primals_out, tangents_out)
+    tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
+
+  def post_process_custom_vjp_call(self, out_tracers, params):
+    raise CustomVJPException()
 
   def join(self, xt, yt):
     xz, yz = type(xt) is Zero, type(yt) is Zero
@@ -625,8 +632,7 @@ def _custom_lin_transpose(cts_out, *invals, num_res, bwd, avals_out):
   res, _ = split_list(invals, [num_res])
   cts_out = map(instantiate_zeros_aval, avals_out, cts_out)
   cts_in = bwd.call_wrapped(*res, *cts_out)
-  cts_in_flat, _ = tree_flatten(cts_in)  # already checked tree structure
-  return [None] * num_res + cts_in_flat
+  return [None] * num_res + list(cts_in)
 primitive_transposes[custom_lin_p] = _custom_lin_transpose
 
 
@@ -695,6 +701,28 @@ def defvjp2(prim, *vjps):
     return ans, vjpfun
   defvjp_all(prim, vjpmaker)
 
+
+class CustomJVPException(Exception):
+  def __init__(self):
+    # TODO(mattjj): track source provenance on AD tracers, improve error
+    msg = ("Detected differentiation of a custom_jvp function with respect to "
+           "a closed-over value. That isn't supported because the custom JVP "
+           "rule only specifies how to differentiate the custom_jvp function "
+           "with respect to explicit input parameters. Try passing the "
+           "closed-over value into the custom_jvp function as an argument, and "
+           "adapting the custom_jvp rule.")
+    super().__init__(msg)
+
+class CustomVJPException(Exception):
+  def __init__(self):
+    # TODO(mattjj): track source provenance on AD tracers, improve error
+    msg = ("Detected differentiation of a custom_vjp function with respect to "
+           "a closed-over value. That isn't supported because the custom VJP "
+           "rule only specifies how to differentiate the custom_vjp function "
+           "with respect to explicit input parameters. Try passing the "
+           "closed-over value into the custom_vjp function as an argument, and "
+           "adapting the custom_vjp fwd and bwd rules.")
+    super().__init__(msg)
 
 @config.register_omnistaging_disabler
 def omnistaging_disabler() -> None:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2793,7 +2793,27 @@ class CustomJVPTest(jtu.JaxTestCase):
     expected = 2.
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    ans = api.grad(api.jit(foo))(3.)
+    expected = 2.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.jit(api.grad(foo))(3.)
+    expected = 2.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
     ans = api.grad(api.grad(foo))(3.)
+    expected = 0.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.grad(api.jit(foo)))(3.)
+    expected = 0.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.jit(api.grad(foo)))(3.)
+    expected = 0.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.jit(api.grad(api.grad(foo)))(3.)
     expected = 0.
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -2816,11 +2836,38 @@ class CustomJVPTest(jtu.JaxTestCase):
     expected = 3. * jnp.ones(3)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    ans = api.vmap(api.jit(foo))(jnp.ones(3))
+    expected = 3. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.jit(api.vmap(foo))(jnp.ones(3))
+    expected = 3. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
     ans = api.grad(lambda x: api.vmap(foo)(x).sum())(jnp.ones(3))
     expected = 2. * jnp.ones(3)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    ans = api.grad(lambda x: api.vmap(api.jit(foo))(x).sum())(jnp.ones(3))
+    expected = 2. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(lambda x: api.jit(api.vmap(foo))(x).sum())(jnp.ones(3))
+    expected = 2. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.jit(lambda x: api.vmap(foo)(x).sum()))(jnp.ones(3))
+    expected = 2. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.jit(api.grad(lambda x: api.vmap(foo)(x).sum()))(jnp.ones(3))
+    expected = 2. * jnp.ones(3)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
   def test_closed_over_tracers_error_message(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
     def f(x):
       @api.custom_jvp
       def g(y):
@@ -2830,10 +2877,8 @@ class CustomJVPTest(jtu.JaxTestCase):
       g.defjvp(g_jvp)
       return g(1.)
 
-    self.assertRaises(
-        core.UnexpectedTracerError, lambda: api.jvp(f, (3.,), (1.,)))
-    self.assertRaises(
-        core.UnexpectedTracerError, lambda: api.grad(f)(3.))
+    self.assertRaises(ad.CustomJVPException, lambda: api.jvp(f, (3.,), (1.,)))
+    self.assertRaises(ad.CustomJVPException, lambda: api.grad(f)(3.))
 
   def test_nondiff_arg(self):
     @partial(api.custom_jvp, nondiff_argnums=(0,))
@@ -2868,6 +2913,25 @@ class CustomJVPTest(jtu.JaxTestCase):
     ans = api.jvp(lambda y: g(2., y), (3.,), (1.,))
     expected = (6., 5.)
     self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_nondiff_arg_hiding_jvp_tracer(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    def f(x):
+      @partial(api.custom_jvp, nondiff_argnums=(0,))
+      def g(h, x):
+        return h(x)
+      @g.defjvp
+      def g_jvp(h, primals, tangents):
+        x, = primals
+        t, = tangents
+        return g(h, x), 2. * t
+      h = lambda y: x + y  # capture x
+      return g(h, x)
+
+    with self.assertRaisesRegex(ad.CustomJVPException, "Detected differentiation"):
+      api.jvp(f, (2.,), (1.,))
 
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test
@@ -3123,6 +3187,77 @@ class CustomJVPTest(jtu.JaxTestCase):
     for ans in results:
       self.assertAllClose(ans, expected)
 
+  def test_nondiff_argnums_vmap_tracer(self):
+    # https://github.com/google/jax/issues/3964
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    @partial(jax.custom_jvp, nondiff_argnums=(0, 2))
+    def sample(shape, param, seed):
+      return jax.random.uniform(key=seed, shape=shape, minval=param)
+
+    @sample.defjvp
+    def sample_jvp(shape, seed, primals, tangents):
+      param, = primals
+      dparam, = tangents
+      dparam = jnp.broadcast_to(dparam, shape)
+      samples = sample(shape, param, seed)
+      return samples, samples * dparam  # dummy jvp for proof of concept
+
+    # check these don't crash
+    jax.vmap(lambda seed: sample((2,3), 1., seed))(
+        jax.random.split(jax.random.PRNGKey(1), 10))
+    jax.jvp(lambda x: sample((2, 3), x, jax.random.PRNGKey(1)),
+            (1.,), (1.,))
+
+  def test_fun_with_nested_calls_2(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    def call(f, *args):
+      f = api.custom_jvp(f)
+      f.defjvp(lambda primals, tangents: (f(*primals), sum(tangents)))
+      return f(*args)
+
+    def fun_with_nested_calls_2(x):
+      def bar(y):
+        def baz(w):
+          q = call(lambda x: y, x)
+          q = q + call(lambda: y)
+          q = q + call(lambda y: w + y, y)
+          q = call(lambda w: call(jnp.sin, x) * y, 1.0) + q
+          return q
+        return api.jit(baz)(x)
+      return call(bar, x)
+
+    # test these don't crash
+    self.assertAllClose(api.jit(fun_with_nested_calls_2)(3.),
+                        fun_with_nested_calls_2(3.))
+    api.vmap(fun_with_nested_calls_2)(jnp.arange(3.))
+
+  def test_closure_with_vmap(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    # https://github.com/google/jax/issues/3822
+    alpha = np.float32(2.)
+
+    def sample(seed):
+      @api.custom_jvp
+      def f(alpha):
+        return jax.random.gamma(seed, alpha, shape=[])
+
+      @f.defjvp
+      def f_jvp(primal, tangent):
+        alpha = primal
+        dalpha = tangent
+        sample = f(alpha)
+        partial_alpha = lax.random_gamma_grad(alpha, sample)
+        return sample, partial_alpha * dalpha
+      return f(alpha)
+
+    api.vmap(sample)(jax.random.split(jax.random.PRNGKey(1), 3))  # don't crash
+
   def test_float0(self):
     @api.custom_jvp
     def f(x, y):
@@ -3156,6 +3291,53 @@ class CustomJVPTest(jtu.JaxTestCase):
     expected_tangents = (2., np.zeros((), float0))
     self.assertArraysEqual(api.jvp(foo, primals, tangents),
                            (primals, expected_tangents))
+
+  def test_remat(self):
+    @api.custom_jvp
+    def f(x):
+      return jnp.sin(x)
+    def f_jvp(primals, tangents):
+      x, = primals
+      g, = tangents
+      return f(x), 2 * jnp.cos(x) * g
+    f.defjvp(f_jvp)
+
+    @api.remat
+    def g(x):
+      return f(f(x))
+
+    ans = g(2.)
+    expected = np.sin(np.sin(2.))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(g)(2.)
+    expected = 4. * api.grad(lambda x: jnp.sin(jnp.sin(x)))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_remat_higher_order(self):
+    @api.custom_jvp
+    def f(x):
+      return jnp.sin(x)
+    def f_jvp(primals, tangents):
+      x, = primals
+      g, = tangents
+      return f(x), 2 * jnp.cos(x) * g
+    f.defjvp(f_jvp)
+
+    def g(x):
+      return f(f(x))
+
+    ans = api.grad(api.grad(api.remat(g)))(2.)
+    expected = api.grad(api.grad(g))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.remat(api.grad(g)))(2.)
+    expected = api.grad(api.grad(g))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.grad(api.grad(api.remat(g))))(2.)
+    expected = api.grad(api.grad(api.grad(g)))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
 
 class CustomVJPTest(jtu.JaxTestCase):
@@ -3395,6 +3577,12 @@ class CustomVJPTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def test_nondiff_arg_tracer(self):
+    # This test is now skipped because we decided not to support this behavior
+    # anymore (namely, nondiff args can't be tracers), but
+    # test_closed_over_tracer is a replacement test for analogous behavior that
+    # we do support
+    raise unittest.SkipTest("removed support for tracers in nondiff args")
+
     @partial(api.custom_vjp, nondiff_argnums=(0,))
     def f(x, y):
       return x * y
@@ -3415,6 +3603,56 @@ class CustomVJPTest(jtu.JaxTestCase):
     ans = api.grad(g, 1)(2., 3.)
     expected = jnp.cos(3.)
     self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_closed_over_tracer(self):
+    # This test is similar to test_nondiff_arg_tracer except it uses lexical
+    # closure rather than the nondiff_argnums mechanism. We decided to disallow
+    # tracers in nondiff_argnums to greatly simplify bookkeeping while still
+    # supporting the cases for which it is necessary.
+    def outer(x):
+      @api.custom_vjp
+      def f(y):
+        return x * y
+      def f_fwd(y):
+        return f(y), jnp.cos(y)
+      def f_rev(cos_y, g):
+        return (cos_y * g,)
+      f.defvjp(f_fwd, f_rev)
+      return f
+
+    @jit
+    def g(x, y):
+      return outer(x)(y)
+
+    ans = g(2, 3.)
+    expected = 6.
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(g, 1)(2., 3.)
+    expected = jnp.cos(3.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_nondiff_arg_tracer_error(self):
+    # This is similar to the old (now skipped) test_nondiff_arg_tracer, except
+    # we're testing for the error message that that usage pattern now raises.
+
+    @partial(api.custom_vjp, nondiff_argnums=(0,))
+    def f(x, y):
+      return x * y
+    def f_fwd(x, y):
+      return f(x, y), jnp.cos(y)
+    def f_rev(x, cos_y, g):
+      return (cos_y * g,)
+    f.defvjp(f_fwd, f_rev)
+
+    @jit
+    def g(x, y):
+      return f(x, y)
+
+    with self.assertRaisesRegex(core.UnexpectedTracerError, "custom_vjp"):
+      _ = g(2, 3.)
+    with self.assertRaisesRegex(core.UnexpectedTracerError, "custom_vjp"):
+      _ = api.grad(g, 1)(2., 3.)
 
   def test_vmap_axes(self):
     raise unittest.SkipTest("TODO")  # TODO(mattjj): write test
@@ -3482,6 +3720,11 @@ class CustomVJPTest(jtu.JaxTestCase):
     jax.grad(g, argnums=(1,))(F(2.0), 0.)  # doesn't crash
 
   def test_nondiff_argnums_stop_gradient(self):
+    # This test is now skipped because we decided not to support this behavior
+    # anymore (namely, nondiff args can't be tracers), but test_clip_gradient is
+    # a replacement showing behavior we do support.
+    raise unittest.SkipTest("removed support for tracers in nondiff args")
+
     # https://github.com/google/jax/issues/2784
     @partial(api.custom_vjp, nondiff_argnums=(0, 1))
     def _clip_gradient(lo, hi, x):
@@ -3502,6 +3745,29 @@ class CustomVJPTest(jtu.JaxTestCase):
       return _clip_gradient(lo, hi, x)
 
     jax.grad(clip_gradient)(1.)  # doesn't crash
+
+  def test_clip_gradient(self):
+    # https://github.com/google/jax/issues/2784
+    @api.custom_vjp
+    def _clip_gradient(lo, hi, x):
+      return x  # identity function when not differentiating
+
+    def clip_gradient_fwd(lo, hi, x):
+      return x, (lo, hi,)
+
+    def clip_gradient_bwd(res, g):
+      lo, hi = res
+      return (None, None, jnp.clip(g, lo, hi),)
+
+    _clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
+
+    def clip_gradient(x):
+      lo = -0.1
+      hi = x + 0.1
+      return _clip_gradient(lo, hi, x)
+
+    g = jax.grad(clip_gradient)(0.1)  # doesn't crash
+    self.assertAllClose(g, jnp.array(0.2))
 
   def test_nestable_vjp(self):
     # Verify that https://github.com/google/jax/issues/3667 is resolved.
@@ -3535,6 +3801,94 @@ class CustomVJPTest(jtu.JaxTestCase):
       return g_vjp
     y, = z(1.0)(3.0)
     self.assertAllClose(y, jnp.array(6.0))
+
+  def test_initial_style_vmap_2(self):
+    # https://github.com/google/jax/issues/4173
+    x = jnp.ones((10, 3))
+
+    # Create the custom function
+    @api.custom_vjp
+    def custom_fun(x):
+        return x.sum()
+    def forward(x):
+        return x.sum(), (jnp.ones_like(x),)
+    def backward(res, g):
+        return g*res[0],
+    custom_fun.defvjp(forward, backward)
+
+    def train_fun(x):
+        def summed_fun(x):
+            return api.vmap(custom_fun)(x).sum()
+        return api.grad(summed_fun)(x)
+
+    def scan_body(carry, inputs):
+        x = carry
+        return carry, train_fun(x)
+
+    scan_range = jnp.arange(4)
+    lax.scan(scan_body, x, scan_range)  # don't crash
+
+  def test_bwd_closes_over_tracer(self):
+    def f(y):
+      @jax.custom_vjp
+      def f(x):
+        return 2. * jnp.sin(x)
+
+      def fwd(x):
+        return f(x), ()
+
+      def bwd(_, g):
+        return (2. * jnp.cos(y) * g,)  # capture!
+
+      f.defvjp(fwd, bwd)
+
+      return jax.grad(f)(1.)
+
+    ans = jax.jit(f)(2.)
+    self.assertAllClose(ans, 2. * jnp.cos(2.))
+
+    ans = jax.vmap(f)(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.jit(jax.vmap(f))(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.vmap(jax.jit(f))(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.grad(f)(4.)
+    self.assertAllClose(ans, -2. * jnp.sin(4.))
+
+  def test_fwd_closes_over_tracer(self):
+    def f(y):
+      @jax.custom_vjp
+      def f(x):
+        return 2. * jnp.sin(x)
+
+      def fwd(x):
+        return f(x), y
+
+      def bwd(y, g):
+        return (2. * jnp.cos(y) * g,)  # capture!
+
+      f.defvjp(fwd, bwd)
+
+      return jax.grad(f)(1.)
+
+    ans = jax.jit(f)(2.)
+    self.assertAllClose(ans, 2. * jnp.cos(2.))
+
+    ans = jax.vmap(f)(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.jit(jax.vmap(f))(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.vmap(jax.jit(f))(jnp.arange(3.))
+    self.assertAllClose(ans, 2. * jnp.cos(jnp.arange(3.)))
+
+    ans = jax.grad(f)(4.)
+    self.assertAllClose(ans, -2. * jnp.sin(4.))
 
   def test_float0(self):
     @api.custom_vjp
@@ -3570,6 +3924,120 @@ class CustomVJPTest(jtu.JaxTestCase):
     y = 3
     self.assertEqual(api.grad(foo, allow_int=True, argnums=(0, 1))(x, y),
                      (2., np.zeros(shape=(), dtype=float0)))
+
+  def test_remat(self):
+    @api.custom_vjp
+    def f(x):
+      return jnp.sin(x)
+    def f_fwd(x):
+      return f(x), jnp.cos(x)
+    def f_rev(cos_x, g):
+      return (2 * cos_x * g,)
+    f.defvjp(f_fwd, f_rev)
+
+    @api.remat
+    def g(x):
+      return f(f(x))
+
+    ans = g(2.)
+    expected = np.sin(np.sin(2.))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(g)(2.)
+    expected = 4. * api.grad(lambda x: jnp.sin(jnp.sin(x)))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_remat_higher_order(self):
+    @api.custom_vjp
+    def f(x):
+      return jnp.sin(x)
+    def f_fwd(x):
+      return f(x), jnp.cos(x)
+    def f_rev(cos_x, g):
+      return (2 * cos_x * g,)
+    f.defvjp(f_fwd, f_rev)
+
+    def g(x):
+      return f(f(x))
+
+    ans = api.grad(api.grad(api.remat(g)))(2.)
+    expected = api.grad(api.grad(g))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.remat(api.grad(g)))(2.)
+    expected = api.grad(api.grad(g))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    ans = api.grad(api.grad(api.grad(api.remat(g))))(2.)
+    expected = api.grad(api.grad(api.grad(g)))(2.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_bwd_nones(self):
+    @api.custom_vjp
+    def f(x, y):
+      return x * jnp.sin(y)
+    def f_fwd(x, y):
+      return f(x, y), jnp.cos(y)
+    def f_rev(cos, g):
+      return (None, 2 * cos * g)
+    f.defvjp(f_fwd, f_rev)
+
+    ans = api.grad(lambda x: f(x, x))(3.)
+    expected = 2 * jnp.cos(3.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_bwd_nones_vmap(self):
+    @api.custom_vjp
+    def f(x, y):
+      return x * jnp.sin(y)
+    def f_fwd(x, y):
+      return f(x, y), jnp.cos(y)
+    def f_rev(cos, g):
+      return (None, 2 * cos * g)
+    f.defvjp(f_fwd, f_rev)
+
+    ans = api.grad(lambda x: api.vmap(f)(x, x).sum())(jnp.arange(3.))
+    expected = 2 * jnp.cos(jnp.arange(3.))
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_bwd_nones_pytree(self):
+    @api.custom_vjp
+    def f(xs, y):
+      x1, x2 = xs
+      return x1 * x2 * jnp.sin(y)
+    def f_fwd(xs, y):
+      return f(xs, y), jnp.cos(y)
+    def f_rev(cos, g):
+      return (None, 2 * cos * g)
+    f.defvjp(f_fwd, f_rev)
+
+    ans = api.grad(lambda x: f((x, x), x))(3.)
+    expected = 2 * jnp.cos(3.)
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+  def test_custom_vjp_closure_4521(self):
+    # https://github.com/google/jax/issues/4521
+    @api.custom_vjp
+    def g(x, y):
+      return None
+    def g_fwd(x, y):
+      return None, y
+    def g_bwd(residuals, z_bar):
+      assert False
+
+    g.defvjp(g_fwd, g_bwd)
+
+    def f(xs, y):
+      v_g = api.vmap(g, in_axes=(0, None), out_axes=None)
+      v_g(xs, y)
+
+    def scan_body(xs, _):
+      y = jnp.zeros(1)
+      _, vjp_f = api.vjp(f, xs, y)
+      vjp_f(None)
+      return xs, None
+
+    lax.scan(scan_body, jnp.ones(5), None, 100)  # doesn't crash
 
   def test_float0_bwd_none(self):
     @api.custom_vjp
@@ -3791,35 +4259,6 @@ class DeprecatedCustomTransformsTest(jtu.JaxTestCase):
     self.assertAllClose(grad_ans, 3. * 4. + np.cos(np.sin(3. * 4)),
                         check_dtypes=False)
 
-  # TODO
-  # def test_defjvp_closure_error(self):
-  #   def foo(x):
-  #     @api.custom_transforms
-  #     def bar(y):
-  #       return x * y
-
-  #     api.defjvp(bar, lambda y_dot, ans, y: x * y)
-  #     return bar(x)
-  #   jtu.check_raises(
-  #       lambda: api.jvp(foo, (1.,), (1.,)), ValueError,
-  #       "Detected differentiation with respect to closed-over values with "
-  #       "custom JVP rule, which isn't supported.")
-
-  # TODO
-  # def test_defvjp_closure_error(self):
-  #   def foo(x):
-  #     @api.custom_transforms
-  #     def bar(y):
-  #       return x * y
-
-  #     api.defvjp(bar, lambda g, ans, y: x * y)
-  #     return bar(x)
-  #   jtu.check_raises(
-  #       lambda: grad(foo)(1.,), ValueError,
-  #       "Detected differentiation w.r.t. variables from outside "
-  #       "the scope of <jax.custom_transforms function bar>, but defvjp and "
-  #       "defvjp_all only support differentiation w.r.t. positional arguments.")
-
   def test_custom_transforms_eval_with_pytrees(self):
     @api.custom_transforms
     def f(x):
@@ -3929,8 +4368,6 @@ class DeprecatedCustomTransformsTest(jtu.JaxTestCase):
     print(gf(a, b))  # doesn't crash
 
 class BufferDonationTest(jtu.JaxTestCase):
-
-  # === pmap ===
 
   @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
   def test_pmap_donate_argnums_invalidates_input(self):


### PR DESCRIPTION
fixes #4566, fixes #4521, fixes #2912, fixes #3822, fixes #4173, fixes #2520, fixes #3808 

If you survey those issues, you'll come to the conclusion that `jax.custom_jvp` and `jax.custom_vjp` don't work with closing over JAX Tracers, and moreover that `nondiff_argnums` can be just as problematic. Indeed, `nondiff_argnums` was effectively implemented in terms of lexical closure. The original plan was not to make `custom_jvp`/`custom_vjp` work with lexical closure, but I never documented that, and the error messages were terrible!

This PR makes `custom_jvp` and `custom_vjp` work with closed-over Tracers. Woo! That is, now `custom_jvp` and `custom_vjp` functions and rules can close over Tracers to our hearts' content. For all non-autodiff transformations, things will Just Work. For autodiff transformations, we'll get a clear error message about why we can't differentiate with respect to values over which a custom_jvp or custom_vjp closes:
> Detected differentiation of a custom_jvp function with respect to a closed-over value. That isn't supported because the custom JVP rule only specifies how to differentiate the custom_jvp function with respect to explicit input parameters. Try passing the closed-over value into the custom_jvp function as an argument, and adapting the custom_jvp rule.

This PR accomplishes that goal by following through on the original _ansatz_ of `custom_jvp` and `custom_vjp`, namely to make them work like `core.call`. That is, we do all the `core.process_env_traces` stuff properly.

TODO:
- [x] make pre-omnistaging version work again
- [x] fix jax2tf sublevels interaction
- [x] fix all google internal users
- [x] update custom derivatives notebook with new custom_vjp nondiff_argnums advice
- [x] write a pr message