### PR TITLE
Drop support in tests for NumPy < 1.16 and jaxlib < 0.1.60

### DIFF
--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -75,8 +75,6 @@ class DLPackTest(jtu.JaxTestCase):
      for dtype in dlpack_dtypes
      for take_ownership in [False, True]))
   def testJaxRoundTrip(self, shape, dtype, take_ownership):
-    if jax.lib.version < (0, 1, 57) and not take_ownership:
-      raise unittest.SkipTest("Requires jaxlib >= 0.1.57");
     rng = jtu.rand_default(self.rng())
     np = rng(shape, dtype)
     x = jnp.array(np)
@@ -120,8 +118,6 @@ class DLPackTest(jtu.JaxTestCase):
      for dtype in dlpack_dtypes))
   @unittest.skipIf(not tf, "Test requires TensorFlow")
   def testJaxToTensorFlow(self, shape, dtype):
-    if jax.lib.version < (0, 1, 57):
-      raise unittest.SkipTest("Requires jaxlib >= 0.1.57");
     if not FLAGS.jax_enable_x64 and dtype in [jnp.int64, jnp.uint64,
                                               jnp.float64]:
       self.skipTest("x64 types are disabled by jax_enable_x64")
@@ -164,8 +160,6 @@ class DLPackTest(jtu.JaxTestCase):
      for dtype in torch_dtypes))
   @unittest.skipIf(not torch, "Test requires PyTorch")
   def testJaxToTorch(self, shape, dtype):
-    if jax.lib.version < (0, 1, 57):
-      raise unittest.SkipTest("Requires jaxlib >= 0.1.57");
     if not FLAGS.jax_enable_x64 and dtype in [jnp.int64, jnp.float64]:
       self.skipTest("x64 types are disabled by jax_enable_x64")
     rng = jtu.rand_default(self.rng())
@@ -202,10 +196,8 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
 
 class Bfloat16Test(jtu.JaxTestCase):
 
-  @unittest.skipIf((not tf or tf_version < (2, 5, 0) or
-                    jax.lib.version < (0, 1, 58)),
-                   "Test requires TensorFlow 2.5.0 or newer and jaxlib 0.1.58 "
-                   "or newer")
+  @unittest.skipIf((not tf or tf_version < (2, 5, 0)),
+                   "Test requires TensorFlow 2.5.0 or newer")
   def testJaxAndTfHaveTheSameBfloat16Type(self):
     self.assertEqual(np.dtype(jnp.bfloat16).num,
                      np.dtype(tf.dtypes.bfloat16.as_numpy_dtype).num)

--- a/tests/tree_util_tests.py
+++ b/tests/tree_util_tests.py
@@ -15,11 +15,9 @@
 
 import collections
 
-from unittest import skipIf
 from absl.testing import absltest
 from absl.testing import parameterized
 
-import jax
 from jax import test_util as jtu
 from jax import tree_util
 
@@ -202,7 +200,6 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(out, (((1, [3]), (2, None)),
                            (([3, 4, 5], ({"foo": "bar"}, 7, [5, 6])))))
 
-  @skipIf(jax.lib.version < (0, 1, 58), "test requires Jaxlib >= 0.1.58")
   def testFlattenIsLeaf(self):
     x = [(1, 2), (3, 4), (5, 6)]
     leaves, _ = tree_util.tree_flatten(x, is_leaf=lambda t: False)
@@ -220,7 +217,6 @@ class TreeTest(jtu.JaxTestCase):
         y, is_leaf=lambda t: isinstance(t, tuple))
     self.assertEqual(leaves, [(1,), (2,), (3,)])
 
-  @skipIf(jax.lib.version < (0, 1, 58), "test requires Jaxlib >= 0.1.58")
   @parameterized.parameters(*TREES)
   def testRoundtripIsLeaf(self, tree):
     xs, treedef = tree_util.tree_flatten(

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -88,8 +88,6 @@ def with_mesh_from_kwargs(f):
 
 class XMapTest(jtu.JaxTestCase):
   def setUp(self):
-    if jax.lib.version < (0, 1, 58):
-      raise SkipTest("xmap requires jaxlib version >= 0.1.58")
     if not config.omnistaging_enabled:
       raise SkipTest("xmap requires omnistaging")
 
@@ -374,8 +372,6 @@ class XMapTestSPMD(XMapTest):
 
 class NamedNumPyTest(jtu.JaxTestCase):
   def setUp(self):
-    if jax.lib.version < (0, 1, 58):
-      raise SkipTest("xmap requires jaxlib version >= 0.1.58")
     if not config.omnistaging_enabled:
       raise SkipTest("xmap requires omnistaging")
 


### PR DESCRIPTION
These are now the minimum versions.