### PR TITLE
tweak cuda/rocm targets

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -248,13 +248,13 @@ def write_bazelrc(python_bin_path=None, remote_build=None,
               .format(cudnn_version=cudnn_version))
     if cuda_compute_capabilities:
       f.write(
-        f'build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="{cuda_compute_capabilities}"')
+        f'build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="{cuda_compute_capabilities}"\n')
     if rocm_toolkit_path:
       f.write("build --action_env ROCM_PATH=\"{rocm_toolkit_path}\"\n"
               .format(rocm_toolkit_path=rocm_toolkit_path))
     if rocm_amdgpu_targets:
       f.write(
-        f'build:rocm --action_env TF_ROCM_AMDGPU_TARGETS="{rocm_amdgpu_targets}"')
+        f'build:rocm --action_env TF_ROCM_AMDGPU_TARGETS="{rocm_amdgpu_targets}"\n')
     if cpu is not None:
       f.write("build --distinct_host_configuration=true\n")
       f.write(f"build --cpu={cpu}\n")


### PR DESCRIPTION
Closes #7955.

@yashk2810  I tweaked the rocm line as well, please review!

> python3 build/build.py --enable_cuda
works here:

```
INFO: Elapsed time: 941.252s, Critical Path: 157.16s
INFO: 11954 processes: 4726 internal, 7228 local.
INFO: Build completed successfully, 11954 total actions
INFO: Running command line: bazel-bin/build/build_wheel '--output_path=/home/skoonce/jax/jax/dist' '--cpu=x86_64'
INFO: Build completed successfully, 11954 total actions
package init file 'jaxlib/xla_extension/__init__.py' not found (or not a regular file)
Output wheel: /home/skoonce/jax/jax/dist/jaxlib-0.1.72-cp38-none-manylinux2010_x86_64.whl

To install the newly-built jaxlib wheel, run:
  pip install /home/skoonce/jax/jax/dist/jaxlib-0.1.72-cp38-none-manylinux2010_x86_64.whl


real    15m57.729s
user    0m14.981s
sys     0m1.706s
```