### PR TITLE
Don't initialize all backends when get_backend() is called with a specific backend.

### DIFF
--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -23,7 +23,7 @@ from jax.lib import xla_client as xc
 mock = absltest.mock
 
 
-class XlaBridgeTest(absltest.TestCase):
+class XlaBridgeTest(jtu.JaxTestCase):
 
   def test_set_device_assignment_no_partition(self):
     compile_options = xb.get_compile_options(
@@ -82,6 +82,113 @@ class XlaBridgeTest(absltest.TestCase):
       with mock.patch(
           "jax.lib.xla_client.make_tpu_client", side_effect=_mock_tpu_client):
         xb.tpu_client_timer_callback(0.01)
+
+
+class GetBackendTest(jtu.JaxTestCase):
+
+  class _DummyBackend:
+    def __init__(self, platform, device_count):
+      self.platform = platform
+      self._device_count = device_count
+
+    def device_count(self):
+      return self._device_count
+
+    def process_index(self):
+      return 0
+
+    def local_devices(self):
+      return []
+
+  def _register_factory(self, platform: str, priority, device_count=1):
+    xb.register_backend_factory(
+        platform, lambda: self._DummyBackend(platform, device_count),
+        priority=priority)
+
+  def setUp(self):
+    self._orig_factories = xb._backend_factories
+    xb._backend_factories = {}
+    self._reset_backend_state()
+
+    # get_backend logic assumes CPU platform is always present.
+    self._register_factory("cpu", 0)
+
+  def tearDown(self):
+    xb._backend_factories = self._orig_factories
+    self._reset_backend_state()
+
+  def _reset_backend_state(self):
+    xb._backends = None
+    xb._backends_errors = None
+    xb._default_backend = None
+    xb.get_backend.cache_clear()
+
+  def test_default(self):
+    self._register_factory("platform_A", 20)
+    self._register_factory("platform_B", 10)
+
+    backend = xb.get_backend()
+    self.assertEqual(backend.platform, "platform_A")
+    # All backends initialized.
+    self.assertEqual(len(xb._backends), len(xb._backend_factories))
+
+  def test_specific_platform(self):
+    self._register_factory("platform_A", 20)
+    self._register_factory("platform_B", 10)
+
+    backend = xb.get_backend("platform_B")
+    self.assertEqual(backend.platform, "platform_B")
+    # All backends initialized.
+    # TODO: only initialize the requested backend
+    self.assertEqual(len(xb._backends), len(xb._backend_factories))
+
+  def test_unknown_backend_error(self):
+    with self.assertRaisesRegex(RuntimeError, "Unknown backend foo"):
+      xb.get_backend("foo")
+
+  def test_backend_init_error(self):
+    def factory():
+      raise RuntimeError("I'm not a real backend")
+
+    xb.register_backend_factory("error", factory, priority=10)
+    # No error raised if there's a fallback backend.
+    default_backend = xb.get_backend()
+    self.assertEqual(default_backend.platform, "cpu")
+
+    with self.assertRaisesRegex(RuntimeError, "I'm not a real backend"):
+      xb.get_backend("error")
+
+  def test_no_devices(self):
+    self._register_factory("no_devices", -10, device_count=0)
+    default_backend = xb.get_backend()
+    self.assertEqual(default_backend.platform, "cpu")
+    with self.assertRaisesRegex(RuntimeError, "Unknown backend no_devices"):
+      xb.get_backend("no_devices")
+
+    self._reset_backend_state()
+
+    # TODO: this doesn't seem like desirable behavior, do something more
+    # consistent
+    self._register_factory("no_devices2", 10, device_count=0)
+    default_backend = xb.get_backend()
+    self.assertEqual(default_backend.platform, "no_devices2")
+    with self.assertRaisesRegex(RuntimeError, "Unknown backend no_devices2"):
+      xb.get_backend("no_devices2")
+
+  def test_factory_returns_none(self):
+    xb.register_backend_factory("none", lambda: None, priority=10)
+    default_backend = xb.get_backend()
+    self.assertEqual(default_backend.platform, "cpu")
+    with self.assertRaisesRegex(RuntimeError, "Unknown backend none"):
+      xb.get_backend("none")
+
+  def cpu_fallback_warning(self):
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      xb.get_backend()
+      self.assertLen(w, 1)
+      msg = str(w[-1].message)
+      self.assertIn("No GPU/TPU found, falling back to CPU", msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change refactors the get_backend() logic to also handle some edge cases more clearly, see the unit test changes.

One side-effect of this change not reflected in the test is that there'll be INFO logging for backend factories that return None or backends with no devices. I'm not sure if this is a good or bad thing, but I don't think it should make a huge difference either way.

Partially addresses https://github.com/google/jax/issues/7622.