### PR TITLE
Fix broken link in 06-parallelism.ipynb

### DIFF
--- a/docs/jax-101/06-parallelism.ipynb
+++ b/docs/jax-101/06-parallelism.ipynb
@@ -544,7 +544,7 @@
     "* the `update()` function\n",
     "* the replication of parameters and splitting of data across devices.\n",
     "\n",
-    "If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/main/docs/jax-101/07-state-in-jax.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture."
+    "If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/main/docs/jax-101/07-state.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture."
    ]
   },
   {

--- a/docs/jax-101/06-parallelism.md
+++ b/docs/jax-101/06-parallelism.md
@@ -223,7 +223,7 @@ There are two places to pay attention to:
 * the `update()` function
 * the replication of parameters and splitting of data across devices.
 
-If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/main/docs/jax-101/07-state-in-jax.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture.
+If this example is too confusing, you can find the same example, but without parallelism, in the next notebook, [State in JAX](https://colab.research.google.com/github/google/jax/blob/main/docs/jax-101/07-state.ipynb). Once that example makes sense, you can compare the differences to understand how parallelism changes the picture.
 
 ```{code-cell}
 :id: cI8xQqzRrc-4


### PR DESCRIPTION
It looks like the notebook `07-state-in-jax.ipynb` was renamed to `07-state.ipynb`, causing a link to it to break. This commit fixes the link by using the correct name.