### PR TITLE
jax.numpy: explicitly use dtypes.scalar_type when appropriate

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -476,8 +476,11 @@ def _np_array(obj, dtype=None, **kwargs):
   arr = np.array(obj, dtype=dtype, **kwargs)
   obj_dtype = getattr(obj, 'dtype', None)
   arr_dtype = np.dtype(arr.dtype).type
-  if dtype is None and obj_dtype is None and arr_dtype in _DEFAULT_TYPEMAP:
-    arr = arr.astype(_DEFAULT_TYPEMAP[arr_dtype])
+  if dtype is None and obj_dtype is None:
+    if dtypes.is_python_scalar(obj):
+      arr = arr.astype(dtypes.dtype(obj))
+    elif arr_dtype in _DEFAULT_TYPEMAP:
+      arr = arr.astype(_DEFAULT_TYPEMAP[arr_dtype])
   return arr
 
 _np_asarray = partial(_np_array, copy=False)


### PR DESCRIPTION
This should be basically a no-op in JAX's current state, but will become important with the changes in #8178, when the default scalar and array types will diverge.