### PR TITLE
implement jnp.copy

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -118,6 +118,7 @@ Not every function in NumPy is implemented; contributions are welcome!
     conj
     conjugate
     convolve
+    copy
     copysign
     corrcoef
     correlate

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2680,6 +2680,11 @@ def asarray(a, dtype=None, order=None):
   return array(a, dtype=dtype, copy=False, order=order)
 
 
+@_wraps(np.copy, lax_description=_ARRAY_DOC)
+def copy(a, order=None):
+  return array(a, copy=True, order=order)
+
+
 @_wraps(np.zeros_like)
 def zeros_like(a, dtype=None, shape=None):
   _check_arraylike("zeros_like", a)

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -94,6 +94,7 @@ from jax._src.numpy.lax_numpy import (
     conj as conj,
     conjugate as conjugate,
     convolve as convolve,
+    copy as copy,
     copysign as copysign,
     corrcoef as corrcoef,
     correlate as correlate,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -3761,15 +3761,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     _check([0.0, np.float16(1)], np.float16, False)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_dtype={np.dtype(dtype)}", "dtype": dtype}
-      for dtype in all_dtypes))
-  def testArrayCopy(self, dtype):
+      {"testcase_name": f"_dtype={np.dtype(dtype)}_func={func}",
+       "dtype": dtype, "func": func}
+      for dtype in all_dtypes
+      for func in ["array", "copy"]))
+  def testArrayCopy(self, dtype, func):
     x = jnp.ones(10, dtype=dtype)
+    copy_func = getattr(jnp, func)
 
     x_view = jnp.asarray(x)
     x_view_jit = jax.jit(jnp.asarray)(x)
-    x_copy = jnp.array(x)
-    x_copy_jit = jax.jit(jnp.array)(x)
+    x_copy = copy_func(x)
+    x_copy_jit = jax.jit(copy_func)(x)
 
     _ptr = lambda x: x.device_buffer.unsafe_buffer_pointer()
 
@@ -6061,6 +6064,7 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'asarray': ['like'],
       'broadcast_to': ['subok', 'array'],
       'clip': ['kwargs'],
+      'copy': ['subok'],
       'corrcoef': ['ddof', 'bias', 'dtype'],
       'cov': ['dtype'],
       'empty_like': ['subok', 'order'],


### PR DESCRIPTION
Now that we have `lax.copy_p`, implementing this function makes sense.