### PR TITLE
ensure lax.transpose and lax.reshape always return DeviceArrays

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -796,7 +796,8 @@ def reshape(operand: Array, new_sizes: Shape,
   new_sizes = tuple(new_sizes)
   same_shape = core.symbolic_equal_shape(np.shape(operand), new_sizes)
   same_dims = dimensions is None or tuple(dimensions) == tuple(range(np.ndim(operand)))
-  if np.shape(operand) and same_shape and same_dims:
+  if (np.shape(operand) and same_shape and same_dims
+      and isinstance(operand, (core.Tracer, xla.DeviceArray))):
     return operand
   else:
     return reshape_p.bind(
@@ -1231,7 +1232,8 @@ def transpose(operand: Array, permutation: Sequence[int]) -> Array:
   operator.
   """
   permutation = tuple(permutation)
-  if permutation == tuple(range(np.ndim(operand))):
+  if (permutation == tuple(range(np.ndim(operand)))
+      and isinstance(operand, (core.Tracer, xla.DeviceArray))):
     return operand
   else:
     return transpose_p.bind(operand, permutation=permutation)


### PR DESCRIPTION
Currently, it is possible for `lax.transpose` and `lax.reshape` to return a non-DeviceArray when the operation is a no-op. For example:
```python
In [1]: from jax import lax

In [2]: import numpy as np

In [3]: type(lax.transpose(np.arange(10), (0,)))
Out[3]: numpy.ndarray

In [4]: lax.reshape(range(10), (10,))
Out[4]: range(0, 10)
```
This PR makes these behave as expected:
```python
In [1]: from jax import lax

In [2]: import numpy as np

In [3]: type(lax.transpose(np.arange(10), (0,)))
Out[3]: jaxlib.xla_extension.DeviceArray

In [4]: lax.reshape(range(10), (10,))
---------------------------------------------------------------------------
TypeError: Argument 'range(0, 10)' of type '<class 'range'>' is not a valid JAX type
```