### PR TITLE
X32 mode: raise OverflowError for large integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     for more information.
   * Python integers larger than the maximum `int64` value will now lead to an overflow
     in all cases, rather than being silently converted to `uint64` in some cases ({jax-issue}`#6047`).
+  * Outside X64 mode, Python integers outside the range representable by `int32` will now lead to an
+    `OverflowError` rather than having their value silently truncated.
 * Bug fixes:
   * `host_callback` now supports empty arrays in arguments and results ({jax-issue}`#6262`).
 

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -121,8 +121,7 @@ def _scalar_type_to_dtype(typ: type, value: Any = None):
   ---------------------------------------------------------------------------
   OverflowError: Python int 9223372036854775808 too large to convert to int64
   """
-  dtype = python_scalar_dtypes[typ]
-  # TODO(jakevdp): use proper overflow for int32.
+  dtype = canonicalize_dtype(python_scalar_dtypes[typ])
   if typ is int and value is not None:
     if value < np.iinfo(dtype).min or value > np.iinfo(dtype).max:
       raise OverflowError(f"Python int {value} too large to convert to {dtype}")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3275,17 +3275,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp.array(3, [('a','<i4'),('b','<i4')])
 
   def testArrayFromInteger(self):
-    # TODO(jakevdp): implement X32 overflow and canonicalize these
-    int_max = jnp.iinfo(jnp.int64).max
-    int_min = jnp.iinfo(jnp.int64).min
+    int_dtype = dtypes.canonicalize_dtype(jnp.int64)
+    int_max = jnp.iinfo(int_dtype).max
+    int_min = jnp.iinfo(int_dtype).min
 
     # Values at extremes are converted correctly.
     for val in [int_min, 0, int_max]:
-      self.assertEqual(jnp.array(val).dtype, dtypes.canonicalize_dtype('int64'))
+      self.assertEqual(jnp.array(val).dtype, int_dtype)
 
     # out of bounds leads to an OverflowError
     val = int_max + 1
-    with self.assertRaisesRegex(OverflowError, f"Python int {val} too large to convert to int64"):
+    with self.assertRaisesRegex(OverflowError, f"Python int {val} too large to convert to {int_dtype.name}"):
       jnp.array(val)
 
     # explicit uint64 should work

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -946,6 +946,9 @@ class LaxRandomTest(jtu.JaxTestCase):
     ]
   ))
   def test_prng_seeds_and_keys(self, seed, type, jit, key):
+    if (jit and type is int and not config.x64_enabled and
+        (seed < np.iinfo('int32').min or seed > np.iinfo('int32').max)):
+      self.skipTest("Expected failure: integer out of range for jit.")
     seed = type(seed)
     if jit:
       actual = api.jit(random.PRNGKey)(seed)
@@ -960,6 +963,8 @@ class LaxRandomTest(jtu.JaxTestCase):
       for seed in [-1, 0, 1, (1 << 32) - 1, (1 << 63) - 1, np.uint64((1 << 64) - 1)]))
   def test_prng_jit_invariance(self, seed, type):
     if type == "int" and seed == (1 << 64) - 1:
+      self.skipTest("Expected failure: Python int too large.")
+    if not config.x64_enabled and seed > np.iinfo(np.int32).max:
       self.skipTest("Expected failure: Python int too large.")
     type = {"int": int, "np.array": np.array, "jnp.array": jnp.array}[type]
     args_maker = lambda: [type(seed)]


### PR DESCRIPTION
Followup to #6047; Fixes #5952

This contains the Python-side changes; C++ changes will have to be made separately.

One note: this breaks jit invariance in PRNGKey code in X32 mode, in the sense that when jit-compiled the JIT dispatch will show an overflow error for large Python integers where the non-jit-compiled version will not. For example:
```python
In [1]: from jax import random, jit

In [2]: random.PRNGKey(hash('hello'))
Out[2]: DeviceArray([       0, 39538479], dtype=uint32)

In [3]: jit(random.PRNGKey)(hash('hello'))
---------------------------------------------------------------------------
OverflowError: Python int -8366683158282023121 too large to convert to int32
```
I opted to not raise an error in the first case because this is a common pattern used for initializing random states in downstream dependencies, and it is rarely used in the second manner.