### PR TITLE
[jax2tf] Clean up code for XlaGather, experimental_compile not necessary

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Experimental module transforms JAX functions to be executed by TensorFlow."""
-
 import functools
 import string
 from typing import Any, Callable, Dict, Iterable, Sequence, Tuple, Union
@@ -25,22 +24,19 @@ from jax import core
 from jax import custom_derivatives
 from jax import dtypes
 from jax import lax
+from jax import lax_linalg
 from jax import linear_util as lu
 from jax import numpy as jnp
 from jax import random
 from jax import tree_util
 from jax import util
 from jax.api_util import flatten_fun
-from jax.lax import lax_control_flow
-from jax.lax import lax_fft
-from jax import lax_linalg
 from jax.interpreters import ad
 from jax.interpreters import partial_eval as pe
-from jax.interpreters import xla
 from jax.interpreters import pxla
-
-from jaxlib import xla_client
-
+from jax.interpreters import xla
+from jax.lax import lax_control_flow
+from jax.lax import lax_fft
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
 
@@ -48,6 +44,9 @@ import tensorflow as tf  # type: ignore[import]
 # pylint: disable=g-direct-tensorflow-import
 from tensorflow.compiler.tf2xla.python import xla as tfxla  # type: ignore[import]
 from tensorflow.compiler.xla import xla_data_pb2  # type: ignore[import]
+
+from jaxlib import xla_client
+
 
 # A value suitable in a TF tracing context: tf.Tensor, tf.Variable,
 # or Python scalar or numpy.ndarray. (A tf.EagerTensor is a tf.Tensor.)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -155,6 +155,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_fft)
+  @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def test_fft(self, harness: primitive_harness.Harness):
     if len(harness.params["fft_lengths"]) > 3:
       with self.assertRaisesRegex(RuntimeError, "FFT only supports ranks 1-3"):
@@ -200,6 +201,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                            atol=1e-5, rtol=1e-5)
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_svd)
+  @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def test_svd(self, harness: primitive_harness.Harness):
     if jtu.device_under_test() == "tpu":
       raise unittest.SkipTest("TODO: test crashes the XLA compiler for some TPU variants")

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -21,7 +21,6 @@ from jax import lax
 import jax.numpy as jnp
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
-import unittest
 
 from jax.experimental import jax2tf
 from jax.experimental.jax2tf.tests import tf_test_util
@@ -125,16 +124,10 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     self._compare_with_saved_model(f_jax, arr)
 
   def test_xla_context_preserved_gather(self):
-    raise unittest.SkipTest("Disable in preparation for fixing b/153556869")
     def f_jax(arr):
       return arr[100]  # out of bounds, should return the last element
     arr = np.arange(10, dtype=np.float32)
-    if jtu.device_under_test() != "tpu":
-      # TODO(b/153556869): the compilation attributes are not saved in savedmodel
-      with self.assertRaisesRegex(BaseException, "Input 2 to .* XlaGather must be a compile-time constant"):
-        self._compare_with_saved_model(f_jax, arr)
-    else:
-      self._compare_with_saved_model(f_jax, arr)
+    self._compare_with_saved_model(f_jax, arr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now that XlaGather has been fixed in XLA, we do not need to use
experimental_compile workaround (which was not sorking anyway when
put in a SavedModel).

This fix requires a recent tf-nightly installation.