### PR TITLE
Reword UnexpectedTracerError and add visual dividers.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -440,31 +440,32 @@ class Trace:
 
 def escaped_tracer_error(tracer, detail=None):
   num_frames = FLAGS.jax_tracer_error_num_traceback_frames
-  msg = ("Encountered an unexpected tracer. Perhaps this tracer escaped "
-         "through global state from a previously traced function.\n"
-         "The functions being transformed should not save traced values to "
-         "global state.")
-  if detail:
-    msg += " Detail: {}.".format(detail)
-  try:
-    line_info = tracer._line_info
-  except AttributeError:
-    pass
-  else:
-    msg += ('\nThe tracer that caused this error was created on line '
-            f'{source_info_util.summarize(line_info)}. The tracer has'
-            f' shape {tracer.shape} and dtype {tracer.dtype}.\n')
-    if num_frames > 0:
-      msg += (f'When the tracer was created, the final {num_frames} stack '
-              'frames (most recent last) excluding JAX-internal frames were:\n'
-              f'{source_info_util.summarize(line_info, num_frames=num_frames)}')
+  msg = ('Encountered an unexpected tracer. A function transformed by JAX '
+         'had a side effect, allowing for a reference to an intermediate value '
+         f'with shape {tracer.shape} and dtype {tracer.dtype} to escape.\n'
+         'JAX transformations require that functions explicitly return their '
+         'outputs, and disallow saving intermediate values to global state.')
   dbg = getattr(tracer._trace.main, 'debug_info', None)
   if dbg is not None:
-    msg += ('\nThe function being traced when the tracer leaked was '
+    msg += ('\nThe function being traced when the value leaked was '
             f'{dbg.func_src_info} traced for {dbg.traced_for}.')
+  line_info = getattr(tracer, '_line_info', None)
+  if line_info is not None:
+    divider = '\n' + '-'*30 + '\n'
+    msg += divider
+    msg += ('The leaked intermediate value was created on line '
+            f'{source_info_util.summarize(line_info)}. ')
+    msg += divider
+    if num_frames > 0:
+      msg += (f'When the value was created, the final {num_frames} stack '
+              'frames (most recent last) excluding JAX-internal frames were:')
+      msg += divider + source_info_util.summarize(
+          line_info, num_frames=num_frames) + divider
   msg += ('\nTo catch the leak earlier, try setting the environment variable '
           'JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context '
           'manager.')
+  if detail:
+    msg += f'Detail: {detail}'
   return UnexpectedTracerError(msg)
 
 class Tracer:


### PR DESCRIPTION
This is an attempt to reword the `UnexpectedTracerError` to mention less about tracers (and mention side-effects specifically). Also add some line dividers to break up the text.

Before:
``` 
jax._src.errors.UnexpectedTracerError: Encountered an unexpected tracer. Perhaps this tracer escaped through global state from a previously traced function.                                                                                                                                                                                                  
The functions being transformed should not save traced values to global state.                                                                                                                                                                                                                                                                                
The tracer that caused this error was created on line /usr/local/git/jax/tests/api_test.py:2258 (f). The tracer has shape () and dtype int32.                                                                                                                                                                                                                 
When the tracer was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:                                                                                                                                                                                                                                                  
/usr/lib/python3.9/unittest/case.py:653 (__call__)                                                                                                                                                                                                                                                                                                            
/usr/lib/python3.9/unittest/case.py:593 (run)                                                                                                                                                                                                                                     /usr/lib/python3.9/unittest/case.py:550 (_callTestMethod)                                                                                                                                                                                                                                                                                                                                                                                 
/usr/local/git/jax/tests/api_test.py:2259 (test_escaped_tracer_omnistaging)                                                                                                                                                                                                                                                                                   
/usr/local/git/jax/tests/api_test.py:2258 (f)                                                                                                                                                                                                                                                                                                                 
The function being traced when the tracer leaked was f at /usr/local/git/jax/tests/api_test.py:2255 traced for jit.                                                                                                                                                                                                                                           
To catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.                                                                                                                                                                                                                     
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError    
```
After:
```
jax._src.errors.UnexpectedTracerError: Encountered an unexpected tracer. A function that you transformed had a side effect of keeping a reference to an intermediate value with shape () and dtype int32.                                                                                                                                               
JAX transforms require all values to be explicitly passed in and out of transformed functions, and can't save intermediate values to global state.                             
The function being traced when the value leaked was f at /usr/local/git/jax/tests/api_test.py:2255 traced for jit.                                                             
------------------------------                                                                                                                                                 
The leaked intermediate value was created on line /usr/local/git/jax/tests/api_test.py:2258 (f).                                                                               
------------------------------                                                                                                                                                 
When the value was created, the final 5 stack frames (most recent last) excluding JAX-internal frames were:                                                                    
------------------------------                                                                                                                                                 
/usr/lib/python3.9/unittest/case.py:653 (__call__)                                                                                                                             
/usr/lib/python3.9/unittest/case.py:593 (run)                                                                                                                                  
/usr/lib/python3.9/unittest/case.py:550 (_callTestMethod)                                                                                                                      
/usr/local/git/jax/tests/api_test.py:2259 (test_escaped_tracer_omnistaging)                                                                                                    
/usr/local/git/jax/tests/api_test.py:2258 (f)                                                                                                                                  
------------------------------                                                                                                                                                 
                                                                                                                                                                               
To catch the leak earlier, try setting the environment variable JAX_CHECK_TRACER_LEAKS or using the `jax.checking_leaks` context manager.                                      
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.UnexpectedTracerError
```