### PR TITLE
[jax2tf] Add a best-effort conversion for gather with enable_xla=False

### DIFF
--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support for jax2tf
 
-*Last generated on (YYYY-MM-DD): 2021-06-14*
+*Last generated on (YYYY-MM-DD): 2021-06-15*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -85,7 +85,6 @@ More detailed information can be found in the
 | erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | erfc | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | fft | TF error: TF function not compileable | complex128, float64 | cpu, gpu | compiled |
-| gather | TF error: TF function aborts for index out-of-bounds, when enable_xla=False | all | cpu, gpu | eager, graph |
 | igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu | graph |

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -85,6 +85,7 @@ More detailed information can be found in the
 | erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | erfc | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | fft | TF error: TF function not compileable | complex128, float64 | cpu, gpu | compiled |
+| gather | TF error: TF function aborts for index out-of-bounds, when enable_xla=False | all | cpu, gpu | eager, graph |
 | igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu | graph |

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -128,7 +128,7 @@ class Jax2TfLimitation(primitive_harness.Limitation):
       "bitcast_convert_type", "broadcast", "broadcast_in_dim", "ceil", "clamp",
       "concatenate", "cos", "cosh", "complex", "conj", "convert_element_type",
       "cummax", "cummin", "device_put", "dynamic_slice",
-      "dynamic_update_slice", "exp", "eq", "floor", "ge", "gt", "imag",
+      "dynamic_update_slice", "exp", "eq", "floor", "gather", "ge", "gt", "imag",
       "iota", "is_finite", "le", "lt", "log", "mul", "ne", "neg", "not",
       "or", "pad", "population_count", "random_split",
       "reduce_and", "reduce_prod", "reduce_or", "reduce_sum",
@@ -598,25 +598,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             modes="compiled"),
         # TODO: very high tolerance
         custom_numeric(tol=1e-3, modes=("eager", "graph", "compiled")),
-    ]
-
-  @classmethod
-  def gather(cls, harness):
-    return [
-        Jax2TfLimitation(
-            "TF function aborts for index out-of-bounds, when enable_xla=False",
-            devices="cpu",
-            modes=("eager", "graph"),
-            enabled=(not harness.params["enable_xla"] and harness.params.get("index_oob", False))),
-        # On GPU, it seems that tf.gather returns 0s for OOB indices in eager
-        # and graph modes.
-        # TODO: Remove when we implement OOB index handling
-        custom_numeric(
-            description="TF produces different results for index out-of-bounds, when enable_xla=False",
-            devices="gpu",
-            modes=("eager", "graph"),
-            custom_assert=lambda *_, **__: None,  # Just skip the comparison
-            enabled=(not harness.params["enable_xla"] and harness.params.get("index_oob", False))),
     ]
 
   @classmethod

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1114,63 +1114,68 @@ for dtype in set(jtu.dtypes.all):
   axis = 0
   define(
       lax.gather_p,
-      f"dtypes_shape={jtu.format_shape_dtype_string(shape, dtype)}_axis={axis}",
+      f"dtypes_shape={jtu.format_shape_dtype_string(shape, dtype)}_axis={axis}_enable_xla=True",
       lambda a, i, axis: jnp.take(a, i, axis=axis),
       [RandArg(shape, dtype), indices,
        StaticArg(axis)],
-      dtype=dtype)
+      dtype=dtype,
+      enable_xla=True)
 
 # Construct gather harnesses using take
 _gather_input = np.arange(1000, dtype=np.float32).reshape((10, 10, 10))
-for indices in [
+for indices, index_oob in [
     # Ensure each set of indices has a distinct shape
-    np.array(2, dtype=np.int32),
-    np.array([2], dtype=np.int32),
-    np.array([2, 4], dtype=np.int32),
-    np.array([[2, 4], [5, 6]], dtype=np.int32),
-    np.array([0, 1, 10], dtype=np.int32),  # Index out of bounds
-    np.array([0, 1, 2, -1], dtype=np.int32),  # Index out of bounds
+    (np.array(2, dtype=np.int32), False),
+    (np.array([2], dtype=np.int32), False),
+    (np.array([2, 4], dtype=np.int32), False),
+    (np.array([[2, 4], [5, 6]], dtype=np.int32), False),
+    (np.array([0, 1, 10], dtype=np.int32), True), # Index out of bounds too high
+    (np.array([0, 1, 2, -1], dtype=np.int32), False), # Index out of bounds, but works
+    (np.array([0, 1, 2, 3, -10], dtype=np.int32), False), # Index out of bounds, but works
+    (np.array([0, 1, 2, 3, 4, -11], dtype=np.int32), True)  # Index out of bounds, too low
 ]:
   for axis in [0, 1, 2]:
-    define(
-        lax.gather_p,
-        f"from_take_indices_shape={indices.shape}_axis={axis}",
-        lambda a, i, axis: jnp.take(a, i, axis=axis),
-        [_gather_input, indices, StaticArg(axis)],
-        dtype=_gather_input.dtype)
+    for enable_xla in [True, False]:
+      define(
+          lax.gather_p,
+          f"from_take_indices_shape={indices.shape}_axis={axis}_enable_xla={enable_xla}",
+          lambda a, i, axis: jnp.take(a, i, axis=axis),
+          [_gather_input, indices, StaticArg(axis)],
+          dtype=_gather_input.dtype,
+          enable_xla=enable_xla,
+          index_oob=index_oob)
 
 # Directly from lax.gather in lax_test.py.
-for shape, idxs, dnums, slice_sizes in [
+for shape, idxs, dnums, slice_sizes, needs_xla in [
     ((5,), np.array([[0], [2]]),
      lax.GatherDimensionNumbers(
          offset_dims=(), collapsed_slice_dims=(0,),
-         start_index_map=(0,)), (1,)),
+         start_index_map=(0,)), (1,), False),
     ((10,), np.array([[0], [0], [0]]),
      lax.GatherDimensionNumbers(
          offset_dims=(1,), collapsed_slice_dims=(),
-         start_index_map=(0,)), (2,)),
-    ((
-        10,
-        5,
-    ), np.array([[0], [2], [1]]),
+         start_index_map=(0,)), (2,), True),
+    ((10, 5,), np.array([[0], [2], [1]]),
      lax.GatherDimensionNumbers(
          offset_dims=(1,), collapsed_slice_dims=(0,),
-         start_index_map=(0,)), (1, 3)),
-    ((10, 5), np.array([[0, 2], [1, 0]]),
+         start_index_map=(0,)), (1, 3), True),
+    ((10, 6), np.array([[0, 2], [1, 0]]),
      lax.GatherDimensionNumbers(
          offset_dims=(1,), collapsed_slice_dims=(0,),
-         start_index_map=(0, 1)), (1, 3)),
+         start_index_map=(0, 1)), (1, 3), True),
 ]:
   dtype = np.float32
-  define(
-      lax.gather_p,
-      f"_shape={shape}_idxs_shape={idxs.shape}_dnums={dnums}_slice_sizes={slice_sizes}",
-      lambda op, idxs, dnums, slice_sizes: lax.gather(
-          op, idxs, dimension_numbers=dnums, slice_sizes=slice_sizes),
-      [RandArg(shape, dtype), idxs,
-       StaticArg(dnums),
-       StaticArg(slice_sizes)],
-      dtype=dtype)
+  for enable_xla in ([True] if needs_xla else [True, False]):
+    define(
+        lax.gather_p,
+        f"shape={shape}_idxs_shape={idxs.shape}_dnums={dnums}_slice_sizes={slice_sizes}_enable_xla={enable_xla}",
+        lambda op, idxs, dnums, slice_sizes: lax.gather(
+            op, idxs, dimension_numbers=dnums, slice_sizes=slice_sizes),
+        [RandArg(shape, dtype), idxs,
+         StaticArg(dnums),
+         StaticArg(slice_sizes)],
+        dtype=dtype,
+        enable_xla=enable_xla)
 
 
 def _make_scatter_harness(name,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1123,22 +1123,22 @@ for dtype in set(jtu.dtypes.all):
 
 # Construct gather harnesses using take
 _gather_input = np.arange(1000, dtype=np.float32).reshape((10, 10, 10))
-for indices, index_oob in [
-    # Ensure each set of indices has a distinct shape
-    (np.array(2, dtype=np.int32), False),
-    (np.array([2], dtype=np.int32), False),
-    (np.array([2, 4], dtype=np.int32), False),
-    (np.array([[2, 4], [5, 6]], dtype=np.int32), False),
-    (np.array([0, 1, 10], dtype=np.int32), True), # Index out of bounds too high
-    (np.array([0, 1, 2, -1], dtype=np.int32), False), # Index out of bounds, but works
-    (np.array([0, 1, 2, 3, -10], dtype=np.int32), False), # Index out of bounds, but works
-    (np.array([0, 1, 2, 3, 4, -11], dtype=np.int32), True)  # Index out of bounds, too low
+for indices, index_oob, indices_name in [
+    # Ensure each set of indices has a distinct name
+    (np.array(2, dtype=np.int32), False, "1"),
+    (np.array([2], dtype=np.int32), False, "2"),
+    (np.array([2, 4], dtype=np.int32), False, "3"),
+    (np.array([[2, 4], [5, 6]], dtype=np.int32), False, "4"),
+    (np.array([[0], [1], [10]], dtype=np.int32), True, "5_oob"), # Index out of bounds too high
+    (np.array([[0, 1], [2, -1]], dtype=np.int32), False, "6_neg"), # Negative index is from the end
+    (np.array([0, 1, 2, 3, -10], dtype=np.int32), False, "7_neg"), # Index out of bounds, but works
+    (np.array([[[0], [1]], [[3], [-11]]], dtype=np.int32), True, "8_neg_oob")  # Index out of bounds, too low
 ]:
   for axis in [0, 1, 2]:
     for enable_xla in [True, False]:
       define(
           lax.gather_p,
-          f"from_take_indices_shape={indices.shape}_axis={axis}_enable_xla={enable_xla}",
+          f"from_take_indices_name={indices_name}_axis={axis}_enable_xla={enable_xla}",
           lambda a, i, axis: jnp.take(a, i, axis=axis),
           [_gather_input, indices, StaticArg(axis)],
           dtype=_gather_input.dtype,

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -954,16 +954,6 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   [RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
                   poly_axes=[1, 0]),
 
-    _make_harness("jnp_take", "",
-                  lambda a, i: jnp.take(a, i, axis=1),
-                  [RandArg((3, 4, 5), _f32), np.array([1, 2], np.int32)],
-                  poly_axes=[0, None]),
-
-    _make_harness("jnp_getitem", "",
-                  lambda a, i: a[i],
-                  [RandArg((3, 4), _f32), np.array([2, 2], np.int32)],
-                  poly_axes=[None, 0]),
-
     # TODO(necula): not supported yet
     # _make_harness("jnp_getitem", "",
     #               lambda a, i: a[i],
@@ -1082,14 +1072,24 @@ _POLY_SHAPE_TEST_HARNESSES = [
 ]
 
 for enable_xla in [False, True]:
-  _POLY_SHAPE_TEST_HARNESSES.append(
-      _make_harness(f"dynamic_slice_enablexla={enable_xla}", "",
+  _POLY_SHAPE_TEST_HARNESSES.extend([
+      _make_harness("dynamic_slice", f"enable_xla={enable_xla}",
                     # x:shape: (b, 4)
                     lambda x: lax.dynamic_slice(x, (0, 1), (x.shape[0], 2)),
                     [RandArg((3, 4), _f32)],
                     poly_axes=[0],
-                    enable_xla=enable_xla)
- )
+                    enable_xla=enable_xla),
+
+      _make_harness("jnp_take", f"enable_xla={enable_xla}",
+                    lambda a, i: jnp.take(a, i, axis=1),
+                    [RandArg((3, 4, 5), _f32), np.array([1, 2], np.int32)],
+                    poly_axes=[0, None], enable_xla=enable_xla),
+
+      _make_harness("jnp_getitem", f"enable_xla={enable_xla}",
+                    lambda a, i: a[i],
+                    [RandArg((3, 4), _f32), np.array([2, 2], np.int32)],
+                    poly_axes=[None, 0], enable_xla=enable_xla),
+ ])
 
 for reduce_op in [jnp.all, jnp.any, jnp.max, jnp.min, jnp.prod, jnp.sum]:
   _POLY_SHAPE_TEST_HARNESSES.append(


### PR DESCRIPTION
In an attempt to support lax.gather in absence of XLA, e.g., for
TFjs converter, we add an alternative conversion for the case
when enable_xla=False. Previously, the conversion would fail in this case.

The important parts of the code are lifeted from an old PR #3486, which was
then removed in #4030 (to avoid having to think about out-of-bounds accesses).

Now we added clipping of the indices so the behavior should match XLA.