### PR TITLE
Cleanup: remove extraneous device_put

### DIFF
--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1393,8 +1393,6 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
     raise TypeError(msg.format(np.shape(fill_value)))
   dtype = dtypes.canonicalize_dtype(dtype or _dtype(fill_value))
   fill_value = convert_element_type(fill_value, dtype)
-  if not config.omnistaging_enabled:
-    fill_value = xla.device_put_p.bind(fill_value)
   return broadcast(fill_value, shape)
 
 def _device_put_raw(x):


### PR DESCRIPTION
Minor issue, but I spent a while trying to understand why this line was here before realizing it was unnecessary.

Quick spot check, using this code:
```python
from jax import config, jit, lax, partial, make_jaxpr
config.disable_omnistaging()
f = partial(lax.full, ())
print(make_jaxpr(f)(0))
print(repr(f(0)))
print(repr(jit(f)(0)))
```
Result on master:
```
{ lambda  ; a.
  let b = device_put a
  in (b,) }
DeviceArray(0, dtype=int32)
DeviceArray(0, dtype=int32)
```
Result on this branch:
```
{ lambda  ; a.
  let 
  in (a,) }
DeviceArray(0, dtype=int32)
DeviceArray(0, dtype=int32)
```
The key observation is that device arrays are being returned, despite the lack of an explicit `device_put` on this branch.