### PR TITLE
Adds MLIR token lowering for effectful jaxprs

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -227,8 +227,6 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
                         "for jit in {elapsed_time} sec"):
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(
         fun, abstract_args, pe.debug_info_final(fun, "jit"), which_explicit)
-  if jaxpr.effects:
-    raise NotImplementedError('Lowering jaxprs with effects not supported.')
   if any(isinstance(c, core.Tracer) for c in consts):
     raise UnexpectedTracerError("Encountered an unexpected tracer.")
   # TODO(mattjj): handle argument pruning w/ dynamic shapes

--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1054,7 +1054,9 @@ def _lu_cpu_gpu_lowering(getrf_impl, ctx, operand):
   sub_ctx = mlir.LoweringRuleContext(module_context=ctx.module_context,
                                      primitive=None,
                                      avals_in=[pivot_aval],
-                                     avals_out=[perm_aval])
+                                     avals_out=[perm_aval],
+                                     tokens_in=ctx.tokens_in,
+                                     tokens_out=ctx.tokens_out)
   perm_fn = mlir.lower_fun(lambda x: lu_pivots_to_permutation(x, m),
                            multiple_results=False)
   perm, = perm_fn(sub_ctx, pivot)
@@ -1234,7 +1236,9 @@ def _qr_cpu_gpu_lowering(geqrf_impl, orgqr_impl, ctx, operand, *,
   sub_ctx = mlir.LoweringRuleContext(module_context=ctx.module_context,
                                      primitive=None,
                                      avals_in=[r_aval],
-                                     avals_out=[r_aval])
+                                     avals_out=[r_aval],
+                                     tokens_in=ctx.tokens_in,
+                                     tokens_out=ctx.tokens_out)
   r, = mlir.lower_fun(jnp.triu, multiple_results=False)(sub_ctx, r)
   return [q, r]
 

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -683,7 +683,9 @@ def _allreduce_lowering(prim, pos_fn, ctx, *args, axes, axis_index_groups):
           module_context=ctx.module_context,
           primitive=None,
           avals_in=[aval],
-          avals_out=[aval_out])
+          avals_out=[aval_out],
+          tokens_in=ctx.tokens_in,
+          tokens_out=ctx.tokens_out)
       out, = reducer(reducer_ctx, arg, axes=tuple(positional_axes))[0]
       return out
     args = map(_positional_reduce, ctx.avals_in, args)
@@ -702,7 +704,8 @@ def _allreduce_lowering(prim, pos_fn, ctx, *args, axes, axis_index_groups):
       lower_reducer = mlir.lower_fun(prim.bind, multiple_results=False)
       reducer_ctx = mlir.LoweringRuleContext(
         module_context = ctx.module_context,
-        primitive=None, avals_in=[scalar_aval] * 2, avals_out=[scalar_aval])
+        primitive=None, avals_in=[scalar_aval] * 2, avals_out=[scalar_aval],
+        tokens_in=ctx.tokens_in, tokens_out=ctx.tokens_out)
       out_nodes = lower_reducer(
           reducer_ctx, *([a] for a in reducer_block.arguments))
       mhlo.ReturnOp(util.flatten(out_nodes))
@@ -1267,7 +1270,8 @@ def _reduce_scatter_lowering(prim, reducer, ctx, x,
       lower_reducer = mlir.lower_fun(prim.bind, multiple_results=False)
       reducer_ctx = mlir.LoweringRuleContext(
         module_context = ctx.module_context,
-        primitive=None, avals_in=[scalar_aval] * 2, avals_out=[scalar_aval])
+        primitive=None, avals_in=[scalar_aval] * 2, avals_out=[scalar_aval],
+        tokens_in=ctx.tokens_in, tokens_out=ctx.tokens_out)
       out_nodes = lower_reducer(
           reducer_ctx, *([a] for a in reducer_block.arguments))
       mhlo.ReturnOp(util.flatten(out_nodes))

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1934,8 +1934,10 @@ def _scatter_lower(ctx, operand, indices, updates, *,
   update = op.update_computation.blocks.append(scalar_type, scalar_type)
   with ir.InsertionPoint(update):
     update_ctx = ctx.module_context.replace(name_stack=util.new_name_stack())
-    out_nodes = mlir.jaxpr_subcomp(
-        update_ctx, update_jaxpr, update_consts,
+    if update_jaxpr.effects:
+      raise NotImplementedError('Cannot lower effectful `scatter`.')
+    out_nodes, _ = mlir.jaxpr_subcomp(
+        update_ctx, update_jaxpr, mlir.TokenSet(), update_consts,
         (update.arguments[0],), (update.arguments[1],))
     mhlo.ReturnOp(util.flatten(out_nodes))
   return op.results

--- a/jax/core.py
+++ b/jax/core.py
@@ -59,6 +59,8 @@ Effects = Set[Effect]
 
 no_effects: Effects = set()
 
+ordered_effects: Set[Effect] = set()
+
 class Jaxpr:
   constvars: List[Var]
   invars: List[Var]

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -712,7 +712,7 @@ def _pjit_lowering(ctx, *args, name, jaxpr, in_axis_resources,
   # TODO(b/228598865): inlined calls cannot have shardings set directly on the
   # inputs or outputs because they are lost during MHLO->HLO conversion.
   # using_sharding_annotation=False means we add an identity operation instead.
-  func = mlir.lower_jaxpr_to_fun(sub_ctx, f"pjit_{name}", jaxpr,
+  func = mlir.lower_jaxpr_to_fun(sub_ctx, f"pjit_{name}", jaxpr, (),
                                  arg_shardings=arg_shardings,
                                  result_shardings=result_shardings,
                                  use_sharding_annotations=False)

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -825,7 +825,9 @@ def _bcoo_dot_general_gpu_lowering(
     sub_ctx = mlir.LoweringRuleContext(module_context=ctx.module_context,
                                        primitive=None,
                                        avals_in=ctx.avals_in[:2],
-                                       avals_out=ctx.avals_in[:2])
+                                       avals_out=ctx.avals_in[:2],
+                                       tokens_in=ctx.tokens_in,
+                                       tokens_out=ctx.tokens_out)
 
     (lhs_data,), (lhs_indices,) = _bcoo_sort_indices_mhlo(
         sub_ctx, lhs_data, lhs_indices, spinfo=lhs_spinfo)

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -1699,8 +1699,8 @@ def _pmap_lowering(ctx, *in_nodes, axis_name,
         axis_context=mlir.ReplicaAxisContext(new_env),
         name_stack=xla.extend_name_stack(ctx.module_context.name_stack,
                                          util.wrap_name(name, 'pmap')))
-    sharded_outs = mlir.jaxpr_subcomp(sub_ctx, call_jaxpr, (),
-                                      *in_nodes_sharded)
+    sharded_outs, _ = mlir.jaxpr_subcomp(sub_ctx, call_jaxpr, mlir.TokenSet(), (),
+                                         *in_nodes_sharded)
   out_avals = [v.aval for v in call_jaxpr.outvars]
   outs = [_mhlo_unshard(aval, new_env, out_axis, shard,
                         platform=ctx.module_context.platform)

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -203,7 +203,8 @@ def _sharded_jit_lowering(ctx, *in_nodes,
   sub_ctx = ctx.module_context.replace(
       name_stack=new_name_stack(wrap_name(name, "sharded_jit")))
   fn = mlir.lower_jaxpr_to_fun(sub_ctx, f"sharded_jit_{name}",
-                               core.ClosedJaxpr(call_jaxpr, ()))
+                               core.ClosedJaxpr(call_jaxpr, ()),
+                               ())
 
   output_types = safe_map(mlir.aval_to_ir_types, ctx.avals_out)
   flat_output_types = util.flatten(output_types)


### PR DESCRIPTION
This PR enables lowering effectful jaxprs in a limited capacity. Specifically, the effects in the jaxpr have to be "lowerable" by adding them to the `mlir.lowerable_effects` allowlist. 

For effects that are in `core.ordered_effects`, we enable threading MLIR tokens to sequence the effects. We do this by creating an `mlir.TokenSet` that will be passed in and out of lowering rules.