### PR TITLE
Don't wrap static arguments in hashable wrappers in pmap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.22 (Unreleased)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.21...main).
+* Breaking Changes
+  * Static arguments to `jax.pmap` must now be hashable.
+
+    Unhashable static arguments have long been disallowed on `jax.jit`, but they
+    were still permitted on `jax.pmap`; `jax.pmap` compared unhashable static
+    arguments using object identity.
+
+    This behavior is a footgun, since comparing arguments using
+    object identity leads to recompilation each time the object identity
+    changes. Instead, we now ban unhashable arguments: if a user of `jax.pmap`
+    wants to compare static arguments by object identity, they can define
+    `__hash__` and `__eq__` methods on their objects that do that, or wrap their
+    objects in an object that has those operations with object identity
+    semantics. Another option is to use `functools.partial` to encapsulate the
+    unhashable static arguments into the function object.
+  * `jax.util.partial` was an accidental export that has now been removed. Use
+    `functools.partial` from the Python standard library instead.
 
 ## jax 0.2.21 (Sept 23, 2021)
 * [GitHub
@@ -19,9 +36,9 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * `jax.api` has been removed. Functions that were available as `jax.api.*`
     were aliases for functions in `jax.*`; please use the functions in
     `jax.*` instead.
-  * `jax.partial`, `jax.lax.partial`, and `jax.util.partial` were accidental
-    exports that have now been removed. Use `functools.partial` from the Python
-    standard library instead.
+  * `jax.partial`, and `jax.lax.partial` were accidental exports that have now
+    been removed. Use `functools.partial` from the Python standard library
+    instead.
   * Boolean scalar indices now raise a `TypeError`; previously this silently
     returned wrong results ({jax-issue}`#7925`).
   * Many more `jax.numpy` functions now require array-like inputs, and will error

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -218,17 +218,14 @@ def prod(xs):
     out *= x
   return out
 
-class WrapHashably:
+class Unhashable:
   __slots__ = ["val"]
 
   def __init__(self, val):
     self.val = val
 
-  def __hash__(self):
-    return id(self.val)
-
   def __eq__(self, other):
-    return self.val is other.val
+    return self.val == other.val
 
 class Hashable:
   __slots__ = ["val"]

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1759,6 +1759,16 @@ class PythonPmapTest(jtu.JaxTestCase):
 
     A().my_func_pmap(jnp.asarray([3] * jax.device_count()))
 
+  def test_pmap_error_on_non_hashable_static_argument(self):
+    f = lambda x, y: x + 3
+    pmapped_f = self.pmap(f, static_broadcasted_argnums=(1,))
+
+    inputs = np.asarray([1] * jax.device_count())
+    with self.assertRaisesRegex(
+        ValueError, "Non-hashable static arguments are not supported.*"):
+      pmapped_f(inputs, np.asarray(1))
+
+
 
 class CppPmapTest(PythonPmapTest):
 


### PR DESCRIPTION
* Delete wrap_hashably().
* In argnums_partial, either enforce hashability or wrap values with an explicitly unhashable wrapper. The intent here is that either we should check for hashability early or we should make sure it's clear that it's not something we intended..
* Delete argnames_partial, which appears unused.