### PR TITLE
Fix code typo

### DIFF
--- a/docs/jax-101/06-parallelism.ipynb
+++ b/docs/jax-101/06-parallelism.ipynb
@@ -522,7 +522,7 @@
     "The reason we specify `axis_name` as a string is so we can use collective operations when nesting `jax.pmap` and `jax.vmap`. For example:\n",
     "\n",
     "```python\n",
-    "jax.vmap4(jax.pmap(f, axis_name='i'), axis_name='j')\n",
+    "jax.vmap(jax.pmap(f, axis_name='i'), axis_name='j')\n",
     "```\n",
     "\n",
     "A `jax.lax.psum(..., axis_name='i')` in `f` would refer only to the pmapped axis, since they share the `axis_name`. \n",

--- a/docs/jax-101/06-parallelism.md
+++ b/docs/jax-101/06-parallelism.md
@@ -206,7 +206,7 @@ Note that `normalized_convolution` will no longer work without being transformed
 The reason we specify `axis_name` as a string is so we can use collective operations when nesting `jax.pmap` and `jax.vmap`. For example:
 
 ```python
-jax.vmap4(jax.pmap(f, axis_name='i'), axis_name='j')
+jax.vmap(jax.pmap(f, axis_name='i'), axis_name='j')
 ```
 
 A `jax.lax.psum(..., axis_name='i')` in `f` would refer only to the pmapped axis, since they share the `axis_name`. 


### PR DESCRIPTION
There's a minor typo in the sixth tutorial of the JAX 101 (parallel evaluation).