### PR TITLE
Use the axis names attached to a primitive when selecting the top trace

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -690,7 +690,7 @@ def _psum_transpose_rule(cts, *args, axes, axis_index_groups):
                                axis_index_groups=axis_index_groups)
   return tree_util.tree_unflatten(treedef, nonzero_in_cts)
 
-psum_p = core.Primitive('psum')
+psum_p = core.AxisPrimitive('psum')
 psum_p.multiple_results = True
 psum_p.def_impl(partial(_allreduce_impl, lax._reduce_sum))
 psum_p.def_abstract_eval(_allreduce_abstract_eval)
@@ -722,11 +722,11 @@ def psum_bind(*args, axes, axis_index_groups):
     else:
       size = prod([core.axis_frame(name).size for name in named_axes])  # type: ignore
     return tuple(lax._const(x, size) * pos_reduce(x) for x in args)
-  return core.Primitive.bind(
+  return core.AxisPrimitive.bind(
       psum_p, *args, axes=axes, axis_index_groups=axis_index_groups)
 
 
-pmax_p = core.Primitive('pmax')
+pmax_p = core.AxisPrimitive('pmax')
 pmax_p.multiple_results = True
 pmax_p.def_impl(partial(_allreduce_impl, lax._reduce_max))
 pmax_p.def_abstract_eval(_allreduce_abstract_eval)
@@ -739,7 +739,7 @@ batching.collective_rules[pmax_p] = \
 core.axis_substitution_rules[pmax_p] = partial(_subst_all_names_in_param, 'axes')
 
 
-pmin_p = core.Primitive('pmin')
+pmin_p = core.AxisPrimitive('pmin')
 pmin_p.multiple_results = True
 pmin_p.def_impl(partial(_allreduce_impl, lax._reduce_min))
 pmin_p.def_abstract_eval(_allreduce_abstract_eval)
@@ -791,7 +791,7 @@ def _ppermute_batcher(frame, vals_in, dims_in, axis_name, perm):
 def _collective_batcher(prim, args, dims, **params):
   return prim.bind(*args, **params), dims if prim.multiple_results else dims[0]
 
-ppermute_p = core.Primitive('ppermute')
+ppermute_p = core.AxisPrimitive('ppermute')
 ppermute_p.def_abstract_eval(lambda x, **params: raise_to_shaped(x))
 ad.deflinear2(ppermute_p, _ppermute_transpose_rule)
 xla.parallel_translations[ppermute_p] = _ppermute_translation_rule
@@ -937,7 +937,7 @@ def _all_to_all_abstract_eval(x, axis_name, split_axis, concat_axis, axis_index_
   shape[concat_axis] *= axis_size
   return input_aval.update(shape=tuple(shape), weak_type=False)
 
-all_to_all_p = core.Primitive('all_to_all')
+all_to_all_p = core.AxisPrimitive('all_to_all')
 all_to_all_p.def_abstract_eval(_all_to_all_abstract_eval)
 xla.parallel_translations[all_to_all_p] = _all_to_all_translation_rule
 ad.deflinear2(all_to_all_p, _all_to_all_transpose_rule)
@@ -1023,11 +1023,7 @@ def _all_gather_via_psum(x, *, all_gather_dimension, axis_name, axis_index_group
   return psum(outs, axis_name, axis_index_groups=axis_index_groups)
 
 def _all_gather_impl(x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size):
-  # Only called when the argument is not mapped.
-  out_shape = list(np.shape(x))
-  out_shape.insert(all_gather_dimension, axis_size)
-  broadcast_dims = [i for i in range(len(out_shape)) if i != all_gather_dimension]
-  return lax.broadcast_in_dim(x, out_shape, broadcast_dims)
+  raise AssertionError("Unexpected call to _all_gather_impl")
 
 def _all_gather_translation_rule(c, x, *, all_gather_dimension, axis_name, axis_index_groups, axis_size, axis_env, platform):
   # TODO(cjfj): Enable this for TPU also?
@@ -1085,10 +1081,14 @@ def _all_gather_batched_collective(frame, vals_in, dims_in, all_gather_dimension
     raise NotImplementedError("Please open a feature request!")
   assert axis_name == (frame.name,), "batcher called with wrong axis name"
   (x,), (d,) = vals_in, dims_in
-  assert d is not batching.not_mapped
+  if d is batching.not_mapped:
+    out_shape = list(np.shape(x))
+    out_shape.insert(all_gather_dimension, axis_size)
+    broadcast_dims = [i for i in range(len(out_shape)) if i != all_gather_dimension]
+    return lax.broadcast_in_dim(x, out_shape, broadcast_dims), batching.not_mapped
   return _moveaxis(d, all_gather_dimension, x), batching.not_mapped
 
-all_gather_p = core.Primitive('all_gather')
+all_gather_p = core.AxisPrimitive('all_gather')
 all_gather_p.def_abstract_eval(_all_gather_abstract_eval)
 all_gather_p.def_impl(_all_gather_impl)
 xla.parallel_translations[all_gather_p] = _all_gather_translation_rule
@@ -1148,7 +1148,7 @@ def _vmap_process_axis_index(self, frame):
 batching.BatchTrace.process_axis_index = _vmap_process_axis_index  # type: ignore
 
 
-pdot_p = core.Primitive('pdot')
+pdot_p = core.AxisPrimitive('pdot')
 core.axis_substitution_rules[pdot_p] = partial(_subst_all_names_in_param, 'axis_name')
 
 @pdot_p.def_impl
@@ -1294,7 +1294,7 @@ def _pgather_collective_batcher(frame, vals_in, dims_in, *, axes):
   else:
     return pgather_p.bind(src, idx, axes=new_axes), batching.not_mapped
 
-pgather_p = core.Primitive('pgather')
+pgather_p = core.AxisPrimitive('pgather')
 pgather_p.def_impl(_pgather_impl)
 pgather_p.def_abstract_eval(_pgather_abstract_eval)
 xla.parallel_translations[pgather_p] = _pgather_parallel_translation

--- a/jax/core.py
+++ b/jax/core.py
@@ -242,6 +242,7 @@ class Primitive:
   multiple_results = False  # set for multi-output primitives
   call_primitive = False    # set for call primitives processed in final style
   map_primitive = False     # set for map primitives processed in final style
+  _dispatch_on_params = False  # whether to include axis names form params in dispatch
 
   def __init__(self, name: str):
     self.name = name
@@ -253,7 +254,8 @@ class Primitive:
   def bind(self, *args, **params):
     assert (not config.jax_enable_checks or
             all(isinstance(arg, Tracer) or valid_jaxtype(arg) for arg in args)), args
-    top_trace = find_top_trace(args)
+    top_trace = find_top_trace(
+        args, used_axis_names(self, params) if self._dispatch_on_params else None)
     tracers = map(top_trace.full_raise, args)
     out = top_trace.process_primitive(self, tracers, params)
     return map(full_lower, out) if self.multiple_results else full_lower(out)
@@ -811,14 +813,17 @@ def full_lower(val):
   else:
     return val
 
-def find_top_trace(xs) -> Trace:
+def find_top_trace(xs, axis_names=None) -> Trace:
+  top_main: Optional[MainTrace] = None
+  if axis_names:
+    top_main = max((axis_frame(a).main_trace for a in axis_names),
+                   default=None, key=lambda t: getattr(t, 'level', -1))
   top_tracer = max((x for x in xs if isinstance(x, Tracer)),
-                    default=None, key=attrgetter('_trace.level'))
+                   default=None, key=attrgetter('_trace.level'))
   if top_tracer is not None:
     top_tracer._assert_live()
-    top_main = top_tracer._trace.main  # type: Optional[MainTrace]
-  else:
-    top_main = None
+    if top_tracer._trace.main.level > getattr(top_main, 'level', -1):
+      top_main = top_tracer._trace.main
   dynamic = thread_local_state.trace_state.trace_stack.dynamic
   top_main = (dynamic if top_main is None or dynamic.level > top_main.level
               else top_main)
@@ -1752,6 +1757,13 @@ def subst_axis_names_jaxpr(jaxpr: Union[Jaxpr, ClosedJaxpr], subst: AxisSubst):
   return new_jaxpr
 
 axis_substitution_rules: Dict[Primitive, Callable[[ParamDict, AxisSubst], ParamDict]] = {}
+
+# ------------------- AxisPrimitive -------------------
+# Primitives that store axis names in params and want those axis names to
+# participate in dispatch should subclass AxisPrimitive.
+
+class AxisPrimitive(Primitive):
+  _dispatch_on_params = True
 
 # ------------------- Jaxpr checking -------------------
 

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -725,6 +725,8 @@ def _process_xmap_default(self, call_primitive, f, tracers, params):
 core.Trace.process_xmap = _process_xmap_default  # type: ignore
 
 def _xmap_axis_subst(params, subst):
+  if 'call_jaxpr' not in params:  # TODO(apaszke): This feels sketchy, but I'm not sure why
+    return params
   def shadowed_subst(name):
     return (name,) if name in params['global_axis_sizes'] else subst(name)
   with core.extend_axis_env_nd(params['global_axis_sizes'].items()):

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -123,12 +123,12 @@ class BatchTrace(Trace):
 
   def process_primitive(self, primitive, tracers, params):
     vals_in, dims_in = unzip2((t.val, t.batch_dim) for t in tracers)
-    if all(bdim is not_mapped for bdim in dims_in):
-      return primitive.bind(*vals_in, **params)
     if (primitive in collective_rules and
           _main_trace_for_axis_names(self.main, core.used_axis_names(primitive, params))):
       frame = core.axis_frame(self.axis_name)
       val_out, dim_out = collective_rules[primitive](frame, vals_in, dims_in, **params)
+    elif all(bdim is not_mapped for bdim in dims_in):
+      return primitive.bind(*vals_in, **params)
     else:
       batched_primitive = get_primitive_batcher(primitive, self)
       val_out, dim_out = batched_primitive(vals_in, dims_in, **params)

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1152,6 +1152,13 @@ class BatchingTest(jtu.JaxTestCase):
     y = vmap(f)(a=jnp.array([1]), b=jnp.array([2]))  # doesn't work
     self.assertAllClose(x, y)
 
+  def testGradOfPsum(self):
+    a = jnp.ones(5)
+    f = vmap(jax.grad(lambda x: -lax.psum(x, 'i')), out_axes=None, axis_name='i')
+    self.assertEqual(
+        f(a),
+        jax.core.jaxpr_as_fun(jax.make_jaxpr(f)(a))(a)[0])
+
   def testAllGatherToUnmapped(self):
     def f(x):
       return lax.all_gather(x, axis_name='i')

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1324,12 +1324,6 @@ class PmapTest(jtu.JaxTestCase):
     ans = pmap(jit(f), 'i')(x)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def testMakeJaxprOfOpenSpmd(self):
-    f = lambda x: x - lax.psum(x, 'i')
-    shape = (xla_bridge.device_count(), 4)
-    x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
-    make_jaxpr(f)(x)  # doesn't crash
-
   def testCompositionWithJitTwice(self):
     @jit
     def f(x):

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -451,6 +451,11 @@ class XMapTest(XMapTestCase):
                   axis_resources=dict(axis_resources))()
     self.assertAllClose(result, jnp.arange(6, dtype=result.dtype))
 
+  def testCollectiveOverNoName(self):
+    result = xmap(lambda: lax.psum(jnp.array(2) ** 2, 'i'),
+                  in_axes={}, out_axes={}, axis_sizes={'i': 4})()
+    self.assertEqual(result, 16)
+
   def VmapOfXmapCases(s):
     xmap_in_axes = ([{}] +
                     [{i: 'x'} for i in range(3)] +


### PR DESCRIPTION
This is useful e.g. for handling psums of values that are not sharded,
but are also not statically known constants that we can fold.