### PR TITLE
add jax.ensure_compile_time_eval to public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * Added a new debugging flag/environment variable `JAX_DUMP_IR_TO=/path`.
     If set, JAX dumps the MHLO/HLO IR it generates for each computation to a
     file under the given path.
+  * Added `jax.ensure_compile_time_eval` to the public api ({jax-issue}`#7987`).
 
 ## jaxlib 0.1.76 (Unreleased)
 * New features

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -38,6 +38,7 @@ Just-in-time compilation (:code:`jit`)
 
     jit
     disable_jit
+    ensure_compile_time_eval
     xla_computation
     make_jaxpr
     eval_shape

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -50,6 +50,7 @@ from jax._src.config import (
   default_prng_impl as default_prng_impl,
   numpy_rank_promotion as numpy_rank_promotion,
 )
+from .core import eval_context as ensure_compile_time_eval
 from jax._src.api import (
   ad,  # TODO(phawkins): update users to avoid this.
   block_until_ready,


### PR DESCRIPTION
alias for `jax.core.eval_context`

fixes #7535