### PR TITLE
Remove frame check assertion in `extend_axis_env`.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1579,8 +1579,7 @@ def omnistaging_enabler() -> None:
     try:
       yield
     finally:
-      frame_ = thread_local_state.trace_state.axis_env.pop()
-      assert frame is frame_
+      thread_local_state.trace_state.axis_env.pop()
 
   def axis_frame(axis_name):
     frames = thread_local_state.trace_state.axis_env


### PR DESCRIPTION
Colab repro: https://colab.research.google.com/drive/18IdjHBcwjJZwZv3bqVPGM9mzYiG_ToXp?usp=sharing

```python
from jax.config import config
config.enable_omnistaging()
import jax
from jax import lax, vmap, pmap
import jax.numpy as jnp

def f(x):
  tiled_x = jax.tree_map(lambda x: jnp.tile(x[None], [jax.device_count()] + [1] * len(x.shape)), x)
  all_x = lax.pswapaxes(tiled_x, 'batch', 0)
  return all_x
pmap(vmap(f), axis_name='batch')(jnp.arange(jax.device_count() * 5 * 2).reshape((jax.device_count(), 5, 2)))
```

When the assertion is commented out, we get the correct error:
`NotImplementedError: Batching rule for 'all_to_all' not implemented`
