### PR TITLE
flake: fix unused import

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -48,7 +48,7 @@ DeviceArray([-1.2655463 , -0.52060574, -0.14522289, -0.10817424,
 
 import functools
 from typing import (
-  Any, Callable, Dict, NamedTuple, NewType, List, Optional, Sequence, Tuple, Union)
+  Any, Callable, Dict, NamedTuple, List, Optional, Sequence, Tuple, Union)
 
 import numpy as np
 


### PR DESCRIPTION
The error snuck in via a patch on #6929