### PR TITLE
Do not perform second call to config_with_absl

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -123,6 +123,8 @@ class Config:
                     update_hook=update_hook)
 
   def config_with_absl(self):
+    if self.use_absl:
+      return
     # Run this before calling `app.run(main)` etc
     import absl.flags as absl_FLAGS  # noqa: F401
     from absl import app, flags as absl_flags


### PR DESCRIPTION
Avoid double-defined flags errors as reported in https://github.com/deepmind/launchpad/issues/5 by not executing logic in config_with_absl if it has been already called.