### PR TITLE
Add atol and rtol arguments to jtu._CheckAgainstNumpy().

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -1026,13 +1026,13 @@ class JaxTestCase(parameterized.TestCase):
                         atol=atol, rtol=rtol)
 
   def _CheckAgainstNumpy(self, numpy_reference_op, lax_op, args_maker,
-                         check_dtypes=True, tol=None,
+                         check_dtypes=True, tol=None, atol=None, rtol=None,
                          canonicalize_dtypes=True):
     args = args_maker()
     lax_ans = lax_op(*args)
     numpy_ans = numpy_reference_op(*args)
     self.assertAllClose(numpy_ans, lax_ans, check_dtypes=check_dtypes,
-                        atol=tol, rtol=tol,
+                        atol=atol or tol, rtol=rtol or tol,
                         canonicalize_dtypes=canonicalize_dtypes)
 
 


### PR DESCRIPTION
Prefer atol and rtol if they are provided.