### PR TITLE
Fix typo/formatting issue in DeviceArray docs

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -454,7 +454,7 @@ JAX DeviceArray
 The JAX :class:`~jax.numpy.DeviceArray` is the core array object in JAX: you can
 think of it as the equivalent of a :class:`numpy.ndarray` backed by a memory buffer
 on a single device. Like :class:`numpy.ndarray`, most users will not need to
-instantiate :class:`DeviceArray`s manually, but rather will create them via
+instantiate :class:`DeviceArray` objects manually, but rather will create them via
 :mod:`jax.numpy` functions like :func:`~jax.numpy.array`, :func:`~jax.numpy.arange`,
 :func:`~jax.numpy.linspace`, and others listed above.
 


### PR DESCRIPTION
Existing version has some parsing/formatting issues due to the back tick appearing in the middle of the string:

![Screen Shot 2021-06-07 at 1 12 07 PM](https://user-images.githubusercontent.com/781659/121081809-110ab880-c792-11eb-92af-b1b651680bbe.png)
