### PR TITLE
[RFC] Support complex dtype in random.normal

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -165,6 +165,17 @@ def issubdtype(a, b):
 can_cast = np.can_cast
 issubsctype = np.issubsctype
 
+# Return the type holding the real part of the input type
+def dtype_real(typ):
+  if np.issubdtype(typ, np.complexfloating):
+    if typ == np.dtype('complex64'):
+      return np.dtype('float32')
+    elif typ == np.dtype('complex128'):
+      return np.dtype('float64')
+    else:
+      raise TypeError("Unknown complex floating type {}".format(typ))
+  else:
+    return typ
 
 # Enumeration of all valid JAX types in order.
 _weak_types = [int, float, complex]

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -40,6 +40,7 @@ config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
 float_dtypes = jtu.dtypes.all_floating
+complex_dtypes = jtu.dtypes.complex
 int_dtypes = jtu.dtypes.all_integer
 uint_dtypes = jtu.dtypes.all_unsigned
 
@@ -208,6 +209,21 @@ class LaxRandomTest(jtu.JaxTestCase):
 
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.norm().cdf)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_dtype={}".format(np.dtype(dtype).name), "dtype": dtype}
+      for dtype in complex_dtypes))
+  def testNormal(self, dtype):
+    key = random.PRNGKey(0)
+    rand = lambda key: random.normal(key, (10000,), dtype)
+    crand = api.jit(rand)
+
+    uncompiled_samples = rand(key)
+    compiled_samples = crand(key)
+
+    for samples in [uncompiled_samples, compiled_samples]:
+      self._CheckKolmogorovSmirnovCDF(jnp.real(samples), scipy.stats.norm(scale=1/np.sqrt(2)).cdf)
+      self._CheckKolmogorovSmirnovCDF(jnp.imag(samples), scipy.stats.norm(scale=1/np.sqrt(2)).cdf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}".format(np.dtype(dtype).name), "dtype": dtype}

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -211,9 +211,9 @@ class LaxRandomTest(jtu.JaxTestCase):
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.norm().cdf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dtype={}".format(np.dtype(dtype).name), "dtype": dtype}
+      {"testcase_name": "dtype={}".format(np.dtype(dtype).name), "dtype": dtype}
       for dtype in complex_dtypes))
-  def testNormal(self, dtype):
+  def testNormalComplex(self, dtype):
     key = random.PRNGKey(0)
     rand = lambda key: random.normal(key, (10000,), dtype)
     crand = api.jit(rand)


### PR DESCRIPTION
As I was asking around in #4680 but had no answer, I decided to take a stab at this.

This is a relatively straightforward PR to support complex dtypes in `random.normal`. The rationale of this is that now stax and flax will support out of the box complex-valued networks. This is especially important for flax because it does some peculiar things behind the scenes...

I would also like to do the same for `jax.random.uniform`, but that requires a bit more care to handle default arguments, so I would like to know first that you would accept this PR.

As for the rationale of supporting complex numbers in complex-valued neural networks, in Quantum Mechanics we use this extensively (read: all the time). Moreover, complex numbers arise naturally whenever one tries to model oscillating systems, which is another potential use case of jax together with physically-inspired neural networks. 

Now:
```python
>>> jax.random.normal(jax.random.PRNGKey(0), (2,2), dtype=jax.numpy.complex64)
DeviceArray([[ 0.1389316 +1.1378783j ,  1.3706678 -0.1433144j ],
             [-0.5311612 -0.59153646j,  0.02033774+0.79466224j]],            dtype=complex64)

```

Before:
```python
>>> jax.random.normal(jax.random.PRNGKey(0), (2,2), dtype=jax.numpy.complex64)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/filippovicentini/Documents/pythonenvs/netket_env/lib64/python3.8/site-packages/jax/random.py", line 635, in normal
    raise ValueError(f"dtype argument to `normal` must be a float dtype, "
ValueError: dtype argument to `normal` must be a float dtype, got <class 'jax._src.numpy.lax_numpy.complex64'>
```