### PR TITLE
simplify custom_jvp_call_p, remove custom_jvp_call_jaxpr_p

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -15,8 +15,8 @@
 from functools import update_wrapper, reduce, partial
 import inspect
 import operator as op
-from typing import (Any, Callable, Generic, List, Optional, Sequence, Set,
-                    Tuple, TypeVar)
+from typing import (Callable, Generic, Optional, Sequence, Tuple, TypeVar, Set,
+                    Any)
 
 from jax import core
 from jax import linear_util as lu
@@ -276,8 +276,6 @@ def _flatten_jvp(in_tree, *args):
   yield primals_out + tangents_out, out_tree
 
 class CustomJVPCallPrimitive(core.CallPrimitive):
-  initial_style: core.Primitive
-
   def bind(self, fun, jvp, *args):
     args = map(core.full_lower, args)
     top_trace = core.find_top_trace(args)
@@ -297,6 +295,23 @@ class CustomJVPCallPrimitive(core.CallPrimitive):
   def post_process(self, trace, out_tracers, jvp_was_run: bool):
     return trace.post_process_custom_jvp_call(out_tracers, jvp_was_run)
 
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    call_jaxpr = new_params.pop('call_jaxpr')
+    num_consts = new_params.pop('num_consts')
+    jvp_jaxpr_thunk = new_params.pop('jvp_jaxpr_thunk')
+    fun = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr))
+
+    @lu.wrap_init
+    def jvp(*xs):
+      jvp_jaxpr, jvp_consts = jvp_jaxpr_thunk()
+      n, ragged = divmod(len(xs), 2)
+      assert not ragged
+      primals, tangents = xs[num_consts:n], xs[n+num_consts:]
+      return core.eval_jaxpr(jvp_jaxpr, jvp_consts, *primals, *tangents)
+
+    return [fun, jvp], new_params
+
 @lu.transformation_with_aux
 def process_env_traces(primitive, level: int, jvp_was_run: bool, *args):
   outs = yield args, {}
@@ -314,6 +329,23 @@ def process_env_traces(primitive, level: int, jvp_was_run: bool, *args):
     todo.append(cur_todo)
   yield outs, tuple(todo)  # Ensure the aux output is immutable
 
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    call_jaxpr = new_params.pop('call_jaxpr')
+    num_consts = new_params.pop('num_consts')
+    jvp_jaxpr_thunk = new_params.pop('jvp_jaxpr_thunk')
+    fun = lu.wrap_init(core.jaxpr_as_fun(call_jaxpr))
+
+    @lu.wrap_init
+    def jvp(*xs):
+      jvp_jaxpr, jvp_consts = jvp_jaxpr_thunk()
+      n, ragged = divmod(len(xs), 2)
+      assert not ragged
+      primals, tangents = xs[num_consts:n], xs[n+num_consts:]
+      return core.eval_jaxpr(jvp_jaxpr, jvp_consts, *primals, *tangents)
+
+    return [fun, jvp], new_params
+
 def _apply_todos(todos, outs):
   todos_list = list(todos)
   while todos_list:
@@ -324,122 +356,35 @@ def _apply_todos(todos, outs):
 allowed_effects: Set[core.Effect] = set()
 custom_jvp_call_p = CustomJVPCallPrimitive('custom_jvp_call')
 
-
-def _custom_jvp_call_jaxpr_impl(*args, fun_jaxpr: core.ClosedJaxpr, **params):
-  del params  # other params ignored because we're just executing the primal fun
-  return core.jaxpr_as_fun(fun_jaxpr)(*args)
-
-def _custom_jvp_call_jaxpr_abstract_eval(*args, fun_jaxpr: core.ClosedJaxpr, **params):
-  del args, params
-  disallowed_effects = {eff for eff in fun_jaxpr.effects if eff not in
+def _custom_jvp_call_typecheck(*in_avals, call_jaxpr, jvp_jaxpr_thunk, num_consts):
+  # TODO(mattjj): could do more checking here...
+  del in_avals, jvp_jaxpr_thunk, num_consts
+  disallowed_effects = {eff for eff in call_jaxpr.effects if eff not in
                         allowed_effects}
   if disallowed_effects:
     raise NotImplementedError(
         f'Effects not supported in `custom_jvp`: {disallowed_effects}')
-  return fun_jaxpr.out_avals, fun_jaxpr.effects
+  return call_jaxpr.out_avals, call_jaxpr.effects
+core.custom_typechecks[custom_jvp_call_p] = _custom_jvp_call_typecheck
 
-custom_jvp_call_jaxpr_p = core.AxisPrimitive('custom_jvp_call_jaxpr')
-custom_jvp_call_jaxpr_p.multiple_results = True
-custom_jvp_call_jaxpr_p.def_impl(_custom_jvp_call_jaxpr_impl)
-custom_jvp_call_jaxpr_p.def_effectful_abstract_eval(_custom_jvp_call_jaxpr_abstract_eval)
-CustomJVPCallPrimitive.initial_style = custom_jvp_call_jaxpr_p
-
-mlir.register_lowering(custom_jvp_call_jaxpr_p, mlir.lower_fun(
-    _custom_jvp_call_jaxpr_impl, multiple_results=True))
-
-
-def _custom_jvp_call_jaxpr_jvp(
-    primals, tangents, *, fun_jaxpr: core.ClosedJaxpr,
-    jvp_jaxpr_thunk: Callable[[], Tuple[core.Jaxpr, Sequence[Any]]],
-    num_consts: int):
-  _, args = split_list(primals, [num_consts])
-  consts_dot, args_dot = split_list(tangents, [num_consts])
-  if any(type(t) is not Zero for t in consts_dot):
-    raise ad.CustomJVPException()
-  jvp_jaxpr, jvp_consts = jvp_jaxpr_thunk()  # consts can be tracers!
-  args_dot = map(ad.instantiate_zeros, args_dot)
-  # Cast float0 to zeros with the primal dtype because custom jvp rules don't
-  # currently handle float0s
-  args_dot = map(ad.replace_float0s, args, args_dot)
-  outs = core.eval_jaxpr(jvp_jaxpr, jvp_consts, *args, *args_dot)
-  primals_out, tangents_out = split_list(outs, [len(outs) // 2])
-  tangents_out = map(ad.recast_to_float0, primals_out, tangents_out)
-  if config.jax_enable_checks:
-    assert all(map(core.typecheck, fun_jaxpr.out_avals, primals_out))
-  return primals_out, tangents_out
-ad.primitive_jvps[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_jvp
-
-def _custom_jvp_call_jaxpr_vmap(
-    axis_size, axis_name, main_type, args, in_dims, *, fun_jaxpr: core.ClosedJaxpr,
-    jvp_jaxpr_thunk: Callable[[], Tuple[core.Jaxpr, Sequence[Any]]],
-    num_consts: int):
-  args = [batching.moveaxis(x, d, 0) if d is not not_mapped and d != 0
-          else x for x, d in zip(args, in_dims)]
-  num_out = len(fun_jaxpr.out_avals)
-
-  in_batched = [d is not not_mapped for d in in_dims]
-  batched_fun_jaxpr, out_batched = batching.batch_jaxpr(
-      fun_jaxpr, axis_size, in_batched, False, axis_name, main_type)
-  out_dims1 = [0 if b else not_mapped for b in out_batched]
-  out_dims2 = []  # mutable cell updated by batched_jvp_jaxpr_thunk
-
-  @pe._memoize
-  def batched_jvp_jaxpr_thunk():
-    jvp_jaxpr = core.ClosedJaxpr(*jvp_jaxpr_thunk())  # consts can be tracers
-    _, args_batched = split_list(in_batched, [num_consts])
-    _, all_batched = batching.batch_jaxpr(jvp_jaxpr, axis_size, args_batched * 2, False,
-                                          axis_name, main_type)
-    primals_batched, tangents_batched = split_list(all_batched, [num_out])
-    out_batched = map(op.or_, primals_batched, tangents_batched)
-    out_dims2.append([0 if b else not_mapped for b in out_batched])
-    batched_jvp_jaxpr, _ = batching.batch_jaxpr(
-        jvp_jaxpr, axis_size, args_batched * 2, out_batched * 2,
-        axis_name, main_type)
-    return batched_jvp_jaxpr.jaxpr, batched_jvp_jaxpr.consts
-
-  batched_outs = custom_jvp_call_jaxpr_p.bind(
-      *args, fun_jaxpr=batched_fun_jaxpr,
-      jvp_jaxpr_thunk=batched_jvp_jaxpr_thunk, num_consts=num_consts)
-  out_dims = out_dims2[0] if out_dims2 else out_dims1
-  return batched_outs, out_dims
-batching.axis_primitive_batchers[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_vmap
-
-xla.register_initial_style_primitive(custom_jvp_call_jaxpr_p)
+def _custom_jvp_call_mlir_translation(ctx, *args, call_jaxpr, jvp_jaxpr_thunk,
+                                      num_consts):
+  del jvp_jaxpr_thunk, num_consts
+  args_ = map(mlir.wrap_singleton_ir_values, args)
+  consts = mlir._ir_consts(call_jaxpr.consts)
+  out, tokens = mlir.jaxpr_subcomp(ctx.module_context, call_jaxpr.jaxpr,
+                                   ctx.tokens_in, consts, *args_)
+  ctx.set_tokens_out(tokens)
+  return out
+mlir.register_lowering(custom_jvp_call_p, _custom_jvp_call_mlir_translation)
 
 # If a (multi)linear function is defined with a custom jvp, then
-# custom_jvp_call_jaxpr can appear in jaxprs to be transposed. Since it's
-# already been linearized, we can drop the jvp rule.
-def _custom_jvp_call_jaxpr_transpose(reduce_axes, cts, *args, fun_jaxpr,
-                                     jvp_jaxpr_thunk, num_consts):
-  del jvp_jaxpr_thunk, num_consts
-  return ad.backward_pass(
-      fun_jaxpr.jaxpr, reduce_axes, False, fun_jaxpr.consts, args, cts)
-ad.reducing_transposes[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_transpose
-
-def custom_jvp_jaxpr_custom_partial_eval_rule(
-    saveable: Callable[..., bool], unks_in: List[bool], inst_in: List[bool],
-    eqn: core.JaxprEqn
-  ) -> Tuple[Optional[core.JaxprEqn], core.JaxprEqn, List[bool], List[bool], List[core.Var]]:
-  # It doesn't make sense to unzip (i.e. break up) a custom_jvp function into
-  # constituent parts, so we always perform full remat. An alternative would be
-  # to allow the policy function to decide whether the value of a
-  # custom_jvp-decorated function's application should be saved or not.
-  # TODO(mattjj,jekbradbury): the user writing the custom_jvp-decorated function
-  # probably has a better idea for what to do under remat (e.g. if the function
-  # contains dots or not), so we should allow for more expressive interaction
-  # (e.g. allow the policy to depend on which custom_jvp-decorated function is
-  # being applied, or annotating the behavior where custom_vjp is called.)
-  inst_out = [True] * len(eqn.outvars)
-  new_inst = [x for x, inst in zip(eqn.invars, inst_in)
-              if type(x) is core.Var and not inst]
-  if any(unks_in):
-    unks_out = [True] * len(eqn.outvars)
-    return None, eqn, unks_out, inst_out, new_inst
-  else:
-    unks_out = [False] * len(eqn.outvars)
-    return eqn, eqn, unks_out, inst_out, new_inst
-pe.partial_eval_jaxpr_custom_rules[custom_jvp_call_jaxpr_p] = \
-    custom_jvp_jaxpr_custom_partial_eval_rule  # type: ignore
+# custom_jvp_call_ can appear in jaxprs to be transposed. Since it's already
+# been linearized, we can drop the jvp rule.
+def _custom_jvp_call_transpose(params, jaxpr, args, ct, _, reduce_axes):
+  del params
+  return ad.backward_pass(jaxpr.jaxpr, reduce_axes, None, jaxpr.consts, args, ct)
+ad.primitive_transposes[custom_jvp_call_p] = _custom_jvp_call_transpose
 
 
 ### VJPs
@@ -775,9 +720,6 @@ xla.register_initial_style_primitive(custom_vjp_call_jaxpr_p)
 
 batching.primitive_batchers[ad.custom_lin_p] = ad._raise_custom_vjp_error_on_jvp
 mlir.register_lowering(ad.custom_lin_p, ad._raise_custom_vjp_error_on_jvp)
-
-pe.partial_eval_jaxpr_custom_rules[custom_vjp_call_jaxpr_p] = \
-    custom_jvp_jaxpr_custom_partial_eval_rule  # type: ignore
 
 
 def custom_gradient(fun):

--- a/jax/core.py
+++ b/jax/core.py
@@ -500,7 +500,8 @@ def escaped_tracer_error(tracer, detail=None):
   num_frames = FLAGS.jax_tracer_error_num_traceback_frames
   msg = ('Encountered an unexpected tracer. A function transformed by JAX '
          'had a side effect, allowing for a reference to an intermediate value '
-         f'with shape {tracer.shape} and dtype {tracer.dtype} to escape.\n'
+         f'with type {tracer.aval.str_short()} wrapped in a '
+         f'{type(tracer).__name__} to escape the scope of the transformation.\n'
          'JAX transformations require that functions explicitly return their '
          'outputs, and disallow saving intermediate values to global state.')
   dbg = getattr(tracer, '_debug_info', None)

--- a/jax/custom_derivatives.py
+++ b/jax/custom_derivatives.py
@@ -20,7 +20,6 @@ from jax._src.custom_derivatives import (
   custom_gradient as custom_gradient,
   custom_jvp as custom_jvp,
   custom_jvp_call_p as custom_jvp_call_p,
-  custom_jvp_call_jaxpr_p as custom_jvp_call_jaxpr_p,
   custom_vjp as custom_vjp,
   custom_vjp_call_p as custom_vjp_call_p,
   custom_vjp_call_jaxpr_p as custom_vjp_call_jaxpr_p,

--- a/jax/experimental/callback.py
+++ b/jax/experimental/callback.py
@@ -264,9 +264,7 @@ def _custom_derivative_call_jaxpr_callback_rule(primitive, trace, *tracers,
   vals = [t.val for t in tracers]
 
   new_closed_jaxpr = callback_jaxpr(fun_jaxpr, trace.callback, strip_calls=trace.strip_calls)
-  if primitive == cd.custom_jvp_call_jaxpr_p:
-    thunk_name = 'jvp_jaxpr_thunk'
-  elif primitive == cd.custom_vjp_call_jaxpr_p:
+  if primitive == cd.custom_vjp_call_jaxpr_p:
     thunk_name = 'fwd_jaxpr_thunk'
     params['bwd'] = callback_subtrace(params['bwd'], main)
   else:
@@ -287,7 +285,5 @@ def _custom_derivative_call_jaxpr_callback_rule(primitive, trace, *tracers,
                        num_consts=new_num_consts, **params)
   return safe_map(trace.pure, out)
 
-custom_callback_rules[cd.custom_jvp_call_jaxpr_p] = partial(
-    _custom_derivative_call_jaxpr_callback_rule, cd.custom_jvp_call_jaxpr_p)
 custom_callback_rules[cd.custom_vjp_call_jaxpr_p] = partial(
     _custom_derivative_call_jaxpr_callback_rule, cd.custom_vjp_call_jaxpr_p)

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1615,8 +1615,8 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
                 # cased to just pass-through the token
                 in_axes=eqn.params["in_axes"] + (None, None),
                 out_axes=eqn.params["out_axes"] + (0, 0))))
-  elif eqn.primitive is custom_derivatives.custom_jvp_call_jaxpr_p:
-    fun_jaxpr = eqn.params["fun_jaxpr"]
+  elif eqn.primitive is custom_derivatives.custom_jvp_call_p:
+    fun_jaxpr = eqn.params["call_jaxpr"]
 
     def unreachable_thunk():
       assert False, "Should not be reached"
@@ -1627,7 +1627,7 @@ def _rewrite_eqn(eqn: core.JaxprEqn, eqns: List[core.JaxprEqn],
             outvars=eqn.outvars + [output_token_var, output_itoken_var],
             params=dict(
                 eqn.params,
-                fun_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
+                call_jaxpr=_rewrite_closed_jaxpr(fun_jaxpr, True, True),
                 jvp_jaxpr_thunk=unreachable_thunk
             )))
   elif eqn.primitive is custom_derivatives.custom_vjp_call_jaxpr_p:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -2788,14 +2788,15 @@ def _tridiagonal_solve(*args: TfVal, _in_avals, _out_aval, **params):
 
 tf_impl_with_avals[lax.linalg.tridiagonal_solve_p] = _tridiagonal_solve
 
-def _custom_jvp_call_jaxpr(*args: TfVal, fun_jaxpr: core.ClosedJaxpr,
+def _custom_jvp_call(*args: TfVal, call_jaxpr: core.ClosedJaxpr,
                            jvp_jaxpr_thunk: Callable,
                            num_consts: int) -> Sequence[TfVal]:
   # TODO(necula): ensure that there is no AD transformation in scope
-  return _interpret_jaxpr(fun_jaxpr, *args, extra_name_stack="custom_jvp")
+  del jvp_jaxpr_thunk, num_consts
+  return _interpret_jaxpr(call_jaxpr, *args, extra_name_stack="custom_jvp")
 
 
-tf_impl[custom_derivatives.custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr
+tf_impl[custom_derivatives.custom_jvp_call_p] = _custom_jvp_call
 
 
 def _custom_vjp_call_jaxpr(*args: TfVal, fun_jaxpr: core.ClosedJaxpr,

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -61,7 +61,6 @@ import numpy as np
 import jax
 from jax import core
 from jax import lax
-from jax.custom_derivatives import custom_jvp_call_jaxpr_p
 from jax.interpreters import xla
 import jax.linear_util as lu
 import jax.numpy as jnp
@@ -681,13 +680,6 @@ def _lax_min_taylor_rule(primal_in, series_in):
     series_out = [select_min_and_avg_eq(*terms_in) for terms_in in zip(*series_in)]
     return primal_out, series_out
 jet_rules[lax.min_p] = _lax_min_taylor_rule
-
-def _custom_jvp_call_jaxpr_rule(primals_in, series_in, *, fun_jaxpr,
-                                jvp_jaxpr_thunk):
-  # TODO(mattjj): do something better than ignoring custom jvp rules for jet?
-  del jvp_jaxpr_thunk
-  return jet(core.jaxpr_as_fun(fun_jaxpr), primals_in, series_in)
-jet_rules[custom_jvp_call_jaxpr_p] = _custom_jvp_call_jaxpr_rule
 
 def _scatter_add_rule(primals_in, series_in, *, update_jaxpr, update_consts,
                       dimension_numbers, indices_are_sorted, unique_indices,

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3163,8 +3163,7 @@ class APITest(jtu.JaxTestCase):
       _ = self._saved_tracer+1
 
   def test_escaped_tracer_shape_dtype(self):
-    with self.assertRaisesRegex(core.UnexpectedTracerError,
-                                r"shape \(4, 3\) and dtype int32"):
+    with self.assertRaisesRegex(core.UnexpectedTracerError, r"int32\[4,3\]"):
       jax.jit(self.helper_save_tracer)(jnp.ones((4, 3), dtype=jnp.int32))
       _ = self._saved_tracer+1
 
@@ -6642,15 +6641,15 @@ class CustomJVPTest(jtu.JaxTestCase):
     def g(x):
       return f(f(x))
 
-    ans = api.grad(api.grad(api.remat(g)))(2.)
+    ans = api.grad(api.grad(new_checkpoint(g)))(2.)
     expected = api.grad(api.grad(g))(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    ans = api.grad(api.remat(api.grad(g)))(2.)
+    ans = api.grad(new_checkpoint(api.grad(g)))(2.)
     expected = api.grad(api.grad(g))(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 
-    ans = api.grad(api.grad(api.grad(api.remat(g))))(2.)
+    ans = api.grad(api.grad(api.grad(new_checkpoint(g))))(2.)
     expected = api.grad(api.grad(api.grad(g)))(2.)
     self.assertAllClose(ans, expected, check_dtypes=False)
 


### PR DESCRIPTION
Remove custom_jvp_call_jaxpr_p and its transformation rules. They were superfluous! Instead use the new mechanism for converting from jaxpr params to bind params (in #9136).

~This PR currently includes the commit from #9136, but it should be considered as a "diffbase".~

The simplification in JaxprTrace.process_custom_jvp_call was actually made possible by omnistaging #3370, though we didn't apply it until now.

In a follow-up PR we'll delete custom_vjp_call_jaxpr_p too (or die trying). I'd like to land this one fully first to make sure this approach works (and hence ensure doing the same to custom_vjp_call_p makes sense).