### PR TITLE
Add precision param for pdot

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -633,7 +633,7 @@ def conv_general_dilated(
       feature_group_count=feature_group_count,
       batch_group_count=batch_group_count,
       lhs_shape=lhs.shape, rhs_shape=rhs.shape,
-      precision=_canonicalize_precision(precision),
+      precision=canonicalize_precision(precision),
       preferred_element_type=preferred_element_type)
 
 def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
@@ -702,7 +702,7 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
   batch_dims = tuple(map(tuple, batch_dims_seq))  # type: ignore
   return dot_general_p.bind(lhs, rhs,
                             dimension_numbers=(contract_dims, batch_dims),
-                            precision=_canonicalize_precision(precision),
+                            precision=canonicalize_precision(precision),
                             preferred_element_type=preferred_element_type)
 
 def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
@@ -6826,7 +6826,7 @@ def remaining(original, *removed_lists):
   return [i for i in original if i not in removed]
 
 
-def _canonicalize_precision(precision: PrecisionLike) -> Optional[Tuple[PrecisionType, PrecisionType]]:
+def canonicalize_precision(precision: PrecisionLike) -> Optional[Tuple[PrecisionType, PrecisionType]]:
   """Turns an API precision specification, into a pair of enumeration values.
 
   The API can take the precision as a string, or int, and either as a single
@@ -6854,7 +6854,7 @@ def _canonicalize_precision(precision: PrecisionLike) -> Optional[Tuple[Precisio
   elif (isinstance(precision, (list, tuple)) and len(precision) == 2 and
         all(isinstance(s, str) for s in precision)):
     s1, s2 = precision
-    return (_canonicalize_precision(s1)[0], _canonicalize_precision(s2)[0])  # type: ignore
+    return (canonicalize_precision(s1)[0], canonicalize_precision(s2)[0])  # type: ignore
   else:
     raise ValueError(
         f"Precision argument must be None, a string in {_precision_strings}, "

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1117,6 +1117,19 @@ class BatchingTest(jtu.JaxTestCase):
     zs = vmap(vmap(f, axis_name='i', in_axes=(1, 0), out_axes=None))(xs, ys)
     self.assertAllClose(zs, jnp.einsum('nij,njk->nik', xs, ys))
 
+  def testPdotPrecision(self):
+    def f(x, y):
+      return lax.pdot(x, y, 'i', precision=lax.Precision.HIGHEST)
+
+    f_jaxpr = make_jaxpr(f, axis_env=(('i', 4),))(jnp.ones(4), jnp.ones(4))
+    self.assertIn('HIGHEST', str(f_jaxpr))
+
+    vmap_jaxpr = make_jaxpr(jax.vmap(f, axis_name='i'))(jnp.ones((3, 4)),
+        jnp.ones((3, 4)))
+    self.assertIn('HIGHEST', str(vmap_jaxpr))
+
+
+
   def testPdotJvp(self):
     def f(x, y):
       return lax.pdot(x, y, 'i')


### PR DESCRIPTION
Currently `pdot` has no precision parameter. When it is lowered we lose information about the `default_matmul_precision` decorator and the precision is always default. This PR adds in the `precision` parameter and plumbs it to the lowered `dot_general`.