### PR TITLE
add a Tracer.__str__ for simpler printing

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -543,6 +543,14 @@ class Tracer:
                                     for name, pp_payload in contents)
     return str(base)
 
+  def __str__(self):
+    if isinstance(self.aval, ConcreteArray):
+      return f'Traced<{self.aval.val}>'
+    elif isinstance(self.aval, (ShapedArray, AbstractUnit)):
+      return f'Traced<{self.aval.str_short()}>'
+    else:
+      return repr(self)
+
   def _contents(self):
     try:
       return [(name, pp(repr(getattr(self, name)))) for name in self.__slots__]


### PR DESCRIPTION
```
In [1]: def f(x):
   ...:     print(x)
   ...:     print(repr(x))
   ...:     return x
   ...:

In [2]: from jax import grad
gra
In [3]: grad(f)(3.14)
Traced<3.14>
Traced<ConcreteArray(3.14, weak_type=True)>with<JVPTrace(level=2/0)>
  with primal = Traced<ConcreteArray(3.14, weak_type=True):JaxprTrace(level=1/0)>
       tangent = Traced<ShapedArray(float32[], weak_type=True):JaxprTrace(level=1/0)>
Out[3]: array(1.)

In [4]: from jax import jit

In [5]: jit(f)(3.14)
Traced<float32[]>
Traced<ShapedArray(float32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
Out[5]: DeviceArray(3.14, dtype=float32)

In [6]: grad(grad(f))(3.14)
Traced<3.14>
Traced<ConcreteArray(3.14, weak_type=True)>with<JVPTrace(level=4/0)>
  with primal = Traced<ConcreteArray(3.14, weak_type=True):JaxprTrace(level=3/0)>
       tangent = Traced<ShapedArray(float32[], weak_type=True):JaxprTrace(level=3/0)>
Out[6]: array(0., dtype=float32)
```

Experiments for #4615