### PR TITLE
convolutions: use flip() to clean up reverse-indexing

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -829,7 +829,7 @@ def _conv(x, y, mode, op, precision):
   elif op == 'convolve':
     if len(x) < len(y):
       x, y = y, x
-    y = y[::-1]
+    y = flip(y)
 
   if mode == 'valid':
     padding = [(0, 0)]

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -45,7 +45,7 @@ def _convolve_nd(in1, in2, mode, *, precision):
   if swap:
     in1, in2 = in2, in1
   shape = in2.shape
-  in2 = in2[tuple(slice(None, None, -1) for s in shape)]
+  in2 = jnp.flip(in2)
 
   if mode == 'valid':
     padding = [(0, 0) for s in shape]
@@ -99,22 +99,22 @@ def correlate2d(in1, in2, mode='full', boundary='fill', fillvalue=0,
   same_shape =  all(s1 == s2 for s1, s2 in zip(in1.shape, in2.shape))
 
   if mode == "same":
-    in1, in2 = in1[::-1, ::-1], in2.conj()
-    result = _convolve_nd(in1, in2, mode, precision=precision)[::-1, ::-1]
+    in1, in2 = jnp.flip(in1), in2.conj()
+    result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   elif mode == "valid":
     if swap and not same_shape:
-      in1, in2 = in2[::-1, ::-1], in1.conj()
+      in1, in2 = jnp.flip(in2), in1.conj()
       result = _convolve_nd(in1, in2, mode, precision=precision)
     else:
-      in1, in2 = in1[::-1, ::-1], in2.conj()
-      result = _convolve_nd(in1, in2, mode, precision=precision)[::-1, ::-1]
+      in1, in2 = jnp.flip(in1), in2.conj()
+      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   else:
     if swap:
-      in1, in2 = in2[::-1, ::-1], in1.conj()
+      in1, in2 = jnp.flip(in2), in1.conj()
       result = _convolve_nd(in1, in2, mode, precision=precision).conj()
     else:
-      in1, in2 = in1[::-1, ::-1], in2.conj()
-      result = _convolve_nd(in1, in2, mode, precision=precision)[::-1, ::-1]
+      in1, in2 = jnp.flip(in1), in2.conj()
+      result = jnp.flip(_convolve_nd(in1, in2, mode, precision=precision))
   return result
 
 


### PR DESCRIPTION
Changes uses of `[::-1]` and `slice(None, None, -1)` to instead use `jnp.flip`. Why? It makes the code & generated jaxprs more clear & marginally reduces jit compilation time for higher-dimensional arrays.