### PR TITLE
Added check for shapes of arguments in jvp, resolves issue #5226

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -1721,7 +1721,7 @@ def _jvp(fun: lu.WrappedFun, primals, tangents):
                       f"{core.primal_dtype_to_tangent_dtype(_dtype(p))}, but got "
                       f"tangent dtype {_dtype(t)} instead.")
     if np.shape(p) != np.shape(t):
-      raise ValueError("jvp called with inconsistent primal and tangent shapes;"
+      raise ValueError("jvp called with different primal and tangent shapes;"
                        f"Got primal shape {np.shape(p)} and tangent shape as {np.shape(t)}")
 
   flat_fun, out_tree = flatten_fun_nokwargs(fun, tree_def)

--- a/jax/api.py
+++ b/jax/api.py
@@ -1720,6 +1720,12 @@ def _jvp(fun: lu.WrappedFun, primals, tangents):
                       f"Got primal dtype {_dtype(p)} and so expected tangent dtype "
                       f"{core.primal_dtype_to_tangent_dtype(_dtype(p))}, but got "
                       f"tangent dtype {_dtype(t)} instead.")
+    try:
+      if p.shape != t.shape:
+        raise ValueError("jvp called with inconsistent primal and tangent shapes;"
+                         f"Got primal shape {p.shape} and tangent shape as {t.shape}")
+    except AttributeError:
+      pass
   flat_fun, out_tree = flatten_fun_nokwargs(fun, tree_def)
   out_primals, out_tangents = ad.jvp(flat_fun).call_wrapped(ps_flat, ts_flat)
   return (tree_unflatten(out_tree(), out_primals),

--- a/jax/api.py
+++ b/jax/api.py
@@ -1720,12 +1720,10 @@ def _jvp(fun: lu.WrappedFun, primals, tangents):
                       f"Got primal dtype {_dtype(p)} and so expected tangent dtype "
                       f"{core.primal_dtype_to_tangent_dtype(_dtype(p))}, but got "
                       f"tangent dtype {_dtype(t)} instead.")
-    try:
-      if p.shape != t.shape:
-        raise ValueError("jvp called with inconsistent primal and tangent shapes;"
-                         f"Got primal shape {p.shape} and tangent shape as {t.shape}")
-    except AttributeError:
-      pass
+    if np.shape(p) != np.shape(t):
+      raise ValueError("jvp called with inconsistent primal and tangent shapes;"
+                       f"Got primal shape {np.shape(p)} and tangent shape as {np.shape(t)}")
+
   flat_fun, out_tree = flatten_fun_nokwargs(fun, tree_def)
   out_primals, out_tangents = ad.jvp(flat_fun).call_wrapped(ps_flat, ts_flat)
   return (tree_unflatten(out_tree(), out_primals),

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -948,11 +948,11 @@ class APITest(jtu.JaxTestCase):
       "primal and tangent arguments to jax.jvp do not match.",
       lambda: api.jvp(lambda x: -x, (np.float16(2),), (np.float32(4),)))
     # If primals and tangents are not of the same shape then raise error
-    self.assertRaisesRegex(
-      ValueError,
-      "jvp called with inconsistent primal and tangent shapes",
-      lambda: api.jvp(lambda x: x+1, (np.random.randn(10,),), (np.random.randn(20,),))
-    )
+    fun = lambda x: x+1
+    with self.assertRaisesRegex(ValueError, "jvp called with inconsistent primal and tangent shapes"):
+      api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.array([1.,2.,3.,4.]),))
+      api.jvp(fun, (jnp.float(10.),), (jnp.array([1.,2.,3.]),))
+      api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.float(20.),))
 
   def test_jvp_non_tuple_arguments(self):
     def f(x, y): return x + y

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -949,10 +949,15 @@ class APITest(jtu.JaxTestCase):
       lambda: api.jvp(lambda x: -x, (np.float16(2),), (np.float32(4),)))
     # If primals and tangents are not of the same shape then raise error
     fun = lambda x: x+1
-    with self.assertRaisesRegex(ValueError, "jvp called with inconsistent primal and tangent shapes"):
+    with self.assertRaisesRegex(
+      ValueError, "jvp called with different primal and tangent shapes"):
       api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.array([1.,2.,3.,4.]),))
-      api.jvp(fun, (jnp.float(10.),), (jnp.array([1.,2.,3.]),))
-      api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.float(20.),))
+    with self.assertRaisesRegex(
+      ValueError, "jvp called with different primal and tangent shapes"):
+      api.jvp(fun, (jnp.float32(10.),), (jnp.array([1.,2.,3.]),))
+    with self.assertRaisesRegex(
+      ValueError, "jvp called with different primal and tangent shapes"):
+      api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.float32(20.),))
 
   def test_jvp_non_tuple_arguments(self):
     def f(x, y): return x + y

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -951,7 +951,7 @@ class APITest(jtu.JaxTestCase):
     self.assertRaisesRegex(
       ValueError,
       "jvp called with inconsistent primal and tangent shapes",
-      lambda: api.jvp(lambda x: x+1, (np.random.randn(10,),), (np.random.randn(20,),)) 
+      lambda: api.jvp(lambda x: x+1, (np.random.randn(10,),), (np.random.randn(20,),))
     )
 
   def test_jvp_non_tuple_arguments(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -954,10 +954,10 @@ class APITest(jtu.JaxTestCase):
       api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.array([1.,2.,3.,4.]),))
     with self.assertRaisesRegex(
       ValueError, "jvp called with different primal and tangent shapes"):
-      api.jvp(fun, (jnp.float32(10.),), (jnp.array([1.,2.,3.]),))
+      api.jvp(fun, (jnp.float32(10.),), (jnp.array([1.,2.,3.], dtype=jnp.float32),))
     with self.assertRaisesRegex(
       ValueError, "jvp called with different primal and tangent shapes"):
-      api.jvp(fun, (jnp.array([1.,2.,3.]),), (jnp.float32(20.),))
+      api.jvp(fun, (jnp.array([1.,2.,3.], dtype=jnp.float32),), (jnp.float32(20.),))
 
   def test_jvp_non_tuple_arguments(self):
     def f(x, y): return x + y

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -947,6 +947,12 @@ class APITest(jtu.JaxTestCase):
       TypeError,
       "primal and tangent arguments to jax.jvp do not match.",
       lambda: api.jvp(lambda x: -x, (np.float16(2),), (np.float32(4),)))
+    # If primals and tangents are not of the same shape then raise error
+    self.assertRaisesRegex(
+      ValueError,
+      "jvp called with inconsistent primal and tangent shapes",
+      lambda: api.jvp(lambda x: x+1, (np.random.randn(10,),), (np.random.randn(20,),)) 
+    )
 
   def test_jvp_non_tuple_arguments(self):
     def f(x, y): return x + y

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -958,6 +958,9 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(
       ValueError, "jvp called with different primal and tangent shapes"):
       api.jvp(fun, (jnp.array([1.,2.,3.], dtype=jnp.float32),), (jnp.float32(20.),))
+    with self.assertRaisesRegex(
+      ValueError, "jvp called with different primal and tangent shapes"):
+      api.jvp(fun, (jnp.array([1.,2.,3.]),), (20.,))
 
   def test_jvp_non_tuple_arguments(self):
     def f(x, y): return x + y


### PR DESCRIPTION
* Added check for the array shape.
* For handling cases where the inputs are ```ints```, ```floats``` I am using ```try/except``` loop. Not sure if this is the best way to go about it 