### PR TITLE
Replace `reshape` with `expand_dims` if possible

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1487,7 +1487,7 @@ def _pgather_impl(src, idx, *, axes):
   non_axes_shape = src_axes_front.shape[len(axes):]
   src_one_axis_front = src_axes_front.reshape((-1,) + non_axes_shape)
   slice_sizes = (1,) + non_axes_shape
-  idx = lax.reshape(idx, idx.shape + (1,))
+  idx = lax.expand_dims(idx, (-1,))
   offset_dims = tuple(range(idx.ndim - 1, idx.ndim + src_one_axis_front.ndim - 2))
   dnums = slicing.GatherDimensionNumbers(
       offset_dims=offset_dims,

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -480,10 +480,7 @@ def norm(x, ord=None, axis : Union[None, Tuple[int, ...], int] = None,
         reducer = jnp.sum
       y = reducer(svd(x, compute_uv=False), axis=-1)
       if keepdims:
-        result_shape = list(x_shape)
-        result_shape[axis[0]] = 1
-        result_shape[axis[1]] = 1
-        y = jnp.reshape(y, result_shape)
+        y = jnp.expand_dims(y, axis)
       return y
     else:
       raise ValueError("Invalid order '{}' for matrix norm.".format(ord))

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -621,7 +621,7 @@ def _handle_scalar_broadcasting(nd, x, d):
   if d is not_mapped or nd == np.ndim(x):
     return x
   else:
-    return x.reshape(x.shape + (1,) * (nd - np.ndim(x)))
+    return jax.lax.expand_dims(x, tuple(range(np.ndim(x), nd)))
 
 def defreducer(prim):
   primitive_batchers[prim] = partial(reducer_batcher, prim)


### PR DESCRIPTION
The [docs](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.reshape.html) recommend using `expand_dims` over `reshape` to preserve information about axis identity.

This PR switches to `expand_dims` in a couple of places where this is possible which also slightly simplifies the code.