### PR TITLE
Add autodidax to dev docs toctree and ignore md file to silence warning.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,8 @@ exclude_patterns = [
     'README.md',
     # Ignore markdown source for notebooks; myst-nb builds from the ipynb
     # These are kept in sync using the jupytext pre-commit hook.
-    'notebooks/*.md'
+    'notebooks/*.md',
+    'autodidax.md',
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ For an introduction to JAX, start at the
 
    developer
    jax_internal_api
+   autodidax
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
Fixes CI failure from google/jax#5827.