### PR TITLE
Substitute axis names in nested jaxprs

### DIFF
--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -437,6 +437,12 @@ class XMapTest(XMapTestCase):
     self.assertNotDeleted(y)
     self.assertDeleted(x)
 
+  @ignore_xmap_warning()
+  def testControlFlow(self):
+    x = jnp.arange(5)
+    xmap(lambda x: lax.fori_loop(0, 10, lambda _, x: lax.psum(x, 'i'), x),
+         in_axes=['i', ...], out_axes=['i', ...])(x)
+
   @with_and_without_mesh
   @ignore_xmap_warning()
   def testAxisSizes(self, mesh, axis_resources):


### PR DESCRIPTION
Previously any collectives buried inside control flow would fail to
compile with xmap, because it would not traverse those with its name
substitution. This adds a "catch-all" default substitution rule which
recursively applies to all jaxpr found in the params (at the top level).