### PR TITLE
fix a custom_vjp post_process bug, related cleanups

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -928,7 +928,7 @@ class TensorFlowTrace(core.Trace):
     del jvp  # Unused.
     return self.process_call(core.call_p, fun, tracers, {})
 
-  def post_process_custom_jvp_call(self, out_tracers, params):
+  def post_process_custom_jvp_call(self, out_tracers, _):
     assert False  # unreachable assuming jax2tf runs with clean trace state
 
   def process_custom_vjp_call(self, prim, fun, fwd, bwd, tracers, out_trees):
@@ -938,7 +938,10 @@ class TensorFlowTrace(core.Trace):
     del fwd, bwd, out_trees  # Unused.
     return self.process_call(core.call_p, fun, tracers, {})
 
-  def post_process_custom_vjp_call(self, out_tracers, params):
+  def post_process_custom_vjp_call(self, out_tracers, _):
+    assert False  # unreachable assuming jax2tf runs with clean trace state
+
+  def post_process_custom_vjp_call_fwd(self, *_, **__):
     assert False  # unreachable assuming jax2tf runs with clean trace state
 
   def get_primitive_impl(self, p: core.Primitive) -> Tuple[Callable, bool]:

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -850,15 +850,15 @@ class EvaluationPlan(NamedTuple):
 # -------- xmap primitive and its transforms --------
 
 # xmap has a different set of parameters than pmap, so we make it its own primitive type
-class XMapPrimitive(core.MapPrimitive):  # Not really a map, but it gives us a few good defaults
+class XMapPrimitive(core.MapPrimitive):
   def __init__(self):
     super().__init__('xmap')
     self.def_impl(xmap_impl)
     self.def_custom_bind(self.bind)
 
-  def bind(self, fun, *args, **params):
-    assert len(params['in_axes']) == len(args), (params['in_axes'], args)
-    return core.call_bind(self, fun, *args, **params)  # type: ignore
+  def bind(self, fun, *args, in_axes, **params):
+    assert len(in_axes) == len(args), (in_axes, args)
+    return core.map_bind(self, fun, *args, in_axes=in_axes, **params)
 
   def process(self, trace, fun, tracers, params):
     return trace.process_xmap(self, fun, tracers, params)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -359,7 +359,7 @@ class JVPTrace(Trace):
     tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
 
-  def post_process_custom_jvp_call(self, out_tracers, params):
+  def post_process_custom_jvp_call(self, out_tracers, _):
     raise CustomJVPException()
 
   def process_custom_vjp_call(self, _, __, fwd, bwd, tracers, *, out_trees):
@@ -375,7 +375,7 @@ class JVPTrace(Trace):
     tangents_out = map(recast_to_float0, primals_out, tangents_out)
     return map(partial(JVPTracer, self), primals_out, tangents_out)
 
-  def post_process_custom_vjp_call(self, out_tracers, params):
+  def post_process_custom_vjp_call(self, out_tracers, _):
     raise CustomVJPException()
 
   def join(self, xt, yt):


### PR DESCRIPTION
related to #8783 (fixes one bug but another remains)

There are a few themes here, the first two being about cleanup and the latter being most directly related to the fix:
1. Some functions, like `core.process_env_traces` and `core.call_bind`, were reused for many similar but not identical applications: for final-style calls (like `core.call_p` and `xla_call_p`), final-style maps (like `pmap_p` and `xmap_p`), and for final-style custom differentiation rules (like `custom_jvp` and `custom_vjp`). That made sense at first because these various instances looked pretty similar, but over time they diverged, and as a result we were packing too much polymorphic functionality into functions like `call_bind` and `process_env_traces`, often under `if`/`else` switches. By splitting these into separate functions the logic of each becomes much simpler, and more importantly easier to follow in the source (without mentally modeling the different types and indirection which might be involved at runtime). We were also able to remove some of the indirection (like the `process` and `post_process` methods on call primitives), and clarify some function signatures (both on the input and output side). Finally, it made this fix easier because this fix involved introducing different signatures for the post-process stuff related to `custom_jvp` and `custom_vjp`.
2. Remove `_IgnoreElemList`. Unless I'm mistaken, I think it was just another mechanism for accomplishing what our `linear_util.Strore`s already do. Maybe this unification was obscured before because of the polymorphism/indirection mentioned above (i.e. having to support the same utility function signatures for both calls and maps).
3. Generalize `post_process_custom_jvp_call` and `post_process_custom_vjp_call` to depend on whether the primal function or the differentiation rule was run. At a high level, `custom_jvp` and `custom_vjp` are call-like primitives. But instead of being parameterized by a single callable, they're parameterized by two, only one of which is run: the primal function (if no differentiation happens) and the JVP or VJP rule (if differentiation does happen). The bug in #8783 arose because I had mistakenly reused the same `post_process` machinery for both cases, but the behaviors need to be different in the two cases (i.e. whether differentiated or not). The heart of this PR is just plumbing that information: for the JVP side I just added a new boolean argument to `post_process_custom_jvp_call` indicating which side was taken (`jvp_was_called`, which is True if differentiation happened and False otherwise), while for the VJP side the signatures for the two cases were different enough that I changed the API to have two different functions, namely `post_process_custom_vjp_call` and `post_process_custom_vjp_call_fwd` (where the former is called when no differentiation happened, and the latter otherwise).

As ever with final-style primitives, the control flow here can be a little tricky to follow.

There's more cleanup I'd like to do along these lines, especially for map primitives (like simplifying `JaxprTrace.process_call` not to handle both maps and calls). But I'll leave that for future work.