### PR TITLE
[jax2tf] Expand the handling of shape-polymorphic einsum.

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -435,7 +435,8 @@ def _einsum_contract_path(*operands, **kwargs):
   # sizes of operands and intermediate results.
   fake_ops = []
   for operand in operands:
-    if isinstance(operand, str):
+    # We replace only array operands
+    if not hasattr(operand, "dtype"):
       fake_ops.append(operand)
     else:
       shape = np.shape(operand)

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -982,13 +982,28 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   [RandArg((3, 4), _f32)],
                   poly_axes=[0]),
 
+    _make_harness("einsum", "0_alt",
+                  lambda x: jnp.einsum(x, (..., 1), [...]),
+                  [RandArg((3, 4), _f32)],
+                  poly_axes=[0]),
+
     _make_harness("einsum", "1",
                   lambda x, y: jnp.einsum("...ij,...jk->...ik", x, y),
                   [RandArg((3, 4, 5), _f32), RandArg((3, 5, 6), _f32)],
                   poly_axes=[0, 0]),
 
+    _make_harness("einsum", "1_alt",
+                  lambda x, y: jnp.einsum(x, [..., 0, 1], y, (..., 1, 2), [..., 0, 2]),
+                  [RandArg((3, 4, 5), _f32), RandArg((3, 5, 6), _f32)],
+                  poly_axes=[0, 0]),
+
     _make_harness("einsum", "2",
                   lambda x, y: jnp.einsum("...ij,jk->...ik", x, y),
+                  [RandArg((3, 4, 5), _f32), RandArg((5, 6), _f32)],
+                  poly_axes=[0, None]),
+
+    _make_harness("einsum", "2_alt",
+                  lambda x, y: jnp.einsum(x, [..., 0, 1], y, [1, 2], [..., 0, 2]),
                   [RandArg((3, 4, 5), _f32), RandArg((5, 6), _f32)],
                   poly_axes=[0, None]),
 
@@ -998,11 +1013,25 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   [RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
                   poly_axes=[1, 0]),
 
+    _make_harness("einsum", "3_alt",
+                  # Reduced dimension is polymorphic
+                  lambda x, y: jnp.einsum(x, [0, 1], y, [1, 2], [0, 2]),
+                  [RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
+                  poly_axes=[1, 0]),
+
     _make_harness("einsum", "4",
                   # Reduced dimension is polymorphic, and is 2*b
                   lambda x, y: jnp.einsum("ij,jk->ik",
                                           jnp.concatenate([x, x], axis=1),
                                           jnp.concatenate([y, y], axis=0)),
+                  [RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
+                  poly_axes=[1, 0]),
+
+    _make_harness("einsum", "4_alt",
+                  # Reduced dimension is polymorphic, and is 2*b
+                  lambda x, y: jnp.einsum(jnp.concatenate([x, x], axis=1), [0, 1],
+                                          jnp.concatenate([y, y], axis=0), [1, 2],
+                                          [0, 2]),
                   [RandArg((3, 4), _f32), RandArg((4, 5), _f32)],
                   poly_axes=[1, 0]),
 


### PR DESCRIPTION
einsum supports an API where the arrays are interleaved with list
of indices.