### PR TITLE
make c++ jit dispatch sensitive to required global context

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -506,6 +506,22 @@ class CPPJitTest(jtu.JaxTestCase):
         f"explicit inner-jit backend specification cpu."):
       f(1.)
 
+  def test_omnistaging(self):
+    # See https://github.com/google/jax/issues/5206
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    key_list = [None]
+
+    def init():
+      key, subkey = jax.random.split(key_list[0])
+      key_list[0] = key
+      return jax.random.normal(subkey, ())
+
+    key_list[0] = np.array([2384771982, 3928867769], dtype=np.uint32)
+    init()
+    self.jit(init)()
+    self.assertIsInstance(key_list[0], core.Tracer)
 
 class PythonJitTest(CPPJitTest):
 


### PR DESCRIPTION
See #5206. The C++ jit dispatch path was not sensitive to the global state introduced by omnistaging, which led to the bug in #5206. In the edge cases where it could occur, the bug had the effect of disabling omnistaging in certain ways, which could lead to higher memory fragmentation. With the C++ jit dispatch path ignoring necessary global context, other bugs could have arisen in the future as it grew to handle more cases.

This was a collaboration with @jblespiau !