### PR TITLE
[sparse] mark sparse objects as unhashable

### DIFF
--- a/jax/experimental/sparse/_base.py
+++ b/jax/experimental/sparse/_base.py
@@ -28,6 +28,9 @@ class JAXSparse(abc.ABC):
   nse: property
   dtype: property
 
+  # Ignore type because of https://github.com/python/mypy/issues/4266.
+  __hash__ = None  # type: ignore
+
   @property
   def size(self):
     return util.prod(self.shape)

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1637,6 +1637,9 @@ class SparseObjectTest(jtu.JaxTestCase):
     assert M.nse == (M.todense() != 0).sum()
     assert M.data.dtype == dtype
 
+    with self.assertRaises(TypeError):
+      hash(M)
+
     if isinstance(M, sparse.CSR):
       assert len(M.data) == len(M.indices)
       assert len(M.indptr) == M.shape[0] + 1


### PR DESCRIPTION
Addresses the issue described in #9024, among others.