### PR TITLE
[jax2tf] Update conversion of scatter for shape polymorphism

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2519,8 +2519,6 @@ def _scatter(operand, scatter_indices, updates, *, update_jaxpr, update_consts,
       xla_update_computation,
       proto,
       indices_are_sorted=indices_are_sorted)
-  # TODO: implement shape analysis for XlaScatter
-  out.set_shape(_aval_to_tf_shape(_out_aval))
   return out
 
 


### PR DESCRIPTION
It turns out that the XlaScatter inference rule is enough, we
don't need the `.set_shape` workaround.