### PR TITLE
[avals with names] abstract eval with while_loop fix

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -271,7 +271,9 @@ def while_loop(cond_fun: Callable[[T], bool],
     if not treedef_is_leaf(cond_tree) or len(cond_jaxpr.out_avals) != 1:
       msg = "cond_fun must return a boolean scalar, but got pytree {}."
       raise TypeError(msg.format(cond_tree))
-    if cond_jaxpr.out_avals[0].strip_weak_type() != ShapedArray((), np.bool_):
+    pred_aval = cond_jaxpr.out_avals[0]
+    if (not isinstance(pred_aval, ShapedArray)
+        or pred_aval.strip_weak_type().strip_named_shape() != ShapedArray((), np.bool_)):
       msg = "cond_fun must return a boolean scalar, but got output type(s) {}."
       raise TypeError(msg.format(cond_jaxpr.out_avals))
     return init_vals, init_avals, body_jaxpr, in_tree, cond_jaxpr, cond_consts, body_consts, body_tree

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1975,10 +1975,9 @@ def _argnum_weak_type(*argnums):
 def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None,
                        weak_type_rule=None, named_shape_rule=None):
   weak_type_rule = weak_type_rule or _standard_weak_type_rule
+  named_shape_rule = named_shape_rule or standard_named_shape_rule
   prim = Primitive(name)
   prim.def_impl(partial(xla.apply_primitive, prim))
-  named_shape_rule = named_shape_rule or partial(
-      fallback_named_shape_rule, prim)
   prim.def_abstract_eval(
       partial(standard_abstract_eval, prim, shape_rule, dtype_rule,
               weak_type_rule, named_shape_rule))
@@ -2005,7 +2004,8 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
     raise TypeError(avals, least_specialized)
 
 def standard_multi_result_abstract_eval(
-    prim, shape_rule, dtype_rule, weak_type_rule, *avals, **kwargs):
+    prim, shape_rule, dtype_rule, weak_type_rule,
+    named_shape_rule, *avals, **kwargs):
   assert prim.multiple_results
   assert all(isinstance(aval, UnshapedArray) for aval in avals), avals
   least_specialized = _max(map(type, avals),
@@ -2018,8 +2018,10 @@ def standard_multi_result_abstract_eval(
   elif least_specialized is ShapedArray:
     out_shapes = shape_rule(*avals, **kwargs)
     out_dtypes = dtype_rule(*avals, **kwargs)
-    return [ShapedArray(s, d, weak_type=weak_type)
-            for s, d, weak_type in safe_zip(out_shapes, out_dtypes, weak_types)]
+    out_named_shapes = named_shape_rule(*avals, **kwargs)
+    return [ShapedArray(s, d, weak_type=weak_type, named_shape=named_shape)
+            for s, d, weak_type, named_shape
+            in safe_zip(out_shapes, out_dtypes, weak_types, out_named_shapes)]
   elif least_specialized is UnshapedArray:
     out_dtypes = dtype_rule(*avals, **kwargs)
     return [UnshapedArray(dtype, weak_type=weak_type)
@@ -2027,57 +2029,12 @@ def standard_multi_result_abstract_eval(
   else:
     raise TypeError(avals, least_specialized)
 
-
 def standard_translate(name, c, *args, **kwargs):
   xla_opname = ''.join(term.capitalize() for term in name.split('_'))
   return getattr(xops, xla_opname)(*args, **kwargs)
 
-
-@lu.transformation_with_aux
-def get_dims_out(dims_in, *args, **kwargs):
-  vals_out, dims_out = yield (args, dims_in), kwargs
-  yield vals_out, dims_out
-
-def fallback_named_shape_rule(prim, *avals, **params):
-  all_named_shape_tuples = set(
-      item for aval in avals for item in aval.named_shape.items())
-  out_named_shape = None
-  # note: this relies on independence of batching over different axes
-  # (= commutativity of batching rules). That isn't true for at least
-  # `while_loop`.
-  for name, size in all_named_shape_tuples:
-    vmap_avals = [aval.update(shape=(size, *aval.shape),
-                              weak_type=False).strip_named_shape()
-                  if name in aval.named_shape else aval for aval in avals]
-    vmap_dims = [0 if name in aval.named_shape else batching.not_mapped
-                 for aval in avals]
-    if prim in batching.collective_rules:
-      raise NotImplementedError(
-          f"collective {prim} should have a custom abstract_eval rule")
-    elif prim in batching.initial_style_batchers:
-      rule = partial(batching.initial_style_batchers[prim], axis_name=name)
-    elif prim in batching.primitive_batchers:
-      rule = batching.primitive_batchers[prim]
-    else:
-      raise NotImplementedError(f"primitive {prim} cannot be used with named "
-                                f"axes because it has no batching rule")
-    f = lu.wrap_init(rule, params)
-    f, vmap_dims_out = get_dims_out(f, vmap_dims)
-    _, in_tree = tree_util.tree_flatten(vmap_avals)
-    f, _ = api_util.flatten_fun_nokwargs(f, in_tree)
-    if config.omnistaging_enabled:
-      pe.trace_to_jaxpr_dynamic(f, vmap_avals)
-    else:
-      vmap_pvals = [pe.PartialVal.unknown(aval) for aval in vmap_avals]
-      pe.trace_to_jaxpr(f, vmap_pvals)
-    dims_out = vmap_dims_out()
-    if not prim.multiple_results: dims_out = [dims_out]
-    mapped_out = [d is not batching.not_mapped for d in dims_out]
-    if out_named_shape is None:
-      out_named_shape = [{} for m in mapped_out]
-    out_named_shape = [{name: size, **ns} if m else ns
-                       for ns, m in safe_zip(out_named_shape, mapped_out)]
-  return out_named_shape
+def standard_named_shape_rule(*avals, **kwargs):
+  return core.join_named_shapes(*(a.named_shape for a in avals))
 
 
 def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
@@ -5011,15 +4968,19 @@ def _reduce_translation_rule(c, *values, computation, jaxpr,
 
 def _reduce_batch_rule(batched_args, batch_dims, *, computation, jaxpr,
                        consts, dimensions):
+  # TODO(mattjj,frostig): use batch_jaxpr, delete computation (assumes poly??)
   num_operands = len(batched_args) // 2
   operands, init_values = split_list(batched_args, [num_operands])
   operand_bdims, init_value_bdims = split_list(batch_dims, [num_operands])
-  if all(init_value_bdim is None for init_value_bdim in init_value_bdims):
+  if all(init_value_bdim is batching.not_mapped
+         for init_value_bdim in init_value_bdims):
     # Assume all batch dims are the same for each of the operands
-    assert all(operand_bdim is not None for operand_bdim in operand_bdims)
-    assert all(operand_bdim == operand_bdims[0] for operand_bdim in operand_bdims)
     # TODO(sharadmv): handle the case when batch dims are different across
     # operands or when some are unbatched
+    if not all(operand_bdim is not batching.not_mapped for operand_bdim in operand_bdims):
+      raise NotImplementedError
+    if not all(operand_bdim == operand_bdims[0] for operand_bdim in operand_bdims):
+      raise NotImplementedError
     operand_bdim = operand_bdims[0]
     new_dimensions = [d + bool(d >= operand_bdim) for d in dimensions]
     new_operand_bdim = operand_bdim - int(np.sum(np.less(dimensions, operand_bdim)))
@@ -5060,12 +5021,26 @@ def _reducer_masking_rule(prim, identity, padded_vals, logical_shapes,
   bind = prim_bind if input_shape is None else partial(prim_bind, input_shape=padded_shape)
   return bind(masked_val, axes=axes)
 
+def _reduce_named_shape_rule(*avals, computation, jaxpr, consts, dimensions):
+  # TODO(mattjj,frostig): see the TODOs noting limitations/assumptions in
+  # _reduce_batching_rule. We're making the same assumptions here for now.
+  num_operands = len(avals) // 2
+  operand_avals, init_avals = split_list(avals, [num_operands])
+  if any(a.named_shape for a in init_avals):
+    raise NotImplementedError
+  named_shapes = [a.named_shape for a in operand_avals]
+  if not all(named_shapes[0] == named_shape for named_shape in named_shapes):
+    raise NotImplementedError
+  return named_shapes
+
+
 reduce_p = core.Primitive('reduce')
 reduce_p.multiple_results = True
 reduce_p.def_impl(partial(xla.apply_primitive, reduce_p))
 reduce_p.def_abstract_eval(
     partial(standard_multi_result_abstract_eval, reduce_p, _reduce_shape_rule,
-            _reduce_dtype_rule, _reduce_weak_type_rule))
+            _reduce_dtype_rule, _reduce_weak_type_rule,
+            _reduce_named_shape_rule))
 xla.translations[reduce_p] = _reduce_translation_rule
 batching.primitive_batchers[reduce_p] = _reduce_batch_rule
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1973,15 +1973,20 @@ def _argnum_weak_type(*argnums):
   return lambda *args, **_: all(args[i].weak_type for i in argnums)
 
 def standard_primitive(shape_rule, dtype_rule, name, translation_rule=None,
-                       weak_type_rule=None):
+                       weak_type_rule=None, named_shape_rule=None):
   weak_type_rule = weak_type_rule or _standard_weak_type_rule
   prim = Primitive(name)
   prim.def_impl(partial(xla.apply_primitive, prim))
-  prim.def_abstract_eval(partial(standard_abstract_eval, prim, shape_rule, dtype_rule, weak_type_rule))
+  named_shape_rule = named_shape_rule or partial(
+      fallback_named_shape_rule, prim)
+  prim.def_abstract_eval(
+      partial(standard_abstract_eval, prim, shape_rule, dtype_rule,
+              weak_type_rule, named_shape_rule))
   xla.translations[prim] = translation_rule or partial(standard_translate, name)
   return prim
 
-def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule, *avals, **kwargs):
+def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
+                           named_shape_rule, *avals, **kwargs):
   assert all(isinstance(aval, UnshapedArray) for aval in avals), avals
   assert not prim.multiple_results
   weak_type = weak_type_rule(*avals, **kwargs)
@@ -1992,7 +1997,8 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule, *avals,
                          weak_type=weak_type)
   elif least_specialized is ShapedArray:
     return ShapedArray(shape_rule(*avals, **kwargs), dtype_rule(*avals, **kwargs),
-                       weak_type=weak_type)
+                       weak_type=weak_type,
+                       named_shape=named_shape_rule(*avals, **kwargs))
   elif least_specialized is UnshapedArray:
     return UnshapedArray(dtype_rule(*avals, **kwargs), weak_type=weak_type)
   else:
@@ -2025,6 +2031,53 @@ def standard_multi_result_abstract_eval(
 def standard_translate(name, c, *args, **kwargs):
   xla_opname = ''.join(term.capitalize() for term in name.split('_'))
   return getattr(xops, xla_opname)(*args, **kwargs)
+
+
+@lu.transformation_with_aux
+def get_dims_out(dims_in, *args, **kwargs):
+  vals_out, dims_out = yield (args, dims_in), kwargs
+  yield vals_out, dims_out
+
+def fallback_named_shape_rule(prim, *avals, **params):
+  all_named_shape_tuples = set(
+      item for aval in avals for item in aval.named_shape.items())
+  out_named_shape = None
+  # note: this relies on independence of batching over different axes
+  # (= commutativity of batching rules). That isn't true for at least
+  # `while_loop`.
+  for name, size in all_named_shape_tuples:
+    vmap_avals = [aval.update(shape=(size, *aval.shape),
+                              weak_type=False).strip_named_shape()
+                  if name in aval.named_shape else aval for aval in avals]
+    vmap_dims = [0 if name in aval.named_shape else batching.not_mapped
+                 for aval in avals]
+    if prim in batching.collective_rules:
+      raise NotImplementedError(
+          f"collective {prim} should have a custom abstract_eval rule")
+    elif prim in batching.initial_style_batchers:
+      rule = partial(batching.initial_style_batchers[prim], axis_name=name)
+    elif prim in batching.primitive_batchers:
+      rule = batching.primitive_batchers[prim]
+    else:
+      raise NotImplementedError(f"primitive {prim} cannot be used with named "
+                                f"axes because it has no batching rule")
+    f = lu.wrap_init(rule, params)
+    f, vmap_dims_out = get_dims_out(f, vmap_dims)
+    _, in_tree = tree_util.tree_flatten(vmap_avals)
+    f, _ = api_util.flatten_fun_nokwargs(f, in_tree)
+    if config.omnistaging_enabled:
+      pe.trace_to_jaxpr_dynamic(f, vmap_avals)
+    else:
+      vmap_pvals = [pe.PartialVal.unknown(aval) for aval in vmap_avals]
+      pe.trace_to_jaxpr(f, vmap_pvals)
+    dims_out = vmap_dims_out()
+    if not prim.multiple_results: dims_out = [dims_out]
+    mapped_out = [d is not batching.not_mapped for d in dims_out]
+    if out_named_shape is None:
+      out_named_shape = [{} for m in mapped_out]
+    out_named_shape = [{name: size, **ns} if m else ns
+                       for ns, m in safe_zip(out_named_shape, mapped_out)]
+  return out_named_shape
 
 
 def unop_dtype_rule(result_dtype, accepted_dtypes, name, aval, **kwargs):
@@ -3150,7 +3203,7 @@ def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
   input_bitwidth = np.dtype(input_dtype).itemsize
   preferred_bitwidth = np.dtype(preferred_element_type).itemsize
   if preferred_bitwidth < input_bitwidth:
-     raise TypeError("`preferred_element_type` must not be narrower than the original type.")
+    raise TypeError("`preferred_element_type` must not be narrower than the original type.")
   return preferred_element_type
 
 def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -626,9 +626,16 @@ def _allreduce_impl(pos_reducer, *args, axes, axis_index_groups):
 
 def _allreduce_abstract_eval(*args, axes, axis_index_groups):
   pos_axes = tuple(axis for axis in axes if isinstance(axis, int))
+  named_shapes = [arg.named_shape for arg in args]
+  if axis_index_groups is None:
+    named_axes = set(axis for axis in axes if not isinstance(axis, int))
+    named_shapes = [{name: size for name, size in arg.named_shape.items()
+                     if name not in named_axes} for arg in args]
+  else:
+    assert len(pos_axes) == 0
   return [ShapedArray(lax._reduce_op_shape_rule(raise_to_shaped(arg), axes=pos_axes),
-                      arg.dtype)
-          for arg in args]
+                      arg.dtype, named_shape=named_shape)
+          for arg, named_shape in zip(args, named_shapes)]
 
 def _allreduce_translation_rule(prim, pos_prim, c, *args, axes, axis_index_groups,
                                 axis_env, platform):
@@ -1082,7 +1089,9 @@ def _all_gather_abstract_eval(x, *, all_gather_dimension, axis_name, axis_index_
   x_aval = raise_to_shaped(x)
   new_shape = list(x_aval.shape)
   new_shape.insert(all_gather_dimension, axis_size)
-  return x_aval.update(shape=new_shape)
+  new_named_shape = {name: size for name, size in x_aval.named_shape.items()
+                     if name != axis_name}
+  return x_aval.update(shape=new_shape, named_shape=new_named_shape)
 
 def _all_gather_transpose_rule(cts, x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size):
   # TODO(cjfj): Add reduce-scatter op to XLA?
@@ -1137,10 +1146,13 @@ def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
   unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
   return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
 
+def _axis_index_abstract_eval(*, axis_name):
+  frame = core.axis_frame(axis_name)
+  return ShapedArray((), np.int32, named_shape={axis_name: frame.size})
+
 axis_index_p = core.Primitive('axis_index')
 xla.parallel_translations[axis_index_p] = _axis_index_translation_rule
-axis_index_p.def_abstract_eval(
-    lambda *args, **params: ShapedArray((), np.int32))
+axis_index_p.def_abstract_eval(_axis_index_abstract_eval)
 pxla.multi_host_supported_collectives.add(axis_index_p)
 core.axis_substitution_rules[axis_index_p] = partial(_subst_all_names_in_param, 'axis_name')
 
@@ -1181,11 +1193,14 @@ def _pdot_impl(x, y, *, axis_name, pos_contract, pos_batch):
 
 @pdot_p.def_abstract_eval
 def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch):
-  # TODO: avals with names, check inputs are mapped along axis_name, eliminate
   if not len(set(axis_name)) == len(axis_name): raise ValueError
-  return lax.dot_general_p.abstract_eval(
+  pos_aval = lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],
       precision=None, preferred_element_type=None)
+  named_shape = {name: size
+                 for aval in (x, y) for name, size in aval.named_shape.items()
+                 if name not in axis_name}
+  return pos_aval.update(named_shape=named_shape)
 
 def _pdot_vmap_collective_rule(frame, vals_in, dims_in, *, axis_name,
                                pos_contract, pos_batch):
@@ -1337,7 +1352,8 @@ def omnistaging_disabler() -> None:
     nreps = dynamic_axis_env.nreps
     trace = frame.pmap_trace
 
-    out_aval = ShapedArray((), np.int32)
+    out_aval = _axis_index_abstract_eval(
+        nreps=nreps, sizes=sizes, axis_name=axis_name)
     out_tracer = pe.JaxprTracer(trace, pe.PartialVal.unknown(out_aval), None)
     eqn = pe.new_eqn_recipe([], [out_tracer], axis_index_p,
                             dict(nreps=nreps, sizes=sizes, axis_name=axis_name),
@@ -1352,7 +1368,9 @@ def omnistaging_disabler() -> None:
     unsigned_index = xops.Rem(xops.Div(xops.ReplicaId(c), div), mod)
     return xops.ConvertElementType(unsigned_index, xb.dtype_to_etype(np.int32))
 
+  def _axis_index_abstract_eval(*, nreps, sizes, axis_name):
+    return ShapedArray((), np.int32, named_shape={axis_name: sizes[-1]})
+
   axis_index_p.def_custom_bind(_axis_index_bind)
-  axis_index_p.def_abstract_eval(
-      lambda *args, **params: ShapedArray((), np.int32))
+  axis_index_p.def_abstract_eval(_axis_index_abstract_eval)
   xla.translations[axis_index_p] = _axis_index_translation_rule

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -625,6 +625,7 @@ def _allreduce_impl(pos_reducer, *args, axes, axis_index_groups):
   return [pos_reducer(arg, axes) for arg in args]
 
 def _allreduce_abstract_eval(*args, axes, axis_index_groups):
+  # TODO(frostig,mattjj,jekbradbury): maybe check aval names here
   pos_axes = tuple(axis for axis in axes if isinstance(axis, int))
   named_shapes = [arg.named_shape for arg in args]
   if axis_index_groups is None:
@@ -1193,6 +1194,7 @@ def _pdot_impl(x, y, *, axis_name, pos_contract, pos_batch):
 
 @pdot_p.def_abstract_eval
 def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch):
+  # TODO(frostig,mattjj,jekbradbury): check inputs have given axis names?
   if not len(set(axis_name)) == len(axis_name): raise ValueError
   pos_aval = lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],

--- a/jax/api.py
+++ b/jax/api.py
@@ -2244,10 +2244,11 @@ def _valid_jaxtype(arg):
 
 
 class ShapeDtypeStruct:
-  __slots__ = ["shape", "dtype"]
-  def __init__(self, shape, dtype):
+  __slots__ = ["shape", "dtype", "named_shape"]
+  def __init__(self, shape, dtype, named_shape={}):
     self.shape = shape
     self.dtype = np.dtype(dtype)
+    self.named_shape = named_shape
 
   size = property(lambda self: prod(self.shape))
   ndim = property(lambda self: len(self.shape))
@@ -2259,7 +2260,8 @@ class ShapeDtypeStruct:
       raise TypeError("len() of unsized object") from e # same as numpy error
 
   def __repr__(self):
-    return f"{type(self).__name__}(shape={self.shape}, dtype={self.dtype.name})"
+    ns = f", named_shape={self.named_shape}" if self.named_shape else ""
+    return f"{type(self).__name__}(shape={self.shape}, dtype={self.dtype.name}{ns})"
 
   __str__ = __repr__
 
@@ -2267,10 +2269,11 @@ class ShapeDtypeStruct:
     if not isinstance(other, ShapeDtypeStruct):
       return False
     else:
-      return (other.shape, other.dtype) == (self.shape, self.dtype)
+      return (other.shape, other.dtype, other.named_shape) == (
+          self.shape, self.dtype, self.named_shape)
 
   def __hash__(self):
-    return hash((self.shape, self.dtype))
+    return hash((self.shape, self.dtype, self.named_shape))
 
 def eval_shape(fun: Callable, *args, **kwargs):
   """Compute the shape/dtype of ``fun`` without any FLOPs.
@@ -2336,7 +2339,7 @@ def eval_shape(fun: Callable, *args, **kwargs):
   wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
   out = pe.abstract_eval_fun(wrapped_fun.call_wrapped,
                              *map(shaped_abstractify, args_flat))
-  out = [ShapeDtypeStruct(x.shape, x.dtype) for x in out]
+  out = [ShapeDtypeStruct(x.shape, x.dtype, x.named_shape) for x in out]
   return tree_unflatten(out_tree(), out)
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2876,16 +2876,8 @@ class JaxprTest(jtu.JaxTestCase):
     def f(x):
       return x - lax.psum(x, 'i')
 
-    class FakeNamedArray:
-      def __init__(self, shape, dtype, named_shape):
-        self.shape = shape
-        self.dtype = dtype
-        self.named_shape = named_shape
-
-    core.pytype_aval_mappings[FakeNamedArray] = lambda x: core.ShapedArray(
-        x.shape, x.dtype, named_shape=x.named_shape)
-
-    x = FakeNamedArray((2, 3), jnp.float32, {'i': 10})
+    x = types.SimpleNamespace(
+        shape=(2, 3), dtype=jnp.float32, named_shape={'i': 10})
     jaxpr = api.make_jaxpr(f, axis_env=[('i', 10)])(x)
     named_shapes = [v.aval.named_shape for v in jaxpr.jaxpr.eqns[1].invars]
     self.assertEqual(named_shapes, [{'i': 10}, {}])

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1259,6 +1259,24 @@ class APITest(jtu.JaxTestCase):
     out_shape = api.eval_shape(lambda x: x, x)  # doesn't crash
     self.assertEqual(out_shape.shape, (3,))
 
+  def test_eval_shape_names(self):
+    def fun(x, y):
+      return lax.psum(x, 'i') + y
+
+    class MyArgArray(object):
+      def __init__(self, shape, dtype, named_shape):
+        self.shape = shape
+        self.dtype = dtype
+        self.named_shape = named_shape
+
+    x = MyArgArray((3, 2), jnp.float32, {'i': 10})
+    y = MyArgArray((3, 2), jnp.float32, {'j': 5})
+    with core.extend_axis_env('i', 10, None):
+      with core.extend_axis_env('j', 5, None):
+        out_shape = api.eval_shape(fun, x, y)
+
+    self.assertEqual(out_shape.named_shape, {'j': 5})
+
   def test_issue_871(self):
     T = jnp.array([[1., 2.], [3., 4.], [5., 6.]])
     x = jnp.array([1, 2, 3])
@@ -2850,6 +2868,27 @@ class JaxprTest(jtu.JaxTestCase):
       return x - lax.psum(x, 'i')
     jaxpr = api.make_jaxpr(f, axis_env=[('i', 4)])(2)
     self.assertIn('psum', str(jaxpr))
+
+  def test_make_jaxpr_named(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    def f(x):
+      return x - lax.psum(x, 'i')
+
+    class FakeNamedArray:
+      def __init__(self, shape, dtype, named_shape):
+        self.shape = shape
+        self.dtype = dtype
+        self.named_shape = named_shape
+
+    core.pytype_aval_mappings[FakeNamedArray] = lambda x: core.ShapedArray(
+        x.shape, x.dtype, named_shape=x.named_shape)
+
+    x = FakeNamedArray((2, 3), jnp.float32, {'i': 10})
+    jaxpr = api.make_jaxpr(f, axis_env=[('i', 10)])(x)
+    named_shapes = [v.aval.named_shape for v in jaxpr.jaxpr.eqns[1].invars]
+    self.assertEqual(named_shapes, [{'i': 10}, {}])
 
 
 class LazyTest(jtu.JaxTestCase):

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -335,6 +335,20 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = np.array([4, 3, 4, 3])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  def testWhileLoopAxisIndexBatched(self):
+    raise SkipTest("leaks axis_index tracer")
+    def fun(x):
+      return lax.while_loop(lambda x: x < lax.axis_index('i'), lambda x: x + 2, x)
+
+    ans = api.vmap(fun, axis_name='i')(np.array([0, 0, 0, 0]))
+    expected = np.array([0, 2, 2, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+    fun = api.jit(fun)
+    ans = api.vmap(fun, axis_name='i')(np.array([0, 0, 0, 0]))
+    expected = np.array([0, 2, 2, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
   def testWhileLoopCondConstsBatched(self):
     def fun(x, y):
       return lax.while_loop(lambda x: x < y, lambda x: x + 2, x)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -335,8 +335,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = np.array([4, 3, 4, 3])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @skipIf(not config.omnistaging_enabled, "test only works with omnistaging")
   def testWhileLoopAxisIndexBatched(self):
-    raise SkipTest("leaks axis_index tracer")
     def fun(x):
       return lax.while_loop(lambda x: x < lax.axis_index('i'), lambda x: x + 2, x)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2453,5 +2453,28 @@ class LazyConstantTest(jtu.JaxTestCase):
     out = lax.cumsum(x)
     self.assertArraysEqual(out, x)
 
+
+class LaxNamedShapeTest(jtu.JaxTestCase):
+
+  def test_abstract_eval(self):
+    aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
+    out = lax.sin_p.abstract_eval(aval1)
+    self.assertEqual(out, aval1)
+
+    aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
+    aval2 = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
+    expected = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
+    out = lax.add_p.abstract_eval(aval1, aval2)
+    self.assertEqual(out, expected)
+
+  def test_abstract_eval_collective(self):
+    if not config.omnistaging_enabled:
+      raise SkipTest("test requires omnistaging")
+    with core.extend_axis_env('i', 10, None):
+      aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
+      expected = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
+      out, = lax.psum_p.abstract_eval(aval1, axes=('i',), axis_index_groups=None)
+      self.assertEqual(out, expected)
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
#5702 broke internal researchers who were doing complicated things with pmapped while loops because it required the loop condition to be scalar even in named axes. That would affect people doing other kinds of batched control flow, too, as soon as we enable named shapes in vmap.

This re-lands that change without the additional requirement.