### PR TITLE
Support mask(pmap)

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -56,6 +56,7 @@ from . import batching
 from . import partial_eval as pe
 from . import xla
 from . import ad
+from . import masking
 
 
 xops = xc.ops
@@ -1121,6 +1122,8 @@ pe.staged_out_calls.add(xla_pmap_p)
 # Set param update handlers to update `donated_invars` just like xla_call_p
 pe.call_param_updaters[xla_pmap_p] = pe.call_param_updaters[xla.xla_call_p]
 ad.call_param_updaters[xla_pmap_p] = ad.call_param_updaters[xla.xla_call_p]
+masking.call_param_updaters[xla_pmap_p] = masking.call_param_updaters[
+    xla.xla_call_p]
 ad.call_transpose_param_updaters[xla_pmap_p] = \
     ad.call_transpose_param_updaters[xla.xla_call_p]
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -819,6 +819,11 @@ def _xla_call_jvp_update_params(params, nz_tangents):
   return dict(params, donated_invars=new_donated_invars)
 ad.call_param_updaters[xla_call_p] = _xla_call_jvp_update_params
 
+def _xla_call_masking_update_params(params, env_size):
+  donated_invars = params['donated_invars']
+  return dict(params, donated_invars=(False,) * env_size + donated_invars)
+masking.call_param_updaters[xla_call_p] = _xla_call_masking_update_params
+
 def _xla_call_transpose_update_params(params, undef_primals, nonzero_cts):
   donated_invars = params['donated_invars']
   donated_primals = [d for d, u in zip(donated_invars, undef_primals) if not u]


### PR DESCRIPTION
This pr adds basic support for mask(pmap(fun)).

The initial motivation for this was to use masking to solve the 'last batch problem' with pmap, but it turns out that this was already do-able on master, by doing the opposite composition, pmap(mask(fun)):
```python                                                               
in_shapes = ['i']  # 'i' is the inner batch size                                                    
out_shape = ''                                                           
                                                                             
@partial(pmap, axis_name='outer_batch')                                        
@partial(mask, in_shapes=in_shapes, out_shape=out_shape)                 
def fun(x):                                                              
  return lax.psum(jnp.sum(x), 'outer_batch')  # Sum out ragged dim first       
                                                                             
args = [jnp.array([[1, 2], [5, 10]])]                                    
logical_env = dict(i=jnp.array([2, 1]))  # Total batch size == 3                   
                                                                             
padded_out = fun(args, logical_env)
# 1 + 2 + 5 = 8 so
# padded_out == array([8, 8])              
```