### PR TITLE
Make lax._const() work for non-canonical weak dtypes

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6343,9 +6343,11 @@ def _dynamic_slice_indices(operand, start_indices):
 
 
 def _const(example, val):
+  dtype = _dtype(example)
   if dtypes.is_python_scalar(example):
-    return dtypes.scalar_type_of(example)(val)
-  return np.array(val, _dtype(example))
+    val = dtypes.scalar_type_of(example)(val)
+    return val if dtype == _dtype(val) else np.array(val, dtype)
+  return np.array(val, dtype)
 
 _zeros: Callable = partial(full_like, fill_value=0)
 _zero: Callable = partial(full_like, shape=(), fill_value=0)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -94,7 +94,9 @@ python_scalar_dtypes : dict = {
 
 def scalar_type_of(x):
   typ = dtype(x)
-  if np.issubdtype(typ, np.bool_):
+  if typ == bfloat16:
+    return float
+  elif np.issubdtype(typ, np.bool_):
     return bool
   elif np.issubdtype(typ, np.integer):
     return int


### PR DESCRIPTION
Motivated by this example:
```python
>>> from jax import lax                                                                                                                                                                                                                                                        
>>> x = lax.convert_element_type(0, 'uint32', weak_type=True)  # non-canonical weak type
>>> lax.lt(x, 1)
-----------------------------------------------------------------------------
TypeError: lt requires arguments to have the same dtypes, got uint32, int32.
```
The issue is that `lax._const(x, 1)` returns a Python integer (because `x` is weakly-typed), which is converted to `int32`, causing the type mismatch in the binary operation.

This change makes `lax._const` more robust to non-canonical weak types.