### PR TITLE
Fixes for Python 3.10.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -156,6 +156,10 @@ config_debug_infs._add_hooks(_update_debug_special_global,
 float0 = dtypes.float0
 
 def _check_callable(fun):
+  # In Python 3.10+, the only thing stopping us from supporting staticmethods
+  # is that we can't take weak references to them, which the C++ JIT requires.
+  if isinstance(fun, staticmethod):
+    raise TypeError(f"staticmethod arguments are not supported, got {fun}")
   if not callable(fun):
     raise TypeError(f"Expected a callable value, got {fun}")
   if _isgeneratorfunction(fun):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -14,6 +14,7 @@
 
 
 import collections
+import collections.abc
 from contextlib import contextmanager
 import copy
 import enum
@@ -331,8 +332,9 @@ class CPPJitTest(jtu.BufferDonationTestCase):
         def my_classmethod_jit(cls, x):
           return x+2
 
-  def test_classmethod_is_not_supported(self):
-    with self.assertRaisesRegex(TypeError, "Expected a callable value"):
+  def test_staticmethod_is_not_supported(self):
+    with self.assertRaisesRegex(TypeError,
+                                "staticmethod arguments are not supported"):
 
       class A:
 
@@ -2133,7 +2135,7 @@ class APITest(jtu.JaxTestCase):
   def test_device_array_hash(self):
     rep = jnp.ones(()) + 1.
     self.assertIsInstance(rep, jax.interpreters.xla.DeviceArray)
-    self.assertNotIsInstance(rep, collections.Hashable)
+    self.assertNotIsInstance(rep, collections.abc.Hashable)
     with self.assertRaisesRegex(TypeError, 'unhashable type'):
       hash(rep)
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -14,6 +14,7 @@
 
 
 import collections
+import functools
 import re
 
 from absl.testing import absltest
@@ -190,6 +191,12 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(actual.func, inputs.func)
     self.assertEqual(actual.args, inputs.args)
     self.assertEqual(actual.keywords, inputs.keywords)
+
+  def testPartialDoesNotMergeWithOtherPartials(self):
+    def f(a, b, c): pass
+    g = functools.partial(f, 2)
+    h = tree_util.Partial(g, 3)
+    self.assertEqual(h.args, (3,))
 
   @parameterized.parameters(*(TREES + LEAVES))
   def testRoundtripViaBuild(self, inputs):


### PR DESCRIPTION
With these changes, the JAX test suite passes on Python 3.10.

Issue #8097 