### PR TITLE
Replace `pow()` with `sqrt()` or `square()` where possible

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1019,7 +1019,7 @@ def _gamma_one(key, alpha):
   alpha = lax.select(lax.ge(alpha, one), alpha, lax.add(alpha, one))
 
   d = lax.sub(alpha, one_over_three)
-  c = lax.div(one_over_three, lax.pow(d, one_over_two))
+  c = lax.div(one_over_three, lax.sqrt(d))
 
   def _cond_fn(kXVU):
     _, X, V, U = kXVU

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -25,11 +25,10 @@ from jax.scipy import special
 @_wraps(osp_stats.norm.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("norm.logpdf", x, loc, scale)
-  two = _constant_like(x, 2)
-  scale_sqrd = lax.pow(scale, two)
+  scale_sqrd = lax.square(scale)
   log_normalizer = lax.log(lax.mul(_constant_like(x, 2 * np.pi), scale_sqrd))
-  quadratic = lax.div(lax.pow(lax.sub(x, loc), two), scale_sqrd)
-  return lax.div(lax.neg(lax.add(log_normalizer, quadratic)), two)
+  quadratic = lax.div(lax.square(lax.sub(x, loc)), scale_sqrd)
+  return lax.div(lax.add(log_normalizer, quadratic), _constant_like(x, -2))
 
 
 @_wraps(osp_stats.norm.pdf, update_doc=False)


### PR DESCRIPTION
This PR replaces `lax.pow()` with `lax.square()` or `lax.sqrt()` where possible. `lax.pow()` may be imprecise for floating-point values so switching to `lax.square()` should be preferred since it uses `lax.integer_power()` under the hood and might even be slightly faster.