### PR TITLE
Py38 docs fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/jax.profiler.rst
+++ b/docs/jax.profiler.rst
@@ -34,3 +34,13 @@ profiling features.
 
   device_memory_profile
   save_device_memory_profile
+
+Deprecated functions
+--------------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+  trace_function
+  TraceContext
+  StepTraceContext

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1928,10 +1928,12 @@ def _isposneginf(infinity, x, out):
     return full_like(x, False, dtype=bool_)
 
 isposinf = _wraps(np.isposinf, skip_params=['out'])(
-  lambda x, out=None: _isposneginf(inf, x, out))
+  lambda x, out=None: _isposneginf(inf, x, out)
+)
 
 isneginf = _wraps(np.isneginf, skip_params=['out'])(
-  lambda x, out=None: _isposneginf(-inf, x, out))
+  lambda x, out=None: _isposneginf(-inf, x, out)
+)
 
 @_wraps(np.isnan)
 def isnan(x):

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -21,6 +21,7 @@ _parameter_break = re.compile("\n(?=[A-Za-z_])")
 _section_break = re.compile(r"\n(?=[^\n]{3,15}\n-{3,15})", re.MULTILINE)
 _numpy_signature_re = re.compile(r'^([\w., ]+=)?\s*[\w\.]+\([\w\W]*?\)$', re.MULTILINE)
 _versionadded = re.compile(r'^\s+\.\.\s+versionadded::', re.MULTILINE)
+_docreference = re.compile(r':doc:`(.*?)\s*<.*?>`')
 
 class ParsedDoc(NamedTuple):
   """
@@ -47,6 +48,10 @@ def _parse_numpydoc(docstr: Optional[str]) -> ParsedDoc:
   """
   if docstr is None or not docstr.strip():
     return ParsedDoc(docstr)
+
+  # Remove any :doc: directives in the docstring to avoid sphinx errors
+  docstr = _docreference.sub(
+    lambda match: f"{match.groups()[0]}", docstr)
 
   signature, body = "", docstr
   match = _numpy_signature_re.match(body)


### PR DESCRIPTION
Fixes #6252, and updates our readthedocs build to use Python 3.8

To be merged after #6318