### PR TITLE
[jax2tf] Implement CLIP mode for scatter.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2132,10 +2132,14 @@ def _scatter(operand, scatter_indices, updates, *, update_jaxpr, update_consts,
              dimension_numbers, indices_are_sorted, unique_indices, mode,
              _in_avals: Sequence[core.ShapedArray],
              _out_aval: core.ShapedArray):
-  del unique_indices, _in_avals
+  del unique_indices
 
   if mode == lax.GatherScatterMode.CLIP:
-    raise NotImplementedError("CLIP scatter mode not implemented in jax2tf")
+    clip_fn = _convert_jax_impl(lax_slicing._clamp_scatter_indices,
+                                multiple_results=False)
+    scatter_indices = clip_fn(
+        operand, scatter_indices, updates, dnums=dimension_numbers,
+        _in_avals=_in_avals, _out_aval=_in_avals[1])
 
   assert len(update_consts) == 0, "Update computation cannot have constants"
 

--- a/jax/experimental/jax2tf/tests/primitives_test.py
+++ b/jax/experimental/jax2tf/tests/primitives_test.py
@@ -100,7 +100,7 @@ class JaxPrimitiveTest(tf_test_util.JaxToTfTestCase):
   @primitive_harness.parameterized(
       primitive_harness.all_harnesses,
       include_jax_unimpl=False,
-      # one_containing="reduce_window_same_padding"
+      #one_containing="mode=GatherScatterMode.CLIP"
   )
   @jtu.ignore_warning(
       category=UserWarning, message="Using reduced precision for gradient.*")

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -1557,7 +1557,14 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   partial(lax.scatter_add, indices_are_sorted=False, unique_indices=True),
                   [RandArg((7, 4), _f32),
                    np.array([[1], [2]], np.int32),  # indices
-                   RandArg((7, 2), _f32),  # upd
+                   RandArg((7, 2), _f32),  # updates
+                   StaticArg(lax.ScatterDimensionNumbers((0,), (1,), (1,)))],
+                  poly_axes=[0, None, 0]),
+    _make_harness("scatter_add", "clip",
+                  partial(lax.scatter_add, indices_are_sorted=False, unique_indices=True, mode=lax.GatherScatterMode.CLIP),
+                  [RandArg((7, 4), _f32),
+                   np.array([[1], [2]], np.int32),  # indices
+                   RandArg((7, 2), _f32),  # updates
                    StaticArg(lax.ScatterDimensionNumbers((0,), (1,), (1,)))],
                   poly_axes=[0, None, 0]),
     _make_harness("select", "0",
@@ -1776,7 +1783,7 @@ class ShapePolyPrimitivesTest(tf_test_util.JaxToTfTestCase):
   # to parameterized below.
   @primitive_harness.parameterized(
       _flatten_harnesses(_POLY_SHAPE_TEST_HARNESSES),
-      #one_containing="arange_stop_error"
+      #one_containing="scatter_add_clip_poly_axes"
   )
   def test_prim(self, harness: Harness):
     args = harness.dyn_args_maker(self.rng())


### PR DESCRIPTION
Also handle a limited form of shape polymorphism, where
the `operand.shape - update.shape` is a constant in the scatter dimensions,
even when the shapes may contain dimension variables.