### PR TITLE
randint: support generating the full range of dtype

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -330,6 +330,47 @@ def _promote_args_inexact(fun_name, *args):
   _check_no_float0s(fun_name, *args)
   return _promote_shapes(fun_name, *_promote_dtypes_inexact(*args))
 
+def _convert_and_clip_integer(val, dtype):
+  """
+  Convert integer-typed val to specified integer dtype, clipping to dtype
+  range rather than wrapping.
+
+  Args:
+    val: value to be converted
+    dtype: dtype of output
+
+  Returns:
+    equivalent of val in new dtype
+
+  Examples
+  --------
+  Normal integer type conversion will wrap:
+
+  >>> val = jnp.uint32(0xFFFFFFFF)
+  >>> val.astype('int32')
+  DeviceArray(-1, dtype=int32)
+
+  This function clips to the values representable in the new type:
+
+  >>> _convert_and_clip_integer(val, 'int32')
+  DeviceArray(2147483647, dtype=int32)
+  """
+  val = val if isinstance(val, ndarray) else asarray(val)
+  dtype = dtypes.canonicalize_dtype(dtype)
+  if not (issubdtype(dtype, integer) and issubdtype(val.dtype, integer)):
+    raise TypeError("_convert_and_clip_integer only accepts integer dtypes.")
+
+  val_dtype = dtypes.canonicalize_dtype(val.dtype)
+  if val_dtype != val.dtype:
+    # TODO(jakevdp): this is a weird corner case; need to figure out how to handle it.
+    # This happens in X32 mode and can either come from a jax value created in another
+    # context, or a Python integer converted to int64.
+    pass
+  min_val = _constant_like(val, _max(iinfo(dtype).min, iinfo(val_dtype).min))
+  max_val = _constant_like(val, _min(iinfo(dtype).max, iinfo(val_dtype).max))
+  return clip(val, min_val, max_val).astype(dtype)
+
+
 def _constant_like(x, const):
   return np.array(const, dtype=_dtype(x))
 


### PR DESCRIPTION
Fixes #5785

Currently `random.randint` converts `minval` and `maxval` to the speficied dtype, which means that trying something like this will lead to unexpected results:
```python
>>> from jax import random
>>> random.randint(random.PRNGKey(0), (10,), 0, 256, 'uint8')
DeviceArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=uint8)
```
~This was partially remedied in #6293 (the maxval is now clipped to 255 rather than being wrapped to 0), but there is still no way to generate the full range of integers for a given type.~ *Edit: this had to be rolled back, and the changes from #6293 are now part of this PR as well.*

The boundary causes other problems as well, even if values are not out of range:
```python
>>> random.randint(random.PRNGKey(0), (10,), 255, 255, 'uint8')
DeviceArray([111, 139,  85, 222,   6, 223, 108,  27,  20, 191], dtype=uint8)
```
Numpy gets around this by doing arithmetic using Python ints where such values are needed; this is not an option in JIT-compatible JAX code.

This PR addresses the issue for dtypes smaller than the largest dtype (i.e. [u]int32 or smaller in X64 mode, [u]int16 in X32 mode) by doing the relevant operations in the larger dtypes. This also fixes and adds tests for other boundary problems along the way.

With this PR, we see the expected results:
```python
>>> from jax import random

>>> random.randint(random.PRNGKey(0), (10,), 0, 256, 'uint8')
DeviceArray([112, 140,  86, 223,   7, 224, 109,  28,  21, 192], dtype=uint8)

>>> random.randint(random.PRNGKey(0), (10,), 255, 255, 'uint8')
DeviceArray([255, 255, 255, 255, 255, 255, 255, 255, 255, 255], dtype=uint8)
```