### PR TITLE
disable implicit rank promotion in lax_numpy_einsum/indexing/vectorize_test

### DIFF
--- a/tests/lax_numpy_einsum_test.py
+++ b/tests/lax_numpy_einsum_test.py
@@ -32,6 +32,15 @@ config.parse_flags_with_absl()
 
 class EinsumTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    super().setUp()
+    self._jax_numpy_rank_promotion = config.jax_numpy_rank_promotion
+    config.update("jax_numpy_rank_promotion", "raise")
+
+  def tearDown(self):
+    config.update("jax_numpy_rank_promotion", self._jax_numpy_rank_promotion)
+    super().tearDown()
+
   def _check(self, s, *ops):
     a = np.einsum(s, *ops)
     b = jnp.einsum(s, *ops, precision=lax.Precision.HIGHEST)

--- a/tests/lax_numpy_vectorize_test.py
+++ b/tests/lax_numpy_vectorize_test.py
@@ -26,6 +26,16 @@ config.parse_flags_with_absl()
 
 
 class VectorizeTest(jtu.JaxTestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._jax_numpy_rank_promotion = config.jax_numpy_rank_promotion
+    config.update("jax_numpy_rank_promotion", "raise")
+
+  def tearDown(self):
+    config.update("jax_numpy_rank_promotion", self._jax_numpy_rank_promotion)
+    super().tearDown()
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_leftshape={}_rightshape={}".format(left_shape, right_shape),
        "left_shape": left_shape, "right_shape": right_shape, "result_shape": result_shape}


### PR DESCRIPTION
Part of #7208