### PR TITLE
Revert "Increase tolerance for CPU test LaxBackedNumpyTests::testCorr…

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3663,10 +3663,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(
         np_fun, jnp_fun, args_maker, check_dtypes=False,
         tol=1e-2 if jtu.device_under_test() == "tpu" else None)
-    # Use very high tolerance to prevent failure after LLVM change
-    # See b/164924709
-    rtol = 1e-1 if jtu.device_under_test() == "cpu" else None
-    self._CompileAndCheck(jnp_fun, args_maker, rtol=rtol)
+    self._CompileAndCheck(jnp_fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}_{}".format(jtu.format_shape_dtype_string(shape, dtype),


### PR DESCRIPTION
…Coef (#4080)"

This reverts commit 22b92c5122ab5af6f5e4560f9be08f5649ae7653.

We revert this change because the LLVM bug that made us relax the
test tolerance is now fixed.