### PR TITLE
validate input on _check_arraylike

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -297,6 +297,7 @@ def _result_dtype(op, *args):
 def _arraylike(x): return isinstance(x, ndarray) or isscalar(x)
 def _check_arraylike(fun_name, *args):
   """Check if all args fit JAX's definition of arraylike (ndarray or scalar)."""
+  assert isinstance(fun_name, str), f"fun_name must be a string. Got {fun_name}"
   if _any(not _arraylike(arg) for arg in args):
     pos, arg = next((i, arg) for i, arg in enumerate(args)
                     if not _arraylike(arg))


### PR DESCRIPTION
Currently if you accidentily call this check without passing the function name, e.g.
```python
_check_arraylike(arr)
```
the check will pass regardless of what `arr` is. This PR adds an assertion to make this silent error a loud one.

(Came up in #5035)