### PR TITLE
[x64] regularize dtype helpers

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -88,6 +88,8 @@ from .._src.config import (flags, config, bool_env, disable_jit as _disable_jit,
 
 traceback_util.register_exclusion(__file__)
 
+_dtype = partial(dtypes.dtype, canonicalize=True)
+
 AxisName = Any
 
 # These TypeVars are used below to express the fact that function types
@@ -1018,7 +1020,7 @@ def value_and_grad(fun: Callable, argnums: Union[int, Sequence[int]] = 0,
       ans, vjp_py, aux = _vjp(
           f_partial, *dyn_args, has_aux=True, reduce_axes=reduce_axes)
     _check_scalar(ans)
-    dtype = dtypes.result_type(ans)
+    dtype = _dtype(ans)
     tree_map(partial(_check_output_dtype_grad, holomorphic), ans)
     g = vjp_py(np.ones((), dtype=dtype))
     g = g[0] if isinstance(argnums, int) else g
@@ -1308,9 +1310,6 @@ def _split(x, indices, axis):
     return np.split(x, indices, axis)
   else:
     return x.split(indices, axis)
-
-def _dtype(x):
-  return dtypes.canonicalize_dtype(dtypes.result_type(x))
 
 
 def vmap(fun: F, in_axes=0, out_axes=0, axis_name=None, axis_size=None) -> F:

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -341,14 +341,18 @@ def is_python_scalar(x):
   except AttributeError:
     return type(x) in python_scalar_dtypes
 
-def dtype(x):
-  if type(x) in python_scalar_dtypes:
-    return python_scalar_dtypes[type(x)]
-  dt = np.result_type(x)
+def dtype(x, *, canonicalize=False):
+  """Return the dtype object for a value or type, optionally canonicalized based on X64 mode."""
+  if isinstance(x, type) and x in python_scalar_dtypes:
+    dt = python_scalar_dtypes[x]
+  elif type(x) in python_scalar_dtypes:
+    dt = python_scalar_dtypes[type(x)]
+  else:
+    dt = np.result_type(x)
   if dt not in _jax_dtype_set:
     raise TypeError(f"Value '{x}' with dtype {dt} is not a valid JAX array "
                     "type. Only arrays of numeric types are supported by JAX.")
-  return dt
+  return canonicalize_dtype(dt) if canonicalize else dt
 
 def _lattice_result_type(*args):
   dtypes, weak_types = zip(*(_dtype_and_weaktype(arg) for arg in args))

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -6475,8 +6475,8 @@ _one: Callable = partial(full_like, shape=(), fill_value=1)
 _twos: Callable = partial(full_like, fill_value=2)
 _two: Callable = partial(full_like, shape=(), fill_value=2)
 
-dtype: Callable = dtypes.result_type
-_dtype: Callable = dtypes.result_type
+dtype: Callable = partial(dtypes.dtype, canonicalize=True)
+_dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 
 def _iscomplex(x) -> bool:
   return dtypes.issubdtype(_dtype(x), np.complexfloating)

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -374,7 +374,7 @@ iscomplexobj = np.iscomplexobj
 shape = _shape = np.shape
 ndim = _ndim = np.ndim
 size = np.size
-_dtype = dtypes.result_type
+_dtype = partial(dtypes.dtype, canonicalize=True)
 
 # At present JAX doesn't have a reason to distinguish between scalars and arrays
 # in its object system. Further, we want JAX scalars to have the same type
@@ -1222,7 +1222,7 @@ mod = _wraps(np.mod)(remainder)
 @jit
 def fmod(x1, x2):
   _check_arraylike("fmod", x1, x2)
-  if issubdtype(_dtype(x1, x2), integer):
+  if issubdtype(result_type(x1, x2), integer):
     x2 = where(x2 == 0, 1, x2)
   return lax.rem(*_promote_args("fmod", x1, x2))
 
@@ -3761,7 +3761,7 @@ def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
   lax._check_user_dtype_supported(dtype, "arange")
   require = partial(core.concrete_or_error, None)
   msg = "It arose in jax.numpy.arange argument `{}`.".format
-  dtype = dtype or _dtype(start, *(x for x in [stop, step] if x is not None))
+  dtype = dtype or result_type(start, *(x for x in [stop, step] if x is not None))
   if stop is None and step is None:
     if not core.is_special_dim_size(start):
       start = require(start, msg("stop"))

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2493,7 +2493,8 @@ class LaxTest(jtu.JaxTestCase):
       val = lax._convert_element_type(0, dtype, weak_type=weak_type)
 
     const = lax._const(val, 0)
-    self.assertEqual(dtypes.result_type(val), dtypes.result_type(const))
+    self.assertEqual(dtypes.dtype(val, canonicalize=True),
+                     dtypes.dtype(const, canonicalize=True))
 
 
   def testIgammaSpecial(self):
@@ -2556,7 +2557,7 @@ class LazyConstantTest(jtu.JaxTestCase):
   def testFilledConstant(self, shape, fill_value, dtype):
     make_const = lambda: lax.full(shape, fill_value, dtype)
     expected = np.full(shape, fill_value,
-                        dtype or dtypes.result_type(fill_value))
+                        dtype or dtypes.dtype(fill_value))
     self._Check(make_const, expected)
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
Part of #8178; followup to #8535.

Background: we currently have two functions related to getting dtypes from values, that have overlapping but sublely different uses:

- `jax._src.dtypes.dtype` is an **internal** function that currently takes a single value or dtype-like object, and returns the **non-canonicalized** dtype, defaulting to numpy types for scalar inputs.
- `jax.dtypes.result_type` is a **public** function (also available via `jax.numpy.result_type`) which takes any number of input values or dtype-like objects and returns the **canonicalized** dtype (for a single input) or the **canonicalized** jax type promotion result (for multiple inputs)

Frequently in the JAX package, we alias a local helper called `dtype` or `_dtype` to `result_type`, which introduces implicit type promotion, and canonicalization in places where it's not necessarily desired.

This PR improves the situation by changing the API of `jax._src.dtypes.dtype` to explicitly use JAX defaults for scalar values (it already "accidentally" does this by virtue of its call to `np.result_type`), and to take an optional `canonicalize` argument. We then can alias local dtype helpers to this rather than to `result_type`. In cases where type promotion of multiple arguments is desired, we call `result_type` explicitly.

These changes should have no user-visible effects currently in either X32 or X64 mode, but cleaning this up makes the X64 deprecation process in  #8178 more straightforward as it can be done orthogonally to these changes.