### PR TITLE
CI: use internal scipy when testing internal numpy

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -67,13 +67,13 @@ jobs:
 #            # Test experimental NumPy dispatch
 #            package-overrides: "git+https://github.com/seberg/numpy-dispatch.git"
 #            num_generated_cases: 10
-          - name-prefix: "with internal numpy"
+          - name-prefix: "with internal numpy/scipy"
             python-version: 3.6
             os: ubuntu-latest
             enable-x64: 1
             enable-omnistaging: 1
             # Test with numpy version that matches Google-internal version
-            package-overrides: "numpy==1.16.4"
+            package-overrides: "numpy==1.16.4 scipy==1.2.1"
             num_generated_cases: 10
           - name-prefix: "without omnistaging"
             python-version: 3.7


### PR DESCRIPTION
This will catch potential issues related to older scipy versions before pulldown.

Note: I'll plan to patch & update the workflow name in the copybara configuration before submitting.