### PR TITLE
Improve nested pmap error message.

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -846,11 +846,19 @@ def parallel_callable(fun: lu.WrappedFun,
   else:
     if num_local_shards != len(local_devices):
       local_devices_str = ", ".join(map(str, local_devices))
-      raise ValueError(
-          "Leading axis size of input to pmapped function must equal the "
-          "number of local devices passed to pmap. Got axis_size=%d, "
-          "num_local_devices=%d.\n(Local devices passed to pmap: %s)"
-          % (axis_size, len(local_devices), local_devices_str))
+      if num_local_shards == axis_size:
+        raise ValueError(
+            f"Leading axis size of input to pmapped function must equal the "
+            f"number of local devices passed to pmap. Got axis_size="
+            f"{axis_size}, num_local_devices={len(local_devices)}.\n(Local "
+            f"devices available to pmap: {local_devices_str})")
+      else:
+        raise ValueError(
+            f"pmapped function requires {num_local_shards} local devices to "
+            f"run due to nested pmapped or other parallel functions, but only "
+            f"{len(local_devices)} are available.\n(outer axis size: "
+            f"{axis_size}, local devices available to pmap: "
+            f"{local_devices_str})")
     if num_global_shards != len(devices):
       raise ValueError("compiling computation that creates %s shards, "
                        "but %s devices were specified" %

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1954,6 +1954,17 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
         r"num_local_devices=\d."):
       f(jnp.ones(xla_bridge.device_count() + 1))
 
+  def testBadAxisSizeErrorNested(self):
+    f = pmap(pmap(lambda x: lax.psum(x, ('i', 'j')),
+                  axis_name='j'),
+             axis_name='i',
+             devices=[jax.local_devices()[0]])
+    with self.assertRaisesRegex(
+        ValueError,
+        r"pmapped function requires 4 local devices to run due to nested "
+        r"pmapped or other parallel functions, but only 1 are available."):
+      f(jnp.ones((1, 4)))
+
   def testNestedPmaps(self):
     if xla_bridge.device_count() % 2 != 0:
       raise SkipTest


### PR DESCRIPTION
It currently gives a misleading error message in the case of nested pmaps without this change.