### PR TITLE
Make MLIR bindings build work under Bazel.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,8 +26,12 @@ build --define=grpc_no_ares=true
 build -c opt
 
 build --config=short_logs
+
+build --copt=-DMLIR_PYTHON_PACKAGE_PREFIX=jaxlib.mlir.
+
 ###########################################################################
 
+build:posix --copt=-fvisibility=hidden
 build:posix --copt=-Wno-sign-compare
 build:posix --cxxopt=-std=c++14
 build:posix --host_cxxopt=-std=c++14

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "432b2bdb4f1f4e5557ace8cb685da95f704dbcf7d3b18de0f024a35031db4497",
-    strip_prefix = "tensorflow-65518cad8e28ab76767dc1a8d37d73b8dc6dcafb",
+    sha256 = "b6d53fd6d6b09b200240e94342ef38ed1723bdac51a7236155a9ae7feafa0b78",
+    strip_prefix = "tensorflow-f994697f9b6bba0efc41513d1783b3f64ad46992",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/65518cad8e28ab76767dc1a8d37d73b8dc6dcafb.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/f994697f9b6bba0efc41513d1783b3f64ad46992.tar.gz",
     ],
 )
 

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -50,6 +50,10 @@ args = parser.parse_args()
 r = runfiles.Create()
 
 
+def _is_mac():
+  return platform.system() == "Darwin"
+
+
 def _is_windows():
   return sys.platform.startswith("win32")
 
@@ -145,7 +149,7 @@ def verify_mac_libraries_dont_reference_chkstack():
 
   This check makes sure we don't release wheels that have this dependency.
   """
-  if platform.system() != "Darwin":
+  if not _is_mac():
     return
   nm = subprocess.run(
     ["nm", "-g",
@@ -228,10 +232,17 @@ def prepare_wheel(sources_path):
   if _is_windows():
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlir.pyd"), dst_dir=mlir_libs_dir)
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlirHlo.pyd"), dst_dir=mlir_libs_dir)
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/jaxlib_mlir_capi.dll"), dst_dir=mlir_libs_dir)
     copy_to_jaxlib(r.Rlocation("org_tensorflow/tensorflow/compiler/xla/python/xla_extension.pyd"))
+  elif _is_mac():
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlir.so"), dst_dir=mlir_libs_dir)
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlirHlo.so"), dst_dir=mlir_libs_dir)
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/libjaxlib_mlir_capi.dylib"), dst_dir=mlir_libs_dir)
+    copy_to_jaxlib(r.Rlocation("org_tensorflow/tensorflow/compiler/xla/python/xla_extension.so"))
   else:
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlir.so"), dst_dir=mlir_libs_dir)
     copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/_mlirHlo.so"), dst_dir=mlir_libs_dir)
+    copy_to_jaxlib(r.Rlocation("__main__/jaxlib/mlir/_mlir_libs/libjaxlib_mlir_capi.so"), dst_dir=mlir_libs_dir)
     copy_to_jaxlib(r.Rlocation("org_tensorflow/tensorflow/compiler/xla/python/xla_extension.so"))
   patch_copy_xla_extension_stubs(jaxlib_dir)
   patch_copy_xla_client_py(jaxlib_dir)

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -24,11 +24,9 @@ package(
     licenses = ["notice"],
 )
 
-
 COPTS = [
     "-fexceptions",
     "-frtti",
-    "-DMLIR_PYTHON_PACKAGE_PREFIX=jaxlib.mlir.",
 ]
 
 py_extension(
@@ -38,8 +36,9 @@ py_extension(
     ],
     copts = COPTS,
     deps = [
-        "@llvm-project//mlir:MLIRBindingsPythonCore",
-        "@llvm-project//mlir:MLIRBindingsPythonHeadersAndDeps",
+        ":jaxlib_mlir_capi_shared_library",
+        "@llvm-project//mlir:MLIRBindingsPythonCoreNoCAPI",
+        "@llvm-project//mlir:MLIRBindingsPythonHeaders",
     ],
 )
 
@@ -54,10 +53,54 @@ py_extension(
     ],
     copts = COPTS,
     deps = [
-        "@llvm-project//mlir:CAPIIR",
-        "@llvm-project//mlir:MLIRBindingsPythonHeadersAndDeps",
-        "@pybind11",
+        ":jaxlib_mlir_capi_shared_library",
+        "@llvm-project//mlir:CAPIIRHeaders",
+        "@llvm-project//mlir:MLIRBindingsPythonHeaders",
         "@local_config_python//:headers",
-        "@org_tensorflow//tensorflow/compiler/mlir/hlo:CAPI",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:CAPIHeaders",
+        "@pybind11",
     ],
+)
+
+cc_library(
+    name = "jaxlib_mlir_capi_shared_library",
+    srcs = select({
+        "@org_tensorflow//tensorflow:windows": [":jaxlib_mlir_capi.dll"],
+        "@org_tensorflow//tensorflow:macos": [":libjaxlib_mlir_capi.dylib"],
+        "//conditions:default": [":libjaxlib_mlir_capi.so"],
+    }),
+)
+
+cc_library(
+    name = "jaxlib_mlir_capi_objects",
+    deps = [
+        "@llvm-project//mlir:MLIRBindingsPythonCAPIObjects",
+        "@org_tensorflow//tensorflow/compiler/mlir/hlo:CAPIObjects",
+    ],
+)
+
+cc_binary(
+    name = "libjaxlib_mlir_capi.so",
+    linkopts = [
+        "-Wl,-soname=libjaxlib_mlir_capi.so",
+        "-Wl,-rpath='$$ORIGIN'",
+    ],
+    linkshared = 1,
+    deps = [":jaxlib_mlir_capi_objects"],
+)
+
+cc_binary(
+    name = "libjaxlib_mlir_capi.dylib",
+    linkopts = [
+        "-Wl,-rpath,@loader_path/",
+        "-Wl,-install_name,@loader_path/libjaxlib_mlir_capi.dylib",
+    ],
+    linkshared = 1,
+    deps = [":jaxlib_mlir_capi_objects"],
+)
+
+cc_binary(
+    name = "jaxlib_mlir_capi.dll",
+    linkshared = 1,
+    deps = [":jaxlib_mlir_capi_objects"],
 )

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -44,6 +44,8 @@ setup(
             'cuda/nvvm/libdevice/libdevice*',
             'mlir/*.py',
             'mlir/dialects/*.py',
+            'mlir/_mlir_libs/*.dll',
+            'mlir/_mlir_libs/*.dylib',
             'mlir/_mlir_libs/*.so',
             'mlir/_mlir_libs/*.pyd',
         ],


### PR DESCRIPTION
Tested on Linux and Mac, but not Windows.