### PR TITLE
test: use colab_tpu.setup_tpu() in TPU test notebook

### DIFF
--- a/tests/notebooks/colab_tpu.ipynb
+++ b/tests/notebooks/colab_tpu.ipynb
@@ -86,34 +86,13 @@
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 34
-        },
-        "outputId": "e66e0f60-6e57-44ed-ba6a-2d3fa906b101"
+        }
       },
       "source": [
-        "import requests\n",
-        "import os\n",
-        "if 'TPU_DRIVER_MODE' not in globals():\n",
-        "  url = 'http://' + os.environ['COLAB_TPU_ADDR'].split(':')[0] + ':8475/requestversion/tpu_driver0.1-dev20200416'\n",
-        "  resp = requests.post(url)\n",
-        "  assert resp.status_code == 200\n",
-        "  TPU_DRIVER_MODE = 1\n",
-        "\n",
-        "# The following is required to use TPU Driver as JAX's backend.\n",
-        "from jax.config import config\n",
-        "config.FLAGS.jax_xla_backend = \"tpu_driver\"\n",
-        "config.FLAGS.jax_backend_target = \"grpc://\" + os.environ['COLAB_TPU_ADDR']\n",
-        "print(config.FLAGS.jax_backend_target)"
+        "import jax.tools.colab_tpu\n",
+        "jax.tools.colab_tpu.setup_tpu()"
       ],
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "grpc://10.69.129.170:8470\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": 2
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
Tested by opening the notebook from this branch in Colab and running all cells: https://colab.research.google.com/github/jakevdp/jax/blob/tpu-test-setup/tests/notebooks/colab_tpu.ipynb