### PR TITLE
Add support for out_axes in pmap

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -456,7 +456,8 @@ captured using the ``xla_pmap`` primitive. Consider this example
                     global_arg_shapes=(None,)
                     global_axis_size=None
                     in_axes=(None, 0)
-                    name=inner ] b a
+                    name=inner
+                    out_axes=(0,) ] b a
   in (c,) }
 
 The ``xla_pmap`` primitive specifies the name of the axis (parameter ``rows``)

--- a/jax/core.py
+++ b/jax/core.py
@@ -34,7 +34,7 @@ from . import linear_util as lu
 
 from jax._src import source_info_util
 from .util import (safe_zip, safe_map, partial, curry, prod, partialmethod,
-                   tuple_insert, tuple_delete)
+                   tuple_insert, tuple_delete, as_hashable_function)
 from ._src.pprint_util import pp, vcat, PrettyPrint
 
 from ._src import traceback_util
@@ -333,8 +333,13 @@ def eval_jaxpr(jaxpr: Jaxpr, consts, *args):
       subfuns = [lu.wrap_init(partial(eval_jaxpr, call_jaxpr, ()))]
     else:
       subfuns = []
+    if eqn.primitive.map_primitive:
+      bind_params = dict(params, out_axes_thunk=lambda: params['out_axes'])
+      del bind_params['out_axes']
+    else:
+      bind_params = params
     with source_info_util.user_context(eqn.source_info):
-      ans = eqn.primitive.bind(*(subfuns + in_vals), **params)
+      ans = eqn.primitive.bind(*(subfuns + in_vals), **bind_params)
     if eqn.primitive.multiple_results:
       map(write, eqn.outvars, ans)
     else:
@@ -1150,12 +1155,19 @@ def apply_todos(todos, outs):
     outs = map(full_lower, todos_list.pop()(outs))
   return outs
 
+class _IgnoreElemList(list):
+  """Compares equal to all other _ignore_elem_lists."""
+  def __hash__(self): return 0
+  def __eq__(self, other):
+    return type(other) is _IgnoreElemList
+
 @lu.transformation_with_aux
 def process_env_traces(primitive: Union['CallPrimitive', 'MapPrimitive'],
-                       level: int, params_tuple: tuple, *args):
+                       level: int, params_tuple: tuple, out_axes_transforms, *args):
   outs = yield args, {}
   params = dict(params_tuple)
   todo = []
+  assert not out_axes_transforms
   while True:
     tracers = [x for x in outs if isinstance(x, Tracer)
                and (level is None or x._trace.level > level)]
@@ -1166,15 +1178,32 @@ def process_env_traces(primitive: Union['CallPrimitive', 'MapPrimitive'],
     trace = ans._trace.main.with_cur_sublevel()
     outs = map(trace.full_raise, outs)
     outs, cur_todo = primitive.post_process(trace, outs, params)
+    if isinstance(primitive, MapPrimitive):
+      cur_todo, out_axes_transform = cur_todo
+      out_axes_transforms.append(out_axes_transform)
     todo.append(cur_todo)
   yield outs, tuple(todo)  # Ensure the aux output is immutable
 
 def call_bind(primitive: Union['CallPrimitive', 'MapPrimitive'],
               fun, *args, **params):
+  out_axes_transforms = _IgnoreElemList()
+  if primitive.map_primitive:
+    out_axes_thunk = params['out_axes_thunk']
+    # The new thunk depends deterministically on the old thunk and the wrapped function.
+    # Any caching already has to include the wrapped function as part of the key, so we
+    # only use the previous thunk for equality checks.
+    @as_hashable_function(key=out_axes_thunk)
+    def new_out_axes_thunk():
+      out_axes = out_axes_thunk()
+      for t in out_axes_transforms:
+        out_axes = t(out_axes)
+      return out_axes
+    params = dict(params, out_axes_thunk=new_out_axes_thunk)
   params_tuple = tuple(params.items())
   top_trace = find_top_trace(args)
   fun, env_trace_todo = process_env_traces(
-      fun, primitive, top_trace and top_trace.level, params_tuple)
+      fun, primitive, top_trace and top_trace.level,
+      params_tuple, out_axes_transforms)
   tracers = map(top_trace.full_raise, args)
   with maybe_new_sublevel(top_trace):
     outs = primitive.process(top_trace, fun, tracers, params)
@@ -1434,6 +1463,9 @@ def check_map(prim, in_avals, params):
   typecheck_assert("in_axes" in params,
                    f"Map primitive {prim} missing 'in_axes' parameter")
   in_axes = params["in_axes"]
+  typecheck_assert("out_axes" in params,
+                   f"Map primitive {prim} missing 'out_axes' parameter")
+  out_axes = params["out_axes"]
 
   binder_avals = [unmapped_aval(axis_size, in_axis, v.aval)
                   if in_axis is not None else v.aval
@@ -1449,8 +1481,8 @@ def check_map(prim, in_avals, params):
   _check_jaxpr(call_jaxpr, mapped_avals)
 
   mapped_out_avals = [v.aval for v in call_jaxpr.outvars]
-  # Assuming out_axes == 0
-  out_avals = [unmapped_aval(axis_size, 0, aval) for aval in mapped_out_avals]
+  out_avals = [unmapped_aval(axis_size, out_axis, aval) if out_axis is not None else aval
+               for aval, out_axis in zip(mapped_out_avals, out_axes)]
   return out_avals
 
 
@@ -1650,12 +1682,26 @@ def omnistaging_disabler() -> None:
 
   def call_bind(primitive: Union['CallPrimitive', 'MapPrimitive'],
                 fun: lu.WrappedFun, *args, **params):
+    out_axes_transforms = _IgnoreElemList()
+    if primitive.map_primitive:
+      out_axes_thunk = params['out_axes_thunk']
+      # The new thunk depends deterministically on the old thunk and the wrapped function.
+      # Any caching already has to include the wrapped function as part of the key, so we
+      # only use the previous thunk for equality checks.
+      @as_hashable_function(key=out_axes_thunk)
+      def new_out_axes_thunk():
+        out_axes = out_axes_thunk()
+        for t in out_axes_transforms:
+          out_axes = t(out_axes)
+        return out_axes
+      params = dict(params, out_axes_thunk=new_out_axes_thunk)
     params_tuple = tuple(params.items())
     top_trace = find_top_trace(args)
     level = (thread_local_state.trace_state.trace_stack.next_level(True)
             if top_trace is None else top_trace.level)
     params_tuple = tuple(params.items())
-    fun, env_trace_todo = process_env_traces(fun, primitive, level, params_tuple)
+    fun, env_trace_todo = process_env_traces(
+        fun, primitive, level, params_tuple, out_axes_transforms)
     if top_trace is None:
       with new_sublevel():
         outs = primitive.impl(fun, *args, **params)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -270,9 +270,9 @@ class CustomJVPCallPrimitive(core.CallPrimitive):
     args = map(core.full_lower, args)
     top_trace = core.find_top_trace(args)
     fun, env_trace_todo1 = core.process_env_traces(
-        fun, self, top_trace and top_trace.level, ())
+        fun, self, top_trace and top_trace.level, (), None)
     jvp, env_trace_todo2 = core.process_env_traces(
-        jvp, self, top_trace and top_trace.level, ())
+        jvp, self, top_trace and top_trace.level, (), None)
     tracers = map(top_trace.full_raise, args)  # type: ignore
     with core.maybe_new_sublevel(top_trace):
       outs = top_trace.process_custom_jvp_call(self, fun, jvp, tracers)  # type: ignore
@@ -569,9 +569,9 @@ class CustomVJPCallPrimitive(core.CallPrimitive):
     args = map(core.full_lower, args)
     top_trace = core.find_top_trace(args)
     fun, env_trace_todo1 = core.process_env_traces(
-        fun, self, top_trace and top_trace.level, ())
+        fun, self, top_trace and top_trace.level, (), None)
     fwd, env_trace_todo2 = core.process_env_traces(
-        fwd, self, top_trace and top_trace.level, ())
+        fwd, self, top_trace and top_trace.level, (), None)
     tracers = map(top_trace.full_raise, args)  # type: ignore
     with core.maybe_new_sublevel(top_trace):
       outs = top_trace.process_custom_vjp_call(self, fun, fwd, bwd, tracers,
@@ -681,9 +681,9 @@ def omnistaging_disabler() -> None:
     args = map(core.full_lower, args)
     top_trace = core.find_top_trace(args)
     fun, env_trace_todo1 = core.process_env_traces(
-        fun, self, top_trace and top_trace.level, ())
+        fun, self, top_trace and top_trace.level, (), None)
     jvp, env_trace_todo2 = core.process_env_traces(
-        jvp, self, top_trace and top_trace.level, ())
+        jvp, self, top_trace and top_trace.level, (), None)
     if top_trace is None:
       with core.new_sublevel():
         outs = self.impl(fun, jvp, *args)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -25,7 +25,8 @@ from ..core import (Trace, Tracer, get_aval, call_p, Primitive, Literal,
                     raise_to_shaped)
 from ..ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_aval,
                        zeros_like_p, Zero)
-from ..util import unzip2, safe_map, safe_zip, partial, split_list, wrap_name, moveaxis
+from ..util import (unzip2, safe_map, safe_zip, partial, split_list, wrap_name,
+                    as_hashable_function)
 from ..tree_util import register_pytree_node
 from .. import linear_util as lu
 from ..api_util import flatten_fun, flatten_fun_nokwargs
@@ -292,7 +293,24 @@ class JVPTrace(Trace):
     if isinstance(call_primitive, core.MapPrimitive):
       in_axes = params['in_axes']
       tangent_in_axes = [ax for ax, nz in zip(in_axes, nz_tangents) if nz]
-      params = dict(params, in_axes=(*in_axes, *tangent_in_axes))
+      out_axes_thunk = params['out_axes_thunk']
+
+      @lu.transformation_with_aux
+      def populate_outputs(*args, **kwargs):
+        results = yield args, kwargs
+        _, tangents_out = tree_unflatten(out_tree_def(), results)
+        yield results, [type(t) is not Zero for t in tangents_out]
+      f_jvp, nz_tangents_out = populate_outputs(f_jvp)
+      # The new thunk depends deterministically on the old thunk and the wrapped function.
+      # Any caching already has to include the wrapped function as part of the key, so we
+      # only use the previous thunk for equality checks.
+      @as_hashable_function(key=out_axes_thunk)
+      def new_out_axes_thunk():
+        out_axes = out_axes_thunk()
+        return (*out_axes, *(ax for ax, nz in zip(out_axes, nz_tangents_out()) if nz))
+      params = dict(params,
+                    in_axes=(*in_axes, *tangent_in_axes),
+                    out_axes_thunk=new_out_axes_thunk)
     update_params = call_param_updaters.get(call_primitive)
     new_params = update_params(params, nz_tangents) if update_params else params
     result = call_primitive.bind(f_jvp, *primals, *nonzero_tangents, **new_params)
@@ -302,16 +320,22 @@ class JVPTrace(Trace):
   def post_process_call(self, call_primitive, out_tracers, params):
     primals, tangents = unzip2((t.primal, t.tangent) for t in out_tracers)
     out, treedef = tree_flatten((primals, tangents))
+    tangents_nz = [type(t) is not Zero for t in tangents]
     del primals, tangents
     main = self.main
     def todo(x):
       primals, tangents = tree_unflatten(treedef, x)
       trace = JVPTrace(main, core.cur_sublevel())
       return map(partial(JVPTracer, trace), primals, tangents)
+    if call_primitive.map_primitive:
+      def out_axes_transform(out_axes):
+        return (*out_axes, *(ax for ax, nz in zip(out_axes, tangents_nz) if nz))
+      todo = (todo, out_axes_transform)
     return out, todo
 
   # The only difference between process_map and process_call is that
-  # the `in_axes` param must be updated; that's handled in process_call.
+  # the `in_axes` and `out_axes_thunk` params must be updated;
+  # that's handled in process_call.
   process_map = process_call
   post_process_map = post_process_call
 
@@ -562,14 +586,26 @@ primitive_transposes[pe.remat_call_p] = remat_transpose
 def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr)
+  @lu.transformation_with_aux
+  def find_nonzero_results(*args, **kwargs):
+    results = yield args, kwargs
+    yield results, [type(r) is not Zero for r in results]
+  fun, nz_arg_cts = find_nonzero_results(fun)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
-  # Preserve axis for primal arguments, skip tangents (represented as undefined primals),
-  # we only support out_axes=0 for now, so hard-code that for each cotangent.
-  new_in_axes = (*[axis for axis, x in zip(params['in_axes'], args)
+  # Preserve axis for primal arguments, skip tangents (represented as undefined primals).
+  in_axes, out_axes = params['in_axes'], params['out_axes']
+  new_in_axes = (*[axis for axis, x in zip(in_axes, args)
                    if not is_undefined_primal(x)],
-                 *[0 for x in ct if type(x) is not Zero])
+                 *[axis for axis, x in zip(out_axes, ct)
+                   if type(x) is not Zero])
+  # The interim strategy we use below (until avals-with-names) only works
+  # when all outputs are mapped.
+  assert all(out_axis is not None for out_axis in out_axes), out_axes
+  def out_axes_thunk():
+    return tuple(axis or 0 for axis, nz in zip(in_axes, nz_arg_cts()) if nz)
   new_params = dict(params, name=wrap_name(params['name'], 'transpose'),
-                    in_axes=new_in_axes)
+                    in_axes=new_in_axes, out_axes_thunk=out_axes_thunk)
+  del new_params['out_axes']
   update_params = call_transpose_param_updaters.get(primitive)
   if update_params:
     new_params = update_params(new_params, map(is_undefined_primal, args),
@@ -577,7 +613,6 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
   out_flat = primitive.bind(fun, *all_args, **new_params)
   arg_cts = tree_unflatten(out_tree(), out_flat)
 
-  in_axes = params['in_axes']
   # The freevars are being fanned out (not mapped). During transpose the
   # dual of fan-out is fan-in-sum. We apply it to the unmapped invars.
   assert len(in_axes) == len(arg_cts)
@@ -585,7 +620,7 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _):
     return (zero if in_axis is None else
             Zero(core.unmapped_aval(params['axis_size'], in_axis, zero.aval)))
   arg_cts = (unmap_zero(arg_ct, in_axis) if type(arg_ct) is Zero else
-             moveaxis(arg_ct, 0, in_axis) if in_axis is not None else
+             arg_ct if in_axis is not None else
              arg_ct.sum(0)
              for arg_ct, in_axis in zip(arg_cts, in_axes))
   return tuple(arg_cts)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -27,7 +27,7 @@ from .. import dtypes
 from .. import linear_util as lu
 from ..ad_util import Zero
 from ..util import (unzip2, safe_zip, safe_map, toposort, partial, split_list,
-                    cache)
+                    cache, as_hashable_function)
 from ..core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
                     unit, unitvar, abstract_unit, ClosedJaxpr, new_jaxpr_eqn,
                     dropvar, ConcreteArray, raise_to_shaped)
@@ -177,13 +177,27 @@ class JaxprTrace(Trace):
       in_pvals = [pval if pval.is_known() or in_axis is None
                   else PartialVal.unknown(mapped_aval(in_axis, pval[0]))
                   for pval, in_axis in zip(in_pvals, params['in_axes'])]
+
+      def app(f, *args):
+        f, num_outputs = count_outputs(f)
+        out_axes_thunk = params['out_axes_thunk']
+        @as_hashable_function(key=out_axes_thunk)
+        def new_out_axes_thunk():
+          out_axes = out_axes_thunk()
+          return out_axes + (0,) * (num_outputs() - len(out_axes))
+        pe_params = dict(params, out_axes_thunk=new_out_axes_thunk)
+        return primitive.bind(f, *args, **pe_params)
+    else:
+      app = partial(primitive.bind, **params)
     jaxpr, out_pvals, consts, env_tracers = self.partial_eval(
-        f, in_pvals, partial(primitive.bind, **params), instantiate=False)
+        f, in_pvals, app, instantiate=False)
     if primitive.map_primitive:
-      unmapped_aval = partial(core.unmapped_aval, params['axis_size'], 0)
-      out_pvals = [pval if pval.is_known()
-                   else PartialVal.unknown(unmapped_aval(pval[0]))
-                   for pval in out_pvals]
+      unmapped_aval = partial(core.unmapped_aval, params['axis_size'])
+      out_axes = params['out_axes_thunk']()
+      out_pvals = [pval if pval.is_known() else
+                   PartialVal.unknown(unmapped_aval(out_axis, pval[0])) if out_axis is not None else
+                   PartialVal.unknown(pval[0])
+                   for pval, out_axis in zip(out_pvals, out_axes)]
 
     # Avoid staging out trivial calls, but maps may involve broadcasting.
     if not jaxpr.eqns and not primitive.map_primitive:
@@ -216,13 +230,16 @@ class JaxprTrace(Trace):
     new_params = dict(params, call_jaxpr=convert_constvars_jaxpr(jaxpr))
     if primitive.map_primitive:
       in_axes = params['in_axes']
-      # NOTE: const_tracers are outputs of the map, and those have had to
-      #       be mapped along axis 0
+      # NOTE: const_tracers are added as map outputs, and we always map them
+      #       along axis 0 (see `new_out_axes_thunk` above).
       new_in_axes = ((0,) * len(const_tracers) +
                      (None,) * len(env_tracers) +
                      tuple(axis for axis, t in zip(in_axes, tracers)
                            if not t.pval.is_known()))
-      new_params = dict(new_params, in_axes=new_in_axes)
+      new_out_axes = tuple(axis for axis, pval in zip(out_axes, out_pvals)
+                           if not pval.is_known())
+      new_params = dict(new_params, in_axes=new_in_axes, out_axes=new_out_axes)
+      del new_params['out_axes_thunk']
     update_params = call_param_updaters.get(primitive)
     if update_params:
       new_params = update_params(new_params, [not t.pval.is_known() for t in tracers])
@@ -239,13 +256,15 @@ class JaxprTrace(Trace):
     jaxpr, consts, env = tracers_to_jaxpr([], out_tracers)
     out_pvs, out_pv_consts = unzip2(t.pval for t in out_tracers)
     out = out_pv_consts + consts
+    nconsts = len(consts)
     del consts, out_pv_consts
     main = self.main
 
     if primitive.map_primitive:
+      out_axes = params['out_axes_thunk']()
       sz = params['axis_size']
-      out_pvs = [None if pv is None else core.unmapped_aval(sz, 0, pv)
-                 for pv in out_pvs]
+      out_pvs = [None if pv is None else core.unmapped_aval(sz, ax, pv)
+                 for pv, ax in zip(out_pvs, out_axes)]
 
     def todo(x):
       n = len(jaxpr.outvars)
@@ -258,10 +277,10 @@ class JaxprTrace(Trace):
 
       new_params = dict(params, call_jaxpr=convert_constvars_jaxpr(jaxpr))
       if primitive.map_primitive:
-        # NOTE: const_tracers are outputs of the map, and those have had to
-        #       be mapped along axis 0
+        # NOTE: We've assigned axis 0 to const tracers below, in out_axes_transform.
         new_in_axes = (0,) * len(const_tracers) + (None,) * len(env)
-        new_params = dict(new_params, in_axes=new_in_axes)
+        new_params = dict(new_params, in_axes=new_in_axes, out_axes=out_axes)
+        del new_params['out_axes_thunk']
       update_params = call_param_updaters.get(primitive)
       if update_params:
         new_params = update_params(new_params, [])
@@ -271,6 +290,12 @@ class JaxprTrace(Trace):
       for t in out_tracers:
         t.recipe = eqn
       return out_tracers
+
+    if primitive.map_primitive:
+      def out_axes_transform(out_axes):
+        return out_axes + (0,) * nconsts
+      todo = (todo, out_axes_transform)
+
     return out, todo
 
   post_process_map = post_process_call
@@ -376,6 +401,10 @@ def partial_eval_wrapper(pvs: Sequence[Optional[AbstractValue]], *consts):
   out = tuple(out_consts) + tuple(consts)
   yield out, (out_pvs, jaxpr, env)
 
+@lu.transformation_with_aux
+def count_outputs(*args, **kwargs):
+  ans = yield args, kwargs
+  yield ans, len(ans)
 
 custom_partial_eval_rules: Dict[core.Primitive, Callable] = {}
 call_partial_eval_rules: Dict[core.Primitive, Callable] = {}
@@ -1081,15 +1110,18 @@ class DynamicJaxprTrace(core.Trace):
     with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.main, reduced_in_avals)
-    out_avals = [core.unmapped_aval(params['axis_size'], 0, a) for a in reduced_out_avals]
+    out_axes = params['out_axes_thunk']()
+    out_avals = [core.unmapped_aval(params['axis_size'], out_axis, a) if out_axis is not None else a
+                 for a, out_axis in zip(reduced_out_avals, out_axes)]
     source_info = source_info_util.current()
     out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     constvars = map(self.getvar, map(self.instantiate_const, consts))
     outvars = map(self.makevar, out_tracers)
     new_in_axes = (None,) * len(consts) + params['in_axes']
-    new_params = dict(params, in_axes=new_in_axes,
+    new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
                       call_jaxpr=convert_constvars_jaxpr(jaxpr))
+    del new_params['out_axes_thunk']
     update_params = call_param_updaters.get(map_primitive)
     if update_params:
       new_params = update_params(new_params, [True] * len(tracers))

--- a/jax/util.py
+++ b/jax/util.py
@@ -288,9 +288,11 @@ def assert_unreachable(x):
   raise AssertionError(f"Unhandled case: {type(x).__name__}")
 
 def tuple_insert(t, idx, val):
+  assert 0 <= idx <= len(t), (idx, len(t))
   return t[:idx] + (val,) + t[idx:]
 
 def tuple_delete(t, idx):
+  assert 0 <= idx < len(t), (idx, len(t))
   return t[:idx] + t[idx + 1:]
 
 # TODO(mattjj): replace with dataclass when Python 2 support is removed
@@ -304,3 +306,24 @@ def taggedtuple(name, fields) -> Callable[..., Any]:
   for i, f in enumerate(fields):
     class_namespace[f] = property(operator.itemgetter(i+1))  # type: ignore
   return type(name, (tuple,), class_namespace)
+
+class HashableFunction:
+  """Makes a function hashable based on the provided key."""
+  def __init__(self, f, key):
+    self.f = f
+    self.key = key
+
+  def __eq__(self, other):
+    return type(other) is HashableFunction and self.key == other.key
+
+  def __hash__(self):
+    return hash(self.key)
+
+  def __call__(self, *args, **kwargs):
+    return self.f(*args, **kwargs)
+
+  def __repr__(self):
+    return f'<HashableFunction with key={self.key}>'
+
+def as_hashable_function(key):
+  return lambda f: HashableFunction(f, key)


### PR DESCRIPTION
Previously `pmap` didn't have the `out_axes` parameter (unlike `vmap`), but its semantics would match the specification of `out_axes=0` (i.e. all outputs should be stacked along the first axis). This patch makes it possible to specify non-zero values for out_axes, but more importantly it lays down the groundwork for `xmap` which will have to use some extremely similar (if not the same) code paths.

One thing to note is that when I started this implementation I was also planning to add support for `out_axes=None`, which would allow us to stop using the `unbroadcast` hack, and most of the code is written with that in mind. Unfortunately it turned out that the correct implementation of the transpose rule for maps that do allow unmapped outputs would require me to pretty much simulate what avals-with-names is supposed to achieve. Technically replicated outputs should work today, for as long as the user does not do reverse-mode AD of `pmap`. But I decided that it's better to just disable them altogether until we can get the full and correct behavior.

## Implementation details

This patch is significantly more involved than the one that implemented general `in_axes` support. That previous one at least had the foundation of `mapped_invars` which already behaved pretty similarly to general `in_axes`. From a quick glance one might think that `out_axes` should behave similarly to `in_axes`, but it turns out that this is not the case, at least not if we're interested in keeping those primitives final-style.

### Thunking

The biggest difficulty with handling `out_axes` in final style primitives is that we want to treat them as a prefix of the output pytree, but we don't know the structure of the output pytree until the user function is evaluated! And the user function is not evaluated until we've applied all transforms and reached the impl rule! The solution to this problem is "straightforward": instead of putting `out_axes` as a primitive parameter, we bundle an `out_axes_thunk` which can only be called successfully after the wrapped function has been executed. The thunk returns a list of flat `out_axes`, expanded to the output pytree. However, the thunking presents us with two problems:

#### Transformations
Each transformation that modifies the number of outputs needs to ensure that the thunk is updated to reflect the new values. To make things worse a lot of the transforms can learn the number of added outputs _only after the wrapped function is evaluated_, which leads to the following "time travel" pattern that can be found in most `Trace`s:
```py
@lu.transformation_with_aux
def compute_output_statistic(*args, **kwargs):
  outputs = yield args, kwargs
  yield outputs, compute_statistic(outputs)
wrapped_fun, output_statistic = compute_output_statistic(wrapped_fun)
def new_out_axes_thunk():
  old_out_axes = params['out_axes_thunk']()
  return compute_new_out_axes(old_out_axes(), output_statistic())
primitive.bind(wrapped_fun, dict(params, out_axes_thunk=new_out_axes_thunk))
```
The reason why we have to structure the code this way is that we can only specify a new `out_axes_thunk` before we bind the primitive, but we need the outputs of bind to know how to update the `out_axes_thunk`. To make things worse, the implementation of `bind` is allowed to make a call to `out_axes_thunk` _immediately after `wrapped_fun` is evaluated_. This means that we cannot compute the output statistic in the implementation of the transformation, but we have to use an extra `lu.transformation_with_aux` for that (this populates the statistic store immediately after `wrapped_fun` is evaluated).

The `compute_statistic` function depends on the transform in question. E.g. in the JVP trace it counts the number of non-zero tangent results.

The situation is of course further complicated when we take `post_process_map` into account. The new `process_env_traces` now always sets up this funny time travel trampoline just in case it ends up being necessary, and `post_process_map` is now expected to return `(outputs, (todo, out_axes_transform))` instead of just `(outputs, todo)`.

#### Compilation cache

Because the `out_axes_thunk`s are now arguments to a _global_ compilation cache (in the form of `lu.cache` decorator on `parallel_callable`), we have to ensure that they implement `hash` and `==`. This is what forces us to add some slightly weird helpers such as `_hashable_function` and `_ignore_elem_list`. The code that uses those makes an assumption that the output pytree depends deterministically on the identity of the wrapped function, which I think is in line with general JAX assumptions. Otherwise the cache would depend on the identity of the thunk, which changes with every function invocation.

Relaxing the global constraint on the cache (e.g. allowing each `pmap(f)` instance to have a separate cache) would make this easier too.

## Why final style? 

Now, making the primitives initial-style would remove the necessity for thunking, because we could have obtained the output pytree right when the function is wrapped. I assumed there is a good argument for making `pmap` pretend that it's a final-style primitive, but I'm not sure why that is? I hope it's something better than just avoiding a single jaxpr tracing.