### PR TITLE
Add item() method to abstract arrays

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -7052,6 +7052,7 @@ def _set_shaped_array_attributes(shaped_array):
   setattr(shaped_array, "split", core.aval_method(split))
   setattr(shaped_array, "compress", _compress_method)
   setattr(shaped_array, "at", core.aval_property(_IndexUpdateHelper))
+  setattr(shaped_array, "item", core.aval_method(device_array.DeviceArray.item))
 
 _set_shaped_array_attributes(ShapedArray)
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -825,6 +825,23 @@ class PythonJitTest(CPPJitTest):
 
 class APITest(jtu.JaxTestCase):
 
+  def test_grad_item(self):
+    def f(x):
+      if x.astype(bool).item():
+        return x ** 2
+      else:
+        return x
+    out = jax.grad(f)(2.0)
+    self.assertEqual(out, 4)
+
+  def test_jit_item(self):
+    def f(x):
+      return x.item()
+    x = jnp.array(1.0)
+    self.assertEqual(f(x), x)
+    with self.assertRaisesRegex(core.ConcretizationTypeError, "Abstract tracer value"):
+      jax.jit(f)(x)
+
   def test_grad_bad_input(self):
     def f(x):
       return x


### PR DESCRIPTION
Fixes #8962, in the sense that it makes the error more explicit rather than appearing to be a missing feature.

Also, this means that `x.item()` essentially delegates to `bool(x)` or `int(x)` for boolean or integer arrays, which means it can be used within autodiff transforms (but not within JIT) due to the existing implementations of those for Concrete arrays.