### PR TITLE
Index update operators: add scatter_apply()

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -14,7 +14,8 @@
 
 import enum
 from functools import partial
-from typing import Any, NamedTuple, Optional, Sequence, Union
+from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
+import weakref
 
 import numpy as np
 
@@ -486,6 +487,67 @@ def scatter_max(
                                        lax._abstractify(lax._const(operand, 0)))
   return scatter_max_p.bind(
       operand, scatter_indices, updates, update_jaxpr=jaxpr,
+      update_consts=consts, dimension_numbers=dimension_numbers,
+      indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
+      mode=GatherScatterMode.from_any(mode))
+
+# To avoid recompilation, we store a dict of weak references to funcs.
+_scatter_apply_cache: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+def scatter_apply(
+  operand: Array, scatter_indices: Array,
+  func: Callable[[Array], Array],
+  dimension_numbers: ScatterDimensionNumbers, *,
+  indices_are_sorted: bool = False, unique_indices: bool = False,
+  mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  """Scatter-apply operator.
+
+  Wraps `XLA's Scatter operator
+  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where values
+  from ``operand`` are replaced with ``func(operand)``, with duplicate indices
+  resulting in multiple applications of ``func``.
+
+  The semantics of scatter are complicated, and its API might change in the
+  future. For most use cases, you should prefer the
+  :attr:`jax.numpy.ndarray.at` property on JAX arrays which uses
+  the familiar NumPy indexing syntax.
+
+  Note that in the current implementation, ``scatter_apply`` is not compatible
+  with automatic differentiation.
+
+  Args:
+    operand: an array to which the scatter should be applied
+    scatter_indices: an array that gives the indices in `operand` to which each
+      update in `updates` should be applied.
+    func: unary function that will be applied at each index.
+    dimension_numbers: a `lax.ScatterDimensionNumbers` object that describes
+      how dimensions of `operand`, `start_indices`, `updates` and the output
+      relate.
+    indices_are_sorted: whether `scatter_indices` is known to be sorted. If
+      true, may improve performance on some backends.
+    unique_indices: whether the indices to be updated in ``operand`` are
+      guaranteed to not overlap with each other. If true, may improve performance on
+      some backends.
+    mode: how to handle indices that are out of bounds: when set to 'clip',
+      indices are clamped so that the slice is within bounds, and when
+      set to 'fill' or 'drop' out-of-bounds updates are dropped. The behavior
+      for out-of-bounds indices when set to 'promise_in_bounds' is
+      implementation-defined.
+
+  Returns:
+    An array containing the result of applying `func` to `operand` at the given indices.
+  """
+  # TODO: can we implement this without a placeholder?
+  unused = lax.full(scatter_indices.shape[:1], 0, operand.dtype)
+  _apply = lambda x, _: func(x)
+  try:
+    _apply = _scatter_apply_cache.setdefault(func, _apply)
+  except TypeError:  # func is not weak referenceable
+    pass
+  jaxpr, consts = lax._reduction_jaxpr(_apply, lax._abstractify(lax._zero(operand)))
+  # TODO: implement this via its own primitive so we can define appropriate autodiff rules.
+  return scatter_p.bind(
+      operand, scatter_indices, unused, update_jaxpr=jaxpr,
       update_consts=consts, dimension_numbers=dimension_numbers,
       indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
       mode=GatherScatterMode.from_any(mode))

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -271,6 +271,7 @@ from jax._src.lax.slicing import (
   index_in_dim as index_in_dim,
   index_take as index_take,
   scatter as scatter,
+  scatter_apply as scatter_apply,
   scatter_add as scatter_add,
   scatter_add_p as scatter_add_p,
   scatter_max as scatter_max,


### PR DESCRIPTION
In the course of exploring a JAX API for numpy's ufunc methods (#9529), it became clear that there is one class of operation for which JAX doesn't currently have any high-level API: namely the equivalent of `np.ufunc.at(idx)` for a unary ufunc. For example:
```python
>>> import numpy as np

>>> x = np.array([2, 2, 2, 2])

>>> np.square.at(x, [1, 2, 2, 3, 3, 3])

>>> x
array([  2,   4,  16, 256])
```
The semantics are that the unary operation is repeatedly applied at the specified indices, something that is not currently possible with JAX (e.g. `x.at[idx].set(func(x[idx]))` only applies the function once in the case of repeated indices).

It turns out we can efficiently provide this functionality in JAX with a relatively thin wrapper around `scatter()`, accessed via `np.ndarray.at`, as is done in this PR:
```python
>>> import jax.numpy as jnp

>>> x = jnp.array([2, 2, 2, 2])

>>> idx = jnp.array([1, 2, 2, 3, 3, 3])

>>> x.at[idx].apply(jnp.square)
DeviceArray([  2,   4,  16, 256], dtype=int32)
```
This seems like it may be a useful API to make available, though admittedly I don't have any specific application in mind.

Why not allow an extra argument and extend this to binary ufuncs? Allowing this may cause confusion, because the semantics of `scatter()` are that updates can be applied in any order, and thus order of operations should not matter. This is not true for general binary functions (which is why we only implement specific binary ops in `scatter_add`, `scatter_mul`, etc.), but it is true of unary functions, so we can provide this more general implementation for the unary case.