### PR TITLE
Clarified tree_flatten is_leaf docstring.

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -43,10 +43,9 @@ def tree_flatten(tree, is_leaf: Optional[Callable[[Any], bool]] = None):
   Args:
     tree: a pytree to flatten.
     is_leaf: an optionally specified function that will be called at each
-      flattening step. It should return a boolean, which indicates whether
-      the flattening should traverse the current object, or if it should be
-      stopped immediately, with the whole subtree being treated as a leaf.
-
+      flattening step. It should return a boolean, with true stopping the
+      traversal and the whole subtree being treated as a leaf, and false
+      indicating the flattening should traverse the current object.
   Returns:
     A pair where the first element is a list of leaf values and the second
     element is a treedef representing the structure of the flattened tree.


### PR DESCRIPTION
This tiny PR clarifies the `tree_flatten` docstring for the `is_leaf` option as per #9520. The is_leaf option of the tree_flatten function is currently described as,

> an optionally specified function that will be called at each flattening step. It should return a boolean, which indicates whether the flattening should traverse the current object, or if it should be stopped immediately, with the whole subtree being treated as a leaf.

This seems to imply true should be returned if the object needs to be traversed, and false if it is a leaf. This PR changes it to something more explicit:

>   an optionally specified function that will be called at each flattening step. It should return a boolean, with true stopping the traversal and the whole subtree being treated as a leaf, and false indicating the flattening should traverse the current object.
