### PR TITLE
Add api.device_put_sharded()

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1990,8 +1990,9 @@ def device_put_sharded(x, devices: Sequence[xc.Device]):
     >>> np.allclose(x, y)
     True
 
-    Sharding a list of equivalent nested objects is equivalent to sharding the list
-    of each entry and repackaging the results to mach
+    Sharding a list of nested objects is equivalent to sharding the list
+    of each entry and repackaging the results to match the nesting. This
+    requires all entries in the list to have the same structure:
 
     >>> x = [(i, jnp.arange(i, i + 4)) for i in range(len(devices))]
     >>> y = api.device_put_sharded(x, devices)
@@ -2044,13 +2045,15 @@ def device_put_replicated(x, devices: Sequence[xc.Device]):
     >>> y.shape == (len(devices),) + x.shape
     True
 
-    Replicating a nested structure across all devices is equivalent to replicating each
-    entry, and then repackaging the result according to the input structure:
+    Replicating a nested structure is equivalent to replicating each entry in the
+    structure individually:
 
     >>> x = (1, jnp.arange(4), jnp.ones((2, 2)))
     >>> y = api.device_put_replicated(x, devices)
     >>> type(y)
     tuple
+    >>> len(y) == len(x)
+    True
     >>> y[2].shape == (len(devices), 2, 2)
     True
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -1968,15 +1968,15 @@ def device_put(x, device: Optional[xc.Device] = None):
 
 
 def device_put_sharded(x: Sequence[Any], devices: Sequence[xc.Device]) -> pxla.ShardedDeviceArray:
-  """Shards the input to specified devices, returning ShardedDeviceArrays.
+  """Transfers pre-sharded input to the specified devices, returning ShardedDeviceArrays.
 
   Args:
     x: A sequence of arrays, scalars, or (nested) standard Python containers thereof.
     devices: A sequence of devices()
 
   Returns:
-    A ShardedDeviceArray or (nested) Python container thereof containing a copy
-    of x sharded across the specified devices.
+    A ShardedDeviceArray or (nested) Python container thereof containing a stacked
+    version of x sharded across the specified devices.
 
   Examples:
     Passing a list of arrays results in a sharded array containing a stacked version

--- a/jax/api.py
+++ b/jax/api.py
@@ -1999,7 +1999,7 @@ def device_put_sharded(x, devices: Sequence[xc.Device]):
     >>> type(y)
     <class 'tuple'>
     >>> y0 = api.device_put_sharded([a for a, b in x], devices)
-    >>> y2 = api.device_put_sharded([b fr a, b in x], devices)
+    >>> y1 = api.device_put_sharded([b for a, b in x], devices)
     >>> np.allclose(y[0], y0)
     True
     >>> np.allclose(y[1], y1)

--- a/jax/api.py
+++ b/jax/api.py
@@ -1997,7 +1997,7 @@ def device_put_sharded(x, devices: Sequence[xc.Device]):
     >>> x = [(i, jnp.arange(i, i + 4)) for i in range(len(devices))]
     >>> y = api.device_put_sharded(x, devices)
     >>> type(y)
-    tuple
+    <class 'tuple'>
     >>> y0 = api.device_put_sharded([a for a, b in x], devices)
     >>> y2 = api.device_put_sharded([b fr a, b in x], devices)
     >>> np.allclose(y[0], y0)
@@ -2051,7 +2051,7 @@ def device_put_replicated(x, devices: Sequence[xc.Device]):
     >>> x = (1, jnp.arange(4), jnp.ones((2, 2)))
     >>> y = api.device_put_replicated(x, devices)
     >>> type(y)
-    tuple
+    <class 'tuple'>
     >>> len(y) == len(x)
     True
     >>> y[2].shape == (len(devices), 2, 2)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -656,26 +656,6 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(y2, jnp.vstack([b for _, b in x]))
     self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
 
-  def test_device_put_replicated(self):
-    devices = api.local_devices()
-    n_devices = len(devices)
-    x = np.arange(4)
-    y = api.device_put_replicated(x, devices)
-    self.assertEqual(len(y.device_buffers), len(devices))
-    self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertAllClose(y, jnp.stack(n_devices * [x]))
-
-  def test_device_put_replicated_pytree(self):
-    devices = api.local_devices()
-    n_devices = len(devices)
-    x = (1, np.arange(4))
-    y1, y2 = api.device_put_replicated(x, devices)
-    self.assertAllClose(y1, jnp.array([x[0] for d in devices]))
-    self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
-    self.assertAllClose(y2, jnp.vstack(n_devices * [x[1]]))
-    self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
-
-
   @jtu.skip_on_devices("tpu")
   def test_jacobian(self):
     R = np.random.RandomState(0).randn

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -637,7 +637,7 @@ class APITest(jtu.JaxTestCase):
       x = api.device_put(val, device=cpu_device)
       self.assertEqual(x.device_buffer.device(), cpu_device)
 
-  def test_device_put_sharded(self):
+  def test_device_put_sharded_array(self):
     devices = api.local_devices()
     n_devices = len(devices)
     x = [np.arange(i, i + 4) for i in range(n_devices)]
@@ -645,6 +645,16 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
     self.assertAllClose(y, jnp.stack(x))
+
+  def test_device_put_sharded_pytree(self):
+    devices = api.local_devices()
+    n_devices = len(devices)
+    x = [(i, np.arange(i, i + 4)) for i in range(n_devices)]
+    y1, y2 = api.device_put_sharded(x, devices)
+    self.assertAllClose(y1, jnp.array([a for a, _ in x]))
+    self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
+    self.assertAllClose(y2, jnp.vstack([b for _, b in x]))
+    self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
 
   def test_device_put_replicated(self):
     devices = api.local_devices()
@@ -654,6 +664,17 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
     self.assertAllClose(y, jnp.stack(n_devices * [x]))
+
+  def test_device_put_replicated_pytree(self):
+    devices = api.local_devices()
+    n_devices = len(devices)
+    x = (1, np.arange(4))
+    y1, y2 = api.device_put_replicated(x, devices)
+    self.assertAllClose(y1, jnp.array([x[0] for d in devices]))
+    self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
+    self.assertAllClose(y2, jnp.vstack(n_devices * [x[1]]))
+    self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
+
 
   @jtu.skip_on_devices("tpu")
   def test_jacobian(self):


### PR DESCRIPTION
There are a number of downstream libraries that roll these functions by reaching into internal APIs. Examples are flax [here](https://github.com/google/flax/blob/14883b01c9f75889577e4f6cd54b1ffff0925452/flax/jax_utils.py#L48-L61) and [here](https://github.com/google/flax/blob/14883b01c9f75889577e4f6cd54b1ffff0925452/flax/jax_utils.py#L154-L161), and trax [here](https://github.com/google/trax/blob/67a4edf83fb77cd1a9df872005130cd2c04d1854/trax/layers/acceleration.py#L227-L264), as well as a number of DM projects.

This is a first pass at providing the types of functionality that these downstream libraries need, so that we can decouple them from private APIs.