### PR TITLE
[shapecheck] Improve the shape computations to work better with the n…

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1136,6 +1136,9 @@ raise_to_shaped_mappings : Dict[type, Callable] = {
 # Registry for valid dimension types. This is used by masking.Poly.
 _DIMENSION_TYPES: Set[type] = {int}
 
+DimSize = Any  # A member of _DIMENSION_TYPES
+Shape = Sequence[DimSize]
+
 def _canonicalize_dimension(dim):
   if type(dim) in _DIMENSION_TYPES:
     return dim

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -197,7 +197,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
   def test_with_custom_vjp(self):
     """Shape-polymorphic custom VJP."""
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     @jax.custom_vjp
     def f(x):
       # x: [b1, b2, d1, d2] (a batch of matrices)
@@ -288,7 +287,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     self.assertEqual((None, 3, 4), tuple(tf_grad.output_shapes[1]["grad"]))
 
   def test_cond(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     # Test the primitive under conditional
     def f(x, y):
       # x: f32[B, H], y : f32[H]
@@ -303,7 +301,6 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
 
   def test_shape_error(self):
     """Some of the examples from the README."""
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     with self.assertRaisesRegex(TypeError,
                                 re.escape("add got incompatible shapes for broadcasting: (v,), (4,)")):
       self.CheckShapePolymorphism(
@@ -430,7 +427,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
   """Tests for primitives that take shape values as parameters."""
 
   def test_matmul(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     def f_jax(x, y):
       return jnp.matmul(x, y)
 
@@ -441,7 +437,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
       expected_output_signature=tf.TensorSpec([None, 8, None]))
 
   def test_reshape(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     def f_jax(x):
       y = jnp.sin(x)
       return y.reshape([2, -1])
@@ -459,7 +454,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
       expected_output_signature=tf.TensorSpec([2, None]))
 
   def test_reshape_compiled(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     # We compile the result of conversion, hence we need to involve the compiler
     # twice, but we trace only once with shape polymorphism
     traced = False
@@ -491,7 +485,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
 
 
   def test_add(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     def f_jax(x, y):
       return jnp.add(x, y)
 
@@ -507,7 +500,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
     self.assertAllClose(f_jax(x, y), f_tf(x, y))
 
   def test_squeeze(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     def f_jax(x):
       return jnp.squeeze(x, axis=1)
     x = np.ones((4, 1))
@@ -533,7 +525,6 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
         expected_output_signature=tf.TensorSpec([None]))
 
   def test_broadcast(self):
-    raise unittest.SkipTest("Failing after fixing Poly unsoundness #4878")
     def f_jax(x):
       return jnp.broadcast_to(x, [x.shape[0], x.shape[0], x.shape[1]])
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -271,7 +271,8 @@ class LaxAutodiffTest(jtu.JaxTestCase):
        for strides in all_strides
        for dtype in float_dtypes
        for padding in ["VALID", "SAME"]))
-  def testConvGrad(self, lhs_shape, rhs_shape, dtype, strides, padding):
+  def testConvGrad(self, lhs_shape=(3, 2, 3, 4), rhs_shape=(3, 2, 1, 2),
+                   dtype=dtypes.bfloat16, strides=(1, 2), padding='VALID'):
     rng = jtu.rand_small(self.rng())
     lhs = rng(lhs_shape, dtype)
     rhs = rng(rhs_shape, dtype)


### PR DESCRIPTION
[shapecheck] Increase coverage of shapecheck, to work with the new sound Poly implementation

This is a follow-up to #4878, which fixed unsoundness in the implementation of Poly (equality and inequality operators
now may return UndefinedPoly). As a side-effect, a number of JAX shape checking rules that depended on the
unsound behavior have stopped working with non-concrete shapes. In order to land #4878, I had to disable
some tests in masking_test.py and jax2tf/tests/shape_poly_test.py.

A summary of the changes here:

  * fixed the shape rules for broadcast, pad, reshape, dot_general, conv, squeeze slice. Added more tests to `masking_test.py`. See below for more details. 
  * removed all the `SkipTest` introduced in #4878. In addition to changes to the shape rules, I had to change the input shape specifications to ensure that the input dimensions are "big enough" for the test. E.g., instead of `in_shape="n"`, I had to
    use `in_shape="n + 1"` if the test was doing negative padding.
  * indirectly this restores the coverage of the jax2tf batch polymorphism where it was before #4878 (most Flax models can be converted batch polymorphically)
  * added better error messages for when Poly inequality comparisons are indeterminate
  * fixed `masking.parse_spec("()")`, was failing before
  * added a missing check in the padding shape rule to prevent cases when the resulting shape has negative-sized axes.
    Previously, these were caught as Internal Errors by XLA. Added new tests to lax_test.py

Next, I discuss a bit the philosophy behind the changes proposed here.

Definition of **soundness of shape polymorhism (and `shapecheck`)**: given a function `f` and `input_shape`/`output_shape` two shape polynomials over a set of shape variables, 
if `shapecheck(in_shape, out_shape)(f)` succeeds, then for any valuation of the shape variables with **non-negative** integers,
let `s_in` and `s_out` be the values of `in_shape` and `out_shape` respectively for the given valuation. 
Then, for any input `x` whose shape is `s_in` we have that `f(x)` **succeeds with an output of shape `s_out`**. 

There are many complex computations with shapes in JAX, , e.g., in the process of lowering
`jax.numpy` to JAX primitives, in the abstract evaluation rules for the primitives, and even in the implementation of the
transformation rules. We want to reuse these with minimal changes, for the case when the shapes are
polymorphic. Adding escape hatches such as `if shape_is_polymorphic(..): ...` makes it hard to ensure soundness.


The current design is to introduce a class `Poly` that duck-types integers and generalizes all shape computations 
in JAX to work over tuples of `Poly`.
The change in #4878 ensures that shape equality and inequality comparisons throw `UndefinedPoly` if the comparison cannot be expressed soundly as a boolean. 
For example, if the Python code contains `shape[0] == 1` and the value of `shape[0]` is the polynomial `m + n`, then it would be unsound to assume that the comparison should be represented as `False`, because there are values for `n` and `m` that would return `True`, and would thus make the Python code that different paths.

**If we avoid all explicit polymorphism checks in the shape computation code, then we have soundness, as long as
the Poly implementation of the arithmetic operators is sound.**

Unfortunately, there are some cases when the ergonomics would suffer (unfriendly error messages or cases that would raise errors too aggressively). We propose to add a limited number of
mechanisms to use in JAX shape computation code to improve the usability, while making soundness easy to review.
The following use cases show a few common instances:

1. Shape computation for error reporting.

There are many instances in JAX of the following form:
```
if shape_comp(): raise ValueError(msg)
```

We want to report the intended error message even if `shape_comp()` raises. We propose the following:
```
with masking.shape_error(ValueError(msg)) as e:
  if shape_comp(): raise e
```

This constructs the exception early, and if the body of the `with` throws `UndefinedPoly`, then
we still raise the intended exception, with an expanded error message:
```
raise type(e)(e.message + ". Polynomial comparison 'n == 1' is inconclusive")
```

2. A common instance of the error checking code is for simple equality comparisons. We propose a simpler form:

```
if not masking.must_equal(v1, v2):
   raise ValueError(msg)
```

The `must_equal` function returns False if the comparison is indeterminate, e.g., `must_equal(1, 1)`, `must_equal(n + 1, n + 1)`, 
but not for `must_equal(1, 2)` nor for `must_equal(n, 1)`.

The programmer must ensure that the code is sound even in the case when `must_equal` returns False with polymorphic shapes but returns True for concrete shapes. 
In the above usage this is easy to see, because if `must_equals` returns False, then we abort, which is always sound during
polymorphic execution.

3. There are a few instances when we need to check an either-or equality, e.g., for broadcasting:
```
if op_dim != 1 and op_dim != target_dim:
   raise ValueError(msg)
```

The problem here is that if `op_dim` and `target_dim` are both `n`, then `op_dim != 1` will raise before we get a chance to see that `op_dim == target_dim`.

For this pattern we propose
```
if not masking.must_equal_or(op_dim, 1, target_dim):
  raise ValueError(msg)
```

4. The most complicated cases are when we have a sequence of nested conditionals on shapes. A good example are the
dilation shape computation, to compute "1 + (0 if shape == 0 else dilation * (shape - 1))",
which was before written as:

```
return np.where(shape == 0, 0,
                         np.multiply(dilation, np.subtract(shape, 1)) + 1)
```

The problem here is that the `shape == 0` array comparison may throw `UndefinedPoly` for some of
the dimensions even if the `dilation` is 1 on that dimension. An alternative way to write this is:

```
[shape[i] if masking.must_equal(dilation[i], 1) else (0 if shape[i] == 0 else 1 + dilation[i] * (shape[i] - 1))
 for i in range(len(shape))]]
```
