### PR TITLE
Fixes for numpy 1.20

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -22,6 +22,10 @@ jax 0.2.10 (Unreleased)
   * :func:`jax.numpy.i0` no longer accepts complex numbers. Previously the
     function computed the absolute value of complex arguments. This change was
     made to match the semantics of NumPy 1.20.0.
+  * Several `jax.numpy` functions no longer accept tuples or lists in place
+    of array arguments: :func:`jax.numpy.pad`, :func`jax.numpy.ravel`,
+    :func:`jax.numpy.repeat`.
+    In general, `jax.numpy` functions should be used with scalars or array arguments.
 
 jaxlib 0.1.60 (Unreleased)
 --------------------------

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -662,9 +662,11 @@ def cond(*args, **kwargs):
   return _cond(*args, **kwargs)
 
 def _cond(pred, true_fun: Callable, false_fun: Callable, operand):
-  if not isinstance(pred, Sequence) and len(np.shape(pred)) != 0:
+  if isinstance(pred, Sequence) or np.ndim(pred) != 0:
     raise TypeError(
-        f"Pred must be a scalar, got {pred} of shape {np.shape(pred)}.")
+        f"Pred must be a scalar, got {pred} of " +
+        (f"type {type(pred)}" if isinstance(pred, Sequence)
+         else f"shape {np.shape(pred)}."))
 
   try:
     pred_dtype = dtypes.result_type(pred)

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -662,7 +662,7 @@ def cond(*args, **kwargs):
   return _cond(*args, **kwargs)
 
 def _cond(pred, true_fun: Callable, false_fun: Callable, operand):
-  if len(np.shape(pred)) != 0:
+  if not isinstance(pred, Sequence) and len(np.shape(pred)) != 0:
     raise TypeError(
         f"Pred must be a scalar, got {pred} of shape {np.shape(pred)}.")
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -131,20 +131,6 @@ ndim = _ndim = np.ndim
 size = np.size
 _dtype = dtypes.result_type
 
-def _ndim_sequence(xs):
-  """A version of np.ndim that works on sequences that may include Tracers.
-
-  Prior to version 1.20, np.ndim worked on sequences."""
-  if isinstance(xs, Sequence):
-    if not xs:
-      return 1
-    ndims = set(_ndim_sequence(x) for x in xs)
-    if len(ndims) > 1:
-      raise ValueError(f"ndim called on a ragged sequence with ndims {ndims}")
-    return 1 + ndims.pop()
-  else:
-    return ndim(xs)
-
 # At present JAX doesn't have a reason to distinguish between scalars and arrays
 # in its object system. Further, we want JAX scalars to have the same type
 # promotion behaviors as JAX arrays. Rather than introducing a new type of JAX
@@ -1266,6 +1252,7 @@ def isrealobj(x):
 
 @_wraps(np.reshape)
 def reshape(a, newshape, order="C"):
+  _check_arraylike("reshape", a)
   try:
     return a.reshape(newshape, order=order)  # forward to method for ndarrays
   except AttributeError:
@@ -1301,6 +1288,7 @@ def _reshape(a, *args, order="C"):
 
 @_wraps(np.ravel)
 def ravel(a, order="C"):
+  _check_arraylike("ravel", a)
   if order == "K":
     raise NotImplementedError("Ravel not implemented for order='K'.")
   return reshape(a, (size(a),), order)
@@ -1349,7 +1337,7 @@ and out-of-bounds indices are clipped.
 @_wraps(np.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(indices, shape):
   indices = asarray(indices)
-  sizes = pad(shape, (0, 1), constant_values=1)
+  sizes = array(tuple(shape) + (1,))
   cumulative_sizes = cumprod(sizes[::-1])[::-1]
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior
@@ -2600,7 +2588,8 @@ the modified array. This is because Jax arrays are immutable.
 (In numpy, "function" mode's argument should modify a rank 1 array in-place.)
 """)
 def pad(array, pad_width, mode="constant", **kwargs):
-  pad_width = _broadcast_to_pairs(pad_width, _ndim_sequence(array), "pad_width")
+  _check_arraylike("pad", array)
+  pad_width = _broadcast_to_pairs(pad_width, ndim(array), "pad_width")
   if pad_width and np.array(pad_width).dtype.kind != 'i':
     raise TypeError('`pad_width` must be of integral type.')
 
@@ -3183,6 +3172,7 @@ will be repeated.
 @_wraps(np.repeat, lax_description=_TOTAL_REPEAT_LENGTH_DOC)
 def repeat(a, repeats, axis: Optional[int] = None, *, total_repeat_length=None):
   _check_arraylike("repeat", a)
+  _check_arraylike("repeat", repeats)
 
   if axis is None:
     a = ravel(a)
@@ -4601,7 +4591,7 @@ def _expand_bool_indices(idx):
     except TypeError:
       abstract_i = None
     if (isinstance(abstract_i, ShapedArray) and issubdtype(abstract_i.dtype, bool_)
-        or isinstance(i, list) and _all(_is_bool_scalar_like(e) for e in i)):
+        or isinstance(i, list) and _all(_is_scalar(e) and issubdtype(_dtype(e), np.bool_) for e in i)):
       if isinstance(i, list):
         i = array(i)
         abstract_i = core.get_aval(i)
@@ -4627,7 +4617,7 @@ def _is_advanced_int_indexer(idx):
   # https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html#advanced-indexing
   assert isinstance(idx, tuple)
   if _all(e is None or e is Ellipsis or isinstance(e, slice)
-          or _is_int_scalar_like(e) for e in idx):
+          or _is_scalar(e) and issubdtype(_dtype(e), np.integer) for e in idx):
     return False
   return _all(e is None or e is Ellipsis or isinstance(e, slice)
               or _is_int_arraylike(e) for e in idx)
@@ -4638,15 +4628,9 @@ def _is_int_arraylike(x):
           or issubdtype(getattr(x, "dtype", None), np.integer)
           or isinstance(x, (list, tuple)) and _all(_is_int_arraylike(e) for e in x))
 
-def _is_int_scalar_like(x):
-  """Returns True if x is a scalar integer, False otherwise."""
-  return (isinstance(x, int) and not isinstance(x, bool)
-          or issubdtype(getattr(x, "dtype", None), np.integer) and np.ndim(x) == 0)
-
-def _is_bool_scalar_like(x):
-  """Returns True if x is a scalar boolean, False otherwise."""
-  return (isinstance(x, bool)
-          or issubdtype(getattr(x, "dtype", None), np.bool_) and np.ndim(x) == 0)
+def _is_scalar(x):
+  """Checks if a Python or NumPy scalar."""
+  return  np.isscalar(x) or (isinstance(x, ndarray) and np.ndim(x) == 0)
 
 def _canonicalize_tuple_index(arr_ndim, idx):
   """Helper to remove Ellipsis and add in the implicit trailing slice(None)."""

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -695,10 +695,10 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         re.escape("Pred type must be either boolean or number, got <function")):
       lax.cond(lambda x: True, lambda top: 2., lambda fop: 3., 1.)
     with self.assertRaisesRegex(TypeError,
-        re.escape("Pred type must be either boolean or number, got foo.")):
+        re.escape("Pred must be a scalar, got foo of type <class 'str'>")):
       lax.cond("foo", lambda top: 2., lambda fop: 3., 1.)
     with self.assertRaisesRegex(TypeError,
-        re.escape("Pred must be a scalar, got (1.0, 1.0) of shape (2,).")):
+        re.escape("Pred must be a scalar, got (1.0, 1.0) of type <class 'tuple'>")):
       lax.cond((1., 1.), lambda top: 2., lambda fop: 3., 1.)
     with self.assertRaisesRegex(TypeError,
         re.escape("true_fun and false_fun output must have same type structure, got * and PyTreeDef(tuple, [*,*]).")):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1494,7 +1494,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         'wrap': {},
         'empty': {}
     }
-    arr = [1, 2, 3]
+    arr = jnp.array([1, 2, 3])
     pad_width = 1
 
     for mode in modes.keys():
@@ -1550,7 +1550,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
   def testPadWithNumpyPadWidth(self):
-    a = [1, 2, 3, 4, 5]
+    a = jnp.array([1, 2, 3, 4, 5])
     f = jax.jit(
         partial(
             jnp.pad,
@@ -1944,7 +1944,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       args_maker = lambda: [m]
 
-    for repeats in [2, [1,3,2,1,1,2], [1,3,0,1,1,2], [2], jnp.array([1,3,2,1,1,2]), jnp.array([2])]:
+    for repeats in [2, jnp.array([1,3,0,1,1,2]), jnp.array([1,3,2,1,1,2]), jnp.array([2])]:
       test_single(m, args_maker, repeats, axis=None)
       test_single(m, args_maker, repeats, axis=0)
 
@@ -1954,10 +1954,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       args_maker = lambda: [m_rect]
 
-    for repeats in [2, [2,1], [2], jnp.array([2,1]), jnp.array([2])]:
+    for repeats in [2, jnp.array([2,1]), jnp.array([2])]:
       test_single(m_rect, args_maker, repeats, axis=0)
 
-    for repeats in [2, [1,3,2], [2], jnp.array([1,3,2]), jnp.array([2])]:
+    for repeats in [2, jnp.array([1,3,2]), jnp.array([2])]:
       test_single(m_rect, args_maker, repeats, axis=1)
 
   def testIssue2330(self):


### PR DESCRIPTION
It seems that `np.ndim` and `np.shape` fail in version 1.20
when used on sequences of Tracers. We avoid invoking these
functions in places where this may happen.

Instead of generalizing `np.ndim` we plan to tighten the API
of `jax.numpy` functions to not accept tuples or lists in lieu
or arrays. 

It is likely that this change will break users. Let's see how the tests are going.

