### PR TITLE
[jax2tf] Fix min_max and add_mul harnesses.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -271,8 +271,10 @@ lax_min_max = tuple(
   for f_jax in [lax.min, lax.max]
   for dtype in jtu.dtypes.all_floating + jtu.dtypes.complex
   for lhs, rhs in [
-    (np.array([np.inf], dtype=dtype), np.array([np.nan], dtype=dtype)),
-    (np.array([-np.inf], dtype=dtype), np.array([np.nan], dtype=dtype))
+    (np.array([np.inf, np.inf], dtype=dtype),
+     np.array([np.nan, np.nan], dtype=dtype)),
+    (np.array([-np.inf, -np.inf], dtype=dtype),
+     np.array([np.nan, np.nan], dtype=dtype))
   ]
 )
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -240,7 +240,7 @@ lax_add_mul = tuple(
 ) + tuple(
   Harness(f"fun={f_jax.__name__}_bounds_{jtu.dtype_str(dtype)}",
           f_jax,
-          [StaticArg(lhs), StaticArg(rhs)],
+          [lhs, rhs],
           f_jax=f_jax,
           dtype=dtype)
   for f_jax in [lax.add, lax.mul]
@@ -265,7 +265,7 @@ lax_min_max = tuple(
 ) + tuple(
   Harness(f"fun={f_jax.__name__}_inf_nan_{jtu.dtype_str(dtype)}_{lhs[0]}_{rhs[0]}",
           f_jax,
-          [StaticArg(lhs), StaticArg(rhs)],
+          [lhs, rhs],
           f_jax=f_jax,
           dtype=dtype)
   for f_jax in [lax.min, lax.max]


### PR DESCRIPTION
Some of the array parameters were wrapped in StaticArg(), which
resulted in the function not being actually converted through
jax2tf.

One oddity is that the test of min_max now requires "always_custom_assert" to
be set to True to run properly, implying that even in compiled
mode, the results produced by jax and jax2tf are inconsistent.

I checked the HLO and did not find an obvious reason why this is
the case, so I left it as a TODO until I get the chance to look at it
more closely.