### PR TITLE
fix jax.checkpoint dce logic

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3997,6 +3997,13 @@ class RematTest(jtu.JaxTestCase):
 
     _ = api.grad(f)(3.)  # doesn't crash
 
+  def test_dce_keeps_eqns_with_used_outputs_but_no_used_inputs(self):
+    @new_checkpoint
+    def f(x):
+      c = jax.jit(lambda: 3.)()
+      return c * x
+
+    _ = jax.grad(f)(3.)  # doesn't crash
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Basically the `jax.checkpoint` `dce_jaxpr` code had an if `any(used_inputs): <keep eqn>` after applying a rule to compute the used inputs. But we need to keep the eqn if there are any used _outputs_! There can be cases where no inputs are used but some outputs are used, like constant creation. Yet this bug didn't manifest in all such cases because it only was in the path where a primitive had a DCE rule defined, which usually meant a higher-order primitive. So it'd arise for a _jitted_ constant creation!

Another condition which was necessary for this constant-creation bug to manifest was to use the new `jax.checkpoint` implementation from #8191, because the old data-dependence-based `jax.checkpoint` _wouldn't touch constant creation_! Yet of course the new "initial-style" one does, which was the main point for the new implementation.