### PR TITLE
Run main test suite under Python 3.8

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include:
           - name-prefix: "with many tests"
-            python-version: 3.6
+            python-version: 3.8
             os: ubuntu-latest
             enable-x64: 0
             enable-omnistaging: 1

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ]
 )


### PR DESCRIPTION
Python 3.8 was released in October 2019, yet our current CI coverage is only Python 3.6-3.7.

This PR changes our CI setup such that the main test suite is run under Python 3.8; we still have decent coverage of Python 3.6 and 3.7 in various other test runs in the matrix.