### PR TITLE
improve pjit in/out_axis_resources pytree errors

### DIFF
--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -55,4 +55,7 @@ from jax._src.tree_util import (
   treedef_children as treedef_children,
   treedef_is_leaf as treedef_is_leaf,
   treedef_tuple as treedef_tuple,
+  register_keypaths as register_keypaths,
+  AttributeKeyPathEntry as AttributeKeyPathEntry,
+  GetitemKeyPathEntry as GetitemKeyPathEntry,
 )

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1138,15 +1138,32 @@ class PJitErrorTest(jtu.JaxTestCase):
   def testAxisResourcesMismatch(self):
     x = jnp.ones([])
     p = [None, None, None]
+
     pjit(lambda x: x, (p,), p)([x, x, x])  # OK
+
     error = re.escape(
-        r"pjit in_axis_resources specification must be a tree prefix of the "
-        r"corresponding value, got specification (None, None, None) for value "
-        r"tree PyTreeDef((*, *)). Note that pjit in_axis_resources that are "
-        r"non-trivial pytrees should always be wrapped in a tuple representing "
-        r"the argument list.")
+        "pjit in_axis_resources specification must be a tree prefix of the "
+        "positional arguments tuple passed to the `pjit`-decorated function. "
+        "In particular, pjit in_axis_resources must either be a None, a "
+        "PartitionSpec, or a tuple of length equal to the number of positional "
+        "arguments. But pjit in_axis_resources is the wrong length: got a "
+        "tuple or list of length 3 for an args tuple of length 2.")
     with self.assertRaisesRegex(ValueError, error):
-      pjit(lambda x, y: x, p, p)(x, x)  # Error, but make sure we hint at tupling
+      pjit(lambda x, y: x, p, p)(x, x)
+
+    Foo = namedtuple('Foo', ['x'])
+    error = "in_axis_resources is not a tuple.*might need to be wrapped"
+    with self.assertRaisesRegex(ValueError, error):
+      pjit(lambda x: x, Foo(None), Foo(None))(Foo(x))
+
+    pjit(lambda x: x, (Foo(None),), Foo(None))(Foo(x))  # OK w/ singleton tuple
+
+    # TODO(apaszke,mattjj): Disable implicit list casts and enable this
+    # error = ("it looks like pjit in_axis_resources might need to be wrapped in "
+    #          "a singleton tuple.")
+    # with self.assertRaisesRegex(ValueError, error):
+    #   pjit(lambda x, y: x, p, p)([x, x, x])
+
     # TODO(apaszke): Disable implicit list casts and enable this
     # error = re.escape(
     # r"pjit in_axis_resources specification must be a tree prefix of the "
@@ -1158,10 +1175,16 @@ class PJitErrorTest(jtu.JaxTestCase):
     # r"singleton tuple.")
     # with self.assertRaisesRegex(ValueError, error):
     # pjit(lambda x: x, p, p)([x, x, x])  # Error, but make sure we hint at singleton tuple
+
     error = re.escape(
-        r"pjit out_axis_resources specification must be a tree prefix of the "
-        r"corresponding value, got specification [[None, None, None], None] for "
-        r"value tree PyTreeDef([*, *, *]).")
+        "pytree structure error: different numbers of pytree children at "
+        "key path\n"
+        "    pjit out_axis_resources tree root\n"
+        "At that key path, the prefix pytree pjit out_axis_resources has a "
+        "subtree of type\n"
+        "    <class 'list'>\n"
+        "with 2 children, but at the same key path the full pytree has a "
+        "subtree of the same type but with 3 children.")
     with self.assertRaisesRegex(ValueError, error):
       pjit(lambda x: x, (p,), [p, None])([x, x, x])  # Error, we raise a generic tree mismatch message
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -439,79 +439,91 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
 
   def test_different_types(self):
     e, = prefix_errors((1, 2), [1, 2])
-    expected = "pytree structure error: different types at in_axes tree root"
+    expected = ("pytree structure error: different types at key path\n"
+                "    in_axes tree root")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_types_nested(self):
     e, = prefix_errors(((1,), (2,)), ([3], (4,)))
-    expected = r"pytree structure error: different types at in_axes\[0\]"
+    expected = ("pytree structure error: different types at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_types_multiple(self):
     e1, e2 = prefix_errors(((1,), (2,)), ([3], [4]))
-    expected = r"pytree structure error: different types at in_axes\[0\]"
+    expected = ("pytree structure error: different types at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e1('in_axes')
-    expected = r"pytree structure error: different types at in_axes\[1\]"
+    expected = ("pytree structure error: different types at key path\n"
+                r"    in_axes\[1\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e2('in_axes')
 
   def test_different_num_children(self):
     e, = prefix_errors((1,), (2, 3))
     expected = ("pytree structure error: different numbers of pytree children "
-                "at in_axes tree root")
+                "at key path\n"
+                "    in_axes tree root")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_num_children_nested(self):
     e, = prefix_errors([[1]], [[2, 3]])
     expected = ("pytree structure error: different numbers of pytree children "
-                r"at in_axes\[0\]")
+                "at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_num_children_multiple(self):
     e1, e2 = prefix_errors([[1], [2]], [[3, 4], [5, 6]])
     expected = ("pytree structure error: different numbers of pytree children "
-                r"at in_axes\[0\]")
+                "at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e1('in_axes')
     expected = ("pytree structure error: different numbers of pytree children "
-                r"at in_axes\[1\]")
+                "at key path\n"
+                r"    in_axes\[1\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e2('in_axes')
 
   def test_different_metadata(self):
     e, = prefix_errors({1: 2}, {3: 4})
     expected = ("pytree structure error: different pytree metadata "
-                "at in_axes tree root")
+                "at key path\n"
+                "    in_axes tree root")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_metadata_nested(self):
     e, = prefix_errors([{1: 2}], [{3: 4}])
     expected = ("pytree structure error: different pytree metadata "
-                r"at in_axes\[0\]")
+                "at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 
   def test_different_metadata_multiple(self):
     e1, e2 = prefix_errors([{1: 2}, {3: 4}], [{3: 4}, {5: 6}])
     expected = ("pytree structure error: different pytree metadata "
-                r"at in_axes\[0\]")
+                "at key path\n"
+                r"    in_axes\[0\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e1('in_axes')
     expected = ("pytree structure error: different pytree metadata "
-                r"at in_axes\[1\]")
+                "at key path\n"
+                r"    in_axes\[1\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e2('in_axes')
 
   def test_fallback_keypath(self):
     e, = prefix_errors(Special(1, [2]), Special(3, 4))
-    expected = ("pytree structure error: different types at "
-                r"in_axes\[<flat index 1>\]")
+    expected = ("pytree structure error: different types at key path\n"
+                r"    in_axes\[<flat index 1>\]")
     with self.assertRaisesRegex(ValueError, expected):
       raise e('in_axes')
 


### PR DESCRIPTION
Fixes #8996.

This is an application to `pjit` of the utilities added in #9372. We still want to apply them to `xmap`, `pmap`, and `vmap` too.

Have you ever tried to use `pjit`'s `in_axes_resources` or `out_axis_resources`, or `vmap`'s `in_axes` or `out_axes`, only to get a giant error message about a pytree mismatch?

And I mean really giant: **here's [a real example](https://gist.github.com/mattjj/bb7ba55f79789ccc6739f6c8116e6eaa)**. What are you supposed to do with an error message like that?

These error messages were gigantic because we just printed two full pytrees, even though pytrees for neural net models can be huge, and even though it might be just one buried pytree node that disagrees. #9372 added utilities to find disagreements between pytrees and report to them more precisely. By using those utilities with `pjit`, we can get more actionable errors.

Here's the new error message on that same real example:
```
ValueError: pytree structure error: different pytree metadata at key path
    pjit out_axis_resources.opt_states[0][2].stats.local_stats['lm']['final_ln']['bias'].diagonal_statistics
At that key path, the prefix pytree pjit out_axis_resources has a subtree of type
    <class 'scalable_shampoo.optax.distributed_shampoo.QuantizedValue'>
with metadata
    (<class 'jax._src.numpy.lax_numpy.float32'>, False, [32])
but at the same key path the full pytree has a subtree of the same type but with metadata
    (<class 'jax._src.numpy.lax_numpy.float32'>, False, (32,))
so the diff in the metadata at these pytree nodes is
    - (<class 'jax._src.numpy.lax_numpy.float32'>, False, [32])
    ?                                                     ^  ^

    + (<class 'jax._src.numpy.lax_numpy.float32'>, False, (32,))
    ?                                                     ^  ^ +
```

(Actually, to get that error message with the full key path we need to submit two-liner updates to Flax and Lingvo. I'll do those too!)

cc @skye 

**Notes for reviewer**:
* The changes in _src/tree_util.py are just (1) tweaks to whitespace in printed errors, and (2) plumbing an optional `is_leaf` function through `prefix_errors` (even though we don't use that argument in this PR);
* Most of the changes in tree_util_test.py are compensating for the whitespace changes mentioned above;
* The changes in pjit_test.py are (1) rephrasing of existing error messages and (2) a few new cases;
* The changes in pjit.py are mainly about calling the `prefix_errors` function, though they also (1) clarified the error-raising logic a bit and (2) don't rely on the `flatten_axes` utility to raise errors anymore (indeed I hope to remove all callers of that function as we move `vmap`, `xmap`, and `pmap` to a pattern more like the one in this PR).