### PR TITLE
Update readthedocs.yaml to new build specification

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -16,6 +21,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,6 @@ sphinx_rtd_theme
 sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2
 myst-nb
-jupyter-core!=4.9.0  # https://github.com/jupyter/jupyter_core/issues/246
 
 # Packages used for CI tests.
 pytest


### PR DESCRIPTION
This change was prompted by the discussion in https://github.com/jupyter/jupyter_core/issues/246

Although jupyter-core is pushing a fix, a more long-term fix was suggested: to follow  https://blog.readthedocs.com/new-build-specification/ and update the way we specify our RTD build environment. I also updated our readthedocs environment to Python 3.9, and removed the now-unnecessary pinning of jupyter-core.