### PR TITLE
Add a test that fails due to unsupported strides.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -5,3 +5,4 @@ pillow
 pytest-benchmark
 pytest-xdist
 wheel
+torch


### PR DESCRIPTION
- test fails during dlpack tensor to buffer conversion
- XLA layout does not support arbitrary dlpack strides
- users should explicit materialze such tensors by making a copy