### PR TITLE
util.wraps: update same attributes as functools.wraps.

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -295,17 +295,22 @@ def ceil_of_ratio(x, y):
 
 @curry
 def wraps(wrapped, fun, namestr="{fun}", docstr="{doc}", **kwargs):
+  """
+  Like functools.wraps, but with finer-grained control over the name and docstring
+  of the resulting function.
+  """
   try:
-    fun.__name__ = namestr.format(fun=get_name(wrapped))
-    fun.__module__ = get_module(wrapped)
-    fun.__doc__ = docstr.format(fun=get_name(wrapped), doc=get_doc(wrapped), **kwargs)
+    name = getattr(wrapped, "__name__", "<unnamed function>")
+    doc = getattr(wrapped, "__doc__", "") or ""
+    fun.__dict__.update(getattr(wrapped, "__dict__", {}))
+    fun.__annotations__ = getattr(wrapped, "__annotations__", {})
+    fun.__name__ = namestr.format(fun=name)
+    fun.__module__ = getattr(wrapped, "__module__", "<unknown module>")
+    fun.__doc__ = docstr.format(fun=name, doc=doc, **kwargs)
+    fun.__qualname__ = getattr(wrapped, "__qualname__", fun.__name__)
     fun.__wrapped__ = wrapped
   finally:
     return fun
-
-def get_name(fun): return getattr(fun, "__name__", "<unnamed function>")
-def get_module(fun): return getattr(fun, "__module__", "<unknown module>")
-def get_doc(fun): return getattr(fun, "__doc__", "")
 
 # NOTE: Ideally we would annotate both the argument and return type as NoReturn
 #       but it seems like pytype doesn't support that...

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -497,6 +497,19 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     self.jit(init)()
     self.assertIsInstance(key_list[0], core.Tracer)
 
+  def test_jit_wrapped_attributes(self):
+    def f(x: int) -> int:
+      """docstring of f."""
+      return x + 1
+    f.some_value = 4
+    jf = self.jit(f)
+    for attr in ["doc", "name", "module", "qualname", "annotations"]:
+      self.assertEqual(
+        {attr: getattr(f, f"__{attr}__")},
+        {attr: getattr(jf, f"__{attr}__")})
+    self.assertEqual(f.some_value, jf.some_value)
+
+
 class PythonJitTest(CPPJitTest):
 
   @property


### PR DESCRIPTION
`util.wraps` was still operating in a Python 2.7 world, ignoring `__qualname__` and `__annotations__`, which could lead jit-decorated functions to have strange representations.

This PR updates `util.wraps()` to work like `functools.wraps()` in a Python 3 world, and adds a test of the behavior.

Possibly related to #5612