### PR TITLE
remat: don't apply cse-foiling widget to primal

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -814,12 +814,12 @@ def _remat_partial_eval(trace, _, f, tracers, params):
 
   # dce jaxpr outputs
   new_jaxpr = _dce_jaxpr(closed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
-  new_params = dict(params, call_jaxpr=new_jaxpr)
+  new_params = dict(params, call_jaxpr=new_jaxpr, differentiated=True)
 
   # set up eqn for unknown outputs
   in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
-  eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p, new_params,
-                       source_info_util.current())
+  eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p,
+                       new_params, source_info_util.current())
   for t in unknown_output_tracers: t.recipe = eqn
   return _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
 call_partial_eval_rules[remat_call_p] = _remat_partial_eval


### PR DESCRIPTION
fixes #6098 (finally)

### The problem

Consider this `jax.remat` (aka `jax.checkpoint`) code

```python
import jax

@jax.remat
def f(x):
  return x ** 2
```

Evaluating `f(3.)`, whether inside a `jax.jit` or not, is made more expensive than just evaluating `x ** 2` by the fact that `jax.remat` always adds a `while`- or `conditional`-based "widget" during XLA lowering to foil CSE optimizations:

```python
print(jax.xla_computation(f)(3.).as_hlo_text())
```

```
HloModule xla_computation_f.23

remat_call_subcomputation.9 {
  constant.12 = pred[] constant(false)
  parameter.10 = (f32[]) parameter(0)
  get-tuple-element.11 = f32[] get-tuple-element(parameter.10), index=0
  multiply.13 = f32[] multiply(get-tuple-element.11, get-tuple-element.11)
  ROOT tuple.14 = (f32[]) tuple(multiply.13)
}

remat_call_dummy_subcomputation.15 {
  parameter.16 = (f32[]) parameter(0)
  constant.17 = f32[] constant(0)
  broadcast.18 = f32[] broadcast(constant.17), dimensions={}
  ROOT tuple.19 = (f32[]) tuple(broadcast.18)
}

ENTRY xla_computation_f.23 {
  constant.2 = pred[] constant(false)
  constant.3 = f32[] constant(0)
  constant.4 = f32[] constant(1)
  rng.5 = f32[]invalid{} rng(constant.3, constant.4), distribution=rng_uniform
  constant.6 = f32[] constant(2)
  compare.7 = pred[]invalid{} compare(rng.5, constant.6), direction=LT
  parameter.1 = f32[] parameter(0)
  tuple.8 = (f32[]) tuple(parameter.1)
  conditional.20 = (f32[]) conditional(compare.7, tuple.8, tuple.8), true_computation=remat_call_subcomputation.9, false_computation=remat_call_dummy_subcomputation.15
  get-tuple-element.21 = f32[] get-tuple-element(conditional.20), index=0
  ROOT tuple.22 = (f32[]) tuple(get-tuple-element.21)
}
```

This cse-foiling widget exists because when we apply reverse-mode AD (or `jax.linearize`) to a `jax.remat`-decorated function, we _want_ some primal values to be recomputed during the backward pass of the computation, and we don't want XLA to perform CSE, which would have the effect of removing the recomputation.

But notice that this widget appears even though no autodiff is happening here! That is, `jax.remat` is incurring a cost even for primal (aka "inference") computations. The cost is made worse because this widget blocks more XLA optimizations than just CSE, including fusion. And when AD isn't involved, the cost is totally unnecessary!

### The solution

The fix here is to add two boolean parameters, "`prevent_cse`" and "`differentiated`", to the underlying `remat_call` primitive which together indicate whether the widget should be generated when lowering a `remat_call` to XLA HLO. The  "`differentiated`" parameter is managed internally: it starts out as False, and is set True when partial evaluation unzips one `remat_call` into two. The "`prevent_cse`" parameter is an API option which allows expert users to disable the CSE-prevention widget entirely (since in some cases, like in a `scan`, it may not be necessary).

This solution makes sense because `remat_call` is all about special partial evaluation behavior. That is, both for `jax.vjp` and `jax.linearize`, the intended behavior for `jax.remat` is to avoid saving any residuals (i.e. intermediates) in the decorated function during partial evaluation, and instead to recompute those values in the backward pass or linearized pass, respectively. Thus when [`remat_call`'s partial eval rule](https://github.com/google/jax/blob/df3cc0d9801cce71a8ce66306c816b1a7813b12b/jax/interpreters/partial_eval.py#L754-L824) unzips one `remat_call` into two, separating the primal and tangent parts of the computation, it copies the nonlinear operations into the tangent part of the computation. (For reverse-mode, its transpose rule handles evaluating these nonlinear constants.) The widget only needs to apply to the copy of the nonlinear operations; those are the ones for which we need to prevent CSE. We don't need to prevent CSE for the original not-generated-by-AD computation!

This solution makes sense for higher-order AD as well: if we differentiate a `remat_call` application which itself was generated by an application of AD, so the boolean parameter is already set to `differentiated=True`, then both the primal (which is itself part of the derivative for the first-order differentiation) and tangent sides of the unzipped computation should inherit `differentiated=True` values.

### The tests

The tests just check the HLO generated by applying a function like `f` above.