### PR TITLE
[jax2tf] Improve conversion of pad when enable_xla=True, add tests.

### DIFF
--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1229,17 +1229,20 @@ for dtype in jtu.dtypes.all:
     [(0, 0, 0), (-2, -2, 4)],  # add big dilation then remove from edges
     [(0, 0, 0), (-2, -3, 1)],  # remove everything in one dimension
   ]:
-    define(
-      lax.pad_p,
-      f"inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_pads={pads}",
-      lax.pad,
-      [RandArg(arg_shape, dtype),
-       np.array(0, dtype),
-       StaticArg(pads)],
-      rng_factory=jtu.rand_small,
-      arg_shape=arg_shape,
-      dtype=dtype,
-      pads=pads)
+    works_without_xla = all(lo >= 0 and hi >= 0 and i == 0 for lo, hi, i in pads)
+    for enable_xla in ([True, False] if works_without_xla else [True]):
+      define(
+        lax.pad_p,
+        f"inshape={jtu.format_shape_dtype_string(arg_shape, dtype)}_pads={pads}_enable_xla={enable_xla}",
+        lax.pad,
+        [RandArg(arg_shape, dtype),
+         np.array(0, dtype),
+         StaticArg(pads)],
+        rng_factory=jtu.rand_small,
+        arg_shape=arg_shape,
+        dtype=dtype,
+        pads=pads,
+        enable_xla=enable_xla)
 
 
 def _make_select_harness(name,

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -261,8 +261,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
       return lax.pad(x, np.float32(0), [(-1, 0, 0), (0, 0, 0)])
 
     with self.assertRaisesRegex(
-        NotImplementedError, "Call to pad can only be converted through "
-                             "TFXLA, but XLA is disabled"):
+        NotImplementedError, "Call to pad cannot be converted with enable_xla=False."):
       self.ConvertAndCompare(
           fun, np.ones((2, 3), dtype=np.float32), enable_xla=False)
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -99,7 +99,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   # If you want to run this test for only one harness, add parameter
   # `one_containing="foo"` to parameterized below.
   @primitive_harness.parameterized(
-      primitive_harness.all_harnesses, include_jax_unimpl=False
+      primitive_harness.all_harnesses, include_jax_unimpl=False,
       )
   @jtu.ignore_warning(
       category=UserWarning, message="Using reduced precision for gradient.*")
@@ -110,7 +110,9 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
                                                   dtype=harness.dtype), limitations))
     func_jax = harness.dyn_fun
     args = harness.dyn_args_maker(self.rng())
-    self.ConvertAndCompare(func_jax, *args, limitations=limitations)
+    enable_xla = harness.params.get("enable_xla", True)
+    self.ConvertAndCompare(func_jax, *args, limitations=limitations,
+                           enable_xla=enable_xla)
 
   def test_primitive_coverage(self):
     """Fail if there are JAX primitives that are not implemented."""


### PR DESCRIPTION
If enable_xla is True we should directly use the XLA conversion, without
trying to see whether the primitive can actually be converted
to non XLA TF ops. This is happening elsewhere, but it was not
happening for pad.

Also discovered that we were never turning enable_xla=False in
tests, even when we had special harnesses for it.