### PR TITLE
Pin numpy to max version 1.19, to avoid errors with 1.20

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,4 +1,6 @@
 flake8
+# For now, we pin the numpy version here, because jaxlib 0.1.59 was built with >=1.12
+numpy>=1.12,<1.20
  # Must be kept in sync with the minimum jaxlib version in jax/lib/__init__.py
 jaxlib==0.1.59
 mypy==0.790

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.12', 'absl-py', 'flatbuffers'],
+    install_requires=['scipy', 'numpy>=1.12,<1.20', 'absl-py', 'flatbuffers'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={'jaxlib': binary_libs},

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_data={'jax': ['py.typed']},
     python_requires='>=3.6',
     install_requires=[
-        'numpy >=1.12',
+        'numpy >=1.12,<1.20',
         'absl-py',
         'opt_einsum',
     ],


### PR DESCRIPTION
Will fix the numpy errors separately.