### PR TITLE
Addition of one more conclusive polynomial comparison case.

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -200,6 +200,10 @@ class Poly(dict):
       return False  # See above.
     elif self == other:
       return True
+    else:
+      diff = self - other
+      if diff.is_constant:
+        return int(diff) >= 0
 
     raise ValueError('Polynomials comparison "{} >= {}" is inconclusive.'
                      .format(self, other))

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -106,6 +106,10 @@ class PolyTest(jtu.JaxTestCase):
     assert 0 < poly
     assert constant_poly(3) >= 1
     assert constant_poly(3) > 1
+    assert poly >= poly
+    assert poly >= poly - 1
+    assert poly < poly + 1
+
     self.assertRaisesRegex(ValueError, "", lambda: poly >= 2)
     self.assertRaisesRegex(ValueError, "", lambda: poly > 1)
 


### PR DESCRIPTION
In the case when the difference between two polynomials is a
constant, it is possible to conclusively compare them. This commit
adds such a case to `masking.Poly.__ge__`.

I ran into such a case in the tests of #4166 ([link](https://github.com/google/jax/pull/4166/checks?check_run_id=1040679020)). This would fix the issue.