### PR TITLE
[jax2tf] Expand coverage of primitives by categorize.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -906,7 +906,8 @@ def _common_reduce_window(operand, init_val, reducer, window_dimensions,
                           window_strides, padding, base_dilation,
                           window_dilation):
   # TODO(tomhennigan): tf2xla should have a shape inference function.
-  out_shape = _reduce_window_shape(lax._reduce_window_sum, operand, window_dimensions,
+  out_shape = _reduce_window_shape(lax._reduce_window_min, operand,
+                                   window_dimensions,
                                    window_strides, padding, base_dilation,
                                    window_dilation)
 

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -4,8 +4,8 @@
 | --- | --- | --- | --- |
 | add | Missing TF support | add is unimplemented for dtype uint16 | CPU, GPU, TPU |
 | add | Missing TF support | add is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| atan2 | Missing TF support | Missing TF kernels for atan2 with dtype bfloat16 | CPU, GPU, TPU |
-| atan2 | Missing TF support | Missing TF kernels for atan2 with dtype float16 | CPU, GPU, TPU |
+| atan2 | Missing TF support | atan2 is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
+| atan2 | Missing TF support | atan2 is unimplemented for dtype float16 | CPU, GPU, TPU |
 | max | Missing TF support | max is unimplemented for dtype bool | CPU, GPU, TPU |
 | max | Missing TF support | max is unimplemented for dtype complex64 | CPU, GPU, TPU |
 | max | Missing TF support | max is unimplemented for dtype int8 | CPU, GPU, TPU |
@@ -22,7 +22,7 @@
 | qr | Missing TF support | qr is unimplemented for dtype complex64 | CPU, GPU, TPU |
 | reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint16 | CPU, GPU, TPU |
 | reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| rem | Missing TF support | Missing TF kernels for rem with dtype bfloat16 | CPU, GPU, TPU |
-| rem | Missing TF support | Missing TF kernels for rem with dtype float16 | CPU, GPU, TPU |
+| rem | Missing TF support | rem is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
+| rem | Missing TF support | rem is unimplemented for dtype float16 | CPU, GPU, TPU |
 | select_and_gather_add | Missing TF support | select_and_gather_add is unimplemented for dtype float32 | TPU |
-| svd | Missing TF support | svd is unimplemented for dtype complex64 | CPU, GPU |
+| svd | Missing TF support | svd is unimplemented for dtype complex64;this works on JAX because JAX uses a custom implementation | CPU, GPU |

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -25,4 +25,4 @@
 | rem | Missing TF support | rem is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
 | rem | Missing TF support | rem is unimplemented for dtype float16 | CPU, GPU, TPU |
 | select_and_gather_add | Missing TF support | select_and_gather_add is unimplemented for dtype float32 | TPU |
-| svd | Missing TF support | svd is unimplemented for dtype complex64;this works on JAX because JAX uses a custom implementation | CPU, GPU |
+| svd | Missing TF support | svd is unimplemented for dtype complex64; this works on JAX because JAX uses a custom implementation | CPU, GPU |

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -2,6 +2,8 @@
 
 | Affected primitive | Type of limitation | Description | Devices affected |
 | --- | --- | --- | --- |
+| add | Missing TF support | add is unimplemented for dtype uint16 | CPU, GPU, TPU |
+| add | Missing TF support | add is unimplemented for dtype uint32 | CPU, GPU, TPU |
 | atan2 | Missing TF support | Missing TF kernels for atan2 with dtype bfloat16 | CPU, GPU, TPU |
 | atan2 | Missing TF support | Missing TF kernels for atan2 with dtype float16 | CPU, GPU, TPU |
 | max | Missing TF support | max is unimplemented for dtype bool | CPU, GPU, TPU |
@@ -14,7 +16,13 @@
 | min | Missing TF support | min is unimplemented for dtype int8 | CPU, GPU, TPU |
 | min | Missing TF support | min is unimplemented for dtype uint16 | CPU, GPU, TPU |
 | min | Missing TF support | min is unimplemented for dtype uint32 | CPU, GPU, TPU |
+| mul | Missing TF support | mul is unimplemented for dtype uint32 | CPU, GPU, TPU |
 | nextafter | Missing TF support | nextafter is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
 | nextafter | Missing TF support | nextafter is unimplemented for dtype float16 | CPU, GPU, TPU |
+| qr | Missing TF support | qr is unimplemented for dtype complex64 | CPU, GPU, TPU |
+| reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint16 | CPU, GPU, TPU |
+| reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint32 | CPU, GPU, TPU |
 | rem | Missing TF support | Missing TF kernels for rem with dtype bfloat16 | CPU, GPU, TPU |
 | rem | Missing TF support | Missing TF kernels for rem with dtype float16 | CPU, GPU, TPU |
+| select_and_gather_add | Missing TF support | select_and_gather_add is unimplemented for dtype float32 | TPU |
+| svd | Missing TF support | svd is unimplemented for dtype complex64 | CPU, GPU |

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -73,7 +73,7 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.float16, dtypes.bfloat16]:
       # b/158006398: TF kernels are missing for 'rem' and 'atan2'
-      tf_unimpl(f"Missing TF kernels for {prim.name} with dtype {np_dtype}")
+      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
 
   if prim is lax.nextafter_p:
     np_dtype = _to_np_dtype(args[0].dtype)

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -14,7 +14,7 @@
 
 import functools
 import numpy as np
-from typing import Callable, List, NamedTuple, Optional, Tuple, Sequence
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Sequence
 
 from jax import core
 from jax import dtypes
@@ -31,6 +31,8 @@ Limitation = NamedTuple("Limitation", [ ("primitive_name", str)
                                       , ("error_string", str)
                                       , ("devices", Tuple[str,...])
                                       ])
+
+NpDType = Any
 
 def categorize(prim: core.Primitive, *args, **kwargs) \
     -> List[Limitation]:
@@ -54,9 +56,14 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
                       devs: Sequence[str] = all_devices) -> None:
     limitations.append(Limitation(prim.name, error_type, msg, tuple(devs)))
 
-  tf_unimpl = functools.partial(_report_failure, "Missing TF support")
+  def tf_unimpl(np_dtype: NpDType, additional_msg: Optional[str] = None,
+                devs: Sequence[str] = all_devices) -> None:
+    msg = f"{prim.name} is unimplemented for dtype {np_dtype}"
+    if additional_msg:
+      msg += ';' + additional_msg
+    _report_failure("Missing TF support", msg, devs=devs)
 
-  def _to_np_dtype(dtype):
+  def _to_np_dtype(dtype) -> NpDType:
     try:
       dtype = to_jax_dtype(dtype)
     except:
@@ -67,37 +74,37 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
                     np.complex64, np.complex128]:
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   if prim in [lax.rem_p, lax.atan2_p]:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.float16, dtypes.bfloat16]:
       # b/158006398: TF kernels are missing for 'rem' and 'atan2'
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   if prim is lax.nextafter_p:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.float16, dtypes.bfloat16]:
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   if prim is lax_linalg.qr_p:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.complex64, np.complex128]:
       # See https://github.com/google/jax/pull/3775#issuecomment-659407824;
       # experimental_compile=True breaks for complex types.
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   if prim is lax_linalg.svd_p:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.float16, dtypes.bfloat16]:
       # TODO: SVD on TPU for bfloat16 seems to work for JAX but fails for TF
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}",
-                devs=["TPU"])
+      tf_unimpl(np_dtype, devs=["TPU"])
     elif np_dtype in [np.complex64, np.complex128]:
       # TODO: on CPU and GPU "No registered 'Svd' OpKernel for XLA_CPU_JIT
       # devices". Works on JAX because JAX uses a custom implementation
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}",
-                devs=["CPU", "GPU"])
+      additional_msg = ("this works on JAX because JAX uses a custom "
+                        "implementation")
+      tf_unimpl(np_dtype, additional_msg=additional_msg, devs=["CPU", "GPU"])
 
   if prim is lax.select_and_gather_add_p:
     np_dtype = _to_np_dtype(args[0].dtype)
@@ -108,20 +115,19 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
       if dtypes.finfo(np_dtype).bits * 2 > max_bits:
         # TODO: getting an exception "XLA encountered an HLO for which this
         # rewriting is not implemented"
-        tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}",
-                  devs=devs)
+        tf_unimpl(np_dtype, devs=devs)
 
   if prim in [lax.add_p, lax.reduce_window_sum_p]:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.uint16, np.uint32, np.uint64]:
       # TODO(bchetioui): tf.math.add is not defined for the above types.
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   if prim is lax.mul_p:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [np.uint32, np.uint64]:
       # TODO(bchetioui): tf.math.multiply is not defined for the above types.
-      tf_unimpl(f"{prim.name} is unimplemented for dtype {np_dtype}")
+      tf_unimpl(np_dtype)
 
   return limitations
 

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -60,7 +60,7 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
                 devs: Sequence[str] = all_devices) -> None:
     msg = f"{prim.name} is unimplemented for dtype {np_dtype}"
     if additional_msg:
-      msg += ';' + additional_msg
+      msg += '; ' + additional_msg
     _report_failure("Missing TF support", msg, devs=devs)
 
   def _to_np_dtype(dtype) -> NpDType:

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -192,28 +192,19 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     if unimplemented_jax:
       raise unittest.SkipTest(f"QR not implemented in JAX for {dtype} on {dut}")
 
-    expect_tf_exceptions = False
-    if dtype in (np.complex64, np.complex128):
-      expect_tf_exceptions = True
     # TODO: see https://github.com/google/jax/pull/3775#issuecomment-659407824.
-    # - experimental_compile=True breaks for complex types;
     # - for now, the performance of the HLO QR implementation called when
     #   compiling with TF is expected to have worse performance than the
     #   custom calls made in JAX.
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions,
                            atol=1e-5, rtol=1e-5)
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_svd)
   def test_svd(self, harness: primitive_harness.Harness):
     if jtu.device_under_test() == "tpu":
       raise unittest.SkipTest("TODO: test crashes the XLA compiler for some TPU variants")
-    expect_tf_exceptions = False
     if harness.params["dtype"] in [np.float16, dtypes.bfloat16]:
-      if jtu.device_under_test() == "tpu":
-        # TODO: SVD on TPU for bfloat16 seems to work for JAX but fails for TF
-        expect_tf_exceptions = True
-      else:
+      if jtu.device_under_test() != "tpu":
         # Does not work in JAX
         with self.assertRaisesRegex(NotImplementedError, "Unsupported dtype"):
           harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
@@ -226,10 +217,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                                     "Binary op compare with different element types"):
           harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
         return
-      else:
-        # TODO: on CPU and GPU "No registered 'Svd' OpKernel for XLA_CPU_JIT devices".
-        # Works on JAX because JAX uses a custom implementation.
-        expect_tf_exceptions = True
 
     def _custom_assert(r_jax, r_tf, atol=1e-6, rtol=1e-6):
       def _reconstruct_operand(result, is_tf: bool):
@@ -258,61 +245,23 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            atol=tol, rtol=tol,
-                           expect_tf_exceptions=expect_tf_exceptions,
                            custom_assert=custom_assert,
                            always_custom_assert=True)
 
   @primitive_harness.parameterized(primitive_harness.lax_select_and_gather_add)
   def test_select_and_gather_add(self, harness: primitive_harness.Harness):
-    dtype = harness.params["dtype"]
-
-    max_bits = 64
-    if jtu.device_under_test() == "tpu":
-      max_bits = 32
-
-    expect_tf_exceptions = False
-    if dtypes.finfo(dtype).bits * 2 > max_bits:
-      # TODO: getting an exception "XLA encountered an HLO for which this rewriting is not implemented"
-      expect_tf_exceptions = True
-
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_reduce_window)
   def test_reduce_window(self, harness: primitive_harness.Harness):
-    f_name = harness.params['computation'].__name__
     dtype = harness.params['dtype']
-
-    expect_tf_exceptions = False
 
     if (jtu.device_under_test() == 'tpu' and dtype is np.complex64):
       raise unittest.SkipTest(
           'TODO: JAX reduce_window on TPU does not handle complex64'
       )
 
-    if ((f_name == 'min' or f_name == 'max') and
-        dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
-                      np.int16, np.int32, np.int64]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/minimum for a list of
-      # the types supported by tf.math.minimum/tf.math.maximum.
-      expect_tf_exceptions = True
-    elif (f_name == 'add' and
-          dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
-                        np.int8, np.int16, np.int32, np.int64, np.complex64,
-                        np.complex128]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/add for a list of the
-      # types supported by tf.math.add.
-      expect_tf_exceptions = True
-    elif (f_name == 'mul' and
-          dtype not in [dtypes.bfloat16, np.float16, np.float32, np.float64, np.uint8,
-                        np.int8, np.uint16, np.int16, np.int32, np.int64,
-                        np.complex64, np.complex128]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/multiply for a list of
-      # the types supported by tf.math.multiply.
-      expect_tf_exceptions = True
-
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_unary_elementwise)
   def test_unary_elementwise(self, harness: primitive_harness.Harness):
@@ -386,19 +335,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_add_mul)
   def test_add_mul(self, harness: primitive_harness.Harness):
-    expect_tf_exceptions = False
-    dtype = harness.params["dtype"]
-    f_name = harness.params["f_jax"].__name__
-
-    if dtype in [np.uint32, np.uint64]:
-      # TODO(bchetioui): tf.math.multiply is not defined for the above types.
-      expect_tf_exceptions = True
-    elif dtype is np.uint16 and f_name == "add":
-      # TODO(bchetioui): tf.math.add is defined for the same types as multiply,
-      # except uint16.
-      expect_tf_exceptions = True
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_min_max)
   def test_min_max(self, harness: primitive_harness.Harness):
@@ -535,34 +472,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_scatter(self, harness: primitive_harness.Harness):
     f_name = harness.params['f_lax'].__name__
     dtype = harness.params['dtype']
-    expect_tf_exceptions = False
 
     if jtu.device_under_test() == 'tpu':
-      if dtype is np.complex64:
-        if f_name in ['scatter_min', 'scatter_max']:
+      if dtype is np.complex64 and f_name in ['scatter_min', 'scatter_max']:
           raise unittest.SkipTest(f"TODO: complex {f_name} on TPU fails in JAX")
-        else:
-          # TODO: TensorFlow fails because of unimplemented cases
-          expect_tf_exceptions = True
 
-    if (f_name in ['scatter_min', 'scatter_max'] and
-        dtype in [np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
-                  np.complex64, np.complex128]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/minimum for a
-      # list of the types supported by tf.math.minimum/tf.math.maximum.
-      expect_tf_exceptions = True
-    elif (f_name == 'scatter_add' and
-          dtype in [np.uint16, np.uint32, np.uint64]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/add for a list
-      # of the types supported by tf.math.add.
-      expect_tf_exceptions = True
-    elif (f_name == 'scatter_mul' and dtype in [np.uint32, np.uint64]):
-      # See https://www.tensorflow.org/api_docs/python/tf/math/multiply for a
-      # list of the types supported by tf.math.multiply.
-      expect_tf_exceptions = True
-
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=expect_tf_exceptions)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   def test_boolean_gather(self):
     values = np.array([[True, True], [False, True], [False, False]],


### PR DESCRIPTION
This commit adds handling logic for the limitations of:
- qr
- svd
- select_and_gather_add
- reduce_window/reduce_window_{min,max,sum}
- add
- mul
- scatter/scatter_{min,max,mul,add}

Also fixes a bug in a call to _infer_shape_jax, which wasn't
compatible with boolean operands and went undetected due to the
high-level handling of TF exceptions in higher-order primitives.

`expect_tf_exception` is now only explicitly set in tests where the issue
is numerical differences, and for `population_count` where it requires
implementing tests for `bitcast`, which will be done in a separate PR.