### PR TITLE
Add source location and expression to error messages for CUDA API calls.

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
         "@local_config_cuda//cuda:cuda_headers",
     ],
 )

--- a/jaxlib/cuda_gpu_kernel_helpers.cc
+++ b/jaxlib/cuda_gpu_kernel_helpers.cc
@@ -19,14 +19,103 @@ limitations under the License.
 
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 namespace jax {
+namespace {
+std::string ErrorToString(cudaError_t error) {
+  return cudaGetErrorString(error);
+}
 
-void ThrowIfError(cudaError_t error) {
-  if (error != cudaSuccess) {
-    throw std::runtime_error(
-        absl::StrCat("CUDA operation failed: ", cudaGetErrorString(error)));
+std::string ErrorToString(cusparseStatus_t status) {
+  return cusparseGetErrorString(status);
+}
+
+std::string ErrorToString(cusolverStatus_t status) {
+  switch (status) {
+    case CUSOLVER_STATUS_SUCCESS:
+      return "cuSolver success.";
+    case CUSOLVER_STATUS_NOT_INITIALIZED:
+      return "cuSolver has not been initialized";
+    case CUSOLVER_STATUS_ALLOC_FAILED:
+      return "cuSolver allocation failed";
+    case CUSOLVER_STATUS_INVALID_VALUE:
+      return "cuSolver invalid value error";
+    case CUSOLVER_STATUS_ARCH_MISMATCH:
+      return "cuSolver architecture mismatch error";
+    case CUSOLVER_STATUS_MAPPING_ERROR:
+      return "cuSolver mapping error";
+    case CUSOLVER_STATUS_EXECUTION_FAILED:
+      return "cuSolver execution failed";
+    case CUSOLVER_STATUS_INTERNAL_ERROR:
+      return "cuSolver internal error";
+    case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
+      return "cuSolver matrix type not supported error";
+    case CUSOLVER_STATUS_NOT_SUPPORTED:
+      return "cuSolver not supported error";
+    case CUSOLVER_STATUS_ZERO_PIVOT:
+      return "cuSolver zero pivot error";
+    case CUSOLVER_STATUS_INVALID_LICENSE:
+      return "cuSolver invalid license error";
+    default:
+      return absl::StrCat("Unknown cuSolver error: ", status);
   }
+}
+
+std::string ErrorToString(cublasStatus_t status) {
+  switch (status) {
+    case CUBLAS_STATUS_SUCCESS:
+      return "cuBlas success";
+    case CUBLAS_STATUS_NOT_INITIALIZED:
+      return "cuBlas has not been initialized";
+    case CUBLAS_STATUS_ALLOC_FAILED:
+      return "cuBlas allocation failure";
+    case CUBLAS_STATUS_INVALID_VALUE:
+      return "cuBlas invalid value error";
+    case CUBLAS_STATUS_ARCH_MISMATCH:
+      return "cuBlas architecture mismatch";
+    case CUBLAS_STATUS_MAPPING_ERROR:
+      return "cuBlas mapping error";
+    case CUBLAS_STATUS_EXECUTION_FAILED:
+      return "cuBlas execution failed";
+    case CUBLAS_STATUS_INTERNAL_ERROR:
+      return "cuBlas internal error";
+    case CUBLAS_STATUS_NOT_SUPPORTED:
+      return "cuBlas not supported error";
+    case CUBLAS_STATUS_LICENSE_ERROR:
+      return "cuBlas license error";
+    default:
+      return "Unknown cuBlas error";
+  }
+}
+
+template <typename T>
+void ThrowError(T status, const char* file, std::int64_t line,
+                const char* expr) {
+  throw std::runtime_error(absl::StrFormat("%s:%d: operation %s failed: %s",
+                                           file, line, expr,
+                                           ErrorToString(status)));
+}
+}  // namespace
+
+void ThrowIfError(cudaError_t error, const char* file, std::int64_t line,
+                  const char* expr) {
+  if (error != cudaSuccess) ThrowError(error, file, line, expr);
+}
+
+void ThrowIfError(cusolverStatus_t status, const char* file, std::int64_t line,
+                  const char* expr) {
+  if (status != CUSOLVER_STATUS_SUCCESS) ThrowError(status, file, line, expr);
+}
+
+void ThrowIfError(cusparseStatus_t status, const char* file, std::int64_t line,
+                  const char* expr) {
+  if (status != CUSPARSE_STATUS_SUCCESS) ThrowError(status, file, line, expr);
+}
+
+void ThrowIfError(cublasStatus_t status, const char* file, std::int64_t line,
+                  const char* expr) {
+  if (status != CUBLAS_STATUS_SUCCESS) ThrowError(status, file, line, expr);
 }
 
 std::unique_ptr<void* []> MakeBatchPointers(cudaStream_t stream, void* buffer,
@@ -38,8 +127,9 @@ std::unique_ptr<void* []> MakeBatchPointers(cudaStream_t stream, void* buffer,
     host_ptrs[i] = ptr;
     ptr += batch_elem_size;
   }
-  ThrowIfError(cudaMemcpyAsync(dev_ptrs, host_ptrs.get(), sizeof(void*) * batch,
-                               cudaMemcpyHostToDevice, stream));
+  JAX_THROW_IF_ERROR(cudaMemcpyAsync(dev_ptrs, host_ptrs.get(),
+                                     sizeof(void*) * batch,
+                                     cudaMemcpyHostToDevice, stream));
   return host_ptrs;
 }
 }  // namespace jax

--- a/jaxlib/cuda_gpu_kernel_helpers.h
+++ b/jaxlib/cuda_gpu_kernel_helpers.h
@@ -18,11 +18,25 @@ limitations under the License.
 
 #include <memory>
 
+#include "third_party/gpus/cuda/include/cublas_v2.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
+#include "third_party/gpus/cuda/include/cusolverDn.h"
+#include "third_party/gpus/cuda/include/cusparse.h"
+
+#define JAX_THROW_IF_ERROR(expr) \
+  jax::ThrowIfError(expr, __FILE__, __LINE__, #expr)
 
 namespace jax {
 
-void ThrowIfError(cudaError_t error);
+// Used via JAX_THROW_IF_ERROR(expr) macro.
+void ThrowIfError(cudaError_t error, const char* file, std::int64_t line,
+                  const char* expr);
+void ThrowIfError(cusolverStatus_t status, const char* file, std::int64_t line,
+                  const char* expr);
+void ThrowIfError(cusparseStatus_t status, const char* file, std::int64_t line,
+                  const char* expr);
+void ThrowIfError(cublasStatus_t status, const char* file, std::int64_t line,
+                  const char* expr);
 
 // Builds an array of pointers to each array in a batch, in device memory.
 // Caution: the return value must be kept alive (e.g., via a stream

--- a/jaxlib/cuda_lu_pivot_kernels.cu.cc
+++ b/jaxlib/cuda_lu_pivot_kernels.cu.cc
@@ -89,7 +89,7 @@ void CudaLuPivotsToPermutation(cudaStream_t stream, void** buffers,
                                 /*dynamic_shared_mem_bytes=*/0, stream>>>(
       pivots, permutation_out, descriptor.batch_size, descriptor.pivot_size,
       descriptor.permutation_size);
-  ThrowIfError(cudaGetLastError());
+  JAX_THROW_IF_ERROR(cudaGetLastError());
 }
 
 }  // namespace jax

--- a/jaxlib/cuda_prng_kernels.cu.cc
+++ b/jaxlib/cuda_prng_kernels.cu.cc
@@ -125,7 +125,7 @@ void CudaThreeFry2x32(cudaStream_t stream, void** buffers, const char* opaque,
   ThreeFry2x32Kernel<<<grid_dim, block_dim, /*dynamic_shared_mem_bytes=*/0,
                        stream>>>(keys[0], keys[1], data[0], data[1], out[0],
                                  out[1], descriptor.n);
-  ThrowIfError(cudaGetLastError());
+  JAX_THROW_IF_ERROR(cudaGetLastError());
 }
 
 }  // namespace jax

--- a/jaxlib/cusolver.cc
+++ b/jaxlib/cusolver.cc
@@ -37,39 +37,7 @@ limitations under the License.
 
 namespace jax {
 namespace {
-
 namespace py = pybind11;
-
-void ThrowIfErrorStatus(cusolverStatus_t status) {
-  switch (status) {
-    case CUSOLVER_STATUS_SUCCESS:
-      return;
-    case CUSOLVER_STATUS_NOT_INITIALIZED:
-      throw std::runtime_error("cuSolver has not been initialized");
-    case CUSOLVER_STATUS_ALLOC_FAILED:
-      throw std::runtime_error("cuSolver allocation failed");
-    case CUSOLVER_STATUS_INVALID_VALUE:
-      throw std::runtime_error("cuSolver invalid value error");
-    case CUSOLVER_STATUS_ARCH_MISMATCH:
-      throw std::runtime_error("cuSolver architecture mismatch error");
-    case CUSOLVER_STATUS_MAPPING_ERROR:
-      throw std::runtime_error("cuSolver mapping error");
-    case CUSOLVER_STATUS_EXECUTION_FAILED:
-      throw std::runtime_error("cuSolver execution failed");
-    case CUSOLVER_STATUS_INTERNAL_ERROR:
-      throw std::runtime_error("cuSolver internal error");
-    case CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED:
-      throw std::invalid_argument("cuSolver matrix type not supported error");
-    case CUSOLVER_STATUS_NOT_SUPPORTED:
-      throw std::runtime_error("cuSolver not supported error");
-    case CUSOLVER_STATUS_ZERO_PIVOT:
-      throw std::runtime_error("cuSolver zero pivot error");
-    case CUSOLVER_STATUS_INVALID_LICENSE:
-      throw std::runtime_error("cuSolver invalid license error");
-    default:
-      throw std::runtime_error("Unknown cuSolver error");
-  }
-}
 
 using SolverHandlePool = HandlePool<cusolverDnHandle_t, cudaStream_t>;
 
@@ -80,13 +48,13 @@ template <>
   absl::MutexLock lock(&pool->mu_);
   cusolverDnHandle_t handle;
   if (pool->handles_.empty()) {
-    ThrowIfErrorStatus(cusolverDnCreate(&handle));
+    JAX_THROW_IF_ERROR(cusolverDnCreate(&handle));
   } else {
     handle = pool->handles_.back();
     pool->handles_.pop_back();
   }
   if (stream) {
-    ThrowIfErrorStatus(cusolverDnSetStream(handle, stream));
+    JAX_THROW_IF_ERROR(cusolverDnSetStream(handle, stream));
   }
   return Handle(pool, handle);
 }
@@ -149,25 +117,25 @@ std::pair<int, py::bytes> BuildPotrfDescriptor(const py::dtype& dtype,
   if (b == 1) {
     switch (type) {
       case Type::F32:
-        ThrowIfErrorStatus(cusolverDnSpotrf_bufferSize(handle.get(), uplo, n,
+        JAX_THROW_IF_ERROR(cusolverDnSpotrf_bufferSize(handle.get(), uplo, n,
                                                        /*A=*/nullptr,
                                                        /*lda=*/n, &lwork));
         workspace_size = lwork * sizeof(float);
         break;
       case Type::F64:
-        ThrowIfErrorStatus(cusolverDnDpotrf_bufferSize(handle.get(), uplo, n,
+        JAX_THROW_IF_ERROR(cusolverDnDpotrf_bufferSize(handle.get(), uplo, n,
                                                        /*A=*/nullptr,
                                                        /*lda=*/n, &lwork));
         workspace_size = lwork * sizeof(double);
         break;
       case Type::C64:
-        ThrowIfErrorStatus(cusolverDnCpotrf_bufferSize(handle.get(), uplo, n,
+        JAX_THROW_IF_ERROR(cusolverDnCpotrf_bufferSize(handle.get(), uplo, n,
                                                        /*A=*/nullptr,
                                                        /*lda=*/n, &lwork));
         workspace_size = lwork * sizeof(cuComplex);
         break;
       case Type::C128:
-        ThrowIfErrorStatus(cusolverDnZpotrf_bufferSize(handle.get(), uplo, n,
+        JAX_THROW_IF_ERROR(cusolverDnZpotrf_bufferSize(handle.get(), uplo, n,
                                                        /*A=*/nullptr,
                                                        /*lda=*/n, &lwork));
         workspace_size = lwork * sizeof(cuDoubleComplex);
@@ -187,9 +155,9 @@ void Potrf(cudaStream_t stream, void** buffers, const char* opaque,
       *UnpackDescriptor<PotrfDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
   if (buffers[1] != buffers[0]) {
-    ThrowIfError(cudaMemcpyAsync(buffers[1], buffers[0],
-                                 SizeOfType(d.type) * d.batch * d.n * d.n,
-                                 cudaMemcpyDeviceToDevice, stream));
+    JAX_THROW_IF_ERROR(cudaMemcpyAsync(buffers[1], buffers[0],
+                                       SizeOfType(d.type) * d.batch * d.n * d.n,
+                                       cudaMemcpyDeviceToDevice, stream));
   }
 
   int* info = static_cast<int*>(buffers[2]);
@@ -198,28 +166,28 @@ void Potrf(cudaStream_t stream, void** buffers, const char* opaque,
     switch (d.type) {
       case Type::F32: {
         float* a = static_cast<float*>(buffers[1]);
-        ThrowIfErrorStatus(cusolverDnSpotrf(handle.get(), d.uplo, d.n, a, d.n,
+        JAX_THROW_IF_ERROR(cusolverDnSpotrf(handle.get(), d.uplo, d.n, a, d.n,
                                             static_cast<float*>(workspace),
                                             d.lwork, info));
         break;
       }
       case Type::F64: {
         double* a = static_cast<double*>(buffers[1]);
-        ThrowIfErrorStatus(cusolverDnDpotrf(handle.get(), d.uplo, d.n, a, d.n,
+        JAX_THROW_IF_ERROR(cusolverDnDpotrf(handle.get(), d.uplo, d.n, a, d.n,
                                             static_cast<double*>(workspace),
                                             d.lwork, info));
         break;
       }
       case Type::C64: {
         cuComplex* a = static_cast<cuComplex*>(buffers[1]);
-        ThrowIfErrorStatus(cusolverDnCpotrf(handle.get(), d.uplo, d.n, a, d.n,
+        JAX_THROW_IF_ERROR(cusolverDnCpotrf(handle.get(), d.uplo, d.n, a, d.n,
                                             static_cast<cuComplex*>(workspace),
                                             d.lwork, info));
         break;
       }
       case Type::C128: {
         cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
-        ThrowIfErrorStatus(cusolverDnZpotrf(
+        JAX_THROW_IF_ERROR(cusolverDnZpotrf(
             handle.get(), d.uplo, d.n, a, d.n,
             static_cast<cuDoubleComplex*>(workspace), d.lwork, info));
         break;
@@ -230,29 +198,29 @@ void Potrf(cudaStream_t stream, void** buffers, const char* opaque,
         stream, buffers[1], workspace, d.batch, SizeOfType(d.type) * d.n * d.n);
     // Make sure that accesses to buffer_ptrs_host complete before we delete it.
     // TODO(phawkins): avoid synchronization here.
-    ThrowIfError(cudaStreamSynchronize(stream));
+    JAX_THROW_IF_ERROR(cudaStreamSynchronize(stream));
     switch (d.type) {
       case Type::F32: {
-        ThrowIfErrorStatus(cusolverDnSpotrfBatched(
+        JAX_THROW_IF_ERROR(cusolverDnSpotrfBatched(
             handle.get(), d.uplo, d.n, static_cast<float**>(workspace), d.n,
 
             info, d.batch));
         break;
       }
       case Type::F64: {
-        ThrowIfErrorStatus(cusolverDnDpotrfBatched(
+        JAX_THROW_IF_ERROR(cusolverDnDpotrfBatched(
             handle.get(), d.uplo, d.n, static_cast<double**>(workspace), d.n,
             info, d.batch));
         break;
       }
       case Type::C64: {
-        ThrowIfErrorStatus(cusolverDnCpotrfBatched(
+        JAX_THROW_IF_ERROR(cusolverDnCpotrfBatched(
             handle.get(), d.uplo, d.n, static_cast<cuComplex**>(workspace), d.n,
             info, d.batch));
         break;
       }
       case Type::C128: {
-        ThrowIfErrorStatus(cusolverDnZpotrfBatched(
+        JAX_THROW_IF_ERROR(cusolverDnZpotrfBatched(
             handle.get(), d.uplo, d.n,
             static_cast<cuDoubleComplex**>(workspace), d.n, info, d.batch));
         break;
@@ -276,22 +244,22 @@ std::pair<int, py::bytes> BuildGetrfDescriptor(const py::dtype& dtype, int b,
   int lwork;
   switch (type) {
     case Type::F32:
-      ThrowIfErrorStatus(cusolverDnSgetrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnSgetrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::F64:
-      ThrowIfErrorStatus(cusolverDnDgetrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnDgetrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::C64:
-      ThrowIfErrorStatus(cusolverDnCgetrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnCgetrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::C128:
-      ThrowIfErrorStatus(cusolverDnZgetrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnZgetrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
@@ -305,7 +273,7 @@ void Getrf(cudaStream_t stream, void** buffers, const char* opaque,
       *UnpackDescriptor<GetrfDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
   if (buffers[1] != buffers[0]) {
-    ThrowIfError(cudaMemcpyAsync(
+    JAX_THROW_IF_ERROR(cudaMemcpyAsync(
         buffers[1], buffers[0],
         SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
             static_cast<std::int64_t>(d.m) * static_cast<std::int64_t>(d.n),
@@ -319,7 +287,7 @@ void Getrf(cudaStream_t stream, void** buffers, const char* opaque,
     case Type::F32: {
       float* a = static_cast<float*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnSgetrf(handle.get(), d.m, d.n, a, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnSgetrf(handle.get(), d.m, d.n, a, d.m,
                                             static_cast<float*>(workspace),
                                             ipiv, info));
         a += d.m * d.n;
@@ -331,7 +299,7 @@ void Getrf(cudaStream_t stream, void** buffers, const char* opaque,
     case Type::F64: {
       double* a = static_cast<double*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnDgetrf(handle.get(), d.m, d.n, a, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnDgetrf(handle.get(), d.m, d.n, a, d.m,
                                             static_cast<double*>(workspace),
                                             ipiv, info));
         a += d.m * d.n;
@@ -343,7 +311,7 @@ void Getrf(cudaStream_t stream, void** buffers, const char* opaque,
     case Type::C64: {
       cuComplex* a = static_cast<cuComplex*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnCgetrf(handle.get(), d.m, d.n, a, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnCgetrf(handle.get(), d.m, d.n, a, d.m,
                                             static_cast<cuComplex*>(workspace),
                                             ipiv, info));
         a += d.m * d.n;
@@ -355,7 +323,7 @@ void Getrf(cudaStream_t stream, void** buffers, const char* opaque,
     case Type::C128: {
       cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnZgetrf(
+        JAX_THROW_IF_ERROR(cusolverDnZgetrf(
             handle.get(), d.m, d.n, a, d.m,
             static_cast<cuDoubleComplex*>(workspace), ipiv, info));
         a += d.m * d.n;
@@ -382,22 +350,22 @@ std::pair<int, py::bytes> BuildGeqrfDescriptor(const py::dtype& dtype, int b,
   int lwork;
   switch (type) {
     case Type::F32:
-      ThrowIfErrorStatus(cusolverDnSgeqrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnSgeqrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::F64:
-      ThrowIfErrorStatus(cusolverDnDgeqrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnDgeqrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::C64:
-      ThrowIfErrorStatus(cusolverDnCgeqrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnCgeqrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
     case Type::C128:
-      ThrowIfErrorStatus(cusolverDnZgeqrf_bufferSize(handle.get(), m, n,
+      JAX_THROW_IF_ERROR(cusolverDnZgeqrf_bufferSize(handle.get(), m, n,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, &lwork));
       break;
@@ -411,7 +379,7 @@ void Geqrf(cudaStream_t stream, void** buffers, const char* opaque,
       *UnpackDescriptor<GeqrfDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
   if (buffers[1] != buffers[0]) {
-    ThrowIfError(cudaMemcpyAsync(
+    JAX_THROW_IF_ERROR(cudaMemcpyAsync(
         buffers[1], buffers[0],
         SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
             static_cast<std::int64_t>(d.m) * static_cast<std::int64_t>(d.n),
@@ -425,7 +393,7 @@ void Geqrf(cudaStream_t stream, void** buffers, const char* opaque,
       float* a = static_cast<float*>(buffers[1]);
       float* tau = static_cast<float*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnSgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
+        JAX_THROW_IF_ERROR(cusolverDnSgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
                                             static_cast<float*>(workspace),
                                             d.lwork, info));
         a += d.m * d.n;
@@ -438,7 +406,7 @@ void Geqrf(cudaStream_t stream, void** buffers, const char* opaque,
       double* a = static_cast<double*>(buffers[1]);
       double* tau = static_cast<double*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnDgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
+        JAX_THROW_IF_ERROR(cusolverDnDgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
                                             static_cast<double*>(workspace),
                                             d.lwork, info));
         a += d.m * d.n;
@@ -451,7 +419,7 @@ void Geqrf(cudaStream_t stream, void** buffers, const char* opaque,
       cuComplex* a = static_cast<cuComplex*>(buffers[1]);
       cuComplex* tau = static_cast<cuComplex*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnCgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
+        JAX_THROW_IF_ERROR(cusolverDnCgeqrf(handle.get(), d.m, d.n, a, d.m, tau,
                                             static_cast<cuComplex*>(workspace),
                                             d.lwork, info));
         a += d.m * d.n;
@@ -464,7 +432,7 @@ void Geqrf(cudaStream_t stream, void** buffers, const char* opaque,
       cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
       cuDoubleComplex* tau = static_cast<cuDoubleComplex*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnZgeqrf(
+        JAX_THROW_IF_ERROR(cusolverDnZgeqrf(
             handle.get(), d.m, d.n, a, d.m, tau,
             static_cast<cuDoubleComplex*>(workspace), d.lwork, info));
         a += d.m * d.n;
@@ -491,25 +459,25 @@ std::pair<int, py::bytes> BuildOrgqrDescriptor(const py::dtype& dtype, int b,
   int lwork;
   switch (type) {
     case Type::F32:
-      ThrowIfErrorStatus(cusolverDnSorgqr_bufferSize(handle.get(), m, n, k,
+      JAX_THROW_IF_ERROR(cusolverDnSorgqr_bufferSize(handle.get(), m, n, k,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, /*tau=*/nullptr,
                                                      &lwork));
       break;
     case Type::F64:
-      ThrowIfErrorStatus(cusolverDnDorgqr_bufferSize(handle.get(), m, n, k,
+      JAX_THROW_IF_ERROR(cusolverDnDorgqr_bufferSize(handle.get(), m, n, k,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, /*tau=*/nullptr,
                                                      &lwork));
       break;
     case Type::C64:
-      ThrowIfErrorStatus(cusolverDnCungqr_bufferSize(handle.get(), m, n, k,
+      JAX_THROW_IF_ERROR(cusolverDnCungqr_bufferSize(handle.get(), m, n, k,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, /*tau=*/nullptr,
                                                      &lwork));
       break;
     case Type::C128:
-      ThrowIfErrorStatus(cusolverDnZungqr_bufferSize(handle.get(), m, n, k,
+      JAX_THROW_IF_ERROR(cusolverDnZungqr_bufferSize(handle.get(), m, n, k,
                                                      /*A=*/nullptr,
                                                      /*lda=*/m, /*tau=*/nullptr,
                                                      &lwork));
@@ -524,7 +492,7 @@ void Orgqr(cudaStream_t stream, void** buffers, const char* opaque,
       *UnpackDescriptor<OrgqrDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
   if (buffers[2] != buffers[0]) {
-    ThrowIfError(cudaMemcpyAsync(
+    JAX_THROW_IF_ERROR(cudaMemcpyAsync(
         buffers[2], buffers[0],
         SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
             static_cast<std::int64_t>(d.m) * static_cast<std::int64_t>(d.n),
@@ -538,7 +506,7 @@ void Orgqr(cudaStream_t stream, void** buffers, const char* opaque,
       float* a = static_cast<float*>(buffers[2]);
       float* tau = static_cast<float*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnSorgqr(handle.get(), d.m, d.n, d.k, a, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnSorgqr(handle.get(), d.m, d.n, d.k, a, d.m,
                                             tau, static_cast<float*>(workspace),
                                             d.lwork, info));
         a += d.m * d.n;
@@ -551,7 +519,7 @@ void Orgqr(cudaStream_t stream, void** buffers, const char* opaque,
       double* a = static_cast<double*>(buffers[2]);
       double* tau = static_cast<double*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(
+        JAX_THROW_IF_ERROR(
             cusolverDnDorgqr(handle.get(), d.m, d.n, d.k, a, d.m, tau,
                              static_cast<double*>(workspace), d.lwork, info));
         a += d.m * d.n;
@@ -564,7 +532,7 @@ void Orgqr(cudaStream_t stream, void** buffers, const char* opaque,
       cuComplex* a = static_cast<cuComplex*>(buffers[2]);
       cuComplex* tau = static_cast<cuComplex*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnCungqr(
+        JAX_THROW_IF_ERROR(cusolverDnCungqr(
             handle.get(), d.m, d.n, d.k, a, d.m, tau,
             static_cast<cuComplex*>(workspace), d.lwork, info));
         a += d.m * d.n;
@@ -577,7 +545,7 @@ void Orgqr(cudaStream_t stream, void** buffers, const char* opaque,
       cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[2]);
       cuDoubleComplex* tau = static_cast<cuDoubleComplex*>(buffers[1]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnZungqr(
+        JAX_THROW_IF_ERROR(cusolverDnZungqr(
             handle.get(), d.m, d.n, d.k, a, d.m, tau,
             static_cast<cuDoubleComplex*>(workspace), d.lwork, info));
         a += d.m * d.n;
@@ -609,22 +577,22 @@ std::pair<int, py::bytes> BuildSyevdDescriptor(const py::dtype& dtype,
       lower ? CUBLAS_FILL_MODE_LOWER : CUBLAS_FILL_MODE_UPPER;
   switch (type) {
     case Type::F32:
-      ThrowIfErrorStatus(cusolverDnSsyevd_bufferSize(
+      JAX_THROW_IF_ERROR(cusolverDnSsyevd_bufferSize(
           handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n, /*W=*/nullptr,
           &lwork));
       break;
     case Type::F64:
-      ThrowIfErrorStatus(cusolverDnDsyevd_bufferSize(
+      JAX_THROW_IF_ERROR(cusolverDnDsyevd_bufferSize(
           handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n, /*W=*/nullptr,
           &lwork));
       break;
     case Type::C64:
-      ThrowIfErrorStatus(cusolverDnCheevd_bufferSize(
+      JAX_THROW_IF_ERROR(cusolverDnCheevd_bufferSize(
           handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n, /*W=*/nullptr,
           &lwork));
       break;
     case Type::C128:
-      ThrowIfErrorStatus(cusolverDnZheevd_bufferSize(
+      JAX_THROW_IF_ERROR(cusolverDnZheevd_bufferSize(
           handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n, /*W=*/nullptr,
           &lwork));
       break;
@@ -637,7 +605,7 @@ void Syevd(cudaStream_t stream, void** buffers, const char* opaque,
   const SyevdDescriptor& d =
       *UnpackDescriptor<SyevdDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
-  ThrowIfError(cudaMemcpyAsync(
+  JAX_THROW_IF_ERROR(cudaMemcpyAsync(
       buffers[1], buffers[0],
       SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
           static_cast<std::int64_t>(d.n) * static_cast<std::int64_t>(d.n),
@@ -650,7 +618,7 @@ void Syevd(cudaStream_t stream, void** buffers, const char* opaque,
       float* a = static_cast<float*>(buffers[1]);
       float* w = static_cast<float*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnSsyevd(handle.get(), jobz, d.uplo, d.n, a,
+        JAX_THROW_IF_ERROR(cusolverDnSsyevd(handle.get(), jobz, d.uplo, d.n, a,
                                             d.n, w, static_cast<float*>(work),
                                             d.lwork, info));
         a += d.n * d.n;
@@ -663,7 +631,7 @@ void Syevd(cudaStream_t stream, void** buffers, const char* opaque,
       double* a = static_cast<double*>(buffers[1]);
       double* w = static_cast<double*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnDsyevd(handle.get(), jobz, d.uplo, d.n, a,
+        JAX_THROW_IF_ERROR(cusolverDnDsyevd(handle.get(), jobz, d.uplo, d.n, a,
                                             d.n, w, static_cast<double*>(work),
                                             d.lwork, info));
         a += d.n * d.n;
@@ -676,7 +644,7 @@ void Syevd(cudaStream_t stream, void** buffers, const char* opaque,
       cuComplex* a = static_cast<cuComplex*>(buffers[1]);
       float* w = static_cast<float*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(
+        JAX_THROW_IF_ERROR(
             cusolverDnCheevd(handle.get(), jobz, d.uplo, d.n, a, d.n, w,
                              static_cast<cuComplex*>(work), d.lwork, info));
         a += d.n * d.n;
@@ -689,7 +657,7 @@ void Syevd(cudaStream_t stream, void** buffers, const char* opaque,
       cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
       double* w = static_cast<double*>(buffers[2]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnZheevd(
+        JAX_THROW_IF_ERROR(cusolverDnZheevd(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<cuDoubleComplex*>(work), d.lwork, info));
         a += d.n * d.n;
@@ -718,7 +686,7 @@ std::pair<int, py::bytes> BuildSyevjDescriptor(const py::dtype& dtype,
   auto handle = SolverHandlePool::Borrow();
   int lwork;
   syevjInfo_t params;
-  ThrowIfErrorStatus(cusolverDnCreateSyevjInfo(&params));
+  JAX_THROW_IF_ERROR(cusolverDnCreateSyevjInfo(&params));
   std::unique_ptr<syevjInfo, void (*)(syevjInfo*)> params_cleanup(
       params, [](syevjInfo* p) { cusolverDnDestroySyevjInfo(p); });
   cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR;
@@ -727,22 +695,22 @@ std::pair<int, py::bytes> BuildSyevjDescriptor(const py::dtype& dtype,
   if (batch == 1) {
     switch (type) {
       case Type::F32:
-        ThrowIfErrorStatus(cusolverDnSsyevj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnSsyevj_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params));
         break;
       case Type::F64:
-        ThrowIfErrorStatus(cusolverDnDsyevj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnDsyevj_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params));
         break;
       case Type::C64:
-        ThrowIfErrorStatus(cusolverDnCheevj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnCheevj_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params));
         break;
       case Type::C128:
-        ThrowIfErrorStatus(cusolverDnZheevj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnZheevj_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params));
         break;
@@ -750,22 +718,22 @@ std::pair<int, py::bytes> BuildSyevjDescriptor(const py::dtype& dtype,
   } else {
     switch (type) {
       case Type::F32:
-        ThrowIfErrorStatus(cusolverDnSsyevjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnSsyevjBatched_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params, batch));
         break;
       case Type::F64:
-        ThrowIfErrorStatus(cusolverDnDsyevjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnDsyevjBatched_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params, batch));
         break;
       case Type::C64:
-        ThrowIfErrorStatus(cusolverDnCheevjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnCheevjBatched_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params, batch));
         break;
       case Type::C128:
-        ThrowIfErrorStatus(cusolverDnZheevjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnZheevjBatched_bufferSize(
             handle.get(), jobz, uplo, n, /*A=*/nullptr, /*lda=*/n,
             /*W=*/nullptr, &lwork, params, batch));
         break;
@@ -780,14 +748,14 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       *UnpackDescriptor<SyevjDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
   if (buffers[1] != buffers[0]) {
-    ThrowIfError(cudaMemcpyAsync(
+    JAX_THROW_IF_ERROR(cudaMemcpyAsync(
         buffers[1], buffers[0],
         SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
             static_cast<std::int64_t>(d.n) * static_cast<std::int64_t>(d.n),
         cudaMemcpyDeviceToDevice, stream));
   }
   syevjInfo_t params;
-  ThrowIfErrorStatus(cusolverDnCreateSyevjInfo(&params));
+  JAX_THROW_IF_ERROR(cusolverDnCreateSyevjInfo(&params));
   std::unique_ptr<syevjInfo, void (*)(syevjInfo*)> params_cleanup(
       params, [](syevjInfo* p) { cusolverDnDestroySyevjInfo(p); });
 
@@ -799,7 +767,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::F32: {
         float* a = static_cast<float*>(buffers[1]);
         float* w = static_cast<float*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnSsyevj(handle.get(), jobz, d.uplo, d.n, a,
+        JAX_THROW_IF_ERROR(cusolverDnSsyevj(handle.get(), jobz, d.uplo, d.n, a,
                                             d.n, w, static_cast<float*>(work),
                                             d.lwork, info, params));
         break;
@@ -807,7 +775,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::F64: {
         double* a = static_cast<double*>(buffers[1]);
         double* w = static_cast<double*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnDsyevj(handle.get(), jobz, d.uplo, d.n, a,
+        JAX_THROW_IF_ERROR(cusolverDnDsyevj(handle.get(), jobz, d.uplo, d.n, a,
                                             d.n, w, static_cast<double*>(work),
                                             d.lwork, info, params));
         break;
@@ -815,7 +783,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::C64: {
         cuComplex* a = static_cast<cuComplex*>(buffers[1]);
         float* w = static_cast<float*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnCheevj(
+        JAX_THROW_IF_ERROR(cusolverDnCheevj(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<cuComplex*>(work), d.lwork, info, params));
         break;
@@ -823,7 +791,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::C128: {
         cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
         double* w = static_cast<double*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnZheevj(
+        JAX_THROW_IF_ERROR(cusolverDnZheevj(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<cuDoubleComplex*>(work), d.lwork, info, params));
         break;
@@ -834,7 +802,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::F32: {
         float* a = static_cast<float*>(buffers[1]);
         float* w = static_cast<float*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnSsyevjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnSsyevjBatched(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<float*>(work), d.lwork, info, params, d.batch));
         break;
@@ -842,7 +810,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::F64: {
         double* a = static_cast<double*>(buffers[1]);
         double* w = static_cast<double*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnDsyevjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnDsyevjBatched(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<double*>(work), d.lwork, info, params, d.batch));
         break;
@@ -850,7 +818,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::C64: {
         cuComplex* a = static_cast<cuComplex*>(buffers[1]);
         float* w = static_cast<float*>(buffers[2]);
-        ThrowIfErrorStatus(cusolverDnCheevjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnCheevjBatched(
             handle.get(), jobz, d.uplo, d.n, a, d.n, w,
             static_cast<cuComplex*>(work), d.lwork, info, params, d.batch));
         break;
@@ -858,7 +826,7 @@ void Syevj(cudaStream_t stream, void** buffers, const char* opaque,
       case Type::C128: {
         cuDoubleComplex* a = static_cast<cuDoubleComplex*>(buffers[1]);
         double* w = static_cast<double*>(buffers[2]);
-        ThrowIfErrorStatus(
+        JAX_THROW_IF_ERROR(
             cusolverDnZheevjBatched(handle.get(), jobz, d.uplo, d.n, a, d.n, w,
                                     static_cast<cuDoubleComplex*>(work),
                                     d.lwork, info, params, d.batch));
@@ -886,19 +854,19 @@ std::pair<int, py::bytes> BuildGesvdDescriptor(const py::dtype& dtype, int b,
   int lwork;
   switch (type) {
     case Type::F32:
-      ThrowIfErrorStatus(
+      JAX_THROW_IF_ERROR(
           cusolverDnSgesvd_bufferSize(handle.get(), m, n, &lwork));
       break;
     case Type::F64:
-      ThrowIfErrorStatus(
+      JAX_THROW_IF_ERROR(
           cusolverDnDgesvd_bufferSize(handle.get(), m, n, &lwork));
       break;
     case Type::C64:
-      ThrowIfErrorStatus(
+      JAX_THROW_IF_ERROR(
           cusolverDnCgesvd_bufferSize(handle.get(), m, n, &lwork));
       break;
     case Type::C128:
-      ThrowIfErrorStatus(
+      JAX_THROW_IF_ERROR(
           cusolverDnZgesvd_bufferSize(handle.get(), m, n, &lwork));
       break;
   }
@@ -921,7 +889,7 @@ void Gesvd(cudaStream_t stream, void** buffers, const char* opaque,
   const GesvdDescriptor& d =
       *UnpackDescriptor<GesvdDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
-  ThrowIfError(cudaMemcpyAsync(
+  JAX_THROW_IF_ERROR(cudaMemcpyAsync(
       buffers[1], buffers[0],
       SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
           static_cast<std::int64_t>(d.m) * static_cast<std::int64_t>(d.n),
@@ -935,7 +903,7 @@ void Gesvd(cudaStream_t stream, void** buffers, const char* opaque,
       float* u = static_cast<float*>(buffers[3]);
       float* vt = static_cast<float*>(buffers[4]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnSgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnSgesvd(handle.get(), d.jobu, d.jobvt, d.m,
                                             d.n, a, d.m, s, u, d.m, vt, d.n,
                                             static_cast<float*>(work), d.lwork,
                                             /*rwork=*/nullptr, info));
@@ -953,7 +921,7 @@ void Gesvd(cudaStream_t stream, void** buffers, const char* opaque,
       double* u = static_cast<double*>(buffers[3]);
       double* vt = static_cast<double*>(buffers[4]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnDgesvd(handle.get(), d.jobu, d.jobvt, d.m,
+        JAX_THROW_IF_ERROR(cusolverDnDgesvd(handle.get(), d.jobu, d.jobvt, d.m,
                                             d.n, a, d.m, s, u, d.m, vt, d.n,
                                             static_cast<double*>(work), d.lwork,
                                             /*rwork=*/nullptr, info));
@@ -971,7 +939,7 @@ void Gesvd(cudaStream_t stream, void** buffers, const char* opaque,
       cuComplex* u = static_cast<cuComplex*>(buffers[3]);
       cuComplex* vt = static_cast<cuComplex*>(buffers[4]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnCgesvd(
+        JAX_THROW_IF_ERROR(cusolverDnCgesvd(
             handle.get(), d.jobu, d.jobvt, d.m, d.n, a, d.m, s, u, d.m, vt, d.n,
             static_cast<cuComplex*>(work), d.lwork, /*rwork=*/nullptr, info));
         a += d.m * d.n;
@@ -988,7 +956,7 @@ void Gesvd(cudaStream_t stream, void** buffers, const char* opaque,
       cuDoubleComplex* u = static_cast<cuDoubleComplex*>(buffers[3]);
       cuDoubleComplex* vt = static_cast<cuDoubleComplex*>(buffers[4]);
       for (int i = 0; i < d.batch; ++i) {
-        ThrowIfErrorStatus(cusolverDnZgesvd(
+        JAX_THROW_IF_ERROR(cusolverDnZgesvd(
             handle.get(), d.jobu, d.jobvt, d.m, d.n, a, d.m, s, u, d.m, vt, d.n,
             static_cast<cuDoubleComplex*>(work), d.lwork,
             /*rwork=*/nullptr, info));
@@ -1022,34 +990,34 @@ std::pair<int, py::bytes> BuildGesvdjDescriptor(const py::dtype& dtype,
   cusolverEigMode_t jobz =
       compute_uv ? CUSOLVER_EIG_MODE_VECTOR : CUSOLVER_EIG_MODE_NOVECTOR;
   gesvdjInfo_t params;
-  ThrowIfErrorStatus(cusolverDnCreateGesvdjInfo(&params));
+  JAX_THROW_IF_ERROR(cusolverDnCreateGesvdjInfo(&params));
   std::unique_ptr<gesvdjInfo, void (*)(gesvdjInfo*)> params_cleanup(
       params, [](gesvdjInfo* p) { cusolverDnDestroyGesvdjInfo(p); });
   if (batch == 1) {
     switch (type) {
       case Type::F32:
-        ThrowIfErrorStatus(cusolverDnSgesvdj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnSgesvdj_bufferSize(
             handle.get(), jobz, /*econ=*/0, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params));
         break;
       case Type::F64:
-        ThrowIfErrorStatus(cusolverDnDgesvdj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnDgesvdj_bufferSize(
             handle.get(), jobz, /*econ=*/0, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params));
         break;
       case Type::C64:
-        ThrowIfErrorStatus(cusolverDnCgesvdj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnCgesvdj_bufferSize(
             handle.get(), jobz, /*econ=*/0, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params));
         break;
       case Type::C128:
-        ThrowIfErrorStatus(cusolverDnZgesvdj_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnZgesvdj_bufferSize(
             handle.get(), jobz, /*econ=*/0, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
@@ -1059,28 +1027,28 @@ std::pair<int, py::bytes> BuildGesvdjDescriptor(const py::dtype& dtype,
   } else {
     switch (type) {
       case Type::F32:
-        ThrowIfErrorStatus(cusolverDnSgesvdjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnSgesvdjBatched_bufferSize(
             handle.get(), jobz, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params, batch));
         break;
       case Type::F64:
-        ThrowIfErrorStatus(cusolverDnDgesvdjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnDgesvdjBatched_bufferSize(
             handle.get(), jobz, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params, batch));
         break;
       case Type::C64:
-        ThrowIfErrorStatus(cusolverDnCgesvdjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnCgesvdjBatched_bufferSize(
             handle.get(), jobz, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
             /*ldv=*/n, &lwork, params, batch));
         break;
       case Type::C128:
-        ThrowIfErrorStatus(cusolverDnZgesvdjBatched_bufferSize(
+        JAX_THROW_IF_ERROR(cusolverDnZgesvdjBatched_bufferSize(
             handle.get(), jobz, m, n,
             /*A=*/nullptr, /*lda=*/m, /*S=*/nullptr,
             /*U=*/nullptr, /*ldu=*/m, /*V=*/nullptr,
@@ -1097,7 +1065,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
   const GesvdjDescriptor& d =
       *UnpackDescriptor<GesvdjDescriptor>(opaque, opaque_len);
   auto handle = SolverHandlePool::Borrow(stream);
-  ThrowIfError(cudaMemcpyAsync(
+  JAX_THROW_IF_ERROR(cudaMemcpyAsync(
       buffers[1], buffers[0],
       SizeOfType(d.type) * static_cast<std::int64_t>(d.batch) *
           static_cast<std::int64_t>(d.m) * static_cast<std::int64_t>(d.n),
@@ -1105,7 +1073,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
   int* info = static_cast<int*>(buffers[5]);
   void* work = buffers[6];
   gesvdjInfo_t params;
-  ThrowIfErrorStatus(cusolverDnCreateGesvdjInfo(&params));
+  JAX_THROW_IF_ERROR(cusolverDnCreateGesvdjInfo(&params));
   std::unique_ptr<gesvdjInfo, void (*)(gesvdjInfo*)> params_cleanup(
       params, [](gesvdjInfo* p) { cusolverDnDestroyGesvdjInfo(p); });
   if (d.batch == 1) {
@@ -1115,7 +1083,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         float* s = static_cast<float*>(buffers[2]);
         float* u = static_cast<float*>(buffers[3]);
         float* v = static_cast<float*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnSgesvdj(
+        JAX_THROW_IF_ERROR(cusolverDnSgesvdj(
             handle.get(), d.jobz, /*econ=*/0, d.m, d.n, a, d.m, s, u, d.m, v,
             d.n, static_cast<float*>(work), d.lwork, info, params));
         break;
@@ -1125,7 +1093,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         double* s = static_cast<double*>(buffers[2]);
         double* u = static_cast<double*>(buffers[3]);
         double* v = static_cast<double*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnDgesvdj(
+        JAX_THROW_IF_ERROR(cusolverDnDgesvdj(
             handle.get(), d.jobz, /*econ=*/0, d.m, d.n, a, d.m, s, u, d.m, v,
             d.n, static_cast<double*>(work), d.lwork, info, params));
         break;
@@ -1135,7 +1103,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         float* s = static_cast<float*>(buffers[2]);
         cuComplex* u = static_cast<cuComplex*>(buffers[3]);
         cuComplex* v = static_cast<cuComplex*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnCgesvdj(
+        JAX_THROW_IF_ERROR(cusolverDnCgesvdj(
             handle.get(), d.jobz, /*econ=*/0, d.m, d.n, a, d.m, s, u, d.m, v,
             d.n, static_cast<cuComplex*>(work), d.lwork, info, params));
         break;
@@ -1145,7 +1113,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         double* s = static_cast<double*>(buffers[2]);
         cuDoubleComplex* u = static_cast<cuDoubleComplex*>(buffers[3]);
         cuDoubleComplex* v = static_cast<cuDoubleComplex*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnZgesvdj(
+        JAX_THROW_IF_ERROR(cusolverDnZgesvdj(
             handle.get(), d.jobz, /*econ=*/0, d.m, d.n, a, d.m, s, u, d.m, v,
             d.n, static_cast<cuDoubleComplex*>(work), d.lwork, info, params));
         break;
@@ -1158,7 +1126,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         float* s = static_cast<float*>(buffers[2]);
         float* u = static_cast<float*>(buffers[3]);
         float* v = static_cast<float*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnSgesvdjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnSgesvdjBatched(
             handle.get(), d.jobz, d.m, d.n, a, d.m, s, u, d.m, v, d.n,
             static_cast<float*>(work), d.lwork, info, params, d.batch));
         break;
@@ -1168,7 +1136,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         double* s = static_cast<double*>(buffers[2]);
         double* u = static_cast<double*>(buffers[3]);
         double* v = static_cast<double*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnDgesvdjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnDgesvdjBatched(
             handle.get(), d.jobz, d.m, d.n, a, d.m, s, u, d.m, v, d.n,
             static_cast<double*>(work), d.lwork, info, params, d.batch));
         break;
@@ -1178,7 +1146,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         float* s = static_cast<float*>(buffers[2]);
         cuComplex* u = static_cast<cuComplex*>(buffers[3]);
         cuComplex* v = static_cast<cuComplex*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnCgesvdjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnCgesvdjBatched(
             handle.get(), d.jobz, d.m, d.n, a, d.m, s, u, d.m, v, d.n,
             static_cast<cuComplex*>(work), d.lwork, info, params, d.batch));
         break;
@@ -1188,7 +1156,7 @@ void Gesvdj(cudaStream_t stream, void** buffers, const char* opaque,
         double* s = static_cast<double*>(buffers[2]);
         cuDoubleComplex* u = static_cast<cuDoubleComplex*>(buffers[3]);
         cuDoubleComplex* v = static_cast<cuDoubleComplex*>(buffers[4]);
-        ThrowIfErrorStatus(cusolverDnZgesvdjBatched(
+        JAX_THROW_IF_ERROR(cusolverDnZgesvdjBatched(
             handle.get(), d.jobz, d.m, d.n, a, d.m, s, u, d.m, v, d.n,
             static_cast<cuDoubleComplex*>(work), d.lwork, info, params,
             d.batch));


### PR DESCRIPTION
Before:

    jax._src.traceback_util.UnfilteredStackTrace: RuntimeError: operation not supported

After:

    jax._src.traceback_util.UnfilteredStackTrace: RuntimeError: third_party/py/jax/jaxlib/cusparse.cc:902: CUDA operation cudaMallocAsync(&buffer, bufferSize, stream) failed: operation not supported