### PR TITLE
CI: test Python 3.9 with numpy dispatch test

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -41,7 +41,7 @@ jobs:
             package-overrides: "none"
             num_generated_cases: 25
           - name-prefix: "with numpy-dispatch"
-            python-version: 3.7
+            python-version: 3.9
             os: ubuntu-latest
             enable-x64: 1
             # Test experimental NumPy dispatch


### PR DESCRIPTION
Why? We currently don't have any Python 3.9 test coverage; this seems like a good candidate for that because it's testing a future numpy API.