### PR TITLE
Add a warning to random.choice

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -435,6 +435,11 @@ def choice(key: KeyArray,
            axis: int = 0) -> jnp.ndarray:
   """Generates a random sample from a given array.
 
+  .. warning::
+    If ``p`` has fewer non-zero elements than the requested number of samples,
+    as specified in ``shape``, and ``replace=False``, the output of this
+    function is ill-defined. Please make sure to use appropriate inputs.
+
   Args:
     key: a PRNG key used as the random key.
     a : array or int. If an ndarray, a random sample is generated from


### PR DESCRIPTION
Add a warning to random.choice to notify users of the ill-defined behaviour when requesting more samples than non-zero probabilities and replace=False. Closes #9548 for now.