### PR TITLE
Doc: change suggested way of starting the profiler

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -37,11 +37,13 @@ from a running program.
 
    ```python
    import jax.profiler
-   jax.profiler.start_server(9999)
+   server = jax.profiler.start_server(9999)
    ```
 
     This starts the profiler server that TensorBoard connects to. The profiler
-    server must be running before you move on to the next step.
+    server must be running before you move on to the next step. It will remain
+    alive and listening until the object returned by `start_server()` is 
+    destroyed.
 
     If you'd like to profile a snippet of a long-running program (e.g. a long
     training loop), you can put this at the beginning of the program and start


### PR DESCRIPTION
When using TensorBoard profiler on Google Compute Platform VM, I noticed that
```
import jax.profiler
jax.profiler.start_server(9999)	   
```
results in TensorBoard not "seeing" the profiling server, i.e. displaying "Failed to capture profile: empty trace result." message. This seems to be fixed after simply using:
```
import jax.profiler
server = jax.profiler.start_server(9999)	   
```

Background is that the server is alive as long as the object returned by `jax.profiler.start_server(9999)` is not destroyed and I think without assigning it to a variable that might happen immediately.

This PR aims at changing the suggested way of starting the server as well as making users aware of server's lifetime.