### PR TITLE
Actions hygiene: set reasonable timeouts for github actions jobs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   lint_and_typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.8.0
@@ -29,6 +30,7 @@ jobs:
   build:
     name: "build ${{ matrix.name-prefix }} (py ${{ matrix.python-version }} on ${{ matrix.os }}, x64=${{ matrix.enable-x64}})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         include:
@@ -108,6 +110,7 @@ jobs:
 
   documentation:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: [3.7]


### PR DESCRIPTION
The default timeout is six hours.

I set these new timeouts by looking at the time taken for a recent set of completed tests: https://github.com/google/jax/actions/runs/640842836

These timeouts are at least two times the expected job completion time.