### PR TITLE
Extend axis env while translating the pmapped jaxpr to XLA

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1589,4 +1589,4 @@ def omnistaging_enabler() -> None:
         return frame
     else:
       raise NameError(f"Unbound axis name: {axis_name}.\n"
-                      f"The currently bound axes are: {[f.name for f in frames]}")
+                      f"The currently bound axes are: {','.join(f.name for f in frames)}")

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -911,6 +911,17 @@ class PmapTest(jtu.JaxTestCase):
     expected = 1 + np.arange(device_count)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testAxisIndexInInitialStyle(self):
+    @partial(pmap, axis_name='i')
+    def f(x):
+      def body(carry, i):
+        return carry + i + lax.axis_index('i'), None
+      return lax.scan(body, 0, x)[0]
+    device_count = xla_bridge.device_count()
+    shape = (device_count, 10)
+    self.assertAllClose(f(jnp.ones(shape, dtype=np.int32)),
+                        (np.arange(device_count) + 1) * 10)
+
   def testVmapOfPmap(self):
     device_count = xla_bridge.device_count()
     f0 = lambda x: x


### PR DESCRIPTION
This is normally unnecessary, because the XLA translation usually
doesn't bind any of the primitives in the jaxpr, but this is not true in
case of scan! Its translation rule reevaluates the jaxpr as a function,
and if it contains collectives such as `axis_index` it can fail due to
axis being missing.