### PR TITLE
[jax2tf] Add testing for add/mul/min/max conversion.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -255,7 +255,7 @@ lax_min_max = tuple(
           f_jax=f_jax,
           dtype=dtype)
   for f_jax in [lax.min, lax.max]
-  for dtype in filter(lambda t: t != np.bool_, jtu.dtypes.all)
+  for dtype in jtu.dtypes.all
   for lhs, rhs in [
     (np.array([1, 2], dtype=dtype), np.array([3, 4], dtype=dtype))
   ]

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, NamedTuple, Sequence
 
 from absl import testing
 from jax import config
+from jax import dtypes
 from jax import test_util as jtu
 from jax import lax
 from jax import lax_linalg
@@ -203,6 +204,72 @@ lax_population_count = tuple(
   for dtype in jtu.dtypes.all_integer + jtu.dtypes.all_unsigned
   for arg in [
     np.array([-1, -2, 0, 1], dtype=dtype)
+  ]
+)
+
+def _get_max_identity(dtype):
+  if dtypes.issubdtype(dtype, np.inexact):
+    return np.array(-np.inf, dtype)
+  elif dtypes.issubdtype(dtype, np.integer):
+    return np.array(dtypes.iinfo(dtype).min, dtype)
+  elif dtypes.issubdtype(dtype, np.bool_):
+    return np.array(False, np.bool_)
+
+def _get_min_identity(dtype):
+  if dtypes.issubdtype(dtype, np.inexact):
+    return np.array(np.inf, dtype)
+  elif dtypes.issubdtype(dtype, np.integer):
+    return np.array(dtypes.iinfo(dtype).max, dtype)
+  elif dtypes.issubdtype(dtype, np.bool_):
+    return np.array(True, np.bool_)
+
+lax_add_mul = tuple(
+  Harness(f"fun={f_jax.__name__}_{jtu.dtype_str(dtype)}",
+          f_jax,
+          [lhs, rhs],
+          f_jax=f_jax,
+          dtype=dtype)
+  for f_jax in [lax.add, lax.mul]
+  for dtype in filter(lambda t: t != np.bool_, jtu.dtypes.all)
+  for lhs, rhs in [
+    (np.array([1, 2], dtype=dtype), np.array([3, 4], dtype=dtype))
+  ]
+) + tuple(
+  Harness(f"fun={f_jax.__name__}_bounds_{jtu.dtype_str(dtype)}",
+          f_jax,
+          [StaticArg(lhs), StaticArg(rhs)],
+          f_jax=f_jax,
+          dtype=dtype)
+  for f_jax in [lax.add, lax.mul]
+  for dtype in filter(lambda t: t != np.bool_, jtu.dtypes.all)
+  for lhs, rhs in [
+    (np.array([3, 3], dtype=dtype),
+     np.array([_get_max_identity(dtype), _get_min_identity(dtype)], dtype=dtype))
+  ]
+)
+
+lax_min_max = tuple(
+  Harness(f"fun={f_jax.__name__}_{jtu.dtype_str(dtype)}",
+          f_jax,
+          [lhs, rhs],
+          f_jax=f_jax,
+          dtype=dtype)
+  for f_jax in [lax.min, lax.max]
+  for dtype in filter(lambda t: t != np.bool_, jtu.dtypes.all)
+  for lhs, rhs in [
+    (np.array([1, 2], dtype=dtype), np.array([3, 4], dtype=dtype))
+  ]
+) + tuple(
+  Harness(f"fun={f_jax.__name__}_inf_nan_{jtu.dtype_str(dtype)}_{lhs[0]}_{rhs[0]}",
+          f_jax,
+          [StaticArg(lhs), StaticArg(rhs)],
+          f_jax=f_jax,
+          dtype=dtype)
+  for f_jax in [lax.min, lax.max]
+  for dtype in jtu.dtypes.all_floating + jtu.dtypes.complex
+  for lhs, rhs in [
+    (np.array([np.inf], dtype=dtype), np.array([np.nan], dtype=dtype)),
+    (np.array([-np.inf], dtype=dtype), np.array([np.nan], dtype=dtype))
   ]
 )
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -383,6 +383,38 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            expect_tf_exceptions=True)
 
+  @primitive_harness.parameterized(primitive_harness.lax_add_mul)
+  def test_add_mul(self, harness: primitive_harness.Harness):
+    expect_tf_exceptions = False
+    dtype = harness.params["dtype"]
+    f_name = harness.params["f_jax"].__name__
+
+    if not dtype in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
+                     np.int8, np.uint16, np.int16, np.int32, np.int64, np.complex64,
+                     np.complex128]:
+      # TODO(bchetioui): tf.math.multiply is only defined for the above types.
+      expect_tf_exceptions = True
+    elif dtype is np.uint16 and f_name == "add":
+      # TODO(bchetioui): tf.math.add is defined for the same types as multiply,
+      # except uint16.
+      expect_tf_exceptions = True
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           expect_tf_exceptions=expect_tf_exceptions)
+
+  @primitive_harness.parameterized(primitive_harness.lax_min_max)
+  def test_min_max(self, harness: primitive_harness.Harness):
+    expect_tf_exceptions = False
+    dtype = harness.params["dtype"]
+
+    if not dtype in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
+                     np.int16, np.int32, np.int64]:
+      # TODO(bchetioui): tf.math.maximum and tf.math.minimum are only defined for
+      # the above types.
+      expect_tf_exceptions = True
+
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
+                           expect_tf_exceptions=expect_tf_exceptions)
+
   @primitive_harness.parameterized(primitive_harness.lax_binary_elementwise)
   def test_binary_elementwise(self, harness):
     lax_name, dtype = harness.params["lax_name"], harness.params["dtype"]

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -389,10 +389,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     dtype = harness.params["dtype"]
     f_name = harness.params["f_jax"].__name__
 
-    if not dtype in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
-                     np.int8, np.uint16, np.int16, np.int32, np.int64, np.complex64,
-                     np.complex128]:
-      # TODO(bchetioui): tf.math.multiply is only defined for the above types.
+    if dtype in [np.uint32, np.uint64]:
+      # TODO(bchetioui): tf.math.multiply is not defined for the above types.
       expect_tf_exceptions = True
     elif dtype is np.uint16 and f_name == "add":
       # TODO(bchetioui): tf.math.add is defined for the same types as multiply,
@@ -406,9 +404,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     expect_tf_exceptions = False
     dtype = harness.params["dtype"]
 
-    if not dtype in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
-                     np.int16, np.int32, np.int64]:
-      # TODO(bchetioui): tf.math.maximum and tf.math.minimum are only defined for
+    if dtype in [np.int8, np.uint16, np.uint32, np.uint64, np.complex64,
+                 np.complex128]:
+      # TODO(bchetioui): tf.math.maximum and tf.math.minimum are not defined for
       # the above types.
       expect_tf_exceptions = True
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -404,8 +404,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     expect_tf_exceptions = False
     dtype = harness.params["dtype"]
 
-    if dtype in [np.int8, np.uint16, np.uint32, np.uint64, np.complex64,
-                 np.complex128]:
+    if dtype in [np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
+                 np.complex64, np.complex128]:
       # TODO(bchetioui): tf.math.maximum and tf.math.minimum are not defined for
       # the above types.
       expect_tf_exceptions = True


### PR DESCRIPTION
Only certain types are supported for each of the operations above.
This commit adds previously missing tests to make this explicit.