### PR TITLE
setup.py: change jax[cpu] to target the current jaxlib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
 
         # CPU-only jaxlib can be installed via:
         # $ pip install jax[cpu]
-        'cpu': [f'jaxlib>={_minimum_jaxlib_version}'],
+        'cpu': [f'jaxlib=={_current_jaxlib_version}'],
 
         # Cloud TPU VM jaxlib can be installed via:
         # $ pip install jax[tpu] -f https://storage.googleapis.com/jax-releases/jax_releases.html


### PR DESCRIPTION
Fixes #7174

Because jaxlib is not always backward compatible with old versions of JAX, it makes sense to pin the current version of the CPU wheel so that in the future it's easier to install a working jax/jaxlib combination for old versions of JAX. Note that we already do this for GPU and TPU.