### PR TITLE
small cleanups to AOT APIs

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1656,15 +1656,19 @@ def lower_mesh_computation(
 class MeshComputation:
   def __init__(self, hlo, *compile_args):
     self._executable = None
-    self.hlo = hlo
+    self._hlo = hlo
     self.compile_args = compile_args
+
+  def hlo(self):
+    # this is a method for api consistency with xla.XlaComputation
+    return self._hlo
 
   def compile(self,
               _allow_propagation_to_outputs : bool = False,
               _allow_compile_replicated : bool = True) -> 'MeshExecutable':
     if self._executable is None:
       self._executable = MeshExecutable(
-          self.hlo, *self.compile_args,
+          self._hlo, *self.compile_args,
           _allow_propagation_to_outputs=_allow_propagation_to_outputs,
           _allow_compile_replicated=_allow_compile_replicated)  # type: ignore
     return self._executable

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -723,6 +723,12 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     f_exe = f_low.compile()
     self.assertAllClose(f_exe(1.), 2.)
 
+  def test_jit_lower_duck_typing(self):
+    f_jit = self.jit(lambda x: 2 * x)
+    f_low = f_jit.lower(jax.ShapeDtypeStruct((), 'float32'))  # doesn't crash
+    f_exe = f_low.compile()
+    self.assertAllClose(f_exe(jnp.float32(1.)), jnp.float32(2.))
+
   def test_jit_lower_compile_in_tree_mismatch(self):
     def f(x):
       return jnp.sqrt(x ** 2) + 1.

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -372,7 +372,7 @@ class PJitTest(jtu.BufferDonationTestCase):
       xla._translations[pjit_p] = rule
 
   @jtu.with_mesh([('x', 2)])
-  def testLowerWithAbstractArgs(self):
+  def testLowerWithDuckTyping(self):
     x = jax.ShapeDtypeStruct((2, 2), jnp.float32)
     # Make sure this doesn't crash
     pjit(lambda x: x + 4, in_axis_resources=P('x'), out_axis_resources=P('x')).lower(x)


### PR DESCRIPTION
Two changes:
* MeshComputation.hlo should be a method (so that callers can work, and for API consistency)
* `jit(f).lower(*args)` should only look at the shape/dtype attributes of the elements of `args`, i.e. duck typing to make things like `ShapeDtypeStruct` work