### PR TITLE
Remove scalar float0 XLA representation.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -82,7 +82,7 @@ def _device_put_unit(_, device):
                                     device),)
 def _make_array_shape(a):
   if a.dtype is dtypes.float0:
-    return (xc.Shape.array_shape(np.dtype('bool'), ()),)
+    return (xc.Shape.array_shape(np.dtype('bool'), a.shape),)
   else:
     return (xc.Shape.array_shape(a.dtype, a.shape),)
 
@@ -129,7 +129,7 @@ def device_put(x, device: Optional[Device] = None) -> Tuple[Any]:
 def _device_put_array(x, device: Optional[Device]):
   backend = xb.get_device_backend(device)
   if x.dtype is dtypes.float0:
-    x = np.zeros((), dtype=np.dtype(bool))
+    x = np.zeros(x.shape, dtype=np.dtype(bool))
   return (backend.buffer_from_pyval(x, device),)
 
 def _device_put_scalar(x, device):

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -407,7 +407,7 @@ def _ndarray_constant_handler(c, val, canonicalize_types=True):
   """
   # TODO(mattjj): revise this to use xops.BroadcastInDim rather than Transpose
   if dtypes.result_type(val) == dtypes.float0:
-    return _numpy_array_constant(c, np.zeros((), dtype=np.bool))
+    return _numpy_array_constant(c, np.zeros(val.shape, dtype=np.bool))
   elif np.any(np.equal(0, val.strides)) and val.size > 0:
     zero_stride_axes, = np.where(np.equal(0, val.strides))
     other_axes, = np.where(np.not_equal(0, val.strides))


### PR DESCRIPTION
Some places in the code (e.g. lower_fun in xla.py) we need to go from an XLA shape to a ShapedArray and cannot do this if we drop shape information earlier.

BUG=169849944