### PR TITLE
Update colab CPU test notebook to be more robust

### DIFF
--- a/tests/notebooks/colab_cpu.ipynb
+++ b/tests/notebooks/colab_cpu.ipynb
@@ -95,7 +95,7 @@
         "arr = jax.random.normal(key, (1000,))\n",
         "device = arr.device_buffer.device()\n",
         "print(f\"JAX device type: {device}\")\n",
-        "assert isinstance(device, xla_extension.CpuDevice), \"unexpected JAX device type\""
+        "assert device.platform == \"cpu\", f\"unexpected JAX device type: {device.platform}\""
       ],
       "execution_count": 2,
       "outputs": [


### PR DESCRIPTION
Tested: opened notebook in Colab and ran all cells: https://colab.sandbox.google.com/github/google/jax/blob/5a0a46cbef29cae674235986d5afbee76dfbb5c3/tests/notebooks/colab_cpu.ipynb