### PR TITLE
cache tracing of (sub)calls when forming a jaxpr

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -62,9 +62,6 @@ def _initial_style_jaxpr(fun, in_avals):
 def _close_jaxpr(jaxpr):
   return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
 
-def _initial_style_staging() -> bool:
-  return core.thread_local_state.trace_state.initial_style
-
 def _sum_tangents(_, x, *xs):
   return reduce(ad.add_tangents, xs, x)
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6775,8 +6775,6 @@ def _multi_slice(arr,
                  start_indices: Tuple[Tuple[int, ...]],
                  limit_indices: Tuple[Tuple[int, ...]],
                  removed_dims: Tuple[Tuple[int, ...]]):
-  print(core.thread_local_state.trace_state.axis_env)
-  breakpoint()
   """Extracts multiple slices from `arr`.
 
   This is used to shard DeviceArray arguments to pmap. It's implemented as a

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6769,6 +6769,7 @@ def _compress_method(a, condition, axis=None, out=None):
   return compress(condition, a, axis, out)
 
 
+@core.stash_axis_env()
 @partial(jit, static_argnums=(1,2,3))
 def _multi_slice(arr,
                  start_indices: Tuple[Tuple[int, ...]],

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6775,6 +6775,8 @@ def _multi_slice(arr,
                  start_indices: Tuple[Tuple[int, ...]],
                  limit_indices: Tuple[Tuple[int, ...]],
                  removed_dims: Tuple[Tuple[int, ...]]):
+  print(core.thread_local_state.trace_state.axis_env)
+  breakpoint()
   """Extracts multiple slices from `arr`.
 
   This is used to shard DeviceArray arguments to pmap. It's implemented as a

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -199,7 +199,7 @@ def cache(max_size=4096):
       if config.jax_check_tracer_leaks:
         return f(*args, **kwargs)
       else:
-        return cached(config._trace_context(), *args, **kwargs)
+        return cached(config.get_thread_local_trace_state(), *args, **kwargs)
 
     wrapper.cache_clear = cached.cache_clear
     wrapper.cache_info = cached.cache_info

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -625,6 +625,7 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
 
   # The freevars are being fanned out (not mapped). During transpose the
   # dual of fan-out is fan-in-sum. We apply it to the unmapped invars.
+  # TODO(mattjj,jekbradbury): should this look at global_axis_size?
   assert len(in_axes) == len(arg_cts)
   def unmap_zero(zero, in_axis):
     return (zero if in_axis is None else

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -260,10 +260,10 @@ def cache(call: Callable):
     cache = fun_caches.setdefault(fun.f, {})
     if config.jax_check_tracer_leaks:
       key = (_copy_main_traces(fun.transforms), fun.params, args,
-             config.x64_enabled, config._trace_context())
+             config.get_thread_local_trace_state())
     else:
-      key = (fun.transforms, fun.params, args, config.x64_enabled,
-             config._trace_context())
+      key = (fun.transforms, fun.params, args,
+             config.get_thread_local_trace_state())
     result = cache.get(key, None)
     if result is not None:
       ans, stores = result

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1260,7 +1260,6 @@ class APITest(jtu.JaxTestCase):
     self.assertEqual(fwd(rev(f, 0), 1)(x, u).shape, (5, 2))
     self.assertEqual(fwd(fwd(f, 0), 1)(x, u).shape, (5, 2))
 
-
   def test_large_device_constant(self):
     ans = jit(lambda x: 2 * x)(jnp.ones(int(2e6)))  # doesn't crash
     self.assertAllClose(ans, np.ones(int(2e6)) * 2., check_dtypes=False)
@@ -3322,6 +3321,49 @@ class APITest(jtu.JaxTestCase):
       api.make_jaxpr(lambda: jnp.array(3))()
     self.assertEqual(count[0], 0)
 
+  def test_subcall_trace_caching(self):
+    should_be_tracing_f = False
+
+    @api.jit
+    def f(x):
+      self.assertTrue(should_be_tracing_f)
+      return x ** 2
+
+    @api.jit
+    def g(x):
+      nonlocal should_be_tracing_f
+      self.assertTrue(should_be_tracing_g)
+      should_be_tracing_f = True
+      y = f(x)
+      should_be_tracing_f = False
+      z = f(x + 1)
+      return y + z
+
+    should_be_tracing_g = True
+    out = g(2)
+    self.assertEqual(out, 13)
+
+    should_be_tracing_g = False
+    out = g(3)
+    self.assertEqual(out, 25)
+
+  def test_subcall_jaxpr_id(self):
+    @api.jit
+    def f(x):
+      return x ** 2
+
+    def g(x):
+      y = f(x)
+      z = f(x + 1)
+      return y + z
+
+    jaxpr = api.make_jaxpr(g)(2)
+    self.assertIn('call_jaxpr', jaxpr.eqns[0].params)
+    self.assertIn('call_jaxpr', jaxpr.eqns[2].params)
+    subjaxpr1 = jaxpr.eqns[0].params['call_jaxpr']
+    subjaxpr2 = jaxpr.eqns[2].params['call_jaxpr']
+    self.assertIs(subjaxpr1, subjaxpr2)
+
 
 class RematTest(jtu.JaxTestCase):
 
@@ -3776,7 +3818,7 @@ class RematTest(jtu.JaxTestCase):
         return seq[0]
 
       remat(g)()
-      remat(g)()
+      remat(lambda: g())()  # lambda defeats caching
 
     with self.assertRaisesRegex(UnexpectedTracerError, "global state"):
       api.jit(f)()

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2908,5 +2908,15 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return lax.while_loop(cond, body, (i, jnp.ones(3)))[1]
     jax.vmap(f, in_axes=(0, 1))(jnp.arange(4), jnp.ones((3, 4)))
 
+  def test_caches_depend_on_axis_env(self):
+    # https://github.com/google/jax/issues/9187
+    scanned_f = lambda _, __: (lax.psum(1, 'i'), None)
+    f = lambda: lax.scan(scanned_f, 0, None, length=1)[0]
+    ans = jax.vmap(f, axis_name='i', axis_size=2, out_axes=None)()
+    self.assertEqual(ans, 2)
+    ans = jax.vmap(f, axis_name='i', axis_size=3, out_axes=None)()
+    self.assertEqual(ans, 3)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1880,8 +1880,9 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertEqual(count[0], 2)  # one for fwd, one for bwd
 
     with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
-      _  = jax.vjp(f, x)
+      _, f_bwd2 = jax.vjp(f, x)
       _ = f_bwd(x)
+      _ = f_bwd2(x)
     self.assertEqual(count[0], 0)  # cache hits on fwd and bwd
 
   @unittest.skipIf(jax._src.lib._xla_extension_version < 44,

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1877,7 +1877,7 @@ class PythonPmapTest(jtu.JaxTestCase):
     with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
       _, f_bwd  = jax.vjp(f, x)
       _ = f_bwd(x)
-    self.assertEqual(count[0], 2)  # one for fwd, one for bwd
+    self.assertEqual(count[0], 2)  # once for fwd, once for bwd
 
     with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
       _, f_bwd2 = jax.vjp(f, x)


### PR DESCRIPTION
cc @hawkinsp 

currently includes changes from #9188 

The main motivations here are:
1. reduce trace times (by not retracing functions to a jaxpr when we can just look up the result in a cache), and
2. reduce compilation times by lowering outlined (as opposed to inlined) functions to our compiler targets.

This PR on its own tackles (1) but not (2). It sets us up for (2) because subjaxprs are now identical Python objects when we trace to a jaxpr, and so we can have have lowerings which are themselves memoized on (sub)jaxpr object id or alternatively we can have an early pass to produce a `JaxprModule` with explicit outlined functions. The latter seems more robust and clearer.

fixes #7155

TODO:
* [ ] traceback surgery for source info (that's the last failing test)