### PR TITLE
make device_array.copy() return a device array

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -2769,11 +2769,11 @@ def _device_get(x):
   if isinstance(x, core.Tracer):
     return x
   try:
-    copy = x.copy
+    toarray = x.__array__
   except AttributeError:
     return x
   else:
-    return copy()
+    return toarray()
 
 def device_get(x: Any):
   """Transfer ``x`` to host.

--- a/jax/_src/device_array.py
+++ b/jax/_src/device_array.py
@@ -199,12 +199,6 @@ class _DeviceArray(DeviceArray):  # type: ignore
 # pylint: disable=protected-access
 for device_array in [DeviceArray]:
 
-
-  def copy(self):
-    """Returns an ndarray (backed by host memory, not device memory)."""
-    return np.asarray(self)
-  setattr(device_array, "copy", copy)
-
   def __repr__(self):
     line_width = np.get_printoptions()["linewidth"]
     prefix = '{}('.format(self.__class__.__name__.lstrip('_'))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4514,7 +4514,7 @@ _operators = {
 # These numpy.ndarray methods are just refs to an equivalent numpy function
 _nondiff_methods = ["all", "any", "argmax", "argmin", "argpartition", "argsort",
                     "nonzero", "searchsorted", "round"]
-_diff_methods = ["choose", "conj", "conjugate", "cumprod", "cumsum",
+_diff_methods = ["choose", "conj", "conjugate", "copy", "cumprod", "cumsum",
                  "diagonal", "dot", "max", "mean", "min", "prod", "ptp",
                  "ravel", "repeat", "sort", "squeeze", "std", "sum",
                  "swapaxes", "take", "tile", "trace", "var"]


### PR DESCRIPTION
Addresses part of #2632

In https://github.com/google/jax/pull/9732 we made `jnp.copy` return a device array rather than a numpy array. This gives the same treatment to the `copy()` method of device arrays.

I think this is the behavior that we want – note that it will not chgne the behavior of `copy.copy()` or `copy.deepcopy()`, which current return numpy arrays due to their use of the `reduce()` method (similar to  `pickle`). We could address those separately via the `__copy__` and `__deepcopy__` methods if we wish.