### PR TITLE
Small speedups to core.raise_to_shaped().

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1331,9 +1331,12 @@ pytype_aval_mappings[Token] = lambda _: abstract_token
 
 
 def raise_to_shaped(aval: AbstractValue, weak_type=None):
+  aval_type = type(aval)
+  if aval_type is ShapedArray and weak_type is None:
+    return aval
   if weak_type is None:
     weak_type = getattr(aval, 'weak_type', False)
-  for typ in type(aval).__mro__:
+  for typ in aval_type.__mro__:
     handler = raise_to_shaped_mappings.get(typ)
     if handler: return handler(aval, weak_type)
   raise TypeError(type(aval))
@@ -1561,7 +1564,7 @@ def canonicalize_shape(shape: Shape, context: str="") -> Shape:
     A tuple of canonical dimension values.
   """
   try:
-    return tuple(map(_canonicalize_dimension, shape))
+    return tuple(unsafe_map(_canonicalize_dimension, shape))
   except TypeError:
     pass
   raise _invalid_shape_error(shape, context)


### PR DESCRIPTION
Avoid forming a new ShapedArray if we already have a ShapedArray.

Don't use the slower safe map() when canonicalizing shapes. We're going
to form a tuple anyway.

Before:
```
In [1]: import numpy as np ; from jax import core, numpy as jnp
In [2]: x = core.ShapedArray((100,100), jnp.float32)
In [3]: %timeit core.raise_to_shaped(x)
4.11 µs ± 30.9 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

After:
```
In [1]: import numpy as np ; from jax import core, numpy as jnp
In [2]: x = core.ShapedArray((100,100), jnp.float32)
In [3]: %timeit core.raise_to_shaped(x)
207 ns ± 0.131 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```