### PR TITLE
[jax2tf] Add tests for rng_uniform

### DIFF
--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -1,6 +1,6 @@
 # Primitives with limited support for jax2tf
 
-*Last generated on (YYYY-MM-DD): 2021-07-31*
+*Last generated on (YYYY-MM-DD): 2021-11-30*
 
 This document summarizes known limitations of the jax2tf conversion.
 There are several kinds of limitations.
@@ -98,6 +98,7 @@ More detailed information can be found in the
 | reduce_min | TF error: op not defined for dtype | complex | cpu, gpu, tpu | compiled, eager, graph |
 | regularized_incomplete_beta | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | rem | TF error: TF integer division fails if divisor contains 0; JAX returns NaN | integer | cpu, gpu, tpu | compiled, eager, graph |
+| rng_uniform | TF error: op not defined for dtype | uint32, uint64 | cpu, gpu, tpu | compiled, eager, graph |
 | round | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | scatter_add | TF test skipped: Not implemented in JAX: unimplemented | bool | cpu, gpu, tpu | compiled, eager, graph |
 | scatter_mul | TF test skipped: Not implemented in JAX: unimplemented | bool | cpu, gpu, tpu | compiled, eager, graph |
@@ -142,6 +143,7 @@ with jax2tf. The following table lists that cases when this does not quite hold:
 | max | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
 | min | May return different values when one of the values is NaN. JAX always returns NaN, while TF returns the value NaN is compared with. | all | cpu, gpu, tpu | compiled, eager, graph |
 | pow | custom numeric comparison | complex | cpu, gpu, tpu | eager, graph |
+| rng_uniform | disabled numeric comparison | all | cpu, gpu, tpu | compiled, eager, graph |
 | sort | Numeric comparison disabled: TODO: TF non-stable multiple-array sort | all | gpu | compiled, eager, graph |
 | svd | custom numeric comparison when compute_uv | all | cpu, gpu | compiled, eager, graph |
 | top_k | Produces different results when the array contains `inf` and `NaN` (they are sorted differently in TF vs. XLA). | floating | cpu, gpu, tpu | eager, graph |

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -931,6 +931,24 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     return []
 
   @classmethod
+  def rng_uniform(cls, harness: primitive_harness.Harness):
+    def custom_assert(tst, r_jax, r_tf, *, args, tol, err_msg):
+      # Since this is using a stateful RNG, we cannot expect to get the
+      # same result if we call repeatedly.
+      return True
+    return [
+        missing_tf_kernel(
+            dtypes=[np.uint32, np.uint64],
+            devices=("cpu", "gpu", "tpu"),
+            modes=("eager", "graph", "compiled")),
+        custom_numeric(
+            description="disabled numeric comparison",
+            custom_assert=custom_assert,
+            devices=("cpu", "gpu", "tpu"),
+            modes=("eager", "graph", "compiled"))
+    ]
+
+  @classmethod
   def round(cls, harness: primitive_harness.Harness):
     return [
         missing_tf_kernel(

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1650,11 +1650,8 @@ for dtype in jtu.dtypes.all_floating + jtu.dtypes.complex:
             lax.linalg.svd_p,
             f"shape={jtu.format_shape_dtype_string(shape, dtype)}_fullmatrices={full_matrices}_computeuv={compute_uv}",
             lambda *args: lax.linalg.svd_p.bind(
-                args[0], full_matrices=args[1], compute_uv=args[2]), [
-                    RandArg(shape, dtype),
-                    StaticArg(full_matrices),
-                    StaticArg(compute_uv)
-                ],
+                args[0], full_matrices=args[1], compute_uv=args[2]),
+            [ RandArg(shape, dtype), StaticArg(full_matrices), StaticArg(compute_uv)],
             jax_unimplemented=[
                 Limitation(
                     "unimplemented",
@@ -3003,10 +3000,23 @@ if config.jax_enable_x64:
         define(
             lax.rng_bit_generator_p,
             f"shape={jtu.format_shape_dtype_string(shape, dtype)}_algorithm={algorithm}",
-            lambda key, shape, dtype, algorithm: lax.rng_bit_generator(key, shape, dtype=dtype,
-                                                                       algorithm=algorithm),
-            [RandArg((2,), np.uint64),
-             StaticArg(shape), StaticArg(dtype), StaticArg(algorithm)],
+            partial(lax.rng_bit_generator, shape=shape, dtype=dtype, algorithm=algorithm),
+            [RandArg((2,), np.uint64)],
             shape=shape,
             dtype=dtype,
             algorithm=algorithm)
+
+for dtype in (set(jtu.dtypes.all) -
+              set(jtu.dtypes.complex) -
+              set([np.int16, np.int8, np.uint16, np.uint8, np.bool_])):
+  for shape in [(), (5, 7), (100, 100)]:
+    define(
+        lax.rng_uniform_p,
+        f"shape={jtu.format_shape_dtype_string(shape, dtype)}",
+        lambda minval, maxval, shape: lax.rng_uniform(minval, maxval, shape=shape),
+        [StaticArg(np.array(0, dtype=dtype)),
+         StaticArg(np.array(5, dtype=dtype)),
+         StaticArg(shape)],
+        shape=shape,
+        dtype=dtype,
+    )


### PR DESCRIPTION
These tests really only verify which dtypes are supported.
The actual numeric comparison is disabled, because rng_uniform
is statefull and calling multiple times produces different results.