### PR TITLE
Prefer `jnp.tile` over `concatenate`

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3267,7 +3267,9 @@ def _roll(a, shift, axis):
                   np.broadcast_to(axis, b_shape)):
     i = _canonicalize_axis(i, a_ndim)
     x = remainder(x, (a_shape[i] or 1))
-    a = lax.concatenate((a, a), i)
+    reps = [1] * a_ndim
+    reps[i] = 2
+    a = tile(a, reps)
     a = lax.dynamic_slice_in_dim(a, a_shape[i] - x, a_shape[i], axis=i)
   return a
 

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -582,7 +582,7 @@ threefry_prng_impl = PRNGImpl(
 
 def _rbg_seed(seed: int) -> jnp.ndarray:
   halfkey = threefry_seed(seed)
-  return jnp.concatenate([halfkey, halfkey])
+  return jnp.tile(halfkey, 2)
 
 def _rbg_split(key: jnp.ndarray, num: int) -> jnp.ndarray:
   return vmap(_threefry_split, (0, None), 1)(key.reshape(2, 2), num).reshape(num, 4)


### PR DESCRIPTION
`jnp.tile` only uses broadcasting which tends to be preferred so this PR replaces `concatenate` with `jnp.tile` in the cases where it is possible.