### PR TITLE
Add setup classifiers fields for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,14 @@ setup(
     packages=find_packages(exclude=["examples"]),
     python_requires='>=3.6',
     install_requires=[
-        'numpy >=1.12', 'absl-py', 'opt_einsum'
+        'numpy >=1.12',
+        'absl-py',
+        'opt_einsum',
     ],
     url='https://github.com/google/jax',
     license='Apache-2.0',
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ]
 )


### PR DESCRIPTION
This is following https://packaging.python.org/tutorials/packaging-projects/.

We might want to add other fields in future, e.g. license, etc.

This metadata shows up conveniently in the left-hand column on PyPI, e.g. https://pypi.org/project/dm-haiku/