### PR TITLE
[sparse] support sparse arguments in xla_call

### DIFF
--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -237,10 +237,22 @@ class SparsifyTest(jtu.JaxTestCase):
     self.assertArraysEqual(out_dense[1], out_sparse[1].todense())
     self.assertArraysEqual(out_dense[2], out_sparse[2].todense())
 
-  def testXlaCallInSparsify(self):
-    # Test handling of xla_call within sparsify jaxpr interpreter.
+  def testSparsifyDenseXlaCall(self):
+    # Test handling of dense xla_call within jaxpr interpreter.
     out = sparsify(jit(lambda x: x + 1))(0.0)
     self.assertEqual(out, 1.0)
+
+  def testSparsifySparseXlaCall(self):
+    # Test sparse lowering of XLA call
+    def func(M):
+      return 2 * M
+
+    M = jnp.arange(6).reshape(2, 3)
+    Msp = BCOO.fromdense(M)
+
+    out_dense = func(M)
+    out_sparse = sparsify(jit(func))(Msp)
+    self.assertArraysEqual(out_dense, out_sparse.todense())
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This takes #7274 one step further and allows `xla_call` over functions with sparse arguments.

~I think to make this work in general, we may need to change the API for declaring sparse rules and pass the consts to the rules, or perhaps refactor `spenv` to make that data available.~