### PR TITLE
Allow `random.choice` and `random.permutation` on multidimensional arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
     default when using jaxlib 0.1.72 or newer. The feature can be disabled using
     the `--experimental_cpp_pmap` flag (or `JAX_CPP_PMAP` environment variable).
   * `jax.numpy.unique` now supports an optional `fill_value` argument ({jax-issue}`#8121`)
+  * `jax.random.choice` and `jax.random.permutation` now support 
+    multidimensional arrays and an optional `axis` argument ({jax-issue}`#8158`)
 
 ## jax 0.2.21 (Sept 23, 2021)
 * [GitHub


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/8158.