### PR TITLE
Ensure that check_jaxpr is done with abstract values

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1344,7 +1344,7 @@ def _check_jaxpr(jaxpr: Jaxpr, in_avals: Sequence[AbstractValue]):
     try:
       in_avals = map(read, eqn.invars)
       typecheck_assert(all(not isinstance(ina, ConcreteArray) for ina in in_avals),
-                       f"Equation given ConcreteArray type inputs")
+                       "Equation given ConcreteArray type inputs")
       if prim in custom_typechecks:
         custom_typechecks[prim](*in_avals, **eqn.params)
       if prim.call_primitive:

--- a/jax/core.py
+++ b/jax/core.py
@@ -1344,7 +1344,7 @@ def _check_jaxpr(jaxpr: Jaxpr, in_avals: Sequence[AbstractValue]):
     try:
       in_avals = map(read, eqn.invars)
       typecheck_assert(all(not isinstance(ina, ConcreteArray) for ina in in_avals),
-                       f"Primitive {prim} takes ConcreteArray abstract inputs")
+                       f"Equation given ConcreteArray type inputs")
       if prim in custom_typechecks:
         custom_typechecks[prim](*in_avals, **eqn.params)
       if prim.call_primitive:

--- a/jax/core.py
+++ b/jax/core.py
@@ -1320,7 +1320,7 @@ def _check_jaxpr(jaxpr: Jaxpr, in_avals: Sequence[AbstractValue]):
 
   def read(v: Atom) -> AbstractValue:
     if isinstance(v, Literal):
-      return get_aval(v.val)
+      return raise_to_shaped(get_aval(v.val))
     else:
       typecheck_assert(v in env, f"Variable '{v}' not defined")
       return env[v]
@@ -1343,6 +1343,8 @@ def _check_jaxpr(jaxpr: Jaxpr, in_avals: Sequence[AbstractValue]):
     prim = eqn.primitive
     try:
       in_avals = map(read, eqn.invars)
+      typecheck_assert(all(not isinstance(ina, ConcreteArray) for ina in in_avals),
+                       f"Primitive {prim} takes ConcreteArray abstract inputs")
       if prim in custom_typechecks:
         custom_typechecks[prim](*in_avals, **eqn.params)
       if prim.call_primitive:


### PR DESCRIPTION
Prior to this it was possible, e.g., for code that contains a Literal,
such as  `broadcast_to_dim[shape=(1000)] 0.0` to result in FLOPS during checking.

The assertion is broken by many tests unless we raise_to_shape for Literals.

I have timed the checks on my laptop and I do not see a reduction in the
total test time.