### PR TITLE
[avals with names] abstract evaluation with named shapes, including rules for standard primitives and a few custom primitives

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1998,10 +1998,9 @@ def _argnum_weak_type(*argnums):
 def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None,
                        weak_type_rule=None, named_shape_rule=None):
   weak_type_rule = weak_type_rule or _standard_weak_type_rule
+  named_shape_rule = named_shape_rule or standard_named_shape_rule
   prim = Primitive(name)
   prim.def_impl(partial(xla.apply_primitive, prim))
-  named_shape_rule = named_shape_rule or partial(
-      fallback_named_shape_rule, prim)
   prim.def_abstract_eval(
       partial(standard_abstract_eval, prim, shape_rule, dtype_rule,
               weak_type_rule, named_shape_rule))
@@ -2028,7 +2027,8 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
     raise TypeError(avals, least_specialized)
 
 def standard_multi_result_abstract_eval(
-    prim, shape_rule, dtype_rule, weak_type_rule, *avals, **kwargs):
+    prim, shape_rule, dtype_rule, weak_type_rule,
+    named_shape_rule, *avals, **kwargs):
   assert prim.multiple_results
   assert all(isinstance(aval, UnshapedArray) for aval in avals), avals
   least_specialized = _max(map(type, avals),
@@ -2041,8 +2041,10 @@ def standard_multi_result_abstract_eval(
   elif least_specialized is ShapedArray:
     out_shapes = shape_rule(*avals, **kwargs)
     out_dtypes = dtype_rule(*avals, **kwargs)
-    return [ShapedArray(s, d, weak_type=weak_type)
-            for s, d, weak_type in safe_zip(out_shapes, out_dtypes, weak_types)]
+    out_named_shapes = named_shape_rule(*avals, **kwargs)
+    return [ShapedArray(s, d, weak_type=weak_type, named_shape=named_shape)
+            for s, d, weak_type, named_shape
+            in safe_zip(out_shapes, out_dtypes, weak_types, out_named_shapes)]
   elif least_specialized is UnshapedArray:
     out_dtypes = dtype_rule(*avals, **kwargs)
     return [UnshapedArray(dtype, weak_type=weak_type)
@@ -2050,57 +2052,12 @@ def standard_multi_result_abstract_eval(
   else:
     raise TypeError(avals, least_specialized)
 
-
 def standard_translate(name, c, *args, **kwargs):
   xla_opname = ''.join(term.capitalize() for term in name.split('_'))
   return getattr(xops, xla_opname)(*args, **kwargs)
 
-
-@lu.transformation_with_aux
-def get_dims_out(dims_in, *args, **kwargs):
-  vals_out, dims_out = yield (args, dims_in), kwargs
-  yield vals_out, dims_out
-
-def fallback_named_shape_rule(prim, *avals, **params):
-  all_named_shape_tuples = set(
-      item for aval in avals for item in aval.named_shape.items())
-  out_named_shape = None
-  # note: this relies on independence of batching over different axes
-  # (= commutativity of batching rules). That isn't true for at least
-  # `while_loop`.
-  for name, size in all_named_shape_tuples:
-    vmap_avals = [aval.update(shape=(size, *aval.shape),
-                              weak_type=False).strip_named_shape()
-                  if name in aval.named_shape else aval for aval in avals]
-    vmap_dims = [0 if name in aval.named_shape else batching.not_mapped
-                 for aval in avals]
-    if prim in batching.collective_rules:
-      raise NotImplementedError(
-          f"collective {prim} should have a custom abstract_eval rule")
-    elif prim in batching.initial_style_batchers:
-      rule = partial(batching.initial_style_batchers[prim], axis_name=name)
-    elif prim in batching.primitive_batchers:
-      rule = batching.primitive_batchers[prim]
-    else:
-      raise NotImplementedError(f"primitive {prim} cannot be used with named "
-                                f"axes because it has no batching rule")
-    f = lu.wrap_init(rule, params)
-    f, vmap_dims_out = get_dims_out(f, vmap_dims)
-    _, in_tree = tree_util.tree_flatten(vmap_avals)
-    f, _ = api_util.flatten_fun_nokwargs(f, in_tree)
-    if config.omnistaging_enabled:
-      pe.trace_to_jaxpr_dynamic(f, vmap_avals)
-    else:
-      vmap_pvals = [pe.PartialVal.unknown(aval) for aval in vmap_avals]
-      pe.trace_to_jaxpr(f, vmap_pvals)
-    dims_out = vmap_dims_out()
-    if not prim.multiple_results: dims_out = [dims_out]
-    mapped_out = [d is not batching.not_mapped for d in dims_out]
-    if out_named_shape is None:
-      out_named_shape = [{} for m in mapped_out]
-    out_named_shape = [{name: size, **ns} if m else ns
-                       for ns, m in safe_zip(out_named_shape, mapped_out)]
-  return out_named_shape
+def standard_named_shape_rule(*avals, **kwargs):
+  return core.join_named_shapes(*(a.named_shape for a in avals))
 
 
 def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
@@ -5031,15 +4988,19 @@ def _reduce_translation_rule(c, *values, computation, jaxpr,
 
 def _reduce_batch_rule(batched_args, batch_dims, *, computation, jaxpr,
                        consts, dimensions):
+  # TODO(mattjj,frostig): use batch_jaxpr, delete computation (assumes poly??)
   num_operands = len(batched_args) // 2
   operands, init_values = split_list(batched_args, [num_operands])
   operand_bdims, init_value_bdims = split_list(batch_dims, [num_operands])
-  if all(init_value_bdim is None for init_value_bdim in init_value_bdims):
+  if all(init_value_bdim is batching.not_mapped
+         for init_value_bdim in init_value_bdims):
     # Assume all batch dims are the same for each of the operands
-    assert all(operand_bdim is not None for operand_bdim in operand_bdims)
-    assert all(operand_bdim == operand_bdims[0] for operand_bdim in operand_bdims)
     # TODO(sharadmv): handle the case when batch dims are different across
     # operands or when some are unbatched
+    if not all(operand_bdim is not batching.not_mapped for operand_bdim in operand_bdims):
+      raise NotImplementedError
+    if not all(operand_bdim == operand_bdims[0] for operand_bdim in operand_bdims):
+      raise NotImplementedError
     operand_bdim = operand_bdims[0]
     new_dimensions = [d + bool(d >= operand_bdim) for d in dimensions]
     new_operand_bdim = operand_bdim - int(np.sum(np.less(dimensions, operand_bdim)))
@@ -5080,12 +5041,26 @@ def _reducer_masking_rule(prim, identity, padded_vals, logical_shapes,
   bind = prim_bind if input_shape is None else partial(prim_bind, input_shape=padded_shape)
   return bind(masked_val, axes=axes)
 
+def _reduce_named_shape_rule(*avals, computation, jaxpr, consts, dimensions):
+  # TODO(mattjj,frostig): see the TODOs noting limitations/assumptions in
+  # _reduce_batching_rule. We're making the same assumptions here for now.
+  num_operands = len(avals) // 2
+  operand_avals, init_avals = split_list(avals, [num_operands])
+  if any(a.named_shape for a in init_avals):
+    raise NotImplementedError
+  named_shapes = [a.named_shape for a in operand_avals]
+  if not all(named_shapes[0] == named_shape for named_shape in named_shapes):
+    raise NotImplementedError
+  return named_shapes
+
+
 reduce_p = core.Primitive('reduce')
 reduce_p.multiple_results = True
 reduce_p.def_impl(partial(xla.apply_primitive, reduce_p))
 reduce_p.def_abstract_eval(
     partial(standard_multi_result_abstract_eval, reduce_p, _reduce_shape_rule,
-            _reduce_dtype_rule, _reduce_weak_type_rule))
+            _reduce_dtype_rule, _reduce_weak_type_rule,
+            _reduce_named_shape_rule))
 xla.translations[reduce_p] = _reduce_translation_rule
 batching.primitive_batchers[reduce_p] = _reduce_batch_rule
 

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -602,6 +602,7 @@ def _allreduce_impl(pos_reducer, *args, axes, axis_index_groups):
   return [pos_reducer(arg, axes) for arg in args]
 
 def _allreduce_abstract_eval(*args, axes, axis_index_groups):
+  # TODO(frostig,mattjj,jekbradbury): maybe check aval names here
   pos_axes = tuple(axis for axis in axes if isinstance(axis, int))
   named_shapes = [arg.named_shape for arg in args]
   if axis_index_groups is None:
@@ -1142,6 +1143,7 @@ def _pdot_impl(x, y, *, axis_name, pos_contract, pos_batch):
 
 @pdot_p.def_abstract_eval
 def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch):
+  # TODO(frostig,mattjj,jekbradbury): check inputs have given axis names?
   if not len(set(axis_name)) == len(axis_name): raise ValueError
   pos_aval = lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -603,9 +603,16 @@ def _allreduce_impl(pos_reducer, *args, axes, axis_index_groups):
 
 def _allreduce_abstract_eval(*args, axes, axis_index_groups):
   pos_axes = tuple(axis for axis in axes if isinstance(axis, int))
+  named_shapes = [arg.named_shape for arg in args]
+  if axis_index_groups is None:
+    named_axes = set(axis for axis in axes if not isinstance(axis, int))
+    named_shapes = [{name: size for name, size in arg.named_shape.items()
+                     if name not in named_axes} for arg in args]
+  else:
+    assert len(pos_axes) == 0
   return [ShapedArray(lax._reduce_op_shape_rule(raise_to_shaped(arg), axes=pos_axes),
-                      arg.dtype)
-          for arg in args]
+                      arg.dtype, named_shape=named_shape)
+          for arg, named_shape in zip(args, named_shapes)]
 
 def _allreduce_translation_rule(prim, pos_prim, c, *args, axes, axis_index_groups,
                                 axis_env, platform):
@@ -1031,7 +1038,9 @@ def _all_gather_abstract_eval(x, *, all_gather_dimension, axis_name, axis_index_
   x_aval = raise_to_shaped(x)
   new_shape = list(x_aval.shape)
   new_shape.insert(all_gather_dimension, axis_size)
-  return x_aval.update(shape=new_shape)
+  new_named_shape = {name: size for name, size in x_aval.named_shape.items()
+                     if name != axis_name}
+  return x_aval.update(shape=new_shape, named_shape=new_named_shape)
 
 def _all_gather_transpose_rule(cts, x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size):
   # TODO(cjfj): Add reduce-scatter op to XLA?
@@ -1086,10 +1095,13 @@ def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
   unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
   return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
 
+def _axis_index_abstract_eval(*, axis_name):
+  frame = core.axis_frame(axis_name)
+  return ShapedArray((), np.int32, named_shape={axis_name: frame.size})
+
 axis_index_p = core.Primitive('axis_index')
 xla.parallel_translations[axis_index_p] = _axis_index_translation_rule
-axis_index_p.def_abstract_eval(
-    lambda *args, **params: ShapedArray((), np.int32))
+axis_index_p.def_abstract_eval(_axis_index_abstract_eval)
 pxla.multi_host_supported_collectives.add(axis_index_p)
 core.axis_substitution_rules[axis_index_p] = partial(_subst_all_names_in_param, 'axis_name')
 
@@ -1130,11 +1142,14 @@ def _pdot_impl(x, y, *, axis_name, pos_contract, pos_batch):
 
 @pdot_p.def_abstract_eval
 def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch):
-  # TODO: avals with names, check inputs are mapped along axis_name, eliminate
   if not len(set(axis_name)) == len(axis_name): raise ValueError
-  return lax.dot_general_p.abstract_eval(
+  pos_aval = lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],
       precision=None, preferred_element_type=None)
+  named_shape = {name: size
+                 for aval in (x, y) for name, size in aval.named_shape.items()
+                 if name not in axis_name}
+  return pos_aval.update(named_shape=named_shape)
 
 def _pdot_vmap_collective_rule(frame, vals_in, dims_in, *, axis_name,
                                pos_contract, pos_batch):
@@ -1286,7 +1301,8 @@ def omnistaging_disabler() -> None:
     nreps = dynamic_axis_env.nreps
     trace = frame.pmap_trace
 
-    out_aval = ShapedArray((), np.int32)
+    out_aval = _axis_index_abstract_eval(
+        nreps=nreps, sizes=sizes, axis_name=axis_name)
     out_tracer = pe.JaxprTracer(trace, pe.PartialVal.unknown(out_aval), None)
     eqn = pe.new_eqn_recipe([], [out_tracer], axis_index_p,
                             dict(nreps=nreps, sizes=sizes, axis_name=axis_name),
@@ -1301,7 +1317,9 @@ def omnistaging_disabler() -> None:
     unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
     return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
 
+  def _axis_index_abstract_eval(*, nreps, sizes, axis_name):
+    return ShapedArray((), np.int32, named_shape={axis_name: sizes[-1]})
+
   axis_index_p.def_custom_bind(_axis_index_bind)
-  axis_index_p.def_abstract_eval(
-      lambda *args, **params: ShapedArray((), np.int32))
+  axis_index_p.def_abstract_eval(_axis_index_abstract_eval)
   xla.translations[axis_index_p] = _axis_index_translation_rule

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1110,8 +1110,9 @@ class DynamicJaxprTrace(core.Trace):
     constvars = map(self.getvar, map(self.instantiate_const, consts))
     outvars = map(self.makevar, out_tracers)
     new_in_axes = (None,) * len(consts) + params['in_axes']
-    new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
-                      call_jaxpr=convert_constvars_jaxpr(jaxpr))
+    with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
+      new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
+                        call_jaxpr=convert_constvars_jaxpr(jaxpr))
     del new_params['out_axes_thunk']
     update_params = call_param_updaters.get(map_primitive)
     if update_params:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1110,6 +1110,9 @@ class DynamicJaxprTrace(core.Trace):
     constvars = map(self.getvar, map(self.instantiate_const, consts))
     outvars = map(self.makevar, out_tracers)
     new_in_axes = (None,) * len(consts) + params['in_axes']
+    # extending the axis env here is necessary for type checking that may happen
+    # in convert_constvars_jaxpr
+    # TODO(mattjj): remove the need for extend_axis_env here
     with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
                         call_jaxpr=convert_constvars_jaxpr(jaxpr))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1233,6 +1233,24 @@ class APITest(jtu.JaxTestCase):
     out_shape = api.eval_shape(lambda x: x, x)  # doesn't crash
     self.assertEqual(out_shape.shape, (3,))
 
+  def test_eval_shape_names(self):
+    def fun(x, y):
+      return lax.psum(x, 'i') + y
+
+    class MyArgArray(object):
+      def __init__(self, shape, dtype, named_shape):
+        self.shape = shape
+        self.dtype = dtype
+        self.named_shape = named_shape
+
+    x = MyArgArray((3, 2), jnp.float32, {'i': 10})
+    y = MyArgArray((3, 2), jnp.float32, {'j': 5})
+    with core.extend_axis_env('i', 10, None):
+      with core.extend_axis_env('j', 5, None):
+        out_shape = api.eval_shape(fun, x, y)
+
+    self.assertEqual(out_shape.named_shape, {'j': 5})
+
   def test_issue_871(self):
     T = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
     x = jnp.array([1, 2, 3])
@@ -2822,6 +2840,27 @@ class JaxprTest(jtu.JaxTestCase):
       return x - lax.psum(x, 'i')
     jaxpr = api.make_jaxpr(f, axis_env=[('i', 4)])(2)
     self.assertIn('psum', str(jaxpr))
+
+  def test_make_jaxpr_named(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    def f(x):
+      return x - lax.psum(x, 'i')
+
+    class FakeNamedArray:
+      def __init__(self, shape, dtype, named_shape):
+        self.shape = shape
+        self.dtype = dtype
+        self.named_shape = named_shape
+
+    core.pytype_aval_mappings[FakeNamedArray] = lambda x: core.ShapedArray(
+        x.shape, x.dtype, named_shape=x.named_shape)
+
+    x = FakeNamedArray((2, 3), jnp.float32, {'i': 10})
+    jaxpr = api.make_jaxpr(f, axis_env=[('i', 10)])(x)
+    named_shapes = [v.aval.named_shape for v in jaxpr.jaxpr.eqns[1].invars]
+    self.assertEqual(named_shapes, [{'i': 10}, {}])
 
 
 class LazyTest(jtu.JaxTestCase):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2848,16 +2848,8 @@ class JaxprTest(jtu.JaxTestCase):
     def f(x):
       return x - lax.psum(x, 'i')
 
-    class FakeNamedArray:
-      def __init__(self, shape, dtype, named_shape):
-        self.shape = shape
-        self.dtype = dtype
-        self.named_shape = named_shape
-
-    core.pytype_aval_mappings[FakeNamedArray] = lambda x: core.ShapedArray(
-        x.shape, x.dtype, named_shape=x.named_shape)
-
-    x = FakeNamedArray((2, 3), jnp.float32, {'i': 10})
+    x = types.SimpleNamespace(
+        shape=(2, 3), dtype=jnp.float32, named_shape={'i': 10})
     jaxpr = api.make_jaxpr(f, axis_env=[('i', 10)])(x)
     named_shapes = [v.aval.named_shape for v in jaxpr.jaxpr.eqns[1].invars]
     self.assertEqual(named_shapes, [{'i': 10}, {}])

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2453,5 +2453,28 @@ class LazyConstantTest(jtu.JaxTestCase):
     out = lax.cumsum(x)
     self.assertArraysEqual(out, x)
 
+
+class LaxNamedShapeTest(jtu.JaxTestCase):
+
+  def test_abstract_eval(self):
+    aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
+    out = lax.sin_p.abstract_eval(aval1)
+    self.assertEqual(out, aval1)
+
+    aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
+    aval2 = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
+    expected = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
+    out = lax.add_p.abstract_eval(aval1, aval2)
+    self.assertEqual(out, expected)
+
+  def test_abstract_eval_collective(self):
+    if not config.omnistaging_enabled:
+      raise SkipTest("test requires omnistaging")
+    with core.extend_axis_env('i', 10, None):
+      aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
+      expected = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
+      out, = lax.psum_p.abstract_eval(aval1, axes=('i',), axis_index_groups=None)
+      self.assertEqual(out, expected)
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This is just one commit past #5626

cc @froystig @jekbradbury 