### PR TITLE
[jax2tf] Fix handling of zeros generated during AD, for shape polymorphism

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -38,7 +38,8 @@ def make_shaped_array(x):
 
 def zeros_like_array(x):
   dtype = dtypes.canonicalize_dtype(dtypes.result_type(x))
-  return zeros_like_shaped_array(ShapedArray(np.shape(x), dtype))
+  aval = ShapedArray(np.shape(x), dtype)
+  return ad_util.zeros_like_aval(aval)
 
 array_types = {np.ndarray, np.bool_,
                np.int8, np.int16, np.int32, np.int64,
@@ -50,15 +51,6 @@ array_types = {np.ndarray, np.bool_,
 for t in array_types:
   core.pytype_aval_mappings[t] = ConcreteArray
   ad_util.jaxval_zeros_likers[t] = zeros_like_array
-
-
-def zeros_like_shaped_array(aval):
-  assert isinstance(aval, ShapedArray)
-  if aval.dtype == dtypes.float0:
-    return np.zeros(aval.shape, dtypes.float0)
-  return np.broadcast_to(np.array(0, aval.dtype), aval.shape)
-
-ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
 core.literalable_types.update(array_types)
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1595,6 +1595,13 @@ def _device_put_raw(x, weak_type=None):
     aval = raise_to_shaped(core.get_aval(x), weak_type=weak_type)
     return xla.array_result_handler(None, aval)(*xla.device_put(x))
 
+def zeros_like_shaped_array(aval):
+  assert isinstance(aval, ShapedArray)
+  # The .astype is useful for float0
+  return broadcast(np.array(0).astype(aval.dtype), aval.shape)
+
+ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
+
 def iota(dtype: DType, size: int) -> Array:
   """Wraps XLA's `Iota
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
@@ -1657,11 +1664,11 @@ def stop_gradient(x):
   >>> jax.grad(lambda x: x**2)(3.)
   DeviceArray(6., dtype=float32)
   >>> jax.grad(lambda x: jax.lax.stop_gradient(x)**2)(3.)
-  array(0., dtype=float32)
+  DeviceArray(0., dtype=float32)
   >>> jax.grad(jax.grad(lambda x: x**2))(3.)
   DeviceArray(2., dtype=float32)
   >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
-  array(0., dtype=float32)
+  DeviceArray(0., dtype=float32)
   """
   def stop(x):
     if (dtypes.issubdtype(_dtype(x), np.floating) or

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -724,13 +724,18 @@ class TensorFlowTracer(core.Tracer):
     self._aval = aval
     if aval is core.abstract_unit:
       self.val = val
-    elif isinstance(val, (tf.Tensor, tf.Variable)):
+      return
+
+    if isinstance(val, (tf.Tensor, tf.Variable)):
       val_shape = val.shape
-      val_dtype = _to_jax_dtype(val.dtype)
-      aval_dtype = np.dtype(self._aval.dtype)  # type: ignore[attr-defined]
 
       if config.jax_enable_checks:
-        assert aval_dtype == val_dtype, f"expected {aval_dtype} == {val_dtype}"
+        # To compare types, we must handle float0 in JAX and x64 in TF
+        if self._aval.dtype == dtypes.float0:
+          assert _to_tf_dtype(self._aval.dtype) == val.dtype, f"expected {self._aval.dtype} == {val.dtype}"
+        else:
+          assert self._aval.dtype == _to_jax_dtype(val.dtype), f"expected {self._aval.dtype} == {val.dtype}"
+
         for aval_dim, val_dim in zip(
             self._aval.shape, val_shape):  # type: ignore[attr-defined]
           if val_dim is None:
@@ -745,10 +750,8 @@ class TensorFlowTracer(core.Tracer):
               continue
             assert aval_int == val_dim, f"expected {self._aval.shape} == {val_shape}. Found {aval_int} != {val_dim}."  # type: ignore
 
-      self.val = val
-    else:  # Must be a numeric value
-      self.val = _tfval_to_tensor_jax_dtype(
-          val, self._aval.dtype)[0]  # type: ignore[attr-defined]
+    self.val = _tfval_to_tensor_jax_dtype(val,
+                                          self._aval.dtype)[0]  # type: ignore[attr-defined]
 
   @property
   def aval(self):

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -652,7 +652,32 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
         res_jax,
         jax2tf.convert(f, polymorphic_shapes=["(b, h)", "h"])(x, y))
 
-  def test_saved_model_shape_poly(self):
+  def test_grad_int_function(self):
+    def f_jax(xi, yf):  # xi is int32 and yf is float32
+      # Return a triple: (1) float constant, with 0 tangent;
+      # (2) the integer input; (3) a float dependending on both inputs.
+      return jnp.zeros(xi.shape, dtype=jnp.float32), xi, xi.astype(np.float32) * 2. * yf
+
+    x_shape = (2, 3, 4)
+    xi = np.arange(np.prod(x_shape), dtype=np.int32).reshape(x_shape)
+    yf = xi.astype(np.float32)
+    res, f_vjp = jax.vjp(f_jax, xi, yf)
+    _ = f_vjp((np.ones(x_shape, dtype=np.float32),
+               np.zeros(x_shape, dtype=jax.float0),
+               np.ones(x_shape, dtype=np.float32)))
+
+    f_tf = jax2tf.convert(f_jax, polymorphic_shapes=["b1, b2, 4", "b1, b2, 4"])
+
+    xiv = tf.Variable(xi)
+    yfv = tf.Variable(yf)
+    with tf.GradientTape() as tape:
+      res_tf = f_tf(xiv, yfv)
+
+    g_tf_xi, g_tf_yf = tape.gradient(res_tf, (xiv, yfv))
+    self.assertIsNone(g_tf_xi)
+    self.assertAllClose(2. * xi.astype(np.float32), g_tf_yf)
+
+  def test_saved_model(self):
     f_jax = jnp.sin
     f_tf = jax2tf.convert(f_jax, polymorphic_shapes=["(b, ...)"])
     x = np.array([0.7, 0.8], dtype=np.float32)
@@ -661,6 +686,31 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     # Ensure that restored_f works at other batch size as well
     y = np.concatenate([x, x])
     self.assertAllClose(f_jax(y), restored_f(y))
+
+  def test_saved_model_int_function(self):
+    def f_jax(x):  # x:[b, 3, 4]
+      return jnp.reshape(x, (-1,))  # : [b * 12]
+    f_tf = jax2tf.convert(f_jax, polymorphic_shapes=["(b, ...)"])
+    x_shape = (2, 3, 4)
+    x = np.arange(np.prod(x_shape), dtype=np.int32).reshape(x_shape)
+
+    # When saving the model with gradients, we trace the gradient function
+    # and we used to get an error when creating zeros_like_aval for a
+    # polymorphic shape
+    restored_f = tf_test_util.SaveAndLoadFunction(f_tf, [tf.TensorSpec((None,) + x.shape[1:], x.dtype)])
+    f_jax_rt = jax2tf.call_tf(restored_f)
+    res_jax_rt = f_jax_rt(x)
+    self.assertAllClose(f_jax(x), res_jax_rt)
+
+  def test_saved_model_constant_gradient(self):
+    def f_jax(x):  # A function whose gradient is a constant
+      return 3.
+
+    f_tf = jax2tf.convert(f_jax, polymorphic_shapes=["(b, ...)"])
+    x = np.array([0.7, 0.8], dtype=np.float32)
+    restored_f = tf_test_util.SaveAndLoadFunction(f_tf, [tf.TensorSpec([None], x.dtype)])
+    self.assertAllClose(3., restored_f(x))
+    self.assertAllClose(np.array([0., 0.], dtype=np.float32), jax.grad(f_jax)(x))
 
   def test_readme_example(self):
     """Some of the examples from the README."""


### PR DESCRIPTION
Relates to ##7102 (ensure zeros from AD are generated on device).
Adds tests.