### PR TITLE
re-export `dtype_real` from jax.dtypes

### DIFF
--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -17,6 +17,7 @@ from jax._src.dtypes import (
     _jax_types,  # TODO(phawkins): fix users and remove?
     bfloat16,
     canonicalize_dtype,
+    dtype_real,
     finfo,  # TODO(phawkins): switch callers to jnp.finfo?
     float0,
     iinfo,  # TODO(phawkins): switch callers to jnp.iinfo?


### PR DESCRIPTION
This was being exported previously.