### PR TITLE
Update weak dtype promotion rules

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -23,6 +23,16 @@ jax 0.2.6 (Unreleased)
   * Raise an error on non-hashable static arguments for jax.jit and
     xla_computation.  See `https://github.com/google/jax/commit/cb48f42`_.
 
+  * Improve consistency of type promotion behavior (#4744):
+    * Adding a complex Python scalar to a JAX floating point number respects the precision of
+      the JAX float. For example, ``jnp.float32(1) + 1j`` now returns ``complex64``, where previously
+      it returned ``complex128``.
+    * Results of type promotion with 3 or more terms involving uint64, a signed int, and a third type
+      are now independent of the order of arguments. For example:
+      ``jnp.result_type(jnp.uint64, jnp.int64, jnp.float16)`` and
+      ``jnp.result_type(jnp.float16, jnp.uint64, jnp.int64)`` both return ``float16``, where previously
+      the first returned ``float64`` and the second returned ``float16``.
+
 jaxlib 0.1.57 (unreleased)
 ------------------------------
 * Fixed a bug where the hash of bfloat16 values was not correctly initialized

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -202,27 +202,29 @@ _jax_type_nums = {t: i for i, t in enumerate(_jax_types)}
 
 
 def _make_type_promotion_table():
-  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s_, f_, c_ = _jax_types
-  #  b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s*, f*, c*
+  # Note: this promotion table is generated via the least upper bounds over a type
+  # promotion lattice. See testPromotionTableLattice for details of this.
+  b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_ = _jax_types
+  #  b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, s*, f*, c*
   return np.array([
-    [b1, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s8, f8, c8],  # b1
-    [u1, u1, u2, u4, u8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8, u1, f8, c8],  # u1
-    [u2, u2, u2, u4, u8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8, u2, f8, c8],  # u2
-    [u4, u4, u4, u4, u8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8, u4, f8, c8],  # u4
-    [u8, u8, u8, u8, u8, f8, f8, f8, f8, bf, f2, f4, f8, c4, c8, u8, f8, c8],  # u8
-    [s1, s2, s4, s8, f8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s1, f8, c8],  # s1
-    [s2, s2, s4, s8, f8, s2, s2, s4, s8, bf, f2, f4, f8, c4, c8, s2, f8, c8],  # s2
-    [s4, s4, s4, s8, f8, s4, s4, s4, s8, bf, f2, f4, f8, c4, c8, s4, f8, c8],  # s4
-    [s8, s8, s8, s8, f8, s8, s8, s8, s8, bf, f2, f4, f8, c4, c8, s8, f8, c8],  # s8
-    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8, bf, bf, c8],  # bf
-    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8, f2, f2, c8],  # f2
-    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8, f4, f4, c8],  # f4
+    [b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # b1
+    [u1, u1, u2, u4, u8, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, u1, f_, c_],  # u1
+    [u2, u2, u2, u4, u8, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, u2, f_, c_],  # u2
+    [u4, u4, u4, u4, u8, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, u4, f_, c_],  # u4
+    [u8, u8, u8, u8, u8, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, u8, f_, c_],  # u8
+    [i1, i2, i4, i8, f_, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i1, f_, c_],  # i1
+    [i2, i2, i4, i8, f_, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, i2, f_, c_],  # i2
+    [i4, i4, i4, i8, f_, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, i4, f_, c_],  # i4
+    [i8, i8, i8, i8, f_, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, i8, f_, c_],  # i8
+    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8, bf, bf, c4],  # bf
+    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8, f2, f2, c4],  # f2
+    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8, f4, f4, c4],  # f4
     [f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, f8, f8, c8],  # f8
     [c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c8, c4, c8, c4, c4, c4],  # c4
     [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8],  # c8
-    [s8, u1, u2, u4, u8, s1, s2, s4, s8, bf, f2, f4, f8, c4, c8, s_, f_, c_],  # s*
-    [f8, f8, f8, f8, f8, f8, f8, f8, f8, bf, f2, f4, f8, c4, c8, f_, f_, c_],  # f*
-    [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c4, c8, c_, c_, c_],  # c*
+    [i_, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # s*
+    [f_, f_, f_, f_, f_, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, f_, f_, c_],  # f*
+    [c_, c_, c_, c_, c_, c_, c_, c_, c_, c4, c4, c4, c8, c4, c8, c_, c_, c_],  # c*
   ])
 
 _type_promotion_table = _make_type_promotion_table()

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -182,11 +182,11 @@ class DtypesTest(jtu.JaxTestCase):
 
 class TestPromotionTables(jtu.JaxTestCase):
 
-  def testWeakDtypesPromotionTable(self):
+  def testObservedPromotionTable(self):
     """Test that the weak & strong dtype promotion table does not change over time."""
     # Note: * here refers to weakly-typed values
     typecodes = \
-      ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
+        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
     if FLAGS.jax_enable_x64:
       expected = [
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
@@ -198,15 +198,15 @@ class TestPromotionTables(jtu.JaxTestCase):
         ['i2','i2','i4','i8','f8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f8','c8'],
         ['i4','i4','i4','i8','f8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f8','c8'],
         ['i8','i8','i8','i8','f8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
-        ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c8'],
-        ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c8'],
-        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c8'],
+        ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c4'],
+        ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c4'],
+        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c4'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','c8','c8','f8','f8','c8'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c8','c4','c8','c4','c4','c4'],
         ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8'],
         ['i8','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
-        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c8','c*','c*','c*'],
+        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
       ]
     else:
       expected = [
@@ -268,6 +268,48 @@ class TestPromotionTables(jtu.JaxTestCase):
       return diffs
 
     self.assertEqual(table, expected, show_differences(expected, table))
+
+  def testPromotionTableLattice(self):
+    """
+    Test that the promotion table can be generated from the least upper bound
+    of a type promotion lattice.
+    """
+    nodes = dtypes._jax_types
+    b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_ = nodes
+
+    # Specify the generating lattice for the promotion table.
+    lattice = {
+      b1: [i_],
+      u1: [i2, u2], u2: [i4, u4], u4: [i8, u8], u8: [f_],
+      i_: [u1, i1], i1: [i2], i2: [i4], i4: [i8], i8: [f_],
+      f_: [bf, f2, c_], bf: [f4], f2: [f4], f4: [f8, c4], f8: [c8],
+      c_: [c4], c4: [c8], c8: [],
+    }
+
+    # Compute all upper bounds of each node.
+    upper_bounds = {node: {node} for node in nodes}
+    for n in nodes:
+      while True:
+        new_upper_bounds = set().union(*(lattice[b] for b in upper_bounds[n]))
+        if n in new_upper_bounds:
+          raise ValueError(f"cycle detected for {n}")
+        if not new_upper_bounds.difference(upper_bounds[n]):
+          break
+        upper_bounds[n] |= new_upper_bounds
+
+    # Function to find the least upper bound of a set of nodes.
+    def least_upper_bound(nodes):
+      common_upper_bounds = set.intersection(*(upper_bounds[n] for n in nodes))
+      least_upper_bounds = common_upper_bounds - set.union(*(upper_bounds[n] - {n}
+                                                             for n in common_upper_bounds))
+      if len(least_upper_bounds) == 1:
+        return least_upper_bounds.pop()
+      else:
+        raise ValueError(f"{nodes} do not have a unique least upper bound.")
+
+    # Table of least upper bounds should equal the type promotion table.
+    lub_table = np.array([[least_upper_bound({n, m}) for n in nodes] for m in nodes])
+    self.assertArraysEqual(lub_table, dtypes._type_promotion_table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates JAX's type promotion table in preparation for a more systematic handling of weak dtypes. The updated promotion table is generated via least upper bounds of the following type promotion lattice, where `*` indicates weakly-typed values:
![lattice](https://user-images.githubusercontent.com/781659/97781249-3a51cf00-1b47-11eb-9ecd-b7dc556e48f8.png)

Introducing this lattice leads to two types of user-visible changes: first is the promotion of strongly-typed floats with weakly-typed complex values in x64 mode:

*Before:*
```python
>>> jnp.float32(1) + 1j
DeviceArray(1.+1.j, dtype=complex128)
```
*After:*
```python
>>> jnp.float32(1) + 1j
DeviceArray(1.+1.j, dtype=complex64)
```
The precision of the strongly-typed float now dictates the precision of the output.

Secondly is the promotion of `uint64` with signed integers, which currently results in a strongly-typed float64, will now result in a weakly-typed float. Because the weak float is backed by a float64, this doesn't actually change the resulting promotion behavior for two values (i.e. `result_type(uint64, int16)` is still `float64` as before), but it does ensure associativity of promotion in the presence of more than two values; for example:

*Before:*
```python
>>> a, b, c = jnp.uint64(1), jnp.int16(1), jnp.float16(1)
>>> jnp.result_type(a, b, c)
dtype('float64')
>>> jnp.result_type(c, a, b)
dtype('float16')
```

*After:*
```python
>>> a, b, c = jnp.uint64(1), jnp.int16(1), jnp.float16(1)
>>> jnp.result_type(a, b, c)
dtype('float16')
>>> jnp.result_type(c, a, b)
dtype('float16')
```

Note that weak types still do not propagate through lax operations (there is an outstanding TODO for that, and it will take care to implement well), so the promotion test tables still show strongly-typed equivalents for all expected outputs.