### PR TITLE
use singleton dims in broadcasting binop batchers

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -597,8 +597,10 @@ def broadcast_batcher(prim, args, dims, **params):
     out = prim.bind(*args, **params)
     return (out, (d,) * len(out)) if prim.multiple_results else (out, d)
   else:
-    size, = {shape[d] for shape, d in shapes if d is not not_mapped}
-    args = [bdim_at_front(x, d, size) if np.ndim(x) else x
+    # We pass size of 1 here because (1) at least one argument has a real batch
+    # dimension and (2) all unmapped axes can have a singleton axis inserted and
+    # then rely on the primitive's built-in broadcasting.
+    args = [bdim_at_front(x, d, 1) if np.ndim(x) else x
             for x, d in zip(args, dims)]
     ndim = max(np.ndim(x) for x in args)  # special-case scalar broadcasting
     args = [_handle_scalar_broadcasting(ndim, x, d) for x, d in zip(args, dims)]


### PR DESCRIPTION
(I think we used to have this optimization!)

We can make vmap more efficient in eager mode by relying on singleton-axis broadcasting built into our broadcasting binop primitives.

Before this change we might've generated this for a double-vmapped pairwise-l1-distances:

```
{ lambda ; a:f32[20,3]. let
    b:f32[20,20,3] = broadcast_in_dim[
      broadcast_dimensions=(0, 2)
      shape=(20, 20, 3)
    ] a
    c:f32[20,20,3] = broadcast_in_dim[
      broadcast_dimensions=(1, 2)
      shape=(20, 20, 3)
    ] a
    d:f32[20,20,3] = sub c b
    e:f32[20,20,3] = abs d
    f:f32[20,20] = reduce_sum[axes=(2,)] e
  in (f,) }
```

but after this change we can do this:

```
{ lambda ; a:f32[20,3]. let
    b:f32[20,1,3] = broadcast_in_dim[
      broadcast_dimensions=(0, 2)
      shape=(20, 1, 3)
    ] a
    c:f32[1,20,3] = broadcast_in_dim[
      broadcast_dimensions=(1, 2)
      shape=(1, 20, 3)
    ] a
    d:f32[20,20,3] = sub c b
    e:f32[20,20,3] = abs d
    f:f32[20,20] = reduce_sum[axes=(2,)] e
  in (f,) }
```

Notice the singleton sizes on intermediates!

(I didn't actually wait for tests to finish before pushing this, so let's see what happens...)