### PR TITLE
Add CUDA 11.2 to wheel builds.

### DIFF
--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -2,12 +2,12 @@
 set -xev
 
 PYTHON_VERSIONS="3.6.8 3.7.2 3.8.0 3.9.0"
-CUDA_VERSIONS="10.1 10.2 11.0 11.1"
+CUDA_VERSIONS="10.1 10.2 11.0 11.1 11.2"
 CUDA_VARIANTS="cuda" # "cuda-included"
 
 mkdir -p dist
 
-# build the cuda linux packages, tagging with linux_x86_64
+# build the cuda linux packages
 for CUDA_VERSION in $CUDA_VERSIONS
 do
   docker build -t jaxbuild jax/build/ --build-arg JAX_CUDA_VERSION=$CUDA_VERSION
@@ -22,7 +22,7 @@ do
   done
 done
 
-# build the pypi linux packages, tagging with manylinux1 for pypi reasons
+# build the pypi linux packages
 docker build -t jaxbuild jax/build/
 for PYTHON_VERSION in $PYTHON_VERSIONS
 do

--- a/build/install_cuda.sh
+++ b/build/install_cuda.sh
@@ -15,19 +15,21 @@ elif [ $CUDA_VERSION = "10.1" ]; then
 elif [ $CUDA_VERSION = "10.2" ]; then
   CUBLAS=libcublas10
   CUBLAS_DEV=libcublas-dev
-  NCCL_VERSION=2.5.6
   CUDNN_VERSION=7.6.5.32
 elif [ $CUDA_VERSION = "11.0" ]; then
   CUBLAS=libcublas-11-0
   CUBLAS_DEV=libcublas-dev-11-0
-  NCCL_VERSION=2.7.3
   CUDNN_VERSION=8.0.0.180
   LIBCUDNN=libcudnn8
 elif [ $CUDA_VERSION = "11.1" ]; then
   CUBLAS=libcublas-11-1
   CUBLAS_DEV=libcublas-dev-11-1
-  NCCL_VERSION=2.7.8
   CUDNN_VERSION=8.0.4.30
+  LIBCUDNN=libcudnn8
+elif [ $CUDA_VERSION = "11.2" ]; then
+  CUBLAS=libcublas-11-2
+  CUBLAS_DEV=libcublas-dev-11-2
+  CUDNN_VERSION=8.1.0.77
   LIBCUDNN=libcudnn8
 else
   echo "Unsupported CUDA version: $CUDA_VERSION"
@@ -35,7 +37,6 @@ else
 fi
 
 echo "Installing cuda version: $CUDA_VERSION"
-echo "nccl version: $NCCL_VERSION"
 echo "cudnn version: $CUDNN_VERSION"
 
 apt-get update
@@ -47,8 +48,6 @@ apt-get install -y --no-install-recommends --allow-downgrades \
   cuda-command-line-tools-$CUDA_VERSION \
   cuda-libraries-dev-$CUDA_VERSION \
   cuda-minimal-build-$CUDA_VERSION \
-  libnccl2=$NCCL_VERSION-1+cuda$CUDA_VERSION \
-  libnccl-dev=$NCCL_VERSION-1+cuda$CUDA_VERSION \
   $LIBCUDNN=$CUDNN_VERSION-1+cuda$CUDA_VERSION \
   $LIBCUDNN-dev=$CUDNN_VERSION-1+cuda$CUDA_VERSION
 rm -f /usr/local/cuda


### PR DESCRIPTION
Remove NCCL from CUDA installation scripts. This is partially because there are no Ubuntu 16.04 CUDA 11.2 NCCL packages, but also because we don't need NCCL packages in the first place since we are building from source.

Issue #5668 