### PR TITLE
Add a reverse=... argument to lax.cumsum/cumprod/...

### DIFF
--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -244,12 +244,13 @@ deflinear(lax.reduce_window_sum_p)
 deflinear(lax_fft.fft_p)
 deflinear(xla.device_put_p)
 
-def _cumulative_jet_rule(primals_in, series_in, *, axis: int,
+def _cumulative_jet_rule(primals_in, series_in, *, axis: int, reverse: bool,
                          combine_fn: Callable):
   # Irrespective of backend, we always use the parallel prefix scan
   # implementation when differentiating because reduce_window is not
   # arbitrarily differentiable.
-  return jet(partial(lax_control_flow.associative_scan, combine_fn, axis=axis),
+  return jet(partial(lax_control_flow.associative_scan, combine_fn, axis=axis,
+                     reverse=reverse),
              primals_in, series_in)
 
 deflinear(lax_control_flow.cumsum_p)

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -743,10 +743,11 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                 eps)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_shape={}_axis={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis),
+      {"testcase_name": "_op={}_shape={}_axis={}_reverse={}"
+       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis,
+               reverse),
        "op": op, "shape": shape, "dtype": dtype,
-       "axis": axis, "rng_factory": rng_factory}
+       "axis": axis, "reverse": reverse}
       for op, types in [
           (lax.cumsum, [np.float32, np.float64]),
           (lax.cumprod, [np.float32, np.float64]),
@@ -754,12 +755,13 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       for dtype in types
       for shape in [[10], [3, 4, 5]]
       for axis in range(len(shape))
-      for rng_factory in [
-          jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
-          else jtu.rand_small]))
-  def testCumulativeReduceGrad(self, op, shape, dtype, axis, rng_factory):
+      for reverse in [False, True]))
+  def testCumulativeReduceGrad(self, op, shape, dtype, axis, reverse):
+    rng_factory = (jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
+                   else jtu.rand_small)
     rng = rng_factory(self.rng())
-    check_grads(partial(op, axis=axis), (rng(shape, dtype),), order=2)
+    check_grads(partial(op, axis=axis, reverse=reverse), (rng(shape, dtype),),
+                order=2)
 
 
   # TODO(b/205052657): enable more tests when supported

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -541,11 +541,11 @@ class LaxVmapTest(jtu.JaxTestCase):
       self._CheckBatching(fun, 3, bdims, (shape,), (dtype,), rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_shape={}_axis={}_bdims={}"
+      {"testcase_name": "_op={}_shape={}_axis={}_bdims={}_reverse={}"
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis,
-               bdims),
+               bdims, reverse),
        "op": op, "shape": shape, "dtype": dtype, "bdims": bdims,
-       "axis": axis, "rng_factory": rng_factory}
+       "axis": axis, "reverse": reverse}
       for op, types in [
           (lax.cumsum, [np.float32, np.float64]),
           (lax.cumprod, [np.float32, np.float64]),
@@ -554,13 +554,13 @@ class LaxVmapTest(jtu.JaxTestCase):
       for shape in [[10], [3, 4, 5]]
       for axis in range(len(shape))
       for bdims in all_bdims(shape)
-      for rng_factory in [
-          jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
-          else jtu.rand_small]))
-  def testCumulativeReduce(self, op, shape, dtype, axis, bdims, rng_factory):
+      for reverse in [False, True]))
+  def testCumulativeReduce(self, op, shape, dtype, axis, bdims, reverse):
+    rng_factory = (jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
+                   else jtu.rand_small)
     rng = rng_factory(self.rng())
-    self._CheckBatching(partial(op, axis=axis), 7, bdims, (shape,), (dtype,),
-                        rng)
+    self._CheckBatching(partial(op, axis=axis, reverse=reverse), 7, bdims,
+                        (shape,), (dtype,), rng)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}_padding={}".format(np.dtype(dtype).name,


### PR DESCRIPTION
This allows us to lower to a more efficient implementation on TPU.