### PR TITLE
DOC: link to install instructions in HTML docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ parallelize, Just-In-Time compile to GPU/TPU, and more.
    :maxdepth: 1
    :caption: Getting Started
 
+   installation
    notebooks/quickstart
    notebooks/thinking_in_jax
    notebooks/Common_Gotchas_in_JAX

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,8 @@
+Installing JAX
+==============
+
+JAX is available to install via the `Python Package Index`_.
+For full installation instructions, please refer to the `Install Guide`_ in the project README.
+
+.. _Python Package Index: https://pypi.org/project/jax/
+.. _Install Guide: https://github.com/google/jax#installation


### PR DESCRIPTION
Fixes #10414 

Preview [here](https://jax--10423.org.readthedocs.build/en/10423/#jax-reference-documentation)