### PR TITLE
DOC: add first JAX-101 notebook

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -1423,6 +1423,18 @@
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ exclude_patterns = [
     # Ignore markdown source for notebooks; myst-nb builds from the ipynb
     # These are kept in sync using the jupytext pre-commit hook.
     'notebooks/*.md',
+    'jax-101/*.md',
     'autodidax.md',
 ]
 
@@ -185,7 +186,9 @@ execution_excludepatterns = [
     'notebooks/score_matching.*',
     'notebooks/maml.*',
     # Strange error apparently due to asynchronous cell execution
-    'notebooks/thinking_in_jax.*'
+    'notebooks/thinking_in_jax.*',
+    # TODO(jakevdp): enable execution on these
+    'notebooks/jax-101/*',
 ]
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,20 +9,25 @@ For an introduction to JAX, start at the
 
 .. toctree::
    :maxdepth: 1
-   :caption: Tutorials
+   :caption: Getting Started
 
    notebooks/quickstart
    notebooks/thinking_in_jax
-   notebooks/autodiff_cookbook
-   notebooks/vmapped_log_probs
-   notebooks/neural_network_with_tfds_data
+   notebooks/Common_Gotchas_in_JAX
+
+.. toctree::
+   :maxdepth: 2
+
+   jax-101/index
 
 .. toctree::
    :maxdepth: 1
    :caption: Advanced JAX Tutorials
 
-   notebooks/Common_Gotchas_in_JAX
    notebooks/convolutions
+   notebooks/autodiff_cookbook
+   notebooks/vmapped_log_probs
+   notebooks/neural_network_with_tfds_data
    notebooks/Custom_derivative_rules_for_Python_code
    notebooks/How_JAX_primitives_work
    notebooks/Writing_custom_interpreters_in_Jax
@@ -30,6 +35,7 @@ For an introduction to JAX, start at the
    notebooks/XLA_in_Python
    notebooks/maml
    notebooks/score_matching
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/jax-101/01-jax-basics.ipynb
+++ b/docs/jax-101/01-jax-basics.ipynb
@@ -1,0 +1,849 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6_117sy0CGEU"
+   },
+   "source": [
+    "# JAX as accelerated NumPy\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/01-jax-basics.ipynb)\n",
+    "\n",
+    "*Authors: Rosalia Schneider & Vladimir Mikulik*\n",
+    "\n",
+    "In this first section you will learn the very fundamentals of JAX."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CXjHL4L6ku3-"
+   },
+   "source": [
+    "## Getting started with JAX numpy\n",
+    "\n",
+    "Fundamentally, JAX is a library that enables transformations of array-manipulating programs written with a NumPy-like API. \n",
+    "\n",
+    "Over the course of this series of guides, we will unpack exactly what that means. For now, you can think of JAX as *differentiable NumPy that runs on accelerators*.\n",
+    "\n",
+    "The code below shows how to import JAX and create a vector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ZqUzvqF1B1TO"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 2 3 4 5 6 7 8 9]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "\n",
+    "x = jnp.arange(10)\n",
+    "print(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rPBmlAxXlBAy"
+   },
+   "source": [
+    "So far, everything is just like NumPy. A big appeal of JAX is that you don't need to learn a new API. Many common NumPy programs would run just as well in JAX if you substitute `np` for `jnp`. However, there are some important differences which we touch on at the end of this section.\n",
+    "\n",
+    "You can notice the first difference if you check the type of `x`. It is a variable of type `DeviceArray`, which is the way JAX represents arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "3fLtgPUAn7mi"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int32)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Yx8VofzzoHFH"
+   },
+   "source": [
+    "One useful feature of JAX is that the same code can be run on different backends -- CPU, GPU and TPU.\n",
+    "\n",
+    "We will now perform a dot product to demonstrate that it can be done in different devices without changing the code. We use `%timeit` to check the performance. \n",
+    "\n",
+    "(Technical detail: when a JAX function is called, the corresponding operation is dispatched to an accelerator to be computed asynchronously when possible. The returned array is therefore not necessarily 'filled in' as soon as the function returns. Thus, if we don't require the result immediately, the computation won't block Python execution. Therefore, unless we `block_until_ready`, we will only time the dispatch, not the actual computation. See [Asynchronous dispatch](https://jax.readthedocs.io/en/latest/async_dispatch.html#asynchronous-dispatch) in the JAX docs.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mRvjVxoqo-Bi"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1000 loops, best of 3: 603 µs per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "long_vector = jnp.arange(int(1e7))\n",
+    "\n",
+    "%timeit jnp.dot(long_vector, long_vector).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DKBB0zs-p-RC"
+   },
+   "source": [
+    "**Tip**: Try running the code above twice, once without an accelerator, and once with a GPU runtime (while in Colab, click *Runtime* → *Change Runtime Type* and choose `GPU`). Notice how much faster it runs on a GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "PkCpI-v0uQQO"
+   },
+   "source": [
+    "## JAX first transformation: `grad`\n",
+    "\n",
+    "A fundamental feature of JAX is that it allows you to transform functions.\n",
+    "\n",
+    "One of the most commonly used transformations is `jax.grad`, which takes a numerical function written in Python and returns you a new Python function that computes the gradient of the original function. \n",
+    "\n",
+    "To use it, let's first define a function that takes an array and returns the sum of squares."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LuaGUVRUvbzQ"
+   },
+   "outputs": [],
+   "source": [
+    "def sum_of_squares(x):\n",
+    "  return jnp.sum(x**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QAqloI1Wvtp2"
+   },
+   "source": [
+    "Applying `jax.grad` to `sum_of_squares` will return a different function, namely the gradient of `sum_of_squares` with respect to its first parameter `x`. \n",
+    "\n",
+    "Then, you can use that function on an array to return the derivatives with respect to each element of the array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dKeorwJfvpeI"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "30.0\n",
+      "[2. 4. 6. 8.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sum_of_squares_dx = jax.grad(sum_of_squares)\n",
+    "\n",
+    "x = jnp.asarray([1.0, 2.0, 3.0, 4.0])\n",
+    "\n",
+    "print(sum_of_squares(x))\n",
+    "\n",
+    "print(sum_of_squares_dx(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VfBt5CYbyKUX"
+   },
+   "source": [
+    "You can think of `jax.grad` by analogy to the $\\nabla$ operator from vector calculus. Given a function $f(x)$, $\\nabla f$ represents the function that computes $f$'s gradient, i.e.\n",
+    "\n",
+    "$$\n",
+    "(\\nabla f)(x)_i = \\frac{\\partial f}{\\partial x_i}(x).\n",
+    "$$\n",
+    "\n",
+    "Analogously, `jax.grad(f)` is the function that computes the gradient, so `jax.grad(f)(x)` is the gradient of `f` at `x`.\n",
+    "\n",
+    "(Like $\\nabla$, `jax.grad` will only work on functions with a scalar output -- it will raise an error otherwise.)\n",
+    "\n",
+    "This makes the JAX API quite different to other autodiff libraries like Tensorflow and PyTorch, where to compute the gradient we use the loss tensor itself (e.g. by calling `loss.backward()`). The JAX API works directly with functions, staying closer to the underlying math. Once you become accustomed to this way of doing things, it feels natural: your loss function in code really is a function of parameters and data, and you find its gradient just like you would in the math.\n",
+    "\n",
+    "This way of doing things makes it straightforward to control things like which variables to differentiate with respect to. By default, `jax.grad` will find the gradient with respect to the first argument. In the example below, the result of `sum_squared_error_dx` will be the gradient of `sum_squared_error` with respect to `x`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f3NfaVu4yrQE"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[-0.20000005 -0.19999981 -0.19999981 -0.19999981]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def sum_squared_error(x, y):\n",
+    "  return jnp.sum((x-y)**2)\n",
+    "\n",
+    "sum_squared_error_dx = jax.grad(sum_squared_error)\n",
+    "\n",
+    "y = jnp.asarray([1.1, 2.1, 3.1, 4.1])\n",
+    "\n",
+    "print(sum_squared_error_dx(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1tOztA5zpLWN"
+   },
+   "source": [
+    "To find the gradient with respect to a different argument (or several), you can set `argnums`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "FQSczVQkqIPY"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(DeviceArray([-0.20000005, -0.19999981, -0.19999981, -0.19999981], dtype=float32),\n",
+       " DeviceArray([0.20000005, 0.19999981, 0.19999981, 0.19999981], dtype=float32))"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.grad(sum_squared_error, argnums=(0, 1))(x, y)  # Find gradient wrt both x & y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yQAMTnZSqo-t"
+   },
+   "source": [
+    "Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/06-pytrees.ipynb). So, most often, use of `jax.grad` looks like this:\n",
+    "\n",
+    "```\n",
+    "def loss_fn(params, data):\n",
+    "  ...\n",
+    "\n",
+    "grads = jax.grad(loss_fn)(params, data_batch)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oBowiovisT97"
+   },
+   "source": [
+    "where `params` is, for example, a nested dict of arrays, and the returned `grads` is another nested dict of arrays with the same structure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LNjf9jUEsZZ8"
+   },
+   "source": [
+    "## Value and Grad\n",
+    "\n",
+    "Often, you need to find both the value and the gradient of a function, e.g. if you want to log the training loss. JAX has a handy sister transformation for efficiently doing that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dWg4_-h3sYwl"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(DeviceArray(0.03999995, dtype=float32),\n",
+       " DeviceArray([-0.20000005, -0.19999981, -0.19999981, -0.19999981], dtype=float32))"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.value_and_grad(sum_squared_error)(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QVT2EWHJsvvv"
+   },
+   "source": [
+    "which returns a tuple of, you guessed it, (value, grad). To be precise, for any `f`,\n",
+    "\n",
+    "```\n",
+    "jax.value_and_grad(f)(*xs) == (f(*xs), jax.grad(f)(*xs)) \n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QmHTVpAks3OX"
+   },
+   "source": [
+    "## Auxiliary data\n",
+    "\n",
+    "In addition to wanting to log the value, we often want to report some intermediate results obtained in computing the loss function. But if we try doing that with regular `jax.grad`, we run into trouble:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ffGCEzT4st41",
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "ignored",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/api.py\u001b[0m in \u001b[0;36m_check_scalar\u001b[1;34m(x)\u001b[0m\n\u001b[0;32m    786\u001b[0m   \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 787\u001b[1;33m     \u001b[0maval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcore\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_aval\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    788\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/core.py\u001b[0m in \u001b[0;36mget_aval\u001b[1;34m(x)\u001b[0m\n\u001b[0;32m    852\u001b[0m   \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 853\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0mconcrete_aval\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    854\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/core.py\u001b[0m in \u001b[0;36mconcrete_aval\u001b[1;34m(x)\u001b[0m\n\u001b[0;32m    845\u001b[0m     \u001b[1;32mif\u001b[0m \u001b[0mhandler\u001b[0m\u001b[1;33m:\u001b[0m \u001b[1;32mreturn\u001b[0m \u001b[0mhandler\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 846\u001b[1;33m   \u001b[1;32mraise\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf\"{type(x)} is not a valid JAX type\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    847\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mTypeError\u001b[0m: <class 'tuple'> is not a valid JAX type",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-29-0df66dbb1715>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      2\u001b[0m   \u001b[1;32mreturn\u001b[0m \u001b[0msum_squared_error\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0my\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mx\u001b[0m\u001b[1;33m-\u001b[0m\u001b[0my\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 4\u001b[1;33m \u001b[0mjax\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mgrad\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msquared_error_with_aux\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0my\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/api.py\u001b[0m in \u001b[0;36mgrad_f\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    704\u001b[0m   \u001b[1;33m@\u001b[0m\u001b[0mapi_boundary\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    705\u001b[0m   \u001b[1;32mdef\u001b[0m \u001b[0mgrad_f\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 706\u001b[1;33m     \u001b[0m_\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mg\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mvalue_and_grad_f\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0margs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    707\u001b[0m     \u001b[1;32mreturn\u001b[0m \u001b[0mg\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    708\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/api.py\u001b[0m in \u001b[0;36mvalue_and_grad_f\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    770\u001b[0m     \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    771\u001b[0m       \u001b[0mans\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvjp_py\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0maux\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0m_vjp\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mf_partial\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m*\u001b[0m\u001b[0mdyn_args\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mhas_aux\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mTrue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 772\u001b[1;33m     \u001b[0m_check_scalar\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mans\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    773\u001b[0m     \u001b[0mdtype\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdtypes\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mresult_type\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mans\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    774\u001b[0m     \u001b[0mtree_map\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpartial\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0m_check_output_dtype_grad\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mholomorphic\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mans\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/api.py\u001b[0m in \u001b[0;36m_check_scalar\u001b[1;34m(x)\u001b[0m\n\u001b[0;32m    787\u001b[0m     \u001b[0maval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcore\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_aval\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    788\u001b[0m   \u001b[1;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 789\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmsg\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"was {}\"\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mfrom\u001b[0m \u001b[0me\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    790\u001b[0m   \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    791\u001b[0m     \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0maval\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mShapedArray\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mTypeError\u001b[0m: Gradient only defined for scalar-output functions. Output was (DeviceArray(0.03999995, dtype=float32), DeviceArray([-0.10000002, -0.0999999 , -0.0999999 , -0.0999999 ], dtype=float32))."
+     ]
+    }
+   ],
+   "source": [
+    "def squared_error_with_aux(x, y):\n",
+    "  return sum_squared_error(x, y), x-y\n",
+    "\n",
+    "jax.grad(squared_error_with_aux)(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IUubno3nth4i"
+   },
+   "source": [
+    "This is because `jax.grad` is only defined on scalar functions, and our new function returns a tuple. But we need to return a tuple to return our intermediate results! This is where `has_aux` comes in:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uzUFihyatgiF"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(DeviceArray([-0.20000005, -0.19999981, -0.19999981, -0.19999981], dtype=float32),\n",
+       " DeviceArray([-0.10000002, -0.0999999 , -0.0999999 , -0.0999999 ], dtype=float32))"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "jax.grad(squared_error_with_aux, has_aux=True)(x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g5s3UiFauwDk"
+   },
+   "source": [
+    "`has_aux` signifies that the function returns a pair, `(out, aux)`. It makes `jax.grad` ignore `aux`, passing it through to the user, while differentiating the function as if only `out` was returned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fk4FUXe7vsW4"
+   },
+   "source": [
+    "## Differences from NumPy\n",
+    "\n",
+    "The `jax.numpy` API closely follows that of NumPy. However, there are some important differences. We cover many of these in future guides, but it's worth pointing some out now.\n",
+    "\n",
+    "The most important difference, and in some sense the root of all the rest, is that JAX is designed to be _functional_, as in _functional programming_. The reason behind this is that the kinds of program transformations that JAX enables are much more feasible in functional-style programs.\n",
+    "\n",
+    "An introduction to functional programming (FP) is out of scope of this guide. If you already are familiar with FP, you will find your FP intuition helpful while learning JAX. If not, don't worry! The important feature of functional programming to grok when working with JAX is very simple: don't write code with side-effects.\n",
+    "\n",
+    "A side-effect is any effect of a function that doesn't appear in its output. One example is modifying an array in place:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "o_YBuLQC1wPJ"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([123,   2,   3])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "x = np.array([1, 2, 3])\n",
+    "\n",
+    "def in_place_modify(x):\n",
+    "  x[0] = 123\n",
+    "  return None\n",
+    "\n",
+    "in_place_modify(x)\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JTtUihVZ13F6"
+   },
+   "source": [
+    "The side-effectful function modifies its argument, but returns a completely unrelated value. The modification is a side-effect. \n",
+    "\n",
+    "The code below will run in NumPy. However, JAX arrays won't allow themselves to be modified in-place:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u6grTYIVcZ3f",
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "ignored",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-32-c984510497e7>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0min_place_modify\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mjnp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0marray\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m  \u001b[1;31m# Raises error when we cast input to jnp.ndarray\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m<ipython-input-31-673da3f71aeb>\u001b[0m in \u001b[0;36min_place_modify\u001b[1;34m(x)\u001b[0m\n\u001b[0;32m      4\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0min_place_modify\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mx\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 6\u001b[1;33m   \u001b[0mx\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;36m123\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      7\u001b[0m   \u001b[1;32mreturn\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      8\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m/google/bin/releases/deepmind/python/dm_notebook3/dm_notebook3.par/google3/third_party/py/jax/_src/numpy/lax_numpy.py\u001b[0m in \u001b[0;36m_unimplemented_setitem\u001b[1;34m(self, i, x)\u001b[0m\n\u001b[0;32m   4816\u001b[0m          \u001b[1;34m\"immutable; perhaps you want jax.ops.index_update or \"\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   4817\u001b[0m          \"jax.ops.index_add instead?\")\n\u001b[1;32m-> 4818\u001b[1;33m   \u001b[1;32mraise\u001b[0m \u001b[0mTypeError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mmsg\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtype\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   4819\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   4820\u001b[0m \u001b[1;32mdef\u001b[0m \u001b[0m_operator_round\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnumber\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mndigits\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;32mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mTypeError\u001b[0m: '<class 'jax.interpreters.xla.DeviceArray'>' object does not support item assignment. JAX arrays are immutable; perhaps you want jax.ops.index_update or jax.ops.index_add instead?"
+     ]
+    }
+   ],
+   "source": [
+    "in_place_modify(jnp.array(x))  # Raises error when we cast input to jnp.ndarray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RGqVfYSpc49s"
+   },
+   "source": [
+    "Helpfully, the error points us to JAX's side-effect-free way of doing the same thing via the [`jax.ops.index_*`](https://jax.readthedocs.io/en/latest/jax.ops.html#indexed-update-operators) ops. They are analogous to in-place modification by index, but create a new array with the corresponding modifications made:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Rmklk6BB2xF0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([123,   2,   3], dtype=int32)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def jax_in_place_modify(x):\n",
+    "  return jax.ops.index_update(x, 0, 123)\n",
+    "\n",
+    "y = jnp.array([1, 2, 3])\n",
+    "jax_in_place_modify(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "91tn_25vdrNf"
+   },
+   "source": [
+    "Note that the old array was untouched, so there is no side-effect:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "KQGXig4Hde6T"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DeviceArray([1, 2, 3], dtype=int32)"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "d5TibzPO25qa"
+   },
+   "source": [
+    "Side-effect-free code is sometimes called *functionally pure*, or just *pure*.\n",
+    "\n",
+    "Isn't the pure version less efficient? Strictly, yes; we are creating a new array. However, as we will explain in the next guide, JAX computations are often compiled before being run using another program transformation, `jax.jit`. If we don't use the old array after modifying it 'in place' using `jax.ops.index_update()`, the compiler can recognise that it can in fact compile to an in-place modify, resulting in efficient code in the end.\n",
+    "\n",
+    "Of course, it's possible to mix side-effectful Python code and functionally pure JAX code, and we will touch on this more later. As you get more familiar with JAX, you will learn how and when this can work. As a rule of thumb, however, any functions intended to be transformed by JAX should avoid side-effects, and the JAX primitives themselves will try to help you do that.\n",
+    "\n",
+    "We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Part 7: Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dFn_VBFFlGCz"
+   },
+   "source": [
+    "## Your first JAX training loop\n",
+    "\n",
+    "We still have much to learn about JAX, but you already know enough to understand how we can use JAX to build a simple training loop.\n",
+    "\n",
+    "To keep things simple, we'll start with a linear regression. \n",
+    "\n",
+    "Our data is sampled according to $y = w_{true} x + b_{true} + \\epsilon$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WGgyEWFqrPq1"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7f3c68ef0828>"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGdNJREFUeJzt3X9s1fW9x/HXaXvKTo1SFiDYUxyy\nslJKoYWDcDMz1BUw4oVSjDB7/xmammVLVG5KJLiJix0IMxeii+ZscWO6DecNK0wWqoBhxilQPCjD\niUzt1p6GrNxRmHCEQ/neP7pT29NzTs/p6ef8+j4fybL29LSfz8myl1/fn8/n/XFYlmUJAJDz8tI9\nAQBAahD4AGATBD4A2ASBDwA2QeADgE0Q+ABgEwQ+ANgEgQ8ANkHgA4BNFKR7AgONHz9eU6ZMSfc0\nACCrtLe36+zZs8O+L6MCf8qUKWpra0v3NAAgq3g8nrjeR0kHAGyCwAcAmyDwAcAmCHwAsAkCHwBs\nwnjg9/T06J577tH06dNVUVGht99+2/SQAJDxWnx+fX3zQd386F59ffNBtfj8xsc0HvgPPfSQ7rzz\nTn344Yd67733VFFRYXpIAMhoLT6/1u86IX9PQJYkf09AD798XNVPvGY0+I3uw79w4YL++Mc/6he/\n+IUkqbCwUIWFhSaHBICMt7X1lALB3iGv9wSCWr/rhCSprsY96uMafcL/5JNPNGHCBH37299WTU2N\nHnjgAV28eNHkkACQ8bp6AlF/Fgj2amvrKSPjGg38q1ev6t1339V3vvMd+Xw+XXfdddq8efOg93i9\nXnk8Hnk8HnV3d5ucDgBkhJJiV8yfx/oHQjKMBn5paalKS0s1f/58SdI999yjd999d9B7Ghsb1dbW\npra2Nk2YMMHkdAAgIzQtKZfLmR/158P9A2GkjAb+pEmTNHnyZJ061fevJwcOHNCMGTNMDgkAGa+u\nxq1N9VUaV+Qc8jOXM19NS8qNjGu8edozzzyjhoYGXblyRVOnTtXPf/5z00MCQMarq3GrrsatFp9f\nW1tPqasnoJJil5qWlBtZsJVSEPjV1dV0wASAKELBnwqctAUAmyDwAcAmCHwAsAkCHwBsgsAHAJsg\n8AHAJgh8ALAJAh8AbILABwCbMH7SFgCyRSrbHKQDgQ8A+uIWqtDFJP6egNHLSNKBkg4AKPItVCYv\nI0kHAh8AFP3SEVOXkaQDgQ8Ain7piKnLSNKBwAcARb6FyuRlJOnAoi0A6IuFWXbpAIANpPIyknQw\nXtLp7e1VTU2N7r77btNDAQBiMB7427dvV0VFhelhAADDMBr4nZ2d2rt3rx544AGTwwAA4mA08B9+\n+GFt2bJFeXlsBgKAdDOWxK+++qomTpyouXPnxnyf1+uVx+ORx+NRd3e3qekAgO05LMuyTPzh9evX\n68UXX1RBQYE+//xzXbhwQfX19XrppZei/o7H41FbW5uJ6QCwiVxvgBZJvNlp7Al/06ZN6uzsVHt7\nu3bu3Kk77rgjZtgDQLJCDdD8PQFZ+qIBWovPn+6pZQT24QPIeqGnen+EvjehBmi5/pQfj5QE/m23\n3abbbrstFUMBsJnwtsaR5FIDtGSwfQZAVovU1jhcLjVASwYlHQAZL9JCrKSoZZyBcq0BWjIIfAAZ\nLdJNVE3/+55kScFrsTcZum2ySydeBD6AjBapZBPsjR30Lme+NtVXEfRhCHwAGS3RBVee6qMj8AFk\ntJJi17B1+hB3sUtvPXqH4RllL3bpAMhokW6icuY75MxzDHqNxdnh8YQPIKNFu4kq0muUcWIj8AFk\nvGg3URHwiaGkAwA2QeADgE1Q0gGQcnZsYZwJCHwAKRXp5Oz6XSckUZM3jcAHMKpafH5t3HNSPYGg\nJGlckVNLZ92oNz7sVldPQHkOh3rD7l2ihXFqEPgARk2Lz6+mV94b1OPm3KWgXnrn7/3fh4d9CC2M\nzWPRFsCo2dp6atiGZtHQwtg8Ah/AqGjx+eNugRCOU7KpYTTwOzo6dPvtt6uiokKVlZXavn27yeEA\npEloITYR+Q6HHOrrf0Nny9QwWsMvKCjQ008/rTlz5uhf//qX5s6dq0WLFmnGjBkmhwWQYvHcOjWQ\nQ9LT984m5FPM6BP+jTfeqDlz5kiSrr/+elVUVMjv5/Z4INckUspxSGpYcBNhnwYp26XT3t4un8+n\n+fPnp2pIACmSH2Gr5UDuYheHrDJASgL/s88+08qVK7Vt2zbdcMMNg37m9Xrl9XolSd3d3amYDoBR\nNlzY06M+MxgP/GAwqJUrV6qhoUH19fVDft7Y2KjGxkZJksfjMT0dAAmItwWCO8olJQ6J3TcZxGgN\n37Is3X///aqoqNDatWtNDgVglIV23vh7ArL0RQuEFt/QdbhIl5RQq888RgP/rbfe0osvvqiDBw+q\nurpa1dXV+sMf/mBySACjJNLOm1ALhHB1NW5tqq+Su9jVv9Xyf1ZV68m6qhTNFvEwWtK59dZbZcWo\n7QHIDJFKN9F23kRrgRDtkhJkDnrpADYX3v/G3xPQ2pePR30/LRCyF60VAJvbuOfkkP4316K8l0XY\n7EbgAzYXamMcD0v0rM9mBD6AuLkp52Q1aviAzYQv0BY583QpGK2I8wU6WmY/Ah+wkcdaTuhX7/xd\noYq9vycgZ75DeQ5pYBnfme/QqnmT+2+poiVCbiDwARto8fn1xO9P6tylofX6YK+lcUVOFRUWEO45\njsAHclz4peGR9FwKyveDxSmcFdKBwAdyVKhWH0/rYvbW2wOBD+SgeJ7qB2Ix1h4IfCDHtPj8+u/f\nvhezZXE46vX2wD58IIeEnuwTCXv21tsHgQ/kkETvlmVvvb1Q0gGy2MBDVMVFzojbLkNcznytnOtm\nb72NEfhAlgpfmI0V9vkOhzbVVxHuNkdJB8hS8ZZvXM58PX3vbMIeBD6QraJdRBKOJ3uEGA/8ffv2\nqby8XGVlZdq8ebPp4QDbKC5yDvsed7GLsEc/ozX83t5effe739Xrr7+u0tJSzZs3T8uWLdOMGTNM\nDgtktUjXDYaHdovPr88+vxrz77ADB+GMPuEfOXJEZWVlmjp1qgoLC7V69Wrt3r3b5JBAVgstxPp7\nArLU181y/a4TavH5B71va+upIbdUDVTsclLKwRBGn/D9fr8mT57c/31paakOHz486D1er1der1eS\n1N3dbXI6QMaLtBAbCPZqa+upQeEdq36/bVU1QY+IjD7hWxFO+zkcjkHfNzY2qq2tTW1tbZowYYLJ\n6QAZL1qQh78erdkZNXvEYjTwS0tL1dHR0f99Z2enSkpKTA4JZK0Wn195YQ9EIeEB37SkXC5n/qDX\nqNljOEZLOvPmzdPp06f16aefyu12a+fOnfr1r39tckggqwxsYeyQFKkqHynIQ0/xwy3uAgMZDfyC\nggI9++yzWrJkiXp7e7VmzRpVVlaaHBLICpFuoIoU9rFOyNbVuAl4JMR4a4W77rpLd911l+lhgKyR\nSK/6a5ZFqGPUcNIWSLFEOlpyExVGE83TAIMiHaKK58pBiUVYjD4CHzAkvHTj7wmo6ZX34vpdN4uw\nMIDABwyJVLqJdTo2hINTMIXAB0bZYy0n9JvDHQldMyhJDkkNC24i7GEMgQ+MosdaTuild/6e8O/l\nOxz0rIdxBD6QhPBF2eF61DvzHJJDCvZ+8fTvcubT6AwpQeADIxRpUTaWYpdTG5f1HTzkhCzSgcAH\n4jSoDYJDSrBEr+vGFPQHOwGPdCDwgTi0+PxqeuW9/l02iYa9FP+VhIApBD4QQXht/p8XL8e1pVJS\n1CZonJpFutFaAQgT6dapQPBa3L/fsOAmWhcjIxH4QJhEet2EG1fk1JN1VdpUXyV3sUsO9Z2aZRcO\nMgElHSDMSGvtznyHHv/Pvl04tC5GJuIJHwgz0lr71ns4OIXMRuADA7T4/Dp38fKIfpewR6YzFvhN\nTU2aPn26Zs2apRUrVqinp8fUUMCoeKzlhB55+bguJbBAG+JmBw6ygLHAX7Rokf785z/r/fff19e+\n9jVt2rTJ1FBA0kI9cEawvZ4dOMgaxgJ/8eLFKijoWxNesGCBOjs7TQ0FJKXF59evRtDwTGIHDrJL\nSnbpvPDCC1q1alUqhgIStrX1VMJP9jQ8QzZKKvBra2t15syZIa83Nzdr+fLl/V8XFBSooaEh4t/w\ner3yer2SpO7u7mSmA8Ql/BTtcE3PxhU5tXTWjXrjw24aniGrOSxrJF1B4rNjxw49//zzOnDggIqK\nioZ9v8fjUVtbm6npwOZafH5t3HNSPYHgoNejtUKQpP9acJOerKsyPjcgGfFmp7GSzr59+/TUU0/p\n0KFDcYU9YFJ4K+OBLA0N/dDtU4Q9comxwP/e976ny5cva9GiRZL6Fm6ff/55U8MBUbX4/Hrk5eMx\n6/SW+hZgKdkglxkL/L/+9a+m/jQQ1cD7ZPMdDi2YOk5vf/zPuBZlCXnkOk7aImeE9tKHLg/vtSy9\n9fE/Fe8xqq2tp8xNDsgABD5yxm8OdyT1+1xQglxH4CNn9Ca54YwLSpDrCHzkjHyHY8S/S3sE2AH9\n8JHVHms5oV8l2AMnzyH9x9Qvq/3/AuzKga0Q+MhaoUXaeI0rcsr3g8UGZwRkNgIfWSO8JULX+fgX\nWQfeRgXYFYGPrBB+Una4/jcDuSnZAJIIfGSJjXtOjvhi8bcevWOUZwNkJwIfGWdg6aa4yKnLwd4R\n3UIlScUu5yjPDsheBD4ySnjp5tylYMz3FznzFAhei7hLx5nn0MZl1O2BEAIfGSH0VJ9IbV6SflQ/\nq782H76oS90eGIzAR9rFal0cy7gi56BAr6txE/BADJy0RdptbT2VcNi7nPlsswQSROAj7RJtWlbs\ncnKfLDAClHSQdsVFzmEXZ/vf63Lq+OOclgVGgsBHyoUvrl6Os5zjcuaz6wZIgvGSzo9//GM5HA6d\nPXvW9FDIAqEFWn9PQJb6TszG2mPvLnbJ8e//powDJMfoE35HR4def/113XTTTSaHQRZJZIHWXezi\nlCwwiowG/iOPPKItW7Zo+fLlJodBBhtYvikqzNfFK/GXb+hPD4wuY4G/Z88eud1uzZ4929QQyHDh\n++tjhX2xy6nrxhRwaAowKKnAr62t1ZkzZ4a83tzcrB/96Ed67bXXhv0bXq9XXq9XktTd3Z3MdJAB\nHms5od8c7kjousHQYiwBD5jlsKwkLwKN4MSJE/rmN7+poqIiSVJnZ6dKSkp05MgRTZo0KerveTwe\ntbW1jfZ0kCKJXkgSsm1VNWEPJCHe7DRS0qmqqtI//vGP/u+nTJmitrY2jR8/3sRwyBC/OdyR8O/k\nOxyEPZAinLTFqEmkjBPyrfmTDcwEQCQpOXjV3t6eimGQZvkOR9TQd0gqKszXpSu9sv793m/Nn6wn\n66pSOkfAzjhpi1HzrfmTI9bw/2vBTQQ7kAEIfCQkVs/5UKiHdunwFA9kFgIfMYVfN/jZ51cVvNZX\ntvH3BLR+1wlJGhT6BDyQmVi0RVThfW/OXQr2h31IINirra2n0jNBAAkh8BHVE78/GVffm0T72QNI\nDwIfEbX4/HH3qC8pdhmeDYDRQA3f5qItwsZbpqHJGZA9CHwbC29uNnARNlaZptjl1PlAkCZnQJYh\n8G0sUm/60CJsSbFL/gihzxWDQPaihm9j0Z7iu3oCalpSLpczf9DrXDEIZDee8G1mYM3e4ZAidUIo\nKXb1l2miHbICkH0IfBsJr9lHCntnvqN/Ebauxk3AAzmEko6NxHOf7HWFBYQ8kKMIfBuJ54DU+UB8\ne+8BZB9KOjYQqtvH062eQ1RA7iLwc1iLz68nfn8y7hOzHKICchuBn6PCF2gjGVfklGWJQ1SATRgN\n/GeeeUbPPvusCgoKtHTpUm3ZssXkcLY3cMtlXozbp6S+G6h8P+AAFWAnxgL/jTfe0O7du/X+++9r\nzJgxgy41x+gLf6If7n5ZavWA/RgL/Oeee06PPvqoxowZI0maOHGiqaFsK5En+oGo1QP2ZGxb5kcf\nfaQ333xT8+fP18KFC3X06NGI7/N6vfJ4PPJ4POru7jY1nZwTfjlJvGFf7HJqU30VtXrAhpJ6wq+t\nrdWZM2eGvN7c3KyrV6/q3Llzeuedd3T06FHde++9+uSTT+RwOAa9t7GxUY2NjZIkj8eTzHRsJZ5D\nVJKU73DommWxKAsgucDfv39/1J8999xzqq+vl8Ph0C233KK8vDydPXtWEyZMSGZI/Fs8h6hcznye\n5gH0M1bSqaur08GDByX1lXeuXLmi8ePHmxrOdoZbdHUXuwh7AIMYW7Rds2aN1qxZo5kzZ6qwsFA7\nduwYUs5BYgYu0o51OaO+z13s0luP3pHCmQHIBsYCv7CwUC+99JKpP2874dsuewJB5Um6FvY+duAA\niIaTtlki0iLtNfXturluTAE96wEMi8DPEtEWac8Hglw5CCAutEfOEtEWaTkxCyBeBH4atPj8+vrm\ng7r50b36+uaDavH5h/2daHfMUq8HEC8CP8XCT8j6ewJ6+OXjqvnhazGDv67GrU31VXIXu+QQ2y4B\nJI4afopFOyF77lJQ63edkKSoIc4dswCSwRN+isU6IRsI9mpr66kUzgaAnRD4KTbcIms8LRMAYCQI\n/BSLtPg6ELtuAJhC4KdYaPG1OEJrBHbdADCJwE+Duhq3jj++WNtWVbPrBkDKsEsnjdh1AyCVeMIH\nAJsg8AHAJgh8ALAJAh8AbILABwCbMBb4x48f14IFC1RdXS2Px6MjR46YGgoAEAdjgb9u3To9/vjj\nOn78uH74wx9q3bp1poYCAMTBWOA7HA5duHBBknT+/HmVlJSYGgoAEAeHZVmWiT/8l7/8RUuWLJFl\nWbp27Zr+9Kc/6Stf+cqQ93m9Xnm9XklSd3e3/va3v5mYDgDkLI/Ho7a2tmHfl1Tg19bW6syZM0Ne\nb25u1oEDB7Rw4UKtXLlSv/3tb+X1erV///5RmTQA4AspCfxYxo4dq56eHjkcDlmWpbFjx/aXeKIh\n8AEgcfFmp7EafklJiQ4dOiRJOnjwoKZNm2ZqKABAHIw1T/vpT3+qhx56SFevXtWXvvSl/jo9ACA9\njAX+rbfeqmPHjpn68wCABHHSFgBsgsAHAJsg8AHAJgh8ALAJAh8AbILABwCbIPABwCYIfACwCWMH\nr1KpxefX1tZT6uoJqKTYpaYl5aqrcad7WgCQUbI+8Ft8fq3fdUKBYK8kyd8T0PpdJySJ0AeAAbK+\npLO19VR/2IcEgr3a2noqTTMCgMyU9YHf1RNI6HUAsKusD/ySYldCrwOAXWV94DctKZfLmT/oNZcz\nX01LytM0IwDITFm/aBtamGWXDgDElvWBL/WFPgEPALElVdJ55ZVXVFlZqby8vCH3KW7atEllZWUq\nLy9Xa2trUpMEACQvqSf8mTNnateuXXrwwQcHvf7BBx9o586dOnnypLq6ulRbW6uPPvpI+fn5Uf4S\nAMC0pJ7wKyoqVF4+dHF09+7dWr16tcaMGaObb75ZZWVlOnLkSDJDAQCSZGSXjt/v1+TJk/u/Ly0t\nld/vNzEUACBOw5Z0amtrdebMmSGvNzc3a/ny5RF/x7KsIa85HI6I7/V6vfJ6vZKk7u7u4aYDABih\nYQN///79Cf/R0tJSdXR09H/f2dmpkpKSiO9tbGxUY2OjJGn8+PHyeDyS+sJ/woQJCY+djez0WSV7\nfV4+a27KtM/a3t4e1/uMbMtctmyZ7rvvPq1du1ZdXV06ffq0brnllmF/7+zZs/1fezyeITt/cpWd\nPqtkr8/LZ81N2fpZk6rh/+53v1NpaanefvttLV26VEuWLJEkVVZW6t5779WMGTN055136ic/+Qk7\ndAAgzZJ6wl+xYoVWrFgR8WcbNmzQhg0bkvnzAIBRlL9x48aN6Z5ENHPnzk33FFLGTp9Vstfn5bPm\npmz8rA4r0pYaAEDOyfpumQCA+GR04H//+9/XrFmzVF1drcWLF6urqyvdUzKmqalJ06dP16xZs7Ri\nxQr19PSke0rGxOrBlCv27dun8vJylZWVafPmzemejlFr1qzRxIkTNXPmzHRPxaiOjg7dfvvtqqio\nUGVlpbZv357uKSXOymDnz5/v/3r79u3Wgw8+mMbZmNXa2moFg0HLsixr3bp11rp169I8I3M++OAD\n68MPP7QWLlxoHT16NN3TGXVXr161pk6dan388cfW5cuXrVmzZlknT55M97SMOXTokHXs2DGrsrIy\n3VMxqquryzp27JhlWZZ14cIFa9q0aVn3v2tGP+HfcMMN/V9fvHgx6mndXLB48WIVFPRtmlqwYIE6\nOzvTPCNzovVgyhVHjhxRWVmZpk6dqsLCQq1evVq7d+9O97SM+cY3vqEvf/nL6Z6GcTfeeKPmzJkj\nSbr++utVUVGRdS1jMr4f/oYNG/TLX/5SY8eO1RtvvJHu6aTECy+8oFWrVqV7GhihSL2kDh8+nMYZ\nYbS1t7fL5/Np/vz56Z5KQtL+hF9bW6uZM2cO+U/oiai5uVkdHR1qaGjQs88+m+bZJme4zyr1fd6C\nggI1NDSkcabJi+ez5iorgV5SyD6fffaZVq5cqW3btg2qQmSDtD/hx9ur57777tPSpUv1xBNPGJ6R\nOcN91h07dujVV1/VgQMHsj4gRtKDKVck0ksK2SUYDGrlypVqaGhQfX19uqeTsLQ/4cdy+vTp/q/3\n7Nmj6dOnp3E2Zu3bt09PPfWU9uzZo6KionRPB0mYN2+eTp8+rU8//VRXrlzRzp07tWzZsnRPC0my\nLEv333+/KioqtHbt2nRPZ2TSvWocS319vVVZWWlVVVVZd999t9XZ2ZnuKRnz1a9+1SotLbVmz55t\nzZ49O6d3JO3atctyu91WYWGhNXHiRGvx4sXpntKo27t3rzVt2jRr6tSp1pNPPpnu6Ri1evVqa9Kk\nSVZBQYHldrutn/3sZ+mekhFvvvmmJcmqqqrq///p3r170z2thHDSFgBsIqNLOgCA0UPgA4BNEPgA\nYBMEPgDYBIEPADZB4AOATRD4AGATBD4A2MT/A/ZGFI7XDLwqAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "xs = np.random.normal(size=(100,))\n",
+    "noise = np.random.normal(scale=0.1, size=(100,))\n",
+    "ys = xs * 3 - 1 + noise\n",
+    "\n",
+    "plt.scatter(xs, ys)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RTh22mo4rR1x"
+   },
+   "source": [
+    "Therefore, our model is $\\hat y(x; \\theta) = wx + b$.\n",
+    "\n",
+    "We will use a single array, `theta = [w, b]` to house both parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TnVrRTMamyzb"
+   },
+   "outputs": [],
+   "source": [
+    "def model(theta, x):\n",
+    "  \"\"\"Computes wx + b on a batch of input x.\"\"\"\n",
+    "  w, b = theta\n",
+    "  return w * x + b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qCrLmmKrn9_h"
+   },
+   "source": [
+    "The loss function is $J(x, y; \\theta) = (\\hat y - y)^2$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "07eMcDLMn9Ww"
+   },
+   "outputs": [],
+   "source": [
+    "def loss_fn(theta, x, y):\n",
+    "  prediction = model(theta, x)\n",
+    "  return jnp.mean((prediction-y)**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ejMt4dulnoYX"
+   },
+   "source": [
+    "How do we optimize a loss function? Using gradient descent. At each update step, we will find the gradient of the loss w.r.t. the parameters, and take a small step in the direction of steepest descent:\n",
+    "\n",
+    "$\\theta_{new} = \\theta - 0.1 (\\nabla_\\theta J) (x, y; \\theta)$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2I6T5Wphpaaa"
+   },
+   "outputs": [],
+   "source": [
+    "def update(theta, x, y, lr=0.1):\n",
+    "  return theta - lr * jax.grad(loss_fn)(theta, x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MAUL1gT_opVn"
+   },
+   "source": [
+    "In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [The Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb).\n",
+    "\n",
+    "This function can then be JIT-compiled in its entirety for maximum efficiency. The next guide will explain exactly how `jax.jit` works, but if you want to, you can try adding `@jax.jit` before the `update()` definition, and see how the training loop below runs much faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WLZxY7nIpuVW"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "w: 2.97, b: -1.00\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD8CAYAAAB0IB+mAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAHZBJREFUeJzt3XtUVNe9B/DvYWYgg03ERFzKgKGI\nBUQQdRTT5MZHEVR6fYBXreQ+YlLS3PQ2xl6s1qSaXilEk0ZvbOKdZCWxMYk2qwatWomvGJuHikGl\npiJ50MBwSeAaxAcqj3P/IDMyw8www8yeMzPn+1mrq8xwhv2bdvWb0332/m1JlmUZREQU8sKULoCI\niPyDgU9EpBIMfCIilWDgExGpBAOfiEglGPhERCrBwCciUgkGPhGRSjDwiYhUQqt0AT0NHjwY8fHx\nSpdBRBRUamtr0dzc3Od1ARX48fHxqKioULoMIqKgYjQa3bqOUzpERCrBwCciUgkGPhGRSjDwiYhU\ngoFPRKQSwgO/paUF8+fPR3JyMlJSUvDhhx+KHpKIKOCVVZpxd+khfHfFHtxdeghllWbhYwoP/Ecf\nfRQzZszAuXPncPr0aaSkpIgekogooJVVmrFyRxXMLW2QAZhb2rB0+ylkPPmO0OAXug6/tbUV7733\nHl599VUAQHh4OMLDw0UOSUQU8NaXV6OtvbPX+y1t7Vi5owoAMHeswefjCr3D//zzzxEdHY37778f\nY8eOxYMPPogrV66IHJKIKOA1tLQ5/V1beyfWl1cLGVdo4Hd0dODjjz/Gww8/jMrKSgwYMAClpaU2\n15hMJhiNRhiNRjQ1NYksh4goIMRE6V3+3tU/ELwhNPBjY2MRGxuLzMxMAMD8+fPx8ccf21xTWFiI\niooKVFRUIDo6WmQ5REQB4d6Rg13+vq9/IPSX0Dn8oUOHIi4uDtXV1UhKSsLBgwcxatQokUMSEQWs\nzi4ZI3651+U1ep0GRTlJQsYX3jztueeeQ0FBAW7cuIGEhAS88soroockIgo4T5dXY9PhT62vfzQx\nDiV56SirNGN9eTUaWtoQE6VHUU6SkAe2gB8CPyMjgx0wiUi12m50IuVX+2zeO792JsK13TPqc8ca\nhAW8vYBqj0xEFEr+/fWT2FvVaH39y1nJKLx3hGL1MPCJiHys6dJ1TCg+YPPeFyWzIEmSQhV1Y+AT\nEfnQtKffxefNN/cbvVAwDjPThilY0U0MfCIiH/j060vI+u17Nu/VluYqVI1jDHwiIi/Fr9hj8/qP\nD38f4+8cpFA1zjHwiYj66YPPmrH4xWPW1+GaMJwvnqlgRa4x8ImI+sH+rv5I0RTceccAhapxDwOf\niMgDfzxZj5+/ddr6ekxcFHY+creCFbmPgU9E5IauLhkJdm0RTv1qOqIig6flOwOfiOhbztocPLv/\nPDYerLFet8AYi3XzxyhYaf8w8ImIcPMUKsvBJOaWNqz44xks3X7K5rrqtTMQodUoUaLXGPhERHB8\nCtW1ji7rz7+YkYyHpyjXFsEXGPhERHB96EggtEXwBeGHmBMRBQNnh44YovQhEfYAA5+ICBW1F2B2\ncIcv8jASJXBKh4hUzX4D1aBIHVqutgs/jEQJDHwiUiX7DVRA4DU78zXhgd/Z2Qmj0QiDwYDdu3eL\nHo6IqE/2d/Vlj9yNjLgoharxH+GBv3HjRqSkpKC1tVX0UERELpX++Rw2H/nM5r1Qv6vvSehD2/r6\neuzZswcPPvigyGGIiFzq7JIRv2KPTdh/sGKaqsIeEHyHv3TpUqxbtw6XLl0SOQwRkVP3vXQMf/m0\n2fr61lu0qFqTo2BFyhEW+Lt378aQIUMwfvx4vPvuu06vM5lMMJlMAICmpiZR5RCRyly+3oHRq8tt\n3vvk1zmIDFfvWhVJlmVZxB9euXIlXnvtNWi1Wly7dg2tra3Iy8vD1q1bnX7GaDSioqJCRDlEpBJl\nleZe/W+mJEXj1fsnKlSReO5mp7A5/JKSEtTX16O2thbbtm3DtGnTXIY9EZG3Nh/5rFfY36INw9yM\n0FlL7w31/n8bIgoZju7qLa51dGF9eXVIbaDqL78E/pQpUzBlyhR/DEVEKrPq7Sq8fuxLl9e4aoym\nJrzDJ6KgZb+ByhlnjdHUhoFPRAHP/iSqqEgdzja4t5kz1BqgeYOBT0QBzdFJVI46WzpiCMEGaN5g\n4BNRQHN0ElVf9DoNSvLSGPR2GPhEFNDcvZu34F29cwx8IgpY7j6UtTBE6fH+immCqgl+PPGKiALO\nV63XXIa9TiNBF2Z77CAfzvaNd/hEFFAcBf2GhRk2q3QswW7/HqdxXGPgE1FA+ODTZix+6ZjNe+fX\nzkS4tnsiwlGYM+A9w8AnIsU5uqtXW696f2DgE5FinjtYg2f2n7d5j0EvDgOfiPzOUbOzhMEDcOg/\npyhTkEow8InIr9LXlKP1WofNe3qdBj/7wUiFKlIPBj4R+VRZpRlrdp1FS1s7AGBQpA656cNw+FyT\n001Ube2dbGHsBwx8IvKZskozit46jfaumwfpfXO1HVs/ct2+GGALY3/gxisi8pn15dU2Ye8JtjAW\nj4FPRD5RVmn2uO+NBXfJ+ofQwK+rq8PUqVORkpKC1NRUbNy4UeRwRKQQSwtjT2gkCRK6+9+ws6V/\nCJ3D12q1eOaZZzBu3DhcunQJ48ePx/Tp0zFq1CiRwxKRn3nawlgC8MyCMQx5PxN6hz9s2DCMGzcO\nAHDrrbciJSUFZrNZ5JBEpABPpnIkAAWThjPsFeC3VTq1tbWorKxEZmamv4YkIj9wp4WxIUrPJmcB\nwC+Bf/nyZeTn52PDhg247bbbbH5nMplgMpkAAE1NTf4oh4h84N51h/Hlhat9Xsce9YFDeOC3t7cj\nPz8fBQUFyMvL6/X7wsJCFBYWAgCMRqPocojIA/aHh1vuzt09mEQCuPomgAidw5dlGQ888ABSUlKw\nbNkykUMRkY9ZVt6YW9ogo3uefun2U73CvrY0FxsWZkCv09i8z7n6wCM08N9//3289tprOHToEDIy\nMpCRkYG9e/eKHJKIfMSdlTeWzpZzxxpQkpcGQ5TeutTy2YUZWDs3zQ+VkruETuncc889kOX+7boj\nIv9xNHXjauWNoxbGc8caeDcf4NhLh0jl7PvfmFvasMyudXFPBrZACFpsrUCkcmt2ne3V/6bLybV8\nCBvcGPhEKmdpY+wOGTxHNpgx8InIbZzOCW6cwydSGfsHtNowoMPZHE4P7GgZ/Bj4RCryeFkVXv/o\nS1hm7J2txNFpJCycEIfD55rYEiGEMPCJVKCs0own/3QW31x1Pl/Pfjehj4FPFOIsO2ZdbaKSAPa7\nUQEGPlGIsszVu9O6mMcLqgMDnygEuXNX3xMfxqoDA58oxJRVmvHzP5xGpwdtTThfrw5ch08UQix3\n9p6EPdfWqwcDnyiEeHq2LNfWqwundIiCWM9NVN+J0ODSdedhr9dpkD/ewLX1KsbAJwpS9g9mXYW9\nRpJQkpfGcFc5TukQBSl3p2/0Og2eWTCGYU8MfKJg5c76egC8sycr4YG/b98+JCUlITExEaWlpaKH\nIwp58Sv2uH2IuCFKz7AnK6Fz+J2dnXjkkUewf/9+xMbGYsKECZg9ezZGjRolcliioObouEFLaLsb\n9ABX4FBvQgP/+PHjSExMREJCAgBg0aJF2LlzJwOfyAn7B7Hmljas3FGFpS6OHHQkSq/DmtmpvLsn\nG0ID32w2Iy4uzvo6NjYWx44ds7nGZDLBZDIBAJqamkSWQxTwHD2IdfRgVgLgbGvVhoUZDHpySOgc\nvuxgt58kSTavCwsLUVFRgYqKCkRHR4sshyjgNfTxILa2NBe1pblOm51xzp5cERr4sbGxqKurs76u\nr69HTEyMyCGJglZZpRlhdjdEPdWW5lp/LspJgl6nsfk95+ypL0KndCZMmICamhp88cUXMBgM2LZt\nG9544w2RQxIFlZ4tjJ1N0+h1GpTkpdm8Z7mLd/Zwl8gRoYGv1WqxadMm5OTkoLOzE0uWLEFqaqrI\nIYmCgqMTqByFvasdsnPHGhjw5BHhrRVmzZqFWbNmiR6GKGh40qu+S5YZ6uQz3GlL5GeedLTkSVTk\nS2yeRiSQo01U7rZE4ENY8jUGPpEgjjZRubuBysCHsCQAA59IEE8PI7HgxikShYFP5GOPl1XhzWN1\nHh0zCHTvni2YNJxhT8Iw8Il86PGyKmz96EuPP6eRJPasJ+EY+EResH8o21drBF2YBEhAe+fNu3/L\nxiqGPYnGwCfqJ0cPZV2xdLAEuEOWlMHAJ3KTTRsECfBwih4DIrTWYGfAkxIY+ERuKKs0o+it02jv\n6k55T8Me6LsTJpFoDHwiB+zn5i9cuW4N+744a4LGXbOkNLZWILJjmZs3t7RBRvfcfFt7l9ufL5g0\nnK2LKSAx8Ins9HfDFAAMitRh7dw0lOSlwRClh4TuXbNchUOBgFM6RHb6O9eu00hY/Y/dq3DYupgC\nEe/wiez0d659/XxunKLAxsAn6qGs0oxvrlzv12cZ9hTohAV+UVERkpOTkZ6ejnnz5qGlpUXUUEQ+\n8XhZFR7bfgpXPXhAa2HgChwKAsICf/r06fjrX/+KM2fO4Hvf+x5KSkpEDUXkNUsPnH4sr+cKHAoa\nwgI/OzsbWm33M+FJkyahvr5e1FBEXimrNOP1fjQ8A7gCh4KLX1bpvPzyy1i4cKE/hiLy2Pryao/v\n7NnwjIKRV4GflZWFxsbGXu8XFxdjzpw51p+1Wi0KCgoc/g2TyQSTyQQAaGpq8qYcIrf03EUbfWsE\nvr7k+iHtoEgdctOH4fC5JjY8o6AmyXJ/uoK4Z8uWLdi8eTMOHjyIyMjIPq83Go2oqKgQVQ6pXFml\nGWt2nUVLW7vbn7lv0nCsnZsmsCoi77mbncKmdPbt24ennnoKR44ccSvsiUSyb2XcF8vpUwx7CiXC\nAv+nP/0prl+/junTpwPofnC7efNmUcMROVVWacZj20/1OU9v+PYAE07ZUKgSFviffvqpqD9N5FTP\n82Q1koRJCYPw4WcX3Hooy5CnUMedthQyLGvpLYeHd8oy3v/sAtzdRrW+vFpccUQBgIFPIePNY3Ve\nfZ4HlFCoY+BTyOj0csEZDyihUMfAp5ChkaR+f5btEUgN2A+fgtrjZVV43cMeOGEScFfC7aj9vzau\nyiFVYeBT0LI8pHXXoEgdKn+VLbAiosDGwKegYX+wuNmDh6w9T6MiUisGPgUF+52ynoS9gVM2RAAY\n+BQk1uw62++Dxd9fMc3H1RAFJwY+BZyeUzdRkTpcb+/s1ylUABCl1/m4OqLgxcCngGI/dfPNVded\nLSN1YWhr73K4SkcXJmHNbM7bE1kw8CkgWO7qPZmbB4Df5KVb5+btH+py3p7IFgOfFOdp62KLQZE6\nm0CfO9bAgCdygTttSXHry6s9Dnu9TsNllkQeYuCT4jxtWhal1/E8WaJ+4JQOKS4qUtfnw1nrtXod\nTq3mblmi/mDgk9/1fLjqSQ8cvU7DVTdEXhA+pfP0009DkiQ0NzeLHoqCgOUBrdnNsDdE6SF9+++c\nxiHyjtA7/Lq6Ouzfvx/Dhw8XOQwFEU8e0Bqi9NwlS+RDQgP/sccew7p16zBnzhyRw1AA6zl9E64N\nw/UO93bMsj89ke8JC/xdu3bBYDBgzJgxooagAGe/vt5V2EfpdRgQoeWmKSKBvAr8rKwsNDY29nq/\nuLgYv/nNb/DOO+/0+TdMJhNMJhMAoKmpyZtyKAA8XlaFN4/VeXTcoOVhLAOeSCxJlr08CNSBqqoq\n/OAHP0BkZCQAoL6+HjExMTh+/DiGDh3q9HNGoxEVFRW+Lof8xNMDSSw2LMxg2BN5wd3sFDKlk5aW\nhq+//tr6Oj4+HhUVFRg8eLCI4ShAvHmszuPPaCSJYU/kJ9xpSz7jyTSOxY8y4wRUQkSO+GXjVW1t\nrT+GIQXFr9jj8vcSgMhwDa7e6ISM7jv7H2XGYe3cNL/UR0TcaUs+0FfY3zdpOIOdKAAw8MkjfbVF\nuG/ScOsqHd7FEwUWBj65ZH/c4OVrHWjv6h31K2cm46HJIwCAAU8UoBj45JS7xw0aovTWsCeiwMVV\nOuTUk38661bfG0/72RORMhj45FBZpdntHvUxUXrB1RCRL3BKR+WcHfy9vrzarc+zyRlR8GDgq5j9\nHL25pQ0rd1RZf3YmSq/DxbZ2NjkjCjIMfBVz1Ju+rb0TS7efcvoZHjFIFLw4h69inj5s5RGDRMGN\nd/gq03POXpIAZ+1vaktznc7vE1FwYuCriP2cvaOwlwA8uzADADB3rIEBTxRCOKWjIu6cJztQr2PI\nE4UoBr6KuDNnf7HNvbX3RBR8OKWjApa5eHe61XMTFVHoYuCHsLJKM57801m3d8xyExVRaGPghyj7\nB7SODIrUQZbBTVREKiE08J977jls2rQJWq0Wubm5WLduncjhVM9mySWALhfXSgAqf8UNVERqIizw\nDx8+jJ07d+LMmTOIiIiwOdScfK/Xkss+rudcPZH6CAv8F154AStWrEBERAQAYMiQIaKGUq2ed/Rh\nkuT2IeKcqydSJ2HLMs+fP4+jR48iMzMTkydPxokTJxxeZzKZYDQaYTQa0dTUJKqckGO5ozd/e9Sg\nu2EfpdehJC+Nc/VEKuTVHX5WVhYaGxt7vV9cXIyOjg588803+Oijj3DixAksWLAAn3/+OSRJsrm2\nsLAQhYWFAACj0ehNOariziYqANBIErpkmQ9lici7wD9w4IDT373wwgvIy8uDJEmYOHEiwsLC0Nzc\njOjoaG+GpG+5s4lKr9Pwbp6IrIRN6cydOxeHDh0C0D29c+PGDQwePFjUcKpy/yvH+3woa4jSM+yJ\nyIawh7ZLlizBkiVLMHr0aISHh2PLli29pnPIMztO1mPZW6f7vM4Qpcf7K6b5oSIiCibCAj88PBxb\nt24V9edVJ/vZIzj/1WWb98LQe609V+AQkTPcaRvgLl/vwOjV5Q5/14XuVTcDIrTsWU9EfWLgB7Dk\nJ/6Ma+2u9st2t0XgkYNE5A62Rw5A9d9cRfyKPTZhHzPwFofXcscsEbmLd/gKcHV0YPyKPTbXPjJ1\nBIpykh02Q+N8PRF5goHvZ/bBbW5pw9Ltp/BEWRUuXbfdSFVbmmv92fIPBJ4xS0T9xcD3M2c7ZHuG\n/YaFGQ6DnGfMEpE3OIfvZ33tkDVE6RnqRCQEA9/P+nrI6k7LBCKi/mDg+9l9mcNd/p6rbohIFM7h\n+4ksy/iXl4/jaE2z02u46oaIRGLg+8HxLy5gwf98aH29+b5xmDF6mMvlmUREvsbAF6ijswszNh7F\np19398BJiB6Ad5beC62meyaNq26IyJ8Y+IKUn23EQ6+dtL7eXjgJmQl3KFgREakdA9/H2m50Yvza\n/bh6o3td/d2Jd2DrA5lsDU1EimPg+9Abx77EL9+usr7+86P/gJRhtylYERHRTQx8H2i5egMZv95v\nfT1/fCye/qcxClZERNQbA99LGw6cx4YDNdbXf/nFVMQOilSwIiIix4QF/qlTp/CTn/wE165dg1ar\nxfPPP4+JEyeKGs7vGlra8P3SQ9bX/zEtET/P5hp6IgpcwgJ/+fLlWL16NWbOnIm9e/di+fLlePfd\nd0UN51crd5zBm8frrK8/fmI6bh8QrmBFRER9Exb4kiShtbUVAHDx4kXExMSIGspvzn91CdnPvmd9\n/V9zUvHPd8UrVxARkQckWZZlEX/4b3/7G3JyciDLMrq6uvDBBx/gzjvv7HWdyWSCyWQCADQ1NeHv\nf/+7iHK8Issy/u2VEzhyvgkAoNNIOL06G5HhfARCRMozGo2oqKjo8zqvAj8rKwuNjY293i8uLsbB\ngwcxefJk5Ofn4w9/+ANMJhMOHDjgk6L9qaL2AuZvvtkW4fmCcZiVNkzBioiIbPkl8F0ZOHAgWlpa\nIEkSZFnGwIEDrVM8zgRS4Hd0dmHmxqOo+bYtwp13ROLAssnQadhglIgCi7vZKWxOIiYmBkeOHMGU\nKVNw6NAhjBw5UtRQPrf/k6/w49/f/A/vzR9Pwl0j2BaBiIKbsMB/8cUX8eijj6KjowO33HKLdZ4+\nkF1r74Rx7QFcvt4BALgr4Q688WO2RSCi0CAs8O+55x6cPHmy7wsDxPYTX+IXf7zZFmHvz/4Bo2LY\nFoGIQofql5lcvNqOMb9+x/o6b5wBv12QoWBFRERiqDrwnztYg2f2n7e+Prp8KuJuZ1sEIgpNqgz8\n/73YhrtKbrZFeGTqCBTlJCtYERGReKoL/FVvV+H1Y19aX598PAt3fCdCwYqIiPxDNYFf89UlTO/R\nFuHJ2an41+/HK1cQEZGfhXzgy7KMJa+ewOHq7rYImjAJZ1ZnY0BEyH91IiIbIZ16J/9+Afkv3GyL\n8LvF45CbzrYIRKROIRn4nV0ycv/7KM41XgIAxN2ux6GfT2FbBCJStZAI/LJKM9aXV6OhpQ2DBoTj\nwpUb1t+98WAmvp84WMHqiIgCQ9AHflmlGSt3VKGtvRMArGE/InoA9j82GWFhbItARAQAQT/Hsb68\n2hr2PV1r72LYExH1EPSB39DS5tH7RERqFfSBHxOl9+h9IiK1CvrAL8pJgl6nsXlPr9OgKCdJoYqI\niAJT0D+0nTvWAADWVToxUXoU5SRZ3yciom5BH/hAd+gz4ImIXPNqSuett95CamoqwsLCep2nWFJS\ngsTERCQlJaG8vNyrIomIyHte3eGPHj0aO3bswEMPPWTz/ieffIJt27bh7NmzaGhoQFZWFs6fPw+N\nRuPkLxERkWhe3eGnpKQgKan3w9GdO3di0aJFiIiIwHe/+10kJibi+PHj3gxFREReErJKx2w2Iy4u\nzvo6NjYWZrNZxFBEROSmPqd0srKy0NjY2Ov94uJizJkzx+FnZFnu9Z4kOd71ajKZYDKZAABNTU19\nlUNERP3UZ+AfOHDA4z8aGxuLuro66+v6+nrExMQ4vLawsBCFhYUAgMGDB8NoNALoDv/o6GiPxw5G\navqugLq+L79raAq071pbW+vWdUKWZc6ePRuLFy/GsmXL0NDQgJqaGkycOLHPzzU3N1t/NhqNvVb+\nhCo1fVdAXd+X3zU0Bet39WoO/+2330ZsbCw+/PBD5ObmIicnBwCQmpqKBQsWYNSoUZgxYwZ+97vf\ncYUOEZHCvLrDnzdvHubNm+fwd6tWrcKqVau8+fNERORDmjVr1qxRughnxo8fr3QJfqOm7wqo6/vy\nu4amYPyukuxoSQ0REYWcoO+WSURE7gnowH/iiSeQnp6OjIwMZGdno6GhQemShCkqKkJycjLS09Mx\nb948tLS0KF2SMK56MIWKffv2ISkpCYmJiSgtLVW6HKGWLFmCIUOGYPTo0UqXIlRdXR2mTp2KlJQU\npKamYuPGjUqX5Dk5gF28eNH688aNG+WHHnpIwWrEKi8vl9vb22VZluXly5fLy5cvV7gicT755BP5\n3Llz8uTJk+UTJ04oXY7PdXR0yAkJCfJnn30mX79+XU5PT5fPnj2rdFnCHDlyRD558qScmpqqdClC\nNTQ0yCdPnpRlWZZbW1vlkSNHBt1/rwF9h3/bbbdZf75y5YrT3bqhIDs7G1pt96KpSZMmob6+XuGK\nxHHWgylUHD9+HImJiUhISEB4eDgWLVqEnTt3Kl2WMPfeey9uv/12pcsQbtiwYRg3bhwA4NZbb0VK\nSkrQtYwJ+H74q1atwu9//3sMHDgQhw8fVrocv3j55ZexcOFCpcugfnLUS+rYsWMKVkS+Vltbi8rK\nSmRmZipdikcUv8PPysrC6NGje/3LckdUXFyMuro6FBQUYNOmTQpX652+vivQ/X21Wi0KCgoUrNR7\n7nzXUCV70EuKgs/ly5eRn5+PDRs22MxCBAPF7/Dd7dWzePFi5Obm4sknnxRckTh9fdctW7Zg9+7d\nOHjwYNAHRH96MIUKT3pJUXBpb29Hfn4+CgoKkJeXp3Q5HlP8Dt+Vmpoa68+7du1CcnKygtWItW/f\nPjz11FPYtWsXIiMjlS6HvDBhwgTU1NTgiy++wI0bN7Bt2zbMnj1b6bLIS7Is44EHHkBKSgqWLVum\ndDn9o/RTY1fy8vLk1NRUOS0tTf7hD38o19fXK12SMCNGjJBjY2PlMWPGyGPGjAnpFUk7duyQDQaD\nHB4eLg8ZMkTOzs5WuiSf27Nnjzxy5Eg5ISFBXrt2rdLlCLVo0SJ56NChslarlQ0Gg/zSSy8pXZIQ\nR48elQHIaWlp1v+d7tmzR+myPMKdtkREKhHQUzpEROQ7DHwiIpVg4BMRqQQDn4hIJRj4REQqwcAn\nIlIJBj4RkUow8ImIVOL/AYGO6OZVBDSeAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "theta = jnp.array([1., 1.])\n",
+    "\n",
+    "for _ in range(1000):\n",
+    "  theta = update(theta, xs, ys)\n",
+    "\n",
+    "plt.scatter(xs, ys)\n",
+    "plt.plot(xs, model(theta, xs))\n",
+    "\n",
+    "w, b = theta\n",
+    "print(f\"w: {w:<.2f}, b: {b:<.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5-q17kJ_rjLc"
+   },
+   "source": [
+    "As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/06-pytrees.ipynb). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "last_runtime": {
+    "build_target": "",
+    "kind": "local"
+   },
+   "name": "Jax Basics.ipynb",
+   "provenance": [
+    {
+     "file_id": "/piper/depot/google3/learning/deepmind/jax/g3doc/codelabs/1_basics/jax_basics.ipynb",
+     "timestamp": 1601629617036
+    },
+    {
+     "file_id": "11dB7Iriv70nYijkjL-iY7nN1mQkiYE_4",
+     "timestamp": 1600933151194
+    }
+   ]
+  },
+  "jupytext": {
+   "formats": "ipynb,md:myst"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/jax-101/01-jax-basics.md
+++ b/docs/jax-101/01-jax-basics.md
@@ -1,0 +1,375 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.10.0
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
++++ {"id": "6_117sy0CGEU"}
+
+# JAX as accelerated NumPy
+
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/01-jax-basics.ipynb)
+
+*Authors: Rosalia Schneider & Vladimir Mikulik*
+
+In this first section you will learn the very fundamentals of JAX.
+
++++ {"id": "CXjHL4L6ku3-"}
+
+## Getting started with JAX numpy
+
+Fundamentally, JAX is a library that enables transformations of array-manipulating programs written with a NumPy-like API. 
+
+Over the course of this series of guides, we will unpack exactly what that means. For now, you can think of JAX as *differentiable NumPy that runs on accelerators*.
+
+The code below shows how to import JAX and create a vector.
+
+```{code-cell} ipython3
+:id: ZqUzvqF1B1TO
+
+import jax
+import jax.numpy as jnp
+
+x = jnp.arange(10)
+print(x)
+```
+
++++ {"id": "rPBmlAxXlBAy"}
+
+So far, everything is just like NumPy. A big appeal of JAX is that you don't need to learn a new API. Many common NumPy programs would run just as well in JAX if you substitute `np` for `jnp`. However, there are some important differences which we touch on at the end of this section.
+
+You can notice the first difference if you check the type of `x`. It is a variable of type `DeviceArray`, which is the way JAX represents arrays.
+
+```{code-cell} ipython3
+:id: 3fLtgPUAn7mi
+
+x
+```
+
++++ {"id": "Yx8VofzzoHFH"}
+
+One useful feature of JAX is that the same code can be run on different backends -- CPU, GPU and TPU.
+
+We will now perform a dot product to demonstrate that it can be done in different devices without changing the code. We use `%timeit` to check the performance. 
+
+(Technical detail: when a JAX function is called, the corresponding operation is dispatched to an accelerator to be computed asynchronously when possible. The returned array is therefore not necessarily 'filled in' as soon as the function returns. Thus, if we don't require the result immediately, the computation won't block Python execution. Therefore, unless we `block_until_ready`, we will only time the dispatch, not the actual computation. See [Asynchronous dispatch](https://jax.readthedocs.io/en/latest/async_dispatch.html#asynchronous-dispatch) in the JAX docs.)
+
+```{code-cell} ipython3
+:id: mRvjVxoqo-Bi
+
+long_vector = jnp.arange(int(1e7))
+
+%timeit jnp.dot(long_vector, long_vector).block_until_ready()
+```
+
++++ {"id": "DKBB0zs-p-RC"}
+
+**Tip**: Try running the code above twice, once without an accelerator, and once with a GPU runtime (while in Colab, click *Runtime* → *Change Runtime Type* and choose `GPU`). Notice how much faster it runs on a GPU.
+
++++ {"id": "PkCpI-v0uQQO"}
+
+## JAX first transformation: `grad`
+
+A fundamental feature of JAX is that it allows you to transform functions.
+
+One of the most commonly used transformations is `jax.grad`, which takes a numerical function written in Python and returns you a new Python function that computes the gradient of the original function. 
+
+To use it, let's first define a function that takes an array and returns the sum of squares.
+
+```{code-cell} ipython3
+:id: LuaGUVRUvbzQ
+
+def sum_of_squares(x):
+  return jnp.sum(x**2)
+```
+
++++ {"id": "QAqloI1Wvtp2"}
+
+Applying `jax.grad` to `sum_of_squares` will return a different function, namely the gradient of `sum_of_squares` with respect to its first parameter `x`. 
+
+Then, you can use that function on an array to return the derivatives with respect to each element of the array.
+
+```{code-cell} ipython3
+:id: dKeorwJfvpeI
+
+sum_of_squares_dx = jax.grad(sum_of_squares)
+
+x = jnp.asarray([1.0, 2.0, 3.0, 4.0])
+
+print(sum_of_squares(x))
+
+print(sum_of_squares_dx(x))
+```
+
++++ {"id": "VfBt5CYbyKUX"}
+
+You can think of `jax.grad` by analogy to the $\nabla$ operator from vector calculus. Given a function $f(x)$, $\nabla f$ represents the function that computes $f$'s gradient, i.e.
+
+$$
+(\nabla f)(x)_i = \frac{\partial f}{\partial x_i}(x).
+$$
+
+Analogously, `jax.grad(f)` is the function that computes the gradient, so `jax.grad(f)(x)` is the gradient of `f` at `x`.
+
+(Like $\nabla$, `jax.grad` will only work on functions with a scalar output -- it will raise an error otherwise.)
+
+This makes the JAX API quite different to other autodiff libraries like Tensorflow and PyTorch, where to compute the gradient we use the loss tensor itself (e.g. by calling `loss.backward()`). The JAX API works directly with functions, staying closer to the underlying math. Once you become accustomed to this way of doing things, it feels natural: your loss function in code really is a function of parameters and data, and you find its gradient just like you would in the math.
+
+This way of doing things makes it straightforward to control things like which variables to differentiate with respect to. By default, `jax.grad` will find the gradient with respect to the first argument. In the example below, the result of `sum_squared_error_dx` will be the gradient of `sum_squared_error` with respect to `x`.
+
+```{code-cell} ipython3
+:id: f3NfaVu4yrQE
+
+def sum_squared_error(x, y):
+  return jnp.sum((x-y)**2)
+
+sum_squared_error_dx = jax.grad(sum_squared_error)
+
+y = jnp.asarray([1.1, 2.1, 3.1, 4.1])
+
+print(sum_squared_error_dx(x, y))
+```
+
++++ {"id": "1tOztA5zpLWN"}
+
+To find the gradient with respect to a different argument (or several), you can set `argnums`:
+
+```{code-cell} ipython3
+:id: FQSczVQkqIPY
+
+jax.grad(sum_squared_error, argnums=(0, 1))(x, y)  # Find gradient wrt both x & y
+```
+
++++ {"id": "yQAMTnZSqo-t"}
+
+Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/06-pytrees.ipynb). So, most often, use of `jax.grad` looks like this:
+
+```
+def loss_fn(params, data):
+  ...
+
+grads = jax.grad(loss_fn)(params, data_batch)
+```
+
++++ {"id": "oBowiovisT97"}
+
+where `params` is, for example, a nested dict of arrays, and the returned `grads` is another nested dict of arrays with the same structure.
+
++++ {"id": "LNjf9jUEsZZ8"}
+
+## Value and Grad
+
+Often, you need to find both the value and the gradient of a function, e.g. if you want to log the training loss. JAX has a handy sister transformation for efficiently doing that:
+
+```{code-cell} ipython3
+:id: dWg4_-h3sYwl
+
+jax.value_and_grad(sum_squared_error)(x, y)
+```
+
++++ {"id": "QVT2EWHJsvvv"}
+
+which returns a tuple of, you guessed it, (value, grad). To be precise, for any `f`,
+
+```
+jax.value_and_grad(f)(*xs) == (f(*xs), jax.grad(f)(*xs)) 
+```
+
++++ {"id": "QmHTVpAks3OX"}
+
+## Auxiliary data
+
+In addition to wanting to log the value, we often want to report some intermediate results obtained in computing the loss function. But if we try doing that with regular `jax.grad`, we run into trouble:
+
+```{code-cell} ipython3
+:id: ffGCEzT4st41
+:tags: [raises-exception]
+
+def squared_error_with_aux(x, y):
+  return sum_squared_error(x, y), x-y
+
+jax.grad(squared_error_with_aux)(x, y)
+```
+
++++ {"id": "IUubno3nth4i"}
+
+This is because `jax.grad` is only defined on scalar functions, and our new function returns a tuple. But we need to return a tuple to return our intermediate results! This is where `has_aux` comes in:
+
+```{code-cell} ipython3
+:id: uzUFihyatgiF
+
+jax.grad(squared_error_with_aux, has_aux=True)(x, y)
+```
+
++++ {"id": "g5s3UiFauwDk"}
+
+`has_aux` signifies that the function returns a pair, `(out, aux)`. It makes `jax.grad` ignore `aux`, passing it through to the user, while differentiating the function as if only `out` was returned.
+
++++ {"id": "fk4FUXe7vsW4"}
+
+## Differences from NumPy
+
+The `jax.numpy` API closely follows that of NumPy. However, there are some important differences. We cover many of these in future guides, but it's worth pointing some out now.
+
+The most important difference, and in some sense the root of all the rest, is that JAX is designed to be _functional_, as in _functional programming_. The reason behind this is that the kinds of program transformations that JAX enables are much more feasible in functional-style programs.
+
+An introduction to functional programming (FP) is out of scope of this guide. If you already are familiar with FP, you will find your FP intuition helpful while learning JAX. If not, don't worry! The important feature of functional programming to grok when working with JAX is very simple: don't write code with side-effects.
+
+A side-effect is any effect of a function that doesn't appear in its output. One example is modifying an array in place:
+
+```{code-cell} ipython3
+:id: o_YBuLQC1wPJ
+
+import numpy as np
+
+x = np.array([1, 2, 3])
+
+def in_place_modify(x):
+  x[0] = 123
+  return None
+
+in_place_modify(x)
+x
+```
+
++++ {"id": "JTtUihVZ13F6"}
+
+The side-effectful function modifies its argument, but returns a completely unrelated value. The modification is a side-effect. 
+
+The code below will run in NumPy. However, JAX arrays won't allow themselves to be modified in-place:
+
+```{code-cell} ipython3
+:id: u6grTYIVcZ3f
+:tags: [raises-exception]
+
+in_place_modify(jnp.array(x))  # Raises error when we cast input to jnp.ndarray
+```
+
++++ {"id": "RGqVfYSpc49s"}
+
+Helpfully, the error points us to JAX's side-effect-free way of doing the same thing via the [`jax.ops.index_*`](https://jax.readthedocs.io/en/latest/jax.ops.html#indexed-update-operators) ops. They are analogous to in-place modification by index, but create a new array with the corresponding modifications made:
+
+```{code-cell} ipython3
+:id: Rmklk6BB2xF0
+
+def jax_in_place_modify(x):
+  return jax.ops.index_update(x, 0, 123)
+
+y = jnp.array([1, 2, 3])
+jax_in_place_modify(y)
+```
+
++++ {"id": "91tn_25vdrNf"}
+
+Note that the old array was untouched, so there is no side-effect:
+
+```{code-cell} ipython3
+:id: KQGXig4Hde6T
+
+y
+```
+
++++ {"id": "d5TibzPO25qa"}
+
+Side-effect-free code is sometimes called *functionally pure*, or just *pure*.
+
+Isn't the pure version less efficient? Strictly, yes; we are creating a new array. However, as we will explain in the next guide, JAX computations are often compiled before being run using another program transformation, `jax.jit`. If we don't use the old array after modifying it 'in place' using `jax.ops.index_update()`, the compiler can recognise that it can in fact compile to an in-place modify, resulting in efficient code in the end.
+
+Of course, it's possible to mix side-effectful Python code and functionally pure JAX code, and we will touch on this more later. As you get more familiar with JAX, you will learn how and when this can work. As a rule of thumb, however, any functions intended to be transformed by JAX should avoid side-effects, and the JAX primitives themselves will try to help you do that.
+
+We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Part 7: Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs.
+
++++ {"id": "dFn_VBFFlGCz"}
+
+## Your first JAX training loop
+
+We still have much to learn about JAX, but you already know enough to understand how we can use JAX to build a simple training loop.
+
+To keep things simple, we'll start with a linear regression. 
+
+Our data is sampled according to $y = w_{true} x + b_{true} + \epsilon$.
+
+```{code-cell} ipython3
+:id: WGgyEWFqrPq1
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+xs = np.random.normal(size=(100,))
+noise = np.random.normal(scale=0.1, size=(100,))
+ys = xs * 3 - 1 + noise
+
+plt.scatter(xs, ys)
+```
+
++++ {"id": "RTh22mo4rR1x"}
+
+Therefore, our model is $\hat y(x; \theta) = wx + b$.
+
+We will use a single array, `theta = [w, b]` to house both parameters:
+
+```{code-cell} ipython3
+:id: TnVrRTMamyzb
+
+def model(theta, x):
+  """Computes wx + b on a batch of input x."""
+  w, b = theta
+  return w * x + b
+```
+
++++ {"id": "qCrLmmKrn9_h"}
+
+The loss function is $J(x, y; \theta) = (\hat y - y)^2$.
+
+```{code-cell} ipython3
+:id: 07eMcDLMn9Ww
+
+def loss_fn(theta, x, y):
+  prediction = model(theta, x)
+  return jnp.mean((prediction-y)**2)
+```
+
++++ {"id": "ejMt4dulnoYX"}
+
+How do we optimize a loss function? Using gradient descent. At each update step, we will find the gradient of the loss w.r.t. the parameters, and take a small step in the direction of steepest descent:
+
+$\theta_{new} = \theta - 0.1 (\nabla_\theta J) (x, y; \theta)$
+
+```{code-cell} ipython3
+:id: 2I6T5Wphpaaa
+
+def update(theta, x, y, lr=0.1):
+  return theta - lr * jax.grad(loss_fn)(theta, x, y)
+```
+
++++ {"id": "MAUL1gT_opVn"}
+
+In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [The Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb).
+
+This function can then be JIT-compiled in its entirety for maximum efficiency. The next guide will explain exactly how `jax.jit` works, but if you want to, you can try adding `@jax.jit` before the `update()` definition, and see how the training loop below runs much faster.
+
+```{code-cell} ipython3
+:id: WLZxY7nIpuVW
+
+theta = jnp.array([1., 1.])
+
+for _ in range(1000):
+  theta = update(theta, xs, ys)
+
+plt.scatter(xs, ys)
+plt.plot(xs, model(theta, xs))
+
+w, b = theta
+print(f"w: {w:<.2f}, b: {b:<.2f}")
+```
+
++++ {"id": "5-q17kJ_rjLc"}
+
+As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/06-pytrees.ipynb). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX.

--- a/docs/jax-101/index.rst
+++ b/docs/jax-101/index.rst
@@ -1,0 +1,14 @@
+Tutorial: JAX 101 (Work in Progress)
+====================================
+
+This is a tutorial developed by engineers and researchers at DeepMind_.
+It is a work in progress; more content will be added soon!
+
+.. toctree::
+  :maxdepth: 2
+  :caption: Tutorial Outline
+
+  01-jax-basics
+
+
+.. _Deepmind: http://deepmind.com


### PR DESCRIPTION
This adds the first of the series of notebooks in the JAX 101 tutorial. The only changes I made were to remove unnecessary ipynb metadata, adjust formats, and change internal links to (currently broken) external links.

You can view the docs built from this PR here: https://jax--5823.org.readthedocs.build/en/5823/