### PR TITLE
Checkify: handle named_call in process_call.

### DIFF
--- a/jax/experimental/checkify.py
+++ b/jax/experimental/checkify.py
@@ -137,8 +137,10 @@ class CheckifyTrace(core.Trace):
     in_vals = [t.val for t in tracers]
     e = popattr(self.main, 'error')
     f, msgs = checkify_subtrace(f, self.main, tuple(e.msgs.items()))
-    params_ = dict(params, donated_invars=(False, False, *params['donated_invars']))
-    err, code, *out_vals = primitive.bind(f, e.err, e.code, *in_vals, **params_)
+    if 'donated_invars' in params:
+      params = dict(params, donated_invars=(False, False,
+                                            *params['donated_invars']))
+    err, code, *out_vals = primitive.bind(f, e.err, e.code, *in_vals, **params)
     setnewattr(self.main, 'error', Error(err, code, msgs()))
     return [CheckifyTracer(self, x) for x in out_vals]
 

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -583,6 +583,13 @@ class AssertPrimitiveTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "foo"):
       f(False)
 
+  def test_cond_of_named_call(self):
+    def g(x):
+      branch = jax.named_call(lambda x: x)
+      out = jax.lax.cond(True, branch, branch, x)
+      return out
+
+    checkify.checkify(g)(0.)  # does not crash
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
named_call does not specify donated_invars, this change handles this missing
param case.

For future reference: we might want to add a call_param_updater registry to define
how call params need to get updated wrt checkify, like eg. partial_eval/ad does.