### PR TITLE
dtypes.result_type: ignore weak_type for single argument

### DIFF
--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -24,6 +24,7 @@ import numpy as np
 
 import jax
 from jax import dtypes
+from jax import lax
 from jax import numpy as jnp
 from jax import test_util as jtu
 from jax.interpreters import xla
@@ -222,6 +223,15 @@ class TestPromotionTables(jtu.JaxTestCase):
     except TypeError:
       val = jaxtype.type(0)
     self.assertIs(dtypes._jax_type(val), jaxtype)
+
+  @parameterized.named_parameters(
+    {"testcase_name": "_dtype={}".format(dtype), "dtype": dtype}
+     for dtype in ['float16', 'int16', 'uint16', 'bool'])
+  def testUnaryResultType(self, dtype):
+    # Regression test for special case of dtypes.result_type.
+    # Previously this would return dtypes.result_type(int).
+    x = lax.convert_element_type(2, dtype, weak_type=False)
+    self.assertEqual(dtypes.result_type(x), dtype)
 
   @jtu.ignore_warning(category=UserWarning,
                       message="Explicitly requested dtype.*")


### PR DESCRIPTION
Within the promotion table, all weak dtypes are canonicalized to `jnp.dtype(int)`, `jnp.dtype(float)`, or `jnp.dtype(complex)`. This means, e.g., that if you have a weakly-typed int32 in X64 mode, you get some strange results:
```python
from jax import config, dtypes, lax                                                                                                                                     
config.update('jax_enable_x64', True)                                                                                                                                   

x = lax.convert_element_type(2, 'int32', weak_type=True)                                                                                                    
print(dtypes.result_type(x))
# int64
```
This is particularly surprising becuase `dtypes.result_type` is used throughout the codebase to find the dtype of single arguments.

This change special-cases the single-argument version of `dtypes.result_type` to return the dtype of the value.