### PR TITLE
CI: use python 3.9 for numpy dispatch tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -59,7 +59,7 @@ jobs:
             package-overrides: "none"
             num_generated_cases: 25
           - name-prefix: "with numpy-dispatch"
-            python-version: 3.7
+            python-version: 3.9
             os: ubuntu-latest
             enable-x64: 1
             enable-omnistaging: 1


### PR DESCRIPTION
We currently have no Python 3.9 test coverage, and this is a good candidate because it is testing behavior of future numpy versions.