### PR TITLE
register filtered stack trace path exclusions from outside of `traceback_util`

### DIFF
--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -20,6 +20,9 @@ from . import ad_util
 from . import core
 from . import dtypes
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 _DIMENSION_TYPES = core._DIMENSION_TYPES
 
 UnshapedArray = core.UnshapedArray

--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -20,6 +20,9 @@ from .tree_util import register_pytree_node
 from typing import Any, Dict, Type
 from .util import safe_map
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 Array = Any
 
 map = safe_map

--- a/jax/api.py
+++ b/jax/api.py
@@ -69,6 +69,9 @@ from .interpreters.invertible_ad import custom_ivjp
 from .custom_derivatives import custom_jvp, custom_vjp, custom_gradient
 from .config import flags, config, bool_env
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 AxisName = Any
 
 # This TypeVar is used below to express the fact that function call signatures

--- a/jax/api.py
+++ b/jax/api.py
@@ -40,7 +40,7 @@ from . import linear_util as lu
 from . import ad_util
 from . import dtypes
 from .core import eval_jaxpr
-from .api_util import (wraps, flatten_fun, apply_flat_fun, flatten_fun_nokwargs,
+from .api_util import (flatten_fun, apply_flat_fun, flatten_fun_nokwargs,
                        flatten_fun_nokwargs2, argnums_partial,
                        argnums_partial_except, flatten_axes, donation_vector,
                        rebase_donate_argnums)
@@ -49,7 +49,7 @@ from .tree_util import (tree_map, tree_flatten, tree_unflatten, tree_structure,
                         tree_transpose, tree_leaves, tree_multimap,
                         treedef_is_leaf, Partial)
 from .util import (unzip2, curry, partial, safe_map, safe_zip, prod, split_list,
-                   extend_name_stack, wrap_name, cache)
+                   extend_name_stack, wrap_name, cache, wraps)
 from .lib import jax_jit
 from .lib import version
 from .lib import xla_bridge as xb

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -19,7 +19,7 @@ from absl import logging
 from .tree_util import (tree_flatten, tree_unflatten, tree_multimap, _replace_nones,
                         tree_structure)
 from . import linear_util as lu
-from .util import safe_map, curry, WrapHashably, Hashable
+from .util import safe_map, WrapHashably, Hashable
 from .core import unit
 
 from . import traceback_util
@@ -27,20 +27,6 @@ traceback_util.register_exclusion(__file__)
 
 map = safe_map
 
-
-@curry
-def wraps(wrapped, fun, namestr="{fun}", docstr="{doc}", **kwargs):
-  try:
-    fun.__name__ = namestr.format(fun=get_name(wrapped))
-    fun.__module__ = get_module(wrapped)
-    fun.__doc__ = docstr.format(fun=get_name(wrapped), doc=get_doc(wrapped), **kwargs)
-    fun.__wrapped__ = wrapped
-  finally:
-    return fun
-
-def get_name(fun): return getattr(fun, "__name__", "<unnamed function>")
-def get_module(fun): return getattr(fun, "__module__", "<unknown module>")
-def get_doc(fun): return getattr(fun, "__doc__", "")
 
 @lu.transformation_with_aux
 def flatten_fun(in_tree, *args_flat):

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -22,6 +22,9 @@ from . import linear_util as lu
 from .util import safe_map, curry, WrapHashably, Hashable
 from .core import unit
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 map = safe_map
 
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -36,6 +36,9 @@ from . import source_info_util
 from .util import safe_zip, safe_map, partial, curry, prod, partialmethod
 from .pprint_util import pp, vcat, PrettyPrint
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 # TODO(dougalm): compilation cache breaks the leak detector. Consisder solving.
 check_leaks = False
 

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -33,6 +33,9 @@ from .interpreters import xla
 from .interpreters.batching import not_mapped
 from .config import config
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 map = safe_map
 zip = safe_zip
 

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -30,6 +30,9 @@ from . import util
 from .config import flags
 from .lib import xla_client
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('jax_enable_x64',
                   strtobool(os.getenv('JAX_ENABLE_X64', 'False')),

--- a/jax/experimental/callback.py
+++ b/jax/experimental/callback.py
@@ -19,11 +19,11 @@ import jax.numpy as jnp
 from jax import core
 from jax.core import Trace, Tracer
 from jax import linear_util as lu
-from jax.util import partial, safe_map
+from jax.util import partial, safe_map, wraps
 
 import inspect
-from jax.api_util import (wraps, flatten_fun_nokwargs)
-from jax.tree_util import (tree_flatten, tree_unflatten)
+from jax.api_util import flatten_fun_nokwargs
+from jax.tree_util import tree_flatten, tree_unflatten
 
 map = safe_map
 

--- a/jax/interpreters/__init__.py
+++ b/jax/interpreters/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+
+from .. import traceback_util
+traceback_util.register_exclusion(os.path.dirname(__file__))

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -26,9 +26,9 @@ from . import xla
 from .. import linear_util as lu
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
-from ..api_util import flatten_axes, flatten_fun, wraps
+from ..api_util import flatten_axes, flatten_fun
 from ..tree_util import tree_flatten, tree_unflatten
-from ..util import extend_name_stack, wrap_name, safe_zip
+from ..util import extend_name_stack, wrap_name, wraps, safe_zip
 from ..config import config
 
 xops = xc._xla.ops

--- a/jax/lazy.py
+++ b/jax/lazy.py
@@ -24,6 +24,9 @@ from .util import safe_map, safe_zip, unzip2, subvals
 from .lib import xla_bridge as xb
 from .lib import xla_client as xc
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 xops = xc.ops
 
 map = safe_map

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -68,6 +68,10 @@ import weakref
 
 from .util import curry
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
+
 class StoreException(Exception): pass
 
 

--- a/jax/pprint_util.py
+++ b/jax/pprint_util.py
@@ -15,6 +15,9 @@
 import functools
 import operator as op
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 
 class PrettyPrint:
   """Crude Hughes-inspired pretty printer."""

--- a/jax/source_info_util.py
+++ b/jax/source_info_util.py
@@ -19,6 +19,10 @@ from typing import Any, Optional
 
 from .lib import xla_client
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
+
 Traceback = Any  # xla_client.Traceback
 Frame = Any  # xla_client.Traceback::Frame
 

--- a/jax/traceback_util.py
+++ b/jax/traceback_util.py
@@ -17,7 +17,9 @@ import sys
 import traceback
 import types
 
-_exclude_paths = [__file__]
+from . import util
+
+_exclude_paths = [__file__, util.__file__]
 
 def register_exclusion(path):
   _exclude_paths.append(path)
@@ -121,12 +123,11 @@ def api_boundary(fun):
   ``api_boundary``, such an exception is accompanied by an additional traceback
   that excludes the frames specific to JAX's implementation.
   '''
-  from .api_util import wraps   # avoid cyclic dependencies
 
   if not filtered_tracebacks_supported():
     return fun
 
-  @wraps(fun)
+  @util.wraps(fun)
   def reraise_with_filtered_traceback(*args, **kwargs):
     try:
       return fun(*args, **kwargs)

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -44,6 +44,10 @@ from .lib import pytree
 
 from .util import partial, safe_zip, unzip2
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
+
 def tree_flatten(tree):
   """Flattens a pytree.
 

--- a/jax/util.py
+++ b/jax/util.py
@@ -20,9 +20,6 @@ import types
 
 import numpy as np
 
-from . import traceback_util
-traceback_util.register_exclusion(__file__)
-
 
 def safe_zip(*args):
   n = len(args[0])
@@ -260,3 +257,17 @@ def canonicalize_axis(axis, num_dims):
 
 def ceil_of_ratio(x, y):
   return -(-x // y)
+
+@curry
+def wraps(wrapped, fun, namestr="{fun}", docstr="{doc}", **kwargs):
+  try:
+    fun.__name__ = namestr.format(fun=get_name(wrapped))
+    fun.__module__ = get_module(wrapped)
+    fun.__doc__ = docstr.format(fun=get_name(wrapped), doc=get_doc(wrapped), **kwargs)
+    fun.__wrapped__ = wrapped
+  finally:
+    return fun
+
+def get_name(fun): return getattr(fun, "__name__", "<unnamed function>")
+def get_module(fun): return getattr(fun, "__module__", "<unknown module>")
+def get_doc(fun): return getattr(fun, "__doc__", "")

--- a/jax/util.py
+++ b/jax/util.py
@@ -20,6 +20,9 @@ import types
 
 import numpy as np
 
+from . import traceback_util
+traceback_util.register_exclusion(__file__)
+
 
 def safe_zip(*args):
   n = len(args[0])


### PR DESCRIPTION
Previously, in `traceback_util.py`, we maintained a list of include/exclude paths under which stack frames were filtered. This PR introduces a module-level function for registering a path exclusion, and uses it throughout the codebase.

Hopefully this is easier maintain consistently. Our recent factor/move of several files under `_src` inadvertently affected what frames were filtered. This PR fixes that in particular.