### PR TITLE
adjust lax.convert_element_type bind to avoid H2D transfers during tracing

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -437,10 +437,8 @@ def convert_element_type(operand: Array, new_dtype: DType = None,
     msg = "Casting complex values to real discards the imaginary part"
     warnings.warn(msg, np.ComplexWarning, stacklevel=2)
 
-  if not isinstance(operand, (core.Tracer, xla.DeviceArray)):
-    return _device_put_raw(np.asarray(operand, dtype=new_dtype),
-                           weak_type=new_weak_type)
-  elif (old_dtype, old_weak_type) == (new_dtype, new_weak_type):
+  if ((old_dtype, old_weak_type) == (new_dtype, new_weak_type)
+      and isinstance(operand, (core.Tracer, xla.DeviceArray))):
     return operand
   else:
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
@@ -2687,10 +2685,13 @@ def _convert_element_type_jvp_rule(tangent, operand , *, new_dtype, weak_type):
   else:
     return convert_element_type_p.bind(tangent, new_dtype=new_dtype, weak_type=weak_type)
 
-convert_element_type_p = standard_primitive(
-    _convert_element_type_shape_rule, _convert_element_type_dtype_rule,
-    'convert_element_type', _convert_element_type_translation_rule,
-    weak_type_rule=_convert_element_type_weak_type_rule)
+convert_element_type_p = core.convert_element_type_p
+convert_element_type_p.def_impl(partial(xla.apply_primitive, convert_element_type_p))
+convert_element_type_p.def_abstract_eval(
+    partial(standard_abstract_eval, convert_element_type_p,
+            _convert_element_type_shape_rule, _convert_element_type_dtype_rule,
+            _convert_element_type_weak_type_rule, standard_named_shape_rule))
+xla.translations[convert_element_type_p] = _convert_element_type_translation_rule
 ad.defjvp(convert_element_type_p, _convert_element_type_jvp_rule)
 ad.primitive_transposes[convert_element_type_p] = _convert_element_type_transpose_rule
 batching.defvectorized(convert_element_type_p)

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -156,13 +156,14 @@ def entr(x):
 @_wraps(osp_special.multigammaln, update_doc=False)
 def multigammaln(a, d):
   d = core.concrete_or_error(int, d, "d argument of multigammaln")
-  a, d = _promote_args_inexact("multigammaln", a, d)
+  a, d_ = _promote_args_inexact("multigammaln", a, d)
 
-  constant = lax.mul(lax.mul(lax.mul(_constant_like(a, 0.25), d),
-                             lax.sub(d, _constant_like(a, 1))),
+  constant = lax.mul(lax.mul(lax.mul(_constant_like(a, 0.25), d_),
+                             lax.sub(d_, _constant_like(a, 1))),
                      lax.log(_constant_like(a, np.pi)))
   res = jnp.sum(gammaln(jnp.expand_dims(a, axis=-1) -
-                        lax.div(jnp.arange(d), _constant_like(a, 2))),
+                        lax.div(jnp.arange(d, dtype=d_.dtype),
+                                _constant_like(a, 2))),
                axis=-1)
   return res + constant
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -978,6 +978,8 @@ def concrete_or_error(force: Any, val: Any, context=""):
   else:
     return force(val)
 
+convert_element_type_p = Primitive('convert_element_type')
+
 class UnshapedArray(AbstractValue):
   __slots__ = ['dtype', 'weak_type']
   array_abstraction_level = 2

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1000,10 +1000,17 @@ def _inline_literals(jaxpr, constvals):
   new_constvars = [var(v) for v in jaxpr.constvars if not lit(v)]
   new_constvals = [c for v, c in zip(jaxpr.constvars, constvals) if not lit(v)]
   new_invars = [var(v) for v in jaxpr.invars]
-  new_eqns = [new_jaxpr_eqn([lit(v) or var(v) for v in eqn.invars],
-                            [var(v) if v in used else dropvar for v in eqn.outvars],
-                            eqn.primitive, eqn.params, eqn.source_info)
-              for eqn in jaxpr.eqns]
+  new_eqns = []
+  for eqn in jaxpr.eqns:
+    invars = [lit(v) or var(v) for v in eqn.invars]
+    if (eqn.primitive is core.convert_element_type_p and type(invars[0]) is Literal):
+      # constant-fold dtype conversion of literals to be inlined
+      consts[eqn.outvars[0]] = np.array(invars[0].val, eqn.params['new_dtype'])
+    else:
+      # might do DCE here, but we won't until we're more careful about effects
+      outvars = [var(v) if v in used else dropvar for v in eqn.outvars]
+      new_eqns.append(new_jaxpr_eqn(invars, outvars, eqn.primitive, eqn.params,
+                                    eqn.source_info))
   new_outvars = [lit(v) or var(v) for v in jaxpr.outvars]
   new_jaxpr = Jaxpr(new_constvars, new_invars, new_outvars, new_eqns)
   return new_jaxpr, new_constvals

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -969,18 +969,12 @@ class LaxRandomTest(jtu.JaxTestCase):
       api.jit(random.PRNGKey)(seed)
 
   def test_random_split_doesnt_device_put_during_tracing(self):
-    raise SkipTest("broken test")  # TODO(mattjj): fix
-
     if not config.omnistaging_enabled:
-      raise SkipTest("test is omnistaging-specific")
-
-    key = random.PRNGKey(1)
+      raise SkipTest("test requires omnistaging")
+    key = random.PRNGKey(1).block_until_ready()
     with jtu.count_device_put() as count:
       api.jit(random.split)(key)
-      key, _ = random.split(key, 2)
-    self.assertEqual(count[0], 1)  # 1 for the argument device_put call
-
-
+    self.assertEqual(count[0], 1)  # 1 for the argument device_put
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@jekbradbury and others noticed that we were performing H2D transfers while tracing, e.g. while tracing `random.split`. @zhangqiaorjc and I tracked it down to how `lax.convert_element_type` would sometimes call a device_put function directly. The fix was to `bind` the `convert_element_type` primitive in more cases. (See also the discussion thread on #5998 about the fix, which was moved from that PR to this one.)

A downside of this fix is that it led to more `convert_element_type` primitive applications in jaxprs, especially for literals. That added visual clutter. This PR fixes that issue by tweaking `_inline_literals` in partial_eval.py to constant-fold dtype conversion of literals at jaxpr formation time. (To do this, I moved `convert_element_type_p` to core.py so that partial_eval.py knows about it.)

~(This PR currently contains two commits from #5998, but once that's merged into master they'll disappear; only the diff from the last commit is relevant to this PR.)~

fixes #5308