### PR TITLE
Propagate weak types through array creation functions

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2735,8 +2735,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
-  if dtype and _dtype(out) != dtype:
-    out = lax.convert_element_type(out, dtype, weak_type=weak_type)
+  out = lax.convert_element_type(out, dtype, weak_type=weak_type)
 
   if ndmin > ndim(out):
     out = lax.broadcast(out, (1,) * (ndmin - ndim(out)))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2702,6 +2702,8 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   if order is not None and order != "K":
     raise NotImplementedError("Only implemented for order='K'")
   lax._check_user_dtype_supported(dtype, "array")
+
+  weak_type = dtype is None and dtypes.is_weakly_typed(object)
   dtype = dtype and dtypes.canonicalize_dtype(dtype)
 
   if _can_call_numpy_array(object):
@@ -2709,13 +2711,13 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   assert type(object) not in dtypes.python_scalar_dtypes
 
   if type(object) is np.ndarray:
-    out = _device_put_raw(object)
+    out = _device_put_raw(object, weak_type=weak_type)
     if dtype: assert _dtype(out) == dtype
   elif isinstance(object, (DeviceArray, core.Tracer)):
     if isinstance(object, DeviceArray) and copy:
       # We perform a copy by bouncing back to the host
       # TODO(phawkins): add a device runtime function to copy a buffer
-      out = _device_put_raw(_np_asarray(object))
+      out = _device_put_raw(_np_asarray(object), weak_type=weak_type)
     else:
       out = object
   elif isinstance(object, (list, tuple)):
@@ -2734,7 +2736,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
   if dtype and _dtype(out) != dtype:
-    out = lax.convert_element_type(out, dtype)
+    out = lax.convert_element_type(out, dtype, weak_type=weak_type)
 
   if ndmin > ndim(out):
     out = lax.broadcast(out, (1,) * (ndmin - ndim(out)))

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -88,8 +88,8 @@ class DtypesTest(jtu.JaxTestCase):
     testcases = [
       (jnp.array(1.), 0., jnp.float_),
       (jnp.array(1.), jnp.array(0.), jnp.float_),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float_),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float_),
+      (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float16),
+      (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float32),
       (jnp.array(1.), jnp.array(0., dtype=jnp.float64), jnp.float64),
       (jnp.array(1., dtype=jnp.float16), 0., jnp.float16),
       (jnp.array(1., dtype=jnp.float32), 0., jnp.float32),
@@ -303,7 +303,7 @@ class TestPromotionTables(jtu.JaxTestCase):
     for xtype, ytype in itertools.product(
       [int, float, jnp.int16, jnp.int32, jnp.float16, jnp.float32], repeat=2)
     for xfun, yfun in itertools.product(
-      [identity, abs], repeat=2)
+      [identity, abs, jnp.array], repeat=2)
     )
   def testBinaryPromotionJitInvariance(self, xtype, ytype, xfun, yfun):
     """Test jit invariance of simple binary promotion rules with and without weak types."""


### PR DESCRIPTION
This propagates weak types through array creation functions. For example:

- `jnp.array(x, dtype)` and `jnp.asarray(x, dtype)` will result in a weakly-typed output if `dtype` is `None` and `x` is either a Python scalar or a weakly-typed JAX array/tracer.
- `jnp.full(shape, value, dtype)` will result in weakly-typed output if `dtype` is `None` and `value` is weakly-typed
- `jnp.full_like(x, value, dtype)`,  `jnp.zeros_like(x, dtype)`, and `jnp.ones_like(x, dtype)` will result in weakly-typed output if `dtype` is `None` and `x` is weakly-typed

This requires the fix in #5158