### PR TITLE
reduce test-case count of the numpy-dispatch CI check

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -62,7 +62,7 @@ jobs:
             enable-omnistaging: 1
             # Test experimental NumPy dispatch
             package-overrides: "git+https://github.com/seberg/numpy-dispatch.git"
-            num_generated_cases: 25
+            num_generated_cases: 10
           - python-version: 3.6
             os: ubuntu-latest
             enable-x64: 1


### PR DESCRIPTION
... to match our other x64-mode CI check.

The numpy-dispatch check seems to be timing out sometimes.