### PR TITLE
Add truncated_normal initializer

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -44,6 +44,12 @@ def normal(stddev=1e-2, dtype=jnp.float_):
     return random.normal(key, shape, dtype) * stddev
   return init
 
+def truncated_normal(stddev=1e-2, lower=-2, upper=2, dtype=jnp.float_):
+  def init(key, shape, dtype=dtype):
+    dtype = dtypes.canonicalize_dtype(dtype)
+    return random.truncated_normal(key, lower, upper, shape, dtype) * stddev
+  return init
+
 def _compute_fans(shape: core.NamedShape, in_axis=-2, out_axis=-1):
   receptive_field_size = shape.total / shape[in_axis] / shape[out_axis]
   fan_in = shape[in_axis] * receptive_field_size

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -47,6 +47,7 @@ def normal(stddev=1e-2, dtype=jnp.float_):
 def truncated_normal(stddev=1e-2, lower=-2, upper=2, dtype=jnp.float_):
   def init(key, shape, dtype=dtype):
     dtype = dtypes.canonicalize_dtype(dtype)
+    stddev = jnp.sqrt(variance) / jnp.array(.87962566103423978, dtype)
     return random.truncated_normal(key, lower, upper, shape, dtype) * stddev
   return init
 


### PR DESCRIPTION
Adds a truncated_normal initializer that does not use variance scaling depending on the input dimensions.