### PR TITLE
DOC: Modify JAX 101 hyperlinks

### DIFF
--- a/docs/jax-101/01-jax-basics.ipynb
+++ b/docs/jax-101/01-jax-basics.ipynb
@@ -290,7 +290,7 @@
     "id": "yQAMTnZSqo-t"
    },
    "source": [
-    "Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05.1-pytrees.ipynb). So, most often, use of `jax.grad` looks like this:\n",
+    "Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://jax.readthedocs.io/en/latest/jax-101/05.1-pytrees.html). So, most often, use of `jax.grad` looks like this:\n",
     "\n",
     "```\n",
     "def loss_fn(params, data):\n",
@@ -612,7 +612,7 @@
     "\n",
     "Of course, it's possible to mix side-effectful Python code and functionally pure JAX code, and we will touch on this more later. As you get more familiar with JAX, you will learn how and when this can work. As a rule of thumb, however, any functions intended to be transformed by JAX should avoid side-effects, and the JAX primitives themselves will try to help you do that.\n",
     "\n",
-    "We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Part 7: Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs."
+    "We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs."
    ]
   },
   {
@@ -738,7 +738,7 @@
     "id": "MAUL1gT_opVn"
    },
    "source": [
-    "In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [The Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb).\n",
+    "In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html).\n",
     "\n",
     "This function can then be JIT-compiled in its entirety for maximum efficiency. The next guide will explain exactly how `jax.jit` works, but if you want to, you can try adding `@jax.jit` before the `update()` definition, and see how the training loop below runs much faster."
    ]
@@ -790,7 +790,7 @@
     "id": "5-q17kJ_rjLc"
    },
    "source": [
-    "As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05.1-pytrees.ipynb). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX."
+    "As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://jax.readthedocs.io/en/latest/jax-101/05.1-pytrees.html). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX."
    ]
   }
  ],

--- a/docs/jax-101/01-jax-basics.md
+++ b/docs/jax-101/01-jax-basics.md
@@ -149,7 +149,7 @@ jax.grad(sum_squared_error, argnums=(0, 1))(x, y)  # Find gradient wrt both x & 
 
 +++ {"id": "yQAMTnZSqo-t"}
 
-Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05.1-pytrees.ipynb). So, most often, use of `jax.grad` looks like this:
+Does this mean that when doing machine learning, we need to write functions with gigantic argument lists, with an argument for each model parameter array? No. JAX comes equipped with machinery for bundling arrays together in data structures called 'pytrees', on which more in a [later guide](https://jax.readthedocs.io/en/latest/jax-101/05.1-pytrees.html). So, most often, use of `jax.grad` looks like this:
 
 ```
 def loss_fn(params, data):
@@ -284,7 +284,7 @@ Isn't the pure version less efficient? Strictly, yes; we are creating a new arra
 
 Of course, it's possible to mix side-effectful Python code and functionally pure JAX code, and we will touch on this more later. As you get more familiar with JAX, you will learn how and when this can work. As a rule of thumb, however, any functions intended to be transformed by JAX should avoid side-effects, and the JAX primitives themselves will try to help you do that.
 
-We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Part 7: Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs.
+We will explain other places where the JAX idiosyncracies become relevant as they come up. There is even a section that focuses entirely on getting used to the functional programming style of handling state: [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html). However, if you're impatient, you can find a [summary of JAX's sharp edges](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html) in the JAX docs.
 
 +++ {"id": "dFn_VBFFlGCz"}
 
@@ -351,7 +351,7 @@ def update(theta, x, y, lr=0.1):
 
 +++ {"id": "MAUL1gT_opVn"}
 
-In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [The Problem of State](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state.ipynb).
+In JAX, it's common to define an `update()` function that is called every step, taking the current parameters as input and returning the new parameters. This is a natural consequence of JAX's functional nature, and is explained in more detail in [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html).
 
 This function can then be JIT-compiled in its entirety for maximum efficiency. The next guide will explain exactly how `jax.jit` works, but if you want to, you can try adding `@jax.jit` before the `update()` definition, and see how the training loop below runs much faster.
 
@@ -372,4 +372,4 @@ print(f"w: {w:<.2f}, b: {b:<.2f}")
 
 +++ {"id": "5-q17kJ_rjLc"}
 
-As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05.1-pytrees.ipynb). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX.
+As you will see going through these guides, this basic recipe underlies almost all training loops you'll see implemented in JAX. The main difference between this example and real training loops is the simplicity of our model: that allows us to use a single array to house all our parameters. We cover managing more parameters in the later [pytree guide](https://jax.readthedocs.io/en/latest/jax-101/05.1-pytrees.html). Feel free to skip forward to that guide now to see how to manually define and train a simple MLP in JAX.

--- a/docs/jax-101/06-parallelism.ipynb
+++ b/docs/jax-101/06-parallelism.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "## The basics\n",
     "\n",
-    "The most basic use of `jax.pmap` is completely analogous to `jax.vmap`, so let's return to the convolution example from the [Vectorisation notebook](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/03-vectorization.ipynb)."
+    "The most basic use of `jax.pmap` is completely analogous to `jax.vmap`, so let's return to the convolution example from the [Automatic Vectorization in JAX](https://jax.readthedocs.io/en/latest/jax-101/03-vectorization.html)."
    ]
   },
   {
@@ -544,7 +544,7 @@
     "* the `update()` function\n",
     "* the replication of parameters and splitting of data across devices.\n",
     "\n",
-    "If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state-in-jax.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture."
+    "If this example is too confusing, you can find the same example, but without parallelism, in the next tutorial, [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture."
    ]
   },
   {

--- a/docs/jax-101/06-parallelism.md
+++ b/docs/jax-101/06-parallelism.md
@@ -56,7 +56,7 @@ jax.devices()
 
 ## The basics
 
-The most basic use of `jax.pmap` is completely analogous to `jax.vmap`, so let's return to the convolution example from the [Vectorisation notebook](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/03-vectorization.ipynb).
+The most basic use of `jax.pmap` is completely analogous to `jax.vmap`, so let's return to the convolution example from the [Automatic Vectorization in JAX](https://jax.readthedocs.io/en/latest/jax-101/03-vectorization.html).
 
 ```{code-cell}
 :id: IIQKBr-CgtD2
@@ -223,7 +223,7 @@ There are two places to pay attention to:
 * the `update()` function
 * the replication of parameters and splitting of data across devices.
 
-If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/07-state-in-jax.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture.
+If this example is too confusing, you can find the same example, but without parallelism, in the next tutorial, [Stateful Computations in JAX](https://jax.readthedocs.io/en/latest/jax-101/07-state.html). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture.
 
 ```{code-cell}
 :id: cI8xQqzRrc-4

--- a/docs/jax-101/07-state.ipynb
+++ b/docs/jax-101/07-state.ipynb
@@ -251,7 +251,7 @@
     "\n",
     "In our case, the `CounterV2` class is nothing more than a namespace bringing all the functions that use `CounterState` into one location. Exercise for the reader: do you think it makes sense to keep it as a class?\n",
     "\n",
-    "Incidentally, you've already seen an example of this strategy in the JAX pseudo-randomness API, `jax.random`, shown in the [Random Numbers section](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05-random-numbers.ipynb). Unlike Numpy, which manages random state using stateful classes, JAX requires the programmer to work directly with the random generator state -- the PRNGKey."
+    "Incidentally, you've already seen an example of this strategy in the JAX pseudo-randomness API, `jax.random`, shown in the [Random Numbers section](https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html). Unlike Numpy, which manages random state using stateful classes, JAX requires the programmer to work directly with the random generator state -- the PRNGKey."
    ]
   },
   {

--- a/docs/jax-101/07-state.md
+++ b/docs/jax-101/07-state.md
@@ -168,7 +168,7 @@ Notice that the need for a class becomes less clear once we have rewritten it th
 
 In our case, the `CounterV2` class is nothing more than a namespace bringing all the functions that use `CounterState` into one location. Exercise for the reader: do you think it makes sense to keep it as a class?
 
-Incidentally, you've already seen an example of this strategy in the JAX pseudo-randomness API, `jax.random`, shown in the [Random Numbers section](https://colab.research.google.com/github/google/jax/blob/master/docs/jax-101/05-random-numbers.ipynb). Unlike Numpy, which manages random state using stateful classes, JAX requires the programmer to work directly with the random generator state -- the PRNGKey.
+Incidentally, you've already seen an example of this strategy in the JAX pseudo-randomness API, `jax.random`, shown in the [Random Numbers section](https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html). Unlike Numpy, which manages random state using stateful classes, JAX requires the programmer to work directly with the random generator state -- the PRNGKey.
 
 +++ {"id": "I2SqRx14_z98"}
 


### PR DESCRIPTION
While I am reading JAX_101 tutorial (which I think is really informative), I found some hyperlinks link to JAX documentation and some links to notebooks.

Therefore, modify hyperlinks to link to JAX documentation instead of notebooks.
Also modify link text to use the title of the tutorials.