### PR TITLE
[x64] make x64_context tests work with updated default dtypes

### DIFF
--- a/jax/experimental/x64_context.py
+++ b/jax/experimental/x64_context.py
@@ -32,9 +32,9 @@ def enable_x64(new_val: bool = True):
 
   Usage::
 
-    >>> import jax.numpy as jnp
+    >>> x = np.arange(5, dtype='float64')
     >>> with enable_x64():
-    ...   print(jnp.arange(10.0).dtype)
+    ...   print(jnp.asarray(x).dtype)
     ...
     float64
 
@@ -51,9 +51,9 @@ def disable_x64():
 
   Usage::
 
-    >>> import jax.numpy as jnp
+    >>> x = np.arange(5, dtype='float64')
     >>> with disable_x64():
-    ...   print(jnp.arange(10.0).dtype)
+    ...   print(jnp.asarray(x).dtype)
     ...
     float32
 


### PR DESCRIPTION
This makes all `x64_context.py` doctests pass under the new `jax_default_dtype_bits` flag, added in #8834. This is part of #8178, extracted from the draft in #8180.

Tested locally by running with all four flag combinations:
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=0 pytest --doctest-modules jax/experimental/x64_context.py
$ JAX_DEFAULT_DTYPE_BITS=64 JAX_ENABLE_X64=0 pytest --doctest-modules jax/experimental/x64_context.py
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest --doctest-modules jax/experimental/x64_context.py
$ JAX_DEFAULT_DTYPE_BITS=64 JAX_ENABLE_X64=1 pytest --doctest-modules jax/experimental/x64_context.py
```