### PR TITLE
jnp.concatenate: add fast path based on lax.reshape for array inputs

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2000,6 +2000,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": "_{}_axis={}".format(
+          jtu.format_shape_dtype_string(shape, dtype), axis),
+        "shape": shape, "dtype": dtype, "axis": axis}
+      for shape in [(4, 1), (4, 3), (4, 5, 6)]
+      for dtype in all_dtypes
+      for axis in [None] + list(range(1 - len(shape), len(shape) - 1))))
+  def testConcatenateArray(self, shape, dtype, axis):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    np_fun = lambda x: np.concatenate(x, axis=axis)
+    jnp_fun = lambda x: jnp.concatenate(x, axis=axis)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   def testConcatenateAxisNone(self):
     # https://github.com/google/jax/issues/3419
     a = jnp.array([[1, 2], [3, 4]])


### PR DESCRIPTION
Part of #6859

This avoids host round-trip  and excess slicing when an array is passed to `jnp.concatenate`. As a followup, I plan to make functions like `hstack`, `vstack`, `dstack`, etc. take advantage of this fast path.

Simple test script:
```python
from jax import make_jaxpr
import jax.numpy as jnp
print(make_jaxpr(jnp.concatenate)(jnp.zeros((10, 5))))
```
jaxpr with this PR:
```
{ lambda  ; a.
  let b = reshape[ dimensions=None
                   new_sizes=(50,) ] a
  in (b,) }
```
jaxpr before:
```
{ lambda  ; a.
  let b = slice[ limit_indices=(1, 5)
                 start_indices=(0, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] b
      c = slice[ limit_indices=(2, 5)
                 start_indices=(1, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] c
      d = slice[ limit_indices=(3, 5)
                 start_indices=(2, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] d
      e = slice[ limit_indices=(4, 5)
                 start_indices=(3, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] e
      f = slice[ limit_indices=(5, 5)
                 start_indices=(4, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] f
      g = slice[ limit_indices=(6, 5)
                 start_indices=(5, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] g
      h = slice[ limit_indices=(7, 5)
                 start_indices=(6, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] h
      i = slice[ limit_indices=(8, 5)
                 start_indices=(7, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] i
      j = slice[ limit_indices=(9, 5)
                 start_indices=(8, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] j
      k = slice[ limit_indices=(10, 5)
                 start_indices=(9, 0)
                 strides=(1, 1) ] a
      _ = squeeze[ dimensions=(0,) ] k
      l = lt 0 0
      m = add 0 10
      n = select l m 0
      o = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(1,) ] n
      p = gather[ dimension_numbers=GatherDimensionNumbers(offset_dims=(0,), collapsed_slice_dims=(0,), start_index_map=(0,))
                  indices_are_sorted=True
                  slice_sizes=(1, 5)
                  unique_indices=True ] a o
      _ = broadcast_in_dim[ broadcast_dimensions=(0,)
                            shape=(5,) ] p
      q = lt 0 0
      r = add 0 10
      s = select q r 0
      t = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(1,) ] s
      u = gather[ dimension_numbers=GatherDimensionNumbers(offset_dims=(0,), collapsed_slice_dims=(0,), start_index_map=(0,))
                  indices_are_sorted=True
                  slice_sizes=(1, 5)
                  unique_indices=True ] a t
      _ = broadcast_in_dim[ broadcast_dimensions=(0,)
                            shape=(5,) ] u
      v = slice[ limit_indices=(1, 5)
                 start_indices=(0, 0)
                 strides=(1, 1) ] a
      w = squeeze[ dimensions=(0,) ] v
      x = slice[ limit_indices=(2, 5)
                 start_indices=(1, 0)
                 strides=(1, 1) ] a
      y = squeeze[ dimensions=(0,) ] x
      z = slice[ limit_indices=(3, 5)
                 start_indices=(2, 0)
                 strides=(1, 1) ] a
      ba = squeeze[ dimensions=(0,) ] z
      bb = slice[ limit_indices=(4, 5)
                  start_indices=(3, 0)
                  strides=(1, 1) ] a
      bc = squeeze[ dimensions=(0,) ] bb
      bd = slice[ limit_indices=(5, 5)
                  start_indices=(4, 0)
                  strides=(1, 1) ] a
      be = squeeze[ dimensions=(0,) ] bd
      bf = slice[ limit_indices=(6, 5)
                  start_indices=(5, 0)
                  strides=(1, 1) ] a
      bg = squeeze[ dimensions=(0,) ] bf
      bh = slice[ limit_indices=(7, 5)
                  start_indices=(6, 0)
                  strides=(1, 1) ] a
      bi = squeeze[ dimensions=(0,) ] bh
      bj = slice[ limit_indices=(8, 5)
                  start_indices=(7, 0)
                  strides=(1, 1) ] a
      bk = squeeze[ dimensions=(0,) ] bj
      bl = slice[ limit_indices=(9, 5)
                  start_indices=(8, 0)
                  strides=(1, 1) ] a
      bm = squeeze[ dimensions=(0,) ] bl
      bn = slice[ limit_indices=(10, 5)
                  start_indices=(9, 0)
                  strides=(1, 1) ] a
      bo = squeeze[ dimensions=(0,) ] bn
      bp = concatenate[ dimension=0 ] w y ba bc be bg bi bk bm bo
  in (bp,) }
```