### PR TITLE
jnp.unique: avoid constructing arrays with explicit int64

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4690,7 +4690,7 @@ def _unique(ar, axis, return_index=False, return_inverse=False, return_counts=Fa
         idx = idx.at[1:].set(where(idx[1:], idx[1:], mask.size))
       ret += (diff(idx),)
     elif ar.shape[axis]:
-      ret += (array([ar.shape[axis]], dtype=int_),)
+      ret += (array([ar.shape[axis]], dtype=dtypes.canonicalize_dtype(int_)),)
     else:
       ret += (empty(0, dtype=int),)
   if return_true_size:


### PR DESCRIPTION
Can test the bug with:
```
$ JAX_NUM_GENERATED_CASES=100 pytest -n auto tests/lax_numpy_test.py -k Unique
```
This fails on main with `UserWarning: Explicitly requested dtype <class 'jax._src.numpy.lax_numpy.int64'> requested in array is not available`, and passes with this change