### PR TITLE
[jax2tf] Change the conversion of dot_general to use XLA op.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.14 (unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jax-v0.2.13...master).
 
+* Bug fixes:
+  * The {func}`jax2tf.convert` now converts `lax.dot_general` using the
+    `XlaDot` TensorFlow op, for better fidelity w.r.t. JAX numerical precision
+    ({jax-issue}`#6717`).
+
 ## jaxlib 0.1.67 (unreleased)
 
 ## jaxlib 0.1.66 (May 11 2021)
+
 * New features:
   * CUDA 11.1 wheels are now supported on all CUDA 11 versions 11.1 or higher.
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6653,6 +6653,11 @@ def remaining(original, *removed_lists):
 
 
 def _canonicalize_precision(precision: PrecisionLike) -> Optional[Tuple[PrecisionType, PrecisionType]]:
+  """Turns an API precision specification, into a pair of enumeration values.
+
+  The API can take the precision as a string, or int, and either as a single
+  value to apply to both operands, or as a sequence of two values.
+  """
   if precision is None:
     if config.jax_default_matmul_precision is None:
       return None

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6652,28 +6652,30 @@ def remaining(original, *removed_lists):
   return [i for i in original if i not in removed]
 
 
-def _canonicalize_precision(precision):
+def _canonicalize_precision(precision: PrecisionLike) -> Optional[Tuple[PrecisionType, PrecisionType]]:
   if precision is None:
     if config.jax_default_matmul_precision is None:
       return None
     try:
-      return _precision_strings[config.jax_default_matmul_precision]
+      precision = _precision_strings[config.jax_default_matmul_precision]
+      return (precision, precision)
     except KeyError:
       raise ValueError(
           "jax_default_matmul_precision flag must be set to None or a value in "
           f"{_precision_strings}, but got {config.jax_default_matmul_precision}"
       ) from None
   elif isinstance(precision, str) and precision in _precision_strings:
-    return _precision_strings.get(precision)
+    precision = _precision_strings.get(precision)
+    return (precision, precision)
   elif isinstance(precision, Precision):
-    return precision
+    return (precision, precision)
   elif (isinstance(precision, (list, tuple)) and len(precision) == 2 and
         all(isinstance(p, Precision) for p in precision)):
-    return precision
+    return precision  # type: ignore[return-value]
   elif (isinstance(precision, (list, tuple)) and len(precision) == 2 and
         all(isinstance(s, str) for s in precision)):
     s1, s2 = precision
-    return (_canonicalize_precision(s1), _canonicalize_precision(s2))
+    return (_canonicalize_precision(s1)[0], _canonicalize_precision(s2)[0])  # type: ignore
   else:
     raise ValueError(
         f"Precision argument must be None, a string in {_precision_strings}, "

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -456,6 +456,7 @@ We use the following TFXLA ops:
    * `XlaPad` (wraps XLA Pad operator). We use this instead of `tf.pad` in order to
      support `lax.pad` interior padding (dilation) or negative edge padding.
    * `XlaConv` (wraps XLA ConvGeneralDilated operator).
+   * `XlaDot` and `XlaDotV2` (wraps XLA DotGeneral operator).
    * `XlaGather` (wraps XLA Gather operator). We could use `tf.gather` in some
      cases but not always. Also, `tf.gather` has a different semantics than `lax.gather`
      for index out of bounds.

--- a/jax/experimental/jax2tf/examples/serving/model_server_request.py
+++ b/jax/experimental/jax2tf/examples/serving/model_server_request.py
@@ -15,7 +15,7 @@
 
 See README.md for instructions.
 """
-import grpc
+import grpc  # type: ignore[import]
 import json
 import logging
 import requests
@@ -26,9 +26,9 @@ from absl import flags
 from jax.experimental.jax2tf.examples import mnist_lib  # type: ignore
 
 import numpy as np
-import tensorflow as tf  # type: ignore
-import tensorflow_datasets as tfds  # type: ignore
-from tensorflow_serving.apis import predict_pb2
+import tensorflow as tf  # type: ignore[import]
+import tensorflow_datasets as tfds  # type: ignore[import]
+from tensorflow_serving.apis import predict_pb2  # type: ignore[import]
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 
 

--- a/jax/experimental/jax2tf/examples/tflite/mnist/mnist.py
+++ b/jax/experimental/jax2tf/examples/tflite/mnist/mnist.py
@@ -21,8 +21,8 @@ from jax.experimental.jax2tf.examples import mnist_lib
 
 import numpy as np
 
-import tensorflow as tf
-import tensorflow_datasets as tfds
+import tensorflow as tf  # type: ignore[import]
+import tensorflow_datasets as tfds  # type: ignore[import]
 
 flags.DEFINE_string('tflite_file_path',
                     '/usr/local/google/home/qiuminxu/jax2tf/mnist.tflite',

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,11 +1,11 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2021-03-29* (YYYY-MM-DD)
+*Last generated on: 2021-05-12* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
-We use a set of 2313 test harnesses to test
-the implementation of 122 numeric JAX primitives.
+We use a set of 2418 test harnesses to test
+the implementation of 121 numeric JAX primitives.
 We consider a JAX primitive supported for a particular data
 type if it is supported on at least one device type.
 The following table shows the dtypes at which primitives
@@ -76,7 +76,7 @@ be updated.
 | device_put | 16 | all |  |
 | digamma | 4 | floating | bool, complex, integer |
 | div | 20 | inexact, integer | bool |
-| dot_general | 125 | all |  |
+| dot_general | 245 | all |  |
 | dynamic_slice | 32 | all |  |
 | dynamic_update_slice | 21 | all |  |
 | eig | 72 | inexact | bool, integer |
@@ -156,7 +156,6 @@ be updated.
 | svd | 120 | inexact | bool, integer |
 | tan | 6 | inexact | bool, integer |
 | tanh | 6 | inexact | bool, integer |
-| tie_in | 15 | all |  |
 | top_k | 15 | bool, floating, integer | complex |
 | transpose | 17 | all |  |
 | triangular_solve | 26 | inexact | bool, integer |
@@ -188,6 +187,9 @@ and search for "limitation".
 |cummax|unimplemented|complex64|tpu|
 |cummin|unimplemented|complex64|tpu|
 |cumprod|unimplemented|complex64|tpu|
+|dot_general|preferred_element_type=c128 not implemented|complex64|tpu|
+|dot_general|preferred_element_type=f64 crashes (b/187884887)|bfloat16, float16, float32|tpu|
+|dot_general|preferred_element_type=i64 not implemented|int16, int32, int8|tpu|
 |eig|only supported on CPU in JAX|all|tpu, gpu|
 |eig|unimplemented|bfloat16, float16|cpu|
 |eigh|complex eigh not supported |complex|tpu|
@@ -202,7 +204,6 @@ and search for "limitation".
 |select_and_scatter_add|works only for 2 or more inactive dimensions|all|tpu|
 |svd|complex not implemented. Works in JAX for CPU and GPU with custom kernels|complex|tpu|
 |svd|unimplemented|bfloat16, float16|cpu, gpu|
-|tie_in|requires omnistaging to be disabled|all|cpu, gpu, tpu|
 |triangular_solve|unimplemented|float16|gpu|
 
 ## Table generation

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -460,17 +460,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             modes="compiled",
             # Works for 2D matrices.
             enabled=(len(harness.params["lhs_shape"]) > 2)),
-        custom_numeric(dtypes=dtypes.bfloat16, tol=0.3),
-        custom_numeric(
-            dtypes=[np.complex64, np.float32], devices=("cpu", "gpu"),
-            tol=1e-5),
-        custom_numeric(
-            dtypes=[np.complex128, np.float64], devices=("cpu", "gpu"),
-            tol=1e-12),
-        custom_numeric(dtypes=np.float32, devices="tpu", tol=0.1),
-        custom_numeric(dtypes=np.complex64, devices="tpu", tol=0.3),
-        custom_numeric(dtypes=np.float16, devices=("gpu", "tpu"), tol=0.1),
-        custom_numeric(dtypes=np.float16, devices="cpu", tol=0.01)
     ]
 
   @classmethod

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -99,7 +99,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   # If you want to run this test for only one harness, add parameter
   # `one_containing="foo"` to parameterized below.
   @primitive_harness.parameterized(
-      primitive_harness.all_harnesses, include_jax_unimpl=False
+      primitive_harness.all_harnesses, include_jax_unimpl=False,
       )
   @jtu.ignore_warning(
       category=UserWarning, message="Using reduced precision for gradient.*")

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -784,7 +784,11 @@ def assert_dot_precision(expected_precision, fun, *args):
                 if eqn.primitive == lax.dot_general_p]
   for precision in precisions:
     msg = "Unexpected precision: {} != {}".format(expected_precision, precision)
-    assert precision == expected_precision, msg
+    if isinstance(precision, tuple):
+      assert precision[0] == expected_precision, msg
+      assert precision[1] == expected_precision, msg
+    else:
+      assert precision == expected_precision, msg
 
 
 _CACHED_INDICES: Dict[int, Sequence[int]] = {}

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2591,23 +2591,23 @@ class APITest(jtu.JaxTestCase):
     with jax.default_matmul_precision("bfloat16"):
       x @ x  # doesn't crash
       jaxpr = jax.make_jaxpr(op.matmul)(x, x)
-    self.assertIn('precision=DEFAULT', str(jaxpr))
+    self.assertIn('Precision.DEFAULT', str(jaxpr))
 
     with jax.default_matmul_precision("tensorfloat32"):
       jnp.dot(x, x)  # doesn't crash
       jaxpr = jax.make_jaxpr(jnp.dot)(x, x)
-    self.assertIn('precision=HIGH\n', str(jaxpr))
+    self.assertIn('Precision.HIGH', str(jaxpr))
 
     with jax.default_matmul_precision("float32"):
       jnp.dot(x, x)  # doesn't crash
       jaxpr = jax.make_jaxpr(jnp.dot)(x, x)
-    self.assertIn('precision=HIGHEST', str(jaxpr))
+    self.assertIn('Precision.HIGHEST', str(jaxpr))
 
     dot = partial(jnp.dot, precision=lax.Precision.HIGHEST)
     with jax.default_matmul_precision("tensorfloat32"):
       dot(x, x)  # doesn't crash
       jaxpr = jax.make_jaxpr(dot)(x, x)
-    self.assertIn('precision=HIGHEST', str(jaxpr))
+    self.assertIn('Precision.HIGHEST', str(jaxpr))
 
   def test_dot_precision_flag(self):
     x = jnp.zeros((2, 2))
@@ -2619,7 +2619,7 @@ class APITest(jtu.JaxTestCase):
       jaxpr = jax.make_jaxpr(jnp.dot)(x, x)
     finally:
       config.FLAGS.jax_default_matmul_precision = prev_val
-    self.assertIn('precision=HIGH', str(jaxpr))
+    self.assertIn('Precision.HIGH', str(jaxpr))
     self.assertEqual(prev_val, config._read("jax_default_matmul_precision"))
 
     prev_val = config._read("jax_default_matmul_precision")
@@ -2629,7 +2629,7 @@ class APITest(jtu.JaxTestCase):
       jaxpr = jax.make_jaxpr(jnp.dot)(x, x)
     finally:
       config.update('jax_default_matmul_precision', prev_val)
-    self.assertIn('precision=HIGH', str(jaxpr))
+    self.assertIn('Precision.HIGH', str(jaxpr))
     self.assertEqual(prev_val, config._read("jax_default_matmul_precision"))
 
   @unittest.skipIf(jax.lib._xla_extension_version <= 17,

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -398,7 +398,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     result, pullback = api.vjp(dot, lhs, rhs)
     gresult = lax.zeros_like_array(result)
     s = str(api.make_jaxpr(pullback)(gresult))
-    assert "precision=HIGHEST" in s
+    assert "Precision.HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
@@ -429,7 +429,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     result, pullback = api.vjp(dot_general, lhs, rhs)
     gresult = lax.zeros_like_array(result)
     s = str(api.make_jaxpr(pullback)(gresult))
-    assert "precision=HIGHEST" in s
+    assert "Precision.HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}".format(


### PR DESCRIPTION
Instead of converting the dot_general to a sea of TF ops, when
we enable_xla we just use the XLA op. This has the advantage
that it also supports the preferred_element_type.

Also, it turns out that `tf.linalg.matmul` now supports tf.bfloat16 and tf.int32, so change the 
conversion for `not _enable_xla` to use `tf.linag.matmul` for those cases as well.