### PR TITLE
Use scikit-learn rather than sklearn in docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,5 +12,5 @@ pytest-xdist
 
 # Packages used for notebook execution
 matplotlib
-sklearn
+scikit-learn
 .[cpu]  # Install jax from the current directory; jaxlib from pypi.


### PR DESCRIPTION
The sklearn package is an historical thing that should probably not be used by anyone see https://github.com/scikit-learn/scikit-learn/issues/8215#issuecomment-344679114 for example for some caveats.