### PR TITLE
jnp.array: raise TypeError for scalar boolean indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 * Breaking Changes
   * `jax.lax.partial` was an accidental export that has now been removed. Use
     `functools.partial` instead.
+  * Boolean scalar indices now raise a `TypeError`; previously this silently
+    returned wrong results ({jax-issue}`#7925`).
 
 ## jax 0.2.20 (Sept 2, 2021)
 * [GitHub

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5682,6 +5682,8 @@ def _expand_bool_indices(idx, shape):
       if not type(abstract_i) is ConcreteArray:
         # TODO(mattjj): improve this error by tracking _why_ the indices are not concrete
         raise errors.NonConcreteBooleanIndexError(abstract_i)
+      elif _ndim(i) == 0:
+        raise TypeError("JAX arrays do not support boolean scalar indices")
       else:
         i_shape = _shape(i)
         expected_shape = shape[len(out): len(out) + _ndim(i)]

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -770,6 +770,13 @@ class IndexingTest(jtu.JaxTestCase):
     i = np.array([True, True, False])
     self.assertRaises(IndexError, lambda: jax.jit(lambda x, i: x[i])(x, i))
 
+  def testScalarBooleanIndexingNotImplemented(self):
+    msg = "JAX arrays do not support boolean scalar indices"
+    with self.assertRaisesRegex(TypeError, msg):
+      jnp.arange(4)[True]
+    with self.assertRaisesRegex(TypeError, msg):
+      jnp.arange(4)[False]
+
   def testIssue187(self):
     x = jnp.ones((5, 5))
     x[[0, 2, 4], [0, 2, 4]]  # doesn't crash


### PR DESCRIPTION
Addresses #7918

Rather than implement numpy's behavior here, we will now raise an explicit `TypeError`. The reason is that numpy's behavior for scalar boolean indices is poorly-documented, not well-defined, and difficult to understand.

See, e.g. https://github.com/google/jax/issues/7918#issuecomment-920260618 and https://stackoverflow.com/a/65598320