### PR TITLE
[jax2tf] Move the no_xla_limitations documentation

### DIFF
--- a/jax/experimental/jax2tf/README.md
+++ b/jax/experimental/jax2tf/README.md
@@ -851,29 +851,12 @@ There are several drawbacks of using XLA TF ops:
 
    * These ops will only be executable by a consumer that has XLA linked in.
    This should not be a problem for TPU execution, since that requires XLA anyway.
-   But for other platforms (CPU, GPU, embedded) this can be a drawback in certain settings.
    * These ops are not yet recognized by tools that process
-   tf.Graph, e.g., TensorFlow.js converter.
+   tf.Graph, e.g., TensorFlow.js converter or the TensorFlow Lite converter.
 
-We use the following XLA TF ops:
-
-   * `XlaPad` (wraps XLA Pad operator). We use this instead of `tf.pad` in order to
-     support `lax.pad` interior padding (dilation) or negative edge padding.
-   * `XlaConv2` (wraps XLA ConvGeneralDilated operator).
-   * `XlaDotV2` (wraps XLA DotGeneral operator).
-   * `XlaGather` (wraps XLA Gather operator). We could use `tf.gather` in some
-     cases but not always. Also, `tf.gather` has a different semantics than `lax.gather`
-     for index out of bounds.
-   * `XlaScatter` (wraps XLA Scatter operator).
-   * `XlaSelectAndScatter` (wraps XLA SelectAndScatter operator).
-   * `XlaDynamicSlice` (wraps XLA DynamicSlice operator).
-     We use this instead of `tf.slice` for reasons explained above for `XlaGather`.
-   * `XlaDynamicUpdateSlice` (wraps XLA DynamicUpdateSlice operator).
-   * `XlaReduceWindow` (wraps XLA ReduceWindow operator). These are used
-     for `lax.reduce_window_sum_p`, `lax.reduce_window_min_p`,
-     `lax.reduce_window_max_p`, and `lax.reduce_window_p`.
-   * `XlaVariadicReduceV2` (for `lax.reduce`, `lax.argmin`, `lax.argmax`).
-   * `XlaVariadicSort` (wraps XLA Sort operator).
+As an experimental feature we implemented alternative conversions to avoid the XLA TF ops.
+You can enable this with the `enable_xla=False` parameter to `jax2tf.convert`.
+For more details see  [no_xla_limitations.md](g3doc/no_xla_limitations.md).
 
 ### Different performance characteristics
 

--- a/jax/experimental/jax2tf/converters_eval/README.md
+++ b/jax/experimental/jax2tf/converters_eval/README.md
@@ -32,7 +32,7 @@ cannot use a number of JAX ops directly, because they don't have a corresponding
 op in TF. For this, we provide support on a case-by-case basis.
 
 To track this, we use a list of known limitations of the `jax2tf` emitter when
-XLA support is not available in [no_xla_limitations.md](no_xla_limitations.md).
+XLA support is not available in [no_xla_limitations.md](../g3doc/no_xla_limitations.md).
 
 ## Description of Converters
 
@@ -50,7 +50,7 @@ for a list of known problems.
 ### `jax2tf_to_tflite`
 
 This converter first converts a JAX model to TF SavedModel format without XLA
-support. Please see [no_xla_limitations.md](no_xla_limitations.md) for a list
+support. Please see [no_xla_limitations.md](../g3doc/no_xla_limitations.md) for a list
 of known limitations for this conversion step.
 
 After that, it converts the SavedModel to TFLite using the
@@ -59,7 +59,7 @@ After that, it converts the SavedModel to TFLite using the
 ### `jax2tf_to_tfjs`
 
 This converter first converts a JAX model to TF SavedModel format without XLA
-support. Please see [no_xla_limitations.md](no_xla_limitations.md) for a list
+support. Please see [no_xla_limitations.md](../g3doc/no_xla_limitations.md) for a list
 of known limitations for this conversion step.
 
 After that, it converts the SavedModel to TF.js using the

--- a/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
+++ b/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
@@ -36,7 +36,7 @@ For a detailed description of these XLA ops, please see the
 | XlaScatter | `lax.scatter_p`, `lax.scatter_min_p`, `lax.scatter_max_p`, `lax.scatter_mul_p`, `lax.scatter_add_p` | Unsupported |
 | XlaSelectAndScatter | `lax.select_and_scatter_add_p` | Unsupported |
 | XlaReduce | `lax.reduce`, `lax.argmin`, `lax.argmax` | Unsupported |
-| XlaSort | `lax.sort` | Unsupported |
+| XlaVariadicSort | `lax.sort` | Unsupported |
 
 
 ## Partially Supported JAX Primitives


### PR DESCRIPTION
Put it in the g3doc directory, along with the other pieces
of jax2tf documentation. This enables special documentation
features in the Google repo.