### PR TITLE
Make JAX treatment of large integers consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     * `trace_function` --> {func}`~jax.profiler.annotate_function`
   * Omnistaging can no longer be disabled. See [omnistaging](https://github.com/google/jax/blob/master/design_notes/omnistaging.md)
     for more information.
+  * Python integers larger than the maximum `int64` value will now lead to an overflow
+    in all cases, rather than being silently converted to `uint64` in some cases ({jax-issue}`#6047`).
 
 
 ## jaxlib 0.1.65 (unreleased)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2891,6 +2891,10 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
   dtype = dtype and dtypes.canonicalize_dtype(dtype)
 
   if _can_call_numpy_array(object):
+    if dtypes.is_python_scalar(object):
+      object = dtypes.coerce_to_array(object)
+    # TODO(jakevdp): falling back to numpy here fails to overflow for lists containing
+    # large integers; see discussion in https://github.com/google/jax/pull/6047.
     object = _np_array(object, dtype=dtype, ndmin=ndmin, copy=False)
 
   assert type(object) not in dtypes.python_scalar_dtypes

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -68,8 +68,9 @@ def _zeros_like_python_scalar(t, x):
   return np.array(0, dtypes.python_scalar_dtypes[t])
 
 def _make_concrete_python_scalar(t, x):
-  return ConcreteArray(np.array(x, dtype=dtypes.python_scalar_dtypes[t]),
-                       weak_type=True)
+  return ConcreteArray(
+    np.array(x, dtype=dtypes._scalar_type_to_dtype(t, x)),
+    weak_type=True)
 
 for t in dtypes.python_scalar_dtypes:
   core.pytype_aval_mappings[t] = partial(_make_concrete_python_scalar, t)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -150,7 +150,7 @@ def _canonicalize_ndarray_dtype(x):
 
 def _canonicalize_python_scalar_dtype(typ, x):
   return np.asarray(
-      x, dtypes.canonicalize_dtype(dtypes.python_scalar_dtypes[typ]))
+      x, dtypes.canonicalize_dtype(dtypes._scalar_type_to_dtype(typ, x)))
 
 canonicalize_dtype_handlers: Dict[Any, Callable] = {core.Unit: identity}
 canonicalize_dtype_handlers.update(
@@ -169,8 +169,8 @@ def abstractify(x) -> core.AbstractValue:
     return abstractify(x.__jax_array__())
   raise TypeError(f"Argument '{x}' of type '{type(x)}' is not a valid JAX type")
 
-def _make_abstract_python_scalar(typ, _):
-  return ShapedArray((), dtypes.python_scalar_dtypes[typ], weak_type=True)
+def _make_abstract_python_scalar(typ, val):
+  return ShapedArray((), dtypes._scalar_type_to_dtype(typ, val), weak_type=True)
 
 pytype_aval_mappings: Dict[Any, Callable[[Any], core.AbstractValue]] = {
     core.Unit: lambda _: core.abstract_unit,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3274,6 +3274,37 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                                 "JAX only supports number and bool dtypes.*"):
       jnp.array(3, [('a','<i4'),('b','<i4')])
 
+  def testArrayFromInteger(self):
+    # TODO(jakevdp): implement X32 overflow and canonicalize these
+    int_max = jnp.iinfo(jnp.int64).max
+    int_min = jnp.iinfo(jnp.int64).min
+
+    # Values at extremes are converted correctly.
+    for val in [int_min, 0, int_max]:
+      self.assertEqual(jnp.array(val).dtype, dtypes.canonicalize_dtype('int64'))
+
+    # out of bounds leads to an OverflowError
+    val = int_max + 1
+    with self.assertRaisesRegex(OverflowError, f"Python int {val} too large to convert to int64"):
+      jnp.array(val)
+
+  # TODO(jakevdp): fix list inputs to jnp.array and enable the following test
+  # def testArrayFromList(self):
+  #   int_max = jnp.iinfo(jnp.int64).max
+  #   int_min = jnp.iinfo(jnp.int64).min
+  #
+  #   # Values at extremes are converted correctly.
+  #   for val in [int_min, 0, int_max]:
+  #     self.assertEqual(jnp.array([val]).dtype, dtypes.canonicalize_dtype('int64'))
+  #
+  #   # list of values results in promoted type.
+  #   self.assertEqual(jnp.array([0, np.float16(1)]).dtype, jnp.result_type('int64', 'float16'))
+  #
+  #   # out of bounds leads to an OverflowError
+  #   val = int_min - 1
+  #   with self.assertRaisesRegex(OverflowError, f"Python int {val} too large to convert to int64"):
+  #     jnp.array([0, val])
+
   def testIssue121(self):
     assert not np.isscalar(jnp.array(3))
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -964,7 +964,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     self._CompileAndCheck(random.PRNGKey, args_maker)
 
   def test_prng_errors(self):
-    seed = np.iinfo(np.uint64).max
+    seed = np.iinfo(np.int64).max + 1
     with self.assertRaises(OverflowError):
       random.PRNGKey(seed)
     with self.assertRaises(OverflowError):


### PR DESCRIPTION
Addresses part of #6045.

The goal here is to make JAX treatment of large Python integers consistent: regardless of how the integer is passed to JAX, the behavior should be the same.

After discussion, we decided on this behavior for X64 mode:
```python
import pytest
from jax import api, config
import jax.numpy as jnp
config.update('jax_enable_x64', True)

functions = [
  jnp.array,
  api.device_put,
  api._python_jit(lambda x: x),
  api._cpp_jit(lambda x: x)
]

big = jnp.iinfo('int64').max
for func in functions:
  assert func(big).dtype == 'int64'
  with pytest.raises(OverflowError):
    func(big + 1)
```
Note that this differs from the current behavior in one case: `jnp.array(big + 1)` returns a `uint64` array rather than raising an OverflowError.

Similar changes for X32 mode will require jaxlib C++ changes, and will be part of a followup PR.