### PR TITLE
Update pillow pin to >= 8.3.1.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -4,7 +4,7 @@ flatbuffers==1.12
 # TODO(jakevdp): unpin maximum version when minimum jaxlib supports newer numpy
 numpy>=1.17,<1.21
 mypy==0.902
-pillow~=8.2.0
+pillow>=8.3.1
 pytest-benchmark
 pytest-xdist
 wheel


### PR DESCRIPTION
8.3.1 fixed the issue from https://github.com/google/jax/pull/7166.