### PR TITLE
[jax2tf] Expanding jax2tf shape polymorphism.

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -6,7 +6,7 @@ a function that uses only TensorFlow operations. The converted function
 can be used in a TensorFlow context and will behave as if it was written in TensorFlow.
 In practice this means that you can take some code written in JAX and execute it using
 TensorFlow eager mode, or stage it out as a TensorFlow graph, even save it
-as a SavedModel for use with TensorFlow tools such as serving tools,
+as a SavedModel for use with TensorFlow tools such as serving stack,
 or TensorFlow Hub.
 
 ### Usage: converting basic functions.
@@ -55,7 +55,7 @@ is trivial.
 # You can save the model just like you would with any other TensorFlow function:
 my_model = tf.Module()
 # Save a function that can take scalar inputs.
-my_model.f = tf.function(f_tf, input_signature=[tf.TensorSpec([], tf.float32)])
+my_model.f = tf.function(jax2tf.convert(f_jax), input_signature=[tf.TensorSpec([], tf.float32)])
 tf.saved_model.save(my_model, '/some/directory')
 
 # Restoring (note: the restored model does *not* require JAX to run, just XLA).
@@ -68,171 +68,128 @@ SavedModel multiple versions of a function for different input shapes, by
 
 ```
 my_model.f = tf.function(jax2tf.convert(f_jax), autograph=False)
-my_model.f(tf.ones([1, 28, 28, 1]))  # a batch size of 1
-my_model.f(tf.ones([16, 28, 28, 1]))  # a batch size of 16
+my_model.f(tf.ones([1, 28, 28]))  # a batch size of 1
+my_model.f(tf.ones([16, 28, 28]))  # a batch size of 16
+tf.saved_model.save(my_model, '/some/directory')
 ```
 
-More involved examples of using SavedModel are described in the
-[getting started Colab](JAX2TF_getting_started.ipynb).
+More involved examples of using SavedModel, including how to prepare
+Flax models for conversion and saving, are described in the
+[getting started Colab](JAX2TensorFlow_getting_started.ipynb). For details of
+how you can save a batch-polymorphic SavedModel see [below](#shape-polymorphic-conversion).
 
 ## Differentiation
 
-The converted code supports differentiation from TF.
-The main challenge with TF-differentiation of the converted code is that some
+The converted code supports differentiation from TensorFlow.
+The main challenge with TensorFlow-differentiation of the converted code is that some
 of the JAX primitives or functions that were used in the original JAX code might
 have had JAX custom gradients. One example is the ``jax.nn.relu``, which
 at 0 has a JAX custom gradient of 0, but the primitive-by-primitive conversion
-to TF is not mathematically differentiable at 0 and may generate another value. In this
-particular case the TF differentiation of the raw conversion returns 1.
-If we were to use ``tf.nn.relu``, then we would get a correct custom TF gradient of 0,
-because ``tf.nn.relu`` has a TF custom gradient.
+to TensorFlow is not mathematically differentiable at 0 and may generate another value. In this
+particular case the TensorFlow differentiation of the raw conversion returns 1.
+If we were to use ``tf.nn.relu``, then we would get a correct custom TensorFlow gradient of 0,
+because ``tf.nn.relu`` has a TensorFlow custom gradient.
 
-Other challenges for differentiation are that some of the TF ops used in translation
+Other challenges for differentiation are that some of the TensorFlow ops used in translation
 do not yet have differentiation rules defined.
 For other ops, we would have to ensure that they match the JAX differentiation rules.
 
 All of these problems are solved by having the converter annotate the converted
-function with a ``tf.custom_gradient`` that, upon TF differentiation, will lazily
+function with a ``tf.custom_gradient`` that, upon TensorFlow differentiation, will lazily
 call into JAX to compute the ``jax.vjp`` of the converted function, followed by
 jax2tf conversion.
 This ensures that JAX’s differentiation uses the JAX rules and custom gradients.
-In particular, TF’s internal op differentiation rules will not be used at all,
+In particular, TensorFlow’s internal op differentiation rules will not be used at all,
 and we need not worry about ops not having differentiation rules that match JAX's.
 The jax2tf converter has an option to skip the custom gradients and wrap
 instead the converted function with ``tf.raw_ops.PreventGradient`` to generated an
 error in case a gradient computation is attempted.
 
 Currently there is a bug that prevents using custom gradients with SavedModel
-(see Caveats below).
+(see [Caveats](#caveats) below).
 
-## Caveats
-
-1.  Some JAX primitives are converted into
-[special TensorFlow ops](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2xla/ops/xla_ops.cc)
-  that are thin wrapper over XLA ops. For this reason, the graphs produced by jax2tf
-  require XLA in order to run. Also, these ops may not be recognized by
-  SavedModel converters, such as the TensorFlow.js converter.
-  We use the following such operations:
-
-     * ``XlaPad`` (wraps XLA Pad operator). We use this instead of ``tf.pad`` in order to
-     support ``lax.pad`` interior padding (dilation) or negative edge padding.
-     * ``XlaConv`` (wraps XLA ConvGeneralDilated operator).
-     * ``XlaGather`` (wraps XLA Gather operator). We could use ``tf.gather`` in some
-     cases but not always. Also, ``tf.gather`` has a different semantics than ``lax.gather``
-     for index out of bounds.
-     * ``XlaScatter`` (wraps XLA Scatter operator).
-     * ``XlaSelectAndScatter`` (wraps XLA SelectAndScatter operator).
-     * ``XlaDynamicSlice`` (wraps XLA DynamicSlice operator).
-     We use this instead of ``tf.slice`` for reasons explained above for ``XlaGather``.
-     * ``XlaDynamicUpdateSlice`` (wraps XLA DynamicUpdateSlice operator).
-     * ``XlaReduceWindow`` (wraps XLA ReduceWindow operator). These are used
-     for ``lax.reduce_window_sum_p``, ``lax.reduce_window_min_p``,
-     ``lax.reduce_window_max_p``, and ``lax.reduce_window_p``.
-     * ``XlaSort`` (wraps XLA Sort operator).
-
-2.  A small number of JAX primitives are not yet converted, or are converted only
-    for certain data types. The main
-    reason is that the required TensorFlow ops are not implemented for certain
-    data types on certain devices. There is an
-    [up-to-date list of unimplemented cases](primitives_with_limited_support.md).
-
-3.  Currently, TF SavedModel does not properly save the ``tf.custom_gradient``.
-    It does save however some attributes that on model restore result in a warning
-    that the model might not be differentiable, and trigger an error if differentiation
-    is attempted. The plan is to fix this. Note that if no gradients are requested,
-    the PreventGradient ops will be saved along with the converted code and will
-    give a nice error if differentiation of the converted code is attempted.
-
-4.  There is currently no support for replicated (e.g. `pmap`) or multi-device
-    (e.g. `sharded_jit`) functions.
-
-5.  The converted code may have slightly different performance characteristics than
-    the original JAX code.
-    If one were to write the same functionality in JAX idiomatic code vs.
-    native TF idiomatic code we could end up with very different compilation paths,
-    when TF is used without XLA. Take for example, the case of batch normalization.
-    In TF if one uses [tf.nn.batch_normalization](https://www.tensorflow.org/api_docs/python/tf/nn/batch_normalization),
-    a “high-level” TF op for batch
-    normalization is generated, and in the absence of XLA, on CPU or GPU,
-    a custom C++ “high-level” kernel implementing batch normalization is executed.
-    In JAX, there is no primitive for batch normalization, and instead the
-    operation is decomposed into low-level primitives (e.g., [flax.nn.BatchNorm](https://flax.readthedocs.io/en/latest/_autosummary/flax.nn.BatchNorm.html#flax.nn.BatchNorm),
-    or haiku.BatchNorm).
-    Once those primitives are converted to TF, and the resulting code is
-    run without XLA, the ensemble of the kernels executed will quite
-    possibly behave differently, performance-wise or even numerically,
-    than either the TF native or JAX native batch normalization.
-    A similar example is that of an LSTM cell.
-
-    Yet another example are the PRNG primitives. JAX programs use a [stateless
-    deterministic PRNG](https://github.com/google/jax/blob/master/design_notes/prng.md)
-    and it has an internal JAX primitive for it.
-    This primitive is at the moment converted to a soup of tf.bitwise operations,
-    which has a clear performance penalty. We plan to look into using the
-    HLO [RNGBitGenerator](https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator)
-
-    (exposed as a TFXLA op), which does implement
-    the same basic Threefry algorithm as JAX’s PRNG, although that would
-    result in different results than JAX’s PRNG.
-
-    We do expect that the performance characteristics of converted code
-    should approximate those of JAX or TF native with XLA. This is because
-    during conversion we try to generate one TF op for one JAX primitive.
-    We expect that the lowering that XLA does is similar to that done by JAX
-    before conversion. (This is a hypothesis, we have not verified it extensively.)
-
-### Shape-polymorphic conversion
+## Shape-polymorphic conversion
 
 **The shape polymorphism support is work in progress. Please report any bugs you encounter.**
 
 We described above how to include in the SavedModel several specializations
 of a converted function for a few specific input shapes. The converter can also produce
 a shape-polymorphic TensorFlow graph that is usable with inputs of any shape matching
-certain constraints. This is useful, e.g., to allow a SavedModel to be used for multiple
-batch sizes.
+certain constraints. This is useful, e.g., to allow a single SavedModel to be used for multiple
+batch sizes. In order to help ensure correctness, we propose below an implementation
+strategy that does not require changes to the JAX core (it uses and builds upon ideas
+and code from JAX’s experimental auto-masking transformation).
 
 The standard TensorFlow technique for producing a shape-polymorphic graph is
-to warm the function on partially-specified (shape polymorphic) inputs.
-For example, if `f_tf` is a TensorFlow function taking a batch of images,
-represented as 4D arrays, then:
+to warm the function on partially-specified (shape polymorphic) inputs, e.g.,
+`tf.TensorSpec([None, 28, 28], tf.float32)` for a function that processes a
+batch (of unspecified batch size) of 28x28 images. For jax2tf it is also necessary
+to specify an additional `in_shapes` parameter for the `jax2tf.convert` function:
 
 ```
-tf.function(f_tf).get_concrete_function(tf.TensorSpec([None, 28, 28, 1], tf.float32))
+f_tf = tf.function(jax2tf.convert(f_jax, in_shapes=["(b, 28, 28)"]), autograph=False)
+f_tf.get_concrete_function(tf.TensorSpec([None, 28, 28], tf.float32))
 ```
 
-will generate and cache a TensorFlow graph that is expected to work for any
-value of the leading dimension. We use below the term `TensorSpec` to refer to
-a *TensorFlow shape specification*, which can be written directly as above,
-possibly including `None` for some dimensions, or can be derived implicitly
-from actual NumPy arrays or `tf.Tensor` passed as actual arguments.
+The `in_shapes` parameter, in the form of a list of strings corresponding to the list of
+arguments, introduces one or more shape variables, e.g., `b`, to stand for shape
+dimensions that are unknown at JAX tracing time. In this particular example, we can 
+also use the `in_shapes=["(b, _, _)"]`, because the `_` placeholders take their value
+from the corresponding dimension of the `tf.TensorSpec` (which must be known)
 
-One challenge for the jax2tf converter is that TensorFlow's shape checking mechanism
-is too permissive in presence of polymorphic shapes. For example, the
-function `lambda x: x + tf.transpose(x)` only makes sense for square matrices,
-but this constraint is not expressible in TensorFlow; we must use the more
-permissive `[None, 16]` shape. The mental model here is that graph generation
-will succeed if the polymorphic `TensorSpec` includes *at least one shape* for
-which the graph is well-defined.
-If the graph is used for other shapes there will be a shape error at runtime.
-
-JAX includes *experimental* support for shape polymorphism but the shape checking
-rules are stricter than in TensorFlow: we must give the jax2tf converter a specification
-of what shapes to specialize the function to, such that the specialization is guaranteed
-to work for *any shape* that matches the specification. For the above example, one can
-obtain a graph that works for all 2D *square* matrices as follows:
+In the example above, the `in_shapes` specification does not convey more information 
+than the partial `tf.TensorSpec`,
+except perhaps giving a name to the unknown dimension so that it can be recognized
+in the error messages. The need for named shape variables arises when there are
+multiple unknown dimensions and there is a relationship between them. For example,
+if the function to be converted is also polymorphic on the size of each image while
+requiring the images to be square, we would add a shape variable `d` to stand for
+the unknown image size:
 
 ```
-f_jax = lambda x: x + x.T
-f_tf = tf.function(jax2tf.convert(f_jax, in_shapes=["(b, b)"]), autograph=False)
-f_tf.get_concrete_function(tf.TensorSpec([None, None], tf.float32))
+f_tf = tf.function(jax2tf.convert(f_jax, in_shapes=["(b, d, d)"]), autograph=False)
+f_tf.get_concrete_function(tf.TensorSpec([None, None, None], tf.float32))
 ```
 
-The novel element here is ```in_shapes=["(b, b)"]```, which introduces
-a dimension variable ```b``` and specifies that the first input is 2D with
-both dimension sizes equal to ```b```. Note that the most precise `TensorSpec`
-available to capture all 2D square matrices is `[None, None]`, which is
-strictly more permissive (TensorFlow does not currently have a notation to
-specify shapes whose dimensions have constraints).
+The JAX tracing mechanism performs shape checking using the same strict rules as 
+when the shapes are fully known. For example, given the `"(b, d, d)"`
+specification for the argument `x` of a function, JAX will know that a conditional
+`x.shape[-2] == x.shape[-1]` is `True`, will know that `x` and `jnp.sin(x)` have the
+same shape of a batch of square matrices that can be passed to `jnp.matmul`.
+
+### Correctness of shape-polymorphic tracing
+
+We want to trust that the converted program produces the same results as the
+original JAX program:
+
+For any function `f_jax` and any input signature `abs_sig` containing partially 
+known `tf.TensorSpec`, and any concrete input `x` whose shape matches `abs_sig`:
+ * If the conversion to TensorFlow succeeds: `f_tf = tf.function(jax2tf.convert(f_jax, in_shapes)).get_concrete_function(abs_sig)`
+ * and if the TensorFlow execution succeeds with result `y`: `f_tf(x) = y`
+ * then the JAX execution would produce the same result: `f_jax(x) = y`,
+
+
+It is crucial to understand that `f_jax(x)` has the freedom to re-invoke the JAX tracing machinery,
+and in fact it does so for each distinct concrete input shape, while the generation of `f_tf`
+uses JAX tracing only once, and invoking `f_tf(x)` does not use JAX tracing anymore. In fact,
+invoking the latter invocation may happen in a production environment when `f_jax` and the JAX
+tracing machinery are not available anymore.
+
+Correctness is very important because it would be nasty to debug a subtle discrepancy
+of the code running in production from the expected behavior written in JAX. We help ensure correctness
+by reusing the same JAX tracing and shape checking mechanism as when the shapes are fully known.
+
+### Coverage of shape-polymorphic tracing
+
+A complementary goal is to be able to convert many shape-polymorphic programs, but at the very
+least batch-size-polymorphic programs, so that one SavedModel can be used for any batch sizes.
+For example, we want to ensure that any function written using `jax.vmap` at the top level can be
+converted with the batch dimension polymorphic and the remaining dimensions concrete.
+
+It is reasonable to expect that there will be JAX programs for which there is a
+shape-polymorphic TensorFlow graph, but which will give an error when converting with jax2tf.
+
+### Details
 
 In order to be able to use shape polymorphism effectively with jax2tf, it
 is worth considering what happens under the hood. When the converted function
@@ -250,8 +207,8 @@ See [how optional parameters are matched to arguments](https://jax.readthedocs.i
 A shape specifier is combined with a `TensorSpec` as follows:
 
   * A shape specifier of `None` means that the shape is given
-    by the actual `TensorSpec`, which must be fully known.
-  * Otherwise, the specifier must be a comma-separated string of the form `(dim_1, ..., dim_n)`, denoting
+    by the actual argument `TensorSpec`, which must be fully known.
+  * Otherwise, the specifier must be a comma-separated string of dimension specifiers: `(dim_1, ..., dim_n)`, denoting
     an n-dimensional array. The `TensorSpec` must also be of rank ``n``. The
     corresponding dimensions from the shape specifier and the `TensorSpec` are matched:
 
@@ -259,13 +216,13 @@ A shape specifier is combined with a `TensorSpec` as follows:
          the actual `TensorSpec`, which have a constant in the corresponding dimension.
        * a dimension specifier can also be a lowercase identifier, denoting a dimension-size
          variable. The abstract value of the dimension is going to be set to this variable.
-         The corresponding dimension in `TensorSpec` should be `None` or can be a
+         The corresponding dimension in `TensorSpec` can be `None` or can be a
          constant.
-       * a dimension specifier can also be a polynomial expression involving dimension
+       * a dimension specifier can also be a **linear** polynomial expression involving shape
          variables. The expression can involve `+`, `*`, integer constants with optional negation
-         sign, and dimension variables. All occurrences of a dimension variable in any dimension
+         sign, and shape variables. All occurrences of a shape variable in any dimension
          for any argument are assumed to be equal. The corresponding dimension in `TensorSpec`
-         should be `None` or can be a known constant.
+         can be `None` or can be a known constant.
 
 Note that `in_shapes` controls the shape abstraction used by JAX when tracing
 the function (with `_` placeholders given by the `TensorSpec`). The `TensorSpec`
@@ -287,11 +244,78 @@ A few examples of shape specifications and uses:
   * `in_shapes=["(batch, _)", "(batch,)"]`: the leading dimensions of the two arguments
      must match. The second dimension of the first argument is taken from the
      actual `TensorSpec`. This can be used with a `TensorSpec` pair `[None, 16]`
-     and `[None]`. It can also be used with a pair `[8, 16]` and `[5]`. (TODO:
-     add some checking that the `TensorSpec` has at least a satisfying solution
-     for the dimension variables.)
+     and `[None]`. It can also be used with a pair `[8, 16]` and `[5]`.
 
-#### Errors in presence of shape polymorphism
+### Shape variables used in the computation
+
+There are some situations when shape variables arise in the computation itself.
+You can see in the following example how elements from the input shapes
+`(1024, 28, 28)` and `(28, 28)` appear in the computation and specifically
+in the `shape` parameter of the `broadcast_in_dim` JAX primitive.
+
+```
+def image_mask_jax(images, mask):
+  # images: f32[B, W, W]  and mask: f32[W, W]
+  return images * mask
+
+print(jax.make_jaxpr(image_mask_jax)(np.ones((1024, 28, 28)), np.ones((28, 28)))
+>> { lambda  ; a b.
+>>   let c = broadcast_in_dim[ broadcast_dimensions=(1, 2)
+>>                            shape=(1, 28, 28) ] b
+>>      d = mul a c
+>>   in (d,) }
+
+# will invoke broadcast_in_dim with shape=(1, w, w)
+convert(image_mask_jax, in_shapes=["(b, w, w)", "(w, w)"])
+```
+
+When tracing and converting with abstract shapes some primitive parameters will contain polynomials
+instead of just constants, e.g., the `shape` parameter of `broadcast_in_dim` will be `(1, w, w)`.
+
+We propose to augment the JAX core type system to include explicit shape variables
+and allow polynomials over shape variables to appear in designated parameters of certain JAX primitives.
+Note that JAX primitives distinguish the inputs, which are array values,
+e.g., `b` for `broadcast_in_dim` above, and the parameters, e.g., `broadcast_dimensions` and `shape`.
+One can consider that certain parameters of the primitives are part of their type.
+
+One must mentally distinguish JAX code that computes shapes from
+JAX code that computes arrays. A shape value is either a vector of integers or the result
+of `arr.shape` for some array value `arr`, or something computed solely from other shape
+values using a small set of operations: addition, subtraction, multiplication,
+(some) division, (some) comparisons, including helper functions such as `np.prod`,
+`np.greater_equal` (see below).
+Without shape polymorphism, all shape values are vectors of compile-time constants.
+With shape polymorphism, shape values are vectors of either integer constants or polynomials.
+
+The JAX shape checking rules operate exclusively on shape values. We can classify the
+inputs of all JAX API calls as either array inputs or shape inputs.
+For example, `lax.reshape(operand: ArrayValue, shape: ShapeValue)`. This distinction
+is easy for the JAX primitives which take only arrays as inputs and can take
+shape values only in certain parameters of certain primitives.
+
+Fortunately, TensorFlow can express code with polymorphic shapes by using the `tf.shape` op,
+so the output of the conversion of `image_mask_jax` could be:
+
+```
+def image_mask_tf(images, mask):
+  b, w, _ = tf.shape(images) # Compute the dynamic values for the shape variables "b" and "w"
+  return tf.math.multiply(images,
+                          tf.broadcast_to(tf.reshape(mask, [1, w, w]),
+                                          [b, w, w]))
+```
+
+To achieve this, when we start converting a function we construct a shape environment,
+mapping the shape variables in the `in_shapes` specification to TensorFlow expressions
+using `tf.shape` on the input parameters.
+To make this easy we **restrict the input shape specifications such that each
+unknown dimension is a shape variable**. The shape environment is global and
+constant for the conversion of one function.
+In the example above, the shape environment is as computed in the first line of `image_mask_tf`.
+When converting primitives that are known to have shape parameters,
+the parameters are evaluated using the shape environment.
+
+
+### Errors in presence of shape polymorphism
 
 When tracing with shape polymorphism we can encounter shape errors:
 
@@ -333,6 +357,82 @@ will have the value of the shape variable `v`. This case is not yet implemented:
 jax2tf.convert(lambda x: jnp.sum(x, axis=0) / x.shape[0],
                in_shapes=["(v, _)"])(np.ones((4, 4)))
 ```
+
+## Caveats
+
+1.  Some JAX primitives are converted into
+[special TensorFlow ops](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/tf2xla/ops/xla_ops.cc)
+  that are thin wrapper over XLA ops. For this reason, the graphs produced by jax2tf
+  require XLA in order to run. Also, these ops may not be recognized by
+  SavedModel converters, such as the TensorFlow.js converter.
+  We use the following such operations:
+
+     * ``XlaPad`` (wraps XLA Pad operator). We use this instead of ``tf.pad`` in order to
+     support ``lax.pad`` interior padding (dilation) or negative edge padding.
+     * ``XlaConv`` (wraps XLA ConvGeneralDilated operator).
+     * ``XlaGather`` (wraps XLA Gather operator). We could use ``tf.gather`` in some
+     cases but not always. Also, ``tf.gather`` has a different semantics than ``lax.gather``
+     for index out of bounds.
+     * ``XlaScatter`` (wraps XLA Scatter operator).
+     * ``XlaSelectAndScatter`` (wraps XLA SelectAndScatter operator).
+     * ``XlaDynamicSlice`` (wraps XLA DynamicSlice operator).
+     We use this instead of ``tf.slice`` for reasons explained above for ``XlaGather``.
+     * ``XlaDynamicUpdateSlice`` (wraps XLA DynamicUpdateSlice operator).
+     * ``XlaReduceWindow`` (wraps XLA ReduceWindow operator). These are used
+     for ``lax.reduce_window_sum_p``, ``lax.reduce_window_min_p``,
+     ``lax.reduce_window_max_p``, and ``lax.reduce_window_p``.
+     * ``XlaSort`` (wraps XLA Sort operator).
+
+2.  A small number of JAX primitives are converted only
+    for certain data types, when the required TensorFlow ops are not implemented for some
+    data types on certain devices. There is an
+    [up-to-date list of unimplemented cases](primitives_with_limited_support.md).
+
+3.  Currently, TensorFlow SavedModel does not properly save the ``tf.custom_gradient``.
+    It does save however some attributes that on model restore result in a warning
+    that the model might not be differentiable, and trigger an error if differentiation
+    is attempted. The plan is to fix this. Note that if no gradients are requested,
+    the PreventGradient ops will be saved along with the converted code and will
+    give a nice error if differentiation of the converted code is attempted.
+
+4.  There is currently no support for replicated (e.g. `pmap`) or multi-device
+    (e.g. `sharded_jit`) functions. The collective operations are not yet handled.
+
+5.  The converted code may have slightly different performance characteristics than
+    the original JAX code.
+    If one were to write the same functionality in JAX idiomatic code vs.
+    native TensorFlow idiomatic code we could end up with very different compilation paths,
+    when TensorFlow is used without XLA. Take for example, the case of batch normalization.
+    In TensorFlow if one uses [tf.nn.batch_normalization](https://www.tensorflow.org/api_docs/python/tf/nn/batch_normalization),
+    a “high-level” TensorFlow op for batch
+    normalization is generated, and in the absence of XLA, on CPU or GPU,
+    a custom C++ “high-level” kernel implementing batch normalization is executed.
+    In JAX, there is no primitive for batch normalization, and instead the
+    operation is decomposed into low-level primitives (e.g., [flax.nn.BatchNorm](https://flax.readthedocs.io/en/latest/_autosummary/flax.nn.BatchNorm.html#flax.nn.BatchNorm),
+    or haiku.BatchNorm).
+    Once those primitives are converted to TensorFlow, and the resulting code is
+    run without XLA, the ensemble of the kernels executed will quite
+    possibly behave differently, performance-wise or even numerically,
+    than either the TensorFlow native or JAX native batch normalization.
+    A similar example is that of an LSTM cell.
+
+    Yet another example are the PRNG primitives. JAX programs use a [stateless
+    deterministic PRNG](https://github.com/google/jax/blob/master/design_notes/prng.md)
+    and it has an internal JAX primitive for it.
+    This primitive is at the moment converted to a soup of tf.bitwise operations,
+    which has a clear performance penalty. We plan to look into using the
+    HLO [RNGBitGenerator](https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator)
+
+    (exposed as a TFXLA op), which does implement
+    the same basic Threefry algorithm as JAX’s PRNG, although that would
+    result in different results than JAX’s PRNG.
+
+    We do expect that the performance characteristics of converted code
+    should approximate those of JAX or TensorFlow native with XLA. This is because
+    during conversion we try to generate one TensorFlow op for one JAX primitive.
+    We expect that the lowering that XLA does is similar to that done by JAX
+    before conversion. (This is a hypothesis, we have not verified it extensively.)
+
 
 ### Running on GPU
 

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert
+from .jax2tf import convert, shape_as_value

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -13,26 +13,18 @@
 # limitations under the License.
 """Experimental module transforms JAX functions to be executed by TensorFlow."""
 import functools
-import itertools
 import string
 from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
 
 import jax
-from jax import ad_util
-from jax import api
-from jax import api_util
-from jax import config
-from jax import core
-from jax import custom_derivatives
-from jax import dtypes
+from jax import ad_util, api, api_util, config
+from jax import core, custom_derivatives, dtypes
 from jax import lax_linalg
 from jax import linear_util as lu
 from jax import numpy as jnp
-from jax import random
-from jax import tree_util
-from jax import util
+from jax import random, tree_util, util
 from jax.api_util import flatten_fun
-from jax.interpreters import ad
+from jax.interpreters import ad, batching
 from jax.interpreters import masking
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import pxla
@@ -41,6 +33,7 @@ from jax._src.lax import lax
 from jax._src.lax import control_flow as lax_control_flow
 from jax._src.lax import fft as lax_fft
 from jax._src.lax import parallel as lax_parallel
+from jax.lib import xla_bridge as xb
 
 import numpy as np
 import tensorflow as tf  # type: ignore[import]
@@ -238,22 +231,29 @@ def convert(fun: Callable, *,
                        in_shapes=vjp_in_shapes)(args, out_cts)
       return in_cts
 
-    if with_gradient:
-      @tf.custom_gradient
-      def converted_fun_flat_with_custom_gradient(*args_flat: TfVal) -> TfVal:
-        out_with_avals = _interpret_fun(flat_fun, args_flat, args_avals_flat)
-        outs, out_avals = util.unzip2(out_with_avals)
-        return (tuple(outs),
-                functools.partial(converted_grad_fn, _out_cts_avals=tuple(out_avals)))
+    try:
+      global _shape_env
+      assert not _shape_env, f"Unexpected shape environment {_shape_env}"
+      _shape_env = _make_shape_env(args_avals_flat, args_flat)
 
-      out_flat = converted_fun_flat_with_custom_gradient(*args_flat)
-    else:
-      out_flat_raw = _interpret_fun(flat_fun, args_flat, args_avals_flat)
-      message = ("The jax2tf-converted function does not support gradients. "
-                 "Use `with_gradient` parameter to enable gradients")
-      # We use PreventGradient, which is propagated through a SavedModel.
-      out_flat = [tf.raw_ops.PreventGradient(input=o, message=message)
-                  for o, _ in out_flat_raw]
+      if with_gradient:
+        @tf.custom_gradient
+        def converted_fun_flat_with_custom_gradient(*args_flat: TfVal) -> TfVal:
+          out_with_avals = _interpret_fun(flat_fun, args_flat, args_avals_flat)
+          outs, out_avals = util.unzip2(out_with_avals)
+          return (tuple(outs),
+                  functools.partial(converted_grad_fn, _out_cts_avals=tuple(out_avals)))
+
+        out_flat = converted_fun_flat_with_custom_gradient(*args_flat)
+      else:
+        out_flat_raw = _interpret_fun(flat_fun, args_flat, args_avals_flat)
+        message = ("The jax2tf-converted function does not support gradients. "
+                   "Use `with_gradient` parameter to enable gradients")
+        # We use PreventGradient, which is propagated through a SavedModel.
+        out_flat = [tf.raw_ops.PreventGradient(input=o, message=message)
+                    for o, _ in out_flat_raw]
+    finally:
+      _shape_env = {}
 
     out = tree_util.tree_unflatten(out_tree_thunk(), out_flat)
     return out
@@ -328,7 +328,9 @@ def _interpret_jaxpr(jaxpr: core.ClosedJaxpr, *args: TfVal) -> Sequence[TfVal]:
 
 ### tracer
 
-def _poly_dim_to_tf_dim(dim: Union[int, masking.Poly]) -> Optional[int]:
+PolyDim = Union[int, masking.Poly]  # A polymorphic shape dimension
+
+def _poly_dim_to_tf_dim(dim: PolyDim) -> Optional[int]:
   if isinstance(dim, int):
     return dim
   elif dim.is_constant:
@@ -358,20 +360,16 @@ def _tfval_shape_dtype(val: TfVal) -> Tuple[Sequence[Optional[int]], DType]:
 
 def _input_avals(args: Sequence[TfVal], in_shapes: Sequence[Optional[str]]) -> Sequence[core.AbstractValue]:
   """Abstract values for the input arguments."""
-  shape_var_id_gen = itertools.count(0)
 
   def input_aval(arg: TfVal, in_shape: Optional[str]) -> core.AbstractValue:
     """The abstract value for an input."""
     raw_shape, dtype = _tfval_shape_dtype(arg)
 
-    def next_shape_var():
-      return f"s{next(shape_var_id_gen)}"
-
     if in_shape is None:
       if any(d is None for d in raw_shape):
-        # Generate fresh shape vars based on the the input spec
-        in_shape = "(" + ",".join(next_shape_var()
-                                  if d is None else str(d) for d in raw_shape) + ")"
+        msg = ("in_shape must be specified when the argument "
+               f"shape {raw_shape} is partially known.")
+        raise TypeError(msg)
       else:
         return core.ShapedArray(raw_shape, dtype)
 
@@ -390,16 +388,180 @@ def _input_avals(args: Sequence[TfVal], in_shapes: Sequence[Optional[str]]) -> S
 
     for dim_idx, (s, raw_s) in enumerate(util.safe_zip(shape, raw_shape)):
       s_int: Optional[int] = _poly_dim_to_tf_dim(s)
-      if s_int != raw_s:
-        if (raw_s is None or s_int is not None):
-          msg = (f"in_shape {in_shape} (resolved to {shape}) does not match "
-                 f"argument shape {raw_shape} in dimension {dim_idx}")
-          raise TypeError(msg)
+      if s_int != raw_s and s_int is not None:
+        msg = (f"in_shape {in_shape} (resolved to {shape}) does not match "
+               f"argument shape {raw_shape} in dimension {dim_idx}")
+        raise TypeError(msg)
 
     return core.ShapedArray(shape, dtype)
 
   return tuple(map(input_aval, args, in_shapes))
 
+# A shape environment maps shape variables to TfVal.
+ShapeEnv = Dict[str, TfVal]
+_shape_env = {}  # type: ShapeEnv
+
+def _eval_shape(shape: Sequence[PolyDim]) -> Sequence[TfVal]:
+  return masking.eval_poly_shape(shape, _shape_env)
+
+# Extracting a shape environment by solving the shape variables.
+# The shape environment will be derived by using `tf.shape` from the
+# dynamic shape of arguments, not their static shape.
+def _make_shape_env(args_avals: Sequence[core.AbstractValue],
+                    args: Sequence[TfVal]) -> Dict[str, TfVal]:
+  eqns = [(p, tf.shape(a)[i])
+          for a_aval, a in util.safe_zip(args_avals, args)
+          for i, p in enumerate(a_aval.shape)]
+  return _solve_shape_vars(eqns)
+
+ShapeEqn = Tuple[PolyDim, TfVal]
+def _solve_shape_vars(eqns: Sequence[ShapeEqn]) -> Dict[str, TfVal]:
+  """Solves a number of equations "poly = tfval" into an shape environment."""
+  # A simple variable elimination algorithm for now
+  solved: Dict[str, TfVal] = {}  # Already solved vars
+
+  def simplify_poly(p: PolyDim) -> Optional[Union[TfVal,
+                                                  Tuple[str, TfVal, TfVal]]]:
+    # Simplifies polynomial given `solved`
+    # Returns (v, f, rest) such that p = v * f + rest, or
+    #         rest such that p = rest, or None
+    v = None
+    f = None
+    rest = []
+    if isinstance(p, int):
+      return tf.constant(p)
+    for m, m_factor in p.items():
+      simpl_m: Union[str, TfVal] = simplify_mon(m, p)
+      if isinstance(simpl_m, str):  # A var
+        if v is not None:
+          return None
+        v = simpl_m
+        f = m_factor
+      else:  # A value
+        rest.append(tf.math.multiply(simpl_m, m_factor))
+    rest_val = functools.reduce(tf.math.add, rest, tf.constant(0))
+    return rest_val if v is None else (v, f, rest_val)
+
+  def simplify_mon(m: masking.Mon, in_poly: masking.Poly) -> Union[str, TfVal]:
+    # Simplifies monomial given `solved`
+    # Returns either a variable, or a solved value
+    if not m:
+      return tf.constant(1)
+    if m.degree > 1:
+      msg = ("only linear polynomials are supported as input shape "
+             f"specifications. Found '{m}' in '{in_poly}'.")
+      raise TypeError(msg)
+    var = list(m.keys())[0]
+    return solved.get(var, var)
+
+  remaining = eqns
+  while remaining:
+    new_remaining = []
+    for eqn in remaining:
+      eq_p, eq_val = eqn
+      p_simpl = simplify_poly(eq_p)
+      if p_simpl is None:
+        new_remaining.append(eqn)
+        continue
+      if not isinstance(p_simpl, tuple):
+        # TODO: add an assertion rest == eq_v
+        continue
+      var, factor, rest = p_simpl
+      # p = var * factor + rest
+      # TODO: add an assertion eq_v >= rest and (eq_v - rest) mod factor == 0
+      solved[var] = tf.math.floordiv(tf.math.subtract(eq_val, rest), factor)
+
+    if len(new_remaining) < len(remaining):
+      remaining = new_remaining
+    else:
+      msg = "Cannot solve"
+      raise ValueError(msg)
+
+  return solved
+
+
+def shape_as_value(x):
+  """Injects the shape of `x` as an array value.
+
+  **Experimental: please give feedback, and expect changes!**
+
+  This allows the use of a shape expression as array argument to JAX functions.
+  A typical example is for implementing a mean operation:
+
+     jnp.sum(x) / np.prod(jax2tf.shape_as_value(x))
+  """
+  return shape_as_value_p.bind(x)
+
+# TODO: move this to masking or to some common library, if approved
+shape_as_value_p = core.Primitive("shape_as_value")
+shape_as_value_p.multiple_results = True
+def _shape_as_value_impl(x):
+  x_shape = np.shape(x)
+  def dim_to_int(dim: PolyDim) -> int:
+    dim_int = _poly_dim_to_tf_dim(dim)
+    if dim_int is None:
+      msg = ("shape_as_value is not implemented for non-constant shapes "
+             "except for masking and jax2tf. "
+             f"Has shape: {x_shape}")
+      raise TypeError(msg)
+    else:
+      return dim_int
+  return tuple(map(dim_to_int, x_shape))
+
+shape_as_value_p.def_impl(_shape_as_value_impl)
+
+def _shape_as_value_abstract(x_aval: core.AbstractValue) -> Sequence[core.AbstractValue]:
+  rank = len(x_aval.shape)  # type: ignore[attr-defined]
+  return (core.ShapedArray((), dtypes.canonicalize_dtype(np.int_), weak_type=True),) * rank
+
+shape_as_value_p.def_abstract_eval(_shape_as_value_abstract)
+
+def _shape_as_value_translation(comp, x):
+  return xla_client._xla.ops.Tuple(comp,
+                                   tuple(xb.constant(comp, d)
+                                         for d in comp.GetShape(x).dimensions()))
+
+xla.translations[shape_as_value_p] = _shape_as_value_translation
+
+def _shape_as_value_jvp_rule(primals, tangents):
+  # The shape does not depend on the contents of the input
+  x, = primals
+  zero = ad.Zero.from_value(0.)
+  return shape_as_value(x), (zero,) * len(x.shape)
+
+ad.primitive_jvps[shape_as_value_p] = _shape_as_value_jvp_rule
+
+def _shape_as_value__batching_rule(batched_args, batch_dims):
+  xv, = batched_args
+  batch_dim, = batch_dims
+  batch_size = xv.shape[batch_dim]
+  batched_shape = shape_as_value(xv)
+  one_shape = batched_shape[0:batch_dim] + batched_shape[batch_dim+1:]
+  res = tuple(jnp.broadcast_to(d, (batch_size, 1)) for d in one_shape)
+  return res, (0,) * len(one_shape)
+
+batching.primitive_batchers[shape_as_value_p] = _shape_as_value__batching_rule
+
+def _shape_as_value_masking_rule(operands, operands_logical_shapes):
+  x_logical_shape, = operands_logical_shapes
+  return tuple(x_logical_shape)
+
+masking.masking_rules[shape_as_value_p] = _shape_as_value_masking_rule
+
+def _shape_as_value_tf(x: TfVal,
+                       _in_avals: Sequence[core.AbstractValue],
+                       _out_aval: core.AbstractValue) -> TfVal:
+  x_aval = _in_avals[0]
+  def dim_to_tfval(dim: PolyDim, dim_idx: int) -> TfVal:
+    dim_int = _poly_dim_to_tf_dim(dim)
+    if dim_int is not None:
+      return tf.convert_to_tensor(dim_int)
+    else:
+      return tf.shape(x)[dim_idx]
+  return tuple(dim_to_tfval(dim, dim_idx)
+               for dim_idx, dim in enumerate(x_aval.shape))  # type: ignore[attr-defined]
+
+tf_impl_with_avals[shape_as_value_p] = _shape_as_value_tf
 
 # TODO(b/26854495): pylint doesn't understand slots and inheritance.
 # pylint: disable=assigning-non-slot
@@ -433,14 +595,29 @@ class TensorFlowTracer(core.Tracer):
     elif isinstance(val, (tf.Tensor, tf.Variable)):
       val_shape, val_dtype = _tfval_shape_dtype(val)
       aval_dtype = np.dtype(self._aval.dtype)  # type: ignore[attr-defined]
-      if val_dtype != aval_dtype and dtypes.canonicalize_dtype(val_dtype) == aval_dtype:
+      if val_dtype != aval_dtype and (val_dtype == tf.int32 and aval_dtype == jnp.int64 or
+                                      val_dtype == tf.int64 and aval_dtype == jnp.int32 or
+                                      val_dtype == tf.float32 and aval_dtype == jnp.float64 or
+                                      val_dtype == tf.float64 and aval_dtype == jnp.float32):
         # We expect that x64 values are turned into x32
         val = tf.cast(val, dtype=aval_dtype)
         val_dtype = aval_dtype
 
       if not core.skip_checks:
         assert aval_dtype == val_dtype, f"expected {aval_dtype} == {val_dtype}"
-        assert _aval_to_tf_shape(self._aval) == val_shape, f"expected {_aval_to_tf_shape(self._aval)} == {val_shape}"
+        for aval_dim, val_dim in util.safe_zip(self._aval.shape, val_shape):  # type: ignore[attr-defined]
+          if val_dim is None:
+            assert isinstance(aval_dim, masking.Poly), f"expected {self._aval.shape} == {val_shape}"  # type: ignore[attr-defined]
+          elif not isinstance(aval_dim, masking.Poly):
+            assert aval_dim == val_dim, f"expected {self._aval.shape} == {val_shape}"  # type: ignore[attr-defined]
+          else:
+            # We have a TF value with known shape, and the abstract shape is a polynomial
+            # As an extra check, verify the value if the shape env are only constants
+            try:
+              aval_int = int(masking.eval_poly(aval_dim, _shape_env))
+            except TypeError:
+              continue
+            assert aval_int == val_dim, f"expected {self._aval.shape} == {val_shape}. Found {aval_int} != {val_dim}."  # type: ignore
 
       self.val = val
     else:  # Must be a numeric value
@@ -696,12 +873,12 @@ tf_impl[lax.mul_p] = tf.math.multiply
 
 
 def _iota(*, dtype, shape, dimension):
-  size = shape[dimension]
-  # Some dtypes are unsupporetd, like uint32, so we just fall back to int32.
+  # Some dtypes are unsupported, like uint32, so we just fall back to int32.
   # TODO(mattjj, necula): improve tf.range dtype handling
-  vec = tf.range(tf.cast(size, tf.int32), dtype=tf.int32)
+  shape_tf = _eval_shape(shape)
+  vec = tf.range(tf.cast(shape_tf[dimension], tf.int32), dtype=tf.int32)
   vec_shape = [-1 if i == dimension else 1 for i in range(len(shape))]
-  return tf.cast(tf.broadcast_to(tf.reshape(vec, vec_shape), shape), dtype)
+  return tf.cast(tf.broadcast_to(tf.reshape(vec, vec_shape), shape_tf), dtype)
 
 tf_impl[lax.iota_p] = _iota
 
@@ -1140,33 +1317,37 @@ def _dot_general(lhs, rhs, dimension_numbers, precision):
 tf_impl[lax.dot_general_p] = _dot_general
 
 
-def _broadcast(operand, sizes):
+def _broadcast(operand, *, sizes):
   return tf.broadcast_to(operand, sizes + tf.shape(operand))
 tf_impl[lax.broadcast_p] = _broadcast
 
 
-def _broadcast_in_dim(operand, shape, broadcast_dimensions):
+def _broadcast_in_dim(operand, *, shape, broadcast_dimensions):
   inshape = tuple(1 if i not in broadcast_dimensions else d
                   for i, d in enumerate(shape))
-  return tf.broadcast_to(tf.reshape(operand, inshape), shape)
+  inshape_tf = _eval_shape(inshape)
+  shape_tf = _eval_shape(shape)
+  return tf.broadcast_to(tf.reshape(operand, inshape_tf), shape_tf)
 tf_impl[lax.broadcast_in_dim_p] = _broadcast_in_dim
 
 
-def _reshape(operand, new_sizes, dimensions):
+def _reshape(operand, *, new_sizes, dimensions):
   if dimensions is None:
     dimensions = tf.range(tf.rank(operand))
-  return tf.reshape(tf.transpose(operand, dimensions), new_sizes)
+  new_sizes_tf = _eval_shape(new_sizes)
+  return tf.reshape(tf.transpose(operand, dimensions), new_sizes_tf)
 tf_impl[lax.reshape_p] = _reshape
 
 
-def _squeeze(operand, dimensions):
-  op_shape = _get_shape_from_tensor_or_array(operand)
+def _squeeze(operand, *, dimensions, _in_avals, _out_aval):
+  op_shape = _in_avals[0].shape
   new_shape = tuple(d for i, d in enumerate(op_shape) if i not in dimensions)
-  return tf.reshape(operand, new_shape)
-tf_impl[lax.squeeze_p] = _squeeze
+  new_shape_tf = _eval_shape(new_shape)
+  return tf.reshape(operand, new_shape_tf)
+tf_impl_with_avals[lax.squeeze_p] = _squeeze
 
 
-def _pad(operand, padding_value, padding_config,
+def _pad(operand, padding_value, *, padding_config,
          _in_avals: Sequence[core.AbstractValue],
          _out_aval: core.AbstractValue):
   del _in_avals
@@ -1181,7 +1362,7 @@ def _pad(operand, padding_value, padding_config,
 tf_impl_with_avals[lax.pad_p] = _pad
 
 
-def _rev(operand, dimensions):
+def _rev(operand, *, dimensions):
   return tf.reverse(operand, dimensions)
 tf_impl[lax.rev_p] = _rev
 
@@ -1534,7 +1715,8 @@ def _gather(operand, start_indices, *, dimension_numbers, slice_sizes,
   """Tensorflow implementation of gather."""
   del _in_avals
   proto = _gather_dimensions_proto(start_indices.shape, dimension_numbers)
-  out = tfxla.gather(operand, start_indices, proto, slice_sizes, False)
+  slice_sizes_tf = _eval_shape(slice_sizes)
+  out = tfxla.gather(operand, start_indices, proto, slice_sizes_tf, False)
   out.set_shape(_aval_to_tf_shape(_out_aval))
   return out
 tf_impl_with_avals[lax.gather_p] = _gather
@@ -1672,8 +1854,9 @@ def _batched_cond_while(*args: TfVal,
                                                   *body_consts, *carry)
 
     def select_one_carry(new_c: TfVal, c: TfVal) -> TfVal:
-      pred_b_bcast = _broadcast_in_dim(pred_b, new_c.shape,
-                                       list(range(len(pred_b.shape))))
+      pred_b_bcast = _broadcast_in_dim(pred_b,
+                                       shape=new_c.shape,
+                                       broadcast_dimensions=list(range(len(pred_b.shape))))
       return tf.where(pred_b_bcast, new_c, c)
 
     selected_carry: Sequence[TfVal] = list(

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -229,7 +229,7 @@ class Poly(dict):
     return str(self)
 
   def __int__(self):
-    assert self.is_constant
+    assert self.is_constant, f"casting polynomial '{self}' to integer"
     return op.index(next(iter(self.values())))
 
   def evaluate(self, env):


### PR DESCRIPTION
Allow shape variables in the primitive parameters, e.g., the
shape parameter for the reshape primitive. More details
are in the updated README.md.

This is another attempt at #4597 which we had to rollback.