### PR TITLE
always use same object for vmap temp axis name

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1256,8 +1256,6 @@ def vmap(fun: F, in_axes=0, out_axes=0, axis_name=None) -> F:
     docstr += "\n\nOriginal documentation:\n\n"
     docstr += fun.__doc__
 
-  axis_name = core._TempAxisName(fun) if axis_name is None else axis_name
-
   if isinstance(in_axes, list):
     # To be a tree prefix of the positional args tuple, in_axes can never be a
     # list: if in_axes is not a leaf, it must be a tuple of trees. However,

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -66,7 +66,7 @@ def _match_axes(axis_size, axis_name, in_dims, out_dims_thunk, out_dim_dests,
   out_dims = out_dims_thunk()
   for od, od_dest in zip(out_dims, out_dim_dests):
     if od is not None and not isinstance(od_dest, int):
-      if not isinstance(axis_name, core._TempAxisName):
+      if not isinstance(axis_name, core._TempAxisName) and axis_name is not None:
         msg = f"vmap has mapped output (axis_name={axis_name}) but out_axes is {od_dest}"
       else:
         msg = f"vmap has mapped output but out_axes is {od_dest}"


### PR DESCRIPTION
Fixes #7621.

We don't need to create a fresh temporary axis name for every `vmap` call which is not given an axis name, since this axis name can't be used in collectives. Instead, we can always use the same object for the name. In particular that means we don't get the cache misses which caused #7621.