### PR TITLE
custom_vjp: automatically handle float0 cotangents

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -2076,9 +2076,3 @@ def pp_kv_pairs(kv_pairs):
     return pp('[ ') >> vcat([pp_kv_pair(k, v) for k, v in kv_pairs]) >> pp(' ]')
   else:
     return pp('')
-
-# Casting float0 array to a float-valued zero array.
-def zeros_like_float0(array, dtype=None):
-  if not dtype:
-    dtype = np.float
-  return np.zeros(array.shape, dtype)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -150,7 +150,7 @@ def unpair_pval(pval):
 
 def replace_float0s(primal, tangent):
   if dtype(tangent) is float0:
-    return core.zeros_like_float0(tangent, dtype(primal))
+    return zeros_like_jaxval(primal)
   else:
     return tangent
 

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -19,7 +19,8 @@ import jax
 from ..config import config
 from .. import core
 from ..core import raise_to_shaped, Trace, Tracer
-from jax._src.ad_util import add_jaxvals, add_jaxvals_p, zeros_like_jaxval, zeros_like_p
+from jax._src.ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval,
+                              zeros_like_p, Zero)
 from .. import linear_util as lu
 from .._src.util import (unzip2, partial, safe_map, safe_zip, wrap_name, split_list,
                          canonicalize_axis, moveaxis, as_hashable_function, curry)
@@ -275,8 +276,23 @@ def batch_custom_vjp_bwd(bwd, axis_name, axis_size, in_dims, out_dim_dests, main
 def _match_axes_and_sum(axis_size, out_dims_thunk, out_dim_dests, *in_vals):
   # this is like _match_axes, but we do reduce-sums as needed
   out_vals = yield in_vals, {}
-  yield map(partial(matchaxis, axis_size, sum_match=True),
+  yield map(partial(_matchaxis_symbolic_zeros, axis_size, sum_match=True),
             out_dims_thunk(), out_dim_dests, out_vals)
+
+def _matchaxis_symbolic_zeros(sz, src, dst, x, sum_match=False):
+  # Just like `matchaxis`, but handles symbolic zeros using ad_util.py
+  if isinstance(x, Zero):
+    if src == dst:
+      return x
+    elif type(src) == type(dst) == int:
+      aval = core.mapped_aval(sz, src, x.aval)
+      return Zero(core.unmapped_aval(sz, dst, aval))
+    elif src is not_mapped and dst is not not_mapped:
+      return Zero(core.unmapped_aval(sz, dst, x.aval))
+    else:
+      raise ValueError((x, src, dst))
+  else:
+    return matchaxis(sz, src, dst, x, sum_match=sum_match)
 
 ### API
 
@@ -437,8 +453,7 @@ def matchaxis(sz, src, dst, x, sum_match=False):
   elif type(src) == type(dst) == int:
     return moveaxis(x, src, dst)
   elif src is not_mapped and dst is not not_mapped:
-    return broadcast(
-      x, sz, canonicalize_axis(dst, np.ndim(x) + 1))
+    return broadcast(x, sz, canonicalize_axis(dst, np.ndim(x) + 1))
   elif dst is None and sum_match:
     return x.sum(src)
   else:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5351,6 +5351,21 @@ class CustomVJPTest(jtu.JaxTestCase):
     self.assertAllClose(g_c, 42. * c, check_dtypes=False)
     self.assertAllClose(g_x, 17. * x, check_dtypes=False)
 
+  def test_float0_cotangents_automatically_handled(self):
+    @jax.custom_vjp
+    def f(x, y):
+      return x
+
+    def f_fwd(x, y):
+      return x, None
+
+    def f_bwd(_, zbar):
+      return (0., 1)
+
+    f.defvjp(f_fwd, f_bwd)
+
+    jax.jit(lambda x: jax.vjp(f, 0., x)[1](1.))(1)  # doesn't crash
+
 
 class CustomTransposeTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
The main issue here was that when a custom_vjp function took a primal input with integer dtype, we would demand (via an internal assertion) that the user's bwd function would produce a value with float0 dtype (i.e. the tangent type corresponding to an integer primal). But users don't know about float0s, and shouldn't have to learn about them! So instead we just automatically handle producing zeros here (with the right dtype).

Also misc cleanups (I'll mark them below in review comments).