### PR TITLE
BUG: fix reduction for scalar input

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2065,7 +2065,7 @@ def mean(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtype=None,
     else:
       normalizer = _axis_size(a, axis)
   else:
-    normalizer = sum(broadcast_to(where, a.shape), axis, dtype=dtype, keepdims=keepdims)
+    normalizer = sum(broadcast_to(where, shape(a)), axis, dtype=dtype, keepdims=keepdims)
 
   if dtype is None:
     if issubdtype(_dtype(a), bool_) or issubdtype(_dtype(a), integer):
@@ -2150,7 +2150,7 @@ def var(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtype=None,
     else:
       normalizer = _axis_size(a, axis)
   else:
-    normalizer = sum(broadcast_to(where, a.shape), axis, dtype=dtype, keepdims=keepdims)
+    normalizer = sum(broadcast_to(where, shape(a)), axis, dtype=dtype, keepdims=keepdims)
   normalizer = normalizer - ddof
 
   result = sum(centered, axis, keepdims=keepdims, where=where)


### PR DESCRIPTION
This is already covered in test cases, but failures weren't hit on github CI because of small `NUM_GENERATED_CASES`, and weren't being hit internally because of a skip based on the numpy version.
Before:
```python
>>> jnp.mean(1, where=True)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-303228f5760a> in <module>
----> 1 jnp.mean(1, where=True)

~/github/google/jax/jax/_src/numpy/lax_numpy.py in mean(a, axis, dtype, out, keepdims, where)
   2066       normalizer = _axis_size(a, axis)
   2067   else:
-> 2068     normalizer = sum(broadcast_to(where, a.shape), axis, dtype=dtype, keepdims=keepdims)
   2069 
   2070   if dtype is None:

AttributeError: 'int' object has no attribute 'shape'
```
After:
```python
>>> jnp.mean(1, where=True)
DeviceArray(1., dtype=float32)
```
Discovered in the course of fixing #6290