### PR TITLE
generalize lax.switch to take any number of operands

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -597,6 +597,40 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertEqual(fun(4), cfun(4))
     self.assertEqual(fun(4), (8, 16))
 
+  def testCondTwoOperands(self):
+    # see https://github.com/google/jax/issues/8469
+    self.skipTest("two-operand cond behavior is ambiguous (#8469)")
+
+    add, mul = lax.add, lax.mul
+
+    def fun(x):
+      return add(x, x) if x == 0 else mul(x, x)
+
+    def cfun(x):
+      return lax.cond(x == 0, add, mul, x, x)
+
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+    cfun = jax.jit(cfun)
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+
+  def testCondThreeOperands(self):
+    add = lambda x, y, z: x + y + z
+    mul = lambda x, y, z: x * y * z
+
+    def fun(x):
+      return add(x, x, x) if x == 0 else mul(x, x, x)
+
+    def cfun(x):
+      return lax.cond(x == 0, add, mul, x, x, x)
+
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+    cfun = jax.jit(cfun)
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+
   def testSwitch(self):
     def branch(x):
       y = lax.mul(2, x)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -665,6 +665,26 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertEqual(fun(2), cfun(2))
     self.assertEqual(fun(3), cfun(3))
 
+  def testSwitchMultiOperands(self):
+    branches = [lax.add, lax.mul]
+
+    def fun(x):
+      i = 0 if x <= 0 else 1
+      return branches[i](x, x)
+
+    def cfun(x):
+      return lax.switch(x, branches, x, x)
+
+    self.assertEqual(fun(-1), cfun(-1))
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+    self.assertEqual(fun(2), cfun(2))
+    cfun = jax.jit(cfun)
+    self.assertEqual(fun(-1), cfun(-1))
+    self.assertEqual(fun(0), cfun(0))
+    self.assertEqual(fun(1), cfun(1))
+    self.assertEqual(fun(2), cfun(2))
+
   def testSwitchResidualsMerge(self):
     def get_conds(fun):
       jaxpr = jax.make_jaxpr(jax.grad(fun))(0., 0)


### PR DESCRIPTION
Also add tests for multi-operand `cond` (#8467), one of which reveals issue #8469.