### PR TITLE
improve an escaped tracer error

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2384,6 +2384,9 @@ class RematTest(jtu.JaxTestCase):
 
   def test_escaped_tracer_remat(self):
     # b/169779185
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
     def f():
       seq = [jnp.zeros([])]
       def g():

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2382,6 +2382,20 @@ class RematTest(jtu.JaxTestCase):
     with assertEvals(2):
       vjp(v)
 
+  def test_escaped_tracer_remat(self):
+    # b/169779185
+    def f():
+      seq = [jnp.zeros([])]
+      def g():
+        seq[0] += 1  # this is line 7 btw
+        return seq[0]
+
+      api.remat(g)()
+      api.remat(g)()
+
+    with self.assertRaisesRegex(core.UnexpectedTracerError, "global state"):
+      api.jit(f)()
+
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Also make the jaxpr formation code related to staging out computation (i.e. related to jit, pmap, and control flow, rather than the part related to reverse-mode autodiff) more strict about when jaxpr variables should be created for tracers.

This is related to internal bug b/169779185. Here was a repro from @tomhennigan, based on one by @mfigurnov:

```python
import jax
import jax.numpy as jnp

def f():
  seq = [jnp.zeros([])]
  def g():
    seq[0] += 1  # this is line 7 btw
    return seq[0]

  jax.remat(g)()
  jax.remat(g)()  # KeyError: a

jax.jit(f)()
```

Before this change, the error message was:

```
Traceback (most recent call last):
  File "jumper.py", line 13, in <module>
    jax.jit(f)()
jax.traceback_util.FilteredStackTrace: KeyError: a

The stack trace above excludes JAX-internal frames.
The following is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "jumper.py", line 13, in <module>
    jax.jit(f)()
  File "/usr/local/google/home/mattjj/packages/jax/jax/traceback_util.py", line 139, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/usr/local/google/home/mattjj/packages/jax/jax/api.py", line 219, in f_jitted
    donated_invars=donated_invars)
  File "/usr/local/google/home/mattjj/packages/jax/jax/core.py", line 1174, in bind
    return call_bind(self, fun, *args, **params)
  File "/usr/local/google/home/mattjj/packages/jax/jax/core.py", line 1165, in call_bind
    outs = primitive.process(top_trace, fun, tracers, params)
  File "/usr/local/google/home/mattjj/packages/jax/jax/core.py", line 1177, in process
    return trace.process_call(self, fun, tracers, params)
  File "/usr/local/google/home/mattjj/packages/jax/jax/core.py", line 576, in process_call
    return primitive.impl(f, *tracers, **params)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 557, in _xla_call_impl
    *unsafe_map(arg_spec, args))
  File "/usr/local/google/home/mattjj/packages/jax/jax/linear_util.py", line 247, in memoized_fun
    ans = call(fun, *args)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 686, in _xla_callable
    extend_name_stack(wrap_name(name, 'jit')), *xla_args)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 446, in jaxpr_subcomp
    name_stack, backend=backend, **new_params)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 1299, in _remat_translation_rule
    *args)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 428, in jaxpr_subcomp
    in_nodes = _flatmap(read, eqn.invars)
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 389, in _flatmap
    return list(it.chain.from_iterable(map(func, vars)))
  File "/usr/local/google/home/mattjj/packages/jax/jax/util.py", line 35, in safe_map
    return list(map(f, *args))
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/xla.py", line 404, in read
    return env[v]
KeyError: a
```

Yuck! Very deep internal error. With `JAX_ENABLE_CHECKS=1` we catch it only slightly earlier:

```
[...]
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/partial_eval.py", line 627, in convert_constvars_jaxpr
    core.skip_checks or core.check_jaxpr(jaxpr)
  File "/usr/local/google/home/mattjj/packages/jax/jax/core.py", line 1317, in check_jaxpr
    raise JaxprTypeError(msg) from None
jax.core.JaxprTypeError: Variable 'a' not defined

in equation:

  b = add a 1.0

from source: jumper.py:7 (g)

while checking jaxpr:

{ lambda  ; .
  let b = add a 1.0
  in (b,) }
```

This is an escaped tracer error, but leading to a really bad error message.

After this change, here's what we get:

```
Traceback (most recent call last):
  File "jumper.py", line 13, in <module>
    jax.jit(f)()
  File "jumper.py", line 11, in f
    jax.remat(g)()  # KeyError: a
  File "jumper.py", line 7, in g
    seq[0] += 1
jax.traceback_util.FilteredStackTrace: jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.
The functions being transformed should not save traced values to global state. Detail: tracer created on line jumper.py:7 (g).

The stack trace above excludes JAX-internal frames.
The following is the original exception that occurred, unmodified.

--------------------
[...] <- just not showing this part
  File "/usr/local/google/home/mattjj/packages/jax/jax/interpreters/partial_eval.py", line 1016, in getvar
    raise core.escaped_tracer_error(detail)
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.
The functions being transformed should not save traced values to global state. Detail: tracer created on line jumper.py:7 (g).
```

We catch the error as soon as possible and raise a descriptive, actionable error message!