### PR TITLE
Fix "Store empty" error due to debug_nans corrupting cache entries.

### DIFF
--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -201,5 +201,18 @@ class DebugInfsTest(jtu.JaxTestCase):
       with self.assertRaisesRegex(FloatingPointError, msg):
         f(1)
 
+  def testDebugNansDoesntCorruptCaches(self):
+    # https://github.com/google/jax/issues/6614
+    @jax.jit
+    def f(x):
+      return jnp.divide(x, x)
+
+    for _ in range(2):
+      try:
+       with jax.debug_nans(True):
+         jax.grad(f)(0.)
+      except FloatingPointError:
+        pass
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Rather than mutating the existing WrappedFun, clone it with fresh stores. The stores aren't connected to anything, but that's fine: we can treat the deoptimized computation as a throwaway computation; the "real" computation is the jit-compiled version and we are ultimately going to use its stores if we don't throw an exception.

Fixes #6614
