### PR TITLE
Fix jnp.diff behavior on scalars

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1012,14 +1012,14 @@ def angle(z):
 
 
 @_wraps(np.diff)
-def diff(a, n=1, axis=-1,):
-  if not isinstance(a, ndarray) or a.ndim == 0:
-    return a
+def diff(a, n=1, axis=-1):
+  _check_arraylike("diff", a)
   if n == 0:
     return a
   if n < 0:
-    raise ValueError(
-      "order must be non-negative but got " + repr(n))
+    raise ValueError(f"order must be non-negative but got {n}")
+  if ndim(a) == 0:
+    raise ValueError(f"diff requires input that is at least one dimensional; got {a}")
 
   nd = a.ndim
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -290,7 +290,7 @@ JAX_COMPOUND_OP_RECORDS = [
               check_dtypes=False),
     op_record("true_divide", 2, all_dtypes, all_shapes, jtu.rand_nonzero,
               ["rev"], inexact=True),
-    op_record("diff", 1, number_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
+    op_record("diff", 1, number_dtypes + bool_dtypes, nonzerodim_shapes, jtu.rand_default, ["rev"]),
     op_record("ediff1d", 3, [np.int32], all_shapes, jtu.rand_default, []),
     op_record("unwrap", 1, float_dtypes, nonempty_nonscalar_array_shapes,
               jtu.rand_default, ["rev"],


### PR DESCRIPTION
Fixes `jnp.diff` erroneously passing-through scalars or non-arrays.

Before this change:
```py
In [1]: import numpy as np                                                                                                               

In [2]: import jax.numpy as jnp                                                                                         

In [3]: np.diff(0)                                                                                                                       
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-85ad82741d0e> in <module>
----> 1 np.diff(0)

<__array_function__ internals> in diff(*args, **kwargs)

~/.local/share/virtualenvs/jax-LBbfM5ix/lib/python3.8/site-packages/numpy/lib/function_base.py in diff(a, n, axis, prepend, append)
   1244     nd = a.ndim
   1245     if nd == 0:
-> 1246         raise ValueError("diff requires input that is at least one dimensional")
   1247     axis = normalize_axis_index(axis, nd)
   1248 

ValueError: diff requires input that is at least one dimensional

In [4]: jnp.diff(0)                                                                                                                      
Out[4]: 0           

In [5]: jnp.diff([1, 2])                                                                                                                 
Out[5]: [1, 2]
```
After this change:
```python
In [1]: import jax.numpy as jnp                                                                                                          
j
In [2]: jnp.diff(0)                                                                                                                      
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-7d09f26f58b9> in <module>
----> 1 jnp.diff(0)

~/github/google/jax/jax/numpy/lax_numpy.py in diff(a, n, axis)
   1020     raise ValueError(f"order must be non-negative but got {n}")
   1021   if ndim(a) == 0:
-> 1022     raise ValueError(f"diff requires input that is at least one dimensional; got {a}")
   1023 
   1024   nd = a.ndim

ValueError: diff requires input that is at least one dimensional; got 0

In [3]: jnp.diff([1, 2])                                                                                                                 
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-ea17d2baf23e> in <module>
----> 1 jnp.diff([1, 2])

~/github/google/jax/jax/numpy/lax_numpy.py in diff(a, n, axis)
   1014 @_wraps(np.diff)
   1015 def diff(a, n=1, axis=-1):
-> 1016   _check_arraylike("diff", a)
   1017   if n == 0:
   1018     return a

~/github/google/jax/jax/numpy/lax_numpy.py in _check_arraylike(fun_name, *args)
    295                     if not _arraylike(arg))
    296     msg = "{} requires ndarray or scalar arguments, got {} at position {}."
--> 297     raise TypeError(msg.format(fun_name, type(arg), pos))
    298 
    299 

TypeError: diff requires ndarray or scalar arguments, got <class 'list'> at position 0.
```