### PR TITLE
Minor type annotation correction

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -501,7 +501,7 @@ def _randint(key, shape, minval, maxval, dtype):
   return lax.add(minval, lax.convert_element_type(random_offset, dtype))
 
 
-def shuffle(key: jnp.ndarray, x: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
+def shuffle(key: jnp.ndarray, x: np.ndarray, axis: int = 0) -> jnp.ndarray:
   """Shuffle the elements of an array uniformly at random along an axis.
 
   Args:
@@ -518,7 +518,7 @@ def shuffle(key: jnp.ndarray, x: jnp.ndarray, axis: int = 0) -> jnp.ndarray:
   return _shuffle(key, x, axis)  # type: ignore
 
 
-def permutation(key: jnp.ndarray, x: IntegerArray) -> jnp.ndarray:
+def permutation(key: jnp.ndarray, x: np.ndarray) -> jnp.ndarray:
   """
   Permute elements of an array along its first axis or return a permuted range.
 
@@ -1281,7 +1281,7 @@ def _gumbel(key, shape, dtype):
 
 
 def categorical(key: jnp.ndarray,
-                logits: jnp.ndarray,
+                logits: np.ndarray,
                 axis: int = -1,
                 shape: Optional[Sequence[int]] = None) -> jnp.ndarray:
   """Sample random values from categorical distributions.


### PR DESCRIPTION
* `jax.random.categorical(key, np.ones(4))` is allowed.
* Similarly `jax.random.shuffle(key, np.arange(4))` is allowed with any
  dtype.
* Made `jax.random.permutation` consistent with `shuffle`.