### PR TITLE
Add a boolean to _check_shapelike to accept or reject shapes

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -4741,8 +4741,10 @@ def _reduce_window_chooser_jvp_rule(prim, g, operand, *, window_dimensions,
 def _common_reduce_window_shape_rule(operand, window_dimensions,
                                      window_strides, padding, base_dilation,
                                      window_dilation):
-  _check_shapelike("reduce_window", "window_dimensions", window_dimensions)
-  _check_shapelike("reduce_window", "window_strides", window_strides)
+  _check_shapelike("reduce_window", "window_dimensions", window_dimensions,
+                   non_zero_shape=True)
+  _check_shapelike("reduce_window", "window_strides", window_strides,
+                   non_zero_shape=True)
   _check_shapelike("reduce_window", "base_dilation", base_dilation)
   _check_shapelike("reduce_window", "window_dilation", window_dilation)
   if operand.ndim != len(window_dimensions):
@@ -5723,7 +5725,7 @@ def conv_transpose_shape_tuple(lhs_shape, rhs_shape, window_strides, padding,
   return tuple(np.take(out_trans, np.argsort(out_perm)))
 
 
-def _check_shapelike(fun_name, arg_name, obj):
+def _check_shapelike(fun_name, arg_name, obj, non_zero_shape=False):
   """Check that `obj` is a shape-like value (e.g. tuple of nonnegative ints)."""
   if not isinstance(obj, (tuple, list, np.ndarray)):
     msg = "{} {} must be of type tuple/list/ndarray, got {}."
@@ -5740,9 +5742,11 @@ def _check_shapelike(fun_name, arg_name, obj):
   except TypeError:
     msg = "{} {} must have every element be an integer type, got {}."
     raise TypeError(msg.format(fun_name, arg_name, tuple(map(type, obj))))
-  if not (obj_arr >= 0).all():
-    msg = "{} {} must have every element be nonnegative, got {}."
-    raise TypeError(msg.format(fun_name, arg_name, obj))
+  lower_bound, bound_error = (
+      (1, "strictly positive") if non_zero_shape else (0, "nonnegative"))
+  if not (obj_arr >= lower_bound).all():
+    msg = "{} {} must have every element be {}, got {}."
+    raise TypeError(msg.format(fun_name, arg_name, bound_error, obj))
 
 
 def _dynamic_slice_indices(operand, start_indices):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1368,7 +1368,8 @@ class LaxTest(jtu.JaxTestCase):
                                window_dimensions=(1,), window_strides=(0,))
 
     for failure_fun in [empty_window_test, zero_stride_test]:
-      self.assertRaisesRegex(TypeError, "must have every element be")
+      with self.assertRaisesRegex(TypeError, "must have every element be"):
+        failure_fun()
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}"

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1358,6 +1358,18 @@ class LaxTest(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CompileAndCheck(fun, args_maker)
 
+  def testReduceWindowFailures(self):
+    def empty_window_test():
+      return lax.reduce_window(np.ones((1,)), 0., lax.add, padding='VALID',
+                               window_dimensions=(0,), window_strides=(1,))
+
+    def zero_stride_test():
+      return lax.reduce_window(np.ones((1,)), 0., lax.add, padding='VALID',
+                               window_dimensions=(1,), window_strides=(0,))
+
+    for failure_fun in [empty_window_test, zero_stride_test]:
+      self.assertRaisesRegex(TypeError, "must have every element be")
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}"
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis),


### PR DESCRIPTION
corresponding to arrays of 0 elements. (Fixes google/jax#3972).

[The corresponding XLA shape checking function](https://github.com/tensorflow/tensorflow/blob/73b40908a4998c368c741188acbfc16d18c7b709/tensorflow/compiler/xla/service/shape_inference.cc#L172:L181) checks that all the elements of `window_strides` and `window_dimensions` are strictly positive. This should therefore also be enforced on our end.