### PR TITLE
[jax2tf] Ensure that in tests TF does not constant-fold in eager mode…

### DIFF
--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -33,15 +33,15 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
 
-    self.ConvertAndCompare(f_jax, True, jnp.float_(1.))
-    self.ConvertAndCompare(f_jax, False, jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(True), jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(False), jnp.float_(1.))
 
   def test_cond_multiple_results(self):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
 
-    self.ConvertAndCompare(f_jax, True, jnp.float_(1.))
-    self.ConvertAndCompare(f_jax, False, jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(True), jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(False), jnp.float_(1.))
 
   def test_cond_partial_eval(self):
     def f(x):


### PR DESCRIPTION
… before compiling

I had noticed that `tf.function(tf.math.maximum, experimental_compile=True)(1., 2.)` would actually just constant fold the operation in eager mode and compile a constant. This can be prevented by using `input_signature` (which this PR does). Alternatively it seems that it would be prevented by ensuring that the arguments are arrays.