### PR TITLE
Disable bfloat16 in jax2tf eigh test.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1659,9 +1659,14 @@ for dtype in jtu.dtypes.all_inexact:
             devices="tpu",
             dtypes=[np.complex64, np.complex128]),
           Limitation(
-            "unimplemented", devices="cpu", dtypes=[np.float16]),
+            "unimplemented", devices="cpu",
+            dtypes=[np.float16, dtypes.bfloat16]),
           Limitation(
-            "unimplemented", devices="gpu", dtypes=[np.float16]),
+            "unimplemented", devices="gpu",
+            dtypes=[np.float16, dtypes.bfloat16]),
+          Limitation(
+            "unimplemented", devices="tpu",
+            dtypes=[np.float16, dtypes.bfloat16]),
         ],
         shape=shape,
         dtype=dtype,


### PR DESCRIPTION
We don't have any bfloat16 implementations, so we shouldn't be testing it.

@gnecula 