### PR TITLE
Don't raise exception for failed docstring parsing

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -138,7 +138,6 @@ def _wraps(fun: Callable, update_doc: bool = True, lax_description: str = "",
         if kept_sections:
           docstr += "\n" + "\n\n".join(kept_sections) + "\n"
       except:
-        raise
         docstr = fun.__doc__
 
     op.__doc__ = docstr


### PR DESCRIPTION
This raise was left in from testing in #5945. The docstrings come from the version of numpy that the user has installed; raising this error may cause JAX to be unimportable if numpy changes their docstrings.

Note that failed docstring parsing will still be caught in the tests by https://github.com/google/jax/blob/ba024414aac06c9a9f8b773f62d5ab3a2ee35663/tests/lax_numpy_test.py#L5280-L5281