### PR TITLE
Add cloudpickle as a test requirement.

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,3 +1,4 @@
+cloudpickle
 colorama>=0.4.4
 flatbuffers==2.0
 pillow>=8.3.1


### PR DESCRIPTION
We have at least one test that tests pickling JAX objects.