### PR TITLE
Fixed a typo in the return type of _array_ir_types

### DIFF
--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -115,7 +115,7 @@ def dtype_to_ir_type(dtype: Union[np.dtype, np.generic]) -> ir.Type:
         f"No dtype_to_ir_type handler for dtype: {dtype}") from err
   return ir_type_factory()
 
-def _array_ir_types(aval: core.ShapedArray) -> ir.Type:
+def _array_ir_types(aval: core.ShapedArray) -> Sequence[ir.Type]:
   return (ir.RankedTensorType.get(aval.shape, dtype_to_ir_type(aval.dtype)),)
 
 ir_type_handlers: Dict[Type[core.AbstractValue],


### PR DESCRIPTION
There could be other typing issues in that module, but I will address them separately.