### PR TITLE
Add support for `all_to_all` in vmap

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -964,9 +964,10 @@ def _pmap_translation_rule(c, axis_env,
     _xla_shard(c, aval, new_env, in_node) if in_node_mapped else in_node
     for aval, in_node, in_node_mapped in zip(in_avals, in_nodes, mapped_invars))
 
-  sharded_outs = xla.jaxpr_subcomp(
-      c, call_jaxpr, backend, new_env, (),
-      extend_name_stack(name_stack, wrap_name(name, 'pmap')), *in_nodes_sharded)
+  with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
+    sharded_outs = xla.jaxpr_subcomp(
+        c, call_jaxpr, backend, new_env, (),
+        extend_name_stack(name_stack, wrap_name(name, 'pmap')), *in_nodes_sharded)
   out_avals = [v.aval for v in call_jaxpr.outvars]
   outs = [_xla_unshard(c, aval, new_env, shard, backend=backend)
           for aval, shard in zip(out_avals, sharded_outs)]

--- a/jax/lax/lax_parallel.py
+++ b/jax/lax/lax_parallel.py
@@ -623,6 +623,39 @@ def _all_to_all_batched_collective(vals_in, dims_in, axis_size, axis_name, split
     split_axis_adj += 1
   return [_moveaxis(d, concat_axis_adj, x)], [split_axis_adj]
 
+def _all_to_all_split_axis_rule(split_name, vals, params):
+  concat_axis = params['concat_axis']
+  split_axis = params['split_axis']
+  axis_names = params['axis_name']
+  assert isinstance(axis_names, tuple)
+  x, = vals
+
+  split_pos = list(axis_names).index(split_name)
+  before_axes = axis_names[:split_pos]
+  after_axes = axis_names[split_pos+1:]
+
+  # Flatten the split_dim
+  split_name_size = psum(1, split_name)
+  before_size = psum(1, before_axes)
+  after_size = psum(1, after_axes)
+  unroll_shape = list(x.shape)
+  unroll_shape[split_axis:split_axis+1] = [before_size, split_name_size, after_size]
+  unroll_x = lax.reshape(x, unroll_shape)
+
+  if before_axes:
+    out_before = all_to_all(unroll_x, before_axes, split_axis, concat_axis=0)
+  else:
+    out_before = _moveaxis(split_axis, 0, unroll_x)
+  out_split = all_to_all(out_before, split_name, split_axis + 1, concat_axis=1)
+  if after_axes:
+    out_after = all_to_all(out_split, after_axes, split_axis + 2, concat_axis=2)
+  else:
+    out_after = _moveaxis(split_axis + 2, 2, out_split)
+
+  # Flatten the concat axes and move them to the right position
+  y = out_after.reshape((np.prod(out_after.shape[:3]), *out_after.shape[3:]))
+  return _moveaxis(0, concat_axis, y)
+
 def _all_to_all_abstract_eval(x, axis_name, split_axis, concat_axis):
   input_aval = raise_to_shaped(x)
   shape = list(input_aval.shape)
@@ -637,6 +670,7 @@ ad.deflinear(all_to_all_p, _all_to_all_transpose_rule)
 pxla.multi_host_supported_collectives.add(all_to_all_p)
 batching.primitive_batchers[all_to_all_p] = _all_to_all_batcher
 batching.collective_rules[all_to_all_p] = _all_to_all_batched_collective
+batching.split_axis_rules[all_to_all_p] = _all_to_all_split_axis_rule
 
 
 def _expand(dim, size, index, x):

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import itertools as it
 import numpy as np
 from unittest import skipIf
 from absl.testing import absltest
@@ -20,6 +21,7 @@ from absl.testing import parameterized
 
 import jax
 import jax.numpy as jnp
+from jax.interpreters import batching
 from jax import test_util as jtu
 from jax import lax
 from jax import lax_linalg
@@ -1017,6 +1019,30 @@ class BatchingTest(jtu.JaxTestCase):
       self.assertAllClose(
         vmap(lambda x: x - lax.ppermute(x, 'i', perm_pairs), axis_name='i')(x),
         x - x[perm])
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_split={split_axis}_concat={concat_axis}_vmap={vmap_axis}",
+       "split_axis": split_axis, "concat_axis": concat_axis, "vmap_axis": vmap_axis}
+      for split_axis, concat_axis, vmap_axis in it.product(range(3), range(3), range(4)))
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testAllToAll(self, vmap_axis, split_axis, concat_axis):
+    d = vmap_axis
+
+    def shape_fun(x, out_d):
+      shape = list(x.shape)
+      vmap_dim_id = shape.pop(d)
+      split_dim_id = shape.pop(split_axis)
+      shape.insert(concat_axis, vmap_dim_id)
+      shape.insert(out_d, split_dim_id)
+      return tuple(shape)
+
+    shape = (2, 3, 4, 5)
+    x = np.arange(np.prod(shape)).reshape(shape)
+    rule = batching.collective_rules[lax.all_to_all_p]
+    (y,), (out_d,) = rule((x,), (d,), None, None, split_axis, concat_axis)
+    exp_shape = shape_fun(x, out_d)
+    self.assertEqual(y.shape, exp_shape)
 
   def testNegativeAxes(self):
     x = np.arange(3*4*5).reshape(3, 4, 5)


### PR DESCRIPTION
This allows us to run `all_to_all` over vmapped axes, and even over axis groups mixing vmapped and pmapped axes.