### PR TITLE
Fix host_callback when there are non-local devices.

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1516,7 +1516,8 @@ def _initialize_outfeed_receiver(
       clients = xla_client._get_local_backends().values()  # type: ignore[protected-class]
       # Drop the interpreter clients
       clients = tuple([c for c in clients if c.platform != "interpreter"])  # type: ignore
-    devices = list(itertools.chain(*[backend.devices() for backend in clients]))
+    devices = list(
+        itertools.chain(*[backend.local_devices() for backend in clients]))
     _outfeed_receiver.clients = clients  # type: ignore[assignment]
     _outfeed_receiver.devices = devices  # type: ignore[assignment]
     logging.vlog(


### PR DESCRIPTION
In combination with a recent change in the outfeed_receiver in the XLA
repository:
https://github.com/tensorflow/tensorflow/commit/ed2134ae4327e1e09ed3808e748489405a845382
this allows host_callback to work correctly in a multi-host TPU setup.

In a multi-host TPU setup we have a situation where not all devices are
local.  However, it is only actually possible to obtain outfeed data
from local devices, in general. Prior to the XLA change linked above,
the presence of non-local devices would result in the outfeed_receiver
trying to obtain outfeed data for these, which would immediately error
(e.g. "Invalid argument: Device TPU_10(host=0,(1,1,0,0)) is not a local
device."). With the XLA change, this error no longer occurs, but there
is still a problem because host_callback currently assumes all devices
are listening for outfeed, rather than just the local ones - e.g.
barrier_wait would wait for more outfeeds that are actually obtainable,
in the multi-host case. This change fixes that issue and allows id_tap
and similar to work as expected.