### PR TITLE
Update jax version number.

### DIFF
--- a/jax/version.py
+++ b/jax/version.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.22"
+__version__ = "0.2.23"
 _minimum_jaxlib_version = "0.1.69"


### PR DESCRIPTION
We're switching to updating the jax version number after a release to the next version number, like jaxlib.