### PR TITLE
docs fix: correct overwriting of step function in optimizers example

### DIFF
--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -78,7 +78,7 @@ Example Usage:
     return value, opt_state
 
   for i in range(num_steps):
-    value, opt_state = step(step, opt_state)
+    value, opt_state = step(i, opt_state)
 """
 
 from typing import Any, Callable, NamedTuple, Tuple, Union

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -77,7 +77,7 @@ Example Usage:
     opt_state = opt_update(step, grads, opt_state)
     return value, opt_state
 
-  for step in range(num_steps):
+  for i in range(num_steps):
     value, opt_state = step(step, opt_state)
 """
 


### PR DESCRIPTION
`step` is used in this example to refer to both step number and the step function, which leads to an error if implemented naively