### PR TITLE
Make jnp.finfo a class and support bfloat16

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -187,6 +187,7 @@ character = np.character
 object_ = np.object_
 
 iinfo = dtypes.iinfo
+finfo = dtypes.finfo
 
 dtype = np.dtype
 can_cast = dtypes.can_cast
@@ -342,10 +343,6 @@ def fmin(x1, x2):
 @_wraps(np.fmax)
 def fmax(x1, x2):
   return where((x1 > x2) | isnan(x2), x1, x2)
-
-@_wraps(np.finfo)
-def finfo(dtype):
-  return dtypes.finfo(dtype)
 
 @_wraps(np.issubdtype)
 def issubdtype(arg1, arg2):


### PR DESCRIPTION
This approach has two advantages:

- `jnp.finfo('bfloat16')` now returns an actual `np.finfo` instance, just as with other dtypes
- because `jnp.finfo` is now a class rather than a function, the `Attributes` section in the documentation will render correctly:

Before: 
<img width="1291" alt="Screen Shot 2021-01-21 at 8 27 49 AM" src="https://user-images.githubusercontent.com/781659/105380357-a1b97100-5bc2-11eb-9e37-458334f992a5.png">


After: 
<img width="1293" alt="Screen Shot 2021-01-21 at 8 27 40 AM" src="https://user-images.githubusercontent.com/781659/105380373-a67e2500-5bc2-11eb-9052-dccf5713d029.png">
