### PR TITLE
Export jnp.broadcast_shapes as user facing function

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -87,6 +87,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     block
     bool_
     broadcast_arrays
+    broadcast_shapes
     broadcast_to
     can_cast
     cbrt

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1733,6 +1733,12 @@ def bincount(x, weights=None, minlength=0, *, length=None):
     raise ValueError("shape of weights must match shape of x.")
   return zeros(length, _dtype(weights)).at[clip(x, 0)].add(weights)
 
+@_wraps(getattr(np, "broadcast_shapes", None))
+def broadcast_shapes(*shapes):
+  if not shapes:
+    return ()
+  shapes = [(shape,) if np.ndim(shape) == 0 else tuple(shape) for shape in shapes]
+  return lax.broadcast_shapes(*shapes)
 
 def broadcast_arrays(*args):
   """Like Numpy's broadcast_arrays but doesn't return views."""

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -25,7 +25,7 @@ from jax._src.numpy.lax_numpy import (
     arcsinh, arctan, arctan2, arctanh, argmax, argmin, argsort, argwhere, around,
     array, array_equal, array_equiv, array_repr, array_split, array_str, asarray, atleast_1d, atleast_2d,
     atleast_3d, average, bartlett, bfloat16, bincount, bitwise_and, bitwise_not,
-    bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays,
+    bitwise_or, bitwise_xor, blackman, block, bool_, broadcast_arrays, broadcast_shapes,
     broadcast_to, can_cast, cbrt, cdouble, ceil, character, choose, clip, column_stack,
     complex128, complex64, complex_, complexfloating, compress, concatenate,
     conj, conjugate, convolve, copysign, corrcoef, correlate, cos, cosh,


### PR DESCRIPTION
Since numpy 1.20 [`np.broadcast_shapes`](https://numpy.org/doc/stable/reference/generated/numpy.broadcast_shapes.html) is part of the public API. This PR adds an alias to `lax.broadcast_shapes` it to `jax.numpy` in order to more closely match numpy.