### PR TITLE
Pin the tpu_driver version used for Cloud TPU Colabs, instead of using nightly.

### DIFF
--- a/jax/tools/colab_tpu.py
+++ b/jax/tools/colab_tpu.py
@@ -32,7 +32,7 @@ def setup_tpu():
 
   if not TPU_DRIVER_MODE:
     colab_tpu_addr = os.environ['COLAB_TPU_ADDR'].split(':')[0]
-    url = f'http://{colab_tpu_addr}:8475/requestversion/tpu_driver_nightly'
+    url = f'http://{colab_tpu_addr}:8475/requestversion/tpu_driver0.1-dev20210603'
     requests.post(url)
     TPU_DRIVER_MODE = 1
 


### PR DESCRIPTION
There have been some recent breakages affecting the nightly driver,
causing JAX operations to fail on Cloud TPU Colabs. Pinning to a
specific version will alleviate these problems. This version may need
to be updated if there are breaking changes to the tpu_driver
client/server boundary, but that doesn't happen very often.