### PR TITLE
support null shape in jax.random.poisson

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -730,6 +730,12 @@ class LaxRandomTest(jtu.JaxTestCase):
     self._CheckChiSquared(samples[:10000], scipy.stats.poisson(2.0).pmf)
     self._CheckChiSquared(samples[10000:], scipy.stats.poisson(20.0).pmf)
 
+  def testPoissonWithoutShape(self):
+    key = self.seed_prng(1)
+    lam = 2 * jnp.ones(10000)
+    samples = random.poisson(key, lam)
+    self._CheckChiSquared(samples, scipy.stats.poisson(2.0).pmf)
+
   def testPoissonShape(self):
     key = self.seed_prng(0)
     x = random.poisson(key, np.array([2.0, 20.0]), shape=(3, 2))


### PR DESCRIPTION
Fixes #7861 

## Issue
```python
jax.random.poisson(key,lam)
```
was giving errors, because default `shape` was not being broadcasted to `lam`

## Changes introduced
- If `shape` argument is not given to `jax.random.poisson`,
it takes the shape of `lam.shape`
- Added tests to cover the case of default shape
```Python
jax.random.poisson(key,lam)
```