### PR TITLE
cleanup: remove _constant_like in favor of lax._const

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -321,7 +321,7 @@ def cholesky_jvp_rule(primals, tangents):
   # Forward-mode rule from https://arxiv.org/pdf/1602.07527.pdf
   def phi(X):
     l = jnp.tril(X)
-    return l / lax.expand_dims(jnp._constant_like(X, 1) + jnp.eye(X.shape[-1], dtype=X.dtype),
+    return l / lax.expand_dims(lax._const(X, 1) + jnp.eye(X.shape[-1], dtype=X.dtype),
                                range(l.ndim - 2))
 
   tmp = triangular_solve(L, sigma_dot, left_side=False, transpose_a=True,
@@ -981,7 +981,7 @@ def _lu_jvp_rule(primals, tangents):
   ndims = len(a_shape)
   l_padding = [(0, 0, 0)] * ndims
   l_padding[-1] = (0, m - k, 0)
-  zero = jnp._constant_like(lu, 0)
+  zero = lax._const(lu, 0)
   l = lax.pad(jnp.tril(lu[..., :, :k], -1), zero, l_padding)
   l = l + lax.expand_dims(jnp.eye(m, m, dtype=dtype), range(l.ndim - 2))
 

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -27,8 +27,7 @@ from jax._src import prng
 from jax.config import config
 from jax.core import NamedShape
 from jax._src.api import jit, vmap
-from jax._src.numpy.lax_numpy import (_arraylike, _check_arraylike,
-                                      _constant_like, _convert_and_clip_integer)
+from jax._src.numpy.lax_numpy import _arraylike, _check_arraylike, _convert_and_clip_integer
 from jax._src.lib import xla_bridge
 from jax.numpy.linalg import cholesky, svd, eigh
 from jax.interpreters import ad
@@ -790,8 +789,8 @@ def cauchy(key: KeyArray,
 def _cauchy(key, shape, dtype):
   _check_shape("cauchy", shape)
   u = uniform(key, shape, dtype, minval=jnp.finfo(dtype).eps, maxval=1.)
-  pi = _constant_like(u, np.pi)
-  return lax.tan(lax.mul(pi, lax.sub(u, _constant_like(u, 0.5))))
+  pi = lax._const(u, np.pi)
+  return lax.tan(lax.mul(pi, lax.sub(u, lax._const(u, 0.5))))
 
 
 def dirichlet(key: KeyArray,
@@ -877,12 +876,12 @@ def _gamma_one(key: KeyArray, alpha):
   # Ref: A simple method for generating gamma variables, George Marsaglia and Wai Wan Tsang
   # The algorithm can also be founded in:
   # https://en.wikipedia.org/wiki/Gamma_distribution#Generating_gamma-distributed_random_variables
-  zero = _constant_like(alpha, 0)
-  one = _constant_like(alpha, 1)
-  minus_one = _constant_like(alpha, -1)
-  one_over_two = _constant_like(alpha, 0.5)
-  one_over_three = _constant_like(alpha, 1. / 3.)
-  squeeze_const = _constant_like(alpha, 0.0331)
+  zero = lax._const(alpha, 0)
+  one = lax._const(alpha, 1)
+  minus_one = lax._const(alpha, -1)
+  one_over_two = lax._const(alpha, 0.5)
+  one_over_three = lax._const(alpha, 1. / 3.)
+  squeeze_const = lax._const(alpha, 0.0331)
   dtype = lax.dtype(alpha)
 
   key, subkey = _split(key)
@@ -924,7 +923,7 @@ def _gamma_one(key: KeyArray, alpha):
     return key, X, V, U
 
   # initial state is chosen such that _cond_fn will return True
-  _, _, V, _ = lax.while_loop(_cond_fn, _body_fn, (key, zero, one, _constant_like(alpha, 2)))
+  _, _, V, _ = lax.while_loop(_cond_fn, _body_fn, (key, zero, one, lax._const(alpha, 2)))
   z = lax.mul(lax.mul(d, V), boost)
   return lax.select(lax.eq(z, zero), jnp.finfo(z.dtype).tiny, z)
 
@@ -1354,7 +1353,7 @@ def _t(key, df, shape, dtype):
   df = lax.convert_element_type(df, dtype)
   key_n, key_g = _split(key)
   n = normal(key_n, shape, dtype)
-  two = _constant_like(n, 2)
+  two = lax._const(n, 2)
   half_df = lax.div(df, two)
   g = gamma(key_n, half_df, shape, dtype)
   return n * jnp.sqrt(half_df / g)

--- a/jax/_src/scipy/stats/bernoulli.py
+++ b/jax/_src/scipy/stats/bernoulli.py
@@ -24,8 +24,8 @@ from jax.scipy.special import xlogy, xlog1py
 @_wraps(osp_stats.bernoulli.logpmf, update_doc=False)
 def logpmf(k, p, loc=0):
   k, p, loc = jnp._promote_args_inexact("bernoulli.logpmf", k, p, loc)
-  zero = jnp._constant_like(k, 0)
-  one = jnp._constant_like(k, 1)
+  zero = lax._const(k, 0)
+  one = lax._const(k, 1)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, p) + xlog1py(lax.sub(one, x), -p)
   return jnp.where(jnp.logical_or(lax.lt(x, zero), lax.gt(x, one)),

--- a/jax/_src/scipy/stats/beta.py
+++ b/jax/_src/scipy/stats/beta.py
@@ -16,15 +16,14 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import (_promote_args_inexact, _constant_like,
-                                      where, inf, logical_or)
+from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf, logical_or
 from jax.scipy.special import betaln, xlogy, xlog1py
 
 
 @_wraps(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
   x, a, b, loc, scale = _promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
-  one = _constant_like(x, 1)
+  one = lax._const(x, 1)
   shape_term = lax.neg(betaln(a, b))
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.add(xlogy(lax.sub(a, one), y),

--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -18,7 +18,7 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like, where, inf, logical_or, nan
+from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf, logical_or, nan
 from jax._src.scipy.special import betaln
 
 scipy_version = tuple(map(int, scipy.version.version.split('.')[:2]))
@@ -28,8 +28,8 @@ def logpmf(k, n, a, b, loc=0):
   """JAX implementation of scipy.stats.betabinom.logpmf."""
   k, n, a, b, loc = _promote_args_inexact("betabinom.logpmf", k, n, a, b, loc)
   y = lax.sub(lax.floor(k), loc)
-  one = _constant_like(y, 1)
-  zero = _constant_like(y, 0)
+  one = lax._const(y, 1)
+  zero = lax._const(y, 0)
   combiln = lax.neg(lax.add(lax.log1p(n), betaln(lax.add(lax.sub(n,y), one), lax.add(y,one))))
   beta_lns = lax.sub(betaln(lax.add(y,a), lax.add(lax.sub(n,y),b)), betaln(a,b))
   log_probs = lax.add(combiln, beta_lns)

--- a/jax/_src/scipy/stats/cauchy.py
+++ b/jax/_src/scipy/stats/cauchy.py
@@ -18,13 +18,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like
+from jax._src.numpy.lax_numpy import _promote_args_inexact
 
 
 @_wraps(osp_stats.cauchy.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("cauchy.logpdf", x, loc, scale)
-  pi = _constant_like(x, np.pi)
+  pi = lax._const(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.mul(pi, scale))
   return lax.neg(lax.add(normalize_term, lax.log1p(lax.mul(scaled_x, scaled_x))))

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -17,14 +17,14 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like, where, inf
+from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 
 
 @_wraps(osp_stats.chi2.logpdf, update_doc=False)
 def logpdf(x, df, loc=0, scale=1):
     x, df, loc, scale = _promote_args_inexact("chi2.logpdf", x, df, loc, scale)
-    one = _constant_like(x, 1)
-    two = _constant_like(x, 2)
+    one = lax._const(x, 1)
+    two = lax._const(x, 2)
     y = lax.div(lax.sub(x, loc), scale)
     df_on_two = lax.div(df, two)
 

--- a/jax/_src/scipy/stats/dirichlet.py
+++ b/jax/_src/scipy/stats/dirichlet.py
@@ -39,7 +39,7 @@ def logpdf(x, alpha):
       "`x` must have either the same number of entries as `alpha` "
       f"or one entry fewer; got x.shape={x.shape}, alpha.shape={alpha.shape}"
     )
-  one = jnp._constant_like(x, 1)
+  one = lax._const(x, 1)
   if x.shape[0] != alpha.shape[0]:
     x = jnp.concatenate([x, lax.sub(one, x.sum(0, keepdims=True))], axis=0)
   normalize_term = jnp.sum(gammaln(alpha)) - gammaln(jnp.sum(alpha))

--- a/jax/_src/scipy/stats/gamma.py
+++ b/jax/_src/scipy/stats/gamma.py
@@ -16,15 +16,14 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import (_promote_args_inexact, _constant_like,
-                                      where, inf)
+from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 from jax.scipy.special import gammaln, xlogy
 
 
 @_wraps(osp_stats.gamma.logpdf, update_doc=False)
 def logpdf(x, a, loc=0, scale=1):
   x, a, loc, scale = _promote_args_inexact("gamma.logpdf", x, a, loc, scale)
-  one = _constant_like(x, 1)
+  one = lax._const(x, 1)
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.sub(xlogy(lax.sub(a, one), y), y)
   shape_terms = lax.add(gammaln(a), lax.log(scale))

--- a/jax/_src/scipy/stats/geom.py
+++ b/jax/_src/scipy/stats/geom.py
@@ -22,8 +22,8 @@ from jax.scipy.special import xlog1py
 @_wraps(osp_stats.geom.logpmf, update_doc=False)
 def logpmf(k, p, loc=0):
     k, p, loc = jnp._promote_args_inexact("geom.logpmf", k, p, loc)
-    zero = jnp._constant_like(k, 0)
-    one = jnp._constant_like(k, 1)
+    zero = lax._const(k, 0)
+    one = lax._const(k, 1)
     x = lax.sub(k, loc)
     log_probs = xlog1py(lax.sub(x, one), -p) + lax.log(p)
     return jnp.where(lax.le(x, zero), -jnp.inf, log_probs)

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -16,13 +16,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like
+from jax._src.numpy.lax_numpy import _promote_args_inexact
 
 
 @_wraps(osp_stats.laplace.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("laplace.logpdf", x, loc, scale)
-  two = _constant_like(x, 2)
+  two = lax._const(x, 2)
   linear_term = lax.div(lax.abs(lax.sub(x, loc)), scale)
   return lax.neg(lax.add(linear_term, lax.log(lax.mul(two, scale))))
 
@@ -33,9 +33,9 @@ def pdf(x, loc=0, scale=1):
 @_wraps(osp_stats.laplace.cdf, update_doc=False)
 def cdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("laplace.cdf", x, loc, scale)
-  half = _constant_like(x, 0.5)
-  one = _constant_like(x, 1)
-  zero = _constant_like(x, 0)
+  half = lax._const(x, 0.5)
+  one = lax._const(x, 1)
+  zero = lax._const(x, 0)
   diff = lax.div(lax.sub(x, loc), scale)
   return lax.select(lax.le(diff, zero),
                     lax.mul(half, lax.exp(diff)),

--- a/jax/_src/scipy/stats/nbinom.py
+++ b/jax/_src/scipy/stats/nbinom.py
@@ -16,7 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like, where, inf
+from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 from jax._src.numpy.util import _wraps
 from jax._src.scipy.special import gammaln, xlogy
 
@@ -25,7 +25,7 @@ from jax._src.scipy.special import gammaln, xlogy
 def logpmf(k, n, p, loc=0):
     """JAX implementation of scipy.stats.nbinom.logpmf."""
     k, n, p, loc = _promote_args_inexact("nbinom.logpmf", k, n, p, loc)
-    one = _constant_like(k, 1)
+    one = lax._const(k, 1)
     y = lax.sub(k, loc)
     comb_term = lax.sub(
         lax.sub(gammaln(lax.add(y, n)), gammaln(n)), gammaln(lax.add(y, one))

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -19,16 +19,16 @@ import scipy.stats as osp_stats
 from jax import lax
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like
+from jax._src.numpy.lax_numpy import _promote_args_inexact
 from jax.scipy import special
 
 @_wraps(osp_stats.norm.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("norm.logpdf", x, loc, scale)
   scale_sqrd = lax.square(scale)
-  log_normalizer = lax.log(lax.mul(_constant_like(x, 2 * np.pi), scale_sqrd))
+  log_normalizer = lax.log(lax.mul(lax._const(x, 2 * np.pi), scale_sqrd))
   quadratic = lax.div(lax.square(lax.sub(x, loc)), scale_sqrd)
-  return lax.div(lax.add(log_normalizer, quadratic), _constant_like(x, -2))
+  return lax.div(lax.add(log_normalizer, quadratic), lax._const(x, -2))
 
 
 @_wraps(osp_stats.norm.pdf, update_doc=False)

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -17,13 +17,13 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like, inf, where
+from jax._src.numpy.lax_numpy import _promote_args_inexact, inf, where
 
 
 @_wraps(osp_stats.pareto.logpdf, update_doc=False)
 def logpdf(x, b, loc=0, scale=1):
   x, b, loc, scale = _promote_args_inexact("pareto.logpdf", x, b, loc, scale)
-  one = _constant_like(x, 1)
+  one = lax._const(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.div(scale, b))
   log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))

--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -24,7 +24,7 @@ from jax.scipy.special import xlogy, gammaln, gammaincc
 @_wraps(osp_stats.poisson.logpmf, update_doc=False)
 def logpmf(k, mu, loc=0):
   k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
-  zero = jnp._constant_like(k, 0)
+  zero = lax._const(k, 0)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, mu) - gammaln(x + 1) - mu
   return jnp.where(lax.lt(x, zero), -jnp.inf, log_probs)
@@ -36,7 +36,7 @@ def pmf(k, mu, loc=0):
 @_wraps(osp_stats.poisson.cdf, update_doc=False)
 def cdf(k, mu, loc=0):
   k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
-  zero = jnp._constant_like(k, 0)
+  zero = lax._const(k, 0)
   x = lax.sub(k, loc)
   p = gammaincc(jnp.floor(1 + x), mu)
   return jnp.where(lax.lt(x, zero), zero, p)

--- a/jax/_src/scipy/stats/t.py
+++ b/jax/_src/scipy/stats/t.py
@@ -18,17 +18,17 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
-from jax._src.numpy.lax_numpy import _promote_args_inexact, _constant_like
+from jax._src.numpy.lax_numpy import _promote_args_inexact
 
 
 @_wraps(osp_stats.t.logpdf, update_doc=False)
 def logpdf(x, df, loc=0, scale=1):
   x, df, loc, scale = _promote_args_inexact("t.logpdf", x, df, loc, scale)
-  two = _constant_like(x, 2)
+  two = lax._const(x, 2)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   df_over_two = lax.div(df, two)
-  df_plus_one_over_two = lax.add(df_over_two, _constant_like(x, 0.5))
-  normalize_term_const = lax.mul(lax.mul(scale, scale), _constant_like(x, np.pi))
+  df_plus_one_over_two = lax.add(df_over_two, lax._const(x, 0.5))
+  normalize_term_const = lax.mul(lax.mul(scale, scale), lax._const(x, np.pi))
   normalize_term_tmp = lax.div(lax.log(lax.mul(normalize_term_const, df)), two)
   normalize_term = lax.sub(lax.add(lax.lgamma(df_over_two), normalize_term_tmp),
                            lax.lgamma(df_plus_one_over_two))


### PR DESCRIPTION
`lax._const` differs slightly in that it will return a Python scalar value if the input is a scalar type, but this seems incidental. I don't think there's any reason to have multiple versions of this utility