### PR TITLE
[jax2tf] Added a non-XLA conversion path for reduce_window_max.

### DIFF
--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -96,7 +96,8 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
   else:
     np_dtype = None
 
-  if prim in [lax.min_p, lax.max_p]:
+  if prim in [lax.min_p, lax.max_p, lax.reduce_window_min_p,
+              lax.reduce_window_max_p]:
     if np_dtype in [np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
                     np.complex64, np.complex128]:
       tf_unimpl(np_dtype)


### PR DESCRIPTION
The new path uses tf.nn.max_pool. The primitive harness for
reduce_window and related primitives has been rewritten completely
to produce better coverage in less tests.