### PR TITLE
[jax2tf] Adjust tolerance in flaky float32 eigh test.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -361,11 +361,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         # specifically for eigenvectors.
         if dtype == np.float64:
           tol = 1e-6
-        elif dtype in [dtypes.bfloat16, np.float32, np.complex64]:
-          if dtype == np.float32 and jtu.device_under_test() in ["gpu", "tpu"]:
-            tol = 1e-2
-          else:
-            tol = 1e-3
+        elif dtype == np.float32:
+          tol = 1e-2
+        elif dtype in [dtypes.bfloat16, np.complex64]:
+          tol = 1e-3
         elif dtype == np.complex128:
           tol = 1e-13
         self.assertAllClose(np.matmul(a, vr) - w[..., None, :] * vr,


### PR DESCRIPTION
Apparently we need to scale up the tolerance to 1e-2 for float32 even on CPU.