### PR TITLE
Validate axes values in reduce_op_shape_rule

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4996,6 +4996,8 @@ def _reduce_op_shape_rule(operand, *, axes, input_shape=None):
   del input_shape  # Unused.
   if len(axes) != len(set(axes)):
     raise ValueError(f"duplicate value in 'axes' of reduction: {axes}")
+  if not all(0 <= a < operand.ndim for a in axes):
+    raise ValueError(f"reduction axes {axes} contains out-of-bounds indices for {operand}.")
   return tuple(np.delete(operand.shape, axes))
 
 def _reduce_prod_translation_rule(c, operand, *, axes):


### PR DESCRIPTION
Before:
```python
>>> lax.reduce(jnp.arange(4), 0, lax.add, (-1,))
RuntimeError: Invalid argument: Reducing out-of-bounds dimension -1 in shape s32[4].: 
This is a bug in JAX's shape-checking rules; please report it!
https://github.com/google/jax/issues
```
After:
```python
>>> lax.reduce(jnp.arange(4), 0, lax.add, (-1,))
ValueError: reduction axes (-1,) contains out-of-bounds indices for ShapedArray(int32[4])
```