### PR TITLE
[shape_poly] Change internal representation of parametric shapes

### DIFF
--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -1564,6 +1564,11 @@ _POLY_SHAPE_TEST_HARNESSES = [
                   lambda x: jnp.reshape(x, [2, -1]),
                   [RandArg((3, 4, 5, 6, 7), _f32)],
                   poly_axes=[(0, 2)]),
+    _make_harness("reshape", "_issue_9975",
+                  # The newshape is a scalar
+                  lambda x: jnp.reshape(x, x.shape[0] * x.shape[1]),
+                  [RandArg((3, 4), _f32)],
+                  poly_axes=[0]),
     _make_harness("reshape", "error",
                   lambda x: x.reshape([x.shape[0], -1, 3]),
                   [RandArg((3, 2, 4), _f32)],


### PR DESCRIPTION
The parametric shapes are implemented as polynomials in terms of
dimension variables. In the previous implementation the representation
is as a `dict`. This happens to confuse a test in `jnp.reshape` because
the polynomial appears to be an iterable.

I removed the inheritance from `dict`, so that a dimension polynomial
is harder to confuse with other types.

Fixes: #9975