### PR TITLE
Add rademacher, maxwell, double_sided_maxwell and weibull_min to jax.random.

### DIFF
--- a/jax/random.py
+++ b/jax/random.py
@@ -1349,3 +1349,133 @@ def _t(key, df, shape, dtype):
   half_df = lax.div(df, two)
   g = gamma(key_n, half_df, shape, dtype)
   return n * jnp.sqrt(half_df / g)
+
+
+def rademacher(key, shape, dtype=dtypes.int_):
+  """Sample from a Rademacher distribution.
+
+  Args:
+    key: a PRNGKey key.
+    shape: The shape of the returned samples.
+    dtype: The type used for samples.
+
+  Returns:
+    A jnp.array of samples, of shape `shape`. Each element in the output has
+    a 50% change of being 1 or -1.
+
+  """
+  dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
+  return _rademacher(key, shape, dtype)
+
+
+@partial(jit, static_argnums=(1, 2))
+def _rademacher(key, shape, dtype):
+  random_bernoulli = categorical(
+      key=key, logits=jnp.array([0.5, 0.5]), shape=shape)
+  return (2 * random_bernoulli - 1).astype(dtype)
+
+
+def one_sided_maxwell(key, shape=(), dtype=dtypes.float_):
+  """Sample from a one sided Maxwell distribution.
+
+  The scipy counterpart is `scipy.stats.maxwell`.
+
+  Args:
+    key: a PRNGKey key.
+    shape: The shape of the returned samples.
+    dtype: The type used for samples.
+
+  Returns:
+    A jnp.array of samples, of shape `shape`.
+
+  """
+  # Generate samples using:
+  # sqrt(X^2 + Y^2 + Z^2), X,Y,Z ~N(0,1)
+  if not dtypes.issubdtype(dtype, np.floating):
+    raise ValueError(f"dtype argument to `one_sided_maxwell` must be a float "
+                     f"dtype, got {dtype}")
+  dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
+  return _one_sided_maxwell(key, shape, dtype)
+
+
+@partial(jit, static_argnums=(1, 2))
+def _one_sided_maxwell(key, shape, dtype):
+  shape = shape + (3,)
+  norm_rvs = normal(key=key, shape=shape, dtype=dtype)
+  return jnp.linalg.norm(norm_rvs, axis=-1)
+
+
+def double_sided_maxwell(key, loc, scale, shape=(), dtype=dtypes.float_):
+  """Sample from a double sided Maxwell distribution.
+
+  Samples using:
+     loc + scale* sgn(U-0.5)* one_sided_maxwell U~Unif;
+
+  Args:
+    key: a PRNGKey key.
+    loc: The location parameter of the distribution.
+    scale: The scale parameter of the distribution.
+    shape: The shape added to the parameters loc and scale broadcastable shape.
+    dtype: The type used for samples.
+
+  Returns:
+    A jnp.array of samples.
+
+  """
+  if not dtypes.issubdtype(dtype, np.floating):
+    raise ValueError(f"dtype argument to `double_sided_maxwell` must be a float"
+                     f" dtype, got {dtype}")
+  dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
+  return _double_sided_maxwell(key, loc, scale, shape, dtype)
+
+
+@partial(jit, static_argnums=(1, 2, 3, 4))
+def _double_sided_maxwell(key, loc, scale, shape, dtype):
+  params_shapes = lax.broadcast_shapes(np.shape(loc), np.shape(scale))
+  if not shape:
+    shape = params_shapes
+
+  shape = shape + params_shapes
+  maxwell_key, rademacher_key = split(key)
+  maxwell_rvs = one_sided_maxwell(maxwell_key, shape=shape, dtype=dtype)
+  # Generate random signs for the symmetric variates.
+  random_sign = rademacher(rademacher_key, shape=shape, dtype=dtype)
+  assert random_sign.shape == maxwell_rvs.shape
+
+  return random_sign * maxwell_rvs * scale + loc
+
+
+def weibull_min(key, scale, concentration, shape=(), dtype=dtypes.float_):
+  """Sample from a Weibull distribution.
+
+  The scipy counterpart is `scipy.stats.weibull_min`.
+
+  Args:
+    key: a PRNGKey key.
+    scale: The scale parameter of the distribution.
+    concentration: The concentration parameter of the distribution.
+    shape: The shape added to the parameters loc and scale broadcastable shape.
+    dtype: The type used for samples.
+
+  Returns:
+    A jnp.array of samples.
+
+  """
+  if not dtypes.issubdtype(dtype, np.floating):
+    raise ValueError(f"dtype argument to `weibull_min` must be a float "
+                     f"dtype, got {dtype}")
+  dtype = dtypes.canonicalize_dtype(dtype)
+  shape = abstract_arrays.canonicalize_shape(shape)
+  return _weibull_min(key, scale, concentration, shape, dtype)
+
+
+@partial(jit, static_argnums=(1, 2, 3, 4))
+def _weibull_min(key, scale, concentration, shape, dtype):
+  random_uniform = uniform(
+      key=key, shape=shape, minval=0, maxval=1, dtype=dtype)
+
+  # Inverse weibull CDF.
+  return jnp.power(-jnp.log1p(-random_uniform), 1.0/concentration) * scale

--- a/jax/random.py
+++ b/jax/random.py
@@ -1376,7 +1376,7 @@ def _rademacher(key, shape, dtype):
   return (2 * random_bernoulli - 1).astype(dtype)
 
 
-def one_sided_maxwell(key, shape=(), dtype=dtypes.float_):
+def maxwell(key, shape=(), dtype=dtypes.float_):
   """Sample from a one sided Maxwell distribution.
 
   The scipy counterpart is `scipy.stats.maxwell`.
@@ -1393,15 +1393,15 @@ def one_sided_maxwell(key, shape=(), dtype=dtypes.float_):
   # Generate samples using:
   # sqrt(X^2 + Y^2 + Z^2), X,Y,Z ~N(0,1)
   if not dtypes.issubdtype(dtype, np.floating):
-    raise ValueError(f"dtype argument to `one_sided_maxwell` must be a float "
+    raise ValueError(f"dtype argument to `maxwell` must be a float "
                      f"dtype, got {dtype}")
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = abstract_arrays.canonicalize_shape(shape)
-  return _one_sided_maxwell(key, shape, dtype)
+  return _maxwell(key, shape, dtype)
 
 
 @partial(jit, static_argnums=(1, 2))
-def _one_sided_maxwell(key, shape, dtype):
+def _maxwell(key, shape, dtype):
   shape = shape + (3,)
   norm_rvs = normal(key=key, shape=shape, dtype=dtype)
   return jnp.linalg.norm(norm_rvs, axis=-1)
@@ -1440,7 +1440,7 @@ def _double_sided_maxwell(key, loc, scale, shape, dtype):
 
   shape = shape + params_shapes
   maxwell_key, rademacher_key = split(key)
-  maxwell_rvs = one_sided_maxwell(maxwell_key, shape=shape, dtype=dtype)
+  maxwell_rvs = maxwell(maxwell_key, shape=shape, dtype=dtype)
   # Generate random signs for the symmetric variates.
   random_sign = rademacher(rademacher_key, shape=shape, dtype=dtype)
   assert random_sign.shape == maxwell_rvs.shape

--- a/jax/random.py
+++ b/jax/random.py
@@ -1371,9 +1371,8 @@ def rademacher(key, shape, dtype=dtypes.int_):
 
 @partial(jit, static_argnums=(1, 2))
 def _rademacher(key, shape, dtype):
-  random_bernoulli = categorical(
-      key=key, logits=jnp.array([0.5, 0.5]), shape=shape)
-  return (2 * random_bernoulli - 1).astype(dtype)
+  bernoulli_samples = bernoulli(key=key, p=0.5, shape=shape)
+  return (2 * bernoulli_samples - 1).astype(dtype)
 
 
 def maxwell(key, shape=(), dtype=dtypes.float_):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -743,6 +743,111 @@ class LaxRandomTest(jtu.JaxTestCase):
     x = random.randint(key, shape, jnp.array([0, 1]), jnp.array([1, 2]))
     assert x.shape == shape
 
+  def testOneSidedMaxwellSample(self):
+    num_samples = 10**5
+    rng = random.PRNGKey(0)
+
+    rand = lambda x: random.one_sided_maxwell(x, (num_samples, ))
+    crand = api.jit(rand)
+
+    loc = scipy.stats.maxwell.mean()
+    std = scipy.stats.maxwell.std()
+
+    uncompiled_samples = rand(rng)
+    compiled_samples = crand(rng)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      # Check first and second moments.
+      self.assertEqual((num_samples,), samples.shape)
+      self.assertAllClose(np.mean(samples), loc, atol=0., rtol=0.1)
+      self.assertAllClose(np.std(samples), std, atol=0., rtol=0.1)
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.maxwell().cdf)
+
+  @parameterized.named_parameters(
+      ('test1', 4.0, 1.0),
+      ('test2', 2.0, 3.0))
+  def testWeibullSample(self, concentration, scale):
+    num_samples = 10**5
+    rng = random.PRNGKey(0)
+
+    rand = lambda x: random.weibull_min(x, scale, concentration, (num_samples,))
+    crand = api.jit(rand)
+
+    loc = scipy.stats.weibull_min.mean(c=concentration, scale=scale)
+    std = scipy.stats.weibull_min.std(c=concentration, scale=scale)
+
+    uncompiled_samples = rand(rng)
+    compiled_samples = crand(rng)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      # Check first and second moments.
+      self.assertEqual((num_samples,), samples.shape)
+      self.assertAllClose(np.mean(samples), loc, atol=0., rtol=0.1)
+      self.assertAllClose(np.std(samples), std, atol=0., rtol=0.1)
+      self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.weibull_min(
+          c=concentration, scale=scale).cdf)
+
+  @parameterized.named_parameters(
+      ('test1', 4.0, 1.0),
+      ('test2', 2.0, 3.0))
+  def testDoublesidedMaxwellSample(self, loc, scale):
+    num_samples = 10**5
+    rng = random.PRNGKey(0)
+
+    rand = lambda key: random.double_sided_maxwell(
+        rng, loc, scale, (num_samples,))
+    crand = api.jit(rand)
+
+    mean = loc
+    std = np.sqrt(3.) * scale
+
+    uncompiled_samples = rand(rng)
+    compiled_samples = crand(rng)
+
+    # Compute the double sided maxwell CDF through the one sided maxwell cdf.
+    # This is done as follows:
+    # P(DSM <= x) = P (loc + scale * radamacher_sample * one_sided_sample <=x) =
+    # P (radamacher_sample * one_sided_sample <= (x - loc) / scale) =
+    # 1/2 P(one_sided_sample <= (x - loc) / scale)
+    #    + 1/2 P( - one_sided_sample <= (x - loc) / scale) =
+    #  1/2 P(one_sided_sample <= (x - loc) / scale)
+    #    + 1/2 P(one_sided_sample >= - (x - loc) / scale) =
+    # 1/2 CDF_one_maxwell((x - loc) / scale))
+    #   + 1/2 (1 - CDF_one_maxwell(- (x - loc) / scale)))
+    def double_sided_maxwell_cdf(x, loc, scale):
+      pos = scipy.stats.maxwell().cdf((x - loc)/ scale)
+      neg = (1 - scipy.stats.maxwell().cdf((-x + loc)/ scale))
+      return (pos + neg) / 2
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      # Check first and second moments.
+      self.assertEqual((num_samples,), samples.shape)
+      self.assertAllClose(np.mean(samples), mean, atol=0., rtol=0.1)
+      self.assertAllClose(np.std(samples), std, atol=0., rtol=0.1)
+
+      self._CheckKolmogorovSmirnovCDF(
+          samples, lambda x: double_sided_maxwell_cdf(x, loc, scale))
+
+  def testRadamacher(self):
+    rng = random.PRNGKey(0)
+    num_samples = 10**5
+
+    rand = lambda x: random.rademacher(x, (num_samples,))
+    crand = api.jit(rand)
+
+    uncompiled_samples = rand(rng)
+    compiled_samples = crand(rng)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      unique_values, counts = np.unique(samples, return_counts=True)
+      assert len(unique_values) == 2
+      assert len(counts) == 2
+
+      self.assertAllClose(
+          counts[0]/ num_samples, 0.5, rtol=1e-03, atol=1e-03)
+      self.assertAllClose(
+          counts[1]/ num_samples, 0.5, rtol=1e-03, atol=1e-03)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -844,9 +844,9 @@ class LaxRandomTest(jtu.JaxTestCase):
       assert len(counts) == 2
 
       self.assertAllClose(
-          counts[0]/ num_samples, 0.5, rtol=1e-03, atol=1e-03)
+          counts[0]/ num_samples, 0.5, rtol=1e-02, atol=1e-02)
       self.assertAllClose(
-          counts[1]/ num_samples, 0.5, rtol=1e-03, atol=1e-03)
+          counts[1]/ num_samples, 0.5, rtol=1e-02, atol=1e-02)
 
 
 if __name__ == "__main__":

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -743,11 +743,11 @@ class LaxRandomTest(jtu.JaxTestCase):
     x = random.randint(key, shape, jnp.array([0, 1]), jnp.array([1, 2]))
     assert x.shape == shape
 
-  def testOneSidedMaxwellSample(self):
+  def testMaxwellSample(self):
     num_samples = 10**5
     rng = random.PRNGKey(0)
 
-    rand = lambda x: random.one_sided_maxwell(x, (num_samples, ))
+    rand = lambda x: random.maxwell(x, (num_samples, ))
     crand = api.jit(rand)
 
     loc = scipy.stats.maxwell.mean()


### PR DESCRIPTION
Implement sampling for the Rademacher, Maxwell, Double Sided Maxwell and Weibull distributions. The Maxwell and Weibull distributions correspond to their `scipy.stats` counterparts (`maxwell` and `weibull_min`). 

Tests for the samplers are added in `random_test`. Tests are done by checking moments as well as the Kolmogorov-Smirnov test by checking correspondence with `scipy.stats` for 'maxwell` and `weibull_min`. For the `double_sided_maxwell`, the cdf is implemented manually in the test, as a function of the `maxwell` CDF provided in `scipy.stats`.