### PR TITLE
ci-build.yaml: mypy jax failing on the current version of Python

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -13,16 +13,9 @@ on:
 jobs:
   lint_and_typecheck:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/setup-python@v2
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -116,15 +109,9 @@ jobs:
 
   documentation:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+    - uses: actions/setup-python@v2
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,7 +1,7 @@
 flake8
  # Must be kept in sync with the minimum jaxlib version in jax/lib/__init__.py
 jaxlib==0.1.57
-mypy==0.770
+mypy
 pillow
 pytest-benchmark
 pytest-xdist

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
  # Must be kept in sync with the minimum jaxlib version in jax/lib/__init__.py
-jaxlib==0.1.55
+jaxlib==0.1.57
 mypy==0.770
 pillow
 pytest-benchmark


### PR DESCRIPTION
% `python3.9 -m mypy jax`
```
jax/_src/image/scale.py:137: error: syntax error in type comment
jax/_src/image/scale.py:138: error: syntax error in type comment
jax/_src/image/scale.py:140: error: syntax error in type comment
jax/_src/image/scale.py:236: error: syntax error in type comment
jax/_src/image/scale.py:261: error: syntax error in type comment
Found 5 errors in 1 file (checked 147 source files)
```