### PR TITLE
CI: bump mypy & flake8 versions to newest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@
 
 repos:
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.8.4'
+  rev: '3.9.2'
   hooks:
   - id: flake8
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.902'
+  rev: 'v0.910'
   hooks:
   - id: mypy
     files: jax/

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,6 +1,5 @@
 flake8
 flatbuffers==1.12
-mypy==0.902
 pillow>=8.3.1
 pytest-benchmark
 pytest-xdist


### PR DESCRIPTION
Also remove mypy from `test-requirements.txt` because we no longer call mypy directly (but use pre-commit hooks instead; see https://jax.readthedocs.io/en/latest/contributing.html#linting-and-type-checking)

Replaces #7684