### PR TITLE
Unpin the tpu_driver version used for Cloud TPU Colabs.

### DIFF
--- a/jax/tools/colab_tpu.py
+++ b/jax/tools/colab_tpu.py
@@ -32,7 +32,7 @@ def setup_tpu():
 
   if not TPU_DRIVER_MODE:
     colab_tpu_addr = os.environ['COLAB_TPU_ADDR'].split(':')[0]
-    url = f'http://{colab_tpu_addr}:8475/requestversion/tpu_driver0.1-dev20210603'
+    url = f'http://{colab_tpu_addr}:8475/requestversion/tpu_driver_nightly'
     requests.post(url)
     TPU_DRIVER_MODE = 1
 


### PR DESCRIPTION
This reverts https://github.com/google/jax/pull/6942. The nightly appears to work again, and we wanna pick up new fixes and improvements.