### PR TITLE
inline jit-decorated jax.random calls

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -371,7 +371,7 @@ if cuda_prng:
       _threefry2x32_gpu_translation_rule
 
 
-@jit
+@partial(jit, inline=True)
 def threefry_2x32(keypair, count):
   """Apply the Threefry 2x32 hash.
 
@@ -408,7 +408,7 @@ def threefry_2x32(keypair, count):
 def threefry_split(key: jnp.ndarray, num: int) -> jnp.ndarray:
   return _threefry_split(key, int(num))  # type: ignore
 
-@partial(jit, static_argnums=(1,))
+@partial(jit, static_argnums=(1,), inline=True)
 def _threefry_split(key, num) -> jnp.ndarray:
   counts = lax.iota(np.uint32, num * 2)
   return lax.reshape(threefry_2x32(key, counts), (num, 2))
@@ -417,12 +417,12 @@ def _threefry_split(key, num) -> jnp.ndarray:
 def threefry_fold_in(key: jnp.ndarray, data: int) -> jnp.ndarray:
   return _threefry_fold_in(key, jnp.uint32(data))
 
-@jit
+@partial(jit, inline=True)
 def _threefry_fold_in(key, data):
   return threefry_2x32(key, threefry_seed(data))
 
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def threefry_random_bits(key: jnp.ndarray, bit_width, shape):
   """Sample uniform random bits of given width and shape using PRNG key."""
   if not _is_threefry_prng_key(key):

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -185,7 +185,7 @@ def uniform(key: KeyArray,
   shape = core.as_named_shape(shape)
   return _uniform(key, shape, dtype, minval, maxval)  # type: ignore
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _uniform(key, shape, dtype, minval, maxval) -> jnp.ndarray:
   _check_shape("uniform", shape)
   if not jnp.issubdtype(dtype, np.floating):
@@ -242,7 +242,7 @@ def randint(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _randint(key, shape, minval, maxval, dtype)
 
-@partial(jit, static_argnums=(1, 4))
+@partial(jit, static_argnums=(1, 4), inline=True)
 def _randint(key, shape, minval, maxval, dtype):
   _check_shape("randint", shape, np.shape(minval), np.shape(maxval))
   if not jnp.issubdtype(dtype, np.integer):
@@ -352,7 +352,7 @@ def permutation(key: KeyArray, x: Array) -> jnp.ndarray:
     return x[ind]
 
 
-@partial(jit, static_argnums=(2,))
+@partial(jit, static_argnums=(2,), inline=True)
 def _shuffle(key, x, axis) -> jnp.ndarray:
   # On parallel architectures, Fisher-Yates is more expensive than doing
   # multiple sorts. This algorithm is based on one developed and analyzed by
@@ -469,7 +469,7 @@ def normal(key: KeyArray,
   shape = core.as_named_shape(shape)
   return _normal(key, shape, dtype)  # type: ignore
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _normal(key, shape, dtype) -> jnp.ndarray:
   if dtypes.issubdtype(dtype, np.complexfloating):
     sqrt2 = np.array(np.sqrt(2), dtype)
@@ -482,7 +482,7 @@ def _normal(key, shape, dtype) -> jnp.ndarray:
   else:
     return _normal_real(key, shape, dtype) # type: ignore
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _normal_real(key, shape, dtype) -> jnp.ndarray:
   _check_shape("normal", shape)
   lo = np.nextafter(np.array(-1., dtype), np.array(0., dtype), dtype=dtype)
@@ -529,7 +529,7 @@ def multivariate_normal(key: KeyArray,
     shape = core.canonicalize_shape(shape)
   return _multivariate_normal(key, mean, cov, shape, dtype, method)  # type: ignore
 
-@partial(jit, static_argnums=(3, 4, 5))
+@partial(jit, static_argnums=(3, 4, 5), inline=True)
 def _multivariate_normal(key, mean, cov, shape, dtype, method) -> jnp.ndarray:
   if not np.ndim(mean) >= 1:
     msg = "multivariate_normal requires mean.ndim >= 1, got mean.ndim == {}"
@@ -594,7 +594,7 @@ def truncated_normal(key: KeyArray,
     shape = core.as_named_shape(shape)
   return _truncated_normal(key, lower, upper, shape, dtype)  # type: ignore
 
-@partial(jit, static_argnums=(3, 4))
+@partial(jit, static_argnums=(3, 4), inline=True)
 def _truncated_normal(key, lower, upper, shape, dtype) -> jnp.ndarray:
   if shape is None:
     shape = lax.broadcast_shapes(np.shape(lower), np.shape(upper))
@@ -645,7 +645,7 @@ def bernoulli(key: KeyArray,
   p = lax.convert_element_type(p, dtype)
   return _bernoulli(key, p, shape)  # type: ignore
 
-@partial(jit, static_argnums=(2,))
+@partial(jit, static_argnums=(2,), inline=True)
 def _bernoulli(key, p, shape) -> jnp.ndarray:
   if shape is None:
     # TODO: Use the named part of `p` as well
@@ -727,7 +727,7 @@ def cauchy(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _cauchy(key, shape, dtype)
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _cauchy(key, shape, dtype):
   _check_shape("cauchy", shape)
   u = uniform(key, shape, dtype, minval=jnp.finfo(dtype).eps, maxval=1.)
@@ -767,7 +767,7 @@ def dirichlet(key: KeyArray,
     shape = core.canonicalize_shape(shape)
   return _dirichlet(key, alpha, shape, dtype)
 
-@partial(jit, static_argnums=(2, 3))
+@partial(jit, static_argnums=(2, 3), inline=True)
 def _dirichlet(key, alpha, shape, dtype):
   if not np.ndim(alpha) >= 1:
     msg = "dirichlet requires alpha.ndim >= 1, got alpha.ndim == {}"
@@ -806,7 +806,7 @@ def exponential(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _exponential(key, shape, dtype)
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _exponential(key, shape, dtype):
   _check_shape("exponential", shape)
   u = uniform(key, shape, dtype)
@@ -954,7 +954,7 @@ def gamma_threefry2x32(key: jnp.ndarray,  # raw ndarray form of a 2x32 key
     shape = core.canonicalize_shape(shape)
   return _gamma(key, a, shape, dtype)
 
-@partial(jit, static_argnums=(2, 3))
+@partial(jit, static_argnums=(2, 3), inline=True)
 def _gamma(key, a, shape, dtype):
   if shape is None:
     shape = np.shape(a)
@@ -967,7 +967,7 @@ def _gamma(key, a, shape, dtype):
   return random_gamma_p.bind(key, a)
 
 
-@partial(jit, static_argnums=(2, 3, 4))
+@partial(jit, static_argnums=(2, 3, 4), inline=True)
 def _poisson_knuth(key, lam, shape, dtype, max_iters):
   # Knuth's algorithm for generating Poisson random variates.
   # Reference:
@@ -990,7 +990,7 @@ def _poisson_knuth(key, lam, shape, dtype, max_iters):
   return (k - 1).astype(dtype)
 
 
-@partial(jit, static_argnums=(2, 3, 4))
+@partial(jit, static_argnums=(2, 3, 4), inline=True)
 def _poisson_rejection(key, lam, shape, dtype, max_iters):
   # Transformed rejection due to Hormann.
   # Reference:
@@ -1033,7 +1033,7 @@ def _poisson_rejection(key, lam, shape, dtype, max_iters):
   return k.astype(dtype)
 
 
-@partial(jit, static_argnums=(2, 3))
+@partial(jit, static_argnums=(2, 3), inline=True)
 def _poisson(key, lam, shape, dtype):
   # The implementation matches TensorFlow and NumPy:
   # https://github.com/tensorflow/tensorflow/blob/v2.2.0-rc3/tensorflow/core/kernels/random_poisson_op.cc
@@ -1106,7 +1106,7 @@ def gumbel(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _gumbel(key, shape, dtype)
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _gumbel(key, shape, dtype):
   _check_shape("gumbel", shape)
   return -jnp.log(-jnp.log(
@@ -1174,7 +1174,7 @@ def laplace(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _laplace(key, shape, dtype)
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _laplace(key, shape, dtype):
   _check_shape("laplace", shape)
   u = uniform(
@@ -1205,7 +1205,7 @@ def logistic(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _logistic(key, shape, dtype)
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _logistic(key, shape, dtype):
   _check_shape("logistic", shape)
   x = uniform(key, shape, dtype, minval=jnp.finfo(dtype).eps, maxval=1.)
@@ -1241,7 +1241,7 @@ def pareto(key: KeyArray,
     shape = core.canonicalize_shape(shape)
   return _pareto(key, b, shape, dtype)
 
-@partial(jit, static_argnums=(2, 3))
+@partial(jit, static_argnums=(2, 3), inline=True)
 def _pareto(key, b, shape, dtype):
   if shape is None:
     shape = np.shape(b)
@@ -1281,7 +1281,7 @@ def t(key: KeyArray,
   shape = core.canonicalize_shape(shape)
   return _t(key, df, shape, dtype)
 
-@partial(jit, static_argnums=(2, 3))
+@partial(jit, static_argnums=(2, 3), inline=True)
 def _t(key, df, shape, dtype):
   if shape is None:
     shape = np.shape(df)
@@ -1318,7 +1318,7 @@ def rademacher(key: KeyArray,
   return _rademacher(key, shape, dtype)
 
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _rademacher(key, shape, dtype):
   bernoulli_samples = bernoulli(key=key, p=0.5, shape=shape)
   return (2 * bernoulli_samples - 1).astype(dtype)
@@ -1351,7 +1351,7 @@ def maxwell(key: KeyArray,
   return _maxwell(key, shape, dtype)
 
 
-@partial(jit, static_argnums=(1, 2))
+@partial(jit, static_argnums=(1, 2), inline=True)
 def _maxwell(key, shape, dtype):
   shape = shape + (3,)
   norm_rvs = normal(key=key, shape=shape, dtype=dtype)
@@ -1388,7 +1388,7 @@ def double_sided_maxwell(key: KeyArray,
   return _double_sided_maxwell(key, loc, scale, shape, dtype)
 
 
-@partial(jit, static_argnums=(3, 4))
+@partial(jit, static_argnums=(3, 4), inline=True)
 def _double_sided_maxwell(key, loc, scale, shape, dtype):
   params_shapes = lax.broadcast_shapes(np.shape(loc), np.shape(scale))
   if not shape:
@@ -1433,7 +1433,7 @@ def weibull_min(key: KeyArray,
   return _weibull_min(key, scale, concentration, shape, dtype)
 
 
-@partial(jit, static_argnums=(3, 4))
+@partial(jit, static_argnums=(3, 4), inline=True)
 def _weibull_min(key, scale, concentration, shape, dtype):
   random_uniform = uniform(
       key=key, shape=shape, minval=0, maxval=1, dtype=dtype)


### PR DESCRIPTION
This makes for prettier jaxprs.

Example:

```python
from jax import random
from jax import lax
from jax import make_jaxpr, linearize

key = random.PRNGKey(0)

def body(carry, _):
  i, x = carry
  x = x * random.normal(random.fold_in(key, i), (10,))
  i = i + 1
  return (i, x), None

def f(x):
  return lax.scan(body, (0, x), None, length=2)[1]


x = random.normal(key, (10,))
print(make_jaxpr(lambda x: linearize(f, x)[1](x))(x))
```

### Before
![image](https://user-images.githubusercontent.com/1458824/130291584-70ad7c25-7777-4158-95ab-2359928cab14.png)

### After

```
{ lambda a ; b.
  let c = slice[ limit_indices=(1,)
                 start_indices=(0,)
                 strides=(1,) ] a
      d = squeeze[ dimensions=(0,) ] c
      e = slice[ limit_indices=(2,)
                 start_indices=(1,)
                 strides=(1,) ] a
      f = squeeze[ dimensions=(0,) ] e
      g = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(1,) ] -0.9999999403953552
      h = broadcast_in_dim[ broadcast_dimensions=(  )
                            shape=(1,) ] 1.0
      i = iota[ dimension=0
                dtype=uint32
                shape=(10,) ]
      j = slice[ limit_indices=(5,)
                 start_indices=(0,)
                 strides=None ] i
      k = slice[ limit_indices=(10,)
                 start_indices=(5,)
                 strides=None ] i
      l = sub h g
      _ _ _ _ =
        scan[ jaxpr={ lambda  ; f g h x y bg a b c d.
                      let e = add b 1
                          i = convert_element_type[ new_dtype=uint32
                                                    weak_type=False ] b
                          j = shift_right_logical i 32
                          k = reshape[ dimensions=None
                                       new_sizes=(1,) ] j
                          l = and i 4294967295
                          m = reshape[ dimensions=None
                                       new_sizes=(1,) ] l
                          n = concatenate[ dimension=0 ] k m
                          o = slice[ limit_indices=(1,)
                                     start_indices=(0,)
                                     strides=None ] n
                          p = slice[ limit_indices=(2,)
                                     start_indices=(1,)
                                     strides=None ] n
                          q r = threefry2x32 g h o p
                          s = concatenate[ dimension=0 ] q r
                          t = slice[ limit_indices=(1,)
                                     start_indices=(0,)
                                     strides=(1,) ] s
                          u = squeeze[ dimensions=(0,) ] t
                          v = slice[ limit_indices=(2,)
                                     start_indices=(1,)
                                     strides=(1,) ] s
                          w = squeeze[ dimensions=(0,) ] v
                          z ba = threefry2x32 u w x y
                          bb = concatenate[ dimension=0 ] z ba
                          bc = shift_right_logical bb 9
                          bd = or bc 1065353216
                          be = bitcast_convert_type[ new_dtype=float32 ] bd
                          bf = sub be 1.0
                          bh = mul bf bg
                          bi = add bh f
                          bj = max f bi
                          bk = erf_inv bj
                          bl = mul bk 1.4142135381698608
                          bm = mul c bl
                      in (e, bm, *, bl) }
              length=2
              linear=(False, False, False, False, False, False, True, False, False, True)
              num_carry=3
              num_consts=7
              reverse=False
              unroll=1 ] g d f j k l * 0 b *
  in () }
```

So much less indentation!