### PR TITLE
Support numpy int in reduction axis

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1908,13 +1908,12 @@ def _reduction_dims(a, axis):
   if axis is None:
     return tuple(range(ndim(a)))
   elif isinstance(axis, (np.ndarray, tuple, list)):
+    axis = tuple(_canonicalize_axis(x, ndim(a)) for x in axis)
     if len(axis) != len(set(axis)):
       raise ValueError(f"duplicate value in 'axis': {axis}")
-    return tuple(_canonicalize_axis(x, ndim(a)) for x in axis)
-  elif isinstance(axis, int):
-    return (_canonicalize_axis(axis, ndim(a)),)
+    return axis
   else:
-    raise TypeError("Unexpected type of axis argument: {}".format(type(axis)))
+    return (_canonicalize_axis(axis, ndim(a)),)
 
 def _reduction_init_val(a, init_val):
   a_dtype = dtypes.canonicalize_dtype(_dtype(a))


### PR DESCRIPTION
This fixes handling of some corner cases in the `axis` argument for reductions, including supporting numpy and jax.numpy integers.

Before:
```python
>>> jnp.arange(4).sum(np.int32(0))
<...>
TypeError: Unexpected type of axis argument: <class 'numpy.int32'>

>>> jnp.ones((2, 2)).sum((jnp.int32(0),))    
<...>
TypeError: JAX DeviceArray, like numpy.ndarray, is not hashable.
```
After:
```python
>>> jnp.arange(4).sum(np.int32(0))
DeviceArray(6, dtype=int32)

>>> jnp.ones((2, 2)).sum((jnp.int32(0),))
DeviceArray([2., 2.], dtype=float32)
```
Compare to Numpy:
```python
>>> np.arange(4).sum(np.int32(0))                                                                                                         
6

>>> np.ones((2, 2)).sum((jnp.int32(0),))                                                                                                  
array([2., 2.])
```