### PR TITLE
[sparse] make JAXSparse an ABC & declare BCOO methods

### DIFF
--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 """Base JAX Sparse object."""
+import abc
 from typing import Tuple
 
 from jax import core
 import jax.numpy as jnp
 
 
-class JAXSparse:
+class JAXSparse(abc.ABC):
   """Base class for high-level JAX sparse objects."""
   data: jnp.ndarray
   shape: Tuple[int, ...]
@@ -47,38 +48,58 @@ class JAXSparse:
       repr_ = f"{type(self.data).__name__}[{repr_}]"
     return repr_
 
+  @abc.abstractmethod
   def tree_flatten(self):
-    raise NotImplementedError("tree_flatten")
+    ...
 
   @classmethod
   def tree_unflatten(cls, aux_data, children):
     return cls(children, **aux_data)
 
-  def matvec(self, v):
-    raise NotImplementedError("matvec")
-
-  def matmat(self, B):
-    raise NotImplementedError("matmat")
-
+  @abc.abstractmethod
   def transpose(self, axes=None):
-    raise NotImplementedError()
+    ...
 
   @property
   def T(self):
     return self.transpose()
 
-  def __matmul__(self, other):
-    if isinstance(other, JAXSparse):
-      raise NotImplementedError("matmul between two sparse objects.")
-    other = jnp.asarray(other)
-    if other.ndim == 1:
-      return self.matvec(other)
-    elif other.ndim == 2:
-      return self.matmat(other)
-    else:
-      raise NotImplementedError(f"matmul with object of shape {other.shape}")
-
   def block_until_ready(self):
     for arg in self.tree_flatten()[0]:
       arg.block_until_ready()
     return self
+
+  # Not abstract methods because not all sparse classes implement them
+
+  def sum(self, *args, **kwargs):
+    raise NotImplementedError(f"{self.__class__}.sum")
+
+  def __neg__(self):
+    raise NotImplementedError(f"{self.__class__}.__neg__")
+
+  def __pos__(self):
+    raise NotImplementedError(f"{self.__class__}.__pos__")
+
+  def __matmul__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__matmul__")
+
+  def __rmatmul__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__rmatmul__")
+
+  def __mul__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__mul__")
+
+  def __rmul__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__rmul__")
+
+  def __add__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__add__")
+
+  def __radd__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__radd__")
+
+  def __sub__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__sub__")
+
+  def __rsub__(self, other):
+    raise NotImplementedError(f"{self.__class__}.__rsub__")


### PR DESCRIPTION
Fixes pytype issue introduced by refactoring in https://github.com/google/jax/commit/da319cf30292c9a54e1d41c7f71a8db1961f86d9