### PR TITLE
[jax2tf] Force TF compilation for code under jax.jit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.26 (Unreleased)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.25...main).
+
 * Bug fixes:
   * Out-of-bounds indices to `jax.ops.segment_sum` will now be handled with
     `FILL_OR_DROP` semantics, as documented. This primarily afects the
     reverse-mode derivative, where gradients corresponding to out-of-bounds
     indices will now be returned as 0. (#8634).
+  * jax2tf will force the converted code to use XLA for the code fragments
+    under jax.jit, e.g., most jax.numpy functions ({jax-issue}`#7839`).
 
 ## jaxlib 0.1.74 (Nov 17, 2021)
 * Enabled peer-to-peer copies between GPUs. Previously, GPU copies were bounced via
@@ -35,7 +38,6 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 * Breaking changes
   * Moved `jax.experimental.stax` to `jax.example_libraries.stax`
   * Moved `jax.experimental.optimizers` to `jax.example_libraries.optimizers`
-
 * New features:
   * Added `jax.lax.linalg.qdwh`.
 

--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -84,6 +84,12 @@ accuracy w.r.t. the JAX execution:
 ```python
 tf.function(jax2tf.convert(f_jax), autograph=False, jit_compile=True)(x)
 ```
+The above happens automatically for JAX code that uses `jax.jit`. E.g.,
+the above is equivalent to:
+
+```python
+jax2tf.convert(jax.jit(f_jax))(x)
+```
 
 ## Usage: saved model
 


### PR DESCRIPTION
Previously, jax.jit was ignored by jax2tf. This can result in the
converted code being much slower than the JAX core, unless the
user adds an explicit `tf.function(jit_compile=True)`. With this
change that wrapper is added automatically for all code fragments
under jax.jit. Note that most jax.numpy functions are annotated
with jax.jit, so with this change they will all be compiled.

When doing this I ran into problems with tf.custom_gradient and
tf.function. As documented in the
[tf.custom_gradient](https://www.tensorflow.org/api_docs/python/tf/custom_gradient)
documentation, you get a LookupError when trying to build the gradient
of a tf.function, even if it has a tf.custom_gradient defined. The
recommended solution is to add a tf.stop_gradient. This is safe, since
jax2tf will always wrap the converted functions with a tf.custom_gradient.