### PR TITLE
Implement "function" padding mode in jax.numpy.pad

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2470,9 +2470,6 @@ def _pad_empty(array, pad_width):
 
 
 def _pad_func(array, pad_width, func, **kwargs):
-  # Note: In numpy, `func` should modify a rank 1 array in-place.
-  # However, since Jax arrays are immutable, `func` should return
-  # the modified array.
   pad_width = _broadcast_to_pairs(pad_width, ndim(array), "pad_width")
   padded = _pad_constant(array, np.array(pad_width), 0)
   for axis in range(ndim(padded)):
@@ -2552,7 +2549,11 @@ def _pad(array, pad_width, mode, constant_values, stat_length, end_values, refle
                    "not implemented modes")
 
 
-@_wraps(np.pad)
+@_wraps(np.pad, lax_description="""\
+Unlike numpy, JAX "function" mode's argument (which is another function) should return
+the modified array. This is because Jax arrays are immutable.
+(In numpy, "function" mode's argument should modify a rank 1 array in-place.)
+""")
 def pad(array, pad_width, mode="constant", **kwargs):
   if isinstance(pad_width, Iterable):
     pad_width = tuple(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1516,6 +1516,31 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       with self.assertRaisesRegex(NotImplementedError, match):
         jnp.pad(arr, pad_width, mode)
 
+  @unittest.skipIf(numpy_version < (1, 17, 0), "function mode is new in numpy 1.17.0")
+  def testPadFunction(self):
+    def np_pad_with(vector, pad_width, iaxis, kwargs):
+      pad_value = kwargs.get('padder', 10)
+      vector[:pad_width[0]] = pad_value
+      vector[-pad_width[1]:] = pad_value
+
+    def jnp_pad_with(vector, pad_width, iaxis, kwargs):
+      pad_value = kwargs.get('padder', 10)
+      vector = jax.ops.index_update(
+          vector, jax.ops.index[:pad_width[0]], pad_value)
+      vector = jax.ops.index_update(
+          vector, jax.ops.index[-pad_width[1]:], pad_value)
+      return vector
+
+    arr = np.arange(6).reshape(2, 3)
+    np_res = np.pad(arr, 2, np_pad_with)
+    jnp_res = jnp.pad(arr, 2, jnp_pad_with)
+    np.testing.assert_equal(np_res, jnp_res)
+
+    arr = np.arange(24).reshape(2, 3, 4)
+    np_res = np.pad(arr, 1, np_pad_with, padder=100)
+    jnp_res = jnp.pad(arr, 1, jnp_pad_with, padder=100)
+    np.testing.assert_equal(np_res, jnp_res)
+
   def testPadWithNumpyPadWidth(self):
     a = [1, 2, 3, 4, 5]
     f = jax.jit(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1541,6 +1541,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_res = jnp.pad(arr, 1, jnp_pad_with, padder=100)
     np.testing.assert_equal(np_res, jnp_res)
 
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(arr.shape, arr.dtype)]
+    jnp_fun = partial(jnp.pad, pad_width=1, mode=jnp_pad_with)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   def testPadWithNumpyPadWidth(self):
     a = [1, 2, 3, 4, 5]
     f = jax.jit(


### PR DESCRIPTION
Implemented "function" padding mode in jax.numpy.pad

There was an issue about this implementation which was
> the function version would have to be implemented differently from numpy, because numpy's version has the function to modify the array in-place, while JAX arrays are immutable. https://github.com/google/jax/issues/5010#issuecomment-744621850

I think we can circumvent this problem by expecting different argument from numpy that `func` should return the modified array (while numpy `func` modify array in-place).

Related #5010 