### PR TITLE
Revive all to all

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1698,7 +1698,8 @@ def check_map(prim, in_avals, params):
   mapped_avals = [mapped_aval(axis_size, in_axis, aval)
                   if in_axis is not None else aval
                   for aval, in_axis in zip(in_avals, in_axes)]
-  _check_jaxpr(call_jaxpr, mapped_avals)
+  with extend_axis_env(params['axis_name'], axis_size, None):
+    _check_jaxpr(call_jaxpr, mapped_avals)
 
   mapped_out_avals = [v.aval for v in call_jaxpr.outvars]
   out_avals = [unmapped_aval(axis_size, out_axis, aval) if out_axis is not None else aval

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1100,25 +1100,25 @@ class DynamicJaxprTrace(core.Trace):
     with core.extend_axis_env(axis_name, axis_size, None):  # type: ignore
       jaxpr, reduced_out_avals, consts = trace_to_subjaxpr_dynamic(
           f, self.main, reduced_in_avals)
-    out_axes = params['out_axes_thunk']()
-    out_avals = [core.unmapped_aval(params['axis_size'], out_axis, a)
-                 if out_axis is not None else a
-                 for a, out_axis in zip(reduced_out_avals, out_axes)]
-    source_info = source_info_util.current()
-    out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
-    invars = map(self.getvar, tracers)
-    constvars = map(self.getvar, map(self.instantiate_const, consts))
-    outvars = map(self.makevar, out_tracers)
-    new_in_axes = (None,) * len(consts) + params['in_axes']
-    new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
-                      call_jaxpr=convert_constvars_jaxpr(jaxpr))
-    del new_params['out_axes_thunk']
-    update_params = call_param_updaters.get(map_primitive)
-    if update_params:
-      new_params = update_params(new_params, [True] * len(tracers))
-    eqn = new_jaxpr_eqn([*constvars, *invars], outvars, map_primitive,
-                        new_params, source_info)
-    self.frame.eqns.append(eqn)
+      out_axes = params['out_axes_thunk']()
+      out_avals = [core.unmapped_aval(params['axis_size'], out_axis, a)
+                  if out_axis is not None else a
+                  for a, out_axis in zip(reduced_out_avals, out_axes)]
+      source_info = source_info_util.current()
+      out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
+      invars = map(self.getvar, tracers)
+      constvars = map(self.getvar, map(self.instantiate_const, consts))
+      outvars = map(self.makevar, out_tracers)
+      new_in_axes = (None,) * len(consts) + params['in_axes']
+      new_params = dict(params, in_axes=new_in_axes, out_axes=out_axes,
+                        call_jaxpr=convert_constvars_jaxpr(jaxpr))
+      del new_params['out_axes_thunk']
+      update_params = call_param_updaters.get(map_primitive)
+      if update_params:
+        new_params = update_params(new_params, [True] * len(tracers))
+      eqn = new_jaxpr_eqn([*constvars, *invars], outvars, map_primitive,
+                          new_params, source_info)
+      self.frame.eqns.append(eqn)
     return out_tracers
 
   def post_process_map(self, map_primitive, out_tracers, params):

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -15,13 +15,12 @@
 
 import itertools as it
 import numpy as np
-from unittest import skipIf, SkipTest
+from unittest import skipIf
 from absl.testing import absltest
 from absl.testing import parameterized
 
 import jax
 import jax.numpy as jnp
-from jax.interpreters import batching
 from jax import test_util as jtu
 from jax import lax
 from jax._src.lax import parallel
@@ -1032,7 +1031,6 @@ class BatchingTest(jtu.JaxTestCase):
   @skipIf(not jax.config.omnistaging_enabled,
           "vmap collectives only supported when omnistaging is enabled")
   def testAllToAllSplitAxis(self, vmap_axis, split_axis, concat_axis):
-    raise SkipTest("all_to_all split axis broken after #4835")  # TODO(mattjj,apaszke)
     shape = (4, 4, 4)
     x = np.arange(np.prod(shape)).reshape(shape)
 

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -618,6 +618,7 @@ class PmapTest(jtu.JaxTestCase):
 
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_slow_all_to_all_warning()
   def testGradOfGather(self):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")
@@ -1146,6 +1147,7 @@ class PmapTest(jtu.JaxTestCase):
     self.assertAllClose(expected_bz1, bz1, check_dtypes=False)
     self.assertAllClose(bz2, bz2, check_dtypes=False)
 
+  @ignore_slow_all_to_all_warning()
   def testPswapaxes(self):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")
@@ -1157,6 +1159,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.swapaxes(x, 0, 2)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_slow_all_to_all_warning()
   def testGradOfPswapaxes(self):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -215,6 +215,7 @@ class PmapTest(jtu.JaxTestCase):
       {"testcase_name": f"_split={split_axis}_concat={concat_axis}",
       "split_axis": split_axis, "concat_axis": concat_axis}
       for split_axis, concat_axis in it.product(range(2), range(2)))
+  @ignore_slow_all_to_all_warning()
   def testAllToAll(self, split_axis, concat_axis):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")
@@ -237,6 +238,7 @@ class PmapTest(jtu.JaxTestCase):
       {"testcase_name": f"_split={split_axis}_concat={concat_axis}",
        "split_axis": split_axis, "concat_axis": concat_axis}
       for split_axis, concat_axis in it.product(range(2), range(2)))
+  @ignore_slow_all_to_all_warning()
   def testAllToAllSplitAxis(self, split_axis, concat_axis):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")
@@ -1172,6 +1174,7 @@ class PmapTest(jtu.JaxTestCase):
     expected = np.tile(w, reps=device_count).reshape(shape)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_slow_all_to_all_warning()
   def testAllToAllReplicaGroups(self):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")
@@ -1202,6 +1205,7 @@ class PmapTest(jtu.JaxTestCase):
         1, 2).reshape(shape)
     self.assertAllClose(fn(x), expected, check_dtypes=False)
 
+  @ignore_slow_all_to_all_warning()
   def testGradOfAllToAllReplicaGroups(self):
     if not config.omnistaging_enabled:
       self.skipTest("all_to_all doesn't work without omnistaging")


### PR DESCRIPTION
#### Make all_to_all primitive match XLA semantics

This has the benefit of limiting the insane axis arithmetic (with some
axes getting removed, and others introduced with their positions offset
by the removals) to the all_to_all user-facing function, but all the
collective rules should now be simpler to write. This should be a no-op
from the point of view of the users, but should make enabling all_to_all
splitting easier.

#### Reenable multi-axis all_to_all
