### PR TITLE
unify reduction collectives' implementations

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -401,7 +401,8 @@ def _allreduce_translation_rule(prim, c, *args, axis_name, axis_index_groups,
     is_complex = dtypes.issubdtype(dtype, np.complexfloating)
     n = len(dtype_args)
     if is_complex and prim is lax.add_p:
-      # we handle complex-dtype sum-reduction directly as a special case
+      # TODO(b/141575627): we handle complex-dtype sum-reduction directly as a
+      # special case because it's not currently handled by XLA:GPU or XLA:CPU
       dtype_args = ([xops.Real(x) for x in dtype_args] +
                     [xops.Imag(x) for x in dtype_args])
     scalar = ShapedArray((), c.get_shape(dtype_args[0]).numpy_dtype())
@@ -431,7 +432,8 @@ def _notuple_allreduce_translation_rule(prim, c, *args, axis_name, axis_env,
                                           None, None)
 
     if dtypes.issubdtype(dtype, np.complexfloating) and prim is lax.add_p:
-      # we handle complex-dtype sum-reduction directly as a special case
+      # TODO(b/141575627): we handle complex-dtype sum-reduction directly as a
+      # special case because it's not currently handled by XLA:GPU or XLA:CPU
       return xops.Complex(all_reduce(xops.Real(val)),
                           all_reduce(xops.Imag(val)))
     else:

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -450,7 +450,7 @@ psum_p.multiple_results = True
 psum_p.def_abstract_eval(lambda *args, **params: map(raise_to_shaped, args))
 pxla.soft_pmap_rules[psum_p] = \
     partial(_allreduce_soft_pmap_rule, psum_p, lax._reduce_sum)
-xla.parallel_translations[psum_p] = partial(_allreduce_translation_rule, lax.add_p)
+xla.parallel_translations[psum_p] = partial(_allreduce_translation_rule, lax.add_p)  # type: ignore
 ad.deflinear(psum_p, _psum_transpose_rule)
 pxla.multi_host_supported_collectives.add(psum_p)
 batching.primitive_batchers[psum_p] = partial(_collective_batcher, psum_p)


### PR DESCRIPTION
The implementation of `psum` had diverged from that of `pmin` and `pmax` because the former had been adapted to to generate a single XLA collective ops with a tuple of inputs and outputs, rather than many separate collective ops. (See #2337 for the motivation to make `psum` operate on tuples.)

This PR updates the `pmin` and `pmax` implementations to follow that of `psum`, so that they can share code. This fixes a TODO from #4835.