### PR TITLE
Add jax.invertible to the JAX documentation

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -39,6 +39,7 @@ Just-in-time compilation (:code:`jit`)
     device_put_sharded
     default_backend
     named_call
+    invertible
 
 .. _jax-grad:
 
@@ -94,6 +95,7 @@ Parallelization (:code:`pmap`)
 .. autofunction:: device_put_sharded
 .. autofunction:: default_backend
 .. autofunction:: named_call
+.. autofunction:: invertible
 
 .. autofunction:: grad
 .. autofunction:: value_and_grad


### PR DESCRIPTION
This PR adds `jax.invertible` to the official JAX documentation at https://jax.readthedocs.io/en/latest/jax.html

I noticed that the `jax/api.py` function defines `invertible`, which seems like a useful-but-undocumented function. So I decided to try to PR it. Is this the correct way to add something to the docs? If anything else needs to be done, let me know.


(If `jax.invertible` isn't intended to be a public API, feel free to close this PR.)