### PR TITLE
Make sublevel weak-referable, and enable the leak checker on sublevels.

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2329,6 +2329,25 @@ class APITest(jtu.JaxTestCase):
         lax.scan(to_scan, x, None, length=1)
       f(np.arange(5.))  # doesn't crash
 
+  def test_leak_checker_catches_a_sublevel_leak(self):
+    if not config.omnistaging_enabled:
+      raise unittest.SkipTest("test only works with omnistaging")
+
+    with core.checking_leaks():
+      @jit
+      def f(x):
+        lst = []
+        @jit
+        def g(x):
+          lst.append(x)
+          return x
+
+        x = g(x)
+        return x
+
+      with self.assertRaisesRegex(Exception, r"Leaked sublevel"):
+        f(3)
+
   def test_default_backend(self):
     first_local_device = api.local_devices()[0]
     self.assertEqual(first_local_device.platform, api.default_backend())


### PR DESCRIPTION
Reimplement Sublevel to not inherit from `int`.
See [docs on weakref](https://docs.python.org/3/library/weakref.html#:~:text=Other%20built-in%20types%20such%20as%20tuple%20and%20int): "CPython implementation detail: Other built-in types
such as tuple and int do not support weak references even when subclassed."