### PR TITLE
[x64] improve consistency in handling dtype=None

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -343,7 +343,9 @@ def is_python_scalar(x):
 
 def dtype(x, *, canonicalize=False):
   """Return the dtype object for a value or type, optionally canonicalized based on X64 mode."""
-  if isinstance(x, type) and x in python_scalar_dtypes:
+  if x is None:
+    return float_
+  elif isinstance(x, type) and x in python_scalar_dtypes:
     dt = python_scalar_dtypes[x]
   elif type(x) in python_scalar_dtypes:
     dt = python_scalar_dtypes[type(x)]

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6550,7 +6550,7 @@ def nanmedian(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, out=None,
 
 def _astype(arr, dtype):
   lax._check_user_dtype_supported(dtype, "astype")
-  return lax.convert_element_type(arr, dtype)
+  return lax.convert_element_type(arr, float_ if dtype is None else dtype)
 
 
 def _nbytes(arr):

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1044,7 +1044,7 @@ class BCOO(ops.JAXSparse):
       raise NotImplementedError("BCOO.fromscipy with nonzero n_dense/n_batch")
     mat = mat.tocoo()
     data = jnp.asarray(mat.data)
-    indices = jnp.column_stack((mat.row, mat.col)).astype(index_dtype)
+    indices = jnp.column_stack((mat.row, mat.col)).astype(index_dtype or jnp.int32)
     return cls((data, indices), shape=mat.shape)
 
   def _unbatch(self):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -224,6 +224,8 @@ class DtypesTest(jtu.JaxTestCase):
   def testDtypeFromString(self, dtype):
     self.assertEqual(dtypes.dtype(str(dtype)), dtype)
 
+  def testDtypeFromNone(self):
+    self.assertEqual(dtypes.dtype(None), dtypes.float_)
 
 class TestPromotionTables(jtu.JaxTestCase):
 
@@ -244,6 +246,9 @@ class TestPromotionTables(jtu.JaxTestCase):
     except TypeError:
       val = jaxtype.type(0)
     self.assertIs(dtypes._jax_type(*dtypes._dtype_and_weaktype(val)), jaxtype)
+
+  def testResultTypeNone(self):
+    self.assertEqual(dtypes.result_type(None), dtypes.canonicalize_dtype(dtypes.float_))
 
   @jtu.ignore_warning(category=UserWarning,
                       message="Explicitly requested dtype.*")

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3998,6 +3998,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
+  def testAstypeNone(self):
+    rng = np.random.RandomState(0)
+    args_maker = lambda: [rng.randn(3, 4).astype("int32")]
+    np_op = lambda x: np.asarray(x).astype(None)
+    jnp_op = lambda x: jnp.asarray(x).astype(None)
+    self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
+    self._CompileAndCheck(jnp_op, args_maker)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}".format(
           jtu.format_shape_dtype_string(shape, dtype)),


### PR DESCRIPTION
This makes JAX's `astype()` method match the behavior of numpy's with `dtype=None`.

Numpy behavior treats `None` as its default float type:
```python
>>> import numpy as np
>>> np.arange(4).astype(None)
array([0., 1., 2., 3.])
```
JAX behavior before:
```python
>>> import jax.numpy as jnp
>>> jnp.arange(4).astype(None)
DeviceArray([0, 1, 2, 3], dtype=int32)
```
JAX behavior after:
```python
>>> import jax.numpy as jnp
>>> jnp.arange(4).astype(None)
DeviceArray([0., 1., 2., 3.], dtype=float32)
```
Also clean up and test handling of `None` within `jax.dtypes` helpers, ensuring that `dtypes.dtype(None)` returns the default floating point type. This does not change behavior currently, but will make things more consistent for #8178