### PR TITLE
Adds support for is_leaf in tree_util.tree_(multi)map

### DIFF
--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -194,6 +194,14 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(out, (((1, [3]), (2, None)),
                            ((3, {"foo": "bar"}), (4, 7), (5, [5, 6]))))
 
+  def testTreeMultimapWithIsLeafArgument(self):
+    x = ((1, 2), [3, 4, 5])
+    y = (([3], None), ({"foo": "bar"}, 7, [5, 6]))
+    out = tree_util.tree_multimap(lambda *xs: tuple(xs), x, y,
+                                  is_leaf=lambda n: isinstance(n, list))
+    self.assertEqual(out, (((1, [3]), (2, None)),
+                           (([3, 4, 5], ({"foo": "bar"}, 7, [5, 6])))))
+
   @skipIf(jax.lib.version < (0, 1, 58), "test requires Jaxlib >= 0.1.58")
   def testFlattenIsLeaf(self):
     x = [(1, 2), (3, 4), (5, 6)]


### PR DESCRIPTION
pytree.flatten supports an optional `is_leaf` argument (see `jax.tree_flatten`).
In some situations it is useful to forward this argument to the flatten call in `tree_map` and `tree_multimap`.

A completely made-up example (my original use-case is quite involved):
```
class P(NamedTuple):
  w: jnp.ndarray
  b: jnp.ndarray

params = {'top': P(...), 'nested': [P(...), P(...)]}
rescale = lambda p: p._replace(w=2*p.w)
tree_map(rescale, params, is_leaf=lambda n: isinstance(n, P))
```