### PR TITLE
Replace an assertion with no error message with an error message.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1597,8 +1597,11 @@ def _mapped_axis_size(tree, vals, dims, name, *, kws=False):
     if kws:
       # if keyword arguments are included in the tree, we make adapt the error
       # message only to be about the positional arguments
-      tree, leaf = treedef_children(tree)
-      assert treedef_is_leaf(leaf)
+      tree, kwargs_treedef = treedef_children(tree)
+      if not treedef_is_leaf(kwargs_treedef):
+        raise ValueError(
+            "Keyword arguments are expected to be a leaf. Try without them.")
+
     # TODO(mattjj,phawkins): add a way to inspect pytree kind more directly
     if tree == tree_flatten((core.unit,) * tree.num_leaves)[1]:
       lines1 = [f"arg {i} has shape {np.shape(x)} and axis {d} is to be mapped"

--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -291,8 +291,10 @@ def flatten_axes(name, treedef, axis_tree, *, kws=False, tupled_args=False):
     if kws:
       # if keyword arguments are included in the tree, we make adapt the error
       # message only to be about the positional arguments
-      treedef, leaf = treedef_children(treedef)
-      assert treedef_is_leaf(leaf)
+      treedef, kwargs_treedef = treedef_children(treedef)
+      if not treedef_is_leaf(kwargs_treedef):
+        raise ValueError(
+            "Keyword arguments are expected to be a leaf. Try without them.")
       axis_tree, _ = axis_tree
     hint = ""
     if tupled_args:


### PR DESCRIPTION
I do not fully understand what is happening, but this can be reached with

```
jax.vmap(lambda a, b: 1, in_axes=[None, 1])(a=np.zeros([1]), b=np.zeros([3]))
```