### PR TITLE
Include `experimental.jet` into docs

### DIFF
--- a/docs/jax.experimental.jet.rst
+++ b/docs/jax.experimental.jet.rst
@@ -1,0 +1,9 @@
+jax.experimental.jet module
+===========================
+
+.. automodule:: jax.experimental.jet
+
+API
+---
+
+.. autofunction:: jet

--- a/docs/jax.experimental.rst
+++ b/docs/jax.experimental.rst
@@ -19,6 +19,7 @@ Experimental Modules
     jax.experimental.maps
     jax.experimental.pjit
     jax.experimental.sparse
+    jax.experimental.jet
 
 Experimental APIs
 -----------------

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -18,19 +18,19 @@ r"""Jet is an experimental module for higher-order automatic differentiation
   How? Through the propagation of truncated Taylor polynomials.
   Let :math:`x: \mathbb{R} \rightarrow \mathbb{R}^n` be the Taylor polynomial
 
-  .. math:: x(t) := x_0 + x_1 t + \frac{x_2}{2!} t^2 + ... + \frac{1}{d!} x_d t^d.
+  .. math:: x(t) := x_0 + x_1 t + \frac{1}{2!} x_2 t^2 + ... + \frac{1}{d!} x_d t^d.
 
   For some function :math:`f: \mathbb{R}^n \rightarrow \mathbb{R}^m`,
   you can use :func:`jet` to compute the
   Taylor polynomial
 
-  .. math:: y(t) := y_0 + y_1 t + \frac{y_2}{2!} t^2 + ... + \frac{1}{d!} y_d t^d.
+  .. math:: y(t) := y_0 + y_1 t + \frac{1}{2!} y_2 t^2 + ... + \frac{1}{d!} y_d t^d.
 
   corresponding to :math:`f(x(\cdot)):\mathbb{R} \rightarrow \mathbb{R}^m`,
   and relates to :math:`x(t)` and :math:`f(z)` through
 
   .. math::
-    y_k = \frac{d^k}{dt^k}f(x(t_0)), \quad k=0,...,d.
+    y_k = \partial^k f(x(t_0)), \quad k=0,...,d.
 
   More specifically, :func:`jet` computes
 
@@ -40,7 +40,7 @@ r"""Jet is an experimental module for higher-order automatic differentiation
   and can thus be used for high-order
   automatic differentiation of :math:`f`.
   Details are explained in
-  `this paper <https://openreview.net/forum?id=SkxEF3FNPH>`__.
+  `these notes <https://github.com/google/jax/files/6717197/jet.pdf>`__.
 
   Note:
     Help improve :func:`jet` by contributing

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -26,7 +26,7 @@ r"""Jet is an experimental module for higher-order automatic differentiation
 
   .. math:: y(t) := y_0 + y_1 t + \frac{y_2}{2!} t^2 + ... + \frac{1}{d!} y_d t^d.
 
-  which approximates :math:`f(x(\cdot)):\mathbb{R} \rightarrow \mathbb{R}^m`,
+  corresponding to :math:`f(x(\cdot)):\mathbb{R} \rightarrow \mathbb{R}^m`,
   and relates to :math:`x(t)` and :math:`f(z)` through
 
   .. math::

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -104,13 +104,13 @@ def jet(fun, primals, series):
   :func:`jet` returns the Taylor coefficients of :math:`f(x(t)) = \sin(t^3)`:
 
   >>> print(y0,  np.sin(x0))
-  0.12 0.12
+  0.12467473 0.12467473
 
   >>> print(y1, np.cos(x0) * x1)
-  0.74 0.74
+  0.7441479 0.74414825
 
   >>> print(y2, -np.sin(x0) * x1 +  x2)
-  2.9099998 2.9099998
+  2.9064622 2.906494
   """
   try:
     order, = set(map(len, series))

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -107,7 +107,8 @@ def jet(fun, primals, series):
   >>> h0, h1, h2 = 0.5**3., 3.*0.5**2., 6.*0.5
   >>> f, df, ddf = np.sin, np.cos, lambda *args: -np.sin(*args)
 
-  :func:`jet` returns the Taylor coefficients of :math:`f(h(z)) = \sin(z^3)`:
+  :func:`jet` returns the Taylor coefficients of :math:`f(h(z)) = \sin(z^3)`
+  according to Faà di Bruno's formula:
 
   >>> f0, (f1, f2) =  jet(f, (h0,), ((h1, h2),))
   >>> print(f0,  f(h0))
@@ -116,8 +117,8 @@ def jet(fun, primals, series):
   >>> print(f1, df(h0) * h1)
   0.7441479 0.74414825
 
-  >>> print(f2, ddf(h0) * h1 + h2)
-  2.9064622 2.906494
+  >>> print(f2, ddf(h0) * h1 ** 2 + df(h0) * h2)
+  2.9064622 2.9064634
   """
   try:
     order, = set(map(len, series))

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -27,7 +27,7 @@ r"""Jet is an experimental module for higher-order automatic differentiation
 
   .. math::
     (h_0, ... h_K) :=
-    (h(x), \partial h(x)[v], \partial^2 h(x)[v], ..., \partial^K h(x)[v,...,v]),
+    (h(x), \partial h(x)[v], \partial^2 h(x)[v, v], ..., \partial^K h(x)[v,...,v]),
 
   which represents a :math:`K`-th order Taylor approximation
   of :math:`h` at :math:`x`, :func:`jet` returns a :math:`K`-th order
@@ -35,7 +35,7 @@ r"""Jet is an experimental module for higher-order automatic differentiation
 
   .. math::
     (f_0, ..., f_K) :=
-    (f(x), \partial f(x)[v], \partial^2 f(x)[v], ..., \partial^K f(x)[v,...,v]).
+    (f(x), \partial f(x)[v], \partial^2 f(x)[v, v], ..., \partial^K f(x)[v,...,v]).
 
   More specifically, :func:`jet` computes
 


### PR DESCRIPTION
This PR introduces a module-level docstring for `jax.experimental.jet.py` and a function-level docstring for `jet.jet()`.

See the issue #3730 and the discussion #9536 for context.

The content of the docstrings is tightly coupled to how I use the API and how I understand the maths based on https://openreview.net/pdf?id=SkxEF3FNPH (as well as Griewank/Walther). Please let me know if I should rephrase some statements. I will leave comments in the diff, where I explain the thought process behind specific statements. 