### PR TITLE
Add github issue templates to direct users in the right direction

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,18 @@
+---
+name: 'Bug report'
+about: 'Report a bug to help improve the package'
+labels: 'bug'
+---
+
+Please:
+
+- [ ] Check for duplicate issues.
+- [ ] Provide a complete example of how to reproduce the bug, wrapped in triple backticks like this:
+
+```python
+import jax.numpy as jnp
+print(jnp.arange(10))
+# [0 1 2 3 4 5 6 7 8 9]
+```
+
+- [ ] If applicable, include full error messages/tracebacks.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,10 @@
+---
+name: 'Feature Request'
+about: 'Suggest a new idea or improvement for JAX'
+labels: 'enhancement'
+---
+
+Please:
+
+- [ ] Check for duplicate requests.
+- [ ] Describe your goal, and if possible provide a code snippet with a motivating example.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/google/jax/discussions
+    about: Please ask questions on the Discussions tab


### PR DESCRIPTION
With this change, when a user clicks "new issue", they will be directed to a screen that lets them choose what kind of issue they have: a bug report, a feature request, or a question. The first two open issue templates, and the third redirects to the Discussions tab.

For an example of how this would look in practice, see the [Vega-Lite repository](https://github.com/vega/vega-lite/issues/new/choose), which has a similar setup.