### PR TITLE
Use myst-nb to build docs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -121,7 +121,6 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        sudo apt install -y pandoc
         pip install -r docs/requirements.txt
     - name: Test documentation
       run: |

--- a/docs/async_dispatch.rst
+++ b/docs/async_dispatch.rst
@@ -1,3 +1,5 @@
+.. _async-dispatch:
+
 Asynchronous dispatch
 =====================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,9 +66,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'matplotlib.sphinxext.plot_directive',
-    'nbsphinx',
     'sphinx_autodoc_typehints',
-    'myst_parser',
+    'myst_nb',
 ]
 
 intersphinx_mapping = {
@@ -81,9 +80,11 @@ intersphinx_mapping = {
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-source_suffix = '.rst'
+# Note: important to list ipynb before md here: we have both md and ipynb
+# copies of each notebook, and myst will choose which to convert based on
+# the order in the source_suffix list. Notebooks which are not executed have
+# outputs stored in ipynb but not in md, so we must convert the ipynb.
+source_suffix = ['.rst', '.ipynb', '.md']
 
 # The master toctree document.
 main_doc = 'index'
@@ -99,18 +100,12 @@ language = None
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    # Slow notebook: long time to load tf.ds
-    'notebooks/neural_network_with_tfds_data.ipynb',
-    # Slow notebook
-    'notebooks/Neural_Network_and_Data_Loading.ipynb',
-    'notebooks/score_matching.ipynb',
-    'notebooks/maml.ipynb',
-    # Fails with shape error in XL
-    'notebooks/XLA_in_Python.ipynb',
     # Sometimes sphinx reads its own outputs as inputs!
     'build/html',
+    'build/jupyter_execute',
+    'notebooks/README.md',
     'README.md',
-    # Ignore markdown source for notebooks; nbsphinx builds from the ipynb
+    # Ignore markdown source for notebooks; myst-nb builds from the ipynb
     # These are kept in sync using the jupytext pre-commit hook.
     'notebooks/*.md'
 ]
@@ -121,74 +116,6 @@ pygments_style = None
 
 autosummary_generate = True
 napolean_use_rtype = False
-
-# -- Options for nbsphinx -----------------------------------------------------
-
-# Execute notebooks before conversion: 'always', 'never', 'auto' (default)
-# We execute all notebooks, exclude the slow ones using 'exclude_patterns'
-nbsphinx_execute = 'always'
-
-# Use this kernel instead of the one stored in the notebook metadata:
-#nbsphinx_kernel_name = 'python3'
-
-# List of arguments to be passed to the kernel that executes the notebooks:
-# nbsphinx_execute_arguments = []
-
-# If True, the build process is continued even if an exception occurs:
-#nbsphinx_allow_errors = True
-
-
-# Controls when a cell will time out (defaults to 30; use -1 for no timeout):
-nbsphinx_timeout = 180
-
-# Default Pygments lexer for syntax highlighting in code cells:
-#nbsphinx_codecell_lexer = 'ipython3'
-
-# Width of input/output prompts used in CSS:
-#nbsphinx_prompt_width = '8ex'
-
-# If window is narrower than this, input/output prompts are on separate lines:
-#nbsphinx_responsive_width = '700px'
-
-# This is processed by Jinja2 and inserted before each notebook
-nbsphinx_prolog = r"""
-{% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
-
-.. only:: html
-
-    .. role:: raw-html(raw)
-        :format: html
-
-    .. nbinfo::
-
-        Interactive online version:
-        :raw-html:`<a href="https://colab.research.google.com/github/google/jax/blob/master/{{ docname }}"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom"></a>`
-
-    __ https://github.com/google/jax/blob/
-        {{ env.config.release }}/{{ docname }}
-"""
-
-# This is processed by Jinja2 and inserted after each notebook
-# nbsphinx_epilog = r"""
-# """
-
-# Input prompt for code cells. "%s" is replaced by the execution count.
-#nbsphinx_input_prompt = 'In [%s]:'
-
-# Output prompt for code cells. "%s" is replaced by the execution count.
-#nbsphinx_output_prompt = 'Out[%s]:'
-
-# Specify conversion functions for custom notebook formats:
-#import jupytext
-#nbsphinx_custom_formats = {
-#    '.Rmd': lambda s: jupytext.reads(s, '.Rmd'),
-#}
-
-# Link or path to require.js, set to empty string to disable
-#nbsphinx_requirejs_path = ''
-
-# Options for loading require.js
-#nbsphinx_requirejs_options = {'async': 'async'}
 
 # mathjax_config = {
 #     'TeX': {'equationNumbers': {'autoNumber': 'AMS', 'useLabelIds': True}},
@@ -232,6 +159,27 @@ html_static_path = ['_static']
 #
 # html_sidebars = {}
 
+# -- Options for myst ----------------------------------------------
+execution_allow_errors = False
+execution_fail_on_error = True  # Requires https://github.com/executablebooks/MyST-NB/pull/296
+
+# Notebook cell execution timeout; defaults to 30.
+execution_timeout = 100
+
+# List of patterns, relative to source directory, that match notebook
+# files that will not be executed.
+execution_excludepatterns = [
+    # Slow notebook: long time to load tf.ds
+    'notebooks/neural_network_with_tfds_data.*',
+    # Slow notebook
+    'notebooks/Neural_Network_and_Data_Loading.*',
+    'notebooks/score_matching.*',
+    'notebooks/maml.*',
+    # Fails with shape error in XL
+    'notebooks/XLA_in_Python.*',
+    # Strange error apparently due to asynchronous cell execution
+    'notebooks/thinking_in_jax.*'
+]
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
@@ -313,3 +261,25 @@ epub_exclude_files = ['search.html']
 # Tell sphinx-autodoc-typehints to generate stub parameter annotations including
 # types, even if the parameters aren't explicitly documented.
 always_document_param_types = True
+
+# Monkey-patch the myst-nb execution logger
+# TODO(jakevdp): remove this monkey-patch when execution_fail_on_error is available.
+# See https://github.com/executablebooks/MyST-NB/pull/296
+from myst_nb import execution
+
+class _FakeLogger:
+    def __init__(self, logger):
+        self._logger = logger
+
+    def verbose(self, *args, **kwargs):
+        return self._logger.verbose(*args, **kwargs)
+
+    def info(self, *args, **kwargs):
+        return self._logger.info(*args, **kwargs)
+
+    def error(self, *args, **kwargs):
+        if str(args[0]).lower().startswith("execution failed"):
+            raise ValueError(args[0])
+        return self._logger.error(*args, **kwargs)
+
+execution.LOGGER = _FakeLogger(execution.LOGGER)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -195,27 +195,19 @@ mypy --config=mypy.ini --show-error-codes jax
 # Update documentation
 
 To rebuild the documentation, install several packages:
-
 ```
 pip install -r docs/requirements.txt
 ```
-
-You must also install `pandoc` in order to regenerate the notebooks.
-See [Install Pandoc](https://pandoc.org/installing.html),
-or using [Miniconda](https://docs.conda.io/en/latest/miniconda.html) which
-I have used successfully on the Mac: `conda install -c conda-forge pandoc`.
-If you do not want to install `pandoc` then you should regenerate the documentation
-without the notebooks.
-
-You run at top-level one of the following commands:
-
+And then run:
 ```
-sphinx-build -b html docs docs/build/html  # with the notebooks
-sphinx-build -b html -D nbsphinx_execute=never docs docs/build/html  # without the notebooks
+sphinx-build -b html docs docs/build/html
 ```
-
-You can then see the generated documentation in
-`docs/build/html/index.html`.
+This can take a long time because it executes many of the notebooks in the documentation source;
+if you'd prefer to build the docs without exeuting the notebooks, you can run:
+```
+sphinx-build -b html -D jupyter_execute_notebooks=off docs docs/build/html
+```
+You can then see the generated documentation in `docs/build/html/index.html`.
 
 ## Update notebooks
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,12 @@ For an introduction to JAX, start at the
    notebooks/Common_Gotchas_in_JAX
    notebooks/Custom_derivative_rules_for_Python_code
    notebooks/How_JAX_primitives_work
-   notebooks/Writing_custom_interpreters_in_Jax.ipynb
+   notebooks/Writing_custom_interpreters_in_Jax
+   notebooks/Neural_Network_and_Data_Loading
+   notebooks/XLA_in_Python
+   notebooks/maml
+   notebooks/neural_network_with_tfds_data
+   notebooks/score_matching
 
 .. toctree::
    :maxdepth: 1

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -7,7 +7,9 @@
     "id": "hjM_sV_AepYf"
    },
    "source": [
-    "# 🔪 JAX - The Sharp Bits 🔪"
+    "# 🔪 JAX - The Sharp Bits 🔪\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # 🔪 JAX - The Sharp Bits 🔪
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)
+
 +++ {"colab_type": "text", "id": "4k5PVzEo2uJO"}
 
 *levskaya@ mattjj@*

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -8,6 +8,8 @@
    "source": [
     "# Custom derivative rules for JAX-transformable Python functions\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)\n",
+    "\n",
     "*mattjj@ Mar 19 2020, last updated Oct 14 2020*\n",
     "\n",
     "There are two ways to define differentiation rules in JAX:\n",

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -15,6 +15,8 @@ kernelspec:
 
 # Custom derivative rules for JAX-transformable Python functions
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)
+
 *mattjj@ Mar 19 2020, last updated Oct 14 2020*
 
 There are two ways to define differentiation rules in JAX:

--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# How JAX primitives work\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)\n",
+    "\n",
     "*necula@google.com*, October 2019.\n",
     "\n",
     "JAX implements certain transformations of Python functions, e.g., `jit`, `grad`,\n",

--- a/docs/notebooks/How_JAX_primitives_work.md
+++ b/docs/notebooks/How_JAX_primitives_work.md
@@ -15,6 +15,8 @@ kernelspec:
 
 # How JAX primitives work
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)
+
 *necula@google.com*, October 2019.
 
 JAX implements certain transformations of Python functions, e.g., `jit`, `grad`,

--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# Training a Simple Neural Network, with PyTorch Data Loading\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)\n",
+    "\n",
     "**Copyright 2018 Google LLC.**\n",
     "\n",
     "Licensed under the Apache License, Version 2.0 (the \"License\");you may not use this file except in compliance with the License.\n",

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # Training a Simple Neural Network, with PyTorch Data Loading
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)
+
 **Copyright 2018 Google LLC.**
 
 Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
@@ -7,7 +7,9 @@
     "id": "M-hPMKlwXjMr"
    },
    "source": [
-    "# Writing custom Jaxpr interpreters in JAX"
+    "# Writing custom Jaxpr interpreters in JAX\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.md
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # Writing custom Jaxpr interpreters in JAX
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)
+
 +++ {"colab_type": "text", "id": "r-3vMiKRYXPJ"}
 
 JAX offers several composable function transformations (`jit`, `grad`, `vmap`,

--- a/docs/notebooks/XLA_in_Python.ipynb
+++ b/docs/notebooks/XLA_in_Python.ipynb
@@ -8,6 +8,8 @@
    "source": [
     "# XLA in Python\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)\n",
+    "\n",
     "<img style=\"height:100px;\" src=\"https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/compiler/xla/g3doc/images/xlalogo.png\"> <img style=\"height:100px;\" src=\"https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg\">\n",
     "\n",
     "_Anselm Levskaya_, _Qiao Zhang_\n",

--- a/docs/notebooks/XLA_in_Python.md
+++ b/docs/notebooks/XLA_in_Python.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # XLA in Python
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)
+
 <img style="height:100px;" src="https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/compiler/xla/g3doc/images/xlalogo.png"> <img style="height:100px;" src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg">
 
 _Anselm Levskaya_, _Qiao Zhang_

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -8,6 +8,8 @@
    "source": [
     "# The Autodiff Cookbook\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)\n",
+    "\n",
     "*alexbw@, mattjj@*  \n",
     "\n",
     "JAX has a pretty general automatic differentiation system. In this notebook, we'll go through a whole bunch of neat autodiff ideas that you can cherry pick for your own work, starting with the basics."

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # The Autodiff Cookbook
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)
+
 *alexbw@, mattjj@*  
 
 JAX has a pretty general automatic differentiation system. In this notebook, we'll go through a whole bunch of neat autodiff ideas that you can cherry pick for your own work, starting with the basics.

--- a/docs/notebooks/maml.ipynb
+++ b/docs/notebooks/maml.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# MAML Tutorial with JAX\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)\n",
+    "\n",
     "Eric Jang\n",
     "\n",
     "Blog post: https://blog.evjang.com/2019/02/maml-jax.html\n",

--- a/docs/notebooks/maml.md
+++ b/docs/notebooks/maml.md
@@ -15,6 +15,8 @@ kernelspec:
 
 # MAML Tutorial with JAX
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)
+
 Eric Jang
 
 Blog post: https://blog.evjang.com/2019/02/maml-jax.html

--- a/docs/notebooks/neural_network_with_tfds_data.ipynb
+++ b/docs/notebooks/neural_network_with_tfds_data.ipynb
@@ -7,7 +7,7 @@
     "id": "18AF5Ab4p6VL"
    },
    "source": [
-    "##### Copyright 2018 Google LLC.\n",
+    "**Copyright 2018 Google LLC.**\n",
     "\n",
     "Licensed under the Apache License, Version 2.0 (the \"License\");"
    ]
@@ -41,6 +41,8 @@
    "source": [
     "# Training a Simple Neural Network, with tensorflow/datasets Data Loading\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)\n",
+    "\n",
     "_Forked from_ `neural_network_and_data_loading.ipynb`\n",
     "\n",
     "![JAX](https://raw.githubusercontent.com/google/jax/master/images/jax_logo_250px.png)\n",
@@ -72,7 +74,7 @@
     "id": "MTVcKi-ZYB3R"
    },
    "source": [
-    "### Hyperparameters\n",
+    "## Hyperparameters\n",
     "Let's get a few bookkeeping items out of the way."
    ]
   },
@@ -114,7 +116,7 @@
     "id": "BtoNk_yxWtIw"
    },
    "source": [
-    "### Auto-batching predictions\n",
+    "## Auto-batching predictions\n",
     "\n",
     "Let us first define our prediction function. Note that we're defining this for a _single_ image example. We're going to use JAX's `vmap` function to automatically handle mini-batches, with no performance penalty."
    ]
@@ -254,7 +256,7 @@
     "id": "NwDuFqc9X7ER"
    },
    "source": [
-    "### Utility and loss functions"
+    "## Utility and loss functions"
    ]
   },
   {
@@ -294,7 +296,7 @@
     "id": "umJJGZCC2oKl"
    },
    "source": [
-    "### Data Loading with `tensorflow/datasets`\n",
+    "## Data Loading with `tensorflow/datasets`\n",
     "\n",
     "JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll use the `tensorflow/datasets` data loader."
    ]
@@ -365,7 +367,7 @@
     "id": "xxPd6Qw3Z98v"
    },
    "source": [
-    "### Training Loop"
+    "## Training Loop"
    ]
   },
   {

--- a/docs/notebooks/neural_network_with_tfds_data.md
+++ b/docs/notebooks/neural_network_with_tfds_data.md
@@ -14,7 +14,7 @@ kernelspec:
 
 +++ {"colab_type": "text", "id": "18AF5Ab4p6VL"}
 
-##### Copyright 2018 Google LLC.
+**Copyright 2018 Google LLC.**
 
 Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -36,6 +36,8 @@ limitations under the License.
 
 # Training a Simple Neural Network, with tensorflow/datasets Data Loading
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)
+
 _Forked from_ `neural_network_and_data_loading.ipynb`
 
 ![JAX](https://raw.githubusercontent.com/google/jax/master/images/jax_logo_250px.png)
@@ -56,7 +58,7 @@ from jax import random
 
 +++ {"colab_type": "text", "id": "MTVcKi-ZYB3R"}
 
-### Hyperparameters
+## Hyperparameters
 Let's get a few bookkeeping items out of the way.
 
 ```{code-cell} ipython3
@@ -87,7 +89,7 @@ params = init_network_params(layer_sizes, random.PRNGKey(0))
 
 +++ {"colab_type": "text", "id": "BtoNk_yxWtIw"}
 
-### Auto-batching predictions
+## Auto-batching predictions
 
 Let us first define our prediction function. Note that we're defining this for a _single_ image example. We're going to use JAX's `vmap` function to automatically handle mini-batches, with no performance penalty.
 
@@ -165,7 +167,7 @@ At this point, we have all the ingredients we need to define our neural network 
 
 +++ {"colab_type": "text", "id": "NwDuFqc9X7ER"}
 
-### Utility and loss functions
+## Utility and loss functions
 
 ```{code-cell} ipython3
 :colab: {}
@@ -194,7 +196,7 @@ def update(params, x, y):
 
 +++ {"colab_type": "text", "id": "umJJGZCC2oKl"}
 
-### Data Loading with `tensorflow/datasets`
+## Data Loading with `tensorflow/datasets`
 
 JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll use the `tensorflow/datasets` data loader.
 
@@ -240,7 +242,7 @@ print('Test:', test_images.shape, test_labels.shape)
 
 +++ {"colab_type": "text", "id": "xxPd6Qw3Z98v"}
 
-### Training Loop
+## Training Loop
 
 ```{code-cell} ipython3
 :colab: {}

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# JAX Quickstart\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb)\n",
+    "\n",
     "**JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance machine learning research.**\n",
     "\n",
     "With its updated version of [Autograd](https://github.com/hips/autograd), JAX\n",
@@ -33,8 +35,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "SY8mDvEvCGqk"
    },
    "outputs": [],
@@ -42,6 +42,20 @@
     "import jax.numpy as jnp\n",
     "from jax import grad, jit, vmap\n",
     "from jax import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Execute this to consume & hide the GPU warning.\n",
+    "jnp.arange(10)"
    ]
   },
   {
@@ -70,8 +84,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "u0nseKZNqOoH"
    },
    "outputs": [],
@@ -95,8 +107,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "eXn8GUl6CG5N"
    },
    "outputs": [],
@@ -113,7 +123,7 @@
     "id": "0AlN7EbonyaR"
    },
    "source": [
-    "We added that `block_until_ready` because [JAX uses asynchronous execution by default](https://jax.readthedocs.io/en/latest/async_dispatch.html).\n",
+    "We added that `block_until_ready` because JAX uses asynchronous execution by default (see {ref}`async-dispatch`).\n",
     "\n",
     "JAX NumPy functions work on regular NumPy arrays."
    ]
@@ -122,8 +132,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "ZPl0MuwYrM7t"
    },
    "outputs": [],
@@ -140,15 +148,13 @@
     "id": "_SrcB2IurUuE"
    },
    "source": [
-    "That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using `device_put`."
+    "That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using {func}`~jax.device_put`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "Jj7M7zyRskF0"
    },
    "outputs": [],
@@ -167,7 +173,7 @@
     "id": "clO9djnen8qi"
    },
    "source": [
-    "The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster."
+    "The output of {func}`~jax.device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of {func}`~jax.device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster."
    ]
   },
   {
@@ -184,8 +190,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "RzXK8GnIs7VV"
    },
    "outputs": [],
@@ -203,9 +207,9 @@
    "source": [
     "JAX is much more than just a GPU-backed NumPy. It also comes with a few program transformations that are useful when writing numerical code. For now, there's three main ones:\n",
     "\n",
-    " - `jit`, for speeding up your code\n",
-    " - `grad`, for taking derivatives\n",
-    " - `vmap`, for automatic vectorization or batching.\n",
+    " - {func}`~jax.jit`, for speeding up your code\n",
+    " - {func}`~jax.grad`, for taking derivatives\n",
+    " - {func}`~jax.vmap`, for automatic vectorization or batching.\n",
     "\n",
     "Let's go over these, one-by-one. We'll also end up composing these in interesting ways."
    ]
@@ -217,7 +221,7 @@
     "id": "bTTrTbWvgLUK"
    },
    "source": [
-    "## Using `jit` to speed up functions"
+    "## Using {func}`~jax.jit` to speed up functions"
    ]
   },
   {
@@ -234,8 +238,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "qLGdCtFKFLOR"
    },
    "outputs": [],
@@ -261,8 +263,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "fh4w_3NpFYTp"
    },
    "outputs": [],
@@ -278,17 +278,15 @@
     "id": "HxpBc4WmfsEU"
    },
    "source": [
-    "## Taking derivatives with `grad`\n",
+    "## Taking derivatives with {func}`~jax.grad`\n",
     "\n",
-    "In addition to evaluating numerical functions, we also want to transform them. One transformation is [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation). In JAX, just like in [Autograd](https://github.com/HIPS/autograd), you can compute gradients with the `grad` function."
+    "In addition to evaluating numerical functions, we also want to transform them. One transformation is [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation). In JAX, just like in [Autograd](https://github.com/HIPS/autograd), you can compute gradients with the {func}`~jax.grad` function."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "IMAgNJaMJwPD"
    },
    "outputs": [],
@@ -315,8 +313,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "JXI7_OZuKZVO"
    },
    "outputs": [],
@@ -337,15 +333,13 @@
     "id": "Q2CUZjOWNZ-3"
    },
    "source": [
-    "Taking derivatives is as easy as calling `grad`. `grad` and `jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:"
+    "Taking derivatives is as easy as calling {func}`~jax.grad`. {func}`~jax.grad` and {func}`~jax.jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "TO4g8ny-OEi4"
    },
    "outputs": [],
@@ -360,15 +354,13 @@
     "id": "yCJ5feKvhnBJ"
    },
    "source": [
-    "For more advanced autodiff, you can use `jax.vjp` for reverse-mode vector-Jacobian products and `jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:"
+    "For more advanced autodiff, you can use {func}`jax.vjp` for reverse-mode vector-Jacobian products and {func}`jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "Z-JxbiNyhxEW"
    },
    "outputs": [],
@@ -385,7 +377,7 @@
     "id": "TI4nPsGafxbL"
    },
    "source": [
-    "## Auto-vectorization with `vmap`"
+    "## Auto-vectorization with {func}`~jax.vmap`"
    ]
   },
   {
@@ -395,7 +387,7 @@
     "id": "PcxkONy5aius"
    },
    "source": [
-    "JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand."
+    "JAX has one more transformation in its API that you might find useful: {func}`~jax.vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with {func}`~jax.jit`, it can be just as fast as adding the batch dimensions by hand."
    ]
   },
   {
@@ -405,15 +397,13 @@
     "id": "TPiX4y-bWLFS"
    },
    "source": [
-    "We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using `vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions."
+    "We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using {func}`~jax.vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "8w0Gpsn8WYYj"
    },
    "outputs": [],
@@ -439,8 +429,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "KWVc9BsZv0Ki"
    },
    "outputs": [],
@@ -466,8 +454,6 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "ipei6l8nvrzH"
    },
    "outputs": [],
@@ -487,15 +473,13 @@
     "id": "1eF8Nhb-szAb"
    },
    "source": [
-    "However, suppose we had a more complicated function without batching support. We can use `vmap` to add batching support automatically."
+    "However, suppose we had a more complicated function without batching support. We can use {func}`~jax.vmap` to add batching support automatically."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
     "id": "67Oeknf5vuCl"
    },
    "outputs": [],
@@ -515,7 +499,7 @@
     "id": "pYVl3Z2nbZhO"
    },
    "source": [
-    "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation."
+    "Of course, {func}`~jax.vmap` can be arbitrarily composed with {func}`~jax.jit`, {func}`~jax.grad`, and any other JAX transformation."
    ]
   },
   {

--- a/docs/notebooks/score_matching.ipynb
+++ b/docs/notebooks/score_matching.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Generative Modeling by Estimating Gradients of Data Distribution in JAX\n",
     "\n",
-    "[![Run in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
     "\n",
     "In this notebook we'll implement __Generative Modeling by Estimating Gradients of the Data Distribution__ [[arxiv]](https://arxiv.org/abs/1907.05600).\n",
     "\n",
@@ -82,7 +82,7 @@
     "id": "5X-LN4rwG6TH"
    },
    "source": [
-    "### Compute score matching objective\n",
+    "## Compute score matching objective\n",
     "\n",
     "The method we apply here was originally proposed by [Hyvarinen et al. (2005)](http://jmlr.org/papers/volume6/hyvarinen05a/old.pdf). The idea behind score matching is to __learn scores:__ the gradients of $\\log p(x)$ w.r.t. $x$. When trained this model can \"improve\" a sample $x$ by changing it in the direction of highest log-probability. However, training such model can get tricky. When predicting a continuous variable, ML folks usually minimize squared error:\n",
     "\n",
@@ -173,7 +173,7 @@
     "id": "Qxza8fDvG6TL"
    },
    "source": [
-    "### Training loop"
+    "## Training loop"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "id": "Ug91tS-RG6TP"
    },
    "source": [
-    "### Plot gradient directions\n",
+    "## Plot gradient directions\n",
     "Once the model is trained we can use it to predict scores at each point. Since those are gradient vectors, we'll use [`Quiver Plot`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.quiver.html) to draw them."
    ]
   },
@@ -328,33 +328,7 @@
     "id": "gsXvXhgfG6TS"
    },
    "source": [
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "```\n",
-    "\n",
-    "\n",
-    "\n",
-    "### Sampling with Langevin Dynamics\n",
+    "## Sampling with Langevin Dynamics\n",
     "\n",
     "Once we have $\\nabla_x log p(x)$, we can use it to generate data. One simple thing you can do is a gradient ascent w.r.t image to find a local maximum of p(x):\n",
     "$$\\hat x_{t + 1} := x_t + \\epsilon \\nabla_{x_t} log p(x_t)$$\n",
@@ -466,7 +440,7 @@
     "id": "vZrW00brG6TX"
    },
    "source": [
-    "### Sliced Score Matching\n",
+    "## Sliced Score Matching\n",
     "\n",
     "Now the problem with our previous loss function is that the computation of $tr(\\mathbf{J}_x [\\space model(x)])$ takes a $O(N^2 + N)$ time to compute, thus not being suitable for high-dimensional problems. The solution is using jacobian vector products which can be easily computed using forward mode auto-differentiation. This method is called Sliced Score Matching and was proposed by [Yang Song et al. (2019)](https://arxiv.org/abs/1905.07088).\n",
     "\n",
@@ -761,7 +735,7 @@
     "id": "jMfcQxhWG6Tm"
    },
    "source": [
-    "### This is just the beginning\n",
+    "## This is just the beginning\n",
     "\n",
     "In their paper, [Song et al. (2019)](https://arxiv.org/abs/1907.05600) propose a more sophisticated sampling procedure that can efficiently sample larger images. They also utilize a technique called _Denoising Score Matching_ which can be safely ported even to earthling frameworks like tensorflow and pytorch. Go take a look!\n",
     "\n",

--- a/docs/notebooks/score_matching.md
+++ b/docs/notebooks/score_matching.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # Generative Modeling by Estimating Gradients of Data Distribution in JAX
 
-[![Run in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)
 
 In this notebook we'll implement __Generative Modeling by Estimating Gradients of the Data Distribution__ [[arxiv]](https://arxiv.org/abs/1907.05600).
 
@@ -53,7 +53,7 @@ plt.scatter(*sample_batch(10**4).T, alpha=0.1)
 
 +++ {"colab_type": "text", "id": "5X-LN4rwG6TH"}
 
-### Compute score matching objective
+## Compute score matching objective
 
 The method we apply here was originally proposed by [Hyvarinen et al. (2005)](http://jmlr.org/papers/volume6/hyvarinen05a/old.pdf). The idea behind score matching is to __learn scores:__ the gradients of $\log p(x)$ w.r.t. $x$. When trained this model can "improve" a sample $x$ by changing it in the direction of highest log-probability. However, training such model can get tricky. When predicting a continuous variable, ML folks usually minimize squared error:
 
@@ -123,7 +123,7 @@ __Note__: we use `jax.jacfwd` since the input dimension is only 2
 
 +++ {"colab_type": "text", "id": "Qxza8fDvG6TL"}
 
-### Training loop
+## Training loop
 
 ```{code-cell} ipython3
 :colab: {}
@@ -175,7 +175,7 @@ for i in range(2000):
 
 +++ {"colab_type": "text", "id": "Ug91tS-RG6TP"}
 
-### Plot gradient directions
+## Plot gradient directions
 Once the model is trained we can use it to predict scores at each point. Since those are gradient vectors, we'll use [`Quiver Plot`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.quiver.html) to draw them.
 
 ```{code-cell} ipython3
@@ -207,33 +207,7 @@ Seriously though, this paper takes advantage of two new ideas: sampling with __L
 
 +++ {"colab_type": "text", "id": "gsXvXhgfG6TS"}
 
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-```
-
-
-
-### Sampling with Langevin Dynamics
+## Sampling with Langevin Dynamics
 
 Once we have $\nabla_x log p(x)$, we can use it to generate data. One simple thing you can do is a gradient ascent w.r.t image to find a local maximum of p(x):
 $$\hat x_{t + 1} := x_t + \epsilon \nabla_{x_t} log p(x_t)$$
@@ -304,7 +278,7 @@ plt.scatter(*sample_batch(10_000).T, alpha=0.025)
 
 +++ {"colab_type": "text", "id": "vZrW00brG6TX"}
 
-### Sliced Score Matching
+## Sliced Score Matching
 
 Now the problem with our previous loss function is that the computation of $tr(\mathbf{J}_x [\space model(x)])$ takes a $O(N^2 + N)$ time to compute, thus not being suitable for high-dimensional problems. The solution is using jacobian vector products which can be easily computed using forward mode auto-differentiation. This method is called Sliced Score Matching and was proposed by [Yang Song et al. (2019)](https://arxiv.org/abs/1905.07088).
 
@@ -493,7 +467,7 @@ for t, x_t in enumerate(xx):
 
 +++ {"colab_type": "text", "id": "jMfcQxhWG6Tm"}
 
-### This is just the beginning
+## This is just the beginning
 
 In their paper, [Song et al. (2019)](https://arxiv.org/abs/1907.05600) propose a more sophisticated sampling procedure that can efficiently sample larger images. They also utilize a technique called _Denoising Score Matching_ which can be safely ported even to earthling frameworks like tensorflow and pytorch. Go take a look!
 

--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -5,7 +5,9 @@
    "execution_count": 1,
    "metadata": {
     "id": "aPUwOm-eCSFD",
-    "nbsphinx": "hidden"
+    "tags": [
+     "remove-cell"
+    ]
    },
    "outputs": [],
    "source": [
@@ -30,6 +32,8 @@
    },
    "source": [
     "# How to Think in JAX\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/thinking_ind_jax.ipynb)\n",
     "\n",
     "JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively."
    ]
@@ -1208,9 +1212,6 @@
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
-  },
-  "nbsphinx": {
-   "execute": "never"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -13,7 +13,7 @@ kernelspec:
 
 ```{code-cell}
 :id: aPUwOm-eCSFD
-:nbsphinx: hidden
+:tags: [remove-cell]
 
 # Configure ipython to hide long tracebacks.
 import sys
@@ -32,6 +32,8 @@ ipython.showtraceback = minimal_traceback
 +++ {"id": "LQHmwePqryRU"}
 
 # How to Think in JAX
+
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/thinking_ind_jax.ipynb)
 
 JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively.
 

--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# Autobatching log-densities example\n",
     "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)\n",
+    "\n",
     "This notebook demonstrates a simple Bayesian inference example where autobatching makes user code easier to write, easier to read, and less likely to include bugs.\n",
     "\n",
     "Inspired by a notebook by @davmre."

--- a/docs/notebooks/vmapped_log_probs.md
+++ b/docs/notebooks/vmapped_log_probs.md
@@ -16,6 +16,8 @@ kernelspec:
 
 # Autobatching log-densities example
 
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)
+
 This notebook demonstrates a simple Bayesian inference example where autobatching makes user code easier to write, easier to read, and less likely to include bugs.
 
 Inspired by a notebook by @davmre.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,8 +8,7 @@ sphinx-autodoc-typehints <1.11
 
 jaxlib
 ipykernel
-nbsphinx
-myst-parser[sphinx]
+myst-nb
 # The next packages are for notebooks
 matplotlib
 sklearn


### PR DESCRIPTION
This PR does two main things:

- Changes our documentation build process from one based on [nbsphinx](https://nbsphinx.readthedocs.io/) to one based on [myst-nb](https://myst-nb.readthedocs.io/)
- Updates `quickstart.md`/`quickstart.ipynb` to use myst-md features & to show how this affects our documentation source (see the generated page [here](https://jax--5537.org.readthedocs.build/en/5537/notebooks/quickstart.html); compare to the version in the [current documentation](https://jax.readthedocs.io/en/latest/notebooks/quickstart.html)).
- Adds several unexecuted notebooks to the docs. Previously in the nbsphinx workflow these were left out of the HTML build.

Advantages of this approach:
- myst-nb can use sphinx cross-referencing directives to make our documentation more dynamic and links more stable.
- myst-nb has a lighter dependency chain (no pandoc!)
- Currently with `nbsphinx` we ignore slow notebooks, removing them from the HTML documentation. MyST-NB lets us mark these as not to be executed,  but still include them in the docs.
 
Disadvantages of this approach:
- the "Open in Colab" links now must be added manually to each notebook, rather than being inserted automatically by nbsphinx.
- minor: myst-nb does not have stored output cells, so we must treat the ipynb sources as primary in order to render unexecuted notebooks with code outputs
 
One feature we need is not yet implemented in myst-nb; I have a pull request for it at https://github.com/executablebooks/MyST-NB/pull/296. In the meantime, a temporary monkeypatch in `conf.py` gives us the behavior we want.

On the balance, I think the `myst-nb` approach will give us more flexibility in creating & maintaining JAX documentation.