### PR TITLE
Add support for arm64 builds to build.py and build_wheel scripts.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -79,17 +79,22 @@ def check_python_version(python_version):
 BAZEL_BASE_URI = "https://github.com/bazelbuild/bazel/releases/download/3.7.2/"
 BazelPackage = collections.namedtuple("BazelPackage", ["file", "sha256"])
 bazel_packages = {
-    "Linux":
+    ("Linux", "x86_64"):
         BazelPackage(
             file="bazel-3.7.2-linux-x86_64",
             sha256=
             "70dc0bee198a4c3d332925a32d464d9036a831977501f66d4996854ad4e4fc0d"),
-    "Darwin":
+    ("Linux", "aarch64"):
+        BazelPackage(
+            file="bazel-3.7.2-linux-arm64",
+            sha256=
+            "6ebd9eccbcb8f63c92a324c0c86cec11963aa9dcb914dd4718f592fdfeda9823"),
+    ("Darwin", "x86_64"):
         BazelPackage(
             file="bazel-3.7.2-darwin-x86_64",
             sha256=
             "80c82e93a12ba30021692b11c78007807e82383a673be1602573b944beb359ab"),
-    "Windows":
+    ("Windows", "x86_64"):
         BazelPackage(
             file="bazel-3.7.2-windows-x86_64.exe",
             sha256=
@@ -99,7 +104,7 @@ bazel_packages = {
 
 def download_and_verify_bazel():
   """Downloads a bazel binary from Github, verifying its SHA256 hash."""
-  package = bazel_packages.get(platform.system())
+  package = bazel_packages.get((platform.system(), platform.machine()))
   if package is None:
     return None
 

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -216,12 +216,16 @@ def prepare_wheel(sources_path):
 
 def build_wheel(sources_path, output_path):
   """Builds a wheel in `output_path` using the source tree in `sources_path`."""
-  platform_name = {
-    "Linux": "manylinux2010",
-    "Darwin": "macosx_10_9",
-    "Windows": "win",
-  }[platform.system()]
-  cpu_name = "amd64" if platform.system() == "Windows" else "x86_64"
+  if platform.system() == "Windows":
+    cpu_name = "amd64"
+    platform_name = "win"
+  else:
+    platform_name, cpu_name = {
+      ("Linux", "x86_64"): ("manylinux2010", "x86_64"),
+      ("Linux", "aarch64"): ("manylinux2014", "aarch64"),
+      ("Darwin", "x86_64"): ("macosx_10_9", "x86_64"),
+      ("Darwin", "arm64"): ("macosx_11_0", "arm64"),
+    }[(platform.system(), platform.machine())]
   python_tag_arg = (f"--python-tag=cp{sys.version_info.major}"
                     f"{sys.version_info.minor}")
   platform_tag_arg = f"--plat-name={platform_name}_{cpu_name}"


### PR DESCRIPTION
This is untested, but there are requests for aarch64 support on Linux and Mac, and this may help with builds.

Issue #5501 
Fixes #6506
Fixes #773