### PR TITLE
Run doctest on all source files except jax2tf

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -143,4 +143,4 @@ jobs:
     - name: Test documentation
       run: |
         pytest -n 1 docs
-        pytest -n 1 --doctest-modules jax/api.py jax/_src/errors.py
+        pytest -n 1 --doctest-modules --ignore=jax/experimental/jax2tf jax

--- a/conftest.py
+++ b/conftest.py
@@ -11,3 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""pytest configuration"""
+
+import jax
+import numpy
+import os
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def add_imports(doctest_namespace):
+  doctest_namespace["jax"] = jax
+  doctest_namespace["lax"] = jax.lax
+  doctest_namespace["jnp"] = jax.numpy
+  doctest_namespace["np"] = numpy
+
+
+@pytest.fixture(autouse=True)
+def spoof_devices(doctest_namespace):
+  # Set up runtime to mimic an 8-core machine
+  flags = os.environ.get('XLA_FLAGS', '')
+  os.environ['XLA_FLAGS'] = flags + " --xla_force_host_platform_device_count=8"

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2403,7 +2403,7 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
   Example 1: partial sums of an array of numbers:
 
   >>> lax.associative_scan(jnp.add, jnp.arange(0, 4))
-  [ 0, 1, 3, 6]
+  DeviceArray([0, 1, 3, 6], dtype=int32)
 
   Example 2: partial products of an array of matrices
 
@@ -2415,7 +2415,7 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
   Example 3: reversed partial sums of an array of numbers
 
   >>> lax.associative_scan(jnp.add, jnp.arange(0, 4), reverse=True)
-  [ 6, 6, 5, 3]
+  DeviceArray([6, 6, 5, 3], dtype=int32)
 
   .. [BLE1990] Blelloch, Guy E. 1990. "Prefix Sums and Their Applications.",
     Technical Report CMU-CS-90-190, School of Computer Science, Carnegie Mellon

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1568,11 +1568,11 @@ def stop_gradient(x):
   For example:
 
   >>> jax.grad(lambda x: x**2)(3.)
-  array(6., dtype=float32)
+  DeviceArray(6., dtype=float32)
   >>> jax.grad(lambda x: jax.lax.stop_gradient(x)**2)(3.)
   array(0., dtype=float32)
   >>> jax.grad(jax.grad(lambda x: x**2))(3.)
-  array(2., dtype=float32)
+  DeviceArray(2., dtype=float32)
   >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
   array(0., dtype=float32)
   """

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -73,7 +73,7 @@ def psum(x, axis_name, *, axis_index_groups=None):
   [6 6 6 6]
   >>> y = jax.pmap(lambda x: x / jax.lax.psum(x, 'i'), axis_name='i')(x)
   >>> print(y)
-  [ 0.          0.16666667  0.33333334  0.5       ]
+  [0.         0.16666667 0.33333334 0.5       ]
   """
   if not isinstance(axis_name, (tuple, list)):
     axis_name = (axis_name,)
@@ -111,10 +111,10 @@ def pmean(x, axis_name, *, axis_index_groups=None):
   >>> x = np.arange(4)
   >>> y = jax.pmap(lambda x: jax.lax.pmean(x, 'i'), axis_name='i')(x)
   >>> print(y)
-  [ 1.5         1.5         1.5         1.5       ]
+  [1.5 1.5 1.5 1.5]
   >>> y = jax.pmap(lambda x: x / jax.lax.pmean(x, 'i'), axis_name='i')(x)
   >>> print(y)
-  [ 0.          0.66666667  1.33333334  2.0       ]
+  [0.        0.6666667 1.3333334 2.       ]
   """
   x = psum(x, axis_name=axis_name, axis_index_groups=axis_index_groups)
   n = psum(1, axis_name=axis_name, axis_index_groups=axis_index_groups)
@@ -1024,21 +1024,23 @@ def all_gather(x, axis_name, *, axis_index_groups=None):
 
   >>> x = np.arange(16).reshape(4, 4)
   >>> print(x)
-  [[ 0.  1.  2.  3.]
-   [ 4.  5.  6.  7.]
-   [ 8.  9. 10. 11.]
-   [12. 13. 14. 15.]]
-  >>> y = jax.pmap(lambda x: jax.lax.all_gather(
-  ... x, 'i', axis_index_groups=[[0, 2], [3, 1]]))(x)
+    [[ 0  1  2  3]
+     [ 4  5  6  7]
+     [ 8  9 10 11]
+     [12 13 14 15]]
+  >>> def f(x):
+  ...   return jax.lax.all_gather(
+  ...       x, 'i', axis_index_groups=[[0, 2], [3, 1]])
+  >>> y = jax.pmap(f, axis_name='i')(x)
   >>> print(y)
-  [[[ 0.  1.  2.  3.]
-    [ 8.  9. 10. 11.]]
-   [[12. 13. 14. 15.]
-    [ 4.  5.  6.  7.]]
-   [[ 0.  1.  2.  3.]
-    [ 8.  9. 10. 11.]]
-   [[12. 13. 14. 15.]
-    [ 4.  5.  6.  7.]]
+  [[[ 0  1  2  3]
+    [ 8  9 10 11]]
+   [[12 13 14 15]
+    [ 4  5  6  7]]
+   [[ 0  1  2  3]
+    [ 8  9 10 11]]
+   [[12 13 14 15]
+    [ 4  5  6  7]]]
   """
   axis_size = psum(1, axis_name, axis_index_groups=axis_index_groups)
   bind = partial(all_gather_p.bind, all_gather_dimension=0,

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -61,15 +61,16 @@ is value dependent.
 
 The general implementation can therefore not be transformed with jit.
 If the coefficients are guaranteed to have no leading zeros, use the
-keyword argument `strip_zeros=False` to get a jit-compatible variant::
+keyword argument `strip_zeros=False` to get a jit-compatible variant:
 
-    >>> roots_unsafe = jax.jit(functools.partial(jnp.roots, strip_zeros=False))
-    >>> roots_unsafe([1, 2])     # ok
-    DeviceArray([-2.+0.j], dtype=complex64)
-    >>> roots_unsafe([0, 1, 2])  # problem
-    DeviceArray([nan+nanj, nan+nanj], dtype=complex64)
-    >>> jnp.roots([0, 1, 2])         # use the no-jit version instead
-    DeviceArray([-2.+0.j], dtype=complex64)
+>>> from functools import partial
+>>> roots_unsafe = jax.jit(partial(jnp.roots, strip_zeros=False))
+>>> roots_unsafe([1, 2])     # ok
+DeviceArray([-2.+0.j], dtype=complex64)
+>>> roots_unsafe([0, 1, 2])  # problem
+DeviceArray([nan+nanj, nan+nanj], dtype=complex64)
+>>> jnp.roots([0, 1, 2])     # use the no-jit version instead
+DeviceArray([-2.+0.j], dtype=complex64)
 """)
 def roots(p, *, strip_zeros=True):
   # ported from https://github.com/numpy/numpy/blob/v1.17.0/numpy/lib/polynomial.py#L168-L251

--- a/jax/_src/numpy/vectorize.py
+++ b/jax/_src/numpy/vectorize.py
@@ -209,22 +209,21 @@ def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
     Vectorized version of the given function.
 
   Here a few examples of how one could write vectorized linear algebra routines
-  using :func:`vectorize`::
+  using :func:`vectorize`:
 
-    import jax.numpy as jnp
-    from functools import partial
+  >>> from functools import partial
 
-    @partial(jnp.vectorize, signature='(k),(k)->(k)')
-    def cross_product(a, b):
-      assert a.shape == b.shape and a.ndim == b.ndim == 1
-      return jnp.array([a[1] * b[2] - a[2] * b[1],
-                        a[2] * b[0] - a[0] * b[2],
-                        a[0] * b[1] - a[1] * b[0]])
+  >>> @partial(jnp.vectorize, signature='(k),(k)->(k)')
+  ... def cross_product(a, b):
+  ...   assert a.shape == b.shape and a.ndim == b.ndim == 1
+  ...   return jnp.array([a[1] * b[2] - a[2] * b[1],
+  ...                     a[2] * b[0] - a[0] * b[2],
+  ...                     a[0] * b[1] - a[1] * b[0]])
 
-    @partial(jnp.vectorize, signature='(n,m),(m)->(n)')
-    def matrix_vector_product(matrix, vector):
-      assert matrix.ndim == 2 and matrix.shape[1:] == vector.shape
-      return matrix @ vector
+  >>> @partial(jnp.vectorize, signature='(n,m),(m)->(n)')
+  ... def matrix_vector_product(matrix, vector):
+  ...   assert matrix.ndim == 2 and matrix.shape[1:] == vector.shape
+  ...   return matrix @ vector
 
   These functions are only written to handle 1D or 2D arrays (the ``assert``
   statements will never be violated), but with vectorize they support
@@ -236,14 +235,21 @@ def vectorize(pyfunc, *, excluded=frozenset(), signature=None):
   (2, 3)
   >>> cross_product(jnp.ones((1, 2, 3)), jnp.ones((2, 1, 3))).shape
   (2, 2, 3)
-  >>> matrix_vector_product(jnp.ones(3), jnp.ones(3))
+  >>> matrix_vector_product(jnp.ones(3), jnp.ones(3))  # doctest: +IGNORE_EXCEPTION_DETAIL
+  Traceback (most recent call last):
   ValueError: input with shape (3,) does not have enough dimensions for all
   core dimensions ('n', 'k') on vectorized function with excluded=frozenset()
   and signature='(n,k),(k)->(k)'
   >>> matrix_vector_product(jnp.ones((2, 3)), jnp.ones(3)).shape
   (2,)
   >>> matrix_vector_product(jnp.ones((2, 3)), jnp.ones((4, 3))).shape
-  (4, 2)  # not the same as jnp.matmul
+  (4, 2)
+
+  Note that this has different semantics than `jnp.matmul`:
+
+  >>> jnp.matmul(jnp.ones((2, 3)), jnp.ones((4, 3)))  # doctest: +IGNORE_EXCEPTION_DETAIL
+  Traceback (most recent call last):
+  TypeError: dot_general requires contracting dimensions to have the same shape, got [3] and [4].
   """
   if any(not isinstance(exclude, int) for exclude in excluded):
     raise TypeError("jax.numpy.vectorize can only exclude integer arguments, "

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -155,11 +155,11 @@ def index_add(x: Array,
 
   >>> x = jax.numpy.ones((5, 6))
   >>> jax.ops.index_add(x, jax.ops.index[2:4, 3:], 6.)
-  array([[1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 7., 7., 7.],
-         [1., 1., 1., 7., 7., 7.],
-         [1., 1., 1., 1., 1., 1.]], dtype=float32)
+  DeviceArray([[1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 7., 7., 7.],
+               [1., 1., 1., 7., 7., 7.],
+               [1., 1., 1., 1., 1., 1.]], dtype=float32)
   """
   return _scatter_update(
       x, idx, y, lax.scatter_add, indices_are_sorted, unique_indices)
@@ -202,11 +202,11 @@ def index_mul(x: Array,
 
   >>> x = jax.numpy.ones((5, 6))
   >>> jax.ops.index_mul(x, jax.ops.index[2:4, 3:], 6.)
-  array([[1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 1., 1., 1.]], dtype=float32)
+  DeviceArray([[1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 1., 1., 1.]], dtype=float32)
   """
   return _scatter_update(x, idx, y, lax.scatter_mul,
                          indices_are_sorted, unique_indices)
@@ -246,12 +246,12 @@ def index_min(x: Array,
     An array.
 
   >>> x = jax.numpy.ones((5, 6))
-  >>> jax.ops.index_minimum(x, jax.ops.index[2:4, 3:], 0.)
-  array([[1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 0., 0., 0.],
-         [1., 1., 1., 0., 0., 0.],
-         [1., 1., 1., 1., 1., 1.]], dtype=float32)
+  >>> jax.ops.index_min(x, jax.ops.index[2:4, 3:], 0.)
+  DeviceArray([[1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 0., 0., 0.],
+               [1., 1., 1., 0., 0., 0.],
+               [1., 1., 1., 1., 1., 1.]], dtype=float32)
   """
   return _scatter_update(
       x, idx, y, lax.scatter_min, indices_are_sorted, unique_indices)
@@ -291,11 +291,11 @@ def index_max(x: Array,
 
   >>> x = jax.numpy.ones((5, 6))
   >>> jax.ops.index_max(x, jax.ops.index[2:4, 3:], 6.)
-  array([[1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 1., 1., 1.]], dtype=float32)
+  DeviceArray([[1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 1., 1., 1.]], dtype=float32)
   """
   return _scatter_update(
       x, idx, y, lax.scatter_max, indices_are_sorted, unique_indices)
@@ -336,11 +336,11 @@ def index_update(x: Array,
 
   >>> x = jax.numpy.ones((5, 6))
   >>> jax.ops.index_update(x, jax.ops.index[::2, 3:], 6.)
-  array([[1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 6., 6., 6.],
-         [1., 1., 1., 1., 1., 1.],
-         [1., 1., 1., 6., 6., 6.]], dtype=float32)
+  DeviceArray([[1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 6., 6., 6.],
+               [1., 1., 1., 1., 1., 1.],
+               [1., 1., 1., 6., 6., 6.]], dtype=float32)
   """
   return _scatter_update(
       x, idx, y, lax.scatter, indices_are_sorted, unique_indices)

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -115,10 +115,9 @@ class TraceAnnotation(xla_client.profiler.TraceMe):
 
   For example:
 
-  >>> import jax, jax.numpy as jnp
   >>> x = jnp.ones((1000, 1000))
   >>> with jax.profiler.TraceAnnotation("my_label"):
-  ...   jnp.dot(x, x.T).block_until_ready()
+  ...   result = jnp.dot(x, x.T).block_until_ready()
 
   This will cause a "my_label" event to show up on the trace timeline if the
   event occurs while the process is being traced.
@@ -144,12 +143,10 @@ class StepTraceAnnotation(TraceAnnotation):
   For example, it can be used to mark training steps and enable the profiler to
   provide the performance analysis per step:
 
-  >>> import jax
-  >>>
-  >>> while global_step < NUM_STEPS:
-  ...   with jax.profiler.StepTraceAnnotation("train", step_num=global_step):
-  ...     train_step()
-  ...     global_step += 1
+  >>> while global_step < NUM_STEPS:                                           # doctest: +SKIP
+  ...   with jax.profiler.StepTraceAnnotation("train", step_num=global_step):  # doctest: +SKIP
+  ...     train_step()                                                         # doctest: +SKIP
+  ...     global_step += 1                                                     # doctest: +SKIP
 
   This will cause a "train xx" event to show up on the trace timeline if the
   event occurs while the process is being traced by TensorBoard. In addition,
@@ -177,27 +174,24 @@ def annotate_function(func: Callable, name: str = None, **kwargs):
 
   For example:
 
-  >>> import jax, jax.numpy as jnp
-  >>>
   >>> @jax.profiler.annotate_function
-  >>> def f(x):
+  ... def f(x):
   ...   return jnp.dot(x, x.T).block_until_ready()
   >>>
-  >>> f(jnp.ones((1000, 1000))
+  >>> result = f(jnp.ones((1000, 1000)))
 
   This will cause an "f" event to show up on the trace timeline if the
   function execution occurs while the process is being traced by TensorBoard.
 
   Arguments can be passed to the decorator via :py:func:`functools.partial`.
 
-  >>> import jax, jax.numpy as jnp
   >>> from functools import partial
-  >>>
-  >>> @partial(jax.profiler.trace_function, name="event_name")
-  >>> def f(x):
+
+  >>> @partial(jax.profiler.annotate_function, name="event_name")
+  ... def f(x):
   ...   return jnp.dot(x, x.T).block_until_ready()
-  >>>
-  >>> f(jnp.ones((1000, 1000))
+
+  >>> result = f(jnp.ones((1000, 1000)))
   """
 
   name = name or getattr(func, '__qualname__', None)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -99,8 +99,6 @@ class custom_jvp:
 
   For example::
 
-    import jax.numpy as jnp
-
     @jax.custom_jvp
     def f(x, y):
       return jnp.sin(x) * y
@@ -141,8 +139,6 @@ class custom_jvp:
       None.
 
     Example::
-
-      import jax.numpy as jnp
 
       @jax.custom_jvp
       def f(x, y):
@@ -388,8 +384,6 @@ class custom_vjp:
 
   For example::
 
-    import jax.numpy as jnp
-
     @jax.custom_vjp
     def f(x, y):
       return jnp.sin(x) * y
@@ -441,8 +435,6 @@ class custom_vjp:
       None.
 
     Example::
-
-      import jax.numpy as jnp
 
       @jax.custom_vjp
       def f(x, y):
@@ -882,45 +874,42 @@ def linear_call(fun: Callable, fun_transpose: Callable, residual_args,
   ``linear_call`` primitive is another ``linear_call`` to
   ``fun_transpose``, with ``fun`` as its custom transposition.
 
-  For example, if::
+  For example:
 
-    def f(r, x):
-      return x / r
+  >>> def f(r, x):
+  ...   return x / r
 
-    def t(r, t):
-      return t / r
+  >>> def t(r, t):
+  ...   return t / r
 
-    def div_add(denom, x):
-      return x + linear_call(f, t, denom, x)
+  >>> def div_add(x, denom):
+  ...   return x + linear_call(f, t, denom, x)
 
-    def transpose(f, x_example):
-      def transposed(y):
-        x, = jax.linear_transpose(f, x_example)(y)
-        return x
-      return transposed
-
-  Then:
+  >>> def transpose(f, x_example):
+  ...   def transposed(y):
+  ...     x, = jax.linear_transpose(f, x_example)(y)
+  ...     return x
+  ...   return transposed
 
   >>> div_add(9., 3.)
-  12.0
-  >>> transpose(partial(div_add, 3.), 1.)(18.)  # custom
-  24.0
+  DeviceArray(12., dtype=float32)
+
+  >>> transpose(partial(div_add, denom=3.), 1.)(18.)  # custom
+  DeviceArray(24., dtype=float32)
+
   >>> transpose(lambda x: x + x / 3., 1.)(18.)  # reference
-  24.0
+  DeviceArray(24., dtype=float32)
 
   The above definition of ``f`` illustrates the purpose of a residual
   argument: division is linear in one of its inputs (the dividend
   ``x``) but not the other (the divisor ``r``).
 
-  As another example, if::
+  As another example:
 
-    def custom_id(x):
-      def f(_, x): return x
-      def t(_, t): return 7.
-      return linear_call(f, t, (), x)
-
-  Then:
-
+  >>> def custom_id(x):
+  ...   def f(_, x): return x
+  ...   def t(_, t): return 7.
+  ...   return linear_call(f, t, (), x)
   >>> custom_id(1.)
   1.0
   >>> transpose(custom_id, 1.)(1.)

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -107,19 +107,19 @@ def _scalar_type_to_dtype(typ: type, value: Any = None):
 
   Examples
   --------
-  >>> _scalar_dtype_to_dtype(int)
-  numpy.int64
-  >>> _scalar_dtype_to_dtype(float)
-  numpy.float64
-  >>> _scalar_dtype_to_dtype(complex)
-  numpy.complex128
-  >>> _scalar_dtype_to_dtype(int)
-  np.int64
-  >>> _scalar_dtype_to_dtype(int, 0)
-  np.int64
-  >>> _scalar_dtype_to_dtype(int, 1 << 63)  # doctest: +IGNORE_EXCEPTION_DETAIL
-  ---------------------------------------------------------------------------
-  OverflowError: Python int 9223372036854775808 too large to convert to int64
+  >>> _scalar_type_to_dtype(int)
+  dtype('int32')
+  >>> _scalar_type_to_dtype(float)
+  dtype('float32')
+  >>> _scalar_type_to_dtype(complex)
+  dtype('complex64')
+  >>> _scalar_type_to_dtype(int)
+  dtype('int32')
+  >>> _scalar_type_to_dtype(int, 0)
+  dtype('int32')
+  >>> _scalar_type_to_dtype(int, 1 << 63)  # doctest: +IGNORE_EXCEPTION_DETAIL
+  Traceback (most recent call last):
+  OverflowError: Python int 9223372036854775808 too large to convert to int32
   """
   dtype = canonicalize_dtype(python_scalar_dtypes[typ])
   if typ is int and value is not None:

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -367,8 +367,8 @@ def xmap(fun: Callable,
   >>> xmap(jnp.vdot,
   ...      in_axes=({0: 'left'}, {1: 'right'}),
   ...      out_axes=['left', 'right', ...])(x, x.T)
-  [[ 2,  3],
-   [ 6, 11]]
+  DeviceArray([[ 30,  80],
+               [ 80, 255]], dtype=int32)
 
   Note that the contraction in the program is performed over the positional axes,
   while named axes are just a convenient way to achieve batching. While this

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -607,14 +607,12 @@ def flatten_shape(s: XlaShape) -> Sequence[Tuple[Sequence[int], XlaShape]]:
   We can query the arrays in the output tuple:
 
   >>> flatten_shape(c.GetShape(o))
-  (((0,), f32[1]{0}),
-   ((1,), f32[2]{0}),
-   ((2,), f32[3]{0}))
+  [((0,), f32[1]{0}), ((1,), f32[2]{0}), ((2,), f32[3]{0})]
 
   Or the arrays in one of the parameters (which is itself an array):
 
   >>> flatten_shape(c.GetShape(p0))
-  (((), f32[1]{0}),)
+  [((), f32[1]{0})]
 
   Args
     s: The input shape.

--- a/jax/random.py
+++ b/jax/random.py
@@ -20,10 +20,12 @@ generation of sequences of pseudorandom numbers.
 Basic usage
 -----------
 
+>>> seed = 1701
+>>> num_steps = 100
 >>> key = jax.random.PRNGKey(seed)
 >>> for i in range(num_steps):
 ...   key, subkey = jax.random.split(key)
-...   params = compiled_update(subkey, params, next(batches))
+...   params = compiled_update(subkey, params, next(batches))  # doctest: +SKIP
 
 PRNG Keys
 ---------

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ filterwarnings =
     error
     ignore:No GPU/TPU found, falling back to CPU.:UserWarning
     ignore:outfeed_receiver is unnecessary and deprecated:DeprecationWarning
+    # xmap
+    ignore:xmap is an experimental feature and probably has bugs!
     # The rest are for experimental/jax_to_tf
     ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__:ImportWarning


### PR DESCRIPTION
We had previously not been testing most docstrings; turns out a few of them were stale and/or contained typos.

The documentation test CI job now tests everything in jax except `jax/experimental/jax2tf` (this one has a number of errors that don't seem trivial to fix).