### PR TITLE
Fix code rendering in optimizers documentation

### DIFF
--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -66,6 +66,9 @@ the JAX transforms defined in api.py) and it has to be consumable by update_fun
 and get_params.
 
 Example Usage:
+
+.. code-block:: python
+
   opt = optimizers.sgd(learning_rate)
   opt_state = opt.init(params)
 

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -73,7 +73,7 @@ Example Usage:
   opt_state = opt.init(params)
 
   def step(step, opt_state):
-    value, grads = jax.value_and_grad(loss_fn)(opt.get_params(state))
+    value, grads = jax.value_and_grad(loss_fn)(opt.get_params(opt_state))
     opt_state = opt.update(step, grads, opt_state)
     return value, opt_state
 


### PR DESCRIPTION
The old documentation on https://jax.readthedocs.io/en/latest/jax.experimental.optimizers.html looks like:
<img width="603" alt="Screen Shot 2020-09-15 at 12 33 36 PM" src="https://user-images.githubusercontent.com/1733389/93256266-f437dc00-f74f-11ea-8c73-98b4cd4537ed.png">

This pull request attempts to fix the rendering of this block to be an actual code block.
It also fixes a small typo in the code.

The new rendered documentation at https://jax--4296.org.readthedocs.build/en/4296/jax.experimental.optimizers.html#module-jax.experimental.optimizers looks as follows:
<img width="715" alt="Screen Shot 2020-09-15 at 1 54 19 PM" src="https://user-images.githubusercontent.com/1733389/93263692-fb181c00-f75a-11ea-94a8-caaefd06b16d.png">
