### PR TITLE
Add support for linear algebra ops on ROCm using rocBLAS/rocSolver

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -15,6 +15,7 @@
 # JAX is Autograd and XLA
 
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "if_not_windows")
 
 licenses(["notice"])  # Apache 2
@@ -36,6 +37,8 @@ py_binary(
         "//jaxlib:cublas_kernels",
         "//jaxlib:cusolver_kernels",
         "//jaxlib:cuda_prng_kernels",
+    ]) + if_rocm([
+        "//jaxlib:rocblas_kernels",
     ]),
     deps = ["@bazel_tools//tools/python/runfiles"],
 )

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -144,9 +144,13 @@ def prepare_wheel(sources_path):
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cusolver_kernels.pyd"))
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cublas_kernels.pyd"))
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cuda_prng_kernels.pyd"))
+  if r.Rlocation("__main__/jaxlib/cusolver.py") is not None:
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cusolver.py"))
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cuda_prng.py"))
+  if r.Rlocation("__main__/jaxlib/rocblas_kernels.so") is not None:
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/rocblas_kernels.so"))
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/rocsolver.py"))
   copy_to_jaxlib(r.Rlocation("__main__/jaxlib/version.py"))
-  copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cusolver.py"))
-  copy_to_jaxlib(r.Rlocation("__main__/jaxlib/cuda_prng.py"))
 
   if _is_windows():
     copy_to_jaxlib(r.Rlocation("org_tensorflow/tensorflow/compiler/xla/python/xla_extension.pyd"))

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -32,7 +32,9 @@ from jax._src.lax.lax import (
     _input_dtype, _broadcasting_select)
 from jax._src.lax import lax as lax_internal
 from jax.lib import lapack
+
 from jax.lib import cusolver
+from jax.lib import rocsolver
 
 from jax.lib import xla_client
 from jax.lib import xla_bridge as xb
@@ -330,8 +332,13 @@ def _cholesky_cpu_gpu_translation_rule(potrf_impl, c, operand):
 xla.backend_specific_translations['cpu'][cholesky_p] = partial(
   _cholesky_cpu_gpu_translation_rule, lapack.potrf)
 
-xla.backend_specific_translations['gpu'][cholesky_p] = partial(
-  _cholesky_cpu_gpu_translation_rule, cusolver.potrf)
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][cholesky_p] = partial(
+    _cholesky_cpu_gpu_translation_rule, cusolver.potrf)
+
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][cholesky_p] = partial(
+    _cholesky_cpu_gpu_translation_rule, rocsolver.potrf)
 
 # Asymmetric eigendecomposition
 
@@ -520,10 +527,13 @@ _cpu_syevd = lapack.syevd
 xla.backend_specific_translations['cpu'][eigh_p] = partial(
   _eigh_cpu_gpu_translation_rule, _cpu_syevd)
 
-xla.backend_specific_translations['gpu'][eigh_p] = partial(
-  _eigh_cpu_gpu_translation_rule, cusolver.syevd)
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][eigh_p] = partial(
+    _eigh_cpu_gpu_translation_rule, cusolver.syevd)
 
-
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][eigh_p] = partial(
+    _eigh_cpu_gpu_translation_rule, rocsolver.syevd)
 
 
 triangular_solve_dtype_rule = partial(
@@ -671,7 +681,7 @@ def _triangular_solve_cpu_translation_rule(
 xla.backend_specific_translations['cpu'][triangular_solve_p] = \
   _triangular_solve_cpu_translation_rule
 
-def _triangular_solve_gpu_translation_rule(
+def _triangular_solve_gpu_translation_rule(trsm_impl,
     c, a, b, left_side, lower, transpose_a, conjugate_a, unit_diagonal):
   shape = c.get_shape(a)
   dims = shape.dimensions()
@@ -681,7 +691,7 @@ def _triangular_solve_gpu_translation_rule(
     a = xops.Conj(a)
     conjugate_a = False
   if batch > 1 and m <= 32 and n <= 32:
-    return cusolver.trsm(
+    return trsm_impl(
       c, a, b, left_side, lower, transpose_a,
       conjugate_a, unit_diagonal)
   else:
@@ -694,8 +704,13 @@ def _triangular_solve_gpu_translation_rule(
     return xops.TriangularSolve(a, b, left_side, lower, unit_diagonal,
                                 transpose)
 
-xla.backend_specific_translations['gpu'][triangular_solve_p] = \
-    _triangular_solve_gpu_translation_rule
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][triangular_solve_p] = \
+      partial(_triangular_solve_gpu_translation_rule, cusolver.trsm)
+
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][triangular_solve_p] = \
+      partial(_triangular_solve_gpu_translation_rule, rocsolver.trsm)
 
 # LU decomposition
 
@@ -889,8 +904,13 @@ batching.primitive_batchers[lu_p] = _lu_batching_rule
 xla.backend_specific_translations['cpu'][lu_p] = partial(
   _lu_cpu_gpu_translation_rule, lapack.getrf)
 
-xla.backend_specific_translations['gpu'][lu_p] = partial(
-  _lu_cpu_gpu_translation_rule, cusolver.getrf)
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][lu_p] = partial(
+    _lu_cpu_gpu_translation_rule, cusolver.getrf)
+
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][lu_p] = partial(
+    _lu_cpu_gpu_translation_rule, rocsolver.getrf)
 
 xla.backend_specific_translations['tpu'][lu_p] = _lu_tpu_translation_rule
 
@@ -1058,14 +1078,17 @@ def _qr_cpu_gpu_translation_rule(geqrf_impl, orgqr_impl, c, operand,
     q = xops.Pad(r, xops.Constant(c, np.array(0, dtype=shape.element_type())),
                  xla_client.make_padding_config(padding_config))
     q, info_orgqr = orgqr_impl(c, q, tau)
+  if info_geqrf is not None:
+    ok = xops.And(
+      xops.Eq(info_geqrf, xops.ConstantLiteral(c, np.array(0, np.int32))),
+      xops.Eq(info_orgqr, xops.ConstantLiteral(c, np.array(0, np.int32))))
+    q = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), q,
+                             _nan_like(c, q))
+    r = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), r,
+                             _nan_like(c, r))
+  else:
+    pass # rocsolver does not return info
 
-  ok = xops.And(
-    xops.Eq(info_geqrf, xops.ConstantLiteral(c, np.array(0, np.int32))),
-    xops.Eq(info_orgqr, xops.ConstantLiteral(c, np.array(0, np.int32))))
-  q = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), q,
-                           _nan_like(c, q))
-  r = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), r,
-                           _nan_like(c, r))
   r = xla.lower_fun(jnp.triu, multiple_results=False)(c, r)
   return xops.Tuple(c, [q, r])
 
@@ -1080,8 +1103,13 @@ batching.primitive_batchers[qr_p] = qr_batching_rule
 xla.backend_specific_translations['cpu'][qr_p] = partial(
   _qr_cpu_gpu_translation_rule, lapack.geqrf, lapack.orgqr)
 
-xla.backend_specific_translations['gpu'][qr_p] = partial(
-  _qr_cpu_gpu_translation_rule, cusolver.geqrf, cusolver.orgqr)
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][qr_p] = partial(
+    _qr_cpu_gpu_translation_rule, cusolver.geqrf, cusolver.orgqr)
+
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][qr_p] = partial(
+    _qr_cpu_gpu_translation_rule, rocsolver.geqrf, rocsolver.orgqr)
 
 
 # Singular value decomposition
@@ -1166,17 +1194,23 @@ def _svd_cpu_gpu_translation_rule(gesvd_impl, c, operand, full_matrices, compute
   s, u, vt, info = gesvd_impl(c, operand,
                               full_matrices=full_matrices,
                               compute_uv=compute_uv)
-  ok = xops.Eq(info, xops.ConstantLiteral(c, np.array(0, np.int32)))
-  s = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), s,
-                           _nan_like(c, s))
+  if info is not None:
+    ok = xops.Eq(info, xops.ConstantLiteral(c, np.array(0, np.int32)))
+    s = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), s,
+                             _nan_like(c, s))
+  else:
+    pass # rocsolver does not return info
 
   result = [s]
 
   if compute_uv:
-    u = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), u,
-                             _nan_like(c, u))
-    vt = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vt,
-                              _nan_like(c, vt))
+    if info is not None:
+      u = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), u,
+                               _nan_like(c, u))
+      vt = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vt,
+                                _nan_like(c, vt))
+    else:
+      pass # rocsolver does not return info
     result += [u, vt]
 
   return xops.Tuple(c, result)
@@ -1203,5 +1237,10 @@ xla.translations[svd_p] = svd_translation_rule
 xla.backend_specific_translations['cpu'][svd_p] = partial(
   _svd_cpu_gpu_translation_rule, lapack.gesdd)
 
-xla.backend_specific_translations['gpu'][svd_p] = partial(
-  _svd_cpu_gpu_translation_rule, cusolver.gesvd)
+if cusolver is not None:
+  xla.backend_specific_translations['gpu'][svd_p] = partial(
+    _svd_cpu_gpu_translation_rule, cusolver.gesvd)
+
+if rocsolver is not None:
+  xla.backend_specific_translations['gpu'][svd_p] = partial(
+    _svd_cpu_gpu_translation_rule, rocsolver.gesvd)

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -16,7 +16,7 @@
 # checking on import.
 
 __all__ = [
-  'cuda_prng', 'cusolver', 'jaxlib', 'lapack',
+  'cuda_prng', 'cusolver', 'rocsolver', 'jaxlib', 'lapack',
   'pytree', 'tpu_client', 'version', 'xla_client'
 ]
 
@@ -57,7 +57,17 @@ if version <  (0, 1, 53):
 else:
   pytree = xla_client._xla.pytree
   jax_jit = xla_client._xla.jax_jit
-from jaxlib import cusolver
+
+try:
+  from jaxlib import cusolver
+except ImportError:
+  cusolver = None
+
+try:
+  from jaxlib import rocsolver
+except ImportError:
+  rocsolver = None
+
 try:
   from jaxlib import cuda_prng
 except ImportError:

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -16,7 +16,8 @@
 
 load("@org_tensorflow//tensorflow/core/platform/default:build_config.bzl", "pyx_library")
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "pybind_extension")
-load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "cuda_library", "if_cuda_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "rocm_library", "if_rocm_is_configured")
 load("@flatbuffers//:build_defs.bzl", "flatbuffer_cc_library", "flatbuffer_py_library")
 
 licenses(["notice"])
@@ -65,9 +66,9 @@ cc_library(
 )
 
 cc_library(
-    name = "gpu_kernel_helpers",
-    srcs = ["gpu_kernel_helpers.cc"],
-    hdrs = ["gpu_kernel_helpers.h"],
+    name = "cuda_gpu_kernel_helpers",
+    srcs = ["cuda_gpu_kernel_helpers.cc"],
+    hdrs = ["cuda_gpu_kernel_helpers.h"],
     copts = [
         "-fexceptions",
     ],
@@ -80,6 +81,23 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "rocm_gpu_kernel_helpers",
+    srcs = ["rocm_gpu_kernel_helpers.cc"],
+    hdrs = ["rocm_gpu_kernel_helpers.h"],
+    copts = [
+        "-fexceptions",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@local_config_rocm//rocm:rocm_headers",
+    ],
+)
+
+
 pyx_library(
     name = "lapack",
     srcs = ["lapack.pyx"],
@@ -89,13 +107,16 @@ pyx_library(
 py_library(
     name = "jaxlib",
     srcs = [
-        "cuda_prng.py",
-        "cusolver.py",
         "init.py",
         "pocketfft.py",
         "setup.py",
         "version.py",
-    ],
+        ] + if_cuda_is_configured([
+         "cuda_prng.py",
+         "cusolver.py",
+        ]) + if_rocm_is_configured ([
+         "rocsolver.py",
+        ]),
     deps = [":pocketfft_flatbuffers_py"],
 )
 
@@ -118,7 +139,7 @@ pybind_extension(
     features = ["-use_header_modules"],
     module_name = "cublas_kernels",
     deps = [
-        ":gpu_kernel_helpers",
+        ":cuda_gpu_kernel_helpers",
         ":handle_pool",
         ":kernel_pybind11_helpers",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cublas_lib",
@@ -148,7 +169,7 @@ pybind_extension(
     features = ["-use_header_modules"],
     module_name = "cusolver_kernels",
     deps = [
-        ":gpu_kernel_helpers",
+        ":cuda_gpu_kernel_helpers",
         ":handle_pool",
         ":kernel_pybind11_helpers",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
@@ -172,7 +193,7 @@ cuda_library(
     srcs = ["cuda_prng_kernels.cu.cc"],
     hdrs = ["cuda_prng_kernels.h"],
     deps = [
-        ":gpu_kernel_helpers",
+        ":cuda_gpu_kernel_helpers",
         ":kernel_helpers",
         "@local_config_cuda//cuda:cuda_headers",
     ],
@@ -192,6 +213,33 @@ pybind_extension(
         ":kernel_pybind11_helpers",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@local_config_cuda//cuda:cuda_headers",
+        "@pybind11",
+    ],
+)
+
+pybind_extension(
+    name = "rocblas_kernels",
+    srcs = ["rocblas.cc"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    module_name = "rocblas_kernels",
+    deps = [
+        ":rocm_gpu_kernel_helpers",
+        ":handle_pool",
+        ":kernel_pybind11_helpers",
+        "@com_google_absl//absl/algorithm:container",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/hash",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/synchronization",
+        "@local_config_rocm//rocm:rocm",
         "@pybind11",
     ],
 )

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -52,6 +52,19 @@ cc_library(
 )
 
 cc_library(
+    name = "handle_pool",
+    hdrs = ["handle_pool.h"],
+    copts = [
+        "-fexceptions",
+        "-fno-strict-aliasing",
+    ],
+    features = ["-use_header_modules"],
+    deps = [
+        "@com_google_absl//absl/base",
+    ],
+)
+
+cc_library(
     name = "gpu_kernel_helpers",
     srcs = ["gpu_kernel_helpers.cc"],
     hdrs = ["gpu_kernel_helpers.h"],
@@ -106,6 +119,7 @@ pybind_extension(
     module_name = "cublas_kernels",
     deps = [
         ":gpu_kernel_helpers",
+        ":handle_pool",
         ":kernel_pybind11_helpers",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cublas_lib",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
@@ -135,6 +149,7 @@ pybind_extension(
     module_name = "cusolver_kernels",
     deps = [
         ":gpu_kernel_helpers",
+        ":handle_pool",
         ":kernel_pybind11_helpers",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cudart_stub",
         "@org_tensorflow//tensorflow/stream_executor/cuda:cusolver_lib",

--- a/jaxlib/cublas.cc
+++ b/jaxlib/cublas.cc
@@ -23,15 +23,15 @@ limitations under the License.
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
-#include "third_party/gpus/cuda/include/cublas_v2.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "include/pybind11/numpy.h"
 #include "include/pybind11/pybind11.h"
 #include "include/pybind11/stl.h"
-#include "jaxlib/gpu_kernel_helpers.h"
+#include "jaxlib/cuda_gpu_kernel_helpers.h"
 #include "jaxlib/handle_pool.h"
 #include "jaxlib/kernel_pybind11_helpers.h"
+#include "third_party/gpus/cuda/include/cublas_v2.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 
 namespace jax {
 namespace {

--- a/jaxlib/cuda_gpu_kernel_helpers.cc
+++ b/jaxlib/cuda_gpu_kernel_helpers.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "jaxlib/gpu_kernel_helpers.h"
+#include "jaxlib/cuda_gpu_kernel_helpers.h"
 
 #include <stdexcept>
 

--- a/jaxlib/cuda_gpu_kernel_helpers.h
+++ b/jaxlib/cuda_gpu_kernel_helpers.h
@@ -1,0 +1,37 @@
+/* Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef JAXLIB_CUDA_GPU_KERNEL_HELPERS_H_
+#define JAXLIB_CUDA_KERNEL_HELPERS_H_
+
+#include <memory>
+
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+
+namespace jax {
+
+void ThrowIfError(cudaError_t error);
+
+// Builds an array of pointers to each array in a batch, in device memory.
+// Caution: the return value must be kept alive (e.g., via a stream
+// synchronization) until the copy enqueued by MakeBatchPointers on `stream`
+// completes.
+std::unique_ptr<void*[]> MakeBatchPointers(cudaStream_t stream, void* buffer,
+                                           void* dev_ptrs, int batch,
+                                           int batch_elem_size);
+
+}  // namespace jax
+
+#endif  // JAXLIB_CUDA_GPU_KERNEL_HELPERS_H_

--- a/jaxlib/cuda_prng.py
+++ b/jaxlib/cuda_prng.py
@@ -24,7 +24,7 @@ from jaxlib import xla_client
 try:
   from jaxlib import cuda_prng_kernels
   for _name, _value in cuda_prng_kernels.registrations().items():
-    xla_client.register_custom_call_target(_name, _value, platform="gpu")
+    xla_client.register_custom_call_target(_name, _value, platform="CUDA")
 except ImportError:
   pass
 

--- a/jaxlib/cuda_prng_kernels.cu.cc
+++ b/jaxlib/cuda_prng_kernels.cu.cc
@@ -17,7 +17,7 @@ limitations under the License.
 #include <cstddef>
 
 #include "jaxlib/cuda_prng_kernels.h"
-#include "jaxlib/gpu_kernel_helpers.h"
+#include "jaxlib/cuda_gpu_kernel_helpers.h"
 #include "jaxlib/kernel_helpers.h"
 
 namespace jax {

--- a/jaxlib/cusolver.cc
+++ b/jaxlib/cusolver.cc
@@ -25,15 +25,15 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
-#include "third_party/gpus/cuda/include/cusolverDn.h"
 #include "include/pybind11/numpy.h"
 #include "include/pybind11/pybind11.h"
 #include "include/pybind11/stl.h"
-#include "jaxlib/gpu_kernel_helpers.h"
+#include "jaxlib/cuda_gpu_kernel_helpers.h"
 #include "jaxlib/handle_pool.h"
 #include "jaxlib/kernel_pybind11_helpers.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "third_party/gpus/cuda/include/cusolverDn.h"
 
 namespace jax {
 namespace {

--- a/jaxlib/cusolver.py
+++ b/jaxlib/cusolver.py
@@ -23,14 +23,14 @@ from jaxlib import xla_client
 try:
   from jaxlib import cublas_kernels
   for _name, _value in cublas_kernels.registrations().items():
-    xla_client.register_custom_call_target(_name, _value, platform="gpu")
+    xla_client.register_custom_call_target(_name, _value, platform="CUDA")
 except ImportError:
   pass
 
 try:
   from jaxlib import cusolver_kernels
   for _name, _value in cusolver_kernels.registrations().items():
-    xla_client.register_custom_call_target(_name, _value, platform="gpu")
+    xla_client.register_custom_call_target(_name, _value, platform="CUDA")
 except ImportError:
   pass
 

--- a/jaxlib/handle_pool.h
+++ b/jaxlib/handle_pool.h
@@ -1,0 +1,103 @@
+/* Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef JAXLIB_HANDLE_POOL_H_
+#define JAXLIB_HANDLE_POOL_H_
+
+#include <vector>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+
+namespace jax {
+namespace {
+
+// To avoid creating cublas/cusolver contexts in the middle of execution, we
+// maintain a pool of them.
+template <typename HandleType, typename StreamType>
+class HandlePool {
+ public:
+  HandlePool() = default;
+
+  // RAII class representing a cublas/cusolver handle borrowed from the pool.
+  // Returns the handle to the pool on destruction.
+  class Handle {
+   public:
+    Handle() = default;
+    ~Handle() {
+      if (pool_) {
+        pool_->Return(handle_);
+      }
+    }
+
+    Handle(Handle const&) = delete;
+    Handle(Handle&& other) {
+      pool_ = other.pool_;
+      handle_ = other.handle_;
+      other.pool_ = nullptr;
+      other.handle_ = nullptr;
+    }
+    Handle& operator=(Handle const&) = delete;
+    Handle& operator=(Handle&& other) {
+      pool_ = other.pool_;
+      handle_ = other.handle_;
+      other.pool_ = nullptr;
+      other.handle_ = nullptr;
+      return *this;
+    }
+
+    HandleType get() { return handle_; }
+
+   private:
+    friend class HandlePool<HandleType, StreamType>;
+    Handle(HandlePool<HandleType, StreamType>* pool, HandleType handle)
+        : pool_(pool), handle_(handle) {}
+    HandlePool<HandleType, StreamType>* pool_ = nullptr;
+    HandleType handle_ = nullptr;
+  };
+
+  // Borrows a handle from the pool. If 'stream' is non-null, sets the stream
+  // associated with the handle.
+  static Handle Borrow(StreamType stream = nullptr);
+
+ private:
+  static HandlePool<HandleType, StreamType>* Instance();
+
+  void Return(HandleType handle);
+
+  absl::Mutex mu_;
+  std::vector<HandleType> handles_ ABSL_GUARDED_BY(mu_);
+};
+
+template <typename HandleType, typename StreamType>
+/*static*/ HandlePool<HandleType, StreamType>*
+HandlePool<HandleType, StreamType>::Instance() {
+  static auto* pool = new HandlePool<HandleType, StreamType>;
+  return pool;
+}
+
+template <typename HandleType, typename StreamType>
+void HandlePool<HandleType, StreamType>::Return(HandleType handle) {
+  absl::MutexLock lock(&mu_);
+  handles_.push_back(handle);
+}
+
+// template <typename HandleType, typename StreamType>
+// HandlePool<HandleType, StreamType>::Borrow(StreamType stream)
+
+}  // namespace
+}  // namespace jax
+
+#endif  // JAXLIB_HANDLE_POOL_H_

--- a/jaxlib/rocblas.cc
+++ b/jaxlib/rocblas.cc
@@ -1,0 +1,901 @@
+/* Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+
+#include "absl/base/casts.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
+#include "include/pybind11/numpy.h"
+#include "include/pybind11/pybind11.h"
+#include "include/pybind11/stl.h"
+#include "jaxlib/handle_pool.h"
+#include "jaxlib/kernel_pybind11_helpers.h"
+#include "jaxlib/rocm_gpu_kernel_helpers.h"
+#include "rocm/include/hip/hip_runtime.h"
+#include "rocm/include/hip/hip_runtime_api.h"
+#include "rocm/include/rocblas.h"
+#include "rocm/include/rocsolver.h"
+
+
+namespace jax {
+namespace {
+
+namespace py = pybind11;
+
+void ThrowIfErrorStatus(rocblas_status status) {
+  switch (status) {
+    case rocblas_status_success:
+      return;
+    default:
+      throw std::runtime_error(rocblas_status_to_string(status));
+  }
+}
+
+using rocBlasHandlePool = HandlePool<rocblas_handle, hipStream_t>;
+
+template <>
+/*static*/ rocBlasHandlePool::Handle rocBlasHandlePool::Borrow(
+    hipStream_t stream) {
+  rocBlasHandlePool* pool = Instance();
+  absl::MutexLock lock(&pool->mu_);
+  rocblas_handle handle;
+  if (pool->handles_.empty()) {
+    ThrowIfErrorStatus(rocblas_create_handle(&handle));
+  } else {
+    handle = pool->handles_.back();
+    pool->handles_.pop_back();
+  }
+  if (stream) {
+    ThrowIfErrorStatus(rocblas_set_stream(handle, stream));
+  }
+  return rocBlasHandlePool::Handle(pool, handle);
+}
+
+// Set of types known to Rocsolver.
+enum class Type {
+  F32,
+  F64,
+  C64,
+  C128,
+};
+
+// Converts a NumPy dtype to a Type.
+Type DtypeToType(const py::dtype& np_type) {
+  static auto* types = new absl::flat_hash_map<std::pair<char, int>, Type>({
+      {{'f', 4}, Type::F32},
+      {{'f', 8}, Type::F64},
+      {{'c', 8}, Type::C64},
+      {{'c', 16}, Type::C128},
+  });
+  auto it = types->find({np_type.kind(), np_type.itemsize()});
+  if (it == types->end()) {
+    throw std::invalid_argument(
+        absl::StrFormat("Unsupported dtype %s", py::repr(np_type)));
+  }
+  return it->second;
+}
+
+int SizeOfType(Type type) {
+  switch (type) {
+    case Type::F32:
+      return sizeof(float);
+    case Type::F64:
+      return sizeof(double);
+    case Type::C64:
+      return sizeof(rocblas_float_complex);
+    case Type::C128:
+      return sizeof(rocblas_double_complex);
+  }
+}
+
+// the buffers[] are all allocated in rocsolver.py
+// where the number of buffers and their size is determined / hardcoded as
+// expected here
+
+//##########################
+// rocblas
+//##########################
+
+// Batched triangular solve: Trsm
+
+struct TrsmDescriptor {
+  Type type;
+  int batch, m, n;
+  rocblas_side side;
+  rocblas_fill uplo;
+  rocblas_operation trans;
+  rocblas_diagonal diag;
+};
+
+// Returns the descriptor for a Trsm operation.
+std::pair<size_t, py::bytes> BuildTrsmDescriptor(const py::dtype& dtype,
+                                                 int batch, int m, int n,
+                                                 bool left_side, bool lower,
+                                                 bool trans_a, bool conj_a,
+                                                 bool unit_diagonal) {
+  std::int64_t lwork =
+      batch * sizeof(void*);  // number of bytes needed for the batch pointers
+  TrsmDescriptor desc;
+  desc.type = DtypeToType(dtype);
+  desc.batch = batch;
+  desc.m = m;
+  desc.n = n;
+  desc.side = left_side ? rocblas_side_left : rocblas_side_right;
+  desc.uplo = lower ? rocblas_fill_lower : rocblas_fill_upper;
+  desc.trans = trans_a ? (conj_a ? rocblas_operation_conjugate_transpose
+                                 : rocblas_operation_transpose)
+                       : rocblas_operation_none;
+  desc.diag = unit_diagonal ? rocblas_diagonal_unit : rocblas_diagonal_non_unit;
+  return {lwork, PackDescriptor(desc)};
+}
+
+void Trsm(hipStream_t stream, void** buffers, const char* opaque,
+          size_t opaque_len) {
+  const TrsmDescriptor& d =
+      *UnpackDescriptor<TrsmDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+
+  // b is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[2] != buffers[1]) {
+    ThrowIfError(hipMemcpyAsync(buffers[2], buffers[1],
+                                SizeOfType(d.type) * d.batch * d.m * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+  const int lda = d.side == rocblas_side_left ? d.m : d.n;
+  const int ldb = d.m;
+
+  if (d.batch == 1) {
+    switch (d.type) {
+      case Type::F32: {
+        float* a = static_cast<float*>(buffers[0]);
+        float* b = static_cast<float*>(buffers[2]);
+        const float alpha = 1.0f;
+        ThrowIfErrorStatus(rocblas_strsm(handle.get(), d.side, d.uplo, d.trans,
+                                         d.diag, d.m, d.n, &alpha,
+                                         const_cast<float*>(a), lda, b, ldb));
+        break;
+      }
+      case Type::F64: {
+        double* a = static_cast<double*>(buffers[0]);
+        double* b = static_cast<double*>(buffers[2]);
+        const double alpha = 1.0;
+        ThrowIfErrorStatus(rocblas_dtrsm(handle.get(), d.side, d.uplo, d.trans,
+                                         d.diag, d.m, d.n, &alpha,
+                                         const_cast<double*>(a), lda, b, ldb));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex* a =
+            static_cast<rocblas_float_complex*>(buffers[0]);
+        rocblas_float_complex* b =
+            static_cast<rocblas_float_complex*>(buffers[2]);
+        const rocblas_float_complex alpha = {1.0f, 0.0f};
+        ThrowIfErrorStatus(rocblas_ctrsm(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<rocblas_float_complex*>(a), lda, b, ldb));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex* a =
+            static_cast<rocblas_double_complex*>(buffers[0]);
+        rocblas_double_complex* b =
+            static_cast<rocblas_double_complex*>(buffers[2]);
+        const rocblas_double_complex alpha = {1.0d, 0.0d};
+        ThrowIfErrorStatus(rocblas_ztrsm(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<rocblas_double_complex*>(a), lda, b, ldb));
+        break;
+      }
+    }
+  } else {
+    auto a_batch_host =
+        MakeBatchPointers(stream, buffers[0], buffers[3], d.batch,
+                          SizeOfType(d.type) * lda * lda);
+    auto b_batch_host =
+        MakeBatchPointers(stream, buffers[2], buffers[4], d.batch,
+                          SizeOfType(d.type) * d.m * d.n);
+    // TODO(phawkins): ideally we would not need to synchronize here, but to
+    // avoid it we need a way to keep the host-side buffer alive until the copy
+    // completes.
+    ThrowIfError(hipStreamSynchronize(stream));
+
+    switch (d.type) {
+      case Type::F32: {
+        float** a_batch_ptrs = static_cast<float**>(buffers[3]);
+        float** b_batch_ptrs = static_cast<float**>(buffers[4]);
+        const float alpha = 1.0f;
+        ThrowIfErrorStatus(rocblas_strsm_batched(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<float**>(a_batch_ptrs), lda, b_batch_ptrs, ldb,
+            d.batch));
+        break;
+      }
+      case Type::F64: {
+        double** a_batch_ptrs = static_cast<double**>(buffers[3]);
+        double** b_batch_ptrs = static_cast<double**>(buffers[4]);
+        const double alpha = 1.0;
+        ThrowIfErrorStatus(rocblas_dtrsm_batched(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<double**>(a_batch_ptrs), lda, b_batch_ptrs, ldb,
+            d.batch));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex** a_batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[3]);
+        rocblas_float_complex** b_batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[4]);
+        const rocblas_float_complex alpha = {1.0f, 0.0f};
+        ThrowIfErrorStatus(rocblas_ctrsm_batched(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<rocblas_float_complex**>(a_batch_ptrs), lda,
+            b_batch_ptrs, ldb, d.batch));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex** a_batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[3]);
+        rocblas_double_complex** b_batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[4]);
+        const rocblas_double_complex alpha = {1.0d, 0.0d};
+        ThrowIfErrorStatus(rocblas_ztrsm_batched(
+            handle.get(), d.side, d.uplo, d.trans, d.diag, d.m, d.n, &alpha,
+            const_cast<rocblas_double_complex**>(a_batch_ptrs), lda,
+            b_batch_ptrs, ldb, d.batch));
+        break;
+      }
+    }
+  }
+}
+
+//##########################
+// rocsolver
+//##########################
+
+// potrf: Cholesky decomposition
+
+struct PotrfDescriptor {
+  Type type;
+  rocblas_fill uplo;
+  std::int64_t batch, n;
+};
+
+// Returns the descriptor for a potrf operation.
+std::pair<int, py::bytes> BuildPotrfDescriptor(const py::dtype& dtype,
+                                               bool lower, int b, int n) {
+  Type type = DtypeToType(dtype);
+  rocblas_fill uplo = lower ? rocblas_fill_lower : rocblas_fill_upper;
+  std::int64_t lwork =
+      b * sizeof(void*);  // number of bytes needed for the batch pointers
+  return {lwork, PackDescriptor(PotrfDescriptor{type, uplo, b, n})};
+}
+
+void Potrf(hipStream_t stream, void** buffers, const char* opaque,
+           size_t opaque_len) {
+  const PotrfDescriptor& d =
+      *UnpackDescriptor<PotrfDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+  // a is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[1] != buffers[0]) {
+    ThrowIfError(hipMemcpyAsync(buffers[1], buffers[0],
+                                SizeOfType(d.type) * d.batch * d.n * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+
+  int* info = static_cast<int*>(buffers[2]);
+  if (d.batch == 1) {
+    switch (d.type) {
+      case Type::F32: {
+        float* a = static_cast<float*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_spotrf(handle.get(), d.uplo, d.n, a, d.n, info));
+        break;
+      }
+      case Type::F64: {
+        double* a = static_cast<double*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_dpotrf(handle.get(), d.uplo, d.n, a, d.n, info));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex* a =
+            static_cast<rocblas_float_complex*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_cpotrf(handle.get(), d.uplo, d.n, a, d.n, info));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex* a =
+            static_cast<rocblas_double_complex*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_zpotrf(handle.get(), d.uplo, d.n, a, d.n, info));
+        break;
+      }
+    }
+  } else {
+    auto a_ptrs_host =
+        MakeBatchPointers(stream, buffers[1], buffers[3], d.batch,
+                          SizeOfType(d.type) * d.n * d.n);
+    // TODO(phawkins): ideally we would not need to synchronize here, but to
+    // avoid it we need a way to keep the host-side buffer alive until the copy
+    // completes.
+    ThrowIfError(hipStreamSynchronize(stream));
+
+    switch (d.type) {
+      case Type::F32: {
+        float** a_batch_ptrs = static_cast<float**>(buffers[3]);
+        ThrowIfErrorStatus(rocsolver_spotrf_batched(
+            handle.get(), d.uplo, d.n, a_batch_ptrs, d.n, info, d.batch));
+        break;
+      }
+      case Type::F64: {
+        double** a_batch_ptrs = static_cast<double**>(buffers[3]);
+        ThrowIfErrorStatus(rocsolver_dpotrf_batched(
+            handle.get(), d.uplo, d.n, a_batch_ptrs, d.n, info, d.batch));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex** a_batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[3]);
+        ThrowIfErrorStatus(rocsolver_cpotrf_batched(
+            handle.get(), d.uplo, d.n, a_batch_ptrs, d.n, info, d.batch));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex** a_batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[3]);
+        ThrowIfErrorStatus(rocsolver_zpotrf_batched(
+            handle.get(), d.uplo, d.n, a_batch_ptrs, d.n, info, d.batch));
+        break;
+      }
+    }
+  }
+}
+
+// getrf: LU decomposition
+
+struct GetrfDescriptor {
+  Type type;
+  int batch, m, n;
+};
+
+// Returns the descriptor for a getrf operation.
+std::pair<int, py::bytes> BuildGetrfDescriptor(const py::dtype& dtype, int b,
+                                               int m, int n) {
+  Type type = DtypeToType(dtype);
+  std::int64_t lwork =
+      b * sizeof(void*);  // number of bytes needed for the batch pointers
+  return {lwork, PackDescriptor(GetrfDescriptor{type, b, m, n})};
+}
+
+void Getrf(hipStream_t stream, void** buffers, const char* opaque,
+           size_t opaque_len) {
+  const GetrfDescriptor& d =
+      *UnpackDescriptor<GetrfDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+
+  // a is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[1] != buffers[0]) {
+    ThrowIfError(hipMemcpyAsync(buffers[1], buffers[0],
+                                SizeOfType(d.type) * d.batch * d.m * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+
+  int* ipiv = static_cast<int*>(buffers[2]);
+  int* info = static_cast<int*>(buffers[3]);
+
+  if (d.batch == 1) {
+    switch (d.type) {
+      case Type::F32: {
+        float* a = static_cast<float*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_sgetrf(handle.get(), d.m, d.n, a, d.m, ipiv, info));
+        break;
+      }
+      case Type::F64: {
+        double* a = static_cast<double*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_dgetrf(handle.get(), d.m, d.n, a, d.m, ipiv, info));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex* a =
+            static_cast<rocblas_float_complex*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_cgetrf(handle.get(), d.m, d.n, a, d.m, ipiv, info));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex* a =
+            static_cast<rocblas_double_complex*>(buffers[1]);
+        ThrowIfErrorStatus(
+            rocsolver_zgetrf(handle.get(), d.m, d.n, a, d.m, ipiv, info));
+        break;
+      }
+    }
+  } else {
+    auto a_ptrs_host =
+        MakeBatchPointers(stream, buffers[1], buffers[4], d.batch,
+                          SizeOfType(d.type) * d.m * d.n);
+    // TODO(phawkins): ideally we would not need to synchronize here, but to
+    // avoid it we need a way to keep the host-side buffer alive until the copy
+    // completes.
+    ThrowIfError(hipStreamSynchronize(stream));
+
+    switch (d.type) {
+      case Type::F32: {
+        float** batch_ptrs = static_cast<float**>(buffers[4]);
+        ThrowIfErrorStatus(
+            rocsolver_sgetrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     ipiv, std::min(d.m, d.n), info, d.batch));
+        break;
+      }
+      case Type::F64: {
+        double** batch_ptrs = static_cast<double**>(buffers[4]);
+        ThrowIfErrorStatus(
+            rocsolver_dgetrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     ipiv, std::min(d.m, d.n), info, d.batch));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex** batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[4]);
+        ThrowIfErrorStatus(
+            rocsolver_cgetrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     ipiv, std::min(d.m, d.n), info, d.batch));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex** batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[4]);
+        ThrowIfErrorStatus(
+            rocsolver_zgetrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     ipiv, std::min(d.m, d.n), info, d.batch));
+        break;
+      }
+    }
+  }
+}
+
+// geqrf: QR decomposition
+
+struct GeqrfDescriptor {
+  Type type;
+  int batch, m, n;
+};
+
+std::pair<int, py::bytes> BuildGeqrfDescriptor(const py::dtype& dtype, int b,
+                                               int m, int n) {
+  Type type = DtypeToType(dtype);
+  std::int64_t lwork =
+      b * sizeof(void*);  // number of bytes needed for the batch pointers
+  return {lwork, PackDescriptor(GeqrfDescriptor{type, b, m, n})};
+}
+
+void Geqrf(hipStream_t stream, void** buffers, const char* opaque,
+           size_t opaque_len) {
+  const GeqrfDescriptor& d =
+      *UnpackDescriptor<GeqrfDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+
+  // a is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[1] != buffers[0]) {
+    ThrowIfError(hipMemcpyAsync(buffers[1], buffers[0],
+                                SizeOfType(d.type) * d.batch * d.m * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+
+  // here tau is tau
+
+  if (d.batch == 1) {
+    switch (d.type) {
+      case Type::F32: {
+        float* a = static_cast<float*>(buffers[1]);
+        float* tau = static_cast<float*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_sgeqrf(handle.get(), d.m, d.n, a, d.m, tau));
+        break;
+      }
+      case Type::F64: {
+        double* a = static_cast<double*>(buffers[1]);
+        double* tau = static_cast<double*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_dgeqrf(handle.get(), d.m, d.n, a, d.m, tau));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex* a =
+            static_cast<rocblas_float_complex*>(buffers[1]);
+        rocblas_float_complex* tau =
+            static_cast<rocblas_float_complex*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_cgeqrf(handle.get(), d.m, d.n, a, d.m, tau));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex* a =
+            static_cast<rocblas_double_complex*>(buffers[1]);
+        rocblas_double_complex* tau =
+            static_cast<rocblas_double_complex*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_zgeqrf(handle.get(), d.m, d.n, a, d.m, tau));
+        break;
+      }
+    }
+  } else {
+    auto a_ptrs_host =
+        MakeBatchPointers(stream, buffers[1], buffers[3], d.batch,
+                          SizeOfType(d.type) * d.m * d.n);
+    // TODO(phawkins): ideally we would not need to synchronize here, but to
+    // avoid it we need a way to keep the host-side buffer alive until the copy
+    // completes.
+    ThrowIfError(hipStreamSynchronize(stream));
+
+    switch (d.type) {
+      case Type::F32: {
+        float** batch_ptrs = static_cast<float**>(buffers[3]);
+        float* tau = static_cast<float*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_sgeqrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     tau, std::min(d.m, d.n), d.batch));
+        break;
+      }
+      case Type::F64: {
+        double** batch_ptrs = static_cast<double**>(buffers[3]);
+        double* tau = static_cast<double*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_dgeqrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     tau, std::min(d.m, d.n), d.batch));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex** batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[3]);
+        rocblas_float_complex* tau =
+            static_cast<rocblas_float_complex*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_cgeqrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     tau, std::min(d.m, d.n), d.batch));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex** batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[3]);
+        rocblas_double_complex* tau =
+            static_cast<rocblas_double_complex*>(buffers[2]);
+        ThrowIfErrorStatus(
+            rocsolver_zgeqrf_batched(handle.get(), d.m, d.n, batch_ptrs, d.m,
+                                     tau, std::min(d.m, d.n), d.batch));
+        break;
+      }
+    }
+  }
+}
+
+// orgqr/ungqr: apply elementary Householder transformations
+struct OrgqrDescriptor {
+  Type type;
+  int batch, m, n, k;
+};
+
+std::pair<int, py::bytes> BuildOrgqrDescriptor(const py::dtype& dtype, int b,
+                                               int m, int n, int k) {
+  Type type = DtypeToType(dtype);
+  std::int64_t lwork = 0;
+  return {lwork, PackDescriptor(OrgqrDescriptor{type, b, m, n, k})};
+}
+
+void Orgqr(hipStream_t stream, void** buffers, const char* opaque,
+           size_t opaque_len) {
+  const OrgqrDescriptor& d =
+      *UnpackDescriptor<OrgqrDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+
+  // a is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[2] != buffers[0]) {
+    ThrowIfError(hipMemcpyAsync(buffers[2], buffers[0],
+                                SizeOfType(d.type) * d.batch * d.m * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+
+  switch (d.type) {
+      // orgqr
+
+    case Type::F32: {
+      float* a = static_cast<float*>(buffers[2]);
+      float* tau = static_cast<float*>(buffers[1]);
+      for (int i = 0; i < d.batch; ++i) {
+        ThrowIfErrorStatus(
+            rocsolver_sorgqr(handle.get(), d.m, d.n, d.k, a, d.m, tau));
+        a += d.m * d.n;
+        tau += d.k;
+      }
+      break;
+    }
+    case Type::F64: {
+      double* a = static_cast<double*>(buffers[2]);
+      double* tau = static_cast<double*>(buffers[1]);
+      for (int i = 0; i < d.batch; ++i) {
+        ThrowIfErrorStatus(
+            rocsolver_dorgqr(handle.get(), d.m, d.n, d.k, a, d.m, tau));
+        a += d.m * d.n;
+        tau += d.k;
+      }
+      break;
+    }
+
+      // ungqr
+
+    case Type::C64: {
+      rocblas_float_complex* a =
+          static_cast<rocblas_float_complex*>(buffers[2]);
+      rocblas_float_complex* tau =
+          static_cast<rocblas_float_complex*>(buffers[1]);
+      for (int i = 0; i < d.batch; ++i) {
+        ThrowIfErrorStatus(
+            rocsolver_cungqr(handle.get(), d.m, d.n, d.k, a, d.m, tau));
+        a += d.m * d.n;
+        tau += d.k;
+      }
+      break;
+    }
+    case Type::C128: {
+      rocblas_double_complex* a =
+          static_cast<rocblas_double_complex*>(buffers[2]);
+      rocblas_double_complex* tau =
+          static_cast<rocblas_double_complex*>(buffers[1]);
+      for (int i = 0; i < d.batch; ++i) {
+        ThrowIfErrorStatus(
+            rocsolver_zungqr(handle.get(), d.m, d.n, d.k, a, d.m, tau));
+        a += d.m * d.n;
+        tau += d.k;
+      }
+      break;
+    }
+  }
+}
+
+// Symmetric (Hermitian) eigendecomposition, QR algorithm: syevd/heevd
+// not implemented yet in rocsolver
+
+// Symmetric (Hermitian) eigendecomposition, Jacobi algorithm: syevj/heevj
+// not implemented yet in rocsolver
+
+// Singular value decomposition using QR algorithm: gesvd
+
+struct GesvdDescriptor {
+  Type type;
+  int batch, m, n;
+  rocblas_svect jobu, jobvt;
+};
+
+std::pair<int, py::bytes> BuildGesvdDescriptor(const py::dtype& dtype, int b,
+                                               int m, int n, bool compute_uv,
+                                               bool full_matrices) {
+  Type type = DtypeToType(dtype);
+
+  std::int64_t lwork =
+      b * sizeof(void*);  // number of bytes needed for the batch pointers
+
+  rocblas_svect jobu, jobvt;
+  if (compute_uv) {
+    if (full_matrices) {
+      jobu = jobvt = rocblas_svect_all;
+    } else {
+      jobu = jobvt = rocblas_svect_singular;
+    }
+  } else {
+    jobu = jobvt = rocblas_svect_none;
+  }
+
+  return {lwork, PackDescriptor(GesvdDescriptor{type, b, m, n, jobu, jobvt})};
+}
+
+void Gesvd(hipStream_t stream, void** buffers, const char* opaque,
+           size_t opaque_len) {
+  const GesvdDescriptor& d =
+      *UnpackDescriptor<GesvdDescriptor>(opaque, opaque_len);
+  auto handle = rocBlasHandlePool::Borrow(stream);
+
+  // a is INOUT, so we copy the input to the output and use that if they are not
+  // already the same
+  if (buffers[1] != buffers[0]) {
+    ThrowIfError(hipMemcpyAsync(buffers[1], buffers[0],
+                                SizeOfType(d.type) * d.batch * d.m * d.n,
+                                hipMemcpyDeviceToDevice, stream));
+  }
+
+  int* info = static_cast<int*>(buffers[5]);
+
+  const rocblas_int lda = d.m;
+  const rocblas_int ldu = d.m;
+  const rocblas_int ldv = d.n;
+
+  if (d.batch == 1) {
+    switch (d.type) {
+      case Type::F32: {
+        float* a = static_cast<float*>(buffers[1]);
+        float* s = static_cast<float*>(buffers[2]);
+        float* u = static_cast<float*>(buffers[3]);
+        float* vt = static_cast<float*>(buffers[4]);
+        float* e = static_cast<float*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_sgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+                                            d.n, a, lda, s, u, ldu, vt, ldv, e,
+                                            rocblas_inplace, info));
+        break;
+      }
+      case Type::F64: {
+        double* a = static_cast<double*>(buffers[1]);
+        double* s = static_cast<double*>(buffers[2]);
+        double* u = static_cast<double*>(buffers[3]);
+        double* vt = static_cast<double*>(buffers[4]);
+        double* e = static_cast<double*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_dgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+                                            d.n, a, lda, s, u, ldu, vt, ldv, e,
+                                            rocblas_inplace, info));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex* a =
+            static_cast<rocblas_float_complex*>(buffers[1]);
+        float* s = static_cast<float*>(buffers[2]);
+        rocblas_float_complex* u =
+            static_cast<rocblas_float_complex*>(buffers[3]);
+        rocblas_float_complex* vt =
+            static_cast<rocblas_float_complex*>(buffers[4]);
+        float* e = static_cast<float*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_cgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+                                            d.n, a, lda, s, u, ldu, vt, ldv, e,
+                                            rocblas_inplace, info));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex* a =
+            static_cast<rocblas_double_complex*>(buffers[1]);
+        double* s = static_cast<double*>(buffers[2]);
+        rocblas_double_complex* u =
+            static_cast<rocblas_double_complex*>(buffers[3]);
+        rocblas_double_complex* vt =
+            static_cast<rocblas_double_complex*>(buffers[4]);
+        double* e = static_cast<double*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_zgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+                                            d.n, a, lda, s, u, ldu, vt, ldv, e,
+                                            rocblas_inplace, info));
+        break;
+      }
+    }
+  } else {
+    const rocblas_stride stride_s = std::min(d.m, d.n);
+    const rocblas_stride stride_u = ldu * d.m;
+    const rocblas_stride stride_v = ldv * d.n;
+    const rocblas_stride stride_e = std::min(d.m, d.n) - 1;
+
+    auto a_ptrs_host =
+        MakeBatchPointers(stream, buffers[1], buffers[7], d.batch,
+                          SizeOfType(d.type) * d.m * d.n);
+    // TODO(phawkins): ideally we would not need to synchronize here, but to
+    // avoid it we need a way to keep the host-side buffer alive until the copy
+    // completes.
+    ThrowIfError(hipStreamSynchronize(stream));
+
+    switch (d.type) {
+      case Type::F32: {
+        float** a_batch_ptrs = static_cast<float**>(buffers[7]);
+        float* s = static_cast<float*>(buffers[2]);
+        float* u = static_cast<float*>(buffers[3]);
+        float* vt = static_cast<float*>(buffers[4]);
+        float* e = static_cast<float*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_sgesvd_batched(
+            handle.get(), d.jobu, d.jobvt, d.m, d.n, a_batch_ptrs, lda, s,
+            stride_s, u, ldu, stride_u, vt, ldv, stride_v, e, stride_e,
+            rocblas_inplace, info, d.batch));
+        break;
+      }
+      case Type::F64: {
+        double** a_batch_ptrs = static_cast<double**>(buffers[7]);
+        double* s = static_cast<double*>(buffers[2]);
+        double* u = static_cast<double*>(buffers[3]);
+        double* vt = static_cast<double*>(buffers[4]);
+        double* e = static_cast<double*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_dgesvd_batched(
+            handle.get(), d.jobu, d.jobvt, d.m, d.n, a_batch_ptrs, lda, s,
+            stride_s, u, ldu, stride_u, vt, ldv, stride_v, e, stride_e,
+            rocblas_inplace, info, d.batch));
+        break;
+      }
+      case Type::C64: {
+        rocblas_float_complex** a_batch_ptrs =
+            static_cast<rocblas_float_complex**>(buffers[7]);
+        float* s = static_cast<float*>(buffers[2]);
+        rocblas_float_complex* u =
+            static_cast<rocblas_float_complex*>(buffers[3]);
+        rocblas_float_complex* vt =
+            static_cast<rocblas_float_complex*>(buffers[4]);
+        float* e = static_cast<float*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_cgesvd_batched(
+            handle.get(), d.jobu, d.jobvt, d.m, d.n, a_batch_ptrs, lda, s,
+            stride_s, u, ldu, stride_u, vt, ldv, stride_v, e, stride_e,
+            rocblas_inplace, info, d.batch));
+        break;
+      }
+      case Type::C128: {
+        rocblas_double_complex** a_batch_ptrs =
+            static_cast<rocblas_double_complex**>(buffers[7]);
+        double* s = static_cast<double*>(buffers[2]);
+        rocblas_double_complex* u =
+            static_cast<rocblas_double_complex*>(buffers[3]);
+        rocblas_double_complex* vt =
+            static_cast<rocblas_double_complex*>(buffers[4]);
+        double* e = static_cast<double*>(buffers[6]);
+        ThrowIfErrorStatus(rocsolver_zgesvd_batched(
+            handle.get(), d.jobu, d.jobvt, d.m, d.n, a_batch_ptrs, lda, s,
+            stride_s, u, ldu, stride_u, vt, ldv, stride_v, e, stride_e,
+            rocblas_inplace, info, d.batch));
+        break;
+      }
+    }
+  }
+}
+
+// Singular value decomposition using Jacobi algorithm: gesvdj
+// not implemented yet in rocsolver
+
+py::dict Registrations() {
+  py::dict dict;
+  dict["rocblas_trsm"] = EncapsulateFunction(Trsm);
+  // there are differnent versions of getrf in cublas and cusolver
+  // however with rocm there is just one in rocsolver
+
+  dict["rocsolver_potrf"] = EncapsulateFunction(Potrf);
+  dict["rocsolver_getrf"] = EncapsulateFunction(Getrf);
+  dict["rocsolver_geqrf"] = EncapsulateFunction(Geqrf);
+  dict["rocsolver_orgqr"] = EncapsulateFunction(Orgqr);
+  //  dict["rocsolver_syevd"] = EncapsulateFunction(Syevd);
+  //  dict["rocsolver_syevj"] = EncapsulateFunction(Syevj);
+  dict["rocsolver_gesvd"] = EncapsulateFunction(Gesvd);
+  //  dict["rocsolver_gesvdj"] = EncapsulateFunction(Gesvdj);
+
+  return dict;
+}
+
+PYBIND11_MODULE(rocblas_kernels, m) {
+  m.def("registrations", &Registrations);
+
+  m.def("build_trsm_descriptor", &BuildTrsmDescriptor);
+
+  m.def("build_potrf_descriptor", &BuildPotrfDescriptor);
+  m.def("build_getrf_descriptor", &BuildGetrfDescriptor);
+  m.def("build_geqrf_descriptor", &BuildGeqrfDescriptor);
+  m.def("build_orgqr_descriptor", &BuildOrgqrDescriptor);
+  //  m.def("build_syevd_descriptor", &BuildSyevdDescriptor);
+  //  m.def("build_syevj_descriptor", &BuildSyevjDescriptor);
+  m.def("build_gesvd_descriptor", &BuildGesvdDescriptor);
+  //  m.def("build_gesvdj_descriptor", &BuildGesvdjDescriptor);
+}
+
+}  // namespace
+}  // namespace jax

--- a/jaxlib/rocm_gpu_kernel_helpers.cc
+++ b/jaxlib/rocm_gpu_kernel_helpers.cc
@@ -1,0 +1,45 @@
+/* Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "jaxlib/rocm_gpu_kernel_helpers.h"
+
+#include <stdexcept>
+
+#include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
+
+namespace jax {
+
+void ThrowIfError(hipError_t error) {
+  if (error != hipSuccess) {
+    throw std::runtime_error(
+        absl::StrCat("ROCm operation failed: ", hipGetErrorString(error)));
+  }
+}
+
+std::unique_ptr<void* []> MakeBatchPointers(hipStream_t stream, void* buffer,
+                                            void* dev_ptrs, int batch,
+                                            int batch_elem_size) {
+  char* ptr = static_cast<char*>(buffer);
+  auto host_ptrs = absl::make_unique<void*[]>(batch);
+  for (int i = 0; i < batch; ++i) {
+    host_ptrs[i] = ptr;
+    ptr += batch_elem_size;
+  }
+  ThrowIfError(hipMemcpyAsync(dev_ptrs, host_ptrs.get(), sizeof(void*) * batch,
+                              hipMemcpyHostToDevice, stream));
+  return host_ptrs;
+}
+}  // namespace jax

--- a/jaxlib/rocm_gpu_kernel_helpers.h
+++ b/jaxlib/rocm_gpu_kernel_helpers.h
@@ -18,17 +18,17 @@ limitations under the License.
 
 #include <memory>
 
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "rocm/include/hip/hip_runtime_api.h"
 
 namespace jax {
 
-void ThrowIfError(cudaError_t error);
+void ThrowIfError(hipError_t error);
 
 // Builds an array of pointers to each array in a batch, in device memory.
 // Caution: the return value must be kept alive (e.g., via a stream
 // synchronization) until the copy enqueued by MakeBatchPointers on `stream`
 // completes.
-std::unique_ptr<void*[]> MakeBatchPointers(cudaStream_t stream, void* buffer,
+std::unique_ptr<void*[]> MakeBatchPointers(hipStream_t stream, void* buffer,
                                            void* dev_ptrs, int batch,
                                            int batch_elem_size);
 

--- a/jaxlib/rocsolver.py
+++ b/jaxlib/rocsolver.py
@@ -1,0 +1,349 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import operator
+
+import numpy as np
+
+from jaxlib import xla_client
+
+try:
+  from jaxlib import rocblas_kernels
+  for _name, _value in rocblas_kernels.registrations().items():
+    xla_client.register_custom_call_target(_name, _value, platform="ROCM")
+except ImportError:
+  pass
+
+# we have a single module for both rocsolver and rocblas functions
+rocsolver_kernels = rocblas_kernels
+
+_ops = xla_client.ops
+_Shape = xla_client.Shape
+
+
+def _real_type(dtype):
+  """Returns the real equivalent of 'dtype'."""
+  if dtype == np.float32:
+    return np.float32
+  elif dtype == np.float64:
+    return np.float64
+  elif dtype == np.complex64:
+    return np.float32
+  elif dtype == np.complex128:
+    return np.float64
+  else:
+    raise NotImplementedError("Unsupported dtype {}".format(dtype))
+
+
+_prod = lambda xs: functools.reduce(operator.mul, xs, 1)
+
+
+def trsm(c,
+         a,
+         b,
+         left_side=False,
+         lower=False,
+         trans_a=False,
+         conj_a=False,
+         diag=False):
+  """triangular solve"""
+  b_shape = c.get_shape(b)
+  dtype = b_shape.element_type()
+  dims = b_shape.dimensions()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  batch = _prod(batch_dims)
+  k = m if left_side else n
+
+  a_shape = c.get_shape(a)
+  if (batch_dims + (k, k) != a_shape.dimensions() or a_shape.element_type() != dtype):
+    raise ValueError("Argument mismatch for trsm, got {} and {}".format(
+        a_shape, b_shape))
+
+  if conj_a and not trans_a:
+    raise NotImplementedError("Conjugation without transposition not supported")
+
+  lwork, opaque = rocblas_kernels.build_trsm_descriptor(np.dtype(dtype), batch, m, n,
+                                                        left_side, lower, trans_a,
+                                                        conj_a, diag)
+  layout = (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+  out = _ops.CustomCallWithLayout(
+      c,
+      b"rocblas_trsm",
+      operands=(a, b),
+      shape_with_layout=_Shape.tuple_shape((
+          _Shape.array_shape(dtype, b_shape.dimensions(),
+                             layout),  # buffers[2] (b, OUT)
+          _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                             (0,)),  # buffers[3] (a batch pointers)
+          _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                             (0,)))),  # buffers[4] (b batch pointers)
+      operand_shapes_with_layout=(
+          _Shape.array_shape(dtype, a_shape.dimensions(), layout),  # buffers[0] (a)
+          _Shape.array_shape(dtype, b_shape.dimensions(), layout),  # buffers[1] (b, IN)
+      ),
+      opaque=opaque)
+  return _ops.GetTupleElement(out, 0)
+
+
+def potrf(c, a, lower):
+  """Cholesky decomposition."""
+  a_shape = c.get_shape(a)
+  dtype = a_shape.element_type()
+  dims = a_shape.dimensions()
+  m, n = dims[-2:]
+  assert m == n
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  batch = _prod(batch_dims)
+
+  lwork, opaque = rocsolver_kernels.build_potrf_descriptor(np.dtype(dtype), lower,
+                                                           batch, n)
+  kernel = b"rocsolver_potrf"
+
+  out = _ops.CustomCallWithLayout(
+      c,
+      kernel,
+      operands=(a,),
+      shape_with_layout=_Shape.tuple_shape((
+          _Shape.array_shape(dtype, batch_dims + (n, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[1] (a, OUT)
+          _Shape.array_shape(np.dtype(np.int32), batch_dims,
+                             tuple(range(num_bd - 1, -1, -1))),  # buffers[2] (info)
+          _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                             (0,)),  # buffers[3] (a batch pointers)
+      )),
+      operand_shapes_with_layout=(
+          _Shape.array_shape(dtype, batch_dims + (n, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[0] (a, IN)
+      ),
+      opaque=opaque)
+  return _ops.GetTupleElement(out, 0), _ops.GetTupleElement(out, 1)
+
+
+def getrf(c, a):
+  """LU decomposition."""
+  a_shape = c.get_shape(a)
+  dtype = a_shape.element_type()
+  dims = a_shape.dimensions()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  batch = _prod(batch_dims)
+
+  lwork, opaque = rocsolver_kernels.build_getrf_descriptor(np.dtype(dtype), batch, m, n)
+  kernel = b"rocsolver_getrf"
+
+  out = _ops.CustomCallWithLayout(
+      c,
+      kernel,
+      operands=(a,),
+      shape_with_layout=_Shape.tuple_shape((
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[1] (a, OUT)
+          _Shape.array_shape(np.dtype(np.int32), batch_dims + (min(m, n),),
+                             tuple(range(num_bd, -1, -1))),  # buffers[2] (ipiv)
+          _Shape.array_shape(np.dtype(np.int32), batch_dims,
+                             tuple(range(num_bd - 1, -1, -1))),  # buffers[3] (info)
+          _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                             (0,)),  # buffers[4] (a batch pointers)
+      )),
+      operand_shapes_with_layout=(
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[0] (a, IN)
+      ),
+      opaque=opaque)
+  return (_ops.GetTupleElement(out, 0), _ops.GetTupleElement(out, 1),
+          _ops.GetTupleElement(out, 2))
+
+
+def geqrf(c, a):
+  """QR decomposition."""
+  a_shape = c.get_shape(a)
+  dtype = a_shape.element_type()
+  dims = a_shape.dimensions()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  batch = _prod(batch_dims)
+
+  lwork, opaque = rocsolver_kernels.build_geqrf_descriptor(np.dtype(dtype), batch, m, n)
+  kernel = b"rocsolver_geqrf"
+
+  out = _ops.CustomCallWithLayout(
+      c,
+      kernel,
+      operands=(a,),
+      shape_with_layout=_Shape.tuple_shape((
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[1] (a, OUT)
+          _Shape.array_shape(dtype, batch_dims + (min(m, n),),
+                             tuple(range(num_bd, -1, -1))),  # buffers[2] (tau)
+          # buffers[3]  (a batch pointers)
+          _Shape.array_shape(np.dtype(np.int8), (lwork,), (0,)),
+      )),
+      operand_shapes_with_layout=(
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[0] (a, IN)
+      ),
+      opaque=opaque)
+  # rocsolver geqrf does not return info
+  return (_ops.GetTupleElement(out, 0), _ops.GetTupleElement(out, 1), None)
+
+
+def orgqr(c, a, tau):
+  """Product of elementary Householder reflections."""
+  a_shape = c.get_shape(a)
+  dtype = a_shape.element_type()
+  dims = a_shape.dimensions()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  batch = _prod(batch_dims)
+
+  tau_dims = c.get_shape(tau).dimensions()
+  assert tau_dims[:-1] == dims[:-2]
+  k = tau_dims[-1]
+
+  _, opaque = rocsolver_kernels.build_orgqr_descriptor(np.dtype(dtype), batch, m, n, k)
+  kernel = b"rocsolver_orgqr"
+
+  out = _ops.CustomCallWithLayout(
+      c,
+      kernel,
+      operands=(a, tau),
+      shape_with_layout=_Shape.tuple_shape((
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[2]  (a OUT)
+      )),
+      operand_shapes_with_layout=(
+          _Shape.array_shape(dtype, batch_dims + (m, n),
+                             (num_bd, num_bd + 1) + tuple(range(num_bd - 1, -1, -1))
+                             ),  # buffers[0]  (a, IN)
+          _Shape.array_shape(dtype, batch_dims + (k,),
+                             tuple(range(num_bd, -1, -1))),  # buffers[1]  (tau IN)
+      ),
+      opaque=opaque)
+  return (_ops.GetTupleElement(out, 0), None)  # ROCSolver orgqr does not return info
+
+
+def syevd(c, a, lower=False):
+  raise NotImplementedError(
+      "Symmetric (Hermitian) eigendecomposition is not yet implemented in ROCSolver")
+
+
+def gesvd(c, a, full_matrices=True, compute_uv=True):
+  """Singular value decomposition."""
+  a_shape = c.get_shape(a)
+  dims = a_shape.dimensions()
+  dtype = a_shape.element_type()
+  assert len(dims) >= 2
+  m, n = dims[-2:]
+  batch_dims = tuple(dims[:-2])
+  num_bd = len(batch_dims)
+  b = _prod(batch_dims)
+  singular_vals_dtype = np.dtype(_real_type(dtype))
+
+  # gesvdj is not yet implemented in ROCSolver
+  # if m < 32 and n < 32:
+  # ...
+  # elif m < n:
+
+  if m < n:
+    lwork, opaque = rocsolver_kernels.build_gesvd_descriptor(np.dtype(dtype), b, n, m,
+                                                             compute_uv, full_matrices)
+    scalar_layout = tuple(range(num_bd - 1, -1, -1))
+    vector_layout = (num_bd,) + scalar_layout
+    matrix_layout = (num_bd + 1, num_bd) + scalar_layout
+    out = _ops.CustomCallWithLayout(
+        c,
+        b"rocsolver_gesvd",
+        operands=(a,),
+        shape_with_layout=_Shape.tuple_shape((
+            _Shape.array_shape(dtype, batch_dims + (m, n),
+                               matrix_layout),  # buffers[1] (a, OUT)
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n),),
+                               vector_layout),  # buffers[2] (s)
+            # buffers[3] (u; actually vt)
+            _Shape.array_shape(dtype, batch_dims + (n, n), matrix_layout),
+            # buffers[4] (vt; actually u)
+            _Shape.array_shape(dtype, batch_dims + (m, m), matrix_layout),
+            _Shape.array_shape(singular_vals_dtype, (min(m, n) - 1,),
+                               (0,)),  # buffers[5] (e)
+            _Shape.array_shape(np.dtype(np.int32), batch_dims,
+                               scalar_layout),  # buffers[6] (info)
+            _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                               (0,)),  # buffers[7] (a batch pointers)
+        )),
+        operand_shapes_with_layout=(
+            _Shape.array_shape(dtype, batch_dims + (m, n),
+                               matrix_layout),  # a (buffers[0]))
+        ),
+        opaque=opaque)
+    s = _ops.GetTupleElement(out, 1)
+    vt = _ops.GetTupleElement(out, 2)
+    u = _ops.GetTupleElement(out, 3)
+    info = _ops.GetTupleElement(out, 5)
+  else:
+    lwork, opaque = rocsolver_kernels.build_gesvd_descriptor(np.dtype(dtype), b, m, n,
+                                                             compute_uv, full_matrices)
+    scalar_layout = tuple(range(num_bd - 1, -1, -1))
+    vector_layout = (num_bd,) + scalar_layout
+    matrix_layout = (num_bd, num_bd + 1) + scalar_layout
+    out = _ops.CustomCallWithLayout(
+        c,
+        b"rocsolver_gesvd",
+        operands=(a,),
+        shape_with_layout=_Shape.tuple_shape((
+            _Shape.array_shape(dtype, batch_dims + (m, n),
+                               matrix_layout),  # buffers[1] (a, OUT)
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n),),
+                               vector_layout),  # buffers[2] (s)
+            _Shape.array_shape(dtype, batch_dims + (m, m),
+                               matrix_layout),  # buffers[3] (u)
+            _Shape.array_shape(dtype, batch_dims + (n, n),
+                               matrix_layout),  # buffers[4] (vt)
+            _Shape.array_shape(singular_vals_dtype, (min(m, n) - 1,),
+                               (0,)),  # buffers[5] (e)
+            _Shape.array_shape(np.dtype(np.int32), batch_dims,
+                               scalar_layout),  # buffers[6] (info)
+            _Shape.array_shape(np.dtype(np.int8), (lwork,),
+                               (0,)),  # buffers[7] (a batch pointers)
+        )),
+        operand_shapes_with_layout=(
+            _Shape.array_shape(dtype, batch_dims + (m, n),
+                               matrix_layout),  # buffers[0] (a, IN)
+        ),
+        opaque=opaque)
+    s = _ops.GetTupleElement(out, 1)
+    u = _ops.GetTupleElement(out, 2)
+    vt = _ops.GetTupleElement(out, 3)
+    info = _ops.GetTupleElement(out, 5)
+  if not full_matrices:
+    u = _ops.Slice(u, (0,) * len(dims), batch_dims + (m, min(m, n)), (1,) * len(dims))
+    vt = _ops.Slice(vt, (0,) * len(dims), batch_dims + (min(m, n), n), (1,) * len(dims))
+  return s, u, vt, info


### PR DESCRIPTION
sequel to https://github.com/google/jax/pull/5114

Also enables the use of the built-in prng for ROCm (instead of a custom kernel like with cuda) since we did not include that in the last one.

The accompanying changes in TF/XLA were merged with https://github.com/tensorflow/tensorflow/pull/45583.
 
partially solves https://github.com/google/jax/issues/2012.

@hawkinsp 