### PR TITLE
allow recursive uses of `custom_transpose`

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -164,8 +164,10 @@ def recast_to_float0(primal, tangent):
   else:
     return tangent
 
-# NOTE: The FIXMEs below are caused by primal/tangent mixups (type errors if you will)
-def backward_pass(jaxpr: core.Jaxpr, reduce_axes, transform_stack, consts, primals_in, cotangents_in):
+# NOTE: The FIXMEs below are caused by primal/tangent mixups (type
+# errors if you will)
+def backward_pass(jaxpr: core.Jaxpr, reduce_axes, transform_stack,
+                  consts, primals_in, cotangents_in):
   if all(type(ct) is Zero for ct in cotangents_in):
     return map(lambda v: Zero(v.aval), jaxpr.invars)
 


### PR DESCRIPTION
[I sent this PR a second time as #10041 in order to work around pulldown issues.]

Previously, a `custom_transpose` function could not call itself from its transpose rule, because staging out the `custom_transpose` primitive would result in endless recursion. Instead of staging out the transpose rule when the enclosing `custom_transpose` rule is staged out, this change replaces it temporarily by a thunk (relieving the recursive staging issue). The thunk allows us to lazily stage out the original transpose rule, a process that needs to happen only when the enclosing `custom_transpose` primitive is bound or transposed.

Along the way: in order to write a test that involves staging without compilation, we relied on `lax.cond`. But to transpose `lax.cond` explicitly (i.e. using `jax.linear_transpose`), we need a way to indicate that the conditional branches are linear in their operands. We already have the means to do this internally; the `cond` primitive has a sequence of linear indicators (the JVP rule for `cond` sets these to a non-trivial pattern). This change simply allows one to control the same linear operand indicators when calling the `cond` traceable directly.

Part of #9129.