### PR TITLE
simplify public lax.convert_element_type api

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -266,7 +266,7 @@ def _promote_dtypes(*args):
   else:
     to_dtype, weak_type = dtypes._lattice_result_type(*args)
     to_dtype = dtypes.canonicalize_dtype(to_dtype)
-    return [lax.convert_element_type(x, to_dtype, weak_type) for x in args]
+    return [lax._convert_element_type(x, to_dtype, weak_type) for x in args]
 
 def _promote_dtypes_inexact(*args):
   """Convenience function to apply Numpy argument dtype promotion.
@@ -276,7 +276,7 @@ def _promote_dtypes_inexact(*args):
   to_dtype = dtypes.canonicalize_dtype(to_dtype)
   to_dtype_inexact = _to_inexact_dtype(to_dtype)
   weak_type = (weak_type and to_dtype == to_dtype_inexact)
-  return [lax.convert_element_type(x, to_dtype_inexact, weak_type) for x in args]
+  return [lax._convert_element_type(x, to_dtype_inexact, weak_type) for x in args]
 
 def _to_inexact_dtype(dtype):
   """Promotes a dtype into an inexact dtype, if it is not already one."""
@@ -2922,7 +2922,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 
-  out = lax.convert_element_type(out, dtype, weak_type=weak_type)
+  out = lax._convert_element_type(out, dtype, weak_type=weak_type)
 
   if ndmin > ndim(out):
     out = lax.broadcast(out, (1,) * (ndmin - ndim(out)))

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -94,6 +94,7 @@ from jax._src.lax.lax import (
   conv_transpose_shape_tuple,
   conv_with_general_padding,
   convert_element_type,
+  _convert_element_type,
   convert_element_type_p,
   cos,
   cos_p,

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -340,7 +340,7 @@ class TestPromotionTables(jtu.JaxTestCase):
   )
   def testUnaryPromotion(self, dtype, weak_type):
     # Regression test for https://github.com/google/jax/issues/6051
-    x = lax.convert_element_type(0, dtype, weak_type=weak_type)
+    x = lax._convert_element_type(0, dtype, weak_type=weak_type)
     y = jnp.array(0, dtype=dtypes.result_type(x))
     assert x.dtype == y.dtype
 
@@ -352,7 +352,7 @@ class TestPromotionTables(jtu.JaxTestCase):
   )
   def testBinaryNonPromotion(self, dtype, weak_type):
     # Regression test for https://github.com/google/jax/issues/6051
-    x = lax.convert_element_type(0, dtype, weak_type=weak_type)
+    x = lax._convert_element_type(0, dtype, weak_type=weak_type)
     y = (x + x)
     assert x.dtype == y.dtype
     assert dtypes.is_weakly_typed(y) == dtypes.is_weakly_typed(x)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2857,7 +2857,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     if numpy_version < (1, 19) and out_shape == ():
       raise SkipTest("Numpy < 1.19 treats out_shape=() like out_shape=None")
     rng = jtu.rand_default(self.rng())
-    x = lax.convert_element_type(rng(shape, in_dtype), weak_type=weak_type)
+    x = lax._convert_element_type(rng(shape, in_dtype), weak_type=weak_type)
     fun = lambda x: getattr(jnp, func)(x, *args, dtype=out_dtype, shape=out_shape)
     expected_weak_type = weak_type and (out_dtype is None)
     self.assertEqual(dtypes.is_weakly_typed(fun(x)), expected_weak_type)
@@ -2889,7 +2889,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for slc in [slice(None), slice(0), slice(3), 0, ...]))
   def testSliceWeakTypes(self, shape, dtype, weak_type, slc):
     rng = jtu.rand_default(self.rng())
-    x = lax.convert_element_type(rng(shape, dtype), weak_type=weak_type)
+    x = lax._convert_element_type(rng(shape, dtype), weak_type=weak_type)
     op = lambda x: x[slc]
     self.assertEqual(op(x).aval.weak_type, weak_type)
     self.assertEqual(api.jit(op)(x).aval.weak_type, weak_type)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -217,7 +217,7 @@ class LaxTest(jtu.JaxTestCase):
   def testConvertElementType(self, from_dtype, to_dtype, weak_type):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng((2, 3), from_dtype)]
-    op = lambda x: lax.convert_element_type(x, to_dtype, weak_type)
+    op = lambda x: lax._convert_element_type(x, to_dtype, weak_type)
     self._CompileAndCheck(op, args_maker)
 
     x = rng((1,), from_dtype)
@@ -272,7 +272,8 @@ class LaxTest(jtu.JaxTestCase):
       for weak_type in [True, False]))
   def testBitcastConvertWeakType(self, from_dtype, to_dtype, weak_type):
     rng = jtu.rand_default(self.rng())
-    x_in = lax.convert_element_type(rng((2, 3), from_dtype), weak_type=weak_type)
+    x_in = lax._convert_element_type(rng((2, 3), from_dtype),
+                                     weak_type=weak_type)
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
     x_out = op(x_in)
@@ -1535,8 +1536,8 @@ class LaxTest(jtu.JaxTestCase):
       for init_weak_type in [True, False]))
   def testReduceWeakType(self, op_namespace, op, arr_weak_type, init_weak_type):
     op = getattr(op_namespace, op)
-    arr = lax.convert_element_type(np.arange(10), int, weak_type=arr_weak_type)
-    init = lax.convert_element_type(1, int, weak_type=init_weak_type)
+    arr = lax._convert_element_type(np.arange(10), int, weak_type=arr_weak_type)
+    init = lax._convert_element_type(1, int, weak_type=init_weak_type)
     fun = lambda arr, init: lax.reduce(arr, init, op, (0,))
     out = fun(arr, init)
     self.assertEqual(dtypes.is_weakly_typed(out), arr_weak_type and init_weak_type)
@@ -2309,7 +2310,7 @@ class LaxTest(jtu.JaxTestCase):
     if dtype in set(python_scalar_types):
       val = dtype(0)
     else:
-      val = lax.convert_element_type(0, dtype, weak_type=weak_type)
+      val = lax._convert_element_type(0, dtype, weak_type=weak_type)
 
     const = lax._const(val, 0)
     self.assertEqual(dtypes.result_type(val), dtypes.result_type(const))
@@ -2445,7 +2446,7 @@ class LazyConstantTest(jtu.JaxTestCase):
       for weak_type in [True, False]))
   def testArgMinMaxWeakType(self, jax_fn, weak_type):
     op = lambda x: jax_fn(x, axis=0, index_dtype=np.int32)
-    x_in = lax.convert_element_type(np.ones((2, 2)), weak_type=weak_type)
+    x_in = lax._convert_element_type(np.ones((2, 2)), weak_type=weak_type)
     self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
     x_out = op(x_in)
     self.assertEqual(dtypes.is_weakly_typed(x_out), False)


### PR DESCRIPTION
Specifically:
1. don't expose weak_type in the public api, as it's jax-internal
2. don't make new_dtype optional, which could make bugs easier to write

This change keeps the public API simpler, and also makes convert_element_type match the ConvertElementType HLO. As an internal API we can call `lax._convert_element_type` just like before.