### PR TITLE
introduce `custom_batching.sequential_vmap`

### DIFF
--- a/jax/custom_batching.py
+++ b/jax/custom_batching.py
@@ -15,4 +15,5 @@
 # flake8: noqa: F401
 from jax._src.custom_batching import (
   custom_vmap,
+  sequential_vmap,
 )


### PR DESCRIPTION
An anticipated common use of `custom_vmap` is in order to implement a map via loop (i.e. to sequentially apply the mapped function), instead of actually vectorizing.

This essentially handles #7199, but not until custom batching (#9073) is complete (supporting all transformations, documented, and public).