### PR TITLE
Add support for negative axes to vmap.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1024,22 +1024,21 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
     fun: Function to be mapped over additional axes.
     in_axes: An integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof specifying which input array axes to map over.
+
       If each positional argument to ``fun`` is an array, then ``in_axes`` can
       be an integer, a None, or a tuple of integers and Nones with
       length equal to the number of positional arguments to ``fun``.
-
       An integer or ``None`` indicates which array axis to map over for all
-      arguments (with
-      None indicating not to map any axis), and a tuple indicates which axis to
-      map for each corresponding positional argument. Axis integers must be
-      in the range ``[-ndim, ndim)`` for each array, where ``ndim`` is the
-      number of dimensions of the corresponding input array.
+      arguments (with ``None`` indicating not to map any axis), and a tuple
+      indicates which axis to map for each corresponding positional argument.
+      Axis integers must be in the range ``[-ndim, ndim)`` for each array, where
+      ``ndim`` is the number of dimensions of the corresponding input array.
 
-      If the positional
-      arguments to ``fun`` are container types, the corresponding element of
-      ``in_axes`` can itself be a matching container, so that distinct array
-      axes can be mapped for different container elements. ``in_axes`` must be a
-      container tree prefix of the positional argument tuple passed to ``fun``.
+      If the positional arguments to ``fun`` are container types, the
+      corresponding element of ``in_axes`` can itself be a matching container,
+      so that distinct array axes can be mapped for different container
+      elements. ``in_axes`` must be a container tree prefix of the positional
+      argument tuple passed to ``fun``.
 
       At least one positional argument must have ``in_axes`` not None. The sizes
       of the mapped input axes for all mapped positional arguments must all

--- a/jax/api.py
+++ b/jax/api.py
@@ -1144,12 +1144,6 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
     msg = ("vmap out_axes must be an int, None, or (nested) container with "
            "those types as leaves, but got {}.")
     raise TypeError(msg.format(out_axes))
-  if any(l < 0 for l in in_axes_ if l is not batching.last):
-    msg = "vmap in_axes leaves must be non-negative integers or None, but got {}."
-    raise TypeError(msg.format(in_axes))
-  if any(l < 0 for l in out_axes_ if l is not batching.last):
-    msg = "vmap out_axes leaves must be non-negative integers or None, but got {}."
-    raise TypeError(msg.format(out_axes))
   del in_axes_, out_axes_
 
   @wraps(fun, docstr=docstr)

--- a/jax/api.py
+++ b/jax/api.py
@@ -1049,7 +1049,9 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
       in the output. All outputs with a mapped axis must have a non-None
       ``out_axes`` specification. Axis integers must be
       in the range ``[-ndim, ndim)`` for each output array, where ``ndim`` is
-      the number of dimensions of the output array.
+      the number of dimensions of the array returned by the :func:`vmap`-ed
+      function, which is one more than the number of dimensions of the
+      corresponding array returned by ``fun``.
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to

--- a/jax/api.py
+++ b/jax/api.py
@@ -1022,14 +1022,20 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
 
   Args:
     fun: Function to be mapped over additional axes.
-    in_axes: A non-negative integer, None, or (nested) standard Python container
+    in_axes: An integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof specifying which input array axes to map over.
       If each positional argument to ``fun`` is an array, then ``in_axes`` can
-      be a non-negative integer, a None, or a tuple of integers and Nones with
-      length equal to the number of positional arguments to ``fun``. An integer
-      or None indicates which array axis to map over for all arguments (with
+      be an integer, a None, or a tuple of integers and Nones with
+      length equal to the number of positional arguments to ``fun``.
+
+      An integer or ``None`` indicates which array axis to map over for all
+      arguments (with
       None indicating not to map any axis), and a tuple indicates which axis to
-      map for each corresponding positional argument. If the positional
+      map for each corresponding positional argument. Axis integers must be
+      in the range ``[-ndim, ndim)`` for each array, where ``ndim`` is the
+      number of dimensions of the corresponding input array.
+
+      If the positional
       arguments to ``fun`` are container types, the corresponding element of
       ``in_axes`` can itself be a matching container, so that distinct array
       axes can be mapped for different container elements. ``in_axes`` must be a
@@ -1039,10 +1045,12 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
       of the mapped input axes for all mapped positional arguments must all
       be equal.
 
-    out_axes: A non-negative integer, None, or (nested) standard Python container
+    out_axes: An integer, None, or (nested) standard Python container
       (tuple/list/dict) thereof indicating where the mapped axis should appear
       in the output. All outputs with a mapped axis must have a non-None
-      ``out_axes`` specification.
+      ``out_axes`` specification. Axis integers must be
+      in the range ``[-ndim, ndim)`` for each output array, where ``ndim`` is
+      the number of dimensions of the output array.
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -353,7 +353,8 @@ def matchaxis(sz, src, dst, x, sum_match=False):
   elif type(src) == int and dst is last:
     return moveaxis(x, src, -1)
   elif src is not_mapped and dst is not not_mapped:
-    return broadcast(x, sz, canonicalize_axis(dst, np.ndim(x) + 1))
+    return broadcast(
+      x, sz, canonicalize_axis(dst, np.ndim(x) + 1) if dst is not last else dst)
   elif dst is None and sum_match:
     return x.sum(src)
   else:

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -338,7 +338,9 @@ def moveaxis(x, src, dst):
     return core.unit
   if src == dst:
     return x
-  src, dst = canonicalize_axis(src, x.ndim), canonicalize_axis(dst, x.ndim)
+  src = canonicalize_axis(src, x.ndim)
+  # TODO(phawkins): replace the `min(...)` clause with `dst` after fixing users.
+  dst = canonicalize_axis(min(dst, x.ndim - 1), x.ndim)
   perm = [i for i in range(np.ndim(x)) if i != src]
   perm.insert(dst, src)
   return x.transpose(perm)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -22,7 +22,8 @@ from ..core import Trace, Tracer
 from ..abstract_arrays import ShapedArray, raise_to_shaped
 from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
 from .. import linear_util as lu
-from ..util import unzip2, partial, safe_map, wrap_name, split_list
+from ..util import (unzip2, partial, safe_map, wrap_name, split_list,
+                    canonicalize_axis)
 from . import xla
 from . import partial_eval as pe
 
@@ -55,6 +56,9 @@ def batch_fun(fun : lu.WrappedFun, in_dims, out_dim_dests, axis_name,
 def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
                *in_vals, **params):
   in_dims = in_dims() if callable(in_dims) else in_dims
+  in_dims = [
+    canonicalize_axis(dim, np.ndim(val)) if isinstance(dim, int) else dim
+    for val, dim in zip(in_vals, in_dims)]
   size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
   with core.new_master(BatchTrace) as master:
     with core.extend_axis_env(axis_name, size, master):
@@ -334,7 +338,7 @@ def moveaxis(x, src, dst):
     return core.unit
   if src == dst:
     return x
-  src, dst = src % x.ndim, dst % x.ndim
+  src, dst = canonicalize_axis(src, x.ndim), canonicalize_axis(dst, x.ndim)
   perm = [i for i in range(np.ndim(x)) if i != src]
   perm.insert(dst, src)
   return x.transpose(perm)
@@ -349,7 +353,7 @@ def matchaxis(sz, src, dst, x, sum_match=False):
   elif type(src) == int and dst is last:
     return moveaxis(x, src, -1)
   elif src is not_mapped and dst is not not_mapped:
-    return broadcast(x, sz, dst)
+    return broadcast(x, sz, canonicalize_axis(dst, np.ndim(x) + 1))
   elif dst is None and sum_match:
     return x.sum(src)
   else:

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -296,7 +296,7 @@ from .lax import (_reduce_sum, _reduce_max, _reduce_min, _reduce_or,
                   _const, _eq_meet, _broadcasting_select,
                   _check_user_dtype_supported, _one, _zero, _const,
                   _upcast_fp16_for_computation, _broadcasting_shape_rule,
-                  _eye, _tri, _delta, _ones, _zeros, _canonicalize_axis)
+                  _eye, _tri, _delta, _ones, _zeros)
 from .lax_control_flow import (
   cond,
   cond_p,

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -39,7 +39,7 @@ from ..interpreters import ad
 from ..interpreters import invertible_ad as iad
 from ..interpreters import batching
 from ..interpreters import masking
-from ..util import cache, safe_zip, partial, prod, safe_map
+from ..util import cache, safe_zip, partial, prod, safe_map, canonicalize_axis
 from ..tree_util import tree_map
 from ..lib import pytree
 from ..lib import xla_bridge
@@ -1340,20 +1340,20 @@ def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
       raise TypeError("Sort requires at least one operand")
     if not (1 <= num_keys <= len(operand)):
       raise ValueError(f"num_keys={num_keys} must be between 1 and len(operand)={len(operand)}")
-    dimension = _canonicalize_axis(dimension, len(operand[0].shape))
+    dimension = canonicalize_axis(dimension, len(operand[0].shape))
     return tuple(sort_p.bind(*operand, dimension=dimension,
                              is_stable=is_stable,
                              num_keys=num_keys))
   else:
     if num_keys != 1:
       raise ValueError(f"num_keys={num_keys} must equal 1 for a single operand.")
-    dimension = _canonicalize_axis(dimension, len(operand.shape))
+    dimension = canonicalize_axis(dimension, len(operand.shape))
     return sort_p.bind(operand, dimension=dimension, is_stable=is_stable, num_keys=1)[0]
 
 def sort_key_val(keys: Array, values: Array, dimension: int = -1,
                  is_stable: bool = True) -> Tuple[Array, Array]:
   """Sorts ``keys`` along ``dimension`` and applies same permutation to ``values``."""
-  dimension = _canonicalize_axis(dimension, len(keys.shape))
+  dimension = canonicalize_axis(dimension, len(keys.shape))
   k, v = sort_p.bind(keys, values, dimension=dimension, is_stable=is_stable, num_keys=1)
   return k, v
 
@@ -3269,7 +3269,7 @@ masking.masking_rules[pad_p] = _pad_masking_rule
 def squeeze(array: Array, dimensions: Tuple[int, ...]) -> Array:
   """Squeeze any number of size 1 dimensions from an array."""
   ndim = np.ndim(array)
-  dimensions = tuple(sorted(_canonicalize_axis(i, ndim) for i in dimensions))
+  dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
   if not dimensions:
     return array
   return squeeze_p.bind(array, dimensions=dimensions)
@@ -3316,7 +3316,7 @@ batching.primitive_batchers[squeeze_p] = _squeeze_batch_rule
 def expand_dims(array: Array, dimensions: Tuple[int, ...]) -> Array:
   """Insert any number of size 1 dimensions into an array."""
   ndim_out = np.ndim(array) + len(dimensions)
-  dims_set = frozenset(_canonicalize_axis(i, ndim_out) for i in dimensions)
+  dims_set = frozenset(canonicalize_axis(i, ndim_out) for i in dimensions)
   result_shape = list(np.shape(array))
   for i in sorted(dims_set):
     result_shape.insert(i, 1)
@@ -5953,18 +5953,6 @@ def _check_user_dtype_supported(dtype, fun_name=None):
     fun_name = "requested in {}".format(fun_name) if fun_name else ""
     truncated_dtype = dtypes.canonicalize_dtype(dtype).name
     warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
-
-
-def _canonicalize_axis(axis, num_dims):
-  """Canonicalize an axis in [-num_dims, num_dims) to [0, num_dims)."""
-  axis = operator.index(axis)
-  if not -num_dims <= axis < num_dims:
-      raise ValueError(
-          "axis {} is out of bounds for array of dimension {}".format(
-              axis, num_dims))
-  if axis < 0:
-    axis = axis + num_dims
-  return axis
 
 
 @config.omnistaging_enablers.append

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -50,7 +50,7 @@ from .. import lax
 from ..lax.lax import _device_put_raw
 from .. import ops
 from ..util import (partial, unzip2, prod as _prod,
-                    subvals, safe_zip)
+                    subvals, safe_zip, canonicalize_axis as _canonicalize_axis)
 from ..tree_util import tree_leaves, tree_flatten
 
 FLAGS = flags.FLAGS
@@ -203,8 +203,6 @@ load = np.load
 
 
 ### utility functions
-
-_canonicalize_axis = lax._canonicalize_axis
 
 _DEFAULT_TYPEMAP = {
   np.bool_: bool_,

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -29,7 +29,7 @@ from .lax_numpy import _not_implemented
 from ._util import _wraps
 from .vectorize import vectorize
 from . import lax_numpy as jnp
-from ..util import get_module_functions
+from ..util import get_module_functions, canonicalize_axis
 from ..third_party.numpy.linalg import cond, multi_dot, tensorinv, tensorsolve # noqa: F401
 
 _T = lambda x: jnp.swapaxes(x, -1, -2)
@@ -351,9 +351,9 @@ def _norm(x, ord, axis: Union[None, Tuple[int, ...], int], keepdims):
       return jnp.sqrt(jnp.sum(jnp.real(x * jnp.conj(x)), keepdims=keepdims))
     axis = tuple(range(ndim))
   elif isinstance(axis, tuple):
-    axis = tuple(jnp._canonicalize_axis(x, ndim) for x in axis)
+    axis = tuple(canonicalize_axis(x, ndim) for x in axis)
   else:
-    axis = (jnp._canonicalize_axis(axis, ndim),)
+    axis = (canonicalize_axis(axis, ndim),)
 
   num_axes = len(axis)
   if num_axes == 1:

--- a/jax/util.py
+++ b/jax/util.py
@@ -15,6 +15,7 @@
 
 import functools
 import itertools as it
+import operator
 import types
 
 import numpy as np
@@ -242,3 +243,14 @@ def wrap_name(name, transform_name):
 
 def extend_name_stack(stack, name=''):
   return stack + name + '/'
+
+def canonicalize_axis(axis, num_dims):
+  """Canonicalize an axis in [-num_dims, num_dims) to [0, num_dims)."""
+  axis = operator.index(axis)
+  if not -num_dims <= axis < num_dims:
+      raise ValueError(
+          "axis {} is out of bounds for array of dimension {}".format(
+              axis, num_dims))
+  if axis < 0:
+    axis = axis + num_dims
+  return axis

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1020,7 +1020,6 @@ class BatchingTest(jtu.JaxTestCase):
 
 
   def testNegativeAxes(self):
-    rng = jtu.rand_default(self.rng())
     x = np.arange(3*4*5).reshape(3, 4, 5)
     self.assertAllClose(jax.vmap(jnp.sum, in_axes=-3)(x),
                         jnp.sum(x, axis=(1, 2)))

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1018,5 +1018,39 @@ class BatchingTest(jtu.JaxTestCase):
         vmap(lambda x: x - lax.ppermute(x, 'i', perm_pairs)[0], axis_name='i')(x),
         x - x[perm])
 
+
+  def testNegativeAxes(self):
+    rng = jtu.rand_default(self.rng())
+    x = np.arange(3*4*5).reshape(3, 4, 5)
+    self.assertAllClose(jax.vmap(jnp.sum, in_axes=-3)(x),
+                        jnp.sum(x, axis=(1, 2)))
+    self.assertAllClose(jax.vmap(jnp.sum, in_axes=-2)(x),
+                        jnp.sum(x, axis=(0, 2)))
+    self.assertAllClose(jax.vmap(jnp.sum, in_axes=-1)(x),
+                        jnp.sum(x, axis=(0, 1)))
+
+    with self.assertRaisesRegex(ValueError, "vmap got arg 0 of rank 3 but axis to be mapped -4"):
+      jax.vmap(jnp.sum, in_axes=-4)(x)
+
+    id = lambda y: y
+    self.assertAllClose(x, jax.vmap(id, in_axes=0, out_axes=-3)(x))
+    self.assertAllClose(x.transpose(1, 0, 2),
+                        jax.vmap(id, in_axes=0, out_axes=-2)(x))
+    self.assertAllClose(x.transpose(1, 2, 0),
+                        jax.vmap(id, in_axes=0, out_axes=-1)(x))
+
+    with self.assertRaisesRegex(ValueError, "axis -4 is out of bounds.*"):
+      jax.vmap(id, in_axes=0, out_axes=-4)(x)
+
+    self.assertAllClose(
+      np.full((5,), 7),
+      jax.vmap(lambda *xs: xs, in_axes=(0, None), out_axes=(0, -1))(
+        np.arange(5), 7)[1])
+
+    with self.assertRaisesRegex(ValueError, "axis -2 is out of bounds.*"):
+      jax.vmap(lambda *xs: xs, in_axes=(0, None), out_axes=(0, -2))(
+        np.arange(5), 7)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
In a subsequent change, we could also probably remove `batching.last` in favor of `-1`, although I did not make that change in this PR.