### PR TITLE
clear some caches when setting up jaxpr typecheck tests

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2625,6 +2625,7 @@ def omnistaging_disabler() -> None:
     closed_jaxpr = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
     return closed_jaxpr, consts, out_tree()
 
+  @cache()
   def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
                                               in_tree, in_avals):
     # When staging the branches of a conditional into jaxprs, constants are

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -22,6 +22,7 @@ import numpy as np
 from absl.testing import absltest
 from absl.testing import parameterized
 
+import jax
 from jax import core
 from jax import lax
 from jax import numpy as jnp
@@ -317,6 +318,12 @@ class CoreTest(jtu.JaxTestCase):
 
 
 class JaxprTypeChecks(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    jax._src.lax.control_flow._initial_style_open_jaxpr.cache_clear()
+    jax._src.lax.control_flow._initial_style_jaxpr.cache_clear()
+    jax._src.lax.control_flow._initial_style_jaxprs_with_common_consts.cache_clear()
 
   def test_check_jaxpr_correct(self):
     jaxpr = make_jaxpr(lambda x: jnp.sin(x) + jnp.cos(x))(1.).jaxpr

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2464,7 +2464,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         lambda: core.check_jaxpr(jaxpr))
 
   def test_cond_typecheck_param(self):
-    raise SkipTest("TODO: test is flaky b/176769043")
     def new_jaxpr():
       jaxpr = api.make_jaxpr(
           lambda x: lax.switch(0, [jnp.sin, jnp.cos], x))(1.).jaxpr

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -27,6 +27,7 @@ from absl.testing import parameterized
 import numpy as np
 import numpy.random as npr
 
+import jax
 from jax import api
 from jax import core
 from jax import lax
@@ -94,6 +95,12 @@ def posify(matrix):
 
 
 class LaxControlFlowTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    jax._src.lax.control_flow._initial_style_open_jaxpr.cache_clear()
+    jax._src.lax.control_flow._initial_style_jaxpr.cache_clear()
+    jax._src.lax.control_flow._initial_style_jaxprs_with_common_consts.cache_clear()
 
   def testWhileWithTuple(self):
     limit = 10


### PR DESCRIPTION
In order to test that the typechecker identifies invalid jaxprs, some tests modify jaxprs in place. This is typically not allowed, since jaxprs are assumed immutable, and may be cached. As a workaround, this change clears the relevant caches before every test. This ought to prevent some order-dependent test failures.