### PR TITLE
Fix UnexpectedTracer omnistaging error.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -779,8 +779,13 @@ def full_lower(val):
     return val
 
 def find_top_trace(xs) -> Trace:
-  top_main = max((x._trace.main for x in xs if isinstance(x, Tracer)),
-                 default=None, key=attrgetter('level'))
+  top_tracer = max((x for x in xs if isinstance(x, Tracer)),
+                    default=None, key=attrgetter('_trace.level'))
+  if top_tracer is not None:
+    top_tracer._assert_live()
+    top_main = top_tracer._trace.main  # type: Optional[MainTrace]
+  else:
+    top_main = None
   dynamic = thread_local_state.trace_state.trace_stack.dynamic
   top_main = (dynamic if top_main is None or dynamic.level > top_main.level
               else top_main)


### PR DESCRIPTION
Before: 

```
jax/core.py", line 1220, in call_bind                                                                                                                                                  
    tracers = map(top_trace.full_raise, args)                                                                                                                                                                                                                                           
jax/util.py", line 36, in safe_map                                                                                                                                                     
    return list(map(f, *args))
jax/core.py", line 377, in full_raise                                                                                                                                                  
    return self.pure(val)                                                                                                                   
jax/interpreters/partial_eval.py", line 1034, in new_const                                                                                                                             
    self.frame.tracers.append(tracer)                                                                                                       
jax/interpreters/partial_eval.py", line 1022, in frame                                                                                                                                 
    return self.main.jaxpr_stack[-1]  # pytype: disable=attribute-error                                                                                                                                                                                                                 
IndexError: tuple index out of range
```

After:
```
jax/core.py", line 1219, in call_bind
    top_trace = find_top_trace(args)
jax/core.py", line 785, in find_top_trace
    top_tracer._assert_live()
jax/interpreters/partial_eval.py", line 950, in _assert_live
    raise core.escaped_tracer_error(msg)
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.
The functions being transformed should not save traced values to global state. Detail: tracer created on line (...).
```