### PR TITLE
Fix broken link to experimental/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For a deeper dive into JAX:
 notebooks](https://github.com/google/jax/tree/main/docs/notebooks).
 
 You can also take a look at [the mini-libraries in
-`jax.example_libraries`](https://github.com/google/jax/tree/main/jax/experimental/README.md),
+`jax.example_libraries`](https://github.com/google/jax/tree/main/jax/example_libraries/README.md),
 like [`stax` for building neural
 networks](https://github.com/google/jax/tree/main/jax/example_libraries/README.md#neural-net-building-with-stax)
 and [`optimizers` for first-order stochastic


### PR DESCRIPTION
Hey there! I just happened to notice this broken link when looking over your docs, figured I'd send a fix.