### PR TITLE
Mention how to turn on logging in "No GPU/TPU found" warning.

### DIFF
--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -23,9 +23,10 @@ XLA. There are also a handful of related casting utilities.
 from functools import partial
 import os
 from typing import Callable, Dict, Tuple, Union
-import warnings
 
 from absl import logging
+# Disable "WARNING: Logging before flag parsing goes to stderr." message
+logging._warn_preinit_stderr = 0
 
 from ..config import flags
 from .. import util
@@ -127,7 +128,8 @@ def _get_local_backend(platform=None):
     raise RuntimeError("No local XLA backends found.")
 
   if backend.platform == 'cpu' and platform != 'cpu':
-    warnings.warn('No GPU/TPU found, falling back to CPU.')
+    logging.warning('No GPU/TPU found, falling back to CPU. '
+                    '(Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)')
 
   return backend
 


### PR DESCRIPTION
This is useful when debugging when a GPU/TPU is expected to be found,
e.g. #4569, and hopefully isn't too noisy when expecting to run on
CPU.

Also changes the warning to use logging.warn instead of warnings.warn,
and suppresses an inactionable warning from the absl logging module
itself.

Old message:
```
>>> import jax; jax.devices()
/usr/local/google/home/skyewm/jax/jax/lib/xla_bridge.py:130: UserWarning: No GPU/TPU found, falling back to CPU.
  warnings.warn('No GPU/TPU found, falling back to CPU.')
[CpuDevice(id=0)]
```

New message looks like:
```
>>> import jax; jax.devices()
W1013 18:33:31.047047 139848542200192 xla_bridge.py:132] No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
[CpuDevice(id=0)]
```