### PR TITLE
Add GMRES to `jax.scipy.sparse.linalg`

### DIFF
--- a/jax/scipy/sparse/linalg.py
+++ b/jax/scipy/sparse/linalg.py
@@ -17,10 +17,14 @@ import operator
 
 import numpy as np
 import jax.numpy as jnp
-from jax import lax, device_put
+from jax import scipy as jsp
+from jax import lax, device_put, jit
 from jax.tree_util import tree_leaves, tree_map, tree_multimap, tree_structure
 from jax.util import safe_map as map
 
+
+_dot = partial(jnp.dot, precision=lax.Precision.HIGHEST)
+_vdot = partial(jnp.vdot, precision=lax.Precision.HIGHEST)
 
 def _vdot_real_part(x, y):
   """Vector dot-product guaranteed to have a real valued result."""
@@ -28,23 +32,26 @@ def _vdot_real_part(x, y):
   # `z^T M z` where `M` is positive definite and Hermitian, so the result is
   # real valued:
   # https://en.wikipedia.org/wiki/Definiteness_of_a_matrix#Definitions_for_complex_matrices
-  vdot = partial(jnp.vdot, precision=lax.Precision.HIGHEST)
-  result = vdot(x.real, y.real)
+  result = _vdot(x.real, y.real)
   if jnp.iscomplexobj(x) or jnp.iscomplexobj(y):
-    result += vdot(x.imag, y.imag)
+    result += _vdot(x.imag, y.imag)
   return result
 
 
 # aliases for working with pytrees
 
-def _vdot_tree(x, y):
-  return sum(tree_leaves(tree_multimap(_vdot_real_part, x, y)))
+def _vdot_tree(x, y, assume_real=True):
+  if assume_real:
+    return sum(tree_leaves(tree_multimap(_vdot_real_part, x, y)))
+  else:
+    return sum(tree_leaves(tree_multimap(_vdot, x, y)))
 
 def _mul(scalar, tree):
   return tree_map(partial(operator.mul, scalar), tree)
 
 _add = partial(tree_multimap, operator.add)
 _sub = partial(tree_multimap, operator.sub)
+_dot_tree = partial(tree_multimap, _dot)
 
 
 def _identity(x):
@@ -173,4 +180,131 @@ def cg(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
   x = lax.custom_linear_solve(
       A, b, solve=cg_solve, transpose_solve=cg_solve, symmetric=symmetric)
   info = None  # TODO(shoyer): return the real iteration count here
+  return x, info
+
+
+def _normalize(x, return_norm=False):
+  norm = jnp.sqrt(_vdot_tree(x, x, assume_real=False))
+  normalized_x = tree_map(lambda v: v / norm, x)
+  if return_norm:
+    return normalized_x, norm
+  else:
+    return normalized_x
+
+
+def _iterative_classical_gram_schmidt(Q, x, iterations=2):
+  """Orthogonalize x against the columns of Q."""
+  # "twice is enough"
+  # http://slepc.upv.es/documentation/reports/str1.pdf
+  q = x
+  r = tree_map(lambda X: jnp.zeros(X.shape[1]), Q)
+  for _ in range(iterations):
+    h = _dot_tree(tree_map(lambda X: X.T.conj(), Q), q)
+    q = _sub(q, _dot_tree(Q, h))
+    r = _add(r, h)
+  return q, r
+
+
+def arnoldi_iteration(A, b, n, M=None):
+  # https://en.wikipedia.org/wiki/Arnoldi_iteration#The_Arnoldi_iteration
+  if M is None:
+    M = _identity
+  q = _normalize(b)
+  Q = tree_map(lambda x: jnp.pad(x[:, None], ((0, 0), (0, n))), q)
+  H = jnp.zeros((n, n + 1), tree_leaves(b)[0].dtype)
+  def step(carry, k):
+    Q, H = carry
+    q = tree_map(lambda x: x[:, k], Q)
+    v = A(M(q))
+    v, h = _iterative_classical_gram_schmidt(Q, v, iterations=1)
+    v, v_norm = _normalize(v, return_norm=True)
+    Q = tree_multimap(lambda X, y: X.at[:, k + 1].set(y), Q, v)
+    h = h.at[k + 1].set(v_norm)
+    H = H.at[k, :].set(h)
+    return (Q, H), None
+
+  (Q, H), _ = lax.scan(step, (Q, H), jnp.arange(n))
+  return Q, H
+
+
+@jit
+def _lstsq(a, b):
+  # slightly faster than jnp.linalg.lstsq
+  return jsp.linalg.solve(_dot(a.T, a), _dot(a.T, b), sym_pos=True)
+
+
+def _gmres(A, b, x0, n, M, residual=None):
+  # https://www-users.cs.umn.edu/~saad/Calais/PREC.pdf
+  Q, H = arnoldi_iteration(A, b, n, M)
+  if residual is None:
+    residual = _sub(b, A(x0))
+
+  beta = jnp.sqrt(_vdot_tree(residual, residual, assume_real=False))
+  dtype = beta.dtype
+  e1 = jnp.concatenate([jnp.ones((1,), dtype), jnp.zeros((n,), dtype)])
+  y = _lstsq(H.T, beta * e1)
+
+  dx = M(tree_map(lambda X: _dot(X[:, :-1], y), Q))
+  x = _add(x0, dx)
+  return x
+
+
+def _gmres_solve(A, b, x0, *, tol, atol, restart, maxiter, M):
+  bs = _vdot_tree(b, b, assume_real=False)
+  atol2 = jnp.maximum(jnp.square(tol) * bs, jnp.square(atol))
+  num_restarts = maxiter // restart
+
+  def cond_fun(value):
+    x, residual, k = value
+    sqr_error = _vdot_tree(residual, residual, assume_real=False)
+    return (sqr_error > atol2) & (k < num_restarts)
+
+  def body_fun(value):
+    x, residual, k = value
+    x = _gmres(A, b, x, restart, M, residual)
+    residual = _sub(b, A(x))
+    return x, residual, k + 1
+
+  residual = _sub(b, A(x0))
+  if num_restarts:
+    x, residual, _ = lax.while_loop(
+      cond_fun, body_fun, (x0, residual, 0))
+  else:
+    x = x0
+
+  iters_left = maxiter % restart
+  sqr_error = _vdot_tree(residual, residual, assume_real=False)
+  x_final = lax.cond(
+    (iters_left > 0) & (sqr_error > atol2),
+    true_fun=lambda values: _gmres(A, b, values[0], iters_left, M, values[1]),
+    false_fun=lambda values: values[0],
+    operand=(x, residual),
+  )
+  return x_final
+
+
+def gmres(A, b, x0=None, *, tol=1e-5, atol=0.0, restart=20, maxiter=None,
+          M=None):
+  if x0 is None:
+    x0 = tree_map(jnp.zeros_like, b)
+  if M is None:
+    M = _identity
+
+  if maxiter is None:
+    size = sum(bi.size for bi in tree_leaves(b))
+    maxiter = 10 * size  # copied from scipy
+
+  if tree_structure(x0) != tree_structure(b):
+    raise ValueError(
+      'x0 and b must have matching tree structure: '
+      f'{tree_structure(x0)} vs {tree_structure(b)}')
+
+  b, x0 = device_put((b, x0))
+
+  def _solve(A, b):
+    return _gmres_solve(A, b, x0, tol=tol, atol=atol, maxiter=maxiter,
+                        restart=restart, M=M)
+
+  x = lax.custom_linear_solve(A, b, solve=_solve, transpose_solve=_solve)
+  info = None
   return x, info


### PR DESCRIPTION
Implementation of GMRES based off of @shoyer's [prototype](https://gist.github.com/shoyer/dc33a5850337b6a87d48ed97b4727d29) augmented with:
- support for pytrees
- looped with termination condition
- scipy-like `restart` argument (at least my best interpretation of it. I had a hard time parsing scipy's source code for GMRES)

To do:
- [ ] Improve numerical stability. I can't currently get it to reliably pass tests when not running in Float64 mode, i.e., `jax_enable_x64 == True`.
- [ ] Add documentation
- [ ] Add tests
- [ ] Make sure scipy's implementation behaves similarly

Relevant issues:
- #1531 