### PR TITLE
Add deprecation warning for indexing with non-tuple sequences

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4232,10 +4232,28 @@ def _eliminate_deprecated_list_indexing(idx):
   # deprecated by NumPy and exists for backward compatibility.
   if not isinstance(idx, tuple):
     if isinstance(idx, Sequence) and not isinstance(idx, ndarray):
+      # As of numpy 1.16, some non-tuple sequences of indices result in a warning, while
+      # others are converted to arrays, based on a set of somewhat convoluted heuristics
+      # (See https://github.com/numpy/numpy/blob/v1.19.2/numpy/core/src/multiarray/mapping.c#L179-L343)
+      # In JAX, we raise a warning for *all* non-tuple sequences, and in the future will
+      # *always* raise a TypeError here, rather than silently converting to an array or tuple
+      # depending on the contents of the list as numpy will. "Explicit is better than implicit".
+      # TODO(jakevdp): raise a TypeError here.
       if _any(_should_unpack_list_index(i) for i in idx):
+        msg = ("Using a non-tuple sequence for multidimensional indexing is deprecated; "
+               "use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will "
+               "result in a TypeError. See https://github.com/google/jax/issues/4564 "
+               "for discussion of why this type of indexing is being deprecated.")
         idx = tuple(idx)
       else:
+        msg = ("Using a non-tuple sequence for multidimensional indexing is deprecated; "
+               "use `arr[array(seq)]` instead of `arr[seq]`. In the future this will "
+               "result in a TypeError. See https://github.com/google/jax/issues/4564 "
+               "for discussion of why this type of indexing is being deprecated.")
         idx = (idx,)
+      # TODO(jakevdp): this stacklevel is appropriate for x[idx]; for ops.index_update
+      # we should use stacklevel=5; for x.at[idx].set() we should use stacklevel=6.
+      warnings.warn(msg, FutureWarning, stacklevel=4)
     else:
       idx = (idx,)
   return idx

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3696,7 +3696,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testIssue776(self):
     """Tests that the scatter-add transpose rule instantiates symbolic zeros."""
     def f(u):
-      y = jax.ops.index_add(np.ones(10,), [2, 4, 5], u)
+      y = jnp.ones(10).at[np.array([2, 4, 5])].add(u)
       # The transpose rule for lax.tie_in returns a symbolic zero for its first
       # argument.
       return lax.tie_in(y, 7.)
@@ -4008,7 +4008,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = rng_factory(self.rng())
     endpoints = rng((2,), dtype)
     out = jnp.linspace(*endpoints, 10, dtype=dtype)
-    self.assertAllClose(out[[0, -1]], endpoints, rtol=0, atol=0)
+    self.assertAllClose(out[np.array([0, -1])], endpoints, rtol=0, atol=0)
 
   @parameterized.named_parameters(
       jtu.cases_from_list(


### PR DESCRIPTION
Fixes #4564 

The goal here is to prevent JAX indexing from giving different results than numpy indexing in future numpy versions.

Note that with this change, JAX will raise a warning in some cases that numpy does not; e.g.
```python
x = jnp.arange(6).reshape(3, 2)
idx = [0, 1]
x[idx]
```
This PR is setting up JAX to be **more** strict than numpy, in that it will always error on non-tuple sequences of indices. This is consistent with JAX's behavior in other settings, where we avoid silent promotion of lists to arrays within `jax.numpy` functions.