### PR TITLE
add axis_env argument to make_jaxpr

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2775,6 +2775,15 @@ class JaxprTest(jtu.JaxTestCase):
                 api.ShapeDtypeStruct(shape=(2,), dtype=jnp.float32))
     self.assertEqual(shape_tree, expected)
 
+  def test_make_jaxpr_axis_env(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    def f(x):
+      return x - lax.psum(x, 'i')
+    jaxpr = api.make_jaxpr(f, axis_env=[('i', 4)])(2)
+    self.assertIn('psum', str(jaxpr))
+
 
 class LazyTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
fixes #5522

```python
import jax

def f(x):
  return x - jax.lax.psum(x, 'i')
jaxpr = jax.make_jaxpr(f, axis_env=[('i', 4)])(2)
print(jaxpr)
```

```
{ lambda  ; a.
  let b = psum[ axis_index_groups=None
                axis_name=('i',) ] a
      c = sub a b
  in (c,) }
```