### PR TITLE
deprecate lax.broadcast_p

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1755,14 +1755,6 @@ def _dot_general(lhs, rhs, *, dimension_numbers,
 tf_impl_with_avals[lax.dot_general_p] = _dot_general
 
 
-def _broadcast(operand, *, sizes):
-  result_shape = tf.TensorShape(sizes).concatenate(operand.shape)
-  return tf.broadcast_to(operand, result_shape)
-
-
-tf_impl[lax.broadcast_p] = _broadcast
-
-
 def _broadcast_in_dim(operand, *, shape, broadcast_dimensions):
   inshape = [1] * len(shape)
   for orig_shape_i, broadcast_dim_i in zip(operand.shape, broadcast_dimensions):

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1083,28 +1083,6 @@ for shape, outshape, broadcast_dimensions in [
       outshape=outshape,
       broadcast_dimensions=broadcast_dimensions)
 
-
-def _make_broadcast_harness(name, *, dtype=np.float32, shape=(2,), sizes=()):
-  define(
-      lax.broadcast_p,
-      f"{name}_shape={jtu.format_shape_dtype_string(shape, dtype)}_sizes={sizes}",
-      lambda operand: lax.broadcast_p.bind(operand, sizes=sizes),
-      [RandArg(shape, dtype)],
-      shape=shape,
-      dtype=dtype,
-      sizes=sizes)
-
-
-for dtype in jtu.dtypes.all:
-  _make_broadcast_harness("dtypes", dtype=dtype)
-
-# Validate sizes
-for sizes in [
-    (2,),  # broadcast 1 dim
-    (1, 2, 3),  # broadcast n > 1 dims
-]:
-  _make_broadcast_harness("sizes", sizes=sizes)
-
 for dtype in jtu.dtypes.all_floating:
   for arg1, arg2, arg3 in [
       (np.array([-1.6, -1.4, -1.0, 0.0, 0.1, 0.3, 1, 1.4, 1.6], dtype=dtype),

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -65,7 +65,6 @@ from jax._src.lax.lax import (
   bitwise_or,
   bitwise_xor,
   broadcast,
-  broadcast_p,
   broadcast_in_dim,
   broadcast_in_dim_p,
   broadcast_shapes,


### PR DESCRIPTION
Why? It has been subsumed by lax.broadcast_in_dim_p