### PR TITLE
Specify weak_type in DeviceArray repr

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -83,3 +83,7 @@ JAX Glossary of Terms
       Short for *Accelerated Linear Algebra*, XLA is a domain-specific compiler for linear
       algebra operations that is the primary backend for :term:`JIT`-compiled JAX code.
       See https://www.tensorflow.org/xla/.
+
+    weak type
+      A JAX data type that has the same type promotion semantics as Python scalars;
+      see :ref:`weak-types`.

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -37,9 +37,11 @@ where, for example:
 * ``bf`` means :code:`np.bfloat16`,
 * ``f2`` means :code:`np.float16`,
 * ``c8`` means :code:`np.complex128`,
-* ``i*`` means Python :code:`int`,
-* ``f*`` means Python :code:`float`, and
-* ``c*`` means Python :code:`complex`.
+* ``i*`` means Python :code:`int` or weakly-typed :code:`int`,
+* ``f*`` means Python :code:`float` or weakly-typed :code:`float`, and
+* ``c*`` means Python :code:`complex` or weakly-typed :code:`complex`.
+
+(for more about weak types, see :ref:`weak-types` below).
 
 Promotion between any two types is given by their `join <https://en.wikipedia.org/wiki/Join_and_meet>`_
 on this lattice, which generates the following binary promotion table:
@@ -130,7 +132,7 @@ Jax's type promotion rules differ from those of NumPy, as given by
 :func:`numpy.promote_types`, in those cells highlighted with a green background
 in the table above. There are three key differences:
 
-* When promoting a Python scalar value against a typed JAX value of the same category,
+* When promoting a weakly typed value against a typed JAX value of the same category,
   JAX always prefers the precision of the JAX value. For example, ``jnp.int16(1) + 1``
   will return ``int16`` rather than promoting to ``int64`` as in NumPy.
   Note that this applies only to Python scalar values; if the constant is a NumPy
@@ -159,10 +161,52 @@ accelerator devices and are less aggressive about promoting floating point
 types. The promotion rules used by JAX for floating-point types are similar to
 those used by PyTorch.
 
-Note that operators like `+` will dispatch based on the Python type of the two
-values being added. This means that, for example, ``np.int16(1) + 1`` will
+Effects of Python operator dispatch
+-----------------------------------
+Keep in mind that Python operators like `+` will dispatch based on the Python type of
+the two values being added. This means that, for example, ``np.int16(1) + 1`` will
 promote using NumPy rules, whereas ``jnp.int16(1) + 1`` will promote using JAX rules.
 This can lead to potentially confusing non-associative promotion semantics when
 the two types of promotion are combined;
 for example with ``np.int16(1) + 1 + jnp.int16(1)``.
 
+.. _weak-types:
+
+Weakly-typed values in JAX
+--------------------------
+*Weakly-typed* values in JAX can in most cases be thought of as equivalent to
+Python scalars, such as the integer scalar ``2`` in the following:
+
+.. code-block:: python
+
+   >>> x = jnp.arange(5, dtype='int8')
+   >>> 2 * x
+   DeviceArray([0, 2, 4, 6, 8], dtype=int8)
+
+JAX's weak type framework is designed to prevent unwanted type promotion within
+binary operations between JAX values and values with no explicitly user-specified type,
+such as Python scalar literals. For example, if ``2`` were not treated as weakly-typed,
+the expression above would lead to an implicit type promotion:
+
+.. code-block:: python
+
+   >>> jnp.int32(2) * x
+   DeviceArray([0, 2, 4, 6, 8], dtype=int32)
+
+When used in JAX, Python scalars are sometimes promoted to :class:`~jax.numpy.DeviceArray`
+objects, for example during JIT compilation. To maintain the desired promotion
+semantics in this case, :class:`~jax.numpy.DeviceArray` objects carry a ``weak_type`` flag
+that can be seen in an array's string representation:
+
+.. code-block:: python
+
+   >>> jnp.asarray(2)
+   DeviceArray(2, dtype=int32, weak_type=True)
+
+If the ``dtype`` is specified explicitly, it will instead result in a standard
+strongly-typed array value:
+
+.. code-block:: python
+
+   >>> jnp.asarray(2, dtype='int32')
+   DeviceArray(2, dtype=int32)

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1249,7 +1249,7 @@ def vmap(fun: F, in_axes=0, out_axes=0, axis_name=None) -> F:
   broadcast across the mapped axis:
 
   >>> print(vmap(lambda x, y: (x + y, y * 2.), in_axes=(0, None), out_axes=0)(jnp.arange(2.), 4.))
-  (DeviceArray([4., 5.], dtype=float32), DeviceArray([8., 8.], dtype=float32))
+  (DeviceArray([4., 5.], dtype=float32), DeviceArray([8., 8.], dtype=float32, weak_type=True))
 
   If the ``out_axes`` is specified for a mapped result, the result is transposed
   accordingly.
@@ -1999,7 +1999,7 @@ def linearize(fun: Callable, *primals) -> Tuple[Any, Callable]:
   >>> def f(x): return 3. * jnp.sin(x) + jnp.cos(x / 2.)
   ...
   >>> jax.jvp(f, (2.,), (3.,))
-  (DeviceArray(3.26819, dtype=float32), DeviceArray(-5.00753, dtype=float32))
+  (DeviceArray(3.26819, dtype=float32, weak_type=True), DeviceArray(-5.00753, dtype=float32, weak_type=True))
   >>> y, f_jvp = jax.linearize(f, 2.)
   >>> print(y)
   3.2681944

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -914,13 +914,13 @@ def linear_call(fun: Callable, fun_transpose: Callable, residual_args,
   ...   return transposed
 
   >>> div_add(9., 3.)
-  DeviceArray(12., dtype=float32)
+  DeviceArray(12., dtype=float32, weak_type=True)
 
   >>> transpose(partial(div_add, denom=3.), 1.)(18.)  # custom
-  DeviceArray(24., dtype=float32)
+  DeviceArray(24., dtype=float32, weak_type=True)
 
   >>> transpose(lambda x: x + x / 3., 1.)(18.)  # reference
-  DeviceArray(24., dtype=float32)
+  DeviceArray(24., dtype=float32, weak_type=True)
 
   The above definition of ``f`` illustrates the purpose of a residual
   argument: division is linear in one of its inputs (the dividend

--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -423,7 +423,7 @@ class TracerIntegerConversionError(JAXTypeError):
       ...   return L[i]
 
       >>> func(0)
-      DeviceArray(1, dtype=int32)
+      DeviceArray(1, dtype=int32, weak_type=True)
 
   To understand more subtleties having to do with tracers vs. regular values,
   and concrete vs. abstract values, you may want to read
@@ -463,12 +463,12 @@ class UnexpectedTracerError(JAXTypeError):
       >>> outs = []
       >>> @jit                   # 1
       ... def side_effecting(x):
-      ...   y = x+1              # 3
+      ...   y = x + 1            # 3
       ...   outs.append(y)       # 4
 
       >>> x = 1
       >>> side_effecting(x)      # 2
-      >>> outs[0]+1              # 5  # doctest: +IGNORE_EXCEPTION_DETAIL
+      >>> outs[0] + 1            # 5  # doctest: +IGNORE_EXCEPTION_DETAIL
       Traceback (most recent call last):
           ...
       UnexpectedTracerError: Encountered an unexpected tracer.
@@ -520,8 +520,8 @@ class UnexpectedTracerError(JAXTypeError):
       >>> x = 1
       >>> y = not_side_effecting(x)
       >>> outs.append(y)
-      >>> outs[0]+1  # all good! no longer a leaked value.
-      DeviceArray(3, dtype=int32)
+      >>> outs[0] + 1  # all good! no longer a leaked value.
+      DeviceArray(3, dtype=int32, weak_type=True)
 
   Leak checker
     As discussed in point 2 and 3 above, JAX shows a reconstructed stack trace

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -278,7 +278,7 @@ class Partial(functools.partial):
   >>> import jax.numpy as jnp
   >>> add_one = Partial(jnp.add, 1)
   >>> add_one(2)
-  DeviceArray(3, dtype=int32)
+  DeviceArray(3, dtype=int32, weak_type=True)
 
   Pytree compatibility means that the resulting partial function can be passed
   as an argument within transformed JAX functions, which is not possible with a
@@ -290,13 +290,13 @@ class Partial(functools.partial):
   ...   return f(*args)
   ...
   >>> call_func(add_one, 2)
-  DeviceArray(3, dtype=int32)
+  DeviceArray(3, dtype=int32, weak_type=True)
 
   Passing zero arguments to ``Partial`` effectively wraps the original function,
   making it a valid argument in JAX transformed functions:
 
   >>> call_func(Partial(jnp.add), 1, 2)
-  DeviceArray(3, dtype=int32)
+  DeviceArray(3, dtype=int32, weak_type=True)
 
   Had we passed ``jnp.add`` to ``call_func`` directly, it would have resulted in a
   ``TypeError``.

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1244,7 +1244,10 @@ for device_array in [DeviceArray]:
     prefix = '{}('.format(self.__class__.__name__.lstrip('_'))
     s = np.array2string(self._value, prefix=prefix, suffix=',',
                         separator=', ', max_line_width=line_width)
-    dtype_str = 'dtype={})'.format(self.dtype.name)
+    if self.aval.weak_type:
+      dtype_str = f'dtype={self.dtype.name}, weak_type=True)'
+    else:
+      dtype_str = f'dtype={self.dtype.name})'
     last_line_len = len(s) - s.rfind('\n') + 1
     sep = ' '
     if last_line_len + len(dtype_str) + 1 > line_width:

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -358,5 +358,21 @@ class TestPromotionTables(jtu.JaxTestCase):
     assert x.dtype == y.dtype
     assert dtypes.is_weakly_typed(y) == dtypes.is_weakly_typed(x)
 
+  @parameterized.named_parameters(
+    {"testcase_name": "_dtype={}_weak_type={}".format(dtype, weak_type),
+     "dtype": dtype, "weak_type": weak_type}
+    for dtype in all_dtypes
+    for weak_type in [True, False]
+  )
+  def testDeviceArrayRepr(self, dtype, weak_type):
+    val = lax._convert_element_type(0, dtype, weak_type=weak_type)
+    rep = repr(val)
+    self.assertStartsWith(rep, 'DeviceArray(')
+    if weak_type:
+      self.assertEndsWith(rep, f"dtype={val.dtype.name}, weak_type=True)")
+    else:
+      self.assertEndsWith(rep, f"dtype={val.dtype.name})")
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
JAX arrays that are weakly typed have different promotion semantics than regular strongly-typed arrays, but this difference is not currently visible in the array repr.  This PR adds weak type information to the `repr` of `DeviceArray` objects. For example:
```python
>>> import jax.numpy as jnp

>>> jnp.array(1)
DeviceArray(1, dtype=int32, weak_type=True)

>>>  jnp.array(1, dtype='int32')
DeviceArray(1, dtype=int32)
```
Other options for weak type reprs would be something more compact like:

- `DeviceArray(1, dtype=int32*)`
- `DeviceArray(1, dtype=int32[weak])`
- `DeviceArray(1, dtype=weak_int32)`

I think the longer one (`weak_type=True`) might be easier to search the docs for.