### PR TITLE
Propagate weak types through unary and binary ops

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -207,8 +207,10 @@ For example:
 ...
 >>> print(make_jaxpr(one_of_three)(1, 5.))
 { lambda  ; a b.
-  let c = clamp 0 a 2
-      d = cond[ branches=( { lambda  ; a.
+  let c = convert_element_type[ new_dtype=int32
+                                weak_type=False ] a
+      d = clamp 0 c 2
+      e = cond[ branches=( { lambda  ; a.
                              let b = add a 1.0
                              in (b,) }
                            { lambda  ; a.
@@ -217,8 +219,8 @@ For example:
                            { lambda  ; a.
                              let b = add a 3.0
                              in (b,) } )
-                linear=(False,) ] c b
-  in (d,) }
+                linear=(False,) ] d b
+  in (e,) }
 
 The cond primitive has a number of parameters:
 
@@ -247,7 +249,8 @@ Another example, using :py:func:`lax.cond`:
 >>> print(make_jaxpr(func7)(5.))
 { lambda  ; a.
   let b = ge a 0.0
-      c = convert_element_type[ new_dtype=int32 ] b
+      c = convert_element_type[ new_dtype=int32
+                                weak_type=False ] b
       d = cond[ branches=( { lambda  ; a.
                              let b = sub a 3.0
                              in (b,) }
@@ -277,16 +280,20 @@ contains a constant ``jnp.ones(1)`` that is hoisted as a `constvar`
 >>> print(make_jaxpr(func8)(5., (jnp.zeros(1), 2.)))
 { lambda a ; b c d.
   let e = ge b 0.0
-      f = convert_element_type[ new_dtype=int32 ] e
+      f = convert_element_type[ new_dtype=int32
+                                weak_type=False ] e
       g = cond[ branches=( { lambda  ; a b c.
-                             let d = convert_element_type[ new_dtype=float32 ] a
+                             let d = convert_element_type[ new_dtype=float32
+                                                           weak_type=True ] a
                                  e = add d c
                              in (e,) }
                            { lambda  ; f_ a b.
-                             let
+                             let 
                              in (a,) } )
                 linear=(False, False, False) ] f a c d
   in (g,) }
+
+
 
 
 While
@@ -367,9 +374,13 @@ For the example consider the function ``func11`` below
                             shape=(16,) ] 1.0
       d e = scan[ jaxpr={ lambda  ; a b c d.
                           let e = mul c d
-                              f = add b e
-                              g = add f a
-                          in (g, b) }
+                              f = convert_element_type[ new_dtype=float32
+                                                        weak_type=False ] b
+                              g = add f e
+                              h = convert_element_type[ new_dtype=float32
+                                                        weak_type=False ] a
+                              i = add g h
+                          in (i, b) }
                   length=16
                   linear=(False, False, False, False)
                   num_carry=1
@@ -410,14 +421,20 @@ computation should run. For example
                     call_jaxpr={ lambda  ; a b.
                                  let c = broadcast_in_dim[ broadcast_dimensions=(  )
                                                            shape=(1,) ] 1.0
-                                     d = mul a c
-                                     e = add b d
-                                 in (e,) }
+                                     d = convert_element_type[ new_dtype=float32
+                                                               weak_type=False ] a
+                                     e = mul d c
+                                     f = convert_element_type[ new_dtype=float32
+                                                               weak_type=False ] b
+                                     g = add f e
+                                 in (g,) }
                     device=None
                     donated_invars=(False, False)
                     name=inner ] a b
-      d = add a c
-  in (d,) }
+      d = convert_element_type[ new_dtype=float32
+                                weak_type=False ] a
+      e = add d c
+  in (e,) }
 
 
 XLA_pmap
@@ -440,14 +457,16 @@ captured using the ``xla_pmap`` primitive. Consider this example
                     axis_size=1
                     backend=None
                     call_jaxpr={ lambda  ; a b.
-                                 let c = add b a
-                                     d = broadcast_in_dim[ broadcast_dimensions=(  )
+                                 let c = convert_element_type[ new_dtype=float32
+                                                               weak_type=False ] a
+                                     d = add b c
+                                     e = broadcast_in_dim[ broadcast_dimensions=(  )
                                                            shape=(1,) ] 1.0
-                                     e = add c d
-                                     f = psum[ axis_index_groups=None
+                                     f = add d e
+                                     g = psum[ axis_index_groups=None
                                                axis_name=('rows',) ] b
-                                     g = div e f
-                                 in (g,) }
+                                     h = div f g
+                                 in (h,) }
                     devices=None
                     donated_invars=(False, False)
                     global_arg_shapes=(None,)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -410,9 +410,9 @@ def lt(x: Array, y: Array) -> Array:
   r"""Elementwise less-than: :math:`x < y`."""
   return lt_p.bind(x, y)
 
-def convert_element_type(operand: Array, new_dtype: DType) -> Array:
+def convert_element_type(operand: Array, new_dtype: DType = None,
+                         weak_type: bool = False) -> Array:
   """Elementwise cast.
-
   Wraps XLA's `ConvertElementType
   <https://www.tensorflow.org/xla/operation_semantics#convertelementtype>`_
   operator, which performs an elementwise conversion from one type to another.
@@ -421,27 +421,35 @@ def convert_element_type(operand: Array, new_dtype: DType) -> Array:
   Args:
     operand: an array or scalar value to be cast
     new_dtype: the new type. Should be a NumPy type.
+    weak_type: whether the new dtype should be weak.
 
   Returns:
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
+  new_weak_type = bool(weak_type)
   # Avoids dropping precision by casting Python scalars to the default Jax
   # type. If we passed a Python scalar directly to the bind call below, it is
   # cast to the default type as part of the calling convention.
   if type(operand) in dtypes.python_scalar_dtypes:
-    operand = np.asarray(operand, new_dtype)
+    operand = np.asarray(operand, dtype=new_dtype)
+
   old_dtype = dtypes.canonicalize_dtype(_dtype(operand))
-  if old_dtype == new_dtype:
-    if isinstance(operand, (core.Tracer, xla.DeviceArray)):
-      return operand
-    else:
-      return _device_put_raw(np.asarray(operand))
+  old_weak_type = dtypes.is_weakly_typed(operand)
+
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
     msg = "Casting complex values to real discards the imaginary part"
     warnings.warn(msg, np.ComplexWarning, stacklevel=2)
-  return convert_element_type_p.bind(operand, new_dtype=new_dtype)
+
+  if not isinstance(operand, (core.Tracer, xla.DeviceArray)):
+    return _device_put_raw(np.asarray(operand, dtype=new_dtype),
+                           weak_type=new_weak_type)
+  elif (old_dtype, old_weak_type) == (new_dtype, new_weak_type):
+    return operand
+  else:
+    return convert_element_type_p.bind(operand, new_dtype=new_dtype,
+                                       weak_type=new_weak_type)
 
 def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
   """Elementwise bitcast.
@@ -1452,11 +1460,11 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
   fill_value = convert_element_type(fill_value, dtype)
   return broadcast(fill_value, shape)
 
-def _device_put_raw(x):
+def _device_put_raw(x, weak_type=None):
   if isinstance(x, xla.DeviceArray):
     return x
   else:
-    aval = raise_to_shaped(core.get_aval(x))
+    aval = raise_to_shaped(core.get_aval(x), weak_type=weak_type)
     return xla.array_result_handler(None, aval)(*xla.device_put(x))
 
 def iota(dtype: DType, size: int) -> Array:
@@ -1492,7 +1500,7 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
   if config.omnistaging_enabled:
     bool_eye = eq(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
                   broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_eye, new_dtype=dtype)
+    return convert_element_type_p.bind(bool_eye, new_dtype=dtype, weak_type=False)
   else:
     lazy_expr = lazy.eye(dtype, (N, M), offset)
     aval = ShapedArray((N, M), dtype)
@@ -1508,7 +1516,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
     iotas = [broadcasted_iota(np.uint32, base_shape, i)
              for i in range(len(base_shape))]
     eyes = [eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    result = convert_element_type_p.bind(_reduce(operator.and_, eyes), new_dtype=dtype)
+    result = convert_element_type_p.bind(_reduce(operator.and_, eyes), new_dtype=dtype, weak_type=False)
     return broadcast_in_dim(result, shape, axes)
   else:
     lazy_expr = lazy.broadcast(lazy.delta(dtype, base_shape), shape, axes)
@@ -1523,7 +1531,7 @@ def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
   if config.omnistaging_enabled:
     bool_tri = ge(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
                   broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_tri, new_dtype=dtype)
+    return convert_element_type_p.bind(bool_tri, new_dtype=dtype, weak_type=False)
   else:
     lazy_expr = lazy.tri(dtype, (N, M), offset)
     aval = ShapedArray((N, M), dtype)
@@ -1967,34 +1975,36 @@ _fixed_dtype = lambda dtype: lambda *args, **kwargs: dtypes.canonicalize_dtype(d
 _complex_basetype = lambda dtype: np.abs(np.zeros((), dtype)).dtype
 
 def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None,
-                       multiple_results=False):
+                       multiple_results=False, weak_type_rule=None):
+  weak_type_rule = weak_type_rule or partial(_standard_weak_type_rule, name)
   prim = Primitive(name)
   prim.multiple_results = multiple_results
   prim.def_impl(partial(xla.apply_primitive, prim))
-  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule))
+  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule, weak_type_rule))
   xla.translations[prim] = translation_rule or partial(standard_translate, name)
   return prim
 
-
-def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
+def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule, *args, **kwargs):
   assert all(isinstance(arg, UnshapedArray) for arg in args), args
+  weak_type = weak_type_rule(*args, **kwargs)
   least_specialized = _max(
       map(type, args), key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is ConcreteArray:
     out_vals = prim.impl(*[x.val for x in args], **kwargs)
     if not prim.multiple_results:
       out_vals = [out_vals]
-    out_avals = safe_map(ConcreteArray, out_vals)
+    out_avals = [ConcreteArray(v, weak_type=weak_type) for v in out_vals]
   elif least_specialized is ShapedArray:
     shapes, dtypes = shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs)
     if not prim.multiple_results:
       shapes, dtypes = [shapes], [dtypes]
-    out_avals = safe_map(ShapedArray, shapes, dtypes)
+    out_avals = [ShapedArray(shape, dtype, weak_type=weak_type)
+                 for shape, dtype in safe_zip(shapes, dtypes)]
   elif least_specialized is UnshapedArray:
     dtypes = dtype_rule(*args, **kwargs)
     if not prim.multiple_results:
       dtypes = [dtypes]
-    out_avals = safe_map(UnshapedArray, dtypes)
+    out_avals = [UnshapedArray(dtype, weak_type=weak_type) for dtype in dtypes]
   else:
     raise TypeError(args, least_specialized)
   if not prim.multiple_results:
@@ -2018,8 +2028,9 @@ def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
 
 def unop(result_dtype, accepted_dtypes, name, translation_rule=None):
   dtype_rule = partial(unop_dtype_rule, result_dtype, accepted_dtypes, name)
+  weak_type_rule = partial(_naryop_weak_type_rule, name)
   prim = standard_primitive(_attrgetter('shape'), dtype_rule, name,
-                            translation_rule=translation_rule)
+                            translation_rule=translation_rule, weak_type_rule=weak_type_rule)
   batching.defvectorized(prim)
   masking.defvectorized(prim)
   return prim
@@ -2063,12 +2074,30 @@ def _broadcasting_shape_rule(name, *avals):
     raise TypeError(msg.format(name, ', '.join(map(str, map(tuple, shapes)))))
   return result_shape
 
+def _standard_weak_type_rule(name, *avals, **kwargs):
+  # TODO(jakevdp): add logic to propagate weak types.
+  return False
+
+def _naryop_weak_type_rule(name, *avals, **kwargs):
+  if any(aval.dtype is dtypes.float0 for aval in avals):
+    pos = next(i for i, aval in enumerate(avals) if aval.dtype is dtypes.float0)
+    raise TypeError(
+        f"Called {name} with a float0 at position {pos}. "
+        "float0s do not support any operations by design, because they "
+        "are not compatible with non-trivial vector spaces. No implicit dtype "
+        "conversion is done. You can use np.zeros_like(arr, dtype=np.float) "
+        "to cast a float0 array to a regular zeros array. \n"
+        "If you didn't expect to get a float0 you might have accidentally "
+        "taken a gradient with respect to an integer argument.")
+  return all(aval.weak_type for aval in avals)
 
 def naryop(result_dtype, accepted_dtypes, name, translation_rule=None):
   dtype_rule = partial(naryop_dtype_rule, result_dtype, accepted_dtypes, name)
   shape_rule = partial(_broadcasting_shape_rule, name)
+  weak_type_rule = partial(_naryop_weak_type_rule, name)
   prim = standard_primitive(shape_rule, dtype_rule, name,
-                            translation_rule=translation_rule)
+                            translation_rule=translation_rule,
+                            weak_type_rule=weak_type_rule)
   batching.defbroadcasting(prim)
   masking.defnaryop(prim)
   return prim
@@ -2436,6 +2465,9 @@ def _integer_pow_dtype_rule(x, *, y):
                     f"integer_pow({x}, {y})")
   return dtype
 
+def _integer_pow_weak_type_rule(x, *, y):
+  return x.weak_type and dtypes.is_weakly_typed(y)
+
 def _integer_pow_translation_rule(c, x, *, y):
   if y == 0:
     shape = c.get_shape(x)
@@ -2457,7 +2489,7 @@ def _integer_pow_jvp(g, x, *, y):
 
 integer_pow_p = standard_primitive(
   _attrgetter('shape'), _integer_pow_dtype_rule, 'integer_pow',
-  translation_rule=_integer_pow_translation_rule)
+  translation_rule=_integer_pow_translation_rule, weak_type_rule=_integer_pow_weak_type_rule)
 batching.defvectorized(integer_pow_p)
 masking.defvectorized(integer_pow_p)
 ad.defjvp(integer_pow_p, _integer_pow_jvp)
@@ -2601,13 +2633,16 @@ lt_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'lt')
 ad.defjvp_zero(lt_p)
 
 
-def _convert_element_type_shape_rule(operand, *, new_dtype):
+def _convert_element_type_shape_rule(operand, *, new_dtype, weak_type):
   return operand.shape
 
-def _convert_element_type_dtype_rule(operand, *, new_dtype):
+def _convert_element_type_dtype_rule(operand, *, new_dtype, weak_type):
   return new_dtype
 
-def _convert_element_type_translation_rule(c, operand, *, new_dtype):
+def _convert_element_type_weak_type_rule(operand, *, new_dtype, weak_type):
+  return weak_type
+
+def _convert_element_type_translation_rule(c, operand, *, new_dtype, weak_type):
   old_dtype = c.get_shape(operand).numpy_dtype()
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
@@ -2615,25 +2650,27 @@ def _convert_element_type_translation_rule(c, operand, *, new_dtype):
   new_etype = xla_client.dtype_to_etype(new_dtype)
   return xops.ConvertElementType(operand, new_element_type=new_etype)
 
-def _convert_element_type_transpose_rule(ct, operand, *, new_dtype):
+def _convert_element_type_transpose_rule(ct, operand, *, new_dtype, weak_type):
   assert ad.is_undefined_primal(operand)
   old_dtype = operand.aval.dtype
+  old_weak_type = dtypes.is_weakly_typed(operand)
   if type(ct) is ad_util.Zero:
     return [ad_util.Zero(operand.aval)]
   elif core.primal_dtype_to_tangent_dtype(old_dtype) is dtypes.float0:
     return [ad_util.Zero(ShapedArray(operand.aval.shape, dtype=dtypes.float0))]
   else:
-    return [convert_element_type_p.bind(ct, new_dtype=old_dtype)]
+    return [convert_element_type_p.bind(ct, new_dtype=old_dtype, weak_type=old_weak_type)]
 
-def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype):
+def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype, weak_type):
   if core.primal_dtype_to_tangent_dtype(new_dtype) is dtypes.float0:
     return ad_util.Zero(ShapedArray(tangent.shape, dtype=dtypes.float0))
   else:
-    return convert_element_type_p.bind(tangent, new_dtype=new_dtype)
+    return convert_element_type_p.bind(tangent, new_dtype=new_dtype, weak_type=weak_type)
 
 convert_element_type_p = standard_primitive(
     _convert_element_type_shape_rule, _convert_element_type_dtype_rule,
-    'convert_element_type', _convert_element_type_translation_rule)
+    'convert_element_type', _convert_element_type_translation_rule,
+    weak_type_rule=_convert_element_type_weak_type_rule)
 ad.defjvp(convert_element_type_p, _convert_element_type_jvp_rule)
 ad.primitive_transposes[convert_element_type_p] = _convert_element_type_transpose_rule
 batching.defvectorized(convert_element_type_p)
@@ -6181,7 +6218,6 @@ def _dynamic_slice_indices(operand, start_indices):
             if isinstance(i, (int, np.integer))
             else select(lt(i, _const(i, 0)), add(i, _const(i, d)), i)
             for i, d in zip(start_indices, operand.shape)]
-
 
 
 def _const(example, val):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -270,15 +270,21 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    to_dtype = result_type(*args)
-    return [lax.convert_element_type(x, to_dtype) for x in args]
+    to_dtype_raw = dtypes._result_type_raw(*args)
+    weak_type = to_dtype_raw in set(dtypes._weak_types)
+    to_dtype = dtypes.canonicalize_dtype(to_dtype_raw)
+    return [lax.convert_element_type(x, to_dtype, weak_type) for x in args]
 
 def _promote_dtypes_inexact(*args):
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to an inexact type."""
-  to_dtype = _to_inexact_dtype(result_type(*args))
-  return [lax.convert_element_type(x, to_dtype) for x in args]
+  to_dtype_raw = dtypes._result_type_raw(*args)
+  to_dtype = dtypes.canonicalize_dtype(to_dtype_raw)
+  to_dtype_inexact = _to_inexact_dtype(to_dtype)
+  weak_type = (to_dtype == to_dtype_inexact
+               and to_dtype_raw in set(dtypes._weak_types))
+  return [lax.convert_element_type(x, to_dtype_inexact, weak_type) for x in args]
 
 def _to_inexact_dtype(dtype):
   """Promotes a dtype into an inexact dtype, if it is not already one."""

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -287,10 +287,11 @@ def dtype(x):
     return python_scalar_dtypes[type(x)]
   return np.result_type(x)
 
+def _result_type_raw(*args):
+  if len(args) < 2:
+    return _jax_type(args[0])
+  return _least_upper_bound(*{_jax_type(arg) for arg in args})
+
 def result_type(*args):
   """Convenience function to apply Numpy argument dtype promotion."""
-   # TODO(jakevdp): propagate weak_type to the result.
-  if len(args) < 2:
-    return canonicalize_dtype(dtype(args[0]))
-  # TODO(jakevdp): propagate weak_type to the result when necessary.
-  return canonicalize_dtype(_least_upper_bound(*{_jax_type(arg) for arg in args}))
+  return canonicalize_dtype(_result_type_raw(*args))

--- a/jax/experimental/doubledouble.py
+++ b/jax/experimental/doubledouble.py
@@ -244,11 +244,11 @@ _def_inequality(lax.le_p, operator.le)
 _def_inequality(lax.eq_p, operator.eq)
 _def_inequality(lax.ne_p, operator.ne)
 
-def _convert_element_type(operand, new_dtype):
+def _convert_element_type(operand, *, new_dtype=None, weak_type=False):
   head, tail = operand
-  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype)
+  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype, weak_type=weak_type)
   if tail is not None:
-    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype)
+    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype, weak_type=weak_type)
   if jnp.issubdtype(new_dtype, jnp.floating):
     if tail is None:
       tail = jnp.zeros_like(head)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1098,7 +1098,7 @@ tf_impl[lax.lt_p] = tf.math.less
 
 tf_impl[lax_linalg.cholesky_p] = tf.linalg.cholesky
 
-def _convert_element_type(operand, *, new_dtype):
+def _convert_element_type(operand, *, new_dtype, weak_type=False):
   old_dtype = operand.dtype.as_numpy_dtype
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -100,6 +100,8 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
          dtype=dtype)
     for dtype in [np.int64, np.float64]))
   def test_converts_64bit(self, dtype=np.int64, with_function=False):
+    if not config.FLAGS.jax_enable_x64:
+      self.skipTest("requires x64 mode")
     big_const = np.full((5,), 2 ** 33, dtype=dtype)
     self.ConvertAndCompare(jnp.sin, big_const)
     f_conv = jax2tf.convert(jnp.sin)

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -215,7 +215,7 @@ def _make_convert_element_type_harness(name, *, shape=(100, 100),
                                        dtype=np.float32, new_dtype=np.float32):
   return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_olddtype={jtu.dtype_str(dtype)}_newdtype={jtu.dtype_str(new_dtype)}",
                  lambda arg: (
-                     lax.convert_element_type_p.bind(arg, new_dtype=new_dtype)),
+                     lax.convert_element_type_p.bind(arg, new_dtype=new_dtype, weak_type=False)),
                  [RandArg(shape, dtype)],
                  shape=shape,
                  dtype=dtype,

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -548,8 +548,7 @@ class _WhileBuilder(_LoopBuilder):
       # Conditional function is not allowed to modify the scope state
       for ms, init_ms in zip(carried_state_names, args):
         if not (scope._mutable_state[ms] is init_ms):
-          msg = "Conditional function modifies scope.{} field."
-          raise ValueError(msg.format(ms))
+          raise ValueError(f"Conditional function modifies scope.{ms} field.")
       return res
 
     init_avals = safe_map(_BodyTracer.abstractify, init_vals)
@@ -559,11 +558,10 @@ class _WhileBuilder(_LoopBuilder):
                                             tuple(init_avals)))
     # TODO: share these checks with lax_control_flow.while
     if not tree_util.treedef_is_leaf(cond_tree):
-      msg = "cond_fun must return a boolean scalar, but got pytree {}."
-      raise TypeError(msg.format(cond_tree))
-    if cond_jaxpr.out_avals != [core.ShapedArray((), np.bool_)]:
-      msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
-      raise TypeError(msg.format(cond_jaxpr.out_avals))
+      raise TypeError(f"cond_fun must return a boolean scalar, but got pytree {cond_tree}.")
+    if not safe_map(core.typecompat, cond_jaxpr.out_avals, [core.ShapedArray((), np.bool_)]):
+      raise TypeError(f"cond_fun must return a boolean scalar, but got output type(s) "
+                      f"{cond_jaxpr.out_avals}.")
 
     return lax_control_flow.while_p.bind(*itertools.chain(cond_consts,
                                                           body_const_vals,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1837,9 +1837,9 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(outer_jaxpr.eqns[0].primitive.name, 'xla_call')
     subjaxpr_1 = outer_jaxpr.eqns[0].params["call_jaxpr"]
     self.assertEqual(str(subjaxpr_1), str(inner_jaxpr))
-    self.assertLen(inner_jaxpr.eqns, 2)
-    self.assertEqual(inner_jaxpr.eqns[0].primitive.name, 'mul')
-    self.assertEqual(inner_jaxpr.eqns[1].primitive.name, 'add')
+    self.assertLen(inner_jaxpr.eqns, 2 if config.omnistaging_enabled else 3)
+    self.assertEqual(inner_jaxpr.eqns[-2].primitive.name, 'mul')
+    self.assertEqual(inner_jaxpr.eqns[-1].primitive.name, 'add')
 
   def test_primitive_compilation_cache(self):
     with jtu.count_primitive_compiles() as count:
@@ -2509,7 +2509,8 @@ class JaxprTest(jtu.JaxTestCase):
         let b = ge a 0.0
             c = add a 1.0
             d = add a 2.0
-            e = convert_element_type[ new_dtype=int32 ] b
+            e = convert_element_type[ new_dtype=int32
+                                      weak_type=False ] b
             f = cond[ branches=( { lambda  ; e_ a b c.
                                    let d = sub c a
                                    in (d,) }
@@ -2517,24 +2518,29 @@ class JaxprTest(jtu.JaxTestCase):
                                    let d = add b a
                                    in (d,) } )
                       linear=(False, False, False, False) ] e a a c d
-      in (f,) }
-      """
+        in (f,) }
+        """
     else:
       expected = """
       { lambda  ; a.
         let b = ge a 0.0
-            c = convert_element_type[ new_dtype=int32 ] b
-            d = add a 1.0
-            e = add a 2.0
-            f = cond[ branches=( { lambda  ; e_ c a b.
+            c = convert_element_type[ new_dtype=int32
+                                      weak_type=False ] b
+            d = convert_element_type[ new_dtype=float32
+                                      weak_type=False ] a
+            e = convert_element_type[ new_dtype=float32
+                                      weak_type=False ] a
+            f = add a 1.0
+            g = add a 2.0
+            h = cond[ branches=( { lambda  ; e_ c a b.
                                    let d = sub b c
                                    in (d,) }
                                  { lambda  ; c f_ a b.
                                    let d = add a c
                                    in (d,) } )
-                      linear=(False, False, False, False) ] c a a d e
-        in (f,) }
-        """
+                      linear=(False, False, False, False) ] c d e f g
+        in (h,) }
+      """
     jaxpr = api.make_jaxpr(f)(3.)
     self.assertMultiLineStrippedEqual(expected, str(jaxpr))
 

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -56,6 +56,11 @@ scalar_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                 jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64,
                 jnp.complex64, jnp.complex128]
 
+def identity(x):
+  """A named identity function for use in tests"""
+  return x
+
+
 class DtypesTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
@@ -211,45 +216,45 @@ class TestPromotionTables(jtu.JaxTestCase):
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
     if FLAGS.jax_enable_x64:
       expected = [
-        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
-        ['u1','u1','u2','u4','u8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','u1','f8','c8'],
-        ['u2','u2','u2','u4','u8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','u2','f8','c8'],
-        ['u4','u4','u4','u4','u8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','u4','f8','c8'],
-        ['u8','u8','u8','u8','u8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','u8','f8','c8'],
-        ['i1','i2','i4','i8','f8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i1','f8','c8'],
-        ['i2','i2','i4','i8','f8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f8','c8'],
-        ['i4','i4','i4','i8','f8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f8','c8'],
-        ['i8','i8','i8','i8','f8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
+        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
+        ['u1','u1','u2','u4','u8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','u1','f*','c*'],
+        ['u2','u2','u2','u4','u8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','u2','f*','c*'],
+        ['u4','u4','u4','u4','u8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','u4','f*','c*'],
+        ['u8','u8','u8','u8','u8','f*','f*','f*','f*','bf','f2','f4','f8','c4','c8','u8','f*','c*'],
+        ['i1','i2','i4','i8','f*','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i1','f*','c*'],
+        ['i2','i2','i4','i8','f*','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f*','c*'],
+        ['i4','i4','i4','i8','f*','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f*','c*'],
+        ['i8','i8','i8','i8','f*','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f*','c*'],
         ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c4'],
         ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c4'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','c8','c8','f8','f8','c8'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c8','c4','c8','c4','c4','c4'],
         ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8'],
-        ['i8','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
-        ['f8','f8','f8','f8','f8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
-        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
+        ['i*','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
+        ['f*','f*','f*','f*','f*','f*','f*','f*','f*','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
+        ['c*','c*','c*','c*','c*','c*','c*','c*','c*','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
       ]
     else:
       expected = [
-        ['b1','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
-        ['u1','u1','u2','u4','u4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','u1','f4','c4'],
-        ['u2','u2','u2','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u2','f4','c4'],
-        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f4','c4'],
-        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f4','c4'],
-        ['i1','i2','i4','i4','i4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i1','f4','c4'],
-        ['i2','i2','i4','i4','i4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','i2','f4','c4'],
-        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
-        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
+        ['b1','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
+        ['u1','u1','u2','u4','u4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','u1','f*','c*'],
+        ['u2','u2','u2','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u2','f*','c*'],
+        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f*','c*'],
+        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f*','c*'],
+        ['i1','i2','i4','i4','i4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i1','f*','c*'],
+        ['i2','i2','i4','i4','i4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','i2','f*','c*'],
+        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f*','c*'],
+        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f*','c*'],
         ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f4','c4','c4','bf','bf','c4'],
         ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f4','c4','c4','f2','f2','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','c4','c4','f4','f4','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','c4','c4','f4','f4','c4'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4'],
-        ['i4','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
-        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','bf','f2','f4','f4','c4','c4','f*','f*','c*'],
-        ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c*','c*','c*'],
+        ['i*','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
+        ['f*','f*','f*','f*','f*','f*','f*','f*','f*','bf','f2','f4','f4','c4','c4','f*','f*','c*'],
+        ['c*','c*','c*','c*','c*','c*','c*','c*','c*','c4','c4','c4','c4','c4','c4','c*','c*','c*'],
       ]
     typecode_to_dtype = {
       'b1': jnp.bool_,
@@ -291,6 +296,20 @@ class TestPromotionTables(jtu.JaxTestCase):
 
     self.assertEqual(table, expected, show_differences(expected, table))
 
+  @parameterized.named_parameters(
+    {"testcase_name": "_xtype={}_ytype={}_xfun={}_yfun={}".format(
+      xtype.__name__, ytype.__name__, xfun.__name__, yfun.__name__),
+     "xtype": xtype, "ytype": ytype, "xfun": xfun, "yfun": yfun}
+    for xtype, ytype in itertools.product(
+      [int, float, jnp.int16, jnp.int32, jnp.float16, jnp.float32], repeat=2)
+    for xfun, yfun in itertools.product(
+      [identity, abs], repeat=2)
+    )
+  def testBinaryPromotionJitInvariance(self, xtype, ytype, xfun, yfun):
+    """Test jit invariance of simple binary promotion rules with and without weak types."""
+    f = lambda x, y: xfun(x) + yfun(y)
+    args_maker = lambda: [xtype(1), ytype(1)]
+    self._CompileAndCheck(f, args_maker, check_dtypes=True)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This PR takes the first step toward propagating weak types through JAX operations, adding machinery to abstract evaluation rules to control how they handle weak types, as well as adding a `weak_type` argument to `convert_element_type` that defaults to `False`, which is the current behavior.

Two new tests ensure that weak types are correctly propagated through basic unary and binary operations.