### PR TITLE
Improve segment_sum stability by k-way summation.

### DIFF
--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -302,8 +302,12 @@ def index_update(x, idx, y, indices_are_sorted=False, unique_indices=False):
   return _scatter_update(
       x, idx, y, lax.scatter, indices_are_sorted, unique_indices)
 
-def segment_sum(data, segment_ids, num_segments=None,
-                indices_are_sorted=False, unique_indices=False):
+def segment_sum(data,
+                segment_ids,
+                num_segments=None,
+                indices_are_sorted=False,
+                unique_indices=False,
+                bucket_size=1024):
   """Computes the sum within segments of an array.
 
   Similar to TensorFlow's segment_sum:
@@ -321,8 +325,10 @@ def segment_sum(data, segment_ids, num_segments=None,
       calculated as ``max(max(segment_ids) + 1, max(-segment_ids))``.
       Since `num_segments` determines the size of the output, a static value
       must be provided to use `segment_sum` in a `jit`-compiled function.
-    indices_are_sorted: whether `segment_ids` is known to be sorted
-    unique_indices: whether `segment_ids` is known to be free of duplicates
+    indices_are_sorted: whether `segment_ids` is known to be sorted.
+    unique_indices: whether `segment_ids` is known to be free of duplicates.
+    bucket_size: size of bucket to group indices into. segment_sum is performed
+      on each bucket separately to improve numerical stability of addition.
 
   Returns:
     An array with shape :code:`(num_segments,) + data.shape[1:]` representing the
@@ -334,4 +340,18 @@ def segment_sum(data, segment_ids, num_segments=None,
 
   out = jnp.zeros((num_segments,) + data.shape[1:], dtype=data.dtype)
   segment_ids = jnp.mod(segment_ids, num_segments)
-  return index_add(out, segment_ids, data, indices_are_sorted, unique_indices)
+
+  num_buckets = -(-segment_ids.size // bucket_size)  # ceil_division
+  if num_buckets == 1:
+    return index_add(out, segment_ids, data, indices_are_sorted, unique_indices)
+
+  # Bucketize indices and perform segment_sum on each bucket to improve
+  # numerical stability.
+  outs = []
+  for sub_data, sub_segment_ids in zip(
+      jnp.array_split(data, num_buckets),
+      jnp.array_split(segment_ids, num_buckets)):
+    outs.append(
+        segment_sum(sub_data, sub_segment_ids, num_segments, indices_are_sorted,
+                    unique_indices))
+  return jnp.sum(jnp.stack(outs), axis=0)

--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -307,7 +307,7 @@ def segment_sum(data,
                 num_segments=None,
                 indices_are_sorted=False,
                 unique_indices=False,
-                bucket_size=1024):
+                bucket_size=None):
   """Computes the sum within segments of an array.
 
   Similar to TensorFlow's segment_sum:
@@ -329,6 +329,7 @@ def segment_sum(data,
     unique_indices: whether `segment_ids` is known to be free of duplicates.
     bucket_size: size of bucket to group indices into. segment_sum is performed
       on each bucket separately to improve numerical stability of addition.
+      Default `None` means no bucketing.
 
   Returns:
     An array with shape :code:`(num_segments,) + data.shape[1:]` representing the
@@ -341,7 +342,8 @@ def segment_sum(data,
   out = jnp.zeros((num_segments,) + data.shape[1:], dtype=data.dtype)
   segment_ids = jnp.mod(segment_ids, num_segments)
 
-  num_buckets = -(-segment_ids.size // bucket_size)  # ceil_division
+  num_buckets = 1 if bucket_size is None \
+                  else -(-segment_ids.size // bucket_size)  # ceil_division
   if num_buckets == 1:
     return index_add(out, segment_ids, data, indices_are_sorted, unique_indices)
 

--- a/jax/ops/scatter.py
+++ b/jax/ops/scatter.py
@@ -17,6 +17,7 @@
 
 from .. import lax
 from ..numpy import lax_numpy as jnp
+from .. import util
 
 
 def _scatter_update(x, idx, y, scatter_op, indices_are_sorted,
@@ -307,7 +308,7 @@ def segment_sum(data,
                 num_segments=None,
                 indices_are_sorted=False,
                 unique_indices=False,
-                bucket_size=None):
+                bucket_size=None): # TODO(zhangqiaorjc): use non-None default.
   """Computes the sum within segments of an array.
 
   Similar to TensorFlow's segment_sum:
@@ -343,7 +344,7 @@ def segment_sum(data,
   segment_ids = jnp.mod(segment_ids, num_segments)
 
   num_buckets = 1 if bucket_size is None \
-                  else -(-segment_ids.size // bucket_size)  # ceil_division
+                  else util.ceil_of_ratio(segment_ids.size, bucket_size)
   if num_buckets == 1:
     return index_add(out, segment_ids, data, indices_are_sorted, unique_indices)
 

--- a/jax/util.py
+++ b/jax/util.py
@@ -254,3 +254,6 @@ def canonicalize_axis(axis, num_dims):
   if axis < 0:
     axis = axis + num_dims
   return axis
+
+def ceil_of_ratio(x, y):
+  return -(-x // y)


### PR DESCRIPTION
segment_sum has numerical stability issues when it tries to sum a large number of very small numbers

Here's a simple repro
```python
import jax
import jax.numpy as jnp
import numpy as np

def compute_sums(length, device="cpu"):
  expected_sum = 2.0
  fill_value = expected_sum / length
  tensor = jnp.ones([length], dtype=jnp.float32) * fill_value
  if device == "cpu":
    tensor = jax.device_put(tensor, device=jax.devices('cpu')[0])
  elif device == "gpu":
    tensor = jax.device_put(tensor, device=jax.devices('gpu')[0])
  elif device == "tpu":
    tensor = jax.device_put(tensor, device=jax.devices('tpu')[0])
  else:
    raise RuntimeError("unsupported device")

  segment_ids = jnp.zeros([length], dtype=jnp.int32)
  reduce_sum = jnp.sum(tensor)

  seg_sum = jax.ops.segment_sum(tensor,
                                segment_ids,
                                num_segments=1,
                                indices_are_sorted=True)[0]
  unsorted_segment_sum = jax.ops.segment_sum(tensor,
                                             segment_ids,
                                             num_segments=1,
                                             indices_are_sorted=False)[0]

  print((f"length = {length}, reduce_sum = {reduce_sum},"
         f"seg_sum = {seg_sum},"
         f"unsorted_segment_sum = {unsorted_segment_sum},"))
  return jnp.abs(
      jnp.hstack([
          expected_sum - reduce_sum, expected_sum - seg_sum,
          expected_sum - unsorted_segment_sum
      ]))


lengths = np.array([1000000, 10000000, 25000000, 50000000, 75000000, 100000000])

cpu_sums = []
for length in lengths:
  cpu_sums.append(np.asarray(compute_sums(length, "cpu")))
cpu_sums = np.stack(cpu_sums, axis=0).T
worst_case_diff = cpu_sums[:, -1]
print("diff=", worst_case_diff)

# == Before this fix ==
# length = 1000000, reduce_sum = 2.000000476837158,seg_sum = 2.018077850341797,unsorted_segment_sum = 2.018077850341797,
# length = 10000000, reduce_sum = 2.0000014305114746,seg_sum = 2.129534959793091,unsorted_segment_sum = 2.129534959793091,
# length = 25000000, reduce_sum = 2.000000238418579,seg_sum = 2.0,unsorted_segment_sum = 2.0,
# length = 50000000, reduce_sum = 2.0000007152557373,seg_sum = 1.0,unsorted_segment_sum = 1.0,
# length = 75000000, reduce_sum = 2.0,seg_sum = 0.5,unsorted_segment_sum = 0.5,
# length = 100000000, reduce_sum = 2.0000009536743164,seg_sum = 0.5,unsorted_segment_sum = 0.5,
# diff= [9.536743e-07 1.500000e+00 1.500000e+00]

# == After this fix ==
# length = 1000000, reduce_sum = 2.000000476837158,segment_sum_1 = 2.018077850341797,unsorted_segment_sum_1 = 2.018077850341797,
# length = 10000000, reduce_sum = 2.0000014305114746,segment_sum_1 = 1.9812092781066895,unsorted_segment_sum_1 = 1.9812092781066895,
# length = 25000000, reduce_sum = 2.000000238418579,segment_sum_1 = 1.9934706687927246,unsorted_segment_sum_1 = 1.9934706687927246,
# length = 50000000, reduce_sum = 2.0000007152557373,segment_sum_1 = 1.9934706687927246,unsorted_segment_sum_1 = 1.9934706687927246,
# length = 75000000, reduce_sum = 2.0,segment_sum_1 = 1.9881486892700195,unsorted_segment_sum_1 = 1.9881486892700195,
# length = 100000000, reduce_sum = 2.0000009536743164,segment_sum_1 = 1.9934706687927246,unsorted_segment_sum_1 = 1.9934706687927246,
# diff= [9.536743e-07 6.529331e-03 6.529331e-03]
```