### PR TITLE
[sparse]: add tracer-based implementation of sparsify

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -232,4 +232,7 @@ from .ops import (
 )
 
 from .random import random_bcoo as random_bcoo
-from .transform import sparsify as sparsify
+from .transform import (
+    sparsify as sparsify,
+    SparseTracer as SparseTracer,
+)


### PR DESCRIPTION
Co-authored by: @mattjj

Eventually I think we'll choose one implementation to stick with; for now we'll keep both in parallel.