### PR TITLE
DOC: suppress some warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,11 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 
+suppress_warnings = [
+    'ref.citation',  # Many duplicated citations in numpy/scipy docstrings.
+    'ref.footnote',  # Many unreferenced footnotes in numpy/scipy docstrings
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -313,7 +313,7 @@ def sqrt(x: Array) -> Array:
   return sqrt_p.bind(x)
 
 def rsqrt(x: Array) -> Array:
-  r"""Elementwise reciprocal square root:  :math:`1 \over \sqrt{x}."""
+  r"""Elementwise reciprocal square root:  :math:`1 \over \sqrt{x}`."""
   return rsqrt_p.bind(x)
 
 def bitwise_not(x: Array) -> Array:


### PR DESCRIPTION
With this plus #5748 we're down to only a few remaining warnings in the doc build (from hundreds a few weeks ago). If we get down to zero we can enable the `-W` flag and make our doc build much more robust.