### PR TITLE
test_util: export with_config

### DIFF
--- a/jax/test_util.py
+++ b/jax/test_util.py
@@ -27,6 +27,7 @@ from jax._src.test_util import (
   format_shape_dtype_string,
   rand_uniform,
   skip_on_devices,
+  with_config,
   xla_bridge,
   _default_tolerance
 )


### PR DESCRIPTION
Why? To land #9330 we'll need to give downstream libraries a way to make `JaxTestCase` avoid setting `jax_numpy_rank_promotion='raise'`. The best way to do that is using the `with_config` decorator, but it's currently not exported from `jax.test_util`.