### PR TITLE
[Ready to be submitted] Add more features to the C++ jax.jit.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,10 +28,10 @@ http_archive(
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "03dd1adcfe560a634a63bafe582632d1130376cecf5d91ab03c3b26da2d839c7",
-    strip_prefix = "tensorflow-a2c58558b6f98fd54a3b40097269bdf592195969",
+    sha256 = "3fb86bfd01986be94fa94c74c29ddade8e8981cb56ed8d449cf63a21664a0d8c",
+    strip_prefix = "tensorflow-3c75664e72c40fc202fd986903cea39bd526f63d",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/a2c58558b6f98fd54a3b40097269bdf592195969.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/3c75664e72c40fc202fd986903cea39bd526f63d.tar.gz",
     ],
 )
 

--- a/jaxlib/version.py
+++ b/jaxlib/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.53"
+__version__ = "0.1.54"

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 from absl.testing import absltest
 from absl.testing import parameterized
 import jax
@@ -19,6 +21,7 @@ from jax import lib as jaxlib
 from jax import numpy as jnp
 from jax import test_util as jtu
 from jax.config import flags
+from jax.lib import version
 from jax.lib import xla_bridge
 import numpy as np
 
@@ -77,6 +80,16 @@ class JaxJitTest(parameterized.TestCase):
     self.assertEqual(res, 1 + 1j)
     self.assertEqual(res.dtype, complex_type)
     self.assertEqual(jnp.asarray(1 + 1j).dtype, res.dtype)
+
+  def test_signature_support(self):
+    if version < (0, 1, 54):
+      return
+
+    def f(a, b, c):
+      return a + b + c
+
+    jitted_f = jax.api._cpp_jit(f)
+    self.assertEqual(inspect.signature(f), inspect.signature(jitted_f))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This mainly follows https://github.com/google/jax/pull/4089 by adding:

- support for disable_jit from C++
- support for jax._cpp_jit on methods.
- supporting applying @jax.jit on top-level functions, by delaying the retrieval of the device and backend.
- concurrency support.

Now remains the unknowns bugs and missing features. I will be hunting them down until all tests pass. I think some differences are due to the differences between xla_computation and _xla_callable.)

![benchmark](https://user-images.githubusercontent.com/534945/91557607-100c4700-e935-11ea-8f8b-783782557d2f.png)


See:

- https://i.ibb.co/ZMvZ4nK/benchmark.png for the benchmarking comparison (see
 cr/328899906 + benchmarks for how numbers were generated)
- The results of the Jax tests when enabling this:
http://sponge2/4a67d132-209f-45c5-ab7b-83716d329ec2 (110 fails, 92 passes, but many common cause of failure).