### PR TITLE
[x64] Add initial weak_type logic to abstract eval rules

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -402,7 +402,7 @@ def convert_element_type(operand: Array, new_dtype: DType) -> Array:
   if type(operand) in dtypes.python_scalar_dtypes:
     operand = np.asarray(operand, new_dtype)
   old_dtype = dtypes.canonicalize_dtype(_dtype(operand))
-  if old_dtype == new_dtype:
+  if old_dtype == new_dtype and not dtypes.is_weakly_typed(operand):
     return operand
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
@@ -1939,24 +1939,25 @@ _input_dtype = lambda *args, **_: dtypes.canonicalize_dtype(args[0].dtype)
 _fixed_dtype = lambda dtype: lambda *args, **kwargs: dtypes.canonicalize_dtype(dtype)
 _complex_basetype = lambda dtype: np.abs(np.zeros((), dtype)).dtype
 
-def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None):
+def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None, weak_type_rule=None):
+  weak_type_rule = weak_type_rule or partial(_standard_weak_type_rule, name)
   prim = Primitive(name)
   prim.def_impl(partial(xla.apply_primitive, prim))
-  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule))
+  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule, weak_type_rule))
   xla.translations[prim] = translation_rule or partial(standard_translate, name)
   return prim
 
-
-def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
+def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule, *args, **kwargs):
   assert all(isinstance(arg, UnshapedArray) for arg in args), args
+  weak_type = weak_type_rule(*args, **kwargs)
   least_specialized = _max(
       map(type, args), key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is ConcreteArray:
-    return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs))
+    return ConcreteArray(prim.impl(*[x.val for x in args], **kwargs), weak_type=weak_type)
   elif least_specialized is ShapedArray:
-    return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs))
+    return ShapedArray(shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs), weak_type=weak_type)
   elif least_specialized is UnshapedArray:
-    return UnshapedArray(dtype_rule(*args, **kwargs))
+    return UnshapedArray(dtype_rule(*args, **kwargs), weak_type=weak_type)
   else:
     raise TypeError(args, least_specialized)
 
@@ -2021,6 +2022,12 @@ def _broadcasting_shape_rule(name, *avals):
     msg = '{} got incompatible shapes for broadcasting: {}.'
     raise TypeError(msg.format(name, ', '.join(map(str, map(tuple, shapes)))))
   return result_shape
+
+
+def _standard_weak_type_rule(name, *avals, **kwargs):
+  # Currently this only returns True for a unary primitive with a weakly-typed input.
+  # TODO(jakevdp): expand propagation of weak types to other function signatures.
+  return len(avals) == 1 and getattr(avals[0], 'weak_type', False)
 
 
 def naryop(result_dtype, accepted_dtypes, name, translation_rule=None):
@@ -2507,9 +2514,13 @@ def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype, old_dtype):
     return convert_element_type_p.bind(tangent, new_dtype=new_dtype,
                                        old_dtype=old_dtype)
 
+def _convert_element_type_weak_type_rule(*avals, **kwargs):
+  return False
+
 convert_element_type_p = standard_primitive(
     _convert_element_type_shape_rule, _convert_element_type_dtype_rule,
-    'convert_element_type', _convert_element_type_translation_rule)
+    'convert_element_type', _convert_element_type_translation_rule,
+    _convert_element_type_weak_type_rule)
 ad.defjvp(convert_element_type_p, _convert_element_type_jvp_rule)
 ad.primitive_transposes[convert_element_type_p] = _convert_element_type_transpose_rule
 batching.defvectorized(convert_element_type_p)
@@ -5938,7 +5949,6 @@ def _dynamic_slice_indices(operand, start_indices):
             if isinstance(i, (int, np.integer))
             else select(lt(i, _const(i, 0)), add(i, _const(i, d)), i)
             for i, d in zip(start_indices, operand.shape)]
-
 
 
 def _const(example, val):

--- a/jax/api.py
+++ b/jax/api.py
@@ -1975,20 +1975,26 @@ def make_jaxpr(fun: Callable,
   >>> print(f(3.0))
   -0.83602
   >>> jax.make_jaxpr(f)(3.0)
-  { lambda  ; a.
-    let b = cos a
-        c = sin b
-    in (c,) }
+  { lambda  ; a.    
+    let b = convert_element_type[ new_dtype=float32
+                                  old_dtype=float32 ] a
+        c = cos b
+        d = sin c
+    in (d,) }
   >>> jax.make_jaxpr(jax.grad(f))(3.0)
   { lambda  ; a.
-    let b = cos a
-        c = sin a
-        _ = sin b
-        d = cos b
-        e = mul 1.0 d
-        f = neg e
-        g = mul f c
-    in (g,) }
+    let b = convert_element_type[ new_dtype=float32
+                                  old_dtype=float32 ] a
+        c = cos b
+        d = sin b
+        _ = sin c
+        e = cos c
+        f = mul 1.0 e
+        g = neg f
+        h = mul g d
+        i = convert_element_type[ new_dtype=float32
+                                  old_dtype=float32 ] h
+    in (i,) }
   """
   _check_callable(fun)
   if isinstance(static_argnums, int):

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -202,27 +202,29 @@ _jax_type_nums = {t: i for i, t in enumerate(_jax_types)}
 
 
 def _make_type_promotion_table():
-  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s_, f_, c_ = _jax_types
-  #  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s*, f*, c*
+  # Note: this promotion table is generated via the least upper bounds over a type
+  # promotion lattice. See testPromotionTableLattice for details of this.
+  b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_ = _jax_types
+  #  b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, s*, f*, c*
   return np.array([
-    [b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s8, f8, c8],  # b1
-    [u1, u1, u2, u4, u8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8, u1, f8, c8],  # u1
-    [u2, u2, u2, u4, u8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8, u2, f8, c8],  # u2
-    [u4, u4, u4, u4, u8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8, u4, f8, c8],  # u4
-    [u8, u8, u8, u8, u8, f8, f8, f8, f8, bf, f2, f4, f8, c4, c8, u8, f8, c8],  # u8
-    [s1, s2, s4, s8, f8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s1, f8, c8],  # s1
-    [s2, s2, s4, s8, f8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8, s2, f8, c8],  # s2
-    [s4, s4, s4, s8, f8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8, s4, f8, c8],  # s4
-    [s8, s8, s8, s8, f8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8, s8, f8, c8],  # s8
-    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8, bf, bf, c8],  # bf
-    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8, f2, f2, c8],  # f2
-    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8, f4, f4, c8],  # f4
+    [b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # b1
+    [u1, u1, u2, u4, u8, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, u1, f_, c_],  # u1
+    [u2, u2, u2, u4, u8, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, u2, f_, c_],  # u2
+    [u4, u4, u4, u4, u8, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, u4, f_, c_],  # u4
+    [u8, u8, u8, u8, u8, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, u8, f_, c_],  # u8
+    [i1, i2, i4, i8, f_, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i1, f_, c_],  # i1
+    [i2, i2, i4, i8, f_, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, i2, f_, c_],  # i2
+    [i4, i4, i4, i8, f_, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, i4, f_, c_],  # i4
+    [i8, i8, i8, i8, f_, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, i8, f_, c_],  # i8
+    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8, bf, bf, c4],  # bf
+    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8, f2, f2, c4],  # f2
+    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8, f4, f4, c4],  # f4
     [f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, f8, f8, c8],  # f8
     [c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c8, c4, c8, c4, c4, c4],  # c4
     [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8],  # c8
-    [s8, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s_, f_, c_],  # s*
-    [f8, f8, f8, f8, f8, f8, f8, f8, f8, bf, f2, f4, f8, c4, c8, f_, f_, c_],  # f*
-    [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c4, c8, c_, c_, c_],  # c*
+    [i_, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # s*
+    [f_, f_, f_, f_, f_, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, f_, f_, c_],  # f*
+    [c_, c_, c_, c_, c_, c_, c_, c_, c_, c4, c4, c4, c8, c4, c8, c_, c_, c_],  # c*
   ])
 
 _type_promotion_table = _make_type_promotion_table()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1785,12 +1785,12 @@ class APITest(jtu.JaxTestCase):
   def test_nested_jit_hoisting(self):
     @api.jit
     def f(x, y):
-      z = 2 * x
-      return y + z, 3
+      z = jnp.int32(2) * x
+      return y + z, jnp.int32(3)
 
     @api.jit
     def g(x):
-      return f(2, x)
+      return f(jnp.int32(2), x)
 
     jaxpr_subcomp = xla.jaxpr_subcomp
 
@@ -1801,7 +1801,7 @@ class APITest(jtu.JaxTestCase):
 
     try:
       xla.jaxpr_subcomp = jaxpr_subcomp_and_collect
-      ans = g(3)
+      ans = g(jnp.int32(3))
     finally:
       xla.jaxpr_subcomp = jaxpr_subcomp
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -381,7 +381,7 @@ class JaxprTypeChecks(jtu.JaxTestCase):
       return jnp.sin(x) + jnp.cos(x)
 
     def new_jaxpr():
-      return make_jaxpr(f)(1.).jaxpr
+      return make_jaxpr(f)(jnp.float32(1.)).jaxpr
 
     # jaxpr is:
     #

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -182,11 +182,11 @@ class DtypesTest(jtu.JaxTestCase):
 
 class TestPromotionTables(jtu.JaxTestCase):
 
-  def testWeakDtypesPromotionTable(self):
+  def testObservedPromotionTable(self):
     """Test that the weak & strong dtype promotion table does not change over time."""
     # Note: * here refers to weakly-typed values
     typecodes = \
-      ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
+        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
     if FLAGS.jax_enable_x64:
       expected = [
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
@@ -198,15 +198,15 @@ class TestPromotionTables(jtu.JaxTestCase):
         ['i2','i2','i4','i8','f8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f8','c8'],
         ['i4','i4','i4','i8','f8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f8','c8'],
         ['i8','i8','i8','i8','f8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
-        ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c8'],
-        ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c8'],
-        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c8'],
+        ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c4'],
+        ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c4'],
+        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c4'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','c8','c8','f8','f8','c8'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c8','c4','c8','c4','c4','c4'],
         ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8'],
         ['i8','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
-        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c8','c*','c*','c*'],
+        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
       ]
     else:
       expected = [
@@ -268,6 +268,48 @@ class TestPromotionTables(jtu.JaxTestCase):
       return diffs
 
     self.assertEqual(table, expected, show_differences(expected, table))
+
+  def testPromotionTableLattice(self):
+    """
+    Test that the promotion table can be generated from the least upper bound
+    of a type promotion lattice.
+    """
+    nodes = dtypes._jax_types
+    b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_ = nodes
+
+    # Specify the generating lattice for the promotion table.
+    lattice = {
+      b1: [i_],
+      u1: [i2, u2], u2: [i4, u4], u4: [i8, u8], u8: [f_],
+      i_: [u1, i1], i1: [i2], i2: [i4], i4: [i8], i8: [f_],
+      f_: [bf, f2, c_], bf: [f4], f2: [f4], f4: [f8, c4], f8: [c8],
+      c_: [c4], c4: [c8], c8: [],
+    }
+
+    # Compute all upper bounds of each node.
+    upper_bounds = {node: {node} for node in nodes}
+    for n in nodes:
+      while True:
+        new_upper_bounds = set().union(*(lattice[b] for b in upper_bounds[n]))
+        if n in new_upper_bounds:
+          raise ValueError(f"cycle detected for {n}")
+        if not new_upper_bounds.difference(upper_bounds[n]):
+          break
+        upper_bounds[n] |= new_upper_bounds
+
+    # Function to find the least upper bound of a set of nodes.
+    def least_upper_bound(nodes):
+      common_upper_bounds = set.intersection(*(upper_bounds[n] for n in nodes))
+      max_p = max(len(upper_bounds[p]) for p in common_upper_bounds)
+      least_upper_bounds = [p for p in common_upper_bounds if len(upper_bounds[p]) == max_p]
+      if len(least_upper_bounds) == 1:
+        return least_upper_bounds[0]
+      else:
+        raise ValueError(f"{nodes} do not have a unique least upper bound.")
+
+    # Table of least upper bounds should equal the type promotion table.
+    lub_table = np.array([[least_upper_bound({n, m}) for n in nodes] for m in nodes])
+    self.assertArraysEqual(lub_table, dtypes._type_promotion_table)
 
 
 if __name__ == "__main__":

--- a/tests/jaxpr_util_test.py
+++ b/tests/jaxpr_util_test.py
@@ -30,7 +30,7 @@ class JaxprStatsTest(jtu.JaxTestCase):
       s = jit(jnp.sin)(x)
       return jnp.sin(s) + jnp.cos(y)
 
-    hist = jaxpr_util.primitives(make_jaxpr(f)(1., 1.).jaxpr)
+    hist = jaxpr_util.primitives(make_jaxpr(f)(jnp.float32(1.), jnp.float32(1.)).jaxpr)
 
     for k in ['add', 'sin', 'cos', 'xla_call']:
       assert k in hist, k
@@ -76,7 +76,7 @@ class JaxprStatsTest(jtu.JaxTestCase):
       s = jnp.sin(x)                  # sin
       return jnp.sin(s) + jnp.cos(y)  # sin, cos, add
 
-    hist = jaxpr_util.source_locations(make_jaxpr(f)(1., 1.).jaxpr)
+    hist = jaxpr_util.source_locations(make_jaxpr(f)(jnp.float32(1.), jnp.float32(1.)).jaxpr)
     self.assertEqual(sum(hist.values()), 4)
 
   def test_print_histogram(self):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2329,6 +2329,35 @@ class LazyConstantTest(jtu.JaxTestCase):
     make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+        {"testcase_name": "_{}".format(rec.op),
+         "op_name": rec.op, "rec_dtypes": rec.dtypes}
+      for rec in LAX_OPS if rec.nargs == 1))
+  def testUnaryWeakTypes(self, op_name, rec_dtypes):
+    """Test that all lax unary ops propagate weak_type information appropriately."""
+    if op_name in ['acos', 'asin', 'atan', 'tan']:
+      # TODO(jakevdp): fix this. It will involve handling weakly-typed arrays,
+      # and propagating that weak typing through lax.full and lax.where.
+      self.skipTest(f'lax.{op_name} is a known failure')
+
+    # Find a valid dtype for the function.
+    for dtype in [np.float_, np.int_, np.complex_, np.bool_]:
+      dtype = dtypes.canonicalize_dtype(dtype)
+      if dtype in rec_dtypes:
+        py_val = dtype.type(1).item()
+        lax_val = lax.full((), py_val, dtype)
+        break
+    else:
+      raise ValueError("no available dtypes")
+
+    op = getattr(lax, op_name)
+    py_op = op(py_val)
+    lax_op = op(lax_val)
+
+    self.assertAllClose(py_op, lax_op, check_dtypes=True)
+    self.assertTrue(py_op.aval.weak_type)
+    self.assertFalse(lax_op.aval.weak_type)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This is a small part of the exporation from #3903. The main effect of this change is to make unary lax operations propagate the `weak_type` from input to output. This solves some of the jit invariance issues outlined in #3903, while punting on the more difficult questions of how to handle the full dtype promotion table in the presence of weak types.

Example repro:
```python
import jax.numpy as jnp
from jax import jit

x = jnp.arange(4, dtype='float16')

def add(x, y):
  return x + abs(y)

print(add(x, 1.0).dtype)
print(jit(add)(x, 1.0).dtype)
```
Output before this change:
```
float16
float32
```
Output after this change
```
float16
float16
```