### PR TITLE
Set qualname in jax.numpy.util._wraps

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -103,6 +103,7 @@ def _wraps(fun, update_doc=True, lax_description=""):
           f"{body}")
 
       op.__name__ = fun.__name__
+      op.__qualname__ = fun.__qualname__
       op.__doc__ = docstr
       op.__np_wrapped__ = fun
     finally:


### PR DESCRIPTION
Previous behavior:
```python
import jax.numpy as jnp
print(jnp.cumsum.__qualname__)
# _make_cumulative_reduction.<locals>.cumulative_reduction
```
With this fix:
```python
import jax.numpy as jnp
print(jnp.cumsum.__qualname__)
# cumsum
```
Some editors and code inspectors rely on `__qualname__`, so this should make things cleaner.