### PR TITLE
[jax2tf] Fix random.split when jax_exable_x64

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -617,8 +617,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            rtol=1e-5)
 
-  @primitive_harness.parameterized(primitive_harness.random_split,
-                                   one_containing="i=0")
+  @primitive_harness.parameterized(primitive_harness.random_split)
   def test_random_split(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -112,8 +112,10 @@ def _make_rotate_left(dtype):
   nbits = np.array(jnp.iinfo(dtype).bits, dtype)
 
   def _rotate_left(x, d):
-    if lax.dtype(d) != lax.dtype(x):
-      d = lax.convert_element_type(d, x.dtype)
+    if lax.dtype(d) != dtype:
+      d = lax.convert_element_type(d, dtype)
+    if lax.dtype(x) != dtype:
+      x = lax.convert_element_type(x, dtype)
     return lax.shift_left(x, d) | lax.shift_right_logical(x, nbits - d)
   return _rotate_left
 


### PR DESCRIPTION
Since we do the threefry with signed integers when converting to TF,
we run into the type promotion 'uint32 - int32 = int64', which
then results in lax.shift_right_logical(uint32, int64), which fails.