### PR TITLE
Fix pjit_test infeed subtest to work on GPUs

### DIFF
--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -338,19 +338,23 @@ class PJitTest(jtu.BufferDonationTestCase):
       return x + y + z + w
 
     x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
-
-    # JIT
-    logging.info('Making jit call')
-    res0 = jax.jit(f_for_jit)(x)
     y = x * 2.
     z = x * 3.
     w = x * 4.
 
+    # Transfer data to infeed before executing the function. For GPUs, the
+    # execution of the compiled function is blocking, so transferring data
+    # to infeed before executing ensures that the execution does not deadlock
+    # waiting for the infeed data.
     logging.info('Transfering to infeed for the jit call')
     d = devices[0]
     d.transfer_to_infeed((y,))
     d.transfer_to_infeed((z,))
     d.transfer_to_infeed((w,))
+
+    # JIT
+    logging.info('Making jit call')
+    res0 = jax.jit(f_for_jit)(x)
     self.assertAllClose(res0, x + y + z + w, check_dtypes=True)
 
     # PJIT
@@ -373,12 +377,6 @@ class PJitTest(jtu.BufferDonationTestCase):
           partitions=(P(1, nr_devices),))
       return x + y + z + w
 
-    with mesh(devices, ['d']):
-      logging.info('Making pjit call')
-      res = pjit(
-          f_for_pjit, in_axis_resources=(P('d'),), out_axis_resources=P('d'))(
-              x)
-
     logging.info('Transfering to infeed for the pjit call')
     for didx, d in enumerate(devices):
       # Transfer the whole array to all devices for replicated.
@@ -386,6 +384,12 @@ class PJitTest(jtu.BufferDonationTestCase):
       # For sharded infeed, transfer only the needed slices to each device.
       d.transfer_to_infeed((z[3 * didx:3 * didx + 3, :]))
       d.transfer_to_infeed((w[:, 5 * didx:5 * didx + 5],))
+
+    with mesh(devices, ['d']):
+      logging.info('Making pjit call')
+      res = pjit(
+          f_for_pjit, in_axis_resources=(P('d'),), out_axis_resources=P('d'))(
+              x)
 
     self.assertAllClose(res0, res, check_dtypes=True)
 


### PR DESCRIPTION
For GPUs, since the execution of the jitted function is blocking,
we need to transfer data to the infeed before executing the function
to avoid a deadlock.