### PR TITLE
Relax NumPy version check in tests.

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -50,7 +50,7 @@ from jax.config import config
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
-numpy_version = tuple(map(int, np.__version__.split('.')))
+numpy_version = tuple(map(int, np.__version__.split('.')[:3]))
 
 nonempty_nonscalar_array_shapes = [(4,), (3, 4), (3, 1), (1, 4), (2, 1, 4), (2, 3, 4)]
 nonempty_array_shapes = [()] + nonempty_nonscalar_array_shapes


### PR DESCRIPTION
Only look at the major and minor parts of the NumPy version. There might be non-integer parts of the version for development builds of NumPy.