### PR TITLE
make config.jax_platforms = 'cpu' suppress no-cpu warning

### DIFF
--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -261,9 +261,10 @@ def backends():
                        err)
           _backends_errors[platform] = str(err)
           continue
-    if _default_backend.platform == "cpu" and FLAGS.jax_platform_name != 'cpu':
-      logging.warning('No GPU/TPU found, falling back to CPU. '
-                      '(Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)')
+    if (_default_backend.platform == "cpu" and FLAGS.jax_platform_name != 'cpu'
+        and 'cpu' not in FLAGS.jax_platforms.split(',')):
+      warnings.warn('No GPU/TPU found, falling back to CPU. '
+                    '(Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)')
     return _backends
 
 

--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -205,13 +205,24 @@ class GetBackendTest(jtu.JaxTestCase):
         "Could not initialize backend 'none'"):
       xb.get_backend("none")
 
-  def cpu_fallback_warning(self):
+  def test_cpu_fallback_warning(self):
     with warnings.catch_warnings(record=True) as w:
       warnings.simplefilter("always")
       xb.get_backend()
       self.assertLen(w, 1)
       msg = str(w[-1].message)
       self.assertIn("No GPU/TPU found, falling back to CPU", msg)
+
+  def test_cpu_fallback_warning_suppression(self):
+    orig_jax_platforms = config._read("jax_platforms")
+    try:
+      config.FLAGS.jax_platforms = "cpu"
+      with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        xb.get_backend()
+        self.assertLen(w, 0)
+    finally:
+      config.FLAGS.jax_platforms = orig_jax_platforms
 
   def test_jax_platforms_flag(self):
     self._register_factory("platform_A", 20)


### PR DESCRIPTION
also:
* switch the warning to use `warnings.warn` rather than `absl.logging.warning`
* fix a test which wasn't being run because "test" wasn't in the method name (and it was failing at HEAD because it was using a test technique which only works with `warnings.warn` not `absl.logging.warning`)