### PR TITLE
add experimental pdot primitive, basic tests

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3032,14 +3032,23 @@ def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision):
 
 def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
                             precision):
+  lhs, rhs = batched_args
+  new_dimension_numbers, result_batch_dim = _dot_general_batch_dim_nums(
+      (lhs.ndim, rhs.ndim), batch_dims, dimension_numbers)
+  batched_out = dot_general(lhs, rhs, new_dimension_numbers,
+                            precision=precision)
+  return batched_out, result_batch_dim
+
+def _dot_general_batch_dim_nums(ndims, batch_dims, dimension_numbers):
   # there are three kinds of dimensions in a dot_general:
   # - contraction dimensions appear in lhs and rhs but not the result
   # - batch dimensions appear in lhs, rhs, and result
   # - tensor product dimensions appear in the result and one of lhs or rhs
-  (lhs_contract, rhs_contract), (lhs_batch, rhs_batch) = dimension_numbers
-  lhs, rhs = batched_args
+  lhs_ndim, rhs_ndim = ndims
   lbd, rbd = batch_dims
   assert lbd is not None or rbd is not None
+  (lhs_contract, rhs_contract), (lhs_batch, rhs_batch) = dimension_numbers
+
   def bump_dims(dims, b):
     return tuple(np.add(dims, np.greater_equal(dims, b)))
 
@@ -3053,23 +3062,21 @@ def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
   else:
     # adding a tensor product dimension
     if lbd is not None:
-      other = tuple(d for d in range(lhs.ndim)
+      other = tuple(d for d in range(lhs_ndim)
                     if d not in lhs_batch and d not in lhs_contract)
       result_batch_dim = (len(lhs_batch) + sum(np.less(other, lbd)))
       lhs_batch = bump_dims(lhs_batch, lbd)
       lhs_contract = bump_dims(lhs_contract, lbd)
     else:
-      other = tuple(d for d in range(rhs.ndim)
+      other = tuple(d for d in range(rhs_ndim)
                     if d not in rhs_batch and d not in rhs_contract)
-      result_batch_dim = (lhs.ndim - len(lhs_contract) +
+      result_batch_dim = (lhs_ndim - len(lhs_contract) +
                           sum(np.less(other, rbd)))
       rhs_batch = bump_dims(rhs_batch, rbd)
       rhs_contract = bump_dims(rhs_contract, rbd)
 
   new_dimension_numbers = ((lhs_contract, rhs_contract), (lhs_batch, rhs_batch))
-  batched_out = dot_general(lhs, rhs, new_dimension_numbers,
-                            precision=precision)
-  return batched_out, int(result_batch_dim)
+  return new_dimension_numbers, int(result_batch_dim)
 
 def _dot_using_sum_of_products(lhs, rhs, *, dimension_numbers):
   contract_dims, batch_dims = dimension_numbers

--- a/jax/experimental/general_map.py
+++ b/jax/experimental/general_map.py
@@ -534,7 +534,6 @@ def _delete_aval_axes(aval, axes: AxisNamePos):
     del shape[i]
   return core.ShapedArray(tuple(shape), aval.dtype)
 
-
 def _insert_aval_axes(aval, axes: AxisNamePos, axis_sizes):
   assert isinstance(aval, core.ShapedArray)
   shape = list(aval.shape)
@@ -802,3 +801,27 @@ def subst_eqn_axis_names(eqn, axis_subst: Dict[AxisName, Tuple[AxisName]]):
     axis_names = (axis_names,)
   new_axis_names = sum((axis_subst.get(name, (name,)) for name in axis_names), ())
   return eqn._replace(params=dict(eqn.params, axis_name=new_axis_names))
+
+
+def _dynamic_jaxpr_trace_process_xmap(trace, prim, fun, tracers, params):
+  in_avals = [t.aval for t in tracers]
+  mapped_in_avals = [_delete_aval_axes(aval, in_axes)
+                     for aval, in_axes in zip(in_avals, params['in_axes'])]
+  with core.extend_axis_env_nd(params['axis_sizes'].items()):
+    jaxpr, reduced_out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_in_avals)
+  if consts: raise NotImplementedError  # TODO(mattjj): handle consts
+  out_avals = [_insert_aval_axes(aval, out_axes, params['axis_sizes'])
+               for aval, out_axes in zip(reduced_out_avals, params['out_axes'])]
+  source_info = pe.source_info_util.current()
+  out_tracers = [pe.DynamicJaxprTracer(trace, a, source_info) for a in out_avals]
+  invars = map(trace.getvar, tracers)
+  constvars = map(trace.getvar, map(trace.instantiate_const, consts))
+  outvars = map(trace.makevar, out_tracers)
+  new_in_axes = (None,) * len(consts) + params['in_axes']
+  new_params = dict(params, in_axes=new_in_axes,
+                    call_jaxpr=pe.convert_constvars_jaxpr(jaxpr))
+  eqn = pe.new_jaxpr_eqn([*constvars, *invars], outvars, prim,
+                         new_params, source_info)
+  trace.frame.eqns.append(eqn)
+  return out_tracers
+pe.DynamicJaxprTrace.process_xmap = _dynamic_jaxpr_trace_process_xmap  # type: ignore

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -837,7 +837,7 @@ tf_not_yet_impl = [
   lax.after_all_p, lax_parallel.all_to_all_p, lax.create_token_p,
   lax.infeed_p, lax.outfeed_p, lax_parallel.pmax_p,
   lax_parallel.pmin_p, lax_parallel.ppermute_p, lax_parallel.psum_p,
-  lax_parallel.axis_index_p,
+  lax_parallel.axis_index_p, lax_parallel.pdot_p,
 
   pxla.xla_pmap_p,
 ]

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1105,13 +1105,15 @@ class DynamicJaxprTrace(core.Trace):
   def process_map(self, map_primitive, f, tracers, params):
     in_avals = [t.aval for t in tracers]
     axis_name, axis_size = params['axis_name'], params['axis_size']
-    reduced_in_avals = [core.mapped_aval(axis_size, in_axis, a) if in_axis is not None else a
+    reduced_in_avals = [core.mapped_aval(axis_size, in_axis, a)
+                        if in_axis is not None else a
                         for a, in_axis in zip(in_avals, params['in_axes'])]
     with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.main, reduced_in_avals)
     out_axes = params['out_axes_thunk']()
-    out_avals = [core.unmapped_aval(params['axis_size'], out_axis, a) if out_axis is not None else a
+    out_avals = [core.unmapped_aval(params['axis_size'], out_axis, a)
+                 if out_axis is not None else a
                  for a, out_axis in zip(reduced_out_avals, out_axes)]
     source_info = source_info_util.current()
     out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -337,6 +337,7 @@ from jax._src.lax.parallel import (
   psum,
   psum_p,
   pswapaxes,
+  pdot,
 )
 from jax._src.lax.other import (
   conv_general_dilated_patches

--- a/tests/gmap_test.py
+++ b/tests/gmap_test.py
@@ -30,7 +30,7 @@ import jax.numpy as jnp
 from jax import test_util as jtu
 from jax import vmap
 from jax import lax
-from jax.experimental.general_map import gmap, fake_resources, Mesh, mesh, xmap, A
+from jax.experimental.general_map import gmap, Mesh, mesh, xmap, A
 from jax.lib import xla_bridge
 from jax.util import curry, unzip2
 from jax.interpreters import pxla
@@ -143,50 +143,50 @@ class GmapTest(jtu.JaxTestCase):
   @ignore_gmap_warning()
   @skipIf(not config.omnistaging_enabled,
           "vmap collectives only supported when omnistaging is enabled")
+  @with_mesh([('r1', 4), ('r2', 2), ('r3', 5)])
   def testXMap(self):
     def f(a, b):
       return a + 2, b * 4
-    with fake_resources(r1=4, r2=2, r3=5):
-      fm = xmap(f,
-                in_axes=[A({'x': 0, 'z': 1}), A({'y': 1})],
-                out_axes=[A({'x': 1, 'z': 0}), A({'y': 0})],
-                schedule=[
-                  ('x', 'r1'),
-                  ('x', 'r2'),
-                  ('y', 'r1'),
-                  ('z', 'r3'),
-                  ('x', 'vectorize'),
-                  ('y', 'vectorize'),
-                ])
-      a = jnp.arange(16*5*2).reshape((16, 5, 2))
-      b = jnp.arange(6*16).reshape((6, 16))
-      c, d = fm(a, b)
-      self.assertAllClose(c, (a + 2).transpose((1, 0, 2)))
-      self.assertAllClose(d, (b * 4).T)
+    fm = xmap(f,
+              in_axes=[A({'x': 0, 'z': 1}), A({'y': 1})],
+              out_axes=[A({'x': 1, 'z': 0}), A({'y': 0})],
+              schedule=[
+                ('x', 'r1'),
+                ('x', 'r2'),
+                ('y', 'r1'),
+                ('z', 'r3'),
+                ('x', 'vectorize'),
+                ('y', 'vectorize'),
+              ])
+    a = jnp.arange(16*5*2).reshape((16, 5, 2))
+    b = jnp.arange(6*16).reshape((6, 16))
+    c, d = fm(a, b)
+    self.assertAllClose(c, (a + 2).transpose((1, 0, 2)))
+    self.assertAllClose(d, (b * 4).T)
 
   @ignore_gmap_warning()
   @skipIf(not config.omnistaging_enabled,
           "vmap collectives only supported when omnistaging is enabled")
+  @with_mesh([('r1', 4), ('r2', 2), ('r3', 5)])
   def testXMapCollectives(self):
     def f(a, b):
       return lax.psum(a + 2, 'x'), b * 4
-    with fake_resources(r1=4, r2=2, r3=5):
-      fm = xmap(f,
-                in_axes=[A({'x': 0, 'z': 1}), A({'y': 1})],
-                out_axes=[A({'z': 0}), A({'y': 0})],
-                schedule=[
-                  ('x', 'r1'),
-                  ('x', 'r2'),
-                  ('y', 'r1'),
-                  ('z', 'r3'),
-                  ('x', 'vectorize'),
-                  ('y', 'vectorize'),
-                ])
-      a = jnp.arange(16*5*2).reshape((16, 5, 2))
-      b = jnp.arange(6*16).reshape((6, 16))
-      c, d = fm(a, b)
-      self.assertAllClose(c, (a + 2).sum(0))
-      self.assertAllClose(d, (b * 4).T)
+    fm = xmap(f,
+              in_axes=[A({'x': 0, 'z': 1}), A({'y': 1})],
+              out_axes=[A({'z': 0}), A({'y': 0})],
+              schedule=[
+                ('x', 'r1'),
+                ('x', 'r2'),
+                ('y', 'r1'),
+                ('z', 'r3'),
+                ('x', 'vectorize'),
+                ('y', 'vectorize'),
+              ])
+    a = jnp.arange(16*5*2).reshape((16, 5, 2))
+    b = jnp.arange(6*16).reshape((6, 16))
+    c, d = fm(a, b)
+    self.assertAllClose(c, (a + 2).sum(0))
+    self.assertAllClose(d, (b * 4).T)
 
   @ignore_gmap_warning()
   def testXMapMeshBasic(self):
@@ -315,6 +315,45 @@ class GmapTest(jtu.JaxTestCase):
                                 "Changing the resource environment.*"):
       f(x)
 
+  @ignore_gmap_warning()
+  @skipIf(not config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  @with_mesh([('r1', 2)])
+  def testPdotBasic(self):
+    def f(x, y):
+      return lax.pdot(x, y, 'i')
+
+    f_mapped = xmap(f, in_axes=[A({'i': 1}), A({'i': 0})], out_axes=A(),
+                    schedule=[('i', 'r1'), ('i', 'vectorize')])
+
+    rng = np.random.RandomState(0)
+    x = rng.randn(3, 8)
+    y = rng.randn(8, 5)
+
+    z = f_mapped(x, y)
+
+    self.assertAllClose(z, jnp.dot(x, y))
+
+  @ignore_gmap_warning()
+  @skipIf(not config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  @with_mesh([('r1', 2)])
+  def testPdotBatching(self):
+    def f(x, y):
+      return lax.pdot(x, y, 'i')
+
+    rng = np.random.RandomState(0)
+    x = rng.randn(2, 3, 8)
+    y = rng.randn(2, 8, 5)
+
+    f_mapped = xmap(f,
+                    in_axes=[A({'i': 2, 'j': 0}), A({'i': 1, 'j': 0})],
+                    out_axes=A({'j': 0}),
+                    schedule=[('j', 'vectorize'), ('i', 'r1'), ('i', 'vectorize')])
+
+    z = f_mapped(x, y)
+
+    self.assertAllClose(z, jnp.einsum('nij,njk->nik', x, y))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds `pdot_p` along with impl, vmap, and xla translation rules.

I also added a rudimentary implementation of `DynamicJaxprTrace.process_xmap` (defined in general_map.py for now).

The tests here are super basic at the moment, but on the other hand there's not much to the `pdot` implementation!

For posterity, some [xmap pdot examples](https://gist.github.com/mattjj/ba9b24df446a90902d7b41aeb0766a99).