### PR TITLE
Tolerate NumPy deprecation warnings when using older SciPy.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 """pytest configuration"""
 
-import jax
-import numpy
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def add_imports(doctest_namespace):
+  import jax
+  import numpy
   doctest_namespace["jax"] = jax
   doctest_namespace["lax"] = jax.lax
   doctest_namespace["jnp"] = jax.numpy

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,5 +16,10 @@ filterwarnings =
     ignore:jax.experimental.* is deprecated, import jax.example_libraries.* instead:FutureWarning
     # numpy uses distutils which is deprecated
     ignore:The distutils.* is deprecated.*:DeprecationWarning
+    # numpy deprecation warnings that can be triggered by an old SciPy version on NumPy 1.21.
+    # TODO(phawkins): Remove these when the minimum scipy version no longer triggers these
+    # (seen on scipy 1.2.3).
+    ignore:`np.*` is a deprecated alias for.*:DeprecationWarning
+    ignore:The module numpy.dual is deprecated.*:DeprecationWarning
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"


### PR DESCRIPTION
Simply importing scipy 1.2.3 with NumPy 1.21.5 leads to deprecation
warnings. Tolerate these in pytest.

Also, don't import `jax` directly during `conftest.py`. This improves the tracebacks printed by pytest..