### PR TITLE
Change `PyBuffer.shape` to be PyBuffer.xla_shape` in a backward compa…

### DIFF
--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -61,7 +61,9 @@ def from_dlpack(dlpack, backend=None):
   backend = backend or xla_bridge.get_backend()
   client = getattr(backend, "client", backend)
   buf = xla_client._xla.dlpack_managed_tensor_to_buffer(dlpack, client)
-  xla_shape = buf.shape()
+  # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58 is
+  # the default.
+  xla_shape = getattr(buf, "xla_shape", buf.shape)()
   assert not xla_shape.is_tuple()
   aval = core.ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
   return xla.make_device_array(aval, buf.device(), lazy.array(aval.shape), buf)  # pytype: disable=attribute-error

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -443,7 +443,11 @@ class ShardedDeviceArray(xla.DeviceArray):
   def __getitem__(self, idx):
     if self._npy_value is None and idx in self.indices:
       buf = self.device_buffers[self.indices.index(idx)]
-      aval = ShapedArray(buf.shape().dimensions(), self.aval.dtype)
+      # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58
+      # is the default.
+      aval = ShapedArray(
+          getattr(buf, "xla_shape", buf.shape)().dimensions(),
+          self.aval.dtype)
       return xla.make_device_array(aval, None, lazy.array(aval.shape), buf)
     else:
       return super(ShardedDeviceArray, self).__getitem__(idx)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -362,7 +362,9 @@ def _execute_replicated_primitive(prim, compiled, result_handler, *args):
 
 def check_nans(prim, bufs):
   for buf in bufs:
-    _check_nans(prim.name, buf.shape(), buf)
+    # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58 is
+    # the default.
+    _check_nans(prim.name, getattr(buf, "xla_shape", buf.shape)(), buf)
 
 def _check_nans(name, xla_shape, buf):
   assert not xla_shape.is_tuple()

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -142,8 +142,14 @@ class ShardedJitTest(jtu.JaxTestCase):
     actual = sharded_jit(f, in_parts=P(2,1), out_parts=P(2,1))(x)
     self.assertAllClose(actual, expected, check_dtypes=False)
     self.assertLen(actual.device_buffers, 2)
-    self.assertEqual(actual.device_buffers[0].shape().dimensions(), (4,8))
-    self.assertEqual(actual.device_buffers[1].shape().dimensions(), (4,8))
+    # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58 is
+    # the default.
+    self.assertEqual(
+        getattr(actual.device_buffers[0], "xla_shape",
+                actual.device_buffers[0].shape)().dimensions(), (4, 8))
+    self.assertEqual(
+        getattr(actual.device_buffers[1], "xla_shape",
+                actual.device_buffers[1].shape)().dimensions(), (4, 8))
 
     # Mismatched sharded_jit partitions
     with self.assertRaisesRegex(


### PR DESCRIPTION
…tible way.

We need this as we will update a new Jaxlib with `shape` returning a tuple, and as the submission process in in 2 steps, we need this before updating xla.cc