### PR TITLE
prepare to replace/delete old remat implementation

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -400,6 +400,7 @@ def custom_jvp_jaxpr_custom_partial_eval_rule(
   # contains dots or not), so we should allow for more expressive interaction
   # (e.g. allow the policy to depend on which custom_jvp-decorated function is
   # being applied, or annotating the behavior where custom_vjp is called.)
+  del saveable
   inst_out = [True] * len(eqn.outvars)
   new_inst = [x for x, inst in zip(eqn.invars, inst_in)
               if type(x) is core.Var and not inst]

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2195,7 +2195,14 @@ xla.register_translation(scan_p, xla.lower_fun(_scan_impl, new_style=True,
 batching.axis_primitive_batchers[scan_p] = _scan_batching_rule
 masking.masking_rules[scan_p] = _scan_masking_rule
 core.custom_typechecks[scan_p] = partial(_scan_typecheck, False)
-pe.partial_eval_jaxpr_custom_rules[scan_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
+
+def _scan_partial_eval_custom_rule(saveable_policy, unks_in, inst_in, eqn):
+  if saveable_policy is ad_checkpoint.nothing_saveable:
+    return ad_checkpoint.full_remat_rule(unks_in, inst_in, eqn)
+  else:
+    raise NotImplementedError('scan partial eval for custom policies is not '
+                              'implemented. Please open a feature request!')
+pe.partial_eval_jaxpr_custom_rules[scan_p] = _scan_partial_eval_custom_rule
 
 mlir.register_lowering(scan_p,
                        mlir.lower_fun(_scan_impl, multiple_results=True))


### PR DESCRIPTION
A few months ago we wrote a new version of remat to support custom rematerialization policies. The new version is also built on a simpler basic implementation. But instead of replacing the pre-existing remat implementation, we kept both around because the new remat did not yet support higher-order primitives like scan and cond. Tech debt!

I'd like to start moving on replacing the old remat implementation, since it will enable some additional simplifications throughout the system (like #9137).

To that end, I'd like to first land a version of the new remat *which only supports standard remat policies for scan and cond*. That is, we won't yet have nonstandard remat policies which apply underneath scan and cond.

This restricted version is useful because it's a drop-in replacement for the old remat (which only supported a standard remat policy) and so it'll let us delete the old implementation and remove the tech debt.

This PR updates all remat tests to check the new remat, and also adds rules for scan and cond which work for default policies (and raise a NotImplementedError for nonstandard policies).

TODO:
* [x] remat-of-scan #10576
* [x] remat-of-cond #11651
* [ ] remat-of-while_loop
* [ ] flag which switches between implementations (first default to old impl and land everything, then switch to default to new but leave the flag in place in case of emergency, then delete flag and old impl)