### PR TITLE
XLA translation rule for linear_call

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1056,3 +1056,4 @@ linear_call_p.multiple_results = True
 linear_call_p.def_impl(_linear_call_impl)
 linear_call_p.def_abstract_eval(_linear_call_abstract_eval)
 ad.primitive_transposes[linear_call_p] = _linear_call_transpose_rule
+xla.initial_style_translations[linear_call_p] = xla.lower_fun_initial_style(_linear_call_impl)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5753,6 +5753,20 @@ class CustomTransposeTest(jtu.JaxTestCase):
     self.assertAllClose(ftt(x),  x)
     self.assertAllClose(fttt(x), 7.)
 
+  def test_linear_call_jit(self):
+    def f(x, y):
+      def fn(r, x): return x / r
+      def tp(r, t): return t / r
+      return x + api.linear_call(fn, tp, y, x)
+
+    x = jnp.ones(2) * 6.
+    y = jnp.ones(2) * 3.
+    self.assertAllClose(f(x, y), jax.jit(f)(x, y))
+
+    f1 = lambda x: f(x, y)
+    self.assertAllClose(self.transpose(f1, x)(x),
+                        jax.jit(self.transpose(f1, x))(x))
+
 
 class InvertibleADTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
This adds the missing XLA translation rule for linear_call so that it can be jitted.
I'm not super familiar with this part of the jax source code, but I replicated what was done for `linear_solve_p`.

Example:
```python

import jax
from jax.custom_derivatives import linear_call 
from functools import partial

def f(r, x):
   return x / r

def t(r, t):
   return t / r

def div_add(x, denom):
   return x + linear_call(f, t, denom, x)

def transpose(f, x_example):
   def transposed(y):
     x, = jax.linear_transpose(f, x_example)(y)
     return x
   return transposed

print(jax.jit(div_add)(9., 3.))
print(jax.jit(transpose(partial(div_add, denom=3.), 1.))(18.))
```
```
12.0
24.0
```
which before was throwing `NotImplementedError: XLA translation rule for primitive 'linear_call' not found`)


This should allow to workaround https://github.com/google/jax/issues/6619, as suggested in the last bullet point in
https://github.com/google/jax/issues/6619#issuecomment-841504388.