### PR TITLE
Add init_system API for multi-host GPU.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.24...main).
 
+* New features:
+  * (Experimental) `jax.distributed.initialize` exposes multi-host GPU backend.
 * Breaking changes
   * Moved `jax.experimental.stax` to `jax.example_libraries.stax`
   * Moved `jax.experimental.optimizers` to `jax.example_libraries.optimizers`

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -120,6 +120,7 @@ from .version import __version__ as __version__
 # jax and rely on the names imported above.
 from . import abstract_arrays as abstract_arrays
 from . import api_util as api_util
+from . import distributed as distributed
 from . import dtypes as dtypes
 from . import errors as errors
 from . import image as image

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+from absl import logging
+from jax._src.lib import xla_bridge
+from jax._src.lib import xla_client
+from jax._src.lib import xla_extension
+
+_service = None
+def initialize(coordinator_address: str, num_processes: int, process_id: int):
+  """Initialize distributed system for topology discovery.
+
+  Currently, calling ``initialize`` sets up the multi-host GPU backend, and
+  is not required for CPU or TPU backends.
+
+  Args:
+    coordinator_address: IP address of the coordinator.
+    num_processes: Number of processes.
+    process_id: Id of the current processe.
+
+  Example:
+
+  Suppose there are two GPU hosts, and host 0 is the designated coordinator
+  with address '10.0.0.1:1234', to initialize the GPU cluster, run the
+  following commands before anything else.
+
+  On host 0
+  >>> jax.distributed.initialize('10.0.0.1:1234', 2, 0)  # doctest: +SKIP
+
+  On host 1
+  >>> jax.distributed.initialize('10.0.0.1:1234', 2, 1)  # doctest: +SKIP
+  """
+  if process_id == 0:
+    global _service
+    assert _service is None, 'initialize should be called once only'
+    logging.info('Starting JAX distributed service on %s', coordinator_address)
+    _service = xla_extension.get_distributed_runtime_service(coordinator_address,
+                                                             num_processes)
+
+  client = xla_extension.get_distributed_runtime_client(coordinator_address,
+                                                        process_id)
+  logging.info('Connecting to JAX distributed service on %s', coordinator_address)
+  client.connect()
+
+  factory = functools.partial(xla_client.make_gpu_client, client, process_id)
+  xla_bridge.register_backend_factory('gpu', factory, priority=300)

--- a/jax/distributed.py
+++ b/jax/distributed.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa: F401
+from jax._src.distributed import initialize


### PR DESCRIPTION
Currently JAX doesn't expose our multi-host GPU backend to our open source users.

This PR exposes an experimental API `jax.distributed.initialize` to initialize the multi-host GPU backend.

I tested it on 2 GPU VMs on GCP

== VM0
```bash
$ TF_CPP_MIN_LOG_LEVEL=0 python -c "import jax; jax.distributed.initialize('10.128.0.47:1456', 2, 0)"
2021-10-26 01:19:17.133471: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/service.cc:369] Jax service listening on 10.128.0.47:1456
2021-10-26 01:19:28.339404: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:129] Connected to distributed JAX controller
2021-10-26 01:19:28.375758: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:163] Waiting for all distributed JAX tasks to shut down.
2021-10-26 01:19:28.376179: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:180] Distributed task shutdown result: OK
2021-10-26 01:19:28.397722: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/service.cc:381] Jax service shutting down
```
== VM1
```bash
$ TF_CPP_MIN_LOG_LEVEL=0 python -c "import jax; jax.distributed.initialize('10.128.0.47:1456', 2, 1)"
2021-10-26 01:19:28.339474: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:129] Connected to distributed JAX controller
2021-10-26 01:19:28.371461: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:163] Waiting for all distributed JAX tasks to shut down.
2021-10-26 01:19:28.376473: I external/org_tensorflow/tensorflow/compiler/xla/pjrt/distribute
d/client.cc:180] Distributed task shutdown result: OK
```

An example of this API in action, see code that does model parallelism on 2 GPU VMs

https://gist.github.com/zhangqiaorjc/0ae6e7114fb0b3e9243e6420e4d6f3e4

See screenshot for results

https://photos.google.com/share/AF1QipMfIpFOpmckl86lU4WS4nb2IzMDkrOqLyafa4C3Vx7zMqoyy6NOM8PiS8gH7zaLIw?key=bjVRWHZoRmFUTkhhLVBOdzFlYWg4bG5nZ3NJYVpB