### PR TITLE
Replace core.pp_eqn_compact() with core.str_eqn_compact().

### DIFF
--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -39,7 +39,6 @@ from jax._src.lib.mlir.dialects import chlo
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.lib.mlir.dialects import std
 from jax._src.lib import xla_client as xc
-import jax._src.pretty_printer as pp
 from jax._src import source_info_util
 import jax._src.util as util
 import jax.interpreters.ad as ad
@@ -266,9 +265,7 @@ def _source_info_to_location(
     primitive: core.Primitive, params: Dict,
     source_info: source_info_util.SourceInfo,
     name_stack: str = "") -> ir.Location:
-  eqn_str = str(
-      pp.text(name_stack) +
-      core.pp_eqn_compact(primitive.name, params, core.JaxprPpContext()))
+  eqn_str = name_stack + core.str_eqn_compact(primitive.name, params)
   frame = source_info_util.user_frame(source_info)
   if frame is None:
     loc = ir.Location.unknown()

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -39,8 +39,7 @@ from jax import linear_util as lu
 from jax._src import source_info_util
 from jax._src.abstract_arrays import (make_shaped_array, array_types)
 from jax.core import (ConcreteArray, ShapedArray,
-                      Literal, pp_eqn_compact, JaxprPpContext,
-                      abstract_token)
+                      Literal, str_eqn_compact, abstract_token)
 import jax._src.pretty_printer as pp
 from jax._src import util
 from jax._src.util import (prod, extend_name_stack, wrap_name,
@@ -104,8 +103,7 @@ def make_op_metadata(primitive: core.Primitive,
                      source_info: source_info_util.SourceInfo,
                      name_stack: str = "",
                      ) -> xc.OpMetadata:
-  eqn_str = str(pp.text(name_stack) +
-                pp_eqn_compact(primitive.name, params, JaxprPpContext()))
+  eqn_str = name_stack + str_eqn_compact(primitive.name, params)
   tracebacks[eqn_str] = source_info.traceback
   frame = source_info_util.user_frame(source_info) if source_info else None
   return xc.OpMetadata(


### PR DESCRIPTION
pp_eqn_compact() is used for one purpose only: creating metadata to put
on HLO. In that case, we don't need such carefully-formatted strings,
and speed is more important.

Gave a 6% speedup on a researcher's model.