### PR TITLE
Update Common_Gotchas_in_JAX.ipynb

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -603,7 +603,7 @@
     "id": "eoXrGARWypdR"
    },
    "source": [
-    "However, raising an error on other accelerators can be more difficult. Therefore, JAX does not raise an error and instead returns the last value in the array. "
+    "However, raising an error on other accelerators can be more difficult. Therefore, JAX does not raise an error, instead the index is clamped to the bounds of the array, meaning that for this example the last value of the array will be returned. "
    ]
   },
   {


### PR DESCRIPTION
Clarify that the index is clamped to the bounds of the array when accessing out of bounds.