### PR TITLE
[sparse] add sparse.map_specified_elements primitive

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -249,6 +249,8 @@ from jax.experimental.sparse.api import (
     eye as eye,
     todense as todense,
     todense_p as todense_p,
+    map_specified_elements as map_specified_elements,
+    map_specified_elements_p as map_specified_elements_p,
 )
 
 from jax.experimental.sparse.util import (

--- a/jax/experimental/sparse/api.py
+++ b/jax/experimental/sparse/api.py
@@ -31,13 +31,14 @@ Further down are some examples of potential high-level wrappers for sparse objec
 """
 from functools import partial
 import operator
-from typing import Optional, Union
+from typing import Callable, Optional, Union
+import numpy as np
 
 import jax
 from jax import core
 from jax import tree_util
 from jax.experimental.sparse._base import JAXSparse
-from jax.experimental.sparse.bcoo import BCOO
+from jax.experimental.sparse.bcoo import BCOO, _bcoo_extract
 from jax.experimental.sparse.bcsr import BCSR
 from jax.experimental.sparse.coo import COO
 from jax.experimental.sparse.csr import CSR, CSC
@@ -46,7 +47,9 @@ from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
 from jax._src import dtypes
-from jax._src.typing import Array, DTypeLike, Shape
+from jax._src.typing import Array, ArrayLike, DTypeLike, Shape
+from jax._src import util
+from jax._src.lax.control_flow import _initial_style_jaxpr
 
 
 #----------------------------------------------------------------------
@@ -85,8 +88,6 @@ def _todense_transpose(ct, *bufs, tree):
 
   standin = object()
   obj = tree_util.tree_unflatten(tree, [standin] * len(bufs))
-  from jax.experimental.sparse import BCOO
-  from jax.experimental.sparse.bcoo import _bcoo_extract
   if obj is standin:
     return (ct,)
   elif isinstance(obj, BCOO):
@@ -107,6 +108,95 @@ batching.primitive_batchers[todense_p] = _todense_batching_rule
 mlir.register_lowering(todense_p, mlir.lower_fun(
     _todense_impl, multiple_results=False))
 
+#----------------------------------------------------------------------
+# map_specified_elements – function to map a scalar function to specified elements
+map_specified_elements_p = core.Primitive('map_specified_elements')
+map_specified_elements_p.multiple_results = True
+
+def map_specified_elements(fun: Callable[[ArrayLike], ArrayLike], arg: Union[ArrayLike, JAXSparse]) -> Union[ArrayLike, JAXSparse]:
+  """Map a given function across the specified elements of an array
+
+  If the input is a dense array, ``fun`` will be applied to every array element.
+  If the input is a sparse array, ``fun`` will be applied only to the data buffer.
+
+  Args:
+    fun : a function that accepts a single scalar value and returns a
+      single scalar value.
+    arg : a dense or sparse array.
+
+  Returns:
+    out : a dense or sparse array; same format as the input.
+  """
+  args = (arg,)
+  bufs, tree = tree_util.tree_flatten(args)
+  # TODO(jakevdp): check that arg is a sparse array or dense array, rather than
+  # a more general PyTree.
+  jaxpr, consts = _create_jaxpr(fun, bufs[0])
+  bufs_out = map_specified_elements_p.bind(*consts, *bufs, jaxpr=jaxpr)
+  return tree_util.tree_unflatten(tree, bufs_out)[0]
+
+def _create_jaxpr(fun, flat_val):
+  aval = core.raise_to_shaped(core.get_aval(flat_val))
+  aval_scalar = core.ShapedArray((), aval.dtype, aval.weak_type)
+  _, trivial_tree = tree_util.tree_flatten([1])
+  jaxpr, consts, out_tree = _initial_style_jaxpr(
+    fun, trivial_tree, (aval_scalar,), "map_specified_elements_fun")
+  # TODO(jakevdp) convert asserts into comprehensible user errors
+  assert out_tree == tree_util.tree_flatten(1)[1]
+  assert len(jaxpr.out_avals) == 1
+  assert jaxpr.out_avals[0].shape == ()
+  return jaxpr, consts
+
+@map_specified_elements_p.def_impl
+def _map_specified_elements_impl(*args, jaxpr):
+  # Note: tree here is a way to pass along sparse matrix metadata; it's not a general tree.
+  # TODO(jakevdp): use metadata to check for duplicate entries & handle appropriately
+  num_consts = len(jaxpr.jaxpr.constvars)
+  num_args = len(jaxpr.jaxpr.invars)
+  consts, args, bufs = util.split_list(args, [num_consts, num_args])
+  fun = core.jaxpr_as_fun(jaxpr, *consts)
+
+  if not all(arg.shape == args[0].shape for arg in args[1:]):
+    raise ValueError(f"arg shapes must match; got {args}")
+
+  for _ in range(args[0].ndim):
+    fun = jax.vmap(fun)
+  return (*fun(*args), *bufs)
+
+@map_specified_elements_p.def_abstract_eval
+def _map_specified_elements_abstract_eval(*args, jaxpr):
+  num_consts = len(jaxpr.jaxpr.constvars)
+  num_args = len(jaxpr.jaxpr.invars)
+  assert len(jaxpr.in_avals) == len(jaxpr.out_avals)
+  _, args, bufs = util.split_list(args, [num_consts, num_args])
+  out_avals = (core.ShapedArray(np.shape(arg), out.dtype, out.weak_type)
+               for (arg, out) in zip(args, jaxpr.out_avals))
+  return (*out_avals, *bufs)
+
+def _map_specified_elements_batching_rule(batched_args, batch_dims, *, jaxpr):
+  bdims_out = batch_dims[len(jaxpr.jaxpr.constvars):]
+  mapped = jax.vmap(partial(_map_specified_elements_impl, jaxpr=jaxpr),
+                    in_axes=batch_dims, out_axes=bdims_out)
+  return mapped(*batched_args), bdims_out
+
+def _map_specified_elements_jvp(primals, tangents, jaxpr):
+  num_consts = len(jaxpr.jaxpr.constvars)
+  num_args = len(jaxpr.jaxpr.invars)
+  const_p, arg_p, buf_p = util.split_list(primals, [num_consts, num_args])
+  const_t, arg_t, buf_t = util.split_list(tangents, [num_consts, num_args])
+  assert all(isinstance(t, ad.Zero) for t in const_t)
+  arg_nz = [not isinstance(t, ad.Zero) for t in arg_t]
+  assert all(isinstance(t, ad.Zero) for t in buf_t)
+
+  jaxpr_jvp, _ = ad.jvp_jaxpr(jaxpr, arg_nz, instantiate=False)
+  outs = map_specified_elements_p.bind(*const_p, *const_t, *arg_p, *arg_t, jaxpr=jaxpr_jvp)
+  primals_out, tangents_out = util.split_list(outs, [len(arg_p)])
+  return (*primals_out, *buf_p), (*tangents_out, *buf_t)
+
+ad.primitive_jvps[map_specified_elements_p] = _map_specified_elements_jvp
+batching.primitive_batchers[map_specified_elements_p] = _map_specified_elements_batching_rule
+mlir.register_lowering(map_specified_elements_p, mlir.lower_fun(
+    _map_specified_elements_impl, multiple_results=True))
 
 def empty(shape: Shape, dtype: Optional[DTypeLike]=None, index_dtype: DTypeLike = 'int32',
           sparse_format: str = 'bcoo', **kwds) -> JAXSparse:

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -790,6 +790,18 @@ def _todense_sparse_rule(spenv, spvalue, *, tree):
 
 sparse_rules[sparse.todense_p] = _todense_sparse_rule
 
+def _map_specified_elements_sparse_rule(spenv, *spvalues, jaxpr):
+  # TODO(jakevdp) ensure indices are shared.
+  num_consts = len(jaxpr.jaxpr.constvars)
+  num_args = len(jaxpr.jaxpr.invars)
+  consts, spvalues, bufs = split_list(spvalues, [num_consts, num_args])
+  assert not bufs
+  args = spvalues_to_arrays(spenv, spvalues)
+  bufs, tree = tree_flatten(args)
+  outs = sparse.map_specified_elements_p.bind(*consts, *bufs, jaxpr=jaxpr)
+  return arrays_to_spvalues(spenv, tree_unflatten(tree, outs))
+
+sparse_rules[sparse.map_specified_elements_p] = _map_specified_elements_sparse_rule
 
 #------------------------------------------------------------------------------
 # BCOO methods derived from sparsify


### PR DESCRIPTION
This PR addresses #8967 (more context in https://github.com/google/jax/issues/8967#issuecomment-996152905).  The idea here is to provide an API whereby a user can apply a unary function elementwise to the defined entries of a sparse matrix. like the `sparse.todense_p` primitive, it must also accept dense inputs so that it can be used within a function that is transformed by sparsify.

For example:
```python
>>> from jax.experimental import sparse
>>> import jax.numpy as jnp

>>> x = sparse.BCOO.fromdense(jnp.arange(4.0))
>>> print(x.todense())
[0. 1. 2. 3.]

>>> print(sparse.sparsify(jnp.cos)(x))
---------------------------------------------------------------------------
NotImplementedError: sparse rule for cos is not implemented because it would result in dense output.
If this is your intent, use sparse.todense() to convert your arguments to dense matrices.

>>> out = sparse.map_specified_elements(jnp.cos, x)
>>> print(out.todense())
[ 0.          0.5403023  -0.41614684 -0.9899925 ]
```