### PR TITLE
[jax2tf] Cleanup the way jax2tf limitations are specified

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -126,7 +126,7 @@ for CUDA. One must be mindful to install a version of CUDA that is compatible
 with both [jaxlib](https://github.com/google/jax/blob/master/README.md#pip-installation) and
 [TensorFlow](https://www.tensorflow.org/install/source#tested_build_configurations).
 
-As of today, the tests are run using `tf_nightly==2.5.0-dev20210107`.
+As of today, the tests are run using `tf_nightly==2.5.0-dev20210114`.
 
 ## Caveats
 

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,10 +1,10 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2020-12-31* (YYYY-MM-DD)
+*Last generated on: 2021-01-15* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
-We use a set of 2305 test harnesses to test
+We use a set of 2313 test harnesses to test
 the implementation of 122 numeric JAX primitives.
 We consider a JAX primitive supported for a particular data
 type if it is supported on at least one device type.
@@ -31,6 +31,11 @@ We use below the following abbreviations for sets of dtypes:
 
 See the comment in `primitive_harness.py` for a description
 of test harnesses and their definitions.
+
+Note that automated tests will fail if new limitations appear, but
+they won't when limitations are fixed. If you see a limitation that
+you think it does not exist anymore, please ask for this file to
+be updated.
 
 
 | Primitive | Total test harnesses | dtypes supported on at least one device | dtypes NOT tested on any device |
@@ -143,7 +148,7 @@ of test harnesses and their definitions.
 | sin | 6 | inexact | bool, integer |
 | sinh | 6 | inexact | bool, integer |
 | slice | 24 | all |  |
-| sort | 21 | all |  |
+| sort | 29 | all |  |
 | sqrt | 6 | inexact | bool, integer |
 | squeeze | 23 | all |  |
 | stop_gradient | 15 | all |  |

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md.template
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md.template
@@ -32,6 +32,11 @@ We use below the following abbreviations for sets of dtypes:
 See the comment in `primitive_harness.py` for a description
 of test harnesses and their definitions.
 
+Note that automated tests will fail if new limitations appear, but
+they won't when limitations are fixed. If you see a limitation that
+you think it does not exist anymore, please ask for this file to
+be updated.
+
 {{primitive_coverage_table}}
 
 ## Partially implemented data types for primitives

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,4 +1,4 @@
-# Primitives with limited support
+# Primitives with limited support for jax2tf
 
 *Last generated on (YYYY-MM-DD): 2021-01-15*
 
@@ -12,6 +12,10 @@ There are several kinds of limitations.
   * There are some cases when the converted program computes different results than
   the JAX program, see [below](#generated-summary-of-primitives-with-known-numerical-discrepancies-in-tensorflow).
 
+Note that automated tests will fail if new limitations appear, but
+they won't when limitations are fixed. If you see a limitation that
+you think it does not exist anymore, please ask for this file to
+be updated.
 
 ## Generated summary of primitives with unimplemented support in Tensorflow
 
@@ -59,7 +63,6 @@ More detailed information can be found in the
 | asin | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | asin | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | asinh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
-| asinh | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | atan | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | atan | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | atan2 | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
@@ -68,10 +71,9 @@ More detailed information can be found in the
 | bessel_i1e | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | bitcast_convert_type | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | cholesky | TF error: function not compilable | complex | cpu, gpu | compiled |
-| cholesky | TF error: op not defined for dtype | complex | tpu | compiled |
+| cholesky | TF error: op not defined for dtype | complex | tpu | compiled, graph |
 | clamp | TF error: op not defined for dtype | int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | conv_general_dilated | TF test skipped: TF error: TODO: TF/LLVM crash | complex | gpu | compiled, eager, graph |
-| conv_general_dilated | TF error: XLA bug in the HLO -> LLVM IR lowering | complex | cpu, gpu | compiled, eager, graph |
 | conv_general_dilated | TF error: jax2tf BUG: batch_group_count > 1 not yet converted | all | cpu, gpu, tpu | compiled, eager, graph |
 | cosh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
 | cummax | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
@@ -82,7 +84,7 @@ More detailed information can be found in the
 | cumprod | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
 | cumsum | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
 | cumsum | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| cumsum | TF error: op not defined for dtype | complex64 | tpu | compiled |
+| cumsum | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
 | div | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
@@ -110,7 +112,7 @@ More detailed information can be found in the
 | lt | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
 | lt | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
 | lt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
-| lu | TF error: op not defined for dtype | complex64 | tpu | compiled |
+| lu | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | max | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
 | max | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | min | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
@@ -119,7 +121,7 @@ More detailed information can be found in the
 | neg | TF error: op not defined for dtype | unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | nextafter | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | population_count | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu | eager, graph |
-| qr | TF error: op not defined for dtype | bfloat16 | tpu | compiled |
+| qr | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
 | reduce_max | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_max | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
@@ -136,29 +138,31 @@ More detailed information can be found in the
 | reduce_window_mul | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
 | regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
-| rem | TF error: op not defined for dtype | float16 | cpu, gpu, tpu | eager, graph |
+| rem | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
 | rem | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | rev | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | round | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | rsqrt | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
-| scatter_add | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_add | TF error: op not defined for dtype | bool, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_add | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | scatter_max | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
-| scatter_mul | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
-| select_and_gather_add | TF error: This JAX primitives is not not exposed directly in the JAX API but arises from JVP of `lax.reduce_window` for reducers `lax.max` or `lax.min`. It also arises from second-order VJP of the same. Implemented using XlaReduceWindow | float32 | tpu | compiled |
+| scatter_mul | TF error: op not defined for dtype | bool, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_mul | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
+| select_and_gather_add | TF error: This JAX primitives is not not exposed directly in the JAX API but arises from JVP of `lax.reduce_window` for reducers `lax.max` or `lax.min`. It also arises from second-order VJP of the same. Implemented using XlaReduceWindow | float32 | tpu | compiled, eager, graph |
 | select_and_gather_add | TF error: jax2tf unimplemented for 64-bit inputs because the current implementation relies on packing two values into a single value. This can be fixed by using a variadic XlaReduceWindow, when available | float64 | cpu, gpu | compiled, eager, graph |
 | select_and_scatter_add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
 | select_and_scatter_add | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
 | sign | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | sinh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
-| sort | TF error: op not defined for dtype | complex, float64 | cpu, gpu | compiled, eager, graph |
+| sort | TF error: op not defined for dtype | complex128, float64 | cpu, gpu | compiled, eager, graph |
 | sort | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | sub | TF error: op not defined for dtype | uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | svd | TF error: function not compilable. Implemented using `tf.linalg.svd` and `tf.linalg.adjoint` | complex | cpu, gpu | compiled |
-| svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled |
+| svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
 | top_k | TF error: op not defined for dtype | int64, uint64 | cpu, gpu | compiled |
 | triangular_solve | TF error: op not defined for dtype | bfloat16 | cpu, gpu, tpu | compiled, eager, graph |
-| triangular_solve | TF error: op not defined for dtype | float16 | cpu, gpu, tpu | eager, graph |
+| triangular_solve | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
 
 ## Generated summary of primitives with known numerical discrepancies in Tensorflow
 
@@ -168,24 +172,24 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices | Affected compilation modes |
 | --- | --- | --- | --- | --- | ---|
-| acos | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
-| acosh | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
-| asin | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
-| asinh | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
-| atan | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
-| atanh | May return different but still correct results | complex | cpu, gpu, tpu | compiled, eager, graph |
+| acos | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| acosh | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| asin | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| asinh | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| atan | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
+| atanh | May return different but still correct results | complex | cpu, gpu, tpu | eager, graph |
 | cholesky | May return different values in the strictly upper triangular part of the result. This does not matter for correctness, because this part of the matrix is not considered in the result. | all | cpu, gpu, tpu | compiled, eager, graph |
-| custom_linear_solve | Numeric comparision disabled: TODO: large numerical discrepancy | float32 | tpu | compiled |
+| custom_linear_solve | Numeric comparision disabled: TODO: large numerical discrepancy | float32 | tpu | compiled, eager, graph |
 | digamma | May return different results at singularity points 0 and -1.JAX returns nan and TF returns inf | bfloat16 | cpu, gpu, tpu | eager, graph |
 | eig | May return the eigenvalues and eigenvectors in a potentially different order. The eigenvectors may also be different, but equally valid. | all | cpu, gpu, tpu | eager, graph |
 | eigh | May return the eigenvalues and eigenvectors in a potentially different order. The eigenvectors may also be different, but equally valid. | all | cpu, gpu, tpu | compiled, eager, graph |
 | eigh | Numeric comparision disabled: TODO: numeric discrepancies | float64 | cpu, gpu | compiled |
-| eigh | Numeric comparision disabled: TODO: numeric discrepancies | float16 | tpu | compiled |
+| eigh | Numeric comparision disabled: TODO: numeric discrepancies | float16 | tpu | compiled, eager, graph |
 | erf_inv | May return different results at undefined points (< -1 or > 1): JAX returns `NaN` and TF returns `+inf` or `-inf`. | float32, float64 | cpu, gpu, tpu | compiled, eager, graph |
 | igamma | May return different results at undefined points (both arguments 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu, tpu | eager, graph |
-| igammac | May return different results at undefined points (both arguments less or equal 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu, tpu | eager, graph |
+| igammac | May return different results at undefined points (both arguments less or equal 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu | eager, graph |
 | integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents.  | float32, int32, int64 | cpu, gpu, tpu | compiled, eager, graph |
-| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents. It and `+inf`/`-inf` differently in JAX and TF. | complex64 | tpu | compiled |
+| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents. It and `+inf`/`-inf` differently in JAX and TF. | complex64 | tpu | compiled, eager, graph |
 | integer_pow | custom numeric comparison | complex | cpu, gpu, tpu | compiled, eager, graph |
 | lu | May return different, but also correct, results when the decomposition is not unique | all | cpu, gpu, tpu | compiled, eager, graph |
 | max | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md.template
@@ -1,4 +1,4 @@
-# Primitives with limited support
+# Primitives with limited support for jax2tf
 
 *Last generated on (YYYY-MM-DD): {{generation_date}}*
 
@@ -12,6 +12,10 @@ There are several kinds of limitations.
   * There are some cases when the converted program computes different results than
   the JAX program, see [below](#generated-summary-of-primitives-with-known-numerical-discrepancies-in-tensorflow).
 
+Note that automated tests will fail if new limitations appear, but
+they won't when limitations are fixed. If you see a limitation that
+you think it does not exist anymore, please ask for this file to
+be updated.
 
 ## Generated summary of primitives with unimplemented support in Tensorflow
 

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -74,8 +74,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     if isinstance(modes, str):
       modes = (modes,)
     assert all(m in ["eager", "graph", "compiled"] for m in modes)
-    if devices == ("tpu",):
-      assert modes == ("compiled",), f"{modes}"
     self.modes = modes
     self.expect_tf_error = expect_tf_error
     self.skip_tf_run = skip_tf_run
@@ -153,15 +151,19 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         description="May return different but still correct results",
         dtypes=[np.complex64, np.complex128],
         custom_assert=custom_assert,
-        also_compiled=True)
+        modes=("eager", "graph"))
 
   @classmethod
   def acos(cls, harness: primitive_harness.Harness):
     return [
         missing_tf_kernel(
             dtypes=[np.float16, dtypes.bfloat16, np.complex64],
-            devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.complex128], devices=("cpu", "gpu")),
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
+        missing_tf_kernel(
+            dtypes=[np.complex128],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.complex128, tol=1e-13),
         custom_numeric(dtypes=np.complex64, devices="tpu", tol=1e-3),
         custom_numeric(dtypes=np.complex64, devices=("cpu", "gpu"), tol=1e-4),
@@ -173,7 +175,8 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     return [
         missing_tf_kernel(
             dtypes=[dtypes.bfloat16, np.float16],
-            devices=("cpu", "gpu")),
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.complex64, devices=("cpu", "gpu"), tol=1e-3),
         custom_numeric(dtypes=np.complex128, devices=("cpu", "gpu"), tol=1e-12),
         cls.helper_get_trig_custom_limitation(np.cosh)
@@ -182,33 +185,33 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def add(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.uint16], also_compiled=True),
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-            also_compiled=True)
+        missing_tf_kernel(dtypes=[np.uint16]),
+        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
     ]
 
   @classmethod
   # Also called add_jaxvals
   def add_any(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.uint16, np.uint32, np.uint64], also_compiled=True)
-    ]
+    return [missing_tf_kernel(dtypes=[np.uint16, np.uint32, np.uint64])]
 
   @classmethod
   def asin(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.complex64, np.complex128], also_compiled=True),
+        missing_tf_kernel(
+            dtypes=[np.float16, dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
+        missing_tf_kernel(dtypes=[np.complex64, np.complex128]),
         cls.helper_get_trig_custom_limitation(np.sin)
     ]
 
   @classmethod
   def asinh(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.complex64, np.complex128], also_compiled=True),
+        missing_tf_kernel(
+            dtypes=[np.float16, dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.complex64, devices=("cpu", "gpu"), tol=1e-3),
         custom_numeric(dtypes=np.complex128, devices=("cpu", "gpu"), tol=1e-12),
         cls.helper_get_trig_custom_limitation(np.sinh)
@@ -217,15 +220,21 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def atan(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.complex64, np.complex128], also_compiled=True),
+        missing_tf_kernel(
+            dtypes=[np.float16, dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
+        missing_tf_kernel(dtypes=[np.complex64, np.complex128]),
         cls.helper_get_trig_custom_limitation(np.tan)
     ]
 
   @classmethod
   def atanh(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], devices=("cpu", "gpu")),
+        missing_tf_kernel(
+            dtypes=[np.float16, dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.float64, tol=1e-14),
         custom_numeric(dtypes=np.complex64, tol=1e-3),
         custom_numeric(dtypes=np.complex128, devices=("cpu", "gpu"), tol=1e-12),
@@ -235,13 +244,19 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def atan2(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[np.float16, dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
   def bessel_i0e(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -250,7 +265,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def bitcast_convert_type(cls, harness: primitive_harness.Harness):
-    return [missing_tf_kernel(dtypes=[np.bool_], also_compiled=True)]
+    return [missing_tf_kernel(dtypes=[np.bool_])]
 
   @classmethod
   def cholesky(cls, harness: primitive_harness.Harness):
@@ -272,23 +287,24 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             # mode, but fails otherwise.
             dtypes=[np.complex64, np.complex128],
             devices="tpu",
-            modes="compiled"),
+            modes=("graph", "compiled")),
         # TODO(bchetioui): very high discrepancy in the float32/complex64 case
         custom_numeric(dtypes=[np.float32, np.complex64], tol=1e-2),
         custom_numeric(dtypes=[np.float64, np.complex128], tol=1e-6),
         custom_numeric(dtypes=[dtypes.bfloat16, np.float16], tol=5e-2),
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=True,
+            custom_assert=custom_assert,
             description=(
                 "May return different values in the strictly upper triangular "
                 "part of the result. This does not matter for correctness, "
-                "because this part of the matrix is not considered in the result."))
+                "because this part of the matrix is not considered in the result."
+            ))
     ]
 
   @classmethod
   def clamp(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.int8, np.uint16, np.uint32, np.uint64], also_compiled=True)
+        missing_tf_kernel(dtypes=[np.int8, np.uint16, np.uint32, np.uint64])
     ]
 
   @classmethod
@@ -350,7 +366,10 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def cosh(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[np.float16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -359,10 +378,9 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[np.uint64, np.complex128],
             devices=("cpu", "gpu"),
-            also_compiled=True),
+        ),
         missing_tf_kernel(
-            dtypes=[np.uint16, np.uint32, np.int8, np.complex64],
-            also_compiled=True),
+            dtypes=[np.uint16, np.uint32, np.int8, np.complex64],),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5)
     ]
@@ -373,10 +391,9 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[np.uint64, np.complex128],
             devices=("cpu", "gpu"),
-            also_compiled=True),
+        ),
         missing_tf_kernel(
-            dtypes=[np.uint16, np.uint32, np.int8, np.complex64],
-            also_compiled=True),
+            dtypes=[np.uint16, np.uint32, np.int8, np.complex64],),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5),
     ]
@@ -387,8 +404,8 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[np.uint64],
             devices=("cpu", "gpu"),
-            also_compiled=True),
-        missing_tf_kernel(dtypes=[np.uint32], also_compiled=True),
+        ),
+        missing_tf_kernel(dtypes=[np.uint32]),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5),
     ]
@@ -399,9 +416,9 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[np.uint64],
             devices=("cpu", "gpu"),
-            also_compiled=True),
-        missing_tf_kernel(dtypes=[np.complex64], devices="tpu", modes="compiled"),
-        missing_tf_kernel(dtypes=[np.uint16, np.uint32], also_compiled=True),
+        ),
+        missing_tf_kernel(dtypes=[np.complex64], devices="tpu"),
+        missing_tf_kernel(dtypes=[np.uint16, np.uint32]),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5),
     ]
@@ -413,7 +430,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             "TODO: large numerical discrepancy",
             dtypes=np.float32,
             devices="tpu",
-            modes="compiled",
             expect_tf_error=False,
             skip_comparison=True),
         custom_numeric(dtypes=np.float32, devices="tpu", tol=0.01),
@@ -444,22 +460,28 @@ class Jax2TfLimitation(primitive_harness.Limitation):
           rtol=tol)
 
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu")),
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.float64, tol=1e-13),
         custom_numeric(dtypes=np.float32, devices=["cpu", "gpu"], tol=1e-3),
         custom_numeric(
-            dtypes=dtypes.bfloat16, custom_assert=custom_assert,
+            dtypes=dtypes.bfloat16,
+            custom_assert=custom_assert,
             description=(
                 "May return different results at singularity points 0 and -1."
-                "JAX returns nan and TF returns inf"))
+                "JAX returns nan and TF returns inf"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
   def div(cls, harness: primitive_harness.Harness):
     return [
         missing_tf_kernel(
-            dtypes=[np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16],
-            also_compiled=True),
+            dtypes=[
+                np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16
+            ],),
         Jax2TfLimitation(
             "TF integer division fails if divisor contains 0; JAX returns NaN",
             dtypes=[
@@ -477,16 +499,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             dtypes=[
                 np.bool_, np.uint8, np.uint16, np.uint32, np.uint64, np.int8,
                 np.int16
-            ],
-            also_compiled=True),
+            ],),
         missing_tf_kernel(
-            dtypes=[np.int64],
-            devices=("cpu", "gpu"),
-            modes="compiled"),
+            dtypes=[np.int64], devices=("cpu", "gpu"), modes="compiled"),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.3),
         custom_numeric(
-            dtypes=[np.complex64, np.float32],
-            devices=("cpu", "gpu"),
+            dtypes=[np.complex64, np.float32], devices=("cpu", "gpu"),
             tol=1e-5),
         custom_numeric(dtypes=np.float32, devices="tpu", tol=0.1),
         custom_numeric(dtypes=np.complex64, devices="tpu", tol=0.3),
@@ -549,12 +567,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         Jax2TfLimitation(
             "TF Conversion of eig is not implemented when both compute_left_eigenvectors and compute_right_eigenvectors are set to True",
             enabled=(compute_left_eigenvectors and compute_right_eigenvectors)),
-        custom_numeric(custom_assert=custom_assert,
-                       description=(
-                           "May return the eigenvalues and eigenvectors in a "
-                           "potentially different order. The eigenvectors may "
-                           "also be different, but equally valid."
-                       ))
+        custom_numeric(
+            custom_assert=custom_assert,
+            description=("May return the eigenvalues and eigenvectors in a "
+                         "potentially different order. The eigenvectors may "
+                         "also be different, but equally valid."),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -621,25 +639,28 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         Jax2TfLimitation(
             "TODO: numeric discrepancies",
             dtypes=[np.float16],
-            modes="compiled",
             devices=("tpu",),
             expect_tf_error=False,
             skip_comparison=True),
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=True,
-            description=(
-                "May return the eigenvalues and eigenvectors in a "
-                "potentially different order. The eigenvectors may "
-                "also be different, but equally valid."
-            ))
+            custom_assert=custom_assert,
+            description=("May return the eigenvalues and eigenvectors in a "
+                         "potentially different order. The eigenvectors may "
+                         "also be different, but equally valid."))
     ]
 
   @classmethod
   def ge(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.bool_], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.uint16, np.uint32], devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
+        missing_tf_kernel(dtypes=[np.bool_]),
+        missing_tf_kernel(
+            dtypes=[np.uint16, np.uint32],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
+        missing_tf_kernel(
+            dtypes=[np.uint64],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -649,13 +670,19 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def erf(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
   def erfc(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -674,23 +701,22 @@ class Jax2TfLimitation(primitive_harness.Limitation):
           rtol=tol)
 
     return [
-        Jax2TfLimitation("TODO: erf_inv bug on TPU: nan vs non-nan",
-                         dtypes=np.float32,
-                         devices="tpu",
-                         skip_tf_run=True),
+        Jax2TfLimitation(
+            "TODO: erf_inv bug on TPU: nan vs non-nan",
+            dtypes=np.float32,
+            devices="tpu",
+            skip_tf_run=True),
         missing_tf_kernel(
             dtypes=[dtypes.bfloat16, np.float16],
-            devices=("cpu", "gpu")),
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=[np.float32, np.float64], tol=1e-4),
         custom_numeric(
             dtypes=[np.float32, np.float64],
             custom_assert=custom_assert,
-            also_compiled=True,
             description=(
                 "May return different results at undefined points (< -1 or > 1):"
-                " JAX returns `NaN` and TF returns `+inf` or `-inf`."
-            )
-        )
+                " JAX returns `NaN` and TF returns `+inf` or `-inf`."))
     ]
 
   @classmethod
@@ -722,11 +748,9 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
     return [
         custom_numeric(
-            dtypes=[np.float32, np.complex64], devices="tpu",
-            tol=1e-2),
+            dtypes=[np.float32, np.complex64], devices="tpu", tol=1e-2),
         custom_numeric(
-            dtypes=[np.float32, np.complex64],
-            devices=("cpu", "gpu"),
+            dtypes=[np.float32, np.complex64], devices=("cpu", "gpu"),
             tol=1e-3),
         custom_numeric(dtypes=[np.float64, np.complex128], tol=1e-12),
         custom_numeric(dtypes=np.float16, tol=1),
@@ -735,7 +759,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         custom_numeric(
             dtypes=[np.complex64, np.complex128],
             custom_assert=custom_assert,
-            also_compiled=True)
+        )
     ]
 
   @classmethod
@@ -759,11 +783,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
     return [
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=False,
+            custom_assert=custom_assert,
             description=(
                 "May return different results at undefined points "
                 "(both arguments 0). JAX returns `NaN` and TF returns 0 or "
-                "JAX returns 1 and TF returns `NaN`"))
+                "JAX returns 1 and TF returns `NaN`"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -793,39 +818,38 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         custom_numeric(dtypes=np.float64, tol=1e-9),
         custom_numeric(devices="gpu", tol=1e-3),
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=False,
+            custom_assert=custom_assert,
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"),
             description=(
                 "May return different results at undefined points "
                 "(both arguments less or equal 0). JAX returns `NaN` and TF returns 0 or "
-                "JAX returns 1 and TF returns `NaN`"))
+                "JAX returns 1 and TF returns `NaN`")),
     ]
 
   @classmethod
   def integer_pow(cls, harness: primitive_harness.Harness):
     y = harness.params["y"]
     return [
-               missing_tf_kernel(
-                   dtypes=[
-                       np.uint8, np.uint16, np.int8, np.int16, np.uint32, np.uint64
-                   ],
-                   also_compiled=True),
-               # hitting rtol = nan
-               Jax2TfLimitation(
-                   ("Different overflow behavior for large exponents. It "
-                    "and `+inf`/`-inf` differently in JAX and TF."),
-                   devices="tpu",
-                   dtypes=np.complex64,
-                   modes="compiled",
-                   enabled=(y in [1000, -1000]),
-                   expect_tf_error=False,
-                   skip_comparison=True),
-               Jax2TfLimitation(
-                   "Different overflow behavior for large exponents. ",
-                   dtypes=[np.int32, np.int64, np.float32],
-                   enabled=(y > 10),
-                   expect_tf_error=False,
-                   skip_comparison=True)
-           ] + list(cls._pow_test_util(harness))
+        missing_tf_kernel(
+            dtypes=[
+                np.uint8, np.uint16, np.int8, np.int16, np.uint32, np.uint64
+            ],),
+        # hitting rtol = nan
+        Jax2TfLimitation(("Different overflow behavior for large exponents. It "
+                          "and `+inf`/`-inf` differently in JAX and TF."),
+                         devices="tpu",
+                         dtypes=np.complex64,
+                         enabled=(y in [1000, -1000]),
+                         expect_tf_error=False,
+                         skip_comparison=True),
+        Jax2TfLimitation(
+            "Different overflow behavior for large exponents. ",
+            dtypes=[np.int32, np.int64, np.float32],
+            enabled=(y > 10),
+            expect_tf_error=False,
+            skip_comparison=True)
+    ] + list(cls._pow_test_util(harness))
 
   @classmethod
   def pow(cls, harness: primitive_harness.Harness):
@@ -834,9 +858,15 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def le(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.bool_], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.uint16, np.uint32], devices=("cpu", "gpu")),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
+        missing_tf_kernel(dtypes=[np.bool_]),
+        missing_tf_kernel(
+            dtypes=[np.uint16, np.uint32],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
+        missing_tf_kernel(
+            dtypes=[np.uint64],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -846,7 +876,10 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def lgamma(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu")),
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
         custom_numeric(dtypes=np.float64, tol=1e-11),
         custom_numeric(dtypes=np.float32, tol=1e-3)
     ]
@@ -886,15 +919,15 @@ class Jax2TfLimitation(primitive_harness.Limitation):
           jnp.matmul(p_mat, operand), jnp.matmul(l, u), atol=tol, rtol=tol)
 
     return [
-        missing_tf_kernel(dtypes=[np.complex64], devices="tpu", modes="compiled"),
-        custom_numeric(dtypes=[np.float32, np.complex64], devices="tpu", tol=0.1),
+        missing_tf_kernel(dtypes=[np.complex64], devices="tpu"),
         custom_numeric(
-            dtypes=[np.float32, np.complex64],
-            devices=("cpu", "gpu"),
+            dtypes=[np.float32, np.complex64], devices="tpu", tol=0.1),
+        custom_numeric(
+            dtypes=[np.float32, np.complex64], devices=("cpu", "gpu"),
             tol=1e-5),
         custom_numeric(dtypes=[np.float64, np.complex128], tol=1e-13),
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=True,
+            custom_assert=custom_assert,
             description=("May return different, but also correct, results when "
                          "the decomposition is not unique")),
     ]
@@ -909,18 +942,19 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
     return [
         missing_tf_kernel(
-            dtypes=[np.bool_, np.int8, np.complex64,
-                    np.uint16, np.uint32, np.uint64],
-            also_compiled=True),
+            dtypes=[
+                np.bool_, np.int8, np.complex64, np.uint16, np.uint32, np.uint64
+            ],),
         missing_tf_kernel(
             dtypes=[np.complex128],
             devices=("cpu", "gpu"),
-            also_compiled=True),
+        ),
         custom_numeric(
-            custom_assert=custom_assert, also_compiled=True,
+            custom_assert=custom_assert,
             description=(
                 "May return different values when one of the values is NaN. "
-                "JAX always returns NaN, while TF returns the value NaN is compared with."))
+                "JAX always returns NaN, while TF returns the value NaN is compared with."
+            ))
     ]
 
   @classmethod
@@ -933,28 +967,25 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def mul(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.uint32, np.uint64], also_compiled=True)
-    ]
+    return [missing_tf_kernel(dtypes=[np.uint32, np.uint64])]
 
   @classmethod
   def neg(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(
-            dtypes=[np.uint8, np.uint16, np.uint32, np.uint64],
-            also_compiled=True)
+        missing_tf_kernel(dtypes=[np.uint8, np.uint16, np.uint32, np.uint64],)
     ]
 
   @classmethod
   def nextafter(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], also_compiled=True)
-    ]
+    return [missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16])]
 
   @classmethod
   def population_count(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.uint32, np.uint64], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[np.uint32, np.uint64],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -970,7 +1001,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[dtypes.bfloat16],
             devices="tpu",
-            modes=("compiled",))
+        )
     ]
 
   @classmethod
@@ -980,32 +1011,32 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def reduce_max(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.complex64], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.complex128], also_compiled=True)
+        missing_tf_kernel(dtypes=[np.complex64]),
+        missing_tf_kernel(dtypes=[np.complex128])
     ]
 
   @classmethod
   def reduce_min(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.complex64], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.complex128], also_compiled=True)
+        missing_tf_kernel(dtypes=[np.complex64]),
+        missing_tf_kernel(dtypes=[np.complex128])
     ]
 
   @classmethod
   def reduce_window_add(cls, harness):
     assert "add" == harness.params["computation"].__name__
     return [
-        missing_tf_kernel(dtypes=[np.uint16, np.uint32], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.complex64], devices="tpu", also_compiled=True),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"), also_compiled=True)
+        missing_tf_kernel(dtypes=[np.uint16, np.uint32]),
+        missing_tf_kernel(dtypes=[np.complex64], devices="tpu"),
+        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
     ]
 
   @classmethod
   def reduce_window_mul(cls, harness):
     assert "mul" == harness.params["computation"].__name__
     return [
-        missing_tf_kernel(dtypes=[np.uint32], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"), also_compiled=True)
+        missing_tf_kernel(dtypes=[np.uint32]),
+        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
     ]
 
   @classmethod
@@ -1013,12 +1044,11 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     assert "min" == harness.params["computation"].__name__
     return [
         missing_tf_kernel(
-            dtypes=[np.uint32, np.uint16, np.bool_, np.complex64, np.int8],
-            also_compiled=True),
+            dtypes=[np.uint32, np.uint16, np.bool_, np.complex64, np.int8],),
         missing_tf_kernel(
             dtypes=[np.uint64, np.complex128],
             devices=("cpu", "gpu"),
-            also_compiled=True)
+        )
     ]
 
   @classmethod
@@ -1027,11 +1057,11 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     dtype = harness.dtype
     init_value = harness.params["init_value"]
     return [
-        missing_tf_kernel(dtypes=[np.uint32, np.bool_, np.complex64], also_compiled=True),
+        missing_tf_kernel(dtypes=[np.uint32, np.bool_, np.complex64]),
         missing_tf_kernel(
             dtypes=[np.uint64, np.complex128],
             devices=("cpu", "gpu"),
-            also_compiled=True),
+        ),
         Jax2TfLimitation(
             "TF kernel missing, except when the initial_value is the minimum for the dtype",
             dtypes=[np.uint16, np.int8],
@@ -1043,7 +1073,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   def regularized_incomplete_beta(cls, harness: primitive_harness.Harness):
     return [
         custom_numeric(dtypes=np.float64, tol=1e-14),
-        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16], also_compiled=True)
+        missing_tf_kernel(dtypes=[np.float16, dtypes.bfloat16])
     ]
 
   @classmethod
@@ -1052,8 +1082,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[
                 np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16
-            ],
-            also_compiled=True),
+            ],),
         Jax2TfLimitation(
             "TF integer division fails if divisor contains 0; JAX returns NaN",
             dtypes=[
@@ -1062,35 +1091,42 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             ],
             # Only the harnesses with "singularity" will have divide by 0
             enabled=("singularity" in harness.name)),
-        missing_tf_kernel(dtypes=[np.float16])
+        missing_tf_kernel(
+            dtypes=[np.float16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph")),
     ]
 
   @classmethod
   def rev(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.uint32, np.uint64], also_compiled=True)
-    ]
+    return [missing_tf_kernel(dtypes=[np.uint32, np.uint64])]
 
   @classmethod
   def round(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
   def rsqrt(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
   def scatter_add(cls, harness):
     return [
+        missing_tf_kernel(dtypes=[np.uint16, np.uint32, np.uint64, np.bool_],),
         missing_tf_kernel(
-            dtypes=[
-                np.int8, np.uint16, np.uint32, np.uint64, np.complex64, np.bool_
-            ],
-            also_compiled=True)
+            dtypes=[np.complex64],
+            devices="tpu",
+        ),
     ]
 
   @classmethod
@@ -1100,8 +1136,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             dtypes=[
                 np.int8, np.uint16, np.uint32, np.uint64, np.complex64,
                 np.complex128, np.bool_
-            ],
-            also_compiled=True)
+            ],)
     ]
 
   @classmethod
@@ -1111,46 +1146,46 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             dtypes=[
                 np.int8, np.uint16, np.uint32, np.complex64, np.bool_,
                 np.uint64, np.complex128
-            ],
-            also_compiled=True)
+            ],)
     ]
 
   @classmethod
   def scatter_mul(cls, harness):
     return [
+        missing_tf_kernel(dtypes=[np.uint32, np.uint64, np.bool_],),
         missing_tf_kernel(
-            dtypes=[
-                np.int8, np.uint16, np.uint32, np.uint64, np.complex64, np.bool_
-            ],
-            also_compiled=True)
+            dtypes=[np.complex64],
+            devices="tpu",
+        ),
     ]
 
   @classmethod
   def select_and_gather_add(cls, harness):
     return [
         missing_tf_kernel(
-            dtypes=[np.float32], devices="tpu", modes="compiled",
+            dtypes=[np.float32],
+            devices="tpu",
             description=(
                 "This JAX primitives is not not exposed directly in the JAX API "
                 "but arises from JVP of `lax.reduce_window` for reducers "
                 "`lax.max` or `lax.min`. It also arises from second-order "
                 "VJP of the same. Implemented using XlaReduceWindow")),
-        Jax2TfLimitation(
-            ("jax2tf unimplemented for 64-bit inputs because the current implementation "
-             "relies on packing two values into a single value. This can be "
-             "fixed by using a variadic XlaReduceWindow, when available"),
-            dtypes=[np.float64],
-            devices=("cpu", "gpu"))
+        Jax2TfLimitation((
+            "jax2tf unimplemented for 64-bit inputs because the current implementation "
+            "relies on packing two values into a single value. This can be "
+            "fixed by using a variadic XlaReduceWindow, when available"),
+                         dtypes=[np.float64],
+                         devices=("cpu", "gpu"))
     ]
 
   @classmethod
   def select_and_scatter_add(cls, harness):
     return [
-        missing_tf_kernel(dtypes=[np.uint32, np.uint16], also_compiled=True),
+        missing_tf_kernel(dtypes=[np.uint32, np.uint16]),
         missing_tf_kernel(
             dtypes=[np.uint64],
             devices=("cpu", "gpu"),
-            also_compiled=True)
+        )
     ]
 
   @classmethod
@@ -1159,18 +1194,16 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         missing_tf_kernel(
             dtypes=[
                 np.uint32, np.uint16, np.int16, np.int8, np.uint8, np.uint64
-            ],
-            modes=(
-                "eager",
-                "graph",
-                "compiled",
-            ))
+            ],)
     ]
 
   @classmethod
   def sinh(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[np.float16], devices=("cpu", "gpu"))
+        missing_tf_kernel(
+            dtypes=[np.float16],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"))
     ]
 
   @classmethod
@@ -1180,18 +1213,18 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             # I think that this is because TF is running on CPU even for GPU tests?
             "TODO: TF non-stable multiple-array sort",
             devices="gpu",
-            enabled=(harness.params["num_arrays"] > 1 and not harness.params["is_stable"]),
+            enabled=(harness.params["num_arrays"] > 1 and
+                     not harness.params["is_stable"]),
             expect_tf_error=False,
             skip_comparison=True),
-        missing_tf_kernel(dtypes=[np.complex64, np.complex128, np.float64],
-                          devices=("cpu", "gpu"), also_compiled=True),
-        missing_tf_kernel(dtypes=[np.bool_],
-                          also_compiled=True),
+        missing_tf_kernel(
+            dtypes=[np.complex128, np.float64], devices=("cpu", "gpu")),
+        missing_tf_kernel(dtypes=[np.bool_],),
     ]
 
   @classmethod
   def sub(cls, harness):
-    return [missing_tf_kernel(dtypes=[np.uint64], also_compiled=True)]
+    return [missing_tf_kernel(dtypes=[np.uint64])]
 
   @classmethod
   def svd(cls, harness: primitive_harness.Harness):
@@ -1223,9 +1256,9 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             dtypes=[np.complex64, np.complex128],
             devices=("cpu", "gpu"),
             modes=("compiled",)),
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices="tpu", modes="compiled"),
+        missing_tf_kernel(dtypes=[dtypes.bfloat16], devices="tpu"),
         custom_numeric(tol=1e-4),
-        custom_numeric(custom_assert=custom_assert, also_compiled=True)
+        custom_numeric(custom_assert=custom_assert)
     ]
 
   @classmethod
@@ -1263,7 +1296,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         custom_numeric(
             dtypes=[np.float16, dtypes.bfloat16, np.float32, np.float64],
             custom_assert=custom_assert,
-            also_compiled=True,
             description=(
                "Produces different results when the array contains `inf` and `NaN`"
                " (they are sorted differently in TF vs. XLA).")
@@ -1272,27 +1304,23 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def triangular_solve(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16], also_compiled=True),
-        missing_tf_kernel(dtypes=[np.float16]),
-        custom_numeric(dtypes=np.float32, tol=5e-3)]
+        missing_tf_kernel(dtypes=[dtypes.bfloat16]),
+        missing_tf_kernel(
+            dtypes=[np.float16],
+            devices=("gpu", "cpu"),
+            modes=("eager", "graph")),
+        custom_numeric(dtypes=np.float32, tol=5e-3)
+    ]
 
 
 def custom_numeric(
     *,
     description="custom numeric comparison",
     dtypes=(),  # All
-    modes=("eager", "graph"),
-    also_compiled=False,
+    modes=("eager", "graph", "compiled"),
     devices=("cpu", "gpu", "tpu"),
     custom_assert=None,
     tol=None) -> Jax2TfLimitation:
-  if isinstance(modes, str):
-    modes = (modes,)
-  # If we have just tolerances, we consider them to also applied to compiled case
-  if not custom_assert and tol is not None and not also_compiled:
-    also_compiled = True
-  if also_compiled and "compiled" not in modes:
-    modes = modes + ("compiled",)
 
   return Jax2TfLimitation(
       description,
@@ -1308,13 +1336,9 @@ def missing_tf_kernel(
     *,
     description="op not defined for dtype",
     dtypes,
-    modes=("eager", "graph"),
-    also_compiled=False,
-    devices=("cpu", "gpu", "tpu")) -> Jax2TfLimitation:
-  if isinstance(modes, str):
-    modes = (modes,)
-  if also_compiled and "compiled" not in modes:
-    modes = modes + ("compiled",)
+    modes=("eager", "graph", "compiled"),
+    devices=("cpu", "gpu", "tpu")
+) -> Jax2TfLimitation:
 
   return Jax2TfLimitation(
       description,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1200,7 +1200,8 @@ def _make_scatter_harness(name,
     ],
     jax_unimplemented=[
       Limitation(
-        "unimplemented", devices="tpu", dtypes=np.complex64)
+        "unimplemented", devices="tpu", dtypes=np.complex64,
+        enabled=(f_lax in [lax.scatter_max, lax.scatter_min]))
     ],
     f_lax=f_lax,
     shape=shape,

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -143,10 +143,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
       def log_message(extra):
         return f"[{self._testMethodName}] mode={mode}: {extra}"
 
-      dut = jtu.device_under_test()
-      # For TPU all modes should behave like the compiled one
-      lookup_mode = mode if dut != "tpu" else "compiled"
-      jax2tf_limits = tuple(filter(lambda l: l.filter(mode=lookup_mode), limitations))
+      jax2tf_limits = tuple(filter(lambda l: l.filter(mode=mode), limitations))
 
       skip_tf_run = [l for l in jax2tf_limits if l.skip_tf_run]
       if skip_tf_run:


### PR DESCRIPTION
Now each limitation is very explicit about the modes it applies
to, with the default being all modes. There is no more special
casing for TPUs.