### PR TITLE
[jax2tf] Allows shape polymorphic specification to be polynomials.

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -730,7 +730,7 @@ self.assertEqual(0, f_jax(x0))  # JAX sees that the x.shape[0] == 0
 
 # jax2tf catches the broken assumption b >= 1 if the converted function is executed
 # eagerly.
-# Raises: ValueError: PolyShape ('b',) has dimension variable 'b' corresponding to 0, for argument shapes (TensorShape([0]),)
+# Raises: ValueError: Dimension variable b must have integer value >= 1. Found value 0 when solving b == 0
 jax2tf.convert(f_jax, polymorphic_shapes=["b"])(x0))
 
 # However, if we first trace to a TensorFlow graph, we may miss the broken assumption:
@@ -753,7 +753,7 @@ self.assertEqual(0, f_jax(x45))  # JAX seems that x.shape[0] != x.shape[1]
 
 # jax2tf catches the broken assumption x.shape[0] == x.shape[1] if the converted
 # function is executed eagerly.
-# Raises: ValueError: PolyShape ('b, b',) has dimension variable 'b' corresponding to multiple values {4, 5}, for argument shapes (TensorShape([4, 5]),)
+# Raises: ValueError: polymorphic shape ('b, b',) has dimension variable 'b' corresponding to multiple values {4, 5}, for argument shapes (TensorShape([4, 5]),)
 jax2tf.convert(f_jax, polymorphic_shapes=["b, b"])(x45)
 
 # However, if we first trace to a TensorFlow graph, we may miss the broken assumption.


### PR DESCRIPTION
Until now, the polymorphic_shapes parameters could contain only
a constant or a dimension variable in each dimension. With this PR
we allow polynomials. These are needed in two situations:

  * when converting the VJP of a shape polymorphic function the shape
  specification corresponding to the cotangent must match the
  shape of the output of the primal function, which may contain
  polynomials of dimension variables.
  * one can specify that a dimension is even-sized by writing it
  as "2 * b", or that it is at least 10, by writing "b + 9".

This change requires changes to the code that solves the dimension
variables in terms of `tf.shape(arg)`. The dimension variables
are solved only from linear uni-variate polynomials followed by
replacing the solved variables in the other polynomials and
repeating until all variables are solved.