### PR TITLE
Make jnp.unravel_index rank promotion explicit.

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1403,8 +1403,9 @@ def unravel_index(indices, shape):
   total_size = cumulative_sizes[0]
   # Clip so raveling and unraveling an oob index will not change the behavior
   clipped_indices = clip(indices, -total_size, total_size - 1)
-  # Add enough trailing dims to avoid conflict with flat_index
+  # Add enough trailing dims to avoid conflict with clipped_indices
   cumulative_sizes = cumulative_sizes.reshape([-1] + [1] * indices.ndim)
+  clipped_indices = expand_dims(clipped_indices, axis=0)
   idx = clipped_indices % cumulative_sizes[:-1] // cumulative_sizes[1:]
   return tuple(idx)
 


### PR DESCRIPTION
There was a silent rank promotion in jax.numpy.unravel_index which caused the
code to fail with jax_numpy_rank_promotion='raise'. This commit makes the rank
promotion explicit. Furthermore, it fixes an outdated comment in the same
function.