### PR TITLE
GMRES cleanup/fixup

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -60,6 +60,7 @@ jax.scipy.sparse.linalg
   :toctree: _autosummary
 
    cg
+   gmres
 
 jax.scipy.special
 -----------------

--- a/jax/scipy/sparse/linalg.py
+++ b/jax/scipy/sparse/linalg.py
@@ -15,5 +15,5 @@
 # flake8: noqa: F401
 from jax._src.scipy.sparse.linalg import (
   cg,
-  _gmres,
+  gmres,
 )


### PR DESCRIPTION
1. Switched the interface for picking the solver from `qr_mode=True`/`False` to `solve_method='incremental'`/`'direct'`. I'm open to adjustments here, but I don't think `qr_mode=True` was a good way to describe these algorithm since the "direct" method could also be calculated via a QR decomposition, at least in principle.
2. Fixed a bug in the "direct" calculation.
3. Fixed handling of complex numbers in the "iterative" calculation, by copying the handling of complex numbers in the Givens rotation from SciPy. I also updated the numerics for the Givens rotation to match SciPy, which I guess should be more numerically stable, since it avoids calculating `sqrt(a**2 + b**2)` in favor of calculations like `a * sqrt(1 + (b/a)**2` (xref https://github.com/google/jax/issues/4882).

With these changes, `gmres` passes the full test suite for compatibility with SciPy! If we're happy with the interface, we can do ahead and expose it publicly as `jax.scipy.sparse.linalg.gmres`.