### PR TITLE
Rename overshadowed name in optimizers example usage

### DIFF
--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -72,13 +72,13 @@ Example Usage:
   opt_init, opt_update, get_params = optimizers.sgd(learning_rate)
   opt_state = opt_init(params)
 
-  def step(step, opt_state):
+  def step_(step, opt_state):
     value, grads = jax.value_and_grad(loss_fn)(get_params(opt_state))
     opt_state = opt_update(step, grads, opt_state)
     return value, opt_state
 
   for step in range(num_steps):
-    value, opt_state = step(step, opt_state)
+    value, opt_state = step_(step, opt_state)
 """
 
 from typing import Any, Callable, NamedTuple, Tuple, Union


### PR DESCRIPTION
Hi!

I'm a new user. When I checked the tutorial i copied the example usage I noticed that variable name is overshadowed.