### PR TITLE
[sparse]: make repr safe for invalid BCOO objects

### DIFF
--- a/jax/experimental/sparse/ops.py
+++ b/jax/experimental/sparse/ops.py
@@ -1394,7 +1394,15 @@ class JAXSparse:
     self.shape = shape
 
   def __repr__(self):
-    repr_ = f"{self.__class__.__name__}({self.dtype}{list(self.shape)}, nse={self.nse})"
+    name = self.__class__.__name__
+    try:
+      nse = self.nse
+      dtype = self.dtype
+      shape = list(self.shape)
+    except:
+      repr_ = f"{name}(<invalid>)"
+    else:
+      repr_ = f"{name}({dtype}{shape}, nse={nse})"
     if isinstance(self.data, core.Tracer):
       repr_ = f"{type(self.data).__name__}[{repr_}]"
     return repr_

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1113,6 +1113,13 @@ class SparseGradTest(jtu.JaxTestCase):
 
 
 class SparseObjectTest(jtu.JaxTestCase):
+  def test_repr(self):
+    M = sparse.BCOO.fromdense(jnp.arange(5, dtype='float32'))
+    assert repr(M) == "BCOO(float32[5], nse=4)"
+
+    M_invalid = sparse.BCOO(([], []), shape=100)
+    assert repr(M_invalid) == "BCOO(<invalid>)"
+
   @parameterized.named_parameters(
     {"testcase_name": "_{}".format(Obj.__name__), "Obj": Obj}
     for Obj in [sparse.CSR, sparse.CSC, sparse.COO, sparse.BCOO])


### PR DESCRIPTION
Fixes #7810

Why not validate at object creation? The issue is that JAX transforms often construct pytrees with placeholder values, so we must allow instantiation with invalid values. Long-term we may want a more pointed fix (e.g. validating at creation when possible, and otherwise returning `BCOO(<placeholder>)` or something of that ilk) but for now this fixes the main issue of tracebacks generating additonal errors.