### PR TITLE
make vmap ppermute consistent with pmap/docstring

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -795,7 +795,7 @@ def _ppermute_batcher(axis_size, frame_name, _, vals_in, dims_in, axis_name, per
   assert d is not batching.not_mapped
   perm_indices = np.zeros(axis_size, dtype=int)
   for src, dst in perm:
-    perm_indices[src] = dst
+    perm_indices[dst] = src
   return lax_numpy.take(v, perm_indices, d), d
 
 def _collective_batcher(prim, args, dims, **params):

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -1011,7 +1011,7 @@ class BatchingTest(jtu.JaxTestCase):
       rng.shuffle(perm_pairs)
       self.assertAllClose(
         vmap(lambda x: x - lax.ppermute(x, 'i', perm_pairs), axis_name='i')(x),
-        x - x[perm])
+        x - x[np.argsort(perm)])
 
   @parameterized.named_parameters(
       {"testcase_name": f"_split={split_axis}_concat={concat_axis}_vmap={vmap_axis}",
@@ -1130,8 +1130,6 @@ class BatchingTest(jtu.JaxTestCase):
     vmap_jaxpr = make_jaxpr(jax.vmap(f, axis_name='i'))(jnp.ones((3, 4)),
         jnp.ones((3, 4)))
     self.assertIn('HIGHEST', str(vmap_jaxpr))
-
-
 
   def testPdotJvp(self):
     def f(x, y):


### PR DESCRIPTION
This was a bad bug! Unfortunately our tests didn't catch it, in part because permutations on size-two axes are special. The simplest test might have a size-three axis.

I briefly audited our other primitives for similar lack of vmap test coverage, by looking at `jax.interpreters.batching.axis_index_batchers.keys()` and comparing to our tests. I think this was the only uncovered spot.