### PR TITLE
Type stubs for jaxlib.xla_extension no longer use -stubs suffix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "de22145c9dc51b3ed9399dbee2ab681f094f09e5213d6819451da500f163a14b",
-    strip_prefix = "tensorflow-8cc3ffa8d8e4dd659c1534849cf5984ef4ec3532",
+    sha256 = "7fd95869adcb2769287d95f64768cc7e4c643fa8f881eff63c1e57ada2fde6de",
+    strip_prefix = "tensorflow-75d966de4f859ebcc094d8222432cf1f0f3a217e",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/8cc3ffa8d8e4dd659c1534849cf5984ef4ec3532.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/75d966de4f859ebcc094d8222432cf1f0f3a217e.tar.gz",
     ],
 )
 

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -100,13 +100,8 @@ def patch_copy_xla_extension_stubs(dst_dir):
   # type stubs.
   with open(os.path.join(dst_dir, "py.typed"), "w"):
     pass
-  # The -stubs suffix is required by PEP-561.
-  xla_extension_dir = os.path.join(dst_dir, "xla_extension-stubs")
+  xla_extension_dir = os.path.join(dst_dir, "xla_extension")
   os.makedirs(xla_extension_dir)
-  # Create a dummy __init__.py to convince setuptools that
-  # xla_extension-stubs is a package.
-  with open(os.path.join(xla_extension_dir, "__init__.py"), "w"):
-    pass
   for stub_name in _XLA_EXTENSION_STUBS:
     with open(r.Rlocation(
         "org_tensorflow/tensorflow/compiler/xla/python/xla_extension/" + stub_name)) as f:

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -30,14 +30,14 @@ setup(
     description='XLA library for JAX',
     author='JAX team',
     author_email='jax-dev@google.com',
-    packages=['jaxlib', 'jaxlib.xla_extension-stubs'],
+    packages=['jaxlib', 'jaxlib.xla_extension'],
     python_requires='>=3.7',
     install_requires=['scipy', 'numpy>=1.18', 'absl-py', 'flatbuffers >= 1.12, < 3.0'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     package_data={
         'jaxlib': ['*.so', '*.pyd*', 'py.typed', 'cuda/nvvm/libdevice/libdevice*'],
-        'jaxlib.xla_extension-stubs': ['*.pyi'],
+        'jaxlib.xla_extension': ['*.pyi'],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
PEP-561 does not specify whether subpackages of a non-stub-only-package
could use the -stubs suffix. setuptools seems to allow that, yet mypy fails
to resolve the subpackage with a -stubs suffix.

This PR makes jaxlib.xla_extension a ~normal package with a toplevel `__init__.pyi`.

Unblocks #7386.