### PR TITLE
Remove noisy warnings for var() of int

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1999,7 +1999,7 @@ def _var_promote_types(a_dtype, dtype):
     a_dtype = promote_types(a_dtype, dtype)
   else:
     if not issubdtype(a_dtype, inexact):
-      dtype = a_dtype = float_
+      dtype = a_dtype = dtypes.canonicalize_dtype(float_)
     else:
       dtype = _complex_elem_type(a_dtype)
       a_dtype = promote_types(a_dtype, float32)


### PR DESCRIPTION
In x32 mode.

Before:
```python
>>> jnp.arange(10).var()
'jax._src.numpy.lax_numpy.float64'> requested in mean is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
DeviceArray(8.25, dtype=float32)
```
After:
```python
>>> jnp.arange(10).var()
DeviceArray(8.25, dtype=float32)
```