### PR TITLE
Fix: always canonicalize result_type

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -282,7 +282,7 @@ def result_type(*args):
   """Convenience function to apply Numpy argument dtype promotion."""
   # TODO(dougalm,mattjj): This is a performance bottleneck. Consider memoizing.
   if len(args) < 2:
-    return dtype(args[0])
+    return canonicalize_dtype(dtype(args[0]))
   result_type = functools.reduce(_promote_types_raw, (_jax_type(arg) for arg in args))
   # TODO(jakevdp): propagate weak_type to the result when necessary.
   return canonicalize_dtype(result_type)


### PR DESCRIPTION
Current behavior is inconsistent with only one entry; e.g. in x32 mode:
```python
In [1]: import jax.numpy as jnp                                                                                                                                            

In [2]: import numpy as np                                                                                                                                                 

In [3]: jnp.result_type(np.int64, np.int64)                                                                                                                                
Out[3]: dtype('int32')

In [4]: jnp.result_type(np.int64)                                                                                                                                          
Out[4]: dtype('int64')
```
With this fix, the result is `int32` in both cases.