### PR TITLE
[jax2tf] Change the tests that assert failure in TF

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -279,11 +279,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     if jtu.device_under_test() == "tpu":
       max_bits = 32
 
+    expect_tf_exceptions = False
     if dtypes.finfo(dtype).bits * 2 > max_bits:
-      with self.assertRaisesRegex(BaseException, "XLA encountered an HLO for which this rewriting is not implemented"):
-        self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
-    else:
-      self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+      # TODO: getting an exception "XLA encountered an HLO for which this rewriting is not implemented"
+      expect_tf_exceptions = True
+
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           expect_tf_exceptions=expect_tf_exceptions)
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -21,6 +21,7 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
+import unittest
 
 from jax.experimental import jax2tf
 from jax.experimental.jax2tf.tests import tf_test_util
@@ -124,6 +125,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     self._compare_with_saved_model(f_jax, arr)
 
   def test_xla_context_preserved_gather(self):
+    raise unittest.SkipTest("Disable in preparation for fixing b/153556869")
     def f_jax(arr):
       return arr[100]  # out of bounds, should return the last element
     arr = np.arange(10, dtype=np.float32)


### PR DESCRIPTION
We used to have some tests that asserted for failures in TF after conversion.
The idea was for the tests to be a living record of what is failing. The
problem is that this makes it hard to fix those TF failures, because one
would have to fix at the same time the test.

This change just ensures that we tolerate TF exceptions without actually
ensuring that they arise.