### PR TITLE
Add `pip install jax[tpu]` configuration.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ with open('jax/version.py') as f:
 __version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 
+_libtpu_version = '20210615'
+_libtpu_url = (
+    f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/'
+    f'libtpu-nightly/libtpu_nightly-0.1.dev{_libtpu_version}-py3-none-any.whl')
+
 setup(
     name='jax',
     version=__version__,
@@ -45,6 +50,11 @@ setup(
         # CPU-only jaxlib can be installed via:
         # $ pip install jax[cpu]
         'cpu': [f'jaxlib>={_minimum_jaxlib_version}'],
+
+        # Cloud TPU VM jaxlib can be installed via:
+        # $ pip install jax[tpu]
+        'tpu': [f'jaxlib=={_current_jaxlib_version}',
+                f'libtpu-nightly @ {_libtpu_url}'],
 
         # CUDA installations require adding jax releases URL; e.g.
         # $ pip install jax[cuda110] -f https://storage.googleapis.com/jax-releases/jax_releases.html


### PR DESCRIPTION
This can be used on Cloud TPU VMs to automatically install compatible
versions of jax, jaxlib, and libtpu (the low-level library JAX uses to
access the TPU on Cloud TPU VMs).

The new install command requires a new jax release (`>=0.2.15`) and
jaxlib release (`>=0.1.68`) to work, since it requires both
https://github.com/google/jax/commit/cdfbd9dde17dd97f62b4bae3d972ee001c119e18
and
https://github.com/tensorflow/tensorflow/commit/ce2bc249968344c57e91c45799ad5ec91aad2566
to pick up the pip-installed libtpu. I'll update the README and Cloud
TPU VM documentation once these releases are out.