### PR TITLE
DOC: strip versionadded markup from wrapped docstrings

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -20,6 +20,7 @@ from typing import Callable, NamedTuple, Optional, Dict, Sequence
 _parameter_break = re.compile("\n(?=[A-Za-z_])")
 _section_break = re.compile(r"\n(?=[^\n]{3,15}\n-{3,15})", re.MULTILINE)
 _numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*?\)$', re.MULTILINE)
+_versionadded = re.compile(r'^\s+\.\.\s+versionadded::', re.MULTILINE)
 
 class ParsedDoc(NamedTuple):
   """
@@ -116,7 +117,7 @@ def _wraps(fun: Callable, update_doc: bool = True, lax_description: str = "",
           parsed.sections['Parameters'] = (
             "Parameters\n"
             "----------\n" +
-            "\n".join(desc for p, desc in parameters.items()
+            "\n".join(_versionadded.split(desc)[0].rstrip() for p, desc in parameters.items()
                       if p in op.__code__.co_varnames)
           )
 


### PR DESCRIPTION
This strips the `.. versionadded::` tag and everything that follows it within each parameter description. These tags have always been confusing in wrapped JAX docs, becuase they refer to the version of numpy/scipy rather than the version of JAX.

Before:
```
>>> print(jnp.sum.__doc__)
Sum of array elements over a given axis.

LAX-backend implementation of :func:`sum`.

*Original docstring below.*

Parameters
----------
a : array_like
    Elements to sum.
axis : None or int or tuple of ints, optional
    Axis or axes along which a sum is performed.  The default,
    axis=None, will sum all of the elements of the input array.  If
    axis is negative it counts from the last to the first axis.

    .. versionadded:: 1.7.0

    If axis is a tuple of ints, a sum is performed on all of the axes
    specified in the tuple instead of a single axis or all the axes as
    before.
dtype : dtype, optional
    <...>
```

After
```
>>> print(jnp.sum.__doc__)
Sum of array elements over a given axis.

LAX-backend implementation of :func:`sum`.

*Original docstring below.*

Parameters
----------
a : array_like
    Elements to sum.
axis : None or int or tuple of ints, optional
    Axis or axes along which a sum is performed.  The default,
    axis=None, will sum all of the elements of the input array.  If
    axis is negative it counts from the last to the first axis.
dtype : dtype, optional
    <...>
```