### PR TITLE
DOC: pin docutils==0.16 to restore bullets in lists

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,10 @@ sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2
 myst-nb
 
+# Need to pin docutils to 0.16 to make bulleted lists appear correctly on
+# ReadTheDocs: https://stackoverflow.com/a/68008428
+docutils==0.16.0
+
 # Packages used for CI tests.
 pytest
 pytest-xdist


### PR DESCRIPTION
This appears to fix the issue; bullet points are visible again: https://jax--9302.org.readthedocs.build/en/9302/notebooks/thinking_in_jax.html