### PR TITLE
[host_callback] Fix usage of host_callback together with lower_fun.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -880,7 +880,7 @@ def xla_computation(fun: Callable,
       for axis_name, size in axis_env or []:
         stack.enter_context(core.extend_axis_env(axis_name, size, None))
       jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(jaxtree_fun, avals)
-      jaxpr = dispatch.apply_outfeed_rewriter(jaxpr)
+      jaxpr = core.apply_outfeed_rewriter(jaxpr)
       axis_env_ = make_axis_env(dispatch.jaxpr_replicas(jaxpr))
       if out_parts is None:
         out_parts_flat = None

--- a/jax/core.py
+++ b/jax/core.py
@@ -319,6 +319,15 @@ def extract_call_jaxpr(
     del new_params["call_jaxpr"]
     return (params["call_jaxpr"], new_params)
 
+# We can optionally set a Jaxpr rewriter that can be applied just before
+# compilation. This mechanism is used for compiling id_tap, we can
+# remove it once we bring the id_tap implementation into the core.
+outfeed_rewriter: Optional[Callable[[Jaxpr], Jaxpr]] = None
+def apply_outfeed_rewriter(jaxpr: Jaxpr) -> Jaxpr:
+  if outfeed_rewriter is not None:
+    return outfeed_rewriter(jaxpr)
+  else:
+    return jaxpr
 
 # TODO(mattjj): replace this approach with a primitive-keyed table of rules
 def traverse_jaxpr_params(f, params):

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1736,7 +1736,7 @@ id_p.def_impl(lambda *args: args)
 id_p.def_abstract_eval(lambda *args: args)
 xla.register_translation(id_p, lambda ctx, avals_in, avals_out, *args: args)
 
-dispatch.outfeed_rewriter = lambda j: _rewrite_jaxpr(j, False, False)
+core.outfeed_rewriter = lambda j: _rewrite_jaxpr(j, False, False)
 
 
 class CallbackException(Exception):

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -613,6 +613,8 @@ def lower_fun(fun: Callable, multiple_results: bool = True) -> Callable:
     wrapped_fun = lu.wrap_init(f, params)
     with core.extend_axis_env_nd(zip(ctx.axis_env.names, ctx.axis_env.sizes)):
       jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals_in)
+    # TODO(issue #8853): not quite right, does not pass the tokens properly
+    jaxpr = core.apply_outfeed_rewriter(jaxpr)
     return jaxpr_subcomp(ctx, jaxpr, _ir_consts(consts),
                          *map(wrap_singleton_ir_values, args))
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -874,7 +874,7 @@ def stage_parallel_callable(
                                    "for pmap in {elapsed_time} sec"):
       jaxpr, out_sharded_avals, consts = pe.trace_to_jaxpr_final(
           fun, global_sharded_avals, pe.debug_info_final(fun, "pmap"))
-  jaxpr = dispatch.apply_outfeed_rewriter(jaxpr)
+  jaxpr = core.apply_outfeed_rewriter(jaxpr)
 
   assert len(out_sharded_avals) == len(pci.out_axes), (
       len(out_sharded_avals), len(pci.out_axes))
@@ -1959,7 +1959,7 @@ def lower_mesh_computation(
   _sanitize_mesh_jaxpr(jaxpr)
   if mesh.is_multi_process:
     check_multihost_collective_allowlist(jaxpr)
-  jaxpr = dispatch.apply_outfeed_rewriter(jaxpr)
+  jaxpr = core.apply_outfeed_rewriter(jaxpr)
 
   # 3. Build up the HLO
   tuple_args = len(in_jaxpr_avals) > 100  # pass long arg lists as tuple for TPU

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1019,6 +1019,7 @@ def lower_fun(fun: Callable, *, multiple_results: bool, backend=None,
       wrapped_fun = _tuple_output(wrapped_fun)
     with core.extend_axis_env_nd(zip(axis_env.names, axis_env.sizes)):
       jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
+    jaxpr = core.apply_outfeed_rewriter(jaxpr)
     ctx = TranslationContext(c, backend, axis_env, '')
     outs = jaxpr_subcomp(ctx, jaxpr, _xla_consts(c, consts), *xla_args)
     if (multiple_results or

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -1019,6 +1019,7 @@ def lower_fun(fun: Callable, *, multiple_results: bool, backend=None,
       wrapped_fun = _tuple_output(wrapped_fun)
     with core.extend_axis_env_nd(zip(axis_env.names, axis_env.sizes)):
       jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(wrapped_fun, avals)
+    # TODO(issue #8853): not quite right, does not pass the tokens properly
     jaxpr = core.apply_outfeed_rewriter(jaxpr)
     ctx = TranslationContext(c, backend, axis_env, '')
     outs = jaxpr_subcomp(ctx, jaxpr, _xla_consts(c, consts), *xla_args)


### PR DESCRIPTION
lower_fun is not quite public API, but people do use it when defining
new primitives. lower_fun was missing a call to the outfeed_rewriter.
In order to make the apply_outfeed_rewriter visible from xla.py, I
moved it from dispatch.py to core.py.

Bug: #8853