### PR TITLE
jax.numpy: improved errors for invalid inputs to unary ops

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -342,11 +342,9 @@ def result_type(*args):
 
 def _one_to_one_unop(numpy_fn, lax_fn, promote_to_inexact=False, lax_doc=False):
   if promote_to_inexact:
-    def fn(x):
-      x = lax.convert_element_type(x, _to_inexact_dtype(_dtype(x)))
-      return lax_fn(x)
+    fn = lambda x: lax_fn(*_promote_args_inexact(numpy_fn.__name__, x))
   else:
-    fn = lambda x: lax_fn(x)
+    fn = lambda x: lax_fn(*_promote_args(numpy_fn.__name__, x))
   if lax_doc:
     doc = _dedent('\n\n'.join(lax_fn.__doc__.split('\n\n')[1:])).strip()
     return _wraps(numpy_fn, lax_description=doc)(fn)


### PR DESCRIPTION
Before:
```py
In [1]: import jax.numpy as jnp                                                                                                          

In [2]: jnp.negative([1, 2, 3])                                                                                                          
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-f2d2f6fccc05> in <module>
----> 1 jnp.negative([1, 2, 3])

~/github/google/jax/jax/numpy/lax_numpy.py in <lambda>(x)
    347       return lax_fn(x)
    348   else:
--> 349     fn = lambda x: lax_fn(x)
    350   if lax_doc:
    351     doc = _dedent('\n\n'.join(lax_fn.__doc__.split('\n\n')[1:])).strip()

~/github/google/jax/jax/lax/lax.py in neg(x)
     89 def neg(x: Array) -> Array:
     90   r"""Elementwise negation: :math:`-x`."""
---> 91   return neg_p.bind(x)
     92 
     93 def sign(x: Array) -> Array:

~/github/google/jax/jax/core.py in bind(self, *args, **params)
    264     top_trace = find_top_trace(args)
    265     tracers = map(top_trace.full_raise, args)
--> 266     out = top_trace.process_primitive(self, tracers, params)
    267     return map(full_lower, out) if self.multiple_results else full_lower(out)
    268 

~/github/google/jax/jax/core.py in process_primitive(self, primitive, tracers, params)
    572 
    573   def process_primitive(self, primitive, tracers, params):
--> 574     return primitive.impl(*tracers, **params)
    575 
    576   def process_call(self, primitive, f, tracers, params):

~/github/google/jax/jax/interpreters/xla.py in apply_primitive(prim, *args, **params)
    222 def apply_primitive(prim, *args, **params):
    223   """Impl rule that compiles and runs a single primitive 'prim' using XLA."""
--> 224   compiled_fun = xla_primitive_callable(prim, *unsafe_map(arg_spec, args), **params)
    225   return compiled_fun(*args)
    226 

~/github/google/jax/jax/interpreters/xla.py in arg_spec(x)
    214 
    215 def arg_spec(x):
--> 216   aval = abstractify(x)
    217   try:
    218     return aval, x._device

~/github/google/jax/jax/interpreters/xla.py in abstractify(x)
    163     aval_fn = pytype_aval_mappings.get(typ)
    164     if aval_fn: return aval_fn(x)
--> 165   raise TypeError(f"Argument '{x}' of type '{type(x)}' is not a valid JAX type")
    166 
    167 def _make_abstract_python_scalar(typ, _):

TypeError: Argument '[1, 2, 3]' of type '<class 'list'>' is not a valid JAX type
```
After:
```py
In [1]: import jax.numpy as jnp                                                                                                          

In [2]: jnp.negative([1, 2, 3])                                                                                                          
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-f2d2f6fccc05> in <module>
----> 1 jnp.negative([1, 2, 3])

~/github/google/jax/jax/numpy/lax_numpy.py in <lambda>(x)
    345     fn = lambda x: lax_fn(*_promote_args_inexact(numpy_fn.__name__, x))
    346   else:
--> 347     fn = lambda x: lax_fn(*_promote_args(numpy_fn.__name__, x))
    348   if lax_doc:
    349     doc = _dedent('\n\n'.join(lax_fn.__doc__.split('\n\n')[1:])).strip()

~/github/google/jax/jax/numpy/lax_numpy.py in _promote_args(fun_name, *args)
    300 def _promote_args(fun_name, *args):
    301   """Convenience function to apply Numpy argument shape and dtype promotion."""
--> 302   _check_arraylike(fun_name, *args)
    303   return _promote_shapes(fun_name, *_promote_dtypes(*args))
    304 

~/github/google/jax/jax/numpy/lax_numpy.py in _check_arraylike(fun_name, *args)
    295                     if not _arraylike(arg))
    296     msg = "{} requires ndarray or scalar arguments, got {} at position {}."
--> 297     raise TypeError(msg.format(fun_name, type(arg), pos))
    298 
    299 

TypeError: negative requires ndarray or scalar arguments, got <class 'list'> at position 0.
```