### PR TITLE
Deprecate DeviceArray.tile method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
 
+## jax 0.3.8 (Unreleased)
+* [GitHub
+  commits](https://github.com/google/jax/compare/jax-v0.3.7...main).
+* Changes:
+  * The `DeviceArray.tile()` method is deprecated, because numpy arrays do not have a
+    `tile()` method. As a replacement for this, use {func}`jax.numpy.tile`
+    ({jax-issue}`#10266`).
+
 ## jax 0.3.7 (April 15, 2022)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.3.6...jax-v0.3.7).


### PR DESCRIPTION
We shouldn't add this method to DeviceArray objects, because numpy arrays do not have such a method. I checked that all other methods are present:
```python
In [1]: from jax._src.numpy.lax_numpy import _diff_methods, _nondiff_methods

In [2]: import numpy as np

In [3]: x = np.arange(10)

In [4]: for method in _diff_methods + _nondiff_methods: 
   ...:   if not hasattr(x, method): 
   ...:     print(method) 
   ...:                                                                                               
tile
```
According to https://jax.readthedocs.io/en/latest/api_compatibility.html, we should keep this deprecated method for at least 3 months.