### PR TITLE
Improve pmap caching

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1154,7 +1154,7 @@ def vmap(fun: Callable[..., T], in_axes=0, out_axes=0, axis_name=None) -> Callab
     docstr += "\n\nOriginal documentation:\n\n"
     docstr += fun.__doc__
 
-  axis_name = core._TempAxisName(fun) if axis_name is None else axis_name
+  axis_name = core.fresh_axis_name() if axis_name is None else axis_name
 
   if isinstance(in_axes, list):
     # To be a tree prefix of the positional args tuple, in_axes can never be a
@@ -1444,7 +1444,7 @@ def pmap(fun: Callable[..., T],
   # the given value.
 
   _check_callable(fun)
-  axis_name = core._TempAxisName(fun) if axis_name is None else axis_name
+  axis_name = core.fresh_axis_name() if axis_name is None else axis_name
   static_broadcasted_tuple = _ensure_tuple(static_broadcasted_argnums)
   donate_tuple = rebase_donate_argnums(_ensure_tuple(donate_argnums),
                                        static_broadcasted_tuple)
@@ -1495,7 +1495,7 @@ def soft_pmap(fun: Callable, axis_name: Optional[AxisName] = None, in_axes=0
     raise NotImplementedError("soft_pmap requires omnistaging.")
   warn("soft_pmap is an experimental feature and probably has bugs!")
   _check_callable(fun)
-  axis_name = core._TempAxisName(fun) if axis_name is None else axis_name
+  axis_name = core.fresh_axis_name() if axis_name is None else axis_name
 
   if any(axis != 0 for axis in tree_leaves(in_axes)):
     raise ValueError(f"soft_pmap in_axes leaves must be 0 or None, got {in_axes}")

--- a/jax/experimental/general_map.py
+++ b/jax/experimental/general_map.py
@@ -244,7 +244,7 @@ def gmap(fun: Callable, schedule, axis_name = None) -> Callable:
   warn("gmap is an experimental feature and probably has bugs!")
   _check_callable(fun)
   binds_axis_name = axis_name is not None
-  axis_name = core._TempAxisName(fun) if axis_name is None else axis_name
+  axis_name = core.fresh_axis_name() if axis_name is None else axis_name
 
   @wraps(fun)
   def f_gmapped(*args, **kwargs):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1720,7 +1720,7 @@ class APITest(jtu.JaxTestCase):
       assert python_should_be_executing
       return x
 
-    x = np.ones(1)
+    x = np.ones((1, 1))
 
     python_should_be_executing = True
     api.pmap(f)(x)
@@ -1731,6 +1731,16 @@ class APITest(jtu.JaxTestCase):
     api.pmap(f, 'i')(x)
     python_should_be_executing = False
     api.pmap(f, 'i')(x)
+
+    python_should_be_executing = True
+    api.vmap(api.pmap(f))(x)
+    python_should_be_executing = False
+    api.vmap(api.pmap(f))(x)
+
+    python_should_be_executing = True
+    api.jvp(api.pmap(f), (x,), (x,))
+    python_should_be_executing = False
+    api.jvp(api.pmap(f), (x,), (x,))
 
   def test_device_array_repr(self):
     rep = repr(jnp.ones(()) + 1.)


### PR DESCRIPTION
Previously each result of `vmap(pmap(f))` would get a distinct
compilation cache, leading to potential unexpected recompilations.

Note that while this patch helps with that issue, it still doesn't
address the same problem in the case of `pmap(vmap(f))`. In general the
global caching mechanism seems very fragile and we might want to
reconsider this guarantee.