### PR TITLE
Document jax.lax.Precision

### DIFF
--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -68,7 +68,7 @@ def conv_general_dilated_patches(
       `(lhs_spec, rhs_spec, out_spec)`, where each element is a string
       of length `n+2`. `None` defaults to `("NCHWD..., OIHWD..., NCHWD...")`.
     precision: Optional. Either ``None``, which means the default precision for
-      the backend, or a ``lax.Precision`` enum value (``Precision.DEFAULT``,
+      the backend, or a :class:`~jax.lax.Precision` enum value (``Precision.DEFAULT``,
       ``Precision.HIGH`` or ``Precision.HIGHEST``).
     preferred_element_type: Optional. Either ``None``, which means the default
       accumulation type for the input types, or a datatype, indicating to

--- a/jax/_src/lax/polar.py
+++ b/jax/_src/lax/polar.py
@@ -71,7 +71,7 @@ def polar(a, side='right', method='qdwh', eps=None, maxiter=50):
       If side is "right" then `a = up`. If side is "left" then `a = pu`. The
       default is "right".
     method: Determines the algorithm used, as described above.
-    precision: Controls the TPU matrix multiplication precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
 
     The remaining arguments are only meaningful if method is "qdwh".
     eps: The final result will satisfy |X_k - X_k-1| < |X_k| * (4*eps)**(1/3) .

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -64,9 +64,9 @@ _PRECISION_DOC = """\
 In addition to the original NumPy arguments listed below, also supports
 ``precision`` for extra control over matrix-multiplication precision
 on supported devices. ``precision`` may be set to ``None``, which means
-default precision for the backend, a ``lax.Precision`` enum value
+default precision for the backend, a :class:`~jax.lax.Precision` enum value
 (``Precision.DEFAULT``, ``Precision.HIGH`` or ``Precision.HIGHEST``) or a tuple
-of two ``lax.Precision`` enums indicating separate precision for each argument.
+of two :class:`~jax.lax.Precision` enums indicating separate precision for each argument.
 """
 
 # We replace some builtin names to follow Numpy's API, so we capture here.

--- a/jax/_src/scipy/eigh.py
+++ b/jax/_src/scipy/eigh.py
@@ -98,7 +98,7 @@ def _split_spectrum_jittable(P, H, V0, rank, precision):
     H: Matrix to be projected.
     V0: Accumulates the isometries into the projected subspaces.
     rank: Rank of P.
-    precision: The matmul precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
   Returns:
     H1, V1: Projection of H into the column space of P, and the accumulated
             isometry performing that projection.
@@ -128,7 +128,7 @@ def split_spectrum(H, split_point, V0=None, precision=lax.Precision.HIGHEST):
     H: The Hermitian matrix to split.
     split_point: The eigenvalue to split along.
     V0: Matrix of isometries to be updated.
-    precision: TPU matmul precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
   Returns:
     Hm: A Hermitian matrix sharing the eigenvalues of `H` beneath
       `split_point`.
@@ -164,7 +164,7 @@ def _eigh_work(
   Args:
     H: The Hermitian input.
     V: Stores the isometries projecting H into its subspaces.
-    precision: The matmul precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
 
   Returns:
     H, V: The result of the projection.
@@ -197,7 +197,7 @@ def eigh(
 
   Args:
     H: The `n x n` Hermitian input.
-    precision: The matmul precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
     symmetrize: If True, `0.5 * (H + H.conj().T)` rather than `H` is used.
     termination_size: Recursion ends once the blocks reach this linear size.
   Returns:
@@ -225,7 +225,7 @@ def svd(A, precision=lax.Precision.HIGHEST):
 
   Args:
     A: The `m` by `n` input matrix.
-    precision: TPU matmul precision.
+    precision: :class:`~jax.lax.Precision` object specifying the matmul precision.
   Returns:
     U: An `m` by `m` unitary matrix of `A`'s left singular vectors.
     S: A length-`min(m, n)` vector of `A`'s singular values.


### PR DESCRIPTION
Fixes #8447

View generated documentation here: https://jax--8450.org.readthedocs.build/en/8450/jax.lax.html#jax.lax.Precision

Since it's not possible to set the `__doc__` attribute of a pybind11 enum, I chose to add this documentation through inheritance, and changed some of the call sites based on this.

@hawkinsp please double-check the description of each enum value: I think there may be relevant parts that I missed, and there are details that I'm unsure of. I'm pulling in before review to check for pytype issues.