### PR TITLE
[jax2tf] Port jax2tf to use omnistaging

### DIFF
--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -216,10 +216,12 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     `func` must be a function from one argument to one result. `arg` is
     the argument before the transformation.
 
-    `transform` can be None, "jvp", "grad", "vmap", "jvp_vmap", "grad_vmap"
+    `transform` can be None, "jit", "jvp", "grad", "vmap", "jvp_vmap", "grad_vmap"
     """
     if transform is None:
       return self.ConvertAndCompare(func, arg)
+    if transform == "jit":
+      return self.ConvertAndCompare(jax.jit(func), arg)
     if transform == "jvp":
       t_func = lambda x, xt: jax.jvp(func, (x,), (xt,))
       return self.ConvertAndCompare(t_func, arg, np.full_like(arg, 0.1))


### PR DESCRIPTION
The main change is that we use `dynamic=True` to use an
omnistaging-based tracer. This has the benefit that we can
convert to TF even functions with no arguments (previously
they would be constant-folded by JAX prior to the conversion).

We also add an explicit error if the jax2tf.convert transformation
is nested under other JAX transformations.