### PR TITLE
[jax2tf] Implement proper tracking of which primitives have dedicated tests (WIP)

### DIFF
--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -143,4 +143,4 @@ The conversion of the following JAX primitives is not yet implemented:
 The following JAX primitives have a defined conversion but are known to be
 missing tests:
 
-`argmin`, `broadcast`, `clamp`, `complex`, `conj`, `custom_lin`, `device_put`, `integer_pow`, `rev`, `select_and_scatter`, `tie_in`
+`add_any`, `argmax`, `argmin`, `bitcast_convert_type`, `broadcast`, `broadcast_in_dim`, `clamp`, `complex`, `concatenate`, `conj`, `convert_element_type`, `cumprod`, `cumsum`, `custom_jvp_call_jaxpr`, `custom_lin`, `custom_vjp_call_jaxpr`, `device_put`, `div`, `eq`, `ge`, `gt`, `imag`, `integer_pow`, `iota`, `le`, `lt`, `ne`, `pow`, `real`, `reduce_and`, `reduce_or`, `reshape`, `rev`, `select`, `shape_as_value`, `stop_gradient`, `sub`, `tie_in`, `transpose`, `zeros_like`


### PR DESCRIPTION
We want to know exactly which primitive conversions are missing dedicated tests.
The method we used before was just showing that some primitives were never called throughout the tests, which didn't give much insight into whether they were actually properly tested or not.