### PR TITLE
improve concreteness error due to arguments

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2404,9 +2404,10 @@ def eval_shape(fun: Callable, *args, **kwargs):
   """
   args_flat, in_tree = tree_flatten((args, kwargs))
   wrapped_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
+  debug_info = pe.debug_info(fun, in_tree, True, "eval_shape")
   out = pe.abstract_eval_fun(wrapped_fun.call_wrapped,
                              *map(shaped_abstractify, args_flat),
-                             transform_name="eval_shape")
+                             debug_info=debug_info)
   out = [ShapeDtypeStruct(x.shape, x.dtype, x.named_shape) for x in out]
   return tree_unflatten(out_tree(), out)
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -621,12 +621,13 @@ def power(x1, x2):
   # Using lax.pow may be imprecise for floating-point values; the goal of this
   # code path is to make sure we end up with a precise output for the common
   # pattern ``x ** 2`` or similar.
-  try:
-    x2 = core.concrete_or_error(operator.index, x2)
-  except (core.ConcretizationTypeError, TypeError):
-    pass
-  else:
-    return lax.integer_pow(x1, x2)
+  if isinstance(core.get_aval(x2), ConcreteArray):
+    try:
+      x2 = operator.index(x2)
+    except TypeError:
+      pass
+    else:
+      return lax.integer_pow(x1, x2)
 
   x1, x2 = _promote_args("power", x1, x2)
   dtype = _dtype(x1)

--- a/jax/core.py
+++ b/jax/core.py
@@ -451,12 +451,12 @@ def escaped_tracer_error(tracer, detail=None):
               'frames (most recent last) excluding JAX-internal frames were:\n'
               f'{source_info_util.summarize(line_info, num_frames=num_frames)}')
   try:
-    fun_source_info = tracer._trace.main.source_info
+    dbg = tracer._trace.main.debug_info
   except AttributeError:
     pass
   else:
     msg += ('\nThe function being traced when the tracer leaked was '
-            f'{fun_source_info}.')
+            f'{dbg.func_src_info} traced for {dbg.traced_for}.')
   msg += ('\nTo catch the leak earlier, try setting the environment variable '
           'JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context '
           'manager.')

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import itertools as it
 from collections import namedtuple
 import contextlib
@@ -26,6 +27,8 @@ from .. import core
 from .._src import dtypes
 from .. import linear_util as lu
 from ..ad_util import Zero
+from ..api_util import flattened_fun_in_tree
+from .._src.tree_util import tree_unflatten, tree_leaves
 from .._src.util import (unzip2, safe_zip, safe_map, toposort, partial,
                          split_list, cache, as_hashable_function)
 from ..core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
@@ -400,8 +403,9 @@ call_partial_eval_rules: Dict[core.Primitive, Callable] = {}
 call_param_updaters: Dict[core.Primitive, Callable] = {}
 
 
-def abstract_eval_fun(fun, *avals, transform_name="", **params):
-  _, avals_out, _ = trace_to_jaxpr_dynamic(lu.wrap_init(fun, params), avals, transform_name)
+def abstract_eval_fun(fun, *avals, debug_info=None, **params):
+  _, avals_out, _ = trace_to_jaxpr_dynamic(
+      lu.wrap_init(fun, params), avals, debug_info)
   assert all(isinstance(aval, AbstractValue) for aval in avals_out)
   return avals_out
 
@@ -899,24 +903,25 @@ class DynamicJaxprTracer(core.Tracer):
 
   def _origin_msg(self):
     invar_pos, progenitor_eqns = self._trace.frame.find_progenitors(self)
+    dbg = self._trace.main.debug_info
     if invar_pos:
-      origin = (f"While tracing the function {self._trace.main.source_info}, "
+      origin = (f"While tracing the function {dbg.func_src_info} "
+                f"for {dbg.traced_for}, "
                 "this concrete value was not available in Python because it "
-                "depends on the value of the arguments to "
-                f"{self._trace.main.source_info} at flattened positions {invar_pos}, "
-                "and the computation of these values is being staged out "
-                "(that is, delayed rather than executed eagerly).")
+                f"depends on the value{'s' if len(invar_pos) > 1 else ''} "
+                f"of {dbg.arg_info(invar_pos)}.")
     elif progenitor_eqns:
       msts = [f"  operation {core.pp_eqn(eqn, print_shapes=True)}\n"
               f"    from line {source_info_util.summarize(eqn.source_info)}"
               for eqn in progenitor_eqns]
-      origin = (f"While tracing the function {self._trace.main.source_info}, "
+      origin = (f"While tracing the function {dbg.func_src_info} "
+                f"for {dbg.traced_for}, "
                 "this value became a tracer due to JAX operations on these lines:"
                 "\n\n" + "\n\n".join(msts))
     else:
-      origin = ("The error occured while tracing the function "
-                f"{self._trace.main.source_info}.")
-    return origin
+      origin = (f"The error occured while tracing the function {dbg.func_src_info} "
+                f"for {dbg.traced_for}.")
+    return "\n" + origin
 
   def _assert_live(self) -> None:
     if not self._trace.main.jaxpr_stack:  # type: ignore
@@ -1169,11 +1174,71 @@ def _memoize(thunk):
   return memoized
 
 
+class DebugInfo(NamedTuple):
+  func_src_info: str
+  traced_for: str
+  arg_info: Callable[[int], str]
+
+PyTreeDef = Any
+
+def debug_info_final(fn: lu.WrappedFun, traced_for: str) -> DebugInfo:
+  in_tree, has_kwargs = flattened_fun_in_tree(fn) or (None, False)
+  return debug_info(fn.f, in_tree, has_kwargs, traced_for)
+
+def debug_info(fn: Callable, in_tree: Optional[PyTreeDef], has_kwargs: bool,
+               traced_for: str) -> DebugInfo:
+  func_src_info = fun_sourceinfo(fn)
+  if in_tree is not None:
+    arg_info = partial(arg_info_pytree, fn, in_tree, has_kwargs)
+  else:
+    arg_info = arg_info_flattened  # type: ignore
+  return DebugInfo(func_src_info, traced_for, arg_info)
+
+def fun_sourceinfo(fun: Callable):
+  while isinstance(fun, functools.partial):
+    fun = fun.func
+  try:
+    filename = fun.__code__.co_filename
+    lineno = fun.__code__.co_firstlineno
+    line_info = f"{fun.__name__} at {filename}:{lineno}"
+    return line_info
+  except AttributeError:
+    return "<unknown>"
+
+def arg_info_pytree(fn: Callable, in_tree: PyTreeDef, has_kwargs: bool,
+                    flat_pos: List[int]) -> str:
+  dummy_args = [False] * in_tree.num_leaves
+  for i in flat_pos: dummy_args[i] = True
+  if has_kwargs:
+    args, kwargs = tree_unflatten(in_tree, dummy_args)
+  else:
+    args, kwargs = tree_unflatten(in_tree, dummy_args), {}
+  try:
+    ba = inspect.signature(fn).bind(*args, **kwargs)
+  except (TypeError, ValueError):
+    return arg_info_flattened(flat_pos)
+  arg_names = [f"'{name}'" for name, x in ba.arguments.items()
+               if any(tree_leaves(x))]
+  if len(arg_names) == 1:
+    return f"the argument {arg_names[0]}"
+  elif len(arg_names) == 2:
+    return f"the arguments {arg_names[0]} and {arg_names[1]}"
+  else:
+    *rest, last = arg_names
+    return f"the arguments {', '.join(rest)}, and {last}"
+
+def arg_info_flattened(flat_pos: List[int]) -> str:
+  if len(flat_pos) > 1:
+    return f"the argument passed at flattened positions {flat_pos}"
+  else:
+    return f"the argument passed at flattened position {flat_pos[0]}"
+
+
 def trace_to_jaxpr_dynamic(fun: lu.WrappedFun,
                            in_avals: Sequence[AbstractValue],
-                           transform_name: str = ""):
+                           debug_info: Optional[DebugInfo] = None):
   with core.new_main(DynamicJaxprTrace, dynamic=True) as main:  # type: ignore
-    main.source_info = fun_sourceinfo(fun.f, transform_name)  # type: ignore
+    main.debug_info = debug_info  # type: ignore
     main.jaxpr_stack = ()  # type: ignore
     jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(fun, main, in_avals)
     del main, fun
@@ -1202,9 +1267,9 @@ def extend_jaxpr_stack(main, frame):
 
 def trace_to_jaxpr_final(fun: lu.WrappedFun,
                          in_avals: Sequence[AbstractValue],
-                         transform_name: str = ""):
+                         debug_info: Optional[DebugInfo] = None):
   with core.new_base_main(DynamicJaxprTrace) as main:  # type: ignore
-    main.source_info = fun_sourceinfo(fun.f, transform_name)  # type: ignore
+    main.debug_info = debug_info  # type: ignore
     main.jaxpr_stack = ()  # type: ignore
     jaxpr, out_avals, consts = trace_to_subjaxpr_dynamic(fun, main, in_avals)
     del fun, main
@@ -1217,16 +1282,3 @@ def partial_eval_to_jaxpr_dynamic(fun: lu.WrappedFun, in_pvals: Sequence[Partial
   # TODO(mattjj): alias to trace_to_jaxpr after revising custom_derivatives.py
   with core.new_main(core.EvalTrace, dynamic=True) as _:  # type: ignore
     return trace_to_jaxpr(fun, in_pvals)
-
-def fun_sourceinfo(fun, transform_name: str = ""):
-  if isinstance(fun, functools.partial):
-    fun = fun.func
-  try:
-    filename = fun.__code__.co_filename
-    lineno = fun.__code__.co_firstlineno
-    line_info = f"{fun.__name__} at {filename}:{lineno}"
-    if transform_name:
-      line_info += f', transformed by {transform_name}.'
-    return line_info
-  except AttributeError:
-    return "<unknown>"

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -696,7 +696,8 @@ def parallel_callable(fun: lu.WrappedFun,
   logging.vlog(2, "global_sharded_avals: %s", global_sharded_avals)
 
   with core.extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
-    jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(fun, global_sharded_avals, transform_name="pmap")
+    jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(
+        fun, global_sharded_avals, pe.debug_info_final(fun, "pmap"))
   jaxpr = xla.apply_outfeed_rewriter(jaxpr)
 
   out_axes = out_axes_thunk()

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -648,8 +648,9 @@ def _xla_callable(fun: lu.WrappedFun, device, backend, name, donated_invars, *ar
     raise ValueError("can't specify both a device and a backend for jit, "
                      "got device={} and backend={}".format(device, backend))
 
-  abstract_args, _ = unzip2(arg_specs)
-  jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, abstract_args, transform_name="jit")
+  abstract_args, arg_devices = unzip2(arg_specs)
+  jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(
+      fun, abstract_args, pe.debug_info_final(fun, "jit"))
   if any(isinstance(c, core.Tracer) for c in consts):
     raise core.UnexpectedTracerError("Encountered an unexpected tracer.")
   jaxpr, kept_const_idx, kept_var_idx = _prune_unused_inputs(jaxpr)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2617,7 +2617,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
   def test_unexpected_tracer_error(self):
     with self.assertRaisesRegex(core.UnexpectedTracerError,
-                                "transformed by while_loop"):
+                                "for while_loop"):
       lst = []
       def side_effecting_body(val):
         lst.append(val)
@@ -2626,7 +2626,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lst[0] += 1
 
     with self.assertRaisesRegex(core.UnexpectedTracerError,
-                                "transformed by scan"):
+                                "for scan"):
       lst = []
       def side_effecting_scan(carry, val):
         lst.append(val)


### PR DESCRIPTION
Before this change, when an error occurred due to an argument being abstracted (i.e. staged out), we would raise an error pointing to the argument's position in the pytree-flattened argument list:

```python
import jax

@jax.jit
def f(x, y, z):
  if z > 0:
    pass
f(1, 2, 3)
```

```
...stack trace...
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected:          Traced<ShapedArray(bool[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function.
While tracing the function f at louise.py:5, transformed by jit., this concrete
value was not available in Python because it depends on the value of the
arguments to f at louise.py:5, transformed by jit. at flattened positions [2],
and the computation of these values is being staged out (that is, delayed rather
than executed eagerly).
(https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError)
```

(Notice also some erroneous '.'s in the string here!)

This flattened position is often not helpful, since when pytrees are involved it might be unclear how to map it to the function signature in the source code, and thus unclear how to fix the issue.

After this PR, we point to the argument name (and tweak some details of the error message string):

```
...stack trace...
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected:          Traced<ShapedArray(bool[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function.
While tracing the function f at louise.py:3 for jit, this concrete value was not
available in Python because it depends on the value of the argument 'z'.
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
```

This builds on some excellent work from @LenaMartens !

See the tests for more.