### PR TITLE
ahead-of-time compilation

### DIFF
--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -94,7 +94,7 @@ def argnums_partial(f, dyn_argnums, args):
 
 
 def argnums_partial_except(f: lu.WrappedFun, static_argnums: Tuple[int, ...],
-                           args: Tuple[Any]):
+                           args: Tuple[Any, ...]):
   """Version of ``argnums_partial`` that checks hashability of static_argnums."""
   dyn_argnums = tuple(i for i in range(len(args)) if i not in static_argnums)
   dyn_args = tuple(args[i] for i in dyn_argnums)


### PR DESCRIPTION
```python
$ cat test.py
import jax
import jax.numpy as jnp

def f(x):
  return x + 2.

x = jnp.ones((2, 3))
g = jax.api.compile_for_args(f, x)
print(g(x + 1.))
```

```
$ python test.py
[[4. 4. 4.]
 [4. 4. 4.]]
```