### PR TITLE
[jax2tf] Fix precision casting problem in convolution.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -670,7 +670,7 @@ def _conv_general_precision_config_proto(precision):
     return None
 
   proto = xla_data_pb2.PrecisionConfig()
-  proto.operand_precision.append(precision)
+  proto.operand_precision.append(int(precision))
   return proto
 
 def _conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -905,10 +905,10 @@ lax_conv_general_dilated = tuple( # Validate dtypes and precision
   # This first harness runs the tests for all dtypes and precisions using
   # default values for all the other parameters. Variations of other parameters
   # can thus safely skip testing their corresponding default value.
-  # _make_conv_harness("dtype_precision", dtype=dtype, precision=precision)
-  # for dtype in jtu.dtypes.all_inexact
-  # for precision in [None, lax.Precision.DEFAULT, lax.Precision.HIGH,
-  #                   lax.Precision.HIGHEST]
+  _make_conv_harness("dtype_precision", dtype=dtype, precision=precision)
+  for dtype in jtu.dtypes.all_inexact
+  for precision in [None, lax.Precision.DEFAULT, lax.Precision.HIGH,
+                    lax.Precision.HIGHEST]
 ) + tuple( # Validate variations of feature_group_count and batch_group_count
   _make_conv_harness("group_counts", lhs_shape=lhs_shape, rhs_shape=rhs_shape,
                      feature_group_count=feature_group_count,


### PR DESCRIPTION
In Python 3.6 (maybe 3.7 too?), the lax.Precision enumeration
was not implicitly casted to int, which made the construction
of the xla_data_pb2.PrecisionConfig object fail in the conversion
of convolution.