### PR TITLE
Refactor Jaxpr pretty-printing to use a `JaxprPpSettings` named tuple

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2298,13 +2298,13 @@ def _convert_elt_type_fwd_rule(eqn):
   else:
     return [None], eqn
 
-def _convert_elt_type_pp_rule(eqn, context):
+def _convert_elt_type_pp_rule(eqn, context, settings):
   # don't print new_dtype because the output binder shows it
   printed_params = {}
   if eqn.params['weak_type']:
     printed_params['weak_type'] = True
   return [pp.text(eqn.primitive.name),
-          core.pp_kv_pairs(sorted(printed_params.items()), context),
+          core.pp_kv_pairs(sorted(printed_params.items()), context, settings),
           pp.text(" ") + core.pp_vars(eqn.invars, context)]
 
 

--- a/jax/experimental/djax.py
+++ b/jax/experimental/djax.py
@@ -200,7 +200,8 @@ def pp_eqn(eqn: core.JaxprEqn) -> pp.Doc:
   lhs = pp_vars(eqn.outvars)
   pp_lhs = pp.text(f'{lhs} =')
   pp_rhs = (pp.text(eqn.primitive.name) +
-            core.pp_kv_pairs(sorted(eqn.params.items()), core.JaxprPpContext())
+            core.pp_kv_pairs(sorted(eqn.params.items()), core.JaxprPpContext(),
+                             core.JaxprPpSettings())
             + pp.text(' ') + pp.text(' '.join(map(str, eqn.invars))))
   return pp_lhs + pp.text(' ') + pp_rhs
 

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1257,7 +1257,7 @@ class DynamicJaxprTracer(core.Tracer):
                 f"of {dbg.arg_info(invar_pos)}.")
     elif progenitor_eqns:
       msts = ["  operation "
-              f"{core.pp_eqn(eqn, core.JaxprPpContext(), print_shapes=True)}\n"
+              f"{core.pp_eqn(eqn, core.JaxprPpContext(), core.JaxprPpSettings(print_shapes=True))}\n"
               f"    from line {source_info_util.summarize(eqn.source_info)}"
               for eqn in progenitor_eqns[:5]]  # show at most 5
       origin = (f"While tracing the function {dbg.func_src_info} "

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -888,7 +888,8 @@ pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
 pe.dce_rules[xla_call_p] = pe.dce_jaxpr_call_rule
 
 
-def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext
+def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext,
+                 settings: core.JaxprPpSettings,
                  ) -> List[pp.Doc]:
   printed_params = {k:v for k, v in eqn.params.items() if
                     k == 'call_jaxpr' or k == 'name' or
@@ -896,7 +897,7 @@ def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext
                     k == 'device' and v is not None or
                     k == 'donated_invars' and any(v)}
   return [pp.text(eqn.primitive.name),
-          core.pp_kv_pairs(sorted(printed_params.items()), context),
+          core.pp_kv_pairs(sorted(printed_params.items()), context, settings),
           pp.text(" ") + core.pp_vars(eqn.invars, context)]
 core.pp_eqn_rules[xla_call_p] = _pp_xla_call
 


### PR DESCRIPTION
Currently, there are several pretty printing settings:
* `print_shapes`: Whether or not shapes are printed in Jaxpr eqns/invars/outvars
* `name_stack`: Whether or not the name stack is printed
* `source_info`: Whether or not to print source info annotations
* `custom_pp_eqn_rules`: Whether or not to use custom pretty printing rules

These settings are manually threaded via keyword-arguments through the pretty-printer. Unfortunately, however, they are not passed into the custom rules and the settings provided at the entry `pretty_print(...)` methods are dropped in favor of the default values. For example, if we do `jaxpr.pretty_print(name_stack=True)` and the Jaxpr has an ` xla_call` primitive in it, the name stack printing will not be enabled in the `call_jaxpr` because `xla_call` has a custom pretty printing rule.

This PR does two things:
1. Encapsulates all these settings in a `JaxprPpSettings` named tuple to make the threading easier to manage and make pretty printing easier to extend.
2. Thread the settings into the custom rules so they can be applied recursively instead of being dropped.