### PR TITLE
Add a named_call public function in lax

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -32,6 +32,7 @@ Just-in-time compilation (:code:`jit`)
     make_jaxpr
     eval_shape
     device_put
+    named_call
 
 Automatic differentiation
 -------------------------

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -58,6 +58,7 @@ from .api import (
   linear_transpose,
   make_jaxpr,
   mask,
+  named_call,
   partial,  # TODO(phawkins): update callers to use functools.partial.
   pmap,
   pxla,  # TODO(phawkins): update users to avoid this.

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2449,25 +2449,6 @@ ad.defjvp2(min_p,
            lambda g, ans, x, y: mul(_brcast(g, y), _balanced_eq(x, ans, y)),
            lambda g, ans, x, y: mul(_brcast(g, x), _balanced_eq(y, ans, x)))
 
-named_call_p = core.CallPrimitive('named_call')
-named_call_p.def_impl(core.call_impl)
-ad.primitive_transposes[named_call_p] = functools.partial(ad.call_transpose,
-                                                         named_call_p)
-
-
-def _named_call_translation_rule(c, axis_env, in_nodes, name_stack,
-                                 *, name='core_call', backend, call_jaxpr):
-  subc = xla.xb.make_computation_builder(name)
-  args = [xla.xb.parameter(subc, i, c.GetShape(n))
-          for i, n in enumerate(in_nodes)]
-  out_nodes = xla.jaxpr_subcomp(subc, call_jaxpr, backend, axis_env, (),
-                                jax.util.extend_name_stack(name_stack, name),
-                                *args)
-  subc = subc.Build(xla.xops.Tuple(subc, out_nodes))
-  return xla.xops.Call(c, subc, list(in_nodes))
-
-xla.call_translations[named_call_p] = _named_call_translation_rule
-
 shift_left_p = standard_naryop([_int, _int], 'shift_left')
 ad.defjvp_zero(shift_left_p)
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -1202,8 +1202,8 @@ call_p = CallPrimitive('call')
 call = call_p.bind
 call_p.def_impl(call_impl)
 
-named_call_p = core.CallPrimitive('named_call')
-named_call_p.def_impl(core.call_impl)
+named_call_p = CallPrimitive('named_call')
+named_call_p.def_impl(call_impl)
 
 # ------------------- Map -------------------
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -1202,6 +1202,8 @@ call_p = CallPrimitive('call')
 call = call_p.bind
 call_p.def_impl(call_impl)
 
+named_call_p = core.CallPrimitive('named_call')
+named_call_p.def_impl(core.call_impl)
 
 # ------------------- Map -------------------
 

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -168,7 +168,6 @@ from jax._src.lax.lax import (
   min_p,
   mul,
   mul_p,
-  named_call_p,
   naryop,
   naryop_dtype_rule,
   ne,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2245,25 +2245,6 @@ class LaxTest(jtu.JaxTestCase):
                                              (x,), (1.,)))(1.)
     self.assertLen(jaxpr.jaxpr.eqns, 2)
 
-  def test_named_call(self):
-    # TODO(qiuminxu) Make named_call a public function in lax
-    def named_call(f, name):
-      def named_f(*args):
-        f_ = jax.linear_util.wrap_init(lambda: (f(*args),))
-        out, = lax.named_call_p.bind(f_, name=name)
-        return out
-      return named_f
-
-    def square(x):
-      return x ** 2
-
-    @jax.jit
-    def f(x):
-      return named_call(square, 'name_for_testing')(x)
-
-    c = jax.xla_computation(f)(2)
-    self.assertIn('name_for_testing', c.as_hlo_text())
-
 
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):


### PR DESCRIPTION
Add a named_call public function in lax.

The implementation copies from the flax [_named_call](https://github.com/google/flax/blob/bb3170165010d508e7950d2c66eb9846d3661471/flax/core/lift.py#L674)

[Tests](https://github.com/deepmind/dm-haiku/blob/3fedc4725da8f58b4dae80bb21b195b0e3d9b670/haiku/_src/named_call_test.py#L25) passed after replacing the haiku [named_fun](https://github.com/deepmind/dm-haiku/blob/3fedc4725da8f58b4dae80bb21b195b0e3d9b670/haiku/_src/named_call.py#L109) with this implementation. 



