### PR TITLE
[jax2tf] Group error messages by dtype in pprint_limitations.

### DIFF
--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-09-16*
+*Last generated on (YYYY-MM-DD): 2020-09-17*
 
 ## Updating the documentation
 
@@ -20,8 +20,8 @@ conversion to Tensorflow.
 
 | Affected primitive | Type of limitation | Description | Affected dtypes | Affected devices |
 | --- | --- | --- | --- | --- |
-| acosh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | acosh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| acosh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | add | Missing TF support | Primitive is unimplemented | uint16, uint32, uint64 | CPU, GPU, TPU |
 | asinh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | asinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
@@ -31,12 +31,12 @@ conversion to Tensorflow.
 | bessel_i0e | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | bessel_i1e | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | conv_general_dilated | Missing TF support | Primitive is unimplemented; likely bug in the HLO -> LLVM IR lowering of XlaConv | complex64, complex128 | CPU, GPU, TPU |
-| conv_general_dilated | Missing TF support | Primitive is unimplemented; batch_group_count != 1 unsupported |  | CPU, GPU, TPU |
+| conv_general_dilated | Missing TF support | Primitive is unimplemented; batch_group_count != 1 unsupported | ALL | CPU, GPU, TPU |
 | cosh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | digamma | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | erf | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
-| erf_inv | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | erf_inv | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| erf_inv | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | erfc | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | fft | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | complex128, float64 | CPU, GPU, TPU |
 | lgamma | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
@@ -56,10 +56,10 @@ conversion to Tensorflow.
 | select_and_gather_add | Missing TF support | Primitive is unimplemented | float64 | CPU, GPU |
 | sinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented | complex128, complex64 | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; only sorting on last dimension is supported for XlaSort |  | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; only sorting on last dimension is supported for XlaSort | ALL | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented; sorting 2 arrays where the first one is an array of booleans is not supported for XlaSort | bool | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; sorting more than 2 arrays is not supported for XlaSort |  | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; stable sort not implemented for XlaSort |  | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; sorting more than 2 arrays is not supported for XlaSort | ALL | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; stable sort not implemented for XlaSort | ALL | CPU, GPU, TPU |
 | svd | Missing TF support | Primitive is unimplemented; this works on JAX because JAX uses a custom implementation | complex128, complex64 | CPU, GPU |
 | top_k | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | float64, int64, uint64 | CPU, GPU, TPU |
 

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-09-14*
+*Last generated on (YYYY-MM-DD): 2020-09-16*
 
 ## Updating the documentation
 
@@ -18,79 +18,50 @@ cases even for JAX, e.g., sort does not work for complex numbers on TPUs.
 This table includes only those cases that **work** in JAX but **fail** after
 conversion to Tensorflow.
 
-| Affected primitive | Type of limitation | Description | Devices affected |
-| --- | --- | --- | --- |
-| acosh | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| acosh | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| add | Missing TF support | Primitive is unimplemented for dtype uint16 | CPU, GPU, TPU |
-| add | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| add | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| asinh | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| asinh | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| atan2 | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
-| atan2 | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| atanh | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| atanh | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| bessel_i0e | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| bessel_i1e | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| conv_general_dilated | Missing TF support | Primitive is unimplemented for dtype complex128; likely bug in the HLO -> LLVM IR lowering of XlaConv | CPU, GPU, TPU |
-| conv_general_dilated | Missing TF support | Primitive is unimplemented for dtype complex64; likely bug in the HLO -> LLVM IR lowering of XlaConv | CPU, GPU, TPU |
-| conv_general_dilated | Missing TF support | Primitive is unimplemented; batch_group_count != 1 unsupported | CPU, GPU, TPU |
-| cosh | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| digamma | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| erf | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| erf_inv | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| erf_inv | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| erfc | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| fft | Missing TF support | Primitive is unimplemented for dtype complex128; this is a problem only in compiled mode (experimental_compile=True)) | CPU, GPU, TPU |
-| fft | Missing TF support | Primitive is unimplemented for dtype float64; this is a problem only in compiled mode (experimental_compile=True)) | CPU, GPU, TPU |
-| lgamma | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| max | Missing TF support | Primitive is unimplemented for dtype bool | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype complex128 | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype complex64 | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype int8 | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype uint16 | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| max | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype bool | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype complex128 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype complex64 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype int8 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype uint16 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| min | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| mul | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| mul | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| nextafter | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
-| nextafter | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| population_count | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| population_count | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| qr | Missing TF support | Primitive is unimplemented for dtype complex128 | CPU, GPU, TPU |
-| qr | Missing TF support | Primitive is unimplemented for dtype complex64 | CPU, GPU, TPU |
-| reduce_window_sum | Missing TF support | Primitive is unimplemented for dtype uint16 | CPU, GPU, TPU |
-| reduce_window_sum | Missing TF support | Primitive is unimplemented for dtype uint32 | CPU, GPU, TPU |
-| reduce_window_sum | Missing TF support | Primitive is unimplemented for dtype uint64 | CPU, GPU, TPU |
-| rem | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU, TPU |
-| rem | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| round | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| rsqrt | Missing TF support | Primitive is unimplemented for dtype bfloat16 | CPU, GPU |
-| scatter-add | Missing TF support | Primitive is unimplemented for dtype complex64 | TPU |
-| scatter-mul | Missing TF support | Primitive is unimplemented for dtype complex64 | TPU |
-| select_and_gather_add | Missing TF support | Primitive is unimplemented for dtype float32 | TPU |
-| select_and_gather_add | Missing TF support | Primitive is unimplemented for dtype float64 | CPU, GPU |
-| select_and_gather_add | Missing TF support | Primitive is unimplemented for dtype float64 | TPU |
-| sinh | Missing TF support | Primitive is unimplemented for dtype float16 | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented for dtype bool; sorting 2 arrays where the first one is an array of booleans is not supported for XlaSort | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented for dtype complex128 | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented for dtype complex64 | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; only sorting on last dimension is supported for XlaSort | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; sorting more than 2 arrays is not supported for XlaSort | CPU, GPU, TPU |
-| sort | Missing TF support | Primitive is unimplemented; stable sort not implemented for XlaSort | CPU, GPU, TPU |
-| svd | Missing TF support | Primitive is unimplemented for dtype complex128; this works on JAX because JAX uses a custom implementation | CPU, GPU |
-| svd | Missing TF support | Primitive is unimplemented for dtype complex64; this works on JAX because JAX uses a custom implementation | CPU, GPU |
-| top_k | Missing TF support | Primitive is unimplemented for dtype float64; this is a problem only in compiled mode (experimental_compile=True)) | CPU, GPU, TPU |
-| top_k | Missing TF support | Primitive is unimplemented for dtype int64; this is a problem only in compiled mode (experimental_compile=True)) | CPU, GPU, TPU |
-| top_k | Missing TF support | Primitive is unimplemented for dtype uint64; this is a problem only in compiled mode (experimental_compile=True)) | CPU, GPU, TPU |
+| Affected primitive | Type of limitation | Description | Affected dtypes | Affected devices |
+| --- | --- | --- | --- | --- |
+| acosh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| acosh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| add | Missing TF support | Primitive is unimplemented | uint16, uint32, uint64 | CPU, GPU, TPU |
+| asinh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| asinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| atan2 | Missing TF support | Primitive is unimplemented | bfloat16, float16 | CPU, GPU, TPU |
+| atanh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| atanh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| bessel_i0e | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| bessel_i1e | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| conv_general_dilated | Missing TF support | Primitive is unimplemented; likely bug in the HLO -> LLVM IR lowering of XlaConv | complex64, complex128 | CPU, GPU, TPU |
+| conv_general_dilated | Missing TF support | Primitive is unimplemented; batch_group_count != 1 unsupported |  | CPU, GPU, TPU |
+| cosh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| digamma | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| erf | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| erf_inv | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| erf_inv | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| erfc | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| fft | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | complex128, float64 | CPU, GPU, TPU |
+| lgamma | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| max | Missing TF support | Primitive is unimplemented | bool, complex128, complex64, int8, uint16, uint32, uint64 | CPU, GPU, TPU |
+| min | Missing TF support | Primitive is unimplemented | bool, complex128, complex64, int8, uint16, uint32, uint64 | CPU, GPU, TPU |
+| mul | Missing TF support | Primitive is unimplemented | uint32, uint64 | CPU, GPU, TPU |
+| nextafter | Missing TF support | Primitive is unimplemented | bfloat16, float16 | CPU, GPU, TPU |
+| population_count | Missing TF support | Primitive is unimplemented | uint32, uint64 | CPU, GPU, TPU |
+| qr | Missing TF support | Primitive is unimplemented | complex128, complex64 | CPU, GPU, TPU |
+| reduce_window_sum | Missing TF support | Primitive is unimplemented | uint16, uint32, uint64 | CPU, GPU, TPU |
+| rem | Missing TF support | Primitive is unimplemented | bfloat16, float16 | CPU, GPU, TPU |
+| round | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| rsqrt | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| scatter-add | Missing TF support | Primitive is unimplemented | complex64 | TPU |
+| scatter-mul | Missing TF support | Primitive is unimplemented | complex64 | TPU |
+| select_and_gather_add | Missing TF support | Primitive is unimplemented | float32, float64 | TPU |
+| select_and_gather_add | Missing TF support | Primitive is unimplemented | float64 | CPU, GPU |
+| sinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented | complex128, complex64 | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; only sorting on last dimension is supported for XlaSort |  | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; sorting 2 arrays where the first one is an array of booleans is not supported for XlaSort | bool | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; sorting more than 2 arrays is not supported for XlaSort |  | CPU, GPU, TPU |
+| sort | Missing TF support | Primitive is unimplemented; stable sort not implemented for XlaSort |  | CPU, GPU, TPU |
+| svd | Missing TF support | Primitive is unimplemented; this works on JAX because JAX uses a custom implementation | complex128, complex64 | CPU, GPU |
+| top_k | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | float64, int64, uint64 | CPU, GPU, TPU |
 
 ## Not yet implemented primitive conversions
 
@@ -103,4 +74,4 @@ The conversion of the following JAX primitives is not yet implemented:
 The following JAX primitives have a defined conversion but are known to be
 missing tests:
 
-`argmax`, `argmin`, `broadcast`, `clamp`, `complex`, `conj`, `custom_lin`, `dot_general`, `imag`, `integer_pow`, `real`, `rev`, `select_and_scatter`, `select_and_scatter_add`, `stop_gradient`
+`argmax`, `argmin`, `broadcast`, `clamp`, `complex`, `conj`, `custom_lin`, `device_put`, `dot_general`, `imag`, `integer_pow`, `real`, `rev`, `select_and_scatter`, `select_and_scatter_add`, `stop_gradient`, `tie_in`

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -63,9 +63,8 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
   def _report_failure(error_type: str, msg: str,
                       affected_dtype: Optional[NpDType] = None,
                       devs: Sequence[str] = all_devices) -> None:
-    affected_dtypes: Tuple[NpDType,...] = tuple()
-    if affected_dtype is not None:
-      affected_dtypes = tuple([affected_dtype])
+    affected_dtypes = (
+      tuple([affected_dtype]) if affected_dtype is not None else tuple())
     limitations.append(Limitation(prim.name, error_type, msg,
                                   affected_dtypes, tuple(devs)))
 
@@ -255,7 +254,8 @@ def prettify(limitations: Sequence[Limitation]) -> str:
     table.append([ lim.primitive_name
                  , lim.error_type
                  , lim.error_string
-                 , ', '.join(sorted(list(map(str, lim.affected_dtypes))))
+                 , ('ALL' if len(lim.affected_dtypes) == 0 else
+                    ', '.join(sorted(list(map(str, lim.affected_dtypes)))))
                  , ', '.join(lim.devices)
                  ])
 

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 import datetime
 import functools
 import numpy as np
-from typing import Any, Callable, Collection, List, NamedTuple, Optional, \
+from typing import Any, Callable, Collection, Dict, List, NamedTuple, Optional,\
                    Tuple, Sequence, Set
 
 from jax import core
@@ -32,13 +33,14 @@ def to_jax_dtype(tf_dtype):
     return dtypes.bfloat16
   return tf_dtype.as_numpy_dtype
 
+NpDType = Any
+
 Limitation = NamedTuple("Limitation", [ ("primitive_name", str)
                                       , ("error_type", str)
                                       , ("error_string", str)
+                                      , ("affected_dtypes", Tuple[NpDType,...])
                                       , ("devices", Tuple[str,...])
                                       ])
-
-NpDType = Any
 
 def categorize(prim: core.Primitive, *args, **kwargs) \
     -> List[Limitation]:
@@ -59,8 +61,13 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
   all_devices = ["CPU", "GPU", "TPU"]
 
   def _report_failure(error_type: str, msg: str,
+                      affected_dtype: Optional[NpDType] = None,
                       devs: Sequence[str] = all_devices) -> None:
-    limitations.append(Limitation(prim.name, error_type, msg, tuple(devs)))
+    affected_dtypes: Tuple[NpDType,...] = tuple()
+    if affected_dtype is not None:
+      affected_dtypes = tuple([affected_dtype])
+    limitations.append(Limitation(prim.name, error_type, msg,
+                                  affected_dtypes, tuple(devs)))
 
   def tf_unimpl(np_dtype: Optional[NpDType] = None,
                 additional_msg: Optional[str] = None,
@@ -68,11 +75,9 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
 
     missing_tf_support = "Missing TF support"
     msg = "Primitive is unimplemented"
-    if np_dtype is not None:
-      msg += f" for dtype {np_dtype}"
     if additional_msg:
       msg += '; ' + additional_msg
-    _report_failure(missing_tf_support, msg, devs=devs)
+    _report_failure(missing_tf_support, msg, np_dtype, devs=devs)
 
   def _to_np_dtype(dtype) -> NpDType:
     try:
@@ -215,6 +220,22 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
                                           "mode (experimental_compile=True))"))
   return limitations
 
+def merge_similar_limitations(limitations: Sequence[Limitation]) \
+    -> Sequence[Limitation]:
+  """Merges similar limitations together."""
+  merged_limitations: Dict[Limitation, Set[NpDType]] = defaultdict(set)
+
+  for lim in limitations:
+    key = Limitation(lim.primitive_name, lim.error_type, lim.error_string,
+                     tuple(), lim.devices)
+    value = lim.affected_dtypes
+    merged_limitations[key].update(value)
+
+  def _perform_merge(key: Limitation, values: Set[NpDType]) -> Limitation:
+    return key._replace(affected_dtypes=tuple(values))
+
+  return list(map(lambda kvp: _perform_merge(*kvp), merged_limitations.items()))
+
 def prettify(limitations: Sequence[Limitation]) -> str:
   """Constructs a summary markdown table based on a list of limitations."""
   limitations = sorted(list(set(limitations)))
@@ -225,7 +246,8 @@ def prettify(limitations: Sequence[Limitation]) -> str:
   column_names = [ 'Affected primitive'
                  , 'Type of limitation'
                  , 'Description'
-                 , 'Devices affected' ]
+                 , 'Affected dtypes'
+                 , 'Affected devices' ]
 
   table = [column_names, ['---'] * len(column_names)]
 
@@ -233,6 +255,7 @@ def prettify(limitations: Sequence[Limitation]) -> str:
     table.append([ lim.primitive_name
                  , lim.error_type
                  , lim.error_string
+                 , ', '.join(sorted(list(map(str, lim.affected_dtypes))))
                  , ', '.join(lim.devices)
                  ])
 
@@ -262,6 +285,7 @@ def pprint_limitations(limitations: Sequence[Limitation],
                        covered_primitives: Set[core.Primitive],
                        output_file: str, template_file: str) -> None:
 
+  limitations = merge_similar_limitations(limitations)
   limited_support_table = prettify(limitations)
   not_yet_impl_primitives = prettify_not_yet_implemented()
   not_yet_covered_primitives = prettify_not_yet_covered(covered_primitives)


### PR DESCRIPTION
This makes the output of the categorizer more synthetic in cases
when the error is exactly the same for a given primitive on a set
of devices for different dtypes.