### PR TITLE
Extend .compiler_ir() to accept kwargs controlling IR emission.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -521,10 +521,23 @@ class Lowered:
         self._lowering.compile(), self.in_tree, self.out_tree,
         self.donate_argnums, self._no_kwargs)
 
-  def compiler_ir(self, dialect: Optional[str] = None):
+  def compiler_ir(self, dialect: Optional[str] = None, **kwargs):
+    """Gets compiler IR of a specified 'dialect'
+
+    Args:
+      dialect: One of 'mhlo' or 'hlo' (or None for 'hlo').
+      **kwargs: Dialect specific keyword arguments:
+        'hlo': None
+        'mhlo': Keyword arguments match the MLIR Operation.print() method.
+
+    Returns:
+      A dialect specific representation.
+    """
     if dialect == "mhlo":
-      return self._lowering.mhlo()
+      return self._lowering.mhlo(**kwargs)
     elif dialect == "hlo" or dialect is None:
+      if kwargs:
+        raise TypeError(f"Unsupported keyword arguments: {kwargs.keys()}")
       return self._lowering.hlo()
     else:
       raise ValueError(f"Unknown dialect {dialect}")

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -510,12 +510,16 @@ class XlaComputation:
         mlir.module_to_string(self._hlo),
         use_tuple_args=self.compile_args["tuple_args"])
 
-  def mhlo(self) -> str:
+  def mhlo(self, *, binary=False, enable_debug_info=True,
+           print_generic_op_form=False) -> Union[str, bytes]:
     if self.is_trivial():
       raise ValueError("A trivial computation has no MHLO")
     if isinstance(self._hlo, xc.XlaComputation):
       return xe.mlir.xla_computation_to_mlir_module(self._hlo)
-    return mlir.module_to_string(self._hlo)
+    return mlir.module_to_string(
+        self._hlo, binary=binary,
+        enable_debug_info=enable_debug_info,
+        print_generic_op_form=print_generic_op_form)
 
   def compile(self) -> 'XlaCompiledComputation':
     if self._executable is None:

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -405,10 +405,16 @@ def lower_jaxpr_to_module(
   ctx.module.operation.verify()
   return ctx.module
 
-def module_to_string(module: ir.Module) -> str:
-  output = io.StringIO()
-  module.operation.print(file=output, enable_debug_info=True,
-                         print_generic_op_form=False)
+def module_to_string(module: ir.Module, *,
+    binary: bool = False, enable_debug_info: bool = True,
+    print_generic_op_form: bool = False) -> Union[bytes, str]:
+  if binary:
+    output = io.BytesIO()
+  else:
+    output = io.StringIO()
+  module.operation.print(file=output, binary=binary,
+                         enable_debug_info=enable_debug_info,
+                         print_generic_op_form=print_generic_op_form)
   return output.getvalue()
 
 def _set_up_aliases(avals_in, avals_out, donated_args):


### PR DESCRIPTION
As a user of this API, is important to have access to 'binary=', 'enable_debug_info=', and 'print_generic_op_form=' as different tasks and integrations call for different things (i.e. 'binary=' saves time/space on large programs, 'print_generic_op_form=' is more compatible with tooling to ensure compatibility, etc).

I debated just having it return a live Module object, but I think it is still wise for the moment to keep this API narrow, and that would be a large expansion.