### PR TITLE
Matmul Transpose Functionality

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3154,7 +3154,7 @@ def dot(a, b, *, precision=None):  # pylint: disable=missing-docstring
 
 
 @_wraps(np.matmul, lax_description=_PRECISION_DOC)
-def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
+def matmul(a, b, *, precision=None, transpose_a=False, transpose_b=False):  # pylint: disable=missing-docstring
   _check_arraylike("matmul", a, b)
   for i, x in enumerate((a, b)):
     if ndim(x) < 1:
@@ -3209,8 +3209,12 @@ def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
 
   a = lax.squeeze(a, tuple(a_squeeze))
   b = lax.squeeze(b, tuple(b_squeeze))
+
+  a_contract_dims = ndim(a) - 1 - (a_is_mat and transpose_a)
+  b_contract_dims = ndim(b) - 1 - (b_is_mat and not transpose_b)
+
   out = lax.dot_general(
-    a, b, (((ndim(a) - 1,), (ndim(b) - 1 - b_is_mat,)), (a_batch, b_batch)),
+    a, b, (((a_contract_dims,), (b_contract_dims,)), (a_batch, b_batch)),
     precision=precision)
   return lax.transpose(out, perm)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1016,6 +1016,27 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+
+  def testMatmulTransposed(self):
+    a = np.random.random((3, 2))
+    b = np.random.random((3, 2))
+
+    ab1 = jnp.matmul(jnp.transpose(a), b)
+    ab2 = jnp.matmul(a, b, transpose_a=True)
+    jtu._assert_numpy_allclose(ab1, ab2)
+
+    ab1 = jnp.matmul(a, jnp.transpose(b))
+    ab2 = jnp.matmul(a, b, transpose_b=True)
+    jtu._assert_numpy_allclose(ab1, ab2)
+
+    a = np.random.random((3, 2))
+    b = np.random.random((2, 3))
+
+    ab1 = jnp.matmul(jnp.transpose(a), jnp.transpose(b))
+    ab2 = jnp.matmul(a, b, transpose_a=True, transpose_b=True)
+    jtu._assert_numpy_allclose(ab1, ab2)
+
+
   def testTensordotErrors(self):
     a = np.random.random((3, 2, 2))
     b = np.random.random((2,))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1018,6 +1018,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
 
   def testMatmulTransposed(self):
+    # Test Matrix Matrix Behaviour
     a = np.random.random((3, 2))
     b = np.random.random((3, 2))
 
@@ -1034,6 +1035,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     ab1 = jnp.matmul(jnp.transpose(a), jnp.transpose(b))
     ab2 = jnp.matmul(a, b, transpose_a=True, transpose_b=True)
+    jtu._assert_numpy_allclose(ab1, ab2)
+
+    # Test Tensor Tensor Behaviour
+    a = np.random.random((3, 4, 2))
+    b = np.random.random((3, 4, 2))
+
+    ab1 = jnp.matmul(jnp.transpose(a, [0, 2, 1]), b)
+    ab2 = jnp.matmul(a, b, transpose_a=True)
+    jtu._assert_numpy_allclose(ab1, ab2)
+
+    ab1 = jnp.matmul(a, jnp.transpose(b, [0, 2, 1]))
+    ab2 = jnp.matmul(a, b, transpose_b=True)
     jtu._assert_numpy_allclose(ab1, ab2)
 
 


### PR DESCRIPTION
Added transpose features to `jax.numpy.matmul`.

Behaviour should be similar to how transpose is handled with in [TensorFlow](https://www.tensorflow.org/api_docs/python/tf/linalg/matmul). User can optionally choose to pass in arguments `transpose_a` and `transpose_b` to change the contraction dimensions that simulate a similar behaviour.

### Example

```python
a = np.random.random((3, 2))
b = np.random.random((3, 2))
c = jnp.matmul(a, b, transpose_b=True)
```
The above should be functionally and mathematically equivalent to

```python
c = jnp.matmul(a, jnp.transpose(b))
```
However, the first code uses less instructions to accomplish the same task.
```python
>>> jax.make_jaxpr(lambda a, b: jnp.matmul(a, jnp.transpose(b)))(a, b)
{ lambda  ; a b.
  let c = transpose[ permutation=(1, 0) ] b
      d = dot_general[ dimension_numbers=(((1,), (0,)), ((), ()))
                       precision=None ] a c
  in (d,) }
>>> jax.make_jaxpr(lambda a, b: jnp.matmul(a, b, transpose_b=True))(a, b)
{ lambda  ; a b.
  let c = dot_general[ dimension_numbers=(((1,), (1,)), ((), ()))
                       precision=None ] a b
  in (c,) }
```
I have found that the removal of this unnecessary, explicit transpose helped improve performance quite a bit for very large matrices.

## Testing

Created additional matmul test to verify that it produces expected behaviour. Ran all `pytest -n auto tests/lax_numpy_test.py` to verify that all previous behaviour is consistent.

## Help

Not sure if my testing is sufficient. If anybody could help check them and if they are not sufficient, maybe guide me on how to properly add tests to this repo, that would be great.

Also, not sure how to update the `jax.numpy.matmul` documentation. If someone could please help with that, that would be awesome.