### PR TITLE
[jax2tf] Improved error checking for inconsistent use of a dimension …

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -711,7 +711,7 @@ self.assertEqual(0, f_jax(x0))  # JAX sees that the x.shape[0] == 0
 
 # jax2tf catches the broken assumption b >= 1 if the converted function is executed
 # eagerly.
-# Raises: ValueError: PolyShape 'b' has dimension variable 'b' corresponding to 0, for argument shape (0,)
+# Raises: ValueError: PolyShape ('b',) has dimension variable 'b' corresponding to 0, for argument shapes (TensorShape([0]),)
 jax2tf.convert(f_jax, polymorphic_shapes=["b"])(x0))
 
 # However, if we first trace to a TensorFlow graph, we may miss the broken assumption:
@@ -734,7 +734,7 @@ self.assertEqual(0, f_jax(x45))  # JAX seems that x.shape[0] != x.shape[1]
 
 # jax2tf catches the broken assumption x.shape[0] == x.shape[1] if the converted
 # function is executed eagerly.
-# Raises: ValueError: PolyShape 'b, b' has dimension variable 'b' corresponding to multiple values ([4, 5]), for argument shape (4, 5)
+# Raises: ValueError: PolyShape ('b, b',) has dimension variable 'b' corresponding to multiple values {4, 5}, for argument shapes (TensorShape([4, 5]),)
 jax2tf.convert(f_jax, polymorphic_shapes=["b, b"])(x45)
 
 # However, if we first trace to a TensorFlow graph, we may miss the broken assumption.

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -559,7 +559,7 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
       return functools.reduce(op.mul, map(_parse_factor, factors))
     return functools.reduce(op.add, map(_parse_term, terms))
 
-  shape_var_map: Dict[str, Set[int]] = collections.defaultdict(set)
+
   def _process_dim(i: int, dim_spec: Union[str, int]):
     if isinstance(dim_spec, str):
       dim_spec = dim_spec.strip()
@@ -588,24 +588,9 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
                  f"for known dimension in argument shape {arg_shape}")
           raise ValueError(msg)
         return dim_size
-      # We have a dimension polynomial for a known dimension.
-      dim_var = dim_poly.to_var()  # type: ignore
-      if dim_var is not None:
-        shape_var_map[dim_spec].add(dim_size)  # type: ignore
       return dim_poly
 
   dims = tuple([_process_dim(i, ds) for i, ds in enumerate(spec_tuple)])
-  for dim_var, dim_var_values in shape_var_map.items():
-    if len(dim_var_values) != 1:
-      msg = (f"PolyShape '{spec}' has dimension variable '{dim_var}' "
-             f"corresponding to multiple values ({sorted(dim_var_values)}), for "
-             f"argument shape {arg_shape}")
-      raise ValueError(msg)
-    elif list(dim_var_values)[0] <= 0:
-      msg = (f"PolyShape '{spec}' has dimension variable '{dim_var}' "
-             f"corresponding to 0, for argument shape {arg_shape}")
-      raise ValueError(msg)
-
   return dims
 
 


### PR DESCRIPTION
…variable

Previously the check was done only for multiple occurrences of a shape
variable in one argument. Now we check across all arguments.