### PR TITLE
remove a double warning message with asarray

### DIFF
--- a/jax/numpy/lax_numpy.py
+++ b/jax/numpy/lax_numpy.py
@@ -2500,6 +2500,7 @@ def _can_call_numpy_array(x):
 @_wraps(np.asarray)
 def asarray(a, dtype=None, order=None):
   lax._check_user_dtype_supported(dtype, "asarray")
+  dtype = dtypes.canonicalize_dtype(dtype) if dtype is not None else dtype
   return array(a, dtype=dtype, copy=False, order=order)
 
 


### PR DESCRIPTION
Observed in #4540:

```
In [1]: import jax

In [2]: jax.numpy.asarray([2,3], dtype='int')
/usr/local/google/home/mattjj/packages/jax/jax/lax/lax.py:6190: UserWarning: Explicitly requested dtype int requested in asarray is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
/usr/local/google/home/mattjj/packages/jax/jax/lax/lax.py:6190: UserWarning: Explicitly requested dtype int requested in array is not available, and will be truncated to dtype int32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
/usr/local/google/home/mattjj/packages/jax/jax/lib/xla_bridge.py:130: UserWarning: No GPU/TPU found, falling back to CPU.
  warnings.warn('No GPU/TPU found, falling back to CPU.')
Out[2]: DeviceArray([2, 3], dtype=int32)
```

The double warning arises because `jax.numpy.asarray` checks if the user-requested dtype is supported, then calls into `jax.numpy.array` which does the same check. The check on `jax.numpy.asarray` is redundant.

EDIT: Well, I guess the messages aren't completely redundant: one mentions `asarray` while the other mentions `array`.

@jakevdp what do you think? Better to have double warnings? Or maybe we should figure out a better warning mechanism?