### PR TITLE
change colab.sandbox->colab.research

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ print(normalize(jnp.arange(4.)))
 # prints [0.         0.16666667 0.33333334 0.5       ]
 ```
 
-You can even [nest `pmap` functions](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb#scrollTo=MdRscR5MONuN) for more
+You can even [nest `pmap` functions](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb#scrollTo=MdRscR5MONuN) for more
 sophisticated communication patterns.
 
 It all composes, so you're free to differentiate through parallel computations:
@@ -345,7 +345,7 @@ When reverse-mode differentiating a `pmap` function (e.g. with `grad`), the
 backward pass of the computation is parallelized just like the forward pass.
 
 See the [SPMD
-Cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)
+Cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)
 and the [SPMD MNIST classifier from scratch
 example](https://github.com/google/jax/blob/master/examples/spmd_mnist_classifier_fromscratch.py)
 for more.

--- a/cloud_tpu_colabs/JAX_NeurIPS_2020_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_NeurIPS_2020_demo.ipynb
@@ -451,7 +451,7 @@
     "id": "jC-KIMQ1q-lK"
    },
    "source": [
-    "For more, see the [`pmap` cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
+    "For more, see the [`pmap` cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
    ]
   },
   {

--- a/cloud_tpu_colabs/JAX_demo.ipynb
+++ b/cloud_tpu_colabs/JAX_demo.ipynb
@@ -871,7 +871,7 @@
     "id": "jC-KIMQ1q-lK"
    },
    "source": [
-    "For more, see the [`pmap` cookbook](https://colab.sandbox.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
+    "For more, see the [`pmap` cookbook](https://colab.research.google.com/github/google/jax/blob/master/cloud_tpu_colabs/Pmap_Cookbook.ipynb)."
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# 🔪 JAX - The Sharp Bits 🔪\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # 🔪 JAX - The Sharp Bits 🔪
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Common_Gotchas_in_JAX.ipynb)
 
 +++ {"id": "4k5PVzEo2uJO"}
 

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Custom derivative rules for JAX-transformable Python functions\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)\n",
     "\n",
     "*mattjj@ Mar 19 2020, last updated Oct 14 2020*\n",
     "\n",

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # Custom derivative rules for JAX-transformable Python functions
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb)
 
 *mattjj@ Mar 19 2020, last updated Oct 14 2020*
 
@@ -56,10 +56,9 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: RrNf588X_kJF
-outputId: b962bafb-e8a3-4b0d-ddf4-202e088231c3
----
+:id: RrNf588X_kJF
+:outputId: b962bafb-e8a3-4b0d-ddf4-202e088231c3
+
 from jax import jvp, grad
 
 print(f(2., 3.))
@@ -83,10 +82,9 @@ f.defjvps(lambda x_dot, primal_out, x, y: jnp.cos(x) * x_dot * y,
 ```
 
 ```{code-cell} ipython3
----
-id: Zn81cHeYWVOw
-outputId: bf29b66c-897b-485e-c0a0-ee0fbd729a95
----
+:id: Zn81cHeYWVOw
+:outputId: bf29b66c-897b-485e-c0a0-ee0fbd729a95
+
 print(f(2., 3.))
 y, y_dot = jvp(f, (2., 3.), (1., 0.))
 print(y)
@@ -119,10 +117,9 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: HpSozxKUCXgp
-outputId: 57277102-7bdb-41f0-c805-a27fcf9fb1ae
----
+:id: HpSozxKUCXgp
+:outputId: 57277102-7bdb-41f0-c805-a27fcf9fb1ae
+
 print(grad(f)(2., 3.))
 ```
 
@@ -143,10 +140,9 @@ One application of `jax.custom_jvp` is to improve the numerical stability of dif
 Say we want to write a function called `log1pexp`, which computes $x \mapsto \log ( 1 + e^x )$. We can write that using `jax.numpy`:
 
 ```{code-cell} ipython3
----
-id: 6lWbTvs40ET-
-outputId: 8caff99e-add1-4c70-ace3-212c0c5c6f4e
----
+:id: 6lWbTvs40ET-
+:outputId: 8caff99e-add1-4c70-ace3-212c0c5c6f4e
+
 import jax.numpy as jnp
 
 def log1pexp(x):
@@ -160,10 +156,9 @@ log1pexp(3.)
 Since it's written in terms of `jax.numpy`, it's JAX-transformable:
 
 ```{code-cell} ipython3
----
-id: XgtGKFld02UD
-outputId: 809d399d-8eca-401e-b969-810e46648571
----
+:id: XgtGKFld02UD
+:outputId: 809d399d-8eca-401e-b969-810e46648571
+
 from jax import jit, grad, vmap
 
 print(jit(log1pexp)(3.))
@@ -176,10 +171,9 @@ print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
 But there's a numerical stability problem lurking here:
 
 ```{code-cell} ipython3
----
-id: sVM6iwIO22sB
-outputId: 9c935ee8-f174-475a-ca01-fc80949199e5
----
+:id: sVM6iwIO22sB
+:outputId: 9c935ee8-f174-475a-ca01-fc80949199e5
+
 print(grad(log1pexp)(100.))
 ```
 
@@ -190,10 +184,9 @@ That doesn't seem right! After all, the derivative of $x \mapsto \log (1 + e^x)$
 We can get a bit more insight into what's going on by looking at the jaxpr for the gradient computation:
 
 ```{code-cell} ipython3
----
-id: dO6uZlYR4TVp
-outputId: 61e06b1e-14cd-4030-f330-a949be185df8
----
+:id: dO6uZlYR4TVp
+:outputId: 61e06b1e-14cd-4030-f330-a949be185df8
+
 from jax import make_jaxpr
 
 make_jaxpr(grad(log1pexp))(100.)
@@ -230,18 +223,16 @@ def log1pexp_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: rhiMHulfKBIF
-outputId: 883bc4d2-3a1b-48d3-b205-c500f77d229c
----
+:id: rhiMHulfKBIF
+:outputId: 883bc4d2-3a1b-48d3-b205-c500f77d229c
+
 print(grad(log1pexp)(100.))
 ```
 
 ```{code-cell} ipython3
----
-id: 9cLDuAo6KGUu
-outputId: 59984494-6124-4540-84fd-608ad4fc6bc6
----
+:id: 9cLDuAo6KGUu
+:outputId: 59984494-6124-4540-84fd-608ad4fc6bc6
+
 print(jit(log1pexp)(3.))
 print(jit(grad(log1pexp))(3.))
 print(vmap(jit(grad(log1pexp)))(jnp.arange(3.)))
@@ -262,10 +253,9 @@ log1pexp.defjvps(lambda t, ans, x: (1 - 1/(1 + jnp.exp(x))) * t)
 ```
 
 ```{code-cell} ipython3
----
-id: dtdh-PLaUsvw
-outputId: aa36aec6-15af-4397-fc55-8b9fb7e607d8
----
+:id: dtdh-PLaUsvw
+:outputId: aa36aec6-15af-4397-fc55-8b9fb7e607d8
+
 print(grad(log1pexp)(100.))
 print(jit(log1pexp)(3.))
 print(jit(grad(log1pexp))(3.))
@@ -294,10 +284,9 @@ def f(x):
 As a mathematical function on $\mathbb{R}$ (the full real line), $f$ is not differentiable at zero (because the limit defining the derivative doesn't exist from the left). Correspondingly, autodiff produces a `nan` value:
 
 ```{code-cell} ipython3
----
-id: piI0u5MiHhQh
-outputId: c045308f-2f3b-4c22-ebb2-b9ee582b4d25
----
+:id: piI0u5MiHhQh
+:outputId: c045308f-2f3b-4c22-ebb2-b9ee582b4d25
+
 print(grad(f)(0.))
 ```
 
@@ -324,10 +313,9 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: Gsh9ZvMTKi1O
-outputId: a3076175-6542-4210-ce4a-d0d82e0051c6
----
+:id: Gsh9ZvMTKi1O
+:outputId: a3076175-6542-4210-ce4a-d0d82e0051c6
+
 print(grad(f)(0.))
 ```
 
@@ -346,10 +334,9 @@ f.defjvps(lambda t, ans, x: ((jnp.sqrt(x) + 2) / (2 * (jnp.sqrt(x) + 1)**2)) * t
 ```
 
 ```{code-cell} ipython3
----
-id: uUU5qRmEViK1
-outputId: ea7dc2c4-a100-48f4-a74a-859070daf994
----
+:id: uUU5qRmEViK1
+:outputId: ea7dc2c4-a100-48f4-a74a-859070daf994
+
 print(grad(f)(0.))
 ```
 
@@ -382,10 +369,9 @@ clip_gradient.defvjp(clip_gradient_fwd, clip_gradient_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: 4OLU_vf8Xw2J
-outputId: 5a51ff2c-79c2-41ba-eead-53679b4eddbc
----
+:id: 4OLU_vf8Xw2J
+:outputId: 5a51ff2c-79c2-41ba-eead-53679b4eddbc
+
 import matplotlib.pyplot as plt
 from jax import vmap
 
@@ -396,10 +382,9 @@ plt.plot(vmap(grad(jnp.sin))(t))
 ```
 
 ```{code-cell} ipython3
----
-id: iS8nRuBZYLcD
-outputId: 299dc977-ff2f-43a4-c0d2-9fa6c7eaeeb2
----
+:id: iS8nRuBZYLcD
+:outputId: 299dc977-ff2f-43a4-c0d2-9fa6c7eaeeb2
+
 def clip_sin(x):
   x = clip_gradient(-0.75, 0.75, x)
   return jnp.sin(x)
@@ -465,10 +450,9 @@ def newton_sqrt(a):
 ```
 
 ```{code-cell} ipython3
----
-id: 42Ydd7_6aLXU
-outputId: c576dc92-33df-42b9-b2e8-ad54119514b1
----
+:id: 42Ydd7_6aLXU
+:outputId: c576dc92-33df-42b9-b2e8-ad54119514b1
+
 print(newton_sqrt(2.))
 ```
 
@@ -477,10 +461,9 @@ print(newton_sqrt(2.))
 We can `vmap` or `jit` the function as well:
 
 ```{code-cell} ipython3
----
-id: t_YSXieT3Yyk
-outputId: 76483e18-81f3-47a8-e8aa-e81535c01fe2
----
+:id: t_YSXieT3Yyk
+:outputId: 76483e18-81f3-47a8-e8aa-e81535c01fe2
+
 print(jit(vmap(newton_sqrt))(jnp.array([1., 2., 3., 4.])))
 ```
 
@@ -549,18 +532,16 @@ fixed_point.defvjp(fixed_point_fwd, fixed_point_rev)
 ```
 
 ```{code-cell} ipython3
----
-id: iKzfT6d_mEoB
-outputId: 5d04c4a0-61dd-42de-ffa4-101b71d15a57
----
+:id: iKzfT6d_mEoB
+:outputId: 5d04c4a0-61dd-42de-ffa4-101b71d15a57
+
 print(newton_sqrt(2.))
 ```
 
 ```{code-cell} ipython3
----
-id: Hmcpjr6gmtkO
-outputId: 9c4a406c-0144-4d5f-e789-a7a4c850a3cc
----
+:id: Hmcpjr6gmtkO
+:outputId: 9c4a406c-0144-4d5f-e789-a7a4c850a3cc
+
 print(grad(newton_sqrt)(2.))
 print(grad(grad(newton_sqrt))(2.))
 ```
@@ -570,10 +551,9 @@ print(grad(grad(newton_sqrt))(2.))
 We can check our answers by differentiating `jnp.sqrt`, which uses a totally different implementation:
 
 ```{code-cell} ipython3
----
-id: jj_JnI9Pm4jg
-outputId: 6eb3e158-209b-41f2-865c-376a1d07624b
----
+:id: jj_JnI9Pm4jg
+:outputId: 6eb3e158-209b-41f2-865c-376a1d07624b
+
 print(grad(jnp.sqrt)(2.))
 print(grad(grad(jnp.sqrt))(2.))
 ```
@@ -613,10 +593,9 @@ f.defjvp(f_jvp)
 ```
 
 ```{code-cell} ipython3
----
-id: fxhlECvW7Krj
-outputId: 30dc5e8b-d157-4ae2-cd17-145d4e1ba47b
----
+:id: fxhlECvW7Krj
+:outputId: 30dc5e8b-d157-4ae2-cd17-145d4e1ba47b
+
 from jax import jvp
 
 print(f(3.))
@@ -649,10 +628,9 @@ def f_jvp(primals, tangents):
 Even though we defined only a JVP rule and no VJP rule, we can use both forward- and reverse-mode differentiation on `f`. JAX will automatically transpose the linear computation on tangent values from our custom JVP rule, computing the VJP as efficiently as if we had written the rule by hand:
 
 ```{code-cell} ipython3
----
-id: hl9Io86pQD6s
-outputId: a9ef39aa-4df0-459f-ee1d-64b648cabcc4
----
+:id: hl9Io86pQD6s
+:outputId: a9ef39aa-4df0-459f-ee1d-64b648cabcc4
+
 from jax import grad
 
 print(grad(f)(3.))
@@ -684,10 +662,9 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: QpKwA0oA8DfE
-outputId: 80855f56-04a5-4179-fd8b-199ea7eba476
----
+:id: QpKwA0oA8DfE
+:outputId: 80855f56-04a5-4179-fd8b-199ea7eba476
+
 print(grad(f)(2., 3.))
 ```
 
@@ -706,10 +683,9 @@ f.defjvps(lambda t, ans, x: jnp.cos(x) * t)
 ```
 
 ```{code-cell} ipython3
----
-id: zfSgXrPEap-i
-outputId: bf552090-a60d-4c2a-fc91-603396df94cd
----
+:id: zfSgXrPEap-i
+:outputId: bf552090-a60d-4c2a-fc91-603396df94cd
+
 print(grad(f)(3.))
 ```
 
@@ -729,10 +705,9 @@ f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
 ```
 
 ```{code-cell} ipython3
----
-id: o9ezUYsjbbvC
-outputId: f60f4941-d5e3-49c3-920f-76fd92414697
----
+:id: o9ezUYsjbbvC
+:outputId: f60f4941-d5e3-49c3-920f-76fd92414697
+
 print(grad(f)(2., 3.))
 print(grad(f, 0)(2., 3.))  # same as above
 print(grad(f, 1)(2., 3.))
@@ -754,10 +729,9 @@ f.defjvps(lambda x_dot, primal_out, x, y: 2 * x * y * x_dot,
 ```
 
 ```{code-cell} ipython3
----
-id: jOtQfp-5btSo
-outputId: b60aa797-4c1e-4421-826d-691ba418bc1d
----
+:id: jOtQfp-5btSo
+:outputId: b60aa797-4c1e-4421-826d-691ba418bc1d
+
 print(grad(f)(2., 3.))
 print(grad(f, 0)(2., 3.))  # same as above
 print(grad(f, 1)(2., 3.))
@@ -788,20 +762,18 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: xAlRea95PjA5
-outputId: 10b4db9e-3192-415e-ac1c-0dc57c7dc086
----
+:id: xAlRea95PjA5
+:outputId: 10b4db9e-3192-415e-ac1c-0dc57c7dc086
+
 from jax import vmap, jit
 
 print(f(3.))
 ```
 
 ```{code-cell} ipython3
----
-id: dyD2ow4NmpI-
-outputId: 1d66b67f-c1b4-4a9d-d6ed-12d88767842c
----
+:id: dyD2ow4NmpI-
+:outputId: 1d66b67f-c1b4-4a9d-d6ed-12d88767842c
+
 print(vmap(f)(jnp.arange(3.)))
 print(jit(f)(3.))
 ```
@@ -811,19 +783,17 @@ print(jit(f)(3.))
 The custom JVP rule is invoked during differentiation, whether forward or reverse:
 
 ```{code-cell} ipython3
----
-id: hKF0xyAxPyLZ
-outputId: 214cc5a7-a992-41c8-aa01-8ea4b2b3b4d6
----
+:id: hKF0xyAxPyLZ
+:outputId: 214cc5a7-a992-41c8-aa01-8ea4b2b3b4d6
+
 y, y_dot = jvp(f, (3.,), (1.,))
 print(y_dot)
 ```
 
 ```{code-cell} ipython3
----
-id: Z1KaEgA58MEG
-outputId: 86263d76-5a98-4d96-f5c2-9146bcf1b6fd
----
+:id: Z1KaEgA58MEG
+:outputId: 86263d76-5a98-4d96-f5c2-9146bcf1b6fd
+
 print(grad(f)(3.))
 ```
 
@@ -832,10 +802,9 @@ print(grad(f)(3.))
 Notice that `f_jvp` calls `f` to compute the primal outputs. In the context of higher-order differentiation, each application of a differentiation transform will use the custom JVP rule if and only if the rule calls the original `f` to compute the primal outputs. (This represents a kind of fundamental tradeoff, where we can't make use of intermediate values from the evaluation of `f` in our rule _and also_ have the rule apply in all orders of higher-order differentiation.)
 
 ```{code-cell} ipython3
----
-id: B6PLJooTQgVp
-outputId: 0d7ac628-656e-4b67-d285-f810155b6b9c
----
+:id: B6PLJooTQgVp
+:outputId: 0d7ac628-656e-4b67-d285-f810155b6b9c
+
 grad(grad(f))(3.)
 ```
 
@@ -865,10 +834,9 @@ def f_jvp(primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: QCHmJ56Na2G3
-outputId: 1772d3b4-44ef-4745-edd3-553c6312c553
----
+:id: QCHmJ56Na2G3
+:outputId: 1772d3b4-44ef-4745-edd3-553c6312c553
+
 print(grad(f)(1.))
 print(grad(f)(-1.))
 ```
@@ -902,10 +870,9 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: E8W-H2S0Ngdr
-outputId: cd0dc221-e779-436d-f3b4-21e799f40620
----
+:id: E8W-H2S0Ngdr
+:outputId: cd0dc221-e779-436d-f3b4-21e799f40620
+
 from jax import grad
 
 print(f(3.))
@@ -944,10 +911,9 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: EnRtIhhLnkry
-outputId: e03907ec-463a-4f3c-ae8e-feecb4394b2b
----
+:id: EnRtIhhLnkry
+:outputId: e03907ec-463a-4f3c-ae8e-feecb4394b2b
+
 print(grad(f)(2., 3.))
 ```
 
@@ -979,26 +945,23 @@ f.defvjp(f_fwd, f_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: r0aZ79OmOAR5
-outputId: 9cf16d9e-ca96-4987-e01a-dc0e22405576
----
+:id: r0aZ79OmOAR5
+:outputId: 9cf16d9e-ca96-4987-e01a-dc0e22405576
+
 print(f(3.))
 ```
 
 ```{code-cell} ipython3
----
-id: 7ToB9BYlm6uN
-outputId: aa9f3e3f-e6c3-4ee4-b87a-4526074f43aa
----
+:id: 7ToB9BYlm6uN
+:outputId: aa9f3e3f-e6c3-4ee4-b87a-4526074f43aa
+
 print(grad(f)(3.))
 ```
 
 ```{code-cell} ipython3
----
-id: s1Pn_qCIODcF
-outputId: 423d34e0-35b8-4b57-e89d-f70f20e28ea9
----
+:id: s1Pn_qCIODcF
+:outputId: 423d34e0-35b8-4b57-e89d-f70f20e28ea9
+
 from jax import vjp
 
 y, f_vjp = vjp(f, 3.)
@@ -1006,10 +969,9 @@ print(y)
 ```
 
 ```{code-cell} ipython3
----
-id: dvgQtDHaOHuo
-outputId: d92649c5-0aab-49a9-9158-f7ddc5fccb9b
----
+:id: dvgQtDHaOHuo
+:outputId: d92649c5-0aab-49a9-9158-f7ddc5fccb9b
+
 print(f_vjp(1.))
 ```
 
@@ -1018,10 +980,9 @@ print(f_vjp(1.))
 **Forward-mode autodiff cannot be used on the** `jax.custom_vjp` **function** and will raise an error:
 
 ```{code-cell} ipython3
----
-id: 3RGQRbI_OSEX
-outputId: 6385a024-7a10-445a-8380-b2eef722e597
----
+:id: 3RGQRbI_OSEX
+:outputId: 6385a024-7a10-445a-8380-b2eef722e597
+
 from jax import jvp
 
 try:
@@ -1119,20 +1080,18 @@ def fun(pt):
 ```
 
 ```{code-cell} ipython3
----
-id: My8pbOlPppJj
-outputId: 04cc1129-d0fb-4018-bec1-2ccf8b7906e3
----
+:id: My8pbOlPppJj
+:outputId: 04cc1129-d0fb-4018-bec1-2ccf8b7906e3
+
 pt = Point(1., 2.)
 
 print(f(pt))
 ```
 
 ```{code-cell} ipython3
----
-id: a9qyiCAhqLd3
-outputId: 08bd0615-7c35-44ff-f90b-c175618c2c40
----
+:id: a9qyiCAhqLd3
+:outputId: 08bd0615-7c35-44ff-f90b-c175618c2c40
+
 print(grad(fun)(pt))
 ```
 
@@ -1166,20 +1125,18 @@ def fun(pt):
 ```
 
 ```{code-cell} ipython3
----
-id: 3onW7t6nrJ4E
-outputId: ac455ab0-cac0-41fc-aea3-034931316053
----
+:id: 3onW7t6nrJ4E
+:outputId: ac455ab0-cac0-41fc-aea3-034931316053
+
 pt = Point(1., 2.)
 
 print(f(pt))
 ```
 
 ```{code-cell} ipython3
----
-id: ryyeKIXtrNpd
-outputId: 1780f738-ffd8-4ed7-ffbe-71d84bd62709
----
+:id: ryyeKIXtrNpd
+:outputId: 1780f738-ffd8-4ed7-ffbe-71d84bd62709
+
 print(grad(fun)(pt))
 ```
 
@@ -1214,18 +1171,16 @@ def app_jvp(f, primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: 5W-yEw9IB34S
-outputId: a2c1444a-9cc7-43ee-cb52-6c5d1cec02f1
----
+:id: 5W-yEw9IB34S
+:outputId: a2c1444a-9cc7-43ee-cb52-6c5d1cec02f1
+
 print(app(lambda x: x ** 3, 3.))
 ```
 
 ```{code-cell} ipython3
----
-id: zbVIlOmqB7_O
-outputId: a0174f54-89b0-4957-9362-c05af922f974
----
+:id: zbVIlOmqB7_O
+:outputId: a0174f54-89b0-4957-9362-c05af922f974
+
 print(grad(app, 1)(lambda x: x ** 3, 3.))
 ```
 
@@ -1248,18 +1203,16 @@ def app2_jvp(f, g, primals, tangents):
 ```
 
 ```{code-cell} ipython3
----
-id: J7GsvJTgCfS0
-outputId: 43dd6a02-2e4e-449e-924a-d1a03fe622fe
----
+:id: J7GsvJTgCfS0
+:outputId: 43dd6a02-2e4e-449e-924a-d1a03fe622fe
+
 print(app2(lambda x: x ** 3, 3., lambda y: 5 * y))
 ```
 
 ```{code-cell} ipython3
----
-id: kPP8Jt1CCb1X
-outputId: 6eff9aae-8d6e-4998-92ed-56272c32d6e8
----
+:id: kPP8Jt1CCb1X
+:outputId: 6eff9aae-8d6e-4998-92ed-56272c32d6e8
+
 print(grad(app2, 1)(lambda x: x ** 3, 3., lambda y: 5 * y))
 ```
 
@@ -1288,18 +1241,16 @@ app.defvjp(app_fwd, app_bwd)
 ```
 
 ```{code-cell} ipython3
----
-id: qSgcWa1eDj4r
-outputId: 43939686-f857-47ea-9f85-53f440ef12ee
----
+:id: qSgcWa1eDj4r
+:outputId: 43939686-f857-47ea-9f85-53f440ef12ee
+
 print(app(lambda x: x ** 2, 4.))
 ```
 
 ```{code-cell} ipython3
----
-id: tccagflcDmaz
-outputId: c75ca70b-2431-493b-e335-4f4d340902f1
----
+:id: tccagflcDmaz
+:outputId: c75ca70b-2431-493b-e335-4f4d340902f1
+
 print(grad(app, 1)(lambda x: x ** 2, 4.))
 ```
 

--- a/docs/notebooks/How_JAX_primitives_work.ipynb
+++ b/docs/notebooks/How_JAX_primitives_work.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# How JAX primitives work\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)\n",
     "\n",
     "*necula@google.com*, October 2019.\n",
     "\n",

--- a/docs/notebooks/How_JAX_primitives_work.md
+++ b/docs/notebooks/How_JAX_primitives_work.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # How JAX primitives work
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/How_JAX_primitives_work.ipynb)
 
 *necula@google.com*, October 2019.
 
@@ -60,10 +60,9 @@ functions that are themselves written using JAX primitives, e.g., those
 defined in the `jax.lax` module:
 
 ```{code-cell} ipython3
----
-id: tbOF0LB0EMne
-outputId: 3fb1c8a7-7a4c-4a3a-f7ff-37b7dc740528
----
+:id: tbOF0LB0EMne
+:outputId: 3fb1c8a7-7a4c-4a3a-f7ff-37b7dc740528
+
 from jax import lax
 from jax import api
 
@@ -167,10 +166,9 @@ Instead of using `jax.lax` primitives directly, we can use other functions
 that are already written in terms of those primitives, such as those in `jax.numpy`:
 
 ```{code-cell} ipython3
----
-id: QhKorz6cFRJb
-outputId: aba3cef3-6bcc-4eb3-c7b3-34e405f2f82a
----
+:id: QhKorz6cFRJb
+:outputId: aba3cef3-6bcc-4eb3-c7b3-34e405f2f82a
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -236,10 +234,9 @@ If we try to call the newly defined functions we get an error, because
 we have not yet told JAX anything about the semantics of the new primitive.
 
 ```{code-cell} ipython3
----
-id: _X3PAYxhGpWd
-outputId: 90ea2c6a-9ef3-40ea-e9a3-3ab1cfc59fc8
----
+:id: _X3PAYxhGpWd
+:outputId: 90ea2c6a-9ef3-40ea-e9a3-3ab1cfc59fc8
+
 with expectNotImplementedError():
   square_add_prim(2., 10.)
 ```
@@ -249,10 +246,9 @@ with expectNotImplementedError():
 ### Primal evaluation rules
 
 ```{code-cell} ipython3
----
-id: FT34FFAGHARU
-outputId: 4c54f1c2-8a50-4788-90e1-06aee412c43b
----
+:id: FT34FFAGHARU
+:outputId: 4c54f1c2-8a50-4788-90e1-06aee412c43b
+
 @trace("multiply_add_impl")
 def multiply_add_impl(x, y, z):
   """Concrete implementation of the primitive.
@@ -272,10 +268,9 @@ multiply_add_p.def_impl(multiply_add_impl)
 ```
 
 ```{code-cell} ipython3
----
-id: G5bstKaeNAVV
-outputId: deb94d5b-dfea-4e6f-9ec2-70b416c996c5
----
+:id: G5bstKaeNAVV
+:outputId: deb94d5b-dfea-4e6f-9ec2-70b416c996c5
+
 assert square_add_prim(2., 10.) == 14.
 ```
 
@@ -286,10 +281,9 @@ assert square_add_prim(2., 10.) == 14.
 If we now try to use `jit` we get a `NotImplementedError`:
 
 ```{code-cell} ipython3
----
-id: QG-LULjiHk4b
-outputId: d4ef4406-8dae-4c96-97ca-b662340474ee
----
+:id: QG-LULjiHk4b
+:outputId: d4ef4406-8dae-4c96-97ca-b662340474ee
+
 with expectNotImplementedError():
   api.jit(square_add_prim)(2., 10.)
 ```
@@ -311,10 +305,9 @@ For example, the abstraction of a vector with 3 elements may be `ShapedArray(flo
 In the latter case, JAX uses the actual concrete value wrapped as an abstract value.
 
 ```{code-cell} ipython3
----
-id: ctQmEeckIbdo
-outputId: e751d0cc-460e-4ffd-df2e-fdabf9cffdc2
----
+:id: ctQmEeckIbdo
+:outputId: e751d0cc-460e-4ffd-df2e-fdabf9cffdc2
+
 from jax import abstract_arrays
 @trace("multiply_add_abstract_eval")
 def multiply_add_abstract_eval(xs, ys, zs):
@@ -341,10 +334,9 @@ If we re-attempt to JIT, we see how the abstract evaluation proceeds, but
 we get another error, about missing the actual XLA compilation rule:
 
 ```{code-cell} ipython3
----
-id: eOcNR92SI2h-
-outputId: 356ef229-3703-4696-cc3d-7c05de405fb0
----
+:id: eOcNR92SI2h-
+:outputId: 356ef229-3703-4696-cc3d-7c05de405fb0
+
 with expectNotImplementedError():
   api.jit(square_add_prim)(2., 10.)
 ```
@@ -388,10 +380,9 @@ then compiles the set of primitives it has encountered, including `multiply_add`
 At this point JAX invokes `multiply_add_xla_translation`.
 
 ```{code-cell} ipython3
----
-id: rj3TLsolJgEc
-outputId: e384bee4-1e9c-4344-f49c-d3b5ec08eb32
----
+:id: rj3TLsolJgEc
+:outputId: e384bee4-1e9c-4344-f49c-d3b5ec08eb32
+
 assert api.jit(lambda x, y: square_add_prim(x, y))(2., 10.) == 14.
 ```
 
@@ -404,10 +395,9 @@ in the third argument to `multiply_add_abstract_eval` being
 both `ShapedArray` and `ConcreteArray`.
 
 ```{code-cell} ipython3
----
-id: mPfTwIBoKOEK
-outputId: b293b9b6-a2f9-48f5-f7eb-d4f99c3d905b
----
+:id: mPfTwIBoKOEK
+:outputId: b293b9b6-a2f9-48f5-f7eb-d4f99c3d905b
+
 assert api.jit(lambda x, y: square_add_prim(x, y), 
                static_argnums=1)(2., 10.) == 14.
 ```
@@ -424,10 +414,9 @@ error because we have not yet told JAX how to differentiate
 the `multiply_add` primitive.
 
 ```{code-cell} ipython3
----
-id: OxDx6NQnKwMI
-outputId: ce659ef3-c03c-4856-f252-49ec4b6eb964
----
+:id: OxDx6NQnKwMI
+:outputId: ce659ef3-c03c-4856-f252-49ec4b6eb964
+
 # The second argument `(2., 10.)` are the argument values
 # where we evaluate the Jacobian, and the third `(1., 1.)`
 # are the values of the tangents for the arguments.
@@ -486,10 +475,9 @@ ad.primitive_jvps[multiply_add_p] = multiply_add_value_and_jvp
 ```
 
 ```{code-cell} ipython3
----
-id: ma3KBkiAMfW1
-outputId: f34cbbc6-20d9-48ca-9a9a-b5d91a972cdd
----
+:id: ma3KBkiAMfW1
+:outputId: f34cbbc6-20d9-48ca-9a9a-b5d91a972cdd
+
 # Tangent is: xt*y + x*yt + zt = 1.*2. + 2.*1. + 1. = 5.
 assert api.jvp(square_add_prim, (2., 10.), (1., 1.)) == (14., 5.)
 ```
@@ -510,10 +498,9 @@ TO EXPLAIN:
 We can apply JIT to the forward differentiation function:
 
 ```{code-cell} ipython3
----
-id: hg-hzVu-N-hv
-outputId: 38d32067-e152-4046-ad80-7f95a31ba628
----
+:id: hg-hzVu-N-hv
+:outputId: 38d32067-e152-4046-ad80-7f95a31ba628
+
 assert api.jit(lambda arg_values, arg_tangents: 
                    api.jvp(square_add_prim, arg_values, arg_tangents))(
          (2., 10.), (1., 1.)) == (14., 5.)
@@ -550,10 +537,9 @@ value 0.0 as the tangent for the 3rd argument. This is due to the use
 of the `make_zero` function in the definition of `multiply_add_value_and_jvp`.
 
 ```{code-cell} ipython3
----
-id: 8eAVnexaOjBn
-outputId: e4ee89cf-ab4a-4505-9817-fa978a2865ab
----
+:id: 8eAVnexaOjBn
+:outputId: e4ee89cf-ab4a-4505-9817-fa978a2865ab
+
 # This is reverse differentiation w.r.t. the first argument of square_add_prim
 with expectNotImplementedError():
   api.grad(square_add_prim)(2., 10.)
@@ -676,10 +662,9 @@ ad.primitive_transposes[multiply_add_p] = multiply_add_transpose
 Now we can complete the run of the `grad`:
 
 ```{code-cell} ipython3
----
-id: PogPKS4MPevd
-outputId: d33328d4-3e87-45b5-9b31-21ad624b67af
----
+:id: PogPKS4MPevd
+:outputId: d33328d4-3e87-45b5-9b31-21ad624b67af
+
 assert api.grad(square_add_prim)(2., 10.) == 4.
 ```
 
@@ -697,10 +682,9 @@ Notice that the abstract evaluation of the `multiply_add_value_and_jvp` is using
 abstract values, while in the absensce of JIT we used `ConcreteArray`.
 
 ```{code-cell} ipython3
----
-id: FZ-JGbWZPq2-
-outputId: e42b5222-9c3e-4853-e13a-874f6605d178
----
+:id: FZ-JGbWZPq2-
+:outputId: e42b5222-9c3e-4853-e13a-874f6605d178
+
 assert api.jit(api.grad(square_add_prim))(2., 10.) == 4.
 ```
 
@@ -712,10 +696,9 @@ The batching transformation takes a point-wise computation and turns it
 into a computation on vectors. If we try it right now, we get a `NotImplementedError`:
 
 ```{code-cell} ipython3
----
-id: hFvBR3I9Pzh3
-outputId: 434608bc-281f-4d3b-83bd-eaaf3b51b1cd
----
+:id: hFvBR3I9Pzh3
+:outputId: 434608bc-281f-4d3b-83bd-eaaf3b51b1cd
+
 # The arguments are two vectors instead of two scalars
 with expectNotImplementedError():
   api.vmap(square_add_prim, in_axes=0, out_axes=0)(np.array([2., 3.]),
@@ -761,10 +744,9 @@ batching.primitive_batchers[multiply_add_p] = multiply_add_batch
 ```
 
 ```{code-cell} ipython3
----
-id: VwxNk869P_YG
-outputId: 9d22c921-5803-4d33-9e88-b6e439ba9738
----
+:id: VwxNk869P_YG
+:outputId: 9d22c921-5803-4d33-9e88-b6e439ba9738
+
 assert np.allclose(api.vmap(square_add_prim, in_axes=0, out_axes=0)(
   np.array([2., 3.]),
   np.array([10., 20.])),
@@ -776,10 +758,9 @@ assert np.allclose(api.vmap(square_add_prim, in_axes=0, out_axes=0)(
 #### JIT of batching
 
 ```{code-cell} ipython3
----
-id: xqEdXVUgQCTt
-outputId: 9c22fd9c-919c-491d-bbeb-32c241b808fa
----
+:id: xqEdXVUgQCTt
+:outputId: 9c22fd9c-919c-491d-bbeb-32c241b808fa
+
 assert np.allclose(api.jit(api.vmap(square_add_prim, in_axes=0, out_axes=0))
                     (np.array([2., 3.]),
                      np.array([10., 20.])),

--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Training a Simple Neural Network, with PyTorch Data Loading\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)\n",
     "\n",
     "**Copyright 2018 Google LLC.**\n",
     "\n",

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # Training a Simple Neural Network, with PyTorch Data Loading
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Neural_Network_and_Data_Loading.ipynb)
 
 **Copyright 2018 Google LLC.**
 
@@ -106,10 +106,9 @@ def predict(params, image):
 Let's check that our prediction function only works on single images.
 
 ```{code-cell} ipython3
----
-id: 4sW2A5mnXHc5
-outputId: 9d3b29e8-fab3-4ecb-9f63-bc8c092f9006
----
+:id: 4sW2A5mnXHc5
+:outputId: 9d3b29e8-fab3-4ecb-9f63-bc8c092f9006
+
 # This works on single examples
 random_flattened_image = random.normal(random.PRNGKey(1), (28 * 28,))
 preds = predict(params, random_flattened_image)
@@ -117,10 +116,9 @@ print(preds.shape)
 ```
 
 ```{code-cell} ipython3
----
-id: PpyQxuedXfhp
-outputId: d5d20211-b6da-44e9-f71e-946f2a9d0fc4
----
+:id: PpyQxuedXfhp
+:outputId: d5d20211-b6da-44e9-f71e-946f2a9d0fc4
+
 # Doesn't work with a batch
 random_flattened_images = random.normal(random.PRNGKey(1), (10, 28 * 28))
 try:
@@ -130,10 +128,9 @@ except TypeError:
 ```
 
 ```{code-cell} ipython3
----
-id: oJOOncKMXbwK
-outputId: 31285fab-7667-4871-fcba-28e86adc3fc6
----
+:id: oJOOncKMXbwK
+:outputId: 31285fab-7667-4871-fcba-28e86adc3fc6
+
 # Let's upgrade it to handle batches using `vmap`
 
 # Make a batched version of the `predict` function
@@ -182,10 +179,9 @@ def update(params, x, y):
 JAX is laser-focused on program transformations and accelerator-backed NumPy, so we don't include data loading or munging in the JAX library. There are already a lot of great data loaders out there, so let's just use them instead of reinventing anything. We'll grab PyTorch's data loader, and make a tiny shim to make it work with NumPy arrays.
 
 ```{code-cell} ipython3
----
-id: gEvWt8_u2pqG
-outputId: 2c83a679-9ce5-4c67-bccb-9ea835a8eaf6
----
+:id: gEvWt8_u2pqG
+:outputId: 2c83a679-9ce5-4c67-bccb-9ea835a8eaf6
+
 !pip install torch torchvision
 ```
 
@@ -238,10 +234,9 @@ training_generator = NumpyLoader(mnist_dataset, batch_size=batch_size, num_worke
 ```
 
 ```{code-cell} ipython3
----
-id: FTNo4beUvb6t
-outputId: 65a9087c-c326-49e5-cbfc-e0839212fa31
----
+:id: FTNo4beUvb6t
+:outputId: 65a9087c-c326-49e5-cbfc-e0839212fa31
+
 # Get the full train dataset (for checking accuracy while training)
 train_images = np.array(mnist_dataset.train_data).reshape(len(mnist_dataset.train_data), -1)
 train_labels = one_hot(np.array(mnist_dataset.train_labels), n_targets)
@@ -257,10 +252,9 @@ test_labels = one_hot(np.array(mnist_dataset_test.test_labels), n_targets)
 ## Training Loop
 
 ```{code-cell} ipython3
----
-id: X2DnZo3iYj18
-outputId: 0eba3ca2-24a1-4cba-aaf4-3ac61d0c650e
----
+:id: X2DnZo3iYj18
+:outputId: 0eba3ca2-24a1-4cba-aaf4-3ac61d0c650e
+
 import time
 
 for epoch in range(num_epochs):

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Writing custom Jaxpr interpreters in JAX\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)"
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)"
    ]
   },
   {

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.md
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # Writing custom Jaxpr interpreters in JAX
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/Writing_custom_interpreters_in_Jax.ipynb)
 
 +++ {"id": "r-3vMiKRYXPJ"}
 

--- a/docs/notebooks/XLA_in_Python.ipynb
+++ b/docs/notebooks/XLA_in_Python.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# XLA in Python\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)\n",
     "\n",
     "<img style=\"height:100px;\" src=\"https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/compiler/xla/g3doc/images/xlalogo.png\"> <img style=\"height:100px;\" src=\"https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg\">\n",
     "\n",

--- a/docs/notebooks/XLA_in_Python.md
+++ b/docs/notebooks/XLA_in_Python.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # XLA in Python
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/XLA_in_Python.ipynb)
 
 <img style="height:100px;" src="https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/compiler/xla/g3doc/images/xlalogo.png"> <img style="height:100px;" src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg">
 

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# The Autodiff Cookbook\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)\n",
     "\n",
     "*alexbw@, mattjj@*  \n",
     "\n",

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # The Autodiff Cookbook
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/autodiff_cookbook.ipynb)
 
 *alexbw@, mattjj@*  
 
@@ -43,10 +43,9 @@ key = random.PRNGKey(0)
 You can differentiate a function with `grad`:
 
 ```{code-cell} ipython3
----
-id: 0NLO4Wfknzmk
-outputId: ec6f5fe3-3d90-4ec9-a405-f3191b6099da
----
+:id: 0NLO4Wfknzmk
+:outputId: ec6f5fe3-3d90-4ec9-a405-f3191b6099da
+
 grad_tanh = grad(jnp.tanh)
 print(grad_tanh(2.0))
 ```
@@ -58,10 +57,9 @@ print(grad_tanh(2.0))
 Since `grad` operates on functions, you can apply it to its own output to differentiate as many times as you like:
 
 ```{code-cell} ipython3
----
-id: RDGk1GDsoawu
-outputId: 157bab60-52a8-4ca9-a298-b57561b30032
----
+:id: RDGk1GDsoawu
+:outputId: 157bab60-52a8-4ca9-a298-b57561b30032
+
 print(grad(grad(jnp.tanh))(2.0))
 print(grad(grad(grad(jnp.tanh)))(2.0))
 ```
@@ -104,10 +102,9 @@ b = random.normal(b_key, ())
 Use the `grad` function with its `argnums` argument to differentiate a function with respect to positional arguments.
 
 ```{code-cell} ipython3
----
-id: bpmd8W8-6vu6
-outputId: 5faafcc6-e9c5-4a2d-fc35-5c23e0be2d6d
----
+:id: bpmd8W8-6vu6
+:outputId: 5faafcc6-e9c5-4a2d-fc35-5c23e0be2d6d
+
 # Differentiate `loss` with respect to the first positional argument:
 W_grad = grad(loss, argnums=0)(W, b)
 print('W_grad', W_grad)
@@ -141,10 +138,9 @@ Essentially, when using the `argnums` argument, if `f` is a Python function for 
 Differentiating with respect to standard Python containers just works, so use tuples, lists, and dicts (and arbitrary nesting) however you like.
 
 ```{code-cell} ipython3
----
-id: IY82kdAe6vu_
-outputId: d4004d2d-97ed-4ddc-bb1d-fc4af21edd23
----
+:id: IY82kdAe6vu_
+:outputId: d4004d2d-97ed-4ddc-bb1d-fc4af21edd23
+
 def loss2(params_dict):
     preds = predict(params_dict['W'], params_dict['b'], inputs)
     label_probs = preds * targets + (1 - preds) * (1 - targets)
@@ -166,10 +162,9 @@ You can [register your own container types](https://github.com/google/jax/issues
 Another convenient function is `value_and_grad` for efficiently computing both a function's value as well as its gradient's value:
 
 ```{code-cell} ipython3
----
-id: RsQSyT5p7OJW
-outputId: c2502c2e-091e-4e9c-ca20-1e0c2670fd7a
----
+:id: RsQSyT5p7OJW
+:outputId: c2502c2e-091e-4e9c-ca20-1e0c2670fd7a
+
 from jax import value_and_grad
 loss_value, Wb_grad = value_and_grad(loss, (0, 1))(W, b)
 print('loss value', loss_value)
@@ -183,10 +178,9 @@ print('loss value', loss(W, b))
 A great thing about derivatives is that they're straightforward to check with finite differences:
 
 ```{code-cell} ipython3
----
-id: R8q5RiY3l7Fw
-outputId: 4f2ccbe9-da9f-438e-9f3e-ad03e3c3e247
----
+:id: R8q5RiY3l7Fw
+:outputId: 4f2ccbe9-da9f-438e-9f3e-ad03e3c3e247
+
 # Set a step size for finite differences calculations
 eps = 1e-4
 
@@ -261,10 +255,9 @@ We'll check this implementation a few cells down, once we see how to compute den
 You can compute full Jacobian matrices using the `jacfwd` and `jacrev` functions:
 
 ```{code-cell} ipython3
----
-id: cbETzAvKvf5I
-outputId: 7c8d2361-cc68-4139-9f1f-afa2431b3cd2
----
+:id: cbETzAvKvf5I
+:outputId: 7c8d2361-cc68-4139-9f1f-afa2431b3cd2
+
 from jax import jacfwd, jacrev
 
 # Isolate the function from the weight matrix to the predictions
@@ -288,10 +281,9 @@ These two functions compute the same values (up to machine numerics), but differ
 You can also use `jacfwd` and `jacrev` with container types:
 
 ```{code-cell} ipython3
----
-id: eH46Xnm88bfm
-outputId: ab1f5dce-926e-40b9-9664-5bd5e628e0b5
----
+:id: eH46Xnm88bfm
+:outputId: ab1f5dce-926e-40b9-9664-5bd5e628e0b5
+
 def predict_dict(params, inputs):
     return predict(params['W'], params['b'], inputs)
 
@@ -310,10 +302,9 @@ For more details on forward- and reverse-mode, as well as how to implement `jacf
 Using a composition of two of these functions gives us a way to compute dense Hessian matrices:
 
 ```{code-cell} ipython3
----
-id: n155ypD9rfIZ
-outputId: 69622bc4-9a8d-47f1-aab6-40ab21d450d9
----
+:id: n155ypD9rfIZ
+:outputId: 69622bc4-9a8d-47f1-aab6-40ab21d450d9
+
 def hessian(f):
     return jacfwd(jacrev(f))
 
@@ -532,10 +523,9 @@ Even better, since we didn't have to call `jnp.dot` directly, this `hvp` functio
 Here's an example of how to use it:
 
 ```{code-cell} ipython3
----
-id: bmpuQa5_f1Al
-outputId: 20ef2514-0ab7-4071-c2f4-77b59b013ffc
----
+:id: bmpuQa5_f1Al
+:outputId: 20ef2514-0ab7-4071-c2f4-77b59b013ffc
+
 def f(X):
   return jnp.sum(jnp.tanh(X)**2)
 
@@ -567,10 +557,9 @@ def hvp_revfwd(f, primals, tangents):
 That's not quite as good, though, because forward-mode has less overhead than reverse-mode, and since the outer differentiation operator here has to differentiate a larger computation than the inner one, keeping forward-mode on the outside works best:
 
 ```{code-cell} ipython3
----
-id: lxfv25qTX5gZ
-outputId: b88dae03-7bd1-4836-f994-880c57bc4714
----
+:id: lxfv25qTX5gZ
+:outputId: b88dae03-7bd1-4836-f994-880c57bc4714
+
 # reverse-over-reverse, only works for single arguments
 def hvp_revrev(f, primals, tangents):
   x, = primals
@@ -600,10 +589,9 @@ print("Naive full Hessian materialization")
 Now that we have `jvp` and `vjp` transformations that give us functions to push-forward or pull-back single vectors at a time, we can use JAX's `vmap` [transformation](https://github.com/google/jax#auto-vectorization-with-vmap) to push and pull entire bases at once. In particular, we can use that to write fast matrix-Jacobian and Jacobian-matrix products.
 
 ```{code-cell} ipython3
----
-id: asAWvxVaCmsx
-outputId: 05d3b5f9-f526-42a4-ea2b-6163b267db26
----
+:id: asAWvxVaCmsx
+:outputId: 05d3b5f9-f526-42a4-ea2b-6163b267db26
+
 # Isolate the function from the weight matrix to the predictions
 f = lambda W: predict(W, b, inputs)
 
@@ -636,10 +624,9 @@ assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Matrix-Jacobian Pro
 ```
 
 ```{code-cell} ipython3
----
-id: TDaxsJrlDraK
-outputId: 99a7591c-643d-4b91-c0fc-c7a3c73b0de6
----
+:id: TDaxsJrlDraK
+:outputId: 99a7591c-643d-4b91-c0fc-c7a3c73b0de6
+
 def loop_jmp(f, W, M):
     # jvp immediately returns the primal and tangent values as a tuple,
     # so we'll compute and select the tangents in a list comprehension
@@ -665,7 +652,6 @@ assert jnp.allclose(loop_vs, vmap_vs), 'Vmap and non-vmapped Jacobian-Matrix pro
 +++ {"id": "MXFEFBDz6vvL"}
 
 ### The implementation of `jacfwd` and `jacrev`
-
 
 +++ {"id": "ZAgUb6sp8bf7"}
 
@@ -713,10 +699,9 @@ Interestingly, [Autograd](https://github.com/hips/autograd) couldn't do this. Ou
 Another thing that Autograd couldn't do is `jit`. Interestingly, no matter how much Python dynamism you use in your function to be differentiated, we could always use `jit` on the linear part of the computation. For example:
 
 ```{code-cell} ipython3
----
-id: _5jDflC08bgB
-outputId: 7d37cca8-3954-40b9-bea8-937ac655387c
----
+:id: _5jDflC08bgB
+:outputId: 7d37cca8-3954-40b9-bea8-937ac655387c
+
 def f(x):
     try:
         if x < 3:
@@ -815,10 +800,9 @@ def check(seed):
 ```
 
 ```{code-cell} ipython3
----
-id: I2OBU3OGp-CY
-outputId: 28ae844b-0c25-4255-ca9b-598b0dbeb404
----
+:id: I2OBU3OGp-CY
+:outputId: 28ae844b-0c25-4255-ca9b-598b0dbeb404
+
 check(0)
 check(1)
 check(2)
@@ -894,10 +878,9 @@ What about convenience wrappers like `grad`, `jacfwd`, and `jacrev`?
 For $\mathbb{R} \to \mathbb{R}$ functions, recall we defined `grad(f)(x)` as being `vjp(f, x)[1](1.0)`, which works because applying a VJP to a `1.0` value reveals the gradient (i.e. Jacobian, or derivative). We can do the same thing for $\mathbb{C} \to \mathbb{R}$ functions: we can still use `1.0` as the cotangent vector, and we just get out a complex number result summarizing the full Jacobian:
 
 ```{code-cell} ipython3
----
-id: xz_9lK61wGdm
-outputId: 96693583-2a36-48fd-d811-cd1a0f1a50c5
----
+:id: xz_9lK61wGdm
+:outputId: 96693583-2a36-48fd-d811-cd1a0f1a50c5
+
 def f(z):
   x, y = jnp.real(z), jnp.imag(z)
   return x**2 + y**2
@@ -913,10 +896,9 @@ For geneneral $\mathbb{C} \to \mathbb{C}$ functions, the Jacobian has 4 real-val
 Because this only works for holomorphic functions, to use this trick we need to promise JAX that our function is holomorphic; otherwise, JAX will raise an error when `grad` is used for a complex-output function:
 
 ```{code-cell} ipython3
----
-id: Y3n9hPVrwvXx
-outputId: 20f72dfe-7083-47f8-b086-4a16426ba97b
----
+:id: Y3n9hPVrwvXx
+:outputId: 20f72dfe-7083-47f8-b086-4a16426ba97b
+
 def f(z):
   return jnp.sin(z)
 
@@ -929,10 +911,9 @@ grad(f, holomorphic=True)(z)
 All the `holomorphic=True` promise does is disable the error when the output is complex-valued. We can still write `holomorphic=True` when the function isn't holomorphic, but the answer we get out won't represent the full Jacobian. Instead, it'll be the Jacobian of the function where we just discard the imaginary part of the output:
 
 ```{code-cell} ipython3
----
-id: th9xhwp2xaeU
-outputId: 2dfebe3a-bbfe-46a1-b282-f5d59d53c772
----
+:id: th9xhwp2xaeU
+:outputId: 2dfebe3a-bbfe-46a1-b282-f5d59d53c772
+
 def f(z):
   return jnp.conjugate(z)
 
@@ -955,10 +936,9 @@ In any case, JVPs and VJPs are always unambiguous. And if we wanted to compute t
 You should expect complex numbers to work everywhere in JAX. Here's differentiating through a Cholesky decomposition of a complex matrix:
 
 ```{code-cell} ipython3
----
-id: WrDHHfKI8bgM
-outputId: c04baa8a-2408-4a76-e3dc-4522782d1bc5
----
+:id: WrDHHfKI8bgM
+:outputId: c04baa8a-2408-4a76-e3dc-4522782d1bc5
+
 A = jnp.array([[5.,    2.+3j,    5j],
               [2.-3j,   7.,  1.+7j],
               [-5j,  1.-7j,    12.]])

--- a/docs/notebooks/maml.ipynb
+++ b/docs/notebooks/maml.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# MAML Tutorial with JAX\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)\n",
     "\n",
     "Eric Jang\n",
     "\n",

--- a/docs/notebooks/maml.md
+++ b/docs/notebooks/maml.md
@@ -11,11 +11,11 @@ kernelspec:
   name: python3
 ---
 
-+++ {"id": "oDP4nK_Zgyg-", "colab_type": "text"}
++++ {"colab_type": "text", "id": "oDP4nK_Zgyg-"}
 
 # MAML Tutorial with JAX
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/maml.ipynb)
 
 Eric Jang
 
@@ -44,17 +44,16 @@ import jax.numpy as jnp
 from jax import grad
 ```
 
-+++ {"id": "gMgclHhxgyhI", "colab_type": "text"}
++++ {"colab_type": "text", "id": "gMgclHhxgyhI"}
 
 ## Gradients of Gradients
 
 JAX makes it easy to compute gradients of python functions. Here, we thrice-differentiate $e^x$ and $x^2$
 
 ```{code-cell} ipython3
----
-id: Mt-uRwBGgyhJ
-outputId: db7f718c-c2fb-4f7e-f31c-39a0d36c7051
----
+:id: Mt-uRwBGgyhJ
+:outputId: db7f718c-c2fb-4f7e-f31c-39a0d36c7051
+
 f = lambda x : jnp.exp(x)
 g = lambda x : jnp.square(x)
 print(grad(f)(1.)) # = e^{1}
@@ -66,7 +65,7 @@ print(grad(grad(g))(2.)) # x = 2
 print(grad(grad(grad(g)))(2.)) # x = 0
 ```
 
-+++ {"id": "7mAd3We_gyhP", "colab_type": "text"}
++++ {"colab_type": "text", "id": "7mAd3We_gyhP"}
 
 ## Sinusoid Regression and vmap
 
@@ -109,10 +108,9 @@ def loss(params, inputs, targets):
 ```
 
 ```{code-cell} ipython3
----
-id: sROmpDEmgyhb
-outputId: d1bf00d7-99e7-445e-b439-ea2fabd7a646
----
+:id: sROmpDEmgyhb
+:outputId: d1bf00d7-99e7-445e-b439-ea2fabd7a646
+
 # batch the inference across K=100
 xrange_inputs = jnp.linspace(-5,5,100).reshape((100, 1)) # (k, 1)
 targets = jnp.sin(xrange_inputs)
@@ -151,10 +149,9 @@ net_params = get_params(opt_state)
 ```
 
 ```{code-cell} ipython3
----
-id: Rm9WIz2egyho
-outputId: 183de82d-fdf0-4b81-9b14-01a85e6b8839
----
+:id: Rm9WIz2egyho
+:outputId: 183de82d-fdf0-4b81-9b14-01a85e6b8839
+
 # batch the inference across K=100
 targets = jnp.sin(xrange_inputs)
 predictions = vmap(partial(net_apply, net_params))(xrange_inputs)
@@ -165,7 +162,7 @@ plt.plot(xrange_inputs, targets, label='target')
 plt.legend()
 ```
 
-+++ {"id": "7E8gAJBzgyhs", "colab_type": "text"}
++++ {"colab_type": "text", "id": "7E8gAJBzgyhs"}
 
 ## MAML: Optimizing for Generalization
 
@@ -178,10 +175,9 @@ $x_1, y_2$ and $x_2, y_2$ are identically distributed from $X, Y$. Therefore, MA
 The following toy example checks MAML numerics via parameter $x$ and input $y$.
 
 ```{code-cell} ipython3
----
-id: 2YBFsM2dgyht
-outputId: 46160194-04b7-46c9-897d-ecb11e9738be
----
+:id: 2YBFsM2dgyht
+:outputId: 46160194-04b7-46c9-897d-ecb11e9738be
+
 # gradients of gradients test for MAML
 # check numerics
 g = lambda x, y : jnp.square(x) + y
@@ -195,7 +191,7 @@ print('maml_objective(x,y)={}'.format(maml_objective(x0, y0))) # x**2 + 1 = 5
 print('x0 - maml_objective(x,y) = {}'.format(x0 - grad(maml_objective)(x0, y0))) # x - (2x)
 ```
 
-+++ {"id": "V9G-PMxygyhx", "colab_type": "text"}
++++ {"colab_type": "text", "id": "V9G-PMxygyhx"}
 
 ## Sinusoid Task + MAML
 
@@ -217,10 +213,9 @@ def maml_loss(p, x1, y1, x2, y2):
 ```
 
 ```{code-cell} ipython3
----
-id: bQvg749Xgyh2
-outputId: 5043f859-c537-41b8-c390-23670795d57b
----
+:id: bQvg749Xgyh2
+:outputId: 5043f859-c537-41b8-c390-23670795d57b
+
 x1 = xrange_inputs
 y1 = targets
 x2 = jnp.array([0.])
@@ -228,15 +223,14 @@ y2 = jnp.array([0.])
 maml_loss(net_params, x1, y1, x2, y2)
 ```
 
-+++ {"id": "zMB6BwPogyh6", "colab_type": "text"}
++++ {"colab_type": "text", "id": "zMB6BwPogyh6"}
 
 Let's try minimizing the MAML loss (without batching across multiple tasks, which we will do in the next section)
 
 ```{code-cell} ipython3
----
-id: pB5ldBO-gyh7
-outputId: b2365aa4-d7b8-40a0-d759-8257d3e4d768
----
+:id: pB5ldBO-gyh7
+:outputId: b2365aa4-d7b8-40a0-d759-8257d3e4d768
+
 opt_init, opt_update, get_params = optimizers.adam(step_size=1e-3)  # this LR seems to be better than 1e-2 and 1e-4
 out_shape, net_params = net_init(rng, in_shape)
 opt_state = opt_init(net_params)
@@ -270,10 +264,9 @@ net_params = get_params(opt_state)
 ```
 
 ```{code-cell} ipython3
----
-id: ogcpFdJ9gyh_
-outputId: 856924a3-ede5-44ba-ba3c-381673713fad
----
+:id: ogcpFdJ9gyh_
+:outputId: 856924a3-ede5-44ba-ba3c-381673713fad
+
 # batch the inference across K=100
 targets = jnp.sin(xrange_inputs)
 predictions = vmap(partial(net_apply, net_params))(xrange_inputs)
@@ -290,7 +283,7 @@ for i in range(1,5):
 plt.legend()
 ```
 
-+++ {"id": "7TMYcZKVgyiD", "colab_type": "text"}
++++ {"colab_type": "text", "id": "7TMYcZKVgyiD"}
 
 ## Batching Meta-Gradient Across Tasks
 
@@ -324,10 +317,9 @@ def sample_tasks(outer_batch_size, inner_batch_size):
 ```
 
 ```{code-cell} ipython3
----
-id: 7dCIGObKgyiJ
-outputId: c169b529-0f16-4f20-d20e-d802765e4068
----
+:id: 7dCIGObKgyiJ
+:outputId: c169b529-0f16-4f20-d20e-d802765e4068
+
 outer_batch_size = 2
 x1, y1, x2, y2 = sample_tasks(outer_batch_size, 50)
 for i in range(outer_batch_size):
@@ -338,18 +330,16 @@ plt.legend()
 ```
 
 ```{code-cell} ipython3
----
-id: BrSX--wpgyiP
-outputId: 6d81e7ff-7cd9-4aef-c665-952d442369d5
----
+:id: BrSX--wpgyiP
+:outputId: 6d81e7ff-7cd9-4aef-c665-952d442369d5
+
 x2.shape
 ```
 
 ```{code-cell} ipython3
----
-id: P3WQ8_k2gyiU
-outputId: fed1b78b-7910-4e44-a80b-18f447379022
----
+:id: P3WQ8_k2gyiU
+:outputId: fed1b78b-7910-4e44-a80b-18f447379022
+
 opt_init, opt_update, get_params = optimizers.adam(step_size=1e-3)
 out_shape, net_params = net_init(rng, in_shape)
 opt_state = opt_init(net_params)
@@ -379,10 +369,9 @@ net_params = get_params(opt_state)
 ```
 
 ```{code-cell} ipython3
----
-id: PmxHLrhYgyiX
-outputId: 33ac699e-c66d-46e2-affa-98ae948d52e8
----
+:id: PmxHLrhYgyiX
+:outputId: 33ac699e-c66d-46e2-affa-98ae948d52e8
+
 # batch the inference across K=100
 targets = jnp.sin(xrange_inputs)
 predictions = vmap(partial(net_apply, net_params))(xrange_inputs)
@@ -400,10 +389,9 @@ plt.legend()
 ```
 
 ```{code-cell} ipython3
----
-id: cQf2BeDjgyib
-outputId: fc52caf6-1379-4d60-fe44-99f4e4518698
----
+:id: cQf2BeDjgyib
+:outputId: fc52caf6-1379-4d60-fe44-99f4e4518698
+
 # Comparison of maml_loss for task batch size = 1 vs. task batch size = 8
 plt.plot(np.convolve(np_maml_loss, [.05]*20), label='task_batch=1')
 plt.plot(np.convolve(np_batched_maml_loss, [.05]*20), label='task_batch=4')

--- a/docs/notebooks/neural_network_with_tfds_data.ipynb
+++ b/docs/notebooks/neural_network_with_tfds_data.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "# Training a Simple Neural Network, with tensorflow/datasets Data Loading\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)\n",
     "\n",
     "_Forked from_ `neural_network_and_data_loading.ipynb`\n",
     "\n",

--- a/docs/notebooks/neural_network_with_tfds_data.md
+++ b/docs/notebooks/neural_network_with_tfds_data.md
@@ -36,7 +36,7 @@ limitations under the License.
 
 # Training a Simple Neural Network, with tensorflow/datasets Data Loading
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/neural_network_with_tfds_data.ipynb)
 
 _Forked from_ `neural_network_and_data_loading.ipynb`
 

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# JAX Quickstart\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb)\n",
     "\n",
     "**JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance machine learning research.**\n",
     "\n",

--- a/docs/notebooks/quickstart.md
+++ b/docs/notebooks/quickstart.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # JAX Quickstart
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/quickstart.ipynb)
 
 **JAX is NumPy on the CPU, GPU, and TPU, with great automatic differentiation for high-performance machine learning research.**
 

--- a/docs/notebooks/score_matching.ipynb
+++ b/docs/notebooks/score_matching.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Generative Modeling by Estimating Gradients of Data Distribution in JAX\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)\n",
     "\n",
     "In this notebook we'll implement __Generative Modeling by Estimating Gradients of the Data Distribution__ [[arxiv]](https://arxiv.org/abs/1907.05600).\n",
     "\n",

--- a/docs/notebooks/score_matching.md
+++ b/docs/notebooks/score_matching.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # Generative Modeling by Estimating Gradients of Data Distribution in JAX
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/score_matching.ipynb)
 
 In this notebook we'll implement __Generative Modeling by Estimating Gradients of the Data Distribution__ [[arxiv]](https://arxiv.org/abs/1907.05600).
 
@@ -29,10 +29,9 @@ Let's begin with a simple task: learn to sample from a peculiar probability dist
 well... minus the chocolate. Sorry for that.
 
 ```{code-cell} ipython3
----
-id: 0P1xCZPNG6TE
-outputId: 69be38a1-1f02-462e-f4f1-16a41c35fddf
----
+:id: 0P1xCZPNG6TE
+:outputId: 69be38a1-1f02-462e-f4f1-16a41c35fddf
+
 import matplotlib.pyplot as plt
 %matplotlib inline
 import numpy as np
@@ -106,10 +105,9 @@ def train_step(step_i, opt_state, batch):
     loss = compute_loss(net_params, batch)
     grads = jax.grad(compute_loss, argnums=0)(net_params, batch)
     return loss, opt_update(step_i, grads, opt_state)
-
 ```
 
-+++ {"id": "LkTYRi6qCwn8", "colab_type": "text"}
++++ {"colab_type": "text", "id": "LkTYRi6qCwn8"}
 
 __Note__: we use `jax.jacfwd` since the input dimension is only 2
 
@@ -129,10 +127,9 @@ loss_history = []
 ```
 
 ```{code-cell} ipython3
----
-id: evDOnCHiG6TN
-outputId: 989db5fe-24a2-41ba-fb01-6d981df7cd06
----
+:id: evDOnCHiG6TN
+:outputId: 989db5fe-24a2-41ba-fb01-6d981df7cd06
+
 for i in range(2000):
     x = sample_batch(size=128)
     loss, opt_state = train_step(i, opt_state, x)
@@ -165,10 +162,9 @@ for i in range(2000):
 Once the model is trained we can use it to predict scores at each point. Since those are gradient vectors, we'll use [`Quiver Plot`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.quiver.html) to draw them.
 
 ```{code-cell} ipython3
----
-id: x6SkLg0VG6TQ
-outputId: 710ab2f4-c3c7-4a3b-f929-e84957fbb233
----
+:id: x6SkLg0VG6TQ
+:outputId: 710ab2f4-c3c7-4a3b-f929-e84957fbb233
+
 plt.figure(figsize=[16, 16])
 
 net_params = get_params(opt_state)
@@ -221,10 +217,9 @@ def sample_langevin(x_initial, *, net_params, key, eps=1e-2, eps_decay=0.9, num_
 ```
 
 ```{code-cell} ipython3
----
-id: n6ZWX9Z1G6TV
-outputId: 4e061bf6-93c5-4d96-cc9b-7e2d8b8899af
----
+:id: n6ZWX9Z1G6TV
+:outputId: 4e061bf6-93c5-4d96-cc9b-7e2d8b8899af
+
 plt.figure(figsize=[16, 16])
 
 key = jax.random.PRNGKey(42)
@@ -289,7 +284,7 @@ def train_step(step_i, opt_state, batch, key):
     return loss, opt_update(step_i, grads, opt_state)
 ```
 
-+++ {"id": "GWaKgphWCwoi", "colab_type": "text"}
++++ {"colab_type": "text", "id": "GWaKgphWCwoi"}
 
 __Note:__ we compute Jacobian with `jax.jacfwd` (forward-mode differentiation) because the input dimension of the network is just 2. You can read more about autograd modes in jax [documentation](https://jax.readthedocs.io/en/latest/jax.html?highlight=jacfwd#jax.jacfwd) and on wikipedia [wiki](https://en.wikipedia.org/wiki/Automatic_differentiation)
 
@@ -305,10 +300,9 @@ loss_history = []
 ```
 
 ```{code-cell} ipython3
----
-id: hQyo8kvTG6Tc
-outputId: 184f28fc-4c6d-418a-9c28-e248b8633fbe
----
+:id: hQyo8kvTG6Tc
+:outputId: 184f28fc-4c6d-418a-9c28-e248b8633fbe
+
 for i in range(2_000):
     x = sample_batch(size=128)
     
@@ -343,10 +337,9 @@ for i in range(2_000):
 MNIST 8x8, computing full jacobian would require 64 passes through the network
 
 ```{code-cell} ipython3
----
-id: Y2ZgeMq-G6Tf
-outputId: 435e69a1-3544-4364-b30c-c066feda7064
----
+:id: Y2ZgeMq-G6Tf
+:outputId: 435e69a1-3544-4364-b30c-c066feda7064
+
 from sklearn.datasets import load_digits
 import numpy as np
 
@@ -384,10 +377,9 @@ loss_history = []
 ```
 
 ```{code-cell} ipython3
----
-id: YxWvSQJAG6Ti
-outputId: ae47197d-0aa3-496c-83f6-d10328461a00
----
+:id: YxWvSQJAG6Ti
+:outputId: ae47197d-0aa3-496c-83f6-d10328461a00
+
 for i in range(5_000):
     x = sample_batch(size=128)
     key, subkey = jax.random.split(key)
@@ -402,10 +394,9 @@ for i in range(5_000):
 ```
 
 ```{code-cell} ipython3
----
-id: gof2XcxwG6Tk
-outputId: 02472a07-4931-4444-d406-344907619a01
----
+:id: gof2XcxwG6Tk
+:outputId: 02472a07-4931-4444-d406-344907619a01
+
 key, subkey = jax.random.split(key)
 x = 0.1 * jax.random.uniform(subkey, shape=(64,))
 

--- a/docs/notebooks/thinking_in_jax.ipynb
+++ b/docs/notebooks/thinking_in_jax.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "# How to Think in JAX\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/thinking_in_jax.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/thinking_in_jax.ipynb)\n",
     "\n",
     "JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively."
    ]

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -33,7 +33,7 @@ ipython.showtraceback = minimal_traceback
 
 # How to Think in JAX
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/thinking_in_jax.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/thinking_in_jax.ipynb)
 
 JAX provides a simple and powerful API for writing accelerated numerical code, but working effectively in JAX sometimes requires extra consideration. This document is meant to help build a ground-up understanding of how JAX operates, so that you can use it more effectively.
 

--- a/docs/notebooks/vmapped_log_probs.ipynb
+++ b/docs/notebooks/vmapped_log_probs.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# Autobatching log-densities example\n",
     "\n",
-    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)\n",
     "\n",
     "This notebook demonstrates a simple Bayesian inference example where autobatching makes user code easier to write, easier to read, and less likely to include bugs.\n",
     "\n",

--- a/docs/notebooks/vmapped_log_probs.md
+++ b/docs/notebooks/vmapped_log_probs.md
@@ -16,7 +16,7 @@ kernelspec:
 
 # Autobatching log-densities example
 
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/jax/blob/master/docs/notebooks/vmapped_log_probs.ipynb)
 
 This notebook demonstrates a simple Bayesian inference example where autobatching makes user code easier to write, easier to read, and less likely to include bugs.
 
@@ -62,10 +62,9 @@ y = (np.random.rand(num_points) < sp.special.expit(all_x.dot(true_beta))).astype
 ```
 
 ```{code-cell} ipython3
----
-id: O0nVumAw7IlT
-outputId: 751a3290-a81b-4538-9183-16cd685fbaf9
----
+:id: O0nVumAw7IlT
+:outputId: 751a3290-a81b-4538-9183-16cd685fbaf9
+
 y
 ```
 
@@ -91,18 +90,16 @@ def log_joint(beta):
 ```
 
 ```{code-cell} ipython3
----
-id: e51qW0ro6J7C
-outputId: 2ec6bbbd-12ee-45bc-af76-5111c53e4d5a
----
+:id: e51qW0ro6J7C
+:outputId: 2ec6bbbd-12ee-45bc-af76-5111c53e4d5a
+
 log_joint(np.random.randn(num_features))
 ```
 
 ```{code-cell} ipython3
----
-id: fglQXK1Y6wnm
-outputId: 2b934336-08ad-4776-9a58-aa575bf601eb
----
+:id: fglQXK1Y6wnm
+:outputId: 2b934336-08ad-4776-9a58-aa575bf601eb
+
 # This doesn't work, because we didn't write `log_prob()` to handle batching.
 try:
   batch_size = 10
@@ -136,10 +133,9 @@ def batched_log_joint(beta):
 ```
 
 ```{code-cell} ipython3
----
-id: KdDMr-Gy85CO
-outputId: db746654-68e9-43b8-ce3b-6e5682e22eb5
----
+:id: KdDMr-Gy85CO
+:outputId: db746654-68e9-43b8-ce3b-6e5682e22eb5
+
 batch_size = 10
 batched_test_beta = np.random.randn(batch_size, num_features)
 
@@ -153,10 +149,9 @@ batched_log_joint(batched_test_beta)
 It just works.
 
 ```{code-cell} ipython3
----
-id: SU20bouH8-Za
-outputId: ee450298-982f-4b9a-bed9-a6f9b8f63d92
----
+:id: SU20bouH8-Za
+:outputId: ee450298-982f-4b9a-bed9-a6f9b8f63d92
+
 vmap_batched_log_joint = jax.vmap(log_joint)
 vmap_batched_log_joint(batched_test_beta)
 ```
@@ -205,10 +200,9 @@ elbo_val_and_grad = jax.jit(jax.value_and_grad(elbo, argnums=(0, 1)))
 ### Optimize the ELBO using SGD
 
 ```{code-cell} ipython3
----
-id: 9JrD5nNgH715
-outputId: 80bf62d8-821a-45c4-885c-528b2e449e97
----
+:id: 9JrD5nNgH715
+:outputId: 80bf62d8-821a-45c4-885c-528b2e449e97
+
 def normal_sample(key, shape):
     """Convenience function for quasi-stateful RNG."""
     new_key, sub_key = random.split(key)
@@ -241,10 +235,9 @@ for i in range(1000):
 Coverage isn't quite as good as we might like, but it's not bad, and nobody said variational inference was exact.
 
 ```{code-cell} ipython3
----
-id: zt1NBLoVHtOG
-outputId: fb159795-e6e7-497c-e501-9933ec761af4
----
+:id: zt1NBLoVHtOG
+:outputId: fb159795-e6e7-497c-e501-9933ec761af4
+
 figure(figsize=(7, 7))
 plot(true_beta, beta_loc, '.', label='Approximated Posterior Means')
 plot(true_beta, beta_loc + 2*jnp.exp(beta_log_scale), 'r.', label='Approximated Posterior $2\sigma$ Error Bars')


### PR DESCRIPTION
`colab.sandbox.google.com` redirects to `colab.research.google.com`, but shouldn't be used directly.