### PR TITLE
autodidax: fix jaxpr_subcomp return type annotation

### DIFF
--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -2029,7 +2029,7 @@
    "outputs": [],
    "source": [
     "def jaxpr_subcomp(c: xe.XlaBuilder, jaxpr: Jaxpr, args: List[xe.XlaOp]\n",
-    "                  ) -> xe.XlaOp:\n",
+    "                  ) -> List[xe.XlaOp]:\n",
     "  env: Dict[Var, xe.XlaOp] = {}\n",
     "\n",
     "  def read(x: Atom) -> xe.XlaOp:\n",

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -1589,7 +1589,7 @@ compiled program:
 
 ```{code-cell}
 def jaxpr_subcomp(c: xe.XlaBuilder, jaxpr: Jaxpr, args: List[xe.XlaOp]
-                  ) -> xe.XlaOp:
+                  ) -> List[xe.XlaOp]:
   env: Dict[Var, xe.XlaOp] = {}
 
   def read(x: Atom) -> xe.XlaOp:

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -1583,7 +1583,7 @@ def _xla_shape(aval: ShapedArray) -> xe.Shape:
 
 # +
 def jaxpr_subcomp(c: xe.XlaBuilder, jaxpr: Jaxpr, args: List[xe.XlaOp]
-                  ) -> xe.XlaOp:
+                  ) -> List[xe.XlaOp]:
   env: Dict[Var, xe.XlaOp] = {}
 
   def read(x: Atom) -> xe.XlaOp:


### PR DESCRIPTION
`jaxpr_subcomp` returns a `map(...)` result, but the return type was `xe.XlaOp`.

This PR changes the return type of `jaxpr_subcomp` to `List[xe.XlaOp]`.