### PR TITLE
PRNGSeed: ensure JIT invariance for valid inputs.

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -36,6 +36,21 @@ jax 0.2.6 (Unreleased)
   * The contents of the (undocumented) ``jax.lax_linalg`` linear algebra module
     are now exposed publicly as ``jax.lax.linalg``.
 
+  * ``jax.random.PRNGKey`` now produces the same results in and out of JIT compilation (#4877).
+    This required changing the result for a given seed in a few particular cases:
+
+    * With ``jax_enable_x64=False``, negative seeds passed as Python integers now return a different result
+      outside JIT mode. For example, ``jax.random.PRNGKey(-1)`` previously returned
+      ``[4294967295, 4294967295]``, and now returns ``[0, 4294967295]``. This matches the behavior in JIT.
+    * Seeds outside the range representable by `int64` outside JIT now result in an ``OverflowError``
+      rather than a ``TypeError``. This matches the behavior in JIT.
+
+    To recover the keys returned previously for negative integers with `jax_enable_x64=False` outside JIT,
+    you can use::
+
+        key = random.PRNGKey(-1).at[0].set(0xFFFFFFFF)
+    
+
 jaxlib 0.1.57 (unreleased)
 ------------------------------
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -900,7 +900,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"seed": 3, "type": np.int64, "jit": True, "key": [0, 3]},
       {"seed": 3, "type": np.int64, "jit": False, "key": [0, 3]},
       {"seed": -1, "type": int, "jit": True, "key": [4294967295, 4294967295] if FLAGS.jax_enable_x64 else [0, 4294967295]},
-      {"seed": -1, "type": int, "jit": False, "key": [4294967295, 4294967295]},  # TODO(jakevdp): make consistent with jit=True
+      {"seed": -1, "type": int, "jit": False, "key": [4294967295, 4294967295] if FLAGS.jax_enable_x64 else [0, 4294967295]},
       {"seed": -2, "type": np.int32, "jit": True, "key": [0, 4294967294]},
       {"seed": -2, "type": np.int32, "jit": False, "key": [0, 4294967294]},
       {"seed": -3, "type": np.int64, "jit": True, "key": [4294967295, 4294967293] if FLAGS.jax_enable_x64 else [0, 4294967293]},
@@ -910,7 +910,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"seed": np.iinfo(np.int32).max + 101, "type": np.uint32, "jit": True, "key": [0, 2147483748]},
       {"seed": np.iinfo(np.int32).max + 101, "type": np.uint32, "jit": False, "key": [0, 2147483748]},
       {"seed": np.iinfo(np.int32).min - 100, "type": int, "jit": True, "key": [4294967295, 2147483548] if FLAGS.jax_enable_x64 else [0, 2147483548]},
-      {"seed": np.iinfo(np.int32).min - 100, "type": int, "jit": False, "key": [4294967295, 2147483548]},  # TODO(jakevdp): make consistent with jit=True
+      {"seed": np.iinfo(np.int32).min - 100, "type": int, "jit": False, "key": [4294967295, 2147483548] if FLAGS.jax_enable_x64 else [0, 2147483548]},
       {"seed": np.iinfo(np.int32).min - 101, "type": np.int64, "jit": True, "key": [4294967295, 2147483547] if FLAGS.jax_enable_x64 else [0, 2147483547]},
       {"seed": np.iinfo(np.int32).min - 101, "type": np.int64, "jit": False, "key": [4294967295, 2147483547] if FLAGS.jax_enable_x64 else [0, 2147483547]},
     ]
@@ -929,19 +929,15 @@ class LaxRandomTest(jtu.JaxTestCase):
       for type in ["int", "np.array", "jnp.array"]
       for seed in [-1, 0, 1, (1 << 32) - 1, (1 << 63) - 1, np.uint64((1 << 64) - 1)]))
   def test_prng_jit_invariance(self, seed, type):
-    # TODO(jakevdp): fix these jit invariance failures
-    if seed == (1 << 64) - 1 and type in ["int", "np.array"]:
-      self.skipTest(f"Known failure for seed={type}({seed})")
-    if not FLAGS.jax_enable_x64 and type in ["int", "np.array"] and seed in [-1, (1 << 63) - 1]:
-      self.skipTest(f"Known failure for seed={type}({seed})")
+    if type == "int" and seed == (1 << 64) - 1:
+      self.skipTest("Expected failure: Python int too large.")
     type = {"int": int, "np.array": np.array, "jnp.array": jnp.array}[type]
     args_maker = lambda: [type(seed)]
     self._CompileAndCheck(random.PRNGKey, args_maker)
 
   def test_prng_errors(self):
     seed = np.iinfo(np.uint64).max
-    # TODO(jakevdp): make this TypeError into an OverflowError.
-    with self.assertRaises(TypeError):
+    with self.assertRaises(OverflowError):
       random.PRNGKey(seed)
     with self.assertRaises(OverflowError):
       api.jit(random.PRNGKey)(seed)


### PR DESCRIPTION
This is a less drastic version of #4821 that aims only for JIT invariance for `jax.random.PRNGKey`, leaving dtype invariance breakages untouched. The user-visible changes are:

- In X32 mode, a negative Python integer seed results in a different key in op-by-op mode, matching that of a negative `int32` seed.
- In X32 and X64 mode, a Python int not representable in int64 now raises an `OverflowError` rather than a `TypeError` in op-by-op mode.

The following script shows outputs for a range of relevant inputs:
```python
import jax.numpy as jnp
from jax import jit, random, config, dtypes
config.update('jax_enable_x64', True)

def print_results(s):
  val = eval(s)
  def PRNGKey(val, converter=None):
    try:
      val = val if converter is None else converter(val)
      return random.PRNGKey(val)
    except OverflowError as err:
      return f"OverflowError: {str(err)[:30]}..."
    except TypeError as err:
      return f"TypeError: {str(err)[:30]}..."
  print(f"random.PRNGKey({s})             =", PRNGKey(val))
  for t in [jnp.int32, jnp.int64, jnp.uint32, jnp.uint64]:
    if t == dtypes.canonicalize_dtype(t):
      print(f"random.PRNGKey(jnp.{t.__name__}({s}))  =", PRNGKey(val, t))
  print()

print_results("1")
print_results("-1")
print_results("(1 << 32) - 1")
print_results("(1 << 64) - 1")
```
X64, master branch:
```
random.PRNGKey(1)             = [0 1]
random.PRNGKey(jnp.int32(1))  = [0 1]
random.PRNGKey(jnp.int64(1))  = [0 1]
random.PRNGKey(jnp.uint32(1))  = [0 1]
random.PRNGKey(jnp.uint64(1))  = [0 1]

random.PRNGKey(-1)             = [4294967295 4294967295]
random.PRNGKey(jnp.int32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.int64(-1))  = [4294967295 4294967295]
random.PRNGKey(jnp.uint32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64(-1))  = [4294967295 4294967295]

random.PRNGKey((1 << 32) - 1)             = [         0 4294967295]
random.PRNGKey(jnp.int32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.int64((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64((1 << 32) - 1))  = [         0 4294967295]

random.PRNGKey((1 << 64) - 1)             = TypeError: ufunc 'right_shift' not suppor...
random.PRNGKey(jnp.int32((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.int64((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.uint32((1 << 64) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64((1 << 64) - 1))  = [4294967295 4294967295]
```
X64, this branch:
```
random.PRNGKey(1)             = [0 1]
random.PRNGKey(jnp.int32(1))  = [0 1]
random.PRNGKey(jnp.int64(1))  = [0 1]
random.PRNGKey(jnp.uint32(1))  = [0 1]
random.PRNGKey(jnp.uint64(1))  = [0 1]

random.PRNGKey(-1)             = [4294967295 4294967295]
random.PRNGKey(jnp.int32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.int64(-1))  = [4294967295 4294967295]
random.PRNGKey(jnp.uint32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64(-1))  = [4294967295 4294967295]

random.PRNGKey((1 << 32) - 1)             = [         0 4294967295]
random.PRNGKey(jnp.int32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.int64((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64((1 << 32) - 1))  = [         0 4294967295]

random.PRNGKey((1 << 64) - 1)             = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.int32((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.int64((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.uint32((1 << 64) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint64((1 << 64) - 1))  = [4294967295 4294967295]
```
X32, master branch:
```
random.PRNGKey(1)             = [0 1]
random.PRNGKey(jnp.int32(1))  = [0 1]
random.PRNGKey(jnp.uint32(1))  = [0 1]

random.PRNGKey(-1)             = [4294967295 4294967295]
random.PRNGKey(jnp.int32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32(-1))  = [         0 4294967295]

random.PRNGKey((1 << 32) - 1)             = [         0 4294967295]
random.PRNGKey(jnp.int32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32((1 << 32) - 1))  = [         0 4294967295]

random.PRNGKey((1 << 64) - 1)             = TypeError: ufunc 'right_shift' not suppor...
random.PRNGKey(jnp.int32((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.uint32((1 << 64) - 1))  = [         0 4294967295]
```
X32 mode, this branch:
```
random.PRNGKey(1)             = [0 1]
random.PRNGKey(jnp.int32(1))  = [0 1]
random.PRNGKey(jnp.uint32(1))  = [0 1]

random.PRNGKey(-1)             = [         0 4294967295]
random.PRNGKey(jnp.int32(-1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32(-1))  = [         0 4294967295]

random.PRNGKey((1 << 32) - 1)             = [         0 4294967295]
random.PRNGKey(jnp.int32((1 << 32) - 1))  = [         0 4294967295]
random.PRNGKey(jnp.uint32((1 << 32) - 1))  = [         0 4294967295]

random.PRNGKey((1 << 64) - 1)             = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.int32((1 << 64) - 1))  = OverflowError: Python int too large to conver...
random.PRNGKey(jnp.uint32((1 << 64) - 1))  = [         0 4294967295]
```