### PR TITLE
Giving installation source for gpu/tpu no longer required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Next, run
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install --upgrade "jax[cuda111]"
 ```
 
 The jaxlib version must correspond to the version of the existing CUDA
@@ -451,6 +451,13 @@ create a symlink:
 sudo ln -s /path/to/cuda /usr/local/cuda-X.X
 ```
 
+or set the `xla_gpu_cuda_data_dir` XLA flag, e.g., via the `XLA_FLAGS` environment
+variable prior to running your program:
+
+```bash
+export XLA_FLAGS="--xla_gpu_cuda_data_dir=/path/to/cuda"
+```
+
 Please let us know on [the issue tracker](https://github.com/google/jax/issues)
 if you run into any errors or problems with the prebuilt wheels.
 
@@ -461,7 +468,7 @@ To install JAX along with appropriate versions of `jaxlib` and `libtpu`, you can
 the following in your cloud TPU VM:
 ```bash
 pip install --upgrade pip
-pip install "jax[tpu]>=0.2.16" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install "jax[tpu]>=0.2.16"
 ```
 
 ### Building JAX from source

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,15 @@ __version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 
 _libtpu_version = '0.1.dev20210615'
+_libtpu_wheel_url = "https://storage.googleapis.com/cloud-tpu-tpuvm-artifacts/"\
+    f"wheels/libtpu-nightly/libtpu_nightly-{_libtpu_version}-py3-none-any.whl"
+
+import sys
+def _jaxlib_wheel_url(cuda_ver):
+    python_ver = f"{sys.version_info.major}{sys.version_info.minor}"
+    return f"https://storage.googleapis.com/jax-releases/"\
+           f"cuda{cuda_ver}/jaxlib-{_current_jaxlib_version}"\
+           f"+cuda{cuda_ver}-cp{python_ver}-none-manylinux2010_x86_64.whl"
 
 setup(
     name='jax',
@@ -49,13 +58,13 @@ setup(
         'cpu': [f'jaxlib>={_minimum_jaxlib_version}'],
 
         # Cloud TPU VM jaxlib can be installed via:
-        # $ pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+        # $ pip install jax[tpu]
         'tpu': [f'jaxlib=={_current_jaxlib_version}',
-                f'libtpu-nightly=={_libtpu_version}'],
+                f'libtpu-nightly @ {_libtpu_wheel_url}'],
 
-        # CUDA installations require adding jax releases URL; e.g.
-        # $ pip install jax[cuda110] -f https://storage.googleapis.com/jax-releases/jax_releases.html
-        **{f'cuda{version}': f"jaxlib=={_current_jaxlib_version}+cuda{version}"
+        # CUDA installations require specifying the CUDA version, e.g.
+        # $ pip install jax[cuda102]
+        **{f'cuda{version}': f"jaxlib @ {_jaxlib_wheel_url(version)}"
            for version in _available_cuda_versions}
     },
     url='https://github.com/google/jax',


### PR DESCRIPTION
Installing jax for GPU/TPU previously required to provide the jaxlib release storage url to pip as an additional argument, making this more complicated than it needs to be. This PR hides this from the user by adding a small code snippet to `setup.py` that figures out the exact source URL for the required jaxlib wheel and uses PEP 508 URL notation to remove the need for adding an additional package index by the user.

tl;dr:
`pip install --upgrade "jax[cudaXXX]" -f https://storage.googleapis.com/jax-releases/jax_releases.html`
becomes
`pip install --upgrade "jax[cudaXXX]"`.
Similar for TPU installation.

I also took the liberty of completing the instructions for dealing with non-standard CUDA installation paths that seemed to be incomplete in the README.