### PR TITLE
Fix pmap compilation cache regressions from #4904.

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1516,11 +1516,11 @@ def pmap(fun: Callable[..., T],
       #   out_axes == 0 path working as we look for a better solution.
       out_axes_thunk = HashableFunction(
         lambda: (0,) * out_tree().num_leaves,
-        key=out_axes)
+        closure=out_axes)
     else:
       out_axes_thunk = HashableFunction(
         lambda: tuple(flatten_axes("pmap out_axes", out_tree(), out_axes)),
-        key=out_axes)
+        closure=out_axes)
     out = pxla.xla_pmap(
         flat_fun, *args, backend=backend, axis_name=axis_name,
         axis_size=local_axis_size, global_axis_size=axis_size,
@@ -1557,7 +1557,7 @@ def soft_pmap(fun: Callable, axis_name: Optional[AxisName] = None, in_axes=0
     # See note about out_axes_thunk in pmap for the explanation of why we choose this key
     out_axes_thunk = HashableFunction(
       lambda: tuple(flatten_axes("soft_pmap out_axes", out_tree(), 0)),
-      key=())
+      closure=())
     outs = pxla.soft_pmap(flat_fun, *args_flat, axis_name=axis_name,
                           axis_size=axis_size, in_axes=tuple(in_axes_flat),
                           out_axes_thunk=out_axes_thunk)

--- a/jax/experimental/general_map.py
+++ b/jax/experimental/general_map.py
@@ -227,7 +227,7 @@ def xmap(fun: Callable,
     in_axes_flat = flatten_axes("xmap in_axes", in_tree, in_axes)
     out_axes_thunk = HashableFunction(
       lambda: tuple(flatten_axes("xmap out_axes", out_tree(), out_axes)),
-      key=out_axes)
+      closure=out_axes)
     axis_sizes = _get_axis_sizes(args_flat, in_axes_flat)
     out_flat = xmap_p.bind(
       fun_flat, *args_flat,

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -198,7 +198,10 @@ class BatchTrace(Trace):
         for d, in_axis in zip(dims, params['in_axes']))
       f, dims_out = batch_subtrace(f, self.main, new_dims)
       out_axes_thunk = params['out_axes_thunk']
-      @as_hashable_function(key=out_axes_thunk)
+      # NOTE: This assumes that the choice of the dimensions over which outputs
+      #       are batched is entirely dependent on the function and not e.g. on the
+      #       data or its shapes.
+      @as_hashable_function(closure=out_axes_thunk)
       def new_out_axes_thunk():
         return tuple(out_axis + 1 if both_mapped(out_axis, d) and d < out_axis else out_axis
                      for out_axis, d in zip(out_axes_thunk(), dims_out()))

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -181,7 +181,7 @@ class JaxprTrace(Trace):
       def app(f, *args):
         f, num_outputs = count_outputs(f)
         out_axes_thunk = params['out_axes_thunk']
-        @as_hashable_function(key=out_axes_thunk)
+        @as_hashable_function(closure=out_axes_thunk)
         def new_out_axes_thunk():
           out_axes = out_axes_thunk()
           return out_axes + (0,) * (num_outputs() - len(out_axes))

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -362,14 +362,14 @@ def sharded_jit(fun: Callable, in_parts, out_parts, num_partitions: int = None,
     # there a better way?
     out_parts_thunk = HashableFunction(
         lambda: tuple(flatten_axes("sharded_jit out_parts", out_tree(), out_parts)),
-        key=out_parts)
+        closure=out_parts)
     if local_out_parts:
       local_out_parts_thunk = HashableFunction(
           lambda: tuple(flatten_axes("sharded_jit local_out_parts",
                                      out_tree(), local_out_parts)),
-          key=local_out_parts)
+          closure=local_out_parts)
     else:
-      local_out_parts_thunk = HashableFunction(lambda: None, key=None)
+      local_out_parts_thunk = HashableFunction(lambda: None, closure=None)
 
     out = sharded_call(
         flat_fun,

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -344,6 +344,13 @@ def count_jit_and_pmap_compiles():
   finally:
     xla.jaxpr_subcomp = jaxpr_subcomp
 
+@contextmanager
+def assert_num_jit_and_pmap_compilations(times):
+  with count_jit_and_pmap_compiles() as count:
+    yield
+  if count[0] != times:
+    raise AssertionError(f"Expected exactly {times} XLA compilations, "
+                         f"but executed {count[0]}")
 
 def device_under_test():
   return FLAGS.jax_test_dut or xla_bridge.get_backend().platform

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -845,7 +845,7 @@ class PmapTest(jtu.JaxTestCase):
     device_count = xla_bridge.device_count()
     f = pmap(lambda x: 3)
     x = jnp.arange(device_count)
-    with jtu.count_jit_and_pmap_compiles() as count:
+    with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
       ans = f(x)
     # self.assertEqual(count[0], 0)  # TODO(mattjj): fix this
     expected = np.repeat(3, device_count)
@@ -853,9 +853,8 @@ class PmapTest(jtu.JaxTestCase):
 
     f = pmap(lambda x: (x, 3))
     x = np.arange(device_count)
-    with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
+    with jtu.assert_num_jit_and_pmap_compilations(1):
       _, ans = f(x)
-    self.assertEqual(count[0], 1)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
   def testPmapConstantDevices(self):

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -249,10 +249,9 @@ class ShardedJitTest(jtu.JaxTestCase):
     shape = (2,)
     x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
 
-    with jtu.count_jit_and_pmap_compiles() as count:
+    with jtu.assert_num_jit_and_pmap_compilations(1):
       sharded_f(x)
       sharded_f(x)
-    self.assertEqual(count[0], 1)
 
 
 # TODO(skye): add more error tests


### PR DESCRIPTION
AD didn't use `HashableFunction` enough, tripping up the compilation cache.
I've also used the occasion to make the hashing a little safer by tagging
each place that `HashableFunction` with a unique tag in its key.