### PR TITLE
IDE friendly type annotation for jit

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -227,7 +227,7 @@ def _infer_argnums_and_argnames(
 
 
 def jit(
-  fun: Callable,
+  fun: F,
   *,
   static_argnums: Union[int, Iterable[int], None] = None,
   static_argnames: Union[str, Iterable[str], None] = None,
@@ -235,7 +235,7 @@ def jit(
   backend: Optional[str] = None,
   donate_argnums: Union[int, Iterable[int]] = (),
   inline: bool = False,
-) -> Any:
+) -> Union[F, Any]:
   """Sets up ``fun`` for just-in-time compilation with XLA.
 
   Args:


### PR DESCRIPTION
solve https://github.com/google/jax/issues/9932
https://github.com/google/jax/pull/9558 remove type annotation for passing typecheck
But I think we can add a `Union[F, Any]` annotation, which is useful for IDE and won't raise an error with pytype when we use additional attribute.
![image](https://user-images.githubusercontent.com/83971976/158591907-3485cb22-6f7f-4780-b215-b727921f4c7e.png)
![image](https://user-images.githubusercontent.com/83971976/158591969-14057747-b8e1-4099-94d4-05c063beade3.png)

@hawkinsp 