### PR TITLE
[jax2tf] Add paths that do not use XLA in conv_general_dilated.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -614,22 +614,27 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_conv_general_dilated)
   def test_conv_general_dilated(self, harness: primitive_harness.Harness):
-    if jtu.device_under_test() == "gpu" and harness.params["dtype"] in [np.complex64, np.complex128]:
+    dtype, device = harness.params["dtype"], jtu.device_under_test()
+    if device == "gpu" and dtype in [np.complex64, np.complex128]:
       raise unittest.SkipTest("TODO: crash on GPU in TF")
 
     tol = None
-    if jtu.device_under_test() == "gpu":
+    if device == "gpu":
       tol = 1e-4
-    elif jtu.device_under_test() == "tpu":
+    elif device == "tpu":
       tol = 1e-3
     # TODO(bchetioui): significant discrepancies in some float16 cases.
-    if harness.params["dtype"] == np.float16:
+    if dtype == np.float16:
       tol = 1.
     # TODO(bchetioui): slight occasional discrepancy in float32 cases.
-    elif harness.params["dtype"] == np.float32:
-      tol = 0.5 if jtu.device_under_test() == "tpu" else 1e-4
-    elif harness.params["dtype"] == np.complex64 and jtu.device_under_test() == "tpu":
+    elif dtype == np.float32:
+      tol = 0.5 if device == "tpu" else 1e-4
+    elif dtype == np.complex64 and device == "tpu":
       tol = 0.1
+    # TODO(bchetioui): slight discrepancy when going through the path using
+    # tf.nn.convolution.
+    elif dtype == np.float64 and device == "cpu":
+      tol = 1e-13
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()),
                            atol=tol, rtol=tol)
 


### PR DESCRIPTION
This adds some amount of support for people who want to run
convolutions without having XLA linked in. These paths can
seemingly be converted for TFJS as well. I might have missed
some other "obvious" cases, but this already includes calls like
```python
flax.linen.Conv(features=16, kernel_size=(3, 3), padding='SAME')(x)
```