### PR TITLE
Make xmap into a primitive

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -312,6 +312,13 @@ def extract_call_jaxpr(
     return (params["call_jaxpr"], new_params)
 
 
+def traverse_jaxpr_params(f, params):
+  """Applies f to each jaxpr parameter and returns a tuple of returned values."""
+  return tuple(f(param if type(param) is Jaxpr else param.jaxpr)
+               for param in params.values()
+               if type(param) in (Jaxpr, ClosedJaxpr))
+
+
 def eval_jaxpr(jaxpr: Jaxpr, consts, *args):
   def read(v):
     if type(v) is Literal:

--- a/jax/experimental/general_map.py
+++ b/jax/experimental/general_map.py
@@ -327,17 +327,19 @@ class XMapPrimitive(core.Primitive):
 
   def bind(self, fun, *args, **params):
     assert len(params['in_axes']) == len(args)
-    return core.call_bind(self, fun, *args, **params)
+    return core.call_bind(self, fun, *args, **params)  # type: ignore
 
   def process(self, trace, fun, tracers, params):
     return trace.process_xmap(self, fun, tracers, params)
 
   def post_process(self, trace, out_tracers, params):
     raise NotImplementedError
-    return trace.post_process_xmap(self, out_tracers, params)
 
 xmap_p = XMapPrimitive()
 core.EvalTrace.process_xmap = core.EvalTrace.process_call  # type: ignore
+def _process_xmap_default(self, call_primitive, f, tracers, params):
+  raise NotImplementedError(f"{type(self)} must override process_xmap to handle xmap")
+core.Trace.process_xmap = _process_xmap_default  # type: ignore
 
 def _delete_aval_axes(aval, axes: AxisNamePos):
   assert isinstance(aval, core.ShapedArray)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1223,14 +1223,13 @@ def untile_aval_nd(axis_sizes, out_axes: AxisNameMap, aval):
     shape[axis] *= axis_sizes[name]
   return ShapedArray(tuple(shape), aval.dtype)
 
-# TODO(apaszke): Cache compilation
-def mesh_tiled_callable(*in_avals,
-                        fun: lu.WrappedFun,
+def mesh_tiled_callable(fun: lu.WrappedFun,
                         transformed_name: str,
                         backend_name: Optional[str],
                         mesh: Mesh,
                         in_axes: Sequence[AxisNameMap],
-                        out_axes_thunk: Callable[[], Sequence[AxisNameMap]]):
+                        out_axes: Sequence[AxisNameMap],
+                        *in_avals):
   assert config.omnistaging_enabled
   local_mesh = mesh.local_mesh
 
@@ -1244,7 +1243,6 @@ def mesh_tiled_callable(*in_avals,
                         for aval_in_axes, aval in zip(in_axes, in_avals))
   with core.extend_axis_env_nd(mesh.shape.items()):
     jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(fun, sharded_avals)
-  out_axes = out_axes_thunk()
   assert len(out_axes) == len(out_sharded_avals)
   # TODO(apaszke): What about outfeed?
   # jaxpr = xla.apply_outfeed_rewriter(jaxpr)


### PR DESCRIPTION
Add a compilation cache. Also make sure that it raises a clear error
when you try to use it with other transforms.

Also, add a bunch of checks to make sure that the arguments are valid.