### PR TITLE
disable test that requires omnistaging

### DIFF
--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -273,6 +273,8 @@ class HostCallbackIdTapTest(jtu.JaxTestCase):
                                  testing_stream.output)
     testing_stream.reset()
 
+  @skipIf(not config.omnistaging_enabled,
+          "test works only with omnistaging enabled")
   def test_tap_result_unused(self):
     def tap_func(arg, transforms):
       testing_stream.write(f"called tap_func with {arg}")


### PR DESCRIPTION
Fixes breakage introduced in https://github.com/google/jax/pull/5422