### PR TITLE
Improve performance of array integer indexing

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3535,7 +3535,6 @@ def _rewriting_take(arr, idx, indices_are_sorted=False, unique_indices=False,
   # Computes arr[idx].
   # All supported cases of indexing can be implemented as an XLA gather,
   # followed by an optional reverse and broadcast_in_dim.
-  arr = asarray(arr)
 
   # TODO(mattjj,dougalm): expand dynamic shape indexing support
   if (jax.config.jax_dynamic_shapes and type(idx) is slice and idx.step is None
@@ -3555,7 +3554,7 @@ def _rewriting_take(arr, idx, indices_are_sorted=False, unique_indices=False,
 def _gather(arr, treedef, static_idx, dynamic_idx, indices_are_sorted,
             unique_indices, mode, fill_value):
   idx = _merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx)
-  indexer = _index_to_gather(shape(arr), idx)  # shared with _scatter_update
+  indexer = _index_to_gather(arr.shape, idx)  # shared with _scatter_update
   y = arr
 
   if fill_value is not None:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3657,8 +3657,8 @@ def _merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx):
 def _is_basic_int_index(x):
   if isinstance(x, core.Tracer):
     aval = x.aval
-    return (isinstance(aval, (ConcreteArray, ShapedArray)) and
-            not aval.shape and issubdtype(aval.dtype, integer))
+    return (isinstance(aval, ShapedArray) and not aval.shape
+            and issubdtype(aval.dtype, integer))
   try:
     operator.index(x)
   except TypeError:

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3664,7 +3664,7 @@ def _is_basic_int_index(x):
   except TypeError:
     return False
   else:
-    return not isinstance(x, bool)
+    return not isinstance(x, (bool, np.bool_))
 
 def _index_to_gather(x_shape, idx, normalize_indices=True):
   # Remove ellipses and add trailing slice(None)s.

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3584,7 +3584,10 @@ def _gather(arr, treedef, static_idx, dynamic_idx, indices_are_sorted,
     y = lax.rev(y, indexer.reversed_y_dims)
 
   # This adds np.newaxis/None dimensions.
-  return expand_dims(y, indexer.newaxis_dims)
+  if indexer.newaxis_dims:
+    y = lax.expand_dims(y, indexer.newaxis_dims)
+
+  return y
 
 _Indexer = collections.namedtuple("_Indexer", [
   # The expected shape of the slice output.

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -873,9 +873,10 @@ class IndexingTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       {"testcase_name": f"_{idx_type_name}_{idx}", "idx": idx, "idx_type": idx_type}
-      for idx in (-3, 0, 5)
+      for idx in (-3, 5)
       for idx_type_name, idx_type in (
-        ("int", int), ("np.array", np.array), ("jnp.array", jnp.array)))
+        ("int", int), ("np.array", np.array), ("jnp.array", jnp.array),
+        ("slice_up_to", slice), ("slice_from", lambda s: slice(s, None))))
   def testConstantIndexing(self, idx, idx_type):
     x = jnp.arange(10)
     idx = idx_type(idx)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -871,6 +871,18 @@ class IndexingTest(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(lambda x: x[:4])(np.arange(4))
     self.assertEqual(len(jaxpr.jaxpr.eqns), 0)
 
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{idx_type_name}_{idx}", "idx": idx, "idx_type": idx_type}
+      for idx in (-3, 0, 5)
+      for idx_type_name, idx_type in (
+        ("int", int), ("np.array", np.array), ("jnp.array", jnp.array)))
+  def testConstantIndexing(self, idx, idx_type):
+    x = jnp.arange(10)
+    idx = idx_type(idx)
+    jaxpr = jax.make_jaxpr(lambda: x[idx])()
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
+    self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.gather_p)
+
   def testIndexingEmptyDimension(self):
     # Issue 2671: XLA error when indexing into dimension of size 0
     x = jnp.ones((2, 0))


### PR DESCRIPTION
This PR tries to improve performance of array integer indexing as a first step towards addressing #2878.

Since it seems like using `jit` as suggested in #2891 is difficult I've limited this PR to the case of indexing using a single Python integer outside of `jit` to keep the diff somewhat manageable. Some of the changes should also benefit other cases.

I split the PR into multiple commits that are best reviewed one by one. Also please let me know if these changes would prevent future planned optimisation that I am not aware of. If so I'm happy to close this, or split out some of the optimisation into separate PR's.

## Changes
- 09134b36bd0a3a6fc10609b8a7a28d93c69b2e93 prevents the conversion of Python integers to DeviceArrays and uses plain Python code in favour of `lax` operations for index normalisation when possible. This moves the scalar index computations to the CPU instead of running on an accelerator. I currently can't easily measure the performance impact of this but for me this seems to be preferred for statically known indices.
- 75a092e027b26bcecf832c8cbfe088e98ec8c08d prevents unnecessary calls to `lax.expand_dims`
- b8d70d31a5187c3c4cf72743b3f96a9026627904 removes explicit conversion using `asarray`
- cf8e8ed46062fce095ce76b001626a4d3c248a3f and 19ac51e10339c465f7c40ea3b9acb966320c07a0 remove expensive calls to `core.get_aval` to speedup checks

## Latency impact

I've measured indexing performance using a simple toy example on CPU:
```python
from jax import numpy as jnp

a = jnp.arange(4000)
a[5]
%timeit a[6].block_until_ready()
```

This PR improves performance by a factor of **4.8x**. Jax is still a lot slower than plain numpy but this already seems like a decent improvement.

| commit                                   |   time | reduction |
| ---------------------------------------- | -----: | --------: |
| 88ac4edf63625db10f92d5368a598205aac1deb4 (main baseline) | 468 µs |           |
| 09134b36bd0a3a6fc10609b8a7a28d93c69b2e93 | 225 µs | - 52 %    |
| 75a092e027b26bcecf832c8cbfe088e98ec8c08d | 168 µs | - 25 %    |
| b8d70d31a5187c3c4cf72743b3f96a9026627904 | 143 µs | - 15 %    |
| cf8e8ed46062fce095ce76b001626a4d3c248a3f | 125 µs | - 13 %    |
| 19ac51e10339c465f7c40ea3b9acb966320c07a0 |  98 µs | - 22 %    |
