### PR TITLE
Switch to declarative weak dtype promotion rules.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -997,7 +997,7 @@ class DynamicJaxprTrace(core.Trace):
     return tracer
 
   def new_const(self, val):
-    aval = raise_to_shaped(get_aval(val), weak_type=dtypes.is_python_scalar(val))
+    aval = raise_to_shaped(get_aval(val), weak_type=dtypes.is_weakly_typed(val))
     tracer = DynamicJaxprTracer(self, aval, source_info_util.current())
     self.frame.tracers.append(tracer)
     var = self.frame.tracer_to_var[id(tracer)] = self.getconstvar(val)

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -250,7 +250,7 @@ class TestPromotionTables(jtu.JaxTestCase):
 
     def val_to_typecode(val):
       dtype = dtypes.result_type(val)
-      weak_type = dtypes.is_python_scalar(val)
+      weak_type = dtypes.is_weakly_typed(val)
       typecode = dtype_to_typecode[dtype]
       if weak_type:
         typecode = typecode[:-1] + '*'


### PR DESCRIPTION
This changes our handling of weak types in type promotion from a procedural approach to a declarative approach.

I constructed the type promotion table so as to have no change to the existing promotion behavior, as confirmed by the test added in #4731

We plan to make some changes to weak dtype promotion behavior going forward, and this will make it easier to specify the precise behavior we want JAX to have.