### PR TITLE
CI: pin pillow dependency to 8.2 to avoid failures under 8.3

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -4,7 +4,7 @@ flatbuffers==1.12
 # TODO(jakevdp): unpin maximum version when minimum jaxlib supports newer numpy
 numpy>=1.17,<1.21
 mypy==0.902
-pillow
+pillow~=8.2.0
 pytest-benchmark
 pytest-xdist
 wheel


### PR DESCRIPTION
Our CI started failing this morning, shortly after the 8.3 release of pillow was published (related to https://github.com/python-pillow/Pillow/issues/5571). Pinning to 8.2 should (hopefully) make our CI green again.