### PR TITLE
[jax2tf] General conversion of reduce_window.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -938,9 +938,9 @@ def _specialized_reduce_window(reducer, identity, operand, window_dimensions,
   operand.
 
   Args:
-    reducer: reduction function of type T -> T -> T
-    identity: function that takes a dtype as a parameter and returns the starting
-      value of the reduction.
+    reducer: reduction function of type TfVal -> TfVal -> TfVal
+    identity: function that takes a TensorFlow dtype as a parameter and returns the
+      starting value of the reduction.
     operand: N dimensional array containing elements of type T
     window_dimensions: array of integers for window dimension values
     window_strides: array of integers for window stride values

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -890,6 +890,7 @@ def _common_reduce_window(operand, init_val, reducer, window_dimensions,
   reducer_fn = tf.function(reducer).get_concrete_function(o_spec, o_spec)
 
   if not isinstance(init_val, tf.Tensor):
+    assert core.skip_checks or _is_tfval(init_val), f"Non TfVal: {init_val}"
     init_val = tf.constant(init_val, operand.dtype)
 
   out = tfxla.reduce_window(operand, init_val,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -901,7 +901,22 @@ def _common_reduce_window(operand, init_val, reducer, window_dimensions,
 
 def _reduce_window(operand, init_value, *, jaxpr, consts, window_dimensions,
                    window_strides, padding, base_dilation, window_dilation):
-  """TensorFlow implementation of reduce_window."""
+  """TensorFlow implementation of reduce_window.
+
+  Args:
+    operand: N dimensional array containing elements of type T
+    init_value: starting value of the reduction
+    jaxpr: the jaxpr corresponding to the reduction function
+    consts: the constants associated with jaxpr.
+    window_dimensions: array of integers for window dimension values
+    window_strides: array of integers for window stride values
+    padding: array of pairs of integers for padding values
+    base_dilation: array of integers for base dilation values
+    window_dilation: array of integers for window dilation values
+
+  Returns:
+    The reduced operand.
+  """
   assert len(consts) == 0, "Reduction computation cannot have constants"
 
   def reducer(arg1: TfVal, arg2: TfVal) -> TfVal:
@@ -917,7 +932,25 @@ def _reduce_window(operand, init_value, *, jaxpr, consts, window_dimensions,
 def _specialized_reduce_window(reducer, identity, operand, window_dimensions,
                                window_strides, padding, base_dilation,
                                window_dilation):
-  """TensorFlow implementation of reduce_window_{sum,min,max}."""
+  """Wraps the TensorFlow reduce window operation based on a reducer and an identity
+  function defining the initial value of the reduction depending on the dtype of the
+  operand.
+
+  Args:
+    reducer: reduction function of type T -> T -> T
+    identity: function that takes a dtype as a parameter and returns the starting
+      value of the reduction.
+    operand: N dimensional array containing elements of type T
+    window_dimensions: array of integers for window dimension values
+    window_strides: array of integers for window stride values
+    padding: array of pairs of integers for padding values
+    base_dilation: array of integers for base dilation values
+    window_dilation: array of integers for window dilation values
+
+  Returns:
+    The reduced operand.
+  """
+
   return _common_reduce_window(
       operand, identity(operand.dtype), reducer, window_dimensions,
       window_strides, padding, base_dilation, window_dilation

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -846,10 +846,9 @@ def _select_and_gather_add(tangents: TfVal,
     return tf_impl[lax.select_p](which(fst(x), fst(y)), x=x, y=y)
 
   init = -np.inf if select_prim is lax.ge_p else np.inf
-  jax_f = lax._reduce_window_max if select_prim is lax.ge_p else lax._reduce_window_min
   init_identity = lambda x: pack(const(dtype, init), const(dtype, 0))
 
-  out = _specialized_reduce_window(jax_f, tf.function(reducer), init_identity,
+  out = _specialized_reduce_window(tf.function(reducer), init_identity,
                                    pack(operand, tangents), window_dimensions,
                                    window_strides, padding, base_dilation,
                                    window_dilation)
@@ -882,17 +881,11 @@ def _get_shape_from_tensor_or_array(x):
     return tuple(x.shape.as_list())
   return tuple(x.shape)
 
-
-def _specialized_reduce_window(jax_f, reducer, identity, operand,
-                               window_dimensions, window_strides, padding,
-                               base_dilation, window_dilation,
-                               input_shape=None):
-  """TensorFlow implementation of reduce_window_{sum,min,max}."""
-  del input_shape
-
-  init_val = identity(operand.dtype)
+def _common_reduce_window(operand, init_val, reducer, window_dimensions,
+                          window_strides, padding, base_dilation,
+                          window_dilation):
   # TODO(tomhennigan): tf2xla should have a shape inference function.
-  out_shape = _reduce_window_shape(jax_f, operand, window_dimensions,
+  out_shape = _reduce_window_shape(lax._reduce_window_sum, operand, window_dimensions,
                                    window_strides, padding, base_dilation,
                                    window_dilation)
 
@@ -908,6 +901,32 @@ def _specialized_reduce_window(jax_f, reducer, identity, operand,
                             window_dilations=window_dilation, padding=padding)
   out.set_shape(out_shape)
   return out
+
+def _reduce_window(operand, init_value, *, jaxpr, consts, window_dimensions,
+                   window_strides, padding, base_dilation, window_dilation):
+  """TensorFlow implementation of reduce_window."""
+  assert len(consts) == 0, "Reduction computation cannot have constants"
+
+  def reducer(arg1: TfVal, arg2: TfVal) -> TfVal:
+    typed_jaxpr = _mk_typed_jaxpr(jaxpr, consts)
+    res, = _interpret_jaxpr(typed_jaxpr, arg1, arg2)
+    return res
+
+  reducer = tf.function(reducer)
+
+  return _common_reduce_window(
+      operand, init_value, reducer, window_dimensions, window_strides, padding,
+      base_dilation, window_dilation
+  )
+
+def _specialized_reduce_window(reducer, identity, operand, window_dimensions,
+                               window_strides, padding, base_dilation,
+                               window_dilation):
+  """TensorFlow implementation of reduce_window_{sum,min,max}."""
+  return _common_reduce_window(
+      operand, identity(operand.dtype), reducer, window_dimensions,
+      window_strides, padding, base_dilation, window_dilation
+  )
 
 def _get_max_identity(tf_dtype):
   numpy_tf_dtype = tf_dtype.as_numpy_dtype
@@ -933,43 +952,13 @@ def _get_min_identity(tf_dtype):
     )
     return True
 
-def _reduce_window(operand, init_value, *, jaxpr, consts, window_dimensions,
-                   window_strides, padding, base_dilation, window_dilation):
-  """TensorFlow implementation of reduce_window."""
-  assert len(consts) == 0, "Reduction computation cannot have constants"
-
-  out_shape = _reduce_window_shape(lax._reduce_window_sum, operand, window_dimensions,
-                                   window_strides, padding, base_dilation,
-                                   window_dilation)
-
-  def reducer(arg1: TfVal, arg2: TfVal) -> TfVal:
-    typed_jaxpr = _mk_typed_jaxpr(jaxpr, consts)
-    res, = _interpret_jaxpr(typed_jaxpr, arg1, arg2)
-    return res
-
-  o_spec = tf.TensorSpec(operand.shape, dtype=operand.dtype)
-  reducer_fn = tf.function(reducer).get_concrete_function(o_spec, o_spec)
-
-  if not isinstance(init_value, tf.Tensor):
-    init_value = tf.constant(init_value, operand.dtype)
-
-  out = tfxla.reduce_window(operand, init_value,
-                            reducer_fn, window_dimensions,
-                            window_strides, base_dilations=base_dilation,
-                            window_dilations=window_dilation, padding=padding)
-  out.set_shape(out_shape)
-  return out
-
 # pylint: disable=protected-access
 tf_impl[lax.reduce_window_sum_p] = (
-    functools.partial(_specialized_reduce_window, lax._reduce_window_sum,
-                      _add_fn, lambda x: 0))
+    functools.partial(_specialized_reduce_window, _add_fn, lambda x: 0))
 tf_impl[lax.reduce_window_min_p] = (
-    functools.partial(_specialized_reduce_window, lax._reduce_window_min,
-                      _min_fn, _get_min_identity))
+    functools.partial(_specialized_reduce_window, _min_fn, _get_min_identity))
 tf_impl[lax.reduce_window_max_p] = (
-    functools.partial(_specialized_reduce_window, lax._reduce_window_max,
-                      _max_fn, _get_max_identity))
+    functools.partial(_specialized_reduce_window, _max_fn, _get_max_identity))
 tf_impl[lax.reduce_window_p] = _reduce_window
 # pylint: enable=protected-access
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -645,7 +645,7 @@ lax_select_and_gather_add = tuple(
 
 lax_reduce_window = tuple(
   # Tests with 2d shapes (see tests.lax_test.testReduceWindow)
-  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}",
+  Harness(f"2d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}".replace(' ', ''),
           lax.reduce_window,
           [RandArg(shape, dtype), StaticArg(init_value), StaticArg(computation),
            StaticArg(window_dimensions), StaticArg(window_strides),
@@ -659,10 +659,23 @@ lax_reduce_window = tuple(
           padding=padding,
           base_dilation=base_dilation,
           window_dilation=window_dilation)
-  for dtype in jtu.dtypes.all
-  for shape in [(4, 6)]
-  for init_value in map(dtype, [0, 1] if not dtype in jtu.dtypes.all_floating else [0, -np.inf, np.inf, 1])
   for computation in [lax.add, lax.max, lax.min, lax.mul]
+  for dtype in { lax.add: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               , lax.mul: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               , lax.max: jtu.dtypes.all
+               , lax.min: jtu.dtypes.all
+               }[computation]
+  for init_value in map(
+      dtype,
+      (lambda ts: ts[0] if not dtype in jtu.dtypes.all_floating else ts[1])(
+          { lax.add: ([0, 1], [0, 1])
+          , lax.mul: ([0, 1], [0, 1])
+          , lax.max: ([1], [-np.inf, 1])
+          , lax.min: ([0], [np.inf, 0])
+          }[computation]
+      )
+  )
+  for shape in [(4, 6)]
   for window_dimensions in [(2, 1), (1, 2)]
   for window_strides in [(1, 1), (2, 1), (1, 2)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
@@ -673,7 +686,7 @@ lax_reduce_window = tuple(
   for window_dilation in [(1, 1), (1, 2)]
 ) + tuple(
   # Tests with 4d shapes (see tests.lax_test.testReduceWindow)
-  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}",
+  Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}".replace(' ', ''),
           lax.reduce_window,
           [RandArg(shape, dtype), StaticArg(init_value), StaticArg(computation),
            StaticArg(window_dimensions), StaticArg(window_strides),
@@ -687,10 +700,23 @@ lax_reduce_window = tuple(
           padding=padding,
           base_dilation=base_dilation,
           window_dilation=window_dilation)
-  for dtype in jtu.dtypes.all_floating
-  for shape in [(3, 2, 4, 6)]
-  for init_value in map(dtype, [0, 1] if not dtype in jtu.dtypes.all_floating else [0, -np.inf, np.inf, 1])
   for computation in [lax.add, lax.max, lax.min, lax.mul]
+  for dtype in { lax.add: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               , lax.mul: filter(lambda t: t != np.bool_, jtu.dtypes.all)
+               , lax.max: jtu.dtypes.all
+               , lax.min: jtu.dtypes.all
+               }[computation]
+  for init_value in map(
+      dtype,
+      (lambda ts: ts[0] if not dtype in jtu.dtypes.all_floating else ts[1])(
+          { lax.add: ([0, 1], [0, 1])
+          , lax.mul: ([0, 1], [0, 1])
+          , lax.max: ([0], [-np.inf, 1])
+          , lax.min: ([1], [np.inf, 1])
+          }[computation]
+      )
+  )
+  for shape in [(3, 2, 4, 6)]
   for window_dimensions in [(1, 1, 2, 1), (2, 1, 2, 1)]
   for window_strides in [(1, 2, 2, 1), (1, 1, 1, 1)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -669,21 +669,21 @@ lax_reduce_window = tuple(
       dtype,
       (lambda ts: ts[0] if not dtype in jtu.dtypes.all_floating else ts[1])(
           { lax.add: ([0, 1], [0, 1])
-          , lax.mul: ([0, 1], [0, 1])
+          , lax.mul: ([1], [1])
           , lax.max: ([1], [-np.inf, 1])
           , lax.min: ([0], [np.inf, 0])
           }[computation]
       )
   )
   for shape in [(4, 6)]
-  for window_dimensions in [(2, 1), (1, 2)]
-  for window_strides in [(1, 1), (2, 1), (1, 2)]
+  for window_dimensions in [(1, 2)]
+  for window_strides in [(2, 1)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
                                                       window_strides, p))
                             for p in ['VALID', 'SAME']] +
                            [((0, 3), (1, 2))]))
-  for base_dilation in [(1, 1), (2, 3)]
-  for window_dilation in [(1, 1), (1, 2)]
+  for base_dilation in [(2, 3)]
+  for window_dilation in [(1, 2)]
 ) + tuple(
   # Tests with 4d shapes (see tests.lax_test.testReduceWindow)
   Harness(f"4d_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}".replace(' ', ''),
@@ -710,19 +710,19 @@ lax_reduce_window = tuple(
       dtype,
       (lambda ts: ts[0] if not dtype in jtu.dtypes.all_floating else ts[1])(
           { lax.add: ([0, 1], [0, 1])
-          , lax.mul: ([0, 1], [0, 1])
-          , lax.max: ([0], [-np.inf, 1])
-          , lax.min: ([1], [np.inf, 1])
+          , lax.mul: ([1], [1])
+          , lax.max: ([1], [-np.inf, 1])
+          , lax.min: ([0], [np.inf, 0])
           }[computation]
       )
   )
   for shape in [(3, 2, 4, 6)]
-  for window_dimensions in [(1, 1, 2, 1), (2, 1, 2, 1)]
-  for window_strides in [(1, 2, 2, 1), (1, 1, 1, 1)]
+  for window_dimensions in [(1, 1, 2, 1)]
+  for window_strides in [(1, 2, 2, 1)]
   for padding in tuple(set([tuple(lax.padtype_to_pads(shape, window_dimensions,
                                                       window_strides, p))
                             for p in ['VALID', 'SAME']] +
                            [((0, 1), (1, 0), (2, 3), (0, 2))]))
-  for base_dilation in [(1, 1, 1, 1), (2, 1, 3, 2)]
-  for window_dilation in [(1, 1, 1, 1), (1, 2, 2, 1)]
+  for base_dilation in [(2, 1, 3, 2)]
+  for window_dilation in [(1, 2, 2, 1)]
 )

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -279,20 +279,34 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_reduce_window)
   def test_reduce_window(self, harness: primitive_harness.Harness):
-    computation = harness.params['computation'].__name__
-    init_value = harness.params['init_value']
+    f_name = harness.params['computation'].__name__
     dtype = harness.params['dtype']
 
-    safe_computations = [('sum', dtype(0))]
+    expect_tf_exceptions = False
 
-    if dtype in jtu.dtypes.all_floating:
-      # Only in this case, np.inf can be casted safely to a meaningful value.
-      safe_computations += [('max', dtype(-np.inf)), ('min', dtype(np.inf))]
+    if ((f_name == 'min' or f_name == 'max') and
+        dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
+                      np.int16, np.int32, np.int64]):
+      # See https://www.tensorflow.org/api_docs/python/tf/math/minimum for a list of
+      # the types supported by tf.math.minimum/tf.math.maximum.
+      expect_tf_exceptions = True
+    elif (f_name == 'add' and
+          dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
+                        np.int8, np.int16, np.int32, np.int64, np.complex64,
+                        np.complex128]):
+      # See https://www.tensorflow.org/api_docs/python/tf/math/add for a list of the
+      # types supported by tf.math.add.
+      expect_tf_exceptions = True
+    elif (f_name == 'mul' and
+          dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
+                        np.int8, np.uint16, np.int16, np.int32, np.int64,
+                        np.complex64, np.complex128]):
+      # See https://www.tensorflow.org/api_docs/python/tf/math/multiply for a list of
+      # the types supported by tf.math.multiply.
+      expect_tf_exceptions = True
 
-    if (computation, init_value) not in safe_computations:
-      raise unittest.SkipTest('TODO: only specific instances of max/min/sum are supported for now.')
-
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           expect_tf_exceptions=expect_tf_exceptions)
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -284,6 +284,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     expect_tf_exceptions = False
 
+    if (jtu.device_under_test() == 'tpu' and dtype is np.complex64):
+      raise unittest.SkipTest('TODO: reduce_window on TPU does not handle complex64')
+
     if ((f_name == 'min' or f_name == 'max') and
         dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
                       np.int16, np.int32, np.int64]):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -285,7 +285,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     expect_tf_exceptions = False
 
     if (jtu.device_under_test() == 'tpu' and dtype is np.complex64):
-      raise unittest.SkipTest('TODO: reduce_window on TPU does not handle complex64')
+      raise unittest.SkipTest(
+          'TODO: JAX reduce_window on TPU does not handle complex64'
+      )
 
     if ((f_name == 'min' or f_name == 'max') and
         dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,


### PR DESCRIPTION
Much like scatter_p, the conversion works as well as the underlying
reduction function (e.g. reduce_window_max is not properly converted
for the int8 dtype, because tf.math.maximum is not defined for int8
tensors).