### PR TITLE
Add optional `size` argument to jnp.nonzero to allow use in JIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
   * When combined with jaxlib 0.1.66, {func}`jax.jit` now supports static
     keyword arguments. A new `static_argnames` option has been added to specify
     keyword arguments as static.
+  * {func}`jax.nonzero` has a new optional `size` argument that allows it to
+    be used within `jit` ({jax-issue}`6501`)
 * Breaking changes:
   * Arguments to {func}`jax.jit` other than the function are now marked as
     keyword-only. This change is to prevent accidental breakage when arguments

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -933,6 +933,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
+    # JIT compilation requires specifying the size statically:
+    jnp_fun = lambda x: jnp.nonzero(x, size=np.size(x) // 2)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}".format(
           jtu.format_shape_dtype_string(shape, dtype)),


### PR DESCRIPTION
This changes the implementation of `jnp.nonzero` to allow it to be used within JIT by optionally passing a static `size` argument:
```python
>>> import jax.numpy as jnp
>>> from jax import jit
>>> x = jnp.array([0, 1, 1, 0, 0, 1])

# normal calling pattern still works
>>> jnp.nonzero(x)
(DeviceArray([1, 2, 5], dtype=int32),)

# pass a static size and it works with jit()
>>> jit(jnp.nonzero, static_argnums=1)(x, 3)
(DeviceArray([1, 2, 5], dtype=int32),)

# if the size is too large, the result is zero-padded
>>> jit(jnp.nonzero, static_argnums=1)(x, 5)
(DeviceArray([1, 2, 5, 0, 0], dtype=int32),)
```
Performance-wise, this appears to be comparable to the previous approach; using the following test code:
```python
import jax.numpy as jnp
import numpy as np
x = np.random.randn(200, 300, 400)
x[x < 0] = 0
x = jnp.asarray(x)
%timeit [i.block_until_ready() for i in jnp.nonzero(x)]
```
on master gives:
```
760 ms ± 4.71 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
and in this branch gives:
```
772 ms ± 7.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```