### PR TITLE
[sparse] preserve dtype in bcoo_todense

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -156,7 +156,7 @@ def _bcoo_todense_impl(data, indices, *, shape):
   batch_ind = tuple(grid)[:-1]
 
   if not sparse_ind:
-    data = data.sum(n_batch, keepdims=bool(batch_ind))
+    data = data.sum(n_batch, keepdims=bool(batch_ind), dtype=data.dtype)
   return jnp.zeros(shape, data.dtype).at[batch_ind + sparse_ind].add(data)
 
 @bcoo_todense_p.def_abstract_eval

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -384,7 +384,7 @@ class BCOOTest(jtu.JaxTestCase):
         jtu.format_shape_dtype_string(shape, dtype), n_batch, n_dense),
        "shape": shape, "dtype": dtype, "n_batch": n_batch, "n_dense": n_dense}
       for shape in [(5,), (5, 8), (8, 5), (3, 4, 5), (3, 4, 3, 2)]
-      for dtype in jtu.dtypes.floating + jtu.dtypes.complex
+      for dtype in jtu.dtypes.integer + jtu.dtypes.floating + jtu.dtypes.complex
       for n_batch in range(len(shape) + 1)
       for n_dense in range(len(shape) + 1 - n_batch)))
   def test_bcoo_dense_round_trip(self, shape, dtype, n_batch, n_dense):


### PR DESCRIPTION
Because `data.sum()` will cast integers to higher precision, we need to explicitly set the dtype here. Issue uncovered by #8180.