### PR TITLE
custom pp_eqn rules, simpler xla_call print

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -415,7 +415,6 @@ which the computation should run. For example
 { lambda ; a:f32[]. let
     b:f32[] = sub a 2.0
     c:f32[1] = xla_call[
-      backend=None
       call_jaxpr={ lambda ; d:f32[] e:f32[]. let
           f:f32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] 1.0
           g:f32[] = convert_element_type[new_dtype=float32 weak_type=False] d
@@ -423,9 +422,6 @@ which the computation should run. For example
           i:f32[] = convert_element_type[new_dtype=float32 weak_type=False] e
           j:f32[1] = add i h
         in (j,) }
-      device=None
-      donated_invars=(False, False)
-      inline=False
       name=inner
     ] a b
     k:f32[] = convert_element_type[new_dtype=float32 weak_type=False] a

--- a/jax/core.py
+++ b/jax/core.py
@@ -76,12 +76,14 @@ class Jaxpr:
     self.eqns = list(eqns)
 
   def __str__(self):
-    return str(pp_jaxpr(self, JaxprPpContext()))
+    return str(pp_jaxpr(self, JaxprPpContext(), custom_pp_eqn_rules=True))
   __repr__ = __str__
 
-  def pretty_print(self, *, source_info=False, print_shapes=True, **kw):
+  def pretty_print(self, *, source_info=False, print_shapes=True,
+                   custom_pp_eqn_rules=True, **kw):
     doc = pp_jaxpr(self, JaxprPpContext(), source_info=source_info,
-                   print_shapes=print_shapes)
+                   print_shapes=print_shapes,
+                   custom_pp_eqn_rules=custom_pp_eqn_rules)
     return doc.format(**kw)
 
 
@@ -151,7 +153,9 @@ class JaxprEqn(NamedTuple):
   params: Dict[str, Any]
   source_info: source_info_util.SourceInfo
 
-  def __repr__(self): return str(pp_eqn(self, JaxprPpContext())).rstrip()
+  def __repr__(self):
+    return str(pp_eqn(self, JaxprPpContext(), custom_pp_eqn_rules=False)
+               ).rstrip()
 
 def new_jaxpr_eqn(invars, outvars, primitive, params, source_info=None):
   if primitive.call_primitive:
@@ -2117,13 +2121,13 @@ def pp_kv_pairs(kv_pairs, context: JaxprPpContext) -> pp.Doc:
     + pp.brk("") + pp.text("]")
   )
 
-def pp_eqn(eqn, context: JaxprPpContext, *, print_shapes=True, source_info=False
-          ) -> pp.Doc:
+def pp_eqn(eqn, context: JaxprPpContext, *, print_shapes=True,
+           source_info=False, custom_pp_eqn_rules=True) -> pp.Doc:
   lhs = pp_vars(eqn.outvars, context, print_shapes=print_shapes)
   annotation = (source_info_util.summarize(eqn.source_info)
                 if source_info else None)
   rule = pp_eqn_rules.get(eqn.primitive)
-  if rule:
+  if rule and custom_pp_eqn_rules:
     rhs = rule(eqn, context)
   else:
     rhs = [pp.text(eqn.primitive.name),
@@ -2133,12 +2137,13 @@ def pp_eqn(eqn, context: JaxprPpContext, *, print_shapes=True, source_info=False
 CustomPpEqnRule = Callable[[JaxprEqn, JaxprPpContext], Sequence[pp.Doc]]
 pp_eqn_rules: Dict[Primitive, CustomPpEqnRule]  = {}
 
-def pp_eqns(eqns, context: JaxprPpContext, *, print_shapes=True, source_info=False
-           ) -> pp.Doc:
+def pp_eqns(eqns, context: JaxprPpContext, *, print_shapes=True,
+            source_info=False, custom_pp_eqn_rules=True
+            ) -> pp.Doc:
   return pp.join(
     pp.brk("; "),
-    map(lambda e: pp_eqn(e, context, print_shapes=print_shapes,
-                         source_info=source_info), eqns))
+    [pp_eqn(e, context, print_shapes=print_shapes, source_info=source_info,
+            custom_pp_eqn_rules=custom_pp_eqn_rules) for e in eqns])
 
 def pp_eqn_compact(primitive_name: str, params: Dict, context: JaxprPpContext
                   ) -> pp.Doc:
@@ -2166,9 +2171,10 @@ def pp_jaxpr_skeleton(jaxpr, eqns_fn, context: JaxprPpContext, *,
 
 
 def pp_jaxpr(jaxpr, context: JaxprPpContext, *, print_shapes=True,
-             source_info=False) -> pp.Doc:
+             source_info=False, custom_pp_eqn_rules=True) -> pp.Doc:
   eqns_fn = lambda: pp_eqns(jaxpr.eqns, context, print_shapes=print_shapes,
-                            source_info=source_info)
+                            source_info=source_info,
+                            custom_pp_eqn_rules=custom_pp_eqn_rules)
   return pp_jaxpr_skeleton(jaxpr, eqns_fn, context, print_shapes=print_shapes)
 
 def pp_jaxprs(jaxprs, context: JaxprPpContext) -> pp.Doc:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -717,6 +717,19 @@ pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
 pe.dce_rules[xla_call_p] = pe.dce_jaxpr_call_rule
 
 
+def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext
+                 ) -> List[pp.Doc]:
+  printed_params = {k:v for k, v in eqn.params.items() if
+                    k == 'call_jaxpr' or k == 'name' or
+                    k == 'backend' and v is not None or
+                    k == 'device' and v is not None or
+                    k == 'donated_invars' and any(v)}
+  return [pp.text(eqn.primitive.name),
+          core.pp_kv_pairs(sorted(printed_params.items()), context),
+          pp.text(" ") + core.pp_vars(eqn.invars, context)]
+core.pp_eqn_rules[xla_call_p] = _pp_xla_call
+
+
 ### translation tables
 
 MYPY = False


### PR DESCRIPTION
Add a simple internal mechanism for tweaking `pp_eqn` rules on a primitive-by-primitive basis. Add one such rule for `xla_call_p` so as to suppress printing of default arg values.

```python
import jax
jaxpr = jax.make_jaxpr(jax.jit(lambda x: x))(1.)
print(jaxpr)
```

Before:

```
{ lambda ; a:f32[]. let
    b:f32[] = xla_call[
      backend=None
      call_jaxpr={ lambda ; c:f32[]. let  in (c,) }
      device=None
      donated_invars=(False,)
      inline=False
      name=<lambda>
    ] a
  in (b,) }
```

After:

```
{ lambda ; a:f32[]. let
    b:f32[] = xla_call[
      call_jaxpr={ lambda ; c:f32[]. let  in (c,) }
      name=<lambda>
    ] a
  in (b,) }
```