### PR TITLE
[call_tf] Improved call_tf for op-by-op executions.

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -22,8 +22,9 @@ For examples and details, see
 https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#calling-tensorflow-functions-from-jax.
 
 """
+import functools
 import logging
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence, Tuple
 
 import jax
 from jax import core
@@ -43,36 +44,38 @@ map = util.safe_map
 zip = util.safe_zip
 xops = xla_client._xla.ops  # type: ignore
 
+TfConcreteFunction = Any
+
 # The platforms for which to use DLPack to avoid copying (only works on GPU
 # and CPU at the moment, and only for DeviceArray). For CPU we don't need
 # DLPack, if we are careful.
 _DLPACK_PLATFORMS = ("gpu",)
 
-def call_tf(func_tf: Callable) -> Callable:
+def call_tf(callable_tf: Callable) -> Callable:
   """Calls a TensorFlow function from JAX, with support for reverse autodiff.
 
-  The ``func_tf`` will be called with TensorFlow-compatible arguments (
+  The ``callable_tf`` will be called with TensorFlow-compatible arguments (
   numpy.ndarray, ``tf.Tensor`` or ``tf.Variable``) or pytrees thereof. The
   function must return the same type of results.
 
   If ``call_tf`` appears in a JAX staging context (:func:`jax.jit`,
   or :func:`jax.pmap`, or :func:`jax.xmap`, or a control-flow primitive) then
-  ``func_tf`` will be compiled with ``tf.function(func_tf, jit_compile=True)``
+  ``callable_tf`` will be compiled with ``tf.function(callable_tf, jit_compile=True)``
   and the resulting XLA computation will be embedded in JAX's XLA computation.
 
   If ``call_tf`` appears outside a JAX staging context, it will be called inline
   using TensorFlow eager mode.
 
   The ``call_tf`` supports JAX's reverse-mode autodiff, in which case the
-  ``func_tf`` will be differentiated using ``tf.GradientTape``. This means
+  ``callable_tf`` will be differentiated using ``tf.GradientTape``. This means
   that the gradient will be TensorFlow-accurate, e.g., will respect the
-  custom gradients that may be defined for the code in ``func_tf``.
+  custom gradients that may be defined for the code in ``callable_tf``.
 
   For an example and more details see the
   `README <https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#calling-tensorflow-functions-from-jax>`_.
 
   Args:
-    func_tf: a TensorFlow Callable that can take a pytree of TensorFlow
+    callable_tf: a TensorFlow Callable that can take a pytree of TensorFlow
       arguments.
   Returns: a JAX callable that can be invoked with JAX pytree arguments, in
     op-by-op mode or in a staged context. This callable can be used with
@@ -83,7 +86,7 @@ def call_tf(func_tf: Callable) -> Callable:
   def make_call(*args_jax):
     """We wrap it all in `make_call` so that we can attach custom VJP."""
 
-    args_jax_flat, args_jax_treedef = tree_util.tree_flatten(args_jax)
+    args_flat_jax, args_treedef = tree_util.tree_flatten(args_jax)
     # Canonicalize the arguments; e.g., makes them x32 if JAX is in 32-bit mode
     def canonical_arg(v):
       v = v if getattr(v, "dtype", None) else np.asarray(v)
@@ -92,36 +95,34 @@ def call_tf(func_tf: Callable) -> Callable:
         v = v.astype(dtype)
       return v
 
-    args_jax_flat = tuple(map(canonical_arg, args_jax_flat))
-    args_tf_sig_flat = [
+    args_flat_jax = tuple(map(canonical_arg, args_flat_jax))
+    args_flat_sig_tf = tuple(
         tf.TensorSpec(a_jax.shape, jax2tf_internal._to_tf_dtype(a_jax.dtype))
-        for a_jax in args_jax_flat
-    ]
-    args_tf_sig = args_jax_treedef.unflatten(args_tf_sig_flat)
+        for a_jax in args_flat_jax
+    )
 
-    # Trace once through the function to get the result shape
-    with jax2tf_internal.inside_call_tf():
-      func_tf_concrete = tf.function(func_tf).get_concrete_function(*args_tf_sig)
+    res_treedef = None  # We'll store here the result treedef
+    # The function below will be called at least once, either in eager
+    # or in graph mode.
+    def callable_flat_tf(*args_tf_flat: TfVal) -> Sequence[TfVal]:
+      args_tf = args_treedef.unflatten(args_tf_flat)
+      res_tf = callable_tf(*args_tf)
+      nonlocal res_treedef
+      res_tf_flat, res_treedef_now = tree_util.tree_flatten(res_tf)
+      assert res_treedef is None or res_treedef == res_treedef_now, f"Subsequent calls had different results. Previous {res_treedef} and now {res_treedef_now}"
+      res_treedef = res_treedef_now
+      return res_tf_flat
 
-    res_tf_sig_flat, res_treedef = tree_util.tree_flatten(
-        func_tf_concrete.structured_outputs)
+    # Prepare a tf.function ahead of time, to cache the concrete functions. This
+    # won't be used in op-by-op execution mode.
+    function_flat_tf = tf.function(callable_flat_tf, jit_compile=True)
 
-    # Canonicalize the result signature; e.g., makes them x32 if JAX is in 32-bit mode
-    def res_sig_to_aval(res_sig: tf.TensorSpec) -> core.AbstractValue:
-      return core.ShapedArray(res_sig.shape, jax2tf_internal._to_jax_dtype(res_sig.dtype))
-
-    out_avals = tuple(map(res_sig_to_aval, res_tf_sig_flat))
     res_jax_flat = call_tf_p.bind(
-        *args_jax_flat,
+        *args_flat_jax,
         # Carry the actual function such that op-by-op call can call in TF eager mode.
-        func_tf=func_tf,
-        func_tf_concrete=func_tf_concrete,
-        args_treedef=args_jax_treedef,
-        args_tf_sig_flat=args_tf_sig_flat,
-        res_treedef=res_treedef,
-        out_avals=out_avals)
-    # TODO(necula): check the expected result signature
-    assert len(res_jax_flat) == len(out_avals)
+        callable_flat_tf=callable_flat_tf,
+        function_flat_tf=function_flat_tf,
+        args_flat_sig_tf=args_flat_sig_tf)
     return res_treedef.unflatten(res_jax_flat)
 
   # Define the fwd and bwd custom_vjp functions
@@ -148,7 +149,7 @@ def call_tf(func_tf: Callable) -> Callable:
       watched_args_tf = tf.nest.map_structure(replace_non_float, args_tf)
       with tf.GradientTape(persistent=True) as tape:
         tape.watch(watched_args_tf)
-        res = func_tf(*args_tf)
+        res = callable_tf(*args_tf)
 
       tf.nest.assert_same_structure(res, ct_res_tf)
       dres_darg = tape.gradient(
@@ -164,15 +165,14 @@ def call_tf(func_tf: Callable) -> Callable:
     return call_tf(tf_vjp_fun)(args_jax, ct_res_jax)
 
   make_call.defvjp(make_call_vjp_fwd, make_call_vjp_bwd)
-  return util.wraps(func_tf)(make_call)
+  return util.wraps(callable_tf)(make_call)
 
 
 call_tf_p = core.Primitive("call_tf")
 call_tf_p.multiple_results = True
 
-
-# The impl will be used in op-by-op mode and calls func_tf in TF eager mode.
-def _call_tf_impl(*args_jax_flat, args_treedef, func_tf, out_avals, **_):
+# The impl will be used in op-by-op mode and calls callable_tf in TF eager mode.
+def _call_tf_impl(*args_jax_flat, callable_flat_tf, **_):
   # On GPU we use dlpack to avoid copies of data to the host.
   def _arg_jax_to_tf(arg_jax):
     if (isinstance(arg_jax, xla.DeviceArray) and
@@ -188,12 +188,10 @@ def _call_tf_impl(*args_jax_flat, args_treedef, func_tf, out_avals, **_):
   args_tf_flat = tuple(map(_arg_jax_to_tf, args_jax_flat))
   with jax2tf_internal.inside_call_tf():
     # Call in TF eager mode
-    res_tf = func_tf(*args_treedef.unflatten(args_tf_flat))
-  res_tf_flat, _ = tree_util.tree_flatten(res_tf)
-  # TODO(necula): check the result for tree and aval
+    res_tf_flat = callable_flat_tf(*args_tf_flat)
 
-  def _res_tf_to_jax(res_tf: TfVal, out_aval: core.AbstractValue):
-    res_tf, _ = jax2tf_internal._tfval_to_tensor_jax_dtype(res_tf, jax_dtype=out_aval.dtype)
+  def _res_tf_to_jax(res_tf: TfVal):
+    res_tf, _ = jax2tf_internal._tfval_to_tensor_jax_dtype(res_tf)
     if isinstance(res_tf, tf.Tensor) and res_tf.dtype in dlpack.SUPPORTED_DTYPES:
       res_tf_platform = tf.DeviceSpec.from_string(res_tf.backing_device).device_type
       res_jax_platform = res_tf_platform.lower()
@@ -203,81 +201,124 @@ def _call_tf_impl(*args_jax_flat, args_treedef, func_tf, out_avals, **_):
 
     return jnp.asarray(np.asarray(res_tf))
 
-  return list(map(_res_tf_to_jax, res_tf_flat, out_avals))
+  return list(map(_res_tf_to_jax, res_tf_flat))
 
 
 call_tf_p.def_impl(_call_tf_impl)
 
 
-def _call_tf_abstract_eval(*_, out_avals, **__):
-  return out_avals
+def _call_tf_abstract_eval(*_,
+                           function_flat_tf,
+                           args_flat_sig_tf, **__):
+  # It seems that we cannot count on just TF shape inference to get the
+  # resulting shapes, because tf.function.get_concrete_function sometimes
+  # returns partially known shapes for a TF graph that was loaded with unknown
+  # shapes (e.g., b/128924522). So, we just compile
+  # the code and use the shapes that XLA has figured out. This is safe here
+  # because we only need to get an abstract value when we form a Jaxpr, which
+  # will eventually be lowered to XLA.
+  _, callee_xla_comp = _concrete_function_and_xla_comp(function_flat_tf, args_flat_sig_tf)
+  result_shape = callee_xla_comp.program_shape().result_shape()
+  if not result_shape.is_tuple():
+    # TF does not wrap singletons as tuples, but JAX expects tuples because
+    # call_tf is a multiple_results primitive.
+    result_shapes = (result_shape,)
+  else:
+    result_shapes = result_shape.tuple_shapes()
+
+  # Canonicalize the results; e.g., makes them x32 if JAX is in 32-bit mode
+  def res_shape_to_aval(res_shape: xla.XlaShape) -> core.AbstractValue:
+    return core.ShapedArray(res_shape.dimensions(),
+                            dtypes.canonicalize_dtype(res_shape.numpy_dtype()))
+
+  return tuple(map(res_shape_to_aval, result_shapes))
 
 
 call_tf_p.def_abstract_eval(_call_tf_abstract_eval)
 
 
-def _call_tf_translation_rule(builder, *args_op, func_tf, func_tf_concrete,
-                              args_treedef, args_tf_sig_flat, out_avals,
+def _call_tf_translation_rule(builder: xla.XlaComputationBuilder, *args_op,
+                              function_flat_tf,
+                              args_flat_sig_tf,
                               **_):
-  # TODO(necula): It seems that we need concrete tensors for get_compiler_ir?
-  args_tf_flat = [
-      tf.constant((0 if a.dtype != tf.bool else False),
-                  shape=a.shape,
-                  dtype=a.dtype) for a in args_tf_sig_flat
-  ]
-  args_tf = args_treedef.unflatten(args_tf_flat)
-  func_tf = tf.function(func_tf, jit_compile=True)
-  #func_tf_concrete = func_tf.get_concrete_function(*args_tf)
+  # This will most likely hit the cache, because use used it for abstract_eval
+  concrete_function_flat_tf, callee_xla_comp = _concrete_function_and_xla_comp(function_flat_tf, args_flat_sig_tf)
+
   captured_ops = []  # Same order as captured_inputs
-  if func_tf_concrete.captured_inputs:
+  if concrete_function_flat_tf.captured_inputs:
     # The function uses either captured variables or tensors.
     msg = (
       "call_tf works best with a TensorFlow function that does not capture "
       "variables or tensors from the context. "
       "See https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#calling-tensorflow-functions-from-jax for a discussion. "
-      f"The following captures were found {func_tf_concrete.captured_inputs}")
+      f"The following captures were found {concrete_function_flat_tf.captured_inputs}")
     logging.warning(msg)
 
     next_var_idx = 0
-    for inp in func_tf_concrete.captured_inputs:
+    for inp in concrete_function_flat_tf.captured_inputs:
       if inp.dtype == tf.resource:  # A variable; assume the next variable
-        assert next_var_idx < len(func_tf_concrete.variables)
+        assert next_var_idx < len(concrete_function_flat_tf.variables)
         # TODO(necula): better checking that we are picking the right variable
-        var = func_tf_concrete.variables[next_var_idx]
+        var = concrete_function_flat_tf.variables[next_var_idx]
         next_var_idx += 1
         inp_const = np.asarray(var)
       else:
         inp_const = np.asarray(inp)
       captured_ops.append(xops.ConstantLiteral(builder, np.asarray(inp_const)))
 
-  # TODO(necula): For unoptimized HLO, does it make a difference which device we use?
-  tf_device_name = "/device:CPU:0"
-  func_tf_hlo = func_tf.experimental_get_compiler_ir(*args_tf)(
-      stage="hlo_serialized", device_name=tf_device_name)
-  callee_xla_comp = xla_client.XlaComputation(func_tf_hlo)
   res_tf = xops.Call(builder, callee_xla_comp, args_op + tuple(captured_ops))
-  if len(out_avals) == 1:
+  result_shape = callee_xla_comp.program_shape().result_shape()
+  if not result_shape.is_tuple():
     # TF does not wrap singletons as tuples, but JAX expects tuples because
     # call_tf is a multiple_results primitive.
     res_untupled = (res_tf,)
   else:
-    res_untupled = tuple(xops.GetTupleElement(res_tf, i)
-                         for i in range(len(out_avals)))
+    res_untupled = tuple(xops.GetTupleElement(res_tf, i)  # type: ignore
+                         for i in range(len(result_shape.tuple_shapes())))
   # We may have to cast the results to x32 for JAX
-  def canonicalize_res(res, out_aval: core.AbstractValue):
+  def canonicalize_res(res):
     res_dtype = builder.get_shape(res).numpy_dtype()
-    if res_dtype != out_aval.dtype:
-      new_etype = xla_client.dtype_to_etype(out_aval.dtype)
+    jax_res_dtype = dtypes.canonicalize_dtype(res_dtype)
+    if res_dtype != jax_res_dtype:
+      new_etype = xla_client.dtype_to_etype(jax_res_dtype)
       return xops.ConvertElementType(res, new_element_type=new_etype)
     else:
       return res
 
   canonical_res_untupled = tuple(map(canonicalize_res,
-                                     res_untupled,
-                                     out_avals))
+                                     res_untupled))
   return xops.Tuple(builder, canonical_res_untupled)
 
 
+@functools.lru_cache(maxsize=128)
+def _concrete_function_and_xla_comp(
+    function_flat_tf,
+    args_flat_sig_tf) -> Tuple[TfConcreteFunction,
+                               xla_client.XlaComputation]:
+  # TODO(necula): It seems that we need concrete tensors for get_compiler_ir?
+  args_tf_flat = [
+      tf.constant((0 if a.dtype != tf.bool else False),
+                  shape=a.shape,
+                  dtype=a.dtype) for a in args_flat_sig_tf
+  ]
+
+  # TODO(necula): For unoptimized HLO, does it make a difference which device we use?
+  tf_device_name = "/device:CPU:0"
+  with jax2tf_internal.inside_call_tf():
+    try:
+      func_tf_hlo = function_flat_tf.experimental_get_compiler_ir(*args_tf_flat)(
+          stage="hlo_serialized", device_name=tf_device_name)
+    except Exception as e:
+      msg = ("Error compiling TensorFlow function. call_tf can used " +
+             "in a staged context (under jax.jit, lax.scan, etc.) only with " +
+             "compileable functions.")
+      raise ValueError(msg) from e
+
+    # The above has traced the function and in fact has cached a ConcreteFunction
+    # Grab it now, so that we don't have to construct `args_tf_flat` only to
+    # get a cache hit.
+    concrete_function_flat_tf = function_flat_tf.get_concrete_function(*args_tf_flat)
+  return concrete_function_flat_tf, xla_client.XlaComputation(func_tf_hlo)
 
 
 xla.translations[call_tf_p] = _call_tf_translation_rule
@@ -286,11 +327,9 @@ TfVal = jax2tf_internal.TfVal
 def _jax2tf_call_tf(*args: TfVal,
                     _in_avals: Sequence[core.ShapedArray],
                     _out_aval: core.ShapedArray,
-                    func_tf: Callable,
-                    **kwargs) -> TfVal:
-  res_tf = func_tf(*args)
-  res_tf_flat = tf.nest.flatten(res_tf)
-  # TODO: check that the return values have the right signature
+                    callable_flat_tf: Callable,
+                    **_) -> TfVal:
+  res_tf_flat = callable_flat_tf(*args)
   return res_tf_flat
 
 jax2tf_internal.tf_impl_with_avals[call_tf_p] = _jax2tf_call_tf


### PR DESCRIPTION
There are two major improvements here. First we ensure that
in op-by-op execution we can even execute functions that are not
compileable. We do this by ensuring that we do not trace the
TF function to a graph too early.

The other improvement is to work around some bugs in the TF shape
inference. Some TF graphs has unknown output shapes even when traced
with known inputs shapes. This happens even for some graph that
are generated by jax2tf, which we know should have known shapes. To
work around this, we get the output shapes for the TF function using
the XLA compiler, which is more reliably able to figure out the output
shapes. We do this even during abstract evaluation of the call_tf
primitive, and we use caching to ensure we do not call the TF
compiler repeatedly.