### PR TITLE
Support overriding implementations of JAX functions within a scope

### DIFF
--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -17,3 +17,4 @@ jax.experimental package
 
 .. autofunction:: enable_x64
 .. autofunction:: disable_x64
+.. autofunction:: override_context

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -945,7 +945,7 @@ def _lu_pivots_body_fn(i, permutation_and_swaps):
   return ops.index_update(permutation, ops.index[iotas + (j,)], x), swaps
 
 
-@partial(api.jit, static_argnums=(1,))
+@partial(api.jit, static_argnums=(1,))  # type: ignore
 def lu_pivots_to_permutation(swaps, m):
   """Converts the pivots (row swaps) returned by LU to a permutation.
 
@@ -991,7 +991,7 @@ def _lu_solve_core(lu, permutation, b, trans):
   return lax.reshape(x, b.shape)
 
 
-@partial(api.jit, static_argnums=(3,))
+@partial(api.jit, static_argnums=(3,))  # type: ignore
 def _lu_solve(lu, permutation, b, trans):
   if len(lu.shape) < 2 or lu.shape[-1] != lu.shape[-2]:
     raise ValueError("last two dimensions of LU decomposition must be equal, "

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -449,9 +449,10 @@ def override_context(implementations: Mapping[str, Callable]):
   and hence is thread-safe.
 
   Currently supported functions:
-  checkpoint, grad, hessian, jacfwd, jacrev, jit, jvp, lax.associative_scan,
-  lax.cond, lax.fori_loop, lax.scan, lax.switch, lax.while_loop,
-  linear_transpose, linearize, named_call, pmap, value_and_grad, vjp, vmap
+  checkpoint, eval_shape, grad, hessian, invertible, jacfwd, jacrev, jit, jvp,
+  lax.associative_scan, lax.cond, lax.fori_loop, lax.scan, lax.switch,
+  lax.while_loop, linear_transpose, linearize, named_call, pmap, value_and_grad,
+  vjp, vmap
   """
   tokens = {k: _OVERRIDES[k].set(v) for k, v in implementations.items()}
   try:

--- a/jax/api.py
+++ b/jax/api.py
@@ -2273,6 +2273,8 @@ class ShapeDtypeStruct:
   def __hash__(self):
     return hash((self.shape, self.dtype))
 
+
+@overrideable('eval_shape')
 def eval_shape(fun: Callable, *args, **kwargs):
   """Compute the shape/dtype of ``fun`` without any FLOPs.
 
@@ -2623,6 +2625,7 @@ def defvjp(fun, *vjprules):
     return ans, vjpfun
   defvjp_all(fun, custom_vjp)
 
+@overrideable('invertible')
 def invertible(fun: Callable) -> Callable:
   """Asserts that the decorated function is invertible.
 

--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -16,3 +16,4 @@
 from ..interpreters.sharded_jit import (sharded_jit, PartitionSpec,
                                         with_sharding_constraint)
 from .x64_context import enable_x64, disable_x64
+from .._src.util import override_context

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5018,5 +5018,31 @@ class NamedCallTest(jtu.JaxTestCase):
     self.assertEqual(out, 5)
 
 
+class _CountedCalls:
+  def __init__(self, fun):
+    self.fun = fun
+    self.calls = 0
+  def __call__(self, *args, **kwargs):
+    self.calls += 1
+    return self.fun(*args, **kwargs)
+
+
+class OverrideTest(jtu.JaxTestCase):
+
+  def test(self):
+
+    counted_jit = _CountedCalls(jax.jit)
+
+    jax.jit(lambda x: x)(1)
+    self.assertEqual(counted_jit.calls, 0)
+
+    with jax.experimental.override_context({'jit': counted_jit}):
+      jax.jit(lambda x: x)(1)
+    self.assertEqual(counted_jit.calls, 1)
+
+    jax.jit(lambda x: x)(1)
+    self.assertEqual(counted_jit.calls, 1)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
The idea here is to support overriding the implementation of higher order JAX
functions within a limited scope, for libraries such as Haiku and Flax that
implement their own versions of this functions that support mutation.

Usage example:

    with jax.override_context({'lax.scan': my_scan}):
      # all calls to lax.scan() are replaced by my_scan()
      ...

Ultimately, it would be great to replace this with a unified interface for
mutable state in JAX, but this could be a convenient temporary measure.