### PR TITLE
Cleanup unnecessary metadata from documentation notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ print(normalize(jnp.arange(4.)))
 # prints [0.         0.16666667 0.33333334 0.5       ]
 ```
 
-You can even [nest `pmap` functions](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb#scrollTo=MdRscR5MONuN) for more
+You can even [nest `pmap` functions](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb#scrollTo=MdRscR5MONuN) for more
 sophisticated communication patterns.
 
 It all composes, so you're free to differentiate through parallel computations:
@@ -345,7 +345,7 @@ When reverse-mode differentiating a `pmap` function (e.g. with `grad`), the
 backward pass of the computation is parallelized just like the forward pass.
 
 See the [SPMD
-Cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)
+Cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)
 and the [SPMD MNIST classifier from scratch
 example](https://github.com/google/jax/blob/master/examples/spmd_mnist_classifier_fromscratch.py)
 for more.

--- a/cloud_tpu_colabs/JAX_NeurIPS_2020_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_NeurIPS_2020_demo.ipynb
@@ -451,7 +451,7 @@
     "id": "jC-KIMQ1q-lK"
    },
    "source": [
-    "For more, see the [`pmap` cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
+    "For more, see the [`pmap` cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
    ]
   },
   {

--- a/cloud_tpu_colabs/JAX_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_demo.ipynb
@@ -871,7 +871,7 @@
     "id": "jC-KIMQ1q-lK"
    },
    "source": [
-    "For more, see the [`pmap` cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
+    "For more, see the [`pmap` cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -2,21 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "hjM_sV_AepYf"
-   },
+   "metadata": {},
    "source": [
-    "# 🔪 JAX - The Sharp Bits 🔪"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "4k5PVzEo2uJO"
-   },
-   "source": [
+    "# 🔪 JAX - The Sharp Bits 🔪\n",
+    "\n",
     "*levskaya@ mattjj@*\n",
     "\n",
     "When walking about the countryside of [Italy](https://iaml.it/blog/jax-intro), the people will not hesitate to tell you that __JAX__ has _\"una anima di pura programmazione funzionale\"_.\n",
@@ -28,11 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "GoK_PCxPeYcy"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -51,21 +36,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gX8CZU1g2agP"
-   },
+   "metadata": {},
    "source": [
-    "## 🔪 Pure functions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2oHigBkW2dPT"
-   },
-   "source": [
+    "## 🔪 Pure functions\n",
+    "\n",
     "JAX transformation and compilation are designed to work only on Python functions that are functionally pure: all the input data is passed through the function parameters, all the results are output through the function results. A pure function will always return the same result if invoked with the same inputs. \n",
     "\n",
     "Here are some examples of functions that are not functially pure for which JAX behaves differently than the Python interpreter. Note that these behaviors are not guaranteed by the JAX system; the proper way to use JAX is to use it only on functionally pure Python functions."
@@ -74,15 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 121,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "A6R-pdcm4u3v",
-    "outputId": "389605df-a4d5-4d4b-8d74-64e9d5d39456"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -115,15 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 122,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "-N8GhitI2bhD",
-    "outputId": "f16ce914-1387-43b4-9b8a-1d6e3b97b11d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -155,15 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 123,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "RTB6iFgu4DL6",
-    "outputId": "e93d2a70-1c18-477a-d69d-d09ed556305a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -188,10 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Mlc2pQlp6v-9"
-   },
+   "metadata": {},
    "source": [
     "A Python function can be functionally pure even if it actually uses stateful objects internally, as long as it does not read or write external state:"
    ]
@@ -199,15 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "TP-Mqf_862C0",
-    "outputId": "78df2d95-2c6f-41c9-84a9-feda6329e75e"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def pure_uses_internal_state(x):\n",
@@ -278,36 +217,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oBdKtkVW8Lha"
-   },
+   "metadata": {},
    "source": [
-    "## 🔪 In-Place Updates"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JffAqnEW4JEb"
-   },
-   "source": [
+    "## 🔪 In-Place Updates\n",
+    "\n",
     "In Numpy you're used to doing this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 125,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 153
-    },
-    "colab_type": "code",
-    "id": "om4xV7_84N9j",
-    "outputId": "733f901e-d433-4dc8-b5bb-0c23bf2b1306"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -337,10 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "go3L4x3w4-9p"
-   },
+   "metadata": {},
    "source": [
     "If we try to update a JAX device array in-place, however, we get an __error__!  (☉_☉)"
    ]
@@ -348,18 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": 126,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 54
-    },
-    "colab_type": "code",
-    "id": "2AxeCufq4wAp",
-    "outputId": "d5d873db-cee0-49dc-981d-ec852347f7ca",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -381,10 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7mo76sS25Wco"
-   },
+   "metadata": {},
    "source": [
     "__What gives?!__  \n",
     "\n",
@@ -398,11 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "m5lg1RYq5D9p"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.ops import index, index_add, index_update"
@@ -410,36 +309,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "X2Xjjvd-l8NL"
-   },
+   "metadata": {},
    "source": [
-    "### index_update"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "eM6MyndXL2NY"
-   },
-   "source": [
+    "### index_update\n",
+    "\n",
     "If the __input values__ of __index_update__ aren't reused, __jit__-compiled code will perform these operations _in-place_."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 128,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 221
-    },
-    "colab_type": "code",
-    "id": "ygUJT49b7BBk",
-    "outputId": "1a3511c4-a480-472f-cccb-5e01620cbe99"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -476,36 +356,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7to-sF8EmC_y"
-   },
+   "metadata": {},
    "source": [
-    "### index_add"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "iI5cLY1xMBLs"
-   },
-   "source": [
+    "### index_add\n",
+    "\n",
     "If the __input values__ of __index_update__ aren't reused, __jit__-compiled code will perform these operations _in-place_."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 129,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 221
-    },
-    "colab_type": "code",
-    "id": "tsw2svao8FUp",
-    "outputId": "874acd15-a493-4d63-efe4-9f440d5d2a12"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -538,39 +399,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oZ_jE2WAypdL"
-   },
+   "metadata": {},
    "source": [
-    "## 🔪 Out-of-Bounds Indexing"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "btRFwEVzypdN"
-   },
-   "source": [
+    "## 🔪 Out-of-Bounds Indexing\n",
+    "\n",
     "In Numpy, you are used to errors being thrown when you index an array outside of its bounds, like this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 130,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "5_ZM-BJUypdO",
-    "outputId": "461f38cd-9452-4bcc-a44f-a07ddfa12f42",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -589,10 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "eoXrGARWypdR"
-   },
+   "metadata": {},
    "source": [
     "However, raising an error on other accelerators can be more difficult. Therefore, JAX does not raise an error, instead the index is clamped to the bounds of the array, meaning that for this example the last value of the array will be returned."
    ]
@@ -600,15 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": 131,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "cusaAD0NypdR",
-    "outputId": "48428ad6-6cde-43ad-c12d-2eb9b9fe59cf"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -631,38 +459,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that due to this behavior jnp.nanargmin and jnp.nanargmax return -1 for slices consisting of NaNs whereas Numpy would throw an error."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MUycRNh6e50W"
-   },
-   "source": [
-    "## 🔪 Random Numbers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "O8vvaVt3MRG2"
-   },
-   "source": [
+    "Note that due to this behavior jnp.nanargmin and jnp.nanargmax return -1 for slices consisting of NaNs whereas Numpy would throw an error.\n",
+    "\n",
+    "## 🔪 Random Numbers\n",
+    "\n",
     "> _If all scientific papers whose results are in doubt because of bad \n",
     "> `rand()`s were to disappear from library shelves, there would be a \n",
-    "> gap on each shelf about as big as your fist._ - Numerical Recipes"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Qikt9pPW9L5K"
-   },
-   "source": [
+    "> gap on each shelf about as big as your fist._ - Numerical Recipes\n",
+    "\n",
     "### RNGs and State\n",
     "You're used to _stateful_ pseudorandom number generators (PRNGs) from numpy and other libraries, which helpfully hide a lot of details under the hood to give you a ready fountain of pseudorandomness:"
    ]
@@ -670,15 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": 132,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "rr9FeP41fynt",
-    "outputId": "849d84cf-04ad-4e8b-9505-a92f6c0d7a39"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -698,10 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ORMVVGZJgSVi"
-   },
+   "metadata": {},
    "source": [
     "Underneath the hood, numpy uses the [Mersenne Twister](https://en.wikipedia.org/wiki/Mersenne_Twister) PRNG to power its pseudorandom functions.  The PRNG has a period of $2^{19937}-1$ and at any point can be described by __624 32bit unsigned ints__ and a __position__ indicating how much of this  \"entropy\" has been used up."
    ]
@@ -709,11 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7Pyp2ajzfPO2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(0)\n",
@@ -726,10 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "aJIxHVXCiM6m"
-   },
+   "metadata": {},
    "source": [
     "This pseudorandom state vector is automagically updated behind the scenes every time a random number is needed, \"consuming\" 2 of the uint32s in the Mersenne twister state vector:"
    ]
@@ -737,11 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "GAHaDCYafpAF"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "_ = np.random.uniform()\n",
@@ -768,33 +550,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "N_mWnleNogps"
-   },
+   "metadata": {},
    "source": [
     "The problem with magic PRNG state is that it's hard to reason about how it's being used and updated across different threads, processes, and devices, and it's _very easy_ to screw up when the details of entropy production and consumption are hidden from the end user.\n",
     "\n",
-    "The Mersenne Twister PRNG is also known to have a [number](https://cs.stackexchange.com/a/53475) of problems, it has a large 2.5Kb state size, which leads to problematic [initialization issues](https://dl.acm.org/citation.cfm?id=1276928).  It [fails](http://www.pcg-random.org/pdf/toms-oneill-pcg-family-v1.02.pdf) modern BigCrush tests, and is generally slow."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Uvq7nV-j4vKK"
-   },
-   "source": [
-    "### JAX PRNG"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "COjzGBpO4tzL"
-   },
-   "source": [
+    "The Mersenne Twister PRNG is also known to have a [number](https://cs.stackexchange.com/a/53475) of problems, it has a large 2.5Kb state size, which leads to problematic [initialization issues](https://dl.acm.org/citation.cfm?id=1276928).  It [fails](http://www.pcg-random.org/pdf/toms-oneill-pcg-family-v1.02.pdf) modern BigCrush tests, and is generally slow. \n",
+    "\n",
+    "### JAX PRNG\n",
+    "\n",
     "JAX instead implements an _explicit_ PRNG where entropy production and consumption are handled by explicitly passing and iterating PRNG state.  JAX uses a modern [Threefry counter-based PRNG](https://github.com/google/jax/blob/master/design_notes/prng.md) that's __splittable__.  That is, its design allows us to __fork__ the PRNG state into new PRNGs for use with parallel stochastic generation.\n",
     "\n",
     "The random state is described by two unsigned-int32s that we call a __key__:"
@@ -803,15 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": 135,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "yPHE7KTWgAWs",
-    "outputId": "329e7757-2461-434c-a08c-fde80a2d10c9"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -834,10 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "XjYyWYNfq0hW"
-   },
+   "metadata": {},
    "source": [
     "JAX's random functions produce pseudorandom numbers from the PRNG state, but __do not__ change the state!  \n",
     "\n",
@@ -847,15 +599,7 @@
   {
    "cell_type": "code",
    "execution_count": 136,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
-    },
-    "colab_type": "code",
-    "id": "7zUdQMynoE5e",
-    "outputId": "50617324-b887-42f2-a7ff-2a10f92d876a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -878,10 +622,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "hQN9van8rJgd"
-   },
+   "metadata": {},
    "source": [
     "Instead, we __split__ the PRNG to get usable __subkeys__ every time we need a new pseudorandom number:"
    ]
@@ -889,15 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": 137,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "ASj0_rSzqgGh",
-    "outputId": "bcc2ed60-2e41-4ef8-e84f-c724654aa198"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -919,10 +652,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "tqtFVE4MthO3"
-   },
+   "metadata": {},
    "source": [
     "We propagate the __key__ and make new __subkeys__ whenever we need a new random number:"
    ]
@@ -930,15 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": 138,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "jbC34XLor2Ek",
-    "outputId": "6834a812-7160-4646-ee19-a246f683905a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -960,10 +682,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0KLYUluz3lN3"
-   },
+   "metadata": {},
    "source": [
     "We can generate more than one __subkey__ at a time:"
    ]
@@ -971,15 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": 139,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "lEi08PJ4tfkX",
-    "outputId": "3bb513de-8d14-4d37-ae57-51d6f5eaa762"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -999,21 +710,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "rg4CpMZ8c3ri"
-   },
+   "metadata": {},
    "source": [
-    "## 🔪 Control Flow"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "izLTvT24dAq0"
-   },
-   "source": [
+    "## 🔪 Control Flow\n",
+    "\n",
     "### ✔ python control_flow + autodiff ✔\n",
     "\n",
     "If you just want to apply `grad` to your python functions, you can use regular python control-flow constructs with no problems, as if you were using [Autograd](https://github.com/hips/autograd) (or Pytorch or TF Eager)."
@@ -1022,15 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": 140,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "id": "aAx0T3F8lLtu",
-    "outputId": "808cfa77-d924-4586-af19-35a8fd7d2238"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1054,10 +746,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "hIfPT7WMmZ2H"
-   },
+   "metadata": {},
    "source": [
     "### python control flow + JIT\n",
     "\n",
@@ -1069,15 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": 141,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "OZ_BJX0CplNC",
-    "outputId": "48ce004c-536a-44f5-b020-9267825e7e4d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1099,10 +780,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "22RzeJ4QqAuX"
-   },
+   "metadata": {},
    "source": [
     "So does this:"
    ]
@@ -1110,15 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": 142,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "pinVnmRWp6w6",
-    "outputId": "e3e6f2f7-ba59-4a98-cdfc-905c91b38ed1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1141,10 +811,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TStltU2dqf8A"
-   },
+   "metadata": {},
    "source": [
     "But this doesn't, at least by default:"
    ]
@@ -1152,15 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": 143,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 54
-    },
-    "colab_type": "code",
-    "id": "9z38AIKclRNM",
-    "outputId": "466730dd-df8b-4b80-ac5e-e55b5ea85ec7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1187,10 +846,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "pIbr4TVPqtDN"
-   },
+   "metadata": {},
    "source": [
     "__What gives!?__\n",
     "\n",
@@ -1210,15 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": 144,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "-Tzp0H7Bt1Sn",
-    "outputId": "aba57a88-d8eb-40b0-ff22-7c266d892b13"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1242,10 +890,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MHm1hIQAvBVs"
-   },
+   "metadata": {},
    "source": [
     "Here's another example, this time involving a loop:"
    ]
@@ -1253,15 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": 145,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "iwY86_JKvD6b",
-    "outputId": "1ec847ea-df2b-438d-c0a1-fabf7b93b73d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1290,21 +927,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "nSPTOX8DvOeO"
-   },
+   "metadata": {},
    "source": [
-    "In effect, the loop gets statically unrolled.  JAX can also trace at _higher_ levels of abstraction, like `Unshaped`, but that's not currently the default for any transformation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "wWdg8LTYwCW3"
-   },
-   "source": [
+    "In effect, the loop gets statically unrolled.  JAX can also trace at _higher_ levels of abstraction, like `Unshaped`, but that's not currently the default for any transformation\n",
+    "\n",
     "️⚠️ **functions with argument-__value__ dependent shapes**\n",
     "\n",
     "These control-flow issues also come up in a more subtle way: numerical functions we want to __jit__ can't specialize the shapes of internal arrays on argument _values_ (specializing on argument __shapes__ is ok).  As a trivial example, let's make a function whose output happens to depend on the input variable `length`."
@@ -1313,15 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": 146,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 122
-    },
-    "colab_type": "code",
-    "id": "Tqe9uLmUI_Gv",
-    "outputId": "fe319758-9959-434c-ab9d-0926e599dbc0"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1357,10 +975,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MStx_r2oKxpp"
-   },
+   "metadata": {},
    "source": [
     "`static_argnums` can be handy if `length` in our example rarely changes, but it would be disastrous if it changed a lot!  \n",
     "\n",
@@ -1370,15 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": 147,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "m2ABpRd8K094",
-    "outputId": "64da37a0-aa06-46a3-e975-88c676c5b9fa"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1413,10 +1020,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "uCDcWG4MnVn-"
-   },
+   "metadata": {},
    "source": [
     "### Structured control flow primitives\n",
     "\n",
@@ -1425,16 +1029,9 @@
     " - `lax.cond`  _differentiable_\n",
     " - `lax.while_loop` __fwd-mode-differentiable__\n",
     " - `lax.fori_loop` __fwd-mode-differentiable__\n",
-    " - `lax.scan` _differentiable_"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Sd9xrLMXeK3A"
-   },
-   "source": [
+    " - `lax.scan` _differentiable_\n",
+    "\n",
+    "\n",
     "#### cond\n",
     "python equivalent:\n",
     "\n",
@@ -1450,15 +1047,7 @@
   {
    "cell_type": "code",
    "execution_count": 148,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "SGxz9JOWeiyH",
-    "outputId": "b29da06c-037f-4b05-dbd8-ba52ac35a8cf"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1485,10 +1074,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xkOFAw24eOMg"
-   },
+   "metadata": {},
    "source": [
     "#### while_loop\n",
     "\n",
@@ -1505,15 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": 149,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "jM-D39a-c436",
-    "outputId": "b9c97167-fecf-4559-9ca7-1cb0235d8ad2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1538,10 +1116,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "apo3n3HAeQY_"
-   },
+   "metadata": {},
    "source": [
     "#### fori_loop\n",
     "python equivalent:\n",
@@ -1557,15 +1132,7 @@
   {
    "cell_type": "code",
    "execution_count": 150,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "dt3tUpOmeR8u",
-    "outputId": "864f2959-2429-4666-b364-4baf90a57482"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1591,10 +1158,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "SipXS5qiqk8e"
-   },
+   "metadata": {},
    "source": [
     "#### Summary\n",
     "\n",
@@ -1615,26 +1179,10 @@
     "\\hline\n",
     "\\end{array}\n",
     "$$\n",
-    "<center>$\\ast$ = argument-__value__-independent loop condition - unrolls the loop </center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "bxuUjFVG-v1h"
-   },
-   "source": [
-    "## 🔪 Convolutions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0pcn2LeS-03b"
-   },
-   "source": [
+    "<center>$\\ast$ = argument-__value__-independent loop condition - unrolls the loop </center>\n",
+    "\n",
+    "## 🔪 Convolutions\n",
+    "\n",
     "JAX and XLA offer the very general N-dimensional __conv_general_dilated__ function, but it's not very obvious how to use it.  We'll give some examples of the common use-cases.\n",
     "\n",
     "For the most common kinds of convolutions, see also the convenience functions lax.conv and lax.conv_general_padding, as well as jax.numpy.convolve and jax.scipy.signal.convolve/jax.scipy.signal.convolve2d for an interface similar to that of the numpy and scipy packages.\n",
@@ -1647,15 +1195,7 @@
   {
    "cell_type": "code",
    "execution_count": 151,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 286
-    },
-    "colab_type": "code",
-    "id": "Yud1Y3ss-x1K",
-    "outputId": "5aacee92-2769-4f10-d9a6-475cded80981"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1690,10 +1230,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dITPaPdh_cMI"
-   },
+   "metadata": {},
    "source": [
     "And we'll make a simple synthetic image:"
    ]
@@ -1701,15 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": 152,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 286
-    },
-    "colab_type": "code",
-    "id": "cpbGsIGa_Qyx",
-    "outputId": "e27385e6-8fa2-498d-f952-7d8e04775856"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1745,21 +1274,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_m90y74OWorG"
-   },
+   "metadata": {},
    "source": [
-    "### lax.conv and lax.conv_with_general_padding"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Pv9_QPDnWssM"
-   },
-   "source": [
+    "### lax.conv and lax.conv_with_general_padding\n",
+    "\n",
     "These are the simple convenience functions for convolutions\n",
     "\n",
     "️⚠️ The convenience `lax.conv`, `lax.conv_with_general_padding` helper function assume __NCHW__ images and __OIHW__ kernels."
@@ -1768,15 +1286,7 @@
   {
    "cell_type": "code",
    "execution_count": 153,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 628
-    },
-    "colab_type": "code",
-    "id": "kppxbxpZW0nb",
-    "outputId": "0d72fdd9-19d7-45ae-891b-b19df819620f"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1813,15 +1323,7 @@
   {
    "cell_type": "code",
    "execution_count": 154,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 628
-    },
-    "colab_type": "code",
-    "id": "aonr1tWvYCW9",
-    "outputId": "1b61e1b7-331d-4b60-b524-73a0fbad3ed9"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1860,10 +1362,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "lyOwGRez_ycJ"
-   },
+   "metadata": {},
    "source": [
     "### Dimension Numbers define dimensional layout for conv_general_dilated\n",
     "\n",
@@ -1882,15 +1381,7 @@
   {
    "cell_type": "code",
    "execution_count": 155,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "oXKebfCb_i2B",
-    "outputId": "0243bbe8-ac5a-4923-8c6f-454a8d28f04b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1909,10 +1400,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "elZys_HzFVG6"
-   },
+   "metadata": {},
    "source": [
     "#### SAME padding, no stride, no dilation"
    ]
@@ -1920,15 +1408,7 @@
   {
    "cell_type": "code",
    "execution_count": 156,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 628
-    },
-    "colab_type": "code",
-    "id": "rgb2T15aFVG6",
-    "outputId": "2dae283f-21a6-4ca6-bf10-eaa247e579e7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1967,10 +1447,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "E4i3TI5JFVG9"
-   },
+   "metadata": {},
    "source": [
     "#### VALID padding, no stride, no dilation"
    ]
@@ -1978,15 +1455,7 @@
   {
    "cell_type": "code",
    "execution_count": 157,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 628
-    },
-    "colab_type": "code",
-    "id": "1HQwudKVFVG-",
-    "outputId": "a141ffd2-9c7c-4633-b752-7cd345632fdf"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2025,10 +1494,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "VYKZdqLIFVHB"
-   },
+   "metadata": {},
    "source": [
     "#### SAME padding, 2,2 stride, no dilation"
    ]
@@ -2036,15 +1502,7 @@
   {
    "cell_type": "code",
    "execution_count": 158,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 627
-    },
-    "colab_type": "code",
-    "id": "mKq2-zmmFVHC",
-    "outputId": "065e2f69-3f1d-4d19-864d-28ef59f1b0f8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2083,10 +1541,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gPxttaiaFVHE"
-   },
+   "metadata": {},
    "source": [
     "#### VALID padding, no stride, rhs kernel dilation ~ Atrous convolution (excessive to illustrate)"
    ]
@@ -2094,15 +1549,7 @@
   {
    "cell_type": "code",
    "execution_count": 159,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 628
-    },
-    "colab_type": "code",
-    "id": "_pGr0x6qFVHF",
-    "outputId": "5387205f-3c23-4203-ff1b-ae5115eed5f7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2141,10 +1588,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "v-RhEeUfFVHI"
-   },
+   "metadata": {},
    "source": [
     "#### VALID padding, no stride, lhs=input dilation  ~ Transposed Convolution"
    ]
@@ -2152,15 +1596,7 @@
   {
    "cell_type": "code",
    "execution_count": 160,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 629
-    },
-    "colab_type": "code",
-    "id": "B9Ail8ppFVHJ",
-    "outputId": "3617a5d2-1eaa-46e8-d691-87b365ed1310"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2199,10 +1635,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "A-9OagtrVDyV"
-   },
+   "metadata": {},
    "source": [
     "We can use the last to, for instance, implement _transposed convolutions_:"
    ]
@@ -2210,15 +1643,7 @@
   {
    "cell_type": "code",
    "execution_count": 161,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 629
-    },
-    "colab_type": "code",
-    "id": "5EYIj77-NdHE",
-    "outputId": "f325e6cb-3079-4250-898f-ca4fb081c6c7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2266,36 +1691,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "v8HsE-NCmUxx"
-   },
+   "metadata": {},
    "source": [
-    "### 1D Convolutions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WeP0rw0tm7HK"
-   },
-   "source": [
+    "### 1D Convolutions\n",
+    "\n",
     "You aren't limited to 2D convolutions, a simple 1D demo is below:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 162,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 674
-    },
-    "colab_type": "code",
-    "id": "jJ-jcAn3cig-",
-    "outputId": "64e578be-92c5-4aef-9d5d-ae93939f9b31"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2365,10 +1771,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7XOgXqCTmaPa"
-   },
+   "metadata": {},
    "source": [
     "### 3D Convolutions"
    ]
@@ -2376,15 +1779,7 @@
   {
    "cell_type": "code",
    "execution_count": 163,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 530
-    },
-    "colab_type": "code",
-    "id": "QNvSiq5-mcLd",
-    "outputId": "1c278db7-e2a0-4f53-d7d4-57472f2a794e"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2468,21 +1863,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "DKTMw6tRZyK2"
-   },
+   "metadata": {},
    "source": [
-    "## 🔪 NaNs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ncS0NI4jZrwy"
-   },
-   "source": [
+    "## 🔪 NaNs\n",
+    "\n",
     "### Debugging NaNs\n",
     "\n",
     "If you want to trace where NaNs are occurring in your functions or gradients, you can turn on the NaN-checker by:\n",
@@ -2620,16 +2004,8 @@
    "source": [
     "When this code sees a nan in the output of an `@jit` function, it calls into the de-optimized code, so we still get a clear stack trace. And we can run a post-mortem debugger with `%debug` to inspect all the values to figure out the error.\n",
     "\n",
-    "⚠️ You shouldn't have the NaN-checker on if you're not debugging, as it can introduce lots of device-host round-trips and performance regressions!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YTktlwTTMgFl"
-   },
-   "source": [
+    "⚠️ You shouldn't have the NaN-checker on if you're not debugging, as it can introduce lots of device-host round-trips and performance regressions!\n",
+    "\n",
     "## Double (64bit) precision\n",
     "\n",
     "At the moment, JAX by default enforces single-precision numbers to mitigate the Numpy API's tendency to aggressively promote operands to `double`.  This is the desired behavior for many machine-learning applications, but it may catch you by surprise!"
@@ -2638,15 +2014,7 @@
   {
    "cell_type": "code",
    "execution_count": 164,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "CNNGtzM3NDkO",
-    "outputId": "d1384021-d9bf-450f-a9ae-82024fa5fc1a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2668,10 +2036,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "VcvqzobxNPbd"
-   },
+   "metadata": {},
    "source": [
     "To use double-precision numbers, you need to set the `jax_enable_x64` configuration variable __at startup__.  \n",
     "\n",
@@ -2711,15 +2076,7 @@
   {
    "cell_type": "code",
    "execution_count": 165,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "HqGbBa9Rr-2g",
-    "outputId": "cd241d63-3d00-4fd7-f9c0-afc6af01ecf4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2743,22 +2100,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "6Cks2_gKsXaW"
-   },
+   "metadata": {},
    "source": [
     "### Caveats\n",
-    "⚠️ XLA doesn't support 64-bit convolutions on all backends!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WAHjmL0E2XwO"
-   },
-   "source": [
+    "⚠️ XLA doesn't support 64-bit convolutions on all backends!\n",
+    "\n",
     "## Fin.\n",
     "\n",
     "If something's not covered here that has caused you weeping and gnashing of teeth, please let us know and we'll extend these introductory _advisos_!"

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -12,11 +12,7 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "hjM_sV_AepYf"}
-
 # 🔪 JAX - The Sharp Bits 🔪
-
-+++ {"colab_type": "text", "id": "4k5PVzEo2uJO"}
 
 *levskaya@ mattjj@*
 
@@ -25,11 +21,7 @@ When walking about the countryside of [Italy](https://iaml.it/blog/jax-intro), t
 __JAX__ is a language for __expressing__ and __composing__ __transformations__ of numerical programs. __JAX__ is also able to __compile__ numerical programs for CPU or accelerators (GPU/TPU). 
 JAX works great for many numerical and scientific programs, but __only if they are written with certain constraints__ that we describe below.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: GoK_PCxPeYcy
-
+```{code-cell}
 import numpy as np
 from jax import grad, jit
 from jax import lax
@@ -44,29 +36,15 @@ rcParams['image.cmap'] = 'viridis'
 rcParams['axes.grid'] = False
 ```
 
-+++ {"colab_type": "text", "id": "cxwbr3XK2_mK"}
 
-
-
-+++ {"colab_type": "text", "id": "gX8CZU1g2agP"}
 
 ## 🔪 Pure functions
-
-+++ {"colab_type": "text", "id": "2oHigBkW2dPT"}
 
 JAX transformation and compilation are designed to work only on Python functions that are functionally pure: all the input data is passed through the function parameters, all the results are output through the function results. A pure function will always return the same result if invoked with the same inputs. 
 
 Here are some examples of functions that are not functially pure for which JAX behaves differently than the Python interpreter. Note that these behaviors are not guaranteed by the JAX system; the proper way to use JAX is to use it only on functionally pure Python functions.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 102
-colab_type: code
-id: A6R-pdcm4u3v
-outputId: 389605df-a4d5-4d4b-8d74-64e9d5d39456
----
+```{code-cell}
 def impure_print_side_effect(x):
   print("Executing function")  # This is a side-effect 
   return x
@@ -82,15 +60,7 @@ print ("Second call: ", jit(impure_print_side_effect)(5.))
 print ("Third call, different type: ", jit(impure_print_side_effect)(jnp.array([5.])))
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: -N8GhitI2bhD
-outputId: f16ce914-1387-43b4-9b8a-1d6e3b97b11d
----
+```{code-cell}
 g = 0.
 def impure_uses_globals(x):
   return x + g
@@ -107,15 +77,7 @@ print ("Second call: ", jit(impure_uses_globals)(5.))
 print ("Third call, different type: ", jit(impure_uses_globals)(jnp.array([4.])))
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 51
-colab_type: code
-id: RTB6iFgu4DL6
-outputId: e93d2a70-1c18-477a-d69d-d09ed556305a
----
+```{code-cell}
 g = 0.
 def impure_saves_global(x):
   global g
@@ -127,20 +89,9 @@ print ("First call: ", jit(impure_saves_global)(4.))
 print ("Saved global: ", g)  # Saved global has an internal JAX value
 ```
 
-+++ {"colab_type": "text", "id": "Mlc2pQlp6v-9"}
-
 A Python function can be functionally pure even if it actually uses stateful objects internally, as long as it does not read or write external state:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: TP-Mqf_862C0
-outputId: 78df2d95-2c6f-41c9-84a9-feda6329e75e
----
-
+```{code-cell}
 def pure_uses_internal_state(x):
   state = dict(even=0, odd=0)
   for i in range(10):
@@ -152,7 +103,7 @@ print(jit(pure_uses_internal_state)(5.))
 
 It is not recommended to use iterators in any JAX function you want to `jit` or in any control-flow primitive. The reason is that an iterator is a python object which introduces state to retrieve the next element. Therefore, it is incompatible with JAX functional programming model. In the code below, there are some examples of incorrect attempts to use iterators with JAX. Most of them return an error, but some give unexpected results.
 
-```{code-cell} ipython3
+```{code-cell}
 import jax.numpy as jnp
 import jax.lax as lax
 from jax import make_jaxpr
@@ -180,23 +131,11 @@ iter_operand = iter(range(10))
 # lax.cond(True, iter_operand, lambda x: next(x)+1, iter_operand, lambda x: next(x)-1) # throws error
 ```
 
-+++ {"colab_type": "text", "id": "oBdKtkVW8Lha"}
-
 ## 🔪 In-Place Updates
-
-+++ {"colab_type": "text", "id": "JffAqnEW4JEb"}
 
 In Numpy you're used to doing this:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 153
-colab_type: code
-id: om4xV7_84N9j
-outputId: 733f901e-d433-4dc8-b5bb-0c23bf2b1306
----
+```{code-cell}
 numpy_array = np.zeros((3,3), dtype=np.float32)
 print("original array:")
 print(numpy_array)
@@ -207,20 +146,9 @@ print("updated array:")
 print(numpy_array)
 ```
 
-+++ {"colab_type": "text", "id": "go3L4x3w4-9p"}
-
 If we try to update a JAX device array in-place, however, we get an __error__!  (☉_☉)
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 54
-colab_type: code
-id: 2AxeCufq4wAp
-outputId: d5d873db-cee0-49dc-981d-ec852347f7ca
-tags: [raises-exception]
----
+```{code-cell}
 jax_array = jnp.zeros((3,3), dtype=jnp.float32)
 
 # In place update of JAX's array will yield an error!
@@ -230,8 +158,6 @@ except Exception as e:
   print("Exception {}".format(e))
 ```
 
-+++ {"colab_type": "text", "id": "7mo76sS25Wco"}
-
 __What gives?!__  
 
 Allowing mutation of variables in-place makes program analysis and transformation very difficult. JAX requires a pure functional expression of a numerical program.  
@@ -240,31 +166,15 @@ Instead, JAX offers the _functional_ update functions: [__index_update__](https:
 
 ️⚠️ inside `jit`'d code and `lax.while_loop` or `lax.fori_loop` the __size__ of slices can't be functions of argument _values_ but only functions of argument _shapes_ -- the slice start indices have no such restriction.  See the below __Control Flow__ Section for more information on this limitation.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: m5lg1RYq5D9p
-
+```{code-cell}
 from jax.ops import index, index_add, index_update
 ```
 
-+++ {"colab_type": "text", "id": "X2Xjjvd-l8NL"}
-
 ### index_update
-
-+++ {"colab_type": "text", "id": "eM6MyndXL2NY"}
 
 If the __input values__ of __index_update__ aren't reused, __jit__-compiled code will perform these operations _in-place_.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 221
-colab_type: code
-id: ygUJT49b7BBk
-outputId: 1a3511c4-a480-472f-cccb-5e01620cbe99
----
+```{code-cell}
 jax_array = jnp.zeros((3, 3))
 print("original array:")
 print(jax_array)
@@ -278,23 +188,11 @@ print("new array:")
 print(new_jax_array)
 ```
 
-+++ {"colab_type": "text", "id": "7to-sF8EmC_y"}
-
 ### index_add
-
-+++ {"colab_type": "text", "id": "iI5cLY1xMBLs"}
 
 If the __input values__ of __index_update__ aren't reused, __jit__-compiled code will perform these operations _in-place_.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 221
-colab_type: code
-id: tsw2svao8FUp
-outputId: 874acd15-a493-4d63-efe4-9f440d5d2a12
----
+```{code-cell}
 print("original array:")
 jax_array = jnp.ones((5, 6))
 print(jax_array)
@@ -304,86 +202,43 @@ print("new array post-addition:")
 print(new_jax_array)
 ```
 
-+++ {"colab_type": "text", "id": "oZ_jE2WAypdL"}
-
 ## 🔪 Out-of-Bounds Indexing
-
-+++ {"colab_type": "text", "id": "btRFwEVzypdN"}
 
 In Numpy, you are used to errors being thrown when you index an array outside of its bounds, like this:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: 5_ZM-BJUypdO
-outputId: 461f38cd-9452-4bcc-a44f-a07ddfa12f42
-tags: [raises-exception]
----
+```{code-cell}
 try:
   np.arange(10)[11]
 except Exception as e:
   print("Exception {}".format(e))
 ```
 
-+++ {"colab_type": "text", "id": "eoXrGARWypdR"}
-
 However, raising an error on other accelerators can be more difficult. Therefore, JAX does not raise an error, instead the index is clamped to the bounds of the array, meaning that for this example the last value of the array will be returned. 
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: cusaAD0NypdR
-outputId: 48428ad6-6cde-43ad-c12d-2eb9b9fe59cf
----
+```{code-cell}
 jnp.arange(10)[11]
 ```
 
 Note that due to this behavior jnp.nanargmin and jnp.nanargmax return -1 for slices consisting of NaNs whereas Numpy would throw an error.
 
-+++ {"colab_type": "text", "id": "MUycRNh6e50W"}
-
 ## 🔪 Random Numbers
-
-+++ {"colab_type": "text", "id": "O8vvaVt3MRG2"}
 
 > _If all scientific papers whose results are in doubt because of bad 
 > `rand()`s were to disappear from library shelves, there would be a 
 > gap on each shelf about as big as your fist._ - Numerical Recipes
 
-+++ {"colab_type": "text", "id": "Qikt9pPW9L5K"}
-
 ### RNGs and State
 You're used to _stateful_ pseudorandom number generators (PRNGs) from numpy and other libraries, which helpfully hide a lot of details under the hood to give you a ready fountain of pseudorandomness:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: rr9FeP41fynt
-outputId: 849d84cf-04ad-4e8b-9505-a92f6c0d7a39
----
+```{code-cell}
 print(np.random.random())
 print(np.random.random())
 print(np.random.random())
 ```
 
-+++ {"colab_type": "text", "id": "ORMVVGZJgSVi"}
-
 Underneath the hood, numpy uses the [Mersenne Twister](https://en.wikipedia.org/wiki/Mersenne_Twister) PRNG to power its pseudorandom functions.  The PRNG has a period of $2^{19937}-1$ and at any point can be described by __624 32bit unsigned ints__ and a __position__ indicating how much of this  "entropy" has been used up.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 7Pyp2ajzfPO2
-
+```{code-cell}
 np.random.seed(0)
 rng_state = np.random.get_state()
 #print(rng_state)
@@ -392,15 +247,9 @@ rng_state = np.random.get_state()
 #       3048484911, 1796872496], dtype=uint32), 624, 0, 0.0)
 ```
 
-+++ {"colab_type": "text", "id": "aJIxHVXCiM6m"}
-
 This pseudorandom state vector is automagically updated behind the scenes every time a random number is needed, "consuming" 2 of the uint32s in the Mersenne twister state vector:
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: GAHaDCYafpAF
-
+```{code-cell}
 _ = np.random.uniform()
 rng_state = np.random.get_state()
 #print(rng_state) 
@@ -423,52 +272,27 @@ rng_state = np.random.get_state()
 #      4162027047, 3277342478], dtype=uint32), 2, 0, 0.0)
 ```
 
-+++ {"colab_type": "text", "id": "N_mWnleNogps"}
-
 The problem with magic PRNG state is that it's hard to reason about how it's being used and updated across different threads, processes, and devices, and it's _very easy_ to screw up when the details of entropy production and consumption are hidden from the end user.
 
 The Mersenne Twister PRNG is also known to have a [number](https://cs.stackexchange.com/a/53475) of problems, it has a large 2.5Kb state size, which leads to problematic [initialization issues](https://dl.acm.org/citation.cfm?id=1276928).  It [fails](http://www.pcg-random.org/pdf/toms-oneill-pcg-family-v1.02.pdf) modern BigCrush tests, and is generally slow. 
 
-+++ {"colab_type": "text", "id": "Uvq7nV-j4vKK"}
-
 ### JAX PRNG
-
-+++ {"colab_type": "text", "id": "COjzGBpO4tzL"}
-
 
 JAX instead implements an _explicit_ PRNG where entropy production and consumption are handled by explicitly passing and iterating PRNG state.  JAX uses a modern [Threefry counter-based PRNG](https://github.com/google/jax/blob/master/design_notes/prng.md) that's __splittable__.  That is, its design allows us to __fork__ the PRNG state into new PRNGs for use with parallel stochastic generation.
 
 The random state is described by two unsigned-int32s that we call a __key__:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: yPHE7KTWgAWs
-outputId: 329e7757-2461-434c-a08c-fde80a2d10c9
----
+```{code-cell}
 from jax import random
 key = random.PRNGKey(0)
 key
 ```
 
-+++ {"colab_type": "text", "id": "XjYyWYNfq0hW"}
-
 JAX's random functions produce pseudorandom numbers from the PRNG state, but __do not__ change the state!  
 
 Reusing the same state will cause __sadness__ and __monotony__, depriving the enduser of __lifegiving chaos__:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 85
-colab_type: code
-id: 7zUdQMynoE5e
-outputId: 50617324-b887-42f2-a7ff-2a10f92d876a
----
+```{code-cell}
 print(random.normal(key, shape=(1,)))
 print(key)
 # No no no!
@@ -476,39 +300,19 @@ print(random.normal(key, shape=(1,)))
 print(key)
 ```
 
-+++ {"colab_type": "text", "id": "hQN9van8rJgd"}
-
 Instead, we __split__ the PRNG to get usable __subkeys__ every time we need a new pseudorandom number:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: ASj0_rSzqgGh
-outputId: bcc2ed60-2e41-4ef8-e84f-c724654aa198
----
+```{code-cell}
 print("old key", key)
 key, subkey = random.split(key)
 normal_pseudorandom = random.normal(subkey, shape=(1,))
 print("    \---SPLIT --> new key   ", key)
 print("             \--> new subkey", subkey, "--> normal", normal_pseudorandom)
 ```
-
-+++ {"colab_type": "text", "id": "tqtFVE4MthO3"}
 
 We propagate the __key__ and make new __subkeys__ whenever we need a new random number:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: jbC34XLor2Ek
-outputId: 6834a812-7160-4646-ee19-a246f683905a
----
+```{code-cell}
 print("old key", key)
 key, subkey = random.split(key)
 normal_pseudorandom = random.normal(subkey, shape=(1,))
@@ -516,43 +320,21 @@ print("    \---SPLIT --> new key   ", key)
 print("             \--> new subkey", subkey, "--> normal", normal_pseudorandom)
 ```
 
-+++ {"colab_type": "text", "id": "0KLYUluz3lN3"}
-
 We can generate more than one __subkey__ at a time:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: lEi08PJ4tfkX
-outputId: 3bb513de-8d14-4d37-ae57-51d6f5eaa762
----
+```{code-cell}
 key, *subkeys = random.split(key, 4)
 for subkey in subkeys:
   print(random.normal(subkey, shape=(1,)))
 ```
 
-+++ {"colab_type": "text", "id": "rg4CpMZ8c3ri"}
-
 ## 🔪 Control Flow
-
-+++ {"colab_type": "text", "id": "izLTvT24dAq0"}
 
 ### ✔ python control_flow + autodiff ✔
 
 If you just want to apply `grad` to your python functions, you can use regular python control-flow constructs with no problems, as if you were using [Autograd](https://github.com/hips/autograd) (or Pytorch or TF Eager).
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 51
-colab_type: code
-id: aAx0T3F8lLtu
-outputId: 808cfa77-d924-4586-af19-35a8fd7d2238
----
+```{code-cell}
 def f(x):
   if x < 3:
     return 3. * x ** 2
@@ -563,23 +345,13 @@ print(grad(f)(2.))  # ok!
 print(grad(f)(4.))  # ok!
 ```
 
-+++ {"colab_type": "text", "id": "hIfPT7WMmZ2H"}
-
 ### python control flow + JIT
 
 Using control flow with `jit` is more complicated, and by default it has more constraints.
 
 This works:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: OZ_BJX0CplNC
-outputId: 48ce004c-536a-44f5-b020-9267825e7e4d
----
+```{code-cell}
 @jit
 def f(x):
   for i in range(3):
@@ -589,19 +361,9 @@ def f(x):
 print(f(3))
 ```
 
-+++ {"colab_type": "text", "id": "22RzeJ4QqAuX"}
-
 So does this:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: pinVnmRWp6w6
-outputId: e3e6f2f7-ba59-4a98-cdfc-905c91b38ed1
----
+```{code-cell}
 @jit
 def g(x):
   y = 0.
@@ -612,19 +374,9 @@ def g(x):
 print(g(jnp.array([1., 2., 3.])))
 ```
 
-+++ {"colab_type": "text", "id": "TStltU2dqf8A"}
-
 But this doesn't, at least by default:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 54
-colab_type: code
-id: 9z38AIKclRNM
-outputId: 466730dd-df8b-4b80-ac5e-e55b5ea85ec7
----
+```{code-cell}
 @jit
 def f(x):
   if x < 3:
@@ -638,8 +390,6 @@ try:
 except Exception as e:
   print("Exception {}".format(e))
 ```
-
-+++ {"colab_type": "text", "id": "pIbr4TVPqtDN"}
 
 __What gives!?__
 
@@ -655,15 +405,7 @@ But there's a tradeoff here: if we trace a Python function on a `ShapedArray((),
 
 The good news is that you can control this tradeoff yourself. By having `jit` trace on more refined abstract values, you can relax the traceability constraints. For example, using the `static_argnums` argument to `jit`, we can specify to trace on concrete values of some arguments. Here's that example function again:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: -Tzp0H7Bt1Sn
-outputId: aba57a88-d8eb-40b0-ff22-7c266d892b13
----
+```{code-cell}
 def f(x):
   if x < 3:
     return 3. * x ** 2
@@ -675,19 +417,9 @@ f = jit(f, static_argnums=(0,))
 print(f(2.))
 ```
 
-+++ {"colab_type": "text", "id": "MHm1hIQAvBVs"}
-
 Here's another example, this time involving a loop:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: iwY86_JKvD6b
-outputId: 1ec847ea-df2b-438d-c0a1-fabf7b93b73d
----
+```{code-cell}
 def f(x, n):
   y = 0.
   for i in range(n):
@@ -699,25 +431,13 @@ f = jit(f, static_argnums=(1,))
 f(jnp.array([2., 3., 4.]), 2)
 ```
 
-+++ {"colab_type": "text", "id": "nSPTOX8DvOeO"}
-
 In effect, the loop gets statically unrolled.  JAX can also trace at _higher_ levels of abstraction, like `Unshaped`, but that's not currently the default for any transformation
-
-+++ {"colab_type": "text", "id": "wWdg8LTYwCW3"}
 
 ️⚠️ **functions with argument-__value__ dependent shapes**
 
 These control-flow issues also come up in a more subtle way: numerical functions we want to __jit__ can't specialize the shapes of internal arrays on argument _values_ (specializing on argument __shapes__ is ok).  As a trivial example, let's make a function whose output happens to depend on the input variable `length`.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 122
-colab_type: code
-id: Tqe9uLmUI_Gv
-outputId: fe319758-9959-434c-ab9d-0926e599dbc0
----
+```{code-cell}
 def example_fun(length, val):
   return jnp.ones((length,)) * val
 # un-jit'd works fine
@@ -737,21 +457,11 @@ print(good_example_jit(10, 4))
 print(good_example_jit(5, 4))
 ```
 
-+++ {"colab_type": "text", "id": "MStx_r2oKxpp"}
-
 `static_argnums` can be handy if `length` in our example rarely changes, but it would be disastrous if it changed a lot!  
 
 Lastly, if your function has global side-effects, JAX's tracer can cause weird things to happen. A common gotcha is trying to print arrays inside __jit__'d functions: 
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: m2ABpRd8K094
-outputId: 64da37a0-aa06-46a3-e975-88c676c5b9fa
----
+```{code-cell}
 @jit
 def f(x):
   print(x)
@@ -760,8 +470,6 @@ def f(x):
   return y
 f(2)
 ```
-
-+++ {"colab_type": "text", "id": "uCDcWG4MnVn-"}
 
 ### Structured control flow primitives
 
@@ -772,8 +480,6 @@ There are more options for control flow in JAX. Say you want to avoid re-compila
  - `lax.fori_loop` __fwd-mode-differentiable__
  - `lax.scan` _differentiable_
 
-
-+++ {"colab_type": "text", "id": "Sd9xrLMXeK3A"}
 
 #### cond
 python equivalent:
@@ -786,15 +492,7 @@ def cond(pred, true_operand, true_fun, false_operand, false_fun):
     return false_fun(false_operand)
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: SGxz9JOWeiyH
-outputId: b29da06c-037f-4b05-dbd8-ba52ac35a8cf
----
+```{code-cell}
 from jax import lax
 
 operand = jnp.array([0.])
@@ -803,8 +501,6 @@ lax.cond(True, operand, lambda x: x+1, operand, lambda x: x-1)
 lax.cond(False, operand, lambda x: x+1, operand, lambda x: x-1)
 # --> array([-1.], dtype=float32)
 ```
-
-+++ {"colab_type": "text", "id": "xkOFAw24eOMg"}
 
 #### while_loop
 
@@ -817,23 +513,13 @@ def while_loop(cond_fun, body_fun, init_val):
   return val
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: jM-D39a-c436
-outputId: b9c97167-fecf-4559-9ca7-1cb0235d8ad2
----
+```{code-cell}
 init_val = 0
 cond_fun = lambda x: x<10
 body_fun = lambda x: x+1
 lax.while_loop(cond_fun, body_fun, init_val)
 # --> array(10, dtype=int32)
 ```
-
-+++ {"colab_type": "text", "id": "apo3n3HAeQY_"}
 
 #### fori_loop
 python equivalent:
@@ -845,15 +531,7 @@ def fori_loop(start, stop, body_fun, init_val):
   return val
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: dt3tUpOmeR8u
-outputId: 864f2959-2429-4666-b364-4baf90a57482
----
+```{code-cell}
 init_val = 0
 start = 0
 stop = 10
@@ -861,8 +539,6 @@ body_fun = lambda i,x: x+i
 lax.fori_loop(start, stop, body_fun, init_val)
 # --> array(45, dtype=int32)
 ```
-
-+++ {"colab_type": "text", "id": "SipXS5qiqk8e"}
 
 #### Summary
 
@@ -885,11 +561,7 @@ $$
 $$
 <center>$\ast$ = argument-__value__-independent loop condition - unrolls the loop </center>
 
-+++ {"colab_type": "text", "id": "bxuUjFVG-v1h"}
-
 ## 🔪 Convolutions
-
-+++ {"colab_type": "text", "id": "0pcn2LeS-03b"}
 
 JAX and XLA offer the very general N-dimensional __conv_general_dilated__ function, but it's not very obvious how to use it.  We'll give some examples of the common use-cases.
 
@@ -899,15 +571,7 @@ A survey of the family of convolutional operators, [a guide to convolutional ari
 
 Let's define a simple diagonal edge kernel:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 286
-colab_type: code
-id: Yud1Y3ss-x1K
-outputId: 5aacee92-2769-4f10-d9a6-475cded80981
----
+```{code-cell}
 # 2D kernel - HWIO layout
 kernel = np.zeros((3, 3, 3, 3), dtype=jnp.float32)
 kernel += np.array([[1, 1, 0],
@@ -918,19 +582,9 @@ print("Edge Conv kernel:")
 plt.imshow(kernel[:, :, 0, 0]);
 ```
 
-+++ {"colab_type": "text", "id": "dITPaPdh_cMI"}
-
 And we'll make a simple synthetic image:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 286
-colab_type: code
-id: cpbGsIGa_Qyx
-outputId: e27385e6-8fa2-498d-f952-7d8e04775856
----
+```{code-cell}
 # NHWC layout
 img = np.zeros((1, 200, 198, 3), dtype=jnp.float32)
 for k in range(3):
@@ -942,25 +596,13 @@ print("Original Image:")
 plt.imshow(img[0]);
 ```
 
-+++ {"colab_type": "text", "id": "_m90y74OWorG"}
-
 ### lax.conv and lax.conv_with_general_padding
-
-+++ {"colab_type": "text", "id": "Pv9_QPDnWssM"}
 
 These are the simple convenience functions for convolutions
 
 ️⚠️ The convenience `lax.conv`, `lax.conv_with_general_padding` helper function assume __NCHW__ images and __OIHW__ kernels.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 628
-colab_type: code
-id: kppxbxpZW0nb
-outputId: 0d72fdd9-19d7-45ae-891b-b19df819620f
----
+```{code-cell}
 out = lax.conv(jnp.transpose(img,[0,3,1,2]),    # lhs = NCHW image tensor
                jnp.transpose(kernel,[3,2,0,1]), # rhs = OIHW conv kernel tensor
                (1, 1),  # window strides
@@ -971,15 +613,7 @@ plt.figure(figsize=(10,10))
 plt.imshow(np.array(out)[0,0,:,:]);
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 628
-colab_type: code
-id: aonr1tWvYCW9
-outputId: 1b61e1b7-331d-4b60-b524-73a0fbad3ed9
----
+```{code-cell}
 out = lax.conv_with_general_padding(
   jnp.transpose(img,[0,3,1,2]),    # lhs = NCHW image tensor
   jnp.transpose(kernel,[2,3,0,1]), # rhs = IOHW conv kernel tensor
@@ -992,8 +626,6 @@ print("First output channel:")
 plt.figure(figsize=(10,10))
 plt.imshow(np.array(out)[0,0,:,:]);
 ```
-
-+++ {"colab_type": "text", "id": "lyOwGRez_ycJ"}
 
 ### Dimension Numbers define dimensional layout for conv_general_dilated
 
@@ -1008,34 +640,16 @@ The important argument is the 3-tuple of axis layout arguments:
 
 ⚠️ To demonstrate the flexibility of dimension numbers we choose a __NHWC__ image and __HWIO__ kernel convention for `lax.conv_general_dilated` below.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: oXKebfCb_i2B
-outputId: 0243bbe8-ac5a-4923-8c6f-454a8d28f04b
----
+```{code-cell}
 dn = lax.conv_dimension_numbers(img.shape,     # only ndim matters, not shape
                                 kernel.shape,  # only ndim matters, not shape 
                                 ('NHWC', 'HWIO', 'NHWC'))  # the important bit
 print(dn)
 ```
 
-+++ {"colab_type": "text", "id": "elZys_HzFVG6"}
-
 #### SAME padding, no stride, no dilation
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 628
-colab_type: code
-id: rgb2T15aFVG6
-outputId: 2dae283f-21a6-4ca6-bf10-eaa247e579e7
----
+```{code-cell}
 out = lax.conv_general_dilated(img,    # lhs = image tensor
                                kernel, # rhs = conv kernel tensor
                                (1,1),  # window strides
@@ -1049,19 +663,9 @@ plt.figure(figsize=(10,10))
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "E4i3TI5JFVG9"}
-
 #### VALID padding, no stride, no dilation
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 628
-colab_type: code
-id: 1HQwudKVFVG-
-outputId: a141ffd2-9c7c-4633-b752-7cd345632fdf
----
+```{code-cell}
 out = lax.conv_general_dilated(img,     # lhs = image tensor
                                kernel,  # rhs = conv kernel tensor
                                (1,1),   # window strides
@@ -1075,19 +679,9 @@ plt.figure(figsize=(10,10))
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "VYKZdqLIFVHB"}
-
 #### SAME padding, 2,2 stride, no dilation
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 627
-colab_type: code
-id: mKq2-zmmFVHC
-outputId: 065e2f69-3f1d-4d19-864d-28ef59f1b0f8
----
+```{code-cell}
 out = lax.conv_general_dilated(img,    # lhs = image tensor
                                kernel, # rhs = conv kernel tensor
                                (2,2),  # window strides
@@ -1101,19 +695,9 @@ print("First output channel:")
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "gPxttaiaFVHE"}
-
 #### VALID padding, no stride, rhs kernel dilation ~ Atrous convolution (excessive to illustrate)
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 628
-colab_type: code
-id: _pGr0x6qFVHF
-outputId: 5387205f-3c23-4203-ff1b-ae5115eed5f7
----
+```{code-cell}
 out = lax.conv_general_dilated(img,     # lhs = image tensor
                                kernel,  # rhs = conv kernel tensor
                                (1,1),   # window strides
@@ -1127,19 +711,9 @@ print("First output channel:")
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "v-RhEeUfFVHI"}
-
 #### VALID padding, no stride, lhs=input dilation  ~ Transposed Convolution
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 629
-colab_type: code
-id: B9Ail8ppFVHJ
-outputId: 3617a5d2-1eaa-46e8-d691-87b365ed1310
----
+```{code-cell}
 out = lax.conv_general_dilated(img,               # lhs = image tensor
                                kernel,            # rhs = conv kernel tensor
                                (1,1),             # window strides
@@ -1153,19 +727,9 @@ print("First output channel:")
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "A-9OagtrVDyV"}
-
 We can use the last to, for instance, implement _transposed convolutions_:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 629
-colab_type: code
-id: 5EYIj77-NdHE
-outputId: f325e6cb-3079-4250-898f-ca4fb081c6c7
----
+```{code-cell}
 # The following is equivalent to tensorflow:
 # N,H,W,C = img.shape
 # out = tf.nn.conv2d_transpose(img, kernel, (N,2*H,2*W,C), (1,2,2,1))
@@ -1188,23 +752,11 @@ print("First output channel:")
 plt.imshow(np.array(out)[0,:,:,0]);
 ```
 
-+++ {"colab_type": "text", "id": "v8HsE-NCmUxx"}
-
 ### 1D Convolutions
-
-+++ {"colab_type": "text", "id": "WeP0rw0tm7HK"}
 
 You aren't limited to 2D convolutions, a simple 1D demo is below:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 674
-colab_type: code
-id: jJ-jcAn3cig-
-outputId: 64e578be-92c5-4aef-9d5d-ae93939f9b31
----
+```{code-cell}
 # 1D kernel - WIO layout
 kernel = np.array([[[1, 0, -1], [-1,  0,  1]], 
                     [[1, 1,  1], [-1, -1, -1]]], 
@@ -1236,19 +788,9 @@ plt.figure(figsize=(10,5))
 plt.plot(out[0]);
 ```
 
-+++ {"colab_type": "text", "id": "7XOgXqCTmaPa"}
-
 ### 3D Convolutions
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 530
-colab_type: code
-id: QNvSiq5-mcLd
-outputId: 1c278db7-e2a0-4f53-d7d4-57472f2a794e
----
+```{code-cell}
 # Random 3D kernel - HWDIO layout
 kernel = np.array([
   [[0, 0,  0], [0,  1,  0], [0,  0,   0]],
@@ -1294,11 +836,7 @@ ax.axis('off')
 ax.set_title('3D conv output');
 ```
 
-+++ {"colab_type": "text", "id": "DKTMw6tRZyK2"}
-
 ## 🔪 NaNs
-
-+++ {"colab_type": "text", "id": "ncS0NI4jZrwy"}
 
 ### Debugging NaNs
 
@@ -1427,26 +965,14 @@ When this code sees a nan in the output of an `@jit` function, it calls into the
 
 ⚠️ You shouldn't have the NaN-checker on if you're not debugging, as it can introduce lots of device-host round-trips and performance regressions!
 
-+++ {"colab_type": "text", "id": "YTktlwTTMgFl"}
-
 ## Double (64bit) precision
 
 At the moment, JAX by default enforces single-precision numbers to mitigate the Numpy API's tendency to aggressively promote operands to `double`.  This is the desired behavior for many machine-learning applications, but it may catch you by surprise!
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: CNNGtzM3NDkO
-outputId: d1384021-d9bf-450f-a9ae-82024fa5fc1a
----
+```{code-cell}
 x = random.uniform(random.PRNGKey(0), (1000,), dtype=jnp.float64)
 x.dtype
 ```
-
-+++ {"colab_type": "text", "id": "VcvqzobxNPbd"}
 
 To use double-precision numbers, you need to set the `jax_enable_x64` configuration variable __at startup__.  
 
@@ -1482,27 +1008,15 @@ Note that #2-#4 work for _any_ of JAX's configuration options.
 
 We can then confirm that `x64` mode is enabled:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: HqGbBa9Rr-2g
-outputId: cd241d63-3d00-4fd7-f9c0-afc6af01ecf4
----
+```{code-cell}
 import jax.numpy as jnp
 from jax import random
 x = random.uniform(random.PRNGKey(0), (1000,), dtype=jnp.float64)
 x.dtype # --> dtype('float64')
 ```
 
-+++ {"colab_type": "text", "id": "6Cks2_gKsXaW"}
-
 ### Caveats
 ⚠️ XLA doesn't support 64-bit convolutions on all backends!
-
-+++ {"colab_type": "text", "id": "WAHjmL0E2XwO"}
 
 ## Fin.
 

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "LqiaKasFjH82"
-   },
+   "metadata": {},
    "source": [
     "# Custom derivative rules for JAX-transformable Python functions\n",
     "\n",
@@ -17,33 +15,17 @@
     "\n",
     "This notebook is about #1. To read instead about #2, see the [notebook on adding primitives](https://jax.readthedocs.io/en/latest/notebooks/How_JAX_primitives_work.html).\n",
     "\n",
-    "For an introduction to JAX's automatic differentiation API, see [The Autodiff Cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html). This notebook assumes some familiarity with [jax.jvp](https://jax.readthedocs.io/en/latest/jax.html#jax.jvp) and [jax.grad](https://jax.readthedocs.io/en/latest/jax.html#jax.grad), and the mathematical meaning of JVPs and VJPs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9Fg3NFNY-2RY"
-   },
-   "source": [
-    "## TL;DR"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ZgMNRtXyWIW8"
-   },
-   "source": [
+    "For an introduction to JAX's automatic differentiation API, see [The Autodiff Cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html). This notebook assumes some familiarity with [jax.jvp](https://jax.readthedocs.io/en/latest/jax.html#jax.jvp) and [jax.grad](https://jax.readthedocs.io/en/latest/jax.html#jax.grad), and the mathematical meaning of JVPs and VJPs.\n",
+    "\n",
+    "## TL;DR\n",
+    "\n",
     "### Custom JVPs with `jax.custom_jvp`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "id": "zXic8tr--1PK"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -65,13 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "RrNf588X_kJF",
-    "outputId": "b962bafb-e8a3-4b0d-ddf4-202e088231c3"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -97,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "id": "1kHd3cKOWQgB"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Equivalent alternative using the defjvps convenience wrapper\n",
@@ -115,13 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Zn81cHeYWVOw",
-    "outputId": "bf29b66c-897b-485e-c0a0-ee0fbd729a95"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -144,9 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "N2DOGCREWXFj"
-   },
+   "metadata": {},
    "source": [
     "### Custom VJPs with `jax.custom_vjp`"
    ]
@@ -154,9 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "id": "35ScHqhrBwPh"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import custom_vjp\n",
@@ -179,13 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "HpSozxKUCXgp",
-    "outputId": "57277102-7bdb-41f0-c805-a27fcf9fb1ae"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -201,45 +159,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "p5ypWA7XlZpu"
-   },
+   "metadata": {},
    "source": [
     "## Example problems\n",
     "\n",
-    "To get an idea of what problems `jax.custom_jvp` and `jax.custom_vjp` are meant to solve, let's go over a few examples. A more thorough introduction to the `jax.custom_jvp` and `jax.custom_vjp` APIs is in [the next section](#scrollTo=Dr0aNkBslfQf)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "AR02eyd1GQhC"
-   },
-   "source": [
+    "To get an idea of what problems `jax.custom_jvp` and `jax.custom_vjp` are meant to solve, let's go over a few examples. A more thorough introduction to the `jax.custom_jvp` and `jax.custom_vjp` APIs is in [the next section](#scrollTo=Dr0aNkBslfQf).\n",
+    "\n",
+    "\n",
     "### Numerical stability\n",
     "\n",
-    "One application of `jax.custom_jvp` is to improve the numerical stability of differentiation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "GksPXslaGPaW"
-   },
-   "source": [
+    "One application of `jax.custom_jvp` is to improve the numerical stability of differentiation.\n",
+    "\n",
+    "\n",
     "Say we want to write a function called `log1pexp`, which computes $x \\mapsto \\log ( 1 + e^x )$. We can write that using `jax.numpy`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "6lWbTvs40ET-",
-    "outputId": "8caff99e-add1-4c70-ace3-212c0c5c6f4e"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -265,9 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "PL36r_cD0oE8"
-   },
+   "metadata": {},
    "source": [
     "Since it's written in terms of `jax.numpy`, it's JAX-transformable:"
    ]
@@ -275,13 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "XgtGKFld02UD",
-    "outputId": "809d399d-8eca-401e-b969-810e46648571"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -303,9 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "o56Nr3V61PKS"
-   },
+   "metadata": {},
    "source": [
     "But there's a numerical stability problem lurking here:"
    ]
@@ -313,13 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "sVM6iwIO22sB",
-    "outputId": "9c935ee8-f174-475a-ca01-fc80949199e5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -335,9 +257,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Zu9sR2I73wuO"
-   },
+   "metadata": {},
    "source": [
     "That doesn't seem right! After all, the derivative of $x \\mapsto \\log (1 + e^x)$ is $x \\mapsto \\frac{e^x}{1 + e^x}$, and so for large values of $x$ we'd expect the value to be about 1.\n",
     "\n",
@@ -347,13 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "dO6uZlYR4TVp",
-    "outputId": "61e06b1e-14cd-4030-f330-a949be185df8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -382,9 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "52HR5EW26PEt"
-   },
+   "metadata": {},
    "source": [
     "Stepping through how the jaxpr would be evaluated, we can see that the last line would involve multiplying values that floating point math will round to 0 and $\\infty$, respectively, which is never a good idea. That is, we're effectively evaluating `lambda x: (1 / (1 + jnp.exp(x))) * jnp.exp(x)` for large `x`, which effectively turns into `0. * jnp.inf`.\n",
     "\n",
@@ -400,9 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "id": "XQt6MAuTJewG"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import custom_jvp\n",
@@ -423,13 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "rhiMHulfKBIF",
-    "outputId": "883bc4d2-3a1b-48d3-b205-c500f77d229c"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -446,13 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "9cLDuAo6KGUu",
-    "outputId": "59984494-6124-4540-84fd-608ad4fc6bc6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -472,9 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9sVUGbGkUOqO"
-   },
+   "metadata": {},
    "source": [
     "Here's a `defjvps` convenience wrapper to express the same thing:"
    ]
@@ -482,9 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "id": "xfQTp8F7USEM"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -497,13 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "dtdh-PLaUsvw",
-    "outputId": "aa36aec6-15af-4397-fc55-8b9fb7e607d8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -525,30 +413,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "V9tHAfrSF1N-"
-   },
+   "metadata": {},
    "source": [
     "### Enforcing a differentiation convention\n",
     "\n",
-    "A related application is to enforce a differentiation convention, perhaps at a boundary."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "l_6tdb-QGK-H"
-   },
-   "source": [
+    "A related application is to enforce a differentiation convention, perhaps at a boundary.\n",
+    "\n",
+    "\n",
     "Consider the function $f : \\mathbb{R}_+ \\mapsto \\mathbb{R}_+$ with $f(x) = \\frac{x}{1 + \\sqrt{x}}$, where we take $\\mathbb{R}_+ = [0, \\infty)$. We might implement $f$ as a program like this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "id": "AfF5P7x_GaSe"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def f(x):\n",
@@ -557,9 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "BVcEkF3ZGgv1"
-   },
+   "metadata": {},
    "source": [
     "As a mathematical function on $\\mathbb{R}$ (the full real line), $f$ is not differentiable at zero (because the limit defining the derivative doesn't exist from the left). Correspondingly, autodiff produces a `nan` value:"
    ]
@@ -567,13 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "piI0u5MiHhQh",
-    "outputId": "c045308f-2f3b-4c22-ebb2-b9ee582b4d25"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -589,9 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "IP0H2b7ZHkzD"
-   },
+   "metadata": {},
    "source": [
     "But mathematically if we think of $f$ as a function on $\\mathbb{R}_+$ then it is differentiable at 0 [Rudin's Principles of Mathematical Analysis Definition 5.1, or Tao's Analysis I 3rd ed. Definition 10.1.1 and Example 10.1.6]. Alternatively, we might say as a convention we want to consider the directional derivative from the right. So there is a sensible value for the Python function `grad(f)` to return at `0.0`, namely `1.0`. By default, JAX's machinery for differentiation assumes all functions are defined over $\\mathbb{R}$ and thus doesn't produce `1.0` here.\n",
     "\n",
@@ -601,9 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "id": "ksHmCkcSKQJr"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -622,13 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Gsh9ZvMTKi1O",
-    "outputId": "a3076175-6542-4210-ce4a-d0d82e0051c6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -644,9 +504,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Usbp_gxaVVea"
-   },
+   "metadata": {},
    "source": [
     "Here's the convenience wrapper version:"
    ]
@@ -654,9 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "id": "qXnrxIfaVYCs"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -669,13 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "uUU5qRmEViK1",
-    "outputId": "ea7dc2c4-a100-48f4-a74a-859070daf994"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -691,9 +541,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7J2A85wbSAmF"
-   },
+   "metadata": {},
    "source": [
     "### Gradient clipping\n",
     "\n",
@@ -705,9 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "id": "8jfjSanIW_tJ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -730,14 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 282
-    },
-    "id": "4OLU_vf8Xw2J",
-    "outputId": "5a51ff2c-79c2-41ba-eead-53679b4eddbc"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -778,14 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 282
-    },
-    "id": "iS8nRuBZYLcD",
-    "outputId": "299dc977-ff2f-43a4-c0d2-9fa6c7eaeeb2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -824,43 +656,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "CICQuI86WK4_"
-   },
+   "metadata": {},
    "source": [
     "### Python debugging\n",
     "\n",
-    "Another application that is motivated by development workflow rather than numerics is to set a `pdb` debugger trace in the backward pass of reverse-mode autodiff."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "cgxMjNTrGjJn"
-   },
-   "source": [
+    "Another application that is motivated by development workflow rather than numerics is to set a `pdb` debugger trace in the backward pass of reverse-mode autodiff.\n",
+    "\n",
+    "\n",
     "When trying to track down the source of a `nan` runtime error, or just examine carefully the cotangent (gradient) values being propagated, it can be useful to insert a debugger at a point in the backward pass that corresponds to a specific point in the primal computation. You can do that with `jax.custom_vjp`.\n",
     "\n",
-    "We'll defer an example until the next section."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "IC7tEcr1-Fc5"
-   },
-   "source": [
+    "We'll defer an example until the next section.\n",
+    "\n",
     "### Implicit function differentiation of iterative implementations\n",
     "\n",
-    "This example gets pretty deep in the mathematical weeds!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "szAt97t80hew"
-   },
-   "source": [
+    "This example gets pretty deep in the mathematical weeds!\n",
+    "\n",
     "Another application for `jax.custom_vjp` is reverse-mode differentiation of functions that are JAX-transformable (by `jit`, `vmap`, ...) but not efficiently JAX-differentiable for some reason, perhaps because they involve `lax.while_loop`. (It's not possible to produce an XLA HLO program that efficiently computes the reverse-mode derivative of an XLA HLO While loop because that would require a program with unbounded memory use, which isn't possible to express in XLA HLO, at least without side-effecting interactions through infeed/outfeed.)\n",
     "\n",
     "For example, consider this `fixed_point` routine which computes a fixed point by iteratively applying a function in a `while_loop`:"
@@ -869,9 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "id": "2uA8X2izXH2b"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.lax import while_loop\n",
@@ -891,9 +699,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "p2xFQAte19sF"
-   },
+   "metadata": {},
    "source": [
     "This is an iterative procedure for numerically solving the equation $x = f(a, x)$ for $x$, by iterating $x_{t+1} = f(a, x_t)$ until $x_{t+1}$ is sufficiently close to $x_t$. The result $x^*$ depends on the parameters $a$, and so we can think of there being a function $a \\mapsto x^*(a)$ that is implicity defined by equation $x = f(a, x)$.\n",
     "\n",
@@ -903,9 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "id": "rDDwM8bYYzRT"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def newton_sqrt(a):\n",
@@ -916,13 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "42Ydd7_6aLXU",
-    "outputId": "c576dc92-33df-42b9-b2e8-ad54119514b1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -938,9 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "-yFtYWH13QWm"
-   },
+   "metadata": {},
    "source": [
     "We can `vmap` or `jit` the function as well:"
    ]
@@ -948,13 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "t_YSXieT3Yyk",
-    "outputId": "76483e18-81f3-47a8-e8aa-e81535c01fe2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -970,9 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "emwWIt3d3h1T"
-   },
+   "metadata": {},
    "source": [
     "We can't apply reverse-mode automatic differentiation because of the `while_loop`, but it turns out we wouldn't want to anyway: instead of differentiating through the implementation of `fixed_point` and all its iterations, we can exploit the mathematical structure to do something that is much more memory-efficient (and FLOP-efficient in this case, too!). We can instead use the implicit function theorem [Prop A.25 of Bertsekas's Nonlinear Programming, 2nd ed.], which guarantees (under some conditions) the existence of the mathematical objects we're about to use. In essence, we linearize at the solution and solve those linear equations iteratively to compute the derivatives we want.\n",
     "\n",
@@ -1002,9 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "id": "g4jo-xlvdiym"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import vjp\n",
@@ -1045,13 +831,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "iKzfT6d_mEoB",
-    "outputId": "5d04c4a0-61dd-42de-ffa4-101b71d15a57"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1068,13 +848,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Hmcpjr6gmtkO",
-    "outputId": "9c4a406c-0144-4d5f-e789-a7a4c850a3cc"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1092,9 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "DvVmlaPD7W-4"
-   },
+   "metadata": {},
    "source": [
     "We can check our answers by differentiating `jnp.sqrt`, which uses a totally different implementation:"
    ]
@@ -1102,13 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "jj_JnI9Pm4jg",
-    "outputId": "6eb3e158-209b-41f2-865c-376a1d07624b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1126,28 +892,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "HowvqayEuy-H"
-   },
+   "metadata": {},
    "source": [
-    "A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Dr0aNkBslfQf"
-   },
-   "source": [
-    "## Basic usage of `jax.custom_jvp` and `jax.custom_vjp` APIs"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MojTOg4tmQNT"
-   },
-   "source": [
+    "A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API.\n",
+    "\n",
+    "## Basic usage of `jax.custom_jvp` and `jax.custom_vjp` APIs\n",
+    "\n",
+    "\n",
     "### Use `jax.custom_jvp` to define forward-mode (and, indirectly, reverse-mode) rules\n",
     "\n",
     "Here's a canonical basic example of using `jax.custom_jvp`:"
@@ -1156,9 +907,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "id": "nVkhbIFAOGZk"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import custom_jvp\n",
@@ -1181,13 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "fxhlECvW7Krj",
-    "outputId": "30dc5e8b-d157-4ae2-cd17-145d4e1ba47b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1211,19 +954,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "JaoQVRzSQ9Qd"
-   },
+   "metadata": {},
    "source": [
-    "In words, we start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it a JVP rule function `f_jvp` that takes a pair of inputs representing the primal inputs of type `a` and the corresponding tangent inputs of type `T a`, and produces a pair of outputs representing the primal outputs of type `b` and tangent outputs of type `T b`. The tangent outputs should be a linear function of the tangent inputs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "1xGky7yMOavq"
-   },
-   "source": [
+    "In words, we start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it a JVP rule function `f_jvp` that takes a pair of inputs representing the primal inputs of type `a` and the corresponding tangent inputs of type `T a`, and produces a pair of outputs representing the primal outputs of type `b` and tangent outputs of type `T b`. The tangent outputs should be a linear function of the tangent inputs.\n",
+    "\n",
     "You can also use `f.defjvp` as a decorator, as in\n",
     "\n",
     "```python\n",
@@ -1234,28 +968,15 @@
     "@f.defjvp\n",
     "def f_jvp(primals, tangents):\n",
     "  ...\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "e9R-ppvdQIOC"
-   },
-   "source": [
+    "```\n",
+    "\n",
     "Even though we defined only a JVP rule and no VJP rule, we can use both forward- and reverse-mode differentiation on `f`. JAX will automatically transpose the linear computation on tangent values from our custom JVP rule, computing the VJP as efficiently as if we had written the rule by hand:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "hl9Io86pQD6s",
-    "outputId": "a9ef39aa-4df0-459f-ee1d-64b648cabcc4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1275,28 +996,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "MRlKe5D90svj"
-   },
+   "metadata": {},
    "source": [
-    "For automatic transposition to work, the JVP rule's output tangents must be linear as a function of the input tangents. Otherwise a transposition error is raised."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "GRu-0yg96lXE"
-   },
-   "source": [
+    "For automatic transposition to work, the JVP rule's output tangents must be linear as a function of the input tangents. Otherwise a transposition error is raised.\n",
+    "\n",
     "Multiple arguments work like this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {
-    "id": "JFLXlXuq6pRf"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1315,13 +1025,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "QpKwA0oA8DfE",
-    "outputId": "80855f56-04a5-4179-fd8b-199ea7eba476"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1337,9 +1041,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "YPsPS3rdaGo2"
-   },
+   "metadata": {},
    "source": [
     "The `defjvps` convenience wrapper lets us define a JVP for each argument separately, and the results are computed separately then summed:"
    ]
@@ -1347,9 +1049,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {
-    "id": "CsQIUhUkajua"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1362,13 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "zfSgXrPEap-i",
-    "outputId": "bf552090-a60d-4c2a-fc91-603396df94cd"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1384,9 +1078,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "iYUCLJghbPiP"
-   },
+   "metadata": {},
    "source": [
     "Here's a `defjvps` example with multiple arguments:"
    ]
@@ -1394,9 +1086,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {
-    "id": "Vx4Jv9s9bCi1"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1410,13 +1100,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "o9ezUYsjbbvC",
-    "outputId": "f60f4941-d5e3-49c3-920f-76fd92414697"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1436,9 +1120,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "nuIUkaxibVfD"
-   },
+   "metadata": {},
    "source": [
     "As a shorthand, with `defjvps` you can pass a `None` value to indicate that the JVP for a particular argument is zero:"
    ]
@@ -1446,9 +1128,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {
-    "id": "z4z3esdZbTzQ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1462,13 +1142,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "jOtQfp-5btSo",
-    "outputId": "b60aa797-4c1e-4421-826d-691ba418bc1d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1488,28 +1162,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "kZ0yc-Ihoezk"
-   },
+   "metadata": {},
    "source": [
-    "Calling a `jax.custom_jvp` function with keyword arguments, or writing a `jax.custom_jvp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3FGwfT67PDs9"
-   },
-   "source": [
+    "Calling a `jax.custom_jvp` function with keyword arguments, or writing a `jax.custom_jvp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.\n",
+    "\n",
     "When you're not performing differentiation, the function `f` is called just as if it weren't decorated by `jax.custom_jvp`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {
-    "id": "b-tB3xCHPRFt"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1528,13 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "xAlRea95PjA5",
-    "outputId": "10b4db9e-3192-415e-ac1c-0dc57c7dc086"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1554,13 +1211,7 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "dyD2ow4NmpI-",
-    "outputId": "1d66b67f-c1b4-4a9d-d6ed-12d88767842c"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1580,9 +1231,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "EzB75KZ5Pz7m"
-   },
+   "metadata": {},
    "source": [
     "The custom JVP rule is invoked during differentiation, whether forward or reverse:"
    ]
@@ -1590,13 +1239,7 @@
   {
    "cell_type": "code",
    "execution_count": 48,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "hKF0xyAxPyLZ",
-    "outputId": "214cc5a7-a992-41c8-aa01-8ea4b2b3b4d6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1616,13 +1259,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Z1KaEgA58MEG",
-    "outputId": "86263d76-5a98-4d96-f5c2-9146bcf1b6fd"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1640,9 +1277,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "o8JFxk3lQhOs"
-   },
+   "metadata": {},
    "source": [
     "Notice that `f_jvp` calls `f` to compute the primal outputs. In the context of higher-order differentiation, each application of a differentiation transform will use the custom JVP rule if and only if the rule calls the original `f` to compute the primal outputs. (This represents a kind of fundamental tradeoff, where we can't make use of intermediate values from the evaluation of `f` in our rule _and also_ have the rule apply in all orders of higher-order differentiation.)"
    ]
@@ -1650,13 +1285,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "B6PLJooTQgVp",
-    "outputId": "0d7ac628-656e-4b67-d285-f810155b6b9c"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1686,9 +1315,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "XNxAmFSsaaro"
-   },
+   "metadata": {},
    "source": [
     "You can use Python control flow with `jax.custom_jvp`:"
    ]
@@ -1696,9 +1323,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "metadata": {
-    "id": "kkXlSJL6adU2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_jvp\n",
@@ -1722,13 +1347,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "QCHmJ56Na2G3",
-    "outputId": "1772d3b4-44ef-4745-edd3-553c6312c553"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1746,9 +1365,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9cVdgR7ilt8l"
-   },
+   "metadata": {},
    "source": [
     "### Use `jax.custom_vjp` to define custom reverse-mode-only rules\n",
     "\n",
@@ -1758,9 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "metadata": {
-    "id": "zAZk1n3dUw76"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import custom_vjp\n",
@@ -1785,13 +1400,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "E8W-H2S0Ngdr",
-    "outputId": "cd0dc221-e779-436d-f3b4-21e799f40620"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1811,32 +1420,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "yLING7qEVGGN"
-   },
+   "metadata": {},
    "source": [
     "In words, we again start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it two functions, `f_fwd` and `f_bwd`, which describe how to perform the forward- and backward-passes of reverse-mode autodiff, respectively.\n",
     "\n",
     "The function `f_fwd` describes the forward pass, not only the primal computation but also what values to save for use on the backward pass. Its input signature is just like that of the primal function `f`, in that it takes a primal input of type `a`. But as output it produces a pair, where the first element is the primal output `b` and the second element is any \"residual\" data of type `c` to be stored for use by the backward pass. (This second output is analogous to [PyTorch's save_for_backward mechanism](https://pytorch.org/tutorials/beginner/examples_autograd/two_layer_net_custom_function.html).)\n",
     "\n",
-    "The function `f_bwd` describes the backward pass. It takes two inputs, where the first is the residual data of type `c` produced by `f_fwd` and the second is the output cotangents of type `CT b` corresponding to the output of the primal function. It produces an output of type `CT a` representing the cotangents corresponding to the input of the primal function. In particular, the output of `f_bwd` must be a sequence (e.g. a tuple) of length equal to the number of arguments to the primal function."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "d1b5v67Oncfz"
-   },
-   "source": [
+    "The function `f_bwd` describes the backward pass. It takes two inputs, where the first is the residual data of type `c` produced by `f_fwd` and the second is the output cotangents of type `CT b` corresponding to the output of the primal function. It produces an output of type `CT a` representing the cotangents corresponding to the input of the primal function. In particular, the output of `f_bwd` must be a sequence (e.g. a tuple) of length equal to the number of arguments to the primal function.\n",
+    "\n",
     "So multiple arguments work like this:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 55,
-   "metadata": {
-    "id": "IhMb64gkngAt"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import custom_vjp\n",
@@ -1858,13 +1456,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "EnRtIhhLnkry",
-    "outputId": "e03907ec-463a-4f3c-ae8e-feecb4394b2b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1880,28 +1472,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "GwC26P9kn8qw"
-   },
+   "metadata": {},
    "source": [
-    "Calling a `jax.custom_vjp` function with keyword arguments, or writing a `jax.custom_vjp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "XfH-ae8bYt6-"
-   },
-   "source": [
+    "Calling a `jax.custom_vjp` function with keyword arguments, or writing a `jax.custom_vjp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.\n",
+    "\n",
     "As with `jax.custom_jvp`, the custom VJP rule comprised by `f_fwd` and `f_bwd` is not invoked if differentiation is not applied. If function is evaluated, or transformed with `jit`, `vmap`, or other non-differentiation transformations, then only `f` is called."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 57,
-   "metadata": {
-    "id": "s-_Dbqi-N5Ij"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_vjp\n",
@@ -1923,13 +1504,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "r0aZ79OmOAR5",
-    "outputId": "9cf16d9e-ca96-4987-e01a-dc0e22405576"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1947,13 +1522,7 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "7ToB9BYlm6uN",
-    "outputId": "aa9f3e3f-e6c3-4ee4-b87a-4526074f43aa"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1973,13 +1542,7 @@
   {
    "cell_type": "code",
    "execution_count": 60,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "s1Pn_qCIODcF",
-    "outputId": "423d34e0-35b8-4b57-e89d-f70f20e28ea9"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2001,13 +1564,7 @@
   {
    "cell_type": "code",
    "execution_count": 61,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "dvgQtDHaOHuo",
-    "outputId": "d92649c5-0aab-49a9-9158-f7ddc5fccb9b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2024,9 +1581,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "qFIIpkFcZCNP"
-   },
+   "metadata": {},
    "source": [
     "**Forward-mode autodiff cannot be used on the** `jax.custom_vjp` **function** and will raise an error:"
    ]
@@ -2034,13 +1589,7 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "3RGQRbI_OSEX",
-    "outputId": "6385a024-7a10-445a-8380-b2eef722e597"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2063,28 +1612,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "u04I9j2dntAU"
-   },
+   "metadata": {},
    "source": [
-    "If you want to use both forward- and reverse-mode, use `jax.custom_jvp` instead."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "YN97y7LEZbWV"
-   },
-   "source": [
+    "If you want to use both forward- and reverse-mode, use `jax.custom_jvp` instead.\n",
+    "\n",
     "We can use `jax.custom_vjp` together with `pdb` to insert a debugger trace in the backward pass:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 63,
-   "metadata": {
-    "id": "-DvRKsHPZk_g"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pdb\n",
@@ -2106,9 +1644,7 @@
   {
    "cell_type": "code",
    "execution_count": 64,
-   "metadata": {
-    "id": "49GdkP4pZ2IV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def foo(x):\n",
@@ -2119,9 +1655,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "sGLnRcPwaKoX"
-   },
+   "metadata": {},
    "source": [
     "```python\n",
     "jax.grad(foo)(3.)\n",
@@ -2133,24 +1667,10 @@
     "(Pdb) p g\n",
     "DeviceArray(-0.91113025, dtype=float32)\n",
     "(Pdb) q\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "DaTfAJLAl1Lb"
-   },
-   "source": [
-    "## More features and details"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "LQF_UDApl_UV"
-   },
-   "source": [
+    "```\n",
+    "\n",
+    "## More features and details\n",
+    "\n",
     "### Working with `list` / `tuple` / `dict` containers (and other pytrees)\n",
     "\n",
     "You should expect standard Python containers like lists, tuples, namedtuples, and dicts to just work, along with nested versions of those. In general, any [pytrees](https://github.com/google/jax/blob/master/docs/notebooks/JAX_pytrees.ipynb) are permissible, so long as their structures are consistent according to the type constraints. \n",
@@ -2161,9 +1681,7 @@
   {
    "cell_type": "code",
    "execution_count": 65,
-   "metadata": {
-    "id": "6sDLZ3dAn3P2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from collections import namedtuple\n",
@@ -2192,13 +1710,7 @@
   {
    "cell_type": "code",
    "execution_count": 66,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "My8pbOlPppJj",
-    "outputId": "04cc1129-d0fb-4018-bec1-2ccf8b7906e3"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2217,13 +1729,7 @@
   {
    "cell_type": "code",
    "execution_count": 67,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "a9qyiCAhqLd3",
-    "outputId": "08bd0615-7c35-44ff-f90b-c175618c2c40"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2239,9 +1745,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "BWLN9tu4qWQd"
-   },
+   "metadata": {},
    "source": [
     "And an analogous contrived example with `jax.custom_vjp`:"
    ]
@@ -2249,9 +1753,7 @@
   {
    "cell_type": "code",
    "execution_count": 68,
-   "metadata": {
-    "id": "QkdbwGkJqS3J"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@custom_vjp\n",
@@ -2279,13 +1781,7 @@
   {
    "cell_type": "code",
    "execution_count": 69,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "3onW7t6nrJ4E",
-    "outputId": "ac455ab0-cac0-41fc-aea3-034931316053"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2304,13 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": 70,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "ryyeKIXtrNpd",
-    "outputId": "1780f738-ffd8-4ed7-ffbe-71d84bd62709"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2326,28 +1816,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "JKTNivxbmKWO"
-   },
+   "metadata": {},
    "source": [
-    "### Handling  non-differentiable arguments"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "7g9sXSp_uc36"
-   },
-   "source": [
-    "Some use cases, like the final example problem, call for non-differentiable arguments like function-valued arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9yNIOzyBCvE5"
-   },
-   "source": [
+    "### Handling  non-differentiable arguments\n",
+    "\n",
+    "Some use cases, like the final example problem, call for non-differentiable arguments like function-valued arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`.\n",
+    "\n",
     "#### `jax.custom_jvp` with `nondiff_argnums`\n",
     "\n",
     "Use the optional `nondiff_argnums` parameter to `jax.custom_jvp` to indicate arguments like these. Here's an example with `jax.custom_jvp`:"
@@ -2356,9 +1830,7 @@
   {
    "cell_type": "code",
    "execution_count": 71,
-   "metadata": {
-    "id": "b3YMxxTBvy0I"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from functools import partial\n",
@@ -2377,13 +1849,7 @@
   {
    "cell_type": "code",
    "execution_count": 72,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "5W-yEw9IB34S",
-    "outputId": "a2c1444a-9cc7-43ee-cb52-6c5d1cec02f1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2400,13 +1866,7 @@
   {
    "cell_type": "code",
    "execution_count": 73,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "zbVIlOmqB7_O",
-    "outputId": "a0174f54-89b0-4957-9362-c05af922f974"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2422,9 +1882,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "-b_B_4WaBI2D"
-   },
+   "metadata": {},
    "source": [
     "Notice the gotcha here: no matter where in the argument list these parameters appear, they're placed at the *start* of the signature of the corresponding JVP rule. Here's another example:"
    ]
@@ -2432,9 +1890,7 @@
   {
    "cell_type": "code",
    "execution_count": 74,
-   "metadata": {
-    "id": "9hokWmyHBgKK"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@partial(custom_jvp, nondiff_argnums=(0, 2))\n",
@@ -2451,13 +1907,7 @@
   {
    "cell_type": "code",
    "execution_count": 75,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "J7GsvJTgCfS0",
-    "outputId": "43dd6a02-2e4e-449e-924a-d1a03fe622fe"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2474,13 +1924,7 @@
   {
    "cell_type": "code",
    "execution_count": 76,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "kPP8Jt1CCb1X",
-    "outputId": "6eff9aae-8d6e-4998-92ed-56272c32d6e8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2496,28 +1940,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ECbalHIkC4ts"
-   },
+   "metadata": {},
    "source": [
-    "#### `jax.custom_vjp` with `nondiff_argnums`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "0u0jn4aWC8k1"
-   },
-   "source": [
+    "#### `jax.custom_vjp` with `nondiff_argnums`\n",
+    "\n",
     "A similar option exists for `jax.custom_vjp`, and similarly the convention is that the non-differentiable arguments are passed as the first arguments to the rules, no matter where they appear in the original function's signature. Here's an example:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 77,
-   "metadata": {
-    "id": "yCdu-_9GClWs"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@partial(custom_vjp, nondiff_argnums=(0,))\n",
@@ -2536,13 +1969,7 @@
   {
    "cell_type": "code",
    "execution_count": 78,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "qSgcWa1eDj4r",
-    "outputId": "43939686-f857-47ea-9f85-53f440ef12ee"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2559,13 +1986,7 @@
   {
    "cell_type": "code",
    "execution_count": 79,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "tccagflcDmaz",
-    "outputId": "c75ca70b-2431-493b-e335-4f4d340902f1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -2581,9 +2002,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "BTEnNTk5D0sM"
-   },
+   "metadata": {},
    "source": [
     "See `fixed_point` above for another usage example.\n",
     "\n",

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -11,8 +11,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"id": "LqiaKasFjH82"}
-
 # Custom derivative rules for JAX-transformable Python functions
 
 *mattjj@ Mar 19 2020, last updated Oct 14 2020*
@@ -26,17 +24,11 @@ This notebook is about #1. To read instead about #2, see the [notebook on adding
 
 For an introduction to JAX's automatic differentiation API, see [The Autodiff Cookbook](https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html). This notebook assumes some familiarity with [jax.jvp](https://jax.readthedocs.io/en/latest/jax.html#jax.jvp) and [jax.grad](https://jax.readthedocs.io/en/latest/jax.html#jax.grad), and the mathematical meaning of JVPs and VJPs.
 
-+++ {"id": "9Fg3NFNY-2RY"}
-
 ## TL;DR
-
-+++ {"id": "ZgMNRtXyWIW8"}
 
 ### Custom JVPs with `jax.custom_jvp`
 
 ```{code-cell}
-:id: zXic8tr--1PK
-
 import jax.numpy as jnp
 from jax import custom_jvp
 
@@ -54,12 +46,6 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: RrNf588X_kJF
-outputId: b962bafb-e8a3-4b0d-ddf4-202e088231c3
----
 from jax import jvp, grad
 
 print(f(2., 3.))
@@ -70,8 +56,6 @@ print(grad(f)(2., 3.))
 ```
 
 ```{code-cell}
-:id: 1kHd3cKOWQgB
-
 # Equivalent alternative using the defjvps convenience wrapper
 
 @custom_jvp
@@ -83,12 +67,6 @@ f.defjvps(lambda x_dot, primal_out, x, y: jnp.cos(x) * x_dot * y,
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Zn81cHeYWVOw
-outputId: bf29b66c-897b-485e-c0a0-ee0fbd729a95
----
 print(f(2., 3.))
 y, y_dot = jvp(f, (2., 3.), (1., 0.))
 print(y)
@@ -96,13 +74,9 @@ print(y_dot)
 print(grad(f)(2., 3.))
 ```
 
-+++ {"id": "N2DOGCREWXFj"}
-
 ### Custom VJPs with `jax.custom_vjp`
 
 ```{code-cell}
-:id: 35ScHqhrBwPh
-
 from jax import custom_vjp
 
 @custom_vjp
@@ -121,40 +95,22 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: HpSozxKUCXgp
-outputId: 57277102-7bdb-41f0-c805-a27fcf9fb1ae
----
 print(grad(f)(2., 3.))
 ```
-
-+++ {"id": "p5ypWA7XlZpu"}
 
 ## Example problems
 
 To get an idea of what problems `jax.custom_jvp` and `jax.custom_vjp` are meant to solve, let's go over a few examples. A more thorough introduction to the `jax.custom_jvp` and `jax.custom_vjp` APIs is in [the next section](#scrollTo=Dr0aNkBslfQf).
 
 
-+++ {"id": "AR02eyd1GQhC"}
-
 ### Numerical stability
 
 One application of `jax.custom_jvp` is to improve the numerical stability of differentiation.
-
-+++ {"id": "GksPXslaGPaW"}
 
 
 Say we want to write a function called `log1pexp`, which computes $x \mapsto \log ( 1 + e^x )$. We can write that using `jax.numpy`:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 6lWbTvs40ET-
-outputId: 8caff99e-add1-4c70-ace3-212c0c5c6f4e
----
 import jax.numpy as jnp
 
 def log1pexp(x):
@@ -163,17 +119,9 @@ def log1pexp(x):
 log1pexp(3.)
 ```
 
-+++ {"id": "PL36r_cD0oE8"}
-
 Since it's written in terms of `jax.numpy`, it's JAX-transformable:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: XgtGKFld02UD
-outputId: 809d399d-8eca-401e-b969-810e46648571
----
 from jax import jit, grad, vmap
 
 print(jit(log1pexp)(3.))
@@ -181,39 +129,21 @@ print(jit(grad(log1pexp))(3.))
 print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
 ```
 
-+++ {"id": "o56Nr3V61PKS"}
-
 But there's a numerical stability problem lurking here:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: sVM6iwIO22sB
-outputId: 9c935ee8-f174-475a-ca01-fc80949199e5
----
 print(grad(log1pexp)(100.))
 ```
-
-+++ {"id": "Zu9sR2I73wuO"}
 
 That doesn't seem right! After all, the derivative of $x \mapsto \log (1 + e^x)$ is $x \mapsto \frac{e^x}{1 + e^x}$, and so for large values of $x$ we'd expect the value to be about 1.
 
 We can get a bit more insight into what's going on by looking at the jaxpr for the gradient computation:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: dO6uZlYR4TVp
-outputId: 61e06b1e-14cd-4030-f330-a949be185df8
----
 from jax import make_jaxpr
 
 make_jaxpr(grad(log1pexp))(100.)
 ```
-
-+++ {"id": "52HR5EW26PEt"}
 
 Stepping through how the jaxpr would be evaluated, we can see that the last line would involve multiplying values that floating point math will round to 0 and $\infty$, respectively, which is never a good idea. That is, we're effectively evaluating `lambda x: (1 / (1 + jnp.exp(x))) * jnp.exp(x)` for large `x`, which effectively turns into `0. * jnp.inf`.
 
@@ -226,8 +156,6 @@ This is one application of custom derivative rules for Python functions that are
 Here's a solution using `jax.custom_jvp`:
 
 ```{code-cell}
-:id: XQt6MAuTJewG
-
 from jax import custom_jvp
 
 @custom_jvp
@@ -244,34 +172,18 @@ def log1pexp_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: rhiMHulfKBIF
-outputId: 883bc4d2-3a1b-48d3-b205-c500f77d229c
----
 print(grad(log1pexp)(100.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 9cLDuAo6KGUu
-outputId: 59984494-6124-4540-84fd-608ad4fc6bc6
----
 print(jit(log1pexp)(3.))
 print(jit(grad(log1pexp))(3.))
 print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
 ```
 
-+++ {"id": "9sVUGbGkUOqO"}
-
 Here's a `defjvps` convenience wrapper to express the same thing:
 
 ```{code-cell}
-:id: xfQTp8F7USEM
-
 @custom_jvp
 def log1pexp(x):
   return jnp.log(1. + jnp.exp(x))
@@ -280,59 +192,35 @@ log1pexp.defjvps(lambda t, ans, x: (1 - 1/(1 + jnp.exp(x))) * t)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: dtdh-PLaUsvw
-outputId: aa36aec6-15af-4397-fc55-8b9fb7e607d8
----
 print(grad(log1pexp)(100.))
 print(jit(log1pexp)(3.))
 print(jit(grad(log1pexp))(3.))
 print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
 ```
 
-+++ {"id": "V9tHAfrSF1N-"}
-
 ### Enforcing a differentiation convention
 
 A related application is to enforce a differentiation convention, perhaps at a boundary.
-
-+++ {"id": "l_6tdb-QGK-H"}
 
 
 Consider the function $f : \mathbb{R}_+ \mapsto \mathbb{R}_+$ with $f(x) = \frac{x}{1 + \sqrt{x}}$, where we take $\mathbb{R}_+ = [0, \infty)$. We might implement $f$ as a program like this:
 
 ```{code-cell}
-:id: AfF5P7x_GaSe
-
 def f(x):
   return x / (1 + jnp.sqrt(x))
 ```
 
-+++ {"id": "BVcEkF3ZGgv1"}
-
 As a mathematical function on $\mathbb{R}$ (the full real line), $f$ is not differentiable at zero (because the limit defining the derivative doesn't exist from the left). Correspondingly, autodiff produces a `nan` value:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: piI0u5MiHhQh
-outputId: c045308f-2f3b-4c22-ebb2-b9ee582b4d25
----
 print(grad(f)(0.))
 ```
-
-+++ {"id": "IP0H2b7ZHkzD"}
 
 But mathematically if we think of $f$ as a function on $\mathbb{R}_+$ then it is differentiable at 0 [Rudin's Principles of Mathematical Analysis Definition 5.1, or Tao's Analysis I 3rd ed. Definition 10.1.1 and Example 10.1.6]. Alternatively, we might say as a convention we want to consider the directional derivative from the right. So there is a sensible value for the Python function `grad(f)` to return at `0.0`, namely `1.0`. By default, JAX's machinery for differentiation assumes all functions are defined over $\mathbb{R}$ and thus doesn't produce `1.0` here.
 
 We can use a custom JVP rule! In particular, we can define the JVP rule in terms of the derivative function $x \mapsto \frac{\sqrt{x} + 2}{2(\sqrt{x} + 1)^2}$ on $\mathbb{R}_+$,
 
 ```{code-cell}
-:id: ksHmCkcSKQJr
-
 @custom_jvp
 def f(x):
   return x / (1 + jnp.sqrt(x))
@@ -347,22 +235,12 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Gsh9ZvMTKi1O
-outputId: a3076175-6542-4210-ce4a-d0d82e0051c6
----
 print(grad(f)(0.))
 ```
-
-+++ {"id": "Usbp_gxaVVea"}
 
 Here's the convenience wrapper version:
 
 ```{code-cell}
-:id: qXnrxIfaVYCs
-
 @custom_jvp
 def f(x):
   return x / (1 + jnp.sqrt(x))
@@ -371,16 +249,8 @@ f.defjvps(lambda t, ans, x: ((jnp.sqrt(x) + 2) / (2 * (jnp.sqrt(x) + 1)**2)) * t
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: uUU5qRmEViK1
-outputId: ea7dc2c4-a100-48f4-a74a-859070daf994
----
 print(grad(f)(0.))
 ```
-
-+++ {"id": "7J2A85wbSAmF"}
 
 ### Gradient clipping
 
@@ -389,8 +259,6 @@ While in some cases we want to express a mathematical differentiation computatio
 For gradient clipping, we can use `jnp.clip` together with a `jax.custom_vjp` reverse-mode-only rule:
 
 ```{code-cell}
-:id: 8jfjSanIW_tJ
-
 from functools import partial
 from jax import custom_vjp
 
@@ -409,13 +277,6 @@ clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 282
-id: 4OLU_vf8Xw2J
-outputId: 5a51ff2c-79c2-41ba-eead-53679b4eddbc
----
 import matplotlib.pyplot as plt
 from jax import vmap
 
@@ -426,13 +287,6 @@ plt.plot(vmap(grad(jnp.sin))(t))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 282
-id: iS8nRuBZYLcD
-outputId: 299dc977-ff2f-43a4-c0d2-9fa6c7eaeeb2
----
 def clip_sin(x):
   x = clip_gradient(-0.75, 0.75, x)
   return jnp.sin(x)
@@ -441,34 +295,24 @@ plt.plot(clip_sin(t))
 plt.plot(vmap(grad(clip_sin))(t))
 ```
 
-+++ {"id": "CICQuI86WK4_"}
-
 ### Python debugging
 
 Another application that is motivated by development workflow rather than numerics is to set a `pdb` debugger trace in the backward pass of reverse-mode autodiff.
-
-+++ {"id": "cgxMjNTrGjJn"}
 
 
 When trying to track down the source of a `nan` runtime error, or just examine carefully the cotangent (gradient) values being propagated, it can be useful to insert a debugger at a point in the backward pass that corresponds to a specific point in the primal computation. You can do that with `jax.custom_vjp`.
 
 We'll defer an example until the next section.
 
-+++ {"id": "IC7tEcr1-Fc5"}
-
 ### Implicit function differentiation of iterative implementations
 
 This example gets pretty deep in the mathematical weeds!
-
-+++ {"id": "szAt97t80hew"}
 
 Another application for `jax.custom_vjp` is reverse-mode differentiation of functions that are JAX-transformable (by `jit`, `vmap`, ...) but not efficiently JAX-differentiable for some reason, perhaps because they involve `lax.while_loop`. (It's not possible to produce an XLA HLO program that efficiently computes the reverse-mode derivative of an XLA HLO While loop because that would require a program with unbounded memory use, which isn't possible to express in XLA HLO, at least without side-effecting interactions through infeed/outfeed.)
 
 For example, consider this `fixed_point` routine which computes a fixed point by iteratively applying a function in a `while_loop`:
 
 ```{code-cell}
-:id: 2uA8X2izXH2b
-
 from jax.lax import while_loop
 
 def fixed_point(f, a, x_guess):
@@ -484,45 +328,25 @@ def fixed_point(f, a, x_guess):
   return x_star
 ```
 
-+++ {"id": "p2xFQAte19sF"}
-
 This is an iterative procedure for numerically solving the equation $x = f(a, x)$ for $x$, by iterating $x_{t+1} = f(a, x_t)$ until $x_{t+1}$ is sufficiently close to $x_t$. The result $x^*$ depends on the parameters $a$, and so we can think of there being a function $a \mapsto x^*(a)$ that is implicity defined by equation $x = f(a, x)$.
 
 We can use `fixed_point` to run iterative procedures to convergence, for example running Newton's method to calculate square roots while only executing adds, multiplies, and divides:
 
 ```{code-cell}
-:id: rDDwM8bYYzRT
-
 def newton_sqrt(a):
   update = lambda a, x: 0.5 * (x + a / x)
   return fixed_point(update, a, a)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 42Ydd7_6aLXU
-outputId: c576dc92-33df-42b9-b2e8-ad54119514b1
----
 print(newton_sqrt(2.))
 ```
-
-+++ {"id": "-yFtYWH13QWm"}
 
 We can `vmap` or `jit` the function as well:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: t_YSXieT3Yyk
-outputId: 76483e18-81f3-47a8-e8aa-e81535c01fe2
----
 print(jit(vmap(newton_sqrt))(jnp.array([1., 2., 3., 4.])))
 ```
-
-+++ {"id": "emwWIt3d3h1T"}
 
 We can't apply reverse-mode automatic differentiation because of the `while_loop`, but it turns out we wouldn't want to anyway: instead of differentiating through the implementation of `fixed_point` and all its iterations, we can exploit the mathematical structure to do something that is much more memory-efficient (and FLOP-efficient in this case, too!). We can instead use the implicit function theorem [Prop A.25 of Bertsekas's Nonlinear Programming, 2nd ed.], which guarantees (under some conditions) the existence of the mathematical objects we're about to use. In essence, we linearize at the solution and solve those linear equations iteratively to compute the derivatives we want.
 
@@ -549,8 +373,6 @@ where $w^\mathsf{T} = v^\mathsf{T} (I - A)^{-1}$, or equivalently $w^\mathsf{T} 
 Here's the upshot:
 
 ```{code-cell}
-:id: g4jo-xlvdiym
-
 from jax import vjp
 
 @partial(custom_vjp, nondiff_argnums=(0,))
@@ -587,50 +409,24 @@ fixed_point.defvjp(fixed_point_fwd, fixed_point_rev)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: iKzfT6d_mEoB
-outputId: 5d04c4a0-61dd-42de-ffa4-101b71d15a57
----
 print(newton_sqrt(2.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Hmcpjr6gmtkO
-outputId: 9c4a406c-0144-4d5f-e789-a7a4c850a3cc
----
 print(grad(newton_sqrt)(2.))
 print(grad(grad(newton_sqrt))(2.))
 ```
 
-+++ {"id": "DvVmlaPD7W-4"}
-
 We can check our answers by differentiating `jnp.sqrt`, which uses a totally different implementation:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: jj_JnI9Pm4jg
-outputId: 6eb3e158-209b-41f2-865c-376a1d07624b
----
 print(grad(jnp.sqrt)(2.))
 print(grad(grad(jnp.sqrt))(2.))
 ```
 
-+++ {"id": "HowvqayEuy-H"}
-
 A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API.
 
-+++ {"id": "Dr0aNkBslfQf"}
-
 ## Basic usage of `jax.custom_jvp` and `jax.custom_vjp` APIs
-
-+++ {"id": "MojTOg4tmQNT"}
 
 
 ### Use `jax.custom_jvp` to define forward-mode (and, indirectly, reverse-mode) rules
@@ -638,8 +434,6 @@ A limitation to this approach is that the argument `f` can't close over any valu
 Here's a canonical basic example of using `jax.custom_jvp`:
 
 ```{code-cell}
-:id: nVkhbIFAOGZk
-
 from jax import custom_jvp
 import jax.numpy as jnp
 
@@ -658,12 +452,6 @@ f.defjvp(f_jvp)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: fxhlECvW7Krj
-outputId: 30dc5e8b-d157-4ae2-cd17-145d4e1ba47b
----
 from jax import jvp
 
 print(f(3.))
@@ -673,11 +461,7 @@ print(y)
 print(y_dot)
 ```
 
-+++ {"id": "JaoQVRzSQ9Qd"}
-
 In words, we start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it a JVP rule function `f_jvp` that takes a pair of inputs representing the primal inputs of type `a` and the corresponding tangent inputs of type `T a`, and produces a pair of outputs representing the primal outputs of type `b` and tangent outputs of type `T b`. The tangent outputs should be a linear function of the tangent inputs.
-
-+++ {"id": "1xGky7yMOavq"}
 
 You can also use `f.defjvp` as a decorator, as in
 
@@ -691,34 +475,20 @@ def f_jvp(primals, tangents):
   ...
 ```
 
-+++ {"id": "e9R-ppvdQIOC"}
-
 Even though we defined only a JVP rule and no VJP rule, we can use both forward- and reverse-mode differentiation on `f`. JAX will automatically transpose the linear computation on tangent values from our custom JVP rule, computing the VJP as efficiently as if we had written the rule by hand:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: hl9Io86pQD6s
-outputId: a9ef39aa-4df0-459f-ee1d-64b648cabcc4
----
 from jax import grad
 
 print(grad(f)(3.))
 print(grad(grad(f))(3.))
 ```
 
-+++ {"id": "MRlKe5D90svj"}
-
 For automatic transposition to work, the JVP rule's output tangents must be linear as a function of the input tangents. Otherwise a transposition error is raised.
-
-+++ {"id": "GRu-0yg96lXE"}
 
 Multiple arguments work like this:
 
 ```{code-cell}
-:id: JFLXlXuq6pRf
-
 @custom_jvp
 def f(x, y):
   return x ** 2 * y
@@ -733,23 +503,13 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: QpKwA0oA8DfE
-outputId: 80855f56-04a5-4179-fd8b-199ea7eba476
----
 print(grad(f)(2., 3.))
 ```
-
-+++ {"id": "YPsPS3rdaGo2"}
 
 The `defjvps` convenience wrapper lets us define a JVP for each argument separately, and the results are computed separately then summed:
 
 
 ```{code-cell}
-:id: CsQIUhUkajua
-
 @custom_jvp
 def f(x):
   return jnp.sin(x)
@@ -758,22 +518,12 @@ f.defjvps(lambda t, ans, x: jnp.cos(x) * t)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: zfSgXrPEap-i
-outputId: bf552090-a60d-4c2a-fc91-603396df94cd
----
 print(grad(f)(3.))
 ```
-
-+++ {"id": "iYUCLJghbPiP"}
 
 Here's a `defjvps` example with multiple arguments:
 
 ```{code-cell}
-:id: Vx4Jv9s9bCi1
-
 @custom_jvp
 def f(x, y):
   return x ** 2 * y
@@ -783,24 +533,14 @@ f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: o9ezUYsjbbvC
-outputId: f60f4941-d5e3-49c3-920f-76fd92414697
----
 print(grad(f)(2., 3.))
 print(grad(f, 0)(2., 3.))  # same as above
 print(grad(f, 1)(2., 3.))
 ```
 
-+++ {"id": "nuIUkaxibVfD"}
-
 As a shorthand, with `defjvps` you can pass a `None` value to indicate that the JVP for a particular argument is zero:
 
 ```{code-cell}
-:id: z4z3esdZbTzQ
-
 @custom_jvp
 def f(x, y):
   return x ** 2 * y
@@ -810,28 +550,16 @@ f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: jOtQfp-5btSo
-outputId: b60aa797-4c1e-4421-826d-691ba418bc1d
----
 print(grad(f)(2., 3.))
 print(grad(f, 0)(2., 3.))  # same as above
 print(grad(f, 1)(2., 3.))
 ```
 
-+++ {"id": "kZ0yc-Ihoezk"}
-
 Calling a `jax.custom_jvp` function with keyword arguments, or writing a `jax.custom_jvp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.
-
-+++ {"id": "3FGwfT67PDs9"}
 
 When you're not performing differentiation, the function `f` is called just as if it weren't decorated by `jax.custom_jvp`:
 
 ```{code-cell}
-:id: b-tB3xCHPRFt
-
 @custom_jvp
 def f(x):
   print('called f!')  # a harmless side-effect
@@ -846,74 +574,36 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: xAlRea95PjA5
-outputId: 10b4db9e-3192-415e-ac1c-0dc57c7dc086
----
 from jax import vmap, jit
 
 print(f(3.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: dyD2ow4NmpI-
-outputId: 1d66b67f-c1b4-4a9d-d6ed-12d88767842c
----
 print(vmap(f)(jnp.arange(3.)))
 print(jit(f)(3.))
 ```
 
-+++ {"id": "EzB75KZ5Pz7m"}
-
 The custom JVP rule is invoked during differentiation, whether forward or reverse:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: hKF0xyAxPyLZ
-outputId: 214cc5a7-a992-41c8-aa01-8ea4b2b3b4d6
----
 y, y_dot = jvp(f, (3.,), (1.,))
 print(y_dot)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Z1KaEgA58MEG
-outputId: 86263d76-5a98-4d96-f5c2-9146bcf1b6fd
----
 print(grad(f)(3.))
 ```
-
-+++ {"id": "o8JFxk3lQhOs"}
 
 Notice that `f_jvp` calls `f` to compute the primal outputs. In the context of higher-order differentiation, each application of a differentiation transform will use the custom JVP rule if and only if the rule calls the original `f` to compute the primal outputs. (This represents a kind of fundamental tradeoff, where we can't make use of intermediate values from the evaluation of `f` in our rule _and also_ have the rule apply in all orders of higher-order differentiation.)
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: B6PLJooTQgVp
-outputId: 0d7ac628-656e-4b67-d285-f810155b6b9c
----
 grad(grad(f))(3.)
 ```
-
-+++ {"id": "XNxAmFSsaaro"}
 
 You can use Python control flow with `jax.custom_jvp`:
 
 ```{code-cell}
-:id: kkXlSJL6adU2
-
 @custom_jvp
 def f(x):
   if x > 0:
@@ -933,25 +623,15 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: QCHmJ56Na2G3
-outputId: 1772d3b4-44ef-4745-edd3-553c6312c553
----
 print(grad(f)(1.))
 print(grad(f)(-1.))
 ```
-
-+++ {"id": "9cVdgR7ilt8l"}
 
 ### Use `jax.custom_vjp` to define custom reverse-mode-only rules
 
 While `jax.custom_jvp` suffices for controlling both forward- and, via JAX's automatic transposition, reverse-mode differentiation behavior, in some cases we may want to directly control a VJP rule, for example in the latter two example problems presented above. We can do that with `jax.custom_vjp`:
 
 ```{code-cell}
-:id: zAZk1n3dUw76
-
 from jax import custom_vjp
 import jax.numpy as jnp
 
@@ -972,19 +652,11 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: E8W-H2S0Ngdr
-outputId: cd0dc221-e779-436d-f3b4-21e799f40620
----
 from jax import grad
 
 print(f(3.))
 print(grad(f)(3.))
 ```
-
-+++ {"id": "yLING7qEVGGN"}
 
 In words, we again start with a primal function `f` that takes inputs of type `a` and produces outputs of type `b`. We associate with it two functions, `f_fwd` and `f_bwd`, which describe how to perform the forward- and backward-passes of reverse-mode autodiff, respectively.
 
@@ -992,13 +664,9 @@ The function `f_fwd` describes the forward pass, not only the primal computation
 
 The function `f_bwd` describes the backward pass. It takes two inputs, where the first is the residual data of type `c` produced by `f_fwd` and the second is the output cotangents of type `CT b` corresponding to the output of the primal function. It produces an output of type `CT a` representing the cotangents corresponding to the input of the primal function. In particular, the output of `f_bwd` must be a sequence (e.g. a tuple) of length equal to the number of arguments to the primal function.
 
-+++ {"id": "d1b5v67Oncfz"}
-
 So multiple arguments work like this:
 
 ```{code-cell}
-:id: IhMb64gkngAt
-
 from jax import custom_vjp
 
 @custom_vjp
@@ -1016,26 +684,14 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: EnRtIhhLnkry
-outputId: e03907ec-463a-4f3c-ae8e-feecb4394b2b
----
 print(grad(f)(2., 3.))
 ```
 
-+++ {"id": "GwC26P9kn8qw"}
-
 Calling a `jax.custom_vjp` function with keyword arguments, or writing a `jax.custom_vjp` function definition with default arguments, are both allowed so long as they can be unambiguosly mapped to positional arguments based on the function signature retrieved by the standard library `inspect.signature` mechanism.
-
-+++ {"id": "XfH-ae8bYt6-"}
 
 As with `jax.custom_jvp`, the custom VJP rule comprised by `f_fwd` and `f_bwd` is not invoked if differentiation is not applied. If function is evaluated, or transformed with `jit`, `vmap`, or other non-differentiation transformations, then only `f` is called.
 
 ```{code-cell}
-:id: s-_Dbqi-N5Ij
-
 @custom_vjp
 def f(x):
   print("called f!")
@@ -1053,32 +709,14 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: r0aZ79OmOAR5
-outputId: 9cf16d9e-ca96-4987-e01a-dc0e22405576
----
 print(f(3.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 7ToB9BYlm6uN
-outputId: aa9f3e3f-e6c3-4ee4-b87a-4526074f43aa
----
 print(grad(f)(3.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: s1Pn_qCIODcF
-outputId: 423d34e0-35b8-4b57-e89d-f70f20e28ea9
----
 from jax import vjp
 
 y, f_vjp = vjp(f, 3.)
@@ -1086,26 +724,12 @@ print(y)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: dvgQtDHaOHuo
-outputId: d92649c5-0aab-49a9-9158-f7ddc5fccb9b
----
 print(f_vjp(1.))
 ```
-
-+++ {"id": "qFIIpkFcZCNP"}
 
 **Forward-mode autodiff cannot be used on the** `jax.custom_vjp` **function** and will raise an error:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 3RGQRbI_OSEX
-outputId: 6385a024-7a10-445a-8380-b2eef722e597
----
 from jax import jvp
 
 try:
@@ -1114,17 +738,11 @@ except TypeError as e:
   print('ERROR! {}'.format(e))
 ```
 
-+++ {"id": "u04I9j2dntAU"}
-
 If you want to use both forward- and reverse-mode, use `jax.custom_jvp` instead.
-
-+++ {"id": "YN97y7LEZbWV"}
 
 We can use `jax.custom_vjp` together with `pdb` to insert a debugger trace in the backward pass:
 
 ```{code-cell}
-:id: -DvRKsHPZk_g
-
 import pdb
 
 @custom_vjp
@@ -1142,15 +760,11 @@ debug.defvjp(debug_fwd, debug_bwd)
 ```
 
 ```{code-cell}
-:id: 49GdkP4pZ2IV
-
 def foo(x):
   y = x ** 2
   y = debug(y)  # insert pdb in corresponding backward pass step
   return jnp.sin(y)
 ```
-
-+++ {"id": "sGLnRcPwaKoX"}
 
 ```python
 jax.grad(foo)(3.)
@@ -1164,11 +778,7 @@ DeviceArray(-0.91113025, dtype=float32)
 (Pdb) q
 ```
 
-+++ {"id": "DaTfAJLAl1Lb"}
-
 ## More features and details
-
-+++ {"id": "LQF_UDApl_UV"}
 
 ### Working with `list` / `tuple` / `dict` containers (and other pytrees)
 
@@ -1177,8 +787,6 @@ You should expect standard Python containers like lists, tuples, namedtuples, an
 Here's a contrived example with `jax.custom_jvp`:
 
 ```{code-cell}
-:id: 6sDLZ3dAn3P2
-
 from collections import namedtuple
 Point = namedtuple("Point", ["x", "y"])
 
@@ -1203,34 +811,18 @@ def fun(pt):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: My8pbOlPppJj
-outputId: 04cc1129-d0fb-4018-bec1-2ccf8b7906e3
----
 pt = Point(1., 2.)
 
 print(f(pt))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: a9qyiCAhqLd3
-outputId: 08bd0615-7c35-44ff-f90b-c175618c2c40
----
 print(grad(fun)(pt))
 ```
-
-+++ {"id": "BWLN9tu4qWQd"}
 
 And an analogous contrived example with `jax.custom_vjp`:
 
 ```{code-cell}
-:id: QkdbwGkJqS3J
-
 @custom_vjp
 def f(pt):
   x, y = pt.x, pt.y
@@ -1254,44 +846,24 @@ def fun(pt):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 3onW7t6nrJ4E
-outputId: ac455ab0-cac0-41fc-aea3-034931316053
----
 pt = Point(1., 2.)
 
 print(f(pt))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: ryyeKIXtrNpd
-outputId: 1780f738-ffd8-4ed7-ffbe-71d84bd62709
----
 print(grad(fun)(pt))
 ```
 
-+++ {"id": "JKTNivxbmKWO"}
-
 ### Handling  non-differentiable arguments
 
-+++ {"id": "7g9sXSp_uc36"}
-
 Some use cases, like the final example problem, call for non-differentiable arguments like function-valued arguments to be passed to functions with custom differentiation rules, and for those arguments to also be passed to the rules themselves. In the case of `fixed_point`, the function argument `f` was such a non-differentiable argument. A similar situation arises with `jax.experimental.odeint`.
-
-+++ {"id": "9yNIOzyBCvE5"}
 
 #### `jax.custom_jvp` with `nondiff_argnums`
 
 Use the optional `nondiff_argnums` parameter to `jax.custom_jvp` to indicate arguments like these. Here's an example with `jax.custom_jvp`:
 
 ```{code-cell}
-:id: b3YMxxTBvy0I
-
 from functools import partial
 
 @partial(custom_jvp, nondiff_argnums=(0,))
@@ -1306,32 +878,16 @@ def app_jvp(f, primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 5W-yEw9IB34S
-outputId: a2c1444a-9cc7-43ee-cb52-6c5d1cec02f1
----
 print(app(lambda x: x ** 3, 3.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: zbVIlOmqB7_O
-outputId: a0174f54-89b0-4957-9362-c05af922f974
----
 print(grad(app, 1)(lambda x: x ** 3, 3.))
 ```
-
-+++ {"id": "-b_B_4WaBI2D"}
 
 Notice the gotcha here: no matter where in the argument list these parameters appear, they're placed at the *start* of the signature of the corresponding JVP rule. Here's another example:
 
 ```{code-cell}
-:id: 9hokWmyHBgKK
-
 @partial(custom_jvp, nondiff_argnums=(0, 2))
 def app2(f, x, g):
   return f(g((x)))
@@ -1344,36 +900,18 @@ def app2_jvp(f, g, primals, tangents):
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: J7GsvJTgCfS0
-outputId: 43dd6a02-2e4e-449e-924a-d1a03fe622fe
----
 print(app2(lambda x: x ** 3, 3., lambda y: 5 * y))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: kPP8Jt1CCb1X
-outputId: 6eff9aae-8d6e-4998-92ed-56272c32d6e8
----
 print(grad(app2, 1)(lambda x: x ** 3, 3., lambda y: 5 * y))
 ```
 
-+++ {"id": "ECbalHIkC4ts"}
-
 #### `jax.custom_vjp` with `nondiff_argnums`
-
-+++ {"id": "0u0jn4aWC8k1"}
 
 A similar option exists for `jax.custom_vjp`, and similarly the convention is that the non-differentiable arguments are passed as the first arguments to the rules, no matter where they appear in the original function's signature. Here's an example:
 
 ```{code-cell}
-:id: yCdu-_9GClWs
-
 @partial(custom_vjp, nondiff_argnums=(0,))
 def app(f, x):
   return f(x)
@@ -1388,26 +926,12 @@ app.defvjp(app_fwd, app_bwd)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: qSgcWa1eDj4r
-outputId: 43939686-f857-47ea-9f85-53f440ef12ee
----
 print(app(lambda x: x ** 2, 4.))
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: tccagflcDmaz
-outputId: c75ca70b-2431-493b-e335-4f4d340902f1
----
 print(grad(app, 1)(lambda x: x ** 2, 4.))
 ```
-
-+++ {"id": "BTEnNTk5D0sM"}
 
 See `fixed_point` above for another usage example.
 

--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vfxqky4PCUnh"
-   },
+   "metadata": {},
    "source": [
     "# How JAX primitives work\n",
     "\n",
@@ -41,16 +38,10 @@
     "Consider that we want to add to JAX support for a multiply-add function with three arguments, defined mathematically\n",
     "as \"multiply_add(x, y, z) = x * y + z\". \n",
     "This function operates on 3 identically-shaped tensors of floating point \n",
-    "values and performs the opertions pointwise."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HIJYIHNTD1yI"
-   },
-   "source": [
+    "values and performs the opertions pointwise.\n",
+    "\n",
+    "\n",
+    "\n",
     "## Using existing primitives\n",
     "\n",
     "The easiest way to define new functions is to write them in terms of JAX primitives, or in terms of other\n",
@@ -61,15 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 105
-    },
-    "colab_type": "code",
-    "id": "tbOF0LB0EMne",
-    "outputId": "3fb1c8a7-7a4c-4a3a-f7ff-37b7dc740528"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -108,10 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Cgv60Wm3E_D5"
-   },
+   "metadata": {},
    "source": [
     "In order to understand how JAX is internally using the primitives,\n",
     "we add some helpers for tracing function calls."
@@ -121,10 +101,7 @@
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {
-    "cellView": "form",
-    "colab": {},
-    "colab_type": "code",
-    "id": "mQRQGEGiE53K"
+    "cellView": "form"
    },
    "outputs": [],
    "source": [
@@ -201,10 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Qf4eLrLCFYDl"
-   },
+   "metadata": {},
    "source": [
     "Instead of using `jax.lax` primitives directly, we can use other functions \n",
     "that are already written in terms of those primitives, such as those in `jax.numpy`:"
@@ -213,15 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 255
-    },
-    "colab_type": "code",
-    "id": "QhKorz6cFRJb",
-    "outputId": "aba3cef3-6bcc-4eb3-c7b3-34e405f2f82a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -264,10 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Sg-D8EdeFn4a"
-   },
+   "metadata": {},
    "source": [
     "Notice that in the process of computing `grad`, JAX invokes `square_add_numpy` and\n",
     "`multiply_add_numpy` with special arguments `ConcreteArray(...)` (described further \n",
@@ -277,16 +240,8 @@
     "that JAX may use to abstract the function execution.\n",
     "\n",
     "The JAX traceability property is satisfied as long as the function is written \n",
-    "in terms of JAX primitives."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WxrQO7-XGLcg"
-   },
-   "source": [
+    "in terms of JAX primitives. \n",
+    "\n",
     "## Defining new JAX primitives\n",
     "\n",
     "The right way to add support for multiply-add is in terms of existing\n",
@@ -298,11 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "cPqAH1XOGTN4"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import core\n",
@@ -325,10 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LMzs5PAKGr-4"
-   },
+   "metadata": {},
    "source": [
     "If we try to call the newly defined functions we get an error, because\n",
     "we have not yet told JAX anything about the semantics of the new primitive."
@@ -337,15 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 221
-    },
-    "colab_type": "code",
-    "id": "_X3PAYxhGpWd",
-    "outputId": "90ea2c6a-9ef3-40ea-e9a3-3ab1cfc59fc8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -379,10 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "elha0FdgHSEF"
-   },
+   "metadata": {},
    "source": [
     "### Primal evaluation rules"
    ]
@@ -390,15 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "FT34FFAGHARU",
-    "outputId": "4c54f1c2-8a50-4788-90e1-06aee412c43b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -435,15 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 119
-    },
-    "colab_type": "code",
-    "id": "G5bstKaeNAVV",
-    "outputId": "deb94d5b-dfea-4e6f-9ec2-70b416c996c5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -464,10 +385,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "upBf-uAuHhPJ"
-   },
+   "metadata": {},
    "source": [
     "### JIT\n",
     "\n",
@@ -477,15 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 241
-    },
-    "colab_type": "code",
-    "id": "QG-LULjiHk4b",
-    "outputId": "d4ef4406-8dae-4c96-97ca-b662340474ee"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -519,10 +429,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "rHS1bAGHH44E"
-   },
+   "metadata": {},
    "source": [
     "#### Abstract evaluation rules\n",
     "In order to JIT the function, and for other transformations as well, \n",
@@ -542,15 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "ctQmEeckIbdo",
-    "outputId": "e751d0cc-460e-4ffd-df2e-fdabf9cffdc2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -588,10 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "RPN88X6YI43A"
-   },
+   "metadata": {},
    "source": [
     "If we re-attempt to JIT, we see how the abstract evaluation proceeds, but\n",
     "we get another error, about missing the actual XLA compilation rule:"
@@ -600,15 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 309
-    },
-    "colab_type": "code",
-    "id": "eOcNR92SI2h-",
-    "outputId": "356ef229-3703-4696-cc3d-7c05de405fb0"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -646,10 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "9IOV1R-fJMHp"
-   },
+   "metadata": {},
    "source": [
     "#### XLA Compilation rules\n",
     "\n",
@@ -663,11 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "FYQWSSjKJaWP"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.lib import xla_client\n",
@@ -690,10 +571,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "K98LX-VaJkFu"
-   },
+   "metadata": {},
    "source": [
     "Now we succeed to JIT. Notice below that JAX first evaluates the function\n",
     "abstractly, which triggers the `multiply_add_abstract_eval` function, and \n",
@@ -704,15 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 173
-    },
-    "colab_type": "code",
-    "id": "rj3TLsolJgEc",
-    "outputId": "e384bee4-1e9c-4344-f49c-d3b5ec08eb32"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -735,10 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Omrez-2_KFfo"
-   },
+   "metadata": {},
    "source": [
     "Below is another use of `jit` where we compile only\n",
     "with respect to the first argument. Notice how the second argument to `square_add_prim` is concrete, which leads\n",
@@ -750,15 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 173
-    },
-    "colab_type": "code",
-    "id": "mPfTwIBoKOEK",
-    "outputId": "b293b9b6-a2f9-48f5-f7eb-d4f99c3d905b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -782,10 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_Ya3B5l4J1VA"
-   },
+   "metadata": {},
    "source": [
     "### Forward differentiation\n",
     "\n",
@@ -800,15 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 340
-    },
-    "colab_type": "code",
-    "id": "OxDx6NQnKwMI",
-    "outputId": "ce659ef3-c03c-4856-f252-49ec4b6eb964"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -853,11 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zxG24C1JMIMM"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.interpreters import ad\n",
@@ -910,15 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 357
-    },
-    "colab_type": "code",
-    "id": "ma3KBkiAMfW1",
-    "outputId": "f34cbbc6-20d9-48ca-9a9a-b5d91a972cdd"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -954,26 +790,16 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "69QsEcu-lP4u"
-   },
+   "metadata": {},
    "source": [
     "TO EXPLAIN: \n",
     "\n",
     "  * Why is JAX using ConcreteArray in square_add_prim? There is no abstract evaluation going on here.\n",
     "  * Not sure how to explain that multiply_add_prim is invoked with ConcreteValue, yet\n",
     "  we do not call the multiply_add_abstract_eval.\n",
-    "  * I think it would be useful to show the jaxpr here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Sb6e3ZAHOPHv"
-   },
-   "source": [
+    "  * I think it would be useful to show the jaxpr here\n",
+    " \n",
+    "\n",
     "#### JIT of forward differentiation\n",
     "\n",
     "We can apply JIT to the forward differentiation function:"
@@ -982,15 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 479
-    },
-    "colab_type": "code",
-    "id": "hg-hzVu-N-hv",
-    "outputId": "38d32067-e152-4046-ad80-7f95a31ba628"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1033,24 +851,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jlZt1_v2mU88"
-   },
+   "metadata": {},
    "source": [
     "Notice that first we evaluate `multiply_add_value_and_jvp` abstractly, which in turn\n",
     "evaluates abstractly both the primal and the tangent evaluation (a total of \n",
     "3 invocations of the `ma` primitive). Then we compile the 3 occurrences\n",
-    "of the primitive."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "555yt6ZIOePB"
-   },
-   "source": [
+    "of the primitive.\n",
+    "\n",
     "### Reverse differentiation\n",
     "\n",
     "If we attempt now to use reverse differentiation we\n",
@@ -1076,15 +883,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 666
-    },
-    "colab_type": "code",
-    "id": "8eAVnexaOjBn",
-    "outputId": "e4ee89cf-ab4a-4505-9817-fa978a2865ab"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1144,22 +943,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "fSHLUMDN26AY"
-   },
+   "metadata": {},
    "source": [
     "The above error is because there is a missing piece for JAX to be able\n",
-    "to use the forward differentiation code to compute reverse differentiation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "3ibDbGF-PjK9"
-   },
-   "source": [
+    "to use the forward differentiation code to compute reverse differentiation. \n",
+    "\n",
     "#### Transposition\n",
     "\n",
     "\n",
@@ -1225,11 +1013,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "JaHxFdkRO42r"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@trace(\"multiply_add_transpose\")\n",
@@ -1275,10 +1059,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "PpChox-Jp7wb"
-   },
+   "metadata": {},
    "source": [
     "Now we can complete the run of the `grad`:"
    ]
@@ -1286,15 +1067,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 581
-    },
-    "colab_type": "code",
-    "id": "PogPKS4MPevd",
-    "outputId": "d33328d4-3e87-45b5-9b31-21ad624b67af"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1341,23 +1114,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "8M1xLCXW4fK7"
-   },
+   "metadata": {},
    "source": [
     "Notice the two calls to `multiply_add_transpose`. They correspond to the two\n",
     "uses of `multiply_add_prim` in the computation of the `output_tangent` in `multiply_add_value_and_jvp`. The first call to transpose corresponds to the \n",
-    "last use of `multiply_add_prim`: `multiply_add_prim(xt, y, ...)` where `y` is the constant 2.0."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "EIJs6FYmPg6c"
-   },
-   "source": [
+    "last use of `multiply_add_prim`: `multiply_add_prim(xt, y, ...)` where `y` is the constant 2.0.\n",
+    "\n",
     "#### JIT of reverse differentiation \n",
     "\n",
     "Notice that the abstract evaluation of the `multiply_add_value_and_jvp` is using only\n",
@@ -1367,15 +1129,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 649
-    },
-    "colab_type": "code",
-    "id": "FZ-JGbWZPq2-",
-    "outputId": "e42b5222-9c3e-4853-e13a-874f6605d178"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1426,10 +1180,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "-3lqPkdQPvl5"
-   },
+   "metadata": {},
    "source": [
     "### Batching\n",
     "\n",
@@ -1440,15 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 360
-    },
-    "colab_type": "code",
-    "id": "hFvBR3I9Pzh3",
-    "outputId": "434608bc-281f-4d3b-83bd-eaaf3b51b1cd"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1491,10 +1234,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gILasMiP6elR"
-   },
+   "metadata": {},
    "source": [
     "We need to tell JAX how to evaluate the batched version of the primitive. In this particular case, the `multiply_add_prim` already operates pointwise for any dimension of input vectors. So the batched version can use the same `multiply_add_prim` implementation."
    ]
@@ -1502,11 +1242,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "KQfeqRIrP7zg"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.interpreters import batching\n",
@@ -1543,15 +1279,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 224
-    },
-    "colab_type": "code",
-    "id": "VwxNk869P_YG",
-    "outputId": "9d22c921-5803-4d33-9e88-b6e439ba9738"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1580,10 +1308,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "NmqLlV1TQDCC"
-   },
+   "metadata": {},
    "source": [
     "#### JIT of batching"
    ]
@@ -1591,15 +1316,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 258
-    },
-    "colab_type": "code",
-    "id": "xqEdXVUgQCTt",
-    "outputId": "9c22fd9c-919c-491d-bbeb-32c241b808fa"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/docs/notebooks/How_JAX_primitives_work.md
+++ b/docs/notebooks/How_JAX_primitives_work.md
@@ -11,8 +11,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"id": "vfxqky4PCUnh", "colab_type": "text"}
-
 # How JAX primitives work
 
 *necula@google.com*, October 2019.
@@ -51,8 +49,6 @@ values and performs the opertions pointwise.
 
 
 
-+++ {"id": "HIJYIHNTD1yI", "colab_type": "text"}
-
 ## Using existing primitives
 
 The easiest way to define new functions is to write them in terms of JAX primitives, or in terms of other
@@ -60,14 +56,6 @@ functions that are themselves written using JAX primitives, e.g., those
 defined in the `jax.lax` module:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 105
-colab_type: code
-id: tbOF0LB0EMne
-outputId: 3fb1c8a7-7a4c-4a3a-f7ff-37b7dc740528
----
 from jax import lax
 from jax import api
 
@@ -85,16 +73,11 @@ print("square_add_lax = ", square_add_lax(2., 10.))
 print("grad(square_add_lax) = ", api.grad(square_add_lax, argnums=0)(2.0, 10.))
 ```
 
-+++ {"id": "Cgv60Wm3E_D5", "colab_type": "text"}
-
 In order to understand how JAX is internally using the primitives,
 we add some helpers for tracing function calls.
 
 ```{code-cell}
 :cellView: form
-:colab: {}
-:colab_type: code
-:id: mQRQGEGiE53K
 
 #@title Helper functions (execute this cell)
 import functools
@@ -167,20 +150,10 @@ class expectNotImplementedError(object):
       return False
 ```
 
-+++ {"id": "Qf4eLrLCFYDl", "colab_type": "text"}
-
 Instead of using `jax.lax` primitives directly, we can use other functions 
 that are already written in terms of those primitives, such as those in `jax.numpy`: 
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 255
-colab_type: code
-id: QhKorz6cFRJb
-outputId: aba3cef3-6bcc-4eb3-c7b3-34e405f2f82a
----
 import jax.numpy as jnp
 import numpy as np
 
@@ -198,8 +171,6 @@ print("\nGradient evaluation:")
 print("grad(square_add_numpy) = ", api.grad(square_add_numpy)(2.0, 10.))
 ```
 
-+++ {"id": "Sg-D8EdeFn4a", "colab_type": "text"}
-
 Notice that in the process of computing `grad`, JAX invokes `square_add_numpy` and
 `multiply_add_numpy` with special arguments `ConcreteArray(...)` (described further 
 below in this colab). 
@@ -210,8 +181,6 @@ that JAX may use to abstract the function execution.
 The JAX traceability property is satisfied as long as the function is written 
 in terms of JAX primitives. 
 
-+++ {"id": "WxrQO7-XGLcg", "colab_type": "text"}
-
 ## Defining new JAX primitives
 
 The right way to add support for multiply-add is in terms of existing
@@ -220,10 +189,6 @@ primitives work let us pretend that we want to add a new primitive to
 JAX for the multiply-add functionality.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: cPqAH1XOGTN4
-
 from jax import core
 multiply_add_p = core.Primitive("multiply_add")  # Create the primitive
 
@@ -242,39 +207,17 @@ def square_add_prim(a, b):
   return multiply_add_prim(a, a, b)
 ```
 
-+++ {"id": "LMzs5PAKGr-4", "colab_type": "text"}
-
 If we try to call the newly defined functions we get an error, because
 we have not yet told JAX anything about the semantics of the new primitive.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 221
-colab_type: code
-id: _X3PAYxhGpWd
-outputId: 90ea2c6a-9ef3-40ea-e9a3-3ab1cfc59fc8
----
 with expectNotImplementedError():
   square_add_prim(2., 10.)
 ```
 
-+++ {"id": "elha0FdgHSEF", "colab_type": "text"}
-
 ### Primal evaluation rules
 
-
-
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: FT34FFAGHARU
-outputId: 4c54f1c2-8a50-4788-90e1-06aee412c43b
----
 @trace("multiply_add_impl")
 def multiply_add_impl(x, y, z):
   """Concrete implementation of the primitive.
@@ -294,37 +237,17 @@ multiply_add_p.def_impl(multiply_add_impl)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 119
-colab_type: code
-id: G5bstKaeNAVV
-outputId: deb94d5b-dfea-4e6f-9ec2-70b416c996c5
----
 assert square_add_prim(2., 10.) == 14.
 ```
-
-+++ {"id": "upBf-uAuHhPJ", "colab_type": "text"}
 
 ### JIT
 
 If we now try to use `jit` we get a `NotImplementedError`:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 241
-colab_type: code
-id: QG-LULjiHk4b
-outputId: d4ef4406-8dae-4c96-97ca-b662340474ee
----
 with expectNotImplementedError():
   api.jit(square_add_prim)(2., 10.)
 ```
-
-+++ {"id": "rHS1bAGHH44E", "colab_type": "text"}
 
 #### Abstract evaluation rules
 In order to JIT the function, and for other transformations as well, 
@@ -341,14 +264,6 @@ For example, the abstraction of a vector with 3 elements may be `ShapedArray(flo
 In the latter case, JAX uses the actual concrete value wrapped as an abstract value.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: ctQmEeckIbdo
-outputId: e751d0cc-460e-4ffd-df2e-fdabf9cffdc2
----
 from jax import abstract_arrays
 @trace("multiply_add_abstract_eval")
 def multiply_add_abstract_eval(xs, ys, zs):
@@ -369,25 +284,13 @@ def multiply_add_abstract_eval(xs, ys, zs):
 multiply_add_p.def_abstract_eval(multiply_add_abstract_eval)
 ```
 
-+++ {"id": "RPN88X6YI43A", "colab_type": "text"}
-
 If we re-attempt to JIT, we see how the abstract evaluation proceeds, but
 we get another error, about missing the actual XLA compilation rule:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 309
-colab_type: code
-id: eOcNR92SI2h-
-outputId: 356ef229-3703-4696-cc3d-7c05de405fb0
----
 with expectNotImplementedError():
   api.jit(square_add_prim)(2., 10.)
 ```
-
-+++ {"id": "9IOV1R-fJMHp", "colab_type": "text"}
 
 #### XLA Compilation rules
 
@@ -398,10 +301,6 @@ set of XLA operations is limited, and JAX already has pre-defined primitives
 for most of them. However, XLA includes a `CustomCall` operation that can be used to encapsulate arbitrary functionality defined using C++.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: FYQWSSjKJaWP
-
 from jax.lib import xla_client
 @trace("multiply_add_xla_translation")
 def multiply_add_xla_translation(c, xc, yc, zc):
@@ -420,26 +319,14 @@ from jax.interpreters import xla
 xla.backend_specific_translations['cpu'][multiply_add_p] = multiply_add_xla_translation
 ```
 
-+++ {"id": "K98LX-VaJkFu", "colab_type": "text"}
-
 Now we succeed to JIT. Notice below that JAX first evaluates the function
 abstractly, which triggers the `multiply_add_abstract_eval` function, and 
 then compiles the set of primitives it has encountered, including `multiply_add`.
 At this point JAX invokes `multiply_add_xla_translation`.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 173
-colab_type: code
-id: rj3TLsolJgEc
-outputId: e384bee4-1e9c-4344-f49c-d3b5ec08eb32
----
 assert api.jit(lambda x, y: square_add_prim(x, y))(2., 10.) == 14.
 ```
-
-+++ {"id": "Omrez-2_KFfo", "colab_type": "text"}
 
 Below is another use of `jit` where we compile only
 with respect to the first argument. Notice how the second argument to `square_add_prim` is concrete, which leads
@@ -448,19 +335,9 @@ in the third argument to `multiply_add_abstract_eval` being
 both `ShapedArray` and `ConcreteArray`.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 173
-colab_type: code
-id: mPfTwIBoKOEK
-outputId: b293b9b6-a2f9-48f5-f7eb-d4f99c3d905b
----
 assert api.jit(lambda x, y: square_add_prim(x, y), 
                static_argnums=1)(2., 10.) == 14.
 ```
-
-+++ {"id": "_Ya3B5l4J1VA", "colab_type": "text"}
 
 ### Forward differentiation
 
@@ -472,14 +349,6 @@ error because we have not yet told JAX how to differentiate
 the `multiply_add` primitive.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 340
-colab_type: code
-id: OxDx6NQnKwMI
-outputId: ce659ef3-c03c-4856-f252-49ec4b6eb964
----
 # The second argument `(2., 10.)` are the argument values
 # where we evaluate the Jacobian, and the third `(1., 1.)`
 # are the values of the tangents for the arguments.
@@ -488,10 +357,6 @@ with expectNotImplementedError():
 ```
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: zxG24C1JMIMM
-
 from jax.interpreters import ad
 
 
@@ -540,19 +405,9 @@ ad.primitive_jvps[multiply_add_p] = multiply_add_value_and_jvp
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 357
-colab_type: code
-id: ma3KBkiAMfW1
-outputId: f34cbbc6-20d9-48ca-9a9a-b5d91a972cdd
----
 # Tangent is: xt*y + x*yt + zt = 1.*2. + 2.*1. + 1. = 5.
 assert api.jvp(square_add_prim, (2., 10.), (1., 1.)) == (14., 5.)
 ```
-
-+++ {"id": "69QsEcu-lP4u", "colab_type": "text"}
 
 TO EXPLAIN: 
 
@@ -562,34 +417,20 @@ TO EXPLAIN:
   * I think it would be useful to show the jaxpr here
  
 
-+++ {"id": "Sb6e3ZAHOPHv", "colab_type": "text"}
-
 #### JIT of forward differentiation
 
 We can apply JIT to the forward differentiation function:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 479
-colab_type: code
-id: hg-hzVu-N-hv
-outputId: 38d32067-e152-4046-ad80-7f95a31ba628
----
 assert api.jit(lambda arg_values, arg_tangents: 
                    api.jvp(square_add_prim, arg_values, arg_tangents))(
          (2., 10.), (1., 1.)) == (14., 5.)
 ```
 
-+++ {"id": "jlZt1_v2mU88", "colab_type": "text"}
-
 Notice that first we evaluate `multiply_add_value_and_jvp` abstractly, which in turn
 evaluates abstractly both the primal and the tangent evaluation (a total of 
 3 invocations of the `ma` primitive). Then we compile the 3 occurrences
 of the primitive.
-
-+++ {"id": "555yt6ZIOePB", "colab_type": "text"}
 
 ### Reverse differentiation
 
@@ -613,25 +454,13 @@ value 0.0 as the tangent for the 3rd argument. This is due to the use
 of the `make_zero` function in the definition of `multiply_add_value_and_jvp`.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 666
-colab_type: code
-id: 8eAVnexaOjBn
-outputId: e4ee89cf-ab4a-4505-9817-fa978a2865ab
----
 # This is reverse differentiation w.r.t. the first argument of square_add_prim
 with expectNotImplementedError():
   api.grad(square_add_prim)(2., 10.)
 ```
 
-+++ {"id": "fSHLUMDN26AY", "colab_type": "text"}
-
 The above error is because there is a missing piece for JAX to be able
 to use the forward differentiation code to compute reverse differentiation. 
-
-+++ {"id": "3ibDbGF-PjK9", "colab_type": "text"}
 
 #### Transposition
 
@@ -698,10 +527,6 @@ In particular,
 
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: JaHxFdkRO42r
-
 @trace("multiply_add_transpose")
 def multiply_add_transpose(ct, x, y, z):
   """Evaluates the transpose of a linear primitive.
@@ -743,29 +568,15 @@ def multiply_add_transpose(ct, x, y, z):
 ad.primitive_transposes[multiply_add_p] = multiply_add_transpose
 ```
 
-+++ {"id": "PpChox-Jp7wb", "colab_type": "text"}
-
 Now we can complete the run of the `grad`:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 581
-colab_type: code
-id: PogPKS4MPevd
-outputId: d33328d4-3e87-45b5-9b31-21ad624b67af
----
 assert api.grad(square_add_prim)(2., 10.) == 4.
 ```
-
-+++ {"id": "8M1xLCXW4fK7", "colab_type": "text"}
 
 Notice the two calls to `multiply_add_transpose`. They correspond to the two
 uses of `multiply_add_prim` in the computation of the `output_tangent` in `multiply_add_value_and_jvp`. The first call to transpose corresponds to the 
 last use of `multiply_add_prim`: `multiply_add_prim(xt, y, ...)` where `y` is the constant 2.0.
-
-+++ {"id": "EIJs6FYmPg6c", "colab_type": "text"}
 
 #### JIT of reverse differentiation 
 
@@ -773,18 +584,8 @@ Notice that the abstract evaluation of the `multiply_add_value_and_jvp` is using
 abstract values, while in the absensce of JIT we used `ConcreteArray`.
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 649
-colab_type: code
-id: FZ-JGbWZPq2-
-outputId: e42b5222-9c3e-4853-e13a-874f6605d178
----
 assert api.jit(api.grad(square_add_prim))(2., 10.) == 4.
 ```
-
-+++ {"id": "-3lqPkdQPvl5", "colab_type": "text"}
 
 ### Batching
 
@@ -792,29 +593,15 @@ The batching transformation takes a point-wise computation and turns it
 into a computation on vectors. If we try it right now, we get a `NotImplementedError`:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 360
-colab_type: code
-id: hFvBR3I9Pzh3
-outputId: 434608bc-281f-4d3b-83bd-eaaf3b51b1cd
----
 # The arguments are two vectors instead of two scalars
 with expectNotImplementedError():
   api.vmap(square_add_prim, in_axes=0, out_axes=0)(np.array([2., 3.]),
                                                np.array([10., 20.]))
 ```
 
-+++ {"id": "gILasMiP6elR", "colab_type": "text"}
-
 We need to tell JAX how to evaluate the batched version of the primitive. In this particular case, the `multiply_add_prim` already operates pointwise for any dimension of input vectors. So the batched version can use the same `multiply_add_prim` implementation.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: KQfeqRIrP7zg
-
 from jax.interpreters import batching
 
 
@@ -847,33 +634,15 @@ batching.primitive_batchers[multiply_add_p] = multiply_add_batch
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 224
-colab_type: code
-id: VwxNk869P_YG
-outputId: 9d22c921-5803-4d33-9e88-b6e439ba9738
----
 assert np.allclose(api.vmap(square_add_prim, in_axes=0, out_axes=0)(
   np.array([2., 3.]),
   np.array([10., 20.])),
   [14., 29.])
 ```
 
-+++ {"id": "NmqLlV1TQDCC", "colab_type": "text"}
-
 #### JIT of batching
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 258
-colab_type: code
-id: xqEdXVUgQCTt
-outputId: 9c22fd9c-919c-491d-bbeb-32c241b808fa
----
 assert np.allclose(api.jit(api.vmap(square_add_prim, in_axes=0, out_axes=0))
                     (np.array([2., 3.]),
                      np.array([10., 20.])),

--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "18AF5Ab4p6VL"
-   },
+   "metadata": {},
    "source": [
     "# Training a Simple Neural Network, with PyTorch Data Loading\n",
     "\n",
@@ -20,16 +17,8 @@
     "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
     "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "See the License for the specific language governing permissions and\n",
-    "limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "B_XlLLpcWjkA"
-   },
-   "source": [
+    "limitations under the License.\n",
+    "\n",
     "![JAX](https://raw.githubusercontent.com/google/jax/master/images/jax_logo_250px.png)\n",
     "\n",
     "Let's combine everything we showed in the [quickstart notebook](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb) to train a simple neural network. We will first specify and train a simple MLP on MNIST using JAX for the computation. We will use PyTorch's data loading API to load images and labels (because it's pretty great, and the world doesn't need yet another data loading library).\n",
@@ -40,11 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "OksHydJDtbbI"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -54,10 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MTVcKi-ZYB3R"
-   },
+   "metadata": {},
    "source": [
     "## Hyperparameters\n",
     "Let's get a few bookkeeping items out of the way."
@@ -66,11 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "-fmWA06xYE7d"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# A helper function to randomly initialize weights and biases\n",
@@ -95,10 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "BtoNk_yxWtIw"
-   },
+   "metadata": {},
    "source": [
     "## Auto-batching predictions\n",
     "\n",
@@ -108,11 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7APc6tD7TiuZ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.scipy.special import logsumexp\n",
@@ -134,10 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dRW_TvCTWgaP"
-   },
+   "metadata": {},
    "source": [
     "Let's check that our prediction function only works on single images."
    ]
@@ -145,15 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "4sW2A5mnXHc5",
-    "outputId": "9d3b29e8-fab3-4ecb-9f63-bc8c092f9006"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -173,15 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "PpyQxuedXfhp",
-    "outputId": "d5d20211-b6da-44e9-f71e-946f2a9d0fc4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -203,15 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "oJOOncKMXbwK",
-    "outputId": "31285fab-7667-4871-fcba-28e86adc3fc6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -234,32 +178,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "elsG6nX03BvW"
-   },
+   "metadata": {},
    "source": [
-    "At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "NwDuFqc9X7ER"
-   },
-   "source": [
+    "At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything.\n",
+    "\n",
     "## Utility and loss functions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "6lTI6I4lWdh5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def one_hot(x, k, dtype=jnp.float32):\n",
@@ -284,10 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "umJJGZCC2oKl"
-   },
+   "metadata": {},
    "source": [
     "## Data Loading with PyTorch\n",
     "\n",
@@ -297,15 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 139
-    },
-    "colab_type": "code",
-    "id": "gEvWt8_u2pqG",
-    "outputId": "2c83a679-9ce5-4c67-bccb-9ea835a8eaf6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -327,10 +245,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "cellView": "both",
-    "colab": {},
-    "colab_type": "code",
-    "id": "94PjXZ8y3dVF"
+    "cellView": "both"
    },
    "outputs": [],
    "source": [
@@ -373,11 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "l314jsfP4TN4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -485,15 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 173
-    },
-    "colab_type": "code",
-    "id": "FTNo4beUvb6t",
-    "outputId": "65a9087c-c326-49e5-cbfc-e0839212fa31"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -537,10 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xxPd6Qw3Z98v"
-   },
+   "metadata": {},
    "source": [
     "## Training Loop"
    ]
@@ -548,15 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 425
-    },
-    "colab_type": "code",
-    "id": "X2DnZo3iYj18",
-    "outputId": "0eba3ca2-24a1-4cba-aaf4-3ac61d0c650e"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -608,10 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xC1CMcVNYwxm"
-   },
+   "metadata": {},
    "source": [
     "We've now used the whole of the JAX API: `grad` for derivatives, `jit` for speedups and `vmap` for auto-vectorization.\n",
     "We used NumPy to specify all of our computation, and borrowed the great data loaders from PyTorch, and ran the whole thing on the GPU."

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -12,8 +12,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "18AF5Ab4p6VL"}
-
 # Training a Simple Neural Network, with PyTorch Data Loading
 
 **Copyright 2018 Google LLC.**
@@ -29,34 +27,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-+++ {"colab_type": "text", "id": "B_XlLLpcWjkA"}
-
 ![JAX](https://raw.githubusercontent.com/google/jax/master/images/jax_logo_250px.png)
 
 Let's combine everything we showed in the [quickstart notebook](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb) to train a simple neural network. We will first specify and train a simple MLP on MNIST using JAX for the computation. We will use PyTorch's data loading API to load images and labels (because it's pretty great, and the world doesn't need yet another data loading library).
 
 Of course, you can use JAX with any API that is compatible with NumPy to make specifying the model a bit more plug-and-play. Here, just for explanatory purposes, we won't use any neural network libraries or special APIs for builidng our model.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: OksHydJDtbbI
-
+```{code-cell}
 import jax.numpy as jnp
 from jax import grad, jit, vmap
 from jax import random
 ```
 
-+++ {"colab_type": "text", "id": "MTVcKi-ZYB3R"}
-
 ## Hyperparameters
 Let's get a few bookkeeping items out of the way.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: -fmWA06xYE7d
-
+```{code-cell}
 # A helper function to randomly initialize weights and biases
 # for a dense neural network layer
 def random_layer_params(m, n, key, scale=1e-2):
@@ -77,17 +63,11 @@ n_targets = 10
 params = init_network_params(layer_sizes, random.PRNGKey(0))
 ```
 
-+++ {"colab_type": "text", "id": "BtoNk_yxWtIw"}
-
 ## Auto-batching predictions
 
 Let us first define our prediction function. Note that we're defining this for a _single_ image example. We're going to use JAX's `vmap` function to automatically handle mini-batches, with no performance penalty.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 7APc6tD7TiuZ
-
+```{code-cell}
 from jax.scipy.special import logsumexp
 
 def relu(x):
@@ -105,34 +85,16 @@ def predict(params, image):
   return logits - logsumexp(logits)
 ```
 
-+++ {"colab_type": "text", "id": "dRW_TvCTWgaP"}
-
 Let's check that our prediction function only works on single images.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: 4sW2A5mnXHc5
-outputId: 9d3b29e8-fab3-4ecb-9f63-bc8c092f9006
----
+```{code-cell}
 # This works on single examples
 random_flattened_image = random.normal(random.PRNGKey(1), (28 * 28,))
 preds = predict(params, random_flattened_image)
 print(preds.shape)
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: PpyQxuedXfhp
-outputId: d5d20211-b6da-44e9-f71e-946f2a9d0fc4
----
+```{code-cell}
 # Doesn't work with a batch
 random_flattened_images = random.normal(random.PRNGKey(1), (10, 28 * 28))
 try:
@@ -141,15 +103,7 @@ except TypeError:
   print('Invalid shapes!')
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: oJOOncKMXbwK
-outputId: 31285fab-7667-4871-fcba-28e86adc3fc6
----
+```{code-cell}
 # Let's upgrade it to handle batches using `vmap`
 
 # Make a batched version of the `predict` function
@@ -160,19 +114,11 @@ batched_preds = batched_predict(params, random_flattened_images)
 print(batched_preds.shape)
 ```
 
-+++ {"colab_type": "text", "id": "elsG6nX03BvW"}
-
 At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything.
-
-+++ {"colab_type": "text", "id": "NwDuFqc9X7ER"}
 
 ## Utility and loss functions
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 6lTI6I4lWdh5
-
+```{code-cell}
 def one_hot(x, k, dtype=jnp.float32):
   """Create a one-hot encoding of x of size k."""
   return jnp.array(x[:, None] == jnp.arange(k), dtype)
@@ -193,29 +139,16 @@ def update(params, x, y):
           for (w, b), (dw, db) in zip(params, grads)]
 ```
 
-+++ {"colab_type": "text", "id": "umJJGZCC2oKl"}
-
 ## Data Loading with PyTorch
 
 JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll grab PyTorch's data loader, and make a tiny shim to make it work with NumPy arrays.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 139
-colab_type: code
-id: gEvWt8_u2pqG
-outputId: 2c83a679-9ce5-4c67-bccb-9ea835a8eaf6
----
+```{code-cell}
 !pip install torch torchvision
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :cellView: both
-:colab: {}
-:colab_type: code
-:id: 94PjXZ8y3dVF
 
 import numpy as np
 from torch.utils import data
@@ -253,25 +186,13 @@ class FlattenAndCast(object):
     return np.ravel(np.array(pic, dtype=jnp.float32))
 ```
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: l314jsfP4TN4
-
+```{code-cell}
 # Define our dataset, using torch datasets
 mnist_dataset = MNIST('/tmp/mnist/', download=True, transform=FlattenAndCast())
 training_generator = NumpyLoader(mnist_dataset, batch_size=batch_size, num_workers=0)
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 173
-colab_type: code
-id: FTNo4beUvb6t
-outputId: 65a9087c-c326-49e5-cbfc-e0839212fa31
----
+```{code-cell}
 # Get the full train dataset (for checking accuracy while training)
 train_images = np.array(mnist_dataset.train_data).reshape(len(mnist_dataset.train_data), -1)
 train_labels = one_hot(np.array(mnist_dataset.train_labels), n_targets)
@@ -282,19 +203,9 @@ test_images = jnp.array(mnist_dataset_test.test_data.numpy().reshape(len(mnist_d
 test_labels = one_hot(np.array(mnist_dataset_test.test_labels), n_targets)
 ```
 
-+++ {"colab_type": "text", "id": "xxPd6Qw3Z98v"}
-
 ## Training Loop
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 425
-colab_type: code
-id: X2DnZo3iYj18
-outputId: 0eba3ca2-24a1-4cba-aaf4-3ac61d0c650e
----
+```{code-cell}
 import time
 
 for epoch in range(num_epochs):
@@ -310,8 +221,6 @@ for epoch in range(num_epochs):
   print("Training set accuracy {}".format(train_acc))
   print("Test set accuracy {}".format(test_acc))
 ```
-
-+++ {"colab_type": "text", "id": "xC1CMcVNYwxm"}
 
 We've now used the whole of the JAX API: `grad` for derivatives, `jit` for speedups and `vmap` for auto-vectorization.
 We used NumPy to specify all of our computation, and borrowed the great data loaders from PyTorch, and ran the whole thing on the GPU.

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
@@ -2,21 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "M-hPMKlwXjMr"
-   },
+   "metadata": {},
    "source": [
-    "# Writing custom Jaxpr interpreters in JAX"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "r-3vMiKRYXPJ"
-   },
-   "source": [
+    "# Writing custom Jaxpr interpreters in JAX\n",
+    "\n",
     "JAX offers several composable function transformations (`jit`, `grad`, `vmap`,\n",
     "etc.) that enable writing concise, accelerated code. \n",
     "\n",
@@ -28,11 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "s27RDKvKXFL8"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -44,32 +29,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jb_8mEsJboVM"
-   },
+   "metadata": {},
    "source": [
-    "## What is JAX doing?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KxR2WK0Ubs0R"
-   },
-   "source": [
+    "## What is JAX doing?\n",
+    "\n",
     "JAX provides a NumPy-like API for numerical computing which can be used as is, but JAX's true power comes from composable function transformations. Take the `jit` function transformation, which takes in a function and returns a semantically identical function but is lazily compiled by XLA for accelerators."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "HmlMcICOcSXR"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = random.normal(random.PRNGKey(0), (5000, 5000))\n",
@@ -80,35 +50,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gA8V51wZdsjh"
-   },
+   "metadata": {},
    "source": [
-    "When we call `fast_f`, what happens? JAX traces the function and constructs an XLA computation graph. The graph is then JIT-compiled and executed. Other transformations work similarly in that they first trace the function and handle the output trace in some way. To learn more about Jax's tracing machinery, you can refer to the [\"How it works\"](https://github.com/google/jax#how-it-works) section in the README."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "2Th1vYLVaFBz"
-   },
-   "source": [
+    "When we call `fast_f`, what happens? JAX traces the function and constructs an XLA computation graph. The graph is then JIT-compiled and executed. Other transformations work similarly in that they first trace the function and handle the output trace in some way. To learn more about Jax's tracing machinery, you can refer to the [\"How it works\"](https://github.com/google/jax#how-it-works) section in the README.\n",
+    "\n",
     "## Jaxpr tracer\n",
     "\n",
     "A tracer of special importance in Jax is the Jaxpr tracer, which records ops into a Jaxpr (Jax expression). A Jaxpr is a data structure that can be evaluated like a mini functional programming language and \n",
     "thus Jaxprs are a useful intermediate representation\n",
-    "for function transformation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "pH7s63lpaHJO"
-   },
-   "source": [
+    "for function transformation. \n",
+    "\n",
+    "\n",
     "To get a first look at Jaxprs, consider the `make_jaxpr` transformation. `make_jaxpr` is essentially a \"pretty-printing\" transformation:\n",
     "it transforms a function into one that, given example arguments, produces a Jaxpr representation of its computation.\n",
     "Although we can't generally use the Jaxprs that it returns, it is useful for debugging and introspection.\n",
@@ -119,11 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "RSxEiWi-EeYW"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def examine_jaxpr(typed_jaxpr):\n",
@@ -153,56 +101,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "k-HxK9iagnH6"
-   },
+   "metadata": {},
    "source": [
     "* `jaxpr.invars` - the `invars` of a Jaxpr are a list of the input variables to Jaxpr, analogous to arguments in Python functions\n",
     "* `jaxpr.outvars` - the `outvars` of a Jaxpr are the variables that are returned by the Jaxpr. Every Jaxpr has multiple outputs.\n",
     "* `jaxpr.constvars` - the `constvars` are a list of variables that are also inputs to the Jaxpr, but correspond to constants from the trace (we'll go over these in more detail later)\n",
     "* `jaxpr.eqns` - a list of equations, which are essentially let-bindings. Each equation is list of input variables, a list of output variables, and a *primitive*, which is used to evaluate inputs to produce outputs. Each equation also has a `params`, a dictionary of parameters.\n",
     "\n",
-    "All together, a Jaxpr encapsulates a simple program that can be evaluated with inputs to produce an output. We'll go over how exactly to do this later. The important thing to note now is that a Jaxpr is a data structure that can be manipulated and evaluated in whatever way we want."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "NwY7TurYn6sr"
-   },
-   "source": [
-    "### Why are Jaxprs useful?"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UEy6RorCgdYt"
-   },
-   "source": [
-    "Jaxprs are simple program representations that are easy to transform. And because Jax lets us stage out Jaxprs from Python functions, it gives us a way to transform numerical programs written in Python."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qizTKpbno_ua"
-   },
-   "source": [
-    "## Your first interpreter: `invert`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "OIto-KX4pD7j"
-   },
-   "source": [
+    "All together, a Jaxpr encapsulates a simple program that can be evaluated with inputs to produce an output. We'll go over how exactly to do this later. The important thing to note now is that a Jaxpr is a data structure that can be manipulated and evaluated in whatever way we want.\n",
+    "\n",
+    "### Why are Jaxprs useful?\n",
+    "\n",
+    "Jaxprs are simple program representations that are easy to transform. And because Jax lets us stage out Jaxprs from Python functions, it gives us a way to transform numerical programs written in Python.\n",
+    "\n",
+    "## Your first interpreter: `invert`\n",
+    "\n",
     "Let's try to implement a simple function \"inverter\", which takes in the output of the original function and returns the inputs that produced those outputs. For now, let's focus on simple, unary functions which are composed of other invertible unary functions.\n",
     "\n",
     "Goal:\n",
@@ -223,11 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "BHkg_3P1pXJj"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Importing Jax functions useful for tracing/interpreting.\n",
@@ -241,10 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "CpTml2PTrzZ4"
-   },
+   "metadata": {},
    "source": [
     "This function first flattens its arguments into a list, which are the abstracted and wrapped as partial values. The `pe.trace_to_jaxpr` function is used to then trace a function into a Jaxpr\n",
     "from a list of partial value inputs."
@@ -253,11 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Tc1REN5aq_fH"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def f(x):\n",
@@ -270,10 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WmZ3BcmZsbfR"
-   },
+   "metadata": {},
    "source": [
     "### 2. Evaluating a Jaxpr\n",
     "\n",
@@ -286,11 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "ACMxjIHStHwD"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def eval_jaxpr(jaxpr, consts, *args):\n",
@@ -329,11 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "mGHPc3NruCFV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "closed_jaxpr = jax.make_jaxpr(f)(jnp.ones(5))\n",
@@ -342,23 +233,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "XhZhzbVBvAiT"
-   },
+   "metadata": {},
    "source": [
     "Notice that `eval_jaxpr` will always return a flat list even if the original function does not.\n",
     "\n",
-    "Furthermore, this interpreter does not handle `subjaxprs`, which we will not cover in this guide. You can refer to `core.eval_jaxpr` ([link](https://github.com/google/jax/blob/master/jax/core.py#L185-L212)) to see the edge cases that this interpreter does not cover."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0vb2ZoGrCMM4"
-   },
-   "source": [
+    "Furthermore, this interpreter does not handle `subjaxprs`, which we will not cover in this guide. You can refer to `core.eval_jaxpr` ([link](https://github.com/google/jax/blob/master/jax/core.py#L185-L212)) to see the edge cases that this interpreter does not cover.\n",
+    "\n",
+    "\n",
     "### Custom `inverse` Jaxpr interpreter\n",
     "\n",
     "An `inverse` interpreter doesn't look too different from `eval_jaxpr`. We'll first set up the registry which will map primitives to their inverses. We'll then write a custom interpreter that looks up primitives in the registry.\n",
@@ -369,11 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "gSMIT2z1vUpO"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "inverse_registry = {}"
@@ -381,10 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "JgrpMgDyCrC7"
-   },
+   "metadata": {},
    "source": [
     "We'll now register inverses for some of the primitives. By convention, primitives in Jax end in `_p` and a lot of the popular ones live in `lax`."
    ]
@@ -392,11 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "fUerorGkCqhw"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "inverse_registry[lax.exp_p] = jnp.log\n",
@@ -405,10 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mDtH_lYDC5WK"
-   },
+   "metadata": {},
    "source": [
     "`inverse` will first trace the function, then custom-interpret the Jaxpr. Let's set up a simple skeleton."
    ]
@@ -416,11 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "jGNfV6JJC1B3"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def inverse(fun):\n",
@@ -437,10 +300,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "g6v6wV7SDM7g"
-   },
+   "metadata": {},
    "source": [
     "Now we just need to define `inverse_jaxpr`, which will walk through the Jaxpr backward and invert primitives when it can."
    ]
@@ -448,11 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "uUAd-L-BDKT5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def inverse_jaxpr(jaxpr, consts, *args):\n",
@@ -486,10 +342,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "M8i3wGbVERhA"
-   },
+   "metadata": {},
    "source": [
     "That's it!"
    ]
@@ -497,11 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "cjEKWso-D5Bu"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def f(x):\n",
@@ -513,10 +362,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Ny7Oo4WLHdXt"
-   },
+   "metadata": {},
    "source": [
     "Importantly, you can trace through a Jaxpr interpreter."
    ]
@@ -524,11 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "j6ov_rveHmTb"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "jax.make_jaxpr(inverse(f))(f(1.))"
@@ -536,10 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yfWVBsKwH0j6"
-   },
+   "metadata": {},
    "source": [
     "That's all it takes to add a new transformation to a system, and you get composition with all the others for free! For example, we can use `jit`, `vmap`, and `grad` with `inverse`!"
    ]
@@ -547,11 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "3tjNk21CH4yZ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "jit(vmap(grad(inverse(f))))((jnp.arange(5) + 1.) / 5.)"
@@ -559,10 +394,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "APtG-u_6E4tK"
-   },
+   "metadata": {},
    "source": [
     "## Exercises for the reader\n",
     "\n",

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.md
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.md
@@ -12,11 +12,7 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "M-hPMKlwXjMr"}
-
 # Writing custom Jaxpr interpreters in JAX
-
-+++ {"colab_type": "text", "id": "r-3vMiKRYXPJ"}
 
 JAX offers several composable function transformations (`jit`, `grad`, `vmap`,
 etc.) that enable writing concise, accelerated code. 
@@ -25,11 +21,7 @@ Here we show how to add your own function transformations to the system, by writ
 
 **This example uses internal JAX APIs, which may break at any time. Anything not in [the API Documentation](https://jax.readthedocs.io/en/latest/jax.html) should be assumed internal.**
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: s27RDKvKXFL8
-
+```{code-cell}
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -37,30 +29,18 @@ from jax import jit, grad, vmap
 from jax import random
 ```
 
-+++ {"colab_type": "text", "id": "jb_8mEsJboVM"}
-
 ## What is JAX doing?
-
-+++ {"colab_type": "text", "id": "KxR2WK0Ubs0R"}
 
 JAX provides a NumPy-like API for numerical computing which can be used as is, but JAX's true power comes from composable function transformations. Take the `jit` function transformation, which takes in a function and returns a semantically identical function but is lazily compiled by XLA for accelerators.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: HmlMcICOcSXR
-
+```{code-cell}
 x = random.normal(random.PRNGKey(0), (5000, 5000))
 def f(w, b, x):
   return jnp.tanh(jnp.dot(x, w) + b)
 fast_f = jit(f)
 ```
 
-+++ {"colab_type": "text", "id": "gA8V51wZdsjh"}
-
 When we call `fast_f`, what happens? JAX traces the function and constructs an XLA computation graph. The graph is then JIT-compiled and executed. Other transformations work similarly in that they first trace the function and handle the output trace in some way. To learn more about Jax's tracing machinery, you can refer to the ["How it works"](https://github.com/google/jax#how-it-works) section in the README.
-
-+++ {"colab_type": "text", "id": "2Th1vYLVaFBz"}
 
 ## Jaxpr tracer
 
@@ -69,19 +49,13 @@ thus Jaxprs are a useful intermediate representation
 for function transformation. 
 
 
-+++ {"colab_type": "text", "id": "pH7s63lpaHJO"}
-
 To get a first look at Jaxprs, consider the `make_jaxpr` transformation. `make_jaxpr` is essentially a "pretty-printing" transformation:
 it transforms a function into one that, given example arguments, produces a Jaxpr representation of its computation.
 Although we can't generally use the Jaxprs that it returns, it is useful for debugging and introspection.
 Let's use it to look at how some example Jaxprs
 are structured.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: RSxEiWi-EeYW
-
+```{code-cell}
 def examine_jaxpr(typed_jaxpr):
   jaxpr = typed_jaxpr.jaxpr
   print("invars:", jaxpr.invars)
@@ -107,8 +81,6 @@ print("=====")
 examine_jaxpr(jax.make_jaxpr(bar)(jnp.ones((5, 10)), jnp.ones(5), jnp.ones(10)))
 ```
 
-+++ {"colab_type": "text", "id": "k-HxK9iagnH6"}
-
 * `jaxpr.invars` - the `invars` of a Jaxpr are a list of the input variables to Jaxpr, analogous to arguments in Python functions
 * `jaxpr.outvars` - the `outvars` of a Jaxpr are the variables that are returned by the Jaxpr. Every Jaxpr has multiple outputs.
 * `jaxpr.constvars` - the `constvars` are a list of variables that are also inputs to the Jaxpr, but correspond to constants from the trace (we'll go over these in more detail later)
@@ -116,19 +88,11 @@ examine_jaxpr(jax.make_jaxpr(bar)(jnp.ones((5, 10)), jnp.ones(5), jnp.ones(10)))
 
 All together, a Jaxpr encapsulates a simple program that can be evaluated with inputs to produce an output. We'll go over how exactly to do this later. The important thing to note now is that a Jaxpr is a data structure that can be manipulated and evaluated in whatever way we want.
 
-+++ {"colab_type": "text", "id": "NwY7TurYn6sr"}
-
 ### Why are Jaxprs useful?
-
-+++ {"colab_type": "text", "id": "UEy6RorCgdYt"}
 
 Jaxprs are simple program representations that are easy to transform. And because Jax lets us stage out Jaxprs from Python functions, it gives us a way to transform numerical programs written in Python.
 
-+++ {"colab_type": "text", "id": "qizTKpbno_ua"}
-
 ## Your first interpreter: `invert`
-
-+++ {"colab_type": "text", "id": "OIto-KX4pD7j"}
 
 Let's try to implement a simple function "inverter", which takes in the output of the original function and returns the inputs that produced those outputs. For now, let's focus on simple, unary functions which are composed of other invertible unary functions.
 
@@ -146,11 +110,7 @@ The way we'll implement this is by (1) tracing `f` into a Jaxpr, then (2) interp
 
 We can't use `make_jaxpr` for this, because we need to pull out constants created during the trace to pass into the Jaxpr. However, we can write a function that does something very similar to `make_jaxpr`.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: BHkg_3P1pXJj
-
+```{code-cell}
 # Importing Jax functions useful for tracing/interpreting.
 import numpy as np
 from functools import wraps
@@ -160,16 +120,10 @@ from jax import lax
 from jax._src.util import safe_map
 ```
 
-+++ {"colab_type": "text", "id": "CpTml2PTrzZ4"}
-
 This function first flattens its arguments into a list, which are the abstracted and wrapped as partial values. The `pe.trace_to_jaxpr` function is used to then trace a function into a Jaxpr
 from a list of partial value inputs.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: Tc1REN5aq_fH
-
+```{code-cell}
 def f(x):
   return jnp.exp(jnp.tanh(x))
 
@@ -178,8 +132,6 @@ print(closed_jaxpr)
 print(closed_jaxpr.literals)
 ```
 
-+++ {"colab_type": "text", "id": "WmZ3BcmZsbfR"}
-
 ### 2. Evaluating a Jaxpr
 
 
@@ -187,11 +139,7 @@ Before we write a custom Jaxpr interpreter, let's first implement the "default" 
 
 To do this, we first create an environment to store the values for each of the variables, and update the environment with each equation we evaluate in the Jaxpr.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: ACMxjIHStHwD
-
+```{code-cell}
 def eval_jaxpr(jaxpr, consts, *args):
   # Mapping from variable -> value
   env = {}
@@ -225,22 +173,14 @@ def eval_jaxpr(jaxpr, consts, *args):
   return safe_map(read, jaxpr.outvars) 
 ```
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: mGHPc3NruCFV
-
+```{code-cell}
 closed_jaxpr = jax.make_jaxpr(f)(jnp.ones(5))
 eval_jaxpr(closed_jaxpr.jaxpr, closed_jaxpr.literals, jnp.ones(5))
 ```
 
-+++ {"colab_type": "text", "id": "XhZhzbVBvAiT"}
-
 Notice that `eval_jaxpr` will always return a flat list even if the original function does not.
 
 Furthermore, this interpreter does not handle `subjaxprs`, which we will not cover in this guide. You can refer to `core.eval_jaxpr` ([link](https://github.com/google/jax/blob/master/jax/core.py#L185-L212)) to see the edge cases that this interpreter does not cover.
-
-+++ {"colab_type": "text", "id": "0vb2ZoGrCMM4"}
 
 
 ### Custom `inverse` Jaxpr interpreter
@@ -249,36 +189,20 @@ An `inverse` interpreter doesn't look too different from `eval_jaxpr`. We'll fir
 
 It turns out that this interpreter will also look similar to the "transpose" interpreter used in reverse-mode autodifferentiation [found here](https://github.com/google/jax/blob/master/jax/interpreters/ad.py#L141-L187).
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: gSMIT2z1vUpO
-
+```{code-cell}
 inverse_registry = {}
 ```
 
-+++ {"colab_type": "text", "id": "JgrpMgDyCrC7"}
-
 We'll now register inverses for some of the primitives. By convention, primitives in Jax end in `_p` and a lot of the popular ones live in `lax`.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: fUerorGkCqhw
-
+```{code-cell}
 inverse_registry[lax.exp_p] = jnp.log
 inverse_registry[lax.tanh_p] = jnp.arctanh
 ```
 
-+++ {"colab_type": "text", "id": "mDtH_lYDC5WK"}
-
 `inverse` will first trace the function, then custom-interpret the Jaxpr. Let's set up a simple skeleton.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: jGNfV6JJC1B3
-
+```{code-cell}
 def inverse(fun):
   @wraps(fun)
   def wrapped(*args, **kwargs):
@@ -291,15 +215,9 @@ def inverse(fun):
   return wrapped
 ```
 
-+++ {"colab_type": "text", "id": "g6v6wV7SDM7g"}
-
 Now we just need to define `inverse_jaxpr`, which will walk through the Jaxpr backward and invert primitives when it can.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: uUAd-L-BDKT5
-
+```{code-cell}
 def inverse_jaxpr(jaxpr, consts, *args):
   env = {}
   
@@ -329,15 +247,9 @@ def inverse_jaxpr(jaxpr, consts, *args):
   return safe_map(read, jaxpr.invars)
 ```
 
-+++ {"colab_type": "text", "id": "M8i3wGbVERhA"}
-
 That's it!
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: cjEKWso-D5Bu
-
+```{code-cell}
 def f(x):
   return jnp.exp(jnp.tanh(x))
 
@@ -345,31 +257,17 @@ f_inv = inverse(f)
 assert jnp.allclose(f_inv(f(1.0)), 1.0)
 ```
 
-+++ {"colab_type": "text", "id": "Ny7Oo4WLHdXt"}
-
 Importantly, you can trace through a Jaxpr interpreter.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: j6ov_rveHmTb
-
+```{code-cell}
 jax.make_jaxpr(inverse(f))(f(1.))
 ```
 
-+++ {"colab_type": "text", "id": "yfWVBsKwH0j6"}
-
 That's all it takes to add a new transformation to a system, and you get composition with all the others for free! For example, we can use `jit`, `vmap`, and `grad` with `inverse`!
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 3tjNk21CH4yZ
-
+```{code-cell}
 jit(vmap(grad(inverse(f))))((jnp.arange(5) + 1.) / 5.)
 ```
-
-+++ {"colab_type": "text", "id": "APtG-u_6E4tK"}
 
 ## Exercises for the reader
 

--- a/docs/notebooks/XLA_in_Python.ipynb
+++ b/docs/notebooks/XLA_in_Python.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "sAgUgR5Mzzz2"
-   },
+   "metadata": {},
    "source": [
     "# XLA in Python\n",
     "\n",
@@ -18,15 +16,8 @@
     "\n",
     "As end users we interact with the computational primitives offered to us by the HLO spec.\n",
     "\n",
-    "# Caution:  This is a pedagogical notebook covering some low level XLA details, the APIs herein are neither public nor stable!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "EZK5RseuvZkr"
-   },
-   "source": [
+    "# Caution:  This is a pedagogical notebook covering some low level XLA details, the APIs herein are neither public nor stable!\n",
+    "\n",
     "## References \n",
     "\n",
     "__xla__: the doc that defines what's in HLO - but note that the doc is incomplete and omits some ops.\n",
@@ -49,24 +40,15 @@
     "\n",
     "https://github.com/google/jax/blob/master/jax/lib/xla_bridge.py\n",
     "\n",
-    "https://github.com/google/jax/blob/master/jax/interpreters/xla.py"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3XR2NGmrzBGe"
-   },
-   "source": [
+    "https://github.com/google/jax/blob/master/jax/interpreters/xla.py\n",
+    "\n",
     "## Colab Setup and Imports"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "id": "Ogo2SBd3u18P"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -87,9 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "odmjXyhMuNJ5"
-   },
+   "metadata": {},
    "source": [
     "## Simple Computations"
    ]
@@ -97,13 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "UYUtxVzMYIiv",
-    "outputId": "5c603ab4-0295-472c-b462-9928b2a9520d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -154,13 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "rIA-IVMVvQs2",
-    "outputId": "a4d8ef32-43f3-4a48-f732-e85e158b602e"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -204,9 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "F8kWlLaVuQ1b"
-   },
+   "metadata": {},
    "source": [
     "## Simple While Loop"
    ]
@@ -214,13 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "MDQP1qW515Ao",
-    "outputId": "53245817-b5fb-4285-ee62-7eb33a822be4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -281,9 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7UOnXlY8slI6"
-   },
+   "metadata": {},
    "source": [
     "## While loops w/ Tuples - Newton's Method for sqrt"
    ]
@@ -291,13 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "HEWz-vzd6QPR",
-    "outputId": "ad4c4247-8e81-4739-866f-2950fec5e759"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -374,19 +326,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "yETVIzTInFYr"
-   },
+   "metadata": {},
    "source": [
-    "## Calculate Symm Eigenvalues"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "AiyR1e2NubKa"
-   },
-   "source": [
+    "## Calculate Symm Eigenvalues\n",
+    "\n",
     "Let's exploit the XLA QR implementation to solve some eigenvalues for symmetric matrices.  \n",
     "\n",
     "This is the naive QR algorithm, without acceleration for closely-spaced eigenvalue convergence, nor any permutation to sort eigenvalues by magnitude."
@@ -395,14 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 451
-    },
-    "id": "wjxDPbqCcuXT",
-    "outputId": "2380db52-799d-494e-ded2-856e91f01b0f"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -497,33 +433,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "FpggTihknAOw"
-   },
+   "metadata": {},
    "source": [
-    "## Calculate Full Symm Eigensystem"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "Qos4ankYuj1T"
-   },
-   "source": [
+    "## Calculate Full Symm Eigensystem\n",
+    "\n",
     "We can also calculate the  eigenbasis by accumulating the Qs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 979
-    },
-    "id": "Kp3A-aAiZk0g",
-    "outputId": "bbaff039-20f4-45cd-b8fe-5a664d413f5b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -656,9 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Ee3LMzOvlCuK"
-   },
+   "metadata": {},
    "source": [
     "## Convolutions\n",
     "\n",
@@ -668,9 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "id": "9xh6yeXKS9Vg"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Here we borrow convenience functions from LAX to handle conv dimension numbers.\n",
@@ -710,14 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 110
-    },
-    "id": "J8QkirDalBse",
-    "outputId": "543a03fd-f038-46f2-9a76-a6532b86874e"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -815,9 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9-0PJlqv237S"
-   },
+   "metadata": {},
    "source": [
     "## Fin \n",
     "\n",

--- a/docs/notebooks/XLA_in_Python.md
+++ b/docs/notebooks/XLA_in_Python.md
@@ -12,8 +12,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"id": "sAgUgR5Mzzz2"}
-
 # XLA in Python
 
 <img style="height:100px;" src="https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/compiler/xla/g3doc/images/xlalogo.png"> <img style="height:100px;" src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg">
@@ -27,8 +25,6 @@ XLA computations are built as computation graphs in HLO IR, which is then lowere
 As end users we interact with the computational primitives offered to us by the HLO spec.
 
 # Caution:  This is a pedagogical notebook covering some low level XLA details, the APIs herein are neither public nor stable!
-
-+++ {"id": "EZK5RseuvZkr"}
 
 ## References 
 
@@ -54,13 +50,9 @@ https://github.com/google/jax/blob/master/jax/lib/xla_bridge.py
 
 https://github.com/google/jax/blob/master/jax/interpreters/xla.py
 
-+++ {"id": "3XR2NGmrzBGe"}
-
 ## Colab Setup and Imports
 
-```{code-cell} ipython3
-:id: Ogo2SBd3u18P
-
+```{code-cell}
 import numpy as np
 
 # We only need to import JAX's xla_client, not all of JAX.
@@ -77,17 +69,9 @@ rcParams['image.cmap'] = 'viridis'
 rcParams['axes.grid'] = False
 ```
 
-+++ {"id": "odmjXyhMuNJ5"}
-
 ## Simple Computations
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: UYUtxVzMYIiv
-outputId: 5c603ab4-0295-472c-b462-9928b2a9520d
----
+```{code-cell}
 # make a computation builder
 c = xc.XlaBuilder("simple_scalar")
 
@@ -120,13 +104,7 @@ device_out = compiled_computation.execute([device_input ,])
 device_out[0].to_py()
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: rIA-IVMVvQs2
-outputId: a4d8ef32-43f3-4a48-f732-e85e158b602e
----
+```{code-cell}
 # same as above with vector type:
 
 c = xc.XlaBuilder("simple_vector")
@@ -153,17 +131,9 @@ device_out = compiled_computation.execute([device_input ,])
 device_out[0].to_py()
 ```
 
-+++ {"id": "F8kWlLaVuQ1b"}
-
 ## Simple While Loop
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: MDQP1qW515Ao
-outputId: 53245817-b5fb-4285-ee62-7eb33a822be4
----
+```{code-cell}
 # trivial while loop, decrement until 0
 #   x = 5
 #   while x > 0:
@@ -207,17 +177,9 @@ device_out = compiled_computation.execute([device_input ,])
 device_out[0].to_py()
 ```
 
-+++ {"id": "7UOnXlY8slI6"}
-
 ## While loops w/ Tuples - Newton's Method for sqrt
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: HEWz-vzd6QPR
-outputId: ad4c4247-8e81-4739-866f-2950fec5e759
----
+```{code-cell}
 Xsqr = 2
 guess = 1.0
 converged_delta = 0.001
@@ -282,24 +244,13 @@ device_out = compiled_computation.execute([device_input_y, device_input_x, devic
 print("square root of {y} is {x}".format(y=y, x=device_out[1].to_py()))
 ```
 
-+++ {"id": "yETVIzTInFYr"}
-
 ## Calculate Symm Eigenvalues
-
-+++ {"id": "AiyR1e2NubKa"}
 
 Let's exploit the XLA QR implementation to solve some eigenvalues for symmetric matrices.  
 
 This is the naive QR algorithm, without acceleration for closely-spaced eigenvalue convergence, nor any permutation to sort eigenvalues by magnitude.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 451
-id: wjxDPbqCcuXT
-outputId: 2380db52-799d-494e-ded2-856e91f01b0f
----
+```{code-cell}
 Niter = 200
 matrix_shape = (10, 10)
 
@@ -360,22 +311,11 @@ print('sorted error')
 print(np.sort(eigh_vals) - np.sort(np.linalg.eigh(X)[0]))
 ```
 
-+++ {"id": "FpggTihknAOw"}
-
 ## Calculate Full Symm Eigensystem
-
-+++ {"id": "Qos4ankYuj1T"}
 
 We can also calculate the  eigenbasis by accumulating the Qs.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 979
-id: Kp3A-aAiZk0g
-outputId: bbaff039-20f4-45cd-b8fe-5a664d413f5b
----
+```{code-cell}
 Niter = 100
 matrix_shape = (10, 10)
 
@@ -448,15 +388,11 @@ print('sorted error')
 print(np.sort(eigh_vals) - np.sort(np.linalg.eigh(X)[0]))
 ```
 
-+++ {"id": "Ee3LMzOvlCuK"}
-
 ## Convolutions
 
 I keep hearing from the AGI folks that we can use convolutions to build artificial life.  Let's try it out.
 
-```{code-cell} ipython3
-:id: 9xh6yeXKS9Vg
-
+```{code-cell}
 # Here we borrow convenience functions from LAX to handle conv dimension numbers.
 from typing import NamedTuple, Sequence
 
@@ -491,14 +427,7 @@ def _conv_general_proto(dimension_numbers):
   return proto
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 110
-id: J8QkirDalBse
-outputId: 543a03fd-f038-46f2-9a76-a6532b86874e
----
+```{code-cell}
 Niter=13
 matrix_shape = (1, 1, 20, 20)
 in_shape_0 = xc.Shape.array_shape(np.dtype(np.int32), matrix_shape)
@@ -577,8 +506,6 @@ for i in range(Niter):
   ax1.imshow(movie[i])
 plt.subplots_adjust(left=0.0, right=1.0, top=1.0, bottom=0.0, hspace=0.0, wspace=0.05)
 ```
-
-+++ {"id": "9-0PJlqv237S"}
 
 ## Fin 
 

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -2,9 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Ic1reB4s6vu1"
-   },
+   "metadata": {},
    "source": [
     "# The Autodiff Cookbook\n",
     "\n",
@@ -16,9 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "id": "JTYyZkSO6vuy"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -30,19 +26,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "YxnjtAGN6vu2"
-   },
+   "metadata": {},
    "source": [
-    "## Gradients"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "zqwpfr2vAsvt"
-   },
-   "source": [
+    "## Gradients\n",
+    "\n",
     "### Starting with `grad`\n",
     "\n",
     "You can differentiate a function with `grad`:"
@@ -51,13 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "0NLO4Wfknzmk",
-    "outputId": "ec6f5fe3-3d90-4ec9-a405-f3191b6099da"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -74,9 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "LGcNfDntoBZI"
-   },
+   "metadata": {},
    "source": [
     "`grad` takes a function and returns a function. If you have a Python function `f` that evaluates the mathematical function $f$, then `grad(f)` is a Python function that evaluates the mathematical function $\\nabla f$. That means `grad(f)(x)` represents the value $\\nabla f(x)$.\n",
     "\n",
@@ -86,13 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "RDGk1GDsoawu",
-    "outputId": "157bab60-52a8-4ca9-a298-b57561b30032"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -110,9 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "2rcnpTiinqi8"
-   },
+   "metadata": {},
    "source": [
     "Let's look at computing gradients with `grad` in a linear logistic regression model. First, the setup:"
    ]
@@ -120,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "id": "27TcOT2i6vu5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def sigmoid(x):\n",
@@ -153,9 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "8Wk-Yai7ooh1"
-   },
+   "metadata": {},
    "source": [
     "Use the `grad` function with its `argnums` argument to differentiate a function with respect to positional arguments."
    ]
@@ -163,13 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "bpmd8W8-6vu6",
-    "outputId": "5faafcc6-e9c5-4a2d-fc35-5c23e0be2d6d"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -204,43 +165,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "MDl5UZl4oyzB"
-   },
+   "metadata": {},
    "source": [
     "This `grad` API has a direct correspondence to the excellent notation in Spivak's classic *Calculus on Manifolds* (1965), also used in Sussman and Wisdom's [*Structure and Interpretation of Classical Mechanics*](http://mitpress.mit.edu/sites/default/files/titles/content/sicm_edition_2/book.html) (2015) and their [*Functional Differential Geometry*](https://mitpress.mit.edu/books/functional-differential-geometry) (2013). Both books are open-access. See in particular the \"Prologue\" section of *Functional Differential Geometry* for a defense of this notation.\n",
     "\n",
-    "Essentially, when using the `argnums` argument, if `f` is a Python function for evaluating the mathematical function $f$, then the Python expression `grad(f, i)` evaluates to a Python function for evaluating $\\partial_i f$."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "fuz9E2vzro5E"
-   },
-   "source": [
-    "### Differentiating with respect to nested lists, tuples, and dicts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "QQaPja7puMKi"
-   },
-   "source": [
+    "Essentially, when using the `argnums` argument, if `f` is a Python function for evaluating the mathematical function $f$, then the Python expression `grad(f, i)` evaluates to a Python function for evaluating $\\partial_i f$.\n",
+    "\n",
+    "### Differentiating with respect to nested lists, tuples, and dicts\n",
+    "\n",
     "Differentiating with respect to standard Python containers just works, so use tuples, lists, and dicts (and arbitrary nesting) however you like."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "IY82kdAe6vu_",
-    "outputId": "d4004d2d-97ed-4ddc-bb1d-fc4af21edd23"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -261,41 +200,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "cJ2NxiN58bfI"
-   },
+   "metadata": {},
    "source": [
-    "You can [register your own container types](https://github.com/google/jax/issues/446#issuecomment-467105048) to work with not just `grad` but all the JAX transformations (`jit`, `vmap`, etc.)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "PaCHzAtGruBz"
-   },
-   "source": [
-    "### Evaluate a function and its gradient using `value_and_grad`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "CSgCjjo-ssnA"
-   },
-   "source": [
+    "You can [register your own container types](https://github.com/google/jax/issues/446#issuecomment-467105048) to work with not just `grad` but all the JAX transformations (`jit`, `vmap`, etc.).\n",
+    "\n",
+    "### Evaluate a function and its gradient using `value_and_grad`\n",
+    "\n",
     "Another convenient function is `value_and_grad` for efficiently computing both a function's value as well as its gradient's value:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "RsQSyT5p7OJW",
-    "outputId": "c2502c2e-091e-4e9c-ca20-1e0c2670fd7a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -315,9 +232,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "rYTrH5tKllC_"
-   },
+   "metadata": {},
    "source": [
     "### Checking against numerical differences\n",
     "\n",
@@ -327,13 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "R8q5RiY3l7Fw",
-    "outputId": "4f2ccbe9-da9f-438e-9f3e-ad03e3c3e247"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -366,9 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "InzB-iiJpVcx"
-   },
+   "metadata": {},
    "source": [
     "JAX provides a simple convenience function that does essentially the same thing, but checks up to any order of differentiation that you like:"
    ]
@@ -376,9 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "id": "6Ok2LEfQmOuy"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.test_util import check_grads\n",
@@ -387,9 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "id0DXxwt3VJi"
-   },
+   "metadata": {},
    "source": [
     "### Hessian-vector products with `grad`-of-`grad`\n",
     "\n",
@@ -417,9 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "id": "Ou5OU-gU9epm"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def hvp(f, x, v):\n",
@@ -428,43 +329,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Rb1-5Hpv-ZV0"
-   },
+   "metadata": {},
    "source": [
     "This example shows that you can freely use lexical closure, and JAX will never get perturbed or confused.\n",
     "\n",
-    "We'll check this implementation a few cells down, once we see how to compute dense Hessian matrices. We'll also write an even better version that uses both forward-mode and reverse-mode."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "5A_akvtp8UTu"
-   },
-   "source": [
-    "### Jacobians and Hessians using `jacfwd` and `jacrev`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UP5BbmSm8ZwK"
-   },
-   "source": [
+    "We'll check this implementation a few cells down, once we see how to compute dense Hessian matrices. We'll also write an even better version that uses both forward-mode and reverse-mode.\n",
+    "\n",
+    "### Jacobians and Hessians using `jacfwd` and `jacrev`\n",
+    "\n",
     "You can compute full Jacobian matrices using the `jacfwd` and `jacrev` functions:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "cbETzAvKvf5I",
-    "outputId": "7c8d2361-cc68-4139-9f1f-afa2431b3cd2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -500,32 +379,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "iZDL-n_AvgBt"
-   },
+   "metadata": {},
    "source": [
-    "These two functions compute the same values (up to machine numerics), but differ in their implementation: `jacfwd` uses forward-mode automatic differentiation, which is more efficient for \"tall\" Jacobian matrices, while `jacrev` uses reverse-mode, which is more efficient for \"wide\" Jacobian matrices. For matrices that are near-square, `jacfwd` probably has an edge over `jacrev`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "zeKlr7Xz8bfm"
-   },
-   "source": [
+    "These two functions compute the same values (up to machine numerics), but differ in their implementation: `jacfwd` uses forward-mode automatic differentiation, which is more efficient for \"tall\" Jacobian matrices, while `jacrev` uses reverse-mode, which is more efficient for \"wide\" Jacobian matrices. For matrices that are near-square, `jacfwd` probably has an edge over `jacrev`.\n",
+    "\n",
     "You can also use `jacfwd` and `jacrev` with container types:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "eH46Xnm88bfm",
-    "outputId": "ab1f5dce-926e-40b9-9664-5bd5e628e0b5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -553,32 +417,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "yH34zjV88bfp"
-   },
+   "metadata": {},
    "source": [
-    "For more details on forward- and reverse-mode, as well as how to implement `jacfwd` and `jacrev` as efficiently as possible, read on!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "K6Mpw_7K8bfp"
-   },
-   "source": [
+    "For more details on forward- and reverse-mode, as well as how to implement `jacfwd` and `jacrev` as efficiently as possible, read on!\n",
+    "\n",
     "Using a composition of two of these functions gives us a way to compute dense Hessian matrices:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "n155ypD9rfIZ",
-    "outputId": "69622bc4-9a8d-47f1-aab6-40ab21d450d9"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -614,9 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "wvkk82R6uRoM"
-   },
+   "metadata": {},
    "source": [
     "This shape makes sense: if we start with a function $f : \\mathbb{R}^n \\to \\mathbb{R}^m$, then at a point $x \\in \\mathbb{R}^n$ we expect to get the shapes\n",
     "\n",
@@ -626,24 +473,10 @@
     "\n",
     "and so on.\n",
     "\n",
-    "To implement `hessian`, we could have used `jacfwd(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \\mathbb{R}^n \\to \\mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\\nabla f : \\mathbb{R}^n \\to \\mathbb{R}^n$), which is where forward-mode wins out."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "OMmi9cyhs1bj"
-   },
-   "source": [
-    "## How it's made: two foundational autodiff functions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mtSRvouV6vvG"
-   },
-   "source": [
+    "To implement `hessian`, we could have used `jacfwd(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \\mathbb{R}^n \\to \\mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\\nabla f : \\mathbb{R}^n \\to \\mathbb{R}^n$), which is where forward-mode wins out.\n",
+    "\n",
+    "## How it's made: two foundational autodiff functions\n",
+    "\n",
     "### Jacobian-Vector products (JVPs, aka forward-mode autodiff)\n",
     "\n",
     "JAX includes efficient and general implementations of both forward- and reverse-mode automatic differentiation. The familiar `grad` function is built on reverse-mode, but to explain the difference in the two modes, and when each can be useful, we need a bit of math background.\n",
@@ -676,9 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "id": "pTncYR6F6vvG"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jvp\n",
@@ -695,9 +526,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "m1VJgJYQGfCK"
-   },
+   "metadata": {},
    "source": [
     "In terms of Haskell-like type signatures, we could write\n",
     "\n",
@@ -705,15 +534,8 @@
     "jvp :: (a -> b) -> a -> T a -> (b, T b)\n",
     "```\n",
     "\n",
-    "where we use `T a` to denote the type of the tangent space for `a`. In words, `jvp` takes as arguments a function of type `a -> b`, a value of type `a`, and a tangent vector value of type `T a`. It gives back a pair consisting of a value of type `b` and an output tangent vector of type `T b`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "3RpbiasHGD3X"
-   },
-   "source": [
+    "where we use `T a` to denote the type of the tangent space for `a`. In words, `jvp` takes as arguments a function of type `a -> b`, a value of type `a`, and a tangent vector value of type `T a`. It gives back a pair consisting of a value of type `b` and an output tangent vector of type `T b`.\n",
+    "\n",
     "The `jvp`-transformed function is evaluated much like the original function, but paired up with each primal value of type `a` it pushes along tangent values of type `T a`. For each primitive numerical operation that the original function would have applied, the `jvp`-transformed function executes a \"JVP rule\" for that primitive that both evaluates the primitive on the primals and applies the primitive's JVP at those primal values.\n",
     "\n",
     "That evaluation strategy has some immediate implications about computational complexity: since we evaluate JVPs as we go, we don't need to store anything for later, and so the memory cost is independent of the depth of the computation. In addition, the FLOP cost of the `jvp`-transformed function is about 3x the cost of just evaluating the function (one unit of work for evaluating the original function, for example `sin(x)`; one unit for linearizing, like `cos(x)`; and one unit for applying the linearized function to a vector, like `cos_x * v`). Put another way, for a fixed primal point $x$, we can evaluate $v \\mapsto \\partial f(x) \\cdot v$ for about the same marginal cost as evaluating $f$.\n",
@@ -724,15 +546,8 @@
     "\n",
     "If you're doing gradient-based optimization in machine learning, you probably want to minimize a loss function from parameters in $\\mathbb{R}^n$ to a scalar loss value in $\\mathbb{R}$. That means the Jacobian of this function is a very wide matrix: $\\partial f(x) \\in \\mathbb{R}^{1 \\times n}$, which we often identify with the Gradient vector $\\nabla f(x) \\in \\mathbb{R}^n$. Building that matrix one column at a time, with each call taking a similar number of FLOPs to evaluating the original function, sure seems inefficient! In particular, for training neural networks, where $f$ is a training loss function and $n$ can be in the millions or billions, this approach just won't scale.\n",
     "\n",
-    "To do better for functions like this, we just need to use reverse-mode."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "PhkvkZazdXu1"
-   },
-   "source": [
+    "To do better for functions like this, we just need to use reverse-mode.\n",
+    "\n",
     "### Vector-Jacobian products (VJPs, aka reverse-mode autodiff)\n",
     "\n",
     "Where forward-mode gives us back a function for evaluating Jacobian-vector products, which we can then use to build Jacobian matrices one column at a time, reverse-mode is a way to get back a function for evaluating vector-Jacobian products (equivalently Jacobian-transpose-vector products), which we can use to build Jacobian matrices one row at a time.\n",
@@ -765,9 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "id": "1tFcRuEzkGRR"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import vjp\n",
@@ -786,9 +599,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "oVOZexCEkvv3"
-   },
+   "metadata": {},
    "source": [
     "In terms of Haskell-like type signatures, we could write\n",
     "\n",
@@ -840,28 +651,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "MWHcAPqLdJFn"
-   },
+   "metadata": {},
    "source": [
-    "### Hessian-vector products using both forward- and reverse-mode"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "YG3g5C3KdW7H"
-   },
-   "source": [
+    "### Hessian-vector products using both forward- and reverse-mode\n",
+    "\n",
     "In a previous section, we implemented a Hessian-vector product function just using reverse-mode (assuming continuous second derivatives):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "id": "C70CA-7wdelL"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def hvp(f, x, v):\n",
@@ -870,9 +670,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "zJlJbFKCdfd0"
-   },
+   "metadata": {},
    "source": [
     "That's efficient, but we can do even better and save some memory by using forward-mode together with reverse-mode.\n",
     "\n",
@@ -890,9 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "id": "rq3C0reVfAaI"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jvp, grad\n",
@@ -904,9 +700,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "XUsye1SwfSFm"
-   },
+   "metadata": {},
    "source": [
     "Even better, since we didn't have to call `jnp.dot` directly, this `hvp` function works with arrays of any shape and with arbitrary container types (like vectors stored as nested lists/dicts/tuples), and doesn't even have a dependence on `jax.numpy`.\n",
     "\n",
@@ -916,13 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "bmpuQa5_f1Al",
-    "outputId": "20ef2514-0ab7-4071-c2f4-77b59b013ffc"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -948,9 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "aWTii5TyXL5C"
-   },
+   "metadata": {},
    "source": [
     "Another way you might consider writing this is using reverse-over-forward:"
    ]
@@ -958,9 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "id": "YxwmXZH2XQrw"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# reverse-over-forward\n",
@@ -971,9 +755,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "8z-QG_xTXR4I"
-   },
+   "metadata": {},
    "source": [
     "That's not quite as good, though, because forward-mode has less overhead than reverse-mode, and since the outer differentiation operator here has to differentiate a larger computation than the inner one, keeping forward-mode on the outside works best:"
    ]
@@ -981,13 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "lxfv25qTX5gZ",
-    "outputId": "b88dae03-7bd1-4836-f994-880c57bc4714"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1025,19 +801,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "xtqSUJgzwQXO"
-   },
+   "metadata": {},
    "source": [
-    "## Composing VJPs, JVPs, and `vmap`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "PSL1TciM6vvI"
-   },
-   "source": [
+    "## Composing VJPs, JVPs, and `vmap`\n",
+    "\n",
     "### Jacobian-Matrix and Matrix-Jacobian products\n",
     "\n",
     "Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's `vmap` [transformation](https://github.com/google/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products."
@@ -1046,13 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "asAWvxVaCmsx",
-    "outputId": "05d3b5f9-f526-42a4-ea2b-6163b267db26"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1101,13 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "TDaxsJrlDraK",
-    "outputId": "99a7591c-643d-4b91-c0fc-c7a3c73b0de6"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1146,28 +901,18 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "MXFEFBDz6vvL"
-   },
+   "metadata": {},
    "source": [
-    "### The implementation of `jacfwd` and `jacrev`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "ZAgUb6sp8bf7"
-   },
-   "source": [
+    "### The implementation of `jacfwd` and `jacrev`\n",
+    "\n",
+    "\n",
     "Now that we've seen fast Jacobian-matrix and matrix-Jacobian products, it's not hard to guess how to write `jacfwd` and `jacrev`. We just use the same technique to push-forward or pull-back an entire standard basis (isomorphic to an identity matrix) at once."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "id": "HBEzsDH1U5_4"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jacrev as builtin_jacrev\n",
@@ -1188,9 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "id": "Qd9gVZ5t6vvP"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jacfwd as builtin_jacfwd\n",
@@ -1207,32 +950,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7r5_m9Y68bf_"
-   },
+   "metadata": {},
    "source": [
-    "Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) of reverse-mode `jacobian` in Autograd had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9maev0Nd8bf_"
-   },
-   "source": [
+    "Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) of reverse-mode `jacobian` in Autograd had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`.\n",
+    "\n",
     "Another thing that Autograd couldn't do is `jit`. Interestingly, no matter how much Python dynamism you use in your function to be differentiated, we could always use `jit` on the linear part of the computation. For example:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "_5jDflC08bgB",
-    "outputId": "7d37cca8-3954-40b9-bea8-937ac655387c"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1258,19 +986,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "3fPWLrxK8bgD"
-   },
+   "metadata": {},
    "source": [
-    "## Complex numbers and differentiation"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "2pZOHvrm8bgE"
-   },
-   "source": [
+    "## Complex numbers and differentiation\n",
+    "\n",
     "JAX is great at complex numbers and differentiation. To support both [holomorphic and non-holomorphic differentiation](https://en.wikipedia.org/wiki/Holomorphic_function), it helps to think in terms of JVPs and VJPs.\n",
     "\n",
     "Consider a complex-to-complex function $f: \\mathbb{C} \\to \\mathbb{C}$ and identify it with a corresponding function $g: \\mathbb{R}^2 \\to \\mathbb{R}^2$,"
@@ -1279,9 +998,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "id": "OaqZ2MuP8bgF"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def f(z):\n",
@@ -1294,19 +1011,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "3XB5oGxl8bgH"
-   },
+   "metadata": {},
    "source": [
-    "That is, we've decomposed $f(z) = u(x, y) + v(x, y) i$ where $z = x + y i$, and identified $\\mathbb{C}$ with $\\mathbb{R}^2$ to get $g$."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "6fBBMxqpiVjF"
-   },
-   "source": [
+    "That is, we've decomposed $f(z) = u(x, y) + v(x, y) i$ where $z = x + y i$, and identified $\\mathbb{C}$ with $\\mathbb{R}^2$ to get $g$.\n",
+    "\n",
     "Since $g$ only involves real inputs and outputs, we already know how to write a Jacobian-vector product for it, say given a tangent vector $(c, d) \\in \\mathbb{R}^2$, namely\n",
     "\n",
     "$\\begin{bmatrix} \\partial_0 u(x, y) & \\partial_1 u(x, y) \\\\ \\partial_0 v(x, y) & \\partial_1 v(x, y) \\end{bmatrix}\n",
@@ -1319,24 +1027,15 @@
     "\\begin{bmatrix} \\partial_0 u(x, y) & \\partial_1 u(x, y) \\\\ \\partial_0 v(x, y) & \\partial_1 v(x, y) \\end{bmatrix}\n",
     "\\begin{bmatrix} c \\\\ d \\end{bmatrix}$.\n",
     "\n",
-    "That's our definition of the JVP of a $\\mathbb{C} \\to \\mathbb{C}$ function! Notice it doesn't matter whether or not $f$ is holomorphic: the JVP is unambiguous."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "6SL6dWtFpBUr"
-   },
-   "source": [
+    "That's our definition of the JVP of a $\\mathbb{C} \\to \\mathbb{C}$ function! Notice it doesn't matter whether or not $f$ is holomorphic: the JVP is unambiguous.\n",
+    "\n",
     "Here's a check:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "id": "BGZV__zupIMS"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def check(seed):\n",
@@ -1378,13 +1077,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "I2OBU3OGp-CY",
-    "outputId": "28ae844b-0c25-4255-ca9b-598b0dbeb404"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1404,9 +1097,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "XjWMgDOimUcU"
-   },
+   "metadata": {},
    "source": [
     "What about VJPs? We do something pretty similar: for a cotangent vector $c + di \\in \\mathbb{C}$ we define the VJP of $f$ as\n",
     "\n",
@@ -1415,24 +1106,15 @@
     "\\begin{bmatrix} \\partial_0 u(x, y) & \\partial_1 u(x, y) \\\\ \\partial_0 v(x, y) & \\partial_1 v(x, y) \\end{bmatrix}\n",
     "\\begin{bmatrix} 1 \\\\ -i \\end{bmatrix}$.\n",
     "\n",
-    "What's with the negatives? They're just to take care of complex conjugation, and the fact that we're working with covectors."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "oRu2VRjmtrgB"
-   },
-   "source": [
+    "What's with the negatives? They're just to take care of complex conjugation, and the fact that we're working with covectors.\n",
+    "\n",
     "Here's a check of the VJP rules:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {
-    "id": "4J7edvIBttcU"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def check(seed):\n",
@@ -1475,9 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "id": "RieNCdXgtzs7"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "check(0)\n",
@@ -1487,9 +1167,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7I6A19Myt3qN"
-   },
+   "metadata": {},
    "source": [
     "What about convenience wrappers like `grad`, `jacfwd`, and `jacrev`?\n",
     "\n",
@@ -1499,13 +1177,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "xz_9lK61wGdm",
-    "outputId": "96693583-2a36-48fd-d811-cd1a0f1a50c5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1531,9 +1203,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "jqCvEE8qwGw7"
-   },
+   "metadata": {},
    "source": [
     "For geneneral $\\mathbb{C} \\to \\mathbb{C}$ functions, the Jacobian has 4 real-valued degrees of freedom (as in the 2x2 Jacobian matrices above), so we can't hope to represent all of them with in a complex number. But we can for holomorphic functions! A holomorphic function is precisely a $\\mathbb{C} \\to \\mathbb{C}$ function with the special property that its derivative can be represented as a single complex number. (The [Cauchy-Riemann equations](https://en.wikipedia.org/wiki/Cauchy%E2%80%93Riemann_equations) ensure that the above 2x2 Jacobians have the special form of a scale-and-rotate matrix in the complex plane, i.e. the action of a single complex number under multiplication.) And we can reveal that one complex number using a single call to `vjp` with a covector of `1.0`.\n",
     "\n",
@@ -1543,13 +1213,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Y3n9hPVrwvXx",
-    "outputId": "20f72dfe-7083-47f8-b086-4a16426ba97b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1574,9 +1238,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "LjIbDxX-w9Qf"
-   },
+   "metadata": {},
    "source": [
     "All the `holomorphic=True` promise does is disable the error when the output is complex-valued. We can still write `holomorphic=True` when the function isn't holomorphic, but the answer we get out won't represent the full Jacobian. Instead, it'll be the Jacobian of the function where we just discard the imaginary part of the output:"
    ]
@@ -1584,13 +1246,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "th9xhwp2xaeU",
-    "outputId": "2dfebe3a-bbfe-46a1-b282-f5d59d53c772"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1615,9 +1271,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "R8ytpfeXyBu2"
-   },
+   "metadata": {},
    "source": [
     "There are some useful upshots for how `grad` works here:\n",
     "\n",
@@ -1625,28 +1279,15 @@
     "2. We can use `grad` to optimize $f : \\mathbb{C} \\to \\mathbb{R}$ functions, like real-valued loss functions of complex parameters `x`, by taking steps in the dierction of the conjugate of `grad(f)(x)`.\n",
     "3. If we have an $\\mathbb{R} \\to \\mathbb{R}$ function that just happens to use some complex-valued operations internally (some of which must be non-holomorphic, e.g. FFTs used in covolutions) then `grad` still works and we get the same result that an implementation using only real values would have given.\n",
     "\n",
-    "In any case, JVPs and VJPs are always unambiguous. And if we wanted to compute the full Jacobian matrix of a non-holomorphic $\\mathbb{C} \\to \\mathbb{C}$ function, we can do it with JVPs or VJPs!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "qmXkI37T8bgL"
-   },
-   "source": [
+    "In any case, JVPs and VJPs are always unambiguous. And if we wanted to compute the full Jacobian matrix of a non-holomorphic $\\mathbb{C} \\to \\mathbb{C}$ function, we can do it with JVPs or VJPs!\n",
+    "\n",
     "You should expect complex numbers to work everywhere in JAX. Here's differentiating through a Cholesky decomposition of a complex matrix:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 34,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "WrDHHfKI8bgM",
-    "outputId": "c04baa8a-2408-4a76-e3dc-4522782d1bc5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1680,9 +1321,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Pgr2A60q9gl1"
-   },
+   "metadata": {},
    "source": [
     "## More advanced autodiff\n",
     "\n",

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -12,17 +12,13 @@ kernelspec:
   name: python3
 ---
 
-+++ {"id": "Ic1reB4s6vu1"}
-
 # The Autodiff Cookbook
 
 *alexbw@, mattjj@*  
 
 JAX has a pretty general automatic differentiation system. In this notebook, we'll go through a whole bunch of neat autodiff ideas that you can cherry pick for your own work, starting with the basics.
 
-```{code-cell} ipython3
-:id: JTYyZkSO6vuy
-
+```{code-cell}
 import jax.numpy as jnp
 from jax import grad, jit, vmap
 from jax import random
@@ -30,51 +26,29 @@ from jax import random
 key = random.PRNGKey(0)
 ```
 
-+++ {"id": "YxnjtAGN6vu2"}
-
 ## Gradients
-
-+++ {"id": "zqwpfr2vAsvt"}
 
 ### Starting with `grad`
 
 You can differentiate a function with `grad`:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: 0NLO4Wfknzmk
-outputId: ec6f5fe3-3d90-4ec9-a405-f3191b6099da
----
+```{code-cell}
 grad_tanh = grad(jnp.tanh)
 print(grad_tanh(2.0))
 ```
-
-+++ {"id": "LGcNfDntoBZI"}
 
 `grad` takes a function and returns a function. If you have a Python function `f` that evaluates the mathematical function $f$, then `grad(f)` is a Python function that evaluates the mathematical function $\nabla f$. That means `grad(f)(x)` represents the value $\nabla f(x)$.
 
 Since `grad` operates on functions, you can apply it to its own output to differentiate as many times as you like:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: RDGk1GDsoawu
-outputId: 157bab60-52a8-4ca9-a298-b57561b30032
----
+```{code-cell}
 print(grad(grad(jnp.tanh))(2.0))
 print(grad(grad(grad(jnp.tanh)))(2.0))
 ```
 
-+++ {"id": "2rcnpTiinqi8"}
-
 Let's look at computing gradients with `grad` in a linear logistic regression model. First, the setup:
 
-```{code-cell} ipython3
-:id: 27TcOT2i6vu5
-
+```{code-cell}
 def sigmoid(x):
     return 0.5 * (jnp.tanh(x / 2) + 1)
 
@@ -101,17 +75,9 @@ W = random.normal(W_key, (3,))
 b = random.normal(b_key, ())
 ```
 
-+++ {"id": "8Wk-Yai7ooh1"}
-
 Use the `grad` function with its `argnums` argument to differentiate a function with respect to positional arguments.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: bpmd8W8-6vu6
-outputId: 5faafcc6-e9c5-4a2d-fc35-5c23e0be2d6d
----
+```{code-cell}
 # Differentiate `loss` with respect to the first positional argument:
 W_grad = grad(loss, argnums=0)(W, b)
 print('W_grad', W_grad)
@@ -130,27 +96,15 @@ print('W_grad', W_grad)
 print('b_grad', b_grad)
 ```
 
-+++ {"id": "MDl5UZl4oyzB"}
-
 This `grad` API has a direct correspondence to the excellent notation in Spivak's classic *Calculus on Manifolds* (1965), also used in Sussman and Wisdom's [*Structure and Interpretation of Classical Mechanics*](http://mitpress.mit.edu/sites/default/files/titles/content/sicm_edition_2/book.html) (2015) and their [*Functional Differential Geometry*](https://mitpress.mit.edu/books/functional-differential-geometry) (2013). Both books are open-access. See in particular the "Prologue" section of *Functional Differential Geometry* for a defense of this notation.
 
 Essentially, when using the `argnums` argument, if `f` is a Python function for evaluating the mathematical function $f$, then the Python expression `grad(f, i)` evaluates to a Python function for evaluating $\partial_i f$.
 
-+++ {"id": "fuz9E2vzro5E"}
-
 ### Differentiating with respect to nested lists, tuples, and dicts
-
-+++ {"id": "QQaPja7puMKi"}
 
 Differentiating with respect to standard Python containers just works, so use tuples, lists, and dicts (and arbitrary nesting) however you like.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: IY82kdAe6vu_
-outputId: d4004d2d-97ed-4ddc-bb1d-fc4af21edd23
----
+```{code-cell}
 def loss2(params_dict):
     preds = predict(params_dict['W'], params_dict['b'], inputs)
     label_probs = preds * targets + (1 - preds) * (1 - targets)
@@ -159,44 +113,24 @@ def loss2(params_dict):
 print(grad(loss2)({'W': W, 'b': b}))
 ```
 
-+++ {"id": "cJ2NxiN58bfI"}
-
 You can [register your own container types](https://github.com/google/jax/issues/446#issuecomment-467105048) to work with not just `grad` but all the JAX transformations (`jit`, `vmap`, etc.).
-
-+++ {"id": "PaCHzAtGruBz"}
 
 ### Evaluate a function and its gradient using `value_and_grad`
 
-+++ {"id": "CSgCjjo-ssnA"}
-
 Another convenient function is `value_and_grad` for efficiently computing both a function's value as well as its gradient's value:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: RsQSyT5p7OJW
-outputId: c2502c2e-091e-4e9c-ca20-1e0c2670fd7a
----
+```{code-cell}
 from jax import value_and_grad
 loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
 print('loss value', loss(W, b))
 ```
 
-+++ {"id": "rYTrH5tKllC_"}
-
 ### Checking against numerical differences
 
 A great thing about derivatives is that they're straightforward to check with finite differences:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: R8q5RiY3l7Fw
-outputId: 4f2ccbe9-da9f-438e-9f3e-ad03e3c3e247
----
+```{code-cell}
 # Set a step size for finite differences calculations
 eps = 1e-4
 
@@ -214,18 +148,12 @@ print('W_dirderiv_numerical', W_grad_numerical)
 print('W_dirderiv_autodiff', jnp.vdot(grad(loss)(W, b), unitvec))
 ```
 
-+++ {"id": "InzB-iiJpVcx"}
-
 JAX provides a simple convenience function that does essentially the same thing, but checks up to any order of differentiation that you like:
 
-```{code-cell} ipython3
-:id: 6Ok2LEfQmOuy
-
+```{code-cell}
 from jax.test_util import check_grads
 check_grads(loss, (W, b), order=2)  # check up to 2nd order derivatives
 ```
-
-+++ {"id": "id0DXxwt3VJi"}
 
 ### Hessian-vector products with `grad`-of-`grad`
 
@@ -249,34 +177,20 @@ where $g(x) = \partial f(x) \cdot v$ is a new scalar-valued function that dots t
 
 In JAX code, we can just write this:
 
-```{code-cell} ipython3
-:id: Ou5OU-gU9epm
-
+```{code-cell}
 def hvp(f, x, v):
     return grad(lambda x: jnp.vdot(grad(f)(x), v))(x)
 ```
-
-+++ {"id": "Rb1-5Hpv-ZV0"}
 
 This example shows that you can freely use lexical closure, and JAX will never get perturbed or confused.
 
 We'll check this implementation a few cells down, once we see how to compute dense Hessian matrices. We'll also write an even better version that uses both forward-mode and reverse-mode.
 
-+++ {"id": "5A_akvtp8UTu"}
-
 ### Jacobians and Hessians using `jacfwd` and `jacrev`
-
-+++ {"id": "UP5BbmSm8ZwK"}
 
 You can compute full Jacobian matrices using the `jacfwd` and `jacrev` functions:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: cbETzAvKvf5I
-outputId: 7c8d2361-cc68-4139-9f1f-afa2431b3cd2
----
+```{code-cell}
 from jax import jacfwd, jacrev
 
 # Isolate the function from the weight matrix to the predictions
@@ -291,21 +205,11 @@ print("jacrev result, with shape", J.shape)
 print(J)
 ```
 
-+++ {"id": "iZDL-n_AvgBt"}
-
 These two functions compute the same values (up to machine numerics), but differ in their implementation: `jacfwd` uses forward-mode automatic differentiation, which is more efficient for "tall" Jacobian matrices, while `jacrev` uses reverse-mode, which is more efficient for "wide" Jacobian matrices. For matrices that are near-square, `jacfwd` probably has an edge over `jacrev`.
-
-+++ {"id": "zeKlr7Xz8bfm"}
 
 You can also use `jacfwd` and `jacrev` with container types:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: eH46Xnm88bfm
-outputId: ab1f5dce-926e-40b9-9664-5bd5e628e0b5
----
+```{code-cell}
 def predict_dict(params, inputs):
     return predict(params['W'], params['b'], inputs)
 
@@ -315,21 +219,11 @@ for k, v in J_dict.items():
     print(v)
 ```
 
-+++ {"id": "yH34zjV88bfp"}
-
 For more details on forward- and reverse-mode, as well as how to implement `jacfwd` and `jacrev` as efficiently as possible, read on!
-
-+++ {"id": "K6Mpw_7K8bfp"}
 
 Using a composition of two of these functions gives us a way to compute dense Hessian matrices:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: n155ypD9rfIZ
-outputId: 69622bc4-9a8d-47f1-aab6-40ab21d450d9
----
+```{code-cell}
 def hessian(f):
     return jacfwd(jacrev(f))
 
@@ -337,8 +231,6 @@ H = hessian(f)(W)
 print("hessian, with shape", H.shape)
 print(H)
 ```
-
-+++ {"id": "wvkk82R6uRoM"}
 
 This shape makes sense: if we start with a function $f : \mathbb{R}^n \to \mathbb{R}^m$, then at a point $x \in \mathbb{R}^n$ we expect to get the shapes
 
@@ -350,11 +242,7 @@ and so on.
 
 To implement `hessian`, we could have used `jacfwd(jacrev(f))` or `jacrev(jacfwd(f))` or any other composition of the two. But forward-over-reverse is typically the most efficient. That's because in the inner Jacobian computation we're often differentiating a function wide Jacobian (maybe like a loss function $f : \mathbb{R}^n \to \mathbb{R}$), while in the outer Jacobian computation we're differentiating a function with a square Jacobian (since $\nabla f : \mathbb{R}^n \to \mathbb{R}^n$), which is where forward-mode wins out.
 
-+++ {"id": "OMmi9cyhs1bj"}
-
 ## How it's made: two foundational autodiff functions
-
-+++ {"id": "mtSRvouV6vvG"}
 
 ### Jacobian-Vector products (JVPs, aka forward-mode autodiff)
 
@@ -384,9 +272,7 @@ $\qquad (x, v) \mapsto \partial f(x) v$
 
 Back in Python code, JAX's `jvp` function models this transformation. Given a Python function that evaluates $f$, JAX's `jvp` is a way to get a Python function for evaluating $(x, v) \mapsto (f(x), \partial f(x) v)$.
 
-```{code-cell} ipython3
-:id: pTncYR6F6vvG
-
+```{code-cell}
 from jax import jvp
 
 # Isolate the function from the weight matrix to the predictions
@@ -399,8 +285,6 @@ v = random.normal(subkey, W.shape)
 y, u = jvp(f, (W,), (v,))
 ```
 
-+++ {"id": "m1VJgJYQGfCK"}
-
 In terms of Haskell-like type signatures, we could write
 
 ```haskell
@@ -408,8 +292,6 @@ jvp :: (a -> b) -> a -> T a -> (b, T b)
 ```
 
 where we use `T a` to denote the type of the tangent space for `a`. In words, `jvp` takes as arguments a function of type `a -> b`, a value of type `a`, and a tangent vector value of type `T a`. It gives back a pair consisting of a value of type `b` and an output tangent vector of type `T b`.
-
-+++ {"id": "3RpbiasHGD3X"}
 
 The `jvp`-transformed function is evaluated much like the original function, but paired up with each primal value of type `a` it pushes along tangent values of type `T a`. For each primitive numerical operation that the original function would have applied, the `jvp`-transformed function executes a "JVP rule" for that primitive that both evaluates the primitive on the primals and applies the primitive's JVP at those primal values.
 
@@ -422,8 +304,6 @@ To answer that, first think about how you could use a JVP to build a full Jacobi
 If you're doing gradient-based optimization in machine learning, you probably want to minimize a loss function from parameters in $\mathbb{R}^n$ to a scalar loss value in $\mathbb{R}$. That means the Jacobian of this function is a very wide matrix: $\partial f(x) \in \mathbb{R}^{1 \times n}$, which we often identify with the Gradient vector $\nabla f(x) \in \mathbb{R}^n$. Building that matrix one column at a time, with each call taking a similar number of FLOPs to evaluating the original function, sure seems inefficient! In particular, for training neural networks, where $f$ is a training loss function and $n$ can be in the millions or billions, this approach just won't scale.
 
 To do better for functions like this, we just need to use reverse-mode.
-
-+++ {"id": "PhkvkZazdXu1"}
 
 ### Vector-Jacobian products (VJPs, aka reverse-mode autodiff)
 
@@ -453,9 +333,7 @@ of $f$ at $x$. The key for our purposes is that it goes from something that look
 
 Switching from math back to Python, the JAX function `vjp` can take a Python function for evaluating $f$ and give us back a Python function for evaluating the VJP $(x, v) \mapsto (f(x), v^\mathsf{T} \partial f(x))$.
 
-```{code-cell} ipython3
-:id: 1tFcRuEzkGRR
-
+```{code-cell}
 from jax import vjp
 
 # Isolate the function from the weight matrix to the predictions
@@ -469,8 +347,6 @@ u = random.normal(subkey, y.shape)
 # Pull back the covector `u` along `f` evaluated at `W`
 v = vjp_fun(u)
 ```
-
-+++ {"id": "oVOZexCEkvv3"}
 
 In terms of Haskell-like type signatures, we could write
 
@@ -492,7 +368,7 @@ For more on how reverse-mode works, see [this tutorial video from the Deep Learn
 
 If you're interested in taking vector-valued gradients (like `tf.gradients`):
 
-```{code-cell} ipython3
+```{code-cell}
 from jax import vjp
 
 def vgrad(f, x):
@@ -502,22 +378,14 @@ def vgrad(f, x):
 print(vgrad(lambda x: 3*x**2, jnp.ones((2, 2))))
 ```
 
-+++ {"id": "MWHcAPqLdJFn"}
-
 ### Hessian-vector products using both forward- and reverse-mode
-
-+++ {"id": "YG3g5C3KdW7H"}
 
 In a previous section, we implemented a Hessian-vector product function just using reverse-mode (assuming continuous second derivatives):
 
-```{code-cell} ipython3
-:id: C70CA-7wdelL
-
+```{code-cell}
 def hvp(f, x, v):
     return grad(lambda x: jnp.vdot(grad(f)(x), v))(x)
 ```
-
-+++ {"id": "zJlJbFKCdfd0"}
 
 That's efficient, but we can do even better and save some memory by using forward-mode together with reverse-mode.
 
@@ -531,9 +399,7 @@ $(x, v) \mapsto \partial g(x) v = \partial^2 f(x) v$.
 
 We can translate that almost directly into code:
 
-```{code-cell} ipython3
-:id: rq3C0reVfAaI
-
+```{code-cell}
 from jax import jvp, grad
 
 # forward-over-reverse
@@ -541,19 +407,11 @@ def hvp(f, primals, tangents):
   return jvp(grad(f), primals, tangents)[1]
 ```
 
-+++ {"id": "XUsye1SwfSFm"}
-
 Even better, since we didn't have to call `jnp.dot` directly, this `hvp` function works with arrays of any shape and with arbitrary container types (like vectors stored as nested lists/dicts/tuples), and doesn't even have a dependence on `jax.numpy`.
 
 Here's an example of how to use it:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: bmpuQa5_f1Al
-outputId: 20ef2514-0ab7-4071-c2f4-77b59b013ffc
----
+```{code-cell}
 def f(X):
   return jnp.sum(jnp.tanh(X)**2)
 
@@ -567,30 +425,18 @@ ans2 = jnp.tensordot(hessian(f)(X), V, 2)
 print(jnp.allclose(ans1, ans2, 1e-4, 1e-4))
 ```
 
-+++ {"id": "aWTii5TyXL5C"}
-
 Another way you might consider writing this is using reverse-over-forward:
 
-```{code-cell} ipython3
-:id: YxwmXZH2XQrw
-
+```{code-cell}
 # reverse-over-forward
 def hvp_revfwd(f, primals, tangents):
   g = lambda primals: jvp(f, primals, tangents)[1]
   return grad(g)(primals)
 ```
 
-+++ {"id": "8z-QG_xTXR4I"}
-
 That's not quite as good, though, because forward-mode has less overhead than reverse-mode, and since the outer differentiation operator here has to differentiate a larger computation than the inner one, keeping forward-mode on the outside works best:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: lxfv25qTX5gZ
-outputId: b88dae03-7bd1-4836-f994-880c57bc4714
----
+```{code-cell}
 # reverse-over-reverse, only works for single arguments
 def hvp_revrev(f, primals, tangents):
   x, = primals
@@ -609,23 +455,13 @@ print("Naive full Hessian materialization")
 %timeit -n10 -r3 jnp.tensordot(hessian(f)(X), V, 2)
 ```
 
-+++ {"id": "xtqSUJgzwQXO"}
-
 ## Composing VJPs, JVPs, and `vmap`
-
-+++ {"id": "PSL1TciM6vvI"}
 
 ### Jacobian-Matrix and Matrix-Jacobian products
 
 Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's `vmap` [transformation](https://github.com/google/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: asAWvxVaCmsx
-outputId: 05d3b5f9-f526-42a4-ea2b-6163b267db26
----
+```{code-cell}
 # Isolate the function from the weight matrix to the predictions
 f = lambda W: predict(W, b, inputs)
 
@@ -657,13 +493,7 @@ vmap_vs = vmap_mjp(f, W, M=U)
 assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Matrix-Jacobian Products should be identical'
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: TDaxsJrlDraK
-outputId: 99a7591c-643d-4b91-c0fc-c7a3c73b0de6
----
+```{code-cell}
 def loop_jmp(f, W, M):
     # jvp immediately returns the primal and tangent values as a tuple,
     # so we'll compute and select the tangents in a list comprehension
@@ -686,18 +516,12 @@ print('\nVmapped Jacobian-Matrix product')
 assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Jacobian-Matrix products should be identical'
 ```
 
-+++ {"id": "MXFEFBDz6vvL"}
-
 ### The implementation of `jacfwd` and `jacrev`
 
 
-+++ {"id": "ZAgUb6sp8bf7"}
-
 Now that we've seen fast Jacobian-matrix and matrix-Jacobian products, it's not hard to guess how to write `jacfwd` and `jacrev`. We just use the same technique to push-forward or pull-back an entire standard basis (isomorphic to an identity matrix) at once.
 
-```{code-cell} ipython3
-:id: HBEzsDH1U5_4
-
+```{code-cell}
 from jax import jacrev as builtin_jacrev
 
 def our_jacrev(f):
@@ -713,9 +537,7 @@ def our_jacrev(f):
 assert jnp.allclose(builtin_jacrev(f)(W), our_jacrev(f)(W)), 'Incorrect reverse-mode Jacobian results!'
 ```
 
-```{code-cell} ipython3
-:id: Qd9gVZ5t6vvP
-
+```{code-cell}
 from jax import jacfwd as builtin_jacfwd
 
 def our_jacfwd(f):
@@ -728,21 +550,11 @@ def our_jacfwd(f):
 assert jnp.allclose(builtin_jacfwd(f)(W), our_jacfwd(f)(W)), 'Incorrect forward-mode Jacobian results!'
 ```
 
-+++ {"id": "7r5_m9Y68bf_"}
-
 Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Our [implementation](https://github.com/HIPS/autograd/blob/96a03f44da43cd7044c61ac945c483955deba957/autograd/differential_operators.py#L60) of reverse-mode `jacobian` in Autograd had to pull back one vector at a time with an outer-loop `map`. Pushing one vector at a time through the computation is much less efficient than batching it all together with `vmap`.
-
-+++ {"id": "9maev0Nd8bf_"}
 
 Another thing that Autograd couldn't do is `jit`. Interestingly, no matter how much Python dynamism you use in your function to be differentiated, we could always use `jit` on the linear part of the computation. For example:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: _5jDflC08bgB
-outputId: 7d37cca8-3954-40b9-bea8-937ac655387c
----
+```{code-cell}
 def f(x):
     try:
         if x < 3:
@@ -756,19 +568,13 @@ y, f_vjp = vjp(f, 4.)
 print(jit(f_vjp)(1.))
 ```
 
-+++ {"id": "3fPWLrxK8bgD"}
-
 ## Complex numbers and differentiation
-
-+++ {"id": "2pZOHvrm8bgE"}
 
 JAX is great at complex numbers and differentiation. To support both [holomorphic and non-holomorphic differentiation](https://en.wikipedia.org/wiki/Holomorphic_function), it helps to think in terms of JVPs and VJPs.
 
 Consider a complex-to-complex function $f: \mathbb{C} \to \mathbb{C}$ and identify it with a corresponding function $g: \mathbb{R}^2 \to \mathbb{R}^2$,
 
-```{code-cell} ipython3
-:id: OaqZ2MuP8bgF
-
+```{code-cell}
 def f(z):
   x, y = jnp.real(z), jnp.imag(z)
   return u(x, y) + v(x, y) * 1j
@@ -777,11 +583,7 @@ def g(x, y):
   return (u(x, y), v(x, y))
 ```
 
-+++ {"id": "3XB5oGxl8bgH"}
-
 That is, we've decomposed $f(z) = u(x, y) + v(x, y) i$ where $z = x + y i$, and identified $\mathbb{C}$ with $\mathbb{R}^2$ to get $g$.
-
-+++ {"id": "6fBBMxqpiVjF"}
 
 Since $g$ only involves real inputs and outputs, we already know how to write a Jacobian-vector product for it, say given a tangent vector $(c, d) \in \mathbb{R}^2$, namely
 
@@ -797,13 +599,9 @@ $\partial f(x + y i)(c + d i) =
 
 That's our definition of the JVP of a $\mathbb{C} \to \mathbb{C}$ function! Notice it doesn't matter whether or not $f$ is holomorphic: the JVP is unambiguous.
 
-+++ {"id": "6SL6dWtFpBUr"}
-
 Here's a check:
 
-```{code-cell} ipython3
-:id: BGZV__zupIMS
-
+```{code-cell}
 def check(seed):
   key = random.PRNGKey(seed)
 
@@ -840,19 +638,11 @@ def check(seed):
   print(jnp.allclose(ans, expected))
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: I2OBU3OGp-CY
-outputId: 28ae844b-0c25-4255-ca9b-598b0dbeb404
----
+```{code-cell}
 check(0)
 check(1)
 check(2)
 ```
-
-+++ {"id": "XjWMgDOimUcU"}
 
 What about VJPs? We do something pretty similar: for a cotangent vector $c + di \in \mathbb{C}$ we define the VJP of $f$ as
 
@@ -863,13 +653,9 @@ $(c + di)^* \; \partial f(x + y i) =
 
 What's with the negatives? They're just to take care of complex conjugation, and the fact that we're working with covectors.
 
-+++ {"id": "oRu2VRjmtrgB"}
-
 Here's a check of the VJP rules:
 
-```{code-cell} ipython3
-:id: 4J7edvIBttcU
-
+```{code-cell}
 def check(seed):
   key = random.PRNGKey(seed)
 
@@ -907,27 +693,17 @@ def check(seed):
   assert jnp.allclose(ans, expected, atol=1e-5, rtol=1e-5)
 ```
 
-```{code-cell} ipython3
-:id: RieNCdXgtzs7
-
+```{code-cell}
 check(0)
 check(1)
 check(2)
 ```
 
-+++ {"id": "7I6A19Myt3qN"}
-
 What about convenience wrappers like `grad`, `jacfwd`, and `jacrev`?
 
 For $\mathbb{R} \to \mathbb{R}$ functions, recall we defined `grad(f)(x)` as being `vjp(f, x)[1](1.0)`, which works because applying a VJP to a `1.0` value reveals the gradient (i.e. Jacobian, or derivative). We can do the same thing for $\mathbb{C} \to \mathbb{R}$ functions: we can still use `1.0` as the cotangent vector, and we just get out a complex number result summarizing the full Jacobian:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: xz_9lK61wGdm
-outputId: 96693583-2a36-48fd-d811-cd1a0f1a50c5
----
+```{code-cell}
 def f(z):
   x, y = jnp.real(z), jnp.imag(z)
   return x**2 + y**2
@@ -936,19 +712,11 @@ z = 3. + 4j
 grad(f)(z)
 ```
 
-+++ {"id": "jqCvEE8qwGw7"}
-
 For geneneral $\mathbb{C} \to \mathbb{C}$ functions, the Jacobian has 4 real-valued degrees of freedom (as in the 2x2 Jacobian matrices above), so we can't hope to represent all of them with in a complex number. But we can for holomorphic functions! A holomorphic function is precisely a $\mathbb{C} \to \mathbb{C}$ function with the special property that its derivative can be represented as a single complex number. (The [Cauchy-Riemann equations](https://en.wikipedia.org/wiki/Cauchy%E2%80%93Riemann_equations) ensure that the above 2x2 Jacobians have the special form of a scale-and-rotate matrix in the complex plane, i.e. the action of a single complex number under multiplication.) And we can reveal that one complex number using a single call to `vjp` with a covector of `1.0`.
 
 Because this only works for holomorphic functions, to use this trick we need to promise JAX that our function is holomorphic; otherwise, JAX will raise an error when `grad` is used for a complex-output function:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: Y3n9hPVrwvXx
-outputId: 20f72dfe-7083-47f8-b086-4a16426ba97b
----
+```{code-cell}
 def f(z):
   return jnp.sin(z)
 
@@ -956,25 +724,15 @@ z = 3. + 4j
 grad(f, holomorphic=True)(z)
 ```
 
-+++ {"id": "LjIbDxX-w9Qf"}
-
 All the `holomorphic=True` promise does is disable the error when the output is complex-valued. We can still write `holomorphic=True` when the function isn't holomorphic, but the answer we get out won't represent the full Jacobian. Instead, it'll be the Jacobian of the function where we just discard the imaginary part of the output:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: th9xhwp2xaeU
-outputId: 2dfebe3a-bbfe-46a1-b282-f5d59d53c772
----
+```{code-cell}
 def f(z):
   return jnp.conjugate(z)
 
 z = 3. + 4j
 grad(f, holomorphic=True)(z)  # f is not actually holomorphic!
 ```
-
-+++ {"id": "R8ytpfeXyBu2"}
 
 There are some useful upshots for how `grad` works here:
 
@@ -984,17 +742,9 @@ There are some useful upshots for how `grad` works here:
 
 In any case, JVPs and VJPs are always unambiguous. And if we wanted to compute the full Jacobian matrix of a non-holomorphic $\mathbb{C} \to \mathbb{C}$ function, we can do it with JVPs or VJPs!
 
-+++ {"id": "qmXkI37T8bgL"}
-
 You should expect complex numbers to work everywhere in JAX. Here's differentiating through a Cholesky decomposition of a complex matrix:
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-id: WrDHHfKI8bgM
-outputId: c04baa8a-2408-4a76-e3dc-4522782d1bc5
----
+```{code-cell}
 A = jnp.array([[5.,    2.+3j,    5j],
               [2.-3j,   7.,  1.+7j],
               [-5j,  1.-7j,    12.]])
@@ -1005,8 +755,6 @@ def f(X):
 
 grad(f, holomorphic=True)(A)
 ```
-
-+++ {"id": "Pgr2A60q9gl1"}
 
 ## More advanced autodiff
 

--- a/docs/notebooks/maml.ipynb
+++ b/docs/notebooks/maml.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oDP4nK_Zgyg-"
-   },
+   "metadata": {},
    "source": [
     "# MAML Tutorial with JAX\n",
     "\n",
@@ -32,11 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "zKVdo3FtgyhE"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "### import jax.numpy (almost-drop-in for numpy) and gradient operators.\n",
@@ -46,10 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gMgclHhxgyhI"
-   },
+   "metadata": {},
    "source": [
     "## Gradients of Gradients\n",
     "\n",
@@ -59,15 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 123
-    },
-    "colab_type": "code",
-    "id": "Mt-uRwBGgyhJ",
-    "outputId": "db7f718c-c2fb-4f7e-f31c-39a0d36c7051"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -96,10 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7mAd3We_gyhP"
-   },
+   "metadata": {},
    "source": [
     "## Sinusoid Regression and vmap\n",
     "\n",
@@ -109,11 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "JN9KA1PvgyhQ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import vmap # for auto-vectorizing functions\n",
@@ -128,11 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "DeEALFIHgyhU"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use stax to set up network initialization and evaluation functions\n",
@@ -150,11 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "izIi-P1agyhY"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def loss(params, inputs, targets):\n",
@@ -166,15 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "sROmpDEmgyhb",
-    "outputId": "d1bf00d7-99e7-445e-b439-ea2fabd7a646"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -216,11 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "PxAEhrPGgyhh"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -231,11 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "iZtAZfEZgyhk"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "opt_init, opt_update, get_params = optimizers.adam(step_size=1e-2)\n",
@@ -256,15 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "Rm9WIz2egyho",
-    "outputId": "183de82d-fdf0-4b81-9b14-01a85e6b8839"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -304,10 +247,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7E8gAJBzgyhs"
-   },
+   "metadata": {},
    "source": [
     "## MAML: Optimizing for Generalization\n",
     "\n",
@@ -323,15 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 88
-    },
-    "colab_type": "code",
-    "id": "2YBFsM2dgyht",
-    "outputId": "46160194-04b7-46c9-897d-ecb11e9738be"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -360,10 +292,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "V9G-PMxygyhx"
-   },
+   "metadata": {},
    "source": [
     "## Sinusoid Task + MAML\n",
     "\n",
@@ -374,11 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "s1v5VABkgyhy"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "alpha = .1\n",
@@ -395,15 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
-    },
-    "colab_type": "code",
-    "id": "bQvg749Xgyh2",
-    "outputId": "5043f859-c537-41b8-c390-23670795d57b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -428,10 +345,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "zMB6BwPogyh6"
-   },
+   "metadata": {},
    "source": [
     "Let's try minimizing the MAML loss (without batching across multiple tasks, which we will do in the next section)"
    ]
@@ -439,15 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 371
-    },
-    "colab_type": "code",
-    "id": "pB5ldBO-gyh7",
-    "outputId": "b2365aa4-d7b8-40a0-d759-8257d3e4d768"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -512,15 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "ogcpFdJ9gyh_",
-    "outputId": "856924a3-ede5-44ba-ba3c-381673713fad"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -566,10 +464,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "7TMYcZKVgyiD"
-   },
+   "metadata": {},
    "source": [
     "## Batching Meta-Gradient Across Tasks\n",
     "\n",
@@ -583,11 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "9Pj04Z7MgyiF"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def sample_tasks(outer_batch_size, inner_batch_size):\n",
@@ -613,15 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "7dCIGObKgyiJ",
-    "outputId": "c169b529-0f16-4f20-d20e-d802765e4068"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -661,15 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 35
-    },
-    "colab_type": "code",
-    "id": "BrSX--wpgyiP",
-    "outputId": "6d81e7ff-7cd9-4aef-c665-952d442369d5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -691,15 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 371
-    },
-    "colab_type": "code",
-    "id": "P3WQ8_k2gyiU",
-    "outputId": "fed1b78b-7910-4e44-a80b-18f447379022"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -760,15 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "PmxHLrhYgyiX",
-    "outputId": "33ac699e-c66d-46e2-affa-98ae948d52e8"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -815,15 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 287
-    },
-    "colab_type": "code",
-    "id": "cQf2BeDjgyib",
-    "outputId": "fc52caf6-1379-4d60-fe44-99f4e4518698"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -857,17 +708,6 @@
     "plt.ylim(0., 1e-1)\n",
     "plt.legend()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "vCHCvXh-mm1v"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/neural_network_with_tfds_data.ipynb
+++ b/docs/notebooks/neural_network_with_tfds_data.ipynb
@@ -2,23 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "18AF5Ab4p6VL"
-   },
+   "metadata": {},
    "source": [
     "##### Copyright 2018 Google LLC.\n",
     "\n",
-    "Licensed under the Apache License, Version 2.0 (the \"License\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "crfqaJOyp8bq"
-   },
-   "source": [
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "\n",
     "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "you may not use this file except in compliance with the License.\n",
     "You may obtain a copy of the License at\n",
@@ -29,16 +18,8 @@
     "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
     "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
     "See the License for the specific language governing permissions and\n",
-    "limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "B_XlLLpcWjkA"
-   },
-   "source": [
+    "limitations under the License.\n",
+    "\n",
     "# Training a Simple Neural Network, with tensorflow/datasets Data Loading\n",
     "\n",
     "_Forked from_ `neural_network_and_data_loading.ipynb`\n",
@@ -53,11 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "OksHydJDtbbI"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -67,10 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "MTVcKi-ZYB3R"
-   },
+   "metadata": {},
    "source": [
     "### Hyperparameters\n",
     "Let's get a few bookkeeping items out of the way."
@@ -80,9 +54,6 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "-fmWA06xYE7d",
     "outputId": "520e5fd5-97c4-43eb-ef0e-b714d5287689"
    },
    "outputs": [],
@@ -109,10 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "BtoNk_yxWtIw"
-   },
+   "metadata": {},
    "source": [
     "### Auto-batching predictions\n",
     "\n",
@@ -122,11 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7APc6tD7TiuZ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax.scipy.special import logsumexp\n",
@@ -148,10 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "dRW_TvCTWgaP"
-   },
+   "metadata": {},
    "source": [
     "Let's check that our prediction function only works on single images."
    ]
@@ -160,9 +121,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "4sW2A5mnXHc5",
     "outputId": "ce9d86ed-a830-4832-e04d-10d1abb1fb8a"
    },
    "outputs": [
@@ -185,9 +143,6 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "PpyQxuedXfhp",
     "outputId": "f43bbc9d-bc8f-4168-ee7b-79ee9d33f245"
    },
    "outputs": [
@@ -212,9 +167,6 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "oJOOncKMXbwK",
     "outputId": "fa380024-aaf8-4789-d3a2-f060134930e6"
    },
    "outputs": [
@@ -239,32 +191,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "elsG6nX03BvW"
-   },
+   "metadata": {},
    "source": [
-    "At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "NwDuFqc9X7ER"
-   },
-   "source": [
+    "At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything.\n",
+    "\n",
     "### Utility and loss functions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "6lTI6I4lWdh5"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def one_hot(x, k, dtype=jnp.float32):\n",
@@ -289,10 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "umJJGZCC2oKl"
-   },
+   "metadata": {},
    "source": [
     "### Data Loading with `tensorflow/datasets`\n",
     "\n",
@@ -302,11 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "uWvo1EgZCvnK"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import tensorflow_datasets as tfds\n",
@@ -338,9 +268,6 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "7VMSC03gCvnO",
     "outputId": "e565586e-d598-4fa1-dd6f-10ba39617f6a"
    },
    "outputs": [
@@ -360,10 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xxPd6Qw3Z98v"
-   },
+   "metadata": {},
    "source": [
     "### Training Loop"
    ]
@@ -372,9 +296,6 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "X2DnZo3iYj18",
     "outputId": "bad334e0-127a-40fe-ec21-b0db77c73088"
    },
    "outputs": [
@@ -443,10 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xC1CMcVNYwxm"
-   },
+   "metadata": {},
    "source": [
     "We've now used the whole of the JAX API: `grad` for derivatives, `jit` for speedups and `vmap` for auto-vectorization.\n",
     "We used NumPy to specify all of our computation, and borrowed the great data loaders from `tensorflow/datasets`, and ran the whole thing on the GPU."

--- a/docs/notebooks/neural_network_with_tfds_data.md
+++ b/docs/notebooks/neural_network_with_tfds_data.md
@@ -12,13 +12,9 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "18AF5Ab4p6VL"}
-
 ##### Copyright 2018 Google LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-
-+++ {"colab_type": "text", "id": "crfqaJOyp8bq"}
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,8 +28,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-+++ {"colab_type": "text", "id": "B_XlLLpcWjkA"}
-
 # Training a Simple Neural Network, with tensorflow/datasets Data Loading
 
 _Forked from_ `neural_network_and_data_loading.ipynb`
@@ -44,25 +38,16 @@ Let's combine everything we showed in the [quickstart notebook](https://colab.re
 
 Of course, you can use JAX with any API that is compatible with NumPy to make specifying the model a bit more plug-and-play. Here, just for explanatory purposes, we won't use any neural network libraries or special APIs for builidng our model.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: OksHydJDtbbI
-
+```{code-cell}
 import jax.numpy as jnp
 from jax import grad, jit, vmap
 from jax import random
 ```
 
-+++ {"colab_type": "text", "id": "MTVcKi-ZYB3R"}
-
 ### Hyperparameters
 Let's get a few bookkeeping items out of the way.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: -fmWA06xYE7d
+```{code-cell}
 :outputId: 520e5fd5-97c4-43eb-ef0e-b714d5287689
 
 # A helper function to randomly initialize weights and biases
@@ -85,17 +70,11 @@ n_targets = 10
 params = init_network_params(layer_sizes, random.PRNGKey(0))
 ```
 
-+++ {"colab_type": "text", "id": "BtoNk_yxWtIw"}
-
 ### Auto-batching predictions
 
 Let us first define our prediction function. Note that we're defining this for a _single_ image example. We're going to use JAX's `vmap` function to automatically handle mini-batches, with no performance penalty.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 7APc6tD7TiuZ
-
+```{code-cell}
 from jax.scipy.special import logsumexp
 
 def relu(x):
@@ -113,14 +92,9 @@ def predict(params, image):
   return logits - logsumexp(logits)
 ```
 
-+++ {"colab_type": "text", "id": "dRW_TvCTWgaP"}
-
 Let's check that our prediction function only works on single images.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 4sW2A5mnXHc5
+```{code-cell}
 :outputId: ce9d86ed-a830-4832-e04d-10d1abb1fb8a
 
 # This works on single examples
@@ -129,10 +103,7 @@ preds = predict(params, random_flattened_image)
 print(preds.shape)
 ```
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: PpyQxuedXfhp
+```{code-cell}
 :outputId: f43bbc9d-bc8f-4168-ee7b-79ee9d33f245
 
 # Doesn't work with a batch
@@ -143,10 +114,7 @@ except TypeError:
   print('Invalid shapes!')
 ```
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: oJOOncKMXbwK
+```{code-cell}
 :outputId: fa380024-aaf8-4789-d3a2-f060134930e6
 
 # Let's upgrade it to handle batches using `vmap`
@@ -159,19 +127,11 @@ batched_preds = batched_predict(params, random_flattened_images)
 print(batched_preds.shape)
 ```
 
-+++ {"colab_type": "text", "id": "elsG6nX03BvW"}
-
 At this point, we have all the ingredients we need to define our neural network and train it. We've built an auto-batched version of `predict`, which we should be able to use in a loss function. We should be able to use `grad` to take the derivative of the loss with respect to the neural network parameters. Last, we should be able to use `jit` to speed up everything.
-
-+++ {"colab_type": "text", "id": "NwDuFqc9X7ER"}
 
 ### Utility and loss functions
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 6lTI6I4lWdh5
-
+```{code-cell}
 def one_hot(x, k, dtype=jnp.float32):
   """Create a one-hot encoding of x of size k."""
   return jnp.array(x[:, None] == jnp.arange(k), dtype)
@@ -192,17 +152,11 @@ def update(params, x, y):
           for (w, b), (dw, db) in zip(params, grads)]
 ```
 
-+++ {"colab_type": "text", "id": "umJJGZCC2oKl"}
-
 ### Data Loading with `tensorflow/datasets`
 
 JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll use the `tensorflow/datasets` data loader.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: uWvo1EgZCvnK
-
+```{code-cell}
 import tensorflow_datasets as tfds
 
 data_dir = '/tmp/tfds'
@@ -228,24 +182,16 @@ test_images = jnp.reshape(test_images, (len(test_images), num_pixels))
 test_labels = one_hot(test_labels, num_labels)
 ```
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 7VMSC03gCvnO
+```{code-cell}
 :outputId: e565586e-d598-4fa1-dd6f-10ba39617f6a
 
 print('Train:', train_images.shape, train_labels.shape)
 print('Test:', test_images.shape, test_labels.shape)
 ```
 
-+++ {"colab_type": "text", "id": "xxPd6Qw3Z98v"}
-
 ### Training Loop
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: X2DnZo3iYj18
+```{code-cell}
 :outputId: bad334e0-127a-40fe-ec21-b0db77c73088
 
 import time
@@ -272,8 +218,6 @@ for epoch in range(num_epochs):
   print("Training set accuracy {}".format(train_acc))
   print("Test set accuracy {}".format(test_acc))
 ```
-
-+++ {"colab_type": "text", "id": "xC1CMcVNYwxm"}
 
 We've now used the whole of the JAX API: `grad` for derivatives, `jit` for speedups and `vmap` for auto-vectorization.
 We used NumPy to specify all of our computation, and borrowed the great data loaders from `tensorflow/datasets`, and ran the whole thing on the GPU.

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "xtWX4x9DCF5_"
-   },
+   "metadata": {},
    "source": [
     "# JAX Quickstart\n",
     "\n",
@@ -32,11 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "SY8mDvEvCGqk"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -46,21 +39,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "FQ89jHCYfhpg"
-   },
+   "metadata": {},
    "source": [
-    "## Multiplying Matrices"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Xpy1dSgNqCP4"
-   },
-   "source": [
+    "## Multiplying Matrices\n",
+    "\n",
     "We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see [Common Gotchas in JAX].\n",
     "\n",
     "[Common Gotchas in JAX]: https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Random-Numbers"
@@ -69,11 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "u0nseKZNqOoH"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "key = random.PRNGKey(0)\n",
@@ -83,10 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "hDJF0UPKnuqB"
-   },
+   "metadata": {},
    "source": [
     "Let's dive right in and multiply two big matrices."
    ]
@@ -94,11 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "eXn8GUl6CG5N"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "size = 3000\n",
@@ -108,10 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0AlN7EbonyaR"
-   },
+   "metadata": {},
    "source": [
     "We added that `block_until_ready` because [JAX uses asynchronous execution by default](https://jax.readthedocs.io/en/latest/async_dispatch.html).\n",
     "\n",
@@ -121,11 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "ZPl0MuwYrM7t"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -135,10 +99,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_SrcB2IurUuE"
-   },
+   "metadata": {},
    "source": [
     "That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using `device_put`."
    ]
@@ -146,11 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Jj7M7zyRskF0"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import device_put\n",
@@ -162,32 +119,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "clO9djnen8qi"
-   },
+   "metadata": {},
    "source": [
-    "The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "ghkfKNQttDpg"
-   },
-   "source": [
+    "The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster.\n",
+    "\n",
     "If you have a GPU (or TPU!) these calls run on the accelerator and have the potential to be much faster than on CPU."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "RzXK8GnIs7VV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x = np.random.normal(size=(size, size)).astype(np.float32)\n",
@@ -196,10 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "iOzp0P_GoJhb"
-   },
+   "metadata": {},
    "source": [
     "JAX is much more than just a GPU-backed NumPy. It also comes with a few program transformations that are useful when writing numerical code. For now, there's three main ones:\n",
     "\n",
@@ -207,37 +146,17 @@
     " - `grad`, for taking derivatives\n",
     " - `vmap`, for automatic vectorization or batching.\n",
     "\n",
-    "Let's go over these, one-by-one. We'll also end up composing these in interesting ways."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "bTTrTbWvgLUK"
-   },
-   "source": [
-    "## Using `jit` to speed up functions"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YrqE32mvE3b7"
-   },
-   "source": [
+    "Let's go over these, one-by-one. We'll also end up composing these in interesting ways.\n",
+    "\n",
+    "## Using `jit` to speed up functions\n",
+    "\n",
     "JAX runs transparently on the GPU (or CPU, if you don't have one, and TPU coming soon!). However, in the above example, JAX is dispatching kernels to the GPU one operation at a time. If we have a sequence of operations, we can use the `@jit` decorator to compile multiple operations together using [XLA](https://www.tensorflow.org/xla). Let's try that."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "qLGdCtFKFLOR"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def selu(x, alpha=1.67, lmbda=1.05):\n",
@@ -249,10 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "a_V8SruVHrD_"
-   },
+   "metadata": {},
    "source": [
     "We can speed it up with `@jit`, which will jit-compile the first time `selu` is called and will be cached thereafter."
    ]
@@ -260,11 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "fh4w_3NpFYTp"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "selu_jit = jit(selu)\n",
@@ -273,10 +185,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "HxpBc4WmfsEU"
-   },
+   "metadata": {},
    "source": [
     "## Taking derivatives with `grad`\n",
     "\n",
@@ -286,11 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "IMAgNJaMJwPD"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def sum_logistic(x):\n",
@@ -303,10 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "PtNs881Ohioc"
-   },
+   "metadata": {},
    "source": [
     "Let's verify with finite differences that our result is correct."
    ]
@@ -314,11 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "JXI7_OZuKZVO"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def first_finite_differences(f, x):\n",
@@ -332,10 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Q2CUZjOWNZ-3"
-   },
+   "metadata": {},
    "source": [
     "Taking derivatives is as easy as calling `grad`. `grad` and `jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:"
    ]
@@ -343,11 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "TO4g8ny-OEi4"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(grad(jit(grad(jit(grad(sum_logistic)))))(1.0))"
@@ -355,10 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yCJ5feKvhnBJ"
-   },
+   "metadata": {},
    "source": [
     "For more advanced autodiff, you can use `jax.vjp` for reverse-mode vector-Jacobian products and `jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:"
    ]
@@ -366,11 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Z-JxbiNyhxEW"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jacfwd, jacrev\n",
@@ -380,42 +264,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TI4nPsGafxbL"
-   },
+   "metadata": {},
    "source": [
-    "## Auto-vectorization with `vmap`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "PcxkONy5aius"
-   },
-   "source": [
-    "JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TPiX4y-bWLFS"
-   },
-   "source": [
+    "## Auto-vectorization with `vmap`\n",
+    "\n",
+    "JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand.\n",
+    "\n",
     "We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using `vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8w0Gpsn8WYYj"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mat = random.normal(key, (150, 100))\n",
@@ -427,10 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0zWsc0RisQWx"
-   },
+   "metadata": {},
    "source": [
     "Given a function such as `apply_matrix`, we can loop over a batch dimension in Python, but usually the performance of doing so is poor."
    ]
@@ -438,11 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "KWVc9BsZv0Ki"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def naively_batched_apply_matrix(v_batched):\n",
@@ -454,10 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "qHfKaLE9stbA"
-   },
+   "metadata": {},
    "source": [
     "We know how to batch this operation manually. In this case, `jnp.dot` handles extra batch dimensions transparently."
    ]
@@ -465,11 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "ipei6l8nvrzH"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@jit\n",
@@ -482,10 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "1eF8Nhb-szAb"
-   },
+   "metadata": {},
    "source": [
     "However, suppose we had a more complicated function without batching support. We can use `vmap` to add batching support automatically."
    ]
@@ -493,11 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "67Oeknf5vuCl"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@jit\n",
@@ -510,21 +350,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "pYVl3Z2nbZhO"
-   },
+   "metadata": {},
    "source": [
-    "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WwNnjaI4th_8"
-   },
-   "source": [
+    "Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation.\n",
+    "\n",
     "This is just a taste of what JAX can do. We're really excited to see what you do with it!"
    ]
   }

--- a/docs/notebooks/quickstart.md
+++ b/docs/notebooks/quickstart.md
@@ -12,8 +12,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "xtWX4x9DCF5_"}
-
 # JAX Quickstart
 
 **JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance machine learning research.**
@@ -36,74 +34,44 @@ can express sophisticated algorithms and get maximal performance without having
 to leave Python.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: SY8mDvEvCGqk
-
 import jax.numpy as jnp
 from jax import grad, jit, vmap
 from jax import random
 ```
 
-+++ {"colab_type": "text", "id": "FQ89jHCYfhpg"}
-
 ## Multiplying Matrices
-
-+++ {"colab_type": "text", "id": "Xpy1dSgNqCP4"}
 
 We'll be generating random data in the following examples. One big difference between NumPy and JAX is how you generate random numbers. For more details, see [Common Gotchas in JAX].
 
 [Common Gotchas in JAX]: https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Random-Numbers
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: u0nseKZNqOoH
-
 key = random.PRNGKey(0)
 x = random.normal(key, (10,))
 print(x)
 ```
 
-+++ {"colab_type": "text", "id": "hDJF0UPKnuqB"}
-
 Let's dive right in and multiply two big matrices.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: eXn8GUl6CG5N
-
 size = 3000
 x = random.normal(key, (size, size), dtype=jnp.float32)
 %timeit jnp.dot(x, x.T).block_until_ready()  # runs on the GPU
 ```
-
-+++ {"colab_type": "text", "id": "0AlN7EbonyaR"}
 
 We added that `block_until_ready` because [JAX uses asynchronous execution by default](https://jax.readthedocs.io/en/latest/async_dispatch.html).
 
 JAX NumPy functions work on regular NumPy arrays. 
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: ZPl0MuwYrM7t
-
 import numpy as np
 x = np.random.normal(size=(size, size)).astype(np.float32)
 %timeit jnp.dot(x, x.T).block_until_ready()
 ```
 
-+++ {"colab_type": "text", "id": "_SrcB2IurUuE"}
-
 That's slower because it has to transfer data to the GPU every time. You can ensure that an NDArray is backed by device memory using `device_put`.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: Jj7M7zyRskF0
-
 from jax import device_put
 
 x = np.random.normal(size=(size, size)).astype(np.float32)
@@ -111,24 +79,14 @@ x = device_put(x)
 %timeit jnp.dot(x, x.T).block_until_ready()
 ```
 
-+++ {"colab_type": "text", "id": "clO9djnen8qi"}
-
 The output of `device_put` still acts like an NDArray, but it only copies values back to the CPU when they're needed for printing, plotting, saving to disk, branching, etc. The behavior of `device_put` is equivalent to the function `jit(lambda x: x)`, but it's faster.
-
-+++ {"colab_type": "text", "id": "ghkfKNQttDpg"}
 
 If you have a GPU (or TPU!) these calls run on the accelerator and have the potential to be much faster than on CPU.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: RzXK8GnIs7VV
-
 x = np.random.normal(size=(size, size)).astype(np.float32)
 %timeit np.dot(x, x.T)
 ```
-
-+++ {"colab_type": "text", "id": "iOzp0P_GoJhb"}
 
 JAX is much more than just a GPU-backed NumPy. It also comes with a few program transformations that are useful when writing numerical code. For now, there's three main ones:
 
@@ -138,19 +96,11 @@ JAX is much more than just a GPU-backed NumPy. It also comes with a few program 
 
 Let's go over these, one-by-one. We'll also end up composing these in interesting ways.
 
-+++ {"colab_type": "text", "id": "bTTrTbWvgLUK"}
-
 ## Using `jit` to speed up functions
-
-+++ {"colab_type": "text", "id": "YrqE32mvE3b7"}
 
 JAX runs transparently on the GPU (or CPU, if you don't have one, and TPU coming soon!). However, in the above example, JAX is dispatching kernels to the GPU one operation at a time. If we have a sequence of operations, we can use the `@jit` decorator to compile multiple operations together using [XLA](https://www.tensorflow.org/xla). Let's try that.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: qLGdCtFKFLOR
-
 def selu(x, alpha=1.67, lmbda=1.05):
   return lmbda * jnp.where(x > 0, x, alpha * jnp.exp(x) - alpha)
 
@@ -158,30 +108,18 @@ x = random.normal(key, (1000000,))
 %timeit selu(x).block_until_ready()
 ```
 
-+++ {"colab_type": "text", "id": "a_V8SruVHrD_"}
-
 We can speed it up with `@jit`, which will jit-compile the first time `selu` is called and will be cached thereafter.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: fh4w_3NpFYTp
-
 selu_jit = jit(selu)
 %timeit selu_jit(x).block_until_ready()
 ```
-
-+++ {"colab_type": "text", "id": "HxpBc4WmfsEU"}
 
 ## Taking derivatives with `grad`
 
 In addition to evaluating numerical functions, we also want to transform them. One transformation is [automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation). In JAX, just like in [Autograd](https://github.com/HIPS/autograd), you can compute gradients with the `grad` function.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: IMAgNJaMJwPD
-
 def sum_logistic(x):
   return jnp.sum(1.0 / (1.0 + jnp.exp(-x)))
 
@@ -190,15 +128,9 @@ derivative_fn = grad(sum_logistic)
 print(derivative_fn(x_small))
 ```
 
-+++ {"colab_type": "text", "id": "PtNs881Ohioc"}
-
 Let's verify with finite differences that our result is correct.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: JXI7_OZuKZVO
-
 def first_finite_differences(f, x):
   eps = 1e-3
   return jnp.array([(f(x + eps * v) - f(x - eps * v)) / (2 * eps)
@@ -208,49 +140,27 @@ def first_finite_differences(f, x):
 print(first_finite_differences(sum_logistic, x_small))
 ```
 
-+++ {"colab_type": "text", "id": "Q2CUZjOWNZ-3"}
-
 Taking derivatives is as easy as calling `grad`. `grad` and `jit` compose and can be mixed arbitrarily. In the above example we jitted `sum_logistic` and then took its derivative. We can go further:
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: TO4g8ny-OEi4
-
 print(grad(jit(grad(jit(grad(sum_logistic)))))(1.0))
 ```
-
-+++ {"colab_type": "text", "id": "yCJ5feKvhnBJ"}
 
 For more advanced autodiff, you can use `jax.vjp` for reverse-mode vector-Jacobian products and `jax.jvp` for forward-mode Jacobian-vector products. The two can be composed arbitrarily with one another, and with other JAX transformations. Here's one way to compose them to make a function that efficiently computes full Hessian matrices:
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: Z-JxbiNyhxEW
-
 from jax import jacfwd, jacrev
 def hessian(fun):
   return jit(jacfwd(jacrev(fun)))
 ```
 
-+++ {"colab_type": "text", "id": "TI4nPsGafxbL"}
-
 ## Auto-vectorization with `vmap`
 
-+++ {"colab_type": "text", "id": "PcxkONy5aius"}
-
 JAX has one more transformation in its API that you might find useful: `vmap`, the vectorizing map. It has the familiar semantics of mapping a function along array axes, but instead of keeping the loop on the outside, it pushes the loop down into a function’s primitive operations for better performance. When composed with `jit`, it can be just as fast as adding the batch dimensions by hand.
-
-+++ {"colab_type": "text", "id": "TPiX4y-bWLFS"}
 
 We're going to work with a simple example, and promote matrix-vector products into matrix-matrix products using `vmap`. Although this is easy to do by hand in this specific case, the same technique can apply to more complicated functions.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: 8w0Gpsn8WYYj
-
 mat = random.normal(key, (150, 100))
 batched_x = random.normal(key, (10, 100))
 
@@ -258,15 +168,9 @@ def apply_matrix(v):
   return jnp.dot(mat, v)
 ```
 
-+++ {"id": "0zWsc0RisQWx", "colab_type": "text"}
-
 Given a function such as `apply_matrix`, we can loop over a batch dimension in Python, but usually the performance of doing so is poor.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: KWVc9BsZv0Ki
-
 def naively_batched_apply_matrix(v_batched):
   return jnp.stack([apply_matrix(v) for v in v_batched])
 
@@ -274,15 +178,9 @@ print('Naively batched')
 %timeit naively_batched_apply_matrix(batched_x).block_until_ready()
 ```
 
-+++ {"id": "qHfKaLE9stbA", "colab_type": "text"}
-
 We know how to batch this operation manually. In this case, `jnp.dot` handles extra batch dimensions transparently.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: ipei6l8nvrzH
-
 @jit
 def batched_apply_matrix(v_batched):
   return jnp.dot(v_batched, mat.T)
@@ -291,15 +189,9 @@ print('Manually batched')
 %timeit batched_apply_matrix(batched_x).block_until_ready()
 ```
 
-+++ {"id": "1eF8Nhb-szAb", "colab_type": "text"}
-
 However, suppose we had a more complicated function without batching support. We can use `vmap` to add batching support automatically.
 
 ```{code-cell}
-:colab: {}
-:colab_type: code
-:id: 67Oeknf5vuCl
-
 @jit
 def vmap_batched_apply_matrix(v_batched):
   return vmap(apply_matrix)(v_batched)
@@ -308,10 +200,6 @@ print('Auto-vectorized with vmap')
 %timeit vmap_batched_apply_matrix(batched_x).block_until_ready()
 ```
 
-+++ {"colab_type": "text", "id": "pYVl3Z2nbZhO"}
-
 Of course, `vmap` can be arbitrarily composed with `jit`, `grad`, and any other JAX transformation.
-
-+++ {"id": "WwNnjaI4th_8", "colab_type": "text"}
 
 This is just a taste of what JAX can do. We're really excited to see what you do with it!

--- a/docs/notebooks/score_matching.ipynb
+++ b/docs/notebooks/score_matching.ipynb
@@ -2,14 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "U6IRW9a8G6TB"
-   },
+   "metadata": {},
    "source": [
     "# Generative Modeling by Estimating Gradients of Data Distribution in JAX\n",
     "\n",
-    "[![Run in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
+    "[![Run in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
     "\n",
     "In this notebook we'll implement __Generative Modeling by Estimating Gradients of the Data Distribution__ [[arxiv]](https://arxiv.org/abs/1907.05600).\n",
     "\n",
@@ -25,15 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 286
-    },
-    "colab_type": "code",
-    "id": "0P1xCZPNG6TE",
-    "outputId": "69be38a1-1f02-462e-f4f1-16a41c35fddf"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -77,10 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "5X-LN4rwG6TH"
-   },
+   "metadata": {},
    "source": [
     "### Compute score matching objective\n",
     "\n",
@@ -98,11 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "98wjxKcNG6TI"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax\n",
@@ -125,11 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "FgH-YVaZG6TJ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# v-- jax.jit compiles a function for efficient CPU and GPU execution\n",
@@ -153,37 +131,22 @@
     "    net_params = get_params(opt_state)\n",
     "    loss = compute_loss(net_params, batch)\n",
     "    grads = jax.grad(compute_loss, argnums=0)(net_params, batch)\n",
-    "    return loss, opt_update(step_i, grads, opt_state)"
+    "    return loss, opt_update(step_i, grads, opt_state)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "LkTYRi6qCwn8"
-   },
+   "metadata": {},
    "source": [
-    "__Note__: we use `jax.jacfwd` since the input dimension is only 2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Qxza8fDvG6TL"
-   },
-   "source": [
+    "__Note__: we use `jax.jacfwd` since the input dimension is only 2\n",
+    "\n",
     "### Training loop"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "NNlbbWNIG6TM"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from IPython.display import clear_output\n",
@@ -197,15 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 499
-    },
-    "colab_type": "code",
-    "id": "evDOnCHiG6TN",
-    "outputId": "989db5fe-24a2-41ba-fb01-6d981df7cd06"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -249,10 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Ug91tS-RG6TP"
-   },
+   "metadata": {},
    "source": [
     "### Plot gradient directions\n",
     "Once the model is trained we can use it to predict scores at each point. Since those are gradient vectors, we'll use [`Quiver Plot`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.quiver.html) to draw them."
@@ -261,15 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 938
-    },
-    "colab_type": "code",
-    "id": "x6SkLg0VG6TQ",
-    "outputId": "710ab2f4-c3c7-4a3b-f929-e84957fbb233"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -311,23 +255,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "yewoL6wqG6TS"
-   },
+   "metadata": {},
    "source": [
     "A hot new paper by [Song et al. (2019)](https://arxiv.org/abs/1907.05600) uses this method to generate images by iterative refinement... Apparently it took DL researchers 14 years to understand the proof :)\n",
     "\n",
-    "Seriously though, this paper takes advantage of two new ideas: sampling with __Langevin Dynamics__ and scaling to high dimensions with __Sliced Score Matching__. We'll cover them one at a time."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "gsXvXhgfG6TS"
-   },
-   "source": [
+    "Seriously though, this paper takes advantage of two new ideas: sampling with __Langevin Dynamics__ and scaling to high dimensions with __Sliced Score Matching__. We'll cover them one at a time.\n",
+    "\n",
     "```\n",
     "\n",
     "```\n",
@@ -372,11 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Byq9q1XdG6TT"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def sample_langevin(x_initial, *, net_params, key, eps=1e-2, eps_decay=0.9, num_steps=15, temperature=1.0):\n",
@@ -396,15 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 938
-    },
-    "colab_type": "code",
-    "id": "n6ZWX9Z1G6TV",
-    "outputId": "4e061bf6-93c5-4d96-cc9b-7e2d8b8899af"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -461,10 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "vZrW00brG6TX"
-   },
+   "metadata": {},
    "source": [
     "### Sliced Score Matching\n",
     "\n",
@@ -480,11 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "MkAXz0SmG6TY"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@jax.jit\n",
@@ -511,10 +425,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GWaKgphWCwoi"
-   },
+   "metadata": {},
    "source": [
     "__Note:__ we compute Jacobian with `jax.jacfwd` (forward-mode differentiation) because the input dimension of the network is just 2. You can read more about autograd modes in jax [documentation](https://jax.readthedocs.io/en/latest/jax.html?highlight=jacfwd#jax.jacfwd) and on wikipedia [wiki](https://en.wikipedia.org/wiki/Automatic_differentiation)"
    ]
@@ -522,11 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8dxK2pCxG6Tb"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "key = jax.random.PRNGKey(42)\n",
@@ -540,15 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 499
-    },
-    "colab_type": "code",
-    "id": "hQyo8kvTG6Tc",
-    "outputId": "184f28fc-4c6d-418a-9c28-e248b8633fbe"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -594,10 +493,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "A8Ni7_cGG6Tf"
-   },
+   "metadata": {},
    "source": [
     "## Easy? Let's go deeper!\n",
     "MNIST 8x8, computing full jacobian would require 64 passes through the network"
@@ -606,15 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 109
-    },
-    "colab_type": "code",
-    "id": "Y2ZgeMq-G6Tf",
-    "outputId": "435e69a1-3544-4364-b30c-c066feda7064"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -648,11 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "rKSjSWQXG6Th"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Set up network to predict scores\n",
@@ -676,15 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 281
-    },
-    "colab_type": "code",
-    "id": "YxWvSQJAG6Ti",
-    "outputId": "ae47197d-0aa3-496c-83f6-d10328461a00"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -717,13 +593,6 @@
    "cell_type": "code",
    "execution_count": 37,
    "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 281
-    },
-    "colab_type": "code",
-    "id": "gof2XcxwG6Tk",
-    "outputId": "02472a07-4931-4444-d406-344907619a01",
     "scrolled": false
    },
    "outputs": [
@@ -756,10 +625,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "jMfcQxhWG6Tm"
-   },
+   "metadata": {},
    "source": [
     "### This is just the beginning\n",
     "\n",

--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "id": "aPUwOm-eCSFD",
     "nbsphinx": "hidden"
    },
    "outputs": [],
@@ -25,21 +24,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "LQHmwePqryRU"
-   },
+   "metadata": {},
    "source": [
     "# How to Think in JAX\n",
     "\n",
-    "JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "nayIExVUtsVD"
-   },
-   "source": [
+    "JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively.\n",
+    "\n",
     "## JAX vs. NumPy\n",
     "\n",
     "**Key Concepts:**\n",
@@ -54,14 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 265
-    },
-    "id": "kZaOXL7-uvUP",
-    "outputId": "17a9ee0a-8719-44bb-a9fe-4c9f24649fef"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -89,14 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 282
-    },
-    "id": "18XbGpRLuZlr",
-    "outputId": "9e98d928-1925-45b1-d886-37956ca95e7c"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -129,9 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "kTZcsCJiuPG8"
-   },
+   "metadata": {},
    "source": [
     "The code blocks are identical aside from replacing `np` with `jnp`, and the results are the same. As we can see, JAX arrays can often be used directly in place of NumPy arrays for things like plotting.\n",
     "\n",
@@ -141,13 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "PjFFunI7xNe8",
-    "outputId": "e1706c61-2821-437a-efcd-d8082f913c1f"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -169,13 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "kpv5K7QYxQnX",
-    "outputId": "8a3f1cb6-c6d6-494c-8efe-24a8217a9d55"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -196,9 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Mx94Ri7euEZm"
-   },
+   "metadata": {},
    "source": [
     "Python's [duck-typing](https://en.wikipedia.org/wiki/Duck_typing) allows JAX arrays and NumPy arrays to be used interchangeably in many places.\n",
     "\n",
@@ -210,13 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "fzp-y1ZVyGD4",
-    "outputId": "300a44cc-1ccd-4fb2-f0ee-2179763f7690"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -235,9 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "nQ-De0xcJ1lT"
-   },
+   "metadata": {},
    "source": [
     "The equivalent in JAX results in an error, as JAX arrays are immutable:"
    ]
@@ -245,17 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 215
-    },
-    "id": "pCPX0JR-yM4i",
-    "outputId": "02a442bc-8f23-4dce-9500-81cd28c0b21f",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "TypeError",
@@ -277,9 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "yRYF0YgO3F4H"
-   },
+   "metadata": {},
    "source": [
     "For updating individual elements, JAX provides an [indexed update syntax](https://jax.readthedocs.io/en/latest/jax.ops.html#syntactic-sugar-for-indexed-update-operators) that returns an updated copy:"
    ]
@@ -287,13 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "8zqPEAeP3UK5",
-    "outputId": "7e6c996d-d0b0-4d52-e722-410ba78eb3b1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -312,9 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "886BGDPeyXCu"
-   },
+   "metadata": {},
    "source": [
     "## NumPy, lax & XLA: JAX API layering\n",
     "\n",
@@ -322,15 +254,8 @@
     "\n",
     "- `jax.numpy` is a high-level wrapper that provides a familiar interface.\n",
     "- `jax.lax` is a lower-level API that is stricter and often more powerful.\n",
-    "- All JAX operations are implemented in terms of operations in [XLA](https://www.tensorflow.org/xla/) – the Accelerated Linear Algebra compiler."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BjE4m2sZy4hh"
-   },
-   "source": [
+    "- All JAX operations are implemented in terms of operations in [XLA](https://www.tensorflow.org/xla/) – the Accelerated Linear Algebra compiler.\n",
+    "\n",
     "If you look at the source of `jax.numpy`, you'll see that all the operations are eventually expressed in terms of functions defined in `jax.lax`. You can think of `jax.lax` as a stricter, but often more powerful, API for working with multi-dimensional arrays.\n",
     "\n",
     "For example, while `jax.numpy` will implicitly promote arguments to allow operations between mixed data types, `jax.lax` will not:"
@@ -339,13 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "c6EFPcj12mw0",
-    "outputId": "730e2ca4-30a5-45bc-923c-c3a5143496e2"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -368,17 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 181
-    },
-    "id": "0VkqlcXL2qSp",
-    "outputId": "601b0562-3e6a-402d-f83b-3afdd1e7e7c4",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "TypeError",
@@ -399,9 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "aC9TkXaTEu7A"
-   },
+   "metadata": {},
    "source": [
     "If using `jax.lax` directly, you'll have to do type promotion explicitly in such cases:"
    ]
@@ -409,13 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "3PNQlieT81mi",
-    "outputId": "cb3ed074-f410-456f-c086-23107eae2634"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -436,9 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "M3HDuM4x2eTL"
-   },
+   "metadata": {},
    "source": [
     "Along with this strictness, `jax.lax` also provides efficient APIs for some more general operations than are supported by NumPy.\n",
     "\n",
@@ -448,13 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Bv-7XexyzVCN",
-    "outputId": "f5d38cd8-e7fc-49e2-bff3-a0eee306cb54"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -477,9 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0GPqgT7S0q8r"
-   },
+   "metadata": {},
    "source": [
     "Under the hood, this NumPy operation is translated to a much more general convolution implemented by [`lax.conv_general_dilated`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.conv_general_dilated.html):"
    ]
@@ -487,13 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "pi4f6ikjzc3l",
-    "outputId": "b9b37edc-b911-4010-aaf8-ee8f500111d7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -520,22 +405,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7mdo6ycczlbd"
-   },
+   "metadata": {},
    "source": [
     "This is a batched convolution operation designed to be efficient for the types of convolutions often used in deep neural nets. It requires much more boilerplate, but is far more flexible and scalable than the convolution provided by NumPy (See [JAX Sharp Bits: Convolutions](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Convolutions) for more detail on JAX convolutions).\n",
     "\n",
     "At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.tensorflow.org/xla/operation_semantics#convwithgeneralpadding_convolution).\n",
-    "Every JAX operation is eventually expressed in terms of these fundamental XLA operations, which is what enables just-in-time (JIT) compilation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "NJfWa2PktD5_"
-   },
-   "source": [
+    "Every JAX operation is eventually expressed in terms of these fundamental XLA operations, which is what enables just-in-time (JIT) compilation.\n",
+    "\n",
     "## To JIT or not to JIT\n",
     "\n",
     "**Key Concepts:**\n",
@@ -552,9 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "id": "SQj_UKGc-7kQ"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import jax.numpy as jnp\n",
@@ -566,9 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0yVo_OKSAolW"
-   },
+   "metadata": {},
    "source": [
     "A just-in-time compiled version of the function can be created using the `jax.jit` transform:"
    ]
@@ -576,9 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "id": "oHLwGmhZAnCY"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from jax import jit\n",
@@ -587,9 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Q3H9ig5GA2Ms"
-   },
+   "metadata": {},
    "source": [
     "This function returns the same results as the original, up to standard floating-point accuracy:"
    ]
@@ -597,13 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "oz7zzyS3AwMc",
-    "outputId": "914f9242-82c4-4365-abb2-77843a704e03"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -626,9 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "3GvisB-CA9M8"
-   },
+   "metadata": {},
    "source": [
     "But due to the compilation (which includes fusing of operations, avoidance of allocating temporary arrays, and a host of other tricks), execution times can be orders of magnitude faster in the JIT-compiled case (note the use of `block_until_ready()` to account for JAX's [asynchronous dispatch](https://jax.readthedocs.io/en/latest/async_dispatch.html)):"
    ]
@@ -636,13 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "6mUB6VdDAEIY",
-    "outputId": "5d7e1bbd-4064-4fe3-f3d9-5435b5283199"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -660,9 +514,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "B1eGBGn0tMba"
-   },
+   "metadata": {},
    "source": [
     "That said, `jax.jit` does have limitations: in particular, it requires all arrays to have static shapes. That means that some JAX operations are incompatible with JIT compilation.\n",
     "\n",
@@ -672,13 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "YfZd9mW7CSKM",
-    "outputId": "899fedcc-0857-4381-8f57-bb653e0aa2f1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -703,9 +549,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "g6niKxoQC2mZ"
-   },
+   "metadata": {},
    "source": [
     "But it returns an error if you attempt to execute it in jit mode:"
    ]
@@ -713,17 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 164
-    },
-    "id": "yYWvE4rxCjPK",
-    "outputId": "765b46d3-49cd-41b7-9815-e8bb7cd80175",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "IndexError",
@@ -743,19 +577,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "vFL6DNpECfVz"
-   },
+   "metadata": {},
    "source": [
-    "This is because the function generates an array whose shape is not known at compile time: the size of the output depends on the values of the input array, and so it is not compatible with JIT."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "BzBnKbXwXjLV"
-   },
-   "source": [
+    "This is because the function generates an array whose shape is not known at compile time: the size of the output depends on the values of the input array, and so it is not compatible with JIT.\n",
+    "\n",
     "## JIT mechanics: tracing and static variables\n",
     "\n",
     "**Key Concepts:**\n",
@@ -770,13 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "TfjVIVuD4gnc",
-    "outputId": "df6ad898-b047-4ad1-eb18-2fbcb3fd2ab3"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -818,9 +637,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Ts1fP45A40QV"
-   },
+   "metadata": {},
    "source": [
     "Notice that the print statements execute, but rather than printing the data we passed to the function, though, it prints *tracer* objects that stand-in for them.\n",
     "\n",
@@ -832,13 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "xGntvzNH7skE",
-    "outputId": "66694b8b-181f-4635-a8e2-1fc7f244d94b"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -861,9 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9EB9WkRX7fm0"
-   },
+   "metadata": {},
    "source": [
     "The extracted sequence of operations is encoded in a JAX expression, or *jaxpr* for short. You can view the jaxpr using the `jax.make_jaxpr` transformation:"
    ]
@@ -871,13 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "89TMp_Op5-JZ",
-    "outputId": "151210e2-af6f-4950-ac1e-9fdb81d4aae1"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -908,9 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0Oq9S4MZ90TL"
-   },
+   "metadata": {},
    "source": [
     "Note one consequence of this: because JIT compilation is done *without* information on the content of the array, control flow statements in the function cannot depend on traced values. For example, this fails:"
    ]
@@ -918,17 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 419
-    },
-    "id": "A0rFdM95-Ix_",
-    "outputId": "d7ffa367-b241-488e-df96-ad0576536605",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "ConcretizationTypeError",
@@ -952,9 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "DkTO9m8j-TYI"
-   },
+   "metadata": {},
    "source": [
     "If there are variables that you would not like to be traced, they can be marked as static for the purposes of JIT compilation:"
    ]
@@ -962,13 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "K1C7ZnVv-lbv",
-    "outputId": "cdbdf152-30fd-4ecb-c9ec-1d1124f337f7"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -995,9 +778,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "dD7p4LRsGzhx"
-   },
+   "metadata": {},
    "source": [
     "Note that calling a JIT-compiled function with a different static argument results in re-compilation, so the function still works as expected:"
    ]
@@ -1005,13 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "sXqczBOrG7-w",
-    "outputId": "3a3f50e6-d1fc-42bb-d6df-eb3d206e4b67"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1032,19 +807,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ZESlrDngGVb1"
-   },
+   "metadata": {},
    "source": [
-    "Understanding which values and operations will be static and which will be traced is a key part of using `jax.jit` effectively."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "r-RCl_wD5lI7"
-   },
-   "source": [
+    "Understanding which values and operations will be static and which will be traced is a key part of using `jax.jit` effectively.\n",
+    "\n",
     "## Static vs Traced Operations\n",
     "\n",
     "**Key Concepts:**\n",
@@ -1061,17 +827,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 385
-    },
-    "id": "XJCQ7slcD4iU",
-    "outputId": "a89a5614-7359-4dc7-c165-03e7d0fc6610",
-    "tags": [
-     "raises-exception"
-    ]
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "ConcretizationTypeError",
@@ -1099,9 +855,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ZO3GMGrHBZDS"
-   },
+   "metadata": {},
    "source": [
     "This fails with an error specifying that a tracer was found in `jax.numpy.reshape`. Let's add some print statements to the function to understand why this is happening:"
    ]
@@ -1109,13 +863,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Cb4mbeVZEi_q",
-    "outputId": "f72c1ce3-950c-400f-bfea-10c0d0118911"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1141,9 +889,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "viSQPc3jEwJr"
-   },
+   "metadata": {},
    "source": [
     "Notice that although `x` is traced, `x.shape` is a static value. However, when we use `jnp.array` and `jnp.prod` on this static value, it becomes a traced value, at which point it cannot be used in a function like `reshape()` that requires a static input (recall: array shapes must be static).\n",
     "\n",
@@ -1153,13 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "GiovOOPcGJhg",
-    "outputId": "399ee059-1807-4866-9beb-1c5131e38e15"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1188,9 +928,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "C-QZ5d1DG-dv"
-   },
+   "metadata": {},
    "source": [
     "For this reason, a standard convention in JAX programs is to `import numpy as np` and `import jax.numpy as jnp` so that both interfaces are available for finer control over whether operations are performed in a static matter (with `numpy`, once at compile-time) or a traced manner (with `jax.numpy`, optimized at run-time)."
    ]

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -12,7 +12,6 @@ kernelspec:
 ---
 
 ```{code-cell}
-:id: aPUwOm-eCSFD
 :nbsphinx: hidden
 
 # Configure ipython to hide long tracebacks.
@@ -29,13 +28,9 @@ def minimal_traceback(*args, **kwargs):
 ipython.showtraceback = minimal_traceback
 ```
 
-+++ {"id": "LQHmwePqryRU"}
-
 # How to Think in JAX
 
 JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively.
-
-+++ {"id": "nayIExVUtsVD"}
 
 ## JAX vs. NumPy
 
@@ -48,13 +43,6 @@ JAX provides a simple and powerful API for writing accelerated numerical code, b
 NumPy provides a well-known, powerful API for working with numerical data. For convenience, JAX provides `jax.numpy` which closely mirrors the numpy API and provides easy entry into JAX. Almost anything that can be done with `numpy` can be done with `jax.numpy`:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 265
-id: kZaOXL7-uvUP
-outputId: 17a9ee0a-8719-44bb-a9fe-4c9f24649fef
----
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -64,13 +52,6 @@ plt.plot(x_np, y_np);
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 282
-id: 18XbGpRLuZlr
-outputId: 9e98d928-1925-45b1-d886-37956ca95e7c
----
 import jax.numpy as jnp
 
 x_jnp = jnp.linspace(0, 10, 1000)
@@ -78,33 +59,17 @@ y_jnp = 2 * jnp.sin(x_jnp) * jnp.cos(x_jnp)
 plt.plot(x_jnp, y_jnp);
 ```
 
-+++ {"id": "kTZcsCJiuPG8"}
-
 The code blocks are identical aside from replacing `np` with `jnp`, and the results are the same. As we can see, JAX arrays can often be used directly in place of NumPy arrays for things like plotting.
 
 The arrays themselves are implemented as different Python types:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: PjFFunI7xNe8
-outputId: e1706c61-2821-437a-efcd-d8082f913c1f
----
 type(x_np)
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: kpv5K7QYxQnX
-outputId: 8a3f1cb6-c6d6-494c-8efe-24a8217a9d55
----
 type(x_jnp)
 ```
-
-+++ {"id": "Mx94Ri7euEZm"}
 
 Python's [duck-typing](https://en.wikipedia.org/wiki/Duck_typing) allows JAX arrays and NumPy arrays to be used interchangeably in many places.
 
@@ -113,53 +78,27 @@ However, there is one important difference between JAX and NumPy arrays: JAX arr
 Here is an example of mutating an array in NumPy:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: fzp-y1ZVyGD4
-outputId: 300a44cc-1ccd-4fb2-f0ee-2179763f7690
----
 # NumPy: mutable arrays
 x = np.arange(10)
 x[0] = 10
 print(x)
 ```
 
-+++ {"id": "nQ-De0xcJ1lT"}
-
 The equivalent in JAX results in an error, as JAX arrays are immutable:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 215
-id: pCPX0JR-yM4i
-outputId: 02a442bc-8f23-4dce-9500-81cd28c0b21f
-tags: [raises-exception]
----
 # JAX: immutable arrays
 x = jnp.arange(10)
 x[0] = 10
 ```
 
-+++ {"id": "yRYF0YgO3F4H"}
-
 For updating individual elements, JAX provides an [indexed update syntax](https://jax.readthedocs.io/en/latest/jax.ops.html#syntactic-sugar-for-indexed-update-operators) that returns an updated copy:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 8zqPEAeP3UK5
-outputId: 7e6c996d-d0b0-4d52-e722-410ba78eb3b1
----
 y = x.at[0].set(10)
 print(x)
 print(y)
 ```
-
-+++ {"id": "886BGDPeyXCu"}
 
 ## NumPy, lax & XLA: JAX API layering
 
@@ -169,79 +108,39 @@ print(y)
 - `jax.lax` is a lower-level API that is stricter and often more powerful.
 - All JAX operations are implemented in terms of operations in [XLA](https://www.tensorflow.org/xla/) – the Accelerated Linear Algebra compiler.
 
-+++ {"id": "BjE4m2sZy4hh"}
-
 If you look at the source of `jax.numpy`, you'll see that all the operations are eventually expressed in terms of functions defined in `jax.lax`. You can think of `jax.lax` as a stricter, but often more powerful, API for working with multi-dimensional arrays.
 
 For example, while `jax.numpy` will implicitly promote arguments to allow operations between mixed data types, `jax.lax` will not:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: c6EFPcj12mw0
-outputId: 730e2ca4-30a5-45bc-923c-c3a5143496e2
----
 import jax.numpy as jnp
 jnp.add(1, 1.0)  # jax.numpy API implicitly promotes mixed types.
 ```
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 181
-id: 0VkqlcXL2qSp
-outputId: 601b0562-3e6a-402d-f83b-3afdd1e7e7c4
-tags: [raises-exception]
----
 from jax import lax
 lax.add(1, 1.0)  # jax.lax API requires explicit type promotion.
 ```
 
-+++ {"id": "aC9TkXaTEu7A"}
-
 If using `jax.lax` directly, you'll have to do type promotion explicitly in such cases:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 3PNQlieT81mi
-outputId: cb3ed074-f410-456f-c086-23107eae2634
----
 lax.add(jnp.float32(1), 1.0)
 ```
-
-+++ {"id": "M3HDuM4x2eTL"}
 
 Along with this strictness, `jax.lax` also provides efficient APIs for some more general operations than are supported by NumPy.
 
 For example, consider a 1D convolution, which can be expressed in NumPy this way:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Bv-7XexyzVCN
-outputId: f5d38cd8-e7fc-49e2-bff3-a0eee306cb54
----
 x = jnp.array([1, 2, 1])
 y = jnp.ones(10)
 jnp.convolve(x, y)
 ```
 
-+++ {"id": "0GPqgT7S0q8r"}
-
 Under the hood, this NumPy operation is translated to a much more general convolution implemented by [`lax.conv_general_dilated`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.conv_general_dilated.html):
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: pi4f6ikjzc3l
-outputId: b9b37edc-b911-4010-aaf8-ee8f500111d7
----
 from jax import lax
 result = lax.conv_general_dilated(
     x.reshape(1, 1, 3).astype(float),  # note: explicit promotion
@@ -251,14 +150,10 @@ result = lax.conv_general_dilated(
 result[0, 0]
 ```
 
-+++ {"id": "7mdo6ycczlbd"}
-
 This is a batched convolution operation designed to be efficient for the types of convolutions often used in deep neural nets. It requires much more boilerplate, but is far more flexible and scalable than the convolution provided by NumPy (See [JAX Sharp Bits: Convolutions](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-Convolutions) for more detail on JAX convolutions).
 
 At their heart, all `jax.lax` operations are Python wrappers for operations in XLA; here, for example, the convolution implementation is provided by [XLA:ConvWithGeneralPadding](https://www.tensorflow.org/xla/operation_semantics#convwithgeneralpadding_convolution).
 Every JAX operation is eventually expressed in terms of these fundamental XLA operations, which is what enables just-in-time (JIT) compilation.
-
-+++ {"id": "NJfWa2PktD5_"}
 
 ## To JIT or not to JIT
 
@@ -273,8 +168,6 @@ The fact that all JAX operations are expressed in terms of XLA allows JAX to use
 For example, consider this function that normalizes the rows of a 2D matrix, expressed in terms of `jax.numpy` operations:
 
 ```{code-cell}
-:id: SQj_UKGc-7kQ
-
 import jax.numpy as jnp
 
 def norm(X):
@@ -282,61 +175,33 @@ def norm(X):
   return X / X.std(0)
 ```
 
-+++ {"id": "0yVo_OKSAolW"}
-
 A just-in-time compiled version of the function can be created using the `jax.jit` transform:
 
 ```{code-cell}
-:id: oHLwGmhZAnCY
-
 from jax import jit
 norm_compiled = jit(norm)
 ```
 
-+++ {"id": "Q3H9ig5GA2Ms"}
-
 This function returns the same results as the original, up to standard floating-point accuracy:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: oz7zzyS3AwMc
-outputId: 914f9242-82c4-4365-abb2-77843a704e03
----
 np.random.seed(1701)
 X = jnp.array(np.random.rand(10000, 10))
 np.allclose(norm(X), norm_compiled(X), atol=1E-6)
 ```
 
-+++ {"id": "3GvisB-CA9M8"}
-
 But due to the compilation (which includes fusing of operations, avoidance of allocating temporary arrays, and a host of other tricks), execution times can be orders of magnitude faster in the JIT-compiled case (note the use of `block_until_ready()` to account for JAX's [asynchronous dispatch](https://jax.readthedocs.io/en/latest/async_dispatch.html)):
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 6mUB6VdDAEIY
-outputId: 5d7e1bbd-4064-4fe3-f3d9-5435b5283199
----
 %timeit norm(X).block_until_ready()
 %timeit norm_compiled(X).block_until_ready()
 ```
-
-+++ {"id": "B1eGBGn0tMba"}
 
 That said, `jax.jit` does have limitations: in particular, it requires all arrays to have static shapes. That means that some JAX operations are incompatible with JIT compilation.
 
 For example, this operation can be executed in op-by-op mode:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: YfZd9mW7CSKM
-outputId: 899fedcc-0857-4381-8f57-bb653e0aa2f1
----
 def get_negatives(x):
   return x[x < 0]
 
@@ -344,27 +209,13 @@ x = jnp.array(np.random.randn(10))
 get_negatives(x)
 ```
 
-+++ {"id": "g6niKxoQC2mZ"}
-
 But it returns an error if you attempt to execute it in jit mode:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 164
-id: yYWvE4rxCjPK
-outputId: 765b46d3-49cd-41b7-9815-e8bb7cd80175
-tags: [raises-exception]
----
 jit(get_negatives)(x)
 ```
 
-+++ {"id": "vFL6DNpECfVz"}
-
 This is because the function generates an array whose shape is not known at compile time: the size of the output depends on the values of the input array, and so it is not compatible with JIT.
-
-+++ {"id": "BzBnKbXwXjLV"}
 
 ## JIT mechanics: tracing and static variables
 
@@ -377,12 +228,6 @@ This is because the function generates an array whose shape is not known at comp
 To use `jax.jit` effectively, it is useful to understand how it works. Let's put a few `print()` statements within a JIT-compiled function and then call the function:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: TfjVIVuD4gnc
-outputId: df6ad898-b047-4ad1-eb18-2fbcb3fd2ab3
----
 @jit
 def f(x, y):
   print("Running f():")
@@ -397,8 +242,6 @@ y = np.random.randn(4)
 f(x, y)
 ```
 
-+++ {"id": "Ts1fP45A40QV"}
-
 Notice that the print statements execute, but rather than printing the data we passed to the function, though, it prints *tracer* objects that stand-in for them.
 
 These tracer objects are what `jax.jit` uses to extract the sequence of operations specified by the function. Basic tracers are stand-ins that encode the **shape** and **dtype** of the arrays, but are agnostic to the values. This recorded sequence of computations can then be efficiently applied within XLA to new inputs with the same shape and dtype, without having to re-execute the Python code.
@@ -406,28 +249,14 @@ These tracer objects are what `jax.jit` uses to extract the sequence of operatio
 When we call the compiled fuction again on matching inputs, no re-compilation is required and nothing is printed because the result is computed in compiled XLA rather than in Python:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: xGntvzNH7skE
-outputId: 66694b8b-181f-4635-a8e2-1fc7f244d94b
----
 x2 = np.random.randn(3, 4)
 y2 = np.random.randn(4)
 f(x2, y2)
 ```
 
-+++ {"id": "9EB9WkRX7fm0"}
-
 The extracted sequence of operations is encoded in a JAX expression, or *jaxpr* for short. You can view the jaxpr using the `jax.make_jaxpr` transformation:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: 89TMp_Op5-JZ
-outputId: 151210e2-af6f-4950-ac1e-9fdb81d4aae1
----
 from jax import make_jaxpr
 
 def f(x, y):
@@ -436,19 +265,9 @@ def f(x, y):
 make_jaxpr(f)(x, y)
 ```
 
-+++ {"id": "0Oq9S4MZ90TL"}
-
 Note one consequence of this: because JIT compilation is done *without* information on the content of the array, control flow statements in the function cannot depend on traced values. For example, this fails:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 419
-id: A0rFdM95-Ix_
-outputId: d7ffa367-b241-488e-df96-ad0576536605
-tags: [raises-exception]
----
 @jit
 def f(x, neg):
   return -x if neg else x
@@ -456,17 +275,9 @@ def f(x, neg):
 f(1, True)
 ```
 
-+++ {"id": "DkTO9m8j-TYI"}
-
 If there are variables that you would not like to be traced, they can be marked as static for the purposes of JIT compilation:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: K1C7ZnVv-lbv
-outputId: cdbdf152-30fd-4ecb-c9ec-1d1124f337f7
----
 from functools import partial
 
 @partial(jit, static_argnums=(1,))
@@ -476,25 +287,13 @@ def f(x, neg):
 f(1, True)
 ```
 
-+++ {"id": "dD7p4LRsGzhx"}
-
 Note that calling a JIT-compiled function with a different static argument results in re-compilation, so the function still works as expected:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: sXqczBOrG7-w
-outputId: 3a3f50e6-d1fc-42bb-d6df-eb3d206e4b67
----
 f(1, False)
 ```
 
-+++ {"id": "ZESlrDngGVb1"}
-
 Understanding which values and operations will be static and which will be traced is a key part of using `jax.jit` effectively.
-
-+++ {"id": "r-RCl_wD5lI7"}
 
 ## Static vs Traced Operations
 
@@ -509,14 +308,6 @@ Understanding which values and operations will be static and which will be trace
 This distinction between static and traced values makes it important to think about how to keep a static value static. Consider this function:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 385
-id: XJCQ7slcD4iU
-outputId: a89a5614-7359-4dc7-c165-03e7d0fc6610
-tags: [raises-exception]
----
 import jax.numpy as jnp
 from jax import jit
 
@@ -528,17 +319,9 @@ x = jnp.ones((2, 3))
 f(x)
 ```
 
-+++ {"id": "ZO3GMGrHBZDS"}
-
 This fails with an error specifying that a tracer was found in `jax.numpy.reshape`. Let's add some print statements to the function to understand why this is happening:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: Cb4mbeVZEi_q
-outputId: f72c1ce3-950c-400f-bfea-10c0d0118911
----
 @jit
 def f(x):
   print(f"x = {x}")
@@ -550,19 +333,11 @@ def f(x):
 f(x)
 ```
 
-+++ {"id": "viSQPc3jEwJr"}
-
 Notice that although `x` is traced, `x.shape` is a static value. However, when we use `jnp.array` and `jnp.prod` on this static value, it becomes a traced value, at which point it cannot be used in a function like `reshape()` that requires a static input (recall: array shapes must be static).
 
 A useful pattern is to use `numpy` for operations that should be static (i.e. done at compile-time), and use `jax.numpy` for operations that should be traced (i.e. compiled and executed at run-time). For this function, it might look like this:
 
 ```{code-cell}
----
-colab:
-  base_uri: https://localhost:8080/
-id: GiovOOPcGJhg
-outputId: 399ee059-1807-4866-9beb-1c5131e38e15
----
 from jax import jit
 import jax.numpy as jnp
 import numpy as np
@@ -573,7 +348,5 @@ def f(x):
 
 f(x)
 ```
-
-+++ {"id": "C-QZ5d1DG-dv"}
 
 For this reason, a standard convention in JAX programs is to `import numpy as np` and `import jax.numpy as jnp` so that both interfaces are available for finer control over whether operations are performed in a static matter (with `numpy`, once at compile-time) or a traced manner (with `jax.numpy`, optimized at run-time).

--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "6umP1IKf4Dg6"
-   },
+   "metadata": {},
    "source": [
     "# Autobatching log-densities example\n",
     "\n",
@@ -17,11 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "8RZDkfbV3zdR"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import functools\n",
@@ -45,10 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "p2VcZS1d34C6"
-   },
+   "metadata": {},
    "source": [
     "## Generate a fake binary classification dataset"
    ]
@@ -56,11 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "pq41hMvn4c_i"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(10009)\n",
@@ -76,15 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 102
-    },
-    "colab_type": "code",
-    "id": "O0nVumAw7IlT",
-    "outputId": "751a3290-a81b-4538-9183-16cd685fbaf9"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -109,34 +87,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "DZRVvhpn5aB1"
-   },
+   "metadata": {},
    "source": [
     "## Write the log-joint function for the model\n",
     "\n",
-    "We'll write a non-batched version, a manually batched version, and an autobatched version."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "C_mDXInL7nsP"
-   },
-   "source": [
+    "We'll write a non-batched version, a manually batched version, and an autobatched version.\n",
+    "\n",
     "### Non-batched"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "ZHyL2sJh5ajG"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def log_joint(beta):\n",
@@ -150,15 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "e51qW0ro6J7C",
-    "outputId": "2ec6bbbd-12ee-45bc-af76-5111c53e4d5a"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -180,15 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "id": "fglQXK1Y6wnm",
-    "outputId": "2b934336-08ad-4776-9a58-aa575bf601eb"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -211,10 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "_lQ8MnKq7sLU"
-   },
+   "metadata": {},
    "source": [
     "### Manually batched"
    ]
@@ -222,11 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "2g5-4bQE7gRA"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def batched_log_joint(beta):\n",
@@ -247,15 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "KdDMr-Gy85CO",
-    "outputId": "db746654-68e9-43b8-ce3b-6e5682e22eb5"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -281,10 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "-uuGlHQ_85kd"
-   },
+   "metadata": {},
    "source": [
     "### Autobatched with vmap\n",
     "\n",
@@ -294,15 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "id": "SU20bouH8-Za",
-    "outputId": "ee450298-982f-4b9a-bed9-a6f9b8f63d92"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -326,34 +247,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "L1KNBo9y_yZJ"
-   },
+   "metadata": {},
    "source": [
     "## Self-contained variational inference example\n",
     "\n",
-    "A little code is copied from above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "lQTPaaQMJh8Y"
-   },
-   "source": [
+    "A little code is copied from above.\n",
+    "\n",
     "### Set up the (batched) log-joint function"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "AITXbaofA3Pm"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@jax.jit\n",
@@ -369,10 +275,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UmmFMQ8LJk6a"
-   },
+   "metadata": {},
    "source": [
     "### Define the ELBO and its gradient"
    ]
@@ -380,11 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "MJtnskL6BKwV"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def elbo(beta_loc, beta_log_scale, epsilon):\n",
@@ -397,10 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oQC7xKYnJrp5"
-   },
+   "metadata": {},
    "source": [
     "### Optimize the ELBO using SGD"
    ]
@@ -408,15 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
-    },
-    "colab_type": "code",
-    "id": "9JrD5nNgH715",
-    "outputId": "80bf62d8-821a-45c4-885c-528b2e449e97"
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -553,10 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "b3ZAe5fJJ2KM"
-   },
+   "metadata": {},
    "source": [
     "### Display the results\n",
     "\n",
@@ -566,15 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 463
-    },
-    "colab_type": "code",
-    "id": "zt1NBLoVHtOG",
-    "outputId": "fb159795-e6e7-497c-e501-9933ec761af4"
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -612,17 +489,6 @@
     "ylabel('Estimated beta')\n",
     "legend(loc='best')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "_bXdOlvUEJl0"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/vmapped_log_probs.md
+++ b/docs/notebooks/vmapped_log_probs.md
@@ -12,19 +12,13 @@ kernelspec:
   name: python3
 ---
 
-+++ {"colab_type": "text", "id": "6umP1IKf4Dg6"}
-
 # Autobatching log-densities example
 
 This notebook demonstrates a simple Bayesian inference example where autobatching makes user code easier to write, easier to read, and less likely to include bugs.
 
 Inspired by a notebook by @davmre.
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 8RZDkfbV3zdR
-
+```{code-cell}
 import functools
 import itertools
 import re
@@ -44,15 +38,9 @@ import numpy as np
 import scipy as sp
 ```
 
-+++ {"colab_type": "text", "id": "p2VcZS1d34C6"}
-
 ## Generate a fake binary classification dataset
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: pq41hMvn4c_i
-
+```{code-cell}
 np.random.seed(10009)
 
 num_features = 10
@@ -63,33 +51,17 @@ all_x = np.random.randn(num_points, num_features).astype(jnp.float32)
 y = (np.random.rand(num_points) < sp.special.expit(all_x.dot(true_beta))).astype(jnp.int32)
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 102
-colab_type: code
-id: O0nVumAw7IlT
-outputId: 751a3290-a81b-4538-9183-16cd685fbaf9
----
+```{code-cell}
 y
 ```
-
-+++ {"colab_type": "text", "id": "DZRVvhpn5aB1"}
 
 ## Write the log-joint function for the model
 
 We'll write a non-batched version, a manually batched version, and an autobatched version.
 
-+++ {"colab_type": "text", "id": "C_mDXInL7nsP"}
-
 ### Non-batched
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: ZHyL2sJh5ajG
-
+```{code-cell}
 def log_joint(beta):
     result = 0.
     # Note that no `axis` parameter is provided to `jnp.sum`.
@@ -98,27 +70,11 @@ def log_joint(beta):
     return result
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: e51qW0ro6J7C
-outputId: 2ec6bbbd-12ee-45bc-af76-5111c53e4d5a
----
+```{code-cell}
 log_joint(np.random.randn(num_features))
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 34
-colab_type: code
-id: fglQXK1Y6wnm
-outputId: 2b934336-08ad-4776-9a58-aa575bf601eb
----
+```{code-cell}
 # This doesn't work, because we didn't write `log_prob()` to handle batching.
 try:
   batch_size = 10
@@ -129,15 +85,9 @@ except ValueError as e:
   print("Caught expected exception " + str(e))
 ```
 
-+++ {"colab_type": "text", "id": "_lQ8MnKq7sLU"}
-
 ### Manually batched
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: 2g5-4bQE7gRA
-
+```{code-cell}
 def batched_log_joint(beta):
     result = 0.
     # Here (and below) `sum` needs an `axis` parameter. At best, forgetting to set axis
@@ -153,55 +103,29 @@ def batched_log_joint(beta):
     return result
 ```
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: KdDMr-Gy85CO
-outputId: db746654-68e9-43b8-ce3b-6e5682e22eb5
----
+```{code-cell}
 batch_size = 10
 batched_test_beta = np.random.randn(batch_size, num_features)
 
 batched_log_joint(batched_test_beta)
 ```
 
-+++ {"colab_type": "text", "id": "-uuGlHQ_85kd"}
-
 ### Autobatched with vmap
 
 It just works.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 68
-colab_type: code
-id: SU20bouH8-Za
-outputId: ee450298-982f-4b9a-bed9-a6f9b8f63d92
----
+```{code-cell}
 vmap_batched_log_joint = jax.vmap(log_joint)
 vmap_batched_log_joint(batched_test_beta)
 ```
-
-+++ {"colab_type": "text", "id": "L1KNBo9y_yZJ"}
 
 ## Self-contained variational inference example
 
 A little code is copied from above.
 
-+++ {"colab_type": "text", "id": "lQTPaaQMJh8Y"}
-
 ### Set up the (batched) log-joint function
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: AITXbaofA3Pm
-
+```{code-cell}
 @jax.jit
 def log_joint(beta):
     result = 0.
@@ -213,15 +137,9 @@ def log_joint(beta):
 batched_log_joint = jax.jit(jax.vmap(log_joint))
 ```
 
-+++ {"colab_type": "text", "id": "UmmFMQ8LJk6a"}
-
 ### Define the ELBO and its gradient
 
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: MJtnskL6BKwV
-
+```{code-cell}
 def elbo(beta_loc, beta_log_scale, epsilon):
     beta_sample = beta_loc + jnp.exp(beta_log_scale) * epsilon
     return jnp.mean(batched_log_joint(beta_sample), 0) + jnp.sum(beta_log_scale - 0.5 * np.log(2*np.pi))
@@ -230,19 +148,9 @@ elbo = jax.jit(elbo)
 elbo_val_and_grad = jax.jit(jax.value_and_grad(elbo, argnums=(0, 1)))
 ```
 
-+++ {"colab_type": "text", "id": "oQC7xKYnJrp5"}
-
 ### Optimize the ELBO using SGD
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 1000
-colab_type: code
-id: 9JrD5nNgH715
-outputId: 80bf62d8-821a-45c4-885c-528b2e449e97
----
+```{code-cell}
 def normal_sample(key, shape):
     """Convenience function for quasi-stateful RNG."""
     new_key, sub_key = random.split(key)
@@ -268,21 +176,11 @@ for i in range(1000):
         print('{}\t{}'.format(i, elbo_val))
 ```
 
-+++ {"colab_type": "text", "id": "b3ZAe5fJJ2KM"}
-
 ### Display the results
 
 Coverage isn't quite as good as we might like, but it's not bad, and nobody said variational inference was exact.
 
-```{code-cell} ipython3
----
-colab:
-  base_uri: https://localhost:8080/
-  height: 463
-colab_type: code
-id: zt1NBLoVHtOG
-outputId: fb159795-e6e7-497c-e501-9933ec761af4
----
+```{code-cell}
 figure(figsize=(7, 7))
 plot(true_beta, beta_loc, '.', label='Approximated Posterior Means')
 plot(true_beta, beta_loc + 2*jnp.exp(beta_log_scale), 'r.', label='Approximated Posterior $2\sigma$ Error Bars')
@@ -292,12 +190,4 @@ plot([-plot_scale, plot_scale], [-plot_scale, plot_scale], 'k')
 xlabel('True beta')
 ylabel('Estimated beta')
 legend(loc='best')
-```
-
-```{code-cell} ipython3
-:colab: {}
-:colab_type: code
-:id: _bXdOlvUEJl0
-
-
 ```


### PR DESCRIPTION
This makes the markdown source more readable. I accomplished this using a series of regex find/replace in the markdown versions, then ran `jupytext --sync`.

The only downside here is that cell IDs in the Colab versions of the notebooks will change, so if anyone was linking to a particular cell via that mechanism, the links will no longer find the correct cell. My judgment is that it's better to have a cleaner documentation source than to try to maintain consistent Colab cell IDs.