### PR TITLE
jax.numpy: add missing uint definition

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -42,11 +42,13 @@ _bfloat16_dtype: np.dtype = np.dtype(bfloat16)
 
 bool_: type = np.bool_
 int_: type = np.int64
+uint: type = np.uint64
 float_: type = np.float64
 complex_: type = np.complex128
 
 # TODO(phawkins): change the above defaults to:
 # int_ = np.int32
+# uint = np.uint32
 # float_ = np.float32
 # complex_ = np.complex64
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -418,6 +418,7 @@ complex64 = csingle = _make_scalar_type(np.complex64)
 complex128 = cdouble = _make_scalar_type(np.complex128)
 
 int_ = int32 if dtypes.int_ == np.int32 else int64
+uint = uint32 if dtypes.uint == np.uint32 else uint64
 float_ = float32 if dtypes.float_ == np.float32 else float64
 complex_ = complex64 if dtypes.complex_ == np.complex64 else complex128
 

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -365,6 +365,7 @@ from jax._src.numpy.lax_numpy import (
     triu_indices_from as triu_indices_from,
     true_divide as true_divide,
     trunc as trunc,
+    uint as uint,
     uint16 as uint16,
     uint32 as uint32,
     uint64 as uint64,


### PR DESCRIPTION
numpy defines `np.uint`, which is the unsigned equivalent of `np.int_`. JAX should define this as well. Related to #8178.