### PR TITLE
Reenable a GMRES test on CPU.

### DIFF
--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -317,12 +317,14 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
       for dtype in [np.float64, np.complex128]
       for preconditioner in [None, 'identity', 'exact', 'random']
       for solve_method in ['incremental', 'batched']))
-  # TODO(b/186133663): test fails on CPU after LLVM change.
-  @jtu.skip_on_devices("cpu")
   def test_gmres_against_scipy(
       self, shape, dtype, preconditioner, solve_method):
     if not config.x64_enabled:
       raise unittest.SkipTest("requires x64 mode")
+
+    # The LLVM bug that caused this appears to be fixed in jaxlib 0.1.67.
+    if jtu.device_under_test() == "cpu" and jax.lib.version <= (0, 1, 66):
+      raise unittest.SkipTest("test fails on CPU jaxlib <= 0.1.66")
 
     rng = jtu.rand_default(self.rng())
     A = rng(shape, dtype)


### PR DESCRIPTION
It appears to pass once again with jaxlib 0.1.67. Unfortunately it just missed the 0.1.66 release.