### PR TITLE
Add support for non-numeric dtypes in associative_scan

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2461,7 +2461,7 @@ def associative_scan(fn: Callable, elems, reverse: bool = False, axis: int = 0):
   if not all(int(elem.shape[axis]) == num_elems for elem in elems_flat[1:]):
     raise ValueError('Array inputs to associative_scan must have the same '
                      'first dimension. (saw: {})'
-                     .format([elems.shape for elem in elems_flat]))
+                     .format([elem.shape for elem in elems_flat]))
 
 
   # Summary of algorithm:

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2466,6 +2466,15 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertAllClose(result.second, np.array([0., 10., 30.]),
                         check_dtypes=False)
 
+  def testAssociativeScanOfBools(self):
+    # Make sure we can do associative scan for non-numeric dtypes.
+    data = np.zeros([100], bool)
+    data[4] = True
+    expected = np.zeros([100], bool)
+    expected[4:] = True
+    result = lax.associative_scan(operator.or_, data)
+    self.assertAllClose(result, expected, check_dtypes=False)
+
   def test_scan_typecheck_param(self):
     d = jnp.ones(2)
     def f(c, a):


### PR DESCRIPTION
`associative_scan` uses an interleave method, which was implemented
using `lax.add`, meaning that it only worked for numeric dtypes.
Instead, we can use dynamic updating to set the elements without having
to add zeros to them.