### PR TITLE
only construct one axis_index_p primitive

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1436,7 +1436,7 @@ axis_frame = None
 def omnistaging_enabler() -> None:
   global thread_local_state, call_bind, find_top_trace, initial_style_staging, \
       new_master, reset_trace_state, extend_axis_env, axis_frame, \
-      axis_index, axis_index_p, new_base_master, eval_context, \
+      axis_index, new_base_master, eval_context, \
       TraceStack, TraceState
   del initial_style_staging
 
@@ -1629,5 +1629,5 @@ def omnistaging_enabler() -> None:
     """
     return axis_index_p.bind(axis_name=axis_name)
 
-  axis_index_p = Primitive('axis_index')
-  axis_index_p.def_abstract_eval(lambda *, axis_name: ShapedArray((), np.int32))
+
+axis_index_p = Primitive('axis_index')

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1399,7 +1399,7 @@ def omnistaging_enable() -> None:
 
   soft_pmap_rules[axis_index_p] = _axis_index_soft_pmap_rule  # type: ignore
 
-  axis_index_p.bind = partial(core.Primitive.bind, axis_index_p)
+  axis_index_p.bind = partial(core.Primitive.bind, axis_index_p)  # type: ignore
   axis_index_p.def_abstract_eval(lambda *, axis_name: ShapedArray((), np.int32))
   del xla.translations[axis_index_p]
 

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -37,7 +37,7 @@ from jax.interpreters.pxla import axis_index
 
 xops = xc.ops
 
-pxla.multi_host_supported_collectives.add(pxla.axis_index_p)
+pxla.multi_host_supported_collectives.add(core.axis_index_p)
 
 
 ### parallel traceables


### PR DESCRIPTION
Before this change, there were two versions of `axis_index_p`, one used with omnistaging and one without. But that made bookkeeping hard and buggy. This change defines the axis_index_p primitive in core.py. Some of its rules are still changed when omnistaging is enabled.

cc @trevorcai @skye 