### PR TITLE
Fix issue in jax.dtypes._jax_type

### DIFF
--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -182,6 +182,24 @@ class DtypesTest(jtu.JaxTestCase):
 
 class TestPromotionTables(jtu.JaxTestCase):
 
+  @parameterized.named_parameters(
+    {"testcase_name": "_jaxtype={}".format(jaxtype),
+     "jaxtype": jaxtype}
+     for jaxtype in dtypes._jax_types)
+  def testJaxTypeFromType(self, jaxtype):
+    self.assertIs(dtypes._jax_type(jaxtype), jaxtype)
+
+  @parameterized.named_parameters(
+    {"testcase_name": "_jaxtype={}".format(jaxtype),
+     "jaxtype": jaxtype}
+     for jaxtype in dtypes._jax_types)
+  def testJaxTypeFromVal(self, jaxtype):
+    try:
+      val = jaxtype(0)
+    except TypeError:
+      val = jaxtype.type(0)
+    self.assertIs(dtypes._jax_type(val), jaxtype)
+
   def testObservedPromotionTable(self):
     """Test that the weak & strong dtype promotion table does not change over time."""
     # Note: * here refers to weakly-typed values


### PR DESCRIPTION
Before:
```python
>>> from jax import dtypes                                                                                                                                             
>>> dtypes._jax_type(float)                                                                                                                                            
dtype('float64')
```
After:
```python
>>> from jax import dtypes                                                                                                                                             
>>> dtypes._jax_type(float)                                                                                                                                            
float
```
Since this utility is core to the way type promotion works in JAX, I also added some quick & comprehensive unit tests.