### PR TITLE
Add fast path for `jnp.diagonal(a, offset=0)`

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2925,6 +2925,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
+    jaxpr = jax.make_jaxpr(jnp_fun)(jnp.zeros(shape, dtype))
+    need_index_computation = "concatenate" in str(jaxpr)
+    assert need_index_computation == (offset != 0)
 
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_shape={}_n={}".format(np.dtype(dtype).name, n),


### PR DESCRIPTION
#10160 was reverted since it blew up TPU compilation times. So this PR adds a fast path for `jnp.diagonal(a, offset=0)` that prevents unneeded index manipulations. I am actually not sure if it would fix the concrete problem in #10160, but it definitely simplifies the generated Jaxpr and HLO code and also slightly speeds up compilation on my CPU machine.

On `main`
```python
from jax import numpy as jnp
import jax

jax.make_jaxpr(jnp.diagonal)(jnp.zeros((3, 3)))
```
generates:
```python
{ lambda a:i32[3]; b:f32[3,3]. let
    c:f32[3] = xla_call[
      call_jaxpr={ lambda ; d:i32[3] e:f32[3,3]. let
          f:i32[3] = iota[dimension=0 dtype=int32 shape=(3,)] 
          g:bool[3] = lt f 0
          h:i32[3] = add f 3
          i:i32[3] = select_n g f h
          j:bool[3] = lt d 0
          k:i32[3] = add d 3
          l:i32[3] = select_n j d k
          m:i32[3,1] = broadcast_in_dim[broadcast_dimensions=(0,) shape=(3, 1)] i
          n:i32[3,1] = broadcast_in_dim[broadcast_dimensions=(0,) shape=(3, 1)] l
          o:i32[3,2] = concatenate[dimension=1] m n
          p:f32[3] = gather[
            dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0, 1), start_index_map=(0, 1))
            fill_value=None
            indices_are_sorted=False
            mode=GatherScatterMode.PROMISE_IN_BOUNDS
            slice_sizes=(1, 1)
            unique_indices=False
          ] e o
        in (p,) }
      name=diagonal
    ] a b
  in (c,) }
```
With this PR, the index manipulations (including the concatenation which currently isn't folded away by hlo) are replaced by a single call to `iota`:
```python
{ lambda ; a:f32[3,3]. let
    b:f32[3] = xla_call[
      call_jaxpr={ lambda ; c:f32[3,3]. let
          d:i32[3,2] = iota[dimension=0 dtype=int32 shape=(3, 2)] 
          e:f32[3] = gather[
            dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0, 1), start_index_map=(0, 1))
            fill_value=None
            indices_are_sorted=False
            mode=GatherScatterMode.PROMISE_IN_BOUNDS
            slice_sizes=(1, 1)
            unique_indices=True
          ] c d
        in (e,) }
      name=diagonal
    ] a
  in (b,) }
```

After implementing this it turned out to be much less readable, so I am not sure if a cleaner Jaxpr is worth the added complexity in this case. I guess you are in a much better position to judge this which is why I am posting the PR anyway.