### PR TITLE
Remove custom __hash__ implementation

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1311,11 +1311,6 @@ for device_array in [DeviceArray]:
   # clobbered when jax.numpy is imported, but useful in tests
   setattr(device_array, "__eq__", lambda self, other: self._value == other)
 
-  def __hash__(self):
-    raise TypeError("JAX DeviceArray, like numpy.ndarray, is not hashable.")
-
-  setattr(device_array, "__hash__", __hash__)
-
   # The following methods are dynamically overridden in lax_numpy.py.
   def raise_not_implemented():
     raise NotImplementedError

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1308,6 +1308,9 @@ for device_array in [DeviceArray]:
   setattr(device_array, "__reduce__",
           partialmethod(_forward_to_value, op.methodcaller("__reduce__")))
 
+  # explicitly set to be unhashable.
+  setattr(device_array, "__hash__", None)
+
   # clobbered when jax.numpy is imported, but useful in tests
   setattr(device_array, "__eq__", lambda self, other: self._value == other)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2077,10 +2077,7 @@ class APITest(jtu.JaxTestCase):
     rep = jnp.ones(()) + 1.
     self.assertIsInstance(rep, jax.interpreters.xla.DeviceArray)
     msg = "JAX DeviceArray, like numpy.ndarray, is not hashable."
-    with self.assertRaisesRegex(TypeError, msg):
-      hash(rep)
-    with self.assertRaisesRegex(TypeError, msg):
-      hash(rep.device_buffer)
+    self.assertNotIsInstance(rep, collections.Hashable)
 
   def test_grad_without_enough_args_error_message(self):
     # https://github.com/google/jax/issues/1696

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2076,7 +2076,6 @@ class APITest(jtu.JaxTestCase):
   def test_device_array_hash(self):
     rep = jnp.ones(()) + 1.
     self.assertIsInstance(rep, jax.interpreters.xla.DeviceArray)
-    msg = "JAX DeviceArray, like numpy.ndarray, is not hashable."
     self.assertNotIsInstance(rep, collections.Hashable)
 
   def test_grad_without_enough_args_error_message(self):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2077,6 +2077,8 @@ class APITest(jtu.JaxTestCase):
     rep = jnp.ones(()) + 1.
     self.assertIsInstance(rep, jax.interpreters.xla.DeviceArray)
     self.assertNotIsInstance(rep, collections.Hashable)
+    with self.assertRaisesRegex(TypeError, 'unhashable type'):
+      hash(rep)
 
   def test_grad_without_enough_args_error_message(self):
     # https://github.com/google/jax/issues/1696


### PR DESCRIPTION
Currently Jax arrays pass the check isinstance(x, collections.Hashable) despite not being hashable.  The [python datamodel](https://docs.python.org/3/reference/datamodel.html#object.__hash__) says that 

> A class that overrides __eq__() and does not define __hash__() will have its __hash__() implicitly set to None. When the __hash__() method of a class is None, instances of the class will raise an appropriate TypeError when a program attempts to retrieve their hash value, and will also be correctly identified as unhashable when checking isinstance(obj, collections.abc.Hashable).

This PR removes the custom implementation of __hash__.