### PR TITLE
Add a fast C++ jit codepath.

### DIFF
--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -39,11 +39,11 @@ def _check_jaxlib_version():
     msg = 'jaxlib is version {}, but this version of jax requires version {}.'
 
     if version == (0, 1, 23):
-        msg += ('\n\nA common cause of this error is that you installed jaxlib '
-                'using pip, but your version of pip is too old to support '
-                'manylinux2010 wheels. Try running:\n\n'
-                'pip install --upgrade pip\n'
-                'pip install --upgrade jax jaxlib\n')
+      msg += ('\n\nA common cause of this error is that you installed jaxlib '
+              'using pip, but your version of pip is too old to support '
+              'manylinux2010 wheels. Try running:\n\n'
+              'pip install --upgrade pip\n'
+              'pip install --upgrade jax jaxlib\n')
     raise ValueError(msg.format('.'.join(map(str, version)),
                                 '.'.join(map(str, _minimum_jaxlib_version))))
 


### PR DESCRIPTION
This starts a C++ jit codepath to speed up dispatch time.
It will be enabled only after we support all features and extensive
testing within Google.

Supported features:
- scalar, numpy array and DeviceArray argument support:
  - integer, floats, boolean, and complex scalars arguments are supported.
  - The jax_enable_x64 flag will be used at object-creation type to cast scalars and numpy arrays.
  - The Jax `weak_type` attribute for arguments is supported (DeviceArray and scalars).
- The donate_argnums argument.
- Use an XLA tuple for more than 100 arguments

Unsupported features:
- jax._cpp_jit on methods e.g
    @functools.partial(jax.jit, static_argnums=0)
    def _compute_log_data(self, ...)
      ...
  This is currently not supported by the C++ codepath, because "self" won't be automatically added.
- disable_jit.

This is currently only for the XLA execution path, not the tracing path.