### PR TITLE
[jax2tf] Improved error checking for call_tf.

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -280,7 +280,7 @@ def _code_generator_and_avals(
   # TODO(necula): For unoptimized HLO, does it make a difference which device we use?
   tf_device_name = "/device:CPU:0"
   with jax2tf_internal.inside_call_tf():
-    concrete_function_flat_tf = function_flat_tf.get_concrete_function(*args_tf_flat)
+    concrete_function_flat_tf = function_flat_tf.get_concrete_function(*args_flat_sig_tf)
 
   captured_inputs = []
   if concrete_function_flat_tf.captured_inputs:

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -295,9 +295,9 @@ def _code_generator_and_avals(
     for inp in concrete_function_flat_tf.captured_inputs:
       if inp.dtype == tf.resource:  # A variable; assume the next variable
         assert next_var_idx < len(concrete_function_flat_tf.variables)
-        # TODO(necula): better checking that we are picking the right variable
         var = concrete_function_flat_tf.variables[next_var_idx]
         next_var_idx += 1
+        assert inp is var.handle  # For extra safety
         captured_inputs.append(var)
       else:
         captured_inputs.append(inp)

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -277,8 +277,15 @@ def _code_generator_and_avals(
                   shape=a.shape,
                   dtype=a.dtype) for a in args_flat_sig_tf]
 
-  # TODO(necula): For unoptimized HLO, does it make a difference which device we use?
-  tf_device_name = "/device:CPU:0"
+  # TODO(necula): We should use the proper device, because in some cases we
+  # generate different HLO for different devices.
+  # One example is when the code refers to variables on one device. Or, for
+  # sharding annotations (only supported on TPU).
+  # For now we just use the default device, but ideally we should pass the
+  # intended platform in. The problem is that we want to reuse and cache this
+  # function across abstract_eval and XLA translation, but for abstract_eval
+  # we do not know the platform.
+  tf_device_name = f"/device:{jax.default_backend().upper()}:0"
   with jax2tf_internal.inside_call_tf():
     concrete_function_flat_tf = function_flat_tf.get_concrete_function(*args_flat_sig_tf)
 

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -289,7 +289,7 @@ class CallTfTest(tf_test_util.JaxToTfTestCase):
     self.assertAllClose(x * 4. + 1, res, check_dtypes=False)
 
   @parameterized_jit
-  def test_with_tensor_capture(self, with_jit=False):
+  def test_with_tensor_capture(self, with_jit=True):
     outer_tensor = tf.constant(3., dtype=np.float32)
 
     def fun_tf(x):
@@ -804,6 +804,7 @@ class RoundTripToJaxTest(tf_test_util.JaxToTfTestCase):
     #     with tf.init_scope():
     #       added = my_constant * 2
     # The graph tensor has name: args_0:0
+
     # g = jax.grad(f_rt)(x)
 
 class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):

--- a/jax/experimental/jax2tf/tests/call_tf_test.py
+++ b/jax/experimental/jax2tf/tests/call_tf_test.py
@@ -51,7 +51,7 @@ parameterized_jit = parameterized.named_parameters(
     for with_jit in [True, False])
 
 
-class CallTfTest(jtu.JaxTestCase):
+class CallTfTest(tf_test_util.JaxToTfTestCase):
 
   def setUp(self):
     if tf is None:
@@ -639,7 +639,7 @@ class CallTfTest(jtu.JaxTestCase):
     print(jax.make_jaxpr(cos_tf_sin_jax)(x))
     print(jax.xla_computation(cos_tf_sin_jax)(x).as_hlo_text())
 
-class RoundTripToJaxTest(jtu.JaxTestCase):
+class RoundTripToJaxTest(tf_test_util.JaxToTfTestCase):
   "Reloading output of jax2tf into JAX with call_tf"
   def setUp(self):
     if tf is None:
@@ -806,7 +806,7 @@ class RoundTripToJaxTest(jtu.JaxTestCase):
     # The graph tensor has name: args_0:0
     # g = jax.grad(f_rt)(x)
 
-class RoundTripToTfTest(jtu.JaxTestCase):
+class RoundTripToTfTest(tf_test_util.JaxToTfTestCase):
   "Reloading output of call_tf into TF with jax2tf."
 
   def setUp(self):

--- a/jax/experimental/jax2tf/tests/savedmodel_test.py
+++ b/jax/experimental/jax2tf/tests/savedmodel_test.py
@@ -161,7 +161,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
     f_tf = jax2tf.convert(f_jax)
     res = f_tf(*args)
     input_signature = list(tf.TensorSpec(a.shape, a.dtype) for a in args)
-    restored_f = tf_test_util.SaveAndLoadFunction(f_tf, input_signature)
+    restored_f, _ = tf_test_util.SaveAndLoadFunction(f_tf, input_signature)
     res_restored = restored_f(*args)
     self.assertAllClose(res, res_restored)
 
@@ -208,7 +208,7 @@ class SavedModelTest(tf_test_util.JaxToTfTestCase):
                         jnp.sin(np.array([3.14, 2.78], dtype=np.float16)))
 
     # Save and restore SavedModel
-    restored_f = tf_test_util.SaveAndLoadFunction(composed_fn,
+    restored_f, _ = tf_test_util.SaveAndLoadFunction(composed_fn,
                                                   [tf.TensorSpec((2,), dtype=tf.string)])
     res_tf_restored = restored_f(x_str)
     self.assertAllClose(res_tf_restored.numpy(), res_tf.numpy())

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -721,7 +721,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     f_jax = jnp.sin
     f_tf = jax2tf.convert(f_jax, polymorphic_shapes=["(b, ...)"])
     x = np.array([0.7, 0.8], dtype=np.float32)
-    restored_f = tf_test_util.SaveAndLoadFunction(f_tf, [tf.TensorSpec([None], x.dtype)])
+    restored_f, _ = tf_test_util.SaveAndLoadFunction(f_tf, [tf.TensorSpec([None], x.dtype)])
     self.assertAllClose(f_jax(x), restored_f(x))
     # Ensure that restored_f works at other batch size as well
     y = np.concatenate([x, x])
@@ -1369,7 +1369,8 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
   # test will be called "test_prim_xxx_...".
   # If you want to run this test for only one harness that includes "foo"
   # in the name, add parameter `one_containing="foo"` to parameterized below.
-  @primitive_harness.parameterized(_POLY_SHAPE_TEST_HARNESSES)
+  @primitive_harness.parameterized(_POLY_SHAPE_TEST_HARNESSES,
+                                   one_containing="dynamic_slice_enable_xla=True_poly_axes=[0]")
   def test_prim(self, harness: Harness):
     args = harness.dyn_args_maker(self.rng())
     poly_axes = harness.params["poly_axes"]  # type: Sequence[Sequence[int]]


### PR DESCRIPTION
Cleaned up the abstract evaluation for call_tf to work around a bug in TF whereby experimental_get_compiler_ir  cannot be used in a tf.function context.

Added more error messages, e.g., for the case when the TF function has shape-influencing inputs.