### PR TITLE
In some cases axis_name is a tuple instead of string, handling it in …

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1131,7 +1131,7 @@ core.axis_substitution_rules[all_gather_p] = partial(_subst_all_names_in_param, 
 
 def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
   # In some cases axis_name is a tuple instead of string, so handling these types here.
-  if type(axis_name) in [tuple, list]:
+  if isinstance(axis_name,(tuple, list)):
       axis_name = axis_name[0]
   axis_pos = list(axis_env.names).index(axis_name)
   nreplicas = axis_env.nreps // prod(axis_env.sizes)

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1130,6 +1130,9 @@ batching.collective_rules[all_gather_p] = _all_gather_batched_collective
 core.axis_substitution_rules[all_gather_p] = partial(_subst_all_names_in_param, 'axis_name')
 
 def _axis_index_translation_rule(c, *, axis_name, axis_env, platform):
+  # In some cases axis_name is a tuple instead of string, so handling these types here.
+  if type(axis_name) in [tuple, list]:
+      axis_name = axis_name[0]
   axis_pos = list(axis_env.names).index(axis_name)
   nreplicas = axis_env.nreps // prod(axis_env.sizes)
   div = xb.constant(c, np.array(nreplicas * prod(axis_env.sizes[axis_pos+1:]),


### PR DESCRIPTION
In some cases axis_name is a tuple instead of string, so handling below error here.

```
File "/home/mohan/.local/lib/python3.8/site-packages/jax/interpreters/xla.py", line 479, in jaxpr_subcomp
    ans = rule(c, *in_nodes, axis_env=axis_env, platform=platform, **eqn.params)
  File "/home/mohan/.local/lib/python3.8/site-packages/jax/_src/lax/parallel.py", line 1133, in _axis_index_translation_rule
    axis_pos = list(axis_env.names).index(axis_name)
ValueError: ('mp',) is not in list
```