### PR TITLE
[test - do not review] move the x64 context manager threadlocal state from jax/python…

### DIFF
--- a/jax/config.py
+++ b/jax/config.py
@@ -16,6 +16,7 @@ import os
 import sys
 import threading
 from typing import Optional
+from jax import lib
 
 def bool_env(varname: str, default: bool) -> bool:
   """Read an environment variable and interpret it as a boolean.
@@ -49,6 +50,7 @@ class _ThreadLocalState(threading.local):
 
 
 class Config:
+  # TODO(jakevdp): Remove when minimum jaxlib is has extension version 4
   _thread_local_state = _ThreadLocalState()
 
   def __init__(self):
@@ -149,13 +151,23 @@ class Config:
 
   @property
   def x64_enabled(self):
-    if self._thread_local_state.enable_x64 is None:
-      self._thread_local_state.enable_x64 = bool(self.read('jax_enable_x64'))
-    return self._thread_local_state.enable_x64
+   if lib._xla_extension_version >= 4:
+     if lib.jax_jit.get_enable_x64() is None:
+       lib.jax_jit.set_enable_x64(bool(self.read('jax_enable_x64')))
+     return lib.jax_jit.get_enable_x64()
+   else:
+     # TODO(jakevdp): Remove when minimum jaxlib is has extension version 4
+     if self._thread_local_state.enable_x64 is None:
+       self._thread_local_state.enable_x64 = bool(self.read('jax_enable_x64'))
+     return self._thread_local_state.enable_x64
 
   # TODO(jakevdp): make this public when thread-local x64 is fully implemented.
   def _set_x64_enabled(self, state):
-    self._thread_local_state.enable_x64 = bool(state)
+    if lib._xla_extension_version >= 4:
+      lib.jax_jit.set_enable_x64(bool(state))
+    else:
+      # TODO(jakevdp): Remove when minimum jaxlib is has extension version 4
+      self._thread_local_state.enable_x64 = bool(state)
 
 
 class NameSpace(object):

--- a/jax/experimental/x64_context.py
+++ b/jax/experimental/x64_context.py
@@ -18,7 +18,7 @@
 """
 
 from contextlib import contextmanager
-from jax.config import config
+from jax import config
 
 @contextmanager
 def enable_x64():


### PR DESCRIPTION
… to xla/c++

This just exists to benefit from the Github tests and see what happens.