### PR TITLE
[jax2tf] Improved shape poly tests

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1679,7 +1679,7 @@ def _where(condition, x=None, y=None):
     condition = lax.ne(condition, zeros_like(condition))
   x, y = _promote_dtypes(x, y)
   condition, x, y = broadcast_arrays(condition, x, y)
-  return lax.select(condition, x, y) if np.size(x) else x
+  return lax.select(condition, x, y) if not core.is_empty_shape(np.shape(x)) else x
 
 
 _WHERE_DOC = """\

--- a/jax/core.py
+++ b/jax/core.py
@@ -1355,6 +1355,9 @@ def divide_shape_sizes(s1: Shape, s2: Shape) -> int:
 def same_shape_sizes(s1: Shape, s2: Shape) -> bool:
   return 1 == divide_shape_sizes(s1, s2)
 
+def is_empty_shape(s: Shape) -> bool:
+  return any(symbolic_equal_dim(d, 0) for d in s)
+
 def dilate_dim(d: DimSize, dilation: DimSize) -> DimSize:
   """Implements `0 if d == 0 else 1 + dilation * (d - 1))`"""
   handler, ds = _dim_handler_and_canonical(d, dilation)


### PR DESCRIPTION
[jax2tf] Re-organized the tests for shape polymorphism

    Added primitive harnesses and rewrote many existing tests in terms
    of those.

    Fixed the shape polymorphism for jnp.where.