### PR TITLE
X32: don't warn when builtin type passed as dtype

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6256,6 +6256,9 @@ def _abstractify(x):
 
 
 def _check_user_dtype_supported(dtype, fun_name=None):
+  # Avoid using `dtype in [...]` becuase of numpy dtype equality overloading.
+  if isinstance(dtype, type) and dtype in {bool, int, float, complex}:
+    return
   np_dtype = np.dtype(dtype)
   if np_dtype.kind not in "biufc" and np_dtype.type != dtypes.bfloat16:
     msg = f"JAX only supports number and bool dtypes, got dtype {dtype}"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1543,9 +1543,13 @@ class APITest(jtu.JaxTestCase):
         assert len(w) == prev_len
 
     check_warning(lambda: jnp.array([1, 2, 3], dtype="float64"),
-                  lambda: jnp.array([1, 2, 3], dtype="float32"),)
+                  lambda: jnp.array([1, 2, 3], dtype="float32"))
+    check_warning(lambda: jnp.array([1, 2, 3], dtype="float64"),
+                  lambda: jnp.array([1, 2, 3], dtype=float))
     check_warning(lambda: jnp.ones(3, dtype=np.float64),
                   lambda: jnp.ones(3))
+    check_warning(lambda: jnp.ones(3, dtype=np.float64),
+                  lambda: jnp.ones(3, dtype=float))
     check_warning(lambda: jnp.ones_like(3, dtype=np.int64),
                   lambda: jnp.ones_like(3, dtype=np.int32))
     check_warning(lambda: jnp.zeros(3, dtype="int64"),
@@ -1564,6 +1568,10 @@ class APITest(jtu.JaxTestCase):
                   lambda: jnp.linspace(0, 3, dtype=np.float32))
     check_warning(lambda: jnp.tri(2, dtype="float64"),
                   lambda: jnp.tri(2, dtype="float32"))
+    check_warning(lambda: jnp.arange(1).astype("float64"),
+                  lambda: jnp.arange(1).astype(float))
+    check_warning(lambda: jnp.arange(1.0).astype("int64"),
+                  lambda: jnp.arange(1.0).astype(int))
 
   def test_vmap_preserves_docstr(self):
     def superfun(a):


### PR DESCRIPTION
Currently in X32 mode, specifying `int`, `float`, or `complex` in place of a dtype leads to a warning:
```python
In [2]: jnp.arange(4, dtype=float)                                                                                  
/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py:6272: UserWarning: Explicitly requested dtype <class 'float'>
requested in arange is not available, and will be truncated to dtype float32. To enable more dtypes, set the
jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See
https://github.com/google/jax#current-gotchas for more.
  warnings.warn(msg.format(dtype, fun_name , truncated_dtype))
Out[2]: DeviceArray([0., 1., 2., 3.], dtype=float32)
```
This is a legacy of the way that builtin types are handled by numpy's dtype system (i.e. they're interpreted as 64-bit). In JAX, I believe it would make sense to silence these warnings for builtin scalar types, because users rarely mean to strictly specify `float64` when passing `dtype=float`.

More broadly, I think this is a useful part of a larger effort to remove unnecessary warnings in JAX, to avoid getting to where users become accustomed to ignoring them.