### PR TITLE
WIP: MLIR/TACO-like sparse representation

### DIFF
--- a/jax/experimental/mlir_sparse.py
+++ b/jax/experimental/mlir_sparse.py
@@ -1,0 +1,338 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+JAX implementation of a general N-dimensional sparse format being implemented
+in MLIR; see https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020
+"""
+from typing import Any, IO, List, Optional, Tuple
+
+import numpy as np
+import jax.numpy as jnp
+
+
+Array = Any
+
+
+def _compress_indices_sparse(iptr, ind, size):
+  """Utility to compress a series of indices
+
+  Args:
+    iptr : array of N + 1 pointers into ind array. The indices associated with
+      dimension ``i`` are given by ``ind[iptr[i]:iptr[i + 1]]``
+    ind : array of indices within each dimension
+    size : (unused) integer size of the leading dimension.
+
+  Returns:
+    positions : array of N + 1 pointers into indices array. The indices associated
+      with dimension ``i`` are given by ``indices[positions[i]:positions[i + 1]]``.
+    indices : array of length M, with N <= M <= (N * size), containing all non-empty
+      unique indices within each dimension.
+    new_iptr : array of (M + 1) pointers into ind array, indicating the input indices
+      associated with the output indices.
+
+  Example:
+    >>> iptr = jnp.array([0, 3, 7])
+    >>> ind = jnp.array([0, 1, 1, 0, 0, 2, 2])
+    >>> positions, indices, new_iptr = _compress_indices_sparse(iptr, ind, None)
+    >>> positions
+    DeviceArray([0, 2, 4], dtype=int32)
+    >>> indices
+    DeviceArray([0, 1, 0, 2], dtype=int32)
+    >>> new_iptr
+    DeviceArray([0, 1, 3, 5, 7], dtype=int32)
+  """
+  del size  # unused, for now
+
+  # offset each segment so that consecutive indices cannot be equal
+  offset = jnp.cumsum(jnp.zeros(len(ind) + 1).at[iptr].add(ind.max() + 1))
+  offset_ind = offset.at[:-1].add(ind)
+
+  # Use the cumulative sum to identify indices of unique values
+  diffs = offset_ind[1:] != offset_ind[:-1]
+  unique_ind = jnp.cumsum(jnp.concatenate([jnp.array([0]), diffs]))
+
+  # generate the de-duplicated index with zero padding at the end
+  index = jnp.zeros_like(ind).at[unique_ind[:-1]].set(ind)
+  positions = unique_ind[iptr]
+
+  # TODO: need a size on _nonzero here
+  new_iptr = jnp.nonzero(jnp.concatenate([jnp.array([1]), diffs]))[0]
+  # TODO: allow passing the full index through
+  return positions, index[:positions[-1]], new_iptr
+
+
+def _compress_indices_dense(iptr, ind, size, *, full_outputs=False):
+  """Utility for compressing dense indices.
+
+  Args:
+    iptr : array of N + 1 pointers into ind array. The indices associated with
+      dimension ``i`` are given by ``ind[iptr[i]:iptr[i + 1]]``
+    ind : array of indices within each dimension
+    size : integer size of the leading dimension.
+    full_outputs : if True, compute and return `positions` and `indices`. Otherwise
+      return None for these quantities (default=False).
+
+  Returns:
+    positions : None if full_outputs is False, otherwise a length (N + 1) array
+      of pointers into indices array. The indices associated with dimension ``i`` are
+      given by ``indices[positions[i]:positions[i + `]]``.
+    indices : None if full_outputs is False, otherwise an array of length M = N * size
+      containing (possibly empty) unique indices within each dimension.
+    new_iptr : array of (M + 1) pointers into ind array, indicating the input indices
+      associated with the output indices.
+
+  Examples:
+    >>> iptr = jnp.array([0, 3, 7])
+    >>> ind = jnp.array([0, 1, 1, 0, 0, 2, 2])
+    >>> positions, indices, new_iptr = _compress_indices_dense(iptr, ind, 3, full_outputs=True)
+    >>> positions
+    DeviceArray([0, 3, 6], dtype=int32)
+    >>> indices
+    DeviceArray([0, 1, 2, 0, 1, 2], dtype=int32)
+    >>> new_iptr
+    DeviceArray([0, 1, 3, 3, 5, 5, 7], dtype=int32)
+  """
+  # TODO: only use ind[iptr[0]:iptr[-1]]
+  if full_outputs:
+    N = len(iptr) - 1
+    positions = jnp.arange(0, (N + 1) * size, size)
+    indices = jnp.tile(jnp.arange(size), N)
+  else:
+    positions = indices = None
+  step = jnp.cumsum(jnp.zeros_like(ind).at[iptr[1:]].add(size))
+  counts = jnp.bincount(ind + step, length=size * (len(iptr) - 1))
+  iptr = jnp.cumsum(jnp.concatenate([jnp.array([0]), counts]))
+  return positions, indices, iptr
+
+
+def _uncompress_indices_sparse(positions, indices, iptr):
+  """
+  Inverse of _compress_indices_sparse
+
+  Examples:
+    >>> iptr = jnp.array([0, 3, 7])
+    >>> ind = jnp.array([0, 1, 1, 0, 0, 2, 2])
+    >>> size = 3
+
+    >>> args = _compress_indices_sparse(iptr, ind, size)
+    >>> _uncompress_indices_sparse(*args)
+    (DeviceArray([0, 3, 7], dtype=int32), DeviceArray([0, 1, 1, 0, 0, 2, 2], dtype=int32))
+  """
+  sizes = jnp.diff(iptr)
+  # TODO: make this repeat step statically sized
+  ind = jnp.repeat(indices, sizes)
+  iptr = iptr[positions]
+  return iptr, ind
+
+
+def _uncompress_indices_dense(positions, indices, iptr, size, N):
+  """
+  Inverse of _compress_indices_dense.
+
+  Examples:
+    >>> iptr = jnp.array([0, 3, 7])
+    >>> ind = jnp.array([0, 1, 1, 0, 0, 2, 2])
+    >>> size = 3
+    >>> N = len(iptr) - 1
+
+    >>> args = _compress_indices_dense(iptr, ind, size, full_outputs=False)
+    >>> _uncompress_indices_dense(*args, size, N)
+    (DeviceArray([0, 3, 7], dtype=int32), DeviceArray([0, 1, 1, 0, 0, 2, 2], dtype=int32))
+
+    >>> args = _compress_indices_dense(iptr, ind, size, full_outputs=True)
+    >>> _uncompress_indices_dense(*args, size, N)
+    (DeviceArray([0, 3, 7], dtype=int32), DeviceArray([0, 1, 1, 0, 0, 2, 2], dtype=int32))
+  """
+  if positions is None or indices is None:
+    positions = jnp.arange(0, (N + 1) * size, size)
+    indices = jnp.tile(jnp.arange(size), N)
+  return _uncompress_indices_sparse(positions, indices, iptr)
+
+
+def read_frostt(f: IO) -> np.ndarray:
+  """Read a matrix in extended FROSTT format, returning a dense representation.
+
+  Example:
+    >>> import io
+    >>> f = io.StringIO('''
+    ... 3 7
+    ... 3 3 4
+    ... 1 1 1  1.0
+    ... 1 1 4  2.0
+    ... 1 2 1  3.0
+    ... 1 2 2  4.0
+    ... 3 1 2  5.0
+    ... 3 2 3  6.0
+    ... 3 2 4  7.0
+    ... ''')
+    >>> read_frostt(f)
+    array([[[1., 0., 0., 2.],
+            [3., 4., 0., 0.],
+            [0., 0., 0., 0.]],
+           [[0., 0., 0., 0.],
+            [0., 0., 0., 0.],
+            [0., 0., 0., 0.]],
+           [[0., 5., 0., 0.],
+            [0., 0., 6., 7.],
+            [0., 0., 0., 0.]]])
+  """
+  for line in f:
+    line = line.split('#')[0]
+    if line.strip():
+      break
+  ndim, nnz = map(int, line.split())
+
+  line = f.readline().split('#')[0]
+  shape = tuple(map(int, line.split()))
+  assert len(shape) == ndim
+
+  mat = np.zeros(shape, dtype=float)
+  for i in range(nnz):
+    line = f.readline().split('#')[0]
+    *indices, val = line.split()
+    mat[tuple(i - 1 for i in map(int, indices))] = float(val)
+  return mat
+
+
+def mlir_fromdense(mat, *, format):
+  """Convert a dense matrix to a sparse representation with the given format.
+
+  Args:
+    mat : N-dimensional numpy array.
+    format : length-N tuple with "S" for sparse dimensions and "D" for dense.
+
+  Returns:
+    positions, indices, values : general sparse representation
+  """
+  # TODO: allow passing static metadata (e.g. nnz) that allow this to be compiled.
+  mat = jnp.asarray(mat)
+  format = tuple(format)
+
+  assert set(format).issubset({"D", "S"})
+  assert len(format) == mat.ndim
+
+  if "S" not in format:
+    return [None] * mat.ndim, [None] * mat.ndim, mat
+
+  last_s = format[::-1].index("S")
+  axis = tuple(range(len(format) - last_s, len(format)))
+
+  ind_tup = jnp.nonzero(mat.any(axis))
+  values = mat[ind_tup]
+
+  positions = []
+  indices = []
+  iptr = jnp.array([0, len(values)])
+
+  for ind, fmt, size in zip(ind_tup, format, mat.shape):
+    if fmt == "S":
+      position, index, iptr = _compress_indices_sparse(iptr, ind, size)
+    else:
+      position, index, iptr = _compress_indices_dense(iptr, ind, size)
+    indices.append(index)
+    positions.append(position)
+  indices.extend([None] * (mat.ndim - len(indices)))
+  positions.extend([None] * (mat.ndim - len(positions)))
+  return positions, indices, values.ravel()
+
+
+def _mlir_tocoo(positions, indices, values, *, shape):
+  assert len(positions) == len(shape)
+  assert len(indices) == len(shape)
+  format = tuple("D" if p is None else "S" for p in positions)
+  if "S" not in format:
+    return (), values
+
+  last_s = len(shape) - format[::-1].index("S")
+  values = values.reshape((-1,) + shape[last_s:])
+  ind = last_s * [None]
+  iptr = jnp.arange(values.shape[0] + 1, dtype=indices[last_s - 1].dtype)
+  for i in range(last_s)[::-1]:
+    size = shape[i]
+    if format[i] == "S":
+      iptr, ind[i] = _uncompress_indices_sparse(positions[i], indices[i], iptr)
+    else:
+      N = 1 if i == 0 else shape[i - 1] if format[i - 1] == "D" else len(indices[i - 1])
+      iptr, ind[i] = _uncompress_indices_dense(positions[i], indices[i], iptr, size=size, N=N)
+  return tuple(ind), values
+
+
+def mlir_todense(positions, indices, values, *, shape):
+  """Convert a sparse representation to a dense matrix.
+
+  Args:
+    positions : list containing None for dense dimensions and arrays of
+      positions for sparse dimensions.
+    indices : list containing None for dense dimentions and arrays of
+      positions for sparse dimensions.
+    values : array of nonzero values in the sparse representation
+    shape : tuple representing the matrix shape.
+  Returns:
+    mat : dense matrix representation of specified shape.
+  """
+  ind, values = _mlir_tocoo(positions, indices, values, shape=shape)
+  if not ind:
+    return values
+  return jnp.zeros(shape, values.dtype).at[ind].set(values)
+
+
+def mlir_matvec(positions, indices, values, v, *, shape):
+  v = jnp.asarray(v)
+  if v.ndim != 1:
+    raise NotImplementedError("mlir_matvec only supports 1-dimensional `v`")
+  assert v.shape == shape[-1:]
+  ind, values = _mlir_tocoo(positions, indices, values, shape=shape)
+  if indices[-1] is None:
+    return mlir_todense(positions[:-1], indices[:-1], values @ v, shape=shape[:-1])
+  if len(ind) == 1:
+    return values @ v[ind[0]]
+  elif len(ind) == 2:
+    row, col = ind
+    dv = values * v[col]
+    return jnp.zeros(shape[0], dv.dtype).at[row].add(dv)
+  else:
+    # TODO: implement this case.
+    raise NotImplementedError("mlir_matvec only supports 1 or 2 dimensional matrices.")
+
+
+class MLIRSparse:
+  positions: List[Optional[Array]]
+  indices: List[Optional[Array]]
+  values: Array
+  shape: Tuple[int, ...]
+
+  dtype = property(lambda self: self.values.dtype)
+  nnz = property(lambda self: self.values.size)
+  ndim = property(lambda self: len(self.shape))
+
+  def __init__(self, args, *, shape):
+    self.positions, self.indices, self.values = args
+    self.shape = shape
+
+  @classmethod
+  def fromfile(cls, f, format=None):
+    # TODO: avoid trip through dense & pass correct nnz
+    return cls.fromdense(read_frostt(f), format=format)
+
+  @classmethod
+  def fromdense(cls, mat, *, format=None):
+    if format is None:
+      format = "S" * mat.ndim
+    return cls(mlir_fromdense(mat, format=format), shape=mat.shape)
+
+  def todense(self):
+    return mlir_todense(self.positions, self.indices, self.values, shape=self.shape)
+
+  def __matmul__(self, v):
+    return mlir_matvec(self.positions, self.indices, self.values, v, shape=self.shape)

--- a/tests/mlir_sparse_test.py
+++ b/tests/mlir_sparse_test.py
@@ -103,6 +103,7 @@ class MLIRSparseTest(jtu.JaxTestCase):
     self.assertEqual(M.values.dtype, mat.dtype)
 
     self.assertArraysEqual(mat, M.todense())
+    self.assertArraysEqual(mat, jit(M.todense)())
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_format={}".format(
@@ -119,8 +120,7 @@ class MLIRSparseTest(jtu.JaxTestCase):
 
     func = lambda M, v: M @ v
     self.assertAllClose(mat @ v, func(M, v))
-    # TODO(jakevdp): make the tocoo() code JIT-compatible & enable this test.
-    # self.assertAllClose(mat @ v, jit(func)(M, v))
+    self.assertAllClose(mat @ v, jit(func)(M, v))
 
 
 if __name__ == "__main__":

--- a/tests/mlir_sparse_test.py
+++ b/tests/mlir_sparse_test.py
@@ -1,0 +1,127 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import itertools
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+import jax.numpy as jnp
+from jax.experimental import mlir_sparse
+from jax import test_util as jtu
+
+MAT_FROSTT = """
+# extended FROSTT format
+3 7
+3 3 4
+1 1 1  1.0
+1 1 4  2.0
+1 2 1  3.0
+1 2 2  4.0
+3 1 2  5.0
+3 2 3  6.0
+3 2 4  7.0
+"""
+
+
+class MLIRSparseTest(jtu.JaxTestCase):
+  def test_known_input_DDS(self):
+    # See https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020/21
+    M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="DDS")
+
+    self.assertIsNone(M.positions[0])
+    self.assertIsNone(M.positions[1])
+    self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 4, 4, 4, 4, 5, 7, 7]))
+
+    self.assertIsNone(M.indices[0])
+    self.assertIsNone(M.indices[1])
+    self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
+
+    self.assertArraysEqual(M.values, jnp.array([1., 2., 3., 4., 5., 6., 7.]))
+
+  def test_known_input_SSS(self):
+    # See https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020/21
+    M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="SSS")
+
+    self.assertArraysEqual(M.positions[0], jnp.array([0, 2]))
+    self.assertArraysEqual(M.positions[1], jnp.array([0, 2, 4]))
+    self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 5, 7]))
+
+    self.assertArraysEqual(M.indices[0], jnp.array([0, 2]))
+    self.assertArraysEqual(M.indices[1], jnp.array([0, 1, 0, 1]))
+    self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
+
+    self.assertArraysEqual(M.values, jnp.array([1., 2., 3., 4., 5., 6., 7.]))
+
+  def test_known_input_SDS(self):
+    # See https://llvm.discourse.group/t/rfc-introduce-a-sparse-tensor-type-to-core-mlir/2944/35
+    M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="SDS")
+
+    self.assertArraysEqual(M.positions[0], jnp.array([0, 2]))
+    self.assertIsNone(M.positions[1])
+    self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 4, 5, 7, 7]))
+
+    self.assertArraysEqual(M.indices[0], jnp.array([0, 2]))
+    self.assertIsNone(M.indices[1])
+    self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
+
+    self.assertArraysEqual(M.values, jnp.array([1., 2., 3., 4., 5., 6., 7.]))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_format={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), ''.join(format)),
+       "shape": shape, "dtype": dtype, "format": format}
+      for shape in [(5,), (4, 5), (4, 3, 5), (5, 3, 4)]
+      for dtype in jtu.dtypes.all
+      for format in itertools.product("SD", repeat=len(shape))))
+  def test_round_trip(self, shape, dtype, format):
+    rng = jtu.rand_some_zero(self.rng())
+    mat = rng(shape, dtype)
+    M = mlir_sparse.MLIRSparse.fromdense(mat, format=format)
+
+    self.assertIsInstance(M.positions, list)
+    self.assertIsInstance(M.indices, list)
+    self.assertLen(M.positions, mat.ndim)
+    self.assertLen(M.indices, mat.ndim)
+    for i in range(mat.ndim):
+      if format[i] == "D":
+        self.assertIsNone(M.positions[i])
+        self.assertIsNone(M.indices[i])
+      else:
+        self.assertIsInstance(M.positions[i], jnp.ndarray)
+        self.assertIsInstance(M.indices[i], jnp.ndarray)
+    self.assertIsInstance(M.values, jnp.ndarray)
+    self.assertEqual(M.values.dtype, mat.dtype)
+
+    self.assertArraysEqual(mat, M.todense())
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_format={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), ''.join(format)),
+       "shape": shape, "dtype": dtype, "format": format}
+      for shape in [(5, 3), (3, 5), (3,), (5,)]
+      for dtype in jtu.dtypes.floating
+      for format in itertools.product("SD", repeat=len(shape))))
+  def test_matvec(self, shape, dtype, format):
+    rng = jtu.rand_some_zero(self.rng())
+    mat = rng(shape, dtype)
+    M = mlir_sparse.MLIRSparse.fromdense(mat, format=format)
+    v = rng(shape[-1:], dtype)
+
+    self.assertAllClose(mat @ v, M @ v)
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/mlir_sparse_test.py
+++ b/tests/mlir_sparse_test.py
@@ -41,13 +41,11 @@ class MLIRSparseTest(jtu.JaxTestCase):
     # See https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020/21
     M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="DDS")
 
-    self.assertIsNone(M.positions[0])
-    self.assertIsNone(M.positions[1])
-    self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 4, 4, 4, 4, 5, 7, 7]))
+    self.assertLen(M.positions, 1)
+    self.assertArraysEqual(M.positions[0], jnp.array([0, 2, 4, 4, 4, 4, 4, 5, 7, 7]))
 
-    self.assertIsNone(M.indices[0])
-    self.assertIsNone(M.indices[1])
-    self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
+    self.assertLen(M.indices, 1)
+    self.assertArraysEqual(M.indices[0], jnp.array([0, 3, 0, 1, 1, 2, 3]))
 
     self.assertArraysEqual(M.values, jnp.array([1., 2., 3., 4., 5., 6., 7.]))
 
@@ -55,10 +53,12 @@ class MLIRSparseTest(jtu.JaxTestCase):
     # See https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020/21
     M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="SSS")
 
+    self.assertLen(M.positions, 3)
     self.assertArraysEqual(M.positions[0], jnp.array([0, 2]))
     self.assertArraysEqual(M.positions[1], jnp.array([0, 2, 4]))
     self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 5, 7]))
 
+    self.assertLen(M.indices, 3)
     self.assertArraysEqual(M.indices[0], jnp.array([0, 2]))
     self.assertArraysEqual(M.indices[1], jnp.array([0, 1, 0, 1]))
     self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
@@ -69,13 +69,13 @@ class MLIRSparseTest(jtu.JaxTestCase):
     # See https://llvm.discourse.group/t/rfc-introduce-a-sparse-tensor-type-to-core-mlir/2944/35
     M = mlir_sparse.MLIRSparse.fromfile(io.StringIO(MAT_FROSTT), format="SDS")
 
+    self.assertLen(M.positions, 2)
     self.assertArraysEqual(M.positions[0], jnp.array([0, 2]))
-    self.assertIsNone(M.positions[1])
-    self.assertArraysEqual(M.positions[2], jnp.array([0, 2, 4, 4, 5, 7, 7]))
+    self.assertArraysEqual(M.positions[1], jnp.array([0, 2, 4, 4, 5, 7, 7]))
 
+    self.assertLen(M.indices, 2)
     self.assertArraysEqual(M.indices[0], jnp.array([0, 2]))
-    self.assertIsNone(M.indices[1])
-    self.assertArraysEqual(M.indices[2], jnp.array([0, 3, 0, 1, 1, 2, 3]))
+    self.assertArraysEqual(M.indices[1], jnp.array([0, 3, 0, 1, 1, 2, 3]))
 
     self.assertArraysEqual(M.values, jnp.array([1., 2., 3., 4., 5., 6., 7.]))
 
@@ -93,15 +93,11 @@ class MLIRSparseTest(jtu.JaxTestCase):
 
     self.assertIsInstance(M.positions, list)
     self.assertIsInstance(M.indices, list)
-    self.assertLen(M.positions, mat.ndim)
-    self.assertLen(M.indices, mat.ndim)
-    for i in range(mat.ndim):
-      if format[i] == "D":
-        self.assertIsNone(M.positions[i])
-        self.assertIsNone(M.indices[i])
-      else:
-        self.assertIsInstance(M.positions[i], jnp.ndarray)
-        self.assertIsInstance(M.indices[i], jnp.ndarray)
+    self.assertLen(M.positions, format.count("S"))
+    self.assertLen(M.indices, format.count("S"))
+    for pos, ind in zip(M.positions, M.indices):
+      self.assertIsInstance(pos, jnp.ndarray)
+      self.assertIsInstance(ind, jnp.ndarray)
     self.assertIsInstance(M.values, jnp.ndarray)
     self.assertEqual(M.values.dtype, mat.dtype)
 


### PR DESCRIPTION
Still very much a work in progress; related to #6544.

This follows the MLIR format discussed at https://llvm.discourse.group/t/mlir-support-for-sparse-tensors/2020/22

I'm not sure whether we'll want to merge this in the end, but it's a useful exercise.