### PR TITLE
an experiment in handling instances with __jax_array__

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -437,6 +437,9 @@ def convert_element_type(operand: Array, new_dtype: DType = None,
     msg = "Casting complex values to real discards the imaginary part"
     warnings.warn(msg, np.ComplexWarning, stacklevel=2)
 
+  if hasattr(operand, '__jax_array__'):
+    operand = operand.__jax_array__()
+
   if not isinstance(operand, (core.Tracer, xla.DeviceArray)):
     return _device_put_raw(np.asarray(operand, dtype=new_dtype),
                            weak_type=new_weak_type)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -300,9 +300,11 @@ def _result_dtype(op, *args):
   return _dtype(op(*args))
 
 
-def _arraylike(x): return isinstance(x, ndarray) or isscalar(x)
+def _arraylike(x):
+  return isinstance(x, ndarray) or isscalar(x) or hasattr(x, '__jax_array__')
+
 def _check_arraylike(fun_name, *args):
-  """Check if all args fit JAX's definition of arraylike (ndarray or scalar)."""
+  """Check if all args fit JAX's definition of arraylike."""
   assert isinstance(fun_name, str), f"fun_name must be a string. Got {fun_name}"
   if _any(not _arraylike(arg) for arg in args):
     pos, arg = next((i, arg) for i, arg in enumerate(args)

--- a/jax/core.py
+++ b/jax/core.py
@@ -859,6 +859,8 @@ def concrete_aval(x):
   for typ in type(x).mro():
     handler = pytype_aval_mappings.get(typ)
     if handler: return handler(x)
+  if hasattr(x, '__jax_array__'):
+    return concrete_aval(x.__jax_array__())
   raise TypeError(f"{type(x)} is not a valid JAX type")
 
 

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -280,7 +280,10 @@ def is_python_scalar(x):
   try:
     return x.aval.weak_type and np.ndim(x) == 0
   except AttributeError:
-    return type(x) in python_scalar_dtypes
+    if hasattr(x, '__jax_array__'):
+      return is_python_scalar(x.__jax_array__())
+    else:
+      return type(x) in python_scalar_dtypes
 
 def dtype(x):
   if type(x) in python_scalar_dtypes:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -129,7 +129,7 @@ def device_put(x, device: Optional[Device] = None) -> Tuple[Any]:
   elif hasattr(x, '__jax_array__'):
     return device_put(x.__jax_array__(), device)
   else:
-    raise TypeError(f"No device_put handler for type: {type(x)}") from err
+    raise TypeError(f"No device_put handler for type: {type(x)}")
 
 def _device_put_array(x, device: Optional[Device]):
   backend = xb.get_device_backend(device)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2089,6 +2089,11 @@ class APITest(jtu.JaxTestCase):
     y = api.pmap(jnp.sin)(x)
     self.assertAllClose(y, jnp.sin(jnp.array([[1., 2., 3.]])))
 
+    x = jnp.array(1)
+    a = AlexArray(x)
+    for f in [jnp.isscalar, jnp.size, jnp.shape, jnp.dtype]:
+      self.assertEqual(f(x), f(a))
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Before raising an error on an unrecognized type, first check if the object defines a `__jax_array__` method. If it does, call it!

This provides a way for custom types to be auto-converted to JAX-compatible types.

We didn't add a check for `__array__` because that might entail a significant change in behavior. For example, we'd be auto-converting `tf.Tensor` values. Maybe it's better to remain loud in those cases.

Implementing this method is *not* sufficient for a type to be duck-typed enough for use with `jax.numpy`. But it may be necessary. That is, someone trying to add a duck-typed array to be used with JAX identified a need for `__jax_array__` or similar.

This feature is experimental, so it may disappear, change arbitrarily, or never be documented.