### PR TITLE
Fixed Tuple_replace bug: index not incremented to replace

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -332,7 +332,7 @@ def tuple_delete(t, idx):
 
 def tuple_replace(t, idx, val):
   assert 0 <= idx < len(t), (idx, len(t))
-  return t[:idx] + (val,) + t[idx:]
+  return t[:idx] + (val,) + t[idx+1:]
 
 # TODO(mattjj): replace with dataclass when Python 2 support is removed
 def taggedtuple(name, fields) -> Callable[..., Any]:


### PR DESCRIPTION
closes #6745 

### Description:

In the file:  `jax/_src./util.py`

The `tuple_replace` function is identical to the `tuple_insert` function already defined in the same file location (named above). In order to replace the tuple as the function intends the below code should be implemented. 

### Before

``` py
def tuple_replace(t, idx, val):
  assert 0 <= idx < len(t), (idx, len(t))
  return t[:idx] + (val,) + t[idx:]
```
### After

```py
def tuple_replace(t, idx, val):
  assert 0 <= idx < len(t), (idx, len(t))
  return t[:idx] + (val,) + t[idx+1:]
```
```diff
- return t[:idx] + (val,) + t[idx:]
+ return t[:idx] + (val,) + t[idx+1:]
```