### PR TITLE
PRNGKeys can have dtype float0 if they are a tangent.

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -24,6 +24,7 @@ from jax import core
 from jax import numpy as jnp
 from jax import tree_util
 from jax.config import config
+from jax.dtypes import float0
 from jax.interpreters import batching
 from jax.interpreters import xla
 from jax._src.api import jit, vmap
@@ -75,7 +76,7 @@ def _is_prng_key_data(impl, keys: jnp.ndarray) -> bool:
   try:
     return (keys.ndim >= 1 and
             keys.shape[-ndim:] == impl.key_shape and
-            keys.dtype == np.uint32)
+            (keys.dtype == np.uint32 or keys.dtype == float0))
   except AttributeError:
     return False
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1113,6 +1113,13 @@ class LaxRandomWithCustomPRNGTest(LaxRandomTest):
         TypeError, r'unsupported operand type\(s\) for \+*',
         lambda: key + 47)
 
+  @skipIf(np.__version__ == "1.21.0",
+          "https://github.com/numpy/numpy/issues/19305")
+  def test_grad_of_prng_key(self):
+    key = self.seed_prng(73)
+    jax.grad(lambda x: 1., allow_int=True)(key)  # does not crash
+
+
 def _sampler_unimplemented_with_custom_prng(*args, **kwargs):
   raise SkipTest('sampler only implemented for default RNG')
 


### PR DESCRIPTION
Testing question: I've added a test for this in `api_test`, and added a `skipTest` conditioned on `config.jax_enable_custom_prng`, same as the tests in `LaxRandomWithCustomPRNGTest`. Are these tests currently being run? I couldn't find a test configuration which runs these tests with `config.jax_enable_custom_prng=True` so I think they are always skipped?