### PR TITLE
Add simple effect types to Jaxprs (based on #8699)

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -328,7 +328,7 @@ def remat_partial_eval(trace, *tracers, jaxpr, **params):
                        for x in jaxpr_unknown.outvars]
   new_params = dict(params, jaxpr=jaxpr_unknown, differentiated=True)
   recipe = pe.new_eqn_recipe(in_jaxpr_tracers, out_jaxpr_tracers, remat_p,
-                             new_params, source_info_util.current())
+                             new_params, jaxpr_unknown.effects, source_info_util.current())
   for t in out_jaxpr_tracers: t.recipe = recipe
 
   # zip together known and unknown outputs

--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -180,7 +180,7 @@ class CustomTransposePrimitive(core.Primitive):
 
 # TODO(frostig,mattjj): reinstate checks
 def custom_transpose_typecheck(*avals, **params):
-  pass
+  return None, core.no_effects
 
 
 def custom_transpose_transpose_rule(

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -303,7 +303,8 @@ def _prune_unused_inputs(
       (i, v) for i, v in enumerate(jaxpr.constvars) if v in used)
   kept_var_idx, new_invars = util.unzip2(
       (i, v) for i, v in enumerate(jaxpr.invars) if v in used)
-  new_jaxpr = core.Jaxpr(new_constvars, new_invars, jaxpr.outvars, jaxpr.eqns)
+  new_jaxpr = core.Jaxpr(new_constvars, new_invars, jaxpr.outvars, jaxpr.eqns,
+                         jaxpr.effects)
   return new_jaxpr, set(kept_const_idx), set(kept_var_idx)
 
 

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2723,7 +2723,7 @@ def _broadcast_in_dim_staging_rule(
   out_tracer = pe.DynamicJaxprTracer(trace, aval, source_info)
   invars = [trace.getvar(x), *(trace.getvar(d) for d in dyn_shape)]
   eqn = pe.new_jaxpr_eqn(invars, [trace.makevar(out_tracer)],
-                         broadcast_in_dim_p, params, source_info)
+                         broadcast_in_dim_p, params, core.no_effects, source_info)
   trace.frame.eqns.append(eqn)
 
   return out_tracer

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1642,7 +1642,7 @@ def _pdot_abstract_eval(x, y, *, axis_name, pos_contract, pos_batch, precision):
   if not len(set(axis_name)) == len(axis_name): raise ValueError
   pos_aval = lax.dot_general_p.abstract_eval(
       x, y, dimension_numbers=[pos_contract, pos_batch],
-      precision=precision, preferred_element_type=None)
+      precision=precision, preferred_element_type=None)[0]
   common_named_shape = core.join_named_shapes(x.named_shape, y.named_shape)
   named_shape = {name: size
                  for name, size in common_named_shape.items()

--- a/jax/experimental/checkify/checkify_impl.py
+++ b/jax/experimental/checkify/checkify_impl.py
@@ -619,8 +619,7 @@ def ignore_errors_jaxpr(jaxpr, error):
   new_vars = core.gensym([jaxpr])
   new_invars = (new_vars(err_aval), new_vars(code_aval),
                 new_vars(payload_aval), *jaxpr.invars)
-  new_jaxpr = core.Jaxpr(jaxpr.constvars, new_invars,
-                         jaxpr.outvars, jaxpr.eqns)
+  new_jaxpr = jaxpr.replace(invars=new_invars)
   return core.ClosedJaxpr(new_jaxpr, consts)
 
 def while_loop_error_check(error, enabled_errors, *in_flat, cond_nconsts,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -809,7 +809,7 @@ class TensorFlowTrace(core.Trace):
     # abstract evaluation rules can properly track polymorphic shapes.
     # Unfortunately under op-by-op execution this is a rare occasion where we
     # need abstract evaluation.
-    out_aval = primitive.abstract_eval(*args_avals, **params)
+    out_aval, _ = primitive.abstract_eval(*args_avals, **params)
     args_tf: Sequence[TfVal] = [t.val for t in tracers]
     def invoke_impl() -> TfVal:
       if impl_needs_avals:

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -864,6 +864,7 @@ def _pjit_partial_eval(trace, *in_tracers,
                           unknown_tracers_out,
                           pjit_p,
                           unknown_params,
+                          unknown_jaxpr.effects,
                           source_info_util.current())
   for t in unknown_tracers_out: t.recipe = eqn
   return pe._zip_knowns(known_tracers_out, unknown_tracers_out, unknown_outs)

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -707,7 +707,8 @@ def rearrange_binders(jaxpr: core.ClosedJaxpr, primals_in, tangents_in, primals_
   new_invars = _perm(primals_in, tangents_in, jaxpr.jaxpr.invars)
   new_outvars = _perm(primals_out, tangents_out, jaxpr.jaxpr.outvars)
   new_jaxpr = core.Jaxpr(jaxpr.jaxpr.constvars,
-                         new_invars, new_outvars, jaxpr.jaxpr.eqns)
+                         new_invars, new_outvars, jaxpr.jaxpr.eqns,
+                         jaxpr.jaxpr.effects)
   return core.ClosedJaxpr(new_jaxpr, jaxpr.consts)
 
 def _perm(primal_counts, tangent_counts, lst):

--- a/jax/interpreters/masking.py
+++ b/jax/interpreters/masking.py
@@ -492,7 +492,8 @@ class MaskTrace(Trace):
     if masking_rule is None:
       raise NotImplementedError(
         f'Masking rule for {primitive} not implemented yet.')
-    out_aval = primitive.abstract_eval(*(t.aval for t in tracers), **params)
+    # Ignore effects for now.
+    out_aval, _ = primitive.abstract_eval(*(t.aval for t in tracers), **params)
     vals, polymorphic_shapes = unzip2((t.val, t.polymorphic_shape) for t in tracers)
     logical_shapes = map(shape_as_value, polymorphic_shapes)
     # TODO(mattjj): generalize mask rule signature

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -167,19 +167,19 @@ class JaxprTrace(Trace):
       return primitive.bind(*consts, **params)
     tracers = map(self.instantiate_const, tracers)
     avals = [t.aval for t in tracers]
-    out_aval = primitive.abstract_eval(*avals, **params)
+    out_aval, effects = primitive.abstract_eval(*avals, **params)
     name_stack = self._current_truncated_name_stack()
     source = source_info_util.current().replace(name_stack=name_stack)
     if primitive.multiple_results:
       out_tracers = [JaxprTracer(self, PartialVal.unknown(aval), None)
                      for aval in out_aval]
-      eqn = new_eqn_recipe(tracers, out_tracers, primitive, params, source)
+      eqn = new_eqn_recipe(tracers, out_tracers, primitive, params, effects, source)
       for t in out_tracers: t.recipe = eqn
       return out_tracers
     else:
       out_tracer = JaxprTracer(self, PartialVal.unknown(out_aval), None)
       out_tracer.recipe = new_eqn_recipe(tracers, [out_tracer], primitive,
-                                         params, source)
+                                         params, effects, source)
       return out_tracer
 
   def process_call(self, primitive, f: lu.WrappedFun, tracers, params):
@@ -222,7 +222,7 @@ class JaxprTrace(Trace):
     name_stack = self._current_truncated_name_stack()
     source = source_info_util.current().replace(name_stack=name_stack)
     eqn = new_eqn_recipe((*const_tracers, *env_tracers, *unknown_arg_tracers),
-                         out_tracers, primitive, staged_params, source)
+                         out_tracers, primitive, staged_params, jaxpr.effects, source)
     for t in out_tracers: t.recipe = eqn
     return merge_lists(out_knowns, out_tracers, out_consts)
 
@@ -288,6 +288,7 @@ class JaxprTrace(Trace):
                    for a in out_avals]
     eqn = new_eqn_recipe((*const_tracers, *env_tracers, *unknown_arg_tracers),
                          out_tracers, primitive, staged_params,
+                         jaxpr.effects,
                          source_info_util.current())
     for t in out_tracers: t.recipe = eqn
 
@@ -313,7 +314,8 @@ class JaxprTrace(Trace):
       new_params = dict(new_params, call_jaxpr=convert_constvars_jaxpr(jaxpr))
       name_stack = self._current_truncated_name_stack()
       source = source_info_util.current().replace(name_stack=name_stack)
-      eqn = new_eqn_recipe(in_tracers, out_tracers, primitive, new_params, source)
+      eqn = new_eqn_recipe(in_tracers, out_tracers, primitive, new_params,
+          jaxpr.effects, source)
       for t in out_tracers: t.recipe = eqn
       return merge_lists(out_knowns, out_tracers, out_consts)
 
@@ -352,7 +354,7 @@ class JaxprTrace(Trace):
       name_stack = self._current_truncated_name_stack()
       source = source_info_util.current().replace(name_stack=name_stack)
       eqn = new_eqn_recipe((*const_tracers, *env_tracers), out_tracers,
-                           primitive, staged_params, source)
+                           primitive, staged_params, jaxpr.effects, source)
       for t in out_tracers: t.recipe = eqn
       return merge_lists(out_knowns, out_tracers, out_consts)
 
@@ -412,6 +414,7 @@ class JaxprTrace(Trace):
                          dict(fun_jaxpr=closed_jaxpr,
                               jvp_jaxpr_thunk=jvp_jaxpr_thunk,
                               num_consts=len(consts) + len(env)),
+                         jaxpr.effects,
                          source)
     for t in out_tracers: t.recipe = eqn
     return out_tracers
@@ -436,7 +439,7 @@ class JaxprTrace(Trace):
       in_tracers = map(self.instantiate_const, tracers)
       new_params = dict(params, call=call)
       eqn = new_eqn_recipe(in_tracers, out_tracers, prim, new_params,
-                           source_info_util.current())
+          core.no_effects, source_info_util.current())
       for t in out_tracers: t.recipe = eqn
       return out_tracers
 
@@ -473,6 +476,7 @@ class JaxprTrace(Trace):
                               fwd_jaxpr_thunk=fwd_jaxpr_thunk,
                               num_consts=len(consts) + len(env),
                               bwd=bwd, out_trees=out_trees),
+                         jaxpr.effects,
                          source)
     for t in out_tracers: t.recipe = eqn
     return out_tracers
@@ -636,12 +640,14 @@ class JaxprEqnRecipe(NamedTuple):
   outvars: 'Sequence[ref[JaxprTracer]]'
   primitive: Primitive
   params: Dict[str, Any]
+  effects: core.Effects
   source_info: source_info_util.SourceInfo
 
 def new_eqn_recipe(invars: Sequence[JaxprTracer],
                    outvars: Sequence[JaxprTracer],
                    primitive: Primitive,
                    params: Dict[str, Any],
+                   effects: core.Effects,
                    source_info: source_info_util.SourceInfo
                   ) -> JaxprEqnRecipe:
   """Constructs a new JaxEqnRecipe.
@@ -665,17 +671,17 @@ def new_eqn_recipe(invars: Sequence[JaxprTracer],
     assert ("donated_invars" in params and
             len(params["donated_invars"]) == len(params["call_jaxpr"].invars))
   return JaxprEqnRecipe(object(), tuple(invars), map(ref, outvars), primitive,
-                        params, source_info)
+                        params, effects, source_info)
 
 
 def recipe_to_eqn(getvar: Callable[[JaxprTracer], Atom],
                   recipe: JaxprEqnRecipe) -> core.JaxprEqn:
-  _, in_tracers, out_tracer_refs, primitive, params, source_info = recipe
+  _, in_tracers, out_tracer_refs, primitive, params, effects, source_info = recipe
   out_tracers = [t_ref() for t_ref in out_tracer_refs]
   invars  = [getvar(t) for t in in_tracers]
   outvars = [core.DropVar(core.abstract_unit) if t is None
              else cast(Var, getvar(t)) for t in out_tracers]
-  return new_jaxpr_eqn(invars, outvars, primitive, params, source_info)
+  return new_jaxpr_eqn(invars, outvars, primitive, params, effects, source_info)
 
 def tracers_to_jaxpr(
   in_tracers: Sequence[JaxprTracer],
@@ -738,7 +744,9 @@ def tracers_to_jaxpr(
   env_vars, env_vals = unzip2(env.items())
   const_vars, const_vals = unzip2(consts.items())
   # The env_vars are pre-pended to the invars
-  jaxpr = Jaxpr(const_vars, [*env_vars, *invars], map(getvar, out_tracers), eqns)
+  effects = core.join_effects(*(eqn.effects for eqn in eqns))
+  jaxpr = Jaxpr(const_vars, [*env_vars, *invars], map(getvar, out_tracers),
+                eqns, effects)
   config.jax_enable_checks and core.check_jaxpr(jaxpr)
   return jaxpr, const_vals, env_vals
 
@@ -748,7 +756,8 @@ def convert_constvars_jaxpr(jaxpr: Jaxpr) -> Jaxpr:
   config.jax_enable_checks and core.check_jaxpr(jaxpr)
   lifted_jaxpr = Jaxpr(constvars=(),
                        invars=jaxpr.constvars + jaxpr.invars,
-                       outvars=jaxpr.outvars, eqns=jaxpr.eqns)
+                       outvars=jaxpr.outvars, eqns=jaxpr.eqns,
+                       effects=jaxpr.effects)
   config.jax_enable_checks and core.check_jaxpr(lifted_jaxpr)
   return lifted_jaxpr
 
@@ -756,7 +765,8 @@ def convert_envvars_to_constvars(jaxpr: Jaxpr, num_env_vars: int) -> Jaxpr:
   config.jax_enable_checks and core.check_jaxpr(jaxpr)
   env_vars, invars = split_list(jaxpr.invars, [num_env_vars])
   converted_jaxpr = Jaxpr(constvars=jaxpr.constvars + env_vars,
-                          invars=invars, outvars=jaxpr.outvars, eqns=jaxpr.eqns)
+                          invars=invars, outvars=jaxpr.outvars, eqns=jaxpr.eqns,
+                          effects=jaxpr.effects)
   config.jax_enable_checks and core.check_jaxpr(converted_jaxpr)
   return converted_jaxpr
 
@@ -913,7 +923,7 @@ def _remat_partial_eval(trace, _, f, tracers, params):
                          for x in jaxpr_unknown.outvars]
     new_params = dict(params, call_jaxpr=jaxpr_unknown, differentiated=True)
     recipe = new_eqn_recipe(in_jaxpr_tracers, out_jaxpr_tracers, remat_call_p,
-                            new_params, source_info_util.current())
+                            new_params, jaxpr_unknown.effects, source_info_util.current())
     for t in out_jaxpr_tracers: t.recipe = recipe
     return _zip_knowns(out_known_tracers, out_jaxpr_tracers, out_unknowns)
   else:
@@ -960,7 +970,7 @@ def _remat_partial_eval(trace, _, f, tracers, params):
     const_tracers = map(trace.new_instantiated_const, consts)
     in_tracers = (*const_tracers, *env_tracers, *instantiated_tracers)
     eqn = new_eqn_recipe(in_tracers, unknown_output_tracers, remat_call_p,
-                         new_params, source_info_util.current())
+                         new_params, new_jaxpr.effects, source_info_util.current())
     for t in unknown_output_tracers: t.recipe = eqn
     return _zip_knowns(known_output_tracers, unknown_output_tracers, out_unknowns)
 call_partial_eval_rules[remat_call_p] = _remat_partial_eval
@@ -1009,8 +1019,7 @@ def _partial_eval_jaxpr_custom(
       map(write, unks_out, inst_out, eqn.outvars)
     elif any(unks_in):
       inputs = map(ensure_instantiated, inst_in, eqn.invars)
-      staged_eqns.append(new_jaxpr_eqn(inputs, eqn.outvars, eqn.primitive,
-                                       eqn.params, eqn.source_info))
+      staged_eqns.append(eqn.replace(invars=inputs))
       map(partial(write, True, True), eqn.outvars)
     else:
       known_eqns.append(eqn)
@@ -1018,8 +1027,7 @@ def _partial_eval_jaxpr_custom(
         map(partial(write, False, False), eqn.outvars)
       else:
         inputs = map(ensure_instantiated, inst_in, eqn.invars)
-        staged_eqns.append(new_jaxpr_eqn(inputs, eqn.outvars, eqn.primitive,
-                                         eqn.params, eqn.source_info))
+        staged_eqns.append(eqn.replace(invars=inputs))
         map(partial(write, False, True), eqn.outvars)
   out_unknowns, out_inst = unzip2(map(read, jaxpr.outvars))
   assert all(type(v) is Var for v in residuals), residuals
@@ -1027,11 +1035,15 @@ def _partial_eval_jaxpr_custom(
   ins_known, _ = partition_list(in_unknowns, jaxpr.invars)
   outs_known_, _ = partition_list(out_unknowns, jaxpr.outvars)
   outs_known = [x for x in outs_known_ if x.aval is not abstract_unit]
-  jaxpr_known = Jaxpr((), ins_known, [*outs_known, *residuals], known_eqns)
+  known_effects = core.join_effects(*(eqn.effects for eqn in known_eqns))
+  jaxpr_known = Jaxpr((), ins_known, [*outs_known, *residuals], known_eqns,
+                      known_effects)
   config.jax_enable_checks and core.check_jaxpr(jaxpr_known)
 
   _, outs_staged = partition_list(out_inst, jaxpr.outvars)
-  jaxpr_staged = Jaxpr((), [*residuals, *jaxpr.invars], outs_staged, staged_eqns)
+  staged_effects = core.join_effects(*(eqn.effects for eqn in staged_eqns))
+  jaxpr_staged = Jaxpr((), [*residuals, *jaxpr.invars], outs_staged,
+                       staged_eqns, staged_effects)
   config.jax_enable_checks and core.check_jaxpr(jaxpr_staged)
 
   return jaxpr_known, jaxpr_staged, out_unknowns, out_inst, len(residuals)
@@ -1087,9 +1099,10 @@ def call_partial_eval_custom_rule(
   params_known, params_staged = params_updater(
       unks_in, kept_outs_known, kept_outs_staged, num_res, params_known, params_staged)
   eqn_known = new_jaxpr_eqn(ins_known, [*out_binders_known, *residuals],
-                            eqn.primitive, params_known, eqn.source_info)
+                            eqn.primitive, params_known, jaxpr_known.effects, eqn.source_info)
   eqn_staged = new_jaxpr_eqn([*residuals, *eqn.invars], out_binders_staged,
-                             eqn.primitive, params_staged, eqn.source_info)
+                             eqn.primitive, params_staged,
+                             jaxpr_staged.effects, eqn.source_info)
   assert len(eqn_staged.invars) == len(jaxpr_staged.invars)
   new_inst = [x for x, inst in zip(eqn.invars, inst_in)
               if type(x) is Var and not inst]
@@ -1142,7 +1155,7 @@ def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]
   new_jaxpr = Jaxpr((),
                     [v for v, b in zip(jaxpr.invars, used_inputs)   if b],
                     [v for v, b in zip(jaxpr.outvars, used_outputs) if b],
-                    new_eqns[::-1])
+                    new_eqns[::-1], jaxpr.effects)
   config.jax_enable_checks and core.check_jaxpr(new_jaxpr)
 
   return new_jaxpr, used_inputs
@@ -1160,7 +1173,7 @@ def dce_jaxpr_call_rule(used_outputs: List[bool], eqn: JaxprEqn
     new_params = update_params(new_params, used_inputs, 0)
   new_eqn = new_jaxpr_eqn([v for v, used in zip(eqn.invars, used_inputs) if used],
                           [v for v, used in zip(eqn.outvars, used_outputs) if used],
-                          eqn.primitive, new_params, eqn.source_info)
+                          eqn.primitive, new_params, new_jaxpr.effects, eqn.source_info)
   return used_inputs, new_eqn
 dce_rules[core.call_p] = dce_jaxpr_call_rule
 dce_rules[core.named_call_p] = dce_jaxpr_call_rule
@@ -1189,14 +1202,15 @@ def _dce_open_jaxpr(jaxpr: Jaxpr, outputs: Tuple[bool, ...], drop_outputs=False)
       new_eqns.append(eqn)
       needed_vars.update(v for v in eqn.invars if type(v) is not Literal)
   new_eqns = new_eqns[::-1]
-  return Jaxpr(jaxpr.constvars, jaxpr.invars, new_outvars, new_eqns)
+  return Jaxpr(jaxpr.constvars, jaxpr.invars, new_outvars, new_eqns,
+               jaxpr.effects)
 
 @weakref_lru_cache
 def _drop_vars(jaxpr: Jaxpr, drop_ins: Tuple[bool, ...], drop_outs: Tuple[bool, ...]):
   return Jaxpr(jaxpr.constvars,
                [v for v, d in zip(jaxpr.invars, drop_ins) if not d],
                [v for v, d in zip(jaxpr.outvars, drop_outs) if not d],
-               jaxpr.eqns)
+               jaxpr.eqns, jaxpr.effects)
 
 
 def _reconstruct_pval(pval1: PartialVal, const2: core.Value):
@@ -1215,7 +1229,8 @@ def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]) ->
   assert len(closed_jaxpr.in_avals) == len(to_move)
   new_invars = _move_to_front(closed_jaxpr.jaxpr.invars, to_move)
   new_jaxpr = Jaxpr(closed_jaxpr.jaxpr.constvars, new_invars,
-                    closed_jaxpr.jaxpr.outvars, closed_jaxpr.jaxpr.eqns)
+                    closed_jaxpr.jaxpr.outvars, closed_jaxpr.jaxpr.eqns,
+                    closed_jaxpr.jaxpr.effects)
   new_closed_jaxpr = core.ClosedJaxpr(new_jaxpr, closed_jaxpr.consts)
   return new_closed_jaxpr
 
@@ -1286,6 +1301,7 @@ class JaxprStackFrame:
   tracers: List[DynamicJaxprTracer]  # hold onto strong refs for all tracers
   eqns: List[JaxprEqn]
   invars: List[Var]
+  effects: core.Effects
 
   def __init__(self):
     self.gensym = core.gensym()
@@ -1295,13 +1311,18 @@ class JaxprStackFrame:
     self.tracers = []   # circ refs, frame->tracer->trace->main->frame,
     self.eqns = []      # cleared when we pop frame from main
     self.invars = []
+    self.effects = set()
+
+  def add_eqn(self, eqn: core.JaxprEqn):
+    self.eqns.append(eqn)
+    self.effects |= eqn.effects
 
   def to_jaxpr(self, out_tracers):
     # It's not necessary, but we keep the tracer-to-var mapping injective:
     assert len(self.tracer_to_var) == len(set(self.tracer_to_var.values()))
     outvars = [self.tracer_to_var[id(t)] for t in out_tracers]
     constvars, constvals = unzip2(self.constvar_to_val.items())
-    jaxpr = Jaxpr(constvars, self.invars, outvars, self.eqns)
+    jaxpr = Jaxpr(constvars, self.invars, outvars, self.eqns, self.effects)
     jaxpr, constvals = _const_folding_and_forwarding(jaxpr, constvals)
     jaxpr, constvals = _inline_literals(jaxpr, constvals)
     return jaxpr, constvals
@@ -1335,8 +1356,7 @@ def _const_folding_and_forwarding(jaxpr, constvals):
   new_eqns = []
   for eqn in jaxpr.eqns:
     # always apply invar substitutions
-    eqn = JaxprEqn([var_subs.get(v, v) for v in eqn.invars], eqn.outvars,
-                    eqn.primitive, eqn.params, eqn.source_info)
+    eqn = eqn.replace(invars=[var_subs.get(v, v) for v in eqn.invars])
     # if any inputs are constants and we have a constant-folding rule, apply it
     if eqn.primitive in const_fold_rules and any(v in consts for v in eqn.invars):
       consts_in = [consts.get(v) for v in eqn.invars]
@@ -1357,7 +1377,7 @@ def _const_folding_and_forwarding(jaxpr, constvals):
     new_eqns.append(eqn)
   new_constvars, new_constvals = unzip2(consts.items())
   new_outvars = [var_subs.get(v, v) for v in jaxpr.outvars]
-  new_jaxpr = Jaxpr(new_constvars, jaxpr.invars, new_outvars, new_eqns)
+  new_jaxpr = Jaxpr(new_constvars, jaxpr.invars, new_outvars, new_eqns, jaxpr.effects)
   return new_jaxpr, new_constvals
 
 ConstFoldRule = Callable[[List[Optional[Any]], JaxprEqn],
@@ -1402,10 +1422,10 @@ def _inline_literals(jaxpr, constvals):
     invars = [lit(v) or var(v) for v in eqn.invars]
     outvars = [var(v) if v in used else core.DropVar(v.aval)
                for v in eqn.outvars]
-    new_eqns.append(new_jaxpr_eqn(invars, outvars, eqn.primitive, eqn.params,
-                                  eqn.source_info))
+    new_eqns.append(eqn.replace(invars=invars, outvars=outvars))
   new_outvars = [lit(v) or var(v) for v in jaxpr.outvars]
-  new_jaxpr = Jaxpr(new_constvars, new_invars, new_outvars, new_eqns)
+  new_jaxpr = Jaxpr(new_constvars, new_invars, new_outvars, new_eqns,
+      jaxpr.effects)
   return new_jaxpr, new_constvals
 
 class DynamicJaxprTrace(core.Trace):
@@ -1485,14 +1505,14 @@ class DynamicJaxprTrace(core.Trace):
 
   def default_process_primitive(self, primitive, tracers, params):
     avals = [t.aval for t in tracers]
-    out_avals = primitive.abstract_eval(*avals, **params)
+    out_avals, effects = primitive.abstract_eval(*avals, **params)
     out_avals = [out_avals] if not primitive.multiple_results else out_avals
     source_info = source_info_util.current()
     out_tracers = [DynamicJaxprTracer(self, a, source_info) for a in out_avals]
     invars = map(self.getvar, tracers)
     outvars = map(self.makevar, out_tracers)
-    eqn = new_jaxpr_eqn(invars, outvars, primitive, params, source_info)
-    self.frame.eqns.append(eqn)
+    eqn = new_jaxpr_eqn(invars, outvars, primitive, params, effects, source_info)
+    self.frame.add_eqn(eqn)
     return out_tracers if primitive.multiple_results else out_tracers.pop()
 
   def process_call(self, call_primitive, f, tracers, params):
@@ -1520,7 +1540,8 @@ class DynamicJaxprTrace(core.Trace):
       new_params = update_params(new_params, [True] * len(tracers),
                                  len(consts) + len(dim_tracers))
     eqn = new_jaxpr_eqn([*constvars, *invars], outvars,
-                        call_primitive, new_params, source_info)
+                        call_primitive, new_params,
+                        new_params['call_jaxpr'].effects, source_info)
     self.frame.eqns.append(eqn)
     return out_tracers
 
@@ -1554,7 +1575,7 @@ class DynamicJaxprTrace(core.Trace):
       if update_params:
         new_params = update_params(new_params, [True] * len(tracers), len(consts))
       eqn = new_jaxpr_eqn([*constvars, *invars], outvars, map_primitive,
-                          new_params, source_info)
+                          new_params, new_params['call_jaxpr'].effects, source_info)
       self.frame.eqns.append(eqn)
     return out_tracers
 
@@ -1577,6 +1598,7 @@ class DynamicJaxprTrace(core.Trace):
                         dict(fun_jaxpr=closed_fun_jaxpr,
                              jvp_jaxpr_thunk=jvp_jaxpr_thunk,
                              num_consts=len(consts)),
+                        fun_jaxpr.effects,
                         source_info_util.current())
     self.frame.eqns.append(eqn)
     return out_tracers
@@ -1601,6 +1623,7 @@ class DynamicJaxprTrace(core.Trace):
                              fwd_jaxpr_thunk=fwd_jaxpr_thunk,
                              num_consts=len(consts),
                              bwd=bwd, out_trees=out_trees),
+                        fun_jaxpr.effects,
                         source_info_util.current())
     self.frame.eqns.append(eqn)
     return out_tracers
@@ -1640,8 +1663,9 @@ class DynamicJaxprTrace(core.Trace):
                              transpose_jaxpr_thunk=transpose_jaxpr_thunk,
                              out_types=out_types, res_tree=res_tree,
                              lin_tree=lin_tree, out_tree=out_tree),
+                        closed_call_jaxpr.effects,
                         source_info_util.current())
-    self.frame.eqns.append(eqn)
+    self.frame.add_eqn(eqn)
     return out_tracers
 
 

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -1,0 +1,133 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+import jax
+import jax.numpy as jnp
+from jax import core
+from jax import lax
+from jax.config import config
+from jax._src import test_util as jtu
+
+config.parse_flags_with_absl()
+
+effect_p = core.Primitive('effect')
+effect_p.multiple_results = True
+
+@effect_p.def_effectful_abstract_eval
+def _(*, effect):
+  return [], {effect}
+
+
+class JaxprEffectsTest(jtu.JaxTestCase):
+
+  def test_trivial_jaxpr_has_no_effects(self):
+    def f(x):
+      return x + 1.
+    jaxpr = jax.make_jaxpr(f)(2.)
+    self.assertEqual(core.no_effects, jaxpr.effects)
+
+  def test_effectful_primitive_in_jaxpr_creates_effects(self):
+    def f(x):
+      effect_p.bind(effect='foo')
+      return x + 1.
+    jaxpr = jax.make_jaxpr(f)(2.)
+    self.assertEqual({'foo'}, jaxpr.jaxpr.eqns[0].effects)
+    self.assertEqual({'foo'}, jaxpr.effects)
+
+  def test_different_effects_in_jaxpr(self):
+    def f(x):
+      effect_p.bind(effect='foo')
+      effect_p.bind(effect='bar')
+      return x + 1.
+    jaxpr = jax.make_jaxpr(f)(2.)
+    self.assertEqual({'foo'}, jaxpr.jaxpr.eqns[0].effects)
+    self.assertEqual({'bar'}, jaxpr.jaxpr.eqns[1].effects)
+    self.assertEqual({'foo', 'bar'}, jaxpr.effects)
+
+  def test_jaxpr_typecheck_should_verify_eqn_effects_are_subset(self):
+    def f(x):
+      effect_p.bind(effect='foo')
+      effect_p.bind(effect='bar')
+      return x + 1.
+    jaxpr = jax.make_jaxpr(f)(2.).jaxpr
+
+    # Edit jaxpr to make its type wrong
+    jaxpr = jaxpr.replace(effects={'foo'})
+
+    with self.assertRaisesRegex(core.JaxprTypeError,
+        'Equation effects are not subset of Jaxpr effects.'):
+      core.check_jaxpr(jaxpr)
+
+class ControlFlowEffectsTest(jtu.JaxTestCase):
+
+  def test_effects_disallowed_in_cond(self):
+    def f1(x):
+      def true_fun(x):
+        effect_p.bind(effect='foo')
+        return x
+      def false_fun(x):
+        return x
+      return lax.cond(True, true_fun, false_fun, x)
+
+    with self.assertRaisesRegex(NotImplementedError, 'Effects not supported'):
+      jax.make_jaxpr(f1)(2.)
+
+    def f2(x):
+      def true_fun(x):
+        return x
+      def false_fun(x):
+        effect_p.bind(effect='foo')
+        return x
+      return lax.cond(True, true_fun, false_fun, x)
+
+    with self.assertRaisesRegex(NotImplementedError, 'Effects not supported'):
+      jax.make_jaxpr(f2)(2.)
+
+  def test_effects_disallowed_in_while(self):
+    def f1(x):
+      def cond_fun(x):
+        effect_p.bind(effect='foo')
+        return False
+      def body_fun(x):
+        return x
+      return lax.while_loop(cond_fun, body_fun, x)
+
+    with self.assertRaisesRegex(NotImplementedError, 'Effects not supported'):
+      jax.make_jaxpr(f1)(2.)
+
+    def f2(x):
+      def cond_fun(x):
+        return False
+      def body_fun(x):
+        effect_p.bind(effect='foo')
+        return x
+      return lax.while_loop(cond_fun, body_fun, x)
+
+    with self.assertRaisesRegex(NotImplementedError, 'Effects not supported'):
+      jax.make_jaxpr(f2)(2.)
+
+  def test_effects_disallowed_in_scan(self):
+
+    def f(x):
+      def body(carry, x):
+        effect_p.bind(effect='foo')
+        return carry, x
+      return lax.scan(body, x, jnp.arange(4))
+
+    with self.assertRaisesRegex(NotImplementedError, 'Effects not supported'):
+      jax.make_jaxpr(f)(2.)
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2888,20 +2888,20 @@ class LaxNamedShapeTest(jtu.JaxTestCase):
 
   def test_abstract_eval(self):
     aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
-    out = lax.sin_p.abstract_eval(aval1)
+    out, _ = lax.sin_p.abstract_eval(aval1)
     self.assertEqual(out, aval1)
 
     aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10})
     aval2 = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
     expected = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
-    out = lax.add_p.abstract_eval(aval1, aval2)
+    out, _ = lax.add_p.abstract_eval(aval1, aval2)
     self.assertEqual(out, expected)
 
   def test_abstract_eval_collective(self):
     with core.extend_axis_env('i', 10, None):
       aval1 = core.ShapedArray((2, 3), np.float32, False, {'i': 10, 'j': 5})
       expected = core.ShapedArray((2, 3), np.float32, False, {'j': 5})
-      out, = lax.psum_p.abstract_eval(aval1, axes=('i',), axis_index_groups=None)
+      (out,), _ = lax.psum_p.abstract_eval(aval1, axes=('i',), axis_index_groups=None)
       self.assertEqual(out, expected)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds simple effect types to Jaxprs (based on #8699).

This PR is adds a new fields to `Jaxpr`s and `JaxprEqn`s, `effects`, which is a `Set[Any]`. This PR adds the relevant threading of `effects` through the Jaxpr transformations and also adds a `.replace` convenience method for `JaxprEqn`s, `Jaxpr`s and `ClosedJaxpr`s.

Effects are added to Jaxpr at trace time via the `abstract_eval` rule, whose return values are augmented from `List[Aval]` to `Tuple[List[Aval], Set[Any]]`. Rather than rewriting every `abstract_eval` rule, we have `def_abstract_eval` wrap the provided function with one that additionally returns an empty set. Primitives now have a new `def_effectful_abstract_eval` that enables providing `abstract_eval` methods that return both avals and effects.

This PR also disallows effects in control flow primitives (i.e. `cond`, `while_loop`, and `scan`) by erroring if an effect is detected after tracing the body functions to jaxprs.