### PR TITLE
Fix build.py to work on Linux once again.

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -78,6 +78,7 @@ py_library(
     srcs = [
         "cuda_prng.py",
         "cusolver.py",
+        "init.py",
         "pocketfft.py",
         "version.py",
     ],
@@ -105,8 +106,6 @@ pybind_extension(
     deps = [
         ":gpu_kernel_helpers",
         ":kernel_pybind11_helpers",
-        "@org_tensorflow//tensorflow/stream_executor/cuda:cublas_lib",
-        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -118,6 +117,8 @@ pybind_extension(
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cublas_headers",
         "@local_config_cuda//cuda:cuda_headers",
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cublas_lib",
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@pybind11",
     ],
 )
@@ -134,8 +135,6 @@ pybind_extension(
     deps = [
         ":gpu_kernel_helpers",
         ":kernel_pybind11_helpers",
-        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
-        "@org_tensorflow//tensorflow/stream_executor/cuda:cusolver_lib",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/base:core_headers",
@@ -146,6 +145,8 @@ pybind_extension(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@local_config_cuda//cuda:cuda_headers",
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cusolver_lib",
         "@pybind11",
     ],
 )
@@ -173,8 +174,8 @@ pybind_extension(
     deps = [
         ":cuda_prng_kernels_lib",
         ":kernel_pybind11_helpers",
-        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@local_config_cuda//cuda:cuda_headers",
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@pybind11",
     ],
 )

--- a/jaxlib/init.py
+++ b/jaxlib/init.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa: F401
 from .version import __version__


### PR DESCRIPTION
* strip DOS end-of-line characters from build.py for consistency with the rest of the source tree.
* use shutil.copy() instead of shutil.copyfile(). On Unix systems we must preserve execute permissions.
* add code to explicitly delete and recreate the target directory.
* Move build/jaxlib/__init_py to jaxlib/__init__.py and have the script move it into position, so the output directory for the jaxlib is an empty directory that the script creates.