### PR TITLE
Some updates to jax2tf

### DIFF
--- a/jax/experimental/jax2tf/examples/tf_js/quickdraw/README.md
+++ b/jax/experimental/jax2tf/examples/tf_js/quickdraw/README.md
@@ -12,24 +12,28 @@ and is a part of the code featured in the aforementioned blog post.
 ## Training the model
 
 You can train and export the model yourself by running
+
 ```bash
 $ python3 quickdraw.py
 ```
 
-The training itself lasts roughly 30 minutes, assuming the dataset has already
-been downloaded. You can also skip to the [next section](#interacting-with-the-model)
-to see instructions for playing with a pre-trained model.
+This will first download the dataset if it is not downloaded yet, which is about
+11Gb in total. Assuming the dataset has been downloaded already, training for 5
+epochs takes roughly 10 minutes on a CPU (3,5 GHz Dual-Core Intel Core i7). You
+can also skip to the [next section](#interacting-with-the-model) to see
+instructions for playing with a pre-trained model.
 
 The dataset will be downloaded directly into a `data/` directory in the
 `/tmp/jax2tf/tf_js_quickdraw` directory; by default, the model is configured to
-classify inputs into 100 different classes, which corresponds to a dataset of
-roughly 11 Gb. This can be tweaked by modifying the value of the `NB_CLASSES`
-global variable in `quickdraw.py` (max number of classes: 100). Only the files
-corresponding to the first `NB_CLASSES` classes in the dataset will be
+classify inputs into 100 different classes. This can be tweaked using the
+command-line argument `--num_classes` (max number of classes: 100). Only the
+files corresponding to the first `num_classes` classes in the dataset will be
 downloaded.
 
-The training loop runs for 5 epochs, and the model as well as its equivalent
-TF.js-loadable model are subsequently saved into `/tmp/jax2tf/tf_js_quickdraw`.
+The training loop runs for 5 epochs by default (this can be changed using
+the command-line argument `--num_epochs`), and the model as well as its
+equivalent TF.js-loadable model are subsequently saved into
+`/tmp/jax2tf/tf_js_quickdraw`.
 
 ## Interacting with the model
 

--- a/jax/experimental/jax2tf/examples/tf_js/quickdraw/quickdraw.py
+++ b/jax/experimental/jax2tf/examples/tf_js/quickdraw/quickdraw.py
@@ -44,9 +44,9 @@ flags.DEFINE_integer("num_epochs", 5,
                      ("Number of epochs to train for."))
 flags.DEFINE_integer("num_classes", 100, "Number of classification classes.")
 
-flags.register_validator('num_classes',
+flags.register_validator("num_classes",
                          lambda value: value >= 1 and value <= 100,
-                         message='--num_classes must be in range [1, 100]')
+                         message="--num_classes must be in range [1, 100]")
 
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
This PR makes the following changes:
- Replaces `jit_compile` with `experimental_compile` in a call to `tf.function`, since the most recent version of TF (2.4.1) uses this (see [tf.function documentation](https://www.tensorflow.org/api_docs/python/tf/function))
- Not running eval on the entire train set when training the `quickdraw` model reduces training time from 30min to 10min
- Some minor improvements to the quickdraw README
- Using flags in quickdraw for some settings