### PR TITLE
add transformed fun src info to escaped tracer err

### DIFF
--- a/jax/config.py
+++ b/jax/config.py
@@ -35,6 +35,10 @@ def bool_env(varname: str, default: bool) -> bool:
   else:
     raise ValueError("invalid truth value %r for environment %r" % (val, varname))
 
+def int_env(varname: str, default: int) -> int:
+  """Read an environment variable and interpret it as an integer."""
+  return int(os.getenv(varname, default))
+
 
 class Config:
   def __init__(self):
@@ -159,4 +163,10 @@ flags.DEFINE_bool(
     'jax_omnistaging',
     bool_env('JAX_OMNISTAGING', True),
     help='Enable staging based on dynamic context rather than data dependence.'
+)
+
+flags.DEFINE_integer(
+    'jax_tracer_error_num_traceback_frames',
+    int_env('JAX_TRACER_ERROR_NUM_TRACEBACK_FRAMES', 5),
+    help='Set the number of stack frames in JAX tracer error messages.'
 )


### PR DESCRIPTION
This change adds to the error message when we hit an escaped tracer. In particular, it adds source info for the function that was transformed, shown in the last line here:

```
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.
The functions being transformed should not save traced values to global state.
The tracer that caused this error was created on line tests/api_test.py:1988 (f).
When the tracer was created, the final 3 stack frames (most recent last) were:
/usr/local/google/home/mattjj/miniconda3/lib/python3.8/unittest/case.py:633 (_callTestMethod)
tests/api_test.py:1989 (test_escaped_tracer_omnistaging)
tests/api_test.py:1988 (f)
The function being traced was f at tests/api_test.py:1985.
```

This change currently only applies to escaped `DynamicJaxprTracer`s (arising from `jit`, `pmap`, `scan`, and other staging functions) and not other traces. A natural follow-up would be to attach this information to other traces.

Another tweak here was to make it easier to control the number of lines in our escaped tracer error message's special stack trace.

---

In general, here's what a transformation-with-leaked-tracers might look like (stylized):

```python
def foo(x):  # (1) function to be transformed
  ...

foo = jit(foo)  # (2) transformation application

y = foo(x)  # (3) call site of function which might leak tracer

bar()  # (4) call site of function which might interact with leaked tracer
```

Currently (as of this PR) we catch a leaked tracer at (4), and information is printed about (1), (3), and (4). That is:
* this PR adds the `foo` function name and line info for (1), and we already printed more detailed information about where the escaped tracer was created, which would point to certain lines/operations in the body of `foo`;
* the call site (3) (plus more detailed info) can be included in the special stack trace we print as part of the escaped tracer error message (from #5319)
* info about (4) is contained in Python's standard backtrace when the error is raised.

Some improvements we would like to make in the future:
1. The soonest we could catch a leaked tracer would be on line (3), with a kind of leak checker, but we haven't yet managed to revive that in a way that works with JAX's caching.
2. We don't print any information about (2), but that could be helpful in figuring out e.g. whether the leaked tracer originated from a `scan` or a `jit`. It seems feasible to plumb that information, and that could make good follow-up work!

(This came out of a jam session with @LenaMartens and @shoyer.)