### PR TITLE
Fix grad of conv 0D.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6921,6 +6921,9 @@ def _conv_general_vjp_lhs_padding(
 def _conv_general_vjp_rhs_padding(
     in_shape, window_dimensions, window_strides, out_shape, padding,
     lhs_dilation, rhs_dilation):
+
+  if len(in_shape) == 0:  # 0D conv
+    return []
   lhs_dilated_shape = _dilate_shape(in_shape, lhs_dilation)
   rhs_dilated_shape = _dilate_shape(window_dimensions, rhs_dilation)
   out_dilated_shape = _dilate_shape(out_shape, window_strides)


### PR DESCRIPTION
This bug was introduced in #6345, and was not caught by existing tests.
Add a reproducing test.