### PR TITLE
Fix linker error due to cusparseGetErrorString

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -80,6 +80,7 @@ cc_library(
     ],
     features = ["-use_header_modules"],
     deps = [
+        "@org_tensorflow//tensorflow/stream_executor/cuda:cusparse_lib",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
`cusparseGetErrorString` is external symbol, without cusparse_lib as dependency, linker error.