### PR TITLE
Implement squeeze masking rule

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3899,10 +3899,15 @@ def _squeeze_batch_rule(batched_args, batch_dims, *, dimensions):
   dimensions = tuple(np.add(1, dimensions))
   return squeeze(operand, dimensions=dimensions), 0
 
+def _squeeze_masking_rule(padded_args, logical_shapes, *, dimensions):
+  operand, = padded_args
+  return squeeze(operand, dimensions=dimensions)
+
 squeeze_p = standard_primitive(_squeeze_shape_rule, _squeeze_dtype_rule,
                                'squeeze', _squeeze_translation_rule)
 ad.deflinear2(squeeze_p, _squeeze_transpose_rule)
 batching.primitive_batchers[squeeze_p] = _squeeze_batch_rule
+masking.masking_rules[squeeze_p] = _squeeze_masking_rule
 
 
 def expand_dims(array: Array, dimensions: Tuple[int, ...]) -> Array:


### PR DESCRIPTION
This PR implements a masking rule for `lax.squeeze`.

## Why?

`lax.matmul` calls `lax.squeeze`:

https://github.com/google/jax/blob/655a3e79c23060e87595d4a52dc595352fa29c9b/jax/_src/numpy/lax_numpy.py#L4212-L4213

... which was throwing an error when multiplying masked matrices `a` and `b` shaped like:

```
a.polymorphic_shape = (1, 12, 1, n + 1)
b.polymorphic_shape = (1, 12, n + 1, 64)
```