### PR TITLE
Try to download bazel as the last resort

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -178,9 +178,7 @@ def check_bazel_version(bazel_path):
   if match is None:
     return False
   actual_ints = [int(x) for x in match.group(1).split(".")]
-  if (2, 0, 0) > actual_ints:
-    return False
-  return True
+  return actual_ints >= (2, 0, 0)
 
 
 BAZELRC_TEMPLATE = """

--- a/build/build.py
+++ b/build/build.py
@@ -145,7 +145,7 @@ def download_and_verify_bazel():
 
 
 def get_bazel_paths(bazel_path_flag):
-  """Yields a sequence of a guess about bazel path. Some of sequence elements
+  """Yields a sequence of guesses about bazel path. Some of sequence elements
   can be None. The resulting iterator is lazy and potentially has a side
   effects."""
   yield bazel_path_flag
@@ -153,23 +153,23 @@ def get_bazel_paths(bazel_path_flag):
   yield download_and_verify_bazel()
 
 
-def get_bazel_path(bazel_path_flag, min_version, max_version):
+def get_bazel_path(bazel_path_flag):
   """Returns the path to a Bazel binary, downloading Bazel if not found. Also,
-  it checks Bazel's version is in the range [`min_version`, `max_version`).
+  it checks Bazel's version at lease newer than 2.0.0.
 
   NOTE Manual version check is reasonably only for bazel < 2.0.0. Newer bazel
   releases performs version check against .bazelversion (see for details
   https://blog.bazel.build/2019/12/19/bazel-2.0.html#other-important-changes).
   """
   for path in filter(None, get_bazel_paths(bazel_path_flag)):
-    if check_bazel_version(path, min_version, max_version):
+    if check_bazel_version(path):
       return path
 
   print("Cannot find or download bazel. Please install bazel.")
   sys.exit(-1)
 
 
-def check_bazel_version(bazel_path, min_version, max_version):
+def check_bazel_version(bazel_path):
   try:
     version_output = shell([bazel_path, "--bazelrc=/dev/null", "version"])
   except subprocess.CalledProcessError:
@@ -177,15 +177,9 @@ def check_bazel_version(bazel_path, min_version, max_version):
   match = re.search("Build label: *([0-9\\.]+)[^0-9\\.]", version_output)
   if match is None:
     return False
-  version = match.group(1)
-  min_ints = [int(x) for x in min_version.split(".")]
   actual_ints = [int(x) for x in match.group(1).split(".")]
-  if min_ints > actual_ints:
+  if (2, 0, 0) > actual_ints:
     return False
-  if max_version is not None:
-    max_ints = [int(x) for x in max_version.split(".")]
-    if actual_ints >= max_ints:
-      return False
   return True
 
 
@@ -437,7 +431,7 @@ def main():
   os.chdir(os.path.dirname(__file__ or args.prog) or '.')
 
   # Find a working Bazel.
-  bazel_path = get_bazel_path(args.bazel_path, min_version="2.0.0", max_version=None)
+  bazel_path = get_bazel_path(args.bazel_path)
   print("Bazel binary path: {}".format(bazel_path))
 
   python_bin_path = get_python_bin_path(args.python_bin_path)

--- a/build/build.py
+++ b/build/build.py
@@ -144,44 +144,49 @@ def download_and_verify_bazel():
   return os.path.join(".", package.file)
 
 
-def get_bazel_path(bazel_path_flag):
-  """Returns the path to a Bazel binary, downloading Bazel if not found."""
-  if bazel_path_flag:
-    return bazel_path_flag
+def get_bazel_paths(bazel_path_flag):
+  """Yields a sequence of a guess about bazel path. Some of sequence elements
+  can be None. The resulting iterator is lazy and potentially has a side
+  effects."""
+  yield bazel_path_flag
+  yield which("bazel")
+  yield download_and_verify_bazel()
 
-  bazel = download_and_verify_bazel()
-  if bazel:
-    return bazel
 
-  bazel = which("bazel")
-  if bazel:
-    return bazel
+def get_bazel_path(bazel_path_flag, min_version, max_version):
+  """Returns the path to a Bazel binary, downloading Bazel if not found. Also,
+  it checks Bazel's version is in the range [`min_version`, `max_version`).
+
+  NOTE Manual version check is reasonably only for bazel < 2.0.0. Newer bazel
+  releases performs version check against .bazelversion (see for details
+  https://blog.bazel.build/2019/12/19/bazel-2.0.html#other-important-changes).
+  """
+  for path in filter(None, get_bazel_paths(bazel_path_flag)):
+    if check_bazel_version(path, min_version, max_version):
+      return path
 
   print("Cannot find or download bazel. Please install bazel.")
   sys.exit(-1)
 
 
 def check_bazel_version(bazel_path, min_version, max_version):
-  """Checks Bazel's version is in the range [`min_version`, `max_version`)."""
-  version_output = shell([bazel_path, "--bazelrc=/dev/null", "version"])
+  try:
+    version_output = shell([bazel_path, "--bazelrc=/dev/null", "version"])
+  except subprocess.CalledProcessError:
+    return False
   match = re.search("Build label: *([0-9\\.]+)[^0-9\\.]", version_output)
   if match is None:
-    print("Warning: bazel installation is not a release version. Make sure "
-          "bazel is at least {}".format(min_version))
-    return
+    return False
   version = match.group(1)
   min_ints = [int(x) for x in min_version.split(".")]
   actual_ints = [int(x) for x in match.group(1).split(".")]
   if min_ints > actual_ints:
-    print("Outdated bazel revision (>= {} required, found {})".format(
-        min_version, version))
-    sys.exit(-1)
+    return False
   if max_version is not None:
     max_ints = [int(x) for x in max_version.split(".")]
     if actual_ints >= max_ints:
-      print("Please downgrade your bazel revision to build JAX (>= {} and < {}"
-            " required, found {})".format(min_version, max_version, version))
-      sys.exit(-1)
+      return False
+  return True
 
 
 BAZELRC_TEMPLATE = """
@@ -432,8 +437,7 @@ def main():
   os.chdir(os.path.dirname(__file__ or args.prog) or '.')
 
   # Find a working Bazel.
-  bazel_path = get_bazel_path(args.bazel_path)
-  check_bazel_version(bazel_path, min_version="2.0.0", max_version=None)
+  bazel_path = get_bazel_path(args.bazel_path, min_version="2.0.0", max_version=None)
   print("Bazel binary path: {}".format(bazel_path))
 
   python_bin_path = get_python_bin_path(args.python_bin_path)


### PR DESCRIPTION
In some sense this pull request reverts changes suggested in #2217. That changes force to download bazel. Now resolution order of paths to bazel binary is as follows.

1. Use `--bazel_path` command line option.
2. Search bazel binary in `PATH` environment variable.
3. Download required bazel release.

It is worth to note that there are excessive version checks. The first is done by bazel with `.bazelversion` (from [version 2.0.0][1]). The second is done manually in build script. Which one is really mandatory?

[1]: https://blog.bazel.build/2019/12/19/bazel-2.0.html#other-important-changes