### PR TITLE
Replaced Any with concrete types for APIs in jaxlib.xla_client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: mypy
     files: jax/
-    additional_dependencies: [types-requests==0.1.11]
+    additional_dependencies: [types-requests==0.1.11, jaxlib==0.1.70]
 
 - repo: https://github.com/mwouts/jupytext
   rev: v1.10.0

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1804,8 +1804,9 @@ def _cpp_pmap(
 
     return out, fastpath_data
 
-  cpp_mapped_f = pmap_lib.pmap(fun, cache_miss, static_broadcasted_tuple,
-                               pxla._shard_arg)
+  # TODO(slebedev): Remove the ignore once jaxlib>=0.1.71.
+  cpp_mapped_f = pmap_lib.pmap(fun, cache_miss,  # type: ignore[call-arg]
+                               static_broadcasted_tuple, pxla._shard_arg)
 
   # TODO(jblespiau): make cpp callable follow descriptor protocol for bound
   # methods

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2750,7 +2750,8 @@ def _add_inverse(r, x, y):
   yr = r - x
   return xr, yr
 
-add_p = standard_naryop([_num, _num], 'add')
+# TODO(slebedev): Why does mypy fail to infer the type here?
+add_p: Primitive = standard_naryop([_num, _num], 'add')
 ad.primitive_jvps[add_p] = _add_jvp
 ad.primitive_transposes[add_p] = _add_transpose
 iad.definverse(add_p, _add_inverse)
@@ -6588,7 +6589,7 @@ rng_bit_generator_p.def_abstract_eval(
 xla.translations[rng_bit_generator_p] = _rng_bit_generator_translation_rule
 
 RandomAlgorithm = xops.RandomAlgorithm
-RandomAlgorithm.__str__ = lambda algorithm: algorithm.name
+RandomAlgorithm.__str__ = lambda algorithm: algorithm.name  # type: ignore[assignment]
 
 
 def rng_bit_generator(key,

--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -16,7 +16,7 @@ import contextlib
 import itertools
 import os.path
 import threading
-from typing import Any, Optional, Iterator
+from typing import Optional, Iterator
 
 import jax.version
 from jax.lib import xla_client
@@ -25,8 +25,8 @@ from jax._src import traceback_util
 traceback_util.register_exclusion(__file__)
 
 
-Traceback = Any  # xla_client.Traceback
-Frame = Any  # xla_client.Traceback::Frame
+Traceback = xla_client.Traceback
+Frame = xla_client.Frame
 
 _exclude_paths = [os.path.dirname(jax.version.__file__)]
 

--- a/jax/api_util.py
+++ b/jax/api_util.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from . import core
 from ._src import dtypes
-from .tree_util import (tree_flatten, tree_unflatten, tree_multimap,
+from .tree_util import (PyTreeDef, tree_flatten, tree_unflatten, tree_multimap,
                         tree_structure, treedef_children, treedef_is_leaf)
 from ._src.tree_util import _replace_nones
 from . import linear_util as lu
@@ -86,7 +86,6 @@ def apply_flat_fun_nokwargs(fun, io_tree, py_args):
   ans = fun(*args)
   return tree_unflatten(out_tree, ans)
 
-PyTreeDef = Any
 def flattened_fun_in_tree(fn: lu.WrappedFun) -> Optional[Tuple[PyTreeDef, bool]]:
   # This implementation relies on internal details of linear_util.py's
   # WrappedFun, but it's for the worthy cause of better user error messages.

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -494,12 +494,11 @@ def _use_outfeed(platform: str) -> bool:
 
 xops = xla_client._xla.ops
 
-# TODO(necula): fix mypy errors if I define the type aliases below
-XlaOp = Any  # xla_extension.XlaOp
-XlaShape = Any  # xla_client.Shape
-XlaComputationBuilder = Any  # xla_bridge._JaxComputationBuilder
-XlaDevice = Any  # xla_client.Device
-XlaLocalClient = Any  # xla_extension.LocalClient
+XlaOp = xla_client.XlaOp
+XlaShape = xla_client.Shape
+XlaComputationBuilder = xla_client.XlaBuilder
+XlaDevice = xla_client.Device
+XlaLocalClient = xla_client.Client
 DType = Any
 
 T = TypeVar('T')

--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -382,7 +382,7 @@ def _code_generator_and_avals(
 
   result_avals = tuple(map(canonical_res_aval, result_shapes))  # type: ignore
 
-  def code_gen(builder: xla.XlaShape, args_op: Sequence[xla.XlaOp]) -> xla.XlaOp:
+  def code_gen(builder: xla.XlaComputationBuilder, args_op: Sequence[xla.XlaOp]) -> xla.XlaOp:
     captured_ops = [xops.ConstantLiteral(builder, np.asarray(inp))
                     for inp in captured_inputs]
 

--- a/jax/experimental/optimizers.py
+++ b/jax/experimental/optimizers.py
@@ -108,7 +108,7 @@ OptimizerState = namedtuple("OptimizerState",
 register_pytree_node(
     OptimizerState,
     lambda xs: ((xs.packed_state,), (xs.tree_def, xs.subtree_defs)),
-    lambda data, xs: OptimizerState(xs[0], data[0], data[1]))
+    lambda data, xs: OptimizerState(xs[0], data[0], data[1]))  # type: ignore[index]
 
 
 Array = Any

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -28,7 +28,7 @@ from .._src import dtypes
 from .. import linear_util as lu
 from jax._src.ad_util import Zero
 from ..api_util import flattened_fun_in_tree
-from .._src.tree_util import tree_unflatten, tree_leaves
+from .._src.tree_util import PyTreeDef, tree_unflatten, tree_leaves
 from .._src.util import (unzip2, safe_zip, safe_map, toposort, partial,
                          split_list, cache, as_hashable_function)
 from ..core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
@@ -1188,7 +1188,6 @@ class DebugInfo(NamedTuple):
   traced_for: str
   arg_info: Callable[[int], str]
 
-PyTreeDef = Any
 
 def debug_info_final(fn: lu.WrappedFun, traced_for: str) -> DebugInfo:
   in_tree, has_kwargs = flattened_fun_in_tree(fn) or (None, False)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -34,8 +34,9 @@ from collections import defaultdict, OrderedDict
 import itertools as it
 import operator as op
 import threading
-from typing import (Any, Callable, Dict, List, Optional, Sequence, Set, Tuple,
-                    Type, Union, Iterable, NamedTuple, TYPE_CHECKING)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional,
+                    Sequence, Set, Tuple, Type, Union, Iterable)
+
 from absl import logging
 import numpy as np
 
@@ -79,33 +80,12 @@ unsafe_map, map = map, safe_map  # type: ignore
 
 Index = Union[int, slice, Tuple[Union[int, slice], ...]]
 
+NoSharding = pmap_lib.NoSharding
+Chunked = pmap_lib.Chunked
+Unstacked = pmap_lib.Unstacked
 
-# mypy cannot deal with the C++ types. An alternative is to use `# type: ignore`
-if TYPE_CHECKING:
-  # We cannot use `NoSharding = Any` with mypy, otherwise you get:
-  # error: Cannot use isinstance() with Any type  [misc]
-  class NoSharding:
-    pass
-
-  class Chunked(NamedTuple):
-    chunks: List[int]
-
-  class Unstacked(NamedTuple):
-    size: int
-
-  class ShardedAxis(NamedTuple):
-    axis: int
-
-  class Replicated(NamedTuple):
-    replicas: int
-else:
-  # See the C++ code for comments.
-  NoSharding = pmap_lib.NoSharding
-  Chunked = pmap_lib.Chunked
-  Unstacked = pmap_lib.Unstacked
-
-  ShardedAxis = pmap_lib.ShardedAxis
-  Replicated = pmap_lib.Replicated
+ShardedAxis = pmap_lib.ShardedAxis
+Replicated = pmap_lib.Replicated
 
 _UNSHARDED_INSTANCE = NoSharding()
 AvalDimSharding = Union[Unstacked, Chunked, NoSharding]
@@ -501,8 +481,10 @@ def make_sharded_device_array(
   if (_USE_CPP_SDA and
       (not device_buffers or
        isinstance(device_buffers[0], xb.xla_client.Buffer))):
-    return pmap_lib.ShardedDeviceArray(aval, sharding_spec, device_buffers,
-                                       indices, aval.weak_type)
+    # TODO(slebedev): Remove the ignore once jaxlib>=0.1.71.
+    return pmap_lib.ShardedDeviceArray(
+        aval, sharding_spec, device_buffers,  # type: ignore[arg-type, call-arg]
+        indices, aval.weak_type)
 
   return _ShardedDeviceArray(aval, sharding_spec, device_buffers, indices)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -51,14 +51,14 @@ xe = xc._xla
 xops = xc._xla.ops
 
 # Types
-Backend = Any  # xc.LocalBackend (why does mypy not like this?)
-Device = Any  # xc.Device
-Buffer = Any
+Backend = xe.Client
+Device = xc.Device
+Buffer = xe.Buffer
 
-XlaOp = Any  # xla_extension.XlaOp
-XlaShape = Any # xla_client.Shape
-XlaComputationBuilder = Any  # xla_bridge._JaxComputationBuilder
-XlaExecutable = Any # xla_extension.LocalExecutable
+XlaOp = xc.XlaOp
+XlaShape = xc.Shape
+XlaComputationBuilder = xc.XlaBuilder
+XlaExecutable = xc.Executable
 
 # This flag is set on exit; no logging should be attempted
 _on_exit = False
@@ -1097,7 +1097,7 @@ def make_device_array(
   This is to be used only within JAX. It will return either a PythonDeviceArray
   or a C++ equivalent implementation.
   """
-  if (isinstance(device_buffer, _CppDeviceArray)):
+  if isinstance(device_buffer, _CppDeviceArray):
 
     if device_buffer.aval == aval and device_buffer._device == device:
       return device_buffer

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -38,6 +38,7 @@ for examples.
 # flake8: noqa: F401
 from jax._src.tree_util import (
   Partial,
+  PyTreeDef,
   all_leaves,
   build_tree,
   register_pytree_node,


### PR DESCRIPTION
`jaxlib.xla_client` is a native extension module and is therefore opaque to mypy. To overcome that JAX used `Any` for classes defined in `jaxlib.xla_client`. This PR replaces `Any` with concrete types and updates/corrects existing usages to make mypy happy.