### PR TITLE
specialize standard_primitive back to single-output case

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2272,7 +2272,8 @@ class LaxTest(jtu.JaxTestCase):
     operands = {'x': np.ones(5)}
     bad_init_values = {'x': np.ones(5)}
 
-    with self.assertRaisesRegex(ValueError, 'Found non-scalar init_value'):
+    with self.assertRaisesRegex(ValueError,
+                                'reduce found non-scalar initial value'):
       lax.reduce(operands, bad_init_values,
                  lambda x, y: dict(x=x['x'] + y['x']), [0])
 


### PR DESCRIPTION
The multi-output case complicated the logic, and was only being used by `reduce_p`. That also led to a bug (see [this thread](https://github.com/google/jax/pull/5285#issuecomment-778268233) on #5285).