### PR TITLE
implement `jnp.expand_dims` and `jnp.stack` for PRNGKeyArrays

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1188,7 +1188,7 @@ def squeeze(array: Array, dimensions: Sequence[int]) -> Array:
 
 def expand_dims(array: Array, dimensions: Sequence[int]) -> Array:
   """Insert any number of size 1 dimensions into an array."""
-  ndim_out = np.ndim(array) + len(dimensions)
+  ndim_out = np.ndim(array) + len(set(dimensions))
   dims_set = frozenset(canonicalize_axis(i, ndim_out) for i in dimensions)
   result_shape = list(np.shape(array))
   for i in sorted(dims_set):

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1865,8 +1865,11 @@ def _squeeze(a, axis):
 
 @_wraps(np.expand_dims)
 def expand_dims(a, axis: Union[int, Sequence[int]]):
-  _check_arraylike("expand_dims", a)
-  return lax.expand_dims(a, _ensure_index_tuple(axis))
+  _stackable(a) or _check_arraylike("expand_dims", a)
+  axis = _ensure_index_tuple(axis)
+  if hasattr(a, "expand_dims"):
+    return a.expand_dims(axis)
+  return lax.expand_dims(a, axis)
 
 
 @_wraps(np.swapaxes, lax_description=_ARRAY_VIEW_DOC)
@@ -3393,7 +3396,7 @@ def stack(arrays, axis: int = 0, out=None):
     axis = _canonicalize_axis(axis, arrays.ndim)
     return concatenate(expand_dims(arrays, axis + 1), axis=axis)
   else:
-    _check_arraylike("stack", *arrays)
+    _stackable(*arrays) or _check_arraylike("stack", *arrays)
     shape0 = shape(arrays[0])
     axis = _canonicalize_axis(axis, len(shape0) + 1)
     new_arrays = []

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1335,12 +1335,19 @@ class JnpWithPRNGKeyArrayTest(jtu.JaxTestCase):
     key = random.PRNGKey(123)
     keys = random.split(key, 2)
     keys = jnp.concatenate([keys, keys, keys], axis=0)
-    self.assertEqual(keys.shape, (3, 2))
+    self.assertEqual(keys.shape, (6,))
 
   def test_broadcast_to(self):
     key = random.PRNGKey(123)
     keys = jnp.broadcast_to(key, (3,))
     self.assertEqual(keys.shape, (3,))
+
+  def test_expand_dims(self):
+    key = random.PRNGKey(123)
+    keys = random.split(key, 6)
+    keys = jnp.reshape(keys, (2, 3))
+    keys = jnp.expand_dims(keys, 1)
+    self.assertEqual(keys.shape, (2, 1, 3))
 
   def test_broadcast_arrays(self):
     key = random.PRNGKey(123)
@@ -1351,7 +1358,9 @@ class JnpWithPRNGKeyArrayTest(jtu.JaxTestCase):
   def test_append(self):
     key = random.PRNGKey(123)
     keys = jnp.append(key, key)
-    self.assertEqual(keys.shape, (2, 1))
+    self.assertEqual(keys.shape, (2,))
+    keys = jnp.append(keys, keys)
+    self.assertEqual(keys.shape, (4,))
 
   def test_ravel(self):
     key = random.PRNGKey(123)
@@ -1359,6 +1368,13 @@ class JnpWithPRNGKeyArrayTest(jtu.JaxTestCase):
     keys = jnp.reshape(keys, (2, 2))
     keys = jnp.ravel(keys)
     self.assertEqual(keys.shape, (4,))
+
+  def test_stack(self):
+    key = random.PRNGKey(123)
+    keys = jax.random.split(key, 2)
+    keys = jnp.stack([keys, keys, keys], axis=0)
+    self.assertEqual(keys.shape, (3, 2))
+
 
 def _sampler_unimplemented_with_custom_prng(*args, **kwargs):
   raise SkipTest('sampler only implemented for default RNG')


### PR DESCRIPTION
Also:
* fix `jnp.concatenate` and `jnp.append` for PRNGKeyArrays
* add `ndim` property to PRNGKeyArrays
* minor fix to `lax.expand_dims` with duplicate dimensions

Adding `expand_dims` is a step towards implementing other `jnp` operations as well (at least `vstack`). See the PR description for #8381 for more. We can follow up with any of those.

This might make the custom PRNG upgrade (#9263) easier too: the more `jnp` operations, the better.

cc @zhangqiaorjc 