### PR TITLE
Allow non-inexact dtypes for jnp.nan...() reductions.

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2286,6 +2286,9 @@ def flatnonzero(a):
 def _nan_reduction(a, name, jnp_reduction, init_val, nan_if_all_nan,
                    axis=None, keepdims=None, **kwargs):
   _check_arraylike(name, a)
+  if not issubdtype(_dtype(a), inexact):
+    return jnp_reduction(a, axis=axis, keepdims=keepdims, **kwargs)
+
   out = jnp_reduction(where(isnan(a), _reduction_init_val(a, init_val), a),
                       axis=axis, keepdims=keepdims, **kwargs)
   if nan_if_all_nan:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -339,7 +339,7 @@ JAX_REDUCER_RECORDS = [
     op_record("sum", 1, all_dtypes, all_shapes, jtu.rand_default, []),
     op_record("nanmean", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan,
               [], inexact=True),
-    op_record("nanprod", 1, inexact_dtypes, all_shapes, jtu.rand_some_nan, []),
+    op_record("nanprod", 1, all_dtypes, all_shapes, jtu.rand_some_nan, []),
     op_record("nansum", 1, number_dtypes, all_shapes, jtu.rand_some_nan, []),
 ]
 
@@ -370,8 +370,8 @@ JAX_REDUCER_NO_DTYPE_RECORDS = [
               inexact=True),
     op_record("std", 1, all_dtypes, nonempty_shapes, jtu.rand_default, [],
               inexact=True),
-    op_record("nanmax", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
-    op_record("nanmin", 1, inexact_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("nanmax", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
+    op_record("nanmin", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan, []),
     op_record("nanvar", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan,
               [], inexact=True),
     op_record("nanstd", 1, all_dtypes, nonempty_shapes, jtu.rand_some_nan,


### PR DESCRIPTION
Fixes #2349.