### PR TITLE
add jax.device_put_replicated

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -36,6 +36,8 @@ from .api import (
   device_count,
   device_get,
   device_put,
+  device_put_sharded,
+  device_put_replicated,
   devices,
   disable_jit,
   eval_shape,

--- a/jax/api.py
+++ b/jax/api.py
@@ -2059,18 +2059,18 @@ def device_put_sharded(shards: Sequence[Any], devices: Sequence[xc.Device]):
     Passing a list of arrays for ``shards`` results in a sharded array
     containing a stacked version of the inputs:
 
-    >>> from jax import api, numpy as jnp
+    >>> import jax
     >>> devices = jax.local_devices()
-    >>> x = [jnp.ones(5) for device in devices]
+    >>> x = [jax.numpy.ones(5) for device in devices]
     >>> y = jax.device_put_sharded(x, devices)
-    >>> np.allclose(y, jnp.stack(x))
+    >>> np.allclose(y, jax.numpy.stack(x))
     True
 
     Passing a list of nested container objects with arrays at the leaves for
     ``shards`` corresponds to stacking the shards at each leaf. This requires
     all entries in the list to have the same tree structure:
 
-    >>> x = [(i, jnp.arange(i, i + 4)) for i in range(len(devices))]
+    >>> x = [(i, jax.numpy.arange(i, i + 4)) for i in range(len(devices))]
     >>> y = jax.device_put_sharded(x, devices)
     >>> type(y)
     <class 'tuple'>
@@ -2126,11 +2126,11 @@ def device_put_replicated(x: Any, devices: Sequence[xc.Device]):
   Examples:
     Passing an array:
 
-    >>> from jax import api, numpy as jnp
+    >>> import jax
     >>> devices = jax.local_devices()
-    >>> x = jnp.array([1., 2., 3.])
-    >>> y = api.device_put_replicated(x, devices)
-    >>> np.allclose(y, jnp.stack([x for _ in devices]))
+    >>> x = jax.numpy.array([1., 2., 3.])
+    >>> y = jax.device_put_replicated(x, devices)
+    >>> np.allclose(y, jax.numpy.stack([x for _ in devices]))
     True
 
   See also:

--- a/jax/api.py
+++ b/jax/api.py
@@ -2143,7 +2143,8 @@ def device_put_replicated(x: Any, devices: Sequence[xc.Device]):
   def _device_put_replicated(x) -> pxla.ShardedDeviceArray:
     aval = core.unmapped_aval(len(devices), 0,
                               core.raise_to_shaped(core.get_aval(x)))
-    buf, = xla.device_put(x, devices[0])  # assuming single-buf repr
+    assert isinstance(aval, core.ShapedArray) and aval._num_buffers == 1
+    buf, = xla.device_put(x, devices[0])
     rest_bufs = [buf.copy_to_device(d) for d in devices[1:]]
     return pxla.ShardedDeviceArray(aval, [buf, *rest_bufs])
   return tree_map(_device_put_replicated, x)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -710,25 +710,6 @@ class APITest(jtu.JaxTestCase):
       x = api.device_put(val, device=cpu_device)
       self.assertEqual(x.device_buffer.device(), cpu_device)
 
-  def test_device_put_sharded_array(self):
-    devices = api.local_devices()
-    n_devices = len(devices)
-    x = [np.arange(i, i + 4) for i in range(n_devices)]
-    y = api.device_put_sharded(x, devices)
-    self.assertEqual(len(y.device_buffers), len(devices))
-    self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertAllClose(y, jnp.stack(x))
-
-  def test_device_put_sharded_pytree(self):
-    devices = api.local_devices()
-    n_devices = len(devices)
-    x = [(i, np.arange(i, i + 4)) for i in range(n_devices)]
-    y1, y2 = api.device_put_sharded(x, devices)
-    self.assertAllClose(y1, jnp.array([a for a, _ in x]))
-    self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
-    self.assertAllClose(y2, jnp.vstack([b for _, b in x]))
-    self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
-
   @jtu.skip_on_devices("tpu")
   def test_jacobian(self):
     R = np.random.RandomState(0).randn

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2051,7 +2051,7 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertArrayEqual(y, jnp.stack(x))
+    self.assertArraysEqual(y, jnp.stack(x))
 
   def test_device_put_sharded_pytree(self):
     devices = jax.local_devices()
@@ -2059,10 +2059,10 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     x = [(i, np.arange(i, i + 4)) for i in range(n_devices)]
     y1, y2 = jax.device_put_sharded(x, devices)
     self.assertIsInstance(y1, pxla.ShardedDeviceArray)
-    self.assertArrayEqual(y1, jnp.array([a for a, _ in x]))
+    self.assertArraysEqual(y1, jnp.array([a for a, _ in x]))
     self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
     self.assertIsInstance(y2, pxla.ShardedDeviceArray)
-    self.assertArrayEqual(y2, jnp.vstack([b for _, b in x]))
+    self.assertArraysEqual(y2, jnp.vstack([b for _, b in x]))
     self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
 
   def test_device_put_replicated_array(self):
@@ -2072,7 +2072,7 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertArrayEqual(y, np.stack([x for _ in devices]))
+    self.assertArraysEqual(y, np.stack([x for _ in devices]))
 
   def test_device_put_replicated_pytree(self):
     devices = jax.local_devices()
@@ -2084,12 +2084,12 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y1, pxla.ShardedDeviceArray)
     self.assertEqual(len(y1.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
-    self.assertArrayEqual(y1, np.stack([xs['a'] for _ in devices]))
+    self.assertArraysEqual(y1, np.stack([xs['a'] for _ in devices]))
 
     self.assertIsInstance(y2, pxla.ShardedDeviceArray)
     self.assertEqual(len(y2.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
-    self.assertArrayEqual(y2, np.stack([xs['b'] for _ in devices]))
+    self.assertArraysEqual(y2, np.stack([xs['b'] for _ in devices]))
 
 
 class SpecToIndicesTest(jtu.JaxTestCase):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2067,7 +2067,6 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
 
   def test_device_put_replicated_array(self):
     devices = jax.local_devices()
-    n_devices = len(devices)
     x = np.arange(1, 5)
     y = jax.device_put_replicated(x, devices)
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
@@ -2077,7 +2076,6 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
 
   def test_device_put_replicated_pytree(self):
     devices = jax.local_devices()
-    n_devices = len(devices)
     xs = {'a': np.arange(1, 5), 'b': np.arange(3)}
     ys = jax.device_put_replicated(xs, devices)
     self.assertIsInstance(ys, dict)

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2051,7 +2051,7 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertAllClose(y, jnp.stack(x))
+    self.assertArrayEqual(y, jnp.stack(x))
 
   def test_device_put_sharded_pytree(self):
     devices = jax.local_devices()
@@ -2059,10 +2059,10 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     x = [(i, np.arange(i, i + 4)) for i in range(n_devices)]
     y1, y2 = jax.device_put_sharded(x, devices)
     self.assertIsInstance(y1, pxla.ShardedDeviceArray)
-    self.assertAllClose(y1, jnp.array([a for a, _ in x]))
+    self.assertArrayEqual(y1, jnp.array([a for a, _ in x]))
     self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
     self.assertIsInstance(y2, pxla.ShardedDeviceArray)
-    self.assertAllClose(y2, jnp.vstack([b for _, b in x]))
+    self.assertArrayEqual(y2, jnp.vstack([b for _, b in x]))
     self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
 
   def test_device_put_replicated_array(self):
@@ -2073,7 +2073,7 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
     self.assertEqual(len(y.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y.device_buffers, devices)))
-    self.assertAllClose(y, np.stack([x for _ in devices]))
+    self.assertArrayEqual(y, np.stack([x for _ in devices]))
 
   def test_device_put_replicated_pytree(self):
     devices = jax.local_devices()
@@ -2086,12 +2086,12 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
     self.assertIsInstance(y1, pxla.ShardedDeviceArray)
     self.assertEqual(len(y1.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y1.device_buffers, devices)))
-    self.assertAllClose(y1, np.stack([xs['a'] for _ in devices]))
+    self.assertArrayEqual(y1, np.stack([xs['a'] for _ in devices]))
 
     self.assertIsInstance(y2, pxla.ShardedDeviceArray)
     self.assertEqual(len(y2.device_buffers), len(devices))
     self.assertTrue(all(b.device() == d for b, d in zip(y2.device_buffers, devices)))
-    self.assertAllClose(y2, np.stack([xs['b'] for _ in devices]))
+    self.assertArrayEqual(y2, np.stack([xs['b'] for _ in devices]))
 
 
 class SpecToIndicesTest(jtu.JaxTestCase):


### PR DESCRIPTION
Add `jax.device_put_replicated`. Also move tests for `device_put_sharded` into pmap_test.py, since that file tests with multiple devices even in our OSS CI. Add both `device_put_replicated` and `device_put_sharded` to jax/__init__.py so they can be used as `jax.device_put_replicated` and `jax.device_put_sharded`.

DIFFBASE=#5101