### PR TITLE
`custom_transpose` without staging

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2601,6 +2601,7 @@ def linear_transpose(fun: Callable, *primals, reduce_axes=()) -> Callable:
                     "[float or complex], and integer -> integer functions, "
                     f"but got {in_dtypes} -> {out_dtypes}.")
 
+  @api_boundary
   def transposed_fun(consts, out_cotangent):
     out_cotangents, out_tree2 = tree_flatten(out_cotangent)
     if out_tree() != out_tree2:

--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -13,22 +13,19 @@
 # limitations under the License.
 
 import functools
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 from jax import core
 from jax import linear_util as lu
 from jax.interpreters import ad
-from jax.interpreters import partial_eval as pe
-from jax.interpreters import mlir
-from jax.interpreters import xla
-from jax.tree_util import (tree_flatten, tree_leaves, tree_unflatten,
-                           treedef_tuple)
+from jax.tree_util import (tree_flatten, tree_leaves, tree_map,
+                           tree_structure, treedef_tuple, tree_unflatten)
 from jax._src import ad_util
+from jax._src import api_util
 from jax._src import custom_api_util
 from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src import util
-from jax._src.api_util import flatten_fun_nokwargs
 
 
 source_info_util.register_exclusion(__file__)
@@ -39,15 +36,37 @@ map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
 
 
+### bespoke linear_util and api_util deviations
+
+class StoreEqual(lu.Store):
+  """Stores an unchanging value. Checks empty reads and unequal overwrites."""
+  def store(self, val):
+    if self._val is not lu._EMPTY_STORE_VALUE and val != self._val:
+      raise lu.StoreException(
+          f"Store assignment mismatch, from {self._val} to {val}")
+    self._val = val
+
+@util.curry
+def transformation_with_aux(
+    gen, fun: lu.WrappedFun, *gen_static_args) -> Tuple[lu.WrappedFun, Any]:
+  out_store = StoreEqual()
+  out_thunk = lambda: out_store.val
+  return fun.wrap(gen, gen_static_args, out_store), out_thunk
+
+flatten_fun_nokwargs = transformation_with_aux(
+    api_util.flatten_fun_nokwargs.args[0])  # type: ignore[has-type]
+
+
+### api
+
 @custom_api_util.register_custom_decorator_type
 class custom_transpose:
   fun: Callable
-  transpose: Optional[Callable]
+  transpose: Optional[Callable] = None
 
   def __init__(self, fun: Callable):
     functools.update_wrapper(self, fun)
     self.fun = fun  # type: ignore[assignment]
-    self.transpose = None
 
   __getattr__ = custom_api_util.forward_attr
 
@@ -56,83 +75,118 @@ class custom_transpose:
     return transpose
 
   @traceback_util.api_boundary
-  def __call__(self, residual_arg, linear_arg):
-    res_arg, lin_arg = residual_arg, linear_arg
+  def __call__(self, out_types, res_arg, lin_arg):
     _, res_tree = tree_flatten(res_arg)
     _, lin_tree = tree_flatten(lin_arg)
     args_flat, in_tree = tree_flatten((res_arg, lin_arg))
 
-    flat_fun, out_tree = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
-    in_avals = [core.raise_to_shaped(core.get_aval(x)) for x in args_flat]
-    debug = pe.debug_info(self.fun, in_tree, False, "custom_transpose")
-    jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals, debug)
-    assert not len(consts)
-    closed_call = core.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr), ())
-    out_flat = custom_transpose_p.bind(*consts, *args_flat,
-                                       call=closed_call,
-                                       rule=self.transpose,
+    # TODO(frostig,mattjj): check that out_trees match
+    # TODO(frostig,mattjj): could, and should, we avoid flattening
+    # self.fun at this point?
+
+    flat_fun, out_tree2 = flatten_fun_nokwargs(lu.wrap_init(self.fun), in_tree)
+    out_types_flat, out_tree = tree_flatten(out_types)
+    out_flat = custom_transpose_p.bind(flat_fun, *args_flat,
+                                       transpose=self.transpose,
+                                       out_types=out_types_flat,
                                        lin_tree=lin_tree,
                                        res_tree=res_tree,
-                                       out_tree=out_tree())
-    return tree_unflatten(out_tree(), out_flat)
+                                       out_tree=out_tree)
+    return tree_unflatten(out_tree, out_flat)
 
 
 ### utils
+
+def tree_fill(x, treedef):
+  return tree_unflatten(treedef, [x] * treedef.num_leaves)
+
+def tree_fill_like(x, tree):
+  return tree_fill(x, tree_structure(tree))
+
+def tree_broadcast(full_treedef, tree, is_leaf=None):
+  full_tree = tree_fill(0, full_treedef)
+  return tree_map(tree_fill_like, tree, full_tree, is_leaf=is_leaf)
+
+def is_treedef_prefix(entire, prefix):
+  entire = tree_fill(0, entire)
+  prefix = tree_fill(0, prefix)
+  try:
+    tree_map(lambda x, y: x, prefix, entire)
+  except ValueError:
+    return False
+  return True
 
 def rule_name(rule):
   return getattr(rule, '__name__', '<unnamed transpose rule>')
 
 def check_transpose_rule_trees(rule, lin_tree, rule_out_tree):
-  if lin_tree != rule_out_tree and len(lin_tree.children()) == 1:
-    lin_tree2, = lin_tree.children()
-  else:
-    lin_tree2 = lin_tree
-  if lin_tree2 != rule_out_tree:
-    raise ValueError(
-        'structure of custom transpose rule\'s output does not match '
-        'structure of primal function\'s linear inputs under '
-        f'custom transpose rule ({rule_name(rule)}).\n'
-        f'Transpose rule output: {rule_out_tree}\n'
-        f'Linear primal inputs: {lin_tree}')
+  if not is_treedef_prefix(lin_tree, rule_out_tree):
+    if hasattr(rule, '_transpose_type_error'):
+      raise rule._transpose_type_error(lin_tree, rule_out_tree)
+    else:
+      raise TypeError(
+          'structure of custom transpose rule\'s output does not prefix-match '
+          'structure of primal function\'s linear inputs under '
+          f'custom transpose rule ({rule_name(rule)}).\n'
+          f'Transpose rule output: {rule_out_tree}\n'
+          f'Linear primal inputs: {lin_tree}')
 
 
-### custom_transpose_p rules
+### custom_transpose primitive and rules
+
+class CustomTransposePrimitive(core.Primitive):
+  call_primitive = False
+  map_primitive = False
+  multiple_results = True
+
+  def bind(self, call, *args, **params):
+    # TODO(frostig,mattjj): This doesn't handle closures yet, which is
+    # a bit involved. Closures are complicated by us binding `call`
+    # twice in the JVP rule for custom transpose. The `env_trace_todo`
+    # output by `process_env_traces` due to one of those two bindings
+    # should be passable to the other, and need to be passed onward
+    # since the second bind is deferred by partial eval (since it
+    # typically receives unknowns)
+    top_trace = core.find_top_trace(args)
+    tracers = map(top_trace.full_raise, args)
+    outs = top_trace.process_custom_transpose(self, call, tracers, **params)
+    return outs
+
+  # TODO(frostig,mattjj): consider keeping `call` as a named parameter
+  # instead of following this "call primitive" convention.
+  def get_bind_params(self, params):
+    new_params = dict(params)
+    return [new_params.pop('call')], new_params
 
 
-def custom_transpose_impl(*args, call, rule, res_tree, lin_tree, out_tree):
-  del rule, res_tree, lin_tree, out_tree
-  return core.jaxpr_as_fun(call)(*args)
+# TODO(frostig,mattjj): reinstate checks
+def custom_transpose_typecheck(*avals, **params):
+  pass
 
 
 def custom_transpose_transpose_rule(
-    cts, *args, call, rule, res_tree, lin_tree, out_tree):
+    cts, *args, call, transpose, out_types, res_tree, lin_tree, out_tree):
   call_in_tree = treedef_tuple((res_tree, lin_tree))
 
+  # TODO(frostig,mattjj): `lin_arg` indicates the inputs with respect
+  # to which we are transposing (via `ad.is_undefined_primal`).
+  # Consider passing this information to the custom transpose rule?
+
   res_arg, lin_arg = tree_unflatten(call_in_tree, args)
-  assert all(ad.is_undefined_primal(x)     for x in tree_leaves(lin_arg))
+  del lin_arg
   assert all(not ad.is_undefined_primal(x) for x in tree_leaves(res_arg))
 
-  cts = [ad_util.zeros_like_aval(ct_aval) if type(ct) is ad_util.Zero else ct
-         for ct, ct_aval in zip(cts, call.out_avals)]
+  cts = [ad_util.zeros_like_aval(ct.aval) if type(ct) is ad_util.Zero else ct
+         for ct in cts]
   ct_out = tree_unflatten(out_tree, cts)
-  ct_lin = rule(res_arg, ct_out)
-  ct_lin_flat, ct_lin_tree = tree_flatten(ct_lin)
-  check_transpose_rule_trees(rule, lin_tree, ct_lin_tree)
+  ct_lin = transpose(res_arg, ct_out)
+  check_transpose_rule_trees(transpose, lin_tree, tree_structure(ct_lin))
+  ct_lin_flat, _ = tree_flatten(
+      tree_broadcast(lin_tree, ct_lin, is_leaf=lambda x: x is None),
+      is_leaf=lambda x: x is None)
   return [None] * len(tree_leaves(res_arg)) + ct_lin_flat
 
 
-def custom_transpose_abstract_eval(*in_avals, call, **_):
-  return call.out_avals
-
-
-custom_transpose_p = core.Primitive('custom_transpose_call')
-custom_transpose_p.multiple_results = True
-custom_transpose_p.def_impl(custom_transpose_impl)
-custom_transpose_p.def_abstract_eval(custom_transpose_abstract_eval)
+custom_transpose_p = CustomTransposePrimitive('custom_transpose_call')
+core.custom_typechecks[custom_transpose_p] = custom_transpose_typecheck
 ad.primitive_transposes[custom_transpose_p] = custom_transpose_transpose_rule
-xla.register_translation(custom_transpose_p,
-                         xla.lower_fun(custom_transpose_impl, new_style=True,
-                                       multiple_results=True),
-                         initial_style=True)
-mlir.register_lowering(custom_transpose_p, mlir.lower_fun(
-    custom_transpose_impl, multiple_results=True))


### PR DESCRIPTION
Whereas the previous `custom_transpose` implementation staged its callable arguments upfront, this one preserves them as callables. For the time being, this requires callers to additionally supply the target function's output types at call time.

Part of #9129.