### PR TITLE
Add version constraints to flatbuffers versions.

### DIFF
--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension-stubs'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers'],
+    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers >= 1.12, < 3.0'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={


### PR DESCRIPTION
Require 1.12 or newer, because we've only tested 1.12 and 2.0.
Require less than 3.0, because flatbuffers uses semantic versioning and version 3.0 would mean an incompatible change has been made.