### PR TITLE
[jax2tf] Enable bfloat16 tests

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -156,8 +156,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     if len(harness.params["fft_lengths"]) > 3:
       with self.assertRaisesRegex(RuntimeError, "FFT only supports ranks 1-3"):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
-    elif harness.params["dtype"] is dtypes.bfloat16:
-      raise unittest.SkipTest("bfloat16 support not implemented")
     elif jtu.device_under_test() == "tpu" and len(harness.params["fft_lengths"]) > 1:
       # TODO(b/140351181): FFT is mostly unimplemented on TPU, even for JAX
       with self.assertRaisesRegex(RuntimeError, "only 1D FFT is currently supported."):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -288,11 +288,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     arg, = harness.dyn_args_maker(self.rng())
     custom_assert = None
     if lax_name == "digamma":
-      # TODO(necula): fix bug with digamma/f32 on TPU
-      if dtype is np.float32 and jtu.device_under_test() == "tpu":
+      # TODO(necula): fix bug with digamma/(f32|f16) on TPU
+      if dtype in [np.float16, np.float32] and jtu.device_under_test() == "tpu":
         raise unittest.SkipTest("TODO: fix bug: nan vs not-nan")
-      if dtype is np.float16 and jtu.device_under_test() == "tpu":
-        raise unittest.SkipTest("TODO: fix bug: nans and infs")
 
       # In the bfloat16 case, TF and lax both return NaN in undefined cases.
       if not dtype is dtypes.bfloat16:
@@ -312,6 +310,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       # TODO(necula): fix erf_inv bug on TPU
       if jtu.device_under_test() == "tpu":
         raise unittest.SkipTest("erf_inv bug on TPU: nan vs non-nan")
+      # TODO: investigate: in the (b)float16 cases, TF and lax both return the same
+      # result in undefined cases.
       if not dtype in [np.float16, dtypes.bfloat16]:
         # erf_inv is not defined for arg <= -1 or arg >= 1
         def custom_assert(result_jax, result_tf):  # noqa: F811

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -401,11 +401,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_betainc)
   def test_betainc(self, harness: primitive_harness.Harness):
-    if harness.params["dtype"] is dtypes.bfloat16:
-      raise unittest.SkipTest("bfloat16 not implemented")
-    # TODO(necula): fix bug with betainc/f16
-    if harness.params["dtype"] is np.float16:
-      raise unittest.SkipTest("TODO: understand betainc/f16 bug")
+    # TODO: https://www.tensorflow.org/api_docs/python/tf/math/betainc only supports
+    # float32/64 tests.
+    if harness.params["dtype"] in [np.float16, dtypes.bfloat16]:
+      raise unittest.SkipTest("(b)float16 not implemented in TF")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   # TODO(necula): combine tests that are identical except for the harness


### PR DESCRIPTION
This PR enables the `bfloat16` tests in all the "easy" cases.

More elaborate changes are still needed for:
- `select_and_gather_add`

These will be done in a separate PR.