### PR TITLE
rename v to vh

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -329,12 +329,12 @@ def pinv(a, rcond=None):
     max_rows_cols = max(a.shape[-2:])
     rcond = 10. * max_rows_cols * jnp.finfo(a.dtype).eps
   rcond = jnp.asarray(rcond)
-  u, s, v = svd(a, full_matrices=False)
+  u, s, vh = svd(a, full_matrices=False)
   # Singular values less than or equal to ``rcond * largest_singular_value``
   # are set to zero.
   cutoff = rcond[..., jnp.newaxis] * jnp.amax(s, axis=-1, keepdims=True, initial=-jnp.inf)
   s = jnp.where(s > cutoff, s, jnp.inf)
-  res = jnp.matmul(_T(v), jnp.divide(_T(u), s[..., jnp.newaxis]))
+  res = jnp.matmul(_T(vh), jnp.divide(_T(u), s[..., jnp.newaxis]))
   return lax.convert_element_type(res, a.dtype)
 
 


### PR DESCRIPTION
`svd` returns `u`, `s` and `vh`, not `v`.
This patch fixes the confusing naming of the local variable.