### PR TITLE
Fix nondeterministic test ordering in array_interoperability_test.

### DIFF
--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -45,7 +45,8 @@ except:
   tf = None
 
 
-dlpack_dtypes = jax.dlpack.SUPPORTED_DTYPES
+dlpack_dtypes = sorted(list(jax.dlpack.SUPPORTED_DTYPES),
+                       key=lambda x: x.__name__)
 torch_dtypes = [jnp.int8, jnp.int16, jnp.int32, jnp.int64,
                 jnp.uint8, jnp.float16, jnp.float32, jnp.float64]
 


### PR DESCRIPTION
Set ordering is not deterministic, so if a list of types is a set, we must do something to canonicalize the order to avoid errors from `pytest -n ...`