### PR TITLE
cleanup: remove some unnecessary test boilerplate

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -39,8 +39,8 @@ FLAGS = config.FLAGS
 T = lambda x: np.swapaxes(x, -1, -2)
 
 
-float_types = [np.float32, np.float64]
-complex_types = [np.complex64, np.complex128]
+float_types = jtu.dtypes.floating
+complex_types = jtu.dtypes.complex
 
 
 class NumpyLinalgTest(jtu.JaxTestCase):
@@ -59,7 +59,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testCholesky(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     def args_maker():
       factor_shape = shape[:-1] + (2 * shape[-1],)
       a = rng(factor_shape, dtype)
@@ -87,7 +86,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testDet(self, n, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng((n, n), dtype)]
 
     self._CheckAgainstNumpy(np.linalg.det, jnp.linalg.det, args_maker, tol=1e-3)
@@ -108,7 +106,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testDetGrad(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     a = rng(shape, dtype)
     jtu.check_grads(jnp.linalg.det, (a,), 2, atol=1e-1, rtol=1e-1)
     # make sure there are no NaNs when a matrix is zero
@@ -152,7 +149,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types))
   def testTensorsolve(self, m, nq, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
 
     # According to numpy docs the shapes are as follows:
     # Coefficient tensor (a), of shape b.shape + Q.
@@ -186,7 +182,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testSlogdet(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
 
     self._CheckAgainstNumpy(np.linalg.slogdet, jnp.linalg.slogdet, args_maker,
@@ -203,7 +198,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSlogdetGrad(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     a = rng(shape, dtype)
     jtu.check_grads(jnp.linalg.slogdet, (a,), 2, atol=1e-1, rtol=1e-1)
 
@@ -235,7 +229,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   def testEig(self, shape, dtype, compute_left_eigenvectors,
               compute_right_eigenvectors):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     n = shape[-1]
     args_maker = lambda: [rng(shape, dtype)]
 
@@ -282,7 +275,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     # ordering of eigenvalues to change, which will trip up check_grads. So we
     # just test on small-ish matrices.
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     a, = args_maker()
     tol = 1e-4 if dtype in (np.float64, np.complex128) else 1e-1
@@ -300,7 +292,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("gpu", "tpu")
   def testEigvals(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     a, = args_maker()
     w1, _ = jnp.linalg.eig(a)
@@ -322,7 +313,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("gpu", "tpu")
   def testEigBatching(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     shape = (10,) + shape
     args = rng(shape, dtype)
     ws, vs = vmap(jnp.linalg.eig)(args)
@@ -335,10 +325,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
        "n": n, "dtype": dtype, "lower": lower}
       for n in [0, 4, 5, 50]
       for dtype in float_types + complex_types
-      for lower in [False, True]))
+      for lower in [True, False]))
   def testEigh(self, n, dtype, lower):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     tol = 1e-3
     args_maker = lambda: [rng((n, n), dtype)]
 
@@ -373,7 +362,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testEigvalsh(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     n = shape[-1]
     def args_maker():
       a = rng((n, n), dtype)
@@ -418,7 +406,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for eps in [1e-4]))
   def testEighGradVectorComplex(self, shape, dtype, lower, eps):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     # Special case to test for complex eigenvector grad correctness.
     # Exact eigenvector coordinate gradients are hard to test numerically for complex
     # eigensystem solvers given the extra degrees of per-eigenvector phase freedom.
@@ -463,7 +450,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testEighBatching(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     shape = (10,) + shape
     args = rng(shape, dtype)
     args = (args + np.conj(T(args))) / 2
@@ -478,7 +464,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1,), (4,), (5,)]
       for dtype in (np.int32,)))
   def testLuPivotsToPermutation(self, shape, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     pivots_size = shape[-1]
     permutation_size = 2 * pivots_size
 
@@ -496,7 +481,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1,), (4,), (5,)]
       for dtype in (np.int32,)))
   def testLuPivotsToPermutationBatching(self, shape, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     shape = (10,) + shape
     pivots_size = shape[-1]
     permutation_size = 2 * pivots_size
@@ -531,7 +515,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))  # type: ignore
   def testNorm(self, shape, dtype, ord, axis, keepdims):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     if (ord in ('nuc', 2, -2) and (
         jtu.device_under_test() != "cpu" or
         (isinstance(axis, tuple) and len(axis) == 2))):
@@ -561,7 +544,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
         jtu.device_under_test() == "tpu"):
       raise unittest.SkipTest("No complex SVD implementation")
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(b + (m, n), dtype)]
 
     # Norm, adjusted for dimension and type.
@@ -635,7 +617,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for full_matrices in [False, True]))
   def testQr(self, shape, dtype, full_matrices):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     m, n = shape[-2:]
 
     if full_matrices:
@@ -702,7 +683,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   @jtu.skip_on_devices("gpu")  # TODO(#2203): numerical errors
   def testCond(self, shape, pnorm, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     if (jnp.issubdtype(dtype, np.complexfloating) and
         jtu.device_under_test() == "tpu"):
       raise unittest.SkipTest("No complex SVD implementation")
@@ -736,7 +716,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for shape in [(1, 1), (4, 4), (200, 200), (7, 7, 7, 7)]
       for dtype in float_types))
   def testTensorinv(self, shape, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     rng = jtu.rand_default(self.rng())
 
     def tensor_maker():
@@ -773,7 +752,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testSolve(self, lhs_shape, rhs_shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(lhs_shape, dtype), rng(rhs_shape, dtype)]
 
     self._CheckAgainstNumpy(np.linalg.solve, jnp.linalg.solve, args_maker,
@@ -788,7 +766,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types))
   def testInv(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     if jtu.device_under_test() == "gpu" and shape == (200, 200):
       raise unittest.SkipTest("Test is flaky on GPU")
 
@@ -819,7 +796,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
         jtu.device_under_test() == "tpu"):
       raise unittest.SkipTest("No complex SVD implementation")
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
 
     self._CheckAgainstNumpy(np.linalg.pinv, jnp.linalg.pinv, args_maker,
@@ -853,7 +829,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")  # TODO(b/149870255): Bug in XLA:TPU?.
   def testMatrixPower(self, shape, dtype, n):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     tol = 1e-1 if jtu.device_under_test() == "tpu" else 1e-3
     self._CheckAgainstNumpy(partial(np.linalg.matrix_power, n=n),
@@ -873,7 +848,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
         jtu.device_under_test() == "tpu"):
       raise unittest.SkipTest("No complex SVD implementation")
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     a, = args_maker()
     self._CheckAgainstNumpy(np.linalg.matrix_rank, jnp.linalg.matrix_rank,
@@ -893,7 +867,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testMultiDot(self, shapes, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [[rng(shape, dtype) for shape in shapes]]
 
     np_fun = np.linalg.multi_dot
@@ -919,14 +892,13 @@ class NumpyLinalgTest(jtu.JaxTestCase):
           ((6, 6), (6, 1)),
           ((8, 6), (8, 4)),
       ]
-      for lowrank in [True, False]
+      for lowrank in [False, True]
       for rcond in [-1, None, 0.5]
       for dtype in float_types + complex_types))
   @jtu.skip_on_devices("tpu")  # SVD not implemented on TPU.
   @jtu.skip_on_devices("cpu", "gpu")  # TODO(jakevdp) Test fails numerically
   def testLstsq(self, lhs_shape, rhs_shape, dtype, lowrank, rcond):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     np_fun = partial(np.linalg.lstsq, rcond=rcond)
     jnp_fun = partial(jnp.linalg.lstsq, rcond=rcond)
     jnp_fun_numpy_resid = partial(jnp.linalg.lstsq, rcond=rcond, numpy_resid=True)
@@ -1012,7 +984,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testLu(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng(shape, dtype)]
     x, = args_maker()
     p, l, u = jsp.linalg.lu(x)
@@ -1036,7 +1007,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testLuGrad(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     a = rng(shape, dtype)
     lu = vmap(jsp.linalg.lu) if len(shape) > 2 else jsp.linalg.lu
     jtu.check_grads(lu, (a,), 2, atol=5e-2, rtol=3e-1)
@@ -1049,7 +1019,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in [jnp.float32]))
   def testLuBatching(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args = [rng(shape, jnp.float32) for _ in range(10)]
     expected = list(osp.linalg.lu(x) for x in args)
     ps = np.stack([out[0] for out in expected])
@@ -1074,7 +1043,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testLuFactor(self, n, dtype):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng((n, n), dtype)]
 
     x, = args_maker()
@@ -1105,7 +1073,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("cpu")  # TODO(frostig): Test fails on CPU sometimes
   def testLuSolve(self, lhs_shape, rhs_shape, dtype, trans):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     osp_fun = lambda lu, piv, rhs: osp.linalg.lu_solve((lu, piv), rhs, trans=trans)
     jsp_fun = lambda lu, piv, rhs: jsp.linalg.lu_solve((lu, piv), rhs, trans=trans)
 
@@ -1138,7 +1105,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testSolve(self, lhs_shape, rhs_shape, dtype, sym_pos, lower):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     osp_fun = lambda lhs, rhs: osp.linalg.solve(lhs, rhs, sym_pos=sym_pos, lower=lower)
     jsp_fun = lambda lhs, rhs: jsp.linalg.solve(lhs, rhs, sym_pos=sym_pos, lower=lower)
 
@@ -1172,7 +1138,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types))
   def testSolveTriangular(self, lower, transpose_a, unit_diagonal, lhs_shape,
                           rhs_shape, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     rng = jtu.rand_default(self.rng())
     k = rng(lhs_shape, dtype)
     l = np.linalg.cholesky(np.matmul(k, T(k))
@@ -1228,7 +1193,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   def testTriangularSolveGrad(
       self, lower, transpose_a, conjugate_a, unit_diagonal, left_side, a_shape,
       b_shape, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     rng = jtu.rand_default(self.rng())
     # Test lax.linalg.triangular_solve instead of scipy.linalg.solve_triangular
     # because it exposes more options.
@@ -1284,7 +1248,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testExpm(self, n, dtype):
     rng = jtu.rand_small(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     args_maker = lambda: [rng((n, n), dtype)]
 
     osp_fun = lambda a: osp.linalg.expm(a)
@@ -1327,7 +1290,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for lower in [True, False]))
   def testChoSolve(self, lhs_shape, rhs_shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     def args_maker():
       b = rng(rhs_shape, dtype)
       if lower:
@@ -1348,7 +1310,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       for dtype in float_types + complex_types))
   def testExpmFrechet(self, n, dtype):
     rng = jtu.rand_small(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     if dtype == np.float64 or dtype == np.complex128:
       target_norms = [1.0e-2, 2.0e-1, 9.0e-01, 2.0, 3.0]
       # TODO(zhangqiaorjc): Reduce tol to default 1e-15.
@@ -1389,7 +1350,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
      for dtype in float_types + complex_types))
   def testExpmGrad(self, n, dtype):
     rng = jtu.rand_small(self.rng())
-    jtu.skip_if_unsupported_type(dtype)
     a = rng((n, n), dtype)
     if dtype == np.float64 or dtype == np.complex128:
       target_norms = [1.0e-2, 2.0e-1, 9.0e-01, 2.0, 3.0]
@@ -1438,7 +1398,6 @@ class LaxLinalgTest(jtu.JaxTestCase):
      for n in [1, 2, 3, 7, 8, 100]
      for dtype in float_types + complex_types))
   def testToeplitz(self, n, dtype):
-    jtu.skip_if_unsupported_type(dtype)
     for a, b in [[2, -1], [1, 0], [0, 1], [-1e10, 1e10], [-1e-10, 1e-10]]:
       alpha = a * np.ones([n], dtype=dtype)
       beta = b * np.ones([n - 1], dtype=dtype)


### PR DESCRIPTION
Rather than explicitly skipping unsupported dtypes, this uses `jtu.dtypes` to avoid generating those test cases at all.