### PR TITLE
Broadcast arrays manually in categorical sampling.

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1306,7 +1306,10 @@ def categorical(key: jnp.ndarray,
     _check_shape("categorical", shape, batch_shape)
 
   sample_shape = shape[:len(shape)-len(batch_shape)]
-  return jnp.argmax(gumbel(key, sample_shape + logits.shape, logits.dtype) + logits, axis=axis)
+  return jnp.argmax(
+      gumbel(key, sample_shape + logits.shape, logits.dtype) +
+      lax.expand_dims(logits, tuple(range(len(sample_shape)))),
+      axis=axis)
 
 
 def laplace(key: jnp.ndarray,

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -379,6 +379,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     ]
     for sample_shape in [(10000,), (5000, 2)]
     for dtype in jtu.dtypes.floating))
+  @jtu.disable_implicit_rank_promotion
   def testCategorical(self, p, axis, dtype, sample_shape):
     key = random.PRNGKey(0)
     p = np.array(p, dtype=dtype)


### PR DESCRIPTION
This enables sampling with jax_numpy_rank_promotion=raise.