### PR TITLE
Replace AvalDimSharding, MeshDimAssignment and ShardedDeviceArray with the C++ object.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -49,7 +49,7 @@ from ..abstract_arrays import array_types
 from ..core import ConcreteArray, ShapedArray
 from .._src.util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,
                          extend_name_stack, wrap_name, assert_unreachable,
-                         tuple_insert, tuple_delete, curry)
+                         tuple_delete, curry)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from ..lib import pmap_lib
@@ -104,171 +104,164 @@ _UNSHARDED_INSTANCE = NoSharding()
 AvalDimSharding = Union[Unstacked, Chunked, NoSharding]
 MeshDimAssignment = Union[ShardedAxis, Replicated]
 
+if TYPE_CHECKING:
+  class ShardingSpec(NamedTuple):
+    sharding: List[AvalDimSharding]
+    mesh_mapping: List[MeshDimAssignment]
+else:
+  ShardingSpec = pmap_lib.ShardingSpec
 
-class ShardingSpec:
-  """Describes the sharding of an ndarray.
 
-  Attributes:
-    sharding: specifies how the array is supposed to get partitioned into chunks.
-      Its length should match the rank of the array. See the docstring of
-      `AvalDimSharding` for the supported partitioning schemes.
-    mesh_mapping` describes an assignments of the array chunks created by `sharding`
-      to a logical device mesh. The length of the tuple is equal to the rank of the
-      mesh. Each mesh dimension can either get partitions of data varying along one
-      of the sharded dimensions, or the data can be replicated. See the docstring of
-      `MeshDimAssignment` for more information.
-  """
-  sharding: Tuple[AvalDimSharding, ...]
-  mesh_mapping: Tuple[MeshDimAssignment, ...]
 
-  def __init__(self,
-               sharding: Iterable[AvalDimSharding],
-               mesh_mapping: Iterable[MeshDimAssignment]):
-    self.sharding = tuple(sharding)
-    assert all(x is not None for x in self.sharding)
-    self.mesh_mapping = tuple(mesh_mapping)
-
-  @property
-  def mesh_shape(self):
-    sharded_axis_sizes = []
-    for sharding in self.sharding:
-      if isinstance(sharding, NoSharding):
-        continue
-      elif isinstance(sharding, Unstacked):
-        sharded_axis_sizes.append(sharding.size)
-      elif isinstance(sharding, Chunked):
-        sharded_axis_sizes.extend(sharding.chunks)
-      else:
-        assert_unreachable(sharding)
-    return tuple(sharded_axis_sizes[a.axis] if isinstance(a, ShardedAxis) else a.replicas
-                 for a in self.mesh_mapping)
-
-  def sharding_proto(self):
-    """Converts a ShardingSpec to an OpSharding proto.
-
-    See
-    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/xla_data.proto#L601
-    for details on the OpSharding proto.
-    Unfortunately the semantics are not very well described in the proto spec, but the code here might help:
-    https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/experimental/xla_sharding/xla_sharding.py
-    """
-    mesh_shape = self.mesh_shape
-    mesh = np.arange(np.prod(mesh_shape)).reshape(mesh_shape)
-
-    sharded_axes = {}  # maps sharded axis identifiers to mesh axis indices to which they're mapped
-    replicated_maxes = []  # lists mesh axis identifiers to replicate over
-    for maxis, assignment in enumerate(self.mesh_mapping):
-      if isinstance(assignment, Replicated):
-        replicated_maxes.append(maxis)
-      elif isinstance(assignment, ShardedAxis):
-        sharded_axes[assignment.axis] = maxis
-      else:
-        assert_unreachable(assignment)
-
-    proto = xc.OpSharding()
-    if len(replicated_maxes) == len(self.mesh_mapping):
-      proto.type = xc.OpSharding.Type.REPLICATED
-      return proto
+def mesh_shape(self):
+  sharded_axis_sizes = []
+  for sharding in self.sharding:
+    if isinstance(sharding, NoSharding):
+      continue
+    elif isinstance(sharding, Unstacked):
+      sharded_axis_sizes.append(sharding.size)
+    elif isinstance(sharding, Chunked):
+      sharded_axis_sizes.extend(sharding.chunks)
     else:
-      proto.type = xc.OpSharding.Type.OTHER
+      assert_unreachable(sharding)
+  return tuple(sharded_axis_sizes[a.axis] if isinstance(a, ShardedAxis) else a.replicas
+               for a in self.mesh_mapping)
 
-    mesh_permutation = []
-    new_mesh_shape = []
-    next_sharded_axis = 0
-    for axis, sharding in enumerate(self.sharding):
-      if isinstance(sharding, NoSharding):
-        new_mesh_shape.append(1)  # Add a dummy mesh axis we won't be sharding over
-      elif isinstance(sharding, Chunked):
-        for nchunks in sharding.chunks:
-          maxis = sharded_axes[next_sharded_axis]
-          assert mesh_shape[maxis] == nchunks
-          mesh_permutation.append(maxis)
-          next_sharded_axis += 1
-        new_mesh_shape.append(int(np.prod(sharding.chunks)))
-      elif isinstance(sharding, Unstacked):
-        raise RuntimeError("Cannot convert unstacked sharding specs to XLA OpSharding")
-      else:
-        assert_unreachable(sharding)
+def sharding_proto(self):
+  """Converts a ShardingSpec to an OpSharding proto.
 
-    # Create the partial sharding proto if tensor is replicated over some mesh axes
-    if replicated_maxes:
-      new_mesh_shape.append(-1)
-      mesh_permutation.extend(replicated_maxes)
-      proto.replicate_on_last_tile_dim = True
+  See
+  https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/xla_data.proto#L601
+  for details on the OpSharding proto.
+  Unfortunately the semantics are not very well described in the proto spec, but the code here might help:
+  https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/experimental/xla_sharding/xla_sharding.py
+  """
+  mesh_shape = self.mesh_shape
+  mesh = np.arange(np.prod(mesh_shape)).reshape(mesh_shape)
 
-    proto_mesh = mesh.transpose(mesh_permutation).reshape(new_mesh_shape)
-    proto.tile_assignment_dimensions = list(proto_mesh.shape)
-    proto.tile_assignment_devices = list(proto_mesh.flat)
+  sharded_axes = {}  # maps sharded axis identifiers to mesh axis indices to which they're mapped
+  replicated_maxes = []  # lists mesh axis identifiers to replicate over
+  for maxis, assignment in enumerate(self.mesh_mapping):
+    if isinstance(assignment, Replicated):
+      replicated_maxes.append(maxis)
+    elif isinstance(assignment, ShardedAxis):
+      sharded_axes[assignment.axis] = maxis
+    else:
+      assert_unreachable(assignment)
+
+  proto = xc.OpSharding()
+  if len(replicated_maxes) == len(self.mesh_mapping):
+    proto.type = xc.OpSharding.Type.REPLICATED
     return proto
+  else:
+    proto.type = xc.OpSharding.Type.OTHER
 
-  def indices(self, shape: Tuple[int, ...]) -> np.ndarray:
-    """Returns NumPy-style indices corresponding to a sharding spec.
+  mesh_permutation = []
+  new_mesh_shape = []
+  next_sharded_axis = 0
+  for axis, sharding in enumerate(self.sharding):
+    if isinstance(sharding, NoSharding):
+      new_mesh_shape.append(1)  # Add a dummy mesh axis we won't be sharding over
+    elif isinstance(sharding, Chunked):
+      for nchunks in sharding.chunks:
+        maxis = sharded_axes[next_sharded_axis]
+        assert mesh_shape[maxis] == nchunks
+        mesh_permutation.append(maxis)
+        next_sharded_axis += 1
+      new_mesh_shape.append(int(np.prod(sharding.chunks)))
+    elif isinstance(sharding, Unstacked):
+      raise RuntimeError("Cannot convert unstacked sharding specs to XLA OpSharding")
+    else:
+      assert_unreachable(sharding)
 
-    Args:
-      shape: The shape of the logical array being sharded.
+  # Create the partial sharding proto if tensor is replicated over some mesh axes
+  if replicated_maxes:
+    new_mesh_shape.append(-1)
+    mesh_permutation.extend(replicated_maxes)
+    proto.replicate_on_last_tile_dim = True
 
-    Returns:
-      An ndarray with the same shape as the logical mesh (as derived form
-      `mesh_mapping`). Each entry is a NumPy-style index selecting the subset of
-      the data array to be placed on a corresponding device. The indices can be
-      ints, slice objects with step=1, or tuples of those.
-    """
-    assert len(shape) == len(self.sharding), (shape, self.sharding)
+  proto_mesh = mesh.transpose(mesh_permutation).reshape(new_mesh_shape)
+  proto.tile_assignment_dimensions = list(proto_mesh.shape)
+  proto.tile_assignment_devices = list(proto_mesh.flat)
+  return proto
 
-    axis_indices: List[Sequence[Index]] = []
-    shard_indices_shape = []
-    for dim, sharding in enumerate(self.sharding):
-      axis_size = shape[dim]
-      if isinstance(sharding, NoSharding):
-        axis_indices.append([slice(None)])
-        # NOTE: We don't append unsharded dimensions to shard_indices_shape here,
-        #       because they do not appear in the mesh mapping.
-      elif isinstance(sharding, Unstacked):
-        assert axis_size == sharding.size, f'{axis_size} != {sharding.size}'
-        axis_indices.append(range(axis_size))
-        shard_indices_shape.append(axis_size)
-      elif isinstance(sharding, Chunked):
-        total_chunks = int(np.prod(sharding.chunks))
-        shard_size, ragged = divmod(axis_size, total_chunks)
-        assert not ragged, (axis_size, total_chunks, dim)
-        axis_indices.append([slice(i * shard_size, (i + 1) * shard_size)
-                             for i in range(total_chunks)])
-        shard_indices_shape.extend(sharding.chunks)
-      else:
-        assert_unreachable(sharding)
+def indices(self, shape: Tuple[int, ...]) -> np.ndarray:
+  """Returns NumPy-style indices corresponding to a sharding spec.
 
-    # shard_indices is an ndarray representing the sharded axes of the logical array,
-    # with each dimension having size equal to the number of shards across the corresponding
-    # logical array dimension, and each element containing the multi-dimensional index that
-    # is used to extract the corresponding shard of the logical array.
-    shard_indices = np.empty([prod(shard_indices_shape)], dtype=np.object_)
-    for i, idxs in enumerate(it.product(*axis_indices)):
-      shard_indices[i] = idxs
-    shard_indices = shard_indices.reshape(shard_indices_shape)
+  Args:
+    shape: The shape of the logical array being sharded.
 
-    # Ensure that each sharded axis is used exactly once in the mesh mapping
-    num_sharded_dim = len(shard_indices_shape)
-    sharded_dim_perm = [a.axis for a in self.mesh_mapping if isinstance(a, ShardedAxis)]
-    assert (set(sharded_dim_perm) == set(range(num_sharded_dim)) and
-            len(sharded_dim_perm) == num_sharded_dim)
-    # Replicate/reorder the indices according to the mesh mapping
-    replica_sizes = tuple(a.replicas for a in self.mesh_mapping if isinstance(a, Replicated))
-    replica_dim, sharded_dim = it.count(0), iter(sharded_dim_perm)
-    perm = [next(replica_dim) if isinstance(a, Replicated) else
-            len(replica_sizes) + next(sharded_dim)
-            for a in self.mesh_mapping]
-    return (np.broadcast_to(shard_indices, replica_sizes + shard_indices.shape)
-              .transpose(perm))
+  Returns:
+    An ndarray with the same shape as the logical mesh (as derived form
+    `mesh_mapping`). Each entry is a NumPy-style index selecting the subset of
+    the data array to be placed on a corresponding device. The indices can be
+    ints, slice objects with step=1, or tuples of those.
+  """
+  assert len(shape) == len(self.sharding), (shape, self.sharding)
 
-  def __eq__(self, other):
-    return (self.sharding, self.mesh_mapping) == (other.sharding,
-                                                  other.mesh_mapping)
+  axis_indices: List[Sequence[Index]] = []
+  shard_indices_shape = []
+  for dim, sharding in enumerate(self.sharding):
+    axis_size = shape[dim]
+    if isinstance(sharding, NoSharding):
+      axis_indices.append([slice(None)])
+      # NOTE: We don't append unsharded dimensions to shard_indices_shape here,
+      #       because they do not appear in the mesh mapping.
+    elif isinstance(sharding, Unstacked):
+      assert axis_size == sharding.size, f'{axis_size} != {sharding.size}'
+      axis_indices.append(range(axis_size))
+      shard_indices_shape.append(axis_size)
+    elif isinstance(sharding, Chunked):
+      total_chunks = int(np.prod(sharding.chunks))
+      shard_size, ragged = divmod(axis_size, total_chunks)
+      assert not ragged, (axis_size, total_chunks, dim)
+      axis_indices.append([slice(i * shard_size, (i + 1) * shard_size)
+                           for i in range(total_chunks)])
+      shard_indices_shape.extend(sharding.chunks)
+    else:
+      assert_unreachable(sharding)
 
-  def __hash__(self):
-    return hash((self.sharding, self.mesh_mapping))
+  # shard_indices is an ndarray representing the sharded axes of the logical array,
+  # with each dimension having size equal to the number of shards across the corresponding
+  # logical array dimension, and each element containing the multi-dimensional index that
+  # is used to extract the corresponding shard of the logical array.
+  shard_indices = np.empty([prod(shard_indices_shape)], dtype=np.object_)
+  for i, idxs in enumerate(it.product(*axis_indices)):
+    shard_indices[i] = idxs
+  shard_indices = shard_indices.reshape(shard_indices_shape)
 
-  def __repr__(self):
-    return f'ShardingSpec({self.sharding}, {self.mesh_mapping})'
+  # Ensure that each sharded axis is used exactly once in the mesh mapping
+  num_sharded_dim = len(shard_indices_shape)
+  sharded_dim_perm = [a.axis for a in self.mesh_mapping if isinstance(a, ShardedAxis)]
+  assert (set(sharded_dim_perm) == set(range(num_sharded_dim)) and
+          len(sharded_dim_perm) == num_sharded_dim)
+  # Replicate/reorder the indices according to the mesh mapping
+  replica_sizes = tuple(a.replicas for a in self.mesh_mapping if isinstance(a, Replicated))
+  replica_dim, sharded_dim = it.count(0), iter(sharded_dim_perm)
+  perm = [next(replica_dim) if isinstance(a, Replicated) else
+          len(replica_sizes) + next(sharded_dim)
+          for a in self.mesh_mapping]
+  return (np.broadcast_to(shard_indices, replica_sizes + shard_indices.shape)
+            .transpose(perm))
+
+def __eq__(self, other):
+  return (self.sharding, self.mesh_mapping) == (other.sharding,
+                                                other.mesh_mapping)
+
+def __hash__(self):
+  return hash((self.sharding, self.mesh_mapping))
+
+def __repr__(self):
+  return f'ShardingSpec({self.sharding}, {self.mesh_mapping})'
+
+
+pmap_lib.ShardingSpec.mesh_shape = property(mesh_shape)
+pmap_lib.ShardingSpec.sharding_proto = sharding_proto
+pmap_lib.ShardingSpec.indices = indices
+pmap_lib.ShardingSpec.__eq__ = __eq__
+pmap_lib.ShardingSpec.__hash__ = __hash__
+pmap_lib.ShardingSpec.__repr__ = __repr__
+
 
 def spec_to_indices(shape: Tuple[int, ...],
                     spec: ShardingSpec) -> Tuple[Index, ...]:
@@ -281,7 +274,7 @@ def spec_to_indices(shape: Tuple[int, ...],
   Args:
     shape: The shape of the logical array being sharded.
     spec: Describes how the array is sharded and how the shards are assigned to
-          the logical mesh.
+      the logical mesh.
 
   Returns:
     A tuple of length equal to the size of the mesh (inferred as the product of
@@ -428,10 +421,10 @@ def array_result_handler(sharding_spec, indices, aval: ShapedArray):
 pxla_result_handlers[ShapedArray] = array_result_handler
 pxla_result_handlers[ConcreteArray] = array_result_handler
 
-
 ### lazy device-memory persistence and result handling
 
-class ShardedDeviceArray(xla._DeviceArray):
+
+class ShardedDeviceArray(pmap_lib.ShardedDeviceArray, xla._DeviceArray):
   """A ShardedDeviceArray is an ndarray sharded across devices.
 
   The purpose of a ShardedDeviceArray is to reduce the number of transfers when
@@ -456,8 +449,7 @@ class ShardedDeviceArray(xla._DeviceArray):
       stored in the corresponding device buffer, i.e. `array[indices[i]] ==
       device_buffers[i].to_py()`.
   """
-  __slots__ = ["device_buffers", "sharding_spec", "indices",
-               "_one_replica_buffer_indices"]
+  __slots__ = ["indices", "_one_replica_buffer_indices"]
 
   # TODO(skye): expose PyLocalBuffers in xla_client
   def __init__(self,
@@ -479,9 +471,9 @@ class ShardedDeviceArray(xla._DeviceArray):
     # TODO(skye): assert invariants. Keep performance in mind though.
     if indices is None:
       indices = spec_to_indices(aval.shape, sharding_spec)
-    self.aval = aval
-    self.device_buffers = device_buffers
-    self.sharding_spec = sharding_spec
+
+    pmap_lib.ShardedDeviceArray.__init__(self, aval, sharding_spec,
+                                         device_buffers)
     self.indices = indices
     self._npy_value = None
     self._one_replica_buffer_indices = None
@@ -1106,33 +1098,38 @@ def _pmap_sharding_spec(nrep, axis_size, npart, parts, sharded_aval, map_axis: O
   assert not ragged
   # get the sharding spec from inner sharded_jits as if we weren't in a pmap
   pspec = partitioned_sharding_spec(npart, parts, sharded_aval)
-  maybe_replicate = () if replication_factor == 1 else (Replicated(replication_factor),)
+  maybe_replicate = [] if replication_factor == 1 else [Replicated(replication_factor)]
   if map_axis is not None:
-    sharded_in_axis = sum(not isinstance(s, NoSharding) for s in pspec.sharding[:map_axis])
+    sharded_in_axis = sum(
+        not isinstance(s, NoSharding) for s in pspec.sharding[:map_axis])
+
     def shift_sharded_axis(a: MeshDimAssignment):
       if isinstance(a, ShardedAxis) and a.axis >= sharded_in_axis:
         return ShardedAxis(a.axis + 1)
       return a
     # replication_factor represents the product of inner pmaps, so it goes
     # after the outer pmapped axis at index 0
+    l = pspec.sharding
+    idx = map_axis
+    new_sharding = l[:idx] + [Unstacked(axis_size)] + l[idx:]
     return ShardingSpec(
-      sharding=tuple_insert(pspec.sharding, map_axis, Unstacked(axis_size)),
-      mesh_mapping=it.chain([ShardedAxis(sharded_in_axis)],
-                            maybe_replicate,
-                            map(shift_sharded_axis, pspec.mesh_mapping)))
+        sharding=new_sharding,
+        mesh_mapping=list(
+            it.chain([ShardedAxis(sharded_in_axis)], maybe_replicate,
+                     map(shift_sharded_axis, pspec.mesh_mapping))))
   else:
     return ShardingSpec(
-      sharding=pspec.sharding,
-      mesh_mapping=(Replicated(axis_size),) + maybe_replicate + pspec.mesh_mapping)
+        sharding=pspec.sharding,
+        mesh_mapping=[Replicated(axis_size)] + maybe_replicate + pspec.mesh_mapping)  # type: ignore
 
 def partitioned_sharding_spec(num_partitions: int,
                               partitions: Optional[Sequence[int]],
                               aval) -> ShardingSpec:
   if partitions is None:
-    maybe_replicate = () if num_partitions == 1 else (Replicated(num_partitions),)
+    maybe_replicate = [] if num_partitions == 1 else [Replicated(num_partitions)]
     return ShardingSpec(
         sharding=[_UNSHARDED_INSTANCE] * len(aval.shape),
-        mesh_mapping=maybe_replicate)
+        mesh_mapping=maybe_replicate)  # type: ignore
   else:
     assert len(partitions) == len(aval.shape)
     return ShardingSpec(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -472,9 +472,11 @@ class PmapTest(jtu.JaxTestCase):
     y = f(x)
     self.assertIsInstance(y, jnp.ndarray)
     self.assertIsInstance(y, pxla.ShardedDeviceArray)
+    self.assertIsInstance(y, jax.interpreters.xla.DeviceArray)
     self.assertAllClose(y, 2 * x, check_dtypes=False)
     z = f(y)
     self.assertIsInstance(z, pxla.ShardedDeviceArray)
+    self.assertIsInstance(z, jax.interpreters.xla.DeviceArray)
     self.assertAllClose(z, 2 * 2 * x, check_dtypes=False)
 
     # test that we can pass in a regular DeviceArray
@@ -487,7 +489,7 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(z, 2 * 2 * x, check_dtypes=False)
 
     # test that we can handle device movement on dispatch
-    y.device_buffers = y.device_buffers[::-1]
+    y = pxla.ShardedDeviceArray(y.aval, y.sharding_spec, y.device_buffers[::-1])
     z = f(y)
     self.assertAllClose(z, 2 * 2 * x[::-1], check_dtypes=False)
 
@@ -1237,8 +1239,8 @@ class PmapTest(jtu.JaxTestCase):
     bufs = pxla.device_put(shard, xla_bridge.devices()[:4], replicate=True)
     aval = ShapedArray((6,4), shard.dtype)
     sharding_spec = pxla.ShardingSpec(
-        sharding=map(pxla.Chunked, ([2], [2])),
-        mesh_mapping=map(pxla.ShardedAxis, (0, 1)))
+        sharding=list(map(pxla.Chunked, ([2], [2]))),
+        mesh_mapping=list(map(pxla.ShardedAxis, (0, 1))))
     arr = pxla.ShardedDeviceArray(aval, sharding_spec, bufs)
 
     r = pmap(lambda x: x + 1)(arr)
@@ -2211,8 +2213,8 @@ class SpecToIndicesTest(jtu.JaxTestCase):
 
   def testShardsPerAxis(self):
     shape = (4, 8)
-    spec = pxla.ShardingSpec(sharding=map(pxla.Chunked, ([2], [2])),
-                             mesh_mapping=map(pxla.ShardedAxis, (0, 1)))
+    spec = pxla.ShardingSpec(sharding=list(map(pxla.Chunked, ([2], [2]))),
+                             mesh_mapping=list(map(pxla.ShardedAxis, (0, 1))))
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      ((slice(0,2), slice(0,4)),
                       (slice(0,2), slice(4,8)),
@@ -2221,8 +2223,8 @@ class SpecToIndicesTest(jtu.JaxTestCase):
 
   def testShardedAxisPermutation(self):
     shape = (4, 8)
-    spec = pxla.ShardingSpec(sharding=map(pxla.Chunked, ([2], [2])),
-                             mesh_mapping=map(pxla.ShardedAxis, (1, 0)))
+    spec = pxla.ShardingSpec(sharding=list(map(pxla.Chunked, ([2], [2]))),
+                             mesh_mapping=list(map(pxla.ShardedAxis, (1, 0))))
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      ((slice(0,2), slice(0,4)),
                       (slice(2,4), slice(0,4)),
@@ -2231,10 +2233,10 @@ class SpecToIndicesTest(jtu.JaxTestCase):
 
   def testShardedAxisPermutationAndReplication(self):
     shape = (4, 8)
-    spec = pxla.ShardingSpec(sharding=map(pxla.Chunked, ([2], [2])),
-                             mesh_mapping=(pxla.Replicated(2),
+    spec = pxla.ShardingSpec(sharding=list(map(pxla.Chunked, ([2], [2]))),
+                             mesh_mapping=[pxla.Replicated(2),
                                            pxla.ShardedAxis(1),
-                                           pxla.ShardedAxis(0)))
+                                           pxla.ShardedAxis(0)])
     self.assertEqual(pxla.spec_to_indices(shape, spec),
                      ((slice(0,2), slice(0,4)),
                       (slice(2,4), slice(0,4)),
@@ -2325,10 +2327,8 @@ class SpecToIndicesTest(jtu.JaxTestCase):
 
   def testReplicatedScalar(self):
     shape = ()
-    spec = pxla.ShardingSpec(sharding=(),
-                             mesh_mapping=(pxla.Replicated(3),))
-    self.assertEqual(pxla.spec_to_indices(shape, spec),
-                     ((), (), ()))
+    spec = pxla.ShardingSpec(sharding=(), mesh_mapping=(pxla.Replicated(3),))
+    self.assertEqual(pxla.spec_to_indices(shape, spec), ((), (), ()))
 
 
 def _spec_str(spec):
@@ -2354,39 +2354,39 @@ class ShardArgsTest(jtu.JaxTestCase):
       for make_arg in [numpy_array, device_array]
       for shape, spec in [
           # pmap(in_axes=0)
-          [(4, 8), pxla.ShardingSpec(sharding=(pxla.Unstacked(4), pxla.NoSharding()),
-                                     mesh_mapping=(pxla.ShardedAxis(0),))],
+          [(4, 8), pxla.ShardingSpec(sharding=[pxla.Unstacked(4), pxla.NoSharding()],
+                                     mesh_mapping=[pxla.ShardedAxis(0)])],
           # pmap(in_axes=1)
-          [(2, 2), pxla.ShardingSpec(sharding=(pxla.NoSharding(), pxla.Unstacked(2)),
-                                     mesh_mapping=(pxla.ShardedAxis(0),))],
+          [(2, 2), pxla.ShardingSpec(sharding=[pxla.NoSharding(), pxla.Unstacked(2)],
+                                     mesh_mapping=[pxla.ShardedAxis(0)])],
           # unsharded
-          [(4, 8), pxla.ShardingSpec(sharding=(pxla.NoSharding(), pxla.NoSharding()),
-                                     mesh_mapping=())],
+          [(4, 8), pxla.ShardingSpec(sharding=[pxla.NoSharding(), pxla.NoSharding()],
+                                     mesh_mapping=[])],
           # partitioned, 1 axis
-          [(4, 8), pxla.ShardingSpec(sharding=(pxla.Chunked([2]), pxla.NoSharding()),
-                                     mesh_mapping=(pxla.ShardedAxis(0),))],
+          [(4, 8), pxla.ShardingSpec(sharding=[pxla.Chunked([2]), pxla.NoSharding()],
+                                     mesh_mapping=[pxla.ShardedAxis(0)])],
           # partitioned, 2 axes
-          [(4, 8), pxla.ShardingSpec(sharding=(pxla.Chunked([2]), pxla.Chunked([2])),
-                                     mesh_mapping=map(pxla.ShardedAxis, (0, 1)))],
+          [(4, 8), pxla.ShardingSpec(sharding=[pxla.Chunked([2]), pxla.Chunked([2])],
+                                     mesh_mapping=list(map(pxla.ShardedAxis, (0, 1))))],
           # partitioned, 2 axes, permuted
-          [(4, 8), pxla.ShardingSpec(sharding=(pxla.Chunked([2]), pxla.Chunked([2])),
-                                     mesh_mapping=map(pxla.ShardedAxis, (1, 0)))],
+          [(4, 8), pxla.ShardingSpec(sharding=[pxla.Chunked([2]), pxla.Chunked([2])],
+                                     mesh_mapping=list(map(pxla.ShardedAxis, (1, 0))))],
           # partitioned + sharding
-          [(2, 8), pxla.ShardingSpec(sharding=(pxla.Unstacked(2), pxla.Chunked([2])),
-                                     mesh_mapping=map(pxla.ShardedAxis, (0, 1)))],
+          [(2, 8), pxla.ShardingSpec(sharding=[pxla.Unstacked(2), pxla.Chunked([2])],
+                                     mesh_mapping=list(map(pxla.ShardedAxis, (0, 1))))],
           # replication + sharding
-          [(2, 8), pxla.ShardingSpec(sharding=(pxla.Unstacked(2), pxla.NoSharding()),
-                                     mesh_mapping=(pxla.ShardedAxis(0), pxla.Replicated(3)))],
+          [(2, 8), pxla.ShardingSpec(sharding=[pxla.Unstacked(2), pxla.NoSharding()],
+                                     mesh_mapping=[pxla.ShardedAxis(0), pxla.Replicated(3)])],
           # replication, no sharding
           [(2, 8), pxla.ShardingSpec(sharding=(pxla.NoSharding(), pxla.NoSharding()),
-                                     mesh_mapping=(pxla.Replicated(3),))],
+                                     mesh_mapping=[pxla.Replicated(3)])],
           # multiple replicated axes
-          [(1, 8), pxla.ShardingSpec(sharding=(pxla.Unstacked(1), pxla.Chunked([2])),
-                                     mesh_mapping=(pxla.Replicated(2), pxla.ShardedAxis(0),
-                                                   pxla.Replicated(2), pxla.ShardedAxis(1)))],
+          [(1, 8), pxla.ShardingSpec(sharding=[pxla.Unstacked(1), pxla.Chunked([2])],
+                                     mesh_mapping=[pxla.Replicated(2), pxla.ShardedAxis(0),
+                                                   pxla.Replicated(2), pxla.ShardedAxis(1)])],
           # replicated scalar
-          [(), pxla.ShardingSpec(sharding=(),
-                                 mesh_mapping=(pxla.Replicated(2), pxla.Replicated(3)))],
+          [(), pxla.ShardingSpec(sharding=[],
+                                 mesh_mapping=[pxla.Replicated(2), pxla.Replicated(3)])],
       ])
   def testShardArgs(self, shape, spec, make_arg):
     indices = pxla.spec_to_indices(shape, spec)

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -379,11 +379,13 @@ class XMapTest(XMapTestCase):
     x = jnp.arange(np.prod(xshape)).reshape(xshape)
     y = f(x)
     self.assertAllClose(y, (jnp.sin(x * 2).transpose((1, 2, 0)), (x * 2).sum((0, 1))))
-    self.assertEqual(y[0].sharding_spec.sharding,
-                      (pxla.Chunked([2]), pxla.NoSharding(), pxla.NoSharding()))
-    self.assertEqual(y[0].sharding_spec.mesh_mapping,
-                    (pxla.Replicated(2), pxla.ShardedAxis(0)) + (pxla.Replicated(2),) * (len(mesh) - 2))
-
+    self.assertEqual(
+        y[0].sharding_spec.sharding,
+        [pxla.Chunked([2]), pxla.NoSharding(), pxla.NoSharding()])
+    self.assertEqual(
+        y[0].sharding_spec.mesh_mapping,
+        [pxla.Replicated(2), pxla.ShardedAxis(0)] + [pxla.Replicated(2)] *
+        (len(mesh) - 2))
   @with_and_without_mesh
   @ignore_xmap_warning()
   def testMultipleCalls(self, mesh, axis_resources):


### PR DESCRIPTION
The sharding and mesh_mapping fields are lists (instead of the current tuple), but they are immutable (I mean that if you modify it, it won't be reflected on the C++ object. But because it's a list you can decide to modify it).

It's internal to JAX, so it limits the issues with the possible confusion of having lists and not tuples, but it massively simplify the C++ as the casts are trivial.

This follows https://github.com/google/jax/pull/5634 and should be submitted before after.