### PR TITLE
[jax2tf] Fix translation of broadcast_in_dim for TF1

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -369,7 +369,9 @@ class _DimPolynomial(dict):
         return coeff * mon
       else:
         return 0 if coeff == 0 else mon if coeff == 1 else coeff * mon
-    terms = [mul(coeff, prod([pow(env[id], deg) for id, deg in mon.items()]))
+    def pow_opt(v, p):
+      return v if p == 1 else pow(v, p)
+    terms = [mul(coeff, prod([pow_opt(env[id], deg) for id, deg in mon.items()]))
              for mon, coeff in self.items()]
     return sum(terms) if len(terms) > 1 else terms[0]
 

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -1127,6 +1127,21 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   lambda x: jnp.broadcast_to(x, [x.shape[0], x.shape[0], 4]),
                   [RandArg((3, 4), _f32)],
                   poly_axes=[0]),
+    _make_harness("broadcast_in_dim", "0",
+                  lambda x: lax.broadcast_in_dim(x, [x.shape[0], 4, 5, 6],
+                                                 broadcast_dimensions=(0, 2, 3)),
+                  [RandArg((3, 1, 6), _f32)],
+                  poly_axes=[0]),
+    _make_harness("broadcast_in_dim", "poly",
+                  lambda x: lax.broadcast_in_dim(x, [x.shape[0], x.shape[0] + x.shape[0], 4],
+                                                 broadcast_dimensions=(0, 1, 2)),
+                  [RandArg((3, 1, 4), _f32)],
+                  poly_axes=[0]),
+    _make_harness("broadcast_in_dim", "poly2",
+                  lambda x: lax.broadcast_in_dim(x, [x.shape[0], 5, 6, x.shape[2], 4],
+                                                 broadcast_dimensions=(0, 2, 3)),
+                  [RandArg((3, 1, 4), _f32)],
+                  poly_axes=[(0, 2)]),
     _make_harness("clamp", "",
                   lax.clamp,
                   [RandArg((3, 4, 5), _f32), RandArg((3, 4, 5), _f32),
@@ -1585,7 +1600,7 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
   # to parameterized below.
   @primitive_harness.parameterized(
       _flatten_harnesses(_POLY_SHAPE_TEST_HARNESSES),
-      #one_containing="reshape_error_poly_axes"
+      #one_containing="broadcast_in_dim_poly_axes"
   )
   def test_prim(self, harness: Harness):
     args = harness.dyn_args_maker(self.rng())


### PR DESCRIPTION
It turns out that in TF1, a `None` dimension has the property
that `not (shape[0] == 1)` and `not (shape[0] != 1)`. In TF2,
we have `(shape[0] == 1)` is False, and its negation is True.
Both behaviors are unsound.

The TF1 behavior was leading to an error in the broadcast_in_dim
translation rule. I rewrote that rule to not look at the
`operand.shape` and thus not have to compute with TF dimension values.
To the best of my knowledge the previous translation was sound
for TF2, but the new one should be more obviously sound.

Fixes: #7344