### PR TITLE
Expose jit args to accommodate serialization

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -181,6 +181,14 @@ def jit(fun: Callable[..., T],
     return _python_jit(fun, static_argnums, device, backend, donate_argnums)
 
 
+class _JitArgs(NamedTuple):
+  fun: Callable
+  static_argnums: Iterable[int]
+  device: Optional[xc.Device]
+  backend: Optional[str]
+  donate_argnums: Iterable[int]
+
+
 def _python_jit(
     fun: Callable,
     static_argnums: Union[int, Iterable[int]] = (),

--- a/jax/api.py
+++ b/jax/api.py
@@ -192,6 +192,7 @@ def _python_jit(
   _check_callable(fun)
   static_argnums = _ensure_index_tuple(static_argnums)
   donate_argnums = _ensure_index_tuple(donate_argnums)
+  jit_args = _JitArgs(fun, static_argnums, device, backend, donate_argnums)
   donate_argnums = rebase_donate_argnums(donate_argnums, static_argnums)
 
   @wraps(fun)
@@ -225,6 +226,7 @@ def _python_jit(
         donated_invars=donated_invars)
     return tree_unflatten(out_tree(), out)
 
+  f_jitted._jit_args = jit_args  # expose jit args for serialization
   return f_jitted
 
 
@@ -251,6 +253,7 @@ def _cpp_jit(
   _check_callable(fun)
   static_argnums = _ensure_index_tuple(static_argnums)
   donate_argnums = _ensure_index_tuple(donate_argnums)
+  jit_args = _JitArgs(fun, static_argnums, device, backend, donate_argnums)
   donate_argnums = rebase_donate_argnums(donate_argnums, static_argnums)
 
   if device is not None and backend is not None:
@@ -382,6 +385,7 @@ def _cpp_jit(
     else:
       return cpp_jitted_f(*args, **kwargs)
   f_jitted._cpp_jitted_f = cpp_jitted_f
+  f_jitted._jit_args = jit_args  # expose jit args for serialization
 
   return f_jitted
 

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -102,6 +102,24 @@ class JaxJitTest(parameterized.TestCase):
     jitted_f = jax.api._cpp_jit(f)
     self.assertEqual(inspect.signature(f), inspect.signature(jitted_f))
 
+  def test_jit_args(self):
+    def f(a, b, c, d):
+      return a + b + c + d
+
+    with self.subTest('_cpp_jit'):
+      jitted_f = jax.api._cpp_jit(f, static_argnums=(1, 2), donate_argnums=3)
+      jit_args = jitted_f._jit_args
+      self.assertEqual(id(f), id(jit_args.fun))
+      self.assertEqual(jit_args.static_argnums, (1, 2))
+      self.assertEqual(jit_args.donate_argnums, (3,))
+
+    with self.subTest('_python_jit'):
+      jitted_f = jax.api._python_jit(f, static_argnums=(1, 2), donate_argnums=3)
+      jit_args = jitted_f._jit_args
+      self.assertEqual(id(f), id(jit_args.fun))
+      self.assertEqual(jit_args.static_argnums, (1, 2))
+      self.assertEqual(jit_args.donate_argnums, (3,))
+
 
 if __name__ == '__main__':
   jax.config.config_with_absl()


### PR DESCRIPTION
This would expose the original args passed to `jax.jit` as `jitted_func._jit_args` to accommodate serialization of jit-compiled functions along the lines of:

```python
class FunctionApproximator:
  def __init__(self):
    def func(a, b, c, d):
      return a + b + c + d
    self.func = jax.jit(func, static_argnums=(1, 2), donate_argnums=3)

  def __getstate__(self):
    jit_args = self.func._jit_args
    return (jit_args.fun, jit_args.static_argnums, jit_args.donate_argnums)

  def __setstate__(self, state):
    f, s, d = state
    self.func = jax.jit(f, static_argnums=s, donate_argnums=d)

```

closes #5043

