### PR TITLE
Fix dtype behavior with float0s in CustomVJP.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1594,5 +1594,7 @@ def omnistaging_disabler() -> None:
       trace_state.initial_style = prev
 
 # Casting float0 array to a float-valued zero array.
-def zeros_like_float0(array):
-  return np.zeros(array.shape, np.float)
+def zeros_like_float0(array, dtype=None):
+  if not dtype:
+    dtype = np.float
+  return np.zeros(array.shape, dtype)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -303,8 +303,9 @@ class JVPTrace(Trace):
     tangents_in = map(instantiate_zeros, tangents_in)
     # Cast float0 to regular float zeros because custom jvp rules don't
     # currently handle float0s
-    tangents_in = [core.zeros_like_float0(tangent) if dtype(tangent) is float0
-                   else tangent for tangent in tangents_in]
+    tangents_in = [core.zeros_like_float0(tangent, dtype(primal))
+                   if dtype(tangent) is float0 else tangent
+                   for primal, tangent in zip(primals_in, tangents_in)]
     outs = f_jvp.call_wrapped(*it.chain(primals_in, tangents_in))
     primals_out, tangents_out = split_list(outs, [len(outs) // 2])
     return map(partial(JVPTracer, self), primals_out, tangents_out)
@@ -314,8 +315,9 @@ class JVPTrace(Trace):
     tangents_in = map(instantiate_zeros, tangents_in)
     # Cast float0 to regular float zeros because custom vjp rules don't
     # currently handle float0s
-    tangents_in = [core.zeros_like_float0(tangent) if dtype(tangent) is float0
-                   else tangent for tangent in tangents_in]
+    tangents_in = [core.zeros_like_float0(tangent, dtype(primal))
+                   if dtype(tangent) is float0 else tangent
+                   for primal, tangent in zip(primals_in, tangents_in)]
     res_and_primals_out = fwd.call_wrapped(*map(core.full_lower, primals_in))
     out_tree, res_tree = out_trees()
     res, primals_out = split_list(res_and_primals_out, [res_tree.num_leaves])


### PR DESCRIPTION
This reverts the custom_vjp dtype behavior back to before #4039. 