### PR TITLE
Turn lifted_jvp into a PyTree

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1847,11 +1847,12 @@ def linearize(fun: Callable, *primals) -> Tuple[Any, Callable]:
   out_tree = out_tree()
   out_primal_py = tree_unflatten(out_tree, out_primals)
   primal_avals = list(map(core.get_aval, primals_flat))
-  lifted_jvp = partial(_lift_linearized, jaxpr, primal_avals, consts,
-                       (in_tree, out_tree), out_pvals)
+  # Ensure that lifted_jvp is a PyTree
+  lifted_jvp = Partial(partial(_lift_linearized, jaxpr, primal_avals,
+                               (in_tree, out_tree), out_pvals), consts)
   return out_primal_py, lifted_jvp
 
-def _lift_linearized(jaxpr, primal_avals, consts, io_tree, out_pvals, *py_args):
+def _lift_linearized(jaxpr, primal_avals, io_tree, out_pvals, consts, *py_args):
   def fun(*tangents):
     tangent_avals = list(map(core.get_aval, tangents))
     for primal_aval, tangent_aval in zip(primal_avals, tangent_avals):


### PR DESCRIPTION
Allows one to return & pass the `jvp_fun` returned by `jax.linearize` from/to jitted functions.
The same is already possible with the `vjp_fun` returned by `jax.vjp`,
this uses the same trick of using a `jax.Partial` to store the consts of the forward pass in a PyTree.

Example:

```python

%env JAX_LOG_COMPILES=1

import jax
import jax.numpy as jnp
from functools import partial

def f(x):
    return jnp.log(jnp.sin(x))

x = 1.23
v = 2.34
v2 = 3.45


@partial(jax.jit, static_argnums=0)
def fwd_pass(f, x):
    _, jvp_fun = jax.linearize(f, x)
    return jvp_fun

@jax.jit
def do_jvp(jvp_fun, v):
    return jvp_fun(v)

jvp_fun = fwd_pass(f, x)

res = do_jvp(jvp_fun, v)
res2 = do_jvp(jvp_fun, v2)

expected = jax.jvp(f, (x,), (v,))[1]
expected2 = jax.jvp(f, (x,), (v2,))[1]

assert jnp.allclose(res, expected)
assert jnp.allclose(res2, expected2)

```

I think this should make it possible to actually do what is asked in https://github.com/google/jax/discussions/7053