### PR TITLE
Improve error message for  shape

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2658,8 +2658,8 @@ def _broadcast_to_pairs(nvals, nd, name):
     # pad
     return tuple((nvals.flat[0], nvals.flat[0]) for i in range(nd))
   else:
-    raise ValueError(f"{name} given unexpected structure: {nvals}. "
-                     f"See docstring for valid {name} formats.")
+    raise ValueError(f"jnp.pad: {name} with nd={nd} has unsupported shape {nvals.shape}. "
+                     f"Valid shapes are ({nd}, 2), (1, 2), (2,), (1,), or ().")
 
 
 @partial(jit, static_argnums=(1, 2, 4, 5, 6))


### PR DESCRIPTION
Fixes #6605

Previously:
```python
>>> y = jnp.pad(jnp.zeros((2,2)), [[0,0],[0,0],[0,0]], mode='wrap')
ValueError: pad_width given unexpected structure: [[0 0]
 [0 0]
 [0 0]]. See docstring for valid pad_width formats.
```
With this change:
```python
>>> y = jnp.pad(jnp.zeros((2,2)), [[0,0],[0,0],[0,0]], mode='wrap') 
ValueError: jnp.pad: pad_width with nd=2 has unsupported shape (3, 2). Valid shapes are (2, 2), (1, 2), (2,), (1,), or ().
```