### PR TITLE
sparse: add initial higher-level sparse objects

### DIFF
--- a/jax/experimental/sparse_ops.py
+++ b/jax/experimental/sparse_ops.py
@@ -26,9 +26,19 @@ These routines have reference implementations defined via XLA scatter/gather
 operations that will work on any backend, although they are not particularly
 performant. On GPU runtimes with jaxlib 0.1.66 or newer built against CUDA 11.0
 or newer, each operation is computed efficiently via cusparse.
-"""
 
+Further down are some examples of potential high-level wrappers for sparse objects.
+(API should be considered unstable and subject to change).
+"""
+import functools
+import operator
+
+from typing import Any, Tuple
+
+from jax import api
 from jax import core
+from jax import jit
+from jax import tree_util
 from jax.interpreters import xla
 from jax.lib import cusparse
 from jax.lib import xla_bridge
@@ -38,6 +48,19 @@ import numpy as np
 
 xb = xla_bridge
 xops = xla_client.ops
+
+Dtype = Any
+
+#--------------------------------------------------------------------
+# utilities
+@functools.partial(jit, static_argnums=1)
+def _csr_to_coo(indptr, nnz):
+  return jnp.cumsum(jnp.zeros_like(indptr, shape=nnz).at[indptr].add(1)) - 1
+
+@functools.partial(jit, static_argnums=1)
+def _coo_to_csr(row, nrows):
+  indptr = jnp.zeros(nrows + 1, row.dtype)
+  return indptr.at[1:].set(jnp.cumsum(jnp.bincount(row, length=nrows)))
 
 #--------------------------------------------------------------------
 # csr_todense
@@ -60,8 +83,7 @@ def csr_todense(data, indices, indptr, *, shape):
 
 @csr_todense_p.def_impl
 def _csr_todense_impl(data, indices, indptr, *, shape):
-  row = jnp.zeros_like(indices).at[indptr].add(1).cumsum() - 1
-  return _coo_todense_impl(data, row, indices, shape=shape)
+  return _coo_todense_impl(data, _csr_to_coo(indptr, len(indices)), indices, shape=shape)
 
 @csr_todense_p.def_abstract_eval
 def _csr_todense_abstract_eval(data, indices, indptr, *, shape):
@@ -99,10 +121,9 @@ def csr_fromdense(mat, *, nnz, index_dtype=np.int32):
     indices : array of shape ``(nnz,)`` and dtype ``index_dtype``
     indptr : array of shape ``(mat.shape[0] + 1,)`` and dtype ``index_dtype``
   """
-  return csr_fromdense_p.bind(
-      mat,
-      nnz=nnz,
-      index_dtype=np.dtype(index_dtype))
+  mat = jnp.asarray(mat)
+  nnz = core.concrete_or_error(operator.index, nnz, "nnz argument of csr_fromdense()")
+  return csr_fromdense_p.bind(mat, nnz=nnz, index_dtype=np.dtype(index_dtype))
 
 @csr_fromdense_p.def_impl
 def _csr_fromdense_impl(mat, *, nnz, index_dtype):
@@ -165,7 +186,7 @@ def csr_matvec(data, indices, indptr, v, *, shape, transpose=False):
 
 @csr_matvec_p.def_impl
 def _csr_matvec_impl(data, indices, indptr, v, *, shape, transpose):
-  row = jnp.cumsum(jnp.zeros_like(indices).at[indptr].add(1)) - 1
+  row = _csr_to_coo(indptr, len(indices))
   return _coo_matvec_impl(data, row, indices, v, shape=shape, transpose=transpose)
 
 @csr_matvec_p.def_abstract_eval
@@ -216,7 +237,7 @@ def csr_matmat(data, indices, indptr, B, *, shape, transpose=False):
 
 @csr_matmat_p.def_impl
 def _csr_matmat_impl(data, indices, indptr, B, *, shape, transpose):
-  row = jnp.cumsum(jnp.zeros_like(indices).at[indptr].add(1)) - 1
+  row = _csr_to_coo(indptr, len(indices))
   return _coo_matmat_impl(data, row, indices, B, shape=shape, transpose=transpose)
 
 @csr_matmat_p.def_abstract_eval
@@ -296,6 +317,8 @@ def coo_fromdense(mat, *, nnz, index_dtype=jnp.int32):
     row : array of shape ``(nnz,)`` and dtype ``index_dtype``
     col : array of shape ``(nnz,)`` and dtype ``index_dtype``
   """
+  mat = jnp.asarray(mat)
+  nnz = core.concrete_or_error(operator.index, nnz, "nnz argument of coo_fromdense()")
   return coo_fromdense_p.bind(mat, nnz=nnz, index_dtype=index_dtype)
 
 @coo_fromdense_p.def_impl
@@ -430,3 +453,162 @@ xla.translations[coo_matmat_p] = xla.lower_fun(
 if cusparse and cusparse.is_supported:
   xla.backend_specific_translations['gpu'][
       coo_matmat_p] = _coo_matmat_gpu_translation_rule
+
+#----------------------------------------------------------------------
+# Sparse objects (APIs subject to change)
+class JAXSparse:
+  """Base class for high-level JAX sparse objects."""
+  shape: Tuple[int, int]
+  nnz: property
+  dtype: property
+
+  def __init__(self, args, *, shape):
+    self.shape = shape
+
+  def __repr__(self):
+    return f"{self.__class__.__name__}({self.dtype}{list(self.shape)}, nnz={self.nnz})"
+
+  def tree_flatten(self):
+    raise NotImplementedError("tree_flatten")
+
+  @classmethod
+  def tree_unflatten(cls, aux_data, children):
+    return cls(children, **aux_data)
+
+  def matvec(self, v):
+    raise NotImplementedError("matvec")
+
+  def matmat(self, B):
+    raise NotImplementedError("matmat")
+
+  def transpose(self):
+    raise NotImplementedError()
+
+  @property
+  def T(self):
+    return self.transpose()
+
+  def __matmul__(self, other):
+    if isinstance(other, JAXSparse):
+      raise NotImplementedError("matmul between two sparse objects.")
+    other = jnp.asarray(other)
+    if other.ndim == 1:
+      return self.matvec(other)
+    elif other.ndim == 2:
+      return self.matmat(other)
+    else:
+      raise NotImplementedError(f"matmul with object of shape {other.shape}")
+
+
+@tree_util.register_pytree_node_class
+class CSR(JAXSparse):
+  """Experimental CSR matrix implemented in JAX; API subject to change."""
+  data: jnp.ndarray
+  indices: jnp.ndarray
+  indptr: jnp.ndarray
+  nnz = property(lambda self: self.data.size)
+  dtype = property(lambda self: self.data.dtype)
+
+  def __init__(self, args, *, shape):
+    self.data, self.indices, self.indptr = map(jnp.asarray, args)
+    super().__init__(args, shape=shape)
+
+  @classmethod
+  def fromdense(cls, mat, *, nnz=None, index_dtype=np.int32):
+    if nnz is None:
+      nnz = (mat != 0).sum()
+    return cls(csr_fromdense(mat, nnz=nnz, index_dtype=index_dtype), shape=mat.shape)
+
+  @api.jit
+  def todense(self):
+    return csr_todense(self.data, self.indices, self.indptr, shape=self.shape)
+
+  @api.jit
+  def matvec(self, v):
+    return csr_matvec(self.data, self.indices, self.indptr, v, shape=self.shape)
+
+  @api.jit
+  def matmat(self, B):
+    return csr_matmat(self.data, self.indices, self.indptr, B, shape=self.shape)
+
+  def transpose(self):
+    return CSC((self.data, self.indices, self.indptr), shape=self.shape[::-1])
+
+  def tree_flatten(self):
+    return (self.data, self.indices, self.indptr), {"shape": self.shape}
+
+
+@tree_util.register_pytree_node_class
+class CSC(JAXSparse):
+  """Experimental CSC matrix implemented in JAX; API subject to change."""
+  data: jnp.ndarray
+  indices: jnp.ndarray
+  indptr: jnp.ndarray
+  nnz = property(lambda self: self.data.size)
+  dtype = property(lambda self: self.data.dtype)
+
+  def __init__(self, args, *, shape):
+    self.data, self.indices, self.indptr = map(jnp.asarray, args)
+    super().__init__(args, shape=shape)
+
+  @classmethod
+  def fromdense(cls, mat, *, nnz=None, index_dtype=np.int32):
+    if nnz is None:
+      nnz = (mat != 0).sum()
+    return cls(csr_fromdense(mat.T, nnz=nnz, index_dtype=index_dtype), shape=mat.shape)
+
+  @api.jit
+  def todense(self):
+    return csr_todense(self.data, self.indices, self.indptr, shape=self.shape[::-1]).T
+
+  @api.jit
+  def matvec(self, v):
+    return csr_matvec(self.data, self.indices, self.indptr, v, shape=self.shape[::-1], transpose=True)
+
+  @api.jit
+  def matmat(self, B):
+    return csr_matmat(self.data, self.indices, self.indptr, B, shape=self.shape[::-1], transpose=True)
+
+  def transpose(self):
+    return CSR((self.data, self.indices, self.indptr), shape=self.shape[::-1])
+
+  def tree_flatten(self):
+    return (self.data, self.indices, self.indptr), {"shape": self.shape}
+
+
+@tree_util.register_pytree_node_class
+class COO(JAXSparse):
+  """Experimental COO matrix implemented in JAX; API subject to change."""
+  data: jnp.ndarray
+  row: jnp.ndarray
+  col: jnp.ndarray
+  nnz = property(lambda self: self.data.size)
+  dtype = property(lambda self: self.data.dtype)
+
+  def __init__(self, args, *, shape):
+    self.data, self.row, self.col = map(jnp.asarray, args)
+    super().__init__(args, shape=shape)
+
+  @classmethod
+  def fromdense(cls, mat, *, nnz=None, index_dtype=np.int32):
+    if nnz is None:
+      nnz = (mat != 0).sum()
+    return cls(coo_fromdense(mat, nnz=nnz, index_dtype=index_dtype), shape=mat.shape)
+
+  @api.jit
+  def todense(self):
+    return coo_todense(self.data, self.row, self.col, shape=self.shape)
+
+  @api.jit
+  def matvec(self, v):
+    return coo_matvec(self.data, self.row, self.col, v, shape=self.shape)
+
+  @api.jit
+  def matmat(self, B):
+    return coo_matmat(self.data, self.row, self.col, B, shape=self.shape)
+
+  def transpose(self):
+    return COO((self.data, self.col, self.row), shape=self.shape[::-1])
+
+  def tree_flatten(self):
+    return (self.data, self.row, self.col), {"shape": self.shape}

--- a/tests/sparse_ops_test.py
+++ b/tests/sparse_ops_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 from absl.testing import absltest
@@ -30,8 +31,15 @@ from scipy import sparse
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
+MATMUL_TOL = {
+  np.float32: 1E-5,
+  np.float64: 1E-10,
+  np.complex64: 1e-5,
+  np.complex128: 1E-10,
+}
 
-def rand_sparse(rng, nnz=0.1, post=lambda x: x):
+
+def rand_sparse(rng, nnz=0.5, post=lambda x: x):
   def _rand_sparse(shape, dtype, nnz=nnz):
     rand = jtu.rand_default(rng)
     size = np.prod(shape)
@@ -102,8 +110,8 @@ class cuSparseTest(jtu.JaxTestCase):
     args = (M.data, M.indices, M.indptr, v)
     matvec = lambda *args: sparse_ops.csr_matvec(*args, shape=M.shape, transpose=transpose)
 
-    self.assertAllClose(op(M) @ v, matvec(*args))
-    self.assertAllClose(op(M) @ v, jit(matvec)(*args))
+    self.assertAllClose(op(M) @ v, matvec(*args), rtol=MATMUL_TOL)
+    self.assertAllClose(op(M) @ v, jit(matvec)(*args), rtol=MATMUL_TOL)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_T={}".format(jtu.format_shape_dtype_string(shape, dtype), transpose),
@@ -122,8 +130,8 @@ class cuSparseTest(jtu.JaxTestCase):
     args = (M.data, M.indices, M.indptr, B)
     matmat = lambda *args: sparse_ops.csr_matmat(*args, shape=shape, transpose=transpose)
 
-    self.assertAllClose(op(M) @ B, matmat(*args))
-    self.assertAllClose(op(M) @ B, jit(matmat)(*args))
+    self.assertAllClose(op(M) @ B, matmat(*args), rtol=MATMUL_TOL)
+    self.assertAllClose(op(M) @ B, jit(matmat)(*args), rtol=MATMUL_TOL)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(jtu.format_shape_dtype_string(shape, dtype)),
@@ -181,8 +189,8 @@ class cuSparseTest(jtu.JaxTestCase):
     args = (M.data, M.row, M.col, v)
     matvec = lambda *args: sparse_ops.coo_matvec(*args, shape=M.shape, transpose=transpose)
 
-    self.assertAllClose(op(M) @ v, matvec(*args))
-    self.assertAllClose(op(M) @ v, jit(matvec)(*args))
+    self.assertAllClose(op(M) @ v, matvec(*args), rtol=MATMUL_TOL)
+    self.assertAllClose(op(M) @ v, jit(matvec)(*args), rtol=MATMUL_TOL)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_T={}".format(jtu.format_shape_dtype_string(shape, dtype), transpose),
@@ -201,8 +209,8 @@ class cuSparseTest(jtu.JaxTestCase):
     args = (M.data, M.row, M.col, B)
     matmat = lambda *args: sparse_ops.coo_matmat(*args, shape=shape, transpose=transpose)
 
-    self.assertAllClose(op(M) @ B, matmat(*args))
-    self.assertAllClose(op(M) @ B, jit(matmat)(*args))
+    self.assertAllClose(op(M) @ B, matmat(*args), rtol=MATMUL_TOL)
+    self.assertAllClose(op(M) @ B, jit(matmat)(*args), rtol=MATMUL_TOL)
 
   @unittest.skipIf(jtu.device_under_test() != "gpu", "test requires GPU")
   def test_gpu_translation_rule(self):
@@ -229,6 +237,80 @@ class cuSparseTest(jtu.JaxTestCase):
     args = fromdense(M, nnz=nnz, index_dtype=jnp.int32)
     M_out = todense(*args, shape=M.shape)
     self.assertArraysEqual(M, M_out)
+
+
+class SparseObjectTest(jtu.JaxTestCase):
+  @parameterized.named_parameters(
+    {"testcase_name": "_{}".format(Obj.__name__), "Obj": Obj}
+    for Obj in [sparse_ops.CSR, sparse_ops.CSC, sparse_ops.COO])
+  def test_attrs(self, Obj, shape=(5, 8), dtype=np.float16):
+    rng = rand_sparse(self.rng(), post=Obj.fromdense)
+    M = rng(shape, dtype)
+
+    assert isinstance(M, Obj)
+    assert M.shape == shape
+    assert M.dtype == dtype
+    assert M.nnz == (M.todense() != 0).sum()
+    assert M.data.dtype == dtype
+
+    if isinstance(M, sparse_ops.CSR):
+      assert len(M.data) == len(M.indices)
+      assert len(M.indptr) == M.shape[0] + 1
+    elif isinstance(M, sparse_ops.CSC):
+      assert len(M.data) == len(M.indices)
+      assert len(M.indptr) == M.shape[1] + 1
+    elif isinstance(M, sparse_ops.COO):
+      assert len(M.data) == len(M.row) == len(M.col)
+    else:
+      raise ValueError("Obj={Obj} not expected.")
+
+  @parameterized.named_parameters(itertools.chain.from_iterable(
+    jtu.cases_from_list(
+      {"testcase_name": "_{}_Obj={}".format(
+        jtu.format_shape_dtype_string(shape, dtype), Obj.__name__),
+       "shape": shape, "dtype": dtype, "Obj": Obj}
+      for shape in [(5, 8), (8, 5), (5, 5), (8, 8)]
+      for dtype in jtu.dtypes.floating + jtu.dtypes.complex)
+    for Obj in [sparse_ops.CSR, sparse_ops.CSC, sparse_ops.COO]))
+  def test_dense_round_trip(self, shape, dtype, Obj):
+    rng = rand_sparse(self.rng())
+    M = rng(shape, dtype)
+    Msparse = Obj.fromdense(M)
+    self.assertArraysEqual(M, Msparse.todense())
+
+  @parameterized.named_parameters(itertools.chain.from_iterable(
+    jtu.cases_from_list(
+      {"testcase_name": "_{}_Obj={}".format(
+        jtu.format_shape_dtype_string(shape, dtype), Obj.__name__),
+       "shape": shape, "dtype": dtype, "Obj": Obj}
+      for shape in [(5, 8), (8, 5), (5, 5), (8, 8)]
+      for dtype in jtu.dtypes.floating + jtu.dtypes.complex)
+    for Obj in [sparse_ops.CSR, sparse_ops.CSC, sparse_ops.COO]))
+  def test_transpose(self, shape, dtype, Obj):
+    rng = rand_sparse(self.rng())
+    M = rng(shape, dtype)
+    Msparse = Obj.fromdense(M)
+    self.assertArraysEqual(M.T, Msparse.T.todense())
+
+  @unittest.skipIf(jtu.device_under_test() == "tpu", "TPU has insufficient precision")
+  @parameterized.named_parameters(itertools.chain.from_iterable(
+    jtu.cases_from_list(
+      {"testcase_name": "_{}_Obj={}_bshape={}".format(
+        jtu.format_shape_dtype_string(shape, dtype), Obj.__name__, bshape),
+       "shape": shape, "dtype": dtype, "Obj": Obj, "bshape": bshape}
+      for shape in [(5, 8), (8, 5), (5, 5), (8, 8)]
+      for bshape in [shape[-1:] + s for s in [(), (3,), (4,)]]
+      for dtype in jtu.dtypes.floating + jtu.dtypes.complex)
+    for Obj in [sparse_ops.CSR, sparse_ops.CSC, sparse_ops.COO]))
+  def test_matmul(self, shape, dtype, Obj, bshape):
+    rng = rand_sparse(self.rng(), post=jnp.array)
+    rng_b = jtu.rand_default(self.rng())
+    M = rng(shape, dtype)
+    Msp = Obj.fromdense(M)
+    x = rng_b(bshape, dtype)
+    x = jnp.asarray(x)
+
+    self.assertAllClose(M @ x, Msp @ x, rtol=MATMUL_TOL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR proposes some higher-level wrappers of the low-level sparse primitives added in #6429

These are specifically marked as not being the final API, but will be generally useful for building benchmarks of sparse operations.