### PR TITLE
add axis env state to cache keys, fixes #9187

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -21,7 +21,7 @@ import itertools
 import os
 import sys
 import threading
-from typing import Any, List, Callable, NamedTuple, Optional
+from typing import Any, List, Callable, NamedTuple, Optional, Hashable
 import warnings
 
 from jax._src import lib
@@ -324,15 +324,8 @@ class Config:
 
     return _StateContextManager(name, help, update_thread_local_hook, validate)
 
-  def _trace_context(self):
-    """Returns a tuple of configuration values that affect tracing.
-
-    These values are included in the cache key for linear_util.cache.
-
-    Values included in this set should also most likely be included in
-    the C++ JIT state, which is handled separately."""
-    return (self.x64_enabled, self.jax_numpy_rank_promotion,
-            self.jax_default_matmul_precision)
+  def get_trace_state(self):
+    return get_trace_state()
 
 class _StateContextManager:
   def __init__(self, name, help, update_thread_local_hook,
@@ -405,7 +398,7 @@ already_configured_with_absl = False
 
 class GlobalJitState(NamedTuple):
   numpy_rank_promotion: Optional[str] = None
-  default_matmul_precision: Optional[Any] = None
+  default_matmul_precision: Optional[Hashable] = None
 
 
 def update_global_jit_state(**kw):
@@ -415,15 +408,27 @@ def update_global_jit_state(**kw):
 
 
 class ThreadLocalJitState(NamedTuple):
-  dynamic_trace_state: Optional[Any] = None
+  dynamic_trace_state: Optional[Hashable] = None
+  axis_env_state: Optional[Hashable] = None
   numpy_rank_promotion: Optional[str] = None
-  default_matmul_precision: Optional[Any] = None
+  default_matmul_precision: Optional[Hashable] = None
 
 
 def update_thread_local_jit_state(**kw):
   tls = jax_jit.thread_local_state()
   context = tls.extra_jit_context or ThreadLocalJitState()
   tls.extra_jit_context = context._replace(**kw)
+
+
+def get_trace_state() -> Hashable:
+  # This function is used for Python-based caching (as opposed to caching in C++
+  # dispatch code). It reads the axis_env_state from the C++ thread-local state,
+  # but gets everything else off the config object, which reflects the
+  # appropriate unification of global and thread-local settings.
+  tls = jax_jit.thread_local_state()
+  ctx = tls.extra_jit_context or ThreadLocalJitState()
+  return (ctx.axis_env_state, config.jax_enable_x64, config.jax_disable_jit,
+          config.jax_numpy_rank_promotion, config.jax_default_matmul_precision)
 
 
 # TODO(mattjj): remove all uses of this flag

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -21,7 +21,7 @@ import itertools
 import os
 import sys
 import threading
-from typing import Any, List, Callable, NamedTuple, Optional, Hashable
+from typing import Any, List, Callable, NamedTuple, Optional, Hashable, Tuple
 import warnings
 
 from jax._src import lib
@@ -409,7 +409,7 @@ def update_global_jit_state(**kw):
 
 class ThreadLocalJitState(NamedTuple):
   dynamic_trace_state: Optional[Hashable] = None
-  axis_env_state: Optional[Hashable] = None
+  axis_env_state: Tuple[Hashable, ...] = ()
   numpy_rank_promotion: Optional[str] = None
   default_matmul_precision: Optional[Hashable] = None
 
@@ -422,8 +422,9 @@ def update_thread_local_jit_state(**kw):
 
 def get_trace_state() -> Hashable:
   # This function is used for Python-based caching (as opposed to caching in C++
-  # dispatch code). It reads the axis_env_state from the C++ thread-local state,
-  # but gets everything else off the config object, which reflects the
+  # dispatch code). It reads the axis_env_state from the C++ thread-local state
+  # (because there is no process-global axis environment, just a thread-local
+  # one), but gets everything else off the config object, which reflects the
   # appropriate unification of global and thread-local settings.
   tls = jax_jit.thread_local_state()
   ctx = tls.extra_jit_context or ThreadLocalJitState()

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -62,9 +62,6 @@ def _initial_style_jaxpr(fun, in_avals):
 def _close_jaxpr(jaxpr):
   return core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
 
-def _initial_style_staging() -> bool:
-  return core.thread_local_state.trace_state.initial_style
-
 def _sum_tangents(_, x, *xs):
   return reduce(ad.add_tangents, xs, x)
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -6769,6 +6769,7 @@ def _compress_method(a, condition, axis=None, out=None):
   return compress(condition, a, axis, out)
 
 
+@core.stash_axis_env()
 @partial(jit, static_argnums=(1,2,3))
 def _multi_slice(arr,
                  start_indices: Tuple[Tuple[int, ...]],

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -199,7 +199,7 @@ def cache(max_size=4096):
       if config.jax_check_tracer_leaks:
         return f(*args, **kwargs)
       else:
-        return cached(config._trace_context(), *args, **kwargs)
+        return cached(config.get_trace_state(), *args, **kwargs)
 
     wrapper.cache_clear = cached.cache_clear
     wrapper.cache_info = cached.cache_info

--- a/jax/core.py
+++ b/jax/core.py
@@ -1853,33 +1853,40 @@ aval_mapping_handlers: Dict[Type, AvalMapHandlerPair] = {
 @contextmanager
 def extend_axis_env(axis_name: AxisName, size: int, tag: Any):
   frame = AxisEnvFrame(axis_name, size, tag)
-  thread_local_state.trace_state.axis_env.append(frame)
+  ts = thread_local_state.trace_state
+  ts.axis_env.append(frame)
   jax_config.update_thread_local_jit_state(
-      axis_env_state=tuple(thread_local_state.trace_state.axis_env))
+      axis_env_state=tuple(f for f in ts.axis_env
+                           if f.name is not no_axis_name))
   try:
     yield
   finally:
-    thread_local_state.trace_state.axis_env.pop()
+    ts.axis_env.pop()
     jax_config.update_thread_local_jit_state(
-        axis_env_state=tuple(thread_local_state.trace_state.axis_env))
+        axis_env_state=tuple(f for f in ts.axis_env
+                             if f.name is not no_axis_name))
 
 @contextmanager
 def extend_axis_env_nd(axes: Iterable[Tuple[AxisName, int]]):
   frames = [AxisEnvFrame(axis_name, size, None) for axis_name, size in axes]
-  thread_local_state.trace_state.axis_env.extend(frames)
+  ts = thread_local_state.trace_state
+  ts.axis_env.extend(frames)
   jax_config.update_thread_local_jit_state(
-      axis_env_state=tuple(thread_local_state.trace_state.axis_env))
+      axis_env_state=tuple(f for f in ts.axis_env
+                           if f.name is not no_axis_name))
   try:
     yield
   finally:
-    for _ in frames:
-      thread_local_state.trace_state.axis_env.pop()
+    for _ in frames: ts.axis_env.pop()
     jax_config.update_thread_local_jit_state(
-        axis_env_state=tuple(thread_local_state.trace_state.axis_env))
+        axis_env_state=tuple(f for f in ts.axis_env
+                             if f.name is not no_axis_name))
 
 @contextmanager
 def stash_axis_env():
   "Promise that a function or with-suite does not depend implicitly on axis env"
+  # If the promise is broken, then a NameError about an unbound axis name will
+  # be raised.
   s = thread_local_state.trace_state
   prev_axis_env, s.axis_env = s.axis_env, []
   jax_config.update_thread_local_jit_state(axis_env_state=())

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -625,6 +625,7 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
 
   # The freevars are being fanned out (not mapped). During transpose the
   # dual of fan-out is fan-in-sum. We apply it to the unmapped invars.
+  # TODO(mattjj,jekbradbury): should this look at global_axis_size?
   assert len(in_axes) == len(arg_cts)
   def unmap_zero(zero, in_axis):
     return (zero if in_axis is None else

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -260,10 +260,10 @@ def cache(call: Callable):
     cache = fun_caches.setdefault(fun.f, {})
     if config.jax_check_tracer_leaks:
       key = (_copy_main_traces(fun.transforms), fun.params, args,
-             config.x64_enabled, config._trace_context())
+             config.get_trace_state())
     else:
-      key = (fun.transforms, fun.params, args, config.x64_enabled,
-             config._trace_context())
+      key = (fun.transforms, fun.params, args,
+             config.get_trace_state())
     result = cache.get(key, None)
     if result is not None:
       ans, stores = result

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -841,6 +841,15 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     ans      = jax.vmap(g, axis_name='i', axis_size=3, out_axes=None)()
     self.assertEqual(ans, expected)
 
+  def test_caches_dont_depend_on_unnamed_axis_env(self):
+    # https://github.com/google/jax/issues/9187
+    f = jax.jit(lambda: jnp.sin(1))
+    expected = f()
+    with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
+      ans = jax.vmap(f, axis_size=2, out_axes=None)()
+    self.assertEqual(count[0], 0)  # no compiles
+    self.assertArraysAllClose(ans, expected, check_dtypes=True)
+
 
 class PythonJitTest(CPPJitTest):
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2908,5 +2908,15 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return lax.while_loop(cond, body, (i, jnp.ones(3)))[1]
     jax.vmap(f, in_axes=(0, 1))(jnp.arange(4), jnp.ones((3, 4)))
 
+  def test_caches_depend_on_axis_env(self):
+    # https://github.com/google/jax/issues/9187
+    scanned_f = lambda _, __: (lax.psum(1, 'i'), None)
+    f = lambda: lax.scan(scanned_f, 0, None, length=1)[0]
+    ans = jax.vmap(f, axis_name='i', axis_size=2, out_axes=None)()
+    self.assertEqual(ans, 2)
+    ans = jax.vmap(f, axis_name='i', axis_size=3, out_axes=None)()
+    self.assertEqual(ans, 3)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -1880,8 +1880,9 @@ class PythonPmapTest(jtu.JaxTestCase):
     self.assertEqual(count[0], 2)  # one for fwd, one for bwd
 
     with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
-      _  = jax.vjp(f, x)
+      _, f_bwd2 = jax.vjp(f, x)
       _ = f_bwd(x)
+      _ = f_bwd2(x)
     self.assertEqual(count[0], 0)  # cache hits on fwd and bwd
 
   @unittest.skipIf(jax._src.lib._xla_extension_version < 44,


### PR DESCRIPTION
fixes #9187 

This change could cause some new and even unnecessary cache misses. That is, while the cache hits in #9187 were buggy and should be cache misses, to correct them we may end up being overly defensive.

The reason for defensiveness is that in general, even for a fixed sequence of input abstract values to a jitted function, whenever the named axis environment (which represents the mapped-over names bound by `vmap`, `pmap`, and/or `xmap`) is different from one we've seen before with those input abstract values, we need to re-trace the Python callable. That's because the Python callable could bind a collective like `psum` or `axis_index`, and the result of such a collective depends on the axis environment. (When a mapped axis has no name, i.e. when its name is `core.no_axis_name`, this error can't happen. So for caching purposes unnamed axes can be ignored.)

But some Python callables may not involve collectives at all! It'd be a waste to re-trace those. One such instance arose in this PR: the `_multi_slice` function, which is used in `pmap` dispatch, was getting re-traced (and re-compiled) even though it binds no collective primitives. So I introduced a low-level way to, in effect, promise that no collectives are bound: use `core.stash_axis_env` to temporarily empty out the axis environment and thus effectively ignore its value.

Still, this issue could arise in user code... is the only option to provide such a "promise" API to users?

TODO:
* [ ] wrap (almost) all jax.numpy functions in `core.stash_axis_env` (tried this and ran into a weird `__doc__` issue...)