### PR TITLE
Remove tracing special case for trivial subcomputations.

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -199,16 +199,6 @@ class JaxprTrace(Trace):
                    PartialVal.unknown(pval[0])
                    for pval, out_axis in zip(out_pvals, out_axes)]
 
-    # Avoid staging out trivial calls, but maps may involve broadcasting.
-    if not jaxpr.eqns and not primitive.map_primitive:
-      env = {core.unitvar: core.unit}
-      map(env.setdefault, jaxpr.invars, (*env_tracers, *tracers))
-      map(env.setdefault, jaxpr.constvars, consts)
-      return [v.val if type(v) is Literal
-              else pval.get_known() if pval.is_known()
-              else env[v]
-              for v, pval in zip(jaxpr.outvars, out_pvals)]
-
     # Skip known invars and outvars, and lift constants as regular invars
     in_knowns = tuple(t.pval.is_known() for t in it.chain(env_tracers, tracers))
     out_unknowns = tuple(not pval.is_known() for pval in out_pvals)


### PR DESCRIPTION
This undoes #3169 now that omnistaging is in. I'm having trouble
reproducing the original issue with omnistaging disabled (#3143), but
my understanding is that we should no longer have issues with values
being forced by jitted subcomputations, since jit no longer partially
evaluates.

The motivation for this change is that this special case occasionally
causes confusion and unexpected behavior. For example, it bypasses
call-specific error checking (#5188) and can cause trivial nested
pmaps and sharded_jits, which are useful for pre-sharding data across
devices, to have no effect.