### PR TITLE
don't initialize the backend in xla_computation

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -676,12 +676,9 @@ def _xla_computation(
       out_tuple = build_out_tuple()
 
     if any(donated_invars):
-      # TODO(tomhennigan): At call time we should mark these buffers as deleted.
-      backend_ = xb.get_backend(backend)
-      if backend_.platform in ("gpu", "tpu"):
-        donated_invars = xla.set_up_aliases(c, xla_args, out_tuple, donated_invars,
-                                    tuple_args)
-      if any(donated_invars):
+      donated_invars = xla.set_up_aliases(c, xla_args, out_tuple, donated_invars,
+                                          tuple_args)
+      if backend in ("gpu", "tpu") and any(donated_invars):
         shapes = [str(c.GetShape(a)) for a, d in zip(xla_args, donated_invars) if d]
         warn("Some donated buffers were not usable: {}".format(", ".join(shapes)))
     built = c.build(out_tuple)

--- a/jax/api.py
+++ b/jax/api.py
@@ -675,12 +675,12 @@ def _xla_computation(
     else:
       out_tuple = build_out_tuple()
 
-    if any(donated_invars):
+    if any(donated_invars) and backend in ("gpu", "tpu"):
       donated_invars = xla.set_up_aliases(c, xla_args, out_tuple, donated_invars,
                                           tuple_args)
-      if backend in ("gpu", "tpu") and any(donated_invars):
-        shapes = [str(c.GetShape(a)) for a, d in zip(xla_args, donated_invars) if d]
-        warn("Some donated buffers were not usable: {}".format(", ".join(shapes)))
+    if any(donated_invars):
+      shapes = [str(c.GetShape(a)) for a, d in zip(xla_args, donated_invars) if d]
+      warn("Some donated buffers were not usable: {}".format(", ".join(shapes)))
     built = c.build(out_tuple)
     out_shapes_flat = [ShapeDtypeStruct(a.shape, a.dtype) for a in out_avals]
     out_shape = tree_unflatten(out_tree(), out_shapes_flat)

--- a/jax/api.py
+++ b/jax/api.py
@@ -675,7 +675,7 @@ def _xla_computation(
     else:
       out_tuple = build_out_tuple()
 
-    if any(donated_invars) and backend in ("gpu", "tpu"):
+    if any(donated_invars):
       donated_invars = xla.set_up_aliases(c, xla_args, out_tuple, donated_invars,
                                           tuple_args)
     if any(donated_invars):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -239,6 +239,7 @@ class CPPJitTest(jtu.JaxTestCase):
     self.assertDeleted(c)
     self.assertDeleted(d)
 
+  @jtu.skip_on_devices("cpu")  # In/out aliasing not supported on CPU.
   def test_jnp_array_copy(self):
     # https://github.com/google/jax/issues/3412
 


### PR DESCRIPTION
This should allow us to use donate_argnums _and_ build HLO computations for backends not available at build time.

Follow-up on #4121