### PR TITLE
Add weakreaf_lru_cache to prevent caches from pinning jaxprs.

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -219,7 +219,7 @@ def cache(max_size=4096):
 
 memoize = cache(max_size=None)
 
-_CacheInfo = namedtuple("_CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
 
 def weakref_lru_cache(call: Callable, maxsize=2048):
   cache: Dict[Any, Any] = {}
@@ -256,7 +256,7 @@ def weakref_lru_cache(call: Callable, maxsize=2048):
 
   def cache_info():
     with lock:
-      return _CacheInfo(hits, misses, maxsize, len(cache))
+      return CacheInfo(hits, misses, maxsize, len(cache))
 
   def cache_clear():
     nonlocal hits, misses

--- a/jax/core.py
+++ b/jax/core.py
@@ -41,8 +41,8 @@ from jax import linear_util as lu
 
 from jax._src import source_info_util
 from jax._src.util import (safe_zip, safe_map, curry, prod, tuple_insert,
-                        tuple_delete, cache, as_hashable_function,
-                        HashableFunction)
+                        tuple_delete, as_hashable_function,
+                        HashableFunction, weakref_lru_cache)
 import jax._src.pretty_printer as pp
 
 from jax._src import traceback_util
@@ -2031,7 +2031,7 @@ def do_subst_axis_names_jaxpr(jaxpr: Union[Jaxpr, ClosedJaxpr], subst: AxisSubst
     return ClosedJaxpr(new_jaxpr, consts)
   return new_jaxpr
 
-@cache()
+@weakref_lru_cache
 def used_axis_names_jaxpr(jaxpr: Union[Jaxpr, ClosedJaxpr]):
   subst = NameGatheringSubst()
   do_subst_axis_names_jaxpr(jaxpr, subst)

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -46,7 +46,7 @@ from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
 from jax._src.tree_util import prefix_errors
 from jax._src.util import (extend_name_stack, HashableFunction, safe_zip,
                          wrap_name, wraps, distributed_debug_log,
-                         split_list, cache, tuple_insert)
+                         split_list, cache, tuple_insert, weakref_lru_cache)
 xops = xc._xla.ops
 
 class _FromGdaSingleton:
@@ -609,7 +609,7 @@ def _pjit_call_impl(*args, jaxpr,
   return compiled.unsafe_call(*args)
 pjit_p.def_impl(_pjit_call_impl)
 
-@cache()
+@weakref_lru_cache
 def _pjit_lower(
     jaxpr: core.ClosedJaxpr,
     in_axis_resources: Tuple[CanonicalizedParsedPartitionSpec, ...],


### PR DESCRIPTION
To use this cache, the first argument must be some type that is
object identity hashed (like a jaxpr).