### PR TITLE
lax.reduce: check for dtype mismatch in reduce_p abstract eval

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4877,11 +4877,13 @@ def _reduce_shape_rule(*args, computation, jaxpr, consts, dimensions):
 
 
 def _reduce_dtype_rule(*args, computation, jaxpr, consts, dimensions):
-  _, init_value_args = split_list(args, [len(args) // 2])
-  return [
-      dtypes.canonicalize_dtype(in_arg.dtype)
-      for in_arg in init_value_args
-  ]
+  operand_args, init_value_args = split_list(args, [len(args) // 2])
+  operand_dtypes = [dtypes.canonicalize_dtype(op.dtype) for op in operand_args]
+  init_value_dtypes = [dtypes.canonicalize_dtype(init.dtype) for init in init_value_args]
+  if operand_dtypes != init_value_dtypes:
+    raise TypeError(f"operand dtypes should match corresponding initial value dtypes; got "
+                    f"operands={operand_args} and initial_values={init_value_args}")
+  return operand_dtypes
 
 
 def _reduce_translation_rule(c, *values, computation, jaxpr,


### PR DESCRIPTION
Current behavior:
```python
>>> from jax import lax, numpy as jnp
>>> lax.reduce(jnp.ones(10), 0, jnp.add, (0,))
```
```pytb
Traceback (most recent call last):
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 332, in primitive_computation
    return c.build()
RuntimeError: Invalid argument: Reduction function's 1-th parameter shape differs from the input type element type: s32[] vs f32[]: 

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "tmp.py", line 2, in <module>
    lax.reduce(jnp.ones(10), 0, jnp.add, (0,))
  File "/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py", line 1147, in reduce
    out = reduce_p.bind(*(flat_operands + flat_init_values), computation=computation,
  File "/Users/vanderplas/github/google/jax/jax/core.py", line 271, in bind
    out = top_trace.process_primitive(self, tracers, params)
  File "/Users/vanderplas/github/google/jax/jax/core.py", line 595, in process_primitive
    return primitive.impl(*tracers, **params)
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 235, in apply_primitive
    compiled_fun = xla_primitive_callable(prim, *unsafe_map(arg_spec, args), **params)
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 278, in xla_primitive_callable
    built_c = primitive_computation(prim, AxisEnv(nreps, (), ()), backend,
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 337, in primitive_computation
    raise RuntimeError(msg) from e
RuntimeError: Invalid argument: Reduction function's 1-th parameter shape differs from the input type element type: s32[] vs f32[]: 
This is a bug in JAX's shape-checking rules; please report it!
https://github.com/google/jax/issues

```
Behavior after this PR:
```python
>>> from jax import lax, numpy as jnp
>>> lax.reduce(jnp.ones(10), 0, jnp.add, (0,))
```
```pytb
Traceback (most recent call last):
  File "tmp.py", line 2, in <module>
    lax.reduce(jnp.ones(10), 0, jnp.add, (0,))
  File "/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py", line 1147, in reduce
    out = reduce_p.bind(*(flat_operands + flat_init_values), computation=computation,
  File "/Users/vanderplas/github/google/jax/jax/core.py", line 271, in bind
    out = top_trace.process_primitive(self, tracers, params)
  File "/Users/vanderplas/github/google/jax/jax/core.py", line 595, in process_primitive
    return primitive.impl(*tracers, **params)
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 235, in apply_primitive
    compiled_fun = xla_primitive_callable(prim, *unsafe_map(arg_spec, args), **params)
  File "/Users/vanderplas/github/google/jax/jax/interpreters/xla.py", line 260, in xla_primitive_callable
    aval_out = prim.abstract_eval(*avals, **params)
  File "/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py", line 2003, in standard_abstract_eval
    shapes, dtypes = shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs)
  File "/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py", line 4920, in _reduce_dtype_rule
    raise TypeError(f"operand dtypes should match corresponding initial value dtypes; got "
TypeError: operand dtypes should match corresponding initial value dtypes; got operands=[ShapedArray(float32[10])] and initial_values=[ShapedArray(int32[], weak_type=True)]
```