### PR TITLE
Do not unflatten trees with None values in grad.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -865,7 +865,8 @@ def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
 
     f = lu.wrap_init(fun, kwargs)
     f_partial, dyn_args = argnums_partial(f, argnums, args)
-    tree_map(partial(_check_input_dtype_grad, holomorphic, allow_int), dyn_args)
+    for leaf in tree_leaves(dyn_args):
+      _check_input_dtype_grad(holomorphic, allow_int, leaf)
     if not has_aux:
       ans, vjp_py = _vjp(f_partial, *dyn_args, reduce_axes=reduce_axes)
     else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2124,6 +2124,18 @@ class APITest(jtu.JaxTestCase):
     self.assertAllClose(ans1, np.cos(2.), check_dtypes=False)
     self.assertAllClose(ans2, np.cos(3.), check_dtypes=False)
 
+  def test_grad_does_not_unflatten_tree_with_none(self):
+    # https://github.com/google/jax/issues/7546
+    class CustomNode(list):
+      pass
+
+    def unflatten(unused_aux_data, children):
+      self.assertIsNotNone(children[0])
+      return CustomNode(children)
+
+    tree_util.register_pytree_node(CustomNode, lambda x: (x, None), unflatten)
+    grad(lambda x: x[0])(CustomNode([0.]))
+
   def test_trivial_computations(self):
     x = jnp.array([1, 2, 3])
     y = api.jit(lambda x: x)(x)


### PR DESCRIPTION
When checking the data type of the dynamic arguments in jax.value_and_grad the
PyTree is unflattened with `None` (the output of `_check_input_dtype_grad`) as
value for each leaf. This causes an issue if a custom PyTree does not accept
None as a value for the leaves (issue #7546) even though the tree that is
returned from the data type check is never used.

This commit solves this issue by making `_check_input_dtype_grad` an identity
function if the checks pass. That way it is guaranteed that the PyTree can be
unflattened.