### PR TITLE
Use lax.pad in jnp.packbits.

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4101,7 +4101,8 @@ def packbits(a, axis: Optional[int] = None, bitorder='big'):
 
   remainder = a.shape[-1] % 8
   if remainder:
-    a = pad(a, (a.ndim - 1) * [(0, 0)] + [(0, 8 - remainder)])
+    a = lax.pad(a, np.uint8(0),
+                (a.ndim - 1) * [(0, 0, 0)] + [(0, 8 - remainder, 0)])
 
   a = a.reshape(a.shape[:-1] + (a.shape[-1] // 8, 8))
   packed = (a << bits).sum(-1).astype('uint8')


### PR DESCRIPTION
jnp.pad() is overkill for this situation.

Additional context: using `packbits` inside a `vmap`-ed cond fails (b/180481587). This PR works around the issue, and produces a simpler jaxpr so seems like a good change regardless.