### PR TITLE
introduce `linear_call` for custom transposition

### DIFF
--- a/jax/api.py
+++ b/jax/api.py
@@ -73,7 +73,7 @@ from .interpreters import masking
 from .interpreters import invertible_ad as iad
 from .interpreters.invertible_ad import custom_ivjp
 from .custom_derivatives import (closure_convert, custom_gradient, custom_jvp,
-                                 custom_vjp)
+                                 custom_vjp, linear_call)
 from .config import flags, config, bool_env
 
 traceback_util.register_exclusion(__file__)


### PR DESCRIPTION
This adds a primitive with a corresponding traceable function in `custom_derivatives` that takes a callee and its transpose, both functions. When the primitive is encountered during transposition, the given transpose function is invoked instead of transpose-transforming the callee. The invocation of the custom transposition is itself done via a `linear_call`, with the original callee set as the transpose. This maintains, in particular, that transposing twice is an identity.

The `linear_call` docstring gives examples. Here's the IR view of an example.
```python
$ cat test.py
from jax import linear_transpose, make_jaxpr
from jax.custom_derivatives import linear_call

def transpose(f, x_example):
  def transposed(t):
    x, = linear_transpose(f, x_example)(t)
    return x
  return transposed

def halve(x):
  def f(r, x): return x / r
  def t(r, t): return t * r    # custom!
  return linear_call(f, t, 2., x)

x, t = 1., 1.
print(make_jaxpr(halve)(x))
print(make_jaxpr(transpose(halve, x))(t))
```
```
$ python test.py 
{ lambda  ; a.
  let b = linear_call[ callee={ lambda  ; a b.                                  
                                let c = div b a                                 
                                in (c,) }
                       num_callee_consts=0
                       num_res=1
                       num_transpose_consts=0
                       transpose={ lambda  ; a b.                               
                                   let c = mul b a                              
                                   in (c,) } ] 2.0 a                            
  in (b,) }
{ lambda  ; a.
  let b = linear_call[ callee={ lambda  ; a b.
                                let c = mul b a
                                in (c,) }
                       num_callee_consts=0
                       num_res=1
                       num_transpose_consts=0
                       transpose={ lambda  ; a b.
                                   let c = div b a
                                   in (c,) } ] 2.0 a
  in (b,) }
```

Notes:

* We can later revisit whether to tie the transpose's transpose back to the original function via `linear_call`. There might be a good case for "inlining" the custom transpose function instead, as soon as the first transposition happens.
* Unlike many other call primitives, all arguments are fully staged out to jaxpr in advance here.
* This implementation materializes all symbolic zeros encountered when transposing `linear_call`. Representing the custom transpose function as a jaxpr essentially prevents it from accepting and processing symbolic zeros.

Up next: primitive rules for various transformations (batching, etc.).

Further out, I'd like to relate this to custom derivatives. Does custom transposition let us concurrently set up a custom JVP and VJP?

For a function `a -> b`, the current `custom_jvp` setup takes a custom JVP rule of the form:
```haskell
jvp :: (a, T a) -> (b, T b)
```
and `custom_vjp` takes custom forward and reverse functions of the form:
```haskell
fwd :: a -> (b, r)
rev :: (r, T b) -> T a
```
Suppose instead of `jvp` we were given:
```haskell
lin :: a -> T a -> T b
```
mirroring linearization, but without requiring structural linearity. Then we could generate a custom JVP along the lines of:
```python
def jvp(x, tx):
  y, res = fwd(x)
  tf = lin(x)
  ty = linear_call(tf, rev, res, tx)
  return y, ty
```
This satisfies the JVP signature and picks up _some_ custom JVP logic via `lin`, but it also carries out the custom VJP's forward rule. If linearized, it stages out a function that, when later transposed, carries out the custom VJP's reverse rule as well.

There are some potential efficiency losses with this approach, because accepting only `lin` means writing expressions to compute primals separately from tangents within `jvp`. This is perhaps not an issue when both expressions consist entirely of first-order primitives, especially after compiler optimizations. But sometimes primals and tangents can be jointly expressed, say, with one `scan`, while separate expressions require separate `scan` calls. I'm not sure that we can rely on a compiler to always fuse the two loops back into one.