### PR TITLE
[hcb] Simplifications to the host_calback API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.26...main).
 
+* Breaking changes:
+  * The host_callback primitives have been simplified to drop the
+  special autodiff handling for hcb.id_tap and id_print.
+  From now on, only the primals are tapped. The old behavior can be
+  obtained (for a limited time) by setting the ``JAX_HOST_CALLBACK_AD_TRANSFORMS``
+  environment variable, or the ```--flax_host_callback_ad_transforms``` flag.
+  Additionally, added documentation for how to implement the old behavior
+  using JAX custom AD APIs ({jax-issue}`#7839`).
+
 ## jaxlib 0.1.76 (Unreleased)
 
 ## jaxlib 0.1.75 (Dec 8, 2021)

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -463,6 +463,15 @@ flags.DEFINE_bool(
         'Has no effect on TPU, since only the outfeed mechanism is implemented.'
     )
 )
+flags.DEFINE_bool(
+    'jax_host_callback_ad_transforms',
+    bool_env('JAX_HOST_CALLBACK_AD_TRANSFORMS', False),
+    help=(
+        'Enable support for jvp/vjp for the host_callback primitives. Default is '
+        'False, which means that host_callback operates only on primals. '
+        'The flag exists only temporarily, for backward compatibility.'
+    )
+)
 
 enable_checks = config.define_bool_state(
     name='jax_enable_checks',

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1009,6 +1009,9 @@ class JaxTestCase(parameterized.TestCase):
     ignore_space_re = re.compile(r'\s*\n\s*')
     expected_clean = re.sub(ignore_space_re, '\n', expected.strip())
     what_clean = re.sub(ignore_space_re, '\n', what.strip())
+    if what_clean != expected_clean:
+      # Print it so we can copy-and-paste it into the test
+      print(f"Found\n{what}\n")
     self.assertMultiLineEqual(expected_clean, what_clean,
                               msg="Found\n{}\nExpecting\n{}".format(what, expected))
 


### PR DESCRIPTION
* dropping support for special AD handling for hcb.id_tap and id_print.
  From now on, only the primals are tapped.

This allows us to make some significant cleanup in the internals.