### PR TITLE
Reorder nocuda/cuda build to fail early.

### DIFF
--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -7,15 +7,6 @@ CUDA_VARIANTS="cuda" # "cuda-included"
 
 mkdir -p dist
 
-# build the pypi linux packages, tagging with manylinux1 for pypi reasons
-docker build -t jaxbuild jax/build/
-for PYTHON_VERSION in $PYTHON_VERSIONS
-do
-  mkdir -p dist/nocuda/
-  docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
-  mv -f dist/*.whl dist/nocuda/
-done
-
 # build the cuda linux packages, tagging with linux_x86_64
 for CUDA_VERSION in $CUDA_VERSIONS
 do
@@ -29,4 +20,13 @@ do
       mv -f dist/*.whl dist/${CUDA_VARIANT}${CUDA_VERSION//.}/
     done
   done
+done
+
+# build the pypi linux packages, tagging with manylinux1 for pypi reasons
+docker build -t jaxbuild jax/build/
+for PYTHON_VERSION in $PYTHON_VERSIONS
+do
+  mkdir -p dist/nocuda/
+  docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
+  mv -f dist/*.whl dist/nocuda/
 done


### PR DESCRIPTION
CUDA builds tend to fail more often. Reordering allows early failure.