### PR TITLE
allow vmapped function to accept kwargs

### DIFF
--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1160,6 +1160,16 @@ class BatchingTest(jtu.JaxTestCase):
     self.assertAllClose(x_bar, jnp.dot(z_bar, y.T))
     self.assertAllClose(y_bar, jnp.dot(x.T, z_bar))
 
+  def testVmapKwargs(self):
+    # https://github.com/google/jax/issues/912
+
+    def f(a, b):
+      return (2*a, 3*b)
+
+    x = vmap(f)(jnp.array([1]), jnp.array([2]))  # works
+    y = vmap(f)(a=jnp.array([1]), b=jnp.array([2]))  # doesn't work
+    self.assertAllClose(x, y)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Arguments passed as keywords are always batched along their leading axis. The in_tree specification must correspond to arguments passed positionally.

This brings vmap in line with pmap. That is, pmap already followed this convention for arguments passed via keywords. Consistency is good!

I had to adapt some utility functions so as not to change the error messages raised. In particular, we have tests for vmap error messages which report the in_axes and argument tree structure; naively including keyword arguments changed those error messages. The error messages are worth preserving. This change also brought the pmap error messages in line with the vmap ones.

I also did some 80char wrapping of lines and docstring updating.

Fixes #912. Another user had the same issue and reported the same expected behavior.