### PR TITLE
ravel_multi_index implementation

### DIFF
--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -59,7 +59,7 @@ from .lax_numpy import (
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,
     trim_zeros, triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,
-    unpackbits, unravel_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
+    unpackbits, unravel_index, ravel_multi_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
     vstack, where, zeros, zeros_like, _NOT_IMPLEMENTED)
 
 from .polynomial import roots

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1196,6 +1196,24 @@ def unravel_index(indices, shape):
   idx = clipped_indices % cumulative_sizes[:-1] // cumulative_sizes[1:]
   return tuple(idx)
 
+@_wraps(np.ravel_multi_index)
+def ravel_multi_index(multi_index, dims):
+  multi_index = asarray(multi_index)
+  index_dims = ndim(multi_index)
+
+  if index_dims == 1:
+    N = shape(multi_index)[0]
+  elif index_dims == 2:
+    N, _ = shape(multi_index)
+  else:
+    raise ValueError("multi_index must be tuple of arrays.")
+
+  clipped_indices = [clip(multi_index[i], -dims[i], dims[i] - 1) for i in range(N)]
+  clipped_indices = asarray(clipped_indices)
+  sizes = pad(dims[1:], (0, 1), constant_values=1)
+  cumulative_sizes = cumprod(sizes[::-1])[::-1]
+  idx = dot(cumulative_sizes, clipped_indices)
+  return idx
 
 @_wraps(np.squeeze)
 def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1202,7 +1202,7 @@ def ravel_multi_index(multi_index, dims):
   index_dims = ndim(multi_index)
 
   if index_dims == 1:
-    N = shape(multi_index)[0]
+    N = multi_index.size
   elif index_dims == 2:
     N, _ = shape(multi_index)
   else:

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1212,8 +1212,7 @@ def ravel_multi_index(multi_index, dims):
   clipped_indices = asarray(clipped_indices)
   sizes = pad(dims[1:], (0, 1), constant_values=1)
   cumulative_sizes = cumprod(sizes[::-1])[::-1]
-  idx = dot(cumulative_sizes, clipped_indices)
-  return idx
+  return dot(cumulative_sizes, clipped_indices)
 
 @_wraps(np.squeeze)
 def squeeze(a, axis: Union[int, Tuple[int, ...]] = None):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2751,6 +2751,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(jnp.unravel_index(-2, (2, 1, 3,)), (1, 0, 1))
     self.assertEqual(jnp.unravel_index(-3, (2,)), (0,))
 
+  @parameterized.parameters(
+    ([[3, 6, 6], [4, 5, 1]], (7, 6)),
+    ([[3, 6, 6], [4, 5, 1],[3, 2, 2]], (7, 8, 5)),
+    ((3, 1, 4, 1), (6, 7, 8, 9)))
+  def testRavelMultiIndex(self, multi_index, dims):
+    args_maker = lambda: (multi_index, dims)
+    self._CheckAgainstNumpy(np.ravel_multi_index, jnp.ravel_multi_index,
+                            args_maker)
+    self._CompileAndCheck(jnp.ravel_multi_index, args_maker)
+
+  def testRavelMultiIndexOOB(self):
+    self.assertEqual(tuple(jnp.ravel_multi_index([[3, 6, 6], [4, 5, 1]], (5, 6))), (22, 29, 25))
+    # self.assertEqual(jnp.ravel_multi_index(-2, (2, 1, 3,)), (1, 0, 1))
+    # self.assertEqual(jnp.ravel_multi_index(-3, (2,)), (0,))
+
   def testAstype(self):
     rng = np.random.RandomState(0)
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2763,8 +2763,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testRavelMultiIndexOOB(self):
     self.assertEqual(tuple(jnp.ravel_multi_index([[3, 6, 6], [4, 5, 1]], (5, 6))), (22, 29, 25))
-    # self.assertEqual(jnp.ravel_multi_index(-2, (2, 1, 3,)), (1, 0, 1))
-    # self.assertEqual(jnp.ravel_multi_index(-3, (2,)), (0,))
+    self.assertEqual(tuple(jnp.ravel_multi_index([[-3, 6, 6], [4, 5, 4]], (5, 6))), (-14, 29, 28))
+    self.assertEqual(jnp.ravel_multi_index((3, 1, -4, 1), (6, 7, 8, 9)), 1549)
 
   def testAstype(self):
     rng = np.random.RandomState(0)


### PR DESCRIPTION
Hello, I wanted to implement numpy's ravel_multi_index however I just noticed [here](https://github.com/google/jax/issues/70) that it was marked as implemented but I don't actually see it anywhere.  If it actually has been implemented and I just missed it I can go ahead and close this.