### PR TITLE
Add jaxlib version check on newly-added NumpyLinalgTest.testEighZeroDiagonal test.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -356,6 +356,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     self._CompileAndCheck(partial(jnp.linalg.eigh, UPLO=uplo), args_maker,
                           rtol=1e-3)
 
+  @unittest.skipIf(jax.lib.version < (0, 1, 68), "fails with earlier jaxlibs")
   def testEighZeroDiagonal(self):
     a = np.array([[0., -1., -1.,  1.],
                   [-1.,  0.,  1., -1.],


### PR DESCRIPTION
This is testing behavior recently added to jaxlib, so fails on older jaxlibs.