### PR TITLE
Better error messages for test_util.check_grads()

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -124,13 +124,13 @@ default_gradient_tolerance = {
   np.dtype(np.complex128): 1e-5,
 }
 
-def _assert_numpy_allclose(a, b, atol=None, rtol=None):
+def _assert_numpy_allclose(a, b, atol=None, rtol=None, err_msg=''):
   a = a.astype(np.float32) if a.dtype == _dtypes.bfloat16 else a
   b = b.astype(np.float32) if b.dtype == _dtypes.bfloat16 else b
   kw = {}
   if atol: kw["atol"] = atol
   if rtol: kw["rtol"] = rtol
-  np.testing.assert_allclose(a, b, **kw)
+  np.testing.assert_allclose(a, b, **kw, err_msg=err_msg)
 
 def tolerance(dtype, tol=None):
   tol = {} if tol is None else tol
@@ -155,19 +155,20 @@ def join_tolerance(tol1, tol2):
     out[k] = max(v, tol1.get(k, 0))
   return out
 
-def _assert_numpy_close(a, b, atol=None, rtol=None):
+def _assert_numpy_close(a, b, atol=None, rtol=None, err_msg=''):
   assert a.shape == b.shape
   atol = max(tolerance(a.dtype, atol), tolerance(b.dtype, atol))
   rtol = max(tolerance(a.dtype, rtol), tolerance(b.dtype, rtol))
-  _assert_numpy_allclose(a, b, atol=atol * a.size, rtol=rtol * b.size)
+  _assert_numpy_allclose(a, b, atol=atol * a.size, rtol=rtol * b.size,
+                         err_msg=err_msg)
 
+def check_eq(xs, ys, err_msg=''):
+  assert_close = partial(_assert_numpy_allclose, err_msg=err_msg)
+  tree_all(tree_multimap(assert_close, xs, ys))
 
-def check_eq(xs, ys):
-  tree_all(tree_multimap(_assert_numpy_allclose, xs, ys))
-
-
-def check_close(xs, ys, atol=None, rtol=None):
-  assert_close = partial(_assert_numpy_close, atol=atol, rtol=rtol)
+def check_close(xs, ys, atol=None, rtol=None, err_msg=''):
+  assert_close = partial(_assert_numpy_close, atol=atol, rtol=rtol,
+                         err_msg=err_msg)
   tree_all(tree_multimap(assert_close, xs, ys))
 
 def _check_dtypes_match(xs, ys):
@@ -229,7 +230,8 @@ def _merge_tolerance(tol, default):
     out[np.dtype(k)] = v
   return out
 
-def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS):
+
+def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   atol = _merge_tolerance(atol, default_gradient_tolerance)
   rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   rng = np.random.RandomState(0)
@@ -242,24 +244,29 @@ def check_jvp(f, f_jvp, args, atol=None, rtol=None, eps=EPS):
   # In principle we should expect exact equality of v_out and v_out_expected,
   # but due to nondeterminism especially on GPU (e.g., due to convolution
   # autotuning) we only require "close".
-  check_close(v_out, v_out_expected, atol=atol, rtol=rtol)
-  check_close(t_out, t_out_expected, atol=atol, rtol=rtol)
+  check_close(v_out, v_out_expected, atol=atol, rtol=rtol,
+              err_msg=f'{err_msg} primal' if err_msg else 'primal')
+  check_close(t_out, t_out_expected, atol=atol, rtol=rtol,
+              err_msg=f'{err_msg} tangent' if err_msg else 'tangent')
 
 
-def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS):
+def check_vjp(f, f_vjp, args, atol=None, rtol=None, eps=EPS, err_msg=''):
   atol = _merge_tolerance(atol, default_gradient_tolerance)
   rtol = _merge_tolerance(rtol, default_gradient_tolerance)
   _rand_like = partial(rand_like, np.random.RandomState(0))
   v_out, vjpfun = f_vjp(*args)
   v_out_expected = f(*args)
-  check_close(v_out, v_out_expected, atol=atol, rtol=rtol)
+  check_close(v_out, v_out_expected, atol=atol, rtol=rtol,
+              err_msg=f'{err_msg} primal' if err_msg else 'primal')
   tangent = tree_map(_rand_like, args)
   tangent_out = numerical_jvp(f, args, tangent, eps=eps)
   cotangent = tree_map(_rand_like, v_out)
   cotangent_out = conj(vjpfun(conj(cotangent)))
   ip = inner_prod(tangent, cotangent_out)
   ip_expected = inner_prod(tangent_out, cotangent)
-  check_close(ip, ip_expected, atol=atol, rtol=rtol)
+  check_close(ip, ip_expected, atol=atol, rtol=rtol,
+              err_msg=(f'{err_msg} cotangent projection'
+                       if err_msg else 'cotangent projection'))
 
 
 def check_grads(f, args, order,
@@ -288,19 +295,21 @@ def check_grads(f, args, order,
   _check_jvp = partial(check_jvp, atol=atol, rtol=rtol, eps=eps)
   _check_vjp = partial(check_vjp, atol=atol, rtol=rtol, eps=eps)
 
-  def _check_grads(f, args, order):
+  def _check_grads(f, args, order, err_msg=''):
     if "fwd" in modes:
-      _check_jvp(f, partial(api.jvp, f), args)
+      fwd_msg = f'JVP of {err_msg}' if err_msg else 'JVP'
+      _check_jvp(f, partial(api.jvp, f), args, err_msg=fwd_msg)
       if order > 1:
-        _check_grads(partial(api.jvp, f), (args, args), order - 1)
+        _check_grads(partial(api.jvp, f), (args, args), order - 1, fwd_msg)
 
     if "rev" in modes:
-      _check_vjp(f, partial(api.vjp, f), args)
+      rev_msg = f'VJP of {err_msg}' if err_msg else 'VJP'
+      _check_vjp(f, partial(api.vjp, f), args, err_msg=rev_msg)
       if order > 1:
         def f_vjp(*args):
           out_primal_py, vjp_py = api.vjp(f, *args)
           return vjp_py(out_primal_py)
-        _check_grads(f_vjp, args, order - 1)
+        _check_grads(f_vjp, args, order - 1, rev_msg)
 
   _check_grads(f, args, order)
 


### PR DESCRIPTION
Rather than merely reporting a failure in check_grads(), we now
report the *specific* check that failed, e.g., "JVP tangent" or
"VJP of JVP cotangent projection". Gradient tests often fail for
spurious reasons (e.g., due to insufficient precision), so this should
be helpful for debugging.

I tested this manually by relaxing the tolerance for a test in
`linalg_test.py`.