### PR TITLE
Support non-fragmenting mask of reshape

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -403,6 +403,8 @@ class MaskTrace(Trace):
     out_aval = primitive.abstract_eval(*(t.aval for t in tracers), **params)
     vals, polymorphic_shapes = unzip2((t.val, t.polymorphic_shape) for t in tracers)
     logical_shapes = map(shape_as_value, polymorphic_shapes)
+    # TODO(mattjj): generalize mask rule signature
+    if primitive.name == 'reshape': params['polymorphic_shapes'] = polymorphic_shapes
     out = masking_rule(vals, logical_shapes, **params)
     if primitive.multiple_results:
       return map(partial(MaskTracer, self), out, (o.shape for o in out_aval))


### PR DESCRIPTION
Supports `mask(reshape)` for all non-fragmenting cases. 

Restrictions:
- Polymorphic (non-constant) dimensions have to stay in the same order (no swapping/splitting/merging allowed) and
- the product of each polymorphic size and all constant sizes before the next polymorphic dimension has to be unchanged.

For example, reshapes between the following shapes are allowed:
- `(n, 2)` <=> `2n`
- `(n, 2, 4, m)` <=> `(4n, 2, m)`

Examples of reshapes not allowed:
- `(2, n)` <≠> `2n`
- `(a, b)` <≠> `ab`
- `(a, b)` <≠> `(b, a)`

These would require `gather`/`scatter` operations. As we discussed in Jamie's talk, it is to be seen whether the resulting performance would be acceptable. This PR only implements parts that should be supported in any case.