### PR TITLE
track input argument information in one tree at each AOT stage

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -533,8 +533,8 @@ def _jit_lower(fun, static_argnums, static_argnames, device, backend,
     computation = dispatch.lower_xla_callable(flat_fun, device, backend, name,
                                               donated_invars,
                                               *arg_specs_and_device)
-    return stages.Lowered(computation, in_tree, in_tree.unflatten(arg_specs),
-                          out_tree(), donate_argnums)
+    return stages.Lowered.from_flat_info(
+        computation, in_tree, arg_specs, donate_argnums, out_tree())
 
   return lower
 
@@ -2059,9 +2059,8 @@ def _pmap_lower(fun, axis_name, in_axes, out_axes, static_broadcasted_tuple,
         donated_invars=p.donated_invars,
         global_arg_shapes=p.global_arg_shapes_flat,
         avals=abstract_args)
-    return stages.Lowered(
-        computation, p.in_tree, p.in_tree.unflatten(abstract_args),
-        p.out_tree(), donate_tuple)
+    return stages.Lowered.from_flat_info(
+        computation, p.in_tree, abstract_args, donate_tuple, p.out_tree())
 
   return lower
 

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -670,8 +670,8 @@ def xmap(fun: Callable,
 
     in_tree = treedef_tuple([in_tree, tree_flatten({})[1]])
     in_avals = in_tree.unflatten(avals_flat)
-    return stages.Lowered(
-        computation, in_tree, in_avals, out_tree(), donate_argnums,
+    return stages.Lowered.from_flat_info(
+        computation, in_tree, in_avals, donate_argnums, out_tree(),
         no_kwargs=True)
 
   fun_mapped.lower = lower

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -283,8 +283,9 @@ def pjit(fun: Callable,
 
     args_kwargs_in_tree = treedef_tuple([in_tree, tree_flatten({})[1]])
     local_in_avals = args_kwargs_in_tree.unflatten(flat_local_in_avals)
-    return stages.Lowered(lowering, args_kwargs_in_tree, local_in_avals,
-                          out_tree, donate_argnums, no_kwargs=True)
+    return stages.Lowered.from_flat_info(
+        lowering, args_kwargs_in_tree, local_in_avals, donate_argnums, out_tree,
+        no_kwargs=True)
 
   wrapped.lower = lower
   return wrapped


### PR DESCRIPTION
Both `Lowered` and `Compiled` carry information about input arguments for which the underlying computation was lowered (namely avals, donation bits, and the input pytree structure today). This change rearranges some internals so that all of this information is held together in a single pytree of structs. Doing so simplifies the fields of both stage classes and helps ensure the input argument properties are consistent with one another (e.g. now they must share a consistent pytree structure by definition).

cc #7733