### PR TITLE
avoid cache misses when evaluating cond primitives

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -44,7 +44,7 @@ from jax.interpreters import batching
 from jax.interpreters import masking
 from jax.lib import xla_bridge as xb
 from jax.lib import xla_client
-from jax.util import (partial, unzip2, unzip4, safe_map, safe_zip, split_list,
+from jax.util import (partial, unzip2, unzip3, safe_map, safe_zip, split_list,
                       cache, extend_name_stack)
 from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
                            treedef_children, treedef_tuple, tree_multimap,
@@ -64,17 +64,18 @@ Array = Any
 @cache()
 def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals):
   wrapped_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(fun), in_tree)
-  jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals)
-  return jaxpr, out_avals, consts, out_tree()
+  jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, in_avals)
+  return jaxpr, consts, out_tree()
 
 @cache()
 def _initial_style_jaxpr(fun: Callable, in_tree, in_avals):
-  jaxpr, out_avals, consts, out_tree = _initial_style_open_jaxpr(fun, in_tree, in_avals)
+  jaxpr, consts, out_tree = _initial_style_open_jaxpr(fun, in_tree, in_avals)
   closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
   return closed_jaxpr, consts, out_tree
 
+@cache()
 def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
-                                            in_tree, in_avals):
+                                             in_tree, in_avals):
   # When staging the branches of a conditional into jaxprs, constants are
   # extracted from each branch and converted to jaxpr arguments. To use the
   # staged jaxprs as the branches to a conditional *primitive*, we need for
@@ -82,18 +83,18 @@ def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
   # for each one, it makes another that accepts *all* constants, but only uses
   # those that it needs (dropping the rest).
 
-  jaxprs, all_out_avals, all_consts, all_out_trees = unzip4(
+  jaxprs, all_consts, all_out_trees = unzip3(
       _initial_style_open_jaxpr(fun, in_tree, in_avals) for fun in funs)
 
   newvar = core.gensym(jaxprs, suffix='_')
   all_const_avals = [[raise_to_shaped(core.get_aval(c)) for c in consts]
-                    for consts in all_consts]
+                     for consts in all_consts]
   unused_const_vars = [[newvar(aval) for aval in const_avals]
-                      for const_avals in all_const_avals]
+                       for const_avals in all_const_avals]
 
   def pad_jaxpr_constvars(i, jaxpr):
     prefix = util.concatenate(unused_const_vars[:i])
-    suffix = util.concatenate(unused_const_vars[i+1:])
+    suffix = util.concatenate(unused_const_vars[i + 1:])
     constvars = [*prefix, *jaxpr.constvars, *suffix]
     return core.Jaxpr(constvars=constvars, invars=jaxpr.invars,
                       outvars=jaxpr.outvars, eqns=jaxpr.eqns)
@@ -101,7 +102,7 @@ def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
   consts = util.concatenate(all_consts)
   jaxprs = [pad_jaxpr_constvars(i, jaxpr) for i, jaxpr in enumerate(jaxprs)]
   closed_jaxprs = [core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
-                  for jaxpr, out_avals in zip(jaxprs, all_out_avals)]
+                   for jaxpr in jaxprs]
   return closed_jaxprs, consts, all_out_trees
 
 def _abstractify(x):
@@ -2605,6 +2606,8 @@ ad.primitive_jvps[cummax_p] = partial(_cumulative_jvp_rule, combine_fn=lax.max)
 def omnistaging_disabler() -> None:
   global _initial_style_open_jaxpr, _initial_style_jaxpr, \
       _initial_style_jaxprs_with_common_consts
+
+  from jax.util import unzip4
 
   @cache()
   def _initial_style_open_jaxpr(fun: Callable, in_tree, in_avals):


### PR DESCRIPTION
Cache the jaxprs that we form for branches so that the branch params we pass when binding the cond primitive hit the cache for primitive computations.

Simplify the jaxpr branch setup code along the way.

fixes #5210 