### PR TITLE
Mark arguments to jax.jit() other than the function as keyword-only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 * Bug fixes:
   * The {func}`jax2tf.convert` now works in presence of gradients for functions
     with integer inputs ({jax-issue}`#6360`).
+  * Arguments to {func}`jax.jit` other than the function are now marked as
+    keyword-only. This change is to prevent accidental breakage when arguments
+    are added to `jit`.
 
 ## jaxlib 0.1.66 (unreleased)
 

--- a/jax/api.py
+++ b/jax/api.py
@@ -203,6 +203,7 @@ def _infer_argnums_and_argnames(
 
 def jit(
   fun: F,
+  *,
   static_argnums: Union[int, Iterable[int]] = (),
   device: Optional[xc.Device] = None,
   backend: Optional[str] = None,

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -1360,7 +1360,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     if jit_f:
       f = api.jit(f)
     if jit_scan:
-      scan = api.jit(scan, (0,))
+      scan = api.jit(scan, static_argnums=(0,))
 
     as_ = rng.randn(5, 3)
     c = rng.randn(4)
@@ -1391,7 +1391,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     if jit_f:
       f = api.jit(f)
     if jit_scan:
-      scan = api.jit(scan, (0,))
+      scan = api.jit(scan, static_argnums=(0,))
 
     as_ = rng.randn(5, 3)
     c = rng.randn(4)
@@ -1425,7 +1425,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     if jit_f:
       f = api.jit(f)
     if jit_scan:
-      scan = api.jit(scan, (0,))
+      scan = api.jit(scan, static_argnums=(0,))
 
     as_ = rng.randn(5, 3)
     c = rng.randn(4)
@@ -1646,7 +1646,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     if jit_f:
       f = api.jit(f)
     if jit_scan:
-      scan = api.jit(scan, (0,))
+      scan = api.jit(scan, static_argnums=(0,))
 
     as_shape = [5, 3]
     c_shape = [4]

--- a/tests/lax_numpy_vectorize_test.py
+++ b/tests/lax_numpy_vectorize_test.py
@@ -142,7 +142,7 @@ class VectorizeTest(jtu.JaxTestCase):
 
     x = jnp.arange(3)
     self.assertAllClose(x, f('foo', x))
-    self.assertAllClose(x, jax.jit(f, 0)('foo', x))
+    self.assertAllClose(x, jax.jit(f, static_argnums=0)('foo', x))
 
   def test_exclude_second(self):
 
@@ -154,7 +154,7 @@ class VectorizeTest(jtu.JaxTestCase):
 
     x = jnp.arange(3)
     self.assertAllClose(x, f(x, 'foo'))
-    self.assertAllClose(x, jax.jit(f, 1)(x, 'foo'))
+    self.assertAllClose(x, jax.jit(f, static_argnums=1)(x, 'foo'))
 
   def test_exclude_errors(self):
     with self.assertRaisesRegex(


### PR DESCRIPTION
This change is to prevent breakage when options are added or removed.