### PR TITLE
Add a helper decorator to disable implicit rank promotion in unit tests.

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -855,6 +855,20 @@ class JaxTestLoader(absltest.TestLoader):
     return names
 
 
+def disable_implicit_rank_promotion(test_method):
+  """A decorator for test methods to raise error on implicit rank promotion."""
+  @functools.wraps(test_method)
+  def test_method_wrapper(self, *args, **kwargs):
+    try:
+      prev_flag = config.jax_numpy_rank_promotion
+      FLAGS.jax_numpy_rank_promotion = "raise"
+      return test_method(self, *args, **kwargs)
+    finally:
+      FLAGS.jax_numpy_rank_promotion = prev_flag
+
+  return test_method_wrapper
+
+
 class JaxTestCase(parameterized.TestCase):
   """Base class for JAX tests including numerical checks and boilerplate."""
 

--- a/tests/test_util_test.py
+++ b/tests/test_util_test.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+
+from jax import test_util as jtu
+import jax.numpy as jnp
+
+
+class TestUtilTest(jtu.JaxTestCase):
+
+  @jtu.disable_implicit_rank_promotion
+  def testDisableImplicitRankPromotion(self):
+    x = jnp.zeros([2])
+    y = jnp.zeros([2])
+
+    with self.assertRaises(ValueError):
+      x[None, :] + y
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
See discussion in #7147 for details.