### PR TITLE
factor convert_closure from ode to custom_derivatives

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -13,6 +13,11 @@ jax 0.2.8 (Unreleased)
 ----------------------
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.2.7...master>`_.
 
+* New features:
+
+  * Add ``jax.closure_convert`` for use with higher-order custom
+    derivative functions. (`#5244 <https://github.com/google/jax/pull/5244>`_)
+
 * Bug fixes:
 
   * ``jax.numpy.arccosh`` now returns the same branch as ``numpy.arccosh`` for

--- a/jax/api.py
+++ b/jax/api.py
@@ -68,7 +68,8 @@ from .interpreters import batching
 from .interpreters import masking
 from .interpreters import invertible_ad as iad
 from .interpreters.invertible_ad import custom_ivjp
-from .custom_derivatives import custom_jvp, custom_vjp, custom_gradient
+from .custom_derivatives import (closure_convert, custom_gradient, custom_jvp,
+                                 custom_vjp)
 from .config import flags, config, bool_env
 
 traceback_util.register_exclusion(__file__)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -840,7 +840,7 @@ class Residuals:
     return cls(jaxpr, in_tree, out_tree, consts)
 
 
-def closure_convert(fun, example_args):
+def closure_convert(fun, *example_args):
   """Closure conversion utility, for use with higher-order custom derivatives.
 
   To define custom derivatives such as with ``jax.custom_vjp(f)``, the target
@@ -867,7 +867,7 @@ def closure_convert(fun, example_args):
   Example usage::
 
     def minimize(objective_fn, x0):
-      converted_fn, *aux_args = closure_convert(objective_fn, x0)
+      converted_fn, aux_args = closure_convert(objective_fn, x0)
       return _minimize(converted_fn, x0, *aux_args)
 
     @partial(custom_vjp, nondiff_argnums=(0,))
@@ -882,19 +882,20 @@ def closure_convert(fun, example_args):
 
     def rev(objective_fn, res, g):
       y, args = res
-      y_bar, args_bar = g
+      y_bar = g
       # ... custom reverse-mode AD ...
-      return x0_bar, *in_args_bar
+      return x0_bar, *args_bars
 
     _minimize.defvjp(fwd, rev)
 
   Args:
     fun: Python callable to be converted. Must be a pure function.
-    example_args: A tuple of arrays, scalars, or (nested) standard Python
-      containers (tuples, lists, dicts, namedtuples, i.e., pytrees) thereof,
-      used to determine the types of the formal arguments to ``fun``. This
-      type-specialized form of ``fun`` is the function that will be closure
-      converted.
+    example_args: Arrays, scalars, or (nested) standard Python
+      containers (tuples, lists, dicts, namedtuples, i.e., pytrees)
+      thereof, used to determine the types of the formal arguments to
+      ``fun``. This type-specialized form of ``fun`` is the function
+      that will be closure converted.
+
   """
   flat_args, in_tree = tree_flatten(example_args)
   in_avals = tuple(map(abstractify, flat_args))

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -32,60 +32,16 @@ import operator as op
 import jax
 import jax.numpy as jnp
 from jax import core
-from jax import dtypes
+from jax import custom_derivatives
 from jax import lax
-from jax.util import safe_map, safe_zip, cache, split_list
-from jax.api_util import flatten_fun_nokwargs
+from jax.util import safe_map, safe_zip
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import tree_map, tree_flatten, tree_unflatten
-from jax.interpreters import partial_eval as pe
+from jax.tree_util import tree_map
 from jax import linear_util as lu
-from jax import config
 
 map = safe_map
 zip = safe_zip
 
-
-@cache()
-def closure_convert(fun, in_tree, in_avals):
-  if config.omnistaging_enabled:
-    wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
-    jaxpr, out_pvals, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals)
-  else:
-    in_pvals = [pe.PartialVal.unknown(aval) for aval in in_avals]
-    wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
-    with core.initial_style_staging():  # type: ignore
-      jaxpr, out_pvals, consts = pe.trace_to_jaxpr(
-        wrapped_fun, in_pvals, instantiate=True, stage_out=False)  # type: ignore
-  out_tree = out_tree()
-
-  # We only want to closure convert for constants with respect to which we're
-  # differentiating. As a proxy for that, we hoist consts with float dtype.
-  # TODO(mattjj): revise this approach
-  is_float = lambda c: dtypes.issubdtype(dtypes.dtype(c), jnp.inexact)
-  (closure_consts, hoisted_consts), merge = partition_list(is_float, consts)
-  num_consts = len(hoisted_consts)
-
-  def converted_fun(y, t, *hconsts_args):
-    hoisted_consts, args = split_list(hconsts_args, [num_consts])
-    consts = merge(closure_consts, hoisted_consts)
-    all_args, in_tree2 = tree_flatten((y, t, *args))
-    assert in_tree == in_tree2
-    out_flat = core.eval_jaxpr(jaxpr, consts, *all_args)
-    return tree_unflatten(out_tree, out_flat)
-
-  return converted_fun, hoisted_consts
-
-def partition_list(choice, lst):
-  out = [], []
-  which = [out[choice(elt)].append(elt) or choice(elt) for elt in lst]
-  def merge(l1, l2):
-    i1, i2 = iter(l1), iter(l2)
-    return [next(i2 if snd else i1) for snd in which]
-  return out, merge
-
-def abstractify(x):
-  return core.raise_to_shaped(core.get_aval(x))
 
 def ravel_first_arg(f, unravel):
   return ravel_first_arg_(lu.wrap_init(f), unravel).call_wrapped
@@ -213,11 +169,9 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
              "\n{}.")
       raise TypeError(msg.format(arg))
 
-  flat_args, in_tree = tree_flatten((y0, t[0], *args))
-  in_avals = tuple(map(abstractify, flat_args))
-  converted, consts = closure_convert(func, in_tree, in_avals)
-
-  return _odeint_wrapper(converted, rtol, atol, mxstep, y0, t, *consts, *args)
+  converted, consts = custom_derivatives.closure_convert(
+      func, (y0, t[0], *args))
+  return _odeint_wrapper(converted, rtol, atol, mxstep, y0, t, *args, *consts)
 
 @partial(jax.jit, static_argnums=(0, 1, 2, 3))
 def _odeint_wrapper(func, rtol, atol, mxstep, y0, ts, *args):

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -169,8 +169,7 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
              "\n{}.")
       raise TypeError(msg.format(arg))
 
-  converted, consts = custom_derivatives.closure_convert(
-      func, (y0, t[0], *args))
+  converted, consts = custom_derivatives.closure_convert(func, y0, t[0], *args)
   return _odeint_wrapper(converted, rtol, atol, mxstep, y0, t, *args, *consts)
 
 @partial(jax.jit, static_argnums=(0, 1, 2, 3))


### PR DESCRIPTION
Adds a closure-conversion utility to custom derivatives, and in turn to our API, useful when setting up custom derivatives for higher-order functions. This is based on a subroutine in `ode`, with minor modifications to generalize it for wider use.

Fixes #5222 