### PR TITLE
Add support for axis_index inside vmap

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -645,7 +645,7 @@ class TraceStack:
     return new
 
 class Sublevel(int): pass
-AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size', 'tag'])
+AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size', 'master_trace'])
 
 
 class TraceState:
@@ -1436,7 +1436,7 @@ axis_frame = None
 def omnistaging_enabler() -> None:
   global thread_local_state, call_bind, find_top_trace, initial_style_staging, \
       new_master, reset_trace_state, extend_axis_env, axis_frame, \
-      axis_index, new_base_master, eval_context, \
+      new_base_master, eval_context, \
       TraceStack, TraceState
   del initial_style_staging
 
@@ -1573,8 +1573,8 @@ def omnistaging_enabler() -> None:
   Primitive.bind = bind
 
   @contextmanager
-  def extend_axis_env(axis_name, size: int, tag: Any):
-    frame = AxisEnvFrame(axis_name, size, tag)
+  def extend_axis_env(axis_name, size: int, master_trace: Optional[MasterTrace]):
+    frame = AxisEnvFrame(axis_name, size, master_trace)
     thread_local_state.trace_state.axis_env.append(frame)
     try:
       yield
@@ -1588,45 +1588,3 @@ def omnistaging_enabler() -> None:
         return frame
     else:
       raise NameError("unbound axis name: {}".format(axis_name))
-
-  def axis_index(axis_name):
-    """Return the index along the mapped axis ``axis_name``.
-
-    Args:
-      axis_name: hashable Python object used to name the mapped axis.
-
-    Returns:
-      An integer representing the index.
-
-    For example, with 8 XLA devices available:
-
-    >>> from functools import partial
-    >>> @partial(jax.pmap, axis_name='i')
-    ... def f(_):
-    ...   return lax.axis_index('i')
-    ...
-    >>> f(np.zeros(4))
-    ShardedDeviceArray([0, 1, 2, 3], dtype=int32)
-    >>> f(np.zeros(8))
-    ShardedDeviceArray([0, 1, 2, 3, 4, 5, 6, 7], dtype=int32)
-    >>> @partial(jax.pmap, axis_name='i')
-    ... @partial(jax.pmap, axis_name='j')
-    ... def f(_):
-    ...   return lax.axis_index('i'), lax.axis_index('j')
-    ...
-    >>> x, y = f(np.zeros((4, 2)))
-    >>> print(x)
-    [[0 0]
-    [1 1]
-    [2 2]
-    [3 3]]
-    >>> print(y)
-    [[0 1]
-    [0 1]
-    [0 1]
-    [0 1]]
-    """
-    return axis_index_p.bind(axis_name=axis_name)
-
-
-axis_index_p = Primitive('axis_index')

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -408,8 +408,9 @@ tf_not_yet_impl = [
   # Not high priority?
   lax.after_all_p, lax.all_to_all_p, lax.create_token_p, lax.cummax_p, lax.cummin_p,
   lax.infeed_p, lax.outfeed_p, lax.pmax_p, lax.pmin_p, lax.ppermute_p, lax.psum_p,
+  lax.axis_index_p,
 
-  pxla.xla_pmap_p, pxla.axis_index_p,
+  pxla.xla_pmap_p,
 ]
 
 try:

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -142,7 +142,7 @@ class BatchTrace(Trace):
         axis_names = (axis_names,)
       for i, axis_name in enumerate(axis_names):
         frame = core.axis_frame(axis_name)
-        if frame.tag is not self.master:
+        if frame.master_trace is not self.master:
           continue
         # We run the split_axis rule with tracers, which is supposed to never
         # mix this axis name with another one. We will handle any invocations

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -43,7 +43,6 @@ from ..config import flags, config
 from .. import core
 from .. import linear_util as lu
 from .. import lazy
-from .. import source_info_util
 from ..abstract_arrays import ConcreteArray, ShapedArray, array_types
 from ..core import Var, Literal
 from ..util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -45,7 +45,7 @@ from .. import linear_util as lu
 from .. import lazy
 from .. import source_info_util
 from ..abstract_arrays import ConcreteArray, ShapedArray, array_types
-from ..core import Var, Literal, axis_index_p
+from ..core import Var, Literal
 from ..util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,
                     extend_name_stack, wrap_name)
 from ..lib import xla_bridge as xb
@@ -414,79 +414,6 @@ def apply_parallel_primitive(prim, *args, **params):
   return parallel_pure_rules[prim](*args, shape=shape, **params)
 
 parallel_pure_rules: Dict[core.Primitive, Callable] = {}
-
-
-def axis_index(axis_name):
-  """Return the index along the pmapped axis ``axis_name``.
-
-  On multi-host platforms, returns unique indices on each host, in line with the
-  conceptual model of a multi-host pmap running over a single array sharded
-  across hosts. See the "Multi-host platforms" section of the :func:`jax.pmap`
-  documentation.
-
-  Args:
-    axis_name: hashable Python object used to name the pmapped axis (see the
-      :func:`jax.pmap` documentation for more details).
-
-  Returns:
-    An integer representing the index.
-
-  For example, with 8 XLA devices available:
-
-  >>> from functools import partial
-  >>> @partial(pmap, axis_name='i')
-  ... def f(_):
-  ...   return lax.axis_index('i')
-  ...
-  >>> f(np.zeros(4))
-  ShardedDeviceArray([0, 1, 2, 3], dtype=int32)
-  >>> f(np.zeros(8))
-  ShardedDeviceArray([0, 1, 2, 3, 4, 5, 6, 7], dtype=int32)
-  >>> @partial(pmap, axis_name='i')
-  ... @partial(pmap, axis_name='j')
-  ... def f(_):
-  ...   return lax.axis_index('i'), lax.axis_index('j')
-  ...
-  >>> x, y = f(np.zeros((4, 2)))
-  >>> print(x)
-  [[0 0]
-   [1 1]
-   [2 2]
-   [3 3]]
-  >>> print(y)
-  [[0 1]
-   [0 1]
-   [0 1]
-   [0 1]]
-  """
-  return axis_index_p.bind(axis_name=axis_name)
-
-def _axis_index_bind(*, axis_name):
-  dynamic_axis_env = _thread_local_state.dynamic_axis_env
-  frame = dynamic_axis_env[axis_name]
-  sizes = dynamic_axis_env.sizes[:dynamic_axis_env.index(frame)+1]
-  nreps = dynamic_axis_env.nreps
-  trace = frame.pmap_trace
-
-  out_aval = ShapedArray((), np.int32)
-  out_tracer = pe.JaxprTracer(trace, pe.PartialVal.unknown(out_aval), None)
-  eqn = pe.new_eqn_recipe([], [out_tracer], axis_index_p,
-                          dict(nreps=nreps, sizes=sizes, axis_name=axis_name),
-                          source_info_util.current())
-  out_tracer.recipe = eqn
-
-  return out_tracer
-
-def _axis_index_translation_rule(c, nreps, sizes, axis_name):
-  div = xb.constant(c, np.array(nreps // prod(sizes), dtype=np.uint32))
-  mod = xb.constant(c, np.array(sizes[-1], dtype=np.uint32))
-  unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
-  return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
-
-axis_index_p.def_custom_bind(_axis_index_bind)
-axis_index_p.def_abstract_eval(
-    lambda *args, **params: ShapedArray((), np.int32))
-xla.translations[axis_index_p] = _axis_index_translation_rule
 
 
 ### lazy device-memory persistence and result handling
@@ -1222,7 +1149,7 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
     raise NotImplementedError(msg)
 
   jaxpr, _, consts = _soft_pmap_jaxpr(jaxpr, consts, mapped_invars,
-                                      axis_name, chunk_size)
+                                      axis_name, axis_size, chunk_size)
   jaxpr_replicas = xla.jaxpr_replicas(jaxpr)
   if jaxpr_replicas != 1: raise NotImplementedError
 
@@ -1260,11 +1187,12 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
 
   return partial(execute_replicated, compiled, backend, handle_args, handle_outs)
 
-def _soft_pmap_jaxpr(jaxpr, consts, mapped_invars, axis_name, chunk_size):
+def _soft_pmap_jaxpr(jaxpr, consts, mapped_invars, axis_name, axis_size, chunk_size):
   fun = partial(_soft_pmap_interp, chunk_size, jaxpr, consts, mapped_invars)
   in_avals = [core.unmapped_aval(chunk_size, v.aval) if m else v.aval
               for v, m in zip(jaxpr.invars, mapped_invars)]
-  return pe.trace_to_jaxpr_dynamic(lu.wrap_init(fun), in_avals)
+  with core.extend_axis_env(axis_name, axis_size, None):
+    return pe.trace_to_jaxpr_dynamic(lu.wrap_init(fun), in_avals)
 
 def _soft_pmap_interp(chunk_size, jaxpr, consts, mapped_invars, *args):
   env: Dict[Var, Tuple[Any, bool]] = {}
@@ -1351,11 +1279,6 @@ soft_pmap_p.def_impl(soft_pmap_impl)
 
 soft_pmap_rules: Dict[core.Primitive, Callable] = {}
 
-def _axis_index_soft_pmap_rule(vals, mapped, chunk_size, *, axis_name):
-  assert not vals and not mapped
-  idx = core.axis_index(axis_name)  # type: ignore
-  return idx * chunk_size + np.arange(chunk_size), True
-
 def deleted_with_omnistaging(*a, **k):
   assert False, "Should be deleted"
 
@@ -1363,13 +1286,11 @@ def deleted_with_omnistaging(*a, **k):
 def omnistaging_enable() -> None:
   global DynamicAxisEnvFrame, DynamicAxisEnv, _ThreadLocalState, \
       _thread_local_state, extend_dynamic_axis_env, unmapped_device_count, \
-      axis_index, _axis_index_bind, _axis_index_translation_rule, \
       apply_parallel_primitive, parallel_pure_rules, \
       _pvals_to_results_handler, _pval_to_result_handler, replicate, \
-      avals_to_results_handler, axis_index
+      avals_to_results_handler
   del DynamicAxisEnvFrame, DynamicAxisEnv, _ThreadLocalState, \
       _thread_local_state, extend_dynamic_axis_env, unmapped_device_count, \
-      axis_index, _axis_index_bind, _axis_index_translation_rule, \
       _pvals_to_results_handler, _pval_to_result_handler, replicate
 
   apply_parallel_primitive = deleted_with_omnistaging
@@ -1400,11 +1321,3 @@ def omnistaging_enable() -> None:
                     for buf in bufs)
       return [h(bufs) for h, bufs in zip(handlers, buffers)]
     return handler
-
-  soft_pmap_rules[axis_index_p] = _axis_index_soft_pmap_rule  # type: ignore
-
-  axis_index_p.bind = partial(core.Primitive.bind, axis_index_p)  # type: ignore
-  axis_index_p.def_abstract_eval(lambda *, axis_name: ShapedArray((), np.int32))
-  del xla.translations[axis_index_p]
-
-  from ..core import axis_index  # type: ignore # noqa: F401

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1293,11 +1293,3 @@ pe.staged_out_calls.add(xla_call_p)
 def omnistaging_enabler() -> None:
   global _pval_to_result_handler
   del _pval_to_result_handler
-
-  def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
-    div = xb.constant(c, np.array(axis_env.nreps // prod(axis_env.sizes),
-                                  dtype=np.uint32))
-    mod = xb.constant(c, np.array(axis_env.sizes[-1], dtype=np.uint32))
-    unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
-    return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
-  parallel_translations[core.axis_index_p] = _axis_index_translation_rule  # type: ignore

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -322,6 +322,7 @@ from .lax_parallel import (
   all_to_all,
   all_to_all_p,
   axis_index,
+  axis_index_p,
   pmax,
   pmax_p,
   pmean,

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -628,8 +628,6 @@ def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
 def _axis_index_bind(*, axis_name):
   dynamic_axis_env = pxla._thread_local_state.dynamic_axis_env
   frame = dynamic_axis_env[axis_name]
-  sizes = dynamic_axis_env.sizes[:dynamic_axis_env.index(frame)+1]
-  nreps = dynamic_axis_env.nreps
   trace = frame.pmap_trace
 
   out_aval = ShapedArray((), np.int32)

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -673,6 +673,10 @@ def omnistaging_enabler() -> None:
   if psum_p in pxla.parallel_pure_rules:
     del pxla.parallel_pure_rules[psum_p]
 
+  # Axis index doesn't get any arguments, so that the default bind would have no
+  # way to call into a data-dependency based trace such as vmap. Each trace that
+  # wants to bind an axis name has to additionally implement `process_axis_index`
+  # and put its master trace on the axis env stack.
   def _axis_index_bind(*, axis_name):
     frame = core.axis_frame(axis_name)
     if frame.master_trace is not None:

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -22,22 +22,21 @@ import numpy as np
 from jax import core
 from jax import dtypes
 from jax import tree_util
+from jax import source_info_util
 from jax.lax import lax
 from jax.abstract_arrays import ShapedArray, raise_to_shaped
 from jax.interpreters import ad
 from jax.interpreters import xla
 from jax.interpreters import pxla
 from jax.interpreters import batching
+from jax.interpreters import partial_eval as pe
 from jax.util import partial, unzip2, prod
 from jax.lib import xla_client as xc
+from jax.lib import xla_bridge as xb
 from jax.config import config
 from jax.numpy import lax_numpy
 
-from jax.interpreters.pxla import axis_index
-
 xops = xc.ops
-
-pxla.multi_host_supported_collectives.add(core.axis_index_p)
 
 
 ### parallel traceables
@@ -288,6 +287,46 @@ def all_to_all(x, axis_name, split_axis, concat_axis):
     return all_to_all_p.bind(x, split_axis=split_axis, concat_axis=concat_axis,
                              axis_name=axis_name)
   return tree_util.tree_map(bind, x)
+
+def axis_index(axis_name):
+  """Return the index along the mapped axis ``axis_name``.
+
+  Args:
+    axis_name: hashable Python object used to name the mapped axis.
+
+  Returns:
+    An integer representing the index.
+
+  For example, with 8 XLA devices available:
+
+  >>> from functools import partial
+  >>> @partial(jax.pmap, axis_name='i')
+  ... def f(_):
+  ...   return lax.axis_index('i')
+  ...
+  >>> f(np.zeros(4))
+  ShardedDeviceArray([0, 1, 2, 3], dtype=int32)
+  >>> f(np.zeros(8))
+  ShardedDeviceArray([0, 1, 2, 3, 4, 5, 6, 7], dtype=int32)
+  >>> @partial(jax.pmap, axis_name='i')
+  ... @partial(jax.pmap, axis_name='j')
+  ... def f(_):
+  ...   return lax.axis_index('i'), lax.axis_index('j')
+  ...
+  >>> x, y = f(np.zeros((4, 2)))
+  >>> print(x)
+  [[0 0]
+  [1 1]
+  [2 2]
+  [3 3]]
+  >>> print(y)
+  [[0 1]
+  [0 1]
+  [0 1]
+  [0 1]]
+  """
+  return axis_index_p.bind(axis_name=axis_name)
+
 
 ### parallel primitives
 
@@ -579,6 +618,43 @@ def all_gather(x, axis_name):
   return _allgather(x, 0, psum(1, axis_name), axis_name)
 
 
+def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
+  div = xb.constant(c, np.array(axis_env.nreps // prod(axis_env.sizes),
+                                dtype=np.uint32))
+  mod = xb.constant(c, np.array(axis_env.sizes[-1], dtype=np.uint32))
+  unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
+  return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
+
+def _axis_index_bind(*, axis_name):
+  dynamic_axis_env = pxla._thread_local_state.dynamic_axis_env
+  frame = dynamic_axis_env[axis_name]
+  sizes = dynamic_axis_env.sizes[:dynamic_axis_env.index(frame)+1]
+  nreps = dynamic_axis_env.nreps
+  trace = frame.pmap_trace
+
+  out_aval = ShapedArray((), np.int32)
+  out_tracer = pe.JaxprTracer(trace, pe.PartialVal.unknown(out_aval), None)
+  eqn = pe.new_eqn_recipe([], [out_tracer], axis_index_p,
+                          dict(axis_name=axis_name),
+                          source_info_util.current())
+  out_tracer.recipe = eqn
+
+  return out_tracer
+
+def _axis_index_soft_pmap_rule(vals, mapped, chunk_size, *, axis_name):
+  assert not vals and not mapped
+  idx = axis_index(axis_name)  # type: ignore
+  return idx * chunk_size + np.arange(chunk_size), True
+
+axis_index_p = core.Primitive('axis_index')
+xla.parallel_translations[axis_index_p] = _axis_index_translation_rule
+pxla.soft_pmap_rules[axis_index_p] = _axis_index_soft_pmap_rule  # type: ignore
+axis_index_p.def_custom_bind(_axis_index_bind)
+axis_index_p.def_abstract_eval(
+    lambda *args, **params: ShapedArray((), np.int32))
+pxla.multi_host_supported_collectives.add(axis_index_p)
+
+
 @config.register_omnistaging_enabler
 def omnistaging_enabler() -> None:
   # We set a special bind rule for psum so that psum(1, 'i') can be evaluated at
@@ -598,3 +674,17 @@ def omnistaging_enabler() -> None:
 
   if psum_p in pxla.parallel_pure_rules:
     del pxla.parallel_pure_rules[psum_p]
+
+  def _axis_index_bind(*, axis_name):
+    frame = core.axis_frame(axis_name)
+    if frame.master_trace is not None:
+      trace = frame.master_trace.trace_type(frame.master_trace, core.cur_sublevel())
+      return trace.process_axis_index(frame)
+    return core.Primitive.bind(axis_index_p, axis_name=axis_name)
+
+  axis_index_p.def_custom_bind(_axis_index_bind)
+
+  def process_axis_index(self, frame):
+    return batching.BatchTracer(self, lax_numpy.arange(frame.size, dtype=np.int32), 0)
+
+  batching.BatchTrace.process_axis_index = process_axis_index

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1004,7 +1004,7 @@ class BatchingTest(jtu.JaxTestCase):
 
   @skipIf(not jax.config.omnistaging_enabled,
           "vmap collectives only supported when omnistaging is enabled")
-  def testPpermute(self):
+  def testPPermute(self):
     nelem = 10
     ntests = 10
     x = np.arange(nelem)
@@ -1017,7 +1017,6 @@ class BatchingTest(jtu.JaxTestCase):
       self.assertAllClose(
         vmap(lambda x: x - lax.ppermute(x, 'i', perm_pairs)[0], axis_name='i')(x),
         x - x[perm])
-
 
   def testNegativeAxes(self):
     x = np.arange(3*4*5).reshape(3, 4, 5)
@@ -1049,6 +1048,14 @@ class BatchingTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "axis -2 is out of bounds.*"):
       jax.vmap(lambda *xs: xs, in_axes=(0, None), out_axes=(0, -2))(
         np.arange(5), 7)
+
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testAxisIndex(self):
+    x = np.arange(10)
+    self.assertAllClose(
+      vmap(lambda x: x - lax.axis_index('i'), axis_name='i')(x),
+      x - np.arange(x.shape[0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also, reorganize the code to put all `axis_index` related functions in
`lax_parallel.py`, next to all other parallel collectives.