### PR TITLE
Use `lax.iota` also for `jnp.arange(0, stop)`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2074,6 +2074,9 @@ def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
     start = require(start, msg("start"))
     stop = None if stop is None else require(stop, msg("stop"))
     step = None if step is None else require(step, msg("step"))
+    if step is None and start == 0 and stop is not None:
+      stop = np.ceil(stop).astype(int)
+      return lax.iota(dtype, stop)
     return array(np.arange(start, stop=stop, step=step, dtype=dtype))
 
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4309,6 +4309,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     # from https://github.com/google/jax/issues/3450
     self.assertAllClose(np_arange(2.5),
                         jnp.arange(2.5))
+    self.assertAllClose(np_arange(0., 2.5),
+                        jnp.arange(0., 2.5))
 
   def testArangeTypes(self):
     # Test that arange() output type is equal to the default types.
@@ -5019,6 +5021,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     ans = jax.jit(lambda: jnp.arange(5))()
     expected = jtu.with_jax_dtype_defaults(np.arange)(5)
     self.assertAllClose(ans, expected)
+
+  @parameterized.named_parameters(
+    {"testcase_name": f"_{args}", "args": args} for args in [(5,), (0, 5)])
+  def testArangeJaxpr(self, args):
+    jaxpr = jax.make_jaxpr(lambda: jnp.arange(*args))()
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
+    self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.iota_p)
 
   def testIssue830(self):
     a = jnp.arange(4, dtype=jnp.complex64)


### PR DESCRIPTION
This PR updates `jnp.arange` to also use `lax.iota` when calling it with `jnp.arange(0, stop)`. `jnp.arange(0, stop)` and `jnp.arange(stop)` will now return the same Jaxpr.

This was inspired by https://github.com/google/jax/pull/10176#discussion_r846166229 as `jnp.arange` is often called with an explicit `start` argument that equals zero.