### PR TITLE
Use None as a trivial lazy expression, rather than lazy.array().

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -114,8 +114,7 @@ def aval_to_result_handler(device: Optional[Device], aval: core.AbstractValue) -
 def array_result_handler(device: Optional[Device], aval: core.ShapedArray):
   if aval.dtype is dtypes.float0:
     return lambda _: np.zeros(aval.shape, dtypes.float0)
-  return partial(make_device_array, raise_to_shaped(aval), device,
-                 lazy.array(aval.shape))
+  return partial(make_device_array, raise_to_shaped(aval), device, None)
 
 
 xla_result_handlers: Dict[Type[core.AbstractValue], Callable[..., Callable]] = {
@@ -1349,7 +1348,7 @@ def _force(x: DeviceArrayProtocol) -> DeviceArrayProtocol:
       device = x.device_buffer.device()
     force_fun = _lazy_force_computation(x.aval, device, x._lazy_expr)
     result = force_fun(x)
-    return make_device_array(x.aval, x._device, lazy.array(x.aval.shape), result)
+    return make_device_array(x.aval, x._device, None, result)
 
 @cache()
 def _lazy_force_computation(aval: core.ShapedArray,


### PR DESCRIPTION
Improves a 1000-argument version of the jit_simple_many_args by around 20%.

It is faster for C++ to pattern-match a None than to pattern-match a complicated Python data structure. And we know that `None` should be handled correctly, because the C++ buffer object reports `None` as its lazy expression already.

```
Before:
name                       cpu/op
jit_simple_many_args_1000  3.12ms ± 3%

After:
name                       cpu/op
jit_simple_many_args_1000  2.60ms ± 5%
```