### PR TITLE
all_to_all: Add optional axis_index_groups argument

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1039,7 +1039,7 @@ class BatchingTest(jtu.JaxTestCase):
     shape = (2, 3, 4, 5)
     x = np.arange(np.prod(shape)).reshape(shape)
     rule = batching.collective_rules[lax.all_to_all_p]
-    y, out_d = rule(None, (x,), (d,), None, split_axis, concat_axis)
+    y, out_d = rule(None, (x,), (d,), None, split_axis, concat_axis, None)
     exp_shape = shape_fun(x, out_d)
     self.assertEqual(y.shape, exp_shape)
 


### PR DESCRIPTION
Most XLA collective ops support a `replica_groups` argument, which Jax typically exposes as `axis_index_groups`. psum, pmean, all_gather, etc support this, but all_to_all doesn't even though XLA allows it as well (https://www.tensorflow.org/xla/operation_semantics#alltoall).

This PR adds this feature to jax.lax.all_to_all function. 

However, notice that this PR is not fully functional yet. Although the "forward" call to the function works as expected (check the new testAllToAllReplicaGroups test), when computing gradients Jax raises two mysterious exceptions:

- testGradOfAllToAllReplicaGroups:
```
[...]
  File "jax/util.py", line 35, in safe_map
    assert len(arg) == n, 'length mismatch: {}'.format(list(map(len, args)))
AssertionError: length mismatch: [1, 8]
```

- testGradOfPswapaxes:
```
[...]
  File "jax/interpreters/ad.py", line 180, in write_cotangent
    assert v.aval.strip_weak_type() == joined_aval, (prim, v.aval, ct_aval)
AssertionError: (all_to_all, ShapedArray(float32[1,8]), ShapedArray(float32[8]))
```

I say that they are "mysterious" because pswapaxes just calls all_to_all, so I don't understand why they are different. Also, pswaxes (in that test) uses axis_index_groups=None, which should yield the same results as before (and it does in the "forward" call).