### PR TITLE
Remove unused variable from notebooks

### DIFF
--- a/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.ipynb
@@ -80,7 +80,6 @@
     "  return [random_layer_params(m, n, k) for m, n, k in zip(sizes[:-1], sizes[1:], keys)]\n",
     "\n",
     "layer_sizes = [784, 512, 512, 10]\n",
-    "param_scale = 0.1\n",
     "step_size = 0.01\n",
     "num_epochs = 8\n",
     "batch_size = 128\n",

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -67,7 +67,6 @@ def init_network_params(sizes, key):
   return [random_layer_params(m, n, k) for m, n, k in zip(sizes[:-1], sizes[1:], keys)]
 
 layer_sizes = [784, 512, 512, 10]
-param_scale = 0.1
 step_size = 0.01
 num_epochs = 8
 batch_size = 128

--- a/docs/notebooks/neural_network_with_tfds_data.ipynb
+++ b/docs/notebooks/neural_network_with_tfds_data.ipynb
@@ -93,7 +93,6 @@
     "  return [random_layer_params(m, n, k) for m, n, k in zip(sizes[:-1], sizes[1:], keys)]\n",
     "\n",
     "layer_sizes = [784, 512, 512, 10]\n",
-    "param_scale = 0.1\n",
     "step_size = 0.01\n",
     "num_epochs = 10\n",
     "batch_size = 128\n",

--- a/docs/notebooks/neural_network_with_tfds_data.md
+++ b/docs/notebooks/neural_network_with_tfds_data.md
@@ -75,7 +75,6 @@ def init_network_params(sizes, key):
   return [random_layer_params(m, n, k) for m, n, k in zip(sizes[:-1], sizes[1:], keys)]
 
 layer_sizes = [784, 512, 512, 10]
-param_scale = 0.1
 step_size = 0.01
 num_epochs = 10
 batch_size = 128


### PR DESCRIPTION
Both the "Training a Simple Neural Network" notebooks include a `param_scale` variable that is not used.