### PR TITLE
[x64] avoid dtype conversions for arange arguments

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3759,7 +3759,7 @@ def identity(n, dtype=None):
 def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
            step: Optional[core.DimSize]=None, dtype=None):
   lax._check_user_dtype_supported(dtype, "arange")
-  require = partial(core.concrete_or_error, _np_asarray)
+  require = partial(core.concrete_or_error, None)
   msg = "It arose in jax.numpy.arange argument `{}`.".format
   dtype = dtype or _dtype(start, *(x for x in [stop, step] if x is not None))
   if stop is None and step is None:


### PR DESCRIPTION
Part of #8178. Followup to #8544

Why make this change individually? It's not an operation that is required for inputs to `arange` (I think I added it originally because I did not know `None` was an option in `canonicalize_or_error`), but the operation introduces problems with the changes in #8178. Making this change separately from #8178 reduces the complexity of the larger change, and emphasizes that this particular diff has basically no consequence to user code.