### PR TITLE
Factor out wheel-building functions in build_jaxlib_wheels.sh.

### DIFF
--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -1,32 +1,11 @@
 #!/bin/bash
 set -xev
 
+source "$(dirname $(realpath $0))/build_jaxlib_wheels_helpers.sh"
+
 PYTHON_VERSIONS="3.6.8 3.7.2 3.8.0 3.9.0"
 CUDA_VERSIONS="10.1 10.2 11.0 11.1 11.2"
 CUDA_VARIANTS="cuda" # "cuda-included"
 
-mkdir -p dist
-
-# build the cuda linux packages
-for CUDA_VERSION in $CUDA_VERSIONS
-do
-  docker build -t jaxbuild jax/build/ --build-arg JAX_CUDA_VERSION=$CUDA_VERSION
-  for PYTHON_VERSION in $PYTHON_VERSIONS
-  do
-    for CUDA_VARIANT in $CUDA_VARIANTS
-    do
-      mkdir -p dist/${CUDA_VARIANT}${CUDA_VERSION//.}
-      docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION $CUDA_VARIANT $CUDA_VERSION
-      mv -f dist/*.whl dist/${CUDA_VARIANT}${CUDA_VERSION//.}/
-    done
-  done
-done
-
-# build the pypi linux packages
-docker build -t jaxbuild jax/build/
-for PYTHON_VERSION in $PYTHON_VERSIONS
-do
-  mkdir -p dist/nocuda/
-  docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
-  mv -f dist/*.whl dist/nocuda/
-done
+build_cuda_wheels "$PYTHON_VERSIONS" "$CUDA_VERSIONS" "$CUDA_VARIANTS"
+build_nocuda_wheels "$PYTHON_VERSIONS"

--- a/build/build_jaxlib_wheels_helpers.sh
+++ b/build/build_jaxlib_wheels_helpers.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+build_cuda_wheels() {
+  local PYTHON_VERSIONS=$1
+  local CUDA_VERSIONS=$2
+  local CUDA_VARIANTS=$3
+  mkdir -p dist
+  for CUDA_VERSION in $CUDA_VERSIONS
+  do
+    docker build -t jaxbuild jax/build/ --build-arg JAX_CUDA_VERSION=$CUDA_VERSION
+    for PYTHON_VERSION in $PYTHON_VERSIONS
+    do
+      for CUDA_VARIANT in $CUDA_VARIANTS
+      do
+        mkdir -p dist/${CUDA_VARIANT}${CUDA_VERSION//.}
+        docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION $CUDA_VARIANT $CUDA_VERSION
+        mv -f dist/*.whl dist/${CUDA_VARIANT}${CUDA_VERSION//.}/
+      done
+    done
+  done
+}
+
+build_nocuda_wheels() {
+  local PYTHON_VERSIONS=$1
+  mkdir -p dist
+  docker build -t jaxbuild jax/build/
+  for PYTHON_VERSION in $PYTHON_VERSIONS
+  do
+    mkdir -p dist/nocuda/
+    docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
+    mv -f dist/*.whl dist/nocuda/
+  done
+}


### PR DESCRIPTION
This will make it easier to build a single wheel, e.g. for GPU CI testing.

TESTING=I manually ran both build_jaxlib_wheels.sh and the individual
helper functions. I didn't do a full release build, but I verified
that a complete nocuda wheel can be successfully built.