### PR TITLE
Fix dtypes.is_weakly_typed

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -274,10 +274,13 @@ def is_weakly_typed(x):
   try:
     return x.aval.weak_type
   except AttributeError:
-    return type(x) in python_scalar_dtypes
+    return type(x) in _weak_types
 
 def is_python_scalar(x):
-  return is_weakly_typed(x) and np.ndim(x) == 0
+  try:
+    return x.aval.weak_type and np.ndim(x) == 0
+  except AttributeError:
+    return type(x) in python_scalar_dtypes
 
 def dtype(x):
   if type(x) in python_scalar_dtypes:


### PR DESCRIPTION
This makes the `is_weakly_typed` utility closer to our evolved definition of a weak type: in particular, `float0` and `bool` values are not considered weakly-typed.