### PR TITLE
[jax2tf] Implementation of the conversion of eigh_p.

### DIFF
--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-09-18*
+*Last generated on (YYYY-MM-DD): 2020-09-21*
 
 ## Updating the documentation
 
@@ -23,8 +23,8 @@ conversion to Tensorflow.
 | acosh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | acosh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | add | Missing TF support | Primitive is unimplemented | uint16, uint32, uint64 | CPU, GPU, TPU |
-| asinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | asinh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
+| asinh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
 | atan2 | Missing TF support | Primitive is unimplemented | bfloat16, float16 | CPU, GPU, TPU |
 | atanh | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | atanh | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
@@ -37,6 +37,7 @@ conversion to Tensorflow.
 | digamma | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | eig | Missing TF support | Primitive is unimplemented; it is not possible to request both left and right eigenvectors for now | ALL | CPU, GPU, TPU |
 | eig | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | ALL | CPU, GPU, TPU |
+| eigh | Missing TF support | Primitive is unimplemented; this is a problem only in compiled mode (experimental_compile=True)) | complex128, complex64 | CPU, GPU, TPU |
 | erf | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | erf_inv | Missing TF support | Primitive is unimplemented | bfloat16 | CPU, GPU |
 | erf_inv | Missing TF support | Primitive is unimplemented | float16 | CPU, GPU, TPU |
@@ -70,7 +71,7 @@ conversion to Tensorflow.
 
 The conversion of the following JAX primitives is not yet implemented:
 
-`after_all`, `all_to_all`, `axis_index`, `create_token`, `cummax`, `cummin`, `custom_linear_solve`, `eigh`, `igamma_grad_a`, `infeed`, `lu`, `outfeed`, `pmax`, `pmin`, `ppermute`, `psum`, `random_gamma_grad`, `reduce`, `rng_uniform`, `triangular_solve`, `xla_pmap`
+`after_all`, `all_to_all`, `axis_index`, `create_token`, `cummax`, `cummin`, `custom_linear_solve`, `igamma_grad_a`, `infeed`, `lu`, `outfeed`, `pmax`, `pmin`, `ppermute`, `psum`, `random_gamma_grad`, `reduce`, `rng_uniform`, `triangular_solve`, `xla_pmap`
 
 ## Primitive conversions with missing tests
 

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -126,6 +126,14 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if compute_left_eigenvectors and compute_right_eigenvectors:
       tf_unimpl(additional_msg=("it is not possible to request both left and "
                                 "right eigenvectors for now"))
+
+  if prim is lax_linalg.eigh_p:
+    np_dtype = _to_np_dtype(args[0].dtype)
+    if np_dtype in [np.complex64, np.complex128]:
+      # See https://github.com/google/jax/pull/3775#issuecomment-659407824;
+      # experimental_compile=True breaks for complex types.
+      tf_unimpl(np_dtype, additional_msg=("this is a problem only in compiled "
+                                          "mode (experimental_compile=True))"))
   if prim is lax_linalg.svd_p:
     np_dtype = _to_np_dtype(args[0].dtype)
     if np_dtype in [dtypes.bfloat16]:

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -620,6 +620,20 @@ lax_linalg_eig = tuple(
   for compute_right_eigenvectors in [False, True]
 )
 
+lax_linalg_eigh = tuple(
+  Harness(f"_shape={jtu.format_shape_dtype_string(shape, dtype)}_lower={lower}",
+          lax_linalg.eigh,
+          [RandArg(shape, dtype), StaticArg(lower), StaticArg(False)],
+          shape=shape,
+          dtype=dtype,
+          lower=lower)
+  for dtype in jtu.dtypes.all_inexact
+  for shape in [(0, 0), (50, 50), (2, 20, 20)]
+  for lower in [False, True]
+  # Filter out cases where implementation is missing in JAX
+  if dtype != np.float16
+)
+
 lax_slice = tuple(
   Harness(f"_shape={shape}_start_indices={start_indices}_limit_indices={limit_indices}_strides={strides}",  # type: ignore
           lax.slice,


### PR DESCRIPTION
The main issue is a huge loss of precision in compiled mode.

I believe (but couldn't test) that `always_custom_assert` can be set to False on TPU, since the implementation for that platform does not seem to use custom calls.