### PR TITLE
Change absl flag documentation to mention `re.search`

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -71,12 +71,12 @@ flags.DEFINE_bool(
 
 flags.DEFINE_string(
   'test_targets', '',
-  'Regular expression specifying which tests to run, called via re.match on '
+  'Regular expression specifying which tests to run, called via re.search on '
   'the test name. If empty or unspecified, run all tests.'
 )
 flags.DEFINE_string(
   'exclude_test_targets', '',
-  'Regular expression specifying which tests NOT to run, called via re.match '
+  'Regular expression specifying which tests NOT to run, called via re.search '
   'on the test name. If empty or unspecified, run all tests.'
 )
 


### PR DESCRIPTION
The absl help texts for test target discovery mention that targets
will be discovered by `re.match` use. However, in the subsequent
implementation, actually `re.search` is used. This commit changes the
help texts for the `test_targets` and `exclude_test_targets` flags
to correctly mention `re.search` as the discovery algorithm.