### PR TITLE
jnp.take: require array argument (but not indices) to be arraylike

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5078,6 +5078,7 @@ def take(a, indices, axis: Optional[int] = None, out=None, mode=None):
 def _take(a, indices, axis: Optional[int] = None, out=None, mode=None):
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.take is not supported.")
+  _check_arraylike("take", a)
   a = asarray(a)
   indices = asarray(indices)
 


### PR DESCRIPTION
Part of #7737

I'm leaving out the `indices` argument for now, because it's quite common downstream for users to pass lists of indices to `jnp.take`. I will likely revisit the indices later.