### PR TITLE
Add a note about extra Google Colab setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,11 @@ the following in your cloud TPU VM:
 pip install --upgrade pip
 pip install "jax[tpu]>=0.2.16" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
 ```
+Colab TPU runtimes come with JAX pre-installed, but before importing JAX you must run the following code to initialize the TPU:
+```python
+import jax.tools.colab_tpu
+jax.tools.colab_tpu.setup_tpu()
+```
 
 ### Building JAX from source
 See [Building JAX from


### PR DESCRIPTION
As noted in #7883, user must run `jax.tools.colab_tpu.setup_tpu()` to initialize TPUs on Google Colab. Might be worth also linking [to this](https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html#colab-tpu-setup), but it seems like it's in a weird place (part 7 of the 101 series). General install instructions should probably be in readme, and Colab is used frequently enough that it deserves to be there I think.