### PR TITLE
add support for scipy.stats.poisson.cdf

### DIFF
--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -18,7 +18,7 @@ import scipy.stats as osp_stats
 from jax import lax
 from jax._src.numpy.util import _wraps
 from jax._src.numpy import lax_numpy as jnp
-from jax.scipy.special import xlogy, gammaln
+from jax.scipy.special import xlogy, gammaln, gammaincc
 
 
 @_wraps(osp_stats.poisson.logpmf, update_doc=False)
@@ -32,3 +32,11 @@ def logpmf(k, mu, loc=0):
 @_wraps(osp_stats.poisson.pmf, update_doc=False)
 def pmf(k, mu, loc=0):
   return jnp.exp(logpmf(k, mu, loc))
+
+@_wraps(osp_stats.poisson.cdf, update_doc=False)
+def cdf(k, mu, loc=0):
+  k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
+  zero = jnp._constant_like(k, 0)
+  x = lax.sub(k, loc)
+  p = gammaincc(jnp.floor(1 + x), mu)
+  return jnp.where(lax.lt(x, zero), zero, p)

--- a/jax/scipy/stats/poisson.py
+++ b/jax/scipy/stats/poisson.py
@@ -17,4 +17,5 @@
 from jax._src.scipy.stats.poisson import (
   logpmf,
   pmf,
+  cdf
 )

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -79,6 +79,23 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     self._CompileAndCheck(lax_fun, args_maker)
 
   @genNamedParametersNArgs(3)
+  def testPoissonCdf(self, shapes, dtypes):
+    rng = jtu.rand_default(self.rng())
+    scipy_fun = osp_stats.poisson.cdf
+    lax_fun = lsp_stats.poisson.cdf
+
+    def args_maker():
+      k, mu, loc = map(rng, shapes, dtypes)
+      # clipping to ensure that rate parameter is strictly positive
+      mu = np.clip(np.abs(mu), a_min=0.1, a_max=None)
+      return [k, mu, loc]
+
+    self._CheckAgainstNumpy(scipy_fun, lax_fun, args_maker, check_dtypes=False,
+                            tol=1e-3)
+    self._CompileAndCheck(lax_fun, args_maker)
+
+
+  @genNamedParametersNArgs(3)
   def testBernoulliLogPmf(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     scipy_fun = osp_stats.bernoulli.logpmf


### PR DESCRIPTION
This adds support for evaluating the cumulative distribution function of a Poisson random variable.