### PR TITLE
jnp.searchsorted: properly handle NaNs

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -50,7 +50,7 @@ from jax.config import config
 from jax.interpreters import pxla
 from jax import lax
 from jax._src import device_array
-from jax._src.lax.lax import _array_copy
+from jax._src.lax.lax import _array_copy, _float_to_int_for_sort
 from jax._src.ops import scatter
 from jax._src.util import (unzip2, prod as _prod, subvals, safe_zip, ceil_of_ratio,
                            canonicalize_axis as _canonicalize_axis, maybe_named_axis)
@@ -6456,7 +6456,11 @@ def _searchsorted(a, v, side):
   if len(a) == 0:
     return 0
   op = operator.le if side == 'left' else operator.lt
-
+  # TODO(jakevdp): handle NaNs correctly for complex. This will likely involve
+  # adding lexicographic sorting capabilities to the following.
+  a, v = _promote_dtypes(a, v)
+  if issubdtype(a.dtype, floating):
+    a, v = map(_float_to_int_for_sort, (a, v))
   def body_fun(i, state):
     low, high = state
     mid = (low + high) // 2

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2979,6 +2979,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": f"_dtype={dtype.__name__}", "dtype": dtype}
+    for dtype in inexact_dtypes))
+  def testSearchsortedNans(self, dtype):
+    if np.issubdtype(dtype, np.complexfloating):
+      raise SkipTest("Known failure for complex inputs; see #9107")
+    sorted = jnp.array([-np.nan, -np.inf, -1, 0, 1, np.inf, np.nan], dtype=dtype)
+    self.assertArraysEqual(
+      jnp.searchsorted(sorted, sorted, side='left'),
+      jnp.arange(len(sorted)))
+    self.assertArraysEqual(
+      jnp.searchsorted(sorted, sorted, side='right'),
+      jnp.arange(1, 1 + len(sorted)))
+
+  @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_x={}_bins={}_right={}_reverse={}".format(
       jtu.format_shape_dtype_string(xshape, dtype),
       jtu.format_shape_dtype_string(binshape, dtype),


### PR DESCRIPTION
Fixes #9107

Still TODO is to properly handle complex inputs; this will be a bit, *ahem*, complex because `lax.sort` sorts complex numbers lexicographically, so we'd have to modify the binary search to handle lexicographic sorting.