### PR TITLE
Replace dead Colab notebook link

### DIFF
--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -2174,7 +2174,7 @@
       "source": [
         "### Working with `list` / `tuple` / `dict` containers (and other pytrees)\n",
         "\n",
-        "You should expect standard Python containers like lists, tuples, namedtuples, and dicts to just work, along with nested versions of those. In general, any [pytrees](https://github.com/google/jax/blob/master/docs/notebooks/JAX_pytrees.ipynb) are permissible, so long as their structures are consistent according to the type constraints. \n",
+        "You should expect standard Python containers like lists, tuples, namedtuples, and dicts to just work, along with nested versions of those. In general, any [pytrees](https://github.com/google/jax/blob/master/docs/pytrees.rst) are permissible, so long as their structures are consistent according to the type constraints. \n",
         "\n",
         "Here's a contrived example with `jax.custom_jvp`:"
       ]


### PR DESCRIPTION
Replaces the link to a now-deleted Colab notebook (`docs/notebooks/JAX_pytrees.ipynb`) with a link to a doc explaining what pytrees are (`docs/pytrees.rst`).