### PR TITLE
Add support for union1d

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -362,6 +362,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     uint64
     uint8
     unique
+    union1d
     unpackbits
     unravel_index
     unsignedinteger

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1515,6 +1515,16 @@ def setdiff1d(ar1, ar2, assume_unique=False):
   idx = in1d(ar1, ar2, invert=True)
   return ar1[idx]
 
+
+@_wraps(np.union1d)
+def union1d(ar1, ar2):
+  ar1 = core.concrete_or_error(asarray, ar1, "The error arose in union1d()")
+  ar2 = core.concrete_or_error(asarray, ar2, "The error arose in union1d()")
+
+  conc = concatenate((ar1, ar2), axis=None)
+  return unique(conc)
+
+
 @partial(jit, static_argnums=2)
 def _intersect1d_sorted_mask(ar1, ar2, return_indices=False):
   """

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -60,7 +60,7 @@ from jax._src.numpy.lax_numpy import (
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,
     trim_zeros, triu, triu_indices, triu_indices_from, true_divide, trunc, uint16, uint32, uint64, uint8, unique,
-    unpackbits, unravel_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
+    union1d, unpackbits, unravel_index, unsignedinteger, unwrap, vander, var, vdot, vsplit,
     vstack, where, zeros, zeros_like, _NOT_IMPLEMENTED)
 
 from jax._src.numpy.polynomial import roots

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1163,6 +1163,23 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.setdiff1d, jnp.setdiff1d, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_{}".format(
+       jtu.format_shape_dtype_string(shape1, dtype1),
+       jtu.format_shape_dtype_string(shape2, dtype2)),
+       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2}
+      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for shape1 in nonempty_nonscalar_array_shapes
+      for shape2 in nonempty_nonscalar_array_shapes))
+  def testUnion1d(self, shape1, shape2, dtype1, dtype2):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
+    def np_fun(arg1, arg2):
+      dtype = jnp.promote_types(arg1.dtype, arg2.dtype)
+      return np.union1d(arg1, arg2).astype(dtype)
+    self._CheckAgainstNumpy(np_fun, jnp.union1d, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}_assume_unique={}_return_indices={}".format(
        jtu.format_shape_dtype_string(shape1, dtype1),
        jtu.format_shape_dtype_string(shape2, dtype2),


### PR DESCRIPTION
This is the implementation for np.union1d from #70 (and #2078 ).

Try to closely follow `np.union1d` implemetation.