### PR TITLE
Support numpy integers in arr.reshape()

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1294,7 +1294,7 @@ def _reshape_method(a, *newshape, **kwargs):
     invalid_kwargs = "'{}'".format("'".join(kwargs))
     msg = "{} are invalid keyword arguments for this function"
     raise TypeError(msg.format(invalid_kwargs))  # different from NumPy error
-  if (len(newshape) == 1 and not isinstance(newshape[0], int) and
+  if (len(newshape) == 1 and not np.isscalar(newshape[0]) and
           type(newshape[0]) is not Poly):
     newshape = newshape[0]
   return _reshape(a, newshape, order=order)


### PR DESCRIPTION
Test code:
```python
import jax.numpy as jnp
import numpy as np

x = jnp.ones((2, 2))
print(x.reshape(np.prod(x.shape)))
```
Before:
```pytb
Traceback (most recent call last):
  File "tmp.py", line 5, in <module>
    x.reshape(np.prod(x.shape))
  File "/Users/vanderplas/github/google/jax/jax/_src/numpy/lax_numpy.py", line 1300, in _reshape_method
    return _reshape(a, newshape, order=order)
  File "/Users/vanderplas/github/google/jax/jax/_src/numpy/lax_numpy.py", line 1278, in _reshape
    return lax.reshape(a, computed_newshape, None)
  File "/Users/vanderplas/github/google/jax/jax/_src/lax/lax.py", line 719, in reshape
    new_sizes = canonicalize_shape(new_sizes)  # TODO
  File "/Users/vanderplas/github/google/jax/jax/core.py", line 1160, in canonicalize_shape
    if any(isinstance(x, Tracer) and isinstance(get_aval(x), ShapedArray)
TypeError: 'int' object is not iterable
```
After:
```
[1. 1. 1. 1.]
```