### PR TITLE
Use the jax module to determine the jax source directory base, rather…

### DIFF
--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -17,6 +17,7 @@ import os.path
 import threading
 from typing import Any, Optional
 
+import jax
 from jax.lib import xla_client
 
 from jax._src import traceback_util
@@ -26,7 +27,7 @@ traceback_util.register_exclusion(__file__)
 Traceback = Any  # xla_client.Traceback
 Frame = Any  # xla_client.Traceback::Frame
 
-_jax_path = os.path.dirname(__file__)
+_jax_path = os.path.dirname(jax.__file__)
 
 def user_frame(source_info: Optional[Traceback]) -> Optional[Frame]:
   """Heuristic that guesses the identity of the user's code in a stack trace."""


### PR DESCRIPTION
… than the source_info module.

Fixes some misattributed code source information.