### PR TITLE
[jax2tf] Improve the error message when forgetting polymorphic_shapes

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -228,10 +228,10 @@ f_tf.get_concrete_function(tf.TensorSpec([None, 28, 28], tf.float32))
 
 The `polymorphic_shapes` parameter, in the form of a sequence of strings corresponding
 to the sequence of positional
-arguments, introduces one or more shape variables, e.g., `b`, to stand for shape
+arguments, introduces one or more dimension variables, e.g., `b`, to stand for shape
 dimensions that are assumed to be unknown at JAX tracing time, even if the actual
 parameter value (here `tf.TensorSpec(...)`) happens to have fully known shape.
-Shape variables are assumed to range
+Dimension variables are assumed to range
 over all strictly positive integers.
 In this particular example, we can
 also abbreviate `polymorphic_shapes=["(b, _, _)"]`,
@@ -249,7 +249,7 @@ multiple unknown dimensions and there is a relationship between them.
 For example,
 if the function to be converted is also polymorphic on the size of each
 image while requiring the images to be square,
-we would add a shape variable `d` to stand for
+we would add a dimension variable `d` to stand for
 the unknown image size:
 
 ```
@@ -329,7 +329,7 @@ A shape specifier is combined with a `TensorSpec` as follows:
          The abstract value of the dimension is going to be set to this variable.
          The corresponding dimension in `TensorSpec` can be `None` or can be a
          constant.
-       * All occurrences of a shape variable in any dimension
+       * All occurrences of a dimension variable in any dimension
          for any argument are assumed to be equal.
 
 Note that `polymorphic_shapes` controls the shape abstraction used by JAX when tracing
@@ -429,14 +429,14 @@ values of the dimension variables `b` and `w`:
 
 ```
 def image_mask_tf(images, mask):
-  b, w, _ = tf.shape(images) # Compute the dynamic values for the shape variables "b" and "w"
+  b, w, _ = tf.shape(images) # Compute the dynamic values for the dimension variables "b" and "w"
   return tf.math.multiply(images,
                           tf.broadcast_to(tf.reshape(mask, [1, w, w]),
                                           [b, w, w]))
 ```
 
 To achieve this, when we start converting a function we construct a shape environment,
-mapping the shape variables in the `polymorphic_shapes` specification to TensorFlow expressions
+mapping the dimension variables in the `polymorphic_shapes` specification to TensorFlow expressions
 using `tf.shape` on the input parameters.
 
 
@@ -498,7 +498,7 @@ jax2tf.convert(lambda x: jnp.reshape(x, (-1, x.shape[0])),
 
 Finally, certain codes that use shapes in the actual computation may not yet work
 if those shapes are polymorphic. In the code below, the expression `x.shape[0]`
-will have the value of the shape variable `v`. This case is not yet implemented:
+will have the value of the dimension variable `v`. This case is not yet implemented:
 
 ```
 jax2tf.convert(lambda x: jnp.sum(x, axis=0) / x.shape[0],

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -62,7 +62,7 @@ class _DimMon(dict):
 
   The representation is a dictionary mapping var:exponent.
   The `var` are strings and the exponents are >= 1.
-  The shape variables are assumed to range over integers >= 1.
+  The dimension variables are assumed to range over integers >= 1.
   """
   def __hash__(self):
     return hash(frozenset(self.items()))
@@ -127,7 +127,7 @@ class _DimMon(dict):
 class _DimPolynomial(dict):
   """Polynomial with integer coefficients for polymorphic shapes.
 
-  The shape variables are assumed to range over integers >= 1.
+  The dimension variables are assumed to range over integers >= 1.
 
   We overload integer operations, but we do that soundly, raising
   :class:`InconclusiveDimensionOperation` when the result is not
@@ -599,15 +599,18 @@ def parse_spec(spec: Optional[Union[str, PolyShape]],
     if isinstance(dim_size, tf.compat.v1.Dimension):
       dim_size = dim_size.value
     if dim_size is None:
-      if dim_spec == "_":
-        msg = (f"PolyShape {repr(spec)} in axis {i} must contain a shape variable "
+      def need_dim_var_msg():
+        msg = (f"PolyShape {repr(spec)} in axis {i} must contain a dimension variable "
                f"for unknown dimension in argument shape {arg_shape}")
-        raise ValueError(msg)
+        if spec is None:
+          msg += ". Perhaps you forgot to add the polymorphic_shapes= parameter to jax2tf.convert?"
+        return msg
+
+      if dim_spec == "_":
+        raise ValueError(need_dim_var_msg())
       dim_poly = _parse_dim(dim_spec)
       if not is_poly_dim(dim_poly):
-        msg = (f"PolyShape {repr(spec)} in axis {i} must contain a shape variable "
-               f"for unknown dimension in argument shape {arg_shape}")
-        raise ValueError(msg)
+        raise ValueError(need_dim_var_msg())
       return dim_poly
     else:  # dim_size is known
       dim_size = int(dim_size)

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -337,6 +337,14 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
         polymorphic_shapes=PS("h", "h"),
         expected_output_signature=tf.TensorSpec([None, None]))
 
+  def test_forgot_polymorphic_shapes_error(self):
+    msg_re = "PolyShape None in axis .* must contain a dimension variable for unknown dimension in argument shape .*. Perhaps you forgot to add the polymorphic_shapes"
+    with self.assertRaisesRegex(ValueError, msg_re):
+      self.CheckShapePolymorphism(
+          jnp.sin,
+          input_signature=[tf.TensorSpec([1, None])],
+          polymorphic_shapes=None)
+
   def test_arg_avals(self):
     """Test conversion of actual arguments to abstract values."""
 
@@ -479,7 +487,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     with self.assertRaisesRegex(
         ValueError,
         re.escape(
-            "PolyShape None in axis 1 must contain a shape variable for unknown dimension in argument shape (2, None)"
+            "PolyShape None in axis 1 must contain a dimension variable for unknown dimension in argument shape (2, None)"
         )):
       check_avals(
           args=[tf_var([2, None], initializer_shape=(2, 3))],
@@ -495,7 +503,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     with self.assertRaisesRegex(
         ValueError,
         re.escape(
-            "PolyShape '(_, _)' in axis 1 must contain a shape variable "
+            "PolyShape '(_, _)' in axis 1 must contain a dimension variable "
             "for unknown dimension in argument shape (2, None)"
         )):
       check_avals(
@@ -517,7 +525,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     with self.assertRaisesRegex(
         ValueError,
         re.escape(
-            "PolyShape '(2, 3)' in axis 1 must contain a shape variable for "
+            "PolyShape '(2, 3)' in axis 1 must contain a dimension variable for "
             "unknown dimension in argument shape (2, None)"
         )):
       check_avals(
@@ -856,7 +864,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
     self.assertEqual(1, f_tf(x0))
 
     # Unsoundness: not checking that the actual dimensions denoted by the same
-    # shape variables have equal sizes.
+    # dimension variables have equal sizes.
     def f_jax(x):
       return 0 if x.shape[0] != x.shape[1] else 1
 
@@ -986,7 +994,7 @@ def _make_harness(group_name: str, name: str,
   polymorphic axis), or a tuple of ints (for multiple polymorphic axes).
 
   For each argument, we use its `poly_axes` entry to generate the polymorphic_shapes
-  specification, creating shape variables `b0`, `b1, ..., for each of its
+  specification, creating dimension variables `b0`, `b1, ..., for each of its
   polymorphic axes. This means that separate arguments will share the same
   dimension variable names, in the order in which the axes are listed in
   poly_axes.


### PR DESCRIPTION
Also replaced "shape variable" with "dimension variable" in error
message and documentation.

Fixes: #7213