### PR TITLE
Delete dead axis_index code

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1191,48 +1191,6 @@ def axis_frame(axis_name):
 
   raise NameError("unbound axis name: {}".format(axis_name))
 
-def axis_index(axis_name):
-  """Return the index along the mapped axis ``axis_name``.
-
-  Args:
-    axis_name: hashable Python object used to name the mapped axis.
-
-  Returns:
-    An integer representing the index.
-
-  For example, with 8 XLA devices available:
-
-  >>> from functools import partial
-  >>> @partial(jax.pmap, axis_name='i')
-  ... def f(_):
-  ...   return lax.axis_index('i')
-  ...
-  >>> f(np.zeros(4))
-  ShardedDeviceArray([0, 1, 2, 3], dtype=int32)
-  >>> f(np.zeros(8))
-  ShardedDeviceArray([0, 1, 2, 3, 4, 5, 6, 7], dtype=int32)
-  >>> @partial(jax.pmap, axis_name='i')
-  ... @partial(jax.pmap, axis_name='j')
-  ... def f(_):
-  ...   return lax.axis_index('i'), lax.axis_index('j')
-  ...
-  >>> x, y = f(np.zeros((4, 2)))
-  >>> print(x)
-  [[0 0]
-  [1 1]
-  [2 2]
-  [3 3]]
-  >>> print(y)
-  [[0 1]
-  [0 1]
-  [0 1]
-  [0 1]]
-  """
-  return axis_index_p.bind(axis_name=axis_name)
-
-axis_index_p = Primitive('axis_index')
-axis_index_p.def_abstract_eval(lambda *, axis_name: ShapedArray((), np.int32))
-
 
 # ------------------- Jaxpr checking -------------------
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1277,15 +1277,6 @@ def _call_translation_rule(c, axis_env, in_nodes, name_stack,
 call_translations[core.call_p] = _call_translation_rule
 
 
-def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
-  div = xb.constant(c, np.array(axis_env.nreps // prod(axis_env.sizes),
-                                dtype=np.uint32))
-  mod = xb.constant(c, np.array(axis_env.sizes[-1], dtype=np.uint32))
-  unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
-  return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
-parallel_translations[core.axis_index_p] = _axis_index_translation_rule  # type: ignore
-
-
 @config.register_omnistaging_disabler
 def omnistaging_disabler() -> None:
   global _pval_to_result_handler


### PR DESCRIPTION
The primitive was moved to `lax_parallel.py` some time ago, so the one
in `core` should no longer be used. This is probably a result of a
botched rebase.