### PR TITLE
Update jaxlib version, minimum jaxlib version, readme, and changelog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ package. Next, run
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade jax jaxlib==0.1.57+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install --upgrade jax jaxlib==0.1.59+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
 ```
 
 The jaxlib version must correspond to the version of the existing CUDA

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
  # Must be kept in sync with the minimum jaxlib version in jax/lib/__init__.py
-jaxlib==0.1.55
+jaxlib==0.1.59
 mypy==0.790
 pillow
 pytest-benchmark

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -21,17 +21,18 @@ jax 0.2.9 (Unreleased)
     than wrapping them into the segment ID space. This was done for performance
     reasons.
 
-
-These are the release notes for JAX.
-
-next version
--------------
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.2.8...jax-v0.2.9>`_.
 
 * New features:
 
   * Extend the `jax.experimental.loops` module with support for pytrees. Improved
     error checking and error messages.
+
+jaxlib 0.1.60 (Unreleased)
+------------------------------
+
+jaxlib 0.1.59 (January 15 2021)
+------------------------------
 
 jax 0.2.8 (January 12 2021)
 ---------------------------
@@ -144,7 +145,7 @@ jax 0.2.6 (Nov 18 2020)
   * DeviceArray now raises ``RuntimeError`` instead of ``ValueError`` when trying
     to access its value while it has been deleted.
 
-jaxlib 0.1.58 (Unreleased)
+jaxlib 0.1.58 (January 12ish 2021)
 ------------------------------
 
 * Fixed a bug that meant JAX sometimes return platform-specific types (e.g.,

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 import jaxlib
 
 # Must be kept in sync with the jaxlib version in build/test-requirements.txt
-_minimum_jaxlib_version = (0, 1, 55)
+_minimum_jaxlib_version = (0, 1, 59)
 try:
   from jaxlib import version as jaxlib_version
 except Exception as err:

--- a/jaxlib/version.py
+++ b/jaxlib/version.py
@@ -14,4 +14,4 @@
 
 # This should be increased after releasing the current version (i.e. this
 # is always the next version to be released).
-__version__ = "0.1.59"
+__version__ = "0.1.60"


### PR DESCRIPTION
Bumping the min jaxlib version to support https://github.com/google/jax/pull/5213.