### PR TITLE
Eliminate redundancies in jax.scipy.linalg.expm

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -294,15 +294,15 @@ def _calc_P_Q(A):
    A = A / 2**n_squarings
    conds = jnp.array([1.495585217958292e-002, 2.539398330063230e-001,
                       9.504178996162932e-001, 2.097847961257068e+000, jnp.inf])
-   idx = jnp.argmax(A_L1 < conds)
-   U, V = lax.switch(idx, [_pade3, _pade5, _pade7, _pade9, _pade13])
+   idx = jnp.argwhere(A_L1 < conds, size=1).squeeze()
+   U, V = lax.switch(idx, [_pade3, _pade5, _pade7, _pade9, _pade13], A)
   elif A.dtype == 'float32' or A.dtype == 'complex64':
     maxnorm = 3.925724783138660
     n_squarings = jnp.maximum(0, jnp.floor(jnp.log2(A_L1 / maxnorm)))
     A = A / 2**n_squarings
     conds = jnp.array([4.258730016922831e-001, 1.880152677804762e+000, jnp.inf])
-    idx = jnp.argmax(A_L1 < conds)
-    U, V = lax.switch(idx, [_pade3, _pade5, _pade7])
+    idx = jnp.argwhere(A_L1 < conds, size=1).squeeze()
+    U, V = lax.switch(idx, [_pade3, _pade5, _pade7], A)
   else:
     raise TypeError("A.dtype={} is not supported.".format(A.dtype))
   P = U + V  # p_m(A) : numerator

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -293,15 +293,15 @@ def _calc_P_Q(A):
    n_squarings = jnp.maximum(0, jnp.floor(jnp.log2(A_L1 / maxnorm)))
    A = A / 2**n_squarings
    conds = jnp.array([1.495585217958292e-002, 2.539398330063230e-001,
-                      9.504178996162932e-001, 2.097847961257068e+000, jnp.inf])
-   idx = jnp.argwhere(A_L1 < conds, size=1).squeeze()
+                      9.504178996162932e-001, 2.097847961257068e+000])
+   idx = jnp.digitize(A_L1, conds)
    U, V = lax.switch(idx, [_pade3, _pade5, _pade7, _pade9, _pade13], A)
   elif A.dtype == 'float32' or A.dtype == 'complex64':
     maxnorm = 3.925724783138660
     n_squarings = jnp.maximum(0, jnp.floor(jnp.log2(A_L1 / maxnorm)))
     A = A / 2**n_squarings
-    conds = jnp.array([4.258730016922831e-001, 1.880152677804762e+000, jnp.inf])
-    idx = jnp.argwhere(A_L1 < conds, size=1).squeeze()
+    conds = jnp.array([4.258730016922831e-001, 1.880152677804762e+000])
+    idx = jnp.digitize(A_L1, conds)
     U, V = lax.switch(idx, [_pade3, _pade5, _pade7], A)
   else:
     raise TypeError("A.dtype={} is not supported.".format(A.dtype))

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -289,28 +289,20 @@ def _calc_P_Q(A):
   A_L1 = np_linalg.norm(A,1)
   n_squarings = 0
   if A.dtype == 'float64' or A.dtype == 'complex128':
-   U3, V3 = _pade3(A)
-   U5, V5 = _pade5(A)
-   U7, V7 = _pade7(A)
-   U9, V9 = _pade9(A)
    maxnorm = 5.371920351148152
    n_squarings = jnp.maximum(0, jnp.floor(jnp.log2(A_L1 / maxnorm)))
    A = A / 2**n_squarings
-   U13, V13 = _pade13(A)
    conds = jnp.array([1.495585217958292e-002, 2.539398330063230e-001,
-                      9.504178996162932e-001, 2.097847961257068e+000])
-   U = jnp.select((A_L1 < conds), (U3, U5, U7, U9), U13)
-   V = jnp.select((A_L1 < conds), (V3, V5, V7, V9), V13)
+                      9.504178996162932e-001, 2.097847961257068e+000, jnp.inf])
+   idx = jnp.argmax(A_L1 < conds)
+   U, V = lax.switch(idx, [_pade3, _pade5, _pade7, _pade9, _pade13])
   elif A.dtype == 'float32' or A.dtype == 'complex64':
-    U3,V3 = _pade3(A)
-    U5,V5 = _pade5(A)
     maxnorm = 3.925724783138660
     n_squarings = jnp.maximum(0, jnp.floor(jnp.log2(A_L1 / maxnorm)))
     A = A / 2**n_squarings
-    U7,V7 = _pade7(A)
-    conds = jnp.array([4.258730016922831e-001, 1.880152677804762e+000])
-    U = jnp.select((A_L1 < conds), (U3, U5), U7)
-    V = jnp.select((A_L1 < conds), (V3, V5), V7)
+    conds = jnp.array([4.258730016922831e-001, 1.880152677804762e+000, jnp.inf])
+    idx = jnp.argmax(A_L1 < conds)
+    U, V = lax.switch(idx, [_pade3, _pade5, _pade7])
   else:
     raise TypeError("A.dtype={} is not supported.".format(A.dtype))
   P = U + V  # p_m(A) : numerator


### PR DESCRIPTION
## Summary

This PR introduces a minor change to the `expm` function:
- Currently, given the matrix `A`, `expm` computes all Pade approximant numerators/denominators, then selects which one to use based on the norm of the matrix.
- This PR modifies this to only compute the relevant Pade approximant numerator/denominator by using `switch` conditioned on the norm of the matrix `A`.

Closes #5647

## Speed testing

I unfortunately don't currently have access to a GPU, but have run some CPU speed tests comparing the code in this PR to the current release. Testing in 64 bit mode with complex matrices of dimensions `[5, 10, 50, 100, 500, 1000, 5000]`, the ratios by dimension of "release run time" / "PR run time" for `expm` (once compiled) are:
```
[1.0794702 , 3.63815789, 3.41229117, 3.38029568, 1.68847097, 1.54355993, 1.61012301]
```
These are not the most rigorous (I'm just generating random matrices and measuring time by sandwiching `time()` calls around a single exponentiation for each dimension), but seem pretty reasonable based on the number of matrix multiplications this is potentially saving (which varies based on matrix norm).

I've attached the jupyter notebook I've run the tests in [jax_expm_speed_test.ipynb.zip](https://github.com/google/jax/files/7898241/jax_expm_speed_test.ipynb.zip), which include a cell of the saved list of execution times for JAX version (release and this PR). 

## Going forward

I'm trying to finally get GPU access in my org and will reply with GPU speed comparisons here when possible. In the meantime, please let me know if there's anything you'd like to see in terms of speed comparisons.