### PR TITLE
Add sleep to attempt to fix RTD build error

### DIFF
--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -810,6 +810,23 @@
     {
       "cell_type": "code",
       "metadata": {
+        "nbsphinx": "hidden",
+        "id": "lIYdn1woOS1n"
+      },
+      "source": [
+        "# Workaround for https://github.com/google/jax/issues/5587\n",
+        "# TODO(jakevdp): remove this workaround\n",
+        "import time\n",
+        "time.sleep(1)\n",
+        "print('Done sleeping.')\n",
+        "get_ipython().execution_count -= 1"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },


### PR DESCRIPTION
RTD is periodically failing with a `NameError`; see #5587 

I've not been able to identify the root cause. This is an attempt to work around the issue by adding a hidden cell with a short `time.sleep()`.