### PR TITLE
Remove backward compatibility code paths for jaxlib < 0.1.65.

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -125,7 +125,7 @@ class TraceAnnotation(xla_client.profiler.TraceMe):
   pass
 
 
-# TODO: remove this sometime after jax 0.1.11 is released
+# TODO: remove this sometime after jax 0.2.11 is released
 class TraceContext(TraceAnnotation):
   def __init__(self, *args, **kwargs):
     warnings.warn(
@@ -160,7 +160,7 @@ class StepTraceAnnotation(TraceAnnotation):
     super().__init__(name, _r=1, **kwargs)
 
 
-# TODO: remove this sometime after jax 0.1.11 is released
+# TODO: remove this sometime after jax 0.2.11 is released
 class StepTraceContext(StepTraceAnnotation):
   def __init__(self, *args, **kwargs):
     warnings.warn(
@@ -204,7 +204,7 @@ def annotate_function(func: Callable, name: str = None, **kwargs):
   return wrapper
 
 
-# TODO: remove this sometime after jax 0.1.11 is released
+# TODO: remove this sometime after jax 0.2.11 is released
 def trace_function(*args, **kwargs):
   warnings.warn(
       "trace_function has been renamed to annotate_function. This alias "

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1037,7 +1037,7 @@ class _DeviceArray(DeviceArray):  # type: ignore
   """A DeviceArray is an ndarray backed by a single device memory buffer."""
   # We don't subclass ndarray because that would open up a host of issues,
   # but lax_numpy.py overrides isinstance behavior and attaches ndarray methods.
-  # TODO(phawkins): make __weakref__ an unconditional slot when jaxlib 0.1.65
+  # TODO(phawkins): make __weakref__ an unconditional slot when jaxlib 0.1.66
   # is the minimum version.
   __slots__ = [
       "aval", "device_buffer", "_npy_value", "_device"

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -492,8 +492,6 @@ class LaxTest(jtu.JaxTestCase):
                              feature_group_count, batch_group_count,
                              dimension_numbers, perms):
     if np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.bool_):
-      if jtu.device_under_test() == "cpu" and jax.lib.version < (0, 1, 65):
-        raise SkipTest("Integer convolution requires jaxlib 0.1.65 or newer on CPU")
       # TODO(b/183565702): Support integer convolutions on CPU/GPU.
       if jtu.device_under_test() == "gpu":
         raise SkipTest("Integer convolution not yet supported on GPU")
@@ -631,8 +629,6 @@ class LaxTest(jtu.JaxTestCase):
                                                   dimension_numbers,
                                                   precision):
     if np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.bool_):
-      if jtu.device_under_test() == "cpu" and jax.lib.version < (0, 1, 65):
-        raise SkipTest("Integer convolution requires jaxlib 0.1.65 or newer on CPU")
       # TODO(b/183565702): Support integer convolutions on CPU/GPU.
       if jtu.device_under_test() == "gpu":
         raise SkipTest("Integer convolution not yet supported on GPU")


### PR DESCRIPTION
Fix up a few version comments.