### PR TITLE
Make safe_zip return iterator to match Python 3 builtin zip

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3498,8 +3498,8 @@ def _pad_transpose(t, operand, padding_value, *, padding_config):
     total = lambda x: _reduce_sum(x, list(range(t.ndim)))
 
     def t_op():
-      unpad_config = safe_zip(np.negative(lo), np.negative(hi),
-                              np.zeros_like(interior))
+      unpad_config = tuple(safe_zip(np.negative(lo), np.negative(hi),
+                                    np.zeros_like(interior)))
       unpadded = pad(t, np.array(0., t.dtype), unpad_config)
       return slice(unpadded, np.zeros_like(lo), unpadded.shape, np.add(interior, 1))
 
@@ -6512,7 +6512,7 @@ def _conv_general_vjp_lhs_padding(
   pad_before = np.subtract(rhs_dilated_shape, [lo for lo, _ in padding]) - 1
   pad_after = (np.add(lhs_dilated_shape, rhs_dilated_shape) - 1
                - out_dilated_shape - pad_before)
-  return safe_zip(pad_before, pad_after)
+  return list(safe_zip(pad_before, pad_after))
 
 
 def _conv_general_vjp_rhs_padding(

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -30,7 +30,7 @@ def safe_zip(*args):
   n = len(args[0])
   for arg in args[1:]:
     assert len(arg) == n, 'length mismatch: {}'.format(list(map(len, args)))
-  return list(zip(*args))
+  return zip(*args)
 
 def safe_map(f, *args):
   args = list(map(list, args))

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1381,7 +1381,7 @@ def _pad(operand, padding_value, *, padding_config,
   del _in_avals
   low, high, interior = util.unzip3(padding_config)
   if all(lo >= 0 and hi >= 0 and i == 0 for lo, hi, i in padding_config):
-    return tf.pad(operand, util.safe_zip(low, high),
+    return tf.pad(operand, list(util.safe_zip(low, high)),
                   mode="CONSTANT", constant_values=padding_value)
   if not _enable_xla:
     raise _xla_path_disabled_error("pad")

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -131,7 +131,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
   def test_solve_shape_vars(self):
     def solve_shape_vars(shape_spec: str, shape: Sequence[int]) -> Dict[str, int]:
       shape_polys = masking.parse_spec(shape_spec)
-      return jax2tf.jax2tf._solve_shape_vars(util.safe_zip(shape_polys, shape))
+      return jax2tf.jax2tf._solve_shape_vars(list(util.safe_zip(shape_polys, shape)))
 
     self.assertAllClose(solve_shape_vars("(a, b, c)", [1, 2, 3]),
                          dict(a=1, b=2, c=3), check_dtypes=False)

--- a/tests/generated_fun_test.py
+++ b/tests/generated_fun_test.py
@@ -196,7 +196,7 @@ def gen_vals(vs):
   return [gen_array_val(v.vartype) for v in vs]
 
 def inner_prod(xs, ys):
-  xys = zip(xs, ys)
+  xys = list(zip(xs, ys))
   assert all(x.shape == y.shape for x, y in xys)
   return sum(jnp.sum(x * y) for x, y in xys)
 


### PR DESCRIPTION
This PR changes `utils.safe_zip` to return an `Iterator` instead of a list to match the signature of the builtin [Python 3 `zip`](https://docs.python.org/3/library/functions.html#zip) function.
Since `utils.safe_zip` is mostly iterated over only once or passed directly to other builtin functions like `enumerate` that support iterators, this PR removes the need to allocate temporary lists during these iterations.