### PR TITLE
Call check_arraylike() in jax.numpy reductions

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1668,7 +1668,7 @@ def _make_reduction(name, np_fun, op, init_val, preproc=None, bool_op=None,
     if out is not None:
       raise ValueError("reduction does not support the `out` argument.")
     _check_arraylike(name, a)
-    
+
     a = a if isinstance(a, ndarray) else asarray(a)
     a = preproc(a) if preproc else a
     dims = _reduction_dims(a, axis)
@@ -2325,16 +2325,6 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 def _can_call_numpy_array(x):
   return _all(not isinstance(l, (core.Tracer, DeviceArray))
               for l in tree_leaves(x))
-
-
-def _strict_asarray(a, dtype=None):
-  """A more restrictive jnp.asarray.
-  Accepts scalars and JAX or numpy array-like objects, but raises
-  an error for tuples or lists.
-  """
-  if not isinstance(a, (np.ndarray, ndarray) + _scalar_types):
-    raise TypeError(f"Array input required; got {a} of type {type(a)}")
-  return asarray(a, dtype)
 
 
 @_wraps(np.asarray)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1657,7 +1657,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
 ### Reducers
 
 
-def _make_reduction(np_fun, op, init_val, preproc=None, bool_op=None,
+def _make_reduction(name, np_fun, op, init_val, preproc=None, bool_op=None,
                     upcast_f16_for_computation=False):
   """Creates reduction function given a binary operation and monoid identity."""
 
@@ -1667,11 +1667,8 @@ def _make_reduction(np_fun, op, init_val, preproc=None, bool_op=None,
   def reduction(a, axis=None, dtype=None, out=None, keepdims=False):
     if out is not None:
       raise ValueError("reduction does not support the `out` argument.")
-
-    if isinstance(a, (list, tuple)):
-      msg = ("jax.numpy reductions won't accept lists and tuples in future "
-             "versions, only scalars and ndarrays")
-      warnings.warn(msg, category=FutureWarning)
+    _check_arraylike(name, a)
+    
     a = a if isinstance(a, ndarray) else asarray(a)
     a = preproc(a) if preproc else a
     dims = _reduction_dims(a, axis)
@@ -1714,14 +1711,14 @@ def _reduction_init_val(a, init_val):
 
 _cast_to_bool = partial(lax.convert_element_type, new_dtype=bool_)
 
-sum = _make_reduction(np.sum, lax.add, 0, upcast_f16_for_computation=True,
+sum = _make_reduction("sum", np.sum, lax.add, 0, upcast_f16_for_computation=True,
                       bool_op=lax.bitwise_or)
-product = prod = _make_reduction(np.prod, lax.mul, 1, bool_op=lax.bitwise_and,
+product = prod = _make_reduction("prod", np.prod, lax.mul, 1, bool_op=lax.bitwise_and,
                                  upcast_f16_for_computation=True)
-amax = max = _make_reduction(np.max, lax.max, -np.inf)
-amin = min = _make_reduction(np.min, lax.min, np.inf)
-all = alltrue = _make_reduction(np.all, lax.bitwise_and, True, _cast_to_bool)
-any = sometrue = _make_reduction(np.any, lax.bitwise_or, False, _cast_to_bool)
+amax = max = _make_reduction("max", np.max, lax.max, -np.inf)
+amin = min = _make_reduction("min", np.min, lax.min, np.inf)
+all = alltrue = _make_reduction("all", np.all, lax.bitwise_and, True, _cast_to_bool)
+any = sometrue = _make_reduction("any", np.any, lax.bitwise_or, False, _cast_to_bool)
 
 
 @_wraps(np.mean)
@@ -2328,6 +2325,16 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 def _can_call_numpy_array(x):
   return _all(not isinstance(l, (core.Tracer, DeviceArray))
               for l in tree_leaves(x))
+
+
+def _strict_asarray(a, dtype=None):
+  """A more restrictive jnp.asarray.
+  Accepts scalars and JAX or numpy array-like objects, but raises
+  an error for tuples or lists.
+  """
+  if not isinstance(a, (np.ndarray, ndarray) + _scalar_types):
+    raise TypeError(f"Array input required; got {a} of type {type(a)}")
+  return asarray(a, dtype)
 
 
 @_wraps(np.asarray)


### PR DESCRIPTION
This is a breaking change, but the warning has been in place since #3369

This replaces the approach in #4155