### PR TITLE
Some Simplification

### DIFF
--- a/jax/_src/nn/initializers.py
+++ b/jax/_src/nn/initializers.py
@@ -129,15 +129,15 @@ def _compute_fans(shape: core.NamedShape, in_axis=-2, out_axis=-1,
   if isinstance(in_axis, int):
     in_size = shape[in_axis]
   else:
-    in_size = int(np.prod([shape[i] for i in in_axis]))
+    in_size = prod(shape[i] for i in in_axis)
   if isinstance(out_axis, int):
     out_size = shape[out_axis]
   else:
-    out_size = int(np.prod([shape[i] for i in out_axis]))
+    out_size = prod(shape[i] for i in out_axis)
   if isinstance(batch_axis, int):
     batch_size = shape[batch_axis]
   else:
-    batch_size = int(np.prod([shape[i] for i in batch_axis]))
+    batch_size = prod(shape[i] for i in batch_axis)
   receptive_field_size = shape.total / in_size / out_size / batch_size
   fan_in = in_size * receptive_field_size
   fan_out = out_size * receptive_field_size

--- a/jax/core.py
+++ b/jax/core.py
@@ -1676,8 +1676,7 @@ def canonicalize_shape(shape: Shape, context: str="") -> Shape:
   try:
     return tuple(unsafe_map(_canonicalize_dimension, shape))
   except TypeError:
-    pass
-  raise _invalid_shape_error(shape, context)
+    raise _invalid_shape_error(shape, context)
 
 def canonicalize_dim(d: DimSize, context: str="") -> DimSize:
   """Canonicalizes and checks for errors in a user-provided shape dimension value.

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -641,7 +641,7 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
   operand, = batched_args
   bdim, = batch_dims
   axes = tuple(np.where(np.less(axes, bdim), axes, np.add(axes, 1)))
-  bdim_out = int(list(np.delete(np.arange(operand.ndim), axes)).index(bdim))
+  bdim_out = list(np.delete(np.arange(operand.ndim), axes)).index(bdim)
   if 'input_shape' in params:
     params = dict(params, input_shape=operand.shape)
   return prim.bind(operand, axes=axes, **params), bdim_out


### PR DESCRIPTION
`list.index` already return `int`
`prod` is faster than `np.prod` in most cases, and `np.prod([])` returns `1.0` of type `np.float64`.