### PR TITLE
Specify scipy in setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,10 @@ setup(
     package_data={'jax': ['py.typed']},
     python_requires='>=3.7',
     install_requires=[
-        'numpy>=1.18',
         'absl-py',
+        'numpy>=1.18',
         'opt_einsum',
+        'scipy>=1.2.1',
     ],
     extras_require={
         # Minimum jaxlib version; used in testing.


### PR DESCRIPTION
Why? `import jax` will fail if scipy is not installed. We have not hit this in our CI because `test-requirements.txt` includes `scikit-learn`, which itself depends on scipy.