### PR TITLE
Turn transposed_fun into a PyTree

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2047,7 +2047,7 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
                     "[float or complex], and integer -> integer functions, "
                     f"but got {in_dtypes} -> {out_dtypes}.")
 
-  def transposed_fun(out_cotangent):
+  def transposed_fun(consts, out_cotangent):
     out_cotangents, out_tree2 = tree_flatten(out_cotangent)
     if out_tree() != out_tree2:
       raise TypeError("cotangent tree does not match function output, "
@@ -2061,7 +2061,8 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
         ad.backward_pass(jaxpr, reduce_axes, consts, dummies, out_cotangents))
     return tree_unflatten(in_tree, in_cotangents)
 
-  return transposed_fun
+  # Ensure that transposed_fun is a PyTree
+  return Partial(transposed_fun, consts)
 
 
 def make_jaxpr(fun: Callable,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2841,6 +2841,50 @@ class APITest(jtu.JaxTestCase):
       jitted_f = api.jit(f)
       np.testing.assert_allclose(jitted_f(x, delta), f(x, delta))
 
+  def test_vjp_fun_jit(self):
+    # test that the function returned by vjp can be returned
+    # from and passed to jitted functions
+    f = lambda x: 2. * x
+
+    @partial(jit, static_argnums=0)
+    def linearize_vjp(f, x):
+      _, vjp_fun = api.vjp(f, x)
+      return vjp_fun
+
+    linearized = linearize_vjp(f, 1.)
+    actual = jit(lambda f, x: f(x))(linearized, 3.)
+    expected = (6.,)
+    self.assertEqual(actual, expected)
+
+  def test_linearize_fun_jit(self):
+    # test that the function returned by linearize can be returned
+    # from and passed to jitted functions
+    f = lambda x: 2. * x
+
+    @partial(jit, static_argnums=0)
+    def linearize(f, x):
+      _, jvp_fun = api.linearize(f, x)
+      return jvp_fun
+
+    linearized = linearize(f, 1.)
+    actual = jit(lambda f, x: f(x))(linearized, 3.)
+    expected = 6.
+    self.assertEqual(actual, expected)
+
+  def test_linear_transpose_fun_jit(self):
+    # test that the function returned by linear_transpose can be returned
+    # from and passed to jitted functions
+    f = lambda x: 2. * x
+
+    @partial(jit, static_argnums=0)
+    def transpose(f, x):
+      return api.linear_transpose(f, x)
+
+    transposed = transpose(f, 1.)
+    actual = jit(lambda f, x: f(x))(transposed, 3.)
+    expected = (6.,)
+    self.assertEqual(actual, expected)
+
 
 class RematTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Follow-up to https://github.com/google/jax/pull/7101, as suggested in https://github.com/google/jax/discussions/7053#discussioncomment-917964. 

Allows using the function returned by jax.linear_transpose with jit. 

Example:

```python
import jax
import jax.numpy as jnp
from functools import partial

A = jnp.array([[1.,2.],[3.,4.]])
x = jnp.array([5., 6.])
y = jnp.array([7., 8.])


def f(x):
    return A@x

@partial(jax.jit, static_argnums=0)
def transpose(f, x):
    return jax.linear_transpose(f, x)

ft = transpose(f, x)

assert jnp.allclose(ft(y), A.T@y)
assert jnp.allclose(jax.jit(ft)(y), A.T@y)
```
