### PR TITLE
[jax2tf] Add support for generating HLO OpMetadata in the TF graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
     unknown dimensions are used in arithmetic operations, e.g., `jnp.reshape(-1)`
     ({jax-issue}`#6827`).    
 
+  * The {func}`jax2tf.convert` generates custom attributes with location information
+   in TF ops. The code that XLA generates after jax2tf
+   has the same location information as JAX/XLA.
+
 * Breaking changes:
 
 * Bug fixes:
@@ -29,8 +33,6 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
   * The {func}`jax2tf.convert` now scopes the `enable_xla` conversion parameter
     properly to apply only during the just-in-time conversion
     ({jax-issue}`#6720`).
-  * Fixed assertion failure in {func}`jax2tf.call_tf` when used with captured
-    `tf.Variable` ({jax-issue}`#6572`).
   * The {func}`jax2tf.convert` now converts `lax.dot_general` using the
     `XlaDot` TensorFlow op, for better fidelity w.r.t. JAX numerical precision
     ({jax-issue}`#6717`).

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -39,8 +39,10 @@ def user_frames(source_info: Optional[Traceback]) -> Iterator[Frame]:
   # We don't use traceback_util.path_starts_with because that incurs filesystem
   # access, which may be slow; we call this function when e.g. adding source
   # provenance annotations to XLA lowerings, so we don't want to incur the cost.
+  # We consider files that end with _test.py as user frames, to allow testing
+  # this mechanism from tests.
   return (x for x in (source_info.frames if source_info else [])
-          if not any(x.file_name.startswith(p) for p in _exclude_paths))
+          if x.file_name.endswith("_test.py") or not any(x.file_name.startswith(p) for p in _exclude_paths))
 
 def user_frame(source_info: Optional[Traceback]) -> Optional[Frame]:
   return next(user_frames(source_info), None)

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -525,6 +525,20 @@ in [savedmodel_test.py](https://github.com/google/jax/blob/master/jax/experiment
 There is currently no support for `pmap` or`xmap`, nor for the collective
 operations. There is support for `sharded_jit` and `pjit`.
 
+### SavedModel is large (contains a large amount of source information)
+
+The SavedModel obtained from a `jax2tf.convert`-ed function includes source
+location information. This ensures that the debugging experience is similar
+for JAX with XLA vs. `jax2tf.convert` with XLA. However, this debugging information
+increases the size of the SavedModel, even possibly doubling it. You can
+disable the generation of this metadata with the parameter
+`include_xla_op_metadata`.
+
+### SavedModel supports only first-order gradients
+
+The `jax2tf`-converted function supports higher-order gradients, but when the
+function is saved in a SavedModel, only the first-order gradient is saved.
+
 ### Converting gradients for integer-argument functions
 
 When JAX differentiates over functions with integer arguments, the gradients will

--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -29,6 +29,8 @@ config.parse_flags_with_absl()
 
 class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond(self):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
@@ -36,6 +38,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(f_jax, jnp.bool_(True), 1.)
     self.ConvertAndCompare(f_jax, jnp.bool_(False), 1.)
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_multiple_results(self):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
@@ -43,13 +47,16 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(f_jax, jnp.bool_(True), 1.)
     self.ConvertAndCompare(f_jax, jnp.bool_(False), 1.)
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_partial_eval(self):
     def f(x):
       res = lax.cond(True, lambda op: op * x, lambda op: op + x, x)
       return res
     self.ConvertAndCompare(jax.grad(f), 1.)
 
-
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_units(self):
     def g(x):
       return lax.cond(True, lambda x: x, lambda y: y, x)
@@ -57,7 +64,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.ConvertAndCompare(g, 0.7)
     self.ConvertAndCompare(jax.grad(g), 0.7)
 
-
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_custom_jvp(self):
     """Conversion of function with custom JVP, inside cond.
     This exercises the custom_jvp_call_jaxpr primitives."""
@@ -84,7 +92,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.TransformConvertAndCompare(g, arg, "grad")
     self.TransformConvertAndCompare(g, arg, "grad_vmap")
 
-
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_cond_custom_vjp(self):
     """Conversion of function with custom VJP, inside cond.
     This exercises the custom_vjp_call_jaxpr primitives."""
@@ -109,7 +118,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     self.TransformConvertAndCompare(g, arg, "vmap")
     self.TransformConvertAndCompare(g, arg, "grad_vmap")
 
-
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_while_single_carry(self):
     """A while with a single carry"""
     def func(x):
@@ -169,6 +179,8 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
 
     self.ConvertAndCompare(product_xs_ys, xs, ys)
 
+  @jtu.ignore_warning(category=UserWarning,
+                      message="Explicitly requested dtype .* requested in array is not available")
   def test_while_custom_jvp(self):
     """Conversion of function with custom JVP, inside while.
     This exercises the custom_jvp_call_jaxpr primitives."""
@@ -217,7 +229,6 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
       return c_out
 
     arg = np.arange(10, dtype=np.float32)
-    print(jax.make_jaxpr(jax.grad(f_jax))(arg, arg))
     self.ConvertAndCompare(jax.grad(f_jax), arg, arg)
 
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -79,6 +79,20 @@ def _make_array_shape(a):
   else:
     return (xc.Shape.array_shape(a.dtype, a.shape),)
 
+tracebacks = {}
+def make_op_metadata(primitive: core.Primitive,
+                     params: Dict, *,
+                     name_stack: str = "",
+                     source_info: Optional[source_info_util.Traceback] = None
+                     ) -> xc.OpMetadata:
+  tracebacks[str(pp(name_stack) >> pp_eqn_compact(primitive.name, params))] = source_info
+  frame = source_info_util.user_frame(source_info) if source_info else None
+  return xc.OpMetadata(
+        op_type=primitive.name,
+        op_name=str(pp(name_stack) >> pp_eqn_compact(primitive.name, params)),
+        source_file=frame.file_name if frame else None,
+        source_line=frame.line_num if frame else None)
+
 ### handlers
 
 xb.register_constant_handler(core.Unit, lambda c, *_: _make_unit_constant(c))
@@ -306,9 +320,8 @@ def _device_from_arg_devices(devices: Sequence[Optional[Device]]) -> Optional[De
 @cache()
 def primitive_computation(prim, axis_env, backend, tuple_args, *avals, **params):
   c = xb.make_computation_builder(f"primitive_computation_{prim.name}")
-  c.set_op_metadata(xc.OpMetadata(
-      op_type=prim.name,
-      op_name=str(pp_eqn_compact(prim.name, params))))
+  op_metadata = make_op_metadata(prim, params)
+  c.set_op_metadata(op_metadata)
   platform = xb.get_backend(backend).platform
   xla_args, _ = _xla_callable_args(c, avals, tuple_args)
   # return val always set as a side-effect on c
@@ -429,13 +442,10 @@ def jaxpr_subcomp(c, jaxpr, backend, axis_env, consts, name_stack, *args):
   _partitionmap(write, jaxpr.constvars, consts)
   _partitionmap(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    frame = source_info_util.user_frame(eqn.source_info)
-    c.set_op_metadata(xc.OpMetadata(
-        op_type=eqn.primitive.name,
-        op_name=str(pp(name_stack) >> pp_eqn_compact(
-            eqn.primitive.name, eqn.params)),
-        source_file=frame.file_name if frame else None,
-        source_line=frame.line_num if frame else None))
+    op_metadata = make_op_metadata(
+        eqn.primitive, eqn.params, name_stack=name_stack,
+        source_info=eqn.source_info)
+    c.set_op_metadata(op_metadata)
     in_nodes = _flatmap(read, eqn.invars)
     # TODO(jakevdp): migrate `translations` table to `translations_with_avals`
     if eqn.primitive in backend_specific_translations[platform]:


### PR DESCRIPTION
The goal is to ensure that the HLO that
jax2tf->TF/XLA generates has the same metadata as what JAX generates.
This includes `op_type`, `op_name`, and source information, which are
used for debugging and profiling.

In order to ensure that this metadata is carried from the JAX tracing
time to TF/XLA, we save the metadata in custom TF op attributes. These
attributes are automatically preserved through SavedModel. This relies
on a separate change in TF/XLA to look for these custom attributes
and override its default.

For the source information, we use pretty much the same code that
xla.py uses. HLO OpMetadata has room for only one source location.
JAX (xla.py) picks the top-most user frame, which is obtained by
filtering out the stack frames in the JAX source tree. When used
with jax2tf we also need to filter out stack frames in the
TensorFlow source tree.

The hardest part is to generate the `op_name`, which is a hierarchical
name with components separated by '/', e.g., `jax2tf(top_func)/while/cond/le`.
We carry the current `name_stack` in thread-local state. Unfortunately, there
is no easy way to share the exact code that achieves this in xla.py. At the
same time it is not crucial that we have exactly identical name stacks as in
JAX.

I attempted to also carry this state in the JAX `MainTrace`, but could not
fully control the name stack. E.g., when calling a jitted-function we
have to reuse the current `MainTrace` although we want to push an element
on the name stack.