### PR TITLE
CI: temporarily pin numpy to <1.21

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,7 +1,8 @@
 flake8
 flatbuffers==1.12
 # For now, we pin the numpy version here
-numpy>=1.17
+# TODO(jakevdp): unpin maximum version when minimum jaxlib supports newer numpy
+numpy>=1.17,<1.21
 mypy==0.902
 pillow
 pytest-benchmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,4 +13,6 @@ pytest-xdist
 # Packages used for notebook execution
 matplotlib
 scikit-learn
+# TODO(jakevdp) remove numpy pinning when minimum jaxlib supports newer numpy.
+numpy<1.21
 .[cpu]  # Install jax from the current directory; jaxlib from pypi.


### PR DESCRIPTION
Fix CI breakage due to this morning's numpy release.

Work-around for #7052 