### PR TITLE
Make scipy.ndimage.map_coordinates fail when coordinates is rank 1

### DIFF
--- a/jax/_src/scipy/ndimage.py
+++ b/jax/_src/scipy/ndimage.py
@@ -58,9 +58,12 @@ def _linear_indices_and_weights(coordinate):
 @functools.partial(api.jit, static_argnums=(2, 3, 4))
 def _map_coordinates(input, coordinates, order, mode, cval):
   input = jnp.asarray(input)
-  coordinates = [jnp.asarray(c) for c in coordinates]
+  coordinates = jnp.asarray(coordinates)
   cval = jnp.asarray(cval, input.dtype)
 
+  if len(coordinates.shape[1:]) < 1:
+    raise RuntimeError('coordinates must have '
+                       'shape=(input.ndim, <num mapped coordinates>)')
   if len(coordinates) != input.ndim:
     raise ValueError('coordinates must be a sequence of length input.ndim, but '
                      '{} != {}'.format(len(coordinates), input.ndim))

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -105,7 +105,8 @@ class NdimageTest(jtu.JaxTestCase):
 
   def testMapCoordinatesErrors(self):
     x = np.arange(5.0)
-    c = [np.linspace(0, 5, num=3)]
+    _c = np.linspace(0, 5, num=3)
+    c = [_c]
     with self.assertRaisesRegex(NotImplementedError, 'requires order<=1'):
       lsp_ndimage.map_coordinates(x, c, order=2)
     with self.assertRaisesRegex(
@@ -113,6 +114,8 @@ class NdimageTest(jtu.JaxTestCase):
       lsp_ndimage.map_coordinates(x, c, order=1, mode='reflect')
     with self.assertRaisesRegex(ValueError, 'sequence of length'):
       lsp_ndimage.map_coordinates(x, [c, c], order=1)
+    with self.assertRaisesRegex(RuntimeError, 'coordinates must have shape'):
+      lsp_ndimage.map_coordinates(x, _c, order=1)
 
   def testMapCoordinateDocstring(self):
     self.assertIn("Only nearest neighbor",


### PR DESCRIPTION
This will fix the just raised issue:
https://github.com/google/jax/issues/5685

