### PR TITLE
Call asarray() rather than array() to avoid host round-trips.

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -288,7 +288,7 @@ def one_hot(x, num_classes, *, dtype=jnp.float64):
   x = jnp.asarray(x)
   lhs = x[..., jnp.newaxis]
   rhs = lax.broadcast_to_rank(jnp.arange(num_classes, dtype=x.dtype), lhs.ndim)
-  return jnp.array(lhs == rhs, dtype=dtype)
+  return jnp.asarray(lhs == rhs, dtype=dtype)
 
 def relu6(x):
   r"""Rectified Linear Unit 6 activation function.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -877,7 +877,7 @@ def histogram_bin_edges(a, bins=10, range=None, weights=None):
   if isinstance(bins, str):
     raise NotImplementedError("string values for `bins` not implemented.")
   a = ravel(a)
-  b = array(bins)
+  b = asarray(bins)
   if b.ndim == 1:
     return b
   if range is None:
@@ -1593,7 +1593,7 @@ def bincount(x, weights=None, minlength=0, *, length=None):
     msg = f"x argument to bincount must have an integer type; got {x.dtype}"
     raise TypeError(msg)
   if length is None:
-    x = core.concrete_or_error(array, x,
+    x = core.concrete_or_error(asarray, x,
       "The error occured because of argument 'x' of jnp.bincount. "
       "To avoid this error, pass a static `length` argument.")
     length = max(x) + 1
@@ -2446,7 +2446,7 @@ def concatenate(arrays, axis=0):
   # (https://github.com/google/jax/issues/653).
   k = 16
   if len(arrays) == 1:
-    return array(arrays[0])
+    return asarray(arrays[0])
   else:
     while len(arrays) > 1:
       arrays = [lax.concatenate(arrays[i:i+k], axis)
@@ -2477,7 +2477,7 @@ def dstack(tup):
 def column_stack(tup):
   arrays = []
   for v in tup:
-    arr = array(v)
+    arr = asarray(v)
     if arr.ndim < 2:
       arr = atleast_2d(arr).T
     arrays.append(arr)
@@ -2494,7 +2494,7 @@ def choose(a, choices, out=None, mode='raise'):
   N = len(choices)
 
   if mode == 'raise':
-    a = core.concrete_or_error(array, a,
+    a = core.concrete_or_error(asarray, a,
       "The error occurred because jnp.choose was jit-compiled"
       " with mode='raise'. Use mode='wrap' or mode='clip' instead.")
     if any((a < 0) | (a >= N)):
@@ -2540,7 +2540,7 @@ def block(arrays):
 @_wraps(np.atleast_1d, update_doc=False)
 def atleast_1d(*arys):
   if len(arys) == 1:
-    arr = array(arys[0])
+    arr = asarray(arys[0])
     return arr if ndim(arr) >= 1 else reshape(arr, -1)
   else:
     return [atleast_1d(arr) for arr in arys]
@@ -2549,7 +2549,7 @@ def atleast_1d(*arys):
 @_wraps(np.atleast_2d, update_doc=False)
 def atleast_2d(*arys):
   if len(arys) == 1:
-    arr = array(arys[0])
+    arr = asarray(arys[0])
     if ndim(arr) >= 2:
       return arr
     elif ndim(arr) == 1:
@@ -2563,7 +2563,7 @@ def atleast_2d(*arys):
 @_wraps(np.atleast_3d, update_doc=False)
 def atleast_3d(*arys):
   if len(arys) == 1:
-    arr = array(arys[0])
+    arr = asarray(arys[0])
     if ndim(arr) == 0:
       arr = expand_dims(arr, axis=(0, 1, 2))
     elif ndim(arr) == 1:
@@ -2598,7 +2598,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
       out = object
   elif isinstance(object, (list, tuple)):
     if object:
-      out = stack([array(elt, dtype=dtype) for elt in object])
+      out = stack([asarray(elt, dtype=dtype) for elt in object])
     else:
       out = _device_put_raw(_np_array([], dtype=dtype))
   else:
@@ -3998,7 +3998,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
 @_wraps(np.unique)
 def unique(ar, return_index=False, return_inverse=False,
            return_counts=False, axis=None):
-  ar = core.concrete_or_error(array, ar, "The error arose in jnp.unique()")
+  ar = core.concrete_or_error(asarray, ar, "The error arose in jnp.unique()")
 
   if iscomplexobj(ar):
     raise NotImplementedError(
@@ -4489,8 +4489,8 @@ def compress(condition, a, axis=None, out=None):
     raise NotImplementedError("The 'out' argument to jnp.compress is not supported.")
   if ndim(condition) != 1:
     raise ValueError("condition must be a 1D array")
-  condition = array(condition).astype(bool)
-  a = array(a)
+  condition = asarray(condition).astype(bool)
+  a = asarray(a)
   if axis is None:
     axis = 0
     a = ravel(a)

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -214,7 +214,7 @@ def _cofactor_solve(a, b):
   # Compute (partial) determinant, ignoring last diagonal of LU
   diag = jnp.diagonal(lu, axis1=-2, axis2=-1)
   parity = jnp.count_nonzero(pivots != jnp.arange(a_shape[-1]), axis=-1)
-  sign = jnp.array(-2 * (parity % 2) + 1, dtype=dtype)
+  sign = jnp.asarray(-2 * (parity % 2) + 1, dtype=dtype)
   # partial_det[:, -1] contains the full determinant and
   # partial_det[:, -2] contains det(u) / u_{nn}.
   partial_det = jnp.cumprod(diag, axis=-1) * sign[..., None]

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -59,7 +59,7 @@ def PRNGKey(seed: int) -> jnp.ndarray:
     seed = np.int64(seed)
   # Converting to jnp.array may truncate bits when jax_enable_x64=False, but this
   # is necessary for the sake of JIT invariance of the result for such values.
-  seed = jnp.array(seed)
+  seed = jnp.asarray(seed)
 
   convert = lambda k: lax.reshape(lax.convert_element_type(k, np.uint32), [1])
   k1 = convert(lax.shift_right_logical(seed, lax._const(seed, 32)))

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -51,4 +51,4 @@ def logcdf(x, loc=0, scale=1):
 
 @_wraps(osp_stats.norm.ppf, update_doc=False)
 def ppf(q, loc=0, scale=1):
-  return jnp.array(special.ndtri(q) * scale + loc, 'float64')
+  return jnp.asarray(special.ndtri(q) * scale + loc, 'float64')

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -104,7 +104,7 @@ def interp_fit_dopri(y0, y1, k, dt):
       -2691868925 / 45128329728 / 2, 187940372067 / 1594534317056 / 2,
       -1776094331 / 19743644256 / 2, 11237099 / 235043384 / 2])
   y_mid = y0 + dt * jnp.dot(dps_c_mid, k)
-  return jnp.array(fit_4th_order_polynomial(y0, y1, y_mid, k[0], k[-1], dt))
+  return jnp.asarray(fit_4th_order_polynomial(y0, y1, y_mid, k[0], k[-1], dt))
 
 def fit_4th_order_polynomial(y0, y1, y_mid, dy0, dy1, dt):
   a = -2.*dt*dy0 + 2.*dt*dy1 -  8.*y0 -  8.*y1 + 16.*y_mid


### PR DESCRIPTION
Related to #4486, I was looking at some memory performance issues and realized that `jnp.array()`, unlike `jnp.asarray()`, will round-trip DeviceArray inputs to numpy arrays stored on the host before pushing them back to device: https://github.com/google/jax/blob/30bb4cf58676c5d173cbbe68b86c5a3b2a8966b0/jax/_src/numpy/lax_numpy.py#L2594-L2596

This makes it a very poor choice for library functions to call on inputs that may be device arrays: it adds an unnecessary round-trip to the host in order to copy the data.

This PR rectifies all the places in jax where I found this inadvertent round-trip.