### PR TITLE
add jax_default_matmul_precision flag and context manager

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -31,7 +31,8 @@ del _cloud_tpu_init
 
 # flake8: noqa: F401
 from .config import (config, enable_checks, check_tracer_leaks, checking_leaks,
-                     debug_nans, debug_infs, log_compiles)
+                     debug_nans, debug_infs, log_compiles,
+                     default_matmul_precision, numpy_rank_promotion)
 from .api import (
   ad,  # TODO(phawkins): update users to avoid this.
   argnums_partial,  # TODO(phawkins): update Haiku to not use this.


### PR DESCRIPTION
~**Notice the "diffbase" on the flag-cleanup branch, i.e. #6112**.~ See the comment on #6112 for more context.

fixes #2161

This PR adds a configuration option `jax_default_matmul_precision` and a context manager `jax.default_matmul_precision(...)` to control the default precision of internal computations used in matrix multiplies and convolutions on float32 inputs for supported backends (currently just TPU but likely soon A100 GPUs as well).

For example, say we have a function `foo` which includes a `jnp.dot` call:

```python
def foo(...):
  ...
  z = jnp.dot(x, y)  # x and y are float32 arrays
  ...
```

We can ensure that `dot` is computed at the highest (or lowest) precision using any of these methods:
1. we can set the shell environment variable `JAX_DEFAULT_MATMUL_PRECISION=float32` (or `JAX_DEFAULT_MATMUL_PRECISION=bfloat16`);
2. if our main script parses flags with [`absl`](https://github.com/abseil/abseil-py), then we can use the command-line flag `--jax_default_matmul_precision=float32` (or `--jax_default_matmul_precision=bfloat16`);
3. at the top of our main script, we can put `jax.config.update('jax_default_matmul_precision', 'float32')` (or `jax.config.update('jax_default_matmul_precision', 'bfloat16')`);
4. when we call `foo`, we can use the `jax.default_matmul_precision` context manager:
```python
with jax.default_matmul_precision('float32'):   # or 'bfloat16' for lowest
  ... = foo(...)
```

This configuration option controls the _default_ precision in the sense that convolution operations like `lax.conv_general_dilated` and matrix multiply operations like `lax.dot` take an optional `precision` argument. This configuration option does not change the behaviors of such calls with explicit precision arguments; it only changes the behaviors of calls with no such argument provided.

This PR does **not** change the default default dot precision; that remains `'bfloat16'`. It only adds new ways to control the default dot precision. We might change the default in follow-up work.

In follow-up work we may add an analogous bit of enum state for controlling the default device. But I think we should land this part first.

TODO:
- [x] write PR message
- [x] add tests

cc @rohan-anil @sharadmv @shoyer @SiegeLordEx @jonbarron