### PR TITLE
Fix host_callback docs

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -229,7 +229,7 @@ Behavior under JAX autodiff transformations
 -------------------------------------------
 
 When used under a JAX autodiff transformation, the host callback functions
-operate on the primal values only. Consider the following example:
+operate on the primal values only. Consider the following example::
 
     def power3(x):
       y = x * x


### PR DESCRIPTION
There was a missing ':' causing invalid rendering of the docs.