### PR TITLE
[jax2tf]  Add support for shape polymorphism for jax2tf; some refactoring of shape computations in JAX core

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -129,7 +129,7 @@ sets up symbolic links from site-packages into the repository.
 
 To run all the JAX tests, we recommend using `pytest-xdist`, which can run tests in
 parallel. First, install `pytest-xdist` and `pytest-benchmark` by running
-`pip install pytest-xdist pytest-benchmark`.
+`ip install -r build/test-requirements.txt`.
 Then, from the repository root directory run:
 
 ```

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4472,7 +4472,7 @@ def _scatter_shape_rule(operand, scatter_indices, updates, *, update_jaxpr,
 
   for i in range(len(update_window_dims)):
     update_window_dim = update_window_dims[i]
-    if updates.shape[update_window_dim] > max_update_slice_sizes[i]:
+    if not core.dim_greater_equal(max_update_slice_sizes[i], updates.shape[update_window_dim]):
       raise TypeError(f"Bounds of the window dimensions of updates must not "
                       f"exceed the bounds of the corresponding dimensions of "
                       f"operand. For dimension {update_window_dim}, updates "

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3812,7 +3812,7 @@ def _select_batch_rule(batched_args, batch_dims, **unused_kwargs):
       return select(pred, on_true, on_false), ot_bdim
 
   pred = batching.bdim_at_front(pred, pred_bdim, size) if np.shape(pred) else pred
-  if not np.shape(on_true) == np.shape(on_false) == ():
+  if not () == np.shape(on_true) == np.shape(on_false):
     on_true = batching.bdim_at_front(on_true, ot_bdim, size)
     on_false = batching.bdim_at_front(on_false, of_bdim, size)
   assert np.shape(on_true) == np.shape(on_false)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1763,7 +1763,7 @@ def broadcast_to(arr, shape):
   shape = (shape,) if ndim(shape) == 0 else shape
   shape = canonicalize_shape(shape)  # check that shape is concrete
   arr_shape = _shape(arr)
-  if core.dim_symbolic_equal_shape(arr_shape, shape):
+  if core.shape_symbolic_equal(arr_shape, shape):
     return arr
   else:
     nlead = len(shape) - len(arr_shape)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1314,7 +1314,7 @@ def _compute_newshape(a, newshape):
   except: iterable = False
   else: iterable = True
   newshape = core.canonicalize_shape(newshape if iterable else [newshape])
-  return tuple(d if d is not -1 else - core.dim_divide_shape_sizes(np.shape(a), newshape)
+  return tuple(d if d is not -1 else - core.divide_shape_sizes(np.shape(a), newshape)
                for d in newshape)
 
 
@@ -1763,17 +1763,17 @@ def broadcast_to(arr, shape):
   shape = (shape,) if ndim(shape) == 0 else shape
   shape = canonicalize_shape(shape)  # check that shape is concrete
   arr_shape = _shape(arr)
-  if core.shape_symbolic_equal(arr_shape, shape):
+  if core.symbolic_equal_shape(arr_shape, shape):
     return arr
   else:
     nlead = len(shape) - len(arr_shape)
     shape_tail = shape[nlead:]
-    compatible = _all(core.dim_symbolic_equal_one_of(arr_d, [1, shape_d])
+    compatible = _all(core.symbolic_equal_one_of_dim(arr_d, [1, shape_d])
                       for arr_d, shape_d in safe_zip(arr_shape, shape_tail))
     if nlead < 0 or not compatible:
       msg = "Incompatible shapes for broadcasting: {} and requested shape {}"
       raise ValueError(msg.format(arr_shape, shape))
-    diff, = np.where(tuple(not core.dim_symbolic_equal(arr_d, shape_d)
+    diff, = np.where(tuple(not core.symbolic_equal_dim(arr_d, shape_d)
                            for arr_d, shape_d in safe_zip(arr_shape, shape_tail)))
     new_dims = tuple(range(nlead)) + tuple(nlead + diff)
     kept_dims = tuple(np.delete(np.arange(len(shape)), new_dims))
@@ -3845,13 +3845,13 @@ def matmul(a, b, *, precision=None):  # pylint: disable=missing-docstring
       idx_b_other.append(i)
     elif bb is None:
       idx_a_other.append(i)
-    elif core.dim_symbolic_equal(ba, 1):
+    elif core.symbolic_equal_dim(ba, 1):
       idx_b_other.append(i)
       a_squeeze.append(len(idx_batch) + len(idx_a_other) + len(a_squeeze))
-    elif core.dim_symbolic_equal(bb, 1):
+    elif core.symbolic_equal_dim(bb, 1):
       idx_a_other.append(i)
       b_squeeze.append(len(idx_batch) + len(idx_b_other) + len(b_squeeze))
-    elif core.dim_symbolic_equal(ba, bb):
+    elif core.symbolic_equal_dim(ba, bb):
       a_batch.append(len(idx_batch) + len(idx_a_other))
       b_batch.append(len(idx_batch) + len(idx_b_other))
       idx_batch.append(i)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1314,7 +1314,8 @@ def _compute_newshape(a, newshape):
   except: iterable = False
   else: iterable = True
   newshape = core.canonicalize_shape(newshape if iterable else [newshape])
-  return tuple(d if d is not -1 else - core.divide_shape_sizes(np.shape(a), newshape)
+  return tuple(- core.divide_shape_sizes(np.shape(a), newshape)
+               if core.symbolic_equal_dim(d, -1) else d
                for d in newshape)
 
 

--- a/jax/abstract_arrays.py
+++ b/jax/abstract_arrays.py
@@ -23,8 +23,6 @@ from ._src import dtypes
 from ._src import traceback_util
 traceback_util.register_exclusion(__file__)
 
-_DIMENSION_TYPES = core._DIMENSION_TYPES
-
 UnshapedArray = core.UnshapedArray
 ShapedArray = core.ShapedArray
 ConcreteArray = core.ConcreteArray

--- a/jax/core.py
+++ b/jax/core.py
@@ -1316,25 +1316,25 @@ def symbolic_equal_one_of_dim(d1: DimSize, dlist: Sequence[DimSize]) -> bool:
 def symbolic_equal_shape(s1: Shape, s2: Shape) -> bool:
   """See DimensionHandler.symbolic_equal."""
   return (len(s1) == len(s2) and
-          all(safe_map(symbolic_equal_dim, s1, s2)))
+          all(map(symbolic_equal_dim, s1, s2)))
 
 def greater_equal_dim(d1: DimSize, d2: DimSize) -> bool:
   return _get_dim_handler(d1, d2).greater_equal(d1, d2)
 
 def greater_equal_shape(s1: Shape, s2: Shape) -> bool:
-  return all(safe_map(greater_equal_dim, s1, s2))
+  return all(map(greater_equal_dim, s1, s2))
 
 def sum_dim(*ds: DimSize) -> DimSize:
   return _get_dim_handler(*ds).sum(*ds)
 
 def sum_shapes(*ss: Shape) -> Shape:
-  return tuple(safe_map(sum_dim, *ss))
+  return tuple(map(sum_dim, *ss))
 
 def diff_dim(d1: DimSize, d2: DimSize) -> DimSize:
   return _get_dim_handler(d1, d2).diff(d1, d2)
 
 def diff_shape(s1: Shape, s2: Shape) -> Shape:
-  return tuple(safe_map(diff_dim, s1, s2))
+  return tuple(map(diff_dim, s1, s2))
 
 def divide_shape_sizes(s1: Shape, s2: Shape) -> int:
   s1 = s1 or (1,)
@@ -1349,14 +1349,14 @@ def dilate_dim(d: DimSize, dilation: DimSize) -> DimSize:
   return _get_dim_handler(d, dilation).dilate(d, dilation)
 
 def dilate_shape(s: Shape, dilations: Sequence[int]) -> Shape:
-  return tuple(safe_map(dilate_dim, s, dilations))
+  return tuple(map(dilate_dim, s, dilations))
 
 def stride_dim(d: DimSize, window_size: DimSize, window_stride: DimSize) -> DimSize:
   return _get_dim_handler(d, window_size, window_stride).stride(d, window_size, window_stride)
 
 def stride_shape(s: Shape, window_size: Shape, window_stride: Shape) -> Shape:
   """(s - window_size) // window_stride + 1"""
-  return tuple(safe_map(stride_dim, s, window_size, window_stride))
+  return tuple(map(stride_dim, s, window_size, window_stride))
 
 
 def _canonicalize_dimension(dim: DimSize) -> DimSize:

--- a/jax/core.py
+++ b/jax/core.py
@@ -1263,6 +1263,8 @@ class DimensionHandler:
   def add(self, *d: DimSize):
     return sum(d)
 
+  def diff(self, d1: DimSize, d2: DimSize) -> DimSize:
+    return d1 - d2
 
 _dimension_handler_int = DimensionHandler()
 _SPECIAL_DIMENSION_HANDLERS: Dict[type, DimensionHandler] = {}
@@ -1297,12 +1299,16 @@ def dim_symbolic_equal_one_of(d1: DimSize, dlist: Sequence[DimSize]) -> bool:
   """True iff `d1` is symbolic equal to one of `dlist`"""
   return _get_dim_handler(d1, *dlist).symbolic_equal_one_of(d1, dlist)
 
-def dim_symbolic_equal_shape(s1: Shape, s2: Shape) -> bool:
+def shape_symbolic_equal(s1: Shape, s2: Shape) -> bool:
   return (len(s1) == len(s2) and
           all(dim_symbolic_equal(d1, d2) for d1, d2 in safe_zip(s1, s2)))
 
 def dim_greater_equal(d1: DimSize, d2: DimSize) -> bool:
   return _get_dim_handler(d1, d2).greater_equal(d1, d2)
+
+def shape_greater_equal(s1: Shape, s2: Shape) -> bool:
+  return all(safe_map(dim_greater_equal, s1, s2))
+
 
 def dim_divide_shape_sizes(s1: Shape, s2: Shape) -> DimSize:
   """Computes the division of the size of arr_shape and newshape.
@@ -1331,6 +1337,13 @@ def dim_sum(*d: DimSize) -> Shape:
 def shapes_sum(*s: Shape) -> Shape:
   """Implements sum(s)"""
   return tuple(safe_map(dim_sum, *s))
+
+def dim_diff(d1: DimSize, d2: DimSize) -> DimSize:
+  return _get_dim_handler(d1, d2).diff(d1, d2)
+
+def shape_diff(s1: Shape, s2: Shape) -> Shape:
+  return tuple(safe_map(dim_diff, s1, s2))
+
 
 def dim_stride(d: DimSize, window_size: DimSize, window_stride: DimSize) -> DimSize:
   return _get_dim_handler(d, window_size, window_stride).stride(d, window_size, window_stride)

--- a/jax/core.py
+++ b/jax/core.py
@@ -1260,8 +1260,8 @@ class DimensionHandler:
     """Implements `0 if d == 0 else 1 + dilation * (d - 1))`"""
     return 0 if d == 0 else 1 + dilation * (d - 1)
 
-  def add(self, *d: DimSize):
-    return sum(d)
+  def sum(self, *ds: DimSize):
+    return sum(ds)
 
   def diff(self, d1: DimSize, d2: DimSize) -> DimSize:
     return d1 - d2
@@ -1330,9 +1330,9 @@ def dim_dilate_shape(s: Shape, dilations: Sequence[int]) -> Shape:
   """Implements `dim_dilate` for each dimension."""
   return tuple(safe_map(dim_dilate, s, dilations))
 
-def dim_sum(*d: DimSize) -> Shape:
+def dim_sum(*ds: DimSize) -> Shape:
   """sum(d)"""
-  return _get_dim_handler(*d).add(*d)
+  return _get_dim_handler(*ds).sum(*ds)
 
 def shapes_sum(*s: Shape) -> Shape:
   """Implements sum(s)"""

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert, shape_as_value, split_to_logical_devices
+from .jax2tf import convert, shape_as_value, split_to_logical_devices, PolyShape
 from .call_tf import call_tf

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1354,6 +1354,8 @@ def _pad(operand, padding_value, *, padding_config,
   if not _enable_xla:
     raise _xla_path_disabled_error("pad")
   out = tfxla.pad(operand, padding_value, low, high, interior)
+  # TODO(b/184499027): improve shape inference for XlaPad
+  out.set_shape(_aval_to_tf_shape(_out_aval))
   return out
 tf_impl_with_avals[lax.pad_p] = _pad
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1943,7 +1943,6 @@ def _sort(*operands: TfVal, dimension: int, is_stable: bool,
   if not _enable_xla:
     raise _xla_path_disabled_error("sort")
   assert 1 <= num_keys <= len(operands)
-  assert all([operands[0].shape == op.shape for op in operands[1:]])
   assert 0 <= dimension < len(
       operands[0].shape
   ), f"Invalid {dimension} for ndim {len(operands[0].shape)}"

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -126,6 +126,12 @@ class DimensionHandlerVar(core.DimensionHandler):
       raise TypeError(f"Adding non-zero to shape variables is not supported {' + '.join(map(str, d))}")
     return d_vars[0]
 
+  def diff(self, d1: DimSize, d2: DimSize) -> DimSize:
+    if self.symbolic_equal(d1, d2):
+      return 0
+    if d2 in {0}:
+      return d1
+    raise TypeError(f"Subtracting shape variables is not supported ({d1} - {d2})")
 
 core._SPECIAL_DIMENSION_HANDLERS[DimVar] = DimensionHandlerVar()
 

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -67,6 +67,7 @@ class DimVar:
   def __ne__(self, other):
     return not self == other
 
+## TODO: add unit tests
 
 class DimensionHandlerVar(core.DimensionHandler):
   """See core.DimensionHandler."""
@@ -104,6 +105,26 @@ class DimensionHandlerVar(core.DimensionHandler):
       msg = (f"Shapes {s1} and {s2} must have the same set of shape variables.")
       raise TypeError(msg)
     return super(DimensionHandlerVar, self).divide_shape_sizes(s1_ints, s2_ints)
+
+  def dilate(self, d: DimSize, dilation: DimSize) -> DimSize:
+    """Implements `0 if d == 0 else 1 + dilation * (d - 1))`"""
+    if dilation not in {1}:
+      raise TypeError(f"Dilation is not supported for shape variables (d = {dilation})")
+    return d
+
+  def stride(self, d: DimSize, window_size: DimSize, window_stride: DimSize) -> DimSize:
+    """Implements `(d - window_size) // window_stride + 1`"""
+    if {window_size, window_stride} != {1}:
+      raise TypeError(f"Striding is not supported for shape variables (window_size = {window_size}, stride = {window_stride}")
+    return d
+
+  def add(self, *d: DimSize):
+    d_ints, d_vars = _split_shape_ints(d)
+    if len(d_vars) != 1:
+      raise TypeError(f"Adding shape variables is not supported ({' + '.join(map(str, d))})")
+    if sum(d_ints) != 0:
+      raise TypeError(f"Adding non-zero to shape variables is not supported {' + '.join(map(str, d))}")
+    return d_vars[0]
 
 
 core._SPECIAL_DIMENSION_HANDLERS[DimVar] = DimensionHandlerVar()

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -1,0 +1,187 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TODO
+
+"""
+import logging
+import collections
+import string
+from typing import Callable, Dict, Optional, Sequence, Set, Tuple, Union
+
+import jax
+from jax import core
+from jax import dlpack
+from jax import dtypes
+from jax import numpy as jnp
+from jax import tree_util
+from jax._src import util
+from jax.interpreters import xla
+from jax.lib import xla_bridge
+from jax.lib import xla_client
+
+import numpy as np
+import tensorflow as tf  # type: ignore[import]
+
+DimSize = core.DimSize
+Shape = core.Shape
+
+
+class InconclusiveDimensionOperation(Exception):
+  """Raised when we cannot conclusively compute with DimVars"""
+  pass
+
+
+class DimVar:
+  """A shape dimension variable.
+  We assume that these range over integer values >= 1.
+  """
+  def __init__(self, varname: str):
+    self.varname = varname
+
+  def __str__(self):
+    return self.varname
+
+  def __repr__(self):
+    return str(self)
+
+  def __hash__(self):
+    return hash(self.varname)
+
+  def __eq__(self, other):
+    if isinstance(other, DimVar) and self.varname == other.varname:
+      return True
+    else:
+      raise InconclusiveDimensionOperation(f"Shape variable comparison {self} == {other} is inconclusive")
+
+  def __ne__(self, other):
+    return not self == other
+
+
+class DimensionHandlerVar(core.DimensionHandler):
+  """See core.DimensionHandler."""
+  def as_index(self, d: DimSize) -> DimSize:
+    return d
+
+  def symbolic_equal(self, d1: DimSize, d2: DimSize) -> bool:
+    # The set inclusion will use the __hash__ first, and only then __eq__
+    return d1 in {d2}
+
+  def symbolic_equal_one_of(self, d1: DimSize, dlist: Sequence[DimSize]) -> bool:
+    return d1 in set(dlist)
+
+  def greater_equal(self, d1: DimSize, d2: DimSize):
+    if d1 in {d2}:
+      return True
+
+    if type(d2) is not DimVar and d2 <= 1:
+      return True
+    else:
+      raise InconclusiveDimensionOperation(f"Shape variable comparison {d1} >= {d2} is inconclusive")
+
+  def same_total_size(self, s1: Shape, s2: Shape) -> int:
+    s1_ints, s1_vars = _split_shape_ints(s1)
+    s2_ints, s2_vars = _split_shape_ints(s2)
+    if collections.Counter(s1_vars) != collections.Counter(s2_vars):
+      msg = (f"Shapes {s1} and {s2} must have the same set of shape variables.")
+      raise TypeError(msg)
+    return np.prod(s1_ints) == np.prod(s2_ints)
+
+  def divide_shape_sizes(self, s1: Shape, s2: Shape) -> Shape:
+    s1_ints, s1_vars = _split_shape_ints(s1)
+    s2_ints, s2_vars = _split_shape_ints(s2)
+    if collections.Counter(s1_vars) != collections.Counter(s2_vars):
+      msg = (f"Shapes {s1} and {s2} must have the same set of shape variables.")
+      raise TypeError(msg)
+    return super(DimensionHandlerVar, self).divide_shape_sizes(s1_ints, s2_ints)
+
+
+core._SPECIAL_DIMENSION_HANDLERS[DimVar] = DimensionHandlerVar()
+
+def _split_shape_ints(shape: Shape) -> Tuple[Sequence[int], Sequence[DimVar]]:
+  """Splits the shape into an integer sequence and a sequence of vars."""
+  shape_ints, shape_vars = [], []
+  for d in shape:
+    (shape_ints if isinstance(d, int) else shape_vars).append(d)
+  return shape_ints, shape_vars
+
+
+class ShapeSyntaxError(Exception): pass
+
+_identifiers = frozenset(string.ascii_lowercase)
+def parse_spec(spec: Optional[str],
+               arg_shape: Tuple[Optional[int], ...]) -> Tuple[DimSize, ...]:
+  """Parse the shape polymorphic specification for one array argument.
+  Args:
+    spec: a shape polymorphic specification.
+    arg_shape: an actual shape, possibly containing unknown dimensions (None).
+
+  The placeholders `_` in the specification are replaced with the values from
+  the actual shape, which must be known.
+
+  TO FINISH
+  """
+  shape_var_map: Dict[str, Set[int]] = collections.defaultdict(set)
+  def _parse_dim(dim_spec: str, dim_size: Optional[int]) -> Union[int, DimSize]:
+    if dim_spec == '_':
+      if dim_size is None:
+        msg = (f"polymorphic_shape '{spec}' has `_` placeholders for argument shape "
+               f"dimensions that are unknown: {arg_shape}")
+        raise ValueError(msg)
+      return dim_size
+    elif dim_spec.isdigit():
+      spec_size = int(dim_spec)
+      if dim_size != spec_size:
+        if dim_size is None:
+          msg = (f"polymorphic_shape '{spec}' must contain shape variables for argument shape "
+                 f"dimensions that are unknown: {arg_shape}")
+        else:
+          msg = (f"polymorphic_shape '{spec}' does not match argument shape {arg_shape}")
+        raise ValueError(msg)
+      return spec_size
+    elif dim_spec[0] in _identifiers:
+      if dim_size is not None:
+        shape_var_map[dim_spec].add(dim_size)
+      return DimVar(dim_spec)
+    else:
+      raise ShapeSyntaxError(dim_spec)
+
+  if not spec:
+    if any(d is None for d in arg_shape):
+      msg = ("polymorphic_shape must be specified when the argument "
+             f"shape {arg_shape} is partially known.")
+      raise ValueError(msg)
+    return arg_shape
+
+  if spec[0] == '(':
+    if spec[-1] != ')':
+      raise ShapeSyntaxError(spec)
+    spec_ = spec[1:-1]
+  else:
+    spec_ = spec
+  specs = spec_.replace(' ', '').strip(',').split(',')
+  if len(specs) != len(arg_shape):
+    msg = (f"polymorphic_shape '{spec}' has different rank than argument "
+           f"shape {arg_shape}")
+    raise ValueError(msg)
+  dims = tuple(map(_parse_dim, specs, arg_shape))
+
+  for dim_var, dim_var_values in shape_var_map.items():
+    if len(dim_var_values) != 1:
+      msg = (f"polymorphic shape variable '{dim_var}' corresponds to multiple "
+             f"values ({sorted(dim_var_values)}), in polymorphic_shape '{spec}' and "
+             f"argument shape {arg_shape}")
+      raise ValueError(msg)
+
+  return dims
+

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -118,12 +118,12 @@ class DimensionHandlerVar(core.DimensionHandler):
       raise TypeError(f"Striding is not supported for shape variables (window_size = {window_size}, stride = {window_stride}")
     return d
 
-  def add(self, *d: DimSize):
-    d_ints, d_vars = _split_shape_ints(d)
+  def sum(self, *ds: DimSize):
+    d_ints, d_vars = _split_shape_ints(ds)
     if len(d_vars) != 1:
-      raise TypeError(f"Adding shape variables is not supported ({' + '.join(map(str, d))})")
+      raise TypeError(f"Adding shape variables is not supported ({' + '.join(map(str, ds))})")
     if sum(d_ints) != 0:
-      raise TypeError(f"Adding non-zero to shape variables is not supported {' + '.join(map(str, d))}")
+      raise TypeError(f"Adding non-zero to shape variables is not supported {' + '.join(map(str, ds))}")
     return d_vars[0]
 
   def diff(self, d1: DimSize, d2: DimSize) -> DimSize:

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -2275,7 +2275,7 @@ for dtype in (np.float32, np.float64):
   for shape in ((), (3,)):
     define(
       "random_gamma",
-      f"_shape={jtu.format_shape_dtype_string(shape, dtype)}",
+      f"shape={jtu.format_shape_dtype_string(shape, dtype)}",
       jax.jit(jax.random.gamma),
       [np.array([42, 43], dtype=np.uint32),
        RandArg(shape, dtype)],
@@ -2290,7 +2290,7 @@ for key_i, key in enumerate([
 ]):
   define(
     "random_split",
-    f"_i={key_i}",
+    f"i={key_i}",
     jax.jit(lambda key: jax.random.split(key, 2)), [key],
     dtype=key.dtype)
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -69,7 +69,7 @@ from jax.experimental import jax2tf
 from jax.interpreters import xla
 
 import numpy as np
-import tensorflow as tf
+import tensorflow as tf  # type: ignore[import]
 
 config.parse_flags_with_absl()
 

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -251,7 +251,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
         must match the `input_signature`. (see jax2tf.convert).
     """
     f_tf = tf.function(
-        jax2tf.convert(f_jax, polymorphic_shapes=polymorphic_shapes),
+        jax2tf.convert(f_jax, polymorphic_shapes_experimental=polymorphic_shapes),
         autograph=False,
         input_signature=input_signature)
     concrete_f_tf = f_tf.get_concrete_function(*input_signature)

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -251,7 +251,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
         must match the `input_signature`. (see jax2tf.convert).
     """
     f_tf = tf.function(
-        jax2tf.convert(f_jax, polymorphic_shapes_experimental=polymorphic_shapes),
+        jax2tf.convert(f_jax, polymorphic_shapes=polymorphic_shapes),
         autograph=False,
         input_signature=input_signature)
     concrete_f_tf = f_tf.get_concrete_function(*input_signature)

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -239,7 +239,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
 
   def CheckShapePolymorphism(self, f_jax: Callable, *,
                              input_signature: Sequence[tf.TensorSpec],
-                             in_shapes: Optional[Sequence[Any]],
+                             polymorphic_shapes: Optional[Sequence[Any]],
                              expected_output_signature: tf.TensorSpec):
     """Convert a function using polymorphic shapes.
 
@@ -250,7 +250,7 @@ class JaxToTfTestCase(jtu.JaxTestCase):
         must match the `input_signature`. (see jax2tf.convert).
     """
     f_tf = tf.function(
-        jax2tf.convert(f_jax, in_shapes=in_shapes),
+        jax2tf.convert(f_jax, polymorphic_shapes=polymorphic_shapes),
         autograph=False,
         input_signature=input_signature)
     concrete_f_tf = f_tf.get_concrete_function(*input_signature)
@@ -262,18 +262,18 @@ class JaxToTfTestCase(jtu.JaxTestCase):
           tuple(concrete_output_tf_shape))
     return f_tf
 
-  def MakeInputSignature(self, *in_shapes):
+  def MakeInputSignature(self, *polymorphic_shapes):
     """From a pytree of in_shape string specification, make a pytree of tf.TensorSpec.
 
     Dimension variables are replaced with None.
     """
 
-    def in_shape_to_tensorspec(in_shape: str) -> tf.TensorSpec:
-      in_spec = masking.parse_spec(in_shape)
+    def polymorphic_shape_to_tensorspec(poly_shape: str) -> tf.TensorSpec:
+      in_spec = masking.parse_spec(poly_shape)
       return tf.TensorSpec(
           tuple(
               int(dim_spec) if dim_spec.is_constant else None
               for dim_spec in in_spec),
           dtype=tf.float32)
 
-    return tree_util.tree_multimap(in_shape_to_tensorspec, in_shapes)
+    return tree_util.tree_multimap(polymorphic_shape_to_tensorspec, polymorphic_shapes)

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -120,7 +120,7 @@ def _polys_to_ints(shape):
 def is_polymorphic(shape: Sequence['Size']):
   return any(map(lambda d: type(d) is Poly, shape))
 
-class UndefinedPoly(Exception):
+class UndefinedPoly(core.InconclusiveDimensionOperation):
   """Exception raised when an operation involving polynomials is not defined.
 
   An operation `op` on polynomials `p1` and `p2` either raises this exception,
@@ -306,17 +306,15 @@ def mul(coeff, mon):
 
 
 class DimensionHandlerPoly(core.DimensionHandler):
-  def as_index(self, d: DimSize) -> DimSize:
-    return d
+  """See core.DimensionHandler.
 
+  Most methods are inherited.
+  """
   def symbolic_equal(self, d1: core.DimSize, d2: core.DimSize) -> bool:
     try:
       return d1 == d2
     except UndefinedPoly:
       return False
-
-  def symbolic_equal_one_of(self, d1: core.DimSize, dlist: Sequence[core.DimSize]) -> bool:
-    return any(self.symbolic_equal(d1, d2) for d2 in dlist)
 
 
 core._SPECIAL_DIMENSION_HANDLERS[Poly] = DimensionHandlerPoly()

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ filterwarnings =
     ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
     ignore:can't resolve package from __spec__ or __package__:ImportWarning
     ignore:Using or importing the ABCs.*:DeprecationWarning
+    # jax2tf tests due to mix of JAX and TF
+    ignore:numpy.ufunc size changed
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1277,8 +1277,12 @@ class LaxTest(jtu.JaxTestCase):
   def testPadErrors(self):
     with self.assertRaisesRegex(ValueError, "padding_config"):
       lax.pad(np.zeros(2), 0., [(0, 1, 0), (0, 1, 0)])
-    with self.assertRaisesRegex(ValueError, "padding_config"):
+    with self.assertRaisesRegex(ValueError, "interior padding in padding_config must be nonnegative"):
       lax.pad(np.zeros(2), 0., [(0, 1, -1)])
+    with self.assertRaisesRegex(ValueError, "Dimension size after padding is not at least 0"):
+      lax.pad(np.zeros(2), 0., [(-3, 0, 0)])
+    with self.assertRaisesRegex(ValueError, "Dimension size after padding is not at least 0"):
+      lax.pad(np.zeros(2), 0., [(-4, 0, 1)])
 
   def testReverse(self):
     rev = api.jit(lambda operand: lax.rev(operand, dimensions))


### PR DESCRIPTION
Add back support for shape polymorphism to jax2tf, aiming for both soundness and clean interactions with JAX core. 

The main goal is to allow saving of a batch-polymorphic SavedModel for a JAX function, which is a very important feature for users of jax2tf.

**This support is highly experimental. We expect that when the conversion succeeds, it is correct (see below for definition of soundness), but we also expect that there will be valid shape-polymorphic JAX programs for which the conversion will fail, hopefully with a helpful error message. We will aim to increase coverage, without complicating the JAX core internals.**

Unlike previous attempts, we do not use `masking` (see below for a history of this feature). This means that the code should be easier to see it is sound, and it should result in cleaner `lax.py` and `lax_numpy.py`.

We aim to support the conversion of JAX programs for which one or more dimensions of the inputs have sizes that are specified as *dimension variables*. 

**Soundness**: The conversion should succeed only if the converted TF program **faithfully represents all the executions of the original JAX function for any non-zero value of the dimension variables**. This means that we must reject programs that have conditionals dependent on a value of a dimension variable (e.g., `if x.shape[0] == 16: ...`), whether such conditionals are in the user JAX program, in the `jax.numpy` implementation, or in JAX's internal abstract evaluation and transformation rules. We must also reject conditionals `if x.shape[0] == x.shape[1]` if the two dimension are distinct dimension variables. 

In order to ensure soundness, we want to avoid polluting JAX internals with `if shape_is_polymorphic ...`. Instead, we have identified in the JAX internal code a small number of basic shape and dimension computations (e.g., `greater_equal_dim`, `dilate_dim`, `stride_dim`) and have introduced some functions in `core.py` to implement these computations. All that we should see in `lax.py` and `lax_numpy.py` should be references to these helper functions. These helper functions are extensible. They have a base implementation in `core.DimensionHandlerBase` and are customized by sub-classes `masking.DimensionHandlerPoly` and  `shape_poly.DimensionHandlerDimVar`. 

Unlike `masking.Poly`, the dimension variables do not support arbitrary arithmetic and in particular do not duck-type integers. E.g., you must use explicit `core.sum_dim` to add dimensions, and when one of the dimensions is a variable, then only 0 can be added. There is no way to represent the result of other additions.

Completeness is best effort: there will be JAX programs that are shape polymorphic but the jax2tf converter won't recognize as such. One of the goals is to ensure that we can convert with shape polymorphism the output of `jax.vmap` for all primitives. We have tested this fairly exhaustively, by taking all primitive harnesses, picking those for which `jax.vmap` works in JAX, and then converting them shape-polymorphically to TF. All 440 such harnesses work, except for `random_gamma`, `lu`, `custom_linear_solve` and `conv_general_dilated` (for which the batching rule does some shape computation that I have not yet ported). Most cases of `conv_general_dilated` actually work. 

The only know source of unsoundness is that there is no check that the TF function resulting from conversion is applied to arguments whose shapes can be obtained by some replacement of dimension variables with non-zero integers. E.g., `jax2tdf.convert(f_jax, polymorphic_shapes_experimental=["(b, b)"])` should only be applied to a square 2D matrix with non-zero dimensions. Applying it anything else is not guaranteed to produce the same result as in JAX. It *may* result in a TF error, or may not.  

This is a follow-up to a series of previous PRs:
* #4360: add a first version of shape polymorphism, based on `masking.Poly` and `jax.shapecheck`.
* #4878: roll-back the jax2tf shape polymorphism, once we discovered that the underlying `masking.Poly` comparison operations were unsound
* #5286: an attempt to fix jax2tf shape polymorphism (not merged, will abandon)
* #6081: remove more mentions of jax2tf shape polymorphism