### PR TITLE
Export split_dict from jax.util

### DIFF
--- a/jax/util.py
+++ b/jax/util.py
@@ -20,6 +20,7 @@ from jax._src.util import (
   partial,
   safe_map,
   safe_zip,
+  split_dict,
   split_list,
   split_merge,
   subvals,


### PR DESCRIPTION
Commit 3ac809ede30d961b873ca62f9828090709ced6be dropped `split_dict` from the list of exported symbols, this has broken jaxnet and any others who are using this function.