### PR TITLE
add flag for jaxpr colorful syntax highlighting

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -441,6 +441,12 @@ flags.DEFINE_integer(
 )
 
 flags.DEFINE_bool(
+    'jax_pprint_use_color',
+    bool_env('JAX_PPRINT_USE_COLOR', False),
+    help='Enable jaxpr pretty-printing with colorful syntax highlighting.'
+)
+
+flags.DEFINE_bool(
     'jax_host_callback_inline',
     bool_env('JAX_HOST_CALLBACK_INLINE', False),
     help='Inline the host_callback, if not in a staged context.'

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -47,6 +47,7 @@ from jax.interpreters import ad
 from jax.interpreters import invertible_ad as iad
 from jax.interpreters import batching
 from jax.interpreters import masking
+import jax._src.pretty_printer as pp
 from jax._src import util
 from jax._src.util import (cache, safe_zip, prod, safe_map, canonicalize_axis,
                            split_list)
@@ -2250,6 +2251,16 @@ def _convert_elt_type_fwd_rule(eqn):
   else:
     return [None], eqn
 
+def _convert_elt_type_pp_rule(eqn, context):
+  # don't print new_dtype because the output binder shows it
+  printed_params = {}
+  if eqn.params['weak_type']:
+    printed_params['weak_type'] = True
+  return [pp.text(eqn.primitive.name),
+          core.pp_kv_pairs(sorted(printed_params.items()), context),
+          pp.text(" ") + core.pp_vars(eqn.invars, context)]
+
+
 convert_element_type_p = Primitive('convert_element_type')
 convert_element_type_p.def_impl(partial(xla.apply_primitive, convert_element_type_p))
 convert_element_type_p.def_abstract_eval(
@@ -2264,6 +2275,8 @@ batching.defvectorized(convert_element_type_p)
 masking.defvectorized(convert_element_type_p)
 pe.const_fold_rules[convert_element_type_p] = _convert_elt_type_folding_rule
 pe.forwarding_rules[convert_element_type_p] = _convert_elt_type_fwd_rule
+# TODO(mattjj): un-comment the next line (see #9456)
+# core.pp_eqn_rules[convert_element_type_p] = _convert_elt_type_pp_rule
 
 def _real_dtype(dtype): return np.finfo(dtype).dtype
 

--- a/jax/_src/pretty_printer.py
+++ b/jax/_src/pretty_printer.py
@@ -29,6 +29,7 @@ import abc
 import enum
 from functools import partial
 from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
+from jax.config import config
 
 try:
   import colorama  # pytype: disable=import-error
@@ -41,6 +42,7 @@ class Doc(abc.ABC):
 
   def format(self, width: int = 80, use_color: bool = False,
              annotation_prefix=" # ") -> str:
+    use_color = use_color or config.FLAGS.jax_pprint_use_color
     return _format(self, width, use_color=use_color,
                    annotation_prefix=annotation_prefix)
 
@@ -374,8 +376,9 @@ def color(doc: Doc, *, foreground: Optional[Color] = None,
                    intensity=intensity)
 
 
-dim = partial(color, intensity=Intensity.DIM)
-bright = partial(color, intensity=Intensity.BRIGHT)
+type_annotation = partial(color, intensity=Intensity.NORMAL,
+                          foreground=Color.MAGENTA)
+keyword = partial(color, intensity=Intensity.BRIGHT, foreground=Color.BLUE)
 
 
 def join(sep: Doc, docs: Sequence[Doc]) -> Doc:

--- a/jax/core.py
+++ b/jax/core.py
@@ -87,6 +87,9 @@ class Jaxpr:
                    custom_pp_eqn_rules=custom_pp_eqn_rules)
     return doc.format(**kw)
 
+  def _repr_pretty_(self, p, cycle):
+    return p.text(self.pretty_print(use_color=True))
+
 
 def jaxprs_in_params(params) -> Iterator[Jaxpr]:
   for val in params.values():
@@ -141,6 +144,10 @@ class ClosedJaxpr:
   def pretty_print(self, *, source_info=False, print_shapes=True, **kw):
     return pp_jaxpr(self.jaxpr, JaxprPpContext(), source_info=source_info,
                     print_shapes=print_shapes).format(**kw)
+
+
+  def _repr_pretty_(self, p, cycle):
+    return p.text(self.pretty_print(use_color=True))
 
 @curry
 def jaxpr_as_fun(closed_jaxpr: ClosedJaxpr, *args):
@@ -2248,7 +2255,7 @@ def pp_vars(vs: Sequence[Any], context: JaxprPpContext,
     return pp.nest(2, pp.group(
       pp.join(pp.text(separator) + pp.group(pp.brk()), [
         pp.text(pp_var(v, context)) +
-        pp.dim(pp.text(":" + pp_aval(v.aval, context)))
+        pp.type_annotation(pp.text(":" + pp_aval(v.aval, context)))
         for v in vs
       ])
     ))
@@ -2321,11 +2328,11 @@ def pp_jaxpr_skeleton(jaxpr, eqns_fn, context: JaxprPpContext, *,
     pp.text("("), pp_vars(jaxpr.outvars, context, separator=","),
     pp.text(")" if len(jaxpr.outvars) != 1 else ",)")])
   return pp.group(pp.nest(2, pp.concat([
-    pp.text("{ "), pp.bright(pp.text("lambda ")),
+    pp.text("{ "), pp.keyword(pp.text("lambda ")),
     constvars, pp.text("; "), invars,
-    pp.text(". "), pp.bright(pp.text("let")),
+    pp.text(". "), pp.keyword(pp.text("let")),
     pp.nest(2, pp.brk() + eqns), pp.brk(),
-    pp.bright(pp.text("in ")), outvars
+    pp.keyword(pp.text("in ")), outvars
   ])) + pp.text(" }"))
 
 


### PR DESCRIPTION
@hawkinsp added all the cool stuff here, this PR is just turning it on by default in ipython and jupyter notebooks, and making it easier to switch on manually!

Also use real colors, not just intensity.

![image](https://user-images.githubusercontent.com/1458824/152626868-1e0264f8-7d9d-4e76-898d-04bb5f9978ff.png)

![image](https://user-images.githubusercontent.com/1458824/152626922-f99fba0a-6178-4f31-8446-0fa1c5c2c8e0.png)

---

TODO:
* [x] detect if output is a terminal emulator or ipython session (and not e.g. `less`), and only print colors by default then