### PR TITLE
[jax2tf] Fix and trim FFT conversion test.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -170,8 +170,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                                   "only 1D FFT is currently supported."):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
     else:
+      tol = None if jtu.device_under_test() == "tpu" else 1e-3
       self.ConvertAndCompare(harness.dyn_fun,
-                             *harness.dyn_args_maker(self.rng()))
+                             *harness.dyn_args_maker(self.rng()),
+                             atol=tol, rtol=tol)
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_cholesky)
   def test_cholesky(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -170,15 +170,8 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                                   "only 1D FFT is currently supported."):
         harness.dyn_fun(*harness.dyn_args_maker(self.rng()))
     else:
-      tol = None
-      if jtu.device_under_test() in ("cpu", "gpu"):
-        if harness.params["dtype"] in jtu.dtypes.boolean:
-          tol = 0.01
-        else:
-          tol = 1e-3
       self.ConvertAndCompare(harness.dyn_fun,
-                             *harness.dyn_args_maker(self.rng()),
-                             atol=tol, rtol=tol)
+                             *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_linalg_cholesky)
   def test_cholesky(self, harness: primitive_harness.Harness):


### PR DESCRIPTION
It turns out that most of the tests in the `"dtypes"` harnesses were useless, as [lax.fft promotes the dtypes as needed to pass them to lax.fft_p](https://github.com/google/jax/blob/f58f1ee4563852de2853115d885c2eec7a69a77b/jax/_src/lax/fft.py#L55:L66). Passing arrays with other dtypes to `lax.fft_p` results in `RuntimeError`s, similarly to the cases outlined in #4734.