### PR TITLE
Fix typo in thinking_in_jax notebook

### DIFF
--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -1138,7 +1138,7 @@
     "  print(f\"x.shape = {x.shape}\")\n",
     "  print(f\"jnp.array(x.shape).prod() = {jnp.array(x.shape).prod()}\")\n",
     "  # comment this out to avoid the error:\n",
-    "  # return x.reshape(jnp.array(x.shape).prot())\n",
+    "  # return x.reshape(jnp.array(x.shape).prod())\n",
     "\n",
     "f(x)"
    ]

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -547,7 +547,7 @@ def f(x):
   print(f"x.shape = {x.shape}")
   print(f"jnp.array(x.shape).prod() = {jnp.array(x.shape).prod()}")
   # comment this out to avoid the error:
-  # return x.reshape(jnp.array(x.shape).prot())
+  # return x.reshape(jnp.array(x.shape).prod())
 
 f(x)
 ```


### PR DESCRIPTION
The commented code attempted to call `prot()`, which looked like a typo in trying to call `prod()`.