### PR TITLE
jax2tf: Small fix for backprop through functions using bfloat16

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -389,7 +389,7 @@ def convert(fun: Callable,
 
         in_cts_flat_jax, in_cts_tree = tree_util.tree_flatten(in_cts_jax)
         def fix_in_ct(in_ct, arg_aval: core.ShapedArray):
-          if np.issubdtype(arg_aval.dtype, np.inexact):
+          if jnp.issubdtype(arg_aval.dtype, jnp.inexact):
             return in_ct
           else:
             assert in_ct.dtype == dtypes.float0

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -155,7 +155,7 @@ class Jax2TfTest(tf_test_util.JaxToTfTestCase):
     f_jax = lambda a, b: (a + b).astype(jnp.bfloat16)
     f_tf = jax2tf.convert(f_jax)
     self.assertEqual(f_tf(1., 2.).dtype, tf.bfloat16)
-    
+
   @jtu.skip_on_devices("gpu")
   def test_bfloat16_tf_grad(self):
     f_jax = lambda a, b: a + b


### PR DESCRIPTION
np.issubdtype excludes bfloat16, so I believe jnp.issubdtype is more appropriate here.