### PR TITLE
use strict action env on windows to avoid constant full rebuilding

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -261,6 +261,7 @@ build:windows --linkopt=/OPT:REF
 build:windows --host_linkopt=/OPT:REF
 build:windows --linkopt=/OPT:ICF
 build:windows --host_linkopt=/OPT:ICF
+build:windows --experimental_strict_action_env=true
 
 # Suppress all warning messages.
 build:short_logs --output_filter=DONT_MATCH_ANYTHING


### PR DESCRIPTION
On windows, without `experimental_strict_action_env`, rebooting or maybe terminal restarting results in a full rebuild.

 