### PR TITLE
[hcb] Add support for remat2 to host_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 
 * Breaking changes:
   * The host_callback primitives have been simplified to drop the
-  special autodiff handling for hcb.id_tap and id_print.
-  From now on, only the primals are tapped. The old behavior can be
-  obtained (for a limited time) by setting the ``JAX_HOST_CALLBACK_AD_TRANSFORMS``
-  environment variable, or the ```--flax_host_callback_ad_transforms``` flag.
-  Additionally, added documentation for how to implement the old behavior
-  using JAX custom AD APIs ({jax-issue}`#7839`).
+    special autodiff handling for hcb.id_tap and id_print.
+    From now on, only the primals are tapped. The old behavior can be
+    obtained (for a limited time) by setting the ``JAX_HOST_CALLBACK_AD_TRANSFORMS``
+    environment variable, or the ```--flax_host_callback_ad_transforms``` flag.
+    Additionally, added documentation for how to implement the old behavior
+    using JAX custom AD APIs ({jax-issue}`#8678`).
+
+* Bug fixes:
+  * host_callback now supports ad_checkpoint.checkpoint ({jax-issue}`#8907`).
 
 * New features:
   * add `jax.block_until_ready` ({jax-issue}`#8941)

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -321,32 +321,6 @@ def apply_outfeed_rewriter(jaxpr: core.Jaxpr) -> core.Jaxpr:
   else:
     return jaxpr
 
-outfeed_primitives: Set[core.Primitive] = set()
-def jaxpr_uses_outfeed(jaxpr: core.Jaxpr) -> bool:
-  """Finds if there are outfeed primitives anywhere inside a Jaxpr."""
-  return any(primitive_uses_outfeed(eqn.primitive, eqn.params)
-             for eqn in jaxpr.eqns)
-
-def _param_uses_outfeed(param):
-  if type(param) is core.Jaxpr:
-    if jaxpr_uses_outfeed(param):
-      return True
-  elif type(param) is core.ClosedJaxpr:
-    if jaxpr_uses_outfeed(param.jaxpr):
-      return True
-  return False
-
-def primitive_uses_outfeed(prim: core.Primitive, params: Dict) -> bool:
-  if prim in outfeed_primitives:
-    return True
-  for param in params.values():
-    if isinstance(param, tuple):
-      if any(unsafe_map(_param_uses_outfeed, param)):
-        return True
-    elif _param_uses_outfeed(param):
-      return True
-  return False
-
 
 def jaxpr_replicas(jaxpr) -> int:
   """The number of replicas needed for a jaxpr.

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1029,7 +1029,7 @@ def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]
     used_outs = map(read, eqn.outvars)
     # If any outputs are used, then we need to keep a version of the eqn and
     # potentially mark some inputs as used. Otherwise mark all inputs as unused.
-    if any(used_outs):
+    if any(used_outs) or core.primitive_uses_outfeed(eqn.primitive, eqn.params):
       # If there's a rule for modifying the eqn and computing used inputs, apply
       # it. Otherwise, keep the eqn unmodified and mark all inputs as used.
       rule = dce_rules.get(eqn.primitive)


### PR DESCRIPTION
A callback under ad_checkpoint.checkpoint will be invoked
twice when taking the gradient: once during the forward pass
and once again during the backward pass when the residuals
for the forward pass are rematerialized.