### PR TITLE
Fix typo in _scatter_add_lower_gpu

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1965,7 +1965,7 @@ def _scatter_add_lower_gpu(ctx, operand, indices, updates,
 
   if mode == GatherScatterMode.CLIP:
     clip_fn = mlir.lower_fun(_clamp_scatter_indices, multiple_results=False)
-    (indices,), = clip_fn(ctx, ctx.avals_in, None, operand, indices, updates,
+    (indices,), = clip_fn(ctx.replace(avals_out=None), operand, indices, updates,
                           dnums=dimension_numbers)
 
   aval_out, = ctx.avals_out

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2272,11 +2272,11 @@ class LaxTest(jtu.JaxTestCase):
       lax.gather(operand, indices, dimension_numbers, slice_sizes)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}".format(
+      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}_mode={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums),
+          idxs, update_shape, dnums, mode),
        "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums}
+       "update_shape": update_shape, "dnums": dnums, "mode": mode}
       for dtype in inexact_dtypes
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
@@ -2288,14 +2288,15 @@ class LaxTest(jtu.JaxTestCase):
           ((10, 5,), np.array([[0], [2], [1]]), (3, 3), lax.ScatterDimensionNumbers(
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
-      ]))
-  def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums):
+      ]
+      for mode in ["clip", "fill", None]))
+  def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums, mode):
     rng = jtu.rand_default(self.rng())
     rng_idx = jtu.rand_int(self.rng(), high=max(arg_shape))
     rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
     args_maker = lambda: [rng(arg_shape, dtype), rand_idxs(),
                           rng(update_shape, dtype)]
-    fun = partial(lax.scatter_add, dimension_numbers=dnums)
+    fun = partial(lax.scatter_add, dimension_numbers=dnums, mode=mode)
     self._CompileAndCheck(fun, args_maker)
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
https://github.com/google/jax/commit/a87b21148c6d7eb9b46c751dde40b17ca0e7b03e doesn't notice `_scatter_add_lower_gpu` using `mlir.lower_fun` instead of `xla.lower_fun`.
I follow the change done in that commit for _scatter_lower.
https://github.com/google/jax/blob/0ed29b63f08fa404b1e837b4ab8b96b481c4b78f/jax/_src/lax/slicing.py#L1915-L1921

IIUC, `replace(avals_out=None)` is not necessary, just indicating that `avals_out` is not used.

I don't really understand what does the code do. Need review from @hawkinsp 