### PR TITLE
Update README.md for jaxlib 0.1.60.

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Next, run
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade jax jaxlib==0.1.59+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install --upgrade jax jaxlib==0.1.60+cuda110 -f https://storage.googleapis.com/jax-releases/jax_releases.html
 ```
 
 The jaxlib version must correspond to the version of the existing CUDA

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,8 +1,8 @@
 flake8
-# For now, we pin the numpy version here, because jaxlib 0.1.59 was built with >=1.12
-numpy>=1.12,<1.20
+# For now, we pin the numpy version here
+numpy>=1.16,<1.20
  # Must be kept in sync with the minimum jaxlib version in jax/lib/__init__.py
-jaxlib==0.1.59
+jaxlib==0.1.60
 mypy==0.790
 pillow
 pytest-benchmark

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -7,6 +7,12 @@ Change Log
 
 .. PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 
+jaxlib 0.1.61 (Unreleased)
+--------------------------
+
+* Bug fixes:
+
+
 jax 0.2.10 (Unreleased)
 -----------------------
 * `GitHub commits <https://github.com/google/jax/compare/jax-v0.2.9...master>`__.

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 import jaxlib
 
 # Must be kept in sync with the jaxlib version in build/test-requirements.txt
-_minimum_jaxlib_version = (0, 1, 59)
+_minimum_jaxlib_version = (0, 1, 60)
 try:
   from jaxlib import version as jaxlib_version
 except Exception as err:

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.12,<1.20', 'absl-py', 'flatbuffers'],
+    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={'jaxlib': binary_libs},

--- a/jaxlib/version.py
+++ b/jaxlib/version.py
@@ -14,4 +14,4 @@
 
 # This should be increased after releasing the current version (i.e. this
 # is always the next version to be released).
-__version__ = "0.1.60"
+__version__ = "0.1.61"


### PR DESCRIPTION
Bump jaxlib version to 0.1.61 and update changelog.

Change jaxlib numpy version limit to >=1.16 for next release. Releases older than 1.16 are deprecated per NEP 00029. Reenable NumPy 1.20.

Bump minimum jaxlib version to 0.1.60.