### PR TITLE
insert a stop_gradient in lax.create_token

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -5688,7 +5688,7 @@ def create_token(x):
        value of `x` is ignored.
   """
   # x is a dummy argument used to tie the operator into a trace.
-  return create_token_p.bind(x)
+  return create_token_p.bind(stop_gradient(x))
 
 create_token_p = Primitive("create_token")
 create_token_p.def_impl(partial(xla.apply_primitive, create_token_p))


### PR DESCRIPTION
see #4292 

The data dependency forced on the operand is false. There's no need to follow it for derivatives, and doing so can lead to unexpected errors.