### PR TITLE
[ROCm] Change skip_on_devices to handle device tags

### DIFF
--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -105,6 +105,7 @@ class FftTest(jtu.JaxTestCase):
       for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
       for axes in _get_fftn_test_axes(shape)
       for s in _get_fftn_test_s(shape, axes)))
+  @jtu.skip_on_devices("rocm")
   def testFftn(self, inverse, real, shape, dtype, axes, s):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)
@@ -123,6 +124,7 @@ class FftTest(jtu.JaxTestCase):
       tol = 0.15
       jtu.check_grads(jnp_fn, args_maker(), order=2, atol=tol, rtol=tol)
 
+  @jtu.skip_on_devices("rocm")
   def testIrfftTranspose(self):
     # regression test for https://github.com/google/jax/issues/6223
     def build_matrix(linear_func, size):
@@ -182,6 +184,7 @@ class FftTest(jtu.JaxTestCase):
       for shape in [(10,)]
       for n in [None, 1, 7, 13, 20]
       for axis in [-1, 0]))
+  @jtu.skip_on_devices("rocm")
   def testFft(self, inverse, real, hermitian, shape, dtype, n, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)
@@ -246,6 +249,7 @@ class FftTest(jtu.JaxTestCase):
       for dtype in (real_dtypes if real and not inverse else all_dtypes)
       for shape in [(16, 8, 4, 8), (16, 8, 4, 8, 4)]
       for axes in [(-2, -1), (0, 1), (1, 3), (-1, 2)]))
+  @jtu.skip_on_devices("rocm")
   def testFft2(self, inverse, real, shape, dtype, axes):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)


### PR DESCRIPTION
**Please do not merge this PR before merging https://github.com/tensorflow/tensorflow/pull/50972. Its functionality depends on the change in platform_version in TF/PJRT**

This PR changes the skip_in_devices to compare the input list of skipped devices to a set of tags assigned based on the underlying device. 

How does it work?
When a test case decorated with skip_on_devices is executed, we find all the associated tags with the current device and compare it with the skip_on_devices list. If there is a common item between these two, we skip the test.

How can it be helpful?
At runtime, we specify all the tags associated with the device and it is more flexible than using a single tag for the device. For example, we have adopted this to skip on some FFT tests only for ROCm.

@hawkinsp , @deven-amd
