### PR TITLE
Fix SVD on ROCm

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1207,23 +1207,17 @@ def _svd_cpu_gpu_translation_rule(gesvd_impl, c, operand, full_matrices, compute
   s, u, vt, info = gesvd_impl(c, operand,
                               full_matrices=full_matrices,
                               compute_uv=compute_uv)
-  if info is not None:
-    ok = xops.Eq(info, xops.ConstantLiteral(c, np.array(0, np.int32)))
-    s = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), s,
-                             _nan_like(c, s))
-  else:
-    pass # rocsolver does not return info
+  ok = xops.Eq(info, xops.ConstantLiteral(c, np.array(0, np.int32)))
+  s = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1,)), s,
+                           _nan_like(c, s))
 
   result = [s]
 
   if compute_uv:
-    if info is not None:
-      u = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), u,
-                               _nan_like(c, u))
-      vt = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vt,
-                                _nan_like(c, vt))
-    else:
-      pass # rocsolver does not return info
+    u = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), u,
+                             _nan_like(c, u))
+    vt = _broadcasting_select(c, xops.Reshape(ok, batch_dims + (1, 1)), vt,
+                              _nan_like(c, vt))
     result += [u, vt]
 
   return xops.Tuple(c, result)

--- a/jaxlib/rocm_gpu_kernel_helpers.h
+++ b/jaxlib/rocm_gpu_kernel_helpers.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef JAXLIB_GPU_KERNEL_HELPERS_H_
-#define JAXLIB_GPU_KERNEL_HELPERS_H_
+#ifndef JAXLIB_ROCM_GPU_KERNEL_HELPERS_H_
+#define JAXLIB_ROCM_GPU_KERNEL_HELPERS_H_
 
 #include <memory>
 
@@ -34,4 +34,4 @@ std::unique_ptr<void*[]> MakeBatchPointers(hipStream_t stream, void* buffer,
 
 }  // namespace jax
 
-#endif  // JAXLIB_GPU_KERNEL_HELPERS_H_
+#endif  // JAXLIB_ROCM_GPU_KERNEL_HELPERS_H_

--- a/jaxlib/rocsolver.py
+++ b/jaxlib/rocsolver.py
@@ -292,22 +292,22 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
             _Shape.array_shape(dtype, batch_dims + (n, n), matrix_layout),
             # buffers[4] (vt; actually u)
             _Shape.array_shape(dtype, batch_dims + (m, m), matrix_layout),
-            _Shape.array_shape(singular_vals_dtype, (min(m, n) - 1,),
-                               (0,)),  # buffers[5] (e)
             _Shape.array_shape(np.dtype(np.int32), batch_dims,
-                               scalar_layout),  # buffers[6] (info)
+                               scalar_layout),  # buffers[5] (info)
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n) - 1,),
+                               vector_layout),  # buffers[6] (e)
             _Shape.array_shape(np.dtype(np.int8), (lwork,),
                                (0,)),  # buffers[7] (a batch pointers)
         )),
         operand_shapes_with_layout=(
             _Shape.array_shape(dtype, batch_dims + (m, n),
-                               matrix_layout),  # a (buffers[0]))
+                               matrix_layout),  # buffers[0] (a, IN)
         ),
         opaque=opaque)
     s = _ops.GetTupleElement(out, 1)
     vt = _ops.GetTupleElement(out, 2)
     u = _ops.GetTupleElement(out, 3)
-    info = _ops.GetTupleElement(out, 5)
+    info = _ops.GetTupleElement(out, 4)
   else:
     lwork, opaque = rocsolver_kernels.build_gesvd_descriptor(np.dtype(dtype), b, m, n,
                                                              compute_uv, full_matrices)
@@ -327,10 +327,10 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
                                matrix_layout),  # buffers[3] (u)
             _Shape.array_shape(dtype, batch_dims + (n, n),
                                matrix_layout),  # buffers[4] (vt)
-            _Shape.array_shape(singular_vals_dtype, (min(m, n) - 1,),
-                               (0,)),  # buffers[5] (e)
             _Shape.array_shape(np.dtype(np.int32), batch_dims,
-                               scalar_layout),  # buffers[6] (info)
+                               scalar_layout),  # buffers[5] (info)
+            _Shape.array_shape(singular_vals_dtype, batch_dims + (min(m, n) - 1,),
+                               vector_layout),  # buffers[6] (e)
             _Shape.array_shape(np.dtype(np.int8), (lwork,),
                                (0,)),  # buffers[7] (a batch pointers)
         )),
@@ -342,7 +342,7 @@ def gesvd(c, a, full_matrices=True, compute_uv=True):
     s = _ops.GetTupleElement(out, 1)
     u = _ops.GetTupleElement(out, 2)
     vt = _ops.GetTupleElement(out, 3)
-    info = _ops.GetTupleElement(out, 5)
+    info = _ops.GetTupleElement(out, 4)
   if not full_matrices:
     u = _ops.Slice(u, (0,) * len(dims), batch_dims + (m, min(m, n)), (1,) * len(dims))
     vt = _ops.Slice(vt, (0,) * len(dims), batch_dims + (min(m, n), n), (1,) * len(dims))


### PR DESCRIPTION
Fixes the order of the buffers and the size of the buffer for `E` when batched (which I got wrong in https://github.com/google/jax/pull/5115).
Also info is returned, so that workaround is not necessary for gesvd.

@hawkinsp 