### PR TITLE
[x64] ensure scatter functionality preserves weak_type

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from jax import core
 from jax import lax
+from jax._src import dtypes
 from jax._src.numpy import lax_numpy as jnp
 from jax._src import util
 
@@ -77,6 +78,7 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
                   indices_are_sorted, unique_indices, mode,
                   normalize_indices):
   dtype = lax.dtype(x)
+  weak_type = dtypes.is_weakly_typed(x)
 
   idx = jnp._merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx)
   indexer = jnp._index_to_gather(jnp.shape(x), idx,
@@ -108,7 +110,7 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
     indices_are_sorted=indexer.indices_are_sorted or indices_are_sorted,
     unique_indices=indexer.unique_indices or unique_indices,
     mode=mode)
-  return lax.convert_element_type(out, dtype)
+  return lax._convert_element_type(out, dtype, weak_type)
 
 
 class _Indexable(object):

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -27,9 +27,10 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-from jax import dtypes
+from jax import lax
 from jax import numpy as jnp
 from jax import ops
+from jax._src import dtypes
 from jax._src import test_util as jtu
 from jax._src import util
 
@@ -895,6 +896,21 @@ class IndexingTest(jtu.JaxTestCase):
     self.assertArraysEqual(
       x.at[idx].get(mode="fill", fill_value=7),
       jnp.array([7, 7, 1, 2, 1, 4, 5, 7, 7, 7], jnp.int32))
+
+  def testIndexingWeakTypes(self):
+    x = lax._convert_element_type(jnp.arange(5), int, weak_type=True)
+
+    a = x.at[0].set(1.0)
+    self.assertEqual(a.dtype, x.dtype)
+    self.assertTrue(dtypes.is_weakly_typed(a))
+
+    b = x.at[0].add(1.0)
+    self.assertEqual(b.dtype, x.dtype)
+    self.assertTrue(dtypes.is_weakly_typed(b))
+
+    c = x.at[0].mul(1.0)
+    self.assertEqual(c.dtype, x.dtype)
+    self.assertTrue(dtypes.is_weakly_typed(c))
 
 
 def _broadcastable_shapes(shape):


### PR DESCRIPTION
Part of #8178

I came across this issue when trying to satisfy the following test case, related to #8722:
```python
def test_gmres_weak_types(self):
  x, _ = jax.scipy.sparse.linalg.gmres(lambda x: x, 1.0)
  self.assertTrue(dtypes.is_weakly_typed(x))
```