### PR TITLE
remove check for TypedJaxpr literals arent tracers

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -116,8 +116,6 @@ class TypedJaxpr:
     assert len(literals) == len(jaxpr.constvars)
     assert len(in_avals) == len(jaxpr.invars)
 
-    assert not any(isinstance(l, Tracer) for l in literals), literals
-
     if not skip_checks:
       in_avals_raised = [raise_to_shaped(v) for v in in_avals]
       out_avals_raised = [raise_to_shaped(v) for v in out_avals]


### PR DESCRIPTION
In the original usage of TypedJaxpr, literals could not be tracers because they were only produced by initial-style transformations of jaxprs. But now TypedJaxpr is used in several other ways, e.g. in make_jaxpr, and moreover its avals are redundant. It should probably be renamed ClosedJaxpr since it mainly serves to package a jaxpr together with its constant arrays. This check was limiting the utility of TypedJaxpr, and it was only added relatively recently anyway.