### PR TITLE
Promotion via lattice

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -166,10 +166,8 @@ can_cast = np.can_cast
 issubsctype = np.issubsctype
 
 
-# List of all valid JAX dtypes, in the order they appear in the type promotion
-# table.
+# Enumeration of all valid JAX types in order.
 _weak_types = [int, float, complex]
-
 _jax_types = [
   np.dtype('bool'),
   np.dtype('uint8'),
@@ -190,7 +188,7 @@ _jax_types = [
 
 def _jax_type(value):
   """Return the jax type for a value or type."""
-  # Note: `value in _weak_types` can return false positives due to dtype comparator overloading.
+  # Note: `x in _weak_types` can return false positives due to dtype comparator overloading.
   if any(value is typ for typ in _weak_types):
     return value
   dtype_ = dtype(value)
@@ -200,37 +198,61 @@ def _jax_type(value):
       return pytype
   return dtype_
 
-# Mapping from types to their type numbers.
-_jax_type_nums = {t: i for i, t in enumerate(_jax_types)}
-
-
-def _make_type_promotion_table():
-  # Note: this promotion table is generated via the least upper bounds over a type
-  # promotion lattice. See testPromotionTableLattice for details of this.
+def _type_promotion_lattice():
+  """
+  Return the type promotion lattice in the form of a DAG.
+  This DAG maps each type to its immediately higher type on the lattice.
+  """
   b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_ = _jax_types
-  #  b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, s*, f*, c*
-  return np.array([
-    [b1, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # b1
-    [u1, u1, u2, u4, u8, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, u1, f_, c_],  # u1
-    [u2, u2, u2, u4, u8, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, u2, f_, c_],  # u2
-    [u4, u4, u4, u4, u8, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, u4, f_, c_],  # u4
-    [u8, u8, u8, u8, u8, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, u8, f_, c_],  # u8
-    [i1, i2, i4, i8, f_, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i1, f_, c_],  # i1
-    [i2, i2, i4, i8, f_, i2, i2, i4, i8, bf, f2, f4, f8, c4, c8, i2, f_, c_],  # i2
-    [i4, i4, i4, i8, f_, i4, i4, i4, i8, bf, f2, f4, f8, c4, c8, i4, f_, c_],  # i4
-    [i8, i8, i8, i8, f_, i8, i8, i8, i8, bf, f2, f4, f8, c4, c8, i8, f_, c_],  # i8
-    [bf, bf, bf, bf, bf, bf, bf, bf, bf, bf, f4, f4, f8, c4, c8, bf, bf, c4],  # bf
-    [f2, f2, f2, f2, f2, f2, f2, f2, f2, f4, f2, f4, f8, c4, c8, f2, f2, c4],  # f2
-    [f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f4, f8, c4, c8, f4, f4, c4],  # f4
-    [f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, f8, c8, c8, f8, f8, c8],  # f8
-    [c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c4, c8, c4, c8, c4, c4, c4],  # c4
-    [c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8, c8],  # c8
-    [i_, u1, u2, u4, u8, i1, i2, i4, i8, bf, f2, f4, f8, c4, c8, i_, f_, c_],  # s*
-    [f_, f_, f_, f_, f_, f_, f_, f_, f_, bf, f2, f4, f8, c4, c8, f_, f_, c_],  # f*
-    [c_, c_, c_, c_, c_, c_, c_, c_, c_, c4, c4, c4, c8, c4, c8, c_, c_, c_],  # c*
-  ])
+  return {
+    b1: [i_],
+    u1: [i2, u2], u2: [i4, u4], u4: [i8, u8], u8: [f_],
+    i_: [u1, i1], i1: [i2], i2: [i4], i4: [i8], i8: [f_],
+    f_: [bf, f2, c_], bf: [f4], f2: [f4], f4: [f8, c4], f8: [c8],
+    c_: [c4], c4: [c8], c8: [],
+  }
 
-_type_promotion_table = _make_type_promotion_table()
+def _make_lattice_upper_bounds():
+  lattice = _type_promotion_lattice()
+  upper_bounds = {node: {node} for node in lattice}
+  for n in lattice:
+    while True:
+      new_upper_bounds = set().union(*(lattice[b] for b in upper_bounds[n]))
+      if n in new_upper_bounds:
+        raise ValueError(f"cycle detected in type promotion lattice for node {n}")
+      if new_upper_bounds.issubset(upper_bounds[n]):
+        break
+      upper_bounds[n] |= new_upper_bounds
+  return upper_bounds
+_lattice_upper_bounds = _make_lattice_upper_bounds()
+
+@functools.lru_cache(512)
+def _least_upper_bound(*nodes):
+  # This function computes the least upper bound of a set of nodes N within a partially
+  # ordered set defined by the lattice generated above.
+  # Given a partially ordered set S, let the set of upper bounds of n ∈ S be
+  #   UB(n) ≡ {m ∈ S | n ≤ m}
+  # Further, for a set of nodes N ⊆ S, let the set of common upper bounds be given by
+  #   CUB(N) ≡ {a ∈ S | ∀ b ∈ N: a ∈ UB(b)}
+  # Then the least upper bound of N is defined as
+  #   LUB(N) ≡ {c ∈ CUB(N) | ∀ d ∈ CUB(N), c ≤ d}
+  # The definition of an upper bound implies that c ≤ d if and only if d ∈ UB(c),
+  # so the LUB can be expressed:
+  #   LUB(N) = {c ∈ CUB(N) | ∀ d ∈ CUB(N): d ∈ UB(c)}
+  # or, equivalently:
+  #   LUB(N) = {c ∈ CUB(N) | CUB(N) ⊆ UB(c)}
+  # By definition, LUB(N) has a cardinality of 1 for a partially ordered set.
+  # Note a potential algorithmic shortcut: from the definition of CUB(N), we have
+  #   ∀ c ∈ N: CUB(N) ⊆ UB(c)
+  # So if N ∩ CUB(N) is nonempty, if follows that LUB(N) = N ∩ CUB(N).
+  N = set(nodes)
+  UB = _lattice_upper_bounds
+  CUB = set.intersection(*(UB[n] for n in N))
+  LUB = (CUB & N) or {c for c in CUB if CUB.issubset(UB[c])}
+  if len(LUB) == 1:
+    return LUB.pop()
+  else:
+    raise ValueError(f"{nodes} do not have a unique least upper bound.")
 
 def promote_types(a, b):
   """Returns the type to which a binary operation should cast its arguments.
@@ -244,17 +266,9 @@ def promote_types(a, b):
   Returns:
     A :class:`numpy.dtype` object.
   """
-  return np.dtype(_promote_types_raw(np.dtype(a), np.dtype(b)))
-
-def _promote_types_raw(a, b):
-  # Note: `x in _weak_types` can return false positives due to dtype comparator overloading.
   a = a if any(a is t for t in _weak_types) else np.dtype(a)
   b = b if any(b is t for t in _weak_types) else np.dtype(b)
-  try:
-    return _type_promotion_table[_jax_type_nums[a], _jax_type_nums[b]]
-  except KeyError:
-    pass
-  raise TypeError("Invalid type promotion of {} and {}".format(a, b))
+  return np.dtype(_least_upper_bound(a, b))
 
 def is_weakly_typed(x):
   try:
@@ -272,9 +286,8 @@ def dtype(x):
 
 def result_type(*args):
   """Convenience function to apply Numpy argument dtype promotion."""
-  # TODO(dougalm,mattjj): This is a performance bottleneck. Consider memoizing.
+   # TODO(jakevdp): propagate weak_type to the result.
   if len(args) < 2:
     return canonicalize_dtype(dtype(args[0]))
-  result_type = functools.reduce(_promote_types_raw, (_jax_type(arg) for arg in args))
   # TODO(jakevdp): propagate weak_type to the result when necessary.
-  return canonicalize_dtype(result_type)
+  return canonicalize_dtype(_least_upper_bound(*{_jax_type(arg) for arg in args}))


### PR DESCRIPTION
Now that JAX type promotion is derived from a lattice rather than specified in a table, we could use the lattice directly and avoid pre-computation of the table as suggested by @hawkinsp in review of #4748. This PR explores that possibility.

The main potential downside is greater overhead in determining output types, but it turns out that with careful cacheing, the lattice approach has slightly faster amortized performance.

TLDR; micro-benchmarks show:

- import time precomputation goes from 350 µs to 160 µs
- first-time type promotion is a factor of 2 slower than current table lookup
- subsequent type promotions with `lru_cache` are 10% faster than current table lookup

Timing on the master branch for retrieving the promotion table:
```python
In [1]: import numpy as np 
   ...: from jax import dtypes, config 
   ...: config.update('jax_enable_x64', True) 
   ...: %timeit [dtypes.result_type(a, b) for a in dtypes._jax_types for b in dtypes._jax_types]                                                                           
1.59 ms ± 22.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
Amortized time on this branch for computing the promotion table:
```python
In [1]: import numpy as np 
   ...: from jax import dtypes, config 
   ...: config.update('jax_enable_x64', True) 
   ...: %timeit [dtypes.result_type(a, b) for a in dtypes._jax_types for b in dtypes._jax_types]                                                                           
1.43 ms ± 14.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
In this PR, the table of lattice upper bounds is computed on import. This is the cost of this operation:
```python  
In [1]: from jax import dtypes                                                                                                                                             
In [2]: %timeit dtypes._make_lattice_upper_bounds()                                                                                                                        
161 µs ± 4.06 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
This is about 2x as fast as the current method that constructs the full promotion table on import:
```python
In [1]: from jax import dtypes                                                                                                                                             

In [2]: %timeit dtypes._make_type_promotion_table()                                                                                                                        
349 µs ± 5.04 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
Removing `functools.lru_cache` from `_least_upper_bound` shows that the average first-time type promotion cost is only about 40% greater than the cost of a cached type promotion:
```python
In [1]: import numpy as np 
   ...: from jax import dtypes, config 
   ...: config.update('jax_enable_x64', True) 
   ...: %timeit [dtypes.result_type(a, b) for a in dtypes._jax_types for b in dtypes._jax_types]                                                                           
1.86 ms ± 24.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
All told, I think this lattice-based approach is a win in terms of simplicity of implementation, and avoids the excessive overhead that I feared would make it a non-starter.