### PR TITLE
jax.numpy: add missing x.choose() method

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5987,7 +5987,7 @@ _operators = {
 # These numpy.ndarray methods are just refs to an equivalent numpy function
 _nondiff_methods = ["all", "any", "argmax", "argmin", "argpartition", "argsort",
                     "nonzero", "searchsorted", "round"]
-_diff_methods = ["clip", "conj", "conjugate", "cumprod", "cumsum",
+_diff_methods = ["choose", "clip", "conj", "conjugate", "cumprod", "cumsum",
                  "diagonal", "dot", "max", "mean", "min", "prod", "ptp",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
                  "swapaxes", "take", "tile", "trace", "var"]


### PR DESCRIPTION
With this change, the following works:
```python
In [11]: import numpy as np                                                                                                                                        

In [12]: import jax.numpy as jnp                                                                                                                                   

In [13]: x = np.arange(3)                                                                                                                                          

In [14]: y = np.random.rand(3, 3)                                                                                                                                  

In [15]: x.choose(y)                                                                                                                                               
Out[15]: array([0.98189954, 0.62586081, 0.19377603])

In [16]: jnp.array(x).choose(y)                                                                                                                                    
Out[16]: DeviceArray([0.98189956, 0.6258608 , 0.19377603], dtype=float32)
```
I thought about adding test coverage, but I don't think any of these array methods are explicitly tested as methods: they have coverage via their equivalent `jnp`/`np` namespace functions.