### PR TITLE
Use `raise .. from ..` to chain exceptions

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -981,8 +981,8 @@ class ShapedArray(UnshapedArray):
   def __len__(self):
     try:
       return self.shape[0]
-    except IndexError:
-      raise TypeError("len() of unsized object")  # same as numpy error
+    except IndexError as err:
+      raise TypeError("len() of unsized object") from err  # same as numpy error
 
   def _len(self, ignored_tracer):
     return len(self)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -936,9 +936,9 @@ def _initialize_outfeed_receiver(
   """
   try:
     outfeed_receiver_module = xla_extension.outfeed_receiver
-  except AttributeError:
+  except AttributeError as err:
     raise NotImplementedError(
-        "id_tap works only with jaxlib version 0.1.51 and higher")
+        "id_tap works only with jaxlib version 0.1.51 and higher") from err
 
   with _outfeed_receiver.lock:
     if _outfeed_receiver.receiver is not None:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -380,9 +380,9 @@ class TensorFlowTrace(core.Trace):
   def get_primitive_impl(self, p):
     try:
       return tf_impl[p]
-    except KeyError:
+    except KeyError as err:
       msg = "TensorFlow interpretation rule for '{}' not implemented"
-      raise NotImplementedError(msg.format(p))
+      raise NotImplementedError(msg.format(p)) from err
 
 def to_tf_dtype(jax_dtype):
   if jax_dtype == jnp.bfloat16:

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -5961,9 +5961,9 @@ def _check_shapelike(fun_name, arg_name, obj, non_zero_shape=False):
     raise TypeError(msg.format(obj_arr.ndim))
   try:
     canonicalize_shape(obj_arr)
-  except TypeError:
+  except TypeError as err:
     msg = "{} {} must have every element be an integer type, got {}."
-    raise TypeError(msg.format(fun_name, arg_name, tuple(map(type, obj))))
+    raise TypeError(msg.format(fun_name, arg_name, tuple(map(type, obj)))) from err
   lower_bound, bound_error = (
       (1, "strictly positive") if non_zero_shape else (0, "nonnegative"))
   if not (obj_arr >= lower_bound).all():

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -252,7 +252,7 @@ def merge_linear_aux(aux1, aux2):
     try:
       out2 = aux2()
     except StoreException:
-      raise StoreException("neither store occupied")
+      raise StoreException("neither store occupied") from None
     else:
       return False, out2
   else:

--- a/jax/numpy/linalg.py
+++ b/jax/numpy/linalg.py
@@ -72,8 +72,8 @@ def matrix_power(a, n):
     raise TypeError("Last 2 dimensions of the array must be square")
   try:
     n = operator.index(n)
-  except TypeError:
-    raise TypeError("exponent must be an integer, got {}".format(n))
+  except TypeError as err:
+    raise TypeError("exponent must be an integer, got {}".format(n)) from err
 
   if n == 0:
     return jnp.broadcast_to(jnp.eye(a.shape[-2], dtype=a.dtype), a.shape)


### PR DESCRIPTION
I'd like to suggest an enhancement in the way that Python 3's exception chaining is used.

## Motivation
Almost all places where `raise`ing exceptions in `except` use `raise .. from ..` syntax to explicitly chain exceptions ([PEP 3134](https://www.python.org/dev/peps/pep-3134/)). However, at some places, `raise .. from ..` syntax is not used, which can lead users to confusion (because it outputs `The above exception was the direct cause of the following exception` between tracebacks instead of `During handling of the above exception, another exception occurred`).

## Description of the changes
I used either:
- `raise .. from e` to chain exceptions where the exception `e` has valuable information and seems useful for users.
- `raise .. from None` to unchain exceptions where the previous exception has no valuable information and seems noisy and redundant.
