### PR TITLE
Simplify multi slice implementation

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5954,7 +5954,7 @@ def _multi_slice(arr,
   for starts, limits, removed in safe_zip(start_indices, limit_indices, removed_dims):
     sliced = lax.slice(arr, starts, limits)
     if removed:
-      sliced = sliced.reshape(np.delete(sliced.shape, removed_dims))
+      sliced = lax.squeeze(sliced, removed)
     results.append(sliced)
   return results
 setattr(_DeviceArray, "_multi_slice", _multi_slice)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -348,8 +348,8 @@ for _t in array_types:
   shard_arg_handlers[_t] = _shard_array
 
 def _shard_device_array(x, devices, indices):
-  start_indices, limit_indices, removed_dims = map(tuple, unzip3(
-      _as_slice_indices(x, idx) for idx in indices))
+  start_indices, limit_indices, removed_dims = unzip3(
+      _as_slice_indices(x, idx) for idx in indices)
   shards = x._multi_slice(start_indices, limit_indices, removed_dims)
   return device_put(shards, devices)
 shard_arg_handlers[xla._DeviceArray] = _shard_device_array


### PR DESCRIPTION
This PR simplifies the multi slice implementation by switching from `lax.reshape` to `lax.squeeze` for removing dimensions.