### PR TITLE
update out of date comment in Pmap_Cookbook.ipynb

### DIFF
--- a/cloud_tpu_colabs/Pmap_Cookbook.ipynb
+++ b/cloud_tpu_colabs/Pmap_Cookbook.ipynb
@@ -210,8 +210,8 @@
       "source": [
         "Notice that applying `vmap(f)` to these arguments leads to a `dot_general` to express the batch matrix multiplication in a single primitive, while applying `pmap(f)` instead leads to a primitive that calls replicas of the original `f` in parallel.\n",
         "\n",
-        "There is also an important constraint with using `pmap`, ",        
-        "with `pmap` the mapped axis size must be less than or equal to the number of XLA devices available (and for nested `pmap` functions, the product of the mapped axis sizes must be less than or equal to the number of XLA devices).\n",
+        "An important constraint with using `pmap` is that ",        
+        "the mapped axis size must be less than or equal to the number of XLA devices available (and for nested `pmap` functions, the product of the mapped axis sizes must be less than or equal to the number of XLA devices).\n",
         "\n",
         "You can use the output of a `pmap` function just like any other value:"
       ]

--- a/cloud_tpu_colabs/Pmap_Cookbook.ipynb
+++ b/cloud_tpu_colabs/Pmap_Cookbook.ipynb
@@ -210,9 +210,8 @@
       "source": [
         "Notice that applying `vmap(f)` to these arguments leads to a `dot_general` to express the batch matrix multiplication in a single primitive, while applying `pmap(f)` instead leads to a primitive that calls replicas of the original `f` in parallel.\n",
         "\n",
-        "There are also important constraints with using `pmap`:\n",
-        "1. `pmap` always maps over the leading axis of all of its arguments (while with `vmap` you can use `in_axes` to specify which axes get mapped),\n",
-        "2. with `pmap` the mapped axis size must be less than or equal to the number of XLA devices available (and for nested `pmap` functions, the product of the mapped axis sizes must be less than or equal to the number of XLA devices).\n",
+        "There is also an important constraint with using `pmap`, ",        
+        "with `pmap` the mapped axis size must be less than or equal to the number of XLA devices available (and for nested `pmap` functions, the product of the mapped axis sizes must be less than or equal to the number of XLA devices).\n",
         "\n",
         "You can use the output of a `pmap` function just like any other value:"
       ]

--- a/cloud_tpu_colabs/Pmap_Cookbook.ipynb
+++ b/cloud_tpu_colabs/Pmap_Cookbook.ipynb
@@ -207,7 +207,7 @@
         "id": "BjDnQkzSa_vZ",
         "colab_type": "text"
       },
-      "source": [
+      "source":  [
         "Notice that applying `vmap(f)` to these arguments leads to a `dot_general` to express the batch matrix multiplication in a single primitive, while applying `pmap(f)` instead leads to a primitive that calls replicas of the original `f` in parallel.\n",
         "\n",
         "An important constraint with using `pmap` is that ",        


### PR DESCRIPTION
update comment regarding `pmap` not supporting `in_axes`, because it does now.