### PR TITLE
Make `input_shape` explicitly integer-typed in `_reduce_jvp`

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -5353,7 +5353,7 @@ def _reduction_computation(c, jaxpr, consts, init_values, singleton=True):
   return subc.build(out_nodes)
 
 def _reduce_jvp(reducer, init_values, primals, tangents, axes):
-  input_shape = np.array(primals[0].shape)
+  input_shape = np.array(primals[0].shape, dtype=np.int_)
 
   n = np.prod(input_shape[list(axes)])
   non_axes = np.delete(np.arange(len(input_shape)), axes)

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -643,6 +643,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       ]
       for dtype in dtypes
       for shape, dims in [
+          [(), ()],
           [(3, 4, 5), ()],
           [(3, 4, 5), (0,)],
           [(3, 4, 5), (1, 2)],


### PR DESCRIPTION
This is to avoid accidental float shapes when primal shape is `()`. Example where this fails: `grad(jnp.prod)(jnp.ones(()))`. Add a test.