### PR TITLE
Support broadcasting of batch dims in jax.numpy.linalg.solve

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -253,6 +253,12 @@ def _check_solve_shapes(a, b):
 def _solve(a, b):
   _check_solve_shapes(a, b)
 
+  # Broadcast leading dimensions of b to the shape of a, as is required by
+  # custom_linear_solve.
+  out_shape = tuple(d_a if d_b == 1 else d_b
+                    for d_a, d_b in zip(a.shape[:-1] + (1,), b.shape))
+  b = jnp.broadcast_to(b, out_shape)
+
   # With custom_linear_solve, we can reuse the same factorization when
   # computing sensitivities. This is considerably faster.
   lu_, _, permutation = lu(lax.stop_gradient(a))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -706,7 +706,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
           ((4, 4), (4,)),
           ((8, 8), (8, 4)),
           ((1, 2, 2), (3, 2)),
-          ((2, 1, 3, 3), (2, 4, 3, 4)),
+          ((2, 1, 3, 3), (1, 4, 3, 4)),
           ((1, 0, 0), (1, 0, 2)),
       ]
       for dtype in float_types + complex_types))


### PR DESCRIPTION
Fixes #826

Note that I didn't apply this fix to `jax.scipy.linalg.solve`, because `scipy.linalg.solve` does not support batched inputs as `numpy.linalg.solve` does.