### PR TITLE
Add xla translation rules that accept avals

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -207,9 +207,9 @@ threefry2x32_p.multiple_results = True
 threefry2x32_p.def_impl(partial(xla.apply_primitive, threefry2x32_p))
 threefry2x32_p.def_abstract_eval(_threefry2x32_abstract_eval)
 batching.defbroadcasting(threefry2x32_p)
-xla.translations[threefry2x32_p] = xla.lower_fun(
+xla.translations_with_avals[threefry2x32_p] = xla.lower_fun(
     partial(_threefry2x32_lowering, use_rolled_loops=False),
-    multiple_results=True)
+    multiple_results=True, with_avals=True)
 xla.backend_specific_translations['cpu'][threefry2x32_p] = xla.lower_fun(
     partial(_threefry2x32_lowering, use_rolled_loops=True),
     multiple_results=True)
@@ -1014,9 +1014,9 @@ random_gamma_p = core.Primitive('random_gamma')
 random_gamma_p.def_impl(_gamma_impl)
 random_gamma_p.def_abstract_eval(lambda key, a: core.raise_to_shaped(a))
 ad.defjvp2(random_gamma_p, None, lambda tangent, ans, key, a: tangent * _gamma_grad(ans, a))
-xla.translations[random_gamma_p] = xla.lower_fun(
+xla.translations_with_avals[random_gamma_p] = xla.lower_fun(
     partial(_gamma_impl, use_vmap=True),
-    multiple_results=False)
+    multiple_results=False, with_avals=True)
 xla.backend_specific_translations['cpu'][random_gamma_p] = xla.lower_fun(
     partial(_gamma_impl, use_vmap=False),
     multiple_results=False)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -320,6 +320,9 @@ def primitive_computation(prim, axis_env, backend, tuple_args, *avals, **params)
   elif prim in translations:
     rule = translations[prim]
     ans = rule(c, *xla_args, **params)
+  elif prim in translations_with_avals:
+    rule = translations_with_avals[prim]
+    ans = rule(c, avals, xla_args, params)
   elif prim in initial_style_translations:
     rule = initial_style_translations[prim]
     ans = rule(c, axis_env, extend_name_stack(prim.name), avals, backend,
@@ -430,11 +433,15 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
         source_file=frame.file_name if frame else None,
         source_line=frame.line_num if frame else None))
     in_nodes = _flatmap(read, eqn.invars)
+    # TODO(jakevdp): migrate `translations` table to `translations_with_avals`
     if eqn.primitive in backend_specific_translations[platform]:
       rule = backend_specific_translations[platform][eqn.primitive]
       ans = rule(c, *in_nodes, **eqn.params)
     elif eqn.primitive in translations:
       ans = translations[eqn.primitive](c, *in_nodes, **eqn.params)
+    elif eqn.primitive in translations_with_avals:
+      rule = translations_with_avals[eqn.primitive]
+      ans = rule(c, map(aval, eqn.invars), in_nodes, eqn.params)
     elif eqn.primitive in initial_style_translations:
       new_params = check_backend_params(eqn.params, backend)
       rule = initial_style_translations[eqn.primitive]
@@ -897,6 +904,7 @@ ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
 ### translation tables
 
 translations: Dict[core.Primitive, Callable] = {}
+translations_with_avals: Dict[core.Primitive, Callable] = {}
 parallel_translations: Dict[core.Primitive, Callable] = {}
 initial_style_translations: Dict[core.Primitive, Callable] = {}
 call_translations: Dict[core.Primitive, Callable] = {}
@@ -925,17 +933,13 @@ def _tuple_output(*args, **kwargs):
   ans = yield args, kwargs
   yield (ans,)
 
-def lower_fun(fun, multiple_results, parallel=False):
-  # This function can only be used to lower functions that take JAX array types
-  # as arguments (and e.g. don't accept unit values), because it assumes it can
-  # map from XLA types to JAX types. In general that mapping is not possible (as
-  # the mapping from JAX types to XLA types is not invertible), but for now at
-  # least we assume that the mapping from JAX *array* types to XLA array types
-  # is invertible. This assumption is unchecked!
-  # TODO(mattjj): remove assumption can map XLA array types to JAX array types
+def lower_fun(fun, multiple_results, parallel=False, with_avals=False):
+  # TODO(jakevdp): migrate dependent code & always use the with_avals=True.
   def f(c, *xla_args, **params):
-    # TODO(mattjj): revise this 'calling convention'
     avals = [_array_aval_from_xla_shape(c.get_shape(x)) for x in xla_args]
+    return f_with_avals(c, avals, xla_args, params)
+
+  def f_with_avals(c, avals, xla_args, params):
     if parallel:
       axis_env = params.pop('axis_env')
       del params['platform']
@@ -954,12 +958,13 @@ def lower_fun(fun, multiple_results, parallel=False):
                                           stage_out=True)  # type: ignore
       xla_consts = _xla_consts(c, consts)
       outs = jaxpr_subcomp(c, jaxpr, None, axis_env, xla_consts, '', *xla_args)
-    if multiple_results:
+    if multiple_results or any(v.aval._num_buffers > 1 for v in jaxpr.outvars):
       return xops.Tuple(c, outs)
     else:
       assert len(outs) == 1, outs
       return outs[0]
-  return f
+
+  return f_with_avals if with_avals else f
 
 def _array_aval_from_xla_shape(xla_shape):
   # This function instantiates the assumption that we can map fro XLA array

--- a/tests/custom_object_test.py
+++ b/tests/custom_object_test.py
@@ -118,6 +118,8 @@ def _sp_indices_abstract_eval(mat):
 def _sp_indices_translation_rule(c, data, indices):
   return indices
 
+# Note: cannot use lower_fun to define attribute access primitives
+# because it leads to infinite recursion.
 xla.translations[sp_indices_p] = _sp_indices_translation_rule
 
 sp_data_p = core.Primitive('sp_data')
@@ -133,6 +135,8 @@ def _sp_data_abstract_eval(mat):
 def _sp_data_translation_rule(c, data, indices):
   return data
 
+# Note: cannot use lower_fun to define attribute access primitives
+# because it leads to infinite recursion.
 xla.translations[sp_data_p] = _sp_data_translation_rule
 
 def identity(x):
@@ -142,16 +146,30 @@ identity_p = core.Primitive('identity')
 
 @identity_p.def_impl
 def _identity_impl(mat):
-  return SparseArray(mat.aval, mat.data, mat.indices)
+  return mat
 
 @identity_p.def_abstract_eval
 def _identity_abstract_eval(mat):
-  return mat
+  return AbstractSparseArray(mat.shape, mat.dtype, mat.index_dtype, mat.nnz)
 
-def _identity_translation_rule(c, data, indices):
-  return xops.Tuple(c, (data, indices))
+xla.translations_with_avals[identity_p] = xla.lower_fun(_identity_impl, multiple_results=False, with_avals=True)
 
-xla.translations[identity_p] = _identity_translation_rule
+def split(x):
+  return split_p.bind(x)
+
+split_p = core.Primitive('split')
+split_p.multiple_results = True
+
+@split_p.def_impl
+def _split_impl(mat):
+  return mat, mat
+
+@split_p.def_abstract_eval
+def _split_abstract_eval(mat):
+  m = AbstractSparseArray(mat.shape, mat.dtype, mat.index_dtype, mat.nnz)
+  return m, m
+
+xla.translations_with_avals[split_p] = xla.lower_fun(_split_impl, multiple_results=True, with_avals=True)
 
 def make_sparse_array(rng, shape, dtype, nnz=0.2):
   mat = rng(shape, dtype)
@@ -233,6 +251,25 @@ class CustomObjectTest(jtu.JaxTestCase):
     self.assertEqual(M.index_dtype, M2.index_dtype)
     self.assertAllClose(M.data, M2.data)
     self.assertAllClose(M.indices, M2.indices)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_compile={}".format(compile),
+       "compile": compile}
+      for compile in [True, False]))
+  def testSparseSplit(self, compile):
+    f = jit(split) if compile else split
+    rng = jtu.rand_default(self.rng())
+    M = make_sparse_array(rng, (10,), jnp.float32)
+    M2, M3 = f(M)
+
+    jaxpr = make_jaxpr(f)(M).jaxpr
+    core.check_jaxpr(jaxpr)
+
+    for MM in M2, M3:
+      self.assertEqual(M.dtype, MM.dtype)
+      self.assertEqual(M.index_dtype, MM.index_dtype)
+      self.assertArraysEqual(M.data, MM.data)
+      self.assertArraysEqual(M.indices, MM.indices)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_compile={}_primitive={}".format(compile, primitive),


### PR DESCRIPTION
Currently, default xla translations assume a one-to-one mapping between XLA buffers and JAX abstract values; with the advent of multi-buffer JAX types, this is no longer sufficient.

~~We could address this by adding a new flavor of translation rules that accept avals, but we already have a proliferation of these (including `translations`, `initial_style_translations`, `parallel_translations`, and `call_translations`)~~

~~This PR introduces a `general_translations` table which contains translation rules with a syntax that is flexible enough to encompass *all* the above flavors of translation rule. This primarily solves the direct problem at hand (the ability to explicitly accept avals in lowered translation rules), and also allow us to migrate other translation forms to this single table and eventually remove the other translation tables (mentioned in new TODOs).~~

This PR adds a `translations_with_avals` table that passes the avals to translation rules; eventually we should be able to move all standard translations to this form, but for now this unblocks the multi-buffer lower_fun work.