### PR TITLE
[jax2tf] Add testing for the conversion of (almost) all the remaining untested primitives

### DIFF
--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -27,6 +27,11 @@ Additionally, some primitives have numerical differences between JAX and TF in s
   both arguments less or equal to 0 for `igammac`) JAX returns `NaN` and TF returns 0 or
   JAX returns 1 and TF returns `NaN`.
 
+  * `integer_pow` does not have the right overflow behavior in compiled mode
+  for int32 and int64 dtypes. Additionally, the overflow behavior for floating
+  point and complex numbers produces `NaN`s and `+inf`/`-inf` differently in
+  JAX and TF.
+
   * `erf_inv` is converted to `tf.math.erfinv` with discrepancies at
   undefined points (< -1 or > 1): At undefined points with dtype float32 JAX
   returns `NaN` and TF returns `+inf` or `-inf`.
@@ -112,7 +117,6 @@ conversion to Tensorflow.
 | ge | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
 | gt | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
 | integer_pow | Missing TF support | Primitive is unimplemented in TF | int16, int8, uint16, uint32, uint64, uint8 | CPU, GPU, TPU |
-| integer_pow | Missing TF support | Primitive is unimplemented in TF; integer types can not be raised to power > 3 in compiled mode (experimental_compile=True) | int32, int64 | CPU, GPU, TPU |
 | le | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
 | lgamma | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | lt | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-11-20*
+*Last generated on (YYYY-MM-DD): 2020-12-01*
 
 We do not yet have support for `pmap` (with its collective primitives),
 nor for `sharded_jit` (SPMD partitioning).
@@ -80,6 +80,7 @@ conversion to Tensorflow.
 | acosh | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | acosh | Missing TF support | Primitive is unimplemented in TF | float16 | CPU, GPU, TPU |
 | add | Missing TF support | Primitive is unimplemented in TF | uint16, uint32, uint64 | CPU, GPU, TPU |
+| add_any | Missing TF support | Primitive is unimplemented in TF | uint16, uint32, uint64 | CPU, GPU, TPU |
 | asinh | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | asinh | Missing TF support | Primitive is unimplemented in TF | float16 | CPU, GPU, TPU |
 | atan2 | Missing TF support | Primitive is unimplemented in TF | bfloat16, float16 | CPU, GPU, TPU |
@@ -87,6 +88,7 @@ conversion to Tensorflow.
 | atanh | Missing TF support | Primitive is unimplemented in TF | float16 | CPU, GPU, TPU |
 | bessel_i0e | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | bessel_i1e | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
+| bitcast_convert_type | Missing TF support | Primitive is unimplemented in TF | bool | CPU, GPU, TPU |
 | cholesky | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | complex128, complex64 | CPU, GPU, TPU |
 | clamp | Missing TF support | Primitive is unimplemented in TF | int8, uint16, uint32, uint64 | CPU, GPU, TPU |
 | conv_general_dilated | Missing TF support | Primitive is unimplemented in TF; batch_group_count != 1 unsupported | ALL | CPU, GPU, TPU |
@@ -109,6 +111,8 @@ conversion to Tensorflow.
 | fft | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | complex128, float64 | CPU, GPU, TPU |
 | ge | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
 | gt | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
+| integer_pow | Missing TF support | Primitive is unimplemented in TF | int16, int8, uint16, uint32, uint64, uint8 | CPU, GPU, TPU |
+| integer_pow | Missing TF support | Primitive is unimplemented in TF; integer types can not be raised to power > 3 in compiled mode (experimental_compile=True) | int32, int64 | CPU, GPU, TPU |
 | le | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
 | lgamma | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | lt | Missing TF support | Primitive is unimplemented in TF | bool, uint16, uint32, uint64 | CPU, GPU, TPU |
@@ -127,6 +131,7 @@ conversion to Tensorflow.
 | regularized_incomplete_beta | Missing TF support | Primitive is unimplemented in TF | bfloat16, float16 | CPU, GPU, TPU |
 | rem | Missing TF support | Primitive is unimplemented in TF | float16, int16, int8, uint16, uint32, uint64, uint8 | CPU, GPU, TPU |
 | rem | Missing TF support | Primitive is unimplemented in TF; integer division fails if the divisor contains a 0 | int32, int64 | CPU, GPU, TPU |
+| rev | Missing TF support | Primitive is unimplemented in TF | uint32, uint64 | CPU, GPU, TPU |
 | round | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | rsqrt | Missing TF support | Primitive is unimplemented in TF | bfloat16 | CPU, GPU |
 | select_and_gather_add | Missing TF support | Primitive is unimplemented in TF | float32, float64 | TPU |
@@ -138,6 +143,7 @@ conversion to Tensorflow.
 | sort | Missing TF support | Primitive is unimplemented in TF; sorting 2 arrays where the first one is an array of booleans is not supported for XlaSort | bool | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented in TF; sorting more than 2 arrays is not supported for XlaSort | ALL | CPU, GPU, TPU |
 | sort | Missing TF support | Primitive is unimplemented in TF; stable sort not implemented for XlaSort | ALL | CPU, GPU, TPU |
+| sub | Missing TF support | Primitive is unimplemented in TF | uint64 | CPU, GPU, TPU |
 | svd | Missing TF support | Primitive is unimplemented in TF; this works on JAX because JAX uses a custom implementation | complex128, complex64 | CPU, GPU |
 | top_k | Missing TF support | Primitive is unimplemented in TF; this is a problem only in compiled mode (experimental_compile=True)) | float64, int64, uint64 | CPU, GPU, TPU |
 | triangular_solve | Missing TF support | Primitive is unimplemented in TF | bfloat16, float16 | CPU, GPU, TPU |
@@ -153,4 +159,4 @@ The conversion of the following JAX primitives is not yet implemented:
 The following JAX primitives have a defined conversion but are known to be
 missing tests:
 
-`complex`, `custom_lin`, `device_put`, `integer_pow`, `rev`, `select_and_scatter`, `tie_in`
+`custom_lin`, `select_and_scatter`, `tie_in`

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
@@ -27,6 +27,11 @@ Additionally, some primitives have numerical differences between JAX and TF in s
   both arguments less or equal to 0 for `igammac`) JAX returns `NaN` and TF returns 0 or
   JAX returns 1 and TF returns `NaN`.
 
+  * `integer_pow` does not have the right overflow behavior in compiled mode
+  for int32 and int64 dtypes. Additionally, the overflow behavior for floating
+  point and complex numbers produces `NaN`s and `+inf`/`-inf` differently in
+  JAX and TF.
+
   * `erf_inv` is converted to `tf.math.erfinv` with discrepancies at
   undefined points (< -1 or > 1): At undefined points with dtype float32 JAX
   returns `NaN` and TF returns `+inf` or `-inf`.

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1110,7 +1110,7 @@ tf_impl[lax.convert_element_type_p] = _convert_element_type
 
 
 def _bitcast_convert_type(operand, new_dtype):
-  return tf.bitcast(operand, new_dtype)
+  return tf.bitcast(operand, to_tf_dtype(new_dtype))
 tf_impl[lax.bitcast_convert_type_p] = _bitcast_convert_type
 
 

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -284,6 +284,19 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
       # operations.
       tf_unimpl(np_dtype)
 
+  if prim is lax.integer_pow_p:
+    if np_dtype in [np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
+                    np.int16]:
+      tf_unimpl(np_dtype)
+    elif np_dtype in [np.int32, np.int64] and kwargs["y"] > 3:
+      # TODO(bchetioui): as of 20/11/20, this triggers the following exception
+      # in compiled mode:
+      # tensorflow.python.framework.errors_impl.UnimplementedError: binary integer op 'power' [Op:__inference_converted_fun_1104]
+      tf_unimpl(np_dtype, additional_msg=(
+        "integer types can not be raised to power > 3 in compiled mode "
+        "(experimental_compile=True)"))
+
+
   if prim in [lax.le_p, lax.lt_p, lax.ge_p, lax.gt_p]:
     if np_dtype in [np.bool_, np.uint16, np.uint32, np.uint64]:
       tf_unimpl(np_dtype)

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -304,6 +304,10 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype == np.uint64:
       tf_unimpl(np_dtype)
 
+  if prim is lax.bitcast_convert_type_p:
+    if np_dtype == np.bool_:
+      tf_unimpl(np_dtype)
+
   if prim in [lax.le_p, lax.lt_p, lax.ge_p, lax.gt_p]:
     if np_dtype in [np.bool_, np.uint16, np.uint32, np.uint64]:
       tf_unimpl(np_dtype)

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -289,13 +289,6 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype in [np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
                     np.int16]:
       tf_unimpl(np_dtype)
-    elif np_dtype in [np.int32, np.int64] and kwargs["y"] > 3:
-      # TODO(bchetioui): as of 20/11/20, this triggers the following exception
-      # in compiled mode:
-      # tensorflow.python.framework.errors_impl.UnimplementedError: binary integer op 'power' [Op:__inference_converted_fun_1104]
-      tf_unimpl(np_dtype, additional_msg=(
-        "integer types can not be raised to power > 3 in compiled mode "
-        "(experimental_compile=True)"))
 
   if prim is lax.rev_p:
     if np_dtype in [np.uint32, np.uint64]:

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -300,6 +300,10 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype in [np.uint32, np.uint64]:
       tf_unimpl(np_dtype)
 
+  if prim is lax.sub_p:
+    if np_dtype == np.uint64:
+      tf_unimpl(np_dtype)
+
   if prim in [lax.le_p, lax.lt_p, lax.ge_p, lax.gt_p]:
     if np_dtype in [np.bool_, np.uint16, np.uint32, np.uint64]:
       tf_unimpl(np_dtype)

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -19,6 +19,7 @@ import numpy as np
 from typing import Any, Callable, Collection, Dict, List, NamedTuple, Optional,\
                    Tuple, Sequence, Set
 
+from jax import ad_util
 from jax import core
 from jax import dtypes
 from jax import lax
@@ -205,7 +206,7 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
         # rewriting is not implemented"
         tf_unimpl(np_dtype, devs=devs)
 
-  if prim in [lax.add_p, lax.reduce_window_sum_p]:
+  if prim in [ad_util.add_jaxvals_p, lax.add_p, lax.reduce_window_sum_p]:
     if np_dtype in [np.uint16, np.uint32, np.uint64]:
       # TODO(bchetioui): tf.math.add is not defined for the above types.
       tf_unimpl(np_dtype)

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -296,6 +296,9 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
         "integer types can not be raised to power > 3 in compiled mode "
         "(experimental_compile=True)"))
 
+  if prim is lax.rev_p:
+    if np_dtype in [np.uint32, np.uint64]:
+      tf_unimpl(np_dtype)
 
   if prim in [lax.le_p, lax.lt_p, lax.ge_p, lax.gt_p]:
     if np_dtype in [np.bool_, np.uint16, np.uint32, np.uint64]:

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -233,6 +233,27 @@ lax_convert_element_type = tuple( # Validate dtypes to dtypes
                    else set(jtu.dtypes.all) - set(jtu.dtypes.all_unsigned))
 )
 
+def _make_integer_pow_harness(name, *, shape=(20, 30), dtype=np.int32, y=3):
+  return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_y={y}",
+                 lax.integer_pow,
+                 [RandArg(shape, dtype), StaticArg(y)],
+                 shape=shape,
+                 dtype=dtype,
+                 y=y)
+
+lax_integer_pow = tuple( # Validate dtypes and y values
+  _make_integer_pow_harness("dtypes", dtype=dtype)
+  for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean)
+) + tuple( # Validate overflow behavior by dtype
+  _make_integer_pow_harness("overflow", y=y, dtype=dtype)
+  for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean)
+  for y in [1000]
+) + tuple( # Validate negative y by dtype
+  _make_integer_pow_harness("negative_exp", y=y, dtype=dtype)
+  for dtype in jtu.dtypes.all_inexact
+  for y in [-1000]
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -411,6 +411,24 @@ ad_util_add_jaxvals = tuple( # Validate dtypes
   for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean)
 )
 
+lax_tie_in = tuple(
+  Harness(f"lhs={jtu.format_shape_dtype_string(lhs_shape, lhs_dtype)}_rhs={jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)}",
+          lax.tie_in_p.bind,
+          [RandArg(lhs_shape, lhs_dtype), RandArg(rhs_shape, rhs_dtype)],
+          lhs_shape=lhs_shape,
+          lhs_dtype=lhs_dtype,
+          rhs_shape=rhs_shape,
+          rhs_dtype=rhs_dtype,
+          primitive=lax.tie_in_p)
+  for lhs_shape, rhs_shape in [
+    ((2, 3), (4, 5))
+  ]
+  for rhs_dtype in jtu.dtypes.all
+  for lhs_dtype in [
+    np.float32
+  ]
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -398,6 +398,19 @@ lax_bitcast_convert_type = tuple( # Validate dtypes combinations
   for new_dtype in filter(partial(_can_bitcast, dtype), jtu.dtypes.all)
 )
 
+def _make_add_jaxvals_harness(name, *, shapes=((2,), (2,)),
+                              dtype=np.float32):
+  return Harness(f"{name}_lhs={jtu.format_shape_dtype_string(shapes[0], dtype)}_rhs={jtu.format_shape_dtype_string(shapes[1], dtype)}",
+                 ad_util.add_jaxvals_p.bind,
+                 list(map(lambda s: RandArg(s, dtype), shapes)),
+                 shapes=shapes,
+                 dtypes=dtypes)
+
+ad_util_add_jaxvals = tuple( # Validate dtypes
+  _make_add_jaxvals_harness("dtypes", dtype=dtype)
+  for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean)
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -351,6 +351,26 @@ xla_device_put = tuple( # Validate dtypes
   ]
 )
 
+def _make_sub_harness(name, *, lhs_shape=(2, 3), rhs_shape=(2, 3),
+                      dtype=np.float32):
+  return Harness(f"{name}_lhs={jtu.format_shape_dtype_string(lhs_shape, dtype)}_rhs={jtu.format_shape_dtype_string(rhs_shape, dtype)}",
+                 lax.sub,
+                 [RandArg(lhs_shape, dtype), RandArg(rhs_shape, dtype)],
+                 lhs_shape=lhs_shape,
+                 rhs_shape=rhs_shape,
+                 dtype=dtype)
+
+lax_sub = tuple( # Validate dtypes
+  _make_sub_harness("dtypes", dtype=dtype)
+  for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean)
+) + tuple( # Validate broadcasting behaviour
+  _make_sub_harness("broadcasting", lhs_shape=lhs_shape, rhs_shape=rhs_shape)
+  for lhs_shape, rhs_shape in [
+    ((), (2, 3)),     # broadcast scalar
+    ((1, 2), (3, 2)), # broadcast along specific axis
+  ]
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -429,6 +429,18 @@ lax_tie_in = tuple(
   ]
 )
 
+ad_util_stop_gradient = tuple( # Validate dtypes
+  Harness(f"{jtu.format_shape_dtype_string(shape, dtype)}",
+          ad_util.stop_gradient_p.bind,
+          [RandArg(shape, dtype)],
+          shape=shape,
+          dtype=dtype)
+  for shape in [
+    (20, 20)
+  ]
+  for dtype in jtu.dtypes.all
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -308,6 +308,28 @@ lax_reshape = tuple( # Validate dtypes
   ]
 )
 
+def _make_rev_harness(name, *, shape=(4, 5), dtype=np.float32,
+                      dimensions=(0,)):
+  return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_dimensions={dimensions}",
+                 lax.rev,
+                 [RandArg(shape, dtype), StaticArg(dimensions)],
+                 shape=shape,
+                 dtype=dtype,
+                 dimensions=dimensions)
+
+lax_rev = tuple( # Validate dtypes
+  _make_rev_harness("dtypes", dtype=dtype)
+  for dtype in jtu.dtypes.all
+) + tuple( # Validate dimensions
+  _make_rev_harness("dimensions", shape=shape, dimensions=dimensions)
+  for shape, dimensions in [
+    ((3, 4, 5), ()),        # empty dimensions
+    ((3, 4, 5), (0, 2)),    # some dimensions
+    ((3, 4, 5), (0, 1, 2)), # all dimensions (ordered)
+    ((3, 4, 5), (2, 0, 1)), # all dimensions (unordered)
+  ]
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -254,6 +254,30 @@ lax_integer_pow = tuple( # Validate dtypes and y values
   for y in [-1000]
 )
 
+def _make_pow_harness(name, *, shapes=((20, 30), (20, 30)), dtype=np.float32,
+                      lhs=None, rhs=None):
+  lhs = RandArg(shapes[0], dtype) if lhs is None else lhs
+  rhs = RandArg(shapes[1], dtype) if rhs is None else rhs
+  return Harness(f"{name}_lhs={jtu.format_shape_dtype_string(lhs.shape, dtype)}_rhs={jtu.format_shape_dtype_string(rhs.shape, dtype)}",
+                 lax.pow,
+                 [lhs, rhs],
+                 lhs=lhs,
+                 rhs=rhs,
+                 dtype=dtype)
+
+lax_pow = tuple( # Validate dtypes
+  _make_pow_harness("dtypes", dtype=dtype)
+  for dtype in jtu.dtypes.all_inexact
+) + tuple( # Validate broadcasting behavior
+  _make_pow_harness("broadcast", shapes=shapes)
+  for shapes in [
+    ((), (4, 5, 6)),        # broadcasting lhs
+    ((4, 5, 6), ()),        # broadcasting rhs
+    ((4, 1, 6), (4, 5, 6)), # broadcasting lhs on a specific axis
+    ((4, 5, 6), (4, 1, 6)), # broadcasting rhs on a specific axis
+  ]
+)
+
 _LAX_COMPARATORS = (
   lax.eq, lax.ge, lax.gt, lax.le, lax.lt, lax.ne)
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -628,6 +628,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_bitcast_convert_type)
   def test_bitcast_convert_type(self, harness: primitive_harness.Harness):
+    dtype, new_dtype = harness.params["dtype"], harness.params["new_dtype"]
+    if dtype == new_dtype == np.complex64 and jtu.device_under_test() == "tpu":
+      raise unittest.SkipTest( "TODO(bchetioui): bitcast_convert_type from "
+                              f"{dtype} to {new_dtype} fails in JAX on TPU.")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
   @primitive_harness.parameterized(primitive_harness.ad_util_add_jaxvals)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -635,6 +635,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_add_jaxvals(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_tie_in)
+  def test_tie_in(self, harness: primitive_harness.Harness):
+    if config.omnistaging_enabled:
+      raise unittest.SkipTest("tie_in test requires omnistaging to be disabled")
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -623,6 +623,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_device_put(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_sub)
+  def test_sub(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -33,7 +33,6 @@ from jax.experimental.jax2tf.tests import tf_test_util
 from jax.interpreters import xla
 
 import numpy as np
-import tensorflow as tf  # type: ignore[import]
 
 config.parse_flags_with_absl()
 
@@ -641,6 +640,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       raise unittest.SkipTest("tie_in test requires omnistaging to be disabled")
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.ad_util_stop_gradient)
+  def test_stop_gradient(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
@@ -984,10 +987,6 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   @primitive_harness.parameterized(primitive_harness.random_split)
   def test_random_split(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
-
-  def test_stop_gradient(self):
-    f = jax2tf.convert(lax.stop_gradient)
-    self.assertEqual(f(tf.ones([])), 1.)
 
   # test_bfloat16_constant checks that https://github.com/google/jax/issues/3942 is
   # fixed

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -579,7 +579,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     dtype = harness.params["dtype"]
     custom_assert = rtol = None
     if dtype in [np.float32, np.complex64]:
-      rtol = 1e-3
+      rtol = 1e-2 if jtu.device_under_test() == "tpu" else 1e-3
     elif dtype in [np.float64, np.complex128]:
       rtol = 1e-12
     elif dtype == np.float16:
@@ -610,6 +610,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
     if dtype in [np.int32, np.int64] and y > 10:
       raise unittest.SkipTest("TODO(bchetioui): integer_pow has inconsistent "
                               "overflow behavior for dtype {}".format(dtype))
+    if (dtype in [np.complex64, np.float32] and
+        jtu.device_under_test() == "tpu" and y in [-1000, 1000]):
+      raise unittest.SkipTest("TODO(bchetioui): hitting rtol = nan for "
+                              "dtype {} on TPU".format(dtype))
     self._pow_test_util(harness)
 
   @primitive_harness.parameterized(primitive_harness.lax_pow)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -571,9 +571,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   @primitive_harness.parameterized(primitive_harness.lax_round)
   def test_round(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
-  
-  @primitive_harness.parameterized(primitive_harness.lax_integer_pow)
-  def test_integer_pow(self, harness: primitive_harness.Harness):
+
+  @primitive_harness.parameterized(primitive_harness.lax_convert_element_type)
+  def test_convert_element_type(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
+  def _pow_test_util(self, harness: primitive_harness.Harness):
     dtype = harness.params["dtype"]
     custom_assert = rtol = None
     if dtype in [np.float32, np.complex64]:
@@ -600,9 +603,13 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                            rtol=rtol, custom_assert=custom_assert,
                            always_custom_assert=True)
 
-  @primitive_harness.parameterized(primitive_harness.lax_convert_element_type)
-  def test_convert_element_type(self, harness: primitive_harness.Harness):
-    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+  @primitive_harness.parameterized(primitive_harness.lax_integer_pow)
+  def test_integer_pow(self, harness: primitive_harness.Harness):
+    self._pow_test_util(harness)
+
+  @primitive_harness.parameterized(primitive_harness.lax_pow)
+  def test_pow(self, harness: primitive_harness.Harness):
+    self._pow_test_util(harness)
 
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -611,6 +611,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_pow(self, harness: primitive_harness.Harness):
     self._pow_test_util(harness)
 
+  @primitive_harness.parameterized(primitive_harness.lax_reshape)
+  def test_reshape(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -619,6 +619,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_rev(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.xla_device_put)
+  def test_device_put(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -631,6 +631,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_bitcast_convert_type(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.ad_util_add_jaxvals)
+  def test_add_jaxvals(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -615,6 +615,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_reshape(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_rev)
+  def test_rev(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -604,6 +604,12 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
   @primitive_harness.parameterized(primitive_harness.lax_integer_pow)
   def test_integer_pow(self, harness: primitive_harness.Harness):
+    dtype, y = harness.params["dtype"], harness.params["y"]
+    # TODO(bchetioui): y > 10 is an arbitrary bound here, to skip tests that
+    # might cause an overflow behavior.
+    if dtype in [np.int32, np.int64] and y > 10:
+      raise unittest.SkipTest("TODO(bchetioui): integer_pow has inconsistent "
+                              "overflow behavior for dtype {}".format(dtype))
     self._pow_test_util(harness)
 
   @primitive_harness.parameterized(primitive_harness.lax_pow)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -627,6 +627,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_sub(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_bitcast_convert_type)
+  def test_bitcast_convert_type(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))


### PR DESCRIPTION
This PR contains testing (and some fixes) for the conversion of:
- `integer_pow`
- `pow`
- `reshape`
- `rev`
- `device_put`
- `sub`
- `bitcast_convert_type`
- `add_any`
- `tie_in`
- `stop_gradient`

Three last primitives are completely missing from the tests:
- `convert_element_type` – which is waiting on (#5063 and #4959)
- `shape_as_value`
- `custom_lin`

Another missing thing from this PR might be the harnesses for the unary elementwise/binary elementwise operations as well, which I plan to rewrite as some previous examples seem to indicate they do not provide sufficient coverage.