### PR TITLE
DOC: fix typos.

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -994,7 +994,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With this pytree-handling `jvp` impelmentation, we can now handle arbitrary\n",
+    "With this pytree-handling `jvp` implementation, we can now handle arbitrary\n",
     "input and output containers. That'll come in handy with future transformations\n",
     "too!"
    ]

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -725,7 +725,7 @@ def _tree_unflatten(treedef: PyTreeDef, xs: Iterator) -> Any:
     return treedef.node_type.from_iterable(treedef.node_metadata, children)
 ```
 
-With this pytree-handling `jvp` impelmentation, we can now handle arbitrary
+With this pytree-handling `jvp` implementation, we can now handle arbitrary
 input and output containers. That'll come in handy with future transformations
 too!
 

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -687,7 +687,7 @@ def _tree_unflatten(treedef: PyTreeDef, xs: Iterator) -> Any:
     return treedef.node_type.from_iterable(treedef.node_metadata, children)
 # -
 
-# With this pytree-handling `jvp` impelmentation, we can now handle arbitrary
+# With this pytree-handling `jvp` implementation, we can now handle arbitrary
 # input and output containers. That'll come in handy with future transformations
 # too!
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -203,7 +203,7 @@ And then run:
 sphinx-build -b html docs docs/build/html
 ```
 This can take a long time because it executes many of the notebooks in the documentation source;
-if you'd prefer to build the docs without exeuting the notebooks, you can run:
+if you'd prefer to build the docs without executing the notebooks, you can run:
 ```
 sphinx-build -b html -D jupyter_execute_notebooks=off docs docs/build/html
 ```

--- a/docs/notebooks/autodiff_cookbook.ipynb
+++ b/docs/notebooks/autodiff_cookbook.ipynb
@@ -723,7 +723,7 @@
     "\n",
     "$\\qquad (x, v) \\mapsto v \\partial f(x)$,\n",
     "\n",
-    "where $v$ is an element of the cotangent space of $f$ at $x$ (isomorphic to another copy of $\\mathbb{R}^m$). When being rigorous, we should think of $v$ as a linear map $v : \\mathbb{R}^m \\to \\mathbb{R}$, and when we write $v \\partial f(x)$ we mean function composition $v \\circ \\partial f(x)$, where the types work out because $\\partial f(x) : \\mathbb{R}^n \\to \\mathbb{R}^m$. But in the common case we can identify $v$ with a vector in $\\mathbb{R}^m$ and use the two almost interchageably, just like we might sometimes flip between \"column vectors\" and \"row vectors\" without much comment.\n",
+    "where $v$ is an element of the cotangent space of $f$ at $x$ (isomorphic to another copy of $\\mathbb{R}^m$). When being rigorous, we should think of $v$ as a linear map $v : \\mathbb{R}^m \\to \\mathbb{R}$, and when we write $v \\partial f(x)$ we mean function composition $v \\circ \\partial f(x)$, where the types work out because $\\partial f(x) : \\mathbb{R}^n \\to \\mathbb{R}^m$. But in the common case we can identify $v$ with a vector in $\\mathbb{R}^m$ and use the two almost interchangeably, just like we might sometimes flip between \"column vectors\" and \"row vectors\" without much comment.\n",
     "\n",
     "With that identification, we can alternatively think of the linear part of a VJP as the transpose (or adjoint conjugate) of the linear part of a JVP:\n",
     "\n",

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -415,7 +415,7 @@ Starting from our notation for JVPs, the notation for VJPs is pretty simple:
 
 $\qquad (x, v) \mapsto v \partial f(x)$,
 
-where $v$ is an element of the cotangent space of $f$ at $x$ (isomorphic to another copy of $\mathbb{R}^m$). When being rigorous, we should think of $v$ as a linear map $v : \mathbb{R}^m \to \mathbb{R}$, and when we write $v \partial f(x)$ we mean function composition $v \circ \partial f(x)$, where the types work out because $\partial f(x) : \mathbb{R}^n \to \mathbb{R}^m$. But in the common case we can identify $v$ with a vector in $\mathbb{R}^m$ and use the two almost interchageably, just like we might sometimes flip between "column vectors" and "row vectors" without much comment.
+where $v$ is an element of the cotangent space of $f$ at $x$ (isomorphic to another copy of $\mathbb{R}^m$). When being rigorous, we should think of $v$ as a linear map $v : \mathbb{R}^m \to \mathbb{R}$, and when we write $v \partial f(x)$ we mean function composition $v \circ \partial f(x)$, where the types work out because $\partial f(x) : \mathbb{R}^n \to \mathbb{R}^m$. But in the common case we can identify $v$ with a vector in $\mathbb{R}^m$ and use the two almost interchangeably, just like we might sometimes flip between "column vectors" and "row vectors" without much comment.
 
 With that identification, we can alternatively think of the linear part of a VJP as the transpose (or adjoint conjugate) of the linear part of a JVP:
 


### PR DESCRIPTION
- `exeuting` → `executing`
- `interchageably` → `interchangeably`
- `impelmentation` → `implementation`