### PR TITLE
[jax2tf] Bump TF nightly version in README.

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -126,7 +126,7 @@ for CUDA. One must be mindful to install a version of CUDA that is compatible
 with both [jaxlib](https://github.com/google/jax/blob/master/README.md#pip-installation) and
 [TensorFlow](https://www.tensorflow.org/install/source#tested_build_configurations).
 
-As of today, the tests are run using `tf_nightly==2.4.0.dev20200916`.
+As of today, the tests are run using `tf_nightly==2.5.0-dev20201207`.
 
 ## Caveats
 


### PR DESCRIPTION
After updates were made to bfloat16 in XLA/jaxlib in late October, this version has to be bumped up :)