### PR TITLE
Remat extensions for scan-over-layers

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1390,9 +1390,9 @@ def _remat_using_while(
 
 def _remat_translation_rule(c, axis_env, in_nodes,
                             name_stack, backend, name, call_jaxpr,
-                            device=None, concrete=None, extend=None,
-                            gadget=None):
-  del device, concrete, extend  # Unused.
+                            device=None, concrete=None,
+                            checkpoint_dots=None, gadget=None):
+  del device, concrete, checkpoint_dots  # Unused.
   if not gadget:
     return _named_call_translation_rule(
       c, axis_env, in_nodes, name_stack, name="remat_call",

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1390,8 +1390,13 @@ def _remat_using_while(
 
 def _remat_translation_rule(c, axis_env, in_nodes,
                             name_stack, backend, name, call_jaxpr,
-                            device=None, concrete=None):
-  del device, concrete  # Unused.
+                            device=None, concrete=None, extend=None,
+                            gadget=None):
+  del device, concrete, extend  # Unused.
+  if not gadget:
+    return _named_call_translation_rule(
+      c, axis_env, in_nodes, name_stack, name="remat_call",
+      backend=backend, call_jaxpr=call_jaxpr)
   if backend == "gpu":
     return _remat_using_while(
         c, axis_env, in_nodes, name_stack, backend, name, call_jaxpr)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3080,6 +3080,26 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(num_calls, 2)
 
 
+  def test_reblake(self):
+    def f(x, W1, W2):
+      def body(x, _):
+        return jnp.dot(jnp.sin(jnp.dot(x, W1)), W2), None
+      return lax.scan(api.remat(body, checkpoint_dots=True), x, None, length=2)[0].sum()
+
+    # We swap out sin_p's impl rule to count how many times it's invoked
+    called = []
+    sin_impl = lax.sin_p.impl
+    try:
+      lax.sin_p.def_impl(lambda x: called.append(1) or sin_impl(x))
+      with jax.disable_jit():
+        api.grad(f, argnums=(0, 1, 2))(jnp.ones((5,)), jnp.ones((5, 5)), jnp.ones((5, 5)))
+    finally:
+      lax.sin_p.def_impl(sin_impl)
+    num_calls = len(called)
+    # Should be invoked once in forward pass and once in backward for each step
+    self.assertEqual(num_calls, 4)
+
+
 class JaxprTest(jtu.JaxTestCase):
 
   def test_scalar_literals(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3100,6 +3100,27 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(num_calls, 4)
 
 
+  def test_reblake_jit(self):
+    def f(x, W1, W2):
+      def body(x, _):
+        return api.jit(jnp.dot)(jnp.sin(api.jit(jnp.dot)(x, W1)), W2), None
+      return lax.scan(api.remat(body, checkpoint_dots=True), x, None, length=2)[0].sum()
+
+    api.grad(f, argnums=(0, 1, 2))(jnp.ones((5,)), jnp.ones((5, 5)), jnp.ones((5, 5)))
+    # # We swap out sin_p's impl rule to count how many times it's invoked
+    # called = []
+    # sin_impl = lax.sin_p.impl
+    # try:
+    #   lax.sin_p.def_impl(lambda x: called.append(1) or sin_impl(x))
+    #   with jax.disable_jit():
+    #     api.grad(f, argnums=(0, 1, 2))(jnp.ones((5,)), jnp.ones((5, 5)), jnp.ones((5, 5)))
+    # finally:
+    #   lax.sin_p.def_impl(sin_impl)
+    # num_calls = len(called)
+    # # Should be invoked once in forward pass and once in backward for each step
+    # self.assertEqual(num_calls, 4)
+
+
 class JaxprTest(jtu.JaxTestCase):
 
   def test_scalar_literals(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3059,6 +3059,26 @@ class RematTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(core.UnexpectedTracerError, "global state"):
       api.jit(f)()
 
+  def test_remat_extend(self):
+    def f(x, W):
+      def body(x, _):
+        return jnp.dot(api.remat(jnp.sin, extend=True)(x), W), None
+      # The optimization is currently special-cased to initial-style staging
+      return lax.scan(body, x, None, length=2)[0].sum()
+
+    # We swap out sin_p's impl rule to count how many times it's invoked
+    called = []
+    sin_impl = lax.sin_p.impl
+    try:
+      lax.sin_p.def_impl(lambda x: called.append(1) or sin_impl(x))
+      with jax.disable_jit():
+        api.grad(f, argnums=1)(jnp.ones((5,)), jnp.ones((5, 5)))
+    finally:
+      lax.sin_p.def_impl(sin_impl)
+    num_calls = len(called)
+    # Should be invoked once in forward pass and once in backward
+    self.assertEqual(num_calls, 2)
+
 
 class JaxprTest(jtu.JaxTestCase):
 

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -2699,6 +2699,8 @@ class OutfeedRewriterTest(jtu.JaxTestCase):
                                                                              f = mul e d
                                                                          in (f, i, j) }
                                                             concrete=False
+                                                            extend=False
+                                                            gadget=True
                                                             name=f ] a c f g
                                     in (d, b, e, h, i) }
                        body_nconsts=0


### PR DESCRIPTION
We would like to express a stack of repeated neural network layers
(e.g. a ResNet or Transformer) using lax.scan, in order to reduce
compile times and obtain better control over memory usage.
Unlike grad of straight-line code, XLA compilation of grad of scan won't
touch JAX's residual choices (including those made through jax.remat).
But in order to express the residual choices we want, without blocking
other needed optimizations, we need a few extensions to remat. This
change adds the following params to remat_call and kwargs to jax.remat:

(1) allows disabling the "gadget" that blocks XLA optimizations across a
    remat block (since an outer scan already prevents undoing remat,
    and the extra gadget prevents important optimizations)
(2) adds an "extend" param that enables a remat block to be
    automatically extended to encompass certain primitives that are
    direct consumers of outputs of the remat (and would otherwise cause
    those outputs to be unnecessarily saved as residuals)

The intent of the latter option is to enable "one residual per matmul"
by wrapping nonlinearities and normalizers in jax.remat.