### PR TITLE
Cleanup: remove unnecessary utility

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -214,18 +214,6 @@ def issubdtype(a, b):
 can_cast = np.can_cast
 issubsctype = np.issubsctype
 
-# Return the type holding the real part of the input type
-def dtype_real(typ):
-  if np.issubdtype(typ, np.complexfloating):
-    if typ == np.dtype('complex64'):
-      return np.dtype('float32')
-    elif typ == np.dtype('complex128'):
-      return np.dtype('float64')
-    else:
-      raise TypeError("Unknown complex floating type {}".format(typ))
-  else:
-    return typ
-
 # Enumeration of all valid JAX types in order.
 _weak_types = [int, float, complex]
 _jax_types = [

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -666,9 +666,9 @@ def _normal(key, shape, dtype) -> jnp.ndarray:
     sqrt2 = np.array(np.sqrt(2), dtype)
 
     key_re, key_im = split(key)
-    dtype = dtypes.dtype_real(dtype)
-    _re = _normal_real(key_re, shape, dtype)
-    _im = _normal_real(key_im, shape, dtype)
+    real_dtype = np.array(0, dtype).real.dtype
+    _re = _normal_real(key_re, shape, real_dtype)
+    _im = _normal_real(key_im, shape, real_dtype)
     return (_re + 1j * _im) / sqrt2
   else:
     return _normal_real(key, shape, dtype) # type: ignore


### PR DESCRIPTION
This is no longer part of the public-facing API as of #6364, is only used in one place, and can be replaced by a single line.