### PR TITLE
Some minor typing fixes

### DIFF
--- a/jax/ad_util.py
+++ b/jax/ad_util.py
@@ -17,7 +17,7 @@ from jax import core
 from .core import (lattice_join, Primitive, Unit, unit, AbstractUnit,
                    valid_jaxtype, raise_to_shaped, get_aval)
 from .tree_util import register_pytree_node
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Type
 from ._src.util import safe_map
 
 from ._src import traceback_util
@@ -27,7 +27,7 @@ Array = Any
 
 map = safe_map
 
-jaxval_adders = {}
+jaxval_adders: Dict[type, Callable] = {}
 jaxval_adders[Unit] = lambda _, __: unit
 
 def add_jaxvals(x, y):
@@ -36,7 +36,7 @@ def add_jaxvals(x, y):
   else:
     return add_jaxvals_p.bind(x, y)
 
-add_jaxvals_p = Primitive('add_any')
+add_jaxvals_p: Primitive = Primitive('add_any')
 add_any_p = add_jaxvals_p
 
 @add_jaxvals_p.def_impl
@@ -58,7 +58,7 @@ aval_zeros_likers[AbstractUnit] = lambda _: unit
 def zeros_like_jaxval(val):
   return zeros_like_p.bind(val)
 
-zeros_like_p = Primitive('zeros_like')
+zeros_like_p: Primitive = Primitive('zeros_like')
 
 @zeros_like_p.def_impl
 def zeros_like_impl(example):
@@ -85,6 +85,6 @@ def _stop_gradient_impl(x):
                     f"input argument is: {x}")
   return x
 
-stop_gradient_p = Primitive('stop_gradient')
+stop_gradient_p : Primitive = Primitive('stop_gradient')
 stop_gradient_p.def_impl(_stop_gradient_impl)
 stop_gradient_p.def_abstract_eval(lambda x: x)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -40,8 +40,8 @@ flags.DEFINE_bool('jax_enable_x64',
                   'Enable 64-bit types to be used.')
 
 # bfloat16 support
-bfloat16 = xla_client.bfloat16
-_bfloat16_dtype = np.dtype(bfloat16)
+bfloat16: type = xla_client.bfloat16
+_bfloat16_dtype: np.dtype = np.dtype(bfloat16)
 
 # Default types.
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -870,7 +870,7 @@ def _execute_trivial(jaxpr, device: Optional[Device], consts, avals, handlers, *
   return [_copy_device_array_to_device(x, device) if type_is_device_array(x)
           else h(*device_put(x, device)) for h, x in zip(handlers, outs)]
 
-xla_call_p = core.CallPrimitive('xla_call')
+xla_call_p: core.CallPrimitive = core.CallPrimitive('xla_call')
 xla_call = xla_call_p.bind
 xla_call_p.def_impl(_xla_call_impl)
 


### PR DESCRIPTION
For reasons I don't entirely understand, the introduction of the new `jax/_src/errors.py` file in #5888 led to mypy flagging some issues in existing files. This commit fixes the errors (submitted as a separate PR because it's an orthogonal change).

I will wait until this is merged and then rebase #5888.