### PR TITLE
Check input of broadcast_shapes:

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -113,6 +113,9 @@ def _broadcast_shapes_cached(*shapes: Tuple[int, ...]) -> Tuple[int, ...]:
   return _broadcast_shapes_uncached(*shapes)
 
 def _broadcast_shapes_uncached(*shapes):
+  shapes = [canonicalize_shape(shape) for shape in shapes]
+  if not all([all(el >= 0 for el in shape) for shape in shapes]):
+    raise ValueError('negative dimensions are not allowed')
   fst, *rst = shapes
   if not rst: return fst
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5653,6 +5653,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # Test against np.broadcast_shapes once numpy 1.20 is minimum required version
     np.testing.assert_equal(jnp.broadcast_shapes(*shapes), broadcasted_shape)
 
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{shapes}", "shapes": shapes}
+      for shapes in ["this is not a valid shape",
+                     ((2, 3), "this is not a valid shape")])
+  def testBroadcastShapesRaisesTypeError(self, shapes):
+    with self.assertRaises(TypeError):
+      jnp.broadcast_shapes(*shapes)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{shapes}", "shapes": shapes}
+      for shapes in [(2, -1), ((2, 3), (2, -1)), ((2, 3), np.array([2, -1]))])
+  def testBroadcastShapesRaisesValueError(self, shapes):
+    with self.assertRaises(ValueError):
+      jnp.broadcast_shapes(*shapes)
+
   def testBroadcastToIssue1522(self):
     self.assertRaisesRegex(
         ValueError, "Incompatible shapes for broadcasting: .*",


### PR DESCRIPTION
Check input of broadcast_shapes:
* canonicalize provided shapes to catch type errors et al
* do extra check on positivity of canonicalized dimensions and raise value error
* add test for type and value errors

This PR closes #9527