### PR TITLE
fix api.linearize type check, and ConcreteArray lattice joins

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1762,10 +1762,11 @@ def _lift_linearized(jaxpr, primal_avals, consts, io_tree, out_pvals, *py_args):
     tangent_avals = list(map(core.get_aval, tangents))
     for primal_aval, tangent_aval in zip(primal_avals, tangent_avals):
       try:
-        core.lattice_join(primal_aval, tangent_aval)
+        core.lattice_join(primal_aval.at_least_vspace(), tangent_aval)
       except TypeError as e:
         msg = ("linearized function called on tangent values inconsistent with "
-               "the original primal values.")
+               "the original primal values: "
+               f"got {tangent_aval} for primal aval {primal_aval}")
         raise ValueError(msg) from e
     tangents_out = eval_jaxpr(jaxpr, consts, *tangents)
     return tuple(map(lambda out_pv, tan_out: out_pv.merge_with_known(tan_out),

--- a/jax/api.py
+++ b/jax/api.py
@@ -1767,7 +1767,7 @@ def _lift_linearized(jaxpr, primal_avals, consts, io_tree, out_pvals, *py_args):
         msg = ("linearized function called on tangent values inconsistent with "
                "the original primal values: "
                f"got {tangent_aval} for primal aval {primal_aval}")
-        raise ValueError(msg) from e
+        raise ValueError(msg)
     tangents_out = eval_jaxpr(jaxpr, consts, *tangents)
     return tuple(map(lambda out_pv, tan_out: out_pv.merge_with_known(tan_out),
                      out_pvals, tangents_out))

--- a/jax/core.py
+++ b/jax/core.py
@@ -1025,9 +1025,12 @@ class ConcreteArray(ShapedArray):
     assert self.dtype != np.dtype('O'), val
 
   def __eq__(self, other):
-    return (type(self) is type(other) and self.dtype == other.dtype
-            and self.shape == other.shape and self.weak_type == other.weak_type
-            and np.all(self.val == other.val))
+    if (type(self) is type(other) and self.dtype == other.dtype
+        and self.shape == other.shape and self.weak_type == other.weak_type):
+      with eval_context():  # in case self.val is a DeviceArray
+        return (self.val == other.val).all()
+    else:
+      return False
 
   def __hash__(self):
     return id(self.val)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1133,16 +1133,16 @@ class APITest(jtu.JaxTestCase):
   def test_issue_871(self):
     T = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
     x = jnp.array([1, 2, 3])
+    msg = ("linearized function called on tangent values inconsistent with "
+           "the original primal values")
 
     y, f_jvp = api.linearize(jnp.sum, x)
-    jtu.check_raises(lambda: f_jvp(T), ValueError,
-                     ("linearized function called on tangent values "
-                      "inconsistent with the original primal values."))
+    with self.assertRaisesRegex(ValueError, msg):
+      f_jvp(T)
 
     y, f_jvp = api.linearize(api.jit(jnp.sum), x)
-    jtu.check_raises(lambda: f_jvp(T), ValueError,
-                     ("linearized function called on tangent values "
-                      "inconsistent with the original primal values."))
+    with self.assertRaisesRegex(ValueError, msg):
+      f_jvp(T)
 
   def test_partial_eval_lower(self):
     # this is a simplified model of a bug that arose when we first used @jit in

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1966,6 +1966,38 @@ class APITest(jtu.JaxTestCase):
       xla.device_put = orig_device_put
     self.assertEqual(count, 0)
 
+  def test_join_concrete_arrays_with_omnistaging(self):
+    # https://github.com/google/jax/issues/4622
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test is omnistaging-specific")
+
+    x = jnp.array([1., 2., 3.])
+    y = jnp.array([1., 2., 4.])
+
+    @jit
+    def f():
+      core.lattice_join(core.ConcreteArray(x), core.ConcreteArray(y))
+
+    f()  # doesn't crash
+
+  def test_linearize_aval_error(self):
+    # https://github.com/google/jax/issues/4622
+    f = lambda x: x
+
+    # these should not error
+    _, f_jvp = api.linearize(f, 1.)
+    f_jvp(1.)
+    _, f_jvp = api.linearize(f, np.ones(2, np.int32))
+    f_jvp(np.zeros(2, float0))
+
+    # these should error
+    _, f_jvp = api.linearize(f, 1.)
+    with self.assertRaisesRegex(ValueError, "tangent values inconsistent"):
+      f_jvp(1)
+    _, f_jvp = api.linearize(f, np.ones(2, np.int32))
+    with self.assertRaisesRegex(ValueError, "tangent values inconsistent"):
+      f_jvp(np.ones(2, np.int32))
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Fixes #4622 

There are two bugs being fixed here:
1. a check in `api.linearize` (more precisely in `api._lift_linearized`) was requiring that primal avals equal tangent avals, but it should've been that the tangent avals match the expected tangent aval type for each corresponding primal aval;
2. doing a lattice join of two `ConcreteArrays` backed by DeviceArrays when an omnistaging trace is present could cause a ConcretizationError, as an equality check would get hoisted into the trace.

See the thread in #4622 for more information.