### PR TITLE
optimize scan partial_eval to fix #4510

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -232,9 +232,6 @@ class Literal:
   def __hash__(self):
     assert False
 
-  def __eq__(self, other):
-    assert False
-
   def __repr__(self):
     if hasattr(self, 'hash'):
       return '{}'.format(self.val)

--- a/jax/lax/lax_control_flow.py
+++ b/jax/lax/lax_control_flow.py
@@ -1601,8 +1601,8 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
 
   # Propagate the forwarded extensive outputs using fwd_extensive.
   out_carry, out_extensive = split_list(out_flat, [num_carry])
-  out_extensive = iter(out_extensive)
-  out_extensive = [next(out_extensive) if i is None else
+  out_extensive_iter = iter(out_extensive)
+  out_extensive = [next(out_extensive_iter) if i is None else
                    tracers[i].pval[1] if tracers[i].is_known() else tracers[i]
                    for i in fwd_extensive]
   out_flat = out_carry + out_extensive


### PR DESCRIPTION
Fixes #4510. See that thread for a description of the issue.

In short, in some cases the extensive residuals generated by the vjp-of-scan forward pass would be identical to extensive inputs. ("Extensive" means "scanned-over".) Yet in the forward pass those residuals were being produced by in effect scanning an identity function over the inputs, basically implementing a copy in terms of a loop of dynamic-update-slices. It's more efficient to elide that copy and just forward the inputs to the outputs.

This PR adds that optimization: in scan's partial eval rule, we identify extensive outputs (both residuals and non-residuals, because why not) that are just forwarding inputs (with a copy) and we replace them with the inputs (without a copy).

Before this change, the jaxpr in #4510 looked like

```
{ lambda  ; a b c.
  let d = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(64, 1024) ] 1.0
      _ _ _ _ e f =
        scan[ jaxpr={ lambda  ; a b c d.
                      let e = mul c a
                      in (e, *, a, *, a, c) }
              length=1024
              linear=(False, True, False, True)
              num_carry=2
              num_consts=0
              reverse=False
              unroll=1 ] d * a *
      _ _ _ g =
        scan[ jaxpr={ lambda  ; a b c d e f.
                      let g = mul b f
                          h = add_any d g
                          i = mul b e
                      in (*, h, *, i) }
              length=1024
              linear=(True, True, True, True, False, False)
              num_carry=2
              num_consts=0
              reverse=True
              unroll=1 ] * c * b e f
  in (g,) }
```

After the change, it looks like

```
{ lambda  ; a b c.
  let d = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(64, 1024) ] 1.0
      _ _ _ _ e =
        scan[ jaxpr={ lambda  ; a b c d.
                      let e = mul c a
                      in (e, *, a, *, a) }
              length=1024
              linear=(False, True, False, True)
              num_carry=2
              num_consts=0
              reverse=False
              unroll=1 ] d * a *
      _ _ _ f =
        scan[ jaxpr={ lambda  ; a b c d e f.
                      let g = mul b f
                          h = add_any d g
                          i = mul b e
                      in (*, h, *, i) }
              length=1024
              linear=(True, True, True, True, False, False)
              num_carry=2
              num_consts=0
              reverse=True
              unroll=1 ] * c * b e a
  in (f,) }
```

Notice that before the change the first scan operation (the forward pass) produced two live outputs, while after the change it produces only one. The second scan has the same number of inputs before and after the change, but after the change one of those inputs is the top-level jaxpr's input argument `a` rather than being an output from the first scan.

Since scan is so heavily used, I'm going to run a global presubmit check on this before merging.