### PR TITLE
[sparse] consolidate flavors of bcoo_dot_general

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -201,8 +201,6 @@ from jax.experimental.sparse.bcoo import (
     bcoo_multiply_dense as bcoo_multiply_dense,
     bcoo_multiply_sparse as bcoo_multiply_sparse,
     bcoo_reduce_sum as bcoo_reduce_sum,
-    bcoo_rdot_general as bcoo_rdot_general,
-    bcoo_spdot_general as bcoo_spdot_general,
     bcoo_spdot_general_p as bcoo_spdot_general_p,
     bcoo_todense as bcoo_todense,
     bcoo_todense_p as bcoo_todense_p,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -434,14 +434,8 @@ for _prim in [
 def _dot_general_sparse(spenv, *spvalues, dimension_numbers, precision, preferred_element_type):
   # TODO(jakevdp): pass along these unused configurations?
   del precision, preferred_element_type  # unused
-  if spvalues[0].is_sparse() and spvalues[1].is_sparse():
-    func = sparse.bcoo_spdot_general
-  elif spvalues[0].is_sparse():
-    func = sparse.bcoo_dot_general
-  else:
-    func = sparse.bcoo_rdot_general
-  A, B = spvalues_to_arrays(spenv, spvalues)
-  result = func(A, B, dimension_numbers=dimension_numbers)
+  result = sparse.bcoo_dot_general(*spvalues_to_arrays(spenv, spvalues),
+                                   dimension_numbers=dimension_numbers)
   return arrays_to_spvalues(spenv, [result])
 
 sparse_rules[lax.dot_general_p] = _dot_general_sparse

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1815,6 +1815,9 @@ class BCOOTest(jtu.JaxTestCase):
     # bcoo_dot_general
     self.assertArraysEqual(x_sp @ y_de, x_de @ y_de)
 
+    # bcoo_rdot_general
+    self.assertArraysEqual(x_de @ y_sp, x_de @ y_de)
+
     # bcoo_spdot_general
     self.assertArraysEqual((x_sp @ y_sp).todense(), x_de @ y_de)
     self.assertArraysEqual((y_sp @ x_sp).todense(), y_de @ x_de)


### PR DESCRIPTION
Consolidate the high-level `bcoo_rdot_general` and `bcoo_spdot_general` into `bcoo_dot_general`.