### PR TITLE
Add eval_shape to the UnexpectedTracerError too.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2391,7 +2391,8 @@ def eval_shape(fun: Callable, *args, **kwargs):
   args_flat, in_tree = tree_flatten((args, kwargs))
   wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
   out = pe.abstract_eval_fun(wrapped_fun.call_wrapped,
-                             *map(shaped_abstractify, args_flat))
+                             *map(shaped_abstractify, args_flat),
+                             transform_name="eval_shape")
   out = [ShapeDtypeStruct(x.shape, x.dtype, x.named_shape) for x in out]
   return tree_unflatten(out_tree(), out)
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -400,8 +400,8 @@ call_partial_eval_rules: Dict[core.Primitive, Callable] = {}
 call_param_updaters: Dict[core.Primitive, Callable] = {}
 
 
-def abstract_eval_fun(fun, *avals, **params):
-  _, avals_out, _ = trace_to_jaxpr_dynamic(lu.wrap_init(fun, params), avals)
+def abstract_eval_fun(fun, *avals, transform_name="", **params):
+  _, avals_out, _ = trace_to_jaxpr_dynamic(lu.wrap_init(fun, params), avals, transform_name)
   assert all(isinstance(aval, AbstractValue) for aval in avals_out)
   return avals_out
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2207,6 +2207,11 @@ class APITest(jtu.JaxTestCase):
       jax.pmap(self.helper_save_tracer)(jnp.ones((1, 2)))
       _ = self._saved_tracer+1
 
+    with self.assertRaisesRegex(core.UnexpectedTracerError,
+                                "transformed by eval_shape"):
+      jax.eval_shape(self.helper_save_tracer, 1)
+      _ = self._saved_tracer+1
+
   def test_pmap_static_kwarg_error_message(self):
     # https://github.com/google/jax/issues/3007
     def f(a, b):


### PR DESCRIPTION
One side-effect of filtering out JAX internal frames from the UnexpectedTracerError is that we can't see what transform kicked of the trace which leaked the value. There is a trade-off here, because including the JAX frames means there is probably going to be no user code in this stack trace, which is unhelpful too (maybe we could re-include `api.py` specifically?)

We previously added some transform_names to the error to make up for this missing info in #6189, here's one more.