### PR TITLE
[sparse] move experimental/sparse_ops.py to experimental/sparse/ops.py

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa: F401
+from .ops import (
+    bcoo_dot_general,
+    bcoo_extract,
+    bcoo_fromdense,
+    bcoo_reduce_sum,
+    bcoo_rdot_general,
+    bcoo_todense,
+    coo_fromdense,
+    coo_matmat,
+    coo_matvec,
+    coo_todense,
+    csr_fromdense,
+    csr_matmat,
+    csr_matvec,
+    csr_todense,
+    COO,
+    CSC,
+    CSR,
+    BCOO,
+)

--- a/jax/experimental/sparse/ops.py
+++ b/jax/experimental/sparse/ops.py
@@ -16,10 +16,9 @@
 
 This is experimental work to explore sparse support in JAX.
 
-The primitives defined here are deliberately low-level: i.e. for now there is
-no JAX CSR or COO matrix class. Each primitive implements a common sparse
-operation (sparse to dense, dense to sparse, sparse matrix/vector product,
-sparse matrix/matrix product) for two common sparse representations
+The primitives defined here are deliberately low-level: each primitive implements
+a common sparse operation (sparse to dense, dense to sparse, sparse matrix/vector
+product, sparse matrix/matrix product) for two common sparse representations
 (CSR and COO).
 
 These routines have reference implementations defined via XLA scatter/gather


### PR DESCRIPTION
Moves `jax/experimental/sparse_ops.py` to `jax/experimental/sparse/ops.py`, with public-ish imports from `jax.experimental.sparse`.

Why? This project is growing too large for a single file, particularly with the work on the sparsify transform in #6929 