### PR TITLE
[jax2tf] Fix the 32/64-bit behavior to follow JAX rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ PLEASE REMEMBER TO CHANGE THE '..master' WITH AN ACTUAL TAG in GITHUB LINK.
 * Breaking changes:
 
 * Bug fixes:
+  * The {func}`jax2tf.convert` now ensures that it uses the same typing rules
+    for Python scalars and for choosing 32-bit vs. 64-bit computations
+    as JAX ({jax-issue}`#6883`).
   * The {func}`jax2tf.convert` now scopes the `enable_xla` conversion parameter
     properly to apply only during the just-in-time conversion
     ({jax-issue}`#6720`).
   * Fixed assertion failure in {func}`jax2tf.call_tf` when used with captured
     `tf.Variable` ({jax-issue}`#6572`).
-
-* Bug fixes:
   * The {func}`jax2tf.convert` now converts `lax.dot_general` using the
     `XlaDot` TensorFlow op, for better fidelity w.r.t. JAX numerical precision
     ({jax-issue}`#6717`).

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert, shape_as_value, split_to_logical_devices, PolyShape
+from .jax2tf import convert, dtype_of_val, shape_as_value, split_to_logical_devices, PolyShape
 from .call_tf import call_tf

--- a/jax/experimental/jax2tf/tests/control_flow_ops_test.py
+++ b/jax/experimental/jax2tf/tests/control_flow_ops_test.py
@@ -33,29 +33,29 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: t + 1., lambda f: f, x)
 
-    self.ConvertAndCompare(f_jax, jnp.bool_(True), jnp.float_(1.))
-    self.ConvertAndCompare(f_jax, jnp.bool_(False), jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(True), 1.)
+    self.ConvertAndCompare(f_jax, jnp.bool_(False), 1.)
 
   def test_cond_multiple_results(self):
     def f_jax(pred, x):
       return lax.cond(pred, lambda t: (t + 1., 1.), lambda f: (f + 2., 2.), x)
 
-    self.ConvertAndCompare(f_jax, jnp.bool_(True), jnp.float_(1.))
-    self.ConvertAndCompare(f_jax, jnp.bool_(False), jnp.float_(1.))
+    self.ConvertAndCompare(f_jax, jnp.bool_(True), 1.)
+    self.ConvertAndCompare(f_jax, jnp.bool_(False), 1.)
 
   def test_cond_partial_eval(self):
     def f(x):
       res = lax.cond(True, lambda op: op * x, lambda op: op + x, x)
       return res
-    self.ConvertAndCompare(jax.grad(f), jnp.float_(1.))
+    self.ConvertAndCompare(jax.grad(f), 1.)
 
 
   def test_cond_units(self):
     def g(x):
       return lax.cond(True, lambda x: x, lambda y: y, x)
 
-    self.ConvertAndCompare(g, jnp.float_(0.7))
-    self.ConvertAndCompare(jax.grad(g), jnp.float_(0.7))
+    self.ConvertAndCompare(g, 0.7)
+    self.ConvertAndCompare(jax.grad(g), 0.7)
 
 
   def test_cond_custom_jvp(self):
@@ -76,7 +76,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def g(x):
       return lax.cond(True, f, lambda y: y, x)
 
-    arg = jnp.float_(0.7)
+    arg = 0.7
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "jvp")
     self.TransformConvertAndCompare(g, arg, "vmap")
@@ -104,7 +104,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
     def g(x):
       return lax.cond(True, f, lambda y: y, x)
 
-    arg = jnp.float_(0.7)
+    arg = 0.7
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "vmap")
     self.TransformConvertAndCompare(g, arg, "grad_vmap")
@@ -117,7 +117,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
       #      for(i=x; i < 4; i++);
       return lax.while_loop(lambda c: c < 4, lambda c: c + 1, x)
 
-    self.ConvertAndCompare(func, jnp.int_(0))
+    self.ConvertAndCompare(func, 0)
 
   def test_while(self):
     # Some constants to capture in the conditional branches
@@ -189,7 +189,7 @@ class ControlFlowOpsTest(tf_test_util.JaxToTfTestCase):
                             lambda carry: (carry[0] + 1., f(carry[1])),
                             (0., x))
 
-    arg = jnp.float_(0.7)
+    arg = 0.7
     self.TransformConvertAndCompare(g, arg, None)
     self.TransformConvertAndCompare(g, arg, "jvp")
     self.TransformConvertAndCompare(g, arg, "vmap")

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -81,8 +81,9 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     def check_avals(*, args: Sequence[jax2tf.jax2tf.TfVal],
                     polymorphic_shapes: Sequence[Optional[Union[str, PS]]],
                     expected_avals: Sequence[core.ShapedArray]):
+      arg_dtypes = tuple(map(lambda a: jax2tf.jax2tf._to_jax_dtype(jax2tf.dtype_of_val(a)), args))
       avals, shape_env = jax2tf.jax2tf._args_to_avals_and_env(
-          args, polymorphic_shapes)  # The function under test
+          args, arg_dtypes, polymorphic_shapes)  # The function under test
       self.assertEqual(expected_avals, avals)
       # TODO: Check the shape_env
 


### PR DESCRIPTION
JAX and TensorFlow have different behavior w.r.t. 32-64 bit
computations. This PR cleans up the handling of types in jax2tf
to ensure that we follow the same behavior in jax2tf and in JAX.

This means that f_jax(args) always does the computation with the
same precision as jax2tf.convert(f_jax)(args). This may mean that
the result of the conversion depends on the value of JAX_ENABLE_x64.

See README.md for more details.