### PR TITLE
lax.convert_element_type: stricter dtype validation

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -344,7 +344,7 @@ def is_python_scalar(x):
 def dtype(x, *, canonicalize=False):
   """Return the dtype object for a value or type, optionally canonicalized based on X64 mode."""
   if x is None:
-    return float_
+    raise ValueError(f"Invalid argument to dtype: {x}.")
   elif isinstance(x, type) and x in python_scalar_dtypes:
     dt = python_scalar_dtypes[x]
   elif type(x) in python_scalar_dtypes:
@@ -375,7 +375,7 @@ def result_type(*args):
   """Convenience function to apply JAX argument dtype promotion."""
   if len(args) == 0:
     raise ValueError("at least one array or dtype is required")
-  dtype, weak_type = _lattice_result_type(*args)
+  dtype, weak_type = _lattice_result_type(*(float_ if arg is None else arg for arg in args))
   if weak_type:
     dtype = _default_types['f' if dtype == _bfloat16_dtype else dtype.kind]
   return canonicalize_dtype(dtype)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -464,10 +464,14 @@ def _convert_element_type(operand: Array, new_dtype: Optional[DType] = None,
                           weak_type: bool = False):
   # Don't canonicalize old_dtype because x64 context might cause
   # un-canonicalized operands to be passed in.
-  old_dtype = np.result_type(operand)
+  old_dtype = dtypes.dtype(operand, canonicalize=False)
   old_weak_type = dtypes.is_weakly_typed(operand)
 
-  new_dtype = dtypes.canonicalize_dtype(new_dtype or old_dtype)
+  if new_dtype is None:
+    new_dtype = old_dtype
+  else:
+    new_dtype = np.dtype(new_dtype)
+  new_dtype = dtypes.dtype(new_dtype, canonicalize=True)
   new_weak_type = bool(weak_type)
 
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6549,8 +6549,10 @@ def nanmedian(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, out=None,
 
 
 def _astype(arr, dtype):
+  if dtype is None:
+    dtype = dtypes.canonicalize_dtype(float_)
   lax._check_user_dtype_supported(dtype, "astype")
-  return lax.convert_element_type(arr, float_ if dtype is None else dtype)
+  return lax.convert_element_type(arr, dtype)
 
 
 def _nbytes(arr):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -225,7 +225,8 @@ class DtypesTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.dtype(str(dtype)), dtype)
 
   def testDtypeFromNone(self):
-    self.assertEqual(dtypes.dtype(None), dtypes.float_)
+    with self.assertRaisesRegex(ValueError, "Invalid argument to dtype"):
+      dtypes.dtype(None)
 
 class TestPromotionTables(jtu.JaxTestCase):
 
@@ -248,6 +249,7 @@ class TestPromotionTables(jtu.JaxTestCase):
     self.assertIs(dtypes._jax_type(*dtypes._dtype_and_weaktype(val)), jaxtype)
 
   def testResultTypeNone(self):
+    # This matches the behavior of np.result_type(None) => np.float_
     self.assertEqual(dtypes.result_type(None), dtypes.canonicalize_dtype(dtypes.float_))
 
   @jtu.ignore_warning(category=UserWarning,


### PR DESCRIPTION
Following up on https://github.com/google/jax/pull/8741#discussion_r759798787

This includes a couple changes to how lax handles dtype inputs. In particular:

- dtypes.dtype(None) now raises an error rather than returning `float64`. The previous behavior came from the fact that it fell back to `np.result_type` for general inputs.
- `lax.convert_element_type(arr, None)` previously was a no-op. This is in contrast to `jax.numpy` and `numpy`, for which `x.astype(None)` converts to float. This was confusing, so `lax.convert_element_type(arr, None)` now results in an error.
- The dtype argument to `lax.convert_element_type` is now validated as a dtype. Previously, the implementation allowed any object with a dtype to be passed, so for example `lax.convert_element_type(x, jnp.arange(3))` would convert `x` to the dtype of the second argument. This now results in an error.
- As part of this, `dtypes.dtype(None)` now returns an error rather than `np.float_`. To keep the behavior of `arr.astype(None)` consistent with numpy's behavior, we now explicitly enumerate this case and convert to float.

All these previous behaviors were unintentional (I believe) and the new behavior is more in line with lax's philosophy of requiring strict/explicit inputs.