### PR TITLE
[jax2tf] Added support for x64 for the remaining test files

### DIFF
--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -33,29 +33,29 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
 
-    self.ConvertAndCompare(f_jax, True, 1.)
-    self.ConvertAndCompare(f_jax, False, 1.)
+    self.ConvertAndCompare(f_jax, True, jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, False, jnp.float_(1.))
 
   def test_cond_multiple_results(self):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
 
-    self.ConvertAndCompare(f_jax, True, 1.)
-    self.ConvertAndCompare(f_jax, False, 1.)
+    self.ConvertAndCompare(f_jax, True, jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, False, jnp.float_(1.))
 
   def test_cond_partial_eval(self):
     def f(x):
       res = lax.cond(True, lambda op: op * x, lambda op: op + x, x)
       return res
-    self.ConvertAndCompare(jax.grad(f), 1.)
+    self.ConvertAndCompare(jax.grad(f), jnp.float_(1.))
 
 
   def test_cond_units(self, with_function=True):
     def g(x):
       return lax.cond(True, lambda x: x, lambda y: y, x)
 
-    self.ConvertAndCompare(g, 0.7)
-    self.ConvertAndCompare(jax.grad(g), 0.7)
+    self.ConvertAndCompare(g, jnp.float_(0.7))
+    self.ConvertAndCompare(jax.grad(g), jnp.float_(0.7))
 
 
   def test_cond_custom_jvp(self):
@@ -76,7 +76,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def g(x):
       return lax.cond(True, f, lambda y: y, x)
 
-    arg = 0.7
+    arg = jnp.float_(0.7)
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "jvp")
     self.TransformConvertAndCompare(g, arg, "vmap")
@@ -104,7 +104,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def g(x):
       return lax.cond(True, f, lambda y: y, x)
 
-    arg = 0.7
+    arg = jnp.float_(0.7)
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "vmap")
     self.TransformConvertAndCompare(g, arg, "grad_vmap")
@@ -117,7 +117,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
       #      for(i=x; i < 4; i++);
       return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
 
-    self.ConvertAndCompare(func, 0)
+    self.ConvertAndCompare(func, jnp.int_(0))
 
   def test_while(self):
     # Some constants to capture in the conditional branches
@@ -188,7 +188,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
       return lax.while_loop(lambda carry: carry[0] < 10,
                             lambda carry: (carry[0] + 1, f(carry[1])),
                             (0, x))
-    arg = 0.7
+    arg = jnp.float_(0.7)
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "jvp")
     self.TransformConvertAndCompare(g, arg, "vmap")

--- a/jax/experimental/jax2tf/tests/stax_test.py
+++ b/jax/experimental/jax2tf/tests/stax_test.py
@@ -18,6 +18,7 @@ import jax
 from jax import test_util as jtu
 import numpy as np
 import os
+import unittest
 import sys
 
 from jax.experimental.jax2tf.tests import tf_test_util
@@ -43,11 +44,12 @@ from jax.config import config
 
 config.parse_flags_with_absl()
 
-
 class StaxTest(tf_test_util.JaxToTfTestCase):
 
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def test_res_net(self):
+    if config.FLAGS.jax_enable_x64:
+      raise unittest.SkipTest("ResNet test fails on JAX when X64 is enabled")
     key = jax.random.PRNGKey(0)
     shape = (224, 224, 3, 1)
     init_fn, apply_fn = resnet50.ResNet50(1000)


### PR DESCRIPTION
This includes:
- control_flow_ops_test.py
- jax2tf_test.py
- saved_model_test.py
- stax_test