### PR TITLE
Add support for 'preferred_element_type' arg in `dot` and `dot_general`.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -609,7 +609,8 @@ def conv_general_dilated(
       lhs_shape=lhs.shape, rhs_shape=rhs.shape,
       precision=_canonicalize_precision(precision))
 
-def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None) -> Array:
+def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
+        preferred_element_type: Optional[DType] = None) -> Array:
   """Vector/vector, matrix/vector, and matrix/matrix multiplication.
 
   Wraps XLA's `Dot
@@ -625,13 +626,16 @@ def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None) -> Array:
       the backend, a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
       ``lax.Precision`` enums indicating precision of ``lhs``` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     An array containing the product.
   """
   if 1 <= lhs.ndim <= 2 and 1 <= rhs.ndim <= 2 and lhs.shape[-1] == rhs.shape[0]:
     return dot_general(lhs, rhs, (((lhs.ndim - 1,), (0,)), ((), ())),
-                       precision=precision)
+                       precision=precision, preferred_element_type=preferred_element_type)
   else:
     raise TypeError("Incompatible shapes for dot: got {} and {}.".format(
         lhs.shape, rhs.shape))
@@ -641,7 +645,8 @@ DotDimensionNumbers = Tuple[Tuple[Sequence[int], Sequence[int]],
                             Tuple[Sequence[int], Sequence[int]]]
 
 def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
-                precision: PrecisionLike = None) -> Array:
+                precision: PrecisionLike = None,
+                preferred_element_type: Optional[DType] = None) -> Array:
   """More general contraction operator.
 
   Wraps XLA's `DotGeneral
@@ -658,6 +663,9 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
       the backend, a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
       ``lax.Precision`` enums indicating precision of ``lhs``` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     An array containing the result.
@@ -667,7 +675,8 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
   batch_dims = tuple(map(lambda x: tuple(x), batch_dims_seq))
   return dot_general_p.bind(lhs, rhs,
                             dimension_numbers=(contract_dims, batch_dims),
-                            precision=_canonicalize_precision(precision))
+                            precision=_canonicalize_precision(precision),
+                            preferred_element_type=preferred_element_type)
 
 def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
   """Broadcasts an array, adding new major dimensions.
@@ -3024,7 +3033,8 @@ def _precision_config(precision):
   return None
 
 
-def _dot_general_shape_rule(lhs, rhs, *, dimension_numbers, precision):
+def _dot_general_shape_rule(lhs, rhs, *, dimension_numbers, precision,
+                            preferred_element_type: Optional[DType]):
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   if not all(np.all(np.greater_equal(d, 0)) and np.all(np.less(d, lhs.ndim))
              for d in (lhs_contracting, lhs_batch)):
@@ -3090,12 +3100,23 @@ def _dot_general_shape_rule(lhs, rhs, *, dimension_numbers, precision):
   rhs_tensored_shape = tuple(np.delete(rhs.shape, rhs_contract_or_batch))
   return batch_shape + lhs_tensored_shape + rhs_tensored_shape
 
-
-def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision):
-  return naryop_dtype_rule(_input_dtype, [_any, _any], 'dot_general', lhs, rhs)
-
+def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
+                            preferred_element_type: Optional[DType]):
+  input_dtype = naryop_dtype_rule(_input_dtype, [_any, _any], 'dot_general', lhs, rhs)
+  if preferred_element_type is None:
+    return input_dtype
+  if dtypes.issubdtype(input_dtype, np.integer) and not dtypes.issubdtype(preferred_element_type, np.integer):
+    raise TypeError("`preferred_element_type` and the original type must both be integral or both be floating point.")
+  if dtypes.issubdtype(input_dtype, np.signedinteger) and not dtypes.issubdtype(preferred_element_type, np.signedinteger):
+    raise TypeError("`preferred_element_type` must have the same signedness as the original type.")
+  input_bitwidth = np.dtype(input_dtype).itemsize
+  preferred_bitwidth = np.dtype(preferred_element_type).itemsize
+  if preferred_bitwidth < input_bitwidth:
+     raise TypeError("`preferred_element_type` must not be narrower than the original type.")
+  return preferred_element_type
 
 def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
+                               preferred_element_type: Optional[DType],
                                swap_ans=False):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   x_ndim = g.ndim - y.ndim + len(x_batch) + 2 * len(x_contract)
@@ -3108,24 +3129,28 @@ def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
   dims = ((ans_y, y_kept), (ans_batch, y_batch))
   x_contract_sorted_by_y = list(np.take(x_contract, np.argsort(y_contract)))
   out_axes = np.argsort(list(x_batch) + x_kept + x_contract_sorted_by_y)
-  return transpose(dot_general(g, y, dims, precision=precision),
+  return transpose(dot_general(g, y, dims, precision=precision, preferred_element_type=preferred_element_type),
                    tuple(out_axes))
 
-def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision):
+def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision,
+                               preferred_element_type: Optional[DType]):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   swapped_dimension_numbers = ((y_contract, x_contract), (y_batch, x_batch))
   return _dot_general_transpose_lhs(
     g, x, dimension_numbers=swapped_dimension_numbers, precision=precision,
+    preferred_element_type=preferred_element_type,
     swap_ans=True)
 
 
 def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
-                            precision):
+                            precision,
+                            preferred_element_type: Optional[DType]):
   lhs, rhs = batched_args
   new_dimension_numbers, result_batch_dim = _dot_general_batch_dim_nums(
       (lhs.ndim, rhs.ndim), batch_dims, dimension_numbers)
   batched_out = dot_general(lhs, rhs, new_dimension_numbers,
-                            precision=precision)
+                            precision=precision,
+                            preferred_element_type=preferred_element_type)
   return batched_out, result_batch_dim
 
 def _dot_general_batch_dim_nums(ndims, batch_dims, dimension_numbers):
@@ -3195,27 +3220,18 @@ def _dot_using_sum_of_products(lhs, rhs, *, dimension_numbers):
   return reduce(op_product(lhs, rhs), _zero(lhs), op_sum,
                 tuple(range(out_ndim, out_ndim + len(lhs_contract_dims))))
 
-def _dot_general_translation_rule(c, lhs, rhs, *, dimension_numbers, precision):
+def _dot_general_translation_rule(c, lhs, rhs, *, dimension_numbers, precision,
+                                  preferred_element_type: Optional[DType]):
+  if preferred_element_type is not None:
+    preferred_element_type = xla_client.dtype_to_etype(preferred_element_type)
   return xops.DotGeneral(lhs, rhs,
                          xc.make_dot_dimension_numbers(dimension_numbers),
-                         precision_config=_precision_config(precision))
-
-def _dot_general_cpu_translation_rule(c, lhs, rhs, *, dimension_numbers,
-                                      precision):
-  dtype = c.get_shape(lhs).numpy_dtype()
-  if dtypes.issubdtype(dtype, np.inexact):
-    return xops.DotGeneral(lhs, rhs,
-                           xc.make_dot_dimension_numbers(dimension_numbers),
-                           precision_config=_precision_config(precision))
-  else:
-    # TODO(b/134526360): XLA doesn't support bool or some integer dots on CPU,
-    # so we emit a sum of products instead.
-    translation = xla.lower_fun(_dot_using_sum_of_products,
-                                multiple_results=False)
-    return translation(c, lhs, rhs, dimension_numbers=dimension_numbers)
+                         precision_config=_precision_config(precision),
+                         preferred_element_type=preferred_element_type)
 
 def _dot_general_masking_rule(padded_vals, logical_shapes, *, dimension_numbers,
-                              precision):
+                              precision,
+                              preferred_element_type: Optional[DType]):
   lhs, rhs = padded_vals
   # Only need to mask off contraction dims of one side - we mask the lhs here
   # but this is arbitrary. Could check the sizes of lhs and rhs and mask
@@ -3223,7 +3239,8 @@ def _dot_general_masking_rule(padded_vals, logical_shapes, *, dimension_numbers,
   lhs_shape, _ = logical_shapes
   (lhs_contract, _), _ = dimension_numbers
   return dot_general(_masked(lhs, lhs_shape, lhs_contract),
-                     rhs, dimension_numbers, precision=precision)
+                     rhs, dimension_numbers, precision=precision,
+                     preferred_element_type=preferred_element_type)
 
 dot_general_p = standard_primitive(_dot_general_shape_rule,
                                    _dot_general_dtype_rule, 'dot_general',
@@ -3232,9 +3249,6 @@ ad.defbilinear(dot_general_p,
                _dot_general_transpose_lhs, _dot_general_transpose_rhs)
 batching.primitive_batchers[dot_general_p] = _dot_general_batch_rule
 masking.masking_rules[dot_general_p] = _dot_general_masking_rule
-xla.backend_specific_translations['cpu'][dot_general_p] = \
-    _dot_general_cpu_translation_rule
-
 
 def _broadcast_shape_rule(operand, sizes):
   _check_shapelike('broadcast', 'sizes', sizes)

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -797,7 +797,7 @@ def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch):
   # TODO: avals with names, check inputs are mapped along axis_name, eliminate
   return lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],
-      precision=None)
+      precision=None, preferred_element_type=None)
 
 def _pdot_vmap_collective_rule(frame, vals_in, dims_in, *, axis_name,
                                pos_contract, pos_batch):
@@ -829,7 +829,8 @@ batching.primitive_batchers[pdot_p] = _pdot_vmap_batching_rule
 def _pdot_translation_rule(c, x, y, *, axis_name, pos_contract, pos_batch,
                            axis_env, platform):
   local_out = lax._dot_general_translation_rule(
-      c, x, y, dimension_numbers=[pos_contract, pos_batch], precision=None)
+      c, x, y, dimension_numbers=[pos_contract, pos_batch], precision=None,
+      preferred_element_type=None)
   if axis_name:
     out_tup = xla.parallel_translations[psum_p](
         c, local_out, axis_name=axis_name, axis_index_groups=None,
@@ -843,11 +844,13 @@ xla.parallel_translations[pdot_p] = _pdot_translation_rule
 def _pdot_transpose_lhs(g, y, *, axis_name, pos_contract, pos_batch):
   # TODO: avals with names, call pbroadcast with axis_name
   return lax._dot_general_transpose_lhs(
-      g, y, dimension_numbers=[pos_contract, pos_batch], precision=None)
+      g, y, dimension_numbers=[pos_contract, pos_batch], precision=None,
+      preferred_element_type=None)
 def _pdot_transpose_rhs(g, x, *, axis_name, pos_contract, pos_batch):
   # TODO: avals with names, call pbroadcast with axis_name
   return lax._dot_general_transpose_rhs(
-      g, x, dimension_numbers=[pos_contract, pos_batch], precision=None)
+      g, x, dimension_numbers=[pos_contract, pos_batch], precision=None,
+      preferred_element_type=None)
 ad.defbilinear(pdot_p, _pdot_transpose_lhs, _pdot_transpose_rhs)
 
 pxla.multi_host_supported_collectives.add(pdot_p)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1287,9 +1287,10 @@ def _conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation,
 tf_impl_with_avals[lax.conv_general_dilated_p] = _conv_general_dilated
 
 
-def _dot_general(lhs, rhs, dimension_numbers, precision):
+def _dot_general(lhs, rhs, dimension_numbers, precision, preferred_element_type):
   """Implementation of lax.dot_general_p in terms of tf.linalg.einsum."""
   del precision
+  del preferred_element_type
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   lhs_dim, rhs_dim = len(lhs.shape), len(rhs.shape)
   # This condition ensures that:


### PR DESCRIPTION
XLA recently added support for this parameter to xops.DotGeneral. It's an optional parameter that controls the accumulation type used by the dot operation.

This is useful for eg quantized ANNs, where you might want to do matrix multiples with int8 tensors and get back an int32 tensor instead of an int8 tensor that suffers from severe overflow. Note it's not sufficient in this case to cast the inputs to 'dot' to int32 beforehand and rely on the default output dtype inference, since backend devices might have an accelerated path for int8*int8->int32 matmuls and we want that explicitly represented in the HLO.

Note because XLA still doesn't support integer dots on the CPU backend, that use case can't tested with a CPU-only test at the moment. I was hoping the experts could weigh on the proper place to add a test for this.

This closes https://github.com/google/jax/issues/4465.