### PR TITLE
Use jax.* APIs rather than api.* names in tests.

### DIFF
--- a/tests/host_callback_to_tf_test.py
+++ b/tests/host_callback_to_tf_test.py
@@ -24,7 +24,7 @@ import unittest
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax._src import api
+import jax
 from jax.config import config
 from jax import numpy as jnp
 from jax import test_util as jtu
@@ -64,7 +64,7 @@ def call_tf_simple_ad(tf_fun: Callable, arg, *, result_shape):
   functions and must be called outside the JAX computation.
   """
 
-  @api.custom_vjp
+  @jax.custom_vjp
   def make_call(arg):
     """We wrap it all in `make_call` so that we can attach custom VJP."""
     return call_tf_no_ad(tf_fun, arg, result_shape=result_shape)
@@ -103,7 +103,7 @@ def call_tf_full_ad(tf_fun: Callable, arg, *, result_shape):
   Supports higher-order AD and pytree arguments.
   """
 
-  @api.custom_vjp
+  @jax.custom_vjp
   def make_call(arg):
     """We wrap it all in `make_call` so that we can attach custom VJP."""
     return call_tf_no_ad(tf_fun, arg, result_shape=result_shape)
@@ -181,7 +181,7 @@ class CallToTFTest(jtu.JaxTestCase):
 
     res = f_outside(3.)
     self.assertAllClose(f_jax(3.), res)
-    self.assertAllClose(f_jax(3.), api.jit(f_outside)(3.))
+    self.assertAllClose(f_jax(3.), jax.jit(f_outside)(3.))
 
   @parameterized.named_parameters(
       dict(
@@ -201,8 +201,8 @@ class CallToTFTest(jtu.JaxTestCase):
     x = 4.
     self.assertAllClose(f_jax(x), f_outside(x))
 
-    grad_f = api.grad(f_outside)(x)
-    self.assertAllClose(api.grad(f_jax)(x), grad_f)
+    grad_f = jax.grad(f_outside)(x)
+    self.assertAllClose(jax.grad(f_jax)(x), grad_f)
 
   def test_grad_pytree(self):
     call_tf = call_tf_full_ad
@@ -220,8 +220,8 @@ class CallToTFTest(jtu.JaxTestCase):
 
     xy = (5., 6.)
     self.assertAllClose(f_jax(xy), f_outside(xy))
-    res_jax = api.grad(f_jax)(xy)
-    self.assertAllClose(res_jax, api.grad(f_outside)(xy))
+    res_jax = jax.grad(f_jax)(xy)
+    self.assertAllClose(res_jax, jax.grad(f_outside)(xy))
 
   @parameterized.named_parameters(
       dict(
@@ -241,8 +241,8 @@ class CallToTFTest(jtu.JaxTestCase):
     grad_jax = f_jax
     grad_outside = f_outside
     for i in range(degree):
-      grad_jax = api.grad(grad_jax)
-      grad_outside = api.grad(grad_outside)
+      grad_jax = jax.grad(grad_jax)
+      grad_outside = jax.grad(grad_outside)
 
     res_jax = grad_jax(5.)
     self.assertAllClose(res_jax, grad_outside(5.))

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -24,7 +24,6 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-from jax._src import api
 from jax import dtypes
 from jax import lax
 from jax import test_util as jtu
@@ -405,9 +404,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
     check_grads_bilinear(dot, (lhs, rhs), order=2, modes=["fwd", "rev"],
                          atol=tol, rtol=tol)
     # check that precision config is preserved
-    result, pullback = api.vjp(dot, lhs, rhs)
+    result, pullback = jax.vjp(dot, lhs, rhs)
     gresult = lax.zeros_like_array(result)
-    s = str(api.make_jaxpr(pullback)(gresult))
+    s = str(jax.make_jaxpr(pullback)(gresult))
     assert "Precision.HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -436,9 +435,9 @@ class LaxAutodiffTest(jtu.JaxTestCase):
                           precision=lax.Precision.HIGHEST)
     check_grads_bilinear(dot_general, (lhs, rhs), order=2, modes=["fwd", "rev"])
     # check that precision config is preserved
-    result, pullback = api.vjp(dot_general, lhs, rhs)
+    result, pullback = jax.vjp(dot_general, lhs, rhs)
     gresult = lax.zeros_like_array(result)
-    s = str(api.make_jaxpr(pullback)(gresult))
+    s = str(jax.make_jaxpr(pullback)(gresult))
     assert "Precision.HIGHEST" in s
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -1016,15 +1015,15 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       return lax.sin(x) * lax.cos(y)
 
     x = 3.14
-    ans = api.grad(f)(x)
-    expected = api.grad(f2)(x, x)
+    ans = jax.grad(f)(x)
+    expected = jax.grad(f2)(x, x)
     self.assertAllClose(ans, expected)
 
-    ans = api.grad(api.grad(f))(x)
-    expected = api.grad(api.grad(f2))(x, x)
+    ans = jax.grad(jax.grad(f))(x)
+    expected = jax.grad(jax.grad(f2))(x, x)
     self.assertAllClose(ans, expected)
 
-    ans = api.grad(lambda x: lax.stop_gradient({'foo':x})['foo'])(3.)
+    ans = jax.grad(lambda x: lax.stop_gradient({'foo':x})['foo'])(3.)
     expected = np.array(0.0)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -1058,14 +1057,14 @@ class LaxAutodiffTest(jtu.JaxTestCase):
 
   def test_linear_transpose_real(self):
     f = lambda x: x.real
-    transpose = api.linear_transpose(f, 1.j)
+    transpose = jax.linear_transpose(f, 1.j)
     actual, = transpose(1.)
     expected = 1.
     self.assertEqual(actual, expected)
 
   def test_linear_transpose_imag(self):
     f = lambda x: x.imag
-    transpose = api.linear_transpose(f, 1.j)
+    transpose = jax.linear_transpose(f, 1.j)
     actual, = transpose(1.)
     expected = -1.j
     self.assertEqual(actual, expected)

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -26,7 +26,6 @@ import numpy as np
 import scipy.special as osp_special
 
 import jax
-from jax._src import api
 from jax import numpy as jnp
 from jax import lax
 from jax import scipy as jsp
@@ -305,14 +304,14 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
   def testGradOfXlogyAtZero(self):
     partial_xlogy = functools.partial(lsp_special.xlogy, 0.)
-    self.assertAllClose(api.grad(partial_xlogy)(0.), 0., check_dtypes=False)
+    self.assertAllClose(jax.grad(partial_xlogy)(0.), 0., check_dtypes=False)
 
   def testXlog1pyShouldReturnZero(self):
     self.assertAllClose(lsp_special.xlog1py(0., -1.), 0., check_dtypes=False)
 
   def testGradOfXlog1pyAtZero(self):
     partial_xlog1py = functools.partial(lsp_special.xlog1py, 0.)
-    self.assertAllClose(api.grad(partial_xlog1py)(-1.), 0., check_dtypes=False)
+    self.assertAllClose(jax.grad(partial_xlog1py)(-1.), 0., check_dtypes=False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -26,7 +26,6 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-from jax._src import api
 from jax import core
 from jax._src import dtypes
 from jax import lax
@@ -294,7 +293,7 @@ class LaxTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
     x_out = op(x_in)
     self.assertEqual(dtypes.is_weakly_typed(x_out), False)
-    x_out_jit = api.jit(op)(x_in)
+    x_out_jit = jax.jit(op)(x_in)
     self.assertEqual(dtypes.is_weakly_typed(x_out_jit), False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -814,7 +813,7 @@ class LaxTest(jtu.JaxTestCase):
     placeholder = np.ones(o_layout, data.dtype)
     conv = lambda x: lax.conv_general_dilated(x, kernel, strides, padding,
                                               one, rhs_dilation, dn)
-    _, g = api.vjp(conv, placeholder)
+    _, g = jax.vjp(conv, placeholder)
     return g(data)[0]
 
   @staticmethod
@@ -1358,7 +1357,7 @@ class LaxTest(jtu.JaxTestCase):
       lax.pad(np.zeros(2), 0., [(-4, 0, 1)])
 
   def testReverse(self):
-    rev = api.jit(lambda operand: lax.rev(operand, dimensions))
+    rev = jax.jit(lambda operand: lax.rev(operand, dimensions))
 
     dimensions = []
     self.assertAllClose(np.array([0, 1, 2, 3]), rev(np.array([0, 1, 2, 3])),
@@ -1628,7 +1627,7 @@ class LaxTest(jtu.JaxTestCase):
     fun = lambda arr, init: lax.reduce(arr, init, op, (0,))
     out = fun(arr, init)
     self.assertEqual(dtypes.is_weakly_typed(out), arr_weak_type and init_weak_type)
-    out_jit = api.jit(fun)(arr, init)
+    out_jit = jax.jit(fun)(arr, init)
     self.assertEqual(dtypes.is_weakly_typed(out_jit), arr_weak_type and init_weak_type)
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -1929,7 +1928,7 @@ class LaxTest(jtu.JaxTestCase):
 
   def testCollapse(self):
 
-    @api.jit
+    @jax.jit
     def collapse_first_two(x):
       return lax.collapse(x, 0, 2)
 
@@ -2256,9 +2255,9 @@ class LaxTest(jtu.JaxTestCase):
     # Tests the DeviceTuple constant handler
     def f(x):
       g = lambda *args: args[1]
-      return api.jit(lax.fori_loop, static_argnums=(2,))( 0, 10, g, x)
+      return jax.jit(lax.fori_loop, static_argnums=(2,))( 0, 10, g, x)
 
-    api.jit(f)(1.)  # doesn't crash
+    jax.jit(f)(1.)  # doesn't crash
 
   def testReshapeWithUnusualShapes(self):
     ans = lax.reshape(np.ones((3,), np.float32), (lax.add(1, 2), 1))
@@ -2295,7 +2294,7 @@ class LaxTest(jtu.JaxTestCase):
     # with core.skipping_checks():
     #   with self.assertRaisesRegex(
     #       TypeError, ".* of type .*tuple.* is not a valid JAX type"):
-    #     api.make_jaxpr(lambda x: lax.tie_in((x, x), 1))(1.)
+    #     jax.make_jaxpr(lambda x: lax.tie_in((x, x), 1))(1.)
 
   def test_primitive_jaxtype_error(self):
     with jax.enable_checks(False):
@@ -2400,7 +2399,7 @@ class LaxTest(jtu.JaxTestCase):
           k, shape=(5, 7), algorithm=lax.RandomAlgorithm.RNG_THREE_FRY)
 
     out = fn(key)
-    out_jit = api.jit(fn)(key)
+    out_jit = jax.jit(fn)(key)
     self.assertEqual(out[0].shape, (2,))
     self.assertEqual(out[1].shape, (5, 7))
     self.assertArraysEqual(out[0], out_jit[0])
@@ -2460,7 +2459,7 @@ class LazyConstantTest(jtu.JaxTestCase):
     argument_result = lax.add(zero, make_const())
 
     # check looping into a compiled computation works
-    jit_result = api.jit(lambda x: lax.add(x, make_const()))(zero)
+    jit_result = jax.jit(lambda x: lax.add(x, make_const()))(zero)
 
     # ensure they're all the same
     self.assertAllClose(asarray_result, expected)
@@ -2543,7 +2542,7 @@ class LazyConstantTest(jtu.JaxTestCase):
   def testConvertElementReturnType(self, input_type, dtype, value, jit):
     op = lambda x: lax.convert_element_type(x, dtype)
     if jit:
-      op = api.jit(op)
+      op = jax.jit(op)
     result = op(input_type(value))
     assert isinstance(result, xla.DeviceArray)
 
@@ -2603,7 +2602,7 @@ class LazyConstantTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.is_weakly_typed(x_in), weak_type)
     x_out = op(x_in)
     self.assertEqual(dtypes.is_weakly_typed(x_out), False)
-    x_out_jit = api.jit(op)(x_in)
+    x_out_jit = jax.jit(op)(x_in)
     self.assertEqual(dtypes.is_weakly_typed(x_out_jit), False)
 
   def testArgMaxOfNanChoosesNaN(self):

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -23,7 +23,7 @@ from absl.testing import parameterized
 
 import numpy as np
 
-from jax._src import api
+import jax
 from jax import dtypes
 from jax import lax
 from jax import test_util as jtu
@@ -73,7 +73,7 @@ class LaxVmapTest(jtu.JaxTestCase):
     batched_shapes = map(partial(add_bdim, bdim_size), bdims, shapes)
     args = [rng(shape, dtype) for shape, dtype in zip(batched_shapes, dtypes)]
     args_slice = args_slicer(args, bdims)
-    ans = api.vmap(op, bdims)(*args)
+    ans = jax.vmap(op, bdims)(*args)
     if bdim_size == 0:
       args = [rng(shape, dtype) for shape, dtype in zip(shapes, dtypes)]
       out = op(*args)
@@ -293,7 +293,7 @@ class LaxVmapTest(jtu.JaxTestCase):
                         rng)
 
     # Checks that batching didn't introduce any transposes or broadcasts.
-    jaxpr = api.make_jaxpr(dot)(np.zeros(lhs_shape, dtype),
+    jaxpr = jax.make_jaxpr(dot)(np.zeros(lhs_shape, dtype),
                                 np.zeros(rhs_shape, dtype))
     for eqn in jtu.iter_eqns(jaxpr.jaxpr):
       self.assertFalse(eqn.primitive in ["transpose", "broadcast"])
@@ -608,7 +608,7 @@ class LaxVmapTest(jtu.JaxTestCase):
       return lax._select_and_scatter_add(operand, cotangents, lax.ge_p, dims,
                                          strides, pads)
     ones = (1,) * len(shape)
-    cotangent_shape = api.eval_shape(
+    cotangent_shape = jax.eval_shape(
       lambda x: lax._select_and_gather_add(x, x, lax.ge_p, dims, strides,
                                            pads, ones, ones),
       np.ones(shape, dtype)).shape

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -21,7 +21,7 @@ import numpy as np
 import scipy as osp
 import scipy.stats as osp_stats
 
-from jax._src import api
+import jax
 from jax import test_util as jtu
 from jax.scipy import stats as lsp_stats
 from jax.scipy.special import expit
@@ -557,7 +557,7 @@ class LaxBackedScipyStatsTests(jtu.JaxTestCase):
     cov = factor @ factor.transpose(0, 2, 1)
 
     result1 = lsp_stats.multivariate_normal.logpdf(x, mean, cov)
-    result2 = api.vmap(lsp_stats.multivariate_normal.logpdf)(x, mean, cov)
+    result2 = jax.vmap(lsp_stats.multivariate_normal.logpdf)(x, mean, cov)
     self.assertArraysEqual(result1, result2)
 
 

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -20,6 +20,7 @@ import time
 from absl.testing import absltest
 from absl.testing import parameterized
 
+import jax
 from jax._src import api
 from jax import lax
 from jax import random
@@ -152,7 +153,7 @@ class X64ContextTests(jtu.JaxTestCase):
     y = x.astype(jnp.int32)
     self.assertEqual(y.dtype, jnp.int32)
 
-    z = api.jit(lambda x: x.astype(jnp.int32))(x)
+    z = jax.jit(lambda x: x.astype(jnp.int32))(x)
     self.assertEqual(z.dtype, jnp.int32)
 
 if __name__ == "__main__":

--- a/tests/xla_interpreter_test.py
+++ b/tests/xla_interpreter_test.py
@@ -14,8 +14,8 @@
 
 from absl.testing import absltest
 
+import jax
 from jax import test_util as jtu
-from jax._src import api
 from jax.interpreters import xla
 
 
@@ -25,7 +25,7 @@ class XlaInterpreterTest(jtu.JaxTestCase):
     def f(*args):
       return args[0]
 
-    closed_jaxpr = api.make_jaxpr(f)(*range(10))
+    closed_jaxpr = jax.make_jaxpr(f)(*range(10))
     pruned_jaxpr, kept_const_idx, kept_var_idx = xla._prune_unused_inputs(
         closed_jaxpr.jaxpr)
     assert len(pruned_jaxpr.invars) == 1


### PR DESCRIPTION
Tests should use our own public APIs where they exist.