### PR TITLE
README: mention that CUDA installation is for linux only

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,8 @@ install [CUDA](https://developer.nvidia.com/cuda-downloads) and
 [CuDNN](https://developer.nvidia.com/CUDNN),
 if they have not already been installed. Unlike some other popular deep
 learning systems, JAX does not bundle CUDA or CuDNN as part of the `pip`
-package. The CUDA 10 JAX wheels require CuDNN 7, whereas the CUDA 11 wheels of
+package. JAX provides pre-built CUDA-compatible wheels for **linux only**;
+the CUDA 10 JAX wheels require CuDNN 7, whereas the CUDA 11 wheels of
 JAX require CuDNN 8. Other combinations of CUDA and CuDNN are possible but
 require building from source.
 
@@ -428,7 +429,7 @@ Next, run
 
 ```bash
 pip install --upgrade pip
-pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install --upgrade "jax[cuda111]" -f https://storage.googleapis.com/jax-releases/jax_releases.html  # Note: wheels only available on linux.
 ```
 
 The jaxlib version must correspond to the version of the existing CUDA


### PR DESCRIPTION
Trying this on other operating systems causes pip to cycle through past JAX versions until it hits JAX 0.2.15 and then hit the error `Packages installed from PyPI cannot depend on packages which are not also hosted on PyPI.` from #7083.

I don't know of any way we can improve that error path, but at least we can document it.