### PR TITLE
Remove fake xmap resources, remove gmap

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -86,8 +86,8 @@ pytype_library(
 )
 
 pytype_library(
-    name = "general_map",
-    srcs = ["experimental/general_map.py"],
+    name = "maps",
+    srcs = ["experimental/maps.py"],
     srcs_version = "PY3",
     deps = [":jax"],
 )


### PR DESCRIPTION
xmap can now handle real devices, so there's no point in maintaining the
simulated codepaths. Also, remove single-dimensional gmap as it will
have to be superseeded by a more xmap-friendly alternative.