### PR TITLE
remove mysterious code that is no longer needed

### DIFF
--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1566,10 +1566,6 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
       lu.wrap_init(core.jaxpr_as_fun(jaxpr_1)), in_pvals_1,
       instantiate=[True] * (num_carry + num_ys) + [False] * num_res)
 
-  # TODO(cjfj): Explain the need for the code below.
-  for var in jaxpr_1_opt.invars[:num_consts]:
-    var.aval = core.abstract_unit
-
   jaxpr_1_opt = pe.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr_1_opt), ())
   num_consts_1 = num_consts + len(consts_1)
   # any now-known residuals are intensive, so we want to revise jaxpr_2 to take


### PR DESCRIPTION
@chr1sj0nes had a TODO to explain this code, but as far as I can tell we don't need it anymore, so no need to explain anything! (My guess is that @froystig may have fixed this at one point via dropvar, or something.)

Tests pass locally, but let's see what CI says.