### PR TITLE
Return consistent results for image.scale_and_translate with negative dims

### DIFF
--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -90,9 +90,8 @@ def _scale_and_translate(x, output_shape: core.Shape,
   contractions = []
   in_indices = list(range(len(output_shape)))
   out_indices = list(range(len(output_shape)))
-  spatial_ndim = len(spatial_dims)
   for i, d in enumerate(spatial_dims):
-    d = canonicalize_axis(d, spatial_ndim)
+    d = canonicalize_axis(d, x.ndim)
     m = input_shape[d]
     n = output_shape[d]
     w = compute_weight_mat(m, n, scale[i], translation[i],

--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -89,7 +89,10 @@ def _scale_and_translate(x, output_shape: core.Shape,
   contractions = []
   in_indices = list(range(len(output_shape)))
   out_indices = list(range(len(output_shape)))
+  spatial_ndim = len(spatial_dims)
   for i, d in enumerate(spatial_dims):
+    if d < 0:
+      d = spatial_ndim + d
     m = input_shape[d]
     n = output_shape[d]
     w = compute_weight_mat(m, n, scale[i], translation[i],

--- a/jax/_src/image/scale.py
+++ b/jax/_src/image/scale.py
@@ -20,6 +20,7 @@ from jax import core
 from jax import jit
 from jax import lax
 from jax import numpy as jnp
+from jax._src.util import canonicalize_axis
 import numpy as np
 
 
@@ -91,8 +92,7 @@ def _scale_and_translate(x, output_shape: core.Shape,
   out_indices = list(range(len(output_shape)))
   spatial_ndim = len(spatial_dims)
   for i, d in enumerate(spatial_dims):
-    if d < 0:
-      d = spatial_ndim + d
+    d = canonicalize_axis(d, spatial_ndim)
     m = input_shape[d]
     n = output_shape[d]
     w = compute_weight_mat(m, n, scale[i], translation[i],

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -382,6 +382,13 @@ class ImageTest(jtu.JaxTestCase):
     translate_out = jax.grad(translate_fn)(translation_a)
     self.assertTrue(jnp.all(jnp.isfinite(translate_out)))
 
+  def testScaleAndTranslateNegativeDims(self):
+    data = jnp.full((3, 3), 0.5)
+    actual = jax.image.scale_and_translate(
+      data, (5, 5), (-2, -1), jnp.ones(2), jnp.zeros(2), "linear")
+    expected = jax.image.scale_and_translate(
+      data, (5, 5), (0, 1), jnp.ones(2), jnp.zeros(2), "linear")
+    self.assertAllClose(actual, expected)
 
   def testResizeWithUnusualShapes(self):
     x = jnp.ones((3, 4))


### PR DESCRIPTION
Currently, when specified negative dimensions, we get some weird results, probably because `jnp.einsum` expected non-negative numbers for contractions. This PR fixes the issue and adds a regression test.