### PR TITLE
Implement a proper shape checking rule for gather.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3838,28 +3838,6 @@ def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
   operator and following the outline of the implementation of
   ShapeInference::InferGatherShape in TensorFlow.
   """
-  rank = lambda arr: len(arr.shape)
-
-  def _is_sorted(dims, name):
-    for i in range(1, len(dims)):
-      if dims[i] < dims[i - 1]:
-        raise TypeError(f"{name} in gather op must be sorted; got {dims}")
-
-  def _sorted_dims_in_range(dims, rank, name):
-    if len(dims) == 0:
-      return
-    invalid_dim = None
-    if dims[0] < 0:
-      invalid_dim = dims[0]
-    elif dims[-1] >= rank:
-      invalid_dim = dims[-1]
-    if invalid_dim:
-      raise TypeError(f"Invalid {name} set in gather op; valid range is "
-                      f"[0, {rank}); got: {invalid_dim}.")
-
-  def _no_duplicate_dims(dims, name):
-    if len(set(dims)) != len(dims):
-      raise TypeError(f"{name} in gather op must not repeat; got: {dims}.")
 
   offset_dims = dimension_numbers.offset_dims
   collapsed_slice_dims = dimension_numbers.collapsed_slice_dims
@@ -3867,15 +3845,15 @@ def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
 
   # Note: in JAX, index_vector_dim is always computed as below, cf. the
   # documentation of the GatherDimensionNumbers class.
-  index_vector_dim = rank(start_indices) - 1
+  index_vector_dim = _rank(start_indices) - 1
 
   # This case should never happen in JAX, due to the implicit construction of
   # index_vector_dim, but is included for completeness.
-  if rank(start_indices) < index_vector_dim or index_vector_dim < 0:
+  if _rank(start_indices) < index_vector_dim or index_vector_dim < 0:
     raise TypeError(f"Gather index leaf dimension must be within [0, rank("
                     f"start_indices) + 1). rank(start_indices) is "
-                    f"{rank(start_indices)} and gather index leaf dimension is "
-                    f"{index_vector_dim}.")
+                    f"{_rank(start_indices)} and gather index leaf dimension "
+                    f"is {index_vector_dim}.")
 
   expanded_start_indices_shape = list(start_indices.shape)
 
@@ -3888,11 +3866,11 @@ def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
   # In the error messages output by XLA, "offset_dims" is called "Output window
   # dimensions" in error messages. For consistency's sake, our error messages
   # stick to "offset_dims".
-  _is_sorted(offset_dims, "offset_dims")
-  _no_duplicate_dims(offset_dims, "offset_dims")
+  _is_sorted(offset_dims, "gather", "offset_dims")
+  _no_duplicate_dims(offset_dims, "gather", "offset_dims")
 
   output_offset_dim_count = len(offset_dims)
-  output_shape_rank = len(offset_dims) + rank(start_indices) - 1
+  output_shape_rank = len(offset_dims) + _rank(start_indices) - 1
 
   for i in range(output_offset_dim_count):
     offset_dim = offset_dims[i]
@@ -3911,27 +3889,27 @@ def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
   for i in range(len(start_index_map)):
     operand_dim_for_start_index_i = start_index_map[i]
     if (operand_dim_for_start_index_i < 0 or
-        operand_dim_for_start_index_i >= rank(operand)):
+        operand_dim_for_start_index_i >= _rank(operand)):
       raise TypeError(f"Invalid start_index_map; domain is "
-                      f"[0, {rank(operand)}), got: "
+                      f"[0, {_rank(operand)}), got: "
                       f"{i}->{operand_dim_for_start_index_i}.")
 
-  _no_duplicate_dims(start_index_map, "start_index_map")
+  _no_duplicate_dims(start_index_map, "gather", "start_index_map")
 
   # _is_sorted and _sorted_dims_in_range are checked in the opposite order
   # compared to the XLA implementation. In cases when the input is not sorted
   # AND there are problematic collapsed_slice_dims, the error message will thus
   # be different.
-  _is_sorted(collapsed_slice_dims, "collapsed_slice_dims")
-  _sorted_dims_in_range(collapsed_slice_dims, rank(operand),
+  _is_sorted(collapsed_slice_dims, "gather", "collapsed_slice_dims")
+  _sorted_dims_in_range(collapsed_slice_dims, _rank(operand), "gather",
                         "collapsed_slice_dims")
-  _no_duplicate_dims(collapsed_slice_dims, "collapsed_slice_dims")
+  _no_duplicate_dims(collapsed_slice_dims, "gather", "collapsed_slice_dims")
   # End ValidateGatherDimensions
 
-  if rank(operand) != len(slice_sizes):
+  if _rank(operand) != len(slice_sizes):
     raise TypeError(f"Gather op must have one slice size for every input "
                     f"dimension; got: len(slice_sizes)={len(slice_sizes)}, "
-                    f"input_shape.rank={rank(operand)}")
+                    f"input_shape.rank={_rank(operand)}")
 
   if len(slice_sizes) != len(offset_dims) + len(collapsed_slice_dims):
     raise TypeError(f"All components of the offset index in a gather op must "
@@ -4074,6 +4052,29 @@ def _scatter_dtype_rule(operand, scatter_indices, updates, **kwargs):
   _check_same_dtypes("scatter", False, operand.dtype, updates.dtype)
   return dtypes.canonicalize_dtype(operand.dtype)
 
+_rank = lambda arr: len(arr.shape)
+
+def _is_sorted(dims, op_name, name):
+  for i in range(1, len(dims)):
+    if dims[i] < dims[i - 1]:
+      raise TypeError(f"{name} in {op_name} op must be sorted; got {dims}")
+
+def _sorted_dims_in_range(dims, rank, op_name, name):
+  if len(dims) == 0:
+    return
+  invalid_dim = None
+  if dims[0] < 0:
+    invalid_dim = dims[0]
+  elif dims[-1] >= rank:
+    invalid_dim = dims[-1]
+  if invalid_dim:
+    raise TypeError(f"Invalid {name} set in {op_name} op; valid range is "
+                    f"[0, {rank}); got: {invalid_dim}.")
+
+def _no_duplicate_dims(dims, op_name, name):
+  if len(set(dims)) != len(dims):
+    raise TypeError(f"{name} in {op_name} op must not repeat; got: {dims}.")
+
 def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
                         update_consts, dimension_numbers, indices_are_sorted,
                         unique_indices):
@@ -4085,42 +4086,20 @@ def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
   operator and following the outline of the implementation of
   ShapeInference::InferScatterShape in TensorFlow.
   """
-  rank = lambda arr: len(arr.shape)
-
-  def _is_sorted(dims, name):
-    for i in range(1, len(dims)):
-      if dims[i] < dims[i - 1]:
-        raise TypeError(f"{name} in scatter op must be sorted; got {dims}")
-
-  def _sorted_dims_in_range(dims, rank, name):
-    if len(dims) == 0:
-      return
-    invalid_dim = None
-    if dims[0] < 0:
-      invalid_dim = dims[0]
-    elif dims[-1] >= rank:
-      invalid_dim = dims[-1]
-    if invalid_dim:
-      raise TypeError(f"Invalid {name} set in scatter op; valid range is "
-                      f"[0, {rank}); got: {invalid_dim}.")
-
-  def _no_duplicate_dims(dims, name):
-    if len(set(dims)) != len(dims):
-      raise TypeError(f"{name} in scatter op must not repeat; got: {dims}.")
 
   update_window_dims = dimension_numbers.update_window_dims
   inserted_window_dims = dimension_numbers.inserted_window_dims
   scatter_dims_to_operand_dims = dimension_numbers.scatter_dims_to_operand_dims
   # Note: in JAX, index_vector_dim is always computed as below, cf. the
   # documentation of the ScatterDimensionNumbers class.
-  index_vector_dim = rank(scatter_indices) - 1
+  index_vector_dim = _rank(scatter_indices) - 1
 
   # This case should never happen in JAX, due to the implicit construction of
   # index_vector_dim, but is included for completeness.
-  if rank(scatter_indices) < index_vector_dim or index_vector_dim < 0:
+  if _rank(scatter_indices) < index_vector_dim or index_vector_dim < 0:
     raise TypeError(f"Scatter index leaf dimension must be within [0, "
                     f"rank(scatter_indices) + 1). rank(scatter_indices) is "
-                    f"{rank(scatter_indices)} and scatter index leaf "
+                    f"{_rank(scatter_indices)} and scatter index leaf "
                     f"dimension is {index_vector_dim}.")
 
   expanded_scatter_indices_shape = list(scatter_indices.shape)
@@ -4132,26 +4111,27 @@ def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
   expected_updates_rank = (len(expanded_scatter_indices_shape) - 1 +
                            len(update_window_dims))
 
-  if rank(updates) != expected_updates_rank:
+  if _rank(updates) != expected_updates_rank:
     raise TypeError(f"Updates tensor must be of rank {expected_updates_rank}; "
-                    f"got {rank(updates)}.")
+                    f"got {_rank(updates)}.")
 
   # Validate update_window_dims
-  _is_sorted(update_window_dims, "update_window_dims")
-  _no_duplicate_dims(update_window_dims, "update_window_dims")
-  _sorted_dims_in_range(update_window_dims, rank(updates), "update_window_dims")
+  _is_sorted(update_window_dims, "scatter", "update_window_dims")
+  _no_duplicate_dims(update_window_dims, "scatter", "update_window_dims")
+  _sorted_dims_in_range(update_window_dims, _rank(updates), "scatter",
+                        "update_window_dims")
 
   # Validate inserted_window_dims
-  _is_sorted(inserted_window_dims, "inserted_window_dims")
-  _no_duplicate_dims(inserted_window_dims, "inserted_window_dims")
-  _sorted_dims_in_range(inserted_window_dims, rank(operand),
+  _is_sorted(inserted_window_dims, "scatter", "inserted_window_dims")
+  _no_duplicate_dims(inserted_window_dims, "scatter", "inserted_window_dims")
+  _sorted_dims_in_range(inserted_window_dims, _rank(operand), "scatter",
                         "inserted_window_dims")
 
   # Validate window_size
   window_size = len(update_window_dims) + len(inserted_window_dims)
-  if rank(operand) != window_size:
+  if _rank(operand) != window_size:
     raise TypeError(f"Scatter op has window of size {window_size}; doesn't "
-                    f"match operand of rank {rank(operand)}.")
+                    f"match operand of rank {_rank(operand)}.")
 
   # Validate scatter_dims_to_operand_dims
   if (len(scatter_dims_to_operand_dims) !=
@@ -4165,11 +4145,11 @@ def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
 
   for i in range(len(scatter_dims_to_operand_dims)):
     dim = scatter_dims_to_operand_dims[i]
-    if dim < 0 or dim >= rank(operand):
+    if dim < 0 or dim >= _rank(operand):
       raise TypeError(f"Invalid scatter_dims_to_operand_dims mapping; domain "
-                      f"is [0, {rank(operand)}), got: {i}->{dim}.")
+                      f"is [0, {_rank(operand)}), got: {i}->{dim}.")
 
-  _no_duplicate_dims(scatter_dims_to_operand_dims,
+  _no_duplicate_dims(scatter_dims_to_operand_dims, "scatter",
                      "scatter_dims_to_operand_dims")
 
   max_update_slice_sizes = [operand.shape[i] for i in range(len(operand.shape))
@@ -4184,7 +4164,7 @@ def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
                       f"bound is {updates.shape[update_window_dim]}, operand "
                       f"bound is {max_update_slice_sizes[i]}.")
 
-  update_scatter_dims = [dim for dim in range(rank(updates)) if dim not in
+  update_scatter_dims = [dim for dim in range(_rank(updates)) if dim not in
                          set(update_window_dims)]
 
   scatter_dims_seen = 0

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -3831,15 +3831,137 @@ def _gather_dtype_rule(operand, start_indices, **kwargs):
 
 def _gather_shape_rule(operand, start_indices, *, dimension_numbers,
                        slice_sizes):
-  if len(operand.shape) != len(slice_sizes):
-    msg = ("slice_sizes must have rank equal to the gather operand; "
-          "operand.shape={}, slice_sizes={}".format(operand.shape, slice_sizes))
-    raise ValueError(msg)
-  result_rank = len(dimension_numbers.offset_dims) + start_indices.ndim - 1
-  start_indices_shape = iter(start_indices.shape[:-1])
-  slice_sizes = iter(np.delete(slice_sizes, dimension_numbers.collapsed_slice_dims))
-  return tuple(next(slice_sizes) if i in dimension_numbers.offset_dims
-               else next(start_indices_shape) for i in range(result_rank))
+  """Validates the well-formedness of the arguments to Gather.
+
+  The code implements the checks based on the detailed operation semantics of
+  XLA's `Gather <https://www.tensorflow.org/xla/operation_semantics#gather>`_
+  operator and following the outline of the implementation of
+  ShapeInference::InferGatherShape in TensorFlow.
+  """
+  rank = lambda arr: len(arr.shape)
+
+  def _is_sorted(dims, name):
+    for i in range(1, len(dims)):
+      if dims[i] < dims[i - 1]:
+        raise TypeError(f"{name} in gather op must be sorted; got {dims}")
+
+  def _sorted_dims_in_range(dims, rank, name):
+    if len(dims) == 0:
+      return
+    invalid_dim = None
+    if dims[0] < 0:
+      invalid_dim = dims[0]
+    elif dims[-1] >= rank:
+      invalid_dim = dims[-1]
+    if invalid_dim:
+      raise TypeError(f"Invalid {name} set in gather op; valid range is "
+                      f"[0, {rank}); got: {invalid_dim}.")
+
+  def _no_duplicate_dims(dims, name):
+    if len(set(dims)) != len(dims):
+      raise TypeError(f"{name} in gather op must not repeat; got: {dims}.")
+
+  offset_dims = dimension_numbers.offset_dims
+  collapsed_slice_dims = dimension_numbers.collapsed_slice_dims
+  start_index_map = dimension_numbers.start_index_map
+
+  # Note: in JAX, index_vector_dim is always computed as below, cf. the
+  # documentation of the GatherDimensionNumbers class.
+  index_vector_dim = rank(start_indices) - 1
+
+  # This case should never happen in JAX, due to the implicit construction of
+  # index_vector_dim, but is included for completeness.
+  if rank(start_indices) < index_vector_dim or index_vector_dim < 0:
+    raise TypeError(f"Gather index leaf dimension must be within [0, rank("
+                    f"start_indices) + 1). rank(start_indices) is "
+                    f"{rank(start_indices)} and gather index leaf dimension is "
+                    f"{index_vector_dim}.")
+
+  expanded_start_indices_shape = list(start_indices.shape)
+
+  # This case should never happen in JAX, due to the implicit construction of
+  # index_vector_dim, but is included for completeness.
+  if len(expanded_start_indices_shape) == index_vector_dim:
+    expanded_start_indices_shape.append(1)
+
+  # Start ValidateGatherDimensions
+  # In the error messages output by XLA, "offset_dims" is called "Output window
+  # dimensions" in error messages. For consistency's sake, our error messages
+  # stick to "offset_dims".
+  _is_sorted(offset_dims, "offset_dims")
+  _no_duplicate_dims(offset_dims, "offset_dims")
+
+  output_offset_dim_count = len(offset_dims)
+  output_shape_rank = len(offset_dims) + rank(start_indices) - 1
+
+  for i in range(output_offset_dim_count):
+    offset_dim = offset_dims[i]
+    if offset_dim < 0 or offset_dim >= output_shape_rank:
+      raise TypeError(f"Offset dimension {i} in gather op is out of bounds; "
+                      f"got {offset_dim}, but should have been in "
+                      f"[0, {output_shape_rank})")
+
+  if len(start_index_map) != start_indices.shape[index_vector_dim]:
+    raise TypeError(f"Gather op has {len(start_index_map)} elements in "
+                    f"start_index_map and the bound of dimension "
+                    f"index_vector_dim={index_vector_dim} of start_indices is "
+                    f"{start_indices.shape[index_vector_dim]}. These two "
+                    f"numbers must be equal.")
+
+  for i in range(len(start_index_map)):
+    operand_dim_for_start_index_i = start_index_map[i]
+    if (operand_dim_for_start_index_i < 0 or
+        operand_dim_for_start_index_i >= rank(operand)):
+      raise TypeError(f"Invalid start_index_map; domain is "
+                      f"[0, {rank(operand)}), got: "
+                      f"{i}->{operand_dim_for_start_index_i}.")
+
+  _no_duplicate_dims(start_index_map, "start_index_map")
+
+  # _is_sorted and _sorted_dims_in_range are checked in the opposite order
+  # compared to the XLA implementation. In cases when the input is not sorted
+  # AND there are problematic collapsed_slice_dims, the error message will thus
+  # be different.
+  _is_sorted(collapsed_slice_dims, "collapsed_slice_dims")
+  _sorted_dims_in_range(collapsed_slice_dims, rank(operand),
+                        "collapsed_slice_dims")
+  _no_duplicate_dims(collapsed_slice_dims, "collapsed_slice_dims")
+  # End ValidateGatherDimensions
+
+  if rank(operand) != len(slice_sizes):
+    raise TypeError(f"Gather op must have one slice size for every input "
+                    f"dimension; got: len(slice_sizes)={len(slice_sizes)}, "
+                    f"input_shape.rank={rank(operand)}")
+
+  if len(slice_sizes) != len(offset_dims) + len(collapsed_slice_dims):
+    raise TypeError(f"All components of the offset index in a gather op must "
+                    f"either be a offset dimension or explicitly collapsed; "
+                    f"got len(slice_sizes)={len(slice_sizes)}, "
+                    f"output_slice_sizes={offset_dims}, collapsed_slice_dims="
+                    f"{collapsed_slice_dims}.")
+
+  for i in range(len(slice_sizes)):
+    slice_size = slice_sizes[i]
+    corresponding_input_size = operand.shape[i]
+
+    if slice_size < 0 or slice_size > corresponding_input_size:
+      raise TypeError(f"Slice size at index {i} in gather op is out of range, "
+                      f"must be within [0, {corresponding_input_size + 1}), "
+                      f"got {slice_size}.")
+
+  for i in range(len(collapsed_slice_dims)):
+    bound = slice_sizes[collapsed_slice_dims[i]]
+    if bound > 1:
+      raise TypeError(f"Gather op can only collapse slice dims with bound 1 "
+                      f"or 0, but bound is {bound} for index "
+                      f"{collapsed_slice_dims[i]} at position {i}.")
+
+  expanded_start_indices_shape.pop(index_vector_dim)
+  start_indices_shape = iter(expanded_start_indices_shape)
+
+  slice_sizes = iter(np.delete(slice_sizes, collapsed_slice_dims))
+  return tuple(next(slice_sizes) if i in offset_dims
+               else next(start_indices_shape) for i in range(output_shape_rank))
 
 def _gather_translation_rule(c, operand, start_indices, *, dimension_numbers,
                              slice_sizes):


### PR DESCRIPTION
The implementation is based on the corresponding shape inference
code in `tensorflow/compiler/xla/service/shape_inference.cc`. The
tests added in `tests/lax_test.py` are similarly mirroring the
corresponding tests in tensorflow, with slight adaptations for the
particular setting of JAX. Fixes google/jax#2826, and in principle
fixes google/jax#4154, fixes google/jax#3905, fixes google/jax#4003.