### PR TITLE
Check for non-tuples and not int subclasses in Chunked

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -83,7 +83,7 @@ class Chunked:
   chunks: Tuple[int, ...]
 
   def __init__(self, chunks: Union[int, Tuple[int, ...]]):
-    if isinstance(chunks, int):
+    if not isinstance(chunks, tuple):
       chunks = (chunks,)
     object.__setattr__(self, 'chunks', chunks)
 


### PR DESCRIPTION
Apparently some projects like to pass in instances of `numpy.int64`
where `int`s are expected, and those fail the subclass check. This
should be a hotfix for them, though it would be good to figure out where
does the NumPy scalar come from, and make them well typed.