### PR TITLE
Fix markdown embedded within html

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -1636,7 +1636,12 @@
     "\\hline\n",
     "\\end{array}\n",
     "$$\n",
-    "<center>$\\ast$ = argument-__value__-independent loop condition - unrolls the loop </center>"
+    "\n",
+    "<center>\n",
+    "\n",
+    "$\\ast$ = argument-<b>value</b>-independent loop condition - unrolls the loop\n",
+    "\n",
+    "</center>"
    ]
   },
   {

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -810,7 +810,12 @@ $$
 \hline
 \end{array}
 $$
-<center>$\ast$ = argument-__value__-independent loop condition - unrolls the loop </center>
+
+<center>
+
+$\ast$ = argument-<b>value</b>-independent loop condition - unrolls the loop
+
+</center>
 
 +++ {"id": "DKTMw6tRZyK2"}
 


### PR DESCRIPTION
A rendering issue is showing up on this docs page: 
https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#summary

This is because markdown rendering is not enabled inside of an html element unless extra newlines are added.
For more info see: 
https://stackoverflow.com/questions/29368902/how-can-i-wrap-my-markdown-in-an-html-div

Before:
![Screen Shot 2021-09-09 at 6 32 05 PM](https://user-images.githubusercontent.com/15711120/132771230-e369974e-9570-4467-8817-5ab02367f817.png)

After fix and rebuild:
![Screen Shot 2021-09-09 at 6 32 27 PM](https://user-images.githubusercontent.com/15711120/132771688-d82e17af-d994-4fe7-bc10-8c9f37ed3929.png)

