### PR TITLE
Fix while loop batching rule for loops with constant bodies

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -393,7 +393,7 @@ def _while_loop_batching_rule(axis_size, axis_name, main_type, args, dims,
   # reach a fixpoint.
   for _ in range(1 + len(carry_bat)):
     _, carry_bat_out = batching.batch_jaxpr(
-        body_jaxpr, axis_size, bconst_bat + carry_bat, instantiate=False,
+        body_jaxpr, axis_size, bconst_bat + carry_bat, instantiate=carry_bat,
         axis_name=axis_name, main_type=main_type)
     if carry_bat == carry_bat_out:
       break

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -357,6 +357,15 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = np.array([0, 2, 2, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  # TODO(b/202709967): Enable once fixed
+  @unittest.skipIf(jtu.device_under_test() == 'gpu', "Test triggers an internal XLA:GPU error")
+  def testWhileLoopBatchedWithConstBody(self):
+    def f(x):
+      def body_fn(_): return jnp.asarray(0., dtype=jnp.float32)
+      def cond_fn(_): return jnp.logical_not(False) == False
+      return jax.lax.while_loop(cond_fn, body_fn, x)
+    x = jnp.arange(5, dtype=jnp.float32)
+    self.assertAllClose(jax.vmap(f)(x), x)
 
   def testWhileLoopCondConstsBatched(self):
     def fun(x, y):


### PR DESCRIPTION
The previous implementation failed to reach a fixpoint when the body was
ignoring the carry and was returning an unbatched constant. Ensuring
that the result carry is at least as batched as the input carry should
fix the issue.