### PR TITLE
Wrong instruction in building from source for Windows #7912

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -94,7 +94,7 @@ for more details. Install the following packages:
 ```
 pacman -S patch coreutils
 ```
-`realpath` command should be found in shell command line.
+Once coreutils is installed, the realpath command should be present in your shell's path.
 
 Once everything is installed. Open PowerShell, and make sure MSYS2 is in the
 path of the current session. Ensure `bazel`, `patch` and `realpath` are
@@ -106,11 +106,9 @@ python .\build\build.py `
   --enable_cuda `
   --cuda_path='C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.1' `
   --cudnn_path='C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.1' `
-  --cuda_compute_capabilities='6.1' `
   --cuda_version='10.1' `
   --cudnn_version='7.6.5'
 ```
-Discard `--cuda_compute_capabilities` flag in case of argument exception.
 
 To build with debug information, add the flag `--bazel_options='--copt=/Z7'`.
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -92,8 +92,9 @@ is needed. See [Installing Bazel on Windows](https://docs.bazel.build/versions/m
 for more details. Install the following packages:
 
 ```
-pacman -S patch realpath
+pacman -S patch coreutils
 ```
+`realpath` command should be found in shell command line.
 
 Once everything is installed. Open PowerShell, and make sure MSYS2 is in the
 path of the current session. Ensure `bazel`, `patch` and `realpath` are
@@ -109,6 +110,7 @@ python .\build\build.py `
   --cuda_version='10.1' `
   --cudnn_version='7.6.5'
 ```
+Discard `--cuda_compute_capabilities` flag in case of argument exception.
 
 To build with debug information, add the flag `--bazel_options='--copt=/Z7'`.
 


### PR DESCRIPTION
Modified trivial errors in Google JAX docs about building from source instruction in Windows.
[#7912](https://github.com/google/jax/issues/7912)