### PR TITLE
Fix axis_index inside nested pmaps

### DIFF
--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -678,7 +678,7 @@ def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
 def _axis_index_soft_pmap_rule(vals, mapped, chunk_size, *, axis_name):
   assert not vals and not mapped
   idx = axis_index(axis_name)  # type: ignore
-  return idx * chunk_size + np.arange(chunk_size), True
+  return idx * chunk_size + np.arange(chunk_size, dtype=np.int32), True
 
 axis_index_p = core.Primitive('axis_index')
 xla.parallel_translations[axis_index_p] = _axis_index_translation_rule


### PR DESCRIPTION
The previous translation rule has assumed that `axis_index` is always
taken over the outermost axis in the `axis_env`, and was always producing
the same output, no matter which axis has been specified. This fixes the
translation rule to start taking the `axis_name` into account.

Additionally, this adds support for querying the index along multiple
axes, which will be useful for `gmap`.