### PR TITLE
Consolidate primitive and jit lowering paths.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -436,7 +436,7 @@ def _cpp_jit(
         all(xla.type_is_device_array(x) for x in out_flat))
     ### If we can use the fastpath, we return required info to the caller.
     if use_fastpath:
-      xla_executable, _, result_handlers, kept_var_idx = execute.args
+      _, xla_executable, _, result_handlers, kept_var_idx = execute.args
       sticky_device = None
       avals = []
       lazy_exprs = [None] * len(result_handlers)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6111,7 +6111,8 @@ def _select_and_scatter_add_translation(
   dtype = shape.numpy_dtype()
   scalar = ShapedArray((), dtype)
   select = xla.primitive_subcomputation(select_prim, scalar, scalar)
-  scatter = xla.primitive_subcomputation(add_p, scalar, scalar)
+  scatter = xla.primitive_subcomputation(or_p if dtype == np.bool_ else add_p,
+                                         scalar, scalar)
   zero = xb.constant(c, np.array(0, dtype))
   # TODO(b/161704903): remove this workaround when XLA:CPU bug is fixed.
   expand_padding = (expand_padding and

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -356,21 +356,11 @@ def count_device_put():
 def count_primitive_compiles():
   xla.xla_primitive_callable.cache_clear()
 
-  # We count how many times we call primitive_computation (which is called
-  # inside xla_primitive_callable) instead of xla_primitive_callable so we don't
-  # count cache hits.
-  primitive_computation = xla.primitive_computation
-  count = [0]
-
-  def primitive_computation_and_count(*args, **kwargs):
-    count[0] += 1
-    return primitive_computation(*args, **kwargs)
-
-  xla.primitive_computation = primitive_computation_and_count
+  count = [-1]
   try:
     yield count
   finally:
-    xla.primitive_computation = primitive_computation
+    count[0] = xla.xla_primitive_callable.cache_info().misses
 
 
 @contextmanager

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -94,6 +94,9 @@ def high_precision_dot(a, b):
 def posify(matrix):
   return high_precision_dot(matrix, matrix.T.conj())
 
+ignore_jit_of_pmap_warning = partial(
+  jtu.ignore_warning, message=".*jit-of-pmap.*")
+
 
 class LaxControlFlowTest(jtu.JaxTestCase):
 
@@ -2446,6 +2449,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     expected = np.arange(10)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_jit_of_pmap_warning()
   def test_while_loop_of_pmap(self):
     # code from jsnoek@
 
@@ -2464,6 +2468,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
     self.assertAllClose(ans, expected, check_dtypes=False)
 
+  @ignore_jit_of_pmap_warning()
   def test_while_loop_of_pmap_error_message(self):
 
     def body(i, x):
@@ -2476,9 +2481,9 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertRaisesRegex(
         ValueError,
         re.escape(
-            "compiling a primitive computation `scan` that requires {} "
-            "replicas, but only {} XLA devices are available on backend {}."
-            .format(too_big, jax.device_count(), jtu.device_under_test())),
+            "compiling computation `scan` that requires {} "
+            "replicas, but only {} XLA devices are available."
+            .format(too_big, jax.device_count())),
         lambda: f_loop(jnp.ones(too_big)))
 
   @parameterized.named_parameters(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1182,7 +1182,8 @@ class PythonPmapTest(jtu.JaxTestCase):
     pts = jnp.ones(device_count)
     qs = jnp.asarray(((0,0), (3,3), (2,2)))
 
-    _, expected = map_version(qs, pts)
+    with ignore_jit_of_pmap_warning():
+      _, expected = map_version(qs, pts)
     _, ans = vmap_version(qs, pts)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
@@ -1574,7 +1575,8 @@ class PythonPmapTest(jtu.JaxTestCase):
 
     result1 = vmap(lambda b: matrix_vector(x, b, True))(y)       # vmap + pmap
     result2 = lax.map(lambda b: matrix_vector(x, b, False), y)   # map + map
-    result3 = lax.map(lambda b: matrix_vector(x, b, True), y)    # map + pmap
+    with ignore_jit_of_pmap_warning():
+      result3 = lax.map(lambda b: matrix_vector(x, b, True), y)    # map + pmap
     result4 = jnp.stack([matrix_vector(x, b, False) for b in y])  # none + map
 
     self.assertAllClose(result1, result2, check_dtypes=False, atol=1e-3, rtol=1e-3)
@@ -1761,7 +1763,8 @@ class PythonPmapTest(jtu.JaxTestCase):
       y = lax.cond(True, jax.pmap(identity), jax.pmap(identity), x)
       return y
 
-    cond_of_pmap(jnp.zeros((jax.device_count(), 2)))
+    with ignore_jit_of_pmap_warning():
+      cond_of_pmap(jnp.zeros((jax.device_count(), 2)))
 
   def test_static_argnum_on_method(self):
 


### PR DESCRIPTION
Before this change, primitives have a special case dispatch path that attempts
to avoid building a jaxpr in the cache miss case. However, there's no good
reason for this: it makes the code more complicated, and we're not particularly
optimizing for fast cache misses anyway (we care mostly about cache hits).

Make the primitive lowering path trace a small function using the xla_callable
lowering path instead.

As a side effect, this makes the jit-of-pmap warning trigger when using, say, `scan(pmap(...))`. This is a desirable side effect: that case is indeed slow, we just weren't warning about it before.