### PR TITLE
docs: fix simple typo, specifed -> specified

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -5898,7 +5898,7 @@ def infeed(token, shape=None, partitions=None):
   """Consumes an infeed value of `shape` from the host. Experimental.
 
   `token` is used to sequence infeed and outfeed effects.
-  `partitions` may be specifed inside a `sharded_jit` function.
+  `partitions` may be specified inside a `sharded_jit` function.
   """
   flat_shapes, treedef = pytree.flatten(shape)
   for shape in flat_shapes:


### PR DESCRIPTION
There is a small typo in jax/_src/lax/lax.py.

Should read `specified` rather than `specifed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md