### PR TITLE
CI: Install wheel pkg to improve pip-cache

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -75,7 +75,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         echo "::set-output name=dir::$(pip cache dir)"
     - name: pip cache
       uses: actions/cache@v2
@@ -122,7 +122,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel
         echo "::set-output name=dir::$(pip cache dir)"
     - name: pip cache
       uses: actions/cache@v2


### PR DESCRIPTION
This PR ensures that the [`wheel`](https://github.com/pypa/wheel) is installed on CI to improve the pip cache. This allows to store wheels for packages that might not provide prebuilt ones in the cache and [removes warnings during install](https://github.com/google/jax/pull/6467/checks?check_run_id=2357962697#step:7:78).