### PR TITLE
Add a prototype implementation of recursive checkpointing

### DIFF
--- a/jax/experimental/checkpoint.py
+++ b/jax/experimental/checkpoint.py
@@ -1,0 +1,50 @@
+from typing import Callable
+from functools import partial
+import itertools as it
+
+from .. import checkpoint
+from .. import core
+from .. import linear_util as lu
+from ..interpreters import partial_eval as pe
+from ..api_util import wraps, flatten_fun
+from ..tree_util import tree_flatten, tree_unflatten
+from ..traceback_util import api_boundary
+
+# TODO: Support concrete?
+def checkpoint_recursive(fun: Callable, threshold=1) -> Callable:
+  if threshold < 1:
+    raise ValueError(f"threshold has to be at least 1, got {threshold}")
+  @wraps(fun)
+  @api_boundary
+  def fun_recursive(*args, **kwargs):
+    args_flat, in_tree = tree_flatten((args, kwargs))
+    flat_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
+    avals_flat = [core.raise_to_shaped(core.get_aval(arg)) for arg in args_flat]
+    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, avals_flat)
+    jaxpr_noconst = pe.convert_constvars_jaxpr(jaxpr)
+    checkp_fun = _recursive_checkpoint_jaxpr(jaxpr_noconst, threshold=threshold)
+    out_flat = checkp_fun(*consts, *args_flat)
+    return tree_unflatten(out_tree(), out_flat)
+  return fun_recursive
+
+def _recursive_checkpoint_jaxpr(jaxpr, threshold):
+  assert not jaxpr.constvars
+  eqns = jaxpr.eqns
+  if len(jaxpr.eqns) <= threshold:
+    return partial(core.eval_jaxpr, jaxpr, ())
+  split_point = (len(eqns) + 1) // 2
+  eqns1, eqns2 = eqns[:split_point], eqns[split_point:]
+  residuals = list(_jaxpr_free_vars(core.Jaxpr([], [], jaxpr.outvars, eqns2)))
+  jaxpr1 = core.Jaxpr([], jaxpr.invars, residuals, eqns1)
+  jaxpr2 = core.Jaxpr([], residuals, jaxpr.outvars, eqns2)
+  f1 = checkpoint(_recursive_checkpoint_jaxpr(jaxpr1, threshold))
+  f2 = _recursive_checkpoint_jaxpr(jaxpr2, threshold)
+  return lambda *args: f2(*f1(*args))
+
+def _jaxpr_free_vars(jaxpr):
+  free = set(jaxpr.outvars)
+  for eqn in jaxpr.eqns[::-1]:
+    free -= set(eqn.outvars)
+    free |= set(eqn.invars)
+  free -= set(it.chain(jaxpr.invars, jaxpr.constvars))
+  return free

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 from absl.testing import absltest
+from unittest import skipIf
 
 import jax
 from jax import core
@@ -26,12 +28,13 @@ config.parse_flags_with_absl()
 FLAGS = flags.FLAGS
 
 class CheckpointTest(jtu.JaxTestCase):
+  @skipIf(not jax.config.omnistaging_enabled, "need omnistaging")
   def testSimpleChain(self):
     def f(x):
       for i in range(8):
         x = jnp.exp(x)
       return x
-    x = jnp.ones((4,))
+    x = np.ones((4,))
     jaxpr = jax.make_jaxpr(C.checkpoint_recursive(f))(x).jaxpr
     def verify(jaxpr, lvl):
       if lvl < 0: return

--- a/tests/checkpoint_test.py
+++ b/tests/checkpoint_test.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+import jax
+from jax import core
+from jax import numpy as jnp
+from jax import test_util as jtu
+import jax.experimental.checkpoint as C
+
+from jax.config import config, flags
+config.parse_flags_with_absl()
+
+FLAGS = flags.FLAGS
+
+class CheckpointTest(jtu.JaxTestCase):
+  def testSimpleChain(self):
+    def f(x):
+      for i in range(8):
+        x = jnp.exp(x)
+      return x
+    x = jnp.ones((4,))
+    jaxpr = jax.make_jaxpr(C.checkpoint_recursive(f))(x).jaxpr
+    def verify(jaxpr, lvl):
+      if lvl < 0: return
+      remats, exp = jaxpr.eqns[:-1], jaxpr.eqns[-1]
+      self.assertEqual([eqn.primitive.name for eqn in remats],
+                       ["remat_call"] * lvl)
+      self.assertEqual(exp.primitive.name, "exp")
+      for i, remat in enumerate(remats):
+        verify(core.extract_call_jaxpr(remat.primitive, remat.params)[0], lvl - 1 - i)
+    verify(jaxpr, 3)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Example:
```py
import jax                                               
import jax.numpy as jnp                                  
from jax.experimental.checkpoint import checkpoint_recursive
                                                         
@checkpoint_recursive                                     
def f(x):                                                
  for i in range(8):                                     
    x = jnp.exp(x)                                       
  return x                                               
                                                         
print(jax.make_jaxpr(f)(jnp.ones((4,))))                 
```

produces the following jaxpr:

<details>

```
{ lambda  ; a.
  let b = remat_call[ call_jaxpr={ lambda  ; a.
                                   let b = remat_call[ call_jaxpr={ lambda  ; a.
                                                                    let b = remat_call[ call_jaxpr={ lambda  ; a.
                                                                                                     let b = exp a
                                                                                                     in (b,) }
                                                                                        concrete=False
                                                                                        name=<unnamed wrapped function> ] a
                                                                        c = exp b
                                                                    in (c,) }
                                                       concrete=False
                                                       name=<lambda> ] a
                                       c = remat_call[ call_jaxpr={ lambda  ; a.
                                                                    let b = exp a
                                                                    in (b,) }
                                                       concrete=False
                                                       name=<unnamed wrapped function> ] b
                                       d = exp c
                                   in (d,) }
                      concrete=False
                      name=<lambda> ] a
      c = remat_call[ call_jaxpr={ lambda  ; a.
                                   let b = remat_call[ call_jaxpr={ lambda  ; a.
                                                                    let b = exp a
                                                                    in (b,) }
                                                       concrete=False
                                                       name=<unnamed wrapped function> ] a
                                       c = exp b
                                   in (c,) }
                      concrete=False
                      name=<lambda> ] b
      d = remat_call[ call_jaxpr={ lambda  ; a.
                                   let b = exp a
                                   in (b,) }
                      concrete=False
                      name=<unnamed wrapped function> ] c
      e = exp d
  in (e,) }

```

</details>

**TODO:**
* [ ] Tests
* [ ] Better cost estimation (loops, calls, conditionals all can have an arbitrary number of primitives inside)
* [ ] Loop splitting, when the half-point of operation count lies inside a loop