### PR TITLE
setup.py: add Python 3.9 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
We currently have CI tests for Python 3.9, so we should include this in our package classifiers: https://github.com/google/jax/blob/a50dd080f6f8296c5217bccfd2a545c84c3193f1/.github/workflows/ci-build.yaml#L43-L49