### PR TITLE
Fix JAX functions to work if the default gather mode is set to "fill".

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5431,7 +5431,8 @@ def _take(a, indices, axis: Optional[int] = None, out=None, mode=None):
     collapsed_slice_dims=(axis_idx,),
     start_index_map=(axis_idx,))
   return lax.gather(a, indices[..., None], dimension_numbers=dnums,
-                    slice_sizes=tuple(slice_sizes))
+                    slice_sizes=tuple(slice_sizes),
+                    mode="clip")
 
 
 def _normalize_index(index, axis_size):

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1028,7 +1028,7 @@ def _sph_harm(m: jnp.ndarray,
   cos_colatitude = jnp.cos(phi)
 
   legendre = _gen_associated_legendre(n_max, cos_colatitude, True)
-  legendre_val = legendre[abs(m), n, jnp.arange(len(n))]
+  legendre_val = legendre.at[abs(m), n, jnp.arange(len(n))].get(mode="clip")
 
   angle = abs(m) * theta
   vandermonde = lax.complex(jnp.cos(angle), jnp.sin(angle))


### PR DESCRIPTION
These functions really do want "clip".