### PR TITLE
Add lax.searchsorted_p primitive

### DIFF
--- a/jax/_src/lax/search.py
+++ b/jax/_src/lax/search.py
@@ -1,0 +1,191 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import partial
+
+import numpy as np
+
+import jax
+from jax._src import ad_util
+from jax._src import api
+from jax._src import util
+from jax._src.api_util import _ensure_index_tuple
+from jax._src.lax import lax
+from jax._src.lax.control_flow import fori_loop
+from jax import core
+from jax.interpreters import ad
+from jax.interpreters import batching
+from jax.interpreters import xla
+
+
+def searchsorted(sorted_arr, query, *, side='left', dimension=0, batch_dims=None, method="default"):
+  """Find indices of query values within a sorted array.
+
+  Args:
+    sorted_arr : N-dimensional array, which is assumed to be sorted in increasing
+      order along ``dimension``.
+    query : N-dimensional array of query values.
+    side : {'left', 'right'}. If 'left', find the index of the first suitable
+      location. If 'right', find the index of the last.
+    dimension : integer specifying the dimension along which to insert query values.
+    batch_dims : length-2 tuple of sequences specifying corresponding batch indices
+      for `sorted_arr` and `query`.
+    method : {'default', 'scan', 'sort'} The method used to compute the result.
+      Outside JIT, this defaults to "scan". Within JIT, this defaults to "scan"
+      on CPU, and "sort" otherwise. Assume ``M = query.size`` and
+      ``N = sorted_arr.shape[dimension]``. ``method='scan'`` uses an *O[M log N]*
+      binary search algorithm, while ``method='sort'`` uses an *O[(M+N) log(M+N)]*
+      co-sorting approach. Although ``method='scan'`` may appear to have better
+      scaling overall, in practice it cannot take advantage of parallelism inherent
+      to accelerators, and so in most cases is slower than ``method='sort'`` on GPU
+      and TPU backends.
+
+  Returns:
+    indices : an array specifying the insertion locations of `query` into `sorted_arr`.
+  """
+  dimension = util.canonicalize_axis(dimension, len(sorted_arr.shape))
+  batch_dims = ((), ()) if batch_dims is None else tuple(_ensure_index_tuple(d) for d in batch_dims)
+  return searchsorted_p.bind(sorted_arr, query, side=side, dimension=dimension, batch_dims=batch_dims, method=method)
+
+def _searchsorted_abstract_eval(sorted_arr, query, *, side, dimension, batch_dims, method):
+  lhs_batch, rhs_batch = batch_dims
+  if sorted_arr.dtype != query.dtype:
+    raise ValueError("dtypes of sorted_arr and query must match; got "
+                     f"{sorted_arr.dtype} and {query.dtype}")
+  if method not in ["default", "scan", "sort"]:
+    raise ValueError(f"invalid argument method={method!r}; expected 'default', 'scan', or 'sort'.")
+  if side not in ["left", "right"]:
+    raise ValueError(f"invalid argument side={side!r}, expected 'left' or 'right'")
+  if not 0 <= dimension < sorted_arr.ndim:
+    raise ValueError(f"dimension={dimension}")
+  if any(dim == dimension for dim in lhs_batch):
+    raise ValueError("dimension cannot appear among batch_dims")
+  if any(len(set(dims)) != len(dims) for dims in batch_dims):
+    raise ValueError(f"batch dimensions cannot have repeated entries; got {batch_dims}")
+  if not all((0 <= d1 < sorted_arr.ndim) and (0 <= d2 < query.ndim) for d1, d2 in zip(*batch_dims)):
+    raise ValueError(f"Out of range batch dimensions {batch_dims} for arrays of shape "
+                     f"{sorted_arr.shape} and {query.shape}")
+  if any(sorted_arr.shape[d1] != query.shape[d2] for d1, d2 in zip(*batch_dims)):
+    raise ValueError(f"Incompatible batch dimensions {batch_dims} for arrays of shape "
+                     f"{sorted_arr.shape} and {query.shape}")
+  shape = (*(sorted_arr.shape[d] for d in lhs_batch),
+           *(s for d, s in enumerate(sorted_arr.shape) if d not in (dimension, *lhs_batch)),
+           *(s for d, s in enumerate(query.shape) if d not in rhs_batch))
+  dtype = np.int32 if sorted_arr.shape[dimension] < np.iinfo(np.int32).max else np.int64
+  return core.ShapedArray(shape, dtype)
+
+def _searchsorted_impl(sorted_arr, query, *, side, dimension, batch_dims, method):
+  if method == "scan":
+    _searchsorted = _searchsorted_scan_unbatched
+  elif method == "sort":
+    _searchsorted = _searchsorted_sort_unbatched
+  else:
+    raise ValueError(f"invalid argument method={method!r}; expected 'sort' or 'scan'")
+  out_aval = _searchsorted_abstract_eval(sorted_arr, query, side=side, dimension=dimension,
+                                         batch_dims=batch_dims, method=method)
+  lhs_batch, rhs_batch = batch_dims
+  lhs_extra = lax.remaining(range(len(sorted_arr.shape)), lhs_batch, [dimension])
+  rhs_extra = lax.remaining(range(len(query.shape)), rhs_batch)
+  sorted_arr = lax.transpose(sorted_arr, (*lhs_batch, *lhs_extra, dimension))
+  query = lax.transpose(query, (*rhs_batch, *rhs_extra))
+  fun = partial(_searchsorted, side=side, dtype=out_aval.dtype)
+
+  for _ in lhs_extra:
+    fun = api.vmap(fun, in_axes=(0, None))
+  for _ in lhs_batch:
+    fun = api.vmap(fun, in_axes=0)
+  return fun(sorted_arr, query)
+
+@partial(jax.jit, static_argnames=['side', 'dtype'])
+def _searchsorted_scan_unbatched(sorted_arr, query, *, side, dtype):
+  assert sorted_arr.ndim == 1
+  assert side in ['left', 'right']
+  if len(sorted_arr) == 0:
+    return lax._zeros(query, dtype=dtype)
+  if query.ndim > 0:
+    return api.vmap(partial(_searchsorted_scan_unbatched, side=side, dtype=dtype), in_axes=(None, 0))(sorted_arr, query)
+
+  op = lax._sort_le_comparator if side == 'left' else lax._sort_lt_comparator
+
+  def body_fun(i, state):
+    low, high = state
+    mid = (low + high) // 2
+    go_left = op(query, sorted_arr[mid])
+    return (lax.select(go_left, low, mid), lax.select(go_left, mid, high))
+
+  N, = sorted_arr.shape
+  n_levels = int(np.ceil(np.log2(N + 1)))
+  return fori_loop(0, n_levels, body_fun, (dtype.type(0), dtype.type(N)))[1]
+
+@partial(jax.jit, static_argnames=['side', 'dtype'])
+def _searchsorted_sort_unbatched(sorted_arr, query, *, side, dtype):
+  assert sorted_arr.ndim == 1
+  assert side in ['left', 'right']
+  def _rank(x):
+    idx = lax.iota(dtype, len(x))
+    return lax._zeros(idx).at[lax.sort_key_val(x, idx)[1]].set(idx)
+  if side == 'left':
+    index = _rank(lax.concatenate([query.ravel(), sorted_arr], 0))[:query.size]
+  else:
+    index = _rank(lax.concatenate([sorted_arr, query.ravel()], 0))[sorted_arr.size:]
+  return lax.reshape(lax.sub(index, _rank(index)), np.shape(query))
+
+def _searchsorted_batch_rule(batched_args, bdims, *, side, dimension, batch_dims, method):
+  sorted_arr, _ = batched_args
+  lhs_bdim, rhs_bdim = bdims
+
+  lhs_batch, rhs_batch = batch_dims
+
+  if lhs_bdim is not None:
+    lhs_batch = tuple(d if d < lhs_bdim else d + 1 for d in lhs_batch)
+    if dimension >= lhs_bdim:
+      dimension += 1
+  if rhs_bdim is not None:
+    rhs_batch = tuple(d if d < rhs_bdim else d + 1 for d in rhs_batch)
+
+  if lhs_bdim is None:
+    out_bdim = sorted_arr.ndim - 1 + rhs_bdim - sum(d < rhs_bdim for d in rhs_batch)
+  elif rhs_bdim is None:
+    out_bdim = len(lhs_batch) + lhs_bdim - sum(d < lhs_bdim for d in (dimension, *lhs_batch))
+  else:
+    lhs_batch = (lhs_bdim, *lhs_batch)
+    rhs_batch = (rhs_bdim, *rhs_batch)
+    out_bdim = 0
+
+  return searchsorted_p.bind(*batched_args, side=side, dimension=dimension, batch_dims=[lhs_batch, rhs_batch], method=method), out_bdim
+
+def _searchsorted_impl_scan_default(sorted_arr, query, *, side, dimension, batch_dims, method):
+  return _searchsorted_impl(sorted_arr, query, side=side, dimension=dimension, batch_dims=batch_dims,
+                            method="scan" if method == "default" else method)
+
+def _searchsorted_impl_sort_default(sorted_arr, query, *, side, dimension, batch_dims, method):
+  return _searchsorted_impl(sorted_arr, query, side=side, dimension=dimension, batch_dims=batch_dims,
+                            method="sort" if method == "default" else method)
+
+def _searchsorted_jvp(primals, tangents, *, side, dimension, batch_dims, method):
+  primal_out = searchsorted_p.bind(*primals, side=side, dimension=dimension, batch_dims=batch_dims, method=method)
+  return primal_out, ad_util.Zero.from_value(primal_out)
+
+searchsorted_p = core.Primitive("searchsorted")
+searchsorted_p.def_abstract_eval(_searchsorted_abstract_eval)
+searchsorted_p.def_impl(_searchsorted_impl_scan_default)
+ad.primitive_jvps[searchsorted_p] = _searchsorted_jvp
+batching.primitive_batchers[searchsorted_p] = _searchsorted_batch_rule
+
+# Default to method=scan on CPU; method=sort on accelerators.
+xla.register_translation(searchsorted_p, xla.lower_fun(
+  _searchsorted_impl_sort_default, multiple_results=False, new_style=True))
+xla.register_translation(searchsorted_p, xla.lower_fun(
+  _searchsorted_impl_scan_default, multiple_results=False, new_style=True),
+  platform="cpu")

--- a/jax/_src/lax/search.py
+++ b/jax/_src/lax/search.py
@@ -129,7 +129,7 @@ def _searchsorted_sort_unbatched(sorted_arr, query, *, side, dtype):
     index = _rank(lax.concatenate([query.ravel(), sorted_arr], 0))[:query.size]
   else:
     index = _rank(lax.concatenate([sorted_arr, query.ravel()], 0))[sorted_arr.size:]
-  return lax.reshape(lax.sub(index, _rank(index)), np.shape(query))
+  return lax.reshape(lax.sub(index, _rank(query.ravel())), np.shape(query))
 
 def _searchsorted_batch_rule(batched_args, bdims, *, side, dimension, batch_dims, method):
   sorted_arr, query = batched_args

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -338,6 +338,10 @@ from jax._src.lax.control_flow import (
   while_loop as while_loop,
   while_p as while_p,
 )
+from jax._src.lax.search import (
+  searchsorted as searchsorted,
+  searchsorted_p as searchsorted_p,
+)
 from jax._src.lax.fft import (
   fft as fft,
   fft_p as fft_p,

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -409,6 +409,38 @@ class BatchingTest(jtu.JaxTestCase):
     self.assertAllClose(ans, expected, check_dtypes=False)
     assert len(np.unique(ans)) == 10 * 3 * 2
 
+  def testSearchsorted(self):
+    rng = self.rng()
+    sorted_arr = np.linspace(0, 1, 12).reshape(3, 4)
+    query = rng.rand(3, 4)
+    query2 = rng.rand(2, 3, 4)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=0))(sorted_arr, query)
+    ind2 = lax.searchsorted(sorted_arr, query, batch_dims=1, dimension=1)
+    self.assertAllClose(ind1, ind2)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=0), in_axes=(0, None))(sorted_arr, query)
+    ind2 = lax.searchsorted(sorted_arr, query, dimension=1)
+    self.assertAllClose(ind1, ind2)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=1), in_axes=(None, 0))(sorted_arr, query)
+    ind2 = lax.searchsorted(sorted_arr, query, dimension=1).transpose(1, 0, 2)
+    self.assertAllClose(ind1, ind2)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=1, batch_dims=1), in_axes=(None, 0))(sorted_arr, query2)
+    ind2 = lax.searchsorted(sorted_arr, query2.transpose(1, 2, 0), dimension=1, batch_dims=1).transpose(2, 0, 1)
+    self.assertAllClose(ind1, ind2)
+
+    sorted_arr = np.linspace(0, 1, 24).reshape(3, 2, 4)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=1, batch_dims=1), in_axes=(1, None))(sorted_arr, query)
+    ind2 = lax.searchsorted(sorted_arr, query, batch_dims=1, dimension=2).transpose(1, 0, 2)
+    self.assertAllClose(ind1, ind2)
+
+    ind1 = vmap(partial(lax.searchsorted, dimension=1, batch_dims=1), in_axes=(1, 0))(sorted_arr, query2)
+    ind2 = lax.searchsorted(sorted_arr.transpose(1, 0, 2), query2, batch_dims=2, dimension=2)
+    self.assertAllClose(ind1, ind2)
+
   def testSort(self):
     v = np.arange(12)[::-1].reshape(3, 4)
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2983,21 +2983,22 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_a={}_v={}_side={}".format(
+    {"testcase_name": "_a={}_v={}_side={}_method={}".format(
       jtu.format_shape_dtype_string(ashape, dtype),
       jtu.format_shape_dtype_string(vshape, dtype),
-      side), "ashape": ashape, "vshape": vshape, "side": side,
-     "dtype": dtype}
+      side, method), "ashape": ashape, "vshape": vshape, "side": side,
+     "dtype": dtype, "method": method}
     for ashape in [(15,), (16,), (17,)]
     for vshape in [(), (5,), (5, 5)]
     for side in ['left', 'right']
+    for method in ['default', 'scan', 'sort']
     for dtype in number_dtypes
   ))
-  def testSearchsorted(self, ashape, vshape, side, dtype):
+  def testSearchsorted(self, ashape, vshape, side, dtype, method):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [np.sort(rng(ashape, dtype)), rng(vshape, dtype)]
-    np_fun = lambda a, v: np.searchsorted(a, v, side=side)
-    jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side)
+    np_fun = lambda a, v: np.searchsorted(a, v, side=side).astype('int32')
+    jnp_fun = lambda a, v: jnp.searchsorted(a, v, side=side, method=method)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
@@ -3037,7 +3038,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     order = jnp.index_exp[::-1] if reverse else jnp.index_exp[:]
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), jnp.sort(rng(binshape, dtype))[order]]
-    np_fun = lambda x, bins: np.digitize(x, bins, right=right)
+    np_fun = lambda x, bins: np.digitize(x, bins, right=right).astype('int32')
     jnp_fun = lambda x, bins: jnp.digitize(x, bins, right=right)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1997,9 +1997,9 @@ class LaxTest(jtu.JaxTestCase):
       for method in ["sort", "scan"]
       for dtype in float_dtypes + int_dtypes
       for shape, queryshape, dimension, batch_dims in [
-        ((8,), (5,), 0, None),
-        ((4, 8), (), 0, None),
-        ((4, 8), (5, 4), 1, ((0,), (1,))),
+        ((8,), (5,), 0, 0),
+        ((4, 8), (), 0, 0),
+        ((4, 8), (4, 5), 1, 1),
       ]))
   def testSearchsorted(self, shape, queryshape, dtype, batch_dims, dimension, side, method):
     rng = jtu.rand_some_equal(self.rng())


### PR DESCRIPTION
Make `searchsorted` a lax primitive, primarily to allow switching to a more efficient implementation on accelerators.

~Also addresses one of the TODOs left over from #9107 (correct results for complex inputs in the presence of NaNs)~

Still a few TODOs/things to think about:

- ~I previously ran some benchmarks on early versions of these implementations that convinced me this was worth doing; I plan to run some benchmarks on top of this change to better convince us that the backend-specific default implementations are suitable.~ Benchmarks here: https://colab.research.google.com/drive/1kt9dwAFWZIkClOrrKr3zZLmAyWBroxj3?usp=sharing
- ~The form of the `batch_dims` argument (a tuple of lists of batch indices) is the most general approach I could think of, but it may be simpler to specify `batch_dims` as an integer and require then to be at the front of both arrays. The downside is this would in general require transposes within the batch rule.~ Done: I like the simplified version better.
- ~Should the primitive be generalized further to take `N` sorted arrays and `N` query arrays? I can think of some applications, e.g. sparse-sparse matmul implementations.~ No, we'll punt on this for now. Variadic searchsorted can be added in a fully backward-compatible way, if desired.

~This needs to be rebased against #9127 once that is merged.~