### PR TITLE
re-enable lax autodiff test

### DIFF
--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -360,9 +360,6 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                                  padding, lhs_dil, rhs_dil, dimension_numbers,
                                  perms, feature_group_count, batch_group_count,
                                  rng_factory):
-    if jtu.device_under_test() == "cpu" and dtype == np.float32:
-      raise SkipTest            # TODO(b/169977272): enable when fixed
-
     if dtype == np.float16:
       raise SkipTest("float16 numerical issues")  # TODO(mattjj): resolve
 


### PR DESCRIPTION
xla:cpu bug was due to a change in llvm, now reverted