### PR TITLE
Fix Iree backend to for copy_to_device and executable results

### DIFF
--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -59,6 +59,9 @@ class IreeBuffer(xla_client.DeviceArrayBase):
     self._device = device
     self._npy_value = np.asarray(npy_value)
 
+  def copy_to_device(self, device):
+    return self
+
   def to_py(self) -> np.ndarray:
     return self._npy_value
 
@@ -89,7 +92,7 @@ class IreeExecutable:
     outputs = self.module_object[self.function_name](*inputs)
     # TODO(phawkins): Have a way to just have it always return the list,
     # regardless of arity.
-    if not isinstance(outputs, list):
+    if not isinstance(outputs, list) and not isinstance(outputs, tuple):
       outputs = [outputs]
     return [
         IreeBuffer(self.client, self._devices[0], output) for output in outputs


### PR DESCRIPTION
Executable results can be a tuple, if so iterate over the entires.

Copy to device should just return the the IREE buffer as device buffer
management is still in progress.