### PR TITLE
[jax2tf] Fix conversion of gradients for shape polymorphic functions.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1080,7 +1080,7 @@ class ShapedArray(UnshapedArray):
                        self.weak_type, self.named_shape)
 
   def join(self, other):
-    if self.shape == other.shape and self.dtype == other.dtype:
+    if symbolic_equal_shape(self.shape, other.shape) and self.dtype == other.dtype:
       weak_type = self.weak_type and other.weak_type
       named_shape = join_named_shapes(self.named_shape, other.named_shape)
       return self.update(weak_type=weak_type, named_shape=named_shape)

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -585,7 +585,6 @@ def _args_to_avals_and_env(
 
     for i, d in enumerate(aval_shape):
       if not shape_poly.is_poly_dim(d):
-        assert isinstance(d, int)
         assert d == arg_shape[i]
       else:
         d_var = d.to_var()  # type: ignore
@@ -1923,7 +1922,7 @@ def _common_reduce_window(operand, init_val, reducer, window_dimensions,
   reducer_fn = tf.function(
       reducer, autograph=False).get_concrete_function(o_spec, o_spec)
 
-  if not isinstance(init_val, tf.Tensor):
+  if not isinstance(init_val, (tf.Tensor, tf.Variable)):
     init_val = tf.constant(init_val, operand.dtype)
   out = tfxla.reduce_window(
       operand,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -335,7 +335,7 @@ def convert(fun: Callable,
             in_tree.children()[0], polymorphic_shapes_flat)
         out_cts_polymorphic_shapes = tree_util.tree_unflatten(
             out_tree,
-            tuple(str(out_aval.shape)
+            tuple(str(out_aval.shape)  # Note: may be polynomials, not just DimVar
                   for out_aval in _out_cts_avals))  # type: ignore
         vjp_polymorphic_shapes = [
             args_polymorphic_shapes, out_cts_polymorphic_shapes
@@ -584,18 +584,20 @@ def _args_to_avals_and_env(
     aval_shape = shape_poly.parse_spec(polymorphic_shape, arg_shape)
 
     for i, d in enumerate(aval_shape):
-      if type(d) is int:
+      if not shape_poly.is_poly_dim(d):
+        assert isinstance(d, int)
         assert d == arg_shape[i]
-      elif shape_poly.is_poly_dim(d) and d not in shapeenv:
-        # Even if the shape of `arg` is known, we still use `tf.shape` for
-        # safety, because the promise is that we will convert the function
-        # to work for any value of the dimension.
-        v = d.to_var()  # type: ignore
-        assert v is not None
-        shapeenv[v] = tf.shape(arg)[i]  # type: ignore[index]
       else:
-        # TODO: add an assertion tf.shape(arg)[i] == env[d]
-        pass
+        d_var = d.to_var()  # type: ignore
+        if d_var is not None and d_var not in shapeenv:
+          # Even if the shape of `arg` is known, we still use `tf.shape` for
+          # safety, because the promise is that we will convert the function
+          # to work for any value of the dimension.
+          shapeenv[d_var] = tf.shape(arg)[i]  # type: ignore[index]
+        else:
+          # TODO: add an assertion tf.shape(arg)[i] == env[d]
+          pass
+
 
     return core.ShapedArray(aval_shape, arg_jax_dtype)
 

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -220,7 +220,9 @@ class _DimPolynomial(dict):
 
   def __pow__(self, power, modulo=None):
     assert modulo is None
-    if not isinstance(power, int):
+    try:
+      power = int(power)
+    except:
       raise InconclusiveDimensionOperation(f"Dimension polynomial cannot be raised to non-integer power '{self}' ^ '{power}'")
     return functools.reduce(op.mul, [self] * power)
 
@@ -281,7 +283,7 @@ class _DimPolynomial(dict):
     err_msg = f"Dimension polynomial '{self}' is not a multiple of '{divisor}'"
     # invariant: self = dividend + divisor * quotient
     # the leading term of dividend decreases through the loop.
-    while not (isinstance(dividend, int) or dividend.is_constant):
+    while is_poly_dim(dividend) and not dividend.is_constant:
       mon, count = dividend.leading_term
       try:
         qmon = mon.divide(dmon)
@@ -566,16 +568,17 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
                f"for unknown dimension in argument shape {arg_shape}")
         raise ValueError(msg)
       dim_poly = _parse_dim(dim_spec)
-      if not isinstance(dim_poly, _DimPolynomial):
+      if not is_poly_dim(dim_poly):
         msg = (f"PolyShape '{spec}' in axis {i} must contain a shape variable "
                f"for unknown dimension in argument shape {arg_shape}")
         raise ValueError(msg)
       return dim_poly
     else:  # dim_size is known
+      dim_size = int(dim_size)
       if dim_spec == "_":
         return dim_size
       dim_poly = _parse_dim(dim_spec)
-      if isinstance(dim_poly, int):
+      if not is_poly_dim(dim_poly):
         if dim_poly != dim_size:
           msg = (f"PolyShape '{spec}' in axis {i} must contain a constant or '_' "
                  f"for known dimension in argument shape {arg_shape}")

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -21,6 +21,7 @@ import collections
 import itertools
 import functools
 import operator as op
+import re
 from typing import Any, Dict, Optional, Sequence, Set, Tuple, Union
 
 
@@ -64,7 +65,7 @@ class _DimMon(dict):
     return hash(frozenset(self.items()))
 
   def __str__(self):
-    return ' '.join(f'{key}^{exponent}' if exponent != 1 else str(key)
+    return "*".join(f"{key}^{exponent}" if exponent != 1 else str(key)
                     for key, exponent in sorted(self.items()))
 
   @classmethod
@@ -184,8 +185,14 @@ class _DimPolynomial(dict):
     return hash(tuple(sorted(self.items())))
 
   def __str__(self):
-    return ' + '.join(f'{c} {mon}' if c != 1 or mon.degree == 0 else str(mon)
-                      for mon, c in sorted(self.items(), reverse=True)).strip()
+    def _one_monomial(mon, c):
+      if mon.degree == 0:
+        return str(c)
+      if c == 1:
+        return str(mon)
+      return f"{c}*{mon}"
+    return " + ".join(_one_monomial(mon, c)
+                      for mon, c in sorted(self.items(), reverse=True))
 
   def __repr__(self):
     return str(self)
@@ -210,6 +217,12 @@ class _DimPolynomial(dict):
       mon = mon1.mul(mon2)
       coeffs[mon] = coeffs.get(mon, 0) + coeff1 * coeff2
     return _DimPolynomial.from_coeffs(coeffs)
+
+  def __pow__(self, power, modulo=None):
+    assert modulo is None
+    if not isinstance(power, int):
+      raise InconclusiveDimensionOperation(f"Dimension polynomial cannot be raised to non-integer power '{self}' ^ '{power}'")
+    return functools.reduce(op.mul, [self] * power)
 
   def __rmul__(self, other: DimSize) -> DimSize:
     return self * other  # multiplication commutes
@@ -476,32 +489,25 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
   if spec is None:
     spec_tuple = (...,)  # type: Tuple[Any,...]
   elif isinstance(spec, PolyShape):
-    spec_tuple = tuple(spec)
+    spec_tuple = spec
   elif isinstance(spec, str):
-    spec_ = spec.replace(" ", "")
+    spec_ = spec.strip()
     if spec_[0] == "(":
       if spec_[-1] != ")":
         raise ValueError(f"PolyShape '{spec}' has invalid syntax")
       spec_ = spec_[1:-1]
+      spec_ = spec_.strip()
     spec_ = spec_.rstrip(",")
     if not spec_:
       spec_tuple = ()
     else:
-      specs = spec_.split(',')
-      def parse_dim(ds: str):
-        if ds == "...":
-          return ...
-        elif ds.isdigit():
-          return int(ds)
-        elif ds == "_" or ds.isalnum():
-          return ds
-        else:
-          raise ValueError(f"PolyShape '{spec}' has invalid syntax")
-
-      spec_tuple = tuple(map(parse_dim, specs))
+      spec_tuple = spec_.split(",")  # type: ignore
   else:
     raise ValueError(f"PolyShape '{spec}' must be either None, a string, or PolyShape.")
 
+  # Process ...
+  spec_tuple = tuple(map(lambda s: ... if isinstance(s, str) and s.strip() == "..." else s,
+                         spec_tuple))
   ds_ellipses = tuple(ds for ds in spec_tuple if ds == ...)
   if ds_ellipses:
     if len(ds_ellipses) > 1 or spec_tuple[-1] != ...:
@@ -513,29 +519,73 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
   if len(arg_shape) != len(spec_tuple):
     raise ValueError(f"PolyShape '{spec}' must match the rank of arguments {arg_shape}.")
 
+  # The actual parsing.
+  # We actually parse not just dimension variables, but polynomials.
+  # This is not a supported feature of the API, but is needed when parsing the
+  # polymorphic_shapes of a gradient function, when the primal function has polynomial
+  # output shapes.
+  def _parse_dim(dim_spec: Union[str, int]) -> DimSize:
+    if isinstance(dim_spec, int):
+      return dim_spec  #
+    dim_spec = dim_spec.strip()
+    if not dim_spec:
+      raise ValueError(f"PolyShape '{spec}' has invalid syntax (empty dimension {dim_spec}')")
+    # Terms are separated by "+"
+    terms = dim_spec.split("+")
+    if not terms:
+      raise ValueError(f"PolyShape '{spec}' has invalid syntax (empty dimension {dim_spec}')")
+    def _parse_term(term_spec: str) -> DimSize:
+      term_spec = term_spec.strip()
+      # Factors are separated by "*"
+      factors = term_spec.split("*")
+      if not factors:
+        raise ValueError(f"PolyShape '{spec}' has invalid syntax (unexpected term '{term_spec}')")
+      def _parse_factor(factor_spec: str) -> DimSize:
+        factor_spec = factor_spec.strip()
+        if re.match(r"^-?\d+$", factor_spec):
+          return int(factor_spec)
+        m = re.match(r"^([a-zA-Z]\w*)(\^(\d+))?$", factor_spec)
+        if not m:
+          raise ValueError(f"PolyShape '{spec}' has invalid syntax (unexpected term '{factor_spec}')")
+        var = _DimPolynomial.from_var(m.group(1))
+        if m.group(3) is None:
+          return var
+        return var ** int(m.group(3))
+
+      return functools.reduce(op.mul, map(_parse_factor, factors))
+    return functools.reduce(op.add, map(_parse_term, terms))
+
   shape_var_map: Dict[str, Set[int]] = collections.defaultdict(set)
-  def _process_dim(i: int, dim_spec):
-    if not isinstance(dim_spec, (str, int)):
-      raise ValueError(f"PolyShape '{spec}' in axis {i} must contain only integers, strings, or Ellipsis.")
+  def _process_dim(i: int, dim_spec: Union[str, int]):
+    if isinstance(dim_spec, str):
+      dim_spec = dim_spec.strip()
     dim_size = arg_shape[i]
     if dim_size is None:
-      if dim_spec == "_" or not isinstance(dim_spec, str):
+      if dim_spec == "_":
         msg = (f"PolyShape '{spec}' in axis {i} must contain a shape variable "
                f"for unknown dimension in argument shape {arg_shape}")
         raise ValueError(msg)
-      return _DimPolynomial.from_var(dim_spec)
+      dim_poly = _parse_dim(dim_spec)
+      if not isinstance(dim_poly, _DimPolynomial):
+        msg = (f"PolyShape '{spec}' in axis {i} must contain a shape variable "
+               f"for unknown dimension in argument shape {arg_shape}")
+        raise ValueError(msg)
+      return dim_poly
     else:  # dim_size is known
       if dim_spec == "_":
         return dim_size
-      if isinstance(dim_spec, int):
-        if dim_spec != dim_size:
+      dim_poly = _parse_dim(dim_spec)
+      if isinstance(dim_poly, int):
+        if dim_poly != dim_size:
           msg = (f"PolyShape '{spec}' in axis {i} must contain a constant or '_' "
                  f"for known dimension in argument shape {arg_shape}")
           raise ValueError(msg)
         return dim_size
-      # We have a dimension variable for a known dimension.
-      shape_var_map[dim_spec].add(dim_size)
-      return _DimPolynomial.from_var(dim_spec)
+      # We have a dimension polynomial for a known dimension.
+      dim_var = dim_poly.to_var()
+      if dim_var is not None:
+        shape_var_map[dim_spec].add(dim_size)  # type: ignore
+      return dim_poly
 
   dims = tuple([_process_dim(i, ds) for i, ds in enumerate(spec_tuple)])
   for dim_var, dim_var_values in shape_var_map.items():

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -326,6 +326,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
       return tf.Variable(
           np.ones(initializer_shape, np.float32), dtype=tf.float32, shape=shape)
 
+
     # Known shapes for the arguments
     check_avals(
         args=[const((2, 3))],
@@ -378,6 +379,12 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
         polymorphic_shapes=["(c, b, a)"],
         expected_avals=(shaped_array("(c, b, a)", (2, 3, 4)),),
     )
+
+    # Check when the shapes are TensorSpec
+    check_avals(
+        args=[tf_var(tf.TensorShape([2, 3]), initializer_shape=(2, 3))],
+        polymorphic_shapes=[PS("b", ...)],
+        expected_avals=(shaped_array("(b, 3)", (2, 3)),))
 
     # Some errors
     for invalid_syntax in [")(", "2a", "a@", "a - 2"]:


### PR DESCRIPTION
This fixes the case when the primal shape polymorphic function has
output shapes that are polynomials of the input shapes (not just
dimension variables).