### PR TITLE
Remove `.[minimum-jaxlib]` from test-requirements.txt

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -79,7 +79,9 @@ jobs:
           pip install ${{ matrix.package-overrides }}
         fi
         if [ "${{ matrix.use-latest-jaxlib }}" == "true" ]; then
-          pip install -e .[cpu]
+          pip install .[cpu]
+        else
+          pip install .[minimum-jaxlib]
         fi
 
     - name: Run tests

--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -3,5 +3,3 @@ pillow>=8.3.1
 pytest-benchmark
 pytest-xdist
 wheel
-# Install jax from the current directory with minimum jaxlib from pypi.
-.[minimum-jaxlib]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ Follow these steps to contribute code:
    git clone https://github.com/YOUR_USERNAME/jax
    cd jax
    pip install -r build/test-requirements.txt  # Installs all testing requirements.
-   pip install -e .  # Installs JAX from the current directory in editable mode.
+   pip install -e .[cpu]  # Installs JAX from the current directory in editable mode.
    ```
 
 4. Add the JAX repo as an upstream remote, so you can use it to sync your
@@ -91,7 +91,7 @@ Follow these steps to contribute code:
    git rebase upstream/main
    ```
 
-   Finally, push your commit on your development branch and create a remote 
+   Finally, push your commit on your development branch and create a remote
    branch in your fork that you can use to create a pull request from:
 
    ```bash


### PR DESCRIPTION
This means that jax and its dependencies (e.g. jaxlib) must be
manually installed before running the tests. This is useful for
testing an existing jax install, e.g. a later version of jaxlib, GPU
jaxlib, etc.