### PR TITLE
Support reshape/concatenate/broadcast on PRNGKeyArrays.

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1237,6 +1237,49 @@ class LaxRandomWithUnsafeRBGPRNGTest(LaxRandomWithRBGPRNGTest):
   def seed_prng(self, seed):
     return prng.seed_with_impl(prng.unsafe_rbg_prng_impl, seed)
 
+@skipIf(not config.jax_enable_custom_prng,
+        'custom PRNG tests require config.jax_enable_custom_prng')
+class JnpWithPRNGKeyArrayTest(jtu.JaxTestCase):
+  def test_reshape(self):
+    key = random.PRNGKey(123)
+    keys = random.split(key, 4)
+    keys = jnp.reshape(keys, (2, 2))
+    self.assertEqual(keys.shape, (2, 2))
+
+  def test_tile(self):
+    key = random.PRNGKey(123)
+    keys = jnp.tile(key, 3)
+    self.assertEqual(keys.shape, (3,))
+
+  def test_concatenate(self):
+    key = random.PRNGKey(123)
+    keys = random.split(key, 2)
+    keys = jnp.concatenate([keys, keys, keys], axis=0)
+    self.assertEqual(keys.shape, (3, 2))
+
+  def test_broadcast_to(self):
+    key = random.PRNGKey(123)
+    keys = jnp.broadcast_to(key, (3,))
+    self.assertEqual(keys.shape, (3,))
+
+  def test_broadcast_arrays(self):
+    key = random.PRNGKey(123)
+    keys = jax.random.split(key, 3)
+    key, _ = jnp.broadcast_arrays(key, keys)
+    self.assertEqual(key.shape, (3,))
+
+  def test_append(self):
+    key = random.PRNGKey(123)
+    keys = jnp.append(key, key)
+    self.assertEqual(keys.shape, (2, 1))
+
+  def test_ravel(self):
+    key = random.PRNGKey(123)
+    keys = jax.random.split(key, 4)
+    keys = jnp.reshape(keys, (2, 2))
+    keys = jnp.ravel(keys)
+    self.assertEqual(keys.shape, (4,))
+
 def _sampler_unimplemented_with_rbg(*args, **kwargs):
   # TODO(mattjj): enable these tests if/when RngBitGenerator supports them
   raise SkipTest('8- and 16-bit types not supported with RBG PRNG')


### PR DESCRIPTION
`PRNGKeyArrays` (which are currently behind the `enable_custom_prng` flag) do not support any `jnp` operations. This makes sense for operations which act on the value of a key (we shouldn't support operations like `key0 + key1`), but we want to keep supporting operations which are agnostic about the value of a key  (eg. a `broadcast`). 

This PR adds a way to overload `jnp.reshape`, `jnp.concatenate` and `jnp.broadcast`, then overloads them for `PRNGKeyArrays`. The claim is that overloading these three operations is sufficient to support most `jnp` functions users care about.

Given we support  `reshape`, `concatenate` and `broadcast`, there are some `jnp` functions we get for free (eg. `tile`), but there are some which are implemented in terms of `lax` primitives like `lax.expand_dims` instead. The motivation for this is described in https://github.com/google/jax/pull/3217 (preserve the notion of axis identity for reshapes which add/remove singleton dimensions)
 
I see two options to support these functions:
- overload `expand_dims` and `squeeze` for `PRNGKeyArrays`
- rewrite `jnp.expand_dims/squeeze` to use `reshape`/`broadcast` instead

Happy to discuss what operations should be supported here, and how best to go about it :)

----
For completeness, here's an enumeration of `jnp` functions which we _could_ support for PRNGKeyArrays, and what needs to be overloaded to support them.  

I see 5 categories of `jnp` functions, in terms of the base ops they are implemented with:
1. operations which are implemented in terms of reshape/concatenate/broadcast, and we get for free (eg. `append`)
2. **operations which use expand_dims/squeeze, but could be implemented with reshapes (eg. `stack`)**
3. operations which use indexing (which we probably don't want to support?) (eg. `delete`)
4. operations which create/cast to arrays (should we support `jnp.array(PRNGKeyArray)`?)
5. transposes (shuffling of elements)

(Incomplete) list of `jnp` operations which we could support for PRNGKeyArrays and their categories (see above):
jnp op | implemented with.. | category
-- | -- | --
atleast_1d | reshape+array | 4
atleast_2d | expand_dims+array | 4
append(arr, values[, axis]) | concatenate | 1
array(object[, dtype, copy, order, ndmin, …]) | array | 4
array_split(ary, indices_or_sections[, axis]) | split=slice | 3
asarray(a[, dtype, order]) | array | 4
broadcast_arrays(*args) | broadcast_to | 1
broadcast_to(arr, shape) | broadcast | 1
choose(a, choices[, out, mode]) | broadcast+index | 3
compress(condition, a[, axis, out]) | index | 3
concatenate(arrays[, axis]) | concatenate | 1
delete(arr, obj[, axis]) | ravel+index | 3
empty_like(a[, dtype, shape]) | zeros_like | 4
expand_dims(a, axis) | expand_dims (could be broadcast/reshape?) | 2
flip(m[, axis]) | lax.rev | 5
fliplr(m) | flip=rev | 5
flipud(m) | flip=rev | 5
hsplit(ary, indices_or_sections) | split=slice | 3
hstack(tup) | concatenate+atleast_1dim | 2
insert(arr, obj, values[, axis]) | indexing | 3
moveaxis(a, source, destination) | lax.transpose | 5
ones_like(a[, dtype, shape]) | lax.full_like | 4
ravel(a[, order]) | reshape | 1
repeat(a, repeats[, axis, total_repeat_length]) | take | 3
reshape(a, newshape[, order]) | reshape | 1
resize(a, new_shape) | reshape+tile+indexing | 3
roll(a, shift[, axis]) | indexing | 3
rollaxis(a, axis[, start]) | move_axis | 5
row_stack(tup) | vstack | 2
split(ary, indices_or_sections[, axis]) | lax.slice | 3
squeeze(a[, axis]) | lax.squeeze | 2
stack(arrays[, axis, out]) | concatenate+expand_dims | 2
swapaxes(a, axis1, axis2) | lax.transpose | 5
take(a, indices[, axis, out, mode]) | index | 3
take_along_axis(arr, indices, axis) | index | 3
transpose(a[, axes]) | lax.transpose | 5
tile | broadcast_to+reshape | 1
vsplit(ary, indices_or_sections) | split | 3
vstack(tup) | concatenate+expand_dims | 2
zeros_like(a[, dtype, shape]) | lax.full_like | 4
