### PR TITLE
Replace `host_id` with `process_index` terminology.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     keyword arguments. A new `static_argnames` option has been added to specify
     keyword arguments as static.
 * Breaking changes:
+  * The following function names have changed. There are still aliases, so this
+    should not break existing code, but the aliases will eventually be removed
+    so please change your code.
+    * `host_id` --> {func}`~jax.process_index`
+    * `host_count` --> {func}`~jax.process_count`
+    * `host_ids` --> `range(jax.process_count())`
+  * Similarly, the argument to {func}`~jax.local_devices` has been renamed from
+    `host_id` to `process_index`.
   * Arguments to {func}`jax.jit` other than the function are now marked as
     keyword-only. This change is to prevent accidental breakage when arguments
     are added to `jit`.

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -77,11 +77,10 @@ Parallelization (:code:`pmap`)
     pmap
     devices
     local_devices
-    host_id
-    host_ids
+    process_index
     device_count
     local_device_count
-    host_count
+    process_count
 
 
 .. autofunction:: jit
@@ -124,8 +123,7 @@ Parallelization (:code:`pmap`)
 .. autofunction:: pmap
 .. autofunction:: devices
 .. autofunction:: local_devices
-.. autofunction:: host_id
-.. autofunction:: host_ids
+.. autofunction:: process_index
 .. autofunction:: device_count
 .. autofunction:: local_device_count
-.. autofunction:: host_count
+.. autofunction:: process_count

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -82,6 +82,8 @@ from ._src.api import (
   named_call,
   partial,  # TODO(phawkins): update callers to use functools.partial.
   pmap,
+  process_count,
+  process_index,
   pxla,  # TODO(phawkins): update users to avoid this.
   remat,
   shapecheck,

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -62,8 +62,8 @@ from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 # Unused imports to be exported
 from ..lib.xla_bridge import (device_count, local_device_count, devices,
-                              local_devices, host_id, host_ids, host_count,
-                              default_backend)
+                              local_devices, process_index, process_count,
+                              host_id, host_ids, host_count, default_backend)
 from ..core import ConcreteArray, ShapedArray, raise_to_shaped
 from ..interpreters import partial_eval as pe
 from ..interpreters import xla
@@ -1372,20 +1372,20 @@ def pmap(
     :py:func:`pmap` compiles ``fun``, so while it can be combined with
     :py:func:`jit`, it's usually unnecessary.
 
-  **Multi-host platforms:** On multi-host platforms such as TPU pods,
+  **Multi-process platforms:** On multi-process platforms such as TPU pods,
   :py:func:`pmap` is designed to be used in SPMD Python programs, where every
-  host is running the same Python code such that all hosts run the same pmapped
-  function in the same order. Each host should still call the pmapped function
-  with mapped axis size equal to the number of *local* devices (unless
+  process is running the same Python code such that all processes run the same
+  pmapped function in the same order. Each process should still call the pmapped
+  function with mapped axis size equal to the number of *local* devices (unless
   ``devices`` is specified, see below), and an array of the same leading axis
   size will be returned as usual. However, any collective operations in ``fun``
   will be computed over *all* participating devices, including those on other
-  hosts, via device-to-device communication.  Conceptually, this can be thought
-  of as running a pmap over a single array sharded across hosts, where each host
-  "sees" only its local shard of the input and output. The SPMD model requires
-  that the same multi-host pmaps must be run in the same order on all devices,
-  but they can be interspersed with arbitrary operations running on a single
-  host.
+  processes, via device-to-device communication.  Conceptually, this can be
+  thought of as running a pmap over a single array sharded across processes,
+  where each process "sees" only its local shard of the input and output. The
+  SPMD model requires that the same multi-process pmaps must be run in the same
+  order on all devices, but they can be interspersed with arbitrary operations
+  running in a single process.
 
   Args:
     fun: Function to be mapped over argument axes. Its arguments and return
@@ -1519,26 +1519,26 @@ def pmap(
   >>> print(doubly_normed.sum((0, 1)))  # doctest: +SKIP
   1.0
 
-  On multi-host platforms, collective operations operate over all devices,
-  including those on other hosts. For example, assuming the following code runs
-  on two hosts with 4 XLA devices each:
+  On multi-process platforms, collective operations operate over all devices,
+  including those on other processes. For example, assuming the following code
+  runs on two processes with 4 XLA devices each:
 
   >>> f = lambda x: x + jax.lax.psum(x, axis_name='i')
-  >>> data = jnp.arange(4) if jax.host_id() == 0 else jnp.arange(4, 8)
+  >>> data = jnp.arange(4) if jax.process_index() == 0 else jnp.arange(4, 8)
   >>> out = pmap(f, axis_name='i')(data)  # doctest: +SKIP
   >>> print(out)  # doctest: +SKIP
-  [28 29 30 31] # on host 0
-  [32 33 34 35] # on host 1
+  [28 29 30 31] # on process 0
+  [32 33 34 35] # on process 1
 
-  Each host passes in a different length-4 array, corresponding to its 4 local
-  devices, and the psum operates over all 8 values. Conceptually, the two
+  Each process passes in a different length-4 array, corresponding to its 4
+  local devices, and the psum operates over all 8 values. Conceptually, the two
   length-4 arrays can be thought of as a sharded length-8 array (in this example
-  equivalent to jnp.arange(8)) that is mapped over, with the length-8 mapped axis
-  given name 'i'. The pmap call on each host then returns the corresponding
-  length-4 output shard.
+  equivalent to jnp.arange(8)) that is mapped over, with the length-8 mapped
+  axis given name 'i'. The pmap call on each process then returns the
+  corresponding length-4 output shard.
 
   The ``devices`` argument can be used to specify exactly which devices are used
-  to run the parallel computation. For example, again assuming a single host
+  to run the parallel computation. For example, again assuming a single process
   with 8 devices, the following code defines two parallel computations, one
   which runs on the first six devices and one on the remaining two:
 
@@ -1556,9 +1556,9 @@ def pmap(
   >>> print(f2(jnp.array([2., 3.])))  # doctest: +SKIP
   [ 13.  13.]
   """
-  # axis_size is an optional integer representing the global axis size.
-  # The aggregate size (across all hosts) size of the mapped axis must match
-  # the given value.
+  # axis_size is an optional integer representing the global axis size.  The
+  # aggregate size (across all processes) size of the mapped axis must match the
+  # given value.
 
   _check_callable(fun)
   axis_name = core._TempAxisName(fun) if axis_name is None else axis_name

--- a/jax/api.py
+++ b/jax/api.py
@@ -54,4 +54,3 @@ from jax._src.api import (
   _std_basis,
   _unravel_array_into_pytree,
 )
-

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -683,7 +683,7 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
         f"compiling computation that requires {nreps} replicas, but only "
         f"{xb.device_count(backend)} XLA devices are available")
 
-  if xb.host_count() > 1 and (nreps > 1 or jaxpr_has_pmap(jaxpr)):
+  if xb.process_count() > 1 and (nreps > 1 or jaxpr_has_pmap(jaxpr)):
     raise NotImplementedError(
         "jit of multi-host pmap not implemented (and jit-of-pmap can cause "
         "extra data movement anyway, so maybe you don't want it after all).")

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -51,7 +51,7 @@ class XlaBridgeTest(absltest.TestCase):
 
   def test_local_devices(self):
     self.assertNotEmpty(xb.local_devices())
-    with self.assertRaisesRegex(ValueError, "Unknown host_id 100"):
+    with self.assertRaisesRegex(ValueError, "Unknown process_index 100"):
       xb.local_devices(100)
     with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
       xb.local_devices(backend="foo")


### PR DESCRIPTION
We're switching to the new terminology to avoid confusion in cases
where multiple jax processes are running on a single host, and each
process has a unique process_index/host_id.
    
This keeps aliases for the old `host_id` APIs for now, but these will
eventually be removed.