### PR TITLE
Use traced identity in jacobian std_basis

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1118,9 +1118,8 @@ def hessian(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
 def _std_basis(pytree):
   leaves, _ = tree_flatten(pytree)
   ndim = sum(map(np.size, leaves))
-  # TODO(mattjj): use a symbolic identity matrix here
   dtype = dtypes.result_type(*leaves)
-  flat_basis = np.eye(ndim, dtype=dtype)
+  flat_basis = jax.numpy.eye(ndim, dtype=dtype)
   return _unravel_array_into_pytree(pytree, 1, flat_basis)
 
 def _unravel_array_into_pytree(pytree, axis, arr):


### PR DESCRIPTION
Fixes #7949 - significantly reduces compilation time for some jacobians by avoiding embedding of a large matrix constant in HLO.

Before (3.34s compilation):
```python
In [1]: from jax import jit, jacrev, numpy as jnp                                                                                
In [2]: f = jit(jacrev(lambda x: x[1:]))                                                                                         
In [3]: x = jnp.ones(1000)                                                                                                       

In [4]: _ = %time f(x).block_until_ready()  # measure compilation time
CPU times: user 3.34 s, sys: 19.6 ms, total: 3.36 s
Wall time: 3.37 s

In [5]: %timeit f(x).block_until_ready()  # measure execution time
382 µs ± 5.69 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
After (0.06s compilation):
```python
In [4]: _ = %time f(x).block_until_ready()  # measure compilation time
CPU times: user 57.9 ms, sys: 7.49 ms, total: 65.3 ms
Wall time: 60.2 ms

In [5]: %timeit f(x).block_until_ready()  # measure execution time
225 µs ± 9.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```