### PR TITLE
NumpyUfuncTests: improve test generation

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -458,12 +458,6 @@ def supported_dtypes():
     types -= {np.uint64, np.int64, np.float64, np.complex128}
   return types
 
-def skip_if_unsupported_type(dtype):
-  dtype = np.dtype(dtype)
-  if dtype.type not in supported_dtypes():
-    raise unittest.SkipTest(
-      f"Type {dtype.name} not supported on {device_under_test()}")
-
 def is_device_rocm():
   return xla_bridge.get_backend().platform_version.startswith('rocm')
 


### PR DESCRIPTION
This improves the test generation code to avoid generating a large number of skipped test cases.

Also, some bonus deletion of obviated code.

Before:
```
(jax) bash-3.2$ JAX_ENABLE_X64=0 pytest tests/lax_numpy_test.py -k NumpyUfuncTests
======================================== test session starts =========================================
platform darwin -- Python 3.8.2, pytest-6.2.4, py-1.8.2, pluggy-0.13.1
rootdir: /Users/vanderplas/github/google/jax, configfile: pytest.ini
plugins: env-0.6.2, xdist-2.3.0, cov-2.10.0, forked-1.3.0
collected 4512 items / 3614 deselected / 898 selected                                                

tests/lax_numpy_test.py .s..ss..s..s..ss..s.s.sss.ss.s.s..ss..s..s..ss..s..s..ss..s..s..ss..s. [  7%]
.s.s..s....s..ss..s..ss.ss..s..s..s........s...s..s..s......s..s........s.s..s....s.s..s..s..s [ 18%]
s..s..s..ss..s..s.s..s....s..ss..s..s..ss..s....s.s..s....s.s..s.s.sss.ss.s.s.s..ss..s.sss.ss. [ 28%]
s.s..ss..s..s..ss..s..s..ss..s....s.s..s.s.sss.ss.s..s.s..ss....s.s..s.s.sss.ss.ss.sss.ss.s.s. [ 39%]
s..ss.....s.s..s.ss....s..ss.s.sss.ss.ssss.ss.s.s.s..s....s.s..s......s...s..s..ss..s..s..ss.. [ 49%]
s..s..ss..s.......s..s..s..ss.s.ss..ss....s.s.sss.ss.ssss.ss.s.s..ss..s..s..ss..s..s..ss..s..s [ 60%]
..ss..s..s.s..s....s.s..s...s.sss.ss.s.s..ss..s.s.sss.ss.ss.sss.ss.ss.sss.ss.ss.sss.ss.ss.sss. [ 70%]
ss.s.s.s..ss.....s.s..s.s.sss.ss.ss....s.....s.s..s...s.sss.ss.ss....s....s.sss.ss.s...s.s..s. [ 81%]
...s.s..s..s..ss..s..s.s..ss..ss..ss....ss..ss..s.s....s.......s.s..s..s..ss..s..s..ss..s.ssss [ 91%]
ssssss.s..ss..s.ss..ss..s.ssssssss...s..ss..s..s..ss..s.s.sss.ss.s...s.s..s.                   [100%]

========================= 502 passed, 396 skipped, 3614 deselected in 13.48s =========================

```
After:
```
(jax) bash-3.2$ JAX_ENABLE_X64=0 pytest tests/lax_numpy_test.py -k NumpyUfuncTests
======================================== test session starts =========================================
platform darwin -- Python 3.8.2, pytest-6.2.4, py-1.8.2, pluggy-0.13.1
rootdir: /Users/vanderplas/github/google/jax, configfile: pytest.ini
plugins: env-0.6.2, xdist-2.3.0, cov-2.10.0, forked-1.3.0
collected 4492 items / 3614 deselected / 878 selected                                                

tests/lax_numpy_test.py ...................................................................... [  7%]
.....................s........................................................................ [ 18%]
.............................................................................................. [ 29%]
.............................................................................................. [ 40%]
........s.....s............................................................................... [ 50%]
.....................ssss...s................................................................. [ 61%]
.............................................................................................. [ 72%]
................................................................s............................. [ 82%]
..............ssss...s..s...............................................sssssssss..........s.. [ 93%]
........................................................                                       [100%]

========================= 853 passed, 25 skipped, 3614 deselected in 14.23s ==========================

```