### PR TITLE
refine constant-hoisting heuristic in closure_convert

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -568,7 +568,7 @@ class Tracer:
 
   def __repr__(self):
     base = pp('Traced<{}>with<{}>'.format(self.aval, self._trace))
-    contents = self._contents()
+    contents = [(name, pp(repr(attr))) for name, attr in self._contents()]
     if contents:
       base += pp('  with ') >> vcat(pp('{} = '.format(name)) >> pp_payload
                                     for name, pp_payload in contents)
@@ -576,7 +576,7 @@ class Tracer:
 
   def _contents(self):
     try:
-      return [(name, pp(repr(getattr(self, name)))) for name in self.__slots__]
+      return [(name, getattr(self, name)) for name in self.__slots__]
     except AttributeError:
       return ()
 


### PR DESCRIPTION
Instead of hoisting all float-type arrays during closure conversion, only hoist values of type `JVPTracer` (or tracers carrying such tracers indirectly). Doing so better approximates the subset of closure-captured values that participate in automatic differentiation.

Potentially fixes #6415