### PR TITLE
Support scipy.fft.dct/dctn type=2

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -1,6 +1,17 @@
 jax.scipy package
 =================
 
+jax.scipy.fft
+-------------
+
+.. automodule:: jax.scipy.fft
+
+.. autosummary::
+  :toctree: _autosummary
+
+   dct
+   dctn
+
 jax.scipy.linalg
 ----------------
 

--- a/docs/sphinxext/jax_extensions.py
+++ b/docs/sphinxext/jax_extensions.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from docutils import nodes
+from docutils import nodes, utils
+
+from sphinx.util.nodes import split_explicit_title
 
 def jax_issue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
   """Generate links to jax issues or PRs in sphinx.
@@ -32,5 +34,15 @@ def jax_issue_role(name, rawtext, text, lineno, inliner, options={}, content=[])
   node = nodes.reference(rawtext, '#' + text, refuri=url, **options)
   return [node], []
 
+def doi_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+  text = utils.unescape(text)
+  has_explicit_title, title, part = split_explicit_title(text)
+  full_url = 'https://doi.org/' + part
+  if not has_explicit_title:
+    title = 'DOI:' + part
+  pnode = nodes.reference(title, title, internal=False, refuri=full_url)
+  return [pnode], []
+
 def setup(app):
   app.add_role('jax-issue', jax_issue_role)
+  app.add_role('doi', doi_role)

--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import scipy.fftpack as osp_fft  # TODO use scipy.fft once scipy>=1.4.0 is used
+from jax import lax, numpy as jnp, partial
+from jax._src.lax.lax import _canonicalize_axis
+from jax._src.numpy.util import _wraps
+
+def _W4(N, k):
+  return jnp.exp(-.5j * jnp.pi * k / N)
+
+def _dct_interleave(x, axis):
+  v0 = lax.slice_in_dim(x, None, None, 2, axis)
+  v1 = lax.rev(lax.slice_in_dim(x, 1, None, 2, axis), (axis,))
+  return lax.concatenate([v0, v1], axis)
+
+def _dct_ortho_norm(out, axis):
+  factor = lax.concatenate([lax.full((1,), 4, out.dtype), lax.full((out.shape[axis] - 1,), 2, out.dtype)], 0)
+  factor = lax.expand_dims(factor, [a for a in range(out.ndim) if a != axis])
+  return out / lax.sqrt(factor * out.shape[axis])
+
+# Implementation based on
+# John Makhoul: A Fast Cosine Transform in One and Two Dimensions (1980)
+
+@_wraps(osp_fft.dct)
+def dct(x, type=2, n=None, axis=-1, norm=None):
+  if type != 2:
+    raise NotImplementedError('Only DCT type 2 is implemented.')
+
+  axis = _canonicalize_axis(axis, x.ndim)
+  if n is not None:
+    x = lax.pad(x, jnp.array(0, x.dtype),
+                [(0, n - x.shape[axis] if a == axis else 0, 0)
+                 for a in range(x.ndim)])
+
+  N = x.shape[axis]
+  v = _dct_interleave(x, axis)
+  V = jnp.fft.fft(v, axis=axis)
+  k = lax.expand_dims(jnp.arange(N), [a for a in range(x.ndim) if a != axis])
+  out = V * _W4(N, k)
+  out = 2 * out.real
+  if norm == 'ortho':
+    out = _dct_ortho_norm(out, axis)
+  return out
+
+
+def _dct2(x, axes, norm):
+  axis1, axis2 = map(partial(_canonicalize_axis, num_dims=x.ndim), axes)
+  N1, N2 = x.shape[axis1], x.shape[axis2]
+  v = _dct_interleave(_dct_interleave(x, axis1), axis2)
+  V = jnp.fft.fftn(v, axes=axes)
+  k1 = lax.expand_dims(jnp.arange(N1), [a for a in range(x.ndim) if a != axis1])
+  k2 = lax.expand_dims(jnp.arange(N2), [a for a in range(x.ndim) if a != axis2])
+  out = _W4(N1, k1) * (_W4(N2, k2) * V + _W4(N2, -k2) * jnp.roll(jnp.flip(V, axis=axis2), shift=1, axis=axis2))
+  out = 2 * out.real
+  if norm == 'ortho':
+    return _dct_ortho_norm(_dct_ortho_norm(out, axis1), axis2)
+  return out
+
+
+@_wraps(osp_fft.dctn)
+def dctn(x, type=2, s=None, axes=None, norm=None):
+  if type != 2:
+    raise NotImplementedError('Only DCT type 2 is implemented.')
+
+  if axes is None:
+    axes = range(x.ndim)
+
+  if len(axes) == 1:
+    return dct(x, n=s[0] if s is not None else None, axis=axes[0], norm=norm)
+
+  if s is not None:
+    ns = {a: n for a, n in zip(axes, s)}
+    pads = [(0, ns[a] - x.shape[a] if a in ns else 0, 0) for a in range(x.ndim)]
+    x = lax.pad(x, jnp.array(0, x.dtype), pads)
+
+  if len(axes) == 2:
+    return _dct2(x, axes=axes, norm=norm)
+
+  # compose high-D DCTs from 2D and 1D DCTs:
+  for axes_block in [axes[i:i+2] for i in range(0, len(axes), 2)]:
+    x = dctn(x, axes=axes_block, norm=norm)
+  return x

--- a/jax/scipy/fft.py
+++ b/jax/scipy/fft.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from . import linalg
-from . import ndimage
-from . import signal
-from . import sparse
-from . import special
-from . import stats
-from . import fft
+
+from jax._src.scipy.fft import (
+  dct,
+  dctn
+)

--- a/tests/scipy_fft_test.py
+++ b/tests/scipy_fft_test.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+
+from absl.testing import absltest, parameterized
+
+from jax import test_util as jtu
+import jax.scipy.fft as jsp_fft
+import scipy.fftpack as osp_fft  # TODO use scipy.fft once scipy>=1.4.0 is used
+
+from jax.config import config
+
+config.parse_flags_with_absl()
+
+float_dtypes = jtu.dtypes.floating
+real_dtypes = float_dtypes + jtu.dtypes.integer + jtu.dtypes.boolean
+
+def _get_dctn_test_axes(shape):
+  axes = [[]]
+  ndims = len(shape)
+  axes.append(None)
+  for naxes in range(1, min(ndims, 3) + 1):
+    axes.extend(itertools.combinations(range(ndims), naxes))
+  for index in range(1, ndims + 1):
+    axes.append((-index,))
+  return axes
+
+def _get_dctn_test_s(shape, axes):
+  s_list = [None]
+  if axes is not None:
+    s_list.extend(itertools.product(*[[shape[ax]+i for i in range(-shape[ax]+1, shape[ax]+1)] for ax in axes]))
+  return s_list
+
+class LaxBackedScipyFftTests(jtu.JaxTestCase):
+  """Tests for LAX-backed scipy.fft implementations"""
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_shape={jtu.format_shape_dtype_string(shape, dtype)}_n={n}_axis={axis}_norm={norm}",
+         shape=shape, dtype=dtype, n=n, axis=axis, norm=norm)
+      for dtype in real_dtypes
+      for shape in [(10,), (2, 5)]
+      for n in [None, 1, 7, 13, 20]
+      for axis in [-1, 0]
+      for norm in [None, 'ortho']))
+  @jtu.skip_on_devices("rocm")
+  def testDct(self, shape, dtype, n, axis, norm):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: (rng(shape, dtype),)
+    jnp_fn = lambda a: jsp_fft.dct(a, n=n, axis=axis, norm=norm)
+    np_fn = lambda a: osp_fft.dct(a, n=n, axis=axis, norm=norm)
+    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=False,
+                            tol=1e-4)
+    self._CompileAndCheck(jnp_fn, args_maker, atol=1e-4)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    dict(testcase_name=f"_shape={jtu.format_shape_dtype_string(shape, dtype)}_axes={axes}_s={s}_norm={norm}",
+         shape=shape, dtype=dtype, s=s, axes=axes, norm=norm)
+    for dtype in real_dtypes
+    for shape in [(10,), (10, 10), (9,), (2, 3, 4), (2, 3, 4, 5)]
+    for axes in _get_dctn_test_axes(shape)
+    for s in _get_dctn_test_s(shape, axes)
+    for norm in [None, 'ortho']))
+  @jtu.skip_on_devices("rocm")
+  def testDctn(self, shape, dtype, s, axes, norm):
+    rng = jtu.rand_default(self.rng())
+    args_maker = lambda: (rng(shape, dtype),)
+    jnp_fn = lambda a: jsp_fft.dctn(a, s=s, axes=axes, norm=norm)
+    np_fn = lambda a: osp_fft.dctn(a, shape=s, axes=axes, norm=norm)
+    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=False,
+                            tol=1e-4)
+    self._CompileAndCheck(jnp_fn, args_maker, atol=1e-4)
+
+if __name__ == "__main__":
+    absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Implementation is based on `fft/fftn` (single call for 1D and 2D, same size) to keep it simple for now. I could switch to `rfft/rfftn` in a follow-up.