### PR TITLE
Cleanup: remove unnecessary rng_factory boilerplate in lax_numpy_test

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -968,8 +968,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axes),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes, "rng_factory": rng_factory}
-      for rng_factory in [jtu.rand_default]
+       "axes": axes}
       for lhs_shape, rhs_shape, axes in [
           [(2,), (2,), (-1, -1, -1, None)], # scalar output
           [(2, 4), (2, 4), (-1, -1, -1, 0)], # 2D vectors
@@ -983,8 +982,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 5, 2), (4, 5, 2), (-1, -1, -1, None)] # same as before
       ]
       for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
-    rng = rng_factory(self.rng())
+  def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     axisa, axisb, axisc, axis = axes
     jnp_fun = lambda a, b: jnp.cross(a, b, axisa, axisb, axisc, axis)
@@ -1007,9 +1006,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng_factory": rng_factory}
-      for rng_factory in [jtu.rand_default]
+       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
       for name, lhs_shape, rhs_shape in [
           ("matrix-scalar", (3, 3), ()),
           ("scalar-matrix", (), (3, 3)),
@@ -1022,8 +1019,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("matrix-tensor", (5, 2), (3, 2, 4)),
           ("tensor-tensor", (2, 3, 4), (5, 4, 1))]
       for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     tol = {np.float16: 1e-2, np.float32: 1e-5, np.float64: 1e-14,
            np.complex128: 1e-14}
@@ -1044,9 +1041,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng_factory": rng_factory}
-      for rng_factory in [jtu.rand_default]
+       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
       for name, lhs_shape, rhs_shape in [
           ("vector-vector", (3,), (3,)),
           ("matrix-vector", (3, 3), (3,)),
@@ -1059,8 +1054,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("tensor-tensor", (5, 3, 4), (5, 4, 1)),
           ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]
       for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    rng = jtu.rand_default(self.rng())
     def np_fun(x, y):
       dtype = jnp.promote_types(lhs_dtype, rhs_dtype)
       return np.matmul(x, y).astype(dtype)
@@ -1079,8 +1074,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axes),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
        "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes, "rng_factory": rng_factory}
-      for rng_factory in [jtu.rand_default]
+       "axes": axes}
       for lhs_shape, rhs_shape, axes in [
           [(3,), (), 0],
           [(2, 3, 4), (5, 6, 7), 0],  # from issue #740
@@ -1090,8 +1084,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(1, 2, 3, 4), (4, 5, 3, 6), [[2, 3], [2, 0]]],
       ]
       for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     jnp_fun = lambda a, b: jnp.tensordot(a, b, axes)
     def np_fun(a, b):
@@ -1205,16 +1199,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
           jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
        "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "rng_factory": jtu.rand_default}
+       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
       # TODO(phawkins): support integer dtypes too.
       for lhs_shape, lhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
       for rhs_shape, rhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
       if len(jtu._dims_of_shape(lhs_shape)) == 0
       or len(jtu._dims_of_shape(rhs_shape)) == 0
       or lhs_shape[-1] == rhs_shape[-1]))
-  def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     def np_fun(lhs, rhs):
       lhs = lhs if lhs_dtype != jnp.bfloat16 else lhs.astype(np.float32)
@@ -1237,15 +1230,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_amin={}_amax={}".format(
           jtu.format_shape_dtype_string(shape, dtype), a_min, a_max),
-       "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max,
-       "rng_factory": jtu.rand_default}
+       "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max}
       for shape in all_shapes for dtype in number_dtypes
       for a_min, a_max in [(-1, None), (None, 1), (-0.9, 1),
                            (-np.ones(1), None),
                            (None, np.ones(1)),
                            (np.full(1, -0.9), np.ones(1))]))
-  def testClipStaticBounds(self, shape, dtype, a_min, a_max, rng_factory):
-    rng = rng_factory(self.rng())
+  def testClipStaticBounds(self, shape, dtype, a_min, a_max):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.clip(x, a_min=a_min, a_max=a_max)
     jnp_fun = lambda x: jnp.clip(x, a_min=a_min, a_max=a_max)
     args_maker = lambda: [rng(shape, dtype)]
@@ -1260,12 +1252,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_decimals={}".format(
           jtu.format_shape_dtype_string(shape, dtype), decimals),
-       "shape": shape, "dtype": dtype, "decimals": decimals,
-       "rng_factory": jtu.rand_default}
+       "shape": shape, "dtype": dtype, "decimals": decimals}
       for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)
       for decimals in [0, 1, -2]))
-  def testRoundStaticDecimals(self, shape, dtype, decimals, rng_factory):
-    rng = rng_factory(self.rng())
+  def testRoundStaticDecimals(self, shape, dtype, decimals):
+    rng = jtu.rand_default(self.rng())
     if jnp.issubdtype(dtype, np.integer) and decimals < 0:
       self.skipTest("Integer rounding with decimals < 0 not implemented")
     np_fun = lambda x: np.round(x, decimals=decimals)
@@ -1298,8 +1289,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype), mode, pad_width,
           constant_values),
        "shape": shape, "dtype": dtype, "mode": mode,
-       "pad_width": pad_width, "constant_values": constant_values,
-       "rng_factory": jtu.rand_default}
+       "pad_width": pad_width, "constant_values": constant_values}
       for mode, shapes in [
           ('constant', all_shapes),
           ('symmetric', nonempty_shapes),
@@ -1335,8 +1325,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       if (pad_width != () and constant_values != () and
           ((mode == 'constant' and constant_values is not None) or
            (mode != 'constant' and constant_values is None)))))
-  def testPad(self, shape, dtype, mode, pad_width, constant_values, rng_factory):
-    rng = rng_factory(self.rng())
+  def testPad(self, shape, dtype, mode, pad_width, constant_values):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     if constant_values is None:
       np_fun = partial(np.pad, pad_width=pad_width, mode=mode)
@@ -1371,13 +1361,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape=[{}]_reps={}".format(
           jtu.format_shape_dtype_string(shape, dtype), reps),
-       "shape": shape, "dtype": dtype, "reps": reps,
-       "rng_factory": jtu.rand_default}
+       "shape": shape, "dtype": dtype, "reps": reps}
       for reps in [(), (2,), (3, 4), (2, 3, 4), (1, 0, 2)]
       for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
       ))
-  def testTile(self, shape, dtype, reps, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTile(self, shape, dtype, reps):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.tile(arg, reps)
     jnp_fun = lambda arg: jnp.tile(arg, reps)
 
@@ -1548,14 +1537,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_axis={}_baseshape=[{}]_dtypes=[{}]".format(
           axis, ",".join(str(d) for d in base_shape),
           ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
-       "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
-       "rng_factory": jtu.rand_default}
+       "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes}
       for num_arrs in [3]
       for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, num_arrs)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
-  def testConcatenate(self, axis, base_shape, arg_dtypes, rng_factory):
-    rng = rng_factory(self.rng())
+  def testConcatenate(self, axis, base_shape, arg_dtypes):
+    rng = jtu.rand_default(self.rng())
     wrapped_axis = axis % len(base_shape)
     shapes = [base_shape[:wrapped_axis] + (size,) + base_shape[wrapped_axis+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), arg_dtypes)]
@@ -1582,13 +1570,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_axis={}_baseshape=[{}]_dtypes=[{}]".format(
           axis, ",".join(str(d) for d in base_shape),
           ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
-       "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes,
-       "rng_factory": jtu.rand_default}
+       "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes}
       for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, 2)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
       for axis in range(-len(base_shape)+1, len(base_shape))))
-  def testAppend(self, axis, base_shape, arg_dtypes, rng_factory):
-    rng = rng_factory(self.rng())
+  def testAppend(self, axis, base_shape, arg_dtypes):
+    rng = jtu.rand_default(self.rng())
     wrapped_axis = axis % len(base_shape)
     shapes = [base_shape[:wrapped_axis] + (size,) + base_shape[wrapped_axis+1:]
               for size, _ in zip(itertools.cycle([3, 1, 4]), arg_dtypes)]
@@ -1657,13 +1644,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           axis, repeats, fixed_size),
        "axis": axis, "shape": shape, "dtype": dtype, "repeats": repeats,
-       "rng_factory": jtu.rand_default, 'fixed_size': fixed_size}
+       'fixed_size': fixed_size}
       for repeats in [0, 1, 2]
       for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
       for axis in [None] + list(range(-len(shape), max(1, len(shape))))
       for fixed_size in [True, False]))
-  def testRepeat(self, axis, shape, dtype, repeats, rng_factory, fixed_size):
-    rng = rng_factory(self.rng())
+  def testRepeat(self, axis, shape, dtype, repeats, fixed_size):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.repeat(arg, repeats=repeats, axis=axis)
     np_fun = _promote_like_jnp(np_fun)
     if fixed_size:
@@ -1780,7 +1767,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(yshape, dtype),
           mode),
        "xshape": xshape, "yshape": yshape, "dtype": dtype, "mode": mode,
-       "rng_factory": jtu.rand_default,
        "jnp_op": getattr(jnp, op),
        "np_op": getattr(np, op)}
       for mode in ['full', 'same', 'valid']
@@ -1788,8 +1774,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for dtype in default_dtypes
       for xshape in one_dim_array_shapes
       for yshape in one_dim_array_shapes))
-  def testConvolutions(self, xshape, yshape, dtype, mode, rng_factory, jnp_op, np_op):
-    rng = rng_factory(self.rng())
+  def testConvolutions(self, xshape, yshape, dtype, mode, jnp_op, np_op):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
     precision = lax.Precision.HIGHEST if jtu.device_under_test() == "tpu" else None
     np_fun = partial(np_op, mode=mode)
@@ -1803,15 +1789,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           op, jtu.format_shape_dtype_string(shape, dtype), axis,
           out_dtype.__name__),
        "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
-       "rng_factory": jtu.rand_default, "jnp_op": getattr(jnp, op),
-       "np_op": getattr(np, op)}
+       "jnp_op": getattr(jnp, op), "np_op": getattr(np, op)}
       for op in ["cumsum", "cumprod"]
       for dtype in all_dtypes
       for out_dtype in default_dtypes
       for shape in all_shapes
       for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op, rng_factory):
-    rng = rng_factory(self.rng())
+  def testCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np_op(arg, axis=axis, dtype=out_dtype)
     np_fun = jtu.ignore_warning(category=np.ComplexWarning)(np_fun)
     jnp_fun = lambda arg: jnp_op(arg, axis=axis, dtype=out_dtype)
@@ -1902,14 +1887,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_k={}".format(
           op, jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "op": op, "k": k,
-       "rng_factory": jtu.rand_default}
+       "dtype": dtype, "shape": shape, "op": op, "k": k}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for op in ["tril", "triu"]
       for k in list(range(-3, 3))))
-  def testTriLU(self, dtype, shape, op, k, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTriLU(self, dtype, shape, op, k):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: getattr(np, op)(arg, k=k)
     jnp_fun = lambda arg: getattr(jnp, op)(arg, k=k)
     args_maker = lambda: [rng(shape, dtype)]
@@ -1943,12 +1927,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_shape={}_k={}".format(
       jtu.format_shape_dtype_string(shape, dtype), k),
-      "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
+      "dtype": dtype, "shape": shape, "k": k}
     for dtype in default_dtypes
     for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
     for k in [-1, 0, 1]))
-  def testTriuIndicesFrom(self, shape, dtype, k, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTriuIndicesFrom(self, shape, dtype, k):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arr, k: np.triu_indices_from(arr, k=k)
     jnp_fun = lambda arr, k: jnp.triu_indices_from(arr, k=k)
     args_maker = lambda: [rng(shape, dtype), k]
@@ -1957,12 +1941,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_shape={}_k={}".format(
       jtu.format_shape_dtype_string(shape, dtype), k),
-      "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
+      "dtype": dtype, "shape": shape, "k": k}
     for dtype in default_dtypes
     for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
     for k in [-1, 0, 1]))
-  def testTrilIndicesFrom(self, shape, dtype, k, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTrilIndicesFrom(self, shape, dtype, k):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arr, k: np.tril_indices_from(arr, k=k)
     jnp_fun = lambda arr, k: jnp.tril_indices_from(arr, k=k)
     args_maker = lambda: [rng(shape, dtype), k]
@@ -1995,12 +1979,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_k={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "k": k, "rng_factory": jtu.rand_default}
+       "dtype": dtype, "shape": shape, "k": k}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) in (1, 2)]
       for k in list(range(-4, 4))))
-  def testDiag(self, shape, dtype, k, rng_factory):
-    rng = rng_factory(self.rng())
+  def testDiag(self, shape, dtype, k):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.diag(arg, k)
     jnp_fun = lambda arg: jnp.diag(arg, k)
     args_maker = lambda: [rng(shape, dtype)]
@@ -2047,15 +2031,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_offset={}_axis1={}_axis2={}".format(
           jtu.format_shape_dtype_string(shape, dtype), offset, axis1, axis2),
        "dtype": dtype, "shape": shape, "offset": offset, "axis1": axis1,
-       "axis2": axis2, "rng_factory": jtu.rand_default}
+       "axis2": axis2}
       for dtype in default_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in [a for a in range(-len(shape), len(shape))
                     if a % len(shape) != axis1 % len(shape)]
       for offset in list(range(-4, 4))))
-  def testDiagonal(self, shape, dtype, offset, axis1, axis2, rng_factory):
-    rng = rng_factory(self.rng())
+  def testDiagonal(self, shape, dtype, offset, axis1, axis2):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.diagonal(arg, offset, axis1, axis2)
     jnp_fun = lambda arg: jnp.diagonal(arg, offset, axis1, axis2)
     args_maker = lambda: [rng(shape, dtype)]
@@ -2160,7 +2144,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, dtype),
           out_dtype, offset, axis1, axis2),
        "dtype": dtype, "out_dtype": out_dtype, "shape": shape, "offset": offset,
-       "axis1": axis1, "axis2": axis2, "rng_factory": jtu.rand_default}
+       "axis1": axis1, "axis2": axis2}
       for dtype in default_dtypes
       for out_dtype in [None] + number_dtypes
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
@@ -2168,8 +2152,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for axis2 in range(-len(shape), len(shape))
       if (axis1 % len(shape)) != (axis2 % len(shape))
       for offset in list(range(-4, 4))))
-  def testTrace(self, shape, dtype, out_dtype, offset, axis1, axis2, rng_factory):
-    rng = rng_factory(self.rng())
+  def testTrace(self, shape, dtype, out_dtype, offset, axis1, axis2):
+    rng = jtu.rand_default(self.rng())
     def np_fun(arg):
       if out_dtype == jnp.bfloat16:
         return np.trace(arg, offset, axis1, axis2, np.float32).astype(jnp.bfloat16)
@@ -2185,15 +2169,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(ashape, dtype),
       jtu.format_shape_dtype_string(vshape, dtype),
       side), "ashape": ashape, "vshape": vshape, "side": side,
-     "dtype": dtype, "rng_factory": rng_factory}
+     "dtype": dtype}
     for ashape in [(15,), (16,), (17,)]
     for vshape in [(), (5,), (5, 5)]
     for side in ['left', 'right']
     for dtype in default_dtypes
-    for rng_factory in [jtu.rand_default]
   ))
-  def testSearchsorted(self, ashape, vshape, side, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testSearchsorted(self, ashape, vshape, side, dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [np.sort(rng(ashape, dtype)), rng(vshape, dtype)]
     np_fun = lambda a, v: np.searchsorted(a, v, side=side)
     jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side)
@@ -2205,17 +2188,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jtu.format_shape_dtype_string(xshape, dtype),
       jtu.format_shape_dtype_string(binshape, dtype),
       right, reverse), "xshape": xshape, "binshape": binshape,
-      "right": right, "reverse": reverse, "dtype": dtype, "rng_factory": rng_factory}
+      "right": right, "reverse": reverse, "dtype": dtype}
     for xshape in [(20,), (5, 4)]
     for binshape in [(1,), (5,)]
     for right in [True, False]
     for reverse in [True, False]
     for dtype in default_dtypes
-    for rng_factory in [jtu.rand_default]
   ))
-  def testDigitize(self, xshape, binshape, right, reverse, dtype, rng_factory):
+  def testDigitize(self, xshape, binshape, right, reverse, dtype):
     order = jax.ops.index[::-1] if reverse else jax.ops.index[:]
-    rng = rng_factory(self.rng())
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), jnp.sort(rng(binshape, dtype))[order]]
     np_fun = lambda x, bins: np.digitize(x, bins, right=right)
     jnp_fun = lambda x, bins: jnp.digitize(x, bins, right=right)
@@ -2245,7 +2227,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), axis),
-       "shape": shape, "axis": axis, "dtypes": dtypes, "rng_factory": rng_factory}
+       "shape": shape, "axis": axis, "dtypes": dtypes}
       for dtypes in [
         [np.float32],
         [np.float32, np.float32],
@@ -2254,10 +2236,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         [np.float32, np.int32, np.float64],
       ]
       for shape in [(), (2,), (3, 4), (1, 100)]
-      for axis in range(-len(shape), len(shape) + 1)
-      for rng_factory in [jtu.rand_default]))
-  def testStack(self, shape, axis, dtypes, rng_factory):
-    rng = rng_factory(self.rng())
+      for axis in range(-len(shape), len(shape) + 1)))
+  def testStack(self, shape, axis, dtypes):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [[rng(shape, dtype) for dtype in dtypes]]
     np_fun = _promote_like_jnp(partial(np.stack, axis=axis))
     jnp_fun = partial(jnp.stack, axis=axis)
@@ -2267,7 +2248,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_{}".format(
           op, jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes)),
-       "shape": shape, "op": op, "dtypes": dtypes, "rng_factory": rng_factory}
+       "shape": shape, "op": op, "dtypes": dtypes}
       for op in ["hstack", "vstack", "dstack"]
       for dtypes in [
         [np.float32],
@@ -2276,10 +2257,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         [np.float32, np.int64, np.float32],
         [np.float32, np.int32, np.float64],
       ]
-      for shape in [(), (2,), (3, 4), (1, 100), (2, 3, 4)]
-      for rng_factory in [jtu.rand_default]))
-  def testHVDStack(self, shape, op, dtypes, rng_factory):
-    rng = rng_factory(self.rng())
+      for shape in [(), (2,), (3, 4), (1, 100), (2, 3, 4)]))
+  def testHVDStack(self, shape, op, dtypes):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [[rng(shape, dtype) for dtype in dtypes]]
     np_fun = _promote_like_jnp(getattr(np, op))
     jnp_fun = getattr(jnp, op)
@@ -2291,12 +2271,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(shape, fill_value_dtype),
           np.dtype(out_dtype).name if out_dtype else "None"),
        "shape": shape, "fill_value_dtype": fill_value_dtype,
-       "out_dtype": out_dtype, "rng_factory": jtu.rand_default}
+       "out_dtype": out_dtype}
       for shape in array_shapes + [3, np.array(7, dtype=np.int32)]
       for fill_value_dtype in default_dtypes
       for out_dtype in [None] + default_dtypes))
-  def testFull(self, shape, fill_value_dtype, out_dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testFull(self, shape, fill_value_dtype, out_dtype):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda fill_value: np.full(shape, fill_value, dtype=out_dtype)
     jnp_fun = lambda fill_value: jnp.full(shape, fill_value, dtype=out_dtype)
     args_maker = lambda: [rng((), fill_value_dtype)]
@@ -2377,13 +2357,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}_{}sections".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
        "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype, "rng_factory": jtu.rand_default}
+       "dtype": dtype}
       for shape, axis, num_sections in [
           ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
       for dtype in default_dtypes))
-  def testSplitStaticInt(self, shape, num_sections, axis, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testSplitStaticInt(self, shape, num_sections, axis, dtype):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.split(x, num_sections, axis=axis)
     jnp_fun = lambda x: jnp.split(x, num_sections, axis=axis)
     args_maker = lambda: [rng(shape, dtype)]
@@ -2552,13 +2532,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}_{}sections".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
        "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype, "rng_factory": jtu.rand_default}
+       "dtype": dtype}
       for shape, axis, num_sections in [
           ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]
       for dtype in default_dtypes))
-  def testHVDSplit(self, shape, num_sections, axis, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testHVDSplit(self, shape, num_sections, axis, dtype):
+    rng = jtu.rand_default(self.rng())
     def fn(module, axis):
       if axis == 0:
         return module.vsplit
@@ -2580,7 +2560,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           jtu.format_shape_dtype_string(out_shape, dtype),
           order),
        "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "order": order, "rng_factory": jtu.rand_default}
+       "order": order}
       for dtype in default_dtypes
       for order in ["C", "F"]
       for arg_shape, out_shape in [
@@ -2593,8 +2573,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
       ]))
-  def testReshape(self, arg_shape, out_shape, dtype, order, rng_factory):
-    rng = rng_factory(self.rng())
+  def testReshape(self, arg_shape, out_shape, dtype, order):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.reshape(x, out_shape, order=order)
     jnp_fun = lambda x: jnp.reshape(x, out_shape, order=order)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -2605,16 +2585,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_outshape={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype),
           jtu.format_shape_dtype_string(out_shape, dtype)),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "rng_factory": jtu.rand_default}
+       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype}
       for dtype in default_dtypes
       for arg_shape, out_shape in [
           ((7, 0), (0, 42, 101)),
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
       ]))
-  def testReshapeMethod(self, arg_shape, out_shape, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+  def testReshapeMethod(self, arg_shape, out_shape, dtype):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.reshape(x, out_shape)
     jnp_fun = lambda x: x.reshape(*out_shape)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -2624,15 +2603,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_expanddim={!r}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), dim),
-       "arg_shape": arg_shape, "dtype": dtype, "dim": dim,
-       "rng_factory": jtu.rand_default}
+       "arg_shape": arg_shape, "dtype": dtype, "dim": dim}
       for arg_shape in [(), (3,), (3, 4)]
       for dtype in default_dtypes
       for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
                   + [np.array(0), np.array(-1), (0,), (np.array(0),),
                      (len(arg_shape), len(arg_shape) + 1)])))
-  def testExpandDimsStaticDim(self, arg_shape, dtype, dim, rng_factory):
-    rng = rng_factory(self.rng())
+  def testExpandDimsStaticDim(self, arg_shape, dtype, dim):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.expand_dims(x, dim)
     jnp_fun = lambda x: jnp.expand_dims(x, dim)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -2645,14 +2623,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_axes=({},{})".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), ax1, ax2),
-       "arg_shape": arg_shape, "dtype": dtype, "ax1": ax1, "ax2": ax2,
-       "rng_factory": jtu.rand_default}
+       "arg_shape": arg_shape, "dtype": dtype, "ax1": ax1, "ax2": ax2}
       for arg_shape, ax1, ax2 in [
           ((3, 4), 0, 1), ((3, 4), 1, 0), ((3, 4, 5), 1, 2),
           ((3, 4, 5), -1, -2), ((3, 4, 5), 0, 1)]
       for dtype in default_dtypes))
-  def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2, rng_factory):
-    rng = rng_factory(self.rng())
+  def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.swapaxes(x, ax1, ax2)
     jnp_fun = lambda x: jnp.swapaxes(x, ax1, ax2)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -2662,8 +2639,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_axis={!r}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype), ax),
-       "arg_shape": arg_shape, "dtype": dtype, "ax": ax,
-       "rng_factory": jtu.rand_default}
+       "arg_shape": arg_shape, "dtype": dtype, "ax": ax}
       for arg_shape, ax in [
           ((3, 1), None),
           ((3, 1), 1),
@@ -2673,8 +2649,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((1, 3, 1), (0,)),
           ((1, 4, 1), (np.array(0),))]
       for dtype in default_dtypes))
-  def testSqueeze(self, arg_shape, dtype, ax, rng_factory):
-    rng = rng_factory(self.rng())
+  def testSqueeze(self, arg_shape, dtype, ax):
+    rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.squeeze(x, ax)
     jnp_fun = lambda x: jnp.squeeze(x, ax)
     args_maker = lambda: [rng(arg_shape, dtype)]
@@ -2687,7 +2663,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           axis,
           (None if weights_shape is None else jtu.format_shape_dtype_string(weights_shape, dtype)),
           returned),
-       "rng_factory": jtu.rand_default, "shape": shape, "dtype": dtype, "axis": axis,
+       "shape": shape, "dtype": dtype, "axis": axis,
        "weights_shape": weights_shape, "returned": returned}
       for shape, dtype in _shape_and_dtypes(nonempty_shapes, number_dtypes)
       for axis in list(range(-len(shape), len(shape))) + [None]
@@ -2696,8 +2672,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for weights_shape in ([None, shape] if axis is None or len(shape) == 1
                             else [None, (shape[axis],), shape])
       for returned in [False, True]))
-  def testAverage(self, shape, dtype, axis, weights_shape, returned, rng_factory):
-    rng = rng_factory(self.rng())
+  def testAverage(self, shape, dtype, axis, weights_shape, returned):
+    rng = jtu.rand_default(self.rng())
     if weights_shape is None:
       np_fun = lambda x: np.average(x, axis, returned=returned)
       jnp_fun = lambda x: jnp.average(x, axis, returned=returned)
@@ -2897,13 +2873,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis}
+       "shape": shape, "dtype": dtype, "axis": axis}
       for shape in [(3,), (2, 3)]
       for dtype in default_dtypes
       for axis in list(range(-len(shape), len(shape))) + [None]  # Test negative axes
-      for rng_factory in [jtu.rand_default]))
-  def testFlip(self, shape, dtype, axis, rng_factory):
-    rng = rng_factory(self.rng())
+    ))
+  def testFlip(self, shape, dtype, axis):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     jnp_op = lambda x: jnp.flip(x, axis)
     np_op = lambda x: np.flip(x, axis)
@@ -2913,12 +2889,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
+       "shape": shape, "dtype": dtype}
       for shape in [(3,), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testFlipud(self, shape, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+      for dtype in default_dtypes))
+  def testFlipud(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     jnp_op = lambda x: jnp.flipud(x)
     np_op = lambda x: np.flipud(x)
@@ -2929,12 +2904,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(
           jtu.format_shape_dtype_string(shape, dtype)),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype}
+       "shape": shape, "dtype": dtype}
       for shape in [(3, 2), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testFliplr(self, shape, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+      for dtype in default_dtypes))
+  def testFliplr(self, shape, dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     jnp_op = lambda x: jnp.fliplr(x)
     np_op = lambda x: np.fliplr(x)
@@ -2945,7 +2919,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_k={}_axes={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k, axes),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "k": k, "axes": axes}
+       "shape": shape, "dtype": dtype, "k": k, "axes": axes}
       for shape, axes in [
           [(2, 3), (0, 1)],
           [(2, 3), (1, 0)],
@@ -2953,10 +2927,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(4, 3, 2), (2, 1)],
       ]
       for k in range(-3, 4)
-      for dtype in default_dtypes
-      for rng_factory in [jtu.rand_default]))
-  def testRot90(self, shape, dtype, k, axes, rng_factory):
-    rng = rng_factory(self.rng())
+      for dtype in default_dtypes))
+  def testRot90(self, shape, dtype, k, axes):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     jnp_op = lambda x: jnp.rot90(x, k, axes)
     np_op = lambda x: np.rot90(x, k, axes)
@@ -3231,8 +3204,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_shifts={}_axis={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           shifts, axis),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "shifts": shifts,
-       "axis": axis}
+       "shape": shape, "dtype": dtype, "shifts": shifts, "axis": axis}
       for dtype in all_dtypes
       for shape in [(3, 4), (3, 4, 5), (7, 4, 0)]
       for shifts, axis in [
@@ -3243,10 +3215,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ((1, 2), (0, -1)),
         ((4, 2, 5, 5, 2, 4), None),
         (100, None),
-      ]
-      for rng_factory in [jtu.rand_default]))
-  def testRoll(self, shape, dtype, shifts, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      ]))
+  def testRoll(self, shape, dtype, shifts, axis):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype), np.array(shifts)]
     jnp_op = partial(jnp.roll, axis=axis)
     np_op = partial(np.roll, axis=axis)
@@ -3257,15 +3228,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_{}_axis={}_start={}".format(
           jtu.format_shape_dtype_string(shape, dtype),
           axis, start),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis,
+       "shape": shape, "dtype": dtype, "axis": axis,
        "start": start}
       for dtype in all_dtypes
       for shape in [(1, 2, 3, 4)]
       for axis in [-3, 0, 2, 3]
-      for start in [-4, -1, 2, 4]
-      for rng_factory in [jtu.rand_default]))
-  def testRollaxis(self, shape, dtype, start, axis, rng_factory):
-    rng = rng_factory(self.rng())
+      for start in [-4, -1, 2, 4]))
+  def testRollaxis(self, shape, dtype, start, axis):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     jnp_op = partial(jnp.rollaxis, axis=axis, start=start)
     np_op = partial(np.rollaxis, axis=axis, start=start)
@@ -3275,17 +3245,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}_bitorder={}".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, bitorder),
-       "rng_factory": rng_factory, "shape": shape, "dtype": dtype, "axis": axis,
+       "shape": shape, "dtype": dtype, "axis": axis,
        "bitorder": bitorder}
       for dtype in [np.uint8, np.bool_]
       for bitorder in ['big', 'little']
       for shape in [(1, 2, 3, 4)]
-      for axis in [None, 0, 1, -2, -1]
-      for rng_factory in [jtu.rand_some_zero]))
-  def testPackbits(self, shape, dtype, axis, bitorder, rng_factory):
+      for axis in [None, 0, 1, -2, -1]))
+  def testPackbits(self, shape, dtype, axis, bitorder):
     if numpy_version < (1, 17, 0):
       raise SkipTest("bitorder arg added in numpy 1.17.0")
-    rng = rng_factory(self.rng())
+    rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     jnp_op = partial(jnp.packbits, axis=axis, bitorder=bitorder)
     np_op = partial(np.packbits, axis=axis, bitorder=bitorder)
@@ -3398,14 +3367,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       {"testcase_name": "_shape={}_n={}_increasing={}".format(
           jtu.format_shape_dtype_string([shape], dtype),
           n, increasing),
-       "dtype": dtype, "shape": shape, "n": n, "increasing": increasing,
-       "rng_factory": jtu.rand_default}
+       "dtype": dtype, "shape": shape, "n": n, "increasing": increasing}
       for dtype in inexact_dtypes
       for shape in [0, 5]
       for n in [2, 4]
       for increasing in [False, True]))
-  def testVander(self, shape, dtype, n, increasing, rng_factory):
-    rng = rng_factory(self.rng())
+  def testVander(self, shape, dtype, n, increasing):
+    rng = jtu.rand_default(self.rng())
     def np_fun(arg):
       arg = arg.astype(np.float32) if dtype == jnp.bfloat16 else arg
       return np.vander(arg, N=n, increasing=increasing)
@@ -3418,14 +3386,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix("nan_to_num", [shape],
-                                                      [dtype]),
-         "rng_factory": jtu.rand_some_inf_and_nan, "shape": shape,
-         "dtype": dtype}
+        {"testcase_name": jtu.format_test_name_suffix(
+            "nan_to_num", [shape], [dtype]),
+         "shape": shape, "dtype": dtype}
         for shape in array_shapes
         for dtype in inexact_dtypes))
-  def testNanToNum(self, rng_factory, shape, dtype):
-    rng = rng_factory(self.rng())
+  def testNanToNum(self, shape, dtype):
+    rng = jtu.rand_some_inf_and_nan(self.rng())
     dtype = np.dtype(dtypes.canonicalize_dtype(dtype)).type
     def np_fun(x):
       if dtype == jnp.bfloat16:
@@ -3445,15 +3412,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix("ix_", shapes, dtypes),
-         "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
+         "shapes": shapes, "dtypes": dtypes}
         for shapes, dtypes in (
           ((), ()),
           (((7,),), (np.int32,)),
           (((3,), (4,)), (np.int32, np.int32)),
           (((3,), (1,), (4,)), (np.int32, np.int32, np.int32)),
         )))
-  def testIx_(self, rng_factory, shapes, dtypes):
-    rng = rng_factory(self.rng())
+  def testIx_(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)
                           for shape, dtype in zip(shapes, dtypes)]
     self._CheckAgainstNumpy(np.ix_, jnp.ix_, args_maker)
@@ -3597,12 +3564,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     {"testcase_name": "_{}".format("_".join(
         jtu.format_shape_dtype_string(shape, dtype)
         for shape, dtype in zip(shapes, dtypes))),
-     "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
+     "shapes": shapes, "dtypes": dtypes}
     for shapes in filter(_shapes_are_broadcast_compatible,
                          itertools.combinations_with_replacement(all_shapes, 3))
     for dtypes in itertools.combinations_with_replacement(all_dtypes, 3)))
-  def testWhereThreeArgument(self, rng_factory, shapes, dtypes):
-    args_maker = self._GetArgsMaker(rng_factory(self.rng()), shapes, dtypes)
+  def testWhereThreeArgument(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     def np_fun(cond, x, y):
       return _promote_like_jnp(partial(np.where, cond))(x, y)
     self._CheckAgainstNumpy(np_fun, jnp.where, args_maker)
@@ -3614,16 +3582,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(x.dtype, np.dtype(np.float32))
 
   @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix("", shapes,
-                                                      (np.bool_,) * n + dtypes),
-         "rng_factory": jtu.rand_default, "shapes": shapes, "dtypes": dtypes}
+        {"testcase_name": jtu.format_test_name_suffix(
+            "", shapes, (np.bool_,) * n + dtypes),
+         "shapes": shapes, "dtypes": dtypes}
         for n in range(1, 3)
         for shapes in filter(
           _shapes_are_broadcast_compatible,
           itertools.combinations_with_replacement(all_shapes, 2 * n + 1))
         for dtypes in itertools.combinations_with_replacement(all_dtypes, n + 1)))
-  def testSelect(self, rng_factory, shapes, dtypes):
-    rng = rng_factory(self.rng())
+  def testSelect(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
     n = len(dtypes) - 1
     def args_maker():
       condlist = [rng(shape, np.bool_) for shape in shapes[:n]]
@@ -3707,17 +3675,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       "dtype": dtype,
       "weights": weights,
       "minlength": minlength,
-      "length": length,
-      "rng_factory": rng_factory}
+      "length": length}
     for shape in [(5,), (10,)]
     for dtype in int_dtypes
     for weights in [True, False]
     for minlength in [0, 20]
     for length in [None, 10]
-    for rng_factory in [jtu.rand_positive]
   ))
-  def testBincount(self, shape, dtype, weights, minlength, length, rng_factory):
-    rng = rng_factory(self.rng())
+  def testBincount(self, shape, dtype, weights, minlength, length):
+    rng = jtu.rand_positive(self.rng())
     args_maker = lambda: (rng(shape, dtype), (rng(shape, 'float32') if weights else None))
 
     np_fun = partial(np.bincount, minlength=minlength)
@@ -3906,16 +3872,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "_shape={}_dtype={}_out_dtype={}_axis={}_ddof={}_keepdims={}"
          .format(shape, dtype, out_dtype, axis, ddof, keepdims),
          "shape": shape, "dtype": dtype, "out_dtype": out_dtype, "axis": axis,
-         "ddof": ddof, "keepdims": keepdims, "rng_factory": rng_factory}
+         "ddof": ddof, "keepdims": keepdims}
         for shape in [(5,), (10, 5)]
         for dtype in all_dtypes
         for out_dtype in inexact_dtypes
         for axis in [None, 0, -1]
         for ddof in [0, 1, 2]
-        for keepdims in [False, True]
-        for rng_factory in [jtu.rand_default]))
-  def testVar(self, shape, dtype, out_dtype, axis, ddof, keepdims, rng_factory):
-    rng = rng_factory(self.rng())
+        for keepdims in [False, True]))
+  def testVar(self, shape, dtype, out_dtype, axis, ddof, keepdims):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     @jtu.ignore_warning(category=RuntimeWarning,
                         message="Degrees of freedom <= 0 for slice.")
@@ -3941,16 +3906,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "_shape={}_dtype={}_out_dtype={}_axis={}_ddof={}_keepdims={}"
          .format(shape, dtype, out_dtype, axis, ddof, keepdims),
          "shape": shape, "dtype": dtype, "out_dtype": out_dtype, "axis": axis,
-         "ddof": ddof, "keepdims": keepdims, "rng_factory": rng_factory}
+         "ddof": ddof, "keepdims": keepdims}
         for shape in [(5,), (10, 5)]
         for dtype in all_dtypes
         for out_dtype in inexact_dtypes
         for axis in [None, 0, -1]
         for ddof in [0, 1, 2]
-        for keepdims in [False, True]
-        for rng_factory in [jtu.rand_some_nan]))
-  def testNanVar(self, shape, dtype, out_dtype, axis, ddof, keepdims, rng_factory):
-    rng = rng_factory(self.rng())
+        for keepdims in [False, True]))
+  def testNanVar(self, shape, dtype, out_dtype, axis, ddof, keepdims):
+    rng = jtu.rand_some_nan(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     @jtu.ignore_warning(category=RuntimeWarning,
                         message="Degrees of freedom <= 0 for slice.")
@@ -4076,14 +4040,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         {"testcase_name": "_shapes={}_dtype={}_indexing={}_sparse={}".format(
             shapes, dtype, indexing, sparse),
          "shapes": shapes, "dtype": dtype, "indexing": indexing,
-         "sparse": sparse, "rng_factory": rng_factory}
+         "sparse": sparse}
         for shapes in [(), (5,), (5, 3)]
         for dtype in number_dtypes
         for indexing in ['xy', 'ij']
-        for sparse in [True, False]
-        for rng_factory in [jtu.rand_default]))
-  def testMeshGrid(self, shapes, dtype, indexing, sparse, rng_factory):
-    rng = rng_factory(self.rng())
+        for sparse in [True, False]))
+  def testMeshGrid(self, shapes, dtype, indexing, sparse):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [(x,) for x in shapes],
                                     [dtype] * len(shapes))
     np_fun = partial(np.meshgrid, indexing=indexing, sparse=sparse)
@@ -4098,19 +4061,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
             start_shape, stop_shape, num, endpoint, retstep, dtype),
          "start_shape": start_shape, "stop_shape": stop_shape,
          "num": num, "endpoint": endpoint, "retstep": retstep,
-         "dtype": dtype, "rng_factory": rng_factory}
+         "dtype": dtype}
         for start_shape in [(), (2,), (2, 2)]
         for stop_shape in [(), (2,), (2, 2)]
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for retstep in [True, False]
-        for dtype in number_dtypes + [None,]
-        for rng_factory in [jtu.rand_default]))
-  def testLinspace(self, start_shape, stop_shape, num, endpoint,
-                   retstep, dtype, rng_factory):
+        for dtype in number_dtypes + [None,]))
+  def testLinspace(self, start_shape, stop_shape, num, endpoint, retstep, dtype):
     if num == 1 and not endpoint and numpy_version < (1, 17, 5):
       raise SkipTest("Numpy < 1.17.5 has a linspace bug.")
-    rng = rng_factory(self.rng())
+    rng = jtu.rand_default(self.rng())
     # relax default tolerances slightly
     tol = jtu.tolerance(dtype if dtype else np.float32) * 10
     args_maker = self._GetArgsMaker(rng,
@@ -4135,14 +4096,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       jtu.cases_from_list(
-        {"testcase_name": "_dtype={}".format(dtype),
-         "dtype": dtype,
-         "rng_factory": rng_factory}
-        for dtype in number_dtypes
-        for rng_factory in [jtu.rand_default]))
-  def testLinspaceEndpoints(self, dtype, rng_factory):
+        {"testcase_name": "_dtype={}".format(dtype), "dtype": dtype}
+        for dtype in number_dtypes))
+  def testLinspaceEndpoints(self, dtype):
     """Regression test for Issue #3014."""
-    rng = rng_factory(self.rng())
+    rng = jtu.rand_default(self.rng())
     endpoints = rng((2,), dtype)
     out = jnp.linspace(*endpoints, 10, dtype=dtype)
     self.assertAllClose(out[np.array([0, -1])], endpoints, rtol=0, atol=0)
@@ -4156,22 +4114,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
          "start_shape": start_shape,
          "stop_shape": stop_shape,
          "num": num, "endpoint": endpoint, "base": base,
-         "dtype": dtype, "rng_factory": rng_factory}
+         "dtype": dtype}
         for start_shape in [(), (2,), (2, 2)]
         for stop_shape in [(), (2,), (2, 2)]
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for base in [10.0, 2, np.e]
-        for dtype in inexact_dtypes + [None,]
-        for rng_factory in [jtu.rand_default]))
+        for dtype in inexact_dtypes + [None,]))
   def testLogspace(self, start_shape, stop_shape, num,
-                   endpoint, base, dtype, rng_factory):
+                   endpoint, base, dtype):
     if (dtype in int_dtypes and
         jtu.device_under_test() in ("gpu", "tpu") and
         not FLAGS.jax_enable_x64):
       raise unittest.SkipTest("GPUx32 truncated exponentiation"
                               " doesn't exactly match other platforms.")
-    rng = rng_factory(self.rng())
+    rng = jtu.rand_default(self.rng())
     # relax default tolerances slightly
     tol = {np.float16: 2e-2, np.float32: 1e-2, np.float64: 1e-6,
            np.complex64: 1e-3, np.complex128: 1e-6}
@@ -4317,16 +4274,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       {"testcase_name": "_from={}_to={}".format(from_shape, to_shape),
-       "rng_factory": rng_factory, "from_shape": from_shape, "to_shape": to_shape}
+       "from_shape": from_shape, "to_shape": to_shape}
       for from_shape, to_shape in [
           [(1, 3), (4, 3)],
           [(3,), (2, 1, 3)],
           [(3,), (3, 3)],
           [(1,), (3,)],
-      ]
-      for rng_factory in [jtu.rand_default])
-  def testBroadcastTo(self, from_shape, to_shape, rng_factory):
-    rng = rng_factory(self.rng())
+      ])
+  def testBroadcastTo(self, from_shape, to_shape):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [from_shape], [np.float32])
     np_op = lambda x: np.broadcast_to(x, to_shape)
     jnp_op = lambda x: jnp.broadcast_to(x, to_shape)
@@ -4397,20 +4353,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       jtu.cases_from_list(
-        {"testcase_name": ("_shape={}_varargs={} axis={}_dtype={}")
-         .format(shape, varargs, axis, dtype),
-         "shape": shape,
-         "varargs": varargs,
-         "axis": axis,
-         "dtype": dtype, "rng_factory": rng_factory}
+        {"testcase_name": "_shape={}_varargs={} axis={}_dtype={}".format(
+            shape, varargs, axis, dtype),
+         "shape": shape, "varargs": varargs, "axis": axis, "dtype": dtype}
         for shape in [(10,), (10, 15), (10, 15, 20)]
         for _num_axes in range(len(shape))
         for varargs in itertools.combinations(range(1, len(shape) + 1), _num_axes)
         for axis in itertools.combinations(range(len(shape)), _num_axes)
-        for dtype in inexact_dtypes
-        for rng_factory in [jtu.rand_default]))
-  def testGradient(self, shape, varargs, axis, dtype, rng_factory):
-    rng = rng_factory(self.rng())
+        for dtype in inexact_dtypes))
+  def testGradient(self, shape, varargs, axis, dtype):
+    rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
     jnp_fun = lambda y: jnp.gradient(y, *varargs, axis=axis)
     np_fun = lambda y: np.gradient(y, *varargs, axis=axis)


### PR DESCRIPTION
This was previously the accepted style for specifying tests; now we generally specify rngs directly.