### PR TITLE
DOC: lax.linalg.eigh

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -106,13 +106,14 @@ def eigh(x, lower: bool = True, symmetrize_input: bool = True):
       eigendecomposition by computing :math:`\\frac{1}{2}(x + x^H)`.
 
   Returns:
-    A tuple ``(w, v)``.
+    A tuple ``(v, w)``.
 
-    ``w`` is an array with the same dtype as ``x`` such that ``w[..., :, i]`` is
-    the eigenvector corresponding to ``v[..., i]``.
+    ``v`` is an array with the same dtype as ``x`` such that ``v[..., :, i]`` is
+    the normalized eigenvector corresponding to eigenvalue ``w[..., i]``.
 
-    ``v`` is an array with the same dtype as ``x`` (or its real counterpart if
-    complex) with shape ``[..., n]`` containing the eigenvalues of ``x``.
+    ``w`` is an array with the same dtype as ``x`` (or its real counterpart if
+    complex) with shape ``[..., n]`` containing the eigenvalues of ``x`` in
+    ascending order(each repeated according to its multiplicity).
   """
   if symmetrize_input:
     x = symmetrize(x)


### PR DESCRIPTION
Fix the inconsistency of variable name between docstring and source code. Also have the same naming convention as `numpy`, i.e. `w` refer to eigenvalues.
Also add some detailed description for eigenvectors and eigenvalues.
Inspired by #5504, but #5504 use different naming convention to `numpy` and is a breaking change.
