### PR TITLE
Remove the _num_buffers attribute from core.AbstractValue.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2613,7 +2613,8 @@ def device_put_replicated(x: Any, devices: Sequence[xc.Device]):
   def _device_put_replicated(x):
     aval = core.unmapped_aval(len(devices), core.no_axis_name, 0,
                               core.raise_to_shaped(core.get_aval(x)))
-    assert isinstance(aval, core.ShapedArray) and aval._num_buffers == 1
+    assert (isinstance(aval, core.ShapedArray) and
+            len(xla.aval_to_xla_shapes(aval)) == 1)
     buf, = xla.device_put(x, devices[0])
     rest_bufs = [buf.copy_to_device(d) for d in devices[1:]]
     return pxla.make_sharded_device_array(aval, None, [buf, *rest_bufs])

--- a/jax/core.py
+++ b/jax/core.py
@@ -886,7 +886,6 @@ def find_top_trace(xs, axis_names=None) -> Trace:
 
 class AbstractValue:
   __slots__: List[str] = []
-  _num_buffers: int = 1  # number of buffers used to represent the value.
 
   def at_least_vspace(self):
     raise NotImplementedError("must override")
@@ -918,8 +917,6 @@ class Bot(AbstractValue): pass
 bot = Bot()
 
 class AbstractUnit(AbstractValue):
-  # TODO(jakevdp): make it possible to set zero buffers
-  # _num_buffers = 0
   def at_least_vspace(self): return self
   def join(self, other):
     if config.jax_enable_checks:

--- a/tests/custom_object_test.py
+++ b/tests/custom_object_test.py
@@ -58,7 +58,6 @@ class SparseArray:
 
 class AbstractSparseArray(core.ShapedArray):
   __slots__ = ['index_dtype', 'nnz', 'data_aval', 'indices_aval']
-  _num_buffers = 2
 
   def __init__(self, shape, dtype, index_dtype, nnz, weak_type=False,
                named_shape=None):
@@ -236,7 +235,6 @@ class Empty:
     self.aval = aval
 
 class AbstractEmpty(core.AbstractValue):
-  _num_buffers = 0
 
   def join(self, other):
     assert isinstance(other, self.__class__), other


### PR DESCRIPTION
The number of buffers used to represent an abstract value is a property specific to a particular representation of that abstract value. Currently the only representation is an XLA representation, but that may change in the future. Instead, callers who want to know how the XLA lowering would represent an aval should ask the XLA module instead. In this case, call `len(xla.aval_to_xla_shapes(...))` instead.