### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -566,7 +566,7 @@ def switch(index, branches: Sequence[Callable], operand):
       index = clamp(0, index, len(branches) - 1)
       return branches[index](operand)
 
-  Arguments:
+  Args:
     index: Integer scalar type, indicating which branch function to apply.
     branches: Sequence of functions (A -> B) to be applied based on `index`.
     operand: Operand (A) input to whichever branch is applied.
@@ -643,7 +643,7 @@ def cond(*args, **kwargs):
         operand=None)
 
 
-  Arguments:
+  Args:
     pred: Boolean scalar type, indicating which branch function to apply.
     true_fun: Function (A -> B), to be applied if ``pred`` is True.
     false_fun: Function (A -> B), to be applied if ``pred`` is False.

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1437,7 +1437,7 @@ def tie_in(x: Array, y: Array) -> Array:
 def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Array:
   """Returns an array of `shape` filled with `fill_value`.
 
-  Arguments:
+  Args:
     shape: sequence of integers, describing the shape of the output array.
     fill_value: the value to fill the new array with.
     dtype: the type of the output array, or `None`. If not `None`, `fill_value`

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -512,7 +512,7 @@ def axis_groups(axis_env: AxisEnv, name):
 def _axis_groups(mesh_spec, mesh_axes):
   """Computes replica group ids for a collective performed over a subset of the mesh.
 
-  Arguments:
+  Args:
     mesh_spec: A sequence of integers representing the mesh shape.
     mesh_axes: A sequence of integers between 0 and `len(mesh_spec)` (exclusive)
       indicating over which axes the collective is performed.

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -109,7 +109,7 @@ class Store(object):
 class WrappedFun(object):
   """Represents a function `f` to which `transforms` are to be applied.
 
-  Arguments:
+  Args:
     f: the function to be transformed.
     transforms: a list of `(gen, gen_static_args)` tuples representing
       transformations to apply to `f.` Here `gen` is a generator function


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the JAX codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings:

```sh
(jax#c5d628)$ for name in 'Args:' 'Arguments:'; do
    printf '%-10s %04d\n' "$name" "$(rg -IFtpy --count-matches "$name" | paste -s -d+ -- | bc)"; done
Args:      0217
Arguments: 0005
```

It is easy enough to extend my parsers to support both variants, howevever it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)
  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)
  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the JAX codebase.

PS: For similar contributed to the [TensorFlow](https://github.com/tensorflow/tensorflow), [keras-team](https://github.com/keras-team), and [PyTorch](https://github.com/pytorch/pytorch) organisations, see trackbacks at https://github.com/tensorflow/tensorflow/pull/45420.