### PR TITLE
Add jax.numpy.array_equiv

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -68,6 +68,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     around
     array
     array_equal
+    array_equiv
     array_repr
     array_split
     array_str

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -23,7 +23,7 @@ from .lax_numpy import (
     alltrue, amax, amin, angle, any, append,
     apply_along_axis, apply_over_axes, arange, arccos, arccosh, arcsin,
     arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, argwhere, around,
-    array, array_equal, array_repr, array_split, array_str, asarray, atleast_1d, atleast_2d,
+    array, array_equal, array_equiv, array_repr, array_split, array_str, asarray, atleast_1d, atleast_2d,
     atleast_3d, average, bartlett, bfloat16, bincount, bitwise_and, bitwise_not,
     bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays,
     broadcast_to, can_cast, cbrt, cdouble, ceil, character, clip, column_stack,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2418,6 +2418,20 @@ def array_equal(a1, a2, equal_nan=False):
   return all(eq)
 
 
+@_wraps(np.array_equiv)
+def array_equiv(a1, a2):
+  try:
+    a1, a2 = asarray(a1), asarray(a2)
+  except Exception:
+    return False
+  try:
+    lax.broadcast_shapes(shape(a1), shape(a2))
+  except ValueError:
+    return False
+  eq = asarray(a1 == a2)
+  return all(eq)
+
+
 # We can't create uninitialized arrays in XLA; use zeros for empty.
 empty_like = zeros_like
 empty = zeros

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -142,6 +142,7 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
               all_shapes, jtu.rand_default, ["rev"], inexact=True, tolerance=0),
     op_record("not_equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
     op_record("array_equal", 2, number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
+    op_record("array_equiv", 2, number_dtypes, all_shapes, jtu.rand_some_equal, ["rev"]),
     op_record("reciprocal", 1, inexact_dtypes, all_shapes, jtu.rand_default, []),
     op_record("subtract", 2, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("signbit", 1, default_dtypes + bool_dtypes, all_shapes,


### PR DESCRIPTION
Adds jax implementation of `np.array_equiv`.