### PR TITLE
Update contributing.md with OS X instructions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,6 +42,15 @@ Follow these steps to contribute code:
    pip install -r build/test-requirements.txt  # Installs all testing requirements.
    pip install -e .[cpu]  # Installs JAX from the current directory in editable mode.
    ```
+   
+
+   *Note*: if you're using [zsh](https://en.wikipedia.org/wiki/Z_shell) on OS X and
+   the command `pip install -e .[cpu]` fails with the error
+   `zsh: no matches found: .[cpu]`, try running `pip install -e ."[cpu]"` instead.
+
+   zsh uses brackets for
+   [globbing](https://en.wikipedia.org/wiki/Glob_(programming)). Using quotes
+   causes zsh to pass the string as an arg to pip rather than globbing.
 
 4. Add the JAX repo as an upstream remote, so you can use it to sync your
    changes.


### PR DESCRIPTION
Hi! I'm following the instructions [here](https://jax.readthedocs.io/en/latest/contributing.html) to install JAX on my local machine for contributing (OS X), and I ran into an issue running one of the pip commands for installation. Specifically, running
`pip install -e .[cpu]` causes an issue because zsh, the default shell on OS X, uses square brackets as part of the [globbing syntax](https://zsh.sourceforge.io/Guide/zshguide05.html#l137).

So, I modified the docs with a note indicating a fix for that I've tested on my machine.

Feel free to reject this PR if contributing to JAX isn't supported on OS X for whatever reason.
