### PR TITLE
avoid spurious device interactions

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -657,7 +657,8 @@ def broadcast_in_dim(operand: Array, shape: Shape,
   """
   shape = _broadcast_in_dim_shape_rule(
     operand, shape=shape, broadcast_dimensions=broadcast_dimensions)
-  if np.ndim(operand) == len(shape) and not len(broadcast_dimensions):
+  if (np.ndim(operand) == len(shape) and not len(broadcast_dimensions)
+      and isinstance(operand, (xla.DeviceArray, core.Tracer))):
     return operand
   return broadcast_in_dim_p.bind(
       operand, shape=tuple(shape),
@@ -1392,10 +1393,7 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
     raise TypeError(msg.format(np.shape(fill_value)))
   dtype = dtypes.canonicalize_dtype(dtype or _dtype(fill_value))
   fill_value = convert_element_type(fill_value, dtype)
-  if config.omnistaging_enabled:
-    if not isinstance(fill_value, (xla.DeviceArray, core.Tracer)):
-      fill_value = _device_put_raw(fill_value)
-  else:
+  if not config.omnistaging_enabled:
     fill_value = xla.device_put_p.bind(fill_value)
   return broadcast(fill_value, shape)
 
@@ -3031,6 +3029,8 @@ ad.deflinear(broadcast_p, lambda t, sizes: [_reduce_sum(t, range(len(sizes)))])
 batching.primitive_batchers[broadcast_p] = _broadcast_batch_rule
 
 def _broadcast_in_dim_impl(operand, *, shape, broadcast_dimensions):
+  if type(operand) is np.ndarray:
+    operand = _device_put_raw(operand)
   if type(operand) is xla.DeviceArray and np.all(
       np.equal(operand.shape, np.take(shape, broadcast_dimensions))):
     shape = _broadcast_in_dim_shape_rule(

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1798,6 +1798,9 @@ class APITest(jtu.JaxTestCase):
     f()  # doesn't crash
 
   def test_xla_computation_zeros_doesnt_device_put(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test is omnistaging-specific")
+
     count = 0
     def device_put_and_count(*args, **kwargs):
       nonlocal count


### PR DESCRIPTION
Before this change, `jax.xla_computation(lambda: jnp.zeros(3))` would require initializing a backend and do device runtime operations.