### PR TITLE
Nit: fix typo in custom_derivatives.py ("separate")

### DIFF
--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -88,7 +88,7 @@ class custom_jvp:
   :py:func:`~jax.custom_jvp.defjvp` for defining a *single* custom JVP rule for
   all the function's inputs, and for convenience
   :py:func:`~jax.custom_jvp.defjvps`, which wraps
-  :py:func:`~jax.custom_jvp.defjvp`, and allows you to provide seperate
+  :py:func:`~jax.custom_jvp.defjvp`, and allows you to provide separate
   definitions for the partial derivatives of the function w.r.t. each of its
   arguments.
 


### PR DESCRIPTION
Noticed a small thing while reading the `jit` compile docs (https://jax.readthedocs.io/en/latest/jax.html#just-in-time-compilation-jit). 

Custom JVPs docstring ("seperate" -> "separate"):

```
class custom_jvp:
  """Set up a JAX-transformable function for a custom JVP rule definition.
...
  :py:func:`~jax.custom_jvp.defjvp`, and allows you to provide separate
  definitions for the partial derivatives of the function w.r.t. each of its
  arguments.
...