### PR TITLE
Add in runtime tokens for effectful jaxprs

### DIFF
--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1053,8 +1053,9 @@ def lower_parallel_callable(
   tuple_args = should_tuple_args(shards)
   module_name = f"pmap_{fun.__name__}"
   with maybe_extend_axis_env(axis_name, global_axis_size, None):  # type: ignore
+    effects = list(closed_jaxpr.effects)
     module = mlir.lower_jaxpr_to_module(
-        module_name, closed_jaxpr, backend.platform, mlir.ReplicaAxisContext(axis_env),
+        module_name, closed_jaxpr, effects, backend.platform, mlir.ReplicaAxisContext(axis_env),
         name_stack, donated_invars, replicated_args=replicated_args,
         arg_shardings=_shardings_to_mlir_shardings(parts.arg_parts),
         result_shardings=_shardings_to_mlir_shardings(parts.out_parts))
@@ -2236,8 +2237,9 @@ def lower_mesh_computation(
   module: Union[str, xc.XlaComputation]
   module_name = f"{api_name}_{fun_name}"
   with core.extend_axis_env_nd(mesh.shape.items()):
+    effects = list(closed_jaxpr.effects)
     module = mlir.lower_jaxpr_to_module(
-        module_name, closed_jaxpr, backend.platform, axis_ctx, name_stack,
+        module_name, closed_jaxpr, effects, backend.platform, axis_ctx, name_stack,
         donated_invars, replicated_args=replicated_args,
         arg_shardings=in_partitions, result_shardings=out_partitions)
 

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -140,9 +140,11 @@ def _sharded_callable(
               fun.__name__, nparts, global_abstract_args)
 
   axis_env = xla.AxisEnv(nrep, (), ())
+  effects = list(jaxpr.effects)
   module = mlir.lower_jaxpr_to_module(
       "spjit_{}".format(fun.__name__),
       core.ClosedJaxpr(jaxpr, consts),
+      effects,
       platform=platform,
       axis_context=mlir.ReplicaAxisContext(axis_env),
       name_stack=new_name_stack(wrap_name(name, "sharded_jit")),


### PR DESCRIPTION
This PR adds runtime tokens for effectful jaxprs. 

We want to support enforcing ordering for side-effects in JAX. JAX can execute compiled functions asychronously (for performance reasons), which is usually okay to do when there are no side-effects present. However, when there are side-effects, they could potentially be reordered. Take the following example:
```python
@partial(jit, device=<device 0>)
def f():
  <something expensive>
  do_effect()

@partial(jit, device=<device 1>)
def g():
  do_effect()

f()
g()
```
If `f()` and `g()` are executed asynchronously (e.g. we are using GPUs), the effect in `g()` will probably happen before the effect in `f()` because these two functions are happening in parallel. The single-threaded Python programming model, however, would enforce that `f()` is finished before we start executing `g()`.

If users want that sort of ordering for effects (the order in the code matches the order of execution), we need to sequence `f()` and `g()` in the JAX runtime. We can accomplish this by first passing a dummy value into `f()` which is then returned and passed into `g()`, resulting in the following transformed code:
```python
@partial(jit, device=<device 0>)
def f(dummy):
  <something expensive>
  do_effect()
  return dummy

@partial(jit, device=<device 1>)
def g(dummy):
  do_effect()
  return dummy

dummy = <some dummy value>
dummy = f(dummy)
dummy = g(dummy)
```
Now, despite `f` and `g` executing asynchronously, we can't call `g()` until we receive the return dummy value of `f()`, forcing the two calls to be sequenced.

We may not want to do this for all side-effects though, since now we lose out on the performance gains from parallelism by sequencing `f()` and `g()`. Instead, we enable this behavior via an allow-list, `core.ordered_effects`. These dummy values will be automatically threaded in and out of functions that have side-effects in `core.ordered_effects`.

As part of this PR, each side-effect will be provided a different dummy value so functions with the same effects will be sequenced.

This sequencing is only within a single Python thread. If a user would like to run the same ordered effect in parallel, they can do so via Python threads.
