### PR TITLE
Combine initial_style_batchers with collective_rules

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1263,6 +1263,8 @@ def vmap(fun: F, in_axes=0, out_axes=0, axis_name=None) -> F:
     docstr += "\n\nOriginal documentation:\n\n"
     docstr += fun.__doc__
 
+  axis_name = core.no_axis_name if axis_name is None else axis_name
+
   if isinstance(in_axes, list):
     # To be a tree prefix of the positional args tuple, in_axes can never be a
     # list: if in_axes is not a leaf, it must be a tuple of trees. However,
@@ -2460,7 +2462,7 @@ def device_put_replicated(x: Any, devices: Sequence[xc.Device]):
     raise ValueError("`devices` argument to `device_put_replicated must be "
                      "a non-empty sequence.")
   def _device_put_replicated(x):
-    aval = core.unmapped_aval(len(devices), None, 0,
+    aval = core.unmapped_aval(len(devices), core.no_axis_name, 0,
                               core.raise_to_shaped(core.get_aval(x)))
     assert isinstance(aval, core.ShapedArray) and aval._num_buffers == 1
     buf, = xla.device_put(x, devices[0])

--- a/jax/core.py
+++ b/jax/core.py
@@ -700,6 +700,8 @@ class Sublevel:
 AxisEnvFrame = namedtuple('AxisEnvFrame', ['name', 'size', 'main_trace'])
 AxisName = Hashable
 
+no_axis_name = object()
+
 class TraceState:
   trace_stack: TraceStack
   substack: List[Sublevel]
@@ -1810,7 +1812,7 @@ def subst_axis_names_jaxpr(jaxpr: Union[Jaxpr, ClosedJaxpr], subst: AxisSubst):
   if isinstance(jaxpr, ClosedJaxpr):
     consts = jaxpr.consts
     jaxpr = jaxpr.jaxpr
-  var_map: Dict[Var, Var] = {}
+  var_map: Dict[Var, Var] = {unitvar: unitvar}
   invars = [subst_axis_names_var(v, subst, var_map) for v in jaxpr.invars]
   constvars = [subst_axis_names_var(v, subst, var_map) for v in jaxpr.constvars]
   eqns = [subst_axis_names_eqn(eqn, subst, var_map) for eqn in jaxpr.eqns]

--- a/jax/experimental/djax.py
+++ b/jax/experimental/djax.py
@@ -988,7 +988,7 @@ def batch_jaxpr(jaxpr, axis_size, in_dims):
   dimvars = dict((v, v.aval) for v in jaxpr.in_dim_binders)
   in_avals = [_replace_vars_with_avals(dimvars, v.aval) for v in jaxpr.in_binders]
 
-  in_avals = [core.unmapped_aval(axis_size, None, d, aval)
+  in_avals = [core.unmapped_aval(axis_size, core.no_axis_name, d, aval)
               if d is not batching.not_mapped else aval
               for d, aval in zip(in_dims, in_avals)]
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1500,12 +1500,11 @@ def untile_aval_nd(axis_sizes, out_axes: ArrayMapping, aval):
 
 
 class SPMDBatchTrace(batching.BatchTrace):
-  def get_primitive_batcher(self, primitive):
+  def get_axis_primitive_batcher(self, primitive, frame):
     if primitive in spmd_primitive_batchers:
       return partial(spmd_primitive_batchers[primitive],
-                     axis_name=self.axis_name,
-                     main_type=self.main.trace_type)
-    return super().get_primitive_batcher(primitive)
+          frame.size, frame.name, frame.main_trace.trace_type)
+    return super().get_axis_primitive_batcher(primitive, frame)
 
 
 spmd_primitive_batchers: Dict[core.Primitive, Callable] = {}

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -354,6 +354,12 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = np.array([0, 2, 2, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+    ans = api.vmap(lambda _, x: fun(x), axis_name='i', in_axes=(0, None))(
+        np.array([0, 0, 0, 0]), 0)
+    expected = np.array([0, 2, 2, 4])
+    self.assertAllClose(ans, expected, check_dtypes=False)
+
+
   def testWhileLoopCondConstsBatched(self):
     def fun(x, y):
       return lax.while_loop(lambda x: x < y, lambda x: x + 2, x)

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -89,12 +89,12 @@ def powerset(s):
 
 ensure_bdim_p = core.Primitive('ensure_bdim')
 ensure_bdim_p.def_abstract_eval(lambda x, **kwargs: core.raise_to_shaped(x))
-def _ensure_bdim_batcher(frame, vals_in, dims_in, axis_name, bdim):
+def _ensure_bdim_batcher(axis_size, frame_name, main_type, vals_in, dims_in, axis_name, bdim):
   v, = vals_in
   d, = dims_in
   assert d is not batching.not_mapped
   return jnp.moveaxis(v, d, bdim), bdim
-batching.collective_rules[ensure_bdim_p] = _ensure_bdim_batcher
+batching.axis_primitive_batchers[ensure_bdim_p] = _ensure_bdim_batcher
 batching.primitive_batchers[ensure_bdim_p] = lambda v, d: (v[0], d[0])
 core.axis_substitution_rules[ensure_bdim_p] = partial(jax._src.lax.parallel._subst_all_names_in_param,
                                                       'axis_name')


### PR DESCRIPTION
Initial style primitives (control flow primitives, custom derivative primitives) currently do not work with collectives under certain conditions. Suppose we have an initial style primitive with a call to `axis_index` in it. At some point, the `vmap` transformation needs to turn that call into the actual index. When it's inside of an initial style primitive though, the `BatchTrace` can often miss the staged jaxpr entirely. In order for it to trigger, several things need to happen:

1. The initial style primitive takes batched tracers as inputs. This is the usual route by which JAX dispatches primitives to traces in `bind`. 
2. The primitive is an `AxisPrimitive`, leading to a special `bind`. `AxisPrimitive.bind` checks if the primitive uses an axis names and dispatches to the appropriate `BatchTrace`.

Since initial style primitives are generally *not* `AxisPrimitive`s, we only really have the 1st option. Unfortunately that means if we have an initial style primitive that doesn't take in a batched value but calls `axis_index`, the `BatchTrace` will miss it entirely, leading to errors when we hit the `impl` rule for `axis_index`. This leads to the issue found in #7047 for custom derivative primitives (and there is an analogous case for control flow primitives).

## Solution

We make all initial style primitives `AxisPrimitive`s. This will use the special `bind` that will dispatch to `BatchTrace` if the initial style primitive uses axis names in its body. 

Once we do this, the `BatchTrace` is triggered but we run into yet another issue. The `BatchTrace` short circuits to `primitive.bind` if it sees none of the inputs have batch dimensions (which is the case we're talking about). Before it does this, however, it checks to see if the primitive has a `collective_rule` (generally reserved for `psum`, `pmax`, etc.). It turns out that `initial_style_batchers` (the usual way of batching an initial style primitive) and `collective_rules` share a lot of similarities and since they essentially serve the same purpose, we unify them. All previously `initial_style_batcher`s rules will be converted into `collective_rules` since the code path for triggering an initial style batcher via `AxisPrimitive.bind` matches the path for the other collectives.

Also as suggested by @apaszke, we add a `no_axis_name` sentinel instead of `None`.

Fixes: #7047