### PR TITLE
enable custom transformation "stacking"

### DIFF
--- a/jax/_src/custom_api_util.py
+++ b/jax/_src/custom_api_util.py
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_custom_wrapper_types = set()
+
+def register_custom_decorator_type(cls):
+  _custom_wrapper_types.add(cls)
+  return cls
+
+def forward_attr(self_, name):
+  if name.startswith('def') and type(self_.fun) in _custom_wrapper_types:
+    return getattr(self_.fun, name)
+  else:
+    raise AttributeError

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -24,6 +24,7 @@ from jax import linear_util as lu
 from jax.tree_util import (tree_flatten, tree_unflatten, tree_map,
                         tree_multimap, treedef_is_leaf, treedef_tuple,
                         register_pytree_node_class)
+from jax._src import custom_api_util
 from jax._src.util import cache, safe_zip, safe_map, split_list, Unhashable
 from jax._src.api_util import flatten_fun_nokwargs, argnums_partial
 from jax.core import raise_to_shaped
@@ -81,6 +82,7 @@ def _stop_gradient(x):
 ### JVPs
 ReturnValue = TypeVar('ReturnValue')
 
+@custom_api_util.register_custom_decorator_type
 class custom_jvp(Generic[ReturnValue]):
   """Set up a JAX-transformable function for a custom JVP rule definition.
 
@@ -122,12 +124,15 @@ class custom_jvp(Generic[ReturnValue]):
   def __init__(self,
                fun: Callable[..., ReturnValue],
                nondiff_argnums: Tuple[int, ...] = ()):
+    update_wrapper(self, fun)
     self.fun = fun
     self.nondiff_argnums = nondiff_argnums
     self.jvp: Optional[Callable[..., Tuple[ReturnValue, ReturnValue]]] = None
-    update_wrapper(self, fun)
 
-  def defjvp(self, jvp: Callable[..., Tuple[ReturnValue, ReturnValue]]) -> None:
+  __getattr__ = custom_api_util.forward_attr
+
+  def defjvp(self, jvp: Callable[..., Tuple[ReturnValue, ReturnValue]]
+    ) -> Callable[..., Tuple[ReturnValue, ReturnValue]]:
     """Define a custom JVP rule for the function represented by this instance.
 
     Args:
@@ -158,6 +163,7 @@ class custom_jvp(Generic[ReturnValue]):
         return primal_out, tangent_out
     """
     self.jvp = jvp
+    return jvp
 
   def defjvps(self, *jvps: Optional[Callable[..., ReturnValue]]):
     """Convenience wrapper for defining JVPs for each argument separately.
@@ -415,6 +421,7 @@ pe.partial_eval_jaxpr_custom_rules[custom_jvp_call_jaxpr_p] = \
 
 ### VJPs
 
+@custom_api_util.register_custom_decorator_type
 class custom_vjp(Generic[ReturnValue]):
   """Set up a JAX-transformable function for a custom VJP rule definition.
 
@@ -452,11 +459,13 @@ class custom_vjp(Generic[ReturnValue]):
   def __init__(self,
                fun: Callable[..., ReturnValue],
                nondiff_argnums: Tuple[int, ...] = ()):
+    update_wrapper(self, fun)
     self.fun = fun
     self.nondiff_argnums = nondiff_argnums
     self.fwd: Optional[Callable[..., Tuple[ReturnValue, Any]]] = None
     self.bwd: Optional[Callable[..., Tuple[Any, ...]]] = None
-    update_wrapper(self, fun)
+
+  __getattr__ = custom_api_util.forward_attr
 
   def defvjp(self,
              fwd: Callable[..., Tuple[ReturnValue, Any]],

--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -24,6 +24,7 @@ from jax.interpreters import xla
 from jax.tree_util import (tree_flatten, tree_leaves, tree_unflatten,
                            treedef_tuple)
 from jax._src import ad_util
+from jax._src import custom_api_util
 from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src import util
@@ -38,14 +39,17 @@ map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
 
+@custom_api_util.register_custom_decorator_type
 class custom_transpose:
   fun: Callable
   transpose: Optional[Callable]
 
   def __init__(self, fun: Callable):
+    functools.update_wrapper(self, fun)
     self.fun = fun  # type: ignore[assignment]
     self.transpose = None
-    functools.update_wrapper(self, fun)
+
+  __getattr__ = custom_api_util.forward_attr
 
   def def_transpose(self, transpose: Callable):
     self.transpose = transpose


### PR DESCRIPTION
Make custom transformation wrappers such as `custom_jvp` behave interchangeably when directly composed. For example, enable the following usage:

```python
@custom_jvp
@custom_transpose
def solve(A, b): ...

@solve.def_transpose
def solve_transpose(A, x): return solve(A.T, x)

@solve.defjvp
def solve_jvp(primals, tangents): ...
```

In particular:

* Forward `def*` methods on custom transformations.
* Have unary `def*` methods return their argument so that, when used as decorators, they do not replace their target with `None`.
* Fix a bug in the use of `functools.update_wrapper`: previously a wrapper would overwrite its own attributes with those of the target callable (including its reference to the target callable).