### PR TITLE
add source line info to more escaped tracer errors

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -426,7 +426,7 @@ class JaxprTracer(Tracer):
     pv, const = pval
     if isinstance(const, Tracer) and const._trace.level >= trace.level:
       raise core.escaped_tracer_error(
-          "Tracer from a higher level: {} in trace {}".format(const, trace))
+          const, "Tracer from a higher level: {} in trace {}".format(const, trace))
     self._trace = trace
     self.pval = pval
     self.recipe = recipe
@@ -622,7 +622,7 @@ def tracers_to_jaxpr(
     elif isinstance(recipe, LambdaBinding):
       if not any(t is in_tracer for in_tracer in in_tracers):
         raise core.escaped_tracer_error(
-            "Tracer not among input tracers {}".format(t))
+            t, "Tracer not among input tracers {}".format(t))
       assert in_tracers, "Lambda binding with no args"
     elif isinstance(recipe, FreeVar):
       env[cast(core.Var, getvar(t))] = recipe.val
@@ -897,12 +897,12 @@ def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
 
 
 class DynamicJaxprTracer(core.Tracer):
-  __slots__ = ['aval', 'line_info']
+  __slots__ = ['aval']
 
   def __init__(self, trace, aval, line_info=None):
     self._trace = trace
+    self._line_info = line_info
     self.aval = aval
-    self.line_info = line_info
 
   def full_lower(self):
     return self
@@ -936,8 +936,7 @@ class DynamicJaxprTracer(core.Tracer):
 
   def _assert_live(self) -> None:
     if not self._trace.main.jaxpr_stack:  # type: ignore
-      msg = f"tracer created on line {source_info_util.summarize(self.line_info)}"
-      raise core.escaped_tracer_error(msg)
+      raise core.escaped_tracer_error(self, None)
 
 class JaxprStackFrame:
   __slots__ = ['newvar', 'tracer_to_var', 'constid_to_var', 'constvar_to_val',
@@ -1031,11 +1030,7 @@ class DynamicJaxprTrace(core.Trace):
   def getvar(self, tracer):
     var = self.frame.tracer_to_var.get(id(tracer))
     if var is None:
-      if tracer.line_info is not None:
-        detail = f"tracer created on line {source_info_util.summarize(tracer.line_info)}"
-      else:
-        detail = None
-      raise core.escaped_tracer_error(detail)
+      raise core.escaped_tracer_error(tracer)
     return var
 
   def makevar(self, tracer):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1997,7 +1997,7 @@ class APITest(jtu.JaxTestCase):
       lax.scan(f, None, None, length=2)
 
     with self.assertRaisesRegex(core.UnexpectedTracerError,
-                                "tracer created on line"):
+                                "was created on line"):
       g()
 
   def test_escaped_tracer_omnistaging_top_trace(self):
@@ -2014,7 +2014,7 @@ class APITest(jtu.JaxTestCase):
     lax.scan(f, None, None, length=2)  # leaked a tracer! (of level 1!)
 
     with self.assertRaisesRegex(core.UnexpectedTracerError,
-                                "tracer created on line"):
+                                "was created on line"):
       # The following call will try and raise the ones array to the count tracer
       # level, which is no longer live.
       jax.jit(jnp.add)(jnp.ones(()), count)

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 import traceback
 import unittest
 
 from absl.testing import absltest
 
-import jax
 from jax import grad, jit, vmap
 import jax.numpy as jnp
 from jax import test_util as jtu
 from jax._src import traceback_util
-from jax._src import source_info_util
 
 
 from jax.config import config
@@ -147,12 +144,6 @@ class FilteredTracebackTest(jtu.JaxTestCase):
     self.assertIsInstance(e.__cause__, ValueError)
     self.assertIsInstance(e.__cause__.__cause__,
                           traceback_util.FilteredStackTrace)
-
-
-class SourceInfoTest(jtu.JaxTestCase):
-
-  def testJaxPathMatchesSourceInfoPath(self):
-    self.assertEqual(source_info_util._jax_path, os.path.dirname(jax.__file__))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The main goal here is to generate better error messages, particularly related to escaped tracers (e.g. due to side effects in user code). In addition to the regular traceback, it's helpful to show information about where the problematic tracer was created. That is, while the error is being raised on the line where a problematic tracer is _encountered_, we also want to explain how this problematic tracer came into being.

This extra source info is still only on jaxpr staging tracers, but those seem to be the most common culprits. I moved the `_line_info` attribute to the base Tracer class in core.py in anticipation of populating it for more traces than just DynamicJaxprTrace, but I'll leave that extension to follow-up.

I adapted the main escaped tracer error messages in core.py, and also slightly generalized and debugged source_info_util functions (thanks for explaining the path prefix bug, @froystig !).

Now an error message that used to look like this:

> The functions being transformed should not save traced values to global state. Detail: Incompatible sublevel: DynamicJaxprTrace(level=1/1), (2, 0). Offending tracer created on /foo/bar/baz.py:104 (__call__)..

Turns into something like this:

> jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.
> The functions being transformed should not save traced values to global state. Detail: Incompatible sublevel: DynamicJaxprTrace(level=1/1), (2, 0).
> The tracer that caused this error was created on line /foo/bar/baz.py:104 (__call__).
> When the tracer was created, the final 10 stack frames (most recent last) were:
> /foo/bar/baz.py:111 (__call__)
> ... suppressed a few lines in this example ...
> /foo/bar/baz.py:104 (__call__)