### PR TITLE
Fix bug in omnistaging_enabler

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -596,4 +596,5 @@ def omnistaging_enabler() -> None:
     return core.Primitive.bind(
         psum_p, *args, axis_name=axis_name, axis_index_groups=axis_index_groups)
 
-  del pxla.parallel_pure_rules[psum_p]
+  if psum_p in pxla.parallel_pure_rules:
+    del pxla.parallel_pure_rules[psum_p]


### PR DESCRIPTION
This code was failing with "KeyError: psum" for the tests
"//third_party/py/flax/...". I suspect that the error is due to the
ordering of the omnistaging enablers, changed in #4152.

I am not sure of this fix, but this seemed to be enough for all the
presubmit tests to pass and allow the copybara import.