### PR TITLE
[jax2tf] Refinements for the auto-generated limitations documentation

### DIFF
--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,23 +1,25 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2020-12-28* (YYYY-MM-DD)
+*Last generated on: 2020-12-29* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
-We use a set of 2305 test harnesses for testing
+We use a set of 2305 test harnesses to test
 the implementation of 122 numeric JAX primitives.
-Not all primitives are supported in JAX at all
-data types. The following table shows the dtypes at which
-**primitives are NOT supported on any device**.
+We consider a JAX primitive supported for a particular data
+type if it is supported on at least one device type.
+The following table shows the dtypes at which primitives
+are supported in JAX and at which dtypes they are not
+supported on any device.
 (In reality, this shows for each primitive what dtypes are not covered
-by the current harnesses on any device.)
+by the current test harnesses on any device.)
 
-Note also that the set of supported dtypes include 64-bit types
+The set of supported dtypes include 64-bit types
 (`float64`, `int64`, `uint64`, `complex128`) only if the
-flag `--jax_enable_x64` is set (or the JAX_ENABLE_X64 environment
-variable).
+flag `--jax_enable_x64` or the JAX_ENABLE_X64 environment
+variable are set.
 
-We use the following abbreviations for sets of dtypes:
+We use below the following abbreviations for sets of dtypes:
 
   * `signed` = `int8`, `int16`, `int32`, `int64`
   * `unsigned` = `uint8`, `uint16`, `uint32`, `uint64`
@@ -27,138 +29,138 @@ We use the following abbreviations for sets of dtypes:
   * `inexact` = `floating`, `complex`
   * `all` = `integer`, `inexact`, `bool`
 
-In order to experiment with increased coverage, add more harnesses for
-more data types.
+See the comment in `primitive_harness.py` for a description
+of test harnesses and their definitions.
 
 
 | Primitive | Total test harnesses | dtypes supported on at least one device | dtypes NOT tested on any device |
 | --- | --- | --- | --- | --- |
-| abs | 10 | complex, floating, signed | bool, unsigned |
-| acos | 6 | complex, floating | bool, integer |
-| acosh | 6 | complex, floating | bool, integer |
-| add | 16 | complex, floating, integer | bool |
-| add_any | 14 | complex, floating, integer | bool |
-| and | 11 | bool, integer | complex, floating |
+| abs | 10 | inexact, signed | bool, unsigned |
+| acos | 6 | inexact | bool, integer |
+| acosh | 6 | inexact | bool, integer |
+| add | 16 | inexact, integer | bool |
+| add_any | 14 | inexact, integer | bool |
+| and | 11 | bool, integer | inexact |
 | argmax | 22 | bool, floating, integer | complex |
 | argmin | 22 | bool, floating, integer | complex |
-| asin | 6 | complex, floating | bool, integer |
-| asinh | 6 | complex, floating | bool, integer |
-| atan | 6 | complex, floating | bool, integer |
+| asin | 6 | inexact | bool, integer |
+| asinh | 6 | inexact | bool, integer |
+| atan | 6 | inexact | bool, integer |
 | atan2 | 6 | floating | bool, complex, integer |
-| atanh | 6 | complex, floating | bool, integer |
+| atanh | 6 | inexact | bool, integer |
 | bessel_i0e | 4 | floating | bool, complex, integer |
 | bessel_i1e | 4 | floating | bool, complex, integer |
-| bitcast_convert_type | 41 | bool, complex, floating, integer |  |
-| broadcast | 17 | bool, complex, floating, integer |  |
-| broadcast_in_dim | 19 | bool, complex, floating, integer |  |
+| bitcast_convert_type | 41 | all |  |
+| broadcast | 17 | all |  |
+| broadcast_in_dim | 19 | all |  |
 | ceil | 4 | floating | bool, complex, integer |
-| cholesky | 30 | complex, floating | bool, integer |
+| cholesky | 30 | inexact | bool, integer |
 | clamp | 17 | floating, integer | bool, complex |
 | complex | 4 | float32, float64 | bfloat16, bool, complex, float16, integer |
-| concatenate | 17 | bool, complex, floating, integer |  |
+| concatenate | 17 | all |  |
 | conj | 5 | complex, float32, float64 | bfloat16, bool, float16, integer |
-| conv_general_dilated | 58 | complex, floating | bool, integer |
-| convert_element_type | 201 | bool, complex, floating, integer |  |
-| cos | 6 | complex, floating | bool, integer |
-| cosh | 6 | complex, floating | bool, integer |
-| cummax | 17 | complex, floating, integer | bool |
-| cummin | 17 | complex, floating, integer | bool |
-| cumprod | 17 | complex, floating, integer | bool |
-| cumsum | 17 | complex, floating, integer | bool |
+| conv_general_dilated | 58 | inexact | bool, integer |
+| convert_element_type | 201 | all |  |
+| cos | 6 | inexact | bool, integer |
+| cosh | 6 | inexact | bool, integer |
+| cummax | 17 | inexact, integer | bool |
+| cummin | 17 | inexact, integer | bool |
+| cumprod | 17 | inexact, integer | bool |
+| cumsum | 17 | inexact, integer | bool |
 | custom_linear_solve | 4 | float32, float64 | bfloat16, bool, complex, float16, integer |
-| device_put | 16 | bool, complex, floating, integer |  |
+| device_put | 16 | all |  |
 | digamma | 4 | floating | bool, complex, integer |
-| div | 20 | complex, floating, integer | bool |
-| dot_general | 125 | bool, complex, floating, integer |  |
-| dynamic_slice | 32 | bool, complex, floating, integer |  |
-| dynamic_update_slice | 21 | bool, complex, floating, integer |  |
-| eig | 72 | complex, floating | bool, integer |
-| eigh | 36 | complex, floating | bool, integer |
-| eq | 17 | bool, complex, floating, integer |  |
+| div | 20 | inexact, integer | bool |
+| dot_general | 125 | all |  |
+| dynamic_slice | 32 | all |  |
+| dynamic_update_slice | 21 | all |  |
+| eig | 72 | inexact | bool, integer |
+| eigh | 36 | inexact | bool, integer |
+| eq | 17 | all |  |
 | erf | 4 | floating | bool, complex, integer |
 | erf_inv | 4 | floating | bool, complex, integer |
 | erfc | 4 | floating | bool, complex, integer |
-| exp | 6 | complex, floating | bool, integer |
-| expm1 | 6 | complex, floating | bool, integer |
+| exp | 6 | inexact | bool, integer |
+| expm1 | 6 | inexact | bool, integer |
 | fft | 20 | complex, float32, float64 | bfloat16, bool, float16, integer |
 | floor | 4 | floating | bool, complex, integer |
-| gather | 37 | bool, complex, floating, integer |  |
+| gather | 37 | all |  |
 | ge | 15 | bool, floating, integer | complex |
 | gt | 15 | bool, floating, integer | complex |
 | igamma | 6 | floating | bool, complex, integer |
 | igammac | 6 | floating | bool, complex, integer |
 | imag | 2 | complex | bool, floating, integer |
-| integer_pow | 34 | complex, floating, integer | bool |
-| iota | 16 | complex, floating, integer | bool |
+| integer_pow | 34 | inexact, integer | bool |
+| iota | 16 | inexact, integer | bool |
 | is_finite | 4 | floating | bool, complex, integer |
 | le | 15 | bool, floating, integer | complex |
 | lgamma | 4 | floating | bool, complex, integer |
-| log | 6 | complex, floating | bool, integer |
-| log1p | 6 | complex, floating | bool, integer |
+| log | 6 | inexact | bool, integer |
+| log1p | 6 | inexact | bool, integer |
 | lt | 15 | bool, floating, integer | complex |
-| lu | 18 | complex, floating | bool, integer |
-| max | 29 | bool, complex, floating, integer |  |
-| min | 29 | bool, complex, floating, integer |  |
-| mul | 16 | complex, floating, integer | bool |
-| ne | 17 | bool, complex, floating, integer |  |
-| neg | 14 | complex, floating, integer | bool |
+| lu | 18 | inexact | bool, integer |
+| max | 29 | all |  |
+| min | 29 | all |  |
+| mul | 16 | inexact, integer | bool |
+| ne | 17 | all |  |
+| neg | 14 | inexact, integer | bool |
 | nextafter | 6 | floating | bool, complex, integer |
-| or | 11 | bool, integer | complex, floating |
-| pad | 90 | bool, complex, floating, integer |  |
-| population_count | 8 | integer | bool, complex, floating |
-| pow | 10 | complex, floating | bool, integer |
-| qr | 60 | complex, floating | bool, integer |
+| or | 11 | bool, integer | inexact |
+| pad | 90 | all |  |
+| population_count | 8 | integer | bool, inexact |
+| pow | 10 | inexact | bool, integer |
+| qr | 60 | inexact | bool, integer |
 | random_gamma | 4 | float32, float64 | bfloat16, bool, complex, float16, integer |
-| random_split | 5 | uint32 | bool, complex, floating, integer |
+| random_split | 5 | uint32 | all |
 | real | 2 | complex | bool, floating, integer |
-| reduce_and | 1 | bool | complex, floating, integer |
-| reduce_max | 15 | bool, complex, floating, integer |  |
-| reduce_min | 15 | bool, complex, floating, integer |  |
-| reduce_or | 1 | bool | complex, floating, integer |
-| reduce_prod | 14 | complex, floating, integer | bool |
-| reduce_sum | 14 | complex, floating, integer | bool |
-| reduce_window_add | 33 | complex, floating, integer | bool |
-| reduce_window_max | 37 | bool, complex, floating, integer |  |
-| reduce_window_min | 15 | bool, complex, floating, integer |  |
-| reduce_window_mul | 42 | complex, floating, integer | bool |
+| reduce_and | 1 | bool | inexact, integer |
+| reduce_max | 15 | all |  |
+| reduce_min | 15 | all |  |
+| reduce_or | 1 | bool | inexact, integer |
+| reduce_prod | 14 | inexact, integer | bool |
+| reduce_sum | 14 | inexact, integer | bool |
+| reduce_window_add | 33 | inexact, integer | bool |
+| reduce_window_max | 37 | all |  |
+| reduce_window_min | 15 | all |  |
+| reduce_window_mul | 42 | inexact, integer | bool |
 | regularized_incomplete_beta | 4 | floating | bool, complex, integer |
 | rem | 18 | floating, integer | bool, complex |
-| reshape | 19 | bool, complex, floating, integer |  |
-| rev | 19 | bool, complex, floating, integer |  |
+| reshape | 19 | all |  |
+| rev | 19 | all |  |
 | round | 7 | floating | bool, complex, integer |
-| rsqrt | 6 | complex, floating | bool, integer |
-| scatter_add | 14 | complex, floating, integer | bool |
-| scatter_max | 15 | bool, complex, floating, integer |  |
-| scatter_min | 19 | bool, complex, floating, integer |  |
-| scatter_mul | 14 | complex, floating, integer | bool |
-| select | 16 | bool, complex, floating, integer |  |
+| rsqrt | 6 | inexact | bool, integer |
+| scatter_add | 14 | inexact, integer | bool |
+| scatter_max | 15 | all |  |
+| scatter_min | 19 | all |  |
+| scatter_mul | 14 | inexact, integer | bool |
+| select | 16 | all |  |
 | select_and_gather_add | 15 | floating | bool, complex, integer |
 | select_and_scatter_add | 27 | bool, floating, integer | complex |
-| shift_left | 10 | integer | bool, complex, floating |
-| shift_right_arithmetic | 10 | integer | bool, complex, floating |
-| shift_right_logical | 10 | integer | bool, complex, floating |
-| sign | 14 | complex, floating, integer | bool |
-| sin | 6 | complex, floating | bool, integer |
-| sinh | 6 | complex, floating | bool, integer |
-| slice | 24 | bool, complex, floating, integer |  |
-| sort | 21 | bool, complex, floating, integer |  |
-| sqrt | 6 | complex, floating | bool, integer |
-| squeeze | 23 | bool, complex, floating, integer |  |
-| stop_gradient | 15 | bool, complex, floating, integer |  |
-| sub | 16 | complex, floating, integer | bool |
-| svd | 120 | complex, floating | bool, integer |
-| tan | 6 | complex, floating | bool, integer |
-| tanh | 6 | complex, floating | bool, integer |
-| tie_in | 15 | bool, complex, floating, integer |  |
+| shift_left | 10 | integer | bool, inexact |
+| shift_right_arithmetic | 10 | integer | bool, inexact |
+| shift_right_logical | 10 | integer | bool, inexact |
+| sign | 14 | inexact, integer | bool |
+| sin | 6 | inexact | bool, integer |
+| sinh | 6 | inexact | bool, integer |
+| slice | 24 | all |  |
+| sort | 21 | all |  |
+| sqrt | 6 | inexact | bool, integer |
+| squeeze | 23 | all |  |
+| stop_gradient | 15 | all |  |
+| sub | 16 | inexact, integer | bool |
+| svd | 120 | inexact | bool, integer |
+| tan | 6 | inexact | bool, integer |
+| tanh | 6 | inexact | bool, integer |
+| tie_in | 15 | all |  |
 | top_k | 15 | bool, floating, integer | complex |
-| transpose | 17 | bool, complex, floating, integer |  |
-| triangular_solve | 26 | complex, floating | bool, integer |
-| xor | 11 | bool, integer | complex, floating |
-| zeros_like | 15 | bool, complex, floating, integer |  |
+| transpose | 17 | all |  |
+| triangular_solve | 26 | inexact | bool, integer |
+| xor | 11 | bool, integer | inexact |
+| zeros_like | 15 | all |  |
 
 ## Partially implemented data types for primitives
 
-In some cases, a primitive is supported at a given data type but
+In some cases, a primitive is supported in JAX at a given data type but
 it may be missing implementations for some of the devices.
 For example, the eigen decomposition (`lax.eig`) is implemented
 in JAX using custom kernels only on CPU and GPU. There is no
@@ -170,8 +172,9 @@ The following table shows which of the supported data types
 are partially implemented for each primitive. This table already
 excludes the unsupported data types (previous table).
 
-In order to see the actual errors for all entries above look at
-the logs of the `test_jax_implemented` from `jax_primitives_coverage_test.py`.
+In order to see the actual errors for all entries look through
+the logs of the `test_jax_implemented` from `jax_primitives_coverage_test.py`
+and search for "limitation".
 
 
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices |
@@ -206,7 +209,7 @@ the logs of the `test_jax_implemented` from `jax_primitives_coverage_test.py`.
 
 ## Table generation
 
-To regenerate this table run on a CPU machine::
+To regenerate this table run (on a CPU machine):
 
 ```
   JAX_OUTPUT_LIMITATIONS_DOC=1 JAX_ENABLE_X64=1 python jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py JaxPrimitiveTest.test_generate_primitives_coverage_doc

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md.template
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md.template
@@ -4,20 +4,22 @@
 
 ## Supported data types for primitives
 
-We use a set of {{nr_harnesses}} test harnesses for testing
+We use a set of {{nr_harnesses}} test harnesses to test
 the implementation of {{nr_primitives}} numeric JAX primitives.
-Not all primitives are supported in JAX at all
-data types. The following table shows the dtypes at which
-**primitives are NOT supported on any device**.
+We consider a JAX primitive supported for a particular data
+type if it is supported on at least one device type.
+The following table shows the dtypes at which primitives
+are supported in JAX and at which dtypes they are not
+supported on any device.
 (In reality, this shows for each primitive what dtypes are not covered
-by the current harnesses on any device.)
+by the current test harnesses on any device.)
 
-Note also that the set of supported dtypes include 64-bit types
+The set of supported dtypes include 64-bit types
 (`float64`, `int64`, `uint64`, `complex128`) only if the
-flag `--jax_enable_x64` is set (or the JAX_ENABLE_X64 environment
-variable).
+flag `--jax_enable_x64` or the JAX_ENABLE_X64 environment
+variable are set.
 
-We use the following abbreviations for sets of dtypes:
+We use below the following abbreviations for sets of dtypes:
 
   * `signed` = `int8`, `int16`, `int32`, `int64`
   * `unsigned` = `uint8`, `uint16`, `uint32`, `uint64`
@@ -27,14 +29,14 @@ We use the following abbreviations for sets of dtypes:
   * `inexact` = `floating`, `complex`
   * `all` = `integer`, `inexact`, `bool`
 
-In order to experiment with increased coverage, add more harnesses for
-more data types.
+See the comment in `primitive_harness.py` for a description
+of test harnesses and their definitions.
 
 {{primitive_coverage_table}}
 
 ## Partially implemented data types for primitives
 
-In some cases, a primitive is supported at a given data type but
+In some cases, a primitive is supported in JAX at a given data type but
 it may be missing implementations for some of the devices.
 For example, the eigen decomposition (`lax.eig`) is implemented
 in JAX using custom kernels only on CPU and GPU. There is no
@@ -46,14 +48,15 @@ The following table shows which of the supported data types
 are partially implemented for each primitive. This table already
 excludes the unsupported data types (previous table).
 
-In order to see the actual errors for all entries above look at
-the logs of the `test_jax_implemented` from `jax_primitives_coverage_test.py`.
+In order to see the actual errors for all entries look through
+the logs of the `test_jax_implemented` from `jax_primitives_coverage_test.py`
+and search for "limitation".
 
 {{primitive_unimpl_table}}
 
 ## Table generation
 
-To regenerate this table run on a CPU machine::
+To regenerate this table run (on a CPU machine):
 
 ```
   JAX_OUTPUT_LIMITATIONS_DOC=1 JAX_ENABLE_X64=1 python jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py JaxPrimitiveTest.test_generate_primitives_coverage_doc

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,16 +1,16 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-12-28*
+*Last generated on (YYYY-MM-DD): 2020-12-29*
 
 We do not yet have support for `pmap` (with its collective primitives),
 nor for `sharded_jit` (SPMD partitioning).
 
 A few JAX primitives are converted to TF ops that have incomplete coverage
 for data types on different kinds of devices. The most [up-to-date list of
-limitations is generated automatically](#generated-summary-of-primitives-with-limited-support)
+limitations is generated automatically](#generated-summary-of-primitives-with-limited-support-in-tensorflow)
 by the jax2tf coverage tests.
 More detailed information can be found in the
-[source code of categorize](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/tests/primitives_test.py)
+[source code for the limitation specification](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/tests/primitives_test.py)
 for some cases.
 
 Additionally, some primitives have numerical differences between JAX and TF in some corner cases:
@@ -98,7 +98,7 @@ On TPU only "compiled" mode is ever used.
 
 
 This table only shows errors for cases that are working in JAX (see [separate
-list of unsupported or partially-supported primitives](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md)
+list of unsupported or partially-supported primitives](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md) )
 
 We use the following abbreviations for sets of dtypes:
 
@@ -113,114 +113,116 @@ We use the following abbreviations for sets of dtypes:
 
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices | Affected compilation modes |
 | --- | --- | --- | --- | --- | ---|
-|acos|TF error: op not defined for dtype|bfloat16, complex64, float16|cpu, gpu|eager, graph|
-|acos|TF error: op not defined for dtype|complex128|cpu, gpu|eager, graph|
-|acosh|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|add|TF error: op not defined for dtype|uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|add|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|add_any|TF error: op not defined for dtype|uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|asin|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|asin|TF error: op not defined for dtype|complex|cpu, gpu, tpu|compiled, eager, graph|
-|asinh|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|asinh|TF error: op not defined for dtype|complex|cpu, gpu, tpu|compiled, eager, graph|
-|atan|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|atan|TF error: op not defined for dtype|complex|cpu, gpu, tpu|compiled, eager, graph|
-|atan2|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|atanh|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|bessel_i0e|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|bessel_i1e|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|bitcast_convert_type|TF error: op not defined for dtype|bool|cpu, gpu, tpu|compiled, eager, graph|
-|cholesky|TF error: function not compilable|complex|cpu, gpu|compiled|
-|cholesky|TF error: op not defined for dtype|complex|tpu|compiled|
-|clamp|TF error: op not defined for dtype|int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|conv_general_dilated|TF error: jax2tf BUG: batch_group_count > 1 not yet converted||cpu, gpu, tpu|compiled, eager, graph|
-|conv_general_dilated|TF error: XLA bug in the HLO -> LLVM IR lowering|complex|cpu, gpu|compiled, eager, graph|
-|cosh|TF error: op not defined for dtype|float16|cpu, gpu|eager, graph|
-|cummax|TF error: op not defined for dtype|complex128, uint64|cpu, gpu|compiled, eager, graph|
-|cummax|TF error: op not defined for dtype|complex64, int8, uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|cummin|TF error: op not defined for dtype|complex128, uint64|cpu, gpu|compiled, eager, graph|
-|cummin|TF error: op not defined for dtype|complex64, int8, uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|cumprod|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|cumprod|TF error: op not defined for dtype|uint32|cpu, gpu, tpu|compiled, eager, graph|
-|cumsum|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|cumsum|TF error: op not defined for dtype|complex64|tpu|compiled|
-|cumsum|TF error: op not defined for dtype|uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|digamma|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|div|TF error: op not defined for dtype|int16, int8, unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|div|TF error: TF integer division fails if divisor contains 0; JAX returns NaN|integer|cpu, gpu, tpu|compiled, eager, graph|
-|dot_general|TF error: op not defined for dtype|bool, int16, int8, unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|dot_general|TF error: op not defined for dtype|int64|cpu, gpu|compiled|
-|eig|TF error: function not compilable||cpu, gpu, tpu|compiled|
-|eig|TF error: TF Conversion of eig is not implemented when both compute_left_eigenvectors and compute_right_eigenvectors are set to True||cpu, gpu, tpu|compiled, eager, graph|
-|eigh|TF error: function not compilable|complex|cpu, gpu, tpu|compiled|
-|erf|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|erf_inv|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu|eager, graph|
-|erfc|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|fft|TF error: TF function not compileable|complex128, float64|cpu, gpu|compiled|
-|ge|TF error: op not defined for dtype|bool|cpu, gpu, tpu|compiled, eager, graph|
-|ge|TF error: op not defined for dtype|uint16, uint32|cpu, gpu|eager, graph|
-|ge|TF error: op not defined for dtype|uint64|cpu, gpu|eager, graph|
-|gt|TF error: op not defined for dtype|bool|cpu, gpu, tpu|compiled, eager, graph|
-|gt|TF error: op not defined for dtype|uint16, uint32|cpu, gpu|eager, graph|
-|gt|TF error: op not defined for dtype|uint64|cpu, gpu|eager, graph|
-|integer_pow|TF error: op not defined for dtype|int16, int8, unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|le|TF error: op not defined for dtype|bool|cpu, gpu, tpu|compiled, eager, graph|
-|le|TF error: op not defined for dtype|uint16, uint32|cpu, gpu|eager, graph|
-|le|TF error: op not defined for dtype|uint64|cpu, gpu|eager, graph|
-|lgamma|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|lt|TF error: op not defined for dtype|bool|cpu, gpu, tpu|compiled, eager, graph|
-|lt|TF error: op not defined for dtype|uint16, uint32|cpu, gpu|eager, graph|
-|lt|TF error: op not defined for dtype|uint64|cpu, gpu|eager, graph|
-|lu|TF error: op not defined for dtype|complex64|tpu|compiled|
-|max|TF error: op not defined for dtype|bool, complex64, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|max|TF error: op not defined for dtype|complex128|cpu, gpu|compiled, eager, graph|
-|min|TF error: op not defined for dtype|bool, complex64, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|min|TF error: op not defined for dtype|complex128|cpu, gpu|compiled, eager, graph|
-|mul|TF error: op not defined for dtype|uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|neg|TF error: op not defined for dtype|unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|nextafter|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu, tpu|compiled, eager, graph|
-|population_count|TF error: op not defined for dtype|uint32, uint64|cpu, gpu|eager, graph|
-|qr|TF error: op not defined for dtype|bfloat16|tpu|compiled|
-|reduce_max|TF error: op not defined for dtype|complex64|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_max|TF error: op not defined for dtype|complex128|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_min|TF error: op not defined for dtype|complex64|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_min|TF error: op not defined for dtype|complex128|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_add|TF error: op not defined for dtype|uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_add|TF error: op not defined for dtype|complex64|tpu|compiled, eager, graph|
-|reduce_window_add|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|reduce_window_max|TF error: op not defined for dtype|bool, complex64, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_max|TF error: op not defined for dtype|complex128, uint64|cpu, gpu|compiled, eager, graph|
-|reduce_window_max|TF error: TF kernel missing, except when the initial_value is the minimum for the dtype|int8, uint16|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_min|TF error: op not defined for dtype|bool, complex64, int8, uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_min|TF error: op not defined for dtype|complex128, uint64|cpu, gpu|compiled, eager, graph|
-|reduce_window_mul|TF error: op not defined for dtype|uint32|cpu, gpu, tpu|compiled, eager, graph|
-|reduce_window_mul|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|regularized_incomplete_beta|TF error: op not defined for dtype|bfloat16, float16|cpu, gpu, tpu|compiled, eager, graph|
-|rem|TF error: op not defined for dtype|int16, int8, unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|rem|TF error: TF integer division fails if divisor contains 0; JAX returns NaN|integer|cpu, gpu, tpu|compiled, eager, graph|
-|rem|TF error: op not defined for dtype|float16|cpu, gpu, tpu|eager, graph|
-|rev|TF error: op not defined for dtype|uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|round|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|rsqrt|TF error: op not defined for dtype|bfloat16|cpu, gpu|eager, graph|
-|scatter_add|TF error: op not defined for dtype|bool, complex64, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|scatter_max|TF error: op not defined for dtype|bool, complex, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|scatter_min|TF error: op not defined for dtype|bool, complex, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|scatter_mul|TF error: op not defined for dtype|bool, complex64, int8, uint16, uint32, uint64|cpu, gpu, tpu|compiled, eager, graph|
-|select_and_gather_add|TF error: op not defined for dtype|float32|tpu|compiled|
-|select_and_gather_add|TF error: jax2tf unimplemented|float64|cpu, gpu|compiled, eager, graph|
-|select_and_scatter_add|TF error: op not defined for dtype|uint16, uint32|cpu, gpu, tpu|compiled, eager, graph|
-|select_and_scatter_add|TF error: op not defined for dtype|uint64|cpu, gpu|compiled, eager, graph|
-|sign|TF error: op not defined for dtype|int16, int8, unsigned|cpu, gpu, tpu|compiled, eager, graph|
-|sinh|TF error: op not defined for dtype|float16|cpu, gpu|eager, graph|
-|sort|TF error: op not defined for dtype|complex|cpu, gpu|eager, graph|
-|sort|TF error: TODO: XlaSort does not support more than 2 arrays||cpu, gpu, tpu|compiled, eager, graph|
-|sort|TF error: TODO: XlaSort does not support sorting axis||cpu, gpu, tpu|compiled, eager, graph|
-|sub|TF error: op not defined for dtype|uint64|cpu, gpu, tpu|compiled, eager, graph|
-|svd|TF error: function not compilable|complex|cpu, gpu|compiled|
-|svd|TF error: op not defined for dtype|bfloat16|tpu|compiled|
-|top_k|TF error: op not defined for dtype|int64, uint64|cpu, gpu|compiled|
-|triangular_solve|TF error: op not defined for dtype|bfloat16|cpu, gpu, tpu|compiled, eager, graph|
-|triangular_solve|TF error: op not defined for dtype|float16|cpu, gpu, tpu|eager, graph|
+| acos | TF error: op not defined for dtype | bfloat16, complex64, float16 | cpu, gpu | eager, graph |
+| acos | TF error: op not defined for dtype | complex128 | cpu, gpu | eager, graph |
+| acosh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| add | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| add_any | TF error: op not defined for dtype | uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| asin | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| asin | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
+| asinh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| asinh | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
+| atan | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| atan | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
+| atan2 | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| atanh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| bessel_i0e | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| bessel_i1e | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| bitcast_convert_type | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
+| cholesky | TF error: function not compilable | complex | cpu, gpu | compiled |
+| cholesky | TF error: op not defined for dtype | complex | tpu | compiled |
+| clamp | TF error: op not defined for dtype | int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| conv_general_dilated | TF test skipped: TF error: TODO: TF/LLVM crash | complex | gpu | compiled, eager, graph |
+| conv_general_dilated | TF error: jax2tf BUG: batch_group_count > 1 not yet converted | all | cpu, gpu, tpu | compiled, eager, graph |
+| conv_general_dilated | TF error: XLA bug in the HLO -> LLVM IR lowering | complex | cpu, gpu | compiled, eager, graph |
+| cosh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
+| cummax | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
+| cummax | TF error: op not defined for dtype | complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| cummin | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
+| cummin | TF error: op not defined for dtype | complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| cumprod | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| cumprod | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| cumsum | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| cumsum | TF error: op not defined for dtype | complex64 | tpu | compiled |
+| cumsum | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| div | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
+| dot_general | TF error: op not defined for dtype | bool, int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| dot_general | TF error: op not defined for dtype | int64 | cpu, gpu | compiled |
+| eig | TF error: function not compilable | all | cpu, gpu, tpu | compiled |
+| eig | TF error: TF Conversion of eig is not implemented when both compute_left_eigenvectors and compute_right_eigenvectors are set to True | all | cpu, gpu, tpu | compiled, eager, graph |
+| eigh | TF error: function not compilable | complex | cpu, gpu, tpu | compiled |
+| erf | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| erf_inv | TF test skipped: TF error: TODO: erf_inv bug on TPU: nan vs non-nan | float32 | tpu | compiled, eager, graph |
+| erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
+| erfc | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| fft | TF error: TF function not compileable | complex128, float64 | cpu, gpu | compiled |
+| ge | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
+| ge | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
+| ge | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
+| gt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
+| gt | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
+| gt | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
+| integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| le | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
+| le | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
+| le | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
+| lgamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| lt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
+| lt | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
+| lt | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
+| lu | TF error: op not defined for dtype | complex64 | tpu | compiled |
+| max | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| max | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
+| min | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| min | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
+| mul | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| neg | TF error: op not defined for dtype | unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| nextafter | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
+| population_count | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu | eager, graph |
+| qr | TF error: op not defined for dtype | bfloat16 | tpu | compiled |
+| reduce_max | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_max | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_min | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_min | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_add | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_add | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
+| reduce_window_add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| reduce_window_max | TF error: op not defined for dtype | bool, complex64, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_max | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
+| reduce_window_max | TF error: TF kernel missing, except when the initial_value is the minimum for the dtype | int8, uint16 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_min | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_min | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
+| reduce_window_mul | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_mul | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
+| rem | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
+| rem | TF error: op not defined for dtype | float16 | cpu, gpu, tpu | eager, graph |
+| rev | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| round | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| rsqrt | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
+| scatter_add | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_max | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_mul | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| select_and_gather_add | TF error: op not defined for dtype | float32 | tpu | compiled |
+| select_and_gather_add | TF error: jax2tf unimplemented | float64 | cpu, gpu | compiled, eager, graph |
+| select_and_scatter_add | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| select_and_scatter_add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
+| sign | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| sinh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
+| sort | TF error: op not defined for dtype | complex | cpu, gpu | eager, graph |
+| sort | TF error: TODO: XlaSort does not support more than 2 arrays | all | cpu, gpu, tpu | compiled, eager, graph |
+| sort | TF error: TODO: XlaSort does not support sorting axis | all | cpu, gpu, tpu | compiled, eager, graph |
+| sub | TF error: op not defined for dtype | uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| svd | TF error: function not compilable | complex | cpu, gpu | compiled |
+| svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled |
+| top_k | TF error: op not defined for dtype | int64, uint64 | cpu, gpu | compiled |
+| triangular_solve | TF error: op not defined for dtype | bfloat16 | cpu, gpu, tpu | compiled, eager, graph |
+| triangular_solve | TF error: op not defined for dtype | float16 | cpu, gpu, tpu | eager, graph |
 
 ## Updating the documentation
 

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
@@ -7,10 +7,10 @@ nor for `sharded_jit` (SPMD partitioning).
 
 A few JAX primitives are converted to TF ops that have incomplete coverage
 for data types on different kinds of devices. The most [up-to-date list of
-limitations is generated automatically](#generated-summary-of-primitives-with-limited-support)
+limitations is generated automatically](#generated-summary-of-primitives-with-limited-support-in-tensorflow)
 by the jax2tf coverage tests.
 More detailed information can be found in the
-[source code of categorize](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/tests/primitives_test.py)
+[source code for the limitation specification](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/tests/primitives_test.py)
 for some cases.
 
 Additionally, some primitives have numerical differences between JAX and TF in some corner cases:
@@ -98,7 +98,7 @@ On TPU only "compiled" mode is ever used.
 
 
 This table only shows errors for cases that are working in JAX (see [separate
-list of unsupported or partially-supported primitives](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md)
+list of unsupported or partially-supported primitives](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md) )
 
 We use the following abbreviations for sets of dtypes:
 

--- a/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
+++ b/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
@@ -41,6 +41,10 @@ from jax.experimental.jax2tf.tests import primitive_harness
 
 class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
 
+  # This test runs for all primitive harnesses. For each primitive "xxx" the
+  # test will be called "test_jax_implemented_xxx_...". The test harnesses,
+  # including which dtypes are expected to fail, are defined in the
+  # file primitive_harness.py.
   @primitive_harness.parameterized(primitive_harness.all_harnesses,
                                    include_jax_unimpl=True)
   @jtu.ignore_warning(category=UserWarning,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -244,7 +244,7 @@ def dtypes_to_str(dtype_list: Sequence, empty_means_all=False) -> str:
   if all([t in names for t in complex]):
     names = (names - complex) | {"complex"}
 
-  inexact = {"", "all_complex"}
+  inexact = {"floating", "complex"}
   if all([t in names for t in inexact]):
     names = (names - inexact) | {"inexact"}
 
@@ -329,6 +329,12 @@ class Limitation:
       dtypes = tuple(dtypes)
     self.dtypes = dtypes
     self.enabled = enabled  # Does it apply to the current harness?
+
+  def __str__(self):
+    return (f"\"{self.description}\" devices={self.devices} "
+            f"dtypes={[np.dtype(dt).name for dt in self.dtypes]}")
+  __repr__ = __str__
+
 
   def filter(self, device_under_test: str) -> bool:
     """Check that a limitation is enabled for the current harness and device."""


### PR DESCRIPTION
* fixed the summarization of "inexact" types in the generated docs
* added support for 'skip_tf_run' to the limitations
* cleaned up the logging for the jax2tf tests