### PR TITLE
allow custom_vjp bwd to return Nones for zeros

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3445,7 +3445,7 @@ class CustomVJPTest(jtu.JaxTestCase):
       return x, None
 
     def foo_bwd(_, g):
-      return g
+      return (g, g)
 
     f.defvjp(foo_fwd, foo_bwd)
 
@@ -3458,7 +3458,7 @@ class CustomVJPTest(jtu.JaxTestCase):
             "and in particular must produce a tuple of length equal to the "
             "number of arguments to the primal function, but got VJP output "
             "structure {} for primal input structure {}.".format(
-                tree_util.tree_structure(1),
+                tree_util.tree_structure((1, 1)),
                 tree_util.tree_structure((1,)))
         ),
         lambda: api.grad(f)(2.))


### PR DESCRIPTION
This change allows the `bwd` function of a `custom_vjp` to return `None` values to indicate that the corresponding cotangent (or in general sub-pytree of cotangents) is zero. It's a convenience mechanism so that users have a shorthand to produce zero cotangents, rather than having to produce arrays/trees of the right shape/dtype/structure.

The purpose is to set up some internal users so that we can then land #4008. #4008 also includes this `bwd`-can-return-`None` behavior. The behavior became valuable in #4008 because we no longer recommend using `nondiff_argnums` as much, e.g. for array arguments with integer dtype, and so having a convenient way to produce zero cotangents became valuable.

One downside is that if a user _wanted_ to have the argument list of a `custom_vjp` function to contain `Nones`, to be treated as part of the pytree structure, then they can no longer have `bwd` produce the correct pytree structure. I don't think that use case is likely ever to arise, but if it did we could solve it by using a different sentinel.