### PR TITLE
[x64] fix jax2tf_test for default_dtype

### DIFF
--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -136,9 +136,9 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     mk_sharded = lambda f: jax.pmap(lambda x: x)(f([n]))
     f_tf = tf.function(lambda x: x)
     self.assertAllClose(f_tf(mk_sharded(jnp.zeros)).numpy(),
-                        np.zeros([n]))
+                        jnp.zeros([n]))
     self.assertAllClose(f_tf(mk_sharded(jnp.ones)).numpy(),
-                        np.ones([n]))
+                        jnp.ones([n]))
 
   @jtu.skip_on_devices("gpu")
   def test_bfloat16_passed_by_tf(self):


### PR DESCRIPTION
This makes all `jax2tf_test.py` pass under the new `jax_default_dtype_bits` flag, added in #8834. This is part of #8178, extracted from the draft in #8180.

Tested locally by running with all four flag combinations:
```
$ JAX_ENABLE_X64=0 JAX_DEFAULT_DTYPE_BITS=32 pytest -n auto jax/experimental/jax2tf/tests/jax2tf_test.py
$ JAX_ENABLE_X64=0 JAX_DEFAULT_DTYPE_BITS=64 pytest -n auto jax/experimental/jax2tf/tests/jax2tf_test.py
$ JAX_ENABLE_X64=1 JAX_DEFAULT_DTYPE_BITS=32 pytest -n auto jax/experimental/jax2tf/tests/jax2tf_test.py
$ JAX_ENABLE_X64=1 JAX_DEFAULT_DTYPE_BITS=64 pytest -n auto jax/experimental/jax2tf/tests/jax2tf_test.py
```