### PR TITLE
Convert arguments of pad into kwargs and handle invalid kwargs

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2521,29 +2521,30 @@ def _pad(array, pad_width, mode, constant_values, stat_length, end_values, refle
   if mode == "constant":
     return _pad_constant(array, pad_width, constant_values)
 
-  if mode == "wrap":
+  elif mode == "wrap":
     return _pad_wrap(array, pad_width)
 
-  if mode in ("symmetric", "reflect"):
+  elif mode in ("symmetric", "reflect"):
     return _pad_symmetric_or_reflect(array, pad_width, mode, reflect_type)
 
-  if mode == "edge":
+  elif mode == "edge":
     return _pad_edge(array, pad_width)
 
-  if mode == "linear_ramp":
+  elif mode == "linear_ramp":
     end_values = _broadcast_to_pairs(end_values, nd, "end_values")
     return _pad_linear_ramp(array, pad_width, end_values)
 
-  if mode in stat_funcs:
+  elif mode in stat_funcs:
     if stat_length is not None:
       stat_length = _broadcast_to_pairs(stat_length, nd, "stat_length")
     return _pad_stats(array, pad_width, stat_length, stat_funcs[mode])
 
-  if mode == "empty":
+  elif mode == "empty":
     return _pad_empty(array, pad_width)
 
-  assert False, ("Should not be reached since pad already handled unsupported and"
-                 "not implemented modes")
+  else:
+    assert False, ("Should not be reached since pad already handled unsupported and"
+                   "not implemented modes")
 
 
 @_wraps(np.pad)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1509,6 +1509,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         with self.assertRaisesRegex(ValueError, match):
           jnp.pad(arr, pad_width, mode, **{key: value})
 
+    # Test if unsupported mode raise error.
+    unsupported_modes = [1, None, "foo"]
+    for mode in unsupported_modes:
+      match = "Unimplemented padding mode '{}' for np.pad.".format(mode)
+      with self.assertRaisesRegex(NotImplementedError, match):
+        jnp.pad(arr, pad_width, mode)
+
   def testPadWithNumpyPadWidth(self):
     a = [1, 2, 3, 4, 5]
     f = jax.jit(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1477,6 +1477,38 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     np.testing.assert_equal(arr, jnp_res[2:-3, 3:-1])
     np.testing.assert_equal(np_res[2:-3, 3:-1], jnp_res[2:-3, 3:-1])
 
+  def testPadKwargs(self):
+    modes = {
+        'constant': {'constant_values': 0},
+        'edge': {},
+        'linear_ramp': {'end_values': 0},
+        'maximum': {'stat_length': None},
+        'mean': {'stat_length': None},
+        'median': {'stat_length': None},
+        'minimum': {'stat_length': None},
+        'reflect': {'reflect_type': 'even'},
+        'symmetric': {'reflect_type': 'even'},
+        'wrap': {},
+        'empty': {}
+    }
+    arr = [1, 2, 3]
+    pad_width = 1
+
+    for mode in modes.keys():
+      allowed = modes[mode]
+      not_allowed = {}
+      for kwargs in modes.values():
+        if kwargs != allowed:
+          not_allowed.update(kwargs)
+
+      # Test if allowed keyword arguments pass
+      jnp.pad(arr, pad_width, mode, **allowed)
+      # Test if prohibited keyword arguments of other modes raise an error
+      match = "unsupported keyword arguments for mode '{}'".format(mode)
+      for key, value in not_allowed.items():
+        with self.assertRaisesRegex(ValueError, match):
+          jnp.pad(arr, pad_width, mode, **{key: value})
+
   def testPadWithNumpyPadWidth(self):
     a = [1, 2, 3, 4, 5]
     f = jax.jit(
@@ -4801,7 +4833,6 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'histogramdd': ['normed'],
       'ones': ['order'],
       'ones_like': ['subok', 'order'],
-      'pad': ['kwargs'],
       'zeros_like': ['subok', 'order']
     }
 
@@ -4809,7 +4840,6 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'broadcast_to': ['arr'],
       'einsum': ['precision'],
       'einsum_path': ['subscripts'],
-      'pad': ['constant_values'],
     }
 
     mismatches = {}


### PR DESCRIPTION
Unsupported keyword argumenets for jax.numpy.pad should raise an error.
In numpy,

```python
>>> import numpy as np
>>> a = [1, 2, 3]
>>> np.pad(a, mode='maximum', pad_width=2, reflect_type='odd')
ValueError: unsupported keyword arguments for mode 'maximum': {'reflect_type'}
```

In jax,
Before
```python
>>> import jax.numpy as jnp
>>> a = [1, 2, 3]
>>> jnp.pad(a, mode='maximum', pad_width=2, reflect_type='odd')
DeviceArray([3, 3, 1, 2, 3, 3, 3], dtype=int32)
```

After
```python
>>> import jax.numpy as jnp
>>> a = [1, 2, 3]
>>> jnp.pad(a, mode='maximum', pad_width=2, reflect_type='odd')
ValueError: unsupported keyword arguments for mode 'maximum': {'reflect_type'}
```

Related #5010 