### PR TITLE
Require `-f` for new install commands (again)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,16 +13,10 @@
 # limitations under the License.
 
 from setuptools import setup, find_packages
-import sys
 
 # The following should be updated with each new jaxlib release.
 _current_jaxlib_version = '0.1.68'
 _available_cuda_versions = ['101', '102', '110', '111']
-_jaxlib_cuda_url = (
-    f'https://storage.googleapis.com/jax-releases/cuda{{version}}/'
-    f'jaxlib-{_current_jaxlib_version}+cuda{{version}}'
-    f'-cp{sys.version_info.major}{sys.version_info.minor}-none-manylinux2010_x86_64.whl'
-)
 
 _dct = {}
 with open('jax/version.py') as f:
@@ -63,8 +57,8 @@ setup(
                 f'libtpu-nightly @ {_libtpu_url}'],
 
         # CUDA installations require adding jax releases URL; e.g.
-        # $ pip install jax[cuda110]
-        **{f'cuda{version}': f"jaxlib @ {_jaxlib_cuda_url.format(version=version)}"
+        # $ pip install jax[cuda110] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+        **{f'cuda{version}': f"jaxlib=={_current_jaxlib_version}+cuda{version}"
            for version in _available_cuda_versions}
     },
     url='https://github.com/google/jax',

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@ with open('jax/version.py') as f:
 __version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 
-_libtpu_version = '20210615'
-_libtpu_url = (
-    f'https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/wheels/'
-    f'libtpu-nightly/libtpu_nightly-0.1.dev{_libtpu_version}-py3-none-any.whl')
+_libtpu_version = '0.1.dev20210615'
 
 setup(
     name='jax',
@@ -52,9 +49,9 @@ setup(
         'cpu': [f'jaxlib>={_minimum_jaxlib_version}'],
 
         # Cloud TPU VM jaxlib can be installed via:
-        # $ pip install jax[tpu]
+        # $ pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/jax_releases.html
         'tpu': [f'jaxlib=={_current_jaxlib_version}',
-                f'libtpu-nightly @ {_libtpu_url}'],
+                f'libtpu-nightly=={_libtpu_version}'],
 
         # CUDA installations require adding jax releases URL; e.g.
         # $ pip install jax[cuda110] -f https://storage.googleapis.com/jax-releases/jax_releases.html


### PR DESCRIPTION
We previously changed the new install commands (e.g. `pip install jax[tpu]`) to use URLs directly to the required wheels hosted in GCS buckets. However, this doesn't work when installing jax from pypi because:
`ERROR: Packages installed from PyPI cannot depend on packages which are not also hosted on PyPI.`

This PR contains two commits which revert to using `-f https://storage.googleapis.com/jax-releases/jax_releases.html` instead:

1.
    Revert "Improve support for pip install jax[cuda111]"
    
    This reverts commit dfcaf0feb81db0d2594b9a78154e8679b0366533.


2.
    Fix `pip install jax[tpu]`
    
    * Updates jax_releases.html index to include libtpu wheels
    * Change [tpu] extras to specify `libtpu-nightly` instead of wheel URL
    
    The full install command will now be:
    `pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/jax_releases.html`
    (similar to the cuda install commands)
    
    I've already pushed an updated jax_releases.html to the jax-releases GCS bucket.
