### PR TITLE
add 'inline' option to xla_call for jaxpr inlining

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -433,6 +433,7 @@ computation should run. For example
                                  in (g,) }
                     device=None
                     donated_invars=(False, False)
+                    inline=False
                     name=inner ] a b
       d = convert_element_type[ new_dtype=float32
                                 weak_type=False ] a

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -263,7 +263,10 @@ def jit(
       buffers to reduce the amount of memory needed to perform a computation,
       for example recycling one of your input buffers to store a result. You
       should not reuse buffers that you donate to a computation, JAX will raise
-      an error if you try to.
+      an error if you try to. By default, no arguments are donated.
+    inline: Specify whether this function should be inlined into enclosing
+      jaxprs (rather than being represented as an application of the xla_call
+      primitive with its own subjaxpr). Default False.
 
   Returns:
     A wrapped version of ``fun``, set up for just-in-time compilation.
@@ -304,7 +307,7 @@ def _python_jit(
     donate_argnums: Union[int, Iterable[int]] = (),
     inline: bool = False,
 ) -> F:
-  """The Python implementation of `jax.jit`, being slowly replaced by _cpp_jit."""
+  # The Python implementation of `jax.jit`, being slowly replaced by _cpp_jit.
   _check_callable(fun)
   static_argnums, static_argnames = _infer_argnums_and_argnames(
       fun, static_argnums, static_argnames)
@@ -365,15 +368,13 @@ def _cpp_jit(
     donate_argnums: Union[int, Iterable[int]] = (),
     inline: bool = False,
 ) -> F:
-  """An implementation of `jit` that tries to do as much as possible in C++.
-
-  The goal of this function is to speed up the time it takes to process the
-  arguments, find the correct C++ executable, start the transfer of arguments
-  and schedule the computation.
-  As long as it does not support all features of the Python implementation
-  the C++ code will fallback to `_python_jit` when it faces some unsupported
-  feature.
-  """
+  # An implementation of `jit` that tries to do as much as possible in C++.
+  # The goal of this function is to speed up the time it takes to process the
+  # arguments, find the correct C++ executable, start the transfer of arguments
+  # and schedule the computation.
+  # As long as it does not support all features of the Python implementation
+  # the C++ code will fallback to `_python_jit` when it faces some unsupported
+  # feature.
   _check_callable(fun)
   static_argnums, static_argnames = _infer_argnums_and_argnames(
       fun, static_argnums, static_argnames)

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -270,13 +270,13 @@ class CustomJVPCallPrimitive(core.CallPrimitive):
     jvp, env_trace_todo2 = core.process_env_traces(
         jvp, self, top_trace and top_trace.level, (), None)
     tracers = map(top_trace.full_raise, args)  # type: ignore
-    with core.maybe_new_sublevel(top_trace):
-      outs = top_trace.process_custom_jvp_call(self, fun, jvp, tracers)  # type: ignore
+    outs = top_trace.process_custom_jvp_call(self, fun, jvp, tracers)  # type: ignore
     _, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)
     return _apply_todos(env_trace_todo, map(core.full_lower, outs))
 
   def impl(self, fun, _, *args):
-    return fun.call_wrapped(*args)
+    with core.new_sublevel():
+      return fun.call_wrapped(*args)
 
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_custom_jvp_call(out_tracers, params)
@@ -563,15 +563,15 @@ class CustomVJPCallPrimitive(core.CallPrimitive):
     fwd, env_trace_todo2 = core.process_env_traces(
         fwd, self, top_trace and top_trace.level, (), None)
     tracers = map(top_trace.full_raise, args)  # type: ignore
-    with core.maybe_new_sublevel(top_trace):
-      outs = top_trace.process_custom_vjp_call(self, fun, fwd, bwd, tracers,
-                                               out_trees=out_trees)
+    outs = top_trace.process_custom_vjp_call(self, fun, fwd, bwd, tracers,
+                                              out_trees=out_trees)
     _, env_trace_todo = lu.merge_linear_aux(env_trace_todo1, env_trace_todo2)
     return _apply_todos(env_trace_todo, map(core.full_lower, outs))
 
   def impl(self, fun, fwd, bwd, *args, out_trees):
     del fwd, bwd, out_trees
-    return fun.call_wrapped(*args)
+    with core.new_sublevel():
+      return fun.call_wrapped(*args)
 
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_custom_vjp_call(out_tracers, params)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1419,7 +1419,8 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
           dict(
               call_jaxpr=transformed_cond_jaxpr.jaxpr,
               name="cond_before",
-              donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals)),
+              donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals),
+              inline=False),
           eqn.source_info))
   # Make a new cond "lambda pred, carry, token, itoken: pred"
   new_cond_pred_invar = mk_new_var(cond_jaxpr.out_avals[0])
@@ -1462,7 +1463,8 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
           dict(
               call_jaxpr=transformed_body_jaxpr.jaxpr,
               name="body",
-              donated_invars=(False,) * len(transformed_body_jaxpr.in_avals)),
+              donated_invars=(False,) * len(transformed_body_jaxpr.in_avals),
+              inline=False),
           eqn.source_info),
       core.new_jaxpr_eqn(
           new_body_invars_cond_constvars + new_body_carry2 + [new_body_token2, new_body_itoken2],
@@ -1470,7 +1472,8 @@ def _rewrite_while_outfeed_cond(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
           dict(
               call_jaxpr=transformed_cond_jaxpr.jaxpr,
               name="cond_body",
-              donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals)),
+              donated_invars=(False,) * len(transformed_cond_jaxpr.in_avals),
+              inline=False),
           eqn.source_info)
   ]
   new_body_jaxpr = core.ClosedJaxpr(

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1003,7 +1003,7 @@ def _xmap_translation_rule_replica(c, axis_env,
   # NOTE: We don't extend the resource env with the mesh shape, because those
   #       resources are already in scope! It's the outermost xmap that introduces
   #       them!
-  vectorized_jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(f, local_avals)
+  vectorized_jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(f, local_avals)
   _check_out_avals_vs_out_axes(out_avals, out_axes, global_axis_sizes)
   assert not consts
 
@@ -1121,7 +1121,7 @@ def _xmap_translation_rule_spmd(c, axis_env,
   global_in_avals = [core.ShapedArray(xla_type.dimensions(), xla_type.numpy_dtype())
                      for in_node in global_in_nodes
                      for xla_type in (c.get_shape(in_node),)]
-  vectorized_jaxpr, global_out_avals, consts = pe.trace_to_jaxpr_final(f, global_in_avals)
+  vectorized_jaxpr, global_out_avals, consts = pe.trace_to_jaxpr_dynamic(f, global_in_avals)
   assert not consts
 
   global_sharding_spec = pxla.mesh_sharding_specs(mesh.shape, mesh.axis_names)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -218,7 +218,10 @@ def primitive_uses_outfeed(prim: core.Primitive, params: Dict) -> bool:
 
 ### op-by-op execution
 
-def arg_spec(x):
+
+ArgSpec = Tuple[core.AbstractValue, Optional[Device]]
+
+def arg_spec(x: Any) -> ArgSpec:
   aval = abstractify(x)
   try:
     return aval, x._device
@@ -240,8 +243,7 @@ def _partition_outputs(avals, outs):
 
 
 @cache()
-def xla_primitive_callable(prim, *arg_specs: Tuple[core.AbstractValue,
-                                                   Optional[Device]], **params):
+def xla_primitive_callable(prim, *arg_specs: ArgSpec, **params):
   avals, arg_devices = unzip2(arg_specs)
   donated_invars = (False,) * len(arg_specs)
   device = _device_from_arg_devices(arg_devices)
@@ -573,7 +575,9 @@ def jaxpr_collectives(jaxpr):
 
 ### xla_call underlying jit
 
-def _xla_call_impl(fun: lu.WrappedFun, *args, device, backend, name, donated_invars):
+def _xla_call_impl(fun: lu.WrappedFun, *args, device, backend, name,
+                   donated_invars, inline):
+  del inline  # Only used at tracing time
   compiled_fun = _xla_callable(fun, device, backend, name, donated_invars,
                                *unsafe_map(arg_spec, args))
   try:
@@ -591,7 +595,8 @@ def _xla_call_impl(fun: lu.WrappedFun, *args, device, backend, name, donated_inv
     # intentional here, to avoid "Store occupied" errors we reset the stores to
     # be empty.
     for store in fun.stores: store and store.reset()
-    return fun.call_wrapped(*args)  # probably won't return
+    with core.new_sublevel():
+      return fun.call_wrapped(*args)  # probably won't return
 
 def flatten_shape(s: XlaShape) -> Sequence[Tuple[Sequence[int], XlaShape]]:
   """Expands a given shape tree into a flat list of indices to arrays.
@@ -692,7 +697,8 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
 
   c = xb.make_computation_builder("jit_{}".format(fun.__name__))
   xla_consts = _xla_consts(c, consts)
-  xla_args, donated_invars = _xla_callable_args(c, abstract_args, tuple_args, donated_invars=donated_invars)
+  xla_args, donated_invars = _xla_callable_args(c, abstract_args, tuple_args,
+                                                donated_invars=donated_invars)
   out_nodes = jaxpr_subcomp(
       c, jaxpr, backend, AxisEnv(nreps, (), ()), xla_consts,
       extend_name_stack(wrap_name(name, 'jit')), *xla_args)
@@ -789,9 +795,9 @@ def _xla_callable_args(
                 for (a, r, p) in safe_zip(avals, replicated, parts)
                 for xla_shape in aval_to_xla_shapes(a)]
     if donated_invars is not None:
-      donated_invars = [d
-                        for (a, r, p, d) in safe_zip(avals, replicated, parts, donated_invars)
-                        for xla_shape in aval_to_xla_shapes(a)]
+      donated_invars = [
+          d for (a, _, _, d) in zip(avals, replicated, parts, donated_invars)
+          for xla_shape in aval_to_xla_shapes(a)]
     return xla_args, donated_invars
   else:
     if replicated is not None:
@@ -885,8 +891,8 @@ ad.call_transpose_param_updaters[xla_call_p] = _xla_call_transpose_update_params
 
 def _xla_call_translation_rule(c, axis_env,
                                in_nodes, name_stack, backend, name,
-                               call_jaxpr, donated_invars, device=None):
-  del device, donated_invars  # Ignored.
+                               call_jaxpr, donated_invars, inline, device=None):
+  del device, donated_invars, inline  # Ignored.
   subc = xb.make_computation_builder(f"jit_{name}")
   args = [xb.parameter(subc, i, c.get_shape(n)) for i, n in enumerate(in_nodes)]
   out_nodes = jaxpr_subcomp(subc, call_jaxpr, backend, axis_env, (),

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2343,7 +2343,7 @@ class APITest(jtu.JaxTestCase):
         lst.append(x)
         return x
 
-      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+      with self.assertRaisesRegex(Exception, r"Leaked"):
         f(3)
 
   def test_leak_checker_catches_a_pmap_leak(self):
@@ -2355,7 +2355,7 @@ class APITest(jtu.JaxTestCase):
         lst.append(x)
         return x
 
-      with self.assertRaisesRegex(Exception, r"Leaked trace"):
+      with self.assertRaisesRegex(Exception, r"Leaked"):
         f(np.ones(1))
 
   def test_leak_checker_catches_a_grad_leak(self):
@@ -2677,6 +2677,21 @@ class APITest(jtu.JaxTestCase):
 
     jtu.check_grads(batched_scan_over_mul, (x_batch, coeff), order=2,
                     modes=['rev'])
+
+  def test_jit_inline(self):
+    @partial(api.jit, inline=False)
+    def f(x):
+      return x * 2
+
+    jaxpr = api.make_jaxpr(f)(3)
+    self.assertIn('xla_call', str(jaxpr))
+
+    @partial(api.jit, inline=True)
+    def f(x):
+      return x * 2
+
+    jaxpr = api.make_jaxpr(f)(3)
+    self.assertNotIn('xla_call', str(jaxpr))
 
 
 class RematTest(jtu.JaxTestCase):


### PR DESCRIPTION
The basic idea here is to add a boolean 'inline' option to `jit` (i.e. to the `xla_call` primitive). It doesn't affect the behavior of calling a jitted function from Python, i.e. it doesn't affect anything at the "top level", but instead it only affects nested `jit` calls.

With `inline=False` (the default value) we see the previous behavior:

```python
from functools import partial
import jax

@partial(jax.jit, inline=False)
def f(x):
  return x * 2

print(jax.make_jaxpr(f)(3))
```

```
{ lambda  ; a.
  let b = xla_call[ backend=None
                    call_jaxpr={ lambda  ; a.
                                 let b = mul a 2
                                 in (b,) }
                    device=None
                    donated_invars=(False,)
                    inline=False
                    name=f ] a
  in (b,) }
```

But any `jit` call with `inline=True` will get inlined into an outer jaxpr:

```python
@partial(jax.jit, inline=True)
def f(x):
  return x * 2

print(jax.make_jaxpr(f)(3))
```

```
{ lambda  ; a.
  let b = mul a 2
  in (b,) }
```

This jaxpr is much cleaner!

The main motivation for this change is to put `jit` in lots more places within JAX, in particular on lots of `jax.numpy` functions, without cluttering up jaxprs (or affecting tests that check jaxprs, even though we discourage such tests). cc @hawkinsp 

---

The basic implementation mechanism is to tweak the jaxpr-building tracer used for staging out computation (i.e. used for jit, pmap, make_jaxpr, control flow, rather than the jaxpr-building tracer for reverse-mode autodiff), and in particular to tweak the behavior when it encounters a call primitive with an 'inline' parameter. That is, we add two lines to `DynamicJaxprTrace.process_call`, so that if `inline=True` then immediately after forming the jaxpr we apply it to the tracer arguments using `core.eval_jaxpr`:

```python
  # in DynamicJaxprTrace.process_call
  with core.new_sublevel():
    jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(f, self.main, in_avals)
+ if params.get('inline', False):
+   return core.eval_jaxpr(jaxpr, consts, *tracers)
```

(One might wonder why we bother building the jaxpr first, instead of just applying `fun.call_wrapped` to the tracers immediately. Read on to see why...)

So... what's with all the other changed lines? And what the heck are sublevels anyway!?

The sublevel, a global integer, indicates at trace time how many nested `jit`s we're inside. More precisely, it indicates how many levels of final-style higher-order primitives we're inside, so `pmap`, `xmap`, `custom_jvp`, and `custom_vjp` count too. Levels, on the other hand, count how many transformations we're inside.

Sublevels are only used for catching errors. Each Tracer instance is tagged with a sublevel, just like it's tagged with a level, and we check that sublevels make sense in core.py, particularly in the `full_raise` function. If a Tracer is leaked, e.g. via a side-effect, it might end up interacting with a Tracer of a different sublevel which doesn't make sense.

For example, while this is a _level_ error, to do with transformations like `grad` rather than final-style higher-order primitives like `jit`:

```python
from jax import grad

def f(x):
  y = None
  def g(x):
    nonlocal y
    y = x
    return x
  return grad(g)(x) + y
grad(f)(1.)
```

```
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. [...]
Detail: Can't lift level Traced<ConcreteArray(2.0)>with<JVPTrace(level=4/0)>
```

If we do something similar with `jit`, we might get a _sublevel_ error:

```python
from jax import jit

def f(x):
  y = None
  def g(x):
    nonlocal y
    y = x
    return x
  return jit(g)(x) + y
jit(f)(1.)
```

```
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. [...]
Detail: Can't lift sublevels 2 to 1.
```

Or this one using both `jit` and `grad`:

```python
from jax import jit, grad

def f(x):
  y = None
  def g(x):
    nonlocal y
    y = x
    return x
  return jit(g)(x) + y

grad(f)(1.)
```

```
jax.core.UnexpectedTracerError: Encountered an unexpected tracer. [...]
Detail: Can't lift sublevels 1 to 0.
```

See [these api tests](https://github.com/google/jax/blob/4fcfaeb8a9ce55098269a40bfb45565db71bf344/tests/api_test.py#L2109-L2156) for more examples of exercising these error paths.

We increment the sublevel when we run the callable argument to a final-style higher-order primitive, and we decrement it again when the callable exits. That ensures that the primitive binds we encountered within the callable would see an incremented sublevel, and binds that happened after the callable finishes would be back at the previous sublevel. We do that with the context manager `core.new_sublevel`. There are a few different places where we'd run the callable: for example, when we evaluate the application of a call primitive, i.e. in `call_impl`, and also when we stage out the application, i.e. in `DynamicJaxprTrace.process_call`.

Before this PR, we actually used a helper function `core.maybe_new_sublevel`. That helper function checked whether the trace for which we were about to call `process_call` was the 'dynamic' trace (introduced in #3370, see also [Autodidax](https://jax.readthedocs.io/en/latest/autodidax.html)), leveraging the rule that a trace would run the call primitive's callable argument if and only if it is the 'dynamic' trace (which represents the bottom of the interpreter stack).

But we can't use `maybe_new_sublevel` anymore with this inlining logic! The reason is that we need `DynamicJaxprTrace.process_call` to run the jaxpr to be inlined, i.e. to call `eval_jaxpr` and thus run primitive binds, but running those operations should _not_ happen with an incremented sublevel. That is, we need `DynamicJaxprTrace.process_call` to manage the sublevel itself, and be able to run binds at two different sublevels (an incremeneted one while it traces the Python callable, and a non-incremented one when it inlines the jaxpr). (I'd wanted to make this change earlier, for some other reason, which I can't remember.)

So that's why this PR includes a refactor which removes `maybe_new_sublevel` and instead puts explicit `new_sublevel` calls in several places.

Now that we have that refactoring, why do we have to bother forming the jaxpr inside `DynamicJaxprTrace.process_call`, rather than just calling `fun.call_wrapped(*tracers)` directly? It has to do with the assumptions that `trace_to_subjaxpr_dynamic` makes about whether the sublevel has been incremented. That is, we've already set up the Python callable (in a `WrappedFun`) to expect the sublevel to be incremented; we can't run it without raising the sublevel, and yet we can't inline it with an incremented sublevel. We could probably perform a larger refactor to avoid the need to form the jaxpr, but I decided it was better to keep this change relatively small.