### PR TITLE
Fix scan carry types in gradient of complex ODE

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -276,6 +276,8 @@ def _odeint_rev(func, rtol, atol, mxstep, res, g):
     y_bar, t0_bar, args_bar = carry
     # Compute effect of moving measurement time
     t_bar = jnp.dot(func(ys[i], ts[i], *args), g[i])
+    # `t_bar` should not be complex as it represents time
+    t_bar = lax.convert_element_type(t_bar, t0_bar.dtype)
     t0_bar = t0_bar - t_bar
     # Run augmented system backwards to previous observation
     _, y_bar, t0_bar, args_bar = odeint(

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -31,7 +31,6 @@ import jax.numpy as jnp
 from jax import core
 from jax import dtypes
 from jax import lax
-from jax import ops
 from jax.util import safe_map, safe_zip, cache, split_list
 from jax.api_util import flatten_fun_nokwargs
 from jax.flatten_util import ravel_pytree
@@ -152,9 +151,9 @@ def runge_kutta_step(func, y0, f0, t0, dt):
     ti = t0 + dt * alpha[i-1]
     yi = y0 + dt * jnp.dot(beta[i-1, :], k)
     ft = func(yi, ti)
-    return ops.index_update(k, jax.ops.index[i, :], ft)
+    return k.at[i, :].set(ft)
 
-  k = ops.index_update(jnp.zeros((7, f0.shape[0])), ops.index[0, :], f0)
+  k = jnp.zeros((7, f0.shape[0]), f0.dtype).at[0, :].set(f0)
   k = lax.fori_loop(1, 7, body_fun, k)
 
   y1 = dt * jnp.dot(c_sol, k) + y0
@@ -162,10 +161,16 @@ def runge_kutta_step(func, y0, f0, t0, dt):
   f1 = k[-1]
   return y1, f1, y1_error, k
 
+def abs2(x):
+  if jnp.iscomplexobj(x):
+    return x.real ** 2 + x.imag ** 2
+  else:
+    return x ** 2
+
 def error_ratio(error_estimate, rtol, atol, y0, y1):
   err_tol = atol + rtol * jnp.maximum(jnp.abs(y0), jnp.abs(y1))
   err_ratio = error_estimate / err_tol
-  return jnp.mean(jnp.square(err_ratio))
+  return jnp.mean(abs2(err_ratio))
 
 def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
                       dfactor=0.2, order=5.0):
@@ -275,9 +280,8 @@ def _odeint_rev(func, rtol, atol, mxstep, res, g):
   def scan_fun(carry, i):
     y_bar, t0_bar, args_bar = carry
     # Compute effect of moving measurement time
-    t_bar = jnp.dot(func(ys[i], ts[i], *args), g[i])
     # `t_bar` should not be complex as it represents time
-    t_bar = lax.convert_element_type(t_bar, t0_bar.dtype)
+    t_bar = jnp.dot(func(ys[i], ts[i], *args), g[i]).real
     t0_bar = t0_bar - t_bar
     # Run augmented system backwards to previous observation
     _, y_bar, t0_bar, args_bar = odeint(

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -236,17 +236,18 @@ class ODETest(jtu.JaxTestCase):
   def test_complex_odeint(self):
     # https://github.com/google/jax/issues/3986
 
-    def dy_dt(vals, t):
-      alpha, y = vals
-      return alpha, alpha * y
+    def dy_dt(y, t, alpha):
+      return alpha * y
+
+    def f(y0, ts, alpha):
+      return odeint(dy_dt, y0, ts, alpha).real
 
     alpha = 3 + 4j
     y0 = 1 + 2j
     ts = jnp.linspace(0., 1., 11)
     tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
 
-    integrate = partial(odeint, dy_dt, t=ts)
-    jtu.check_grads(integrate, ([alpha, y0],), modes=["rev"], order=2, atol=tol, rtol=tol)
+    jtu.check_grads(f, (y0, ts, alpha), modes=["rev"], order=2, atol=tol, rtol=tol)
 
 
 if __name__ == '__main__':

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -232,6 +232,22 @@ class ODETest(jtu.JaxTestCase):
 
     jax.grad(f)(jnp.ones(2))  # doesn't crash
 
+  @jtu.skip_on_devices("tpu", "gpu")
+  def test_complex_odeint(self):
+    # https://github.com/google/jax/issues/3986
+
+    def dy_dt(vals, t):
+      alpha, y = vals
+      return alpha, alpha * y
+
+    alpha = 3 + 4j
+    y0 = 1 + 2j
+    ts = jnp.linspace(0., 1., 11)
+    tol = 1e-1 if jtu.num_float_bits(np.float64) == 32 else 1e-3
+
+    integrate = partial(odeint, dy_dt, t=ts)
+    jtu.check_grads(integrate, ([alpha, y0],), modes=["rev"], order=2, atol=tol, rtol=tol)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This pull request fixes issue #3986. The included test case is currently **not** working properly, I am creating this pull request for further discussion.

> To make it slightly more comprehensive, I might suggest also adding a single complex-valued parameter `alpha` with which to differentiate against as well, i.e., testing the ODE `∂y/∂t = α y`.

As @shoyer suggested, I have added a complex-valued `alpha` in the differential equation but this causes the gradient to be wrong:
```python
def dy_dt(vals, t):
  alpha, y = vals
  return alpha, alpha * y
```
The assertion error from `check_grads()` is:
```python
AssertionError:
Not equal to tolerance rtol=0.1, atol=0.1

Mismatched elements: 1 / 1 (100%)
Max absolute difference: 375.89012743
Max relative difference: 0.53135127
x: array(-331.532907)
y: array(-707.42303, dtype=float32)
```
If `alpha` is real or not present in the differential equation the test works and also correctly checks for the problem that was fixed in the first place.

Interestingly enough, everything also works correctly if `alpha` is added to `y`, subtracted from `y`, divided by `y` or dividing `y`. The gradient mismatch only occurs if `alpha` is multiplied with `y`. I am not sure why this might be the case, could there be another bug causing this behavior?