### PR TITLE
add staging logic for polymorphic shapes in jaxprs

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -105,7 +105,7 @@ def _try_broadcast_shapes(shapes):
   if not rank: return ()  # scalar case
   result_shape = [None] * rank
   for i, sizes in enumerate(zip(*shapes)):
-    non_1s = set([d for d in sizes if not core.symbolic_equal_dim(d, 1)])
+    non_1s = {d for d in sizes if not core.symbolic_equal_dim(d, 1)}
     if len(non_1s) > 1:
       return None  # must have equal sizes other than 1-sized axes
     result_shape[i] = next(iter(non_1s), 1)
@@ -1355,11 +1355,19 @@ def _broadcasting_shape_rule(name, *avals):
   if len({len(shape) for shape in shapes}) != 1:
     msg = '{}: arrays must have same number of dimensions, got {}.'
     raise TypeError(msg.format(name, ', '.join(map(str, map(tuple, shapes)))))
-  result_shape = _try_broadcast_shapes(shapes)
-  if result_shape is None:
-    msg = '{} got incompatible shapes for broadcasting: {}.'
-    raise TypeError(msg.format(name, ', '.join(map(str, map(tuple, shapes)))))
-  return result_shape
+  result_shape = []
+  for ds in zip(*shapes):
+    if all(d is ds[0] for d in ds):
+      # if all axes are identical objects, the resulting size is the object
+      result_shape.append(ds[0])
+    else:
+      # if all dims are equal (or 1), the result is the non-1 size
+      non_1s = {d for d in ds if not core.symbolic_equal_dim(d, 1)}
+      if len(non_1s) > 1:
+        raise TypeError(f'{name} got incompatible shapes for broadcasting: '
+                        f'{", ".join(map(str, map(tuple, shapes)))}.')
+      result_shape.append(non_1s.pop() if non_1s else 1)
+  return tuple(result_shape)
 
 def _naryop_weak_type_rule(name, *avals, **kwargs):
   if any(aval.dtype is dtypes.float0 for aval in avals):
@@ -3401,7 +3409,8 @@ def _reduce_op_shape_rule(operand, *, axes, input_shape=None):
     raise ValueError(f"duplicate value in 'axes' of reduction: {axes}")
   if not all(0 <= a < operand.ndim for a in axes):
     raise ValueError(f"reduction axes {axes} contains out-of-bounds indices for {operand}.")
-  return tuple(np.delete(operand.shape, axes))
+  axes = frozenset(axes)
+  return tuple(d for i, d in enumerate(operand.shape) if i not in axes)
 
 def _reduce_prod_translation_rule(ctx, avals_in, avals_out, operand, *, axes):
   operand_aval, = avals_in

--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -66,6 +66,9 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
     return core.ShapedArray(shape_rule(*avals, **kwargs),
                             dtype_rule(*avals, **kwargs), weak_type=weak_type,
                             named_shape=named_shape_rule(*avals, **kwargs))
+  elif least_specialized is core.DShapedArray:
+    return core.DShapedArray(shape_rule(*avals, **kwargs),
+                             dtype_rule(*avals, **kwargs), weak_type)
   elif least_specialized is core.UnshapedArray:
     return core.UnshapedArray(dtype_rule(*avals, **kwargs), weak_type=weak_type)
   else:

--- a/jax/core.py
+++ b/jax/core.py
@@ -1038,7 +1038,7 @@ def _short_dtype_name(dtype):
 
 class UnshapedArray(AbstractValue):
   __slots__ = ['dtype', 'weak_type']
-  array_abstraction_level = 2
+  array_abstraction_level = 3
 
   def __init__(self, dtype, weak_type=False):
     self.dtype = np.dtype(dtype)
@@ -1101,6 +1101,58 @@ class UnshapedArray(AbstractValue):
            "https://github.com/google/jax/issues because it's unexpected for "
            "UnshapedArray instances to ever be produced.")
     raise TypeError(msg)
+
+
+# We have a convention of reusing AbsractValues as types, in particular reusing
+# ShapedArrays as types, even though we could make a distinction and use
+# abstract values during tracing only. This reuse becomes a bit more extreme
+# with DShapedArrays. A DShapedArray's shape attribute is a tuple which can
+# contain several different types: ints, other AbstractValues (specifically at
+# the input and output to pe.trace_to_jaxpr_dynamic), Tracers (while tracing),
+# or Vars (when used as jaxpr type annotations). We could reduce this
+# polymorphism if it seems cleaner, though it's kind of convenient!
+AxisSizeForTracing = Union[int, Tracer]
+AxisSizeForJaxprType = Union[int, Var]
+AxisSizeForJaxprTracingSpec = Union[int, AbstractValue]
+AxisSize = Union[AxisSizeForTracing, AxisSizeForJaxprType,
+                 AxisSizeForJaxprTracingSpec]
+
+class DShapedArray(UnshapedArray):
+  __slots__ = ['shape']
+  shape: Tuple[AxisSize, ...]  # see comment above
+  array_abstraction_level = 2
+
+  def __init__(self, shape, dtype, weak_type):
+    self.shape = shape
+    self.dtype = dtype
+    self.weak_type = weak_type
+
+  ndim = property(lambda self: len(self.shape))
+  size = property(lambda self: prod(self.shape))
+
+  def str_short(self, short_dtypes=False) -> str:
+    del short_dtypes  # ignored
+    shape = f'{",".join(str(d) for d in self.shape)}' if self.shape else ''
+    dtype = _short_dtype_name(self.dtype)
+    return f'{dtype}[{shape}]'
+  __str__ = __repr__ = str_short
+
+  def __eq__(self, other):
+    return (type(self) is type(other) and
+            self.dtype == other.dtype and self.shape == other.shape and
+            self.weak_type == other.weak_type)
+
+  def update(self, shape=None, dtype=None, weak_type=None):
+    if shape is None:
+      shape = self.shape
+    if dtype is None:
+      dtype = self.dtype
+    if weak_type is None:
+      weak_type = self.weak_type
+    return DShapedArray(shape, dtype, weak_type)
+
+del AxisSize, AxisSizeForTracing, AxisSizeForJaxprType, \
+    AxisSizeForJaxprTracingSpec
 
 class ShapedArray(UnshapedArray):
   __slots__ = ['shape', 'named_shape']
@@ -2109,9 +2161,17 @@ class JaxprPpContext:
     self.var_ids = collections.defaultdict(it.count().__next__)
 
 
-def pp_var(v: Var, context: JaxprPpContext):
+def pp_var(v: Var, context: JaxprPpContext) -> str:
   if isinstance(v, (Literal, DropVar)): return str(v)
   return f"{_encode_digits_alphabetic(context.var_ids[v])}{v.suffix}"
+
+def pp_aval(a: AbstractValue, context: JaxprPpContext) -> str:
+  if isinstance(a, DShapedArray):
+    shape = [pp_var(d, context) if type(d) is Var else str(d) for d in a.shape]
+    dtype = _short_dtype_name(a.dtype)
+    return f'{dtype}[{",".join(shape)}]'
+  else:
+    return a.str_short(short_dtypes=True)
 
 def pp_vars(vs: Sequence[Any], context: JaxprPpContext,
             *, separator="", print_shapes: bool = False) -> pp.Doc:
@@ -2119,7 +2179,7 @@ def pp_vars(vs: Sequence[Any], context: JaxprPpContext,
     return pp.nest(2, pp.group(
       pp.join(pp.text(separator) + pp.group(pp.brk()), [
         pp.text(pp_var(v, context)) +
-        pp.dim(pp.text(":" + v.aval.str_short(short_dtypes=True)))
+        pp.dim(pp.text(":" + pp_aval(v.aval, context)))
         for v in vs
       ])
     ))


### PR DESCRIPTION
This is the first in a sequence of PRs adding some dynamic shape capabilities to the core system. This first PR is just about being able to represent shape-polymorphic functions in jaxprs and to stage them out from Python functions. They can't yet be built from any public-facing APIs, and they can't yet be lowered to any compiler either.

By shape-polymorphic we basically mean
1. array types in jaxprs can have variables, rather than just integer literals, in their axis sizes, but
2. those variables can only be bound at the top level of a jaxpr, and e.g. can't be let-bound in the middle of a jaxpr.

By _dynamic shapes_ we mean removing the constraint (2) above, so that axis sizes can be let-bound in the middle of a jaxpr, e.g. for `jnp.where(x)` and boolean indexing.

The fundamental design here is aimed at ultimately supporting _dynamic_ shapes, as well as things like ragged shapes, which are required for closure under `vmap` and `grad` given dynamic shapes. That's why, for example, we don't syntactically distinguish the axis size binders at the top of a jaxpr, even though this PR only supports binding them there.

Some pieces to follow:
- [ ] add a mechanism for `make_jaxpr` and `jit` to stage out computations involving axis size variables (e.g. add a convention so that when we abstract from values to avals we abstract over some axis sizes)
- [ ] add an XLA lowering path, together with a bounded int type
- [ ] add jaxpr typechecking for these new jaxprs
- [ ] make more primitives work with axis size variables
- [ ] make the `jax.numpy` layer work with axis size variables (currently only a few parts of the `lax` layer work)

We've got prototypes of the first three, in djax.py and in some more recent drafts.

Most of the thinking is copied from djax.py and other dynamic-shape prototypes that @dougalm and I pair programmed (though I'll take the blame for any conceptual bugs introduced here!).

---

Here are some examples.

### Example 1

```python
n = core.DShapedArray((), jnp.dtype('int32'), weak_type=False)
a = core.DShapedArray((n,), jnp.dtype('float32'), weak_type=False)
b = core.DShapedArray((n,), jnp.dtype('float32'), weak_type=False)

@lu.wrap_init
def f(x, y):
  return x, y

jaxpr, _, _ = pe.trace_to_jaxpr_dynamic(f, [n, a, b], keep_inputs=[False, True, True])
print(jaxpr)
```

```
{ lambda ; a:i32[] b:f32[a] c:f32[a]. let  in (b, c) }
```

Notice the new `keep_inputs` argument to `trace_to_jaxpr_dynamic`. The abstract values passed to `trace_to_jaxpr_dynamic` are in direct correspondence to the input binders (`invars`) of the jaxpr it returns. But in general the `Tracer`s passed to the function `f` correspond only to a subset of those abstract values. That's because axis size variables may not be explicit arguments to `f`, while we make everything explicit in the jaxpr.

Notice also that there are no axis size bounds here.

### Example 2

```python
@lu.wrap_init
def f(x, y):
  @jax.jit
  def g(x, y, z, w):
    return (x, y)
  return g(x, y, x, y)

jaxpr, _, _ = pe.trace_to_jaxpr_dynamic(f, [n, a, b], keep_inputs=[False, True, True])
print(jaxpr)
```

```
{ lambda ; a:i32[] b:f32[a] c:f32[a]. let
    d:f32[a] e:f32[a] = xla_call[
      call_jaxpr={ lambda ; f:i32[] g:f32[f] h:f32[f] i:f32[f] j:f32[f]. let

        in (g, h) }
      name=g
    ] a b c b c
  in (d, e) }
```

### Example 3

```python
@lu.wrap_init
def f(x, y):
  z = lax.mul(x, y)
  w = lax.sin(z)
  u = lax._reduce_sum(w, [0])
  return (u,)

jaxpr, _, _ = pe.trace_to_jaxpr_dynamic(f, [n, a, b], keep_inputs=[False, True, True])
print(jaxpr)
```

```
{ lambda ; a:i32[] b:f32[a] c:f32[a]. let
    d:f32[a] = mul b c
    e:f32[a] = sin d
    f:f32[] = reduce_sum[axes=(0,)] e
  in (f,) }
```

---

Here are some things to notice:
* We [added a new `DShapedArray`](https://github.com/google/jax/pull/8955/files#diff-6bc6fb90ca348a8206e5beaccb59ed850154ace9a3683019641e5e690008281bR1105) abstract value to represent avals/types of arrays which might have variables in their shapes. At the moment it's basically redundant with `ShapedArray`. The main reasons to distinguish it are (1) to keep anything to do with polymorphic/dynamic shapes clearly separate from existing stuff so we are sure not to disturb existing stuff as we rapidly iterate, and (2) as we add things like raggedness (for closure under `grad`/`vmap`) we will generalize this abstract value to look different from ShapedArrays.
* We have a convention of reusing `AbsractValue`s as types, in particular reusing `ShapedArray`s as types, even though we could make a distinction and use abstract values during tracing only. This reuse becomes a bit more extreme with `DShapedArray`s. A `DShapedArray`'s `shape` attribute is a tuple which can contain several different types: ints, other `AbstractValue`s (specifically at the input and output to `pe.trace_to_jaxpr_dynamic`), `Tracer`s (while tracing), or `Var`s (when used as types). We could reduce this polymorphism if it seems cleaner, though it's kind of convenient!
* Related to the above bullet, there are a places where we need to: [substitute `Tracer`s for `AbstractValue`s in `DShapedArray` shapes when we kick off a trace](https://github.com/google/jax/pull/8955/files#diff-440d9df723b313bb263bc7704103cad1dcc886ff6553aa78c30188b0b323b686R1604), [substitute `AbstractValue`s for `Tracer`s when we process nested `jit`s](https://github.com/google/jax/pull/8955/files#diff-440d9df723b313bb263bc7704103cad1dcc886ff6553aa78c30188b0b323b686R1629), or substitute `AbstractValue`s for `Tracer`s when we are about to return from `trace_to_jaxpr`. 
*  To make some basic binary primitives work, we [adapted `_broadcasting_shape_rule`](https://github.com/google/jax/pull/8955/files#diff-a81a5cc54c9a9c2797bcca38f5f1c13d5c9883763ee1e14ae5f0e215aa115bcfR1359) to first check identity as sufficient for equality.
* We [updated jaxpr pretty-printing](https://github.com/google/jax/pull/8955/files#diff-6bc6fb90ca348a8206e5beaccb59ed850154ace9a3683019641e5e690008281bR2137) just to handle variables in avals/types by threading the `JaxprPpContext` instance to the right place.

That's pretty much it for this PR!