### PR TITLE
Use core.concrete_or_error() to improve errors in reductions

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -867,6 +867,8 @@ def concretization_function_error(fun, suggest_astype=False):
 
 def concrete_or_error(force: Any, val: Any, context=""):
   """Like force(val), but gives the context in the error message."""
+  if force is None:
+    force = lambda x: x
   if isinstance(val, Tracer):
     if isinstance(val.aval, ConcreteArray):
       return force(val.aval.val)

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1739,6 +1739,7 @@ def _make_reduction(name, np_fun, op, init_val, preproc=None, bool_op=None,
     if out is not None:
       raise ValueError("reduction does not support the `out` argument.")
     _check_arraylike(name, a)
+    axis = core.concrete_or_error(None, axis, f"axis argument to jnp.{name}().")
 
     a = a if isinstance(a, ndarray) else asarray(a)
     a = preproc(a) if preproc else a


### PR DESCRIPTION
Old error:
```python
>>> import jax.numpy as jnp
>>> from jax import jit                                                                             
>>> jit(jnp.sum)(jnp.arange(4), 0) 
[...]
TypeError: Unexpected type of axis argument: <class 'jax.interpreters.partial_eval.DynamicJaxprTracer'>
```
New error:
```python                                                               
>>> jit(jnp.sum)(jnp.arange(4), 0) 
[...]
ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected.

axis argument to jnp.sum().

The error occured while tracing the function sum at /Users/vanderplas/github/google/jax/jax/numpy/lax_numpy.py:1737.

You can use transformation parameters such as `static_argnums` for `jit` to avoid tracing particular arguments of transformed functions.

See https://jax.readthedocs.io/en/latest/faq.html#abstract-tracer-value-encountered-where-concrete-value-is-expected-error for more information.

Encountered tracer value: Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
```