### PR TITLE
jnp.unique: don't apply fill_value to indices

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -5576,10 +5576,7 @@ def _unique1d(ar, return_index=False, return_inverse=False,
 
   ret = (result,)
   if return_index:
-    perm_ind = perm[ind]
-    if size is not None and fill_value is not None:
-      perm_ind = where(arange(size) >= mask.sum(), fill_value, perm_ind)
-    ret += (perm_ind,)
+    ret += (perm[ind],)
   if return_inverse:
     imask = cumsum(mask) - 1
     inv_idx = zeros(mask.shape, dtype=dtypes.canonicalize_dtype(int_))
@@ -5629,10 +5626,7 @@ def _unique_axis(ar, axis, return_index=False, return_inverse=False,
   ret = (result,)
   if return_index:
     if aux.size:
-      perm_ind = perm[ind]
-      if size is not None and fill_value is not None:
-        perm_ind = where(arange(size) >= mask.sum(), fill_value, perm_ind)
-      ret += (perm_ind,)
+      ret += (perm[ind],)
     else:
       ret += (perm,)
   if return_inverse:

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2377,7 +2377,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         u_fill = u[tuple(slices)] if fill_value is None else fill_value
         slices[axis] = slice(n_unique, None)
         u[tuple(slices)] = u_fill
-        ind = np.pad(ind, extra, constant_values=ind[0] if fill_value is None else fill_value)
+        ind = np.pad(ind, extra, constant_values=ind[0])
         counts = np.pad(counts, extra, constant_values=0)
       return u, ind, inv, counts
 


### PR DESCRIPTION
Why? This is confusing because `fill_value` should match the data type, and index type will not in general be the same. If we need this feature, we should probably add an `index_fill_value` option; I'm going to punt on adding that because I'm not sure how useful it will be in practice.

This problematic behavior was added within the last few days, in #8121 and #8186. Related to #3614.