### PR TITLE
pretty print improvements

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1423,7 +1423,7 @@ def pp_jaxpr(jaxpr: Jaxpr, source_info: bool = False, print_shapes: bool = False
   pps = pp_eqns(jaxpr.eqns, source_info, print_shapes)
   str_outvars = str(tuple(jaxpr.outvars))
   return (pp('{{ lambda {} ; {}.'.format(pp_vars(jaxpr.constvars, print_shapes),
-                                         pp_vars(jaxpr.invars), print_shapes)) +
+                                         pp_vars(jaxpr.invars, print_shapes))) +
           ((pp('let ') >> vcat(pps))
            + pp('in {} }}'.format(str_outvars))).indent(2))
 

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -30,6 +30,9 @@ class PrettyPrint:
     (i, s), *rest = self.lines
     return PrettyPrint([(i, s.ljust(length) + f" [{msg}]")] + list(rest))
 
+  def width(self):
+    return max(i + len(s) for i, s in self.lines)
+
   def __add__(self, rhs):
     return PrettyPrint(self.lines + rhs.lines)
 


### PR DESCRIPTION
For primitives that take jaxprs as parameters, print params on a newline.

Also improve print_shapes=True.