### PR TITLE
add BatchTrace.process_custom_vjp_call

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -259,6 +259,8 @@ class BatchTrace(Trace):
       out_dims = out_dims[-len(out_vals) % len(out_dims):]
     return [BatchTracer(self, v, d) for v, d in zip(out_vals, out_dims)]
 
+  post_process_custom_vjp_call = post_process_custom_jvp_call
+
 def _main_trace_for_axis_names(main_trace: core.MainTrace,
                                axis_name: Union[core.AxisName, Tuple[core.AxisName, ...]]
                                ) -> bool:


### PR DESCRIPTION
It was an oversight not to include this! Notice we have BatchTrace.process_custom_jvp_call. In fact, we can use the same function! We just needed the simplest possible post-process-call which just peels and packages.

fixes #5440