### PR TITLE
Import numpy explicitly in the jax namespace

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -124,6 +124,7 @@ from . import errors as errors
 from . import image as image
 from . import lax as lax
 from . import nn as nn
+from . import numpy as numpy
 from . import ops as ops
 from . import profiler as profiler
 from . import random as random
@@ -131,9 +132,3 @@ from . import tree_util as tree_util
 from . import util as util
 
 import jax.lib  # TODO(phawkins): remove this export.
-
-def _init():
-  from . import numpy as numpy # side-effecting import sets up operator overloads
-
-_init()
-del _init


### PR DESCRIPTION
Why? We already do import it by default, so
```python
import jax
print(jax.numpy)
```
will work (because `jax.numpy` falls back to a `sys.modules` lookup), and I suspect we have users that depend on this.

Currently, though, static analyzers will flag this as an error, because `numpy` is not part of the declared `jax` namespace.

Since we already import it for initialization purposes, there is no cost to making `jax.numpy` explicitly part of the `jax` namespace at import.

Note also that the import in line 115... https://github.com/google/jax/blob/484b5af5c915fb6356f2cd1de8c9c826eb7d1938/jax/__init__.py#L115 ...already results in `jax.numpy` being imported: https://github.com/google/jax/blob/484b5af5c915fb6356f2cd1de8c9c826eb7d1938/jax/experimental/maps.py#L25 ...so moving the explicit import to its alphabetical order in this PR is essentially a no-op.