### PR TITLE
Support mapping a single logical axis to multiple mesh axes

### DIFF
--- a/jax/util.py
+++ b/jax/util.py
@@ -300,9 +300,9 @@ def taggedtuple(name, fields) -> Callable[..., Any]:
   """Lightweight version of namedtuple where equality depends on the type."""
   def __new__(cls, *xs):
     return tuple.__new__(cls, (cls,) + xs)
-  def __str__(self):
+  def __repr__(self):
     return '{}{}'.format(name, tuple.__str__(self[1:]))
-  class_namespace = {'__new__' : __new__, '__str__': __str__}
+  class_namespace = {'__new__' : __new__, '__repr__': __repr__}
   for i, f in enumerate(fields):
     class_namespace[f] = property(operator.itemgetter(i+1))  # type: ignore
   return type(name, (tuple,), class_namespace)


### PR DESCRIPTION
This requires further relaxations to `ShardingSpec`s, so that `Chunked` dimensions can actually introduce multiple `ShardedAxis` indices.

cc @jekbradbury @skye 