### PR TITLE
Add complex types to mlir constant handlers

### DIFF
--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -241,9 +241,10 @@ def _ndarray_constant_handler(val: np.ndarray, canonicalize_types
 register_constant_handler(np.ndarray, _ndarray_constant_handler)
 
 for _scalar_type in [np.int8, np.int16, np.int32, np.int64,
-                    np.uint8, np.uint16, np.uint32, np.uint64,
-                    np.float16, np.float32, np.float64,
-                    np.bool_, np.longlong, dtypes.bfloat16]:
+                     np.uint8, np.uint16, np.uint32, np.uint64,
+                     np.float16, np.float32, np.float64,
+                     np.complex64, np.complex128,
+                     np.bool_, np.longlong, dtypes.bfloat16]:
   register_constant_handler(_scalar_type, _ndarray_constant_handler)
 
 def _python_scalar_handler(dtype, val, canonicalize_dtypes):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3120,6 +3120,16 @@ class APITest(jtu.JaxTestCase):
     expected = jnp.arange(1) + 1
     self.assertAllClose(ans, expected)
 
+  @parameterized.named_parameters([
+      {"testcase_name": f"{dtype.__name__}", "dtype": dtype}
+      for dtype in jtu.dtypes.all])
+  def test_constant_handlers(self, dtype):
+    # https://github.com/google/jax/issues/9380
+    @jax.jit
+    def f():
+      return jnp.exp(dtype(0))
+    f()  # doesn't error
+
   def test_large_python_ints(self):
     with self.assertRaises(OverflowError):
       jnp.multiply(2 ** 100, 3.)


### PR DESCRIPTION
Fixes #9380

What's still unclear to me is why this only errors with the most recent jaxlib release. 