### PR TITLE
Add support for pmap in_axes other than 0 and None 

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -454,7 +454,7 @@ captured using the ``xla_pmap`` primitive. Consider this example
                     devices=None
                     donated_invars=(False, False)
                     global_axis_size=None
-                    mapped_invars=(False, True)
+                    in_axes=(None, 0)
                     name=inner ] b a
   in (c,) }
 
@@ -462,6 +462,6 @@ The ``xla_pmap`` primitive specifies the name of the axis (parameter ``rows``)
 and the body of the function to be mapped as the ``call_jaxpr`` parameter.
 value of this parameter is a Jaxpr with 3 input variables:
 
-The parameter ``mapped_invars`` specify which of the input variables should be
+The parameter ``in_axes`` specifies which of the input variables should be
 mapped and which should be broadcast. In our example, the value of ``extra``
 is broadcast, the other input values are mapped.

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -1585,7 +1585,7 @@ def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
   # outputs from the jaxpr here, and updating out_flat below.
   extensive_invars = jaxpr_1_opt.jaxpr.invars[num_consts_1 + num_carry:]
   extensive_outvars = jaxpr_1_opt.jaxpr.outvars[num_carry:]
-  extensive_avals = [core.unmapped_aval(length, core.raise_to_shaped(v.aval))
+  extensive_avals = [core.unmapped_aval(length, 0, core.raise_to_shaped(v.aval))
                      for v in extensive_outvars]
   fwd_extensive = [num_consts + num_carry + extensive_invars.index(v)
                    if v in extensive_invars else None for v in extensive_outvars]
@@ -1833,7 +1833,7 @@ def _scan_typecheck(bind_time, *avals, reverse, length, num_consts, num_carry,
   const_avals_jaxpr, init_avals_jaxpr, x_avals_jaxpr = split_list(
       jaxpr.in_avals, [num_consts, num_carry])
   carry_avals_jaxpr, _ = split_list(jaxpr.out_avals, [num_carry])
-  x_avals_mapped = _map(partial(core.mapped_aval, length), x_avals)
+  x_avals_mapped = _map(partial(core.mapped_aval, length, 0), x_avals)
 
   core.typecheck_assert(
       all(_map(core.typematch, init_avals_jaxpr, carry_avals_jaxpr)),

--- a/jax/api.py
+++ b/jax/api.py
@@ -1337,7 +1337,6 @@ def pmap(fun: Callable[..., T],
       axis so that parallel collectives can be applied.
     in_axes: A non-negative integer, None, or nested Python container thereof
       that specifies which axes in the input to map over (see :py:func:`vmap`).
-      Currently, only 0 and None are supported axes for pmap.
     static_broadcasted_argnums: An int or collection of ints specifying which
       positional arguments to treat as static (compile-time constant).
       Operations that only depend on static arguments will be constant-folded.
@@ -1497,9 +1496,6 @@ def pmap(fun: Callable[..., T],
   donate_tuple = rebase_donate_argnums(_ensure_tuple(donate_argnums),
                                        static_broadcasted_tuple)
 
-  if any(axis != 0 for axis in tree_leaves(in_axes)):
-    raise ValueError(f"pmap in_axes leaves must be 0 or None, got {in_axes}")
-
   @wraps(fun)
   @api_boundary
   def f_pmapped(*args, **kwargs):
@@ -1533,7 +1529,7 @@ def pmap(fun: Callable[..., T],
         flat_fun, *args, backend=backend, axis_name=axis_name,
         axis_size=local_axis_size, global_axis_size=axis_size,
         devices=None if devices is None else tuple(devices),
-        mapped_invars=tuple(axis is not None for axis in in_axes_flat),
+        in_axes=tuple(in_axes_flat),
         name=flat_fun.__name__, donated_invars=tuple(donated_invars))
     return tree_unflatten(out_tree(), out)
 
@@ -1557,12 +1553,11 @@ def soft_pmap(fun: Callable, axis_name: Optional[AxisName] = None, in_axes=0
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten((args, kwargs))
     in_axes_flat = flatten_axes("soft_pmap in_axes", in_tree, (in_axes, 0))
-    mapped_invars = tuple(axis is not None for axis in in_axes_flat)
     axis_size = _mapped_axis_size(in_tree, args_flat, in_axes_flat, "soft_pmap")
     for arg in args_flat: _check_arg(arg)
     flat_fun, out_tree = flatten_fun(f, in_tree)
     outs = pxla.soft_pmap(flat_fun, *args_flat, axis_name=axis_name,
-                          axis_size=axis_size, mapped_invars=mapped_invars)
+                          axis_size=axis_size, in_axes=tuple(in_axes_flat))
     return tree_unflatten(out_tree(), outs)
   return f_pmapped
 

--- a/jax/experimental/general_map.py
+++ b/jax/experimental/general_map.py
@@ -250,7 +250,7 @@ def gmap(fun: Callable, schedule, axis_name = None) -> Callable:
   def f_gmapped(*args, **kwargs):
     f = lu.wrap_init(fun)
     args_flat, in_tree = tree_flatten((args, kwargs))
-    mapped_invars = (True,) * len(args_flat)
+    in_axes = (0,) * len(args_flat)
     axis_size = _mapped_axis_size(in_tree, args_flat, (0,) * len(args_flat), "gmap")
     parsed_schedule = _normalize_schedule(schedule, axis_size, binds_axis_name)
     for arg in args_flat: _check_arg(arg)
@@ -259,7 +259,7 @@ def gmap(fun: Callable, schedule, axis_name = None) -> Callable:
         flat_fun, *args_flat,
         axis_name=axis_name,
         axis_size=axis_size,
-        mapped_invars=mapped_invars,
+        in_axes=in_axes,
         schedule=parsed_schedule,
         binds_axis_name=binds_axis_name)
     return tree_unflatten(out_tree(), outs)
@@ -308,10 +308,10 @@ def _parse_name(name):
     raise ValueError(f"Unrecognized loop type: {name}") from err
 
 
-def gmap_impl(fun: lu.WrappedFun, *args, axis_size, axis_name, binds_axis_name, mapped_invars, schedule):
+def gmap_impl(fun: lu.WrappedFun, *args, axis_size, axis_name, binds_axis_name, in_axes, schedule):
   avals = [core.raise_to_shaped(core.get_aval(arg)) for arg in args]
   scheduled_fun = _apply_schedule(fun, axis_size, axis_name, binds_axis_name,
-                                  mapped_invars, schedule, *avals)
+                                  in_axes, schedule, *avals)
   return scheduled_fun(*args)
 
 class _GMapSubaxis:
@@ -330,12 +330,12 @@ class _GMapSubaxis:
 @lu.cache
 def _apply_schedule(fun: lu.WrappedFun,
                     axis_size, full_axis_name, binds_axis_name,
-                    mapped_invars,
+                    in_axes,
                     schedule,
                     *avals):
-  assert all(mapped_invars)
-  mapped_avals = [core.mapped_aval(axis_size, aval) if mapped else aval
-                  for mapped, aval in zip(mapped_invars, avals)]
+  mapped_avals = [core.mapped_aval(axis_size, in_axis, aval)
+                  if in_axis is not None else aval
+                  for aval, in_axis in zip(avals, in_axes)]
   with core.extend_axis_env(full_axis_name, axis_size, None):
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_avals)
 
@@ -346,19 +346,20 @@ def _apply_schedule(fun: lu.WrappedFun,
   sched_fun = lambda *args: core.eval_jaxpr(jaxpr, consts, *args)
   for (ltype, size), axis_name in list(zip(schedule, axis_names))[::-1]:
     if ltype is LoopType.vectorized:
-      sched_fun = jax.vmap(sched_fun, axis_name=axis_name)
+      sched_fun = jax.vmap(sched_fun, axis_name=axis_name, in_axes=in_axes)
     elif ltype is LoopType.parallel:
-      sched_fun = jax.pmap(sched_fun, axis_name=axis_name)
+      sched_fun = jax.pmap(sched_fun, axis_name=axis_name, in_axes=in_axes)
     elif ltype is LoopType.sequential:
       if binds_axis_name:
         raise NotImplementedError("gmaps with sequential components of the schedule don't support "
                                   "collectives yet. Please open a feature request!")
       assert not binds_axis_name
-      sched_fun = lambda *args, sched_fun=sched_fun: jax.lax.map(lambda xs: sched_fun(*xs), args)
+      sched_fun = lambda *args, sched_fun=sched_fun: _sequential_map(sched_fun, in_axes, args)
 
   dim_sizes = tuple(loop.size for loop in schedule)
   def sched_fun_wrapper(*args):
-    split_args = [arg.reshape(dim_sizes + arg.shape[1:]) for arg in args]
+    split_args = [arg.reshape(arg.shape[:in_axis] + dim_sizes + arg.shape[in_axis + 1:])
+                  for arg, in_axis in zip(args, in_axes)]
     results = sched_fun(*split_args)
     return [res.reshape((axis_size,) + res.shape[len(dim_sizes):]) for res in results]
   return sched_fun_wrapper
@@ -366,6 +367,12 @@ def _apply_schedule(fun: lu.WrappedFun,
 gmap_p = core.MapPrimitive('gmap')
 gmap_p.def_impl(gmap_impl)
 
+def _sequential_map(f, flat_in_axes, args):
+  flat_args, treedef = tree_flatten(args)
+  flat_args_leading = [jnp.moveaxis(arg, in_axis, 0)
+                       for arg, in_axis in zip(flat_args, flat_in_axes)]
+  args_leading = tree_unflatten(treedef, flat_args_leading)
+  return jax.lax.map(lambda xs: f(*xs), args_leading)
 
 def subst_axis_names(jaxpr, axis_subst: Dict[AxisName, Tuple[AxisName]]):
   eqns = [subst_eqn_axis_names(eqn, axis_subst) for eqn in jaxpr.eqns]

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -25,7 +25,7 @@ from ..core import Trace, Tracer, get_aval, call_p, Primitive, Literal
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
                        zeros_like_p, Zero)
 from ..abstract_arrays import raise_to_shaped
-from ..util import unzip2, safe_map, safe_zip, partial, split_list, wrap_name
+from ..util import unzip2, safe_map, safe_zip, partial, split_list, wrap_name, moveaxis
 from ..tree_util import register_pytree_node
 from .. import linear_util as lu
 from ..api_util import flatten_fun, flatten_fun_nokwargs
@@ -165,12 +165,16 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
 
   def write_cotangent(v, ct):
     # assert v not in primal_env
-    if (ct is not None and type(v) is not Literal and
-        type(ct) is not Zero and ct is not Zero):
-      ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
-      if not core.skip_checks:
-        ct_aval = core.get_aval(ct_env[v])
-        assert v.aval.strip_weak_type() == core.lattice_join(v.aval, ct_aval).strip_weak_type(), (v.aval, ct_aval)
+    if ct is None or type(v) is Literal:
+      return
+    if type(ct) is Zero:
+      # FIXME: This triggers a lot of failures!
+      # assert v.aval == ct.aval, (v.aval, ct.aval)
+      return
+    ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
+    if not core.skip_checks:
+      ct_aval = core.get_aval(ct_env[v])
+      assert v.aval.strip_weak_type() == core.lattice_join(v.aval, ct_aval).strip_weak_type(), (v.aval, ct_aval)
 
   def read_cotangent(v):
     return ct_env.get(v, Zero(v.aval))
@@ -284,9 +288,9 @@ class JVPTrace(Trace):
     nz_tangents = [type(t) is not Zero for t in tangents]
     params = dict(params, name=wrap_name(params['name'], 'jvp'))
     if isinstance(call_primitive, core.MapPrimitive):
-      mapped_invars = params['mapped_invars']
-      mapped_tangents = [m for m, nz in zip(mapped_invars, nz_tangents) if nz]
-      params = dict(params, mapped_invars=(*mapped_invars, *mapped_tangents))
+      in_axes = params['in_axes']
+      tangent_in_axes = [ax for ax, nz in zip(in_axes, nz_tangents) if nz]
+      params = dict(params, in_axes=(*in_axes, *tangent_in_axes))
     update_params = call_param_updaters.get(call_primitive)
     new_params = update_params(params, nz_tangents) if update_params else params
     result = call_primitive.bind(f_jvp, *primals, *nonzero_tangents, **new_params)
@@ -305,7 +309,7 @@ class JVPTrace(Trace):
     return out, todo
 
   # The only difference between process_map and process_call is that
-  # the `mapped_invars` param must be updated; that's handled in process_call.
+  # the `in_axes` param must be updated; that's handled in process_call.
   process_map = process_call
   post_process_map = post_process_call
 
@@ -557,11 +561,13 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
-  new_mapped_invars = (*[m for m, x in zip(params['mapped_invars'], args)
-                         if not is_undefined_primal(x)],
-                       *[True for x in ct if type(x) is not Zero])
+  # Preserve axis for primal arguments, skip tangents (represented as undefined primals),
+  # we only support out_axes=0 for now, so hard-code that for each cotangent.
+  new_in_axes = (*[axis for axis, x in zip(params['in_axes'], args)
+                   if not is_undefined_primal(x)],
+                 *[0 for x in ct if type(x) is not Zero])
   new_params = dict(params, name=wrap_name(params['name'], 'transpose'),
-                    mapped_invars=new_mapped_invars)
+                    in_axes=new_in_axes)
   update_params = call_transpose_param_updaters.get(primitive)
   if update_params:
     new_params = update_params(new_params, map(is_undefined_primal, args),
@@ -569,14 +575,18 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   out_flat = primitive.bind(fun, *all_args, **new_params)
   arg_cts = tree_unflatten(out_tree(), out_flat)
 
-  mapped_invars = params['mapped_invars']  # True for each mapped invar
+  in_axes = params['in_axes']
   # The freevars are being fanned out (not mapped). During transpose the
   # dual of fan-out is fan-in-sum. We apply it to the unmapped invars.
-  assert len(mapped_invars) == len(arg_cts)
-  arg_cts = (arg_ct if arg_mapped or type(arg_ct) is Zero else arg_ct.sum(0)
-             for arg_ct, arg_mapped in zip(arg_cts, mapped_invars))
-
-  return arg_cts
+  assert len(in_axes) == len(arg_cts)
+  def unmap_zero(zero, in_axis):
+    return (zero if in_axis is None else
+            Zero(core.unmapped_aval(params['axis_size'], in_axis, zero.aval)))
+  arg_cts = (unmap_zero(arg_ct, in_axis) if type(arg_ct) is Zero else
+             moveaxis(arg_ct, 0, in_axis) if in_axis is not None else
+             arg_ct.sum(0)
+             for arg_ct, in_axis in zip(arg_cts, in_axes))
+  return tuple(arg_cts)
 
 
 def jvp_jaxpr(jaxpr, nonzeros, instantiate):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -23,7 +23,7 @@ from ..abstract_arrays import ShapedArray, raise_to_shaped
 from ..ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
 from .. import linear_util as lu
 from ..util import (unzip2, partial, safe_map, wrap_name, split_list,
-                    canonicalize_axis)
+                    canonicalize_axis, moveaxis)
 from . import xla
 from . import partial_eval as pe
 
@@ -188,14 +188,28 @@ class BatchTrace(Trace):
     if all(dim is not_mapped for dim in dims):
       return map_primitive.bind(f, *vals, **params)
     else:
-      mapped_invars = params['mapped_invars']
-      size, = {x.shape[d] for x, d in zip(vals, dims) if d is not not_mapped}
-      vals = [moveaxis(x, d, 1) if d == 0 and mapped_invar else x
-              for x, d, mapped_invar in zip(vals, dims, mapped_invars)]
-      dims = tuple(not_mapped if d is not_mapped else max(0, d - mapped_invar)
-                   for d, mapped_invar in zip(dims, mapped_invars))
-      f, dims_out = batch_subtrace(f, self.main, dims)
-      vals_out = map_primitive.bind(f, *vals, **params)
+      assert len({x.shape[d] for x, d in zip(vals, dims) if d is not not_mapped}) == 1
+      # The logic for the dimension math below is as follows:
+      # ╔═════════════╦════════════════════════════════════════╦═══════════╗
+      # ║ d / in_axis ║ None                                   ║ int       ║
+      # ╠═════════════╬════════════════════════════════════════╩═══════════╣
+      # ║ None        ║ No extra axis, so in_axis unaffected               ║
+      # ╠═════════════╬════════════════════════════════════════╦═══════════╣
+      # ║ int         ║ Not mapped, so batching dim unaffected ║ See below ║
+      # ╚═════════════╩════════════════════════════════════════╩═══════════╝
+      # When both d and in_axis are defined then:
+      # - If `d <= in_axis`, we have to move the `in_axis` one dimension further;
+      # - If `d >  in_axis`, we have to decrement `d` (as `in_axis` will get removed).
+      def fmap(x, f): return None if x is None else f(x)
+      new_in_axes = tuple(fmap(in_axis,
+                               lambda ax: ax + (1 if d is not None and d <= in_axis else 0))
+                          for d, in_axis in zip(dims, params['in_axes']))
+      new_dims = tuple(fmap(d,
+                            lambda dv: dv - (1 if in_axis is not None and in_axis < d else 0))
+                       for d, in_axis in zip(dims, params['in_axes']))
+      f, dims_out = batch_subtrace(f, self.main, new_dims)
+      vals_out = map_primitive.bind(f, *vals, **dict(params, in_axes=new_in_axes))
+      # We assume that out_axes are all 0, so we increment d
       dims_out = tuple(d + 1 if d is not not_mapped else d for d in dims_out())
       return [BatchTracer(self, v, d) for v, d in zip(vals_out, dims_out)]
 
@@ -343,17 +357,6 @@ def broadcast(x, sz, axis):
   shape.insert(axis, sz)
   broadcast_dims = tuple(np.delete(np.arange(len(shape)), axis))
   return jax.lax.broadcast_in_dim(x, shape, broadcast_dims)
-
-def moveaxis(x, src, dst):
-  if core.get_aval(x) is core.abstract_unit:
-    return core.unit
-  if src == dst:
-    return x
-  src = canonicalize_axis(src, x.ndim)
-  dst = canonicalize_axis(dst, x.ndim)
-  perm = [i for i in range(np.ndim(x)) if i != src]
-  perm.insert(dst, src)
-  return x.transpose(perm)
 
 def matchaxis(sz, src, dst, x, sum_match=False):
   if core.get_aval(x) is core.abstract_unit:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -175,13 +175,13 @@ class JaxprTrace(Trace):
     in_pvals = [t.pval for t in tracers]
     if primitive.map_primitive:
       mapped_aval = partial(core.mapped_aval, params['axis_size'])
-      in_pvals = [pval if pval.is_known() or not is_mapped
-                  else PartialVal.unknown(mapped_aval(pval[0]))
-                  for pval, is_mapped in zip(in_pvals, params['mapped_invars'])]
+      in_pvals = [pval if pval.is_known() or in_axis is None
+                  else PartialVal.unknown(mapped_aval(in_axis, pval[0]))
+                  for pval, in_axis in zip(in_pvals, params['in_axes'])]
     jaxpr, out_pvals, consts, env_tracers = self.partial_eval(
         f, in_pvals, partial(primitive.bind, **params), instantiate=False)
     if primitive.map_primitive:
-      unmapped_aval = partial(core.unmapped_aval, params['axis_size'])
+      unmapped_aval = partial(core.unmapped_aval, params['axis_size'], 0)
       out_pvals = [pval if pval.is_known()
                    else PartialVal.unknown(unmapped_aval(pval[0]))
                    for pval in out_pvals]
@@ -216,12 +216,14 @@ class JaxprTrace(Trace):
     # Set up new params
     new_params = dict(params, call_jaxpr=convert_constvars_jaxpr(jaxpr))
     if primitive.map_primitive:
-      mapped_invars = params['mapped_invars']
-      new_mapped_invars = ((True,) * len(const_tracers) +
-                           (False,) * len(env_tracers) +
-                           tuple(v for v, t in zip(mapped_invars, tracers)
-                                 if not t.pval.is_known()))
-      new_params = dict(new_params, mapped_invars=new_mapped_invars)
+      in_axes = params['in_axes']
+      # NOTE: const_tracers are outputs of the map, and those have had to
+      #       be mapped along axis 0
+      new_in_axes = ((0,) * len(const_tracers) +
+                     (None,) * len(env_tracers) +
+                     tuple(axis for axis, t in zip(in_axes, tracers)
+                           if not t.pval.is_known()))
+      new_params = dict(new_params, in_axes=new_in_axes)
     update_params = call_param_updaters.get(primitive)
     if update_params:
       new_params = update_params(new_params, [not t.pval.is_known() for t in tracers])
@@ -243,7 +245,7 @@ class JaxprTrace(Trace):
 
     if primitive.map_primitive:
       sz = params['axis_size']
-      out_pvs = [None if pv is None else core.unmapped_aval(sz, pv)
+      out_pvs = [None if pv is None else core.unmapped_aval(sz, 0, pv)
                  for pv in out_pvs]
 
     def todo(x):
@@ -257,8 +259,10 @@ class JaxprTrace(Trace):
 
       new_params = dict(params, call_jaxpr=convert_constvars_jaxpr(jaxpr))
       if primitive.map_primitive:
-        new_mapped_invars = (True,) * len(const_tracers) + (False,) * len(env)
-        new_params = dict(new_params, mapped_invars=new_mapped_invars)
+        # NOTE: const_tracers are outputs of the map, and those have had to
+        #       be mapped along axis 0
+        new_in_axes = (0,) * len(const_tracers) + (None,) * len(env)
+        new_params = dict(new_params, in_axes=new_in_axes)
       update_params = call_param_updaters.get(primitive)
       if update_params:
         new_params = update_params(new_params, [])
@@ -539,8 +543,8 @@ def new_eqn_recipe(invars: Sequence[JaxprTracer],
   if primitive.call_primitive or primitive.map_primitive:
     assert "call_jaxpr" in params
   if primitive.map_primitive:
-    assert ("mapped_invars" in params and
-            len(params["mapped_invars"]) == len(params["call_jaxpr"].invars))
+    assert ("in_axes" in params and
+            len(params["in_axes"]) == len(params["call_jaxpr"].invars))
     assert ("donated_invars" in params and
             len(params["donated_invars"]) == len(params["call_jaxpr"].invars))
   return JaxprEqnRecipe(object(), tuple(invars), map(ref, outvars), primitive,
@@ -1073,19 +1077,19 @@ class DynamicJaxprTrace(core.Trace):
   def process_map(self, map_primitive, f, tracers, params):
     in_avals = [t.aval for t in tracers]
     axis_name, axis_size = params['axis_name'], params['axis_size']
-    reduced_in_avals = [core.mapped_aval(axis_size, a) if m else a
-                        for m, a in zip(params['mapped_invars'], in_avals)]
+    reduced_in_avals = [core.mapped_aval(axis_size, in_axis, a) if in_axis is not None else a
+                        for a, in_axis in zip(in_avals, params['in_axes'])]
     with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.main, reduced_in_avals)
-    out_avals = [core.unmapped_aval(params['axis_size'], a) for a in reduced_out_avals]
+    out_avals = [core.unmapped_aval(params['axis_size'], 0, a) for a in reduced_out_avals]
     source_info = source_info_util.current()
     out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     constvars = map(self.getvar, map(self.instantiate_const, consts))
     outvars = map(self.makevar, out_tracers)
-    new_mapped_invars = (False,) * len(consts) + params['mapped_invars']
-    new_params = dict(params, mapped_invars=new_mapped_invars,
+    new_in_axes = (None,) * len(consts) + params['in_axes']
+    new_params = dict(params, in_axes=new_in_axes,
                       call_jaxpr=convert_constvars_jaxpr(jaxpr))
     update_params = call_param_updaters.get(map_primitive)
     if update_params:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -46,7 +46,8 @@ from .. import lazy
 from ..abstract_arrays import ConcreteArray, ShapedArray, array_types
 from ..core import Var, Literal
 from ..util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,
-                    extend_name_stack, wrap_name, assert_unreachable)
+                    extend_name_stack, wrap_name, assert_unreachable,
+                    tuple_insert, tuple_delete)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from ..tree_util import tree_flatten, tree_map
@@ -278,30 +279,30 @@ def _as_slice_indices(arr: xla.DeviceArray, idx: Index) -> Tuple[
     elif sub_idx == slice(None):
       continue
     else:
-      assert isinstance(sub_idx, slice)
-      assert isinstance(sub_idx.start, int)
-      assert isinstance(sub_idx.stop, int)
+      assert isinstance(sub_idx, slice), sub_idx
+      assert isinstance(sub_idx.start, int), sub_idx
+      assert isinstance(sub_idx.stop, int), sub_idx
       start_indices[dim] = sub_idx.start
       limit_indices[dim] = sub_idx.stop
 
   return tuple(start_indices), tuple(limit_indices), tuple(removed_dims) # type: ignore
 
 
-def shard_aval(size, aval):
+def shard_aval(size, axis: int, aval):
   try:
-    return shard_aval_handlers[type(aval)](size, aval)
+    return shard_aval_handlers[type(aval)](size, axis, aval)
   except KeyError as err:
-    raise TypeError("No shard_aval handler for type: {}".format(type(aval))
-                    ) from err
-shard_aval_handlers: Dict[Type[core.AbstractValue], Callable[[int, Any], Any]] = {}
-shard_aval_handlers[core.AbstractUnit] = lambda size, x: x
-def _shard_abstract_array(size, x):
-  if not x.shape:
-    raise ValueError("Scalar cannot be split across {} shards.".format(size))
-  if x.shape[0] != size:
-    raise ValueError("Axis size {} does not match leading dimension of "
-                     "shape {}".format(size, x.shape))
-  return ShapedArray(x.shape[1:], x.dtype)
+    raise TypeError(f"No shard_aval handler for type: {type(aval)}") from err
+shard_aval_handlers: Dict[Type[core.AbstractValue], Callable[[int, int, Any], Any]] = {}
+shard_aval_handlers[core.AbstractUnit] = lambda size, axis, x: x
+def _shard_abstract_array(size, axis: int, x):
+  try:
+    if x.shape[axis] != size:
+      raise ValueError(f"Axis size {size} does not match dimension {axis} of "
+                       f"shape {x.shape}")
+  except IndexError:
+    raise ValueError("Cannot split a {x.dim}D value along axis {axis}") from None
+  return ShapedArray(tuple_delete(x.shape, axis), x.dtype)
 shard_aval_handlers[ShapedArray] = _shard_abstract_array
 
 # TODO(skye): expose PyLocalBuffers in xla_client
@@ -376,12 +377,12 @@ class ShardedDeviceArray(xla.DeviceArray):
                indices: Optional[Tuple[Index, ...]] = None):
     # TODO(skye): this is temporary staging while we switch users over to
     # providing sharding_spec. It assumes that any pre-existing callers are
-    # creating pmap-style ShardedDeviceArrays.
+    # creating pmap-style ShardedDeviceArrays over the first dimension.
     if device_buffers is None:
       device_buffers = sharding_spec
       sharded_aval = ShapedArray(aval.shape[1:], aval.dtype)
       sharding_spec = _pmap_sharding_spec(aval.shape[0], aval.shape[0],
-                                          1, None, sharded_aval, True)
+                                          1, None, sharded_aval, 0)
 
     # TODO(skye): assert invariants. Keep performance in mind though.
     if indices is None:
@@ -503,10 +504,10 @@ xla.canonicalize_dtype_handlers[ShardedDeviceArray] = identity
 ### the xla_pmap primitive and its rules are comparable to xla_call in xla.py
 
 def xla_pmap_impl(fun: lu.WrappedFun, *args, backend, axis_name, axis_size,
-                  global_axis_size, devices, name, mapped_invars, donated_invars):
+                  global_axis_size, devices, name, in_axes, donated_invars):
   abstract_args = unsafe_map(xla.abstractify, args)
   compiled_fun = parallel_callable(fun, backend, axis_name, axis_size,
-                                   global_axis_size, devices, name, mapped_invars,
+                                   global_axis_size, devices, name, in_axes,
                                    donated_invars, *abstract_args)
   return compiled_fun(*args)
 
@@ -518,7 +519,7 @@ def parallel_callable(fun: lu.WrappedFun,
                       global_axis_size: Optional[int],
                       devices: Optional[Sequence[Any]],
                       name: str,
-                      mapped_invars: Iterable[bool],
+                      in_axes: Iterable[Optional[int]],
                       donated_invars: Iterable[bool],
                       *avals):
   if devices is not None and len(devices) == 0:
@@ -562,8 +563,8 @@ def parallel_callable(fun: lu.WrappedFun,
     local_devices = None  # type: ignore
 
   if config.omnistaging_enabled:
-    sharded_avals = tuple(shard_aval(axis_size, aval) if m else aval
-                          for m, aval in zip(mapped_invars, avals))
+    sharded_avals = tuple(shard_aval(axis_size, axis, aval) if axis is not None else aval
+                          for axis, aval in zip(in_axes, avals))
     with core.extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
       jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, sharded_avals)
     jaxpr = xla.apply_outfeed_rewriter(jaxpr)
@@ -573,13 +574,13 @@ def parallel_callable(fun: lu.WrappedFun,
       with extend_dynamic_axis_env(axis_name, dummy._trace, global_axis_size):  # type: ignore
         return fun.call_wrapped(*args)
 
-    sharded_avals = tuple(shard_aval(axis_size, aval) if m else aval
-                          for m, aval in zip(mapped_invars, avals))
+    sharded_avals = tuple(shard_aval(axis_size, axis, aval) if axis is not None else aval
+                          for axis, aval in zip(in_axes, avals))
     pvals = [pe.PartialVal.unknown(aval) for aval in sharded_avals]
     # We add a dummy first invar, to carry the trace  details to `dynamic_fun`
     pval = pe.PartialVal.unknown(core.abstract_unit)  # dummy value for axis env
     jaxpr, out_pvals, consts = pe.trace_to_jaxpr(  # type: ignore
-        dynamic_fun, [pval] + pvals, instantiate=False, stage_out=True, bottom=True)
+      dynamic_fun, [pval] + pvals, instantiate=False, stage_out=True, bottom=True)  # type: ignore
     jaxpr.invars = jaxpr.invars[1:]  # ignore dummy
     jaxpr = xla.apply_outfeed_rewriter(jaxpr)
 
@@ -605,8 +606,9 @@ def parallel_callable(fun: lu.WrappedFun,
       # out multi-replica XLA computations regardless of the hardware available.
       # The 'None' values here are just dummies we know will be ignored.
       handlers = [
-        _pval_to_result_handler(axis_size, None, None, None, pval, local_devices,  # type: ignore
-                                backend_name) for pval in out_pvals
+        _pval_to_result_handler(  # type: ignore
+          axis_size, None, None, None, pval, local_devices, backend_name)  # type: ignore
+        for pval in out_pvals
       ]
       results = [handler(None) for handler in handlers]
       return lambda *_: results
@@ -656,8 +658,9 @@ def parallel_callable(fun: lu.WrappedFun,
 
   c = xb.make_computation_builder("pmap_{}".format(fun.__name__))
   xla_consts = map(partial(xb.constant, c), consts)
+  replicated_args = [axis is None for axis in in_axes]
   xla_args, donated_invars = xla._xla_callable_args(c, sharded_avals, tuple_args,
-                                                    map(op.not_, mapped_invars), arg_parts,
+                                                    replicated_args, arg_parts,
                                                     donated_invars=donated_invars)
   with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
     out_nodes = xla.jaxpr_subcomp(c, jaxpr, backend_name, axis_env, xla_consts,
@@ -728,9 +731,9 @@ def parallel_callable(fun: lu.WrappedFun,
   arg_parts_ = arg_parts or [None] * len(avals)
   input_sharding_specs = [
       _pmap_sharding_spec(num_local_replicas, axis_size, num_partitions, parts,
-                          aval, mapped)
+                          aval, in_axis)
       if aval is not core.abstract_unit else None
-      for aval, parts, mapped in zip(sharded_avals, arg_parts_, mapped_invars)]
+      for aval, parts, in_axis in zip(sharded_avals, arg_parts_, in_axes)]
   input_indices = [spec_to_indices(aval.shape, spec)
                    if spec is not None else None
                    for aval, spec in zip(avals, input_sharding_specs)]
@@ -834,13 +837,14 @@ def avals_to_results_handler(size, nrep, npart, out_parts, out_avals):
     out_parts = (None,) * len(out_avals)
 
   # TODO(mattjj,skyewm): can probably clean up this logic
-  out_specs = [_pmap_sharding_spec(nrep, size, npart, parts, aval, True)
+  out_axis = 0
+  out_specs = [_pmap_sharding_spec(nrep, size, npart, parts, aval, out_axis)
               if aval is not core.abstract_unit else None
               for parts, aval in zip(out_parts, out_avals)]
-  out_indices = [spec_to_indices(core.unmapped_aval(size, aval).shape, spec)
+  out_indices = [spec_to_indices(core.unmapped_aval(size, out_axis, aval).shape, spec)
                 if aval is not core.abstract_unit else None
                 for aval, spec in zip(out_avals, out_specs)]  # pytype: disable=attribute-error
-  handlers = [aval_to_result_handler(spec, idcs, core.unmapped_aval(size, aval))
+  handlers = [aval_to_result_handler(spec, idcs, core.unmapped_aval(size, out_axis, aval))
               for spec, idcs, aval in zip(out_specs, out_indices, out_avals)]
 
   def handler(out_bufs):
@@ -854,7 +858,7 @@ def avals_to_results_handler(size, nrep, npart, out_parts, out_avals):
     return [h(bufs) for h, bufs in zip(handlers, buffers)]
   return handler
 
-def replicate(val, axis_size, nrep, devices=None, backend=None):
+def replicate(val, axis_size, nrep, devices=None, backend=None, in_axis=0):
   """Replicates ``val`` across multiple devices.
 
   Args:
@@ -867,6 +871,7 @@ def replicate(val, axis_size, nrep, devices=None, backend=None):
     devices: the devices to replicate across. If None, ``nrep`` will be used to
       generate a default device assignment.
     backend: string specifying which backend to use.
+    in_axis: axis along which the value is to be replciated.
 
   Returns:
     A ShardedDeviceArray of length `axis_size` where each shard is equal to
@@ -890,11 +895,11 @@ def replicate(val, axis_size, nrep, devices=None, backend=None):
   aval = xla.abstractify(val)  # type: ShapedArray
   replicated_aval = ShapedArray((axis_size,) + aval.shape, aval.dtype)
   # TODO(skye): figure out how partitioning should work here
-  sharding_spec = _pmap_sharding_spec(nrep, axis_size, 1, None, aval, True)
+  sharding_spec = _pmap_sharding_spec(nrep, axis_size, 1, None, aval, in_axis)
   device_buffers = device_put(val, devices, replicate=True)
   return ShardedDeviceArray(replicated_aval, sharding_spec, device_buffers)
 
-def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
+def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, in_axis: Optional[int]):
   """Sharding spec for arguments or results of a pmap.
   Args:
     nrep: number of local XLA replicas (product of local axis sizes)
@@ -903,7 +908,7 @@ def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
     parts: the partitioning of the value or None
     sharded_aval: the aval of the value inside the outer pmap, an instance of
       a ShapedArray.
-    mapped: whether the value is mapped in the outer pmap
+    in_axis: the axis along which the value is mapped in the outer pmap
   Returns:
     A ShardingSpec.
   """
@@ -913,14 +918,17 @@ def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
   # get the sharding spec from inner sharded_jits as if we weren't in a pmap
   pspec = partitioned_sharding_spec(npart, parts, sharded_aval)
   maybe_replicate = () if replication_factor == 1 else (Replicated(replication_factor),)
-  def shift_sharded_axis(dim_as: MeshDimAssignment):
-    return ShardedAxis(dim_as.axis + 1) if isinstance(dim_as, ShardedAxis) else dim_as
-  if mapped:
+  if in_axis is not None:
+    sharded_in_axis = sum(s is not None for s in pspec.sharding[:in_axis])
+    def shift_sharded_axis(a: MeshDimAssignment):
+      if isinstance(a, ShardedAxis) and a.axis >= sharded_in_axis:
+        return ShardedAxis(a.axis + 1)
+      return a
     # replication_factor represents the product of inner pmaps, so it goes
     # after the outer pmapped axis at index 0
     return ShardingSpec(
-      sharding=(Unstacked(axis_size),) + pspec.sharding,
-      mesh_mapping=it.chain([ShardedAxis(0)],
+      sharding=tuple_insert(pspec.sharding, in_axis, Unstacked(axis_size)),
+      mesh_mapping=it.chain([ShardedAxis(sharded_in_axis)],
                             maybe_replicate,
                             map(shift_sharded_axis, pspec.mesh_mapping)))
   else:
@@ -929,8 +937,8 @@ def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, mapped):
       mesh_mapping=(Replicated(axis_size),) + maybe_replicate + pspec.mesh_mapping)
 
 def partitioned_sharding_spec(num_partitions: int,
-                               partitions: Optional[Sequence[int]],
-                               aval) -> ShardingSpec:
+                              partitions: Optional[Sequence[int]],
+                              aval) -> ShardingSpec:
   if partitions is None:
     maybe_replicate = () if num_partitions == 1 else (Replicated(num_partitions),)
     return ShardingSpec(sharding=[None] * len(aval.shape),
@@ -960,7 +968,7 @@ ad.call_transpose_param_updaters[xla_pmap_p] = \
 def _pmap_translation_rule(c, axis_env,
                            in_nodes, name_stack, axis_name, axis_size,
                            global_axis_size, devices, name,
-                           call_jaxpr, *, backend=None, mapped_invars,
+                           call_jaxpr, *, backend=None, in_axes,
                            donated_invars):
   del donated_invars  # Unused.
   # We in-line here rather than generating a Call HLO as in the xla_call
@@ -973,8 +981,8 @@ def _pmap_translation_rule(c, axis_env,
   # Shard the in_nodes that are mapped
   in_avals = [v.aval for v in call_jaxpr.invars]
   in_nodes_sharded = (
-    _xla_shard(c, aval, new_env, in_node) if in_node_mapped else in_node
-    for aval, in_node, in_node_mapped in zip(in_avals, in_nodes, mapped_invars))
+    _xla_shard(c, aval, new_env, in_node, in_axis) if in_axis is not None else in_node
+    for aval, in_node, in_axis in zip(in_avals, in_nodes, in_axes))
 
   with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
     sharded_outs = xla.jaxpr_subcomp(
@@ -988,14 +996,19 @@ def _pmap_translation_rule(c, axis_env,
 xla.call_translations[xla_pmap_p] = _pmap_translation_rule
 ad.primitive_transposes[xla_pmap_p] = partial(ad.map_transpose, xla_pmap_p)
 
-def _xla_shard(c, aval, axis_env, x):
+def _xla_shard(c, aval, axis_env, x, in_axis):
   if aval is core.abstract_unit:
     return x
   elif isinstance(aval, ShapedArray):
     dims = list(c.get_shape(x).dimensions())
     zero = xb.constant(c, np.zeros((), dtype=np.uint32))
-    idxs = [_unravel_index(c, axis_env)] + [zero] * (len(dims) - 1)
-    return xops.Reshape(xops.DynamicSlice(x, idxs, [1] + dims[1:]), dims[1:])
+    idxs = [zero] * (len(dims) - 1)
+    idxs.insert(in_axis, _unravel_index(c, axis_env))
+    dims_unsqueezed = dims.copy()
+    dims_unsqueezed[in_axis] = 1
+    dims_squeezed = dims.copy()
+    dims_squeezed.pop(in_axis)
+    return xops.Reshape(xops.DynamicSlice(x, idxs, dims_unsqueezed), dims_squeezed)
   else:
     raise TypeError((aval, c.get_shape(x)))
 
@@ -1035,16 +1048,16 @@ def _unravel_index(c, axis_env):
   return xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
 
 
-def soft_pmap_impl(fun: lu.WrappedFun, *args, axis_name, axis_size, mapped_invars):
+def soft_pmap_impl(fun: lu.WrappedFun, *args, axis_name, axis_size, in_axes):
   abstract_args = unsafe_map(xla.abstractify, args)
-  compiled_fun = _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars,
+  compiled_fun = _soft_pmap_callable(fun, axis_name, axis_size, in_axes,
                                      *abstract_args)
   return compiled_fun(*args)
 
 @lu.cache
-def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
-  mapped_avals = [core.mapped_aval(axis_size, aval) if m else aval
-                  for m, aval in zip(mapped_invars, avals)]
+def _soft_pmap_callable(fun, axis_name, axis_size, in_axes, *avals):
+  mapped_avals = [core.mapped_aval(axis_size, in_axis, aval) if in_axis is not None else aval
+                  for in_axis, aval in zip(in_axes, avals)]
   with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_avals)
   jaxpr = xla.apply_outfeed_rewriter(jaxpr)
@@ -1055,7 +1068,7 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
     msg = f"number of devices {num_devices} must divide axis size {axis_size}"
     raise NotImplementedError(msg)
 
-  jaxpr, _, consts = _soft_pmap_jaxpr(jaxpr, consts, mapped_invars,
+  jaxpr, _, consts = _soft_pmap_jaxpr(jaxpr, consts, in_axes,
                                       axis_name, axis_size, chunk_size)
   jaxpr_replicas = xla.jaxpr_replicas(jaxpr)
   if jaxpr_replicas != 1: raise NotImplementedError
@@ -1064,8 +1077,8 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
 
   c = xb.make_computation_builder("soft_pmap_{}".format(fun.__name__))
   xla_consts = map(partial(xb.constant, c), consts)
-  chunked_avals = [core.unmapped_aval(chunk_size, aval) if m else aval
-                   for m, aval in zip(mapped_invars, mapped_avals)]
+  chunked_avals = [core.unmapped_aval(chunk_size, in_axis, aval) if in_axis is not None else aval
+                   for in_axis, aval in zip(in_axes, mapped_avals)]
   xla_args, _ = xla._xla_callable_args(c, chunked_avals, tuple_args)
   axis_env = xla.AxisEnv(num_devices, (axis_name,), (num_devices,), None)
   out_nodes = xla.jaxpr_subcomp(c, jaxpr, None, axis_env, xla_consts,
@@ -1079,12 +1092,14 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
   compiled = xla.backend_compile(backend, built, compile_options)
 
   input_specs = [
-      ShardingSpec(sharding=[Chunked(num_devices)] + [None] * (aval.ndim - 1),
+      ShardingSpec(sharding=tuple_insert((None,) * (aval.ndim - 1),
+                                         in_axis,
+                                         Chunked(num_devices)),
                    mesh_mapping=[ShardedAxis(0)])
-      if mapped else
+      if in_axis is not None else
       ShardingSpec(sharding=[None] * aval.ndim,
                    mesh_mapping=[Replicated(num_devices)])
-      for aval, mapped in zip(avals, mapped_invars)]
+      for aval, in_axis in zip(avals, in_axes)]
   input_indices = [spec and spec_to_indices(aval.shape, spec)
                    for aval, spec in zip(avals, input_specs)]
   handle_args = partial(shard_args, compiled.local_devices(), input_indices)
@@ -1092,14 +1107,17 @@ def _soft_pmap_callable(fun, axis_name, axis_size, mapped_invars, *avals):
 
   return partial(execute_replicated, compiled, backend, handle_args, handle_outs)
 
-def _soft_pmap_jaxpr(jaxpr, consts, mapped_invars, axis_name, axis_size, chunk_size):
+def _soft_pmap_jaxpr(jaxpr, consts, in_axes, axis_name, axis_size, chunk_size):
+  assert all(in_axis is None or in_axis == 0 for in_axis in in_axes), in_axes
+  mapped_invars = [in_axis is not None for in_axis in in_axes]
   fun = partial(_soft_pmap_interp, chunk_size, jaxpr, consts, mapped_invars)
-  in_avals = [core.unmapped_aval(chunk_size, v.aval) if m else v.aval
-              for v, m in zip(jaxpr.invars, mapped_invars)]
+  in_avals = [core.unmapped_aval(chunk_size, in_axis, v.aval) if in_axis is not None else v.aval
+              for v, in_axis in zip(jaxpr.invars, in_axes)]
   with core.extend_axis_env(axis_name, axis_size, None):
     return pe.trace_to_jaxpr_dynamic(lu.wrap_init(fun), in_avals)
 
 def _soft_pmap_interp(chunk_size, jaxpr, consts, mapped_invars, *args):
+
   env: Dict[Var, Tuple[Any, bool]] = {}
 
   def read(atom: Union[Var, Literal]) -> Tuple[Any, bool]:
@@ -1195,7 +1213,7 @@ def omnistaging_disabler() -> None:
       _thread_local_state, extend_dynamic_axis_env, unmapped_device_count, \
       apply_parallel_primitive, parallel_pure_rules, \
       _pvals_to_results_handler, _pval_to_result_handler, replicate, \
-      avals_to_results_handler, axis_index, maybe_extend_axis_env
+      axis_index, maybe_extend_axis_env
 
   @contextmanager
   def maybe_extend_axis_env(*args, **kwargs):
@@ -1247,8 +1265,7 @@ def omnistaging_disabler() -> None:
     else:
       if pv is not core.abstract_unit:
         unsharded_aval = ShapedArray((axis_size,) + pv.shape, pv.dtype)
-        sharding_spec = _pmap_sharding_spec(nrep, axis_size, npart, parts, pv,
-                                            True)
+        sharding_spec = _pmap_sharding_spec(nrep, axis_size, npart, parts, pv, 0)
         indices = spec_to_indices(unsharded_aval.shape, sharding_spec)
       else:
         sharding_spec = indices = None

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -512,7 +512,7 @@ def jaxpr_replicas(jaxpr):
   For a eqn, multiply the `axis_size` with the `jaxpr_replicas` of the
   subjaxprs. For a list of eqns, take the maximum number of replicas.
   """
-  return max(it.chain([1], (eqn_replicas(eqn) for eqn in jaxpr.eqns)))
+  return max((eqn_replicas(eqn) for eqn in jaxpr.eqns), default=1)
 
 # TODO(mattjj): this function assumes that only pmap has a parameter named
 # axis_size, and that it corresponds to cross-replica mapping

--- a/jax/util.py
+++ b/jax/util.py
@@ -255,6 +255,15 @@ def canonicalize_axis(axis, num_dims):
     axis = axis + num_dims
   return axis
 
+def moveaxis(x, src, dst):
+  if src == dst:
+    return x
+  src = canonicalize_axis(src, x.ndim)
+  dst = canonicalize_axis(dst, x.ndim)
+  perm = [i for i in range(np.ndim(x)) if i != src]
+  perm.insert(dst, src)
+  return x.transpose(perm)
+
 def ceil_of_ratio(x, y):
   return -(-x // y)
 
@@ -276,3 +285,9 @@ def get_doc(fun): return getattr(fun, "__doc__", "")
 #       but it seems like pytype doesn't support that...
 def assert_unreachable(x):
   raise AssertionError(f"Unhandled case: {type(x).__name__}")
+
+def tuple_insert(t, idx, val):
+  return t[:idx] + (val,) + t[idx:]
+
+def tuple_delete(t, idx):
+  return t[:idx] + t[idx + 1:]


### PR DESCRIPTION
... and in map primitives in general (which is why the patch touches
most traces).

This also fixes a bug in the transpose rule for map primitives, which
would fail to adjust the aval associated with zeros returned from the
map body.