### PR TITLE
Add x.at[idx].get().

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -100,9 +100,10 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
     inserted_window_dims=indexer.dnums.collapsed_slice_dims,
     scatter_dims_to_operand_dims=indexer.dnums.start_index_map
   )
-  out = scatter_op(x, indexer.gather_indices, y, dnums,
-                   indices_are_sorted=indices_are_sorted,
-                   unique_indices=indexer.unique_indices or unique_indices)
+  out = scatter_op(
+    x, indexer.gather_indices, y, dnums,
+    indices_are_sorted=indexer.indices_are_sorted or indices_are_sorted,
+    unique_indices=indexer.unique_indices or unique_indices)
   return lax.convert_element_type(out, dtype)
 
 

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -442,6 +442,21 @@ class IndexingTest(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
+  @parameterized.named_parameters(jtu.cases_from_list({
+      "testcase_name": "{}_inshape={}_indexer={}".format(
+          name, jtu.format_shape_dtype_string( shape, dtype), indexer),
+       "shape": shape, "dtype": dtype, "indexer": indexer
+  } for name, index_specs in STATIC_INDEXING_TESTS
+    for shape, indexer in index_specs
+    for dtype in all_dtypes))
+  def testStaticIndexingWithAtGet(self, shape, dtype, indexer):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: [rng(shape, dtype)]
+    np_fun = lambda x: np.asarray(x)[indexer]
+    jnp_fun = lambda x: jnp.asarray(x).at[indexer].get()
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
   @parameterized.named_parameters({
       "testcase_name":
           "{}_inshape={}_indexer={}".format(name,


### PR DESCRIPTION
This allows the sorted/unique keyword arguments to be passed to indexed gather operations.