### PR TITLE
Dedent wrapped doc sections individually

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -70,7 +70,7 @@ def _wraps(fun, update_doc=True, lax_description=""):
       # We (a) move the summary to the top, since it is what the Sphinx
       # autosummary extension expects, and (b) add a comment below the summary
       # to the effect that this is a LAX wrapper of a Numpy function.
-      sections = textwrap.dedent(fun.__doc__).split("\n\n")
+      sections = list(map(textwrap.dedent, fun.__doc__.split("\n\n")))
 
       signatures = []
       summary = None


### PR DESCRIPTION
Slight modification of #5427: some docstrings start with no indent, and so the wrapped docs still have incorrect indentation. For example:

Before:
![Screen Shot 2021-01-15 at 10 08 52 AM](https://user-images.githubusercontent.com/781659/104762769-c1135280-5719-11eb-896c-bf90543675da.png)


After:
![Screen Shot 2021-01-15 at 10 08 59 AM](https://user-images.githubusercontent.com/781659/104762780-c4a6d980-5719-11eb-80c0-6daef23bf29d.png)
