### PR TITLE
Prevent negative output shapes in shape inference for reduce_window.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1511,7 +1511,11 @@ class DimensionHandler:
     return sz1 // sz2
 
   def stride(self, d: DimSize, window_size: DimSize, window_stride: DimSize) -> DimSize:
-    """(d - window_size) // window_stride + 1"""
+    """(d - window_size) // window_stride + 1.
+
+    If d == 0 or window_size > d, returns 0.
+    """
+    if d == 0 or window_size > d: return 0
     return (d - window_size) // window_stride + 1
 
   def dilate(self, d: DimSize, dilation: int) -> DimSize:

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -442,6 +442,7 @@ class DimensionHandlerPoly(core.DimensionHandler):
   def stride(self, d: DimSize, window_size: DimSize, window_stride: DimSize) -> DimSize:
     """Implements `(d - window_size) // window_stride + 1`"""
     try:
+      # TODO(necula): check for d == 0 or window_size > d and return 0.
       q, r = _ensure_poly(d - window_size).divmod(window_stride)
       return q + 1
     except InconclusiveDimensionOperation as e:

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1931,6 +1931,17 @@ class LaxTest(jtu.JaxTestCase):
     # to https://www.tensorflow.org/xla/operation_semantics#reducewindow.
     self.assertEqual(shape, result.shape)
 
+  def testReduceWindowWithEmptyOutput(self):
+    # https://github.com/google/jax/issues/10315
+    shape = (5, 3, 2)
+    operand, padding, strides = np.ones(shape), 'VALID', (1,) * len(shape)
+    out = jax.eval_shape(lambda x: lax.reduce_window(x, 0., lax.add, padding=padding,
+                         window_strides=strides,
+                         window_dimensions=(3, 1, 1),
+                         window_dilation=(3, 1, 1)), operand)
+    self.assertEqual((0, 3, 2), out.shape)
+
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_op={}_shape={}_axis={}_reverse={}"
        .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis,


### PR DESCRIPTION
The example in #10315 yields a negative shape in a jaxpr, which doesn't go well. Clamp the size of the output when the dilated window is larger than the input.

Fixes https://github.com/google/jax/issues/10315