### PR TITLE
jnp.quantile: explicitly raise error for complex input

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6321,6 +6321,8 @@ def _quantile(a, q, axis, interpolation, keepdims, squash_nans):
     raise ValueError("interpolation can only be 'linear', 'lower', 'higher', "
                      "'midpoint', or 'nearest'")
   a, q = _promote_dtypes_inexact(a, q)
+  if issubdtype(a.dtype, np.complexfloating):
+    raise ValueError("quantile does not support complex input, as the operation is poorly defined.")
   if axis is None:
     a = ravel(a)
     axis = 0

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1603,6 +1603,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       if (pad_width != () and stat_length != () and
           not (dtype in bool_dtypes and mode == 'mean'))))
   def testPadStatValues(self, shape, dtype, mode, pad_width, stat_length):
+    if mode == 'median' and np.issubdtype(dtype, np.complexfloating):
+      self.skipTest("median statistic is not supported for dtype=complex.")
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
 


### PR DESCRIPTION
Fixes #8623.

This already raises an error; this PR improves things by making the error more informative.

Also skips problematic test case that happened to be avoided in our current test sampling.