### PR TITLE
DOC: add examples to jax.tree_util.Partial

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -327,6 +327,15 @@ class Partial(functools.partial):
   >>> call_func(add_one, 2)
   DeviceArray(3, dtype=int32)
 
+  Passing zero arguments to ``Partial`` effectively wraps the original function,
+  making it a valid argument in JAX transformed functions:
+
+  >>> call_func(Partial(jnp.add), 1, 2)
+  DeviceArray(3, dtype=int32)
+
+  Had we passed ``jnp.add`` to ``call_func`` directly, it would have resulted in a
+  ``TypeError``.
+
   Note that if the result of ``Partial`` is used in the context where the
   value is traced, it results in all bound arguments being traced when passed
   to the partially-evaluated function:

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -306,6 +306,36 @@ class Partial(functools.partial):
 
   (You need to explicitly opt-in to this behavior because we didn't want to give
   functools.partial different semantics than normal function closures.)
+
+  For example, here is a basic usage of ``Partial`` in a manner similar to
+  ``functools.partial``:
+
+  >>> import jax.numpy as jnp
+  >>> add_one = Partial(jnp.add, 1)
+  >>> add_one(2)
+  DeviceArray(3, dtype=int32)
+
+  Pytree compatibility means that the resulting partial function can be passed
+  as an argument within transformed JAX functions, which is not possible with a
+  standard ``functools.partial`` function:
+
+  >>> from jax import jit
+  >>> @jit
+  ... def call_func(f, *args):
+  ...   return f(*args)
+  ...
+  >>> call_func(add_one, 2)
+  DeviceArray(3, dtype=int32)
+
+  Note that if the result of ``Partial`` is used in the context where the
+  value is traced, it results in all bound arguments being traced when passed
+  to the partially-evaluated function:
+
+  >>> print_zero = Partial(print, 0)
+  >>> print_zero()
+  0
+  >>> call_func(print_zero)
+  Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
   """
 
 register_pytree_node(


### PR DESCRIPTION
Clarify how the function is intended to work in traced contexts.