### PR TITLE
Make xmapped functions with no axis resources callable more than once

### DIFF
--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -304,7 +304,9 @@ def make_xmap_callable(fun: lu.WrappedFun,
                                     EXPERIMENTAL_SPMD_LOWERING,
                                     *in_avals)
   else:
-    return f.call_wrapped
+    # We have to trace again, because `f` is a linear function, so we can't just return it.
+    final_jaxpr, _, final_consts = pe.trace_to_jaxpr_final(f, mapped_in_avals)
+    return core.jaxpr_as_fun(core.ClosedJaxpr(jaxpr, consts))
 
 class EvaluationPlan(NamedTuple):
   """Encapsulates preprocessing common to top-level xmap invocations and its translation rule."""

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -25,6 +25,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 from functools import partial
 
+import jaxlib
 import jax
 import jax.numpy as jnp
 from jax import test_util as jtu
@@ -65,6 +66,8 @@ def tearDownModule():
 
 @curry
 def with_mesh(named_shape, f):
+  if not named_shape:
+    return f
   def new_f(*args, **kwargs):
     axis_names, shape = unzip2(named_shape)
     size = np.prod(shape)
@@ -93,6 +96,8 @@ def use_spmd_lowering(f):
 class XMapTest(jtu.JaxTestCase):
 
   def setUp(self):
+    if jaxlib.__version__.split('.') < ['0', '1', '58']:
+      raise SkipTest("xmap requires jaxlib version >= 0.1.58")
     if not config.omnistaging_enabled:
       raise SkipTest("xmap requires omnistaging")
 
@@ -301,6 +306,28 @@ class XMapTest(jtu.JaxTestCase):
     z = f_mapped(x, y)
 
     self.assertAllClose(z, jnp.einsum('nij,njk->nik', x, y))
+
+  @parameterized.named_parameters(
+    {"testcase_name": name, "mesh": mesh, "axis_resources": axis_resources}
+    for name, mesh, axis_resources in (
+      ('', (), ()),
+      ('Mesh', (('x', 2),), (('i', 'x'),))
+    ))
+  @ignore_xmap_warning()
+  def testMultipleCalls(self, mesh, axis_resources):
+    def f(x, y):
+      return x * y
+
+    @with_mesh(mesh)
+    def run_test():
+      f_mapped = xmap(f,
+                      in_axes=(['i', ...], ['j', ...]),
+                      out_axes=['i', 'j', ...],
+                      axis_resources=dict(axis_resources))
+      x = jnp.arange(10).reshape(2, 5)
+      for i in range(10):
+        f_mapped(x, x)
+    run_test()
 
 
 class XMapErrorTest(jtu.JaxTestCase):


### PR DESCRIPTION
When no XLA lowering was involved (i.e. when using a purely vectorized
schedule), we used to return `f.call_wrapped` as the xmapped function.
This obviously didn't end well when someone tried to call it multiple
times, which this patch should fix.