### PR TITLE
docs: use intersphinx links for wrapped functions

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -138,6 +138,10 @@ def _wraps(fun: Optional[Callable], update_doc: bool = True, lax_description: st
   """
   def wrap(op):
     docstr = getattr(fun, "__doc__", None)
+    try:
+      name = f"{fun.__module__}.{fun.__name__}"
+    except AttributeError:
+      name = getattr(fun, "__name__", getattr(op, "__name__", str(op)))
     if docstr:
       try:
         parsed = _parse_numpydoc(docstr)
@@ -156,7 +160,6 @@ def _wraps(fun: Optional[Callable], update_doc: bool = True, lax_description: st
           )
 
         docstr = parsed.summary.strip() + "\n" if parsed.summary else ""
-        name = getattr(fun, "__name__", getattr(op, "__name__", str(op)))
         docstr += f"\nLAX-backend implementation of :func:`{name}`.\n"
         if lax_description:
           docstr += "\n" + lax_description.strip() + "\n"


### PR DESCRIPTION
This makes it so that, e.g. the first line of the rendered documentation for `jnp.append` looks like this:

> LAX-backend implementation of [numpy.append()](https://numpy.org/doc/stable/reference/generated/numpy.append.html#numpy.append).

with the link pointing to the numpy documentation for the wrapped function

Previously it looked like this:

> LAX-backend implementation of [append()](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.append.html#jax.numpy.append).

with the link doing nothing because it points to the current page.