### PR TITLE
Fix extraneous dtype warning in jnp.mean

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -1865,6 +1865,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):
       dtype = float_
     else:
       dtype = _dtype(a)
+  dtype = dtypes.canonicalize_dtype(dtype)
 
   return lax.div(
       sum(a, axis, dtype=dtype, keepdims=keepdims),


### PR DESCRIPTION
Fixes #4490 