### PR TITLE
add pytree utilities for better errors

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1404,11 +1404,12 @@ def vmap(fun: F, in_axes=0, out_axes=0, axis_name=None, axis_size=None) -> F:
       range ``[-ndim, ndim)`` for each array, where ``ndim`` is the number of
       dimensions (axes) of the corresponding input array.
 
-      If the positional arguments to ``fun`` are container types, the
+      If the positional arguments to ``fun`` are container (pytree) types, the
       corresponding element of ``in_axes`` can itself be a matching container,
       so that distinct array axes can be mapped for different container
       elements. ``in_axes`` must be a container tree prefix of the positional
-      argument tuple passed to ``fun``.
+      argument tuple passed to ``fun``. See this link for more detail:
+      https://jax.readthedocs.io/en/latest/pytrees.html#applying-optional-parameters-to-pytrees
 
       Either ``axis_size`` must be provided explicitly, or at least one
       positional argument must have ``in_axes`` not None. The sizes of the


### PR DESCRIPTION
This PR adds internal-only utility functions. My plan is to use these utilities to raise better pytree disagreement errors, especially for the `in_axes` and `in_axis_resources` arguments for functions like `vmap`, `pmap`, `xmap`, and `pjit` (see e.g. #8996 for `pjit`). But I wanted to get feedback on them and check them in first before making those changes. That is, none of these functions are actually used yet (except in tests).

I also included a `broadcast_prefix` function which I think will replace `api_util.flatten_axes`.

For example, here's a complex `vmap` where we might get a tree prefix error:

```python
full = lambda x: jnp.full((3,), x)

x = {'a': [(full(1), full(2), 3)], 'b': [(full(4), full(5), 6)], 'c': [(full(7), full(8), 9)]}
in_axes = {'a': [(0, 0, None)], 'b': [(0,)], 'c': [(0, 0, None)]}
jax.vmap(lambda x: x, in_axes=in_axes)(x)
```

```
# BEFORE this PR
ValueError: vmap in_axes specification must be a tree prefix of the
corresponding value, got specification {'a': [(0, 0, None)], 'b': [(0,)], 'c':
[(0, 0, None)]} for value tree PyTreeDef(({'a': [(*, *, *)], 'b': [(*, *, *)],
'c': [(*, *, *)]},)).
```

In real world examples, often involving neural network parameter trees, these errors can be _much_ longer, with hundreds or thousands of tree leaves and significant nesting!

Here's a better kind of error that the new utility function lets us raise:

```python
from jax._src.tree_util import prefix_errors
all_errors = prefix_errors(in_axes, x)
e = all_errors[0]
raise e('in_axes')
```

```
# AFTER this PR
ValueError: pytree structure error: different numbers of pytree children at
in_axes['b'][0]: prefix pytree in_axes has 1 children where full pytree has 3
children.
```