### PR TITLE
jnp.where: add optional size argument

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1704,14 +1704,19 @@ _WHERE_DOC = """\
 At present, JAX does not support JIT-compilation of the single-argument form
 of :py:func:`jax.numpy.where` because its output shape is data-dependent. The
 three-argument form does not have a data-dependent shape and can be JIT-compiled
-successfully.
+successfully. Alternatively, you can specify the optional ``size`` keyword:
+if specified, the first ``size`` True elements will be returned; if there
+are fewer True elements than ``size`` indicates, the index arrays will be
+padded with zeros.
 """
 
 @_wraps(np.where, update_doc=False, lax_description=_WHERE_DOC)
-def where(condition, x=None, y=None):
+def where(condition, x=None, y=None, *, size=None):
   if x is None and y is None:
-    return nonzero(asarray(condition))
+    return nonzero(asarray(condition), size=size)
   else:
+    if size is not None:
+      raise ValueError("size argument cannot be used in three-term where function.")
     return _where(condition, x, y)
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4221,6 +4221,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
+    # JIT compilation requires specifying a size statically. Full test of
+    # this behavior is in testNonzeroSize().
+    jnp_fun = lambda x: jnp.where(x, size=np.size(x) // 2)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
       "testcase_name": "_{}".format("_".join(
         jtu.format_shape_dtype_string(shape, dtype)


### PR DESCRIPTION
Part of #3614; uses #6501