### PR TITLE
Fix a bug in xmap mesh slicing code

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1371,12 +1371,12 @@ class Mesh:
     return Mesh(self.devices[subcube_indices], self.axis_names)
 
   def __getitem__(self, new_axes):
-    indices = [0] * len(self.axis_names)
     axis_pos = {name: i for i, name in enumerate(self.axis_names)}
-    for axis in new_axes:
-      indices[axis_pos[axis]] = slice(None)
-    new_devices = self.devices[tuple(indices)]
-    new_devices = new_devices.transpose(tuple(axis_pos[axis] for axis in new_axes))
+    new_devices = self.devices.transpose(tuple(axis_pos[axis] for axis in new_axes) +
+                                         tuple(axis_pos[axis] for axis in self.axis_names
+                                               if axis not in new_axes))
+    new_devices = new_devices[(slice(None),) * len(new_axes) +
+                              (0,) * (len(self.axis_names) - len(new_axes))]
     return Mesh(new_devices, new_axes)
 
   @property

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -185,6 +185,14 @@ class XMapTest(jtu.JaxTestCase):
                           (pxla.ShardedAxis(1), pxla.ShardedAxis(0))))
 
   @ignore_xmap_warning()
+  @with_mesh([('x', 2), ('y', 2)])
+  def testSkipFirstMeshDim(self):
+    def run(axis_resources):
+      return xmap(lambda x: x * 2, in_axes=['i', ...], out_axes=['i', ...],
+                  axis_resources=axis_resources)(jnp.ones((4,)))
+    self.assertAllClose(run({'i': 'x'}), run({'i': 'y'}))
+
+  @ignore_xmap_warning()
   @with_mesh([('x', 2)])
   def testCompilationCache(self):
     def f(x):


### PR DESCRIPTION
The previous version didn't adjust the axes indices after slicing the
devices array, leading to out-of-bounds errors when doing the transpose.