### PR TITLE
Fix nanquantile handling of negative nans

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5170,9 +5170,10 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
     raise ValueError("q must be have rank <= 1, got shape {}".format(shape(q)))
 
   a_shape = shape(a)
-  a = lax.sort(a, dimension=axis)
 
   if squash_nans:
+    a = where(isnan(a), nan, a) # Ensure nans are positive so they sort to the end.
+    a = lax.sort(a, dimension=axis)
     counts = sum(logical_not(isnan(a)), axis=axis, dtype=q.dtype,
                  keepdims=keepdims)
     shape_after_reduction = counts.shape
@@ -5200,6 +5201,7 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
     index[axis] = high
     high_value = a[tuple(index)]
   else:
+    a = lax.sort(a, dimension=axis)
     n = a_shape[axis]
     q = lax.mul(q, _constant_like(q, n - 1))
     low = lax.floor(q)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -666,10 +666,13 @@ def rand_some_nan(rng):
       return base_rand(shape, dtype)
 
     dims = _dims_of_shape(shape)
-    nan_flips = rng.rand(*dims) < 0.1
+    r = rng.rand(*dims)
+    nan_flips = r < 0.1
+    neg_nan_flips = r < 0.05
 
     vals = base_rand(shape, dtype)
     vals = np.where(nan_flips, np.array(np.nan, dtype=dtype), vals)
+    vals = np.where(neg_nan_flips, np.array(-np.nan, dtype=dtype), vals)
 
     return _cast_to_shape(np.asarray(vals, dtype=dtype), shape, dtype)
 


### PR DESCRIPTION
Fixes #6431

The issue was than `nanmedian`, via `nanquantile`, relies on the assumption that nans sort to the end of an array, but lax sorts negative NaNs to the start of the array.

Rather than create a new purpose-built test, I opted to modify the test utils to catch this kind of issue more broadly.