### PR TITLE
add limit to number of tracer provenance lines

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1159,11 +1159,13 @@ class DynamicJaxprTracer(core.Tracer):
       msts = ["  operation "
               f"{core.pp_eqn(eqn, core.JaxprPpContext(), print_shapes=True)}\n"
               f"    from line {source_info_util.summarize(eqn.source_info)}"
-              for eqn in progenitor_eqns]
+              for eqn in progenitor_eqns[:5]]  # show at most 5
       origin = (f"While tracing the function {dbg.func_src_info} "
                 f"for {dbg.traced_for}, "
                 "this value became a tracer due to JAX operations on these lines:"
                 "\n\n" + "\n\n".join(msts))
+      if len(progenitor_eqns) > 5:
+        origin += "\n\n(Additional originating lines are not shown.)"
     else:
       origin = (f"The error occured while tracing the function {dbg.func_src_info} "
                 f"for {dbg.traced_for}.")

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2765,6 +2765,16 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
       f()
 
+  def test_concrete_error_because_const_2(self):
+    @jax.jit
+    def f():
+      result = sum(jnp.add(1, 1) for _ in range(6))
+      assert result > 0
+
+    msg = "Additional originating lines are not shown."
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      f()
+
   def test_xla_computation_zeros_doesnt_device_put(self):
     with jtu.count_device_put() as count:
       api.xla_computation(lambda: jnp.zeros(3))()


### PR DESCRIPTION
fixes #8910

Consider:

```python
import jax
import jax.numpy as jnp

N = 10

@jax.jit
def f():
  result = sum(jnp.add(1, 1) for _ in range(N))
  assert result > 0

f()
```

On main, that generates:

```
Traceback (most recent call last):
  File "/home/mattjj/packages/jax/issue8910.py", line 9, in <module>
    f()
  File "/home/mattjj/packages/jax/issue8910.py", line 7, in f
    assert result > 0
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected:          Traced<ShapedArray(bool[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function.
While tracing the function f at /home/mattjj/packages/jax/issue8910.py:4 for jit, this value became a tracer due to   JAX operations on these lines:

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b c
    from line /home/mattjj/packages/jax/issue8910.py:6 (f)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = convert_element_type[new_dtype=int32 weak_type=True] b
    from line /home/mattjj/packages/jax/issue8910.py:7 (f)

See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
```

The number of lines printed scales with `N` without bound, and could be in the hundreds or thousands in practice.

After this PR, we'd instead get

```
Traceback (most recent call last):
  File "/home/mattjj/packages/jax/issue8910.py", line 9, in <module>
    f()
  File "/home/mattjj/packages/jax/issue8910.py", line 7, in f
    assert result > 0
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected:          Traced<ShapedArray(bool[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function.
While tracing the function f at /home/mattjj/packages/jax/issue8910.py:4 for jit, this value became a tracer due to   JAX operations on these lines:

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b c
    from line /home/mattjj/packages/jax/issue8910.py:6 (f)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

  operation a:i32[] = add b b
    from line /home/mattjj/packages/jax/issue8910.py:6 (<genexpr>)

(Additional originating lines are not shown.)

See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
```

Here there is a limit of 5 what-led-to-this-value-becoming-a-tracer info messages included.