### PR TITLE
Cleanup outdated jaxlib TODOs in jax/_src/lax/fft.py

### DIFF
--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -23,7 +23,6 @@ from jax.core import Primitive
 from jax.interpreters import xla
 from jax.util import prod
 from jax import dtypes, lax
-from jax import lib
 from jax.lib import xla_client
 from jax.interpreters import ad
 from jax.interpreters import batching
@@ -38,18 +37,10 @@ __all__ = [
 
 def _promote_to_complex(arg):
   dtype = dtypes.result_type(arg, np.complex64)
-  # XLA's FFT op only supports C64 in jaxlib versions 0.1.47 and earlier.
-  # TODO(phawkins): remove when minimum jaxlib version is 0.1.48 or newer.
-  if lib.version <= (0, 1, 47) and dtype == np.complex128:
-    dtype = np.complex64
   return lax.convert_element_type(arg, dtype)
 
 def _promote_to_real(arg):
   dtype = dtypes.result_type(arg, np.float32)
-  # XLA's FFT op only supports F32.
-  # TODO(phawkins): remove when minimum jaxlib version is 0.1.48 or newer.
-  if lib.version <= (0, 1, 47) and dtype == np.float64:
-    dtype = np.float32
   return lax.convert_element_type(arg, dtype)
 
 def fft(x, fft_type, fft_lengths):


### PR DESCRIPTION
I believe we can remove this since `_minimum_jaxlib_version = (0, 1, 55)`!