### PR TITLE
WIP: named call context manager

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -600,7 +600,7 @@ default_matmul_precision = config.define_enum_state(
 traceback_filtering = config.define_enum_state(
     name = 'jax_traceback_filtering',
     enum_values=["off", "tracebackhide", "remove_frames", "auto"],
-    default="auto",
+    default="off",
     help="Controls how JAX filters internal frames out of tracebacks.\n\n"
          "Valid values are:\n"
          " * \"off\": disables traceback filtering.\n"

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -340,7 +340,7 @@ def _while_loop_translation_rule(ctx, avals_in, avals_out, *args, cond_jaxpr,
   cond_carry = xb.parameter(cond_c, 0, c.get_shape(init_carry))
   cond_carry_elts = [xops.GetTupleElement(cond_carry, i) for i in range(len(args))]
   x, _, z = split_list(cond_carry_elts, [cond_nconsts, body_nconsts])
-  name_stack = source_info_util.current_name_stack().extend('while')
+  name_stack = ctx.name_stack.extend('while')
   cond_ctx = ctx.replace(builder=cond_c, name_stack=name_stack.extend('cond'))
   pred, = xla.jaxpr_subcomp(
       cond_ctx, cond_jaxpr.jaxpr,
@@ -802,9 +802,7 @@ def _cond_abstract_eval(*args, **kwargs):
 def _cond_translation_rule(ctx, avals_in, avals_out, index, *args, branches,
                            linear):
   del linear  # Unused.
-  name_stack = source_info_util.current_name_stack()
-
-  name_stack = name_stack.extend("cond")
+  name_stack = ctx.name_stack.extend("cond")
   def make_computation(name, jaxpr, op_shape):
     c = xla_client.XlaBuilder(name + '_comp')
     op = xb.parameter(c, 0, op_shape)

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -128,8 +128,11 @@ def register_pytree_node(nodetype: Type[T],
       unflattened children. The function should return an instance of
       ``nodetype``.
   """
-  pytree.register_node(nodetype, flatten_func, unflatten_func)
-  _registry[nodetype] = _RegistryEntry(flatten_func, unflatten_func)
+  try:
+    pytree.register_node(nodetype, flatten_func, unflatten_func)
+    _registry[nodetype] = _RegistryEntry(flatten_func, unflatten_func)
+  except ValueError:
+    pass
 
 def register_pytree_node_class(cls):
   """Extends the set of types that are considered internal nodes in pytrees.

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1371,10 +1371,10 @@ def _rewrite_jaxpr(jaxpr: core.Jaxpr, has_input_token: bool,
     # We need tokens but none is given in input; make one depending on all invars
     eqns.append(
         core.new_jaxpr_eqn(jaxpr.invars, [last_token_var],
-                           lax.create_token_p, {}, source_info_util.current()))
+                           lax.create_token_p, {}, source_info_util.current_traceback()))
     eqns.append(
         core.new_jaxpr_eqn(jaxpr.invars, [last_itoken_var],
-                           lax.create_token_p, {}, source_info_util.current()))
+                           lax.create_token_p, {}, source_info_util.current_traceback()))
 
   for eqn in jaxpr.eqns:
     if not xla.primitive_uses_outfeed(eqn.primitive, eqn.params):

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -821,7 +821,7 @@ class TensorFlowTrace(core.Trace):
     if _thread_local_state.include_xla_op_metadata:
       op_metadata = xla.make_op_metadata(primitive, params,
                                          name_stack=_get_current_name_stack(),
-                                         source_info=source_info_util.current())
+                                         source_info=source_info_util.current_traceback())
       op_metadata_proto = xla_data_pb2.OpMetadata(
           op_type=op_metadata.op_type,
           op_name=op_metadata.op_name,

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -842,7 +842,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # A simple example
     # The user_frame is used to compute line numbers for ops in the test.
-    user_frame = source_info_util.user_frame(source_info_util.current())
+    user_frame = source_info_util.user_frame(source_info_util.current_traceback())
     def f_simple(x):
       return jnp.sin(x)
 
@@ -861,7 +861,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # Calling a jitted-function
     # The user_frame is used to compute line numbers for ops in the test.
-    user_frame = source_info_util.user_frame(source_info_util.current())
+    user_frame = source_info_util.user_frame(source_info_util.current_traceback())
     def f_callee(x):
       return jnp.cos(x)
     def f_caller(x):
@@ -895,7 +895,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # Calling a jax.named_call
     # The user_frame is used to compute line numbers for ops in the test.
-    user_frame = source_info_util.user_frame(source_info_util.current())
+    user_frame = source_info_util.user_frame(source_info_util.current_traceback())
     def f_callee(x):
       return jnp.cos(x)
     def f_caller(x):
@@ -929,7 +929,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # An example with while and cond
     # The user_frame is used to compute line numbers for ops in the test.
-    user_frame = source_info_util.user_frame(source_info_util.current())
+    user_frame = source_info_util.user_frame(source_info_util.current_traceback())
     def f_while_cond(x):
       def body_fun(i_acc):
         i, acc = i_acc
@@ -970,7 +970,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     self.skipTest("include_xla_op_metadata not yet enabled")
     # An example with while and cond
     # The user_frame is used to compute line numbers for ops in the test.
-    user_frame = source_info_util.user_frame(source_info_util.current())
+    user_frame = source_info_util.user_frame(source_info_util.current_traceback())
     @jax.vmap
     def f_while(x):
       def body_fun(carry):

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1020,7 +1020,7 @@ def _dynamic_jaxpr_process_xmap(self, primitive, f, tracers, params):
   out_avals = [_insert_aval_axes(a, a_out_axes, local_axis_sizes)
                for a, a_out_axes in zip(mapped_out_avals, out_axes)]
   _check_out_avals_vs_out_axes(out_avals, out_axes, params['global_axis_sizes'])
-  source_info = source_info_util.current()
+  source_info = source_info_util.current_traceback()
   out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
   invars = map(self.getvar, tracers)
   constvars = map(self.getvar, map(self.instantiate_const, consts))
@@ -1177,7 +1177,7 @@ def _jaxpr_trace_process_xmap(self, primitive, f: lu.WrappedFun, tracers, params
 
   eqn = new_eqn_recipe((*const_tracers, *unknown_tracers_in),
                        unknown_tracers_out,
-                       primitive, new_params, source_info_util.current())
+                       primitive, new_params, source_info_util.current_traceback())
   for t in unknown_tracers_out: t.recipe = eqn
   return pe._zip_knowns(known_tracers_out, unknown_tracers_out, out_unknowns)
 pe.JaxprTrace.process_xmap = _jaxpr_trace_process_xmap

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -638,7 +638,7 @@ def _pjit_partial_eval(trace, *in_tracers,
                           unknown_tracers_out,
                           pjit_p,
                           unknown_params,
-                          source_info_util.current())
+                          source_info_util.current_traceback())
   for t in unknown_tracers_out: t.recipe = eqn
   return pe._zip_knowns(known_tracers_out, unknown_tracers_out, unknown_outs)
 pe.custom_partial_eval_rules[pjit_p] = _pjit_partial_eval

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import contextlib
 import functools
 from functools import partial
 import itertools as it
@@ -40,20 +41,24 @@ map = safe_map
 def identity(x): return x
 
 
-def jvp(fun: lu.WrappedFun, has_aux=False, instantiate=True) -> Any:
+def jvp(fun: lu.WrappedFun, has_aux=False, instantiate=True,
+    transform_stack=True) -> Any:
   if not has_aux:
-    return jvpfun(jvp_subtrace(fun), instantiate)
+    return jvpfun(jvp_subtrace(fun), instantiate, transform_stack)
   else:
     fun, aux = jvp_subtrace_aux(fun)
-    return jvpfun(fun, instantiate), aux
+    return jvpfun(fun, instantiate, transform_stack), aux
 
 
 @lu.transformation
-def jvpfun(instantiate, primals, tangents):
+def jvpfun(instantiate, transform_stack, primals, tangents):
   tangents = [Zero.from_value(t) if not isinstance(t, Zero)
               and dtype(t) is float0 else t for t in tangents]
   with core.new_main(JVPTrace) as main:
-    out_primals, out_tangents = yield (main, primals, tangents), {}
+    ctx = (source_info_util.transform_name_stack('jvp') if transform_stack
+        else contextlib.nullcontext())
+    with ctx:
+      out_primals, out_tangents = yield (main, primals, tangents), {}
     del main
   if type(instantiate) is bool:
     instantiate = [instantiate] * len(out_tangents)
@@ -120,7 +125,7 @@ def vjp(traceable, primals, has_aux=False, reduce_axes=()):
   def unbound_vjp(pvals, jaxpr, consts, *cts):
     cts = tuple(map(ignore_consts, cts, pvals))
     dummy_args = [UndefinedPrimal(v.aval) for v in jaxpr.invars]
-    arg_cts = backward_pass(jaxpr, reduce_axes, consts, dummy_args, cts)
+    arg_cts = backward_pass(jaxpr, reduce_axes, True, consts, dummy_args, cts)
     return map(instantiate_zeros, arg_cts)
 
   # Ensure that vjp_ is a PyTree so that we can pass it from the forward to the backward
@@ -162,7 +167,9 @@ def recast_to_float0(primal, tangent):
     return tangent
 
 # NOTE: The FIXMEs below are caused by primal/tangent mixups (type errors if you will)
-def backward_pass(jaxpr: core.Jaxpr, reduce_axes, consts, primals_in, cotangents_in):
+def backward_pass(jaxpr: core.Jaxpr, reduce_axes, transform_stack, consts, primals_in, cotangents_in):
+  ctx = (source_info_util.transform_name_stack('transpose') if transform_stack
+      else contextlib.nullcontext())
   if all(type(ct) is Zero for ct in cotangents_in):
     return map(lambda v: Zero(v.aval), jaxpr.invars)
 
@@ -207,35 +214,38 @@ def backward_pass(jaxpr: core.Jaxpr, reduce_axes, consts, primals_in, cotangents
   map(write_primal, jaxpr.invars, primals_in)
 
   ct_env: Dict[Any, Any] = {}
-  map(partial(write_cotangent, 'outvars'), jaxpr.outvars, cotangents_in)
-  for eqn in jaxpr.eqns[::-1]:
-    # FIXME: Some invars correspond to tangents
-    invals = map(read_primal, eqn.invars)
-    if eqn.primitive.multiple_results:
-      cts_in = map(read_cotangent, eqn.outvars)
-    else:
-      cts_in, = map(read_cotangent, eqn.outvars)
-    with source_info_util.user_context(eqn.source_info):
-      if eqn.primitive.call_primitive or eqn.primitive.map_primitive:
-        cts_in_avals = [v.aval for v in eqn.outvars]
-        call_jaxpr, params = core.extract_call_jaxpr(eqn.primitive, eqn.params)
-        cts_out = get_primitive_transpose(eqn.primitive)(
-            params, call_jaxpr, invals, cts_in, cts_in_avals, reduce_axes)
-      elif eqn.primitive in reducing_transposes:
-        cts_out = reducing_transposes[eqn.primitive](
-            reduce_axes, cts_in, *invals, **eqn.params)
+  with ctx:
+    map(partial(write_cotangent, 'outvars'), jaxpr.outvars, cotangents_in)
+    for eqn in jaxpr.eqns[::-1]:
+      # FIXME: Some invars correspond to tangents
+      invals = map(read_primal, eqn.invars)
+      if eqn.primitive.multiple_results:
+        cts_in = map(read_cotangent, eqn.outvars)
       else:
-        cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals,
-                                                         **eqn.params)
-    cts_out = [Zero(v.aval) for v in eqn.invars] if cts_out is Zero else cts_out
-    # FIXME: Some invars correspond to primals!
-    map(partial(write_cotangent, eqn.primitive), eqn.invars, cts_out)
+        cts_in, = map(read_cotangent, eqn.outvars)
+      name_stack = source_info_util.current_name_stack() + eqn.source_info.name_stack
+      with source_info_util.user_context(eqn.source_info.traceback,
+          name_stack=name_stack):
+        if eqn.primitive.call_primitive or eqn.primitive.map_primitive:
+          cts_in_avals = [v.aval for v in eqn.outvars]
+          call_jaxpr, params = core.extract_call_jaxpr(eqn.primitive, eqn.params)
+          cts_out = get_primitive_transpose(eqn.primitive)(
+              params, call_jaxpr, invals, cts_in, cts_in_avals, reduce_axes)
+        elif eqn.primitive in reducing_transposes:
+          cts_out = reducing_transposes[eqn.primitive](
+              reduce_axes, cts_in, *invals, **eqn.params)
+        else:
+          cts_out = get_primitive_transpose(eqn.primitive)(cts_in, *invals,
+                                                           **eqn.params)
+        cts_out = [Zero(v.aval) for v in eqn.invars] if cts_out is Zero else cts_out
+        # FIXME: Some invars correspond to primals!
+        map(partial(write_cotangent, eqn.primitive), eqn.invars, cts_out)
 
   cotangents_out = map(read_cotangent, jaxpr.invars)
   return cotangents_out
 
-def closed_backward_pass(jaxpr: core.ClosedJaxpr, reduce_axes, primals_in, cotangents_in):
-  return backward_pass(jaxpr.jaxpr, reduce_axes, jaxpr.consts, primals_in, cotangents_in)
+def closed_backward_pass(jaxpr: core.ClosedJaxpr, reduce_axes, transform_stack, primals_in, cotangents_in):
+  return backward_pass(jaxpr.jaxpr, reduce_axes, transform_stack, jaxpr.consts, primals_in, cotangents_in)
 
 
 class UndefinedPrimal:
@@ -548,7 +558,8 @@ def traceable(num_primals, in_tree_def, *primals_and_tangents):
 
 def call_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
   all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
-  fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr, reduce_axes)
+  fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr,
+      reduce_axes, True)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   new_params = dict(params, name=wrap_name(params['name'], 'transpose'))
   update_params = call_transpose_param_updaters.get(primitive)
@@ -576,7 +587,7 @@ def remat_transpose(params, call_jaxpr, primals_in, cotangents_in,
     residuals = core.jaxpr_as_fun(primal_jaxpr)(*primals_in)[len(cotangents_in):]
     # Now that we have a purely linear jaxpr, we can transpose it
     cotangents_out = backward_pass(
-        tangent_jaxpr.jaxpr, reduce_axes, (), primals_in + residuals, cotangents_in)
+        tangent_jaxpr.jaxpr, reduce_axes, True (), primals_in + residuals, cotangents_in)
     # backward_pass will return cotangents computed for all invars, but some of them
     # are residuals appended by partial eval, so we need to skip those before we return.
     return cotangents_out[:len(primals_in)]
@@ -638,7 +649,8 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
 def jvp_jaxpr(jaxpr, nonzeros, instantiate):
   assert len(jaxpr.in_avals) == len(nonzeros)
   f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
-  f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate), nonzeros)
+  f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate,
+    transform_stack=False), nonzeros)
   tangent_avals = [aval for aval, nz in zip(jaxpr.in_avals, nonzeros) if nz]
   avals_in = list(it.chain(jaxpr.in_avals, tangent_avals))
   jaxpr_out, avals_out, literals_out = pe.trace_to_jaxpr_dynamic(f_jvp, avals_in)

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -575,9 +575,9 @@ def jaxpr_subcomp(ctx: TranslationContext, jaxpr: core.Jaxpr,
       raise NotImplementedError(
           f"XLA translation rule for primitive '{eqn.primitive.name}' not found")
 
-    with source_info_util.user_context(eqn.source_info.traceback):
-      ans = rule(ctx, map(aval, eqn.invars), map(aval, eqn.outvars),
-                 *in_nodes, **eqn.params)
+    eqn_ctx = ctx.replace(name_stack=source_info.name_stack)
+    ans = rule(eqn_ctx, map(aval, eqn.invars), map(aval, eqn.outvars),
+               *in_nodes, **eqn.params)
 
     assert isinstance(ans, collections.abc.Sequence), (ans, eqn)
     assert all(isinstance(x, xe.XlaOp) for x in ans), (ans, eqn)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6281,7 +6281,11 @@ class NamedCallTest(jtu.JaxTestCase):
       return my_test_function(x)
 
     c = jax.xla_computation(f)(2)
-    self.assertIn("my_test_function", c.as_hlo_text())
+    print_opts = xla_client._xla.HloPrintOptions.short_parsable()
+    print_opts.print_metadata = True
+    hlo_text = c.as_hlo_module().to_string(print_opts)
+    print(hlo_text)
+    self.assertIn("my_test_function", hlo_text)
 
   def test_non_jaxtype_arg(self):
     # For the test to fail without the invalid JaxType filter we need to pass


### PR DESCRIPTION
This draft PR will track the progress on the WIP named call context manager implementation. 

Feature completeness:
- [x] Simple context manager usage
  - [x] Inline

    <details>
      <summary>Example</summary>
  
      ```python
      def f(x):
        with extend_name_stack('foo'):
          y = x * 2.
        with extend_name_stack('bar'):
          with extend_name_stack('baz'):
            return jnp.square(y) + 3.
      ```
      Expected jaxpr:
      ```
      { lambda ; a:f32[]. let
          b:f32[] = mul a 2.0          # [foo]
          c:f32[] = integer_pow[y=2] b # [bar/baz]
          d:f32[] = add c 3.0          # [bar/baz]
        in (d,) }
      ```
    </details>
  - [x] Usage with call primitives
    <details>
      <summary>Example</summary>
  
      ```python
      @functools.partial(jax.named_call, name='baz')
      @jax.jit
      def f(x):
        with extend_name_stack('foo'):
          return jax.named_call(lambda x: jnp.square(x * 2.) + 3., name='bar')(x)
      ```
      Expected jaxpr: 
      ```
      { lambda ; a:f32[]. let
          b:f32[] = xla_call[                  # [baz]
            backend=None
            call_jaxpr={ lambda ; c:f32[]. let
                d:f32[] = mul c 2.0            # [foo/bar]
                e:f32[] = integer_pow[y=2] d   # [foo/bar]
                f:f32[] = add e 3.0            # [foo/bar]
              in (f,) }
            device=None
            donated_invars=(False,)
            inline=False
            name=f
          ] a
    in (b,) }
      ```
    </details>
  
- [x] Transformations
  - [x] vmap
    <details>
      <summary>Example</summary>
  
      ```python
      @jax.vmap
      def f(x):
        with extend_name_stack('foo'):
          return jnp.square(x * 2.) + 3.
      ```
      Expected jaxpr: 
      ```
      { lambda ; a:f32[3]. let
          b:f32[3] = mul a 2.0          # [vmap(foo)]
          c:f32[3] = integer_pow[y=2] b # [vmap(foo)]
          d:f32[3] = add c 3.0          # [vmap(foo)]
        in (d,) }
      ```
      </details>

  - [x] JVP
    <details>
      <summary>Example</summary>
  
      ```python
      @jax.named_call
      def f(x):
        with extend_name_stack('bar'):
          y = jax.jit(lambda x: x * jnp.ones((5, 2)))(x)
        with extend_name_stack('baz'):
          return jnp.sum(y)

     (lambda x, t: jax.jvp(f, (x,), (t,)))(jnp.ones((5, 2)), jnp.ones((5, 2)))
      ```
      Expected jaxpr: 
      ```
      { lambda ; a:f32[5,2] b:f32[5,2]. let
          c:f32[5,2] = broadcast_in_dim[broadcast_dimensions=() shape=(5, 2)] 1.0 # [jvp(f)/jvp(bar)]
          d:f32[5,2] = mul a c                                                    # [jvp(f)/jvp(bar)]
          e:f32[5,2] = mul b c                                                    # [jvp(f)/jvp(bar)]
          f:f32[] = reduce_sum[axes=(0, 1)] d                                     # [jvp(f)/jvp(baz)]
          g:f32[] = reduce_sum[axes=(0, 1)] e                                     # [jvp(f)/jvp(baz)]
        in (f, g) }
      ```
      </details>
  - [x] grad
    <details>
      <summary>Example</summary>
  
      ```python
      @functools.partial(jax.vmap, out_axes=None)
      @jax.grad
      @functools.partial(jax.named_call, name='foo')
      def f(x):
        with extend_name_stack('bar'):
          y = x * jnp.ones((5, 2))
          return jnp.sum(y)
      ```
      Expected jaxpr: 
      ```
      { lambda ; a:f32[3,5,2]. let
          b:f32[5,2] = broadcast_in_dim[broadcast_dimensions=() shape=(5, 2)] 1.0        # [vmap(jvp(foo))/vmap(jvp(bar))]
          c:f32[3,5,2] = broadcast_in_dim[broadcast_dimensions=(1, 2) shape=(3, 5, 2)] b # [vmap(jvp(foo))/vmap(jvp(bar))]
          d:f32[3,5,2] = mul a c                                                         # [vmap(jvp(foo))/vmap(jvp(bar))]
          _:* = reduce_sum[axes=(1, 2)] d                                                # [vmap(jvp(foo))/vmap(jvp(bar))]
          e:f32[5,2] = broadcast_in_dim[broadcast_dimensions=() shape=(5, 2)] 1.0        # [vmap(transpose(jvp(foo)))/vmap(transpose(jvp(bar)))]
          f:f32[5,2] = mul e b                                                           # [vmap(transpose(jvp(foo)))/vmap(transpose(jvp(bar)))]
        in (f,) }
      ```
      </details>

  - [x] pmap
  
- [x]  Control flow
  - [x] while_loop
  - [x] scan
  - [x] cond
- [ ] Test suite