### PR TITLE
Raise OverflowError in X32 mode for large Python integers

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2873,7 +2873,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   dtype = dtype and dtypes.canonicalize_dtype(dtype)
 
   if _can_call_numpy_array(object):
-    object = _np_array(object, dtype=dtype, ndmin=ndmin, copy=False)
+    object = dtypes.coerce_to_array(object, dtype=dtype, ndmin=ndmin, copy=False)
 
   assert type(object) not in dtypes.python_scalar_dtypes
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -160,8 +160,12 @@ def _canonicalize_ndarray_dtype(x):
   return np.asarray(x, dtypes.canonicalize_dtype(dtypes.result_type(x)))
 
 def _canonicalize_python_scalar_dtype(typ, x):
-  return np.asarray(
-      x, dtypes.canonicalize_dtype(dtypes.python_scalar_dtypes[typ]))
+  dtype = dtypes.canonicalize_dtype(dtypes.python_scalar_dtypes[typ])
+  if np.issubdtype(dtype, np.integer):
+    info = np.iinfo(dtype)
+    if not info.min <= x <= info.max:
+      raise OverflowError(f"Python int {x} too large to convert to {dtype}")
+  return np.asarray(x, dtype=dtype)
 
 canonicalize_dtype_handlers: Dict[Any, Callable] = {core.Unit: identity}
 canonicalize_dtype_handlers.update(

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -71,6 +71,25 @@ def identity(x):
 
 class DtypesTest(jtu.JaxTestCase):
 
+  def test_array_overflow(self):
+    dtype = dtypes.canonicalize_dtype(int)
+
+    underflow = jnp.iinfo(dtype).min - 1
+    with self.assertRaises(OverflowError):
+      jnp.array(underflow)
+    with self.assertRaises(OverflowError):
+      jax.jit(lambda x: x)(underflow)
+    if not config.x64_enabled:
+      self.assertEqual(jnp.array(underflow, dtype=dtype), np.array(underflow))
+
+    overflow = jnp.iinfo(dtype).max + 1
+    with self.assertRaises(OverflowError):
+      jnp.array(overflow)
+    with self.assertRaises(OverflowError):
+      jax.jit(lambda x: x)(overflow)
+    if not config.x64_enabled:
+      self.assertEqual(jnp.array(overflow, dtype=dtype), np.array(overflow))
+
   def test_canonicalize_type(self):
     expected = {
         True: _EXPECTED_CANONICALIZE_X64,

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -26,6 +26,7 @@ import scipy.stats
 
 from jax import api
 from jax import core
+from jax import dtypes
 from jax import grad
 from jax import lax
 from jax import numpy as jnp
@@ -930,12 +931,8 @@ class LaxRandomTest(jtu.JaxTestCase):
       {"seed": -2, "type": np.int32, "jit": False, "key": [0, 4294967294]},
       {"seed": -3, "type": np.int64, "jit": True, "key": [4294967295, 4294967293] if config.x64_enabled else [0, 4294967293]},
       {"seed": -3, "type": np.int64, "jit": False, "key": [4294967295, 4294967293] if config.x64_enabled else [0, 4294967293]},
-      {"seed": np.iinfo(np.int32).max + 100, "type": int, "jit": True, "key": [0, 2147483747]},
-      {"seed": np.iinfo(np.int32).max + 100, "type": int, "jit": False, "key": [0, 2147483747]},
       {"seed": np.iinfo(np.int32).max + 101, "type": np.uint32, "jit": True, "key": [0, 2147483748]},
       {"seed": np.iinfo(np.int32).max + 101, "type": np.uint32, "jit": False, "key": [0, 2147483748]},
-      {"seed": np.iinfo(np.int32).min - 100, "type": int, "jit": True, "key": [4294967295, 2147483548] if config.x64_enabled else [0, 2147483548]},
-      {"seed": np.iinfo(np.int32).min - 100, "type": int, "jit": False, "key": [4294967295, 2147483548] if config.x64_enabled else [0, 2147483548]},
       {"seed": np.iinfo(np.int32).min - 101, "type": np.int64, "jit": True, "key": [4294967295, 2147483547] if config.x64_enabled else [0, 2147483547]},
       {"seed": np.iinfo(np.int32).min - 101, "type": np.int64, "jit": False, "key": [4294967295, 2147483547] if config.x64_enabled else [0, 2147483547]},
     ]
@@ -954,7 +951,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       for type in ["int", "np.array", "jnp.array"]
       for seed in [-1, 0, 1, (1 << 32) - 1, (1 << 63) - 1, np.uint64((1 << 64) - 1)]))
   def test_prng_jit_invariance(self, seed, type):
-    if type == "int" and seed == (1 << 64) - 1:
+    if type != "np.array" and seed > jnp.iinfo(dtypes.canonicalize_dtype(int)).max:
       self.skipTest("Expected failure: Python int too large.")
     type = {"int": int, "np.array": np.array, "jnp.array": jnp.array}[type]
     args_maker = lambda: [type(seed)]


### PR DESCRIPTION
Python integers are arbitrary width, meaning that they can represent values that are not representable by numpy's `int64`. In these cases, numpy raises an overflow error. For example:
```python
>>> import numpy as np
>>> np.array(1 << 65, dtype=int)
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-36-bc194570c3ad> in <module>
----> 1 np.array(1 << 65, dtype=int)

OverflowError: Python int too large to convert to C long
```
In X64 mode, JAX inherits this property via numpy:
```python
>>> import jax.numpy as jnp
>>> from jax import config; config.update('jax_enable_x64', True)
>>> np.array(1 << 65, dtype=int)
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-3-e4d8a251ed7e> in <module>
----> 1 jnp.array(1 << 65, dtype=int)

~/github/google/jax/jax/_src/numpy/lax_numpy.py in array(object, dtype, copy, order, ndmin)
   2874 
   2875   if _can_call_numpy_array(object):
-> 2876     object = _np_array(object, dtype=dtype, ndmin=ndmin, copy=False)
   2877 
   2878   assert type(object) not in dtypes.python_scalar_dtypes

~/github/google/jax/jax/_src/numpy/lax_numpy.py in _np_array(obj, dtype, **kwargs)
    228   uses Jax's default dtypes.
    229   """
--> 230   arr = np.array(obj, dtype=dtype, **kwargs)
    231   obj_dtype = getattr(obj, 'dtype', None)
    232   arr_dtype = np.dtype(arr.dtype).type

OverflowError: Python int too large to convert to C long
```
With X64 disabled, however, values that are too large to be stored in `int32` are silently truncated to zero:
```python
>>> import jax.numpy as jnp
>>> jnp.array(1 << 33)
DeviceArray(0, dtype=int32)
```
Such silent data loss is problematic, particularly because X32 is the default mode.

This PR adds a value check when Python integers are coerced to arrays, so that an `OverflowError` is raised as appropriate for the default integer type:
```python
>>> import jax.numpy as jnp
>>> jnp.array(1 << 33)
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
<ipython-input-2-50cb794a933c> in <module>
----> 1 jnp.array(1 << 33)

~/github/google/jax/jax/_src/numpy/lax_numpy.py in array(object, dtype, copy, order, ndmin)
   2872 
   2873   if _can_call_numpy_array(object):
-> 2874     object = dtypes.coerce_to_array(object, dtype=dtype, ndmin=ndmin, copy=False)
   2875 
   2876   assert type(object) not in dtypes.python_scalar_dtypes

~/github/google/jax/jax/dtypes.py in coerce_to_array(x, dtype, ndmin, copy)
    125     info = np.iinfo(dtype)
    126     if not info.min <= x <= info.max:
--> 127       raise OverflowError(f"Python int {x} too large to convert to {dtype}")
    128   return np.array(x, dtype=dtype, ndmin=ndmin, copy=copy)
    129 

OverflowError: Python int 8589934592 too large to convert to int32
```
This also required a minor change to `random.PRNGseed` as well, as the previous behavior was built on the assumption that out-of-bounds inputs were truncated rather than leading to an error.