### PR TITLE
Add method parameter to jax.random.multivariate_normal

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -658,7 +658,7 @@ def multivariate_normal(key: jnp.ndarray,
       broadcasting together the batch shapes of ``mean`` and ``cov``.
     dtype: optional, a float dtype for the returned values (default float64 if
       jax_enable_x64 is true, otherwise float32).
-    method: optinoal, a method to compute the factor of ``cov``.
+    method: optional, a method to compute the factor of ``cov``.
       Must be one of 'svd', eigh, and 'cholesky'. Default 'cholesky'.
   Returns:
     A random array with the specified dtype and shape given by

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -620,11 +620,13 @@ class LaxRandomTest(jtu.JaxTestCase):
       self._CheckKolmogorovSmirnovCDF(samples, scipy.stats.t(df).cdf)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dim={}_dtype={}".format(dim, np.dtype(dtype)),
-       "dim": dim, "dtype": dtype}
+      {"testcase_name": "_dim={}_dtype={}_method={}".format(
+          dim, np.dtype(dtype), method),
+       "dim": dim, "dtype": dtype, "method": method}
       for dim in [1, 3, 5]
-      for dtype in float_dtypes))
-  def testMultivariateNormal(self, dim, dtype):
+      for dtype in float_dtypes
+      for method in ['svd', 'eigh', 'cholesky']))
+  def testMultivariateNormal(self, dim, dtype, method):
     r = np.random.RandomState(dim)
     mean = r.randn(dim)
     cov_factor = r.randn(dim, dim)
@@ -632,7 +634,7 @@ class LaxRandomTest(jtu.JaxTestCase):
 
     key = random.PRNGKey(0)
     rand = partial(random.multivariate_normal, mean=mean, cov=cov,
-                   shape=(10000,))
+                   shape=(10000,), method=method)
     crand = api.jit(rand)
 
     uncompiled_samples = np.asarray(rand(key), np.float64)


### PR DESCRIPTION
Add `method` parameter to `jax.random.multivariate_normal` to support 'svd' and 'eigh'.
Numpy's default method is 'svd' https://numpy.org/devdocs/reference/random/generated/numpy.random.Generator.multivariate_normal.html
but for JAX, I set default method to 'cholesky' for backward compatibility.

Related #5296