### PR TITLE
support generating bit widths other than 32 in `lax.rng_bit_generator`

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2501,6 +2501,18 @@ class LaxTest(jtu.JaxTestCase):
     self.assertArraysEqual(out[0], out_jit[0])
     self.assertArraysEqual(out[1], out_jit[1])
 
+  def testRngBitGenerator2(self):
+    def f(key):
+      return lax.rng_bit_generator(key, shape=(5, 7))
+
+    key = np.array((1, 2, 3, 4)).astype(np.uint32)
+    out1 = f(key)
+    out2 = jax.jit(f)(key)
+    self.assertEqual(out1[0].shape, (4,))
+    self.assertEqual(out1[1].shape, (5, 7))
+    self.assertArraysEqual(out1[0], out2[0])
+    self.assertArraysEqual(out1[1], out2[1])
+
   @jtu.skip_on_devices("tpu")
   def testRngBitGeneratorReturnedKey(self):
     # This test ensures that the key bit-packing/unpacking operations used in


### PR DESCRIPTION
Three parts:

* The underlying XLA operation (RngBitGenerator) doesn't support generating bit widths 8 and 16, so generate 32 bits and truncate in the translation rule.
* Canonicalize the dtype given to `rng_bit_generator` to avoid requests for U64 when x64 mode is off.
* Test the effect of this on PRNG implementations backed by `rng_bit_generator`. Namely, their `random_bits` method should now support all bit widths, and their keys can be used in samplers such as `random.uniform` and `random.randint` to generate 16-bit floats, and {8,16}-bit integers respectively.

Fixes #9274