### PR TITLE
add more options for jax_default_matmul_precision

### DIFF
--- a/jax/config.py
+++ b/jax/config.py
@@ -420,7 +420,9 @@ numpy_rank_promotion = config.define_enum_state(
 
 default_matmul_precision = config.define_enum_state(
     name='jax_default_matmul_precision',
-    enum_values=['bfloat16', 'tensorfloat32', 'float32'],
+    enum_values=['bfloat16', 'fastest',
+                 'tensorfloat32', 'bfloat16_3x',
+                 'float32', 'highest'],
     default=None,
     help=('Control the default matmul and conv precision for 32bit inputs.\n\n'
 
@@ -436,5 +438,6 @@ default_matmul_precision = config.define_enum_state(
           'level for computations involved in matrix multiplication and '
           'convolution on 32bit inputs. The levels roughly describe the '
           "precision at which scalar products are computed. The 'bfloat16' "
-          "option is the fastest and least precise; 'float32' is similar to "
-          "full float32 precision; 'tensorfloat32' is intermediate.\n\n"))
+          "option is the fastest and least precise (alias: 'fastest'); "
+          "'float32' is similar to full float32 precision (alias: 'highest'); "
+          "'tensorfloat32' is intermediate (alias: 'bfloat16_3x').\n\n"))


### PR DESCRIPTION
This PR adds three aliases to the jax_default_matmul_precision enum options.

Currently (and in #6143) 'tensorfloat32' means the same thing as 'bfloat16_3x', but I think @hawkinsp may not like that. Now's our chance to make it right! WDYT?