### PR TITLE
Added special cases for 2x2 and 3x3 determinant

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -238,11 +238,36 @@ def _cofactor_solve(a, b):
   return partial_det[..., -1], x
 
 
+def _det_2x2(a):
+  return (a[..., 0, 0] * a[..., 1, 1] -
+           a[..., 0, 1] * a[..., 1, 0])
+
+
+def _det_3x3(a):
+  return (a[..., 0, 0] * a[..., 1, 1] * a[..., 2, 2] +
+          a[..., 0, 1] * a[..., 1, 2] * a[..., 2, 0] +
+          a[..., 0, 2] * a[..., 1, 0] * a[..., 2, 1] -
+          a[..., 0, 2] * a[..., 1, 1] * a[..., 2, 0] -
+          a[..., 0, 0] * a[..., 1, 2] * a[..., 2, 1] -
+          a[..., 0, 1] * a[..., 1, 0] * a[..., 2, 2])
+
+
 @custom_jvp
 @_wraps(np.linalg.det)
+@jit
 def det(a):
-  sign, logdet = slogdet(a)
-  return sign * jnp.exp(logdet)
+  a = _promote_arg_dtypes(jnp.asarray(a))
+  a_shape = jnp.shape(a)
+  if len(a_shape) >= 2 and a_shape[-1] == 2 and a_shape[-2] == 2:
+    return _det_2x2(a)
+  elif len(a_shape) >= 2 and a_shape[-1] == 3 and a_shape[-2] == 3:
+    return _det_3x3(a)
+  elif len(a_shape) >= 2 and a_shape[-1] == a_shape[-2]:
+    sign, logdet = slogdet(a)
+    return sign * jnp.exp(logdet)
+  else:
+    msg = "Argument to _det() must have shape [..., n, n], got {}"
+    raise ValueError(msg.format(a_shape))
 
 
 @det.defjvp

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -82,7 +82,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
        "n": n, "dtype": dtype}
-      for n in [0, 4, 5, 25]  # TODO(mattjj): complex64 unstable on large sizes?
+      for n in [0, 2, 3, 4, 5, 25]  # TODO(mattjj): complex64 unstable on large sizes?
       for dtype in float_types + complex_types))
   def testDet(self, n, dtype):
     rng = jtu.rand_default(self.rng())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -82,7 +82,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),
        "n": n, "dtype": dtype}
-      for n in [0, 4, 5, 25]  # TODO(mattjj): complex64 unstable on large sizes?
+      for n in [0, 2, 3, 4, 5, 25]  # TODO(mattjj): complex64 unstable on large sizes?
       for dtype in float_types + complex_types))
   def testDet(self, n, dtype):
     rng = jtu.rand_default(self.rng())
@@ -137,7 +137,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     b = jnp.array([[ 36, -42,  18],
                   [-42,  49, -21],
                   [ 18, -21,   9]], dtype=jnp.float32)
-    jtu.check_grads(jnp.linalg.det, (b,), 1, atol=1e-1, rtol=1e-1)
+    jtu.check_grads(jnp.linalg.det, (b,), 1, atol=1e-1, rtol=1e-1, eps=1e-1)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":


### PR DESCRIPTION
Added special cases for 2x2, 3x3 linalg dets, and added test coverage for these cases.