### PR TITLE
Add scipy.linalg.rsf2csf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * added array creation routines {func}`jax.numpy.frombuffer`, {func}`jax.numpy.fromfunction`,
     and {func}`jax.numpy.fromstring` ({jax-issue}`#10049`).
   * `DeviceArray.copy()` now returns a `DeviceArray` rather than a `np.ndarray` ({jax-issue}`#10069`)
+  * added {func}`jax.scipy.linalg.rsf2csf`
 * Deprecations:
   * {func}`jax.nn.normalize` is being deprecated. Use {func}`jax.nn.standardize` instead ({jax-issue}`#9899`).
   * {func}`jax.tree_util.tree_multimap` is deprecated. Use {func}`jax.tree_util.tree_map` instead ({jax-issue}`#5746`).

--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -36,6 +36,7 @@ jax.scipy.linalg
    polar
    polar_unitary
    qr
+   rsf2csf
    schur
    sqrtm
    solve

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -30,6 +30,7 @@ from jax._src.scipy.linalg import (
   lu_solve as lu_solve,
   polar as polar,
   qr as qr,
+  rsf2csf as rsf2csf,
   schur as schur,
   sqrtm as sqrtm,
   solve as solve,

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1391,6 +1391,25 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       self._CompileAndCheck(jsp.linalg.schur, args_maker)
 
   @parameterized.named_parameters(
+        jtu.cases_from_list({
+            "testcase_name":
+            "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),
+            "shape": shape, "dtype": dtype
+        } for shape in [(1, 1), (4, 4), (15, 15), (50, 50), (100, 100)]
+                            for dtype in float_types + complex_types))
+  @jtu.skip_on_devices("gpu", "tpu")
+  def testRsf2csf(self, shape, dtype):
+      rng = jtu.rand_default(self.rng())
+      args_maker = lambda: [rng(shape, dtype), rng(shape, dtype)]
+      if shape[0] >= 50:
+        tol = 1e-5
+      else:
+        tol = 1e-6
+      self._CheckAgainstNumpy(osp.linalg.rsf2csf, jsp.linalg.rsf2csf,
+                              args_maker, tol=tol)
+      self._CompileAndCheck(jsp.linalg.rsf2csf, args_maker)
+
+  @parameterized.named_parameters(
     jtu.cases_from_list({
         "testcase_name":
         "_shape={}".format(jtu.format_shape_dtype_string(shape, dtype)),


### PR DESCRIPTION
This adds [`scipy.linalg.rsf2csf`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.rsf2csf.html#scipy.linalg.rsf2csf).

I followed the SciPy implementation as closely as I could, although operations such as 
```python
T[m-1:m+1, m-1:] = G @ T[m-1:m+1, m-1:]
```
(where `m` is variable) were quite fiddly to recreate in lax primitives (though what I have seems to work). Perhaps there's a more idiomatic Jax way I've missed?

For the tests, arrays of shape `(50, 50)` and larger, I had to set `tol=1e-05` to get passing tests. I wasn't 100% sure about how to mimic the dtype promotion that the SciPy implementation uses or how to maximise precision over larger numbers of loop iterations, so please let me know if I should look at improving the PR in this area too.