### PR TITLE
[jax2tf] Fix conversion for integer division for TF 1

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -956,8 +956,9 @@ tf_impl[lax.iota_p] = _iota
 def _div(lhs, rhs):
   if lhs.dtype.is_integer:
     quotient = tf.math.floordiv(lhs, rhs)
-    select = tf.math.logical_and(tf.math.sign(lhs) != tf.math.sign(rhs),
-                                 tf.math.floormod(lhs, rhs) != 0)
+    select = tf.math.logical_and(
+        tf.not_equal(tf.math.sign(lhs), tf.math.sign(rhs)),
+        tf.not_equal(tf.math.floormod(lhs, rhs), 0))
     return tf.where(select, quotient + 1, quotient)
   else:
     return tf.math.truediv(lhs, rhs)

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -65,9 +65,11 @@ from jax import lax
 from jax import numpy as jnp
 from jax import test_util as jtu
 from jax.config import config
+from jax.experimental import jax2tf
 from jax.interpreters import xla
 
 import numpy as np
+import tensorflow as tf
 
 config.parse_flags_with_absl()
 
@@ -241,6 +243,16 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
         x = np.array([1, 2], dtype=x_dtype)
         y = np.array([3, 4], dtype=y_dtype)
         self.ConvertAndCompare(f_jax, x, y)
+
+  def test_integer_div(self):
+    x = jnp.array([-4, -3, -1, 0, 1, 3, 6])
+    y = np.int32(3)
+    self.ConvertAndCompare(jnp.floor_divide, x, y)
+    expected = jnp.floor_divide(x, y)
+    # Try it with TF 1 as well (#5831)
+    with tf.compat.v1.Session() as sess:
+      tf1_res = sess.run(jax2tf.convert(jnp.floor_divide)(x, y))
+      self.assertAllClose(expected, tf1_res)
 
   def test_disable_xla(self):
 


### PR DESCRIPTION
Bug: #5831
It seems that TF 1 has a different broadcasting behavior than TF2. Change
the conversion of integer division to use `tf.not_equal` instead of `!=`.