### PR TITLE
Cleanup: pass function name rather than function object

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -850,7 +850,7 @@ def fmod(x1, x2):
   _check_arraylike("fmod", x1, x2)
   if issubdtype(_dtype(x1, x2), integer):
     x2 = where(x2 == 0, 1, x2)
-  return lax.rem(*_promote_args(np.fmod, x1, x2))
+  return lax.rem(*_promote_args("fmod", x1, x2))
 
 
 @_wraps(np.cbrt)


### PR DESCRIPTION
I quickly searched for other instances of this in `_promote_args` and related functions, but this seems to be the only one.