### PR TITLE
CI: fix broken package-overrides check

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r build/test-requirements.txt
-        if [ ${{ matrix.package-overrides }} != none ]; then
+        if [ "${{ matrix.package-overrides }}" != "none" ]; then
           pip install ${{ matrix.package-overrides }}
         fi
 


### PR DESCRIPTION
This has been failing to install overrides whenever `package-overrides` had a space in it.

Tested: confirmed that the correct numpy/scipy versions are installed in the CI runs for this PR.