### PR TITLE
Add shape and dtype of leaked tracer to UnexpectedTracerError.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -445,7 +445,8 @@ def escaped_tracer_error(tracer, detail=None):
     pass
   else:
     msg += ('\nThe tracer that caused this error was created on line '
-            f'{source_info_util.summarize(line_info)}.\n')
+            f'{source_info_util.summarize(line_info)}. The tracer has'
+            f' shape {tracer.shape} and dtype {tracer.dtype}.\n')
     if num_frames > 0:
       msg += (f'When the tracer was created, the final {num_frames} stack '
               'frames (most recent last) excluding JAX-internal frames were:\n'

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2292,6 +2292,12 @@ class APITest(jtu.JaxTestCase):
       jax.eval_shape(self.helper_save_tracer, 1)
       _ = self._saved_tracer+1
 
+  def test_escaped_tracer_shape_dtype(self):
+    with self.assertRaisesRegex(core.UnexpectedTracerError,
+                                r"shape \(4, 3\) and dtype int32"):
+      jax.jit(self.helper_save_tracer)(jnp.ones((4, 3), dtype=jnp.int32))
+      _ = self._saved_tracer+1
+
   def test_pmap_static_kwarg_error_message(self):
     # https://github.com/google/jax/issues/3007
     def f(a, b):


### PR DESCRIPTION
Adding some extra info which helped me track down a leaked tracer. Looks like:
```
...
The tracer that caused this error was created on line (...)
The tracer has shape (4, 3) and dtype int32.
...
```