### PR TITLE
Fixing weird behavior in segment_sum when num_segments is None.

### DIFF
--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -316,8 +316,10 @@ def segment_sum(data, segment_ids, num_segments=None,
       need not be sorted. Values outside of the range [0, num_segments) are
       wrapped into that range by applying jnp.mod.
     num_segments: optional, an int with positive value indicating the number of
-      segments. The default is ``max(segment_ids % data.shape[0]) + 1`` but
-      since `num_segments` determines the size of the output, a static value
+      segments. The default is set to be the minimum number of segments that
+      would support all positive and negative indices in `segment_ids`
+      calculated as ``max(max(segment_ids) + 1, max(-segment_ids))``.
+      Since `num_segments` determines the size of the output, a static value
       must be provided to use `segment_sum` in a `jit`-compiled function.
     indices_are_sorted: whether `segment_ids` is known to be sorted
     unique_indices: whether `segment_ids` is known to be free of duplicates
@@ -327,7 +329,7 @@ def segment_sum(data, segment_ids, num_segments=None,
     segment sums.
   """
   if num_segments is None:
-    num_segments = jnp.max(jnp.mod(segment_ids, data.shape[0])) + 1
+    num_segments = max(jnp.max(segment_ids) + 1, jnp.max(-segment_ids))
   num_segments = int(num_segments)
 
   out = jnp.zeros((num_segments,) + data.shape[1:], dtype=data.dtype)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1058,9 +1058,28 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     expected = np.array([13, 2, 7, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    # test with explicit num_segments larger than the higher index.
+    ans = ops.segment_sum(data, segment_ids, num_segments=5)
+    expected = np.array([13, 2, 7, 4, 0])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
     # test without explicit num_segments
     ans = ops.segment_sum(data, segment_ids)
     expected = np.array([13, 2, 7, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    # test with negative segment ids and segment ids larger than num_segments,
+    # that will be wrapped with the `mod`.
+    segment_ids = np.array([0, 4, 8, 1, 2, -6, -1, 3])
+    ans = ops.segment_sum(data, segment_ids, num_segments=4)
+    expected = np.array([13, 2, 7, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    # test with negative segment ids and without without explicit num_segments
+    # such as num_segments is defined by the smaller index.
+    segment_ids = np.array([3, 3, 3, 4, 5, 5, -7, -6])
+    ans = ops.segment_sum(data, segment_ids)
+    expected = np.array([1, 3, 0, 13, 2, 7, 0])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testIndexDtypeError(self):


### PR DESCRIPTION
For some reason, the default calculation of `num_segments` involved taking the mod with respect to the number of input rows:
> `num_segments = jnp.max(jnp.mod(segment_ids, data.shape[0])) + 1`

It is not obvious why the number of rows should affect the number of segments at all, and this indeed causes some weird behavior such, as for example for `segment_ids=[0, 3, 3]` the calculated `num_segments` turns out to be 1 (when it should probably be 4, as in the `tf.segment_sum` cited in the documentation). Similarly for `segment_ids=[0, 3]`, `num_segments`  would evaluate to 2, just by removing one index.

Instead this PR changes the default for `num_segments` to be:
`max(max(segment_ids) + 1, max(-segment_ids))`, so the calculated number of segments would be just large enough to support any positive or negative segment_id passed to the method.

It also adds a couple of tests to test the previously documented, but not tested, `mod` behavior:
> Values outside of the range [0, num_segments) are wrapped into that range by applying jnp.mod.