### PR TITLE
Fix shape checking rule for conv_general_dilated.

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -2471,6 +2471,10 @@ def _conv_general_dilated_shape_rule(
     lhs_dilation, rhs_dilation, dimension_numbers, feature_group_count,
     batch_group_count, **unused_kwargs) -> Tuple[int, ...]:
   assert type(dimension_numbers) is ConvDimensionNumbers
+  if len(lhs.shape) != len(rhs.shape):
+    msg = ("conv_general_dilated lhs and rhs must have the same number of "
+           "dimensions, but got {} and {}.")
+    raise ValueError(msg.format(lhs.shape, rhs.shape))
   if not feature_group_count > 0:
     msg = ("conv_general_dilated feature_group_count "
            "must be a positive integer, got {}.")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2011,7 +2011,7 @@ class LaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, msg):
       lax.population_count(True)
 
-  def test_conv_general_dilated_different_shapes_error(self):
+  def test_conv_general_dilated_different_input_ranks_error(self):
     # https://github.com/google/jax/issues/4316
     msg = ("conv_general_dilated lhs and rhs must have the same number of "
            "dimensions")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2011,6 +2011,26 @@ class LaxTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, msg):
       lax.population_count(True)
 
+  def test_conv_general_dilated_different_shapes_error(self):
+    # https://github.com/google/jax/issues/4316
+    msg = ("conv_general_dilated lhs and rhs must have the same number of "
+           "dimensions")
+    dimension_numbers = lax.ConvDimensionNumbers(lhs_spec=(0, 1, 2),
+                                                 rhs_spec=(0, 1, 2),
+                                                 out_spec=(0, 1, 2))
+    kwargs = { 'window_strides': (1,)
+             , 'padding': ((0, 0),)
+             , 'lhs_dilation': (1,)
+             , 'rhs_dilation': (1,)
+             , 'dimension_numbers': dimension_numbers
+             , 'feature_group_count': 1
+             , 'batch_group_count': 1
+             , 'precision': None
+             }
+    lhs, rhs = np.ones((1, 1, 1)), np.ones((1, 1, 1, 1))
+    with self.assertRaisesRegex(ValueError, msg):
+      lax.conv_general_dilated(lhs, rhs, **kwargs)
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):


### PR DESCRIPTION
This closes google/jax#4316.