### PR TITLE
fix xla.lower_fun axis env issue

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1021,7 +1021,8 @@ def lower_fun(fun, multiple_results, parallel=False, with_avals=False, backend=N
     wrapped_fun = lu.wrap_init(fun, params)
     if not multiple_results:
       wrapped_fun = _tuple_output(wrapped_fun)
-    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
+    with core.extend_axis_env_nd(zip(axis_env.names, axis_env.sizes)):
+      jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
     outs = jaxpr_subcomp(c, jaxpr, backend, axis_env, _xla_consts(c, consts), '',
                          *xla_args)
     if multiple_results or any(v.aval._num_buffers > 1 for v in jaxpr.outvars):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1788,6 +1788,17 @@ class APITest(jtu.JaxTestCase):
   def test_xla_computation_donate_argnums(self):
     api.xla_computation(lambda x: None, donate_argnums=(0,))(3)  # doesn't crash
 
+  def test_xla_computation_lower_fun_axis_env(self):
+    axis_name = 'i'
+    def fn(x):
+      y = lax.all_gather(
+              x, axis_name=axis_name)
+      return y * lax.axis_index(axis_name).astype(jnp.float32)
+
+    input_x = jnp.ones((5,6,4))
+    axis_env = [(axis_name, api.local_device_count())]
+    _ = api.xla_computation(fn, axis_env=axis_env, backend='cpu')(input_x)
+
   def test_concurrent_device_get_and_put(self):
     def f(x):
       for _ in range(100):


### PR DESCRIPTION
We weren't using the translation-time axis env to populate the tracing-time axis env when calling `xla.lower_fun`, as done in the all_gather translation on non-gpu backends.

Usually we think of translation-to-XLA as happening after all the tracing is done. But actually it's convenient to write translation rules by writing out some Python which calls into `lax`/`jnp` and then tracing it, rather than writing explicit calls into the XLA Builder API. So our translation rules sometimes turn around and do more tracing, using the `xla.lower_fun` utility!

That was the setting for this issue. When we define axis names, we have a (global) trace-time data structure which tracks their sizes, which is how e.g. axis size data is available at trace time (e.g. via `psum(1, axis_name)`, which evaluates to a regular Python integer that you can print and branch on). We also need that information at translation-to-xla time, so there's a separate (local) translation-time environment.

But when our translation-to-XLA process jumps back into tracing Python using `xla.lower_fun`, that means we again might use the tracing-time axis environment. Hence we need the translation-time axis environment to populate the tracing-time axis environment! That part was missing, but was a one-liner fix.

The test uses `all_gather` which on non-GPU backends calls into `xla.lower_fun`.