### PR TITLE
[jax2tf] Disable the CI tests for jax2tf.

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -110,9 +110,6 @@ jobs:
         echo "JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES"
         echo "JAX_ENABLE_X64=$JAX_ENABLE_X64"
         echo "JAX_OMNISTAGING=$JAX_OMNISTAGING"
-        if [ $JAX_ENABLE_X64 = 0 -a $JAX_OMNISTAGING = 0 ]; then
-          pytest -n auto jax/experimental/jax2tf/tests
-        fi
         pytest -n auto tests examples
 
 

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -4,6 +4,4 @@ mypy==0.770
 pillow
 pytest-benchmark
 pytest-xdist
-# jax2tf needs some fixes that are not in latest tensorflow
-tf-nightly==2.4.0.dev20200729
 wheel


### PR DESCRIPTION
We do this to see if this reduces the incidence of errors fetching
the tf-nightly package. These tests are being run when we import
the code in Google.