### PR TITLE
[jax2tf] Reduce number of tests for top_k.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -452,39 +452,30 @@ lax_pad = tuple(
   ]
 )
 
-lax_top_k = tuple( # random testing
-  Harness(f"_inshape={jtu.format_shape_dtype_string(shape, dtype)}_k={k}",
-          lax.top_k,
-          [RandArg(shape, dtype), StaticArg(k)],
-          shape=shape,
-          dtype=dtype,
-          k=k)
+def _make_top_k_harness(name, *, operand=None, shape=(5, 3), dtype=np.float32,
+                        k=2):
+  if operand is None:
+    operand = RandArg(shape, dtype)
+  return Harness(f"{name}_inshape={jtu.format_shape_dtype_string(operand.shape, operand.dtype)}_k={k}",
+                 lax.top_k,
+                 [operand, StaticArg(k)],
+                 shape=operand.shape,
+                 dtype=operand.dtype,
+                 k=k)
+
+lax_top_k = tuple( # Validate dtypes
+  _make_top_k_harness("dtypes", dtype=dtype)
   for dtype in jtu.dtypes.all
-  for shape in [(3,), (5, 3)]
-  for k in [-1, 1, 3, 4]
-  for rng_factory in [jtu.rand_default]
-) + tuple( # stability test
-  Harness(f"stability_inshape={jtu.format_shape_dtype_string(arr.shape, arr.dtype)}_k={k}",
-          lax.top_k,
-          [arr, StaticArg(k)],
-          shape=arr.shape,
-          dtype=arr.dtype,
-          k=k)
-  for arr in [
-      np.array([5, 7, 5, 8, 8, 5], dtype=np.int32)
+) + tuple( # Validate k
+  _make_top_k_harness("k", k=k)
+  for k in [-2]
+) + tuple( # Validate implicit properties of the sort
+  _make_top_k_harness(name, operand=operand, k=k)
+  for name, operand, k in [
+      ("stability", np.array([5, 7, 5, 8, 8, 5], dtype=np.int32), 3),
+      ("sort_inf_nan", np.array([+np.inf, np.nan, -np.nan, -np.inf, 3],
+                                dtype=np.float32), 5)
   ]
-  for k in [1, 3, 6]
-) + tuple( # nan/inf sorting test
-  Harness(f"nan_inshape={jtu.format_shape_dtype_string(arr.shape, arr.dtype)}_k={k}",
-          lax.top_k,
-          [arr, StaticArg(k)],
-          shape=arr.shape,
-          dtype=arr.dtype,
-          k=k)
-  for arr in [
-      np.array([+np.inf, np.nan, -np.nan, np.nan, -np.inf, 3], dtype=np.float32)
-  ]
-  for k in [1, 3, 6]
 )
 
 lax_sort = tuple( # one array, random data, all axes, all dtypes


### PR DESCRIPTION
Reduces the number of tests from 126 to 18. Also edited the code in `primitives_test` to handle mismatching cases more gracefully.