### PR TITLE
[jax2tf] Added tests for reduce_window translation

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -394,7 +394,7 @@ for unexpected in [
 
 # Primitives that are not yet implemented must be explicitly declared here.
 tf_not_yet_impl = [
-  lax.reduce_p, lax.reduce_window_p, lax.rng_uniform_p,
+  lax.reduce_p, lax.rng_uniform_p,
 
   lax.linear_solve_p,
   lax_linalg.cholesky_p, lax_linalg.eig_p, lax_linalg.eigh_p,
@@ -911,6 +911,7 @@ tf_impl[lax.reduce_window_min_p] = (
     functools.partial(_reduce_window, lax._reduce_window_min, _min_fn, np.inf))
 tf_impl[lax.reduce_window_max_p] = (
     functools.partial(_reduce_window, lax._reduce_window_max, _max_fn, -np.inf))
+tf_impl[lax.reduce_window_p] = _reduce_window
 # pylint: enable=protected-access
 
 def _select_and_scatter(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -659,9 +659,9 @@ lax_reduce_window = tuple(
           padding=padding,
           base_dilation=base_dilation,
           window_dilation=window_dilation)
-  for dtype in jtu.dtypes.all_floating
+  for dtype in jtu.dtypes.all
   for shape in [(4, 6)]
-  for init_value in map(dtype, [0, -np.inf, np.inf, 1])
+  for init_value in map(dtype, [0, 1] if not dtype in jtu.dtypes.all_floating else [0, -np.inf, np.inf, 1])
   for computation in [lax.add, lax.max, lax.min, lax.mul]
   for window_dimensions in [(2, 1), (1, 2)]
   for window_strides in [(1, 1), (2, 1), (1, 2)]
@@ -689,7 +689,7 @@ lax_reduce_window = tuple(
           window_dilation=window_dilation)
   for dtype in jtu.dtypes.all_floating
   for shape in [(3, 2, 4, 6)]
-  for init_value in map(dtype, [0, -np.inf, np.inf, 1])
+  for init_value in map(dtype, [0, 1] if not dtype in jtu.dtypes.all_floating else [0, -np.inf, np.inf, 1])
   for computation in [lax.add, lax.max, lax.min, lax.mul]
   for window_dimensions in [(1, 1, 2, 1), (2, 1, 2, 1)]
   for window_strides in [(1, 2, 2, 1), (1, 1, 1, 1)]

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -661,10 +661,8 @@ lax_reduce_window = tuple(
           window_dilation=window_dilation)
   for dtype in jtu.dtypes.all_floating
   for shape in [(4, 6)]
-  for init_value, computation in [(0, lax.add),
-                                  (-np.inf, lax.max),
-                                  (np.inf, lax.min),
-                                  (1, lax.mul)]
+  for init_value in map(dtype, [0, -np.inf, np.inf, 1])
+  for computation in [lax.add, lax.max, lax.min, lax.mul]
   for window_dimensions in [(2, 1), (1, 2)]
   for window_strides in [(1, 1), (2, 1), (1, 2)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
@@ -691,10 +689,8 @@ lax_reduce_window = tuple(
           window_dilation=window_dilation)
   for dtype in jtu.dtypes.all_floating
   for shape in [(3, 2, 4, 6)]
-  for init_value, computation in [(0, lax.add),
-                                  (-np.inf, lax.max),
-                                  (np.inf, lax.min),
-                                  (1, lax.mul)]
+  for init_value in map(dtype, [0, -np.inf, np.inf, 1])
+  for computation in [lax.add, lax.max, lax.min, lax.mul]
   for window_dimensions in [(1, 1, 2, 1), (2, 1, 2, 1)]
   for window_strides in [(1, 2, 2, 1), (1, 1, 1, 1)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -642,3 +642,65 @@ lax_select_and_gather_add = tuple(
   for base_dilation in [(1, 1, 1, 1)]
   for window_dilation in [(1, 1, 1, 1)]
 )
+
+lax_reduce_window = tuple(
+  # Tests with 2d shapes (see tests.lax_test.testReduceWindow)
+  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}",
+          lax.reduce_window,
+          [RandArg(shape, dtype), StaticArg(init_value), StaticArg(computation),
+           StaticArg(window_dimensions), StaticArg(window_strides),
+           StaticArg(padding), StaticArg(base_dilation), StaticArg(window_dilation)],
+          shape=shape,
+          dtype=dtype,
+          init_value=init_value,
+          computation=computation,
+          window_dimensions=window_dimensions,
+          window_strides=window_strides,
+          padding=padding,
+          base_dilation=base_dilation,
+          window_dilation=window_dilation)
+  for dtype in jtu.dtypes.all_floating
+  for shape in [(4, 6)]
+  for init_value, computation in [(0, lax.add),
+                                  (-np.inf, lax.max),
+                                  (np.inf, lax.min),
+                                  (1, lax.mul)]
+  for window_dimensions in [(2, 1), (1, 2)]
+  for window_strides in [(1, 1), (2, 1), (1, 2)]
+  for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
+                                                      window_strides, p))
+                            for p in ['VALID', 'SAME']] +
+                           [((0, 3), (1, 2))]))
+  for base_dilation in [(1, 1), (2, 3)]
+  for window_dilation in [(1, 1), (1, 2)]
+) + tuple(
+  # Tests with 4d shapes (see tests.lax_test.testReduceWindow)
+  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}",
+          lax.reduce_window,
+          [RandArg(shape, dtype), StaticArg(init_value), StaticArg(computation),
+           StaticArg(window_dimensions), StaticArg(window_strides),
+           StaticArg(padding), StaticArg(base_dilation), StaticArg(window_dilation)],
+          shape=shape,
+          dtype=dtype,
+          init_value=init_value,
+          computation=computation,
+          window_dimensions=window_dimensions,
+          window_strides=window_strides,
+          padding=padding,
+          base_dilation=base_dilation,
+          window_dilation=window_dilation)
+  for dtype in jtu.dtypes.all_floating
+  for shape in [(3, 2, 4, 6)]
+  for init_value, computation in [(0, lax.add),
+                                  (-np.inf, lax.max),
+                                  (np.inf, lax.min),
+                                  (1, lax.mul)]
+  for window_dimensions in [(1, 1, 2, 1), (2, 1, 2, 1)]
+  for window_strides in [(1, 2, 2, 1), (1, 1, 1, 1)]
+  for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
+                                                      window_strides, p))
+                            for p in ['VALID', 'SAME']] +
+                           [((0, 1), (1, 0), (2, 3), (0, 2))]))
+  for base_dilation in [(1, 1, 1, 1), (2, 1, 3, 2)]
+  for window_dilation in [(1, 1, 1, 1), (1, 2, 2, 1)]
+)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -279,8 +279,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_reduce_window)
   def test_reduce_window(self, harness: primitive_harness.Harness):
-    if harness.params['computation'].__name__ not in ['max', 'min', 'sum']:
-      raise unittest.SkipTest('TODO: only max, min and sum supported for now.')
+    computation = harness.params['computation'].__name__
+    init_value = harness.params['init_value']
+    dtype = harness.params['dtype']
+
+    if (computation, init_value) not in [('max', dtype(-np.inf)), ('sum', dtype(0)),
+                                         ('min', dtype(np.inf))]:
+      raise unittest.SkipTest('TODO: only specific instances of max/min/sum are supported for now.')
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -277,6 +277,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            expect_tf_exceptions=expect_tf_exceptions)
 
+  @primitive_harness.parameterized(primitive_harness.lax_reduce_window)
+  def test_reduce_window(self, harness: primitive_harness.Harness):
+    if harness.params['computation'].__name__ not in ['max', 'min', 'sum']:
+      raise unittest.SkipTest('TODO: only max, min and sum supported for now.')
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):
     dtype = harness.params["dtype"]

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -283,9 +283,15 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     init_value = harness.params['init_value']
     dtype = harness.params['dtype']
 
-    if (computation, init_value) not in [('max', dtype(-np.inf)), ('sum', dtype(0)),
-                                         ('min', dtype(np.inf))]:
+    safe_computations = [('sum', dtype(0))]
+
+    if dtype in jtu.dtypes.all_floating:
+      # Only in this case, np.inf can be casted safely to a meaningful value.
+      safe_computations += [('max', dtype(-np.inf)), ('min', dtype(np.inf))]
+
+    if (computation, init_value) not in safe_computations:
       raise unittest.SkipTest('TODO: only specific instances of max/min/sum are supported for now.')
+
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)


### PR DESCRIPTION
This is a work in progress.
So far, only the manually registered reduction functions pass the tests successfully, i.e.
- `max`
- `min`
- `sum`

A test has been added using `mul` as a reduction function, which fails.