### PR TITLE
Remove all `stop_gradient` calls from `custom_root`.

### DIFF
--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -1070,7 +1070,7 @@
     "id": "HowvqayEuy-H"
    },
    "source": [
-    "A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API."
+    "A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. For this use case, consider using the low-level primitive `lax.custom_root`, which allows for deriviatives in closed-over variables with custom root-finding functions."
    ]
   },
   {

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -560,7 +560,7 @@ print(grad(grad(jnp.sqrt))(2.))
 
 +++ {"id": "HowvqayEuy-H"}
 
-A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. While other JAX mechanisms can handle closed-over transformation-traced values in the arguments to higher-order functions (as is done for the control flow primitives like `lax.cond`, `lax.scan`, and `lax.while_loop` itself), `jax.custom_vjp` used as above cannot. A `fixed_point` routine that used a bit more of JAX's internals could have a more convenient and robust API.
+A limitation to this approach is that the argument `f` can't close over any values involved in differentiation. That is, you might notice that we kept the parameter `a` explicit in the argument list of `fixed_point`. For this use case, consider using the low-level primitive `lax.custom_root`, which allows for deriviatives in closed-over variables with custom root-finding functions.
 
 +++ {"id": "Dr0aNkBslfQf"}
 


### PR DESCRIPTION
Resolves #8744 by removing all calls to `stop_gradient` in `jax.lax.control_flow.custom_root`.

### Context

The `custom_root` function allows users to create custom root finders, i.e., methods that solve `f(x, y) == 0` for `x`, and then automatically generates the gradient of the found `x` with respect to `y` using the implicit function theorem.

Unfortunately, `custom_root` does not support root-finding methods that require gradients, e.g., Newton's method and related approaches. The main issue was the application of `lax.stop_gradient` to all arguments of the root-finding method. This approach was needed in the past due to 

1. Implementation of `custom_root` as a primitive, and
2. The lack of differentiability of many jax control structures, such as `while_loop`.

Fortunately, both of these issues are no longer blocking, so we can remove the application of `stop_gradient`.


### Changes

1. Removes `_stop_gradient_fun` from `lax.control_flow`. (Key functional change.)
2. Adds tests, including an implementation of a simple newton `custom_root` solver. Extant tests updated to use this solver in addition to binary search.