### PR TITLE
add a memory leak test for jit jaxpr construction

### DIFF
--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -275,7 +275,24 @@ class CoreTest(jtu.JaxTestCase):
     try:
       fn(params)
       gc.set_debug(gc.DEBUG_SAVEALL)
-      self.assertEqual(gc.collect(), 0)
+      self.assertEqual(gc.collect(), 0, msg=str(gc.garbage))
+    finally:
+      gc.set_debug(debug)
+
+  def test_reference_cycles_jit(self):
+    gc.collect()
+
+    def f(x):
+      return x.sum()
+
+    fn = jit(f)
+    params = jnp.zeros([])
+
+    debug = gc.get_debug()
+    try:
+      fn(params).block_until_ready()
+      gc.set_debug(gc.DEBUG_SAVEALL)
+      self.assertEqual(gc.collect(), 0, msg=str(gc.garbage))
     finally:
       gc.set_debug(debug)
 


### PR DESCRIPTION
Tweak implementation for `_inline_literals` not to include a class defined in a function, since that seemed to cause leaking! At least we know the test catches something :)

I also verified the test works by changing the jaxpr building code path used by `jit` to create reference cycles, and the test indeed fails!