### PR TITLE
Don't refer to deprecated jax.ops.index_update in error messages

### DIFF
--- a/docs/jax.ops.rst
+++ b/docs/jax.ops.rst
@@ -31,7 +31,8 @@ Alternate syntax           Equivalent in-place expression
 =========================  ===================================================
 
 None of these expressions modify the original `x`; instead they return
-a modified copy of `x`.
+a modified copy of `x`. However, inside a :py:func:`jit` compiled function,
+expressions like ``x = x.at[idx].set(y)`` are guaranteed to be applied inplace.
 
 
 Indexed update functions (deprecated)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5945,8 +5945,9 @@ def _swap_args(f):
 
 def _unimplemented_setitem(self, i, x):
   msg = ("'{}' object does not support item assignment. JAX arrays are "
-         "immutable; perhaps you want jax.ops.index_update or "
-         "jax.ops.index_add instead?")
+         "immutable. Instead of ``x[idx] = y``, use ``x = x.at[idx].set(y)`` "
+         "or another .at[] method: "
+         "https://jax.readthedocs.io/en/latest/jax.ops.html")
   raise TypeError(msg.format(type(self)))
 
 def _operator_round(number, ndigits=None):

--- a/jax/core.py
+++ b/jax/core.py
@@ -547,8 +547,8 @@ class Tracer:
   def __float__(self): return self.aval._float(self)
   def __complex__(self): return self.aval._complex(self)
 
-  def __setitem__(self, idx, val):
-    raise TypeError("JAX 'Tracer' objects do not support item assignment")
+  # raises the better error message from ShapedArray
+  def __setitem__(self, idx, val): return self.aval._setitem(self, idx, val)
 
   # NumPy also only looks up special methods on classes.
   def __array_module__(self, types): return self.aval._array_module(self, types)


### PR DESCRIPTION
This came up when a user asked about _how_ exactly they were supposed to use `jax.ops.index_update` :)

I've also updated the docs for ``jax.ops`` to note that ``at[].set()`` is guaranteed to be performed in-place under JIT. Someone who knows XLA well should double check that fact!