### PR TITLE
clean up symbolic zero handling in transpose rules

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2717,7 +2717,13 @@ def _conv_general_dilated_transpose_rhs(
   assert type(dimension_numbers) is ConvDimensionNumbers
   if np.size(g) == 0:
     # Avoids forming degenerate convolutions where the RHS has spatial size 0.
-    return ad_util.Zero
+    # Awkwardly, we don't have an aval for the rhs readily available, so instead
+    # of returning an ad_util.Zero instance here, representing a symbolic zero
+    # value, we instead return a None, which is meant to represent having no
+    # cotangent at all (and is thus incorrect for this situation), since the two
+    # are treated the same operationally.
+    # TODO(mattjj): adjust defbilinear so that the rhs aval is available here
+    return None
   lhs_sdims, rhs_sdims, out_sdims = map(_conv_sdims, dimension_numbers)
   lhs_trans, rhs_trans, out_trans = map(_conv_spec_transpose, dimension_numbers)
   assert batch_group_count == 1 or feature_group_count == 1
@@ -3283,7 +3289,8 @@ def _concatenate_transpose_rule(t, *operands, dimension):
   operand_shapes = [o.aval.shape if ad.is_undefined_primal(o) else o.shape
                     for o in operands]
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
+    return [ad_util.Zero(o.aval) if ad.is_undefined_primal(o) else None
+            for o in operands]
   else:
     limit_points = np.cumsum([shape[dimension] for shape in operand_shapes])
     starts = np.zeros((len(operands), t.ndim), dtype=int)
@@ -3334,20 +3341,20 @@ def _pad_shape_rule(operand, padding_value, *, padding_config):
 
 def _pad_transpose(t, operand, padding_value, *, padding_config):
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
+    t_operand = ad_util.Zero(operand.aval) if ad.is_undefined_primal(operand) else None
+    t_padv = ad_util.Zero(padding_value.aval) if ad.is_undefined_primal(padding_value) else None
+  else:
+    lo, hi, interior = zip(*padding_config)
+    total = lambda x: _reduce_sum(x, list(range(t.ndim)))
 
-  lo, hi, interior = zip(*padding_config)
-  total = lambda x: _reduce_sum(x, list(range(t.ndim)))
+    def t_op():
+      unpad_config = safe_zip(np.negative(lo), np.negative(hi),
+                              np.zeros_like(interior))
+      unpadded = pad(t, np.array(0., t.dtype), unpad_config)
+      return slice(unpadded, np.zeros_like(lo), unpadded.shape, np.add(interior, 1))
 
-  def t_op():
-    unpad_config = safe_zip(np.negative(lo), np.negative(hi),
-                            np.zeros_like(interior))
-    unpadded = pad(t, np.array(0., t.dtype), unpad_config)
-    return slice(unpadded, np.zeros_like(lo), unpadded.shape, np.add(interior, 1))
-
-  t_operand = t_op() if ad.is_undefined_primal(operand) else None
-  t_padv = sub(total(t), total(t_operand)) if ad.is_undefined_primal(padding_value) else None
-
+    t_operand = t_op() if ad.is_undefined_primal(operand) else None
+    t_padv = sub(total(t), total(t_operand)) if ad.is_undefined_primal(padding_value) else None
   return [t_operand, t_padv]
 
 def _pad_batch_rule(batched_args, batch_dims, *, padding_config):
@@ -3632,7 +3639,9 @@ def _select_dtype_rule(pred, on_true, on_false):
 def _select_transpose_rule(t, pred, on_true, on_false):
   assert not ad.is_undefined_primal(pred)
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
+    return [None,
+            ad_util.Zero(on_true.aval) if ad.is_undefined_primal(on_true) else None,
+            ad_util.Zero(on_false.aval) if ad.is_undefined_primal(on_false) else None]
   else:
     zeros = full_like(t, 0)
     return [None,
@@ -3936,11 +3945,15 @@ def _dynamic_update_slice_transpose_rule(t, operand, update, *start_indices):
     update_shape = update.aval.shape
   else:
     update_shape = update.shape
-  dus = dynamic_update_slice
-  ds = dynamic_slice
-  zeros = _zeros(t, shape=update_shape)
-  operand_t = dus(t, zeros, start_indices) if ad.is_undefined_primal(operand) else None
-  update_t = ds(t, start_indices, update_shape) if ad.is_undefined_primal(update) else None
+  if type(t) is ad_util.Zero:
+    operand_t = ad_util.Zero(operand.aval) if ad.is_undefined_primal(operand) else None
+    update_t = ad_util.Zero(update.aval) if ad.is_undefined_primal(update) else None
+  else:
+    dus = dynamic_update_slice
+    ds = dynamic_slice
+    zeros = _zeros(t, shape=update_shape)
+    operand_t = dus(t, zeros, start_indices) if ad.is_undefined_primal(operand) else None
+    update_t = ds(t, start_indices, update_shape) if ad.is_undefined_primal(update) else None
   return [operand_t, update_t] + [None] * len(start_indices)
 
 def _dynamic_update_slice_translation_rule(c, operand, update, *start_indices):
@@ -4143,18 +4156,19 @@ def _gather_transpose_rule(t, operand, start_indices, *, dimension_numbers,
   assert ad.is_undefined_primal(operand)
   operand_shape = operand.aval.shape
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
-  if config.omnistaging_enabled:
-    zeros = full(operand_shape, _zero(t))
+    out = ad_util.Zero(operand.aval)
   else:
-    zeros = full(operand_shape, tie_in(t, _zero(t)))
-  scatter_dnums = ScatterDimensionNumbers(
-    update_window_dims=dimension_numbers.offset_dims,
-    inserted_window_dims=dimension_numbers.collapsed_slice_dims,
-    scatter_dims_to_operand_dims=dimension_numbers.start_index_map)
-  out = scatter_add(zeros, start_indices, t, scatter_dnums,
-                    indices_are_sorted=False,
-                    unique_indices=False)
+    if config.omnistaging_enabled:
+      zeros = full(operand_shape, _zero(t))
+    else:
+      zeros = full(operand_shape, tie_in(t, _zero(t)))
+    scatter_dnums = ScatterDimensionNumbers(
+      update_window_dims=dimension_numbers.offset_dims,
+      inserted_window_dims=dimension_numbers.collapsed_slice_dims,
+      scatter_dims_to_operand_dims=dimension_numbers.start_index_map)
+    out = scatter_add(zeros, start_indices, t, scatter_dnums,
+                      indices_are_sorted=False,
+                      unique_indices=False)
   return [out, ad_util.Zero.from_value(start_indices)]
 
 def _gather_batching_rule(batched_args, batch_dims, *, dimension_numbers,
@@ -4412,27 +4426,28 @@ def _scatter_add_transpose_rule(t, operand, scatter_indices, updates, *,
   else:
     updates_shape = updates.shape
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
+    operand_t = ad_util.Zero(operand.aval) if ad.is_undefined_primal(operand) else None
+    update_t = ad_util.Zero(updates.aval) if ad.is_undefined_primal(updates) else None
+  else:
+    operand_t = update_t = None
+    if ad.is_undefined_primal(operand):
+      operand_t = t
 
-  operand_t = update_t = None
-  if ad.is_undefined_primal(operand):
-    operand_t = t
-
-  if ad.is_undefined_primal(updates):
-    gather_dnums = GatherDimensionNumbers(
-      offset_dims=dimension_numbers.update_window_dims,
-      collapsed_slice_dims=dimension_numbers.inserted_window_dims,
-      start_index_map=dimension_numbers.scatter_dims_to_operand_dims)
-    slice_sizes = []
-    pos = 0
-    for i in range(len(t.shape)):
-      if i in dimension_numbers.inserted_window_dims:
-        slice_sizes.append(1)
-      else:
-        slice_sizes.append(updates_shape[dimension_numbers.update_window_dims[pos]])
-        pos += 1
-    update_t = gather(t, scatter_indices, dimension_numbers=gather_dnums,
-                      slice_sizes=slice_sizes)
+    if ad.is_undefined_primal(updates):
+      gather_dnums = GatherDimensionNumbers(
+        offset_dims=dimension_numbers.update_window_dims,
+        collapsed_slice_dims=dimension_numbers.inserted_window_dims,
+        start_index_map=dimension_numbers.scatter_dims_to_operand_dims)
+      slice_sizes = []
+      pos = 0
+      for i in range(len(t.shape)):
+        if i in dimension_numbers.inserted_window_dims:
+          slice_sizes.append(1)
+        else:
+          slice_sizes.append(updates_shape[dimension_numbers.update_window_dims[pos]])
+          pos += 1
+      update_t = gather(t, scatter_indices, dimension_numbers=gather_dnums,
+                        slice_sizes=slice_sizes)
   return [operand_t, None, update_t]
 
 def _scatter_mul_transpose_rule(t, operand, scatter_indices, updates, *,
@@ -4444,29 +4459,29 @@ def _scatter_mul_transpose_rule(t, operand, scatter_indices, updates, *,
   else:
     updates_shape = updates.shape
   if type(t) is ad_util.Zero:
-    return ad_util.Zero
-
-  operand_t = update_t = None
-  if ad.is_undefined_primal(operand):
-    operand_t = scatter_mul(
-        t, scatter_indices, updates, dimension_numbers=dimension_numbers,
-        indices_are_sorted=indices_are_sorted, unique_indices=unique_indices)
-
-  if ad.is_undefined_primal(updates):
-    gather_dnums = GatherDimensionNumbers(
-      offset_dims=dimension_numbers.update_window_dims,
-      collapsed_slice_dims=dimension_numbers.inserted_window_dims,
-      start_index_map=dimension_numbers.scatter_dims_to_operand_dims)
-    slice_sizes = []
-    pos = 0
-    for i in range(len(t.shape)):
-      if i in dimension_numbers.inserted_window_dims:
-        slice_sizes.append(1)
-      else:
-        slice_sizes.append(updates_shape[dimension_numbers.update_window_dims[pos]])
-        pos += 1
-    update_t = gather(mul(t, operand), scatter_indices,
-                      dimension_numbers=gather_dnums, slice_sizes=slice_sizes)
+    operand_t = ad_util.Zero(operand.aval) if ad.is_undefined_primal(operand) else None
+    update_t = ad_util.Zero(updates.aval) if ad.is_undefined_primal(updates) else None
+  else:
+    operand_t = update_t = None
+    if ad.is_undefined_primal(operand):
+      operand_t = scatter_mul(
+          t, scatter_indices, updates, dimension_numbers=dimension_numbers,
+          indices_are_sorted=indices_are_sorted, unique_indices=unique_indices)
+    if ad.is_undefined_primal(updates):
+      gather_dnums = GatherDimensionNumbers(
+        offset_dims=dimension_numbers.update_window_dims,
+        collapsed_slice_dims=dimension_numbers.inserted_window_dims,
+        start_index_map=dimension_numbers.scatter_dims_to_operand_dims)
+      slice_sizes = []
+      pos = 0
+      for i in range(len(t.shape)):
+        if i in dimension_numbers.inserted_window_dims:
+          slice_sizes.append(1)
+        else:
+          slice_sizes.append(updates_shape[dimension_numbers.update_window_dims[pos]])
+          pos += 1
+      update_t = gather(mul(t, operand), scatter_indices,
+                        dimension_numbers=gather_dnums, slice_sizes=slice_sizes)
   return [operand_t, None, update_t]
 
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -166,13 +166,12 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
 
   def write_cotangent(v, ct):
     # assert v not in primal_env
+    assert ct is not Zero  # check for an old harmless type error
     if ct is None or type(v) is Literal:
       return
     if type(ct) is Zero:
       # FIXME: This triggers a lot of failures!
       # assert v.aval == ct.aval, (v.aval, ct.aval)
-      return
-    if ct is Zero: # FIXME: This should never happen, but seems to be necessary
       return
     ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
     if not core.skip_checks:


### PR DESCRIPTION
We had a few transpose rules in which:
1. didn't correctly handle symbolic zero cotangent inputs, and/or
2. returned the ad_util.Zero class rather than an instance of it (and/or returned a singleton where they should return a list)

This solves a FIXME in the code left by @apaszke (because he first spotted these issues' effects on ad.backward_pass).