### PR TITLE
jnp.eye(): improve input validation

### DIFF
--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -14,8 +14,8 @@
 
 
 from typing import Sequence, Tuple, Union
-import numpy as np
 from jax._src.numpy import lax_numpy as jnp
+from jax.util import prod
 from . import lax
 
 
@@ -84,7 +84,7 @@ def conv_general_dilated_patches(
 
   lhs_spec, rhs_spec, out_spec = dimension_numbers
 
-  spatial_size = np.prod(filter_shape)
+  spatial_size = prod(filter_shape)
   n_channels = lhs.shape[lhs_spec[1]]
 
   # Move separate `lhs` spatial locations into separate `rhs` channels.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2934,16 +2934,11 @@ empty = zeros
 def eye(N, M=None, k=0, dtype=None):
   lax._check_user_dtype_supported(dtype, "eye")
   dtype = float_ if dtype is None else dtype
-  M = N if M is None else M
-  k = int(k)
+  N = operator.index(N)
+  M = N if M is None else operator.index(M)
   if N < 0 or M < 0:
-    msg = "negative dimensions are not allowed, got {} and {}"
-    raise ValueError(msg.format(N, M))
-  if k is not None:
-    k_dtype = _dtype(k)
-    if not issubdtype(k_dtype, integer):
-      msg = "eye argument `k` must be of integer dtype, got {}"
-      raise TypeError(msg.format(k_dtype))
+    raise ValueError(f"negative dimensions are not allowed, got {N} and {M}")
+  k = operator.index(k)
   return lax._eye(dtype, (N, M), k)
 
 


### PR DESCRIPTION
Previously, floats passed to `jnp.eye()` would be silently truncated to integers. This makes the result an error, similar to `np.eye`