### PR TITLE
Add associated Legendre functions of the first kind

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -99,6 +99,7 @@ jax.scipy.special
    log_ndtr
    logit
    logsumexp
+   lpmn
    multigammaln
    ndtr
    ndtri

--- a/jax/scipy/special.py
+++ b/jax/scipy/special.py
@@ -32,6 +32,7 @@ from jax._src.scipy.special import (
   i1e,
   logit,
   logsumexp,
+  lpmn,
   multigammaln,
   log_ndtr,
   ndtr,


### PR DESCRIPTION
Uses three recurrence relations to compute normalized associated Legendre functions.  The maximum order and maximum degree are the same.