### PR TITLE
Enforce the the `args` argument to jax.scipy.optimize.minimize is a t…

### DIFF
--- a/jax/_src/scipy/optimize/minimize.py
+++ b/jax/_src/scipy/optimize/minimize.py
@@ -91,6 +91,10 @@ def minimize(
   if options is None:
     options = {}
 
+  if not isinstance(args, tuple):
+    msg = "args argument to jax.scipy.optimize.minimize must be a tuple, got {}"
+    raise TypeError(msg.format(args))
+
   fun_with_args = lambda x: fun(x, *args)
 
   if method.lower() == 'bfgs':

--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -94,6 +94,13 @@ class TestBFGS(jtu.JaxTestCase):
     results = jax.scipy.optimize.minimize(f, jnp.ones(n), method='BFGS')
     self.assertAllClose(results.x, jnp.zeros(n), atol=1e-6, rtol=1e-6)
 
+  def test_args_must_be_tuple(self):
+    A = jnp.eye(2) * 1e4
+    def f(x):
+      return jnp.mean((A @ x) ** 2)
+    with self.assertRaisesRegex(TypeError, "args .* must be a tuple"):
+      jax.scipy.optimize.minimize(f, jnp.ones(2), args=45, method='BFGS')
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
…uple.

Fixes https://github.com/google/jax/issues/5732