### PR TITLE
DOC: fix update_numpydoc to prevent deleting docstring content

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -15,6 +15,7 @@
 import re
 import textwrap
 
+_parameter_break = re.compile("\n(?=[A-Za-z_])")
 
 def update_numpydoc(docstr, fun, op):
   '''Transforms the numpy docstring to remove references of
@@ -34,15 +35,13 @@ def update_numpydoc(docstr, fun, op):
   begin_idx = docstr.find("--\n", begin_idx) + 2
   end_idx = docstr.find("Returns", begin_idx)
 
-  parameters = docstr[begin_idx:end_idx]
-  param_list = parameters.replace('\n    ', '@@').split('\n')
+  param_list = _parameter_break.split(docstr[begin_idx:end_idx])
   for idx, p in enumerate(param_list):
     param = p[:p.find(' : ')].split(", ")[0]
     if param not in op.__code__.co_varnames:
       param_list[idx] = ''
-  param_list = [param for param in param_list if param != '']
-  parameters = '\n'.join(param_list).replace('@@', '\n    ')
-  return docstr[:begin_idx + 1] + parameters + docstr[end_idx - 2:]
+  parameters = '\n'.join(param for param in param_list if param != '')
+  return docstr[:begin_idx + 1] + parameters + docstr[end_idx:]
 
 _numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*\)$')
 

--- a/jax/_src/scipy/optimize/minimize.py
+++ b/jax/_src/scipy/optimize/minimize.py
@@ -82,9 +82,9 @@ def minimize(
       options.
     options: a dictionary of solver options. All methods accept the following
       generic options:
-        maxiter : int
-            Maximum number of iterations to perform. Depending on the
-            method each iteration may use several function evaluations.
+
+      - maxiter (int): Maximum number of iterations to perform. Depending on the
+        method each iteration may use several function evaluations.
 
   Returns:
     An :class:`OptimizeResults` object.


### PR DESCRIPTION
The previous approach resulted in parts of docstrings being inadvertently deleted. e.g.

Before:
```
>>> print(jnp.average.__doc__)
Compute the weighted average along the specified axis.

LAX-backend implementation of :func:`average`.

*Original docstring below.*

Parameters
----------
a : array_like
    Array containing data to be averaged. If `a` is not an array, a
    conversion is attempted.
axis : None or int or tuple of ints, optional
    Axis or axes along which to average `a`.  The default,
    axis=None, will average over all of the elements of the input array.
    If axis is negative it counts from the last to the first axis.
weights : array_like, optional
    An array of weights associated with the values in `a`. Each value in
    `a` contributes to the average according to its associated weight.
    The weights array can either be 1-D (in which case its length must be
    the size of `a` along the given axis) or of the same shape as `a`.
    If `weights=None`, then all data in `a` are assumed to have a
    weight equal to one.  The 1-D calculation is::
returned : bool, optional
    Default is `False`. If `True`, the tuple (`average`, `sum_of_weights`)
    is returned, otherwise only the average is returned.
    If `weights=None`, `sum_of_weights` is equivalent to the number of
    elements over which the average is taken.
<...>
```
After:
```
>>> print(jnp.average.__doc__)
Compute the weighted average along the specified axis.

LAX-backend implementation of :func:`average`.

*Original docstring below.*

Parameters
----------
a : array_like
    Array containing data to be averaged. If `a` is not an array, a
    conversion is attempted.
axis : None or int or tuple of ints, optional
    Axis or axes along which to average `a`.  The default,
    axis=None, will average over all of the elements of the input array.
    If axis is negative it counts from the last to the first axis.

    .. versionadded:: 1.7.0

    If axis is a tuple of ints, averaging is performed on all of the axes
    specified in the tuple instead of a single axis or all the axes as
    before.
weights : array_like, optional
    An array of weights associated with the values in `a`. Each value in
    `a` contributes to the average according to its associated weight.
    The weights array can either be 1-D (in which case its length must be
    the size of `a` along the given axis) or of the same shape as `a`.
    If `weights=None`, then all data in `a` are assumed to have a
    weight equal to one.  The 1-D calculation is::

        avg = sum(a * weights) / sum(weights)

    The only constraint on `weights` is that `sum(weights)` must not be 0.
returned : bool, optional
    Default is `False`. If `True`, the tuple (`average`, `sum_of_weights`)
    is returned, otherwise only the average is returned.
    If `weights=None`, `sum_of_weights` is equivalent to the number of
    elements over which the average is taken.
<...>
```
In terms of import overhead, this is basically a wash:

Before:
```python
In [1]: %time import jax                                                                                                                                                         
CPU times: user 1.15 s, sys: 233 ms, total: 1.38 s
Wall time: 714 ms
```
After:
```python
In [1]: %time import jax                                                                                                                                                         
CPU times: user 1.16 s, sys: 216 ms, total: 1.38 s
Wall time: 708 ms
```