### PR TITLE
custom vmap: abstract eval and translation

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -985,6 +985,7 @@ tf_not_yet_impl = [
     "all_to_all",
     "create_token",
     "custom_transpose_call",
+    "custom_vmap_call",
     "infeed",
     "linear_call",
     "outfeed",


### PR DESCRIPTION
Also fix and test a tree-flattening bug in the custom_vmap batching rule.

Part of #9073.