### PR TITLE
revive the leak checker, as a debug mode

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -108,12 +108,6 @@ def _initial_style_jaxprs_with_common_consts(funs: Sequence[Callable],
 def _abstractify(x):
   return raise_to_shaped(core.get_aval(x))
 
-def _disable_jit_impl(prim, interp, *args, **kwargs):
-  if jax.api._jit_is_disabled():
-    return interp(*args, **kwargs)
-  else:
-    return xla.apply_primitive(prim, *args, **kwargs)
-
 def _typecheck_param(prim, param, name, msg_required, pred):
   msg = (f'invalid {prim} param {name} of type {type(param).__name__}, '
          f'{msg_required} required:')

--- a/jax/config.py
+++ b/jax/config.py
@@ -170,3 +170,9 @@ flags.DEFINE_integer(
     int_env('JAX_TRACER_ERROR_NUM_TRACEBACK_FRAMES', 5),
     help='Set the number of stack frames in JAX tracer error messages.'
 )
+
+flags.DEFINE_bool(
+    'jax_check_tracer_leaks',
+    bool_env('JAX_CHECK_TRACER_LEAKS', False),
+    help='Turn on checking for leaked tracers as soon as a trace completes.'
+)

--- a/jax/config.py
+++ b/jax/config.py
@@ -174,5 +174,7 @@ flags.DEFINE_integer(
 flags.DEFINE_bool(
     'jax_check_tracer_leaks',
     bool_env('JAX_CHECK_TRACER_LEAKS', False),
-    help='Turn on checking for leaked tracers as soon as a trace completes.'
+    help=('Turn on checking for leaked tracers as soon as a trace completes. '
+          'Enabling leak checking may have performance impacts: some caching '
+          'is disabled, and other overheads may be added.'),
 )

--- a/jax/core.py
+++ b/jax/core.py
@@ -18,6 +18,7 @@ from operator import attrgetter
 from contextlib import contextmanager, suppress
 from collections import namedtuple
 from functools import total_ordering
+import gc
 import itertools as it
 from weakref import ref
 import threading
@@ -41,21 +42,32 @@ from ._src.pprint_util import pp, vcat, PrettyPrint
 from ._src import traceback_util
 traceback_util.register_exclusion(__file__)
 
-# TODO(dougalm): compilation cache breaks the leak detector. Consisder solving.
-check_leaks = False
-
-# Disables internal invariant checks
-skip_checks = not FLAGS.jax_enable_checks  # not __debug__  # google doesn't use -O
+# TODO(mattjj): move this into debug_state
+skip_checks = not FLAGS.jax_enable_checks
 
 @contextmanager
 def skipping_checks():
-  """Context manager for temporarily disabling checks."""
+  """Context manager for temporarily disabling internal checks."""
   global skip_checks
   old_value, skip_checks = skip_checks, True
   try:
     yield
   finally:
     skip_checks = old_value
+
+@contextmanager
+def checking_leaks():
+  """Context manager for temporarily enabling tracer leak checks."""
+  old_value, debug_state.check_leaks = debug_state.check_leaks, True
+  try:
+    yield
+  finally:
+    debug_state.check_leaks = old_value
+
+class DebugState(threading.local):
+  def __init__(self):
+    self.check_leaks = FLAGS.jax_check_tracer_leaks
+debug_state = DebugState()
 
 zip = safe_zip
 map = safe_map
@@ -742,16 +754,22 @@ def new_main(trace_type: Type[Trace],
   try:
     yield main
   finally:
-    thread_local_state.trace_state.trace_stack.pop()
+    stack.pop()
     if dynamic:
       stack.dynamic = prev_dynamic
 
-  if check_leaks:
+  if debug_state.check_leaks:
     t = ref(main)
     del main
     if t() is not None:
-      print(thread_local_state.trace_state.trace_stack)
-      raise Exception('Leaked trace {}'.format(t()))
+      # handle case where gc doesn't see the leak (Python internal error?)
+      # TODO(mattjj): investigate this issue
+      refs = gc.get_referrers
+      if not (len(refs(t())) == 1 and                          # Trace
+              len(refs(refs(t())[0])) == 1 and                 # Tracer
+              len(refs(refs(refs(t())[0])[0])) == 1 and        # Tracers arglist
+              len(refs(refs(refs(refs(t())[0])[0])[0])) == 0): # nothing...
+        raise Exception(f'Leaked trace {t()}')
 
 @contextmanager
 def new_base_main(trace_type: Type[Trace]) -> Generator[MainTrace, None, None]:
@@ -765,6 +783,12 @@ def new_base_main(trace_type: Type[Trace]) -> Generator[MainTrace, None, None]:
   finally:
     stack.dynamic = prev_dynamic
     stack.stack[0] = prev_base
+
+  if debug_state.check_leaks:
+    t = ref(main)
+    del main
+    if t() is not None:
+      raise Exception('Leaked trace {}'.format(t()))
 
 @contextmanager
 def eval_context():
@@ -780,11 +804,12 @@ def new_sublevel() -> Generator[None, None, None]:
   finally:
     thread_local_state.trace_state.substack.pop()
 
-  if check_leaks:
-    t = ref(sublevel)
-    del sublevel
-    if t() is not None:
-      raise Exception('Leaked sublevel {}'.format(t()))
+  # TODO(mattjj): to check sublevel leaks, we need to make Sublevel weakref-able
+  # if debug_state.check_leaks:
+  #   t = ref(sublevel)
+  #   del sublevel
+  #   if t() is not None:
+  #     raise Exception('Leaked sublevel {}'.format(t()))
 
 def maybe_new_sublevel(trace):
   # dynamic traces run the WrappedFun, so we raise the sublevel for them
@@ -1136,7 +1161,7 @@ class AbstractToken(AbstractValue):
   def str_short(self): return 'Tok'
   def at_least_vspace(self): return self
 
-abstract_token = AbstractToken()
+abstract_token: AbstractToken = AbstractToken()
 
 
 def raise_to_shaped(aval: AbstractValue, weak_type=None):
@@ -1678,7 +1703,7 @@ def omnistaging_disabler() -> None:
     finally:
       thread_local_state.trace_state.trace_stack.pop(bottom)
 
-    if check_leaks:
+    if debug_state.check_leaks:
       t = ref(main)
       del main
       if t() is not None:

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -627,13 +627,14 @@ def _custom_vjp_call_jaxpr_vmap(
     args, in_dims, axis_name, *, fun_jaxpr: core.ClosedJaxpr,
     fwd_jaxpr_thunk: Callable[[], Tuple[core.Jaxpr, Sequence[Any]]],
     bwd: lu.WrappedFun, out_trees: Callable, num_consts: int):
-  size, = {x.shape[d] for x, d in zip(args, in_dims) if d is not not_mapped}
+  axis_size, = {x.shape[d] for x, d in zip(args, in_dims) if d is not not_mapped}
   args = [batching.moveaxis(x, d, 0) if d is not not_mapped and d != 0
           else x for x, d in zip(args, in_dims)]
 
   in_batched = [d is not not_mapped for d in in_dims]
   _, args_batched = split_list(in_batched, [num_consts])
-  batched_fun_jaxpr, out_batched = batching.batch_jaxpr(fun_jaxpr, size, in_batched, False, axis_name)
+  batched_fun_jaxpr, out_batched = batching.batch_jaxpr(
+      fun_jaxpr, axis_size, in_batched, False, axis_name)
   out_dims1 = [0 if b else not_mapped for b in out_batched]
   out_dims2 = []
 
@@ -641,15 +642,14 @@ def _custom_vjp_call_jaxpr_vmap(
   def batched_fwd_jaxpr_thunk():
     fwd_jaxpr = core.ClosedJaxpr(*fwd_jaxpr_thunk())  # consts can be tracers
     batched_fwd_jaxpr, out_batched = batching.batch_jaxpr(
-        fwd_jaxpr, size, args_batched, False, axis_name)
+        fwd_jaxpr, axis_size, args_batched, False, axis_name)
     out_dims2.append([0 if b else not_mapped for b in out_batched])
     return batched_fwd_jaxpr.jaxpr, batched_fwd_jaxpr.consts
 
   fwd_args_batched = [0 if b else not_mapped for b in args_batched]
   fwd_out_dims = lambda: out_dims2[0]
-  # TODO(mattjj,apaszke): Support collectives in custom_vjp?
-  batched_bwd = batching.batch_fun(bwd, fwd_out_dims, fwd_args_batched,
-                                   axis_name='__unused_axis_name', sum_match=True)
+  batched_bwd = batching.batch(bwd, axis_name, axis_size, fwd_out_dims,
+                               fwd_args_batched)
 
   batched_outs = custom_vjp_call_jaxpr_p.bind(
       *args, fun_jaxpr=batched_fun_jaxpr,

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -899,7 +899,10 @@ def closure_convert(fun, *example_args):
   """
   flat_args, in_tree = tree_flatten(example_args)
   in_avals = tuple(map(abstractify, flat_args))
-  return _closure_convert_for_avals(fun, in_tree, in_avals)
+  if core.debug_state.check_leaks:
+    return _closure_convert_for_avals.__wrapped__(fun, in_tree, in_avals)
+  else:
+    return _closure_convert_for_avals(fun, in_tree, in_avals)
 
 @cache()
 def _closure_convert_for_avals(fun, in_tree, in_avals):

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -487,7 +487,7 @@ def defbilinear_broadcasting(bcast, prim, lhs_rule, rhs_rule):
   rhs_jvp = lambda g, x, y, **kwargs: prim.bind(x, bcast(g, x), **kwargs)
   defjvp(prim, lhs_jvp, rhs_jvp)
   primitive_transposes[prim] = partial(bilinear_transpose, lhs_rule, rhs_rule)
-defbilinear = partial(defbilinear_broadcasting, lambda g, x: g)
+defbilinear: Callable = partial(defbilinear_broadcasting, lambda g, x: g)
 
 def bilinear_transpose(lhs_rule, rhs_rule, cotangent, x, y, **kwargs):
   assert is_undefined_primal(x) ^ is_undefined_primal(y)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -28,52 +28,54 @@ from . import partial_eval as pe
 
 map = safe_map
 
+def batch(fun: lu.WrappedFun, axis_name, axis_size, in_dims, out_dim_dests,
+          ) -> lu.WrappedFun:
+  # anlogue of `jvp` in ad.py
+  fun, out_dims_thunk = batch_subtrace(fun)
+  return _match_axes(batchfun(fun, axis_name, axis_size, in_dims),
+                     axis_size, out_dims_thunk, out_dim_dests)
 
-def batch(fun: lu.WrappedFun, in_vals, in_dims, out_dim_dests, axis_name):
-  # executes a batched version of `fun` following out_dim_dests
-  batched_fun = batch_fun(fun, in_dims, out_dim_dests, axis_name=axis_name)
-  return batched_fun.call_wrapped(*in_vals)
+@lu.transformation
+def batchfun(axis_name, axis_size, in_dims, *in_vals):
+  # analogue of `jvpfun` in ad.py
+  in_dims = in_dims() if callable(in_dims) else in_dims
+  in_dims = [canonicalize_axis(ax, np.ndim(x)) if isinstance(ax, int)
+             and not isinstance(core.get_aval(x), core.AbstractUnit)  # non-omnistaging
+             else ax for x, ax in zip(in_vals, in_dims)]
+  with core.new_main(BatchTrace, axis_name=axis_name) as main:
+    with core.extend_axis_env(axis_name, axis_size, main):
+      out_vals = yield (main, in_dims, *in_vals), {}
+      del main
+  yield out_vals
 
 @lu.transformation_with_aux
-def batch_subtrace(main, in_dims, *in_vals, **params):
+def batch_subtrace(main, in_dims, *in_vals):
+  # analogue of `jvp_subtrace` in ad.py
   trace = main.with_cur_sublevel()
   in_tracers = [BatchTracer(trace, val, dim) if dim is not None else val
                 for val, dim in zip(in_vals, in_dims)]
-  outs = yield in_tracers, params
+  outs = yield in_tracers, {}
   out_tracers = map(trace.full_raise, outs)
   out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
   yield out_vals, out_dims
 
-
-def batch_fun(fun : lu.WrappedFun, in_dims, out_dim_dests, axis_name,
-              sum_match=False):
-  # transformation version of batch, which doesn't call the function
-  fun, out_dims = batch_subtrace(fun)
-  return _batch_fun(fun, axis_name, sum_match, in_dims, out_dims, out_dim_dests)
-
 @lu.transformation
-def _batch_fun(axis_name, sum_match, in_dims, out_dims_thunk, out_dim_dests,
-               *in_vals, **params):
-  in_dims = in_dims() if callable(in_dims) else in_dims
-  in_dims = [
-    canonicalize_axis(dim, np.ndim(val)) if isinstance(dim, int) else dim
-    for val, dim in zip(in_vals, in_dims)]
-  axis_size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
-  with core.new_main(BatchTrace, axis_name=axis_name) as main:
-    with core.extend_axis_env(axis_name, axis_size, main):
-      out_vals = yield (main, in_dims,) + in_vals, params
-      del main
+def _match_axes(axis_size, out_dims_thunk, out_dim_dests, *in_vals):
+  out_vals = yield in_vals, {}
   out_dim_dests = out_dim_dests() if callable(out_dim_dests) else out_dim_dests
   out_dims = out_dims_thunk()
   for od, od_dest in zip(out_dims, out_dim_dests):
-    if od is not None and not isinstance(od_dest, int) and not sum_match:
+    if od is not None and not isinstance(od_dest, int):
       msg = f"vmap has mapped output but out_axes is {od_dest}"
       raise ValueError(msg)
-  out_vals = map(partial(matchaxis, axis_size, sum_match=sum_match),
-                 out_dims, out_dim_dests, out_vals)
-  yield out_vals
+  yield map(partial(matchaxis, axis_size), out_dims, out_dim_dests, out_vals)
 
-def batch_fun2(fun : lu.WrappedFun, in_dims):
+
+# These next two functions, `batch_fun2` and `_batch_fun2`, are deprecated; the
+# former is only called from `custom_transforms`, which itself is deprecated.
+# TODO(mattjj): delete these along with custom_transforms
+
+def batch_fun2(fun: lu.WrappedFun, in_dims):
   # like `batch_fun` but returns output batch dims (so no out_dim_dests)
   fun, out_dims = batch_subtrace(fun)
   return _batch_fun2(fun, in_dims), out_dims
@@ -248,11 +250,12 @@ class BatchTrace(Trace):
 
   def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, *, out_trees):
     in_vals, in_dims = unzip2((t.val, t.batch_dim) for t in tracers)
+    axis_size, = {x.shape[d] for x, d in zip(in_vals, in_dims)
+                  if d is not not_mapped}
     fun, out_dims1 = batch_subtrace(fun, self.main, in_dims)
     fwd, out_dims2 = batch_subtrace(fwd, self.main, in_dims)
-    # TODO(mattjj,apaszke): support collectives in custom_vjp?
-    bwd = batch_fun(bwd, out_dims2, in_dims,
-                    axis_name='__unused_axis_name', sum_match=True)
+    bwd = batch_custom_vjp_bwd(bwd, self.axis_name, axis_size,
+                               out_dims2, in_dims)
     out_vals = prim.bind(fun, fwd, bwd, *in_vals, out_trees=out_trees)
     fst, out_dims = lu.merge_linear_aux(out_dims1, out_dims2)
     if not fst:
@@ -270,6 +273,18 @@ def _main_trace_for_axis_names(main_trace: core.MainTrace,
   if not isinstance(axis_name, (list, tuple)):
     axis_name = (axis_name,)
   return any(main_trace is core.axis_frame(n).main_trace for n in axis_name)
+
+def batch_custom_vjp_bwd(bwd, axis_name, axis_size, in_dims, out_dim_dests):
+  bwd, out_dims_thunk = batch_subtrace(bwd)
+  return _match_axes_and_sum(batchfun(bwd, axis_name, axis_size, in_dims),
+                             axis_size, out_dims_thunk, out_dim_dests)
+
+@lu.transformation
+def _match_axes_and_sum(axis_size, out_dims_thunk, out_dim_dests, *in_vals):
+  # this is like _match_axes, but we do reduce-sums as needed
+  out_vals = yield in_vals, {}
+  yield map(partial(matchaxis, axis_size, sum_match=True),
+            out_dims_thunk(), out_dim_dests, out_vals)
 
 
 ### primitives
@@ -399,35 +414,30 @@ def bdim_at_front(x, bdim, size):
     return moveaxis(x, bdim, 0)
 
 
-def _promote_aval_rank(sz, aval):
-  if aval is core.abstract_unit:
-    return core.abstract_unit
-  else:
-    return ShapedArray((sz,) + aval.shape, aval.dtype)
-
-def batch_jaxpr(closed_jaxpr, size, batched, instantiate, axis_name):
+def batch_jaxpr(closed_jaxpr, axis_size, in_batched, instantiate, axis_name):
   f = lu.wrap_init(core.jaxpr_as_fun(closed_jaxpr))
-  f, batched_out = batched_traceable(f, size, batched, instantiate, axis_name)
-  avals_in = [_promote_aval_rank(size, a) if b else a
-              for a, b in zip(closed_jaxpr.in_avals, batched)]
+  f, out_batched = batch_subtrace_instantiate(f, instantiate, axis_size)
+  f = batchfun(f, axis_name, axis_size, [0 if b else None for b in in_batched])
+  avals_in = [core.unmapped_aval(axis_size, 0, aval) if b else aval
+              for aval, b in zip(closed_jaxpr.in_avals, in_batched)]
   jaxpr_out, _, consts = pe.trace_to_jaxpr_dynamic(f, avals_in)
-  return core.ClosedJaxpr(jaxpr_out, consts), batched_out()
+  return core.ClosedJaxpr(jaxpr_out, consts), out_batched()
 
 @lu.transformation_with_aux
-def batched_traceable(size, batched, instantiate, axis_name, *vals):
-  in_dims = [0 if b else None for b in batched]
-  with core.new_main(BatchTrace, axis_name=axis_name) as main:
-    with core.extend_axis_env(axis_name, size, main):
-      trace = main.with_cur_sublevel()
-      in_tracers = map(partial(BatchTracer, trace), vals, in_dims)
-      ans = yield in_tracers, {}
-      out_tracers = map(trace.full_raise, ans)
-      out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
-      del main, trace, ans, in_tracers, out_tracers
+def batch_subtrace_instantiate(instantiate, axis_size, main, in_dims, *in_vals):
+  # this is like `batch_subtrace` but we take an extra `instantiate` arg
+  # analogue of `jvp_subtrace` in ad.py
+  trace = main.with_cur_sublevel()
+  in_tracers = [BatchTracer(trace, val, dim) if dim is not None else val
+                for val, dim in zip(in_vals, in_dims)]
+  outs = yield in_tracers, {}
+  out_tracers = map(trace.full_raise, outs)
+  out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
+
   if type(instantiate) is bool:
     instantiate = [instantiate] * len(out_vals)
   out_vals = [moveaxis(x, d, 0) if d is not not_mapped and d != 0
-              else broadcast(x, size, 0) if d is not_mapped and inst else x
+              else broadcast(x, axis_size, 0) if d is not_mapped and inst else x
               for x, d, inst in zip(out_vals, out_dims, instantiate)]
   out_batched = [d is not not_mapped or inst
                  for d, inst in zip(out_dims, instantiate)]
@@ -464,15 +474,16 @@ def _merge_bdims(x, y):
 def omnistaging_disabler() -> None:
   global batch_jaxpr
 
-  def batch_jaxpr(jaxpr, size, batched, instantiate, axis_name):
+  def batch_jaxpr(jaxpr, axis_size, in_batched, instantiate, axis_name):
     f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
-    f, batched_out = batched_traceable(f, size, batched, instantiate, axis_name)
-    avals_in = [_promote_aval_rank(size, a) if b else a
-                for a, b in zip(jaxpr.in_avals, batched)]
+    f, out_batched = batch_subtrace_instantiate(f, instantiate, axis_size)
+    f = batchfun(f, axis_name, axis_size, [0 if b else None for b in in_batched])
+    avals_in = [core.unmapped_aval(axis_size, 0, aval) if b else aval
+                for aval, b in zip(jaxpr.in_avals, in_batched)]
     in_pvals = [pe.PartialVal.unknown(aval) for aval in avals_in]
     jaxpr_out, pvals_out, consts_out = pe.trace_to_jaxpr(f, in_pvals, instantiate=True)
     avals_out, _ = unzip2(pvals_out)
-    return core.ClosedJaxpr(jaxpr_out, consts_out), batched_out()
+    return core.ClosedJaxpr(jaxpr_out, consts_out), out_batched()
 
 
 collective_rules: Dict[core.Primitive, Callable] = {}

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -505,7 +505,7 @@ def trace_to_jaxpr(fun: lu.WrappedFun, pvals: Sequence[PartialVal],
     fun = trace_to_subjaxpr(fun, main, instantiate)
     jaxpr, (out_pvals, consts, env) = fun.call_wrapped(pvals)
     assert not env
-    del main
+    del main, fun, env
 
   return jaxpr, out_pvals, consts
 
@@ -1184,7 +1184,7 @@ def trace_to_jaxpr_dynamic(fun: lu.WrappedFun, in_avals: Sequence[AbstractValue]
     main.source_info = fun_sourceinfo(fun.f)  # type: ignore
     main.jaxpr_stack = ()  # type: ignore
     jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(fun, main, in_avals)
-    del main
+    del main, fun
   return jaxpr, out_avals, consts
 
 def trace_to_subjaxpr_dynamic(fun: lu.WrappedFun, main: core.MainTrace,
@@ -1195,7 +1195,8 @@ def trace_to_subjaxpr_dynamic(fun: lu.WrappedFun, main: core.MainTrace,
     in_tracers = map(trace.new_arg, in_avals)
     ans = fun.call_wrapped(*in_tracers)
     out_tracers = map(trace.full_raise, ans)
-  jaxpr, out_avals, consts = frame.to_jaxpr(in_tracers, out_tracers)
+    jaxpr, out_avals, consts = frame.to_jaxpr(in_tracers, out_tracers)
+    del fun, main, trace, frame, in_tracers, out_tracers, ans
   return jaxpr, out_avals, consts
 
 @contextlib.contextmanager
@@ -1213,7 +1214,7 @@ def trace_to_jaxpr_final(fun: lu.WrappedFun, in_avals: Sequence[AbstractValue]):
     main.source_info = fun_sourceinfo(fun.f)  # type: ignore
     main.jaxpr_stack = ()  # type: ignore
     jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(fun, main, in_avals)
-    del main
+    del fun, main
   return jaxpr, out_avals, consts
 
 def partial_eval_to_jaxpr_dynamic(fun: lu.WrappedFun, in_pvals: Sequence[PartialVal]):

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1542,10 +1542,7 @@ def vtile(f_flat,
     yield map(untile_axis, outputs_flat, out_axes_flat)
 
   return _map_to_tile(
-    batching.batch_fun(f_flat,
-                       in_axes_flat,
-                       out_axes_flat,
-                       axis_name=axis_name))
+      batching.batch(f_flat, axis_name, tile_size, in_axes_flat, out_axes_flat))
 
 _forbidden_primitives = {
   'xla_pmap': 'pmap',

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1438,7 +1438,7 @@ def _remat_translation_rule(c, axis_env, in_nodes,
   dummy_subc = dummy_subc.build(xops.Tuple(dummy_subc, out_nodes))
 
   return xops.Conditional(pred, true_op, remat_subc, false_op, dummy_subc)
-call_translations[pe.remat_call_p] = _remat_translation_rule
+call_translations[pe.remat_call_p] = _remat_translation_rule  # type: ignore
 
 
 ad.primitive_transposes[core.named_call_p] = partial(ad.call_transpose,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2174,6 +2174,127 @@ class APITest(jtu.JaxTestCase):
     # Should not crash.
     vjp_fun(arr)
 
+  def test_leak_checker_catches_a_jit_leak(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      lst = []
+
+      @jit
+      def f(x):
+        lst.append(x)
+        return x
+
+      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+        f(3)
+
+  def test_leak_checker_catches_a_pmap_leak(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      lst = []
+
+      @api.pmap
+      def f(x):
+        lst.append(x)
+        return x
+
+      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+        f(np.ones(1))
+
+  def test_leak_checker_catches_a_grad_leak(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      lst = []
+
+      def f(x):
+        lst.append(x)
+        return x
+
+      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+        api.grad(f)(3.)
+
+  def test_leak_checker_avoids_false_positives(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      @jit
+      def f(x):
+        return x
+      f(3)  # doesn't crash
+      api.vmap(f)(np.arange(3))  # doesn't crash
+      api.grad(f)(3.)  # doesn't crash
+
+      @api.pmap
+      def f(x):
+        return x
+      f(np.ones(1))  # doesn't crash
+      api.vmap(f)(np.ones((1, 1)))  # doesn't crash
+
+  def test_leak_checker_catches_a_scan_leak(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      lst = []
+
+      to_scan = lambda c, x: (lst.append(c) or jnp.sin(c), None)
+
+      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+        lax.scan(to_scan, 1., np.arange(3.))
+
+  def test_leak_checker_avoids_false_positives_scan(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      to_scan = lambda c, x: (jnp.sin(c), None)
+      lax.scan(to_scan, 1., np.arange(3.))  # doesn't crash
+
+  def test_leak_checker_avoids_false_positives_scan_jvp(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      to_scan = lambda c, x: (c, None)
+
+      def f(x):
+        lax.scan(to_scan, x, None, length=1)
+      api.jvp(f, (3.,), (1.,))  # doesn't crash
+
+  def test_leak_checker_avoids_false_positives_scan_vmap(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      to_scan = lambda c, _: (1., None)
+
+      @api.vmap
+      def f(x):
+        print(x)
+        lax.scan(to_scan, x, None, length=1)
+      f(np.arange(5.))  # doesn't crash
+
+  def test_leak_checker_avoids_false_positives_scan_vmap_2(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    # This test covers an edge case which fails without the extra check in
+    # core.py, with the comment "gc doesn't see the leak".
+    with core.checking_leaks():
+      to_scan = lambda c, _: (c, None)
+
+      @api.vmap
+      def f(x):
+        print(x)
+        lax.scan(to_scan, x, None, length=1)
+      f(np.arange(5.))  # doesn't crash
+
 
 class RematTest(jtu.JaxTestCase):
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2276,7 +2276,6 @@ class APITest(jtu.JaxTestCase):
 
       @api.vmap
       def f(x):
-        print(x)
         lax.scan(to_scan, x, None, length=1)
       f(np.arange(5.))  # doesn't crash
 
@@ -2284,14 +2283,11 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    # This test covers an edge case which fails without the extra check in
-    # core.py, with the comment "gc doesn't see the leak".
     with core.checking_leaks():
       to_scan = lambda c, _: (c, None)
 
       @api.vmap
       def f(x):
-        print(x)
         lax.scan(to_scan, x, None, length=1)
       f(np.arange(5.))  # doesn't crash
 


### PR DESCRIPTION
Revive the tracer leak-checker! It's best to think of this feature as part of a 'debug mode', as it disables some caches and adds some data structure traversals/copying on jit cache misses, which might affect performance (but perhaps in unimportant ways).

Coauthored with @jekbradbury.

The idea is to provide a flag and corresponding context manager for enabling leak-checking, raising an error as soon as a trace finishes where one of its corresponding tracers was stashed in global context by a user side-effect:

```python
lst = []

@jit
def f(x):
  lst.append(x)
  return x

with jax.core.checking_leaks():
  f(3.)  # raises exception!
```

One can alternatively enable the leak checker globally using the env var `JAX_CHECK_TRACER_LEAKS` and the corresponding flag.

This should help us (and eventually users) catch one of the main sources of confusing bugs with JAX, for new users and old ones alike. (It also should make it easier to squash the trickiest omnistaging issues.)

The implementation mechanism is one that @dougalm devised long ago, before we even had this version of JAX hooked up to XLA: use Python reference counting! More specifically:
1. when we kick off a transformation's tracing, we create exactly one MainTrace instance;
2. all Tracer instances (the things that box values, which propagate through user code) have a reference to that MainTrace instance (indirectly, by having references to Trace instances which in turn have references to the MainTrace instance);
3. users never get references to MainTrace or Trace instances, and instead only get references to Tracers, which they might stash with side-effect bugs;
4. so once we've completed a trace, if we delete our reference to the MainTrace instance, then it should have zero references, unless the user code leaked a Tracer;
5. we can check whether there are any remaining references using the `weakref` API, relying on Python's reference counting.

On that last point, the basic mechanism looks like this, after we've completed the trace:

```python
t = ref(main)
del main
if t() is not None:
  raise Exception("leaked tracer!")
```

The trouble with this approach, and the reason why we had to disable it when we hooked up XLA, is caching. Our caches tend to hold onto MainTraces or Tracers. In particular:
1. the `jit` and `pmap` caching mechanisms, namely `linear_util.cache` and the C++-jit-dispatch equivalent, hold references to MainTrace instances in their key (via the `linear_util.WrappedFun` `transforms` attribute);
2. the caching we do with the `util.cache` decorator for control flow can hold references to Tracers in their output (e.g. if we have closed-over traced constants) as well as (I think) Tracers in their input (if the Python callable closes over Tracers).

We solve those two issues in this PR by, respectively,:
1. when we're checking leaks, copy all MainTrace instances when forming the `linear_util.cache` key, since we only need equality not identity;
2. when we're checking leaks, disable all `util.cache` caching.

~There was one other hitch: the `test_leak_checker_avoids_false_positives_scan_vmap_2` test case shows something that kept giving false positives, even though if we swapped the `vmap` transform for a `jvp` transform things would work. I couldn't figure out what was persisting a reference to the MainTrace! Using `gc.get_referrers`, I found that as far as the garbage collector could tell, there _were_ no remaining references: there was a MainTrace referred to by a BatchTrace, which was referred to by a BatchTracer (corresponding to one of the inputs to the vmapped function), which was referred to by a single-element list containing that BatchTracer (the `in_tracers` list for the function), which was referenced by... nothing! I wonder if it's a CPython bug or something. In any case, I just added a [special check for this pattern, where `gc` thinks there are no live references to the tracer](https://github.com/google/jax/pull/5492/files#diff-6bc6fb90ca348a8206e5beaccb59ed850154ace9a3683019641e5e690008281bR765-R772), to rule out this false positive. I think this hack is okay because (a) this is just for a debug mode so performance doesn't matter, and (b) this hack might buy us a debugging superpower!~

^- Of course, @hawkinsp figured this issue out! What a baller. Here's what was up: it had to do with how `batch_jaxpr` was factored differently from `jvp_jaxpr`, and in particular how in `jvp_jaxpr` the main trace is created in a different lu.transformation than the one that creates/destroys the tracers ([1](https://github.com/google/jax/blob/bc3cd1286b506803b7d4eafd313be162565ee2d2/jax/interpreters/ad.py#L53-L54), [2](https://github.com/google/jax/blob/bc3cd1286b506803b7d4eafd313be162565ee2d2/jax/interpreters/ad.py#L68)) whereas with `batch_jaxpr` those two things were fused [3](https://github.com/google/jax/blob/bc3cd1286b506803b7d4eafd313be162565ee2d2/jax/interpreters/batching.py#L419-L422). In the batching case, that led to `lu.WrappedFun.call_wrapped` holding onto a tracer reference in its `ans`, and then `gen.send(ans)` triggering the leak check before that `ans` ref had been dropped (by assigning `ans = gen.send(ans)`, i.e. clobbering the lhs) ([4](https://github.com/google/jax/blob/bc3cd1286b506803b7d4eafd313be162565ee2d2/jax/linear_util.py#L173)). By separating the two, the tracer creation/elimination and the main trace creation, the jvp approach didn't have this issue, as there were two separate evaluations of the `ans = gen.send(ans)` line, one for each of the transformations: the first one served to drop all references to the tracers and the second triggered the check.

(I had _thought_ I had ruled out this explanation, by doing `ans = [ans]; ans = gen.send(ans.pop())`, but apparently that doesn't drop the reference to the arg in the caller frame.)

Ultimately the solution was just to refactor the batching.py logic to be more like the ad.py logic, which gave the opportunity to clean it up in other ways too. We think an alternative would be to follow the convention everywhere that what gets sent into the generator is some unpackable object, like a list you pop from or maybe a single-element iterator, so that the callee can destroy the remaining references, but we haven't explored that yet.

Some follow-up work:
* make the leaked tracer error message better, in particular including source provenance for the leaked tracer (maybe by following the `gc.get_referrers` trail up from the MainTrace instance we have in hand to find any Tracers that still live)