### PR TITLE
Filter out non-integer index_dtypes in argmin/max.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4863,6 +4863,9 @@ def _argminmax_shape_rule(operand, *, axes, index_dtype):
   return tuple(np.delete(operand.shape, axis))
 
 def _argminmax_dtype_rule(operand, *, axes, index_dtype):
+  if not dtypes.issubdtype(index_dtype, np.integer):
+    raise TypeError("index_dtype must be an integer type, but got {}"
+                    .format(np.dtype(index_dtype).name))
   return index_dtype
 
 def _argminmax_translation_rule(value_comparator, identity,

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2348,6 +2348,16 @@ class LazyConstantTest(jtu.JaxTestCase):
     make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_fn={}_indexdtype={}"
+       .format(jax_fn.__name__, np.dtype(index_dtype).name),
+       "index_dtype": index_dtype, "jax_fn": jax_fn}
+      for index_dtype in jtu.dtypes.all_inexact + jtu.dtypes.boolean
+      for jax_fn in [lax.argmin, lax.argmax]))
+  def testArgMinMaxIndexDtypeError(self, jax_fn, index_dtype):
+    with self.assertRaisesRegex(TypeError,
+                                "index_dtype must be an integer type"):
+      jax_fn(np.ones((2, 2)), axis=0, index_dtype=index_dtype)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Specifying non-integer index dtypes in the two primitives is supported on CPU/TPU, but not on GPU as a custom translation rule is used. This change makes the behavior consistent.

I am not sure where to add a test for it, since this is specifically a test on the primitive rather than the wrapper. The harnesses in #4883 will ensure that this passes once in.