### PR TITLE
Add array_split (#70)

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -67,6 +67,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     array
     array_equal
     array_repr
+    array_split
     array_str
     asarray
     atleast_1d

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -22,7 +22,7 @@ from .lax_numpy import (
     ComplexWarning, NINF, NZERO, PZERO, abs, absolute, add, all, allclose,
     alltrue, amax, amin, angle, any, append, arange, arccos, arccosh, arcsin,
     arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, argwhere, around,
-    array, array_equal, array_repr, array_str, asarray, atleast_1d, atleast_2d,
+    array, array_equal, array_repr, array_split, array_str, asarray, atleast_1d, atleast_2d,
     atleast_3d, average, bartlett, bfloat16, bincount, bitwise_and, bitwise_not,
     bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays,
     broadcast_to, can_cast, cbrt, cdouble, ceil, character, clip, column_stack,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1486,26 +1486,33 @@ def broadcast_to(arr, shape):
     kept_dims = tuple(np.delete(np.arange(len(shape)), new_dims))
     return lax.broadcast_in_dim(squeeze(arr, tuple(diff)), shape, kept_dims)
 
-
-@_wraps(np.split)
-def split(ary, indices_or_sections, axis=0):
-  axis = core.concrete_or_error(int, axis, "in jax.numpy.split argument `axis`")
+def _split(op, ary, indices_or_sections, axis=0):
+  axis = core.concrete_or_error(int, axis, f"in jax.numpy.{op} argument `axis`")
   size = ary.shape[axis]
   if isinstance(indices_or_sections, (tuple, list) + _arraylike_types):
-    indices_or_sections = [core.concrete_or_error(int, i_s, "in jax.numpy.split argument 1")
+    indices_or_sections = [core.concrete_or_error(int, i_s, f"in jax.numpy.{op} argument 1")
                            for i_s in indices_or_sections]
     split_indices = np.concatenate([[0], indices_or_sections, [size]])
   else:
     indices_or_sections = core.concrete_or_error(int, indices_or_sections,
-                                                 "in jax.numpy.split argument 1")
+                                                 f"in jax.numpy.{op} argument 1")
     part_size, r = _divmod(size, indices_or_sections)
-    if r != 0:
+    if r == 0:
+      split_indices = np.arange(indices_or_sections + 1) * part_size
+    elif op == "array_split":
+      split_indices = np.concatenate([np.arange(r + 1) * (part_size + 1),
+                                      np.arange(indices_or_sections - r) * part_size
+                                      + ((r + 1) * (part_size + 1) - 1)])
+    else:
       raise ValueError("array split does not result in an equal division")
-    split_indices = np.arange(indices_or_sections + 1) * part_size
   starts, ends = [0] * ndim(ary), shape(ary)
   _subval = lambda x, i, v: subvals(x, [(i, v)])
   return [lax.slice(ary, _subval(starts, axis, start), _subval(ends, axis, end))
           for start, end in zip(split_indices[:-1], split_indices[1:])]
+
+@_wraps(np.split)
+def split(ary, indices_or_sections, axis=0):
+  return _split("split", ary, indices_or_sections, axis=axis)
 
 def _split_on_axis(np_fun, axis):
   @_wraps(np_fun, update_doc=False)
@@ -1517,6 +1524,9 @@ vsplit = _split_on_axis(np.vsplit, axis=0)
 hsplit = _split_on_axis(np.hsplit, axis=1)
 dsplit = _split_on_axis(np.dsplit, axis=2)
 
+@_wraps(np.array_split)
+def array_split(ary, indices_or_sections, axis=0):
+  return _split("array_split", ary, indices_or_sections, axis=axis)
 
 @_wraps(np.clip)
 def clip(a, a_min=None, a_max=None):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2154,6 +2154,23 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_axis={}_{}sections".format(
+          jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
+       "shape": shape, "num_sections": num_sections, "axis": axis, "dtype": dtype}
+      # All testcases split the specified axis unequally
+      for shape, axis, num_sections in [
+          ((3,), 0, 2), ((12,), 0, 5), ((12, 4), 0, 7), ((12, 4), 1, 3),
+          ((2, 3, 5), -1, 2), ((2, 4, 4), -2, 3), ((7, 2, 2), 0, 3)]
+      for dtype in default_dtypes))
+  def testArraySplitStaticInt(self, shape, num_sections, axis, dtype):
+    rng = jtu.rand_default(self.rng())
+    np_fun = lambda x: np.array_split(x, num_sections, axis=axis)
+    jnp_fun = lambda x: jnp.array_split(x, num_sections, axis=axis)
+    args_maker = lambda: [rng(shape, dtype)]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   def testSplitTypeError(self):
     # If we pass an ndarray for indices_or_sections -> no error
     self.assertEqual(3, len(jnp.split(jnp.zeros(3), jnp.array([1, 2]))))


### PR DESCRIPTION
This implements `array_split`.

As I was finishing this change, I noticed an [existing open draft PR for `array_split`](https://github.com/google/jax/pull/3639) (my fault for missing it when I checked first time round!).

Because that PR appears to have been inactive for some time and my code is quite different, I've opened a new PR here. However, if the other PR should be given priority, I'm happy to close this as a duplicate and for my proposed changes to be recycled if useful.