### PR TITLE
[jax2tf] Turn on with_gradient by default

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -134,7 +134,7 @@ def _tfval_add_unit(vals: Sequence[TfValOrUnit],
 tf_impl: Dict[core.Primitive,
               Callable[..., Any]] = {}
 
-def convert(fun, with_gradient=False):
+def convert(fun, with_gradient=True):
   """Transforms `fun` to be executed by TensorFlow.
 
   Args:

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -120,7 +120,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
          with_function=with_function)
     for with_function in [False, True]))
   def test_gradients_disabled(self, with_function=False):
-    f_tf = jax2tf.convert(jnp.tan)
+    f_tf = jax2tf.convert(jnp.tan, with_gradient=False)
     if with_function:
       f_tf = tf.function(f_tf, autograph=False)
     x = tf.ones([])

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -73,7 +73,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     all_primitives = tuple(sorted(all_primitives, key=str))
     for p in all_primitives:
-      if p.name == "axis_index":
+      # TODO: remove tie_in once omnistaging is on by default
+      if p.name == "axis_index" or p.name == "tie_in":
         continue
       if p in tf_not_yet_impl:
         self.assertNotIn(p, tf_impl)  # Should not be in both tf_impl and tf_not_yet_impl

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -54,7 +54,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
   def test_gradient_disabled(self):
     f_jax = lambda x: x * x
     model = tf.Module()
-    model.f = tf.function(jax2tf.convert(f_jax),
+    model.f = tf.function(jax2tf.convert(f_jax, with_gradient=False),
                           autograph=False,
                           input_signature=[tf.TensorSpec([], tf.float32)])
     x = np.array(0.7)


### PR DESCRIPTION
As I was writing the demo I realized that it makes more sense for
with_gradient to be set to True by default.

I have also fixed a bug with tie_in in omnistaging.