### PR TITLE
jax.experimental.tree_math

### DIFF
--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -256,7 +256,11 @@ def _get_tree(vector):
   return vector.tree
 
 
-def unwrap(fun, vector_argnums=None, vector_argnames=None):
+def _maybe_vector(condition, arg):
+  return Vector(arg) if condition else arg
+
+
+def unwrap(fun, vector_argnums=None, vector_argnames=None, out_vectors=True):
   """Convert a pytree -> pytree function to a vector -> vector function."""
   vector_argnums, vector_argnames = _infer_argnums_and_argnames(
       fun, vector_argnums, vector_argnames)
@@ -264,7 +268,6 @@ def unwrap(fun, vector_argnums=None, vector_argnames=None):
   def wrapper(*args, **kwargs):
     args = _apply_argnums(_get_tree, args, vector_argnums)
     kwargs = _apply_argnames(_get_tree, kwargs, vector_argnames)
-    # TODO(shoyer): add out_vectors argument so this behavior can be customized,
-    # similar to vmap's out_axes.
-    return Vector(fun(*args, **kwargs))
+    result = fun(*args, **kwargs)
+    return tree_util.tree_map(_maybe_vector, out_vectors, result)
   return wrapper

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -19,7 +19,6 @@ from typing import Tuple
 
 from jax import tree_util
 from jax._src import api
-from jax._src.util import prod
 import jax.numpy as jnp
 
 
@@ -142,7 +141,7 @@ class Vector:
   @property
   def size(self):
     values = tree_util.tree_leaves(self.tree)
-    return sum(prod(jnp.shape(value)) for value in values)
+    return sum(jnp.size(value) for value in values)
 
   def __len__(self):
     return self.size

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -230,8 +230,9 @@ def _apply_argnames(wrapper, kwargs, argnames):
           for k, arg in kwargs.items()}
 
 
-def _get_tree(vector):
-  return vector.tree
+
+def _maybe_get_tree(arg):
+  return arg.tree if isinstance(arg, Vector) else arg
 
 
 def _is_vector(arg):
@@ -247,8 +248,12 @@ def wrap(fun, vector_argnums=None, vector_argnames=None):
     args = _apply_argnums(Vector, args, vector_argnums)
     kwargs = _apply_argnames(Vector, kwargs, vector_argnames)
     result = fun(*args, **kwargs)
-    return tree_util.tree_map(_get_tree, result, is_leaf=_is_vector)
+    return tree_util.tree_map(_maybe_get_tree, result, is_leaf=_is_vector)
   return wrapper
+
+
+def _get_tree(vector):
+  return vector.tree
 
 
 def unwrap(fun, vector_argnums=None, vector_argnames=None):

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -1,0 +1,240 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import operator
+import typing
+from typing import Tuple
+
+from jax import tree_util
+from jax._src.util import prod
+import jax.numpy as jnp
+
+
+def _flatten_together(*args):
+  """Flatten a collection of pytrees with matching structure/shapes together."""
+  all_values, all_treedefs = zip(*map(tree_util.tree_flatten, args))
+  all_treedefs = typing.cast(Tuple[tree_util.PyTreeDef, ...], all_treedefs)
+
+  if not all(treedef == all_treedefs[0] for treedef in all_treedefs[1:]):
+    treedefs_str = ' vs '.join(map(str, all_treedefs))
+    raise ValueError(
+        f"arguments have different tree structures: {treedefs_str}"
+    )
+
+  all_shapes = [list(map(jnp.shape, values)) for values in all_values]
+  if not all(shapes == all_shapes[0] for shapes in all_shapes[1:]):
+    shapes_str = ' vs '.join(map(str, all_shapes))
+    raise ValueError(f"tree leaves have different array shapes: {shapes_str}")
+
+  return all_values, all_treedefs[0]
+
+
+def _argnums_partial(f, args, static_argnums):
+  def g(*args3):
+    args3 = list(args3)
+    for i in static_argnums:
+      args3.insert(i, args[i])
+    return f(*args3)
+  args2 = tuple(x for i, x in enumerate(args) if i not in static_argnums)
+  return g, args2
+
+def _broadcasting_map(func, *args):
+  """Like tree_map, but scalar arguments are broadcast to all leaves."""
+  static_argnums = [i for i, x in enumerate(args) if not isinstance(x, Vector)]
+  func2, vector_args = _argnums_partial(func, args, static_argnums)
+  if not vector_args:
+    # TODO(shoyer): return a trivial Vector instead?
+    return func2()
+  # check shape compatibility
+  _flatten_together(*[arg.tree for arg in vector_args])
+  for arg in args:
+    if not isinstance(arg, Vector):
+      shape = jnp.shape(arg)
+      if shape != ():
+        raise TypeError(f"non-tree_math.Vector arguments must be scalars: {arg}")
+  return tree_util.tree_map(func2, *vector_args)
+
+
+def _binary_method(func, name):
+  """Implement a forward binary method, e.g., __add__."""
+  def wrapper(self, other):
+    return _broadcasting_map(func, self, other)
+  wrapper.__name__ = f'__{name}__'
+  return wrapper
+
+
+def _reflected_binary_method(func, name):
+  """Implement a reflected binary method, e.g., __radd__."""
+  def wrapper(self, other):
+    return _broadcasting_map(func, other, self)
+  wrapper.__name__ = f'__r{name}__'
+  return wrapper
+
+
+def _numeric_methods(func, name):
+  """Implement forward and reflected methods."""
+  return (_binary_method(func, name), _reflected_binary_method(func, name))
+
+
+def _unary_method(func, name):
+  def wrapper(self):
+    return tree_util.tree_map(func, self)
+  wrapper.__name__ = f'__{name}__'
+  return wrapper
+
+
+def matmul(left, right, *, precision=None):
+  if not isinstance(left, Vector) or not isinstance(right, Vector):
+    raise TypeError("matmul arguments must both be tree_math.Vector objects")
+
+  def _vector_dot(a, b):
+    return jnp.dot(jnp.ravel(a), jnp.ravel(b), precision=precision)
+
+  (left_values, right_values), _ = _flatten_together(left.tree, right.tree)
+  parts = map(_vector_dot, left_values, right_values)
+  return functools.reduce(operator.add, parts)
+
+
+@tree_util.register_pytree_node_class
+class Vector:
+  """A wrapper for treating an arbitrary pytree as a 1D vector."""
+  def __init__(self, tree):
+    self._tree = tree
+
+  @property
+  def tree(self):
+    return self._tree
+
+  # TODO(shoyer): consider casting to a common dtype?
+
+  def __repr__(self):
+    return f'tree_math.Vector({self._tree!r})'
+
+  def tree_flatten(self):
+    return (self.tree,), None
+
+  @classmethod
+  def tree_unflatten(cls, _, args):
+    return cls(*args)
+
+  def __len__(self):
+    values = tree_util.tree_leaves(self.tree)
+    return sum(prod(jnp.shape(value)) for value in values)
+
+  @property
+  def shape(self):
+    return (len(self),)
+
+  @property
+  def ndim(self):
+    return 1
+
+  @property
+  def dtype(self):
+    values = tree_util.tree_leaves(self.tree)
+    return jnp.result_type(*values)
+
+  # comparison
+  __lt__ = _binary_method(operator.lt, 'lt')
+  __le__ = _binary_method(operator.le, 'le')
+  __eq__ = _binary_method(operator.eq, 'eq')
+  __ne__ = _binary_method(operator.ne, 'ne')
+  __ge__ = _binary_method(operator.ge, 'ge')
+  __gt__ = _binary_method(operator.gt, 'gt')
+
+  # arithmetic
+  __add__, __radd__ = _numeric_methods(operator.add, 'add')
+  __sub__, __rsub__ = _numeric_methods(operator.sub, 'sub')
+  __mul__, __rmul__ = _numeric_methods(operator.mul, 'mul')
+  __truediv__, __rtruediv__ = _numeric_methods(operator.truediv, 'truediv')
+  __floordiv__, __rfloordiv__ = _numeric_methods(operator.floordiv, 'floordiv')
+  __mod__, __rmod__ = _numeric_methods(operator.mod, 'mod')
+  __pow__, __rpow__ = _numeric_methods(operator.pow, 'pow')
+  # __divmod__, __rdivmod__ = _numeric_methods(divmod, 'divmod')  # TODO(shoyer): fix me
+  __matmul__ = __rmatmul__ = matmul
+
+  # bitwise
+  __lshift__, __rlshift__ = _numeric_methods(operator.lshift, 'lshift')
+  __rshift__, __rrshift__ = _numeric_methods(operator.rshift, 'rshift')
+  __and__, __rand__ = _numeric_methods(operator.and_, 'and')
+  __xor__, __rxor__ = _numeric_methods(operator.xor, 'xor')
+  __or__, __ror__ = _numeric_methods(operator.or_, 'or')
+
+  # unary methods
+  __neg__ = _unary_method(operator.neg, 'neg')
+  __pos__ = _unary_method(operator.pos, 'pos')
+  __abs__ = _unary_method(abs, 'abs')
+  __invert__ = _unary_method(operator.invert, 'invert')
+
+  # numpy methods
+  conj = _unary_method(jnp.conj, 'conj')
+
+  def sum(self):
+    parts = map(jnp.sum, tree_util.tree_leaves(self))
+    return functools.reduce(operator.add, parts)
+
+  def mean(self):
+    return self.sum() / len(self)
+
+  def min(self):
+    parts = map(jnp.min, tree_util.tree_leaves(self))
+    return jnp.asarray(list(parts)).min()
+
+  def max(self):
+    parts = map(jnp.max, tree_util.tree_leaves(self))
+    return jnp.asarray(list(parts)).max()
+
+
+def where(condition, x, y):
+  """Tree math compatible version of jnp.where."""
+  return _broadcasting_map(jnp.where, condition, x, y)
+
+
+zeros_like = functools.partial(tree_util.tree_map, jnp.zeros_like)
+ones_like = functools.partial(tree_util.tree_map, jnp.ones_like)
+
+def full_like(x, *args, **kwargs):
+  return tree_util.tree_map(lambda y: jnp.full_like(y, *args, **kwargs), x)
+
+maximum = functools.partial(_broadcasting_map, jnp.maximum)
+minimum = functools.partial(_broadcasting_map, jnp.minimum)
+square = functools.partial(_broadcasting_map, jnp.square)
+
+
+def _get_tree(vector):
+  return vector.tree
+
+
+def _is_vector(arg):
+  return isinstance(arg, Vector)
+
+
+# TODO(shoyer): add an explicit option for indicating
+# vector_argnums/vector_argnames in wrap/unwrap like
+# static_argnums/static_argnames in jit.
+
+def wrap(func):
+  """Convert a vector -> vector function to a pytree -> pytree function."""
+  def wrapper(*args):
+    result = func(*map(Vector, args))
+    return tree_util.tree_map(_get_tree, result, is_leaf=_is_vector)
+  return wrapper
+
+
+def unwrap(func):
+  """Convert a pytree -> pytree function to a vector -> vector function."""
+  def wrapper(*args):
+    return Vector(func(*[arg.tree for arg in args]))
+  return wrapper

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -19,6 +19,7 @@ from typing import Tuple
 
 from jax import tree_util
 from jax._src import api
+from jax._src.tree_util import tree_unflatten
 from jax._src.util import prod
 import jax.numpy as jnp
 
@@ -50,6 +51,7 @@ def _argnums_partial(f, args, static_argnums):
     return f(*args3)
   args2 = tuple(x for i, x in enumerate(args) if i not in static_argnums)
   return g, args2
+
 
 def _broadcasting_map(func, *args):
   """Like tree_map, but scalar arguments are broadcast to all leaves."""
@@ -163,8 +165,13 @@ class Vector:
   __floordiv__, __rfloordiv__ = _numeric_methods(operator.floordiv, 'floordiv')
   __mod__, __rmod__ = _numeric_methods(operator.mod, 'mod')
   __pow__, __rpow__ = _numeric_methods(operator.pow, 'pow')
-  # __divmod__, __rdivmod__ = _numeric_methods(divmod, 'divmod')  # TODO(shoyer): fix me
   __matmul__ = __rmatmul__ = matmul
+
+  # TODO(shoyer): implement this via divmod() on the leaves
+  def __divmod__(self, other):
+    return self // other, self % other
+  def __rdivmod__(self, other):
+    return other // self, other % self
 
   # bitwise
   __lshift__, __rlshift__ = _numeric_methods(operator.lshift, 'lshift')

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -19,7 +19,6 @@ from typing import Tuple
 
 from jax import tree_util
 from jax._src import api
-from jax._src.tree_util import tree_unflatten
 from jax._src.util import prod
 import jax.numpy as jnp
 

--- a/jax/experimental/tree_math.py
+++ b/jax/experimental/tree_math.py
@@ -199,6 +199,8 @@ class Vector:
   # numpy methods
   conj = _unary_method(jnp.conj, 'conj')
   dot = matmul
+  real = property(_unary_method(jnp.real, 'real'))
+  imag = property(_unary_method(jnp.imag, 'imag'))
 
   def sum(self):
     parts = map(jnp.sum, tree_util.tree_leaves(self))
@@ -246,7 +248,6 @@ def _apply_argnums(wrapper, args, argnums):
 def _apply_argnames(wrapper, kwargs, argnames):
   return {k: wrapper(arg) if argnames is None or k in argnames else arg
           for k, arg in kwargs.items()}
-
 
 
 def _maybe_get_tree(arg):

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -214,6 +214,21 @@ class TreeMathTest(jtu.JaxTestCase):
     expected = tm.Vector({'b': 2})
     self.assertTreeEqual(actual, expected, check_dtypes=True)
 
+  def test_unwrap_out_vectors(self):
+    f = lambda *args: args
+
+    expected = tm.Vector((1, 2))
+    actual = tm.unwrap(f, out_vectors=True)(tm.Vector(1), tm.Vector(2))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+    expected = (1, 2)
+    actual = tm.unwrap(f, out_vectors=False)(tm.Vector(1), tm.Vector(2))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+    expected = (tm.Vector(1), 2)
+    actual = tm.unwrap(f, out_vectors=(True, False))(tm.Vector(1), tm.Vector(2))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
   def test_wrap_argnums_argnames(self):
 
     def f(x, y):

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -236,6 +236,18 @@ class TreeMathTest(jtu.JaxTestCase):
     tm.wrap(g, vector_argnames='y')(1, 2)
     tm.wrap(g, vector_argnames='y')(x=1, y=2)
 
+  def test_norm(self):
+
+    @tm.wrap
+    def norm(x, y):
+      return ((x - y) ** 2).sum() ** 0.5
+
+    x = {'a': 1, 'b': 1}
+    y = {'a': 1 + 3, 'b': 1 + 4}
+    expected = 5.0
+    actual = norm(x, y)
+    self.assertAllClose(actual, expected)
+
   def test_cg(self):
     # an integration test to verify non-trivial examples work
 

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -254,6 +254,7 @@ class TreeMathTest(jtu.JaxTestCase):
     @functools.partial(tm.wrap, vector_argnames=['b', 'x0'])
     def cg(A, b, x0, M=lambda x: x, maxiter=5, tol=1e-5, atol=0.0):
       A = tm.unwrap(A)
+      M = tm.unwrap(M)
 
       # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
       bs = b @ b

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -14,7 +14,6 @@
 
 import functools
 import operator
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -141,6 +141,13 @@ class TreeMathTest(jtu.JaxTestCase):
     expected = tm.Vector({"a": jnp.array([1, -1j])})
     self.assertTreeEqual(actual, expected, check_dtypes=True)
 
+  def test_real_imag(self):
+    vector = tm.Vector({"a": jnp.array([1, 1j])})
+    real_part = tm.Vector({"a": jnp.array([1.0, 0.0])})
+    imag_part = tm.Vector({"a": jnp.array([0.0, 1.0])})
+    self.assertTreeEqual(vector.real, real_part, check_dtypes=True)
+    self.assertTreeEqual(vector.imag, imag_part, check_dtypes=True)
+
   def test_sum_mean_min_max(self):
     vector = tm.Vector({"a": 1, "b": jnp.array([2, 3, 4])})
     self.assertTreeEqual(vector.sum(), 10, check_dtypes=True)

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -239,13 +239,21 @@ class TreeMathTest(jtu.JaxTestCase):
   def test_norm(self):
 
     @tm.wrap
-    def norm(x, y):
+    def norm1(x, y):
       return ((x - y) ** 2).sum() ** 0.5
+
+    @tm.wrap
+    def norm2(x, y):
+      d = x - y
+      return (d @ d) ** 0.5
 
     x = {'a': 1, 'b': 1}
     y = {'a': 1 + 3, 'b': 1 + 4}
     expected = 5.0
-    actual = norm(x, y)
+    actual = norm1(x, y)
+    self.assertAllClose(actual, expected)
+
+    actual = norm2(x, y)
     self.assertAllClose(actual, expected)
 
   def test_cg(self):
@@ -285,7 +293,6 @@ class TreeMathTest(jtu.JaxTestCase):
       initial_value = (x0, r0, gamma0, p0, 0)
 
       x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
-
       return x_final
 
     A = lambda x: {'a': x['a'] + 0.5 * x['b'], 'b': 0.5 * x['a'] + x['b']}

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -1,0 +1,263 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+import unittest
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from jax import lax
+from jax._src import test_util as jtu
+import jax.numpy as jnp
+from jax.experimental import tree_math as tm
+from jax.tree_util import tree_map, tree_flatten, tree_leaves
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+
+class TreeMathTest(jtu.JaxTestCase):
+
+  def assertTreeEqual(self, expected, actual, check_dtypes):
+    expected_leaves, expected_treedef = tree_flatten(expected)
+    actual_leaves, actual_treedef = tree_flatten(actual)
+    self.assertEqual(actual_treedef, expected_treedef)
+    for actual_leaf, expected_leaf in zip(actual_leaves, expected_leaves):
+      self.assertArraysEqual(actual_leaf, expected_leaf, check_dtypes=check_dtypes)
+
+  def test_vector(self):
+    tree = {'a': 0, 'b': jnp.array([1, 2], dtype=jnp.int32)}
+    vector = tm.Vector(tree)
+    self.assertEqual(len(vector), 3)
+    self.assertEqual(vector.shape, (3,))
+    self.assertEqual(vector.ndim, 1)
+    self.assertEqual(vector.dtype, jnp.int32)
+    self.assertEqual(repr(tm.Vector({'a': 1})), "tree_math.Vector({'a': 1})")
+    self.assertTreeEqual(tree_leaves(tree), tree_leaves(vector), check_dtypes=True)
+    vector2 = tree_map(lambda x: x, vector)
+    self.assertTreeEqual(vector, vector2, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": op.__name__, "op": op}
+      for op in [operator.pos, operator.neg, abs, operator.invert]
+  ))
+  def test_unary_math(self, op):
+    tree = {'a': 1, 'b': -jnp.array([2, 3])}
+    expected = tm.Vector(tree_map(op, tree))
+    actual = op(tm.Vector(tree))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_arithmetic_with_scalar(self):
+    vector = tm.Vector({'a': 0, 'b': jnp.array([1, 2])})
+    expected = tm.Vector({'a': 1, 'b': jnp.array([2, 3])})
+    self.assertTreeEqual(vector + 1, expected, check_dtypes=True)
+    self.assertTreeEqual(1 + vector, expected, check_dtypes=True)
+    with self.assertRaisesRegex(
+        TypeError, "non-tree_math.Vector arguments must be scalars",
+    ):
+      vector + jnp.ones((3,))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": op.__name__, "op": op}
+      for op in [
+          operator.add,
+          operator.sub,
+          operator.mul,
+          operator.truediv,
+          operator.floordiv,
+          operator.mod,
+      ]
+  ))
+  def test_binary_arithmetic(self, op):
+    rng = jtu.rand_default(self.rng())
+    tree1 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
+    tree2 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
+    expected = tm.Vector(tree_map(op, tree1, tree2))
+    actual = op(tm.Vector(tree1), tm.Vector(tree2))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_pow(self):
+    expected = tm.Vector({'a': 2 ** 3})
+    actual = tm.Vector({'a': 2}) ** tm.Vector({'a': 3})
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_divmod(self):
+    raise unittest.SkipTest("not working yet")
+    x, y = divmod(jnp.arange(5), 2)
+    expected = tm.Vector({'a': x}), tm.Vector({'a': y})
+    actual = divmod(tm.Vector({'a': jnp.arange(5)}), 2)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_matmul_scalars(self):
+    actual = tm.Vector(1.0) @ tm.Vector(2.0)
+    expected = 2.0
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_matmul(self):
+    rng = jtu.rand_default(self.rng())
+    tree1 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
+    tree2 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
+    expected = tree1['a'] * tree2['a'] + tree1['b'].ravel() @ tree2['b'].ravel()
+    vector1 = tm.Vector(tree1)
+    vector2 = tm.Vector(tree2)
+    actual = vector1 @ vector2
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+    with self.assertRaisesRegex(
+        TypeError, "matmul arguments must both be tree_math.Vector objects",
+    ):
+      vector1 @ jnp.ones((7,))
+
+  # TODO(shoyer): test comparisons and bitwise ops
+
+  def test_conj(self):
+    vector = tm.Vector({"a": jnp.array([1, 1j])})
+    actual = vector.conj()
+    expected = tm.Vector({"a": jnp.array([1, -1j])})
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_sum_mean_min_max(self):
+    vector = tm.Vector({"a": 1, "b": jnp.array([2, 3, 4])})
+    self.assertTreeEqual(vector.sum(), 10, check_dtypes=True)
+    self.assertTreeEqual(vector.min(), 1, check_dtypes=True)
+    self.assertTreeEqual(vector.max(), 4, check_dtypes=True)
+
+  def test_where(self):
+    condition = tm.Vector({"a": jnp.array([True, False])})
+    x = tm.Vector({"a": jnp.array([1, 2])})
+    y = 3
+    expected = tm.Vector({"a": jnp.array([1, 3])})
+    actual = tm.where(condition, x, y)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_where_all_scalars(self):
+    expected = 1
+    actual = tm.where(True, 1, 2)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_zeros_like(self):
+    x = jnp.array([1, 2])
+    expected = tm.Vector({"a": jnp.zeros_like(x)})
+    actual = tm.zeros_like(tm.Vector({"a": x}))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_ones_like(self):
+    x = jnp.array([1, 2])
+    expected = tm.Vector({"a": jnp.ones_like(x)})
+    actual = tm.ones_like(tm.Vector({"a": x}))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_full_like(self):
+    x = jnp.array([1, 2])
+    expected = tm.Vector({"a": jnp.full_like(x, 3)})
+    actual = tm.full_like(tm.Vector({"a": x}), 3)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": name, "func_name": name}
+      for name in ["maximum", "minimum"]
+  ))
+  def test_binary_ufuncs(self, func_name):
+    jnp_func = getattr(jnp, func_name)
+    tree_func = getattr(tm, func_name)
+    x = jnp.array([1, 2, 3])
+    y = jnp.array([4, 3, 2])
+    expected = tm.Vector({"a": jnp_func(x, y)})
+    actual = tree_func(tm.Vector({"a": x}), tm.Vector({"a": y}))
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_basic_wrap(self):
+    @tm.wrap
+    def f(x, y):
+      return x - y
+
+    x = {'a': 10, 'b': jnp.array([20, 30])}
+    y = {'a': 1, 'b': jnp.array([2, 3])}
+    expected = {'a': 9, 'b': jnp.array([18, 27])}
+    actual = f(x, y)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_tree_out_wrap(self):
+    @tm.wrap
+    def f(x, y):
+      return x + y, x - y
+
+    x = {'a': 10, 'b': jnp.array([20, 30])}
+    y = {'a': 1, 'b': jnp.array([2, 3])}
+    expected = ({'a': 11, 'b': jnp.array([22, 33])},
+                {'a': 9, 'b': jnp.array([18, 27])})
+    actual = f(x, y)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_unwrap(self):
+
+    @tm.unwrap
+    def f(x):
+      return {'b': x['a'] + 1}
+
+    actual = f(tm.Vector({'a': 1}))
+    expected = tm.Vector({'b': 2})
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+  def test_cg(self):
+    # an integration test to verify non-trivial examples work
+
+    def cg(b, x0, maxiter=5, tol=1e-5, atol=0.0):
+
+      # tolerance handling uses the "non-legacy" behavior of scipy.sparse.linalg.cg
+      bs = b @ b
+      atol2 = tm.maximum(tol**2 * bs, atol**2)
+
+      # https://en.wikipedia.org/wiki/Conjugate_gradient_method#The_preconditioned_conjugate_gradient_method
+
+      def cond_fun(value):
+        x, r, gamma, p, k = value
+        rs = r @ r
+        return (rs > atol2) & (k < maxiter)
+
+      def body_fun(value):
+        x, r, gamma, p, k = value
+        Ap = A(p)
+        alpha = gamma / (p.conj() @ Ap)
+        x_ = x + alpha * p
+        r_ = r - alpha * Ap
+        z_ = M(r_)
+        gamma_ = r_.conj() @ z_
+        beta_ = gamma_ / gamma
+        p_ = z_ + beta_ * p
+        return x_, r_, gamma_, p_, k + 1
+
+      r0 = b - A(x0)
+      p0 = z0 = M(r0)
+      gamma0 = r0 @ z0
+      initial_value = (x0, r0, gamma0, p0, 0)
+
+      x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
+
+      return x_final
+
+    A = tm.unwrap(
+        lambda x: {'a': x['a'] + 0.5 * x['b'], 'b': 0.5 * x['a'] + x['b']}
+    )
+    b = {'a': 1.0, 'b': -1.0}
+    x0 = {'a': 0.0, 'b': 0.0}
+    M = lambda x: x
+
+    actual = tm.wrap(cg)(b, x0)
+
+    expected = {'a': 2.0, 'b': -2.0}
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -94,10 +94,14 @@ class TreeMathTest(jtu.JaxTestCase):
     self.assertTreeEqual(actual, expected, check_dtypes=True)
 
   def test_divmod(self):
-    raise unittest.SkipTest("not working yet")
     x, y = divmod(jnp.arange(5), 2)
     expected = tm.Vector({'a': x}), tm.Vector({'a': y})
     actual = divmod(tm.Vector({'a': jnp.arange(5)}), 2)
+    self.assertTreeEqual(actual, expected, check_dtypes=True)
+
+    x, y = divmod(5, jnp.arange(5))
+    expected = tm.Vector({'a': x}), tm.Vector({'a': y})
+    actual = divmod(5, tm.Vector({'a': jnp.arange(5)}))
     self.assertTreeEqual(actual, expected, check_dtypes=True)
 
   def test_matmul_scalars(self):

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -102,7 +102,7 @@ class TreeMathTest(jtu.JaxTestCase):
   def test_matmul_scalars(self):
     actual = tm.Vector(1.0) @ tm.Vector(2.0)
     expected = 2.0
-    self.assertTreeEqual(actual, expected, check_dtypes=True)
+    self.assertAllClose(actual, expected, check_dtypes=True)
 
   def test_matmul(self):
     rng = jtu.rand_default(self.rng())
@@ -112,7 +112,7 @@ class TreeMathTest(jtu.JaxTestCase):
     vector1 = tm.Vector(tree1)
     vector2 = tm.Vector(tree2)
     actual = vector1 @ vector2
-    self.assertTreeEqual(actual, expected, check_dtypes=True)
+    self.assertAllClose(actual, expected, check_dtypes=True)
     with self.assertRaisesRegex(
         TypeError, "matmul arguments must both be tree_math.Vector objects",
     ):

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -65,7 +65,7 @@ class TreeMathTest(jtu.JaxTestCase):
     self.assertTreeEqual(vector + 1, expected, check_dtypes=True)
     self.assertTreeEqual(1 + vector, expected, check_dtypes=True)
     with self.assertRaisesRegex(
-        TypeError, "non-tree_math.Vector arguments must be scalars",
+        TypeError, "non-tree_math.Vector argument is not a scalar",
     ):
       vector + jnp.ones((3,))
 
@@ -145,6 +145,10 @@ class TreeMathTest(jtu.JaxTestCase):
     expected = 1
     actual = tm.where(True, 1, 2)
     self.assertTreeEqual(actual, expected, check_dtypes=True)
+    with self.assertRaisesRegex(
+        TypeError, "non-tree_math.Vector argument is not a scalar",
+    ):
+      tm.where(True, jnp.array([1, 2]), 3)
 
   def test_zeros_like(self):
     x = jnp.array([1, 2])

--- a/tests/tree_math_test.py
+++ b/tests/tree_math_test.py
@@ -39,6 +39,7 @@ class TreeMathTest(jtu.JaxTestCase):
   def test_vector(self):
     tree = {'a': 0, 'b': jnp.array([1, 2], dtype=jnp.int32)}
     vector = tm.Vector(tree)
+    self.assertEqual(vector.size, 3)
     self.assertEqual(len(vector), 3)
     self.assertEqual(vector.shape, (3,))
     self.assertEqual(vector.ndim, 1)
@@ -112,11 +113,21 @@ class TreeMathTest(jtu.JaxTestCase):
     rng = jtu.rand_default(self.rng())
     tree1 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
     tree2 = {'a': rng((), jnp.float32), 'b': rng((2, 3), jnp.float32)}
+
     expected = tree1['a'] * tree2['a'] + tree1['b'].ravel() @ tree2['b'].ravel()
+
     vector1 = tm.Vector(tree1)
     vector2 = tm.Vector(tree2)
+
     actual = vector1 @ vector2
     self.assertAllClose(actual, expected, check_dtypes=True)
+
+    actual = tm.dot(vector1, vector2)
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
+    actual = vector1.dot(vector2)
+    self.assertAllClose(actual, expected, check_dtypes=True)
+
     with self.assertRaisesRegex(
         TypeError, "matmul arguments must both be tree_math.Vector objects",
     ):


### PR DESCRIPTION
Fixes #1012

The idea behind this PR is to make it easy to implement numerical algorithms that work on pytrees, by transforming code written to handle vectors.

For example, we could implement an ODE solver that supports pytrees with something like:
```python
import functools
from jax import lax
from jax.experimental import tree_math

@functools.partial(tree_math.wrap, vector_argnums=(1,))
def odeint_midpoint(f, y0, dt, steps):
    f = tree_math.unwrap(f, vector_argnums=(0,))
    def step_fun(i, y):
        t = i * dt
        return y + dt * f(y + dt/2 * f(y, t), t + dt/2)
    return lax.fori_loop(0, num_steps, step_fun, y0)
```
Aside from `wrap` and `unwrap`, this is exactly how you would write a simple ODE solver in JAX without support for PyTrees. We currently [do something very similar](https://github.com/google/jax-cfd/blob/a92862fb757d122e7c5eee23a3b783997a2aeafe/jax_cfd/spectral/time_stepping.py#L92) for implementing ODE solvers in JAX-CFD. The tests for this PR include a rewriten version of `jax.scipy.sparse.linalg.cg`, which is also much more readable than what we currently have in JAX.

The idea here is a simpler alternative to #3263, based on a custom pytree (`tree_math.Vector`) rather than introducing a new final-style transformation:
- The upside of this approach is that writing a custom pytree is easy and entirely decoupled from JAX's other transformations. So we get support for JAX transformations (e.g., `grad`/`jit`/`vmap`) and control flow primitives (e.g., `while_loop`) for free.
- The downside is that it won't be possible to use standard `jax.numpy` functions on `Vector` objects, unless we make `jax.numpy` aware of `tree_math` (ala #8381). Instead, I've added a few specialized helper functions like `where` and `maximum`. For now, this seems like an acceptable trade-off, given that the core use-case for tree math is to
make it easy to write new algorithms from scientific computing, for which infix arithmetic is important enough that it should easily justify minor deviations from standard `jax.numpy`.

The other change from #3263 is that I've only written a simple "Vector" class for now rather than making an attempt to support arbitrary higher dimensional arrays. This also considerably simplifies the implementation. In the future, we probably will also want to add a "Matrix" class, for methods that need to keep track of multiple vectors (e.g., ODE solvers, GMRES, L-BFGS, Lanczos, etc). I don't think we'll need support for representing pytrees as higher dimensional arrays, which don't come up very often in fundamental numerical algorithms.