### PR TITLE
Preserve name scope of named_call primitive in jax2tf

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -753,8 +753,7 @@ class TensorFlowTrace(core.Trace):
         vals_out: Sequence[Tuple[TfVal,
                                  core.AbstractValue]] = f.call_wrapped(*vals)
     else:
-      vals_out: Sequence[Tuple[TfVal,
-                               core.AbstractValue]] = f.call_wrapped(*vals)
+      vals_out = f.call_wrapped(*vals)
     return [TensorFlowTracer(self, v, a) for v, a in vals_out]
 
   def post_process_call(self, call_primitive: core.Primitive,

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -410,6 +410,18 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         ValueError, "convert must be used outside all JAX transformations"):
       self.TransformConvertAndCompare(outer, np.ones((4,)), transform)
 
+  def test_name_scope(self):
+    log = []
+
+    @jax.named_call
+    def my_test_function(x):
+      y = tf.Variable(1., name="foo")
+      log.append(y.name)
+      return x * x
+
+    jax2tf.convert(my_test_function)(2)
+    self.assertIn("my_test_function/foo", log[0])
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
named_call primitive has been used in Flax to add higher level model information.  The namescope information has not been preserved in jax2tf converter. 

This PR looks for the named_call primitive and uses tf.name_scope to pass the name scope information to the converted tensorflow ops. The PR also sanitizes the names to valid tensorflow name scopes.

screenshot before:
Namescope not perserved after jax2tf conversion.
![namescope_before](https://user-images.githubusercontent.com/3082188/96544394-58702300-125b-11eb-940d-8685650d07f0.png)

screenshot after:
Profiler traces shows namescopes from named_call primitive.
![namescope_after](https://user-images.githubusercontent.com/3082188/96544397-59a15000-125b-11eb-92ea-0f5f8c2cb44c.png)

