### PR TITLE
tests: add unsigned ints to all_dtypes

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -609,7 +609,10 @@ def _rand_dtype(rand, shape, dtype, scale=1., post=lambda x: x):
     An ndarray of the given shape and dtype using random values based on a call
     to rand but scaled, converted to the appropriate dtype, and post-processed.
   """
-  r = lambda: np.asarray(scale * rand(*_dims_of_shape(shape)), dtype)
+  if _dtypes.issubdtype(dtype, np.unsignedinteger):
+    r = lambda: np.asarray(scale * abs(rand(*_dims_of_shape(shape))), dtype)
+  else:
+    r = lambda: np.asarray(scale * rand(*_dims_of_shape(shape)), dtype)
   if _dtypes.issubdtype(dtype, np.complexfloating):
     vals = r() + 1.0j * r()
   else:


### PR DESCRIPTION
In the course of testing the uint64 promotion change (#9396), I realized that we have poor test coverage of this because in `lax_numpy_test.py`, `all_dtypes` does not include unsigned!

This PR rectifies this, as well as making a modification to `jax.test_util.default_rng` to avoid generating large unsigned integers in the standard case.