### PR TITLE
Fix lax.convert_element_type() with dtype=None

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -426,7 +426,7 @@ def convert_element_type(operand: Array, new_dtype: DType = None,
   Returns:
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
-  new_dtype = dtypes.canonicalize_dtype(new_dtype)
+  new_dtype = dtypes.canonicalize_dtype(new_dtype or _dtype(operand))
   new_weak_type = bool(weak_type)
   # Avoids dropping precision by casting Python scalars to the default Jax
   # type. If we passed a Python scalar directly to the bind call below, it is


### PR DESCRIPTION
#4850 added a default value of `dtype=None` to `lax.convert_element_type` intended to leave the dtype of the input unchanged. This was silently being interpreted as `jnp.float_` within `dtypes.canonicalize_dtype`.

This PR fixes the issue and adds a testcase covering this.