### PR TITLE
[jax2tf] Fix the scoping of the enable_xla conversion parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 
 ## jax 0.2.14 (unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jax-v0.2.13...master).
+* New features:
+
+* Breaking changes:
+
+* Bug fixes:
+  * The {func}`jax2tf.convert` now scopes the `enable_xla` conversion parameter
+    properly to apply only during the just-in-time conversion
+    ({jax-issue}`#6720`).
+  * Fixed assertion failure in {func}`jax2tf.call_tf` when used with captured
+    `tf.Variable` ({jax-issue}`#6572`).
 
 * Bug fixes:
   * The {func}`jax2tf.convert` now converts `lax.dot_general` using the

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -190,8 +190,6 @@ def convert(fun: Callable, *,
     A version of `fun` that expects TfVals as arguments (or
     tuple/lists/dicts) thereof, and returns TfVals as outputs.
   """
-  global _enable_xla
-  _enable_xla = enable_xla
   api._check_callable(fun)
 
   def converted_fun(*args: TfVal) -> TfVal:
@@ -276,6 +274,9 @@ def convert(fun: Callable, *,
     try:
       global _shape_env
       assert not _shape_env, f"Unexpected shape environment {_shape_env}"
+      global _enable_xla
+      prev_enable_xla = _enable_xla
+      _enable_xla = enable_xla
       _shape_env = shapeenv
 
       if with_gradient:
@@ -296,6 +297,7 @@ def convert(fun: Callable, *,
                     for o, _ in out_flat_raw]
     finally:
       _shape_env = {}
+      _enable_xla = prev_enable_xla
 
     out_flat = [tf.identity(x, "jax2tf_out") for x in out_flat]
     out = tree_util.tree_unflatten(out_tree_thunk(), out_flat)


### PR DESCRIPTION
Previously, the global enable_xla flag was set upon entry to
`jax.convert`. It should instead be set only for the duration
of the just-in-time conversion, which may happen later when
the converted function is invoked.