### PR TITLE
Typo ?

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -55,7 +55,7 @@ You can install the necessary Python dependencies using ``pip``::
 To build ``jaxlib`` with CUDA support, you can run::
 
     python build/build.py --enable_cuda
-    pip install -e dist/*.whl  # installs jaxlib (includes XLA)
+    pip install dist/*.whl  # installs jaxlib (includes XLA)
 
 
 See ``python build/build.py --help`` for configuration options, including ways to


### PR DESCRIPTION
I removed "-e" option from "pip install -e dist/*.whl  # installs jaxlib (includes XLA)" line 58. It is now coherent with lines 69-70. 
When I tried the command with the "-e" it threw an error, without "-e" it worked fine.