### PR TITLE
remove constants from lazy sublanguage

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -218,7 +218,7 @@ def convert(fun, with_gradient=True):
 def _interpret_fun(fun: lu.WrappedFun,
                    in_vals: Sequence[TfValOrUnit]) -> Sequence[TfValOrUnit]:
   new_main = core.new_base_main if config.omnistaging_enabled else core.new_main
-  with new_main(TensorFlowTrace) as main:
+  with new_main(TensorFlowTrace) as main:  # type: ignore
     fun = _interpret_subtrace(fun, main)
     out_vals: Sequence[TfValOrUnit] = fun.call_wrapped(*in_vals)
     del main

--- a/jax/lax/lax.py
+++ b/jax/lax/lax.py
@@ -1409,17 +1409,9 @@ def iota(dtype: DType, size: int) -> Array:
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
   operator.
   """
-  if config.omnistaging_enabled:
-    dtype = dtypes.canonicalize_dtype(dtype)
-    size = core.concrete_or_error(int, size, "size argument of lax.iota")
-    return iota_p.bind(dtype=dtype, shape=(size,), dimension=0)
-  else:
-    size = size if type(size) is masking.Poly else int(size)
-    shape = canonicalize_shape((size,))
-    dtype = dtypes.canonicalize_dtype(dtype)
-    lazy_expr = lazy.iota(dtype, shape[0])
-    aval = ShapedArray(shape, dtype)
-    return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
+  dtype = dtypes.canonicalize_dtype(dtype)
+  size = core.concrete_or_error(int, size, "size argument of lax.iota")
+  return iota_p.bind(dtype=dtype, shape=(size,), dimension=0)
 
 def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
   """Convenience wrapper around ``iota``."""
@@ -1434,15 +1426,10 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
   N, M = tuple(map(int, shape))
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
-  if config.omnistaging_enabled:
-    bool_eye = eq(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
-                  broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_eye, new_dtype=dtype,
-                                       old_dtype=np.bool_)
-  else:
-    lazy_expr = lazy.eye(dtype, (N, M), offset)
-    aval = ShapedArray((N, M), dtype)
-    return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
+  bool_eye = eq(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
+                broadcasted_iota(np.int32, (N, M), 1))
+  return convert_element_type_p.bind(bool_eye, new_dtype=dtype,
+                                     old_dtype=np.bool_)
 
 def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
   """This utility function exists for creating Kronecker delta arrays."""
@@ -1450,32 +1437,22 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
   axes = tuple(map(int, axes))
   dtype = dtypes.canonicalize_dtype(dtype)
   base_shape = tuple(np.take(shape, axes))
-  if config.omnistaging_enabled:
-    iotas = [broadcasted_iota(np.uint32, base_shape, i)
-             for i in range(len(base_shape))]
-    eyes = [eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    result = convert_element_type_p.bind(_reduce(operator.and_, eyes),
-                                         new_dtype=dtype, old_dtype=np.bool_)
-    return broadcast_in_dim(result, shape, axes)
-  else:
-    lazy_expr = lazy.broadcast(lazy.delta(dtype, base_shape), shape, axes)
-    aval = ShapedArray(shape, dtype)
-    return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
+  iotas = [broadcasted_iota(np.uint32, base_shape, i)
+           for i in range(len(base_shape))]
+  eyes = [eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
+  result = convert_element_type_p.bind(_reduce(operator.and_, eyes),
+                                       new_dtype=dtype, old_dtype=np.bool_)
+  return broadcast_in_dim(result, shape, axes)
 
 def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
   """Like numpy.tri, create a 2D array with ones below a diagonal."""
   N, M = tuple(map(int, shape))
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
-  if config.omnistaging_enabled:
-    bool_tri = ge(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
-                  broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_tri, old_dtype=np.int32,
-                                       new_dtype=dtype)
-  else:
-    lazy_expr = lazy.tri(dtype, (N, M), offset)
-    aval = ShapedArray((N, M), dtype)
-    return xla.DeviceArray(aval, None, lazy_expr, xla.DeviceConstant())
+  bool_tri = ge(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
+               broadcasted_iota(np.int32, (N, M), 1))
+  return convert_element_type_p.bind(bool_tri, old_dtype=np.int32,
+                                     new_dtype=dtype)
 
 def stop_gradient(x):
   """Stops gradient computation.

--- a/jax/lazy.py
+++ b/jax/lazy.py
@@ -47,25 +47,8 @@ def taggedtuple(name, fields) -> Callable[..., Any]:
 
 ### lazy sublanguage
 
-# There are two components to a LazyExpr: an input and a reindexing
-# specification. The input represents a base array to which the reindexing
-# specification is applied.
-#
-# An input can represent an array constructor (Iota, Eye, etc.) or it can be an
-# ArrayVar which encodes that the base array is some exogenous array value (from
-# an environment with only a single value in it). These LazyExprs are attached
-# to DeviceArrays, so when the input part of the expression is ArrayVar that
-# basically means the associated device buffer represents the input, while if
-# the input is an array constructor then the associated device_buffer field of
-# the DeviceArray should be set to a DeviceConstant sentinel value. For the
-# array constructor expressions:
-#   * Iota builds a 1D sequence [0, 1, ..., N-1],
-#   * Eye builds a 2D array with ones on a (possibly offset) diagonal and zeros
-#     elsewhere (like numpy.eye),
-#   * Tri builds a triangular matrix with ones on and below a diagonal and zeros
-#     elsewhere (like numpy.tri), and
-#   * Delta builds a Kronecker delta array with ones along its multidimensional
-#     main diagonal and zeros elsewhere (for use in tensor contractions).
+# A LazyExpr contains a reindexing specification. The reindexing expression is
+# applied to the value represented by the device buffer backing a DeviceArray.
 #
 # The reindexing specification encodes the shape of the final result and a list
 # of dimensions, which are integers or Nones. The integer entries take on values
@@ -73,21 +56,6 @@ def taggedtuple(name, fields) -> Callable[..., Any]:
 # axes of the input array are to be mapped in the final output. When an entry is
 # None that indicates that the corresponding axis of the result is a broadcasted
 # one.
-#
-# Here are some examples of lazy expressions and the arrays they represent:
-#
-# LazyExpr(input=Iota(dtype=dtype('float32'), size=3),
-#          shape=(3, 4), dims=(0, None))
-# DeviceArray([[0., 0., 0., 0.],
-#              [1., 1., 1., 1.],
-#              [2., 2., 2., 2.]], dtype=float32)
-#
-# LazyExpr(input=Iota(dtype=dtype('float32'), size=3),
-#          shape=(4, 3), dims=(None, 0))
-# DeviceArray([[0., 1., 2.],
-#              [0., 1., 2.],
-#              [0., 1., 2.],
-#              [0., 1., 2.]], dtype=float32)
 #
 # For performance, some functions on lazy expressions accept None as an input to
 # stand for the identity lazy expression.
@@ -101,48 +69,25 @@ def taggedtuple(name, fields) -> Callable[..., Any]:
 # but we want hashes to be sensitive to the type tag (while still being fast).
 
 # pytype: disable=wrong-arg-count
-LazyExpr = namedtuple('LazyExpr', ['input', 'shape', 'dims'])
-ArrayVar = taggedtuple('ArrayVar', [])
-Iota = taggedtuple('Iota', ['dtype', 'size'])           # like np.arange(N)
-Eye = taggedtuple('Eye', ['dtype', 'shape', 'offset'])  # like np.eye
-Tri = taggedtuple('Tri', ['dtype', 'shape', 'offset'])  # like np.tri
-Delta = taggedtuple('Delta', ['dtype', 'shape'])  # kronecker delta arrays
+LazyExpr = namedtuple('LazyExpr', ['shape', 'dims'])
 # pytype: enable=wrong-arg-count
 
 def array(shape):
-  return LazyExpr(ArrayVar(), shape, tuple(range(len(shape))))
-
-def iota(dtype, size):
-  return LazyExpr(Iota(dtype, size), (size,), (0,))
-
-def eye(dtype, shape, offset):
-  assert len(shape) == 2
-  return LazyExpr(Eye(dtype, shape, offset), shape, (0, 1))
-
-def tri(dtype, shape, offset):
-  assert len(shape) == 2
-  return LazyExpr(Tri(dtype, shape, offset), shape, (0, 1))
-
-def delta(dtype, shape):
-  return LazyExpr(Delta(dtype, shape), shape, tuple(range(len(shape))))
+  return LazyExpr(shape, tuple(range(len(shape))))
 
 def broadcast(lexpr, shape, broadcast_dimensions):
   new_dims = [None] * len(shape)
   for i, d in enumerate(broadcast_dimensions):
     new_dims[d] = lexpr.dims[i]
-  return LazyExpr(lexpr.input, shape, tuple(new_dims))
+  return LazyExpr(shape, tuple(new_dims))
 
 def transpose(lexpr: LazyExpr, perm: Sequence[int]):
   new_shape = tuple(lexpr.shape[i] for i in perm)
   new_dims = tuple(lexpr.dims[i] for i in perm)
-  return LazyExpr(lexpr.input, new_shape, new_dims)
-
-def is_constant(lexpr: Optional[LazyExpr]):
-  return lexpr is not None and type(lexpr.input) is not ArrayVar
+  return LazyExpr(new_shape, new_dims)
 
 def is_trivial(lexpr: LazyExpr) -> bool:
-  return (type(lexpr.input) is ArrayVar and
-          lexpr.dims == tuple(range(len(lexpr.shape))))
+  return lexpr.dims == tuple(range(len(lexpr.shape)))
 
 
 def eval_lexpr(lexpr, x):
@@ -155,41 +100,14 @@ def eval_lexpr(lexpr, x):
   """
   if is_trivial(lexpr):
     return x
-
-  input_, shape, dims = lexpr
-
-  # first create a starting ndarray from input_
-  t = type(input_)
-  if t is ArrayVar:
-    assert x is not None and type(x) is np.ndarray
-  elif t is Iota:
-    assert x is None
-    x = np.arange(input_.size, dtype=input_.dtype)
-  elif t is Eye:
-    assert x is None
-    N, M = input_.shape
-    x = np.eye(N, M, dtype=input_.dtype, k=input_.offset)
-  elif t is Tri:
-    assert x is None
-    N, M = input_.shape
-    x = np.tri(N, M, dtype=input_.dtype, k=input_.offset)
-  elif t is Delta:
-    ones = [1] * len(input_.shape)
-    iotas = [np.arange(d).reshape(subvals(ones, [(i, -1)]))
-             for i, d in enumerate(input_.shape)]
-    eyes = [i1 == i2 for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    x = np.asarray(functools.reduce(op.and_, eyes), input_.dtype)
-  else:
-    assert False
-
-  # then apply the reindexing operation
+  assert x is not None
+  shape, dims = lexpr
   perm = [d for d in dims if d is not None]
   if perm != list(range(len(perm))):
     x = np.transpose(x, perm)
   if shape != x.shape:
     in_shape = [1 if d is None else s for d, s in zip(dims, shape)]
     x = np.broadcast_to(np.reshape(x, in_shape), shape)
-
   return x
 
 
@@ -204,48 +122,11 @@ def stage_lexpr(c, lexpr: Optional[LazyExpr], x):
   """
   if lexpr is None or is_trivial(lexpr):
     return x
-
-  input_, shape, dims = lexpr
-
-  # first create a starting XlaOp from input_
-  t = type(input_)
-  if t is ArrayVar:
-    assert x is not None
-  elif t is Iota:
-    assert x is None
-    x = xops.Iota(c, xb.dtype_to_etype(input_.dtype), input_.size)
-  elif t is Eye:
-    assert x is None
-    N, M = input_.shape
-    xla_shape = xc.Shape.array_shape(xc.PrimitiveType.S32, (N, M))
-    bool_eye = xops.Eq(
-      xops.Add(xops.Iota(c, xla_shape, 0),
-               xb.constant(c, np.array(input_.offset, np.int32))),
-      xops.Iota(c, xla_shape, 1))
-    x = xops.ConvertElementType(bool_eye, xb.dtype_to_etype(input_.dtype))
-  elif t is Tri:
-    assert x is None
-    N, M = input_.shape
-    xla_shape = xc.Shape.array_shape(xc.PrimitiveType.S32, (N, M))
-    bool_tri = xops.Ge(
-      xops.Add(xops.Iota(c, xla_shape, 0),
-               xb.constant(c, np.array(input_.offset, np.int32))),
-      xops.Iota(c, xla_shape, 1))
-    x = xops.ConvertElementType(bool_tri, xb.dtype_to_etype(input_.dtype))
-  elif t is Delta:
-    etype = xb.dtype_to_etype(input_.dtype)
-    iotas = [xops.Iota(c, xc.Shape.array_shape(xc.PrimitiveType.U32, input_.shape), i)
-             for i in range(len(input_.shape))]
-    eyes = [xops.Eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    x = xops.ConvertElementType(functools.reduce(xops.And, eyes), etype)
-  else:
-    assert False
-
-  # then apply the operations encoded in reindex
+  assert x is not None
+  shape, dims = lexpr
   bcast_dims, perm = unzip2((i, d) for i, d in enumerate(dims) if d is not None)
   if tuple(perm) != tuple(range(len(perm))):
     x = xops.Transpose(x, perm)
   if shape != c.get_shape(x).dimensions():
     x = xops.BroadcastInDim(x, shape, bcast_dims)
-
   return x

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3622,11 +3622,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(type(jnp.arange(77, dtype=jnp.int32)),
                       type(lax.iota(np.int32, 77)))
 
-    # test laziness for int dtypes
-    if not config.omnistaging_enabled:
-      self.assertTrue(xla.is_device_constant(jnp.arange(77)))
-      self.assertTrue(xla.is_device_constant(jnp.arange(77, dtype=jnp.int32)))
-
   def testArangeJit(self):
     ans = api.jit(lambda: jnp.arange(5))()
     expected = np.arange(5)
@@ -3646,9 +3641,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testIssue764(self):
     x = jnp.linspace(190, 200, 4)
     f = api.grad(lambda x: jnp.sum(jnp.tanh(x)))
-    # Expected values computed with autograd in float64 precision.
+    # Expected values computed with Autograd in float64 precision.
     expected = np.array([3.71669453e-165, 4.72999108e-168, 6.01954653e-171,
-                          7.66067839e-174], np.float64)
+                         7.66067839e-174], np.float64)
     self.assertAllClose(f(x), expected, check_dtypes=False)
 
   def testIssue776(self):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -858,6 +858,8 @@ class LaxRandomTest(jtu.JaxTestCase):
       random.choice(key, 5, 2, replace=True)
 
   def test_eval_shape_big_random_array(self):
+    if not config.omnistaging_enabled:
+      raise SkipTest("after deleting lazy constants, requires omnistaging")
     def f(x):
       return random.normal(random.PRNGKey(x), (int(1e12),))
     with core.skipping_checks():  # check_jaxpr will materialize array


### PR DESCRIPTION
Follow-up to #4535 (it's treated as a diff base).

This is **removing**  the device constant part of #1668. We can do this because after #3370 and #4038 omnistaging removes the need for lazy device constants in a jitted context. (They could still in principle be useful in an op-by-op context, but the power:weight isn't worthwhile anymore.)

After this change, the only parts of the lazy sublanguage that remain are those to do with broadcasts and transposes. We may or may not kill those in a follow-up (it hinges on whether any benefit to op-by-op execution is worth the extra complexity).

This change regresses non-omnistaging users. As one particular example, `test_eval_shape_big_random_array` no longer passes with omnistaging disabled.

fyi @jblespiau 