### PR TITLE
[jax2tf] Refactored the handling of float0.

### DIFF
--- a/jax/experimental/jax2tf/call_tf.py
+++ b/jax/experimental/jax2tf/call_tf.py
@@ -374,7 +374,7 @@ def _code_generator_and_avals(
     # call_tf is a multiple_results primitive.
     result_shapes = (result_shape,)
   else:
-    result_shapes = result_shape.tuple_shapes()
+    result_shapes = result_shape.tuple_shapes()  # type: ignore
 
   result_avals = tuple(map(canonical_res_aval, result_shapes))  # type: ignore
 

--- a/jax/experimental/jax2tf/examples/serving/model_server_request.py
+++ b/jax/experimental/jax2tf/examples/serving/model_server_request.py
@@ -18,7 +18,7 @@ See README.md for instructions.
 import grpc  # type: ignore[import]
 import json
 import logging
-import requests
+import requests  # type: ignore[import]
 
 from absl import app
 from absl import flags


### PR DESCRIPTION
JAX and TF have different ways of dealing with tangents and co-tangents for
exact types. JAX uses float0 values. TF sometimes uses None, sometines
integer (or boolean) zeros. In the JAX VJP function we convert the
None's to zeros. On exit from the VJP function we convert the float0
to zeros.