### PR TITLE
Require array-like inputs for jnp.poly functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.20 (unreleased)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.19...main).
+* Breaking Changes
+  * `jnp.poly*` functions now require array-like inputs ({jax-issue}`#7732`)
+  * `jnp.unique` and other set-like operations now require array-like inputs
+    ({jax-issue}`#7662`)
 
 ## jax 0.2.19 (Aug 12, 2021)
 * [GitHub


### PR DESCRIPTION
These functions had previously been designed to recognize `np.poly1d` objects; in retrospect I think this was a mistake, because such objects are incompatible with JAX tracing/transformations.

This is a breaking change for users passing `list` or `poly1d` objects to these functions, but disallowing non-array inputs has been a goal for a while (cf. #3038) Part of #7737