### PR TITLE
work around unhashable named shapes in `ShapeDtypeStruct`

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2678,7 +2678,10 @@ class ShapeDtypeStruct:
           self.shape, self.dtype, self.named_shape)
 
   def __hash__(self):
-    return hash((self.shape, self.dtype, self.named_shape))
+    # TODO(frostig): avoid the conversion from dict by addressing
+    # https://github.com/google/jax/issues/8182
+    named = frozenset(self.named_shape.items())
+    return hash((self.shape, self.dtype, named))
 
 def eval_shape(fun: Callable, *args, **kwargs):
   """Compute the shape/dtype of ``fun`` without any FLOPs.

--- a/jax/core.py
+++ b/jax/core.py
@@ -1550,7 +1550,8 @@ class NamedShape:
     raise TypeError(f"NamedShape doesn't support comparisons with {type(other)}")
 
   def __hash__(self):
-    return hash((self.__positional, tuple(self.__named.items())))
+    named = frozenset(self.__named.items())
+    return hash((self.__positional, named))
 
 def join_named_shapes(*named_shapes):
   result = {}

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1428,6 +1428,13 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "len[(][)] of unsized object"):
       _ = len(s)
 
+  def test_shape_dtype_struct_hash(self):
+    s1 = api.ShapeDtypeStruct(shape=(2, 3), dtype=jnp.float32)
+    s2 = api.ShapeDtypeStruct(shape=(2, 3), dtype=jnp.float32)
+    s3 = api.ShapeDtypeStruct(shape=(2, 4), dtype=jnp.float32)
+    self.assertEqual(hash(s1), hash(s2))
+    self.assertNotEqual(hash(s1), hash(s3))
+
   def test_eval_shape(self):
     def fun(x, y):
       return jnp.tanh(jnp.dot(x, y) + 3.)


### PR DESCRIPTION
Addresses the hashing bug mentioned in #8182 in the near term.

Also updates `NamedShape`'s hash to be similarly order-independent.