### PR TITLE
make convert_element_type_p not require old_dtype

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -247,8 +247,7 @@ Another example, using :py:func:`lax.cond`:
 >>> print(make_jaxpr(func7)(5.))
 { lambda  ; a.
   let b = ge a 0.0
-      c = convert_element_type[ new_dtype=int32
-                                old_dtype=bool ] b
+      c = convert_element_type[ new_dtype=int32 ] b
       d = cond[ branches=( { lambda  ; a.
                              let b = sub a 3.0
                              in (b,) }
@@ -278,11 +277,9 @@ contains a constant ``jnp.ones(1)`` that is hoisted as a `constvar`
 >>> print(make_jaxpr(func8)(5., (jnp.zeros(1), 2.)))
 { lambda a ; b c d.
   let e = ge b 0.0
-      f = convert_element_type[ new_dtype=int32
-                                old_dtype=bool ] e
+      f = convert_element_type[ new_dtype=int32 ] e
       g = cond[ branches=( { lambda  ; a b c.
-                             let d = convert_element_type[ new_dtype=float32
-                                                           old_dtype=int32 ] a
+                             let d = convert_element_type[ new_dtype=float32 ] a
                                  e = add d c
                              in (e,) }
                            { lambda  ; f_ a b.

--- a/jax/experimental/doubledouble.py
+++ b/jax/experimental/doubledouble.py
@@ -244,11 +244,11 @@ _def_inequality(lax.le_p, operator.le)
 _def_inequality(lax.eq_p, operator.eq)
 _def_inequality(lax.ne_p, operator.ne)
 
-def _convert_element_type(operand, new_dtype, old_dtype):
+def _convert_element_type(operand, new_dtype):
   head, tail = operand
-  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype, old_dtype=old_dtype)
+  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype)
   if tail is not None:
-    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype, old_dtype=old_dtype)
+    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype)
   if jnp.issubdtype(new_dtype, jnp.floating):
     if tail is None:
       tail = jnp.zeros_like(head)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1094,8 +1094,7 @@ tf_impl[lax.lt_p] = tf.math.less
 
 tf_impl[lax_linalg.cholesky_p] = tf.linalg.cholesky
 
-def _convert_element_type(operand, new_dtype, old_dtype):
-  del old_dtype
+def _convert_element_type(operand, new_dtype):
   return tf.dtypes.cast(operand, to_tf_dtype(new_dtype))
 tf_impl[lax.convert_element_type_p] = _convert_element_type
 
@@ -1484,8 +1483,8 @@ def _select_and_gather_add(tangents: TfVal,
     def pack(a, b):
       a = _bitcast_convert_type(a, word_dtype)
       b = _bitcast_convert_type(b, word_dtype)
-      a = _convert_element_type(a, double_word_dtype, word_dtype)
-      b = _convert_element_type(b, double_word_dtype, word_dtype)
+      a = _convert_element_type(a, double_word_dtype)
+      b = _convert_element_type(b, double_word_dtype)
       a = tf.bitwise.left_shift(a, const(double_word_dtype, nbits))
       return tf.bitwise.bitwise_or(a, b)
 
@@ -1494,13 +1493,13 @@ def _select_and_gather_add(tangents: TfVal,
       assert t.dtype == double_word_dtype
       st = _shift_right_logical(t, const(double_word_dtype, nbits))
       return _bitcast_convert_type(
-        _convert_element_type(st, word_dtype, double_word_dtype), dtype
+        _convert_element_type(st, word_dtype), dtype
       )
 
     # Unpacks the second element of a tuple.
     def snd(t):
       return _bitcast_convert_type(
-        _convert_element_type(t, word_dtype, double_word_dtype), dtype
+        _convert_element_type(t, word_dtype), dtype
       )
 
   else:

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -214,12 +214,10 @@ def _make_convert_element_type_harness(name, *, shape=(100, 100),
                                        dtype=np.float32, new_dtype=np.float32):
   return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_olddtype={jtu.dtype_str(dtype)}_newdtype={jtu.dtype_str(new_dtype)}",
                  lambda arg: (
-                     lax.convert_element_type_p.bind(arg, old_dtype=dtype,
-                                                     new_dtype=new_dtype)),
+                     lax.convert_element_type_p.bind(arg, new_dtype=new_dtype)),
                  [RandArg(shape, dtype)],
                  shape=shape,
                  dtype=dtype,
-                 old_dtype=dtype,
                  new_dtype=new_dtype)
 
 lax_convert_element_type = tuple( # Validate dtypes to dtypes

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2513,8 +2513,7 @@ class JaxprTest(jtu.JaxTestCase):
         let b = ge a 0.0
             c = add a 1.0
             d = add a 2.0
-            e = convert_element_type[ new_dtype=int32
-                                      old_dtype=bool ] b
+            e = convert_element_type[ new_dtype=int32 ] b
             f = cond[ branches=( { lambda  ; e_ a b c.
                                    let d = sub c a
                                    in (d,) }
@@ -2528,8 +2527,7 @@ class JaxprTest(jtu.JaxTestCase):
       expected = """
       { lambda  ; a.
         let b = ge a 0.0
-            c = convert_element_type[ new_dtype=int32
-                                      old_dtype=bool ] b
+            c = convert_element_type[ new_dtype=int32 ] b
             d = add a 1.0
             e = add a 2.0
             f = cond[ branches=( { lambda  ; e_ c a b.

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -1274,8 +1274,7 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
     self.assertRewrite("""
         { lambda a ; b c h.
           let d = gt c 0
-              e = convert_element_type[ new_dtype=int32
-                                        old_dtype=bool ] d
+              e = convert_element_type[ new_dtype=int32 ] d
               f g i = cond[ branches=( { lambda  ; a b c d f.
                                          let e g = id_tap[ arg_treedef_=*
                                                            has_token_=True

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2343,15 +2343,6 @@ class LazyConstantTest(jtu.JaxTestCase):
     make_const = lambda: lax.broadcast_in_dim(arr, (2, 1, 3), (0, 2))
     self._Check(make_const, expected)
 
-  def testConvertElementTypeMismatchedDTypeOldDType(self):
-    raise SkipTest("test is no longer relevant after removing old_dtype param")
-    arr = np.ones((2, 2), dtype=np.float32)
-    with self.assertRaisesRegex(
-        TypeError, "operand dtype and old_dtype must be the same, but got "
-                   "operand.dtype=float32 and old_dtype=complex64"):
-      lax.convert_element_type_p.bind(arr, old_dtype=np.complex64,
-                                      new_dtype=np.bool_)
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_fn={}_indexdtype={}"
        .format(jax_fn.__name__, np.dtype(index_dtype).name),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2344,6 +2344,7 @@ class LazyConstantTest(jtu.JaxTestCase):
     self._Check(make_const, expected)
 
   def testConvertElementTypeMismatchedDTypeOldDType(self):
+    raise SkipTest("test is no longer relevant after removing old_dtype param")
     arr = np.ones((2, 2), dtype=np.float32)
     with self.assertRaisesRegex(
         TypeError, "operand dtype and old_dtype must be the same, but got "


### PR DESCRIPTION
Previously we needed to add old_dtype to the primitive's parameters so that it could be transposed. However, now that avals information is available in more places (in particular, attached to the UndefinedPrimal instances we use to indicate inputs with respect to which we are transposing), we don't need that kind of a hack!

This is a follow-up to #2410.