### PR TITLE
Add new public API: pxla.device_put()

### DIFF
--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1073,7 +1073,7 @@ class PmapTest(jtu.JaxTestCase):
     # subsequent pmap
     shard_shape = (3,2)
     shard = jnp.arange(prod(shard_shape)).reshape(shard_shape)
-    bufs = [xla.device_put(shard, d) for d in xla_bridge.devices()[:4]]
+    bufs = pxla.device_put(shard, xla_bridge.devices()[:4], replicate=True)
     aval = ShapedArray((6,4), shard.dtype)
     sharding_spec = pxla.ShardingSpec(
         shards_per_axis=(2, 2),


### PR DESCRIPTION
Why? We are changing the behavior of `device_put()` in #3983; this causes issues for downstream libraries that use internal APIs. An example is the trax project [here](https://github.com/google/trax/blob/67a4edf83fb77cd1a9df872005130cd2c04d1854/trax/layers/acceleration.py#L260-L264).

This PR introduces a new API to cover this, `pxla.device_put()`, so that we can change internal APIs without breaking downstream users.

Once this change is in, trax can use this new API and not be broken by #3983.