### PR TITLE
add xeinsum, an einsum for xmap (& jnp.einsum easter egg)

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3604,9 +3604,15 @@ def tensordot(a, b, axes=2, *, precision=None):
 
 
 @_wraps(np.einsum, lax_description=_PRECISION_DOC)
-def einsum(*operands, out=None, optimize='greedy', precision=None):
+def einsum(*operands, out=None, optimize='greedy', precision=None,
+           _use_xeinsum=False):
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.einsum is not supported.")
+
+  if (_use_xeinsum or isinstance(operands[0], str) and '{' in operands[0] and
+      len(operands[1:]) == 2):
+    return lax.xeinsum(*operands)
+
   optimize = 'greedy' if optimize is True else optimize
   # using einsum_call=True here is an internal api for opt_einsum
   operands, contractions = opt_einsum.contract_path(

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -343,6 +343,7 @@ from jax._src.lax.parallel import (
   psum_p,
   pswapaxes,
   pdot,
+  xeinsum,
 )
 from jax._src.lax.other import (
   conv_general_dilated_patches

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -684,14 +684,18 @@ class PDotTests(jtu.JaxTestCase):
                in_axes=(['i', 'j', ...], ['j', 'k', ...]),
                out_axes=['i', 'k', ...])(x, y)
     expected = np.einsum('ij,jk->ik', x, y)
-    self.assertAllClose(out, expected, check_dtypes=True)
+    tol = 1e-1 if jtu.device_under_test() == "tpu" else None
+    self.assertAllClose(out, expected, check_dtypes=True,
+                        atol=tol, rtol=tol)
 
     # order of named axes in the spec doesn't matter!
     out = xmap(partial(jnp.einsum, '{i,j},{k,j}->{k,i}'),
                in_axes=(['i', 'j', ...], ['j', 'k', ...]),
                out_axes=['i', 'k', ...])(x, y)
     expected = np.einsum('ij,jk->ik', x, y)
-    self.assertAllClose(out, expected, check_dtypes=True)
+    tol = 1e-1 if jtu.device_under_test() == "tpu" else None
+    self.assertAllClose(out, expected, check_dtypes=True,
+                        atol=tol, rtol=tol)
 
   def test_xeinsum_no_named_axes_vector_dot(self):
     rng = np.random.RandomState(0)


### PR DESCRIPTION
We upgraded `jnp.einsum` to work with `xmap`'s named axes, lowering to `pdot`!

There's still a lot more to do, including:
* handling more than two operands
* handling more positional axis cases
* maybe de-duplicating some positional axis logic with the rest of `jnp.einsum`
* lots more tests
* checks once we have avals-with-names
* docs!

But already this is a convenient wrapper around `pdot`.

Because this is a strict generalization of the existing `einsum` API, and in particular a generalization of the axis specification string language, we don't need a new user-facing API function: we can just extend `jnp.einsum` to handle mapped axes! For now, this path is like an undocumented easter egg in `jnp.einsum`, but it may already be useful for those playing with `xmap`.

Co-authored w/ @apaszke.