### PR TITLE
Added initial implementation of numpy equivalent for trim_zeros to jax

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -342,6 +342,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     tril
     tril_indices
     tril_indices_from
+    trim_zeros
     triu
     triu_indices
     triu_indices_from

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -58,7 +58,7 @@ from .lax_numpy import (
     signedinteger, sin, sinc, single, sinh, size, sometrue, sort, sort_complex, split, sqrt,
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,
-    triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,
+    trim_zeros, triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,
     unpackbits, unravel_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
     vstack, where, zeros, zeros_like, _NOT_IMPLEMENTED)
 

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2847,23 +2847,12 @@ def polyder(p, m=1):
 
 @_wraps(np.trim_zeros)
 def trim_zeros(filt, trim='fb'):
-  first = 0
-  trim = trim.upper()
-  if 'F' in trim:
-    for v in filt:
-      if v != 0:
-        break
-      else:
-        first = first + 1
-  last = len(filt)
-  if 'B' in trim:
-    for v in filt[::-1]:
-      if v != 0:
-        break
-      else:
-        last = last - 1
-  
-  return filt[first:last]
+  nz = asarray(filt) == 0
+  if all(nz):
+    return empty(0, _dtype(filt))
+  start = argmin(nz) if 'f' in trim.lower() else 0
+  end = argmin(nz[::-1]) if 'b' in trim.lower() else 0
+  return filt[start:len(filt) - end]
 
 _LEADING_ZEROS_DOC="""\
 Setting trim_leading_zeros=True makes the output match that of numpy.

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2851,6 +2851,26 @@ def _trim_zeros(a):
       return a[i:]
   return a[:0]
 
+@_wraps(np.trim_zeros)
+def trim_zeros(filt, trim='fb'):
+  first = 0
+  trim = trim.upper()
+  if 'F' in trim:
+    for v in filt:
+      if v != 0:
+        break
+      else:
+        first = first + 1
+  last = len(filt)
+  if 'B' in trim:
+    for v in filt[::-1]:
+      if v != 0:
+        break
+      else:
+        last = last - 1
+  
+  return filt[first:last]
+
 _LEADING_ZEROS_DOC="""\
 Setting trim_leading_zeros=True makes the output match that of numpy.
 But prevents the function from being able to be used in compiled code.

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2845,12 +2845,6 @@ def polyder(p, m=1):
   coeff = (arange(len(p), m, -1) - 1 - arange(m)[:, newaxis]).prod(0)
   return p[:-m] * coeff
 
-def _trim_zeros(a):
-  for i, v in enumerate(a):
-    if v != 0:
-      return a[i:]
-  return a[:0]
-
 @_wraps(np.trim_zeros)
 def trim_zeros(filt, trim='fb'):
   first = 0
@@ -2883,7 +2877,7 @@ def polymul(a1, a2, *, trim_leading_zeros=False):
   if isinstance(a2, np.poly1d):
     a2 = asarray(a2)
   if trim_leading_zeros and (len(a1) > 1 or len(a2) > 1):
-    a1, a2 = _trim_zeros(a1), _trim_zeros(a2)
+    a1, a2 = trim_zeros(a1, trim='f'), trim_zeros(a2, trim='f')
   if len(a1) == 0:
     a1 = asarray([0.])
   if len(a2) == 0:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1228,6 +1228,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": "a_shape={}".format(
+      jtu.format_shape_dtype_string(a_shape, dtype)),
+     "dtype": dtype, "a_shape": a_shape}
+    for dtype in default_dtypes
+    for a_shape in one_dim_array_shapes))
+  def testTrimZeros(self, a_shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    np_fun = lambda arg1: np.trim_zeros(arg1)
+    jnp_fun = lambda arg1: jnp.trim_zeros(arg1)
+    args_maker = lambda: [rng(a_shape, dtype)]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
+
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "a_shape={} , b_shape={}".format(
           jtu.format_shape_dtype_string(a_shape, dtype),
           jtu.format_shape_dtype_string(b_shape, dtype)),

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1228,26 +1228,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "a_shape={}".format(
-      jtu.format_shape_dtype_string(a_shape, dtype)),
-     "dtype": dtype, "a_shape": a_shape}
+    {"testcase_name": "{}_trim={}".format(
+      jtu.format_shape_dtype_string(a_shape, dtype), trim),
+     "dtype": dtype, "a_shape": a_shape, "trim": trim}
     for dtype in default_dtypes
-    for a_shape in one_dim_array_shapes))
-  def testTrimZeros(self, a_shape, dtype):
+    for a_shape in one_dim_array_shapes
+    for trim in ["f", "b", "fb"]))
+  def testTrimZeros(self, a_shape, dtype, trim):
     rng = jtu.rand_some_zero(self.rng())
-    np_fun = lambda arg1: np.trim_zeros(arg1)
-    jnp_fun = lambda arg1: jnp.trim_zeros(arg1)
-
-    np_fun_f = lambda arg1: np.trim_zeros(arg1, trim='f')
-    jnp_fun_f = lambda arg1: np.trim_zeros(arg1, trim='f')
-
-    np_fun_b = lambda arg1: np.trim_zeros(arg1, trim='b')
-    jnp_fun_b = lambda arg1: np.trim_zeros(arg1, trim='b')
-
     args_maker = lambda: [rng(a_shape, dtype)]
+    np_fun = lambda arg1: np.trim_zeros(arg1, trim)
+    jnp_fun = lambda arg1: jnp.trim_zeros(arg1, trim)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
-    self._CheckAgainstNumpy(np_fun_f, jnp_fun_f, args_maker, check_dtypes=True)
-    self._CheckAgainstNumpy(np_fun_b, jnp_fun_b, args_maker, check_dtypes=True)
 
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1234,11 +1234,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     for dtype in default_dtypes
     for a_shape in one_dim_array_shapes))
   def testTrimZeros(self, a_shape, dtype):
-    rng = jtu.rand_default(self.rng())
+    rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda arg1: np.trim_zeros(arg1)
     jnp_fun = lambda arg1: jnp.trim_zeros(arg1)
+
+    np_fun_f = lambda arg1: np.trim_zeros(arg1, trim='f')
+    jnp_fun_f = lambda arg1: np.trim_zeros(arg1, trim='f')
+
+    np_fun_b = lambda arg1: np.trim_zeros(arg1, trim='b')
+    jnp_fun_b = lambda arg1: np.trim_zeros(arg1, trim='b')
+
     args_maker = lambda: [rng(a_shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(np_fun_f, jnp_fun_f, args_maker, check_dtypes=True)
+    self._CheckAgainstNumpy(np_fun_b, jnp_fun_b, args_maker, check_dtypes=True)
 
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
Hi,

This is my initial attempt to add ```trim_zeros``` function from ```numpy``` to ```jax```.

One problem I am facing is when I add ```_CompileAndCheck``` to the test function, the test fails. I am not sure why this is the case and any help in this regard is appreciated.

Thanks