### PR TITLE
Fixed error in autodidax broadasting batching

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -1154,6 +1154,7 @@
     "  if x_bdim != y_bdim:\n",
     "    if x_bdim is not_mapped:\n",
     "      x = move_batch_axis(axis_size, x_bdim, y_bdim, x)\n",
+    "      x_bdim = y_bdim\n",
     "    else:\n",
     "      y = move_batch_axis(axis_size, y_bdim, x_bdim, y)\n",
     "  return [op(x, y)], [x_bdim]\n",

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -838,6 +838,7 @@ def broadcasting_binop_batching_rule(op, axis_size, vals_in, dims_in):
   if x_bdim != y_bdim:
     if x_bdim is not_mapped:
       x = move_batch_axis(axis_size, x_bdim, y_bdim, x)
+      x_bdim = y_bdim
     else:
       y = move_batch_axis(axis_size, y_bdim, x_bdim, y)
   return [op(x, y)], [x_bdim]

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -802,6 +802,7 @@ def broadcasting_binop_batching_rule(op, axis_size, vals_in, dims_in):
   if x_bdim != y_bdim:
     if x_bdim is not_mapped:
       x = move_batch_axis(axis_size, x_bdim, y_bdim, x)
+      x_bdim = y_bdim
     else:
       y = move_batch_axis(axis_size, y_bdim, x_bdim, y)
   return [op(x, y)], [x_bdim]


### PR DESCRIPTION
I'm still pretty new to jax and am going through the autodidax tutorial. Either I'm misunderstanding what autodidax's vmap is supposed to do, or there's a bug.

Currently, the tutorial includes this example:

```python
def add_one_to__scalar(scalar):
  assert np.ndim(scalar) == 0
  return 1 + scalar

vector_in = np.arange(3.)
vector_out = vmap(add_one_to_a_scalar, (0,))(vector_in)

print(vector_in)
print(vector_out)
```

```
[0. 1. 2.]
[[1. 2. 3.]
 [1. 2. 3.]
 [1. 2. 3.]]
```
Similarly, we have

```python
def jacfwd(f, x):
  pushfwd = lambda v: jvp(f, (x,), (v,))[1]
  vecs_in = np.eye(np.size(x)).reshape(np.shape(x) * 2)
  return vmap(pushfwd, (0,))(vecs_in)

def f(x):
  return sin(x)

jacfwd(f, np.arange(3.))
```

```
array([[[ 1.        ,  0.        , -0.        ],
        [ 0.        ,  0.54030231, -0.        ],
        [ 0.        ,  0.        , -0.41614684]],

       [[ 1.        ,  0.        , -0.        ],
        [ 0.        ,  0.54030231, -0.        ],
        [ 0.        ,  0.        , -0.41614684]],

       [[ 1.        ,  0.        , -0.        ],
        [ 0.        ,  0.54030231, -0.        ],
        [ 0.        ,  0.        , -0.41614684]]])
```

I'm *pretty* sure It's not intended to broadcast over the 0th dimension.

So I added `x_bdim = y_bdim` in here:

```python
def broadcasting_binop_batching_rule(op, axis_size, vals_in, dims_in):
  (x, y), (x_bdim, y_bdim) = vals_in, dims_in
  if x_bdim != y_bdim:
    if x_bdim is not_mapped:
      x = move_batch_axis(axis_size, x_bdim, y_bdim, x)
      x_bdim = y_bdim
    else:
      y = move_batch_axis(axis_size, y_bdim, x_bdim, y)
  return [op(x, y)], [x_bdim]
vmap_rules[add_p] = partial(broadcasting_binop_batching_rule, add)
vmap_rules[mul_p] = partial(broadcasting_binop_batching_rule, mul)
``` 
After that, we get what I'd expect:
```python
vmap(add_one_to_a_scalar, (0,))(vector_in)
```

```
[1. 2. 3.]
```
And:
```python
jacfwd(f, np.arange(3.))
```
```
array([[ 1.        ,  0.        , -0.        ],
       [ 0.        ,  0.54030231, -0.        ],
       [ 0.        ,  0.        , -0.41614684]])
```
The problem was in `move_batch_axis(axis_size, bdim, 0, val_out)` in `vmap_flat`, which adds an extra 0th axis when the broadcast gives a `NotMapped` back to it.

----

Or maybe I'm missing the whole point of the function and it was fine.

I think I've followed the contributor directions, but this is my first contribution so ¯\\\_(ツ)\_/¯