### PR TITLE
Delete batching.last.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -841,7 +841,7 @@ def jacfwd(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
     f_partial, dyn_args = argnums_partial(f, argnums, args)
     tree_map(partial(_check_input_dtype_jacfwd, holomorphic), dyn_args)
     pushfwd = partial(_jvp, f_partial, dyn_args)
-    y, jac = vmap(pushfwd, out_axes=(None, batching.last))(_std_basis(dyn_args))
+    y, jac = vmap(pushfwd, out_axes=(None, -1))(_std_basis(dyn_args))
     tree_map(partial(_check_output_dtype_jacfwd, holomorphic), y)
     example_args = dyn_args[0] if isinstance(argnums, int) else dyn_args
     return tree_map(partial(_unravel_array_into_pytree, example_args, -1), jac)
@@ -1140,11 +1140,11 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
     in_axes = tuple(in_axes)
 
   in_axes_, out_axes_ = tree_leaves(in_axes), tree_leaves(out_axes)
-  if not all(isinstance(l, (type(None), int, batching._Last)) for l in in_axes_):
+  if not all(isinstance(l, (type(None), int)) for l in in_axes_):
     msg = ("vmap in_axes must be an int, None, or (nested) container with "
            "those types as leaves, but got {}.")
     raise TypeError(msg.format(in_axes))
-  if not all(isinstance(l, (type(None), int, batching._Last)) for l in out_axes_):
+  if not all(isinstance(l, (type(None), int)) for l in out_axes_):
     msg = ("vmap out_axes must be an int, None, or (nested) container with "
            "those types as leaves, but got {}.")
     raise TypeError(msg.format(out_axes))

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -67,7 +67,7 @@ def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
   out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
   out_dims = out_dims_thunk()
   for od, od_dest in zip(out_dims, out_dim_dests):
-    if od is not None and not isinstance(od_dest, int) and not od_dest is last and not sum_match:
+    if od is not None and not isinstance(od_dest, int) and not sum_match:
       msg = f"vmap has mapped output but out_axes is {od_dest}"
       raise ValueError(msg)
   out_vals = map(partial(matchaxis, size, sum_match=sum_match), out_dims, out_dim_dests, out_vals)
@@ -320,14 +320,9 @@ defvectorized(xla.device_put_p)
 
 ### util
 
-class _Last(object): pass
-last = _Last()
-
 def broadcast(x, sz, axis):
   if core.get_aval(x) is core.abstract_unit:
     return core.unit
-  if axis is last:
-    axis = np.ndim(x)
   shape = list(np.shape(x))
   shape.insert(axis, sz)
   broadcast_dims = tuple(np.delete(np.arange(len(shape)), axis))
@@ -352,11 +347,9 @@ def matchaxis(sz, src, dst, x, sum_match=False):
     return x
   elif type(src) == type(dst) == int:
     return moveaxis(x, src, dst)
-  elif type(src) == int and dst is last:
-    return moveaxis(x, src, -1)
   elif src is not_mapped and dst is not not_mapped:
     return broadcast(
-      x, sz, canonicalize_axis(dst, np.ndim(x) + 1) if dst is not last else dst)
+      x, sz, canonicalize_axis(dst, np.ndim(x) + 1))
   elif dst is None and sum_match:
     return x.sum(src)
   else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1616,7 +1616,7 @@ class APITest(jtu.JaxTestCase):
       g(jnp.ones((1, 1)), b=1)
 
   def test_vmap_unmapped_last(self):
-    @partial(jax.vmap, out_axes=jax.interpreters.batching.last)
+    @partial(jax.vmap, out_axes=-1)
     def f(x):
       return np.zeros((2,))
     f(np.zeros((5,)))


### PR DESCRIPTION
A -1 axis works just as well at head.