### PR TITLE
improve sinc jvp at zero

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1015,9 +1015,9 @@ def _sinc_maclaurin(k, x):
   # compute the kth derivative of x -> sin(x)/x evaluated at zero (since we
   # compute the monomial term in the jvp rule)
   if k % 2:
-    return lax._const(x, 0)
+    return lax.full_like(x, 0)
   else:
-    return lax._const(x, (-1) ** (k // 2) / (k + 1))
+    return lax.full_like(x, (-1) ** (k // 2) / (k + 1))
 
 @_sinc_maclaurin.defjvp
 def _sinc_maclaurin_jvp(k, primals, tangents):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1005,10 +1005,24 @@ def sinc(x):
   _check_arraylike("sinc", x)
   x, = _promote_dtypes_inexact(x)
   eq_zero = lax.eq(x, lax._const(x, 0))
-  safe_x = where(eq_zero, lax._const(x, 0), x)
-  pi_x = lax.mul(lax._const(x, pi), safe_x)
-  return where(eq_zero,
-               lax._const(x, 1), lax.div(lax.sin(pi_x), pi_x))
+  pi_x = lax.mul(lax._const(x, pi), x)
+  safe_pi_x = where(eq_zero, lax._const(x, 0), pi_x)
+  return where(eq_zero, _sinc_maclaurin(0, pi_x),
+               lax.div(lax.sin(safe_pi_x), safe_pi_x))
+
+@partial(custom_jvp, nondiff_argnums=(0,))
+def _sinc_maclaurin(k, x):
+  # compute the kth derivative of x -> sin(x)/x evaluated at zero (since we
+  # compute the monomial term in the jvp rule)
+  if k % 2:
+    return lax._const(x, 0)
+  else:
+    return lax._const(x, (-1) ** (k // 2) / (k + 1))
+
+@_sinc_maclaurin.defjvp
+def _sinc_maclaurin_jvp(k, primals, tangents):
+  (x,), (t,) = primals, tangents
+  return _sinc_maclaurin(k, x), _sinc_maclaurin(k + 1, x) * t
 
 
 @_wraps(np.transpose)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4558,6 +4558,10 @@ class NumpyGradTests(jtu.JaxTestCase):
     for ops in itertools.combinations_with_replacement([deriv, api.grad], 4):
       self.assertAllClose(apply_all(ops, jnp.sinc)(0.), d4)
 
+  def testSincGradArrayInput(self):
+    # tests for a bug almost introduced in #5077
+    jax.grad(lambda x: jnp.sinc(x).sum())(jnp.arange(10.))  # doesn't crash
+
   def testTakeAlongAxisIssue1521(self):
     # https://github.com/google/jax/issues/1521
     idx = jnp.repeat(jnp.arange(3), 10).reshape((30, 1))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4531,6 +4531,33 @@ class NumpyGradTests(jtu.JaxTestCase):
     check_grads(op, (special_value,), order, ["fwd", "rev"],
                 atol={np.float32: 3e-3})
 
+  def testSincAtZero(self):
+    # Some manual tests for sinc at zero, since it doesn't have well-behaved
+    # numerical derivatives at zero
+    def deriv(f):
+      return lambda x: api.jvp(f, (x,), (1.,))[1]
+
+    def apply_all(fns, x):
+      for f in fns:
+        x = f(x)
+      return x
+
+    d1 = 0.
+    for ops in itertools.combinations_with_replacement([deriv, api.grad], 1):
+      self.assertAllClose(apply_all(ops, jnp.sinc)(0.), d1)
+
+    d2 = -np.pi ** 2 / 3
+    for ops in itertools.combinations_with_replacement([deriv, api.grad], 2):
+      self.assertAllClose(apply_all(ops, jnp.sinc)(0.), d2)
+
+    d3 = 0.
+    for ops in itertools.combinations_with_replacement([deriv, api.grad], 3):
+      self.assertAllClose(apply_all(ops, jnp.sinc)(0.), d3)
+
+    d4 = np.pi ** 4 / 5
+    for ops in itertools.combinations_with_replacement([deriv, api.grad], 4):
+      self.assertAllClose(apply_all(ops, jnp.sinc)(0.), d4)
+
   def testTakeAlongAxisIssue1521(self):
     # https://github.com/google/jax/issues/1521
     idx = jnp.repeat(jnp.arange(3), 10).reshape((30, 1))


### PR DESCRIPTION
Thanks to @dougalm for thinking this through with me!

The basic problem in #5054 is that we had for `sinc` an expression like

```python
  return where(x == 0, 1., sin(pi * x) / (pi * x))
```

One way to read that is at `x == 0`, we're replacing the function with its zeroth-order Taylor expansion. But that meant at zero we aren't computing its correct derivatives! (We were getting lucky with the first derivative at zero: it happens to be zero because that's the slope of the sinc function at zero, but we were computing zero because we were differentiating a constant function.)

One way to think about the fix here is that we're replacing the constant function at zero with a truncated Taylor series at zero. For any fixed Taylor series truncation level, we'd only be able to support some finite order of autodiff before incorrectly truncating the derivatives to zero. So we play a trick: we use a `custom_jvp` rule to in effect generate all the Taylor series coefficients we need, lazily as we differentiate.

fixes #5054