### PR TITLE
Add methods to interact with `DeviceArray` objects.

### DIFF
--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -64,4 +64,4 @@ def from_dlpack(dlpack, backend=None):
   xla_shape = buf.shape()
   assert not xla_shape.is_tuple()
   aval = core.ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
-  return xla.DeviceArray(aval, buf.device(), lazy.array(aval.shape), buf)  # pytype: disable=attribute-error
+  return xla.make_device_array(aval, buf.device(), lazy.array(aval.shape), buf)  # pytype: disable=attribute-error

--- a/jax/api.py
+++ b/jax/api.py
@@ -298,7 +298,7 @@ def _cpp_jit(
         execute is not None and
         execute.func is xla._execute_compiled and  # not trivial, not pmap
         # Not supported: ShardedDeviceArray, DeviceConstant.
-        all(type(x) is xla.DeviceArray for x in out_flat) and
+        all(xla.type_is_device_array(x) for x in out_flat) and
         # TODO(mattjj): Add support for lazy-expression.
         # If the input is a DeviceArray, then it should have a trivial LazyExpr.
         all(

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -444,7 +444,7 @@ class ShardedDeviceArray(xla.DeviceArray):
     if self._npy_value is None and idx in self.indices:
       buf = self.device_buffers[self.indices.index(idx)]
       aval = ShapedArray(buf.shape().dimensions(), self.aval.dtype)
-      return xla.DeviceArray(aval, None, lazy.array(aval.shape), buf)
+      return xla.make_device_array(aval, None, lazy.array(aval.shape), buf)
     else:
       return super(ShardedDeviceArray, self).__getitem__(idx)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2603,7 +2603,7 @@ class LazyTest(jtu.JaxTestCase):
         jax_x = jnp.tri(N, M, k, dtype=dtype)
       else:
         assert False
-      assert type(np_x) is np.ndarray and type(jax_x) is xla.DeviceArray
+      assert type(np_x) is np.ndarray and xla.type_is_device_array(jax_x)
       return np_x, jax_x
 
     def random_op(rng, shape):

--- a/tests/custom_object_test.py
+++ b/tests/custom_object_test.py
@@ -79,8 +79,8 @@ class ConcreteSparseArray(AbstractSparseArray):
 
 def sparse_array_result_handler(device, aval):
   def build_sparse_array(data_buf, indices_buf):
-    data = xla.DeviceArray(aval.data_aval, device, lazy.array(aval.data_aval.shape), data_buf)
-    indices = xla.DeviceArray(aval.indices_aval, device, lazy.array(aval.indices_aval.shape), indices_buf)
+    data = xla.make_device_array(aval.data_aval, device, lazy.array(aval.data_aval.shape), data_buf)
+    indices = xla.make_device_array(aval.indices_aval, device, lazy.array(aval.indices_aval.shape), indices_buf)
     return SparseArray(aval, data, indices)
   return build_sparse_array
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1674,7 +1674,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     expected_np_input_after_call = np.ones((1))
     expected_jnp_input_after_call = jnp.ones((1))
 
-    self.assertIs(type(jnp.concatenate([np_input])), jnp.DeviceArray)
+    self.assertTrue(xla.type_is_device_array(jnp.concatenate([np_input])))
 
     attempt_sideeffect(np_input)
     attempt_sideeffect(jnp_input)
@@ -2640,19 +2640,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     assert not np.isscalar(jnp.array(3))
 
   def testArrayOutputsDeviceArrays(self):
-    assert type(jnp.array([])) == jax.interpreters.xla.DeviceArray
-    assert type(jnp.array(np.array([]))) == jax.interpreters.xla.DeviceArray
+    assert xla.type_is_device_array(jnp.array([]))
+    assert xla.type_is_device_array(jnp.array(np.array([])))
 
     class NDArrayLike:
       def __array__(self, dtype=None):
         return np.array([], dtype=dtype)
-    assert type(jnp.array(NDArrayLike())) == jax.interpreters.xla.DeviceArray
+    assert xla.type_is_device_array(jnp.array(NDArrayLike()))
 
     # NOTE(mattjj): disabled b/c __array__ must produce ndarrays
     # class DeviceArrayLike:
     #     def __array__(self, dtype=None):
     #         return jnp.array([], dtype=dtype)
-    # assert type(jnp.array(DeviceArrayLike())) == jax.interpreters.xla.DeviceArray
+    # assert  xla.type_is_device_array(jnp.array(DeviceArrayLike()))
 
   def testArrayMethod(self):
     class arraylike(object):


### PR DESCRIPTION
We are going to add a C++ implementation, this is a useful refectoring to ease the transition. In short,

- `isinstance(x, DeviceArray)` will continue to work
- type(x) is DeviceArray will be replaced by `type_is_device_array(x)`
- DeviceArray(...) constructor will be replaced by `get_device_array(...)`.