### PR TITLE
Make jax.random.categorical compatible with jax_numpy_rank_promotion='raise'

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1246,7 +1246,10 @@ def categorical(key, logits, axis=-1, shape=None):
     _check_shape("categorical", shape, batch_shape)
 
   sample_shape = shape[:len(shape)-len(batch_shape)]
-  return jnp.argmax(gumbel(key, sample_shape + logits.shape, logits.dtype) + logits, axis=axis)
+  return jnp.argmax(
+      gumbel(key, sample_shape + logits.shape, logits.dtype) +
+      logits.reshape((1,) * len(sample_shape) + logits.shape),
+      axis=axis)
 
 
 def laplace(key, shape=(), dtype=dtypes.float_):


### PR DESCRIPTION
Without this, jax.random.categorical raises an exception when using a non-empty sample_shape and jax_numpy_rank_promotion is set to 'raise'.