### PR TITLE
Docs: Fix broken link in quickstart

### DIFF
--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -61,7 +61,7 @@
         "id": "Xpy1dSgNqCP4"
       },
       "source": [
-        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see the [README](../../README.md)."
+        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see [Common Gotchas in JAX](Common_Gotchas_in_JAX.ipynb#🔪-Random-Numbers)."
       ]
     },
     {

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -61,7 +61,9 @@
         "id": "Xpy1dSgNqCP4"
       },
       "source": [
-        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see [Common Gotchas in JAX](Common_Gotchas_in_JAX.ipynb#🔪-Random-Numbers)."
+        "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see [Common Gotchas in JAX].\n",
+        "\n",
+        "[Common Gotchas in JAX]: https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Random-Numbers"
       ]
     },
     {


### PR DESCRIPTION
Hi,

I was reading through the [JAX quickstart](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html).

The link to the README in this section: 
![image](https://user-images.githubusercontent.com/2182503/90647482-43155300-e230-11ea-97b6-df64cc3ac84e.png)

points to https://jax.readthedocs.io/en/README.md, which is broken for me.

Seems like it should probably point [here](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Random-Numbers) instead.
