### PR TITLE
[sparse] support dense xla_call within sparsify jaxpr interpreter

### DIFF
--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -19,7 +19,7 @@ from absl.testing import parameterized
 
 import numpy as np
 
-from jax import config, lax, partial
+from jax import config, jit, lax, partial
 import jax.numpy as jnp
 import jax.test_util as jtu
 from jax.experimental.sparse import BCOO, sparsify
@@ -236,6 +236,11 @@ class SparsifyTest(jtu.JaxTestCase):
     self.assertArraysEqual(out_dense[0], out_dense[0])
     self.assertArraysEqual(out_dense[1], out_sparse[1].todense())
     self.assertArraysEqual(out_dense[2], out_sparse[2].todense())
+
+  def testXlaCallInSparsify(self):
+    # Test handling of xla_call within sparsify jaxpr interpreter.
+    out = sparsify(jit(lambda x: x + 1))(0.0)
+    self.assertEqual(out, 1.0)
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This does not yet provide a sparse version of xla_call, but fixes the fallback in case of no sparse arguments. The new testcase failed previous to this change.

Quick preview of what this enables: logistic regression over sparse data
```python
import jax
import jax.scipy.optimize
import jax.numpy as jnp
import jax.scipy as jsp
from sklearn.datasets import make_classification
from jax.experimental import sparse

X, y = make_classification(n_classes=2, random_state=1701)

def sigmoid(x):
  return 0.5 * (jnp.tanh(x / 2) + 1)

def loss(params, X, y):
  y_hat = sigmoid(jnp.dot(X, params[:-1]) + params[-1])
  return -jnp.mean(y * jnp.log(y_hat) + (1 - y) * jnp.log(1 - y_hat))

def fit_logreg(X, y):
  params = jnp.zeros(X.shape[1] + 1)
  result = jsp.optimize.minimize(jax.partial(loss, X=X, y=y), x0=params, method='BFGS')
  return result.x

result_dense = fit_logreg(X, y)
print(result_dense)
# [ 0.29878765  1.0246305  -0.44430432  0.8784207  -0.7722533  -0.62882096
#   0.29335386  0.82934445  0.16820648 -0.39764518 -0.5069731   0.2025782
#   0.5226711  -0.37401187 -0.7102661   2.4209461   0.63105875 -0.6702331
#   0.03132926 -0.0535662  -0.72971433]

Xsp = sparse.BCOO.fromdense(X)
fit_logreg_sp = sparse.sparsify(fit_logreg)
result_sparse = fit_logreg_sp(Xsp, y)
print(result_sparse)
# [ 0.2984554   1.0241764  -0.44405258  0.8782281  -0.7718836  -0.62865126
#   0.29329264  0.828708    0.16805805 -0.3974281  -0.50664973  0.20231716
#   0.5225492  -0.37384456 -0.7099645   2.4202223   0.63091725 -0.6697538
#   0.03128913 -0.05348948 -0.7292782 ]
```