### PR TITLE
[x64] make jax.experimental.loops consistent with default dtype flag

### DIFF
--- a/jax/experimental/loops.py
+++ b/jax/experimental/loops.py
@@ -115,7 +115,6 @@ from typing import Any, Dict, List, cast
 from jax import lax, core
 from jax._src.lax import control_flow as lax_control_flow
 from jax import tree_util
-from jax import numpy as jnp
 from jax.errors import UnexpectedTracerError
 from jax.interpreters import partial_eval as pe
 from jax._src.util import safe_map
@@ -500,7 +499,7 @@ class _BoundedLoopBuilder(_LoopBuilder):
 
   def build_output_vals(self, scope, carried_state_names, carried_tree,
                         init_vals, body_closed_jaxpr, body_const_vals):
-    arange_val = jnp.arange(self.start, stop=self.stop, step=self.step)
+    arange_val = np.arange(self.start, stop=self.stop, step=self.step)
     return lax_control_flow.scan_p.bind(*body_const_vals, *init_vals, arange_val,
                                         reverse=False, length=arange_val.shape[0],
                                         jaxpr=body_closed_jaxpr,

--- a/tests/loops_test.py
+++ b/tests/loops_test.py
@@ -62,7 +62,7 @@ class LoopsTest(jtu.JaxTestCase):
     self.assertAllClose(5., jax.grad(f_op)(2.))
     self.assertAllClose(5., jax.grad(f_op)(2.))
     inc_batch = np.arange(5.0)
-    self.assertAllClose(jnp.array([f_expected(inc) for inc in inc_batch]),
+    self.assertAllClose(np.array([f_expected(inc) for inc in inc_batch]),
                         jax.vmap(f_op)(inc_batch))
 
 


### PR DESCRIPTION
This makes all `loops_test.py` tests pass under the new `jax_default_dtype_bits` flag, added in #8834. This is part of #8178, extracted (with some modification & cleanup) from the draft in #8180.

Tested locally by running with all four flag combinations:
```
$ JAX_DEFAULT_DTYPE_BITS=64 JAX_ENABLE_X64=0 pytest -n auto tests/loops_test.py
$ JAX_DEFAULT_DTYPE_BITS=64 JAX_ENABLE_X64=1 pytest -n auto tests/loops_test.py
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=0 pytest -n auto tests/loops_test.py
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/loops_test.py
```