### PR TITLE
Add an optional mode= argument to jnp.take_along_axis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * `jax.experimental.maps.mesh` has been deleted.
     Please use `jax.experimental.maps.Mesh`. Please see https://jax.readthedocs.io/en/latest/_autosummary/jax.experimental.maps.Mesh.html#jax.experimental.maps.Mesh
     for more information.
+  * {func}`jax.numpy.take_along_axis` now takes an optional `mode` parameter
+    that specifies the behavior of out-of-bounds indexing.
 
 ## jaxlib 0.3.8 (Unreleased)
 * [GitHub

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4573,6 +4573,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     q1 = np.take_along_axis( h, g, axis=-1)
     np.testing.assert_equal(q0, q1)
 
+  def testTakeAlongAxisOutOfBounds(self):
+    x = jnp.arange(10, dtype=jnp.float32)
+    idx = jnp.array([-11, -10, -9, -5, -1, 0, 1, 5, 9, 10, 11])
+    out = jnp.take_along_axis(x, idx, axis=0)
+    expected_clip = np.array([0, 0, 1, 5, 9, 0, 1, 5, 9, 9, 9], np.float32)
+    np.testing.assert_array_equal(expected_clip, out)
+    out = jnp.take_along_axis(x, idx, axis=0, mode="clip")
+    np.testing.assert_array_equal(expected_clip, out)
+    expected_fill = np.array([jnp.nan, 0, 1, 5, 9, 0, 1, 5, 9, jnp.nan,
+                              jnp.nan], np.float32)
+    out = jnp.take_along_axis(x, idx, axis=0, mode="fill")
+    np.testing.assert_array_equal(expected_fill, out)
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_n={}_increasing={}".format(
           jtu.format_shape_dtype_string([shape], dtype),
@@ -6162,6 +6175,7 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'broadcast_to': ['arr'],
       'einsum': ['precision'],
       'einsum_path': ['subscripts'],
+      'take_along_axis': ['mode'],
     }
 
     mismatches = {}


### PR DESCRIPTION
This allows users of jnp.take_along_axis to override the out-of-bounds indexing behavior.
Default to "clip", which for the forward computation is identical to the current behavior. In a future change, we will change this to "fill".

https://github.com/google/jax/pull/10365 reverted the previous attempt to set the default gather mode to `fill` because it broke users. This option will allow users who want the current `clip` behavior to opt into it when we switch the default in a subsequent change.