### PR TITLE
prefer operator.index over int

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -205,8 +205,8 @@ def fori_loop(lower, upper, body_fun, init_val):
   if (isinstance(core.get_aval(lower), ConcreteArray) and
       isinstance(core.get_aval(upper), ConcreteArray)):
     try:
-      lower_ = int(lower)
-      upper_ = int(upper)
+      lower_ = operator.index(lower)
+      upper_ = operator.index(upper)
     except TypeError:
       use_scan = False
     else:
@@ -1382,7 +1382,7 @@ def scan(f: Callable[[Carry, X], Tuple[Carry, Y]],
                            if not hasattr(x, 'shape')))) from err
 
   if length is not None:
-    length = int(length)
+    length = operator.index(length)
     if not all(length == l for l in lengths):
       msg = ("scan got `length` argument of {} which disagrees with "
              "leading axis sizes {}.")

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1062,7 +1062,7 @@ def sort_key_val(keys: Array, values: Array, dimension: int = -1,
 
 def top_k(operand: Array, k: int) -> Tuple[Array, Array]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``."""
-  k = int(k)
+  k = operator.index(k)
   if k < 0:
     raise ValueError("k argument to top_k must be nonnegative, got {}".format(k))
   return top_k_p.bind(operand, k=k)
@@ -1118,7 +1118,7 @@ def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
 
 def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
   """Like numpy.eye, create a 2D array with ones on a diagonal."""
-  offset = int(offset)
+  offset = operator.index(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
   bool_eye = eq(add(broadcasted_iota(np.int32, shape, 0), np.int32(offset)),
                 broadcasted_iota(np.int32, shape, 1))
@@ -1138,7 +1138,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
 
 def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
   """Like numpy.tri, create a 2D array with ones below a diagonal."""
-  offset = int(offset)
+  offset = operator.index(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
   bool_tri = ge(add(broadcasted_iota(np.int32, shape, 0), np.int32(offset)),
                 broadcasted_iota(np.int32, shape, 1))
@@ -1340,7 +1340,7 @@ def _iter(tracer):
   if tracer.ndim == 0:
     raise TypeError("iteration over a 0-d array")  # same as numpy error
   else:
-    n = int(tracer.shape[0])
+    n = operator.index(tracer.shape[0])
     # return (index_in_dim(tracer, i, keepdims=False) for i in range(n))
     return iter([slicing.index_in_dim(tracer, i, keepdims=False)
                  for i in range(n)])
@@ -2464,7 +2464,7 @@ def _dot_general_batch_dim_nums(ndims, batch_dims, dimension_numbers):
       rhs_contract = bump_dims(rhs_contract, rbd)
 
   new_dimension_numbers = ((lhs_contract, rhs_contract), (lhs_batch, rhs_batch))
-  return new_dimension_numbers, int(result_batch_dim)
+  return new_dimension_numbers, operator.index(result_batch_dim)
 
 def _dot_general_masking_rule(padded_vals, logical_shapes, *, dimension_numbers,
                               precision,

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -14,6 +14,7 @@
 
 import enum
 from functools import partial
+import operator
 from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
 import weakref
 
@@ -642,10 +643,10 @@ def slice_in_dim(operand: Array, start_index: Optional[int],
   if limit_index_int < 0:
     limit_index_int = limit_index_int + len_axis
 
-  axis = int(axis)
+  axis = operator.index(axis)
   start_indices[axis] = start_index_int
   limit_indices[axis] = limit_index_int
-  strides[axis] = int(stride)
+  strides[axis] = operator.index(stride)
 
   return slice(operand, start_indices, limit_indices, strides)
 
@@ -653,7 +654,7 @@ def slice_in_dim(operand: Array, start_index: Optional[int],
 def index_in_dim(operand: Array, index: int, axis: int = 0,
                  keepdims: bool = True) -> Array:
   """Convenience wrapper around slice to perform int indexing."""
-  index, axis = core._canonicalize_dimension(index), int(axis)
+  index, axis = core._canonicalize_dimension(index), operator.index(axis)
   axis_size = operand.shape[axis]
   wrapped_index = index + axis_size if index < 0 else index
   if not 0 <= wrapped_index < axis_size:
@@ -672,7 +673,7 @@ def dynamic_slice_in_dim(operand: Array, start_index: Array,
   start_indices = [lax._zero(start_index)] * operand.ndim
   slice_sizes = list(operand.shape)
 
-  axis = int(axis)
+  axis = operator.index(axis)
   start_indices[axis] = start_index
   slice_sizes[axis] = core._canonicalize_dimension(slice_size)
   return dynamic_slice(operand, start_indices, slice_sizes)
@@ -693,7 +694,7 @@ def dynamic_update_slice_in_dim(operand: Array, update: Array,
   """Convenience wrapper around :func:`dynamic_update_slice` to update a slice
      in a single ``axis``.
   """
-  axis = int(axis)
+  axis = operator.index(axis)
   start_indices = [lax._zero(start_index)] * lax._ndim(operand)
   start_indices[axis] = start_index
   return dynamic_update_slice(operand, update, start_indices)
@@ -704,7 +705,7 @@ def dynamic_update_index_in_dim(operand: Array, update: Array, index: Array,
   """Convenience wrapper around :func:`dynamic_update_slice` to update a slice
      of size 1 in a single ``axis``.
   """
-  axis = int(axis)
+  axis = operator.index(axis)
   if lax._ndim(update) != lax._ndim(operand):
     assert lax._ndim(update) + 1 == lax._ndim(operand)
     update = lax.expand_dims(update, (axis,))

--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -18,6 +18,7 @@ used in Keras and Sonnet.
 """
 
 
+import operator
 from typing import Any, Callable, Sequence, Union
 
 import numpy as np
@@ -129,15 +130,15 @@ def _compute_fans(shape: core.NamedShape, in_axis=-2, out_axis=-1,
   if isinstance(in_axis, int):
     in_size = shape[in_axis]
   else:
-    in_size = int(np.prod([shape[i] for i in in_axis]))
+    in_size = operator.index(prod(shape[i] for i in in_axis))
   if isinstance(out_axis, int):
     out_size = shape[out_axis]
   else:
-    out_size = int(np.prod([shape[i] for i in out_axis]))
+    out_size = operator.index(prod(shape[i] for i in out_axis))
   if isinstance(batch_axis, int):
     batch_size = shape[batch_axis]
   else:
-    batch_size = int(np.prod([shape[i] for i in batch_axis]))
+    batch_size = operator.index(prod(shape[i] for i in batch_axis))
   receptive_field_size = shape.total / in_size / out_size / batch_size
   fan_in = in_size * receptive_field_size
   fan_out = out_size * receptive_field_size

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -774,7 +774,7 @@ def ravel(a, order="C"):
 @_wraps(np.ravel_multi_index)
 def ravel_multi_index(multi_index, dims, mode='raise', order='C'):
   assert len(multi_index) == len(dims), f"len(multi_index)={len(multi_index)} != len(dims)={len(dims)}"
-  dims = tuple(core.concrete_or_error(int, d, "in `dims` argument of ravel_multi_index().") for d in dims)
+  dims = tuple(core.concrete_or_error(operator.index, d, "in `dims` argument of ravel_multi_index().") for d in dims)
   _check_arraylike("ravel_multi_index", *multi_index)
   for index in multi_index:
     if mode == 'raise':
@@ -1057,7 +1057,7 @@ The JAX version does not necessarily return a view of the input.
 def _split(op, ary, indices_or_sections, axis=0):
   _check_arraylike(op, ary)
   ary = asarray(ary)
-  axis = core.concrete_or_error(int, axis, f"in jax.numpy.{op} argument `axis`")
+  axis = core.concrete_or_error(operator.index, axis, f"in jax.numpy.{op} argument `axis`")
   size = ary.shape[axis]
   if isinstance(indices_or_sections, (tuple, list)):
     indices_or_sections = np.array(
@@ -1216,7 +1216,7 @@ def nonzero(a, *, size=None, fill_value=None):
   mask = a != 0
   if size is None:
     size = mask.sum()
-  size = core.concrete_or_error(int, size,
+  size = core.concrete_or_error(operator.index, size,
     "The size argument of jnp.nonzero must be statically specified "
     "to use jnp.nonzero within JAX transformations.")
   if a.size == 0 or size == 0:
@@ -2097,8 +2097,7 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
              axis: int = 0):
   num = core.concrete_or_error(operator.index, num, "'num' argument of jnp.linspace")
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.linspace")
-  return _linspace(start, stop, int(num), endpoint, retstep, dtype,
-                   operator.index(axis))
+  return _linspace(start, stop, num, endpoint, retstep, dtype, axis)
 
 @partial(jit, static_argnames=('num', 'endpoint', 'retstep', 'dtype', 'axis'))
 def _linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
@@ -2160,8 +2159,7 @@ def logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
              axis: int = 0):
   num = core.concrete_or_error(operator.index, num, "'num' argument of jnp.logspace")
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.logspace")
-  return _logspace(start, stop, int(num), endpoint, base, dtype,
-                   operator.index(axis))
+  return _logspace(start, stop, num, endpoint, base, dtype, axis)
 
 @partial(jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
 def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
@@ -2184,8 +2182,7 @@ def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
 def geomspace(start, stop, num=50, endpoint=True, dtype=None, axis: int = 0):
   num = core.concrete_or_error(operator.index, num, "'num' argument of jnp.geomspace")
   axis = core.concrete_or_error(operator.index, axis, "'axis' argument of jnp.geomspace")
-  return _geomspace(start, stop, int(num), endpoint, dtype,
-                    operator.index(axis))
+  return _geomspace(start, stop, num, endpoint, dtype, axis)
 
 @partial(jit, static_argnames=('num', 'endpoint', 'dtype', 'axis'))
 def _geomspace(start, stop, num=50, endpoint=True, dtype=None, axis: int = 0):
@@ -2267,7 +2264,7 @@ def ix_(*args):
 @_wraps(np.indices)
 def indices(dimensions, dtype=int32, sparse=False):
   dimensions = tuple(
-      core.concrete_or_error(int, d, "dimensions argument of jnp.indices")
+      core.concrete_or_error(operator.index, d, "dimensions argument of jnp.indices")
       for d in dimensions)
   N = len(dimensions)
   output = []
@@ -2486,7 +2483,7 @@ def diagonal(a, offset=0, axis1: int = 0, axis2: int = 1):
 
 @_wraps(np.diag, lax_description=_ARRAY_VIEW_DOC)
 def diag(v, k=0):
-  return _diag(v, int(k))
+  return _diag(v, operator.index(k))
 
 @partial(jit, static_argnames=('k',))
 def _diag(v, k):

--- a/jax/_src/numpy/polynomial.py
+++ b/jax/_src/numpy/polynomial.py
@@ -109,7 +109,7 @@ Also, it works best on rcond <= 10e-3 values.
 @partial(jit, static_argnames=('deg', 'rcond', 'full', 'cov'))
 def polyfit(x, y, deg, rcond=None, full=False, w=None, cov=False):
   _check_arraylike("polyfit", x, y)
-  deg = core.concrete_or_error(int, deg, "deg must be int")
+  deg = core.concrete_or_error(operator.index, deg, "deg must be int")
   order = deg + 1
   # check arguments
   if deg < 0:

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -15,6 +15,7 @@
 # Helpers for indexed updates.
 
 import sys
+import operator
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -154,7 +155,7 @@ def _segment_update(name: str,
   dtype = data.dtype
   if num_segments is None:
     num_segments = jnp.max(segment_ids) + 1
-  num_segments = core.concrete_or_error(int, num_segments, "segment_sum() `num_segments` argument.")
+  num_segments = core.concrete_or_error(operator.index, num_segments, "segment_sum() `num_segments` argument.")
   if num_segments is not None and num_segments < 0:
     raise ValueError("num_segments must be non-negative.")
 

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -14,6 +14,7 @@
 
 
 from functools import partial
+import operator
 from typing import Callable, Iterator, NamedTuple, Sequence
 import warnings
 
@@ -454,7 +455,7 @@ def threefry_2x32(keypair, count):
 
 
 def threefry_split(key: jnp.ndarray, num: int) -> jnp.ndarray:
-  return _threefry_split(key, int(num))  # type: ignore
+  return _threefry_split(key, operator.index(num))  # type: ignore
 
 @partial(jit, static_argnums=(1,), inline=True)
 def _threefry_split(key, num) -> jnp.ndarray:

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -14,6 +14,7 @@
 
 
 from functools import partial
+import operator
 from typing import Any, Optional, Sequence, Union
 import warnings
 
@@ -396,7 +397,7 @@ def permutation(key: KeyArray,
   if not np.ndim(x):
     if not np.issubdtype(lax.dtype(x), np.integer):
       raise TypeError("x must be an integer or at least 1-dimensional")
-    r = core.concrete_or_error(int, x, 'argument x of jax.random.permutation()')
+    r = core.concrete_or_error(operator.index, x, 'argument x of jax.random.permutation()')
     return _shuffle(key, jnp.arange(r), axis)
   if independent or np.ndim(x) == 1:
     return _shuffle(key, x, axis)
@@ -470,11 +471,11 @@ def choice(key: KeyArray,
                     f"got {shape}")
   _check_arraylike("choice", a)
   if np.ndim(a) == 0:
-    a = core.concrete_or_error(int, a, "The error occurred in jax.random.choice()")
+    a = core.concrete_or_error(operator.index, a, "The error occurred in jax.random.choice()")
   else:
     a = jnp.asarray(a)
   axis = canonicalize_axis(axis, np.ndim(a) or 1)
-  n_inputs = int(a) if np.ndim(a) == 0 else a.shape[axis]  # type: ignore[arg-type]
+  n_inputs = operator.index(a) if np.ndim(a) == 0 else a.shape[axis]  # type: ignore[arg-type]
   n_draws = prod(shape)
   if n_draws == 0:
     return jnp.zeros(shape, dtype=lax.dtype(a))

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -257,7 +257,7 @@ def _spectral_helper(x, y,
   axis = canonicalize_axis(axis, x.ndim)
 
   if nperseg is not None:  # if specified by user
-    nperseg = jax.core.concrete_or_error(int, nperseg,
+    nperseg = jax.core.concrete_or_error(operator.index, nperseg,
                                          "nperseg of windowed-FFT")
     if nperseg < 1:
       raise ValueError('nperseg must be a positive integer')
@@ -268,12 +268,12 @@ def _spectral_helper(x, y,
   if noverlap is None:
     noverlap = nperseg // 2
   else:
-    noverlap = jax.core.concrete_or_error(int, noverlap,
+    noverlap = jax.core.concrete_or_error(operator.index, noverlap,
                                           "noverlap of windowed-FFT")
   if nfft is None:
     nfft = nperseg
   else:
-    nfft = jax.core.concrete_or_error(int, nfft,
+    nfft = jax.core.concrete_or_error(operator.index, nfft,
                                       "nfft of windowed-FFT")
 
   _check_arraylike("_spectral_helper", x)
@@ -506,7 +506,7 @@ def _overlap_and_add(x, step_size):
     An array with `(..., output_size)`-shape containing overlapped signal.
   """
   _check_arraylike("_overlap_and_add", x)
-  step_size = jax.core.concrete_or_error(int, step_size,
+  step_size = jax.core.concrete_or_error(operator.index, step_size,
                                         "step_size for overlap_and_add")
   if x.ndim < 2:
     raise ValueError('Input must have (..., frames, frame_length) shape.')
@@ -560,7 +560,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
   n_default = (2 * (Zxx.shape[freq_axis] - 1) if input_onesided
                else Zxx.shape[freq_axis])
 
-  nperseg = jax.core.concrete_or_error(int, nperseg or n_default,
+  nperseg = jax.core.concrete_or_error(operator.index, nperseg or n_default,
                                        "nperseg: segment length of STFT")
   if nperseg < 1:
     raise ValueError('nperseg must be a positive integer')
@@ -570,12 +570,12 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if input_onesided and nperseg == n_default + 1:
       nfft += 1  # Odd nperseg, no FFT padding
   else:
-    nfft = jax.core.concrete_or_error(int, nfft, "nfft of STFT")
+    nfft = jax.core.concrete_or_error(operator.index, nfft, "nfft of STFT")
   if nfft < nperseg:
     raise ValueError(
         f'FFT length ({nfft}) must be longer than nperseg ({nperseg}).')
 
-  noverlap = jax.core.concrete_or_error(int, noverlap or nperseg // 2,
+  noverlap = jax.core.concrete_or_error(operator.index, noverlap or nperseg // 2,
                                         "noverlap of STFT")
   if noverlap >= nperseg:
     raise ValueError('noverlap must be less than nperseg.')

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from functools import partial
+import operator
 
 import numpy as np
 import scipy.special as osp_special
@@ -172,7 +173,7 @@ def entr(x):
 
 @_wraps(osp_special.multigammaln, update_doc=False)
 def multigammaln(a, d):
-  d = core.concrete_or_error(int, d, "d argument of multigammaln")
+  d = core.concrete_or_error(operator.index, d, "d argument of multigammaln")
   a, d_ = _promote_args_inexact("multigammaln", a, d)
 
   constant = lax.mul(lax.mul(lax.mul(_lax_const(a, 0.25), d_),
@@ -950,8 +951,8 @@ def lpmn(m: int, n: int, z: jnp.ndarray) -> Tuple[jnp.ndarray, jnp.ndarray]:
   if z.ndim != 1:
     raise ValueError('z must be a 1D array.')
 
-  m = core.concrete_or_error(int, m, 'Argument m of lpmn.')
-  n = core.concrete_or_error(int, n, 'Argument n of lpmn.')
+  m = core.concrete_or_error(operator.index, m, 'Argument m of lpmn.')
+  n = core.concrete_or_error(operator.index, n, 'Argument n of lpmn.')
 
   if m != n:
     raise NotImplementedError('Computations for m!=n are not yet supported.')
@@ -1007,8 +1008,8 @@ def lpmn_values(m: int, n: int, z: jnp.ndarray, is_normalized: bool) -> jnp.ndar
   if z.ndim != 1:
     raise ValueError('z must be a 1D array.')
 
-  m = core.concrete_or_error(int, m, 'Argument m of lpmn.')
-  n = core.concrete_or_error(int, n, 'Argument n of lpmn.')
+  m = core.concrete_or_error(operator.index, m, 'Argument m of lpmn.')
+  n = core.concrete_or_error(operator.index, n, 'Argument n of lpmn.')
 
   if m != n:
     raise NotImplementedError('Computations for m!=n are not yet supported.')

--- a/jax/core.py
+++ b/jax/core.py
@@ -1676,8 +1676,7 @@ def canonicalize_shape(shape: Shape, context: str="") -> Shape:
   try:
     return tuple(unsafe_map(_canonicalize_dimension, shape))
   except TypeError:
-    pass
-  raise _invalid_shape_error(shape, context)
+    raise _invalid_shape_error(shape, context)
 
 def canonicalize_dim(d: DimSize, context: str="") -> DimSize:
   """Canonicalizes and checks for errors in a user-provided shape dimension value.

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -641,7 +641,7 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
   operand, = batched_args
   bdim, = batch_dims
   axes = tuple(np.where(np.less(axes, bdim), axes, np.add(axes, 1)))
-  bdim_out = int(list(np.delete(np.arange(operand.ndim), axes)).index(bdim))
+  bdim_out = list(np.delete(np.arange(operand.ndim), axes)).index(bdim)
   if 'input_shape' in params:
     params = dict(params, input_shape=operand.shape)
   return prim.bind(operand, axes=axes, **params), bdim_out


### PR DESCRIPTION
`int` allows `float`, while `operator.index` doesn't
```python
int(1.1)
int(np.float32(1.1))
```
I can't understand `interpreters.masking` so I don't change it.
Breaking change:
`int` allows class with `__index__` and `__int__`, while `operator.index` only allows `__index__`.
Let's see if this break anything.