### PR TITLE
disable implicit rank promotion in a number of remaining tests

### DIFF
--- a/examples/examples_test.py
+++ b/examples/examples_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 
 import numpy as np
 
+import jax
 from jax import lax
 from jax import random
 import jax.numpy as jnp
@@ -73,6 +74,7 @@ class ExamplesTest(parameterized.TestCase):
       for num_classes in [5, 10]
       for input_shape in [(224, 224, 3, 2)])
   @unittest.skipIf(config.x64_enabled, "skip in x64 mode")
+  @jax.numpy_rank_promotion("allow")  # Uses stax, which exercises implicit rank promotion.
   def testResNet50Shape(self, num_classes, input_shape):
     init_fun, apply_fun = resnet50.ResNet50(num_classes)
     _CheckShapeAgreement(self, init_fun, apply_fun, input_shape)

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -120,7 +120,7 @@ def _irfft_transpose(t, fft_lengths):
        full(1.0, shape=(1 - is_odd,))],
       dimension=0)
   scale = 1 / prod(fft_lengths)
-  out = scale * mask * x
+  out = scale * lax.expand_dims(mask, range(x.ndim - 1)) * x
   assert out.dtype == _complex_dtype(t.dtype), (out.dtype, t.dtype)
   # Use JAX's convention for complex gradients
   # https://github.com/google/jax/issues/6223#issuecomment-807740707

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -40,6 +40,7 @@ config.parse_flags_with_absl()
 # These are 'manual' tests for batching (vmap). The more exhaustive, more
 # systematic tests are in lax_test.py's LaxVmapTest class.
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class BatchingTest(jtu.JaxTestCase):
 
   def testConstantFunction(self):
@@ -888,7 +889,7 @@ class BatchingTest(jtu.JaxTestCase):
     vec = self.rng().randn(10)
 
     def f(scale):
-      scaled_mat = scale * psd_mat
+      scaled_mat = scale[jnp.newaxis] * psd_mat
       chol = jnp.linalg.cholesky(scaled_mat)
       return -0.5 * jnp.sum((jnp.einsum('ij,j->i', chol, vec))**2)
     vmapped_f = vmap(f)

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -93,6 +93,7 @@ def _zero_for_irfft(z, axes):
   return jnp.concatenate(parts, axis=axis)
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class FftTest(jtu.JaxTestCase):
 
   def testNotImplemented(self):

--- a/tests/infeed_test.py
+++ b/tests/infeed_test.py
@@ -26,8 +26,10 @@ import numpy as np
 
 config.parse_flags_with_absl()
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class InfeedTest(jtu.JaxTestCase):
 
+  @jax.numpy_rank_promotion("allow")  # Test explicitly exercises implicit rank promotion.
   def testInfeed(self):
 
     @jax.jit
@@ -66,6 +68,7 @@ class InfeedTest(jtu.JaxTestCase):
     device.transfer_to_infeed(tuple(flat_to_infeed))
     self.assertAllClose(f(x), to_infeed)
 
+  @jax.numpy_rank_promotion("allow")  # Test explicitly exercises implicit rank promotion.
   def testInfeedThenOutfeed(self):
     hcb.stop_outfeed_receiver()
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -189,6 +189,7 @@ def check_grads_bilinear(f, args, order,
   check_grads(lambda rhs: f(lhs, rhs), (rhs,), order,
               modes=modes, atol=atol, rtol=rtol, eps=1.)
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class LaxAutodiffTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
@@ -845,6 +846,7 @@ class LaxAutodiffTest(jtu.JaxTestCase):
           [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 1)],
           [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 2)],
       ]))
+  @jax.numpy_rank_promotion('allow')  # Test explicitly exercises implicit rank promotion.
   def testIndexTakeGrad(self, shape, dtype, idxs, axes):
     rng = jtu.rand_default(self.rng())
     src = rng(shape, dtype)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -181,6 +181,7 @@ LAX_OPS = [
 ]
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class LaxTest(jtu.JaxTestCase):
   """Numerical tests for LAX operations."""
 
@@ -2042,6 +2043,7 @@ class LaxTest(jtu.JaxTestCase):
           [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 1)],
           [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 2)],
       ]))
+  @jax.numpy_rank_promotion('allow')  # Test explicitly exercises implicit rank promotion.
   def testIndexTake(self, shape, dtype, idxs, axes):
     rng = jtu.rand_default(self.rng())
     rand_idxs = lambda: tuple(rng(e.shape, e.dtype) for e in idxs)
@@ -2567,6 +2569,7 @@ class LaxTest(jtu.JaxTestCase):
         np.array(lax.dynamic_slice(x, np.uint8([128]), (1,))), [128])
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class LazyConstantTest(jtu.JaxTestCase):
   def _Check(self, make_const, expected):
     # check casting to ndarray works
@@ -2769,6 +2772,7 @@ class LazyConstantTest(jtu.JaxTestCase):
         np.log1p(np.float32(1e-5)), lax.log1p(np.complex64(1e-5)))
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class LaxNamedShapeTest(jtu.JaxTestCase):
 
   def test_abstract_eval(self):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -35,16 +35,8 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class NNFunctionsTest(jtu.JaxTestCase):
-
-  def setUp(self):
-    super().setUp()
-    config.update("jax_numpy_rank_promotion", "raise")
-
-  def tearDown(self):
-    super().tearDown()
-    config.update("jax_numpy_rank_promotion", "allow")
-
   @jtu.skip_on_flag("jax_skip_slow_tests", True)
   def testSoftplusGrad(self):
     check_grads(nn.softplus, (1e-8,), order=4,
@@ -238,16 +230,8 @@ INITIALIZER_RECS = [
     initializer_record("delta_orthogonal", nn.initializers.delta_orthogonal, jtu.dtypes.floating, 4, 4)
 ]
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class NNInitializersTest(jtu.JaxTestCase):
-
-  def setUp(self):
-    super().setUp()
-    config.update("jax_numpy_rank_promotion", "raise")
-
-  def tearDown(self):
-    super().tearDown()
-    config.update("jax_numpy_rank_promotion", "allow")
-
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name":
        "_{}_{}".format(

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -109,6 +109,7 @@ ignore_xmap_warning = partial(
   jtu.ignore_warning, message=".*is an experimental.*")
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class PythonPmapTest(jtu.JaxTestCase):
 
   @property
@@ -1517,7 +1518,7 @@ class PythonPmapTest(jtu.JaxTestCase):
 
       @jit
       def g(z):
-        return self.pmap(lambda x: x * y)(z)
+        return self.pmap(lambda x: x[jnp.newaxis] * y)(z)
 
       return g(x)
 
@@ -1899,6 +1900,7 @@ class CppPmapTest(PythonPmapTest):
     return src_api._cpp_pmap
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class VmapOfPmapTest(jtu.JaxTestCase):
 
   # TODO(apaszke)
@@ -1940,6 +1942,8 @@ class VmapOfPmapTest(jtu.JaxTestCase):
       axis=vmap_out_axes)
     self.assertAllClose(ans, expected)
 
+
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class VmapPmapCollectivesTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
@@ -2125,6 +2129,7 @@ class VmapPmapCollectivesTest(jtu.JaxTestCase):
     self.assertAllClose(f(jax.pmap)(x), f(jax.vmap)(x))
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class PmapWithDevicesTest(jtu.JaxTestCase):
 
   def testAllDevices(self):
@@ -2377,6 +2382,7 @@ class PmapWithDevicesTest(jtu.JaxTestCase):
                         jax.grad(mk_case(vmap))(x, y))
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class ShardedDeviceArrayTest(jtu.JaxTestCase):
 
   def testThreadsafeIndexing(self):
@@ -2482,6 +2488,7 @@ class ShardedDeviceArrayTest(jtu.JaxTestCase):
       _ = x[0]
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class SpecToIndicesTest(jtu.JaxTestCase):
 
   def testShardsPerAxis(self):
@@ -2611,6 +2618,7 @@ def _spec_str(spec):
           f"{spec.mesh_mapping},)")
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class ShardArgsTest(jtu.JaxTestCase):
 
   def numpy_array(x):

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -15,12 +15,12 @@
 """Tests for the library of QDWH-based polar decomposition."""
 import functools
 
-from jax import test_util as jtu
 from jax.config import config
 import jax.numpy as jnp
 import numpy as np
 import scipy.linalg as osp_linalg
 from jax._src.lax import qdwh
+from jax._src import test_util as jtu
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -58,6 +58,7 @@ def _compute_relative_diff(actual, expected):
 _dot = functools.partial(jnp.dot, precision="highest")
 
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class QdwhTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(
@@ -72,7 +73,7 @@ class QdwhTest(jtu.JaxTestCase):
     a = jnp.triu(jnp.ones((m, n)))
     u, s, v = jnp.linalg.svd(a, full_matrices=False)
     cond = 10**log_cond
-    s = jnp.linspace(cond, 1, min(m, n))
+    s = jnp.expand_dims(jnp.linspace(cond, 1, min(m, n)), range(u.ndim - 1))
     a = (u * s) @ v
     is_symmetric = _check_symmetry(a)
     max_iterations = 2
@@ -99,7 +100,7 @@ class QdwhTest(jtu.JaxTestCase):
     a = jnp.triu(jnp.ones((m, n))).astype(_QDWH_TEST_DTYPE)
     u, s, v = jnp.linalg.svd(a, full_matrices=False)
     cond = 10**log_cond
-    s = jnp.linspace(cond, 1, min(m, n))
+    s = jnp.expand_dims(jnp.linspace(cond, 1, min(m, n)), range(u.ndim - 1))
     a = (u * s) @ v
     is_symmetric = _check_symmetry(a)
     max_iterations = 10
@@ -142,7 +143,7 @@ class QdwhTest(jtu.JaxTestCase):
     a = rng((m, n), _QDWH_TEST_DTYPE)
     u, s, v = jnp.linalg.svd(a, full_matrices=False)
     cond = 10**log_cond
-    s = jnp.linspace(cond, 1, min(m, n))
+    s = jnp.expand_dims(jnp.linspace(cond, 1, min(m, n)), range(u.ndim - 1))
     a = (u * s) @ v
     is_symmetric = _check_symmetry(a)
     max_iterations = 10
@@ -181,7 +182,7 @@ class QdwhTest(jtu.JaxTestCase):
     u, s, v = jnp.linalg.svd(a, full_matrices=False)
     cond = 10**log_cond
     s = jnp.linspace(cond, 1, min(m, n))
-    s = s.at[-1].set(0)
+    s = jnp.expand_dims(s.at[-1].set(0), range(u.ndim - 1))
     a = (u * s) @ v
 
     is_symmetric = _check_symmetry(a)

--- a/tests/scipy_fft_test.py
+++ b/tests/scipy_fft_test.py
@@ -42,6 +42,7 @@ def _get_dctn_test_s(shape, axes):
     s_list.extend(itertools.product(*[[shape[ax]+i for i in range(-shape[ax]+1, shape[ax]+1)] for ax in axes]))
   return s_list
 
+@jtu.with_config(jax_numpy_rank_promotion="raise")
 class LaxBackedScipyFftTests(jtu.JaxTestCase):
   """Tests for LAX-backed scipy.fft implementations"""
 

--- a/tests/scipy_stats_test.py
+++ b/tests/scipy_stats_test.py
@@ -43,6 +43,8 @@ def genNamedParametersNArgs(n):
           for dtypes in itertools.combinations_with_replacement(jtu.dtypes.floating, n)))
 
 
+# Allow implicit rank promotion in these tests, as virtually every test exercises it.
+@jtu.with_config(jax_numpy_rank_promotion="allow")
 class LaxBackedScipyStatsTests(jtu.JaxTestCase):
   """Tests for LAX-backed scipy.stats implementations"""
 

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -46,6 +46,8 @@ def _CheckShapeAgreement(test_case, init_fun, apply_fun, input_shape):
   test_case.assertEqual(result.shape, result_shape)
 
 
+# stax makes use of implicit rank promotion, so we allow it in the tests.
+@jtu.with_config(jax_numpy_rank_promotion="allow")
 class StaxTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
Part of #7208 (Contains a number of changes extracted from #9330). Also needs #9346 for tests to pass.

After this PR, we should be able to globally disable rank promotion in `JaxTestCase` without any additional changes to the package.