### PR TITLE
pjit: add test for basic static_argnums

### DIFF
--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -622,6 +622,15 @@ class PJitTest(jtu.BufferDonationTestCase):
         "called with:\n.*int32.*",
         lambda: exe(x_i32, x_i32))
 
+  @jtu.with_mesh([('x', 2)])
+  def test_static_argnums(self):
+    @partial(pjit, in_axis_resources=None, out_axis_resources=None,
+             static_argnums=(1,))
+    def f(x, y):
+      return x + (3 if y == 'hi' else 4)
+
+    self.assertEqual(f(1, 'hi' ), 4)
+    self.assertEqual(f(1, 'bye'), 5)
 
 class GDAPjitTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Two fixes:
1. In pjit's `infer_params`, the `dyn_args` were being ignored! We want to use them.
2. In pjit, we want to call `_check_arg` on the flat argument list after the static ones have been pruned.