### PR TITLE
BUG: ensure that explicit conversion to uint64 does not overflow

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2892,7 +2892,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
 
   if _can_call_numpy_array(object):
     if dtypes.is_python_scalar(object):
-      object = dtypes.coerce_to_array(object)
+      object = dtypes.coerce_to_array(object, dtype)
     # TODO(jakevdp): falling back to numpy here fails to overflow for lists containing
     # large integers; see discussion in https://github.com/google/jax/pull/6047.
     object = _np_array(object, dtype=dtype, ndmin=ndmin, copy=False)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -129,16 +129,14 @@ def _scalar_type_to_dtype(typ: type, value: Any = None):
   return dtype
 
 
-def coerce_to_array(x):
+def coerce_to_array(x, dtype=None):
   """Coerces a scalar or NumPy array to an np.array.
 
   Handles Python scalar type promotion according to JAX's rules, not NumPy's
   rules.
   """
-  if type(x) in python_scalar_dtypes:
+  if dtype is None and type(x) in python_scalar_dtypes:
     dtype = _scalar_type_to_dtype(type(x), x)
-  else:
-    dtype = None
   return np.asarray(x, dtype)
 
 iinfo = np.iinfo

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3288,6 +3288,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(OverflowError, f"Python int {val} too large to convert to int64"):
       jnp.array(val)
 
+    # explicit uint64 should work
+    if config.x64_enabled:
+      self.assertEqual(val, jnp.array(val, dtype='uint64'))
+
   # TODO(jakevdp): fix list inputs to jnp.array and enable the following test
   # def testArrayFromList(self):
   #   int_max = jnp.iinfo(jnp.int64).max


### PR DESCRIPTION
I overlooked this case in #6047