### PR TITLE
Add derivative for eigenvalues

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -237,6 +237,33 @@ def triangular_solve(a, b, left_side: bool = False, lower: bool = False,
 
 
 # utilities
+@partial(vectorize, signature='(n,m),(m)->(n)')
+def _matvec_multiply(a, b):
+  return lax.dot(a, b, precision=lax.Precision.HIGHEST)
+
+def _check_solve_shapes(a, b):
+  if not (a.ndim >= 2 and a.shape[-1] == a.shape[-2] and b.ndim >= 1):
+    msg = ("The arguments to solve must have shapes a=[..., m, m] and "
+           "b=[..., m, k] or b=[..., m]; got a={} and b={}")
+    raise ValueError(msg.format(a.shape, b.shape))
+
+def _solve(a, b):
+  _check_solve_shapes(a, b)
+
+  # With custom_linear_solve, we can reuse the same factorization when
+  # computing sensitivities. This is considerably faster.
+  lu_, _, permutation = lu(lax.stop_gradient(a))
+  custom_solve = partial(
+      lax.custom_linear_solve,
+      lambda x: _matvec_multiply(a, x),
+      solve=lambda _, x: lu_solve(lu_, permutation, x, trans=0),
+      transpose_solve=lambda _, x: lu_solve(lu_, permutation, x, trans=1))
+  if a.ndim == b.ndim + 1:
+    # b.shape == [..., m]
+    return custom_solve(b)
+  else:
+    # b.shape == [..., m, k]
+    return api.vmap(custom_solve, b.ndim - 1, max(a.ndim, b.ndim) - 1)(b)
 
 def _T(x): return jnp.swapaxes(x, -1, -2)
 def _H(x): return jnp.conj(_T(x))
@@ -380,6 +407,20 @@ def eig_batching_rule(batched_args, batch_dims, *, compute_left_eigenvectors,
                      compute_right_eigenvectors=compute_right_eigenvectors),
           (0,) * (1 + compute_left_eigenvectors + compute_right_eigenvectors))
 
+def eig_jvp_rule(primals, tangents, *, compute_left_eigenvectors,
+                 compute_right_eigenvectors):
+  if compute_left_eigenvectors or compute_right_eigenvectors:
+    raise NotImplementedError(
+        'The derivatives of eigenvectors are not implemented, only '
+        'eigenvalues. See '
+        'https://github.com/google/jax/issues/2748 for discussion.')
+  # Formula for derivative of eigenvalues w.r.t. a is eqn 4.60 in
+  # https://arxiv.org/abs/1701.00392
+  a, = primals
+  da, = tangents
+  l, v = eig(a, compute_left_eigenvectors=False)
+  return [l], [jnp.sum(_solve(v, da.astype(v.dtype)) * _T(v), -1)]
+
 eig_p = Primitive('eig')
 eig_p.multiple_results = True
 eig_p.def_impl(eig_impl)
@@ -387,6 +428,7 @@ eig_p.def_abstract_eval(eig_abstract_eval)
 xla.translations[eig_p] = eig_translation_rule
 xla.backend_specific_translations['cpu'][eig_p] = eig_cpu_translation_rule
 batching.primitive_batchers[eig_p] = eig_batching_rule
+ad.primitive_jvps[eig_p] = eig_jvp_rule
 
 
 # Symmetric/Hermitian eigendecomposition

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -46,7 +46,7 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 @partial(jit, static_argnums=(2,))
 def _cho_solve(c, b, lower):
   c, b = np_linalg._promote_arg_dtypes(jnp.asarray(c), jnp.asarray(b))
-  np_linalg._check_solve_shapes(c, b)
+  lax_linalg._check_solve_shapes(c, b)
   b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
                                   transpose_a=not lower, conjugate_a=not lower)
   b = lax_linalg.triangular_solve(c, b, left_side=True, lower=lower,
@@ -168,14 +168,14 @@ def _solve(a, b, sym_pos, lower):
     return np_linalg.solve(a, b)
 
   a, b = np_linalg._promote_arg_dtypes(jnp.asarray(a), jnp.asarray(b))
-  np_linalg._check_solve_shapes(a, b)
+  lax_linalg._check_solve_shapes(a, b)
 
   # With custom_linear_solve, we can reuse the same factorization when
   # computing sensitivities. This is considerably faster.
   factors = cho_factor(lax.stop_gradient(a), lower=lower)
   custom_solve = partial(
       lax.custom_linear_solve,
-      lambda x: np_linalg._matvec_multiply(a, x),
+      lambda x: lax_linalg._matvec_multiply(a, x),
       solve=lambda _, x: cho_solve(factors, x),
       symmetric=True)
   if a.ndim == b.ndim + 1:


### PR DESCRIPTION
We aren't supporting eigenvectors for now because eigenvectors are not uniquely determined by the input matrix, they're only determined up to 'gauge' (that is multiplication by a complex scalar with absolute value 1). This means that eigenvalue second (and higher) derivatives aren't supported either, because they involve differentiating the eigvals jvp, which itself depends on eigenvectors.

I had to move the body of `solve` from jnp.linalg into lax.linalg, because it's needed in the jvp rule.

This fixes partially https://github.com/google/jax/issues/2748.