### PR TITLE
Fix logsumexp issue with debug_nans and disable_jit

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -120,8 +120,8 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     out = lax.add(lax.log(jnp.sum(lax.exp(lax.sub(a, amax_with_dims)),
                                   axis=dims, keepdims=keepdims)),
                   amax)
-    sign = jnp.where(jnp.isnan(out), np.nan, 1.0).astype(out.dtype)
-    sign = jnp.where(jnp.isneginf(out), 0.0, sign)
+    sign = jnp.where(jnp.isnan(out), out, 1.0)
+    sign = jnp.where(jnp.isneginf(out), 0.0, sign).astype(out.dtype)
   else:
     expsub = lax.exp(lax.sub(a, amax_with_dims))
     if b is not None:

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -214,6 +214,13 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(osp_special.logsumexp, lsp_special.logsumexp, args_maker)
       self._CompileAndCheck(lsp_special.logsumexp, args_maker)
 
+  def testLogSumExpNans(self):
+    # Regression test for https://github.com/google/jax/issues/7634
+    with jax.debug_nans(True):
+      with jax.disable_jit():
+        result = lsp_special.logsumexp(1.0)
+    self.assertEqual(result, 1.0)
+
   @parameterized.named_parameters(itertools.chain.from_iterable(
     jtu.cases_from_list(
         {"testcase_name": jtu.format_test_name_suffix(


### PR DESCRIPTION
Fixes #7634

This is a subtle bug that only comes up with both `debug_nans` and `disable_jit`. The implementation of `logsumexp` uses `np.nan` explicitly. With the default `disable_jit=False`, this is passed directly to a jit-compiled `jnp.where`, and so the value is immediately converted to a tracer at the JIT boundary, which does not trigger a NaN error. But if you set `disable_jit=True`, the NaN constant is passed into the eagerly-evaluated `jnp.where` code, where it does trigger a NaN error.

The workaround is to use the NaN values from `out` itself, which avoids the need to explicitly instantiate new NaN values that trigger the error in this case.