### PR TITLE
Add protocol for ndarray.at

### DIFF
--- a/jax/_src/numpy/ndarray.py
+++ b/jax/_src/numpy/ndarray.py
@@ -14,12 +14,216 @@
 
 import abc
 from typing import Any, Tuple, Optional, Union
+from typing_extensions import Protocol
 
 from jax import core
 from jax.interpreters import pxla
 from jax._src import device_array
 import numpy as np
 
+class Indexed(Protocol):
+  """Helper object to call indexed update functions for an (advanced) index.
+
+  This object references a source array and a specific indexer into that array.
+  Methods on this object return copies of the source array that have been
+  modified at the positions specified by the indexer.
+  """
+
+  def get(self, indices_are_sorted=False, unique_indices=False,
+          mode=None, fill_value=None):
+    """Equivalent to ``x[idx]``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexing <numpy.doc.indexing>` ``x[idx]``. This function differs from
+    the usual array indexing syntax in that it allows additional keyword
+    arguments ``indices_are_sorted`` and ``unique_indices`` to be passed.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def set(self, values, indices_are_sorted=False, unique_indices=False,
+          mode=None):
+    """Pure equivalent of ``x[idx] = y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:`indexed assignment <numpy.doc.indexing>` ``x[idx] = y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def apply(self, func, indices_are_sorted=False, unique_indices=False,
+            mode=None):
+    """Pure equivalent of ``func.at(x, idx)`` for a unary ufunc ``func``.
+
+    Returns the value of ``x`` that would result from applying the unary
+    function ``func`` to ``x`` at the given indices. This is similar to
+    ``x.at[idx].set(func(x[idx]))``, but differs in the case of repeated indices:
+    in ``x.at[idx].apply(func)``, repeated indices result in the function being
+    applied multiple times.
+
+    Note that in the current implementation, ``scatter_apply`` is not compatible
+    with automatic differentiation.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def add(self, values, indices_are_sorted=False, unique_indices=False,
+          mode=None):
+    """Pure equivalent of ``x[idx] += y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] += y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def multiply(self, values, indices_are_sorted=False, unique_indices=False,
+               mode=None):
+    """Pure equivalent of ``x[idx] *= y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] *= y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def mul(self, values, indices_are_sorted=False, unique_indices=False,
+               mode=None):
+    """Pure equivalent of ``x[idx] *= y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] *= y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def divide(self, values, indices_are_sorted=False, unique_indices=False,
+             mode=None):
+    """Pure equivalent of ``x[idx] /= y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] /= y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def power(self, values, indices_are_sorted=False, unique_indices=False,
+            mode=None):
+    """Pure equivalent of ``x[idx] **= y``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] **= y``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def min(self, values, indices_are_sorted=False, unique_indices=False,
+          mode=None):
+    """Pure equivalent of ``x[idx] = minimum(x[idx], y)``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>`
+    ``x[idx] = minimum(x[idx], y)``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+  def max(self, values, indices_are_sorted=False, unique_indices=False,
+          mode=None):
+    """Pure equivalent of ``x[idx] = maximum(x[idx], y)``.
+
+    Returns the value of ``x`` that would result from the NumPy-style
+    :mod:indexed assignment <numpy.doc.indexing>`
+    ``x[idx] = maximum(x[idx], y)``.
+
+    See :mod:`jax.ops` for details.
+    """
+
+class At(Protocol):
+  """Helper property for index update functionality.
+
+  The ``at`` property provides a functionally pure equivalent of in-place
+  array modificatons.
+
+  In particular:
+
+  ==============================  ================================
+  Alternate syntax                Equivalent In-place expression
+  ==============================  ================================
+  ``x = x.at[idx].set(y)``        ``x[idx] = y``
+  ``x = x.at[idx].add(y)``        ``x[idx] += y``
+  ``x = x.at[idx].multiply(y)``   ``x[idx] *= y``
+  ``x = x.at[idx].divide(y)``     ``x[idx] /= y``
+  ``x = x.at[idx].power(y)``      ``x[idx] **= y``
+  ``x = x.at[idx].min(y)``        ``x[idx] = minimum(x[idx], y)``
+  ``x = x.at[idx].max(y)``        ``x[idx] = maximum(x[idx], y)``
+  ``x = x.at[idx].apply(ufunc)``  ``ufunc.at(x, idx)``
+  ``x = x.at[idx].get()``         ``x = x[idx]``
+  ==============================  ================================
+
+  None of the ``x.at`` expressions modify the original ``x``; instead they return
+  a modified copy of ``x``. However, inside a :py:func:`~jax.jit` compiled function,
+  expressions like :code:`x = x.at[idx].set(y)` are guaranteed to be applied in-place.
+
+  Unlike NumPy in-place operations such as :code:`x[idx] += y`, if multiple
+  indices refer to the same location, all updates will be applied (NumPy would
+  only apply the last update, rather than applying all updates.) The order
+  in which conflicting updates are applied is implementation-defined and may be
+  nondeterministic (e.g., due to concurrency on some hardware platforms).
+
+  By default, JAX assumes that all indices are in-bounds. There is experimental
+  support for giving more precise semantics to out-of-bounds indexed accesses,
+  via the ``mode`` parameter (see below).
+
+  Arguments
+  ---------
+  mode : str
+      Specify out-of-bound indexing mode. Options are:
+
+      - ``"promise_in_bounds"``: (default) The user promises that indices are in bounds.
+        No additional checking will be performed. In practice, this means that
+        out-of-bounds indices in ``get()`` will be clipped, and out-of-bounds indices
+        in ``set()``, ``add()``, etc. will be dropped.
+      - ``"clip"``: clamp out of bounds indices into valid range.
+      - ``"drop"``: ignore out-of-bound indices.
+      - ``"fill"``: alias for ``"drop"``.  For `get()`, the optional ``fill_value``
+        argument specifies the value that will be returned.
+
+  indices_are_sorted : bool
+      If True, the implementation will assume that the indices passed to ``at[]``
+      are sorted in ascending order, which can lead to more efficient execution
+      on some backends.
+  unique_indices : bool
+      If True, the implementation will assume that the indices passed to ``at[]``
+      are unique, which can result in more efficient execution on some backends.
+  fill_value : Any
+      Only applies to the ``get()`` method: the fill value to return for out-of-bounds
+      slices when `mode` is ``'fill'``. Ignored otherwise. Defaults to ``NaN`` for
+      inexact types, the largest negative value for signed types, the largest positive
+      value for unsigned types, and ``True`` for booleans.
+
+  Examples
+  --------
+  >>> x = jnp.arange(5.0)
+  >>> x
+  DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
+  >>> x.at[2].add(10)
+  DeviceArray([ 0.,  1., 12.,  3.,  4.], dtype=float32)
+  >>> x.at[10].add(10)  # out-of-bounds indices are ignored
+  DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
+  >>> x.at[20].add(10, mode='clip')
+  DeviceArray([ 0.,  1.,  2.,  3., 14.], dtype=float32)
+  >>> x.at[2].get()
+  DeviceArray(2., dtype=float32)
+  >>> x.at[20].get()  # out-of-bounds indices clipped
+  DeviceArray(4., dtype=float32)
+  >>> x.at[20].get(mode='fill')  # out-of-bounds indices filled with NaN
+  DeviceArray(nan, dtype=float32)
+  >>> x.at[20].get(mode='fill', fill_value=-1)  # custom fill value
+  DeviceArray(-1., dtype=float32)
+  """
+  def __getitem__(self, index) -> Indexed:
+    pass
 
 class ArrayMeta(abc.ABCMeta):
   """Metaclass for overriding ndarray isinstance checks."""
@@ -277,7 +481,7 @@ class ndarray(metaclass=ArrayMeta):
   # JAX extensions
   @property
   @abc.abstractmethod
-  def at(self) -> Any: ...
+  def at(self) -> At: ...
   @property
   @abc.abstractmethod
   def aval(self) -> Any: ...


### PR DESCRIPTION
interface and docstr are copied from lax_numpy.py _IndexUpdateHelper and _IndexUpdateRef

Note docstr are outdated, refering to deprecated `jax.ops`.