### PR TITLE
CI: pin pillow<9.1 to prevent deprecation warnings

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,7 +1,8 @@
 cloudpickle
 colorama>=0.4.4
 flatbuffers==2.0
-pillow>=8.3.1
+# TODO(jakevdp): fix use of deprecated NEAREST resampling for more recent pillow.
+pillow>=8.3.1,<9.1.0
 pytest-benchmark
 pytest-xdist
 wheel


### PR DESCRIPTION
The warnings are coming from keras, via `import tensorflow` in `tests/image_test.py`. We'll have to wait for keras to update in order to use newer PIL versions.