### PR TITLE
bcoo_todense: fix corner case

### DIFF
--- a/jax/experimental/sparse_ops.py
+++ b/jax/experimental/sparse_ops.py
@@ -639,8 +639,8 @@ def _bcoo_todense_impl(data, indices, *, shape):
   batch_slices = tuple(slice(s) for s in shape[:n_batch])
   sparse_ind = tuple(indices[tuple(np.mgrid[batch_slices]) + (i,)] for i in range(n_sparse))
   batch_ind = tuple(np.mgrid[batch_slices + (slice(1),)])[:-1]
-  if not (batch_ind or sparse_ind):
-    return data[0]
+  if not sparse_ind:
+    data = data.sum(n_batch, keepdims=bool(batch_ind))
   return jnp.zeros(shape, data.dtype).at[batch_ind + sparse_ind].add(data)
 
 @bcoo_todense_p.def_abstract_eval


### PR DESCRIPTION
Fixes for cases with `n_sparse=0` and duplicate entries; e.g.
```python
import jax.numpy as jnp
from jax.experimental.sparse_ops import bcoo_todense

data = jnp.arange(12)
indices = jnp.zeros((0, 12), dtype=int)
print(bcoo_todense(data, indices, shape=()))
# 66

data = jnp.arange(12).reshape(2, 6)
indices = jnp.zeros((2, 0, 6), dtype=int)
print(bcoo_todense(data, indices, shape=(2,)))
# [15 51]
```