### PR TITLE
Fix docstrings for jnp ufunc wrappers

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -101,8 +101,13 @@ def _wraps(fun, update_doc=True, lax_description=""):
           f"*Original docstring below.*\n\n"
           f"{body}")
 
-      op.__name__ = fun.__name__
-      op.__qualname__ = fun.__qualname__
+      for attr in ['__name__', '__qualname__']:
+        try:
+          value = getattr(fun, attr)
+        except AttributeError:
+          pass
+        else:
+          setattr(op, attr, value)
       op.__doc__ = docstr
       op.__np_wrapped__ = fun
     finally:

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -35,7 +35,7 @@ from jax._src.numpy.lax_numpy import (
     empty_like, equal, euler_gamma, exp, exp2, expand_dims, expm1, extract, eye,
     fabs, finfo, fix, flatnonzero, flexible, flip, fliplr, flipud, float16, float32,
     float64, float_, float_power, floating, floor, floor_divide, fmax, fmin,
-    fmod, frexp, full, full_like, function, gcd, geomspace, gradient, greater,
+    fmod, frexp, full, full_like, gcd, geomspace, gradient, greater,
     greater_equal, hamming, hanning, heaviside, histogram, histogram_bin_edges, histogram2d, histogramdd,
     hsplit, hstack, hypot, i0, identity, iinfo, imag,
     indices, inexact, in1d, inf, inner, int16, int32, int64, int8, int_, integer, 


### PR DESCRIPTION
Fixes breakage caused by #5748

numpy ufuncs have no `__qualname__`, so docstrings of `jax.numpy` wrappers were not getting properly applied, because the `AttributeError` was happening in a catch-all try/except block.

After this change, `jnp.sin` has a docstring again 😬 

Also added a test to catch these kinds of issues. It failed on `jnp.function` which should not ever have been exported, as it's a local variable that leaked out of a loop scope: https://github.com/google/jax/blob/02cf04b60b615e882e7c0c14e22ff4a3e1a1718c/jax/_src/numpy/lax_numpy.py#L5336-L5337