### PR TITLE
Improve support for pip install jax[cuda111]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 from setuptools import setup, find_packages
+import sys
 
 # The following should be updated with each new jaxlib release.
 _current_jaxlib_version = '0.1.67'
 _available_cuda_versions = ['101', '102', '110', '111']
+_jaxlib_cuda_url = (
+    f'https://storage.googleapis.com/jax-releases/cuda{{version}}/'
+    f'jaxlib-{_current_jaxlib_version}+cuda{{version}}'
+    f'-cp{sys.version_info.major}{sys.version_info.minor}-none-manylinux2010_x86_64.whl'
+)
 
 _dct = {}
 with open('jax/version.py') as f:
@@ -57,8 +63,8 @@ setup(
                 f'libtpu-nightly @ {_libtpu_url}'],
 
         # CUDA installations require adding jax releases URL; e.g.
-        # $ pip install jax[cuda110] -f https://storage.googleapis.com/jax-releases/jax_releases.html
-        **{f'cuda{version}': f"jaxlib=={_current_jaxlib_version}+cuda{version}"
+        # $ pip install jax[cuda110]
+        **{f'cuda{version}': f"jaxlib @ {_jaxlib_cuda_url.format(version=version)}"
            for version in _available_cuda_versions}
     },
     url='https://github.com/google/jax',


### PR DESCRIPTION
This allows you to run, e.g.
```
$ pip install jax[cuda111]
```
directly, rather than having to add `-f https://storage.googleapis.com/jax-releases/jax_releases.html` as was required previously.

Tested on a Colab GPU runtime:
```
!pip uninstall -y jax jaxlib
!git clone https://github.com/jakevdp/jax.git
!cd jax && git checkout gpu-install && pip install -U .[cuda110]
```
```
Uninstalling jax-0.2.13:
  Successfully uninstalled jax-0.2.13
Uninstalling jaxlib-0.1.66+cuda110:
  Successfully uninstalled jaxlib-0.1.66+cuda110
Cloning into 'jax'...
remote: Enumerating objects: 48261, done.
remote: Counting objects: 100% (201/201), done.
remote: Compressing objects: 100% (116/116), done.
remote: Total 48261 (delta 123), reused 139 (delta 85), pack-reused 48060
Receiving objects: 100% (48261/48261), 37.23 MiB | 28.79 MiB/s, done.
Resolving deltas: 100% (37494/37494), done.
Branch 'gpu-install' set up to track remote branch 'gpu-install' from 'origin'.
Switched to a new branch 'gpu-install'
Processing /content/jax
Requirement already satisfied, skipping upgrade: numpy>=1.17 in /usr/local/lib/python3.7/dist-packages (from jax==0.2.14) (1.19.5)
Requirement already satisfied, skipping upgrade: absl-py in /usr/local/lib/python3.7/dist-packages (from jax==0.2.14) (0.12.0)
Requirement already satisfied, skipping upgrade: opt_einsum in /usr/local/lib/python3.7/dist-packages (from jax==0.2.14) (3.3.0)
Collecting jaxlib@ https://storage.googleapis.com/jax-releases/cuda110/jaxlib-0.1.67+cuda110-cp37-none-manylinux2010_x86_64.whl
  Downloading https://storage.googleapis.com/jax-releases/cuda110/jaxlib-0.1.67+cuda110-cp37-none-manylinux2010_x86_64.whl (172.6MB)
     |████████████████████████████████| 172.6MB 75kB/s 
Requirement already satisfied, skipping upgrade: six in /usr/local/lib/python3.7/dist-packages (from absl-py->jax==0.2.14) (1.15.0)
Requirement already satisfied, skipping upgrade: scipy in /usr/local/lib/python3.7/dist-packages (from jaxlib@ https://storage.googleapis.com/jax-releases/cuda110/jaxlib-0.1.67+cuda110-cp37-none-manylinux2010_x86_64.whl->jax==0.2.14) (1.4.1)
Requirement already satisfied, skipping upgrade: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from jaxlib@ https://storage.googleapis.com/jax-releases/cuda110/jaxlib-0.1.67+cuda110-cp37-none-manylinux2010_x86_64.whl->jax==0.2.14) (1.12)
Building wheels for collected packages: jax
  Building wheel for jax (setup.py) ... done
  Created wheel for jax: filename=jax-0.2.14-cp37-none-any.whl size=788185 sha256=7d9073c2224357ba4c6026d36bfc4bb442cca44e0965595c4900bbe919217af5
  Stored in directory: /tmp/pip-ephem-wheel-cache-w_apwjf9/wheels/67/34/ed/e997cced2760c4085aef0f8ce9f8c23232a87f29d1a725f83a
Successfully built jax
Installing collected packages: jaxlib, jax
Successfully installed jax-0.2.14 jaxlib-0.1.67+cuda110
```

