### PR TITLE
odeint: args validation allows pytrees

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -36,7 +36,7 @@ from jax import custom_derivatives
 from jax import lax
 from jax._src.util import safe_map, safe_zip
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import tree_map
+from jax.tree_util import tree_leaves, tree_map
 from jax import linear_util as lu
 
 map = safe_map
@@ -165,7 +165,7 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
     point in `t`, represented as an array (or pytree of arrays) with the same
     shape/structure as `y0` except with a new leading axis of length `len(t)`.
   """
-  for arg in args:
+  for arg in tree_leaves(args):
     if not isinstance(arg, core.Tracer) and not core.valid_jaxtype(arg):
       msg = ("The contents of odeint *args must be arrays or scalars, but got "
              "\n{}.")


### PR DESCRIPTION
Fixes issue introduced by #8315