### PR TITLE
change while loop batching fixed point condition

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -470,17 +470,31 @@ def bdim_at_front(x, bdim, size):
     return moveaxis(x, bdim, 0)
 
 
+zero_if_mapped = object()
+
 def batch_jaxpr(closed_jaxpr, axis_size, in_batched, instantiate, axis_name, main_type):
+  if instantiate is None:
+    instantiate = False
+  if isinstance(instantiate, bool):
+    instantiate = [instantiate] * len(closed_jaxpr.out_avals)
+  out_axes = [0 if inst else zero_if_mapped for inst in instantiate]
+  return batch_jaxpr_axes(
+      closed_jaxpr, axis_size,
+      [0 if b else not_mapped for b in in_batched],
+      out_axes,
+      axis_name, main_type)
+
+def batch_jaxpr_axes(closed_jaxpr, axis_size, in_axes, out_axes, axis_name, main_type):
   f = lu.wrap_init(core.jaxpr_as_fun(closed_jaxpr))
-  f, out_batched = batch_subtrace_instantiate(f, instantiate, axis_size)
-  f = batchfun(f, axis_name, axis_size, [0 if b else None for b in in_batched], main_type)
-  avals_in = [core.unmapped_aval(axis_size, 0, aval) if b else aval
-              for aval, b in zip(closed_jaxpr.in_avals, in_batched)]
+  f, out_batched = batch_subtrace_instantiate(f, axis_size, out_axes)
+  f = batchfun(f, axis_name, axis_size, in_axes, main_type)
+  avals_in = [core.unmapped_aval(axis_size, b, aval) if b is not not_mapped
+              else aval for aval, b in zip(closed_jaxpr.in_avals, in_axes)]
   jaxpr_out, _, consts = pe.trace_to_jaxpr_dynamic(f, avals_in)
   return core.ClosedJaxpr(jaxpr_out, consts), out_batched()
 
 @lu.transformation_with_aux
-def batch_subtrace_instantiate(instantiate, axis_size, main, in_dims, *in_vals):
+def batch_subtrace_instantiate(axis_size, out_axes, main, in_dims, *in_vals):
   # this is like `batch_subtrace` but we take an extra `instantiate` arg
   # analogue of `jvp_subtrace` in ad.py
   trace = main.with_cur_sublevel()
@@ -490,13 +504,12 @@ def batch_subtrace_instantiate(instantiate, axis_size, main, in_dims, *in_vals):
   out_tracers = map(trace.full_raise, outs)
   out_vals, out_dims = unzip2((t.val, t.batch_dim) for t in out_tracers)
 
-  if type(instantiate) is bool:
-    instantiate = [instantiate] * len(out_vals)
-  out_vals = [moveaxis(x, d, 0) if d is not not_mapped and d != 0
-              else broadcast(x, axis_size, 0) if d is not_mapped and inst else x
-              for x, d, inst in zip(out_vals, out_dims, instantiate)]
-  out_batched = [d is not not_mapped or inst
-                 for d, inst in zip(out_dims, instantiate)]
+  out_axes = [(None if od is not_mapped else 0) if out_axis is zero_if_mapped else out_axis
+              for od, out_axis in zip(out_dims, out_axes)]
+  out_vals = [moveaxis(x, d, od) if d is not not_mapped
+              else broadcast(x, axis_size, od) if od is not None else x
+              for x, d, od in zip(out_vals, out_dims, out_axes)]
+  out_batched = [od is not None for od in out_axes]
   yield out_vals, out_batched
 
 @lu.transformation_with_aux


### PR DESCRIPTION
Adjust the while loop fixed point to address the error in #7063. 

Here's the relevant repro:
```python
import jax
from jax import lax
from jax.experimental import maps

def f(x):
  z = x + lax.axis_index('a')
  y = x + lax.axis_index('b')
  def cond(carry):
    i, x = carry
    return x < 5
  def body(carry):
    i, x = carry
    return i + 1, x + lax.psum(y, 'b')
  return lax.while_loop(cond, body, (0, z))[1]
maps.xmap(f, axis_sizes=dict(a=2, b=10), out_axes=(['a']), in_axes={})(1.)
```

The translation rule for while loop requires that the predicate shape is a prefix for the carry shapes (if predicate is scalar, this is trivially true). However, when predicate is *not* a scalar, we need to make sure that this is the case. Previously, if the predicate was not a scalar, we'd batch every value in the carry and batch the predicate. This would ensure that the predicate shape remains a prefix of the carry shape, satisfying the condition in the while loop. However, this overbatching can cause problems.

In the repro, the batching rule for `while` is triggered twice, once for axis `'a'` and once for axis `'b'`. The body has the `x` value in the carry, which mapped across `'a'`, and closes over `y` (which has a `'b`' axis). However, the input and output carry axes do not include `'b'`, because it is summed out with the `psum`.

With the current batching rule, for `'a'` we properly batch the body and cond of the while loop. In the batching rule for `'b'`, specifically in the fixed point, we instantiate the output for the cond_jaxpr because `bool(cond_jaxpr.avals.out_shape[0])` is `True` (this is because we have batched the cond for `'a'`). This causes us to map the entire `carry`, which adds an axis to the carry for `'b'` when none needs to exist.

What we'd instead like to do is not `instantiate` if the predicate is is non-scalar. We check the `pred_bat` produced by `batching.batch_jaxpr` (which tells us if the predicate is batched or not). If it is, we do need to batch everything and reproduce the `instantiate=True` behavior. If it is not, we need to make sure to have the batched predicate shape still be a prefix of the carry shapes. We accomplish this with some extra bookkeeping and modifications to `batching.batch_jaxpr` to allow us to thread axes in as opposed to bools indicating whether something is batched on the leading dimension.

Co-authored-by: Sharad Vikram <sharad.vikram@gmail.com>
Co-authored-by: Adam Paszke <apaszke@google.com>