### PR TITLE
fix skip logic for test that requires portpicker

### DIFF
--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -87,7 +87,7 @@ class ProfilerTest(unittest.TestCase):
     self.assertEqual(1, len(glob.glob(path)),
                      'Expected one path match: ' + path)
 
-  @unittest.skipIf(not (portpicker or profiler_client or tf_profiler),
+  @unittest.skipIf(not (portpicker and profiler_client and tf_profiler),
     "Test requires tensorflow.profiler and portpicker")
   def testSingleWorkerSamplingMode(self, delay_ms=None):
     def on_worker(port, worker_start):


### PR DESCRIPTION
Local testing fails for me without this change, since the test isn't skipped even though I don't have portpicker.