### PR TITLE
[jax2tf] Improved handling of getitem for shape polymorphism

### DIFF
--- a/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
+++ b/jax/experimental/jax2tf/tests/jax_primitives_coverage_test.py
@@ -47,6 +47,7 @@ class JaxPrimitiveTest(jtu.JaxTestCase):
   # If you want to run this test for only one harness, add parameter
   # `one_containing="foo"` to parameterized below.
   @primitive_harness.parameterized(primitive_harness.all_harnesses,
+                                   #one_containing="gather_from_slicing_name",
                                    include_jax_unimpl=True)
   @jtu.ignore_warning(category=UserWarning,
                       message="Using reduced precision for gradient.*")


### PR DESCRIPTION
* give an error for NumPy indexing with slices when the elements
  of the slices are not constant. This check existed, but was
  throing an error when the elements are dimension polynomials.
* give an error for NumPy indexing with slices when the dimension
  size is not constant.
* Improvements in the handling of enable_xla=False for shape
  polymorphism.
* Added test cases for the above.