### PR TITLE
[impl] Add support for setdiff1d

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -316,6 +316,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     searchsorted
     select
     set_printoptions
+    setdiff1d
     shape
     sign
     signbit

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1464,6 +1464,19 @@ def in1d(ar1, ar2, assume_unique=False, invert=False):
   else:
     return (ar1[:, None] == ar2).any(-1)
 
+@_wraps(np.setdiff1d, lax_description="""
+In the JAX version, the `assume_unique` argument is not referenced.
+""")
+def setdiff1d(ar1, ar2, assume_unique=False):
+  ar1 = core.concrete_or_error(asarray, ar1, "The error arose in setdiff1d()")
+  ar2 = core.concrete_or_error(asarray, ar2, "The error arose in setdiff1d()")
+
+  ar1 = unique(ar1)
+  ar2 = unique(ar2)
+
+  idx = in1d(ar1, ar2, invert=True)
+  return ar1[idx]
+
 @partial(jit, static_argnums=2)
 def _intersect1d_sorted_mask(ar1, ar2, return_indices=False):
   """

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -55,7 +55,7 @@ from jax._src.numpy.lax_numpy import (
     prod, product, promote_types, ptp, quantile,
     rad2deg, radians, ravel, ravel_multi_index, real, reciprocal, remainder, repeat, reshape,
     result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,
-    save, savez, searchsorted, select, set_printoptions, shape, sign, signbit,
+    save, savez, searchsorted, select, set_printoptions, setdiff1d, shape, sign, signbit,
     signedinteger, sin, sinc, single, sinh, size, sometrue, sort, sort_complex, split, sqrt,
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1073,6 +1073,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_{}".format(
+       jtu.format_shape_dtype_string(shape1, dtype1),
+       jtu.format_shape_dtype_string(shape2, dtype2)),
+       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2}
+      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for shape1 in all_shapes
+      for shape2 in all_shapes))
+  def testSetdiff1d(self, shape1, shape2, dtype1, dtype2):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
+    self._CheckAgainstNumpy(np.setdiff1d, jnp.setdiff1d, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}_assume_unique={}_return_indices={}".format(


### PR DESCRIPTION
This is the implementation for [np.setdiff1d](https://numpy.org/doc/stable/reference/generated/numpy.setdiff1d.html) from [#70 ](https://github.com/google/jax/issues/70) (and [#2078 ](https://github.com/google/jax/issues/2078)). I was unable to make the assume_unique work due to in1d not supporting assume_unique as well.