### PR TITLE
Update XLA.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "7bdf5567236f8bca19a11a09b1681734bf98009c579a1971fb765e471682352f",
-    strip_prefix = "tensorflow-ec6cfabc82708a449015e7afe96421c84afa334b",
+    sha256 = "960c2bf502e2407cfaa2fdfb9c362909715c312d19e8fd2eacdd26ec1377c0ee",
+    strip_prefix = "tensorflow-53ab21aa8672365728a6f76c0dc3ebd172fde88d",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/ec6cfabc82708a449015e7afe96421c84afa334b.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/53ab21aa8672365728a6f76c0dc3ebd172fde88d.tar.gz",
     ],
 )
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -20,6 +20,11 @@ jax 0.2.10 (Unreleased)
 jaxlib 0.1.60 (Unreleased)
 --------------------------
 
+* Bug fixes:
+
+  * ``bool``, ``int8``, and ``uint8`` are now considered safe to cast to
+    ``bfloat16`` NumPy extension type.
+
 jax 0.2.9 (January 26 2021)
 ---------------------------
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.2.8...jax-v0.2.9>`__.


### PR DESCRIPTION
Includes https://github.com/tensorflow/tensorflow/commit/53ab21aa8672365728a6f76c0dc3ebd172fde88d, which fixes a number of test failures under NumPy 1.20.0.