### PR TITLE
[host_callback] Added API to call host computations and return values to the accelerator computation

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -15,8 +15,11 @@ jax 0.2.8 (Unreleased)
 
 * New features:
 
-  * Add ``jax.closure_convert`` for use with higher-order custom
+  * Add :func:`jax.closure_convert` for use with higher-order custom
     derivative functions. (`#5244 <https://github.com/google/jax/pull/5244>`_)
+  * Add :func:`jax.experimental.host_callback.call` to call a custom Python
+    function on the host and return a result to the device computation.
+    (`#5243 <https://github.com/google/jax/pull/5243>`_)
 
 * Bug fixes:
 
@@ -26,13 +29,23 @@ jax 0.2.8 (Unreleased)
     optional parameter for ``id_tap`` and ``id_print`` to request that the
     device from which the value is tapped be passed as a keyword argument
     to the tap function (`#5182 <https://github.com/google/jax/pull/5182>`_).
-  * ``host_callback.outfeed_receiver`` has been removed (it is not necessary,
-    and was deprecated a few months ago).
+
 
 * Breaking changes:
 
-  * ``jax.numpy.pad`` now take keyword arguments. Positional argument ``constant_values``
+  * ``jax.numpy.pad`` now takes keyword arguments. Positional argument ``constant_values``
     has been removed. In addition, passing unsupported keyword arguments raises an error.
+  * Changes for :func:`jax.experimental.host_callback.id_tap` (`#5243 <https://github.com/google/jax/pull/5243>`_):
+
+    * Removed support for ``kwargs`` for :func:`jax.experimental.host_callback.id_tap`.
+      (This support has been deprecated for a few months.)
+    * Changed the printing of tuples for :func:`jax.experimental.host_callback.id_print`
+      to use '(' instead of '['.
+    * Changed the :func:`jax.experimental.host_callback.id_print` in presence of JVP
+      to print a pair of primal and tangent. Previously, there were two separate
+      print operations for the primals and the tangent.
+    * ``host_callback.outfeed_receiver`` has been removed (it is not necessary,
+      and was deprecated a few months ago).
 
 jax 0.2.7 (Dec 4 2020)
 ----------------------

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -233,7 +233,8 @@ For each automated documentation build you can see the
 
 If you want to test the documentation generation on Readthedocs, you can push code to the ``test-docs``
 branch. That branch is also built automatically, and you can
-see the generated documentation `here <https://jax.readthedocs.io/en/test-docs/>`_.
+see the generated documentation `here <https://jax.readthedocs.io/en/test-docs/>`_. If the documentation build
+fails you may want to `wipe the build environment for test-docs <https://docs.readthedocs.io/en/stable/guides/wipe-environment.html>`_.
 
 For a local test, I was able to do it in a fresh directory by replaying the commands
 I saw in the Readthedocs logs::

--- a/docs/jax.experimental.host_callback.rst
+++ b/docs/jax.experimental.host_callback.rst
@@ -9,7 +9,8 @@ API
 
 .. autofunction:: id_tap
 .. autofunction:: id_print
-.. autofunction:: outfeed_receiver
+.. autofunction:: call
+.. autofunction:: barrier_wait
 .. autoexception:: TapFunctionException
 
 

--- a/docs/jax.experimental.host_callback.rst
+++ b/docs/jax.experimental.host_callback.rst
@@ -11,7 +11,7 @@ API
 .. autofunction:: id_print
 .. autofunction:: call
 .. autofunction:: barrier_wait
-.. autoexception:: TapFunctionException
+.. autoexception:: CallbackException
 
 
 

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -40,7 +40,7 @@ NumPy arrays to the device computation.
 Host computation is useful, e.g., when a device computation needs some data
 that requires I/O on the host, or it needs a library that is available on the
 host and you do not want to code it in JAX.
-For example, eigen decomposition in JAX does not work on TPU.
+For example, eigen decomposition for general matrices in JAX does not work on TPU.
 We can call the Numpy implementation from any JAX accelerator computation,
 using a host computation::
 
@@ -447,7 +447,7 @@ def id_tap(tap_func, arg, *, result=None, tap_with_device=False, **kwargs):
         "Support for **kwargs in ``id_tap`` has been removed. Instead, "
         "pre-apply keyword arguments, either by using a closure or by passing "
         "``functools.partial(tap_func, **kwargs)``.")
-    raise ValueError(msg)
+    raise TypeError(msg)
 
   _initialize_outfeed_receiver()  # Lazy initialization
   api._check_callable(tap_func)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -11,12 +11,118 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Primitives for calling from accelerators to Python functions on the host.
+"""Primitives for calling from JAX accelerator code to Python functions on the host.
 
 **Experimental: please give feedback, and expect changes.**
 
-This module introduces the host callback functions :func:`id_tap` and
-:func:`id_print`, which behave like the identity function but have the
+This module introduces the host callback functions :func:`call`,
+:func:`id_tap`, and :func:`id_print`, that send their arguments from the device
+to the host and invoke user-defined Python functions on the host, optionally
+returning results back to the device computation.
+
+We show below how these functions can be used. We start with :func:`call`,
+and we discuss examples of calling from JAX to NumPy CPU custom kernels,
+or to TensorFlow functions, or to JAX running on another device. In the latter
+two cases we show how we can support JAX autodiff for the host callbacks,
+by deferring to the reverse-mode AD on the target platform. Then we
+show uses of :func:`id_tap` and :func:`id_print`, which have the restriction
+that they cannot return values from the host to the device.
+These primitives are generally faster
+because they are executed asynchronously with the device code and they also
+support the whole spectrum of JAX transformations. In particular, they can be
+used to tap into and to debug JAX-transformed code.
+
+Using :func:`call` to call a host function and return results to device
+-----------------------------------------------------------------------
+
+Use :func:`call` to invoke a computation on the host and return
+NumPy arrays to the device computation.
+Host computation is useful, e.g., when a device computation needs some data
+that requires I/O on the host, or it needs a library that is available on the
+host and you do not want to code it in JAX.
+For example, eigen decomposition in JAX does not work on TPU.
+We can call the Numpy implementation from any JAX accelerator computation,
+using a host computation::
+
+  # This function runs on the host
+  def host_eig(m: np.ndarray) -> np.ndarray:
+    return np.linalg.eigvals(m)
+
+  # This function is used in JAX
+  def device_fun(m):
+    # We send "m" to the host, asking it to call "host_eig" and return the result.
+    # We have to specify the result shape and dtype, either in the form of an
+    # example return value or any object that has `shape` and `dtype` attributes,
+    # e.g., a NumPy array or a `jax.ShapeDtypeStruct`.
+    return hcb.call(host_eig, m,
+                    # Given an input of shape (..., d, d), eig output has shape (..., d)
+                    result_shape=jax.ShapeDtypeStruct(m.shape[:-1], m.dtype))
+
+
+The :func:`call` function and the Python host function both take a single argument
+and return a single result, but those can be pytrees. Note that we must tell
+the :func:`call` what shape and dtype to expect from the host invocation, using
+the ``result_shape`` kwarg.
+This is important because the device code is compiled with that expectation.
+There will be an error raised at runtime if the actual invocation produces a
+different result shape. In general, **such errors and also exceptions raised
+by the host computation may be difficult to debug**. See the Debugging section
+below.
+This is a problem for :func:`call` but not for :func:`id_tap`.
+
+The :func:`call` API can be used inside a jit or pmap computation or inside
+cond/scan/while control flow. When used inside :func:`jax.pmap`, there will be
+separate calls to the host from each of the participating devices::
+
+  def host_sin(x, *, device):
+    print(f"Invoking host_sin with {x.shape} on {device}")
+    return np.sin(x)
+
+  # Use pmap to run the computation on two devices
+  jax.pmap(lambda x: hcb.call(host_sin, x,
+                              result_shape=x,
+                              # Ask that the `host_sin` function be passed `device=dev`
+                              call_with_device=True))(
+           np.ones((2, 4), dtype=np.float32))
+
+  # prints (in arbitrary order)
+  # Invoking host_sin with (4,) on cpu:0
+  # Invoking host_sin with (4,) on cpu:1
+
+Note that :func:`call` does not (yet) support any JAX transformations, but as we
+show in the next section one can make use of the
+existing support for `Custom differentiation in JAX <https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html>`_.
+
+Using :func:`call` to call a TensorFlow function, with reverse-mode autodiff support
+------------------------------------------------------------------------------------
+
+Another possible use for host computation is to invoke a library written for
+another framework, such as TensorFlow.
+In this case it becomes interesting to support JAX autodiff for host callbacks
+by defering to the autodiff mechanism in TensorFlow,
+using the :func:`jax.custom_vjp` mechanism.
+
+This is relatively easy to do, once one understands both the JAX custom VJP
+and the TensorFlow autodiff mechanisms.
+The code for how this can be done is shown in the ``call_tf_full_ad``
+function in `host_callback_to_tf_test.py <https://github.com/google/jax/blob/master/tests/host_callback_to_tf_test.py>`_.
+This example supports arbitrary higher-order differentiation as well.
+
+Using :func:`call` to call a JAX function on another device, with reverse-mode autodiff support
+------------------------------------------------------------------------------------------------
+
+It should not be surprising that we can use host computation to invoke a JAX
+computation on another device. The arguments are sent from the accelerator to
+the host, and then to the outside device on which the JAX host
+computation will run, and then the results are sent back to the original accelerator.
+
+The code for how this can be done is shown in the ``call_jax_other_device function``
+in `host_callback_test.py <https://github.com/google/jax/blob/master/tests/host_callback_test.py>`_.
+
+Using :func:`id_tap` to call a JAX function on another device, with no returned values, but full JAX transformation support
+---------------------------------------------------------------------------------------------------------------------------
+
+The :func:`id_tap` and :func:`id_print` behave like the identity function but have the
 side-effect of sending the arguments from the device to the host and
 invoking a user-specified Python function (for :func:`id_tap`) or printing the
 arguments on the host (for :func:`id_print`). The Python function passed
@@ -45,7 +151,7 @@ the difference that :func:`id_print` takes one positional argument (to print
 on the host), the optional kwarg ``result``, and possibly additional kwargs
 that are also printed along with the automatic kwarg ``transforms``.
 
-The order of execution of the tap functions is constrained by data dependency:
+The order of execution of the callback functions is constrained by data dependency:
 the arguments are tapped after all the arguments are computed and before the
 result of the call is used. As of September 2020, it is not strictly necessary
 anymore for the results of the tap to be used in the rest of the computation.
@@ -55,48 +161,14 @@ You can just do::
 
 The tap function will execute based on program order. However, if this code
 is subject to transformations, it is possible for the tap to appear to
-the transformation as dead code and to be removed from the computation.
+the transformation as dead code and to be removed from the computation. In
+that case it is best to use the result of the callback.
 
-The host tap functions will be executed for each device in the order in which
-the send operations were performed on the device.
+Behavior under JAX transformations
+----------------------------------
 
-The host tap functions for multiple devices may be interleaved.
-The data from the devices is received by separate threads managed by the JAX
-runtime (one thread per device). The runtime maintains a buffer of
-configurable size. When the buffer is full, all the receiving threads are paused
-which eventually pauses the computation on devices. The runtime has one
-additional thread that invokes the Python user functions with the received data.
-If the processing of the callbacks is slow, it may actually lead to the runtime
-buffer filling up, and eventually pausing the computation on the devices
-when they need to send something. For more details on the outfeed receiver
-runtime mechanism see
-`runtime code
-<https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/python/outfeed_receiver.cc>`_.
-
-Exceptions from the user-defined tap functions are logged along with their
-stack traces, but the receiving threads are not stopped.
-
-In order to pause the execution until all data from computations already
-started on devices has arrived and has been processed, use :func:`barrier_wait`.
-This will also raise :exc:`TapFunctionException` if any exception had occurred
-in one of the tap functions.
-
-The current implementation uses the outfeed mechanism provided by XLA. The
-mechanism itself is quite primitive in the sense that a receiver must know
-exactly the shape of each incoming packet, and how many packets are expected.
-This makes it hard to use for multiple kinds of data in the same computation,
-and it is practically impossible to use it under conditionals or in loops
-of non-constant iteration count. Furthermore, code that uses the outfeed
-mechanism directly cannot be transformed by JAX. All these limitations are
-addressed by the host callback functions. The tapping API introduced here
-makes it easy to share the outfeed mechanism for multiple purposes, while
-supporting all transformations.
-
-**Note that after you have used the host callback functions, you cannot
-use lax.outfeed directly**. You may want to :func:`stop_outfeed_receiver`
-if you later need to use lax.outfeed.
-
-We describe the behaviour under transformations in the context of the
+We describe the behaviour under transformations for :func:`id_tap` and
+:func:`id_print` in the context of the
 following function definition::
 
   def power3(x):
@@ -148,24 +220,88 @@ or :func:`id_tap`, so that you see which device is sending which data::
 See documentation for :func:`id_tap` and :func:`id_print`.
 For more usage example, see tests/host_callback_test.py.
 
-Still to do:
-  * Performance tests.
-  * Add flags for logging.
-  * Add unit tests with mocks.
-  * Explore implementation with outside compilation.
-  * Explore an extended API that allows the host function to return
-    values to the accelerator computation.
-
-
 Low-level details and debugging
 -------------------------------
+
+The host callback functions will be executed for each device in the order in which
+the send operations were performed on the device.
+
+The host callback functions for multiple devices may be interleaved.
+The data from the devices is received by separate threads managed by the JAX
+runtime (one thread per device). The runtime maintains a buffer of
+configurable size. When the buffer is full, all the receiving threads are paused
+which eventually pauses the computation on devices. The runtime has one
+additional thread that invokes the Python user functions with the received data.
+If the processing of the callbacks is slow, it may actually lead to the runtime
+buffer filling up, and eventually pausing the computation on the devices
+when they need to send something. For more details on the outfeed receiver
+runtime mechanism see
+`runtime code
+<https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/python/outfeed_receiver.cc>`_.
+
+In order to pause the execution until all data from computations already
+started on devices has arrived and has been processed, use :func:`barrier_wait`.
+Note that this is needed only for :func:`id_tap` and :func:`id_print`, which
+are processed asyncronously with the device computation.
+
+Exceptions from the user-defined callback functions are logged along with their
+stack traces, but the receiving threads are not stopped. Instead the last
+exception is recorded and the subsequent :func:`barrier_wait` will
+raise :exc:`TapFunctionException` if any exception had occurred
+in one of the tap functions. This exception will include the text and the
+stack trace of the last exception encountered.
+
+One further complication arises for callback functions that must return
+results to the call origin device. In order to avoid the device computation
+being stuck waiting for a result that will never arrive, in case of any
+error during the processing of the callback (whether raised by the user-code
+itself or due to a mismatch of the returned value and the expected return_shape)
+we send the device a "fake" result of shape ``int8[12345]``. This will make the device
+computation abort because the received data is different than then one that
+it expects. On CPU the runtime will crash with a distinctive error message:
+
+```
+Check failed: buffer->length() == buffer_length (12345 vs. ...)
+```
+
+On GPU, the failure is more user-friendly and will be surfaced to the Python
+program as:
+
+```
+RET_CHECK failure ... Mismatch between infeed source buffer shape s8[12345] ...
+```
+
+On TPU, there is currently no shape check for infeed, so we take the safer
+route to not send anything in case of errors, and let the computation hang.
+
+The current implementation uses the outfeed mechanism provided by XLA. The
+mechanism itself is quite primitive in the sense that a receiver must know
+exactly the shape of each incoming packet, and how many packets are expected.
+This makes it hard to use for multiple kinds of data in the same computation,
+and it is practically impossible to use it under conditionals or in loops
+of non-constant iteration count. Furthermore, code that uses the outfeed
+mechanism directly cannot be transformed by JAX. All these limitations are
+addressed by the host callback functions. The tapping API introduced here
+makes it easy to share the outfeed mechanism for multiple purposes, while
+supporting all transformations.
+
+**Note that after you have used the host callback functions, you cannot
+use lax.outfeed directly**. You may want to :func:`stop_outfeed_receiver`
+if you later need to use lax.outfeed.
+
+Since the actual calls to your callback functions are made from the C++
+receiver, it may be hard to debug the calls. In particular, the stack trace
+will not include the calling code. You can use the flag
+``jax_inline_host_callback`` (or the environment variable
+``JAX_INLINE_HOST_CALLBACK``) to ensure that the calls to the callbacks are
+inlined. This works only if the calls are outside a staging context (``jit``
+or a control-flow primitive).
 
 The C++ `receiver
 <https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/python/outfeed_receiver.cc>`_
 is started automatically on the first call to :func:`id_tap`. In order to stop
 it properly, upon start an ``atexit`` handler is registered to call
 :func:`barrier_wait` with the logging name "at_exit".
-
 
 There are a few environment variables that you can use to turn on logging
 for the C++ outfeed `receiver backend
@@ -183,17 +319,32 @@ You should also use the ``--verbosity=2`` flag so that you see the logs from Pyt
 
 For example:
 ```
-TF_CPP_MIN_LOG_LEVEL=0 TF_CPP_VMODULE=outfeed_receiver=3,host_callback=3,outfeed_receiver_py=3,outfeed_thunk=3,cpu_transfer_manager=3,xfeed_manager=3,pjrt_client=3 python tests/host_callback_test.py --verbosity=2 HostCallbackTest.test_jit_simple
+TF_CPP_MIN_LOG_LEVEL=0 TF_CPP_VMODULE=outfeed_receiver=3,host_callback=3,outfeed_receiver_py=3,outfeed_thunk=3,infeed_thunk=3,cpu_transfer_manager=3,cpu_runtime=3,xfeed_manager=3,pjrt_client=3 python tests/host_callback_test.py --verbosity=2 HostCallbackIdTapTest.test_jit_simple
 ```
+
+(For blaze tests use --test_arg=--vmodule=...
+
+Still to do:
+  * More performance tests.
+  * Explore implementation with outside compilation for TPU.
+  * Explore implementation with XLA CustomCall for CPU and GPU.
+
 """
-from absl import logging
 import atexit
 import functools
 import itertools
+import threading
+import traceback
+from typing import (Any, Callable, Dict, List, Optional, NamedTuple, Sequence,
+                    Tuple, TypeVar, cast)
+import typing
+from absl import logging
 
 from jax import api
 from jax import core
+from jax.config import config, bool_env
 from jax import custom_derivatives
+from jax import dtypes
 from jax import lax
 from jax.lib import pytree
 from jax.interpreters import ad, xla, batching, masking, pxla
@@ -204,14 +355,22 @@ from jax import util
 from jaxlib import xla_client
 from jaxlib import xla_extension
 
-
 import numpy as np
-import threading
-import traceback
-from typing import (Any, Callable, Dict, List, Optional, NamedTuple, Sequence,
-                    Tuple, TypeVar, cast)
-import typing
-import warnings
+
+
+FLAGS = config.FLAGS
+config.DEFINE_bool(
+    'jax_inline_host_callback',
+    bool_env('JAX_INLINE_HOST_CALLBACK', False),
+    help='Inline the host_callback, if not in a staged context.'
+)
+
+def inline_host_callback() -> bool:
+  try:
+    return FLAGS.jax_inline_host_callback
+  except AttributeError:
+    # TODO: I cannot get this flag to be seen for py3.6 tests in Github
+    return False
 
 xops = xla_client._xla.ops
 
@@ -222,23 +381,26 @@ XlaComputationBuilder = Any  # xla_bridge._JaxComputationBuilder
 XlaDevice = Any  # xla_client.Device
 XlaLocalClient = Any  # xla_extension.LocalClient
 
-
 T = TypeVar('T')
 U = TypeVar('U')
 _Transforms = Sequence[Tuple[str, Dict[str, Any]]]
 _TapFunc = Callable[[T, _Transforms], Any]
 
+
 @typing.overload
 def id_tap(tap_func: _TapFunc, arg: T) -> T:
   ...
+
 
 @typing.overload
 def id_tap(tap_func: _TapFunc, arg: T, *, result: U) -> U:
   ...
 
+
 @typing.overload
 def id_tap(tap_func: _TapFunc, arg: T, *, result: U, tap_with_device: bool) -> U:
   ...
+
 
 def id_tap(tap_func, arg, *, result=None, tap_with_device=False, **kwargs):
   """Host-callback tap primitive, like identity function with a call to ``tap_func``.
@@ -278,16 +440,15 @@ def id_tap(tap_func, arg, *, result=None, tap_with_device=False, **kwargs):
 
   For more details see the
   `module documentation
-  <https://jax.readthedocs.io/en/latest/jax.experimental.host_callback.html>`_.
+  <jax.experimental.host_callback.html>`_.
   """
   if kwargs:
-    warnings.warn(
-        "Support for **kwargs in ``id_tap`` is deprecated and will be removed "
-        "in the future. Instead, pre-apply keyword arguments, either by using "
-        "a closure or by passing ``functools.partial(tap_func, **kwargs)`` "
-        "instead.",
-        FutureWarning, stacklevel=2)
-    tap_func = functools.partial(tap_func, **kwargs)
+    msg = (
+        "Support for **kwargs in ``id_tap`` has been removed. Instead, "
+        "pre-apply keyword arguments, either by using a closure or by passing "
+        "``functools.partial(tap_func, **kwargs)``.")
+    raise ValueError(msg)
+
   _initialize_outfeed_receiver()  # Lazy initialization
   api._check_callable(tap_func)
   flat_args, arg_treedef = pytree.flatten(arg)
@@ -297,18 +458,17 @@ def id_tap(tap_func, arg, *, result=None, tap_with_device=False, **kwargs):
   params = {}
   params["tap_func_"] = tap_func
   params["arg_treedef_"] = arg_treedef
-  params["nr_tapped_args_"] = len(flat_args)
   if tap_with_device:
     params["tap_with_device_"] = tap_with_device
   if result is not None:
     flat_results, result_treedef = pytree.flatten(result)
     for result in flat_results:
       api._check_arg(result)
-    all_args = flat_args + flat_results
-    nr_results = len(flat_results)
-    flat_outs = id_tap_p.bind(*all_args, **params)  # Returns all_args
-    flat_results = flat_outs[-nr_results:]  # type: ignore[unsupported-operands]
-    return result_treedef.unflatten(flat_results)
+    flat_outs = id_tap_p.bind(*flat_args, **params)  # Returns all_args
+    assert flat_outs
+    flat_tied_results = [id_tap_dep_p.bind(r, flat_outs[0])
+                         for r in flat_results]
+    return result_treedef.unflatten(flat_tied_results)
   else:
     flat_outs = id_tap_p.bind(*flat_args, **params)
     return arg_treedef.unflatten(flat_outs)
@@ -341,33 +501,105 @@ def id_print(arg, *, result=None, tap_with_device=False,
   return id_tap(printer, arg, result=result, tap_with_device=tap_with_device)
 
 
-def _unpack_transform(name, *params):
-  if name == "batch":
-    return name, dict(batch_dims=params[0])
-  elif name == "mask":
-    return name, dict(logical_shapes=params[0])
-  else:
-    assert not params, f"{name}, {params}"
-    return name, dict()
+def call(callback_func: Callable, arg, *,
+         result_shape=None,
+         call_with_device=False):
+  """Make a call to the host, and expect a result.
+
+  **Experimental: please give feedback, and expect changes!**
+
+  Args:
+    callback_func: The Python function to invoke on the host as
+      ``callback_func(arg)``. If the ``call_with_device`` optional argument is True,
+      then the invocation also includes the ``device`` kwarg with the device
+      from which the call originates: ``callback_func(arg, device=dev)``. This function
+      must return a pytree of numpy ndarrays.
+
+    arg: the argument passed to the callback function, can be a pytree of JAX
+      types.
+
+    result_shape: a value that describes the expected shape and dtype of the
+      result. This can be a numeric scalar, from which a shape and dtype are
+      obtained, or an object that has ``.shape`` and ``.dtype`` attributes.
+      If the result of the callback is a pytree, then ``result_shape`` should
+      also be a pytree with the same structure. In particular, ``result_shape``
+      can be `()` or `None` if the function does not have any results.
+      The device code containing ``call`` is compiled with the expected result shape and dtype,
+      and an error will be raised at runtime if the actual ``callback_func``
+      invocation returns a different kind of result.
+
+    call_with_device: if True then the callback function is invoked with the
+      device from which the call originates as a keyword argument.
+
+  Returns:
+    the result of the ``callback_func`` invocation.
+
+  For more details see the
+  `module documentation
+  <jax.experimental.host_callback.html>`_.
+  """
+  _initialize_outfeed_receiver()  # Lazy initialization
+  api._check_callable(callback_func)
+  flat_args, arg_treedef = pytree.flatten(arg)
+  for arg in flat_args:
+    api._check_arg(arg)
+  # See definition of outside_call_p for what parameters it takes
+  params: Dict[str, Any] = {}
+  params["outside_computation"] = callback_func
+  params["call_with_device"] = call_with_device
+  flat_args_aval = [core.raise_to_shaped(core.get_aval(a)) for a in flat_args]
+  params["arg_treedef"] = arg_treedef
+  params["flat_args_aval"] = tuple(flat_args_aval)
+
+  # Turn abstract values into ShapesDtypeStruct
+  flat_results_shape, result_treedef = pytree.flatten(result_shape)
+  try:
+    flat_results_aval = [core.ShapedArray(np.shape(r), dtypes.result_type(r))
+                         for r in flat_results_shape]
+  except Exception:
+    msg = ("result_shape should be a pytree of values with structure "
+           "matching the expected result of the callback function. The "
+           "values must be either numeric scalars, or must have 'shape' and "
+           f"'dtype' attributes. Got {result_shape}")
+    raise ValueError(msg)
+
+  params["result_treedef"] = result_treedef
+  params["flat_results_aval"] = tuple(flat_results_aval)
+  flat_results = outside_call_p.bind(*flat_args, **params)
+  return result_treedef.unflatten(flat_results)
 
 
 # A registry of outfeed consumers, used upon receiving outfeeds
 class _ConsumerCallable(NamedTuple):
-  """Host-side information for an outfeed consumer."""
+  """Host-side information for an outfeed consumer.
+
+  Must be hashable.
+  """
+  # All fields are private
   func: Callable
   transforms: Tuple[tuple, ...]
   tap_with_device: bool
   arg_treedef: Any
-  arg_shape: XlaShape  # XlaShape implements __hash__.
 
   def _unpack_transforms(self) -> Tuple[Tuple[str, Dict[str, Any]], ...]:
+    def _unpack_transform(name, *params):
+      if name == "batch":
+        return name, dict(batch_dims=params[0])
+      elif name == "mask":
+        return name, dict(logical_shapes=5)
+      else:
+        assert not params, f"{name}, {params}"
+        return name, dict()
+
     return tuple(_unpack_transform(*t) for t in self.transforms)
 
-  def invoke(self, arg, device):
+  def invoke(self, arrays, device):
+    arg = api.tree_unflatten(self.arg_treedef, arrays)
     if self.tap_with_device:
       return self.func(arg, self._unpack_transforms(), device=device)
     else:
       return self.func(arg, self._unpack_transforms())
+
 
 def _register_consumer(cons: _ConsumerCallable) -> int:
   """Registers a tap function, cache by hash of cons."""
@@ -400,6 +632,7 @@ def _print_consumer(
     threshold: the value of numpy.array2string threshold parameter.
     **kwargs: all other keyword args are printed before printing `arg`.
   """
+
   def emit_str(s: str):
     if output_stream is not None:
       output_stream.write(s + "\n")
@@ -418,7 +651,10 @@ def _print_consumer(
     emit_str(kv_pairs)
 
   def pp_val(arg) -> ppu.PrettyPrint:
-    if isinstance(arg, (tuple, list)):
+    if isinstance(arg, tuple):
+      return (
+          ppu.pp("( ") >> ppu.vcat([pp_val(e) for e in arg]) >> ppu.pp(" )"))
+    elif isinstance(arg, list):
       return (
           ppu.pp("[ ") >> ppu.vcat([pp_val(e) for e in arg]) >> ppu.pp(" ]"))
     elif isinstance(arg, dict):
@@ -433,61 +669,159 @@ def _print_consumer(
   emit_str(str(pp_val(arg)))
 
 
+def _outside_call_consumer(call_func, expected_result_treedef,
+                           expected_flat_results_aval, call_with_device,
+                           arg, transforms,
+                           *, device):
+  logging.vlog(2, f"Outside call consumer invoking call_func {call_func} with {arg}")
+  try:
+    if call_with_device:
+      res = call_func(arg, device=device)
+    else:
+      res = call_func(arg)
+
+    flat_results, result_treedef = pytree.flatten(res)
+    canonical_flat_results = util.safe_map(xla.canonicalize_dtype, flat_results)
+    flat_results_aval = [core.raise_to_shaped(core.get_aval(r), weak_type=False)
+                         for r in canonical_flat_results]
+    logging.vlog(2, f"Outside call consumer {call_func} result {res} : {flat_results_aval}. Sending to infeed.")
+
+    if expected_result_treedef != result_treedef:
+      msg = (f"Callback func {call_func} should have returned a result "
+             f"with pytree {expected_result_treedef} but returned "
+             f"{result_treedef}")
+      raise TypeError(msg)
+
+    if not all(ea.strip_weak_type() == ra.strip_weak_type()
+               for ea, ra in util.safe_zip(expected_flat_results_aval,
+                                           flat_results_aval)):
+      msg = (f"Callback func {call_func} should have returned a result "
+             "with abstract values "
+             f"{expected_result_treedef.unflatten(expected_flat_results_aval)} "
+             f"but returned {result_treedef.unflatten(flat_results_aval)}")
+      raise TypeError(msg)
+  except Exception as e:
+    # Prepare some results to send in case of error. We are sending something
+    # with a distinctive shape (int8[12345]), one that is unlikely to be what the device
+    # expects. This should have the effect to abort the device computation,
+    # with an error message that we recognize. On TPU there seem to be no
+    # such check, and if we send anything at all the device computation will
+    # use some garbage data. So, on TPU we prefer to not send anything and let
+    # the computation hang.
+    if device.platform == "tpu":
+      canonical_flat_results = None
+    else:
+      canonical_flat_results = [xla.canonicalize_dtype(np.arange(12345, dtype=np.int8))]
+    logging.vlog(2, f"Outside call consumer {call_func} exception {e}. Sending to infeed the error result.")
+    raise e
+  finally:
+    # No matter what, if the device expects results we must send something,
+    # otherwise the device computation hangs forever.
+    # We must transfer the flattened results, as a tuple
+    if expected_flat_results_aval and canonical_flat_results is not None:
+      device.transfer_to_infeed(tuple(canonical_flat_results))
+
+
+### The id_tap_dep primitive
+"""
+The id_tap_dep_p primitive is used to create a dependency of the result of
+id_tap on the actual tap operation. This is only needed when the
+id_tap function is used with the `result` parameter. This primitive acts
+as the identity operator on the first argument.
+
+For example, given `id_tap(f, (a, b), result=(r, s)`, we convert this to
+
+   a1, b1 = id_tap_p(f, a, b)
+   r1 = id_tap_dep_p(r, a1)
+   s1 = id_tap_dep_p(s, a1)
+
+There are always two arguments and the result is equal to the first.
+"""
+id_tap_dep_p = core.Primitive("id_tap_dep")
+id_tap_dep_p.multiple_results = False
+id_tap_dep_p.def_impl(lambda r, _: r)
+xla.translations[id_tap_dep_p] = lambda comp, a_res, a_tap: a_res
+id_tap_dep_p.def_abstract_eval(lambda r_a, _: r_a)
+ad.primitive_jvps[id_tap_dep_p] = (
+    lambda primals, tangents: (
+        id_tap_dep_p.bind(primals[0], primals[1]),
+        id_tap_dep_p.bind(tangents[0], tangents[1])))
+
+
+def _id_tap_dep_transpose_rule(cts, arg_res, arg_tap):
+  assert ad.is_undefined_primal(arg_res)
+  assert ad.is_undefined_primal(arg_tap)
+  return (_instantiate_zeros(arg_res, cts), ad.Zero(arg_tap.aval))
+
+
+ad.primitive_transposes[id_tap_dep_p] = _id_tap_dep_transpose_rule
+
+
+def _id_tap_dep_batching_rule(batched_args, batch_dims):
+  arg_res, arg_tap = batched_args
+  return id_tap_dep_p.bind(arg_res, arg_tap), batch_dims[0]
+
+
+batching.primitive_batchers[id_tap_dep_p] = _id_tap_dep_batching_rule
+
+
+def _id_tap_dep_masking_rule(operands, operands_logical_shapes):
+  arg_res, arg_tap = operands
+  return id_tap_dep_p.bind(arg_res, arg_tap)
+
+
+masking.masking_rules[id_tap_dep_p] = _id_tap_dep_masking_rule
+
+### The id_tap_p primitive
 """The id_tap_p primitive acts like the identity function.
 
 It has a number of positional arguments. The result of the primitive are
 the positional arguments.
 
 The primitive has the following parameters:
-  * has_token_: a boolean, when True it means that the last positional argument
-    is the current token. In this case, the result of the primitive is
-    going to be the non-token positional arguments, along with the updated
-    token. The tokens and this parameter are added after all the JAX
-    transformations, just before staging XLA.
-  * nr_tapped_args_: how many positional arguments from the head should be
-    passed to the tap function. The remaining positional arguments are there
-    for data dependency, for implementing the "result" feature, and for
-    the current token.
-  * tapped_args_treedef_: the treedef of the tapped positional arguments.
   * tap_func_: the actual (Python) function to invoke with the tapped positional
     arguments (unflatted according to tapped_args_treedef_) and
     the parameters that were passed to the id_tap function.
+  * arg_treedef_: the treedef of the tapped positional argument.
+  * tap_with_device_: a boolean that specifies whether the tap function
+    takes an additional device keyword argument.
   * transforms: a tuple of the transformations that have been applied. Each
     element of the tuple is itself a tuple with the first element the name
     of the transform. The remaining elements depend on the transform. For
     example, for `batch`, the parameters are the dimensions that have been
     batched, and for `mask` the logical shapes. These are unpacked by
     _ConsumerCallable before passing to the user function.
-  * tap_with_device_: a boolean that specifies whether the tap function
-    takes an additional device keyword argument.
-  * the remaining parameters are from the user's invocation of the id_tap
-    API function and are passed to the tap function.
+  * has_token_: a boolean, when True it means that the last positional argument
+    is the current token. In this case, the result of the primitive is
+    going to be the non-token positional arguments, along with the updated
+    token. The tokens and this parameter are added after all the JAX
+    transformations, just before staging XLA.
 """
 id_tap_p = core.Primitive("id_tap")
 id_tap_p.multiple_results = True
 xla.outfeed_primitives.add(id_tap_p)
 
 
-def _add_transform(params: Dict, name: str, *transform_params) -> Dict:
-  """Adds the `transform` to the params["transforms"].
-
-  Uses a tuple representation internally, will be unpacked before the
-  callback by _ConsumerCallable.
-  """
-  new_transform = (name, *transform_params)
-  return dict(
-      params, transforms=(params.get("transforms", ()) + (new_transform,)))
-
-
-def _id_tap_impl(*arrays, **params):
-  # We use the jitted-version of the primitive even for eager execution, both
-  # so that we do not duplicate logic, but also so that all outfeed is received
-  # by the outfeed_listeners, in the same thread from a given device. If we were
-  # to process the tap here, it would be coming from the main thread. Also,
-  # even in eager execution some primitives, such as while, are compiled.
-  # It would be confusing to process a sequence "id_tap; while" in two
-  # different threads.
-  return xla.apply_primitive(id_tap_p, *arrays, **params)
+# We use the jitted-version of the primitive even for eager execution, both
+# so that we do not duplicate logic, but also so that all outfeed is received
+# by the outfeed_listeners, in the same thread from a given device. If we were
+# to process the tap here, it would be coming from the main thread. Also,
+# even in eager execution some primitives, such as while, are compiled.
+# It would be confusing to process a sequence "id_tap; while" in two
+# different threads.
+def _id_tap_impl(*args, tap_func_, arg_treedef_,
+                 transforms=(),
+                 tap_with_device_=False):
+  if inline_host_callback():
+    callable = _ConsumerCallable(tap_func_, transforms, tap_with_device_, arg_treedef_)
+    callable.invoke(args, api.devices()[0])
+    return args
+  else:
+    return xla.apply_primitive(id_tap_p, *args,
+                               arg_treedef_=arg_treedef_,
+                               tap_func_=tap_func_,
+                               transforms=transforms,
+                               tap_with_device_=tap_with_device_)
 
 
 id_tap_p.def_impl(_id_tap_impl)
@@ -499,6 +833,43 @@ def _id_tap_abstract_eval(*args_a: pe.AbstractValue, **params) \
 
 
 id_tap_p.def_abstract_eval(_id_tap_abstract_eval)
+
+
+def _id_tap_translation_rule(comp: XlaComputationBuilder,
+                             *args_op: XlaOp,
+                             tap_func_=None,
+                             arg_treedef_=None,
+                             has_token_=False,
+                             tap_with_device_=False,
+                             transforms=()):
+  # We expect the current token at the end, inserted by _rewrite_jaxpr.
+  assert has_token_
+  current_token = args_op[-1]
+  args_to_outfeed = args_op[:-1]  # last args_op is the token
+
+  assert not comp.get_shape(current_token).is_array(), (
+      "The last argument must be a token")
+  consumer_id = _register_consumer(
+      _ConsumerCallable(tap_func_, transforms, tap_with_device_, arg_treedef_))
+  next_token = _outfeed_receiver.receiver.add_outfeed(comp, current_token,
+                                                      consumer_id,
+                                                      args_to_outfeed)
+  results = (args_op[:-1] + (next_token,))
+  return xops.Tuple(comp, results)
+
+
+xla.translations[id_tap_p] = _id_tap_translation_rule
+
+
+def _add_transform(params: Dict, name: str, *transform_params) -> Dict:
+  """Adds the `transform` to the params["transforms"].
+
+  Uses a tuple representation internally, will be unpacked before the
+  callback by _ConsumerCallable.
+  """
+  new_transform = (name, *transform_params)
+  return dict(
+      params, transforms=(params.get("transforms", ()) + (new_transform,)))
 
 
 # TODO(necula): there must be a better way to do this.
@@ -516,30 +887,102 @@ def _instantiate_zeros(arg, tan):
     return ad.zeros_like_jaxval(arg)
 
 
+def _instantiate_zeros_aval(aval, tan):
+  """Turn special ad.zero tangents into arrays of 0s."""
+  if type(tan) is not ad.Zero:
+    return tan
+
+  return ad.instantiate_zeros_aval(aval, tan)
+
+
 def _id_tap_jvp_rule(primals, tangents, **params):
-  # Put primals through id_tap separately, so that partial evaluation
-  # can do its job when they are known (for grad)
-  out_primals = id_tap_p.bind(
-      *primals, **params)
-  # Add one primal output as untapped, to create data dependency.
-  tangent_zeros = tuple(map(_instantiate_zeros, primals, tangents))
-  out_tangents_extra = id_tap_p.bind(
-      *tangent_zeros,
-      out_primals[0],
-      **_add_transform(params, "jvp"))
-  return tuple(out_primals), tuple(out_tangents_extra[:-1])
+  tangent_instantiated = tuple(map(_instantiate_zeros, primals, tangents))
+  assert "has_token_" not in params
+
+  arg_treedef = params["arg_treedef_"]
+  # The argument to the jvp tap is a pair of the tapped primals and tangents
+  _, jvp_arg_treedef = api.tree_flatten(
+      (arg_treedef.unflatten(primals),
+       arg_treedef.unflatten(tangent_instantiated)))
+  out_all = id_tap_p.bind(
+      *primals, *tangent_instantiated,
+      **dict(_add_transform(params, "jvp"),
+             arg_treedef_=jvp_arg_treedef))
+  out_primals_tapped, out_tangents_tapped = util.split_list(out_all, [len(primals)])
+  return tuple(out_primals_tapped), tuple(out_tangents_tapped)
 
 
 ad.primitive_jvps[id_tap_p] = _id_tap_jvp_rule
 
 
+def _id_tap_partial_eval_rule(trace, *args, **params):
+  # The args have been prepared by the id_tap_jvp_rule: primals, tangents
+  transforms = params.get("transforms", ())
+  if not transforms or transforms[-1] != ("jvp",):
+    # We are not in the process of computing VJP
+    return trace.default_process_primitive(id_tap_p, args, params)
+
+  assert len(args) % 2 == 0
+  nr_primals = len(args) // 2
+
+  consts = [t.pval.get_known() for t in args]
+  if all(c is not None for c in consts):
+    return trace.default_process_primitive(id_tap_p, args, params)
+  # Split into two taps, one for the knowns and one for the unknowns
+  # We implement here only the case when primals are known, and we make a tap
+  # with just the primals.
+  primals, tangents = util.split_list(args, [nr_primals])
+  c_primals_tapped, _ = util.split_list(consts, [nr_primals])
+  assert all([c is not None for c in c_primals_tapped])
+
+  prims, _ = params["arg_treedef_"].unflatten(args)
+  _, primals_treedef = api.tree_flatten(prims)
+
+  outs_known = trace.default_process_primitive(
+      id_tap_p, primals,
+      dict(params,
+           arg_treedef_=primals_treedef,
+           transforms=transforms[:-1]))
+  # Now compute the unknowns using the whole tap, and merge them with the tapped ones
+  outs_all_unknown = trace.default_process_primitive(id_tap_p, args, params)
+  outs_primals_unknown, outs_tangents_unknown = util.split_list(
+      outs_all_unknown, [nr_primals])
+  outs_combined = (
+      [pe.JaxprTracer(trace, pe.PartialVal.known(primal_known),
+                      primal_unknown.recipe)
+       for primal_known, primal_unknown in util.safe_zip(outs_known, outs_primals_unknown)] +
+      outs_tangents_unknown)
+  return tuple(outs_combined)
+
+
+pe.custom_partial_eval_rules[id_tap_p] = _id_tap_partial_eval_rule
+
+
 def _id_tap_transpose_rule(cts, *args, **params):
   assert len(cts) == len(args)
-  cts_zeros = tuple(map(_instantiate_zeros, args, cts))
-  ct_args = id_tap_p.bind(
-      *cts_zeros,
-      **_add_transform(params, "transpose"))
-  return ct_args
+  cts_instantiated = tuple(map(_instantiate_zeros, args, cts))
+
+  # The args have been prepared by the id_tap_jvp_rule: tapped_primals, tapped_tangents, rest_primals, rest_tangents
+  transforms = params.get("transforms", ())
+  if not transforms or transforms[-1] != ("jvp",):
+    # TODO: I should understand better when can this happen. It seems to arise
+    # in scan.
+    return id_tap_p.bind(
+        *cts_instantiated,
+        **_add_transform(params, "transpose"))
+
+  assert len(args) % 2 == 0
+  nr_primals = len(args) // 2
+
+  args_unflat, tan_unflat = params["arg_treedef_"].unflatten(args)
+  _, vjp_arg_treedef = api.tree_flatten(args_unflat)
+  # We want to tap the cts_tapped_tangents
+  cts_primals, cts_tangents = util.split_list(cts_instantiated, [nr_primals])
+  cts_tangents_through_tap = id_tap_p.bind(
+      *cts_tangents,
+      **dict(_add_transform(params, "transpose"),
+             arg_treedef_=vjp_arg_treedef))
+  return (cts_primals + cts_tangents_through_tap)
 
 
 ad.primitive_transposes[id_tap_p] = _id_tap_transpose_rule
@@ -553,49 +996,128 @@ def _id_tap_batching_rule(batched_args, batch_dims, **params):
 
 batching.primitive_batchers[id_tap_p] = _id_tap_batching_rule
 
-# def _id_tap_shape_rule(*operands, **params):
-#  return tuple([op.shape for op in operands])
-
 
 def _id_tap_masking_rule(operands, operands_logical_shapes, **params):
-  new_params = _add_transform(params, "mask", tuple(operands_logical_shapes))
-  return id_tap_p.bind(*operands, **new_params)
+  assert "has_token_" not in params
+
+  assert len(operands) == len(operands_logical_shapes)
+  arg_treedef = params["arg_treedef_"]
+  # We will send the pair of (arg, arg_logical_shapes)
+  packed_operands, packed_arg_tree = api.tree_flatten(
+      (api.tree_unflatten(arg_treedef, operands),
+       api.tree_unflatten(arg_treedef, operands_logical_shapes)))
+
+  packed_results = id_tap_p.bind(*packed_operands,
+                                 tap_func_=params["tap_func_"],
+                                 arg_treedef_=packed_arg_tree,
+                                 transforms=params.get("transforms", ()) + (("mask",),))
+  return packed_results[:len(operands)] + packed_results[len(packed_operands):]
 
 
 masking.masking_rules[id_tap_p] = _id_tap_masking_rule
 
-####
-#### XLA compilation ####
-####
+### The outside_call primitive
+"""
+This primitive is used to implement the `call` function. It takes several
+positional arguments that are the flattening of the argument to `call`.
+It takes the following parameters:
+
+ * outside_computation: the function to invoke with the unflattened arguments.
+ * arg_treedef, flat_args_aval: the treedef and flat list of abstract values
+   for the argument.
+ * result_treedef, flat_results_aval: the treedef and flag list of abstracct
+   value for the expected result.
+ * call_with_device: whether the outside_computation must be invoked with
+   a device keyword argument.
+"""
+outside_call_p = core.Primitive("outside_call")
+outside_call_p.multiple_results = True
+xla.outfeed_primitives.add(outside_call_p)
 
 
-def _id_tap_translation_rule(comp: XlaComputationBuilder,
-                             *args_op: XlaOp,
-                             tap_func_=None,
-                             nr_tapped_args_,
-                             arg_treedef_=None,
-                             has_token_=False,
-                             tap_with_device_=False,
-                             transforms=()):
+def _outside_call_impl(*args, outside_computation,
+                       arg_treedef,
+                       flat_args_aval,
+                       result_treedef,
+                       flat_results_aval, call_with_device,
+                       **params):
+  if inline_host_callback():
+    arg = arg_treedef.unflatten(args)
+    if call_with_device:
+      res = outside_computation(arg, device=api.devices()[0])
+    else:
+      res = outside_computation(arg)
+    flat_results, result_treedef_actual = api.tree_flatten(res)
+    assert result_treedef_actual == result_treedef, f"expected {result_treedef} but found {result_treedef_actual}"
+    return flat_results
+  else:
+    return xla.apply_primitive(outside_call_p, *args,
+                               outside_computation=outside_computation,
+                               arg_treedef=arg_treedef,
+                               flat_args_aval=flat_args_aval,
+                               result_treedef=result_treedef,
+                               flat_results_aval=flat_results_aval,
+                               call_with_device=call_with_device,
+                               **params)
 
-  # We expect the current token at the end, inserted by _rewrite_jaxpr.
+
+outside_call_p.def_impl(_outside_call_impl)
+
+
+def _outside_call_abstract_eval(*args_a: pe.AbstractValue,
+                                flat_results_aval, **params) -> Sequence[pe.AbstractValue]:
+  if "has_token_" in params and params["has_token_"]:
+    assert len(args_a) >= 2 and args_a[-1] is core.abstract_token and args_a[-2] is core.abstract_token
+    return flat_results_aval + (core.abstract_token, core.abstract_token)
+  else:
+    return flat_results_aval
+
+
+outside_call_p.def_abstract_eval(_outside_call_abstract_eval)
+
+
+def _outside_call_translation_rule(
+    comp: XlaComputationBuilder, *args_op: XlaOp,
+    outside_computation,
+    arg_treedef,
+    flat_args_aval,
+    result_treedef=None,
+    flat_results_aval=None,
+    has_token_=False,
+    call_with_device=False):
+  # We expect the current tokens at the end, inserted by _rewrite_jaxpr.
   assert has_token_
-  current_token = args_op[-1]
-  assert not comp.get_shape(current_token).is_array(), (
-      "The last argument must be a token")
+  current_token = args_op[-2]
+  current_itoken = args_op[-1]
+  # TODO: expose shape.is_token
+  assert not comp.get_shape(current_token).is_array() and not comp.get_shape(current_token).is_array(), (
+      "The last two arguments must be tokens")
+  assert not comp.get_shape(current_itoken).is_array() and not comp.get_shape(current_itoken).is_array(), (
+      "The last two arguments must be tokens")
 
-  args_to_outfeed = args_op[0:nr_tapped_args_]
+  args_to_outfeed = args_op[:-2]
   consumer_id = _register_consumer(
-      _ConsumerCallable(tap_func_, transforms, tap_with_device_, arg_treedef_,
-                        comp.get_shape(xops.Tuple(comp, args_to_outfeed))))
+      _ConsumerCallable(functools.partial(_outside_call_consumer,
+                                          outside_computation, result_treedef,
+                                          flat_results_aval, call_with_device),
+                        (), True, arg_treedef))
   next_token = _outfeed_receiver.receiver.add_outfeed(comp, current_token,
                                                       consumer_id,
                                                       args_to_outfeed)
-  results = (args_op[:-1] + (next_token,))
-  return xops.Tuple(comp, results)
+  if flat_results_aval:
+    after_outfeed_itoken = xops.AfterAll(comp, [current_itoken, next_token])
+
+    results_and_token = xla.translations[lax.infeed_p](comp, after_outfeed_itoken,
+                                                       shapes=flat_results_aval, partitions=None)
+    next_itoken = xops.GetTupleElement(results_and_token, len(flat_results_aval))
+    results = [xops.GetTupleElement(results_and_token, i) for i in range(len(flat_results_aval))]
+    return xops.Tuple(comp, results + [next_token, next_itoken])
+  else:
+    return xops.Tuple(comp, [next_token, current_itoken])
 
 
-xla.translations[id_tap_p] = _id_tap_translation_rule
+xla.translations[outside_call_p] = _outside_call_translation_rule
+
 
 ####
 #### Jaxpr rewriting logic to thread the tokens through stateful primitives.
@@ -622,13 +1144,17 @@ def _rewrite_jaxpr(jaxpr: core.Jaxpr, has_input_token: bool,
 
   eqns: List[core.JaxprEqn] = []
   last_token_var = mk_new_var(core.abstract_token)  # store the incoming token
+  last_itoken_var = mk_new_var(core.abstract_token)  # store the incoming token
   if has_input_token:
-    invars = jaxpr.invars + [last_token_var]
+    invars = jaxpr.invars + [last_token_var, last_itoken_var]
   else:
     invars = jaxpr.invars
     # We need tokens but none is given in input; make one depending on all invars
     eqns.append(
         core.new_jaxpr_eqn(jaxpr.invars, [last_token_var],
+                           lax.create_token_p, {}, source_info_util.current()))
+    eqns.append(
+        core.new_jaxpr_eqn(jaxpr.invars, [last_itoken_var],
                            lax.create_token_p, {}, source_info_util.current()))
 
   for eqn in jaxpr.eqns:
@@ -636,16 +1162,19 @@ def _rewrite_jaxpr(jaxpr: core.Jaxpr, has_input_token: bool,
       eqns.append(eqn)
     else:
       output_token_var = mk_new_var(core.abstract_token)
-      _rewrite_eqn(eqn, eqns, last_token_var, output_token_var, mk_new_var)
+      output_itoken_var = mk_new_var(core.abstract_token)
+      _rewrite_eqn(eqn, eqns, last_token_var, output_token_var, last_itoken_var, output_itoken_var, mk_new_var)
       last_token_var = output_token_var
+      last_itoken_var = output_itoken_var
 
-  outvars = jaxpr.outvars + ([last_token_var] if has_output_token else [])
+  outvars = jaxpr.outvars + ([last_token_var, last_itoken_var] if has_output_token else [])
   new_jaxpr = core.Jaxpr(jaxpr.constvars, invars, outvars, eqns)
   return new_jaxpr
 
 
 def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
                  input_token_var: core.Var, output_token_var: core.Var,
+                 input_itoken_var: core.Var, output_itoken_var: core.Var,
                  mk_new_var: Callable[[core.AbstractValue], core.Var]):
   """Rewrite an `eqn` and append equations to `eqns`.
 
@@ -662,121 +1191,136 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
                            eqn.outvars + [output_token_var], eqn.primitive,
                            dict(eqn.params, has_token_=True),
                            eqn.source_info))
+    eqns.append(
+        core.new_jaxpr_eqn([input_itoken_var],
+                           [output_itoken_var], id_p,
+                           dict(),
+                           eqn.source_info))
+  elif eqn.primitive is outside_call_p:
+    assert "has_token_" not in eqn.params
+    eqns.append(
+        core.new_jaxpr_eqn(eqn.invars + [input_token_var, input_itoken_var],
+                           eqn.outvars + [output_token_var, output_itoken_var], eqn.primitive,
+                           dict(eqn.params, has_token_=True),
+                           eqn.source_info))
   elif eqn.primitive is lax.while_p:
     cond_jaxpr, _, body_jaxpr, _ = util.split_dict(
         eqn.params,
         ["cond_jaxpr", "cond_nconsts", "body_jaxpr", "body_nconsts"])
     if xla.jaxpr_uses_outfeed(cond_jaxpr.jaxpr):
       _rewrite_while_outfeed_cond(eqn, eqns, input_token_var, output_token_var,
+                                  input_itoken_var, output_itoken_var,
                                   mk_new_var)
       return
 
     eqns.append(
         core.new_jaxpr_eqn(
-            eqn.invars + [input_token_var], eqn.outvars + [output_token_var],
+            eqn.invars + [input_token_var, input_itoken_var],
+            eqn.outvars + [output_token_var, output_itoken_var],
             eqn.primitive,
             dict(
                 eqn.params,
                 body_jaxpr=_rewrite_closed_jaxpr(body_jaxpr, True, True),
                 cond_jaxpr=_rewrite_closed_jaxpr(cond_jaxpr, True,
-                                                False)), eqn.source_info))
+                                                 False)), eqn.source_info))
   elif eqn.primitive is lax.cond_p:
     branches, linear = util.split_dict(eqn.params, ["branches", "linear"])
     index, *operands = eqn.invars
-    new_invars = [index, *operands, input_token_var]
+    new_invars = [index, *operands, input_token_var, input_itoken_var]
     eqns.append(
         core.new_jaxpr_eqn(
-            new_invars, eqn.outvars + [output_token_var], eqn.primitive,
+            new_invars, eqn.outvars + [output_token_var, output_itoken_var], eqn.primitive,
             dict(
                 eqn.params,
-                branches=tuple(
-                    _rewrite_closed_jaxpr(jaxpr, True, True)
-                    for jaxpr in branches),
-                linear=(*linear, False)), eqn.source_info))
+                branches=tuple(_rewrite_closed_jaxpr(jaxpr, True, True)
+                               for jaxpr in branches),
+                linear=(*linear, False, False)), eqn.source_info))
   elif eqn.primitive is lax.scan_p:
     num_consts, num_carry, carry_jaxpr, linear, _, _, _ = util.split_dict(
         eqn.params,
         ["num_consts", "num_carry", "jaxpr", "linear", "reverse", "length",
          "unroll"])
-    # We add the token right at the end of carry
+    # We add the tokens right at the end of carry
     nr_const_and_carry = num_consts + num_carry
     new_invars = eqn.invars[0:nr_const_and_carry] + [
-        input_token_var
-    ] + eqn.invars[nr_const_and_carry:]
+        input_token_var, input_itoken_var] + eqn.invars[nr_const_and_carry:]
     new_jaxpr = _rewrite_closed_jaxpr(carry_jaxpr, True, True)
     # The rewrite has put the token at end, it has to be at end of carry
     new_jaxpr_invars = new_jaxpr.jaxpr.invars
     new_jaxpr_invars = (
-        new_jaxpr_invars[0:nr_const_and_carry] + [new_jaxpr_invars[-1]] +
-        new_jaxpr_invars[nr_const_and_carry:-1])
+        new_jaxpr_invars[0:nr_const_and_carry] + new_jaxpr_invars[-2:] +
+        new_jaxpr_invars[nr_const_and_carry:-2])
     new_jaxpr.jaxpr.invars = new_jaxpr_invars
 
     new_jaxpr_outvars = new_jaxpr.jaxpr.outvars
     new_jaxpr_outvars = (
-        new_jaxpr_outvars[0:num_carry] + [new_jaxpr_outvars[-1]] +
-        new_jaxpr_outvars[num_carry:-1])
+        new_jaxpr_outvars[0:num_carry] + new_jaxpr_outvars[-2:] +
+        new_jaxpr_outvars[num_carry:-2])
     new_jaxpr.jaxpr.outvars = new_jaxpr_outvars
     eqns.append(
         core.new_jaxpr_eqn(
             new_invars,
             # Output token is at the end of carry result
-            eqn.outvars[0:num_carry] + [output_token_var] +
+            eqn.outvars[0:num_carry] + [output_token_var, output_itoken_var] +
             eqn.outvars[num_carry:],
             eqn.primitive,
             dict(
                 eqn.params,
                 jaxpr=new_jaxpr,
-                num_carry=num_carry + 1,
-                linear=linear + (False,)),
+                num_carry=num_carry + 2,
+                linear=linear[0:nr_const_and_carry] + (False, False) + linear[nr_const_and_carry:]),
             eqn.source_info))
   elif eqn.primitive is xla.xla_call_p:
     call_jaxpr = cast(core.Jaxpr, eqn.params["call_jaxpr"])
     eqns.append(
         core.new_jaxpr_eqn(
-            eqn.invars + [input_token_var], eqn.outvars + [output_token_var],
+            eqn.invars + [input_token_var, input_itoken_var], eqn.outvars + [output_token_var, output_itoken_var],
             eqn.primitive,
             dict(
                 eqn.params,
                 call_jaxpr=_rewrite_jaxpr(call_jaxpr, True, True),
-                donated_invars=eqn.params["donated_invars"] + (False,)
+                donated_invars=eqn.params["donated_invars"] + (False, False)
             ),
-          eqn.source_info))
+            eqn.source_info))
   elif eqn.primitive is pxla.xla_pmap_p:
     # We broadcast the input token into an array of tokens
     call_jaxpr = cast(core.Jaxpr, eqn.params["call_jaxpr"])
     eqns.append(
         core.new_jaxpr_eqn(
-            eqn.invars + [input_token_var], eqn.outvars + [output_token_var],
+            eqn.invars + [input_token_var, input_itoken_var], eqn.outvars + [output_token_var, output_itoken_var],
             eqn.primitive,
             dict(
                 eqn.params,
                 call_jaxpr=_rewrite_jaxpr(call_jaxpr, True, True),
-                donated_invars=eqn.params["donated_invars"] + (False,),
+                donated_invars=eqn.params["donated_invars"] + (False, False),
                 # Sharding/unsharding of tokens in pmap_translation are special
                 # cased to just pass-through the token
-                in_axes=eqn.params["in_axes"] + (0,),
-                out_axes=eqn.params["out_axes"] + (0,)
+                in_axes=eqn.params["in_axes"] + (0, 0),
+                out_axes=eqn.params["out_axes"] + (0, 0)
             ),
-          eqn.source_info))
+            eqn.source_info))
   elif eqn.primitive is pe.remat_call_p:
     call_jaxpr = cast(core.Jaxpr, eqn.params["call_jaxpr"])
     eqns.append(
         core.new_jaxpr_eqn(
-            eqn.invars + [input_token_var], eqn.outvars + [output_token_var],
+            eqn.invars + [input_token_var, input_itoken_var],
+            eqn.outvars + [output_token_var, output_itoken_var],
             eqn.primitive,
             dict(
                 eqn.params,
                 call_jaxpr=_rewrite_jaxpr(call_jaxpr, True, True),
             ),
-          eqn.source_info))
+            eqn.source_info))
   elif eqn.primitive is custom_derivatives.custom_jvp_call_jaxpr_p:
     fun_jaxpr = eqn.params["fun_jaxpr"]
-    new_invars = [*eqn.invars, input_token_var]
+
     def unreachable_thunk():
       assert False, "Should not be reached"
+
     eqns.append(
         core.new_jaxpr_eqn(
-            new_invars, eqn.outvars + [output_token_var], eqn.primitive,
+            eqn.invars + [input_token_var, input_itoken_var],
+            eqn.outvars + [output_token_var, output_itoken_var], eqn.primitive,
             dict(
                 eqn.params,
                 fun_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
@@ -785,12 +1329,14 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             eqn.source_info))
   elif eqn.primitive is custom_derivatives.custom_vjp_call_jaxpr_p:
     fun_jaxpr = eqn.params["fun_jaxpr"]
-    new_invars = [*eqn.invars, input_token_var]
+    new_invars = [*eqn.invars, input_token_var, input_itoken_var]
+
     def unreachable_thunk():
       assert False, "Should not be reached"
+
     eqns.append(
         core.new_jaxpr_eqn(
-            new_invars, eqn.outvars + [output_token_var], eqn.primitive,
+            new_invars, eqn.outvars + [output_token_var, output_itoken_var], eqn.primitive,
             dict(
                 eqn.params,
                 fun_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
@@ -806,51 +1352,52 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
     call_jaxpr = cast(core.Jaxpr, eqn.params["call_jaxpr"])
     eqns.append(
         core.new_jaxpr_eqn(
-            eqn.invars + [input_token_var], eqn.outvars + [output_token_var],
+            eqn.invars + [input_token_var, input_itoken_var],
+            eqn.outvars + [output_token_var, output_itoken_var],
             eqn.primitive,
             dict(
                 eqn.params,
                 call_jaxpr=_rewrite_jaxpr(call_jaxpr, True, True),
             ),
-          eqn.source_info))
+            eqn.source_info))
   else:
     raise NotImplementedError(f"outfeed rewrite {eqn.primitive}")
 
 
 def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
-                                input_token_var: core.Var,
-                                output_token_var: core.Var,
+                                input_token_var: core.Var, output_token_var: core.Var,
+                                input_itoken_var: core.Var, output_itoken_var: core.Var,
                                 mk_new_var: Callable):
   """Rewrite a while whose cond has outfeed"""
   cond_jaxpr, cond_nconsts, body_jaxpr, body_nconsts = util.split_dict(
       eqn.params, ["cond_jaxpr", "cond_nconsts", "body_jaxpr", "body_nconsts"])
   transformed_cond_jaxpr = _rewrite_closed_jaxpr(cond_jaxpr, True, True)
   carry_invars = eqn.invars[cond_nconsts + body_nconsts:]
-  # pred1, token1 = rewrite(COND)(cond_consts, carry_invars, input_token)
+  # pred1, token1, itoken1 = rewrite(COND)(cond_consts, carry_invars, input_token, input_itoken)
   pred1_and_token1 = [
       mk_new_var(ov.aval) for ov in transformed_cond_jaxpr.jaxpr.outvars
   ]
   eqns.append(
       core.new_jaxpr_eqn(
-          eqn.invars[0:cond_nconsts] + carry_invars + [input_token_var],
+          eqn.invars[0:cond_nconsts] + carry_invars + [input_token_var, input_itoken_var],
           pred1_and_token1, xla.xla_call_p,
           dict(
               call_jaxpr=transformed_cond_jaxpr.jaxpr,
               name="cond_before",
               donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals)),
           eqn.source_info))
-  # Make a new cond "lambda pred, carry, token: pred"
+  # Make a new cond "lambda pred, carry, token, itoken: pred"
   new_cond_pred_invar = mk_new_var(cond_jaxpr.out_avals[0])
   new_cond_invars = ([new_cond_pred_invar] +
                      [mk_new_var(cv.aval) for cv in carry_invars] +
-                     [mk_new_var(core.abstract_token)])
+                     [mk_new_var(core.abstract_token), mk_new_var(core.abstract_token)])
   new_cond_jaxpr = core.ClosedJaxpr(
       core.Jaxpr([], new_cond_invars, [new_cond_pred_invar], []), [])
   # Make a new body:
-  #   "lambda cond_constvars, body_constvars, pred, carry, token:
-  #        carry2, token2 = rewrite(BODY)(body_constvars, carry, token)
-  #        pred2, token3 = rewrite(COND)(cond_constvars, carry2, token2)
-  #        (pred2, carry2, token3)
+  #   "lambda cond_constvars, body_constvars, pred, carry, token, itoken:
+  #        carry2, token2, itoken2 = rewrite(BODY)(body_constvars, carry, token, itoken)
+  #        pred2, token3, itoken3 = rewrite(COND)(cond_constvars, carry2, token2, itoken2)
+  #        (pred2, carry2, token3, itoken3)
   transformed_body_jaxpr = _rewrite_closed_jaxpr(body_jaxpr, True, True)
   new_body_invars_cond_constvars = [
       mk_new_var(v.aval) for v in eqn.invars[0:cond_nconsts]
@@ -862,16 +1409,20 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
   new_body_invars_pred = mk_new_var(cond_jaxpr.out_avals[0])
   new_body_invars_carry = [mk_new_var(cv.aval) for cv in carry_invars]
   new_body_invars_token = mk_new_var(core.abstract_token)
+  new_body_invars_itoken = mk_new_var(core.abstract_token)
 
   new_body_carry2 = [mk_new_var(cv.aval) for cv in carry_invars]
   new_body_token2 = mk_new_var(core.abstract_token)
+  new_body_itoken2 = mk_new_var(core.abstract_token)
   new_body_pred2 = mk_new_var(cond_jaxpr.out_avals[0])
   new_body_token3 = mk_new_var(core.abstract_token)
+  new_body_itoken3 = mk_new_var(core.abstract_token)
 
   new_body_eqns = [
       core.new_jaxpr_eqn(
           new_body_invars_body_constvars + new_body_invars_carry +
-          [new_body_invars_token], new_body_carry2 + [new_body_token2],
+          [new_body_invars_token, new_body_invars_itoken],
+          new_body_carry2 + [new_body_token2, new_body_itoken2],
           xla.xla_call_p,
           dict(
               call_jaxpr=transformed_body_jaxpr.jaxpr,
@@ -879,8 +1430,8 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
               donated_invars=(False,) * len(transformed_body_jaxpr.in_avals)),
           eqn.source_info),
       core.new_jaxpr_eqn(
-          new_body_invars_cond_constvars + new_body_carry2 + [new_body_token2],
-          [new_body_pred2, new_body_token3], xla.xla_call_p,
+          new_body_invars_cond_constvars + new_body_carry2 + [new_body_token2, new_body_itoken2],
+          [new_body_pred2, new_body_token3, new_body_itoken3], xla.xla_call_p,
           dict(
               call_jaxpr=transformed_cond_jaxpr.jaxpr,
               name="cond_body",
@@ -890,16 +1441,17 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
   new_body_jaxpr = core.ClosedJaxpr(
       core.Jaxpr([], (new_body_invars_cond_constvars +
                       new_body_invars_body_constvars + [new_body_invars_pred] +
-                      new_body_invars_carry + [new_body_invars_token]),
-                 ([new_body_pred2] + new_body_carry2 + [new_body_token3]),
+                      new_body_invars_carry + [new_body_invars_token, new_body_invars_itoken]),
+                 ([new_body_pred2] + new_body_carry2 + [new_body_token3, new_body_itoken3]),
                  new_body_eqns), [])
 
   pred_out = mk_new_var(cond_jaxpr.out_avals[0])
   eqns.append(
       core.new_jaxpr_eqn(
           (eqn.invars[0:cond_nconsts + body_nconsts] + [pred1_and_token1[0]] +
-           carry_invars + [pred1_and_token1[1]]),
-          ([pred_out] + eqn.outvars + [output_token_var]), lax.while_p,
+           carry_invars + pred1_and_token1[1:]),
+          ([pred_out] + eqn.outvars + [output_token_var, output_itoken_var]),
+          lax.while_p,
           dict(
               cond_jaxpr=new_cond_jaxpr,
               cond_nconsts=0,
@@ -907,13 +1459,20 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
               body_nconsts=cond_nconsts + body_nconsts), eqn.source_info))
 
 
+# We need an identity primitive to simplify rewriting
+id_p = core.Primitive("id")
+id_p.multiple_results = True
+id_p.def_impl(lambda *args: args)
+id_p.def_abstract_eval(lambda *args: args)
+xla.translations[id_p] = lambda c, *args: xops.Tuple(c, args)
+
 xla.outfeed_rewriter = lambda j: _rewrite_jaxpr(j, False, False)
 
 
 class TapFunctionException(Exception):
   """Signals that some tap function had exceptions.
 
-  Raised by :func:`outfeed_receiver`.
+  Raised by :func:`barrier_wait`.
   """
   pass
 
@@ -923,7 +1482,7 @@ class _OutfeedReceiverData:
   """Keep track of the outfeed receiver data."""
   receiver: Any
   lock: threading.Lock
-  num_tap_exceptions: int
+  last_tap_exception: Optional[str]
   clients: Tuple[XlaLocalClient, ...]
   devices: Tuple[XlaDevice, ...]
   consumer_registry: Dict[_ConsumerCallable, int]
@@ -932,7 +1491,7 @@ class _OutfeedReceiverData:
   def __init__(self):
     self.receiver = None  # Initialize lazily, when first needed
     self.lock = threading.Lock()
-    self.num_tap_exceptions = 0
+    self.last_tap_exception = None
     self.clients = ()
     self.devices = ()
     # The consumer registries must be live for the lifetime of the program,
@@ -954,23 +1513,17 @@ _outfeed_receiver = _OutfeedReceiverData()
 
 # This function is called from C++; it must not allow exceptions through.
 def _outfeed_receiver_callback(device, consumer_id, arrays):
-  #logging.vlog(
+  # logging.vlog(
   #    2, f"Outfeed received on device {device} for consumer {consumer_id} " +
   #    (" ".join([f"({a.dtype}{a.shape})" for a in arrays])))
   consumer = _outfeed_receiver.consumer_registry_by_id.get(consumer_id)
   assert consumer is not None, "We should have crashed in the runtime"
   try:
-    arg = api.tree_unflatten(consumer.arg_treedef, arrays)
-    consumer.invoke(arg, device)
-  except Exception as e:
-    if isinstance(e, TypeError):
-      logging.error("The signature host_callback.id_tap uses to calls wrapped "
-                    "functions has changed: ``transforms`` was previously "
-                    "passed as a keyword argument, but is now passed by "
-                    "position.")
-    logging.error("Postponing exception raised in tap function: %s\n%s", str(e),
-                  traceback.format_exc())
-    _outfeed_receiver.num_tap_exceptions += 1
+    consumer.invoke(arrays, device)
+  except Exception:
+    edata = traceback.format_exc()
+    logging.error("Postponing exception raised in tap function: %s", edata)
+    _outfeed_receiver.last_tap_exception = edata
     return
 
 
@@ -1007,7 +1560,7 @@ def _initialize_outfeed_receiver(
     _outfeed_receiver.devices = devices  # type: ignore[assignment]
     logging.vlog(
         2, f"Starting outfeed_receiver for {[str(d) for d in devices]}. "
-        f"max_callback_queue_size_bytes={max_callback_queue_size_bytes}")
+           f"max_callback_queue_size_bytes={max_callback_queue_size_bytes}")
     _outfeed_receiver.receiver = outfeed_receiver_module.start(
         _outfeed_receiver_callback, tuple(clients),
         max_callback_queue_size_bytes)
@@ -1052,7 +1605,7 @@ def barrier_wait(logging_name: Optional[str] = None):
     nonlocal num_at_large
     logging.vlog(
         2, f"barrier_wait[{logging_name}]: at barrier_tap for device {_outfeed_receiver.devices[dev_idx]} "
-        f". Thread {threading.current_thread()}")
+           f". Thread {threading.current_thread()}")
     with lock:
       num_at_large -= 1
       logging.vlog(2, f"barrier_wait[{logging_name}]: still waiting for {num_at_large} barrier_tap")
@@ -1066,10 +1619,13 @@ def barrier_wait(logging_name: Optional[str] = None):
   with lock:
     cv.wait_for(lambda: num_at_large == 0)
   logging.vlog(2, f"barrier_wait[{logging_name}]: done")
-  if _outfeed_receiver.num_tap_exceptions > 0:
-    _outfeed_receiver.num_tap_exceptions = 0
+  if _outfeed_receiver.last_tap_exception is not None:
+    last_exception = _outfeed_receiver.last_tap_exception
+    _outfeed_receiver.last_tap_exception = None
     raise TapFunctionException(
-        "There were exceptions during id_tap processing.")
+        "There were exceptions during id_tap processing. "
+        f"Last one was: {last_exception}")
+
 
 def stop_outfeed_receiver():
   """Stops the outfeed receiver runtime.

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -521,7 +521,7 @@ def instantiate_zeros(tangent):
   else:
     return tangent
 
-# This function seems similar to instantaite_zeros, but it is sometimes used
+# This function seems similar to instantiate_zeros, but it is sometimes used
 # to instantiate zero abstract units with a different aval
 def instantiate_zeros_aval(aval, tangent):
   if type(tangent) is Zero:

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+from functools import partial
 import itertools
 import logging
 import os
@@ -20,7 +20,7 @@ import re
 import threading
 import time
 from typing import Callable, Optional, Sequence
-from unittest import SkipTest
+from unittest import SkipTest, skipIf
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -32,12 +32,10 @@ from jax import test_util as jtu
 from jax.config import config
 from jax.experimental import host_callback as hcb
 from jax.lib import xla_bridge
-from jax.util import prod
 import numpy as np
 
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
-
 
 class _TestingOutputStream(object):
   """Use as `output_stream` for tests."""
@@ -81,11 +79,12 @@ testing_stream = _TestingOutputStream()
 def fun1(a):
   y = hcb.id_print(a * 2., what="a * 2", output_stream=testing_stream)
   y = hcb.id_print(y * 3., what="y * 3", output_stream=testing_stream, result=y)
-  return y**2  # Some computation to make the gradient interesting
+  return y ** 2  # Some computation to make the gradient interesting
 
 
 def fun1_equiv(a):  # Numerical equivalent of fun`
-  return (a * 2.)**2
+  return (a * 2.) ** 2
+
 
 def maybe_print(do_print: bool, arg, what: str, tap_with_device: Optional[bool] = False):
   """Conditionally print on testing_string"""
@@ -95,20 +94,24 @@ def maybe_print(do_print: bool, arg, what: str, tap_with_device: Optional[bool] 
   else:
     return arg
 
-ignore_jit_of_pmap_warning = functools.partial(
-  jtu.ignore_warning, message=".*jit-of-pmap.*")
+
+ignore_jit_of_pmap_warning = partial(
+    jtu.ignore_warning, message=".*jit-of-pmap.*")
+
 
 def assertMultiLineStrippedEqual(tst: jtu.JaxTestCase,
                                  expected: str, what: str):
   """A variant that preprocesses the string to eliminate non-determinism in
   floating point values, and several uninteresting id_tap primitive params.
   """
+
   # Sometimes we get floating points in the output; we round them
   def repl_floats(match_group):
     matched = match_group.group(0)
     if matched == ".": return matched
     x = np.around(float(matched), decimals=2)
     return f"{x:.2f}"
+
   what = re.sub(r"\-?\d*\.[\-\def]*", repl_floats, what)
   what = re.sub(r"output_stream=[^\]\n,]*,?", "", what)
   what = re.sub(r"threshold=[^\]\n,]*,?", "", what)
@@ -118,17 +121,41 @@ def assertMultiLineStrippedEqual(tst: jtu.JaxTestCase,
   what = re.sub(r"jvp_jaxpr_thunk=[^\]\n]*", "", what)
   # Empty lines
   what = re.sub(r"^\s*\n", "", what, flags=re.MULTILINE)
+
   def repl_func(match_group):
     matched = match_group.group(0)
     if "function _print_consumer" in matched:
       return "tap_func_=_print"
     else:
       return "..."
+
   what = re.sub(r"tap_func_=([^\]\n,]*),?", repl_func, what)
   tst.assertMultiLineStrippedEqual(expected, what)
 
 
+def helper_set_hlo_dump():
+  flags_str = os.getenv("XLA_FLAGS", "")
+  import shutil
+  dump_dir = "/tmp/xla_dump"
+  os.environ["XLA_FLAGS"] = f"{flags_str} --xla_dump_to={dump_dir}"
+  if os.path.isdir(dump_dir):
+    logging.warning(f"Deleting old XLA dump directory {dump_dir}")
+    shutil.rmtree(dump_dir)
+  logging.warning(f"Setting XLA dump directory {dump_dir}")
+  # Clear any cached backends so new CPU backend will pick up the env var.
+  xla_bridge.get_backend.cache_clear()
+
+
+def helper_print_optimized_hlo(fun, *args):
+  backend = api.lib.xla_bridge.get_backend()
+  c = api.xla_computation(fun)(*args)
+  print(re.sub(r", metadata.*", "",
+               backend.compile(c).hlo_modules()[0].to_string()))
+
+
 prev_xla_flags = None
+
+
 def setUpModule():
   global prev_xla_flags
   # This will control the CPU devices. On TPU we always have 2 devices
@@ -162,14 +189,13 @@ def assertMultiDeviceOutputEqual(tst: jtu.JaxTestCase,
 
   def replace_device_name(m) -> str:
     return str(api.devices()[int(m.group(1))])
+
   expected = re.sub(r'cpu:(\d+)', replace_device_name, expected)
   what = testing_stream.output_sorted_by_device
   return assertMultiLineStrippedEqual(tst, expected, what)
 
 
-
-
-class HostCallbackTest(jtu.JaxTestCase):
+class HostCallbackIdTapTest(jtu.JaxTestCase):
 
   def setUp(self):
     testing_stream.reset()
@@ -182,16 +208,7 @@ class HostCallbackTest(jtu.JaxTestCase):
       xla_bridge.get_backend.cache_clear()
     hcb.barrier_wait("HostCallbackTest.tearDown")
 
-  def helper_set_hlo_dump(self):
-    flags_str = os.getenv("XLA_FLAGS", "")
-    os.environ["XLA_FLAGS"] = f"{flags_str} --xla_dump_to=/tmp/xla_dump"
-    # Clear any cached backends so new CPU backend will pick up the env var.
-    xla_bridge.get_backend.cache_clear()
-
   def test_eval(self):
-    # TODO: renable jaxpr golden tests when changing host_callback
-    #assertMultiLineStrippedEqual(self, "", str(api.make_jaxpr(fun1)(5.)))
-
     self.assertAllClose((5. * 2.) ** 2, fun1(5.))
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
@@ -210,8 +227,8 @@ class HostCallbackTest(jtu.JaxTestCase):
     hcb.barrier_wait()
 
     assertMultiLineStrippedEqual(self, """
-        [ 6.00
-          9.00 ]""", testing_stream.output)
+        ( 6.00
+          9.00 )""", testing_stream.output)
     testing_stream.reset()
 
   def test_with_dict_results(self):
@@ -235,8 +252,8 @@ class HostCallbackTest(jtu.JaxTestCase):
     self.assertEqual(3. * 4., func2(3.))
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
-        [ 6.00
-          9.00 ]""", testing_stream.output)
+        ( 6.00
+          9.00 )""", testing_stream.output)
     testing_stream.reset()
 
   def test_print_with_device(self):
@@ -250,14 +267,14 @@ class HostCallbackTest(jtu.JaxTestCase):
     hcb.barrier_wait()
     assertMultiDeviceOutputEqual(self, """
       device: cpu:0
-      [ 6.00
-        9.00 ]""")
+      ( 6.00
+        9.00 )""")
     testing_stream.reset()
 
   def test_eval_tap_exception(self):
     # Simulate a tap error
     def tap_err(*args, **kwargs):
-      raise NotImplementedError
+      raise ValueError("Some user message")
 
     def func(x):
       x1 = hcb.id_print(x + 1, what="x1", output_stream=testing_stream)
@@ -265,7 +282,10 @@ class HostCallbackTest(jtu.JaxTestCase):
       x3 = hcb.id_print(x2 + 1, what="x3", output_stream=testing_stream)
       return x3
 
-    with self.assertRaises(hcb.TapFunctionException):
+    with self.assertRaisesRegex(
+        hcb.TapFunctionException,
+        re.compile("There were exceptions during id_tap processing. Last one was:.*"
+                   "ValueError: Some user message", re.DOTALL)):
       func(0)
       hcb.barrier_wait()
 
@@ -323,9 +343,9 @@ class HostCallbackTest(jtu.JaxTestCase):
       return hcb.id_print(x1 + 1, where="2", output_stream=testing_stream)
 
     logging.info("%s: %s", self._testMethodName,
-          api.make_jaxpr(func)(1))
+                 api.make_jaxpr(func)(1))
     logging.info("%s: %s", self._testMethodName,
-          api.xla_computation(func)(1).as_hlo_text())
+                 api.xla_computation(func)(1).as_hlo_text())
     self.assertEqual(2, api.jit(func)(1))
     hcb.barrier_wait()
 
@@ -338,6 +358,7 @@ class HostCallbackTest(jtu.JaxTestCase):
 
   def test_jit2(self):
     """A sequence of JIT."""
+
     def func(x):
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
       x2 = hcb.id_print(x1 + 1, where="2", output_stream=testing_stream)
@@ -357,10 +378,11 @@ class HostCallbackTest(jtu.JaxTestCase):
         11""", testing_stream.output)
     testing_stream.reset()
 
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_jit_result_unused(self):
     """We can id_print even if we don't use the result."""
-    if not config.omnistaging_enabled:
-      raise SkipTest("Test requires omnistaging")
+
     def func(x):
       hcb.id_print(x, where="1", output_stream=testing_stream)
       hcb.id_print(x + 1, where="2", output_stream=testing_stream)
@@ -383,9 +405,11 @@ class HostCallbackTest(jtu.JaxTestCase):
   def test_jit_nested(self):
     def func(x):
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
+
       def func_nested(x):
         x2 = hcb.id_print(x + 1, where="nested", output_stream=testing_stream)
         return x2
+
       x3 = api.jit(func_nested)(x1)
       return hcb.id_print(x3 + 1, where="3", output_stream=testing_stream)
 
@@ -404,6 +428,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     """Running on multiple devices."""
     devices = api.local_devices()
     logging.info(f"{self._testMethodName}: has devices {devices}")
+
     def func(x, device_id):
       x1 = hcb.id_print(x, dev=str(device_id), output_stream=testing_stream)
       x2 = hcb.id_print(x1 + 1, dev=str(device_id), output_stream=testing_stream)
@@ -434,6 +459,7 @@ class HostCallbackTest(jtu.JaxTestCase):
         return dict(a=2 * x, b=3 * x)
       else:
         assert False
+
     tap_count = 0
 
     def tap_func(a, _, *, what=""):
@@ -445,10 +471,10 @@ class HostCallbackTest(jtu.JaxTestCase):
     for what in ("pair_1_x", "pair_x_2x", "dict"):
       transformed = transform(
           lambda x: hcb.id_tap(
-              functools.partial(tap_func, what=what),
+              partial(tap_func, what=what),
               func(x, what),
               result=func(x * 2, what))
-          )(5)
+      )(5)
       self.assertEqual(func(10, what), transformed)
     hcb.barrier_wait()  # Wait for receivers to be done
     self.assertEqual(3, tap_count)
@@ -472,6 +498,7 @@ class HostCallbackTest(jtu.JaxTestCase):
       raise SkipTest("concurrent id_tap not supported on GPU")
     received = set()
     count = 5
+
     def pause_tap(idx, _):
       received.add(int(idx))
       logging.info(f"Starting do_tap {idx}. Sleeping 1sec ...")
@@ -530,8 +557,11 @@ class HostCallbackTest(jtu.JaxTestCase):
               testcase_name=f"_with_jit_{with_jit}",
               with_jit=with_jit)
           for with_jit in [True, False]))
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_cond(self, with_jit=False):
     """A conditional"""
+
     def func(x):
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
       x2 = hcb.id_print(x1 + 1, where="2", output_stream=testing_stream)
@@ -564,10 +594,13 @@ class HostCallbackTest(jtu.JaxTestCase):
           dict(testcase_name=f"_with_jit_{with_jit}",
                with_jit=with_jit)
           for with_jit in [True, False]))
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_while_cond(self, with_jit=False):
     def func(x):
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
       x2 = hcb.id_print(x1 + 1, where="2", output_stream=testing_stream)
+
       def body(x):
         x3 = hcb.id_print(x, where="w_b_1", output_stream=testing_stream)
         x4 = lax.cond(x % 2 == 0,
@@ -577,6 +610,7 @@ class HostCallbackTest(jtu.JaxTestCase):
                                              result=x, output_stream=testing_stream),
                       x3 + 1)
         return hcb.id_print(x4, where="w_b_2", output_stream=testing_stream)
+
       x10 = lax.while_loop(lambda x: x <= 3, body, x2)
       res = hcb.id_print(x10, where="end", output_stream=testing_stream)
       return res
@@ -607,6 +641,7 @@ class HostCallbackTest(jtu.JaxTestCase):
 
   def test_jit_while_pred_tap(self):
     """While with printing in the conditional."""
+
     def func(x):
       x1 = hcb.id_print(x, where="1")
       x10 = lax.while_loop(lambda x: hcb.id_print(x < 3,
@@ -621,19 +656,19 @@ class HostCallbackTest(jtu.JaxTestCase):
     self.assertEqual(3, api.jit(func)(1))
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self,
-        """
-        where: w_p
-        True
-        where: w_b
-        2
-        where: w_p
-        True
-        where: w_b
-        3
-        where: w_p
-        False
-        where: 3
-        3""", testing_stream.output)
+                                 """
+                                 where: w_p
+                                 True
+                                 where: w_b
+                                 2
+                                 where: w_p
+                                 True
+                                 where: w_b
+                                 3
+                                 where: w_p
+                                 False
+                                 where: 3
+                                 3""", testing_stream.output)
     testing_stream.reset()
 
   @parameterized.named_parameters(
@@ -642,7 +677,9 @@ class HostCallbackTest(jtu.JaxTestCase):
               testcase_name=f"_with_jit_{with_jit}",
               with_jit=with_jit)
           for with_jit in [True, False]))
-  def test_scan_cond(self, with_jit=False):
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
+  def test_scan_cond(self, with_jit=True):
     def func(x):
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
       x2 = hcb.id_print(x1 + 1, where="2", output_stream=testing_stream)
@@ -703,7 +740,7 @@ class HostCallbackTest(jtu.JaxTestCase):
   def test_jit_types(self, nr_args=2, dtype=jnp.int16, shape=(2,)):
     if dtype in (jnp.complex64, jnp.complex128, jnp.bool_):
       raise SkipTest(f"id_print jit not implemented for {dtype}.")
-    args = [jnp.arange(prod(shape), dtype=dtype).reshape(shape)]
+    args = [jnp.arange(np.prod(shape), dtype=dtype).reshape(shape)]
     if nr_args > 1:
       args = args * nr_args
     jit_fun1 = api.jit(lambda xs: hcb.id_print(
@@ -726,10 +763,12 @@ class HostCallbackTest(jtu.JaxTestCase):
     # Several jit's without data dependencies; they may interfere
     count = 0  # Count tap invocations
     nr_arrays = 5
+
     def tap_func(arg, _):
       nonlocal count
       assert len(arg) == nr_arrays
       count += 1
+
     # This is the function that we'll run multiple times
     def func(x, count):
       for i in range(count):
@@ -748,6 +787,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     # Simulate a tap error
     def tap_err(*args, **kwargs):
       raise NotImplementedError
+
     def func(x):
       x1 = hcb.id_print(x + 1, what="x1", output_stream=testing_stream)
       x2 = hcb.id_tap(tap_err, x1 + 1)
@@ -775,9 +815,10 @@ class HostCallbackTest(jtu.JaxTestCase):
 
     def func(x):
       return lax.while_loop(
-        lambda c: c[1] < 5,
-        lambda c: (y, hcb.id_print(c[1], output_stream=testing_stream) + 1),
-        (x, 1))
+          lambda c: c[1] < 5,
+          lambda c: (y, hcb.id_print(c[1], output_stream=testing_stream) + 1),
+          (x, 1))
+
     func(y)
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
@@ -787,6 +828,8 @@ class HostCallbackTest(jtu.JaxTestCase):
         4""", testing_stream.output)
     testing_stream.reset()
 
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_jvp(self):
     jvp_fun1 = lambda x, xt: api.jvp(fun1, (x,), (xt,))
     res_primals, res_tangents = jvp_fun1(jnp.float32(5.), jnp.float32(0.1))
@@ -794,19 +837,18 @@ class HostCallbackTest(jtu.JaxTestCase):
     self.assertAllClose(4., res_tangents, check_dtypes=False)
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
-        what: a * 2
-        10.00
         transforms: ['jvp'] what: a * 2
-        0.20
-        what: y * 3
-        30.00
+        ( 10.00
+          0.20 )
         transforms: ['jvp'] what: y * 3
-        0.60""", testing_stream.output)
+        ( 30.00
+          0.60 )""", testing_stream.output)
     testing_stream.reset()
 
   def test_grad_primal_unused(self):
     if not config.omnistaging_enabled:
       raise SkipTest("Test requires omnistaging")
+
     # The output of id_print is not needed for backwards pass
     def func(x):
       return 2. * hcb.id_print(x * 3., what="x * 3",
@@ -821,14 +863,13 @@ class HostCallbackTest(jtu.JaxTestCase):
         { lambda  ; a.
           let b = mul a 3.00
               c = id_tap[ arg_treedef_=*
-                          nr_tapped_args_=1
-                          tap_func_=_print   what='x * 3') ] b
+                          tap_func_=_print   what='x * 3')
+                          transforms=(  ) ] b
               _ = mul c 2.00
               d = mul 1.00 2.00
-              e _ = id_tap[ arg_treedef_=*
-                            nr_tapped_args_=1
-                            tap_func_=_print   what='x * 3')
-                            transforms=(('jvp',), ('transpose',)) ] d 0.00
+              e = id_tap[ arg_treedef_=*
+                          tap_func_=_print   what='x * 3')
+                          transforms=(('jvp',), ('transpose',)) ] d
               f = mul e 3.00
           in (f,) }""", jaxpr)
     assertMultiLineStrippedEqual(self, "", testing_stream.output)
@@ -850,6 +891,7 @@ class HostCallbackTest(jtu.JaxTestCase):
       y = hcb.id_print(x * 2., what="x * 2", output_stream=testing_stream)
       return x * hcb.id_print(y * 3., what="y * 3",
                               output_stream=testing_stream)
+
     grad_func = api.grad(func)
 
     res_grad = grad_func(jnp.float32(5.))
@@ -866,9 +908,10 @@ class HostCallbackTest(jtu.JaxTestCase):
         15.00""", testing_stream.output)
     testing_stream.reset()
 
-  def test_grad_double(self):
+  def test_grad_grad(self):
     if not config.omnistaging_enabled:
       raise SkipTest("Test requires omnistaging")
+
     def func(x):
       y = hcb.id_print(x * 2., what="x * 2", output_stream=testing_stream)
       return x * (y * 3.)
@@ -888,10 +931,34 @@ class HostCallbackTest(jtu.JaxTestCase):
         10.00
         transforms: ['jvp', 'transpose'] what: x * 2
         15.00
-        transforms: ['jvp', 'transpose', 'jvp', 'transpose'] what: x * 2
-        2.00
         transforms: ['jvp', 'transpose'] what: x * 2
-        3.00""", testing_stream.output)
+        3.00
+        transforms: ['jvp', 'transpose', 'jvp', 'transpose'] what: x * 2
+        2.00""", testing_stream.output)
+    testing_stream.reset()
+
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
+  def test_grad_pytree(self):
+    def func(x):
+      x4, x5 = hcb.id_print((x * 2., x * 3.), what="pair",
+                            result=(x * 4., x * 5.),
+                            output_stream=testing_stream)
+      return x4 + 2. * x5
+
+    x = jnp.float32(5.)
+    grad_func = api.grad(func)
+    print(api.make_jaxpr(grad_func)(x))
+    res_grad = grad_func(x)
+    self.assertAllClose(14., res_grad, check_dtypes=False)
+    hcb.barrier_wait()
+    assertMultiLineStrippedEqual(self, """
+        what: pair
+        ( 10.00
+          15.00 )
+        transforms: ['jvp', 'transpose'] what: pair
+        ( 0.00
+          0.00 )""", testing_stream.output)
     testing_stream.reset()
 
   def test_vmap(self):
@@ -902,12 +969,13 @@ class HostCallbackTest(jtu.JaxTestCase):
     assertMultiLineStrippedEqual(self, """
         transforms: [('batch', {'batch_dims': (0,)})] what: a * 2
         [ 8.00 10.00]
-        transforms: [('batch', {'batch_dims': (0, 0)})] what: y * 3
+        transforms: [('batch', {'batch_dims': (0,)})] what: y * 3
         [24.00 30.00]""", testing_stream.output)
     testing_stream.reset()
 
   def test_vmap_not_batched(self):
     x = 3.
+
     def func(y):
       # x is not mapped, y is mapped
       _, y = hcb.id_print((x, y), output_stream=testing_stream)
@@ -918,23 +986,25 @@ class HostCallbackTest(jtu.JaxTestCase):
     _ = vmap_func(vargs)
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
-        transforms: [('batch', {'batch_dims': (None, 0)})]
-        [ 3.00
-          [4.00 5.00] ]""", testing_stream.output)
+      transforms: [('batch', {'batch_dims': (None, 0)})]
+      ( 3.00
+        [4.00 5.00] )""", testing_stream.output)
     testing_stream.reset()
 
-  def test_double_vmap(self):
+  def test_vmap_vmap(self):
     # A 2D tensor with x[i, j] = i + j using 2 vmap
     def sum(x, y):
       return hcb.id_print(x + y, output_stream=testing_stream)
+
     def sum_rows(xv, y):
       return api.vmap(sum, in_axes=(0, None))(xv, y)
+
     def sum_all(xv, yv):
       return api.vmap(sum_rows, in_axes=(None, 0))(xv, yv)
 
     xv = jnp.arange(5, dtype=np.int32)
     yv = jnp.arange(3, dtype=np.int32)
-    #assertMultiLineStrippedEqual(self, "", str(api.make_jaxpr(sum_all)(xv, yv)))
+    # assertMultiLineStrippedEqual(self, "", str(api.make_jaxpr(sum_all)(xv, yv)))
     _ = sum_all(xv, yv)
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
@@ -951,9 +1021,9 @@ class HostCallbackTest(jtu.JaxTestCase):
       # like max(x, 2)
       x1 = hcb.id_print(x, where="1", output_stream=testing_stream)
       x2 = lax.while_loop(lambda x: x < 2,
-                           lambda x: hcb.id_print(x + 1, where="w_b",
-                                                  output_stream=testing_stream),
-                           x1)
+                          lambda x: hcb.id_print(x + 1, where="w_b",
+                                                 output_stream=testing_stream),
+                          x1)
       res = hcb.id_print(x2, where="3", output_stream=testing_stream)
       return res
 
@@ -1009,13 +1079,14 @@ class HostCallbackTest(jtu.JaxTestCase):
 
   def test_pmap(self):
     xv = jnp.arange(api.device_count(), dtype=jnp.int32)
-    def fun1(x, do_print=False): # x: i32
+
+    def fun1(x, do_print=False):  # x: i32
       return maybe_print(do_print, x * 2, "x * 2", tap_with_device=True)
 
-    pmap_fun1 = api.pmap(functools.partial(fun1, do_print=True))
+    pmap_fun1 = api.pmap(partial(fun1, do_print=True))
     res = pmap_fun1(xv)
     hcb.barrier_wait()
-    expected_res = api.pmap(functools.partial(fun1, do_print=False))(xv)
+    expected_res = api.pmap(partial(fun1, do_print=False))(xv)
     self.assertAllClose(expected_res, res, check_dtypes=False)
     # Assertion text is for 2 devices (also works for 1 device)
     assertMultiDeviceOutputEqual(self, """
@@ -1035,11 +1106,11 @@ class HostCallbackTest(jtu.JaxTestCase):
     def fun1(x, do_print=False):  # x: i32
       return maybe_print(do_print, x * 2, "x * 2", tap_with_device=True)
 
-    pmap_vmap_fun1 = api.pmap(api.vmap(functools.partial(fun1, do_print=True)))
+    pmap_vmap_fun1 = api.pmap(api.vmap(partial(fun1, do_print=True)))
 
     res = pmap_vmap_fun1(matrix)
     hcb.barrier_wait()
-    expected_res = api.pmap(api.vmap(functools.partial(fun1, do_print=False)))(matrix)
+    expected_res = api.pmap(api.vmap(partial(fun1, do_print=False)))(matrix)
     self.assertAllClose(expected_res, res, check_dtypes=False)
     # Assertion text is for 2 devices (also works for 1 device)
     assertMultiDeviceOutputEqual(self, """
@@ -1058,14 +1129,15 @@ class HostCallbackTest(jtu.JaxTestCase):
     shape = (2, nr_devices // 2, 3)
     matrix = np.fromfunction(lambda i, j, k: 100. * i + 10. * j + k, shape,
                              dtype=np.float32)
-    def fun1(x, do_print=False): # x: f32
+
+    def fun1(x, do_print=False):  # x: f32
       y = maybe_print(do_print, x * 2., "x * 2", tap_with_device=True)
       return y ** 2
 
-    pmap_fun1 = api.pmap(api.pmap(api.vmap(functools.partial(fun1, do_print=True))))
+    pmap_fun1 = api.pmap(api.pmap(api.vmap(partial(fun1, do_print=True))))
     res = pmap_fun1(matrix)
     hcb.barrier_wait()
-    expected_res = api.pmap(api.pmap(api.vmap(functools.partial(fun1, do_print=False))))(matrix)
+    expected_res = api.pmap(api.pmap(api.vmap(partial(fun1, do_print=False))))(matrix)
     self.assertAllClose(expected_res, res, check_dtypes=False)
     # Assertion text is for 2 devices (also works for 1 device)
     assertMultiDeviceOutputEqual(self, """
@@ -1085,6 +1157,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     shape = (2, 1, 3)
     matrix = np.fromfunction(lambda i, j, k: 100. * i + 10. * j + k, shape,
                              dtype=np.float32)
+
     def fun(xv, do_print=False):
       # This will be printed on all devices, with shape [1, 3]
       xv = maybe_print(do_print, xv + 1., "before", tap_with_device=True)
@@ -1092,7 +1165,7 @@ class HostCallbackTest(jtu.JaxTestCase):
       # This will be printed on all devices, with shape [1, 3]
       return maybe_print(do_print, res + 1., "after", tap_with_device=True)
 
-    res = api.pmap(functools.partial(fun, do_print=True))(matrix)
+    res = api.pmap(partial(fun, do_print=True))(matrix)
     self.assertAllClose(fun(matrix, do_print=False), res, check_dtypes=False)
     hcb.barrier_wait()
     # Assertion text is for 2 devices (also works for 1 device)
@@ -1112,12 +1185,15 @@ class HostCallbackTest(jtu.JaxTestCase):
 
     testing_stream.reset()
 
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_jvp_pmap_vmap(self):
     # A matrix M[ijk] = i * 100 + j * 10 * k
     nr_devices = api.local_device_count()
     shape = (nr_devices, 2, 3)
     matrix = np.fromfunction(lambda i, j, k: 100. * i + 10. * j + k, shape,
                              dtype=np.float32)
+
     def fun(xv, do_print=False):
       # x: f32[3]
       return api.jvp(api.pmap(api.vmap(lambda x: maybe_print(do_print, x * 2., "x * 2", tap_with_device=True))),
@@ -1130,18 +1206,16 @@ class HostCallbackTest(jtu.JaxTestCase):
     # Assertion text is for 2 devices (also works for 1 device)
     # Device 0 will get to execute api.jvp(api.vmap(...)) for matrix[0, :, :]
     assertMultiDeviceOutputEqual(self, """
-      device: cpu:0 transforms: [('batch', {'batch_dims': (0,)})] what: x * 2
-      [[ 0.00  2.00  4.00]
-       [20.00 22.00 24.00]]
       device: cpu:0 transforms: [('batch', {'batch_dims': (0,)}), 'jvp'] what: x * 2
-      [[0.20 0.20 0.20]
-       [0.20 0.20 0.20]]
-      device: cpu:1 transforms: [('batch', {'batch_dims': (0,)})] what: x * 2
-      [[200.00 202.00 204.00]
-       [220.00 222.00 224.00]]
+      ( [[ 0.00  2.00  4.00]
+         [20.00 22.00 24.00]]
+        [[0.20 0.20 0.20]
+         [0.20 0.20 0.20]] )
       device: cpu:1 transforms: [('batch', {'batch_dims': (0,)}), 'jvp'] what: x * 2
-      [[0.20 0.20 0.20]
-       [0.20 0.20 0.20]]""")
+      ( [[200.00 202.00 204.00]
+         [220.00 222.00 224.00]]
+        [[0.20 0.20 0.20]
+         [0.20 0.20 0.20]] )""")
     testing_stream.reset()
 
   def test_vmap_pmap(self):
@@ -1150,6 +1224,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     shape = (2, nr_devices, 3)
     matrix = np.fromfunction(lambda i, j, k: 100. * i + 10. * j + k, shape,
                              dtype=np.float32)
+
     def fun(xv, do_print=False):
       # x: f32[3]
       return api.vmap(api.pmap(lambda x: maybe_print(do_print, x * 2., "x * 2", tap_with_device=True)))(xv)
@@ -1174,6 +1249,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     """jit of a pmap surrounded by extra code."""
     # A matrix M[ij] = i * 10 + j
     nr_devices = api.local_device_count()
+    assert nr_devices in (1, 2)
     shape = (nr_devices, 3)
     matrix = np.fromfunction(lambda i, j: 10. * i + j, shape,
                              dtype=np.float32)
@@ -1185,7 +1261,7 @@ class HostCallbackTest(jtu.JaxTestCase):
       # This will be printed on all devices with shape (nr_devices, 3)
       return maybe_print(do_print, res + 1., "after", tap_with_device=True)
 
-    res = api.jit(functools.partial(fun, do_print=True))(matrix)
+    res = api.jit(partial(fun, do_print=True))(matrix)
     self.assertAllClose(fun(matrix, do_print=False), res, check_dtypes=False)
     hcb.barrier_wait()
     if api.device_count() == 2:
@@ -1225,11 +1301,14 @@ class HostCallbackTest(jtu.JaxTestCase):
     shape = (nr_devices, 3)
     matrix = np.fromfunction(lambda i, j: 10. * i + j, shape,
                              dtype=np.float32)
+
     def fun1(x, do_print=False):
       return maybe_print(do_print, x * 2., "x * 2")
+
     def fun2(cond, xv, do_print=False):
-      return lax.cond(cond, api.pmap(functools.partial(fun1, do_print=do_print)),
+      return lax.cond(cond, api.pmap(partial(fun1, do_print=do_print)),
                       lambda xv: xv, xv)
+
     res = fun2(True, matrix)
     self.assertAllClose(fun2(True, matrix, do_print=False), res, check_dtypes=False)
     hcb.barrier_wait()
@@ -1240,6 +1319,7 @@ class HostCallbackTest(jtu.JaxTestCase):
   def test_scan_custom_jvp(self):
     """custom JVP, inside scan.
     This exercises the custom_jvp_call_jaxpr primitives."""
+
     @api.custom_jvp
     def f(x):
       return x * hcb.id_print(x, output_stream=testing_stream, what="x")
@@ -1283,6 +1363,7 @@ class HostCallbackTest(jtu.JaxTestCase):
   def test_scan_custom_vjp(self):
     """custom VJP, inside scan.
     This exercises the custom_vjp_call_jaxpr primitives."""
+
     @api.custom_vjp
     def f(x):
       return x * hcb.id_print(x, output_stream=testing_stream, what="x")
@@ -1290,6 +1371,7 @@ class HostCallbackTest(jtu.JaxTestCase):
     # f_fwd: a -> (b, residual)
     def f_fwd(x):
       return f(x), 3. * x
+
     # f_bwd: (residual, CT b) -> [CT a]
     def f_bwd(residual, ct_b):
       return residual * hcb.id_print(ct_b, output_stream=testing_stream, what="ct_b"),
@@ -1325,17 +1407,72 @@ class HostCallbackTest(jtu.JaxTestCase):
         what: ct_b
         1.""", testing_stream.output)
 
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_mask(self):
 
-    @functools.partial(api.mask, in_shapes=['n'], out_shape='')
+    @partial(api.mask, in_shapes=['n'], out_shape='')
     def padded_sum(x):
-      return jnp.sum(hcb.id_print(x, what="x", output_stream=testing_stream))
-    args = [jnp.arange(4)], dict(n=np.int64(2))
-    _ = padded_sum(*args)
+      three_x = hcb.id_print((x, 2 * x), result=3 * x, what="x",
+                             output_stream=testing_stream)
+      return jnp.sum(three_x)
+
+    x = np.arange(5.)
+
+    self.assertAllClose(9., padded_sum([x], dict(n=3)))
     hcb.barrier_wait()
     self.assertMultiLineStrippedEqual("""
-        transforms: [('mask', {'logical_shapes': ((2,),)})] what: x
-        [0 1 2 3]""", testing_stream.output)
+        transforms: [('mask', {'logical_shapes': 5})] what: x
+        ( ( [0. 1. 2. 3. 4.]
+            [0. 2. 4. 6. 8.] )
+          ( ( 3 )
+            ( 3 ) ) )""", testing_stream.output)
+    testing_stream.reset()
+
+    # With VMAP
+    xv = np.arange(10.).reshape((2, 5))  # logical_shape = 5
+    self.assertAllClose(
+        np.array([9., 78.]),
+        # batch_size = 2, n=3 and 4 for the two elements
+        api.vmap(padded_sum)([xv],
+                             dict(n=np.array([3., 4.]))))
+    hcb.barrier_wait()
+    self.assertMultiLineStrippedEqual("""
+        transforms: [('mask', {'logical_shapes': 5}), ('batch', {'batch_dims': (0, 0, 0, 0)})] what: x
+        ( ( [[0. 1. 2. 3. 4.]
+             [5. 6. 7. 8. 9.]]
+            [[ 0.  2.  4.  6.  8.]
+             [10. 12. 14. 16. 18.]] )
+          ( ( [3. 4.] )
+            ( [3. 4.] ) ) )""", testing_stream.output)
+    testing_stream.reset()
+
+    # With JVP
+    self.assertAllClose((9., 0.9),
+                        api.jvp(lambda arg: padded_sum([arg], dict(n=3)),
+                                (x,), (x * 0.1,)))
+    hcb.barrier_wait()
+    self.assertMultiLineStrippedEqual("""
+        transforms: [('mask', {'logical_shapes': 5}), 'jvp'] what: x
+        ( ( ( [0. 1. 2. 3. 4.]
+              [0. 2. 4. 6. 8.] )
+            ( ( 3 )
+              ( 3 ) ) )
+          ( ( [0.  0.1 0.2 0.3 0.4]
+              [0.  0.2 0.4 0.6 0.8] )
+            ( ( 0 )
+              ( 0 ) ) ) )""", testing_stream.output)
+    testing_stream.reset()
+
+    # Now with JIT
+    self.assertAllClose(9., api.jit(padded_sum)([x], dict(n=3)))
+    hcb.barrier_wait()
+    self.assertMultiLineStrippedEqual("""
+      transforms: [('mask', {'logical_shapes': 5})] what: x
+      ( ( [0. 1. 2. 3. 4.]
+          [0. 2. 4. 6. 8.] )
+        ( ( 3 )
+          ( 3 ) ) )""", testing_stream.output)
     testing_stream.reset()
 
   def test_callback_delay(self):
@@ -1376,7 +1513,6 @@ class HostCallbackTest(jtu.JaxTestCase):
     hcb.barrier_wait()
     self.assertMultiLineStrippedEqual(expected, testing_stream.output)
 
-
   def test_error_bad_consumer_id(self):
     """Try to use reserved consumer ID 0.
 
@@ -1409,11 +1545,11 @@ class HostCallbackTest(jtu.JaxTestCase):
           comp, token, 123,
           [xla_bridge.constant(comp, np.zeros((2,), dtype=np.float32))])
 
-  def test_id_tap_deprecated_kwargs(self):
+  def test_id_tap_removed_kwargs(self):
     def func(x, transforms, y):
       pass
-    with self.assertWarnsRegex(
-        FutureWarning, r"Support for \*\*kwargs in ``id_tap``"):
+
+    with self.assertRaisesRegex(ValueError, r"Support for \*\*kwargs in ``id_tap``"):
       hcb.id_tap(func, 1, y=2)
 
   def test_odeint(self):
@@ -1439,6 +1575,7 @@ class HostCallbackTest(jtu.JaxTestCase):
 
     def loss(k):
       return lax.fori_loop(0, 2, api.remat(f), k)
+
     print(loss(3))
     hcb.barrier_wait()
     expected = """
@@ -1449,14 +1586,16 @@ class HostCallbackTest(jtu.JaxTestCase):
   def test_named_call(self):
     if not config.omnistaging_enabled:
       raise SkipTest("Test requires omnistaging")
+
     def tap_scalar(init, do_print=False):
-      @functools.partial(api.named_call, name="step")
+      @partial(api.named_call, name="step")
       def step(acc, step_nr):
         acc = acc + step_nr
         maybe_print(do_print, step_nr, what="step_nr")
         return acc, None
 
       return lax.scan(step, init, np.arange(2))
+
     self.assertAllClose(tap_scalar(3., do_print=False), tap_scalar(3., do_print=True))
     hcb.barrier_wait()
     expected = """
@@ -1465,6 +1604,379 @@ class HostCallbackTest(jtu.JaxTestCase):
       what: step_nr
       1"""
     self.assertMultiLineStrippedEqual(expected, testing_stream.output)
+
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
+  def test_composed(self):
+    def power(x, n):
+      x, n = hcb.id_print((x, n))
+      return x ** n
+
+    def f(x, n):
+      return x * power(x + 1., n)
+
+    x = 3.
+    print("impl = ", f(x, 2.))
+    print("jvp = ", api.jvp(lambda x: f(x, 2), (x,), (1.,)))
+    print("grad = ", api.grad(f)(x, 2.))
+    xv = np.array([3., 4.])
+    print("vmap o grad = ", api.vmap(api.grad(f))(xv, np.array([2., 3.])))
+
+
+class HostCallbackCallTest(jtu.JaxTestCase):
+  """Tests for hcb.call"""
+
+  def setUp(self):
+    testing_stream.reset()
+    testing_stream.test_method_name = self._testMethodName
+
+  def tearDown(self) -> None:
+    hcb.barrier_wait("HostCallbackCallTest.tearDown")
+
+  def call_log_testing_stream(self, func, arg, *, result_shape, name=""):
+    """Call `func` and log inputs and outputs to the testing stream"""
+
+    def call_log(arg):
+      def val2str(v):
+        return np.array2string(np.array(arg))
+      testing_stream.write(f"Call {name}({val2str(arg)})\n")
+      res = func(arg)
+      testing_stream.write(f"  = {val2str(res)}\n")
+      return res
+    return hcb.call(call_log, arg, result_shape=result_shape)
+
+  def test_call_simple(self):
+    def f_outside(args):
+      x, y = args
+      return x * y
+
+    def fun(x, use_outside=True):
+      return 2 * (hcb.call(f_outside, (x, x + 1),
+                           result_shape=x)
+                  if use_outside else f_outside((x, x + 1)))
+
+    res_inside = fun(2, use_outside=False)
+    self.assertAllClose(res_inside, fun(2, use_outside=True))
+
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
+  def test_call_no_result(self):
+    def f_outside(arg):
+      self.call_log_testing_stream(lambda x: None, arg,
+                                   result_shape=None,
+                                   name="outside")
+      return arg
+
+    self.assertAllClose((3., 4.), f_outside((3., 4.)))
+    hcb.barrier_wait()
+    expected = """
+        Call outside([3. 4.])
+          = [3. 4.]"""
+    self.assertMultiLineStrippedEqual(expected, testing_stream.output)
+
+  def test_call_cond(self):
+    def f_outside(args):
+      x, y = args
+      return x * y
+
+    def loop(x, use_outside=True):
+      def body(i, acc):
+        return lax.cond(i % 2 == 1,
+                        lambda _: (hcb.call(f_outside, (acc, i),
+                                            result_shape=acc)
+                                   if use_outside else f_outside((acc, i))),
+                        lambda _: acc,
+                        None)
+
+      return lax.fori_loop(0, 18, body, x)
+
+    res_inside = loop(1.2, use_outside=False)
+    self.assertAllClose(res_inside, loop(1.2, use_outside=True))
+
+  def test_jit_scan_call(self):
+    def f_outside(x):
+      return x
+
+    def loop(x, use_outside=True):
+      def body(carry, i):
+        if use_outside:
+          return carry + hcb.call(f_outside, i,
+                                  result_shape=i), None
+        else:
+          return carry + i, None
+
+      return lax.scan(body, 0, x)
+
+    x = np.arange(5, dtype=np.int32)
+
+    res_outside = api.jit(partial(loop, use_outside=True))(x)
+    self.assertAllClose(res_outside, loop(x, use_outside=False))
+
+  def test_doc_example1(self):
+    """Examples from the documentation: simplest, call a function"""
+
+    def host_eig(x):
+      return np.linalg.eigvals(x)
+
+    shape = (2, 5, 4, 4)
+
+    m = np.ones(shape, dtype=np.float32)
+
+    def fun(m):
+      eig_m = hcb.call(host_eig, m,
+                       result_shape=api.ShapeDtypeStruct(m.shape[:-1], m.dtype))
+      return eig_m
+
+    expected_res = np.linalg.eigvals(m)
+    self.assertAllClose(expected_res, fun(m))
+
+  def test_doc_example_hlo(self):
+    """Examples from the documentation: simplest, call a function"""
+
+    def fun(m):
+      return jnp.sin(hcb.call(lambda x: np.cos,
+                              jnp.cos(m),
+                              result_shape=m))
+
+    m = np.ones((2,), np.float32)
+    helper_print_optimized_hlo(fun, m)
+
+    def fun(m):
+      x = hcb.call(lambda x: None, 2, result_shape=())
+      return x
+
+    m = np.ones((2,), np.float32)
+    helper_print_optimized_hlo(fun, m)
+
+  def test_call_with_device(self):
+    def callback_func(x, device=None):
+      testing_stream.write(f"device: {device}\n Called with {x}")
+      return x
+
+    def func(x):
+      return hcb.call(callback_func, x,
+                      result_shape=x,
+                      call_with_device=True)
+
+    self.assertEqual(3., func(3.))
+    assertMultiDeviceOutputEqual(self, """
+        device: cpu:0
+         Called with 3.00""")
+    testing_stream.reset()
+
+  def test_call_pmap(self):
+    # Works for 1 or 2 devices
+    def callback_func(x, device=None):
+      testing_stream.write(f"device: {device}\n Called with {x}")
+      return x * np.array(3, np.int32)
+
+    def fun(x):  # x: i32
+      return hcb.call(callback_func, x * 2,
+                      result_shape=x,
+                      call_with_device=True)
+
+    xv = jnp.arange(api.device_count(), dtype=jnp.int32)
+    res = api.pmap(fun)(xv)
+    self.assertAllClose(api.pmap(lambda x: x * 6)(xv), res)
+    # Assertion text is for 2 devices (also works for 1 device)
+    assertMultiDeviceOutputEqual(self, """
+        device: cpu:0
+         Called with 0
+        device: cpu:1
+         Called with 2""")
+    testing_stream.reset()
+
+  def test_call_vmap(self):
+    def f_outside(x): return x
+
+    def fun(x):
+      return hcb.call(f_outside, x, result_shape=x)
+
+    with self.assertRaisesRegex(NotImplementedError, "Batching rule for 'outside_call' not implemented"):
+      api.vmap(fun)(np.ones((2, 3)))
+
+  def test_error_bad_result_shape(self):
+    with self.assertRaisesRegex(
+        ValueError,
+        "The values must be either numeric scalars, or must have 'shape' and 'dtype' attributes"):
+      hcb.call(lambda x: x, 3., result_shape="string")
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "The values must be either numeric scalars, or must have 'shape' and 'dtype' attributes"):
+      hcb.call(lambda x: x, 3., result_shape=lambda x: x)
+      hcb.barrier_wait("wait for error")
+
+  def helper_check_callback_errors(self, thunk: Callable,
+                                   expected_exc_txt: str):
+    """Calls thunk() and checks for expected exceptions.
+    """
+    if jtu.device_under_test() == "cpu":
+      # On CPU the runtime crashes, and the tests are all aborted
+      raise SkipTest("TODO: CPU runtime crashes on unexpected infeed")
+    elif jtu.device_under_test() == "gpu":
+      # On GPU we get a nice error back to Python
+      with self.assertRaisesRegex(
+          RuntimeError,
+          "RET_CHECK failure .* Mismatch between infeed source buffer shape s8.12345."):
+        thunk()
+    elif jtu.device_under_test() == "tpu":
+      # On TPU we get no error!!!
+      raise SkipTest("TODO: TPU runtime does not check infeed, and just computes with garbage")
+
+    # Both on GPU and TPU we also get an error during the barrier_wait at the
+    # end of the test. Run a barrier_wait now, to consume that error.
+    with self.assertRaisesRegex(
+        hcb.TapFunctionException,
+        re.compile(
+            "There were exceptions during id_tap processing.*Last one was:.*" +
+            expected_exc_txt,
+            re.DOTALL)):
+      hcb.barrier_wait("Waiting for error")
+
+  def test_error_callback_throws_exception(self):
+    def f_outside(x):
+      raise ValueError("user exception")
+    def fun(x):
+      return hcb.call(f_outside, x, result_shape=x)
+
+    self.helper_check_callback_errors(lambda: fun(3.),
+                                      "ValueError: user exception")
+
+  def test_error_callback_returns_unexpected_shape(self):
+    def fun(x):
+      return hcb.call(lambda x: (x, x), x, result_shape=x)
+
+    self.helper_check_callback_errors(lambda: fun(3.),
+                                      "Callback func .* should have returned a result with pytree")
+
+  def test_error_then_compute(self):
+    # Continue computation on device after error
+    def f_outside(x):
+      raise ValueError("user exception")
+    def fun(x):
+      x1 = hcb.call(f_outside, x, result_shape=x)
+      return x1
+    arg = np.arange(3, dtype=np.int32)
+    self.helper_check_callback_errors(lambda: self.assertAllClose(arg, fun(arg)),
+                                      "ValueError: user exception")
+
+
+def call_jax_other_device(jax_outside_fun, arg, *, device):
+  """Calls a JAX function on a specific device with simple support for reverse AD.
+
+  Functions whose name starts with "jax_outside" are called on another device,
+  by way of hcb.call.
+  """
+
+  def run_jax_outside_fun(arg):
+    return api.jit(jax_outside_fun)(api.device_put(arg, device))
+
+  @api.custom_vjp
+  def make_call(arg):
+    return hcb.call(run_jax_outside_fun, arg,
+                    result_shape=api.eval_shape(jax_outside_fun, arg))
+
+  # Define the fwd and bwd custom_vjp functions
+  def make_call_vjp_fwd(arg):
+    # Return the primal argument as the residual. Use `make_call` for the
+    # primal computation to enable higher-order AD.
+    return make_call(arg), arg  # Return the primal argument as the residual
+
+  def make_call_vjp_bwd(res, ct_res):
+    arg = res  # residual is the primal argument
+
+    def jax_outside_vjp_fun(arg_and_ct):
+      arg, ct = arg_and_ct
+      _, f_vjp = api.vjp(jax_outside_fun, arg)
+      ct_in, = f_vjp(ct)
+      return ct_in
+
+    return (call_jax_other_device(jax_outside_vjp_fun, (arg, ct_res), device=device),)
+
+  make_call.defvjp(make_call_vjp_fwd, make_call_vjp_bwd)
+  return make_call(arg)
+
+
+class CallJaxTest(jtu.JaxTestCase):
+  """Tests using `call_jax_other_device`."""
+
+  def setUp(self):
+    if jtu.device_under_test() != "cpu":
+      assert api.devices("cpu")
+      self.outside_device = api.devices("cpu")[0]
+    else:
+      if len(api.devices("cpu")) == 1:
+        raise SkipTest("Test needs at least two devices. On CPU use XLA_FLAGS=--xla_force_host_platform_device_count=2")
+      self.outside_device = api.devices("cpu")[1]
+
+  def test_impl(self):
+    def f_jax(x):
+      return jnp.sin(x)
+
+    def f_outside(x):
+      return call_jax_other_device(f_jax, x, device=self.outside_device)
+
+    self.assertAllClose(f_jax(3.), f_outside(3.))
+    self.assertAllClose(f_jax(3.), api.jit(f_outside)(3.))
+
+  def test_impl_pytree(self):
+    def f_jax(x):
+      # x : dict(a=..., b=...) and output is a list of two elements
+      return [jnp.sin(x["a"]), jnp.sin(x["b"])]
+
+    def f_outside(x):
+      return call_jax_other_device(f_jax, x, device=self.outside_device)
+
+    x = dict(a=3., b=4.)
+    res_jax = f_jax(x)
+    # print(f"outside_jaxpr = {api.make_jaxpr(f_outside)(x)}")
+    res_outside = f_outside(x)
+    self.assertAllClose(res_jax, res_outside)
+
+  def test_grad(self):
+    def f_jax(x):
+      return 2. * jnp.sin(x)
+
+    def f_outside(x):
+      return 2. * call_jax_other_device(jnp.sin, x, device=self.outside_device)
+
+    res_jax = api.grad(f_jax)(3.)
+    # print(f"res_jax = {res_jax}")
+    # print(f"jax_jaxpr = {api.make_jaxpr(api.grad(f_jax))(3.)}")
+    # print(f"outside_jaxpr = {api.make_jaxpr(api.grad(f_outside))(3.)}")
+    self.assertAllClose(res_jax, api.grad(f_outside)(3.))
+
+  def test_grad_pytree(self):
+    def f_jax(x):
+      # x : dict(a=..., b=...) and output is a float
+      return 3. * jnp.sin(x["a"]) + jnp.sin(x["b"])
+
+    def f_outside(x):
+      return call_jax_other_device(f_jax, x, device=self.outside_device)
+
+    x = dict(a=3., b=4.)
+    res_jax = api.grad(f_jax)(x)
+    # print(f"res_jax = {res_jax}")
+    # print(f"jax_jaxpr = {api.make_jaxpr(api.grad(f_jax))(3.)}")
+    # print(f"outside_jaxpr = {api.make_jaxpr(api.grad(f_outside))(3.)}")
+    self.assertAllClose(res_jax, api.grad(f_outside)(x))
+
+  def test_grad_of_grad(self):
+    def f_jax(x):
+      return 2. * x * x * x
+
+    def f_outside(x):
+      return 2. * call_jax_other_device(lambda x: x * x * x, x, device=self.outside_device)
+
+    res_jax = api.grad(api.grad(f_jax))(5.)
+    # print(f"res_jax = {res_jax}")
+    # print(f"jax_jaxpr = {api.make_jaxpr(api.grad(api.grad(f_jax)))(5.)}")
+    # print(f"outside_jaxpr = {api.make_jaxpr(api.grad(api.grad(f_outside)))(5.)}")
+    # print(f"outside xla = {api.xla_computation(api.grad(api.grad(f_outside)))(5.).as_hlo_text()}")
+    res_outside = api.grad(api.grad(f_outside))(5.)
+    # print(f"res_outside = {res_outside}")
+    self.assertAllClose(res_jax, res_outside)
 
 
 class OutfeedRewriterTest(jtu.JaxTestCase):
@@ -1480,7 +1992,7 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
     # before making changes to the code generation and Jaxpr rewriting, turn on
     # the checking, update the expected Jaxpr, and then make the changes.
     # assertMultiLineStrippedEqual(self, expected, str(rewritten))
-    del jaxpr
+    del rewritten
 
   def test_no_outfeed(self):
     self.assertRewrite("""
@@ -1488,50 +2000,52 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
           let b = mul a a
               c = add a b
           in (c,) }""", lambda x: x + x * x, [0], has_input_token=False,
-                              has_output_token=False)
+                       has_output_token=False)
     self.assertRewrite("""
-        { lambda  ; a d.
+        { lambda  ; a d e.
           let b = mul a a
               c = add a b
           in (c,) }""", lambda x: x + x * x, [0], has_output_token=False)
     self.assertRewrite("""
-        { lambda  ; a d.
+        { lambda  ; a d e.
           let b = mul a a
               c = add a b
-          in (c, d) }""", lambda x: x + x * x, [0])
+          in (c, d, e) }""", lambda x: x + x * x, [0])
 
   def test_simple_outfeed(self):
     self.assertRewrite("""
-        { lambda  ; a d.
+        { lambda  ; a d e.
           let b = add a a
-              c e = id_tap[ arg_treedef_=*
+              c f = id_tap[ arg_treedef_=*
                             has_token_=True
-                            nr_tapped_args_=1
                             tap_func_=_print  ] b d
-          in (c, e) }""", lambda x: hcb.id_print(x + x), [0])
+              g = id e
+          in (c, f, g) }""", lambda x: hcb.id_print(x + x), [0])
 
   def test_simple_outfeed_without_input_token(self):
     self.assertRewrite("""
         { lambda  ; a b.
           let e = create_token a b
+              f = create_token a b
               c = add a b
-              d f = id_tap[ arg_treedef_=*
+              d g = id_tap[ arg_treedef_=*
                             has_token_=True
-                            nr_tapped_args_=1
                             tap_func_=_print  ] c e
+              h = id f
           in (d,) }""", lambda x1, x2: hcb.id_print(x1 + x2), [1, 2],
-                        has_input_token=False, has_output_token=False)
+                       has_input_token=False, has_output_token=False)
 
   def test_simple_outfeed_without_input_token_nor_invars(self):
     self.assertRewrite("""
         { lambda  ; .
           let b = create_token
-              a c = id_tap[ arg_treedef_=*
+              c = create_token
+              a d = id_tap[ arg_treedef_=*
                             has_token_=True
-                            nr_tapped_args_=1
                             tap_func_=_print  ] 42 b
+              e = id c
           in (a,) }""", lambda: hcb.id_print(42), [],
-                        has_input_token=False, has_output_token=False)
+                       has_input_token=False, has_output_token=False)
 
   def test_multiple_tap_without_dependencies(self):
     def f(x):
@@ -1540,40 +2054,42 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
       return 2
 
     self.assertRewrite("""
-        { lambda  ; a c.
-          let _ d = id_tap[ arg_treedef_=*
+        { lambda  ; a c d.
+          let _ e = id_tap[ arg_treedef_=*
                             has_token_=True
-                            nr_tapped_args_=1
                             tap_func_=_print   what='x') ] a c
+              f = id d
               b = add a 1
-              _ e = id_tap[ arg_treedef_=*
+              _ g = id_tap[ arg_treedef_=*
                             has_token_=True
-                            nr_tapped_args_=1
-                            tap_func_=_print   what='x + 1') ] b d
-          in (2, e) }""", f, [1])
+                            tap_func_=_print   what='x + 1') ] b e
+              h = id f
+          in (2, g, h) }""", f, [1])
 
   def test_cond(self):
     y = jnp.ones(5)  # captured const
+
     def func(x, z):
       return lax.cond(z > 0, (1, 2), lambda a: (a[0], jnp.zeros(5)),
                       z, lambda a: (hcb.id_print(a), y))
+
     self.assertRewrite("""
-        { lambda a ; b c h.
+        { lambda a ; b c h i.
           let d = gt c 0
-              e = convert_element_type[ new_dtype=int32
-                                        weak_type=False ] d
-              f g i = cond[ branches=( { lambda  ; a b c d f.
-                                         let e g = id_tap[ arg_treedef_=*
-                                                           has_token_=True
-                                                           nr_tapped_args_=1
-                                                           tap_func_=_print  ] d f
-                                         in (e, a, g) }
-                                       { lambda  ; f_ a b c g.
-                                         let d = broadcast_in_dim[ broadcast_dimensions=(  )
-                                                                   shape=(5,) ] 0.00
-                                         in (a, d, g) } )
-                            linear=(False, False, False, False, False) ] e a 1 2 c h
-          in (f, g, i) }""", func, [y, 5])
+              e = convert_element_type[ new_dtype=int32 ] d
+              f g j k =
+                cond[ branches=( { lambda  ; a b c d f g.
+                                   let e h = id_tap[ arg_treedef_=*
+                                                     has_token_=True
+                                                     tap_func_=_print  ] d f
+                                       i = id g
+                                   in (e, a, h, i) }
+                                 { lambda  ; f_ a b c g h.
+                                   let d = broadcast_in_dim[ broadcast_dimensions=(  )
+                                                             shape=(5,) ] 0.00
+                                   in (a, d, g, h) } )
+                      linear=(False, False, False, False, False, False) ] e a 1 2 c h i
+          in (f, g, j, k) }""", func, [y, 5])
 
   def test_while(self):
     ct_body = jnp.ones(5, np.float32)  # captured const for the body
@@ -1585,28 +2101,30 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
       return lax.while_loop(lambda c: c[1] < jnp.sum(c[0] + ct_cond),
                             lambda c: (ct_body, hcb.id_print(c[1]) + 1.),
                             (x, np.float32(1.)))
+
     self.assertRewrite("""
-        { lambda a b ; c f.
-          let d e g = while[ body_jaxpr={ lambda  ; a b c f.
-                                          let d g = id_tap[ arg_treedef_=*
-                                                            has_token_=True
-                                                            nr_tapped_args_=1
-                                                            tap_func_=_print  ] c f
-                                              e = add d 1.00
-                                          in (a, e, g) }
-                             body_nconsts=1
-                             cond_jaxpr={ lambda  ; a b c g.
-                                          let d = add b a
-                                              e = reduce_sum[ axes=(0,) ] d
-                                              f = lt c e
-                                          in (f,) }
-                             cond_nconsts=1 ] a b c 1.00 f
-          in (d, e, g) }""", func, [ct_body])
+        { lambda a b ; c f g.
+          let d e h i =
+                while[ body_jaxpr={ lambda  ; a b c f g.
+                                    let d h = id_tap[ arg_treedef_=*
+                                                      has_token_=True
+                                                      tap_func_=_print  ] c f
+                                        i = id g
+                                        e = add d 1.00
+                                    in (a, e, h, i) }
+                       body_nconsts=1
+                       cond_jaxpr={ lambda  ; a b c g h.
+                                    let d = add b a
+                                        e = reduce_sum[ axes=(0,) ] d
+                                        f = lt c e
+                                    in (f,) }
+                       cond_nconsts=1 ] a b c 1.00 f g
+          in (d, e, h, i) }""", func, [ct_body])
 
   def test_while_pred_outfeed(self):
     """A while with outfeed in the pred."""
     ct_body = jnp.ones(5)  # captured const for the body
-    ct_cond = jnp.ones(2) # captured const for the conditional
+    ct_cond = jnp.ones(2)  # captured const for the conditional
 
     def func(x):
       return lax.while_loop(lambda c: hcb.id_print(ct_cond, result=c[1]) < 5,
@@ -1614,68 +2132,75 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
                             (x, 1))
 
     self.assertRewrite("""
-        { lambda a b ; c f.
-          let h i = xla_call[ call_jaxpr={ lambda  ; a b c f.
-                                           let _ d g = id_tap[ arg_treedef_=*
+        { lambda a b ; c f g.
+          let j k l = xla_call[ call_jaxpr={ lambda  ; a b c g h.
+                                             let d i = id_tap[ arg_treedef_=*
                                                                has_token_=True
-                                                               nr_tapped_args_=1
-                                                               tap_func_=_print  ] a c f
-                                               e = lt d 5
-                                           in (e, g) }
-                              donated_invars=(False, False, False, False)
-                              name=cond_before ] a c 1 f
-              y d e g =
-                while[ body_jaxpr={ lambda  ; n o p q r s.
-                                    let t u v = xla_call[ call_jaxpr={ lambda  ; a b c f.
-                                                                       let d g = id_tap[ arg_treedef_=*
-                                                                                         has_token_=True
-                                                                                         nr_tapped_args_=1
-                                                                                         tap_func_=_print  ] c f
-                                                                           e = add d 1
-                                                                       in (a, e, g) }
-                                                          donated_invars=(False, False, False, False)
-                                                          name=body ] o q r s
-                                        w x = xla_call[ call_jaxpr={ lambda  ; a b c f.
-                                                                     let _ d g = id_tap[ arg_treedef_=*
-                                                                                         has_token_=True
-                                                                                         nr_tapped_args_=1
-                                                                                         tap_func_=_print  ] a c f
-                                                                         e = lt d 5
-                                                                     in (e, g) }
-                                                        donated_invars=(False, False, False, False)
-                                                        name=cond_body ] n t u v
-                                    in (w, t, u, x) }
+                                                               tap_func_=_print  ] a g
+                                                 j = id h
+                                                 e = id_tap_dep c d
+                                                 f = lt e 5
+                                             in (f, i, j) }
+                                donated_invars=(False, False, False, False, False)
+                                name=cond_before ] a c 1 f g
+              bf d e h i =
+                while[ body_jaxpr={ lambda  ; r s t u v w x.
+                                    let y z ba bb =
+                                          xla_call[ call_jaxpr={ lambda  ; a b c f g.
+                                                                 let d h = id_tap[ arg_treedef_=*
+                                                                                   has_token_=True
+                                                                                   tap_func_=_print  ] c f
+                                                                     i = id g
+                                                                     e = add d 1
+                                                                 in (a, e, h, i) }
+                                                    donated_invars=(False, False, False, False, False)
+                                                    name=body ] s u v w x
+                                        bc bd be =
+                                          xla_call[ call_jaxpr={ lambda  ; a b c g h.
+                                                                 let d i = id_tap[ arg_treedef_=*
+                                                                                   has_token_=True
+                                                                                   tap_func_=_print  ] a g
+                                                                     j = id h
+                                                                     e = id_tap_dep c d
+                                                                     f = lt e 5
+                                                                 in (f, i, j) }
+                                                    donated_invars=(False, False, False, False, False)
+                                                    name=cond_body ] r y z ba bb
+                                    in (bc, y, z, bd, be) }
                        body_nconsts=2
-                       cond_jaxpr={ lambda  ; j k l m.
+                       cond_jaxpr={ lambda  ; m n o p q.
                                     let
-                                    in (j,) }
-                       cond_nconsts=0 ] a b h c 1 i
-          in (d, e, g) }""", func, [ct_body])
+                                    in (m,) }
+                       cond_nconsts=0 ] a b j c 1 k l
+          in (d, e, h, i) }""", func, [ct_body])
 
   def test_scan(self):
     y = jnp.ones(5)  # captured const
+
     def func(x):
       return lax.scan(lambda c, a: (hcb.id_print(c), y), (1, 2), x)
+
     self.assertRewrite("""
-        { lambda a ; b f.
-          let c d g e =
-                scan[ jaxpr={ lambda  ; a b c g d.
-                              let e f h = id_tap[ arg_treedef_=PyTreeDef(tuple, [*,*])
+        { lambda a ; b f g.
+          let c d h i e =
+                scan[ jaxpr={ lambda  ; a b c g h d.
+                              let e f i = id_tap[ arg_treedef_=PyTreeDef(tuple, [*,*])
                                                   has_token_=True
-                                                  nr_tapped_args_=2
                                                   tap_func_=_print  ] b c g
-                              in (e, f, h, a) }
+                                  j = id h
+                              in (e, f, i, j, a) }
                       length=5
-                      linear=(False, False, False, False, False)
-                      num_carry=3
+                      linear=(False, False, False, False, False, False)
+                      num_carry=4
                       num_consts=1
                       reverse=False
-                      unroll=1 ] a 1 2 f b
-          in (c, d, e, g) }""", func, [y])
+                      unroll=1 ] a 1 2 f g b
+          in (c, d, e, h, i) }""", func, [y])
 
   def test_scan_custom_jvp(self):
     """custom JVP, inside scan.
     This exercises the custom_jvp_call_jaxpr primitives."""
+
     @api.custom_jvp
     def f(x):
       return x * hcb.id_print(x)
@@ -1696,66 +2221,68 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
 
     arg = np.full((5,), 0.7)
     self.assertRewrite("""
-      { lambda  ; a c.
-        let b d _ = scan[ jaxpr={ lambda  ; a e b.
-                                  let c f = custom_jvp_call_jaxpr[ fun_jaxpr={ lambda  ; a d.
-                                                                               let b e = id_tap[ arg_treedef_=*
-                                                                                                 has_token_=True
-                                                                                                 nr_tapped_args_=1
-                                                                                                 tap_func_=_print  ] a d
-                                                                                   c = mul a b
-                                                                               in (c, e) }
-                                                                   num_consts=0 ] b e
-                                      d = add a c
-                                  in (d, f, 0.00) }
-                          length=5
-                          linear=(False, False, False)
-                          num_carry=2
-                          num_consts=0
-                          reverse=False
-                          unroll=1 ] 0.00 c a
-        in (b, d) }""", g, [arg])
+        { lambda  ; a c d.
+          let b e f _ =
+                scan[ jaxpr={ lambda  ; a e f b.
+                              let c g h = custom_jvp_call_jaxpr[ fun_jaxpr={ lambda  ; a d e.
+                                                                             let b f = id_tap[ arg_treedef_=*
+                                                                                               has_token_=True
+                                                                                               tap_func_=_print  ] a d
+                                                                                 g = id e
+                                                                                 c = mul a b
+                                                                             in (c, f, g) }
+                                                                 num_consts=0 ] b e f
+                                  d = add a c
+                              in (d, g, h, 0.00) }
+                      length=5
+                      linear=(False, False, False, False)
+                      num_carry=3
+                      num_consts=0
+                      reverse=False
+                      unroll=1 ] 0.00 c d a
+          in (b, e, f) }""", g, [arg])
     self.assertRewrite("""
-      { lambda  ; a d.
-        let _ _ e _ b =
-              scan[ jaxpr={ lambda  ; a b h c d.
-                            let e i = custom_jvp_call_jaxpr[ fun_jaxpr={ lambda  ; a d.
-                                                                         let b e = id_tap[ arg_treedef_=*
-                                                                                           has_token_=True
-                                                                                           nr_tapped_args_=1
-                                                                                           tap_func_=_print  ] a d
-                                                                             c = mul a b
-                                                                         in (c, e) }
-                                                             num_consts=0 ] c h
-                                f = add a e
-                                g = mul c 3.00
-                            in (f, *, i, 0.00, g) }
-                    length=5
-                    linear=(False, True, False, True, False)
-                    num_carry=3
-                    num_consts=0
-                    reverse=False
-                    unroll=1 ] 0.00 * d a *
-            _ _ f _ c =
-              scan[ jaxpr={ lambda  ; a b g c d.
-                            let e = mul b d
-                                f h = id_tap[ arg_treedef_=*
-                                              has_token_=True
-                                              nr_tapped_args_=1
-                                              tap_func_=_print
-                                              transforms=(('transpose',),) ] e g
-                            in (*, b, h, *, f) }
-                    length=5
-                    linear=(True, True, True, False, False)
-                    num_carry=3
-                    num_consts=0
-                    reverse=True
-                    unroll=1 ] * 1.00 e * b
-        in (c, f) }""", api.grad(g), [arg])
+        { lambda  ; a d e.
+          let _ _ f g _ b =
+                scan[ jaxpr={ lambda  ; a b h i c d.
+                              let e j k = custom_jvp_call_jaxpr[ fun_jaxpr={ lambda  ; a d e.
+                                                                             let b f = id_tap[ arg_treedef_=*
+                                                                                               has_token_=True
+                                                                                               tap_func_=_print  ] a d
+                                                                                 g = id e
+                                                                                 c = mul a b
+                                                                             in (c, f, g) }
+                                                                 num_consts=0 ] c h i
+                                  f = add a e
+                                  g = mul c 3.00
+                              in (f, *, j, k, 0.00, g) }
+                      length=5
+                      linear=(False, True, False, False, False, True)
+                      num_carry=4
+                      num_consts=0
+                      reverse=False
+                      unroll=1 ] 0.00 * d e a *
+              _ _ h i _ c =
+                scan[ jaxpr={ lambda  ; a b g h c d.
+                              let e = mul b d
+                                  f i = id_tap[ arg_treedef_=*
+                                                has_token_=True
+                                                tap_func_=_print
+                                                transforms=(('transpose',),) ] e g
+                                  j = id h
+                              in (*, b, i, j, *, f) }
+                      length=5
+                      linear=(True, True, False, False, True, False)
+                      num_carry=4
+                      num_consts=0
+                      reverse=True
+                      unroll=1 ] * 1.00 f g * b
+          in (c, h, i) }""", api.grad(g), [arg])
 
   def test_scan_custom_vjp(self):
     """custom VJP, inside scan.
     This exercises the custom_vjp_call_jaxpr primitives."""
+
     @api.custom_vjp
     def f(x):
       return x * hcb.id_print(x)
@@ -1763,6 +2290,7 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
     # f_fwd: a -> (b, residual)
     def f_fwd(x):
       return f(x), 3. * x
+
     # f_bwd: (residual, CT b) -> [CT a]
     def f_bwd(residual, ct_b):
       return residual * hcb.id_print(ct_b),
@@ -1777,65 +2305,66 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
 
     arg = np.full((2,), 0.7)
     self.assertRewrite("""
-      { lambda  ; a c.
-        let b d _ = scan[ jaxpr={ lambda  ; a e b.
-                                  let c f = custom_vjp_call_jaxpr[
-                                                                   fun_jaxpr={ lambda  ; a d.
-                                                                               let b e = id_tap[ arg_treedef_=*
-                                                                                                 has_token_=True
-                                                                                                 nr_tapped_args_=1
-                                                                                                 tap_func_=_print  ] a d
-                                                                                   c = mul a b
-                                                                               in (c, e) }
-                                                                   num_consts=0
-                                                                   ] b e
-                                      d = add a c
-                                  in (d, f, 0.00) }
-                          length=2
-                          linear=(False, False, False)
-                          num_carry=2
-                          num_consts=0
-                          reverse=False
-                          unroll=1 ] 0.00 c a
-        in (b, d) }""", g, [arg])
+        { lambda  ; a c d.
+          let b e f _ =
+                scan[ jaxpr={ lambda  ; a e f b.
+                              let c g h = custom_vjp_call_jaxpr[
+                                                                 fun_jaxpr={ lambda  ; a d e.
+                                                                             let b f = id_tap[ arg_treedef_=*
+                                                                                               has_token_=True
+                                                                                               tap_func_=_print  ] a d
+                                                                                 g = id e
+                                                                                 c = mul a b
+                                                                             in (c, f, g) }
+                                                                 num_consts=0
+                                                                 ] b e f
+                                  d = add a c
+                              in (d, g, h, 0.00) }
+                      length=2
+                      linear=(False, False, False, False)
+                      num_carry=3
+                      num_consts=0
+                      reverse=False
+                      unroll=1 ] 0.00 c d a
+          in (b, e, f) }""", g, [arg])
     self.assertRewrite("""
-      { lambda  ; a d.
-        let _ _ e _ b =
-              scan[ jaxpr={ lambda  ; a b h c d.
-                            let e i = custom_vjp_call_jaxpr[
-                                                             fun_jaxpr={ lambda  ; a d.
-                                                                         let b e = id_tap[ arg_treedef_=*
-                                                                                           has_token_=True
-                                                                                           nr_tapped_args_=1
-                                                                                           tap_func_=_print  ] a d
-                                                                             c = mul a b
-                                                                         in (c, e) }
-                                                             num_consts=0
-                                                             ] c h
-                                f = add a e
-                                g = mul c 3.00
-                            in (f, *, i, 0.00, g) }
-                    length=2
-                    linear=(False, True, False, True, False)
-                    num_carry=3
-                    num_consts=0
-                    reverse=False
-                    unroll=1 ] 0.00 * d a *
-            _ _ f _ c =
-              scan[ jaxpr={ lambda  ; a b g c d.
-                            let e h = id_tap[ arg_treedef_=*
-                                              has_token_=True
-                                              nr_tapped_args_=1
-                                              tap_func_=_print  ] b g
-                                f = mul d e
-                            in (*, b, h, *, f) }
-                    length=2
-                    linear=(True, True, True, False, False)
-                    num_carry=3
-                    num_consts=0
-                    reverse=True
-                    unroll=1 ] * 1.00 e * b
-        in (c, f) }""", api.grad(g), [arg])
+        { lambda  ; a d e.
+          let _ _ f g _ b =
+                scan[ jaxpr={ lambda  ; a b h i c d.
+                              let e j k = custom_vjp_call_jaxpr[
+                                                                 fun_jaxpr={ lambda  ; a d e.
+                                                                             let b f = id_tap[ arg_treedef_=*
+                                                                                               has_token_=True
+                                                                                               tap_func_=_print  ] a d
+                                                                                 g = id e
+                                                                                 c = mul a b
+                                                                             in (c, f, g) }
+                                                                 num_consts=0
+                                                                 ] c h i
+                                  f = add a e
+                                  g = mul c 3.00
+                              in (f, *, j, k, 0.00, g) }
+                      length=2
+                      linear=(False, True, False, False, False, True)
+                      num_carry=4
+                      num_consts=0
+                      reverse=False
+                      unroll=1 ] 0.00 * d e a *
+              _ _ h i _ c =
+                scan[ jaxpr={ lambda  ; a b g h c d.
+                              let e i = id_tap[ arg_treedef_=*
+                                                has_token_=True
+                                                tap_func_=_print  ] b g
+                                  j = id h
+                                  f = mul d e
+                              in (*, b, i, j, *, f) }
+                      length=2
+                      linear=(True, True, False, False, True, False)
+                      num_carry=4
+                      num_consts=0
+                      reverse=True
+                      unroll=1 ] * 1.00 f g * b
+          in (c, h, i) }""", api.grad(g), [arg])
 
   def test_remat_loop(self):
     def f(k, x):
@@ -1846,41 +2375,41 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
       return lax.fori_loop(0, 1, api.remat(f), k)
 
     self.assertRewrite("""
-        { lambda  ; a c.
-          let _ _ b d =
-                while[ body_jaxpr={ lambda  ; a b c f.
+        { lambda  ; a c d.
+          let _ _ b e f =
+                while[ body_jaxpr={ lambda  ; a b c f g.
                                     let d = add a 1
-                                        e g = remat_call[ call_jaxpr={ lambda  ; a b g.
-                                                                       let c = add a b
-                                                                           d h = id_tap[ arg_treedef_=*
-                                                                                         has_token_=True
-                                                                                         nr_tapped_args_=1
-                                                                                         tap_func_=_print  ] c g
-                                                                           e = neg a
-                                                                           f = mul e d
-                                                                       in (f, h) }
-                                                          concrete=False
-                                                          name=f ] a c f
-                                    in (d, b, e, g) }
+                                        e h i = remat_call[ call_jaxpr={ lambda  ; a b g h.
+                                                                         let c = add a b
+                                                                             d i = id_tap[ arg_treedef_=*
+                                                                                           has_token_=True
+                                                                                           tap_func_=_print  ] c g
+                                                                             j = id h
+                                                                             e = neg a
+                                                                             f = mul e d
+                                                                         in (f, i, j) }
+                                                            concrete=False
+                                                            name=f ] a c f g
+                                    in (d, b, e, h, i) }
                        body_nconsts=0
-                       cond_jaxpr={ lambda  ; a b c e.
+                       cond_jaxpr={ lambda  ; a b c e f.
                                     let d = lt a b
                                     in (d,) }
-                       cond_nconsts=0 ] 0 1 a c
-          in (b, d) }""", loss, [2])
+                       cond_nconsts=0 ] 0 1 a c d
+          in (b, e, f) }""", loss, [2])
 
   def test_named_call(self):
-
     def tap_scalar(init, do_print=False):
-      @functools.partial(api.named_call, name="step")
+      @partial(api.named_call, name="step")
       def step(acc, step_nr):
         acc = acc + step_nr
         maybe_print(do_print, step_nr, what="step_nr")
         return acc, None
 
       return lax.scan(step, init, np.arange(2, dtype=np.int32))
+
     self.assertRewrite("""
-        { lambda a ; b d.
+        { lambda a ; b d e.
           let c = scan[ jaxpr={ lambda  ; a b.
                                 let c = named_call[ call_jaxpr={ lambda  ; a b.
                                                                  let c = add a b
@@ -1893,7 +2422,7 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
                         num_consts=0
                         reverse=False
                         unroll=1 ] b a
-          in (c, d) }""", tap_scalar, [np.int32(3)])
+          in (c, d, e) }""", tap_scalar, [np.int32(3)])
 
   def test_pmap(self):
     def f(xv):
@@ -1901,28 +2430,28 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
                axis_name="i")(xv)
 
     self.assertRewrite("""
-      { lambda  ; a b.
-        let _ c = xla_pmap[ axis_name=i
-                            axis_size=1
-                            backend=None
-                            call_jaxpr={ lambda  ; a e.
-                                         let b f = id_tap[ arg_treedef_=*
-                                                           has_token_=True
-                                                           nr_tapped_args_=1
-                                                           tap_func_=_print
-                                                           tap_with_device_=True ] a e
-                                             c = convert_element_type[ new_dtype=float32
-                                                                       weak_type=False ] b
-                                             d = sin c
-                                         in (d, f) }
-                            devices=None
-                            donated_invars=(False, False)
-                            global_arg_shapes=(None,)
-                            global_axis_size=None
-                            in_axes=(0, 0)
-                            name=<lambda>
-                            out_axes=(0, 0) ] a b
-        in (c,) }""", f, [np.array([2])])
+        { lambda  ; a b c.
+          let _ d e = xla_pmap[ axis_name=i
+                                axis_size=1
+                                backend=None
+                                call_jaxpr={ lambda  ; a e f.
+                                             let b g = id_tap[ arg_treedef_=*
+                                                               has_token_=True
+                                                               tap_func_=_print
+                                                               tap_with_device_=True ] a e
+                                                 h = id f
+                                                 c = convert_element_type[ new_dtype=float32 ] b
+                                                 d = sin c
+                                             in (d, g, h) }
+                                devices=None
+                                donated_invars=(False, False, False)
+                                global_arg_shapes=(None,)
+                                global_axis_size=None
+                                in_axes=(0, 0, 0)
+                                name=<lambda>
+                                out_axes=(0, 0, 0) ] a b c
+          in (d, e) }""", f, [np.array([2])])
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -1,0 +1,256 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An example of using host_callback.call to invoke on the host functions
+written in Tensorflow. The interesting aspect here is how we can differentiate
+through the outside computation, using tf.GradientTape on the host.
+
+This is separate from host_callback_test because it needs a TF dependency.
+"""
+from typing import Callable
+import unittest
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from jax import api
+from jax.config import config
+from jax import numpy as jnp
+from jax import test_util as jtu
+from jax.experimental import host_callback as hcb
+
+try:
+  import tensorflow as tf
+except ImportError:
+  tf = None
+
+config.parse_flags_with_absl()
+FLAGS = config.FLAGS
+
+
+def call_tf_no_ad(tf_fun: Callable, arg, *, result_shape):
+  """The simplest implementation of calling to TF, without AD support.
+
+  We must use hcb.call because the TF invocation must happen outside the
+  JAX staged computation."""
+
+  def tf_to_numpy(t):
+    return t.numpy() if isinstance(t, tf.Tensor) else t
+
+  return hcb.call(lambda arg: tf.nest.map_structure(tf_to_numpy,
+                                                    tf_fun(arg)),
+                  arg, result_shape=result_shape)
+
+
+def call_tf_simple_ad(tf_fun: Callable, arg, *, result_shape):
+  """Calls a TensorFlow function with simple support for reverse AD.
+
+  Works only for 1st order AD and only for arguments and results being a single
+  ndarray (no pytrees). Functions whose name starts with "tf_" are TensorFlow
+  functions and must be called outside the JAX computation.
+  """
+
+  @api.custom_vjp
+  def make_call(arg):
+    """We wrap it all in `make_call` so that we can attach custom VJP."""
+    return call_tf_no_ad(tf_fun, arg, result_shape=result_shape)
+
+  # Define the fwd and bwd custom_vjp functions
+  def make_call_vjp_fwd(arg):
+    # Return the primal argument as the residual. Use `make_call` for the
+    # primal computation to enable higher-order AD.
+    return make_call(arg), arg
+
+  def make_call_vjp_bwd(res, ct_res):
+    arg = res  # residual is the primal argument
+
+    def tf_vjp_fun(arg_and_ct_res):
+      """Invoke TF gradient; used with hcb.call."""
+      arg, ct_res = arg_and_ct_res
+      arg_var = tf.Variable(arg)
+      with tf.GradientTape(persistent=True) as tape:
+        res = tf_fun(arg_var)
+
+      dres_darg = tape.gradient(res, sources=arg_var,
+                                unconnected_gradients=tf.UnconnectedGradients.ZERO)
+      return dres_darg * ct_res
+
+    return (call_tf_simple_ad(tf_vjp_fun, (arg, ct_res),
+                              result_shape=arg),)
+
+  make_call.defvjp(make_call_vjp_fwd, make_call_vjp_bwd)
+  return make_call(arg)
+
+
+def call_tf_full_ad(tf_fun: Callable, arg, *, result_shape):
+  """Calls a TensorFlow function with support for reverse AD.
+
+  Supports higher-order AD and pytree arguments.
+  """
+
+  @api.custom_vjp
+  def make_call(arg):
+    """We wrap it all in `make_call` so that we can attach custom VJP."""
+    return call_tf_no_ad(tf_fun, arg, result_shape=result_shape)
+
+  # Define the fwd and bwd custom_vjp functions
+  def make_call_vjp_fwd(arg):
+    return make_call(arg), arg  # Return the primal argument as the residual
+
+  def make_call_vjp_bwd(res, ct_res):
+    arg = res  # residual is the primal argument
+
+    def tf_vjp_fun(arg_and_ct_res):
+      """Invoke TF gradient; used with hcb.call."""
+      arg, ct_res = arg_and_ct_res
+
+      def make_var(a):
+        return a if isinstance(a, tf.Variable) else tf.Variable(a)
+
+      arg_var = tf.nest.map_structure(make_var, arg)
+
+      with tf.GradientTape(persistent=True) as tape:
+        res = tf_fun(arg_var)
+
+      tf.nest.assert_same_structure(res, ct_res)
+      accumulator = None  # Accumulate argument cotangent. Same structure as "arg"
+
+      def acc_ct(res_, ct_res_):
+        dres_darg = tape.gradient(res_, sources=arg_var,
+                                  unconnected_gradients=tf.UnconnectedGradients.ZERO)
+        tf.nest.assert_same_structure(dres_darg, arg)
+        scaled_dres_darg = tf.nest.map_structure(lambda d: d * ct_res_, dres_darg)
+        nonlocal accumulator
+        accumulator = (scaled_dres_darg if accumulator is None
+                       else tf.nest.map_structure(lambda x, y: x + y,
+                                                  accumulator, scaled_dres_darg))
+
+      tf.nest.map_structure(acc_ct, res, ct_res)
+      return accumulator
+
+    return (call_tf_full_ad(tf_vjp_fun, (arg, ct_res),
+                            result_shape=arg),)
+
+  make_call.defvjp(make_call_vjp_fwd, make_call_vjp_bwd)
+  return make_call(arg)
+
+
+CALL_TF_IMPLEMENTATIONS = {
+    "none": call_tf_no_ad,
+    "simple": call_tf_simple_ad,
+    "full": call_tf_full_ad,
+}
+
+
+class CallToTFTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    if tf is None:
+      raise unittest.SkipTest("Test requires tensorflow")
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name=f"_ad={ad}",
+          ad=ad)
+      for ad in CALL_TF_IMPLEMENTATIONS.keys())
+  def test_impl(self, ad="simple"):
+    call_tf = CALL_TF_IMPLEMENTATIONS[ad]
+
+    def f_jax(x):
+      return jnp.sin(x)
+
+    def f_outside(x):
+      return call_tf(tf.math.sin, x,
+                     result_shape=x)
+
+    res = f_outside(3.)
+    self.assertAllClose(f_jax(3.), res)
+    self.assertAllClose(f_jax(3.), api.jit(f_outside)(3.))
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name=f"_ad={ad}",
+          ad=ad)
+      for ad in CALL_TF_IMPLEMENTATIONS.keys()
+      if ad != "none")
+  def test_grad(self, ad="simple"):
+    call_tf = CALL_TF_IMPLEMENTATIONS[ad]
+
+    def f_jax(x):
+      return 3. * jnp.sin(2. * x)
+
+    def f_outside(x):
+      return 3. * call_tf(tf.math.sin, 2. * x, result_shape=x)
+
+    x = 4.
+    self.assertAllClose(f_jax(x), f_outside(x))
+
+    # print(f"outside_jaxpr = {api.make_jaxpr(f_outside)(xy)}")
+    # print(api.xla_computation(f_outside)(4.).as_hlo_text())
+    grad_f = api.grad(f_outside)(x)
+    # print(f"grad_outside_jaxpr = {api.make_jaxpr(api.grad(f_outside))(xy)}")
+    self.assertAllClose(api.grad(f_jax)(x), grad_f)
+
+  def test_grad_pytree(self):
+    call_tf = call_tf_full_ad
+
+    def f_jax(xy):
+      dict_ab = dict(a=2. * xy[0], b=xy[0] * xy[1])
+      return 3. * dict_ab["a"] + 4. * dict_ab["b"]
+
+    def f_outside(xy):
+      dict_ab = call_tf(
+          lambda xy: dict(a=2. * xy[0], b=xy[0] * xy[1]),
+          xy,
+          result_shape=dict(a=xy[0], b=xy[1]))
+      return 3. * dict_ab["a"] + 4. * dict_ab["b"]
+
+    xy = (5., 6.)
+    # print(f"outside_jaxpr = {api.make_jaxpr(f_outside)(xy)}")
+    # print(api.xla_computation(f_outside)(xy).as_hlo_text())
+    self.assertAllClose(f_jax(xy), f_outside(xy))
+    res_jax = api.grad(f_jax)(xy)
+    # print(f"grad_outside_jaxpr = {api.make_jaxpr(api.grad(f_outside))(xy)}")
+    self.assertAllClose(res_jax, api.grad(f_outside)(xy))
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name=f"_degree=_{degree}",
+          degree=degree)
+      for degree in [1, 2, 3, 4])
+  def test_higher_order_grad(self, degree=4):
+    call_tf = call_tf_full_ad
+
+    def f_jax(x):
+      return 2. * x * x * x
+
+    def f_outside(x):
+      return 2. * call_tf(lambda y: y * y * y, x,
+                          result_shape=x)
+
+    grad_jax = f_jax
+    grad_outside = f_outside
+    for i in range(degree):
+      grad_jax = api.grad(grad_jax)
+      grad_outside = api.grad(grad_outside)
+
+    res_jax = grad_jax(5.)
+    # print(f"res_jax = {res_jax}")
+    # print(f"jax_jaxpr = {api.make_jaxpr(api.grad(f_jax))(3.)}")
+    # print(f"outside_jaxpr = {api.make_jaxpr(api.grad(f_outside))(3.)}")
+    self.assertAllClose(res_jax, grad_outside(5.))
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -83,8 +83,9 @@ def call_tf_simple_ad(tf_fun: Callable, arg, *, result_shape):
         res = tf_fun(arg_var)
 
       dres_darg = tape.gradient(res, sources=arg_var,
+                                output_gradients=ct_res,
                                 unconnected_gradients=tf.UnconnectedGradients.ZERO)
-      return dres_darg * ct_res
+      return dres_darg
 
     return (call_tf_simple_ad(tf_vjp_fun, (arg, ct_res),
                               result_shape=arg),)

--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -49,7 +49,7 @@ def call_tf_no_ad(tf_fun: Callable, arg, *, result_shape):
 
   def tf_to_numpy(t):
     # Turn the Tensor to NumPy array without copying.
-    return np.array(memoryview(t)) if isinstance(t, tf.Tensor) else t
+    return np.asarray(memoryview(t)) if isinstance(t, tf.Tensor) else t
 
   return hcb.call(lambda arg: tf.nest.map_structure(tf_to_numpy,
                                                     tf_fun(arg)),
@@ -162,6 +162,7 @@ class CallToTFTest(jtu.JaxTestCase):
   def setUp(self):
     if tf is None:
       raise unittest.SkipTest("Test requires tensorflow")
+    super().setUp()
 
   @parameterized.named_parameters(
       dict(

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2457,6 +2457,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         lambda: core.check_jaxpr(jaxpr))
 
   def test_cond_typecheck_param(self):
+    raise SkipTest("TODO: test is flaky b/176769043")
     def new_jaxpr():
       jaxpr = api.make_jaxpr(
           lambda x: lax.switch(0, [jnp.sin, jnp.cos], x))(1.).jaxpr


### PR DESCRIPTION
This PR extends the `host_callback` module with one new function (`call`) to call a Python function on the host and feed the result back to the device computation. 

The PR contains the documentation of the API at the top of `host_callback.py`, along with relevant examples of use cases: 
calling from JAX to NumPy CPU custom kernels, to TensorFlow functions, or to JAX running on another device. In the latter
two cases we show how we can support reverse-mode AD for the host callbacks, by deferring to the reverse-mode AD on the target platform. The relevant examples are in `host_callback_test.py` and `host_callback_to_tf_test.py`.

In addition to the user documentation, here are some design considerations to discuss. 

Choice of API
--------------

* We have both `id_tap` and `call` (for now). This is because `id_tap` and `id_print` support all JAX transformations, while `call` does not have support for any transformation (yet).
* The `call` function takes only a single argument (like the `id_tap` and `id_print`). If the user wants to pass multiple arguments, they can pass a pytree. 
* The `call` function takes an optional parameter `call_with_device`, that will ensure that a `device=dev` kwarg is passed to the host callback function. This is useful in presence of execution on multiple devices, e.g., inside pmap. In many other cases it is not interesting. Alternative designs would be:
    * Always pass the device to all callback functions. I think that most functions will not need that argument, but perhaps this option makes sense for uniformity. 
    * Or, use the `inspect` module to see if the host function expects a `device` kwarg and pass it. I opted for the more explicit option. 

* The `call` function takes a `result_shape` parameter, which can be an example value from which the shape and dtype are determined, or any object with `shape` and `dtype` properties, e.g.,  `np.ndarray`, or `jax.ShapeDtypeStruct`. The compilation of `call` needs to know the expected shape and dtype of the result. There are several alternative designs:
   * Always require an object with `shape` and `dtype`. This is annoying when the argument is a scalar and the user needs to make some jax.ShapeDtypeStruct from it. So, I have decided to allow scalars to be passed as example values. 
   * JAX could obtain the result shape by actually running the callback function when the `call` is encountered during tracing. This works very well outside of staging contexts (jit, pmap, control-flow primitives), because it effectively inlines the host function. This can in fact be the implementation of `call` outside of staging contexts. But in staging contexts, it may be confusing to execute the callback function once during tracing, with actual arguments manufactured from the JAX abstract values and perhaps triggering side-effects. For the cases when the programmer wishes to, the proposed API allows the programmer to construct the result shape by calling the actual host function to get an example result. 

Unpleasant ergnonomics in presence of errors
----------------------------------------------

For `call` (but not for `id_tap`, nor for `call` that does not have results), if there is an exception in the Python user-defined function, or if the function returns a result that does not have the expected shape, we can log an error and we can throw an exception but by this point the accelerator computation will likely block waiting for the result. 

I have tried several things here. The only safe solution seems to be to abort the device computation in a way that surfaces a Python exception. Returning anything that allows the computation to continue seems unsafe. 

I will continue to investigate how to abort the computation.

The best option I have at the moment is to send something with a shape that is different than what the device expects, counting on a shape check failure. I picked a distinctive shape s8[12345] so that we can recognize it in the error
messages. This works for CPU (runtime crash), for GPU (a nice Python error message), but not for TPU. On TPU there is no shape check, the computation will just go ahead with whatever garbage it thinks it got. So, for TPU I am not sending anything and let the computation hang.


This is especially bad for Colab uses because the user may not see the error logs. 

Implementation mechanism
----------------------------

Currently, the implementation uses `outfeed` to send the arguments to the host, and (optionally) `infeed` if there are expected results (for `call` when the results are not empty). Two tokens are threaded through the computation (after all the transformations and before compilation to XLA): one token for outfeed and one for infeed, carried through the nested control-flow primitives to ensure that the infeed/outfeed operations are happening in the proper order. The outfeed operations are sequenced among themselves, and the infeed operation corresponding to an outfeed is sequenced after the outfeed, and after previous infeed operations.

Consider the compilation of the following code that computes `sin(cos(x))` but passing the result of `cos(x)` to the host. 
```
def func(x):
  return jnp.sin(hcb.call(lambda x_host: x_host, 
                                        jnp.cos(x), result_shape=x))
```

The following shows the compilation, with comments
```
ENTRY %xla_computation_fun.24 (parameter.1: f32[2]) -> (f32[2]) {
  %after-all.4 = token[] after-all()    # create an infeed token, if none is passed in 
  %parameter.1 = f32[2]{0} parameter(0)
  %cosine.5 = f32[2]{0} cosine(f32[2]{0} %parameter.1)       # jnp.cos(x)
  %tuple.6 = (f32[2]{0}) tuple(f32[2]{0} %cosine.5)    # prepare for outfeed
  %constant.7 = u32[2]{0} constant({271828, 12253941})   # outfeed first a descriptor identifying the callback function and argument shape
  %after-all.3 = token[] after-all()    # create an outfeed token, if none is passed in
  %outfeed.8 = token[] outfeed(u32[2]{0} %constant.7, token[] %after-all.3)   # outfeed the descriptor
  %outfeed.9 = token[] outfeed((f32[2]{0}) %tuple.6, token[] %outfeed.8)  # outfeed the arguments, after the descriptor
  %after-all.10 = token[] after-all(token[] %after-all.4, token[] %outfeed.9)     # a token after the outfeed and the previous infeeds
  %infeed.11 = ((f32[2]{0}), token[]) infeed(token[] %after-all.10)   # infeed the result. The compiler may schedule other computation before
  %get-tuple-element.12 = (f32[2]{0}) get-tuple-element(((f32[2]{0}), token[]) %infeed.11), index=0
  %get-tuple-element.14 = f32[2]{0} get-tuple-element((f32[2]{0}) %get-tuple-element.12), index=0
  %sine.22 = f32[2]{0} sine(f32[2]{0} %get-tuple-element.14)   # the jnp.sin operation
  ROOT %tuple.23 = (f32[2]{0}) tuple(f32[2]{0} %sine.22)
}
```
(The computation is optimized if the `call` does not have expected result: the `infeed` is skipped)

The outfeed/infeed mechanism has the advantage of working on all platforms. It has the drawback of using one global communication channel for each device and thus requires the descriptor mechanism shown above to pick the right callback function in presence of control flow in the device computation. (We need to do two separate outfeed operations due to a limitation/bug in the GPU implementation of outfeed; it would be nice to have a single outfeed that includes the descriptor and payload in the same operation.)

We are now exploring an alternative implementation on CPU and GPU that would use XLA CustomCall to call directly to the callback function.

