### PR TITLE
Fix nomenclature in type promotion doc

### DIFF
--- a/docs/_static/type_lattice.svg
+++ b/docs/_static/type_lattice.svg
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<!-- Created with matplotlib (https://matplotlib.org/) -->
-<svg height="153pt" version="1.1" viewBox="0 0 460.8 153" width="460.8pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="158.544pt" version="1.1" viewBox="0 0 460.8 158.544" width="460.8pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <metadata>
   <rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2020-11-05T11:56:05.657973</dc:date>
+    <dc:date>2022-02-15T12:56:43.285995</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
-      <dc:title>Matplotlib v3.3.2, https://matplotlib.org/</dc:title>
+      <dc:title>Matplotlib v3.4.2, https://matplotlib.org/</dc:title>
      </cc:Agent>
     </dc:creator>
    </cc:Work>
@@ -22,8 +21,8 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 153 
-L 460.8 153 
+   <path d="M 0 158.544 
+L 460.8 158.544 
 L 460.8 0 
 L 0 0 
 z
@@ -31,698 +30,740 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path clip-path="url(#pbde559b380)" d="M 52.12539 123.205378 
-Q 62.706512 105.136406 72.72266 88.032216 
+    <path clip-path="url(#p15dc812c16)" d="M 52.190895 127.729258 
+Q 62.706707 109.053516 72.673965 91.351986 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 68.975496 90.473273 
-L 72.72266 88.032216 
-L 72.427207 92.494582 
-L 68.975496 90.473273 
+    <path clip-path="url(#p15dc812c16)" d="M 68.968678 93.856153 
+L 72.673965 91.351986 
+L 72.454126 95.818716 
+L 68.968678 93.856153 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_3">
-    <path clip-path="url(#pbde559b380)" d="M 125.259965 133.772727 
-Q 129.784012 133.772727 133.190025 133.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 125.759443 138.835636 
+Q 129.781393 138.835636 132.685309 138.835636 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 129.190025 131.772727 
-L 133.190025 133.772727 
-L 129.190025 135.772727 
-L 129.190025 131.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 128.685309 136.835636 
+L 132.685309 138.835636 
+L 128.685309 140.835636 
+L 128.685309 136.835636 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_4">
-    <path clip-path="url(#pbde559b380)" d="M 116.456672 122.016857 
-Q 129.784207 76.499027 142.797573 32.054182 
+    <path clip-path="url(#p15dc812c16)" d="M 116.468954 126.565905 
+Q 129.783705 79.272769 142.795468 33.055828 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 139.754156 35.331011 
-L 142.797573 32.054182 
-L 143.592986 36.455014 
-L 139.754156 35.331011 
+    <path clip-path="url(#p15dc812c16)" d="M 139.786305 36.364142 
+L 142.795468 33.055828 
+L 143.636621 37.448147 
+L 139.786305 36.364142 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_5">
-    <path clip-path="url(#pbde559b380)" d="M 149.995365 122.016857 
-Q 163.3229 76.499027 176.336266 32.054182 
+    <path clip-path="url(#p15dc812c16)" d="M 150.007647 126.565905 
+Q 163.322398 79.272769 176.334161 33.055828 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 173.292849 35.331011 
-L 176.336266 32.054182 
-L 177.131679 36.455014 
-L 173.292849 35.331011 
+    <path clip-path="url(#p15dc812c16)" d="M 173.324997 36.364142 
+L 176.334161 33.055828 
+L 177.175313 37.448147 
+L 173.324997 36.364142 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_6">
-    <path clip-path="url(#pbde559b380)" d="M 158.798658 133.772727 
-Q 163.322705 133.772727 166.728718 133.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 159.298135 138.835636 
+Q 163.320086 138.835636 166.224002 138.835636 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 162.728718 131.772727 
-L 166.728718 133.772727 
-L 162.728718 135.772727 
-L 162.728718 131.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 162.224002 136.835636 
+L 166.224002 138.835636 
+L 162.224002 140.835636 
+L 162.224002 136.835636 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_7">
-    <path clip-path="url(#pbde559b380)" d="M 192.33735 133.772727 
-Q 196.861397 133.772727 200.267411 133.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 192.836828 138.835636 
+Q 196.858778 138.835636 199.762695 138.835636 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 196.267411 131.772727 
-L 200.267411 133.772727 
-L 196.267411 135.772727 
-L 196.267411 131.772727 
+    <path clip-path="url(#p15dc812c16)" d="M 195.762695 136.835636 
+L 199.762695 138.835636 
+L 195.762695 140.835636 
+L 195.762695 136.835636 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_8">
-    <path clip-path="url(#pbde559b380)" d="M 183.534058 122.016857 
-Q 196.861592 76.499027 209.874959 32.054182 
+    <path clip-path="url(#p15dc812c16)" d="M 183.54634 126.565905 
+Q 196.861091 79.272769 209.872853 33.055828 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 206.831541 35.331011 
-L 209.874959 32.054182 
-L 210.670372 36.455014 
-L 206.831541 35.331011 
+    <path clip-path="url(#p15dc812c16)" d="M 206.86369 36.364142 
+L 209.872853 33.055828 
+L 210.714006 37.448147 
+L 206.86369 36.364142 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_9">
-    <path clip-path="url(#pbde559b380)" d="M 219.818854 123.205378 
-Q 230.399975 105.136406 240.416124 88.032216 
+    <path clip-path="url(#p15dc812c16)" d="M 219.884359 127.729258 
+Q 230.40017 109.053516 240.367429 91.351986 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 236.668959 90.473273 
-L 240.416124 88.032216 
-L 240.120671 92.494582 
-L 236.668959 90.473273 
+    <path clip-path="url(#p15dc812c16)" d="M 236.662142 93.856153 
+L 240.367429 91.351986 
+L 240.14759 95.818716 
+L 236.662142 93.856153 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_10">
-    <path clip-path="url(#pbde559b380)" d="M 85.664083 87.06735 
-Q 96.245204 105.136321 106.261353 122.240511 
+    <path clip-path="url(#p15dc812c16)" d="M 85.729588 90.378379 
+Q 96.245399 109.054121 106.212658 126.75565 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 105.9659 117.778145 
-L 106.261353 122.240511 
-L 102.514189 119.799454 
-L 105.9659 117.778145 
+    <path clip-path="url(#p15dc812c16)" d="M 105.992819 122.288921 
+L 106.212658 126.75565 
+L 102.507371 124.251483 
+L 105.992819 122.288921 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_11">
-    <path clip-path="url(#pbde559b380)" d="M 85.664083 65.93265 
-Q 96.245204 47.863679 106.261353 30.759489 
+    <path clip-path="url(#p15dc812c16)" d="M 85.729588 68.165621 
+Q 96.245399 49.489879 106.212658 31.78835 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 102.514189 33.200546 
-L 106.261353 30.759489 
-L 105.9659 35.221855 
-L 102.514189 33.200546 
+    <path clip-path="url(#p15dc812c16)" d="M 102.507371 34.292517 
+L 106.212658 31.78835 
+L 105.992819 36.255079 
+L 102.507371 34.292517 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_12">
-    <path clip-path="url(#pbde559b380)" d="M 125.259965 19.227273 
-Q 129.784012 19.227273 133.190025 19.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 125.759443 19.708364 
+Q 129.781393 19.708364 132.685309 19.708364 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 129.190025 17.227273 
-L 133.190025 19.227273 
-L 129.190025 21.227273 
-L 129.190025 17.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 128.685309 17.708364 
+L 132.685309 19.708364 
+L 128.685309 21.708364 
+L 128.685309 17.708364 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_13">
-    <path clip-path="url(#pbde559b380)" d="M 158.798658 19.227273 
-Q 163.322705 19.227273 166.728718 19.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 159.298135 19.708364 
+Q 163.320086 19.708364 166.224002 19.708364 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 162.728718 17.227273 
-L 166.728718 19.227273 
-L 162.728718 21.227273 
-L 162.728718 17.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 162.224002 17.708364 
+L 166.224002 19.708364 
+L 162.224002 21.708364 
+L 162.224002 17.708364 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_14">
-    <path clip-path="url(#pbde559b380)" d="M 192.33735 19.227273 
-Q 196.861397 19.227273 200.267411 19.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 192.836828 19.708364 
+Q 196.858778 19.708364 199.762695 19.708364 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 196.267411 17.227273 
-L 200.267411 19.227273 
-L 196.267411 21.227273 
-L 196.267411 17.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 195.762695 17.708364 
+L 199.762695 19.708364 
+L 195.762695 21.708364 
+L 195.762695 17.708364 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_15">
-    <path clip-path="url(#pbde559b380)" d="M 219.818854 29.794622 
-Q 230.399975 47.863594 240.416124 64.967784 
+    <path clip-path="url(#p15dc812c16)" d="M 219.884359 30.814742 
+Q 230.40017 49.490484 240.367429 67.192014 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 240.120671 60.505418 
-L 240.416124 64.967784 
-L 236.668959 62.526727 
-L 240.120671 60.505418 
+    <path clip-path="url(#p15dc812c16)" d="M 240.14759 62.725284 
+L 240.367429 67.192014 
+L 236.662142 64.687847 
+L 240.14759 62.725284 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_16">
-    <path clip-path="url(#pbde559b380)" d="M 253.357546 65.93265 
-Q 263.938668 47.863679 273.954817 30.759489 
+    <path clip-path="url(#p15dc812c16)" d="M 253.423052 68.165621 
+Q 263.938863 49.489879 273.906121 31.78835 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 270.207652 33.200546 
-L 273.954817 30.759489 
-L 273.659363 35.221855 
-L 270.207652 33.200546 
+    <path clip-path="url(#p15dc812c16)" d="M 270.200835 34.292517 
+L 273.906121 31.78835 
+L 273.686283 36.255079 
+L 270.200835 34.292517 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_17">
-    <path clip-path="url(#pbde559b380)" d="M 258.318546 71.422918 
-Q 272.325527 65.04447 285.315006 59.129369 
+    <path clip-path="url(#p15dc812c16)" d="M 258.693154 73.814424 
+Q 272.324685 67.358648 284.945769 61.381411 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 280.845822 58.966924 
-L 285.315006 59.129369 
-L 282.50354 62.60725 
-L 280.845822 58.966924 
+    <path clip-path="url(#p15dc812c16)" d="M 280.474653 61.285942 
+L 284.945769 61.381411 
+L 282.186724 64.901023 
+L 280.474653 61.285942 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_18">
-    <path clip-path="url(#pbde559b380)" d="M 258.318546 81.577082 
-Q 272.325527 87.95553 285.315006 93.870631 
+    <path clip-path="url(#p15dc812c16)" d="M 258.693154 84.729576 
+Q 272.324685 91.185352 284.945769 97.162589 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 282.50354 90.39275 
-L 285.315006 93.870631 
-L 280.845822 94.033076 
-L 282.50354 90.39275 
+    <path clip-path="url(#p15dc812c16)" d="M 282.186724 93.642977 
+L 284.945769 97.162589 
+L 280.474653 97.258058 
+L 282.186724 93.642977 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_19">
-    <path clip-path="url(#pbde559b380)" d="M 308.626585 94.332009 
-Q 322.633566 87.953561 335.623045 82.03846 
+    <path clip-path="url(#p15dc812c16)" d="M 309.001193 97.639878 
+Q 322.632724 91.184103 335.253808 85.206866 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 331.153861 81.876015 
-L 335.623045 82.03846 
-L 332.811579 85.516341 
-L 331.153861 81.876015 
+    <path clip-path="url(#p15dc812c16)" d="M 330.782692 85.111396 
+L 335.253808 85.206866 
+L 332.494763 88.726477 
+L 330.782692 85.111396 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_20">
-    <path clip-path="url(#pbde559b380)" d="M 308.626585 58.667991 
-Q 322.633566 65.046439 335.623045 70.96154 
+    <path clip-path="url(#p15dc812c16)" d="M 309.001193 60.904122 
+Q 322.632724 67.359897 335.253808 73.337134 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 332.811579 67.483659 
-L 335.623045 70.96154 
-L 331.153861 71.123985 
-L 332.811579 67.483659 
+    <path clip-path="url(#p15dc812c16)" d="M 332.494763 69.817523 
+L 335.253808 73.337134 
+L 330.782692 73.432604 
+L 332.494763 69.817523 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_21">
-    <path clip-path="url(#pbde559b380)" d="M 353.973624 65.93265 
-Q 364.554746 47.863679 374.570895 30.759489 
+    <path clip-path="url(#p15dc812c16)" d="M 354.03913 68.165621 
+Q 364.554941 49.489879 374.5222 31.78835 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 370.82373 33.200546 
-L 374.570895 30.759489 
-L 374.275441 35.221855 
-L 370.82373 33.200546 
+    <path clip-path="url(#p15dc812c16)" d="M 370.816913 34.292517 
+L 374.5222 31.78835 
+L 374.302361 36.255079 
+L 370.816913 34.292517 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_22">
-    <path clip-path="url(#pbde559b380)" d="M 360.030814 76.5 
-Q 364.554861 76.5 367.960874 76.5 
+    <path clip-path="url(#p15dc812c16)" d="M 360.530291 79.272 
+Q 364.552242 79.272 367.456158 79.272 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 363.960874 74.5 
-L 367.960874 76.5 
-L 363.960874 78.5 
-L 363.960874 74.5 
+    <path clip-path="url(#p15dc812c16)" d="M 363.456158 77.272 
+L 367.456158 79.272 
+L 363.456158 81.272 
+L 363.456158 77.272 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_23">
-    <path clip-path="url(#pbde559b380)" d="M 387.512317 65.93265 
-Q 398.093439 47.863679 408.109588 30.759489 
+    <path clip-path="url(#p15dc812c16)" d="M 387.577822 68.165621 
+Q 398.093634 49.489879 408.060892 31.78835 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 404.362423 33.200546 
-L 408.109588 30.759489 
-L 407.814134 35.221855 
-L 404.362423 33.200546 
+    <path clip-path="url(#p15dc812c16)" d="M 404.355606 34.292517 
+L 408.060892 31.78835 
+L 407.841054 36.255079 
+L 404.355606 34.292517 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_24">
-    <path clip-path="url(#pbde559b380)" d="M 292.956499 19.227273 
-Q 331.017302 19.227273 367.96007 19.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 293.45393 19.708364 
+Q 331.016236 19.708364 367.460508 19.708364 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 363.96007 17.227273 
-L 367.96007 19.227273 
-L 363.96007 21.227273 
-L 363.96007 17.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 363.460508 17.708364 
+L 367.460508 19.708364 
+L 363.460508 21.708364 
+L 363.460508 17.708364 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="patch_25">
-    <path clip-path="url(#pbde559b380)" d="M 393.569507 19.227273 
-Q 398.093554 19.227273 401.499567 19.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 394.068984 19.708364 
+Q 398.090934 19.708364 400.994851 19.708364 
 " style="fill:none;stroke:#000000;stroke-linecap:round;"/>
-    <path clip-path="url(#pbde559b380)" d="M 397.499567 17.227273 
-L 401.499567 19.227273 
-L 397.499567 21.227273 
-L 397.499567 17.227273 
+    <path clip-path="url(#p15dc812c16)" d="M 396.994851 17.708364 
+L 400.994851 19.708364 
+L 396.994851 21.708364 
+L 396.994851 17.708364 
 z
 " style="stroke:#000000;stroke-linecap:round;"/>
    </g>
    <g id="PathCollection_1">
     <defs>
-     <path d="M 0 12.247449 
-C 3.248061 12.247449 6.363528 10.95698 8.660254 8.660254 
-C 10.95698 6.363528 12.247449 3.248061 12.247449 0 
-C 12.247449 -3.248061 10.95698 -6.363528 8.660254 -8.660254 
-C 6.363528 -10.95698 3.248061 -12.247449 0 -12.247449 
-C -3.248061 -12.247449 -6.363528 -10.95698 -8.660254 -8.660254 
-C -10.95698 -6.363528 -12.247449 -3.248061 -12.247449 0 
-C -12.247449 3.248061 -10.95698 6.363528 -8.660254 8.660254 
-C -6.363528 10.95698 -3.248061 12.247449 0 12.247449 
+     <path d="M 0 12.747549 
+C 3.380689 12.747549 6.62337 11.404387 9.013878 9.013878 
+C 11.404387 6.62337 12.747549 3.380689 12.747549 0 
+C 12.747549 -3.380689 11.404387 -6.62337 9.013878 -9.013878 
+C 6.62337 -11.404387 3.380689 -12.747549 0 -12.747549 
+C -3.380689 -12.747549 -6.62337 -11.404387 -9.013878 -9.013878 
+C -11.404387 -6.62337 -12.747549 -3.380689 -12.747549 0 
+C -12.747549 3.380689 -11.404387 6.62337 -9.013878 9.013878 
+C -6.62337 11.404387 -3.380689 12.747549 0 12.747549 
 z
-" id="mb27db99286" style="stroke:#d3d3d3;"/>
+" id="mf96788dac4" style="stroke:#d3d3d3;"/>
     </defs>
-    <g clip-path="url(#pbde559b380)">
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="45.93719" xlink:href="#mb27db99286" y="133.772727"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="113.014576" xlink:href="#mb27db99286" y="133.772727"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="146.553268" xlink:href="#mb27db99286" y="133.772727"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="180.091961" xlink:href="#mb27db99286" y="133.772727"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="213.630654" xlink:href="#mb27db99286" y="133.772727"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="79.475883" xlink:href="#mb27db99286" y="76.5"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="113.014576" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="146.553268" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="180.091961" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="213.630654" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="247.169346" xlink:href="#mb27db99286" y="76.5"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="297.477385" xlink:href="#mb27db99286" y="99.409091"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="297.477385" xlink:href="#mb27db99286" y="53.590909"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="347.785424" xlink:href="#mb27db99286" y="76.5"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="381.324117" xlink:href="#mb27db99286" y="76.5"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="280.708039" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="381.324117" xlink:href="#mb27db99286" y="19.227273"/>
-     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="414.86281" xlink:href="#mb27db99286" y="19.227273"/>
+    <g clip-path="url(#p15dc812c16)">
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="45.93719" xlink:href="#mf96788dac4" y="138.835636"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="113.014576" xlink:href="#mf96788dac4" y="138.835636"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="146.553268" xlink:href="#mf96788dac4" y="138.835636"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="180.091961" xlink:href="#mf96788dac4" y="138.835636"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="213.630654" xlink:href="#mf96788dac4" y="138.835636"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="79.475883" xlink:href="#mf96788dac4" y="79.272"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="113.014576" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="146.553268" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="180.091961" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="213.630654" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="247.169346" xlink:href="#mf96788dac4" y="79.272"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="297.477385" xlink:href="#mf96788dac4" y="103.097455"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="297.477385" xlink:href="#mf96788dac4" y="55.446545"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="347.785424" xlink:href="#mf96788dac4" y="79.272"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="381.324117" xlink:href="#mf96788dac4" y="79.272"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="280.708039" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="381.324117" xlink:href="#mf96788dac4" y="19.708364"/>
+     <use style="fill:#d3d3d3;stroke:#d3d3d3;" x="414.86281" xlink:href="#mf96788dac4" y="19.708364"/>
     </g>
    </g>
    <g id="text_1">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- b1 -->
-     <g transform="translate(38.310628 137.083977)scale(0.12 -0.12)">
+     <g transform="translate(38.310628 142.146886)scale(0.12 -0.12)">
       <defs>
-       <path d="M 48.6875 27.296875 
-Q 48.6875 37.203125 44.609375 42.84375 
-Q 40.53125 48.484375 33.40625 48.484375 
-Q 26.265625 48.484375 22.1875 42.84375 
-Q 18.109375 37.203125 18.109375 27.296875 
-Q 18.109375 17.390625 22.1875 11.75 
-Q 26.265625 6.109375 33.40625 6.109375 
-Q 40.53125 6.109375 44.609375 11.75 
-Q 48.6875 17.390625 48.6875 27.296875 
+       <path d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
 z
-M 18.109375 46.390625 
-Q 20.953125 51.265625 25.265625 53.625 
-Q 29.59375 56 35.59375 56 
-Q 45.5625 56 51.78125 48.09375 
-Q 58.015625 40.1875 58.015625 27.296875 
-Q 58.015625 14.40625 51.78125 6.484375 
-Q 45.5625 -1.421875 35.59375 -1.421875 
-Q 29.59375 -1.421875 25.265625 0.953125 
-Q 20.953125 3.328125 18.109375 8.203125 
-L 18.109375 0 
-L 9.078125 0 
-L 9.078125 75.984375 
-L 18.109375 75.984375 
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
 z
-" id="DejaVuSans-98"/>
-       <path d="M 12.40625 8.296875 
-L 28.515625 8.296875 
-L 28.515625 63.921875 
-L 10.984375 60.40625 
-L 10.984375 69.390625 
-L 28.421875 72.90625 
-L 38.28125 72.90625 
-L 38.28125 8.296875 
-L 54.390625 8.296875 
-L 54.390625 0 
-L 12.40625 0 
+" id="DejaVuSans-62" transform="scale(0.015625)"/>
+       <path d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
-" id="DejaVuSans-49"/>
+" id="DejaVuSans-31" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-98"/>
-      <use x="63.476562" xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-62"/>
+      <use x="63.476562" xlink:href="#DejaVuSans-31"/>
      </g>
     </g>
    </g>
    <g id="text_2">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- u1 -->
-     <g transform="translate(105.394576 137.083977)scale(0.12 -0.12)">
+     <g transform="translate(105.394576 142.146886)scale(0.12 -0.12)">
       <defs>
-       <path d="M 8.5 21.578125 
-L 8.5 54.6875 
-L 17.484375 54.6875 
-L 17.484375 21.921875 
-Q 17.484375 14.15625 20.5 10.265625 
-Q 23.53125 6.390625 29.59375 6.390625 
-Q 36.859375 6.390625 41.078125 11.03125 
-Q 45.3125 15.671875 45.3125 23.6875 
-L 45.3125 54.6875 
-L 54.296875 54.6875 
-L 54.296875 0 
-L 45.3125 0 
-L 45.3125 8.40625 
-Q 42.046875 3.421875 37.71875 1 
-Q 33.40625 -1.421875 27.6875 -1.421875 
-Q 18.265625 -1.421875 13.375 4.4375 
-Q 8.5 10.296875 8.5 21.578125 
+       <path d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
 z
-M 31.109375 56 
+M 1991 3584 
+L 1991 3584 
 z
-" id="DejaVuSans-117"/>
+" id="DejaVuSans-75" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-117"/>
-      <use x="63.378906" xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-75"/>
+      <use x="63.378906" xlink:href="#DejaVuSans-31"/>
      </g>
     </g>
    </g>
    <g id="text_3">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- u2 -->
-     <g transform="translate(138.933268 137.083977)scale(0.12 -0.12)">
+     <g transform="translate(138.933268 142.146886)scale(0.12 -0.12)">
       <defs>
-       <path d="M 19.1875 8.296875 
-L 53.609375 8.296875 
-L 53.609375 0 
-L 7.328125 0 
-L 7.328125 8.296875 
-Q 12.9375 14.109375 22.625 23.890625 
-Q 32.328125 33.6875 34.8125 36.53125 
-Q 39.546875 41.84375 41.421875 45.53125 
-Q 43.3125 49.21875 43.3125 52.78125 
-Q 43.3125 58.59375 39.234375 62.25 
-Q 35.15625 65.921875 28.609375 65.921875 
-Q 23.96875 65.921875 18.8125 64.3125 
-Q 13.671875 62.703125 7.8125 59.421875 
-L 7.8125 69.390625 
-Q 13.765625 71.78125 18.9375 73 
-Q 24.125 74.21875 28.421875 74.21875 
-Q 39.75 74.21875 46.484375 68.546875 
-Q 53.21875 62.890625 53.21875 53.421875 
-Q 53.21875 48.921875 51.53125 44.890625 
-Q 49.859375 40.875 45.40625 35.40625 
-Q 44.1875 33.984375 37.640625 27.21875 
-Q 31.109375 20.453125 19.1875 8.296875 
+       <path d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
-" id="DejaVuSans-50"/>
+" id="DejaVuSans-32" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-117"/>
-      <use x="63.378906" xlink:href="#DejaVuSans-50"/>
+      <use xlink:href="#DejaVuSans-75"/>
+      <use x="63.378906" xlink:href="#DejaVuSans-32"/>
      </g>
     </g>
    </g>
    <g id="text_4">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- u4 -->
-     <g transform="translate(172.471961 137.083977)scale(0.12 -0.12)">
+     <g transform="translate(172.471961 142.146886)scale(0.12 -0.12)">
       <defs>
-       <path d="M 37.796875 64.3125 
-L 12.890625 25.390625 
-L 37.796875 25.390625 
+       <path d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
 z
-M 35.203125 72.90625 
-L 47.609375 72.90625 
-L 47.609375 25.390625 
-L 58.015625 25.390625 
-L 58.015625 17.1875 
-L 47.609375 17.1875 
-L 47.609375 0 
-L 37.796875 0 
-L 37.796875 17.1875 
-L 4.890625 17.1875 
-L 4.890625 26.703125 
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
-" id="DejaVuSans-52"/>
+" id="DejaVuSans-34" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-117"/>
-      <use x="63.378906" xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75"/>
+      <use x="63.378906" xlink:href="#DejaVuSans-34"/>
      </g>
     </g>
    </g>
    <g id="text_5">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- u8 -->
-     <g transform="translate(206.010654 137.083977)scale(0.12 -0.12)">
+     <g transform="translate(206.010654 142.146886)scale(0.12 -0.12)">
       <defs>
-       <path d="M 31.78125 34.625 
-Q 24.75 34.625 20.71875 30.859375 
-Q 16.703125 27.09375 16.703125 20.515625 
-Q 16.703125 13.921875 20.71875 10.15625 
-Q 24.75 6.390625 31.78125 6.390625 
-Q 38.8125 6.390625 42.859375 10.171875 
-Q 46.921875 13.96875 46.921875 20.515625 
-Q 46.921875 27.09375 42.890625 30.859375 
-Q 38.875 34.625 31.78125 34.625 
+       <path d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
 z
-M 21.921875 38.8125 
-Q 15.578125 40.375 12.03125 44.71875 
-Q 8.5 49.078125 8.5 55.328125 
-Q 8.5 64.0625 14.71875 69.140625 
-Q 20.953125 74.21875 31.78125 74.21875 
-Q 42.671875 74.21875 48.875 69.140625 
-Q 55.078125 64.0625 55.078125 55.328125 
-Q 55.078125 49.078125 51.53125 44.71875 
-Q 48 40.375 41.703125 38.8125 
-Q 48.828125 37.15625 52.796875 32.3125 
-Q 56.78125 27.484375 56.78125 20.515625 
-Q 56.78125 9.90625 50.3125 4.234375 
-Q 43.84375 -1.421875 31.78125 -1.421875 
-Q 19.734375 -1.421875 13.25 4.234375 
-Q 6.78125 9.90625 6.78125 20.515625 
-Q 6.78125 27.484375 10.78125 32.3125 
-Q 14.796875 37.15625 21.921875 38.8125 
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
 z
-M 18.3125 54.390625 
-Q 18.3125 48.734375 21.84375 45.5625 
-Q 25.390625 42.390625 31.78125 42.390625 
-Q 38.140625 42.390625 41.71875 45.5625 
-Q 45.3125 48.734375 45.3125 54.390625 
-Q 45.3125 60.0625 41.71875 63.234375 
-Q 38.140625 66.40625 31.78125 66.40625 
-Q 25.390625 66.40625 21.84375 63.234375 
-Q 18.3125 60.0625 18.3125 54.390625 
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
 z
-" id="DejaVuSans-56"/>
+" id="DejaVuSans-38" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-117"/>
-      <use x="63.378906" xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-75"/>
+      <use x="63.378906" xlink:href="#DejaVuSans-38"/>
      </g>
     </g>
    </g>
    <g id="text_6">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- i* -->
-     <g transform="translate(74.809008 79.81125)scale(0.12 -0.12)">
+     <g transform="translate(74.809008 82.58325)scale(0.12 -0.12)">
       <defs>
-       <path d="M 9.421875 54.6875 
-L 18.40625 54.6875 
-L 18.40625 0 
-L 9.421875 0 
+       <path d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
 z
-M 9.421875 75.984375 
-L 18.40625 75.984375 
-L 18.40625 64.59375 
-L 9.421875 64.59375 
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
 z
-" id="DejaVuSans-105"/>
-       <path d="M 47.015625 60.890625 
-L 29.5 51.421875 
-L 47.015625 41.890625 
-L 44.1875 37.109375 
-L 27.78125 47.015625 
-L 27.78125 28.609375 
-L 22.21875 28.609375 
-L 22.21875 47.015625 
-L 5.8125 37.109375 
-L 2.984375 41.890625 
-L 20.515625 51.421875 
-L 2.984375 60.890625 
-L 5.8125 65.71875 
-L 22.21875 55.8125 
-L 22.21875 74.21875 
-L 27.78125 74.21875 
-L 27.78125 55.8125 
-L 44.1875 65.71875 
+" id="DejaVuSans-69" transform="scale(0.015625)"/>
+       <path d="M 3009 3897 
+L 1888 3291 
+L 3009 2681 
+L 2828 2375 
+L 1778 3009 
+L 1778 1831 
+L 1422 1831 
+L 1422 3009 
+L 372 2375 
+L 191 2681 
+L 1313 3291 
+L 191 3897 
+L 372 4206 
+L 1422 3572 
+L 1422 4750 
+L 1778 4750 
+L 1778 3572 
+L 2828 4206 
+L 3009 3897 
 z
-" id="DejaVuSans-42"/>
+" id="DejaVuSans-2a" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-105"/>
-      <use x="27.783203" xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-69"/>
+      <use x="27.783203" xlink:href="#DejaVuSans-2a"/>
      </g>
     </g>
    </g>
    <g id="text_7">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- i1 -->
-     <g transform="translate(107.530201 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-105"/>
-      <use x="27.783203" xlink:href="#DejaVuSans-49"/>
+     <g transform="translate(107.530201 23.019614)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-69"/>
+      <use x="27.783203" xlink:href="#DejaVuSans-31"/>
      </g>
     </g>
    </g>
    <g id="text_8">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- i2 -->
-     <g transform="translate(141.068893 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-105"/>
-      <use x="27.783203" xlink:href="#DejaVuSans-50"/>
+     <g transform="translate(141.068893 23.019614)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-69"/>
+      <use x="27.783203" xlink:href="#DejaVuSans-32"/>
      </g>
     </g>
    </g>
    <g id="text_9">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- i4 -->
-     <g transform="translate(174.607586 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-105"/>
-      <use x="27.783203" xlink:href="#DejaVuSans-52"/>
+     <g transform="translate(174.607586 23.019614)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-69"/>
+      <use x="27.783203" xlink:href="#DejaVuSans-34"/>
      </g>
     </g>
    </g>
    <g id="text_10">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- i8 -->
-     <g transform="translate(208.146279 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-105"/>
-      <use x="27.783203" xlink:href="#DejaVuSans-56"/>
+     <g transform="translate(208.146279 23.019614)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-69"/>
+      <use x="27.783203" xlink:href="#DejaVuSans-38"/>
      </g>
     </g>
    </g>
    <g id="text_11">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- f* -->
-     <g transform="translate(242.057159 79.81125)scale(0.12 -0.12)">
+     <g transform="translate(242.057159 82.58325)scale(0.12 -0.12)">
       <defs>
-       <path d="M 37.109375 75.984375 
-L 37.109375 68.5 
-L 28.515625 68.5 
-Q 23.6875 68.5 21.796875 66.546875 
-Q 19.921875 64.59375 19.921875 59.515625 
-L 19.921875 54.6875 
-L 34.71875 54.6875 
-L 34.71875 47.703125 
-L 19.921875 47.703125 
-L 19.921875 0 
-L 10.890625 0 
-L 10.890625 47.703125 
-L 2.296875 47.703125 
-L 2.296875 54.6875 
-L 10.890625 54.6875 
-L 10.890625 58.5 
-Q 10.890625 67.625 15.140625 71.796875 
-Q 19.390625 75.984375 28.609375 75.984375 
+       <path d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
 z
-" id="DejaVuSans-102"/>
+" id="DejaVuSans-66" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-102"/>
-      <use x="35.205078" xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-66"/>
+      <use x="35.205078" xlink:href="#DejaVuSans-2a"/>
      </g>
     </g>
    </g>
    <g id="text_12">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- bf -->
-     <g transform="translate(291.556135 102.720341)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-98"/>
-      <use x="63.476562" xlink:href="#DejaVuSans-102"/>
+     <g transform="translate(291.556135 106.408705)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-62"/>
+      <use x="63.476562" xlink:href="#DejaVuSans-66"/>
      </g>
     </g>
    </g>
    <g id="text_13">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- f2 -->
-     <g transform="translate(291.547698 56.902159)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-102"/>
-      <use x="35.205078" xlink:href="#DejaVuSans-50"/>
+     <g transform="translate(291.547698 58.757795)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use x="35.205078" xlink:href="#DejaVuSans-32"/>
      </g>
     </g>
    </g>
    <g id="text_14">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- f4 -->
-     <g transform="translate(341.855737 79.81125)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-102"/>
-      <use x="35.205078" xlink:href="#DejaVuSans-52"/>
+     <g transform="translate(341.855737 82.58325)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use x="35.205078" xlink:href="#DejaVuSans-34"/>
      </g>
     </g>
    </g>
    <g id="text_15">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- f8 -->
-     <g transform="translate(375.39443 79.81125)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-102"/>
-      <use x="35.205078" xlink:href="#DejaVuSans-56"/>
+     <g transform="translate(375.39443 82.58325)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-66"/>
+      <use x="35.205078" xlink:href="#DejaVuSans-38"/>
      </g>
     </g>
    </g>
    <g id="text_16">
-    <g clip-path="url(#pbde559b380)">
+    <g clip-path="url(#p15dc812c16)">
      <!-- c* -->
-     <g transform="translate(274.408977 22.538523)scale(0.12 -0.12)">
+     <g transform="translate(274.408977 23.019614)scale(0.12 -0.12)">
       <defs>
-       <path d="M 48.78125 52.59375 
-L 48.78125 44.1875 
-Q 44.96875 46.296875 41.140625 47.34375 
-Q 37.3125 48.390625 33.40625 48.390625 
-Q 24.65625 48.390625 19.8125 42.84375 
-Q 14.984375 37.3125 14.984375 27.296875 
-Q 14.984375 17.28125 19.8125 11.734375 
-Q 24.65625 6.203125 33.40625 6.203125 
-Q 37.3125 6.203125 41.140625 7.25 
-Q 44.96875 8.296875 48.78125 10.40625 
-L 48.78125 2.09375 
-Q 45.015625 0.34375 40.984375 -0.53125 
-Q 36.96875 -1.421875 32.421875 -1.421875 
-Q 20.0625 -1.421875 12.78125 6.34375 
-Q 5.515625 14.109375 5.515625 27.296875 
-Q 5.515625 40.671875 12.859375 48.328125 
-Q 20.21875 56 33.015625 56 
-Q 37.15625 56 41.109375 55.140625 
-Q 45.0625 54.296875 48.78125 52.59375 
+       <path d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
 z
-" id="DejaVuSans-99"/>
+" id="DejaVuSans-63" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-99"/>
-      <use x="54.980469" xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use x="54.980469" xlink:href="#DejaVuSans-2a"/>
      </g>
     </g>
    </g>
    <g id="text_17">
-    <g clip-path="url(#pbde559b380)">
-     <!-- c4 -->
-     <g transform="translate(374.207555 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-99"/>
-      <use x="54.980469" xlink:href="#DejaVuSans-52"/>
+    <g clip-path="url(#p15dc812c16)">
+     <!-- c8 -->
+     <g transform="translate(374.207555 23.019614)scale(0.12 -0.12)">
+      <use xlink:href="#DejaVuSans-63"/>
+      <use x="54.980469" xlink:href="#DejaVuSans-38"/>
      </g>
     </g>
    </g>
    <g id="text_18">
-    <g clip-path="url(#pbde559b380)">
-     <!-- c8 -->
-     <g transform="translate(407.746247 22.538523)scale(0.12 -0.12)">
-      <use xlink:href="#DejaVuSans-99"/>
-      <use x="54.980469" xlink:href="#DejaVuSans-56"/>
+    <g clip-path="url(#p15dc812c16)">
+     <!-- c16 -->
+     <g transform="translate(403.928747 23.019614)scale(0.12 -0.12)">
+      <defs>
+       <path d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" id="DejaVuSans-36" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use x="54.980469" xlink:href="#DejaVuSans-31"/>
+      <use x="118.603516" xlink:href="#DejaVuSans-36"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbde559b380">
-   <rect height="138.6" width="446.4" x="7.2" y="7.2"/>
+  <clipPath id="p15dc812c16">
+   <rect height="144.144" width="446.4" x="7.2" y="7.2"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/type_promotion.rst
+++ b/docs/type_promotion.rst
@@ -16,18 +16,18 @@ JAX's type promotion behavior is determined via the following type promotion lat
     lattice = {
       'b1': ['i*'], 'u1': ['u2', 'i2'], 'u2': ['i4', 'u4'], 'u4': ['u8', 'i8'], 'u8': ['f*'],
       'i*': ['u1', 'i1'], 'i1': ['i2'], 'i2': ['i4'], 'i4': ['i8'], 'i8': ['f*'],
-      'f*': ['c*', 'f2', 'bf'], 'bf': ['f4'], 'f2': ['f4'], 'f4': ['c4', 'f8'], 'f8': ['c8'],
-      'c*': ['c4'], 'c4': ['c8'], 'c8': [],
+      'f*': ['c*', 'f2', 'bf'], 'bf': ['f4'], 'f2': ['f4'], 'f4': ['c8', 'f8'], 'f8': ['c16'],
+      'c*': ['c8'], 'c8': ['c16'], 'c16': [],
     }
     graph = nx.from_dict_of_lists(lattice, create_using=nx.DiGraph)
     pos = {
       'b1': [0, 0], 'u1': [2, 0], 'u2': [3, 0], 'u4': [4, 0], 'u8': [5, 0],
       'i*': [1, 1], 'i1': [2, 2], 'i2': [3, 2], 'i4': [4, 2], 'i8': [5, 2],
       'f*': [6, 1], 'bf': [7.5, 0.6], 'f2': [7.5, 1.4], 'f4': [9, 1], 'f8': [10, 1],
-      'c*': [7, 2], 'c4': [10, 2], 'c8': [11, 2],
+      'c*': [7, 2], 'c8': [10, 2], 'c16': [11, 2],
     }
-    fig, ax = plt.subplots(figsize=(8, 2.5))
-    nx.draw(graph, with_labels=True, node_size=600, node_color='lightgray', pos=pos, ax=ax)
+    fig, ax = plt.subplots(figsize=(8, 2.6))
+    nx.draw(graph, with_labels=True, node_size=650, node_color='lightgray', pos=pos, ax=ax)
     fig.savefig('type_lattice.svg', bbox_inches='tight')
 
 where, for example:
@@ -37,7 +37,7 @@ where, for example:
 * ``u4`` means :code:`np.uint32`,
 * ``bf`` means :code:`np.bfloat16`,
 * ``f2`` means :code:`np.float16`,
-* ``c8`` means :code:`np.complex128`,
+* ``c8`` means :code:`np.complex64`,
 * ``i*`` means Python :code:`int` or weakly-typed :code:`int`,
 * ``f*`` means Python :code:`float` or weakly-typed :code:`float`, and
 * ``c*`` means Python :code:`complex` or weakly-typed :code:`complex`.
@@ -74,45 +74,42 @@ on this lattice, which generates the following binary promotion table:
     </style>
 
     <table id="types">
-    <tr><th></th><th>b1</th><th>u1</th><th>u2</th><th>u4</th><th>u8</th><th>i1</th><th>i2</th><th>i4</th><th>i8</th><th>bf</th><th>f2</th><th>f4</th><th>f8</th><th>c4</th><th>c8</th><th>i*</th><th>f*</th><th>c*</th></tr>
-    <tr><td>b1</td><td>b1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td>i8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>u1</td><td>u1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">u1</td><td>f8</td><td>c8</td></tr>
-    <tr><td>u2</td><td>u2</td><td>u2</td><td>u2</td><td>u4</td><td>u8</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">u2</td><td>f8</td><td>c8</td></tr>
-    <tr><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td class="d">u4</td><td>f8</td><td>c8</td></tr>
-    <tr><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td class="d">u8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>i1</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td>f8</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">i1</td><td>f8</td><td>c8</td></tr>
-    <tr><td>i2</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td>f8</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">i2</td><td>f8</td><td>c8</td></tr>
-    <tr><td>i4</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td>f8</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td class="d">i4</td><td>f8</td><td>c8</td></tr>
-    <tr><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td>i8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">f4</td><td class="d">f4</td><td class="d">f8</td><td class="d">c4</td><td class="d">c8</td><td class="d">bf</td><td class="d">bf</td><td class="d">c4</td></tr>
-    <tr><td>f2</td><td>f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f4</td><td>f2</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">f2</td><td class="d">f2</td><td class="d">c4</td></tr>
-    <tr><td>f4</td><td>f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td>f8</td><td>c4</td><td>c8</td><td class="d">f4</td><td class="d">f4</td><td class="d">c4</td></tr>
-    <tr><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">f8</td><td>f8</td><td>f8</td><td>f8</td><td>c8</td><td>c8</td><td>f8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>c4</td><td>c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td class="d">c4</td><td class="d">c4</td><td class="d">c4</td><td>c4</td><td>c4</td><td>c8</td><td>c4</td><td>c8</td><td class="d">c4</td><td class="d">c4</td><td class="d">c4</td></tr>
-    <tr><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td class="d">c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td></tr>
-    <tr><td>i*</td><td>i8</td><td class="d">u1</td><td class="d">u2</td><td class="d">u4</td><td class="d">u8</td><td class="d">i1</td><td class="d">i2</td><td class="d">i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td>i8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>f*</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c4</td><td>c8</td><td>f8</td><td>f8</td><td>c8</td></tr>
-    <tr><td>c*</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td class="d">c4</td><td class="d">c4</td><td class="d">c4</td><td>c8</td><td class="d">c4</td><td>c8</td><td>c8</td><td>c8</td><td>c8</td></tr>
+    <tr><th></th><th>b1</th><th>u1</th><th>u2</th><th>u4</th><th>u8</th><th>i1</th><th>i2</th><th>i4</th><th>i8</th><th>bf</th><th>f2</th><th>f4</th><th>f8</th><th>c8</th><th>c16</th><th>i*</th><th>f*</th><th>c*</th></tr>
+    <tr><td>b1</td><td>b1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td>i*</td><td>f*</td><td>c*</td></tr>
+    <tr><td>u1</td><td>u1</td><td>u1</td><td>u2</td><td>u4</td><td>u8</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">u1</td><td>f*</td><td>c*</td></tr>
+    <tr><td>u2</td><td>u2</td><td>u2</td><td>u2</td><td>u4</td><td>u8</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">u2</td><td>f*</td><td>c*</td></tr>
+    <tr><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u4</td><td>u8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td class="d">u4</td><td>f*</td><td>c*</td></tr>
+    <tr><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>u8</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td class="d">u8</td><td>f*</td><td>c*</td></tr>
+    <tr><td>i1</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td>f*</td><td>i1</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td>f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">i1</td><td>f*</td><td>c*</td></tr>
+    <tr><td>i2</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td>f*</td><td>i2</td><td>i2</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">i2</td><td>f*</td><td>c*</td></tr>
+    <tr><td>i4</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td>f*</td><td>i4</td><td>i4</td><td>i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td class="d">i4</td><td>f*</td><td>c*</td></tr>
+    <tr><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f*</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td>i8</td><td>f*</td><td>c*</td></tr>
+    <tr><td>bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">bf</td><td class="d">f4</td><td class="d">f4</td><td class="d">f8</td><td class="d">c8</td><td class="d">c16</td><td class="d">bf</td><td class="d">bf</td><td class="d">c8</td></tr>
+    <tr><td>f2</td><td>f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td>f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f2</td><td class="d">f4</td><td>f2</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">f2</td><td class="d">f2</td><td class="d">c8</td></tr>
+    <tr><td>f4</td><td>f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td class="d">f4</td><td class="d">f4</td><td class="d">f4</td><td>f4</td><td>f4</td><td>f8</td><td>c8</td><td>c16</td><td class="d">f4</td><td class="d">f4</td><td class="d">c8</td></tr>
+    <tr><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td>f8</td><td class="d">f8</td><td>f8</td><td>f8</td><td>f8</td><td>c16</td><td>c16</td><td>f8</td><td>f8</td><td>c16</td></tr>
+    <tr><td>c8</td><td>c8</td><td>c8</td><td>c8</td><td class="d">c8</td><td class="d">c8</td><td>c8</td><td>c8</td><td class="d">c8</td><td class="d">c8</td><td class="d">c8</td><td>c8</td><td>c8</td><td>c16</td><td>c8</td><td>c16</td><td class="d">c8</td><td class="d">c8</td><td class="d">c8</td></tr>
+    <tr><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td class="d">c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td><td>c16</td></tr>
+    <tr><td>i*</td><td>i*</td><td class="d">u1</td><td class="d">u2</td><td class="d">u4</td><td class="d">u8</td><td class="d">i1</td><td class="d">i2</td><td class="d">i4</td><td>i8</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td>i*</td><td>f*</td><td>c*</td></tr>
+    <tr><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td>f*</td><td class="d">bf</td><td class="d">f2</td><td class="d">f4</td><td>f8</td><td class="d">c8</td><td>c16</td><td>f*</td><td>f*</td><td>c*</td></tr>
+    <tr><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td>c*</td><td class="d">c8</td><td class="d">c8</td><td class="d">c8</td><td>c16</td><td class="d">c8</td><td>c16</td><td>c*</td><td>c*</td><td>c*</td></tr>
     </table><p>
 
 .. The table above was generated by the following Python code.
     import numpy as np
     import jax.numpy as jnp
+    from jax._src import dtypes
 
     types = [np.bool_, np.uint8, np.uint16, np.uint32, np.uint64,
-             np.int8, np.int16, np.int32, np.int64,
-             jnp.bfloat16, np.float16, np.float32, np.float64,
-             np.complex64, np.complex128, int, float, complex]
+              np.int8, np.int16, np.int32, np.int64,
+              jnp.bfloat16, np.float16, np.float32, np.float64,
+              np.complex64, np.complex128, int, float, complex]
 
     def name(d):
-      if d in {int, float, complex}:
-        return f"{d.__name__[0]}*"
-      d = np.dtype(d)
-      if d == np.dtype(jnp.bfloat16):
+      if d == jnp.bfloat16:
         return "bf"
-      return "{}{}".format(
-        d.kind,
-        d.itemsize // 2 if np.issubdtype(d, np.complexfloating) else d.itemsize)
+      itemsize = "*" if d in {int, float, complex} else np.dtype(d).itemsize
+      return f"{np.dtype(d).kind}{itemsize}"
 
     out = "<tr><th></th>"
     for t in types:
@@ -122,8 +119,10 @@ on this lattice, which generates the following binary promotion table:
     for t1 in types:
       out += "<tr><td>{}</td>".format(name(t1))
       for t2 in types:
-        t = jnp.promote_types(t1, t2)
-        different = jnp.bfloat16 in (t1, t2) or t is not np.promote_types(t1, t2)
+        t, weak_type = dtypes._lattice_result_type(t1, t2)
+        if weak_type:
+          t = type(t.type(0).item())
+        different = jnp.bfloat16 in (t1, t2) or jnp.promote_types(t1, t2) is not np.promote_types(t1, t2)
         out += "<td{}>{}</td>".format(" class=\"d\"" if different else "", name(t))
       out += "</tr>\n"
 
@@ -131,7 +130,7 @@ on this lattice, which generates the following binary promotion table:
 
 Jax's type promotion rules differ from those of NumPy, as given by
 :func:`numpy.promote_types`, in those cells highlighted with a green background
-in the table above. There are three key differences:
+in the table above. There are three key classes of differences:
 
 * When promoting a weakly typed value against a typed JAX value of the same category,
   JAX always prefers the precision of the JAX value. For example, ``jnp.int16(1) + 1``


### PR DESCRIPTION
Replaces #9550

Changes shorthands for `(complex64, complex128)` from `(c4, c8)` to `(c8, c16)` to be more consistent with numpy's use of these shorthands.

I also updated the promotion table to correctly display weakly-typed outputs.