### PR TITLE
remove ShapedArray.__len__

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1159,14 +1159,11 @@ class ShapedArray(UnshapedArray):
   def strip_named_shape(self):
     return self.update(named_shape={})
 
-  def __len__(self):
+  def _len(self, ignored_tracer):
     try:
       return self.shape[0]
     except IndexError as err:
       raise TypeError("len() of unsized object") from err  # same as numpy error
-
-  def _len(self, ignored_tracer):
-    return len(self)
 
 
 def _forward_to_value(self, fun, ignored_tracer, *args):

--- a/jax/experimental/sparse/ops.py
+++ b/jax/experimental/sparse/ops.py
@@ -206,7 +206,7 @@ def _csr_matvec_abstract_eval(data, indices, indptr, v, *, shape, transpose):
   assert data.shape == indices.shape
   assert data.dtype == v.dtype
   assert indices.dtype == indptr.dtype
-  assert len(indptr) == shape[0] + 1
+  assert indptr.shape[0] == shape[0] + 1
   out_shape = shape[1] if transpose else shape[0]
   assert v.shape[0] == (shape[0] if transpose else shape[1])
   return core.ShapedArray((out_shape,), data.dtype)
@@ -258,7 +258,7 @@ def _csr_matmat_abstract_eval(data, indices, indptr, B, *, shape, transpose):
   assert data.shape == indices.shape
   assert data.dtype == B.dtype
   assert indices.dtype == indptr.dtype
-  assert len(indptr) == shape[0] + 1
+  assert indptr.shape[0] == shape[0] + 1
   out_shape = shape[1] if transpose else shape[0]
   assert B.shape[0] == (shape[0] if transpose else shape[1])
   return core.ShapedArray((out_shape, B.shape[1]), data.dtype)


### PR DESCRIPTION
It was confusing to overload, since we sometimes think of avals like shapes paired with dtypes, and in that case len(aval) should perhaps be like len(aval.shape). The only place where this behavior was relied on was sparse/ops.py.

(It bit @zhangqiaorjc recently!)