### PR TITLE
Fix inaccurate type annotations

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -40,10 +40,10 @@ _bfloat16_dtype: np.dtype = np.dtype(bfloat16)
 
 # Default types.
 
-bool_ = np.bool_
-int_: np.dtype = np.int64  # type: ignore
-float_: np.dtype = np.float64  # type: ignore
-complex_ = np.complex128
+bool_: type = np.bool_
+int_: type = np.int64
+float_: type = np.float64
+complex_: type = np.complex128
 
 # TODO(phawkins): change the above defaults to:
 # int_ = np.int32


### PR DESCRIPTION
Each `dtype` has two associated python types, the type class (e.g. `np.float64`) and the dtype class (e.g. `np.dtype('float64')`). The annotations used in `dtypes.py` are currently assuming the wrong object:
```python
>>> isinstance(np.float64, np.dtype)
False
>>> type(np.float64)
type
>>> isinstance(np.dtype(np.float64), np.dtype)
True
```