### PR TITLE
Test: add test of random.fold_in for large integers

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -714,6 +714,12 @@ class LaxRandomTest(jtu.JaxTestCase):
     keys = [random.fold_in(key, i) for i in range(10)]
     assert np.unique(np.ravel(keys)).shape == (20,)
 
+  def testFoldInBig(self):
+    key = random.PRNGKey(0)
+    seeds = [2 ** 32 - 2, 2 ** 32 - 1]
+    keys = [random.fold_in(key, seed) for seed in seeds]
+    assert np.unique(np.ravel(keys)).shape == (4,)
+
   def testStaticShapeErrors(self):
     if config.jax_disable_jit:
       raise SkipTest("test only relevant when jit enabled")


### PR DESCRIPTION
Why? This is the [documented behavior](https://github.com/google/jax/blob/5eb07c1b4acd099ff51c29b129950139dfdaf1d9/jax/_src/random.py#L276) and is depended on by downstream libraries, but I inadvertently broke this in while working on #6269 and none of our tests caught the breakage.