### PR TITLE
custom_vjp: use more symbolic zeros

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -242,6 +242,7 @@ def _flatten_jvp(in_tree, *args):
     msg = ("Custom JVP rule must produce primal and tangent outputs with equal "
            "container (pytree) structures, but got {} and {} respectively.")
     raise TypeError(msg.format(out_tree, out_tree2))
+  # TODO(mattjj): compare primals' tangent types to tangent objects' types
   primal_avals_out = [
       raise_to_shaped(core.get_aval(x), weak_type=False).strip_named_shape()
       for x in primals_out]
@@ -555,7 +556,8 @@ def _flatten_bwd(in_tree, in_avals, out_trees, *args):
     raise TypeError(msg.format(in_tree2, in_tree)) from None
   # Ignore any None cotangents, and any corresponding to inputs for which the
   # type doesn't equal the tangent type (i.e. float0s)
-  yield [zeros_like_aval(a.at_least_vspace()) if ct is zero or a != a.at_least_vspace()
+  # TODO(mattjj): change this to check if tangent type represents 0dim vspace
+  yield [Zero(a.at_least_vspace()) if ct is zero or a != a.at_least_vspace()
          else ct for a, ct in zip(in_avals, cts_in_flat)]
 
 

--- a/jax/core.py
+++ b/jax/core.py
@@ -2076,9 +2076,3 @@ def pp_kv_pairs(kv_pairs):
     return pp('[ ') >> vcat([pp_kv_pair(k, v) for k, v in kv_pairs]) >> pp(' ]')
   else:
     return pp('')
-
-# Casting float0 array to a float-valued zero array.
-def zeros_like_float0(array, dtype=None):
-  if not dtype:
-    dtype = np.float
-  return np.zeros(array.shape, dtype)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -150,7 +150,7 @@ def unpair_pval(pval):
 
 def replace_float0s(primal, tangent):
   if dtype(tangent) is float0:
-    return core.zeros_like_float0(tangent, dtype(primal))
+    return zeros_like_jaxval(primal)
   else:
     return tangent
 


### PR DESCRIPTION
This is the second part of #7651. See that PR for comments on each change.

The main change here is to use symbolic zeros, rather than actually creating zeros arrays, in a new place. Otherwise there are minor tweaks.