### PR TITLE
cleanup: remove redundant entry from test-requirements

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,10 +1,9 @@
 flake8
 flatbuffers==1.12
-numpy>=1.17
 mypy==0.902
 pillow>=8.3.1
 pytest-benchmark
 pytest-xdist
 wheel
-# Install jax from the current directory; minimum required jaxlib from pypi.
+# Install jax from the current directory with minimum jaxlib from pypi.
 .[minimum-jaxlib]


### PR DESCRIPTION
The required numpy version is already specified in `setup.py`: https://github.com/google/jax/blob/705d5ed59bb6877d4dd1d243b579108f4bc3cbe2/setup.py#L38-L42