### PR TITLE
add pargmin_p / pargmax_p primitives

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -180,6 +180,16 @@ def pmin(x, axis_name, *, axis_index_groups=None):
                          axis_index_groups=axis_index_groups)
   return tree_util.tree_unflatten(treedef, out_flat)
 
+def pargmax(x, axis_name):
+  if isinstance(axis_name, (tuple, list)):
+    raise TypeError(f"pargmax only accepts a single axis, got {axis_name}")
+  return pargmax_p.bind(x, axis=axis_name)
+
+def pargmin(x, axis_name):
+  if isinstance(axis_name, (tuple, list)):
+    raise TypeError(f"pargmin only accepts a single axis, got {axis_name}")
+  return pargmin_p.bind(x, axis=axis_name)
+
 def _validate_axis_index_groups(axis_index_groups):
   if axis_index_groups is None:
     return
@@ -730,6 +740,82 @@ batching.collective_rules[pmin_p] = \
 core.axis_substitution_rules[pmin_p] = partial(_subst_all_names_in_param, 'axes')
 
 
+# TODO(mattjj): merge with lax.argmin_p / lax.argmax_p
+pargmax_p = core.Primitive('pargmax')
+pargmin_p = core.Primitive('pargmin')
+
+def _pargminmax_impl(prim, x, *, axis):
+  if not isinstance(axis, int): raise NameError(f"unbound axis name: {axis}")
+  return xla.apply_primitive(prim, x, axis=axis)
+pargmax_p.def_impl(partial(_pargminmax_impl, pargmax_p))
+pargmin_p.def_impl(partial(_pargminmax_impl, pargmin_p))
+
+def _pargminmax_abstract_eval(x, *, axis):
+  if isinstance(axis, int):
+    if not 0 <= axis < np.ndim(x):
+      raise ValueError(f"axis index {axis} for operand shape {np.shape(x)}")
+    shape = tuple(np.delete(np.shape(x), axis))
+  else:
+    # TODO(mattjj): avals with names, check and eliminate axis name
+    shape = np.shape(x)
+  return ShapedArray(shape, np.dtype('int32'))
+pargmax_p.def_abstract_eval(_pargminmax_abstract_eval)
+pargmin_p.def_abstract_eval(_pargminmax_abstract_eval)
+
+def _pargminmax_vmap_collective_rule(reducer, frame, vals_in, dims_in, *, axis):
+  del frame, axis  # Unused.
+  (x,), (d,) = vals_in, dims_in
+  return reducer(x, d, np.dtype('int32')), None
+batching.collective_rules[pargmax_p] = partial(_pargminmax_vmap_collective_rule,
+                                               lax.argmax)
+batching.collective_rules[pargmin_p] = partial(_pargminmax_vmap_collective_rule,
+                                               lax.argmin)
+
+def _pargminmax_vmap_batching_rule(prim, vals_in, dims_in, *, axis):
+  (x,), (d,) = vals_in, dims_in
+  if isinstance(axis, int):
+    new_axis = axis + (d <= axis)
+    return prim.bind(x, axis=new_axis)
+  else:
+    return prim.bind(x, axis)
+batching.primitive_batchers[pargmax_p] = partial(_pargminmax_vmap_batching_rule,
+                                                 pargmax_p)
+batching.primitive_batchers[pargmin_p] = partial(_pargminmax_vmap_batching_rule,
+                                                 pargmin_p)
+
+def _pargminmax_axis_subst_rule(params: core.ParamDict, subst: core.AxisSubst
+                             ) -> core.ParamDict:
+  axis = params['axis']
+  if isinstance(axis, int):
+    return params
+  else:
+    return dict(params, axis=subst(axis))
+core.axis_substitution_rules[pargmax_p] = _pargminmax_axis_subst_rule
+core.axis_substitution_rules[pargmin_p] = _pargminmax_axis_subst_rule
+
+def _pargminmax_translation_rule(prim, reduc, c, x, *, axis, axis_env, platform):
+  if isinstance(axis, int):
+    rule = xla.backend_specific_translations[platform].get(prim)
+    rule = rule or xla.translations[prim]
+    return rule(c, x, axes=(axis,), index_dtype=np.dtype('int32'))
+  else:
+    def translation(x):
+      idx = lax.broadcast(axis_index(axis), x.shape)
+      maxval = lax.full_like(idx, dtypes.iinfo(dtypes.dtype(idx)).max)
+      return pmin(lax.select(reduc(x, axis) == x, idx, maxval), axis)
+    rule = xla.lower_fun(translation, multiple_results=False, parallel=True)
+    return rule(c, x, axis_env=axis_env, platform=platform)
+xla.parallel_translations[pargmax_p] = partial(_pargminmax_translation_rule,
+                                               lax.argmax_p, pmax)  # type: ignore
+xla.parallel_translations[pargmin_p] = partial(_pargminmax_translation_rule,
+                                               lax.argmin_p, pmin)  # type: ignore
+
+ad.defjvp_zero(pargmax_p)
+ad.defjvp_zero(pargmin_p)
+pxla.multi_host_supported_collectives.add(pargmax_p)
+pxla.multi_host_supported_collectives.add(pargmin_p)
+
+
 def _ppermute_translation_rule(c, x, *, axis_name, axis_env, perm, platform):
   replica_groups = _replica_groups(axis_env, axis_name, None)
   group_size = len(replica_groups[0])
@@ -1049,13 +1135,16 @@ batching.collective_rules[all_gather_p] = _all_gather_batched_collective
 core.axis_substitution_rules[all_gather_p] = partial(_subst_all_names_in_param, 'axis_name')
 
 def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
-  axis_pos = list(axis_env.names).index(axis_name)
-  nreplicas = axis_env.nreps // prod(axis_env.sizes)
-  div = xb.constant(c, np.array(nreplicas * prod(axis_env.sizes[axis_pos+1:]),
-                                dtype=np.uint32))
-  mod = xb.constant(c, np.array(axis_env.sizes[axis_pos], dtype=np.uint32))
-  unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
-  return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
+  if len(axis_env.names) == 1:
+    return xops.ConvertElementType(xops.ReplicaId(c), xb.dtype_to_etype(np.int32))
+  else:
+    axis_pos = list(axis_env.names).index(axis_name)
+    nreplicas = axis_env.nreps // prod(axis_env.sizes)
+    div = xb.constant(c, np.array(nreplicas * prod(axis_env.sizes[axis_pos+1:]),
+                                  dtype=np.uint32))
+    mod = xb.constant(c, np.array(axis_env.sizes[axis_pos], dtype=np.uint32))
+    unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
+    return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
 
 axis_index_p = core.Primitive('axis_index')
 xla.parallel_translations[axis_index_p] = _axis_index_translation_rule
@@ -1069,20 +1158,23 @@ core.axis_substitution_rules[axis_index_p] = partial(_subst_all_names_in_param, 
 # wants to bind an axis name has to additionally implement `process_axis_index`
 # and put its main trace on the axis env stack.
 def _axis_index_bind(*, axis_name):
-  if not isinstance(axis_name, (tuple, list)):
-    axis_name = (axis_name,)
-  inner_size = 1
-  index = 0
-  for name in reversed(axis_name):
+  def name_idx(name):
     frame = core.axis_frame(name)
     if frame.main_trace is not None:
       trace = frame.main_trace.with_cur_sublevel()
-      name_idx = trace.process_axis_index(frame)
+      return trace.process_axis_index(frame)
     else:
-      name_idx = core.Primitive.bind(axis_index_p, axis_name=name)
-    index += name_idx * inner_size
-    inner_size *= psum(1, name)
-  return index
+      return core.Primitive.bind(axis_index_p, axis_name=name)
+
+  if not isinstance(axis_name, (tuple, list)):
+    return name_idx(axis_name)
+  else:
+    inner_size = 1
+    index = 0
+    for name in reversed(axis_name):
+      index += name_idx(name) * inner_size
+      inner_size *= psum(1, name)
+    return index
 axis_index_p.def_custom_bind(_axis_index_bind)
 
 def _process_axis_index(self, frame):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -153,7 +153,7 @@ class BatchTrace(Trace):
     if all(bdim is not_mapped for bdim in dims_in):
       return primitive.bind(*vals_in, **params)
     if (primitive in collective_rules and
-          _main_trace_for_axis_names(self.main, core.used_axis_names(primitive, params))):
+        _main_trace_for_axis_names(self.main, core.used_axis_names(primitive, params))):
       frame = core.axis_frame(self.axis_name)
       val_out, dim_out = collective_rules[primitive](frame, vals_in, dims_in, **params)
     else:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -414,6 +414,7 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
     platform = xb.get_backend(backend).platform  # canonicalize
   else:
     platform = backend
+  assert platform in ('cpu', 'gpu', 'tpu')
 
   def read(v):
     if type(v) is Literal:

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -24,6 +24,7 @@ import jax.numpy as jnp
 from jax.interpreters import batching
 from jax import test_util as jtu
 from jax import lax
+from jax._src.lax import parallel
 from jax import random
 from jax.api import jit, grad, jvp, vjp, make_jaxpr, jacfwd, jacrev, hessian
 from jax.api import vmap
@@ -1221,6 +1222,29 @@ class BatchingTest(jtu.JaxTestCase):
     a, b = vmap(f, axis_name='i', in_axes=1, out_axes=None)(x)
     self.assertAllClose(a, jnp.ones(shape=(5, 3), dtype=x.dtype))
     self.assertAllClose(b, jnp.ones(shape=(5,), dtype=b.dtype))
+
+  @parameterized.named_parameters(
+      {"testcase_name": "_shape={}_axis={}_collective={}".format(
+          jtu.format_shape_dtype_string(shape, dtype),
+          axis, collective.__name__.replace(" ", "")),
+       "shape": shape, "dtype": dtype, "axis": axis,
+       "collective": collective, "bulk_op": bulk_op}
+      for collective, bulk_op in [
+          (parallel.pargmax, jnp.argmax),
+          (parallel.pargmin, jnp.argmin)]
+      for dtype in [np.float32, np.int32]
+      for shape in [(7,), (5, 8), (3, 4, 5)]
+      for axis in range(len(shape))
+  )
+  @skipIf(not jax.config.omnistaging_enabled,
+          "vmap collectives only supported when omnistaging is enabled")
+  def testArgAllReduce(self, shape, dtype, axis, collective, bulk_op):
+    rng = jtu.rand_default(self.rng())
+    x = rng(shape, dtype)
+    ans = vmap(lambda x: collective(x, 'i'), in_axes=axis, out_axes=None,
+               axis_name='i')(x)
+    expected = bulk_op(x, axis=axis)
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -33,6 +33,7 @@ import jax.numpy as jnp
 from jax import test_util as jtu
 from jax import tree_util
 from jax import lax
+from jax._src.lax import parallel
 from jax import random
 from jax.core import ShapedArray
 from jax import (pmap, soft_pmap, jit, vmap, jvp, grad, make_jaxpr,
@@ -1652,6 +1653,34 @@ class PmapTest(jtu.JaxTestCase):
     y = jnp.arange(num_devices * 5).reshape(num_devices, 5)
     z = pmap(f, axis_name='i', out_axes=None)(x, y)
     self.assertAllClose(z, jnp.dot(x.T, y))
+
+  @parameterized.named_parameters(
+      {"testcase_name": "_shape={}_axis={}_collective={}".format(
+          jtu.format_shape_dtype_string(shape, dtype),
+          axis, collective.__name__.replace(" ", "")),
+       "shape": shape, "dtype": dtype, "axis": axis,
+       "collective": collective, "bulk_op": bulk_op}
+      for collective, bulk_op in [
+          (parallel.pargmax, jnp.argmax),
+          (parallel.pargmin, jnp.argmin)
+      ]
+      for dtype in [np.float32, np.int32]
+      for shape in [(4,), (2, 2), (2, 4), (4, 2)]
+      for axis in range(len(shape))
+  )
+  def testArgAllReduce(self, shape, dtype, axis, collective, bulk_op):
+    if xla_bridge.device_count() < shape[axis]:
+      raise SkipTest(f"test requires at least {shape[axis]} devices")
+    if (jtu.device_under_test() == 'cpu' and
+        np.issubdtype(dtype, np.floating) and
+        len(shape) > 1):
+      raise SkipTest("skipped on cpu due to strange failures")  # TODO(mattjj)
+    rng = jtu.rand_default(self.rng())
+    x = rng(shape, dtype)
+    ans = pmap(lambda x: collective(x, 'i'), in_axes=axis, out_axes=None,
+               axis_name='i')(x)
+    expected = bulk_op(x, axis=axis)
+    self.assertAllClose(ans, expected, check_dtypes=False)
 
 
 class VmapOfPmapTest(jtu.JaxTestCase):


### PR DESCRIPTION
Follow up from #5682, which added these functions without defining new primitives.

By defining new primitives, we make `vmap`-of-`pargmin` more efficient, avoiding the "vectorized efficiency problem", which is the same reason why we're defining `psum`, `pdot`, etc. as primitives that support both named and positional axis arguments.

Because these primitives support both named and positional arguments, they can replace `argmin_p` and `argmax_p`, though that's left as follow-up work.

---

There's some weird failure with 2D float32 pmap test cases on CPU. It seems to be CPU-specific because the failures don't happen on TPU. The same issue does not arise on CPU in the int32 test cases with the same shape. (The failures are **not** due to the changes in `_axis_index_bind` or `_axis_index_translation_rule`; I made those changes to simplify the XLA HLO computation I was looking at while trying to debug this issue.)

An example of this failure is `PmapTest.testArgAllReduce_shape=float32[4,2]_axis=1_collective=pargmax`. The expected output is `[0, 1, 1, 0]` but the actual output is `[         0, 2147483647, 2147483647,          0]`. The HLO looks correct though:

```
HloModule pmap__lambda_.26

primitive_computation_max.9 {
  parameter.10 = f32[] parameter(0)
  parameter.11 = f32[] parameter(1)
  ROOT maximum.12 = f32[] maximum(parameter.10, parameter.11)
}

primitive_computation_min.18 {
  parameter.19 = s32[] parameter(0)
  parameter.20 = s32[] parameter(1)
  ROOT minimum.21 = s32[] minimum(parameter.19, parameter.20)
}

ENTRY pmap__lambda_.26 {
  constant.2 = pred[] constant(false)
  constant.3 = pred[] constant(false)
  parameter.1 = f32[4]{0} parameter(0), parameter_replication={false}
  all-reduce.13 = f32[4]{0} all-reduce(parameter.1), replica_groups={{0,1}}, to_apply=primitive_computation_max.9
  tuple.14 = (f32[4]{0}) tuple(all-reduce.13)
  get-tuple-element.15 = f32[4]{0} get-tuple-element(tuple.14), index=0
  compare.16 = pred[4]{0} compare(get-tuple-element.15, parameter.1), direction=EQ
  replica-id.4 = u32[] replica-id()
  convert.5 = s32[] convert(replica-id.4)
  broadcast.6 = s32[4]{0} broadcast(convert.5), dimensions={}
  constant.7 = s32[] constant(2147483647)
  broadcast.8 = s32[4]{0} broadcast(constant.7), dimensions={}
  select.17 = s32[4]{0} select(compare.16, broadcast.6, broadcast.8)
  all-reduce.22 = s32[4]{0} all-reduce(select.17), replica_groups={{0,1}}, to_apply=primitive_computation_min.18
  tuple.23 = (s32[4]{0}) tuple(all-reduce.22)
  get-tuple-element.24 = s32[4]{0} get-tuple-element(tuple.23), index=0
  ROOT tuple.25 = (s32[4]{0}) tuple(get-tuple-element.24)
}
```

I think I may just file an XLA:CPU bug about this...