### PR TITLE
fix cond-of-pmap bug

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -307,11 +307,13 @@ def extract_call_jaxpr(
     return (params["call_jaxpr"], new_params)
 
 
+# TODO(mattjj): replace this approach with a primitive-keyed table of rules
 def traverse_jaxpr_params(f, params):
   """Applies f to each jaxpr parameter and returns a tuple of returned values."""
-  return {name: f(param)
+  return {name: f(p)
           for name, param in params.items()
-          if type(param) in (Jaxpr, ClosedJaxpr)}
+          for p in (param if isinstance(param, (tuple, list)) else [param])
+          if type(p) in (Jaxpr, ClosedJaxpr)}
 
 
 def eval_jaxpr(jaxpr: Jaxpr, consts, *args):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1701,6 +1701,17 @@ class PmapTest(jtu.JaxTestCase):
     out_dtype = func(unused_arg).dtype
     self.assertEqual(out_dtype, dtype)
 
+  def test_num_replicas_with_switch(self):
+    # https://github.com/google/jax/issues/7411
+    def identity(x):
+      return x
+
+    def cond_of_pmap(x):
+      y = lax.cond(True, jax.pmap(identity), jax.pmap(identity), x)
+      return y
+
+    cond_of_pmap(jnp.zeros((xla_bridge.device_count(), 2)))
+
 
 class VmapOfPmapTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Fixes #7411

From that issue:

> The issue was in core.traverse_jaxpr_params, which assumed that all subjaxprs appear as values in the params dict, while lax.switch (aka lax.cond) actually has a param value which is a tuple of jaxprs. Those tuple elements were being ignored!

> I'm going to make a quick fix which just flattens params to one level, but I think a better approach here would be to have a primitive-keyed table of rules for traversing subjaxprs.