### PR TITLE
Warn on host round-trip caused by jnp.array()

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -198,7 +198,7 @@ def gelu(x, approximate: bool = True):
     cdf = 0.5 * (1.0 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * (x ** 3))))
     return x * cdf
   else:
-    return jnp.array(x * (lax.erf(x / np.sqrt(2)) + 1) / 2, dtype=x.dtype)
+    return jnp.asarray(x * (lax.erf(x / np.sqrt(2)) + 1) / 2, dtype=x.dtype)
 
 def glu(x, axis=-1):
   """Gated linear unit activation function."""

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2717,6 +2717,10 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     if isinstance(object, DeviceArray) and copy:
       # We perform a copy by bouncing back to the host
       # TODO(phawkins): add a device runtime function to copy a buffer
+      warnings.warn(
+        "Calling jnp.array(x) for a DeviceArray x will result in a "
+        "round-trip of the data to the host. Consider jnp.asarray(x) as "
+        "a more efficient alternative.", RuntimeWarning, stacklevel=2)
       out = _device_put_raw(_np_asarray(object), weak_type=weak_type)
     else:
       out = object

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1516,6 +1516,12 @@ class APITest(jtu.JaxTestCase):
     for x, y in zip(xs, ys):
       self.assertAllClose(x, y)
 
+  def test_efficiency_warning(self):
+    x = jnp.arange(10)
+    msg = r"Calling jnp.array\(x\) for a DeviceArray x will result in a round-trip"
+    with self.assertWarnsRegex(RuntimeWarning, msg):
+      jnp.array(x)
+
   def test_dtype_warning(self):
     # cf. issue #1230
     if FLAGS.jax_enable_x64:

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -303,7 +303,7 @@ class TestPromotionTables(jtu.JaxTestCase):
     for xtype, ytype in itertools.product(
       [int, float, jnp.int16, jnp.int32, jnp.float16, jnp.float32], repeat=2)
     for xfun, yfun in itertools.product(
-      [identity, abs, jnp.array], repeat=2)
+      [identity, abs, jnp.asarray], repeat=2)
     )
   def testBinaryPromotionJitInvariance(self, xtype, ytype, xfun, yfun):
     """Test jit invariance of simple binary promotion rules with and without weak types."""


### PR DESCRIPTION
This adds a warning that will alert users to the type of inefficiencies fixed in #5012.

Along with being a user-facing warning, this doubles as a regression test for the changes in #5012, because our pytest settings are configured to treat warnings as errors. This change caught one additional place in our codebase where we should have been using `jnp.asarray`.