### PR TITLE
Change the translation rule for lax.nextafter_p to ensure

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2152,7 +2152,7 @@ ad.defjvp_zero(sign_p)
 
 nextafter_p = standard_naryop(
   [_float, _float], 'nextafter',
-  translation_rule=lambda c, x1, x2: xops.NextAfter(x1, x2))
+  translation_rule=_broadcast_translate(partial(standard_translate, 'next_after')))
 
 floor_p = standard_unop(_float, 'floor')
 ad.defjvp_zero(floor_p)

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,6 +1,6 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2021-01-15* (YYYY-MM-DD)
+*Last generated on: 2021-01-18* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
@@ -194,10 +194,9 @@ and search for "limitation".
 |eigh|unimplemented|float16|cpu|
 |eigh|unimplemented|float16|gpu|
 |fft|only 1D FFT is currently supported b/140351181.|all|tpu|
-|igamma|XLA internal error|bfloat16, float16|cpu, gpu, tpu|
-|igammac|XLA internal error|bfloat16, float16|cpu, gpu, tpu|
+|igamma|XLA internal error b/177754567|bfloat16, float16|cpu, gpu, tpu|
+|igammac|XLA internal error b/177754567|bfloat16, float16|cpu, gpu, tpu|
 |lu|unimplemented|bfloat16, float16|cpu, gpu, tpu|
-|nextafter|XLA internal error, implicit broadcasting not implemented|all|cpu, gpu, tpu|
 |qr|unimplemented|bfloat16, float16|cpu, gpu|
 |reduce_window_max|unimplemented in XLA|complex64|tpu|
 |reduce_window_min|unimplemented in XLA|complex64|tpu|
@@ -209,7 +208,7 @@ and search for "limitation".
 |select_and_scatter_add|works only for 2 or more inactive dimensions|all|tpu|
 |svd|complex not implemented. Works in JAX for CPU and GPU with custom kernels|complex|tpu|
 |svd|unimplemented|bfloat16, float16|cpu, gpu|
-|tie_in|requires omnistaging to be disabled|all|cpu, gpu, tpu|
+|tie_in|tie_in exists only pre-omnistaging|all|cpu, gpu, tpu|
 |triangular_solve|unimplemented|float16|gpu|
 
 ## Table generation

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -694,7 +694,7 @@ for rhs_dtype in jtu.dtypes.all:
      RandArg(rhs_shape, rhs_dtype)],
     jax_unimplemented=[
       Limitation(
-        "requires omnistaging to be disabled",
+        "tie_in exists only pre-omnistaging",
         enabled=config.omnistaging_enabled)
     ],
     dtype=rhs_dtype,
@@ -951,7 +951,7 @@ _make_binary_elementwise_harnesses(
   dtypes=jtu.dtypes.all_floating,
   jax_unimplemented=lambda *_, dtype, **kwargs: [
     Limitation(
-      "XLA internal error", dtypes=[np.float16, dtypes.bfloat16]),
+      "XLA internal error b/177754567", dtypes=[np.float16, dtypes.bfloat16]),
   ])
 
 _make_binary_elementwise_harnesses(
@@ -959,17 +959,12 @@ _make_binary_elementwise_harnesses(
   dtypes=jtu.dtypes.all_floating,
   jax_unimplemented=lambda *_, dtype, **kwargs: [
     Limitation(
-      "XLA internal error", dtypes=[np.float16, dtypes.bfloat16]),
+      "XLA internal error b/177754567", dtypes=[np.float16, dtypes.bfloat16]),
   ])
 
 _make_binary_elementwise_harnesses(
   prim=lax.nextafter_p,
-  dtypes=jtu.dtypes.all_floating,
-  jax_unimplemented=lambda *_, shapes, **params: [
-    Limitation(
-      "XLA internal error, implicit broadcasting not implemented",
-      enabled=(shapes[0] != shapes[1]))
-  ])
+  dtypes=jtu.dtypes.all_floating)
 
 _make_binary_elementwise_harnesses(
   prim=lax.and_p,


### PR DESCRIPTION
broadcasting during translation.

Previously, this was the only binary arithmetic primitive that
did not have broadcasting during translation. Trying to use it
with non-equal shapes resulted in the error:

```
 RuntimeError: Internal: RET_CHECK failure
(external/org_tensorflow/tensorflow/compiler/xla/client/xla_builder.cc:748)
non_scalar_shape.value().dimensions() == shape->dimensions() Unimplemented
implicit broadcast.:
       This is a bug in JAX's shape-checking rules; please report it!
```