### PR TITLE
Fix `jsp.linalg.lu` translation rule to pass backend arg to `lower_fun`.

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -989,7 +989,7 @@ def _tuple_output(*args, **kwargs):
   ans = yield args, kwargs
   yield (ans,)
 
-def lower_fun(fun, multiple_results, parallel=False, with_avals=False):
+def lower_fun(fun, multiple_results, parallel=False, with_avals=False, backend=None):
   # TODO(jakevdp): migrate dependent code & always use the with_avals=True.
   def f(c, *xla_args, **params):
     avals = [_array_aval_from_xla_shape(c.get_shape(x)) for x in xla_args]
@@ -1005,7 +1005,7 @@ def lower_fun(fun, multiple_results, parallel=False, with_avals=False):
     if not multiple_results:
       wrapped_fun = _tuple_output(wrapped_fun)
     jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
-    outs = jaxpr_subcomp(c, jaxpr, None, axis_env, _xla_consts(c, consts), '',
+    outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, _xla_consts(c, consts), '',
                          *xla_args)
     if multiple_results or any(v.aval._num_buffers > 1 for v in jaxpr.outvars):
       return xops.Tuple(c, outs)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1065,6 +1065,11 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     self.assertAllClose(ls, actual_ls, rtol=5e-6)
     self.assertAllClose(us, actual_us)
 
+  @jtu.skip_on_devices("cpu", "tpu")
+  def testLuCPUBackendOnGPU(self):
+    # tests running `lu` on cpu when a gpu is present.
+    jit(jsp.linalg.lu, backend="cpu")(np.ones((2, 2)))  # does not crash
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_n={}".format(jtu.format_shape_dtype_string((n,n), dtype)),


### PR DESCRIPTION
If it doesn't, trying to run `lu` with a custom CPU backend when a GPU is present results in a `Unable to resolve runtime symbol: 'cuda_lu_pivots_to_permutation'` fatal error.

eg. fixes following repro from a user:
```
a = jnp.eye(2)
jax.jit(jnp.linalg.inv, backend='cpu')(a)
```
which before this fix throws:
```
E0513 20:00:46.341652 2455650 simple_orc_jit.cc:197] Unable to resolve runtime symbol:
`cuda_lu_pivots_to_permutation'.  
Hint: if the symbol a custom call target, make sure you've registered it with the JIT 
using XLA_CPU_REGISTER_CUSTOM_CALL_TARGET.
JIT session error: Symbols not found: [ cuda_lu_pivots_to_permutation ]
```

I didn't investigate deeply if there's other `lower_fun` translation rules that need to be updated in the same way, maybe that could be done as a follow-up?