### PR TITLE
[x64] set scalar defaults to 64-bit types

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -79,10 +79,10 @@ def canonicalize_dtype(dtype):
 
 # Default dtypes corresponding to Python scalars.
 python_scalar_dtypes : dict = {
-  bool: np.dtype(bool_),
-  int: np.dtype(int_),
-  float: np.dtype(float_),
-  complex: np.dtype(complex_),
+  bool: np.dtype('bool'),
+  int: np.dtype('int64'),
+  float: np.dtype('float64'),
+  complex: np.dtype('complex128'),
 }
 
 def scalar_type_of(x):


### PR DESCRIPTION
Part of #8178

Why this change? We always want python scalars to translate to 64-bit (weak) types, because otherwise values like `np.pi` would lose precision. In the current codebase this PR doesn't change any behavior, because e.g. `jnp.float_` is the same as `jnp.float64`. But as we look at changing that in #8178 (i.e. satisfying [this TODO](https://github.com/google/jax/blob/3ac3ec9a83291fa50d29d3fd2e2c4e7bd1773035/jax/_src/dtypes.py#L49)), we don't want the scalar type defaults to change with the `jax.numpy` type defaults.