### PR TITLE
Disallow jax2tf translation of multi-process pjits

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -3042,6 +3042,9 @@ def _pjit(*args: TfVal,
           _in_avals: Sequence[core.ShapedArray],
           _out_aval: core.ShapedArray) -> TfVal:
   del donated_invars
+  if resource_env.physical_mesh.is_multi_process:
+    raise NotImplementedError("jax2tf translation for pjit over multi-process "
+                              "meshes is not supported yet")
   # TODO: add `name` to the name stack
   shard_value_for_mesh = partial(_shard_value, resource_env.physical_mesh)
   # Apply sharding annotation to the arguments


### PR DESCRIPTION
I'm pretty sure it doesn't handle the local/global shape boundary
correctly which likely leads to very confusing errors on the TF side.