### PR TITLE
Add transform name to UnexpectedTracerError.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -685,7 +685,7 @@ def parallel_callable(fun: lu.WrappedFun,
   logging.vlog(2, "global_sharded_avals: %s", global_sharded_avals)
 
   with core.extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
-    jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(fun, global_sharded_avals)
+    jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(fun, global_sharded_avals, transform_name="pmap")
   jaxpr = xla.apply_outfeed_rewriter(jaxpr)
 
   out_axes = out_axes_thunk()

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -649,7 +649,7 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
                      "got device={} and backend={}".format(device, backend))
 
   abstract_args, arg_devices = unzip2(arg_specs)
-  jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, abstract_args)
+  jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, abstract_args, transform_name="jit")
   if any(isinstance(c, core.Tracer) for c in consts):
     raise core.UnexpectedTracerError("Encountered an unexpected tracer.")
   map(prefetch, it.chain(consts, jaxpr_literals(jaxpr)))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2070,6 +2070,17 @@ class APITest(jtu.JaxTestCase):
       # level, which is no longer live.
       jax.jit(jnp.add)(jnp.ones(()), count)
 
+  def test_escaped_tracer_transform_name(self):
+    with self.assertRaisesRegex(core.UnexpectedTracerError,
+                                "transformed by jit"):
+      jax.jit(self.helper_save_tracer)(1)
+      _ = self._saved_tracer+1
+
+    with self.assertRaisesRegex(core.UnexpectedTracerError,
+                                "transformed by pmap"):
+      jax.pmap(self.helper_save_tracer)(jnp.ones((1, 2)))
+      _ = self._saved_tracer+1
+
   def test_pmap_static_kwarg_error_message(self):
     # https://github.com/google/jax/issues/3007
     def f(a, b):


### PR DESCRIPTION
If we thread through the name of the transform that kicked off a jaxpr trace, we can add this information to the `UnexpectedTracerError`. This is useful to track down where the actual tracer side-effect occurred. 
Happy to be convinced of a different approach which uses some global tracer state :)