### PR TITLE
[jax2tf] Added testing for the conversion of convert_element_type.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1094,8 +1094,18 @@ tf_impl[lax.lt_p] = tf.math.less
 
 tf_impl[lax_linalg.cholesky_p] = tf.linalg.cholesky
 
-def _convert_element_type(operand, new_dtype, old_dtype):
+def _convert_element_type(operand, *, old_dtype, new_dtype):
   del old_dtype
+  old_dtype = operand.dtype.as_numpy_dtype
+  if (dtypes.issubdtype(old_dtype, np.complexfloating) and
+      not dtypes.issubdtype(new_dtype, np.complexfloating)):
+    operand = tf.math.real(operand)
+  if (dtypes.issubdtype(old_dtype, np.floating) and
+      not (dtypes.issubdtype(new_dtype, np.floating) or
+           dtypes.issubdtype(new_dtype, np.complexfloating) or
+           new_dtype == np.bool_)):
+    sign = tf.math.sign(operand)
+    operand = sign * tf.math.floor(sign * operand)
   return tf.dtypes.cast(operand, to_tf_dtype(new_dtype))
 tf_impl[lax.convert_element_type_p] = _convert_element_type
 
@@ -1484,8 +1494,10 @@ def _select_and_gather_add(tangents: TfVal,
     def pack(a, b):
       a = _bitcast_convert_type(a, word_dtype)
       b = _bitcast_convert_type(b, word_dtype)
-      a = _convert_element_type(a, double_word_dtype, word_dtype)
-      b = _convert_element_type(b, double_word_dtype, word_dtype)
+      a = _convert_element_type(a, new_dtype=double_word_dtype,
+                                old_dtype=word_dtype)
+      b = _convert_element_type(b, new_dtype=double_word_dtype,
+                                old_dtype=word_dtype)
       a = tf.bitwise.left_shift(a, const(double_word_dtype, nbits))
       return tf.bitwise.bitwise_or(a, b)
 
@@ -1494,13 +1506,15 @@ def _select_and_gather_add(tangents: TfVal,
       assert t.dtype == double_word_dtype
       st = _shift_right_logical(t, const(double_word_dtype, nbits))
       return _bitcast_convert_type(
-        _convert_element_type(st, word_dtype, double_word_dtype), dtype
+        _convert_element_type(st, new_dtype=word_dtype,
+                              old_dtype=double_word_dtype), dtype
       )
 
     # Unpacks the second element of a tuple.
     def snd(t):
       return _bitcast_convert_type(
-        _convert_element_type(t, word_dtype, double_word_dtype), dtype
+        _convert_element_type(t, new_dtype=word_dtype,
+                              old_dtype=double_word_dtype), dtype
       )
 
   else:

--- a/jax/experimental/jax2tf/tests/correctness_stats.py
+++ b/jax/experimental/jax2tf/tests/correctness_stats.py
@@ -273,6 +273,10 @@ def categorize(prim: core.Primitive, *args, **kwargs) \
     if np_dtype == dtypes.bfloat16:
       tf_unimpl(np_dtype, devs=["CPU", "GPU"])
 
+  if prim is lax.convert_element_type_p:
+    if np_dtype == dtypes.bfloat16:
+      tf_unimpl(np_dtype, devs=["CPU", "GPU"])
+
   if prim in [lax.sinh_p, lax.cosh_p, lax.atanh_p, lax.asinh_p, lax.acosh_p,
               lax.erf_inv_p]:
     if np_dtype == np.float16:

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -572,6 +572,10 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   def test_round(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
 
+  @primitive_harness.parameterized(primitive_harness.lax_convert_element_type)
+  def test_convert_element_type(self, harness: primitive_harness.Harness):
+    self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))
+
   @primitive_harness.parameterized(primitive_harness.lax_comparators)
   def test_comparators(self, harness: primitive_harness.Harness):
     self.ConvertAndCompare(harness.dyn_fun, *harness.dyn_args_maker(self.rng()))


### PR DESCRIPTION
This PR currently fails tests for `uint` dtypes, which is why they are disabled.
I believe the bug is in the XLA implementation of `convert_element_type`, however (see #5082).