### PR TITLE
simplify the implementation of vmap collectives

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -448,7 +448,7 @@ captured using the ``xla_pmap`` primitive. Consider this example
                                                            shape=(1,) ] 1.0
                                      e = add c d
                                      f = psum[ axis_index_groups=None
-                                               axis_name=rows ] b
+                                               axis_name=('rows',) ] b
                                      g = div e f
                                  in (g,) }
                     devices=None

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -380,6 +380,9 @@ def _batched_reduction_collective2(
     prim, if_mapped, if_unmapped, frame, vals_in, dims_in, axis_name,
     axis_index_groups):
   assert not prim.multiple_results  # cf. _batched_reduction_collective
+  if axis_index_groups is not None:
+    raise NotImplementedError("axis_index_groups not supported in vmap collectives. "
+                              "Please open a feature request!")
   (v,), (d,) = vals_in, dims_in
   val_out = (if_mapped(v, d) if d is not batching.not_mapped
              else if_unmapped(v, frame.size))
@@ -538,6 +541,7 @@ def _ppermute_transpose_rule(t, perm, axis_name):
 
 def _ppermute_batcher(frame, vals_in, dims_in, axis_name, perm):
   assert len(perm) == frame.size, "Permutation doesn't match the axis size!"
+  assert axis_name == frame.name, "ppermute batcher called with wrong axis name"
   (v,), (d,) = vals_in, dims_in
   assert d is not batching.not_mapped
   perm_indices = [None] * frame.size

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -74,6 +74,8 @@ def psum(x, axis_name, *, axis_index_groups=None):
   >>> print(y)
   [ 0.          0.16666667  0.33333334  0.5       ]
   """
+  if not isinstance(axis_name, (tuple, list)):
+    axis_name = (axis_name,)
   _validate_axis_index_groups(axis_index_groups)
   leaves, treedef = tree_util.tree_flatten(x)
   leaves = [lax.convert_element_type(l, np.int32)
@@ -134,6 +136,8 @@ def pmax(x, axis_name, *, axis_index_groups=None):
     Array(s) with the same shape as ``x`` representing the result of an
     all-reduce max along the axis ``axis_name``.
   """
+  if not isinstance(axis_name, (tuple, list)):
+    axis_name = (axis_name,)
   _validate_axis_index_groups(axis_index_groups)
   return tree_util.tree_map(partial(
       pmax_p.bind, axis_name=axis_name, axis_index_groups=axis_index_groups), x)
@@ -157,6 +161,8 @@ def pmin(x, axis_name, *, axis_index_groups=None):
     Array(s) with the same shape as ``x`` representing the result of an
     all-reduce min along the axis ``axis_name``.
   """
+  if not isinstance(axis_name, (tuple, list)):
+    axis_name = (axis_name,)
   _validate_axis_index_groups(axis_index_groups)
   return tree_util.tree_map(partial(
       pmin_p.bind, axis_name=axis_name, axis_index_groups=axis_index_groups), x)
@@ -347,42 +353,41 @@ def _allreduce_translation_rule(prim, c, val, *, axis_name, axis_index_groups,
   replica_groups_protos = xc.make_replica_groups(replica_groups)
   return xops.AllReduce(val, computation, replica_groups_protos, None, None)
 
-# It is assumed that all collectives that use this rule are commutative
-# and associative over axis names if they support tuples. That is,
-# they have to satisfy:
-#   collective(x, ('i', 'j')) == collective(x, ('j', 'i'))
-#                             == collective(collective(x, 'j'), 'i')
-def _split_axis_comm_assoc(primitive, split_name, args, params):
-  axis_names = params['axis_name']
-  assert isinstance(axis_names, tuple)
-  if params['axis_index_groups'] is not None:
-    raise NotImplementedError("axis_index_groups not supported in axis splitting. "
-                              "Please open a feature request!")
-  remaining_axes = list(axis_names)
-  remaining_axes.remove(split_name)
-  remaining_axes = tuple(remaining_axes)
-  split_params = dict(params, axis_name=split_name)
-  remain_params = dict(params, axis_name=remaining_axes)
-  split_result = primitive.bind(*args, **split_params)
-  if not primitive.multiple_results:
-    split_result = (split_result,)
-  return primitive.bind(*split_result, **remain_params)
 
-# NB: This is only used for collectives that do not include the vmapped axis name,
-#     which is why the rule is so simple. All other collectives go through split_axis.
+# This is only used for collectives that do not include the vmapped axis name,
+# which is why the rule is so simple.
 def _collective_batcher(prim, args, dims, **params):
   return prim.bind(*args, **params), dims if prim.multiple_results else dims[0]
 
-def _batched_reduction_collective(prim, if_mapped, if_unmapped,
-                                  vals_in, dims_in, axis_size,
-                                  axis_name, axis_index_groups):
+def _batched_reduction_collective(
+    prim, if_mapped, if_unmapped, frame, vals_in, dims_in, axis_name,
+    axis_index_groups):
+  assert prim.multiple_results
+  assert frame.name in axis_name
   if axis_index_groups is not None:
-    raise NotImplementedError("axis_index_groups not implemented in vmap collectives. "
+    raise NotImplementedError("axis_index_groups not supported in vmap collectives. "
                               "Please open a feature request!")
-  vals_out = [if_mapped(v, d) if d is not batching.not_mapped else if_unmapped(v, axis_size)
-              for v, d in zip(vals_in, dims_in)]
-  dims_out = [batching.not_mapped] * len(vals_in)
-  return vals_out, dims_out
+  vals_out = [if_mapped(v, d) if d is not batching.not_mapped
+              else if_unmapped(v, frame.size) for v, d in zip(vals_in, dims_in)]
+  if len(axis_name) > 1:
+    remaining_axis_names = tuple(n for n in axis_name if n != frame.name)
+    vals_out = prim.bind(*vals_out, axis_name=remaining_axis_names,
+                         axis_index_groups=None)
+  return vals_out, [batching.not_mapped] * len(vals_out)
+
+# TODO(mattjj): update pmin/pmax to have multiple_results like psum, delete this
+def _batched_reduction_collective2(
+    prim, if_mapped, if_unmapped, frame, vals_in, dims_in, axis_name,
+    axis_index_groups):
+  assert not prim.multiple_results  # cf. _batched_reduction_collective
+  (v,), (d,) = vals_in, dims_in
+  val_out = (if_mapped(v, d) if d is not batching.not_mapped
+             else if_unmapped(v, frame.size))
+  if len(axis_name) > 1:
+    remaining_axis_names = tuple(n for n in axis_name if n != frame.name)
+    val_out = prim.bind(val_out, axis_name=remaining_axis_names,
+                        axis_index_groups=None)
+  return val_out, batching.not_mapped
 
 def _replica_groups(axis_env, axis_name, axis_index_groups):
   replica_groups = xla.axis_groups(axis_env, axis_name)
@@ -463,7 +468,6 @@ pxla.soft_pmap_rules[psum_p] = \
 xla.parallel_translations[psum_p] = _psum_translation_rule
 ad.deflinear(psum_p, _psum_transpose_rule)
 pxla.multi_host_supported_collectives.add(psum_p)
-batching.split_axis_rules[psum_p] = partial(_split_axis_comm_assoc, psum_p)
 batching.primitive_batchers[psum_p] = partial(_collective_batcher, psum_p)
 batching.collective_rules[psum_p] = \
   partial(_batched_reduction_collective,
@@ -478,7 +482,7 @@ def psum_bind(*args, axis_name, axis_index_groups):
   if all(not isinstance(x, core.Tracer) for x in args):
     if axis_index_groups is not None:
       size = len(axis_index_groups[0])
-    elif type(axis_name) is tuple:
+    elif isinstance(axis_name, (list, tuple)):
       size = prod([core.axis_frame(name).size for name in axis_name])  # type: ignore
     else:
       size = core.axis_frame(axis_name).size  # type: ignore
@@ -492,10 +496,9 @@ pmax_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
 xla.parallel_translations[pmax_p] = \
     partial(_allreduce_translation_rule, lax.max_p)
 pxla.multi_host_supported_collectives.add(pmax_p)
-batching.split_axis_rules[pmax_p] = partial(_split_axis_comm_assoc, pmax_p)
 batching.primitive_batchers[pmax_p] = partial(_collective_batcher, pmax_p)
 batching.collective_rules[pmax_p] = \
-  partial(_batched_reduction_collective,
+  partial(_batched_reduction_collective2,
           pmax_p,
           lambda v, d: v.max(d),
           lambda v, axis_size: v)
@@ -506,10 +509,9 @@ pmin_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
 xla.parallel_translations[pmin_p] = \
     partial(_allreduce_translation_rule, lax.min_p)
 pxla.multi_host_supported_collectives.add(pmin_p)
-batching.split_axis_rules[pmin_p] = partial(_split_axis_comm_assoc, pmin_p)
 batching.primitive_batchers[pmin_p] = partial(_collective_batcher, pmin_p)
 batching.collective_rules[pmin_p] = \
-  partial(_batched_reduction_collective,
+  partial(_batched_reduction_collective2,
           pmin_p,
           lambda v, d: v.min(d),
           lambda v, axis_size: v)
@@ -534,14 +536,14 @@ def _ppermute_transpose_rule(t, perm, axis_name):
   inverse_perm = list(zip(dsts, srcs))
   return [ppermute(t, axis_name=axis_name, perm=inverse_perm)]
 
-def _ppermute_batcher(vals_in, dims_in, axis_size, axis_name, perm):
-  assert len(perm) == axis_size, "Permutation doesn't match the axis size!"
-  perm_indices = np.full((axis_size,), -1, dtype=np.int32)
-  for s, d in perm:
-    perm_indices[s] = d
-  vals_out = [lax_numpy.take(v, perm_indices, d) if d is not batching.not_mapped else v
-              for v, d in zip(vals_in, dims_in)]
-  return vals_out, dims_in
+def _ppermute_batcher(frame, vals_in, dims_in, axis_name, perm):
+  assert len(perm) == frame.size, "Permutation doesn't match the axis size!"
+  (v,), (d,) = vals_in, dims_in
+  assert d is not batching.not_mapped
+  perm_indices = [None] * frame.size
+  for src, dst in perm:
+    perm_indices[src] = dst
+  return lax_numpy.take(v, perm_indices, d), d
 
 ppermute_p = core.Primitive('ppermute')
 ppermute_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
@@ -614,7 +616,10 @@ def _all_to_all_batcher(vals_in, dims_in, *, axis_name, split_axis, concat_axis)
   result = all_to_all_p.bind(x, axis_name=axis_name, split_axis=split_axis, concat_axis=concat_axis)
   return result, d
 
-def _all_to_all_batched_collective(vals_in, dims_in, axis_size, axis_name, split_axis, concat_axis):
+def _all_to_all_batched_collective(frame, vals_in, dims_in,
+                                   axis_name, split_axis, concat_axis):
+  if isinstance(axis_name, (list, tuple)) and len(axis_name) > 1:
+    raise NotImplementedError("update after #4835")  # TODO(mattjj,apaszke)
   x, = vals_in
   d, = dims_in
   split_axis_adj = split_axis + (1 if d <= split_axis else 0)
@@ -623,40 +628,7 @@ def _all_to_all_batched_collective(vals_in, dims_in, axis_size, axis_name, split
     split_axis_adj -= 1
   elif concat_axis_adj < split_axis_adj < d:
     split_axis_adj += 1
-  return [_moveaxis(d, concat_axis_adj, x)], [split_axis_adj]
-
-def _all_to_all_split_axis_rule(split_name, vals, params):
-  concat_axis = params['concat_axis']
-  split_axis = params['split_axis']
-  axis_names = params['axis_name']
-  assert isinstance(axis_names, tuple)
-  x, = vals
-
-  split_pos = list(axis_names).index(split_name)
-  before_axes = axis_names[:split_pos]
-  after_axes = axis_names[split_pos+1:]
-
-  # Flatten the split_dim
-  split_name_size = psum(1, split_name)
-  before_size = psum(1, before_axes)
-  after_size = psum(1, after_axes)
-  unroll_shape = list(x.shape)
-  unroll_shape[split_axis:split_axis+1] = [before_size, split_name_size, after_size]
-  unroll_x = lax.reshape(x, unroll_shape)
-
-  if before_axes:
-    out_before = all_to_all(unroll_x, before_axes, split_axis, concat_axis=0)
-  else:
-    out_before = _moveaxis(split_axis, 0, unroll_x)
-  out_split = all_to_all(out_before, split_name, split_axis + 1, concat_axis=1)
-  if after_axes:
-    out_after = all_to_all(out_split, after_axes, split_axis + 2, concat_axis=2)
-  else:
-    out_after = _moveaxis(split_axis + 2, 2, out_split)
-
-  # Flatten the concat axes and move them to the right position
-  y = out_after.reshape((np.prod(out_after.shape[:3]), *out_after.shape[3:]))
-  return _moveaxis(0, concat_axis, y)
+  return _moveaxis(d, concat_axis_adj, x), split_axis_adj
 
 def _all_to_all_abstract_eval(x, axis_name, split_axis, concat_axis):
   input_aval = raise_to_shaped(x)
@@ -672,7 +644,6 @@ ad.deflinear(all_to_all_p, _all_to_all_transpose_rule)
 pxla.multi_host_supported_collectives.add(all_to_all_p)
 batching.primitive_batchers[all_to_all_p] = _all_to_all_batcher
 batching.collective_rules[all_to_all_p] = _all_to_all_batched_collective
-batching.split_axis_rules[all_to_all_p] = _all_to_all_split_axis_rule
 
 
 def _expand(dim, size, index, x):

--- a/jax/core.py
+++ b/jax/core.py
@@ -24,7 +24,7 @@ import threading
 import types
 from typing import (Any, Callable, ClassVar, Dict, Generator,
                     Iterator, List, NamedTuple, Optional, Sequence, Set, Tuple,
-                    Type, Union, cast, Iterable)
+                    Type, Union, cast, Iterable, Hashable)
 
 import numpy as np
 
@@ -660,6 +660,7 @@ class TraceStack:
 
 class Sublevel(int): pass
 AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size', 'main_trace'])
+AxisName = Hashable
 
 class TraceState:
   trace_stack: TraceStack
@@ -1257,9 +1258,6 @@ class MapPrimitive(Primitive):
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_map(self, out_tracers, params)
 
-# TODO: Use a more concrete type annotation (we need __eq__ and __hash__)
-AxisName = Any
-
 @contextmanager
 def extend_axis_env(axis_name: AxisName, size: int, tag: Any):
   frame = AxisEnvFrame(axis_name, size, tag)
@@ -1306,16 +1304,11 @@ def axis_frame(axis_name):
   for frame in reversed(frames):
     if frame.name == axis_name:
       return frame
-
-  named_axis = [
-      frame.name
-      for frame in reversed(frames)
-      if not isinstance(frame.name, _TempAxisName)
-  ]
+  named_axes = [frame.name for frame in reversed(frames)
+                if not isinstance(frame.name, _TempAxisName)]
   raise NameError(
       f'unbound axis name: {axis_name}. The following axis names (e.g. defined '
-      'by pmap) are available to collective operations:'
-      f'{named_axis}')
+      f'by pmap) are available to collective operations: {named_axes}')
 
 
 # ------------------- Jaxpr checking -------------------

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -58,9 +58,9 @@ def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
   in_dims = [
     canonicalize_axis(dim, np.ndim(val)) if isinstance(dim, int) else dim
     for val, dim in zip(in_vals, in_dims)]
-  size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
+  axis_size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
   with core.new_main(BatchTrace, axis_name=axis_name) as main:
-    with core.extend_axis_env(axis_name, size, main):
+    with core.extend_axis_env(axis_name, axis_size, main):
       out_vals = yield (main, in_dims,) + in_vals, params
     del main
   out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
@@ -69,7 +69,8 @@ def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
     if od is not None and not isinstance(od_dest, int) and not sum_match:
       msg = f"vmap has mapped output but out_axes is {od_dest}"
       raise ValueError(msg)
-  out_vals = map(partial(matchaxis, size, sum_match=sum_match), out_dims, out_dim_dests, out_vals)
+  out_vals = map(partial(matchaxis, axis_size, sum_match=sum_match),
+                 out_dims, out_dim_dests, out_vals)
   yield out_vals
 
 def batch_fun2(fun : lu.WrappedFun, in_dims):
@@ -139,25 +140,13 @@ class BatchTrace(Trace):
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
     if all(bdim is not_mapped for bdim in dims_in):
       return primitive.bind(*vals_in, **params)
-    elif config.omnistaging_enabled and primitive in collective_rules:
-      axis_names = params['axis_name']
-      if not isinstance(axis_names, (tuple, list)):
-        axis_names = (axis_names,)
-      for i, axis_name in enumerate(axis_names):
-        frame = core.axis_frame(axis_name)
-        if frame.main_trace is not self.main:
-          continue
-        # We run the split_axis rule with tracers, which is supposed to never
-        # mix this axis name with another one. We will handle any invocations
-        # of collectives over the vmapped axis in a recursive call from a tracer.
-        if len(axis_names) > 1:
-          return split_axis(primitive, axis_name, tracers, params)
-        vals_out, dims_out = collective_rules[primitive](vals_in, dims_in, frame.size, **params)
-        results = map(partial(BatchTracer, self), vals_out, dims_out)
-        return results if primitive.multiple_results else results[0]
-    # TODO(mattjj,phawkins): if no rule implemented, could vmap-via-map here
-    batched_primitive = get_primitive_batcher(primitive, self.axis_name)
-    val_out, dim_out = batched_primitive(vals_in, dims_in, **params)
+    if (primitive in collective_rules and
+          _main_trace_for_axis_names(self.main, params['axis_name'])):
+      frame = core.axis_frame(self.axis_name)
+      val_out, dim_out = collective_rules[primitive](frame, vals_in, dims_in, **params)
+    else:
+      batched_primitive = get_primitive_batcher(primitive, self.axis_name)
+      val_out, dim_out = batched_primitive(vals_in, dims_in, **params)
     if primitive.multiple_results:
       return map(partial(BatchTracer, self), val_out, dim_out)
     else:
@@ -266,6 +255,16 @@ class BatchTrace(Trace):
     if not fst:
       out_dims = out_dims[-len(out_vals) % len(out_dims):]
     return [BatchTracer(self, v, d) for v, d in zip(out_vals, out_dims)]
+
+def _main_trace_for_axis_names(main_trace: core.MainTrace,
+                               axis_name: Union[core.AxisName, Tuple[core.AxisName, ...]]
+                               ) -> bool:
+  # This function exists to identify whether a main trace corresponds to any of
+  # the axis names used by a primitive. Axis names alone aren't enough because
+  # axis names can shadow, so we use the main trace as a tag.
+  if not isinstance(axis_name, (list, tuple)):
+    axis_name = (axis_name,)
+  return any(main_trace is core.axis_frame(n).main_trace for n in axis_name)
 
 
 ### primitives
@@ -471,10 +470,4 @@ def omnistaging_disabler() -> None:
     return core.ClosedJaxpr(jaxpr_out, consts_out), batched_out()
 
 
-# collective_rules can assume that the collective is only carried out throughout
-# the vmapped axis (i.e. no tuples in axis_name).
 collective_rules: Dict[core.Primitive, Callable] = {}
-split_axis_rules: Dict[core.Primitive, Callable] = {}
-
-def split_axis(primitive, split_name, args, params):
-  return split_axis_rules[primitive](split_name, args, params)

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1751,6 +1751,7 @@ class VmapPmapCollectivesTest(jtu.JaxTestCase):
           "vmap collectives only supported when omnistaging is enabled")
   @ignore_slow_all_to_all_warning()
   def testAllToAllMultipleAxesVsVmap(self, axes, split_axis, concat_axis):
+    raise SkipTest("multi-axis all_to_all broken after #4835")  # TODO(mattjj,apaszke)
     if xla_bridge.device_count() < 4:
       raise SkipTest("test requires at least four devices")
 


### PR DESCRIPTION
These changes came from experimenting with a `pdot` primitive.

The main intended changes here are:
1. remove the need for split axis rules in batching.py, and instead rely on just the collective rules (namely to handle vectorizing their operation over a single named axis even if the collective is applied over multiple named axes)
2. simplify `BatchTrace.process_primitive` so that we don't pass tracers into rules and rely on a somewhat subtle recursion

Another minor change is we factor some tests to be more granular, so as to make it easier to select individual cases from the command line.

---


Before this PR, we had two separate tables in batching.py which held rules for handling collectives:
1. `collective_rules` which only needed to handle the case of operating over single named axes (rather than tuples of named axes), e.g. `psum(x, 'i')` but not `psum(x, ('i', 'j')`, and
2. `split_axis_rules` which would split a collective operating over more than one axis into a composition of primitives operating on single axes, e.g. `psum(x, ('i', 'j'))` would be split into `psum(psum(x, 'i'), 'j')`.

These two rules were used together to support collectives with `vmap`, where the latter would decompose things so that they could be handled by the former.

However, there was a complexity cost: the logic in `BatchTrace.process_primitive` involved a subtle recursion, and we had two tables of rules instead of one.

After this PR, we just have a table of `collective_rules`, where these rules do need to handle the case of collectives that operate over multiple axis names. This rule setup is more general, in that one can always implement this kind of a rule by composing the functions that constituted the previous set of rules, but we aren't forced to factor the code that way. Moreover, we avoid the subtle recursion in `BatchTrace.process_primitive`.

---

Follow-up work needed:
* This change breaks multi-axis all_to_all. We can either implement the previous logic in terms of the new rule organization (not included in this PR just because it's very tricky logic and supporting it is not a blocker), or we can avoid the need for multi-axis all_to_all by adjusting how gmap/xmap lowering works (so we don't need to do any axis splitting for all_to_all, thus avoiding the trickiness).
* Make `pmin_p` and `pmax_p` be multi-input/multi-output to bring them in line with `psum_p` so that we can share more helper code among these three monoid reducer collectives (#5011).
* Rename the `axis_name` parameter used by collectives to be `axis_names`, and correspondingly ensure at the "traceable" level (e.g. in the `psum` function that calls `psum_p.bind`) that it's always a tuple, rather than a tuple-or-singleton as it is now. This way we handle the polymorphism as early as possible, so the growing amount of downstream code that processes collectives doesn't need to handle both cases.