### PR TITLE
raise_to_shaped: preserve weak_type by default

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1065,7 +1065,9 @@ class AbstractToken(AbstractValue):
 abstract_token = AbstractToken()
 
 
-def raise_to_shaped(aval: AbstractValue, weak_type=False):
+def raise_to_shaped(aval: AbstractValue, weak_type=None):
+  if weak_type is None:
+    weak_type = getattr(aval, 'weak_type', False)
   for typ in type(aval).mro():
     handler = raise_to_shaped_mappings.get(typ)
     if handler: return handler(aval, weak_type)
@@ -1235,8 +1237,7 @@ def typecompat(aval_ref: AbstractValue, aval: AbstractValue) -> bool:
     return False
 
 def typematch(aval1: UnshapedArray, aval2: UnshapedArray) -> bool:
-  return (raise_to_shaped(aval1).strip_weak_type() ==
-          raise_to_shaped(aval2).strip_weak_type())
+  return raise_to_shaped(aval1, weak_type=False) == raise_to_shaped(aval2, weak_type=False)
 
 class JaxprTypeError(TypeError): pass
 

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -246,8 +246,8 @@ def _flatten_jvp(in_tree, *args):
     msg = ("Custom JVP rule must produce primal and tangent outputs with equal "
            "container (pytree) structures, but got {} and {} respectively.")
     raise TypeError(msg.format(out_tree, out_tree2))
-  primal_avals_out = [raise_to_shaped(core.get_aval(x)) for x in primals_out]
-  tangent_avals_out = [raise_to_shaped(core.get_aval(t)) for t in tangents_out]
+  primal_avals_out = [raise_to_shaped(core.get_aval(x), weak_type=False) for x in primals_out]
+  tangent_avals_out = [raise_to_shaped(core.get_aval(t), weak_type=False) for t in tangents_out]
   if primal_avals_out != tangent_avals_out:
     if len(primal_avals_out) == 1:
       (av1,), (av2,) = primal_avals_out, tangent_avals_out

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -344,7 +344,7 @@ class TensorFlowTrace(core.Trace):
         *[t.aval for t in tracers], **params)
       if primitive.multiple_results:
         for o, expected_aval in zip(out, expected_out_aval):  # type: ignore
-          assert o.aval == expected_aval, (
+          assert o.aval.strip_weak_type() == expected_aval.strip_weak_type(), (
             f"{primitive}: out.aval = {o.aval}; expected {expected_aval}")
       else:
         assert out.aval == expected_out_aval, (  # type: ignore

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -169,7 +169,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
       ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
       if not core.skip_checks:
         ct_aval = core.get_aval(ct_env[v])
-        assert v.aval == core.lattice_join(v.aval, ct_aval), (v.aval, ct_aval)
+        assert v.aval.strip_weak_type() == core.lattice_join(v.aval, ct_aval).strip_weak_type(), (v.aval, ct_aval)
 
   def read_cotangent(v):
     return ct_env.get(v, Zero(v.aval))
@@ -371,8 +371,8 @@ class JVPTracer(Tracer):
 
 def _primal_tangent_shapes_match(primal, tangent):
   if type(tangent) is not Zero:
-    primal_aval = raise_to_shaped(get_aval(primal))
-    tangent_aval = raise_to_shaped(get_aval(tangent))
+    primal_aval = raise_to_shaped(get_aval(primal), weak_type=False)
+    tangent_aval = raise_to_shaped(get_aval(tangent), weak_type=False)
     assert primal_aval.shape == tangent_aval.shape, (primal_aval.shape, tangent_aval.shape)
     expected_tangent_dtype = core.primal_dtype_to_tangent_dtype(primal_aval.dtype)
     assert expected_tangent_dtype == tangent_aval.dtype, (expected_tangent_dtype, tangent_aval.dtype)

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -264,16 +264,29 @@ def while_loop(cond_fun: Callable[[T], bool],
       # transformation on it), so we fall back to the primitive version.
       pass
 
-  init_vals, in_tree = tree_flatten((init_val,))
-  init_avals = tuple(_map(_abstractify, init_vals))
-  cond_jaxpr, cond_consts, cond_tree = _initial_style_jaxpr(cond_fun, in_tree, init_avals)
-  body_jaxpr, body_consts, body_tree = _initial_style_jaxpr(body_fun, in_tree, init_avals)
-  if not treedef_is_leaf(cond_tree) or len(cond_jaxpr.out_avals) != 1:
-    msg = "cond_fun must return a boolean scalar, but got pytree {}."
-    raise TypeError(msg.format(cond_tree))
-  if cond_jaxpr.out_avals[0].strip_weak_type() != ShapedArray((), np.bool_):
-    msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
-    raise TypeError(msg.format(cond_jaxpr.out_avals))
+  # The body input and output avals must match exactly. However, we want to account for
+  # the case when init contains weakly-typed values (e.g. Python scalars), with avals that
+  # may not match the output despite being compatible by virtue of their weak type.
+  # To do this, we compute the jaxpr in two passes: first with the raw inputs, and if
+  # necessary, a second time with modified init values.
+  for pass_ in ["first", "second"]:
+    init_vals, in_tree = tree_flatten((init_val,))
+    init_avals = tuple(_map(_abstractify, init_vals))
+    cond_jaxpr, cond_consts, cond_tree = _initial_style_jaxpr(cond_fun, in_tree, init_avals)
+    body_jaxpr, body_consts, body_tree = _initial_style_jaxpr(body_fun, in_tree, init_avals)
+    if not treedef_is_leaf(cond_tree) or len(cond_jaxpr.out_avals) != 1:
+      msg = "cond_fun must return a boolean scalar, but got pytree {} in {} pass."
+      raise TypeError(msg.format(cond_tree, pass_))
+    if cond_jaxpr.out_avals[0].strip_weak_type() != ShapedArray((), np.bool_):
+      msg = "cond_fun must return a boolean scalar, but got output type(s) {} in {} pass."
+      raise TypeError(msg.format(cond_jaxpr.out_avals, pass_))
+
+    if pass_ != "first":
+      break
+    new_init_vals, changed = _promote_weak_typed_inputs(init_vals, init_avals, body_jaxpr.out_avals)
+    if not changed:
+      break
+    init_val, = tree_unflatten(in_tree, new_init_vals)
 
   in_tree_children = in_tree.children()
   assert len(in_tree_children) == 1
@@ -1235,18 +1248,10 @@ def scan(f, init, xs, length=None, reverse=False, unroll=1):
     # weak type logic run only on the first pass.
     if pass_ != 'first':
       break
-    # this error will be caught by the check below.
-    if len(carry_avals) != len(carry_avals_out):
+    new_init_flat, changed = _promote_weak_typed_inputs(init_flat, carry_avals, carry_avals_out)
+    if not changed:
       break
-    weak_mismatches = [i for i, (a1, a2) in enumerate(zip(carry_avals, carry_avals_out))
-                       if a1.weak_type and not core.typematch(a1, a2)]
-    if not weak_mismatches:
-      break
-
-    for i in weak_mismatches:
-      new_dtype = dtypes.result_type(init_flat[i], carry_avals_out[i])
-      init_flat[i] = lax.convert_element_type(init_flat[i], new_dtype)
-    init = tree_unflatten(init_tree, init_flat)
+    init = tree_unflatten(init_tree, new_init_flat)
 
   _check_tree_and_avals("scan carry output and input",
                         # Extract the subtree and avals for the first element of the return tuple
@@ -1908,6 +1913,29 @@ def _check_tree(func_name, expected_name, actual_tree, expected_tree):
         f"{func_name}() output pytree structure must match {expected_name}, "
         f"got {actual_tree} and {expected_tree}.")
 
+
+def _promote_weak_typed_inputs(in_vals, in_avals, out_avals):
+  """Promote weakly-typed in_vals to be compatible with out_avals.
+  
+  Args:
+    in_vals : flattened list of input values.
+    in_avals : corresponding list of avals.
+    out_avals : list of target output avals.
+  Returns:
+    in_vals_new : flattened list of modified in_vals with no weak types.
+    changed : bool; true if in_vals required modification.
+  """
+  if len(in_vals) != len(in_avals) or len(in_avals) != len(out_avals):
+    # Calling function is responsible for catching this.
+    return in_vals, False
+  weak_mismatches = [i for i, (a1, a2) in enumerate(zip(in_avals, out_avals))
+                    if getattr(a1, 'weak_type', False) and not core.typematch(a1, a2)]
+  if not weak_mismatches:
+    return in_vals, False
+  for i in weak_mismatches:
+    new_dtype = dtypes.result_type(in_vals[i], out_avals[i])
+    in_vals[i] = lax.convert_element_type(in_vals[i], new_dtype)
+  return in_vals, True
 
 def _stop_gradient_fun(f):
   """Create a version of f() that stops all gradients."""

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1916,7 +1916,7 @@ def _check_tree(func_name, expected_name, actual_tree, expected_tree):
 
 def _promote_weak_typed_inputs(in_vals, in_avals, out_avals):
   """Promote weakly-typed in_vals to be compatible with out_avals.
-  
+
   Args:
     in_vals : flattened list of input values.
     in_avals : corresponding list of avals.

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -453,6 +453,15 @@ class JaxprTypeChecks(jtu.JaxTestCase):
         r"Variable '.+_test' not defined\n\nin equation:",
         lambda: core.check_jaxpr(jaxpr))
 
+  @parameterized.parameters(
+    {'value': 0, 'weak_type': True},
+    {'value': np.int32(0), 'weak_type': False},
+    {'value': np.array([0]), 'weak_type': False}
+  )
+  def test_raise_to_shaped_weak_type(self, value, weak_type):
+    aval = core.raise_to_shaped(core.get_aval(value))
+    self.assertEqual(aval.weak_type, weak_type)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1532,7 +1532,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     a = jnp.arange(5)
     # Body output not a tuple
     with self.assertRaisesRegex(TypeError,
-        re.escape("scan body output must be a pair, got ShapedArray(float32[]).")):
+        re.escape("scan body output must be a pair, got ShapedArray(float32[]) in first pass.")):
       lax.scan(lambda c, x: np.float32(0.), 0, a)
     with  self.assertRaisesRegex(TypeError,
         re.escape("scan carry output and input must have same type structure, "
@@ -2462,6 +2462,15 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         r'invalid cond param linear of type str, '
         r'tuple of bool required:\nmulti\nline',
         lambda: core.check_jaxpr(jaxpr))
+
+  def test_scan_weak_type(self):
+    def func(x, y):
+      return x + y, y
+    init = 0
+    x = jnp.ones(5, dtype='int16')
+    carry, result = lax.scan(func, init, x)
+    self.assertEqual(carry, x.sum())
+    self.assertArraysEqual(result, x)
 
 
 if __name__ == '__main__':

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -240,7 +240,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lax.while_loop(lambda c: True, lambda c: (1., 1.), 0.)
     with self.assertRaisesWithLiteralMatch(TypeError,
         ("body_fun output and input must have identical types, got\n"
-         "ShapedArray(bool[])\n"
+         "ShapedArray(bool[], weak_type=True)\n"
          "and\n"
          "ShapedArray(float32[]).")):
       lax.while_loop(lambda c: True, lambda c: True, np.float32(0.))

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -230,10 +230,10 @@ class LaxControlFlowTest(jtu.JaxTestCase):
   def testWhileTypeErrors(self):
     """Test typing error messages for while."""
     with self.assertRaisesRegex(TypeError,
-        re.escape("cond_fun must return a boolean scalar, but got pytree PyTreeDef(tuple, [*,*]).")):
+        re.escape("cond_fun must return a boolean scalar, but got pytree PyTreeDef(tuple, [*,*]) in first pass.")):
       lax.while_loop(lambda c: (1., 1.), lambda c: c, 0.)
     with  self.assertRaisesRegex(TypeError,
-        re.escape("cond_fun must return a boolean scalar, but got output type(s) [ShapedArray(float32[])].")):
+        re.escape("cond_fun must return a boolean scalar, but got output type(s) [ShapedArray(float32[])] in first pass.")):
       lax.while_loop(lambda c: np.float32(1.), lambda c: c, np.float32(0.))
     with self.assertRaisesRegex(TypeError,
         re.escape("body_fun output and input must have same type structure, got PyTreeDef(tuple, [*,*]) and *.")):
@@ -2463,14 +2463,32 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         r'tuple of bool required:\nmulti\nline',
         lambda: core.check_jaxpr(jaxpr))
 
-  def test_scan_weak_type(self):
-    def func(x, y):
-      return x + y, y
-    init = 0
-    x = jnp.ones(5, dtype='int16')
-    carry, result = lax.scan(func, init, x)
+  @parameterized.named_parameters(
+      {"testcase_name": f"_dtype={dtype.__name__}", "dtype": dtype}
+      for dtype in jtu.dtypes.all_integer)
+  def test_scan_init_weak_type(self, dtype):
+    def func(carry, x):
+      return carry + x, x
+    init_weak = 0  # Python scalars are weakly-typed.
+    x = jnp.ones(5, dtype=dtype)
+    carry, result = lax.scan(func, init_weak, x)
     self.assertEqual(carry, x.sum())
     self.assertArraysEqual(result, x)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_dtype={dtype.__name__}", "dtype": dtype}
+      for dtype in jtu.dtypes.all_integer)
+  def test_while_loop_init_weak_type(self, dtype):
+    # This tests whether lax.while_loop can properly handle weakly-typed
+    # initial values.
+    def cond_fun(val):
+      return val < 2
+    def body_fun(val):
+      return val + increment
+    increment = jnp.array(1, dtype=dtype)
+    init_weak = 0  # Python scalars are weakly-typed.
+    result = lax.while_loop(cond_fun, body_fun, init_weak)
+    self.assertArraysEqual(result, jnp.full_like(increment, 2))
 
 
 if __name__ == '__main__':

--- a/tests/multi_device_test.py
+++ b/tests/multi_device_test.py
@@ -142,7 +142,7 @@ class MultiDeviceTest(jtu.JaxTestCase):
   def test_primitive_compilation_cache(self):
     devices = self.get_devices()
 
-    x = jax.device_put(1, devices[1])
+    x = jax.device_put(jnp.int32(1), devices[1])
 
     with jtu.count_primitive_compiles() as count:
       y = lax.add(x, x)

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1038,7 +1038,7 @@ class PmapTest(jtu.JaxTestCase):
       return lax.scan(body, 0, x)[0]
     device_count = xla_bridge.device_count()
     shape = (device_count, 10)
-    self.assertAllClose(f(jnp.ones(shape, dtype=np.int32)),
+    self.assertAllClose(f(jnp.ones(shape, dtype=int)),
                         (np.arange(device_count) + 1) * 10)
 
   def testVmapOfPmap(self):


### PR DESCRIPTION
As we look at deprecating the X64 flag, the notion of weakly-typed abstract values becomes more important (see #3903). This will require `weak_type` to be preserved within `aval` transformations wherever possible; this PR makes that change for the `raise_to_shaped` utility.