### PR TITLE
Allow comparing NamedShape to None

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1639,13 +1639,11 @@ class NamedShape:
             f"{', '.join(f'{k}={v}' for k, v in self.__named.items())})")
 
   def __eq__(self, other):
-    if other is None:
-      return False
     if isinstance(other, NamedShape):
       return (self.__positional, self.__named) == (other.__positional, other.__named)
     if isinstance(other, tuple):
       return not self.__named and self.__positional == other
-    raise TypeError(f"NamedShape doesn't support comparisons with {type(other)}")
+    return False
 
   def __hash__(self):
     named = frozenset(self.__named.items())

--- a/jax/core.py
+++ b/jax/core.py
@@ -1639,6 +1639,8 @@ class NamedShape:
             f"{', '.join(f'{k}={v}' for k, v in self.__named.items())})")
 
   def __eq__(self, other):
+    if other is None:
+      return False
     if isinstance(other, NamedShape):
       return (self.__positional, self.__named) == (other.__positional, other.__named)
     if isinstance(other, tuple):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -515,6 +515,13 @@ class JaxprTypeChecks(jtu.JaxTestCase):
     aval3 = core.ShapedArray((2, 3), np.float32, False, {'i': 5})
     self.assertFalse(core.typecompat(aval1, aval3))
 
+  def test_named_shape_comparision(self):
+    self.assertTrue(core.NamedShape(2, 3) == (2, 3))
+    self.assertFalse(core.NamedShape(2, i=3) == (2,))
+    self.assertFalse(core.NamedShape(2, i=3) == (2, 3))
+    self.assertFalse(core.NamedShape(2, i=3) == None)
+    self.assertFalse(core.NamedShape() == [])
+
 
 class DynamicShapesTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Fixes #8416

The description of [jax.jit](https://jax.readthedocs.io/en/latest/jax.html#jax.jit) says `Static arguments should be hashable, meaning both __hash__ and __eq__ are implemented, and immutable.` but currently, we don't allow comparing NamedShape and None. Despite that, it seems that we can still jit a function that takes either NamedShape or None static arguments.

Unfortunately, CI [occasionally performs such comparison](https://github.com/pyro-ppl/numpyro/runs/4907710743?check_suite_focus=true#step:5:6871) (NamedShape vs None):
```
>     return _bernoulli(key, p, shape)  # type: ignore
E     ValueError: static arguments should be comparable using __eq__.The following error was raised during a call to '_bernoulli' when comparing two objects of types <class 'jax.core.NamedShape'> and <class 'NoneType'>. The error was:
E     TypeError: NamedShape doesn't support comparisons with <class 'NoneType'>
E     
E     At:
E       /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jax/core.py(1642): __eq__
E       /opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jax/_src/random.py(705): bernoulli
```
in `jax.random.bernoulli`. We can bypass the error by restarting the CI but it is a bit annoying (the errors have been happening for a few months).