### PR TITLE
[jax2tf] Expand shape polymorphism support to use dimension polynomials as values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,18 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.19 (unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jax-v0.2.18...main).
 
+* New features:
+  * Improved the support for shape polymorphism in jax2tf for operations that
+    need to use a dimension size in array computation, e.g., `jnp.mean`.
+    ({jax-issue}`#7317`)
+  
 ## jaxlib 0.1.70 (unreleased)
 * Breaking changes:
   * Support for Python 3.6 has been dropped, per the
     [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html).
     Please upgrade to a supported Python version.
-
-
-* Breaking changes:
-  * The host_callback mechnism now uses one thread per local device for
+    
+  * The host_callback mechanism now uses one thread per local device for
     making the calls to the Python callbacks. Previously there was a single
     thread for all devices. This means that the callbacks may now be called
     interleaved. The callbacks corresponding to one device will still be

--- a/jax/core.py
+++ b/jax/core.py
@@ -1283,6 +1283,9 @@ class DimensionHandler:
     """Implements `0 if d == 0 else 1 + dilation * (d - 1))`"""
     return 0 if d == 0 else 1 + dilation * (d - 1)
 
+  def as_value(self, d: DimSize):
+    """Turns a dimension size into a JAX value that we can compute with."""
+    return d
 
 _dimension_handler_int = DimensionHandler()
 _SPECIAL_DIMENSION_HANDLERS: Dict[type, DimensionHandler] = {}
@@ -1378,6 +1381,11 @@ def stride_shape(s: Shape, window_size: Shape, window_stride: Shape) -> Shape:
   """(s - window_size) // window_stride + 1"""
   return tuple(map(stride_dim, s, window_size, window_stride))
 
+def dimension_as_value(d: DimSize):
+  """Turns a dimension size into a JAX value that we can compute with.
+     This is the identity function for constant dimensions."""
+  handler, ds = _dim_handler_and_canonical(d)
+  return handler.as_value(*ds)
 
 def _canonicalize_dimension(dim: DimSize) -> DimSize:
   if type(dim) in _SPECIAL_DIMENSION_HANDLERS:

--- a/jax/experimental/jax2tf/__init__.py
+++ b/jax/experimental/jax2tf/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from .jax2tf import convert, dtype_of_val, shape_as_value, split_to_logical_devices, PolyShape
+from .jax2tf import convert, dtype_of_val, split_to_logical_devices, PolyShape
 from .call_tf import call_tf

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -338,8 +338,8 @@ class JaxToTfTestCase(jtu.JaxTestCase):
     """
     f_tf = jax2tf.convert(f_jax, polymorphic_shapes=polymorphic_shapes,
                              enable_xla=enable_xla)
-    f_tf = tf.function(f_tf, autograph=False, input_signature=input_signature)
-    concrete_f_tf = f_tf.get_concrete_function(*input_signature)
+    f_tf_func = tf.function(f_tf, autograph=False, input_signature=input_signature)
+    concrete_f_tf = f_tf_func.get_concrete_function(*input_signature)
     if expected_output_signature:
       # Strangely, output_shapes can be a single shape for a function with a
       # single result, or a list/tuple of shapes.


### PR DESCRIPTION

The goal of this change is to support shape polymorphism for operations
such as average (which needs to divide by the size of a dimension) or
indexing (which needs to normalize indices by comparing them with 0 and
adding dimension size for negative indices). In both of these cases
the size of a dimenion needs to be used as a value in the array
computation. In general, the size of a dimension is used only to
customize primitives.

This change introduces `core.dim_as_value` which must be used on
a dimension size before using it as a value in the array computation.
E.g.,

```
def average(x):
   return jnp.sum(x, axis=0) / core.dim_as_value(x.shape[0])
```

This function is the identity function if the dimension size is
constant, otherwise it uses a new primitive `shape_poly.dim_as_value_p`.

Note that this does not change fundamentally the flavor of shape
polymorphism supported in jax2tf: intermediate shapes and their values
may depend on the input shapes, but never does a shape depend on the
input values. In fact, one could have expressed the `dim_as_value`
already:

```
def dim_as_value(d):
   jnp.sum(jnp.broadcast_to(jnp.array(1), shape=(d,)))
```

We were able to suppot `jnp.mean` and `jnp.take` by using
`core.dim_as_value` internally, but to fully roll-up the solution
we need to make `core.dim_as_value` a public API and teach the
users how to use it when they want to use shape polymorphism.
Alternatively, perhaps there is a way to automatically convert
dimension polynomials to values when passed to the lax primitives.