### PR TITLE
readthedocs: set fail_on_warning=true

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,25 +267,3 @@ epub_exclude_files = ['search.html']
 # Tell sphinx-autodoc-typehints to generate stub parameter annotations including
 # types, even if the parameters aren't explicitly documented.
 always_document_param_types = True
-
-# Monkey-patch the myst-nb execution logger
-# TODO(jakevdp): remove this monkey-patch when execution_fail_on_error is available.
-# See https://github.com/executablebooks/MyST-NB/pull/296
-from myst_nb import execution
-
-class _FakeLogger:
-    def __init__(self, logger):
-        self._logger = logger
-
-    def verbose(self, *args, **kwargs):
-        return self._logger.verbose(*args, **kwargs)
-
-    def info(self, *args, **kwargs):
-        return self._logger.info(*args, **kwargs)
-
-    def error(self, *args, **kwargs):
-        if str(args[0]).lower().startswith("execution failed"):
-            raise ValueError(args[0])
-        return self._logger.error(*args, **kwargs)
-
-execution.LOGGER = _FakeLogger(execution.LOGGER)


### PR DESCRIPTION
Over the past six weeks, I've been slowly chipping away at our documentation build warnings: we had 300+, and are now down to zero! Warnings are non-fatal by default, but generally indicate that mis-formatted HTML will be generated.

Now that we're at zero, let's keep it that way!

This PR sets readthedocs so that any new warnings will be treated as errors; this will help us prevent introducing new formatting issues into the documentation. As a bonus, this obviates the myst-nb monkeypatch that we had been using to turn cell execution failure warnings into errors.