### PR TITLE
rm padded env from masking.py

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1218,6 +1218,7 @@ def scan(f, init, xs, length=None, reverse=False, unroll=1):
              "leading axis sizes {}.")
       raise ValueError(msg.format(length, [x.shape[0] for x in xs_flat]))
   else:
+    lengths = [getattr(l, 'logical', l) for l in lengths]
     unique_lengths = set(lengths)
     if len(unique_lengths) > 1:
       msg = "scan got values with different leading axis sizes: {}."
@@ -1824,7 +1825,7 @@ def _scan_typecheck(bind_time, *avals, reverse, length, num_consts, num_carry,
 def scan_bind(*args, **params):
   if not core.skip_checks:
     avals = _map(core.get_aval, args)
-    _scan_typecheck(True, *avals, **params)
+    _scan_typecheck(True, *_map(masking.logical_aval, avals), **params)
     core.check_jaxpr(params['jaxpr'].jaxpr)
   return core.Primitive.bind(scan_p, *args, **params)
 


### PR DESCRIPTION
I observed whilst working on https://github.com/google/jax/pull/4046 that it might be convenient to get rid of padded_env, and instead pair up (evaluated) padded axis sizes with (unevaluated) polynomial axis sizes and propagate them together. Something like this is necessary to do shapecheck(pmap), since abstract_eval(pmap) requires knowledge of the physical (padded) shape of inputs, and masking envs aren't available because we're not MaskTracing during a shapecheck. Keeping padded and polynomial axis sizes paired up also allows us to have a unified axis_env in jax.core, which will simplify https://github.com/google/jax/pull/4046.

Furthermore, this change actually makes masking more flexible! This is because physical axis sizes no longer need to be in the subset of integers which are possible values of the polynomial axis size. To emphasize this, I've named the class which holds the logical and padded values together [`AxisConstraint`](https://github.com/google/jax/compare/master...j-towns:rm-padded-env?expand=1#diff-800398f0bb289f4261c71ba0a0cbb403R227). Note the `AxisConstraint.__repr__` method which makes the meaning explicit:
```python
def __repr__(self):
  return '0 ≤ ' + str(self.logical) + ' ≤ ' + str(self.padded)
```
During mask tracing, shapes can be a mixture of `int` and `AxisConstraint` elements, so if you print an array's shape while masking you might see something like this:
```
(2, 3, 0 ≤ m * n + 1 ≤ 7)
```
I propose that we generalize shape rules to avals with `AxisConstraint` shape dimensions by propagating the logical (polynomial) values as before, and deciding on output constraint padded values by doing _constraint inference_, i.e. finding an output padded value such that the output constraint is implied by the input constraints. This makes it straightforward for us to specify a correctness guarantee which we can offer: if the user supplies values which satisfy the constraints on a function's inputs, we guarantee that all of the rest of the constraints in the function will be satisfied (or we raise an Exception). In particular, we guarantee that there will never be 'overflow' where a logical size is too big for a padded size, or 'underflow' where a logical size is negative.

It also enables us to support things like addition of two values with _different_ padded sizes, as long as they have the same logical size. The shape rule for a primitive `add_vectors` might look something like this (imagining that we're able to pattern match constraints):
```python
def add_vectors_shape_rule(c1, c2):
  (0 ≤ l1 ≤ p1) = c1
  (0 ≤ l2 ≤ p2) = c2
  if l1 == l2:
    return 0 ≤ l1 ≤ min(p1, p2)
  else:
    raise ShapeError
```
This pr is the beginning of an implementation of the above idea, to test the water and get some feedback. WDYT @mattjj? Is this completely insane?