### PR TITLE
Improve error message when passing a tuple of non-concrete values as …

### DIFF
--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -147,7 +147,7 @@ class ConcretizationTypeError(JAXTypeError):
   """
   def __init__(self, tracer: "core.Tracer", context: str = ""):
     super().__init__(
-        "Abstract tracer value encountered where concrete value is expected: "
+        "Abstract tracer value encountered where a concrete value is expected: "
         f"{tracer}\n{context}{tracer._origin_msg()}\n")
 
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2253,6 +2253,11 @@ def _ensure_optional_axes(x):
       return operator.index(x)
     except TypeError:
       return tuple(i if isinstance(i, str) else operator.index(i) for i in x)
+
+  if isinstance(x, tuple):
+    return tuple(core.concrete_or_error(
+      force, e, "The axis argument must be known statically.") for e in x)
+
   return core.concrete_or_error(
     force, x, "The axis argument must be known statically.")
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3660,6 +3660,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
 
     self.assertRaises(jax.errors.ConcretizationTypeError, lambda: g(3.))
 
+    @jax.jit
+    def h(x, y):
+      return jnp.sum(x, axis=(y,))
+
+    self.assertRaises(jax.errors.ConcretizationTypeError,
+                      lambda: h(jnp.arange(5), 0))
+
   def testTracingPrimitiveWithNoTranslationErrorMessage(self):
     # TODO(mattjj): update this for jax3
     self.skipTest("test needs jax3 update")


### PR DESCRIPTION
…an axis argument.

Previously, we would see the less helpful error:

```
jax._src.errors.TracerIntegerConversionError: The __index__() method was called on the JAX Tracer object Traced<ShapedArray(int32[])>with<DynamicJaxprTrace(level=5/0)>
See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerIntegerConversionError
```

Whereas now we see:

```
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
The axis argument must be known statically.
While tracing the function h at /Users/phawkins/p/jax/tests/lax_numpy_test.py:3663 for jit, this concrete value was not available in Python because it depends on the value of the argument 'y'.

See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
```