### PR TITLE
Add jax.numpy.polyint

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -282,6 +282,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     piecewise
     polyadd
     polyder
+    polyint
     polymul
     polysub
     polyval

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -51,7 +51,7 @@ from .lax_numpy import (
     nanmax, nanmean, nanmin, nanprod, nanstd, nansum, nanvar, ndarray, ndim,
     negative, newaxis, nextafter, nonzero, not_equal, number, numpy_version,
     object_, ones, ones_like, operator_name, outer, packbits, pad, percentile,
-    pi, piecewise, polyadd, polyder, polymul, polysub, polyval, positive, power,
+    pi, piecewise, polyadd, polyder, polyint, polymul, polysub, polyval, positive, power,
     prod, product, promote_types, ptp, quantile,
     rad2deg, radians, ravel, ravel_multi_index, real, reciprocal, remainder, repeat, reshape,
     result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,

--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -3055,13 +3055,37 @@ def polyadd(a1, a2):
 def polyder(p, m=1):
   p = asarray(p)
   if m < 0:
-    raise ValueError("Order of derivative must be positive")
+    raise ValueError("Order of derivative must be nonnegative")
   if m == 0:
     return p
   if m % 1:
     raise ValueError("m must be an integer")
-  coeff = (arange(len(p), m, -1) - 1 - arange(m)[:, newaxis]).prod(0)
+  coeff = (np.arange(len(p), m, -1) - 1 - np.arange(m)[:, newaxis]).prod(0)
   return p[:-m] * coeff
+
+
+@_wraps(np.polyint)
+def polyint(p, m=1, k=None):
+  p = asarray(p)
+  if m < 0:
+    raise ValueError("Order of antiderivative must be nonnegative")
+  if m == 0:
+    return p
+  if m % 1:
+    raise ValueError("m must be an integer")
+  if k is None:
+    k = zeros(m)
+  else:
+    k = atleast_1d(k)
+    if len(k) == 1 and m > 1:
+      k = k * ones(m)
+    if ndim(k) > 1 or len(k) < m:
+      raise ValueError("k must be a scalar or a rank-1 array of length 1 or >=m.")
+  coeff = 1 / np.prod([np.pad(np.arange(len(p) + i, 0, -1),
+                              (0, m - i), "constant", constant_values=1)
+                       for i in range(m)], 0)
+  return concatenate([p, k[:m]]) * coeff
+
 
 @_wraps(np.trim_zeros)
 def trim_zeros(filt, trim='fb'):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1349,6 +1349,25 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_shape={}_order={}_constants={}".format(
+          jtu.format_shape_dtype_string(a_shape, dtype),
+          order,
+          None if k_shape is None else jtu.format_shape_dtype_string(k_shape, dtype)),
+       "dtype": dtype, "a_shape": a_shape, "order" : order, "k_shape": k_shape}
+      for dtype in default_dtypes
+      for a_shape in one_dim_array_shapes
+      for order in range(5)
+      for k_shape in set([None, (), (1,), (order,), (order + 1,)])))
+  def testPolyInt(self, a_shape, order, k_shape, dtype):
+    rng = jtu.rand_default(self.rng())
+    np_fun = lambda arg1, arg2: np.polyint(arg1, m=order, k=arg2)
+    jnp_fun = lambda arg1, arg2: jnp.polyint(arg1, m=order, k=arg2)
+    args_maker = lambda: [rng(a_shape, dtype), None if k_shape is None else rng(k_shape, dtype)]
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+    self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
+
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
        "shape": shape, "dtype": dtype, "axis": axis}


### PR DESCRIPTION
Though not mentioned in the numpy [documentation](https://numpy.org/doc/stable/reference/generated/numpy.polyint.html), this implementation matches `np.polyint` in the cases `m > 1 and len(k) == 1` as well as `len(k) > m`.

I've also added some `np.` (i.e., base `numpy`) qualifiers in the `polyder` implementation as my impression is that this improves constant-folding for `jax.make_jaxpr` and `jax.jit`.