### PR TITLE
Fix crash returning a Token from a jit computation on GPU.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -744,7 +744,7 @@ def set_up_aliases(c, xla_args, out_tuple, donated_args, tuple_args):
   for arg_index, arg in enumerate(xla_args):
     if donated_args[arg_index]:
       for param_index, element in flatten_shape(c.GetShape(arg)):
-        key = (element.dimensions(), element.numpy_dtype())
+        key = (element.dimensions(), element.xla_element_type())
         if tuple_args:
           param_number = 0
           param_index = (arg_index,) + tuple(param_index)
@@ -756,7 +756,7 @@ def set_up_aliases(c, xla_args, out_tuple, donated_args, tuple_args):
   # Consume donations for outputs.
   out_donated_args = list(donated_args)
   for output_index, element in flatten_shape(c.GetShape(out_tuple)):
-    key = (element.dimensions(), element.numpy_dtype())
+    key = (element.dimensions(), element.xla_element_type())
     if donations.get(key, ()):
       param_number, param_index, arg_index = donations[key].popleft()
       out_donated_args[arg_index] = False

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2216,6 +2216,10 @@ class APITest(jtu.JaxTestCase):
     # Should not crash.
     vjp_fun(arr)
 
+  def test_jit_returning_token(self):
+    x = jax.jit(jax.lax.create_token)(1.0)
+    self.assertIsInstance(x, jax.interpreters.xla.Token)
+
   def test_leak_checker_catches_a_jit_leak(self):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")


### PR DESCRIPTION
Calling .numpy_dtype() doesn't work on tokens. But we don't need a numpy dtype here, an XLA dtype works just as well.

Fixes #5949 