### PR TITLE
checkify: small updates

### DIFF
--- a/jax/experimental/checkify.py
+++ b/jax/experimental/checkify.py
@@ -222,8 +222,15 @@ def check_errors_traceable(msgs, err, code, *args):
 ## assert primitive
 
 def assert_(pred: Bool, msg: str) -> None:
+  if not is_scalar_pred(pred):
+    raise TypeError(f"assert_ takes a scalar pred as argument, got {pred}")
   code = next_code()
   return assert2_(pred, code, {code: msg})
+
+def is_scalar_pred(pred) -> bool:
+  return (isinstance(pred, bool) or
+          isinstance(pred, jnp.ndarray) and pred.shape == () and
+          pred.dtype == jnp.dtype('bool'))
 
 def assert2_(pred: Bool, code: Int, msgs: Dict[int, str]) -> None:
   return assert_p.bind(pred, code, msgs=msgs)


### PR DESCRIPTION
Co-authored-by: Lena Martens <lenamartens@google.com>

The real MVP was the ~friends we made along the way~ notes we took in a meeting, exploring the interactions between assert, checkify, and autodiff:

```python
import jax
import jax.numpy as jnp
from jax.experimental.checkify import assert_, checkify
jax.config.update('jax_platform_name', 'cpu')

### investigate assert interaction with AD

# question 1: jvp of assert?

def f(x):
  assert_(x > 0, "must be positive!")
  return jnp.log(x)

# try: y = f(0.)
# except AssertionError as e: print(e)

# try: jax.jvp(f, (0.,), (1.,))
# except AssertionError as e: print(e)

jax.jvp(f, (1.,), (0.,))

# answer 1: assert only touches primals
#
# don't actually have to write this rule because booleans drop out of jvp
#
# def assert_jvp_rule(primals, tangents):
#   x, = primals
#   xdot, = tangents
#   assert_(x, ...)
#   return x, xdot

# question 2: what if we did want to assert on the tangents?

@jax.custom_jvp
def assert_tangent_not_zero(x):
  return x

@assert_tangent_not_zero.defjvp
def jvp(primals, tangents):
  (x,), (xdot,) = primals, tangents
  y = assert_tangent_not_zero(x)
  assert_(xdot != 0, "tangent of zero")
  return y, xdot

assert_tangent_not_zero(0.)

jax.jvp(assert_tangent_not_zero, (1.,), (1.,))

# try: jax.jvp(assert_tangent_not_zero, (1.,), (0.,))
# except AssertionError as e: print(e)

# answer 2: just frickin works

# question 2': what about cotangents? first, with custom_jvp

# try: jax.grad(assert_tangent_not_zero)(1.)
# except Exception as e: print(e)

# answer 2': cant' be staged, maybe that's good... can't have assertions in
# linear code to be transposed
# but this means we cant assert anything on tangents and then use reverse
# mode...
# bad error
# TODO but maybe also we'd ideally want some other behavior

# question 2'': what about custom_vjp

@jax.custom_vjp
def assert_cotangent_not_zero(x):
  return x

def fwd(x):
  return x, None

def bwd(_, ybar):
  assert_(ybar != 0, "cotangent of zero")
  return (ybar,)

assert_cotangent_not_zero.defvjp(fwd, bwd)

jax.grad(assert_cotangent_not_zero)(1.)  # doesn't crash...

# _, vjp = jax.vjp(assert_cotangent_not_zero, 1.)
# try: vjp(0.)
# except AssertionError as e: print(e)

# answer 2'': just works, so sick
# the special jaxpr dialect only consumed by ad.backward_pass can have arbitrary
# python callbacks in it. this is just another arbitrary python thing, so no
# restrictions.


# main findings:
#  1. stuff pretty much works decently
#  2. one potential limitation is we can't make assertions that are kept in
#     transposable jaxprs
#     * to do this may require an assert effect in jaxprs (not a functional
#       one), or we need transpose machinery to handle functional assert value
#       outputs specially, transpose : (a -> Err b) -> (b -> Err a)



### what about checkify, adding checks?
# guess: checkify-of-grad will be good, but grad-of-checkify maybe not

# q3: does checkify-of-grad work? what's provenance look like?

def f(x):
  def g(x):
    w = jnp.cos(x)
    return w + 1.
  _, vjp = jax.vjp(g, x)
  xbar, = vjp(jnp.inf)
  return xbar

# err, xbar = checkify(f)(0.)
# print(xbar)
# print(err.get())

# answer 3: basically works, provenance is not terrible but could be improved

from functools import partial
from jax import lax

def app(f, x):
  def scanned_fun(x, _):
    return f(x), _
  y, _ = lax.scan(scanned_fun, x, None, length=1)
  return y

def f(x):
  def g(x):
    w = jnp.cos(x)
    return w + 1.
  g_ = partial(app, g)
  _, vjp = jax.vjp(g_, x)
  xbar, = vjp(jnp.inf)
  return xbar

err, xbar = checkify(f)(0.)
print(xbar)
print(err.get())

# amazing it works with scan
```