### PR TITLE
typing for jit

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -227,7 +227,7 @@ def _infer_argnums_and_argnames(
 
 
 def jit(
-  fun: Callable,
+  fun: F,
   *,
   static_argnums: Union[int, Iterable[int], None] = None,
   static_argnames: Union[str, Iterable[str], None] = None,
@@ -235,7 +235,7 @@ def jit(
   backend: Optional[str] = None,
   donate_argnums: Union[int, Iterable[int]] = (),
   inline: bool = False,
-) -> Any:
+) -> F:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:


### PR DESCRIPTION
express the fact that function types (i.e. call signatures) are invariant under the jit transformation.
The TypeVar `F` has been defined at L109
```python
F = TypeVar("F", bound=Callable)
```
Ok, I see https://github.com/google/jax/commit/799ecfa92052f20c51ce7634f9408fcb8df84b85
But I think we can get a workaround for IDE hint and auto complement.