### PR TITLE
NotImplementedError for new_checkpoint-of-xmap

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -617,7 +617,8 @@ xla.register_translation(while_p, _while_loop_translation_rule,
                          initial_style=True)
 ad.primitive_transposes[while_p] = _while_transpose_error
 batching.axis_primitive_batchers[while_p] = _while_loop_batching_rule
-pe.partial_eval_jaxpr_custom_rules[while_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
+pe.partial_eval_jaxpr_custom_rules[while_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'while_loop')
 
 
 def _pred_bcast_select_mhlo(
@@ -1403,7 +1404,8 @@ pe.custom_partial_eval_rules[cond_p] = _cond_partial_eval
 batching.axis_primitive_batchers[cond_p] = _cond_batching_rule
 xla.register_translation(cond_p, _cond_translation_rule, initial_style=True)
 core.custom_typechecks[cond_p] = _cond_typecheck
-pe.partial_eval_jaxpr_custom_rules[cond_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
+pe.partial_eval_jaxpr_custom_rules[cond_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'cond')
 
 if jax._src.lib._xla_extension_version < 51:
 
@@ -2225,7 +2227,8 @@ xla.register_translation(scan_p, xla.lower_fun(_scan_impl, new_style=True,
 batching.axis_primitive_batchers[scan_p] = _scan_batching_rule
 masking.masking_rules[scan_p] = _scan_masking_rule
 core.custom_typechecks[scan_p] = partial(_scan_typecheck, False)
-pe.partial_eval_jaxpr_custom_rules[scan_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
+pe.partial_eval_jaxpr_custom_rules[scan_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'scan')
 
 mlir.register_lowering(scan_p,
                        mlir.lower_fun(_scan_impl, multiple_results=True))
@@ -2783,7 +2786,8 @@ xla.register_translation(
     initial_style=True)
 ad.primitive_transposes[linear_solve_p] = _linear_solve_transpose_rule
 batching.axis_primitive_batchers[linear_solve_p] = _linear_solve_batching_rule
-pe.partial_eval_jaxpr_custom_rules[linear_solve_p] = pe.partial_eval_jaxpr_custom_rule_not_implemented
+pe.partial_eval_jaxpr_custom_rules[linear_solve_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'linear_solve')
 
 
 def _interleave(a, b, axis):

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1067,6 +1067,8 @@ def _dynamic_jaxpr_process_xmap(self, primitive, f, tracers, params):
   self.frame.eqns.append(eqn)
   return out_tracers
 pe.DynamicJaxprTrace.process_xmap = _dynamic_jaxpr_process_xmap  # type: ignore
+pe.partial_eval_jaxpr_custom_rules[xmap_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'xmap')
 
 
 @lu.transformation_with_aux

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -975,9 +975,11 @@ PartialEvalCustomRule = Callable[
 partial_eval_jaxpr_custom_rules: Dict[Primitive, PartialEvalCustomRule] = {}
 
 def partial_eval_jaxpr_custom_rule_not_implemented(
-    saveable: Callable[..., bool], unks_in: Sequence[bool], inst_in: Sequence[bool],
-    eqn: JaxprEqn) -> PartialEvalCustomResult:
-  raise NotImplementedError
+    name: str, saveable: Callable[..., bool], unks_in: Sequence[bool],
+    inst_in: Sequence[bool], eqn: JaxprEqn) -> PartialEvalCustomResult:
+  msg = (f'custom-policy remat rule not implemented for {name}, '
+         'open a feature request at https://github.com/google/jax/issues!')
+  raise NotImplementedError(msg)
 
 
 ParamsUpdater = Callable[[List[bool], int, dict, dict], Tuple[dict, dict]]

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1535,6 +1535,8 @@ xla_pmap_p.def_impl(xla_pmap_impl)
 
 # Set param update handlers to update `donated_invars` just like xla_call_p
 pe.call_param_updaters[xla_pmap_p] = pe.call_param_updaters[xla.xla_call_p]
+pe.partial_eval_jaxpr_custom_rules[xla_pmap_p] = \
+    partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'pmap')
 ad.call_param_updaters[xla_pmap_p] = ad.call_param_updaters[xla.xla_call_p]
 ad.call_transpose_param_updaters[xla_pmap_p] = \
     ad.call_transpose_param_updaters[xla.xla_call_p]

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -46,6 +46,7 @@ from jax._src.util import curry, unzip2, split_list, prod
 from jax._src.lax.lax import DotDimensionNumbers
 from jax._src.lax.parallel import pgather
 from jax.interpreters import batching, pxla
+from jax.ad_checkpoint import checkpoint
 
 from jax.config import config
 config.parse_flags_with_absl()
@@ -616,6 +617,11 @@ class XMapTest(XMapTestCase):
         "Computation compiled for input types:\n.*float32.*\n"
         "called with:\n.*int32.*",
         lambda: f_exe(x_i32))
+
+  def testNewCheckpointError(self):
+    f = checkpoint(xmap(lambda x: x, in_axes=['i', ...], out_axes=['i', ...]))
+    with self.assertRaisesRegex(NotImplementedError, 'xmap'):
+      jax.grad(f)(jnp.arange(3.))
 
 
 class XMapTestSPMD(SPMDTestMixin, XMapTest):


### PR DESCRIPTION
Previously this was getting a default behavior which caused surprising errors downstream.