### PR TITLE
Update scipy intersphinx inventory for SciPy 1.8.0.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/', None),
 }
 
 suppress_warnings = [


### PR DESCRIPTION
According to https://github.com/scipy/scipy/issues/14267 the SciPy docs seems to have moved.