### PR TITLE
Progress towards static kwargs for jit

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -208,7 +208,7 @@ def prod(xs):
     out *= x
   return out
 
-class WrapHashably(object):
+class WrapHashably:
   __slots__ = ["val"]
 
   def __init__(self, val):
@@ -220,7 +220,7 @@ class WrapHashably(object):
   def __eq__(self, other):
     return self.val is other.val
 
-class Hashable(object):
+class Hashable:
   __slots__ = ["val"]
 
   def __init__(self, val):
@@ -228,6 +228,18 @@ class Hashable(object):
 
   def __hash__(self):
     return hash(self.val)
+
+  def __eq__(self, other):
+    return self.val == other.val
+
+class WrapKwArgs:
+  __slots__ = ["val"]
+
+  def __init__(self, val):
+    self.val = val
+
+  def __hash__(self):
+    return hash(tuple((k, v) for k, v in sorted(self.val.items())))
 
   def __eq__(self, other):
     return self.val == other.val

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import operator
-from typing import Any, Tuple, Union
+from typing import Any, Dict, Iterable, Tuple, Union
 
 import numpy as np
 
@@ -23,7 +23,7 @@ from .tree_util import (tree_flatten, tree_unflatten, tree_multimap,
                         tree_structure, treedef_children, treedef_is_leaf)
 from ._src.tree_util import _replace_nones
 from . import linear_util as lu
-from ._src.util import safe_map, WrapHashably, Hashable
+from ._src.util import safe_map, WrapHashably, WrapKwArgs, Hashable
 from .core import unit
 
 from ._src import traceback_util
@@ -44,6 +44,18 @@ def _ensure_index_tuple(x: Any) -> Tuple[int, ...]:
     return (operator.index(x),)
   except TypeError:
     return tuple(map(operator.index, x))
+
+def _ensure_str(x: str) -> str:
+  if not isinstance(x, str):
+    raise TypeError(f"argument is not a string: {x}")
+  return x
+
+def _ensure_str_tuple(x: Union[str, Iterable[str]]) -> Tuple[str, ...]:
+  """Convert x to a tuple of strings."""
+  if isinstance(x, str):
+    return (x,)
+  else:
+    return tuple(map(_ensure_str, x))
 
 @lu.transformation_with_aux
 def flatten_fun(in_tree, *args_flat):
@@ -88,20 +100,26 @@ def flatten_fun_nokwargs2(in_tree, *args_flat):
 
 def argnums_partial(f, dyn_argnums, args):
   dyn_argnums = _ensure_index_tuple(dyn_argnums)
-  fixed_args = tuple([unit if i in dyn_argnums else wrap_hashably(arg)
-                      for i, arg in enumerate(args)])
+  fixed_args = tuple(unit if i in dyn_argnums else wrap_hashably(arg)
+                     for i, arg in enumerate(args))
   dyn_args = tuple(args[i] for i in dyn_argnums)
   return _argnums_partial(f, dyn_argnums, fixed_args), dyn_args
 
 
 def argnums_partial_except(f: lu.WrappedFun, static_argnums: Tuple[int, ...],
-                           args: Tuple[Any]):
+                           args: Tuple[Any], *, allow_invalid: bool):
   """Version of ``argnums_partial`` that checks hashability of static_argnums."""
+  if not static_argnums:
+    return f, args
   dyn_argnums = tuple(i for i in range(len(args)) if i not in static_argnums)
   dyn_args = tuple(args[i] for i in dyn_argnums)
 
   fixed_args = [unit] * len(args)  # type: ignore
   for i in static_argnums:
+    # TODO(shoyer): set allow_invalid=True permanently after enabling
+    # static_argnames.
+    if allow_invalid and i >= len(args):
+      continue
     static_arg = args[i]
     try:
       hash(static_arg)
@@ -123,6 +141,48 @@ def _argnums_partial(dyn_argnums, fixed_args, *dyn_args, **kwargs):
     args[i] = arg
   ans = yield args, kwargs
   yield ans
+
+
+def argnames_partial(f, dyn_argnames, kwargs):
+  dyn_argnames = _ensure_str_tuple(dyn_argnames)
+  fixed_kwargs = tuple((k, unit if k in dyn_argnames else wrap_hashably(v))
+                       for k, v in kwargs.items())
+  dyn_kwargs = {k: kwargs[k] for k in dyn_argnames}
+  return _argnames_partial(f, WrapKwArgs(fixed_kwargs)), dyn_kwargs
+
+
+def argnames_partial_except(f: lu.WrappedFun, static_argnames: Tuple[str, ...],
+                            kwargs: Dict[str, Any]):
+  if not static_argnames:
+    return f, kwargs
+  dyn_kwargs = {k: v for k, v in kwargs.items() if k not in static_argnames}
+
+  fixed_kwargs: Dict[str, Any] = {}
+  for k, arg in kwargs.items():
+    if k in dyn_kwargs:
+      fixed_kwargs[k] = unit
+    else:
+      try:
+        hash(arg)
+      except TypeError:
+        raise ValueError(
+            "Non-hashable static arguments are not supported, as this can lead "
+            f"to unexpected cache-misses. Static argument (name {k}) of type "
+            f"{type(arg)} for function {f.__name__} is non-hashable.")
+      else:
+        fixed_kwargs[k] = Hashable(arg)  # type: ignore
+
+  return _argnames_partial(f, WrapKwArgs(fixed_kwargs)), dyn_kwargs
+
+
+@lu.transformation
+def _argnames_partial(fixed_kwargs: WrapKwArgs, *args, **dyn_kwargs):
+  kwargs = {k: None if arg is unit else arg.val
+            for k, arg in fixed_kwargs.val.items()}
+  kwargs.update(dyn_kwargs)
+  ans = yield args, kwargs
+  yield ans
+
 
 def donation_vector(donate_argnums, args, kwargs) -> Tuple[bool, ...]:
   """Returns a tuple with a boolean value for each leaf in args."""

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -69,7 +69,8 @@ def pjit(fun: Callable,
 
     f = lu.wrap_init(fun)
     if static_argnums:
-      f, dyn_args = argnums_partial_except(f, static_argnums, args)
+      f, dyn_args = argnums_partial_except(
+          f, static_argnums, args, allow_invalid=False)
     else:
       dyn_args = args
 


### PR DESCRIPTION
Based on #3532, but not exposed via `jax.jit` yet, while we work on the C++ implementation.

See #3532 for the description. To test it, use `jax.api._python_jit_with_static_argnames` in place of `jax.jit`.