### PR TITLE
Set zip_safe=False in setuptools.setup for mypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-    ]
+    ],
+    zip_safe=False,
 )


### PR DESCRIPTION
MyPy requires setting `zip_safe` to `False` in `setuptools.setup` for PEP-561 compliance (mentioned in the note [here](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages)).