### PR TITLE
rollback of #4850

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -410,41 +410,38 @@ def lt(x: Array, y: Array) -> Array:
   r"""Elementwise less-than: :math:`x < y`."""
   return lt_p.bind(x, y)
 
-def convert_element_type(operand: Array, new_dtype: DType = None,
-                         weak_type: bool = False) -> Array:
+def convert_element_type(operand: Array, new_dtype: DType) -> Array:
   """Elementwise cast.
+
   Wraps XLA's `ConvertElementType
   <https://www.tensorflow.org/xla/operation_semantics#convertelementtype>`_
   operator, which performs an elementwise conversion from one type to another.
   Similar to a C++ `static_cast`.
 
   Args:
-    operand: an array or scalar value to be cast
+    operand: an array or scalar value to be cast.
     new_dtype: the new type. Should be a NumPy type.
-    weak_type: whether the new dtype should be weak.
 
   Returns:
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
-  new_dtype = dtypes.canonicalize_dtype(new_dtype or _dtype(operand))
-  new_weak_type = bool(weak_type)
-
+  new_dtype = dtypes.canonicalize_dtype(new_dtype)
+  # Avoids dropping precision by casting Python scalars to the default Jax
+  # type. If we passed a Python scalar directly to the bind call below, it is
+  # cast to the default type as part of the calling convention.
+  if type(operand) in dtypes.python_scalar_dtypes:
+    operand = np.asarray(operand, new_dtype)
   old_dtype = dtypes.canonicalize_dtype(_dtype(operand))
-  old_weak_type = dtypes.is_weakly_typed(operand)
-
+  if old_dtype == new_dtype:
+    if isinstance(operand, (core.Tracer, xla.DeviceArray)):
+      return operand
+    else:
+      return _device_put_raw(np.asarray(operand))
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
     msg = "Casting complex values to real discards the imaginary part"
     warnings.warn(msg, np.ComplexWarning, stacklevel=2)
-
-  if not isinstance(operand, (core.Tracer, xla.DeviceArray)):
-    return _device_put_raw(np.asarray(operand, dtype=new_dtype),
-                           weak_type=new_weak_type)
-  elif (old_dtype, old_weak_type) == (new_dtype, new_weak_type):
-    return operand
-  else:
-    return convert_element_type_p.bind(operand, new_dtype=new_dtype,
-                                       weak_type=new_weak_type)
+  return convert_element_type_p.bind(operand, new_dtype=new_dtype)
 
 def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
   """Elementwise bitcast.
@@ -463,7 +460,11 @@ def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
     `new_dtype`.
   """
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
-  return bitcast_convert_type_p.bind(operand, new_dtype=new_dtype)
+  old_dtype = _dtype(operand)
+  if old_dtype != new_dtype:
+    return bitcast_convert_type_p.bind(operand, new_dtype=new_dtype)
+  else:
+    return operand
 
 def clamp(min: Array, x: Array, max: Array) -> Array:
   r"""Elementwise clamp.
@@ -1130,9 +1131,7 @@ def reduce(operands: Array, init_values: Array, computation: Callable,
                      f' {len(flat_operands)} vs. {len(flat_init_values)}')
   monoid_reducer = _get_monoid_reducer(computation, flat_init_values)
   if monoid_reducer:
-    # monoid reducers bypass the weak_type_rule, so we set it explicitly.
-    weak_type = dtypes.is_weakly_typed(*flat_operands) and dtypes.is_weakly_typed(*flat_init_values)
-    return convert_element_type(monoid_reducer(*flat_operands, dimensions), weak_type=weak_type)
+    return monoid_reducer(*flat_operands, dimensions)
   else:
     flat_init_avals = safe_map(_abstractify, flat_init_values)
     jaxpr, consts, out_tree = _variadic_reduction_jaxpr(
@@ -1167,7 +1166,7 @@ def _get_monoid_reducer(monoid_op: Callable, xs: Array) -> Optional[Callable]:
   dtype = _dtype(x)
   if (type(aval) is ConcreteArray) and aval.shape == ():
     if monoid_op is add:
-      return np.equal(aval.val, 0) and partial(_reduce_sum)
+      return np.equal(aval.val, 0) and _reduce_sum
     elif monoid_op is mul:
       return np.equal(aval.val, 1) and _reduce_prod
     elif monoid_op is bitwise_or and dtype == np.bool_:
@@ -1448,16 +1447,15 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
   if np.shape(fill_value):
     msg = "full must be called with scalar fill_value, got fill_value.shape {}."
     raise TypeError(msg.format(np.shape(fill_value)))
-  weak_type = dtype is None and dtypes.is_weakly_typed(fill_value)
   dtype = dtypes.canonicalize_dtype(dtype or _dtype(fill_value))
-  fill_value = convert_element_type(fill_value, dtype, weak_type)
+  fill_value = convert_element_type(fill_value, dtype)
   return broadcast(fill_value, shape)
 
-def _device_put_raw(x, weak_type=None):
+def _device_put_raw(x):
   if isinstance(x, xla.DeviceArray):
     return x
   else:
-    aval = raise_to_shaped(core.get_aval(x), weak_type=weak_type)
+    aval = raise_to_shaped(core.get_aval(x))
     return xla.array_result_handler(None, aval)(*xla.device_put(x))
 
 def iota(dtype: DType, size: int) -> Array:
@@ -1493,7 +1491,7 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
   if config.omnistaging_enabled:
     bool_eye = eq(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
                   broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_eye, new_dtype=dtype, weak_type=False)
+    return convert_element_type_p.bind(bool_eye, new_dtype=dtype)
   else:
     lazy_expr = lazy.eye(dtype, (N, M), offset)
     aval = ShapedArray((N, M), dtype)
@@ -1509,7 +1507,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
     iotas = [broadcasted_iota(np.uint32, base_shape, i)
              for i in range(len(base_shape))]
     eyes = [eq(i1, i2) for i1, i2 in zip(iotas[:-1], iotas[1:])]
-    result = convert_element_type_p.bind(_reduce(operator.and_, eyes), new_dtype=dtype, weak_type=False)
+    result = convert_element_type_p.bind(_reduce(operator.and_, eyes), new_dtype=dtype)
     return broadcast_in_dim(result, shape, axes)
   else:
     lazy_expr = lazy.broadcast(lazy.delta(dtype, base_shape), shape, axes)
@@ -1524,7 +1522,7 @@ def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
   if config.omnistaging_enabled:
     bool_tri = ge(add(broadcasted_iota(np.int32, (N, M), 0), np.int32(offset)),
                   broadcasted_iota(np.int32, (N, M), 1))
-    return convert_element_type_p.bind(bool_tri, new_dtype=dtype, weak_type=False)
+    return convert_element_type_p.bind(bool_tri, new_dtype=dtype)
   else:
     lazy_expr = lazy.tri(dtype, (N, M), offset)
     aval = ShapedArray((N, M), dtype)
@@ -1739,11 +1737,9 @@ def full_like(x: Array, fill_value: Array, dtype: Optional[DType] = None,
     `fill_value`, similar to the output of np.full.
   """
   fill_shape = np.shape(x) if shape is None else canonicalize_shape(shape)
-  weak_type = dtype is None and dtypes.is_weakly_typed(x)
-  dtype = dtype or _dtype(x)
   if not config.omnistaging_enabled:
     fill_value = tie_in(x, fill_value)
-  return full(fill_shape, convert_element_type(fill_value, dtype, weak_type))
+  return full(fill_shape, fill_value, dtype or _dtype(x))
 
 
 def collapse(operand: Array, start_dimension: int,
@@ -1969,43 +1965,35 @@ _input_dtype = lambda *args, **_: dtypes.canonicalize_dtype(args[0].dtype)
 _fixed_dtype = lambda dtype: lambda *args, **kwargs: dtypes.canonicalize_dtype(dtype)
 _complex_basetype = lambda dtype: np.abs(np.zeros((), dtype)).dtype
 
-_strip_weak_type = lambda *args, **_: False
-def _argnum_weak_type(*argnums):
-  return lambda *args, **_: all(args[i].weak_type for i in argnums)
-
 def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None,
-                       multiple_results=False, weak_type_rule=None):
-  weak_type_rule = weak_type_rule or partial(_standard_weak_type_rule, name)
+                       multiple_results=False):
   prim = Primitive(name)
   prim.multiple_results = multiple_results
   prim.def_impl(partial(xla.apply_primitive, prim))
-  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule, weak_type_rule))
+  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule))
   xla.translations[prim] = translation_rule or partial(standard_translate, name)
   return prim
 
-def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule, *args, **kwargs):
+
+def standard_abstract_eval(prim, shape_rule, dtype_rule, *args, **kwargs):
   assert all(isinstance(arg, UnshapedArray) for arg in args), args
-  weak_types = weak_type_rule(*args, **kwargs)
   least_specialized = _max(
       map(type, args), key=operator.attrgetter('array_abstraction_level'))
   if least_specialized is ConcreteArray:
     out_vals = prim.impl(*[x.val for x in args], **kwargs)
     if not prim.multiple_results:
-      out_vals, weak_types = [out_vals], [weak_types]
-    out_avals = [ConcreteArray(v, weak_type=weak_type)
-                 for v, weak_type in safe_zip(out_vals, weak_types)]
+      out_vals = [out_vals]
+    out_avals = safe_map(ConcreteArray, out_vals)
   elif least_specialized is ShapedArray:
     shapes, dtypes = shape_rule(*args, **kwargs), dtype_rule(*args, **kwargs)
     if not prim.multiple_results:
-      shapes, dtypes, weak_types = [shapes], [dtypes], [weak_types]
-    out_avals = [ShapedArray(shape, dtype, weak_type=weak_type)
-                 for shape, dtype, weak_type in safe_zip(shapes, dtypes, weak_types)]
+      shapes, dtypes = [shapes], [dtypes]
+    out_avals = safe_map(ShapedArray, shapes, dtypes)
   elif least_specialized is UnshapedArray:
     dtypes = dtype_rule(*args, **kwargs)
     if not prim.multiple_results:
-      dtypes, weak_types = [dtypes], [weak_types]
-    out_avals = [UnshapedArray(dtype, weak_type=weak_type)
-                 for dtype, weak_type in safe_zip(dtypes, weak_types)]
+      dtypes = [dtypes]
+    out_avals = safe_map(UnshapedArray, dtypes)
   else:
     raise TypeError(args, least_specialized)
   if not prim.multiple_results:
@@ -2029,9 +2017,8 @@ def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
 
 def unop(result_dtype, accepted_dtypes, name, translation_rule=None):
   dtype_rule = partial(unop_dtype_rule, result_dtype, accepted_dtypes, name)
-  weak_type_rule = partial(_naryop_weak_type_rule, name)
   prim = standard_primitive(_attrgetter('shape'), dtype_rule, name,
-                            translation_rule=translation_rule, weak_type_rule=weak_type_rule)
+                            translation_rule=translation_rule)
   batching.defvectorized(prim)
   masking.defvectorized(prim)
   return prim
@@ -2075,29 +2062,11 @@ def _broadcasting_shape_rule(name, *avals):
     raise TypeError(msg.format(name, ', '.join(map(str, map(tuple, shapes)))))
   return result_shape
 
-def _standard_weak_type_rule(name, *avals, **kwargs):
-  return all(aval.weak_type for aval in avals)
-
-def _naryop_weak_type_rule(name, *avals, **kwargs):
-  if any(aval.dtype is dtypes.float0 for aval in avals):
-    pos = next(i for i, aval in enumerate(avals) if aval.dtype is dtypes.float0)
-    raise TypeError(
-        f"Called {name} with a float0 at position {pos}. "
-        "float0s do not support any operations by design, because they "
-        "are not compatible with non-trivial vector spaces. No implicit dtype "
-        "conversion is done. You can use np.zeros_like(arr, dtype=np.float) "
-        "to cast a float0 array to a regular zeros array. \n"
-        "If you didn't expect to get a float0 you might have accidentally "
-        "taken a gradient with respect to an integer argument.")
-  return all(aval.weak_type for aval in avals)
-
 def naryop(result_dtype, accepted_dtypes, name, translation_rule=None):
   dtype_rule = partial(naryop_dtype_rule, result_dtype, accepted_dtypes, name)
   shape_rule = partial(_broadcasting_shape_rule, name)
-  weak_type_rule = partial(_naryop_weak_type_rule, name)
   prim = standard_primitive(shape_rule, dtype_rule, name,
-                            translation_rule=translation_rule,
-                            weak_type_rule=weak_type_rule)
+                            translation_rule=translation_rule)
   batching.defbroadcasting(prim)
   masking.defnaryop(prim)
   return prim
@@ -2631,16 +2600,13 @@ lt_p = naryop(_fixed_dtype(np.bool_), [_any, _any], 'lt')
 ad.defjvp_zero(lt_p)
 
 
-def _convert_element_type_shape_rule(operand, *, new_dtype, weak_type):
+def _convert_element_type_shape_rule(operand, *, new_dtype):
   return operand.shape
 
-def _convert_element_type_dtype_rule(operand, *, new_dtype, weak_type):
+def _convert_element_type_dtype_rule(operand, *, new_dtype):
   return new_dtype
 
-def _convert_element_type_weak_type_rule(operand, *, new_dtype, weak_type):
-  return weak_type
-
-def _convert_element_type_translation_rule(c, operand, *, new_dtype, weak_type):
+def _convert_element_type_translation_rule(c, operand, *, new_dtype):
   old_dtype = c.get_shape(operand).numpy_dtype()
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
@@ -2648,27 +2614,25 @@ def _convert_element_type_translation_rule(c, operand, *, new_dtype, weak_type):
   new_etype = xla_client.dtype_to_etype(new_dtype)
   return xops.ConvertElementType(operand, new_element_type=new_etype)
 
-def _convert_element_type_transpose_rule(ct, operand, *, new_dtype, weak_type):
+def _convert_element_type_transpose_rule(ct, operand, *, new_dtype):
   assert ad.is_undefined_primal(operand)
   old_dtype = operand.aval.dtype
-  old_weak_type = dtypes.is_weakly_typed(operand)
   if type(ct) is ad_util.Zero:
     return [ad_util.Zero(operand.aval)]
   elif core.primal_dtype_to_tangent_dtype(old_dtype) is dtypes.float0:
     return [ad_util.Zero(ShapedArray(operand.aval.shape, dtype=dtypes.float0))]
   else:
-    return [convert_element_type_p.bind(ct, new_dtype=old_dtype, weak_type=old_weak_type)]
+    return [convert_element_type_p.bind(ct, new_dtype=old_dtype)]
 
-def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype, weak_type):
+def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype):
   if core.primal_dtype_to_tangent_dtype(new_dtype) is dtypes.float0:
     return ad_util.Zero(ShapedArray(tangent.shape, dtype=dtypes.float0))
   else:
-    return convert_element_type_p.bind(tangent, new_dtype=new_dtype, weak_type=weak_type)
+    return convert_element_type_p.bind(tangent, new_dtype=new_dtype)
 
 convert_element_type_p = standard_primitive(
     _convert_element_type_shape_rule, _convert_element_type_dtype_rule,
-    'convert_element_type', _convert_element_type_translation_rule,
-    weak_type_rule=_convert_element_type_weak_type_rule)
+    'convert_element_type', _convert_element_type_translation_rule)
 ad.defjvp(convert_element_type_p, _convert_element_type_jvp_rule)
 ad.primitive_transposes[convert_element_type_p] = _convert_element_type_transpose_rule
 batching.defvectorized(convert_element_type_p)
@@ -2687,8 +2651,7 @@ def _bitcast_convert_type_translation_rule(c, operand, *, new_dtype):
 
 bitcast_convert_type_p = standard_primitive(
     _bitcast_convert_type_shape_rule, _bitcast_convert_type_dtype_rule,
-    'bitcast_convert_type', _bitcast_convert_type_translation_rule,
-    weak_type_rule=_strip_weak_type)
+    'bitcast_convert_type', _bitcast_convert_type_translation_rule)
 ad.defjvp_zero(bitcast_convert_type_p)
 batching.defvectorized(bitcast_convert_type_p)
 masking.defvectorized(bitcast_convert_type_p)
@@ -3295,7 +3258,7 @@ def _broadcast_in_dim_impl(operand, *, shape, broadcast_dimensions):
       np.equal(operand.shape, np.take(shape, broadcast_dimensions))):
     shape = _broadcast_in_dim_shape_rule(
       operand, shape=shape, broadcast_dimensions=broadcast_dimensions)
-    aval = ShapedArray(shape, _dtype(operand), weak_type=dtypes.is_weakly_typed(operand))
+    aval = ShapedArray(shape, _dtype(operand))
     if operand._lazy_expr is None:
       lazy_expr = lazy.broadcast(lazy.array(operand.shape), shape, broadcast_dimensions)
     else:
@@ -3839,8 +3802,7 @@ def _select_jvp(primals, tangents):
     out_dot = select(pred, on_true_dot, on_false_dot)
   return out, out_dot
 
-select_p = standard_primitive(_select_shape_rule, _select_dtype_rule, 'select',
-                              weak_type_rule=_argnum_weak_type(1, 2))
+select_p = standard_primitive(_select_shape_rule, _select_dtype_rule, 'select')
 ad.primitive_jvps[select_p] = _select_jvp
 ad.primitive_transposes[select_p] = _select_transpose_rule
 batching.primitive_batchers[select_p] = _select_batch_rule
@@ -4032,7 +3994,7 @@ def _dynamic_slice_batching_rule(batched_args, batch_dims, *, slice_sizes):
 
 dynamic_slice_p = standard_primitive(
     _dynamic_slice_shape_rule, _dynamic_slice_dtype_rule, 'dynamic_slice',
-    _dynamic_slice_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _dynamic_slice_translation_rule)
 ad.primitive_jvps[dynamic_slice_p] = _dynamic_slice_jvp  # TODO
 ad.primitive_transposes[dynamic_slice_p] = _dynamic_slice_transpose_rule
 batching.primitive_batchers[dynamic_slice_p] = _dynamic_slice_batching_rule
@@ -4363,7 +4325,7 @@ def _gather_batching_rule(batched_args, batch_dims, *, dimension_numbers,
 
 gather_p = standard_primitive(
     _gather_shape_rule, _gather_dtype_rule, 'gather',
-    _gather_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _gather_translation_rule)
 ad.defjvp(gather_p, _gather_jvp_rule, None)
 
 ad.primitive_transposes[gather_p] = _gather_transpose_rule
@@ -4674,7 +4636,7 @@ def _scatter_batching_rule(scatter_op, batched_args, batch_dims, *,
 
 scatter_add_p = standard_primitive(
     _scatter_shape_rule, _scatter_dtype_rule, 'scatter-add',
-    _scatter_add_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _scatter_add_translation_rule)
 ad.primitive_jvps[scatter_add_p] = _scatter_add_jvp
 ad.primitive_transposes[scatter_add_p] = _scatter_add_transpose_rule
 batching.primitive_batchers[scatter_add_p] = (
@@ -4685,7 +4647,7 @@ xla.backend_specific_translations['gpu'][scatter_add_p] = partial(
 
 scatter_mul_p = standard_primitive(
     _scatter_shape_rule, _scatter_dtype_rule, 'scatter-mul',
-    _scatter_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _scatter_translation_rule)
 
 def _scatter_mul_jvp_rhs(g, x, i, y, *, dimension_numbers,
                          indices_are_sorted, unique_indices, **kw):
@@ -4802,14 +4764,14 @@ def _scatter_extremal_jvp(scatter_op, primals, tangents, update_jaxpr,
 
 scatter_min_p = standard_primitive(
     _scatter_shape_rule, _scatter_dtype_rule, 'scatter-min',
-    _scatter_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _scatter_translation_rule)
 batching.primitive_batchers[scatter_min_p] = (
   partial(_scatter_batching_rule, scatter_min))
 ad.primitive_jvps[scatter_min_p] = partial(_scatter_extremal_jvp, scatter_min_p)
 
 scatter_max_p = standard_primitive(
     _scatter_shape_rule, _scatter_dtype_rule, 'scatter-max',
-    _scatter_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _scatter_translation_rule)
 batching.primitive_batchers[scatter_max_p] = (
   partial(_scatter_batching_rule, scatter_max))
 ad.primitive_jvps[scatter_max_p] = partial(_scatter_extremal_jvp, scatter_max_p)
@@ -4897,7 +4859,7 @@ def _scatter_jvp(primals, tangents, *, update_jaxpr, update_consts,
 
 scatter_p = standard_primitive(
     _scatter_shape_rule, _scatter_dtype_rule, 'scatter',
-    _scatter_translation_rule, weak_type_rule=_argnum_weak_type(0))
+    _scatter_translation_rule)
 ad.primitive_jvps[scatter_p] = _scatter_jvp
 batching.primitive_batchers[scatter_p] = (
   partial(_scatter_batching_rule, scatter))
@@ -4921,10 +4883,6 @@ def _reduce_dtype_rule(*args, computation, jaxpr, consts, dimensions):
       for in_arg in init_value_args
   ]
 
-def _reduce_weak_type_rule(*args, computation, jaxpr, consts, dimensions):
-  operand_args, init_value_args = split_list(args, [len(args) // 2])
-  return [op.weak_type and init_value.weak_type
-          for op, init_value in safe_zip(operand_args, init_value_args)]
 
 def _reduce_translation_rule(c, *values, computation, jaxpr,
                              consts, dimensions):
@@ -4992,7 +4950,7 @@ def _reducer_masking_rule(prim, identity, padded_vals, logical_shapes,
 
 reduce_p = standard_primitive(_reduce_shape_rule, _reduce_dtype_rule,
                               'reduce', translation_rule=_reduce_translation_rule,
-                              multiple_results=True, weak_type_rule=_reduce_weak_type_rule)
+                              multiple_results=True)
 batching.primitive_batchers[reduce_p] = _reduce_batch_rule
 
 
@@ -5178,8 +5136,7 @@ _argmax_translation_rule = partial(_argminmax_translation_rule, xops.Gt,
                                    _get_max_identity)
 
 argmin_p = standard_primitive(_argminmax_shape_rule, _argminmax_dtype_rule,
-                              'argmin', _argmin_translation_rule,
-                              weak_type_rule=_strip_weak_type)
+                              'argmin', _argmin_translation_rule)
 batching.defreducer(argmin_p)
 ad.defjvp_zero(argmin_p)
 xla.backend_specific_translations['gpu'][argmin_p] = xla.lower_fun(
@@ -5187,8 +5144,7 @@ xla.backend_specific_translations['gpu'][argmin_p] = xla.lower_fun(
   multiple_results=False)
 
 argmax_p = standard_primitive(_argminmax_shape_rule, _argminmax_dtype_rule,
-                              'argmax', _argmax_translation_rule,
-                              weak_type_rule=_strip_weak_type)
+                              'argmax', _argmax_translation_rule)
 batching.defreducer(argmax_p)
 ad.defjvp_zero(argmax_p)
 xla.backend_specific_translations['gpu'][argmax_p] = xla.lower_fun(
@@ -5210,16 +5166,14 @@ def _reduce_logical_translation_rule(prim, identity, c, operand, *, axes):
 _reduce_or_translation_rule = partial(_reduce_logical_translation_rule,
                                       or_p, _get_max_identity)
 reduce_or_p = standard_primitive(_reduce_logical_shape_rule, _fixed_dtype(np.bool_),
-                                 'reduce_or', _reduce_or_translation_rule,
-                                 weak_type_rule=_strip_weak_type)
+                                 'reduce_or', _reduce_or_translation_rule)
 batching.defreducer(reduce_or_p)
 
 
 _reduce_and_translation_rule = partial(_reduce_logical_translation_rule,
                                        and_p, _get_min_identity)
 reduce_and_p = standard_primitive(_reduce_logical_shape_rule, _fixed_dtype(np.bool_),
-                                 'reduce_and', _reduce_and_translation_rule,
-                                 weak_type_rule=_strip_weak_type)
+                                  'reduce_and', _reduce_and_translation_rule)
 batching.defreducer(reduce_and_p)
 
 def _reduce_window_shape_rule(operand, init_value, *, jaxpr, consts,
@@ -5833,7 +5787,7 @@ def _top_k_abstract_eval(operand, *, k):
     msg = "k argument to top_k must be no larger than minor dimension; {} vs {}"
     raise ValueError(msg.format(k, shape))
   shape[-1] = k
-  return (ShapedArray(shape, operand.dtype, operand.weak_type),
+  return (ShapedArray(shape, operand.dtype),
           ShapedArray(shape, np.dtype(np.int32)))
 
 def _top_k_jvp(primals, tangents, *, k):
@@ -6034,7 +5988,7 @@ def _rng_uniform_abstract_eval(a, b, *, shape):
     raise ValueError(
       "Arguments to rng_uniform must be scalars; got shapes {} and {}."
       .format(a.shape, b.shape))
-  return ShapedArray(shape, a.dtype, weak_type=(a.weak_type and b.weak_type))
+  return ShapedArray(shape, a.dtype)
 
 def _rng_uniform_translation_rule(c, a, b, *, shape):
   xla_shape = xc.Shape.array_shape(c.get_shape(a).xla_element_type(), shape)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -270,21 +270,15 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    to_dtype_raw = dtypes._result_type_raw(*args)
-    weak_type = to_dtype_raw in set(dtypes._weak_types)
-    to_dtype = dtypes.canonicalize_dtype(to_dtype_raw)
-    return [lax.convert_element_type(x, to_dtype, weak_type) for x in args]
+    to_dtype = result_type(*args)
+    return [lax.convert_element_type(x, to_dtype) for x in args]
 
 def _promote_dtypes_inexact(*args):
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to an inexact type."""
-  to_dtype_raw = dtypes._result_type_raw(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype_raw)
-  to_dtype_inexact = _to_inexact_dtype(to_dtype)
-  weak_type = (to_dtype == to_dtype_inexact
-               and to_dtype_raw in set(dtypes._weak_types))
-  return [lax.convert_element_type(x, to_dtype_inexact, weak_type) for x in args]
+  to_dtype = _to_inexact_dtype(result_type(*args))
+  return [lax.convert_element_type(x, to_dtype) for x in args]
 
 def _to_inexact_dtype(dtype):
   """Promotes a dtype into an inexact dtype, if it is not already one."""
@@ -2758,8 +2752,6 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   if order is not None and order != "K":
     raise NotImplementedError("Only implemented for order='K'")
   lax._check_user_dtype_supported(dtype, "array")
-
-  weak_type = dtype is None and dtypes.is_weakly_typed(object)
   dtype = dtype and dtypes.canonicalize_dtype(dtype)
 
   if _can_call_numpy_array(object):
@@ -2767,13 +2759,13 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   assert type(object) not in dtypes.python_scalar_dtypes
 
   if type(object) is np.ndarray:
-    out = _device_put_raw(object, weak_type=weak_type)
+    out = _device_put_raw(object)
     if dtype: assert _dtype(out) == dtype
   elif isinstance(object, (DeviceArray, core.Tracer)):
     if isinstance(object, DeviceArray) and copy:
       # We perform a copy by bouncing back to the host
       # TODO(phawkins): add a device runtime function to copy a buffer
-      out = _device_put_raw(_np_asarray(object), weak_type=weak_type)
+      out = _device_put_raw(_np_asarray(object))
     else:
       out = object
   elif isinstance(object, (list, tuple)):
@@ -2791,7 +2783,8 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
-  out = lax.convert_element_type(out, dtype, weak_type=weak_type)
+  if dtype and _dtype(out) != dtype:
+    out = lax.convert_element_type(out, dtype)
 
   if ndmin > ndim(out):
     out = lax.broadcast(out, (1,) * (ndmin - ndim(out)))

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -287,11 +287,10 @@ def dtype(x):
     return python_scalar_dtypes[type(x)]
   return np.result_type(x)
 
-def _result_type_raw(*args):
-  if len(args) < 2:
-    return _jax_type(args[0])
-  return _least_upper_bound(*{_jax_type(arg) for arg in args})
-
 def result_type(*args):
   """Convenience function to apply Numpy argument dtype promotion."""
-  return canonicalize_dtype(_result_type_raw(*args))
+   # TODO(jakevdp): propagate weak_type to the result.
+  if len(args) < 2:
+    return canonicalize_dtype(dtype(args[0]))
+  # TODO(jakevdp): propagate weak_type to the result when necessary.
+  return canonicalize_dtype(_least_upper_bound(*{_jax_type(arg) for arg in args}))

--- a/jax/experimental/doubledouble.py
+++ b/jax/experimental/doubledouble.py
@@ -244,11 +244,11 @@ _def_inequality(lax.le_p, operator.le)
 _def_inequality(lax.eq_p, operator.eq)
 _def_inequality(lax.ne_p, operator.ne)
 
-def _convert_element_type(operand, *, new_dtype=None, weak_type=False):
+def _convert_element_type(operand, new_dtype):
   head, tail = operand
-  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype, weak_type=weak_type)
+  head = lax.convert_element_type_p.bind(head, new_dtype=new_dtype)
   if tail is not None:
-    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype, weak_type=weak_type)
+    tail = lax.convert_element_type_p.bind(tail, new_dtype=new_dtype)
   if jnp.issubdtype(new_dtype, jnp.floating):
     if tail is None:
       tail = jnp.zeros_like(head)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1101,7 +1101,7 @@ tf_impl[lax.lt_p] = tf.math.less
 
 tf_impl[lax_linalg.cholesky_p] = tf.linalg.cholesky
 
-def _convert_element_type(operand, *, new_dtype, weak_type=False):
+def _convert_element_type(operand, *, new_dtype):
   old_dtype = operand.dtype.as_numpy_dtype
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -100,8 +100,6 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
          dtype=dtype)
     for dtype in [np.int64, np.float64]))
   def test_converts_64bit(self, dtype=np.int64, with_function=False):
-    if not config.FLAGS.jax_enable_x64:
-      self.skipTest("requires x64 mode")
     big_const = np.full((5,), 2 ** 33, dtype=dtype)
     self.ConvertAndCompare(jnp.sin, big_const)
     f_conv = jax2tf.convert(jnp.sin)

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -368,7 +368,7 @@ def _make_convert_element_type_harness(name, *, shape=(100, 100),
                                        dtype=np.float32, new_dtype=np.float32):
   return Harness(f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_olddtype={jtu.dtype_str(dtype)}_newdtype={jtu.dtype_str(new_dtype)}",
                  lambda arg: (
-                     lax.convert_element_type_p.bind(arg, new_dtype=new_dtype, weak_type=False)),
+                     lax.convert_element_type_p.bind(arg, new_dtype=new_dtype)),
                  [RandArg(shape, dtype)],
                  shape=shape,
                  dtype=dtype,

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -548,8 +548,7 @@ class _WhileBuilder(_LoopBuilder):
       # Conditional function is not allowed to modify the scope state
       for ms, init_ms in zip(carried_state_names, args):
         if not (scope._mutable_state[ms] is init_ms):
-          msg = "Conditional function modifies scope.{} field."
-          raise ValueError(msg.format(ms))
+          raise ValueError(f"Conditional function modifies scope.{ms} field.")
       return res
 
     init_avals = safe_map(_BodyTracer.abstractify, init_vals)
@@ -559,11 +558,10 @@ class _WhileBuilder(_LoopBuilder):
                                             tuple(init_avals)))
     # TODO: share these checks with lax_control_flow.while
     if not tree_util.treedef_is_leaf(cond_tree):
-      msg = "cond_fun must return a boolean scalar, but got pytree {}."
-      raise TypeError(msg.format(cond_tree))
-    if cond_jaxpr.out_avals != [core.ShapedArray((), np.bool_)]:
-      msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
-      raise TypeError(msg.format(cond_jaxpr.out_avals))
+      raise TypeError(f"cond_fun must return a boolean scalar, but got pytree {cond_tree}.")
+    if not safe_map(core.typecompat, cond_jaxpr.out_avals, [core.ShapedArray((), np.bool_)]):
+      raise TypeError(f"cond_fun must return a boolean scalar, but got output type(s) "
+                      f"{cond_jaxpr.out_avals}.")
 
     return lax_control_flow.while_p.bind(*itertools.chain(cond_consts,
                                                           body_const_vals,

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -548,7 +548,8 @@ class _WhileBuilder(_LoopBuilder):
       # Conditional function is not allowed to modify the scope state
       for ms, init_ms in zip(carried_state_names, args):
         if not (scope._mutable_state[ms] is init_ms):
-          raise ValueError(f"Conditional function modifies scope.{ms} field.")
+          msg = "Conditional function modifies scope.{} field."
+          raise ValueError(msg.format(ms))
       return res
 
     init_avals = safe_map(_BodyTracer.abstractify, init_vals)
@@ -558,10 +559,11 @@ class _WhileBuilder(_LoopBuilder):
                                             tuple(init_avals)))
     # TODO: share these checks with lax_control_flow.while
     if not tree_util.treedef_is_leaf(cond_tree):
-      raise TypeError(f"cond_fun must return a boolean scalar, but got pytree {cond_tree}.")
-    if not safe_map(core.typecompat, cond_jaxpr.out_avals, [core.ShapedArray((), np.bool_)]):
-      raise TypeError(f"cond_fun must return a boolean scalar, but got output type(s) "
-                      f"{cond_jaxpr.out_avals}.")
+      msg = "cond_fun must return a boolean scalar, but got pytree {}."
+      raise TypeError(msg.format(cond_tree))
+    if cond_jaxpr.out_avals != [core.ShapedArray((), np.bool_)]:
+      msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
+      raise TypeError(msg.format(cond_jaxpr.out_avals))
 
     return lax_control_flow.while_p.bind(*itertools.chain(cond_consts,
                                                           body_const_vals,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1879,9 +1879,9 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(outer_jaxpr.eqns[0].primitive.name, 'xla_call')
     subjaxpr_1 = outer_jaxpr.eqns[0].params["call_jaxpr"]
     self.assertEqual(str(subjaxpr_1), str(inner_jaxpr))
-    self.assertLen(inner_jaxpr.eqns, 2 if config.omnistaging_enabled else 3)
-    self.assertEqual(inner_jaxpr.eqns[-2].primitive.name, 'mul')
-    self.assertEqual(inner_jaxpr.eqns[-1].primitive.name, 'add')
+    self.assertLen(inner_jaxpr.eqns, 2)
+    self.assertEqual(inner_jaxpr.eqns[0].primitive.name, 'mul')
+    self.assertEqual(inner_jaxpr.eqns[1].primitive.name, 'add')
 
   def test_primitive_compilation_cache(self):
     with jtu.count_primitive_compiles() as count:
@@ -2570,8 +2570,7 @@ class JaxprTest(jtu.JaxTestCase):
         let b = ge a 0.0
             c = add a 1.0
             d = add a 2.0
-            e = convert_element_type[ new_dtype=int32
-                                      weak_type=False ] b
+            e = convert_element_type[ new_dtype=int32 ] b
             f = cond[ branches=( { lambda  ; e_ a b c.
                                    let d = sub c a
                                    in (d,) }
@@ -2579,29 +2578,24 @@ class JaxprTest(jtu.JaxTestCase):
                                    let d = add b a
                                    in (d,) } )
                       linear=(False, False, False, False) ] e a a c d
-        in (f,) }
-        """
+      in (f,) }
+      """
     else:
       expected = """
       { lambda  ; a.
         let b = ge a 0.0
-            c = convert_element_type[ new_dtype=int32
-                                      weak_type=False ] b
-            d = convert_element_type[ new_dtype=float32
-                                      weak_type=False ] a
-            e = convert_element_type[ new_dtype=float32
-                                      weak_type=False ] a
-            f = add a 1.0
-            g = add a 2.0
-            h = cond[ branches=( { lambda  ; e_ c a b.
+            c = convert_element_type[ new_dtype=int32 ] b
+            d = add a 1.0
+            e = add a 2.0
+            f = cond[ branches=( { lambda  ; e_ c a b.
                                    let d = sub b c
                                    in (d,) }
                                  { lambda  ; c f_ a b.
                                    let d = add a c
                                    in (d,) } )
-                      linear=(False, False, False, False) ] c d e f g
-        in (h,) }
-      """
+                      linear=(False, False, False, False) ] c a a d e
+        in (f,) }
+        """
     jaxpr = api.make_jaxpr(f)(3.)
     self.assertMultiLineStrippedEqual(expected, str(jaxpr))
 

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -56,11 +56,6 @@ scalar_types = [jnp.bool_, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                 jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64,
                 jnp.complex64, jnp.complex128]
 
-def identity(x):
-  """A named identity function for use in tests"""
-  return x
-
-
 class DtypesTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
@@ -88,8 +83,10 @@ class DtypesTest(jtu.JaxTestCase):
     testcases = [
       (jnp.array(1.), 0., jnp.float_),
       (jnp.array(1.), jnp.array(0.), jnp.float_),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float16),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float32),
+      (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float_),
+      (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float_),
+      # (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float16),
+      # (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float32),
       (jnp.array(1.), jnp.array(0., dtype=jnp.float64), jnp.float64),
       (jnp.array(1., dtype=jnp.float16), 0., jnp.float16),
       (jnp.array(1., dtype=jnp.float32), 0., jnp.float32),
@@ -216,45 +213,45 @@ class TestPromotionTables(jtu.JaxTestCase):
         ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*']
     if FLAGS.jax_enable_x64:
       expected = [
-        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
-        ['u1','u1','u2','u4','u8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','u1','f*','c*'],
-        ['u2','u2','u2','u4','u8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','u2','f*','c*'],
-        ['u4','u4','u4','u4','u8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','u4','f*','c*'],
-        ['u8','u8','u8','u8','u8','f*','f*','f*','f*','bf','f2','f4','f8','c4','c8','u8','f*','c*'],
-        ['i1','i2','i4','i8','f*','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i1','f*','c*'],
-        ['i2','i2','i4','i8','f*','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f*','c*'],
-        ['i4','i4','i4','i8','f*','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f*','c*'],
-        ['i8','i8','i8','i8','f*','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f*','c*'],
+        ['b1','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
+        ['u1','u1','u2','u4','u8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','u1','f8','c8'],
+        ['u2','u2','u2','u4','u8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','u2','f8','c8'],
+        ['u4','u4','u4','u4','u8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','u4','f8','c8'],
+        ['u8','u8','u8','u8','u8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','u8','f8','c8'],
+        ['i1','i2','i4','i8','f8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i1','f8','c8'],
+        ['i2','i2','i4','i8','f8','i2','i2','i4','i8','bf','f2','f4','f8','c4','c8','i2','f8','c8'],
+        ['i4','i4','i4','i8','f8','i4','i4','i4','i8','bf','f2','f4','f8','c4','c8','i4','f8','c8'],
+        ['i8','i8','i8','i8','f8','i8','i8','i8','i8','bf','f2','f4','f8','c4','c8','i8','f8','c8'],
         ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f8','c4','c8','bf','bf','c4'],
         ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f8','c4','c8','f2','f2','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f8','c4','c8','f4','f4','c4'],
         ['f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','f8','c8','c8','f8','f8','c8'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c8','c4','c8','c4','c4','c4'],
         ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8','c8'],
-        ['i*','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
-        ['f*','f*','f*','f*','f*','f*','f*','f*','f*','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
-        ['c*','c*','c*','c*','c*','c*','c*','c*','c*','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
+        ['i8','u1','u2','u4','u8','i1','i2','i4','i8','bf','f2','f4','f8','c4','c8','i*','f*','c*'],
+        ['f8','f8','f8','f8','f8','f8','f8','f8','f8','bf','f2','f4','f8','c4','c8','f*','f*','c*'],
+        ['c8','c8','c8','c8','c8','c8','c8','c8','c8','c4','c4','c4','c8','c4','c8','c*','c*','c*'],
       ]
     else:
       expected = [
-        ['b1','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
-        ['u1','u1','u2','u4','u4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','u1','f*','c*'],
-        ['u2','u2','u2','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u2','f*','c*'],
-        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f*','c*'],
-        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f*','c*'],
-        ['i1','i2','i4','i4','i4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i1','f*','c*'],
-        ['i2','i2','i4','i4','i4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','i2','f*','c*'],
-        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f*','c*'],
-        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f*','c*'],
+        ['b1','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
+        ['u1','u1','u2','u4','u4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','u1','f4','c4'],
+        ['u2','u2','u2','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u2','f4','c4'],
+        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f4','c4'],
+        ['u4','u4','u4','u4','u4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','u4','f4','c4'],
+        ['i1','i2','i4','i4','i4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i1','f4','c4'],
+        ['i2','i2','i4','i4','i4','i2','i2','i4','i4','bf','f2','f4','f4','c4','c4','i2','f4','c4'],
+        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
+        ['i4','i4','i4','i4','i4','i4','i4','i4','i4','bf','f2','f4','f4','c4','c4','i4','f4','c4'],
         ['bf','bf','bf','bf','bf','bf','bf','bf','bf','bf','f4','f4','f4','c4','c4','bf','bf','c4'],
         ['f2','f2','f2','f2','f2','f2','f2','f2','f2','f4','f2','f4','f4','c4','c4','f2','f2','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','c4','c4','f4','f4','c4'],
         ['f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','f4','c4','c4','f4','f4','c4'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4'],
         ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4'],
-        ['i*','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
-        ['f*','f*','f*','f*','f*','f*','f*','f*','f*','bf','f2','f4','f4','c4','c4','f*','f*','c*'],
-        ['c*','c*','c*','c*','c*','c*','c*','c*','c*','c4','c4','c4','c4','c4','c4','c*','c*','c*'],
+        ['i4','u1','u2','u4','u4','i1','i2','i4','i4','bf','f2','f4','f4','c4','c4','i*','f*','c*'],
+        ['f4','f4','f4','f4','f4','f4','f4','f4','f4','bf','f2','f4','f4','c4','c4','f*','f*','c*'],
+        ['c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c4','c*','c*','c*'],
       ]
     typecode_to_dtype = {
       'b1': jnp.bool_,
@@ -296,20 +293,21 @@ class TestPromotionTables(jtu.JaxTestCase):
 
     self.assertEqual(table, expected, show_differences(expected, table))
 
-  @parameterized.named_parameters(
-    {"testcase_name": "_xtype={}_ytype={}_xfun={}_yfun={}".format(
-      xtype.__name__, ytype.__name__, xfun.__name__, yfun.__name__),
-     "xtype": xtype, "ytype": ytype, "xfun": xfun, "yfun": yfun}
-    for xtype, ytype in itertools.product(
-      [int, float, jnp.int16, jnp.int32, jnp.float16, jnp.float32], repeat=2)
-    for xfun, yfun in itertools.product(
-      [identity, abs, jnp.array], repeat=2)
-    )
-  def testBinaryPromotionJitInvariance(self, xtype, ytype, xfun, yfun):
-    """Test jit invariance of simple binary promotion rules with and without weak types."""
-    f = lambda x, y: xfun(x) + yfun(y)
-    args_maker = lambda: [xtype(1), ytype(1)]
-    self._CompileAndCheck(f, args_maker, check_dtypes=True)
+# TODO(jakevdp): re-apply #4850 after rollback
+#   @parameterized.named_parameters(
+#     {"testcase_name": "_xtype={}_ytype={}_xfun={}_yfun={}".format(
+#       xtype.__name__, ytype.__name__, xfun.__name__, yfun.__name__),
+#      "xtype": xtype, "ytype": ytype, "xfun": xfun, "yfun": yfun}
+#     for xtype, ytype in itertools.product(
+#       [int, float, jnp.int16, jnp.int32, jnp.float16, jnp.float32], repeat=2)
+#     for xfun, yfun in itertools.product(
+#       [identity, abs, jnp.array], repeat=2)
+#     )
+#   def testBinaryPromotionJitInvariance(self, xtype, ytype, xfun, yfun):
+#     """Test jit invariance of simple binary promotion rules with and without weak types."""
+#     f = lambda x, y: xfun(x) + yfun(y)
+#     args_maker = lambda: [xtype(1), ytype(1)]
+#     self._CompileAndCheck(f, args_maker, check_dtypes=True)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2570,62 +2570,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-
-  @unittest.skipIf(numpy_version < (1, 17), "shape parameter not supported in older numpy")
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_func={}_inshape={}_weak_type={}_outshape={}_outdtype={}".format(
-          func, jtu.format_shape_dtype_string(shape, in_dtype),
-          weak_type, out_shape, out_dtype),
-       "func": func, "args": args,
-       "shape": shape, "in_dtype": in_dtype, "weak_type": weak_type,
-       "out_shape": out_shape, "out_dtype": out_dtype}
-      for shape in array_shapes
-      for in_dtype in [np.int32, np.float32, np.complex64]
-      for weak_type in [True, False]
-      for out_shape in [None, (), (10,)]
-      for func, args in [("full_like", (-100,)), ("ones_like", ()), ("zeros_like", ())]
-      for out_dtype in [None, float]))
-  def testZerosOnesFullLikeWeakType(self, func, args, shape, in_dtype, weak_type, out_shape, out_dtype):
-    if numpy_version < (1, 19) and out_shape == ():
-      raise SkipTest("Numpy < 1.19 treats out_shape=() like out_shape=None")
-    rng = jtu.rand_default(self.rng())
-    x = lax.convert_element_type(rng(shape, in_dtype), weak_type=weak_type)
-    fun = lambda x: getattr(jnp, func)(x, *args, dtype=out_dtype, shape=out_shape)
-    expected_weak_type = weak_type and (out_dtype is None)
-    self.assertEqual(dtypes.is_weakly_typed(fun(x)), expected_weak_type)
-    self.assertEqual(dtypes.is_weakly_typed(api.jit(fun)(x)), expected_weak_type)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_funcname={}_input_type={}_val={}_dtype={}".format(
-          funcname, input_type, val, dtype),
-       "funcname": funcname, "input_type": input_type, "val": val, "dtype": dtype}
-      for funcname in ["array", "asarray"]
-      for dtype in [int, float, None]
-      for val in [0, 1]
-      for input_type in [int, float, np.int32, np.float32]))
-  def testArrayWeakType(self, funcname, input_type, val, dtype):
-    func = lambda x: getattr(jnp, funcname)(x, dtype=dtype)
-    fjit = api.jit(func)
-    val = input_type(val)
-    expected_weak_type = dtype is None and input_type in set(dtypes._weak_types)
-    self.assertEqual(dtypes.is_weakly_typed(func(val)), expected_weak_type)
-    self.assertEqual(dtypes.is_weakly_typed(fjit(val)), expected_weak_type)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_weak_type={}_slc={}".format(
-        jtu.format_shape_dtype_string(shape, dtype), weak_type, slc),
-       "shape": shape, "dtype": dtype, "weak_type": weak_type, "slc": slc}
-      for shape in nonempty_nonscalar_array_shapes
-      for dtype in [int, float, complex]
-      for weak_type in [True, False]
-      for slc in [slice(None), slice(0), slice(3), 0, ...]))
-  def testSliceWeakTypes(self, shape, dtype, weak_type, slc):
-    rng = jtu.rand_default(self.rng())
-    x = lax.convert_element_type(rng(shape, dtype), weak_type=weak_type)
-    op = lambda x: x[slc]
-    self.assertEqual(op(x).aval.weak_type, weak_type)
-    self.assertEqual(api.jit(op)(x).aval.weak_type, weak_type)
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_axis={}_{}sections".format(
           jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -16,7 +16,6 @@
 import collections
 from functools import partial
 import itertools
-import operator
 from unittest import SkipTest
 
 from absl.testing import absltest

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -207,22 +207,16 @@ class LaxTest(jtu.JaxTestCase):
   # TODO test shift_left, shift_right_arithmetic, shift_right_logical
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}_weak_type={}".format(
-          from_dtype, to_dtype, weak_type),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "weak_type": weak_type}
+      {"testcase_name": "_from_dtype={}_to_dtype={}".format(
+          from_dtype, to_dtype),
+       "from_dtype": from_dtype, "to_dtype": to_dtype}
       for from_dtype, to_dtype in itertools.product(
-          [None, np.float32, np.int32, "float32", "int32"], repeat=2)
-      for weak_type in [True, False]))
-  def testConvertElementType(self, from_dtype, to_dtype, weak_type):
+          [np.float32, np.int32, "float32", "int32"], repeat=2)))
+  def testConvertElementType(self, from_dtype, to_dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.convert_element_type(x, to_dtype, weak_type)
+    op = lambda x: lax.convert_element_type(x, to_dtype)
     self._CompileAndCheck(op, args_maker)
-
-    x = rng((1,), from_dtype)
-    out = op(x)
-    self.assertEqual(out.dtype, dtypes.canonicalize_dtype(to_dtype or x.dtype))
-    self.assertEqual(out.aval.weak_type, weak_type)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_from_dtype={}_to_dtype={}"
@@ -261,23 +255,6 @@ class LaxTest(jtu.JaxTestCase):
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     numpy_op = lambda x: lax_reference.bitcast_convert_type(x, to_dtype)
     self._CheckAgainstNumpy(numpy_op, op, args_maker)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_from_dtype={}_to_dtype={}_weak_type={}"
-       .format(from_dtype, to_dtype, weak_type),
-       "from_dtype": from_dtype, "to_dtype": to_dtype, "weak_type": weak_type}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for weak_type in [True, False]))
-  def testBitcastConvertWeakType(self, from_dtype, to_dtype, weak_type):
-    rng = jtu.rand_default(self.rng())
-    x_in = lax.convert_element_type(rng((2, 3), from_dtype), weak_type=weak_type)
-    op = lambda x: lax.bitcast_convert_type(x, to_dtype)
-    self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
-    x_out = op(x_in)
-    self.assertEqual(dtypes.is_weakly_typed(x_out), False)
-    x_out_jit = api.jit(op)(x_in)
-    self.assertEqual(dtypes.is_weakly_typed(x_out_jit), False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_min_shape={}_operand_shape={}_max_shape={}".format(
@@ -1480,24 +1457,6 @@ class LaxTest(jtu.JaxTestCase):
     self._CompileAndCheck(fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}.{}_arr_weak_type={}_init_weak_type={}"
-       .format(op_namespace.__name__, op, arr_weak_type, init_weak_type),
-       "op": op, "op_namespace": op_namespace, "arr_weak_type": arr_weak_type, "init_weak_type": init_weak_type}
-      for op in ["add", "mul"]
-      for op_namespace in [lax, operator]
-      for arr_weak_type in [True, False]
-      for init_weak_type in [True, False]))
-  def testReduceWeakType(self, op_namespace, op, arr_weak_type, init_weak_type):
-    op = getattr(op_namespace, op)
-    arr = lax.convert_element_type(np.arange(10), np.int32, weak_type=arr_weak_type)
-    init = lax.convert_element_type(1, np.int32, weak_type=init_weak_type)
-    fun = lambda arr, init: lax.reduce(arr, init, op, (0,))
-    out = fun(arr, init)
-    self.assertEqual(dtypes.is_weakly_typed(out), arr_weak_type and init_weak_type)
-    out_jit = api.jit(fun)(arr, init)
-    self.assertEqual(dtypes.is_weakly_typed(out_jit), arr_weak_type and init_weak_type)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
                          "_basedilation={}_windowdilation={}")
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype),
@@ -2353,50 +2312,6 @@ class LazyConstantTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError,
                                 "index_dtype must be an integer type"):
       jax_fn(np.ones((2, 2)), axis=0, index_dtype=index_dtype)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_fn={}_weaktype={}".format(jax_fn.__name__, weak_type),
-       "jax_fn": jax_fn, "weak_type": weak_type}
-      for jax_fn in [lax.argmin, lax.argmax]
-      for weak_type in [True, False]))
-  def testArgMinMaxWeakType(self, jax_fn, weak_type):
-    op = lambda x: jax_fn(x, axis=0, index_dtype=np.int32)
-    x_in = lax.convert_element_type(np.ones((2, 2)), weak_type=weak_type)
-    self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
-    x_out = op(x_in)
-    self.assertEqual(dtypes.is_weakly_typed(x_out), False)
-    x_out_jit = api.jit(op)(x_in)
-    self.assertEqual(dtypes.is_weakly_typed(x_out_jit), False)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": "_{}".format(rec.op),
-         "op_name": rec.op, "rec_dtypes": rec.dtypes}
-      for rec in LAX_OPS if rec.nargs == 1))
-  def testUnaryWeakTypes(self, op_name, rec_dtypes):
-    """Test that all lax unary ops propagate weak_type information appropriately."""
-    # Find a valid dtype for the function.
-    for dtype in [np.float_, np.int_, np.complex_, np.bool_]:
-      dtype = dtypes.canonicalize_dtype(dtype)
-      if dtype in rec_dtypes:
-        py_val = dtype.type(1).item()
-        lax_val = lax.full((), py_val, dtype)
-        break
-    else:
-      raise ValueError("no available dtypes")
-
-    op = getattr(lax, op_name)
-    py_op = op(py_val)
-    lax_op = op(lax_val)
-
-    self.assertAllClose(py_op, lax_op, check_dtypes=True)
-    self.assertTrue(py_op.aval.weak_type)
-    self.assertFalse(lax_op.aval.weak_type)
-
-  def testCumsumLengthOne(self):
-    # regression test for issue 4672
-    x = lax.full((1,), 1)
-    out = lax.cumsum(x)
-    self.assertArraysEqual(out, x)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
We have to roll back #4850 due to important downstream breakages. Unfortunately that meant I had to roll back some other changes that depended on #4850 too.

I did my best here, but the changes are tricky and I might not have performed a perfect minimal rollback. We don't know exactly what broke the downstream user, and because changes have piled up since, it's tricky to identify the root cause.

cc @jakevdp 