### PR TITLE
de-duplicate util.memoize and util.cache

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -206,18 +206,7 @@ def cache(max_size=4096):
     return wrapper
   return wrap
 
-def memoize(f):
-  @functools.lru_cache(None)
-  def memoized(_, *args, **kwargs):
-    return f(*args, **kwargs)
-
-  @functools.wraps(f)
-  def wrapper(*args, **kwargs):
-    return memoized(config._trace_context(), *args, **kwargs)
-
-  wrapper.cache_clear = memoized.cache_clear
-  wrapper.cache_info = memoized.cache_info
-  return wrapper
+memoize = cache(max_size=None)
 
 def prod(xs):
   out = 1


### PR DESCRIPTION
The only difference between the two was that jax.config.jax_check_tracer_leaks disables the caching under util.cache but not under util.memoize.

We could add that as an option on the same function if it turns out to be important, but it seems unnecessary. Moreover there are only two callers (in dtypes.py and in batching.py).