### PR TITLE
Add optional distributed debugging logging.

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -174,8 +174,9 @@ class Config:
     update_thread_local_hook: Optional[Callable[[Optional[bool]], None]] = None):
     """Set up thread-local state and return a contextmanager for managing it.
 
-    This function is a convenience wrapper. It defines a flag and corresponding
-    thread-local state, which can be managed via the contextmanager it returns.
+    This function is a convenience wrapper. It defines a flag, environment
+    variable, and corresponding thread-local state, which can be managed via the
+    contextmanager it returns.
 
     The thread-local state value can be read via the ``config.<option_name>``
     attribute, where ``config`` is the singleton ``Config`` instance.
@@ -396,6 +397,13 @@ log_compiles = config.define_bool_state(
           'computation. Logging is performed with `absl.logging`. When this '
           'option is set, the log level is WARNING; otherwise the level is '
           'DEBUG.'))
+
+distributed_debug = config.define_bool_state(
+    name="jax_distributed_debug",
+    default=False,
+    help=('Enable logging useful for debugging multi-process distributed '
+          'computations. Logging is performed with `absl.logging` at WARNING '
+          'level.'))
 
 def _update_x64_global(val):
   lib.jax_jit.global_state().enable_x64 = val

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -19,6 +19,7 @@ import operator
 import types
 from typing import Any, Callable
 
+from absl import logging
 import numpy as np
 
 from jax.config import config
@@ -392,3 +393,22 @@ def maybe_named_axis(axis, if_pos, if_named):
   except TypeError:
     named = True
   return if_named(axis) if named else if_pos(pos)
+
+def distributed_debug_log(*pairs):
+  """Format and log `pairs` if config.jax_distributed_debug is enabled.
+
+  Args:
+    pairs: A sequence of label/value pairs to log. The first pair is treated as
+    a heading for subsequent pairs.
+  """
+  if config.jax_distributed_debug:
+    lines = ["\nDISTRIBUTED_DEBUG_BEGIN"]
+    try:
+      lines.append(f"{pairs[0][0]}: {pairs[0][1]}")
+      for label, value in pairs[1:]:
+        lines.append(f"  {label}: {value}")
+    except Exception as e:
+      lines.append("DISTRIBUTED_DEBUG logging failed!")
+      lines.append(f"{e}")
+    lines.append("DISTRIBUTED_DEBUG_END")
+    logging.warning("\n".join(lines))

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -47,7 +47,7 @@ from ..abstract_arrays import array_types
 from ..core import ConcreteArray, ShapedArray
 from .._src.util import (partial, unzip3, prod, safe_map, safe_zip,
                          extend_name_stack, wrap_name, assert_unreachable,
-                         tuple_insert, tuple_delete)
+                         tuple_insert, tuple_delete, distributed_debug_log)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from ..lib import pmap_lib
@@ -614,6 +614,12 @@ def xla_pmap_impl(fun: lu.WrappedFun, *args, backend, axis_name, axis_size,
                                    in_axes, out_axes_thunk,
                                    donated_invars, global_arg_shapes,
                                    *abstract_args)
+  # Don't re-abstractify args unless logging is enabled for performance.
+  if config.jax_distributed_debug:
+    distributed_debug_log(("Running pmapped function", name),
+                          ("python function", fun.f),
+                          ("devices", devices),
+                          ("abstract args", map(xla.abstractify, args)))
   return compiled_fun(*args)
 
 @lu.cache

--- a/jax/lib/xla_bridge.py
+++ b/jax/lib/xla_bridge.py
@@ -173,11 +173,16 @@ def get_backend(platform=None):
     return platform
 
   with _backend_lock:
-    backend = _backends.get(FLAGS.jax_xla_backend)
-    if backend is None:
+    backend_factory = _backends.get(FLAGS.jax_xla_backend)
+    if backend_factory is None:
       msg = 'Unknown jax_xla_backend value "{}".'
       raise ValueError(msg.format(FLAGS.jax_xla_backend))
-    return backend(platform)
+    backend = backend_factory(platform)
+    util.distributed_debug_log(("Initialized backend", backend.platform),
+                               ("process_index", backend.process_index()),
+                               ("device_count", backend.device_count()),
+                               ("local_devices", backend.local_devices()))
+    return backend
 
 
 def get_device_backend(device=None):


### PR DESCRIPTION
This can be enabled by setting the environment variable
`JAX_DISTRIBUTED_DEBUG=1` (or other true-like values), the flag
`--jax_distributed_debug=1`, or `jax.config.distributed_debug =
True`. It's off by default.

This enables WARNING-level logging of each distributed computation
that's run and related debugging information. This is designed to help
with multi-process debugging, e.g. to identify mismatched pmaps across
processes. All debugging information is enclosed between
`DISTRIBUTED_DEBUG_BEGIN` and `DISTRIBUTED_DEBUG_END` to faciliate
grepping for this info.

Example output:

```
DISTRIBUTED_DEBUG_BEGIN
Initialized backend: tpu
  process_index: 0
  device_count: 8
  local_devices: [TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1), TpuDevice(id=2, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=3, process_index=0, coords=(1,0,0), core_on_chip=1), TpuDevice(id=4, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=5, process_index=0, coords=(0,1,0), core_on_chip=1), TpuDevice(id=6, process_index=0, coords=(1,1,0), core_on_chip=0), TpuDevice(id=7, process_index=0, coords=(1,1,0), core_on_chip=1)]
DISTRIBUTED_DEBUG_END

DISTRIBUTED_DEBUG_BEGIN
Running pmapped function: <lambda>
  python function: <function PmapTest.testArgAllReduce.<locals>.<lambda> at 0x7f77924d6c80>
  devices: None
  abstract args: [ShapedArray(float32[2,2])]
DISTRIBUTED_DEBUG_END

DISTRIBUTED_DEBUG_BEGIN
Running xmapped function: <lambda>
  python function: <function XMapTest.testAxisSizes.<locals>.<lambda> at 0x7fb33d86e158>
  mesh: Mesh(array([TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0),
       TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1)],
      dtype=object), ('x',))
  abstract args: []
DISTRIBUTED_DEBUG_END

DISTRIBUTED_DEBUG_BEGIN
Running pjit'd function: f
  python function: <function PJitTest.testShardingConstraintPyTree.<locals>.f at 0x7fad672b8b70>
  mesh: Mesh(array([[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0)],
       [TpuDevice(id=1, process_index=0, coords=(0,0,0), core_on_chip=1)]],
      dtype=object), ('x', 'y'))
  abstract args: [ShapedArray(int32[8,8]), ShapedArray(int32[8,8]), ShapedArray(int32[8,8])]
DISTRIBUTED_DEBUG_END
```