### PR TITLE
[jax2tf] Update the limitations due to improvements in TF

### DIFF
--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,6 +1,6 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2021-01-18* (YYYY-MM-DD)
+*Last generated on: 2021-01-29* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
@@ -194,8 +194,6 @@ and search for "limitation".
 |eigh|unimplemented|float16|cpu|
 |eigh|unimplemented|float16|gpu|
 |fft|only 1D FFT is currently supported b/140351181.|all|tpu|
-|igamma|XLA internal error|bfloat16, float16|cpu, gpu, tpu|
-|igammac|XLA internal error|bfloat16, float16|cpu, gpu, tpu|
 |lu|unimplemented|bfloat16, float16|cpu, gpu, tpu|
 |qr|unimplemented|bfloat16, float16|cpu, gpu|
 |reduce_window_max|unimplemented in XLA|complex64|tpu|

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support for jax2tf
 
-*Last generated on (YYYY-MM-DD): 2021-01-18*
+*Last generated on (YYYY-MM-DD): 2021-01-29*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -57,9 +57,6 @@ More detailed information can be found in the
 | acos | TF error: op not defined for dtype | complex128 | cpu, gpu | eager, graph |
 | acos | TF error: op not defined for dtype | bfloat16, complex64, float16 | cpu, gpu | eager, graph |
 | acosh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
-| add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| add | TF error: op not defined for dtype | uint16 | cpu, gpu, tpu | compiled, eager, graph |
-| add_any | TF error: op not defined for dtype | uint16, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | asin | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | asin | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | asinh | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
@@ -75,14 +72,10 @@ More detailed information can be found in the
 | clamp | TF error: op not defined for dtype | int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | conv_general_dilated | TF error: jax2tf BUG: batch_group_count > 1 not yet converted | all | cpu, gpu, tpu | compiled, eager, graph |
 | cosh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
-| cummax | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
-| cummax | TF error: op not defined for dtype | complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| cummax | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
+| cummax | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | cummin | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
 | cummin | TF error: op not defined for dtype | complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| cumprod | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| cumprod | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| cumsum | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| cumsum | TF error: op not defined for dtype | uint16 | cpu, gpu, tpu | compiled, eager, graph |
 | cumsum | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
@@ -96,26 +89,20 @@ More detailed information can be found in the
 | erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | erfc | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | fft | TF error: TF function not compileable | complex128, float64 | cpu, gpu | compiled |
-| ge | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
-| ge | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
 | ge | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
-| gt | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
-| gt | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
 | gt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
-| integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
-| le | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
-| le | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
+| igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
+| igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
+| integer_pow | TF error: op not defined for dtype | unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | le | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | lgamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
-| lt | TF error: op not defined for dtype | uint16, uint32 | cpu, gpu | eager, graph |
-| lt | TF error: op not defined for dtype | uint64 | cpu, gpu | eager, graph |
 | lt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | lu | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | max | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
-| max | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| max | TF error: op not defined for dtype | int8, uint16, uint32, uint64 | cpu, gpu | eager, graph |
+| max | TF error: op not defined for dtype | bool, complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | min | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
 | min | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
-| mul | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | neg | TF error: op not defined for dtype | unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | nextafter | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | population_count | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu | eager, graph |
@@ -124,16 +111,10 @@ More detailed information can be found in the
 | reduce_max | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| reduce_window_add | TF error: op not defined for dtype | uint16 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_window_add | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
-| reduce_window_max | TF error: TF kernel missing, except when the initial_value is the minimum for the dtype | int8, uint16 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_max | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
-| reduce_window_max | TF error: op not defined for dtype | bool, complex64, uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_min | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
-| reduce_window_min | TF error: op not defined for dtype | bool, complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_mul | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| reduce_window_mul | TF error: op not defined for dtype | uint32 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_max | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
+| reduce_window_max | TF error: op not defined for dtype | bool, complex64 | cpu, gpu, tpu | compiled, eager, graph |
+| reduce_window_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
@@ -141,21 +122,17 @@ More detailed information can be found in the
 | rev | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | round | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | rsqrt | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
-| scatter_add | TF error: op not defined for dtype | bool, uint16, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_add | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_add | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
-| scatter_max | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_max | TF error: op not defined for dtype | bool, complex | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
-| scatter_mul | TF error: op not defined for dtype | bool, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
+| scatter_mul | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_mul | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | select_and_gather_add | TF error: This JAX primitives is not not exposed directly in the JAX API but arises from JVP of `lax.reduce_window` for reducers `lax.max` or `lax.min`. It also arises from second-order VJP of the same. Implemented using XlaReduceWindow | float32 | tpu | compiled, eager, graph |
 | select_and_gather_add | TF error: jax2tf unimplemented for 64-bit inputs because the current implementation relies on packing two values into a single value. This can be fixed by using a variadic XlaReduceWindow, when available | float64 | cpu, gpu | compiled, eager, graph |
-| select_and_scatter_add | TF error: op not defined for dtype | uint64 | cpu, gpu | compiled, eager, graph |
-| select_and_scatter_add | TF error: op not defined for dtype | uint16 | cpu, gpu, tpu | compiled, eager, graph |
 | sign | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
 | sinh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
-| sort | TF error: op not defined for dtype | complex128, float64 | cpu, gpu | compiled, eager, graph |
 | sort | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
-| sub | TF error: op not defined for dtype | uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | svd | TF error: function not compilable. Implemented using `tf.linalg.svd` and `tf.linalg.adjoint` | complex | cpu, gpu | compiled |
 | svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
 | top_k | TF error: op not defined for dtype | int64, uint64 | cpu, gpu | compiled |
@@ -186,8 +163,7 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 | erf_inv | May return different results at undefined points (< -1 or > 1): JAX returns `NaN` and TF returns `+inf` or `-inf`. | float32, float64 | cpu, gpu, tpu | compiled, eager, graph |
 | igamma | May return different results at undefined points (both arguments 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu, tpu | eager, graph |
 | igammac | May return different results at undefined points (both arguments less or equal 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu | eager, graph |
-| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents.  | float32, int32, int64 | cpu, gpu, tpu | compiled, eager, graph |
-| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents. It and `+inf`/`-inf` differently in JAX and TF. | complex64 | tpu | compiled, eager, graph |
+| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents.  | complex64, float32, signed | cpu, gpu, tpu | compiled, eager, graph |
 | integer_pow | custom numeric comparison | complex | cpu, gpu, tpu | compiled, eager, graph |
 | lu | May return different, but also correct, results when the decomposition is not unique | all | cpu, gpu, tpu | compiled, eager, graph |
 | max | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -139,7 +139,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   }
 
 
-
   @classmethod
   def helper_get_trig_custom_limitation(cls, np_inverse):
 
@@ -184,15 +183,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def add(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.uint16]),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
-    ]
+    return []
 
   @classmethod
   # Also called add_jaxvals
   def add_any(cls, harness: primitive_harness.Harness):
-    return [missing_tf_kernel(dtypes=[np.uint16, np.uint64])]
+    return []
 
   @classmethod
   def asin(cls, harness: primitive_harness.Harness):
@@ -332,26 +328,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         custom_numeric(dtypes=np.float64, devices="cpu", tol=1e-13),
     ]
 
-    # TODO(bchetioui): unidentified bug in compiled mode. The test that fails is
-    #
-    # test_conv_general_dilated_tf_conversion_path_3d_lhs=float32[1,4,28,28,1]_rhs=float32[2,3,3,1,16]_windowstrides=(1,1,1)_padding=VALID_lhsdilation=(1,1,1)_rhsdilation=(1,1,2)_dimensionnumbers=('NDHWC','DHWIO','NDHWC')_featuregroupcount=1_batchgroupcount=1_precision=None_enablexla=False
-    #
-    # with the following assertion error in TensorFlowTrace.process_primitive:
-    #
-    # AssertionError: conv_general_dilated: out.aval = ShapedArray(float32[1,3,24,26,16]); expected ShapedArray(float32[1,3,26,24,16])
-    #
-    # Deactivating this assertion is enough to pass the test, which suggests
-    # that the end shape is indeed the correct one (i.e. (1,3,26,24,16)).
-    # Further investigation is required to really understand this behavior,
-    # which we have not managed to reproduce as a pure TF test.
-    #
-    # This bug is low priority since it only occurs when using a non-TFXLA
-    # conversion path in compiled mode, i.e. in a context where using the
-    # TFXLA path is possible.
-    # if harness.name == "_tf_conversion_path_3d_lhs=float32[1,4,28,28,1]_rhs=float32[2,3,3,1,16]_windowstrides=(1,1,1)_padding=VALID_lhsdilation=(1,1,1)_rhsdilation=(1,1,2)_dimensionnumbers=('NDHWC','DHWIO','NDHWC')_featuregroupcount=1_batchgroupcount=1_precision=None_enablexla=False":
-    #  raise unittest.SkipTest("TODO: known but unidentified bug in compiled "
-    #                          "mode")
-
   @classmethod
   def cosh(cls, harness: primitive_harness.Harness):
     return [
@@ -365,11 +341,10 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   def cummax(cls, harness):
     return [
         missing_tf_kernel(
-            dtypes=[np.uint64, np.complex128],
+            dtypes=[np.complex128],
             devices=("cpu", "gpu"),
         ),
-        missing_tf_kernel(
-            dtypes=[np.uint16, np.uint32, np.int8, np.complex64],),
+        missing_tf_kernel(dtypes=[np.complex64]),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5)
     ]
@@ -390,11 +365,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def cumprod(cls, harness):
     return [
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-        ),
-        missing_tf_kernel(dtypes=[np.uint32]),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5),
     ]
@@ -402,12 +372,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def cumsum(cls, harness):
     return [
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-        ),
         missing_tf_kernel(dtypes=[np.complex64], devices="tpu"),
-        missing_tf_kernel(dtypes=[np.uint16]),
         custom_numeric(dtypes=np.float16, tol=0.1),
         custom_numeric(dtypes=dtypes.bfloat16, tol=0.5),
     ]
@@ -642,17 +607,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def ge(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.bool_]),
-        missing_tf_kernel(
-            dtypes=[np.uint16, np.uint32],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph")),
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph"))
-    ]
+    return [missing_tf_kernel(dtypes=[np.bool_])]
 
   @classmethod
   def gt(cls, harness: primitive_harness.Harness):
@@ -768,6 +723,8 @@ class Jax2TfLimitation(primitive_harness.Limitation):
       tst.assertAllClose(result_jax[~special_cases], result_tf[~special_cases])
 
     return [
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16, np.float16]),
         custom_numeric(
             custom_assert=custom_assert,
             description=(
@@ -801,6 +758,8 @@ class Jax2TfLimitation(primitive_harness.Limitation):
           rtol=tol)
 
     return [
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16, np.float16]),
         custom_numeric(dtypes=np.float64, tol=1e-9),
         custom_numeric(devices="gpu", tol=1e-3),
         custom_numeric(
@@ -819,20 +778,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     return [
         missing_tf_kernel(
             dtypes=[
-                np.uint8, np.uint16, np.int8, np.int16, np.uint32, np.uint64
+                np.uint8, np.uint16, np.uint32, np.uint64
             ],),
-        # hitting rtol = nan
-        Jax2TfLimitation(("Different overflow behavior for large exponents. It "
-                          "and `+inf`/`-inf` differently in JAX and TF."),
-                         devices="tpu",
-                         dtypes=np.complex64,
-                         enabled=(y in [1000, -1000]),
-                         expect_tf_error=False,
-                         skip_comparison=True),
         Jax2TfLimitation(
             "Different overflow behavior for large exponents. ",
-            dtypes=[np.int8, np.int16, np.int32, np.int64, np.float32],
-            enabled=(y > 10),
+            dtypes=[np.int8, np.int16, np.int32, np.int64, np.float32, np.complex64],
+            enabled=(abs(y) > 10),
             expect_tf_error=False,
             skip_comparison=True)
     ] + list(cls._pow_test_util(harness))
@@ -843,17 +794,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def le(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(dtypes=[np.bool_]),
-        missing_tf_kernel(
-            dtypes=[np.uint16, np.uint32],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph")),
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph"))
-    ]
+    return cls.ge(harness)
 
   @classmethod
   def lt(cls, harness: primitive_harness.Harness):
@@ -919,7 +860,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     ]
 
   @classmethod
-  def _min_max_test_util(cls, harness: primitive_harness.Harness):
+  def max(cls, harness: primitive_harness.Harness):
     # TODO(bchetioui): discrepancies between TF & JAX when comparing with NaN;
     # JAX always returns NaN, while TF returns the value NaN is compared with.
     def custom_assert(tst, result_jax, result_tf, **_):
@@ -928,9 +869,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
     return [
         missing_tf_kernel(
-            dtypes=[
-                np.bool_, np.int8, np.complex64, np.uint16, np.uint32, np.uint64
-            ],),
+            dtypes=[np.int8, np.uint16, np.uint32, np.uint64],
+            devices=("cpu", "gpu"),
+            modes=("eager", "graph"),
+        ),
+        missing_tf_kernel(
+            dtypes=[np.bool_, np.complex64]),
         missing_tf_kernel(
             dtypes=[np.complex128],
             devices=("cpu", "gpu"),
@@ -944,16 +888,32 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     ]
 
   @classmethod
-  def max(cls, harness: primitive_harness.Harness):
-    return cls._min_max_test_util(harness)
-
-  @classmethod
   def min(cls, harness: primitive_harness.Harness):
-    return cls._min_max_test_util(harness)
+    # TODO(bchetioui): discrepancies between TF & JAX when comparing with NaN;
+    # JAX always returns NaN, while TF returns the value NaN is compared with.
+    def custom_assert(tst, result_jax, result_tf, **_):
+      mask = np.isnan(result_jax)
+      tst.assertAllClose(result_jax[~mask], result_tf[~mask])
+
+    return [
+        missing_tf_kernel(
+            dtypes=[np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
+                    np.complex64]),
+        missing_tf_kernel(
+            dtypes=[np.complex128],
+            devices=("cpu", "gpu"),
+        ),
+        custom_numeric(
+            custom_assert=custom_assert,
+            description=(
+                "May return different values when one of the values is NaN. "
+                "JAX always returns NaN, while TF returns the value NaN is compared with."
+            ))
+    ]
 
   @classmethod
   def mul(cls, harness: primitive_harness.Harness):
-    return [missing_tf_kernel(dtypes=[np.uint32, np.uint64])]
+    return []
 
   @classmethod
   def neg(cls, harness: primitive_harness.Harness):
@@ -1012,17 +972,18 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   def reduce_window_add(cls, harness):
     assert "add" == harness.params["computation"].__name__
     return [
-        missing_tf_kernel(dtypes=[np.uint16]),
         missing_tf_kernel(dtypes=[np.complex64], devices="tpu"),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
     ]
 
   @classmethod
-  def reduce_window_mul(cls, harness):
-    assert "mul" == harness.params["computation"].__name__
+  def reduce_window_max(cls, harness):
+    assert "max" == harness.params["computation"].__name__
     return [
-        missing_tf_kernel(dtypes=[np.uint32]),
-        missing_tf_kernel(dtypes=[np.uint64], devices=("cpu", "gpu"))
+        missing_tf_kernel(dtypes=[np.bool_, np.complex64]),
+        missing_tf_kernel(
+            dtypes=[np.complex128],
+            devices=("cpu", "gpu"),
+        )
     ]
 
   @classmethod
@@ -1030,30 +991,15 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     assert "min" == harness.params["computation"].__name__
     return [
         missing_tf_kernel(
-            dtypes=[np.uint32, np.uint16, np.bool_, np.complex64, np.int8],),
-        missing_tf_kernel(
-            dtypes=[np.uint64, np.complex128],
-            devices=("cpu", "gpu"),
+            dtypes=[np.bool_, np.int8, np.uint16, np.uint32, np.uint64,
+                    np.complex64, np.complex128],
         )
     ]
 
   @classmethod
-  def reduce_window_max(cls, harness):
-    assert "max" == harness.params["computation"].__name__
-    dtype = harness.dtype
-    init_value = harness.params["init_value"]
-    return [
-        missing_tf_kernel(dtypes=[np.uint32, np.bool_, np.complex64]),
-        missing_tf_kernel(
-            dtypes=[np.uint64, np.complex128],
-            devices=("cpu", "gpu"),
-        ),
-        Jax2TfLimitation(
-            "TF kernel missing, except when the initial_value is the minimum for the dtype",
-            dtypes=[np.uint16, np.int8],
-            enabled=((dtype == np.uint16 and init_value != 0) or
-                     (dtype == np.int8 and init_value != -128)))
-    ]
+  def reduce_window_mul(cls, harness):
+    assert "mul" == harness.params["computation"].__name__
+    return []
 
   @classmethod
   def regularized_incomplete_beta(cls, harness: primitive_harness.Harness):
@@ -1108,7 +1054,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def scatter_add(cls, harness):
     return [
-        missing_tf_kernel(dtypes=[np.uint16, np.uint64, np.bool_],),
+        missing_tf_kernel(dtypes=[np.bool_],),
         missing_tf_kernel(
             dtypes=[np.complex64],
             devices="tpu",
@@ -1119,10 +1065,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   def scatter_max(cls, harness):
     return [
         missing_tf_kernel(
-            dtypes=[
-                np.int8, np.uint16, np.uint32, np.uint64, np.complex64,
-                np.complex128, np.bool_
-            ],)
+            dtypes=[np.bool_, np.complex64, np.complex128])
     ]
 
   @classmethod
@@ -1138,7 +1081,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def scatter_mul(cls, harness):
     return [
-        missing_tf_kernel(dtypes=[np.uint32, np.uint64, np.bool_],),
+        missing_tf_kernel(dtypes=[np.bool_],),
         missing_tf_kernel(
             dtypes=[np.complex64],
             devices="tpu",
@@ -1166,13 +1109,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def select_and_scatter_add(cls, harness):
-    return [
-        missing_tf_kernel(dtypes=[np.uint16]),
-        missing_tf_kernel(
-            dtypes=[np.uint64],
-            devices=("cpu", "gpu"),
-        )
-    ]
+    return []
 
   @classmethod
   def sign(cls, harness: primitive_harness.Harness):
@@ -1203,14 +1140,12 @@ class Jax2TfLimitation(primitive_harness.Limitation):
                      not harness.params["is_stable"]),
             expect_tf_error=False,
             skip_comparison=True),
-        missing_tf_kernel(
-            dtypes=[np.complex128, np.float64], devices=("cpu", "gpu")),
         missing_tf_kernel(dtypes=[np.bool_],),
     ]
 
   @classmethod
   def sub(cls, harness):
-    return [missing_tf_kernel(dtypes=[np.uint64])]
+    return []
 
   @classmethod
   def svd(cls, harness: primitive_harness.Harness):

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -508,12 +508,12 @@ def _make_integer_pow_harness(name, *, shape=(20, 30), dtype=np.int32, y=3):
 for dtype in set(jtu.dtypes.all) - set(jtu.dtypes.boolean):
   # Validate dtypes and y values
   _make_integer_pow_harness("dtypes", dtype=dtype)
-  # Validate overflow behavior by dtype
-  _make_integer_pow_harness("overflow", y=1000, dtype=dtype)
+  # Validate overflow behavior by dtype. 127
+  _make_integer_pow_harness("overflow", y=127, dtype=dtype)
 
 for dtype in jtu.dtypes.all_inexact:
   # Validate negative y by dtype
-  _make_integer_pow_harness("negative_exp", y=-1000, dtype=dtype)
+  _make_integer_pow_harness("negative_exp", y=-127, dtype=dtype)
 
 
 def _make_pow_harness(name,
@@ -948,19 +948,11 @@ _make_binary_elementwise_harnesses(
 
 _make_binary_elementwise_harnesses(
   prim=lax.igamma_p,
-  dtypes=jtu.dtypes.all_floating,
-  jax_unimplemented=lambda *_, dtype, **kwargs: [
-    Limitation(
-      "XLA internal error", dtypes=[np.float16, dtypes.bfloat16]),
-  ])
+  dtypes=jtu.dtypes.all_floating)
 
 _make_binary_elementwise_harnesses(
   prim=lax.igammac_p,
-  dtypes=jtu.dtypes.all_floating,
-  jax_unimplemented=lambda *_, dtype, **kwargs: [
-    Limitation(
-      "XLA internal error", dtypes=[np.float16, dtypes.bfloat16]),
-  ])
+  dtypes=jtu.dtypes.all_floating)
 
 _make_binary_elementwise_harnesses(
   prim=lax.nextafter_p,

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -14,19 +14,21 @@
 
 import contextlib
 import logging
-import numpy as np
+
 from typing import Any, Callable, List, Optional, Sequence
-import tensorflow as tf  # type: ignore[import]
+
 
 import jax
-from jax.config import config
 from jax import dtypes
-from jax.experimental import jax2tf
-from jax.interpreters import masking
+from jax import numpy as jnp
 from jax import test_util as jtu
 from jax import tree_util
-from jax import numpy as jnp
 
+from jax.config import config
+from jax.experimental import jax2tf
+from jax.interpreters import masking
+import numpy as np
+import tensorflow as tf  # type: ignore[import]
 
 DType = Any
 
@@ -201,7 +203,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
              "successful modes:\n" + "\n".join(unexpected_successes))
       logging.warning(msg)
       # Uncomment the below if you want to see warnings as failures
-      #self.assertEmpty(msg)
+      # self.assertEmpty(msg)
     return result_jax, result_tf
 
   def TransformConvertAndCompare(self, func: Callable, arg,


### PR DESCRIPTION
TF now handles a few more ops for unsigned types.
Also igamma and igammac support for f16 anf bf16 were added to
JAX, but not yet to TF, hence the new limitations in TF.