### PR TITLE
[ROCm] Fix jaxlib bazel file for ROCm

### DIFF
--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -107,7 +107,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
     ] + if_rocm_is_configured([
-        "@org_tensorflow//tensorflow/third_party/rocm/google:rocm_headers",
+        "@local_config_rocm//rocm:rocm_headers",
     ]),
 )
 


### PR DESCRIPTION
Fix for #9864.

@jakevdp, was there any particular reason behind [this](https://github.com/google/jax/commit/616df55ad47862cd02d1a1131d4df692eb006d05)? For building jax alone, the gating is not necessary because ```hip_gpu_kernel_helpers``` is only used for rocm builds.

In other words, If we remove the gating logic and let the ```hip_gpu_kernel_helper``` remains similar to cuda_gpu_kernel_helpers, what would be the issue?
