### PR TITLE
Transpose rule for imag

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2306,6 +2306,7 @@ real_p = unop(_complex_basetype, _complex, 'real')
 ad.deflinear(real_p, lambda t: [complex(t, np.zeros((), _dtype(t)))])
 
 imag_p = unop(_complex_basetype, _complex, 'imag')
+ad.deflinear(imag_p, lambda t: [complex(np.zeros((), _dtype(t)), mul(_const(t, -1), t))])
 ad.defjvp(imag_p, lambda g, _: real(mul(_const(g, -1j), g)))
 
 _complex_dtype = lambda dtype, *args: (np.zeros((), dtype) + np.zeros((), np.complex64)).dtype

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2306,7 +2306,7 @@ real_p = unop(_complex_basetype, _complex, 'real')
 ad.deflinear(real_p, lambda t: [complex(t, np.zeros((), _dtype(t)))])
 
 imag_p = unop(_complex_basetype, _complex, 'imag')
-ad.deflinear(imag_p, lambda t: [complex(np.zeros((), _dtype(t)), mul(_const(t, -1), t))])
+ad.deflinear(imag_p, lambda t: [complex(np.zeros((), _dtype(t)), neg(t))])
 
 _complex_dtype = lambda dtype, *args: (np.zeros((), dtype) + np.zeros((), np.complex64)).dtype
 complex_p = naryop(_complex_dtype, [_complex_elem_types, _complex_elem_types],

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2307,7 +2307,6 @@ ad.deflinear(real_p, lambda t: [complex(t, np.zeros((), _dtype(t)))])
 
 imag_p = unop(_complex_basetype, _complex, 'imag')
 ad.deflinear(imag_p, lambda t: [complex(np.zeros((), _dtype(t)), mul(_const(t, -1), t))])
-ad.defjvp(imag_p, lambda g, _: real(mul(_const(g, -1j), g)))
 
 _complex_dtype = lambda dtype, *args: (np.zeros((), dtype) + np.zeros((), np.complex64)).dtype
 complex_p = naryop(_complex_dtype, [_complex_elem_types, _complex_elem_types],

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -1067,6 +1067,20 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     grad_fn = jax.grad(jax.grad(jax.grad(jax.grad(jax.grad(jax.grad(inv))))))
     self.assertAllClose(np.float32(0.0439453125), grad_fn(np.float32(4.)))
 
+  def test_linear_transpose_real(self):
+    f = lambda x: x.real
+    transpose = api.linear_transpose(f, 1.j)
+    actual, = transpose(1.)
+    expected = 1.
+    self.assertEqual(actual, expected)
+
+  def test_linear_transpose_imag(self):
+    f = lambda x: x.imag
+    transpose = api.linear_transpose(f, 1.j)
+    actual, = transpose(1.)
+    expected = -1.j
+    self.assertEqual(actual, expected)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This PR is an attempt to bring back a corrected version of the transpose rule for imag.

Back in https://github.com/google/jax/pull/981 the (wrong) linear transpose rule for imag was replaced with a (correct) jvp rule in order to fix https://github.com/google/jax/issues/979. 
However ommitting a transpose rule also broke linear_transpose for imag:

```
import jax
import types
import numpy as np
complex_scalar = types.SimpleNamespace(shape=(), dtype=np.complex64)

def f(x):
    return (-1j*x).real

def g(x):
    return x.imag

print(jax.linear_transpose(f, complex_scalar)(1.))
print(jax.linear_transpose(g, complex_scalar)(1.))
```
before:
```
(DeviceArray(0.-1.j, dtype=complex64),)

...
NotImplementedError: Transpose rule (for reverse-mode differentiation) for 'imag' not implemented
```
after the changes in this PR:
```
(DeviceArray(0.-1.j, dtype=complex64),)
(DeviceArray(0.-1.j, dtype=complex64),)
```