### PR TITLE
numpy histogramdd implementation

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -176,6 +176,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     heaviside
     histogram
     histogram_bin_edges
+    histogramdd
     hsplit
     hstack
     hypot

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -36,7 +36,7 @@ from .lax_numpy import (
     fabs, finfo, fix, flatnonzero, flexible, flip, fliplr, flipud, float16, float32,
     float64, float_, float_power, floating, floor, floor_divide, fmax, fmin,
     fmod, frexp, full, full_like, function, gcd, geomspace, gradient, greater,
-    greater_equal, hamming, hanning, heaviside, histogram, histogram_bin_edges,
+    greater_equal, hamming, hanning, heaviside, histogram, histogram_bin_edges, histogramdd,
     hsplit, hstack, hypot, i0, identity, iinfo, imag,
     indices, inexact, in1d, inf, inner, int16, int32, int64, int8, int_, integer, 
     interp, intersect1d, invert,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -897,6 +897,44 @@ def histogram(a, bins=10, range=None, weights=None, density=None):
     counts = counts / bin_widths / counts.sum()
   return counts, bin_edges
 
+@_wraps(np.histogramdd)
+def histogramdd(sample, bins=10, range=None, weights=None, density=None):
+  _check_arraylike("histogramdd", sample)
+  N, D = shape(sample)
+
+  if weights is not None and weights.shape != (N,):
+    raise ValueError("should have one weight for each sample.")
+
+  bin_idx_by_dim = D*[None]
+  nbins = np.empty(D, int)
+  bin_edges_by_dim = D*[None]
+  dedges = D*[None]
+
+  for i in builtins.range(D):
+    bin_edges = histogram_bin_edges(sample[:, i], bins[i], range, weights)
+    bin_idx = searchsorted(bin_edges, sample[:, i], side='right')
+    bin_idx = where(sample[:, i] == bin_edges[-1], bin_idx - 1, bin_idx)
+    bin_idx_by_dim[i] = bin_idx
+    nbins[i] = len(bin_edges) + 1
+    bin_edges_by_dim[i] = bin_edges
+    dedges[i] = diff(bin_edges_by_dim[i])
+
+  xy = ravel_multi_index(bin_idx_by_dim, nbins, mode='clip')
+  hist = bincount(xy, weights, length=nbins.prod())
+  hist = reshape(hist, nbins)
+  core = D*(slice(1, -1),)
+  hist = hist[core]
+
+  if density:
+    s = sum(hist)
+    for i in builtins.range(D):
+      _shape = np.ones(D, int)
+      _shape[i] = nbins[i] - 2
+      hist = hist / reshape(dedges[i], _shape)
+
+    hist /= s
+
+  return hist, bin_edges_by_dim
 
 @_wraps(np.heaviside)
 def heaviside(x1, x2):


### PR DESCRIPTION
Hello, first real contribution here.  I wanted to implement numpy's [histogramdd](https://numpy.org/doc/stable/reference/generated/numpy.histogramdd.html#numpy.histogramdd).  One possible issue is that I wasn't able to use `self._CompileAndCheck` within my test because histogramdd uses multi_ravel_index with mode = 'raise' which causes issues with `self._CompileAndCheck` as shown [here](https://github.com/google/jax/blob/5b3cbc5e18bd4750fb27a0021f2d7012c97013f1/tests/lax_numpy_test.py#L2818).