### PR TITLE
Validate `lax.broadcast_shape` inputs before control flow execution

### DIFF
--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -723,6 +723,15 @@ class LaxVmapTest(jtu.JaxTestCase):
     out_shape = lax.broadcast_shapes(shape1, shape2)
     self.assertTrue(all(type(s) is int for s in out_shape))
 
+  def testBroadcastShapesFaultyInputs(self):
+    err_shape1, err_shape2 = (-1,), "hello"
+    # negative inputs should fail while informing about illegal negative indices...
+    with self.assertRaisesRegex(TypeError, "Only non-negative indices are allowed.*"):
+      lax.broadcast_shapes(err_shape1)
+    # ... while non-integers should error earlier, in the canonicalize_shape machinery.
+    with self.assertRaisesRegex(TypeError, "Shapes must be 1D sequences.*"):
+      lax.broadcast_shapes(err_shape2)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_k={}_bdims={}".format(
           jtu.format_shape_dtype_string(shape, dtype), k, bdims),


### PR DESCRIPTION
Addresses #9527.

This commit addresses previously unvalidated inputs to `jax.lax.broadcast_shapes` by adding a small validation check before control flow execution. A legal input to `lax.broadcast_shapes` hereafter is defined as an input that
1) is a sequence (i.e., implements `for..in` iteration) of integers and
2) said integers are all non-negative.

In addition, two tests were added to `tests.lax_vmap_test` to check that proper errors are raised when attempting to use illegal inputs with `lax.broadcast_shapes`.

Two more things:
- Is the type check fine? I arrived at this after (successfully, at least locally) debugging some test failures, but this could be wrong for reasons that I did not see.
- The type hint there is probably wrong now, since I moved the validation check up from `_try_broadcast_shapes` to the main control flow? I guess inputs at that stage could also be `core.Tracer` objects. Please let me know what you think.