### PR TITLE
Fix bug in jax.test_util._dtype

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -84,10 +84,12 @@ flags.DEFINE_string(
 EPS = 1e-4
 
 def _dtype(x):
-  return (getattr(x, 'dtype', None) or
-          np.dtype(_dtypes.python_scalar_dtypes.get(type(x), None)) or
-          np.asarray(x).dtype)
-
+  if hasattr(x, 'dtype'):
+    return x.dtype
+  elif type(x) in _dtypes.python_scalar_dtypes:
+    return np.dtype(_dtypes.python_scalar_dtypes[type(x)])
+  else:
+    return np.asarray(x).dtype
 
 def num_float_bits(dtype):
   return _dtypes.finfo(_dtypes.canonicalize_dtype(dtype)).bits


### PR DESCRIPTION
Previous incorrect behavior:
```python
from jax._src.test_util import _dtype
print(_dtype([1, 2, 3]))
# float64
```
New correct behavior:
```python
from jax._src.test_util import _dtype
print(_dtype([1, 2, 3]))
# int64
```
The reason for this is that `np.dtype(None)` returns `float64`, so any non-array input passed to this helper would result in `float64`.