### PR TITLE
jnp.isclose/jnp.allclose: require array inputs

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1623,7 +1623,7 @@ def moveaxis(a, source: Union[int, Sequence[int]],
 
 @_wraps(np.isclose)
 def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-  a, b = _promote_args("isclose", asarray(a), asarray(b))
+  a, b = _promote_args("isclose", a, b)
   dtype = _dtype(a)
   if issubdtype(dtype, inexact):
     if issubdtype(dtype, complexfloating):
@@ -2423,6 +2423,7 @@ def ptp(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, out=None,
 
 @_wraps(np.allclose)
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+  _check_arraylike("allclose", a, b)
   return all(isclose(a, b, rtol, atol, equal_nan))
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3555,7 +3555,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testAllClose(self, x, y, equal_nan):
     jnp_fun = partial(jnp.allclose, equal_nan=equal_nan, rtol=1E-3)
     np_fun = partial(np.allclose, equal_nan=equal_nan, rtol=1E-3)
-    args_maker = lambda: [x, y]
+    args_maker = lambda: [np.array(x), np.array(y)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 


### PR DESCRIPTION
Part of #7737

TGP passes.