### PR TITLE
[x64] add new jax_default_dtype_bits flag

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -543,6 +543,14 @@ hlo_source_file_canonicalization_regex = config.define_string_state(
           'persistent compilation cache, which includes HLO metadata in the '
           'cache key.'))
 
+config.define_enum_state(
+    name='jax_default_dtype_bits',
+    enum_values=['32', '64'],
+    default='64',
+    help=('Specify bit width of default dtypes, either 32-bit or 64-bit. '
+          'This is a temporary flag that will be used during the process '
+          'of deprecating the ``jax_enable_x64`` flag.'))
+
 def _update_x64_global(val):
   lib.jax_jit.global_state().enable_x64 = val
 

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -39,18 +39,11 @@ bfloat16: type = xla_client.bfloat16
 _bfloat16_dtype: np.dtype = np.dtype(bfloat16)
 
 # Default types.
-
 bool_: type = np.bool_
-int_: type = np.int64
-uint: type = np.uint64
-float_: type = np.float64
-complex_: type = np.complex128
-
-# TODO(phawkins): change the above defaults to:
-# int_ = np.int32
-# uint = np.uint32
-# float_ = np.float32
-# complex_ = np.complex64
+int_: type = np.int32 if config.jax_default_dtype_bits == '32' else np.int64
+uint: type = np.uint32 if config.jax_default_dtype_bits == '32' else np.uint64
+float_: type = np.float32 if config.jax_default_dtype_bits == '32' else np.float64
+complex_: type = np.complex64 if config.jax_default_dtype_bits == '32' else np.complex128
 _default_types = {'b': bool_, 'i': int_, 'u': uint, 'f': float_, 'c': complex_}
 
 # Trivial vectorspace datatype needed for tangent values of int/bool primals

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -31,6 +31,8 @@ from jax._src import test_util as jtu
 from jax.config import config
 config.parse_flags_with_absl()
 
+FLAGS = config.FLAGS
+
 bool_dtypes = [np.dtype('bool')]
 
 signed_dtypes = [np.dtype('int8'), np.dtype('int16'), np.dtype('int32'),
@@ -227,6 +229,16 @@ class DtypesTest(jtu.JaxTestCase):
   def testDtypeFromNone(self):
     with self.assertRaisesRegex(ValueError, "Invalid argument to dtype"):
       dtypes.dtype(None)
+
+  def testDefaultDtypes(self):
+    precision = config.jax_default_dtype_bits
+    assert precision in ['32', '64']
+    self.assertEqual(dtypes.bool_, np.bool_)
+    self.assertEqual(dtypes.int_, np.int32 if precision == '32' else np.int64)
+    self.assertEqual(dtypes.uint, np.uint32 if precision == '32' else np.uint64)
+    self.assertEqual(dtypes.float_, np.float32 if precision == '32' else np.float64)
+    self.assertEqual(dtypes.complex_, np.complex64 if precision == '32' else np.complex128)
+
 
 class TestPromotionTables(jtu.JaxTestCase):
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5713,6 +5713,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(_promote_like_jnp(np_op), jnp.logaddexp2, args_maker, tol=tol)
     self._CompileAndCheck(jnp.logaddexp2, args_maker, rtol=tol, atol=tol)
 
+  def testDefaultDtypes(self):
+    precision = config.jax_default_dtype_bits
+    assert precision in ['32', '64']
+    self.assertEqual(jnp.bool_, np.bool_)
+    self.assertEqual(jnp.int_, np.int32 if precision == '32' else np.int64)
+    self.assertEqual(jnp.uint, np.uint32 if precision == '32' else np.uint64)
+    self.assertEqual(jnp.float_, np.float32 if precision == '32' else np.float64)
+    self.assertEqual(jnp.complex_, np.complex64 if precision == '32' else np.complex128)
+
 # Most grad tests are at the lax level (see lax_test.py), but we add some here
 # as needed for e.g. particular compound ops of interest.
 


### PR DESCRIPTION
This is part of landing step 1 of #8178.

This adds a new `jax_default_dtype` flag, which defaults to `'x64'`, and can be set to `'x32'`. It controls the precision of `dtypes.int_`, `dtypes.float_`, `jnp.int_`, `jnp.float_`, etc. and by extension, controls the default precision of arrays created by functions like `jnp.arange`, `jnp.linspace`, `jnp.argsort`, etc.

This makes it such that the core change of #8180 will simply be to flip the default flag value to `'32'`. Having the flag available during the transition to this new default will allow a softer landing for teams affected by this change.