### PR TITLE
Fix exception when tokens are used in AD.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1134,6 +1134,7 @@ class AbstractToken(AbstractValue):
     else:
       assert False, f"Cannot join {self} with {other}"
   def str_short(self): return 'Tok'
+  def at_least_vspace(self): return self
 
 abstract_token = AbstractToken()
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -367,10 +367,9 @@ def _execute_replicated_primitive(prim, compiled, result_handler, *args):
 
 
 def check_special(prim, bufs):
-  for buf in bufs:
-    # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58 is
-    # the default.
-    _check_special(prim.name, getattr(buf, "xla_shape", buf.shape)(), buf)
+  if FLAGS.jax_debug_infs or FLAGS.jax_debug_nans:
+    for buf in bufs:
+      _check_special(prim.name, buf.xla_shape(), buf)
 
 def _check_special(name, xla_shape, buf):
   assert not xla_shape.is_tuple()


### PR DESCRIPTION
Fixes #5463 

Also avoids calling some .shape methods when we aren't checking infs or nans. These currently crash for tokens; that's a problem I will look into separately.