### PR TITLE
[x64] Make autodiff respect weak types

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -37,8 +37,9 @@ def make_shaped_array(x):
   return ShapedArray(np.shape(x), dtype)
 
 def zeros_like_array(x):
-  dtype = dtypes.canonicalize_dtype(dtypes.result_type(x))
-  aval = ShapedArray(np.shape(x), dtype)
+  dtype, weak_type = dtypes._lattice_result_type(x)
+  dtype = dtypes.canonicalize_dtype(dtype)
+  aval = ShapedArray(np.shape(x), dtype, weak_type=weak_type)
   return ad_util.zeros_like_aval(aval)
 
 array_types = {np.ndarray, np.bool_,
@@ -55,7 +56,8 @@ for t in array_types:
 core.literalable_types.update(array_types)
 
 def _zeros_like_python_scalar(t, x):
-  return np.array(0, dtypes.python_scalar_dtypes[t])
+  aval = core.ShapedArray((), dtypes.python_scalar_dtypes[t], weak_type=True)
+  return ad_util.zeros_like_aval(aval)
 
 def _make_concrete_python_scalar(t, x):
   return ConcreteArray(

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -170,7 +170,7 @@ def checkpoint(fun: Callable, prevent_cse: bool = True,
   ...   return z
   ...
   >>> jax.value_and_grad(g)(2.0)
-  (DeviceArray(0.78907233, dtype=float32, weak_type=True), DeviceArray(-0.2556391, dtype=float32))
+  (DeviceArray(0.78907233, dtype=float32, weak_type=True), DeviceArray(-0.2556391, dtype=float32, weak_type=True))
 
   Here, the same value is produced whether or not the :func:`jax.checkpoint`
   decorator is present. When the decorator is not present, the values

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1520,11 +1520,10 @@ def _device_put_raw(x, weak_type=None):
 
 def zeros_like_shaped_array(aval):
   assert isinstance(aval, ShapedArray)
-  scalar_zero = np.array(0).astype(aval.dtype)
-  if scalar_zero.dtype != aval.dtype:
-    # For numpy 1.17.5 we get here for float0. We use an alternate construction.
-    assert aval.dtype == dtypes.float0
+  if aval.dtype == dtypes.float0:
     scalar_zero = np.zeros((), dtype=aval.dtype)
+  else:
+    scalar_zero = _convert_element_type(0, aval.dtype, aval.weak_type)
   return broadcast(scalar_zero, aval.shape)
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
@@ -1586,13 +1585,13 @@ def stop_gradient(x):
   For example:
 
   >>> jax.grad(lambda x: x**2)(3.)
-  DeviceArray(6., dtype=float32)
+  DeviceArray(6., dtype=float32, weak_type=True)
   >>> jax.grad(lambda x: jax.lax.stop_gradient(x)**2)(3.)
-  DeviceArray(0., dtype=float32)
+  DeviceArray(0., dtype=float32, weak_type=True)
   >>> jax.grad(jax.grad(lambda x: x**2))(3.)
-  DeviceArray(2., dtype=float32)
+  DeviceArray(2., dtype=float32, weak_type=True)
   >>> jax.grad(jax.grad(lambda x: jax.lax.stop_gradient(x)**2))(3.)
-  DeviceArray(0., dtype=float32)
+  DeviceArray(0., dtype=float32, weak_type=True)
   """
   def stop(x):
     if (dtypes.issubdtype(_dtype(x), np.floating) or

--- a/jax/core.py
+++ b/jax/core.py
@@ -1177,9 +1177,9 @@ class ConcreteArray(ShapedArray):
   __slots__ = ['val']
   array_abstraction_level = 0
 
-  def __init__(self, val, weak_type=False):
+  def __init__(self, val, weak_type=None):
     super().__init__(np.shape(val), np.result_type(val),
-                     weak_type=weak_type)
+                     weak_type=dtypes.is_weakly_typed(val) if weak_type is None else weak_type)
     # Note: canonicalized self.dtype doesn't necessarily match self.val
     self.val = val
     assert self.dtype != np.dtype('O'), val


### PR DESCRIPTION
Came up in the process of working on #8178.

The issue this solves is the fact that, currently, autodiff results in functions that treat inputs as strongly-typed:
```python
In [1]: import jax.numpy as jnp

In [2]: from jax import grad

In [3]: jnp.sin(0.0)
Out[3]: DeviceArray(0., dtype=float32, weak_type=True)

In [4]: jnp.cos(0.0)
Out[4]: DeviceArray(1., dtype=float32, weak_type=True)

In [5]: grad(jnp.sin)(0.0)
Out[5]: DeviceArray(1., dtype=float32)  # <------- not weakly typed!
```
This makes it easy for 64-bit values to slip into otherwise 32-bit computations in a post-X64 world.