### PR TITLE
Make forces_retrace tests more robust

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3174,7 +3174,8 @@ class APITest(jtu.JaxTestCase):
       return jnp.dot(x, x)
 
     for f in [f_jit, f_cond]:
-      precision = config.jax_default_matmul_precision
+      # Use _read() to read the flag value rather than threadlocal value.
+      precision = config._read('jax_default_matmul_precision')
       try:
         num_traces = 0
         x = jnp.zeros((2, 2))
@@ -3328,8 +3329,6 @@ class APITest(jtu.JaxTestCase):
       api.make_jaxpr(lambda: jnp.array(3))()
     self.assertEqual(count[0], 0)
 
-
-class RankPromotionTest(jtu.JaxTestCase):
   def test_rank_promotion_forces_retrace(self):
     num_traces = 0
 
@@ -3347,8 +3346,10 @@ class RankPromotionTest(jtu.JaxTestCase):
       return x + x
 
     for f in [f_jit, f_cond]:
-      allow_promotion = config.jax_numpy_rank_promotion
+      # Use _read() to read the flag value rather than threadlocal value.
+      allow_promotion = config._read('jax_numpy_rank_promotion')
       try:
+        FLAGS.jax_numpy_rank_promotion = "allow"
         num_traces = 0
         @jax.jit
         def f(x):


### PR DESCRIPTION
This addresses two issues (mentioned in https://github.com/google/jax/issues/9304#issuecomment-1021675514 & related discussion):

- the `test_rank_promotion_forces_retrace` test previously failed if run with the `jax_numpy_rank_promotion` flag set to a non-default value
- both `*_forces_retrace` tests were resetting the flag value to the threadlocal value; these two could diverge in cases that the test is wrapped in a context manager that changes the threadlocal value. Using `_read()` instead ensures that running the test does not change the global state.

The bug in the second point is the reason that I had to put the test in its own test class as part of #9301; now that this is fixed I removed this class as well.