### PR TITLE
Make it possible to vmap xmapped functions

### DIFF
--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -305,7 +305,7 @@ def make_xmap_callable(fun: lu.WrappedFun,
                                     EXPERIMENTAL_SPMD_LOWERING,
                                     *in_avals)
   else:
-    # We have to trace again, because `f` is a linear function, so we can't just return it.
+    # We have to trace again, because `f` is an lu.WrappedFun, so we can't just return it.
     final_jaxpr, out_avals, final_consts = pe.trace_to_jaxpr_final(f, in_avals)
     return core.jaxpr_as_fun(core.ClosedJaxpr(final_jaxpr, final_consts))
 


### PR DESCRIPTION
Or perhaps more importantly make it possible to nest xmaps that don't
specify any `axis_resources`. The math is a little tricky, so I've added
a fairly strong test that enumerates a wide range of potential ways of
interleaving vmapped and xmapped axes in both inputs and the output.
Thanks to that, I've actually caught one very subtle bug in the dynamic
tracing rule for xmap (sorting by dimension names instead of positional
axes).