### PR TITLE
linalg_test: disable implicit rank promotion

### DIFF
--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -136,7 +136,7 @@ def _lu(a, permute_l):
   lu, pivots, permutation = lax_linalg.lu(a)
   dtype = lax.dtype(a)
   m, n = jnp.shape(a)
-  p = jnp.real(jnp.array(permutation == jnp.arange(m)[:, None], dtype=dtype))
+  p = jnp.real(jnp.array(permutation[None, :] == jnp.arange(m)[:, None], dtype=dtype))
   k = min(m, n)
   l = jnp.tril(lu, -1)[:, :k] + jnp.eye(m, k, dtype=dtype)
   u = jnp.triu(lu)[:k, :]


### PR DESCRIPTION
Related to #7208

In this case, rather than manually reshaping arrays to avoid rank promotion errors, I locally disabled the rank promotion instead, as I judged that manual reshapes obscured the logic too much (happy to go the other way if anyone feels strongly).