### PR TITLE
Fixes padding generation for padding == 'SAME' in reduce_window to

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1143,7 +1143,9 @@ def reduce_window(operand: Array, init_value: Array, computation: Callable,
   operator.
   """
   if isinstance(padding, str):
-    padding = tuple(padtype_to_pads(operand.shape, window_dimensions,
+    dilated_window_dims = (window_dimensions if window_dilation is None else
+                           _dilate_shape(window_dimensions, window_dilation))
+    padding = tuple(padtype_to_pads(operand.shape, dilated_window_dims,
                                     window_strides, padding))
   else:
     padding = tuple(padding)


### PR DESCRIPTION
take window_dilation into account. (Fixes google/jax#3973).

This commit applies the fix suggested by James on the issue,
which is backed by the meaning of padding described on
https://www.tensorflow.org/xla/operation_semantics#reducewindow.