### PR TITLE
[jax2tf] Added support for shape polymorphism conversion.

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -39,8 +39,12 @@ f_tf(np.random(...))
 
 # Additionally you can use tools like `tf.function` to improve the execution
 # time of your function, or to stage it out to a SavedModel:
-f_tf_graph = tf.function(f_tf)
+f_tf_graph = tf.function(f_tf, autograph=False)
 ```
+
+The Autograph feature of `tf.function` cannot be expected to work on
+functions converted from JAX as above, so it is recommended to
+set `autograph=False` in order to avoid warnings or outright errors.
 
 ### Usage: saved model
 
@@ -50,11 +54,22 @@ is trivial.
 ```python
 # You can save the model just like you would with any other TensorFlow function:
 my_model = tf.Module()
+# Save a function that can take scalar inputs.
 my_model.f = tf.function(f_tf, input_signature=[tf.TensorSpec([], tf.float32)])
 tf.saved_model.save(my_model, '/some/directory')
 
 # Restoring (note: the restored model does *not* require JAX to run, just XLA).
 restored_model = tf.saved_model.load('/some/directory')
+```
+
+Just like for regular TensorFlow functions, it is possible to include in the
+SavedModel multiple versions of a function for different input shapes, by
+"warming up" the function on different input shapes:
+
+```
+my_model.f = tf.function(jax2tf.convert(f_jax), autograph=False)
+my_model.f(tf.ones([1, 28, 28, 1]))  # a batch size of 1
+my_model.f(tf.ones([16, 28, 28, 1]))  # a batch size of 16
 ```
 
 More involved examples of using SavedModel are described in the
@@ -131,15 +146,7 @@ Currently there is a bug that prevents using custom gradients with SavedModel
 4.  There is currently no support for replicated (e.g. `pmap`) or multi-device
     (e.g. `sharded_jit`) functions.
 
-5. In the current version of the converter, every distinct input signature for the
-   converted function will trigger its own distinct conversion. This ensures accurate
-   conversion, even if the original JAX code takes different control-flow paths
-   for different input signatures. When using SavedModel, one would have to
-   `warm up` the saved function on all the necessary input signatures. We are working
-   on a mechanism to allow a single jax2tf conversion to produce a shape-polymorphic
-   TF graph.
-
-6.  The converted code may have slightly different performance characteristics than
+5.  The converted code may have slightly different performance characteristics than
     the original JAX code.
     If one were to write the same functionality in JAX idiomatic code vs.
     native TF idiomatic code we could end up with very different compilation paths,
@@ -163,6 +170,7 @@ Currently there is a bug that prevents using custom gradients with SavedModel
     This primitive is at the moment converted to a soup of tf.bitwise operations,
     which has a clear performance penalty. We plan to look into using the
     HLO [RNGBitGenerator](https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator)
+
     (exposed as a TFXLA op), which does implement
     the same basic Threefry algorithm as JAX’s PRNG, although that would
     result in different results than JAX’s PRNG.
@@ -173,6 +181,158 @@ Currently there is a bug that prevents using custom gradients with SavedModel
     We expect that the lowering that XLA does is similar to that done by JAX
     before conversion. (This is a hypothesis, we have not verified it extensively.)
 
+### Shape-polymorphic conversion
+
+**The shape polymorphism support is work in progress. Please report any bugs you encounter.**
+
+We described above how to include in the SavedModel several specializations
+of a converted function for a few specific input shapes. The converter can also produce
+a shape-polymorphic TensorFlow graph that is usable with inputs of any shape matching
+certain constraints. This is useful, e.g., to allow a SavedModel to be used for multiple
+batch sizes.
+
+The standard TensorFlow technique for producing a shape-polymorphic graph is
+to warm the function on partially-specified (shape polymorphic) inputs.
+For example, if `f_tf` is a TensorFlow function taking a batch of images,
+represented as 4D arrays, then:
+
+```
+tf.function(f_tf).get_concrete_function(tf.TensorSpec([None, 28, 28, 1], tf.float32))
+```
+
+will generate and cache a TensorFlow graph that is expected to work for any
+value of the leading dimension. We use below the term `TensorSpec` to refer to
+a *TensorFlow shape specification*, which can be written directly as above,
+possibly including `None` for some dimensions, or can be derived implicitly
+from actual NumPy arrays or `tf.Tensor` passed as actual arguments.
+
+One challenge for the jax2tf converter is that TensorFlow's shape checking mechanism
+is too permissive in presence of polymorphic shapes. For example, the
+function `lambda x: x + tf.transpose(x)` only makes sense for square matrices,
+but this constraint is not expressible in TensorFlow; we must use the more
+permissive `[None, 16]` shape. The mental model here is that graph generation
+will succeed if the polymorphic `TensorSpec` includes *at least one shape* for
+which the graph is well-defined.
+If the graph is used for other shapes there will be a shape error at runtime.
+
+JAX includes *experimental* support for shape polymorphism but the shape checking
+rules are stricter than in TensorFlow: we must give the jax2tf converter a specification
+of what shapes to specialize the function to, such that the specialization is guaranteed
+to work for *any shape* that matches the specification. For the above example, one can
+obtain a graph that works for all 2D *square* matrices as follows:
+
+```
+f_jax = lambda x: x + x.T
+f_tf = tf.function(jax2tf.convert(f_jax, in_shapes=["(b, b)"]), autograph=False)
+f_tf.get_concrete_function(tf.TensorSpec([None, None], tf.float32))
+```
+
+The novel element here is ```in_shapes=["(b, b)"]```, which introduces
+a dimension variable ```b``` and specifies that the first input is 2D with
+both dimension sizes equal to ```b```. Note that the most precise `TensorSpec`
+available to capture all 2D square matrices is `[None, None]`, which is
+strictly more permissive (TensorFlow does not currently have a notation to
+specify shapes whose dimensions have constraints).
+
+In order to be able to use shape polymorphism effectively with jax2tf, it
+is worth considering what happens under the hood. When the converted function
+is invoked with a `TensorSpec`, the jax2tf converter will combine the
+`TensorSpec` from the actual argument with the `in_shapes` parameter to
+obtain a shape abstraction to be used to specialize the converted function.
+Normally, the shape abstraction contains the dimension sizes, but in the
+presence of shape polymorphism, some dimensions may be polynomials
+of dimension variables.
+
+The `in_shapes` parameter must be either `None`,
+or a sequence (one per argument) of shape specifiers.
+(A value `None` for `in_shapes` is equivalent to a list of `None`.
+See [how optional parameters are matched to arguments](https://jax.readthedocs.io/en/latest/pytrees.html#applying-optional-parameters-to-pytrees).)
+A shape specifier is combined with a `TensorSpec` as follows:
+
+  * A shape specifier of `None` means that the shape is given
+    by the actual `TensorSpec`, which must be fully known.
+  * Otherwise, the specifier must be a comma-separated string of the form `(dim_1, ..., dim_n)`, denoting
+    an n-dimensional array. The `TensorSpec` must also be of rank ``n``. The
+    corresponding dimensions from the shape specifier and the `TensorSpec` are matched:
+
+       * the dimension specifier of `_` means that the value of the dimension is given by
+         the actual `TensorSpec`, which have a constant in the corresponding dimension.
+       * a dimension specifier can also be a lowercase identifier, denoting a dimension-size
+         variable. The abstract value of the dimension is going to be set to this variable.
+         The corresponding dimension in `TensorSpec` should be `None` or can be a
+         constant.
+       * a dimension specifier can also be a polynomial expression involving dimension
+         variables. The expression can involve `+`, `*`, integer constants with optional negation
+         sign, and dimension variables. All occurrences of a dimension variable in any dimension
+         for any argument are assumed to be equal. The corresponding dimension in `TensorSpec`
+         should be `None` or can be a known constant.
+
+Note that `in_shapes` controls the shape abstraction used by JAX when tracing
+the function (with `_` placeholders given by the `TensorSpec`). The `TensorSpec`
+gives the shape abstraction that TensorFlow will associate with the produced
+graph, and can be more specific.
+
+A few examples of shape specifications and uses:
+
+  * `in_shapes=["(b, _, _)", None]` can be used for a function with two arguments, the first
+    having a batch leading dimension that should be polymorphic. The other dimensions for the
+    first argument and the shape of the second argument are specialized based on the actual
+    `TensorSpec`, which must be known. The converted function can be used, e.g.,
+    with `TensorSpec`s `[None, 28, 28]` and `[28, 16]` for the first and second argument
+    respectively. An alternative `TensorSpec` pair can be `[1, 28, 28]` and `[28, 16]`,
+    in which case the JAX tracing is done for the same polymorphic shape given by
+    `in_shapes=["(b, 28, 28)", "(28, 16)"]` but the TensorFlow graph is monomorphic
+    for the shapes given by `TensorSpec`.
+
+  * `in_shapes=["(batch, _)", "(batch,)"]`: the leading dimensions of the two arguments
+     must match. The second dimension of the first argument is taken from the
+     actual `TensorSpec`. This can be used with a `TensorSpec` pair `[None, 16]`
+     and `[None]`. It can also be used with a pair `[8, 16]` and `[5]`. (TODO:
+     add some checking that the `TensorSpec` has at least a satisfying solution
+     for the dimension variables.)
+
+#### Errors in presence of shape polymorphism
+
+When tracing with shape polymorphism we can encounter shape errors:
+
+```
+four_ones = np.ones((4,))
+jax2tf.convert(lambda x, y: x + y,
+               in_shapes=["(v,)", "(4,)"])(four_ones, four_ones)
+```
+
+with result in the error 'add got incompatible shapes for broadcasting: (v,), (4,)'
+because the shape abstraction is given by the `in_shapes`, even though the
+actual arguments are more specific and would actually work.
+
+Also,
+```
+jax2tf.convert(lambda x: jnp.matmul(x, x),
+             in_shapes=["(v, 4)"])(np.ones((4, 4)))
+```
+
+will result in the error 'dot_general requires contracting dimensions to have the same shape, got [4] and [v].'.
+Since the converted function work only for square matrices, the correct
+`in_shapes` is `["(v, v)"]`.
+
+You may also encounter shape errors due to not-yet-implemented shape-polymorphism
+rules for JAX primitives:
+
+```
+jax2tf.convert(lambda x: jnp.split(x, 2),
+             in_shapes=["(2*v,)"])(four_ones)
+```
+
+will give the error 'Only integers, .* tensors are valid indices, got 0' (TO FIX).
+
+Finally, certain codes that use shapes in the actual computation may not yet work
+if those shapes are polymorphic. In the code below, the expression `x.shape[0]`
+will have the value of the shape variable `v`. This case is not yet implemented:
+
+```
+jax2tf.convert(lambda x: jnp.sum(x, axis=0) / x.shape[0],
+               in_shapes=["(v, _)"])(np.ones((4, 4)))
+```
 
 ### Running on GPU
 

--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-10-09*
+*Last generated on (YYYY-MM-DD): 2020-10-14*
 
 ## Updating the documentation
 
@@ -39,6 +39,10 @@ conversion to Tensorflow.
 | conv_general_dilated | Missing TF support | Primitive is unimplemented in TF; likely bug in the HLO -> LLVM IR lowering of XlaConv | complex128, complex64 | CPU, GPU, TPU |
 | cosh | Missing TF support | Primitive is unimplemented in TF | float16 | CPU, GPU, TPU |
 | digamma | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
+| dot_general | Missing TF support | Primitive is unimplemented in TF | bool, int8, uint16, uint32, uint64, uint8 | CPU, GPU, TPU |
+| dot_general | Missing TF support | Primitive is unimplemented in TF | int16 | TPU |
+| dot_general | Missing TF support | Primitive is unimplemented in TF; only cases representable as 2D matrix multiplication can be converted properly | int16 | CPU, GPU |
+| dot_general | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | int64 | CPU, GPU |
 | eig | Missing TF support | Primitive is unimplemented in TF; it is not possible to request both left and right eigenvectors for now | ALL | CPU, GPU, TPU |
 | eig | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | ALL | CPU, GPU, TPU |
 | eigh | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | complex128, complex64 | CPU, GPU, TPU |
@@ -59,6 +63,8 @@ conversion to Tensorflow.
 | round | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | rsqrt | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | scatter-add | Missing TF support | Primitive is unimplemented in TF | complex64 | TPU |
+| scatter-max | Missing TF support | Primitive is unimplemented in TF | bool | CPU, GPU, TPU |
+| scatter-min | Missing TF support | Primitive is unimplemented in TF | bool | CPU, GPU, TPU |
 | scatter-mul | Missing TF support | Primitive is unimplemented in TF | complex64 | TPU |
 | select_and_gather_add | Missing TF support | Primitive is unimplemented in TF | float32, float64 | TPU |
 | select_and_gather_add | Missing TF support | Primitive is unimplemented in TF | float64 | CPU, GPU |
@@ -84,4 +90,4 @@ The conversion of the following JAX primitives is not yet implemented:
 The following JAX primitives have a defined conversion but are known to be
 missing tests:
 
-`argmax`, `argmin`, `broadcast`, `clamp`, `complex`, `conj`, `custom_lin`, `device_put`, `dot_general`, `imag`, `integer_pow`, `real`, `rev`, `select_and_scatter`, `select_and_scatter_add`, `stop_gradient`, `tie_in`
+`argmax`, `argmin`, `broadcast`, `clamp`, `complex`, `conj`, `custom_lin`, `device_put`, `imag`, `integer_pow`, `real`, `rev`, `select_and_scatter`, `select_and_scatter_add`, `stop_gradient`, `tie_in`

--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -50,7 +50,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(jax.grad(f), jnp.float_(1.))
 
 
-  def test_cond_units(self, with_function=True):
+  def test_cond_units(self):
     def g(x):
       return lax.cond(True, lambda x: x, lambda y: y, x)
 

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -195,6 +195,10 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype == np.complex64:
       tf_unimpl(np_dtype, devs=["TPU"])
 
+  if prim in [lax.scatter_max_p, lax.scatter_min_p, lax.scatter_p]:
+    if np_dtype == np.bool_:
+      tf_unimpl(np_dtype)
+
   if prim is lax.sort_p:
     if np_dtype in [np.complex64, np.complex128]:
       tf_unimpl(np_dtype)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -69,7 +69,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                       | set(xla.initial_style_translations)
                       | set(xla.parallel_translations))
 
-    tf_impl = set(jax.experimental.jax2tf.jax2tf.tf_impl)
+    tf_impl = set(jax.experimental.jax2tf.jax2tf.tf_impl) | set(jax.experimental.jax2tf.jax2tf.tf_impl_with_avals)
     tf_not_yet_impl = set(jax.experimental.jax2tf.jax2tf.tf_not_yet_impl)
 
     all_primitives = tuple(sorted(all_primitives, key=str))

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -1,0 +1,343 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the jax2tf conversion for control-flow primitives."""
+
+from absl.testing import absltest
+
+import functools
+import operator
+import re
+import unittest
+
+import jax
+from jax import core
+from jax.experimental import jax2tf
+import jax.numpy as jnp
+from jax import test_util as jtu
+import numpy as np
+from jax.interpreters import masking
+
+
+from jax.experimental.jax2tf.tests import tf_test_util
+
+import tensorflow as tf  # type: ignore[import]
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+class ShapePolyTest(tf_test_util.JaxToTfTestCase):
+
+  def test_simple(self):
+    """Test shape polymorphism for a simple case."""
+    def f_jax(x):
+      return x + jnp.sin(x)
+
+    self.CheckShapePolymorphism(f_jax,
+                                input_signature=[tf.TensorSpec([2, 3])],
+                                in_shapes=None,
+                                expected_output_signature=tf.TensorSpec([2, 3]))
+
+    self.CheckShapePolymorphism(f_jax,
+                                input_signature=[tf.TensorSpec([2, None])],
+                                in_shapes=None,
+                                expected_output_signature=tf.TensorSpec([2, None]))
+
+    self.CheckShapePolymorphism(f_jax,
+                                input_signature=[tf.TensorSpec([2, None])],
+                                in_shapes=["(_, h)"],
+                                expected_output_signature=tf.TensorSpec([2, None]))
+
+    self.CheckShapePolymorphism(f_jax,
+                                input_signature=[tf.TensorSpec([None, None])],
+                                in_shapes=["(h, h)"],
+                                expected_output_signature=tf.TensorSpec([None, None]))
+
+  def test_arg_avals(self):
+    """Test conversion of actual arguments to abstract values"""
+    input_avals = jax2tf.jax2tf._input_avals
+    def shaped_array(shape):
+      if isinstance(shape, str):
+        return core.ShapedArray(masking.parse_spec(shape), np.float32)
+      else:
+        return core.ShapedArray(shape, np.float32)
+
+    def const(shape):
+      return np.ones(shape, dtype=np.float32)
+    def tf_const(shape):
+      return tf.convert_to_tensor(np.ones(shape, dtype=np.float32))
+    def tf_var(init_shape, shape):
+      return tf.Variable(np.ones(init_shape, np.float32),
+                         dtype=tf.float32, shape=shape)
+
+    # Known shapes
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([const((2, 3))], [None]))
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([tf_const((2, 3))], [None]))
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([tf_var((2, 3), (2, 3))], [None]))
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([const((2, 3))], ["(2, 3)"]))
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([tf_const((2, 3))], ["(_, 3)"]))
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                  input_avals([tf_const((2, 3))], ["(_, 3)"]))
+    #
+    # # Partially known shapes
+    # self.assertEqual((shaped_array([2, 3]),),
+    #                   input_avals([tf_var((2, 3), [None, 3])], ["(2, 3)"]))
+    #
+    # self.assertEqual((shaped_array("(h, h)"),),
+    #                   input_avals([tf_var((2, 3), [None, None])], [("h, h")]))
+    #
+    # # Partially known shapes, create shape variables
+    # self.assertEqual((shaped_array("(s0, s1)"),),
+    #                   input_avals([tf_var((2, 3), [None, None])], [None]))
+    # self.assertEqual((shaped_array("(2, s0)"),),
+    #                   input_avals([tf_var((2, 3), [2, None])], [None]))
+
+    # Some errors
+    with self.assertRaisesRegex(
+        TypeError,
+        re.escape("in_shape (_) has different rank than actual argument shape (2, 3)")):
+      input_avals([const((2, 3))], ["(_)"])
+
+    with self.assertRaisesRegex(
+        TypeError,
+        re.escape("in_shape (_, _) has `_` placeholders for argument shape dimensions that are unknown: (2, None)")):
+      input_avals([tf_var((2, 3), [2, None])], ["(_, _)"])
+
+    with self.assertRaisesRegex(
+        TypeError,
+        re.escape("in_shape (2, 13) (resolved to (2, 13)) does not match argument shape (2, 3) in dimension 1")):
+      input_avals([const((2, 3))], ["(2, 13)"])
+
+    with self.assertRaisesRegex(
+        TypeError,
+        re.escape("in_shape (2, 3) (resolved to (2, 3)) does not match argument shape (2, None) in dimension 1")):
+      input_avals([tf_var((2, 3), [2, None])], ["(2, 3)"])
+
+
+  def test_bad_in_shapes(self):
+    def add2(x, y):
+      return x + y
+
+    with self.assertRaisesRegex(masking.ShapeSyntaxError, ""):
+      self.CheckShapePolymorphism(add2,
+                                  input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
+                                  in_shapes=[") + (", None],
+                                  expected_output_signature=tf.TensorSpec([None]))
+
+    with self.assertRaisesRegex(TypeError,
+                                re.escape("in_shapes must be a sequence as long as the argument list (2). "
+                                          "Got in_shapes=['(b, 4)']")):
+      self.CheckShapePolymorphism(add2,
+                                  input_signature=[tf.TensorSpec([None]), tf.TensorSpec([None])],
+                                  in_shapes=["(b, 4)"],
+                                  expected_output_signature=tf.TensorSpec([None]))
+
+
+  def test_pytree(self):
+    """Arguments and in_shapes are pytrees."""
+
+    # Arguments are of the form [([x00, x01], [x10]), dict(a=ya, b=yb)]
+    def add_all_jax(x_pair_of_list, y_dict):
+      x_list_0, x_list_1 = x_pair_of_list
+      return functools.reduce(operator.add,
+                              x_list_0 + x_list_1 + [y_dict["a"], y_dict["b"]])
+
+    self.CheckShapePolymorphism(
+      add_all_jax,
+      input_signature=[([tf.TensorSpec([None]), tf.TensorSpec([None])],
+                        [tf.TensorSpec([None])]),
+                       dict(a=tf.TensorSpec([None]), b=tf.TensorSpec([None]))],
+      in_shapes=[(["(v,)", "(v,)"], [("v,")]),
+                 dict(a="(v,)", b="(v,)")],
+      expected_output_signature=tf.TensorSpec([None]))
+
+    # Now partial in_shapes; the parts of the in_shapes that are not specified
+    # must have full input_signatures.
+    self.CheckShapePolymorphism(
+      add_all_jax,
+      input_signature=[([tf.TensorSpec([4]), tf.TensorSpec([4])],
+                        [tf.TensorSpec([4])]),
+                       dict(a=tf.TensorSpec([4]), b=tf.TensorSpec([4]))],
+      in_shapes=[(["(4,)", "(_,)"], [("4,")]),
+                 dict(a="(_,)", b="(4,)")],
+      expected_output_signature=tf.TensorSpec([4]))
+
+
+  def test_with_custom_vjp(self):
+    """Shape-polymorphic custom VJP."""
+    # TODO: is this test really adding anything???
+    @jax.custom_vjp
+    def f(x):
+      # x: [b1, b2, d1, d2] (a batch of matrices)
+      # res: [b1, b2, d1, d1]
+      return jnp.matmul(x, jnp.transpose(x, axes=(0, 1, 3, 2)))
+
+    # f_fwd: a -> (b, residual)
+    def f_fwd(x):
+      # x: [b1, b2, d1, d2]
+      # b: [b1, b2, d1, d1]
+      # residual: [b1, b2, d1, d2]
+      return f(x), 3. * x
+    # f_bwd: (residual, CT b) -> [CT a]
+    def f_bwd(residual, ct_b):
+      # residual: [b1, b2, d1, d2]
+      # ct_b: [b1, b2, d1, d1]
+      # ct_a: [b1, b2, d1, d2]
+      return jnp.matmul(ct_b, residual),
+
+    f.defvjp(f_fwd, f_bwd)
+    x = np.ones((2, 3, 4, 5), dtype=np.float32)
+    res_jax = f(x)
+    res_jax_grad = jax.grad(lambda x: jnp.sum(f(x)))(x)
+
+    f_tf = self.CheckShapePolymorphism(
+      f,
+      input_signature=[tf.TensorSpec([None, None, None, None])],
+      in_shapes=["(batch1, batch2, d1, d2)"],
+      expected_output_signature=tf.TensorSpec([None, None, None, None]))
+
+    self.assertAllClose(res_jax, f_tf(x))
+
+    xv = tf.Variable(x, dtype=np.float32)
+    def tf_value_and_grad(xv):
+      with tf.GradientTape() as tape:
+        tape.watch(xv)
+        res_tf = f_tf(xv)
+        res_tf_grad = tape.gradient(res_tf, xv)
+        return res_tf, res_tf_grad
+
+    res_tf, res_tf_grad = tf_value_and_grad(xv)
+    self.assertAllClose(res_jax, res_tf)
+    self.assertAllClose(res_jax_grad, res_tf_grad)
+
+    # Now use TF tracing for the gradient
+    tf_grad = tf.function(
+      tf_value_and_grad,
+      autograph=False).get_concrete_function(tf.TensorSpec([None, None, 8, 9]))
+
+    # The shape of the value
+    self.assertEqual((None, None, 8, 8), tuple(tf_grad.output_shapes[0]))
+    # The shape of the gradient should match the input
+    # TODO: there seems to be a bug here, the output should be (None, None, 8, 9)
+    # self.assertEqual((None, None, 8, None), tuple(tf_grad.output_shapes[1]))
+
+
+  def test_gradients_pytree(self):
+    """Shape polymorphism with gradients and pytrees for inputs and outputs."""
+    def f(x):
+      # x: dict(x=[b, 3, 4])
+      # res: dict(res=[b, 3, 4])
+      return dict(res=x["x"] * 2.)
+
+    f_tf = self.CheckShapePolymorphism(
+      f,
+      input_signature=[dict(x=tf.TensorSpec([None, 3, 4]))],
+      in_shapes=[dict(x=("b, 3, 4"))],
+      expected_output_signature=None)
+
+    x = dict(x=np.ones((2, 3, 4), dtype=np.float32))
+    xv = tf.Variable(x["x"], dtype=np.float32)
+    def tf_value_and_grad(xv):
+      # xv: [b, 3, 4]
+      # res_value: dict(res=[b, 3, 4])
+      # res_grad: dict(grad=[b, 3, 4])
+      with tf.GradientTape() as tape:
+        tape.watch(xv)
+        res_tf = f_tf(dict(x=xv))
+        res_tf_grad = tape.gradient(res_tf, xv)
+        return res_tf, dict(grad=res_tf_grad)
+
+    res_tf, res_tf_grad = tf_value_and_grad(xv)
+    # Now use TF tracing for the gradient
+    tf_grad = tf.function(tf_value_and_grad, autograph=False).get_concrete_function(
+      tf.TensorSpec([None, 3, 4]))
+    # The shape of the value
+    self.assertEqual((None, 3, 4), tuple(tf_grad.output_shapes[0]["res"]))
+    # The shape of the gradient should match the input
+    self.assertEqual((None, 3, 4), tuple(tf_grad.output_shapes[1]["grad"]))
+
+
+  def test_matmul(self):
+    def f_jax(x, y):
+      return jnp.matmul(x, y)
+
+    self.CheckShapePolymorphism(
+      f_jax,
+      input_signature=[tf.TensorSpec([None, 8, 4]), tf.TensorSpec([None, 4, None])],
+      in_shapes=["(batch, _, 4)", "(batch, 4, w)"],
+      expected_output_signature=tf.TensorSpec([None, 8, None]))
+
+  def test_reshape(self):
+    raise unittest.SkipTest("Not implemented")
+    def f_jax(x):
+      y = jnp.sin(x)
+      yshape0, yshape1 = y.shape
+      return y.reshape([2, -1])
+
+    self.CheckShapePolymorphism(
+      f_jax,
+      input_signature=[tf.TensorSpec([None, None])],
+      in_shapes=["(2 * batch, d)"],
+      expected_output_signature=tf.TensorSpec([2, None]))
+
+
+  def test_mean(self):
+    raise unittest.SkipTest("Not yet implemented")
+    def f_jax(x):
+      return jnp.sum(x, axis=0) / jax2tf.shape_as_value(x)[0]
+
+    f_tf = self.CheckShapePolymorphism(
+      f_jax,
+      input_signature=[tf.TensorSpec([None, 4])],
+      in_shapes=[("batch, _")],
+      expected_output_signature=tf.TensorSpec([4]))
+    x = np.arange(12.).reshape((3, 4))
+    self.assertAllClose(np.array([4., 5., 6., 7.]), f_tf(x))
+
+
+  def test_shape_error(self):
+    """Some of the examples from the README."""
+    with self.assertRaisesRegex(TypeError,
+                                re.escape("add got incompatible shapes for broadcasting: (v,), (4,)")):
+      self.CheckShapePolymorphism(
+        lambda x, y: x + y,
+        input_signature=[tf.TensorSpec([None]), tf.TensorSpec([4])],
+        in_shapes=["(v,)", "(4,)"],
+        expected_output_signature=tf.TensorSpec([None]))
+
+    four_ones = np.ones((4,))
+    # We get the error even if we use correct actual arguments
+    with self.assertRaisesRegex(TypeError,
+                                re.escape("add got incompatible shapes for broadcasting: (v,), (4,)")):
+      jax2tf.convert(lambda x, y: x + y,
+                     in_shapes=["(v,)", "(4,)"])(four_ones, four_ones)
+
+    with self.assertRaisesRegex(TypeError,
+                                re.escape("dot_general requires contracting dimensions to have the same shape, got [4] and [v].")):
+      jax2tf.convert(lambda x: jnp.matmul(x, x),
+                     in_shapes=["(v, 4)"])(np.ones((4, 4)))
+
+    # TODO: this is an opportunity to improve the translation, should not error
+    with self.assertRaisesRegex(TypeError,
+                                "Only integers, .* tensors are valid indices, got 0"):
+      jax2tf.convert(lambda x: jnp.split(x, 2),
+                     in_shapes=["(2*v,)"])(four_ones)
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -307,6 +307,7 @@ class ShapeSpec(tuple):
     return 'ShapeSpec({})'.format(', '.join(map(str, self)))
 
 def finalize_spec(polymorphic_shape, padded_shape):
+  # TODO: what if polymorphic_shape has a constant that does not match padded_shape?
   return tuple(_parse_lit(d) if e is _monomorphic_dim else e
                for e, d in zip(polymorphic_shape, padded_shape))
 
@@ -326,7 +327,7 @@ def _parse_dim(spec):
     return prod(map(_parse_dim, spec.split('*')))
   elif spec.isdigit() or spec.startswith('-') and spec[1:].isdigit():
     return _parse_lit(spec)
-  elif spec in _identifiers:
+  elif spec[0] in _identifiers:
     return _parse_id(spec)
   elif spec == '_':
     return _monomorphic_dim


### PR DESCRIPTION
The intended usage, and some design challenges, for this feature
are described in README.md.

In order to enable this change, I had to first change
TensorFlowTracer to carry explicitly the JAX abstract value
for the undelying TF value (previously, we would just compute
the abstract value from the TF value. This is not possible
when the TF value has partially known shape. In that case we
want the JAX abstract value, using masking.ShapeSpec.

As a beneficial side-effect of adding explicit abstract values
to TensorFlowTracer we can clean up all the hacky handling of
core.unit (we would store core.unit as a TF value, hence the
need for TfValOrUnit, and we would swap it with tf.nan
when going to TF). Now we can just store tf.name as the TF value
and core.abstract_unit for the abstract value.

The key smarts in this change are just reused from jax.interpreters.masking.
All we really added is carefully carrying that information through.

A tricky part was carrying the abstract shapes for tf.custom_gradient.