### PR TITLE
Fix manylinux2010 compliance of GPU wheels.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,9 +13,9 @@ RUN /pyenv/bin/pyenv install 3.7.2
 RUN /pyenv/bin/pyenv install 3.8.0
 
 # We pin numpy to a version < 1.16 to avoid version compatibility issues.
-RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.6.8 && pip install numpy==1.15.4 scipy cython setuptools wheel packaging six
-RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.7.2 && pip install numpy==1.15.4 scipy cython setuptools wheel packaging six
-RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.8.0 && pip install numpy==1.17.3 scipy cython setuptools wheel packaging six
+RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.6.8 && pip install numpy==1.15.4 scipy cython setuptools wheel packaging six auditwheel
+RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.7.2 && pip install numpy==1.15.4 scipy cython setuptools wheel packaging six auditwheel
+RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.8.0 && pip install numpy==1.17.3 scipy cython setuptools wheel packaging six auditwheel
 
 # Change the CUDA version if it doesn't match the installed version.
 ARG JAX_CUDA_VERSION=10.0

--- a/build/build_wheel_docker_entrypoint.sh
+++ b/build/build_wheel_docker_entrypoint.sh
@@ -7,6 +7,7 @@ then
 fi
 
 export CC=/dt7/usr/bin/gcc
+export GCC_HOST_COMPILER_PATH=/dt7/usr/bin/gcc
 export PYENV_ROOT="/pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
@@ -61,4 +62,8 @@ esac
 
 export JAX_CUDA_VERSION=$3
 python setup.py bdist_wheel --python-tag "$PY_TAG" --plat-name "$PLAT_NAME"
+if python -m auditwheel show dist/jaxlib-*.whl  | grep -v 'platform tag: "manylinux2010_x86_64"' > /dev/null; then
+  echo "jaxlib wheel is not manylinux2010 compliant"
+  exit 1
+fi
 cp -r dist/* /dist

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -39,6 +39,7 @@ jax 0.2.6 (Unreleased)
 jaxlib 0.1.57 (unreleased)
 ------------------------------
 
+* Fixed manylinux2010 compliance issues in GPU wheels.
 * Switched the CPU FFT implementation from Eigen to PocketFFT.
 * Fixed a bug where the hash of bfloat16 values was not correctly initialized
   and could change (#4651).


### PR DESCRIPTION
Use GCC_HOST_COMPILER_PATH to point to the devtoolset compiler.
Use auditwheel to verify manylinux2010 compliance.

Fixes #3881 
Fixes #4677