### PR TITLE
fix the precision of complex jax.random.normal

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -634,7 +634,7 @@ def _normal(key, shape, dtype) -> jnp.ndarray:
     dtype = dtypes.dtype_real(dtype)
     _re = _normal_real(key_re, shape, dtype)
     _im = _normal_real(key_im, shape, dtype)
-    return 1 / sqrt2 * (_re + 1j * _im)
+    return (_re + 1j * _im) / sqrt2
   else:
     return _normal_real(key, shape, dtype) # type: ignore
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -223,6 +223,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     for samples in [uncompiled_samples, compiled_samples]:
       self._CheckKolmogorovSmirnovCDF(jnp.real(samples), scipy.stats.norm(scale=1/np.sqrt(2)).cdf)
       self._CheckKolmogorovSmirnovCDF(jnp.imag(samples), scipy.stats.norm(scale=1/np.sqrt(2)).cdf)
+      self.assertEqual(dtype, samples.dtype)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_dtype={}".format(np.dtype(dtype).name), "dtype": dtype}


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/6052

example:
``` python
from jax.config import config
config.update("jax_enable_x64", True)
import jax
print(jax.random.normal(jax.random.PRNGKey(1), dtype=jax.numpy.complex64).dtype)
```
output before: `complex128`
output now: `complex64`