### PR TITLE
Fix core.pytype_aval_mappings for _DeviceArray

### DIFF
--- a/jax/_src/device_array.py
+++ b/jax/_src/device_array.py
@@ -311,4 +311,4 @@ deleted_buffer = DeletedBuffer()
 device_array_types: List[type] = [xc.Buffer, _DeviceArray]
 for _device_array in device_array_types:
   core.literalable_types.add(_device_array)
-  core.pytype_aval_mappings[device_array] = abstract_arrays.canonical_concrete_aval
+  core.pytype_aval_mappings[_device_array] = abstract_arrays.canonical_concrete_aval


### PR DESCRIPTION
Due to a typo, `core.pytype_aval_mappings` wasn't being created for `_DeviceArray`. This manifests itself when users (like me!) try to implement their own custom JAX backends, since we have to inherit from _DeviceArray rather than jaxlib's `DeviceArray`.

I wish I could come up with a unit test to expose this case, but for now I'll settle for fixing the bug.