### PR TITLE
Fix jacfwd, jacrev, and grad for heterogeneous pytrees

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -188,6 +188,9 @@ def build_tree(treedef, xs):
   return treedef.from_iterable_tree(xs)
 
 def tree_transpose(outer_treedef, inner_treedef, pytree_to_transpose):
+  """Transform a tree having tree structure (outer, inner) into one having structure
+  (inner, outer).
+  """
   flat, treedef = tree_flatten(pytree_to_transpose)
   inner_size = inner_treedef.num_leaves
   outer_size = outer_treedef.num_leaves


### PR DESCRIPTION
Changed the behavior of `jacfwd`, `jacrev`, and `grad` when the input
pytree elements have heterogeneous dtypes, e.g., real and complex
elements:

* Changed the dtypes of the pytree elements of the Jacobian produced by
  jacfwd to be those of the input tangent basis.

* Changed the dtypes of the pytree elements of the Jacobian produced by
  jacrev to be those of the output tangent basis.

* Changed the dtypes of the pytree elements of the primals and tangents
  produced by jacfwd and jacrev to be the same as the corresponding
  elements in the input.

Changed the behavior of the flags to `jacfwd` and `jacrev`:

* Changed the allow_int flag to only allows integer and Boolean dtypes.
  Previously, this flag allowed all other types.

Fixes https://github.com/google/jax/issues/7157
Fixes https://github.com/google/jax/issues/7780