### PR TITLE
Delay formatting of the name stack in translation rules

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -54,7 +54,7 @@ from ..tree_util import (tree_map, tree_flatten, tree_unflatten, tree_structure,
                         tree_transpose, tree_leaves, tree_multimap,
                         treedef_is_leaf, treedef_children, Partial)
 from .util import (unzip2, curry, partial, safe_map, safe_zip, prod,
-                        split_list, extend_name_stack, wrap_name, cache, wraps,
+                        split_list, wrap_name, cache, wraps,
                         HashableFunction)
 from ..lib import jax_jit
 from ..lib import version
@@ -737,7 +737,7 @@ def xla_computation(fun: Callable,
         c, avals, should_tuple, partitions=in_parts_flat, donated_invars=donated_invars)
     out_nodes = xla.jaxpr_subcomp(
         c, jaxpr, backend, axis_env_, xla_consts,
-        extend_name_stack(wrap_name(fun_name, "xla_computation")), *xla_args)
+        xla.NameStack.init("xla_computation", fun_name), *xla_args)
     build_out_tuple = partial(xc.ops.Tuple, c, out_nodes)
     if out_parts is not None:
       out_tuple = xb.with_sharding(c, out_parts_flat, build_out_tuple)

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -588,6 +588,7 @@ def make_xmap_callable(fun: lu.WrappedFun,
     submesh = resource_env.physical_mesh[sorted(used_mesh_axes, key=str)]
     mesh_in_axes, mesh_out_axes = plan.to_mesh_axes(in_axes, out_axes)
     return pxla.mesh_callable(f,
+                              xmap_p,
                               name,
                               backend,
                               submesh,
@@ -1017,7 +1018,7 @@ def _xmap_translation_rule_replica(c, axis_env,
   # translation rule just because the extra tuple stuff is a pain.
   tiled_outs = xla.jaxpr_subcomp(
       c, vectorized_jaxpr, backend, axis_env, (),
-      xla.extend_name_stack(name_stack, xla.wrap_name(name, 'xmap')), *tiled_ins)
+      name_stack.extend(xmap_p, name), *tiled_ins)
 
   outs = [_xla_untile(c, axis_env, tiled_out, ans_out_axes, local_mesh_shape, backend)
           if v.aval is not core.abstract_unit else tiled_out
@@ -1133,7 +1134,7 @@ def _xmap_translation_rule_spmd(c, axis_env,
   # translation rule just because the extra tuple stuff is a pain.
   global_out_nodes = xla.jaxpr_subcomp(
       c, vectorized_jaxpr, backend, axis_env, (),
-      xla.extend_name_stack(name_stack, xla.wrap_name(name, 'xmap')),
+      name_stack.extend(xmap_p, name),
       *sharded_global_in_nodes)
 
   sharded_global_out_nodes = [

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -38,7 +38,7 @@ from ..interpreters import partial_eval as pe
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from ..tree_util import tree_flatten, tree_unflatten
-from .._src.util import (extend_name_stack, HashableFunction, safe_zip,
+from .._src.util import (HashableFunction, safe_zip,
                          wrap_name, wraps, distributed_debug_log,
                          split_list, cache, tuple_insert)
 xops = xc._xla.ops
@@ -407,7 +407,7 @@ def pjit_callable(
   local_in_avals = global_to_local(resource_env.physical_mesh,
                                    jaxpr.in_avals, in_axis_resources)
   # TODO(skye): allow for using a submesh of physical_mesh
-  return pxla.mesh_callable(fun, name, None, resource_env.physical_mesh,
+  return pxla.mesh_callable(fun, pjit_p, name, None, resource_env.physical_mesh,
                             in_axes, out_axes, donated_invars,
                             True, *local_in_avals, tile_by_mesh_axes=False,
                             do_resource_typecheck="pjit")
@@ -437,7 +437,7 @@ def _pjit_translation_rule(c, axis_env, in_nodes, name_stack, backend, name,
   # TODO: Think about how to avoid duplicating constants with the outer jaxpr
   out_nodes = xla.jaxpr_subcomp(
       subc, jaxpr.jaxpr, backend, axis_env, xla._xla_consts(subc, jaxpr.consts),
-      extend_name_stack(name_stack, wrap_name(name, "pjit")), *args)
+      name_stack.extend(pjit_p, name), *args)
   out_nodes = [
       xb.set_sharding_proto(subc, out,
                             get_sharding_proto(subc, out, axis_resources, mesh))

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -47,8 +47,8 @@ from jax._src.abstract_arrays import array_types
 from ..core import ConcreteArray, ShapedArray
 from .._src import source_info_util
 from .._src.util import (partial, unzip3, prod, safe_map, safe_zip,
-                         extend_name_stack, wrap_name, assert_unreachable,
-                         tuple_insert, tuple_delete, distributed_debug_log)
+                         assert_unreachable, tuple_insert, tuple_delete,
+                         distributed_debug_log)
 from ..errors import JAXTypeError
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
@@ -791,7 +791,7 @@ def parallel_callable(fun: lu.WrappedFun,
                                                     donated_invars=donated_invars)
   with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
     out_nodes = xla.jaxpr_subcomp(c, jaxpr, backend_name, axis_env, xla_consts,
-                                  extend_name_stack(wrap_name(name, 'pmap')), *xla_args)
+                                  xla.NameStack.init(xla_pmap_p, name), *xla_args)
   build_out_tuple = partial(xops.Tuple, c, out_nodes)
   if out_parts is not None:
     out_tuple = xb.with_sharding(c, out_parts, build_out_tuple)
@@ -1188,7 +1188,7 @@ def _pmap_translation_rule(c, axis_env,
   with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
     sharded_outs = xla.jaxpr_subcomp(
         c, call_jaxpr, backend, new_env, (),
-        extend_name_stack(name_stack, wrap_name(name, 'pmap')), *in_nodes_sharded)
+        name_stack.extend(xla_pmap_p, name), *in_nodes_sharded)
   out_avals = [v.aval for v in call_jaxpr.outvars]
   outs = [_xla_unshard(c, aval, new_env, out_axis, shard, backend=backend)
           for aval, out_axis, shard in safe_zip(out_avals, out_axes, sharded_outs)]
@@ -1424,6 +1424,7 @@ def vtile_by_mesh(fun: lu.WrappedFun,
   return fun
 
 def mesh_callable(fun: lu.WrappedFun,
+                  primitive: core.Primitive,
                   transformed_name: str,
                   backend_name: Optional[str],
                   mesh: Mesh,
@@ -1508,7 +1509,7 @@ def mesh_callable(fun: lu.WrappedFun,
   with core.extend_axis_env_nd(mesh.shape.items()):
     out_nodes = xla.jaxpr_subcomp(
         c, jaxpr, backend_name, axis_env, xla_consts,
-        extend_name_stack(wrap_name(transformed_name, 'xmap')), *xla_args)
+        xla.NameStack.init(primitive, transformed_name), *xla_args)
   backend = xb.get_backend(backend_name)
   if spmd_lowering:
     out_partitions_t = xb.tuple_sharding_proto(out_partitions)

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -82,9 +82,9 @@ class MetadataTest(jtu.JaxTestCase):
     self.assertRegex(hlo, 'op_type="cond"')
     self.assertRegex(hlo, 'op_name=".*cond\\[ linear=\\(False, False\\) \\]"')
     self.assertRegex(hlo, 'op_type="cos"')
-    self.assertRegex(hlo, 'op_name=".*cond/branch_0_fun/cos"')
+    self.assertRegex(hlo, 'op_name=".*cond\\(branch_0_fun\\)/cos"')
     self.assertRegex(hlo, 'op_type="sin"')
-    self.assertRegex(hlo, 'op_name=".*cond/branch_1_fun/sin"')
+    self.assertRegex(hlo, 'op_name=".*cond\\(branch_1_fun\\)/sin"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now the name stack can store the stack of primitives inside which a
given translation rule is called. We can use this to provide more
informative errors and warnings for unsupported configurations of
primitives that cause XLA compilation (think `pmap` in `xmap`,
`with_sharing_constraint` in `jit`, etc.)