### PR TITLE
implement soft_pmap in terms of xmap

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -69,7 +69,6 @@ from .api import (
   shapecheck,
   ShapedArray,
   ShapeDtypeStruct,
-  soft_pmap,
   # TODO(phawkins): hide tree* functions from jax, update callers to use
   # jax.tree_util.
   treedef_is_leaf,
@@ -86,6 +85,7 @@ from .api import (
   xla,  # TODO(phawkins): update users to avoid this.
   xla_computation,
 )
+from .experimental.maps import soft_pmap
 from .version import __version__
 
 # These submodules are separate because they are in an import cycle with

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -35,8 +35,8 @@ from jax import tree_util
 from jax import lax
 from jax import random
 from jax.core import ShapedArray
-from jax.api import (pmap, soft_pmap, jit, vmap, jvp, grad, make_jaxpr,
-                     linearize, device_put)
+from jax import (pmap, soft_pmap, jit, vmap, jvp, grad, make_jaxpr,
+                 linearize, device_put)
 from jax.lib import xla_bridge
 from jax._src.util import prod, safe_map
 from jax.interpreters import pxla
@@ -99,9 +99,6 @@ def tearDownModule():
   else:
     os.environ["XLA_FLAGS"] = prev_xla_flags
   xla_bridge.get_backend.cache_clear()
-
-ignore_soft_pmap_warning = partial(
-  jtu.ignore_warning, message="soft_pmap is an experimental.*")
 
 ignore_jit_of_pmap_warning = partial(
   jtu.ignore_warning, message=".*jit-of-pmap.*")
@@ -1239,7 +1236,7 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(r, arr + 1)
     self.assertEqual(len(r.device_buffers), 6)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapBatchMatmul(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1249,7 +1246,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.einsum('nij,njk->nik', xs, ys)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapBatchMatmulJit(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1259,7 +1256,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.einsum('nij,njk->nik', xs, ys)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapPsumConstant(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1269,7 +1266,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = n * np.ones(n)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapPsum(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1279,7 +1276,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.ones(n) / n
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapAxisIndex(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1289,7 +1286,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = 2 * np.arange(n)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapOfJit(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     n = 4 * xla_bridge.device_count()
@@ -1299,7 +1296,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = 3 * np.arange(n)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapNested(self):
     raise SkipTest("not implemented")  # TODO(mattjj): re-implement
     n = 4 * xla_bridge.device_count()
@@ -1314,7 +1311,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.arange(n ** 2).reshape(n, n).T
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testGradOfSoftPmap(self):
     raise SkipTest("not implemented")  # TODO(mattjj): re-implement
     n = 4 * xla_bridge.device_count()
@@ -1327,7 +1324,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.repeat(np.arange(n)[:, None], n, axis=1)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @ignore_soft_pmap_warning()
+  @ignore_xmap_warning()
   def testSoftPmapDevicePersistence(self):
     if not config.omnistaging_enabled: raise SkipTest("requires omnistaging")
     device_count = xla_bridge.device_count()


### PR DESCRIPTION
We can kill `soft_pmap`, now that `xmap` subsumes it!

~However, there are still two tests that don't work.~ There were two tests that were tricky. They failed because [on this line in `pxla.vtile`, the value of `tile_size: Optional[int]` may be `None`](https://github.com/google/jax/blob/1fd1faa06ca12fed2332ec52b943b4a76bd99da1/jax/interpreters/pxla.py#L1562), but that leads to populating an [`core.AxisEnvFrame`](https://github.com/google/jax/blob/1fd1faa06ca12fed2332ec52b943b4a76bd99da1/jax/core.py#L698) with a `None` in its `size` field (which seems maybe invalid?), and that ultimately leads to things like [`axis_index`](https://github.com/google/jax/blob/1fd1faa06ca12fed2332ec52b943b4a76bd99da1/jax/_src/lax/parallel.py#L983) and [`psum`-of-constant](https://github.com/google/jax/blob/1fd1faa06ca12fed2332ec52b943b4a76bd99da1/jax/_src/lax/parallel.py#L618) failing because they rely on having an integer value of `frame.size`.

I introduced this issue in #5492 because that added `axis_size` to the `batching.batch` function that `pxla.vtile` uses, yet at the call site in `pxla.vtile` the axis size could be `None` because it needs to be inferred from the arguments. That is, after #5492 we assumed the caller of `batching.batch` knows the axis size, but that's not true for `pxla.vtile`. (Our `xmap` tests had not caught the issue, for whatever reason!)

In 71e820a I revised `batching.batchfun` (and `batching._match_axes`) to again allow their `axis_size` arguments to be optional. But to simplify them I'm curious if we can instead adapt `pxla.vtile` to have the axis size on hand.

cc @apaszke 