### PR TITLE
Catch CalledProcessError in build script.

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -48,7 +48,11 @@ def is_windows():
 
 
 def shell(cmd):
-  output = subprocess.check_output(cmd)
+  try:
+    output = subprocess.check_output(cmd)
+  except subprocess.CalledProcessError as e:
+    print(e.output)
+    raise
   return output.decode("UTF-8").strip()
 
 


### PR DESCRIPTION
print(e.output) should tell us the build errors for https://github.com/google/jax/issues/6637