### PR TITLE
Add a fast C++ jit codepath.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-JAX user-facing transformations and utilities.
+"""JAX user-facing transformations and utilities.
 
 The transformations here mostly wrap internal transformations, providing
 convenience flags to control behavior and handling Python containers of
@@ -29,6 +27,8 @@ import functools
 import inspect
 import itertools as it
 import threading
+import weakref
+
 from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, TypeVar, Union
 from warnings import warn
 
@@ -50,6 +50,7 @@ from .util import (unzip2, curry, partial, safe_map, safe_zip, prod,
                    split_list, extend_name_stack, wrap_name, cache)
 from .lib import xla_bridge as xb
 from .lib import xla_client as xc
+from .lib import jax_jit
 # Unused imports to be exported
 from .lib.xla_bridge import (device_count, local_device_count, devices, local_devices,
                              host_id, host_ids, host_count)
@@ -82,8 +83,7 @@ map = safe_map
 zip = safe_zip
 
 FLAGS = flags.FLAGS
-flags.DEFINE_bool("jax_disable_jit",
-                  bool_env("JAX_DISABLE_JIT", False),
+flags.DEFINE_bool("jax_disable_jit", bool_env("JAX_DISABLE_JIT", False),
                   "Disable JIT compilation and just call original Python.")
 
 
@@ -97,7 +97,11 @@ class _ThreadLocalState(threading.local):
   def __init__(self):
     self.jit_is_disabled = False
 
+
 _thread_local_state = _ThreadLocalState()
+# A temporary, internal only constant to control the global behavior of jax.jit
+_EXPERIMENTAL_CPP_JIT = False
+
 
 def jit(fun: Callable[..., T],
         static_argnums: Union[int, Iterable[int]] = (),
@@ -156,6 +160,20 @@ def jit(fun: Callable[..., T],
   [-0.54485  0.27744 -0.29255 -0.91421 -0.62452 -0.24748
    -0.85743 -0.78232  0.76827  0.59566 ]
   """
+  if _EXPERIMENTAL_CPP_JIT:
+    return _cpp_jit(fun, static_argnums, device, backend, donate_argnums)
+  else:
+    return _python_jit(fun, static_argnums, device, backend, donate_argnums)
+
+
+def _python_jit(
+    fun: Callable,
+    static_argnums: Union[int, Iterable[int]] = (),
+    device=None,
+    backend: Optional[str] = None,
+    donate_argnums: Union[int, Iterable[int]] = ()
+) -> Callable:
+  """The Python implementation of `jax.jit`, being replaced by _cpp_jit."""
   _check_callable(fun)
   static_argnums = _ensure_tuple(static_argnums)
   donate_argnums = _ensure_tuple(donate_argnums)
@@ -180,13 +198,118 @@ def jit(fun: Callable[..., T],
       donated_invars = donation_vector(donate_argnums, dyn_args, kwargs)
     else:
       donated_invars = (False,) * len(args_flat)
-    for arg in args_flat: _check_arg(arg)
+    for arg in args_flat:
+      _check_arg(arg)
     flat_fun, out_tree = flatten_fun(f, in_tree)
-    out = xla.xla_call(flat_fun, *args_flat, device=device, backend=backend,
-                       name=flat_fun.__name__, donated_invars=donated_invars)
+    out = xla.xla_call(
+        flat_fun,
+        *args_flat,
+        device=device,
+        backend=backend,
+        name=flat_fun.__name__,
+        donated_invars=donated_invars)
     return tree_unflatten(out_tree(), out)
 
   return f_jitted
+
+
+def _cache_for_plain_function(call):
+  """Cache decorator for plain functions calls.
+
+  This is similar to `cache` from `linear_util.py` but not for wrapped functons.
+
+  Args:
+    call: a function that takes a plain function as a first argument.
+
+  Returns:
+     The memoized `call` function.
+  """
+  fun_caches = weakref.WeakKeyDictionary()
+
+  def memoized_fun(fun: Callable, *args, **kwargs):
+    cache_for_f = fun_caches.setdefault(fun, {})
+    # We need tuples if we want them to be hashable.
+    if "static_argnums" in kwargs:
+      kwargs["static_argnums"] = _ensure_tuple(kwargs["static_argnums"])
+    if "donate_argnums" in kwargs:
+      kwargs["donate_argnums"] = _ensure_tuple(kwargs["donate_argnums"])
+    # We need the frozenset to make the dict hashable.
+    key = (args, frozenset(kwargs.items()))
+    result = cache_for_f.get(key, None)
+    if result is None:
+      result = call(fun, *args, **kwargs)
+      cache_for_f[key] = result
+    return result
+
+  memoized_fun.cache_clear = fun_caches.clear
+  return memoized_fun
+
+
+@_cache_for_plain_function
+def _cpp_jit(
+    fun: Callable,
+    static_argnums: Union[int, Iterable[int]] = (),
+    device=None,
+    backend: Optional[str] = None,
+    donate_argnums: Union[int, Iterable[int]] = ()
+) -> Callable:
+  """An implementation of `jit` that tries to do as much as possible in C++.
+
+  The goal of this function is to speed up the time it takes to process the
+  arguments, find the correct C++ executable, start the transfer of arguments
+  and schedule the computation.
+  As long as it does not support all features of the Python implementation
+  the C++ code will fallback to `_python_jit` when it faces some unsupported
+  feature.
+  """
+  # TODO(jblespiau): Add support for `disable_jit.`
+
+  # TODO(jblespiau): Add support for donate_argnums in the C++ path.
+  if donate_argnums:
+    return _python_jit(fun, static_argnums, device, backend, donate_argnums)
+
+  _check_callable(fun)
+  static_argnums = _ensure_tuple(static_argnums)
+  donate_argnums = _ensure_tuple(donate_argnums)
+  donate_argnums = rebase_donate_argnums(donate_argnums, static_argnums)
+
+  if device is not None and backend is not None:
+    raise ValueError("can't specify both a device and a backend for jit, "
+                     "got device={} and backend={}".format(device, backend))
+
+  backend = device.platform if device else backend
+  backend = xb.get_backend(backend)
+
+  if device is None:
+    device = local_devices()[0]
+
+  def cache_miss(*args, **kw):
+    xla_result = _xla_computation(
+        fun, static_argnums=static_argnums, xla_return=True)(*args, **kw)
+
+    options = xb.get_compile_options(
+        num_replicas=1,
+        num_partitions=1,
+        device_assignment=(device.id,) if device else None)
+    if xla_result.parameter_is_tupled_arguments:
+      options.parameter_is_tupled_arguments = True
+
+    return (
+        # We call xla._backend_compile to ensure the XLA computation appears
+        # separately in Python profiling results.
+        xla._backend_compile(
+            backend,
+            xla_result.xla_computation,
+            options=options),
+        xla_result.out_pytree_def,
+        xla_result.shaped_arrays,
+        xla_result.lazy_expressions)
+
+  return jax_jit.jit(
+      cache_miss,
+      _python_jit(fun, static_argnums, device, backend, donate_argnums),
+      FLAGS.jax_enable_x64, static_argnums, device)
+
 
 @contextmanager
 def disable_jit():
@@ -235,8 +358,9 @@ def disable_jit():
   finally:
     _thread_local_state.jit_is_disabled = prev_val
 
+
 def _jit_is_disabled():
-  return _thread_local_state.jit_is_disabled or config.read('jax_disable_jit')
+  return _thread_local_state.jit_is_disabled or config.read("jax_disable_jit")
 
 
 def xla_computation(fun: Callable,
@@ -345,12 +469,49 @@ def xla_computation(fun: Callable,
     ROOT tuple.18 = (f32[], f32[], f32[]) tuple(all-reduce.7, all-reduce.12, all-reduce.17)
   }
   """
+  return _xla_computation(fun, static_argnums, axis_env, backend, tuple_args,
+                          instantiate_const_outputs, return_shape)
+
+
+_XlaReturn = collections.namedtuple("_XlaReturn", [
+    "xla_computation", "out_shape", "out_pytree_def", "lazy_expressions",
+    "shaped_arrays", "parameter_is_tupled_arguments"
+])
+
+
+def _xla_computation(fun: Callable,
+                     static_argnums: Union[int, Iterable[int]] = (),
+                     axis_env: Optional[Sequence[Tuple[AxisName, int]]] = None,
+                     backend: Optional[str] = None,
+                     tuple_args: Optional[bool] = None,
+                     instantiate_const_outputs: bool = True,
+                     return_shape: bool = False,
+                     xla_return: bool = False) -> Callable:
+  """An internal implementation for `xla_computation` and `_cpp_jit`.
+
+  See `xla_computation` for the full documentation.
+
+  Args:
+    tuple_args: If ``True``, the resulting XLA computation will have a single
+      tuple argument that is unpacked into the specified function arguments.
+      By default (`None`), this will be enabled when there are more than 100
+      argumments, as it will be more efficient and that XLA do not support
+      many arguments otherwise.
+    xla_return: If True, additional information will be returned
+
+  Returns:
+    An `_XlaReturn` object, some field possibly being None depending on
+    `return_shape` and `xla_return`.
+  """
   del instantiate_const_outputs  # Unused
 
   _check_callable(fun)
   if isinstance(static_argnums, int):
     static_argnums = (static_argnums,)
-  fun_name = getattr(fun, '__name__', 'unknown')
+  fun_name = getattr(fun, "__name__", "unknown")
+
+  if xla_return:
+    return_shape = True
 
   def make_axis_env(nreps):
     if axis_env is None:
@@ -383,19 +544,40 @@ def xla_computation(fun: Callable,
       out_avals = [raise_to_shaped(pval.get_aval()) for pval in out_pvals]
     jaxpr = xla.apply_outfeed_rewriter(jaxpr)
     axis_env_ = make_axis_env(xla.jaxpr_replicas(jaxpr))
-    c = xb.make_computation_builder('xla_computation_{}'.format(fun_name))
+    c = xb.make_computation_builder("xla_computation_{}".format(fun_name))
     xla_consts = map(partial(xb.constant, c), consts)
-    xla_args = xla._xla_callable_args(c, avals, tuple_args)
+    # As we cannot modify the closure-captured `tuple_args`, we work on a copy.
+    local_tuple_args = tuple_args
+    if local_tuple_args is None:
+      # pass long arg lists as tuple for TPU
+      local_tuple_args = len(avals) > 100
+
+    xla_args = xla._xla_callable_args(c, avals, local_tuple_args)
     outs = xla.jaxpr_subcomp(
         c, jaxpr, backend, axis_env_, xla_consts,
-        extend_name_stack(wrap_name(fun_name, 'xla_computation')), *xla_args)
+        extend_name_stack(wrap_name(fun_name, "xla_computation")), *xla_args)
     built = c.build(xc.ops.Tuple(c, outs))
     if return_shape:
       out_shapes_flat = [ShapeDtypeStruct(a.shape, a.dtype) for a in out_avals]
       out_shape = tree_unflatten(out_tree(), out_shapes_flat)
-      return built, out_shape
+      if xla_return:
+        for out_aval in out_avals:
+          if not isinstance(out_aval, xla.ShapedArray):
+            raise RuntimeError("As we want to propagate the weak_type, we need "
+                               "to get a ShapedArray, otherwise this "
+                               "information is lost")
+        return _XlaReturn(
+            built,
+            out_shape,
+            out_tree(),
+            lazy_expressions=[xla.lazy.array(a.shape) for a in out_avals],
+            shaped_arrays=out_avals,
+            parameter_is_tupled_arguments=local_tuple_args)
+      else:
+        return built, out_shape
     else:
       return built
+
   return computation_maker
 
 def grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -51,7 +51,8 @@ _check_jaxlib_version()
 
 from jaxlib import xla_client
 from jaxlib import lapack
-from jaxlib import pytree
+pytree = xla_client._xla.pytree
+jax_jit = xla_client._xla.jax_jit
 from jaxlib import cusolver
 try:
   from jaxlib import cuda_prng

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -21,6 +21,7 @@ import re
 import unittest
 import warnings
 import weakref
+import functools
 
 from absl import logging
 from absl.testing import absltest, parameterized
@@ -44,6 +45,128 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
+
+class CPPJitTest(jtu.JaxTestCase):
+
+  @staticmethod
+  def jit(*args, **kwargs):
+    return jax.api._cpp_jit(*args, **kwargs)
+
+  @parameterized.parameters([
+      # Integer support
+      (1, 2, 3, 4, 5),
+      # Numpy array support
+      (
+          np.asarray(1, np.int32),
+          np.asarray(2, np.int32),
+          np.asarray(3, np.int32),
+          np.asarray(4, np.int32),
+          np.asarray(5, np.int32),
+      ),
+  ])
+  def test_jit_static_args(self, one, two, three, four, five):
+    side = []
+
+    def f(x, y, z, flag=False, flag2=False):
+      del flag2  # unused
+      assert flag
+      side.append(None)
+      return 100 * x + 10 * y + z
+
+    f1 = self.jit(f, static_argnums=(3, 4))
+    assert f1(one, two, three, True, False) == 123
+    assert len(side) == 1
+    assert f1(one, two, three, True, False) == 123
+    assert len(side) == 1  # Obvious cache hit.
+    assert f1(two, one, three, True, False) == 213
+    assert len(side) == 1  # Should cache hit because same signature.
+    assert f1(two, one, three, True, True) == 213
+    assert len(side) == 2
+
+    side[:] = []
+    f2 = self.jit(f, static_argnums=(0, 2, 3, 4))
+    assert f2(one, two, three, True, False) == 123
+    assert len(side) == 1
+    assert f2(one, three, three, True, False) == 133
+    assert len(side) == 1
+    assert f2(two, two, three, True, False) == 223
+    assert len(side) == 2
+    assert f2(two, four, three, True, False) == 243
+    assert len(side) == 2
+    assert f2(two, four, three, True, True) == 243
+    assert len(side) == 3
+    assert f2(two, five, three, True, True) == 253
+    assert len(side) == 3
+
+  @parameterized.parameters([
+      (1, 2, 3),
+      (
+          np.asarray(1, np.int32),
+          np.asarray(2, np.int32),
+          np.asarray(3, np.int32),
+      ),
+  ])
+  def test_jit_kwargs(self, one, two, three):
+    side = []
+
+    def f(x, y, z):
+      print(x, y, z)
+      side.append(None)
+      return 100 * x + 10 * y + z
+
+    f = self.jit(f)
+    assert f(one, two, three) == 123
+    assert len(side) == 1
+    assert f(one, two, three) == 123
+    assert len(side) == 1
+
+    assert f(one, two, z=three) == 123
+    assert len(side) == 2  # actually recompiles from kwarg
+    assert f(one, two, z=three) == 123
+    assert len(side) == 2  # but should still cache
+
+    f(one, two, z=np.zeros(3))  # doesn't crash
+    if FLAGS.jax_enable_x64:
+      # In the above call, three is of a new type (int64), thus it should
+      # trigger a new compilation.
+      assert len(side) == 3
+
+  def test_jit_device(self):
+    device = xb.devices()[-1]
+    x = self.jit(lambda x: x, device=device)(3.)
+    self.assertIsInstance(x, xla.DeviceArray)
+    self.assertEqual(x.device_buffer.device(), device)
+
+  def test_complex_support(self):
+    self.assertEqual(jax.jit(lambda x: x+1)(1+1j), 2+1j)
+
+  def test_jit_with_many_args_works(self):
+
+    @self.jit
+    def f(args_list):
+      return sum(args_list)
+
+    self.assertEqual(f(list(range(500))), sum(range(500)))
+
+
+class PythonJitTest(CPPJitTest):
+
+  @staticmethod
+  def jit(*args, **kwargs):
+    return jax.api._python_jit(*args, **kwargs)
+
+  def test_static_argnum_on_method(self):
+
+    class A:
+
+      @functools.partial(jax.api._python_jit, static_argnums=(0,))
+      def my_func(self, x):
+        return x+2
+
+    A().my_func(3)
+
+
+
 class APITest(jtu.JaxTestCase):
 
   def test_grad_argnums(self):
@@ -64,64 +187,6 @@ class APITest(jtu.JaxTestCase):
     assert api.value_and_grad(f)(1.0, 1.0, 1.0, flag=True) == (y, 1.0)
     assert api.value_and_grad(f, argnums=1)(1.0, 1.0, 1.0, flag=True) == (y, 2.0)
     assert api.value_and_grad(f, argnums=(2, 0))(1.0, 1.0, 1.0, flag=True) == (y, (3.0, 1.0))
-
-  def test_jit_static_args(self):
-    side = []
-
-    def f(x, y, z, flag=False, flag2=False):
-      assert flag
-      side.append(None)
-      return 100*x + 10*y + z
-
-    f1 = jit(f, static_argnums=(3, 4))
-    assert f1(1, 2, 3, True, False) == 123
-    assert len(side) == 1
-    assert f1(2, 1, 3, True, False) == 213
-    assert len(side) == 1
-    assert f1(2, 1, 3, True, True) == 213
-    assert len(side) == 2
-
-    side[:] = []
-    f2 = jit(f, static_argnums=(0, 2, 3, 4))
-    assert f2(1, 2, 3, True, False) == 123
-    assert len(side) == 1
-    assert f2(1, 3, 3, True, False) == 133
-    assert len(side) == 1
-    assert f2(2, 2, 3, True, False) == 223
-    assert len(side) == 2
-    assert f2(2, 4, 3, True, False) == 243
-    assert len(side) == 2
-    assert f2(2, 4, 3, True, True) == 243
-    assert len(side) == 3
-    assert f2(2, 5, 3, True, True) == 253
-    assert len(side) == 3
-
-  def test_jit_kwargs(self):
-    side = []
-
-    def f(x, y, z):
-      side.append(None)
-      return 100*x + 10*y + z
-
-    f = jit(f)
-    assert f(1, 2, 3) == 123
-    assert len(side) == 1
-    assert f(1, 2, 3) == 123
-    assert len(side) == 1
-
-    assert f(1, 2, z=3) == 123
-    assert len(side) == 2  # actually recompiles from kwarg
-    assert f(1, 2, z=3) == 123
-    assert len(side) == 2  # but should still cache
-
-    f(1, 2, z=np.zeros(3))  # doesn't crash
-
-  def test_jit_with_many_args_works(self):
-    @jit
-    def f(args_list):
-      return sum(args_list)
-
-    self.assertEqual(f(list(range(500))), sum(range(500)))
 
   def test_grad_of_jit(self):
     side = []
@@ -947,12 +1012,6 @@ class APITest(jtu.JaxTestCase):
     expected = (api.ShapeDtypeStruct(shape=(), dtype=jnp.int32),
                 api.ShapeDtypeStruct(shape=(2,), dtype=jnp.float32))
     self.assertEqual(shape_tree, expected)
-
-  def test_jit_device(self):
-    device = xb.devices()[-1]
-    x = api.jit(lambda x: x, device=device)(3.)
-    self.assertIsInstance(x, xla.DeviceArray)
-    self.assertEqual(x.device_buffer.device(), device)
 
   def test_jit_of_noncallable(self):
     self.assertRaisesRegex(TypeError, "Expected a callable value.*",
@@ -2982,7 +3041,13 @@ class InvertibleADTest(jtu.JaxTestCase):
 
     finv = jax.invertible(f)
 
-    x = jnp.ones((5,))
+    x = jnp.ones((1,))
+
+    def primal_vjp_trace(fun, primals, cotangents):
+      def run(primals, cotangents):
+        out, fun_vjp = jax.vjp(fun, *primals)
+        return fun_vjp(cotangents)
+      return jax.make_jaxpr(run)(primals, cotangents)
 
     if config.omnistaging_enabled:
       expected = """
@@ -3070,19 +3135,6 @@ class InvertibleADTest(jtu.JaxTestCase):
     self.assertAllClose(jax.value_and_grad(partial(reduce, jax.invertible(g)), argnums=(0, 1))(x, x + 2),
                         jax.value_and_grad(partial(reduce, g), argnums=(0, 1))(x, x + 2),
                         check_dtypes=True)
-
-  def test_invertible_partial_diff(self):
-    # Check that we don't have to differentiate with respect to inputs
-    # of the invertible function.
-    def f(x, y):
-      return (jnp.exp(x) * 4) * x, y + 4
-
-    finv = jax.invertible(f)
-    o = np.ones((5,))
-    self.assertAllClose(jax.value_and_grad(lambda x: np.sum(f(x, o)[0]))(o),
-                        jax.value_and_grad(lambda x: np.sum(finv(x, o)[0]))(o),
-                        check_dtypes=True)
-
 
 
 class DeprecatedCustomTransformsTest(jtu.JaxTestCase):

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -1,0 +1,79 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import jax
+from jax import numpy as jnp
+from jax import test_util as jtu
+from jax.config import flags
+from jax.lib import xla_bridge
+import numpy as np
+from jax.lib import xla_client
+
+jax_jit = xla_client._xla.jax_jit
+
+FLAGS = flags.FLAGS
+
+
+class JaxJitTest(parameterized.TestCase):
+
+  def test_convert_scalars(self):
+    jax_enable_x64 = FLAGS.jax_enable_x64
+
+    if jax_enable_x64:
+      int_type = np.int64
+      float_type = np.float64
+      complex_type = np.complex128
+    else:
+      int_type = np.int32
+      float_type = np.float32
+      complex_type = np.complex64
+
+    # int
+    res = jax_jit._ScalarToBuffer(1, jax_enable_x64,
+                                  xla_bridge.get_backend()).to_py()
+    self.assertEqual(res, 1)
+    self.assertEqual(res.dtype, int_type)
+    # We also compare to the Python Jax API, to make sure we have the exact
+    # same behavior. When Jax removes the flag and removes this feature, this
+    # test will fail.
+    self.assertEqual(jnp.asarray(1).dtype, res.dtype)
+
+    # float
+    res = jax_jit._ScalarToBuffer(1.0, jax_enable_x64,
+                                  xla_bridge.get_backend()).to_py()
+    self.assertEqual(res, 1.0)
+    self.assertEqual(res.dtype, float_type)
+    self.assertEqual(jnp.asarray(1.0).dtype, res.dtype)
+
+    # bool
+    for bool_value in [True, False]:
+      res = jax_jit._ScalarToBuffer(bool_value, jax_enable_x64,
+                                    xla_bridge.get_backend()).to_py()
+      self.assertEqual(res, np.asarray(bool_value))
+      self.assertEqual(res.dtype, np.bool)
+      self.assertEqual(jnp.asarray(bool_value).dtype, res.dtype)
+
+    # Complex
+    res = jax_jit._ScalarToBuffer(1 + 1j, jax_enable_x64,
+                                  xla_bridge.get_backend()).to_py()
+    self.assertEqual(res, 1 + 1j)
+    self.assertEqual(res.dtype, complex_type)
+    self.assertEqual(jnp.asarray(1 + 1j).dtype, res.dtype)
+
+
+if __name__ == '__main__':
+  jax.config.config_with_absl()
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This provides a solid start for a C++ jit codepath to speed up dispatch time.

Supported features:
- scalar, numpy array and DeviceArray argument support:
  - integer, floats, boolean, and complex scalars Python arguments are supported.
  - The jax_enable_x64 flag will be used at *object-creation time* to cast scalars and numpy arrays.
    This is very similar to the Python behavior, given that the
    `canonicalize_dtype` is memoized, so the flag value is frozen from
    the first call. Ideally, we would like to move the configs to C++.
  - The Jax `weak_type` attribute for arguments is supported (DeviceArray and scalars).
- Use an XLA tuple for more than 100 arguments

Unsupported features:
- jax._cpp_jit on methods e.g
    @functools.partial(jax.jit, static_argnums=0)
    def _compute_log_data(self, ...)
      ...
  This is currently not supported by the C++ codepath, because "self" won't be automatically added. A next CL is adding it.
- disable_jit.
- donate_argnums (A follow-up CL is adding this).

Follows https://github.com/google/jax/pull/4045