### PR TITLE
Enable custom gradients SavedModel option in test

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -137,8 +137,12 @@ custom gradients and wrap instead the converted function with
 ``tf.raw_ops.PreventGradient`` to generated an error in case a gradient
 computation is attempted.
 
-Currently, there is a bug that prevents using custom gradients with SavedModel
-(see [Caveats](#caveats) below).
+SavedModels enables saving custom derivative rules by using the `experimental_custom_gradients` option:
+
+```
+options = tf.saved_model.SaveOptions(experimental_custom_gradients=True)
+tf.saved_model.save(model, path, options=options)
+```
 
 ## Shape-polymorphic conversion
 
@@ -477,15 +481,6 @@ in [savedmodel_test.py](https://github.com/google/jax/blob/master/jax/experiment
 
 There is currently no support for replicated (e.g. `pmap`) or multi-device
 (e.g. `sharded_jit`) functions. The collective operations are not yet handled.
-
-### No SavedModel fine-tuning
-
-Currently, TensorFlow SavedModel does not properly save the `tf.custom_gradient`.
-It does save however some attributes that on model restore result in a warning
-that the model might not be differentiable, and trigger an error if differentiation
-is attempted. The plan is to fix this. Note that if no gradients are requested,
-the PreventGradient ops will be saved along with the converted code and will
-give a nice error if differentiation of the converted code is attempted.
 
 ### Converting gradients for integer-argument functions
 

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -83,7 +83,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
       x, = primals
       x_dot, = tangents
       primal_out = f_jax(x)
-      tangent_out = 3. * x * x_dot
+      tangent_out = np.float32(3.) * x * x_dot
       return primal_out, tangent_out
 
     model = tf.Module()

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -38,7 +38,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     tf.saved_model.save(
         model,
         model_dir,
-        options=tf.saved_model.SaveOptions(custom_gradients=True))
+        options=tf.saved_model.SaveOptions(experimental_custom_gradients=True))
     restored_model = tf.saved_model.load(model_dir)
     return restored_model
 
@@ -98,7 +98,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     with tf.GradientTape() as tape:
       y = restored_model.f(xv)
     self.assertAllClose(tape.gradient(y, xv).numpy(),
-                        jax.grad(f_jax)(0.7).astype(np.float32))
+                        jax.grad(f_jax)(x).astype(np.float32))
 
   def _compare_with_saved_model(self, f_jax, *args):
     # Certain ops are converted to ensure an XLA context, e.g.,

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -36,8 +36,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     # Roundtrip through saved model on disk.
     model_dir = os.path.join(absltest.get_default_test_tmpdir(), str(id(model)))
     tf.saved_model.save(
-        model,
-        model_dir,
+        model, model_dir,
         options=tf.saved_model.SaveOptions(experimental_custom_gradients=True))
     restored_model = tf.saved_model.load(model_dir)
     return restored_model


### PR DESCRIPTION
TensorFlow SavedModel added the option to save custom gradients in [e6c7ba](https://github.com/tensorflow/tensorflow/commit/e6c7ba3875634d7c142d787c2c5012cea9ad8daa). This change updates the JAX SavedModel test to use this option.