### PR TITLE
Add istft to jax.scipy.signal.

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -79,6 +79,7 @@ jax.scipy.signal
    correlate
    correlate2d
    csd
+   istft
    stft
    welch
 

--- a/jax/scipy/signal.py
+++ b/jax/scipy/signal.py
@@ -21,6 +21,7 @@ from jax._src.scipy.signal import (
   correlate2d as correlate2d,
   detrend as detrend,
   csd as csd,
+  istft as istft,
   stft as stft,
   welch as welch,
 )


### PR DESCRIPTION
Following the discussion in #9411, ISTFT is added to signal.py.
(ISTFT wasn't included in the first PR because it doesn't share a common utility function used for STFT.)
