### PR TITLE
Note flush-denormal-to-zero behavior in docstring of nextafter.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -113,7 +113,18 @@ def sign(x: Array) -> Array:
   return sign_p.bind(x)
 
 def nextafter(x1: Array, x2: Array) -> Array:
-  r"""Returns the next representable value after `x1` in the direction of `x2`."""
+  r"""Returns the next representable value after `x1` in the direction of `x2`.
+
+  Note that in some environments flush-denormal-to-zero semantics is used.
+  This means that, around zero, this function returns strictly non-zero
+  values which appear as zero in any operations. Consider this example::
+    >>> jnp.nextafter(0, 1)  # denormal numbers are representable
+    DeviceArray(1.e-45, dtype=float32)
+    >>> jnp.nextafter(0, 1) * 1  # but are flushed to zero
+    DeviceArray(0., dtype=float32)
+
+  For the smallest usable (i.e. normal) float, use ``tiny`` of ``jnp.finfo``.
+  """
   return nextafter_p.bind(_brcast(x1, x2), _brcast(x2, x1))
 
 def floor(x: Array) -> Array:


### PR DESCRIPTION
The use of flush-denormal-to-zero semantic doesn't seem to be very obviously documented. I eventually learned about this after using `jnp.nextafter`, which in some cases returns denormal values which can be represented but appear as zero in any numeric operations (depending on the environment). It seems useful to me to mention this. See #4042.

It was a bit awkward to add a modified docstring to functions that are imported from `lax.py` into `lax_numpy.py`. This is done with convenience functions, to which I had to add an option to copy the docstring from the lax function and pass it to `_wraps`.