### PR TITLE
[sparse] globally change nnz->nse

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -39,7 +39,7 @@ DeviceArray([-1.2655463 , -0.52060574, -0.14522289, -0.10817424,
 
 >>> mat_sparse = BCOO.fromdense(mat)
 >>> mat_sparse
-BCOO(float32[5, 5], nnz=8)
+BCOO(float32[5, 5], nse=8)
 
 >>> sparsify(f)(mat_sparse, vec)
 DeviceArray([-1.2655463 , -0.52060574, -0.14522289, -0.10817424,

--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -88,7 +88,7 @@ class SparsifyTest(jtu.JaxTestCase):
 
     # Distinct indices
     out = sparsify(operator.add)(x, y)
-    self.assertEqual(out.nnz, 8)  # uses concatenation.
+    self.assertEqual(out.nse, 8)  # uses concatenation.
     self.assertArraysEqual(out.todense(), 3 * jnp.arange(5))
 
     # Shared indices – requires lower level call


### PR DESCRIPTION
"nse" is "Number of Specified Elements" and is a more precise description of the property in question than is "Number of Non-Zeros". For example, there may be explicitly specified zeros in the representation. "nse" also matches what we've started using in our sparse design docs & discussions.