### PR TITLE
Add comments for residuals from f_bwd.

### DIFF
--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -193,10 +193,11 @@
         "  return jnp.sin(x) * y\n",
         "\n",
         "def f_fwd(x, y):\n",
+        "# Returns primal output and residuals to be used in backward pass by f_bwd.\n",
         "  return f(x, y), (jnp.cos(x), jnp.sin(x), y)\n",
         "\n",
         "def f_bwd(res, g):\n",
-        "  cos_x, sin_x, y = res\n",
+        "  cos_x, sin_x, y = res # Gets residuals computed in f_fwd\n",
         "  return (cos_x * g * y, sin_x * g)\n",
         "\n",
         "f.defvjp(f_fwd, f_bwd)"


### PR DESCRIPTION
In my first reading of this notebook, i found it hard to understand what the 2nd return value of f_fwd is, and had to dig through API docstring for f_fwd. It might be easier to use comments to point out that this residual is immediately used by f_bwd.