### PR TITLE
Warn if importing jaxlib on Mac ARM machines.

### DIFF
--- a/jax/lib/__init__.py
+++ b/jax/lib/__init__.py
@@ -15,13 +15,22 @@
 # This module is largely a wrapper around `jaxlib` that performs version
 # checking on import.
 
+import platform
 import os
+import warnings
 from typing import Optional
 
 __all__ = [
   'cuda_linalg', 'cuda_prng', 'cusolver', 'rocsolver', 'jaxlib', 'lapack',
   'pocketfft', 'pytree', 'tpu_client', 'version', 'xla_client'
 ]
+
+# First, before attempting to import jaxlib, warn about experimental machine
+# configurations.
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+  warnings.warn("JAX on Mac ARM machines is experimental and minimally tested. "
+                "Please see https://github.com/google/jax/issues/5501 in the "
+                "event of problems.")
 
 try:
   import jaxlib


### PR DESCRIPTION
We can remove this warning when Mac ARM has CI testing.

Issue #5501 