### PR TITLE
[jax2tf] Build a primitive harness for test_type_promotion.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -875,3 +875,11 @@ random_split = tuple(
                                np.array([0, 0xFFFFFFFF], dtype=np.uint32),
                                np.array([0xFFFFFFFF, 0xFFFFFFFF], dtype=np.uint32)])
 )
+
+type_promotion = tuple(
+  Harness(f"_{f_jax.__name__}", f_jax, [], f_jax=f_jax)
+  for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
+                jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
+                jnp.greater_equal, jnp.not_equal, jnp.maximum,
+                jnp.minimum]
+)

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -875,11 +875,3 @@ random_split = tuple(
                                np.array([0, 0xFFFFFFFF], dtype=np.uint32),
                                np.array([0xFFFFFFFF, 0xFFFFFFFF], dtype=np.uint32)])
 )
-
-type_promotion = tuple(
-  Harness(f"_{f_jax.__name__}", f_jax, [], f_jax=f_jax)
-  for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
-                jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
-                jnp.greater_equal, jnp.not_equal, jnp.maximum,
-                jnp.minimum]
-)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -81,14 +81,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       else:
         self.assertIn(p, tf_impl)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    dict(testcase_name=f"_{f_jax.__name__}",
-         f_jax=f_jax)
-    for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
-                  jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
-                  jnp.greater_equal, jnp.not_equal, jnp.maximum,
-                  jnp.minimum]))
-  def test_type_promotion(self, f_jax=jnp.add):
+  @primitive_harness.parameterized(primitive_harness.type_promotion)
+  def test_type_promotion(self, harness: primitive_harness.Harness):
+    f_jax = harness.params["f_jax"]
     # We only test a few types here, as tensorflow does not support many
     # types like uint* or bool in binary ops.
     types = [dtypes.bfloat16, np.int32, np.int64, np.float32]

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -81,9 +81,14 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       else:
         self.assertIn(p, tf_impl)
 
-  @primitive_harness.parameterized(primitive_harness.type_promotion)
-  def test_type_promotion(self, harness: primitive_harness.Harness):
-    f_jax = harness.params["f_jax"]
+  @parameterized.named_parameters(
+    dict(testcase_name=f"_{f_jax.__name__}",
+         f_jax=f_jax)
+    for f_jax in [jnp.add, jnp.subtract, jnp.multiply, jnp.divide,
+                  jnp.less, jnp.less_equal, jnp.equal, jnp.greater,
+                  jnp.greater_equal, jnp.not_equal, jnp.maximum,
+                  jnp.minimum])
+  def test_type_promotion(self, f_jax=jnp.add):
     # We only test a few types here, as tensorflow does not support many
     # types like uint* or bool in binary ops.
     types = [dtypes.bfloat16, np.int32, np.int64, np.float32]


### PR DESCRIPTION
We were previously generating the cases using `jtu.cases_from_list`,
which by default dropped 2 test cases (JAX_NUM_GENERATED_CASES=10,
number of generated cases = 12).