### PR TITLE
Fix pip install instruction for forks in contributing section

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,7 +39,7 @@ Follow these steps to contribute code:
    ```bash
    git clone https://github.com/YOUR_USERNAME/jax
    cd jax
-   pip install -r requirements.txt  # Installs all testing requirements.
+   pip install -r build/test-requirements.txt  # Installs all testing requirements.
    pip install -e .  # Installs JAX from the current directory in editable mode.
    ```
 


### PR DESCRIPTION
In reference to issue #6610. Fixes the `pip install` instruction in the contributing document by putting the right path to the requirements file.

Maybe it could also be worthwhile to upgrade the "add JAX as an upstream remote" instruction directly below this block to use SSH or at least https, what do you think?