### PR TITLE
Add extras_require to setup.py

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,5 +12,4 @@ pytest-xdist
 # Packages used for notebook execution
 matplotlib
 sklearn
-jaxlib
-.  # install jax itself from current directory.
+.[cpu]  # Install jax from the current directory; jaxlib from pypi.

--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -28,7 +28,9 @@ except ModuleNotFoundError as err:
     'https://github.com/google/jax#installation for installation instructions.'
     ) from err
 
-# Must be kept in sync with the jaxlib version in build/test-requirements.txt
+# Must be kept in sync with the jaxlib versions in
+# - setup.py
+# - build/test-requirements.txt
 _minimum_jaxlib_version = (0, 1, 62)
 try:
   from jaxlib import version as jaxlib_version

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@
 from setuptools import setup, find_packages
 
 __version__ = None
+_minimum_jaxlib_version = '0.1.62'
+_current_jaxlib_version = '0.1.62'
+_available_cuda_versions = ['101', '102', '110', '111', '112']
 
 with open('jax/version.py') as f:
   exec(f.read(), globals())
@@ -33,6 +36,16 @@ setup(
         'absl-py',
         'opt_einsum',
     ],
+    extras_require={
+        # CPU-only jaxlib can be installed via:
+        # $ pip install jax[cpu]
+        'cpu': [f'jaxlib>={_minimum_jaxlib_version}'],
+
+        # CUDA installations require adding jax releases URL; e.g.
+        # $ pip install jax[cuda-110] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+        **{f'cuda-{version}': f"jaxlib=={_current_jaxlib_version}+cuda{version}"
+           for version in _available_cuda_versions}
+    },
     url='https://github.com/google/jax',
     license='Apache-2.0',
     classifiers=[


### PR DESCRIPTION
This partially solves the problem of `jaxlib` not being listed as an explicit dependency for jax installation. The behavior of `pip install jax` does not change. However, once this PR is part of a release, it will be possible to install JAX along with a compatible CPU version of jaxlib using:
```
$ pip install jax[cpu]
```
and to install JAX along with the most recent GPU version of jaxlib, specifying the CUDA version, using, e.g.:
```
$ pip install jax[cuda-112] -f https://storage.googleapis.com/jax-releases/jax_releases.html
```
Unfortunately, there is no way to specify the alternate package repository URL within the setup.py file; this is a deliberate choice made in the `pip` API.

This does add another task to the release checklist (updating the listed versions in `setup.py`). In the case of `minimum_jaxlib_version`, we could read this from its current declared value with a minor refactoring.

If we decide to merge this, we can update installation instructions in the README once this change is part of a release.