### PR TITLE
Fix dtype rule of convert_element_type_p to catch mismatched old_dtype.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1505,7 +1505,7 @@ def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
   if config.omnistaging_enabled:
     bool_tri = ge(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
                   broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_tri, old_dtype=np.int32,
+    return convert_element_type_p.bind(bool_tri, old_dtype=np.bool_,
                                        new_dtype=dtype)
   else:
     lazy_expr = lazy.tri(dtype, (N, M), offset)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2534,6 +2534,10 @@ def _convert_element_type_shape_rule(operand, *, new_dtype, old_dtype):
   return operand.shape
 
 def _convert_element_type_dtype_rule(operand, *, new_dtype, old_dtype):
+  if operand.dtype != old_dtype:
+    raise TypeError("operand dtype and old_dtype must be the same, but got "
+        "operand.dtype={} and old_dtype={}."
+        .format(operand.dtype, np.dtype(old_dtype)))
   return new_dtype
 
 def _convert_element_type_translation_rule(c, operand, *, new_dtype, old_dtype):

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2336,6 +2336,14 @@ class LazyConstantTest(jtu.JaxTestCase):
     make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)
 
+  def testConvertElementTypeMismatchedDTypeOldDType(self):
+    arr = np.ones((2, 2), dtype=np.float32)
+    with self.assertRaisesRegex(
+        TypeError, "operand dtype and old_dtype must be the same, but got "
+                   "operand.dtype=float32 and old_dtype=complex64"):
+      lax.convert_element_type_p.bind(arr, old_dtype=np.complex64,
+                                      new_dtype=np.bool_)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_fn={}_indexdtype={}"
        .format(jax_fn.__name__, np.dtype(index_dtype).name),


### PR DESCRIPTION
It seems that the assumption is that `old_dtype` matches the dtype of the operand. This PR makes sure that this is enforced.