### PR TITLE
jnp.array: remove unused device argument

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3576,7 +3576,7 @@ https://jax.readthedocs.io/en/latest/faq.html).
 
 
 @_wraps(np.array, lax_description=_ARRAY_DOC)
-def array(object, dtype=None, copy=True, order="K", ndmin=0, *, device=None):
+def array(object, dtype=None, copy=True, order="K", ndmin=0):
   if order is not None and order != "K":
     raise NotImplementedError("Only implemented for order='K'")
 


### PR DESCRIPTION
It looks like this argument was inadvertently added as part of #8016; it is undocumented and not referenced within the function.