### PR TITLE
make scan fwd raw extensive inputs as DeviceArray

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2498,7 +2498,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return lax.scan(lambda s, x: (x*s, s), s, x)
 
     rng = np.random.RandomState(1234)
-    x = jnp.asarray(rng.randn(32, 2, 32))
+    x = jnp.asarray(rng.randn(32, 2, 32).astype('float32'))
     _, vjp_fun = api.vjp(cumprod, x)
 
     # Need to spelunk into vjp_fun. This is fragile, and if it causes problems
@@ -2506,7 +2506,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     *_, ext_res = vjp_fun.args[0].args[0]
     self.assertIs(ext_res, x)
 
-    x = rng.randn(32, 2, 32)  # numpy.ndarray, not DeviceArray
+    x = rng.randn(32, 2, 32).astype('float32')  # numpy.ndarray, not DeviceArray
     _, vjp_fun = api.vjp(cumprod, x)
     *_, ext_res = vjp_fun.args[0].args[0]
     self.assertIsInstance(ext_res, xla.DeviceArray)


### PR DESCRIPTION
follow-up on #4517

#4517 had a subtle behavior change: it meant that in op-by-op execution lax.scan might produce numpy.ndarray outputs, by forwarding them from the input (and not calling device_put on them). This change restores the previous behavior, ensuring that op-by-op scan always produces DeviceArray outputs instead of ndarray outputs.