### PR TITLE
CI: quick fix for disable omnistaging test

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -59,10 +59,11 @@ jobs:
             package-overrides: "numpy==1.16.4 scipy==1.2.1"
             num_generated_cases: 10
           - name-prefix: "without omnistaging"
+            # TODO: rename or remove this test
             python-version: 3.7
             os: ubuntu-latest
             enable-x64: 0
-            enable-omnistaging: 0
+            enable-omnistaging: 1
             package-overrides: "none"
             num_generated_cases: 8
     steps:


### PR DESCRIPTION
#6196 made `disable_omnistaging` a no-op, but the CI test was still checking outputs as if omnistaging were still being disabled, leading to timeouts. This is a quick band-aid to make CI pass again.

I think this will solve the failures we're seeing in #6189