### PR TITLE
2nd attempt at jax/jaxlib 0.3.7 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 ## jax 0.3.8 (Unreleased)
 * [GitHub
   commits](https://github.com/google/jax/compare/jax-v0.3.7...main).
-* Changes:
-  * The `DeviceArray.tile()` method is deprecated, because numpy arrays do not have a
-    `tile()` method. As a replacement for this, use {func}`jax.numpy.tile`
-    ({jax-issue}`#10266`).
 
 ## jax 0.3.7 (April 15, 2022)
 * [GitHub
@@ -26,8 +22,14 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * {func}`jax.scipy.special.expit` and {func}`jax.scipy.special.logit` now
     require their arguments to be scalars or JAX arrays. They also now promote
     integer arguments to floating point.
+  * The `DeviceArray.tile()` method is deprecated, because numpy arrays do not have a
+    `tile()` method. As a replacement for this, use {func}`jax.numpy.tile`
+    ({jax-issue}`#10266`).
 
 ## jaxlib 0.3.7 (April 15, 2202)
+* Changes:
+  * Linux wheels are now built conforming to the `manylinux2014` standard, instead
+    of `manylinux2010`.
 
 ## jax 0.3.6 (April 12, 2022)
 * [GitHub

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,10 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #    and update the sha256 with the result.
 http_archive(
     name = "org_tensorflow",
-    sha256 = "9f8bb53e42cd3994bbd2396065c4d8cd87602d596c0ac0fcfbb1bb40d6cc06cc",
-    strip_prefix = "tensorflow-e74ef072ecd54ca54f3940ce9b98af796ded2a1a",
+    sha256 = "ef5a001226c37f59eca9c9bf0506b962cf220906bcc8f24df4d1ed6011a593e9",
+    strip_prefix = "tensorflow-e011187e26dbeed80dede66eb48729d184e3bb1d",
     urls = [
-        "https://github.com/tensorflow/tensorflow/archive/e74ef072ecd54ca54f3940ce9b98af796ded2a1a.tar.gz",
+        "https://github.com/tensorflow/tensorflow/archive/e011187e26dbeed80dede66eb48729d184e3bb1d.tar.gz",
     ],
 )
 


### PR DESCRIPTION
The previous attempt had failing Mac builds, now fixed at TF head.