### PR TITLE
Update sphinx-related packages

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-# sphinx <4 required by myst-nb v0.12.0 (Feb 2021)
 # sphinx >=3 required by sphinx-autodoc-typehints v1.11.1 (Oct 2020)
-sphinx >=3, <4
+sphinx >=3
 sphinx_rtd_theme
+# Newer versions cause issues; see https://github.com/google/jax/pull/6449
 sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2
 myst-nb


### PR DESCRIPTION
A new version of `myst-nb` was recently released, which removes the need to pin to an older sphinx version.