### PR TITLE
Use `SourceInfo` named tuple to keep track of source information

### DIFF
--- a/jax/_src/source_info_util.py
+++ b/jax/_src/source_info_util.py
@@ -16,7 +16,7 @@ import contextlib
 import itertools
 import os.path
 import threading
-from typing import Optional, Iterator
+from typing import Optional, Iterator, NamedTuple
 
 import jax.version
 from jax._src.lib import xla_client
@@ -33,7 +33,17 @@ _exclude_paths = [os.path.dirname(jax.version.__file__)]
 def register_exclusion(path):
   _exclude_paths.append(path)
 
-def user_frames(source_info: Optional[Traceback]) -> Iterator[Frame]:
+class SourceInfo(NamedTuple):
+  traceback: Optional[Traceback]
+
+  def replace(self, *, traceback: Optional[Traceback] = None) -> 'SourceInfo':
+    traceback = traceback or self.traceback
+    return self._replace(traceback=traceback)
+
+def new_source_info() -> SourceInfo:
+  return SourceInfo(None)
+
+def user_frames(source_info: SourceInfo) -> Iterator[Frame]:
   """Heuristic that guesses the identity of the user's code in a stack trace."""
   # Guess the user's frame is the innermost frame not in the jax source tree
   # We don't use traceback_util.path_starts_with because that incurs filesystem
@@ -41,30 +51,33 @@ def user_frames(source_info: Optional[Traceback]) -> Iterator[Frame]:
   # provenance annotations to XLA lowerings, so we don't want to incur the cost.
   # We consider files that end with _test.py as user frames, to allow testing
   # this mechanism from tests.
-  return (x for x in (source_info.frames if source_info else [])
+  traceback = source_info.traceback
+  return (x for x in (traceback.frames if traceback else [])
           if x.file_name.endswith("_test.py") or not any(x.file_name.startswith(p) for p in _exclude_paths))
 
-def user_frame(source_info: Optional[Traceback]) -> Optional[Frame]:
+def user_frame(source_info: SourceInfo) -> Optional[Frame]:
   return next(user_frames(source_info), None)
 
-def summarize(source_info: Optional[Traceback], num_frames=1) -> str:
+def summarize(source_info: SourceInfo, num_frames=1) -> str:
   frames = itertools.islice(user_frames(source_info), num_frames)
   frame_strs = [f"{frame.file_name}:{frame.line_num} ({frame.function_name})"
                 if frame else "unknown" for frame in frames]
   return '\n'.join(reversed(frame_strs))
 
-
 class _SourceInfoContext(threading.local):
-  context: Optional[Traceback]
+  context: SourceInfo
 
   def __init__(self):
-    self.context = None
+    self.context = new_source_info()
 
 _source_info_context = _SourceInfoContext()
 
+def current() -> SourceInfo:
+  context = _source_info_context.context
+  if not context.traceback:
+    return context.replace(traceback=xla_client.Traceback.get_traceback())
+  return context
 
-def current() -> Optional[Traceback]:
-  return _source_info_context.context or xla_client.Traceback.get_traceback()
 
 class JaxStackTraceBeforeTransformation(Exception): pass
 
@@ -81,9 +94,9 @@ def has_user_context(e):
   return False
 
 @contextlib.contextmanager
-def user_context(c):
+def user_context(c: Optional[Traceback]):
   prev = _source_info_context.context
-  _source_info_context.context = c or _source_info_context.context
+  _source_info_context.context = _source_info_context.context.replace(traceback=c)
   filtered_tb = None
   try:
     yield
@@ -94,12 +107,12 @@ def user_context(c):
     if filtered_tb:
       msg = traceback_util.format_exception_only(e)
       msg = f'{msg}\n\n{_message}'
-      c = JaxStackTraceBeforeTransformation(msg).with_traceback(filtered_tb)
-      c.__context__ = e.__context__
-      c.__cause__ = e.__cause__
-      c.__suppress_context__ = e.__suppress_context__
+      exp = JaxStackTraceBeforeTransformation(msg).with_traceback(filtered_tb)
+      exp.__context__ = e.__context__
+      exp.__cause__ = e.__cause__
+      exp.__suppress_context__ = e.__suppress_context__
       e.__context__ = None
-      e.__cause__ = c
+      e.__cause__ = exp
     raise
   finally:
     _source_info_context.context = prev

--- a/jax/core.py
+++ b/jax/core.py
@@ -148,11 +148,11 @@ class JaxprEqn(NamedTuple):
   outvars: List['Var']
   primitive: 'Primitive'
   params: Dict[str, Any]
-  source_info: Optional[source_info_util.Traceback]
+  source_info: source_info_util.SourceInfo
 
   def __repr__(self): return str(pp_eqn(self, JaxprPpContext())).rstrip()
 
-def new_jaxpr_eqn(invars, outvars, primitive, params, source_info=None):
+def new_jaxpr_eqn(invars, outvars, primitive, params, source_info):
   if primitive.call_primitive:
     assert len(outvars) == len(params["call_jaxpr"].outvars)
   return JaxprEqn(invars, outvars, primitive, params, source_info)
@@ -339,7 +339,7 @@ def eval_jaxpr_eqn(eqn, in_vals):
     del bind_params['out_axes']
   else:
     bind_params = params
-  with source_info_util.user_context(eqn.source_info):
+  with source_info_util.user_context(eqn.source_info.traceback):
     return eqn.primitive.bind(*(subfuns + in_vals), **bind_params)
 
 

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -713,7 +713,7 @@ def make_xmap_callable(fun: lu.WrappedFun,
                                  call_jaxpr=jaxpr,
                                  resource_env=resource_env,
                                  name=name),
-                        None, resource_env, {})
+                        source_info_util.new_source_info(), resource_env, {})
   jaxpr = plan.subst_axes_with_resources(jaxpr)
   use_spmd_lowering = config.experimental_xmap_spmd_lowering
   ensure_fixed_sharding = config.experimental_xmap_ensure_fixed_sharding
@@ -950,7 +950,7 @@ def show_axes(axes):
 
 def _resource_typing_xmap(avals,
                           params,
-                          source_info: Optional[source_info_util.Traceback],
+                          source_info: source_info_util.SourceInfo,
                           resource_env,
                           outer_axis_resources):
   axis_resources = params['axis_resources']

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -215,7 +215,7 @@ def backward_pass(jaxpr: core.Jaxpr, reduce_axes, consts, primals_in, cotangents
       cts_in = map(read_cotangent, eqn.outvars)
     else:
       cts_in, = map(read_cotangent, eqn.outvars)
-    with source_info_util.user_context(eqn.source_info):
+    with source_info_util.user_context(eqn.source_info.traceback):
       if eqn.primitive.call_primitive or eqn.primitive.map_primitive:
         cts_in_avals = [v.aval for v in eqn.outvars]
         call_jaxpr, params = core.extract_call_jaxpr(eqn.primitive, eqn.params)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -552,13 +552,13 @@ class JaxprEqnRecipe(NamedTuple):
   outvars: 'Sequence[ref[JaxprTracer]]'
   primitive: Primitive
   params: Dict[str, Any]
-  source_info: Optional[source_info_util.Traceback]
+  source_info: source_info_util.SourceInfo
 
 def new_eqn_recipe(invars: Sequence[JaxprTracer],
                    outvars: Sequence[JaxprTracer],
                    primitive: Primitive,
                    params: Dict[str, Any],
-                   source_info: Optional[source_info_util.Traceback]
+                   source_info: source_info_util.SourceInfo
                   ) -> JaxprEqnRecipe:
   """Constructs a new JaxEqnRecipe.
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -98,12 +98,12 @@ def _get_canonical_source_file(frame: source_info_util.Frame):
 tracebacks = {}
 def make_op_metadata(primitive: core.Primitive,
                      params: Dict, *,
+                     source_info: source_info_util.SourceInfo,
                      name_stack: str = "",
-                     source_info: Optional[source_info_util.Traceback] = None
                      ) -> xc.OpMetadata:
   eqn_str = str(pp.text(name_stack) +
                 pp_eqn_compact(primitive.name, params, JaxprPpContext()))
-  tracebacks[eqn_str] = source_info
+  tracebacks[eqn_str] = source_info.traceback
   frame = source_info_util.user_frame(source_info) if source_info else None
   return xc.OpMetadata(
         op_type=primitive.name,
@@ -573,7 +573,7 @@ def jaxpr_subcomp(ctx: TranslationContext, jaxpr: core.Jaxpr,
       raise NotImplementedError(
           f"XLA translation rule for primitive '{eqn.primitive.name}' not found")
 
-    with source_info_util.user_context(eqn.source_info):
+    with source_info_util.user_context(eqn.source_info.traceback):
       ans = rule(ctx, map(aval, eqn.invars), map(aval, eqn.outvars),
                  *in_nodes, **eqn.params)
 


### PR DESCRIPTION
This change enables using source info to keep track of other information in the future, for example the active name stack.