### PR TITLE
Avoid sharing handles across streams.

### DIFF
--- a/jaxlib/cublas.cc
+++ b/jaxlib/cublas.cc
@@ -45,16 +45,16 @@ template <>
   BlasHandlePool* pool = Instance();
   absl::MutexLock lock(&pool->mu_);
   cublasHandle_t handle;
-  if (pool->handles_.empty()) {
+  if (pool->handles_[stream].empty()) {
     JAX_THROW_IF_ERROR(cublasCreate(&handle));
   } else {
-    handle = pool->handles_.back();
-    pool->handles_.pop_back();
+    handle = pool->handles_[stream].back();
+    pool->handles_[stream].pop_back();
   }
   if (stream) {
     JAX_THROW_IF_ERROR(cublasSetStream(handle, stream));
   }
-  return Handle(pool, handle);
+  return Handle(pool, handle, stream);
 }
 
 // Set of types known to Cusolver.

--- a/jaxlib/cusolver.cc
+++ b/jaxlib/cusolver.cc
@@ -47,16 +47,16 @@ template <>
   SolverHandlePool* pool = Instance();
   absl::MutexLock lock(&pool->mu_);
   cusolverDnHandle_t handle;
-  if (pool->handles_.empty()) {
+  if (pool->handles_[stream].empty()) {
     JAX_THROW_IF_ERROR(cusolverDnCreate(&handle));
   } else {
-    handle = pool->handles_.back();
-    pool->handles_.pop_back();
+    handle = pool->handles_[stream].back();
+    pool->handles_[stream].pop_back();
   }
   if (stream) {
     JAX_THROW_IF_ERROR(cusolverDnSetStream(handle, stream));
   }
-  return Handle(pool, handle);
+  return Handle(pool, handle, stream);
 }
 
 // Set of types known to Cusolver.

--- a/jaxlib/cusparse.cc
+++ b/jaxlib/cusparse.cc
@@ -142,16 +142,16 @@ template <>
   SparseHandlePool* pool = Instance();
   absl::MutexLock lock(&pool->mu_);
   cusparseHandle_t handle;
-  if (pool->handles_.empty()) {
+  if (pool->handles_[stream].empty()) {
     JAX_THROW_IF_ERROR(cusparseCreate(&handle));
   } else {
-    handle = pool->handles_.back();
-    pool->handles_.pop_back();
+    handle = pool->handles_[stream].back();
+    pool->handles_[stream].pop_back();
   }
   if (stream) {
     JAX_THROW_IF_ERROR(cusparseSetStream(handle, stream));
   }
-  return Handle(pool, handle);
+  return Handle(pool, handle, stream);
 }
 
 cusparseIndexType_t DtypeToCuSparseIndexType(const py::dtype& np_type) {

--- a/jaxlib/rocblas.cc
+++ b/jaxlib/rocblas.cc
@@ -58,11 +58,11 @@ template <>
   rocBlasHandlePool* pool = Instance();
   absl::MutexLock lock(&pool->mu_);
   rocblas_handle handle;
-  if (pool->handles_.empty()) {
+  if (pool->handles_[stream].empty()) {
     ThrowIfErrorStatus(rocblas_create_handle(&handle));
   } else {
-    handle = pool->handles_.back();
-    pool->handles_.pop_back();
+    handle = pool->handles_[stream].back();
+    pool->handles_[stream].pop_back();
   }
   if (stream) {
     ThrowIfErrorStatus(rocblas_set_stream(handle, stream));


### PR DESCRIPTION
When running across 8xV100 GPUs we observed the following error:

    libc++abi: terminating with uncaught exception of type std::runtime_error: third_party/py/jax/jaxlib/cusolver.cc:171: operation cusolverDnSpotrf(handle.get(), d.uplo, d.n, a, d.n, static_cast<float*>(workspace), d.lwork, info) failed: cuSolver execution failed

I cannot find documentation to this effect, but I believe that it is unsafe to share cuSolver handles across streams, since keeping the handle pool stream local does solve the issue.