### PR TITLE
add JAX_BACKEND_TARGET env var, fixes #9034

### DIFF
--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -57,7 +57,8 @@ flags.DEFINE_string(
     'jax_xla_backend', '',
     'Deprecated, please use --jax_platforms instead.')
 flags.DEFINE_string(
-    'jax_backend_target', '',
+    'jax_backend_target',
+    os.getenv('JAX_BACKEND_TARGET', '').lower(),
     'Either "local" or "rpc:address" to connect to a remote service target.')
 # TODO(skye): warn when this is used once we test out --jax_platforms a bit
 flags.DEFINE_string(


### PR DESCRIPTION
fixes #9034 (checked manually as below)

```bash
$ COLAB_TPU_ADDR=123456
$ JAX_PLATFORMS=tpu_driver JAX_BACKEND_TARGET="grpc://$COLAB_TPU_ADDR" python
>>> from jax.config import config
>>> config.FLAGS.jax_xla_backend
''
>>> config.FLAGS.jax_platforms
'tpu_driver'
>>> config.FLAGS.jax_backend_target
'grpc://123456'
```