### PR TITLE
remove `_const` from public `jax.lax` module

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -323,8 +323,9 @@ def cholesky_jvp_rule(primals, tangents):
   # Forward-mode rule from https://arxiv.org/pdf/1602.07527.pdf
   def phi(X):
     l = jnp.tril(X)
-    return l / lax.expand_dims(lax._const(X, 1) + jnp.eye(X.shape[-1], dtype=X.dtype),
-                               range(l.ndim - 2))
+    return l / lax.expand_dims(
+        lax_internal._const(X, 1) + jnp.eye(X.shape[-1], dtype=X.dtype),
+        range(l.ndim - 2))
 
   tmp = triangular_solve(L, sigma_dot, left_side=False, transpose_a=True,
                          conjugate_a=True, lower=True)
@@ -991,7 +992,7 @@ def _lu_jvp_rule(primals, tangents):
   ndims = len(a_shape)
   l_padding = [(0, 0, 0)] * ndims
   l_padding[-1] = (0, m - k, 0)
-  zero = lax._const(lu, 0)
+  zero = lax_internal._const(lu, 0)
   l = lax.pad(jnp.tril(lu[..., :, :k], -1), zero, l_padding)
   l = l + lax.expand_dims(jnp.eye(m, m, dtype=dtype), range(l.ndim - 2))
 
@@ -999,7 +1000,8 @@ def _lu_jvp_rule(primals, tangents):
                   ((k, 0, 0), (k, 0, 0)))
   u_padding = [(0, 0, 0)] * ndims
   u_padding[-2] = (0, n - k, 0)
-  u = lax.pad(jnp.triu(lu[..., :k, :]), zero, u_padding) + lax.expand_dims(u_eye, range(lu.ndim - 2))
+  u = (lax.pad(jnp.triu(lu[..., :k, :]), zero, u_padding) +
+       lax.expand_dims(u_eye, range(lu.ndim - 2)))
 
   la = triangular_solve(l, x, left_side=True, transpose_a=False, lower=True,
                         unit_diagonal=True)

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -22,6 +22,7 @@ from typing import Tuple, Union, cast
 
 from jax import jit, custom_jvp
 from jax import lax
+from jax._src.lax import lax as lax_internal
 from jax._src.lax import linalg as lax_linalg
 from jax._src import dtypes
 from jax._src.numpy.util import _wraps
@@ -434,7 +435,7 @@ def norm(x, ord=None, axis : Union[None, Tuple[int, ...], int] = None,
       return jnp.sum(jnp.abs(x), axis=axis, keepdims=keepdims)
     else:
       abs_x = jnp.abs(x)
-      ord = lax._const(abs_x, ord)
+      ord = lax_internal._const(abs_x, ord)
       out = jnp.sum(abs_x ** ord, axis=axis, keepdims=keepdims)
       return jnp.power(out, 1. / ord)
 

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -28,6 +28,7 @@ from jax.dtypes import float0
 from jax.interpreters import batching
 from jax.interpreters import xla
 from jax._src.api import jit, vmap
+from jax._src.lax import lax as lax_internal
 from jax._src.lib import xla_client
 from jax._src.lib import cuda_prng
 from jax._src.numpy.lax_numpy import (
@@ -264,7 +265,8 @@ def threefry_seed(seed: int) -> jnp.ndarray:
     raise TypeError(f"PRNG key seed must be an integer; got {seed!r}")
 
   convert = lambda k: lax.reshape(lax.convert_element_type(k, np.uint32), [1])
-  k1 = convert(lax.shift_right_logical(seed_arr, lax._const(seed_arr, 32)))
+  k1 = convert(
+      lax.shift_right_logical(seed_arr, lax_internal._const(seed_arr, 32)))
   k2 = convert(jnp.bitwise_and(seed_arr, np.uint32(0xFFFFFFFF)))
   return lax.concatenate([k1, k2], 0)
 

--- a/jax/_src/scipy/stats/bernoulli.py
+++ b/jax/_src/scipy/stats/bernoulli.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.scipy.special import xlogy, xlog1py
@@ -24,8 +25,8 @@ from jax.scipy.special import xlogy, xlog1py
 @_wraps(osp_stats.bernoulli.logpmf, update_doc=False)
 def logpmf(k, p, loc=0):
   k, p, loc = jnp._promote_args_inexact("bernoulli.logpmf", k, p, loc)
-  zero = lax._const(k, 0)
-  one = lax._const(k, 1)
+  zero = _lax_const(k, 0)
+  one = _lax_const(k, 1)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, p) + xlog1py(lax.sub(one, x), -p)
   return jnp.where(jnp.logical_or(lax.lt(x, zero), lax.gt(x, one)),

--- a/jax/_src/scipy/stats/beta.py
+++ b/jax/_src/scipy/stats/beta.py
@@ -15,6 +15,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf, logical_or
 from jax.scipy.special import betaln, xlogy, xlog1py
@@ -23,7 +24,7 @@ from jax.scipy.special import betaln, xlogy, xlog1py
 @_wraps(osp_stats.beta.logpdf, update_doc=False)
 def logpdf(x, a, b, loc=0, scale=1):
   x, a, b, loc, scale = _promote_args_inexact("beta.logpdf", x, a, b, loc, scale)
-  one = lax._const(x, 1)
+  one = _lax_const(x, 1)
   shape_term = lax.neg(betaln(a, b))
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.add(xlogy(lax.sub(a, one), y),

--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -17,6 +17,7 @@ import scipy
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf, logical_or, nan
 from jax._src.scipy.special import betaln
@@ -28,8 +29,8 @@ def logpmf(k, n, a, b, loc=0):
   """JAX implementation of scipy.stats.betabinom.logpmf."""
   k, n, a, b, loc = _promote_args_inexact("betabinom.logpmf", k, n, a, b, loc)
   y = lax.sub(lax.floor(k), loc)
-  one = lax._const(y, 1)
-  zero = lax._const(y, 0)
+  one = _lax_const(y, 1)
+  zero = _lax_const(y, 0)
   combiln = lax.neg(lax.add(lax.log1p(n), betaln(lax.add(lax.sub(n,y), one), lax.add(y,one))))
   beta_lns = lax.sub(betaln(lax.add(y,a), lax.add(lax.sub(n,y),b)), betaln(a,b))
   log_probs = lax.add(combiln, beta_lns)

--- a/jax/_src/scipy/stats/cauchy.py
+++ b/jax/_src/scipy/stats/cauchy.py
@@ -17,6 +17,7 @@ import numpy as np
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact
 
@@ -24,7 +25,7 @@ from jax._src.numpy.lax_numpy import _promote_args_inexact
 @_wraps(osp_stats.cauchy.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("cauchy.logpdf", x, loc, scale)
-  pi = lax._const(x, np.pi)
+  pi = _lax_const(x, np.pi)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.mul(pi, scale))
   return lax.neg(lax.add(normalize_term, lax.log1p(lax.mul(scaled_x, scaled_x))))

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 
@@ -23,8 +24,8 @@ from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 @_wraps(osp_stats.chi2.logpdf, update_doc=False)
 def logpdf(x, df, loc=0, scale=1):
     x, df, loc, scale = _promote_args_inexact("chi2.logpdf", x, df, loc, scale)
-    one = lax._const(x, 1)
-    two = lax._const(x, 2)
+    one = _lax_const(x, 1)
+    two = _lax_const(x, 2)
     y = lax.div(lax.sub(x, loc), scale)
     df_on_two = lax.div(df, two)
 

--- a/jax/_src/scipy/stats/dirichlet.py
+++ b/jax/_src/scipy/stats/dirichlet.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.scipy.special import gammaln, xlogy
@@ -39,7 +40,7 @@ def logpdf(x, alpha):
       "`x` must have either the same number of entries as `alpha` "
       f"or one entry fewer; got x.shape={x.shape}, alpha.shape={alpha.shape}"
     )
-  one = lax._const(x, 1)
+  one = _lax_const(x, 1)
   if x.shape[0] != alpha.shape[0]:
     x = jnp.concatenate([x, lax.sub(one, x.sum(0, keepdims=True))], axis=0)
   normalize_term = jnp.sum(gammaln(alpha)) - gammaln(jnp.sum(alpha))

--- a/jax/_src/scipy/stats/gamma.py
+++ b/jax/_src/scipy/stats/gamma.py
@@ -15,6 +15,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 from jax.scipy.special import gammaln, xlogy
@@ -23,7 +24,7 @@ from jax.scipy.special import gammaln, xlogy
 @_wraps(osp_stats.gamma.logpdf, update_doc=False)
 def logpdf(x, a, loc=0, scale=1):
   x, a, loc, scale = _promote_args_inexact("gamma.logpdf", x, a, loc, scale)
-  one = lax._const(x, 1)
+  one = _lax_const(x, 1)
   y = lax.div(lax.sub(x, loc), scale)
   log_linear_term = lax.sub(xlogy(lax.sub(a, one), y), y)
   shape_terms = lax.add(gammaln(a), lax.log(scale))

--- a/jax/_src/scipy/stats/geom.py
+++ b/jax/_src/scipy/stats/geom.py
@@ -15,6 +15,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax.scipy.special import xlog1py
@@ -22,8 +23,8 @@ from jax.scipy.special import xlog1py
 @_wraps(osp_stats.geom.logpmf, update_doc=False)
 def logpmf(k, p, loc=0):
     k, p, loc = jnp._promote_args_inexact("geom.logpmf", k, p, loc)
-    zero = lax._const(k, 0)
-    one = lax._const(k, 1)
+    zero = _lax_const(k, 0)
+    one = _lax_const(k, 1)
     x = lax.sub(k, loc)
     log_probs = xlog1py(lax.sub(x, one), -p) + lax.log(p)
     return jnp.where(lax.le(x, zero), -jnp.inf, log_probs)

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -15,6 +15,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact
 
@@ -22,7 +23,7 @@ from jax._src.numpy.lax_numpy import _promote_args_inexact
 @_wraps(osp_stats.laplace.logpdf, update_doc=False)
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("laplace.logpdf", x, loc, scale)
-  two = lax._const(x, 2)
+  two = _lax_const(x, 2)
   linear_term = lax.div(lax.abs(lax.sub(x, loc)), scale)
   return lax.neg(lax.add(linear_term, lax.log(lax.mul(two, scale))))
 
@@ -33,9 +34,9 @@ def pdf(x, loc=0, scale=1):
 @_wraps(osp_stats.laplace.cdf, update_doc=False)
 def cdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("laplace.cdf", x, loc, scale)
-  half = lax._const(x, 0.5)
-  one = lax._const(x, 1)
-  zero = lax._const(x, 0)
+  half = _lax_const(x, 0.5)
+  one = _lax_const(x, 1)
+  zero = _lax_const(x, 0)
   diff = lax.div(lax.sub(x, loc), scale)
   return lax.select(lax.le(diff, zero),
                     lax.mul(half, lax.exp(diff)),

--- a/jax/_src/scipy/stats/nbinom.py
+++ b/jax/_src/scipy/stats/nbinom.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 from jax._src.numpy.util import _wraps
 from jax._src.scipy.special import gammaln, xlogy
@@ -25,7 +26,7 @@ from jax._src.scipy.special import gammaln, xlogy
 def logpmf(k, n, p, loc=0):
     """JAX implementation of scipy.stats.nbinom.logpmf."""
     k, n, p, loc = _promote_args_inexact("nbinom.logpmf", k, n, p, loc)
-    one = lax._const(k, 1)
+    one = _lax_const(k, 1)
     y = lax.sub(k, loc)
     comb_term = lax.sub(
         lax.sub(gammaln(lax.add(y, n)), gammaln(n)), gammaln(lax.add(y, one))

--- a/jax/_src/scipy/stats/norm.py
+++ b/jax/_src/scipy/stats/norm.py
@@ -17,6 +17,7 @@ import numpy as np
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact
@@ -26,9 +27,9 @@ from jax.scipy import special
 def logpdf(x, loc=0, scale=1):
   x, loc, scale = _promote_args_inexact("norm.logpdf", x, loc, scale)
   scale_sqrd = lax.square(scale)
-  log_normalizer = lax.log(lax.mul(lax._const(x, 2 * np.pi), scale_sqrd))
+  log_normalizer = lax.log(lax.mul(_lax_const(x, 2 * np.pi), scale_sqrd))
   quadratic = lax.div(lax.square(lax.sub(x, loc)), scale_sqrd)
-  return lax.div(lax.add(log_normalizer, quadratic), lax._const(x, -2))
+  return lax.div(lax.add(log_normalizer, quadratic), _lax_const(x, -2))
 
 
 @_wraps(osp_stats.norm.pdf, update_doc=False)

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact, inf, where
 
@@ -23,7 +24,7 @@ from jax._src.numpy.lax_numpy import _promote_args_inexact, inf, where
 @_wraps(osp_stats.pareto.logpdf, update_doc=False)
 def logpdf(x, b, loc=0, scale=1):
   x, b, loc, scale = _promote_args_inexact("pareto.logpdf", x, b, loc, scale)
-  one = lax._const(x, 1)
+  one = _lax_const(x, 1)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   normalize_term = lax.log(lax.div(scale, b))
   log_probs = lax.neg(lax.add(normalize_term, lax.mul(lax.add(b, one), lax.log(scaled_x))))

--- a/jax/_src/scipy/stats/poisson.py
+++ b/jax/_src/scipy/stats/poisson.py
@@ -16,6 +16,7 @@
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy import lax_numpy as jnp
 from jax.scipy.special import xlogy, gammaln, gammaincc
@@ -24,7 +25,7 @@ from jax.scipy.special import xlogy, gammaln, gammaincc
 @_wraps(osp_stats.poisson.logpmf, update_doc=False)
 def logpmf(k, mu, loc=0):
   k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
-  zero = lax._const(k, 0)
+  zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
   log_probs = xlogy(x, mu) - gammaln(x + 1) - mu
   return jnp.where(lax.lt(x, zero), -jnp.inf, log_probs)
@@ -36,7 +37,7 @@ def pmf(k, mu, loc=0):
 @_wraps(osp_stats.poisson.cdf, update_doc=False)
 def cdf(k, mu, loc=0):
   k, mu, loc = jnp._promote_args_inexact("poisson.logpmf", k, mu, loc)
-  zero = lax._const(k, 0)
+  zero = _lax_const(k, 0)
   x = lax.sub(k, loc)
   p = gammaincc(jnp.floor(1 + x), mu)
   return jnp.where(lax.lt(x, zero), zero, p)

--- a/jax/_src/scipy/stats/t.py
+++ b/jax/_src/scipy/stats/t.py
@@ -17,6 +17,7 @@ import numpy as np
 import scipy.stats as osp_stats
 
 from jax import lax
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.util import _wraps
 from jax._src.numpy.lax_numpy import _promote_args_inexact
 
@@ -24,11 +25,11 @@ from jax._src.numpy.lax_numpy import _promote_args_inexact
 @_wraps(osp_stats.t.logpdf, update_doc=False)
 def logpdf(x, df, loc=0, scale=1):
   x, df, loc, scale = _promote_args_inexact("t.logpdf", x, df, loc, scale)
-  two = lax._const(x, 2)
+  two = _lax_const(x, 2)
   scaled_x = lax.div(lax.sub(x, loc), scale)
   df_over_two = lax.div(df, two)
-  df_plus_one_over_two = lax.add(df_over_two, lax._const(x, 0.5))
-  normalize_term_const = lax.mul(lax.mul(scale, scale), lax._const(x, np.pi))
+  df_plus_one_over_two = lax.add(df_over_two, _lax_const(x, 0.5))
+  normalize_term_const = lax.mul(lax.mul(scale, scale), _lax_const(x, np.pi))
   normalize_term_tmp = lax.div(lax.log(lax.mul(normalize_term_const, df)), two)
   normalize_term = lax.sub(lax.add(lax.lgamma(df_over_two), normalize_term_tmp),
                            lax.lgamma(df_plus_one_over_two))

--- a/jax/experimental/jet.py
+++ b/jax/experimental/jet.py
@@ -59,17 +59,20 @@ from functools import partial
 import numpy as np
 
 import jax
-import jax.numpy as jnp
 from jax import core
-from jax._src.util import unzip2
-from jax._src import ad_util
-from jax._src import dispatch
+from jax import lax
+from jax.custom_derivatives import custom_jvp_call_jaxpr_p
+from jax.interpreters import xla
+import jax.linear_util as lu
+import jax.numpy as jnp
 from jax.tree_util import (register_pytree_node, tree_structure,
                            treedef_is_leaf, tree_flatten, tree_unflatten)
-import jax.linear_util as lu
-from jax.interpreters import xla
-from jax.custom_derivatives import custom_jvp_call_jaxpr_p
-from jax import lax
+
+from jax._src import ad_util
+from jax._src import dispatch
+from jax._src.lax import lax as lax_internal
+from jax._src.util import unzip2
+
 
 def jet(fun, primals, series):
   r"""Taylor-mode higher-order automatic differentiation.
@@ -371,7 +374,10 @@ def deriv_prop(prim, deriv, primals_in, series_in):
   return primal_out, series_out
 
 
-def_deriv(lax.erf_p, lambda x: lax.mul(lax._const(x, 2. / np.sqrt(np.pi)), lax.exp(lax.neg(lax.square(x)))))
+def_deriv(lax.erf_p,
+          lambda x: lax.mul(
+              lax_internal._const(x, 2. / np.sqrt(np.pi)),
+              lax.exp(lax.neg(lax.square(x)))))
 
 
 def def_comp(prim, comp):

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -250,7 +250,7 @@ from jax._src.lax.lax import (
 from jax._src.lax.lax import (
   _reduce_sum, _reduce_max, _reduce_min, _reduce_or, _reduce_and,
   _float, _complex, _input_dtype,
-  _const, _eq_meet, _broadcasting_select,
+  _eq_meet, _broadcasting_select,
   _check_user_dtype_supported, _one, _zero,
   _upcast_fp16_for_computation, _broadcasting_shape_rule,
   _eye, _tri, _delta, _ones, _zeros, _dilate_shape)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -26,17 +26,18 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-import jax.numpy as jnp
 from jax import core
-from jax._src import dtypes
 from jax import lax
-from jax._src import test_util as jtu
-from jax import tree_util
-from jax._src import lax_reference
+import jax.numpy as jnp
 from jax.test_util import check_grads
+from jax import tree_util
 import jax.util
-from jax._src.util import prod
 
+from jax._src import dtypes
+from jax._src import test_util as jtu
+from jax._src import lax_reference
+from jax._src.util import prod
+from jax._src.lax import lax as lax_internal
 from jax._src.lax.lax import _device_put_raw
 
 
@@ -2626,7 +2627,7 @@ class LaxTest(jtu.JaxTestCase):
     else:
       val = lax._convert_element_type(0, dtype, weak_type=weak_type)
 
-    const = lax._const(val, 0)
+    const = lax_internal._const(val, 0)
     self.assertEqual(dtypes.dtype(val, canonicalize=True),
                      dtypes.dtype(const, canonicalize=True))
 


### PR DESCRIPTION
Modify all internal call sites to use `jax._src.lax.lax._const` instead.