### PR TITLE
[jax2tf] Handle weakly-typed values in constant lifting correctly.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -25,7 +25,8 @@ import jax
 from jax._src import ad_util
 from jax import api_util, config
 from jax._src import api
-from jax import core, custom_derivatives, dtypes
+from jax import core, custom_derivatives
+from jax._src import dtypes
 from jax import linear_util as lu
 from jax import random, tree_util
 from jax import numpy as jnp
@@ -768,8 +769,9 @@ class TensorFlowTrace(core.Trace):
                               core.abstract_unit)
     else:
       tf_val, jax_dtype = _tfval_to_tensor_jax_dtype(val)
-      return TensorFlowTracer(self, val,
-                              core.ShapedArray(tf_val.shape, jax_dtype))
+      return TensorFlowTracer(
+        self, val, core.ShapedArray(tf_val.shape, jax_dtype,
+                                    weak_type=dtypes.is_weakly_typed(val)))
 
   def lift(self, val: core.Tracer) -> TensorFlowTracer:
     # This would be called when we need to raise a tracer from a lower-level

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -745,6 +745,14 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
         tf_fn_array(np.array([3, 4, 5])), np.array([4.5, 10, 17.5],
                                                    jnp.bfloat16))
 
+  def test_weak_types(self):
+    mul = jax.jit(jnp.multiply)
+    # The value `2` here should be weakly typed, and should not lead to
+    # promotion.
+    tf_fn = jax2tf.convert(lambda x: mul(x, 2.))
+    self.assertAllClose(tf_fn(tf.constant(1.375, tf.bfloat16)).numpy(),
+                        jnp.bfloat16(2.750))
+
   @parameterized.named_parameters(jtu.cases_from_list(
       dict(testcase_name=f"function={with_function}",
            with_function=with_function)


### PR DESCRIPTION
An upcoming change to JAX will add `jit` decorators around many standard library functions. This was causing the pattern in this test case to break: the test before this change returns a float64 value. However, no type promotion should take place because 2. is a Python scalar and should be weakly-typed.