### PR TITLE
Add `jax.default_device` context manager

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -122,14 +122,17 @@ Let's first look at the principles of data and computation placement in JAX.
 
 In JAX, the computation follows data placement. JAX arrays
 have two placement properties: 1) the device where the data resides;
-and 2) whether it is **committed** to the device or not (the data is sometimes 
+and 2) whether it is **committed** to the device or not (the data is sometimes
 referred to as being *sticky* to the device).
 
 By default, JAX arrays are placed uncommitted on the default device
-(``jax.devices()[0]``), which is the first GPU by default. If no GPU is 
-present, ``jax.devices()[0]`` is the first CPU. The default device can 
-be set to "cpu" or "gpu" manually by setting the environment variable 
-``JAX_PLATFORM_NAME`` or the absl flag ``--jax_platform_name``.
+(``jax.devices()[0]``), which is the first GPU or TPU by default. If no GPU or
+TPU is present, ``jax.devices()[0]`` is the CPU. The default device can
+temporarily overridden with the :func:`jax.default_device` context manager, or
+set for the whole process by setting the environment variable ``JAX_PLATFORMS``
+or the absl flag ``--jax_platforms`` to "cpu", "gpu", or "tpu"
+(``JAX_PLATFORMS`` can also be a list of platforms, which determines which
+platforms are available in priority order).
 
 >>> from jax import numpy as jnp
 >>> print(jnp.ones(3).device_buffer.device())  # doctest: +SKIP
@@ -148,15 +151,15 @@ gpu:2
 
 Computations involving some committed inputs will happen on the
 committed device and the result will be committed on the
-same device. Invoking an operation on arguments that are committed 
+same device. Invoking an operation on arguments that are committed
 to more than one device will raise an error.
 
-You can also use :func:`jax.device_put` without a ``device`` parameter. If the data 
-is already on a device (committed or not), it's left as-is. If the data isn't on any 
-device—that is, it's a regular Python or NumPy value—it's placed uncommitted on the default 
+You can also use :func:`jax.device_put` without a ``device`` parameter. If the data
+is already on a device (committed or not), it's left as-is. If the data isn't on any
+device—that is, it's a regular Python or NumPy value—it's placed uncommitted on the default
 device.
 
-Jitted functions behave like any other primitive operations—they will follow the 
+Jitted functions behave like any other primitive operations—they will follow the
 data and will show errors if invoked on data committed on more than one device.
 
 ``jnp.device_put(jnp.zeros(...), jax.devices()[1])`` or similar will actually create the
@@ -164,8 +167,8 @@ array of zeros on ``jax.devices()[1]``, instead of creating the array on the def
 device then moving it. This is thanks to some laziness in array creation, which holds
 for all the constant creation operations (``ones``, ``full``, ``eye``, etc).
 
-(As of April 2020, :func:`jax.jit` has a `device` parameter that affects the device 
-placement. That parameter is experimental, is likely to be removed or changed, 
+(As of April 2020, :func:`jax.jit` has a `device` parameter that affects the device
+placement. That parameter is experimental, is likely to be removed or changed,
 and its use is not recommended.)
 
 For a worked-out example, we recommend reading through
@@ -259,7 +262,7 @@ Broadly speaking:
   they are dispatched asynchronously (see :ref:`async-dispatch`); and they can
   be executed on CPU, GPU, or TPU, each of which have vastly different and continuously
   evolving performance characteristics.
-  
+
 These architectural differences make meaningful direct benchmark comparisons between
 NumPy and JAX difficult.
 

--- a/docs/jax.config.rst
+++ b/docs/jax.config.rst
@@ -11,6 +11,7 @@ JAX configuration
    checking_leaks
    debug_nans
    debug_infs
+   default_device
    default_matmul_precision
    default_prng_impl
    enable_checks

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -53,6 +53,7 @@ from jax._src.config import (
   transfer_guard_host_to_device as transfer_guard_host_to_device,
   transfer_guard_device_to_device as transfer_guard_device_to_device,
   transfer_guard_device_to_host as transfer_guard_device_to_host,
+  default_device as default_device,
 )
 from .core import eval_context as ensure_compile_time_eval
 from jax._src.api import (

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -456,6 +456,13 @@ def _cpp_jit(
     raise ValueError("can't specify both a device and a backend for jit, "
                      f"got device={device} and backend={backend}.")
 
+  if device is not None:
+    jit_device = device
+  elif backend is not None:
+    jit_device = xb.get_backend(backend).get_default_device_assignment(1)[0]
+  else:
+    jit_device = None
+
   @api_boundary
   def cache_miss(*args, **kwargs):
     ### This first part is basically the same code as in _python_jit.
@@ -531,7 +538,7 @@ def _cpp_jit(
                              static_argnums=static_argnums,
                              static_argnames=static_argnames,
                              donate_argnums=donate_argnums,
-                             cache=_cpp_jit_cache)
+                             cache=_cpp_jit_cache, jit_device=jit_device)
   f_jitted = wraps(fun)(cpp_jitted_f)
 
   f_jitted.lower = _jit_lower(fun, static_argnums, static_argnames, device,

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -273,10 +273,11 @@ def cache(call: Callable):
     cache = fun_caches.setdefault(fun.f, {})
     if config.jax_check_tracer_leaks:
       key = (_copy_main_traces(fun.transforms), fun.params, fun.in_type, args,
-             config.x64_enabled, config._trace_context())
+             config.x64_enabled, config.jax_default_device,
+             config._trace_context())
     else:
-      key = (fun.transforms, fun.params, fun.in_type, args,
-             config.x64_enabled, config._trace_context())
+      key = (fun.transforms, fun.params, fun.in_type, args, config.x64_enabled,
+             config.jax_default_device, config._trace_context())
     result = cache.get(key, None)
     if result is not None:
       ans, stores = result

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -228,6 +228,55 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     self.assertIsInstance(x, jnp.DeviceArray)
     self.assertEqual(x.device_buffer.device(), device)
 
+  @jtu.skip_on_devices("cpu")
+  def test_jit_default_device(self):
+    if jax.device_count() == 1:
+      raise unittest.SkipTest("Test requires multiple devices")
+
+    system_default_device = jax.numpy.add(1, 1).device()
+    test_device = jax.devices()[-1]
+    self.assertNotEqual(system_default_device, test_device)
+
+    f = jax.jit(lambda x: x + 1)
+    self.assertEqual(f(1).device(), system_default_device)
+
+    with jax.default_device(test_device):
+      self.assertEqual(jax.numpy.add(1, 1).device(), test_device)
+      self.assertEqual(f(1).device(), test_device)
+
+    self.assertEqual(jax.numpy.add(1, 1).device(), system_default_device)
+    self.assertEqual(f(1).device(), system_default_device)
+
+    with jax.default_device(test_device):
+      # Explicit `device` or `backend` argument to jit overrides default_device
+      self.assertEqual(jax.jit(f, device=system_default_device)(1).device(),
+                       system_default_device)
+      self.assertEqual(jax.jit(f, backend="cpu")(1).platform(), "cpu")
+
+      # Sticky input device overrides default_device
+      sticky = jax.device_put(1, system_default_device)
+      self.assertEqual(jax.numpy.add(sticky, 1).device(), system_default_device)
+      self.assertEqual(f(sticky).device(), system_default_device)
+
+      # Test nested default_devices
+      with jax.default_device(system_default_device):
+        self.assertEqual(f(1).device(), system_default_device)
+      self.assertEqual(f(1).device(), test_device)
+
+    # Test a few more non-default_device calls for good luck
+    self.assertEqual(jax.numpy.add(1, 1).device(), system_default_device)
+    self.assertEqual(f(sticky).device(), system_default_device)
+    self.assertEqual(f(1).device(), system_default_device)
+
+  # TODO(skye): make this work!
+  def test_jit_default_platform(self):
+    with self.assertRaisesWithLiteralMatch(
+        ValueError,
+        "jax.default_device must be passed a Device object "
+        "(e.g. `jax.devices('cpu')[0]`), got: 'cpu'"):
+      with jax.default_device("cpu"):
+        jax.jit(lambda x: x + 1)(1)
+
   def test_complex_support(self):
     self.assertEqual(self.jit(lambda x: x + 1)(1 + 1j), 2 + 1j)
 


### PR DESCRIPTION
This currently only supports setting a specific Device object, not a
platform like "cpu". That should be added in the future.

Bumps the minimum jaxlib version in order to include
https://github.com/tensorflow/tensorflow/pull/53656