### PR TITLE
Add `contiguous_submeshes` option to `mesh_utils.create_device_mesh()`.

### DIFF
--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -95,9 +95,14 @@ def pjit(fun: Callable,
     of ``pjit`` every process only "sees" its local piece of the input and output,
     corresponding to its local sub-mesh.
 
-    The SPMD model requires that the same multi-process ``pjit``'d functions must
-    be run in the same order on all processes, but they can be interspersed with
-    arbitrary operations running in a single process.
+    This means that each process's participating local devices must form a
+    _contiguous_ local sub-mesh within the full global mesh. A contiguous
+    sub-mesh is one where all of its devices are adjacent within the global
+    mesh, and form a rectangular prism.
+
+    The SPMD model also requires that the same multi-process ``pjit``'d
+    functions must be run in the same order on all processes, but they can be
+    interspersed with arbitrary operations running in a single process.
 
   Args:
     fun: Function to be compiled. Should be a pure function, as side-effects may

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1781,9 +1781,11 @@ class Mesh:
 
   @maybe_cached_property
   def local_mesh(self):
+    return self._local_mesh(xb.process_index())
+
+  def _local_mesh(self, process_index):
     if self.empty:
       return self
-    process_index = xb.process_index()
     is_local_device = np.vectorize(
         lambda d: d.process_index == process_index, otypes=[bool])(self.devices)
     subcube_indices = []


### PR DESCRIPTION
Unless you're using GlobalDeviceArrays, the device mesh passed to pjit
must be composed of contiguous submeshes for each process (i.e. each
process's local devices must all be next to each other in the full
mesh and form a rectangular submesh). This change teaches
`create_device_mesh` how to output meshes that satisfy this
constraint in some common cases.

This isn't the default behavior because the resulting meshes are a
little awkward and magical, and eventually we'd like using
GlobalDeviceArrays to be the common use case.