### PR TITLE
Implement a proper shape checking rule for scatter.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3952,7 +3952,131 @@ def _scatter_dtype_rule(operand, scatter_indices, updates, **kwargs):
   _check_same_dtypes("scatter", False, operand.dtype, updates.dtype)
   return dtypes.canonicalize_dtype(operand.dtype)
 
-def _scatter_shape_rule(operand, scatter_indices, updates, **kwargs):
+def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
+                        update_consts, dimension_numbers, indices_are_sorted,
+                        unique_indices):
+  """Validates the well-formedness of the ``dimension_numbers`` argument to
+  Scatter.
+
+  The code implements the checks based on the detailed operation semantics of
+  XLA's `Scatter <https://www.tensorflow.org/xla/operation_semantics#scatter>`_
+  operator and following the outline of the implementation of
+  ShapeInference::InferScatterShape in TensorFlow.
+  """
+  rank = lambda arr: len(arr.shape)
+
+  def _is_sorted(dims, name):
+    for i in range(1, len(dims)):
+      if dims[i] < dims[i - 1]:
+        raise TypeError(f"{name} in scatter op must be sorted; got {dims}")
+
+  def _sorted_dims_in_range(dims, rank, name):
+    if len(dims) == 0:
+      return
+    invalid_dim = None
+    if dims[0] < 0:
+      invalid_dim = dims[0]
+    elif dims[-1] >= rank:
+      invalid_dim = dims[-1]
+    if invalid_dim:
+      raise TypeError(f"Invalid {name} set in scatter op; valid range is "
+                      f"[0, {rank}); got: {invalid_dim}.")
+
+  def _no_duplicate_dims(dims, name):
+    if len(set(dims)) != len(dims):
+      raise TypeError(f"{name} in scatter op must not repeat; got: {dims}.")
+
+  update_window_dims = dimension_numbers.update_window_dims
+  inserted_window_dims = dimension_numbers.inserted_window_dims
+  scatter_dims_to_operand_dims = dimension_numbers.scatter_dims_to_operand_dims
+  # Note: in JAX, index_vector_dim is always computed as below, cf. the
+  # documentation of the ScatterDimensionNumbers class.
+  index_vector_dim = rank(scatter_indices) - 1
+
+  # This case should never happen in JAX, due to the implicit construction of
+  # index_vector_dim, but is included for completeness.
+  if rank(scatter_indices) < index_vector_dim or index_vector_dim < 0:
+    raise TypeError(f"Scatter index leaf dimension must be within [0, "
+                    f"rank(scatter_indices) + 1). rank(scatter_indices) is "
+                    f"{rank(scatter_indices)} and scatter index leaf "
+                    f"dimension is {index_vector_dim}.")
+
+  expanded_scatter_indices_shape = list(scatter_indices.shape)
+  # This case should never happen in JAX, due to the implicit construction of
+  # index_vector_dim, but is included for completeness.
+  if len(expanded_scatter_indices_shape) == index_vector_dim:
+    expanded_scatter_indices_shape.append(1)
+
+  expected_updates_rank = (len(expanded_scatter_indices_shape) - 1 +
+                           len(update_window_dims))
+
+  if rank(updates) != expected_updates_rank:
+    raise TypeError(f"Updates tensor must be of rank {expected_updates_rank}; "
+                    f"got {rank(updates)}.")
+
+  # Validate update_window_dims
+  _is_sorted(update_window_dims, "update_window_dims")
+  _no_duplicate_dims(update_window_dims, "update_window_dims")
+  _sorted_dims_in_range(update_window_dims, rank(updates), "update_window_dims")
+
+  # Validate inserted_window_dims
+  _is_sorted(inserted_window_dims, "inserted_window_dims")
+  _no_duplicate_dims(inserted_window_dims, "inserted_window_dims")
+  _sorted_dims_in_range(inserted_window_dims, rank(operand),
+                        "inserted_window_dims")
+
+  # Validate window_size
+  window_size = len(update_window_dims) + len(inserted_window_dims)
+  if rank(operand) != window_size:
+    raise TypeError(f"Scatter op has window of size {window_size}; doesn't "
+                    f"match operand of rank {rank(operand)}.")
+
+  # Validate scatter_dims_to_operand_dims
+  if (len(scatter_dims_to_operand_dims) !=
+      scatter_indices.shape[index_vector_dim]):
+    raise TypeError(f"Scatter op has {len(scatter_dims_to_operand_dims)} "
+                    f"elements in scatter_dims_to_operand_dims and the bound "
+                    f"of dimension index_vector_dim={index_vector_dim} of "
+                    f"scatter_indices is "
+                    f"{scatter_indices.shape[index_vector_dim]}. These two "
+                    f"numbers must be equal")
+
+  for i in range(len(scatter_dims_to_operand_dims)):
+    dim = scatter_dims_to_operand_dims[i]
+    if dim < 0 or dim >= rank(operand):
+      raise TypeError(f"Invalid scatter_dims_to_operand_dims mapping; domain "
+                      f"is [0, {rank(operand)}), got: {i}->{dim}.")
+
+  _no_duplicate_dims(scatter_dims_to_operand_dims,
+                     "scatter_dims_to_operand_dims")
+
+  max_update_slice_sizes = [operand.shape[i] for i in range(len(operand.shape))
+                            if not i in set(inserted_window_dims)]
+
+  for i in range(len(update_window_dims)):
+    update_window_dim = update_window_dims[i]
+    if updates.shape[update_window_dim] > max_update_slice_sizes[i]:
+      raise TypeError(f"Bounds of the window dimensions of updates must not "
+                      f"exceed the bounds of the corresponding dimensions of "
+                      f"operand. For dimension {update_window_dim}, updates "
+                      f"bound is {updates.shape[update_window_dim]}, operand "
+                      f"bound is {max_update_slice_sizes[i]}.")
+
+  update_scatter_dims = [dim for dim in range(rank(updates)) if dim not in
+                         set(update_window_dims)]
+
+  scatter_dims_seen = 0
+  for i in update_scatter_dims:
+    if scatter_dims_seen == index_vector_dim:
+      scatter_dims_seen += 1
+    if updates.shape[i] != expanded_scatter_indices_shape[scatter_dims_seen]:
+      raise TypeError(f"Bounds of the scatter dimensions of updates must be "
+                      f"the same as the bounds of the corresponding dimensions "
+                      f"of scatter indices. For scatter dimension {i}, updates "
+                      f"bound is {updates.shape[i]}, scatter_indices bound is "
+                      f"{expanded_scatter_indices_shape[scatter_dims_seen]}.")
+    scatter_dims_seen += 1
+
   return operand.shape
 
 def _scatter_translation_rule(c, operand, scatter_indices, updates, *,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1752,7 +1752,7 @@ class LaxTest(jtu.JaxTestCase):
       for rng_idx_factory in [partial(jtu.rand_int, high=max(arg_shape))]
       for rng_factory in [jtu.rand_default]))
   def testScatter(self, arg_shape, dtype, idxs, update_shape, dnums,
-                     rng_factory, rng_idx_factory):
+                  rng_factory, rng_idx_factory):
     rng = rng_factory(self.rng())
     rng_idx = rng_idx_factory(self.rng())
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
@@ -1760,6 +1760,95 @@ class LaxTest(jtu.JaxTestCase):
                           rng(update_shape, dtype)]
     fun = partial(lax.scatter, dimension_numbers=dnums)
     self._CompileAndCheck(fun, args_maker)
+
+  # These tests are adapted from the corresponding tests in
+  # tensorflow/compiler/xla/service/shape_inference_test.cc with slight
+  # variations to account for the implicit setting of index_vector_dim in JAX.
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": f"_{testcase_name}", "operand_shape": operand_shape,
+       "scatter_indices": scatter_indices, "update_shape": update_shape,
+       "dimension_numbers": lax.ScatterDimensionNumbers(
+          update_window_dims=update_window_dims,
+          inserted_window_dims=inserted_window_dims,
+          scatter_dims_to_operand_dims=scatter_dims_to_operand_dims),
+       "msg": msg}
+      for (testcase_name, operand_shape, scatter_indices, update_shape,
+           update_window_dims, inserted_window_dims,
+           scatter_dims_to_operand_dims, msg) in [
+              ("ScatterWithUpdatesBiggerThanInput", (64, 48), np.zeros((32, 1)),
+               (65, 32), (0,), (1,), (1,), "Bounds of the window dimensions"),
+              ("ScatterWithUpdatesBiggerThanInputV2", (64, 48),
+               np.zeros((32, 1)), (32, 49), (1,), (0,), (1,),
+               "Bounds of the window dimensions"),
+              ("ScatterWithUpdatesNotMatchingIndices", (64, 48),
+               np.zeros((32, 1)), (64, 31), (0,), (1,), (1,),
+               "Bounds of the scatter dimensions"),
+              ("ScatterWithUpdatesNotMatchingIndicesV2", (64, 48),
+               np.zeros((32, 1)), (31, 48), (1,), (0,), (1,),
+               "Bounds of the scatter dimensions"),
+              ("ScatterNdWithUpdatesBiggerThanInput", (64, 48),
+               np.zeros((10, 9, 8, 7, 1)), (10, 9, 8, 7, 65), (4,), (1,),
+               (0,), "Bounds of the window dimensions"),
+              ("ScatterNdWithUpdatesNotMatchingIndices", (64, 48),
+               np.zeros((10, 9, 8, 7, 1)), (9, 9, 8, 7, 64), (4,), (1,), (0,),
+               "Bounds of the scatter dimensions"),
+              ("InvalidUpdates", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4, 1),
+               (4, 5, 6), (1, 2), (0, 1, 2, 3, 4),
+               "Updates tensor must be of rank 7; got 8."),
+              ("NonAscendingUpdateWindowDims", (6, 5, 4, 3, 2),
+               np.zeros((5, 4, 3, 2, 1)), (10, 9, 8, 7, 6, 5, 4, 3, 2),
+               (4, 5, 6, 8, 7), (), (0, 1, 2, 3, 4),
+               "update_window_dims in scatter op must be sorted"),
+              ("RepeatedUpdateWindowDims", (6, 5, 4, 3, 2),
+               np.zeros((5, 4, 3, 2, 1)), (10, 9, 8, 7, 6, 5, 4, 3, 2),
+               (4, 5, 6, 7, 7), (), (0, 1, 2, 3, 4),
+               "update_window_dims in scatter op must not repeat"),
+              ("OutOfBoundsUpdateWindowDims", (6, 5, 4, 3, 2),
+               np.zeros((5, 4, 3, 2, 1)), (10, 9, 8, 7, 6, 5, 4, 3, 2),
+               (4, 5, 6, 7, 9), (), (0, 1, 2, 3, 4),
+               "Invalid update_window_dims set in scatter op"),
+              ("NonAscendingInsertedWindowDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (2, 1), (0, 1, 2, 3, 4),
+               "inserted_window_dims in scatter op must be sorted"),
+              ("RepeatedInsertedWindowDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1, 1), (0, 1, 2, 3, 4),
+               "inserted_window_dims in scatter op must not repeat"),
+              ("OutOfBoundsInsertedWindowDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1, 5), (0, 1, 2, 3, 4),
+               "Invalid inserted_window_dims set in scatter op"),
+              ("MismatchingScatterDimsToOperandDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1, 2), (0, 1, 2, 3),
+               "Scatter op has 4 elements in scatter_dims_to_operand_dims and "
+               "the bound of dimension index_vector_dim=4 of scatter_indices "
+               "is 5. These two numbers must be equal"),
+              ("OutOfBoundsScatterDimsToOperandDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1, 2), (0, 1, 2, 3, 10),
+               "Invalid scatter_dims_to_operand_dims mapping"),
+              ("RepeatedValuesInScatterDimsToOperandDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1, 2), (0, 1, 2, 2, 3),
+               "scatter_dims_to_operand_dims in scatter op must not repeat"),
+              ("InsufficientWindowDims", (50, 49, 48, 47, 46),
+               np.zeros((10, 9, 8, 7, 5)), (10, 9, 8, 7, 3, 2, 4),
+               (4, 5, 6), (1,), (0, 1, 2, 3),
+               "Scatter op has window of size 4; doesn't match operand of "
+               "rank 5.")
+           ]
+      ))
+  def testScatterShapeCheckingRule(self, operand_shape, scatter_indices,
+                                   update_shape, dimension_numbers, msg):
+
+      operand = np.ones(operand_shape, dtype=np.int32)
+      updates = np.ones(update_shape, dtype=np.int32)
+
+      with self.assertRaisesRegex(TypeError, msg):
+        lax.scatter(operand, scatter_indices, updates, dimension_numbers)
 
   def testIssue831(self):
     # Tests the DeviceTuple constant handler


### PR DESCRIPTION
The implementation is based on the corresponding shape inference
code in `tensorflow/compiler/xla/service/shape_inference.cc`. The
tests added in `tests/lax_test.py` are similarly mirroring the
corresponding tests in tensorflow, with slight adaptations for
the particular setting of JAX.