### PR TITLE
DOC: move functions in jax.html to their own pages

### DIFF
--- a/docs/jax.experimental.ann.rst
+++ b/docs/jax.experimental.ann.rst
@@ -6,5 +6,8 @@ jax.experimental.ann module
 API
 ---
 
-.. autofunction:: approx_max_k
-.. autofunction:: approx_min_k
+.. autosummary::
+   :toctree: _autosummary
+
+   approx_max_k
+   approx_min_k

--- a/docs/jax.experimental.global_device_array.rst
+++ b/docs/jax.experimental.global_device_array.rst
@@ -6,6 +6,8 @@ jax.experimental.global_device_array module
 API
 ---
 
-.. autoclass:: GlobalDeviceArray
-    :members:
-.. autoclass:: Shard
+.. autosummary::
+   :toctree: _autosummary
+
+   GlobalDeviceArray
+   Shard

--- a/docs/jax.experimental.host_callback.rst
+++ b/docs/jax.experimental.host_callback.rst
@@ -7,11 +7,14 @@ jax.experimental.host_callback module
 API
 ---
 
-.. autofunction:: id_tap
-.. autofunction:: id_print
-.. autofunction:: call
-.. autofunction:: barrier_wait
-.. autoexception:: CallbackException
+.. autosummary::
+   :toctree: _autosummary
+
+   id_tap
+   id_print
+   call
+   barrier_wait
+   CallbackException
 
 
 

--- a/docs/jax.experimental.maps.rst
+++ b/docs/jax.experimental.maps.rst
@@ -6,5 +6,8 @@ jax.experimental.maps module
 API
 ---
 
-.. autofunction:: mesh
-.. autofunction:: xmap
+.. autosummary::
+   :toctree: _autosummary
+  
+   mesh
+   xmap

--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -1,8 +1,13 @@
+.. currentmodule:: jax.experimental
+
 jax.experimental package
 ========================
 
 ``jax.experimental.optix`` has been moved into its own Python package
-(``optax``).
+(https://github.com/deepmind/optax).
+
+Experimental Modules
+--------------------
 
 .. toctree::
     :maxdepth: 1
@@ -15,7 +20,11 @@ jax.experimental package
     jax.experimental.pjit
     jax.experimental.sparse
 
-.. automodule:: jax.experimental
+Experimental APIs
+-----------------
 
-.. autofunction:: enable_x64
-.. autofunction:: disable_x64
+.. autosummary::
+   :toctree: _autosummary
+
+   enable_x64
+   disable_x64

--- a/docs/jax.experimental.sparse.rst
+++ b/docs/jax.experimental.sparse.rst
@@ -6,5 +6,8 @@ jax.experimental.sparse module
 API
 ---
 
-.. autoclass:: BCOO
-.. autofunction:: sparsify
+.. autosummary::
+   :toctree: _autosummary
+
+   BCOO
+   sparsify

--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -35,6 +35,7 @@ Just-in-time compilation (:code:`jit`)
 --------------------------------------
 
 .. autosummary::
+  :toctree: _autosummary
 
     jit
     disable_jit
@@ -48,6 +49,7 @@ Just-in-time compilation (:code:`jit`)
     device_get
     default_backend
     named_call
+    block_until_ready
 
 .. _jax-grad:
 
@@ -55,6 +57,7 @@ Automatic differentiation
 -------------------------
 
 .. autosummary::
+  :toctree: _autosummary
 
     grad
     value_and_grad
@@ -75,14 +78,16 @@ Vectorization (:code:`vmap`)
 ----------------------------
 
 .. autosummary::
+  :toctree: _autosummary
 
     vmap
-    jax.numpy.vectorize
+    numpy.vectorize
 
 Parallelization (:code:`pmap`)
 ------------------------------
 
 .. autosummary::
+  :toctree: _autosummary
 
     pmap
     devices
@@ -91,52 +96,3 @@ Parallelization (:code:`pmap`)
     device_count
     local_device_count
     process_count
-
-
-.. autofunction:: jit
-.. autofunction:: disable_jit
-.. autofunction:: ensure_compile_time_eval
-.. autofunction:: xla_computation
-.. autofunction:: make_jaxpr
-.. autofunction:: eval_shape
-.. autofunction:: device_put
-.. autofunction:: device_put_replicated
-.. autofunction:: device_put_sharded
-.. autofunction:: device_get
-.. autofunction:: block_until_ready
-.. autofunction:: default_backend
-.. autofunction:: named_call
-
-.. autofunction:: grad
-.. autofunction:: value_and_grad
-.. autofunction:: jacfwd
-.. autofunction:: jacrev
-.. autofunction:: hessian
-.. autofunction:: jvp
-.. autofunction:: linearize
-.. autofunction:: linear_transpose
-.. autofunction:: vjp
-.. autoclass:: custom_jvp
-
-    .. automethod:: defjvp
-    .. automethod:: defjvps
-
-.. autoclass:: custom_vjp
-
-    .. automethod:: defvjp
-
-.. autofunction:: closure_convert
-
-.. autofunction:: checkpoint
-
-.. autofunction:: vmap
-.. autofunction:: jax.numpy.vectorize
-  :noindex:
-
-.. autofunction:: pmap
-.. autofunction:: devices
-.. autofunction:: local_devices
-.. autofunction:: process_index
-.. autofunction:: device_count
-.. autofunction:: local_device_count
-.. autofunction:: process_count


### PR DESCRIPTION
Fixes #9435

See the rendered docs here: https://jax--9437.org.readthedocs.build/en/9437/jax.html