### PR TITLE
Remove `-it` flag from `docker run` command in jaxlib build script.

### DIFF
--- a/build/build_jaxlib_wheels_helpers.sh
+++ b/build/build_jaxlib_wheels_helpers.sh
@@ -13,7 +13,7 @@ build_cuda_wheels() {
       for CUDA_VARIANT in $CUDA_VARIANTS
       do
         mkdir -p dist/${CUDA_VARIANT}${CUDA_VERSION//.}
-        docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION $CUDA_VARIANT $CUDA_VERSION
+        docker run --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION $CUDA_VARIANT $CUDA_VERSION
         mv -f dist/*.whl dist/${CUDA_VARIANT}${CUDA_VERSION//.}/
       done
     done
@@ -27,7 +27,7 @@ build_nocuda_wheels() {
   for PYTHON_VERSION in $PYTHON_VERSIONS
   do
     mkdir -p dist/nocuda/
-    docker run -it --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
+    docker run --tmpfs /build:exec --rm -v $(pwd)/dist:/dist jaxbuild $PYTHON_VERSION nocuda
     mv -f dist/*.whl dist/nocuda/
   done
 }


### PR DESCRIPTION
It's unnecessary because the image isn't used interactively in the
script, and it prevents the script from being used when no TTY is
available (e.g. when running from a different script).