### PR TITLE
Add dtype to string representation of ConcreteArray.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1190,7 +1190,7 @@ class ConcreteArray(ShapedArray):
       raise TypeError(self, other)
 
   def str_short(self) -> str:
-    return str(self.val)
+    return f'{self.val}, dtype={self.dtype.name}'
 
   _bool = _nonzero = partialmethod(_forward_to_value, bool)
   _int             = partialmethod(_forward_to_value, int)

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -333,6 +333,12 @@ class CoreTest(jtu.JaxTestCase):
     args_maker = lambda: (core.unit, 1)
     self._CompileAndCheck(f, args_maker)
 
+  def test_concrete_array_string_representation(self):
+    # https://github.com/google/jax/issues/5364
+    self.assertEqual(
+        str(core.ConcreteArray(np.array([1], dtype=np.int32))),
+        'ConcreteArray([1], dtype=int32)')
+
 
 class JaxprTypeChecks(jtu.JaxTestCase):
 


### PR DESCRIPTION
The string representation of ConcreteArray did not include the data type of the
wrapped value. This makes it harder to spot the reason for errors arising from
inconsistent values (issue #5364). This commit adds the data type to the string
representation of ConcreteArray.