### PR TITLE
[masking] Remove references to masking.Poly from lax and lax_numpy

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3863,10 +3863,7 @@ def _slice_shape_rule(operand, *, start_indices, limit_indices, strides):
     msg = ("slice limit_indices must have the same length as start_indices, "
            "got start_indices {} and limit_indices {}.")
     raise TypeError(msg.format(start_indices, limit_indices))
-  # TODO(necula): remove this check for is_polymorphic. It is unsound.
-  if (not masking.is_polymorphic(limit_indices) and
-      not masking.is_polymorphic(operand.shape) and
-      not core.greater_equal_shape(operand.shape, limit_indices)):
+  if not core.greater_equal_shape(operand.shape, limit_indices):
     msg = ("slice limit_indices must be less than or equal to operand shape, "
            "got limit_indices {} for operand shape {}.")
     raise TypeError(msg.format(limit_indices, operand.shape))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -46,7 +46,6 @@ from jax import errors
 from jax.core import UnshapedArray, ShapedArray, ConcreteArray, canonicalize_shape
 from jax.config import config
 from jax.interpreters.xla import DeviceArray, _DeviceArray, _CppDeviceArray
-from jax.interpreters.masking import Poly
 from jax import lax
 from jax._src.lax.lax import _device_put_raw
 from jax import ops
@@ -4408,9 +4407,6 @@ def take(a, indices, axis: Optional[int] = None, out=None, mode=None):
 
 def _normalize_index(index, axis_size):
   """Normalizes an index value in the range [-N, N) to the range [0, N)."""
-  if type(axis_size) is Poly:
-    return index + axis_size if index < 0 else index
-
   return lax.select(
     lax.lt(index, _constant_like(index, 0)),
     lax.add(index, _constant_like(index, axis_size)),
@@ -4434,7 +4430,7 @@ def _take_along_axis(arr, indices, axis):
     lst[axis] = val
     return tuple(lst)
 
-  use_64bit_index = _any([type(d) is Poly or d >= (1 << 31) for d in arr.shape])
+  use_64bit_index = _any([not core.is_constant_dim(d) or d >= (1 << 31) for d in arr.shape])
   index_dtype = int64 if use_64bit_index else int32
   indices = lax.convert_element_type(indices, index_dtype)
 
@@ -4699,7 +4695,7 @@ def _index_to_gather(x_shape, idx, normalize_indices=True):
   collapsed_slice_dims = []
   start_index_map = []
 
-  use_64bit_index = _any([type(d) is Poly or d >= (1 << 31) for d in x_shape])
+  use_64bit_index = _any([not core.is_constant_dim(d) or d >= (1 << 31) for d in x_shape])
   index_dtype = int64 if use_64bit_index else int32
   gather_indices = np.zeros((0,), dtype=index_dtype)  # use np to save a compilation
 
@@ -4758,10 +4754,6 @@ def _index_to_gather(x_shape, idx, normalize_indices=True):
         # XLA gives error when indexing into an axis of size 0
         raise IndexError(f"index is out of bounds for axis {x_axis} with size 0")
       i = _normalize_index(i, x_shape[x_axis]) if normalize_indices else i
-      if type(i) is Poly:
-        # dummy index if i is polynomial, doesn't matter for shape inference
-        # TODO(mattjj,j-towns,juliuskunze): revise this logic
-        i = 0
       i = lax.convert_element_type(i, index_dtype)
       i = broadcast_to(i, tuple(gather_indices.shape[:-1]) + (1,))
       gather_indices = concatenate((gather_indices, i), -1)
@@ -4784,7 +4776,7 @@ def _index_to_gather(x_shape, idx, normalize_indices=True):
       x_axis += 1
     # Handle slice index (only static, otherwise an error is raised)
     elif isinstance(i, slice):
-      if not _all(elt is None or type(elt) is Poly
+      if not _all(elt is None
                   or type(core.get_aval(elt)) is ConcreteArray
                   for elt in (i.start, i.stop, i.step)):
         msg = ("Array slice indices must have static start/stop/step to be used "
@@ -4947,42 +4939,15 @@ def _canonicalize_tuple_index(arr_ndim, idx):
     idx = tuple(idx) + colons
   return idx
 
-def _polymorphic_slice_indices(idx: slice, size: Union[int, Poly]):
-  # like idx.indices(size), but allows for polymorphic indices and size
-  # see https://github.com/python/cpython/blob/6d6508765514c7c10719478a0430f5e47c9a96ac/Objects/sliceobject.c#L372
-  assert isinstance(idx, slice)
-
-  step = 1 if idx.step is None else idx.step
-  step_is_negative = step < 0
-  lower = -1 if step_is_negative else 0
-  upper = size + lower
-
-  def sanitize(index, default):
-    if index is None:
-      return default
-    elif type(index) is Poly:
-      return index
-    elif index < 0:
-      return _max(index + size, lower)
-    else:
-      return _min(index, upper)
-
-  start = sanitize(idx.start, default=upper if step_is_negative else lower)
-  stop = sanitize(idx.stop, default=lower if step_is_negative else upper)
-  return start, stop, step
-
-def _static_idx(idx: slice, size: Union[int, Poly]):
+def _static_idx(idx: slice, size: core.DimSize):
   """Helper function to compute the static slice start/limit/stride values."""
-  if _any(type(s) is Poly for s in (idx.start, idx.stop, idx.step, size)):
-    start, stop, step = _polymorphic_slice_indices(idx, size)
-  elif isinstance(size, int):
+  if isinstance(size, int):
     start, stop, step = idx.indices(size)
   else:
     raise TypeError(size)
 
-  if type(start) is not Poly and type(stop) is not Poly:
-    if (step < 0 and stop >= start) or (step > 0 and start >= stop):
-      return 0, 0, 1, False  # sliced to size zero
+  if (step < 0 and stop >= start) or (step > 0 and start >= stop):
+    return 0, 0, 1, False  # sliced to size zero
 
   if step > 0:
     return start, stop, step, False

--- a/jax/core.py
+++ b/jax/core.py
@@ -1230,6 +1230,10 @@ class DimensionHandler:
   Subclasses should raise InconclusiveDimensionOperation if the result cannot
   be computed in some contexts.
   """
+  def is_constant(self, d: DimSize) -> bool:
+    """The dimension is a constant."""
+    return True
+
   def symbolic_equal(self, d1: DimSize, d2: DimSize) -> bool:
     """True iff the dimension sizes are equal in all contexts; False otherwise.
     Unlike `d1 == d2` this never raises InconclusiveDimensionOperation.
@@ -1302,6 +1306,10 @@ def _get_dim_handler(*dlist: DimSize) -> DimensionHandler:
     return handler
   else:
     return _dimension_handler_int
+
+def is_constant_dim(d: DimSize) -> bool:
+  d, = canonicalize_shape((d,))
+  return _get_dim_handler(d).is_constant(d)
 
 def symbolic_equal_dim(d1: DimSize, d2: DimSize) -> bool:
   d1, d2 = canonicalize_shape((d1, d2))

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -56,6 +56,10 @@ class DimVar:
 
 class DimensionHandlerVar(core.DimensionHandler):
   """See core.DimensionHandler."""
+  def is_constant(self, d: DimSize) -> bool:
+    assert isinstance(d, DimVar)
+    return False
+
   def symbolic_equal(self, d1: DimSize, d2: DimSize) -> bool:
     # We compare hashes first, to avoid InconclusiveDimensionOperation.
     return hash(d1) == hash(d2) and d1 == d2

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -310,6 +310,10 @@ class DimensionHandlerPoly(core.DimensionHandler):
 
   Most methods are inherited.
   """
+  def is_constant(self, d: DimSize) -> bool:
+    assert isinstance(d, Poly)
+    return False
+
   def symbolic_equal(self, d1: core.DimSize, d2: core.DimSize) -> bool:
     try:
       return d1 == d2

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -23,7 +23,6 @@ from jax import lax
 from jax import core
 from jax import test_util as jtu
 from jax.config import config
-from jax._src.numpy.lax_numpy import _polymorphic_slice_indices
 from jax._src.util import safe_map, safe_zip
 from jax.tree_util import tree_flatten
 
@@ -796,24 +795,6 @@ class MaskingTest(jtu.JaxTestCase):
     ans = fun([x, ns], dict(m=2))
     expected = 3+1 + 5+9+2
     self.assertAllClose(ans, expected, check_dtypes=False)
-
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_start={}_stop={}_step={}_length={}"
-       .format(start, stop, step, length),
-       "start": start, "stop": stop, "step": step, "length": length}
-      for length in range(1, 5)
-      for start, stop, step
-      in it.product(it.chain([None], range(-10, 10)), repeat=3)
-      if step != 0))
-  def test_slice_indices(self, start, stop, step, length):
-    s = slice(start, stop, step)
-    assert _polymorphic_slice_indices(s, length) == s.indices(length)
-
-  def test_slice_index_poly_start(self):
-    n = Poly({Mon({'n': 1}): 1})
-    s = slice(n, None, None)
-    assert (n, 2 * n, 1) == _polymorphic_slice_indices(s, 2 * n)
 
 
   def test_slice_oob_indexing(self):


### PR DESCRIPTION
Previously, in order to increase the coverage of masking we added special
cases in lax.py and lax_numpy.py to avoid exceptions in presence of
masking.Poly.

For example:
```
if not isinstance(d, masking.Poly):
   if some_check(d):
      raise ValueError
```

All such conditionals make the code behave potentially differently when
tracing with masking.Poly than when tracing with concrete shapes, which
makes it hard to ensure soundness.

Perhaps the most egregious was:
```
if type(i) is Poly:
  # dummy index if i is polynomial, doesn't matter for shape inference
  i = 0
```