### PR TITLE
[x64] make jax.numpy functionality respect default dtypes

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4737,9 +4737,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(jnp.arange(53, 5, -3),
                         np.arange(53, 5, -3, dtype=jnp.int_))
     self.assertAllClose(jnp.arange(77, dtype=float),
-                        np.arange(77, dtype=float))
+                        np.arange(77, dtype=jnp.float_))
     self.assertAllClose(jnp.arange(2, 13, dtype=int),
-                        np.arange(2, 13, dtype=int))
+                        np.arange(2, 13, dtype=jnp.int_))
     self.assertAllClose(jnp.arange(0, 1, -0.5),
                         np.arange(0, 1, -0.5, dtype=jnp.float_))
 


### PR DESCRIPTION
This PR contains all the modifications of `lax_numpy.py` from #8180

The main goal of these changes is to make a number of functions return values of type `jnp.int_` or `jnp.float_` rather than of type `jnp.int64` or `jnp.float64`. The thinking is that functions like `jnp.zeros`, `jnp.ones`, `jnp.arange`, `jnp.linspace`, etc. should respect JAX's default dtype (matching `jnp.int_`, `jnp.float_`, etc.) rather than always returning `int64` or `float64` like NumPy.

Note that currently, `jnp.int_ = jnp.int64` and `jnp.float_ = jnp.float64`, so **this PR should have no user-visible changes**, but since these changes can be made orthogonally to the rest of the changes in #8180, I think it's useful to do them separately for ease of review.