### PR TITLE
add some simple iree tests

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2784,13 +2784,23 @@ pe.forwarding_rules[broadcast_in_dim_p] = _broadcast_in_dim_fwd_rule
 pe.custom_staging_rules[broadcast_in_dim_p] = _broadcast_in_dim_staging_rule
 pe.padding_rules[broadcast_in_dim_p] = _broadcast_in_dim_padding_rule
 
-def _broadcast_in_dim_lower(ctx, x, *, shape, broadcast_dimensions):
-  del shape
+def _broadcast_in_dim_lower(ctx, x, *dyn_shape, shape, broadcast_dimensions):
   aval_out, = ctx.avals_out
-  return mhlo.BroadcastInDimOp(
-      mlir.aval_to_ir_type(aval_out), x,
-      mlir.dense_int_elements(broadcast_dimensions)
-  ).results
+  if dyn_shape:
+    dyn_shape = iter(dyn_shape)
+    shape = [next(dyn_shape) if d is None else d for d in shape]
+    assert next(dyn_shape, None) is None
+    return mhlo.DynamicBroadcastInDimOp(
+        mlir.aval_to_ir_type(aval_out), x,
+        mlir.shape_tensor(shape),
+        mlir.dense_int_elements(broadcast_dimensions),
+        None, None,
+    ).results
+  else:
+    return mhlo.BroadcastInDimOp(
+        mlir.aval_to_ir_type(aval_out), x,
+        mlir.dense_int_elements(broadcast_dimensions)
+    ).results
 mlir.register_lowering(broadcast_in_dim_p, _broadcast_in_dim_lower)
 
 
@@ -4485,6 +4495,7 @@ def bint_abstract_eval(_, *, bd: int):
   return core.AbstractBInt(bound=bd)
 
 pe.padding_rules[bint_p] = lambda _, __, i, bd: [i]
+mlir.register_lowering(bint_p, lambda ctx, x, bd: [x])
 
 
 ### util

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -8116,21 +8116,46 @@ class DynamicShapeTest(jtu.JaxTestCase):
     self.assertIsInstance(three_, int)
     self.assertEqual(three_, 3)
 
+  @unittest.skipIf(jtu.device_under_test() != 'iree', "iree test")
   def test_jit_basic_iree(self):
     if not jtu.device_under_test() == 'iree':
       raise unittest.SkipTest("test only works on IREE")
+
     @jax.jit
     def f(i):
       return jnp.sum(jnp.ones(i, dtype='float32'))
 
     self.assertAllClose(f(3), jnp.array(3., dtype='float32'), check_dtypes=True)
 
+  @unittest.skipIf(jtu.device_under_test() != 'iree', "iree test")
+  def test_jit_basic_iree_2(self):
+    count = 0
+
+    @partial(jax.jit, abstracted_axes=('n',))
+    def f(x):
+      nonlocal count
+      count += 1
+      return jnp.sum(x)
+
+    x = f(jnp.arange(3))
+    y = f(jnp.arange(4))
+    self.assertAllClose(x, 3., check_dtypes=False)
+    self.assertAllClose(y, 6., check_dtypes=False)
+    self.assertEqual(count, 1)
+
+  # TODO(mattjj,dougalm,phawkins): debug iree failure, "'arith.subi' op requires
+  # the same type for all operands and results"
+  # https://github.com/google/iree/issues/8881
+  @jtu.skip_on_devices('iree')
   def test_slicing_basic(self):
     f = jax.jit(lambda x, n: jnp.sum(x[:n]))
     ans = f(jnp.arange(10), 3)
     expected = jnp.sum(jnp.arange(10)[:3])
     self.assertAllClose(ans, expected, check_dtypes=True)
 
+  # TODO(mattjj,dougalm,phawkins): debug iree failure, "failed to legalize
+  # operation 'mhlo.while' that was explicitly marked illegal"
+  @jtu.skip_on_devices('iree')
   def test_scan_basic(self):
     def cumsum(x):
       def body(i, _):


### PR DESCRIPTION
The following command passes (for dynamic shapes testing), though two of the more interesting tests fail with what might be IREE bugs (and so are currently skipped):

```shell
JAX_PLATFORMS='iree' pytest -n auto tests/core_test.py tests/api_test.py -k Dynamic
```