### PR TITLE
[sparse] re-enable bcoo_spdot_general test

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1045,7 +1045,7 @@ class BCOOTest(jtu.JaxTestCase):
     self.assertAllClose(jr_sparse, jr_dense, atol=tol)
     self.assertAllClose(jf_sparse, jr_sparse, atol=tol)
 
-  @unittest.skip("Jaxlib GPU build failing in OSS.")
+  @unittest.skipIf(jtu.device_under_test() == "tpu", "TPU has insufficient precision")
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}[n_batch={}]_{}[n_batch={}]_dims={}".format(
         jtu.format_shape_dtype_string(lhs_shape, dtype), lhs_n_batch,


### PR DESCRIPTION
Test was disabled in https://github.com/google/jax/commit/0f0bfcaef56c3f44473ff7f6b7ef95ca6576b3e1

I'm unsure what was causing the previous failures, but it seems to be resolved now.