### PR TITLE
cache initial-style jaxpr transformations

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -27,8 +27,8 @@ from jax.core import (Trace, Tracer, get_aval, call_p, Primitive, Literal,
                     raise_to_shaped)
 from jax._src.ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval,
                               zeros_like_aval, zeros_like_p, Zero)
-from jax._src.util import (unzip2, safe_map, safe_zip, split_list,
-                         wrap_name, as_hashable_function)
+from jax._src.util import (unzip2, safe_map, safe_zip, split_list, wrap_name,
+                           as_hashable_function, cache)
 from jax.tree_util import register_pytree_node
 from jax import linear_util as lu
 from jax._src.api_util import flatten_fun, flatten_fun_nokwargs
@@ -637,6 +637,11 @@ def map_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
 
 
 def jvp_jaxpr(jaxpr, nonzeros, instantiate):
+  inst = tuple(instantiate) if isinstance(instantiate, list) else instantiate
+  return _jvp_jaxpr(jaxpr, tuple(nonzeros), inst)
+
+@cache()
+def _jvp_jaxpr(jaxpr, nonzeros, instantiate):
   assert len(jaxpr.in_avals) == len(nonzeros)
   f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
   f_jvp, out_nonzeros = f_jvp_traceable(jvp(f, instantiate=instantiate), nonzeros)

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -28,7 +28,7 @@ from jax._src.ad_util import (add_jaxvals, add_jaxvals_p, zeros_like_jaxval,
 from jax import linear_util as lu
 from jax._src.util import (unzip2, safe_map, safe_zip, wrap_name, split_list,
                            canonicalize_axis, moveaxis, as_hashable_function,
-                           curry, memoize)
+                           curry, memoize, cache)
 from jax.interpreters import partial_eval as pe
 
 map = safe_map
@@ -411,7 +411,15 @@ def batch_subtrace(main, in_dims, *in_vals):
 
 ### API for batching jaxprs
 
-def batch_jaxpr(closed_jaxpr, axis_size, in_batched, instantiate, axis_name, main_type):
+def batch_jaxpr(closed_jaxpr, axis_size, in_batched, instantiate, axis_name,
+                main_type):
+  inst = tuple(instantiate) if isinstance(instantiate, list) else instantiate
+  return _batch_jaxpr(closed_jaxpr, axis_size, tuple(in_batched), inst,
+                      axis_name, main_type)
+
+@cache()
+def _batch_jaxpr(closed_jaxpr, axis_size, in_batched, instantiate, axis_name,
+                 main_type):
   assert (isinstance(instantiate, bool) or
           isinstance(instantiate, (list, tuple)) and
           all(isinstance(b, bool) for b in instantiate))

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -723,6 +723,11 @@ def partial_eval_jaxpr(jaxpr: ClosedJaxpr, unknowns: Sequence[bool],
   to obtain the full outputs once `jaxpr_unknown` is ran. Outputs known ahead of time will
   simply get passed as residual constants and returned immediately.
   """
+  instantiate = tuple(instantiate) if isinstance(instantiate, list) else instantiate
+  return _partial_eval_jaxpr(jaxpr, tuple(unknowns), instantiate)
+
+@cache()
+def _partial_eval_jaxpr(jaxpr, unknowns, instantiate):
   f = lu.wrap_init(core.jaxpr_as_fun(jaxpr))
 
   cell = []


### PR DESCRIPTION
These changes reduce the tracing time on [the shoyer version](https://github.com/google/jax/issues/3847#issuecomment-702845696) of the code in #3847 from ~50s to ~2.5s.

~I'm a little wary to add more caching until we land #9188 to fix #9187.~ But otherwise this is straightforward!

I think we can say this fixes #3847, though there's a lot more improvement we could make in this area.