### PR TITLE
Implement 'reflect' and 'mirror' modes for scipy.ndimage.map_coordinates

### DIFF
--- a/jax/_src/scipy/ndimage.py
+++ b/jax/_src/scipy/ndimage.py
@@ -30,10 +30,22 @@ from jax._src.util import safe_zip as zip
 _nonempty_prod = functools.partial(functools.reduce, operator.mul)
 _nonempty_sum = functools.partial(functools.reduce, operator.add)
 
+
+def _mirror_index_fixer(index, size):
+    s = size - 1 # Half-wavelength of triangular wave
+    # Scaled, integer-valued version of the triangular wave |x - round(x)|
+    return jnp.abs((index + s) % (2 * s) - s)
+
+
+def _reflect_index_fixer(index, size):
+    return jnp.floor_divide(_mirror_index_fixer(2*index+1, 2*size+1) - 1, 2)
+
 _INDEX_FIXERS = {
     'constant': lambda index, size: index,
     'nearest': lambda index, size: jnp.clip(index, 0, size - 1),
     'wrap': lambda index, size: index % size,
+    'mirror': _mirror_index_fixer,
+    'reflect': _reflect_index_fixer,
 }
 
 
@@ -112,7 +124,7 @@ def _map_coordinates(input, coordinates, order, mode, cval):
 
 @_wraps(scipy.ndimage.map_coordinates, lax_description=textwrap.dedent("""\
     Only nearest neighbor (``order=0``), linear interpolation (``order=1``) and
-    modes ``'constant'``, ``'nearest'`` and ``'wrap'`` are currently supported.
+    modes ``'constant'``, ``'nearest'``, ``'wrap'`` ``'mirror'`` and ``'reflect'`` are currently supported.
     Note that interpolation near boundaries differs from the scipy function,
     because we fixed an outstanding bug (https://github.com/scipy/scipy/issues/2640);
     this function interprets the ``mode`` argument as documented by SciPy, but

--- a/tests/scipy_ndimage_test.py
+++ b/tests/scipy_ndimage_test.py
@@ -74,7 +74,7 @@ class NdimageTest(jtu.JaxTestCase):
       for dtype in float_dtypes + int_dtypes
       for coords_dtype in float_dtypes
       for order in [0, 1]
-      for mode in ['wrap', 'constant', 'nearest']
+      for mode in ['wrap', 'constant', 'nearest', 'mirror', 'reflect']
       for cval in ([0, -1] if mode == 'constant' else [0])
       for impl, rng_factory in [
           ("original", partial(jtu.rand_uniform, low=0, high=1)),
@@ -111,7 +111,7 @@ class NdimageTest(jtu.JaxTestCase):
       lsp_ndimage.map_coordinates(x, c, order=2)
     with self.assertRaisesRegex(
         NotImplementedError, 'does not yet support mode'):
-      lsp_ndimage.map_coordinates(x, c, order=1, mode='reflect')
+      lsp_ndimage.map_coordinates(x, c, order=1, mode='grid-wrap')
     with self.assertRaisesRegex(ValueError, 'sequence of length'):
       lsp_ndimage.map_coordinates(x, [c, c], order=1)
 


### PR DESCRIPTION
This PR contains implementations for the `reflect` and `mirror` modes for `scipy.ndimage.map_coordinates`. Tests and docs are adapted accordingly.

The index_fixers are implemented in integer arithmetic to avoid any numerical issues, even though the float formulations might be easier to read. Let me know if I should change this.

Addresses #7837. 