### PR TITLE
Add support for setxor1d

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -317,6 +317,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     select
     set_printoptions
     setdiff1d
+    setxor1d
     shape
     sign
     signbit

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1525,6 +1525,30 @@ def union1d(ar1, ar2):
   return unique(conc)
 
 
+@_wraps(np.setxor1d, lax_description="""
+In the JAX version, the input arrays are explicilty flattened regardless
+of assume_unique value.
+""")
+def setxor1d(ar1, ar2, assume_unique=False):
+  ar1 = core.concrete_or_error(asarray, ar1, "The error arose in setxor1d()")
+  ar2 = core.concrete_or_error(asarray, ar2, "The error arose in setxor1d()")
+
+  ar1 = ravel(ar1)
+  ar2 = ravel(ar2)
+
+  if not assume_unique:
+    ar1 = unique(ar1)
+    ar2 = unique(ar2)
+
+  aux = concatenate((ar1, ar2))
+  if aux.size == 0:
+    return aux
+
+  aux = sort(aux)
+  flag = concatenate((array([True]), aux[1:] != aux[:-1], array([True])))
+  return aux[flag[1:] & flag[:-1]]
+
+
 @partial(jit, static_argnums=2)
 def _intersect1d_sorted_mask(ar1, ar2, return_indices=False):
   """

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -55,7 +55,7 @@ from jax._src.numpy.lax_numpy import (
     prod, product, promote_types, ptp, quantile,
     rad2deg, radians, ravel, ravel_multi_index, real, reciprocal, remainder, repeat, reshape,
     result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,
-    save, savez, searchsorted, select, set_printoptions, setdiff1d, shape, sign, signbit,
+    save, savez, searchsorted, select, set_printoptions, setdiff1d, setxor1d, shape, sign, signbit,
     signedinteger, sin, sinc, single, sinh, size, sometrue, sort, sort_complex, split, sqrt,
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,
     tan, tanh, tensordot, tile, trace, trapz, transpose, tri, tril, tril_indices, tril_indices_from,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1180,6 +1180,30 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp.union1d, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_{}_assume_unique={}".format(
+       jtu.format_shape_dtype_string(shape1, dtype1),
+       jtu.format_shape_dtype_string(shape2, dtype2),
+       assume_unique),
+       "shape1": shape1, "dtype1": dtype1, "shape2": shape2, "dtype2": dtype2,
+       "assume_unique": assume_unique}
+      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
+      for shape1 in all_shapes
+      for shape2 in all_shapes
+      for assume_unique in [False, True]))
+  def testSetxor1d(self, shape1, dtype1, shape2, dtype2, assume_unique):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
+    jnp_fun = lambda ar1, ar2: jnp.setxor1d(ar1, ar2, assume_unique=assume_unique)
+    def np_fun(ar1, ar2):
+      if assume_unique:
+        # pre-flatten the arrays to match with jax implementation
+        ar1 = np.ravel(ar1)
+        ar2 = np.ravel(ar2)
+      return np.setxor1d(ar1, ar2, assume_unique)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_{}_assume_unique={}_return_indices={}".format(
        jtu.format_shape_dtype_string(shape1, dtype1),
        jtu.format_shape_dtype_string(shape2, dtype2),


### PR DESCRIPTION
This is the implementation for np.setxor1d from #70 (and #2078 ).

Including this and #5664, all the NumPy set routines listed in #2078 are implemented.