### PR TITLE
Use pytest's filterwarnings feature instead of filtering each test case.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,6 @@ filterwarnings =
     ignore:Using or importing the ABCs.*:DeprecationWarning
     # jax2tf tests due to mix of JAX and TF
     ignore:numpy.ufunc size changed
+    ignore:.*experimental feature
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"
-


### PR DESCRIPTION
We often forget to put the per-test-case decorators, resulting in test
failures in cases not covered by github CI (e.g. Cloud TPU
tests). This change filters the "experimental feature" warnings by
default.