### PR TITLE
generalize scan weak type handling to fixpoint

### DIFF
--- a/docs/jaxpr.rst
+++ b/docs/jaxpr.rst
@@ -372,11 +372,10 @@ For the example consider the function ``func11`` below
     d:f32[] e:f32[16] = scan[
       jaxpr={ lambda ; f:f32[] g:f32[] h:f32[] i:f32[]. let
           j:f32[] = mul h i
-          k:f32[] = convert_element_type[new_dtype=float32 weak_type=False] g
-          l:f32[] = add k j
-          m:f32[] = convert_element_type[new_dtype=float32 weak_type=False] f
-          n:f32[] = add l m
-        in (n, g) }
+          k:f32[] = add g j
+          l:f32[] = convert_element_type[new_dtype=float32 weak_type=False] f
+          m:f32[] = add k l
+        in (m, g) }
       length=16
       linear=(False, False, False, False)
       num_carry=1

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -364,6 +364,17 @@ def _lattice_result_type(*args):
     result_type = _least_upper_bound(*{_jax_type(d, w) for d, w in zip(dtypes, weak_types)})
     return dtype(result_type), any(result_type is t for t in _weak_types)
 
+# TODO(mattjj,jakevdp): reduce redundancy with _lattice_result_type
+def _dtype_lattice_join(pair1, pair2):
+  dt1, w1 = pair1
+  dt2, w2 = pair2
+  if w1 and w2:
+    result_type = _least_upper_bound(_jax_type(dt1, False), _jax_type(dt2, False))
+    return dtype(result_type), True
+  else:
+    result_type = _least_upper_bound(_jax_type(*pair1), _jax_type(*pair2))
+    return dtype(result_type), w1 and w2
+
 def result_type(*args):
   """Convenience function to apply JAX argument dtype promotion."""
   if len(args) == 0:

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -1642,9 +1642,7 @@ def _promote_dtypes_jaxpr(
     jaxpr: core.ClosedJaxpr, dtypes_in: Tuple[DTypeWeakTypePair, ...],
     out_dtype_min: Tuple[DTypeWeakTypePair, ...]
   ) -> Tuple[core.ClosedJaxpr, Tuple[DTypeWeakTypePair, ...]]:
-  # This implementation relies on evaluating a jaxpr with strong-typed inputs
-  # corresponding to weak-typed binders, even when the dtypes disagree (e.g.
-  # weak-typed int32[] binder and strong-typed int16[] input value).
+  # TODO TODO we need a transform which handles weak type promo
   @lu.wrap_init
   def f(*args):
     outs = core.jaxpr_as_fun(jaxpr)(*args)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2731,6 +2731,21 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     self.assertEqual(carry, x.sum())
     self.assertArraysEqual(result, x)
 
+  def test_scan_init_weak_type_multi(self):
+    def func(carry, x):
+      new_carry = (carry[0] + x, carry[1] + carry[0], carry[2] + carry[1])
+      return new_carry, None
+    init_weak = 0., 0., 0.  # Python scalars are weakly-typed.
+    x = jnp.ones(5, dtype=jnp.float_)
+    _ = lax.scan(func, init_weak, x)  # don't crash
+
+  def test_scan_init_weak_type_multi2(self):
+    def func(carry, x):
+      new_carry = (carry[1], carry[0])
+      return new_carry, None
+    init = 0., jnp.array(0.)
+    _ = lax.scan(func, init, None, length=1)  # don't crash
+
   @parameterized.named_parameters(
       {"testcase_name": f"_dtype={dtype.__name__}", "dtype": dtype}
       for dtype in jtu.dtypes.all_integer)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2735,7 +2735,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     def func(carry, x):
       new_carry = (carry[0] + x, carry[1] + carry[0], carry[2] + carry[1])
       return new_carry, None
-    init_weak = 0., 0., 0.  # Python scalars are weakly-typed.
+    init_weak = 0, 0, 0  # Python scalars are weakly-typed.
     x = jnp.ones(5, dtype=jnp.float_)
     _ = lax.scan(func, init_weak, x)  # don't crash
 


### PR DESCRIPTION
The `scan` weak type handling only did at most two passes, but in general it needs to be a fixpoint loop (with a number of passes up to the length of the flattened carry). Here's an example which fails on main:

```python
import operator
import jax.numpy as jnp
from jax import lax

def safe_map(f, *xs):
  return list(map(f, *xs))

N = 3

def func(carry, x):
  new_carry = [carry[0] + x] + safe_map(operator.add, carry[1:], carry[:-1])
  return new_carry, None
init_weak = [0.] * N
x = jnp.ones(5, dtype='float16')
carry, _ = lax.scan(func, init_weak, x)  # crash!
```

(The version on main succeeds for examples of this type only when the length of the carry is `N`≤1, whereas here it's `N`=3.)

The example succeeds after this PR though!

This PR also avoids ever tracing the user function more than once. That is, if we make `func` above print something, then on main it'll print twice. But the cost is having another transformation around (in this case, to promote dtypes).

I also included:
* rewrapping some comments to 80chars
* raising an Exception instead of assert-failing when fixpoints aren't reached (since assertions can be pruned out with `python -O` or similar)

We need to do the same for `while_loop` too.