### PR TITLE
Fix broken FFT following `flatbuffers` 2.0 release

### DIFF
--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension-stubs'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers<2.0'],
+    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers>=1.12,<2.0'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension-stubs'],
     python_requires='>=3.6',
-    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers'],
+    install_requires=['scipy', 'numpy>=1.16', 'absl-py', 'flatbuffers<2.0'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={


### PR DESCRIPTION
Certain `jax` functions are broken as of today due to a [new `flatbuffers` version](https://github.com/google/flatbuffers/releases/tag/v2.0.0). This PR fixes that by restricting `jaxlib`'s requirements.


### Minimal example
Install latest `jax`, `jaxlib` on a new environment in `Debian GNU/Linux 10 (buster)` and run
```python
import jax.numpy as np
np.fft.rfft(np.zeros(10), axis=0)

```
the above raises `TypeError: EndVector() takes 1 positional argument but 2 were given in jax`.

### NB
I have just realised that this is almost a duplicate of #6712.

The difference is that this PR suggests not to use `flatbuffers 2.0`. Furthermore, this PR suggests a potentially high priority as certain functionality of `jax` is broken right now.