### PR TITLE
Improves jax2tf error message for conv_general_dilated

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1209,7 +1209,8 @@ def _conv_general_dilated(lhs, rhs, window_strides, padding, lhs_dilation,
     if not isinstance(info_or_result, str):
       return info_or_result
     else:
-      raise _xla_path_disabled_error("conv_general_dilated")
+      raise NotImplementedError("Could not convert conv_general_dilated "
+                                f"without XLA, reason: {info_or_result}")
 
   dnums_proto = _conv_general_dimension_numbers_proto(dimension_numbers)
   precision_config_proto = _conv_general_precision_config_proto(precision)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1240,7 +1240,8 @@ def _conv_general_dilated(lhs, rhs, *,
     if not isinstance(info_or_result, str):
       return info_or_result
     else:
-      raise _xla_path_disabled_error("conv_general_dilated")
+      raise NotImplementedError("Could not convert conv_general_dilated "
+                                f"without XLA, reason: {info_or_result}")
 
   dnums_proto = _conv_general_dimension_numbers_proto(dimension_numbers)
   precision_config_proto = _precision_config_proto(precision)


### PR DESCRIPTION
When using `jax2tf` with XLA disabled, `conv_general_dilated` may still convert successfully in some special cases. In those cases where it does not, the variable `info_or_result` contains useful information for debugging why. However, currently this information isn't output. This PR makes sure it is output.

For instance, when trying to convert a [ResNet18](https://github.com/google/flax/blob/master/examples/imagenet/models.py#L121) model, the original error message was:

```
NotImplementedError: Call to conv_general_dilated can only be converted through TFXLA, but XLA is disabled
```

After this PR, the error message is:

```
NotImplementedError: Could not convert conv_general_dilated without using XLA, reason: tf.nn.convolution is not supported for dtype <dtype: 'bfloat16'>
```

This PR also simplifies some of the error raising logic in `_try_tr_conv`.