### PR TITLE
Add more context to the axis_frame error message.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1588,4 +1588,5 @@ def omnistaging_enabler() -> None:
       if frame.name == axis_name:
         return frame
     else:
-      raise NameError("unbound axis name: {}".format(axis_name))
+      raise NameError(f"Unbound axis name: {axis_name}.\n"
+                      f"The currently bound axes are: {[f.name for f in frames]}")


### PR DESCRIPTION
Some of the vmap and gmap collective tests have been failing on master
and I can't seem to be able to reproduce them locally. Hopefully, if
this happens again, this extra bit of information will be useful in
debugging the problem.