### PR TITLE
simpler jaxpr eqn params to bind params conversion

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -296,27 +296,11 @@ class Primitive:
     raise NotImplementedError("Abstract evaluation for '{}' not implemented"
                               .format(self.name))
 
+  def get_bind_params(self, params):
+    return [], params
+
 
 # -------------------- lifting --------------------
-
-# TODO(necula): this belongs next to pe.new_eqn_recipe, but is needed in
-# core.py. Plan to move all these utilities to jaxpr.py.
-def extract_call_jaxpr(
-  primitive: Primitive,
-  params: Dict[str, Any]) -> Tuple[Optional[Jaxpr], Dict[str, Any]]:
-  """Extract the call primitive subjaxpr from the params.
-
-  Returns the subjaxpr and the params without the "call_jaxpr" value. If this is
-  not a call primitive then returns (None, params).
-  """
-  if not (primitive.call_primitive or primitive.map_primitive):
-    return (None, params)
-  else:
-    assert "call_jaxpr" in params
-    new_params = dict(params)
-    del new_params["call_jaxpr"]
-    return (params["call_jaxpr"], new_params)
-
 
 # TODO(mattjj): replace this approach with a primitive-keyed table of rules
 def traverse_jaxpr_params(f, params):
@@ -325,26 +309,6 @@ def traverse_jaxpr_params(f, params):
           for name, param in params.items()
           for p in (param if isinstance(param, (tuple, list)) else [param])
           if type(p) in (Jaxpr, ClosedJaxpr)}
-
-
-def eval_jaxpr_eqn(eqn, in_vals):
-  """Evaluates the jaxpr equation with the provided input values."""
-  call_jaxpr, params = extract_call_jaxpr(eqn.primitive, eqn.params)
-  if call_jaxpr:
-    subfuns = [lu.wrap_init(partial(eval_jaxpr, call_jaxpr, ()))]
-  else:
-    subfuns = []
-  if eqn.primitive in initial_to_final_param_rules:
-    bind_params = initial_to_final_param_rules[eqn.primitive](params)
-  elif eqn.primitive.map_primitive:
-    out_axes_thunk = HashableFunction(lambda: params['out_axes'],
-                                      closure=params['out_axes'])
-    bind_params = dict(params, out_axes_thunk=out_axes_thunk)
-    del bind_params['out_axes']
-  else:
-    bind_params = params
-  with source_info_util.user_context(eqn.source_info.traceback):
-    return eqn.primitive.bind(*(subfuns + in_vals), **bind_params)
 
 
 def eval_jaxpr(jaxpr: Jaxpr, consts, *args):
@@ -362,14 +326,14 @@ def eval_jaxpr(jaxpr: Jaxpr, consts, *args):
   map(write, jaxpr.constvars, consts)
   map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    ans = eval_jaxpr_eqn(eqn, map(read, eqn.invars))
+    subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
+    with source_info_util.user_context(eqn.source_info.traceback):
+      ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
     if eqn.primitive.multiple_results:
       map(write, eqn.outvars, ans)
     else:
       write(eqn.outvars[0], ans)
   return map(read, jaxpr.outvars)
-
-initial_to_final_param_rules: Dict[Primitive, Callable] = {}
 
 
 # -------------------- tracing --------------------
@@ -1713,6 +1677,11 @@ class CallPrimitive(Primitive):
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_call(self, out_tracers, params)
 
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    subfun = lu.wrap_init(partial(eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    return [subfun], new_params
+
 def call_impl(f: lu.WrappedFun, *args, **params):
   del params  # params parameterize the call primitive, not the function
   with new_sublevel():
@@ -1724,6 +1693,7 @@ call_p.def_impl(call_impl)
 
 named_call_p: CallPrimitive = CallPrimitive('named_call')
 named_call_p.def_impl(call_impl)
+
 
 outfeed_primitives: Set[Primitive] = set()
 def jaxpr_uses_outfeed(jaxpr: Jaxpr) -> bool:
@@ -1804,6 +1774,13 @@ class MapPrimitive(Primitive):
 
   def post_process(self, trace, out_tracers, params):
     return trace.post_process_map(self, out_tracers, params)
+
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    subfun = lu.wrap_init(partial(eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    axes = new_params.pop('out_axes')
+    new_params['out_axes_thunk'] = HashableFunction(lambda: axes, closure=axes)
+    return [subfun], new_params
 
 @contextmanager
 def extend_axis_env(axis_name: AxisName, size: int, tag: Any):
@@ -2296,3 +2273,8 @@ def pp_jaxpr_eqn_range(jaxpr: Jaxpr, lo: int, hi: int, context: JaxprPpContext,
         pps.append(pp.text('...'))
     return pp.join(pp.brk("; "), pps)
   return pp_jaxpr_skeleton(jaxpr, eqns_fn, context, print_shapes=print_shapes)
+
+
+# TODO(mattjj): remove this stub, which is a temporary hack for google-internal
+# type checking
+extract_call_jaxpr: Callable

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -866,6 +866,19 @@ class XMapPrimitive(core.MapPrimitive):  # Not really a map, but it gives us a f
   def post_process(self, trace, out_tracers, params):
     raise NotImplementedError
 
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    subfun = lu.wrap_init(partial(core.eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    axes = new_params.pop('out_axes')
+    new_params['out_axes_thunk'] = HashableFunction(lambda: axes, closure=axes)
+    spmd_axes = new_params.pop('spmd_out_axes')
+    if spmd_axes is not None:
+      new_params['spmd_out_axes_thunk'] = \
+          HashableFunction(lambda: spmd_axes, closure=spmd_axes)
+    else:
+      new_params['spmd_out_axes_thunk'] = None
+    return [subfun], new_params
+
 xmap_p = XMapPrimitive()
 core.EvalTrace.process_xmap = core.EvalTrace.process_call  # type: ignore
 def _process_xmap_default(self, call_primitive, f, tracers, params):
@@ -1277,22 +1290,6 @@ def _batch_trace_process_xmap(self, is_spmd, primitive, f: lu.WrappedFun, tracer
 batching.BatchTrace.process_xmap = partialmethod(_batch_trace_process_xmap, False)  # type: ignore
 pxla.SPMDBatchTrace.process_xmap = partialmethod(_batch_trace_process_xmap, True)  # type: ignore
 
-
-def _xmap_initial_to_final_params(params):
-  out_axes_thunk = HashableFunction(lambda: params['out_axes'],
-                                    closure=params['out_axes'])
-  if params['spmd_out_axes'] is not None:
-    spmd_out_axes_thunk = HashableFunction(lambda: params['spmd_out_axes'],
-                                           closure=params['spmd_out_axes'])
-  else:
-    spmd_out_axes_thunk = None
-  bind_params = dict(params,
-                     out_axes_thunk=out_axes_thunk,
-                     spmd_out_axes_thunk=spmd_out_axes_thunk)
-  del bind_params['out_axes']
-  del bind_params['spmd_out_axes']
-  return bind_params
-core.initial_to_final_param_rules[xmap_p] = _xmap_initial_to_final_params
 
 # -------- nested xmap handling --------
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -218,7 +218,8 @@ def backward_pass(jaxpr: core.Jaxpr, reduce_axes, consts, primals_in, cotangents
     with source_info_util.user_context(eqn.source_info.traceback):
       if eqn.primitive.call_primitive or eqn.primitive.map_primitive:
         cts_in_avals = [v.aval for v in eqn.outvars]
-        call_jaxpr, params = core.extract_call_jaxpr(eqn.primitive, eqn.params)
+        params = dict(eqn.params)
+        call_jaxpr = params.pop('call_jaxpr')
         cts_out = get_primitive_transpose(eqn.primitive)(
             params, call_jaxpr, invals, cts_in, cts_in_avals, reduce_axes)
       elif eqn.primitive in reducing_transposes:

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -567,7 +567,7 @@ class DynamicShapesTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.eqns, 1)
     eqn = jaxpr.eqns[0]
     self.assertIsInstance(eqn.primitive, core.CallPrimitive)
-    inner_jaxpr, _ = core.extract_call_jaxpr(eqn.primitive, eqn.params)
+    inner_jaxpr = eqn.params['call_jaxpr']
     self.assertIsInstance(inner_jaxpr, core.Jaxpr)
 
     self.assertLen(inner_jaxpr.invars, 1 + 4)  # one axis size var
@@ -596,7 +596,7 @@ class DynamicShapesTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.eqns, 1)
     eqn = jaxpr.eqns[0]
     self.assertIsInstance(eqn.primitive, core.CallPrimitive)
-    inner_jaxpr, _ = core.extract_call_jaxpr(eqn.primitive, eqn.params)
+    inner_jaxpr = eqn.params['call_jaxpr']
     self.assertIsInstance(inner_jaxpr, core.Jaxpr)
 
     self.assertLen(inner_jaxpr.invars, 1 + 4)  # one axis size var


### PR DESCRIPTION
Final-style higher-order primitives, like call_p, xla_call_p (underlying jit), xla_pmap_p (underlying pmap), and xmap_p (underlying xmap) have slightly different bind signatures (while   tracing) from their signatures when they appear in jaxprs. In particular, their trace-time binds are parameterized by a Python callable (or really a lu.WrappedFun) representing the       function to be applied, while in jaxpr eqns they are parameterized by a jaxpr representing the same.

As a result, to round-trip from jaxpr to Python traceable, in core.eval_jaxpr we have to convert from one parameter signature to the other. (Basically we had to take the jaxpr and turn   it into a Python callable, via lu.wrap_init(partial(core.eval_jaxpr, call_jaxpr, ...)).)

However due to historical path dependence these conversion mechanisms were all slightly distinct and kind of a mess. There was a case analysis for call_jaxpr and map_jaxpr in core.       eval_jaxpr_eqn (a helper function created only because of this complexity), and there was a separate table only used for the xmap rule.

In this PR we uniformized things! We basically only have a table (to simplify core.eval_jaxpr), but instead of having it as a table we just attached the rules to the different primitive  classes (CallPrimitive, MapPrimitive, and XmapPrimitive) to make things less error-prone (we have a few different CallPrimitive instantiations, like call_p, xla_call_p, named_call_p, and remat_call_p, and this way we don't have to remember to populate the table separately for each).

This was actually a warmup simplification before we attempt to simplify custom derivatives (to unify custom_jvp_call_p and custom_jvp_call_jaxpr_p).