### PR TITLE
Pin sphinx-autodoc-typehints version to 1.11.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 # sphinx >=3 required by sphinx-autodoc-typehints v1.11.1 (Oct 2020)
 sphinx >=3, <4
 sphinx_rtd_theme
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2
 myst-nb
 


### PR DESCRIPTION
Our docs build fails with 1.12.1: https://readthedocs.org/projects/jax/builds/13514541/
```
reading sources... [ 50%] _autosummary/jax.numpy.linalg.pinv

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/latest/lib/python3.8/site-packages/sphinx/events.py", line 111, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/latest/lib/python3.8/site-packages/sphinx_autodoc_typehints.py", line 417, in process_docstring
    type_hints = get_all_type_hints(obj, name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/latest/lib/python3.8/site-packages/sphinx_autodoc_typehints.py", line 271, in get_all_type_hints
    rv = backfill_type_hints(obj, name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/jax/envs/latest/lib/python3.8/site-packages/sphinx_autodoc_typehints.py", line 312, in backfill_type_hints
    obj_ast = ast.parse(textwrap.dedent(
  File "/home/docs/.pyenv/versions/3.8.6/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 12
    max_rows_cols = max(a.shape[-2:])
                                    ^
IndentationError: expected an indented block
```

This may be caused by https://github.com/agronholm/sphinx-autodoc-typehints/pull/166