### PR TITLE
Prototype of PRNG Key re-use checking - eager checks

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -44,6 +44,7 @@ from jax._src.config import (
   checking_leaks as checking_leaks,
   enable_custom_prng as enable_custom_prng,
   debug_nans as debug_nans,
+  debug_prng_key_reuse as debug_prng_key_reuse,
   debug_infs as debug_infs,
   log_compiles as log_compiles,
   default_matmul_precision as default_matmul_precision,

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -504,6 +504,14 @@ debug_infs = config.define_bool_state(
           'version in an attempt to more precisely identify the operation '
           'which produced the inf.'))
 
+debug_prng_key_reuse = config.define_bool_state(
+    name='jax_debug_prng_key_reuse',
+    default=False,
+    help=('Enables check which throws an error if a PRNG key is re-used.'
+          'This is a very experimental feature: it does not catch every case of'
+          ' key re-use (especially around JAX control-flow) and only works if'
+          ' `jax_enable_custom_prng` is set to True.'))
+
 log_compiles = config.define_bool_state(
     name='jax_log_compiles',
     default=False,

--- a/jax/errors.py
+++ b/jax/errors.py
@@ -17,6 +17,7 @@ from jax._src.errors import (
   JAXTypeError as JAXTypeError,
   JAXIndexError as JAXIndexError,
   ConcretizationTypeError as ConcretizationTypeError,
+  KeyReuseError as KeyReuseError,
   NonConcreteBooleanIndexError as NonConcreteBooleanIndexError,
   TracerArrayConversionError as TracerArrayConversionError,
   TracerIntegerConversionError as TracerIntegerConversionError,

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -2454,7 +2454,7 @@ for dtype in (np.float32, np.float64):
     define(
         "random_gamma",
         f"shape={jtu.format_shape_dtype_string(shape, dtype)}",
-        jax.jit(jax._src.random.gamma_threefry2x32),
+        jax.jit(jax._src.random.gamma),
         [np.array([42, 43], dtype=np.uint32),
          RandArg(shape, dtype)],
         dtype=dtype)

--- a/tests/key_reuse_test.py
+++ b/tests/key_reuse_test.py
@@ -1,0 +1,301 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PRNG key re-use checking, enabled by `--jax_debug_prng_key_reuse`."""
+
+import functools
+import unittest
+
+from absl.testing import absltest, parameterized
+import jax
+from jax._src import test_util as jtu
+from jax import random
+from jax.errors import KeyReuseError
+import jax.numpy as jnp
+import numpy as np
+
+from jax.config import config
+config.parse_flags_with_absl()
+
+RANDOM_FUNCS = (
+    ('bernoulli', random.bernoulli),
+    ('beta', lambda k: random.beta(k, 1, 2)),
+    ('categorical', lambda k: random.categorical(k, jnp.ones((2,)))),
+    ('cauchy', random.cauchy),
+    ('choice', lambda k: random.choice(k, np.ones(()))),
+    ('dirichlet', lambda k: random.dirichlet(k, jnp.ones((1,)))),
+    ('double_sided_maxwell', lambda k: random.double_sided_maxwell(k, 1, 2)),
+    ('exponential', random.exponential),
+    ('gamma', lambda k: random.gamma(k, 1)),
+    ('gumbel', random.gumbel),
+    ('laplace', random.laplace),
+    ('logistic', random.logistic),
+    ('maxwell', random.maxwell),
+    ('multivariate_normal', lambda k: random.multivariate_normal(k, jnp.ones((1,)), jnp.ones((1, 1)))),
+    ('normal', lambda k: random.normal(k, (), jnp.float32)),
+    ('pareto', lambda k: random.pareto(k, 1)),
+    ('permutation', lambda k: random.permutation(k, 1)),
+    ('poisson', lambda k: random.poisson(k, 1, (), jnp.int32)),
+    ('rademarcher', lambda k: random.rademacher(k, (), jnp.float32)),
+    ('randint', lambda k: random.randint(k, (), 0, 10)),
+    ('shuffle', lambda k: random.shuffle(k, jnp.ones(()))),
+    ('split', random.split),
+    ('t', lambda k: random.t(k, 1, (), jnp.float32)),
+    ('truncated_normal', lambda k: random.truncated_normal(k, 0, 10)),
+    ('uniform', random.uniform),
+    ('weibull_min', lambda k: random.weibull_min(k, 1, 1, (), jnp.float32)),
+)
+
+JAX_FUNCS = (
+    ('eval_shape', lambda f: functools.partial(jax.eval_shape, f)),
+    ('grad', lambda f: jax.grad(f, allow_int=True)),
+    ('jit', jax.jit),
+    )
+
+
+class KeyReuseTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self._custom_prng_enabled = config.jax_enable_custom_prng
+    config.update('jax_enable_custom_prng', True)
+    self._debug_prng_keys_enabled = config.jax_debug_prng_key_reuse
+    config.update('jax_debug_prng_key_reuse', True)
+
+  def tearDown(self):
+    super().tearDown()
+    config.update('jax_enable_custom_prng', self._custom_prng_enabled)
+    config.update('jax_debug_prng_key_reuse', self._debug_prng_keys_enabled)
+
+  # ---- cases which error (correctly) ----
+  @parameterized.named_parameters(*RANDOM_FUNCS)
+  @jtu.ignore_warning(message="jax.random.shuffle is deprecated*")
+  def test_double_use_errors(self, rand_function):
+    key = random.PRNGKey(666)
+    rand_function(key)
+    with self.assertRaises(KeyReuseError):
+      rand_function(key)
+
+  @parameterized.named_parameters(*((rname+'_'+jname, rf, jf)
+                                    for rname, rf in RANDOM_FUNCS
+                                    for jname, jf in JAX_FUNCS))
+  @jtu.ignore_warning(message="jax.random.shuffle is deprecated*")
+  def test_double_use_while_tracing_errors(self, rand_function, jax_function):
+    def double_use(key):
+      rand_function(key)
+      rand_function(key)
+      return 0.
+
+    key = random.PRNGKey(666)
+    with self.assertRaises(KeyReuseError):
+      jax_function(double_use)(key)
+
+  def test_scan_double_use_in_one_iteration_errors(self):
+    def body(key, _):
+      random.split(key)
+      random.split(key)
+    key = random.PRNGKey(666)
+    with self.assertRaises(KeyReuseError):
+      jax.lax.scan(body, key, jnp.ones((1,)))
+
+  def test_scan_closed_over_key_double_use_errors(self):
+    key = random.PRNGKey(666)
+    def body(carry, x):
+      random.split(key)
+      random.split(key)
+      return carry, x
+    with self.assertRaises(KeyReuseError):
+      jax.lax.scan(body, None, jnp.ones((1,)))
+
+  def test_vmap_double_use_in_one_batch_errors(self):
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    def f(k):
+      random.split(k)
+      random.split(k)
+
+    with self.assertRaises(KeyReuseError):
+      jax.vmap(f)(keys)
+
+  def test_vmap_broadcast_key_double_use_errors(self):
+    key = random.PRNGKey(666)
+    def f(k, _):
+      random.split(k)
+      random.split(k)
+
+    with self.assertRaises(KeyReuseError):
+      jax.vmap(f, in_axes=(None, 0))(key, jnp.ones((2,)))
+
+  def test_scan_double_use_zero_iteration_errors(self):
+    # This case is rejected, even if this is a 0 iteration loop and the body
+    # technically does not execute,
+    def body(key, _):
+      random.split(key)
+      random.split(key)
+    key = random.PRNGKey(666)
+    with self.assertRaises(KeyReuseError):
+      jax.lax.scan(body, key, None, length=0)
+
+  def test_different_n_splits_errors(self):
+    key = random.PRNGKey(666)
+    random.split(key, num=2)
+    with self.assertRaises(KeyReuseError):
+      random.split(key, num=3)
+
+  def test_rand_bits_and_split_errors(self):
+    key = random.PRNGKey(666)
+    random.randint(key, (), 0, 10)
+    with self.assertRaises(KeyReuseError):
+      random.split(key, num=2)
+
+  # ---- does not error (correctly) ----
+  @parameterized.named_parameters(*RANDOM_FUNCS)
+  @jtu.ignore_warning(message="jax.random.shuffle is deprecated*")
+  def test_single_use_while_tracing(self, rand_function):
+    def single_use(key):
+      rand_function(key)
+      return 0.
+
+    key = random.PRNGKey(666)
+    jax.jit(single_use)(key)
+
+  def test_cond_uses_on_both_branches(self):
+    # This does not error because only one branch is taken.
+    def f(x, key):
+      return jax.lax.cond(x, random.split, random.split, key)
+    key = random.PRNGKey(777)
+    jax.jit(f)(True, key)
+
+  def test_consuming_slice_different_index(self):
+    # If a broadcast is a copy, this should not error.
+    # This can be thought of as a scan/map which maps over a broadcasted key
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    random.split(keys[0])
+    random.split(keys[1])
+
+  def test_consuming_reference(self):
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    random.split(key)
+    random.split(keys[0])
+
+  def test_scan_reuses_inp(self):
+    def body(carry, key):
+      random.split(key)
+      return carry, None
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    jax.lax.scan(body, None, keys)
+
+  def test_vmap_broadcast_key_cross_batch(self):
+    key = random.PRNGKey(666)
+    def f(k, _):
+      random.split(k)  # Splitting same key across 2 batches.
+
+    # TODO(lenamartens): Is in_axes=(None,) an explicit broadcast?
+    # Should this behave similar to scan_reusing_inp?
+    jax.vmap(f, in_axes=(None, 0))(key, jnp.ones((2,)))
+
+  # TODO(lenamartens) fix false positives and false negatives.
+  # ---- false positives ----
+  @unittest.expectedFailure
+  def test_cond_uses_on_both_branches_closed(self):
+    # TODO(lenamartens): Is this a false positive? Yes, if we allow re-use on
+    # two branches of cond. However, maybe we always want to disallow closing
+    # over keys?
+    def f(x, key):
+      return jax.lax.cond(x,
+                          lambda _: random.split(key),  # key is closed over
+                          lambda _: random.split(key),
+                          operand=None)
+    key = random.PRNGKey(777)
+    f(True, key)
+
+  # ---- false negatives ----
+  @unittest.expectedFailure
+  def test_single_use_while_tracing_call_twice_errors(self):
+    def single_use(key):
+      random.split(key)
+      return 0.
+
+    key = random.PRNGKey(666)
+    jax.jit(single_use)(key)
+    with self.assertRaises(KeyReuseError):
+      jax.jit(single_use)(key)
+
+  @unittest.expectedFailure
+  def test_single_use_multiple_keys_errors(self):
+    def single_use(key, unused_key):
+      random.split(key)
+      return unused_key
+
+    key = random.PRNGKey(666)
+    unused_key = random.PRNGKey(777)
+    jax.jit(single_use)(key, unused_key)
+    random.split(unused_key)  # does not error
+    with self.assertRaises(KeyReuseError):
+      random.split(key)
+
+  @unittest.expectedFailure
+  def test_scan_reuses_carry_errors(self):
+    def body(key, x):
+      random.split(key)
+      return key, x
+    key = random.PRNGKey(666)
+    with self.assertRaises(KeyReuseError):
+      jax.lax.scan(body, key, jnp.ones((2,)))
+
+  @unittest.expectedFailure
+  def test_while_loop_reuse_cond_body(self):
+    def cond(x):
+      i, key = x
+      random.split(key)
+      return i < 3
+    def body(x):
+      i, key = x
+      new_key, _ = random.split(key)
+      return i+1, new_key
+
+    key = random.PRNGKey(666)
+    with self.assertRaises(KeyReuseError):
+      jax.lax.while_loop(cond, body, (0, key))
+
+  @unittest.expectedFailure
+  def test_consuming_slice_same_index(self):
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    # TODO(lenamartens): how to track across references? mutable cell/tensor?
+    random.split(keys[0])
+    with self.assertRaises(KeyReuseError):
+      random.split(keys[0])
+
+  @unittest.expectedFailure
+  def test_consuming_while_iterating(self):
+    key = random.PRNGKey(666)
+    keys = jnp.broadcast_to(key, (2,))
+    _ = [random.split(k) for k in keys]
+    with self.assertRaises(KeyReuseError):
+      _ = [random.split(k) for k in keys]
+
+  @unittest.expectedFailure
+  def test_jit_marks_key_as_consumed(self):
+    key = random.PRNGKey(666)
+    jax.jit(random.split)(key)
+    with self.assertRaises(KeyReuseError):
+      random.uniform(key, ())
+
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
### Introduction

This check is to address a common pitfall in JAX where it's easy to re-use a PRNG key and get the same random bits unintentionally (see https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#jax-prng).

This PR adds a way to check if you've re-used a key when executing code eagerly. It tracks the consumption of a PRNG key, and will throw an error when a key is used after is has already been consumed. A key is consumed if it is passed into a `jax.random.split` call, or any `jax.random` call which generates random_bits from the key (eg. `jax.random.normal`). The error will tell you where the key was consumed for the first time.

```
KeyReuseError: Re-used a key, the key was previously used at (...)file.py:function (73)
```

If you want to re-use a key, you can broadcast it to make copies of the key. The idea is that re-use should be avoided, unless you are explicit about copying the key. We could brain-storm about additional copying APIs, but currently a `keys = jnp.broadcast_to(key, (2,))` will work as a copy.  

### Coverage

This is an incomplete implementation of this kind of check, and does not cover all cases of re-use. As a way of documenting coverage, I've included currently failing cases in `tests/key_reuse_test.py` (all tests decorated with `@unittest.expectedFailure`). These tests can be used to encode the desired final behavior of this check (eg. `test_vmap_broadcast_key_cross_batch`, should we expect this case to pass the re-use check?)

With the current implementation, the check will work if you use a key twice while running eagerly, or if you use a key twice while tracing a function.
For example:

```python
# example 1 - eager
key = random.PRNGKey(123)
with jax.config.debug_prng_key_reuse(True):
  x0 = random.normal(key, ())
  x1 = random.normal(key, ())  # key re-use error!

# example 2 - re-use while tracing
@jax.jit
def f(k):
  x0 = random.normal(k, ())
  x1 = random.normal(k, ())  # key re-use error!

key = random.PRNGKey(456)
with jax.config.debug_prng_key_reuse(True):
  f(k)
```
However, re-use checking will **not** work if you need to track re-use across a staged-out boundary (ie. the key is _not_ re-used while tracing). These cases will need to be handled in a follow-up:
```python
@jax.jit
def f(k):
  x0 = random.normal(k, ())
  return x0

key = random.PRNGKey(123)
with jax.config.debug_prng_key_reuse(True):
  f(k)
  f(k)  # no error!
```
### Implementation details

Some details worth highlighting:
- `PRNGKeyArray._split` consumes itself, but `PRNGKeyArray._random_bits` does not. For `random_bits` the `consume` call is lifted to the wrapper functions in `jax.random`. This is because of the technicality that all `jax.random` calls are internally jitted. Because this PR does not yet handle carrying the consumption flag across the `jit` boundary, the consumption needs to happen outside of that boundary.
- The check is behind a flag called `jax_debug_prng_key_reuse`, which I see as analogous to a flag like `jax_debug_nans`. However, it also needs the new PRNGKeyArray type (enabled through `jax_enable_custom_prng`) to work.
-  If we allow for using the same key on both branches of a `cond` (because semantically only one branch is ever taken), then there is a false positive if those two branches _close over_ the key (see `test_cond_uses_on_both_branches_closed`). This seems undesirable, but maybe we should discourage closing over keys in any case,  or maybe we want to always conservatively reject using one key on both branches of the cond. This is still an open question for me.

---- 
Happy to discuss any of the assumptions made above, but also happy to land this preliminary check and refine in follow-up PRs while it's behind a flag. I think the most interesting point of discussion is the cases in `tests/key_reuse_test.py`, and what the expected behavior for them is (eg. wrt to scan/vmap/slicing into a key array).