### PR TITLE
Improve wording for multi-process docs

### DIFF
--- a/docs/multi_process.md
+++ b/docs/multi_process.md
@@ -12,8 +12,8 @@ operations (e.g. {func}`jax.lax.psum`) in multi-process settings, although other
 communication methods may be useful too depending on your use case (e.g. RPC,
 [mpi4jax](https://github.com/mpi4jax/mpi4jax)). If you’re not already familiar
 with JAX’s collective operations, we recommend starting with the
-{doc}`/jax-101/06-parallelism` notebook. An important feature of multi-process
-environments is direct communication links between accelerators, e.g. the
+{doc}`/jax-101/06-parallelism` notebook. An important requirement of multi-process
+environments in JAX is direct communication links between accelerators, e.g. the
 high-speed interconnects for Cloud TPUs or
 [NCCL](https://developer.nvidia.com/nccl) for GPUs. These links are what allow
 collective operations to run across multiple process’ worth of accelerators.


### PR DESCRIPTION
Currently, there is no direct implication that device-to-device links are a requirement.

Though it is a very small change, it would have saved me a couple of hours in trying to leverage NCCL's ability to create rings over ethernet to run JAX.

I'm sure others will also appreciate this.