### PR TITLE
add random.loggamma and improve dirichlet & beta implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Remember to align the itemized text with the first line of an item within a list
 PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
-## jax 0.3.4 (Unreleased)
+## jax 0.3.5 (Unreleased)
+* [GitHub
+  commits](https://github.com/google/jax/compare/jax-v0.3.4...main).
+* Changes:
+  * added {func}`jax.random.loggamma` & improved behavior of {func}`jax.random.beta`
+    and {func}`jax.random.dirichlet` for small parameter values `({jax-issue}`9906`).
 
 
 ## jaxlib 0.3.3 (Unreleased)
@@ -16,7 +21,7 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 
 ## jax 0.3.4 (March 18, 2022)
 * [GitHub
-  commits](https://github.com/google/jax/compare/jax-v0.3.2...jax-v0.3.4).
+  commits](https://github.com/google/jax/compare/jax-v0.3.3...jax-v0.3.4).
 
 
 ## jax 0.3.3 (March 17, 2022)

--- a/docs/jax.random.rst
+++ b/docs/jax.random.rst
@@ -28,6 +28,7 @@ List of Available Functions
     gamma
     gumbel
     laplace
+    loggamma
     logistic
     maxwell
     multivariate_normal

--- a/jax/random.py
+++ b/jax/random.py
@@ -98,6 +98,7 @@ from jax._src.random import (
   gumbel as gumbel,
   laplace as laplace,
   logistic as logistic,
+  loggamma as loggamma,
   maxwell as maxwell,
   multivariate_normal as multivariate_normal,
   normal as normal,


### PR DESCRIPTION
Fixes #9896

This roughly follows the strategy of TFP, which computes the underlying gamma distribution in normal space and the boost offset in log space (see https://github.com/tensorflow/probability/blob/dc5b6b094cfc1f18f949e120c3491acb2e2af6eb/tensorflow_probability/python/distributions/gamma.py#L453-L459).

Tested by patching-in initial tests from #9919 to ensure that non-corner-case gamma, beta, and dirichlet outputs remain unchanged by this reimplementation.