### PR TITLE
jnp.where: improve error for non-array inputs

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2147,6 +2147,7 @@ def where(condition, x=None, y=None, *, size=None, fill_value=None):
     _check_arraylike("where", condition)
     return nonzero(condition, size=size, fill_value=fill_value)
   else:
+    _check_arraylike("where", condition, x, y)
     if size is not None or fill_value is not None:
       raise ValueError("size and fill_value arguments cannot be used in three-term where function.")
     return _where(condition, x, y)


### PR DESCRIPTION
Fixes #9349; related to #7737 

Behavior before this change:
```python
>>> jnp.where(True, {'a':1}, {'b':2})                                                                                                                                                                         
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
~/github/google/jax/jax/core.py in _len(self, ignored_tracer)
   1247     try:
-> 1248       return self.shape[0]
   1249     except IndexError as err:

IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
<ipython-input-2-5c57b62bc357> in <module>
----> 1 jnp.where(True, {'a':1}, {'b':2})

~/github/google/jax/jax/_src/numpy/lax_numpy.py in where(condition, x, y, size, fill_value)
   2150     if size is not None or fill_value is not None:
   2151       raise ValueError("size and fill_value arguments cannot be used in three-term where function.")
-> 2152     return _where(condition, x, y)
   2153 
   2154 

    [... skipping hidden 14 frame]

~/github/google/jax/jax/_src/numpy/lax_numpy.py in _where(condition, x, y)
   2127   if not issubdtype(_dtype(condition), bool_):
   2128     condition = lax.ne(condition, zeros_like(condition))
-> 2129   x, y = _promote_dtypes(x, y)
   2130   condition, x, y = broadcast_arrays(condition, x, y)
   2131   return lax.select(condition, x, y) if not core.is_empty_shape(np.shape(x)) else x

~/github/google/jax/jax/_src/numpy/lax_numpy.py in _promote_dtypes(*args)
    512     return args
    513   else:
--> 514     to_dtype, weak_type = dtypes._lattice_result_type(*args)
    515     to_dtype = dtypes.canonicalize_dtype(to_dtype)
    516     return [lax._convert_element_type(x, to_dtype, weak_type) for x in args]

    [... skipping hidden 4 frame]

~/.local/share/virtualenvs/jax-LBbfM5ix/lib/python3.8/site-packages/numpy/core/overrides.py in result_type(*args, **kwargs)

~/.local/share/virtualenvs/jax-LBbfM5ix/lib/python3.8/site-packages/numpy/core/_internal.py in _usefields(adict, align)
     60         names = None
     61     if names is None:
---> 62         names, formats, offsets, titles = _makenames_list(adict, align)
     63     else:
     64         formats = []

~/.local/share/virtualenvs/jax-LBbfM5ix/lib/python3.8/site-packages/numpy/core/_internal.py in _makenames_list(adict, align)
     28 
     29     for fname, obj in adict.items():
---> 30         n = len(obj)
     31         if not isinstance(obj, tuple) or n not in (2, 3):
     32             raise ValueError("entry not a 2- or 3- tuple")

    [... skipping hidden 1 frame]

~/github/google/jax/jax/core.py in _len(self, ignored_tracer)
   1248       return self.shape[0]
   1249     except IndexError as err:
-> 1250       raise TypeError("len() of unsized object") from err  # same as numpy error
   1251 
   1252 

TypeError: len() of unsized object
```
Behavior after this change:
```python
>>> jnp.where(True, {'a':1}, {'b':2})                                                                                                                                                                         
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-5c57b62bc357> in <module>
----> 1 jnp.where(True, {'a':1}, {'b':2})

~/github/google/jax/jax/_src/numpy/lax_numpy.py in where(condition, x, y, size, fill_value)
   2148     return nonzero(condition, size=size, fill_value=fill_value)
   2149   else:
-> 2150     _check_arraylike("where", condition, x, y)
   2151     if size is not None or fill_value is not None:
   2152       raise ValueError("size and fill_value arguments cannot be used in three-term where function.")

~/github/google/jax/jax/_src/numpy/lax_numpy.py in _check_arraylike(fun_name, *args)
    557                     if not _arraylike(arg))
    558     msg = "{} requires ndarray or scalar arguments, got {} at position {}."
--> 559     raise TypeError(msg.format(fun_name, type(arg), pos))
    560 
    561 def _check_no_float0s(fun_name, *args):

TypeError: where requires ndarray or scalar arguments, got <class 'dict'> at position 1.