### PR TITLE
[jax2tf] Enable complex sort test on TPU.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -175,8 +175,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         not harness.params["is_stable"]):
       # TODO: fix the TF GPU test
       raise unittest.SkipTest("GPU tests are running TF on CPU")
-    if jtu.device_under_test() == "tpu" and harness.params["dtype"] in jtu.dtypes.complex:
-      raise unittest.SkipTest("JAX sort is not implemented on TPU for complex")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.lax_fft)


### PR DESCRIPTION
The change at google/jax#5052 indicates that this now should work.