### PR TITLE
Upstream implementation of named_call_p primitive to JAX

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2449,6 +2449,24 @@ ad.defjvp2(min_p,
            lambda g, ans, x, y: mul(_brcast(g, y), _balanced_eq(x, ans, y)),
            lambda g, ans, x, y: mul(_brcast(g, x), _balanced_eq(y, ans, x)))
 
+named_call_p = core.CallPrimitive('named_call')
+named_call_p.def_impl(core.call_impl)
+ad.primitive_transposes[named_call_p] = functools.partial(ad.call_transpose,
+                                                         named_call_p)
+
+
+def _named_call_translation_rule(c, axis_env, in_nodes, name_stack,
+                                 *, name='core_call', backend, call_jaxpr):
+  subc = xla.xb.make_computation_builder(name)
+  args = [xla.xb.parameter(subc, i, c.GetShape(n))
+          for i, n in enumerate(in_nodes)]
+  out_nodes = xla.jaxpr_subcomp(subc, call_jaxpr, backend, axis_env, (),
+                                jax.util.extend_name_stack(name_stack, name),
+                                *args)
+  subc = subc.Build(xla.xops.Tuple(subc, out_nodes))
+  return xla.xops.Call(c, subc, list(in_nodes))
+
+xla.call_translations[named_call_p] = _named_call_translation_rule
 
 shift_left_p = standard_naryop([_int, _int], 'shift_left')
 ad.defjvp_zero(shift_left_p)

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -168,6 +168,7 @@ from jax._src.lax.lax import (
   min_p,
   mul,
   mul_p,
+  named_call_p,
   naryop,
   naryop_dtype_rule,
   ne,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2246,7 +2246,7 @@ class LaxTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.jaxpr.eqns, 2)
 
   def test_named_call(self):
-
+    # TODO(qiuminxu) Make named_call a public function in lax. 
     def named_call(f, name):
       def named_f(*args):
         f_ = jax.linear_util.wrap_init(lambda: (f(*args),))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2245,6 +2245,25 @@ class LaxTest(jtu.JaxTestCase):
                                              (x,), (1.,)))(1.)
     self.assertLen(jaxpr.jaxpr.eqns, 2)
 
+  def test_named_call(self):
+
+    def named_call(f, name):
+      def named_f(*args):
+        f_ = jax.linear_util.wrap_init(lambda: (f(*args),))
+        out, = lax.named_call_p.bind(f_, name=name)
+        return out
+      return named_f
+
+    def square(x):
+      return x ** 2
+
+    @jax.jit
+    def f(x):
+      return named_call(square, 'name_for_testing')(x)
+
+    c = jax.xla_computation(f)(2)
+    self.assertIn('name_for_testing', c.as_hlo_text())
+
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2246,7 +2246,7 @@ class LaxTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.jaxpr.eqns, 2)
 
   def test_named_call(self):
-    # TODO(qiuminxu) Make named_call a public function in lax. 
+    # TODO(qiuminxu) Make named_call a public function in lax
     def named_call(f, name):
       def named_f(*args):
         f_ = jax.linear_util.wrap_init(lambda: (f(*args),))


### PR DESCRIPTION
Upstream the implementation of named_call to JAX (there are equivalent implementations in Haiku and Flax).

https://github.com/google/jax/issues/4558

Reference:
Flax implementation:
https://github.com/google/flax/blob/master/flax/core/named_call.py

Haiku implementation:
https://github.com/deepmind/dm-haiku/blob/master/haiku/_src/named_call.py