### PR TITLE
Perform float16 dot()s in float32 on CPU.

### DIFF
--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -405,7 +405,11 @@ class Jax2TfLimitation(primitive_harness.Limitation):
             devices="gpu",
             modes=("eager", "graph", "compiled"),
             enabled=(harness.params["preferred_element_type"] is not None),
-            skip_comparison=True)
+            skip_comparison=True),
+        # JAX performs float16 matmuls in float32 on CPU, so the JAX result
+        # may be more precise.
+        custom_numeric(dtypes=[np.float16], devices=["cpu"], tol=1e-2,
+                       modes=("eager", "graph", "compiled")),
     ]
 
   @classmethod


### PR DESCRIPTION
The XLA/CPU float16 matmul is very slow, so we may as well upcast to float32 for matmuls and cast the result back.

On my laptop, for a 1000x1000 matrix, computing `x @ x.T` previously took about 4.5ms in float32 but 1.5s in float16.

Fixes #7431 