### PR TITLE
Add unary xeinsum & allow named axis reductions for unary/binary xeinsums

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2826,8 +2826,7 @@ def einsum(*operands, out=None, optimize='optimal', precision=None,
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.einsum is not supported.")
 
-  if (_use_xeinsum or isinstance(operands[0], str) and '{' in operands[0] and
-      len(operands[1:]) == 2):
+  if (_use_xeinsum or isinstance(operands[0], str) and '{' in operands[0]):
     return lax.xeinsum(*operands)
 
   optimize = 'optimal' if optimize is True else optimize


### PR DESCRIPTION
The main functional change apart from accepting unary xeinsum is using psum on the named axes which should be reduced. There were some unimplemented/failing cases in binary xeinsums with only subscripts which I have added as tests. The axes to contract/reduce are computed slightly differently now.

In this change I have also extended to XeinsumSpecParser to be less restrictive so that it accepts named axes and subscripts in any order.

It still remains open to support diagonals and traces for unary xeinsums. ('ii->i' and 'ii->').