### PR TITLE
Fix some straggling name stack bugs

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -290,7 +290,7 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
   # pass long arg lists as tuple for TPU
   tuple_args = len(abstract_args) > 100
   axis_env = xla.AxisEnv(nreps, (), ())
-  name_stack = xla.new_name_stack(xla.wrap_name(name, 'jit'))
+  name_stack = util.new_name_stack(util.wrap_name(name, 'jit'))
   closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
   module_name = f"jit_{fun.__name__}"
   module = mlir.lower_jaxpr_to_module(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3389,7 +3389,7 @@ def _reduce_lower(ctx, *values, computation, jaxpr, consts, dimensions):
   ir_types = [mlir.aval_to_ir_type(aval) for aval in init_value_avals]
   reducer = op.regions[0].blocks.append(*(ir_types + ir_types))
   with ir.InsertionPoint(reducer):
-    reducer_ctx = ctx.module_context.replace(name_stack='')
+    reducer_ctx = ctx.module_context.replace(name_stack=util.new_name_stack())
     out_nodes = mlir.jaxpr_subcomp(reducer_ctx, jaxpr, consts,
                                    *([a] for a in reducer.arguments))
     mhlo.ReturnOp(util.flatten(out_nodes))

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1933,7 +1933,7 @@ def _scatter_lower(ctx, operand, indices, updates, *,
   scalar_type = mlir.aval_to_ir_type(core.ShapedArray((), aval_out.dtype))
   update = op.update_computation.blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(update):
-    update_ctx = ctx.module_context.replace(name_stack='')
+    update_ctx = ctx.module_context.replace(name_stack=util.new_name_stack())
     out_nodes = mlir.jaxpr_subcomp(
         update_ctx, update_jaxpr, update_consts,
         (update.arguments[0],), (update.arguments[1],))

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1407,7 +1407,7 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
   # translation rule just because the extra tuple stuff is a pain.
   sub_ctx = ctx.module_context.replace(
       name_stack=xla.extend_name_stack(ctx.module_context.name_stack,
-                                       xla.wrap_name(name, 'xmap')))
+                                       wrap_name(name, 'xmap')))
   tiled_outs = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr, (), *tiled_ins)
 
   outs = [
@@ -1472,7 +1472,7 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
   # translation rule just because the extra tuple stuff is a pain.
   sub_ctx = ctx.module_context.replace(
       name_stack=xla.extend_name_stack(ctx.module_context.name_stack,
-                                       xla.wrap_name(name, 'xmap')))
+                                       wrap_name(name, 'xmap')))
   global_out_nodes = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr, (),
                                         *sharded_global_in_nodes)
 
@@ -1520,7 +1520,7 @@ def _xmap_lowering_rule_spmd_manual(ctx, *global_in_nodes,
   assert isinstance(ctx.module_context.axis_context, mlir.SPMDAxisContext)
   sub_ctx = ctx.module_context.replace(
       name_stack=xla.extend_name_stack(ctx.module_context.name_stack,
-                                       xla.wrap_name(name, 'xmap')),
+                                       wrap_name(name, 'xmap')),
       axis_context=ctx.module_context.axis_context.extend_manual(manual_mesh_axes))
   global_out_nodes = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr, (),
                                         *([n] for n in global_in_nodes))

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -673,7 +673,7 @@ def lower_jaxpr_to_fun(
       else:
         args.append(arg)
     callee_name_stack = xla.extend_name_stack(ctx.name_stack,
-                                              xla.wrap_name(name, 'jit'))
+                                              util.wrap_name(name, 'jit'))
     out_vals = jaxpr_subcomp(ctx.replace(name_stack=callee_name_stack),
                              jaxpr.jaxpr, map(ir_constants, jaxpr.consts),
                              *args)
@@ -834,7 +834,7 @@ def _xla_call_lower(ctx, *args,
                     backend=None, name, call_jaxpr, donated_invars, inline=None,
                     device=None):
   del device, donated_invars, inline  # Ignored.
-  return _call_lowering(name, xla.wrap_name(name, "jit"), call_jaxpr,
+  return _call_lowering(name, util.wrap_name(name, "jit"), call_jaxpr,
                         backend, ctx.module_context, ctx.avals_in, ctx.avals_out,
                         *args)
 

--- a/tests/jax_to_ir_test.py
+++ b/tests/jax_to_ir_test.py
@@ -18,6 +18,7 @@ from absl.testing import absltest
 import jax.numpy as jnp
 from jax.tools import jax_to_ir
 from jax._src import test_util as jtu
+from jax.config import config
 
 try:
   import tensorflow as tf
@@ -89,9 +90,14 @@ class JaxToIRTest(absltest.TestCase):
     ])
 
     # Check that tf debug txt contains a broadcast, add, and multiply.
-    self.assertIn('name: "BroadcastTo"', tf_text)
-    self.assertIn('name: "AddV2"', tf_text)
-    self.assertIn('name: "Mul"', tf_text)
+    if config.jax_experimental_name_stack:
+      self.assertIn('BroadcastTo', tf_text)
+      self.assertIn('AddV2', tf_text)
+      self.assertIn('Mul', tf_text)
+    else:
+      self.assertIn('name: "BroadcastTo"', tf_text)
+      self.assertIn('name: "AddV2"', tf_text)
+      self.assertIn('name: "Mul"', tf_text)
 
     # Check that we can re-import our graphdef.
     gdef = tf.compat.v1.GraphDef()

--- a/tests/metadata_test.py
+++ b/tests/metadata_test.py
@@ -62,9 +62,14 @@ class MetadataTest(jtu.JaxTestCase):
     def foo(x):
       return jnp.sin(x)
     hlo = jax.xla_computation(jax.grad(foo))(1.).get_hlo_module().to_string()
-    self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/sin"')
-    self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/cos"')
-    self.assertRegex(hlo, 'op_name=".*jit\\(transpose\\(jvp\\(foo\\)\\)\\)/mul"')
+    if config.jax_experimental_name_stack:
+      self.assertRegex(hlo, 'op_name=".*jvp\\(jit\\(foo\\)\\)/sin"')
+      self.assertRegex(hlo, 'op_name=".*jvp\\(jit\\(foo\\)\\)/cos"')
+      self.assertRegex(hlo, 'op_name=".*transpose\\(jvp\\(jit\\(foo\\)\\)\\)/mul"')
+    else:
+      self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/sin"')
+      self.assertRegex(hlo, 'op_name=".*jit\\(jvp\\(foo\\)\\)/cos"')
+      self.assertRegex(hlo, 'op_name=".*jit\\(transpose\\(jvp\\(foo\\)\\)\\)/mul"')
 
   def test_cond_metadata(self):
     def true_fun(x):


### PR DESCRIPTION
This PR fixes some straggling name-stack issues. JAX tests will now all pass when name stack is enabled. What's left to do is fix non-JAX usages of the named-call primitive (e.g. Haiku's jaxpr-munging utilities)