### PR TITLE
fix typo in type_promotion.rst

### DIFF
--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -36,7 +36,7 @@ where, for example:
 * ``u4`` means :code:`np.uint32`,
 * ``bf`` means :code:`np.bfloat16`,
 * ``f2`` means :code:`np.float16`,
-* ``c8`` means :code:`np.complex128`,
+* ``c8`` means :code:`np.complex64`,
 * ``i*`` means Python :code:`int` or weakly-typed :code:`int`,
 * ``f*`` means Python :code:`float` or weakly-typed :code:`float`, and
 * ``c*`` means Python :code:`complex` or weakly-typed :code:`complex`.


### PR DESCRIPTION
``c8`` means :code:`np.complex128`
to
``c8`` means :code:`np.complex64`,