### PR TITLE
[sparse] add support for sparse-sparse matrix products

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -193,6 +193,8 @@ from .ops import (
     bcoo_fromdense_p,
     bcoo_reduce_sum,
     bcoo_rdot_general,
+    bcoo_spdot_general,
+    bcoo_spdot_general_p,
     bcoo_todense,
     bcoo_todense_p,
     bcoo_transpose,


### PR DESCRIPTION
This implements the equivalent of `lax.dot_general` between two BCOO sparse matrices, for matrices with a single sparse dimension.

Still TODO:
- multiple sparse dimensions (will take some thought)
- batching (should be easy)
- autodiff (should be excruciating)