### PR TITLE
add core.cur_level() function to get trace level

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -736,6 +736,9 @@ def reset_trace_state() -> bool:
 def cur_sublevel() -> Sublevel:
   return thread_local_state.trace_state.substack[-1]
 
+def cur_level() -> int:
+  return thread_local_state.trace_state.trace_stack.stack[-1].level
+
 TRACER_LEAK_DEBUGGER_WARNING = """\
 JAX check_tracer_leaks behavior can trigger false positives when used with a debugger.
 To avoid false positives and silence this warning, you can disable thread tracing using


### PR DESCRIPTION
This function may be useful for library authors who want to prevent common user errors related to applying JAX transformations to effectful code. By checking the level one can notice if new transformations have been applied when calling effectful functions (e.g. to get a new PRNG key) in the middle of an effectful context (when transformations should be avoided).

This is an experiment in collaboration with particular library authors. If it's useful we may end up documenting this as a "tier 2: libraray author API", as opposed to a "tier 1: public user API".

Here's how it can be used:

```python
import jax

def f():
  print(jax.core.cur_level())
  return 0.

f()  # 0
jax.vmap(f, axis_size=3)()  # 1
jax.vmap(jax.vmap(f, axis_size=3), axis_size=2)()  # 2
jax.jvp(jax.vmap(f, axis_size=1), (), ())  # 2
```

The level reflects proper transformation level and does not reflect staging level for `jit`, `pmap`, or `xmap`:

```python
jax.jit(f)()  # 0
```

If one wants to catch whether such staging is happening, one can check whether `jax.core.thread_local_state.trace_state.trace_stack.dynamic` is a `jax.core.EvalTrace` instance. Or one can just write a primitive for which the abstract eval rule raises an error:

```python
def no_staging():
  no_staging_p.bind()
no_staging_p = jax.core.Primitive('no_staging')

@no_staging_p.def_impl
def no_staging_impl():
  pass

@no_staging_p.def_abstract_eval
def no_staging_abstract_eval():
  raise Exception("can't be staged!")

##
f()  # fine!
jax.jit(f)()  # Exception: can't be staged!
```

But `jit`/`pmap`/`xmap` staging aside, the `cur_level` function added in this PR should be helpful for catching transforamtions.

cc @tomhennigan 

TODO:
* [ ] tweak this to something more like `get_hashable_trace_state`, which would include the level, sublevel, and dynamic trace type.