### PR TITLE
[jax2tf] Finish the conversion of lax.sort

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -126,7 +126,7 @@ for CUDA. One must be mindful to install a version of CUDA that is compatible
 with both [jaxlib](https://github.com/google/jax/blob/master/README.md#pip-installation) and
 [TensorFlow](https://www.tensorflow.org/install/source#tested_build_configurations).
 
-As of today, the tests are run using `tf_nightly==2.5.0-dev20201223`.
+As of today, the tests are run using `tf_nightly==2.5.0-dev20210107`.
 
 ## Caveats
 

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support
 
-*Last generated on (YYYY-MM-DD): 2020-12-31*
+*Last generated on (YYYY-MM-DD): 2021-01-07*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -151,9 +151,8 @@ More detailed information can be found in the
 | select_and_scatter_add | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
 | sign | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | sinh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
-| sort | TF error: TODO: XlaSort does not support more than 2 arrays | all | cpu, gpu, tpu | compiled, eager, graph |
-| sort | TF error: TODO: XlaSort does not support sorting axis | all | cpu, gpu, tpu | compiled, eager, graph |
-| sort | TF error: op not defined for dtype | complex | cpu, gpu | eager, graph |
+| sort | TF error: op not defined for dtype | complex, float64 | cpu, gpu | compiled, eager, graph |
+| sort | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | sub | TF error: op not defined for dtype | uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | svd | TF error: function not compilable. Implemented using `tf.linalg.svd` and `tf.linalg.adjoint` | complex | cpu, gpu | compiled |
 | svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled |

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -1184,17 +1184,13 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             # I think that this is because TF is running on CPU even for GPU tests?
             "TODO: TF non-stable multiple-array sort",
             devices="gpu",
-            enabled=(len(harness.arg_descriptors) == 4 and not harness.params["is_stable"]),
+            enabled=(harness.params["num_arrays"] > 1 and not harness.params["is_stable"]),
             expect_tf_error=False,
             skip_comparison=True),
-        missing_tf_kernel(dtypes=[np.complex64, np.complex128], devices=("cpu", "gpu")),
-        Jax2TfLimitation(
-            "TODO: XlaSort does not support more than 2 arrays",
-            enabled=harness.params["nb_arrays"] > 2),
-        Jax2TfLimitation(
-            "TODO: XlaSort does not support sorting axis",
-            enabled=harness.params["dimension"] !=
-                    len(np.shape(harness.arg_descriptors[0])) - 1)
+        missing_tf_kernel(dtypes=[np.complex64, np.complex128, np.float64],
+                          devices=("cpu", "gpu"), also_compiled=True),
+        missing_tf_kernel(dtypes=[np.bool_],
+                          also_compiled=True),
     ]
 
   @classmethod


### PR DESCRIPTION
We were blocked until now due to limited support for the XlaSort op.
Also removed the patching of the XlaPad output shape; now XlaPad has
shape inference.