### PR TITLE
fix a 'store occupied' error in jax_debug_nans

### DIFF
--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -86,6 +86,10 @@ class Store(object):
       raise StoreException("Store occupied")
     self._val = val
 
+  def reset(self):
+    # This should only be called in exceptional circumstances (e.g. debugging).
+    self._val = _EMPTY_STORE_VALUE
+
   @property
   def val(self):
     if not self:

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -251,7 +251,7 @@ def cache(call: Callable):
       thread_local.most_recent_entry = None
       return result
 
-  memoized_fun.most_recent_entry = _most_recent_entry
+  memoized_fun.most_recent_entry = _most_recent_entry  # type: ignore
   memoized_fun.cache_clear = fun_caches.clear  # type: ignore
 
   return memoized_fun

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -399,6 +399,20 @@ class PythonJitTest(CPPJitTest):
 
     jit_fun(a)  # doesn't crash
 
+  def test_debug_nans(self):
+    @self.jit
+    def f(x):
+      return jnp.add(x, np.nan)
+    f(1)
+
+    msg = "invalid value \(nan\) encountered in add"  # 'add' not 'xla_call'
+    FLAGS.jax_debug_nans = True
+    try:
+      with self.assertRaisesRegex(FloatingPointError, msg):
+        f(1)
+    finally:
+      FLAGS.jax_debug_nans = False
+
 
 class APITest(jtu.JaxTestCase):
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -405,7 +405,7 @@ class PythonJitTest(CPPJitTest):
       return jnp.add(x, np.nan)
     f(1)
 
-    msg = "invalid value \(nan\) encountered in add"  # 'add' not 'xla_call'
+    msg = r"invalid value \(nan\) encountered in add"  # 'add' not 'xla_call'
     FLAGS.jax_debug_nans = True
     try:
       with self.assertRaisesRegex(FloatingPointError, msg):

--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -34,20 +34,24 @@ class DebugNaNsTest(jtu.JaxTestCase):
 
   def testSingleResultPrimitiveNoNaN(self):
     A = jnp.array([[1., 2.], [2., 3.]])
-    _ = jnp.tanh(A)
+    ans = jnp.tanh(A)
+    ans.block_until_ready()
 
   def testMultipleResultPrimitiveNoNaN(self):
     A = jnp.array([[1., 2.], [2., 3.]])
-    _, _ = jnp.linalg.eigh(A)
+    ans, _ = jnp.linalg.eigh(A)
+    ans.block_until_ready()
 
   def testJitComputationNoNaN(self):
     A = jnp.array([[1., 2.], [2., 3.]])
-    _ = jax.jit(jnp.tanh)(A)
+    ans = jax.jit(jnp.tanh)(A)
+    ans.block_until_ready()
 
   def testSingleResultPrimitiveNaN(self):
     A = jnp.array(0.)
     with self.assertRaises(FloatingPointError):
-      _ = 0. / A
+      ans = 0. / A
+      ans.block_until_ready()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This code snippet could cause a 'store occupied' error:

```python
@jit
def f(x):
  return x + np.nan

FLAGS.jax_debug_nans = True
f(1)
```

The reason is that in `xla._xla_call_impl` we would run a `linear_util.WrappedFun` twice, first via `xla._xla_callable` and then again directly (i.e. in op-by-op) if we got a nan on the output. Things would work fine if the second execution also raised a nan error, since then the `WrappedFun` wouldn't complete execution, but if the second execution does not raise an error (as in the above case, because `1 + np.nan` doesn't involve any jax primitive executions) then we'd end up with a StoreOccupied error from running the `WrappedFun` twice.

This StoreOccupied error could crop up any time the de-optimized version didn't raise a nan issue, e.g. because of `jit` changing numerical behavior.

The fix is just to intentionally allow re-running the `WrappedFun`, since the whole point of jax_debug_nans is to re-run functions that in normal circumstances we would only want to execute exactly once.

Thanks @jblespiau for finding this!