### PR TITLE
[WIP] jnp.array: always return strong type

### DIFF
--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -200,7 +200,7 @@ that can be seen in an array's string representation:
 
 .. code-block:: python
 
-   >>> jnp.asarray(2)
+   >>> jax.device_put(2)
    DeviceArray(2, dtype=int32, weak_type=True)
 
 If the ``dtype`` is specified explicitly, it will instead result in a standard
@@ -208,5 +208,5 @@ strongly-typed array value:
 
 .. code-block:: python
 
-   >>> jnp.asarray(2, dtype='int32')
+   >>> jnp.array(2, dtype='int32')
    DeviceArray(2, dtype=int32)

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -61,8 +61,8 @@ def _scatter_update(x, idx, y, scatter_op, indices_are_sorted,
     An ndarray representing an updated `x` after performing the scatter-update.
   """
 
-  x = jnp.asarray(x)
-  y = jnp.asarray(y)
+  x = jnp._asarray(x)
+  y = jnp._asarray(y)
   # XLA gathers and scatters are very similar in structure; the scatter logic
   # is more or less a transpose of the gather equivalent.
   treedef, static_idx, dynamic_idx = jnp._split_index_for_jit(idx, x.shape)
@@ -418,7 +418,7 @@ def _segment_update(name: str,
                     mode: Optional[lax.GatherScatterMode] = None) -> Array:
   jnp._check_arraylike(name, data, segment_ids)
   mode = lax.GatherScatterMode.FILL_OR_DROP if mode is None else mode
-  data = jnp.asarray(data)
+  data = jnp._asarray(data)
   segment_ids = jnp.asarray(segment_ids)
   dtype = data.dtype
   if num_segments is None:

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -680,7 +680,6 @@ def gmres(A, b, x0=None, *, tol=1e-5, atol=0.0, restart=20, maxiter=None,
   else:
     raise ValueError(f"invalid solve_method {solve_method}, must be either "
                      "'incremental' or 'batched'")
-
   def _solve(A, b):
     return _gmres_solve(A, b, x0, atol, ptol, restart, maxiter, M, gmres_func)
   x = lax.custom_linear_solve(A, b, solve=_solve, transpose_solve=_solve)

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -28,8 +28,7 @@ from jax.experimental.sparse.coo import _coo_matmat_impl, _coo_matvec_impl, _coo
 from jax.experimental.sparse.util import _csr_to_coo, _csr_extract, _safe_asarray, CuSparseEfficiencyWarning
 from jax import tree_util
 from jax._src.lib import cusparse
-from jax._src.numpy.lax_numpy import _promote_dtypes
-import jax.numpy as jnp
+import jax._src.numpy.lax_numpy as jnp
 
 
 @tree_util.register_pytree_node_class
@@ -73,8 +72,8 @@ class CSR(JAXSparse):
   def __matmul__(self, other):
     if isinstance(other, JAXSparse):
       raise NotImplementedError("matmul between two sparse objects.")
-    other = jnp.asarray(other)
-    data, other = _promote_dtypes(self.data, other)
+    other = jnp._asarray(other)
+    data, other = jnp._promote_dtypes(self.data, other)
     if other.ndim == 1:
       return csr_matvec(data, self.indices, self.indptr, other, shape=self.shape)
     elif other.ndim == 2:
@@ -127,8 +126,8 @@ class CSC(JAXSparse):
   def __matmul__(self, other):
     if isinstance(other, JAXSparse):
       raise NotImplementedError("matmul between two sparse objects.")
-    other = jnp.asarray(other)
-    data, other = _promote_dtypes(self.data, other)
+    other = jnp._asarray(other)
+    data, other = jnp._promote_dtypes(self.data, other)
     if other.ndim == 1:
       return csr_matvec(data, self.indices, self.indptr, other, shape=self.shape[::-1], transpose=True)
     elif other.ndim == 2:
@@ -224,13 +223,13 @@ def csr_fromdense(mat, *, nse, index_dtype=np.int32):
     indices : array of shape ``(nse,)`` and dtype ``index_dtype``
     indptr : array of shape ``(mat.shape[0] + 1,)`` and dtype ``index_dtype``
   """
-  mat = jnp.asarray(mat)
+  mat = jnp._asarray(mat)
   nse = core.concrete_or_error(operator.index, nse, "nse argument of csr_fromdense()")
   return csr_fromdense_p.bind(mat, nse=nse, index_dtype=np.dtype(index_dtype))
 
 @csr_fromdense_p.def_impl
 def _csr_fromdense_impl(mat, *, nse, index_dtype):
-  mat = jnp.asarray(mat)
+  mat = jnp._asarray(mat)
   assert mat.ndim == 2
   m = mat.shape[0]
 
@@ -367,7 +366,7 @@ def _csr_matvec_transpose(ct, data, indices, indptr, v, *, shape, transpose):
   if ad.is_undefined_primal(v):
     return data, indices, indptr, csr_matvec(data, indices, indptr, ct, shape=shape, transpose=not transpose)
   else:
-    v = jnp.asarray(v)
+    v = jnp._asarray(v)
     # The following lines do this, but more efficiently.
     # return _csr_extract(indices, indptr, jnp.outer(ct, v)), indices, indptr, v
     row, col = _csr_to_coo(indices, indptr)
@@ -449,7 +448,7 @@ def _csr_matmat_transpose(ct, data, indices, indptr, B, *, shape, transpose):
   if ad.is_undefined_primal(B):
     return data, indices, indptr, csr_matmat(data, indices, indptr, ct, shape=shape, transpose=not transpose)
   else:
-    B = jnp.asarray(B)
+    B = jnp._asarray(B)
     row, col = _csr_to_coo(indices, indptr)
     return (ct[row] * B[col]).sum(1), indices, indptr, B
 

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -56,7 +56,7 @@ from jax import core
 from jax import lax
 from jax import linear_util as lu
 from jax.experimental.sparse.bcoo import bcoo_multiply_dense, bcoo_multiply_sparse, BCOOInfo
-import jax.numpy as jnp
+import jax._src.numpy.lax_numpy as jnp
 from jax._src.api_util import flatten_fun_nokwargs
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
@@ -82,7 +82,7 @@ class SparseEnv:
     self._buffers = list(bufs)
 
   def push(self, arr: Array) -> int:
-    self._buffers.append(jnp.asarray(arr))  # type: ignore
+    self._buffers.append(jnp._asarray(arr))  # type: ignore
     return len(self._buffers) - 1
 
   def get(self, ind: int) -> Array:

--- a/jax/experimental/sparse/util.py
+++ b/jax/experimental/sparse/util.py
@@ -18,7 +18,7 @@ import numpy as np
 import jax
 from jax import core
 from jax._src import dtypes
-import jax.numpy as jnp
+import jax._src.numpy.lax_numpy as jnp
 
 
 class CuSparseEfficiencyWarning(UserWarning):
@@ -52,7 +52,7 @@ def _is_aval(*args):
 def _asarray_or_float0(arg):
   if isinstance(arg, np.ndarray) and arg.dtype == dtypes.float0:
     return arg
-  return jnp.asarray(arg)
+  return jnp._asarray(arg)
 
 def _safe_asarray(args):
   if _is_pytree_placeholder(*args) or _is_aval(*args):

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -106,10 +106,10 @@ class DtypesTest(jtu.JaxTestCase):
   def testBinaryPromotion(self, swap, jit):
     testcases = [
       (jnp.array(1.), 0., jnp.float64),
-      (jnp.array(1.), jnp.array(0.), jnp.float64),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float16), jnp.float16),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float32), jnp.float32),
-      (jnp.array(1.), jnp.array(0., dtype=jnp.float64), jnp.float64),
+      (1., jnp.array(0.), jnp.float64),
+      (1., jnp.array(0., dtype=jnp.float16), jnp.float16),
+      (1., jnp.array(0., dtype=jnp.float32), jnp.float32),
+      (1., jnp.array(0., dtype=jnp.float64), jnp.float64),
       (jnp.array(1., dtype=jnp.float16), 0., jnp.float16),
       (jnp.array(1., dtype=jnp.float32), 0., jnp.float32),
       (jnp.array(1., dtype=jnp.float64), 0., jnp.float64),


### PR DESCRIPTION
An experiment in simplifying the API of `jnp.array` to always return strong types.

Before:
```python
>>> import jax.numpy as jnp
>>>  jnp.array(1.0)
DeviceArray(1., dtype=float32, weak_type=True)
```
After:
```python
>>> import jax.numpy as jnp
>>> jnp.array(1.0)
DeviceArray(1., dtype=float32)
```
A part of this that is a bit awkward is that we can no longer call `jnp.asarray()` on inputs to many functions within the JAX API, because it now strips weak types. For that reason, I exposed private `_array` and `_asarray` methods that pass weak types through.