### PR TITLE
clean up WrappedFun.call_wrapped refs on exception

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6546,5 +6546,14 @@ class BackendsTest(jtu.JaxTestCase):
     assert "No GPU/TPU found" not in result.stderr.decode()
 
 
+class CleanupTest(jtu.JaxTestCase):
+  def test_call_wrapped_second_phase_cleanup(self):
+    try:
+      jax.vmap(lambda x: x, out_axes=None)(jnp.arange(3))
+    except:
+      assert core.trace_state_clean()  # this is the hard one
+    assert core.trace_state_clean()
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Functions decorated by linear_util.transformation or transformation_with_aux are coroutines (with two yields). They can raise exceptions, either before or after they yield the first time.

linear_util.WrappedFun.call_wrapped, which is responsible for driving these coroutines, holds references to them.

These coroutines often manipulate global trace state (i.e. core.thread_local_state.trace_state attributes) through context managers (e.g. core.new_main or core.extend_axis_env). These context managers use try/finally to clean up their state changes.

When an exception is raised in a linear_util.transformation coroutine, it is raised into call_wrapped. If call_wrapped doesn't then clean up all the references it has to coroutines, the cleanup finally clauses may not execute until too late.

To ensure the finally clauses are called at the right time (before exiting call_wrapped, basically as soon as possible) we need to clean up the references to the coroutines in call_wrapped.

We had cleaned up these coroutine references when the coroutines raised exceptions in their first part (i.e. before their first yield) in #4226. But we didn't do a similar cleanup for their second part (i.e. after their first yield and before their second).