### PR TITLE
Fix Zero handling in select_jvp.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3899,7 +3899,10 @@ def _select_jvp(primals, tangents):
   _, on_true_dot, on_false_dot = tangents
   out = select(pred, on_true, on_false)
   if type(on_true_dot) is ad_util.Zero:
-    out_dot = select(pred, _zeros(on_false_dot), on_false_dot)
+    if type(on_false_dot) is ad_util.Zero:
+      out_dot = ad_util.Zero(on_true_dot.aval)
+    else:
+      out_dot = select(pred, _zeros(on_false_dot), on_false_dot)
   elif type(on_false_dot) is ad_util.Zero:
     out_dot = select(pred, on_true_dot, _zeros(on_true_dot))
   else:


### PR DESCRIPTION
This fixes an actual bug seen in the wild, but not sure if it's the right fix.

An error occurs calling `_zeros(on_false_dot)`, when `on_false_dot` is a Zero with a `float0` dtype (because it's calling `np.result_type(x)`). 
I forget, do we expect full_like to work on such a Zero? (Maybe that is the true fix)