### PR TITLE
Add experimental x64 context manager

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -28,6 +28,10 @@ jax 0.2.9 (Unreleased)
   * Extend the `jax.experimental.loops` module with support for pytrees. Improved
     error checking and error messages.
 
+  * Add :func:`jax.experimental.enable_x64` and :func:`jax.experimental.disable_x64`.
+    These are context managers which allow X64 mode to be temporarily enabled/disabled
+    within a session.
+
 jaxlib 0.1.60 (Unreleased)
 --------------------------
 

--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -13,3 +13,6 @@ jax.experimental package
     jax.experimental.stax
 
 .. automodule:: jax.experimental
+
+.. autofunction:: enable_x64
+.. autofunction:: disable_x64

--- a/jax/api.py
+++ b/jax/api.py
@@ -375,8 +375,8 @@ def _cpp_jit(
   @wraps(fun)
   @api_boundary
   def f_jitted(*args, **kwargs):
-    context = getattr(core.thread_local_state.trace_state.trace_stack,
-                      'dynamic', None)
+    context = (getattr(core.thread_local_state.trace_state.trace_stack,
+                       'dynamic', None), bool(FLAGS.jax_enable_x64))
     # TODO(jblespiau): Move this to C++.
     if (FLAGS.jax_debug_nans or FLAGS.jax_debug_infs) and not _jit_is_disabled():
       device_arrays = cpp_jitted_f(context, *args, **kwargs)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -260,7 +260,7 @@ def _make_lattice_upper_bounds():
   return upper_bounds
 _lattice_upper_bounds = _make_lattice_upper_bounds()
 
-@functools.lru_cache(512)
+@functools.lru_cache(512)  # don't use util.memoize because there is no X64 dependence.
 def _least_upper_bound(*nodes):
   # This function computes the least upper bound of a set of nodes N within a partially
   # ordered set defined by the lattice generated above.

--- a/jax/experimental/__init__.py
+++ b/jax/experimental/__init__.py
@@ -15,3 +15,4 @@
 # flake8: noqa: F401
 from ..interpreters.sharded_jit import (sharded_jit, PartitionSpec,
                                         with_sharding_constraint)
+from .x64_context import enable_x64, disable_x64

--- a/jax/experimental/x64_context.py
+++ b/jax/experimental/x64_context.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context managers for toggling X64 mode.
+
+**Experimental: please give feedback, and expect changes.**
+"""
+
+from contextlib import contextmanager
+from jax import config
+
+@contextmanager
+def enable_x64():
+  """Experimental context manager to temporarily enable X64 mode.
+
+  Usage::
+
+    >>> import jax.numpy as jnp
+    >>> with enable_x64():
+    ...   print(jnp.arange(10.0).dtype)
+    ...
+    float64
+
+  See Also
+  --------
+  jax.experimental.disable_x64 :  temporarily disable X64 mode.
+  """
+  _x64_state = config.FLAGS.jax_enable_x64
+  config.update('jax_enable_x64', True)
+  try:
+    yield
+  finally:
+    config.update('jax_enable_x64', _x64_state)
+
+@contextmanager
+def disable_x64():
+  """Experimental context manager to temporarily disable X64 mode.
+
+  Usage::
+
+    >>> import jax.numpy as jnp
+    >>> with disable_x64():
+    ...   print(jnp.arange(10.0).dtype)
+    ...
+    float32
+
+  See Also
+  --------
+  jax.experimental.enable_x64 : temporarily enable X64 mode.
+  """
+  _x64_state = config.FLAGS.jax_enable_x64
+  config.update('jax_enable_x64', False)
+  try:
+    yield
+  finally:
+    config.update('jax_enable_x64', _x64_state)

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -20,7 +20,7 @@ XLA. There are also a handful of related casting utilities.
 """
 
 
-from functools import partial
+from functools import partial, lru_cache
 import os
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -161,7 +161,7 @@ if tpu_client:
 
 _backend_lock = threading.Lock()
 
-@util.memoize
+@lru_cache(maxsize=None)  # don't use util.memoize because there is no X64 dependence.
 def get_backend(platform=None):
   # TODO(mattjj,skyewm): remove this input polymorphism after we clean up how
   # 'backend' values are handled

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -72,6 +72,9 @@ from ._src.util import curry
 from .tree_util import tree_map
 
 from ._src import traceback_util
+
+from .config import FLAGS
+
 traceback_util.register_exclusion(__file__)
 
 
@@ -246,9 +249,9 @@ def cache(call: Callable):
   def memoized_fun(fun: WrappedFun, *args):
     cache = fun_caches.setdefault(fun.f, {})
     if core.debug_state.check_leaks:
-      key = (_copy_main_traces(fun.transforms), fun.params, args)
+      key = (_copy_main_traces(fun.transforms), fun.params, args, bool(FLAGS.jax_enable_x64))
     else:
-      key = (fun.transforms, fun.params, args)
+      key = (fun.transforms, fun.params, args, bool(FLAGS.jax_enable_x64))
     result = cache.get(key, None)
     if result is not None:
       ans, stores = result

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import parameterized
+
+from jax import api, config, lax, partial, random
+from jax.experimental import enable_x64, disable_x64
+import jax.numpy as jnp
+import jax.test_util as jtu
+
+def _maybe_jit(jit_type, func, *args, **kwargs):
+  if jit_type == "python":
+    return api._python_jit(func, *args, **kwargs)
+  elif jit_type == "cpp":
+    return api._cpp_jit(func, *args, **kwargs)
+  elif jit_type is None:
+    return func
+  else:
+    raise ValueError(f"Unrecognized jit_type={jit_type!r}")
+
+
+class X64ContextTests(jtu.JaxTestCase):
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_jit={}".format(jit), "jit": jit}
+      for jit in ["python", "cpp", None]))
+  def test_make_array(self, jit):
+    if jit == "cpp" and not config.omnistaging_enabled:
+      self.skipTest("cpp_jit requires omnistaging")
+    func = _maybe_jit(jit, lambda: jnp.arange(10.0))
+    dtype_start = func().dtype
+    with enable_x64():
+      self.assertEqual(func().dtype, 'float64')
+    with disable_x64():
+      self.assertEqual(func().dtype, 'float32')
+    self.assertEqual(func().dtype, dtype_start)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_jit={}".format(jit), "jit": jit}
+      for jit in ["python", "cpp", None]))
+  def test_near_singular_inverse(self, jit):
+    if jit == "cpp" and not config.omnistaging_enabled:
+      self.skipTest("cpp_jit requires omnistaging")
+    @partial(_maybe_jit, jit, static_argnums=1)
+    def near_singular_inverse(key, N, eps):
+      X = random.uniform(key, (N, N))
+      X = X.at[-1].mul(eps)
+      return jnp.linalg.inv(X)
+
+    key = random.PRNGKey(1701)
+    eps = 1E-40
+    N = 5
+
+    with enable_x64():
+      result_64 = near_singular_inverse(key, N, eps)
+      self.assertTrue(jnp.all(jnp.isfinite(result_64)))
+
+    with disable_x64():
+      result_32 = near_singular_inverse(key, N, eps)
+      self.assertTrue(jnp.all(~jnp.isfinite(result_32)))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_jit={}".format(jit), "jit": jit}
+      for jit in ["python", "cpp", None]))
+  def test_while_loop(self, jit):
+    if jit == "cpp" and not config.omnistaging_enabled:
+      self.skipTest("cpp_jit requires omnistaging")
+    @partial(_maybe_jit, jit)
+    def count_to(N):
+      return lax.while_loop(lambda x: x < N, lambda x: x + 1.0, 0.0)
+
+    with enable_x64():
+      self.assertArraysEqual(count_to(10), jnp.float64(10), check_dtypes=True)
+
+    with disable_x64():
+      self.assertArraysEqual(count_to(10), jnp.float32(10), check_dtypes=True)


### PR DESCRIPTION
This is an experiment in allowing the X64 flag to be temporarily set via a context manager. For example:
```python
import numpy as np
import jax.numpy as jnp
from jax import config, jit

from jax.experimental import enable_x64, disable_x64

# Works with and without experimental_cpp_jit
# config.update('experimental_cpp_jit', False)
config.update('jax_enable_x64', False)

x = np.random.randn(100, 100)

print(jnp.array(x).dtype)
# float32

u, s, vt = jnp.linalg.svd(x)
print(u.dtype)
# float32

j_svd = jit(jnp.linalg.svd)

u, s, vt = j_svd(x)
print(u.dtype)
# float32

with enable_x64():
    print(jnp.array(x).dtype)
    # float64

    u, s, vt = jnp.linalg.svd(x)
    print(u.dtype)
    # float64

    with disable_x64(): # Nested context managers!
        print(jnp.array(x).dtype)
        # float32

    u, s, vt = j_svd(x)
    print(u.dtype)
    # float64
```

~I think the CPP jit cache is the one big remaining issue, though there may be others. I'm curious to hear thoughts about this approach!~

Small change made it so this works even with CPP jit (thanks @mattjj!)

Update: added some simple CI tests.