### PR TITLE
Use R2C FFTs to implement jnp.fft.fft() for real inputs.

### DIFF
--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -102,6 +102,12 @@ class FftTest(jtu.JaxTestCase):
       with self.assertRaises(NotImplementedError):
         func()
 
+  def testLaxFftAcceptsStringTypes(self):
+    rng = jtu.rand_default(self.rng())
+    x = rng((10,), np.complex64)
+    self.assertAllClose(np.fft.fft(x), lax.fft(x, "FFT", fft_lengths=(10,)))
+
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inverse={}_real={}_shape={}_axes={}_s={}_norm={}".format(
           inverse, real, jtu.format_shape_dtype_string(shape, dtype), axes, s, norm),


### PR DESCRIPTION
Fixes #7490 for 1-dimensional FFTs.

I couldn't quite figure out the right rule for N-dimensional FFTs, so I leave that for a future PR from someone.