### PR TITLE
[x64] make random_test pass with jax_default_dtype_bits=32

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -92,7 +92,14 @@ def _dtype(x):
 def num_float_bits(dtype):
   return _dtypes.finfo(_dtypes.canonicalize_dtype(dtype)).bits
 
-def _to_default_dtype(arr):
+def to_default_dtype(arr):
+  """Convert a value to an array with JAX's default dtype.
+
+  This is generally used for type conversions of values returned by numpy functions,
+  to make their dtypes take into account the state of the ``jax_enable_x64`` and
+  ``jax_default_dtype_bits`` flags.
+  """
+  arr = np.asarray(arr)
   dtype = _dtypes._default_types.get(arr.dtype.kind)
   return arr.astype(_dtypes.canonicalize_dtype(dtype)) if dtype else arr
 
@@ -113,9 +120,9 @@ def with_jax_dtype_defaults(func, use_defaults=True):
   def wrapped(*args, **kwargs):
     result = func(*args, **kwargs)
     if isinstance(use_defaults, bool):
-      return tree_map(_to_default_dtype, result) if use_defaults else result
+      return tree_map(to_default_dtype, result) if use_defaults else result
     else:
-      f = lambda arr, use_default: _to_default_dtype(arr) if use_default else arr
+      f = lambda arr, use_default: to_default_dtype(arr) if use_default else arr
       return tree_map(f, result, use_defaults)
   return wrapped
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -143,25 +143,26 @@ class PrngTest(jtu.JaxTestCase):
     # Test to ensure consistent random values between JAX versions
     k = random.PRNGKey(0)
 
+    self.assertEqual(random.randint(k, (3, 3), 0, 8).dtype,
+                     dtypes.canonicalize_dtype(jnp.int_))
     if config.x64_enabled:
         self.assertAllClose(
-            random.randint(k, (3, 3), 0, 8),
+            random.randint(k, (3, 3), 0, 8, dtype='int64'),
             np.array([[7, 2, 6],
                        [2, 1, 0],
                        [6, 7, 7]], dtype='int64'))
-    else:
-        self.assertAllClose(
-            random.randint(k, (3, 3), 0, 8),
-            np.array([[2, 1, 3],
-                       [6, 1, 5],
-                       [6, 3, 4]], dtype='int32'))
+    self.assertAllClose(
+        random.randint(k, (3, 3), 0, 8, dtype='int32'),
+        np.array([[2, 1, 3],
+                  [6, 1, 5],
+                  [6, 3, 4]], dtype='int32'))
 
     self.assertAllClose(
         _prng_key_as_array(random.split(k, 4)),
         np.array([[2285895361, 1501764800],
-                   [1518642379, 4090693311],
-                   [ 433833334, 4221794875],
-                   [ 839183663, 3740430601]], dtype='uint32'))
+                  [1518642379, 4090693311],
+                  [ 433833334, 4221794875],
+                  [ 839183663, 3740430601]], dtype='uint32'))
 
     self.assertAllClose(
         _prng_key_as_array(random.fold_in(k, 4)),
@@ -906,10 +907,7 @@ class LaxRandomTest(jtu.JaxTestCase):
   def testIssue756(self):
     key = self.seed_prng(0)
     w = random.normal(key, ())
-    if config.x64_enabled:
-      self.assertEqual(np.result_type(w), np.float64)
-    else:
-      self.assertEqual(np.result_type(w), np.float32)
+    self.assertEqual(w.dtype, dtypes.canonicalize_dtype(jnp.float_))
 
   def testIssue1789(self):
     def f(x):
@@ -939,8 +937,8 @@ class LaxRandomTest(jtu.JaxTestCase):
     rand = lambda x: random.maxwell(x, (num_samples, ))
     crand = jax.jit(rand)
 
-    loc = scipy.stats.maxwell.mean()
-    std = scipy.stats.maxwell.std()
+    loc = jtu.to_default_dtype(scipy.stats.maxwell.mean())
+    std = jtu.to_default_dtype(scipy.stats.maxwell.std())
 
     uncompiled_samples = rand(rng)
     compiled_samples = crand(rng)
@@ -962,8 +960,8 @@ class LaxRandomTest(jtu.JaxTestCase):
     rand = lambda x: random.weibull_min(x, scale, concentration, (num_samples,))
     crand = jax.jit(rand)
 
-    loc = scipy.stats.weibull_min.mean(c=concentration, scale=scale)
-    std = scipy.stats.weibull_min.std(c=concentration, scale=scale)
+    loc = jtu.to_default_dtype(scipy.stats.weibull_min.mean(c=concentration, scale=scale))
+    std = jtu.to_default_dtype(scipy.stats.weibull_min.std(c=concentration, scale=scale))
 
     uncompiled_samples = rand(rng)
     compiled_samples = crand(rng)
@@ -1011,8 +1009,8 @@ class LaxRandomTest(jtu.JaxTestCase):
     for samples in [uncompiled_samples, compiled_samples]:
       # Check first and second moments.
       self.assertEqual((num_samples,), samples.shape)
-      self.assertAllClose(np.mean(samples), mean, atol=0., rtol=0.1)
-      self.assertAllClose(np.std(samples), std, atol=0., rtol=0.1)
+      self.assertAllClose(samples.mean(), jtu.to_default_dtype(mean), atol=0., rtol=0.1)
+      self.assertAllClose(samples.std(), jtu.to_default_dtype(std), atol=0., rtol=0.1)
 
       self._CheckKolmogorovSmirnovCDF(
           samples, lambda x: double_sided_maxwell_cdf(x, loc, scale))


### PR DESCRIPTION
This makes all `tests/random_test.py` pass under the new `jax_default_dtype_bits` flag, added in #8834. This is part of #8178, extracted from the draft in #8180.

Tested locally by running with all four flag combinations:
```
$ JAX_ENABLE_X64=0 JAX_DEFAULT_DTYPE_BITS=32 pytest -n auto tests/random_test.py
$ JAX_ENABLE_X64=0 JAX_DEFAULT_DTYPE_BITS=64 pytest -n auto tests/random_test.py
$ JAX_ENABLE_X64=1 JAX_DEFAULT_DTYPE_BITS=32 pytest -n auto tests/random_test.py
$ JAX_ENABLE_X64=1 JAX_DEFAULT_DTYPE_BITS=64 pytest -n auto tests/random_test.py
```