### PR TITLE
[jax2tf] Update the limitations for unsupported primitives

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -585,17 +585,17 @@ the ``a_inference_cos_tf_68__``HLO function that was compiled by TF from ``cos_t
 ## Notes:
 
   * The TF function must be compileable (`tf.function(func, jit_compile=True`)
-    when used in a JAX staging context. 
+    when used in a JAX staging context.
   * All the metadata inserted by TF during tracing and compilation, e.g.,
     source location information and op names, is carried through to the
     JAX XLA computation.
   * The TF custom gradients are respected, since it is TF that generates the
     gradient computation.
-  * In op-by-op mode, when we call TensorFlow in eager mode, we use 
+  * In op-by-op mode, when we call TensorFlow in eager mode, we use
     DLPack to try to avoid copying the data. This works for CPU (for
     DeviceArray data or for np.ndarray that are aligned on 16-byte
-    boundaries) and on GPU (for DeviceArray). 
-    The zero-copy does not yet work on TPU.   
+    boundaries) and on GPU (for DeviceArray).
+    The zero-copy does not yet work on TPU.
   * ``call_tf`` works best with pure TF functions that do not capture
     ``tf.Variable``s or tensors from the environment, and all such
     context is passed in explicitly through arguments, and if variables
@@ -622,7 +622,7 @@ the ``a_inference_cos_tf_68__``HLO function that was compiled by TF from ``cos_t
           new_var1 = 11.
           return x + new_var1, new_var1
 ```
-    
+
    This use case is likely to be revisited.
 
 ## TODO
@@ -645,3 +645,29 @@ To run jax2tf on GPU, both jaxlib and TensorFlow must be installed with support
 for CUDA. One must be mindful to install a version of CUDA that is compatible
 with both [jaxlib](https://github.com/google/jax/blob/master/README.md#pip-installation) and
 [TensorFlow](https://www.tensorflow.org/install/source#tested_build_configurations).
+
+## Updating the limitations documentation
+
+The jax2tf tests are parameterized by a set of limitations
+(see `tests/primitive_harness.py` and `tests/jax2tf_limitations.py`).
+The limitations specify test harnesses that are known to fail, by
+JAX primitive, data type, device type, and TensorFlow execution mode (`eager`,
+`graph`, or `compiled`). These limitations are also used
+to generate tables of limitations, e.g.,
+
+   * [List of primitives not supported in JAX](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primtives_coverage.md),
+     e.g., due to unimplemented cases in the XLA compiler, and
+   * [List of primitives not supported in jax2tf](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md),
+     e.g., due to unimplemented cases in TensorFlow. This list is incremental
+     on top of the unsupported JAX primitives.
+
+There are instructions for updating those documents at the end of each
+document.
+
+The set of limitations is an over-approximation, in the sense that if XLA
+or TensorFlow improves and support more cases, no test will fail. Instead,
+periodically, we check for unnecessary limitations. We do this by uncommenting
+two assertions (in `tests/jax_primitives_coverage_test.py` and in
+`tests/tf_test_util.py`) and runing all the tests. With these assertions enabled
+the tests will fail and point out unnecessary limitations. We remove limitations
+until the tests pass. Then we re-generate the documentation.

--- a/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
+++ b/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md
@@ -1,10 +1,10 @@
 # Primitives with limited JAX support
 
-*Last generated on: 2021-05-12* (YYYY-MM-DD)
+*Last generated on: 2021-05-17* (YYYY-MM-DD)
 
 ## Supported data types for primitives
 
-We use a set of 2418 test harnesses to test
+We use a set of 2492 test harnesses to test
 the implementation of 121 numeric JAX primitives.
 We consider a JAX primitive supported for a particular data
 type if it is supported on at least one device type.
@@ -95,7 +95,7 @@ be updated.
 | igamma | 6 | floating | bool, complex, integer |
 | igammac | 6 | floating | bool, complex, integer |
 | imag | 2 | complex | bool, floating, integer |
-| integer_pow | 34 | inexact, integer | bool |
+| integer_pow | 108 | inexact, integer | bool |
 | iota | 16 | inexact, integer | bool |
 | is_finite | 4 | floating | bool, complex, integer |
 | le | 15 | bool, floating, integer | complex |
@@ -184,11 +184,7 @@ and search for "limitation".
 | Affected primitive | Description of limitation | Affected dtypes | Affected devices |
 | --- | --- | --- | --- |
 |cholesky|unimplemented|float16|cpu, gpu|
-|cummax|unimplemented|complex64|tpu|
-|cummin|unimplemented|complex64|tpu|
-|cumprod|unimplemented|complex64|tpu|
 |dot_general|preferred_element_type=c128 not implemented|complex64|tpu|
-|dot_general|preferred_element_type=f64 crashes (b/187884887)|bfloat16, float16, float32|tpu|
 |dot_general|preferred_element_type=i64 not implemented|int16, int32, int8|tpu|
 |eig|only supported on CPU in JAX|all|tpu, gpu|
 |eig|unimplemented|bfloat16, float16|cpu|
@@ -196,9 +192,6 @@ and search for "limitation".
 |eigh|unimplemented|bfloat16, float16|cpu, gpu|
 |lu|unimplemented|bfloat16, float16|cpu, gpu, tpu|
 |qr|unimplemented|bfloat16, float16|cpu, gpu|
-|reduce_window_max|unimplemented in XLA|complex64|tpu|
-|reduce_window_min|unimplemented in XLA|complex64|tpu|
-|reduce_window_mul|unimplemented in XLA|complex64|tpu|
 |scatter_max|unimplemented|complex64|tpu|
 |scatter_min|unimplemented|complex64|tpu|
 |select_and_scatter_add|works only for 2 or more inactive dimensions|all|tpu|

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support for jax2tf
 
-*Last generated on (YYYY-MM-DD): 2021-03-29*
+*Last generated on (YYYY-MM-DD): 2021-05-17*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -12,10 +12,10 @@ There are several kinds of limitations.
   * There are some cases when the converted program computes different results than
   the JAX program, see [below](#generated-summary-of-primitives-with-known-numerical-discrepancies-in-tensorflow).
 
-Note that automated tests will ensure that this list of limitations is a
-superset of the actual limitations. If you see a limitation that
-you think it does not exist anymore in a recent TensorFlow version,
-please ask for this file to be updated.
+Note that automated tests will fail if new limitations appear, but
+they won't when limitations are fixed. If you see a limitation that
+you think it does not exist anymore, please ask for this file to
+be updated.
 
 ## Generated summary of primitives with unimplemented support in Tensorflow
 
@@ -31,8 +31,6 @@ to one Tensorflow op, e.g., `sin` is mapped to `tf.math.sin`.
 The errors apply only for certain devices and compilation modes ("eager",
 "graph", and "compiled"). In general, "eager" and "graph" mode share the same errors.
 On TPU only the "compiled" mode is relevant.
-
-Our first priority is to ensure that the coverage of data types is complete for the "compiled" mode.
 
 This table only shows errors for cases that are working in JAX (see [separate
 list of unsupported or partially-supported primitives](https://github.com/google/jax/blob/master/jax/experimental/jax2tf/g3doc/jax_primitives_coverage.md) )
@@ -76,19 +74,16 @@ More detailed information can be found in the
 | conv_general_dilated | TF error: jax2tf BUG: batch_group_count > 1 not yet converted | all | cpu, gpu, tpu | compiled, eager, graph |
 | conv_general_dilated | TF error: op not defined for dtype | complex | gpu | compiled, eager, graph |
 | cosh | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
-| cummax | TF test skipped: Not implemented in JAX: unimplemented | complex64 | tpu | compiled, eager, graph |
 | cummax | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
-| cummax | TF error: op not defined for dtype | complex64 | cpu, gpu | compiled, eager, graph |
-| cummin | TF test skipped: Not implemented in JAX: unimplemented | complex64 | tpu | compiled, eager, graph |
+| cummax | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | cummin | TF error: op not defined for dtype | complex128, uint64 | cpu, gpu | compiled, eager, graph |
 | cummin | TF error: op not defined for dtype | complex64, int8, uint16, uint32 | cpu, gpu, tpu | compiled, eager, graph |
-| cumprod | TF test skipped: Not implemented in JAX: unimplemented | complex64 | tpu | compiled, eager, graph |
-| cumsum | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
 | digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
 | div | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
-| dot_general | TF error: op not defined for dtype | int64 | cpu, gpu | compiled |
-| dot_general | TF error: op not defined for dtype | bool, int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| dot_general | TF test skipped: Not implemented in JAX: preferred_element_type=c128 not implemented | complex64 | tpu | compiled, eager, graph |
+| dot_general | TF test skipped: Not implemented in JAX: preferred_element_type=i64 not implemented | int16, int32, int8 | tpu | compiled, eager, graph |
+| dot_general | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | eig | TF test skipped: Not implemented in JAX: only supported on CPU in JAX | all | gpu, tpu | compiled, eager, graph |
 | eig | TF test skipped: Not implemented in JAX: unimplemented | bfloat16, float16 | cpu | compiled, eager, graph |
 | eig | TF error: TF Conversion of eig is not implemented when both compute_left_eigenvectors and compute_right_eigenvectors are set to True | all | cpu, gpu, tpu | compiled, eager, graph |
@@ -106,7 +101,7 @@ More detailed information can be found in the
 | gt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
-| integer_pow | TF error: op not defined for dtype | unsigned | cpu, gpu, tpu | compiled, eager, graph |
+| integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu | graph |
 | le | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | lgamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | lt | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
@@ -125,13 +120,9 @@ More detailed information can be found in the
 | reduce_max | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex128 | cpu, gpu, tpu | compiled, eager, graph |
 | reduce_min | TF error: op not defined for dtype | complex64 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_add | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
-| reduce_window_max | TF test skipped: Not implemented in JAX: unimplemented in XLA | complex64 | tpu | compiled, eager, graph |
 | reduce_window_max | TF error: op not defined for dtype | complex128 | cpu, gpu | compiled, eager, graph |
 | reduce_window_max | TF error: op not defined for dtype | bool, complex64 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_min | TF test skipped: Not implemented in JAX: unimplemented in XLA | complex64 | tpu | compiled, eager, graph |
 | reduce_window_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
-| reduce_window_mul | TF test skipped: Not implemented in JAX: unimplemented in XLA | complex64 | tpu | compiled, eager, graph |
 | regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
@@ -146,7 +137,6 @@ More detailed information can be found in the
 | scatter_min | TF error: op not defined for dtype | bool, complex, int8, uint16, uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_mul | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_mul | TF error: op not defined for dtype | complex64 | tpu | compiled, eager, graph |
-| select_and_gather_add | TF error: This JAX primitives is not not exposed directly in the JAX API but arises from JVP of `lax.reduce_window` for reducers `lax.max` or `lax.min`. It also arises from second-order VJP of the same. Implemented using XlaReduceWindow | float32 | tpu | compiled, eager, graph |
 | select_and_gather_add | TF error: jax2tf unimplemented for 64-bit inputs because the current implementation relies on packing two values into a single value. This can be fixed by using a variadic XlaReduceWindow, when available | float64 | cpu, gpu | compiled, eager, graph |
 | select_and_scatter_add | TF test skipped: Not implemented in JAX: works only for 2 or more inactive dimensions | all | tpu | compiled, eager, graph |
 | sign | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu, tpu | compiled, eager, graph |
@@ -156,7 +146,6 @@ More detailed information can be found in the
 | svd | TF test skipped: Not implemented in JAX: unimplemented | bfloat16, float16 | cpu, gpu | compiled, eager, graph |
 | svd | TF error: function not compilable. Implemented using `tf.linalg.svd` and `tf.linalg.adjoint` | complex | cpu, gpu | compiled |
 | svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
-| tie_in | TF test skipped: Not implemented in JAX: requires omnistaging to be disabled | all | cpu, gpu, tpu | compiled, eager, graph |
 | top_k | TF error: op not defined for dtype | int64, uint64 | cpu, gpu | compiled |
 | triangular_solve | TF test skipped: Not implemented in JAX: unimplemented | float16 | gpu | compiled, eager, graph |
 | triangular_solve | TF error: op not defined for dtype | bfloat16 | cpu, gpu, tpu | compiled, eager, graph |
@@ -185,12 +174,13 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 | erf_inv | May return different results at undefined points (< -1 or > 1): JAX returns `NaN` and TF returns `+inf` or `-inf`. | float32, float64 | cpu, gpu, tpu | compiled, eager, graph |
 | igamma | May return different results at undefined points (both arguments 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu, tpu | eager, graph |
 | igammac | May return different results at undefined points (both arguments less or equal 0). JAX returns `NaN` and TF returns 0 or JAX returns 1 and TF returns `NaN` | all | cpu, gpu | eager, graph |
-| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents.  | complex64, float32, signed | cpu, gpu, tpu | compiled, eager, graph |
-| integer_pow | custom numeric comparison | complex | cpu, gpu, tpu | compiled, eager, graph |
+| integer_pow | Numeric comparision disabled: Different overflow behavior for large exponents.  | bfloat16, complex, float16, float32, signed | cpu, gpu, tpu | eager, graph |
+| integer_pow | Numeric comparision disabled: Different overflow behavior.  | bfloat16, float16 | tpu | eager, graph |
+| integer_pow | custom numeric comparison | complex | cpu, gpu, tpu | eager, graph |
 | lu | May return different, but also correct, results when the decomposition is not unique | all | cpu, gpu, tpu | compiled, eager, graph |
 | max | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
 | min | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
-| pow | custom numeric comparison | complex | cpu, gpu, tpu | compiled, eager, graph |
+| pow | custom numeric comparison | complex | cpu, gpu, tpu | eager, graph |
 | sort | Numeric comparision disabled: TODO: TF non-stable multiple-array sort | all | gpu | compiled, eager, graph |
 | svd | custom numeric comparison | all | cpu, gpu, tpu | compiled, eager, graph |
 | top_k | Produces different results when the array contains `inf` and `NaN` (they are sorted differently in TF vs. XLA). | floating | cpu, gpu, tpu | compiled, eager, graph |

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1306,13 +1306,6 @@ def _make_cumreduce_harness(name,
                             axis=0,
                             reverse=False):
   limitations = []
-  if f_jax.__name__ != "cumsum":
-    limitations.append(
-      Limitation(
-        "unimplemented",
-        devices="tpu",
-        dtypes=np.complex64,
-      ))
   define(
     f_jax.__name__,
     f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_axis={axis}_reverse={reverse}",
@@ -2166,9 +2159,6 @@ def _make_reduce_window_harness(name,
                                 padding=((0, 0), (0, 0))):
   prim_name = f"reduce_window_{computation.__name__}"
   limitations = []
-  if computation.__name__ in ("max", "mul", "min"):
-    limitations.append(
-      Limitation("unimplemented in XLA", devices="tpu", dtypes=np.complex64))
   define(
     prim_name,
     f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_initvalue={init_value}_windowdimensions={window_dimensions}_windowstrides={window_strides}_padding={padding}_basedilation={base_dilation}_windowdilation={window_dilation}"


### PR DESCRIPTION
This reflects progress in XLA and TF, and recent fixes for the converter. 

Also update the documentation.