### PR TITLE
improve an escaped tracer error message

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -464,9 +464,8 @@ class Tracer:
   def aval(self):
     raise NotImplementedError("must override")
 
-  @property
-  def _live(self):
-    return True  # Override for liveness checking
+  def _assert_live(self) -> None:
+    pass  # Override for liveness checking
 
   # Python looks up special methods only on classes, not instances. This means
   # these methods needs to be defined explicitly rather than relying on
@@ -743,7 +742,7 @@ def full_lower(val):
     return val
 
 def find_top_trace(xs) -> Trace:
-  traces = [x._live and x._trace.main for x in xs if isinstance(x, Tracer)]
+  traces = [x._assert_live() or x._trace.main for x in xs if isinstance(x, Tracer)]  # type: ignore
   top_main = max(traces, default=None, key=attrgetter('level'))
   dynamic = thread_local_state.trace_state.trace_stack.dynamic
   top_main = (dynamic if top_main is None or dynamic.level > top_main.level

--- a/jax/core.py
+++ b/jax/core.py
@@ -422,12 +422,14 @@ class Trace:
     del primitive, fwd, bwd, out_trees  # Unused.
     return fun.call_wrapped(*tracers)
 
-def escaped_tracer_error(detail):
+def escaped_tracer_error(detail=None):
   msg = ("Encountered an unexpected tracer. Perhaps this tracer escaped "
          "through global state from a previously traced function.\n"
          "The functions being transformed should not save traced values to "
-         "global state.\nDetails: {}.")
-  return UnexpectedTracerError(msg.format(detail))
+         "global state.")
+  if detail:
+    msg += " Detail: {}.".format(detail)
+  return UnexpectedTracerError(msg)
 
 class UnexpectedTracerError(Exception): pass
 
@@ -461,6 +463,10 @@ class Tracer:
   @property
   def aval(self):
     raise NotImplementedError("must override")
+
+  @property
+  def _live(self):
+    return True  # Override for liveness checking
 
   # Python looks up special methods only on classes, not instances. This means
   # these methods needs to be defined explicitly rather than relying on
@@ -737,8 +743,8 @@ def full_lower(val):
     return val
 
 def find_top_trace(xs) -> Trace:
-  top_main = max((x._trace.main for x in xs if isinstance(x, Tracer)),
-                    default=None, key=attrgetter('level'))
+  traces = [x._live and x._trace.main for x in xs if isinstance(x, Tracer)]
+  top_main = max(traces, default=None, key=attrgetter('level'))
   dynamic = thread_local_state.trace_state.trace_stack.dynamic
   top_main = (dynamic if top_main is None or dynamic.level > top_main.level
                 else top_main)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -830,12 +830,10 @@ class DynamicJaxprTracer(core.Tracer):
                 f"{self._trace.main.source_info}.")
     return origin
 
-  @property
-  def _live(self):
-    if not self._trace.main.jaxpr_stack:
+  def _assert_live(self) -> None:
+    if not self._trace.main.jaxpr_stack:  # type: ignore
       msg = f"tracer created on line {source_info_util.summarize(self.line_info)}"
       raise core.escaped_tracer_error(msg)
-    return True
 
 class JaxprStackFrame:
   __slots__ = ['newvar', 'tracer_to_var', 'constid_to_var', 'constvar_to_val',

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -830,6 +830,13 @@ class DynamicJaxprTracer(core.Tracer):
                 f"{self._trace.main.source_info}.")
     return origin
 
+  @property
+  def _live(self):
+    if not self._trace.main.jaxpr_stack:
+      msg = f"tracer created on line {source_info_util.summarize(self.line_info)}"
+      raise core.escaped_tracer_error(msg)
+    return True
+
 class JaxprStackFrame:
   __slots__ = ['newvar', 'tracer_to_var', 'constid_to_var', 'constvar_to_val',
                'tracers', 'eqns']
@@ -896,16 +903,18 @@ class DynamicJaxprTrace(core.Trace):
   __slots__ = []  # type: ignore
 
   @property
-  def frame(self): return self.main.jaxpr_stack[-1]  # pytype: disable=attribute-error
+  def frame(self):
+    return self.main.jaxpr_stack[-1]  # pytype: disable=attribute-error
 
   def new_arg(self, aval):
-    tracer = DynamicJaxprTracer(self, aval)
+    tracer = DynamicJaxprTracer(self, aval, source_info_util.current())
     self.frame.tracers.append(tracer)
     self.frame.tracer_to_var[id(tracer)] = self.frame.newvar(aval)
     return tracer
 
   def new_const(self, val):
-    tracer = DynamicJaxprTracer(self, raise_to_shaped(get_aval(val), weak_type=dtypes.is_python_scalar(val)))
+    aval = raise_to_shaped(get_aval(val), weak_type=dtypes.is_python_scalar(val))
+    tracer = DynamicJaxprTracer(self, aval, source_info_util.current())
     self.frame.tracers.append(tracer)
     var = self.frame.tracer_to_var[id(tracer)] = self.getconstvar(val)
     self.frame.constvar_to_val[var] = val
@@ -937,11 +946,11 @@ class DynamicJaxprTrace(core.Trace):
     avals = [t.aval for t in tracers]
     out_avals = primitive.abstract_eval(*avals, **params)
     out_avals = [out_avals] if not primitive.multiple_results else out_avals
-    out_tracers = [DynamicJaxprTracer(self, a) for a in out_avals]
+    source_info = source_info_util.current()
+    out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     outvars = map(self.getvar, out_tracers)
-    eqn = new_jaxpr_eqn(invars, outvars, primitive, params,
-                        source_info_util.current())
+    eqn = new_jaxpr_eqn(invars, outvars, primitive, params, source_info)
     self.frame.eqns.append(eqn)
     return out_tracers if primitive.multiple_results else out_tracers.pop()
 
@@ -950,7 +959,8 @@ class DynamicJaxprTrace(core.Trace):
     jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(f, self.main, in_avals)
     if not jaxpr.eqns:
       return core.eval_jaxpr(jaxpr, consts, *tracers)
-    out_tracers = [DynamicJaxprTracer(self, a) for a in out_avals]
+    source_info = source_info_util.current()
+    out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     outvars = map(self.getvar, out_tracers)
     constvars = map(self.getvar, map(self.instantiate_const, consts))
@@ -958,8 +968,8 @@ class DynamicJaxprTrace(core.Trace):
     update_params = call_param_updaters.get(call_primitive)
     if update_params:
       new_params = update_params(new_params, [True] * len(tracers))
-    eqn = new_jaxpr_eqn([*constvars, *invars], outvars, call_primitive, new_params,
-                        source_info_util.current())
+    eqn = new_jaxpr_eqn([*constvars, *invars], outvars, call_primitive,
+                        new_params, source_info)
     self.frame.eqns.append(eqn)
     return out_tracers
 
@@ -975,7 +985,8 @@ class DynamicJaxprTrace(core.Trace):
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.main, reduced_in_avals)
     out_avals = [core.unmapped_aval(params['axis_size'], a) for a in reduced_out_avals]
-    out_tracers = [DynamicJaxprTracer(self, a) for a in out_avals]
+    source_info = source_info_util.current()
+    out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     outvars = map(self.getvar, out_tracers)
     constvars = map(self.getvar, map(self.instantiate_const, consts))
@@ -985,7 +996,8 @@ class DynamicJaxprTrace(core.Trace):
     update_params = call_param_updaters.get(map_primitive)
     if update_params:
       new_params = update_params(new_params, [True] * len(tracers))
-    eqn = new_jaxpr_eqn([*constvars, *invars], outvars, map_primitive, new_params)
+    eqn = new_jaxpr_eqn([*constvars, *invars], outvars, map_primitive,
+                        new_params, source_info)
     self.frame.eqns.append(eqn)
     return out_tracers
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1690,7 +1690,7 @@ class APITest(jtu.JaxTestCase):
 
   def test_escaped_tracer_omnistaging(self):
     if not config.omnistaging_enabled:
-      raise SkipTest("test is omnistaging-specific")
+      raise unittest.SkipTest("test is omnistaging-specific")
 
     count = 1
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1641,7 +1641,7 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(
         core.UnexpectedTracerError,
         re.compile(
-          "Encountered an unexpected tracer.*Can't lift sublevels 1 to 0",
+          "Encountered an unexpected tracer",
           re.DOTALL)):
       api.jit(lambda x: x)(self._saved_tracer)
 
@@ -1687,6 +1687,30 @@ class APITest(jtu.JaxTestCase):
           "Encountered an unexpected tracer.*Tracer not among input tracers",
           re.DOTALL)):
       api.jit(func1)(2.)
+
+  def test_escaped_tracer_omnistaging(self):
+    if not config.omnistaging_enabled:
+      raise SkipTest("test is omnistaging-specific")
+
+    count = 1
+
+    @jit
+    def f():
+      nonlocal count
+      count = jnp.add(count, 1)
+    f()  # leaked a tracer! but currently undetected
+
+    def f(x, c):
+      jnp.add(count, 1)
+      return None, None
+
+    @jit
+    def g():
+      lax.scan(f, None, None, length=2)
+
+    with self.assertRaisesRegex(core.UnexpectedTracerError,
+                                "tracer created on line"):
+      g()
 
   def test_pmap_static_kwarg_error_message(self):
     # https://github.com/google/jax/issues/3007


### PR DESCRIPTION
Before this commit, encountering an escaped tracer in a specific way would lead to a bad internal error. This change
1. raises an UnexpectedTracerError instead, and
2. includes in the error message the user source line which created the
tracer.

Here's a repro for the original issue, which models an error several users started encountering with Flax and Haiku after we switched omnistaging on by default (#4038):

```python
from jax import jit
from jax import random

key = random.PRNGKey(0)

def init():
  global key
  key, subkey = random.split(key)
  return random.normal(subkey, ())

print(init())  # -1.2515389
print(init())  # -0.58665067

init = jit(init)
print(init())  # 0.48648298
print(init())  # 0.48648298  !!

# That last call has repeated randomness but no error, because we aren't
# re-executing the Python function and thus aren't actually touching the global
# Python key. But if we look at the key, we see an escaped tracer when
# omnistaginig is on (and no tracer when omnisitaging is off):

print(key)

# If we touch that key again, we'll get an error.

# If we touch it this way:
#
#   random.normal(key, ())
#
# We'll get this error:
#
#   jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global      state from a previously traced function.
#   The functions being transformed should not save traced values to global state.
#   Details: Can't lift sublevels 1 to 0.


# But if we touch it in just the right way, we can get a crappy internal error:

from jax import lax

def f(x, c):
  random.normal(key, ())
  return None, None

@jit
def g():
  lax.scan(f, None, None, length=2)

g()

#    File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/partial_eval.py", line 909, in new_const
#      self.frame.tracers.append(tracer)
#    File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/partial_eval.py", line 899, in frame
#      def frame(self): return self.main.jaxpr_stack[-1]  # pytype: disable=attribute-error
#  IndexError: tuple index out of range
```

That's a bad internal error!

Here's the error after this change:

```
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this
tracer escaped through global state from a previously traced function.
The functions being transformed should not save traced values to global state.
Detail: tracer created on line example.py:8 (init).
```

To make for a better error message, we
1. add an optional mechanism for `Tracer`s to implement for checking whether its corresponding main trace is still alive;
2. implement that mechanism for `DynamicJaxprTracer` (used in `jit`, `pmap`, and control flow), since those main traces already have a flag for whether it's still alive (i.e. whether the `jaxpr_stack` is nonempty);
3. update `find_top_trace` to check for liveness using that mechanism (it's the latest we can check for liveness while still having the offending escaped tracer in scope); and
4. add source info to each `DynamicJaxprTracer` instance for it to use in its `UnexpectedTracerError` message (we were already computing the source info for each jaxpr eqn created, and we just had to plumb it into the tracers).

cc @LenaMartens 