### PR TITLE
jnp.power: use integer_power path in all applicable cases

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -579,11 +579,15 @@ def _float_divmod(x1, x2):
 
 @_wraps(np.power)
 def power(x1, x2):
-  # Special case for small positive integer scalars: use binary exponentiation.
+  # Special case for concrete integer scalars: use binary exponentiation.
   # Using lax.pow may be imprecise for floating-point values; the goal of this
   # code path is to make sure we end up with a precise output for the common
   # pattern ``x ** 2`` or similar.
-  if isinstance(x2, int):
+  try:
+    x2 = core.concrete_or_error(operator.index, x2)
+  except (core.ConcretizationTypeError, TypeError):
+    pass
+  else:
     return lax.integer_pow(x1, x2)
 
   x1, x2 = _promote_args("power", x1, x2)


### PR DESCRIPTION
Previously the integer power path was chosen only if `x2` was a Python integer; after this change, the integer power path is chosen for any concrete integer scalar.

As a consequence, some previously incorrect results are now loud failures. For example:

Before:
```python
>>> jnp.power(2, jnp.int32(-1))
DeviceArray(0, dtype=int32)
```
After:
```python
>>> jnp.power(2, jnp.int32(-1))
<...>
TypeError: Integers cannot be raised to negative powers, got integer_pow(ShapedArray(int32[], weak_type=True), -1)
```
Compare to Numpy:
```python
np.power(2, np.int32(-1))                                                                                                             
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-b3a3e57b684d> in <module>
----> 1 np.power(2, np.int32(-1))

ValueError: Integers to negative integer powers are not allowed.
```