### PR TITLE
Add np.polydiv numpy function

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -305,6 +305,7 @@ namespace; they are listed below.
     poly
     polyadd
     polyder
+    polydiv
     polyfit
     polyint
     polymul

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2543,6 +2543,17 @@ def trim_zeros(filt, trim='fb'):
   return filt[start:len(filt) - end]
 
 
+def trim_zeros_tol(filt, tol, trim='fb'):
+  filt = core.concrete_or_error(asarray, filt,
+    "Error arose in the `filt` argument of trim_zeros_tol()")
+  nz = (abs(filt) < tol)
+  if all(nz):
+    return empty(0, _dtype(filt))
+  start = argmin(nz) if 'f' in trim.lower() else 0
+  end = argmin(nz[::-1]) if 'b' in trim.lower() else 0
+  return filt[start:len(filt) - end]
+
+
 @_wraps(np.append)
 @partial(jit, static_argnames=('axis',))
 def append(arr, values, axis: Optional[int] = None):

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -298,6 +298,7 @@ from jax._src.numpy.polynomial import (
     poly as poly,
     polyadd as polyadd,
     polyder as polyder,
+    polydiv as polydiv,
     polyfit as polyfit,
     polyint as polyint,
     polymul as polymul,


### PR DESCRIPTION
This PR is related to #7729 and #70.

Because of the error, the function can't pass the below test.
```python
self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False, tol=tol)
```

Different from the ```polymul```, the size of the residual is not fixed, and it's also hard to distinguish if a value in the result is an error or it's supposed to be small. If you use ```trim_zeros``` to remove the leading zeros in the residual polynomial, because of the error, the shape of jnp result may not match the result from np, so it won't pass ```_CheckAgainstNumpy```.

If we want to remove the values which is supposed to be zero(but not zero because of the error), we may use ```where(x<some_value)``` to make it zero. However, if the other values in the result are big(e.g. 1e8), the error can also be big(e.g. 1). Then we have to use ```where(x < max(some_value, some_value*max(x)))``` to remove those values, then the function won't pass ```_CompileAndCheck```.

Hi @jakevdp - could you please take a look and give some advice?