### PR TITLE
ppermute: avoid passing lists of indices to jnp.take

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -784,7 +784,7 @@ def _ppermute_batcher(axis_size, frame_name, _, vals_in, dims_in, axis_name, per
   assert axis_name[0] == frame_name, "ppermute batcher called with a wrong axis!"
   assert len(perm) == axis_size, "Permutation doesn't match the axis size!"
   assert d is not batching.not_mapped
-  perm_indices = [None] * axis_size
+  perm_indices = np.zeros(axis_size, dtype=int)
   for src, dst in perm:
     perm_indices[src] = dst
   return lax_numpy.take(v, perm_indices, d), d


### PR DESCRIPTION
Why? `jnp.take` is now jit-compiled by default, so a list of indices will be treated as a pytree, with each index individually traced. This may be inefficient as the size of the list grows. Passing the values as a numpy array leads to only a single traced quantity.