### PR TITLE
CI: remove flake8 from test requirements.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,4 +1,3 @@
-flake8
 flatbuffers==2.0
 pillow>=8.3.1
 pytest-benchmark


### PR DESCRIPTION
Why? since #5701, flake8 is invoked via the pre-commit framework, which doesn't reference this file. Instead, the requirement & version is specified here: https://github.com/google/jax/blob/7a40aa0114e46a7a8975e04b175dfbc7b0b388ef/.pre-commit-config.yaml#L11-L14