### PR TITLE
Expose sharded_jit, PartitionSpec, and with_sharding_constraint in jax.experimental namespace.

### DIFF
--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# flake8: noqa: F401
+from ..interpreters.sharded_jit import (sharded_jit, PartitionSpec,
+                                        with_sharding_constraint)

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -28,9 +28,9 @@ from jax import jit, pmap, vjp
 from jax import lax
 from jax import test_util as jtu
 from jax import tree_util
+from jax.experimental import (sharded_jit, with_sharding_constraint,
+                              PartitionSpec as P)
 from jax.interpreters import pxla
-from jax.interpreters.sharded_jit import sharded_jit, with_sharding_constraint
-from jax.interpreters.sharded_jit import PartitionSpec as P
 from jax.util import prod
 import jax.numpy as jnp
 


### PR DESCRIPTION
I didn't move any files to avoid breaking existing callers.