### PR TITLE
ahead-of-time lowering and compilation frontend for pjit

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1657,6 +1657,8 @@ class MeshComputation:
 
 
 class MeshExecutable:
+  __slots__ = ['xla_executable', 'unsafe_call']
+
   def __init__(self,
                computation: xc.XlaComputation,
                mesh: Mesh,
@@ -1716,10 +1718,10 @@ class MeshExecutable:
       handle_args = InputsHandler(compiled.local_devices(), local_input_specs,
                                   input_indices)
       self.unsafe_call = partial(execute_replicated, compiled, backend, handle_args, handle_outs)
-      self.compiled = compiled
+      self.xla_executable = compiled
 
-  def __call__(self, *args):
-    # TODO(apaszke): Validate arguments
+  def call(self, *args):
+    # TODO(apaszke,frostig): Check that args are compatible with input avals!
     return self.unsafe_call(*args)
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -696,7 +696,7 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     live_refs = len([ref for ref in refs if ref() is not None])
     self.assertLessEqual(live_refs, 100)
 
-  def test_lower_compile(self):
+  def test_jit_lower_compile(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
 
@@ -705,7 +705,7 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     f_exe = f_low.compile()
     self.assertAllClose(f_exe(1.), 2.)
 
-  def test_lower_compile_in_tree_mismatch(self):
+  def test_jit_lower_compile_in_tree_mismatch(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.
 
@@ -716,12 +716,12 @@ class CPPJitTest(jtu.BufferDonationTestCase):
         TypeError, "function compiled for .*, called with .*",
         lambda: f_exe([1.]))
 
-  def test_lower_compile_trivial(self):
+  def test_jit_lower_compile_trivial(self):
     def f(x): return x
     out = self.jit(f).lower(1.).compile()(4.)
     self.assertAllClose(out, 4.)
 
-  def test_lower_compile_trivial_in_tree_mismatch(self):
+  def test_jit_lower_compile_trivial_in_tree_mismatch(self):
     def f(x): return x
     f_exe = self.jit(f).lower(1.).compile()
     self.assertRaisesRegex(


### PR DESCRIPTION
Initial take on #7733 corresponding to `jax.pjit`. Generalizes some of the machinery introduced in #7997.