### PR TITLE
Add context manager implementation for name stack handling

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -353,7 +353,7 @@ def remat_transpose(reduce_axes, out_cts, *in_primals, jaxpr, **params):
     primal_fun = lu.wrap_init(partial(core.eval_jaxpr, jaxpr, ()))
     tangent_jaxpr, _, consts = pe.trace_to_jaxpr(primal_fun, in_pvals, False)
     dummy_args = [ad.UndefinedPrimal(v.aval) for v in tangent_jaxpr.invars]
-    in_cts_ = ad.backward_pass(tangent_jaxpr, reduce_axes, consts, dummy_args,
+    in_cts_ = ad.backward_pass(tangent_jaxpr, reduce_axes, False, consts, dummy_args,
                                out_cts)
     in_cts, cell.treedef = tree_flatten(in_cts_)
     return in_cts

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -140,7 +140,6 @@ class Config:
     for name, val in self.values.items():
       flag_type, meta_args, meta_kwargs = self.meta[name]
       absl_defs[flag_type](name, val, *meta_args, **meta_kwargs)
-
     app.call_after_init(lambda: self.complete_absl_config(absl_flags))
 
   def complete_absl_config(self, absl_flags):
@@ -687,6 +686,11 @@ config.define_bool_state(
     default=False,
     help=('Enables experimental features for staging out computations with '
           'dynamic shapes.'))
+
+config.define_bool_state(
+    name='jax_experimental_name_stack',
+    default=False,
+    help='Enable using the context manager-based name stack.')
 
 # This flag is temporary during rollout of the remat barrier.
 # TODO(parkers): Remove if there are no complaints.

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -407,7 +407,7 @@ def _custom_jvp_call_jaxpr_transpose(reduce_axes, cts, *args, fun_jaxpr,
                                      jvp_jaxpr_thunk, num_consts):
   del jvp_jaxpr_thunk, num_consts
   return ad.backward_pass(
-      fun_jaxpr.jaxpr, reduce_axes, fun_jaxpr.consts, args, cts)
+      fun_jaxpr.jaxpr, reduce_axes, False, fun_jaxpr.consts, args, cts)
 ad.reducing_transposes[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_transpose
 
 def custom_jvp_jaxpr_custom_partial_eval_rule(

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -250,7 +250,7 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
   # pass long arg lists as tuple for TPU
   tuple_args = len(abstract_args) > 100
   axis_env = xla.AxisEnv(nreps, (), ())
-  name_stack = xla.extend_name_stack(xla.wrap_name(name, 'jit'))
+  name_stack = xla.new_name_stack(xla.wrap_name(name, 'jit'))
   closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
   module: Union[str, xc.XlaComputation]
   module_name = f"jit_{fun.__name__}"

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -50,7 +50,7 @@ from jax.interpreters import masking
 import jax._src.pretty_printer as pp
 from jax._src import util
 from jax._src.util import (cache, safe_zip, prod, safe_map, canonicalize_axis,
-                           split_list)
+                           split_list, new_name_stack)
 from jax.tree_util import tree_map
 import jax._src.lib
 from jax._src.lib import pytree
@@ -3424,7 +3424,7 @@ def _reduction_computation(ctx, jaxpr, consts, init_values, singleton=True):
   subc = xc.XlaBuilder("reduction_computation")
   assert len(consts) == 0, "Reduction computations cannot have constants"
   args = [xla.parameter(subc, i, shape) for i, shape in enumerate(shapes)]
-  ctx = xla.TranslationContext(subc, platform, axis_env, '')
+  ctx = xla.TranslationContext(subc, platform, axis_env, new_name_stack())
   out_nodes = xla.jaxpr_subcomp(ctx, jaxpr, consts, *args)
   if singleton:
     return subc.build(out_nodes[0])

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -277,7 +277,21 @@ def get_module_functions(module):
 def wrap_name(name, transform_name):
   return transform_name + '(' + name + ')'
 
-def extend_name_stack(stack, name=''):
+def new_name_stack(name: str = ''):
+  if config.jax_experimental_name_stack:
+    from jax._src import source_info_util
+    name_stack = source_info_util.NameStack()
+    if name:
+      name_stack = name_stack.extend(name)
+    return name_stack
+  return name + '/'
+
+def extend_name_stack(stack, name: str):
+  if config.jax_experimental_name_stack:
+    from jax._src import source_info_util
+    assert isinstance(stack, source_info_util.NameStack), stack
+    return stack.extend(name)
+  assert isinstance(stack, str)
   return stack + name + '/'
 
 def canonicalize_axis(axis, num_dims) -> int:

--- a/jax/core.py
+++ b/jax/core.py
@@ -81,10 +81,11 @@ class Jaxpr:
   __repr__ = __str__
 
   def pretty_print(self, *, source_info=False, print_shapes=True,
-                   custom_pp_eqn_rules=True, **kw):
+                   custom_pp_eqn_rules=True, name_stack=False, **kw):
     doc = pp_jaxpr(self, JaxprPpContext(), source_info=source_info,
                    print_shapes=print_shapes,
-                   custom_pp_eqn_rules=custom_pp_eqn_rules)
+                   custom_pp_eqn_rules=custom_pp_eqn_rules,
+                   name_stack=name_stack)
     return doc.format(**kw)
 
   def _repr_pretty_(self, p, cycle):
@@ -141,9 +142,10 @@ class ClosedJaxpr:
   def __str__(self): return str(self.jaxpr)
   def __repr__(self): return repr(self.jaxpr)
 
-  def pretty_print(self, *, source_info=False, print_shapes=True, **kw):
+  def pretty_print(self, *, source_info=False, print_shapes=True,
+                   name_stack=False, **kw):
     return pp_jaxpr(self.jaxpr, JaxprPpContext(), source_info=source_info,
-                    print_shapes=print_shapes).format(**kw)
+                    print_shapes=print_shapes, name_stack=name_stack).format(**kw)
 
 
   def _repr_pretty_(self, p, cycle):
@@ -333,7 +335,8 @@ def eval_jaxpr(jaxpr: Jaxpr, consts, *args):
   map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
     subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
-    with source_info_util.user_context(eqn.source_info.traceback):
+    name_stack = source_info_util.current_name_stack() + eqn.source_info.name_stack
+    with source_info_util.user_context(eqn.source_info.traceback, name_stack=name_stack):
       ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
     if eqn.primitive.multiple_results:
       map(write, eqn.outvars, ans)
@@ -2272,50 +2275,52 @@ def pp_vars(vs: Sequence[Any], context: JaxprPpContext,
               [pp.text(pp_var(v, context)) for v in vs])
     ))
 
-def pp_kv_pair(k:str, v: Any, context: JaxprPpContext) -> pp.Doc:
+def pp_kv_pair(k:str, v: Any, context: JaxprPpContext, name_stack: bool = False) -> pp.Doc:
   if type(v) is tuple and all(isinstance(j, (Jaxpr, ClosedJaxpr)) for j in v):
-    pp_v = pp_jaxprs(v, context)
+    pp_v = pp_jaxprs(v, context, name_stack=name_stack)
   elif isinstance(v, Jaxpr):
-    pp_v = pp_jaxpr(v, context)
+    pp_v = pp_jaxpr(v, context, name_stack=name_stack)
   elif isinstance(v, ClosedJaxpr):
-    pp_v = pp_jaxpr(v.jaxpr, context)
+    pp_v = pp_jaxpr(v.jaxpr, context, name_stack=name_stack)
   else:
     pp_v = pp.text(str(v))
   return pp.text(f'{k}=') + pp_v
 
-def pp_kv_pairs(kv_pairs, context: JaxprPpContext) -> pp.Doc:
+def pp_kv_pairs(kv_pairs, context: JaxprPpContext, name_stack: bool = False) -> pp.Doc:
   if not kv_pairs:
     return pp.nil()
   return pp.group(
     pp.nest(2, pp.concat([
       pp.text("["),  pp.brk(""),
-      pp.join(pp.brk(), [pp_kv_pair(k, v, context) for k, v in kv_pairs])
+      pp.join(pp.brk(), [pp_kv_pair(k, v, context, name_stack=name_stack) for k, v in kv_pairs])
     ]))
     + pp.brk("") + pp.text("]")
   )
 
 def pp_eqn(eqn, context: JaxprPpContext, *, print_shapes=True,
-           source_info=False, custom_pp_eqn_rules=True) -> pp.Doc:
+           source_info=False, custom_pp_eqn_rules=True, name_stack=False) -> pp.Doc:
   lhs = pp_vars(eqn.outvars, context, print_shapes=print_shapes)
   annotation = (source_info_util.summarize(eqn.source_info)
                 if source_info else None)
   rule = pp_eqn_rules.get(eqn.primitive)
+  name_stack_annotation = f'[{eqn.source_info.name_stack}]' if name_stack else None
   if rule and custom_pp_eqn_rules:
     rhs = rule(eqn, context)
   else:
-    rhs = [pp.text(eqn.primitive.name),
-           pp_kv_pairs(sorted(eqn.params.items()), context),
+    rhs = [pp.text(eqn.primitive.name, annotation=name_stack_annotation),
+           pp_kv_pairs(sorted(eqn.params.items()), context, name_stack=name_stack),
            pp.text(" ") + pp_vars(eqn.invars, context)]
   return pp.concat([lhs, pp.text(" = ", annotation=annotation), *rhs])
 CustomPpEqnRule = Callable[[JaxprEqn, JaxprPpContext], Sequence[pp.Doc]]
 pp_eqn_rules: Dict[Primitive, CustomPpEqnRule]  = {}
 
 def pp_eqns(eqns, context: JaxprPpContext, *, print_shapes=True,
-            source_info=False, custom_pp_eqn_rules=True
+            source_info=False, custom_pp_eqn_rules=True, name_stack=False,
             ) -> pp.Doc:
   return pp.join(
     pp.brk("; "),
     [pp_eqn(e, context, print_shapes=print_shapes, source_info=source_info,
+            name_stack=name_stack,
             custom_pp_eqn_rules=custom_pp_eqn_rules) for e in eqns])
 
 def _compact_eqn_should_include(k: str, v: Any) -> bool:
@@ -2349,23 +2354,25 @@ def pp_jaxpr_skeleton(jaxpr, eqns_fn, context: JaxprPpContext, *,
 
 
 def pp_jaxpr(jaxpr, context: JaxprPpContext, *, print_shapes=True,
-             source_info=False, custom_pp_eqn_rules=True) -> pp.Doc:
+             source_info=False, custom_pp_eqn_rules=True, name_stack=False) -> pp.Doc:
   eqns_fn = lambda: pp_eqns(jaxpr.eqns, context, print_shapes=print_shapes,
                             source_info=source_info,
-                            custom_pp_eqn_rules=custom_pp_eqn_rules)
+                            custom_pp_eqn_rules=custom_pp_eqn_rules,
+                            name_stack=name_stack)
   return pp_jaxpr_skeleton(jaxpr, eqns_fn, context, print_shapes=print_shapes)
 
-def pp_jaxprs(jaxprs, context: JaxprPpContext) -> pp.Doc:
+def pp_jaxprs(jaxprs, context: JaxprPpContext, name_stack: bool = False) -> pp.Doc:
   jaxprs = [j.jaxpr if isinstance(j, ClosedJaxpr) else j for j in jaxprs]
   return pp.group(pp.nest(2, pp.concat([
       pp.text('('), pp.brk(""),
-      pp.join(pp.brk(), map(lambda x: pp_jaxpr(x, context), jaxprs))]
+      pp.join(pp.brk(), map(lambda x: pp_jaxpr(x, context, name_stack=name_stack), jaxprs))]
     )) + pp.brk("") + pp.text(')')
   )
 
 
 def pp_jaxpr_eqn_range(jaxpr: Jaxpr, lo: int, hi: int, context: JaxprPpContext,
-                       print_shapes=True, source_info: bool = False) -> pp.Doc:
+                       print_shapes=True, source_info: bool = False,
+                       name_stack: bool = False) -> pp.Doc:
   lo = max(lo, 0)
   hi = max(lo, min(hi, len(jaxpr.eqns)))
   eqns = jaxpr.eqns[lo:hi]
@@ -2377,7 +2384,8 @@ def pp_jaxpr_eqn_range(jaxpr: Jaxpr, lo: int, hi: int, context: JaxprPpContext,
       if lo != 0:
         pps.append(pp.text('...'))
       pps.extend(map((lambda e: pp_eqn(e, context, print_shapes=print_shapes,
-                                       source_info=source_info)), eqns))
+                                       source_info=source_info,
+                                       name_stack=name_stack)), eqns))
       if hi != len(jaxpr.eqns):
         pps.append(pp.text('...'))
     return pp.join(pp.brk("; "), pps)

--- a/jax/experimental/djax.py
+++ b/jax/experimental/djax.py
@@ -24,7 +24,7 @@ from jax._src import source_info_util
 from jax.core import Var, Literal, Atom, Tracer
 from jax._src import util
 from jax._src.util import (safe_zip, safe_map, curry, unzip2, split_list,
-                           tuple_delete)
+                           tuple_delete, new_name_stack)
 import jax._src.pretty_printer as pp
 
 map = safe_map
@@ -806,7 +806,8 @@ def traceable_to_padded_translation(traceable):
 
     operands_ = it.chain.from_iterable([*dims.values(), *operands])
     platform = "cpu"  # TODO: don't hardwire in the CPU translation.
-    ctx = xla.TranslationContext(c, platform, xla.AxisEnv(1, (), ()), '')
+    ctx = xla.TranslationContext(c, platform, xla.AxisEnv(1, (), ()),
+                                 new_name_stack())
     outs = xla.jaxpr_subcomp(ctx, jaxpr, xla._xla_consts(c, consts), *operands_)
     return util.unflatten(outs,
                           [aval_to_num_buffers(aval) for aval in out_avals])

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -261,7 +261,7 @@ def convert(fun: Callable,
   """
   api._check_callable(fun)
   fun_name = getattr(fun, "__name__", "unknown")
-  name_stack = util.extend_name_stack(util.wrap_name(fun_name, "jax2tf"))
+  name_stack = util.wrap_name(fun_name, "jax2tf") + "/"
   def converted_fun(*args: TfVal, **kwargs: TfVal) -> TfVal:
     # TODO: is there a better way to check if we are inside a transformation?
     if not core.trace_state_clean() and not _thread_local_state.inside_call_tf:

--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -117,6 +117,7 @@ from jax._src.lax import control_flow as lax_control_flow
 from jax import tree_util
 from jax.errors import UnexpectedTracerError
 from jax.interpreters import partial_eval as pe
+from jax._src import source_info_util
 from jax._src.util import safe_map
 
 
@@ -291,10 +292,11 @@ class Scope(object):
     """Starts a nested trace, returns the Trace object."""
     # TODO: This follows the __enter__ part of core.new_main.
     level = core.thread_local_state.trace_state.trace_stack.next_level()
-    main = core.MainTrace(level, pe.JaxprTrace)
+    name_stack = source_info_util.current_name_stack()
+    main = core.MainTrace(level, pe.JaxprTrace, name_stack=name_stack)
     core.thread_local_state.trace_state.trace_stack.push(main)
     self._count_subtraces += 1
-    return pe.JaxprTrace(main, core.cur_sublevel())
+    return pe.JaxprTrace(main, core.cur_sublevel(), name_stack=name_stack)
 
   def end_subtrace(self):
     # TODO: This follows the __exit__ part of core.new_main

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -910,7 +910,7 @@ def _xmap_transpose(params, call_jaxpr, args, cts_in, cts_in_avals, reduce_axes)
   all_args, in_tree_def = tree_flatten(((), args, cts_in))  # empty consts
   fun = lu.hashable_partial(
       lu.wrap_init(ad.backward_pass),
-      call_jaxpr, reduce_axes + tuple(params['global_axis_sizes'].keys()))
+      call_jaxpr, reduce_axes + tuple(params['global_axis_sizes'].keys()), False)
   fun, nz_arg_cts = ad.nonzero_outputs(fun)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)
   # Preserve axis for primal arguments, skip tangents (represented as undefined primals).

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -846,7 +846,7 @@ def _pjit_transpose(reduce_axes, cts_in, *primals_in,
     return tuple(x for x, mz in zip(xs, maybe_zeros) if not type(mz) is ty)
 
   body = lu.wrap_init(ad.closed_backward_pass)
-  body = lu.hashable_partial(body, jaxpr, reduce_axes)
+  body = lu.hashable_partial(body, jaxpr, reduce_axes, False)
   primals_and_nz_cts_in, in_treedef = tree_flatten((primals_in, cts_in))
   body, cts_out_treedef_thunk = flatten_fun_nokwargs(body, in_treedef)
 

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -266,8 +266,8 @@ register_constant_handler(
 def _source_info_to_location(
     primitive: core.Primitive, params: Dict,
     source_info: source_info_util.SourceInfo,
-    name_stack: str = "") -> ir.Location:
-  eqn_str = name_stack + core.str_eqn_compact(primitive.name, params)
+    name_stack: Union[str, source_info_util.NameStack] = "") -> ir.Location:
+  eqn_str = str(name_stack) + core.str_eqn_compact(primitive.name, params)
   frame = source_info_util.user_frame(source_info)
   if frame is None:
     loc = ir.Location.unknown()
@@ -280,6 +280,7 @@ def _source_info_to_location(
 
 
 # Translation rules
+NameStack = Union[str, source_info_util.NameStack]
 
 def make_ir_context() -> ir.Context:
   """Creates an MLIR context suitable for JAX IR."""
@@ -334,7 +335,7 @@ class ModuleContext:
   symbol_table: ir.SymbolTable
   platform: str
   axis_context: AxisContext
-  name_stack: str
+  name_stack: NameStack
 
   # Cached primitive lowerings.
   cached_primitive_lowerings: Dict[Any, builtin.FuncOp]
@@ -344,7 +345,7 @@ class ModuleContext:
     return self.axis_context.axis_env
 
   def __init__(
-      self, platform: str, axis_context: AxisContext, name_stack: str,
+      self, platform: str, axis_context: AxisContext, name_stack: NameStack,
       context: Optional[ir.Context] = None,
       module: Optional[ir.Module] = None,
       ip: Optional[ir.InsertionPoint] = None,
@@ -412,7 +413,7 @@ _module_name_regex = re.compile(r"[^\w.-]")
 def lower_jaxpr_to_module(
     module_name: str, jaxpr: core.ClosedJaxpr, platform: str,
     axis_context: AxisContext,
-    name_stack: str, donated_args: Sequence[bool],
+    name_stack: NameStack, donated_args: Sequence[bool],
     replicated_args: Optional[Sequence[bool]] = None,
     arg_shardings: Optional[Sequence[Optional[xc.OpSharding]]] = None,
     result_shardings: Optional[Sequence[Optional[xc.OpSharding]]] = None

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -54,7 +54,7 @@ from jax._src import device_array
 from jax._src import source_info_util
 from jax._src import util
 from jax._src.util import (unzip3, prod, safe_map, safe_zip,
-                           extend_name_stack, wrap_name, assert_unreachable,
+                           extend_name_stack, new_name_stack, wrap_name, assert_unreachable,
                            tuple_insert, tuple_delete, distributed_debug_log)
 from jax.errors import JAXTypeError
 from jax._src import dispatch
@@ -1038,7 +1038,7 @@ def lower_parallel_callable(
 
   axis_env = xla.AxisEnv(
       replicas.num_global_replicas, (axis_name,), (global_axis_size,))
-  name_stack = extend_name_stack(wrap_name(name, 'pmap'))
+  name_stack = new_name_stack(wrap_name(name, 'pmap'))
   closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
   replicated_args = [axis is None for axis in in_axes]
   module: Union[str, xc.XlaComputation]
@@ -2145,7 +2145,7 @@ def lower_mesh_computation(
     in_is_gda: Sequence[bool]):
   assert not mesh.empty
   backend = xb.get_device_backend(mesh.devices.flat[0])
-  name_stack = extend_name_stack(wrap_name(fun_name, api_name))
+  name_stack = new_name_stack(wrap_name(fun_name, api_name))
 
   global_axis_sizes = mesh.shape
 
@@ -2236,7 +2236,7 @@ def lower_mesh_computation(
           partitions_are_protos=partitions_proto)
 
   return MeshComputation(
-      name_stack, module, donated_invars, mesh=mesh, global_in_avals=global_in_avals,
+      str(name_stack), module, donated_invars, mesh=mesh, global_in_avals=global_in_avals,
       global_out_avals=global_out_avals, in_axes=in_axes, out_axes=out_axes,
       spmd_lowering=spmd_lowering, tuple_args=tuple_args, in_is_gda=in_is_gda)
 

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -35,7 +35,7 @@ from jax._src.api_util import (argnums_partial, flatten_axes, flatten_fun,
                                _ensure_index_tuple)
 import jax._src.util as util
 from jax.tree_util import tree_flatten, tree_unflatten
-from jax._src.util import (extend_name_stack, wrap_name, wraps, safe_map,
+from jax._src.util import (new_name_stack, wrap_name, wraps, safe_map,
                            safe_zip, HashableFunction)
 from jax._src.config import config
 
@@ -149,7 +149,7 @@ def _sharded_callable(
   xla_args = _xla_sharded_args(c, global_abstract_args, in_parts)
   axis_env = xla.AxisEnv(nrep, (), ())
   ctx = xla.TranslationContext(
-      c, platform, axis_env, extend_name_stack(wrap_name(name, "sharded_jit")))
+      c, platform, axis_env, new_name_stack(wrap_name(name, "sharded_jit")))
   out_nodes = xla.jaxpr_subcomp(ctx, jaxpr, xla_consts, *xla_args)
   out_tuple = xla.with_sharding(c, out_parts, xops.Tuple, c, out_nodes)
   built = c.Build(out_tuple)
@@ -202,7 +202,7 @@ def _sharded_jit_translation_rule(ctx, avals_in, avals_out, *in_nodes,
 
   sub_ctx = ctx.replace(
       builder=subc,
-      name_stack=extend_name_stack(wrap_name(name, "sharded_jit")))
+      name_stack=new_name_stack(wrap_name(name, "sharded_jit")))
   out_nodes = xla.jaxpr_subcomp(sub_ctx, call_jaxpr, (), *args)
   out_parts = out_parts_thunk()
   assert len(out_parts) == len(out_nodes)
@@ -234,7 +234,7 @@ def _sharded_jit_lowering(ctx, *in_nodes,
       args.append(ns)
 
   sub_ctx = ctx.module_context.replace(
-      name_stack=extend_name_stack(wrap_name(name, "sharded_jit")))
+      name_stack=new_name_stack(wrap_name(name, "sharded_jit")))
   fn = mlir.lower_jaxpr_to_fun(sub_ctx, f"sharded_jit_{name}",
                                core.ClosedJaxpr(call_jaxpr, ()))
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -7311,7 +7311,13 @@ class NamedCallTest(jtu.JaxTestCase):
       return my_test_function(x)
 
     c = jax.xla_computation(f)(2)
-    self.assertIn("my_test_function", c.as_hlo_text())
+    if config.jax_experimental_name_stack:
+      print_opts = xla_client._xla.HloPrintOptions.short_parsable()
+      print_opts.print_metadata = True
+      hlo_text = c.as_hlo_module().to_string(print_opts)
+    else:
+      hlo_text = c.as_hlo_text()
+    self.assertIn("my_test_function", hlo_text)
 
   def test_non_jaxtype_arg(self):
     # For the test to fail without the invalid JaxType filter we need to pass

--- a/tests/name_stack_test.py
+++ b/tests/name_stack_test.py
@@ -1,0 +1,612 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+from jax import core
+from jax import lax
+from jax import linear_util as lu
+from jax.config import config
+from jax._src import test_util as jtu
+from jax._src import source_info_util
+from jax._src.lib import xla_client
+
+config.parse_flags_with_absl()
+extend_name_stack = source_info_util.extend_name_stack
+
+def _get_hlo(f):
+  def wrapped(*args, **kwargs):
+    c = jax.xla_computation(f)(*args, **kwargs)
+    print_opts = xla_client._xla.HloPrintOptions.short_parsable()
+    print_opts.print_metadata = True
+    return c.as_hlo_module().to_string(print_opts)
+  return wrapped
+
+class _EnableNameStackTestCase(jtu.JaxTestCase):
+
+  def setUp(self):
+    self.cfg = config._read("jax_experimental_name_stack")
+    config.update("jax_experimental_name_stack", True)
+
+  def tearDown(self):
+    config.update("jax_experimental_name_stack", self.cfg)
+
+
+class NameStackTest(_EnableNameStackTestCase):
+
+  def test_trivial_name_stack(self):
+
+    def f(x):
+      return x + 1
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    for eqn in jaxpr.eqns:
+      self.assertEqual(str(eqn.source_info.name_stack), '')
+
+  def test_name_call_name_stack(self):
+
+    @jax.named_call
+    def f(x):
+      return x + 1
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    for eqn in jaxpr.eqns:
+      self.assertEqual(str(eqn.source_info.name_stack), 'f')
+
+  def test_manual_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      return x + 1
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    for eqn in jaxpr.eqns:
+      self.assertEqual(str(eqn.source_info.name_stack), 'foo')
+
+  def test_nested_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      with extend_name_stack('bar'):
+        return x + 1
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    for eqn in jaxpr.eqns:
+      self.assertEqual(str(eqn.source_info.name_stack), 'foo/bar')
+
+  def test_multiple_name_stack(self):
+
+    def f(x):
+      with extend_name_stack('foo'):
+        y = x + 1
+      with extend_name_stack('bar'):
+        with extend_name_stack('baz'):
+          return y + 1
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'bar/baz')
+
+  def test_call_primitive_jaxpr_should_not_store_outer_name_stack(self):
+    @extend_name_stack('foo')
+    def f(x):
+      @lu.wrap_init
+      @extend_name_stack('bar')
+      def _f(x):
+        return [x + 1]
+      return core.call(_f, x)[0]
+
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+
+    hlo_text = _get_hlo(f)(2)
+    self.assertIn('foo/core_call/bar', hlo_text)
+
+  def test_xla_call_primitive_jaxpr_should_not_store_outer_name_stack(self):
+    @extend_name_stack('foo')
+    def f(x):
+      @jax.jit
+      @extend_name_stack('bar')
+      def _f(x):
+        return x + 1
+      return _f(x)
+
+    jaxpr = jax.make_jaxpr(f)(2).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+
+    hlo_text = _get_hlo(f)(2)
+    self.assertIn('foo/jit(_f)/bar', hlo_text)
+
+  def test_pmap_call_primitive_jaxpr_should_not_store_outer_name_stack(self):
+    @extend_name_stack('foo')
+    @jax.pmap
+    def f(x):
+      with extend_name_stack('bar'):
+        return x + 1
+    jaxpr = jax.make_jaxpr(f)(jnp.ones(1)).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+
+
+class NameStackTransformationTest(_EnableNameStackTestCase):
+
+  def test_vmap_should_transform_name_stack(self):
+    @jax.vmap
+    def f(x):
+      with extend_name_stack('foo'):
+        return x + 1
+    jaxpr = jax.make_jaxpr(f)(jnp.ones(2)).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(foo)')
+
+  def test_vmap_should_transform_inner_name_stacks(self):
+    @extend_name_stack('foo')
+    @jax.vmap
+    def f(x):
+      with extend_name_stack('bar'):
+        with extend_name_stack('baz'):
+          return x + 1
+    jaxpr = jax.make_jaxpr(f)(jnp.ones(2)).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo/vmap(bar)/vmap(baz)')
+
+  def test_vmap_should_apply_to_call_jaxpr(self):
+    @extend_name_stack('foo')
+    @jax.vmap
+    def f(x):
+      @jax.jit
+      @extend_name_stack('bar')
+      def _f(x):
+        return x + 1
+      return _f(x)
+
+    jaxpr = jax.make_jaxpr(f)(jnp.ones(2)).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+
+    hlo_text = _get_hlo(f)(jnp.ones(2))
+    self.assertIn('foo/vmap(jit(_f))/vmap(bar)', hlo_text)
+
+  def test_jvp_should_transform_stacks(self):
+    def f(x):
+      with extend_name_stack('bar'):
+        with extend_name_stack('baz'):
+          return jnp.square(x)
+    g = extend_name_stack('foo')(lambda x, t: jax.jvp(f, (x,), (t,)))
+    jaxpr = jax.make_jaxpr(g)(1., 1.).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack),
+                     'foo/jvp(bar)/jvp(baz)')
+
+  def test_jvp_should_apply_to_call_jaxpr(self):
+    @jax.jit
+    def f(x):
+      with extend_name_stack('bar'):
+        with extend_name_stack('baz'):
+          return jnp.square(x)
+    g = extend_name_stack('foo')(lambda x, t: jax.jvp(f, (x,), (t,)))
+    jaxpr = jax.make_jaxpr(g)(1., 1.).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(
+        str(jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack),
+        'bar/baz')
+
+    hlo_text = _get_hlo(g)(1., 1.)
+    self.assertIn('foo/jvp(jit(f))/jvp(bar)', hlo_text)
+
+  def test_grad_should_add_jvp_and_transpose_to_name_stack(self):
+    @jax.grad
+    def f(x):
+      with extend_name_stack('foo'):
+        return jnp.sin(x)
+    jaxpr = jax.make_jaxpr(f)(1.).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(jaxpr.eqns[2].source_info.name_stack),
+        'transpose(jvp(foo))')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('jvp(foo)/sin', hlo_text)
+    self.assertIn('jvp(foo)/cos', hlo_text)
+    self.assertIn('transpose(jvp(foo))/mul', hlo_text)
+
+  def test_grad_should_add_jvp_and_transpose_to_call_jaxpr(self):
+    @jax.grad
+    @extend_name_stack('foo')
+    @jax.jit
+    def f(x):
+      with extend_name_stack('bar'):
+        return jnp.sin(x)
+    jaxpr = jax.make_jaxpr(f)(1.).jaxpr
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'transpose(jvp(foo))')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['call_jaxpr'].eqns[1].source_info.name_stack), 'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['call_jaxpr'].eqns[0].source_info.name_stack), 'bar')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('jvp(foo)/jvp(jit(f))/jvp(bar)/sin', hlo_text)
+    self.assertIn('jvp(foo)/jvp(jit(f))/jvp(bar)/cos', hlo_text)
+    self.assertIn(
+        'transpose(jvp(foo))/transpose(jvp(jit(f)))/transpose(jvp(bar))/mul',
+        hlo_text)
+
+
+class NameStackControlFlowTest(_EnableNameStackTestCase):
+
+  def test_while_loop_body_should_not_have_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('bar')
+      def body(x):
+        return x + 1
+      @extend_name_stack('bar_cond')
+      def cond(x):
+        return x < 5
+      return lax.while_loop(cond, body, x)
+    jaxpr = jax.make_jaxpr(f)(0)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['body_jaxpr'].eqns[0].source_info.name_stack),
+      'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['cond_jaxpr'].eqns[0].source_info.name_stack),
+      'bar_cond')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('foo/while/body/bar', hlo_text)
+    self.assertIn('foo/while/cond/bar_cond', hlo_text)
+
+  def test_vmap_of_while_loop_should_transform_name_stack(self):
+
+    @jax.vmap
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('bar')
+      def body(x):
+        return x + 1
+      @extend_name_stack('bar_cond')
+      def cond(x):
+        return x < 5
+      return lax.while_loop(cond, body, x)
+    jaxpr = jax.make_jaxpr(f)(jnp.arange(2))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(foo)')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['body_jaxpr'].eqns[0].source_info.name_stack),
+      'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['cond_jaxpr'].eqns[0].source_info.name_stack),
+      'bar_cond')
+
+    hlo_text = _get_hlo(f)(jnp.arange(2.))
+    self.assertIn('vmap(foo)/vmap(while)/vmap(body)/vmap(bar)', hlo_text)
+    self.assertIn('vmap(foo)/vmap(while)/vmap(cond)/vmap(bar_cond)', hlo_text)
+
+  def test_jvp_of_while_loop_transforms_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('bar')
+      def body(x):
+        return x + 1.
+      @extend_name_stack('bar_cond')
+      def cond(x):
+        return x < 5.
+      return lax.while_loop(cond, body, x)
+    g = lambda x, t: jax.jvp(f, (x,), (t,))
+    jaxpr = jax.make_jaxpr(g)(1., 1.)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['body_jaxpr'].eqns[0].source_info.name_stack),
+      'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['cond_jaxpr'].eqns[0].source_info.name_stack),
+      'bar_cond')
+
+    hlo_text = _get_hlo(g)(1., 1.)
+    self.assertIn('jvp(foo)/jvp(while)/jvp(body)/jvp(bar)', hlo_text)
+    self.assertIn('jvp(foo)/jvp(while)/jvp(cond)/jvp(bar_cond)', hlo_text)
+
+  def test_vmap_of_jvp_of_while_loop_transforms_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('bar')
+      def body(x):
+        return x + 1.
+      @extend_name_stack('bar_cond')
+      def cond(x):
+        return x < 5.
+      return lax.while_loop(cond, body, x)
+    g = jax.vmap(lambda x, t: jax.jvp(f, (x,), (t,)))
+    jaxpr = jax.make_jaxpr(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(jvp(foo))')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['body_jaxpr'].eqns[0].source_info.name_stack),
+      'bar')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['cond_jaxpr'].eqns[0].source_info.name_stack),
+      'bar_cond')
+
+    hlo_text = _get_hlo(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(while))/vmap(jvp(body))/vmap(jvp(bar))',
+        hlo_text)
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(while))/vmap(jvp(cond))/vmap(jvp(bar_cond))',
+        hlo_text)
+
+  def test_cond_body_should_not_have_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x + 1
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x - 1
+      return lax.cond(True, true_fn, false_fn, x)
+    jaxpr = jax.make_jaxpr(f)(0)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][0].eqns[0].source_info.name_stack),
+      'false')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][1].eqns[0].source_info.name_stack),
+      'true')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('foo/cond/branch_0_fun/false/sub', hlo_text)
+    self.assertIn('foo/cond/branch_1_fun/true/add', hlo_text)
+
+  def test_vmap_of_cond_should_transform_name_stack(self):
+
+    @extend_name_stack('foo')
+    @jax.vmap
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x + 1
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x - 1
+      return lax.cond(True, true_fn, false_fn, x)
+    jaxpr = jax.make_jaxpr(f)(jnp.arange(2))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][0].eqns[0].source_info.name_stack),
+      'false')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][1].eqns[0].source_info.name_stack),
+      'true')
+
+    hlo_text = _get_hlo(f)(jnp.arange(2.))
+    self.assertIn('foo/vmap(cond)/vmap(branch_0_fun)/vmap(false)/sub', hlo_text)
+    self.assertIn('foo/vmap(cond)/vmap(branch_1_fun)/vmap(true)/add', hlo_text)
+
+  def test_jvp_of_cond_transforms_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x + 1
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x - 1
+      return lax.cond(True, true_fn, false_fn, x)
+    g = lambda x, t: jax.jvp(f, (x,), (t,))
+    jaxpr = jax.make_jaxpr(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][0].eqns[0].source_info.name_stack),
+      'false')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][1].eqns[0].source_info.name_stack),
+      'true')
+
+    hlo_text = _get_hlo(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertIn('jvp(foo)/jvp(cond)/jvp(branch_0_fun)/jvp(false)/sub', hlo_text)
+    self.assertIn('jvp(foo)/jvp(cond)/jvp(branch_1_fun)/jvp(true)/add', hlo_text)
+
+  def test_vmap_of_jvp_of_cond_transforms_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x + 1
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x - 1
+      return lax.cond(True, true_fn, false_fn, x)
+    g = jax.vmap(lambda x, t: jax.jvp(f, (x,), (t,)))
+    jaxpr = jax.make_jaxpr(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(jvp(foo))')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][0].eqns[0].source_info.name_stack),
+      'false')
+    self.assertEqual(str(
+      jaxpr.eqns[0].params['branches'][1].eqns[0].source_info.name_stack),
+      'true')
+
+    hlo_text = _get_hlo(g)(jnp.arange(2.), jnp.ones(2))
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(cond))/vmap(jvp(branch_0_fun))/vmap(jvp(false))/sub',
+        hlo_text)
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(cond))/vmap(jvp(branch_1_fun))/vmap(jvp(true))/add',
+        hlo_text)
+
+  def test_grad_of_cond_transforms_name_stack(self):
+
+    @jax.grad
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x * 2.
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x / 2.
+      return lax.cond(True, true_fn, false_fn, x)
+    jaxpr = jax.make_jaxpr(f)(1.)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack),
+        'transpose(jvp(foo))')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn(
+        'jvp(foo)/jvp(cond)/jvp(branch_0_fun)/jvp(false)/div',
+        hlo_text)
+    self.assertIn(
+        'jvp(foo)/jvp(cond)/jvp(branch_1_fun)/jvp(true)/mul',
+        hlo_text)
+    self.assertIn(
+        'transpose(jvp(foo))/transpose(jvp(cond))/transpose(jvp(branch_0_fun))/transpose(jvp(false))/div',
+        hlo_text)
+    self.assertIn(
+        'transpose(jvp(foo))/transpose(jvp(cond))/transpose(jvp(branch_1_fun))/transpose(jvp(true))/mul',
+        hlo_text)
+
+  def test_vmap_of_grad_of_cond_transforms_name_stack(self):
+
+    @jax.vmap
+    @jax.grad
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('true')
+      def true_fn(x):
+        return x * 2.
+      @extend_name_stack('false')
+      def false_fn(x):
+        return x / 2.
+      return lax.cond(True, true_fn, false_fn, x)
+    jaxpr = jax.make_jaxpr(f)(jnp.arange(2.))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(jvp(foo))')
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack),
+        'vmap(transpose(jvp(foo)))')
+
+    hlo_text = _get_hlo(f)(jnp.arange(2.))
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(cond))/vmap(jvp(branch_0_fun))/vmap(jvp(false))/div',
+        hlo_text)
+    self.assertIn(
+        'vmap(jvp(foo))/vmap(jvp(cond))/vmap(jvp(branch_1_fun))/vmap(jvp(true))/mul',
+        hlo_text)
+    self.assertIn(
+        'vmap(transpose(jvp(foo)))/vmap(transpose(jvp(cond)))/vmap(transpose(jvp(branch_0_fun)))/vmap(transpose(jvp(false)))/div',
+        hlo_text)
+    self.assertIn(
+        'vmap(transpose(jvp(foo)))/vmap(transpose(jvp(cond)))/vmap(transpose(jvp(branch_1_fun)))/vmap(transpose(jvp(true)))/mul',
+        hlo_text)
+
+  def test_scan_body_should_not_have_name_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('scan_body')
+      def body(carry, x):
+        return carry + x, carry + x
+      return lax.scan(body, x, jnp.arange(5.))
+    jaxpr = jax.make_jaxpr(f)(1.)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
+      'scan_body')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('foo/while/body/scan_body', hlo_text)
+
+  def test_vmap_of_scan_should_transform_stack(self):
+
+    @jax.vmap
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('scan_body')
+      def body(carry, x):
+        return carry + x, carry + x
+      return lax.scan(body, x, jnp.arange(8.))
+    jaxpr = jax.make_jaxpr(f)(jnp.arange(2.))
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'vmap(foo)')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
+      'scan_body')
+
+    hlo_text = _get_hlo(f)(jnp.arange(2.))
+    self.assertIn('vmap(foo)/vmap(while)/vmap(body)/vmap(scan_body)/add', hlo_text)
+
+  def test_jvp_of_scan_should_transform_stack(self):
+
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('scan_body')
+      def body(carry, x):
+        return carry + x, carry + x
+      return lax.scan(body, x, jnp.arange(8.))
+    g = lambda x, t: jax.jvp(f, (x,), (t,))
+    jaxpr = jax.make_jaxpr(g)(1., 1.)
+    self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
+      'scan_body')
+
+    hlo_text = _get_hlo(g)(1., 1.)
+    self.assertIn('jvp(foo)/jvp(while)/jvp(body)/jvp(scan_body)/add', hlo_text)
+
+  def test_grad_of_scan_should_transform_stack(self):
+
+    @jax.grad
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('scan_body')
+      def body(carry, x):
+        return carry * x, carry + x
+      return lax.scan(body, x, jnp.arange(8.))[0]
+    jaxpr = jax.make_jaxpr(f)(1.)
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'jvp(foo)')
+    self.assertEqual(str(jaxpr.eqns[3].source_info.name_stack),
+        'transpose(jvp(foo))')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
+      'scan_body')
+
+    hlo_text = _get_hlo(f)(1.)
+    self.assertIn('jvp(foo)/jvp(while)/jvp(body)/jvp(scan_body)/mul', hlo_text)
+    self.assertIn('transpose(jvp(foo))/transpose(jvp(while))/transpose(jvp(body))/transpose(jvp(scan_body))/mul', hlo_text)
+
+  def test_vmap_of_grad_of_scan_should_transform_stack(self):
+
+    @jax.vmap
+    @jax.grad
+    @extend_name_stack('foo')
+    def f(x):
+      @extend_name_stack('scan_body')
+      def body(carry, x):
+        return carry * x, carry + x
+      return lax.scan(body, x, jnp.arange(8.))[0]
+    jaxpr = jax.make_jaxpr(f)(jnp.arange(2.))
+    self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'vmap(jvp(foo))')
+    self.assertEqual(str(jaxpr.eqns[3].source_info.name_stack),
+        'vmap(transpose(jvp(foo)))')
+    self.assertEqual(str(
+      jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
+      'scan_body')
+
+    hlo_text = _get_hlo(f)(jnp.arange(2.))
+    self.assertIn('vmap(jvp(foo))/vmap(jvp(while))/vmap(jvp(body))/vmap(jvp(scan_body))/mul', hlo_text)
+    self.assertIn('vmap(transpose(jvp(foo)))/vmap(transpose(jvp(while)))/vmap(transpose(jvp(body)))/vmap(transpose(jvp(scan_body)))/mul', hlo_text)
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
TLDR; This PR adds a parallel context manager implementation for name stacks, gated by the `jax_experimental_name_stack` config flag. `named_call` uses this new context manager rather than a call primitive. Another public API to access and manipulate the name stack will be in a forthcoming PR along with more detailed documentation.

# Approach

The name stack is a data structure (a stack) that keeps track of both name scopes and transformations. Both scopes and transformations are pushed and popped off the stack. A stack that looks like `[foo, vmap, bar]` will produce the following OP metadata: `'foo/vmap(bar)'`, indicating that the bar stack is transformed by a `vmap` transformation. The `jvp` and `transpose` transformations are also example transformations that can be on the name stack.

## Part 1: Annotations in jaxprs

The name stack mechanism needs to somehow record information into jaxprs, to ensure it's preserved through transformations that stage out Python code into a jaxpr and reinterpret that jaxpr.

How do we use a context manager to annotate jaxprs? Let’s say that each jaxpr equation has a new `name_stack` field that records the desired XLA HLO annotations we want when the jaxpr is lowered. How do we populate the `name_stack` field with a context manager?

First let’s implement a simple context manager API:
```python
@contextmanager
def extend_name_stack(name):
  # appends `name` to the active name stack

def current_name_stack(name):
  # returns the current name stack
```

A simple use case for this function is annotating primitives within a function.

```python
def f(x):
  with extend_name_stack('bar'):
    return x * 2.
```

We hope that when this function is staged out to a jaxpr we get the following annotations (represented in brackets after the equation).
```
{ lambda a:float64[] .
let b:float64[] = mul a 2.0 # [bar]
in ( b ) }
```

We can modify the trace that builds jaxprs to call `current_name_stack()` when it’s creating an equation to populate the `name_stack` field.

This is a simple strategy for propagating information from a context manager into the staged out jaxpr. In practice, we utilize the `source_info` tracking already present in JAX and augment the `SourceInfo` with a name stack field.

## Part 2: Final style transformations

What’s the desired behavior when functions with `extend_name_stack`s in them are transformed? When a particular primitive is reinterpreted under a transformation we’d like to modify the name stack to include information about the transformation.

Take the following vmap example:
```python
@vmap
def f(x):
  with append_name_stack('bar'):
    return x * 2.
```

We’d like the following annotated jaxpr:
```
{ lambda a:float64[2] .
let b:float64[2] = broadcast [ axes=[0] shape=[2] ] 2.0 # [vmap(bar))]
    c:float64[2] = mul a b # [vmap(bar)]
in ( c ) }
```

See how we have `vmap(bar)` annotations for both the `broadcast` and the `mul`. How do we modify our context manager for this use case? Let’s support adding “transformations” to the name stack.
```python
@contextmanager
def transform_name_stack(name):
  # appends `name` to the active name stack as a transformation
```

In our vmap implementation we can do something like this:
```python
def vmap(f):
  def wrapped(*args, **kwargs):
    with transform_name_stack('vmap'):
      out = …
    …
  return wrapped
```

When we vmap a function we’ll have a transform on the name stack which we can then postprocess to produce the `vmap(bar)` annotation we desire. We can do the same for all final-style transformations, i.e. the transformations implemented as Traces vs jaxpr interpreters (e.g. jvp).

## Part 3: Initial style transformations

Initial style transformations like grad or the control flow primitives first trace a function out into a jaxpr, then reinterpret it in some interesting way. `grad`, for example, traces the partially evaluated `jvp` of a function into a jaxpr and interprets the resulting jaxpr backwards to obtain gradients.

This brings up a potential issue with adding annotations using a dynamically scoped name stack. Recall that we add annotations to jaxpr eqns via the `DynamicJaxprTrace` looking up the currently active name stack. If we’re staging out a jaxpr while inside of another transformation (which is the case in initial style transformations), we’ll include that transform’s annotation in the stack. For example, consider a no-op initial style transformation that stages out and immediately evaluates a jaxpr.
```python
def reinterpret(f):
  def wrapped(*args):
    jaxpr = make_jaxpr(f)(*args)
    return eval_jaxpr(jaxpr, *args)
  return wrapped
```

We could imagine that if there's a `foo` name stack active outside of the call to `reinterpret`, we'll bake `foo` into the name stacks in the `jaxpr` and then add yet another `foo` when calling `eval_jaxpr`. Furthermore, what do we do with the name stacks backed into the jaxpr themselves? We have to be careful about how we treat name stacks in this setting.

#### `eval_jaxpr`

How does eval_jaxpr handle annotations? We have a couple choices. We could have it just inherit the current active name stack, i.e.:
```python
def eval_jaxpr(jaxpr, *args):
  …
  for eqn in jaxpr.eqns:
    …
    ans = eval_eqn(eqn, …)
  …
```
However, if the equations we’re evaluating have name stacks, they will be discarded and we will lose information. We need to somehow preserve the name stacks in the jaxpr we’re evaluating. We could instead re-use that information, throwing away the current name stack info using a `set_name_stack` context manager.
```python
def eval_jaxpr(jaxpr, *args):
  …
  for eqn in jaxpr.eqns:
    …
    with set_name_stack(eqn.name_stack): # overrides current name stack
      ans = eval_eqn(eqn, …)
  …
```
This is also incorrect, however. We want to use the current active name stack as well since we might be transforming eval_jaxpr from the outside. We thus need to prepend the current active name stack to the one from the equation.
```python
def eval_jaxpr(jaxpr, *args):
  …
  for eqn in jaxpr.eqns:
    …
    with set_name_stack(get_current_stack() + eqn.name_stack):       
      ans = eval_eqn(eqn, …)
    …
```

#### `make_jaxpr`
Now consider the following example.
```python
@vmap
@reinterpret
def f(x):
  with append_name_stack('bar'):
    return x * 2.
f(jnp.ones(2))
```

In principle, we should obtain the same annotations as before (`vmap(bar)`). However, in our currently implementation we first obtain a jaxpr in reinterpret. Since that jaxpr is using dynamically scoped annotations, it will annotate the mul with a `vmap(bar)` even though we’re not actually doing a vmap – we’re just staging out an unbatched function. The actual vmapping happens when we call `eval_jaxpr`. If we’re staging out the entirety of `f` into jaxpr, the vmap will still be on the stack when we call `eval_jaxpr` and we will get a doubly-annotated `vmap(vmap(bar))`, an incorrect annotation. This is a huge problem!

This pattern of transforming an initial style transformation occurs everywhere (`vmap(grad)` is an example of this). How do we modify our implementation to get the right annotations?

First, while building the jaxpr, we need to start with an empty active name stack rather than the current active name stack. We can accomplish this with another context manager that essentially clears the active name stack:
```python
@contextmanager
def reset_name_stack():
  # sets the current name stack to be empty
```

Right before we build a jaxpr, we make sure to clear the active name stack.
```python
def make_jaxpr(f):
  def wrapped(*args):
    with reset_name_stack():
      jaxpr = …
    return jaxpr
  return wrapped
```

The jaxpr we now stage from the example will no longer have a `vmap(bar)` annotation (it will just have a bar annotation). When we eval_jaxpr, the vmap on the name stack will be prepended to the bar to produce the appropriate vmap(bar).

This strategy of disabling the name stack when staging out to a jaxpr and prepending the active name stack to the one from the jaxpr equation generalizes to other instances of staging out and reinterpreting, for example with control flow primitives. We need to make sure that when tracing out a body function to a jaxpr, for example, it is staged out without the active name stack. When the body is reinterpreted in the context of a loop, eval_jaxpr will add the active name stack back in.

### Part 4: `partial_eval`
Partial evaluation is a particularly tricky case because it both evaluates and stages at the same time. We thus need to be careful about how we annotate both the evaluated primitives and the staged out ones. We can use the same principles from before though: disable the name stack when we stage out and enable when we are evaluating. 

How do we emulate this when we’re in a final style transformation though? In an initial style transformation, the distinction between staging and evaluation is very clear and there are obvious places to disable and enable the name stack. In a partial eval trace, when we evaluate a primitive there will be names on the stack from outside of the partial eval trace and from inside. When we stage out, we want to annotate the jaxpr equation with the names from the “inside”, not the “outside”. Here’s an example:
```python
@vmap
@partial_eval
def f(x, y):
  with append_name_stack('foo'):
    x = x + 1
  with append_name_stack('bar'):
    y = y + 1
  return x, y
```

Let’s say this partial_eval transformation treats x as known and y as unknown. We thus want to evaluate `x + 1` and stage `y + 1` into a jaxpr. When we evaluate `x + 1` we’d like it to be annotated with `vmap(foo)` but when we stage out `y + 1` we want it to be staged out with just `bar`, not `vmap(bar)`. 

When we’re inside of the partial eval trace, we need to distinguish between the names that are added outside of the partial eval (`vmap` in this case) and the ones inside (`foo` and `bar`). We can accomplish this by recording the name stack before the partial eval trace and removing it when staging out a jaxpr eqn.

```python
def partial_eval_flat(f, pvals_in):                                                                                                                     
                                                                                                           
  outer_stack = current_name_stack()                                                                                                                                                   
  with new_main(PartialEvalTrace, outer_stack) as main:                                                                                                                                                                                                                           
    outs = …                                                                                                                                                         
  return jaxpr, pvals_out, consts
```

Any names added to the stack while doing the partial eval will be the inside names. Inside of the `process_primitive` for partial eval, we can do the following:
```python
def process_primitive(self, primitive, tracers, params):                                                                                                                                       
  if all(t.pval.is_known for t in tracers):      
      return bind(primitive, *map(full_lower, tracers), **params)           
  …
  # grab the portion of the name stack that extends beyond the outer name stack
  name_stack = current_name_stack()[len(self.outer_name_stack):]                                                                                               
  eqn = JaxprEqnRecipe(..., name_stack)
  …                                                                                                                  
```
If we evaluate inside of partial eval, we use the full stack (outer + inner). If we stage out, then we just use the inner names.

# Implementation details

The goal of this implementation is to preserve the previous mechanism and enable the context-manager behind a `config` flag. To accomplish this, we have two parallel mechanisms keeping track of the name stack and decide to use one or the other when lowering.

* To add a name scope to the name stack, we use `source_info_util.extend_name_stack`, a context manager that pushes a name onto the stack and pops it off after the context manager exits. There is also `source_info_util.transform_name_stack` that pushes a transformation onto the stack.
* When we lower a jaxpr to HLO (`xla_subcomp`), we, by default, use the current mechanism for adding OP metadata to the HLO. If `jax_experimental_name_stack` is enabled, however, we use the name stack from the `SourceInfo` (i.e the jaxpr equation). We make sure to thread an equation's name stack into any sub contexts use to generate HLO for say call primitive jaxprs.
* To inspect and debug name stacks, you can now do `jaxpr.pretty_print(name_stack=True)` to have name stacks print for each equation.