### PR TITLE
Don't build CUDA 11.2+ wheels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     with integer inputs ({jax-issue}`#6360`).
 
 ## jaxlib 0.1.66 (unreleased)
+* New features:
+  * CUDA 11.1 wheels are now supported on all CUDA 11 versions 11.1 or higher.
+
+    NVidia now promises compatibility between CUDA minor releases starting with
+    CUDA 11.1. This means that JAX can release a single CUDA 11.1 wheel that
+    is compatible with CUDA 11.2 and 11.3.
+
+    There is no longer a separate jaxlib release for CUDA 11.2 (or higher); use
+    the CUDA 11.1 wheel for those versions (cuda111).
   * Added support for static keyword arguments to the C++ `jit` implementation.
 
 ## jaxlib 0.1.65 (April 7 2021)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "c6458a1a00d6c33833d1434efe0bf7bfe4d7e895e3241b0d904342693127d45f",
-    strip_prefix = "tensorflow-d9ad2a9f62ada961b26d09c8f4856cb0c94d9f8a",
+    sha256 = "ce033795d4d58ecb92a0188d6881c29d5a126e62cd21dd1882eb902e2b5ac226",
+    strip_prefix = "tensorflow-559047cb46f6805dfc50cba6d91b5a1e2d8d1b68",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/d9ad2a9f62ada961b26d09c8f4856cb0c94d9f8a.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/559047cb46f6805dfc50cba6d91b5a1e2d8d1b68.tar.gz",
     ],
 )
 

--- a/build/build_jaxlib_wheels.sh
+++ b/build/build_jaxlib_wheels.sh
@@ -4,7 +4,7 @@ set -xev
 source "$(dirname $(realpath $0))/build_jaxlib_wheels_helpers.sh"
 
 PYTHON_VERSIONS="3.6.8 3.7.2 3.8.0 3.9.0"
-CUDA_VERSIONS="10.1 10.2 11.0 11.1 11.2"
+CUDA_VERSIONS="10.2 11.0 11.1"
 CUDA_VARIANTS="cuda" # "cuda-included"
 
 build_cuda_wheels "$PYTHON_VERSIONS" "$CUDA_VERSIONS" "$CUDA_VARIANTS"


### PR DESCRIPTION
Update XLA.

CUDA 11.1 wheels are compatible with CUDA versions 11.1+, since NVidia now promises enhanced version compatibility between CUDA minor releases starting with CUDA 11.1.

This change will also require documentation changes, e.g., to the README, but they should be made when new wheels are released.