### PR TITLE
type promotion: disable uint64->float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.2.29 (Unreleased)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.2.28...main).
+  * In `jax.numpy` type promotion, values of type `np.uint64` now raise a `TypePromotionError`
+    in case of implicit type promotion to float. This affects its use in binary operations,
+    such as `2.0 * x`, which for `x` of type `uint64` previously returned `float64` and now
+    raises an error. It also affects any function that implicitly casts inputs to float, such
+    as `jnp.exp(x)`, which for `x` of type `uint64` previously returned `float64` and now
+    raises an error. The workaround in either case is to explicitly cast values to
+    `float64` when this behavior is desired; e.g. `2.0 * jnp.float64(x)`.
 
 ## jax 0.2.28 (Feb 1 2022)
 * [GitHub

--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -259,7 +259,7 @@ def _type_promotion_lattice():
   i_, f_, c_ = _weak_types
   return {
     b1: [i_],
-    u1: [i2, u2], u2: [i4, u4], u4: [i8, u8], u8: [f_],
+    u1: [i2, u2], u2: [i4, u4], u4: [i8, u8], u8: [],
     i_: [u1, i1], i1: [i2], i2: [i4], i4: [i8], i8: [f_],
     f_: [bf, f2, c_], bf: [f4], f2: [f4], f4: [f8, c4], f8: [c8],
     c_: [c4], c4: [c8], c8: [],
@@ -278,6 +278,11 @@ def _make_lattice_upper_bounds():
       upper_bounds[n] |= new_upper_bounds
   return upper_bounds
 _lattice_upper_bounds = _make_lattice_upper_bounds()
+
+
+class TypePromotionError(ValueError):
+  pass
+
 
 @functools.lru_cache(512)  # don't use util.memoize because there is no X64 dependence.
 def _least_upper_bound(*nodes):
@@ -313,7 +318,8 @@ def _least_upper_bound(*nodes):
   if len(LUB) == 1:
     return LUB.pop()
   else:
-    raise ValueError(f"{nodes} do not have a unique least upper bound.")
+    raise TypePromotionError(f"{nodes} have no available type promotion path. Try explicitly "
+                             "casting inputs to the desired output type.")
 
 def promote_types(a, b):
   """Returns the type to which a binary operation should cast its arguments.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -531,6 +531,10 @@ def _promote_dtypes_inexact(*args):
   Promotes arguments to an inexact type."""
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
   to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  if to_dtype == np.uint64:
+    # This case errors in dtypes.result_type; catch it here for a more pointed error message.
+    raise dtypes.TypePromotionError("uint64 values cannot be implicitly promoted to float. Try "
+                                    "explicitly casting the value using jnp.float64(value).")
   to_dtype_inexact = _to_inexact_dtype(to_dtype)
   weak_type = (weak_type and to_dtype == to_dtype_inexact)
   return [lax._convert_element_type(x, to_dtype_inexact, weak_type) for x in args]

--- a/jax/dtypes.py
+++ b/jax/dtypes.py
@@ -23,4 +23,5 @@ from jax._src.dtypes import (
     issubdtype,  # TODO(phawkins): switch callers to jnp.issubdtype?
     result_type as result_type,
     scalar_type_of as scalar_type_of,
+    TypePromotionError as TypePromotionError,
 )

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3127,7 +3127,7 @@ class APITest(jtu.JaxTestCase):
     # https://github.com/google/jax/issues/9380
     @jax.jit
     def f():
-      return jnp.exp(dtype(0))
+      return jnp.add(dtype(0), dtype(1))
     f()  # doesn't error
 
   def test_large_python_ints(self):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -68,6 +68,7 @@ float_dtypes = jtu.dtypes.all_floating
 complex_dtypes = jtu.dtypes.complex
 int_dtypes = jtu.dtypes.all_integer
 unsigned_dtypes = jtu.dtypes.all_unsigned
+unsigned_dtypes_no64 = [d for d in unsigned_dtypes if d != np.uint64]
 bool_dtypes = jtu.dtypes.boolean
 default_dtypes = float_dtypes + int_dtypes
 inexact_dtypes = float_dtypes + complex_dtypes
@@ -76,9 +77,6 @@ all_dtypes = number_dtypes + bool_dtypes
 
 
 python_scalar_dtypes = [jnp.bool_, jnp.int_, jnp.float_, jnp.complex_]
-
-# uint64 is problematic because with any uint type it promotes to float:
-int_dtypes_no_uint64 = [d for d in int_dtypes + unsigned_dtypes if d != np.uint64]
 
 def _indexer_with_default_outputs(indexer, use_defaults=True):
   """Like jtu.with_jax_dtype_defaults, but for __getitem__ APIs"""
@@ -132,7 +130,7 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
               all_shapes, jtu.rand_default, ["rev"]),
     op_record("add", 2, all_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("ceil", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("ceil", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("ceil", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_default, [], check_dtypes=False),
     op_record("conj", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"]),
     op_record("equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
@@ -145,7 +143,7 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
                          np.float64: 1e-12, np.complex64: 2e-4,
                          np.complex128: 1e-12}, check_dtypes=False),
     op_record("floor", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("floor", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("floor", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_default, [], check_dtypes=False),
     op_record("greater", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
     op_record("greater_equal", 2, all_dtypes, all_shapes, jtu.rand_some_equal, []),
@@ -174,7 +172,7 @@ JAX_ONE_TO_ONE_OP_RECORDS = [
     op_record("signbit", 1, default_dtypes + bool_dtypes, all_shapes,
               jtu.rand_some_inf_and_nan, ["rev"]),
     op_record("trunc", 1, float_dtypes, all_shapes, jtu.rand_some_inf_and_nan, []),
-    op_record("trunc", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("trunc", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_some_inf_and_nan, [], check_dtypes=False),
     op_record("sin", 1, number_dtypes, all_shapes, jtu.rand_default, ["rev"],
               inexact=True),
@@ -235,11 +233,11 @@ JAX_COMPOUND_OP_RECORDS = [
     op_record("expm1", 1, number_dtypes, all_shapes, jtu.rand_small_positive,
               [], tolerance={np.float64: 1e-8}, inexact=True),
     op_record("fix", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("fix", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("fix", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_default, [], check_dtypes=False),
     op_record("floor_divide", 2, float_dtypes + int_dtypes,
               all_shapes, jtu.rand_nonzero, ["rev"]),
-    op_record("floor_divide", 2, unsigned_dtypes, all_shapes,
+    op_record("floor_divide", 2, unsigned_dtypes_no64, all_shapes,
               jtu.rand_nonzero, ["rev"]),
     op_record("fmin", 2, number_dtypes, all_shapes, jtu.rand_some_nan, []),
     op_record("fmax", 2, number_dtypes, all_shapes, jtu.rand_some_nan, []),
@@ -288,18 +286,18 @@ JAX_COMPOUND_OP_RECORDS = [
               tolerance={np.float16: 1e-2}),
     op_record("mod", 2, default_dtypes, all_shapes, jtu.rand_nonzero, []),
     op_record("modf", 1, float_dtypes, all_shapes, jtu.rand_default, []),
-    op_record("modf", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("modf", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_default, [], check_dtypes=False),
     op_record("rint", 1, inexact_dtypes, all_shapes, jtu.rand_some_inf_and_nan,
               []),
-    op_record("rint", 1, int_dtypes + unsigned_dtypes, all_shapes,
+    op_record("rint", 1, int_dtypes + unsigned_dtypes_no64, all_shapes,
               jtu.rand_default, [], check_dtypes=False),
     op_record("sign", 1, number_dtypes + unsigned_dtypes,
               all_shapes, jtu.rand_some_inf_and_nan, []),
     # numpy 1.16 has trouble mixing uint and bfloat16, so we test these separately.
     op_record("copysign", 2, default_dtypes,
               all_shapes, jtu.rand_some_inf_and_nan, [], check_dtypes=False),
-    op_record("copysign", 2, unsigned_dtypes,
+    op_record("copysign", 2, unsigned_dtypes_no64,
               all_shapes, jtu.rand_some_inf_and_nan, [], check_dtypes=False),
     op_record("sinc", 1, [t for t in number_dtypes if t != jnp.bfloat16],
               all_shapes, jtu.rand_default, ["rev"],
@@ -327,8 +325,8 @@ JAX_COMPOUND_OP_RECORDS = [
               tolerance={dtypes.bfloat16: 1e-1, np.float16: 1e-1}),
     op_record("isclose", 2, [t for t in all_dtypes if t != jnp.bfloat16],
               all_shapes, jtu.rand_small_positive, []),
-    op_record("gcd", 2, int_dtypes_no_uint64, all_shapes, jtu.rand_default, []),
-    op_record("lcm", 2, int_dtypes_no_uint64, all_shapes, jtu.rand_default, []),
+    op_record("gcd", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, jtu.rand_default, []),
+    op_record("lcm", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, jtu.rand_default, []),
 ]
 
 JAX_BITWISE_OP_RECORDS = [
@@ -442,8 +440,8 @@ JAX_OPERATOR_OVERLOADS = [
     # op_record("__and__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
     # op_record("__xor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
     # op_record("__divmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("__lshift__", 2, int_dtypes_no_uint64, all_shapes, partial(jtu.rand_int, high=8), []),
-    op_record("__rshift__", 2, int_dtypes_no_uint64, all_shapes, partial(jtu.rand_int, high=8), []),
+    op_record("__lshift__", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, partial(jtu.rand_int, high=8), []),
+    op_record("__rshift__", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, partial(jtu.rand_int, high=8), []),
 ]
 
 JAX_RIGHT_OPERATOR_OVERLOADS = [
@@ -462,8 +460,8 @@ JAX_RIGHT_OPERATOR_OVERLOADS = [
     # op_record("__rand__", 2, number_dtypes, all_shapes, jtu.rand_default, []),
     # op_record("__rxor__", 2, number_dtypes, all_shapes, jtu.rand_bool, []),
     # op_record("__rdivmod__", 2, number_dtypes, all_shapes, jtu.rand_nonzero, []),
-    op_record("__rlshift__", 2, int_dtypes_no_uint64, all_shapes, partial(jtu.rand_int, high=8), []),
-    op_record("__rrshift__", 2, int_dtypes_no_uint64, all_shapes, partial(jtu.rand_int, high=8), [])
+    op_record("__rlshift__", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, partial(jtu.rand_int, high=8), []),
+    op_record("__rrshift__", 2, int_dtypes + unsigned_dtypes_no64, all_shapes, partial(jtu.rand_int, high=8), [])
 ]
 
 class _OverrideEverything(object):
@@ -742,7 +740,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       # TODO numpy always promotes to shift dtype for zero-dim shapes:
       itertools.combinations_with_replacement(nonzerodim_shapes, 2))
     for dtypes in itertools.product(
-      *(_valid_dtypes_for_shape(s, int_dtypes_no_uint64) for s in shapes))))
+      *(_valid_dtypes_for_shape(s, int_dtypes + unsigned_dtypes_no64) for s in shapes))))
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testShiftOpAgainstNumpy(self, op, dtypes, shapes):
     dtype, shift_dtype = dtypes
@@ -6105,9 +6103,10 @@ class NumpySignaturesTest(jtu.JaxTestCase):
     self.assertEqual(mismatches, {})
 
 
-_all_dtypes: List[str] = [
+# Skip uint64 because it cannot be promoted to inexact.
+_all_dtypes_but_uint64: List[str] = [
   "bool_",
-  "uint8", "uint16", "uint32", "uint64",
+  "uint8", "uint16", "uint32",
   "int8", "int16", "int32", "int64",
   "float16", "float32", "float64",
   "complex64", "complex128",
@@ -6125,7 +6124,7 @@ def _all_numpy_ufuncs() -> Iterator[str]:
 def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:
   """Generate valid dtypes of inputs to the given numpy ufunc."""
   func = getattr(np, name)
-  for arg_dtypes in itertools.product(_all_dtypes, repeat=func.nin):
+  for arg_dtypes in itertools.product(_all_dtypes_but_uint64, repeat=func.nin):
     args = (np.ones(1, dtype=dtype) for dtype in arg_dtypes)
     try:
       with warnings.catch_warnings():


### PR DESCRIPTION
In the current type promotion lattice, there is a promotion path from `uint64` to `float*`, which means that JAX follows numpy's behavior of promoting `np.uint64`  & `np.int64` to float.

This promotion behavior can be surprising, and there are good arguments that we should not do this kind of promotion implicitly.

This PR is a draft that removes this behavior, such that `np.uint64` promoting with any signed type results in an error.

Pulling in before review for additional testing.