### PR TITLE
Remove assertion in testing the model gradient

### DIFF
--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -35,7 +35,9 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
   def save_and_load_model(self, model: tf.Module) -> tf.Module:
     # Roundtrip through saved model on disk.
     model_dir = os.path.join(absltest.get_default_test_tmpdir(), str(id(model)))
-    tf.saved_model.save(model, model_dir)
+    tf.saved_model.save(
+        model, model_dir,
+        options=tf.saved_model.SaveOptions(custom_gradients=True))
     restored_model = tf.saved_model.load(model_dir)
     return restored_model
 
@@ -94,13 +96,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     self.assertAllClose(restored_model.f(x), f_jax(x))
     with tf.GradientTape() as tape:
       y = restored_model.f(xv)
-
-    # TODO: at the moment TF does not fully-support custom_gradient in a
-    # savedmodel (b/123499169), but at least a warning is printed and an
-    # exception is thrown when gradients are taken. The exception, however,
-    # is a very strange one, for now.
-    with self.assertRaisesRegex(TypeError, "An op outside of the function building code is being passed"):
-      _ = tape.gradient(y, xv)
+    _ = tape.gradient(y, xv)
 
   def _compare_with_saved_model(self, f_jax, *args):
     # Certain ops are converted to ensure an XLA context, e.g.,


### PR DESCRIPTION
Custom gradients supported is added to SavedModels in cl/360508711. 

The hope is that these two can be submitted concurrently, but if there are issues let me know! 

edit: I may have done this wrong, closing