### PR TITLE
Add copy button to code snippets in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     'myst_nb',
     "sphinx_remove_toctrees",
+    'sphinx_copybutton',
     'jax_extensions',
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ sphinx-book-theme
 sphinx-remove-toctrees
 # Newer versions cause issues; see https://github.com/google/jax/pull/6449
 sphinx-autodoc-typehints==1.11.1
+sphinx-copybutton>=0.5.0
 jupyter-sphinx>=0.3.2
 myst-nb
 


### PR DESCRIPTION
Add copy-to-clipboard button to JAX docs, using sphinx-copybutton. Closes #9657 