### PR TITLE
Complex SVD JVP rule

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1171,7 +1171,6 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
     raise NotImplementedError(
       "Singular value decomposition JVP not implemented for full matrices")
 
-  k = s.shape[-1]
   Ut, V = _H(U), _H(Vt)
   s_dim = s[..., None, :]
   dS = jnp.matmul(jnp.matmul(Ut, dA), V)
@@ -1180,19 +1179,26 @@ def svd_jvp_rule(primals, tangents, full_matrices, compute_uv):
   if not compute_uv:
     return (s,), (ds,)
 
-  F = 1 / (jnp.square(s_dim) - jnp.square(_T(s_dim)) + jnp.eye(k, dtype=A.dtype))
-  F = F - jnp.eye(k, dtype=A.dtype)
-  dSS = s_dim * dS
-  SdS = _T(s_dim) * dS
-  dU = jnp.matmul(U, F * (dSS + _T(dSS)))
-  dV = jnp.matmul(V, F * (SdS + _T(SdS)))
+  s_diffs = jnp.square(s_dim) - jnp.square(_T(s_dim))
+  s_diffs_zeros = jnp.eye(s.shape[-1], dtype=A.dtype)  # jnp.ones((), dtype=A.dtype) * (s_diffs == 0.)  # is 1. where s_diffs is 0. and is 0. everywhere else
+  F = 1 / (s_diffs + s_diffs_zeros) - s_diffs_zeros
+  dSS = s_dim * dS  # dS.dot(jnp.diag(s))
+  SdS = _T(s_dim) * dS  # jnp.diag(s).dot(dS)
+
+  s_zeros = jnp.ones((), dtype=A.dtype) * (s == 0.)
+  s_inv = 1 / (s + s_zeros) - s_zeros
+  s_inv_mat = jnp.vectorize(jnp.diag, signature='(k)->(k,k)')(s_inv)
+  dUdV_diag = .5 * (dS - _H(dS)) * s_inv_mat
+  dU = jnp.matmul(U, F * (dSS + _H(dSS)) + dUdV_diag)
+  dV = jnp.matmul(V, F * (SdS + _H(SdS)))
 
   m, n = A.shape[-2:]
   if m > n:
     dU = dU + jnp.matmul(jnp.eye(m, dtype=A.dtype) - jnp.matmul(U, Ut), jnp.matmul(dA, V)) / s_dim
   if n > m:
     dV = dV + jnp.matmul(jnp.eye(n, dtype=A.dtype) - jnp.matmul(V, Vt), jnp.matmul(_H(dA), U)) / s_dim
-  return (s, U, Vt), (ds, dU, _T(dV))
+
+  return (s, U, Vt), (ds, dU, _H(dV))
 
 def _svd_cpu_gpu_translation_rule(gesvd_impl, c, operand, full_matrices, compute_uv):
 

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -559,11 +559,34 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
     self._CompileAndCheck(partial(jnp.linalg.svd, full_matrices=full_matrices, compute_uv=compute_uv),
                           args_maker)
-    if not (compute_uv and full_matrices):
+    if not compute_uv:
       svd = partial(jnp.linalg.svd, full_matrices=full_matrices,
                     compute_uv=compute_uv)
       # TODO(phawkins): these tolerances seem very loose.
-      jtu.check_jvp(svd, partial(jvp, svd), (a,), rtol=5e-2, atol=2e-1)
+      if dtype == np.complex128:
+        jtu.check_jvp(svd, partial(jvp, svd), (a,), rtol=1e-4, atol=1e-4, eps=1e-8)
+      else:
+        jtu.check_jvp(svd, partial(jvp, svd), (a,), rtol=5e-2, atol=2e-1)
+
+    if jtu.device_under_test() == "tpu":
+      raise unittest.SkipTest("TPU matmul does not have enough precision")
+    # TODO(frederikwilde): Find the appropriate precision to use for this test on TPUs.
+
+    if compute_uv and (not full_matrices):
+      b, = args_maker()
+      def f(x):
+        u, s, v = jnp.linalg.svd(
+          a + x * b,
+          full_matrices=full_matrices,
+          compute_uv=compute_uv)
+        vdiag = jnp.vectorize(jnp.diag, signature='(k)->(k,k)')
+        return jnp.matmul(jnp.matmul(u, vdiag(s)), v).real
+      _, t_out = jvp(f, (1.,), (1.,))
+      if dtype == np.complex128:
+        atol = 1e-13
+      else:
+        atol = 5e-4
+      self.assertArraysAllClose(t_out, b.real, atol=atol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_fullmatrices={}".format(


### PR DESCRIPTION
The current implementation of the singular value decomposition is only differentiable for real-valued input.
I derived the JVP rule [to appear on arxiv.org soon] for complex matrices and implemented it. I also tested it on various random matrices. Happy holidays!

Here is some minimal example to demonstrate that the current implementation does not work on complex matrices.
```Python
from jax import grad
import jax.numpy as jnp

A = jnp.array([[1.j, .5j], 
               [0.,  0. ]], dtype=jnp.complex64)
B = jnp.array([[1.,  0.],
               [0.,  0.]], dtype=jnp.complex64)
def f(x):
    U, S, V = jnp.linalg.svd(A + x * B, full_matrices=False)
    return U.dot(jnp.diag(S).dot(V))[0, 0].real

print(f'The gradient should give 1 but gives: {grad(f)(1.)}')
```