### PR TITLE
Add quotes to install commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,10 +463,10 @@ version for jaxlib explicitly:
 pip install --upgrade pip
 
 # Installs the wheel compatible with Cuda >= 11.4 and cudnn >= 8.2
-pip install jax[cuda11_cudnn82] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install "jax[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
 
 # Installs the wheel compatible with Cuda >= 11.1 and cudnn >= 8.0.5
-pip install jax[cuda11_cudnn805] -f https://storage.googleapis.com/jax-releases/jax_releases.html
+pip install "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
 ```
 
 You can find your CUDA version with the command:


### PR DESCRIPTION
The commands in the README to install wheels compatible with specific versions of Cuda/cudnn are missing required quotation marks around the group name. This small fix adds those required quotation marks.