### PR TITLE
Fix init with constant Poly shapes

### DIFF
--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -338,7 +338,7 @@ _identifiers = frozenset(string.ascii_lowercase)
 
 def _parse_id(name): return Poly({Mon({name: 1}): 1})
 
-def _parse_lit(val_str): return Poly({Mon(): int(val_str)})
+def _parse_lit(val_str): return int(val_str)
 
 class MonomorphicDim(object):
   def __str__(self): return '_'
@@ -458,8 +458,8 @@ class UniqueIds(dict):
 def remap_ids(names, shape_spec):
   return ShapeSpec(Poly({Mon({names[id] : deg for id, deg in mon.items()})
                          : coeff for mon, coeff in poly.items()})
-                   if poly is not _monomorphic_dim else
-                   _monomorphic_dim for poly in shape_spec)
+                   if isinstance(poly, Poly) else
+                   poly for poly in shape_spec)
 
 def bind_shapes(polymorphic_shapes, padded_shapes):
   env = {}


### PR DESCRIPTION
I'm getting issues with initializer functions in combination with automasking.
Typically when automasking the batch dim of a NN there will be constant `Poly` dims like `Poly(num_features)` passed to the initializers.

As a workaround we can cast the shape to ints we evaluate the Poly's such that the downstream arithmetic will work out correctly.

In the future it would probably be better if the init functions also support non-constant Poly dims but that needs quite a bit more work.