### PR TITLE
prototyping dynamic shapes

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -350,7 +350,7 @@ class Config:
     Values included in this set should also most likely be included in
     the C++ JIT state, which is handled separately."""
     return (self.x64_enabled, self.jax_numpy_rank_promotion,
-            self.jax_default_matmul_precision)
+            self.jax_default_matmul_precision, self.jax_dynamic_shapes)
 
 class _StateContextManager:
   def __init__(self, name, help, update_thread_local_hook,
@@ -424,6 +424,7 @@ already_configured_with_absl = False
 class GlobalJitState(NamedTuple):
   numpy_rank_promotion: Optional[str] = None
   default_matmul_precision: Optional[Any] = None
+  dynamic_shapes: bool = False
 
 
 def update_global_jit_state(**kw):
@@ -436,6 +437,7 @@ class ThreadLocalJitState(NamedTuple):
   dynamic_trace_state: Optional[Any] = None
   numpy_rank_promotion: Optional[str] = None
   default_matmul_precision: Optional[Any] = None
+  dynamic_shapes: bool = False
 
 
 def update_thread_local_jit_state(**kw):
@@ -700,7 +702,11 @@ config.define_bool_state(
     name='jax_dynamic_shapes',
     default=False,
     help=('Enables experimental features for staging out computations with '
-          'dynamic shapes.'))
+          'dynamic shapes.'),
+    update_global_hook=lambda val: \
+      update_global_jit_state(dynamic_shapes=val),
+    update_thread_local_hook=lambda val: \
+      update_thread_local_jit_state(dynamic_shapes=val))
 
 config.define_bool_state(
     name='jax_experimental_name_stack',

--- a/jax/_src/lax/utils.py
+++ b/jax/_src/lax/utils.py
@@ -67,8 +67,10 @@ def standard_abstract_eval(prim, shape_rule, dtype_rule, weak_type_rule,
                             dtype_rule(*avals, **kwargs), weak_type=weak_type,
                             named_shape=named_shape_rule(*avals, **kwargs))
   elif least_specialized is core.DShapedArray:
-    return core.DShapedArray(shape_rule(*avals, **kwargs),
-                             dtype_rule(*avals, **kwargs), weak_type)
+    shape = shape_rule(*avals, **kwargs)
+    ty = (core.ShapedArray if all(type(d) is int for d in shape)
+          else core.DShapedArray)
+    return ty(shape, dtype_rule(*avals, **kwargs), weak_type)
   elif least_specialized is core.UnshapedArray:
     return core.UnshapedArray(dtype_rule(*avals, **kwargs), weak_type=weak_type)
   else:

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -89,7 +89,7 @@ def treedef_children(treedef):
 def treedef_is_leaf(treedef):
   return treedef.num_nodes == 1
 
-def all_leaves(iterable):
+def all_leaves(iterable, is_leaf: Optional[Callable[[Any], bool]] = None):
   """Tests whether all elements in the given iterable are all leaves.
 
   >>> tree = {"a": [1, 2, 3]}
@@ -106,7 +106,11 @@ def all_leaves(iterable):
   Returns:
     A boolean indicating if all elements in the input are leaves.
   """
-  return pytree.all_leaves(iterable)
+  if is_leaf is None:
+    return pytree.all_leaves(iterable)
+  else:
+    lst = list(iterable)
+    return lst == tree_leaves(lst, is_leaf)
 
 
 _Children = TypeVar("_Children", bound=Iterable[Any])

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -674,8 +674,7 @@ def jaxpr_collectives(jaxpr):
   for eqn in jaxpr.eqns:
     if eqn.primitive in _collective_primitives:
       yield eqn.primitive
-  for subjaxpr in core.subjaxprs(jaxpr):
-    yield from jaxpr_collectives(subjaxpr)
+  for subjaxpr in core.subjaxprs(jaxpr): yield from jaxpr_collectives(subjaxpr)
 
 
 ### xla_call underlying jit
@@ -832,6 +831,8 @@ pe.partial_eval_jaxpr_custom_rules[xla_call_p] = \
     partial(pe.call_partial_eval_custom_rule, 'call_jaxpr',
             _xla_call_partial_eval_custom_params_updater)
 pe.dce_rules[xla_call_p] = pe.dce_jaxpr_call_rule
+
+pe.padding_rules[xla_call_p] = partial(pe.call_padding_rule, xla_call_p)
 
 
 def _pp_xla_call(eqn: core.JaxprEqn, context: core.JaxprPpContext,

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -146,6 +146,7 @@ from jax._src.lax.lax import (
   log_p as log_p,
   lt as lt,
   lt_p as lt_p,
+  make_bint as make_bint,
   max as max,
   max_p as max_p,
   min as min,


### PR DESCRIPTION
Co-authored-by: Dougal Maclaurin <dougalm@google.com>

As a result of previous PRs, we could build dynamic shape jaxprs with `jax.make_jaxpr`, but we couldn't do much else.

The main goal here was to hook up dynamic shape fundamentals to `jit`, in two ways:
1. on the front end, add a way to annotate `jit`-decorated functions to indicate when we wish the jaxpr(s) built during `jit` tracing to abstract over particular axis sizes; and
2. on the back end, add a way to lower such jaxprs to dynamic-shape MHLO and compile/execute them (e.g. using IREE).

To accomplish that goal, the main changes here are:
1. **`WrappedFun.in_type`**: We added an optional `in_type` attribute to `WrappedFun` to represent an optional input type annotation for the wrapped Python callable, which (when present) determines how the callable should be traced to a jaxpr (e.g. on what Tracers). The `in_type` attribute has type `Tuple[Tuple[AbstractValue, bool], ...]`, i.e. tuples of (aval, bool) pairs. Each aval represents the type of an input binder, while the boolean indicates whether the argument is _explicit_, in the sense that it should be passed as an argument to the Python callable (otherwise it is _implicit_ to the Python callable, so that its value is inferred from e.g. axis sizes of other explicit arguments). That is, at the jaxpr level all arguments are explicit, but for the Python callable some arguments are implicit. The `in_type` annotation must be adapted by transformations (e.g. `jvp` needs to expand it to accommodate tangent types).
2. **`DBIdx`**: In `in_type`, the shape tuples of some avals may now contain de Bruijn indices which refer to binders at positions in `in_type`. That is, we represent a type like `a:i32[] x:f32[a]` as `a:i32[] x:f32[DBIdx(0)]`. This representation is cache-friendly.
3. **Add `abstracted_axes` to `jit`**: While `in_type` is a nice cleanup on its own, the main reason we put `in_type` on `WrappedFun` is so that we could take user-specified annotations on `jit` "at the api.py level" and plumb them to where they are consumed. Correspondingly we added the `abstracted_axes` argument, which was already on `make_jaxpr`, to `jit`.

All the old tests pass. We've manually tested simple IREE examples; we may make internal-only tests for those.

There are more tests to add but we may land-and-iterate.