### PR TITLE
Add Hilbert matrix to jax.scipy.linalg

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -29,6 +29,7 @@ jax.scipy.linalg
    eigh_tridiagonal
    expm
    expm_frechet
+   hilbert
    inv
    lu
    lu_factor

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -657,7 +657,7 @@ def sqrtm(A, blocksize=1):
       raise NotImplementedError("Blocked version is not implemented yet.")
   return _sqrtm(A)
 
-
+@_wraps(scipy.linalg.hilbert)
 @partial(jit, static_argnames=("n",))
 def hilbert(n):
   a = jnp.arange(n)

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -656,3 +656,13 @@ def sqrtm(A, blocksize=1):
   if blocksize > 1:
       raise NotImplementedError("Blocked version is not implemented yet.")
   return _sqrtm(A)
+
+
+@partial(jit, static_argnames=("n",))
+def hilbert(n):
+  a = jnp.arange(n)
+  return _arange_to_hilbert(a)
+
+@jit
+def _arange_to_hilbert(a):
+  return 1 / (a[:, None] + a[None, :] + 1)

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -661,8 +661,4 @@ def sqrtm(A, blocksize=1):
 @partial(jit, static_argnames=("n",))
 def hilbert(n):
   a = jnp.arange(n)
-  return _arange_to_hilbert(a)
-
-@jit
-def _arange_to_hilbert(a):
   return 1 / (a[:, None] + a[None, :] + 1)

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -37,6 +37,7 @@ from jax._src.scipy.linalg import (
   svd as svd,
   tril as tril,
   triu as triu,
+  hilbert as hilbert,
 )
 
 from jax._src.lax.polar import (

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -24,6 +24,7 @@ from jax._src.scipy.linalg import (
   eigh_tridiagonal as eigh_tridiagonal,
   expm as expm,
   expm_frechet as expm_frechet,
+  hilbert as hilbert,
   inv as inv,
   lu as lu,
   lu_factor as lu_factor,
@@ -37,7 +38,6 @@ from jax._src.scipy.linalg import (
   svd as svd,
   tril as tril,
   triu as triu,
-  hilbert as hilbert,
 )
 
 from jax._src.lax.polar import (

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1564,5 +1564,12 @@ class LaxLinalgTest(jtu.JaxTestCase):
       Ts, Ss = vmap(lax.linalg.schur)(args)
       self.assertAllClose(reconstruct(Ss, Ts), args, atol=1e-4)
 
+  @parameterized.parameters(1, 5)
+  def test_hilbert(self, n):
+      args_maker = lambda: [n]
+      print(n)
+      self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)
+
+
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1564,7 +1564,7 @@ class LaxLinalgTest(jtu.JaxTestCase):
       Ts, Ss = vmap(lax.linalg.schur)(args)
       self.assertAllClose(reconstruct(Ss, Ts), args, atol=1e-4)
 
-  @parameterized.parameters(1, 5)
+  @parameterized.parameters(0, 1, 5)
   def test_hilbert(self, n):
       args_maker = lambda: [n]
       self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1567,7 +1567,6 @@ class LaxLinalgTest(jtu.JaxTestCase):
   @parameterized.parameters(1, 5)
   def test_hilbert(self, n):
       args_maker = lambda: [n]
-      print(n)
       self._CheckAgainstNumpy(osp.linalg.hilbert, jsp.linalg.hilbert, args_maker)
 
 


### PR DESCRIPTION
This PR adds an implementation of Hilbert matrices of order `n` that mirrors the API of `scipy.linalg.hilbert(n)` (https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.hilbert.html#scipy.linalg.hilbert).

See #10144 for context.

Pinging @jakevdp, because he offered to review :) 