### PR TITLE
X32 tests: fail on dtype warnings

### DIFF
--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -54,7 +54,7 @@ def compute_weight_mat(input_size: int, output_size: int, scale,
   # want to interpolate.
   kernel_scale = jnp.maximum(inv_scale, 1.) if antialias else 1.
 
-  sample_f = ((np.arange(output_size) + 0.5) * inv_scale -
+  sample_f = ((jnp.arange(output_size) + 0.5) * inv_scale -
               translation * inv_scale - 0.5)
   x = (
       jnp.abs(sample_f[jnp.newaxis, :] -

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6378,7 +6378,7 @@ def _check_user_dtype_supported(dtype, fun_name=None):
            "See https://github.com/google/jax#current-gotchas for more.")
     fun_name = f"requested in {fun_name}" if fun_name else ""
     truncated_dtype = dtypes.canonicalize_dtype(dtype).name
-    warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
+    warnings.warn(msg.format(dtype, fun_name , truncated_dtype), stacklevel=2)
 
 
 def _canonicalize_axis(axis, num_dims):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4985,7 +4985,7 @@ def _unimplemented_setitem(self, i, x):
 def _operator_round(number, ndigits=None):
   out = round(number, decimals=ndigits or 0)
   # If `ndigits` is None, for a builtin float round(7.5) returns an integer.
-  return out.astype(int_) if ndigits is None else out
+  return out.astype(int) if ndigits is None else out
 
 _operators = {
     "getitem": _rewriting_take,

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -51,4 +51,4 @@ def logcdf(x, loc=0, scale=1):
 
 @_wraps(osp_stats.norm.ppf, update_doc=False)
 def ppf(q, loc=0, scale=1):
-  return jnp.asarray(special.ndtri(q) * scale + loc, 'float64')
+  return jnp.asarray(special.ndtri(q) * scale + loc, float)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 filterwarnings =
     error
     ignore:No GPU/TPU found, falling back to CPU.:UserWarning
-    ignore:Explicitly requested dtype.*is not available.*:UserWarning
     ignore:outfeed_receiver is unnecessary and deprecated:DeprecationWarning
     # The rest are for experimental/jax_to_tf
     ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -563,7 +563,7 @@ class BatchingTest(jtu.JaxTestCase):
   def testCumProd(self):
    x = jnp.arange(9).reshape(3, 3) + 1
    y = vmap(lambda x: jnp.cumprod(x, axis=-1))(x)
-   self.assertAllClose(np.cumprod(x, axis=1, dtype=jnp.int_), y)
+   self.assertAllClose(np.cumprod(x, axis=1, dtype=int), y)
 
   def testSelect(self):
     pred = np.array([True, False])
@@ -930,12 +930,11 @@ class BatchingTest(jtu.JaxTestCase):
     def f(key):
       def body_fn(uk):
         key = uk[1]
-        u = random.uniform(key, (), dtype=jnp.float64)
+        u = random.uniform(key, ())
         key, _ = random.split(key)
         return u, key
 
-      u, _ = lax.while_loop(lambda uk: uk[0] > 0.5, body_fn,
-                            (jnp.float64(1.), key))
+      u, _ = lax.while_loop(lambda uk: uk[0] > 0.5, body_fn, (1., key))
       return u
 
     print(vmap(f)(random.split(random.PRNGKey(0), 2)))  # no crash

--- a/tests/doubledouble_test.py
+++ b/tests/doubledouble_test.py
@@ -17,6 +17,7 @@ import operator
 from absl.testing import absltest
 from absl.testing import parameterized
 
+from jax import dtypes
 from jax import numpy as jnp
 from jax import test_util as jtu
 from jax.experimental.doubledouble import doubledouble, _DoubleDouble
@@ -104,7 +105,7 @@ class DoubleDoubleTest(jtu.JaxTestCase):
     for val in ["6.0221409e23", "3.14159265358", "0", 123456789]
   ))
   def testClassInstantiation(self, dtype, val):
-    dtype = jnp.dtype(dtype).type
+    dtype = dtypes.canonicalize_dtype(dtype).type
     self.assertEqual(dtype(val), _DoubleDouble(val, dtype).to_array())
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -77,6 +77,8 @@ class DtypesTest(jtu.JaxTestCase):
     {"testcase_name": "_swap={}_jit={}".format(swap, jit),
      "swap": swap, "jit": jit}
     for swap in [False, True] for jit in [False, True])
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype.*")
   def testBinaryPromotion(self, swap, jit):
     testcases = [
       (jnp.array(1.), 0., jnp.float_),
@@ -200,6 +202,8 @@ class TestPromotionTables(jtu.JaxTestCase):
       val = jaxtype.type(0)
     self.assertIs(dtypes._jax_type(val), jaxtype)
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype.*")
   def testObservedPromotionTable(self):
     """Test that the weak & strong dtype promotion table does not change over time."""
     # Note: * here refers to weakly-typed values

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -34,6 +34,7 @@ config.parse_flags_with_absl()
 def jvp_taylor(fun, primals, series):
   # Computes the Taylor series the slow way, with nested jvp.
   order, = set(map(len, series))
+  primals = tuple(jnp.asarray(p) for p in primals)
   def composition(eps):
     taylor_terms = [sum([eps ** (i+1) * terms[i] / fact(i + 1)
                          for i in range(len(terms))]) for terms in series]

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1030,36 +1030,36 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testSegmentSum(self):
-    data = np.array([5, 1, 7, 2, 3, 4, 1, 3])
-    segment_ids = np.array([0, 0, 0, 1, 2, 2, 3, 3])
+    data = jnp.array([5, 1, 7, 2, 3, 4, 1, 3])
+    segment_ids = jnp.array([0, 0, 0, 1, 2, 2, 3, 3])
 
     # test with explicit num_segments
     ans = ops.segment_sum(data, segment_ids, num_segments=4)
-    expected = np.array([13, 2, 7, 4])
+    expected = jnp.array([13, 2, 7, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     # test with explicit num_segments larger than the higher index.
     ans = ops.segment_sum(data, segment_ids, num_segments=5)
-    expected = np.array([13, 2, 7, 4, 0])
+    expected = jnp.array([13, 2, 7, 4, 0])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     # test without explicit num_segments
     ans = ops.segment_sum(data, segment_ids)
-    expected = np.array([13, 2, 7, 4])
+    expected = jnp.array([13, 2, 7, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     # test with negative segment ids and segment ids larger than num_segments,
     # that will be wrapped with the `mod`.
-    segment_ids = np.array([0, 4, 8, 1, 2, -6, -1, 3])
+    segment_ids = jnp.array([0, 4, 8, 1, 2, -6, -1, 3])
     ans = ops.segment_sum(data, segment_ids, num_segments=4)
-    expected = np.array([13, 2, 7, 4])
+    expected = jnp.array([13, 2, 7, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
     # test with negative segment ids and without without explicit num_segments
     # such as num_segments is defined by the smaller index.
-    segment_ids = np.array([3, 3, 3, 4, 5, 5, -7, -6])
+    segment_ids = jnp.array([3, 3, 3, 4, 5, 5, -7, -6])
     ans = ops.segment_sum(data, segment_ids)
-    expected = np.array([1, 3, 0, 13, 2, 7, 0])
+    expected = jnp.array([1, 3, 0, 13, 2, 7, 0])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testIndexDtypeError(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3198,7 +3198,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   def testNpMean(self):
     # from https://github.com/google/jax/issues/125
-    x = lax.add(jnp.eye(3, dtype=jnp.float_), 0.)
+    x = lax.add(jnp.eye(3, dtype=float), 0.)
     ans = np.mean(x)
     self.assertAllClose(ans, np.array(1./3), check_dtypes=False)
 
@@ -3825,6 +3825,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testLongLong(self):
     self.assertAllClose(np.int64(7), api.jit(lambda x: x)(np.longlong(7)))
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype.*")
   def testArange(self):
     # test cases inspired by dask tests at
     # https://github.com/dask/dask/blob/master/dask/array/tests/test_creation.py#L92

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -32,8 +32,8 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
-float_types = [np.float32, np.float64]
-complex_types = [np.complex64, np.complex128]
+float_types = jtu.dtypes.floating
+complex_types = jtu.dtypes.complex
 
 
 def matmul_high_precision(a, b):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -304,7 +304,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("gpu", "tpu")
   def testEigvalsInf(self):
     # https://github.com/google/jax/issues/2661
-    x = jnp.array([[jnp.inf]], jnp.float64)
+    x = jnp.array([[jnp.inf]])
     self.assertTrue(jnp.all(jnp.isnan(jnp.linalg.eigvals(x))))
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/loops_test.py
+++ b/tests/loops_test.py
@@ -61,9 +61,8 @@ class LoopsTest(jtu.JaxTestCase):
     self.assertAllClose(f_expected(2.), api.jit(f_op)(2.))
     self.assertAllClose(5., api.grad(f_op)(2.))
     self.assertAllClose(5., api.grad(f_op)(2.))
-    inc_batch = np.arange(5, dtype=jnp.float_)
-    self.assertAllClose(jnp.array([f_expected(inc) for inc in inc_batch],
-                                  dtype=jnp.float_),
+    inc_batch = np.arange(5.0)
+    self.assertAllClose(jnp.array([f_expected(inc) for inc in inc_batch]),
                         api.vmap(f_op)(inc_batch))
 
 

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -407,7 +407,7 @@ class MaskingTest(jtu.JaxTestCase):
     ans = grad(lambda W: vmap(rnn, ((None, 0, 0), 0))((W, seqs, ys), dict(t=ts)).sum())(W)
 
     def rnn_reference(W, seqs, targets):
-      total_loss = jnp.array(0, jnp.float_)
+      total_loss = jnp.array(0.0)
       for xs, target in zip(seqs, targets):
         h = jnp.zeros(n)
         for x in xs:

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -21,7 +21,6 @@ import itertools
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import numpy as np
 import scipy.stats
 
 from jax import core
@@ -67,8 +66,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
     check_grads(nn.softplus, (float('nan'),), order=1,
                 rtol=1e-2 if jtu.device_under_test() == "tpu" else None)
 
-  @parameterized.parameters([
-      int, jnp.int32, float, jnp.float64, jnp.float32, jnp.float64,])
+  @parameterized.parameters([int, float] + jtu.dtypes.floating + jtu.dtypes.integer)
   def testSoftplusZero(self, dtype):
     self.assertEqual(jnp.log(dtype(2)), nn.softplus(dtype(0)))
 
@@ -212,7 +210,7 @@ class NNInitializersTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype}
       for rec in INITIALIZER_RECS
       for shape in rec.shapes
-      for dtype in [np.float32, np.float64]))
+      for dtype in jtu.dtypes.floating))
   def testInitializer(self, initializer, shape, dtype):
     rng = random.PRNGKey(0)
     val = initializer(rng, shape, dtype)
@@ -228,7 +226,7 @@ class NNInitializersTest(jtu.JaxTestCase):
        "shape": shape, "dtype": dtype}
       for rec in INITIALIZER_RECS
       for shape in rec.shapes
-      for dtype in [np.float32, np.float64]))
+      for dtype in jtu.dtypes.floating))
   def testInitializerProvider(self, initializer_provider, shape, dtype):
     rng = random.PRNGKey(0)
     initializer = initializer_provider(dtype=dtype)

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -282,7 +282,7 @@ class OptimizerTests(jtu.JaxTestCase):
       assert trip == 75
       return opt_final
 
-    initial_params = jnp.float64(0.5)
+    initial_params = jnp.array(0.5)
     minimize_structure(initial_params)
 
     def loss(test_params):


### PR DESCRIPTION
Any code in JAX that requests an unavailable dtype results in a warning. For example, in X32 mode:
```python
>>> import jax.numpy as jnp
>>> jnp.arange(10, dtype='float64')                                                                             
/Users/vanderplas/github/google/jax/jax/_src/numpy/lax_numpy.py:2744: UserWarning: Explicitly requested dtype float64 requested in arange is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
  lax._check_user_dtype_supported(dtype, "arange")
DeviceArray([0., 1., 2., 3., 4., 5., 6., 7., 8., 9.], dtype=float32)
```
Currently, there are many places in the jax internals that generate this warning, which is not a great experience for users and contributes to warning fatigue. This issue is not caught because currently, our tests explicitly ignore these warnings.

This PR rectifies the situation: it removes the warning filter from the test suite, and fixes several remaining instances of this warning being generated by internal code & tests.

Related: #5019