### PR TITLE
Improve batched collective rule for all_gather_p

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -743,6 +743,13 @@ def _all_gather_via_psum(x, *, all_gather_dimension, axis_name, axis_index_group
   outs = tree_util.tree_map(partial(_expand, all_gather_dimension, axis_size, index), x)
   return psum(outs, axis_name, axis_index_groups=axis_index_groups)
 
+def _all_gather_impl(x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size):
+  # Only called when the argument is not mapped.
+  out_shape = list(x.shape)
+  out_shape.insert(all_gather_dimension, axis_size)
+  broadcast_dims = [i for i in range(len(out_shape)) if i != all_gather_dimension]
+  return lax.broadcast_in_dim(x, out_shape, broadcast_dims)
+
 def _all_gather_translation_rule(c, x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size, axis_env, platform):
   # TODO(cjfj): Enable this for TPU also?
   if (platform == 'gpu') and (all_gather_dimension == 0):
@@ -800,6 +807,7 @@ def _all_gather_batched_collective(frame, vals_in, dims_in, all_gather_dimension
 
 all_gather_p = core.Primitive('all_gather')
 all_gather_p.def_abstract_eval(_all_gather_abstract_eval)
+all_gather_p.def_impl(_all_gather_impl)
 xla.parallel_translations[all_gather_p] = _all_gather_translation_rule
 ad.deflinear2(all_gather_p, _all_gather_transpose_rule)
 pxla.multi_host_supported_collectives.add(all_gather_p)

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -796,14 +796,7 @@ def _all_gather_batched_collective(frame, vals_in, dims_in, all_gather_dimension
   assert axis_name == frame.name, "batcher called with wrong axis name"
   (x,), (d,) = vals_in, dims_in
   assert d is not batching.not_mapped
-  if d <= all_gather_dimension:
-    all_gather_dimension += 1
-  else:
-    d += 1
-  out_shape = list(x.shape)
-  out_shape.insert(all_gather_dimension, axis_size)
-  broadcast_dims = [i for i in range(len(out_shape)) if i != all_gather_dimension]
-  return lax.broadcast_in_dim(x, out_shape, broadcast_dims), d
+  return _moveaxis(d, all_gather_dimension, x), batching.not_mapped
 
 all_gather_p = core.Primitive('all_gather')
 all_gather_p.def_abstract_eval(_all_gather_abstract_eval)

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -745,7 +745,7 @@ def _all_gather_via_psum(x, *, all_gather_dimension, axis_name, axis_index_group
 
 def _all_gather_impl(x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size):
   # Only called when the argument is not mapped.
-  out_shape = list(x.shape)
+  out_shape = list(np.shape(x))
   out_shape.insert(all_gather_dimension, axis_size)
   broadcast_dims = [i for i in range(len(out_shape)) if i != all_gather_dimension]
   return lax.broadcast_in_dim(x, out_shape, broadcast_dims)

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1170,6 +1170,41 @@ class BatchingTest(jtu.JaxTestCase):
     y = vmap(f)(a=jnp.array([1]), b=jnp.array([2]))  # doesn't work
     self.assertAllClose(x, y)
 
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testAllGatherToUnmapped(self):
+    def f(x):
+      return lax.all_gather(x, axis_name='i')
+
+    x = jnp.arange(15).reshape((3, 5))
+    # Original mapped axis becomes first axis of unmapped return value.
+    self.assertAllClose(vmap(f, axis_name='i', in_axes=1, out_axes=None)(x), x.T)
+
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testBatchedAllGather(self):
+    def f(x):
+      return lax.all_gather(x, axis_name='i')
+
+    x = jnp.arange(15).reshape((3, 5))
+    res = vmap(vmap(f, axis_name='i', out_axes=None), axis_name='j')(x)
+    self.assertAllClose(res, x)
+
+    res = vmap(vmap(f, axis_name='j'), axis_name='i', out_axes=None)(x)
+    self.assertAllClose(res, x.T)
+
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testAllGatherVjp(self):
+    def f(x):
+      return lax.all_gather(x, axis_name='i')
+
+    rng = np.random.RandomState(1)
+    x = rng.randn(3, 4)
+    y_bar = rng.randn(3, 3, 4)
+
+    x_bar, = vmap(lambda x, y_bar: vjp(f, x)[1](y_bar), axis_name='i')(x, y_bar)
+    self.assertAllClose(x_bar, np.sum(y_bar, axis=0))
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1210,12 +1210,14 @@ class BatchingTest(jtu.JaxTestCase):
           "vmap collectives only supported when omnistaging is enabled")
   def testAllGatherOfConst(self):
     def f(x):
-      return lax.all_gather(jnp.ones_like(x), axis_name='i')
+      a = lax.all_gather(jnp.ones_like(x), axis_name='i')
+      b = lax.all_gather(1, axis_name='i')
+      return a, b
 
     x = jnp.arange(15).reshape((3, 5))
-    self.assertAllClose(
-      vmap(f, axis_name='i', in_axes=1, out_axes=None)(x),
-      jnp.ones(shape=(5, 3), dtype=x.dtype))
+    a, b = vmap(f, axis_name='i', in_axes=1, out_axes=None)(x)
+    self.assertAllClose(a, jnp.ones(shape=(5, 3), dtype=x.dtype))
+    self.assertAllClose(b, jnp.ones(shape=(5,), dtype=b.dtype))
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
When an `all_gather` references a `vmap`ped axis, there is a particularly simple way of implementing it: simply "forget" that the axis was mapped, and return the full array. Conveniently, this doesn't require any explicit broadcasting, and makes it possible to use `out_axes=None` with the results.

Also adds an evaluation rule for `all_gather`, which lets you gather constants under a `vmap`. I think I'm missing something here, though, because it seems to not work under a `jit` of `vmap`. Happy to fix that if it's easy, or remove the evaluation rule if it's not the right approach.