### PR TITLE
efficiency: use lax.broadcast_to_rank instead of jnp.broadcast_to in shape promotion

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -244,8 +244,7 @@ def _promote_shapes(fun_name, *args):
       if config.jax_numpy_rank_promotion != "allow":
         _rank_promotion_warning_or_error(fun_name, shapes)
       result_rank = len(lax.broadcast_shapes(*shapes))
-      return [broadcast_to(arg, (1,) * (result_rank - len(shp)) + shp)
-              for arg, shp in zip(args, shapes)]
+      return [lax.broadcast_to_rank(arg, result_rank) for arg in args]
 
 def _rank_promotion_warning_or_error(fun_name, shapes):
   if config.jax_numpy_rank_promotion == "warn":


### PR DESCRIPTION
Why? This is a frequently-used utility (called in all broadcasted numpy binary ops!) and `jnp.broadcast_to` includes a bunch of validation overhead that is not relevant to this case where we know a priori that we're just adding leading ones to the shape.