### PR TITLE
Enable QDWH TPU tests.

### DIFF
--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -180,6 +180,7 @@ def qdwh(x, is_symmetric, max_iterations=10):
                        '`norm(x-x.H) / norm(x)` is {}, which is greater than '
                        'the tolerance {}.'.format(relative_diff, tol))
 
-  u, h, num_iters, is_converged = _qdwh(x, is_symmetric, max_iterations)
+  with jax.default_matmul_precision('float32'):
+     u, h, num_iters, is_converged = _qdwh(x, is_symmetric, max_iterations)
 
   return u, h, num_iters, is_converged


### PR DESCRIPTION
TODO for  `testQdwhWithRandomMatrix` indicates TPU failure, whereas both `gpu` and `tpu` are disabled.  Please let me know if I should disable `gpu` if there is any A100 failue.

>  TODO(tianjianlu): Fails on TPU.
  @jtu.skip_on_devices("gpu", "tpu")
  def testQdwhWithRandomMatrix(self, m, n, log_cond):