### PR TITLE
Add `jax.default_backend()` which returns the default platform name.

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -32,6 +32,7 @@ Just-in-time compilation (:code:`jit`)
     make_jaxpr
     eval_shape
     device_put
+    default_backend
     named_call
 
 Automatic differentiation
@@ -83,6 +84,7 @@ Parallelization (:code:`pmap`)
 .. autofunction:: make_jaxpr
 .. autofunction:: eval_shape
 .. autofunction:: device_put
+.. autofunction:: default_backend
 .. autofunction:: named_call
 
 .. autofunction:: grad

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -30,6 +30,7 @@ from .api import (
   custom_jvp,
   custom_vjp,
   custom_transforms,
+  default_backend,
   defjvp,
   defjvp_all,
   defvjp,

--- a/jax/api.py
+++ b/jax/api.py
@@ -60,7 +60,8 @@ from .lib import xla_bridge as xb
 from .lib import xla_client as xc
 # Unused imports to be exported
 from .lib.xla_bridge import (device_count, local_device_count, devices,
-                             local_devices, host_id, host_ids, host_count)
+                             local_devices, host_id, host_ids, host_count,
+                             default_backend)
 from .core import ConcreteArray, ShapedArray, raise_to_shaped
 from .interpreters import partial_eval as pe
 from .interpreters import xla

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -228,6 +228,11 @@ def devices(backend: Optional[str] = None) -> List[xla_client.Device]:
   return get_backend(backend).devices()
 
 
+def default_backend() -> str:
+  """Returns the platform name of the default XLA backend."""
+  return get_backend(None).platform
+
+
 def local_devices(host_id: Optional[int] = None,
                   backend: Optional[str] = None) -> List[xla_client.Device]:
   """Like :py:func:`jax.devices`, but only returns devices local to a given host.

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2291,6 +2291,10 @@ class APITest(jtu.JaxTestCase):
         lax.scan(to_scan, x, None, length=1)
       f(np.arange(5.))  # doesn't crash
 
+  def test_default_backend(self):
+    first_local_device = api.local_devices()[0]
+    self.assertEqual(first_local_device.platform, api.default_backend())
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This can be useful when you need backend specific behaviour, e.g.:

    if jax.default_backend() == 'gpu':
      dataset = double_buffer(dataset)

Or if you want to assert a given backend is the default:

    assert jax.default_backend() == 'tpu'

I am a bit conflicted by the naming, "backend" is consistent with other APIs in
JAX (e.g. jit, local_devices etc) which accept a "backend" string which is used
to lookup an XLA backend by platform name.