### PR TITLE
import tree_util in the JAX namespace

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -119,6 +119,7 @@ from . import lax
 from . import nn
 from . import profiler
 from . import random
+from . import tree_util
 from . import util
 
 def _init():


### PR DESCRIPTION
Why? It is already implicitly imported:
```python
>>> import jax
>>> jax.tree_util
<module 'jax.tree_util' from '/Users/vanderplas/github/google/jax/jax/tree_util.py'>
```
But using it like this falls afoul of some linters/type checkers, because the name is not declared in the `jax` namespace.

I can think of no downside to including it in the namespace explicitly.