### PR TITLE
Let random.choice mimic numpy behaviour and throw and error if more s…

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -488,6 +488,8 @@ def choice(key: KeyArray,
       r = p_cuml[-1] * (1 - uniform(key, shape))
       ind = jnp.searchsorted(p_cuml, r)
     else:
+      if np.count_nonzero(p) < n_draws:
+        raise ValueError("Fewer non-zero entries in p than size")
       # Gumbel top-k trick: https://timvieira.github.io/blog/post/2019/09/16/algorithms-for-sampling-without-replacement/
       g = -gumbel(key, (n_inputs,)) - jnp.log(p)
       ind = jnp.argsort(g)[:n_draws]

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1128,6 +1128,14 @@ class LaxRandomTest(jtu.JaxTestCase):
     with self.assertRaises(TypeError):
       random.choice(key, 5, 2, replace=True)
 
+  def testMoreSamplesThanNonZeroProbabilitiesReplaceFalseError(self):
+    key = self.seed_prng(0)
+    prob = jnp.zeros(5)
+    prob = prob.at[4].set(1)
+    with self.assertRaises(ValueError):
+      random.choice(key, 5, shape=(2,), replace=False, p=prob)
+    self.assertEqual(random.choice(key, 5, shape=(1,), replace=False, p=prob), 4)
+
   def test_eval_shape_big_random_array(self):
     def f(x):
       return random.normal(self.seed_prng(x), (int(1e12),))


### PR DESCRIPTION
…ample are requested than provided non-zero probabilities and replace is False. Closes #9548 

* add check in random.choice on count_nonzero elements of p
* add tests to check new behavior

I believe that ideally, we would use jnp.count_nonzero instead of the numpy function. However, although using this seems to work for the functions (p and shape are already traced), it returns some errors on the current way the tests of these functions are executed. I'm not sure if I'm allowed to touch this and what would be the preferred way. Don't mind spending time on this if some direction is provided.

```
jax._src.traceback_util.UnfilteredStackTrace: jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: Traced<ShapedArray(bool[])>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function. 
While tracing the function <lambda> at /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 for jit, this value became a tracer due to JAX operations on these lines:

  operation a:i32[] = xla_call[
  call_jaxpr={ lambda ; b:f32[1]. let
      c:bool[1] = ne b 0.0
      d:i32[1] = convert_element_type[new_dtype=int32 weak_type=False] c
      e:i32[] = reduce_sum[axes=(0,)] d
    in (e,) }
  name=count_nonzero
] f
    from line /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 (<lambda>)

  operation a:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
    from line /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 (<lambda>)

See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.

--------------------

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/michaelmarien/anaconda3/envs/jax/lib/python3.9/site-packages/absl/testing/parameterized.py", line 314, in bound_param_test
    return test_method(self, **testcase_params)
  File "/Users/michaelmarien/PycharmProjects/jax/tests/random_test.py", line 521, in testChoice
    self.assertArraysEqual(sample, jax.jit(rand, static_argnames=
  File "/Users/michaelmarien/PycharmProjects/jax/tests/random_test.py", line 508, in <lambda>
    rand = lambda key, x: random.choice(key, x, shape, replace, p, axis)
  File "/Users/michaelmarien/PycharmProjects/jax/jax/_src/random.py", line 491, in choice
    if jnp.count_nonzero(p) < n_draws:
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: Traced<ShapedArray(bool[])>with<DynamicJaxprTrace(level=0/1)>
The problem arose with the `bool` function. 
While tracing the function <lambda> at /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 for jit, this value became a tracer due to JAX operations on these lines:

  operation a:i32[] = xla_call[
  call_jaxpr={ lambda ; b:f32[1]. let
      c:bool[1] = ne b 0.0
      d:i32[1] = convert_element_type[new_dtype=int32 weak_type=False] c
      e:i32[] = reduce_sum[axes=(0,)] d
    in (e,) }
  name=count_nonzero
] f
    from line /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 (<lambda>)

  operation a:i32[] = convert_element_type[new_dtype=int32 weak_type=False] b
    from line /Users/michaelmarien/PycharmProjects/jax/tests/random_test.py:508 (<lambda>)

See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
```