### PR TITLE
[jax2tf] Reformulate test_binary_elementwise.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -349,27 +349,28 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_binary_elementwise)
   def test_binary_elementwise(self, harness):
-    if harness.params["lax_name"] in ("rem", "atan2"):
+    lax_name, dtype = harness.params["lax_name"], harness.params["dtype"]
+    if lax_name in ("rem", "atan2"):
       # b/158006398: TF kernels are missing for 'rem' and 'atan2'
-      if harness.params["dtype"] in [np.float16, dtypes.bfloat16]:
+      if dtype in [np.float16, dtypes.bfloat16]:
         raise unittest.SkipTest("TODO: TF kernels are missing for 'rem' and 'atan2'.")
       # TODO(bchetioui): do we need that here too?
-      if harness.params["dtype"] is np.float32 and jtu.device_under_test() == "tpu":
+      if dtype is np.float32 and jtu.device_under_test() == "tpu":
         raise unittest.SkipTest("TODO: fix bug: nan vs not-nan")
-    if harness.params["lax_name"] in ("igamma", "igammac"):
+    if lax_name in ("igamma", "igammac"):
       # TODO(necula): fix bug with igamma/f16
-      if harness.params["dtype"] in [np.float16, dtypes.bfloat16]:
+      if dtype in [np.float16, dtypes.bfloat16]:
         raise unittest.SkipTest("TODO: igamma(c) unsupported with (b)float16 in JAX")
       # TODO(necula): fix bug with igamma/f32 on TPU
-      if harness.params["dtype"] is np.float32 and jtu.device_under_test() == "tpu":
+      if dtype is np.float32 and jtu.device_under_test() == "tpu":
         raise unittest.SkipTest("TODO: fix bug: nan vs not-nan")
     # TODO(necula): fix bug with nextafter/f16
-    if (harness.params["lax_name"] == "nextafter" and
-        harness.params["dtype"] in [np.float16, dtypes.bfloat16]):
+    if (lax_name == "nextafter" and
+        dtype in [np.float16, dtypes.bfloat16]):
       raise unittest.SkipTest("TODO: understand unimplemented case")
     arg1, arg2 = harness.dyn_args_maker(self.rng())
     custom_assert = None
-    if harness.params["lax_name"] == "igamma":
+    if lax_name == "igamma":
       # igamma is not defined when the first argument is <=0
       def custom_assert(result_jax, result_tf):
         # lax.igamma returns NaN when arg1 == arg2 == 0; tf.math.igamma returns 0
@@ -382,7 +383,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         # non-special cases are equal
         self.assertAllClose(result_jax[~ special_cases],
                             result_tf[~ special_cases])
-    if harness.params["lax_name"] == "igammac":
+    if lax_name == "igammac":
       # igammac is not defined when the first argument is <=0
       def custom_assert(result_jax, result_tf):  # noqa: F811
         # lax.igammac returns 1. when arg1 <= 0; tf.math.igammac returns NaN

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -354,9 +354,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       # b/158006398: TF kernels are missing for 'rem' and 'atan2'
       if dtype in [np.float16, dtypes.bfloat16]:
         raise unittest.SkipTest("TODO: TF kernels are missing for {lax_name}.")
-      # TODO(bchetioui): do we need that here too?
-      if dtype is np.float32 and jtu.device_under_test() == "tpu":
-        raise unittest.SkipTest("TODO: fix bug: nan vs not-nan")
     if lax_name in ("igamma", "igammac"):
       # TODO(necula): fix bug with igamma/f16
       if dtype in [np.float16, dtypes.bfloat16]:

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -353,7 +353,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     if lax_name in ("rem", "atan2"):
       # b/158006398: TF kernels are missing for 'rem' and 'atan2'
       if dtype in [np.float16, dtypes.bfloat16]:
-        raise unittest.SkipTest("TODO: TF kernels are missing for 'rem' and 'atan2'.")
+        raise unittest.SkipTest("TODO: TF kernels are missing for {lax_name}.")
       # TODO(bchetioui): do we need that here too?
       if dtype is np.float32 and jtu.device_under_test() == "tpu":
         raise unittest.SkipTest("TODO: fix bug: nan vs not-nan")


### PR DESCRIPTION
* igamma/igammac are unsupported by JAX on (b)float16
* rem/atan2 have missing TF kernels for (b)float16
* nextafter is unsupported for (b)float16
* reactivated bfloat16 tests for the other operations