### PR TITLE
Annotate nn.initializers

### DIFF
--- a/jax/nn/initializers.py
+++ b/jax/nn/initializers.py
@@ -19,6 +19,7 @@ used in Keras and Sonnet.
 
 from jax._src.nn.initializers import (
   constant as constant,
+  Initializer as Initializer,
   delta_orthogonal as delta_orthogonal,
   glorot_normal as glorot_normal,
   glorot_uniform as glorot_uniform,


### PR DESCRIPTION
This was done to address concerns in this review: https://github.com/google/flax/pull/1803#discussion_r807895042, namely to expose an `Initializers` type annotation that can be used in other libraries.