### PR TITLE
improvements to RBG PRNG

### DIFF
--- a/jax/prng.py
+++ b/jax/prng.py
@@ -21,4 +21,5 @@ from jax._src.prng import (
   threefry_2x32 as threefry_2x32,
   threefry_prng_impl as threefry_prng_impl,
   rbg_prng_impl as rbg_prng_impl,
+  unsafe_rbg_prng_impl as unsafe_rbg_prng_impl,
 )

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1182,6 +1182,10 @@ class LaxRandomWithRBGPRNGTest(LaxRandomTest):
     # TODO(mattjj): enable this test if/when RngBitGenerator supports it
     raise SkipTest('8-bit types not supported with RBG PRNG')
 
+class LaxRandomWithUnsafeRBGPRNGTest(LaxRandomWithRBGPRNGTest):
+  def seed_prng(self, seed):
+    return prng.seed_with_impl(prng.unsafe_rbg_prng_impl, seed)
+
 def _sampler_unimplemented_with_rbg(*args, **kwargs):
   # TODO(mattjj): enable these tests if/when RngBitGenerator supports them
   raise SkipTest('8- and 16-bit types not supported with RBG PRNG')
@@ -1189,6 +1193,7 @@ def _sampler_unimplemented_with_rbg(*args, **kwargs):
 for attr in dir(LaxRandomWithRBGPRNGTest):
   if 'int8' in attr or 'int16' in attr or 'float16' in attr:
     setattr(LaxRandomWithRBGPRNGTest, attr, _sampler_unimplemented_with_rbg)
+    setattr(LaxRandomWithUnsafeRBGPRNGTest, attr, _sampler_unimplemented_with_rbg)
 
 def _sampler_unimplemented_with_custom_prng(*args, **kwargs):
   raise SkipTest('sampler only implemented for default RNG')
@@ -1213,7 +1218,8 @@ for test_prefix in [
               _sampler_unimplemented_with_custom_prng)
       setattr(LaxRandomWithRBGPRNGTest, attr,
               _sampler_unimplemented_with_custom_prng)
-
+      setattr(LaxRandomWithUnsafeRBGPRNGTest, attr,
+              _sampler_unimplemented_with_custom_prng)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. factor out rbg_prng_impl and unsafe_rbg_prng_impl. the former uses
   threefry2x32 for split and fold_in, while the latter uses untested
   heuristics based on calling rng_bit_generator itself as a kind of
   hash function
2. for unsafe_rbg_prng_impl's split and fold_in, generate longer
   sequences from rng_bit_generator (10x iterations) which may be useful on
   some backends
3. for unsafe_rbg_prng_impl, actually apply rng_bit_generator as our
   'hash function' in fold_in