### PR TITLE
Store avals in literals to avoid recanonicalization

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -48,8 +48,12 @@ array_types = {np.ndarray, np.bool_,
                np.complex64, np.complex128,
                np.longlong, np.intc}
 
+def make_concrete_array(val, weak_type=False):
+  dtype = dtypes.canonicalize_dtype(np.result_type(val))
+  return ConcreteArray(val.astype(dtype), weak_type=weak_type)
+
 for t in array_types:
-  core.pytype_aval_mappings[t] = ConcreteArray
+  core.pytype_aval_mappings[t] = make_concrete_array
   ad_util.jaxval_zeros_likers[t] = zeros_like_array
 
 core.literalable_types.update(array_types)

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -63,15 +63,20 @@ _dtype_to_32bit_dtype = {
 @util.memoize
 def canonicalize_dtype(dtype):
   """Convert from a dtype to a canonical dtype based on config.x64_enabled."""
-  try:
-    dtype = np.dtype(dtype)
-  except TypeError as e:
-    raise TypeError(f'dtype {dtype!r} not understood') from e
-
+  dtype = make_array_dtype(dtype)
   if config.x64_enabled:
     return dtype
   else:
     return _dtype_to_32bit_dtype.get(dtype, dtype)
+
+
+@util.memoize
+def make_array_dtype(dtype):
+  """Convert from a potentially non-array dtype to an array dtype."""
+  try:
+    return np.dtype(dtype)
+  except TypeError as e:
+    raise TypeError(f'dtype {dtype!r} not understood') from e
 
 
 # Default dtypes corresponding to Python scalars.

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -1263,7 +1263,7 @@ def scan(f: Callable[[Carry, X], Tuple[Carry, Y]],
     return carry, stacked_y
 
   x_shapes = [masking.padded_shape_as_value(x.shape[1:]) for x in xs_flat]
-  x_dtypes = [x.dtype for x in xs_flat]
+  x_dtypes = [dtypes.canonicalize_dtype(x.dtype) for x in xs_flat]
   x_avals = tuple(_map(ShapedArray, x_shapes, x_dtypes))
 
   def _create_jaxpr(init):
@@ -1820,7 +1820,7 @@ def _masked_scan_jaxpr(jaxpr, num_consts, num_carry):
                  for new_c, c in zip(new_carry, carry)]
     return [i + 1] + new_carry + ys
 
-  aval = ShapedArray((), dtypes.int_)
+  aval = ShapedArray((), dtypes.canonicalize_dtype(dtypes.int_))
   const_avals, carry_avals, x_avals = split_list(jaxpr.in_avals, [num_consts, num_carry])
   return _make_closed_jaxpr(masked, [aval] + const_avals + [aval] + carry_avals + x_avals)
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -209,12 +209,13 @@ class DropVar(Var):
 dropvar = DropVar()
 
 class Literal:
-  __slots__ = ["val", "hash"]
+  __slots__ = ["val", "hash", "aval"]
 
   val: Any
   hash: Optional[int]
 
-  def __init__(self, val):
+  def __init__(self, val, aval):
+    self.aval = raise_to_shaped(aval)
     self.val = val
     try:
       self.hash = hash(val)
@@ -224,10 +225,6 @@ class Literal:
           self.hash = hash((val.item(), val.dtype))
         except (TypeError, AttributeError, ValueError):
           self.hash = None
-
-  @property
-  def aval(self):
-    return raise_to_shaped(get_aval(self.val))
 
   def __hash__(self):
     assert False
@@ -1006,7 +1003,7 @@ class UnshapedArray(AbstractValue):
   array_abstraction_level = 2
 
   def __init__(self, dtype, weak_type=False):
-    self.dtype = np.dtype(dtypes.canonicalize_dtype(dtype))
+    self.dtype = dtypes.make_array_dtype(dtype)
     self.weak_type = weak_type
 
   def update(self, dtype=None, weak_type=None):

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -17,6 +17,7 @@ from jax._src.dtypes import (
     _jax_types,  # TODO(phawkins): fix users and remove?
     bfloat16,
     canonicalize_dtype,
+    make_array_dtype,
     finfo,  # TODO(phawkins): switch callers to jnp.finfo?
     float0,
     iinfo,  # TODO(phawkins): switch callers to jnp.iinfo?

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -462,7 +462,7 @@ class MaskTracer(Tracer):
 
   @property
   def dtype(self):
-    return dtypes.dtype(self.val)
+    return dtypes.canonicalize_dtype(dtypes.dtype(self.val))
 
   def is_pure(self):
     return all(type(poly) is not Poly or poly.is_constant

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -106,7 +106,8 @@ class JaxprTrace(Trace):
     return JaxprTracer(self, PartialVal.known(val), unit)
 
   def new_instantiated_literal(self, val) -> 'JaxprTracer':
-    return JaxprTracer(self, PartialVal.unknown(get_aval(val)), Literal(val))
+    aval = get_aval(val)
+    return JaxprTracer(self, PartialVal.unknown(aval), Literal(val, aval))
 
   def new_instantiated_const(self, val) -> 'JaxprTracer':
     return JaxprTracer(self, PartialVal.unknown(get_aval(val)), ConstVar(val))
@@ -981,7 +982,7 @@ def _inline_literals(jaxpr, constvals):
   def lit(var: core.Var) -> Optional[Any]:
     val = consts.get(var)
     if type(val) in core.literalable_types and not np.shape(val):
-      return Literal(val)
+      return Literal(val, var.aval)
     else:
       return None
 

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -56,7 +56,8 @@ class JaxJitTest(parameterized.TestCase):
       output_buffer = device_put_function(value, device=device)
 
       self.assertFalse(output_buffer.aval.weak_type)
-      self.assertEqual(output_buffer.aval, jax.core.ShapedArray((), dtype))
+      self.assertEqual(output_buffer.aval, jax.core.ShapedArray((),
+        dtypes.canonicalize_dtype(dtype)))
       self.assertEqual(output_buffer.dtype, dtypes.canonicalize_dtype(dtype))
 
   @parameterized.parameters([jax.device_put, _cpp_device_put])
@@ -68,7 +69,8 @@ class JaxJitTest(parameterized.TestCase):
       output_buffer = device_put_function(value, device=device)
 
       self.assertFalse(output_buffer.aval.weak_type)
-      self.assertEqual(output_buffer.aval, jax.core.ShapedArray((3, 4), dtype))
+      self.assertEqual(output_buffer.aval, jax.core.ShapedArray((3, 4),
+        dtypes.canonicalize_dtype(dtype)))
       self.assertEqual(output_buffer.dtype, dtypes.canonicalize_dtype(dtype))
       np.testing.assert_array_equal(output_buffer, np.zeros((3, 4),
                                                             dtype=dtype))

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -20,6 +20,7 @@ from absl.testing import absltest
 from absl.testing import parameterized
 
 from jax._src import api
+from jax import jit
 from jax import lax
 from jax import partial
 from jax import random
@@ -154,6 +155,15 @@ class X64ContextTests(jtu.JaxTestCase):
 
     z = api.jit(lambda x: x.astype(jnp.int32))(x)
     self.assertEqual(z.dtype, jnp.int32)
+
+  def test_jit_with_x64_contextmanager(self):
+    @jit
+    def f(a):
+      with enable_x64():
+        return 1 + a
+    out = f(1)
+    self.assertEqual(out.dtype, jnp.int64)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
TLDR; this PR changes how literal dtypes are "canonicalized" (chosen to be 64 or 32-bit) internally. In this PR we commit the dtypes of literals at trace time, rather than recanonicalizing later.

Generally speaking, this PR also addresses a class of error that arises when we have the `enable_x64` context manager. The context manager will be active at trace time but any subsequent processing of jaxprs after tracing  will not be under the context manager and errors can arise.

## Canonicalizing literals

Internally, dtype *canonicalization* refers to deciding whether dtype values will be 64- or 32-bit. By default, 64-bit dtypes are disabled, so something like `jnp.ones(5, jnp.float64)` will return an f32 array. Eager execution will automatically trigger dtype canonicalization. This decision is made by `dtypes.canonicalize_dtype`, which looks at the value of the `x64_enabled` global flag.

Dtype canonicalization also happens (for literals) while lowering to XLA (converting the jaxpr into an XLA op). When we `jit` a function, the function is traced to a jaxpr (eagerly canonicalizing dtypes at trace time). We'd expect the dtypes to be baked into the jaxpr, but for literals in particular, they are not! A literal in a jaxpr does not store its dtype at trace time, but is rather stored as a raw value. During XLA lowering, when we hit a literal, we canonicalize its dtype (looking up the value of the global flag).

Take the following example:
```python
@jit
def f(a):
  return 1 + a
f(2)
```
When calling the `jit`-ted function, we trace it to a jaxpr that has a `1` literal in it. Because x64 is disabled, `a` is set to `i32` and `1` is set to `i32` (this is because of weak typing). If x64 were enabled, then the `1` input would be `i64` and the literal `1` in the jaxpr would be set to `i64` as well. After tracing, the dtype used for the literal `1` is discarded. At lowering time, we re-infer the dtype for `1` using the value of the x64 flag.

If the global flag were just set once, this wouldn't be a problem (we'd canonicalize the literal at both trace time and lowering time to the same dtype). However, with the `enable_x64` context manager (which is only active at trace time), we now might recanonicalize the literal to be 32-bit when the `x64_enabled` is `False` at lowering time, when we had previously built the jaxpr at trace time based on the literal being 64-bit. 

```python
@jit
def f(a):
  with enable_x64():
    return 1 + a
```
If we were to pass in a strongly typed value, e.g. `jnp.int32(2)`, into `f`, the weakly typed `1` is set to `i32` as well and we have no problems. However, if we pass a weakly typed value, e.g. `f(2)`, it interacts with the `1 +` inside of the `enable_x64`, it is typed to `i64`, and the literal `1` as well is typed to `i64` and in theory we return an `i64` value from this function. However, in the XLA lowering where `enable_x64` is no longer active, we recanonicalize the `1` to an `i32`. This causes an XLA compilation error when we try adding an `i32` to the `i64` `a`.

### Solution

The solution breaks down into several parts, starting with the goal of passing literal dtype informations to the jaxpr lowering, with the goal of avoiding canonicalization during the lowering.
1. We need to somehow "save" the dtype of literals at trace time. Currently literals do not store values about shapes/dtypes. This PR adds an `aval` member to `Literal`s to enable this. The `JaxprTrace` populates the field with the information at trace time. 
2. In the `inline_literals` pass after tracing to a jaxpr, the dtype information is "reset" because the the avals are reconstructed. Reconstructing avals calls the constructor to `UnshapedArray`, which recanonicalizes the dtype, resetting it because the context manager is not active. This PR also removes canonicalization from the `UnshapedArray` constructor. When you construct an aval with a dtype, it will remain that dtype -- no canonicalization.
3. If `UnshapedArray` no longer does dtype canonicalization, we need to do at some point. We often construct avals by extracting them from values using `core.get_aval` where a value like a NumPy array might be passed in at trace-time. `core.get_aval` will in turn call `concrete_aval `for concrete values, which then hands off to a dispatching function that looks up types in `pytype_aval_mappings`. Array types are directly mapped to the `ConcreteArray` constructor, so at no point are we doing canonicalization for array types. We add this back in by changing the `pytype_aval_mappings` entry to do the canonicalization.
4. There are some locations (scan, masking, jax_jit_test) where we manually construct avals without `core.get_aval` and relied on getting an aval with a canonicalized dtype. In these locations we manually canonicalize the dtypes before constructing the avals.
5. Finally, in the XLA lowering (`jaxpr_subcomp`), we use the `aval` of the literal at hand instead of querying the value for its dtype. This avoids producing a 32-bit number when at trace time the number needed to be 64-bit. We no longer are doing any canonicalization during lowering.

This solution is a partial fix for #5982 in that it takes care of the case when we lose information about literals when lowering to XLA. However, there is a broad class of interactions that still do not work with `enable_x64`, such as when we have control flow. These will be dealt with in a future PR.
