### PR TITLE
Improve semantics of out-of-bounds indices in gather and scatter

### DIFF
--- a/docs/jax.ops.rst
+++ b/docs/jax.ops.rst
@@ -21,6 +21,7 @@ follows (where ``idx`` is a NumPy index expression).
 =========================  ===================================================
 Alternate syntax           Equivalent in-place expression
 =========================  ===================================================
+``x.at[idx].get(y)``       ``x[idx]``
 ``x.at[idx].set(y)``       ``x[idx] = y``
 ``x.at[idx].add(y)``       ``x[idx] += y``
 ``x.at[idx].multiply(y)``  ``x[idx] *= y``
@@ -32,14 +33,22 @@ Alternate syntax           Equivalent in-place expression
 
 None of these expressions modify the original `x`; instead they return
 a modified copy of `x`. However, inside a :py:func:`jit` compiled function,
-expressions like ``x = x.at[idx].set(y)`` are guaranteed to be applied inplace.
+expressions like ``x = x.at[idx].set(y)`` are guaranteed to be applied in-place.
+
+By default, JAX assumes that all indices are in-bounds. There is experimental
+support for giving more precise semantics to out-of-bounds indexed accesses,
+via the ``mode`` parameter to functions such as ``get`` and ``set``. Valid
+values for ``mode`` include ``"clip"``, which means that out-of-bounds indices
+will be clamped into range, and ``"fill"``/``"drop"``, which are aliases and
+mean that out-of-bounds reads will be filled with a scalar ``fill_value``,
+and out-of-bounds writes will be discarded.
 
 
 Indexed update functions (deprecated)
 -------------------------------------
 
 The following functions are aliases for the ``x.at[idx].set(y)``
-style operators. Prefer to use the ``x.at[idx]`` operators instead.
+style operators. Use the ``x.at[idx]`` operators instead.
 
 .. autosummary::
   :toctree: _autosummary

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2409,11 +2409,16 @@ def _gather_using_tf_gather(operand: TfVal, start_indices: TfVal, *,
 
 @partial(bool_to_int8, argnums=[0])
 def _gather(operand, start_indices, *, dimension_numbers, slice_sizes,
-            indices_are_sorted, unique_indices,
+            indices_are_sorted, unique_indices, mode, fill_value,
             _in_avals: Sequence[core.ShapedArray],
             _out_aval: core.ShapedArray):
   """Tensorflow implementation of gather."""
-  del unique_indices
+  del unique_indices, fill_value
+
+  if mode == lax.GatherScatterMode.FILL_OR_DROP:
+    raise NotImplementedError("FILL_OR_DROP gather mode is not implemented in "
+                              "jax2tf")
+
   if _thread_local_state.enable_xla:
     proto = _gather_dimensions_proto(start_indices.shape, dimension_numbers)
     slice_sizes_tf = _eval_shape(slice_sizes)
@@ -2534,10 +2539,14 @@ def _scatter_dimensions_proto(indices_shape, dimension_numbers):
 
 
 def _scatter(operand, scatter_indices, updates, *, update_jaxpr, update_consts,
-             dimension_numbers, indices_are_sorted, unique_indices,
+             dimension_numbers, indices_are_sorted, unique_indices, mode,
              _in_avals: Sequence[core.ShapedArray],
              _out_aval: core.ShapedArray):
   del unique_indices, _in_avals
+
+  if mode == lax.GatherScatterMode.CLIP:
+    raise NotImplementedError("CLIP scatter mode not implemented in jax2tf")
+
   assert len(update_consts) == 0, "Update computation cannot have constants"
 
   if not _thread_local_state.enable_xla:

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -590,10 +590,12 @@ def _custom_jvp_call_jaxpr_rule(primals_in, series_in, *, fun_jaxpr,
 jet_rules[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_rule
 
 def _scatter_add_rule(primals_in, series_in, *, update_jaxpr, update_consts,
-                      dimension_numbers, indices_are_sorted, unique_indices):
+                      dimension_numbers, indices_are_sorted, unique_indices,
+                      mode):
   bind = partial(lax.scatter_add_p.bind, update_jaxpr=update_jaxpr,
                  update_consts=update_consts, dimension_numbers=dimension_numbers,
-                 indices_are_sorted=indices_are_sorted, unique_indices=unique_indices)
+                 indices_are_sorted=indices_are_sorted,
+                 unique_indices=unique_indices, mode=mode)
   operand, scatter_indices, updates = primals_in
   primal_out = bind(operand, scatter_indices, updates)
   series_out = [bind(d1, scatter_indices, d2) for d1, _, d2 in zip(*series_in)]

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -18,6 +18,7 @@ from jax._src.lax.lax import (
   ConvGeneralDilatedDimensionNumbers as ConvGeneralDilatedDimensionNumbers,
   DotDimensionNumbers as DotDimensionNumbers,
   GatherDimensionNumbers as GatherDimensionNumbers,
+  GatherScatterMode as GatherScatterMode,
   Precision as Precision,
   RandomAlgorithm as RandomAlgorithm,
   RoundingMethod as RoundingMethod,


### PR DESCRIPTION
Previously the behavior of out-of-bounds indexed accesses was not well-defined. Gathers clamped indices to be in-bounds, whereas out-of-bounds scatters were dropped. Additionally, the gradients of out-of-bounds indices were incorrect, since scatter (the transpose of gather) had different semantics to gather.

This PR adds a new `mode` option to `gather` that allows the user to select one of three modes:
* `"clip"`: clamp out-of-bounds indices into range
* `"fill"`: fill out-of-bounds gathered windows with a constant value, typically NaN or 0.
* `"promise_in_bounds"`: preserve the current behavior, which is `"clip"` for gathers.

The PR also adds the same `mode` option to `scatter`. The modes for `scatter` are identical, but `"fill"` is an alias for `"drop"`, meaning "drop out of bounds updates".

The PR gives two main benefits:
* if we change the default for `gather` to `"fill"`, then we can help users catch accidental out-of-bounds indexing. If no `fill_value` is provided, `gather` defaults to one of NaN, or an extremal integer value. This should indicate the presence of out-of-bounds indices.
*  Since we now have both `"clip"` and `"fill"`/`"drop"` modes for both `gather` and `scatter`, we can now define a correct transpose for out-of-bounds indices. The transpose of a `"clip"` gather is a `"clip"` scatter, and the transpose of a `"fill"` gather is a `"drop"` scatter.

We probably need to add the same semantics to `dynamic_slice` and `dynamic_update_slice` in a future PR.


This PR does not yet change the default mode, since that is likely to break users. For now, it is set to `"promise_in_bounds"`, which preserves the current behavior.