### PR TITLE
Make sure the (p/x)map out_axes in the HashableFunction closure are hashable.

### DIFF
--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -488,9 +488,15 @@ def xmap(fun: Callable,
     # TODO: Check that:
     #         - two axes mapped to the same resource never coincide (even inside f)
     in_axes_flat = flatten_axes("xmap in_axes", in_tree, in_axes)
+
+    # out_axes_thunk closes over the out_axes, they are flattened here to make
+    # them hashable.
+    out_axes_leaves, out_axes_treedef = tree_flatten(out_axes)
     out_axes_thunk = HashableFunction(
-      lambda: tuple(flatten_axes("xmap out_axes", out_tree(), out_axes)),
-      closure=out_axes)
+      lambda: tuple(flatten_axes("xmap out_axes", out_tree(),
+                                 tree_unflatten(out_axes_treedef,
+                                                list(out_axes_leaves)))),
+      closure=(tuple(out_axes_leaves), out_axes_treedef))
 
     axis_resource_count = _get_axis_resource_count(normalized_axis_resources, resource_env)
     for axis, size in axis_sizes.items():

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -2033,6 +2033,15 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
     self.assertAllClose(f(x, y),
                         (jnp.sin(x.transpose((1, 0, 2)) + y).transpose((1, 2, 0)), y * 2))
 
+  def testPmapDictOutAxes(self):
+    # see issue #6410
+    @partial(pmap, out_axes={'a': 0})
+    def f(x):
+      return {'a': x}
+    device_count = xla_bridge.device_count()
+    x = jnp.arange(device_count)
+    tree_util.tree_multimap(self.assertAllClose, f(x), {'a': x})
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": f"_{in_axes}_{out_axes}",
        "in_axes": in_axes, "out_axes": out_axes}

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -1143,6 +1143,12 @@ class XMapErrorTest(jtu.JaxTestCase):
       xmap(lambda x: x, in_axes={0: 'i'}, out_axes={-1: 'i'})(jnp.ones((5,)))
 
   @ignore_xmap_warning()
+  def testDictOutAxes(self):
+    # see issue #6410
+    out = xmap(lambda x: x, in_axes=[...], out_axes={"a": [...]})({"a": 1})
+    self.assertEqual(out, {"a": 1})
+
+  @ignore_xmap_warning()
   def testListAxesRankAssertion(self):
     error = (r"xmap argument has an in_axes specification of \['i', None\], which "
              r"asserts that it should be of rank 2, but the argument has rank 1 "


### PR DESCRIPTION
By flattening them before putting them in the closure, then unflattening when calling out_axes_thunk.

Fixes #6410 (and also pmap out_axes!)