### PR TITLE
DOC: state that digamma only accepts float

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -48,7 +48,8 @@ def betainc(a, b, x):
   return lax.betainc(a, b, x)
 
 
-@_wraps(osp_special.digamma, update_doc=False)
+@_wraps(osp_special.digamma, lax_description="""\
+The JAX version only accepts real-valued inputs.""")
 def digamma(x):
   x, = _promote_args_inexact("digamma", x)
   return lax.digamma(x)


### PR DESCRIPTION
Related to this StackOverflow question: https://stackoverflow.com/questions/67891773/how-to-compute-digamma-function-in-complex-numbers-in-order-to-use-this-function