### PR TITLE
rename and simplify TypedJaxpr -> ClosedJaxpr

### DIFF
--- a/docs/jax_internal_api.rst
+++ b/docs/jax_internal_api.rst
@@ -11,4 +11,4 @@ core
   :toctree: _autosummary
 
    Jaxpr
-   TypedJaxpr
+   ClosedJaxpr

--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -3,46 +3,40 @@ Understanding Jaxprs
 
 Updated: May 3, 2020 (for commit f1a46fe).
 
-Conceptually, one can think of JAX transformations as first tracing the Python
-function to be transformed into a small and well-behaved intermediate form,
-the jaxpr, that is then transformed accordingly, and ultimately compiled and executed.
-One of the reasons JAX can pack so much power into such a small software package
-is that it starts with a familiar and flexible programming interface (Python with NumPy)
-and it uses the actual Python interpreter to do most of the heavy lifting to distill the
-essence of the computation into a simple statically-typed expression language
-with limited higher-order features: the jaxpr language.
+Conceptually, one can think of JAX transformations as first trace-specializing
+the Python function to be transformed into a small and well-behaved
+intermediate form that is then interpreted with transformation-specific
+interpretation rules. One of the reasons JAX can pack so much power into such a
+small software package is that it starts with a familiar and flexible
+programming interface (Python with NumPy) and it uses the actual Python
+interpreter to do most of the heavy lifting to distill the essence of the
+computation into a simple statically-typed expression language with limited
+higher-order features. That language is the jaxpr language.
 
 Not all Python programs can be processed this way, but it turns out that many
-scientific computing and machine learning programs do have this property.
+scientific computing and machine learning programs can.
 
-Before we proceed, it is important to point out that not all JAX transformations
-materialize a jaxpr as described above; some, e.g., differentiation,
-will apply transformations incrementally during tracing.
-Nevertheless, if one wants to understand how JAX works internally, or to
-make use of the result of JAX tracing, it is useful to understand jaxpr.
+Before we proceed, it is important to point out that not all JAX
+transformations literally materialize a jaxpr as described above; some, e.g.,
+differentiation or batching, will apply transformations incrementally during
+tracing. Nevertheless, if one wants to understand how JAX works internally, or
+to make use of the result of JAX tracing, it is useful to understand jaxprs.
 
-A jaxpr instance represents a function with one or more typed parameters (input variables)
-and one or more typed results. The results depend only on the input
-variables; there are no free variables captured from enclosing scopes.
-The inputs and outputs have types, which in JAX are represented as abstract
-values. There are two related representations in the code for jaxprs. The main
-one is :py:class:`jax.core.TypedJaxpr` and is what you obtain when you
-use :py:func:`jax.make_jaxpr` to inspect jaxprs. It has the following
-fields:
+A jaxpr instance represents a function with one or more typed parameters (input
+variables) and one or more typed results. The results depend only on the input
+variables; there are no free variables captured from enclosing scopes. The
+inputs and outputs have types, which in JAX are represented as abstract values.
+There are two related representations in the code for jaxprs,
+:py:class:`jax.core.Jaxpr` and :py:class:`jax.core.ClosedJaxpr`. A
+:py:class:`jax.core.ClosedJaxpr` represents a partially-applied
+:py:class:`jax.core.Jaxpr`, and is what you obtain when you use
+:py:func:`jax.make_jaxpr` to inspect jaxprs. It has the following fields:
 
-  * ``jaxpr``: is the actual computation content of the actual function (described below).
-  * ``literals`` is a list of constants. For various reasons, during tracing JAX
-    will collect the non-scalar constants that arise and will replace them with
-    variables, e.g., constants that appear in the Python program, or the result of
-    constant folding such constants. The variables that stand for these constants
-    are mentioned separately in the enclosed ``jaxpr``.
-    When applying a ``TypedJaxpr`` to some actual
-    arguments, one must pass first the ``literals`` followed by the actual arguments.
-  * ``in_avals`` and ``out_avals`` are the types of the input variables
-    (excluding the ones that correspond to the ``literals``), and of the output values.
-    These types are called in JAX abstract values, e.g., ``ShapedArray(float32[10,10])``.
+  * ``jaxpr``: is a :py:class:`jax.core.Jaxpr` representing the actual
+    computation content of the function (described below).
+  * ``consts`` is a list of constants.
 
-The most interesting part of the TypedJaxpr is the actual execution content,
+The most interesting part of the ClosdJaxpr is the actual execution content,
 represented as a :py:class:`jax.core.Jaxpr` as printed using the following
 grammar::
 
@@ -51,15 +45,18 @@ grammar::
                in  [Expr+] }
 
 where:
-  * The parameter of the jaxpr are shown as two lists of variables separated by
+  * The parameters of the jaxpr are shown as two lists of variables separated by
     ``;``. The first set of variables are the ones that have been introduced
     to stand for constants that have been hoisted out. These are called the
-    `constvars`. The second list of variables are the real input variables.
+    ``constvars``, and in a :py:class:`jax.core.ClosedJaxpr` the ``consts``
+    field holds corresponding values. The second list of variables, called
+    ``invars``, correspond to the inputs of the traced Python function.
   * ``Eqn*`` is a list of equations, defining intermediate variables referring to
     intermediate expressions. Each equation defines one or more variables as the
     result of applying a primitive on some atomic expressions. Each equation uses only
     input variables and intermediate variables defined by previous equations.
-  * ``Expr+``: is a list of output atomic expressions for the jaxpr.
+  * ``Expr+``: is a list of output atomic expressions (literals or variables)
+    for the jaxpr.
 
 Equations are printed as follows::
 
@@ -69,9 +66,10 @@ where:
   * ``Var+`` are one or more intermediate variables to be defined as the
     output of a primitive invocation (some primitives can return multiple values)
   * ``Expr+`` are one or more atomic expressions, each either a variable or a
-    literal constant. A special form of an atomic expression is the `unit`
-    expression, printed as ``*`` and standing for a value that is not needed
-    in the rest of the computation and has been elided.
+    literal constant. A special variable ``unitvar`` or literal ``unit``,
+    printed as ``*``, represents a value that is not needed
+    in the rest of the computation and has been elided. That is, units are just
+    placeholders.
   * ``Param*`` are zero or more named parameters to the primitive, printed in
     square brackets. Each parameter is shown as ``Name = Value``.
 

--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -36,7 +36,7 @@ There are two related representations in the code for jaxprs,
     computation content of the function (described below).
   * ``consts`` is a list of constants.
 
-The most interesting part of the ClosdJaxpr is the actual execution content,
+The most interesting part of the ClosedJaxpr is the actual execution content,
 represented as a :py:class:`jax.core.Jaxpr` as printed using the following
 grammar::
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -1941,7 +1941,7 @@ def linear_transpose(fun: Callable, *primals) -> Callable:
 
 def make_jaxpr(fun: Callable,
                static_argnums: Union[int, Iterable[int]] = ()
-               ) -> Callable[..., core.TypedJaxpr]:
+               ) -> Callable[..., core.ClosedJaxpr]:
   """Creates a function that produces its jaxpr given example args.
 
   Args:
@@ -1952,7 +1952,7 @@ def make_jaxpr(fun: Callable,
 
   Returns:
     A wrapped version of ``fun`` that when applied to example arguments returns
-      a ``TypedJaxpr`` representation of ``fun`` on those arguments.
+      a ``ClosedJaxpr`` representation of ``fun`` on those arguments.
 
   A ``jaxpr`` is JAX's intermediate representation for program traces. The
   ``jaxpr`` language is based on the simply-typed first-order lambda calculus
@@ -2006,8 +2006,7 @@ def make_jaxpr(fun: Callable,
       jaxpr, out_pvals, consts = pe.trace_to_jaxpr(
           jaxtree_fun, in_pvals, instantiate=True, stage_out=True)  # type: ignore
       out_avals = map(raise_to_shaped, unzip2(out_pvals)[0])
-    typed_jaxpr = core.TypedJaxpr(jaxpr, consts, in_avals, out_avals)
-    return typed_jaxpr
+    return core.ClosedJaxpr(jaxpr, consts)
 
   jaxpr_maker.__name__ = "make_jaxpr({})".format(jaxpr_maker.__name__)
   return jaxpr_maker

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -20,7 +20,7 @@ import operator as op
 from . import core
 from . import linear_util as lu
 from .tree_util import tree_flatten, tree_unflatten, tree_map, tree_multimap
-from .util import safe_zip, safe_map, unzip2, split_list
+from .util import safe_zip, safe_map, split_list
 from .api_util import flatten_fun_nokwargs, argnums_partial, wrap_hashably
 from .abstract_arrays import raise_to_shaped
 from .ad_util import Zero, stop_gradient_p

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -635,14 +635,12 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
         new_jaxpr_invars[0:nr_const_and_carry] + [new_jaxpr_invars[-1]] +
         new_jaxpr_invars[nr_const_and_carry:-1])
     new_jaxpr.jaxpr.invars = new_jaxpr_invars
-    new_jaxpr.in_avals = [v.aval for v in new_jaxpr_invars]
 
     new_jaxpr_outvars = new_jaxpr.jaxpr.outvars
     new_jaxpr_outvars = (
         new_jaxpr_outvars[0:num_carry] + [new_jaxpr_outvars[-1]] +
         new_jaxpr_outvars[num_carry:-1])
     new_jaxpr.jaxpr.outvars = new_jaxpr_outvars
-    new_jaxpr.out_avals = [v.aval for v in new_jaxpr_outvars]
     eqns.append(
         core.new_jaxpr_eqn(
             new_invars,
@@ -775,6 +773,8 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
               name="cond_body",
               donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals)),
           eqn.source_info)
+  ]
+  new_body_jaxpr = core.ClosedJaxpr(
       core.Jaxpr([], (new_body_invars_cond_constvars +
                       new_body_invars_body_constvars + [new_body_invars_pred] +
                       new_body_invars_carry + [new_body_invars_token]),

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -531,19 +531,12 @@ xla.translations[id_tap_p] = _id_tap_translation_rule
 ####
 
 
-# TODO: we should really get rid of TypedJaxpr
-def _mk_typed_jaxpr(jaxpr: core.Jaxpr, literals: Sequence) -> core.TypedJaxpr:
-  return core.TypedJaxpr(jaxpr, literals,
-                         tuple(map(lambda v: v.aval, jaxpr.invars)),
-                         tuple(map(lambda v: v.aval, jaxpr.outvars)))
-
-
-def _rewrite_typed_jaxpr(
-    tjaxpr: core.TypedJaxpr, has_input_token: bool,
-    has_output_token: bool) -> core.TypedJaxpr:
-  """Rewrites a TypedJaxpr to thread the token, if needed."""
-  new_jaxpr = _rewrite_jaxpr(tjaxpr.jaxpr, has_input_token, has_output_token)
-  return _mk_typed_jaxpr(new_jaxpr, tjaxpr.literals)
+def _rewrite_closed_jaxpr(
+    cjaxpr: core.ClosedJaxpr, has_input_token: bool,
+    has_output_token: bool) -> core.ClosedJaxpr:
+  """Rewrites a ClosedJaxpr to thread the token, if needed."""
+  new_jaxpr = _rewrite_jaxpr(cjaxpr.jaxpr, has_input_token, has_output_token)
+  return core.ClosedJaxpr(new_jaxpr, cjaxpr.consts)
 
 
 def _rewrite_jaxpr(jaxpr: core.Jaxpr, has_input_token: bool,
@@ -609,8 +602,8 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             eqn.primitive,
             dict(
                 eqn.params,
-                body_jaxpr=_rewrite_typed_jaxpr(body_jaxpr, True, True),
-                cond_jaxpr=_rewrite_typed_jaxpr(cond_jaxpr, True,
+                body_jaxpr=_rewrite_closed_jaxpr(body_jaxpr, True, True),
+                cond_jaxpr=_rewrite_closed_jaxpr(cond_jaxpr, True,
                                                 False)), eqn.source_info))
   elif eqn.primitive is lax.cond_p:
     branches, linear = util.split_dict(eqn.params, ["branches", "linear"])
@@ -622,7 +615,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             dict(
                 eqn.params,
                 branches=tuple(
-                    _rewrite_typed_jaxpr(jaxpr, True, True)
+                    _rewrite_closed_jaxpr(jaxpr, True, True)
                     for jaxpr in branches),
                 linear=(*linear, False)), eqn.source_info))
   elif eqn.primitive is lax.scan_p:
@@ -635,7 +628,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
     new_invars = eqn.invars[0:nr_const_and_carry] + [
         input_token_var
     ] + eqn.invars[nr_const_and_carry:]
-    new_jaxpr = _rewrite_typed_jaxpr(carry_jaxpr, True, True)
+    new_jaxpr = _rewrite_closed_jaxpr(carry_jaxpr, True, True)
     # The rewrite has put the token at end, it has to be at end of carry
     new_jaxpr_invars = new_jaxpr.jaxpr.invars
     new_jaxpr_invars = (
@@ -686,7 +679,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             new_invars, eqn.outvars + [output_token_var], eqn.primitive,
             dict(
                 eqn.params,
-                fun_jaxpr=_rewrite_typed_jaxpr(fun_jaxpr, True, True),
+                fun_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
                 jvp_jaxpr_thunk=unreachable_thunk
             ),
             eqn.source_info))
@@ -700,7 +693,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             new_invars, eqn.outvars + [output_token_var], eqn.primitive,
             dict(
                 eqn.params,
-                fun_jaxpr=_rewrite_typed_jaxpr(fun_jaxpr, True, True),
+                fun_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
                 fwd_jaxpr_thunk=unreachable_thunk,
                 # The following are illegal values for the parameters, they
                 # should not be needed because this rewrite is just before
@@ -720,7 +713,7 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
   """Rewrite a while whose cond has outfeed"""
   cond_jaxpr, cond_nconsts, body_jaxpr, body_nconsts = util.split_dict(
       eqn.params, ["cond_jaxpr", "cond_nconsts", "body_jaxpr", "body_nconsts"])
-  transformed_cond_jaxpr = _rewrite_typed_jaxpr(cond_jaxpr, True, True)
+  transformed_cond_jaxpr = _rewrite_closed_jaxpr(cond_jaxpr, True, True)
   carry_invars = eqn.invars[cond_nconsts + body_nconsts:]
   # pred1, token1 = rewrite(COND)(cond_consts, carry_invars, input_token)
   pred1_and_token1 = [
@@ -740,14 +733,14 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
   new_cond_invars = ([new_cond_pred_invar] +
                      [mk_new_var(cv.aval) for cv in carry_invars] +
                      [mk_new_var(core.abstract_token)])
-  new_cond_jaxpr = _mk_typed_jaxpr(
+  new_cond_jaxpr = core.ClosedJaxpr(
       core.Jaxpr([], new_cond_invars, [new_cond_pred_invar], []), [])
   # Make a new body:
   #   "lambda cond_constvars, body_constvars, pred, carry, token:
   #        carry2, token2 = rewrite(BODY)(body_constvars, carry, token)
   #        pred2, token3 = rewrite(COND)(cond_constvars, carry2, token2)
   #        (pred2, carry2, token3)
-  transformed_body_jaxpr = _rewrite_typed_jaxpr(body_jaxpr, True, True)
+  transformed_body_jaxpr = _rewrite_closed_jaxpr(body_jaxpr, True, True)
   new_body_invars_cond_constvars = [
       mk_new_var(v.aval) for v in eqn.invars[0:cond_nconsts]
   ]
@@ -782,8 +775,6 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
               name="cond_body",
               donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals)),
           eqn.source_info)
-  ]
-  new_body_jaxpr = _mk_typed_jaxpr(
       core.Jaxpr([], (new_body_invars_cond_constvars +
                       new_body_invars_body_constvars + [new_body_invars_pred] +
                       new_body_invars_carry + [new_body_invars_token]),

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -397,7 +397,7 @@ class _BodyTracer(object):
       # (e.g., cond_range and while_range), then in_tracers will not contain
       # the tracer for the index_var, and trace_to_jaxpr_finalize will throw
       # an assertion error.
-      body_typed_jaxpr, body_const_vals = _BodyTracer.trace_to_jaxpr_finalize(
+      body_closed_jaxpr, body_const_vals = _BodyTracer.trace_to_jaxpr_finalize(
         in_tracers=in_tracers,
         out_tracers=body_out_tracers,
         trace=self.trace)
@@ -415,7 +415,7 @@ class _BodyTracer(object):
 
     carried_out_vals = self.loop_builder.build_output_vals(
       self.scope, self.carried_state_names, carried_tree,
-      carried_init_vals, body_typed_jaxpr, body_const_vals)
+      carried_init_vals, body_closed_jaxpr, body_const_vals)
     carried_mutable_state_unflattened = tree_util.tree_unflatten(carried_tree,
                                                                  carried_out_vals)
 
@@ -447,9 +447,8 @@ class _BodyTracer(object):
     in_pvals = [t.pval for t in in_tracers]
     in_avals = tuple(safe_map(abstract_arrays.raise_to_shaped, unzip2(in_pvals)[0]))
 
-    typed_jaxpr = core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
-                                  (), const_avals + in_avals, out_avals)
-    return typed_jaxpr, consts
+    closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+    return closed_jaxpr, consts
 
 
 class _LoopBuilder(object):
@@ -460,7 +459,7 @@ class _LoopBuilder(object):
     raise NotImplementedError
 
   def build_output_vals(self, scope, carried_state_names, carried_tree,
-                        init_vals, body_typed_jaxpr, body_const_vals):
+                        init_vals, body_closed_jaxpr, body_const_vals):
     """Builds the output values for the loop carried state.
 
     Params:
@@ -469,7 +468,7 @@ class _LoopBuilder(object):
         carried through the body.
       carried_tree: the PyTreeDef for the tuple of carried_state_names.
       init_vals: the initial values on body entry corresponding to the init_tree.
-      body_typed_jaxpr: the Jaxpr for the body returning the new values of
+      body_closed_jaxpr: the Jaxpr for the body returning the new values of
         carried_state_names.
       body_const_vals: the constant values for the body.
 
@@ -495,12 +494,12 @@ class _BoundedLoopBuilder(_LoopBuilder):
     return True
 
   def build_output_vals(self, scope, carried_state_names, carried_tree,
-                        init_vals, body_typed_jaxpr, body_const_vals):
+                        init_vals, body_closed_jaxpr, body_const_vals):
     arange_val = jnp.arange(self.start, stop=self.stop, step=self.step)
     return lax_control_flow.scan_p.bind(*itertools.chain(body_const_vals,
                                                          init_vals, [arange_val]),
                                         reverse=False, length=arange_val.shape[0],
-                                        jaxpr=body_typed_jaxpr,
+                                        jaxpr=body_closed_jaxpr,
                                         num_consts=len(body_const_vals),
                                         num_carry=len(init_vals),
                                         linear=(False,) * (len(body_const_vals) +
@@ -518,12 +517,12 @@ class _CondBuilder(_LoopBuilder):
     return False
 
   def build_output_vals(self, scope, carried_state_names, carried_tree,
-                        init_vals, body_typed_jaxpr, body_const_vals):
+                        init_vals, body_closed_jaxpr, body_const_vals):
     # Simulate a pass-through false branch
     in_vals, in_tree = tree_util.tree_flatten(
         (body_const_vals, tree_util.tree_unflatten(carried_tree, init_vals)))
     in_avals = safe_map(_BodyTracer.abstractify, in_vals)
-    pass_through_typed_jaxpr, pass_through_const_vals, _ = (
+    pass_through_closed_jaxpr, pass_through_const_vals, _ = (
       lax_control_flow._initial_style_jaxpr(
           lambda *args: args[1],
           in_tree,
@@ -532,7 +531,7 @@ class _CondBuilder(_LoopBuilder):
     args = list(itertools.chain(body_const_vals, init_vals))
     return lax_control_flow.cond_p.bind(
         self.index, *args,
-        branches=(pass_through_typed_jaxpr, body_typed_jaxpr),
+        branches=(pass_through_closed_jaxpr, body_closed_jaxpr),
         linear=(False,) * len(args))
 
 
@@ -546,7 +545,7 @@ class _WhileBuilder(_LoopBuilder):
     return False
 
   def build_output_vals(self, scope, carried_state_names, carried_tree,
-                        init_vals, body_typed_jaxpr, body_const_vals):
+                        init_vals, body_closed_jaxpr, body_const_vals):
     # Trace the conditional function. cond_func takes 0 arguments, but
     # for lax.while we need a conditional function that takes the
     # carried_state_names. _initial_style_jaxpr will start its own trace and
@@ -584,4 +583,4 @@ class _WhileBuilder(_LoopBuilder):
                                          cond_nconsts=len(cond_consts),
                                          cond_jaxpr=cond_jaxpr,
                                          body_nconsts=len(body_const_vals),
-                                         body_jaxpr=body_typed_jaxpr)
+                                         body_jaxpr=body_closed_jaxpr)

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -117,7 +117,7 @@ from jax.lax import lax_control_flow
 from jax import tree_util
 from jax import numpy as jnp
 from jax.interpreters import partial_eval as pe
-from jax.util import unzip2, safe_map
+from jax.util import safe_map
 from jax.config import config
 
 
@@ -435,18 +435,7 @@ class _BodyTracer(object):
     out_tracers = safe_map(partial(pe.instantiate_const_at, trace),
                            instantiate, out_tracers)
     jaxpr, consts, env = pe.tracers_to_jaxpr(in_tracers, out_tracers)
-    out_pvals = [t.pval for t in out_tracers]
-    # TODO: this is from partial_eval.trace_to_jaxpr. Share.
-    assert not env
-
-    # TODO: this is from the final part of lax_control_flow._initial_style_jaxpr
-    out_avals = safe_map(abstract_arrays.raise_to_shaped, unzip2(out_pvals)[0])
-    const_avals = tuple(abstract_arrays.raise_to_shaped(core.get_aval(c))
-                        for c in consts)
-
-    in_pvals = [t.pval for t in in_tracers]
-    in_avals = tuple(safe_map(abstract_arrays.raise_to_shaped, unzip2(in_pvals)[0]))
-
+    assert not env  # TODO: this is from partial_eval.trace_to_jaxpr. Share.
     closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
     return closed_jaxpr, consts
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -494,8 +494,6 @@ def remat_transpose(params, call_jaxpr, primals_in, cotangents_in, cotangent_in_
   # backward_pass can only transpose linear computations, but the call_jaxpr embedded in
   # remat contains primal (non-linear) equations too. Hence, we have to eliminate those
   # (in this case via partial_eval) before we call into backward_pass again.
-  in_avals = [raise_to_shaped(p.aval if is_undefined_primal(p) else get_aval(p))
-              for p in primals_in]
   typed_call_jaxpr = core.ClosedJaxpr(call_jaxpr, [])
   unknowns = map(is_undefined_primal, primals_in)
   if config.omnistaging_enabled:

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -496,7 +496,7 @@ def remat_transpose(params, call_jaxpr, primals_in, cotangents_in, cotangent_in_
   # (in this case via partial_eval) before we call into backward_pass again.
   in_avals = [raise_to_shaped(p.aval if is_undefined_primal(p) else get_aval(p))
               for p in primals_in]
-  typed_call_jaxpr = core.TypedJaxpr(call_jaxpr, [], in_avals, cotangent_in_avals)
+  typed_call_jaxpr = core.ClosedJaxpr(call_jaxpr, [])
   unknowns = map(is_undefined_primal, primals_in)
   if config.omnistaging_enabled:
     primal_jaxpr, tangent_jaxpr, out_unknowns = \
@@ -556,8 +556,7 @@ def jvp_jaxpr(jaxpr, nonzeros, instantiate):
   tangent_avals = [aval for aval, nz in zip(jaxpr.in_avals, nonzeros) if nz]
   avals_in = list(it.chain(jaxpr.in_avals, tangent_avals))
   jaxpr_out, avals_out, literals_out = pe.trace_to_jaxpr_dynamic(f_jvp, avals_in)
-  jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, avals_in, avals_out)
-  return jaxpr_out, out_nonzeros()
+  return core.ClosedJaxpr(jaxpr_out, literals_out), out_nonzeros()
 
 @lu.transformation_with_aux
 def f_jvp_traceable(nonzeros, *primals_and_nztangents):
@@ -571,16 +570,12 @@ def f_jvp_traceable(nonzeros, *primals_and_nztangents):
   nonzero_tangents_out = [t for t in tangents_out if type(t) is not Zero]
   yield list(primals_out) + nonzero_tangents_out, out_nonzeros
 
-def rearrange_binders(jaxpr: core.TypedJaxpr, primals_in, tangents_in, primals_out, tangents_out):
+def rearrange_binders(jaxpr: core.ClosedJaxpr, primals_in, tangents_in, primals_out, tangents_out):
   new_invars = _perm(primals_in, tangents_in, jaxpr.jaxpr.invars)
   new_outvars = _perm(primals_out, tangents_out, jaxpr.jaxpr.outvars)
   new_jaxpr = core.Jaxpr(jaxpr.jaxpr.constvars,
                          new_invars, new_outvars, jaxpr.jaxpr.eqns)
-  new_in_avals = _perm(primals_in, tangents_in, jaxpr.in_avals)
-  new_out_avals = _perm(primals_out, tangents_out, jaxpr.out_avals)
-  new_typed_jaxpr = core.TypedJaxpr(new_jaxpr, jaxpr.literals, new_in_avals,
-                                    new_out_avals)
-  return new_typed_jaxpr
+  return core.ClosedJaxpr(new_jaxpr, jaxpr.consts)
 
 def _perm(primal_counts, tangent_counts, lst):
   n = sum(primal_counts)
@@ -689,7 +684,5 @@ def omnistaging_disabler() -> None:
     tangent_avals = [aval for aval, nz in zip(jaxpr.in_avals, nonzeros) if nz]
     avals_in = list(it.chain(jaxpr.in_avals, tangent_avals))
     pvals = [pe.PartialVal.unknown(aval) for aval in avals_in]
-    jaxpr_out, pvals_out, literals_out = pe.trace_to_jaxpr(f_jvp, pvals, instantiate=True)
-    avals_out, _ = unzip2(pvals_out)
-    jaxpr_out = core.TypedJaxpr(jaxpr_out, literals_out, avals_in, avals_out)
-    return jaxpr_out, out_nonzeros()
+    jaxpr_out, _, consts = pe.trace_to_jaxpr(f_jvp, pvals, instantiate=True)
+    return core.ClosedJaxpr(jaxpr_out, consts), out_nonzeros()

--- a/jax/interpreters/invertible_ad.py
+++ b/jax/interpreters/invertible_ad.py
@@ -24,7 +24,7 @@ from . import partial_eval as pe
 from ..core import raise_to_shaped, get_aval, Literal, Jaxpr
 from ..api_util import flatten_fun_nokwargs
 from ..tree_util import tree_flatten, tree_unflatten, register_pytree_node
-from ..util import safe_map, safe_zip, unzip2, split_list
+from ..util import safe_map, safe_zip, split_list
 from .. import custom_derivatives
 from ..config import config
 

--- a/jax/interpreters/invertible_ad.py
+++ b/jax/interpreters/invertible_ad.py
@@ -221,8 +221,7 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
           complete_ivjp_flat, map(pe.PartialVal.unknown, in_avals),
           instantiate=True, stage_out=False)  # type: ignore
       assert not ivjp_jaxpr.constvars  # That might happen some time, but don't bother until then
-      out_avals = map(raise_to_shaped, unzip2(out_pvals)[0])
-      ivjp_jaxpr = core.TypedJaxpr(ivjp_jaxpr, [], in_avals, out_avals)
+      ivjp_jaxpr = core.ClosedJaxpr(ivjp_jaxpr, [])
 
     # Once we know what the ivjp can do exactly, we have to isolate the part we are
     # actually able to compute with the values we have at hand.
@@ -243,7 +242,6 @@ def inv_backward_pass(jaxpr: core.Jaxpr, consts, primals_in, primals_out, cotang
     assert not any(unknown_cotangents)
     # Remove residual outputs -- we won't be computing the unknown jaxpr anyway.
     num_outputs = len(jaxpr_unknown.jaxpr.outvars)
-    jaxpr_known.out_avals = jaxpr_known.out_avals[:num_outputs]
     jaxpr_known.jaxpr.outvars = jaxpr_known.jaxpr.outvars[:num_outputs]
     # TODO: We could drop the outputs that correspond to primals that we already know.
     #       This only matters in eager mode, so leaving it out for now...

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -30,7 +30,7 @@ from ..ad_util import Zero
 from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
                     cache)
 from ..core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
-                    unit, unitvar, abstract_unit, TypedJaxpr, new_jaxpr_eqn,
+                    unit, unitvar, abstract_unit, ClosedJaxpr, new_jaxpr_eqn,
                     dropvar)
 from .. import source_info_util
 from ..config import config
@@ -200,7 +200,7 @@ class JaxprTrace(Trace):
     in_knowns = tuple(t.pval.is_known() for t in it.chain(env_tracers, tracers))
     out_unknowns = tuple(not pval.is_known() for pval in out_pvals)
     jaxpr = _drop_invars(jaxpr, in_knowns)
-    jaxpr = _dce_untyped_jaxpr(jaxpr, out_unknowns, drop_outputs=True)
+    jaxpr = _dce_open_jaxpr(jaxpr, out_unknowns, drop_outputs=True)
 
     # Known tracers get propagated as if they were constants
     known_tracers_out = [self.new_const(pval.get_known()) for pval in out_pvals
@@ -353,7 +353,7 @@ class JaxprTracer(Tracer):
   def is_known(self):
       return self.pval.is_known()
 
-# TODO(necula): this should return a TypedJaxpr
+# TODO(necula): this could return a ClosedJaxpr with out_pvals
 def trace_to_jaxpr(fun: lu.WrappedFun, pvals: Sequence[PartialVal],
                    instantiate: Union[bool, Sequence[bool]] = False,
                    ) -> Tuple[Jaxpr, Tuple[PartialVal, ...], Tuple[core.Value, ...]]:
@@ -554,9 +554,9 @@ def convert_constvars_jaxpr(jaxpr: Jaxpr):
 def _split_aval(unknown: bool, aval: AbstractValue) -> Tuple[AbstractValue, AbstractValue]:
   return (abstract_unit, aval) if unknown else (aval, abstract_unit)
 
-def partial_eval_jaxpr(jaxpr: TypedJaxpr, unknowns: Sequence[bool],
+def partial_eval_jaxpr(jaxpr: ClosedJaxpr, unknowns: Sequence[bool],
                        instantiate: Union[bool, Sequence[bool]],
-                       ) -> Tuple[TypedJaxpr, TypedJaxpr, Sequence[bool]]:
+                       ) -> Tuple[ClosedJaxpr, ClosedJaxpr, Sequence[bool]]:
   """Specializes a Jaxpr given an indication of which inputs are known.
 
   Returns: (jaxpr_known, jaxpr_unknown, out_unknowns).
@@ -630,9 +630,7 @@ def partial_eval_jaxpr(jaxpr: TypedJaxpr, unknowns: Sequence[bool],
   out_avals_1 = [*out_avals_1, *res_avals]
   in_avals_2 = [*in_avals_2, *res_avals]
 
-  typed_jaxpr_1 = TypedJaxpr(jaxpr_1, consts_1, in_avals_1, out_avals_1)
-  typed_jaxpr_2 = TypedJaxpr(jaxpr_2, (), in_avals_2, out_avals_2)
-  return typed_jaxpr_1, typed_jaxpr_2, uk_out
+  return ClosedJaxpr(jaxpr_1, consts_1), ClosedJaxpr(jaxpr_2, ()), uk_out
 
 
 remat_call_p = core.CallPrimitive('remat_call')
@@ -679,15 +677,15 @@ def _remat_partial_eval(trace, _, f, tracers, params):
                                else get_aval(var.val) if type(var) is Literal
                                else pval.get_aval())
                for var, pval in zip(jaxpr.outvars, eval_out_pvals)]
-  typed_jaxpr = core.TypedJaxpr(jaxpr, (), in_avals, out_avals)
+  closed_jaxpr = core.ClosedJaxpr(jaxpr, ())
   in_unknowns = ([False] * len(consts) +
                  [not t.is_known() for t in it.chain(env_tracers, tracers)])
   if config.omnistaging_enabled:
     jaxpr_known, jaxpr_unknown, out_unknowns = partial_eval_jaxpr(
-        typed_jaxpr, in_unknowns, instantiate=False)  # type: ignore
+        closed_jaxpr, in_unknowns, instantiate=False)  # type: ignore
   else:
     jaxpr_known, jaxpr_unknown, out_unknowns = partial_eval_jaxpr(
-        typed_jaxpr, in_unknowns, instantiate=False, trace_type=trace.main.trace_type)  # type: ignore
+        closed_jaxpr, in_unknowns, instantiate=False, trace_type=trace.main.trace_type)  # type: ignore
   out_knowns = [not b for b in out_unknowns]
   out_known_pvals, out_unknown_pvals = _partition_knowns(eval_out_pvals, out_unknowns)
 
@@ -717,7 +715,7 @@ def _remat_partial_eval(trace, _, f, tracers, params):
                             for out_pval in out_unknown_pvals]
 
   # dce jaxpr outputs
-  new_jaxpr = _dce_jaxpr(typed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
+  new_jaxpr = _dce_jaxpr(closed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
   new_params = dict(params, call_jaxpr=new_jaxpr)
 
   # set up eqn for unknown outputs
@@ -737,18 +735,17 @@ def _zip_knowns(known_list, unknown_list, which_unknown: Sequence[bool]):
   return [next(unknown_iter) if uk else next(known_iter) for uk in which_unknown]
 
 
-def _dce_jaxpr(typed_jaxpr: TypedJaxpr, outputs: Sequence[bool], drop_outputs=False) -> TypedJaxpr:
+def _dce_jaxpr(closed_jaxpr: ClosedJaxpr, outputs: Sequence[bool], drop_outputs=False) -> ClosedJaxpr:
   if drop_outputs:
-    new_out_avals = [aval for aval, output in zip(typed_jaxpr.out_avals, outputs) if output]
+    new_out_avals = [aval for aval, output in zip(closed_jaxpr.out_avals, outputs) if output]
   else:
     new_out_avals = [aval if output else core.abstract_unit
-                     for aval, output in zip(typed_jaxpr.out_avals, outputs)]
-  new_jaxpr = _dce_untyped_jaxpr(typed_jaxpr.jaxpr, tuple(outputs), drop_outputs)
-  return core.TypedJaxpr(new_jaxpr, typed_jaxpr.literals, typed_jaxpr.in_avals,
-                         new_out_avals)
+                     for aval, output in zip(closed_jaxpr.out_avals, outputs)]
+  new_jaxpr = _dce_open_jaxpr(closed_jaxpr.jaxpr, tuple(outputs), drop_outputs)
+  return core.ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
 
 @cache()
-def _dce_untyped_jaxpr(jaxpr: Jaxpr, outputs: Tuple[bool, ...], drop_outputs=False) -> Jaxpr:
+def _dce_open_jaxpr(jaxpr: Jaxpr, outputs: Tuple[bool, ...], drop_outputs=False) -> Jaxpr:
   # This dead-code elimination is pretty rudimentary, and in particular doesn't
   # nontrivially DCE through scan, call, or other higher-order primitives.
   # TODO(mattjj): better DCE
@@ -785,17 +782,16 @@ def _reconstruct_pval(pval1: PartialVal, const2: core.Value):
       return PartialVal.known(const2)
 
 
-def move_binders_to_front(typed_jaxpr: TypedJaxpr, to_move: Sequence[bool]) -> TypedJaxpr:
+def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]) -> ClosedJaxpr:
   """Reorder the `invars` to move to front the ones for which `to_move` is True."""
-  assert not typed_jaxpr.jaxpr.constvars
-  assert len(typed_jaxpr.in_avals) == len(to_move)
-  new_invars = _move_to_front(typed_jaxpr.jaxpr.invars, to_move)
-  new_jaxpr = core.Jaxpr((), new_invars, typed_jaxpr.jaxpr.outvars,
-                         typed_jaxpr.jaxpr.eqns)
-  new_in_avals = _move_to_front(typed_jaxpr.in_avals, to_move)
-  new_typed_jaxpr = core.TypedJaxpr(new_jaxpr, typed_jaxpr.literals,
-                                    new_in_avals, typed_jaxpr.out_avals)
-  return new_typed_jaxpr
+  assert not closed_jaxpr.jaxpr.constvars
+  assert len(closed_jaxpr.in_avals) == len(to_move)
+  new_invars = _move_to_front(closed_jaxpr.jaxpr.invars, to_move)
+  new_jaxpr = core.Jaxpr((), new_invars, closed_jaxpr.jaxpr.outvars,
+                         closed_jaxpr.jaxpr.eqns)
+  new_in_avals = _move_to_front(closed_jaxpr.in_avals, to_move)
+  new_closed_jaxpr = core.ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
+  return new_closed_jaxpr
 
 def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
   return ([elt for elt, move in zip(lst, to_move) if move] +
@@ -1122,10 +1118,10 @@ def omnistaging_disabler() -> None:
 
     return jaxpr, out_pvals, consts
 
-  def partial_eval_jaxpr(jaxpr: TypedJaxpr, unknowns: Sequence[bool],
+  def partial_eval_jaxpr(jaxpr: ClosedJaxpr, unknowns: Sequence[bool],
                         instantiate: Union[bool, Sequence[bool]],
                         trace_type: Optional[Type[core.Trace]]
-                        ) -> Tuple[TypedJaxpr, TypedJaxpr, Sequence[bool]]:
+                        ) -> Tuple[ClosedJaxpr, ClosedJaxpr, Sequence[bool]]:
     f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
 
     cell = []
@@ -1159,18 +1155,7 @@ def omnistaging_disabler() -> None:
 
     uk_out = [pv is not None for pv in out_pvs_2]
 
-    in_avals_1, in_avals_2 = unzip2(map(_split_aval, unknowns, jaxpr.in_avals))
-    out_avals_1, out_avals_2 = unzip2(map(_split_aval, uk_out, jaxpr.out_avals))
-    # out_avals_1 and in_avals_2 need the residuals added
-    out_pvs, _ = unzip2(out_pvals)
-    res_avals = out_pvs[len(jaxpr.out_avals):]
-    assert len(res_avals) == num_res
-    out_avals_1 = out_avals_1 + res_avals
-    in_avals_2 = in_avals_2 + res_avals
-
-    typed_jaxpr_1 = TypedJaxpr(jaxpr_1, consts_1, in_avals_1, out_avals_1)
-    typed_jaxpr_2 = TypedJaxpr(jaxpr_2, (), in_avals_2, out_avals_2)
-    return typed_jaxpr_1, typed_jaxpr_2, uk_out
+    return ClosedJaxpr(jaxpr_1, consts_1), ClosedJaxpr(jaxpr_2, ()), uk_out
 
   def process_custom_jvp_call(self, prim, fun, jvp, tracers):
     # See comment at top of `JaxprTrace`. This method should be reachable

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -194,7 +194,7 @@ def _param_uses_outfeed(param):
   if type(param) is core.Jaxpr:
     if jaxpr_uses_outfeed(param):
       return True
-  elif type(param) is core.TypedJaxpr:
+  elif type(param) is core.ClosedJaxpr:
     if jaxpr_uses_outfeed(param.jaxpr):
       return True
   return False
@@ -497,7 +497,7 @@ def eqn_replicas(eqn):
 def initial_style_primitive_replicas(params):
   nums = (jaxpr_replicas(param if type(param) is core.Jaxpr else param.jaxpr)
           for param in params.values()
-          if type(param) in (core.Jaxpr, core.TypedJaxpr))
+          if type(param) in (core.Jaxpr, core.ClosedJaxpr))
   return max(it.chain([1], nums))
 
 # TODO(mattjj,skyewm): the functions here are utilities for checking if

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -62,18 +62,17 @@ T = TypeVar('T')
 
 
 @cache()
-def _initial_style_untyped_jaxpr(fun: Callable, in_tree, in_avals):
+def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals):
   wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
   jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals)
   return jaxpr, out_avals, consts, out_tree()
 
 @cache()
 def _initial_style_jaxpr(fun: Callable, in_tree, in_avals):
-  jaxpr, out_avals, consts, out_tree = \
-      _initial_style_untyped_jaxpr(fun, in_tree, in_avals)
+  jaxpr, out_avals, consts, out_tree = _initial_style_open_jaxpr(fun, in_tree, in_avals)
   const_avals = tuple(raise_to_shaped(core.get_aval(c)) for c in consts)
-  typed_jaxpr = core.CosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
-  return typed_jaxpr, consts, out_tree
+  closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+  return closed_jaxpr, consts, out_tree
 
 def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
                                             in_tree, in_avals):
@@ -85,7 +84,7 @@ def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
   # those that it needs (dropping the rest).
 
   jaxprs, all_out_avals, all_consts, all_out_trees = unzip4(
-      _initial_style_untyped_jaxpr(fun, in_tree, in_avals) for fun in funs)
+      _initial_style_open_jaxpr(fun, in_tree, in_avals) for fun in funs)
 
   newvar = core.gensym(jaxprs, suffix='_')
   all_const_avals = [[raise_to_shaped(core.get_aval(c)) for c in consts]
@@ -103,10 +102,9 @@ def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
   consts = util.concatenate(all_consts)
   const_avals = util.concatenate(all_const_avals)
   jaxprs = [pad_jaxpr_constvars(i, jaxpr) for i, jaxpr in enumerate(jaxprs)]
-  typed_jaxprs = [core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
-                                  (), [*const_avals, *in_avals], out_avals)
+  closed_jaxprs = [core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
                   for jaxpr, out_avals in zip(jaxprs, all_out_avals)]
-  return typed_jaxprs, consts, all_out_trees
+  return closed_jaxprs, consts, all_out_trees
 
 def _abstractify(x):
   return raise_to_shaped(core.get_aval(x))
@@ -311,8 +309,7 @@ def _while_loop_translation_rule(c, axis_env, name_stack, avals, backend, *args,
   cond_carry_elts = [xops.GetTupleElement(cond_carry, i) for i in range(len(args))]
   x, _, z = split_list(cond_carry_elts, [cond_nconsts, body_nconsts])
   pred, = xla.jaxpr_subcomp(cond_c, cond_jaxpr.jaxpr, backend, axis_env,
-                            _map(partial(xb.constant, cond_c),
-                                 cond_jaxpr.literals),
+                            _map(partial(xb.constant, cond_c), cond_jaxpr.consts),
                             extend_name_stack(name_stack, 'cond'), *(x + z))
   if batched:
     scalar = ShapedArray((), np.bool_)
@@ -325,11 +322,11 @@ def _while_loop_translation_rule(c, axis_env, name_stack, avals, backend, *args,
   body_carry_elts = [xops.GetTupleElement(body_carry, i) for i in range(len(args))]
   x, y, z = split_list(body_carry_elts, [cond_nconsts, body_nconsts])
   new_z = xla.jaxpr_subcomp(body_c, body_jaxpr.jaxpr, backend, axis_env,
-                            _map(partial(xb.constant, body_c), body_jaxpr.literals),
+                            _map(partial(xb.constant, body_c), body_jaxpr.consts),
                             extend_name_stack(name_stack, 'body'), *(y + z))
   if batched:
     body_pred, = xla.jaxpr_subcomp(body_c, cond_jaxpr.jaxpr, backend, axis_env,
-                                   _map(partial(xb.constant, body_c), cond_jaxpr.literals),
+                                   _map(partial(xb.constant, body_c), cond_jaxpr.consts),
                                    extend_name_stack(name_stack, 'body_pred'), *(x + z))
     new_z = _map(partial(_pred_bcast_select, body_c, body_pred), new_z, z, body_jaxpr.out_avals)
     assert _map(body_c.get_shape, new_z) == _map(body_c.get_shape, z) # no broadcast
@@ -434,12 +431,7 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
                                     invars_aug,
                                     cond_jaxpr.jaxpr.outvars,
                                     cond_jaxpr.jaxpr.eqns)
-  in_avals_aug = (cond_jaxpr.in_avals[:cond_nconsts] +
-                  body_jvp_rearranged.in_avals[body_nconsts + len(bconst_dot):])
-  cond_jaxpr_augmented = core.TypedJaxpr(cond_jaxpr_augmented,
-                                         cond_jaxpr.literals,
-                                         in_avals_aug,
-                                         cond_jaxpr.out_avals)
+  cond_jaxpr_augmented = core.ClosedJaxpr(cond_jaxpr_augmented, cond_jaxpr.consts)
 
   out = while_p.bind(
       *(cconst + bconst + bconst_dot + init + init_dot),
@@ -455,8 +447,8 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
   return out_carry, out_tangents
 
 def _while_partial_eval(trace: pe.JaxprTrace, *tracers: pe.Tracer, cond_nconsts: int,
-                        cond_jaxpr: pe.TypedJaxpr, body_nconsts: int,
-                        body_jaxpr: pe.TypedJaxpr) -> Sequence[pe.Tracer]:
+                        cond_jaxpr: pe.ClosedJaxpr, body_nconsts: int,
+                        body_jaxpr: pe.ClosedJaxpr) -> Sequence[pe.Tracer]:
   """An implementation of partial evaluation for while.
   As long as some carry (and hence output) are known and the output
   of `cond_jaxpr` is known, we use a portion of the loop body to compute the known
@@ -513,7 +505,6 @@ def _while_partial_eval(trace: pe.JaxprTrace, *tracers: pe.Tracer, cond_nconsts:
   # the type of outputs; residuals are at the end
   if len(body_jaxpr_known.out_avals) > len(body_jaxpr.out_avals):
     # TODO(necula): this is not quite enough; we should drop the residual computations also
-    body_jaxpr_known.out_avals = body_jaxpr_known.out_avals[:len(body_jaxpr.out_avals)]
     body_jaxpr_known.jaxpr.outvars = body_jaxpr_known.jaxpr.outvars[:len(body_jaxpr.out_avals)]
   out_known = while_p.bind(
     *in_consts,
@@ -737,7 +728,7 @@ def _cond_translation_rule(c, axis_env, name_stack, avals, backend,
     op = xb.parameter(c, 0, op_shape)
     ops = [xops.GetTupleElement(op, i) for i in range(len(jaxpr.in_avals))]
     outs = xla.jaxpr_subcomp(c, jaxpr.jaxpr, backend, axis_env,
-                             _map(partial(xb.constant, c), jaxpr.literals),
+                             _map(partial(xb.constant, c), jaxpr.consts),
                              extend_name_stack(name_stack, name + '_fun'), *ops)
     return c.build(xops.Tuple(c, outs))
 
@@ -964,7 +955,7 @@ def _join_cond_outputs(jaxprs, all_res_avals, res_aval_indices_per_jaxpr,
       aug_residuals = util.subvals(aug_residuals, zip(res_indices, residuals))
       return outs + list(aug_residuals)
 
-    return _make_typed_jaxpr(f_aug, jaxpr.in_avals)
+    return _make_closed_jaxpr(f_aug, jaxpr.in_avals)
 
   return tuple(_map(augment_jaxpr, jaxprs, res_aval_indices_per_jaxpr))
 
@@ -984,11 +975,9 @@ def _join_cond_pe_staged_jaxpr_inputs(jaxprs, all_res_avals,
 
     aug_res_vars = list(util.subvals(all_res_vars, zip(res_indices, res_vars)))
     aug_invars = aug_res_vars + non_res_vars
-    aug_avals = all_res_avals + non_res_avals
     jaxpr_aug = core.Jaxpr(jaxpr.jaxpr.constvars, aug_invars,
                            jaxpr.jaxpr.outvars, jaxpr.jaxpr.eqns)
-    jaxpr_aug = core.TypedJaxpr(jaxpr_aug, jaxpr.literals, aug_avals,
-                                jaxpr.out_avals)
+    jaxpr_aug = core.ClosedJaxpr(jaxpr_aug, jaxpr.consts)
     return jaxpr_aug
 
   return tuple(_map(augment_jaxpr, jaxprs, res_aval_indices_per_jaxpr))
@@ -1006,11 +995,11 @@ def _transpose_cond_jaxpr(jaxpr, num_res):
     res, cts_out = split_list(args, [num_res])
     primals = res + [ad.UndefinedPrimal(aval) for aval in primal_avals]
     cts_in = ad.backward_pass(
-        jaxpr.jaxpr, jaxpr.literals, primals, cts_out)
+        jaxpr.jaxpr, jaxpr.consts, primals, cts_out)
     _, cts_in = split_list(cts_in, [num_res])
     return _map(ad.instantiate_zeros_aval, primal_avals, cts_in)
 
-  return _make_typed_jaxpr(transposed, res_avals + jaxpr.out_avals)
+  return _make_closed_jaxpr(transposed, res_avals + jaxpr.out_avals)
 
 def _cond_transpose(cts, *args, branches, linear):
   index, *ops = args
@@ -1042,9 +1031,9 @@ def _avals_short(avals):
 
 def _cond_typecheck(*avals, branches, linear):
   tc = partial(_typecheck_param, 'cond')
-  tc(branches, 'branches', 'tuple of TypedJaxpr',
+  tc(branches, 'branches', 'tuple of ClosedJaxpr',
      type(branches) is tuple and
-     all(type(x) is core.TypedJaxpr for x in branches))
+     all(type(x) is core.ClosedJaxpr for x in branches))
   tc(linear, 'linear', 'tuple of bool',
      type(linear) is tuple and all(type(x) is bool for x in linear))
 
@@ -1547,7 +1536,7 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
                      for uk, t in zip(unknowns[:num_consts], tracers[:num_consts])]
   other_pvals = [pe.PartialVal.unknown(a) for a in jaxpr_1.in_avals[num_consts:]]
   in_pvals_1 = invariant_pvals + other_pvals
-  untyped_jaxpr_1, out_pvals_1, consts_1 = pe.trace_to_jaxpr(
+  jaxpr_1_opt, out_pvals_1, consts_1 = pe.trace_to_jaxpr(
       lu.wrap_init(core.jaxpr_as_fun(jaxpr_1)), in_pvals_1,
       instantiate=[True] * (num_carry + num_ys) + [False] * num_res)
   const_avals_1 = [raise_to_shaped(core.get_aval(c)) for c in consts_1]
@@ -1555,11 +1544,10 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
   out_avals_1 = [core.abstract_unit if pv is None else pv for pv, c in out_pvals_1]
 
   # TODO(cjfj): Explain the need for the code below.
-  for var in untyped_jaxpr_1.invars[:num_consts]:
+  for var in jaxpr_1_opt.invars[:num_consts]:
     var.aval = core.abstract_unit
 
-  jaxpr_1_opt = pe.TypedJaxpr(pe.convert_constvars_jaxpr(untyped_jaxpr_1),
-                              (), const_avals_1 + in_avals_1, out_avals_1)
+  jaxpr_1_opt = pe.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr_1_opt), ())
   num_consts_1 = num_consts + len(consts_1)
   # any now-known residuals are intensive, so we want to revise jaxpr_2 to take
   # those inputs as constants rather than as extensive inputs
@@ -1670,23 +1658,22 @@ def _transpose_scan_jaxpr(num_res1, num_c, num_res2, jaxpr):
         res1_cbar_bbar_res2, [num_res1, num_c, num_b])
     primals = (res1 + [ad.UndefinedPrimal(aval) for aval in c_avals] +
                [ad.UndefinedPrimal(aval) for aval in a_avals] + res2)
-    cbar_abar = ad.backward_pass(jaxpr.jaxpr, jaxpr.literals, primals,
-                                    b_bar)
+    cbar_abar = ad.backward_pass(jaxpr.jaxpr, jaxpr.consts, primals, b_bar)
     _, new_c_bar, a_bar, _ = split_list(cbar_abar, [num_res1, num_c, num_a])
     a_bar = _map(ad.instantiate_zeros_aval, a_avals, a_bar)
     c_bar = _map(ad.instantiate_zeros_aval, c_avals,
                 _map(ad.add_tangents, c_bar, new_c_bar))
     return c_bar + a_bar
-  return _make_typed_jaxpr(transposed, res1_avals + c_avals + b_avals + res2_avals)
+  return _make_closed_jaxpr(transposed, res1_avals + c_avals + b_avals + res2_avals)
 
-def _make_typed_jaxpr(traceable: lu.WrappedFun, in_avals: Sequence[core.AbstractValue]):
+def _make_closed_jaxpr(traceable: lu.WrappedFun, in_avals: Sequence[core.AbstractValue]):
   if config.omnistaging_enabled:
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(traceable, in_avals)
   else:
     pvals = [pe.PartialVal.unknown(aval) for aval in in_avals]
     jaxpr, pvals_out, consts = pe.trace_to_jaxpr(traceable, pvals, instantiate=True)
     out_avals, _ = unzip2(pvals_out)
-  return core.TypedJaxpr(jaxpr, consts, in_avals, _map(raise_to_shaped, out_avals))
+  return core.ClosedJaxpr(jaxpr, consts)
 
 
 def _scan_batching_rule(args, dims, reverse, length, jaxpr, num_consts,
@@ -1763,7 +1750,7 @@ def _masked_scan_jaxpr(jaxpr, num_consts, num_carry):
 
   aval = ShapedArray((), dtypes.int_)
   const_avals, carry_avals, x_avals = split_list(jaxpr.in_avals, [num_consts, num_carry])
-  return _make_typed_jaxpr(masked, [aval] + const_avals + [aval] + carry_avals + x_avals)
+  return _make_closed_jaxpr(masked, [aval] + const_avals + [aval] + carry_avals + x_avals)
 
 def _scan_typecheck(bind_time, *avals, reverse, length, num_consts, num_carry,
                     jaxpr, linear, unroll):
@@ -1773,7 +1760,7 @@ def _scan_typecheck(bind_time, *avals, reverse, length, num_consts, num_carry,
      type(num_consts) is int and num_consts >= 0)
   tc(num_carry, 'num_carry', 'non-negative int',
      type(num_carry) is int and num_carry >= 0)
-  tc(jaxpr, 'jaxpr', 'TypedJaxpr', type(jaxpr) is core.TypedJaxpr)
+  tc(jaxpr, 'jaxpr', 'ClosedJaxpr', type(jaxpr) is core.ClosedJaxpr)
   tc(linear, 'linear', 'tuple of bool',
      type(linear) is tuple and all(type(x) is bool for x in linear))
   tc(unroll, 'unroll', 'positive int', type(unroll) is int and unroll > 0)
@@ -2430,11 +2417,11 @@ def associative_scan(fn, elems, reverse=False):
 
 @config.register_omnistaging_disabler
 def omnistaging_disabler() -> None:
-  global _initial_style_untyped_jaxpr, _initial_style_jaxpr, \
+  global _initial_style_open_jaxpr, _initial_style_jaxpr, \
       _initial_style_jaxprs_with_common_consts
 
   @cache()
-  def _initial_style_untyped_jaxpr(fun: Callable, in_tree, in_avals):
+  def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals):
     in_pvals = [pe.PartialVal.unknown(aval) for aval in in_avals]
     wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
     with core.initial_style_staging():  # type: ignore
@@ -2444,13 +2431,12 @@ def omnistaging_disabler() -> None:
 
   @cache()
   def _initial_style_jaxpr(fun: Callable, in_tree, in_avals):
-    jaxpr, out_pvals, consts, out_tree = _initial_style_untyped_jaxpr(
+    jaxpr, out_pvals, consts, out_tree = _initial_style_open_jaxpr(
         fun, in_tree, in_avals)
     out_avals = _map(raise_to_shaped, unzip2(out_pvals)[0])
     const_avals = tuple(raise_to_shaped(core.get_aval(c)) for c in consts)
-    typed_jaxpr = core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
-                                  (), const_avals + in_avals, out_avals)
-    return typed_jaxpr, consts, out_tree()
+    closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
+    return closed_jaxpr, consts, out_tree()
 
   def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
                                               in_tree, in_avals):
@@ -2462,7 +2448,7 @@ def omnistaging_disabler() -> None:
     # those that it needs (dropping the rest).
 
     jaxprs, all_out_pvals, all_consts, all_out_trees = unzip4([
-        _initial_style_untyped_jaxpr(fun, in_tree, in_avals) for fun in funs])
+        _initial_style_open_jaxpr(fun, in_tree, in_avals) for fun in funs])
 
     newvar = core.gensym(jaxprs, suffix='_')
     all_const_avals = tuple(
@@ -2483,12 +2469,11 @@ def omnistaging_disabler() -> None:
 
     def type_and_const_convert_jaxpr(jaxpr, out_pvals):
       out_avals = _map(raise_to_shaped, unzip2(out_pvals)[0])
-      return core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
-                            (), const_avals + in_avals, out_avals)
+      return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
 
     jaxprs = [pad_jaxpr_constvars(i, jaxpr) for i, jaxpr in enumerate(jaxprs)]
-    typed_jaxprs = _map(type_and_const_convert_jaxpr, jaxprs, all_out_pvals)
+    closed_jaxprs = _map(type_and_const_convert_jaxpr, jaxprs, all_out_pvals)
 
-    return (tuple(typed_jaxprs),
+    return (tuple(closed_jaxprs),
             tuple(util.concatenate(all_consts)),
             tuple(out_tree() for out_tree in all_out_trees))

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -72,8 +72,7 @@ def _initial_style_jaxpr(fun: Callable, in_tree, in_avals):
   jaxpr, out_avals, consts, out_tree = \
       _initial_style_untyped_jaxpr(fun, in_tree, in_avals)
   const_avals = tuple(raise_to_shaped(core.get_aval(c)) for c in consts)
-  typed_jaxpr = core.TypedJaxpr(pe.convert_constvars_jaxpr(jaxpr),
-                                (), const_avals + in_avals, out_avals)
+  typed_jaxpr = core.CosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
   return typed_jaxpr, consts, out_tree
 
 def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -323,7 +323,6 @@ class JaxprTypeChecks(jtu.JaxTestCase):
   def test_check_jaxpr_cond_invalid(self):
     jaxpr = make_jaxpr(lambda x: lax.switch(0, [jnp.sin, jnp.cos], x))(1.).jaxpr
     cond = next(eqn for eqn in jaxpr.eqns if eqn.primitive.name == 'cond')
-    cond.params['branches'][0].in_avals = ()
     cond.params['branches'][0].jaxpr.invars = ()
     self.assertRaisesRegex(
         core.JaxprTypeError,
@@ -358,7 +357,6 @@ class JaxprTypeChecks(jtu.JaxTestCase):
         lambda x: lax.switch(0, [jnp.sin, jnp.cos], x), 100))(1.).jaxpr
 
     cond = next(eqn for eqn in jaxpr.eqns if eqn.primitive.name == 'cond')
-    cond.params['branches'][0].in_avals = ()
     cond.params['branches'][0].jaxpr.invars = ()
     msg = ''
     try:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -240,7 +240,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lax.while_loop(lambda c: True, lambda c: (1., 1.), 0.)
     if config.omnistaging_enabled:
       expected = ("body_fun output and input must have identical types, got\n"
-                  "ShapedArray(bool[], weak_type=True)\n"
+                  "ShapedArray(bool[])\n"
                   "and\n"
                   "ShapedArray(float32[]).")
     else:
@@ -1727,7 +1727,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     # To get a cache hit on the second line we'd need to form a jaxpr and
     # compare them for equality (including the literals on identity). We could
     # implement that by adding a __hash__/__eq__ to core.Jaxpr and
-    # core.TypedJaxpr (see #1221).
+    # core.ClosedJaxpr (see #1221).
     raise SkipTest("not implemented")
 
     def cond(x):
@@ -2450,7 +2450,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertRaisesRegex(
         core.JaxprTypeError,
         re.escape('invalid cond param branches of type tuple, '
-                  'tuple of TypedJaxpr required: (4, 2)'),
+                  'tuple of ClosedJaxpr required: (4, 2)'),
         lambda: core.check_jaxpr(jaxpr))
 
     jaxpr, eqn = new_jaxpr()


### PR DESCRIPTION
rename and simplify TypedJaxpr -> ClosedJaxpr

This change:
* simplifies code that constructs TypedJaxprs/ClosedJaxprs (because in_avals/out_avals no longer need to be constructed), making them easier to work with;
* correspondingly rules out a class of errors (mismatches between invars/outvars and in_avals/out_avals);
* provides a more descriptive class name (ClosedJaxprs are like jaxprs but they're closed in that they are packaged with their constant values).

This is part 1 of an attempt to remove TypedJaxprs completely, or at least significantly reduce our use of them. However, I'm not getting rid of them entirely in this first step because it'd require bigger changes (basically allowing all constants to be represented as literals, rather than only scalars) that would not only touch a lot more code (jaxpr formation, jaxpr-to-jaxpr transformations, control flow, XLA lowering) but also might affect XLA lowering right before a  conference deadline (ICLR). Plus I'm trying to make big changes in smaller steps :)