### PR TITLE
DOC: refer to device_put within the jnp.array/asarray docs

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3515,8 +3515,16 @@ def atleast_3d(*arys):
     return [atleast_3d(arr) for arr in arys]
 
 
-@_wraps(np.array)
-def array(object, dtype=None, copy=True, order="K", ndmin=0):
+_ARRAY_DOC = """
+This function will create arrays on JAX's default device. For control of the
+device placement of data, see :func:`jax.device_put`. More information is
+available in the JAX FAQ at :ref:`faq-data-placement` (full FAQ at
+https://jax.readthedocs.io/en/latest/faq.html).
+"""
+
+
+@_wraps(np.array, lax_description=_ARRAY_DOC)
+def array(object, dtype=None, copy=True, order="K", ndmin=0, *, device=None):
   if order is not None and order != "K":
     raise NotImplementedError("Only implemented for order='K'")
 
@@ -3577,7 +3585,7 @@ def _can_call_numpy_array(x):
               for l in tree_leaves(x))
 
 
-@_wraps(np.asarray)
+@_wraps(np.asarray, lax_description=_ARRAY_DOC)
 def asarray(a, dtype=None, order=None):
   lax._check_user_dtype_supported(dtype, "asarray")
   dtype = dtypes.canonicalize_dtype(dtype) if dtype is not None else dtype


### PR DESCRIPTION
Fixes #8007

I opted for a doc-only fix at this point, not because adding a `device` argument to `jnp.array()` would be difficult, but because that style of approach would possibly imply a much larger change, where a `device` argument would be required for every `jax.numpy` function that creates a new array. I wouldn't rule that out, but it would require a longer design discussion (e.g. perhaps a better approach would be to provide a way to change the default device within a scope).