### PR TITLE
Feat: scipy.stats.nbinom implementation

### DIFF
--- a/jax/_src/scipy/stats/nbinom.py
+++ b/jax/_src/scipy/stats/nbinom.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+
+import scipy.stats as osp_stats
+
+from jax import lax
+from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like, where, inf
+from jax._src.numpy.util import _wraps
+from jax._src.scipy.special import gammaln, xlogy
+
+
+@_wraps(osp_stats.nbinom.logpmf, update_doc=False)
+def logpmf(k, n, p, loc=0):
+    """JAX implementation of scipy.stats.nbinom.logpmf."""
+    k, n, p, loc = _promote_args_inexact("nbinom.logpmf", k, n, p, loc)
+    one = _constant_like(k, 1)
+    y = lax.sub(k, loc)
+    comb_term = lax.sub(
+        lax.sub(gammaln(lax.add(y, n)), gammaln(n)), gammaln(lax.add(y, one))
+    )
+    log_linear_term = lax.add(xlogy(n, p), xlogy(y, lax.sub(one, p)))
+    log_probs = lax.add(comb_term, log_linear_term)
+    return where(lax.lt(k, loc), -inf, log_probs)
+
+
+@_wraps(osp_stats.nbinom.pmf, update_doc=False)
+def pmf(k, n, p, loc=0):
+    """JAX implementation of scipy.stats.nbinom.pmf."""
+    return lax.exp(logpmf(k, n, p, loc))

--- a/jax/scipy/stats/nbinom.py
+++ b/jax/scipy/stats/nbinom.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,21 +13,8 @@
 # limitations under the License.
 
 # flake8: noqa: F401
-from . import bernoulli
-from . import beta
-from . import cauchy
-from . import dirichlet
-from . import expon
-from . import gamma
-from . import geom
-from . import laplace
-from . import logistic
-from . import multivariate_normal
-from . import nbinom
-from . import norm
-from . import pareto
-from . import poisson
-from . import t
-from . import uniform
-from . import chi2
-from . import betabinom
+
+from jax._src.scipy.stats.nbinom import (
+  logpmf,
+  pmf,
+)


### PR DESCRIPTION
Hi,

This PR adds [scipy.stats.nbinom](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.nbinom.html) to Jax.
Only the log of the probability mass function (```logpmf```) and the probability mass function (```pmf```) are implemented.
The signatures added follow scipy's:
```logpmf(k, n, p, loc=0)```
and
```pmf(k, n, p, loc=0)```
Thanks,

Cyprien
