### PR TITLE
jaxlib: Fix Python 3.9 build and drop CUDA 10.0 support

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,11 +6,12 @@ WORKDIR /
 RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
 RUN apt-get update
 RUN apt-get install libffi-dev
-RUN git clone --branch v1.2.14 https://github.com/pyenv/pyenv.git /pyenv
+RUN git clone --branch v1.2.21 https://github.com/pyenv/pyenv.git /pyenv
 ENV PYENV_ROOT /pyenv
 RUN /pyenv/bin/pyenv install 3.6.8
 RUN /pyenv/bin/pyenv install 3.7.2
 RUN /pyenv/bin/pyenv install 3.8.0
+RUN /pyenv/bin/pyenv install 3.9.0
 
 # We pin numpy to a version < 1.16 to avoid version compatibility issues.
 RUN eval "$(/pyenv/bin/pyenv init -)" && /pyenv/bin/pyenv local 3.6.8 && pip install numpy==1.15.4 scipy cython setuptools wheel packaging six auditwheel

--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -2,7 +2,7 @@
 set -xev
 
 PYTHON_VERSIONS="3.6.8 3.7.2 3.8.0 3.9.0"
-CUDA_VERSIONS="10.0 10.1 10.2 11.0 11.1"
+CUDA_VERSIONS="10.1 10.2 11.0 11.1"
 CUDA_VARIANTS="cuda" # "cuda-included"
 
 mkdir -p dist

--- a/build/build_wheel_docker_entrypoint.sh
+++ b/build/build_wheel_docker_entrypoint.sh
@@ -62,7 +62,9 @@ esac
 
 export JAX_CUDA_VERSION=$3
 python setup.py bdist_wheel --python-tag "$PY_TAG" --plat-name "$PLAT_NAME"
-if python -m auditwheel show dist/jaxlib-*.whl  | grep -v 'platform tag: "manylinux2010_x86_64"' > /dev/null; then
+if ! python -m auditwheel show dist/jaxlib-*.whl  | grep 'platform tag: "manylinux2010_x86_64"' > /dev/null; then
+  # Print output for debugging
+  python -m auditwheel show dist/jaxlib-*.whl
   echo "jaxlib wheel is not manylinux2010 compliant"
   exit 1
 fi


### PR DESCRIPTION
The TF/XLA build no longer works with CUDA 10.0. This could potentially be fixed, but isn't easy or officially supported.