### PR TITLE
[sparse] add dot_general_sampled primitive

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -17,6 +17,8 @@ from .ad import grad, value_and_grad
 from .ops import (
     bcoo_dot_general,
     bcoo_dot_general_p,
+    bcoo_dot_general_sampled,
+    bcoo_dot_general_sampled_p,
     bcoo_extract,
     bcoo_extract_p,
     bcoo_fromdense,


### PR DESCRIPTION
This primitive implements a sampled general dot product of two dense arrays. For 2D inputs, it would lower to [cusparse SDDMM](https://docs.nvidia.com/cuda/cusparse/index.html#cusparse-generic-function-sddmm); this is mentioned as one of the core sparse matrix computations for deep learning in https://arxiv.org/pdf/2006.10901.pdf

This PR adds JAX machinery plus a (slow) reference implementation in XLA.