### PR TITLE
Switched lax.linalg.eigh return order

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,8 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     of array arguments: {func}`jax.numpy.pad`, :func`jax.numpy.ravel`,
     {func}`jax.numpy.repeat`, {func}`jax.numpy.reshape`.
     In general, {mod}`jax.numpy` functions should be used with scalars or array arguments.
+  * Reversed the order of {func}`jax.lax.linalg.eigh` and underlying primitives to be
+    consistent with documentation and `numpy` and `scipy` wrappers.
 
 ## jaxlib 0.1.62 (Unreleased)
 
@@ -561,7 +563,7 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
   >   > * Forward-mode automatic differentiation (`jvp`) of while loop
   >   (<https://github.com/google/jax/pull/1980>)
   > * New NumPy and SciPy functions:
-  >   
+  >
   >   * {py:func}`jax.numpy.fft.fft2`
   >   * {py:func}`jax.numpy.fft.ifft2`
   >   * {py:func}`jax.numpy.fft.rfft`

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -276,7 +276,7 @@ def eigh(a, UPLO=None, symmetrize_input=True):
     raise ValueError(msg)
 
   a = _promote_arg_dtypes(jnp.asarray(a))
-  v, w = lax_linalg.eigh(a, lower=lower, symmetrize_input=symmetrize_input)
+  w, v = lax_linalg.eigh(a, lower=lower, symmetrize_input=symmetrize_input)
   return w, v
 
 

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -87,7 +87,7 @@ def eigh(a, b=None, lower=True, eigvals_only=False, overwrite_a=False,
         "Only the eigvals=None case of eigh is implemented.")
 
   a = np_linalg._promote_arg_dtypes(jnp.asarray(a))
-  v, w = lax_linalg.eigh(a, lower=lower)
+  w, v = lax_linalg.eigh(a, lower=lower)
 
   if eigvals_only:
     return w


### PR DESCRIPTION
`eigh_p` implementations return `(vectors, values)`. This is propagated into `lax.linalg.eigh`, which is inconsistent both with it's documentation and `jax.[numpy,scipy].linalg.eigh` return order.

This PR reverses the order of the returned arguments in `jax.linalg.eigh`, making it consistent with `numpy`/`scipy` variants and existing documentation, though not `eigh_p` implementations.

This is a breaking change. A non-breaking version of this PR could just fix the documentation and be non-breaking. It won't break code using `jax.[numpy,scipy]` variants.

The inconsistency still exists between `eigh_p` implementations and `lax.linalg.eigh`, but I'm afraid I don't know enough about `xla` internals (e.g. `eigh_translation_rule` and `xops.Eigh`) to fix that.