### PR TITLE
Cleanups for laziness. No functional changes intended.

### DIFF
--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -14,7 +14,6 @@
 
 from jax import core
 from jax import numpy as jnp
-from jax import lazy
 from jax.interpreters import xla
 from jax.lib import xla_client
 from jax.lib import xla_bridge
@@ -62,4 +61,4 @@ def from_dlpack(dlpack, backend=None):
   xla_shape = buf.xla_shape()
   assert not xla_shape.is_tuple()
   aval = core.ShapedArray(xla_shape.dimensions(), xla_shape.numpy_dtype())
-  return xla.make_device_array(aval, buf.device(), lazy.array(aval.shape), buf)  # pytype: disable=attribute-error
+  return xla.make_device_array(aval, buf.device(), None, buf)  # pytype: disable=attribute-error

--- a/jax/api.py
+++ b/jax/api.py
@@ -333,7 +333,7 @@ def _cpp_jit(
       for result_handler in result_handlers:
         aval, sticky_device, lazy_expr = result_handler.args
         avals.append(aval)
-        lazy_exprs.append(None if xla.lazy.is_trivial(lazy_expr) else lazy_expr)
+        lazy_exprs.append(lazy_expr)
       assert len(avals) == len(out_flat)
       fastpath_data = (xla_executable, out_pytree_def, sticky_device, avals, lazy_exprs)
     else:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -44,7 +44,6 @@ import numpy as np
 from ..config import flags, config
 from .. import core
 from .. import linear_util as lu
-from .. import lazy
 from ..abstract_arrays import array_types
 from ..core import ConcreteArray, ShapedArray
 from .._src.util import (partial, unzip2, unzip3, prod, safe_map, safe_zip,
@@ -563,7 +562,7 @@ class ShardedDeviceArray(xla.DeviceArray):  # type: ignore
       if buf_idx is not None:
         buf = self.device_buffers[buf_idx]
         aval = ShapedArray(buf.xla_shape().dimensions(), self.aval.dtype)
-        return xla.make_device_array(aval, None, lazy.array(aval.shape), buf)
+        return xla.make_device_array(aval, None, None, buf)
     return xla.DeviceArray.__getitem__(self, idx)
 
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1323,15 +1323,14 @@ def _copy_device_array_to_device(x: Union[DeviceArrayProtocol, _DeviceArray], de
 def _force(x: DeviceArrayProtocol) -> DeviceArrayProtocol:
   if lazy.is_trivial(x._lazy_expr):
     return x
+  # force x on the device where it lives, but preserve stickiness on result
+  if x._device:
+    device = x._device
   else:
-    # force x on the device where it lives, but preserve stickiness on result
-    if x._device:
-      device = x._device
-    else:
-      device = x.device_buffer.device()
-    force_fun = _lazy_force_computation(x.aval, device, x._lazy_expr)
-    result = force_fun(x)
-    return make_device_array(x.aval, x._device, None, result)
+    device = x.device_buffer.device()
+  force_fun = _lazy_force_computation(x.aval, device, x._lazy_expr)
+  result = force_fun(x)
+  return make_device_array(x.aval, x._device, None, result)
 
 @cache()
 def _lazy_force_computation(aval: core.ShapedArray,

--- a/tests/custom_object_test.py
+++ b/tests/custom_object_test.py
@@ -101,8 +101,8 @@ class ConcreteSparseArray(AbstractSparseArray):
 
 def sparse_array_result_handler(device, aval):
   def build_sparse_array(data_buf, indices_buf):
-    data = xla.make_device_array(aval.data_aval, device, lazy.array(aval.data_aval.shape), data_buf)
-    indices = xla.make_device_array(aval.indices_aval, device, lazy.array(aval.indices_aval.shape), indices_buf)
+    data = xla.make_device_array(aval.data_aval, device, None, data_buf)
+    indices = xla.make_device_array(aval.indices_aval, device, None, indices_buf)
     return SparseArray(aval, data, indices)
   return build_sparse_array
 


### PR DESCRIPTION
Use None as a trivial lazy expression in more places. Simplify some code.