### PR TITLE
Support complex input in jax.scipy.special.logsumexp

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -108,23 +108,33 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     a, = _promote_args_inexact("logsumexp", a)
   pos_dims, dims = _reduction_dims(a, axis)
   amax = jnp.max(a, axis=dims, keepdims=keepdims)
-  amax = lax.stop_gradient(lax.select(lax.is_finite(amax), amax, lax.full_like(amax, 0)))
+  amax = lax.stop_gradient(lax.select(jnp.isfinite(amax), amax, lax.full_like(amax, 0)))
   amax_with_dims = amax if keepdims else lax.expand_dims(amax, pos_dims)
-  if b is None:
+  # fast path if the result cannot be negative.
+  if b is None and not np.issubdtype(a.dtype, np.complexfloating):
     out = lax.add(lax.log(jnp.sum(lax.exp(lax.sub(a, amax_with_dims)),
                                   axis=dims, keepdims=keepdims)),
                   amax)
     sign = jnp.where(jnp.isnan(out), np.nan, 1.0).astype(out.dtype)
     sign = jnp.where(out == -np.inf, 0.0, sign)
   else:
-    sumexp = jnp.sum(lax.mul(lax.exp(lax.sub(a, amax_with_dims)), b),
-                     axis=dims, keepdims=keepdims)
-    sign = lax.stop_gradient(lax.sign(sumexp))
-    out = lax.add(lax.log(lax.abs(sumexp)), amax)
+    expsub = lax.exp(lax.sub(a, amax_with_dims))
+    if b is not None:
+      expsub = lax.mul(expsub, b)
+    sumexp = jnp.sum(expsub, axis=dims, keepdims=keepdims)
+
+    sign = lax.stop_gradient(jnp.sign(sumexp))
+    if np.issubdtype(sumexp.dtype, np.complexfloating):
+      if return_sign:
+        sumexp = sign*sumexp
+      out = lax.add(lax.log(sumexp), amax)
+    else:
+      out = lax.add(lax.log(lax.abs(sumexp)), amax)
   if return_sign:
     return (out, sign)
   if b is not None:
-    out = jnp.where(sign < 0, np.nan, out)
+    if not np.issubdtype(out.dtype, np.complexfloating):
+      out = jnp.where(sign < 0, np.nan, out)
   return out
 
 

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -40,6 +40,7 @@ compatible_shapes = [[(), ()],
                      [(2, 3, 4), (2, 1, 4)]]
 
 float_dtypes = jtu.dtypes.floating
+complex_dtypes = jtu.dtypes.complex
 int_dtypes = jtu.dtypes.integer
 
 OpRecord = collections.namedtuple(
@@ -106,7 +107,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
        "shapes": shapes, "dtype": dtype,
        "axis": axis, "keepdims": keepdims,
        "return_sign": return_sign, "use_b": use_b}
-      for shape_group in compatible_shapes for dtype in float_dtypes + int_dtypes
+      for shape_group in compatible_shapes for dtype in float_dtypes + complex_dtypes + int_dtypes
       for use_b in [False, True]
       for shapes in itertools.product(*(
         (shape_group, shape_group) if use_b else (shape_group,)))


### PR DESCRIPTION
scipy does support complex inputs. 
This PR adds such support to jax too.

To make the case `b=None` work it's only needed to change `lax.is_finite` to `jnp.isfinite`, because the former does not support complex numbers while the latter does.

To support the case `b!=None` a different implementation is used.

The sign is computed with `jnp.sign` instead of `lax.sign` because the latter gives back the phase which is irrelevant here. (Actually, I doubt anybody would need the sign with complex inputs)

This PR uses the same algorithm