### PR TITLE
Schur lapack wrapper

### DIFF
--- a/jax/lax/linalg.py
+++ b/jax/lax/linalg.py
@@ -31,4 +31,6 @@ from jax._src.lax.linalg import (
   triangular_solve_p,
   tridiagonal_solve,
   tridiagonal_solve_p,
+  schur,
+  schur_p
 )

--- a/jaxlib/cpu_kernels.cc
+++ b/jaxlib/cpu_kernels.cc
@@ -97,8 +97,14 @@ XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(
     "lapack_cgeev", ComplexGeev<std::complex<float>>::Kernel, "Host");
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(
     "lapack_zgeev", ComplexGeev<std::complex<double>>::Kernel, "Host");
-
-
+XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("lapack_sgees",
+                                         RealGees<float>::Kernel, "Host");
+XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("lapack_dgees",
+                                         RealGees<double>::Kernel, "Host");
+XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(
+    "lapack_cgees", ComplexGees<std::complex<float>>::Kernel, "Host");
+XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(
+    "lapack_zgees", ComplexGees<std::complex<double>>::Kernel, "Host");
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("pocketfft", PocketFft, "Host");
 
 }  // namespace

--- a/jaxlib/lapack.cc
+++ b/jaxlib/lapack.cc
@@ -115,6 +115,16 @@ void GetLapackKernelsFromScipy() {
   ComplexGeev<std::complex<double>>::fn =
       reinterpret_cast<ComplexGeev<std::complex<double>>::FnType*>(
           lapack_ptr("zgeev"));
+  RealGees<float>::fn =
+      reinterpret_cast<RealGees<float>::FnType*>(lapack_ptr("sgees"));
+  RealGees<double>::fn =
+      reinterpret_cast<RealGees<double>::FnType*>(lapack_ptr("dgees"));
+  ComplexGees<std::complex<float>>::fn =
+      reinterpret_cast<ComplexGees<std::complex<float>>::FnType*>(
+          lapack_ptr("cgees"));
+  ComplexGees<std::complex<double>>::fn =
+      reinterpret_cast<ComplexGees<std::complex<double>>::FnType*>(
+          lapack_ptr("zgees"));
 }
 
 py::dict Registrations() {
@@ -165,6 +175,11 @@ py::dict Registrations() {
       EncapsulateFunction(ComplexGeev<std::complex<float>>::Kernel);
   dict["lapack_zgeev"] =
       EncapsulateFunction(ComplexGeev<std::complex<double>>::Kernel);
+      
+  dict["lapack_sgees"] = EncapsulateFunction(RealGees<float>::Kernel);
+  dict["lapack_dgees"] = EncapsulateFunction(RealGees<double>::Kernel);
+  dict["lapack_cgees"] = EncapsulateFunction(ComplexGees<std::complex<float>>::Kernel);
+  dict["lapack_zgees"] = EncapsulateFunction(ComplexGees<std::complex<double>>::Kernel);
   return dict;
 }
 

--- a/jaxlib/lapack_kernels.h
+++ b/jaxlib/lapack_kernels.h
@@ -149,6 +149,26 @@ struct ComplexGeev {
   static void Kernel(void* out, void** data);
 };
 
+template <typename T>
+struct RealGees {
+  using FnType = void(char* jobvs, char* sort, bool (*select)(T, T), lapack_int* n, T* a,
+                      lapack_int* lda, lapack_int* sdim, T* wr, T* wi, T* vs, lapack_int* ldvs,
+                      T* work, lapack_int* lwork, bool* bwork,
+                      lapack_int* info);
+  static FnType* fn;
+  static void Kernel(void* out, void** data);
+};
+
+template <typename T>
+struct ComplexGees {
+  using FnType = void(char* jobvs, char* sort,  bool (*select)(T), lapack_int* n, T* a,
+                      lapack_int* lda, lapack_int* sdim, T* w, T* vs, lapack_int* ldvs,
+                      T* work, lapack_int* lwork, typename T::value_type* rwork, bool* bwork,
+                      lapack_int* info);
+  static FnType* fn;
+  static void Kernel(void* out, void** data);
+};
+
 }  // namespace jax
 
 #endif  // JAXLIB_LAPACK_KERNELS_H_


### PR DESCRIPTION
This is an implementation of a wrapper for LAPACK's gees routine (in order to close #6478).

The schur primitive calls this wrapper on CPU. Tests for this primitive to make sure it matches scipy's schur decomposition and batching tests are added in tests/linalg_tests.py. 

The tests are only run if `jax._src.lib.version >= (0, 1, 72)`, they are skipped otherwise.

(This is a continuation #8014, where I really messed up my branch, I'm very sorry for the spam it may have sent out)