### PR TITLE
Fix import of datasets in differentially private SGD example

### DIFF
--- a/examples/differentially_private_sgd.py
+++ b/examples/differentially_private_sgd.py
@@ -79,7 +79,7 @@ from jax.experimental import optimizers
 from jax.experimental import stax
 from jax.tree_util import tree_flatten, tree_unflatten
 import jax.numpy as jnp
-from examples import datasets
+from jax.examples import datasets
 import numpy.random as npr
 
 # https://github.com/tensorflow/privacy


### PR DESCRIPTION
Python 3 doesn't like the relative import of `datasets`