### PR TITLE
log tracing and compilation times

### DIFF
--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -707,7 +707,9 @@ def make_xmap_callable(fun: lu.WrappedFun,
   mapped_in_avals = [_delete_aval_axes(aval, in_axes, global_axis_sizes)
                      for aval, in_axes in zip(in_avals, in_axes)]
   with core.extend_axis_env_nd(global_axis_sizes.items()):
-    jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_in_avals)
+    with dispatch.log_elapsed_time(f"Finished tracing + transforming {fun.__name__} "
+                                   "for xmap in {elapsed_time} sec"):
+      jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, mapped_in_avals)
   out_axes = out_axes_thunk()
   _check_out_avals_vs_out_axes(out_avals, out_axes, global_axis_sizes)
   # NOTE: We don't use avals and all params, so only pass in the relevant parts (too lazy...)

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -25,6 +25,7 @@ from jax.experimental.global_device_array import GlobalDeviceArray as GDA
 from jax import core
 from jax import linear_util as lu
 from jax._src.api import _check_callable, _check_arg, Lowered
+from jax._src import dispatch
 from jax._src import source_info_util
 from jax._src.api_util import (argnums_partial_except, flatten_axes,
                                flatten_fun_nokwargs, _ensure_index_tuple,
@@ -324,7 +325,9 @@ def _pjit_jaxpr(fun, mesh, local_in_avals,
   prev_positional = maps._positional_semantics
   try:
     maps._positional_semantics = maps._PositionalSemantics.GLOBAL
-    jaxpr, global_out_avals, consts = pe.trace_to_jaxpr_dynamic(fun, global_in_avals)
+    with dispatch.log_elapsed_time(f"Finished tracing + transforming {fun.__name__} "
+                                   "for pjit in {elapsed_time} sec"):
+      jaxpr, global_out_avals, consts = pe.trace_to_jaxpr_dynamic(fun, global_in_avals)
   finally:
     maps._positional_semantics = prev_positional
   jaxpr = core.ClosedJaxpr(jaxpr, consts)


### PR DESCRIPTION
```python
import jax
import jax.numpy as jnp

@jax.jit
def f(x):
  for _ in range(10000):
    x = jnp.sin(x)
  return x

f(3.)
```

```
$ JAX_LOG_COMPILES=1 python qiao21.py
WARNING:absl:Finished tracing + transforming f for jit in 2.244359254837036 sec
WARNING:absl:Compiling f (140417529333056) for args (ShapedArray(float32[], weak_type=True),).
WARNING:absl:Finished XLA compilation of f in 1.267568826675415 sec
```