### PR TITLE
user-customizable gradient checkpointing strategies

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -45,6 +45,7 @@ from ._src.config import (
 from ._src.api import (
   ad,  # TODO(phawkins): update users to avoid this.
   checkpoint,
+  checkpoint_policies,
   closure_convert,
   curry,  # TODO(phawkins): update users to avoid this.
   custom_ivjp,

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -29,6 +29,7 @@ import itertools as it
 import sys
 import threading
 import weakref
+import types
 from typing import (Any, Callable, Iterable, NamedTuple, Mapping, Optional,
                     Sequence, Tuple, TypeVar, Union, overload)
 from warnings import warn
@@ -36,6 +37,7 @@ from warnings import warn
 import numpy as np
 from contextlib import contextmanager, ExitStack
 
+import jax
 from .. import core
 from .. import lib
 from .. import linear_util as lu
@@ -2686,11 +2688,12 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
       ``pmap``, CSE can defeat the purpose of this decorator. But in some
       settings, like when used inside a ``scan``, this CSE prevention mechanism
       is unnecessary, in which case ``prevent_cse`` can be set to False.
-    policy: Optional, callable which takes as input a type-level specification
-      of a first-order primitive application and returns a boolean indicating
-      whether the corresponding output value(s) can be saved as a residual (or,
-      if not, instead must be recomputed in the (co)tangent computation).
-      Experimental.
+    policy: This is an experimental feature and the API is likely to change.
+      Optional callable, one of the attributes of ``jax.checkpoint_policies``,
+      which takes as input a type-level specification of a first-order primitive
+      application and returns a boolean indicating whether the corresponding
+      output value(s) can be saved as a residual (or, if not, instead must be
+      recomputed in the (co)tangent computation).
 
   Returns:
     A function (callable) with the same input/output behavior as ``fun`` but
@@ -2747,6 +2750,12 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
     return tree_unflatten(out_tree(), out_flat)
   return fun_remat
 remat = checkpoint
+
+checkpoint_policies = types.SimpleNamespace(
+    checkpoint_dots=
+    lambda prim, *_, **__: prim in {jax._src.lax.lax.dot_general_p,
+                                    jax._src.lax.lax.conv_general_dilated_p},
+)
 
 
 def named_call(

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2639,7 +2639,7 @@ def eval_shape(fun: Callable, *args, **kwargs):
 
 
 def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
-               saveable_policy: Optional[Callable[..., bool]] = None,
+               policy: Optional[Callable[..., bool]] = None,
                ) -> Callable:
   """Make ``fun`` recompute internal linearization points when differentiated.
 
@@ -2686,11 +2686,11 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
       ``pmap``, CSE can defeat the purpose of this decorator. But in some
       settings, like when used inside a ``scan``, this CSE prevention mechanism
       is unnecessary, in which case ``prevent_cse`` can be set to False.
-    saveable_policy: Optional, callable which takes as input a type-level
-      specification of a first-order primitive application and returns a boolean
-      indicating whether the corresponding output value(s) can be saved as a
-      residual (or, if not, instead must be recomputed in the (co)tangent
-      computation). Experimental.
+    policy: Optional, callable which takes as input a type-level specification
+      of a first-order primitive application and returns a boolean indicating
+      whether the corresponding output value(s) can be saved as a residual (or,
+      if not, instead must be recomputed in the (co)tangent computation).
+      Experimental.
 
   Returns:
     A function (callable) with the same input/output behavior as ``fun`` but
@@ -2743,7 +2743,7 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
     out_flat = pe.remat_call(flat_fun, *args_flat, name=flat_fun.__name__,
                              concrete=concrete, prevent_cse=prevent_cse,
                              differentiated=False,
-                             saveable_policy=saveable_policy)
+                             policy=policy)
     return tree_unflatten(out_tree(), out_flat)
   return fun_remat
 remat = checkpoint

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2639,6 +2639,7 @@ def eval_shape(fun: Callable, *args, **kwargs):
 
 
 def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
+               saveable_policy: Optional[Callable[..., bool]] = None,
                ) -> Callable:
   """Make ``fun`` recompute internal linearization points when differentiated.
 
@@ -2685,6 +2686,11 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
       ``pmap``, CSE can defeat the purpose of this decorator. But in some
       settings, like when used inside a ``scan``, this CSE prevention mechanism
       is unnecessary, in which case ``prevent_cse`` can be set to False.
+    saveable_policy: Optional, callable which takes as input a type-level
+      specification of a first-order primitive application and returns a boolean
+      indicating whether the corresponding output value(s) can be saved as a
+      residual (or, if not, instead must be recomputed in the (co)tangent
+      computation). Experimental.
 
   Returns:
     A function (callable) with the same input/output behavior as ``fun`` but
@@ -2736,7 +2742,8 @@ def checkpoint(fun: Callable, concrete: bool = False, prevent_cse: bool = True,
     flat_fun, out_tree = flatten_fun(lu.wrap_init(fun), in_tree)
     out_flat = pe.remat_call(flat_fun, *args_flat, name=flat_fun.__name__,
                              concrete=concrete, prevent_cse=prevent_cse,
-                             differentiated=False)
+                             differentiated=False,
+                             saveable_policy=saveable_policy)
     return tree_unflatten(out_tree(), out_flat)
   return fun_remat
 remat = checkpoint

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -383,9 +383,9 @@ def custom_jvp_jaxpr_custom_partial_eval_rule(
     eqn: core.JaxprEqn
   ) -> Tuple[core.JaxprEqn, core.JaxprEqn, List[bool], List[bool], List[core.Var]]:
   # It doesn't make sense to unzip (i.e. break up) a custom_jvp function into
-  # constituient parts, so we always perform full remat. An alternative would be
-  # to allow the policy function to decide whether hte value of a
-  # custom_jvp-decorated function's applicaiton should be saved or not.
+  # constituent parts, so we always perform full remat. An alternative would be
+  # to allow the policy function to decide whether the value of a
+  # custom_jvp-decorated function's application should be saved or not.
   if any(unks_in): raise NotImplementedError  # TODO(mattjj): linear fn
   unks_out = [False] * len(eqn.outvars)
   new_inst = [x for x, inst in zip(eqn.invars, inst_in)

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -681,6 +681,9 @@ xla.initial_style_translations[custom_vjp_call_jaxpr_p] = \
 batching.primitive_batchers[ad.custom_lin_p] = ad._raise_custom_vjp_error_on_jvp
 xla.translations[ad.custom_lin_p] = ad._raise_custom_vjp_error_on_jvp
 
+pe.partial_eval_jaxpr_custom_rules[custom_vjp_call_jaxpr_p] = \
+    custom_jvp_jaxpr_custom_partial_eval_rule  # type: ignore
+
 
 def custom_gradient(fun):
   """Convenience function for defining custom VJP rules (aka custom gradients).
@@ -706,7 +709,9 @@ def custom_gradient(fun):
   over intermediate values computed when evaluating the function to be
   differentiated. That is, use lexical closure to share work between the forward
   pass and the backward pass of reverse-mode automatic differentiation. However,
-  it cannot support Python control flow.
+  it cannot perform Python control flow which depends on the values of the
+  closed-over intermediate values or its cotangent arguments; if the function
+  includes such control flow, an error is raised.
 
   Args:
     fun: a Python callable specifying both the mathematical function to be

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -393,7 +393,7 @@ def custom_jvp_jaxpr_custom_partial_eval_rule(
   inst_out = [True] * len(eqn.outvars)
   return eqn, eqn, unks_out, inst_out, new_inst
 pe.partial_eval_jaxpr_custom_rules[custom_jvp_call_jaxpr_p] = \
-    custom_jvp_jaxpr_custom_partial_eval_rule
+    custom_jvp_jaxpr_custom_partial_eval_rule  # type: ignore
 
 
 ### VJPs

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -560,6 +560,7 @@ pe.custom_partial_eval_rules[while_p] = _while_partial_eval
 xla.initial_style_translations[while_p] = _while_loop_translation_rule
 ad.primitive_transposes[while_p] = _while_transpose_error
 batching.initial_style_batchers[while_p] = _while_loop_batching_rule
+pe.partial_eval_jaxpr_custom_rules[while_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
 
 
 ### cond and switch
@@ -1136,6 +1137,7 @@ pe.custom_partial_eval_rules[cond_p] = _cond_partial_eval
 batching.initial_style_batchers[cond_p] = _cond_batching_rule
 xla.initial_style_translations[cond_p] = _cond_translation_rule
 core.custom_typechecks[cond_p] = _cond_typecheck
+pe.partial_eval_jaxpr_custom_rules[cond_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
 
 
 ### scan
@@ -1887,6 +1889,7 @@ xla.initial_style_translations[scan_p] = xla.lower_fun_initial_style(_scan_impl)
 batching.initial_style_batchers[scan_p] = _scan_batching_rule
 masking.masking_rules[scan_p] = _scan_masking_rule
 core.custom_typechecks[scan_p] = partial(_scan_typecheck, False)
+pe.partial_eval_jaxpr_custom_rules[scan_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
 
 
 @api_boundary
@@ -2434,6 +2437,7 @@ xla.initial_style_translations[linear_solve_p] = \
     xla.lower_fun_initial_style(_custom_linear_solve_impl)
 ad.primitive_transposes[linear_solve_p] = _linear_solve_transpose_rule
 batching.initial_style_batchers[linear_solve_p] = _linear_solve_batching_rule
+pe.partial_eval_jaxpr_custom_rules[linear_solve_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
 
 
 def _interleave(a, b, axis):

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1217,7 +1217,7 @@ def _reduce_scatter_abstract_eval(x, *, axis_name, scatter_dimension,
 reduce_scatter_p = core.AxisPrimitive("reduce_scatter")
 reduce_scatter_p.def_abstract_eval(_reduce_scatter_abstract_eval)
 xla.parallel_translations[reduce_scatter_p] = partial(
-    _reduce_scatter_translation_rule, lax.add_p, psum)
+    _reduce_scatter_translation_rule, lax.add_p, psum)  # type: ignore
 pxla.multi_host_supported_collectives.add(reduce_scatter_p)
 
 

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -23,7 +23,6 @@ from jax._src import util
 _exclude_paths = [__file__, util.__file__]
 
 def register_exclusion(path):
-  return
   _exclude_paths.append(path)
 
 _jax_message_append = (

--- a/jax/_src/traceback_util.py
+++ b/jax/_src/traceback_util.py
@@ -23,6 +23,7 @@ from jax._src import util
 _exclude_paths = [__file__, util.__file__]
 
 def register_exclusion(path):
+  return
   _exclude_paths.append(path)
 
 _jax_message_append = (

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -17,7 +17,7 @@ import functools
 import itertools as it
 import operator
 import types
-from typing import Any, Callable
+from typing import Any, Callable, List, Tuple
 
 from absl import logging
 import numpy as np
@@ -73,6 +73,13 @@ def split_list(args, ns):
     args = args[n:]
   lists.append(args)
   return lists
+
+def partition_list(bs: List[bool], l: List[Any]) -> Tuple[List[Any], List[Any]]:
+  assert len(bs) == len(l)
+  lists = lst1, lst2 = [], []  # type: ignore
+  for b, x in zip(bs, l):
+    lists[b].append(x)
+  return lst1, lst2
 
 def split_dict(dct, names):
   dct = dict(dct)

--- a/jax/core.py
+++ b/jax/core.py
@@ -143,6 +143,8 @@ class JaxprEqn(NamedTuple):
   def __repr__(self): return str(pp_eqn(self)).rstrip()
 
 def new_jaxpr_eqn(invars, outvars, primitive, params, source_info=None):
+  if primitive.call_primitive:
+    assert len(outvars) == len(params["call_jaxpr"].outvars)
   return JaxprEqn(invars, outvars, primitive, params, source_info)
 
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -565,6 +565,8 @@ def new_eqn_recipe(invars: Sequence[JaxprTracer],
   # TODO(necula): move these checks to core.check_jaxpr, and call in more places
   if primitive.call_primitive or primitive.map_primitive:
     assert "call_jaxpr" in params
+    # assert len(invars) == len(params["call_jaxpr"].invars)  # TODO constvars?
+    assert len(outvars) == len(params["call_jaxpr"].outvars)
   if primitive.map_primitive:
     assert ("in_axes" in params and
             len(params["in_axes"]) == len(params["call_jaxpr"].invars))

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 import contextlib
 import functools
 from typing import (Any, Callable, Dict, NamedTuple, Optional, Sequence, Tuple,
-                    List, Union, cast)
+                    List, Union, cast, Set)
 from weakref import ref
 
 import numpy as np
@@ -30,10 +30,11 @@ from jax._src.ad_util import Zero
 from ..api_util import flattened_fun_in_tree
 from .._src.tree_util import PyTreeDef, tree_unflatten, tree_leaves
 from .._src.util import (unzip2, safe_zip, safe_map, toposort, partial,
-                         split_list, cache, as_hashable_function)
+                         split_list, partition_list, cache, as_hashable_function)
 from ..core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
                     unit, unitvar, abstract_unit, ClosedJaxpr, new_jaxpr_eqn,
-                    dropvar, ConcreteArray, raise_to_shaped)
+                    dropvar, ConcreteArray, raise_to_shaped, Var, Atom,
+                    JaxprEqn, Primitive)
 from jax._src import source_info_util
 from ..config import config
 
@@ -401,9 +402,9 @@ def count_outputs(*args, **kwargs):
   ans = yield args, kwargs
   yield ans, len(ans)
 
-custom_partial_eval_rules: Dict[core.Primitive, Callable] = {}
-call_partial_eval_rules: Dict[core.Primitive, Callable] = {}
-call_param_updaters: Dict[core.Primitive, Callable] = {}
+custom_partial_eval_rules: Dict[Primitive, Callable] = {}
+call_partial_eval_rules: Dict[Primitive, Callable] = {}
+call_param_updaters: Dict[Primitive, Callable] = {}
 
 
 def abstract_eval_fun(fun, *avals, debug_info=None, **params):
@@ -542,13 +543,13 @@ class JaxprEqnRecipe(NamedTuple):
   eqn_id: object
   invars: Sequence[JaxprTracer]
   outvars: 'Sequence[ref[JaxprTracer]]'
-  primitive: core.Primitive
+  primitive: Primitive
   params: Dict[str, Any]
   source_info: Optional[source_info_util.Traceback]
 
 def new_eqn_recipe(invars: Sequence[JaxprTracer],
                    outvars: Sequence[JaxprTracer],
-                   primitive: core.Primitive,
+                   primitive: Primitive,
                    params: Dict[str, Any],
                    source_info: Optional[source_info_util.Traceback]
                   ) -> JaxprEqnRecipe:
@@ -572,12 +573,12 @@ def new_eqn_recipe(invars: Sequence[JaxprTracer],
                         params, source_info)
 
 
-def recipe_to_eqn(getvar: Callable[[JaxprTracer], core.Atom],
+def recipe_to_eqn(getvar: Callable[[JaxprTracer], Atom],
                   recipe: JaxprEqnRecipe) -> core.JaxprEqn:
   _, in_tracers, out_tracer_refs, primitive, params, source_info = recipe
   out_tracers = [t_ref() for t_ref in out_tracer_refs]
   invars  = [getvar(t) for t in in_tracers]
-  outvars = [core.dropvar if t is None else cast(core.Var, getvar(t))
+  outvars = [core.dropvar if t is None else cast(Var, getvar(t))
              for t in out_tracers]
   return new_jaxpr_eqn(invars, outvars, primitive, params, source_info)
 
@@ -597,8 +598,8 @@ def tracers_to_jaxpr(
     `invars`.
   """
   newvar = core.gensym()
-  t_to_var: Dict[int, core.Atom] = {}
-  def getvar(t: JaxprTracer) -> core.Atom:
+  t_to_var: Dict[int, Atom] = {}
+  def getvar(t: JaxprTracer) -> Atom:
     var = t_to_var.get(id(t))
     if var is None:
       aval = t.pval.get_aval() if not t.pval.is_known() else abstract_unit
@@ -607,9 +608,9 @@ def tracers_to_jaxpr(
   sorted_tracers = toposort(out_tracers)
   invars = map(getvar, in_tracers)
   eqns: List[core.JaxprEqn] = []
-  env: Dict[core.Var, Any] = {}
-  consts: Dict[core.Var, Any] = {}
-  const_to_var: Dict[int, core.Var] = {}
+  env: Dict[Var, Any] = {}
+  consts: Dict[Var, Any] = {}
+  const_to_var: Dict[int, Var] = {}
   def getconstvar(c):
     var = const_to_var.get(id(c))
     if var is None:
@@ -628,7 +629,7 @@ def tracers_to_jaxpr(
             t, "Tracer not among input tracers {}".format(t))
       assert in_tracers, "Lambda binding with no args"
     elif isinstance(recipe, FreeVar):
-      env[cast(core.Var, getvar(t))] = recipe.val
+      env[cast(Var, getvar(t))] = recipe.val
     elif isinstance(recipe, ConstVar):
       v = t_to_var[id(t)] = getconstvar(recipe.val)
       consts[v] = recipe.val
@@ -747,7 +748,7 @@ def partial_eval_jaxpr(jaxpr: ClosedJaxpr, unknowns: Sequence[bool],
   return ClosedJaxpr(jaxpr_1, consts_1), ClosedJaxpr(jaxpr_2, ()), uk_out
 
 
-remat_call_p: core.Primitive = core.CallPrimitive('remat_call')
+remat_call_p: Primitive = core.CallPrimitive('remat_call')
 remat_call = remat_call_p.bind
 remat_call_p.def_impl(core.call_impl)
 
@@ -772,56 +773,95 @@ def _remat_partial_eval(trace, _, f, tracers, params):
   in_pvals = [t.pval for t in instantiated_tracers]
   jaxpr, eval_out_pvals, consts, env_tracers = trace.partial_eval(
     f, in_pvals, partial(remat_call_p.bind, **params), instantiate=False)
-
-  # Convert consts to inputs, since they may contain Tracer instances.
   jaxpr = convert_constvars_jaxpr(jaxpr)
-  const_tracers = map(trace.new_instantiated_const, consts)
 
   # Since we traced with everything marked as unknown, but we need to know which
   # outputs are known/unknown, we use partial_eval_jaxpr to get out_unknowns.
-  closed_jaxpr = core.ClosedJaxpr(jaxpr, ())
   in_unknowns = ([False] * len(consts) +
                  [not t.is_known() for t in it.chain(env_tracers, tracers)])
-  jaxpr_known, jaxpr_unknown, out_unknowns = partial_eval_jaxpr(
-      closed_jaxpr, in_unknowns, instantiate=False)  # type: ignore
-  out_knowns = [not b for b in out_unknowns]
-  out_known_pvals, out_unknown_pvals = _partition_knowns(eval_out_pvals, out_unknowns)
+  if params['saveable_policy']:
+    # unzip into jaxpr1 and jaxpr2
+    jaxpr1_, jaxpr2_, out_unknowns, out_inst, _ = _partial_eval_jaxpr_custom(
+        jaxpr, in_unknowns, params['saveable_policy'])
+    jaxpr1, in_used1 = dce_jaxpr(jaxpr1_, [True] * len(jaxpr1_.outvars))
+    _, used_outs2 = partition_list(out_inst, out_unknowns)
+    jaxpr2, in_used2 = dce_jaxpr(jaxpr2_, used_outs2)
 
-  # Next, we need values for the outputs that should be known. Since consts
-  # weren't passed through Python for evaluation, we need to evaluate jaxpr_known,
-  # minus the residual outputs that we don't need. When `concrete=True`, as an
-  # optimization we can avoid redoing *some* redundant FLOPs, namely those that
-  # produced concrete avals at the output, simply by using those as computed
-  # values. For the use case of inverse-mode ad in op-by-op ("eager mode")
-  # evaluation, all the primal outputs should be concrete (thus not recomputed).
-  to_compute = [type(pval[0]) is not ConcreteArray
-                for uk, pval in zip(out_unknowns, eval_out_pvals) if not uk]
-  num_outputs = len(jaxpr_unknown.out_avals)
-  num_res = len(jaxpr_known.out_avals) - num_outputs
-  jaxpr_known_nores = _dce_jaxpr(jaxpr_known, out_knowns + [False] * num_res, drop_outputs=True)
-  jaxpr_known_comp = _dce_jaxpr(jaxpr_known_nores, to_compute)
-  _, in_consts = unzip2(t.pval for t in it.chain(env_tracers, tracers))
-  reconstructed_consts = core.jaxpr_as_fun(jaxpr_known_comp)(*consts, *in_consts)
-  out_known_pvals = map(_reconstruct_pval, out_known_pvals, reconstructed_consts)
+    # compute known outputs and residuals (hoisted out of a remat_call)
+    if concrete: raise NotImplementedError  # TODO(mattjj)
+    _, in_consts_ = unzip2(t.pval for t in it.chain(env_tracers, tracers)
+                           if t.pval.is_known())
+    _, in_consts = partition_list(in_used1, [*consts, *in_consts_])
+    out_consts = core.eval_jaxpr(jaxpr1, (), *in_consts)
+    out_consts_ = iter(out_consts)
+    # reconstruct known outs, inserting units
+    outs1 = [unit if x.aval is abstract_unit else next(out_consts_)
+             for uk, x in zip(out_unknowns, jaxpr.outvars) if not uk]
+    # form known outputs and collect residual tracers
+    out_known_tracers = [JaxprTracer(trace, PartialVal.known(c), None)
+                         for c in outs1]
+    residuals = list(out_consts_)
 
-  # Known outputs should keep propagating as constants
-  assert all(pv.is_known() for pv in out_known_pvals)
-  known_output_tracers = [trace.new_const(pval.get_known())
-                          for pval in out_known_pvals]
-  # Unknown outputs get wrapped in tracers with the appropriate recipe
-  unknown_output_tracers = [JaxprTracer(trace, out_pval, None)
-                            for out_pval in out_unknown_pvals]
+    # set up unknown outputs with a recipe to call remat
+    res_tracers = map(trace.new_instantiated_const, residuals)
+    const_tracers = map(trace.new_instantiated_const, consts)
+    in_jaxpr_tracers = [*res_tracers, *const_tracers, *env_tracers,
+                        *instantiated_tracers]
+    _, in_jaxpr_tracers = partition_list(in_used2, in_jaxpr_tracers)
+    out_jaxpr_tracers = [JaxprTracer(trace, PartialVal.unknown(x.aval), None)
+                         for x in jaxpr2.outvars]
+    new_params = dict(params, call_jaxpr=jaxpr2, differentiated=True)
+    recipe = new_eqn_recipe(in_jaxpr_tracers, out_jaxpr_tracers, remat_call_p,
+                            new_params, source_info_util.current())
+    for t in out_jaxpr_tracers: t.recipe = recipe
+    return _zip_knowns(out_known_tracers, out_jaxpr_tracers, out_unknowns)
+  else:
+    # TODO(mattjj): this is an old parallel code path, to be deleted once the
+    # new path is fully functional
+    closed_jaxpr = core.ClosedJaxpr(jaxpr, ())
+    jaxpr_known, jaxpr_unknown, out_unknowns = partial_eval_jaxpr(
+        closed_jaxpr, in_unknowns, instantiate=False)  # type: ignore
+    out_knowns = [not b for b in out_unknowns]
+    out_known_pvals, out_unknown_pvals = _partition_knowns(eval_out_pvals, out_unknowns)
 
-  # dce jaxpr outputs
-  new_jaxpr = _dce_jaxpr(closed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
-  new_params = dict(params, call_jaxpr=new_jaxpr, differentiated=True)
+    # Next, we need values for the outputs that should be known. Since consts
+    # weren't passed through Python for evaluation, we need to evaluate
+    # jaxpr_known, minus the residual outputs that we don't need. When
+    # `concrete=True`, as an optimization we can avoid redoing *some* redundant
+    # FLOPs, namely those that produced concrete avals at the output, simply by
+    # using those as computed values. For the use case of inverse-mode ad in
+    # op-by-op ("eager mode") evaluation, all the primal outputs should be
+    # concrete (thus not recomputed).
+    to_compute = [type(pval[0]) is not ConcreteArray
+                  for uk, pval in zip(out_unknowns, eval_out_pvals) if not uk]
+    num_outputs = len(jaxpr_unknown.out_avals)
+    num_res = len(jaxpr_known.out_avals) - num_outputs
+    jaxpr_known_nores = _dce_jaxpr(jaxpr_known, out_knowns + [False] * num_res,
+                                  drop_outputs=True)
+    jaxpr_known_comp = _dce_jaxpr(jaxpr_known_nores, to_compute)
+    _, in_consts = unzip2(t.pval for t in it.chain(env_tracers, tracers))
+    reconstructed_consts = core.jaxpr_as_fun(jaxpr_known_comp)(*consts, *in_consts)
+    out_known_pvals = map(_reconstruct_pval, out_known_pvals, reconstructed_consts)
 
-  # set up eqn for unknown outputs
-  in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
-  eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p,
-                       new_params, source_info_util.current())
-  for t in unknown_output_tracers: t.recipe = eqn
-  return _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
+    # Known outputs should keep propagating as constants
+    assert all(pv.is_known() for pv in out_known_pvals)
+    known_output_tracers = [trace.new_const(pval.get_known())
+                            for pval in out_known_pvals]
+    # Unknown outputs get wrapped in tracers with the appropriate recipe
+    unknown_output_tracers = [JaxprTracer(trace, out_pval, None)
+                              for out_pval in out_unknown_pvals]
+
+    # dce jaxpr outputs
+    new_jaxpr = _dce_jaxpr(closed_jaxpr, out_unknowns, drop_outputs=True).jaxpr
+    new_params = dict(params, call_jaxpr=new_jaxpr, differentiated=True)
+
+    # set up eqn for unknown outputs
+    const_tracers = map(trace.new_instantiated_const, consts)
+    in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
+    eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p,
+                         new_params, source_info_util.current())
+    for t in unknown_output_tracers: t.recipe = eqn
+    return _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
 call_partial_eval_rules[remat_call_p] = _remat_partial_eval
 
 def _partition_knowns(pvals, unknowns: Sequence[bool]):
@@ -829,8 +869,167 @@ def _partition_knowns(pvals, unknowns: Sequence[bool]):
           [e for e, unknown in zip(pvals, unknowns) if unknown])
 
 def _zip_knowns(known_list, unknown_list, which_unknown: Sequence[bool]):
+  assert len(known_list) + len(unknown_list) == len(which_unknown)
   known_iter, unknown_iter = iter(known_list), iter(unknown_list)
   return [next(unknown_iter) if uk else next(known_iter) for uk in which_unknown]
+
+
+def _partial_eval_jaxpr_custom(
+    jaxpr: Jaxpr, in_unknowns: List[bool], saveable: Callable[..., bool],
+  ) -> Tuple[Jaxpr, Jaxpr, List[bool], List[bool], int]:
+  if jaxpr.constvars: raise NotImplementedError  # TODO
+  env: Dict[Var, Tuple[bool, bool]] = {}
+  residuals: Set[Var] = set()
+
+  def read(x: Atom) -> Tuple[bool, bool]:
+    if type(x) is Var:
+      return env[x]
+    return (False, True)
+
+  def write(unk: bool, inst: bool, v: Var) -> None:
+    assert (unk, inst) != (True, False)
+    env[v] = (unk, inst)
+
+  def ensure_instantiated(inst: bool, x: Atom) -> Atom:
+    if type(x) is Var and not inst:
+      residuals.add(x)
+    return x
+
+  eqns1, eqns2 = [], []
+  write(False, True, unitvar)
+  map(write, in_unknowns, [True] * len(in_unknowns), jaxpr.invars)
+  for eqn in jaxpr.eqns:
+    unks_in, inst_in = unzip2(map(read, eqn.invars))
+    rule = partial_eval_jaxpr_custom_rules.get(eqn.primitive)
+    if rule:
+      eqn1, eqn2, unks_out, inst_out, res = rule(saveable, unks_in, inst_in, eqn)
+      eqn1 and eqns1.append(eqn1); eqn2 and eqns2.append(eqn2)  # type: ignore
+      residuals.update(res)
+      map(write, unks_out, inst_out, eqn.outvars)
+    elif any(unks_in):
+      inputs = map(ensure_instantiated, inst_in, eqn.invars)
+      eqns2.append(new_jaxpr_eqn(inputs, eqn.outvars, eqn.primitive,
+                                 eqn.params, eqn.source_info))
+      map(partial(write, True, True), eqn.outvars)
+    else:
+      eqns1.append(eqn)
+      if saveable(eqn.primitive, *[x.aval for x in eqn.invars], **eqn.params):
+        map(partial(write, False, False), eqn.outvars)
+      else:
+        inputs = map(ensure_instantiated, inst_in, eqn.invars)
+        eqns2.append(new_jaxpr_eqn(inputs, eqn.outvars, eqn.primitive,
+                                   eqn.params, eqn.source_info))
+        map(partial(write, False, True), eqn.outvars)
+  out_unknowns, out_inst = unzip2(map(read, jaxpr.outvars))
+  assert all(type(v) is Var for v in residuals), residuals
+
+  ins1, _ = partition_list(in_unknowns, jaxpr.invars)
+  outs1_, _ = partition_list(out_unknowns, jaxpr.outvars)
+  outs1 = [x for x in outs1_ if x.aval is not abstract_unit]
+  jaxpr1 = Jaxpr((), ins1, [*outs1, *residuals], eqns1)
+  config.jax_enable_checks and core.check_jaxpr(jaxpr1)
+
+  _, outs2 = partition_list(out_inst, jaxpr.outvars)
+  jaxpr2 = Jaxpr((), [*residuals, *jaxpr.invars], outs2, eqns2)
+  config.jax_enable_checks and core.check_jaxpr(jaxpr2)
+
+  return jaxpr1, jaxpr2, out_unknowns, out_inst, len(residuals)
+
+PartialEvalCustomResult = Tuple[Optional[JaxprEqn], Optional[JaxprEqn],
+                                List[bool], List[bool], List[Var]]
+PartialEvalCustomRule = Callable[
+    [Callable[..., bool], List[bool], List[bool], JaxprEqn],
+    PartialEvalCustomResult]
+partial_eval_jaxpr_custom_rules: Dict[Primitive, PartialEvalCustomRule] = {}
+
+def partial_eval_jaxpr_custom_rule_not_implemented(
+    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],
+    eqn: JaxprEqn) -> PartialEvalCustomResult:
+  raise NotImplementedError
+
+
+ParamsUpdater = Callable[[List[bool], int, dict, dict], Tuple[dict, dict]]
+
+def partial_eval_jaxpr_custom_call_rule(
+    params_updater: ParamsUpdater, saveable: Callable[..., bool],
+    unks_in: List[bool], inst_in: List[bool], eqn: JaxprEqn
+  ) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[bool], List[Var]]:
+  jaxpr1, jaxpr2, unks_out, inst_out, num_res = _partial_eval_jaxpr_custom(
+      eqn.params['call_jaxpr'], unks_in, saveable)
+  ins1, _ = partition_list(unks_in, eqn.invars)
+  out_binders1, _ = partition_list(unks_out, eqn.outvars)
+  _, out_binders2 = partition_list(inst_out, eqn.outvars)
+  newvar = core.gensym([jaxpr1, jaxpr2])
+  residuals = [newvar(v.aval) for v in jaxpr2.invars[:num_res]]
+  params1 = dict(eqn.params, call_jaxpr=jaxpr1)
+  params2 = dict(eqn.params, call_jaxpr=jaxpr2)
+  params1, params2 = params_updater(unks_in, num_res, params1, params2)
+  eqn1 = JaxprEqn(ins1, [*out_binders1, *residuals], eqn.primitive,
+                  params1, eqn.source_info)
+  eqn2 = JaxprEqn([*residuals, *eqn.invars], out_binders2, eqn.primitive,
+                  params2, eqn.source_info)
+  assert len(eqn2.invars) == len(jaxpr2.invars)
+  new_inst = [x for x, inst in zip(eqn.invars, inst_in)
+              if type(x) is Var and not inst]
+  return eqn1, eqn2, unks_out, inst_out, new_inst + residuals
+partial_eval_jaxpr_custom_rules[core.call_p] = \
+    partial(partial_eval_jaxpr_custom_call_rule, lambda _, __, x, y: (x, y))
+partial_eval_jaxpr_custom_rules[remat_call_p] = \
+    partial(partial_eval_jaxpr_custom_call_rule,
+            lambda _, __, p1, p2: (p1, dict(p2, differentiated=True)))
+
+
+# TODO unify with dce code below
+def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]
+              ) -> Tuple[Jaxpr, List[bool]]:
+  if jaxpr.constvars: raise NotImplementedError  # TODO
+  env: Dict[Var, bool] = {}
+
+  def read(v: Var) -> bool:
+    return env.get(v, False)
+
+  def write(x: Atom, b: bool) -> None:
+    if type(x) is Var:
+      env[x] = read(x) or b
+
+  new_eqns = []
+  map(write, jaxpr.outvars, used_outputs)
+  for eqn in jaxpr.eqns[::-1]:
+    used_outs = map(read, eqn.outvars)
+    rule = dce_rules.get(eqn.primitive)
+    if rule:
+      used_ins, new_eqn = rule(used_outs, eqn)
+      if any(used_ins): new_eqns.append(new_eqn)
+    else:
+      used_ins = [any(used_outs)] * len(eqn.invars)
+      if any(used_ins): new_eqns.append(eqn)
+    map(write, eqn.invars, used_ins)
+  used_inputs = map(read, jaxpr.invars)
+
+  new_jaxpr = Jaxpr((),
+                    [v for v, b in zip(jaxpr.invars, used_inputs)   if b],
+                    [v for v, b in zip(jaxpr.outvars, used_outputs) if b],
+                    new_eqns[::-1])
+  config.jax_enable_checks and core.check_jaxpr(new_jaxpr)
+
+  return new_jaxpr, used_inputs
+
+DCERule = Callable[[List[bool], JaxprEqn], Tuple[List[bool], JaxprEqn]]
+dce_rules: Dict[Primitive, DCERule] = {}
+
+
+def dce_jaxpr_call_rule(used_outputs: List[bool], eqn: JaxprEqn
+                        ) -> Tuple[List[bool], JaxprEqn]:
+  new_jaxpr, used_inputs = dce_jaxpr(eqn.params['call_jaxpr'], used_outputs)
+  new_params = dict(eqn.params, call_jaxpr=new_jaxpr)
+  update_params = call_param_updaters.get(eqn.primitive)
+  if update_params:
+    new_params = update_params(new_params, used_inputs)
+  new_eqn = JaxprEqn([v for v, used in zip(eqn.invars, used_inputs) if used],
+                     [v for v, used in zip(eqn.outvars, used_outputs) if used],
+                     eqn.primitive, new_params, eqn.source_info)
+  return used_inputs, new_eqn
+dce_rules[core.call_p] = dce_jaxpr_call_rule
 
 
 def _dce_jaxpr(closed_jaxpr: ClosedJaxpr, outputs: Sequence[bool], drop_outputs=False) -> ClosedJaxpr:
@@ -855,13 +1054,12 @@ def _dce_open_jaxpr(jaxpr: Jaxpr, outputs: Tuple[bool, ...], drop_outputs=False)
       new_eqns.append(eqn)
       needed_vars.update(v for v in eqn.invars if type(v) is not Literal)
   new_eqns = new_eqns[::-1]
-  return core.Jaxpr(jaxpr.constvars, jaxpr.invars,
-                    new_outvars, new_eqns)
+  return Jaxpr(jaxpr.constvars, jaxpr.invars, new_outvars, new_eqns)
 
 @cache()
 def _drop_invars(jaxpr: Jaxpr, drop: Tuple[bool, ...]):
-  return core.Jaxpr(jaxpr.constvars, [v for v, d in zip(jaxpr.invars, drop) if not d],
-                    jaxpr.outvars, jaxpr.eqns)
+  return Jaxpr(jaxpr.constvars, [v for v, d in zip(jaxpr.invars, drop) if not d],
+               jaxpr.outvars, jaxpr.eqns)
 
 
 def _reconstruct_pval(pval1: PartialVal, const2: core.Value):
@@ -880,8 +1078,8 @@ def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]) ->
   assert not closed_jaxpr.jaxpr.constvars
   assert len(closed_jaxpr.in_avals) == len(to_move)
   new_invars = _move_to_front(closed_jaxpr.jaxpr.invars, to_move)
-  new_jaxpr = core.Jaxpr((), new_invars, closed_jaxpr.jaxpr.outvars,
-                         closed_jaxpr.jaxpr.eqns)
+  new_jaxpr = Jaxpr((), new_invars, closed_jaxpr.jaxpr.outvars,
+                    closed_jaxpr.jaxpr.eqns)
   new_closed_jaxpr = core.ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
   return new_closed_jaxpr
 
@@ -978,7 +1176,7 @@ def _inline_literals(jaxpr, constvals):
   newvars = {}
   var = lambda v: newvars.get(v) or newvars.setdefault(v, newvar(v.aval))
 
-  def lit(var: core.Var) -> Optional[Any]:
+  def lit(var: Var) -> Optional[Any]:
     val = consts.get(var)
     if type(val) in core.literalable_types and not np.shape(val):
       return Literal(val)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -771,7 +771,7 @@ def _remat_partial_eval(trace, _, f, tracers, params):
     instantiated_tracers = map(trace.instantiate_const_abstracted, tracers)
 
   # Using the instantiated tracers, run call_bind like JaxprTrace.process_call.
-  in_pvals = [t.pval for t in instantiated_tracers]
+  in_pvals = [PartialVal.unknown(t.pval[0]) for t in instantiated_tracers]
   jaxpr, eval_out_pvals, consts, env_tracers = trace.partial_eval(
     f, in_pvals, partial(remat_call_p.bind, **params), instantiate=False)
   jaxpr = convert_constvars_jaxpr(jaxpr)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -37,7 +37,8 @@ from ..core import (ConcreteArray, ShapedArray, AbstractToken,
 from ..errors import UnexpectedTracerError
 from jax._src.pprint_util import pp
 from .._src.util import (partial, partialmethod, cache, prod, unzip2,
-                    extend_name_stack, wrap_name, safe_zip, safe_map)
+                         extend_name_stack, wrap_name, safe_zip, safe_map,
+                         partition_list)
 from ..lib import xla_bridge as xb
 from ..lib import xla_client as xc
 from . import partial_eval as pe
@@ -988,6 +989,22 @@ def _xla_call_translation_rule(c, axis_env, in_nodes, name_stack, backend, name,
 ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
 
 
+def _xla_call_partial_eval_custom_params_updater(
+    unks_in: List[bool], num_res: int, params1: dict, params2: dict
+  ) -> Tuple[dict, dict]:
+  # pruned inputs to jaxpr1 according to unks_in, so prune donated_invars1
+  donated_invars1, _ = partition_list(unks_in, params1['donated_invars'])
+  new_params1 = dict(params1, donated_invars=tuple(donated_invars1))
+  # added num_res new inputs to jaxpr2, so extend donated_invars2
+  donated_invars2 = [*([False] * num_res), *params2['donated_invars']]
+  new_params2 = dict(params2, donated_invars=tuple(donated_invars2))
+  return new_params1, new_params2
+pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
+    partial(pe.partial_eval_jaxpr_custom_call_rule,
+            _xla_call_partial_eval_custom_params_updater)
+pe.dce_rules[xla_call_p] = pe.dce_jaxpr_call_rule
+
+
 ### translation tables
 
 translations: Dict[core.Primitive, Callable] = {}
@@ -1483,8 +1500,9 @@ def _remat_using_while(
 
 def _remat_translation_rule(c, axis_env, in_nodes,
                             name_stack, backend, name, call_jaxpr,
-                            prevent_cse, differentiated, concrete, device=None):
-  del device, concrete  # Unused.
+                            prevent_cse, differentiated, concrete,
+                            saveable_policy, device=None):
+  del device, concrete, saveable_policy  # Unused.
   if differentiated and prevent_cse:
     if backend == "gpu":
       return _remat_using_while(

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1000,7 +1000,7 @@ def _xla_call_partial_eval_custom_params_updater(
   new_params2 = dict(params2, donated_invars=tuple(donated_invars2))
   return new_params1, new_params2
 pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
-    partial(pe.partial_eval_jaxpr_custom_call_rule,
+    partial(pe.call_partial_eval_custom_rule,
             _xla_call_partial_eval_custom_params_updater)
 pe.dce_rules[xla_call_p] = pe.dce_jaxpr_call_rule
 
@@ -1501,8 +1501,8 @@ def _remat_using_while(
 def _remat_translation_rule(c, axis_env, in_nodes,
                             name_stack, backend, name, call_jaxpr,
                             prevent_cse, differentiated, concrete,
-                            saveable_policy, device=None):
-  del device, concrete, saveable_policy  # Unused.
+                            policy, device=None):
+  del device, concrete, policy  # Unused.
   if differentiated and prevent_cse:
     if backend == "gpu":
       return _remat_using_while(

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -990,15 +990,15 @@ ad.primitive_transposes[xla_call_p] = partial(ad.call_transpose, xla_call_p)
 
 
 def _xla_call_partial_eval_custom_params_updater(
-    unks_in: List[bool], num_res: int, params1: dict, params2: dict
+    unks_in: List[bool], num_res: int, params_known: dict, params_staged: dict
   ) -> Tuple[dict, dict]:
-  # pruned inputs to jaxpr1 according to unks_in, so prune donated_invars1
-  donated_invars1, _ = partition_list(unks_in, params1['donated_invars'])
-  new_params1 = dict(params1, donated_invars=tuple(donated_invars1))
-  # added num_res new inputs to jaxpr2, so extend donated_invars2
-  donated_invars2 = [*([False] * num_res), *params2['donated_invars']]
-  new_params2 = dict(params2, donated_invars=tuple(donated_invars2))
-  return new_params1, new_params2
+  # pruned inputs to jaxpr_known according to unks_in, so prune donated_invars
+  donated_invars_known, _ = partition_list(unks_in, params_known['donated_invars'])
+  new_params_known = dict(params_known, donated_invars=tuple(donated_invars_known))
+  # added num_res new inputs to jaxpr_staged, so extend donated_invars
+  donated_invars_staged = [*([False] * num_res), *params_staged['donated_invars']]
+  new_params_staged = dict(params_staged, donated_invars=tuple(donated_invars_staged))
+  return new_params_known, new_params_staged
 pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
     partial(pe.call_partial_eval_custom_rule,
             _xla_call_partial_eval_custom_params_updater)

--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -169,6 +169,7 @@ def join_tolerance(tol1, tol2):
   return out
 
 def _assert_numpy_close(a, b, atol=None, rtol=None, err_msg=''):
+  a, b = np.asarray(a), np.asarray(b)
   assert a.shape == b.shape
   atol = max(tolerance(a.dtype, atol), tolerance(b.dtype, atol))
   rtol = max(tolerance(a.dtype, rtol), tolerance(b.dtype, rtol))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2978,16 +2978,14 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(count[0], 2)
 
 
-test_remat_variants = parameterized.named_parameters(
-    {"testcase_name": f"{suffix}", "remat": remat}
-     for suffix, remat in [
-         ('', api.remat),
-         ('_policy', partial(api.remat, policy=lambda *_, **__: False))
-    ])
-
 class RematTest(jtu.JaxTestCase):
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_basic(self, remat):
     @remat
     def g(x):
@@ -3023,7 +3021,12 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(len(sin_calls), 1)
     self.assertEqual(len(cos_calls), 2)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_freevars(self, remat):
     def f1(x):
       y = 2 * jnp.sin(x)
@@ -3063,7 +3066,12 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_jit(self, remat):
     @remat
     def g(x):
@@ -3085,7 +3093,12 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(np.sin(2.)) * np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_vmap(self, remat):
     @remat
     def g(x):
@@ -3105,7 +3118,12 @@ class RematTest(jtu.JaxTestCase):
     expected = np.diag(np.cos(np.sin(x)) * np.cos(x))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_higher_order_autodiff(self, remat):
     def f(x):
       return lax.cos(lax.sin(x))
@@ -3142,7 +3160,12 @@ class RematTest(jtu.JaxTestCase):
     scan_eqn, = jaxpr.jaxpr.eqns
     self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_no_redundant_flops(self, remat):
     # see https://github.com/google/jax/pull/1749#issuecomment-558267584
 
@@ -3165,7 +3188,12 @@ class RematTest(jtu.JaxTestCase):
     num_calls = len(called)
     self.assertLessEqual(num_calls, 1)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_binomial_checkpointing(self, remat):
     def binom_checkpoint(funs):
       if len(funs) == 1:
@@ -3208,7 +3236,12 @@ class RematTest(jtu.JaxTestCase):
 
     api.grad(func)(5.0)  # doesn't crash
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_jit2(self, remat):
     @api.jit
     def f(x):
@@ -3249,7 +3282,12 @@ class RematTest(jtu.JaxTestCase):
     u0 = jnp.ones_like(target)
     loss(u0, target, 10)  # doesn't crash
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_jit3(self, remat):
     # https://github.com/google/jax/issues/2180
     def f(w, x):
@@ -3307,7 +3345,12 @@ class RematTest(jtu.JaxTestCase):
 
     api.jit(named_call(f), static_argnums=0)(True, 1)  # no crash
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_remat_eval_counter(self, remat):
     # https://github.com/google/jax/issues/2737
     add_one_p = Primitive('add_one')
@@ -3362,7 +3405,12 @@ class RematTest(jtu.JaxTestCase):
     with assertEvals(2):
       vjp(v)
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_escaped_tracer_remat(self, remat):
     # b/169779185
     def f():
@@ -3377,7 +3425,12 @@ class RematTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(UnexpectedTracerError, "global state"):
       api.jit(f)()
 
-  @test_remat_variants
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+      ])
   def test_no_cse_widget_on_primals(self, remat):
     @remat
     def g(x):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2978,14 +2978,16 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(count[0], 2)
 
 
+test_remat_variants = parameterized.named_parameters(
+    {"testcase_name": f"{suffix}", "remat": remat}
+     for suffix, remat in [
+         ('', api.remat),
+         ('_policy', partial(api.remat, policy=lambda *_, **__: False))
+    ])
+
 class RematTest(jtu.JaxTestCase):
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_basic(self, remat):
     @remat
     def g(x):
@@ -3021,12 +3023,7 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(len(sin_calls), 1)
     self.assertEqual(len(cos_calls), 2)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_freevars(self, remat):
     def f1(x):
       y = 2 * jnp.sin(x)
@@ -3066,12 +3063,7 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_jit(self, remat):
     @remat
     def g(x):
@@ -3093,12 +3085,7 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(np.sin(2.)) * np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_vmap(self, remat):
     @remat
     def g(x):
@@ -3118,12 +3105,7 @@ class RematTest(jtu.JaxTestCase):
     expected = np.diag(np.cos(np.sin(x)) * np.cos(x))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_higher_order_autodiff(self, remat):
     def f(x):
       return lax.cos(lax.sin(x))
@@ -3160,12 +3142,7 @@ class RematTest(jtu.JaxTestCase):
     scan_eqn, = jaxpr.jaxpr.eqns
     self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_no_redundant_flops(self, remat):
     # see https://github.com/google/jax/pull/1749#issuecomment-558267584
 
@@ -3188,12 +3165,7 @@ class RematTest(jtu.JaxTestCase):
     num_calls = len(called)
     self.assertLessEqual(num_calls, 1)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_binomial_checkpointing(self, remat):
     def binom_checkpoint(funs):
       if len(funs) == 1:
@@ -3236,12 +3208,7 @@ class RematTest(jtu.JaxTestCase):
 
     api.grad(func)(5.0)  # doesn't crash
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_jit2(self, remat):
     @api.jit
     def f(x):
@@ -3282,12 +3249,7 @@ class RematTest(jtu.JaxTestCase):
     u0 = jnp.ones_like(target)
     loss(u0, target, 10)  # doesn't crash
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_jit3(self, remat):
     # https://github.com/google/jax/issues/2180
     def f(w, x):
@@ -3345,12 +3307,7 @@ class RematTest(jtu.JaxTestCase):
 
     api.jit(named_call(f), static_argnums=0)(True, 1)  # no crash
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_remat_eval_counter(self, remat):
     # https://github.com/google/jax/issues/2737
     add_one_p = Primitive('add_one')
@@ -3405,12 +3362,7 @@ class RematTest(jtu.JaxTestCase):
     with assertEvals(2):
       vjp(v)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_escaped_tracer_remat(self, remat):
     # b/169779185
     def f():
@@ -3425,12 +3377,7 @@ class RematTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(UnexpectedTracerError, "global state"):
       api.jit(f)()
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"{suffix}", "remat": remat}
-      for suffix, remat in [
-          ('', api.remat),
-          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
-      ])
+  @test_remat_variants
   def test_no_cse_widget_on_primals(self, remat):
     @remat
     def g(x):
@@ -3476,7 +3423,7 @@ class RematTest(jtu.JaxTestCase):
   def test_remat_custom_policy(self, policy, in_jaxpr2, not_in_jaxpr2):
     for square in [lambda x: x * x, api.jit(lambda x: x * x)]:
       f = api.remat(lambda x: jnp.sin(square(jnp.sin(x))),
-                    saveable_policy=policy)
+                    policy=policy)
       y, f_lin = api.linearize(f, 1.)
       ydot = f_lin(2.)
       jaxpr_text = str(f_lin.func.args[0])
@@ -3493,7 +3440,7 @@ class RematTest(jtu.JaxTestCase):
   def test_remat_custom_policy_save_cos(self):
     save_cos = lambda prim, *_, **__: str(prim) == 'cos'
     f = api.remat(lambda x: jnp.sin(jnp.sin(x)),  # different function
-                  saveable_policy=save_cos)
+                  policy=save_cos)
     _, f_lin = api.linearize(f, 1.)
     jaxpr_text = str(f_lin.func.args[0])
     self.assertNotIn(' sin ', jaxpr_text)
@@ -3503,7 +3450,7 @@ class RematTest(jtu.JaxTestCase):
   def test_remat_checkpoint_dots(self):
     checkpoint_dots = lambda prim, *_, **__: str(prim) == 'dot_general'
 
-    @partial(api.remat, saveable_policy=checkpoint_dots)
+    @partial(api.remat, policy=checkpoint_dots)
     def f(x):
       x = jnp.dot(x, x)
       x = jnp.sin(x)
@@ -3525,7 +3472,7 @@ class RematTest(jtu.JaxTestCase):
     x = jnp.ones((5,))
 
     def f(W):
-      @partial(api.remat, saveable_policy=checkpoint_dots)
+      @partial(api.remat, policy=checkpoint_dots)
       def f(x):
         x = jnp.sin(jnp.dot(x, W))
         x = jnp.sin(jnp.dot(x, W))
@@ -3562,7 +3509,7 @@ class RematTest(jtu.JaxTestCase):
       return sin(x), jnp.cos(x) * g
     sin.defjvp(sin_jvp)
 
-    @partial(api.remat, saveable_policy=save_sin)
+    @partial(api.remat, policy=save_sin)
     def f(x):
       return sin(sin(x))
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3501,9 +3501,7 @@ class RematTest(jtu.JaxTestCase):
     jtu.check_grads(f, (3.,), order=2, modes=['fwd', 'rev'])
 
   def test_remat_checkpoint_dots(self):
-    checkpoint_dots = lambda prim, *_, **__: str(prim) == 'dot_general'
-
-    @partial(api.remat, policy=checkpoint_dots)
+    @partial(api.remat, policy=jax.checkpoint_policies.checkpoint_dots)
     def f(x):
       x = jnp.dot(x, x)
       x = jnp.sin(x)
@@ -3520,12 +3518,10 @@ class RematTest(jtu.JaxTestCase):
     jtu.check_grads(f, (jnp.ones((2, 2)),), order=2, modes=['fwd', 'rev'])
 
   def test_remat_checkpoint_dots_inside_scan(self):
-    checkpoint_dots = lambda prim, *_, **__: str(prim) == 'dot_general'
-
     x = jnp.ones((5,))
 
     def f(W):
-      @partial(api.remat, policy=checkpoint_dots)
+      @partial(api.remat, policy=jax.checkpoint_policies.checkpoint_dots)
       def f(x):
         x = jnp.sin(jnp.dot(x, W))
         x = jnp.sin(jnp.dot(x, W))

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2980,8 +2980,14 @@ class APITest(jtu.JaxTestCase):
 
 class RematTest(jtu.JaxTestCase):
 
-  def test_remat_basic(self):
-    @api.remat
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_basic(self, remat):
+    @remat
     def g(x):
       return lax.sin(lax.sin(x)), 3.
 
@@ -3015,7 +3021,13 @@ class RematTest(jtu.JaxTestCase):
     self.assertEqual(len(sin_calls), 1)
     self.assertEqual(len(cos_calls), 2)
 
-  def test_remat_freevars(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_freevars(self, remat):
     def f1(x):
       y = 2 * jnp.sin(x)
       z = jnp.cos(x) * jnp.sin(y)
@@ -3023,7 +3035,7 @@ class RematTest(jtu.JaxTestCase):
 
     def f2(x):
       y = 2 * jnp.sin(x)
-      z = api.remat(lambda x: jnp.cos(x) * jnp.sin(y))(x)
+      z = remat(lambda x: jnp.cos(x) * jnp.sin(y))(x)
       return z
 
     ans, f_lin = api.linearize(f2, 2.)
@@ -3054,8 +3066,14 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def test_remat_jit(self):
-    @api.remat
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_jit(self, remat):
+    @remat
     def g(x):
       return lax.sin(lax.sin(x))
 
@@ -3075,8 +3093,14 @@ class RematTest(jtu.JaxTestCase):
     expected = np.cos(np.sin(2.)) * np.cos(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def test_remat_vmap(self):
-    @api.remat
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_vmap(self, remat):
+    @remat
     def g(x):
       return lax.sin(lax.sin(x))
 
@@ -3094,10 +3118,16 @@ class RematTest(jtu.JaxTestCase):
     expected = np.diag(np.cos(np.sin(x)) * np.cos(x))
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-  def test_remat_higher_order_autodiff(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_higher_order_autodiff(self, remat):
     def f(x):
       return lax.cos(lax.sin(x))
-    g = api.remat(f)
+    g = remat(f)
 
     ans = api.grad(api.grad(g))(3.)
     expected = api.grad(api.grad(f))(3.)
@@ -3130,14 +3160,20 @@ class RematTest(jtu.JaxTestCase):
     scan_eqn, = jaxpr.jaxpr.eqns
     self.assertIn(' cos ', str(scan_eqn.params['jaxpr']))
 
-  def test_remat_no_redundant_flops(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_no_redundant_flops(self, remat):
     # see https://github.com/google/jax/pull/1749#issuecomment-558267584
 
     @api.jit
     def g(x):
       return f(2., x)
 
-    @api.remat
+    @remat
     def f(x, y):
       return jnp.sin(x) * y
 
@@ -3152,14 +3188,20 @@ class RematTest(jtu.JaxTestCase):
     num_calls = len(called)
     self.assertLessEqual(num_calls, 1)
 
-  def test_remat_binomial_checkpointing(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_binomial_checkpointing(self, remat):
     def binom_checkpoint(funs):
       if len(funs) == 1:
         return funs[0]
       else:
         f1 = binom_checkpoint(funs[:len(funs)//2])
         f2 = binom_checkpoint(funs[len(funs)//2:])
-        return api.remat(lambda x: f1(f2(x)))
+        return remat(lambda x: f1(f2(x)))
 
     f1 = binom_checkpoint([jnp.sin, jnp.sin, jnp.sin, jnp.sin])
     f2 = lambda x: jnp.sin(jnp.sin(jnp.sin(jnp.sin(x))))
@@ -3194,12 +3236,18 @@ class RematTest(jtu.JaxTestCase):
 
     api.grad(func)(5.0)  # doesn't crash
 
-  def test_remat_jit2(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_jit2(self, remat):
     @api.jit
     def f(x):
       y = 2 * x
 
-      @api.remat
+      @remat
       def g():
         return y
 
@@ -3234,7 +3282,13 @@ class RematTest(jtu.JaxTestCase):
     u0 = jnp.ones_like(target)
     loss(u0, target, 10)  # doesn't crash
 
-  def test_remat_jit3(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_jit3(self, remat):
     # https://github.com/google/jax/issues/2180
     def f(w, x):
       a = jnp.dot(x, w)
@@ -3244,7 +3298,7 @@ class RematTest(jtu.JaxTestCase):
 
     w = jnp.ones([1, 1])
     x = jnp.ones([1, 1, 1])
-    f = api.remat(f)
+    f = remat(f)
     api.grad(f)(w, x)  # doesn't crash
 
     @api.jit
@@ -3258,7 +3312,7 @@ class RematTest(jtu.JaxTestCase):
 
     w = 1.
     x = 1.
-    f = api.remat(f)
+    f = remat(f)
     api.grad(f)(w, x)  # doesn't crash
 
   def test_remat_scan2(self):
@@ -3275,6 +3329,7 @@ class RematTest(jtu.JaxTestCase):
 
   def test_remat_jit_static_argnum_omnistaging(self):
     # https://github.com/google/jax/issues/2833
+    # NOTE(mattjj): after #3370, this test doesn't actually call remat...
     def named_call(f):
       def named_f(*args):
         f_ = lu.wrap_init(lambda: (f(*args),))
@@ -3290,7 +3345,13 @@ class RematTest(jtu.JaxTestCase):
 
     api.jit(named_call(f), static_argnums=0)(True, 1)  # no crash
 
-  def test_remat_eval_counter(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_remat_eval_counter(self, remat):
     # https://github.com/google/jax/issues/2737
     add_one_p = Primitive('add_one')
     add_one = add_one_p.bind
@@ -3318,8 +3379,8 @@ class RematTest(jtu.JaxTestCase):
 
     v = np.zeros((1,))
 
-    f = jax.remat(add_one)
-    g = jax.remat(lambda x: add_one(f(x)))
+    f = remat(add_one)
+    g = remat(lambda x: add_one(f(x)))
 
     # 2 calls needed to evaluate g
     with assertEvals(2):
@@ -3335,7 +3396,7 @@ class RematTest(jtu.JaxTestCase):
           *args, name='foo')[0]
 
     f = call(add_one)
-    g = jax.remat(lambda x: add_one(f(x)))
+    g = remat(lambda x: add_one(f(x)))
 
     # 2 calls needed to evaluate g
     with assertEvals(2):
@@ -3344,7 +3405,13 @@ class RematTest(jtu.JaxTestCase):
     with assertEvals(2):
       vjp(v)
 
-  def test_escaped_tracer_remat(self):
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_escaped_tracer_remat(self, remat):
     # b/169779185
     def f():
       seq = [jnp.zeros([])]
@@ -3352,14 +3419,20 @@ class RematTest(jtu.JaxTestCase):
         seq[0] += 1  # this is line 7 btw
         return seq[0]
 
-      api.remat(g)()
-      api.remat(g)()
+      remat(g)()
+      remat(g)()
 
     with self.assertRaisesRegex(UnexpectedTracerError, "global state"):
       api.jit(f)()
 
-  def test_no_cse_widget_on_primals(self):
-    @api.remat
+  @parameterized.named_parameters(
+      {"testcase_name": f"{suffix}", "remat": remat}
+      for suffix, remat in [
+          ('', api.remat),
+          ('_policy', partial(api.remat, saveable_policy=lambda *_, **__: False))
+      ])
+  def test_no_cse_widget_on_primals(self, remat):
+    @remat
     def g(x):
       return lax.sin(lax.sin(x)), 3.
 
@@ -3392,6 +3465,112 @@ class RematTest(jtu.JaxTestCase):
     self.assertNotIn('while', c.as_hlo_text())
     self.assertNotIn('conditional', c.as_hlo_text())
 
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{policy_name}", "policy": policy,
+       "in_jaxpr2": in_jaxpr2, "not_in_jaxpr2": not_in_jaxpr2}
+      for policy_name, policy, in_jaxpr2, not_in_jaxpr2 in [
+          ('save_anything', lambda *_, **__: True, [], [' sin ', ' cos ']),
+          ('save_nothing',  lambda *_, **__: False, [' sin ', ' cos '], []),
+          ('save_sin',  lambda p, *_, **__: str(p) == 'sin', [' cos '], [' sin ']),
+      ])
+  def test_remat_custom_policy(self, policy, in_jaxpr2, not_in_jaxpr2):
+    for square in [lambda x: x * x, api.jit(lambda x: x * x)]:
+      f = api.remat(lambda x: jnp.sin(square(jnp.sin(x))),
+                    saveable_policy=policy)
+      y, f_lin = api.linearize(f, 1.)
+      ydot = f_lin(2.)
+      jaxpr_text = str(f_lin.func.args[0])
+      for substr in in_jaxpr2:
+        self.assertIn(substr, jaxpr_text)
+      for substr in not_in_jaxpr2:
+        self.assertNotIn(substr, jaxpr_text)
+      y_expected, ydot_expected = api.jvp(lambda x: jnp.sin(square(jnp.sin(x))),
+                                          [1.], [2.])
+      self.assertAllClose(y, y_expected)
+      self.assertAllClose(ydot, ydot_expected)
+      jtu.check_grads(f, (3.,), order=2, modes=['fwd', 'rev'])
+
+  def test_remat_custom_policy_save_cos(self):
+    save_cos = lambda prim, *_, **__: str(prim) == 'cos'
+    f = api.remat(lambda x: jnp.sin(jnp.sin(x)),  # different function
+                  saveable_policy=save_cos)
+    _, f_lin = api.linearize(f, 1.)
+    jaxpr_text = str(f_lin.func.args[0])
+    self.assertNotIn(' sin ', jaxpr_text)
+    self.assertNotIn(' cos ', jaxpr_text)
+    jtu.check_grads(f, (3.,), order=2, modes=['fwd', 'rev'])
+
+  def test_remat_checkpoint_dots(self):
+    checkpoint_dots = lambda prim, *_, **__: str(prim) == 'dot_general'
+
+    @partial(api.remat, saveable_policy=checkpoint_dots)
+    def f(x):
+      x = jnp.dot(x, x)
+      x = jnp.sin(x)
+      x = jnp.dot(x, x)
+      x = jnp.sin(x)
+      x = jnp.dot(x, x)
+      x = jnp.sin(x)
+      return x
+
+    _, f_lin = api.linearize(f, jnp.ones((2, 2)))
+    jaxpr_text = str(f_lin.func.args[0])
+    self.assertEqual(jaxpr_text.count(' sin '), 2)
+    self.assertEqual(jaxpr_text.count(' dot_'), 6)
+    jtu.check_grads(f, (jnp.ones((2, 2)),), order=2, modes=['fwd', 'rev'])
+
+  def test_remat_checkpoint_dots_inside_scan(self):
+    checkpoint_dots = lambda prim, *_, **__: str(prim) == 'dot_general'
+
+    x = jnp.ones((5,))
+
+    def f(W):
+      @partial(api.remat, saveable_policy=checkpoint_dots)
+      def f(x):
+        x = jnp.sin(jnp.dot(x, W))
+        x = jnp.sin(jnp.dot(x, W))
+        x = jnp.sin(jnp.dot(x, W))
+        return x
+
+      def body(x, _): return f(x), None
+      return lax.scan(body, x, None, length=2)[0]
+
+    _, f_vjp = api.vjp(f, jnp.ones((5, 5)))
+    jaxpr_text = str(f_vjp.args[0].func.args[1])
+
+    # Two sine calls in the backward pass because while we don't save sines
+    # within the (rematted) body function, we can save the scan carry, which
+    # effectively saves one sine. Three cosines for the Jacoian coefficients.
+    self.assertEqual(jaxpr_text.count(' sin '), 2)
+    self.assertEqual(jaxpr_text.count(' cos '), 3)
+    # Six calls to dot_general in the backward pass because we save the primal
+    # matmuls and only compure the backward pass ones (two for each primal one).
+    self.assertEqual(jaxpr_text.count(' dot_'), 6)
+
+    jtu.check_grads(api.jit(f), (jnp.ones((5, 5)),), order=2,
+                    modes=['fwd', 'rev'])
+
+  def test_remat_custom_jvp_policy(self):
+    save_sin = lambda prim, *_, **__: str(prim) == 'sin'
+
+    @api.custom_jvp
+    def sin(x):
+      return jnp.sin(x)
+    def sin_jvp(primals, tangents):
+      x, = primals
+      g, = tangents
+      return sin(x), jnp.cos(x) * g
+    sin.defjvp(sin_jvp)
+
+    @partial(api.remat, saveable_policy=save_sin)
+    def f(x):
+      return sin(sin(x))
+
+    jtu.check_grads(f, (3.,), order=2, modes=['fwd', 'rev'])
+
+    def g(x):
+      return lax.scan(lambda x, _: (f(x), None), x, None, length=2)[0]
+    jtu.check_grads(g, (3.,), order=2, modes=['fwd', 'rev'])
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This PR is the real implementation of the Autodidax prototype in #7517. It actually stayed quite close to the prototype!

See the PR message for #7517 for a draft design doc. We'll add that to the design notes in a follow-up PR.

This more general remat code effectively sets up a parallel implementation for standard remat (corresponding to a policy of `lambda *_, **__: False)`). We can delete the previous implementation, but for simplicity we'll leave that to a follow-up PR.

The DCE implementation here is only applied to jaxprs formed via partial evaluation, i.e. those which are formed by AD and assumed to be effect-free. For that reason we can punt on thinking about effects for now. (If/when we apply it to computations we lower to XLA, [for the purpose of pruning inputs](https://github.com/google/jax/blob/9b62fd80d0e6068c0bf05d8fbb184f507b51a087/jax/interpreters/xla.py#L813), we shouldn't prune effectful primitive applications, cc @zhangqiaorjc.)

The remat implementation also pretends effectful primitives don't exist (like a lot of JAX does...).

Some last things to do:
- [x] deflake
- [ ] maybe delete the old DCE implementation and just use the new one (could leave this for follow-up)