### PR TITLE
Remove CpuDevice from documentation index.

### DIFF
--- a/docs/jax.lib.rst
+++ b/docs/jax.lib.rst
@@ -35,6 +35,5 @@ jax.lib.xla_extension
    :toctree: _autosummary
 
    Device
-   CpuDevice
    GpuDevice
    TpuDevice


### PR DESCRIPTION
The corresponding class no longer exists.