### PR TITLE
DOC: pin jupyter-core to fix RTD build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ sphinx_rtd_theme
 sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2
 myst-nb
+jupyter-core!=4.9.0  # https://github.com/jupyter/jupyter_core/issues/246
 
 # Packages used for CI tests.
 pytest


### PR DESCRIPTION
Our readthedocs build was broken by jupyter-core v4.9.0 (see https://github.com/jupyter/jupyter_core/issues/246); this should fix it until the new release.