### PR TITLE
Document that JAX follows the NEP-29 deprecation policy.

### DIFF
--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -1,10 +1,7 @@
 Concurrency
 ===========
 
-JAX has some limited support for Python concurrency.
-
-Concurrency support is experimental and only lightly tested; please report any
-bugs.
+JAX has limited support for Python concurrency.
 
 Clients may call JAX APIs (e.g., :func:`~jax.jit` or :func:`~jax.grad`)
 concurrently from separate Python threads.

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -1,0 +1,10 @@
+# Python and NumPy version support policy
+
+
+JAX follows NumPy's [NEP-29 deprecation policy](https://numpy.org/neps/nep-0029-deprecation_policy.html). JAX supports at least:
+
+* All minor versions of Python released 42 months prior to the project, and at minimum the two latest minor versions.
+
+* All minor versions of numpy released in the 24 months prior to the project, and at minimum the last three minor versions.
+
+JAX may support older versions of Python and NumPy, but support for older versions may be dropped at any time.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ parallelize, Just-In-Time compile to GPU/TPU, and more.
    :maxdepth: 1
    :caption: Notes
 
+   deprecation
    concurrency
    gpu_memory_allocation
    profiling


### PR DESCRIPTION
Remove the "experimental" disclaimer from the concurrency documentation.