### PR TITLE
Add helpful message when `import jaxlib` fails.

### DIFF
--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -20,7 +20,13 @@ __all__ = [
   'pocketfft', 'pytree', 'tpu_client', 'version', 'xla_client'
 ]
 
-import jaxlib
+try:
+  import jaxlib
+except ModuleNotFoundError as err:
+  raise ModuleNotFoundError(
+    'jax requires jaxlib to be installed. See '
+    'https://github.com/google/jax#installation for installation instructions.'
+    ) from err
 
 # Must be kept in sync with the jaxlib version in build/test-requirements.txt
 _minimum_jaxlib_version = (0, 1, 60)


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/6071 in the sense that it points users to the right fix.