### PR TITLE
Speed up test generation 7x

### DIFF
--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -889,20 +889,20 @@ class UpdateOps(enum.Enum):
 
 class IndexedUpdateTest(jtu.JaxTestCase):
 
-  @parameterized.named_parameters(jtu.cases_from_list({
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
       "testcase_name": "{}_inshape={}_indexer={}_update={}_sugared={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), sugared, op.name),
        "shape": shape, "dtype": dtype, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op, "sugared": sugared
-  } for name, index_specs in STATIC_INDEXING_TESTS
-    for shape, indexer in index_specs
-    for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
-    for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for sugared in [True, False]))
+  } for name, index_specs in s(STATIC_INDEXING_TESTS)
+    for shape, indexer in s(index_specs)
+    for op in s(UpdateOps)
+    for dtype in s(all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for update_shape in s(_broadcastable_shapes(_update_shape(shape, indexer)))
+    for update_dtype in s([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in s([True, False]))))
   def testStaticIndexing(self, shape, dtype, update_shape, update_dtype,
                          indexer, sugared, op):
     rng = jtu.rand_default(self.rng())
@@ -915,20 +915,20 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fn, jax_fn, args_maker)
     self._CompileAndCheck(jax_fn, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list({
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
       "testcase_name": "{}_inshape={}_indexer={}_update={}_sugared={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), sugared, op.name),
        "shape": shape, "dtype": dtype, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op, "sugared": sugared
-  } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS
-    for shape, indexer in index_specs
-    for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
-    for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for sugared in [True, False]))
+  } for name, index_specs in s(ADVANCED_INDEXING_TESTS_NO_REPEATS)
+    for shape, indexer in s(index_specs)
+    for op in s(UpdateOps)
+    for dtype in s(all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for update_shape in s(_broadcastable_shapes(_update_shape(shape, indexer)))
+    for update_dtype in s([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in s([True, False]))))
   def testAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
                            indexer, sugared, op):
     rng = jtu.rand_default(self.rng())
@@ -941,20 +941,20 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fn, jax_fn, args_maker)
     self._CompileAndCheck(jax_fn, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list({
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
       "testcase_name": "{}_inshape={}_indexer={}_update={}_sugared={}_op={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), sugared, op.name),
        "shape": shape, "dtype": dtype, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op, "sugared": sugared
-  } for name, index_specs in ADVANCED_INDEXING_TESTS_NO_REPEATS_SORTED
-    for shape, indexer in index_specs
-    for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
-    for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for sugared in [True, False]))
+  } for name, index_specs in s(ADVANCED_INDEXING_TESTS_NO_REPEATS_SORTED)
+    for shape, indexer in s(index_specs)
+    for op in s(UpdateOps)
+    for dtype in s(all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for update_shape in s(_broadcastable_shapes(_update_shape(shape, indexer)))
+    for update_dtype in s([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in s([True, False]))))
   def testAdvancedIndexingSorted(self, shape, dtype, update_shape, update_dtype,
                            indexer, sugared, op):
     rng = jtu.rand_default(self.rng())
@@ -969,20 +969,20 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fn, jax_fn, args_maker, check_dtypes=True)
     self._CompileAndCheck(jax_fn, args_maker, check_dtypes=True)
 
-  @parameterized.named_parameters(jtu.cases_from_list({
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
       "testcase_name": "{}_inshape={}_indexer={}_update={}_op={}_sugared={}".format(
           name, jtu.format_shape_dtype_string(shape, dtype), indexer,
           jtu.format_shape_dtype_string(update_shape, update_dtype), op.name, sugared),
        "shape": shape, "dtype": dtype, "indexer": indexer,
        "update_shape": update_shape, "update_dtype": update_dtype,
        "op": op, "sugared": sugared
-  } for name, index_specs in MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS
-    for shape, indexer in index_specs
-    for op in UpdateOps
-    for dtype in (all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
-    for update_shape in _broadcastable_shapes(_update_shape(shape, indexer))
-    for update_dtype in ([dtype] if op == UpdateOps.ADD else all_dtypes)
-    for sugared in [True, False]))
+  } for name, index_specs in s(MIXED_ADVANCED_INDEXING_TESTS_NO_REPEATS)
+    for shape, indexer in s(index_specs)
+    for op in s(UpdateOps)
+    for dtype in s(all_dtypes if op == UpdateOps.UPDATE else default_dtypes)
+    for update_shape in s(_broadcastable_shapes(_update_shape(shape, indexer)))
+    for update_dtype in s([dtype] if op == UpdateOps.ADD else all_dtypes)
+    for sugared in s([True, False]))))
   def testMixedAdvancedIndexing(self, shape, dtype, update_shape, update_dtype,
                                 indexer, sugared, op):
     rng = jtu.rand_default(self.rng())

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2729,19 +2729,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-       {"testcase_name":
-           "_shape={}_n={}_axis={}_prepend={}_append={}".format(
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+      "testcase_name": "_shape={}_n={}_axis={}_prepend={}_append={}".format(
            jtu.format_shape_dtype_string(shape, dtype),
            n, axis, prepend, append),
         "shape": shape, "dtype": dtype, "n": n, "axis": axis,
-        "prepend": prepend, "append": append}
-       for shape, dtype in _shape_and_dtypes(nonempty_nonscalar_array_shapes, default_dtypes)
-       for n in [0, 1, 2]
-       for axis in list(range(-len(shape), max(1, len(shape))))
-       for prepend in [None, 1, np.zeros(shape, dtype=dtype)]
-       for append in [None, 1, np.zeros(shape, dtype=dtype)]
-       ))
+        "prepend": prepend, "append": append
+    } for shape, dtype in s(_shape_and_dtypes(nonempty_nonscalar_array_shapes, default_dtypes))
+      for n in s([0, 1, 2])
+      for axis in s(list(range(-len(shape), max(1, len(shape)))))
+      for prepend in s([None, 1, np.zeros(shape, dtype=dtype)])
+      for append in s([None, 1, np.zeros(shape, dtype=dtype)])
+      )))
   def testDiff(self, shape, dtype, n, axis, prepend, append):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -2787,20 +2786,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp.ones((-1, 1))
 
   @unittest.skipIf(numpy_version < (1, 17), "shape parameter not supported in older numpy")
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_filldtype={}_fillshape={}_outdtype={}_outshape={}".format(
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+       "testcase_name": "_inshape={}_filldtype={}_fillshape={}_outdtype={}_outshape={}".format(
           jtu.format_shape_dtype_string(shape, in_dtype),
           np.dtype(fill_value_dtype).name, fill_value_shape,
           np.dtype(out_dtype).name, out_shape),
        "shape": shape, "in_dtype": in_dtype,
        "fill_value_dtype": fill_value_dtype, "fill_value_shape": fill_value_shape,
-       "out_dtype": out_dtype, "out_shape": out_shape}
-      for shape in array_shapes
-      for out_shape in [None] + array_shapes
-      for in_dtype in default_dtypes
-      for fill_value_dtype in default_dtypes
-      for fill_value_shape in _compatible_shapes(shape if out_shape is None else out_shape)
-      for out_dtype in default_dtypes))
+       "out_dtype": out_dtype, "out_shape": out_shape
+    } for shape in s(array_shapes)
+      for out_shape in s([None] + array_shapes)
+      for in_dtype in s(default_dtypes)
+      for fill_value_dtype in s(default_dtypes)
+      for fill_value_shape in s(_compatible_shapes(shape if out_shape is None else out_shape))
+      for out_dtype in s(default_dtypes))))
   def testFullLike(self, shape, in_dtype, fill_value_dtype, fill_value_shape, out_dtype, out_shape):
     if numpy_version < (1, 19) and out_shape == ():
       raise SkipTest("Numpy < 1.19 treats out_shape=() like out_shape=None")
@@ -4134,14 +4133,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_{}".format("_".join(
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+      "testcase_name": "_{}".format("_".join(
         jtu.format_shape_dtype_string(shape, dtype)
         for shape, dtype in zip(shapes, dtypes))),
-     "shapes": shapes, "dtypes": dtypes}
-    for shapes in filter(_shapes_are_broadcast_compatible,
-                         itertools.combinations_with_replacement(all_shapes, 3))
-    for dtypes in itertools.combinations_with_replacement(all_dtypes, 3)))
+      "shapes": shapes, "dtypes": dtypes
+    } for shapes in s(filter(_shapes_are_broadcast_compatible,
+                         itertools.combinations_with_replacement(all_shapes, 3)))
+      for dtypes in s(itertools.combinations_with_replacement(all_dtypes, 3)))))
   def testWhereThreeArgument(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
@@ -4155,15 +4154,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                   jnp.ones((2,), dtype=jnp.float32))
     self.assertEqual(x.dtype, np.dtype(np.float32))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix(
-            "", shapes, (np.bool_,) * n + dtypes),
-         "shapes": shapes, "dtypes": dtypes}
-        for n in range(1, 3)
-        for shapes in filter(
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+      "testcase_name": jtu.format_test_name_suffix("", shapes, (np.bool_,) * n + dtypes),
+      "shapes": shapes, "dtypes": dtypes
+    } for n in s(range(1, 3))
+      for shapes in s(filter(
           _shapes_are_broadcast_compatible,
-          itertools.combinations_with_replacement(all_shapes, 2 * n + 1))
-        for dtypes in itertools.combinations_with_replacement(all_dtypes, n + 1)))
+          itertools.combinations_with_replacement(all_shapes, 2 * n + 1)))
+      for dtypes in s(itertools.combinations_with_replacement(all_dtypes, n + 1)))))
   def testSelect(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     n = len(dtypes) - 1

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -459,8 +459,8 @@ class LaxTest(jtu.JaxTestCase):
 
     self._CheckAgainstNumpy(numpy_fun, fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_strides={}_padding={}"
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+       "testcase_name": "_lhs_shape={}_rhs_shape={}_strides={}_padding={}"
        "_lhs_dilation={}_rhs_dilation={}"
        "_dims={}".format(
            jtu.format_shape_dtype_string(lhs_shape, dtype),
@@ -471,22 +471,23 @@ class LaxTest(jtu.JaxTestCase):
        "strides": strides, "padding": padding, "lhs_dilation": lhs_dilation,
        "rhs_dilation": rhs_dilation, "dimension_numbers": dim_nums,
        "feature_group_count": feature_group_count,
-       "batch_group_count": batch_group_count, "perms": perms}
-      for batch_group_count, feature_group_count in [(1, 1), (2, 1), (1, 2)]
-      for lhs_shape, rhs_shape in [
+       "batch_group_count": batch_group_count, "perms": perms
+    } for batch_group_count, feature_group_count in s([(1, 1), (2, 1), (1, 2)])
+      for lhs_shape, rhs_shape in s([
           ((b * batch_group_count, i * feature_group_count, 9, w),
            (j * feature_group_count * batch_group_count, i, 4, 5))
           for w in [0, 10]
-          for b, i, j in itertools.product([2, 3], repeat=3)]
-      for dtype in all_dtypes for strides in [(1, 1), (2, 1)]
-      for padding in [((1, 2), (2, 0)), ((10, 8), (7, 13))]
-      for lhs_dilation, rhs_dilation in itertools.product(
-          [(1, 1), (1, 2), (1, 4)], repeat=2)
-      for dim_nums, perms in [
+          for b, i, j in itertools.product([2, 3], repeat=3)])
+      for dtype in s(all_dtypes)
+      for strides in s([(1, 1), (2, 1)])
+      for padding in s([((1, 2), (2, 0)), ((10, 8), (7, 13))])
+      for lhs_dilation, rhs_dilation in s(itertools.product(
+          [(1, 1), (1, 2), (1, 4)], repeat=2))
+      for dim_nums, perms in s([
         (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
         (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
         (("NCHW", "HWIO", "NHWC"), ([0, 1, 2, 3], [2, 3, 1, 0])),
-      ]))
+      ]))))
   def testConvGeneralDilated(self, lhs_shape, rhs_shape, dtype, strides,
                              padding, lhs_dilation, rhs_dilation,
                              feature_group_count, batch_group_count,

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -100,8 +100,8 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(op, 10, bdims, shapes, [dtype] * len(shapes), rng,
                         atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+       "testcase_name":
        "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_lhs_dilation={}_"
        "rhs_dilation={}_dims={}_feature_group_count={}_batch_group_count={}"
        "_lhs_bdim={}_rhs_bdim={}"
@@ -115,31 +115,30 @@ class LaxVmapTest(jtu.JaxTestCase):
        "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim,
        "feature_group_count": feature_group_count,
        "batch_group_count": batch_group_count,
-       }
-      for batch_group_count, feature_group_count in ([(1, 1), (2, 1), (1, 2)])
-      for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in [
-          ((b * batch_group_count, i * feature_group_count, 6, 7),  # lhs_shape
-           (j * batch_group_count * feature_group_count, i, 1, 2),  # rhs_shape
-           [(1, 1), (1, 2), (2, 1)],  # strides
-           [((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],  # pads
-           [(1, 1), (2, 1)],  # lhs_dils
-           [(1, 1), (2, 2)])  # rhs_dils
-          for b, i, j in itertools.product([1, 2], repeat=3)]
-      for strides in all_strides
-      for rhs_dil in rhs_dils
-      for lhs_dil in lhs_dils
-      for dtype in [np.float32]
-      for padding in all_pads
-      for dim_nums, perms in [
-          (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
-          (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
-          (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))]
-      for lhs_bdim in itertools.chain([cast(Optional[int], None)],
-                                      range(len(lhs_shape) + 1))
-      for rhs_bdim in itertools.chain([cast(Optional[int], None)],
-                                      range(len(rhs_shape) + 1))
-      if (lhs_bdim, rhs_bdim) != (None, None)
-  ))
+     } for batch_group_count, feature_group_count in s([(1, 1), (2, 1), (1, 2)])
+       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in s([
+           ((b * batch_group_count, i * feature_group_count, 6, 7),  # lhs_shape
+            (j * batch_group_count * feature_group_count, i, 1, 2),  # rhs_shape
+            [(1, 1), (1, 2), (2, 1)],  # strides
+            [((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],  # pads
+            [(1, 1), (2, 1)],  # lhs_dils
+            [(1, 1), (2, 2)])  # rhs_dils
+           for b, i, j in itertools.product([1, 2], repeat=3)])
+       for strides in s(all_strides)
+       for rhs_dil in s(rhs_dils)
+       for lhs_dil in s(lhs_dils)
+       for dtype in s([np.float32])
+       for padding in s(all_pads)
+       for dim_nums, perms in s([
+           (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
+           (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
+           (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3]))])
+       for lhs_bdim in s(itertools.chain([cast(Optional[int], None)],
+                                         range(len(lhs_shape) + 1)))
+       for rhs_bdim in s(itertools.chain([cast(Optional[int], None)],
+                                         range(len(rhs_shape) + 1)))
+       if (lhs_bdim, rhs_bdim) != (None, None)
+       )))
   def testConvGeneralDilatedBatching(
       self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dil, rhs_dil,
       dimension_numbers, perms, feature_group_count, batch_group_count,

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1651,19 +1651,20 @@ class PmapTest(jtu.JaxTestCase):
 
 class VmapOfPmapTest(jtu.JaxTestCase):
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"{shapes}_{vmap_in_axes}_{vmap_out_axes}_{pmap_in_axes}_{pmap_out_axes}",
+  # TODO(apaszke)
+  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
+       "testcase_name": f"{shapes}_{vmap_in_axes}_{vmap_out_axes}_{pmap_in_axes}_{pmap_out_axes}",
        "shapes": shapes,
        "vmap_in_axes": vmap_in_axes, "vmap_out_axes": vmap_out_axes,
-       "pmap_in_axes": pmap_in_axes, "pmap_out_axes": pmap_out_axes}
-      for arg_shapes in compatible_shapes
-      for num_args in range(1, 4)
-      for shapes in list(it.combinations_with_replacement(arg_shapes, num_args))
-      for vmap_in_axes in all_bdims(*shapes, pmap=False)
-      for pmap_in_axes in all_bdims(*shapes, pmap=True)
-      for vmap_out_axes in out_bdims(shapes[0], False)
-      for pmap_out_axes in out_bdims(shapes[0], True)
-  ))
+       "pmap_in_axes": pmap_in_axes, "pmap_out_axes": pmap_out_axes
+    } for arg_shapes in s(compatible_shapes)
+      for num_args in s(range(1, 4))
+      for shapes in s(list(it.combinations_with_replacement(arg_shapes, num_args)))
+      for vmap_in_axes in s(all_bdims(*shapes, pmap=False))
+      for pmap_in_axes in s(all_bdims(*shapes, pmap=True))
+      for vmap_out_axes in s(out_bdims(shapes[0], False))
+      for pmap_out_axes in s(out_bdims(shapes[0], True))
+  )))
   def testVmapOfPmap(self, shapes, vmap_in_axes, pmap_in_axes, vmap_out_axes, pmap_out_axes):
     vmapped_size = 3
     pmapped_size = xla_bridge.device_count()


### PR DESCRIPTION
There are a few test cases that generate millions of configurations,
only to have a handful of them selected by `cases_form_list`. I've
found all tests that spend over 100ms in case generation and
converted them to a new "test sampler" approach. The result: test
generation time drops from 15s to around 2s. Doesn't sound like much,
but I expect that we all run tests many times daily, so it seems like a
useful thing to have.

The rough idea is that the sampling generators get parameterized by a
sampler function that should be applied to the range of every `for` loop.
This allows us to sample runs of the generator through different
configurations by restricting each loop to a smaller subset. Right now
we always narrow it down to a single randomly selected instance. But,
we still retain the possibility of adding exhaustive testing in the
future, which can be achieved by passing in an identity sampling
function that wouldn't modify any loop ranges.