### PR TITLE
Add support for `preferred_element_type` arg in convolutions

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -541,7 +541,8 @@ def conv_general_dilated(
   rhs_dilation: Optional[Sequence[int]] = None,
   dimension_numbers: ConvGeneralDilatedDimensionNumbers  = None,
   feature_group_count: int = 1, batch_group_count: int = 1,
-  precision: PrecisionLike = None) -> Array:
+  precision: PrecisionLike = None,
+  preferred_element_type: Optional[DType] = None) -> Array:
   """General n-dimensional convolution operator, with optional dilation.
 
   Wraps XLA's `Conv
@@ -573,6 +574,9 @@ def conv_general_dilated(
       'fastest', see the ``jax.default_matmul_precision`` context manager), or a
       tuple of two ``lax.Precision`` enums or strings indicating precision of
       ``lhs`` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     An array containing the convolution result.
@@ -625,7 +629,8 @@ def conv_general_dilated(
       feature_group_count=feature_group_count,
       batch_group_count=batch_group_count,
       lhs_shape=lhs.shape, rhs_shape=rhs.shape,
-      precision=_canonicalize_precision(precision))
+      precision=_canonicalize_precision(precision),
+      preferred_element_type=preferred_element_type)
 
 def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
         preferred_element_type: Optional[DType] = None) -> Array:
@@ -1585,7 +1590,8 @@ def stop_gradient(x):
 
 
 def conv(lhs: Array, rhs: Array, window_strides: Sequence[int],
-         padding: str, precision: PrecisionLike = None) -> Array:
+         padding: str, precision: PrecisionLike = None,
+         preferred_element_type: Optional[DType] = None) -> Array:
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
@@ -1598,19 +1604,24 @@ def conv(lhs: Array, rhs: Array, window_strides: Sequence[int],
       the backend, a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
       ``lax.Precision`` enums indicating precision of ``lhs``` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     An array containing the convolution result.
   """
   return conv_general_dilated(lhs, rhs, window_strides, padding,
-                              precision=precision)
+                              precision=precision,
+                              preferred_element_type=preferred_element_type)
 
 def conv_with_general_padding(lhs: Array, rhs: Array,
                               window_strides: Sequence[int],
                               padding: Union[str, Sequence[Tuple[int, int]]],
                               lhs_dilation: Optional[Sequence[int]],
                               rhs_dilation: Optional[Sequence[int]],
-                              precision: PrecisionLike = None) -> Array:
+                              precision: PrecisionLike = None,
+                              preferred_element_type: Optional[DType] = None) -> Array:
   """Convenience wrapper around `conv_general_dilated`.
 
   Args:
@@ -1631,13 +1642,17 @@ def conv_with_general_padding(lhs: Array, rhs: Array,
       the backend, a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
       ``lax.Precision`` enums indicating precision of ``lhs``` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     An array containing the convolution result.
   """
   return conv_general_dilated(
       lhs, rhs, window_strides, padding, lhs_dilation=lhs_dilation,
-      rhs_dilation=rhs_dilation, precision=precision)
+      rhs_dilation=rhs_dilation, precision=precision,
+      preferred_element_type=preferred_element_type)
 
 
 def _conv_transpose_padding(k, s, padding):
@@ -1678,7 +1693,8 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
                    rhs_dilation: Optional[Sequence[int]] = None,
                    dimension_numbers: ConvGeneralDilatedDimensionNumbers = None,
                    transpose_kernel: bool = False,
-                   precision: PrecisionLike = None) -> Array:
+                   precision: PrecisionLike = None,
+                   preferred_element_type: Optional[DType] = None) -> Array:
   """Convenience wrapper for calculating the N-d convolution "transpose".
 
   This function directly calculates a fractionally strided conv rather than
@@ -1705,6 +1721,9 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
       the backend, a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple of two
       ``lax.Precision`` enums indicating precision of ``lhs``` and ``rhs``.
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     Transposed N-d convolution, with output padding following the conventions of
@@ -1743,7 +1762,8 @@ def conv_transpose(lhs: Array, rhs: Array, strides: Sequence[int],
     rhs = _flip_axes(rhs, np.array(dn.rhs_spec)[2:])
     rhs = np.swapaxes(rhs, dn.rhs_spec[0], dn.rhs_spec[1])
   return conv_general_dilated(lhs, rhs, one, pads, strides, rhs_dilation, dn,
-                              precision=precision)
+                              precision=precision,
+                              preferred_element_type=preferred_element_type)
 
 
 def full_like(x: Array, fill_value: Array, dtype: Optional[DType] = None,
@@ -2872,11 +2892,26 @@ def _conv_general_dilated_shape_rule(
                                batch_group_count)
   return tuple(np.take(out_trans, np.argsort(out_perm)))  # type: ignore[arg-type]
 
+def _validate_preferred_element_type(input_dtype, preferred_element_type):
+  allowed_types = (np.integer, np.floating, np.complexfloating)
+  if any(dtypes.issubdtype(input_dtype, t) and not dtypes.issubdtype(preferred_element_type, t) for t in allowed_types):
+    raise TypeError("`preferred_element_type` and the original type must both be integral, both be floating point, or both complex.")
+  if dtypes.issubdtype(input_dtype, np.signedinteger) and not dtypes.issubdtype(preferred_element_type, np.signedinteger):
+    raise TypeError("`preferred_element_type` must have the same signedness as the original type.")
+  input_bitwidth = np.dtype(input_dtype).itemsize
+  preferred_bitwidth = np.dtype(preferred_element_type).itemsize
+  if preferred_bitwidth < input_bitwidth:
+    raise TypeError("`preferred_element_type` must not be narrower than the original type.")
+
 def _conv_general_dilated_dtype_rule(
     lhs, rhs, *, window_strides, padding, lhs_dilation, rhs_dilation,
-    dimension_numbers, **unused_kwargs):
-  return naryop_dtype_rule(_input_dtype, [_any, _any],
-                          'conv_general_dilated', lhs, rhs)
+    dimension_numbers, preferred_element_type, **unused_kwargs):
+  input_dtype = naryop_dtype_rule(_input_dtype, [_any, _any],
+                                  'conv_general_dilated', lhs, rhs)
+  if preferred_element_type is None:
+    return input_dtype
+  _validate_preferred_element_type(input_dtype, preferred_element_type)
+  return preferred_element_type
 
 _conv_spec_transpose = lambda spec: (spec[1], spec[0]) + spec[2:]
 _conv_sdims = lambda spec: spec[2:]
@@ -2911,7 +2946,7 @@ _conv_sdims = lambda spec: spec[2:]
 def _conv_general_dilated_transpose_lhs(
     g, rhs, *, window_strides, padding, lhs_dilation, rhs_dilation,
     dimension_numbers, feature_group_count, batch_group_count,
-    lhs_shape, rhs_shape, precision):
+    lhs_shape, rhs_shape, precision, preferred_element_type):
   assert type(dimension_numbers) is ConvDimensionNumbers
   assert batch_group_count == 1 or feature_group_count == 1
   lhs_sdims, rhs_sdims, out_sdims = map(_conv_sdims, dimension_numbers)
@@ -2937,7 +2972,8 @@ def _conv_general_dilated_transpose_lhs(
       lhs_dilation=window_strides, rhs_dilation=rhs_dilation,
       dimension_numbers=trans_dimension_numbers,
       feature_group_count=feature_group_count,
-      batch_group_count=1, precision=precision)
+      batch_group_count=1, precision=precision,
+      preferred_element_type=preferred_element_type)
   if batch_group_count > 1:
     out = _reshape_axis_out_of(lhs_spec[1], batch_group_count, out)
     out = _reshape_axis_into(lhs_spec[1], lhs_spec[0], out)
@@ -2946,7 +2982,8 @@ def _conv_general_dilated_transpose_lhs(
 def _conv_general_dilated_transpose_rhs(
     g, lhs, *, window_strides, padding, lhs_dilation, rhs_dilation,
     dimension_numbers: ConvDimensionNumbers, feature_group_count: int,
-    batch_group_count: int, lhs_shape, rhs_shape, precision):
+    batch_group_count: int, lhs_shape, rhs_shape, precision,
+    preferred_element_type):
   assert type(dimension_numbers) is ConvDimensionNumbers
   if np.size(g) == 0:
     # Avoids forming degenerate convolutions where the RHS has spatial size 0.
@@ -2976,21 +3013,19 @@ def _conv_general_dilated_transpose_rhs(
       lhs_dilation=lhs_dilation, rhs_dilation=window_strides,
       dimension_numbers=trans_dimension_numbers,
       feature_group_count=feature_group_count,
-      batch_group_count=batch_group_count, precision=precision)
+      batch_group_count=batch_group_count, precision=precision,
+      preferred_element_type=preferred_element_type)
 
 
 def _conv_general_dilated_translation_rule(
     c, lhs, rhs, *, window_strides, padding,
     lhs_dilation, rhs_dilation, dimension_numbers, feature_group_count,
-    batch_group_count, precision, expand_complex_convolutions, **unused_kwargs):
+    batch_group_count, precision, expand_complex_convolutions,
+    preferred_element_type, **unused_kwargs):
   assert type(dimension_numbers) is ConvDimensionNumbers
   dimension_numbers = _conv_general_proto(dimension_numbers)
   precision_config = _precision_config(precision)
   dtype = c.get_shape(lhs).numpy_dtype()
-  conv = lambda x, y: xops.ConvGeneralDilated(
-      x, y, window_strides, padding, lhs_dilation, rhs_dilation,
-      dimension_numbers, feature_group_count, batch_group_count,
-      precision_config=precision_config)
   if expand_complex_convolutions and np.issubdtype(dtype, np.complexfloating):
     # We use a trick for complex multiplication due to Gauss which uses three
     # multiplications and five additions; instead of the naive method of four
@@ -3002,18 +3037,38 @@ def _conv_general_dilated_translation_rule(
     # error bound (e.g. 1p-24 in case of float32) would be relative to the
     # maximum of real and imaginary parts of the result instead of being
     # satisfied by the real and imaginary parts independently of each other.
+    if preferred_element_type is not None:
+      # Convert complex dtype to types used for real and imaginary parts
+      assert np.issubdtype(preferred_element_type, np.complexfloating)
+      preferred_element_type = xla_client.dtype_to_etype(
+          np.float64 if preferred_element_type == np.complex128 else np.float32)
+
+    conv = lambda x, y: xops.ConvGeneralDilated(
+        x, y, window_strides, padding, lhs_dilation, rhs_dilation,
+        dimension_numbers, feature_group_count, batch_group_count,
+        precision_config=precision_config,
+        preferred_element_type=preferred_element_type)
     lhs_real, lhs_imag = xops.Real(lhs), xops.Imag(lhs)
     rhs_real, rhs_imag = xops.Real(rhs), xops.Imag(rhs)
     k1 = conv(xops.Add(lhs_real, lhs_imag), rhs_real)
     k2 = conv(lhs_real, xops.Sub(rhs_imag, rhs_real))
     k3 = conv(lhs_imag, xops.Add(rhs_real, rhs_imag))
     return xops.Complex(xops.Sub(k1, k3), xops.Add(k1, k2))
-  return conv(lhs, rhs)
+
+  if preferred_element_type is not None:
+    preferred_element_type = xla_client.dtype_to_etype(preferred_element_type)
+
+  return xops.ConvGeneralDilated(
+      lhs, rhs, window_strides, padding, lhs_dilation, rhs_dilation,
+      dimension_numbers, feature_group_count, batch_group_count,
+      precision_config=precision_config,
+      preferred_element_type=preferred_element_type)
 
 def _conv_general_dilated_batch_rule(
     batched_args, batch_dims, *, window_strides, padding,
     lhs_dilation, rhs_dilation, dimension_numbers,
-    feature_group_count, batch_group_count, precision, **unused_kwargs):
+    feature_group_count, batch_group_count, precision,
+    preferred_element_type, **unused_kwargs):
   assert batch_group_count == 1 or feature_group_count == 1
   lhs, rhs = batched_args
   lhs_bdim, rhs_bdim = batch_dims
@@ -3031,8 +3086,8 @@ def _conv_general_dilated_batch_rule(
     out = conv_general_dilated(
       new_lhs, new_rhs, window_strides, padding, lhs_dilation, rhs_dilation,
       dimension_numbers, feature_group_count=feature_group_count,
-      batch_group_count=batch_group_count,
-      precision=precision)
+      batch_group_count=batch_group_count, precision=precision,
+      preferred_element_type=preferred_element_type)
     out = _reshape_axis_out_of(out_spec[1], lhs.shape[lhs_bdim], out)
     return out, out_spec[1]
 
@@ -3041,7 +3096,8 @@ def _conv_general_dilated_batch_rule(
       new_lhs = _reshape_axis_into(lhs_bdim, lhs_spec[0], lhs)
       out = conv_general_dilated(new_lhs, rhs, window_strides, padding,
                                  lhs_dilation, rhs_dilation, dimension_numbers,
-                                 feature_group_count, precision=precision)
+                                 feature_group_count, precision=precision,
+                                 preferred_element_type=preferred_element_type)
       out = _reshape_axis_out_of(out_spec[0], lhs.shape[lhs_bdim], out)
       return out, out_spec[0]
     else:
@@ -3054,7 +3110,8 @@ def _conv_general_dilated_batch_rule(
       out = conv_general_dilated(new_lhs, rhs, window_strides, padding,
                                  lhs_dilation, rhs_dilation, dimension_numbers,
                                  feature_group_count, batch_group_count,
-                                 precision=precision)
+                                 precision=precision,
+                                 preferred_element_type=preferred_element_type)
       out = _reshape_axis_out_of(out_spec[0], lhs.shape[lhs_bdim], out)
       return out, out_spec[0]
 
@@ -3064,7 +3121,8 @@ def _conv_general_dilated_batch_rule(
       out = conv_general_dilated(lhs, new_rhs, window_strides, padding,
                                  lhs_dilation, rhs_dilation, dimension_numbers,
                                  feature_group_count, batch_group_count,
-                                 precision=precision)
+                                 precision=precision,
+                                 preferred_element_type=preferred_element_type)
       out = _reshape_axis_out_of(out_spec[1], rhs.shape[rhs_bdim], out)
       return out, out_spec[1]
     else:
@@ -3084,7 +3142,8 @@ def _conv_general_dilated_batch_rule(
       out = conv_general_dilated(lhs, new_rhs, window_strides, padding,
                                  lhs_dilation, rhs_dilation, dimension_numbers,
                                  feature_group_count, batch_group_count,
-                                 precision=precision)
+                                 precision=precision,
+                                 preferred_element_type=preferred_element_type)
       out = _reshape_axis_out_of(out_spec[1], group_count, out)
       out = _reshape_axis_out_of(out_spec[1] + 1, rhs.shape[rhs_bdim], out)
       out = _reshape_axis_into(out_spec[1], out_spec[1] + 1, out)
@@ -3108,7 +3167,7 @@ def _masked(padded_value, logical_shape, dimensions, value=0):
 def _conv_general_dilated_masking_rule(
         padded_vals, logical_shapes, window_strides, padding, lhs_dilation,
         rhs_dilation, dimension_numbers, feature_group_count, batch_group_count,
-        lhs_shape, rhs_shape, precision):
+        lhs_shape, rhs_shape, precision, preferred_element_type):
   lhs, rhs = padded_vals
   logical_lhs_shape, logical_rhs_shape = logical_shapes
 
@@ -3127,7 +3186,8 @@ def _conv_general_dilated_masking_rule(
     dimension_numbers=dimension_numbers,
     feature_group_count=feature_group_count,
     batch_group_count=batch_group_count,
-    precision=precision)
+    precision=precision,
+    preferred_element_type=preferred_element_type)
 
 conv_general_dilated_p = standard_primitive(
     _conv_general_dilated_shape_rule, _conv_general_dilated_dtype_rule,
@@ -3250,14 +3310,7 @@ def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
   input_dtype = naryop_dtype_rule(_input_dtype, [_any, _any], 'dot_general', lhs, rhs)
   if preferred_element_type is None:
     return input_dtype
-  if dtypes.issubdtype(input_dtype, np.integer) and not dtypes.issubdtype(preferred_element_type, np.integer):
-    raise TypeError("`preferred_element_type` and the original type must both be integral or both be floating point.")
-  if dtypes.issubdtype(input_dtype, np.signedinteger) and not dtypes.issubdtype(preferred_element_type, np.signedinteger):
-    raise TypeError("`preferred_element_type` must have the same signedness as the original type.")
-  input_bitwidth = np.dtype(input_dtype).itemsize
-  preferred_bitwidth = np.dtype(preferred_element_type).itemsize
-  if preferred_bitwidth < input_bitwidth:
-    raise TypeError("`preferred_element_type` must not be narrower than the original type.")
+  _validate_preferred_element_type(input_dtype, preferred_element_type)
   return preferred_element_type
 
 def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,

--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 
-from typing import Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.util import prod
 from . import lax
 
+DType = Any
 
 def conv_general_dilated_patches(
     lhs: lax.Array,
@@ -28,6 +29,7 @@ def conv_general_dilated_patches(
     rhs_dilation: Sequence[int] = None,
     dimension_numbers: lax.ConvGeneralDilatedDimensionNumbers = None,
     precision: lax.PrecisionType = None,
+    preferred_element_type: Optional[DType] = None,
 ) -> lax.Array:
   """Extract patches subject to the receptive field of `conv_general_dilated`.
 
@@ -68,6 +70,9 @@ def conv_general_dilated_patches(
     precision: Optional. Either ``None``, which means the default precision for
       the backend, or a ``lax.Precision`` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``).
+    preferred_element_type: Optional. Either ``None``, which means the default
+      accumulation type for the input types, or a datatype, indicating to
+      accumulate results to and return a result with that datatype.
 
   Returns:
     A rank `n+2` array containing the flattened image patches in the output
@@ -104,6 +109,7 @@ def conv_general_dilated_patches(
       dimension_numbers=dimension_numbers,
       precision=None if precision is None else (precision,
                                                 lax.Precision.DEFAULT),
-      feature_group_count=n_channels
+      feature_group_count=n_channels,
+      preferred_element_type=preferred_element_type
   )
   return out

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1196,7 +1196,7 @@ def _try_tf_conv(lhs, rhs, window_strides, padding, lhs_dilation, rhs_dilation,
 def _conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation,
                           rhs_dilation, dimension_numbers, feature_group_count,
                           batch_group_count, lhs_shape, rhs_shape, precision,
-                          _in_avals, _out_aval):
+                          preferred_element_type, _in_avals, _out_aval):
   """Implementation of lax.conv_general_dilated_p using XlaConv."""
   if not _enable_xla:
     info_or_result = _try_tf_conv(

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -62,6 +62,18 @@ python_scalar_types = [bool, int, float, complex]
 
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 
+# We check cases where the preferred type is at least as wide as the input
+# type and where both are either both floating-point or both integral,
+# which are the only supported configurations.
+preferred_type_combinations = [
+  (np.float16, np.float16), (np.float16, np.float32), (np.float16, np.float64),
+  (dtypes.bfloat16, dtypes.bfloat16), (dtypes.bfloat16, np.float32),
+  (dtypes.bfloat16, np.float64), (np.float32, np.float32), (np.float32, np.float64),
+  (np.float64, np.float64), (np.int8, np.int8), (np.int8, np.int16), (np.int8, np.int32),
+  (np.int8, np.int64), (np.int16, np.int16), (np.int16, np.int32), (np.int16, np.int64),
+  (np.int32, np.int32), (np.int32, np.int64), (np.int64, np.int64),
+  (np.complex64, np.complex64), (np.complex64, np.complex128), (np.complex128, np.complex128)]
+
 
 OpRecord = collections.namedtuple(
     "OpRecord", ["op", "nargs", "dtypes", "rng_factory", "tol"])
@@ -377,6 +389,50 @@ class LaxTest(jtu.JaxTestCase):
       return lax.conv(lhs, rhs, strides, padding)
 
     self._CompileAndCheck(fun, args_maker)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name":
+       "_lhs_shape={}_rhs_shape={}_preferred_element_type={}".format(
+           jtu.format_shape_dtype_string(lhs_shape, dtype),
+           jtu.format_shape_dtype_string(rhs_shape, dtype),
+           preferred_element_type),
+          "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
+          "preferred_element_type": preferred_element_type}
+      for lhs_shape, rhs_shape in [
+          ((b, i, 9, 10), (j, i, 4, 5))
+          for b, i, j in itertools.product([2, 3], repeat=3)]
+      for dtype, preferred_element_type in preferred_type_combinations))
+  def testConvPreferredElement(self, lhs_shape, rhs_shape, dtype, preferred_element_type):
+    if (not config.x64_enabled and
+       (dtype == np.float64 or preferred_element_type == np.float64
+        or dtype == np.int64 or preferred_element_type == np.int64
+        or dtype == np.complex128 or preferred_element_type == np.complex128)):
+      raise SkipTest("64-bit mode disabled")
+    if jtu.device_under_test() == "gpu" and np.issubdtype(dtype, np.integer):
+      # TODO(b/183565702): Support integer convolutions on CPU/GPU.
+      raise SkipTest("Integer convolution not yet supported on GPU")
+    if (jtu.device_under_test() == "tpu" and
+       (dtype == np.complex128 or preferred_element_type == np.complex128)):
+      raise SkipTest("np.complex128 is not yet supported on TPU")
+    # x64 implementation is only accurate to ~float32 precision for this case.
+    tol = 1e-5 if dtype == np.complex64 and preferred_element_type == np.complex128 else None
+    rng = jtu.rand_default(self.rng())
+    x = rng(lhs_shape, dtype)
+    y = rng(rhs_shape, dtype)
+    # We first compute the conv when both inputs are a lower-precision type and
+    # preferred_element_type is a higher-precision type. We then compute results
+    # where the inputs are first upcast to the higher-precision type and no
+    # `preferred_element_type` is given. We expect the result to be extremely
+    # similar given the semantics of `preferred_element_type`.
+    result_with_preferred_type = lax.conv(
+      x, y, (1, 1), "VALID",
+      preferred_element_type=preferred_element_type)
+    result_with_upcast_inputs = lax.conv(
+      x.astype(preferred_element_type),
+      y.astype(preferred_element_type),
+      (1, 1), "VALID")
+    self.assertArraysAllClose(
+      result_with_preferred_type, result_with_upcast_inputs, rtol=tol, atol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -921,21 +977,15 @@ class LaxTest(jtu.JaxTestCase):
        "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype, "preferred_element_type": preferred_element_type
      }
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
-      # We check cases where the preferred type is at least as wide as the input
-      # type and where both are either both floating-point or both integral,
-      # which are the only supported configurations.
-      for dtype, preferred_element_type in [
-        (np.float16, np.float16), (np.float16, np.float32), (np.float16, np.float64),
-        (dtypes.bfloat16, dtypes.bfloat16), (dtypes.bfloat16, np.float32),
-        (dtypes.bfloat16, np.float64), (np.float32, np.float32), (np.float32, np.float64),
-        (np.float64, np.float64), (np.int8, np.int8), (np.int8, np.int16), (np.int8, np.int32),
-        (np.int8, np.int64), (np.int16, np.int16), (np.int16, np.int32), (np.int16, np.int64),
-        (np.int32, np.int32), (np.int32, np.int64), (np.int64, np.int64)]))
+      for dtype, preferred_element_type in preferred_type_combinations))
   def testDotPreferredElement(self, lhs_shape, rhs_shape, dtype, preferred_element_type):
     if (not config.x64_enabled and
        (dtype == np.float64 or preferred_element_type == np.float64
         or dtype == np.int64 or preferred_element_type == np.int64)):
       raise SkipTest("64-bit mode disabled")
+    if (jtu.device_under_test() == "tpu" and
+       (dtype == np.complex128 or preferred_element_type == np.complex128)):
+      raise SkipTest("np.complex128 is not yet supported on TPU")
     rng = jtu.rand_default(self.rng())
     x = rng(lhs_shape, dtype)
     y = rng(rhs_shape, dtype)


### PR DESCRIPTION
XLA recently added support for integer convolutions on CPU in https://github.com/tensorflow/tensorflow/commit/89fc1ddd96f25aa9d8eb6a0104ca1fdb11b26753.

This PR adds support for the `preferred_element_type` parameter in the `conv`, `conv_general_dilated`, `conv_with_general_padding`, `conv_general_dilated_patches` and `conv_transpose` which is passed through to XLA.

This PR is analogous to #5213 which added support for `preferred_element_type` in `lax.dot`.

Please note that I don't know if this has any implications for GPU since GPUs don't have support integer convolution yet, but hopefully CI will catch any potential problems related to GPUs. Please let me know if I am missing something.

Do you know if there is a timeline integer GPU convolution support in XLA which would be very useful for research on quantized neural networks?