### PR TITLE
Handle negative values for list-like sections in `jnp.split`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1805,7 +1805,8 @@ def _split(op, ary, indices_or_sections, axis=0):
   size = ary.shape[axis]
   if isinstance(indices_or_sections, (tuple, list) + _arraylike_types):
     indices_or_sections = np.array(
-        [core.concrete_or_error(np.int64, i_s, f"in jax.numpy.{op} argument 1")
+        [_canonicalize_axis(core.concrete_or_error(np.int64, i_s,
+                                                   f"in jax.numpy.{op} argument 1"), size)
          for i_s in indices_or_sections], np.int64)
     split_indices = np.concatenate([[np.int64(0)], indices_or_sections,
                                     [np.int64(size)]])

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2925,8 +2925,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
        "shape": shape, "num_sections": num_sections, "axis": axis,
        "dtype": dtype}
       for shape, axis, num_sections in [
-          ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((12, 4), 1, 2),
-          ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
+          ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((3,), 0, [-1]),
+          ((12, 4), 1, 2), ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
       for dtype in default_dtypes))
   def testSplitStaticInt(self, shape, num_sections, axis, dtype):
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
Fixes #6599. I added the repro from that same issue as a test. 

I guess this is technically abuse of notation as `i_s` is not an axis there but rather an index. I did it this way to prefer an existing core functionality over inserting technical debt from my own logic.