### PR TITLE
Allow integer inputs/outputs of linear_transpose

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1126,11 +1126,17 @@ class APITest(jtu.JaxTestCase):
     z, = transpose_fun(y)
     self.assertArraysEqual(2 * y, z, check_dtypes=True)
 
+  def test_linear_transpose_integer(self):
+    f = lambda x: 2 * x
+    transpose = api.linear_transpose(f, 1)
+    actual, = transpose(3)
+    expected = 6
+    self.assertEqual(actual, expected)
+
   def test_linear_transpose_error(self):
     with self.assertRaisesRegex(
-        TypeError, "linear_transpose only supports float and complex inputs"):
-      api.linear_transpose(lambda x: x, 1)
-
+        TypeError, "linear_transpose only supports"):
+      api.linear_transpose(lambda x: 2. * x, 1)
     transpose_fun = api.linear_transpose(lambda x: [x, x], 1.0)
     with self.assertRaisesRegex(TypeError, "cotangent tree does not match"):
       transpose_fun(1.0)


### PR DESCRIPTION
I don't think disallowing integers in linear_transpose should be necessary (at risk of coming across as a nerd: I think they're a special case of the transpose of a module homomorphism 🤓, so mathematically well defined, see the definition of 'transpose' here: https://en.wikipedia.org/wiki/Module_homomorphism#Operations). 

The transpose rules haven't been tested on integers and there might be situations where we get silent failures ... If this change is deemed to be mergeable in principle, then I can implement such tests and add them to this PR.