### PR TITLE
Simplify jax.random.logistic algorithm

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1299,21 +1299,9 @@ def logistic(key, shape=(), dtype=dtypes.float_):
 
 @partial(jit, static_argnums=(1, 2))
 def _logistic(key, shape, dtype):
-  # Mathematically, we can compute the distribution by generating uniformly-distributed
-  # numbers x in the open interval (a, b) and computing:
-  #   z = log[ (x - a) / (b - x))
-  # It's important to avoid x=a or x=b, which lead to infinite values for z.
-  # The uniform() function generates pseudorandom floating point numbers x in the
-  # semi-closed interval [0, 1), so if used directly  with (a,b)=(0,1), it will
-  # lead to infinite output in a small number of cases (as many as 1 in 2^23 for float32).
-  #
-  # Instead, we let (a, b) = (-ε, 1) where ε is the smallest step between floating point
-  # values: then numbers in the interval (-ε, 1) are approximated by standard uniformly
-  # drawn numbers in [0, 1).
   _check_shape("logistic", shape)
-  x = uniform(key, shape, dtype)
-  eps = jnp.finfo(dtype).eps
-  return lax.log(lax.div(lax.add(lax._const(x, eps), x), lax.sub(lax._const(x, 1), x)))
+  x = uniform(key, shape, dtype, minval=jnp.finfo(dtype).eps, maxval=1.)
+  return lax.log(lax.div(x, lax.sub(lax._const(x, 1), x)))
 
 
 def pareto(key, b, shape=None, dtype=dtypes.float_):


### PR DESCRIPTION
Previous algorithm was overly complicated, and potentially biased. This is a much more straightforward approach to computing logistic samples, and changes the results by less than 1 part in 10^7 for float32. Test script:
```python
from jax import random
x = random.logistic(random.PRNGKey(1701), shape=(10000000,))
print(x[:5])
print(x.min(), x.max())
```
Before this PR:
```
[-0.4922756 -1.1400323  1.9611039 -1.1750274  1.8708186]
-15.942385 15.942385
```
After this PR:
```
[-0.4922756 -1.1400323  1.9611038 -1.1750274  1.8708185]
-15.942385 15.942385
```