### PR TITLE
Add jax.nn.initializers.constant

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -32,6 +32,12 @@ from jax import dtypes
 def zeros(key, shape, dtype=jnp.float_): return jnp.zeros(shape, dtypes.canonicalize_dtype(dtype))
 def ones(key, shape, dtype=jnp.float_): return jnp.ones(shape, dtypes.canonicalize_dtype(dtype))
 
+def constant(value, dtype=jnp.float_):
+  def init(key, shape, dtype=dtype):
+    dtype = dtypes.canonicalize_dtype(dtype)
+    return jnp.full(shape, value, dtype=dtype)
+  return init
+
 def uniform(scale=1e-2, dtype=jnp.float_):
   def init(key, shape, dtype=dtype):
     dtype = dtypes.canonicalize_dtype(dtype)

--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -19,6 +19,7 @@ used in Keras and Sonnet.
 
 # flake8: noqa: F401
 from jax._src.nn.initializers import (
+  constant as constant,
   delta_orthogonal as delta_orthogonal,
   glorot_normal as glorot_normal,
   glorot_uniform as glorot_uniform,


### PR DESCRIPTION
Sometimes it's very convenient to initialize parameters to a constant value other than one or zero. This function wraps jax.numpy.full to allow that. (e.g. all VIT-like architectures initialize the bias of the head with the value log(1/num_classes), rather than 0).