### PR TITLE
jnp.histogramdd: more succinct density computation

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1332,13 +1332,9 @@ def histogramdd(sample, bins=10, range=None, weights=None, density=None):
   hist = hist[core]
 
   if density:
-    s = sum(hist)
-    for i in builtins.range(D):
-      _shape = np.ones(D, int)
-      _shape[i] = nbins[i] - 2
-      hist = hist / reshape(dedges[i], _shape)
-
-    hist /= s
+    hist /= hist.sum()
+    for norm in ix_(*dedges):
+      hist /= norm
 
   return hist, bin_edges_by_dim
 


### PR DESCRIPTION
I think when this was implemented, `jnp.ix_` wasn't yet available.