### PR TITLE
Add `-j auto` to the suggested doc build instructions.

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -228,14 +228,17 @@ pip install -r docs/requirements.txt
 ```
 And then run:
 ```
-sphinx-build -b html docs docs/build/html
+sphinx-build -b html docs docs/build/html -j auto
 ```
 This can take a long time because it executes many of the notebooks in the documentation source;
 if you'd prefer to build the docs without executing the notebooks, you can run:
 ```
-sphinx-build -b html -D jupyter_execute_notebooks=off docs docs/build/html
+sphinx-build -b html -D jupyter_execute_notebooks=off docs docs/build/html -j auto
 ```
 You can then see the generated documentation in `docs/build/html/index.html`.
+
+The `-j auto` option controls the parallelism of the build. You can use a number
+in place of `auto` to control how many CPU cores to use.
 
 (update-notebooks)=
 


### PR DESCRIPTION
Despite being marked as experimental, parallelism appears to work fine for JAX doc builds, and speeds up builds significantly.