### PR TITLE
unify configuration state handling

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -30,7 +30,8 @@ except Exception as exc:
 del _cloud_tpu_init
 
 # flake8: noqa: F401
-from .config import config
+from .config import (config, enable_checks, check_tracer_leaks, checking_leaks,
+                     debug_nans, debug_infs, log_compiles)
 from .api import (
   ad,  # TODO(phawkins): update users to avoid this.
   argnums_partial,  # TODO(phawkins): update Haiku to not use this.

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -1113,7 +1113,7 @@ def _cond_typecheck(*avals, branches, linear):
       f'called with operands of type {_avals_short(op_avals)}')
 
 def cond_bind(*args, branches, linear):
-  if not core.skip_checks:
+  if config.jax_enable_checks:
     avals = _map(core.get_aval, args)
     _cond_typecheck(*avals, branches=branches, linear=linear)
     for jaxpr in branches:
@@ -1876,7 +1876,7 @@ def _scan_typecheck(bind_time, *avals, reverse, length, num_consts, num_carry,
       f'called with sequence of type\n{_avals_short(x_avals)}')
 
 def scan_bind(*args, **params):
-  if not core.skip_checks:
+  if config.jax_enable_checks:
     avals = _map(core.get_aval, args)
     _scan_typecheck(True, *avals, **params)
     core.check_jaxpr(params['jaxpr'].jaxpr)

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -21,7 +21,6 @@ from typing import Any, Callable
 
 import numpy as np
 
-import jax
 from jax.config import config
 
 partial = functools.partial
@@ -192,7 +191,7 @@ def cache(max_size=4096):
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-      if jax.core.debug_state.check_leaks:
+      if config.jax_check_tracer_leaks:
         return f(*args, **kwargs)
       else:
         return cached(bool(config.x64_enabled), *args, **kwargs)

--- a/jax/api.py
+++ b/jax/api.py
@@ -41,7 +41,7 @@ from . import lib
 from . import linear_util as lu
 from . import ad_util
 from . import dtypes
-from .core import eval_jaxpr, checking_leaks
+from .core import eval_jaxpr
 from .api_util import (flatten_fun, apply_flat_fun, flatten_fun_nokwargs,
                        flatten_fun_nokwargs2, argnums_partial,
                        argnums_partial_except, flatten_axes, donation_vector,
@@ -362,7 +362,7 @@ def _cpp_jit(
       context = (getattr(core.thread_local_state.trace_state.trace_stack,
                          "dynamic", None), config.x64_enabled)
       # TODO(jblespiau): Move this to C++.
-      if (FLAGS.jax_debug_nans or FLAGS.jax_debug_infs) and not _jit_is_disabled():
+      if (config.jax_debug_nans or config.jax_debug_infs) and not _jit_is_disabled():
         device_arrays = cpp_jitted_f(context, *args, **kwargs)
         try:
           xla.check_special(xla.xla_call_p, [
@@ -372,7 +372,7 @@ def _cpp_jit(
           ])
           return device_arrays
         except FloatingPointError:
-          assert FLAGS.jax_debug_nans or FLAGS.jax_debug_infs  # compiled_fun can only raise in this case
+          assert config.jax_debug_nans or config.jax_debug_infs  # compiled_fun can only raise in this case
           print("Invalid nan value encountered in the output of a C++-jit "
                 "function. Calling the de-optimized version.")
           return cache_miss(*args, **kwargs)[0]  # probably won't return
@@ -389,7 +389,7 @@ def _cpp_jit(
     @api_boundary
     def f_jitted(*args, **kwargs):
       # TODO(jblespiau): Move this to C++.
-      if (FLAGS.jax_debug_nans or FLAGS.jax_debug_infs) and not _jit_is_disabled():
+      if (config.jax_debug_nans or config.jax_debug_infs) and not _jit_is_disabled():
         device_arrays = cpp_jitted_f(*args, **kwargs)
         try:
           xla.check_special(xla.xla_call_p, [
@@ -399,7 +399,7 @@ def _cpp_jit(
           ])
           return device_arrays
         except FloatingPointError:
-          assert FLAGS.jax_debug_nans or FLAGS.jax_debug_infs  # compiled_fun can only raise in this case
+          assert config.jax_debug_nans or config.jax_debug_infs  # compiled_fun can only raise in this case
           print("Invalid nan value encountered in the output of a C++-jit "
                 "function. Calling the de-optimized version.")
           return cache_miss(*args, **kwargs)[0]  # probably won't return

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -914,7 +914,7 @@ def closure_convert(fun, *example_args):
   """
   flat_args, in_tree = tree_flatten(example_args)
   in_avals = tuple(map(abstractify, flat_args))
-  if core.debug_state.check_leaks:
+  if config.jax_check_tracer_leaks:
     return _closure_convert_for_avals.__wrapped__(fun, in_tree, in_avals)
   else:
     return _closure_convert_for_avals(fun, in_tree, in_avals)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -20,27 +20,19 @@
 # so we need our own implementation that deviates from NumPy in places.
 
 
-from distutils.util import strtobool
 import functools
-import os
 from typing import Dict
 
 import numpy as np
 
 from ._src import util
 from .config import flags, config
-from . import lib
 from .lib import xla_client
 
 from ._src import traceback_util
 traceback_util.register_exclusion(__file__)
 
 FLAGS = flags.FLAGS
-flags.DEFINE_bool('jax_enable_x64',
-                  strtobool(os.getenv('JAX_ENABLE_X64', 'False')),
-                  'Enable 64-bit types to be used.')
-lib.jax_jit.global_state().enable_x64 = strtobool(
-    os.getenv('JAX_ENABLE_X64', 'False'))
 
 # bfloat16 support
 bfloat16: type = xla_client.bfloat16

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -135,7 +135,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
          dtype=dtype)
     for dtype in [np.int64, np.float64]))
   def test_converts_64bit(self, dtype=np.int64, with_function=False):
-    if not config.FLAGS.jax_enable_x64:
+    if not config.jax_enable_x64:
       self.skipTest("requires x64 mode")
     big_const = np.full((5,), 2 ** 33, dtype=dtype)
     self.ConvertAndCompare(jnp.sin, big_const)

--- a/jax/experimental/x64_context.py
+++ b/jax/experimental/x64_context.py
@@ -17,31 +17,14 @@
 **Experimental: please give feedback, and expect changes.**
 """
 
+# This file provides
+#  1. a jax.experimental API endpoint;
+#  2. the `disable_x64` wrapper.
+# TODO(jakevdp): remove this file, and consider removing `disable_x64` for
+# uniformity
+
 from contextlib import contextmanager
-from jax import config
-
-@contextmanager
-def enable_x64():
-  """Experimental context manager to temporarily enable X64 mode.
-
-  Usage::
-
-    >>> import jax.numpy as jnp
-    >>> with enable_x64():
-    ...   print(jnp.arange(10.0).dtype)
-    ...
-    float64
-
-  See Also
-  --------
-  jax.experimental.disable_x64 :  temporarily disable X64 mode.
-  """
-  _x64_state = config.x64_enabled
-  config._set_x64_enabled(True)
-  try:
-    yield
-  finally:
-    config._set_x64_enabled(_x64_state)
+from jax.config import enable_x64
 
 @contextmanager
 def disable_x64():
@@ -59,9 +42,5 @@ def disable_x64():
   --------
   jax.experimental.enable_x64 : temporarily enable X64 mode.
   """
-  _x64_state = config.x64_enabled
-  config._set_x64_enabled(False)
-  try:
+  with enable_x64(False):
     yield
-  finally:
-    config._set_x64_enabled(_x64_state)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -174,7 +174,7 @@ def backward_pass(jaxpr: core.Jaxpr, consts, primals_in, cotangents_in):
       # assert v.aval == ct.aval, (prim, v.aval, ct.aval)
       return
     ct_env[v] = add_tangents(ct_env[v], ct) if v in ct_env else ct
-    if not core.skip_checks:
+    if config.jax_enable_checks:
       ct_aval = core.get_aval(ct_env[v])
       joined_aval = core.lattice_join(v.aval, ct_aval).strip_weak_type()
       assert v.aval.strip_weak_type() == joined_aval, (prim, v.aval, ct_aval)
@@ -389,7 +389,7 @@ class JVPTracer(Tracer):
   __slots__ = ['primal', 'tangent']
 
   def __init__(self, trace, primal, tangent):
-    if not core.skip_checks:
+    if config.jax_enable_checks:
       _primal_tangent_shapes_match(primal, tangent)
     self._trace = trace
     self.primal = primal

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -108,7 +108,7 @@ class BatchTracer(Tracer):
   __slots__ = ['val', 'batch_dim']
 
   def __init__(self, trace, val, batch_dim: Optional[int]):
-    assert core.skip_checks or type(batch_dim) in (int, NotMapped)  # type: ignore
+    assert not config.jax_enable_checks or type(batch_dim) in (int, NotMapped)  # type: ignore
     self._trace = trace
     self.val = val
     self.batch_dim = batch_dim

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -49,7 +49,7 @@ class PartialVal(tuple):
   """
   def __new__(cls, xs: Tuple[Optional[AbstractValue], core.Value]):
     pv, const = xs
-    if not core.skip_checks:
+    if config.jax_enable_checks:
       # type checks
       assert isinstance(pv, (AbstractValue, type(None))), xs
       assert isinstance(const, core.Tracer) or type(const) is Zero or core.valid_jaxtype(const), xs
@@ -648,25 +648,25 @@ def tracers_to_jaxpr(
   const_vars, const_vals = unzip2(consts.items())
   # The env_vars are pre-pended to the invars
   jaxpr = Jaxpr(const_vars, [*env_vars, *invars], map(getvar, out_tracers), eqns)
-  core.skip_checks or core.check_jaxpr(jaxpr)
+  config.jax_enable_checks and core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
 @cache()
 def convert_constvars_jaxpr(jaxpr: Jaxpr):
   """Moves the constvars to the start of invars."""
-  core.skip_checks or core.check_jaxpr(jaxpr)
+  config.jax_enable_checks and core.check_jaxpr(jaxpr)
   lifted_jaxpr = Jaxpr(constvars=(),
                        invars=jaxpr.constvars + jaxpr.invars,
                        outvars=jaxpr.outvars, eqns=jaxpr.eqns)
-  core.skip_checks or core.check_jaxpr(lifted_jaxpr)
+  config.jax_enable_checks and core.check_jaxpr(lifted_jaxpr)
   return lifted_jaxpr
 
 def convert_envvars_to_constvars(jaxpr: Jaxpr, num_env_vars: int):
-  core.skip_checks or core.check_jaxpr(jaxpr)
+  config.jax_enable_checks and core.check_jaxpr(jaxpr)
   env_vars, invars = split_list(jaxpr.invars, [num_env_vars])
   converted_jaxpr = Jaxpr(constvars=jaxpr.constvars + env_vars,
                           invars=invars, outvars=jaxpr.outvars, eqns=jaxpr.eqns)
-  core.skip_checks or core.check_jaxpr(converted_jaxpr)
+  config.jax_enable_checks and core.check_jaxpr(converted_jaxpr)
   return converted_jaxpr
 
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -486,7 +486,7 @@ class ShardedDeviceArray(xla.DeviceArray):  # type: ignore
     self.indices = indices
     self._npy_value = None
     self._one_replica_buffer_indices = None
-    if not core.skip_checks:
+    if config.jax_enable_checks:
       assert type(aval) is ShapedArray
 
   @property
@@ -792,7 +792,7 @@ def parallel_callable(fun: lu.WrappedFun,
       f"`axis_size` (or remove the `devices` argument). Got nested_replicas="
       f"{jaxpr_replicas} and nested_partitions={num_partitions}")
 
-  log_priority = logging.WARNING if FLAGS.jax_log_compiles else logging.DEBUG
+  log_priority = logging.WARNING if config.jax_log_compiles else logging.DEBUG
   logging.log(log_priority,
               f"Compiling {fun.__name__} ({id(fun)}) for {num_global_shards} "
               f"devices with args {avals}. (num_replicas={num_global_replicas}"
@@ -1387,7 +1387,7 @@ def mesh_callable(fun: lu.WrappedFun,
   global_axis_sizes = mesh.shape
   local_axis_sizes = local_mesh.shape
 
-  log_priority = logging.WARNING if FLAGS.jax_log_compiles else logging.DEBUG
+  log_priority = logging.WARNING if config.jax_log_compiles else logging.DEBUG
   logging.log(log_priority,
               f"Compiling {fun.__name__} ({id(fun)}) for {tuple(global_axis_sizes.items())} "
               f"mesh with args {local_in_untiled_avals}. Argument mapping: {in_axes}.")

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -144,7 +144,7 @@ def _sharded_callable(
                      for out, parts, lparts
                      in safe_zip(global_out_avals, out_parts, local_out_parts)]
 
-  log_priority = logging.WARNING if FLAGS.jax_log_compiles else logging.DEBUG
+  log_priority = logging.WARNING if config.jax_log_compiles else logging.DEBUG
   logging.log(log_priority,
               f"Compiling {fun.__name__} for {nparts} devices with "
               f"args {global_abstract_args}.")

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -248,7 +248,7 @@ def cache(call: Callable):
 
   def memoized_fun(fun: WrappedFun, *args):
     cache = fun_caches.setdefault(fun.f, {})
-    if core.debug_state.check_leaks:
+    if config.jax_check_tracer_leaks:
       key = (_copy_main_traces(fun.transforms), fun.params, args, config.x64_enabled)
     else:
       key = (fun.transforms, fun.params, args, config.x64_enabled)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -445,7 +445,7 @@ def skip_on_flag(flag_name, skip_value):
   def skip(test_method):        # pylint: disable=missing-docstring
     @functools.wraps(test_method)
     def test_method_wrapper(self, *args, **kwargs):
-      flag_value = getattr(FLAGS, flag_name)
+      flag_value = config._read(flag_name)
       if flag_value == skip_value:
         test_name = getattr(test_method, '__name__', '[unknown test]')
         raise unittest.SkipTest(
@@ -819,7 +819,7 @@ class JaxTestCase(parameterized.TestCase):
 
   def setUp(self):
     super(JaxTestCase, self).setUp()
-    core.skip_checks = False
+    config.update('jax_enable_checks', True)
     # We use the adler32 hash for two reasons.
     # a) it is deterministic run to run, unlike hash() which is randomized.
     # b) it returns values in int32 range, which RandomState requires.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
-show_error_codes=True
+show_error_codes = True
+disable_error_code = attr-defined
 
 [mypy-absl.*]
 ignore_missing_imports = True

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2217,7 +2217,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       lst = []
 
       @jit
@@ -2232,7 +2232,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       lst = []
 
       @api.pmap
@@ -2247,7 +2247,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       lst = []
 
       def f(x):
@@ -2261,7 +2261,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       @jit
       def f(x):
         return x
@@ -2279,7 +2279,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       lst = []
 
       to_scan = lambda c, x: (lst.append(c) or jnp.sin(c), None)
@@ -2291,7 +2291,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       to_scan = lambda c, x: (jnp.sin(c), None)
       lax.scan(to_scan, 1., np.arange(3.))  # doesn't crash
 
@@ -2299,7 +2299,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       to_scan = lambda c, x: (c, None)
 
       def f(x):
@@ -2310,7 +2310,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       to_scan = lambda c, _: (1., None)
 
       @api.vmap
@@ -2322,7 +2322,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       to_scan = lambda c, _: (c, None)
 
       @api.vmap
@@ -2334,7 +2334,7 @@ class APITest(jtu.JaxTestCase):
     if not config.omnistaging_enabled:
       raise unittest.SkipTest("test only works with omnistaging")
 
-    with core.checking_leaks():
+    with jax.checking_leaks():
       @jit
       def f(x):
         lst = []
@@ -4957,29 +4957,29 @@ class DeprecatedCustomTransformsTest(jtu.JaxTestCase):
     api.grad(lambda x, y: f(x, y)[0])(1., 2.)  # doesn't crash
 
   def test_custom_transforms_vjp_nones(self):
-    core.skip_checks = True  # Fails with checks
-    # issue raised by jsnoek@ and jumper@
-    @jax.custom_transforms
-    def solve(a, b):
-      return jnp.dot(jnp.linalg.inv(a), b)
-    # print(solve(a, b))
+    with jax.enable_checks(False):  # fails with checks
+      # issue raised by jsnoek@ and jumper@
+      @jax.custom_transforms
+      def solve(a, b):
+        return jnp.dot(jnp.linalg.inv(a), b)
+      # print(solve(a, b))
 
-    def solve_vjp(a, b):
-      x = solve(a, b)
-      def vjp(x_tangent):
-        dx = jnp.dot(solve(a, x_tangent), x.T)
-        out = (dx, b * 0.)
-        return out
-      return x, vjp
-    jax.defvjp_all(solve, solve_vjp)
-    gf = grad(lambda a,b: jnp.sum(solve(a, b)))
+      def solve_vjp(a, b):
+        x = solve(a, b)
+        def vjp(x_tangent):
+          dx = jnp.dot(solve(a, x_tangent), x.T)
+          out = (dx, b * 0.)
+          return out
+        return x, vjp
+      jax.defvjp_all(solve, solve_vjp)
+      gf = grad(lambda a,b: jnp.sum(solve(a, b)))
 
-    n = 3
-    a_in = jnp.linspace(0, 1, n)[:, None]
-    a = jnp.dot(a_in, a_in.T) + jnp.eye(n) * 0.1
-    real_x = np.random.RandomState(0).randn(n)
-    b = jnp.dot(a + jnp.eye(a.shape[0]), real_x)
-    print(gf(a, b))  # doesn't crash
+      n = 3
+      a_in = jnp.linspace(0, 1, n)[:, None]
+      a = jnp.dot(a_in, a_in.T) + jnp.eye(n) * 0.1
+      real_x = np.random.RandomState(0).randn(n)
+      b = jnp.dot(a + jnp.eye(a.shape[0]), real_x)
+      print(gf(a, b))  # doesn't crash
 
 
 class BufferDonationTest(jtu.BufferDonationTestCase):

--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -30,7 +30,7 @@ config.parse_flags_with_absl()
 class DebugNaNsTest(jtu.JaxTestCase):
 
   def setUp(self):
-    self.cfg = config.read("jax_debug_nans")
+    self.cfg = config._read("jax_debug_nans")
     config.update("jax_debug_nans", True)
 
   def tearDown(self):
@@ -144,7 +144,7 @@ class DebugNaNsTest(jtu.JaxTestCase):
 class DebugInfsTest(jtu.JaxTestCase):
 
   def setUp(self):
-    self.cfg = config.read("jax_debug_infs")
+    self.cfg = config._read("jax_debug_infs")
     config.update("jax_debug_infs", True)
 
   def tearDown(self):

--- a/tests/djax_test.py
+++ b/tests/djax_test.py
@@ -148,7 +148,7 @@ class DJaxADTests(jtu.JaxTestCase):
       y = sin(x)
       return reduce_sum(y, axes=(0,))
     x = bbarray((5,), jnp.arange(2.))
-    with jax.core.skipping_checks():  # TODO implement dxla_call abs eval rule
+    with jax.enable_checks(False):  # TODO implement dxla_call abs eval rule
       z, f_lin = jax.linearize(f, x)
     z_dot = f_lin(ones_like(x))
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -25,7 +25,6 @@ import numpy as np
 
 import jax
 from jax import api
-from jax import core
 from jax import dtypes
 from jax import lax
 from jax import test_util as jtu
@@ -992,7 +991,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     expected = np.array(0.0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    with core.skipping_checks():
+    with jax.enable_checks(False):
       with self.assertRaises(TypeError):
         lax.stop_gradient(lambda x: x)
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1709,7 +1709,6 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertAllClose(carry_out[1], carry_init, check_dtypes=False)
     self.assertAllClose(carry_out[0], jnp.array([2., 2., 2.]), check_dtypes = False)
 
-  # TODO(mattjj, dougalm): fix this test when skip_checks is False
   def testIssue757(self):
     # code from https://github.com/google/jax/issues/757
     def fn(a):

--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -208,7 +208,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
   ))
   def test_bicgstab_against_scipy(
       self, shape, dtype, preconditioner):
-    if not config.FLAGS.jax_enable_x64:
+    if not config.jax_enable_x64:
       raise unittest.SkipTest("requires x64 mode")
 
     rng = jtu.rand_default(self.rng())

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2190,7 +2190,7 @@ class LaxTest(jtu.JaxTestCase):
     #     api.make_jaxpr(lambda x: lax.tie_in((x, x), 1))(1.)
 
   def test_primitive_jaxtype_error(self):
-    with core.skipping_checks():
+    with jax.enable_checks(False):
       with self.assertRaisesRegex(
           TypeError, "Argument .* of type .* is not a valid JAX type"):
         lax.add(1, 'hi')

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -117,12 +117,12 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
   def testEluMemory(self):
     # see https://github.com/google/jax/pull/1640
-    with core.skipping_checks():  # With checks we materialize the array
+    with jax.enable_checks(False):  # With checks we materialize the array
       jax.make_jaxpr(lambda: nn.elu(jnp.ones((10 ** 12,))))  # don't oom
 
   def testHardTanhMemory(self):
     # see https://github.com/google/jax/pull/1640
-    with core.skipping_checks():  # With checks we materialize the array
+    with jax.enable_checks(False):  # With checks we materialize the array
       jax.make_jaxpr(lambda: nn.hard_tanh(jnp.ones((10 ** 12,))))  # don't oom
 
   def testOneHot(self):

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -914,7 +914,7 @@ class LaxRandomTest(jtu.JaxTestCase):
       raise SkipTest("after deleting lazy constants, requires omnistaging")
     def f(x):
       return random.normal(random.PRNGKey(x), (int(1e12),))
-    with core.skipping_checks():  # check_jaxpr will materialize array
+    with jax.enable_checks(False):  # check_jaxpr will materialize array
       api.eval_shape(f, 0)  # doesn't error
 
   @parameterized.named_parameters(jtu.cases_from_list(

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -73,7 +73,7 @@ class X64ContextTests(jtu.JaxTestCase):
       func = _maybe_jit(jit, lambda: jnp.arange(10.0))
       func()
 
-    expected_dtype = "float64" if config.read("jax_enable_x64") else "float32"
+    expected_dtype = "float64" if config._read("jax_enable_x64") else "float32"
     self.assertEqual(func().dtype, expected_dtype)
 
     with enable_x64():


### PR DESCRIPTION
**Reviewer:** The main action is in config.py. The other changed files are downstream of those changes.

This change arose from working on adding a `jax_tpu_dot_precision` flag / context manager (see #6143).

We have a few configurable bits of global state. These bits of configurable state are managed by flags and sometimes dynamically by context managers, but neither the APIs nor implementations are uniform. Moreover the state is spread out through a few different files.

The bits of global state we have in mind are:

1. `core.skip_checks` (state in core.py, flag defined in config.py, not properly thread-local, has a context manager, does *not* affect `jit` dispatch since it's all about trace-time errors)
2. `core.debug_state.check_leaks` (state in core.py, flag defined in config.py, thread-local, has a context manager, does *not* affect `jit` dispatch since it's all about trace-time errors)
3. `jax_debug_nans` / `jax_debug_infs` (flag defined in xla.py, not properly thread-local, no context manager, affects `jit` dispatch in that it adds checks to every execution on the Python side) ([affects `jit` dispatch](https://github.com/google/jax/blob/5e88ed290359c301aa20d57b6c40521b43d4a7bf/jax/api.py#L361-L374))
4. `jax_log_compiles` (flag defined in xla.py, not properly thread-local, no context manager, does *not* affect `jit` dispatch since it's all about trace-time logging)
4. `jax_enable_x64` (work-in-progress, state in jax_jit.cc, context manager being developed in `jax.experimental`, thread-local, [affects `jit` dispatch](https://github.com/google/jax/blob/5e88ed290359c301aa20d57b6c40521b43d4a7bf/jax/api.py#L359) in that it's part of the compilation cache key and affects how input arguments are handled in the c++ code)
5. `jax_default_dot_precision` (work-in-progress, not present yet, affects `jit` dispatch analogously to `jax_enable_x64`)
6. `disable_jit` (state in jax_jit.cc, [affects `jit` dispatch](https://github.com/google/jax/blob/5e88ed290359c301aa20d57b6c40521b43d4a7bf/jax/api.py#L375) in that it's part of the compilation cache key)
7. `jax_numpy_rank_promotion` (flag defined in lax_numpy.py, not thread-local and no context manager, does *not* affect `jit` dispatch in that it's all about trace-time errors)

This PR unifies all the boolean-valued instances of Python state via a single mechanism in config.py which sets up flags, thread-local state, and context manager APIs. This PR doesn't touch `jax_default_dot_precision` or `jax_numpy_rank_promotion` because those are enums rather than booleans; it doesn't touch `disable_jit` or `jax_enable_x64` because those are in C++.

Another effect of this PR is introducing new context managers: `jax.enable_checks`, `jax.check_tracer_leaks`, `jax.debug_nans`, `jax.debug_infs`, and `jax.log_compiles`. Each takes a single boolean argument.

Follow-up work might put more of these bits in C++ (i.e. in jax_jit.cc) for fast dispatch, and/or speed up dispatch times for Python state bits. That work should be easier once we collect all the state in one place as in this PR. It's also follow-up work ~to unify the API with `jax_enable_x64` (cc @jakevdp), and~ to add an enum version of this logic for `jax_default_dot_precision`, `jax_numpy_rank_promotion`, and perhaps the default device. After discussing with @jakevdp , we decided to unify with the implementation of `jax_enable_x64` in this PR, but leave the API endpoints for the x64 stuff unchanged.

Benchmark results on `benchmarks/api_benchmark.py` show no real differences AIUI:

```
name                                old cpu/op  new cpu/op  delta
jit_trivial_dispatch                43.7µs ± 3%  43.3µs ± 2%   ~     (p=0.690 n=5+5)
jit_trivial                         44.9µs ± 2%  44.7µs ± 2%   ~     (p=0.690 n=5+5)
jit_simple_dispatch                 15.3µs ± 1%  15.4µs ± 4%   ~     (p=1.000 n=5+5)
jit_simple                          16.2µs ± 4%  16.1µs ± 3%   ~     (p=1.000 n=5+5)
jit_simple_many_args_dispatch_10    20.1µs ± 2%  20.5µs ± 3%   ~     (p=0.421 n=5+5)
jit_simple_many_args_10             21.7µs ± 2%  22.0µs ± 2%   ~     (p=0.548 n=5+5)
jit_simple_many_args_dispatch_100   65.1µs ± 1%  65.1µs ± 1%   ~     (p=0.841 n=5+5)
jit_simple_many_args_100            66.1µs ± 1%  66.4µs ± 1%   ~     (p=0.222 n=5+5)
jit_simple_many_args_dispatch_1000   535µs ± 2%   538µs ± 2%   ~     (p=0.310 n=5+5)
jit_simple_many_args_1000            549µs ± 3%   555µs ± 2%   ~     (p=0.421 n=5+5)
jit_simple_many_args_dispatch_2000  1.12ms ± 4%  1.11ms ± 2%   ~     (p=0.841 n=5+5)
jit_simple_many_args_2000           1.13ms ± 3%  1.13ms ± 3%   ~     (p=1.000 n=5+5)
jit_dispatch_without_transfer        116µs ± 6%   118µs ± 6%   ~     (p=0.841 n=5+5)
jit_dispatch_with_transfer           126µs ± 7%   124µs ±10%   ~     (p=0.841 n=5+5)
```

This PR doesn't currently include tests, though the code is pretty thoroughly exercised by existing test coverage for `skip_checks`,`check_leaks`, `debug_nans`, `disable_jit`, etc.