### PR TITLE
Support general int axes in jnp.tile()

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2619,10 +2619,13 @@ def stack(arrays, axis: int =0, out=None):
 @_wraps(np.tile)
 def tile(A, reps):
   _check_arraylike("tile", A)
-  if isinstance(reps, int):
+  try:
+    iter(reps)
+  except TypeError:
     reps = (reps,)
+  reps = tuple(operator.index(rep) for rep in reps)
   A_shape = (1,) * (len(reps) - ndim(A)) + shape(A)
-  reps = (1,) * (len(A_shape) - len(reps)) + tuple(reps)
+  reps = (1,) * (len(A_shape) - len(reps)) + reps
   result = broadcast_to(reshape(A, [j for i in A_shape for j in [1, i]]),
                         [k for pair in zip(reps, A_shape) for k in pair])
   return reshape(result, tuple(np.multiply(A_shape, reps)))


### PR DESCRIPTION
Before:
```python
>>> jnp.tile(jnp.zeros((2, 2)), jnp.int32(2))
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
~/github/google/jax/jax/interpreters/xla.py in __len__(self)
   1202     try:
-> 1203       return self.aval.shape[0]
   1204     except IndexError as err:

IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
<ipython-input-2-fe7318fba756> in <module>
----> 1 jnp.tile(jnp.zeros((2, 2)), jnp.int32(2))

~/github/google/jax/jax/_src/numpy/lax_numpy.py in tile(A, reps)
   2622   if isinstance(reps, int):
   2623     reps = (reps,)
-> 2624   A_shape = (1,) * (len(reps) - ndim(A)) + shape(A)
   2625   reps = (1,) * (len(A_shape) - len(reps)) + tuple(reps)
   2626   result = broadcast_to(reshape(A, [j for i in A_shape for j in [1, i]]),

~/github/google/jax/jax/interpreters/xla.py in __len__(self)
   1203       return self.aval.shape[0]
   1204     except IndexError as err:
-> 1205       raise TypeError("len() of unsized object") from err  # same as numpy error
   1206 
   1207   setattr(device_array, "__len__", __len__)

TypeError: len() of unsized object
```
After:
```python
>>> jnp.tile(jnp.zeros((2, 2)), jnp.int32(2))
DeviceArray([[0., 0., 0., 0.],
             [0., 0., 0., 0.]], dtype=float32)
```
Compare to numpy:
```python
>>> np.tile(np.zeros((2, 2)), np.int32(2))
array([[0., 0., 0., 0.],
       [0., 0., 0., 0.]])
```