### PR TITLE
[jax2tf] Remove the argument type promotion in jax2tf.

### DIFF
--- a/jax/experimental/jax2tf/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-10-14*
+*Last generated on (YYYY-MM-DD): 2020-10-16*
 
 ## Updating the documentation
 
@@ -58,6 +58,8 @@ conversion to Tensorflow.
 | nextafter | Missing TF support | Primitive is unimplemented in TF | bfloat16, float16 | CPU, GPU, TPU |
 | population_count | Missing TF support | Primitive is unimplemented in TF | uint32, uint64 | CPU, GPU, TPU |
 | qr | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | complex128, complex64 | CPU, GPU, TPU |
+| reduce_window_max | Missing TF support | Primitive is unimplemented in TF | bool, complex128, complex64, int8, uint16, uint32, uint64 | CPU, GPU, TPU |
+| reduce_window_min | Missing TF support | Primitive is unimplemented in TF | bool, complex128, complex64, int8, uint16, uint32, uint64 | CPU, GPU, TPU |
 | reduce_window_sum | Missing TF support | Primitive is unimplemented in TF | uint16, uint32, uint64 | CPU, GPU, TPU |
 | rem | Missing TF support | Primitive is unimplemented in TF | bfloat16, float16 | CPU, GPU, TPU |
 | round | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
@@ -68,8 +70,6 @@ conversion to Tensorflow.
 | scatter-mul | Missing TF support | Primitive is unimplemented in TF | complex64 | TPU |
 | select_and_gather_add | Missing TF support | Primitive is unimplemented in TF | float32, float64 | TPU |
 | select_and_gather_add | Missing TF support | Primitive is unimplemented in TF | float64 | CPU, GPU |
-| shift_right_arithmetic | Possible incorrect results | If first operand has higher-order bit set the result will not have it set on TPU (JAX/XLA bug) | uint16, uint8 | TPU |
-| shift_right_logical | Possible incorrect results | If first operand is negative the result will be negative on TPU (JAX/XLA bug) | int16, int8 | TPU |
 | sinh | Missing TF support | Primitive is unimplemented in TF | float16 | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented in TF | complex128, complex64 | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented in TF; only sorting on last dimension is supported for XlaSort | ALL | CPU, GPU, TPU |

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -111,16 +111,6 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype in [np.float16, dtypes.bfloat16]:
       tf_unimpl(np_dtype)
 
-  if prim is lax.shift_right_arithmetic_p and np_dtype in [np.uint8, np.uint16]:
-    tf_possible_incorrect(np_dtype,
-      "If first operand has higher-order bit set the result will not have it set on TPU (JAX/XLA bug)",
-      devs=["TPU"])
-
-  if prim is lax.shift_right_logical_p and np_dtype in [np.int8, np.int16]:
-    tf_possible_incorrect(np_dtype,
-      "If first operand is negative the result will be negative on TPU (JAX/XLA bug)",
-      devs=["TPU"])
-
   if prim is lax_linalg.cholesky_p:
     if np_dtype in [np.complex64, np.complex128]:
       # See https://github.com/google/jax/pull/3775#issuecomment-659407824;

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -822,7 +822,7 @@ def _make_reduce_window_harness(name, *, shape=(4, 6), base_dilation=(1, 1),
   return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_computation={computation.__name__}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}".replace(' ', ''),
                  lax.reduce_window,
                  [RandArg(shape, dtype),
-                  np.array(init_value, dtype=dtype),
+                  StaticArg(np.array(init_value, dtype=dtype)),  # Must be static to trigger the picking of the reducers
                   StaticArg(computation), StaticArg(window_dimensions),
                   StaticArg(window_strides), StaticArg(padding),
                   StaticArg(base_dilation), StaticArg(window_dilation)],
@@ -849,7 +849,7 @@ lax_reduce_window = tuple( # Validate dtypes across all execution paths
     (lax.max, _get_max_identity(dtype)), # path through TF reduce_window_max
     (lax.max, 1), # path through reduce_window
   ] + ([
-    (lax.add, 0), # path_through reduce_window_add
+    (lax.add, 0), # path_through reduce_window_sum
     (lax.mul, 1), # path through reduce_window_mul
   ] if dtype != jnp.bool_ else [])
 ) + tuple( # Validate window_dimensions


### PR DESCRIPTION
This was added as a safety mechanism in the past when jax2tf tracking
of types was imprecise. Now it is not needed anymore.

Also removed the mention that shift operations on TPU may produce
incorrect results.