### PR TITLE
[sparse] make bcoo_sort_indices a primitive

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -201,6 +201,8 @@ from jax.experimental.sparse.bcoo import (
     bcoo_multiply_dense as bcoo_multiply_dense,
     bcoo_multiply_sparse as bcoo_multiply_sparse,
     bcoo_reduce_sum as bcoo_reduce_sum,
+    bcoo_sort_indices as bcoo_sort_indices,
+    bcoo_sort_indices_p as bcoo_sort_indices_p,
     bcoo_spdot_general_p as bcoo_spdot_general_p,
     bcoo_todense as bcoo_todense,
     bcoo_todense_p as bcoo_todense_p,


### PR DESCRIPTION
This started as an effort to make `sum_duplicates` a primitive to address the autodiff issues revealed by #10163. I thought about rolling `sum_duplicates` and `sort_indices` into the same primitive, but this ended up adding a level of complexity that I was not happy with. Since `sort_indices` is simpler, I decided to start with that on its own; I'll add a separate `sum_duplicates` primitive in a followup.