### PR TITLE
Cleanup: remove obsolete jaxlib version checks

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -96,7 +96,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_bool("jax_disable_jit", bool_env("JAX_DISABLE_JIT", False),
                   "Disable JIT compilation and just call original Python.")
 flags.DEFINE_bool(
-    "experimental_cpp_jit", bool_env("JAX_CPP_JIT", version >= (0, 1, 57)),
+    "experimental_cpp_jit", bool_env("JAX_CPP_JIT", True),
     "A temporary flag enabling the C++ jax.jit fast path."
     "Set this to `False` only if it crashes otherwise and report "
     "the error to the jax-team.")
@@ -328,10 +328,7 @@ def _cpp_jit(
         avals.append(aval)
         lazy_exprs.append(None if xla.lazy.is_trivial(lazy_expr) else lazy_expr)
       assert len(avals) == len(out_flat)
-      if version >= (0, 1, 58):
-        fastpath_data = (xla_executable, out_pytree_def, sticky_device, avals, lazy_exprs)
-      else:
-        fastpath_data = (xla_executable, result_handlers, out_pytree_def)
+      fastpath_data = (xla_executable, out_pytree_def, sticky_device, avals, lazy_exprs)
     else:
       fastpath_data = None
 

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1503,11 +1503,7 @@ def _initialize_outfeed_receiver(
       size of arrays in the callback queue. When this limit is reached the
       device listener pauses.
   """
-  try:
-    outfeed_receiver_module = xla_extension.outfeed_receiver
-  except AttributeError as err:
-    raise NotImplementedError(
-        "id_tap works only with jaxlib version 0.1.51 and higher") from err
+  outfeed_receiver_module = xla_extension.outfeed_receiver
 
   with _outfeed_receiver.lock:
     if _outfeed_receiver.receiver is not None:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -584,11 +584,7 @@ class ShardedDeviceArray(xla._DeviceArray):
         buf_idx = None
       if buf_idx is not None:
         buf = self.device_buffers[buf_idx]
-        # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58
-        # is the default.
-        aval = ShapedArray(
-            getattr(buf, "xla_shape", buf.shape)().dimensions(),
-            self.aval.dtype)
+        aval = ShapedArray(buf.xla_shape().dimensions(), self.aval.dtype)
         return xla.make_device_array(aval, None, lazy.array(aval.shape), buf)
     return super(ShardedDeviceArray, self).__getitem__(idx)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1013,12 +1013,7 @@ _forward_to_value = partial(_forward_method, "_value")
 
 # The following is used for the type _CppDeviceArray or _DeviceArray.
 DeviceArrayProtocol = Any
-if hasattr(xc, "DeviceArrayBase"):
-  DeviceArray = xc.DeviceArrayBase
-else:
-  # prior to jaxlib version 0.1.58.
-  class DeviceArray:  # type: ignore
-    pass
+DeviceArray = xc.DeviceArrayBase
 
 _CppDeviceArray: DeviceArrayProtocol = xc.Buffer
 

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -17,7 +17,7 @@
 
 __all__ = [
   'cuda_prng', 'cusolver', 'rocsolver', 'jaxlib', 'lapack',
-  'pytree', 'tpu_client', 'version', 'xla_client'
+  'pocketfft', 'pytree', 'tpu_client', 'version', 'xla_client'
 ]
 
 import jaxlib
@@ -52,6 +52,7 @@ _check_jaxlib_version()
 
 from jaxlib import xla_client
 from jaxlib import lapack
+from jaxlib import pocketfft
 
 xla_extension = xla_client._xla
 pytree = xla_client._xla.pytree
@@ -82,10 +83,3 @@ try:
   from jaxlib import tpu_client  # pytype: disable=import-error
 except:
   tpu_client = None
-
-# TODO(phawkins): Make this import unconditional once the minimum jaxlib version
-# is 0.1.57 or greater.
-try:
-  from jaxlib import pocketfft  # pytype: disable=import-error
-except:
-  pocketfft = None

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -65,9 +65,7 @@ def tree_flatten(tree, is_leaf: Optional[Callable[[Any], bool]] = None):
     A pair where the first element is a list of leaf values and the second
     element is a treedef representing the structure of the flattened tree.
   """
-  # We skip the second argument in support of old jaxlibs
-  # TODO: Remove once 0.1.58 becomes the minimum supported jaxlib version
-  return pytree.flatten(tree) if is_leaf is None else pytree.flatten(tree, is_leaf)
+  return pytree.flatten(tree, is_leaf)
 
 
 def tree_unflatten(treedef, leaves):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -43,7 +43,6 @@ from jax.lib import xla_bridge as xb
 from jax import test_util as jtu
 from jax import tree_util
 from jax import linear_util as lu
-from jax.lib import version
 import jax._src.util
 
 from jax.config import config
@@ -65,11 +64,7 @@ class CPPJitTest(jtu.JaxTestCase):
     # TODO(jblespiau,phawkins): Remove this when jaxlib has been released.
     # This is in the future, because we are making a breaking change to
     # Tensorflow.
-    if version <= (0, 1, 55):
-      raise unittest.SkipTest("Disabled because it depends on some future "
-                              "release of jax_jit.cc within jaxlib.")
-    else:
-      return jax.api._cpp_jit
+    return jax.api._cpp_jit
 
   def test_jit_of_noncallable(self):
     self.assertRaisesRegex(TypeError, "Expected a callable value.*",
@@ -135,9 +130,6 @@ class CPPJitTest(jtu.JaxTestCase):
     assert len(side) == 3
 
   def test_static_args_equality(self):
-    if version < (0, 1, 57):
-      raise unittest.SkipTest("this test requires a newest jaxlib")
-
     class A():
 
       def __hash__(self):
@@ -320,9 +312,6 @@ class CPPJitTest(jtu.JaxTestCase):
     assert len(effects) == 3
 
   def test_static_argnum_errors_on_keyword_arguments(self):
-    if version < (0, 1, 58):
-      raise unittest.SkipTest("Disabled because it depends on some future "
-                              "release of jax_jit.cc within jaxlib.")
     f = self.jit(lambda x: x, static_argnums=0)
     msg = ("jitted function has static_argnums=(0,), donate_argnums=() but was "
            "called with only 0 positional arguments.")
@@ -440,10 +429,6 @@ class CPPJitTest(jtu.JaxTestCase):
       jitted_f(1, np.asarray(1))
 
   def test_cpp_jit_raises_on_non_hashable_static_argnum(self):
-    if version < (0, 1, 57):
-      raise unittest.SkipTest("Disabled because it depends on some future "
-                              "release of jax_jit.cc within jaxlib.")
-
     if self.jit != jax.api._cpp_jit:
       raise unittest.SkipTest("this test only applies to _cpp_jit")
 
@@ -474,9 +459,6 @@ class CPPJitTest(jtu.JaxTestCase):
       jitted_f(1, HashableWithoutEq())
 
   def test_cpp_jitted_function_returns_PyBuffer(self):
-    if version < (0, 1, 58):
-      raise unittest.SkipTest("Disabled because it depends on some future "
-                              "release of jax_jit.cc within jaxlib.")
     if self.jit != jax.api._cpp_jit:
       raise unittest.SkipTest("this test only applies to _cpp_jit")
 

--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from jax import test_util as jtu
 from jax import numpy as jnp
-from jax.lib import version
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -57,11 +56,7 @@ class DebugNaNsTest(jtu.JaxTestCase):
       ans.block_until_ready()
 
   def testCallDeoptimized(self):
-    to_test = [jax.api._python_jit]
-    if version > (0, 1, 56):
-      to_test.append(jax.api._cpp_jit)
-
-    for jit in to_test:
+    for jit in [jax.api._python_jit, jax.api._cpp_jit]:
 
       @jit
       def f(x):
@@ -108,11 +103,7 @@ class DebugInfsTest(jtu.JaxTestCase):
       ans.block_until_ready()
 
   def testCallDeoptimized(self):
-    to_test = [jax.api._python_jit]
-    if version > (0, 1, 56):
-      to_test.append(jax.api._cpp_jit)
-
-    for jit in to_test:
+    for jit in [jax.api._python_jit, jax.api._cpp_jit]:
 
       @jit
       def f(x):

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -23,7 +23,6 @@ from jax import lib as jaxlib
 from jax import numpy as jnp
 from jax import test_util as jtu
 from jax.config import config
-from jax.lib import version
 import numpy as np
 
 
@@ -41,19 +40,14 @@ def _cpp_device_put(value, device):
 
 class JaxJitTest(parameterized.TestCase):
 
-  @unittest.skipIf(version <= (0, 1, 56), "old jaxlib version")
   def test_is_float_0(self):
     self.assertTrue(
         jaxlib.jax_jit._is_float0(np.zeros((5, 5), dtype=jax.float0)))
     self.assertFalse(jaxlib.jax_jit._is_float0(np.zeros((5, 5))))
 
-  @unittest.skipIf(version <= (0, 1, 56), "old jaxlib version")
   def test_DtypeTo32BitDtype(self):
     self.assertEqual(np.float32, jaxlib.jax_jit._DtypeTo32BitDtype(np.float64))
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_device_put"),
-                   "old jaxlib version")
   @parameterized.parameters([jax.device_put, _cpp_device_put])
   def test_device_put_on_numpy_scalars(self, device_put_function):
 
@@ -67,9 +61,6 @@ class JaxJitTest(parameterized.TestCase):
       self.assertEqual(output_buffer.aval, jax.core.ShapedArray((), dtype))
       self.assertEqual(output_buffer.dtype, dtypes.canonicalize_dtype(dtype))
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_device_put"),
-                   "old jaxlib version")
   @parameterized.parameters([jax.device_put, _cpp_device_put])
   def test_device_put_on_numpy_arrays(self, device_put_function):
 
@@ -84,9 +75,6 @@ class JaxJitTest(parameterized.TestCase):
       np.testing.assert_array_equal(output_buffer, np.zeros((3, 4),
                                                             dtype=dtype))
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_device_put"),
-                   "old jaxlib version")
   @parameterized.parameters([jax.device_put, _cpp_device_put])
   def test_device_put_on_buffers(self, device_put_function):
     device = jax.devices()[0]
@@ -101,9 +89,6 @@ class JaxJitTest(parameterized.TestCase):
       self.assertEqual(output_buffer.aval, buffer.aval)
       np.testing.assert_array_equal(output_buffer, np.array(value + 1))
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_device_put"),
-                   "old jaxlib version")
   @parameterized.parameters([jax.device_put, _cpp_device_put])
   def test_device_put_on_sharded_device_array(self, device_put_function):
     device = jax.devices()[0]
@@ -119,9 +104,6 @@ class JaxJitTest(parameterized.TestCase):
       self.assertEqual(output_buffer.aval, sda.aval)
       np.testing.assert_array_equal(output_buffer, np.asarray(sda))
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_device_put"),
-                   "old jaxlib version")
   def test_device_put_on_python_scalars(self):
     device = jax.devices()[0]
     int_type = dtypes.canonicalize_dtype(np.int64)
@@ -161,9 +143,6 @@ class JaxJitTest(parameterized.TestCase):
     with self.assertRaisesRegex(OverflowError, "Python int too large.*"):
       jaxlib.jax_jit.device_put(int(1e100), True, jax.devices()[0])
 
-  # TODO(jblespiau): Remove after minimal jaxlib version is 0.1.59 or newer.
-  @unittest.skipIf(not hasattr(jaxlib.jax_jit, "_ArgSignatureOfValue"),
-                   "old jaxlib version")
   def test_arg_signature_of_value(self):
     """Tests the C++ code-path."""
     jax_enable_x64 = config.x64_enabled
@@ -219,9 +198,6 @@ class JaxJitTest(parameterized.TestCase):
     self.assertTrue(signature.weak_type)
 
   def test_signature_support(self):
-    if version < (0, 1, 56):
-      raise unittest.SkipTest("old jaxlib version")
-
     def f(a, b, c):
       return a + b + c
 

--- a/tests/sharded_jit_test.py
+++ b/tests/sharded_jit_test.py
@@ -160,14 +160,8 @@ class ShardedJitTest(jtu.JaxTestCase):
     actual = sharded_jit(f, in_parts=P(2,1), out_parts=P(2,1))(x)
     self.assertAllClose(actual, expected, check_dtypes=False)
     self.assertLen(actual.device_buffers, 2)
-    # TODO(jblespiau): We can simply use buf.xla_shape() when version 0.1.58 is
-    # the default.
-    self.assertEqual(
-        getattr(actual.device_buffers[0], "xla_shape",
-                actual.device_buffers[0].shape)().dimensions(), (4, 8))
-    self.assertEqual(
-        getattr(actual.device_buffers[1], "xla_shape",
-                actual.device_buffers[1].shape)().dimensions(), (4, 8))
+    self.assertEqual(actual.device_buffers[0].xla_shape().dimensions(), (4, 8))
+    self.assertEqual(actual.device_buffers[1].xla_shape().dimensions(), (4, 8))
 
     # Mismatched sharded_jit partitions
     with self.assertRaisesRegex(

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -141,8 +141,6 @@ class TreeTest(jtu.JaxTestCase):
   @parameterized.parameters(*(TREES + LEAVES))
   def testRoundtripWithFlattenUpTo(self, inputs):
     _, tree = tree_util.tree_flatten(inputs)
-    if not hasattr(tree, "flatten_up_to"):
-      self.skipTest("Test requires Jaxlib >= 0.1.23")
     xs = tree.flatten_up_to(inputs)
     actual = tree_util.tree_unflatten(tree, xs)
     self.assertEqual(actual, inputs)
@@ -172,14 +170,10 @@ class TreeTest(jtu.JaxTestCase):
     _, tree = tree_util.tree_flatten(((1, 2, 3), (4,)))
     _, c0 = tree_util.tree_flatten((0, 0, 0))
     _, c1 = tree_util.tree_flatten((7,))
-    if not callable(tree.children):
-      self.skipTest("Test requires Jaxlib >= 0.1.23")
     self.assertEqual([c0, c1], tree.children())
 
   def testFlattenUpTo(self):
     _, tree = tree_util.tree_flatten([(1, 2), None, ATuple(foo=3, bar=7)])
-    if not hasattr(tree, "flatten_up_to"):
-      self.skipTest("Test requires Jaxlib >= 0.1.23")
     out = tree.flatten_up_to([({
         "foo": 7
     }, (3, 4)), None, ATuple(foo=(11, 9), bar=None)])


### PR DESCRIPTION
#5622 bumps the minimum jaxlib version to 0.1.60; this allows us to remove a number of checks for jaxlib versions lower than this.