### PR TITLE
Add missing __init__ file in jax._src.scipy.cluster

### DIFF
--- a/jax/_src/scipy/cluster/__init__.py
+++ b/jax/_src/scipy/cluster/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
This should fix the readthedocs breakage on main. (this was missed in #10383 because readthedocs failed for unrelated reasons).

I'm not sure why this isn't caught by our normal CI processes.