### PR TITLE
Don't compare versions as strings.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1515,7 +1515,7 @@ def _conv_general_dilated(lhs, rhs, *,
 
   def gen_conv(lhs, rhs, preferred_element_type: Optional[DType]):
     tf_version = tuple(int(v) for v in tf.__version__.split(".")[:2])
-    if tf_version >= (2, 8)
+    if tf_version >= (2, 8):
       # TODO(necula): remove when 2.8.0 is the stable TF version (and supports
       # batch_group_count.
       out = tfxla.conv(

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -15,7 +15,6 @@
 from functools import partial
 import contextlib
 import os
-import pkg_resources
 import re
 import threading
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
@@ -1515,8 +1514,9 @@ def _conv_general_dilated(lhs, rhs, *,
   precision_config_proto = _precision_config_proto(precision)
 
   def gen_conv(lhs, rhs, preferred_element_type: Optional[DType]):
-    tf_version = pkg_resources.parse_version(tf.__version__)
-    if tf_version >= pkg_resources.parse_version("2.8.0"):
+    tf_version = tuple(int(v) for v tf.__version__.split(".")[:2])
+    min_version = tuple(int(v) for v in tf.__version__.split(".")[:2])
+    if tf_version >= min_version
       # TODO(necula): remove when 2.8.0 is the stable TF version (and supports
       # batch_group_count.
       out = tfxla.conv(

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -15,6 +15,7 @@
 from functools import partial
 import contextlib
 import os
+import pkg_resources
 import re
 import threading
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
@@ -1514,7 +1515,8 @@ def _conv_general_dilated(lhs, rhs, *,
   precision_config_proto = _precision_config_proto(precision)
 
   def gen_conv(lhs, rhs, preferred_element_type: Optional[DType]):
-    if tf.__version__ >= "2.8.0":
+    tf_version = pkg_resources.parse_version(tf.__version__)
+    if tf_version >= pkg_resources.parse_version("2.8.0"):
       # TODO(necula): remove when 2.8.0 is the stable TF version (and supports
       # batch_group_count.
       out = tfxla.conv(

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1514,9 +1514,8 @@ def _conv_general_dilated(lhs, rhs, *,
   precision_config_proto = _precision_config_proto(precision)
 
   def gen_conv(lhs, rhs, preferred_element_type: Optional[DType]):
-    tf_version = tuple(int(v) for v tf.__version__.split(".")[:2])
-    min_version = tuple(int(v) for v in tf.__version__.split(".")[:2])
-    if tf_version >= min_version
+    tf_version = tuple(int(v) for v in tf.__version__.split(".")[:2])
+    if tf_version >= (2, 8)
       # TODO(necula): remove when 2.8.0 is the stable TF version (and supports
       # batch_group_count.
       out = tfxla.conv(


### PR DESCRIPTION
TF nightly is now 2.10. Comparing as strings will give wrong answer:

```python
>>> "2.10.0" >= "2.8.0"
False
>>> from packaging import version
>>> version.parse("2.10.0") >= version.parse("2.8.0")
True
>>> pkg_resources.parse_version("2.10.0") >= pkg_resources.parse_version("2.8.0")
True
```

Use `pkg_resources.parse_version` as it should not require additional installs.