### PR TITLE
[sparse]: avoid binding transpose primitive for no-ops

### DIFF
--- a/jax/experimental/sparse/ops.py
+++ b/jax/experimental/sparse/ops.py
@@ -849,7 +849,10 @@ bcoo_transpose_p = core.Primitive('bcoo_transpose')
 bcoo_transpose_p.multiple_results = True
 
 def bcoo_transpose(data, indices, *, permutation, shape):
-  return bcoo_transpose_p.bind(data, indices, permutation=permutation, shape=shape)
+  if tuple(permutation) == tuple(range(len(shape))):
+    return data, indices
+  else:
+    return bcoo_transpose_p.bind(data, indices, permutation=permutation, shape=shape)
 
 def _validate_permutation(data, indices, permutation, shape):
   if not isinstance(permutation, (tuple, list, np.ndarray)):


### PR DESCRIPTION
Similar to what is done in lax.py: https://github.com/google/jax/blob/33d9a203f162260fb041ea2ca59ffc22d0a4dd40/jax/_src/lax/lax.py#L1213-L1222

Motivated by making jaxprs of sparse gradients simpler.