### PR TITLE
Unwrap function fully before getting debug_info

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1206,6 +1206,7 @@ def debug_info(fn: Callable, in_tree: Optional[PyTreeDef], has_kwargs: bool,
 def fun_sourceinfo(fun: Callable):
   while isinstance(fun, functools.partial):
     fun = fun.func
+  fun = inspect.unwrap(fun)
   try:
     filename = fun.__code__.co_filename
     lineno = fun.__code__.co_firstlineno


### PR DESCRIPTION
A small bug which surfaces in error messages: if a function has been `functools.wrapped`, some error messages (eg. UnexpectedTracerError) will point to the name of the wrapped function but to the filename of the wrapping function (because `functools.wrapped` does not update the code object of the function, but it _does_ update the name of the function).