### PR TITLE
add internal `vmappable` interface (part 1)

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2750,6 +2750,8 @@ class APITest(jtu.JaxTestCase):
 
   def test_leak_checker_avoids_false_positives(self):
     with jax.checking_leaks():
+      api.vmap(lambda x: x)(np.arange(3.))  # doesn't crash
+
       @jit
       def f(x):
         return x
@@ -3038,37 +3040,6 @@ class APITest(jtu.JaxTestCase):
     f.defvjp(f_fwd, f_rev)
 
     api.grad(lambda x: f(f(f(x))))(1.)
-
-  def test_custom_vjp_scan_batching_edge_case(self):
-    # https://github.com/google/jax/issues/5832
-    @jax.custom_vjp
-    def mul(x, coeff): return x * coeff
-    def mul_fwd(x, coeff): return mul(x, coeff), (x, coeff)
-    def mul_bwd(res, g):
-        x, coeff = res
-        g_x = g * coeff
-        g_coeff = (x * g).sum()
-        return g_x, g_coeff
-    mul.defvjp(mul_fwd, mul_bwd)
-
-    def scan_over_mul(x, coeff):
-        def f_(x, t):
-            return mul(x, coeff), None
-        y, _ = jax.lax.scan(f_, x, jnp.arange(3))
-        return y
-
-    key = jax.random.PRNGKey(0)
-    key1, key2 = jax.random.split(key, 2)
-    x_batch = jax.random.normal(key1, (3, 2))
-    covector_batch = jax.random.normal(key2, (3, 2))
-    coeff = jnp.array(1.)
-
-    batched_scan_over_mul = jax.vmap(scan_over_mul, in_axes=(0, None), out_axes=0)
-    res, vjp_fun = jax.vjp(batched_scan_over_mul, x_batch, coeff)
-    vjp_fun(covector_batch)  # doesn't crash
-
-    jtu.check_grads(batched_scan_over_mul, (x_batch, coeff), order=2,
-                    modes=['rev'])
 
   def test_jit_inline(self):
     @partial(api.jit, inline=False)
@@ -6010,6 +5981,37 @@ class CustomVJPTest(jtu.JaxTestCase):
     f.defvjp(f_fwd, f_bwd)
 
     jax.jit(lambda x: jax.vjp(f, 0., x)[1](1.))(1)  # doesn't crash
+
+  def test_custom_vjp_scan_batching_edge_case(self):
+    # https://github.com/google/jax/issues/5832
+    @jax.custom_vjp
+    def mul(x, coeff): return x * coeff
+    def mul_fwd(x, coeff): return mul(x, coeff), (x, coeff)
+    def mul_bwd(res, g):
+        x, coeff = res
+        g_x = g * coeff
+        g_coeff = (x * g).sum()
+        return g_x, g_coeff
+    mul.defvjp(mul_fwd, mul_bwd)
+
+    def scan_over_mul(x, coeff):
+        def f_(x, t):
+            return mul(x, coeff), None
+        y, _ = jax.lax.scan(f_, x, jnp.arange(3))
+        return y
+
+    key = jax.random.PRNGKey(0)
+    key1, key2 = jax.random.split(key, 2)
+    x_batch = jax.random.normal(key1, (3, 2))
+    covector_batch = jax.random.normal(key2, (3, 2))
+    coeff = jnp.array(1.)
+
+    batched_scan_over_mul = jax.vmap(scan_over_mul, in_axes=(0, None), out_axes=0)
+    res, vjp_fun = jax.vjp(batched_scan_over_mul, x_batch, coeff)
+    vjp_fun(covector_batch)  # doesn't crash
+
+    jtu.check_grads(batched_scan_over_mul, (x_batch, coeff), order=2,
+                    modes=['rev'])
 
 
 class CustomTransposeTest(jtu.JaxTestCase):


### PR DESCRIPTION
This is the first part of a change to add a 'vmappable' typeclass. It's for internal use only at the moment but we may want to open it up to users at some point.

We currently have two ways to add new data types to jax, in the sense of the data types being allowed as inputs and outputs of transformed functions:
1. We can add a new type to jaxprs. That's fully general, and decently modularized, but it is pretty heavyweight: lots of table entries have to be added, reflecting the fact that every part of the system has to learn about the new data type. For example, it needs a lowering to HLO, it needs a tangent type for AD, it needs to be supported by the vmap utility functions, etc.
2. We can add a new pytree type. That's lightweight (no other part of the system has to learn about the new data type!), but pretty restrictive: the data type has to be isomorphic to a tuple (plus some limited metadata). That means we don't get to control how the new data type interacts with, say, AD or vmapping: those interactions are fixed for us (e.g. the tangent type of our new type is determined by its isomorphism to tuples and the tangent type for tuples).

The high level idea here is to add a new mechanism for each transform which gives us both flexibility and light weight.

We want this new mechanism because we want to add some new data types (e.g. PRNGKeyArray, arrays with general element types, sparse array types) which require more general interactions with transformations than afforded by pytrees, but we don't want to plumb them through jaxprs (at least at first). For example, these kinds of mechanisms mean we won't need wrappers for e.g. `grad` and `vmap` in the sparse array code.

This PR starts adding such a mechanism for `vmap`, though we'll also want some others (e.g. for AD). It's just a start because there's immediate follow-up work to do:
* make `vmap` not use pytrees at all, by instead registering all pytree-registered types as vmappable (using the provided isomorphism with tuples to instantiate the vmappable typeclass);
* document the design and the user api;
* add other typeclasses, so that we can e.g. unregister PRNGKeyArray as a pytree.

In other words, I'm attempting some land-and-iterate progress here. This bit should already be useful!

cc @froystig @jakevdp 