### PR TITLE
jnp.array: propagate ndmin argument for memoryviews

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3622,7 +3622,7 @@ def array(object, dtype=None, copy=True, order="K", ndmin=0):
     except TypeError:
       pass  # `object` does not support the buffer interface.
     else:
-      return array(_np_asarray(view), dtype, copy)
+      return array(_np_asarray(view), dtype, copy, ndmin=ndmin)
 
     raise TypeError("Unexpected input type for array: {}".format(type(object)))
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3714,10 +3714,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     assert ans == 3.
 
   def testMemoryView(self):
-    ans = jnp.array(bytearray(b'\x2a'))
     self.assertAllClose(
-        ans,
-        np.array([0x2a], dtype=np.uint8))
+        jnp.array(bytearray(b'\x2a')),
+        np.array(bytearray(b'\x2a'))
+    )
+    self.assertAllClose(
+        jnp.array(bytearray(b'\x2a\xf3'), ndmin=2),
+        np.array(bytearray(b'\x2a\xf3'), ndmin=2)
+    )
 
   def testIsClose(self):
     c_isclose = jax.jit(jnp.isclose)


### PR DESCRIPTION
Weird corner case, but it was broken.