### PR TITLE
fix: miss typo codespell and documentation

### DIFF
--- a/examples/control.py
+++ b/examples/control.py
@@ -33,7 +33,7 @@ import jax.ops as jo
 #   all(X[t + 1] == f(X[t], U[t]) for t in range(T)) .
 #
 # The special case in which `c` is quadratic and `f` is linear is the
-# linear-quadratic regulator (LQR) problem, and can be specified explicity
+# linear-quadratic regulator (LQR) problem, and can be specified explicitly
 # further below.
 #
 ControlSpec = collections.namedtuple(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6564,7 +6564,7 @@ def rng_bit_generator(key,
   (what is required to be an integer type) using the platform specific
   default algorithm or the one specified.
 
-  It provides direct acces to the RngBitGenerator primitive exposed by XLA
+  It provides direct access to the RngBitGenerator primitive exposed by XLA
   (https://www.tensorflow.org/xla/operation_semantics#rngbitgenerator) for low
   level API access.
 
@@ -6980,7 +6980,7 @@ def _abstractify(x):
 
 
 def _check_user_dtype_supported(dtype, fun_name=None):
-  # Avoid using `dtype in [...]` becuase of numpy dtype equality overloading.
+  # Avoid using `dtype in [...]` because of numpy dtype equality overloading.
   if isinstance(dtype, type) and dtype in {bool, int, float, complex}:
     return
   np_dtype = np.dtype(dtype)

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -974,7 +974,7 @@ def all_gather(x, axis_name, *, axis_index_groups=None, axis=0, tiled=False):
       concatenated.
     tiled: when ``False``, the chunks will be stacked into a fresh positional
       axis at index ``axis`` in the output. When ``True``, ``axis`` has to
-      refer to an exising positional dimension and the chunks will be
+      refer to an existing positional dimension and the chunks will be
       concatenated into that dimension.
 
   Returns:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1624,7 +1624,7 @@ def union1d(ar1, ar2, *, size=None):
 
 
 @_wraps(np.setxor1d, lax_description="""
-In the JAX version, the input arrays are explicilty flattened regardless
+In the JAX version, the input arrays are explicitly flattened regardless
 of assume_unique value.
 """)
 def setxor1d(ar1, ar2, assume_unique=False):
@@ -5725,7 +5725,7 @@ def digitize(x, bins, right=False):
 
 _PIECEWISE_DOC = """\
 Unlike `np.piecewise`, :py:func:`jax.numpy.piecewise` requires functions in
-`funclist` to be traceable by JAX, as it is implemeted via :func:`jax.lax.switch`.
+`funclist` to be traceable by JAX, as it is implemented via :func:`jax.lax.switch`.
 See the :func:`jax.lax.switch` documentation for more information.
 """
 

--- a/jax/_src/scipy/eigh.py
+++ b/jax/_src/scipy/eigh.py
@@ -90,7 +90,7 @@ def _projector_subspace(P, H, rank, maxiter=2):
 @jax.partial(jax.jit, static_argnums=(3, 4))
 def _split_spectrum_jittable(P, H, V0, rank, precision):
   """ The jittable portion of `split_spectrum`. At this point the sizes of the
-  relavant matrix blocks have been concretized.
+  relevant matrix blocks have been concretized.
 
   Args:
     P: Projection matrix.
@@ -200,7 +200,7 @@ def eigh(
     symmetrize: If True, `0.5 * (H + H.conj().T)` rather than `H` is used.
     termination_size: Recursion ends once the blocks reach this linear size.
   Returns:
-    vals: The `n` eigenvalues of `H`, sorted from lowest to higest.
+    vals: The `n` eigenvalues of `H`, sorted from lowest to highest.
     vecs: A unitary matrix such that `vecs[:, i]` is a normalized eigenvector
       of `H` corresponding to `vals[i]`. We have `H @ vecs = vals * vecs` up
       to numerical error.

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -994,6 +994,6 @@ The set of limitations is an over-approximation, in the sense that if XLA
 or TensorFlow improves and support more cases, no test will fail. Instead,
 periodically, we check for unnecessary limitations. We do this by uncommenting
 two assertions (in `tests/jax_primitives_coverage_test.py` and in
-`tests/tf_test_util.py`) and runing all the tests. With these assertions enabled
+`tests/tf_test_util.py`) and running all the tests. With these assertions enabled
 the tests will fail and point out unnecessary limitations. We remove limitations
 until the tests pass. Then we re-generate the documentation.

--- a/jax/experimental/jax2tf/examples/serving/model_server_request.py
+++ b/jax/experimental/jax2tf/examples/serving/model_server_request.py
@@ -46,7 +46,7 @@ flags.DEFINE_string(
     "prediction_service_addr",
     "localhost:8500",
     "Stubby endpoint for the prediction service. If you serve your model "
-    "locally using TensorFlow model server, then you can use \"locahost:8500\""
+    "locally using TensorFlow model server, then you can use \"localhost:8500\""
     "for the gRPC server and \"localhost:8501\" for the HTTP REST server.")
 
 flags.DEFINE_integer("serving_batch_size", 1,

--- a/jax/experimental/jax2tf/examples/tflite/mnist/mnist.py
+++ b/jax/experimental/jax2tf/examples/tflite/mnist/mnist.py
@@ -113,7 +113,7 @@ def main(_):
   print('which is about %d%% of the float model size.' %
         (quantized_model_size * 100 / float_model_size))
 
-  # Evaluate the TF Lite float model. You'll find that its accurary is identical
+  # Evaluate the TF Lite float model. You'll find that its accuracy is identical
   # to the original Flax model because they are essentially the same model
   # stored in different format.
   float_accuracy = evaluate_tflite_model(tflite_float_model, test_ds)

--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -74,7 +74,7 @@ More detailed information can be found in the
 | conv_general_dilated | TF error: jax2tf BUG: batch_group_count > 1 not yet converted | all | cpu, gpu, tpu | compiled, eager, graph |
 | digamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | div | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
-| dot_general | TF error: Numeric comparision disabled: Non-deterministic NaN for dot_general with preferred_element_type on GPU (b/189287598) | bfloat16, complex64, float16, float32 | gpu | compiled, eager, graph |
+| dot_general | TF error: Numeric comparison disabled: Non-deterministic NaN for dot_general with preferred_element_type on GPU (b/189287598) | bfloat16, complex64, float16, float32 | gpu | compiled, eager, graph |
 | dot_general | TF test skipped: Not implemented in JAX: preferred_element_type=c128 not implemented | complex64 | tpu | compiled, eager, graph |
 | dot_general | TF test skipped: Not implemented in JAX: preferred_element_type=i64 not implemented | int16, int32, int8 | tpu | compiled, eager, graph |
 | dot_general | TF error: op not defined for dtype | bool | cpu, gpu, tpu | compiled, eager, graph |

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1347,7 +1347,7 @@ def _not(x):
   """Computes bitwise not with support for booleans.
 
   Numpy and JAX support bitwise not for booleans by applying a logical not!
-  This means that applying bitwise_not yields an unexected result:
+  This means that applying bitwise_not yields an unexpected result:
     jnp.bitwise_not(jnp.array([True, False]))
     >> DeviceArray([False,  True], dtype=bool)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4813,7 +4813,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     assertAllEqual(np.mgrid[:3:2, :2, :5], jnp.mgrid[:3:2, :2, :5])
     # Corner cases
     assertAllEqual(np.mgrid[:], jnp.mgrid[:])
-    # When the step length is a complex number, becuase of float calculation,
+    # When the step length is a complex number, because of float calculation,
     # the values between jnp and np might slightly different.
     atol = 1e-6
     rtol = 1e-6

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1148,7 +1148,7 @@ class PmapTest(jtu.JaxTestCase):
     # axis_index_groups = [[0, 2], [1, 3]]
     # output = [[0, 4], [2, 6], [1, 5], [3, 7]]
     #
-    # This is essentially like spliting the number of rows in the input in two
+    # This is essentially like splitting the number of rows in the input in two
     # groups of rows, and swaping the two inner axes (axis=1 and axis=2), which
     # is exactly what the test case checks.
     device_count = xla_bridge.device_count()


### PR DESCRIPTION
fix miss typo codespell and documentation on ```google/jax```