### PR TITLE
[jax2tf] Added conversion for scatter*_p primitives.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1223,6 +1223,12 @@ def _scatter(operand, scatter_indices, updates, update_jaxpr, update_consts,
   xla_update_computation = (
     tf.function(update_computation).get_concrete_function(o_spec, o_spec))
 
+  out = tf.function(
+      lambda o, s, u: tfxla.scatter(o, s, u, xla_update_computation, proto,
+                                    indices_are_sorted=indices_are_sorted),
+      experimental_compile=True
+  )(operand, scatter_indices, updates)
+
   out = tfxla.scatter(operand, scatter_indices, updates, xla_update_computation,
                       proto, indices_are_sorted=indices_are_sorted)
   out.set_shape(out_shape)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1204,30 +1204,36 @@ def _mk_typed_jaxpr(jaxpr: core.Jaxpr, literals: Sequence) -> core.TypedJaxpr:
                          tuple(map(lambda v: v.aval, jaxpr.invars)),
                          tuple(map(lambda v: v.aval, jaxpr.outvars)))
 
-@functools.partial(bool_to_int8, argnums=(1, 3))
-def _scatter(update_computation, operand, scatter_indices, updates,
-             update_jaxpr, update_consts, dimension_numbers,
-             indices_are_sorted, unique_indices):
-  """Tensorflow implementation of scatter with an update computation."""
-  del update_jaxpr, update_consts, unique_indices
+@functools.partial(bool_to_int8, argnums=(0, 2))
+def _scatter(operand, scatter_indices, updates, update_jaxpr, update_consts,
+             dimension_numbers, indices_are_sorted, unique_indices):
+  del unique_indices
+  assert len(update_consts) == 0, "Update computation cannot have constants"
+
   out_shape = _scatter_shape(operand, scatter_indices, updates,
                              dimension_numbers)
   proto = _scatter_dimensions_proto(scatter_indices.shape, dimension_numbers)
-  o_spec = tf.TensorSpec(None, dtype=operand.dtype)
+
+  def update_computation(arg1: TfVal, arg2: TfVal) -> TfVal:
+    typed_jaxpr = _mk_typed_jaxpr(update_jaxpr, update_consts)
+    res, = _interpret_jaxpr(typed_jaxpr, arg1, arg2)
+    return res
+
+  o_spec = tf.TensorSpec((), dtype=operand.dtype)
   xla_update_computation = (
-      tf.function(update_computation).get_concrete_function(o_spec, o_spec))
-  # We compile due to TF bug, see comment on gather
-  out = tf.function(lambda o, s, u: tfxla.scatter(o, s, u, xla_update_computation, proto,
-                                                  indices_are_sorted=indices_are_sorted),
-                    experimental_compile=True)(operand, scatter_indices, updates)
+    tf.function(update_computation).get_concrete_function(o_spec, o_spec))
+
+  out = tfxla.scatter(operand, scatter_indices, updates, xla_update_computation,
+                      proto, indices_are_sorted=indices_are_sorted)
   out.set_shape(out_shape)
+
   return out
 
-tf_impl[lax.scatter_p] = functools.partial(_scatter, lambda x, y: y)
-tf_impl[lax.scatter_min_p] = functools.partial(_scatter, tf.math.minimum)
-tf_impl[lax.scatter_max_p] = functools.partial(_scatter, tf.math.maximum)
-tf_impl[lax.scatter_mul_p] = functools.partial(_scatter, tf.math.multiply)
-tf_impl[lax.scatter_add_p] = functools.partial(_scatter, tf.math.add)
+tf_impl[lax.scatter_p] = _scatter
+tf_impl[lax.scatter_min_p] = _scatter
+tf_impl[lax.scatter_max_p] = _scatter
+tf_impl[lax.scatter_mul_p] = _scatter
+tf_impl[lax.scatter_add_p] = _scatter
 
 def _dynamic_update_slice(operand, update, *start_indices):
   return tfxla.dynamic_update_slice(*promote_types(operand, update),

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1229,8 +1229,6 @@ def _scatter(operand, scatter_indices, updates, update_jaxpr, update_consts,
       experimental_compile=True
   )(operand, scatter_indices, updates)
 
-  out = tfxla.scatter(operand, scatter_indices, updates, xla_update_computation,
-                      proto, indices_are_sorted=indices_are_sorted)
   out.set_shape(out_shape)
 
   return out

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -314,6 +314,46 @@ lax_gather = tuple(
   ]
 )
 
+lax_scatter = tuple(
+  # Directly from lax.scatter in tests/lax_test.py
+  Harness(
+    f"fun={f_lax.__name__}_shape={jtu.format_shape_dtype_string(shape, dtype)}_scatterindices={scatter_indices.tolist()}_updateshape={update_shape}_updatewindowdims={dimension_numbers.update_window_dims}_insertedwindowdims={dimension_numbers.inserted_window_dims}_scatterdimstooperanddims={dimension_numbers.scatter_dims_to_operand_dims}_indicesaresorted={indices_are_sorted}_uniqueindices={unique_indices}".replace(' ', ''),
+    (lambda f_lax: lambda *args: f_lax(*args[:-2], indices_are_sorted=args[-2], unique_indices=args[-1]))(f_lax),
+    [RandArg(shape, dtype), StaticArg(scatter_indices), RandArg(update_shape, dtype),
+     StaticArg(dimension_numbers), StaticArg(indices_are_sorted),
+     StaticArg(unique_indices)],
+    f_lax=f_lax,
+    shape=shape,
+    dtype=dtype,
+    scatter_indices=scatter_indices,
+    update_shape=update_shape,
+    dimension_numbers=dimension_numbers,
+    indices_are_sorted=indices_are_sorted,
+    unique_indices=unique_indices)
+  for f_lax in [lax.scatter, lax.scatter_min, lax.scatter_max, lax.scatter_mul,
+                lax.scatter_add]
+  for dtype in { lax.scatter: jtu.dtypes.all
+               , lax.scatter_min: jtu.dtypes.all
+               , lax.scatter_max: jtu.dtypes.all
+                 # lax.scatter_mul and lax.scatter_add are not compatible with
+                 # np.bool_ operands.
+               , lax.scatter_mul: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               , lax.scatter_add: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               }[f_lax]
+  for shape, scatter_indices, update_shape, dimension_numbers in [
+      ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
+        update_window_dims=(), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))),
+      ((10,), np.array([[0], [0], [0]]), (3, 2), lax.ScatterDimensionNumbers(
+        update_window_dims=(1,), inserted_window_dims=(),
+        scatter_dims_to_operand_dims=(0,))),
+      ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
+        update_window_dims=(1,), inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,))),
+  ]
+  for indices_are_sorted in [False, True]
+  for unique_indices in [False, True]
+)
 
 lax_pad = tuple(
   Harness(f"_inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_pads={pads}",

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -354,7 +354,7 @@ lax_scatter = tuple(
         scatter_dims_to_operand_dims=(0,))),
   ]
   for indices_are_sorted in [False, True]
-  for unique_indices in [False, True]
+  for unique_indices in [False] # TODO: add True case when testing for performance
 )
 
 lax_pad = tuple(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -332,10 +332,12 @@ lax_scatter = tuple(
     dimension_numbers=dimension_numbers,
     indices_are_sorted=indices_are_sorted,
     unique_indices=unique_indices)
-  for f_lax in [lax.scatter, lax.scatter_min, lax.scatter_max, lax.scatter_mul,
+  # We explicitly decide against testing lax.scatter, as its reduction function
+  # is lambda x, y: y, which is not commutative and thus makes results
+  # non-deterministic when an index into the operand is updated several times.
+  for f_lax in [lax.scatter_min, lax.scatter_max, lax.scatter_mul,
                 lax.scatter_add]
-  for dtype in { lax.scatter: jtu.dtypes.all
-               , lax.scatter_min: jtu.dtypes.all
+  for dtype in { lax.scatter_min: jtu.dtypes.all
                , lax.scatter_max: jtu.dtypes.all
                  # lax.scatter_mul and lax.scatter_add are not compatible with
                  # np.bool_ operands.
@@ -354,7 +356,13 @@ lax_scatter = tuple(
         scatter_dims_to_operand_dims=(0,))),
   ]
   for indices_are_sorted in [False, True]
-  for unique_indices in [False] # TODO: add True case when testing for performance
+  # `unique_indices` does not affect correctness, only performance, and thus
+  # does not need to be tested here. If/when it will make sense to add a test
+  # with `unique_indices` = True, particular care will have to be taken with
+  # regards to the choice of parameters, as the results are only predictable
+  # when all the indices to be updated are pairwise non-overlapping. Identifying
+  # such cases is non-trivial.
+  for unique_indices in [False]
 )
 
 lax_pad = tuple(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -20,6 +20,8 @@ NumPy (lax_reference) or TensorFlow.
 import operator
 from typing import Any, Callable, Dict, Iterable, Optional, NamedTuple, Sequence, Tuple, Union
 
+from functools import partial
+
 from absl import testing
 from jax import config
 from jax import test_util as jtu
@@ -318,10 +320,10 @@ lax_scatter = tuple(
   # Directly from lax.scatter in tests/lax_test.py
   Harness(
     f"fun={f_lax.__name__}_shape={jtu.format_shape_dtype_string(shape, dtype)}_scatterindices={scatter_indices.tolist()}_updateshape={update_shape}_updatewindowdims={dimension_numbers.update_window_dims}_insertedwindowdims={dimension_numbers.inserted_window_dims}_scatterdimstooperanddims={dimension_numbers.scatter_dims_to_operand_dims}_indicesaresorted={indices_are_sorted}_uniqueindices={unique_indices}".replace(' ', ''),
-    (lambda f_lax: lambda *args: f_lax(*args[:-2], indices_are_sorted=args[-2], unique_indices=args[-1]))(f_lax),
-    [RandArg(shape, dtype), StaticArg(scatter_indices), RandArg(update_shape, dtype),
-     StaticArg(dimension_numbers), StaticArg(indices_are_sorted),
-     StaticArg(unique_indices)],
+    partial(f_lax, indices_are_sorted=indices_are_sorted,
+            unique_indices=unique_indices),
+    [RandArg(shape, dtype), StaticArg(scatter_indices),
+     RandArg(update_shape, dtype), StaticArg(dimension_numbers)],
     f_lax=f_lax,
     shape=shape,
     dtype=dtype,


### PR DESCRIPTION
Limitations:

- the conversion works as well as the conversion of the underlying reduction functions (e.g. `lax.scatter_max` is not properly converted for the `int8` dtype, because `tf.math.maximum` is not defined for `int8` tensors);
- the conversion can not take advantage of the `unique_indices` parameter. This does not affect correctness, but may affect performance on certain platforms (as stated in the documentation of `lax.scatter`).