### PR TITLE
jax.numpy: change `asarray` to `_strict_asarray`

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1185,7 +1185,7 @@ and out-of-bounds indices are clipped.
 @_wraps(np.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(indices, shape):
   indices = _strict_asarray(indices)
-  sizes = np.pad(shape, (0, 1), constant_values=1).astype(int)
+  sizes = np.pad(shape, (0, 1), mode='constant', constant_values=1).astype(int)
   cumulative_sizes = np.cumprod(sizes[::-1])[::-1]
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior

--- a/jax/random.py
+++ b/jax/random.py
@@ -97,15 +97,6 @@ def _is_prng_key(key: jnp.ndarray) -> bool:
 
 ### utilities
 
-
-# TODO(mattjj,jakevdp): add more info to error message, use this utility more
-def _asarray(x):
-  """A more restrictive jnp.asarray, only accepts JAX arrays and np.ndarrays."""
-  if not isinstance(x, (np.ndarray, jnp.ndarray)):
-    raise TypeError(f"Function requires array input, got {x} of type {type(x)}.")
-  return jnp.asarray(x)
-
-
 def _make_rotate_left(dtype):
   if not jnp.issubdtype(dtype, np.integer):
     raise TypeError("_rotate_left only accepts integer dtypes.")
@@ -571,13 +562,9 @@ def choice(key, a, shape=(), replace=True, p=None):
   if not isinstance(shape, Sequence):
     raise TypeError("shape argument of jax.random.choice must be a sequence, "
                     f"got {shape}")
-  if np.ndim(a) not in [0, 1]:
+  if a.ndim not in [0, 1]:
     raise ValueError("a must be an integer or 1-dimensional")
-  if np.ndim(a) == 0:
-    a = int(a)
-  else:
-    a = _asarray(a)
-  n_inputs = a if np.ndim(a) == 0 else len(a)
+  n_inputs = int(a) if a.ndim == 0 else len(a)
   n_draws = prod(shape)
   if n_draws == 0:
     return jnp.zeros(shape, dtype=lax.dtype(a))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1523,7 +1523,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       args_maker = lambda: [m]
 
-    for repeats in [2, [1,3,2,1,1,2], [1,3,0,1,1,2], [2], jnp.array([1,3,2,1,1,2]), jnp.array([2])]:
+    for repeats in [2, np.array([1,3,2,1,1,2]), np.array([1,3,0,1,1,2]), np.array([2]),
+                    jnp.array([1,3,2,1,1,2]), jnp.array([2])]:
       test_single(m, args_maker, repeats, axis=None)
       test_single(m, args_maker, repeats, axis=0)
 
@@ -1533,10 +1534,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       args_maker = lambda: [m_rect]
 
-    for repeats in [2, [2,1], [2], jnp.array([2,1]), jnp.array([2])]:
+    for repeats in [2, np.array([2,1]), np.array([2]), jnp.array([2,1]), jnp.array([2])]:
       test_single(m_rect, args_maker, repeats, axis=0)
 
-    for repeats in [2, [1,3,2], [2], jnp.array([1,3,2]), jnp.array([2])]:
+    for repeats in [2, np.array([1,3,2]), np.array([2]), jnp.array([1,3,2]), jnp.array([2])]:
       test_single(m_rect, args_maker, repeats, axis=1)
 
   def testIssue2330(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2692,13 +2692,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     (0, (2, 1, 3)),
     (5, (2, 1, 3)),
     (0, ()),
-    ([0, 1, 2], (2, 2)),
-    ([[[0, 1], [2, 3]]], (2, 2)))
+    (np.arange(3), (2, 2)),
+    (np.arange(4).reshape(2, 2), (2, 2)))
   def testUnravelIndex(self, flat_index, shape):
-    args_maker = lambda: (flat_index, shape)
-    self._CheckAgainstNumpy(np.unravel_index, jnp.unravel_index,
-                            args_maker)
-    self._CompileAndCheck(jnp.unravel_index, args_maker)
+    args_maker = lambda: [flat_index]
+    np_fun = lambda x: np.unravel_index(x, shape)
+    jnp_fun = lambda x: jnp.unravel_index(x, shape)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
 
   def testUnravelIndexOOB(self):
     self.assertEqual(jnp.unravel_index(2, (2,)), (1,))


### PR DESCRIPTION
This makes more explicit our policy of not silently pushing lists and tuples to device within `jax.numpy` code. The current API is inconsistent on this front.

This extends the initial work in #4145 and uses the utility in more places.

Note that this *may* cause breakages downstream, because lists are no longer accepted in places where they once were.