### PR TITLE
Decouple ShardedDeviceArray from _DeviceArray

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5350,7 +5350,7 @@ setattr(ShapedArray, "nbytes", core.aval_property(_nbytes))
 
 # Forward operators, methods, and properties on DeviceArray to lax_numpy
 # functions (with no Tracers involved; this forwarding is direct)
-for device_array in [_DeviceArray, _CppDeviceArray]:
+for device_array in [DeviceArray]:
   for operator_name, function in _operators.items():
     setattr(device_array, "__{}__".format(operator_name), function)
   for method_name in _nondiff_methods + _diff_methods:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1172,7 +1172,7 @@ class _DeviceArray(DeviceArray):  # type: ignore
 
 # Adding methods dynamically to both _DeviceArray and _CppDeviceArray
 # pylint: disable=protected-access
-for device_array in [_DeviceArray, _CppDeviceArray]:
+for device_array in [DeviceArray]:
 
 
   def copy(self):


### PR DESCRIPTION
Make `ShardedDeviceArray` inherit directly from `DeviceArray` instead of `_DeviceArray` in order to allow a c++ version of `ShardedDeviceArray`.