### PR TITLE
Use the sphinx-book-theme for JAX documentation.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'sphinx_autodoc_typehints',
     'myst_nb',
+    "sphinx_remove_toctrees",
     'jax_extensions',
 ]
 
@@ -148,13 +149,14 @@ napolean_use_rtype = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_book_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
     'logo_only': True,
+    'show_toc_level': 2,
 }
 
 # The name of an image file (relative to this directory) to place at the top
@@ -280,3 +282,7 @@ epub_exclude_files = ['search.html']
 # Tell sphinx-autodoc-typehints to generate stub parameter annotations including
 # types, even if the parameters aren't explicitly documented.
 always_document_param_types = True
+
+
+# Remove auto-generated API docs from sidebars. They take too long to build.
+remove_from_toctrees = ["_autosummary/*"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,8 @@
 # sphinx >=3 required by sphinx-autodoc-typehints v1.11.1 (Oct 2020)
 sphinx >=3
 sphinx_rtd_theme
+sphinx-book-theme
+sphinx-remove-toctrees
 # Newer versions cause issues; see https://github.com/google/jax/pull/6449
 sphinx-autodoc-typehints==1.11.1
 jupyter-sphinx>=0.3.2


### PR DESCRIPTION
Improves #9434 (there may still be work to do on the page structure to have a usable right navigation).