### PR TITLE
djax: let make_jaxpr build dyn shape jaxprs

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -664,9 +664,18 @@ enable_mlir = config.define_bool_state(
     help=('Enables an experimental code path that compiles JAX programs via '
           'emitting the MLIR MHLO dialect.'))
 
+
 # This flag is temporary and for internal use.
 # TODO(tianjianlu): Removes after providing the information in BCOO meta data.
 bcoo_cusparse_lowering = config.define_bool_state(
     name='jax_bcoo_cusparse_lowering',
     default=False,
     help=('Enables lowering BCOO ops to cuSparse.'))
+
+# TODO(mattjj): remove this flag when we ensure we only succeed at trace-staging
+# if the intended backend can handle lowering the result
+config.define_bool_state(
+    name='jax_dynamic_shapes',
+    default=False,
+    help=('Enables experimental features for staging out computations with '
+          'dynamic shapes.'))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -45,7 +45,8 @@ from jax import core
 from jax._src import dtypes
 from jax._src.api_util import _ensure_index_tuple
 from jax import errors
-from jax.core import UnshapedArray, ShapedArray, ConcreteArray, canonicalize_shape
+from jax.core import (UnshapedArray, ShapedArray, DShapedArray, ConcreteArray,
+                      canonicalize_shape)
 from jax.config import config
 from jax.interpreters import pxla
 from jax import lax
@@ -476,20 +477,21 @@ _INT_DTYPES = {
 }
 
 def _promote_shapes(fun_name, *args):
-  """Prepend implicit leading singleton dimensions for Numpy broadcasting."""
+  """Apply NumPy-style broadcasting, making args shape-compatible for lax.py."""
   if len(args) < 2:
     return args
   else:
     shapes = [shape(arg) for arg in args]
-    nonscalar_ranks = [len(shp) for shp in shapes if shp]
-    if not nonscalar_ranks or len(set(nonscalar_ranks)) == 1:
+    if _all(len(shapes[0]) == len(s) for s in shapes[1:]):
+      return args  # no need for rank promotion, so rely on lax promotion
+    nonscalar_ranks = {len(shp) for shp in shapes if shp}
+    if len(nonscalar_ranks) < 2:
       return args
     else:
       if config.jax_numpy_rank_promotion != "allow":
         _rank_promotion_warning_or_error(fun_name, shapes)
-      result_rank = len(lax.broadcast_shapes(*shapes))
-      return [broadcast_to(arg, (1,) * (result_rank - len(shp)) + shp)
-              for arg, shp in zip(args, shapes)]
+      result_shape = lax.broadcast_shapes(*shapes)
+      return [broadcast_to(arg, result_shape) for arg, shp in zip(args, shapes)]
 
 def _rank_promotion_warning_or_error(fun_name, shapes):
   if config.jax_numpy_rank_promotion == "warn":
@@ -2128,7 +2130,9 @@ def _where(condition, x=None, y=None):
     condition = lax.ne(condition, zeros_like(condition))
   x, y = _promote_dtypes(x, y)
   condition, x, y = broadcast_arrays(condition, x, y)
-  return lax.select(condition, x, y) if not core.is_empty_shape(np.shape(x)) else x
+  try: is_always_empty = core.is_empty_shape(np.shape(x))
+  except: is_always_empty = False  # can fail with dynamic shapes
+  return lax.select(condition, x, y) if not is_always_empty else x
 
 
 _WHERE_DOC = """\
@@ -2210,7 +2214,8 @@ def broadcast_shapes(*shapes):
 def broadcast_arrays(*args):
   """Like Numpy's broadcast_arrays but doesn't return views."""
   shapes = [shape(arg) for arg in args]
-  if len(set(shapes)) == 1:
+  if not shapes or _all(core.symbolic_equal_shape(shapes[0], s) for s in shapes):
+    # TODO(mattjj): remove the array(arg) here
     return [arg if isinstance(arg, ndarray) or isscalar(arg) else array(arg)
             for arg in args]
   result_shape = lax.broadcast_shapes(*shapes)
@@ -2224,7 +2229,8 @@ def broadcast_to(arr, shape):
   if hasattr(arr, "broadcast_to"):
     return arr.broadcast_to(shape)
   arr = arr if isinstance(arr, ndarray) else array(arr)
-  shape = (shape,) if ndim(shape) == 0 else shape
+  if not isinstance(shape, tuple) and ndim(shape) == 0:
+    shape = (shape,)
   shape = canonicalize_shape(shape)  # check that shape is concrete
   arr_shape = _shape(arr)
   if core.symbolic_equal_shape(arr_shape, shape):
@@ -5594,7 +5600,8 @@ def take_along_axis(arr, indices, axis: Optional[int]):
       collapsed_slice_dims.append(i)
       j += 1
     elif idx_shape[i] != 1:
-      iota = lax.iota(_dtype(indices), out_shape[i])
+      # TODO(mattjj): next line needs updating for dynamic shapes
+      iota = lax.iota(_dtype(indices), out_shape[i])  # type: ignore
       iota = lax.broadcast_in_dim(iota, gather_index_shape, (j,))
       gather_indices.append(iota)
       slice_sizes.append(1)
@@ -7101,6 +7108,7 @@ def _set_shaped_array_attributes(shaped_array):
   setattr(shaped_array, "item", core.aval_method(device_array.DeviceArray.item))
 
 _set_shaped_array_attributes(ShapedArray)
+_set_shaped_array_attributes(DShapedArray)
 
 
 def _set_device_array_base_attributes(device_array):

--- a/jax/_src/numpy/vectorize.py
+++ b/jax/_src/numpy/vectorize.py
@@ -121,7 +121,8 @@ def _parse_input_dimensions(
     ndim = arg.ndim - len(core_dims)
     shapes.append(arg.shape[:ndim])
   broadcast_shape = lax.broadcast_shapes(*shapes)
-  return broadcast_shape, dim_sizes
+  # TODO(mattjj): this code needs updating for dynamic shapes (hence ignore)
+  return broadcast_shape, dim_sizes  # type: ignore
 
 
 def _check_output_dims(

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -16,8 +16,8 @@ import collections
 import functools
 from functools import partial
 import operator as op
-from typing import (Any, Callable, Hashable, Iterable, Optional, Tuple, Type,
-                    TypeVar, overload, TYPE_CHECKING)
+from typing import (Any, Callable, Hashable, Iterable, Optional, Tuple, List,
+                    Type, TypeVar, overload, TYPE_CHECKING)
 
 from jax._src.lib import pytree
 
@@ -335,3 +335,13 @@ register_pytree_node(
     lambda partial_: ((partial_.args, partial_.keywords), partial_.func),
     lambda func, xs: Partial(func, *xs[0], **xs[1]),  # type: ignore[index]
 )
+
+
+def broadcast_prefix(prefix_tree: Any, full_tree: Any,
+                     is_leaf: Optional[Callable[[Any], bool]] = None
+                     ) -> List[Any]:
+  result = []
+  num_leaves = lambda t: tree_structure(t).num_leaves
+  add_leaves = lambda x, subtree: result.extend([x] * num_leaves(subtree))
+  tree_map(add_leaves, prefix_tree, full_tree, is_leaf=is_leaf)
+  return result

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -912,7 +912,7 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
                                                                    four_ones)
 
     with self.assertRaisesRegex(TypeError,
-                                re.escape("dot_general requires contracting dimensions to have the same shape, got [4] and [v]")):
+                                re.escape("dot_general requires contracting dimensions to have the same shape, got (4,) and (v,)")):
       jax2tf.convert(lambda x: jnp.matmul(x, x),
                      polymorphic_shapes=["(v, 4)"])(np.ones((4, 4)))
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -245,8 +245,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       lax.while_loop(lambda c: True, lambda c: (1., 1.), 0.)
     with self.assertRaisesWithLiteralMatch(TypeError,
         ("body_fun output and input must have identical types, got\n"
-         "('ShapedArray(bool[], weak_type=True)', "
-         "'DIFFERENT ShapedArray(bool[], weak_type=True) vs. "
+         "('ShapedArray(bool[])', "
+         "'DIFFERENT ShapedArray(bool[]) vs. "
          "ShapedArray(float32[])').")):
       lax.while_loop(lambda c: True, lambda c: (True, True),
                      (np.bool_(True), np.float32(0.)))

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5735,7 +5735,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertRaisesRegex(
         TypeError,
         r"Shapes must be 1D sequences of concrete values of integer type.*\n"
-        "If using `jit`, try using `static_argnums` or applying `jit` to smaller subfunctions.",
+        "If using `jit`, try using `static_argnums` or applying `jit` to "
+        "smaller subfunctions.",
         lambda: jax.jit(jnp.zeros)(2))
 
   def testTraceMethod(self):


### PR DESCRIPTION
Also make small adaptations to the numpy and lax layers so that we can stage out a shape-polymorphic mnist.

TODO:
* [x] flag because we want to gate whether `jax.make_jaxpr(lambda n: jnp.zeros(n))(3)` is an error (after this change it need not be, but we have some tests which check that this is a trace-time error, and trace-time errors can be nicer for users than lowering-time errors, so we need to figure out what to do here. We'll use a flag to unblock the PR though.)

Known issues:
* [ ] for dynamic (rather than just polymorphic) shapes, we need to be able to return arrays with let-bound axis sizes (splatted as a dependent tuple and type annotation)
* [x] with nested jits, closed-over tracers don't get enough substitution into their avals (i.e. avals may contain tracers which also need to be lifted)
