### PR TITLE
Add unique/sorted annotations to gather().

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -102,7 +102,7 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
   )
   out = scatter_op(x, indexer.gather_indices, y, dnums,
                    indices_are_sorted=indices_are_sorted,
-                   unique_indices=unique_indices)
+                   unique_indices=indexer.unique_indices or unique_indices)
   return lax.convert_element_type(out, dtype)
 
 

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2169,6 +2169,7 @@ def _gather_dimensions_proto(indices_shape, dimension_numbers):
 
 @partial(bool_to_int8, argnums=0)
 def _gather(operand, start_indices, *, dimension_numbers, slice_sizes,
+            indices_are_sorted, unique_indices,
             _in_avals, _out_aval):
   """Tensorflow implementation of gather."""
   del _in_avals


### PR DESCRIPTION
XLA itself does not consume these, but they can be propagated onto scatter() when computing gradients.

Compute unique/sorted information on indexed accesses and indexed updates. Non-advanced indexes are always sorted and unique.

This may or may not help with issue #6872 