### PR TITLE
Fix broadcast_in_dim transpose issue.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3302,8 +3302,6 @@ def _broadcast_in_dim_shape_rule(operand, *, shape, broadcast_dimensions):
   return shape
 
 def _broadcast_in_dim_transpose_rule(ct, operand, *, shape, broadcast_dimensions):
-  if type(ct) is ad_util.Zero:
-    return ad_util.Zero
   shape_in = operand.aval.shape
   unit_dimensions = tuple(i for i, s in enumerate(shape_in) if s == 1)
   bdims = tuple(np.delete(broadcast_dimensions, unit_dimensions))
@@ -3323,8 +3321,7 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, *, shape,
 broadcast_in_dim_p = standard_primitive(
     _broadcast_in_dim_shape_rule, _input_dtype, 'broadcast_in_dim')
 broadcast_in_dim_p.def_impl(_broadcast_in_dim_impl)
-ad.primitive_jvps[broadcast_in_dim_p] = partial(ad.linear_jvp, broadcast_in_dim_p)
-ad.primitive_transposes[broadcast_in_dim_p] = _broadcast_in_dim_transpose_rule
+ad.deflinear2(broadcast_in_dim_p, _broadcast_in_dim_transpose_rule)
 batching.primitive_batchers[broadcast_in_dim_p] = _broadcast_in_dim_batch_rule
 
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3301,9 +3301,14 @@ def _broadcast_in_dim_shape_rule(operand, *, shape, broadcast_dimensions):
 
   return shape
 
-def _broadcast_in_dim_transpose_rule(t, *, shape, broadcast_dimensions):
-  axes = tuple(np.delete(range(len(shape)), broadcast_dimensions))
-  return [_reduce_sum(t, axes)]
+def _broadcast_in_dim_transpose_rule(ct, operand, *, shape, broadcast_dimensions):
+  if type(ct) is ad_util.Zero:
+    return ad_util.Zero
+  shape_in = operand.aval.shape
+  unit_dimensions = tuple(i for i, s in enumerate(shape_in) if s == 1)
+  bdims = tuple(np.delete(broadcast_dimensions, unit_dimensions))
+  axes = tuple(np.delete(range(len(shape)), bdims))
+  return [expand_dims(_reduce_sum(ct, axes), unit_dimensions)]
 
 def _broadcast_in_dim_batch_rule(batched_args, batch_dims, *, shape,
                                  broadcast_dimensions):
@@ -3318,7 +3323,8 @@ def _broadcast_in_dim_batch_rule(batched_args, batch_dims, *, shape,
 broadcast_in_dim_p = standard_primitive(
     _broadcast_in_dim_shape_rule, _input_dtype, 'broadcast_in_dim')
 broadcast_in_dim_p.def_impl(_broadcast_in_dim_impl)
-ad.deflinear(broadcast_in_dim_p, _broadcast_in_dim_transpose_rule)
+ad.primitive_jvps[broadcast_in_dim_p] = partial(ad.linear_jvp, broadcast_in_dim_p)
+ad.primitive_transposes[broadcast_in_dim_p] = _broadcast_in_dim_transpose_rule
 batching.primitive_batchers[broadcast_in_dim_p] = _broadcast_in_dim_batch_rule
 
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1021,6 +1021,15 @@ class LaxTest(jtu.JaxTestCase):
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     self._CompileAndCheck(op, args_maker)
 
+  def testBroadcastInDimOperandShapeTranspose(self):
+    # Regression test for https://github.com/google/jax/issues/5276
+    def f(x):
+      return lax.broadcast_in_dim(x, (2, 3, 4), broadcast_dimensions=(0, 1, 2)).sum()
+    def g(x):
+      return lax.broadcast_in_dim(x.reshape((3,)), (2, 3, 4), broadcast_dimensions=(1,)).sum()
+    x = np.ones((1, 3, 1))
+    self.assertArraysEqual(jax.grad(f)(x), jax.grad(g)(x))
+
   @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_inshape={}_outshape={}_bcdims={}".format(
       jtu.format_shape_dtype_string(inshape, np.float32),


### PR DESCRIPTION
Fixes #5276

The `broadcast_in_dim_p` transpose rule currently does not correctly handle broadcasted explicit dimensions.

To handle this correctly, the transpose rule needs information about the input shapes, which is not forwarded by `ad.deflinear()`, but is forwarded by `ad.deflinear2()`.

This change modifies the transpose rule to use `deflinear2`, and return an array of the correct shape as confirmed by [this check](https://github.com/google/jax/blob/2ebd5285c8056989a92d49812ae4f8bfef022a26/jax/interpreters/ad.py#L180) when `core.skip_checks = False`.