### PR TITLE
[jax2tf] Fix bug in population count and move expect_tf_exception

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -454,7 +454,7 @@ tf_impl[lax.nextafter_p] = tf.math.nextafter
 
 def _population_count(x):
   orig_dtype = x.dtype
-  return tf.bitcast(tf.raw_ops.PopulationCount(x=x), orig_dtype)
+  return tf.cast(tf.raw_ops.PopulationCount(x=x), orig_dtype)
 
 tf_impl[lax.population_count_p] = _population_count
 tf_impl[lax.is_finite_p] = tf.math.is_finite

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -19,6 +19,7 @@
 | mul | Missing TF support | mul is unimplemented for dtype uint32 | CPU, GPU, TPU |
 | nextafter | Missing TF support | nextafter is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
 | nextafter | Missing TF support | nextafter is unimplemented for dtype float16 | CPU, GPU, TPU |
+| population_count | Missing TF support | population_count is unimplemented for dtype uint32 | CPU, GPU, TPU |
 | qr | Missing TF support | qr is unimplemented for dtype complex64 | CPU, GPU, TPU |
 | reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint16 | CPU, GPU, TPU |
 | reduce_window_sum | Missing TF support | reduce_window_sum is unimplemented for dtype uint32 | CPU, GPU, TPU |

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -134,6 +134,11 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype == np.complex64:
       tf_unimpl(np_dtype, devs=["TPU"])
 
+  if prim is lax.population_count_p:
+    np_dtype = _to_np_dtype(args[0].dtype)
+    if np_dtype == np.uint32:
+      tf_unimpl(np_dtype)
+
   return limitations
 
 def prettify(limitations: Sequence[Limitation]) -> str:

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -330,8 +330,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_population_count)
   def test_population_count(self, harness: primitive_harness.Harness):
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
-                           expect_tf_exceptions=True)
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_add_mul)
   def test_add_mul(self, harness: primitive_harness.Harness):


### PR DESCRIPTION
into correctness stats.

The code was using `tf.bitcast` instead of `tf.cast`, but using
`expect_tf_exception` in every case was hiding the errors.