### PR TITLE
improve caching of jax.remat

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -17,7 +17,7 @@ import collections
 from collections import namedtuple
 from contextlib import contextmanager
 import functools
-from functools import partial, partialmethod, total_ordering
+from functools import partialmethod, total_ordering
 import gc
 import itertools as it
 import operator
@@ -1712,7 +1712,8 @@ class CallPrimitive(Primitive):
 
   def get_bind_params(self, params):
     new_params = dict(params)
-    subfun = lu.wrap_init(partial(eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    jaxpr = new_params.pop('call_jaxpr')
+    subfun = lu.hashable_partial(lu.wrap_init(eval_jaxpr), jaxpr, ())
     return [subfun], new_params
 
 def call_bind(primitive: CallPrimitive, fun, *args, **params):
@@ -1806,7 +1807,8 @@ class MapPrimitive(Primitive):
 
   def get_bind_params(self, params):
     new_params = dict(params)
-    subfun = lu.wrap_init(partial(eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    jaxpr = new_params.pop('call_jaxpr')
+    subfun = lu.hashable_partial(lu.wrap_init(eval_jaxpr), jaxpr, ())
     axes = new_params.pop('out_axes')
     new_params['out_axes_thunk'] = HashableFunction(lambda: axes, closure=axes)
     return [subfun], new_params

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -884,7 +884,8 @@ class XMapPrimitive(core.MapPrimitive):
 
   def get_bind_params(self, params):
     new_params = dict(params)
-    subfun = lu.wrap_init(partial(core.eval_jaxpr, new_params.pop('call_jaxpr'), ()))
+    jaxpr = new_params.pop('call_jaxpr')
+    subfun = lu.hashable_partial(lu.wrap_init(core.eval_jaxpr), jaxpr, ())
     axes = new_params.pop('out_axes')
     new_params['out_axes_thunk'] = HashableFunction(lambda: axes, closure=axes)
     spmd_axes = new_params.pop('spmd_out_axes')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4323,6 +4323,15 @@ class RematTest(jtu.JaxTestCase):
 
     _ = api.linearize(partial(f, core.unit), 3.)
 
+  def test_linearize_caching(self):
+    # https://github.com/google/jax/issues/9661
+    identity = jax.checkpoint(jax.jit(lambda x: 2 * x))
+    _, f_lin = jax.linearize(identity, 1.)
+    with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
+      for _ in range(10):
+        f_lin(1.).block_until_ready()
+    self.assertEqual(count[0], 1)  # cached after first execution
+
 
 class JaxprTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Consider this program:

```python
import sys
import jax

identity = jax.checkpoint(jax.jit(lambda x: 2 * x))

_, f_lin = jax.linearize(identity, 1.)
for _ in range(int(sys.argv[1])):
  f_lin(1.)
```

Before this change, `env JAX_LOG_COMPILES=1 python repro.py $N` would show a number of compilations that scaled linearly with `N`.

After this change the number of compilations is constant with `N`.

The issue was that when a jitted computation was staged into a jaxpr, like it is with `jax.linearize`, evaluating that jaxpr would never get cache hits because we would in effect create and apply a fresh callable of the form `jit(partial(eval_jaxpr, jitted_fun_jaxpr, ...)(...)` each time. Even if `jitted_fun_jaxpr` is always the same jaxpr object, that constructs a new callable object, and hence we'd never get jit cache hits.

The fix was to reuse a tool we already had: `hashable_partial`. That is, we use `jit(hashable_partial(eval_jaxpr, jitted_fun_jaxpr, ...)(...)` and we'll get cache hits. Since this issue arose in round-tripping from a jaxpr to a traceable, the place it was needed for jit is `CallPrimitive.get_bind_params`, which handles param bookkeeping for those round-trips. (This affects `remat` because it's a call primitive.)

See #9661 for more discussion, and how we got into looking at this.