### PR TITLE
[x64] clean up usage of dtypes.dtype

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6925,29 +6925,29 @@ def _rng_bit_generator_translation_rule(
   # sidestep issues with the jax_enable_x64=False configuration. As a result, we
   # need to convert u32[4] -> u64[2] here in the translation rule. However, we
   # also polymorphically allow a u64[2] for backward compatibility.
-  assert ((key_shape == (4,) and key_dtype == dtypes.dtype('uint32')) or
-          (key_shape == (2,) and key_dtype == dtypes.dtype('uint64'))), (key_shape, key_dtype)
+  assert ((key_shape == (4,) and key_dtype == np.dtype('uint32')) or
+          (key_shape == (2,) and key_dtype == np.dtype('uint64'))), (key_shape, key_dtype)
   xla_shape = xc.Shape.array_shape(np.dtype(dtype), shape)
-  if key_dtype == dtypes.dtype('uint32'):
+  if key_dtype == np.dtype('uint32'):
     # TODO(mattjj): the BitcastConvertType segfaults on GPU
     # TODO(mattjj): remove fallback when minimum jaxlib is 0.1.72 or newer
     if jaxlib_version >= (0, 1, 72) and not backend_is_gpu:
-      u64_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint64'))
+      u64_etype = xla.dtype_to_primitive_type(np.dtype('uint64'))
       key = xops.BitcastConvertType(xops.Reshape(key, (2, 2)), u64_etype)
     else:
       key = _convert_4xU32_to_2xU64_without_bitcast(c, key)
   out_key, out_vals = xla.xla_destructure(
       c, xops.RngBitGenerator(algorithm, key, xla_shape))
-  if key_dtype == dtypes.dtype('uint32'):
+  if key_dtype == np.dtype('uint32'):
     if jaxlib_version >= (0, 1, 72) and not backend_is_gpu:
-      u32_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint32'))
+      u32_etype = xla.dtype_to_primitive_type(np.dtype('uint32'))
       out_key = xops.Reshape(xops.BitcastConvertType(out_key, u32_etype), (4,))
     else:
       out_key = _convert_2xU64_to_4xU32_without_bitcast(c, out_key)
   return [out_key, out_vals]
 
 def _convert_4xU32_to_2xU64_without_bitcast(c, key):
-  u64_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint64'))
+  u64_etype = xla.dtype_to_primitive_type(np.dtype('uint64'))
   new_key = xops.Constant(c, np.zeros(2, dtype=np.dtype('uint64')))
   _32 = xops.Constant(c, np.array(32, np.uint64))
   for i in [0, 2]:
@@ -6959,7 +6959,7 @@ def _convert_4xU32_to_2xU64_without_bitcast(c, key):
   return new_key
 
 def _convert_2xU64_to_4xU32_without_bitcast(c, key):
-  u32_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint32'))
+  u32_etype = xla.dtype_to_primitive_type(np.dtype('uint32'))
   new_key = xops.Constant(c, np.zeros(4, dtype=np.dtype('uint32')))
   _32 = xops.Constant(c, np.array(32, np.uint64))
   for i in [0, 1]:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6551,7 +6551,7 @@ def _view(arr, dtype=None, type=None):
   if arr_dtype == bool_:
     arr = arr.astype(uint8)
   nbits_in = 8 * arr_dtype.itemsize
-  nbits_out = 8 * _dtype(dtype).itemsize
+  nbits_out = 8 * np.dtype(dtype).itemsize
   if nbits_in == nbits_out:
     if dtype == bool_:
       return lax.bitcast_convert_type(arr, uint8).astype(dtype)

--- a/jax/experimental/djax.py
+++ b/jax/experimental/djax.py
@@ -19,7 +19,6 @@ from typing import (Tuple, List, Sequence, Set, Dict, Any, Callable, Union,
                     Optional)
 
 from jax import core
-from jax._src import dtypes
 from jax._src import source_info_util
 from jax.core import Var, Literal, Atom, Tracer
 from jax._src.util import (safe_zip, safe_map, curry, unzip2, split_list,
@@ -42,7 +41,7 @@ class EltTy: pass
 
 class BaseType(EltTy):
   def __init__(self, dtype: DType):
-    self._dtype = dtypes.dtype(dtype)
+    self._dtype = np.dtype(dtype)
 
   def __repr__(self):
     return f'BaseType({self._dtype.name})'
@@ -619,7 +618,7 @@ def _array_xla_shape(aval: AbsArray):
     return (xla.xc.Shape.array_shape(dtype, shape),)
   elif isinstance(aval._eltTy, BoundedIntTy):
     shape = [d._bound if isinstance(d, BoundedInt) else d for d in aval.shape]
-    return (xla.xc.Shape.array_shape(dtypes.dtype('int32'), shape),)
+    return (xla.xc.Shape.array_shape(np.dtype('int32'), shape),)
   else:
     raise NotImplementedError
 xla.xla_shape_handlers[AbsArray] = _array_xla_shape

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -1625,22 +1625,22 @@ translations[lax.rng_uniform_p] = _rng_uniform_lowering
 #   # sidestep issues with the jax_enable_x64=False configuration. As a result, we
 #   # need to convert u32[4] -> u64[2] here in the translation rule. However, we
 #   # also polymorphically allow a u64[2] for backward compatibility.
-#   assert ((key_aval.shape == (4,) and key_aval.dtype == dtypes.dtype('uint32')) or
-#           (key_aval.shape == (2,) and key_aval.dtype == dtypes.dtype('uint64'))), key_aval.shape
+#   assert ((key_aval.shape == (4,) and key_aval.dtype == np.dtype('uint32')) or
+#           (key_aval.shape == (2,) and key_aval.dtype == np.dtype('uint64'))), key_aval.shape
 #   xla_shape = xc.Shape.array_shape(np.dtype(dtype), shape)
-#   if key_dtype == dtypes.dtype('uint32'):
+#   if key_dtype == np.dtype('uint32'):
 #     # TODO(mattjj): the BitcastConvertType segfaults on GPU
 #     # TODO(mattjj): remove fallback when minimum jaxlib is 0.1.72 or newer
 #     if jaxlib_version >= (0, 1, 72) and not backend_is_gpu:
-#       u64_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint64'))
+#       u64_etype = xla.dtype_to_primitive_type(np.dtype('uint64'))
 #       key = xops.BitcastConvertType(xops.Reshape(key, (2, 2)), u64_etype)
 #     else:
 #       key = _convert_4xU32_to_2xU64_without_bitcast(c, key)
 #   out_key, out_vals = xla.xla_destructure(
 #       c, xops.RngBitGenerator(algorithm, key, xla_shape))
-#   if key_dtype == dtypes.dtype('uint32'):
+#   if key_dtype == np.dtype('uint32'):
 #     if jaxlib_version >= (0, 1, 72) and not backend_is_gpu:
-#       u32_etype = xla.dtype_to_primitive_type(dtypes.dtype('uint32'))
+#       u32_etype = xla.dtype_to_primitive_type(np.dtype('uint32'))
 #       out_key = xops.Reshape(xops.BitcastConvertType(out_key, u32_etype), (4,))
 #     else:
 #       out_key = _convert_2xU64_to_4xU32_without_bitcast(c, out_key)


### PR DESCRIPTION
Part of #8178

Why this change? In addressing dtype consistency across the JAX package, we have to be more careful about the use of `dtypes.dtype` and `dtypes.result_type`. This PR replaces unambiguous uses of `dtypes.dtype()` with `np.dtype()` where applicable, in order to streamline that upcoming change.

This PR should have no user-visible effect.