### PR TITLE
IREE's get_default_device_assignment should return List[Device]

### DIFF
--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -125,11 +125,11 @@ class IreeClient:
 
   def get_default_device_assignment(
       self,
-      num_replicas: int,
-      num_partitions: int = 1) -> List[List[IreeDevice]]:
-    if num_replicas != 1 or num_partitions != 1:
+      num_replicas: int) -> List[IreeDevice]:
+    if num_replicas != 1:
       raise NotImplementedError("Only single-device computations implemented")
-    return [[self._devices[0]]]
+    return [self._devices[0]]
+
 
   def compile(self, computation: str,
               compile_options: xla_client.CompileOptions) -> IreeExecutable:


### PR DESCRIPTION
Previously return List[List[Device]] which is not how the function is used.
Updated to use the alternative overload.