### PR TITLE
Implement `jnp.trace` in terms of `jnp.diagonal`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2386,15 +2386,12 @@ def triu(m, k=0):
 @_wraps(np.trace, skip_params=['out'])
 @partial(jit, static_argnames=('offset', 'axis1', 'axis2', 'dtype'))
 def trace(a, offset=0, axis1: int = 0, axis2: int = 1, dtype=None, out=None):
-  _check_arraylike("trace", a)
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.trace is not supported.")
   lax_internal._check_user_dtype_supported(dtype, "trace")
 
-  axis1 = _canonicalize_axis(axis1, ndim(a))
-  axis2 = _canonicalize_axis(axis2, ndim(a))
+  d = _diagonal("trace", a, offset, axis1, axis2)
 
-  a_shape = shape(a)
   if dtype is None:
     dtype = _dtype(a)
     if issubdtype(dtype, integer):
@@ -2402,15 +2399,7 @@ def trace(a, offset=0, axis1: int = 0, axis2: int = 1, dtype=None, out=None):
       if iinfo(dtype).bits < iinfo(default_int).bits:
         dtype = default_int
 
-  # Move the axis? dimensions to the end.
-  perm = [i for i in range(len(a_shape)) if i != axis1 and i != axis2]
-  perm = perm + [axis1, axis2]
-  a = lax.transpose(a, perm)
-
-  # Mask out the diagonal and reduce.
-  a = where(eye(a_shape[axis1], a_shape[axis2], k=offset, dtype=bool),
-            a, zeros_like(a))
-  return sum(a, axis=(-2, -1), dtype=dtype)
+  return sum(d, axis=-1, dtype=dtype)
 
 
 def _wrap_indices_function(f):
@@ -2466,10 +2455,13 @@ def diag_indices_from(arr):
 @_wraps(np.diagonal, lax_description=_ARRAY_VIEW_DOC)
 @partial(jit, static_argnames=('offset', 'axis1', 'axis2'))
 def diagonal(a, offset=0, axis1: int = 0, axis2: int = 1):
-  _check_arraylike("diagonal", a)
+  return _diagonal("diagonal", a, offset, axis1, axis2)
+
+def _diagonal(op, a, offset=0, axis1: int = 0, axis2: int = 1):
+  _check_arraylike(op, a)
   a_shape = shape(a)
   a_ndims = len(a_shape)
-  offset = core.concrete_or_error(operator.index, offset, "'offset' argument of jnp.diagonal()")
+  offset = core.concrete_or_error(operator.index, offset, f"'offset' argument of jnp.{op}()")
 
   # Move the two dimensions to the end.
   axis1 = _canonicalize_axis(axis1, a_ndims)


### PR DESCRIPTION
This PR was inspired by #10140 and implements `jnp.trace` using `jnp.diagonal` to improve performance and simplify the code .

As far as I can tell, this change is covered [by the current unittests](https://github.com/google/jax/blob/1df942f276f99e3b8615a519f49712beeb1d9bb5/tests/lax_numpy_test.py#L2990-L3013) and doesn't change behaviour.
The only slight difference is that `jnp.diagonal` needs to call `concrete_or_error(operator.index, offset, "")` which wasn't the case in `jnp.trace`, but since `offset` is a static argument in `jit` I don't think this is a problem. Or am I missing something?

I briefly checked the CPU performance on my laptop for a few shapes and we can see a large improvement for big arrays:
```python
from jax import numpy as jnp
import numpy as np

shapes = [(256, 256, 32, 32), (128, 64, 64, 32), (128, 64, 64), (32, 32)]

for shape in shapes:
    a = np.random.uniform(size=shape).astype(np.float32)
    np.trace(a)
    %timeit np.trace(a)

# Numpy
# 28.7 µs ± 896 ns per loop
# 15.5 µs ± 631 ns per loop
# 4.09 µs ± 77 ns per loop
# 2.62 µs ± 14.3 ns per loop

for shape in shapes:
    a = np.random.uniform(size=shape).astype(np.float32)
    a = jnp.array(a)
    jnp.trace(a)
    %timeit jnp.trace(a).block_until_ready()

# JAX (main branch)
# 291 ms ± 1.36 ms per loop
# 68.4 ms ± 3.55 ms per loop
# 860 µs ± 62.7 µs per loop
# 4.65 µs ± 228 ns per loop

# JAX (this PR)
# 209 µs ± 2.41 µs per loop
# 89.6 µs ± 826 ns per loop
# 5.79 µs ± 34.7 ns per loop
# 4.21 µs ± 156 ns per loop
```