### PR TITLE
Fix SyntaxError in `jax_to_ir`

### DIFF
--- a/jax/tools/jax_to_ir.py
+++ b/jax/tools/jax_to_ir.py
@@ -41,7 +41,7 @@ Usage:
 
   $ python jax_to_ir.py \
     --fn prog.fn \
-    --input_shapes '[("y": "f32[128,32]"), ("x", "f32[8,128]")]' \
+    --input_shapes '[("y", "f32[128,32]"), ("x", "f32[8,128]")]' \
     --constants '{"z": 3.14159}' \
     --ir_format HLO \
     --ir_human_dest /tmp/fn_hlo.txt \


### PR DESCRIPTION
The example provided in `jax/tools/jax_to_hlo.py` contains a syntax error. This PR fixes it by changing the symbol `:` to `,`.

```
Traceback (most recent call last):
  File "jax_to_hlo.py", line 199, in <module>
    app.run(main)
  File "/usr/local/lib/python3.8/dist-packages/absl/app.py", line 312, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.8/dist-packages/absl/app.py", line 258, in _run_main
    sys.exit(main(argv))
  File "jax_to_hlo.py", line 150, in main
    for name, shape_str in literal_eval(FLAGS.input_shapes)]
  File "/usr/lib/python3.8/ast.py", line 59, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
  File "<unknown>", line 1
    [("y": "f32[128,32]"), ("x", "f32[8,128]")]
         ^
SyntaxError: invalid syntax
```