### PR TITLE
make `xla_executable` a property, consistent across executable types

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -571,15 +571,15 @@ class Compiled:
     representation of the program after such passes, whenever
     possible.
     """
-    return self._executable.xla_executable().hlo_modules()
+    return self._executable.xla_executable.hlo_modules()
 
   def runtime_executable(self):
-    return self._executable.xla_executable()
+    return self._executable.xla_executable
 
   def _xla_executable(self):
     # TODO(frostig): finalize API. For now, return the underlying
     # executable directly via this method.
-    return self._executable.xla_executable()
+    return self._executable.xla_executable
 
   def __call__(self, *args, **kwargs):
     if self._no_kwargs:

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -622,6 +622,7 @@ class XlaCompiledComputation:
   def is_trivial(self):
     return self._xla_executable == None
 
+  @property
   def xla_executable(self):
     if self.is_trivial():
       raise ValueError("A trivial compiled computation has no XLA executable")

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -844,6 +844,20 @@ class CPPJitTest(jtu.BufferDonationTestCase):
         "for a particular signature. Detected .*BatchTracer",
         err)
 
+  def test_jit_lower_compiler_ir(self):
+    f = self.jit(lambda x: x + 4).lower(1.)
+    self.assertIsNotNone(f.compiler_ir())
+    self.assertIsNotNone(f.compiler_ir(dialect='hlo'))
+    self.assertIsNotNone(f.compiler_ir(dialect='mhlo'))
+
+  def test_jit_lower_compile_compiler_ir(self):
+    f = self.jit(lambda x: x + 4).lower(1.).compile()
+    self.assertIsNotNone(f.compiler_ir())
+
+  def test_jit_lower_compile_executable(self):
+    f = self.jit(lambda x: x + 4).lower(1.).compile()
+    self.assertIsNotNone(f.runtime_executable())
+
   @unittest.skipIf(xla_extension_version < 45, "requires jaxlib >= 0.1.75")
   def test_jit_enum_as_dict_keys_fails(self):
     class E(enum.Enum):

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -218,6 +218,29 @@ class PythonPmapTest(jtu.JaxTestCase):
     ans = f_exe(x, y)
     self.assertAllClose(ans, expected)
 
+  def testLowerCompilerIR(self):
+    f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
+    shape = (jax.device_count(), 4)
+    x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
+    f = f.lower(x)
+    self.assertIsNotNone(f.compiler_ir())
+    self.assertIsNotNone(f.compiler_ir(dialect='hlo'))
+    self.assertIsNotNone(f.compiler_ir(dialect='mhlo'))
+
+  def testLowerCompileCompilerIR(self):
+    f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
+    shape = (jax.device_count(), 4)
+    x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
+    f = f.lower(x).compile()
+    self.assertIsNotNone(f.compiler_ir())
+
+  def testLowerCompileExecutable(self):
+    f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
+    shape = (jax.device_count(), 4)
+    x = np.arange(prod(shape), dtype=np.float32).reshape(shape)
+    f = f.lower(x).compile()
+    self.assertIsNotNone(f.runtime_executable())
+
   def testMean(self):
     f = self.pmap(lambda x: x - lax.pmean(x, 'i'), axis_name='i')
 

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -660,6 +660,26 @@ class XMapTest(XMapTestCase):
         "called with:\n.*int32.*",
         lambda: f_exe(x_i32))
 
+  def testLowerCompilerIR(self):
+    f = xmap(lambda x: x + 4, in_axes=['i', ...], out_axes=['i', ...])
+    x = jnp.arange(4, dtype=jnp.float32).reshape((2, 2))
+    f = f.lower(x)
+    self.assertIsNotNone(f.compiler_ir())
+    self.assertIsNotNone(f.compiler_ir(dialect='hlo'))
+    self.assertIsNotNone(f.compiler_ir(dialect='mhlo'))
+
+  def testLowerCompileCompilerIR(self):
+    f = xmap(lambda x: x + 4, in_axes=['i', ...], out_axes=['i', ...])
+    x = jnp.arange(4, dtype=jnp.float32).reshape((2, 2))
+    f = f.lower(x).compile()
+    self.assertIsNotNone(f.compiler_ir())
+
+  def testLowerCompileExecutable(self):
+    f = xmap(lambda x: x + 4, in_axes=['i', ...], out_axes=['i', ...])
+    x = jnp.arange(4, dtype=jnp.float32).reshape((2, 2))
+    f = f.lower(x).compile()
+    self.assertIsNotNone(f.runtime_executable())
+
   def testNewCheckpoint(self):
     f = checkpoint(xmap(lambda x: x, in_axes=['i', ...], out_axes=['i', ...]))
     self.assertAllClose(jax.grad(lambda x: f(x).sum())(jnp.arange(3.)), jnp.ones(3))


### PR DESCRIPTION
Also test IR and executable-related methods of `Lowered` and `Compiled`.

fixes #9192