### PR TITLE
autodidax prototype of user-customizable partial eval strategies

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -335,7 +335,10 @@
     "    raise Exception(\"ShapedArray can't be unambiguously converted to bool\")\n",
     "\n",
     "  def str_short(self):\n",
-    "    return f'{self.dtype.name}[{\",\".join(str(d) for d in self.shape)}]'\n",
+    "    dtype_name = self.dtype.name\n",
+    "    for long_name, short_name in [('float', 'f'), ('int', 'i'), ('bool', 'b')]:\n",
+    "      dtype_name = dtype_name.replace(long_name, short_name)\n",
+    "    return f'{dtype_name}[{\",\".join(str(d) for d in self.shape)}]'\n",
     "\n",
     "  def __hash__(self):\n",
     "    return hash((self.shape, self.dtype))\n",
@@ -1093,9 +1096,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Union\n",
@@ -1348,10 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Set\n",
@@ -1758,8 +1756,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1,
     "tags": [
      "hide-input"
     ]
@@ -1884,9 +1880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@contextmanager\n",
@@ -2457,7 +2451,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -2521,7 +2514,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -2559,6 +2551,38 @@
     "  return vcat([lhs >> pp(' = ') >> rhs,\n",
     "               pp_jaxpr(eqn.params['jaxpr']).indent(2)])\n",
     "pp_rules[xla_call_p] = pprint_xla_call"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we'll tweak how xla_call is pretty-printed in jaxprs.\n",
+    "+ tags=[\"hide-input\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pprint_xla_call(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:\n",
+    "  lhs = pp(' '.join(var_str(names, v) for v in eqn.out_binders))\n",
+    "  params_without_jaxpr = {k:v for k, v in eqn.params.items() if k != 'jaxpr'}\n",
+    "  rhs = (pp(eqn.primitive.name) >> pp_params(params_without_jaxpr) >>\n",
+    "         pp(' '.join(names[x] if isinstance(x, Var) else str(x.val)\n",
+    "                     for x in eqn.inputs)))\n",
+    "  return vcat([lhs >> pp(' = ') >> rhs,\n",
+    "               pp_jaxpr(eqn.params['jaxpr']).indent(2)])\n",
+    "pp_rules[xla_call_p] = pprint_xla_call"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-"
    ]
   },
   {
@@ -2840,9 +2864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from weakref import ref, ReferenceType\n",
@@ -2867,7 +2889,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -3459,7 +3480,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -3612,10 +3632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_end_of_cell_marker": 0,
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def cond(pred, true_fn, false_fn, *operands):\n",
@@ -3668,9 +3685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def cond_impl(pred, *operands, true_jaxpr, false_jaxpr):\n",
@@ -3759,9 +3774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "xs = np.array([1., 2., 3])\n",
@@ -3820,9 +3833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "lines_to_next_cell": 1
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def cond_abstract_eval(pred_type, *in_types, true_jaxpr, false_jaxpr):\n",
@@ -3863,7 +3874,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -3955,7 +3965,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -3996,7 +4005,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "lines_to_end_of_cell_marker": 0,
     "lines_to_next_cell": 1
    },
    "outputs": [],
@@ -4049,6 +4057,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "lines_to_end_of_cell_marker": 0,
+    "lines_to_next_cell": 1,
     "tags": [
      "hide-input"
     ]
@@ -4066,6 +4076,379 @@
     "               pp_jaxpr(true_jaxpr).indent(2),\n",
     "               pp_jaxpr(false_jaxpr).indent(2)])\n",
     "pp_rules[cond_p] = pprint_cond"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User-cusotmizable remat policies (implementation prototype)\n",
+    "\n",
+    "We want to add a variant of partial evaluation which offers control over what\n",
+    "values are saveable as residuals. A value that isn't saveable is instead\n",
+    "recomputed in the staged-out computation. This upgrade allows experts more\n",
+    "control over JAX's automatic differentiation.\n",
+    "\n",
+    "### Implementation of `partial_eval_jaxpr_custom`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "lines_to_end_of_cell_marker": 0,
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "def partial_eval_jaxpr_custom(\n",
+    "    jaxpr: Jaxpr, in_unknowns: List[bool], saveable: Callable[..., bool],\n",
+    "  ) -> Tuple[Jaxpr, Jaxpr, List[bool], List[bool], int]:\n",
+    "  env: Dict[Var, Tuple[bool, bool]] = {}\n",
+    "  residuals: Set[Var] = set()\n",
+    "\n",
+    "  def read(x: Atom) -> Tuple[bool, bool]:\n",
+    "    if type(x) is Var: return env[x]\n",
+    "    return (False, True)\n",
+    "\n",
+    "  def write(unk: bool, inst: bool, v: Var) -> None:\n",
+    "    env[v] = (unk, inst)\n",
+    "\n",
+    "  def ensure_instantiated(inst: bool, x: Atom) -> Atom:\n",
+    "    if type(x) is Var and not inst: residuals.add(x)\n",
+    "    return x\n",
+    "\n",
+    "  eqns1, eqns2 = [], []\n",
+    "  map(write, in_unknowns, [True] * len(in_unknowns), jaxpr.in_binders)\n",
+    "  for eqn in jaxpr.eqns:\n",
+    "    unks_in, inst_in = unzip2(map(read, eqn.inputs))\n",
+    "    rule = partial_eval_jaxpr_custom_rules.get(eqn.primitive)\n",
+    "    if rule:\n",
+    "      eqn1, eqn2, unks_out, inst_out, res = rule(saveable, unks_in, inst_in, eqn)\n",
+    "      eqns1.append(eqn1); eqns2.append(eqn2); residuals.update(res)\n",
+    "      map(write, unks_out, inst_out, eqn.out_binders)\n",
+    "    elif any(unks_in):\n",
+    "      inputs = map(ensure_instantiated, inst_in, eqn.inputs)\n",
+    "      eqns2.append(JaxprEqn(eqn.primitive, inputs, eqn.params, eqn.out_binders))\n",
+    "      map(partial(write, True, True), eqn.out_binders)\n",
+    "    else:\n",
+    "      eqns1.append(eqn)\n",
+    "      if saveable(eqn.primitive, [x.aval for x in eqn.inputs], eqn.params):\n",
+    "        map(partial(write, False, False), eqn.out_binders)\n",
+    "      else:\n",
+    "        inputs = map(ensure_instantiated, inst_in, eqn.inputs)\n",
+    "        eqns2.append(JaxprEqn(eqn.primitive, inputs, eqn.params, eqn.out_binders))\n",
+    "        map(partial(write, False, True), eqn.out_binders)\n",
+    "  out_unknowns, out_inst = unzip2(map(read, jaxpr.outs))\n",
+    "\n",
+    "  residuals, num_res = list(residuals), len(residuals)\n",
+    "  assert all(type(v) is Var for v in residuals), residuals\n",
+    "\n",
+    "  ins1, _ = partition_list(in_unknowns, jaxpr.in_binders)\n",
+    "  outs1, _ = partition_list(out_unknowns, jaxpr.outs)\n",
+    "  jaxpr1 = Jaxpr(ins1, eqns1, outs1 + residuals)\n",
+    "  typecheck_jaxpr(jaxpr1)\n",
+    "  # jaxpr1, used1 = dce_jaxpr(jaxpr1, [True] * len(jaxpr1.outs))  # optional\n",
+    "  # assert all(used1)\n",
+    "\n",
+    "  _, outs2 = partition_list(out_inst, jaxpr.outs)\n",
+    "  jaxpr2 = Jaxpr(residuals + jaxpr.in_binders, eqns2, outs2)\n",
+    "  typecheck_jaxpr(jaxpr2)\n",
+    "\n",
+    "  return jaxpr1, jaxpr2, out_unknowns, out_inst, num_res\n",
+    "\n",
+    "partial_eval_jaxpr_custom_rules: Dict[Primitive, Callable] = {}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that `jaxpr2` is generated with all the input binders as `jaxpr`,\n",
+    "whether or not they are ultimately consumed in jaxpr2, just for convenience to\n",
+    "the caller of this function; we rely on the DCE to follow to clean up any\n",
+    "unused input binders in `jaxpr2`. Moreover `jaxpr2` is constructed to output\n",
+    "all values which might be consumed downstream, rather than just all unknown\n",
+    "values; see Example 3 below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The custom rules are basically for handling higher-order primitives. The\n",
+    "user-supplied callback function is essentially a typing rule for first-order\n",
+    "primitives, but we define the rules for higher-order primitives because their\n",
+    "properties are constrained by desiderata like jit invariance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "lines_to_end_of_cell_marker": 0,
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "def xla_call_peval_jaxpr_custom_rule(\n",
+    "    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],\n",
+    "    eqn: JaxprEqn) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[bool], List[Var]]:\n",
+    "  jaxpr1, jaxpr2, unks_out, inst_out, num_res = partial_eval_jaxpr_custom(\n",
+    "      eqn.params['jaxpr'], unks_in, saveable)\n",
+    "  ins1, _ = partition_list(unks_in, eqn.inputs)\n",
+    "  out_binders1, _ = partition_list(unks_out, eqn.out_binders)\n",
+    "  _, out_binders2 = partition_list(inst_out, eqn.out_binders)\n",
+    "  residuals = [Var(v.aval) for v in jaxpr2.in_binders[:num_res]]\n",
+    "  eqn1 = JaxprEqn(xla_call_p, ins1, dict(jaxpr=jaxpr1, num_consts=0),\n",
+    "                  out_binders1 + residuals)\n",
+    "  eqn2 = JaxprEqn(xla_call_p, residuals + eqn.inputs,\n",
+    "                  dict(jaxpr=jaxpr2, num_consts=0), out_binders2)\n",
+    "  assert len(eqn2.inputs) == len(jaxpr2.in_binders)\n",
+    "  new_inst = [x for x, inst in zip(eqn.inputs, inst_in)\n",
+    "              if type(x) is Var and not inst]\n",
+    "  return eqn1, eqn2, unks_out, inst_out, new_inst + residuals\n",
+    "partial_eval_jaxpr_custom_rules[xla_call_p] = xla_call_peval_jaxpr_custom_rule\n",
+    "\n",
+    "def cond_peval_jaxpr_custom_rule(\n",
+    "    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],\n",
+    "    eqn: JaxprEqn) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[bool], List[Var]]:\n",
+    "  breakpoint()  # TODO\n",
+    "partial_eval_jaxpr_custom_rules[cond_p] = cond_peval_jaxpr_custom_rule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Implementation of dead-code elimination (DCE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]\n",
+    "              ) -> Tuple[Jaxpr, List[bool]]:\n",
+    "  env: Dict[Var, bool] = {}\n",
+    "\n",
+    "  def read(v: Var) -> bool:\n",
+    "    return env.get(v, False)\n",
+    "\n",
+    "  def write(x: Atom, b: bool) -> None:\n",
+    "    if type(x) is Var:\n",
+    "      env[x] = read(x) or b\n",
+    "\n",
+    "  new_eqns = []\n",
+    "  map(write, jaxpr.outs, used_outputs)\n",
+    "  for eqn in jaxpr.eqns[::-1]:\n",
+    "    outputs_used = map(read, eqn.out_binders)\n",
+    "    rule = dce_rules.get(eqn.primitive)\n",
+    "    if rule:\n",
+    "      inputs_used, new_eqn = rule(outputs_used, eqn)\n",
+    "      if any(inputs_used): new_eqns.append(new_eqn)\n",
+    "    else:\n",
+    "      inputs_used = [any(outputs_used)] * len(eqn.inputs)\n",
+    "      if any(inputs_used): new_eqns.append(eqn)\n",
+    "    map(write, eqn.inputs, inputs_used)\n",
+    "  used_inputs = map(read, jaxpr.in_binders)\n",
+    "\n",
+    "  new_jaxpr = Jaxpr([v for v, b in zip(jaxpr.in_binders, used_inputs) if b],\n",
+    "                    new_eqns[::-1],\n",
+    "                    [v for v, b in zip(jaxpr.outs, used_outputs) if b])\n",
+    "  typecheck_jaxpr(new_jaxpr)\n",
+    "\n",
+    "  return new_jaxpr, used_inputs\n",
+    "\n",
+    "dce_rules: Dict[Primitive, Callable] = {}\n",
+    "\n",
+    "def xla_call_dce_rule(used_outputs: List[bool], eqn: JaxprEqn,\n",
+    "                      ) -> Tuple[List[bool], JaxprEqn]:\n",
+    "  new_jaxpr, used_inputs = dce_jaxpr(eqn.params['jaxpr'], used_outputs)\n",
+    "  new_num_consts = sum(used_inputs[:eqn.params['num_consts']])\n",
+    "  new_eqn = JaxprEqn(eqn.primitive,\n",
+    "                     [x for x, b in zip(eqn.inputs, used_inputs) if b],\n",
+    "                     dict(jaxpr=new_jaxpr, num_consts=new_num_consts),\n",
+    "                     [v for v, b in zip(eqn.out_binders, used_outputs) if b])\n",
+    "  return used_inputs, new_eqn\n",
+    "dce_rules[xla_call_p] = xla_call_dce_rule\n",
+    "\n",
+    "def cond_dce_rule(used_outputs: List[bool], eqn: JaxprEqn,\n",
+    "                  ) -> Tuple[List[bool], JaxprEqn]:\n",
+    "  true_jaxpr,  used_inputs1 = dce_jaxpr(eqn.params['true_jaxpr'],  used_outputs)\n",
+    "  false_jaxpr, used_inputs2 = dce_jaxpr(eqn.params['false_jaxpr'], used_outputs)\n",
+    "  used_inputs = map(op.or_, used_inputs1, used_inputs2)\n",
+    "  _, inputs1 = partition_list(used_inputs, eqn.params['true_jaxpr'] .in_binders)\n",
+    "  _, inputs2 = partition_list(used_inputs, eqn.params['false_jaxpr'].in_binders)\n",
+    "  true_jaxpr  = Jaxpr(inputs1, true_jaxpr.eqns,  true_jaxpr.outs)\n",
+    "  false_jaxpr = Jaxpr(inputs2, false_jaxpr.eqns, false_jaxpr.outs)\n",
+    "  typecheck_jaxpr(true_jaxpr) and typecheck_jaxpr(false_jaxpr)\n",
+    "\n",
+    "  new_inputs = [eqn.inputs[0], *partition_list(used_inputs, eqn.inputs[1:])[1]]\n",
+    "  _, new_outputs = partition_list(used_outputs, eqn.outs)\n",
+    "  new_eqn = JaxprEqn(eqn.primitive, new_inputs,\n",
+    "                     dict(true_jaxpr=true_jaxpr, false_jaxpr=false_jaxpr),\n",
+    "                     new_outputs)\n",
+    "  return [True, *used_inputs], new_eqn\n",
+    "dce_rules[cond_p] = cond_dce_rule"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ### Manual testing cruft below here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "policies = [\n",
+    "    ('standard', lambda *_, **__: True),\n",
+    "    ('remat', lambda *_, **__: False),\n",
+    "    ('save sines', lambda prim, *_, **__: prim is sin_p),\n",
+    "    ('save muls', lambda prim, *_, **__: prim is mul_p),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def typecheck_peval_jaxpr_custom(jaxpr, unks_in, unks_out, policy, jaxpr1, jaxpr2):\n",
+    "  jaxprty = typecheck_jaxpr(jaxpr)    # (a1, a2)       -> (b1, b2 )\n",
+    "  jaxpr1ty = typecheck_jaxpr(jaxpr1)  #  a1            -> (b1, res)\n",
+    "  jaxpr2ty = typecheck_jaxpr(jaxpr2)  # (res, a1_, a2) -> b2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "  a1, _ = partition_list(unks_in, jaxprty.in_types)\n",
+    "  b1, b2 = partition_list(unks_out, jaxprty.out_types)\n",
+    "  b1_, res = split_list(jaxpr1ty.out_types, len(b1))\n",
+    "  res_, _ = split_list(jaxpr2ty.in_types, len(res))\n",
+    "  b2_ = jaxpr2ty.out_types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "  if jaxpr1ty.in_types != a1: raise TypeError\n",
+    "  if jaxpr2ty.out_types != b2: raise TypeError\n",
+    "  if b1 != b1_: raise TypeError\n",
+    "  if res != res_: raise TypeError\n",
+    "  # if a2 != a2_: raise TypeError\n",
+    "  if b2 != b2_: raise TypeError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def run(jaxpr, in_uks):\n",
+    "  print('====')\n",
+    "  print(jaxpr)\n",
+    "  for name, policy in policies:\n",
+    "    print(f'== {name} policy')\n",
+    "    jaxpr1, jaxpr2, out_uks, out_inst, _ = partial_eval_jaxpr_custom(\n",
+    "        jaxpr, in_uks, policy)\n",
+    "    print(jaxpr1)\n",
+    "    _, used2 = partition_list(out_inst, out_uks)\n",
+    "    jaxpr2, _ = dce_jaxpr(jaxpr2, used2)  # TODO put this in top-level func\n",
+    "    print(jaxpr2)\n",
+    "    typecheck_peval_jaxpr_custom(jaxpr, in_uks, out_uks, policy, jaxpr1, jaxpr2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def g(x, xdot):\n",
+    "  y, ydot = sin(x), cos(x) * xdot\n",
+    "  z, zdot = y * y, 2. * y * ydot\n",
+    "  w, wdot = sin(z), cos(z) * zdot\n",
+    "  return w, wdot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "x = ShapedArray((), np.dtype('float64'))\n",
+    "jaxpr, *_ = make_jaxpr(g, x, x)\n",
+    "run(jaxpr, [False, True])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def g(x, xdot):\n",
+    "  y, ydot = sin(x), cos(x) * xdot\n",
+    "  z, zdot = jit(lambda y, ydot: (y * y, 2. * y * ydot))(y, ydot)\n",
+    "  w, wdot = sin(z), cos(z) * zdot\n",
+    "  return w, wdot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "x = ShapedArray((), np.dtype('float64'))\n",
+    "jaxpr, *_ = make_jaxpr(g, x, x)\n",
+    "run(jaxpr, [False, True])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def g(x, xdot):\n",
+    "  y, ydot = sin(x), cos(x) * xdot\n",
+    "  z, zdot = y * y, 2. * y * ydot\n",
+    "  w, wdot = jit(lambda z, zdot: (sin(z), cos(z) * zdot))(z, zdot)\n",
+    "  return w, wdot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "x = ShapedArray((), np.dtype('float64'))\n",
+    "jaxpr, *_ = make_jaxpr(g, x, x)\n",
+    "run(jaxpr, [False, True])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "def g(x, xdot):\n",
+    "  y, ydot = sin(x), cos(x) * xdot\n",
+    "  z, zjac = jit(lambda y: (sin(y), cos(y)))(y)\n",
+    "  zdot = zjac * ydot\n",
+    "  return z, zdot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "x = ShapedArray((), np.dtype('float64'))\n",
+    "jaxpr, *_ = make_jaxpr(g, x, x)\n",
+    "run(jaxpr, [False, True])"
    ]
   }
  ],

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -274,7 +274,10 @@ class ShapedArray:
     raise Exception("ShapedArray can't be unambiguously converted to bool")
 
   def str_short(self):
-    return f'{self.dtype.name}[{",".join(str(d) for d in self.shape)}]'
+    dtype_name = self.dtype.name
+    for long_name, short_name in [('float', 'f'), ('int', 'i'), ('bool', 'b')]:
+      dtype_name = dtype_name.replace(long_name, short_name)
+    return f'{dtype_name}[{",".join(str(d) for d in self.shape)}]'
 
   def __hash__(self):
     return hash((self.shape, self.dtype))
@@ -1877,6 +1880,25 @@ def pprint_xla_call(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:
 pp_rules[xla_call_p] = pprint_xla_call
 ```
 
+Finally, we'll tweak how xla_call is pretty-printed in jaxprs.
++ tags=["hide-input"]
+
+```{code-cell}
+def pprint_xla_call(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:
+  lhs = pp(' '.join(var_str(names, v) for v in eqn.out_binders))
+  params_without_jaxpr = {k:v for k, v in eqn.params.items() if k != 'jaxpr'}
+  rhs = (pp(eqn.primitive.name) >> pp_params(params_without_jaxpr) >>
+         pp(' '.join(names[x] if isinstance(x, Var) else str(x.val)
+                     for x in eqn.inputs)))
+  return vcat([lhs >> pp(' = ') >> rhs,
+               pp_jaxpr(eqn.params['jaxpr']).indent(2)])
+pp_rules[xla_call_p] = pprint_xla_call
+```
+
+-
+
++++
+
 ## Part 4: `linearize` and `vjp` (and `grad`!)
 
 The `linearize` and `vjp` autodiff functions are built on `jvp`, but involve
@@ -3001,3 +3023,287 @@ def pprint_cond(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:
                pp_jaxpr(false_jaxpr).indent(2)])
 pp_rules[cond_p] = pprint_cond
 ```
+
+## User-cusotmizable remat policies (implementation prototype)
+
+We want to add a variant of partial evaluation which offers control over what
+values are saveable as residuals. A value that isn't saveable is instead
+recomputed in the staged-out computation. This upgrade allows experts more
+control over JAX's automatic differentiation.
+
+### Implementation of `partial_eval_jaxpr_custom`
+
+```{code-cell}
+def partial_eval_jaxpr_custom(
+    jaxpr: Jaxpr, in_unknowns: List[bool], saveable: Callable[..., bool],
+  ) -> Tuple[Jaxpr, Jaxpr, List[bool], List[bool], int]:
+  env: Dict[Var, Tuple[bool, bool]] = {}
+  residuals: Set[Var] = set()
+
+  def read(x: Atom) -> Tuple[bool, bool]:
+    if type(x) is Var: return env[x]
+    return (False, True)
+
+  def write(unk: bool, inst: bool, v: Var) -> None:
+    env[v] = (unk, inst)
+
+  def ensure_instantiated(inst: bool, x: Atom) -> Atom:
+    if type(x) is Var and not inst: residuals.add(x)
+    return x
+
+  eqns1, eqns2 = [], []
+  map(write, in_unknowns, [True] * len(in_unknowns), jaxpr.in_binders)
+  for eqn in jaxpr.eqns:
+    unks_in, inst_in = unzip2(map(read, eqn.inputs))
+    rule = partial_eval_jaxpr_custom_rules.get(eqn.primitive)
+    if rule:
+      eqn1, eqn2, unks_out, inst_out, res = rule(saveable, unks_in, inst_in, eqn)
+      eqns1.append(eqn1); eqns2.append(eqn2); residuals.update(res)
+      map(write, unks_out, inst_out, eqn.out_binders)
+    elif any(unks_in):
+      inputs = map(ensure_instantiated, inst_in, eqn.inputs)
+      eqns2.append(JaxprEqn(eqn.primitive, inputs, eqn.params, eqn.out_binders))
+      map(partial(write, True, True), eqn.out_binders)
+    else:
+      eqns1.append(eqn)
+      if saveable(eqn.primitive, [x.aval for x in eqn.inputs], eqn.params):
+        map(partial(write, False, False), eqn.out_binders)
+      else:
+        inputs = map(ensure_instantiated, inst_in, eqn.inputs)
+        eqns2.append(JaxprEqn(eqn.primitive, inputs, eqn.params, eqn.out_binders))
+        map(partial(write, False, True), eqn.out_binders)
+  out_unknowns, out_inst = unzip2(map(read, jaxpr.outs))
+
+  residuals, num_res = list(residuals), len(residuals)
+  assert all(type(v) is Var for v in residuals), residuals
+
+  ins1, _ = partition_list(in_unknowns, jaxpr.in_binders)
+  outs1, _ = partition_list(out_unknowns, jaxpr.outs)
+  jaxpr1 = Jaxpr(ins1, eqns1, outs1 + residuals)
+  typecheck_jaxpr(jaxpr1)
+  # jaxpr1, used1 = dce_jaxpr(jaxpr1, [True] * len(jaxpr1.outs))  # optional
+  # assert all(used1)
+
+  _, outs2 = partition_list(out_inst, jaxpr.outs)
+  jaxpr2 = Jaxpr(residuals + jaxpr.in_binders, eqns2, outs2)
+  typecheck_jaxpr(jaxpr2)
+
+  return jaxpr1, jaxpr2, out_unknowns, out_inst, num_res
+
+partial_eval_jaxpr_custom_rules: Dict[Primitive, Callable] = {}
+```
+
+Notice that `jaxpr2` is generated with all the input binders as `jaxpr`,
+whether or not they are ultimately consumed in jaxpr2, just for convenience to
+the caller of this function; we rely on the DCE to follow to clean up any
+unused input binders in `jaxpr2`. Moreover `jaxpr2` is constructed to output
+all values which might be consumed downstream, rather than just all unknown
+values; see Example 3 below.
+
++++
+
+The custom rules are basically for handling higher-order primitives. The
+user-supplied callback function is essentially a typing rule for first-order
+primitives, but we define the rules for higher-order primitives because their
+properties are constrained by desiderata like jit invariance.
+
+```{code-cell}
+def xla_call_peval_jaxpr_custom_rule(
+    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],
+    eqn: JaxprEqn) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[bool], List[Var]]:
+  jaxpr1, jaxpr2, unks_out, inst_out, num_res = partial_eval_jaxpr_custom(
+      eqn.params['jaxpr'], unks_in, saveable)
+  ins1, _ = partition_list(unks_in, eqn.inputs)
+  out_binders1, _ = partition_list(unks_out, eqn.out_binders)
+  _, out_binders2 = partition_list(inst_out, eqn.out_binders)
+  residuals = [Var(v.aval) for v in jaxpr2.in_binders[:num_res]]
+  eqn1 = JaxprEqn(xla_call_p, ins1, dict(jaxpr=jaxpr1, num_consts=0),
+                  out_binders1 + residuals)
+  eqn2 = JaxprEqn(xla_call_p, residuals + eqn.inputs,
+                  dict(jaxpr=jaxpr2, num_consts=0), out_binders2)
+  assert len(eqn2.inputs) == len(jaxpr2.in_binders)
+  new_inst = [x for x, inst in zip(eqn.inputs, inst_in)
+              if type(x) is Var and not inst]
+  return eqn1, eqn2, unks_out, inst_out, new_inst + residuals
+partial_eval_jaxpr_custom_rules[xla_call_p] = xla_call_peval_jaxpr_custom_rule
+
+def cond_peval_jaxpr_custom_rule(
+    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],
+    eqn: JaxprEqn) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[bool], List[Var]]:
+  breakpoint()  # TODO
+partial_eval_jaxpr_custom_rules[cond_p] = cond_peval_jaxpr_custom_rule
+```
+
+### Implementation of dead-code elimination (DCE)
+
+```{code-cell}
+def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]
+              ) -> Tuple[Jaxpr, List[bool]]:
+  env: Dict[Var, bool] = {}
+
+  def read(v: Var) -> bool:
+    return env.get(v, False)
+
+  def write(x: Atom, b: bool) -> None:
+    if type(x) is Var:
+      env[x] = read(x) or b
+
+  new_eqns = []
+  map(write, jaxpr.outs, used_outputs)
+  for eqn in jaxpr.eqns[::-1]:
+    outputs_used = map(read, eqn.out_binders)
+    rule = dce_rules.get(eqn.primitive)
+    if rule:
+      inputs_used, new_eqn = rule(outputs_used, eqn)
+      if any(inputs_used): new_eqns.append(new_eqn)
+    else:
+      inputs_used = [any(outputs_used)] * len(eqn.inputs)
+      if any(inputs_used): new_eqns.append(eqn)
+    map(write, eqn.inputs, inputs_used)
+  used_inputs = map(read, jaxpr.in_binders)
+
+  new_jaxpr = Jaxpr([v for v, b in zip(jaxpr.in_binders, used_inputs) if b],
+                    new_eqns[::-1],
+                    [v for v, b in zip(jaxpr.outs, used_outputs) if b])
+  typecheck_jaxpr(new_jaxpr)
+
+  return new_jaxpr, used_inputs
+
+dce_rules: Dict[Primitive, Callable] = {}
+
+def xla_call_dce_rule(used_outputs: List[bool], eqn: JaxprEqn,
+                      ) -> Tuple[List[bool], JaxprEqn]:
+  new_jaxpr, used_inputs = dce_jaxpr(eqn.params['jaxpr'], used_outputs)
+  new_num_consts = sum(used_inputs[:eqn.params['num_consts']])
+  new_eqn = JaxprEqn(eqn.primitive,
+                     [x for x, b in zip(eqn.inputs, used_inputs) if b],
+                     dict(jaxpr=new_jaxpr, num_consts=new_num_consts),
+                     [v for v, b in zip(eqn.out_binders, used_outputs) if b])
+  return used_inputs, new_eqn
+dce_rules[xla_call_p] = xla_call_dce_rule
+
+def cond_dce_rule(used_outputs: List[bool], eqn: JaxprEqn,
+                  ) -> Tuple[List[bool], JaxprEqn]:
+  true_jaxpr,  used_inputs1 = dce_jaxpr(eqn.params['true_jaxpr'],  used_outputs)
+  false_jaxpr, used_inputs2 = dce_jaxpr(eqn.params['false_jaxpr'], used_outputs)
+  used_inputs = map(op.or_, used_inputs1, used_inputs2)
+  _, inputs1 = partition_list(used_inputs, eqn.params['true_jaxpr'] .in_binders)
+  _, inputs2 = partition_list(used_inputs, eqn.params['false_jaxpr'].in_binders)
+  true_jaxpr  = Jaxpr(inputs1, true_jaxpr.eqns,  true_jaxpr.outs)
+  false_jaxpr = Jaxpr(inputs2, false_jaxpr.eqns, false_jaxpr.outs)
+  typecheck_jaxpr(true_jaxpr) and typecheck_jaxpr(false_jaxpr)
+
+  new_inputs = [eqn.inputs[0], *partition_list(used_inputs, eqn.inputs[1:])[1]]
+  _, new_outputs = partition_list(used_outputs, eqn.outs)
+  new_eqn = JaxprEqn(eqn.primitive, new_inputs,
+                     dict(true_jaxpr=true_jaxpr, false_jaxpr=false_jaxpr),
+                     new_outputs)
+  return [True, *used_inputs], new_eqn
+dce_rules[cond_p] = cond_dce_rule
+```
+
+# ### Manual testing cruft below here
+
++++
+
+policies = [
+    ('standard', lambda *_, **__: True),
+    ('remat', lambda *_, **__: False),
+    ('save sines', lambda prim, *_, **__: prim is sin_p),
+    ('save muls', lambda prim, *_, **__: prim is mul_p),
+]
+
++++
+
+def typecheck_peval_jaxpr_custom(jaxpr, unks_in, unks_out, policy, jaxpr1, jaxpr2):
+  jaxprty = typecheck_jaxpr(jaxpr)    # (a1, a2)       -> (b1, b2 )
+  jaxpr1ty = typecheck_jaxpr(jaxpr1)  #  a1            -> (b1, res)
+  jaxpr2ty = typecheck_jaxpr(jaxpr2)  # (res, a1_, a2) -> b2
+
++++
+
+  a1, _ = partition_list(unks_in, jaxprty.in_types)
+  b1, b2 = partition_list(unks_out, jaxprty.out_types)
+  b1_, res = split_list(jaxpr1ty.out_types, len(b1))
+  res_, _ = split_list(jaxpr2ty.in_types, len(res))
+  b2_ = jaxpr2ty.out_types
+
++++
+
+  if jaxpr1ty.in_types != a1: raise TypeError
+  if jaxpr2ty.out_types != b2: raise TypeError
+  if b1 != b1_: raise TypeError
+  if res != res_: raise TypeError
+  # if a2 != a2_: raise TypeError
+  if b2 != b2_: raise TypeError
+
++++
+
+def run(jaxpr, in_uks):
+  print('====')
+  print(jaxpr)
+  for name, policy in policies:
+    print(f'== {name} policy')
+    jaxpr1, jaxpr2, out_uks, out_inst, _ = partial_eval_jaxpr_custom(
+        jaxpr, in_uks, policy)
+    print(jaxpr1)
+    _, used2 = partition_list(out_inst, out_uks)
+    jaxpr2, _ = dce_jaxpr(jaxpr2, used2)  # TODO put this in top-level func
+    print(jaxpr2)
+    typecheck_peval_jaxpr_custom(jaxpr, in_uks, out_uks, policy, jaxpr1, jaxpr2)
+
++++
+
+def g(x, xdot):
+  y, ydot = sin(x), cos(x) * xdot
+  z, zdot = y * y, 2. * y * ydot
+  w, wdot = sin(z), cos(z) * zdot
+  return w, wdot
+
++++
+
+x = ShapedArray((), np.dtype('float64'))
+jaxpr, *_ = make_jaxpr(g, x, x)
+run(jaxpr, [False, True])
+
++++
+
+def g(x, xdot):
+  y, ydot = sin(x), cos(x) * xdot
+  z, zdot = jit(lambda y, ydot: (y * y, 2. * y * ydot))(y, ydot)
+  w, wdot = sin(z), cos(z) * zdot
+  return w, wdot
+
++++
+
+x = ShapedArray((), np.dtype('float64'))
+jaxpr, *_ = make_jaxpr(g, x, x)
+run(jaxpr, [False, True])
+
++++
+
+def g(x, xdot):
+  y, ydot = sin(x), cos(x) * xdot
+  z, zdot = y * y, 2. * y * ydot
+  w, wdot = jit(lambda z, zdot: (sin(z), cos(z) * zdot))(z, zdot)
+  return w, wdot
+
++++
+
+x = ShapedArray((), np.dtype('float64'))
+jaxpr, *_ = make_jaxpr(g, x, x)
+run(jaxpr, [False, True])
+
++++
+
+def g(x, xdot):
+  y, ydot = sin(x), cos(x) * xdot
+  z, zjac = jit(lambda y: (sin(y), cos(y)))(y)
+  zdot = zjac * ydot
+  return z, zdot
+
++++
+
+x = ShapedArray((), np.dtype('float64'))
+jaxpr, *_ = make_jaxpr(g, x, x)
+run(jaxpr, [False, True])


### PR DESCRIPTION
**This PR comment is a copy-and-paste of a design doc (or most of it) that we wrote to accompany this prototype implementation.** If/when this implementation goes through we'll add a separate design doc in a .md file, so take this PR comment as a draft.

# User-customizable gradient checkpointing policies

_mattjj@, jekbradbury@_

started 2021.07.07, updated 2021.08.05

### Intro and motivation {#intro-and-motivation}

By default, `jax.grad` (and really the underlying `jax.linearize`) computes and stores as much as possible in the forward pass (i.e. the primal computation). For example:


![image](https://user-images.githubusercontent.com/1458824/128421554-089257a1-6c4f-4101-9764-9ed42e7f1fc7.png)


Notice that the cosines are evaluated in the primal computation, with the resulting values stored as "residual" outputs to be used as constants in the tangent or cotangent jaxpr.

`jax.checkpoint` (aliased as `jax.remat`) lets users switch this strategy to the opposite extreme: don't store anything except inputs to the function, and instead recompute (i.e rematerialize) all the values needed for the linear computation. At its heart `jax.checkpoint` is a call-like primitive with a special partial evaluation rule, which is why it works for `jax.linearize` as well as `jax.vjp`: both are based on partial evaluation. For example:


![image](https://user-images.githubusercontent.com/1458824/128421586-4074408e-087c-4030-a306-3f01e76ac3d0.png)


Notice that now the cosines, and even some sines, are evaluated in the tangent and cotangent jaxprs, with no residuals stored beyond the input to the function. (In addition to this custom partial evaluation behavior, the primitive underlying `jax.checkpoint` also has [a special transpose rule](https://github.com/google/jax/blob/78a689bb09799d8b13b28fe90bee6a04bddb7968/jax/interpreters/ad.py#L547-L570) for evaluating these nonlinear expressions first, as well as [a special XLA HLO translation rule](https://github.com/google/jax/blob/78a689bb09799d8b13b28fe90bee6a04bddb7968/jax/interpreters/xla.py#L1465-L1478) to prevent CSE optimizations from foiling its intended behavior. These additional rules are why it makes sense to model `jax.checkpoint` as a call-like primitive.)

Even if neither the “store everything” nor the “store nothing except inputs” policies is right for a particular application, in principle users can apply `jax.checkpoint` to sub-functions as needed to control exactly what to store and what to recompute. But this API can require refactoring model code just to express the kind of checkpointing desired. Not only does the current API make expressing the right thing hard, but it also makes revising the strategy, for example to experiment with new ones or switch based on hardware backend, untenable.

In particular, there’s an intermediate activation-storage policy that’s a good fit for many memory-sensitive neural net applications on accelerators: storing the outputs of dots and convolutions, but recomputing everything else. (The motivation for this policy is that fused element-wise nonlinear operations are generally much cheaper than dots and convolutions on GPUs and TPUs, or, when fused into those operations on TPUs, completely free.) That’s easy to say in words, but it was previously impossible to express at the top level, without diving into neural network layer code that might have been written by others as part of a library. 

The situation was roughly:


```
# in library code
def apply_layer(W, x):
  return jnp.sin(jnp.dot(W, x))

# in top-level user code
def predict(params, x):
  for W in params[:-1]:
    x = apply_layer(W, x)
  return jnp.dot(params[-1], x)
```


We can't get what we want by applying `jax.checkpoint` to `apply_layer`; that would actually recompute the outputs of dots while saving the outputs of the nonlinear operations in the nonlinearity's JVP rule. It's the opposite of what we want! We'd need something more like `jax.checkpoint(lambda W, x: jnp.dot(W, jnp.sin(x)))`, but that's a strange way to organize layers in neural networks. And do we really want to require users to refactor libraries into non-idiomatic organizations just for checkpointing strategies? No way!

Until recently, this issue was somewhat hidden because XLA:TPU optimizations often ended up producing an optimized graph that used this intermediate strategy (specifically, XLA:TPU is able to duplicate these free nonlinear operations into multiple dot/conv fusions). But it sprang up recently in two contexts. First, users reported significantly higher memory usage for the same JAX program on GPU versus TPU, and we traced part of this back to XLA:GPU not performing the same duplication-into-fusions. 

Second, the issue also sprang up recently because of one more element in the large model application: control flow. XLA:TPU can often figure out great rematerialization strategies, regardless of what JAX's AD produces, so manual control over gradient checkpointing isn't always necessary in the toy code above. But in the real example, we couldn't rely on XLA to sort out what should be stored and what shouldn't be because we were actually doing a scan-over-layers. The presence of that control flow primitive foiled XLA’s rematerialization- related optimizations, and thus required JAX's AD to produce more efficient programs.

Our aim here is **to enable easy-to-revise remat strategies** by improving JAX's AD.


### API proposal: parameterize `jax.checkpoint` with a callback {#api-proposal-parameterize-jax-checkpoint-with-a-callback}


##### Basic idea {#basic-idea}

**As an internal API**, the basic idea is to parameterize `jax.checkpoint` with an optional callback function which represents the checkpointing strategy. The callback takes as input a type-level specification of a primitive application, and returns a boolean indicating whether the value of the application should be saved as a residual:


```
def checkpoint_policy(prim: Primitive, *avals: AbstractValue,
                      **params: Any) -> bool:
  ...

@partial(jax.checkpoint, policy=checkpoint_policy)
def f(...):
  ...
```


This way policies can depend not only on which primitives are being applied but also on input and output sizes. The default `jax.checkpoint` strategy would then correspond to a callback which always returns False, indicating that no values of any applications should be saved. Moreover, the default strategy of AD without `jax.checkpoint` corresponds to a callback which always returns True, indicating that values of every nonlinear application (which is ultimately used in the application of a partially-linear primitive, i.e. is not dead code) should be saved:


```
def default_checkpoint_strategy(*_, **__):
  return False  # no intermediates stored as residuals

def default_ad_strategy(*_, **__):
  return True  # store the value of every nonlinear computation as a residual
```


This general API must be an internal one because it depends on internal details like primitives and abstract values.

**To provide a public API**, we can offer some pre-baked strategies. The clearest current candidate is the `checkpoint_dots` strategy described above, where we save the outputs only of dots and convolutions. Internally to JAX, it could be implemented as


```
def checkpoint_dots(prim: Primitive, *_, **__) -> bool:
  return prim in (lax.dot_general_p, lax.conv_general_dilated_p)
```


To employ this strategy, the user would write something like


```
@partial(jax.checkpoint, policy=jax.checkpoint_policies.checkpoint_dots)
def f(...):
  ...
```



##### Example {#example}

Here's an example of how this policy would work on our toy example (residuals and recomputed operations, representing extra memory and extra compute respectively, are highlighted):


![image](https://user-images.githubusercontent.com/1458824/128421648-b4666ae5-402a-402b-a377-a74d7cff8779.png)


Some points to notice:



*   For clarity, where outer products of vectors are needed in cotangent computations, we inlined some transpose expressions into primitive applications and elided insertion of singleton dimensions. These aren't allowed in real jaxprs but keep the example simpler.
*   The sine JVP rule only involves one nonlinear operation (a cosine), but for other nonlinearities there could be greater storage savings relative to the checkpoint-free baseline shown in (a).
*   Since the `checkpoint_dots` strategy used in (c) indicates that we should only save `a1`, it's the only residual output by the primal jaxpr (beyond the inputs to the function that we need, namely `W1`, `W2`, and `x1`). Correspondingly in the cotangent jaxpr we recompute nonlinear values which depend on the value of a1, namely `x2` and `r1`.


##### Nesting: the inner policy wins {#nesting-the-inner-policy-wins}

One detail is how these policies behave under nesting. That is, now that each `jax.checkpoint` decorator can have a different policy, if one `jax.checkpoint`-decorated function calls another, which policy is used for the called function?


```
@partial(jax.checkpoint, policy=policy1)
def f(x):
  ...
  @partial(jax.checkpoint, policy=policy2)
  def g(y):
    ...  # policy1 or policy2 for these primitive applications?
  return g(...)
```


To enable more local control over how autodiff behaves, and to enable more expressive mixing-and-matching of one policy within another, we choose to let the inner policy win. If a top-level power user really wants to control checkpointing policy, and override whatever the library author wanted, they can always resort to a simple transformation to prune inner `jax.checkpoint` primitives.

An alternative, suggested by dougalm@, is that we allow policies to be tagged with a priority score, and when nesting we follow the policy with the higher priority score. That approach gives strictly more control to users and library writers alike, and works well for e.g. NumPy array API priorities. We'll defer on this approach for now because it can be added later as a strict generalization.


### Implementation proposal {#implementation-proposal}

See [the full Autodidax prototype in #7517](https://github.com/google/jax/pull/7517).


##### Fundamentals and jaxpr-to-jaxpr version {#fundamentals-and-jaxpr-to-jaxpr-version}

To explain the implementation of the proposed API, we'll start by thinking in terms of jaxpr-to-jaxpr transformations. The implementation of `jax.checkpoint` would in its partial evaluation rule form a full jaxpr ([like it does currently](https://github.com/google/jax/blob/1646ddaa805625c8acb1385c13de5f111db0aed6/jax/interpreters/partial_eval.py#L754), before this proposal) and then apply this jaxpr-to-jaxpr transformation to build both the eagerly-evaluated jaxpr1 and the staged-out jaxpr2. We'll return to the possibility of doing some transformation work while tracing in a [subsection to follow](#performing-the-non-dce-work-while-tracing-rather-than-jaxpr-to-jaxpr).

Recall from `partial_eval_jaxpr` ([Autodidax reference](https://github.com/google/jax/blob/806899f81d2a2be76e3a25bd0d543bf05138b724/docs/autodidax.py#L2224-L2272)) that partial evaluation 'unzips' one jaxpr into two. Given a jaxpr and a list of booleans indicating which input binders correspond to unknowns, it:



1. for each variable in the jaxpr, associates a boolean indicating whether it is unknown;
2. for each first-order primitive application adds it either into the resulting jaxpr1 (if all its inputs are known, in which case all outputs are known) or else puts it in the resulting jaxpr2 (if any input is unknown, in which case all outputs are unknown); and
3. for each known variable used as an input to a jaxpr2 primitive application, adds it as a residual output to jaxpr1 and residual input to jaxpr2.

The behavior for higher-order primitives is fixed by desiderata like `jit` invariance, which is why we focus on first-order primitives in the descriptions here.

By allowing the user to make some values unsaveable, we need to make some changes:



1. for each variable in the jaxpr, we associate a pair of booleans: one indicating whether the variable is known, and another indicating whether it is instantiated in jaxpr2 (as opposed to being saveable from jaxpr1);
2. some first-order primitive applications may need to be staged into both jaxpr1 and jaxpr2 (as shown in previous examples), and whether a primitive application is ultimately necessary in jaxpr1 or respectively jaxpr2 cannot be decided based solely on the known/unknown and saveable/unsaveable labels of its inputs but instead depends on downstream data dependence, namely whether an output of jaxpr1 or respectively jaxpr2 depends on it (see [Examples](#examples-related-to-dead-code) below);
3. only saveable known inputs to jaxpr2 applications are added as residuals, and the others are made available as outputs of primitive applications in jaxpr2 rather than as top-level residual inputs.

Our implementation is a fairly direct consequence of these new requirements. However, there are a few remaining decisions.

One decision is how much of this work to perform at trace time (i.e. how much to adapt JaxprTrace) versus as a jaxpr-to-jaxpr transformation; we'll defer that discussion to a later subsection.

Another decision is how to handle the dead code issue described in change 2 above, and in particular whether we should generate dead code and then clean it up, or else try to avoid generating it in the first place. We choose the former: we handle 2 by defensively adding some primitive applications to both jaxpr1 and jaxpr2, though they may not be needed downstream; then we rely on a new dead-code elimination (DCE) pass to clean things up. (Notice we can't apply DCE until the very end, i.e. we can't apply it to subjaxprs within a jit since we don't know how its outputs will be used!) An alternative to relying on DCE would be to form jaxpr1 and jaxpr2 in a reverse-dataflow pass; that's viable, but it still requires a backward pass with its own rules for higher-order primitives (i.e. it doesn't offer much of a simplification), and DCE is a useful tool on its own (whereas this alternative backward pass would only be useful for partial evaluation).

Here's [the resulting Autodidax version of partial\_eval\_jaxpr\_custom](https://github.com/google/jax/pull/7517/files#diff-bda36e5567d146410fb8b82f722eba347827bb6faae605b5e87f3a32130f3c99R2905-R2959), as well as [its rule for xla\_call as a higher-order primitive](https://github.com/google/jax/pull/7517/files#diff-bda36e5567d146410fb8b82f722eba347827bb6faae605b5e87f3a32130f3c99R2977-R2994). Here's the implementation of [dce\_jaxpr](https://github.com/google/jax/pull/7517/files#diff-bda36e5567d146410fb8b82f722eba347827bb6faae605b5e87f3a32130f3c99R3006-R3036) and [its rule for xla\_call](https://github.com/google/jax/pull/7517/files#diff-bda36e5567d146410fb8b82f722eba347827bb6faae605b5e87f3a32130f3c99R3040-R3049).


##### Examples related to dead code {#examples-related-to-dead-code}

**Example 1: dead code in jaxpr1 and jaxpr2**

Without DCE, the `partial_eval_jaxpr_custom` implementation described above can produce primitive applications that are unused on either of its output jaxprs. For example, given this input jaxpr to be partially evaluated with a save-nothing policy:


```
{ lambda a:f64[], b:f64[] .
  let c:f64[] = sin a
      d:f64[] = cos a
      e:f64[] = mul d b
  in ( f, e ) }
```

With the inputs labeled as known and unknown, respectively, the cosine is added to jaxpr1 defensively because all its inputs are known, and so based on forward-flow information alone its value could be needed in the primal computation.

In addition, the sine is added to jaxpr2 because the policy does not allow saving its value as a residual, and its value may later be needed in jaxpr2 (as an input to a first-order primitive application with some unknown inputs).

**Example 2: non-dead code in a sub-jaxpr of jaxpr2**

This example is meant to illustrate that we can't perform DCE on jaxpr2 when we form subjaxprs (e.g. for nested `jit` calls), and instead we must defer it until the end. Consider this jaxpr to be partially evaluated with a save-nothing policy:

```
{ lambda a:f64[], b:f64[] .
  let c:f64[] d:f64[] = xla_call [ num_consts=0 ] a
        { lambda a:f64[] .
          let b:f64[] = sin a
              c:f64[] = cos a
          in ( b, c ) }
      e:f64[] = mul d b
  in ( c, e ) }
```

With top-level inputs labeled known and unknown, respectively, both outputs to the xla_call application are known. Yet the value of the cosine application (and not the sine application) is needed in jaxpr2, downstream of the xla_call application, since it is used as an input to a first-order primitive with some unknown inputs.
