### PR TITLE
Pin a newer @platforms in the Bazel workspace to fix Mac ARM builds.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,17 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Force a sufficiently new copy of @platforms, see https://github.com/bazelbuild/bazel/issues/15175 and
+# https://github.com/google/jax/issues/10132. When our transitive dependencies aren't pulling in an
+# old version, we can remove this (the current hypothesis is that the cause is in TFRT).
+http_archive(
+    name = "platforms",
+    sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+    ],
+)
+
 # To update TensorFlow to a new revision,
 # a) update URL and strip_prefix to the new git commit hash
 # b) get the sha256 hash of the commit by running:


### PR DESCRIPTION
Fixes #10132 