### PR TITLE
debug_nans: don't return results of successfully running de-optimized function

### DIFF
--- a/tests/debug_nans_test.py
+++ b/tests/debug_nans_test.py
@@ -220,5 +220,16 @@ class DebugInfsTest(jtu.JaxTestCase):
       except FloatingPointError:
         pass
 
+  def testDebugNansDoesntReturnDeoptimizedResult(self):
+    @jax.jit
+    def f(x):
+      x + 2  # avoid trivial dispatch path by adding some eqn
+      return jnp.nan
+
+    with self.assertRaisesRegex(FloatingPointError, "de-optimized"):
+      with jax.debug_nans(True):
+        f(3)
+
+
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
With `debug_nans` set, when a `jit`-decorated function returns a nan value, we call into the de-optimized/op-by-op (i.e. jit-unwrapped) version of the function in hopes of getting a more precise error message (e.g. op-by-op execution could tell us which operation produced the nan). But in some cases the de-optimized execution might not produce a nan at all, even though the `jit`-decorated function did (e.g. if XLA optimizations introduced the nan in the first place, or if the nan is a constant rather than the output of some JAX operation). In that case, **before this PR we would just return the nan-free result of the de-optimized/op-by-op function application**. But that seems confusing, as it means `debug_nans` itself could effectively change the nan behavior of the program, perhaps avoiding a nan and then encountering a different one downstream, changing the error message.

After this PR, we avoid returning values from the op-by-op application.