### PR TITLE
Improve docs for `jnp.round` and export `jnp.round_`

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -318,6 +318,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     roots
     rot90
     round
+    round_
     row_stack
     save
     savez

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1842,7 +1842,7 @@ def clip(a, a_min=None, a_max=None, out=None):
     a = minimum(a_max, a)
   return a
 
-@_wraps(np.round, update_doc=False, skip_params=['out'])
+@_wraps(np.around, skip_params=['out'])
 def round(a, decimals=0, out=None):
   _check_arraylike("round", a)
   decimals = core.concrete_or_error(operator.index, decimals, "'decimals' argument of jnp.round")
@@ -1874,6 +1874,7 @@ def round(a, decimals=0, out=None):
   else:
     return _round_float(a)
 around = round
+round_ = round
 
 
 @_wraps(np.fix, skip_params=['out'])

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -54,7 +54,7 @@ from jax._src.numpy.lax_numpy import (
     pi, piecewise, poly, polyadd, polyder, polyint, polymul, polysub, polyval, positive, power,
     prod, product, promote_types, ptp, quantile,
     r_, rad2deg, radians, ravel, ravel_multi_index, real, reciprocal, remainder, repeat, reshape,
-    result_type, right_shift, rint, roll, rollaxis, rot90, round, row_stack,
+    result_type, right_shift, rint, roll, rollaxis, rot90, round, round_, row_stack,
     save, savez, searchsorted, select, set_printoptions, setdiff1d, setxor1d, shape, sign, signbit,
     signedinteger, sin, sinc, single, sinh, size, sometrue, sort, sort_complex, split, sqrt,
     square, squeeze, stack, std, subtract, sum, swapaxes, take, take_along_axis,


### PR DESCRIPTION
This PR improves the docs of `jnp.round` by wrapping `np.around` and exports `jnp.round_` to match [`np.round_`](https://numpy.org/doc/stable/reference/generated/numpy.round_.html).
## Before
<img width="421" alt="Screenshot 2021-05-21 at 01 42 23" src="https://user-images.githubusercontent.com/13285808/119065799-419ed400-b9d6-11eb-97e5-52a8b49bd6ba.png">

## After
<img width="741" alt="Screenshot 2021-05-21 at 01 42 35" src="https://user-images.githubusercontent.com/13285808/119065805-4499c480-b9d6-11eb-9f98-92ba9bf2cd4e.png">

## Rendered preview
- https://jax--6803.org.readthedocs.build/en/6803/_autosummary/jax.numpy.around.html
- https://jax--6803.org.readthedocs.build/en/6803/_autosummary/jax.numpy.round.html
- https://jax--6803.org.readthedocs.build/en/6803/_autosummary/jax.numpy.round_.html