### PR TITLE
jnp.abs(): support boolean inputs

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -464,7 +464,8 @@ def right_shift(x1, x2):
 
 @_wraps(np.absolute)
 def absolute(x):
-  return x if issubdtype(_dtype(x), unsignedinteger) else lax.abs(x)
+  dt = _dtype(x)
+  return x if dt == bool_ or issubdtype(dt, unsignedinteger) else lax.abs(x)
 abs = _wraps(np.abs)(absolute)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -104,7 +104,7 @@ def op_record(name, nargs, dtypes, shapes, rng_factory, diff_modes,
                   test_name, check_dtypes, tolerance, inexact)
 
 JAX_ONE_TO_ONE_OP_RECORDS = [
-    op_record("abs", 1, number_dtypes + unsigned_dtypes,
+    op_record("abs", 1, number_dtypes + unsigned_dtypes + bool_dtypes,
               all_shapes, jtu.rand_default, ["rev"]),
     op_record("add", 2, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default, []),


### PR DESCRIPTION
Part of #3913; this is supported by numpy, but not currently by jax.numpy.