### PR TITLE
Update auto jaxlib install to use nvcc CUDA version instead of nvidia-smi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ requires Python 3.6 or above. Jax does not support Python 2 any more.
 To try automatic detection of the correct version for your system, you can run:
 
 ```bash
-pip install --upgrade https://storage.googleapis.com/jax-releases/`nvidia-smi | sed -En "s/.* CUDA Version: ([0-9]*)\.([0-9]*).*/cuda\1\2/p"`/jaxlib-0.1.52-`python3 -V | sed -En "s/Python ([0-9]*)\.([0-9]*).*/cp\1\2/p"`-none-manylinux2010_x86_64.whl jax
+pip install --upgrade https://storage.googleapis.com/jax-releases/`nvcc -V | sed -En "s/.* release ([0-9]*)\.([0-9]*),.*/cuda\1\2/p"`/jaxlib-0.1.52-`python3 -V | sed -En "s/Python ([0-9]*)\.([0-9]*).*/cp\1\2/p"`-none-manylinux2010_x86_64.whl jax
 ```
 
 Please let us know on [the issue tracker](https://github.com/google/jax/issues)


### PR DESCRIPTION
The CUDA version reported by `nvidia-smi` is based on the driver
version, not the runtime/toolkit version, and may be higher than the
toolkit version since the driver supports older runtimes. `nvcc`,
which is also installed as part of the CUDA toolkit, will correctly
report the right CUDA version to target.

Fixes #3984.