### PR TITLE
Make `ConvGeneralDilatedDimensionNumbers` type public

### DIFF
--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -15,6 +15,7 @@
 # flake8: noqa: F401
 from .lax import (
   ConvDimensionNumbers,
+  ConvGeneralDilatedDimensionNumbers,
   DotDimensionNumbers,
   GatherDimensionNumbers,
   Precision,


### PR DESCRIPTION
This type is arguably more user-facing than `ConvDimensionNumbers`, so would be convenient to have it public.