### PR TITLE
[remove-units] prevent scan partial eval from introducing units

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -1681,119 +1681,143 @@ def _prune_zeros(ts):
 def _scan_partial_eval(trace, *tracers, reverse, length, num_consts, num_carry,
                        jaxpr, linear, unroll):
   num_ys = len(jaxpr.out_avals) - num_carry
-
-  unknowns = [t.pval[0] is not None for t in tracers]
+  unknowns = [not t.pval.is_known() for t in tracers]
   const_uk, init_uk, xs_uk = split_list(unknowns, [num_consts, num_carry])
 
-  # Fixpoint computation of which carry are unknown (not a constant): either
-  # unknown from init, or the carry out is unknown. Each iteration promotes
-  # at least one carry to unknown. We need at most len(carry) iterations,
-  # but we need one last iteration to prepare the jaxpr based on the final
-  # carry_uk.
+  # Fixpoint computation of which carry elements are unknown. Each iteration
+  # promotes at least one carry to unknown. We need at most len(carry)
+  # iterations, but we need one last iteration to prepare the jaxpr based on the
+  # final carry_uk.
   carry_uk = init_uk
   for _ in range(1 + len(carry_uk)):
     unknowns = const_uk + carry_uk + xs_uk
-    jaxpr_1, jaxpr_2, out_uk = pe.partial_eval_jaxpr(
+    jaxpr_known, jaxpr_unknown, out_uk, res_avals = pe.partial_eval_jaxpr_nounits(
         jaxpr, unknowns, instantiate=carry_uk + [False] * num_ys)
-    carry_uk_out = out_uk[:num_carry]
+    carry_uk_out, ys_uk = split_list(out_uk, [num_carry])
     if carry_uk_out == carry_uk:
       break
     else:
       carry_uk = _map(operator.or_, carry_uk, carry_uk_out)
   else:
     assert False, "Fixpoint not reached"
-  num_res = len(jaxpr_1.out_avals) - len(jaxpr_2.out_avals)
+  num_res = len(res_avals)
+  del res_avals, carry_uk_out
 
-  # The residuals are treated as extensive outputs of jaxpr_1 (and extensive
-  # inputs to jaxpr_2), but residuals that are loop-invariant can be hoisted.
-  # TODO(mattjj): hoist other loop-invariant values here too (instantiate=False)
-  invariant_pvals = [pe.PartialVal.known(core.unit if uk else t.pval[1])
-                     for uk, t in zip(unknowns[:num_consts], tracers[:num_consts])]
-  other_pvals = [pe.PartialVal.unknown(a) for a in jaxpr_1.in_avals[num_consts:]]
-  in_pvals_1 = invariant_pvals + other_pvals
+  # Instantiate those inputs which must be treated as unknown from the fixpoint.
+  tracers = [trace.instantiate_const(t) if uk else t
+             for t, uk in zip(tracers, unknowns)]
+
+  # The residual inputs and outputs of the jaxprs produced haven't yet been
+  # adapted to the scan calling convention; in particular, jaxpr_known has its
+  # residual outputs all at the end, meaning they're extensive outputs (which is
+  # fully general but may be wasteful for residuals which are loop-invariant)
+  # while jaxpr_unknown has its corresponding residual inputs at the front (just
+  # as a convention with partial_eval_jaxpr_nounits), making them constant
+  # inputs. To make them consistent, we move the residual inputs on
+  # jaxpr_unknown to the end, even though we may move some back in the sequel.
+  jaxpr_unknown = pe.move_binders_to_back(
+      jaxpr_unknown, [True] * num_res + [False] * sum(unknowns))
+
+  # At this point, all residuals are treated as extensive outputs of jaxpr_known
+  # (and extensive inputs to jaxpr_unknown). But residuals that are loop-
+  # invariant can be hoisted out of the scan, rather than letting them get
+  # broadcast (as in e.g. scanning multiplication by a constant matrix; we don't
+  # want to broadcast the matrix!). So, outside the loop we perform a partial
+  # evaluation with known 'const' inputs (but all other inputs unknown).
+  const_pvals = [pe.PartialVal.known(t.pval.get_known())
+                 for t in tracers[:num_consts] if t.pval.is_known()]
+  other_pvals = [pe.PartialVal.unknown(aval)
+                 for aval in jaxpr_known.in_avals[len(const_pvals):]]
   with source_info_util.reset_name_stack():
-    jaxpr_1_opt, out_pvals_1, consts_1 = pe.trace_to_jaxpr(
-        lu.wrap_init(core.jaxpr_as_fun(jaxpr_1)), in_pvals_1,
-        instantiate=[True] * (num_carry + num_ys) + [False] * num_res)
-  jaxpr_1_opt = pe.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr_1_opt), ())
-  num_consts_1 = num_consts + len(consts_1)
-  # any now-known residuals are intensive, so we want to revise jaxpr_2 to take
-  # those inputs as constants rather than as extensive inputs
-  _, _, res_pvals = split_list(out_pvals_1, [num_carry, num_ys])
-  intensive_residuals = [const for pv, const in res_pvals if pv is None]
-  move = [False] * len(jaxpr_1.in_avals) + [pv is None for pv, _ in res_pvals]
-  jaxpr_2_opt = pe.move_binders_to_front(jaxpr_2, move)
-  num_consts_2 = num_consts + len(intensive_residuals)
+    jaxpr_known_, invar_pvals_out, jaxpr_known_consts = pe.trace_to_jaxpr_nounits(
+        lu.wrap_init(core.jaxpr_as_fun(jaxpr_known)), const_pvals + other_pvals,
+        instantiate=[True] * (len(out_uk) - sum(out_uk)) + [False] * num_res)
+  jaxpr_known = pe.ClosedJaxpr(pe.convert_constvars_jaxpr(jaxpr_known_), ())
+  # The above trace_to_jaxpr_nounits call computed loop-invariant residuals
+  # (known values in invar_pvals_out) and also computed loop-invariant values
+  # needed by the new jaxpr_known (in jaxpr_known_consts, which replace the
+  # previous consts). We need to collect the computed inteisive residuals, and
+  # move corresponding intensive residual binders in jaxpr_unknown to the front.
+  res_pvals = invar_pvals_out[len(invar_pvals_out) - num_res:]
+  intensive_res = [pval.get_known() for pval in res_pvals if pval.is_known()]
+  jaxpr_unknown = pe.move_binders_to_front(
+      jaxpr_unknown,
+      [False] * sum(unknowns) + [pval.is_known() for pval in res_pvals])
+  del const_pvals, other_pvals, invar_pvals_out, jaxpr_known_, res_pvals
+  # We use `jaxpr_known_consts` when we call scan_p.bind with jaxpr_known, and
+  # we use `intensive_res` when we build the jaxpr eqn with jaxpr_unknown.
 
   # As another optimization, for any extensive inputs that are just forwarded to
-  # extensive outputs, to avoid a copy (looping over dynamic-update-slice) we'd
-  # rather just forward the input tracer. That means pruning some extensive
-  # outputs from the jaxpr here, and updating out_flat below.
-  extensive_invars = jaxpr_1_opt.jaxpr.invars[num_consts_1 + num_carry:]
-  extensive_outvars = jaxpr_1_opt.jaxpr.outvars[num_carry:]
-  extensive_avals = [core.unmapped_aval(length, core.no_axis_name, 0,
-                                        core.raise_to_shaped(v.aval))
-                     for v in extensive_outvars]
-  fwd_extensive = [num_consts + num_carry + extensive_invars.index(v)
-                   if v in extensive_invars else None for v in extensive_outvars]
-  jaxpr_1_opt.jaxpr.outvars = (
-      jaxpr_1_opt.jaxpr.outvars[:num_carry] +
-      [v for i, v in zip(fwd_extensive, extensive_outvars) if i is None])
+  # extensive outputs, to avoid a copy (which would be looping over
+  # dynamic-update-slice) we'd rather forward the input tracer/value. That means
+  # pruning some outputs from jaxpr_known here, and updating `out_flat` below.
+  fwds_known = pe._jaxpr_forwarding(jaxpr_known.jaxpr)
+  # Prune fwds_known to include only extensive input to extensive output.
+  fwds_known = [in_idx if out_idx >= num_carry - sum(carry_uk) and
+                in_idx is not None and
+                in_idx >= len(jaxpr_known_consts) + num_carry - sum(carry_uk)
+                else None for out_idx, in_idx in enumerate(fwds_known)]
+  # DCE any (extensive) output we can instead get by forwarding an input.
+  jaxpr_known_, kept_inputs = pe.dce_jaxpr(
+      jaxpr_known.jaxpr, [i is None for i in fwds_known])
+  jaxpr_known = core.ClosedJaxpr(jaxpr_known_, ())
+  del jaxpr_known_
+  # We must use `kept_inputs` below when forming the inputs to jaxpr_known, and
+  # we must use `fwds_known` when forming its output.
 
-  in_consts = (list(consts_1) + [core.unit] * num_consts +
-               [core.unit if uk else t.pval[1]
-                for uk, t in zip(unknowns[num_consts:], tracers[num_consts:])])
-  linear_1 = ([False] * len(consts_1) + [True] * num_consts +
-              [lin or uk for uk, lin
-               in zip(unknowns[num_consts:], linear[num_consts:])])
-  out_flat = scan_p.bind(
-      *in_consts, reverse=reverse, length=length, jaxpr=jaxpr_1_opt,
-      num_consts=num_consts_1, num_carry=num_carry, linear=tuple(linear_1),
-      unroll=unroll)
+  # Run the known part of the scan.
+  known_inputs = (list(jaxpr_known_consts) +
+                  [t.pval.get_known() for t in tracers[num_consts:]
+                   if t.pval.is_known()])
+  known_inputs_prune = [c for c, kept in zip(known_inputs, kept_inputs) if kept]
+  kept_consts, kept_carry, _ = split_list(kept_inputs, [len(jaxpr_known_consts),
+                                                        num_carry-sum(carry_uk)])
+  linear_known = [False] * len(known_inputs_prune)  # conservative!
+  out_known = scan_p.bind(
+      *known_inputs_prune, reverse=reverse, length=length, jaxpr=jaxpr_known,
+      num_consts=sum(kept_consts), num_carry=sum(kept_carry),
+      linear=tuple(linear_known), unroll=unroll)
+  # Complete the known output by filling in forwarded values using fwds_known.
+  out_known_iter = iter(out_known)
+  out_known = [next(out_known_iter) if f is None else _maybe_put(known_inputs[f])
+               for f in fwds_known]
+  assert next(out_known_iter, None) is None
+  del kept_inputs, known_inputs, known_inputs_prune, out_known_iter
 
-  # Propagate the forwarded extensive outputs using fwd_extensive. Any
-  # numpy.ndarray inputs should be converted to JAX DeviceArrays.
-  out_carry, out_extensive = split_list(out_flat, [num_carry])
-  out_extensive_iter = iter(out_extensive)
-  out_extensive = [next(out_extensive_iter) if i is None
-                   else _maybe_device_put(tracers[i].pval[1]) if tracers[i].is_known()
-                   else tracers[i] for i in fwd_extensive]
-  assert all(core.typematch(a, core.get_aval(out))
-             for a, out in zip(extensive_avals, out_extensive))
-  out_flat = out_carry + out_extensive
+  # Split known outputs from residuals.
+  out_known, extensive_res = split_list(out_known, [len(out_uk) - sum(out_uk)])
+  assert len(intensive_res) + len(extensive_res) == num_res
 
-  out_carry, ys, res_and_units = split_list(out_flat, [num_carry, num_ys])
-  extensive_residuals = [r for r, (pv, _) in zip(res_and_units, res_pvals) if pv is not None]
-
-  new_tracers = [trace.instantiate_const(t) if uk else trace.new_instantiated_literal(core.unit)
-                 for uk, t in zip(unknowns, tracers)]
-  carry_avals, y_avals = split_list(jaxpr.out_avals, [num_carry])
-  ys_avals = _map(partial(_prepend_dim_to_aval, length), y_avals)
-  out_avals = carry_avals + ys_avals
-  out_pvs = [aval if uk else None for aval, uk in zip(out_avals, out_uk)]
-
-  out_consts = out_carry + ys
-  int_res_tracers = _map(trace.new_instantiated_const, intensive_residuals)
-  ext_res_tracers = _map(trace.new_instantiated_const, extensive_residuals)
-  out_tracers = [pe.JaxprTracer(trace, pe.PartialVal((pv, const)), None)
-                 for pv, const in zip(out_pvs, out_consts)]
+  # Create input tracers for jaxpr_unknown bind.
+  unknown_inputs = [t for t in tracers if not t.pval.is_known()]
+  intensive_res = _map(trace.new_instantiated_const, intensive_res)
+  extensive_res = _map(trace.new_instantiated_const, extensive_res)
+  # Create output tracers for jaxpr_unknown bind, adapting extensive shapes.
+  carry_avals, y_avals = split_list(jaxpr_unknown.out_avals, [sum(carry_uk)])
+  ys_avals = [core.unmapped_aval(length, core.no_axis_name, 0, y_aval)
+              for y_aval in y_avals]
+  out_tracers = [pe.JaxprTracer(trace, pe.PartialVal.unknown(a), None)
+                 for a in itertools.chain(carry_avals, ys_avals)]
+  del carry_avals, y_avals
+  # Create equation.
+  linear_unknown = tuple([False] * len(intensive_res) +
+                         [l for l, uk in zip(linear, unknowns) if uk] +
+                         [False] * len(extensive_res))
   name_stack = source_info_util.current_name_stack()[len(trace.name_stack):]
   source = source_info_util.current().replace(name_stack=name_stack)
-  linear_2 = ([False] * len(int_res_tracers) +
-              [lin or not uk for uk, lin in zip(unknowns, linear)] +
-              [False] * len(ext_res_tracers))
-  eqn = pe.new_eqn_recipe(int_res_tracers + new_tracers + ext_res_tracers,
+  eqn = pe.new_eqn_recipe([*intensive_res, *unknown_inputs, *extensive_res],
                           out_tracers, scan_p,
-                          dict(reverse=reverse, length=length, jaxpr=jaxpr_2_opt,
-                               num_consts=num_consts_2,
-                               num_carry=num_carry, linear=tuple(linear_2),
-                               unroll=unroll),
-                          jaxpr_2_opt.effects,
-                          source)
+                          dict(reverse=reverse, length=length, unroll=unroll,
+                               jaxpr=jaxpr_unknown, linear=linear_unknown,
+                               num_consts=len(intensive_res) + sum(const_uk),
+                               num_carry=sum(carry_uk)),
+                          jaxpr_unknown.effects, source)
   for t in out_tracers: t.recipe = eqn
-  return out_tracers
 
-def _maybe_device_put(x):
+  # Merge known and unknown outputs into final result.
+  return util.merge_lists(out_uk, out_known, out_tracers)
+
+def _maybe_put(x):
   if isinstance(x, np.ndarray):
     return jax.device_put(x, jax.devices('cpu')[0])
   else:

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from collections import namedtuple
 import contextlib
@@ -78,11 +79,11 @@ class PartialVal(tuple):
     return tuple.__new__(cls, xs)
 
   @classmethod
-  def known(cls, const: core.Value) -> 'PartialVal':
+  def known(cls, const: core.Value) -> PartialVal:
     return PartialVal((None, const))
 
   @classmethod
-  def unknown(cls, aval: AbstractValue) -> 'PartialVal':
+  def unknown(cls, aval: AbstractValue) -> PartialVal:
     return PartialVal((aval, core.unit))
 
   def is_known(self) -> bool:
@@ -112,29 +113,29 @@ class JaxprTrace(Trace):
     super().__init__(*args)
     self.name_stack = name_stack
 
-  def pure(self, val) -> 'JaxprTracer':
+  def pure(self, val) -> JaxprTracer:
     return self.new_const(val)
 
-  def lift(self, val) -> 'JaxprTracer':
+  def lift(self, val) -> JaxprTracer:
     return self.new_const(val)
 
-  def sublift(self, val) -> 'JaxprTracer':
+  def sublift(self, val) -> JaxprTracer:
     return JaxprTracer(self, val.pval, FreeVar(val))
 
-  def new_const(self, val) -> 'JaxprTracer':
+  def new_const(self, val) -> JaxprTracer:
     if isinstance(val, Tracer) and val._trace.level == self.level:
       raise Exception
     return JaxprTracer(self, PartialVal.known(val), unit)
 
-  def new_instantiated_literal(self, val) -> 'JaxprTracer':
+  def new_instantiated_literal(self, val) -> JaxprTracer:
     aval = get_aval(val)
     return JaxprTracer(self, PartialVal.unknown(aval),
                        Literal(val, raise_to_shaped(aval)))
 
-  def new_instantiated_const(self, val) -> 'JaxprTracer':
+  def new_instantiated_const(self, val) -> JaxprTracer:
     return JaxprTracer(self, PartialVal.unknown(get_aval(val)), ConstVar(val))
 
-  def new_arg(self, pval: PartialVal) -> 'JaxprTracer':
+  def new_arg(self, pval: PartialVal) -> JaxprTracer:
     const = pval.get_known()
     # XXX: Think twice before changing this constant argument pruning!
     # This has really important consequences for partial_eval_jaxpr.
@@ -155,7 +156,7 @@ class JaxprTrace(Trace):
       else:
         return self.new_instantiated_const(const)
 
-  def instantiate_const_abstracted(self, tracer) -> 'JaxprTracer':
+  def instantiate_const_abstracted(self, tracer) -> JaxprTracer:
     const = tracer.pval.get_known()
     if const is None:
       return tracer
@@ -170,8 +171,9 @@ class JaxprTrace(Trace):
       return self.default_process_primitive(primitive, tracers, params)
 
   def default_process_primitive(self, primitive, tracers, params):
-    """By default, if all the input tracers are known, then execute the primitive
-    and all the outputs are known. Otherwise, all the outputs are unknown."""
+    # By default, if all the input tracers are known, then bind the primitive
+    # and consider all outputs known. Otherwise, stage the application into the
+    # jaxpr and consider all outputs unknown.
     consts = [t.pval.get_known() for t in tracers]
     if all(c is not None for c in consts):
       return primitive.bind(*consts, **params)
@@ -556,7 +558,7 @@ class JaxprTracer(Tracer):
     return self.pval.get_aval()
 
   @property
-  def parents(self) -> Sequence['JaxprTracer']:
+  def parents(self) -> Sequence[JaxprTracer]:
     if isinstance(self.recipe, JaxprEqnRecipe):
       return self.recipe.invars
     else:
@@ -661,7 +663,7 @@ LambdaBinding = namedtuple('LambdaBinding', [])
 class JaxprEqnRecipe(NamedTuple):
   eqn_id: object
   invars: Sequence[JaxprTracer]
-  outvars: 'Sequence[ref[JaxprTracer]]'
+  outvars: Sequence[ref[JaxprTracer]]
   primitive: Primitive
   params: Dict[str, Any]
   effects: core.Effects
@@ -674,14 +676,6 @@ def new_eqn_recipe(invars: Sequence[JaxprTracer],
                    effects: core.Effects,
                    source_info: source_info_util.SourceInfo
                   ) -> JaxprEqnRecipe:
-  """Constructs a new JaxEqnRecipe.
-
-  Params:
-    invars: the tracers for the primitive inputs.
-    outvars: the tracers for the primitive outputs.
-    primitive: the primitive.
-    params: the primitive params
-  """
   # TODO(necula): move these checks to core.check_jaxpr, and call in more places
   if primitive.call_primitive or primitive.map_primitive:
     assert "call_jaxpr" in params
@@ -901,8 +895,10 @@ def _partial_eval_jaxpr_nounits(jaxpr, in_unknowns, instantiate):
   assert ([v.aval for v in jaxpr_unknown.invars] ==
           res_avals + [a for a, uk in zip(jaxpr.in_avals, in_unknowns) if uk])
   # check jaxpr_unknown has output type corresponding to unknown outputs
-  assert ([v.aval for v in jaxpr_unknown.outvars] ==
-          [a for a, uk in zip(jaxpr.out_avals, out_unknowns) if uk])
+  # TODO(mattjj): enable weak type checking here
+  assert ([v.aval.strip_weak_type() for v in jaxpr_unknown.outvars] ==
+          [a.strip_weak_type() for a, uk in zip(jaxpr.out_avals, out_unknowns)
+           if uk])
 
   closed_jaxpr_known = ClosedJaxpr(jaxpr_known, consts_known)
   closed_jaxpr_unknown = ClosedJaxpr(jaxpr_unknown, ())
@@ -1169,6 +1165,21 @@ partial_eval_jaxpr_custom_rules[remat_call_p] = \
             lambda _, __, ___, ____, p1, p2: (p1, dict(p2, differentiated=True)))
 
 
+def _jaxpr_forwarding(jaxpr: Jaxpr) -> List[Optional[int]]:
+  # Compute which inputs are just forwarded to outputs.
+  fwds: Dict[Var, Var] = dict(zip(jaxpr.invars, jaxpr.invars))
+  for eqn in jaxpr.eqns:
+    if eqn.primitive in forwarding_rules:
+      eqn = eqn.replace(invars=[fwds.get(v, v) for v in eqn.invars])  # type: ignore
+      fwd_vars, _ = forwarding_rules[eqn.primitive](eqn)
+      for v_orig, v_new in zip(eqn.outvars, fwd_vars):
+        if v_new is not None:
+          fwds[v_orig] = v_new
+  idxs: Dict[Var, int] = {v: i for i, v in enumerate(jaxpr.invars)}
+  return [None if type(v) is Literal else idxs.get(fwds.get(v))  # type: ignore
+          for v in jaxpr.outvars]
+
+
 # TODO(mattjj): unify with dce code below
 def dce_jaxpr(jaxpr: Jaxpr, used_outputs: List[bool]
               ) -> Tuple[Jaxpr, List[bool]]:
@@ -1275,8 +1286,9 @@ def _reconstruct_pval(pval1: PartialVal, const2: core.Value):
       return PartialVal.known(const2)
 
 
-def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]) -> ClosedJaxpr:
-  """Reorder the `invars` to move to front the ones for which `to_move` is True."""
+def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
+                          ) -> ClosedJaxpr:
+  """Reorder `invars` by moving those indicated in `to_move` to the front."""
   assert len(closed_jaxpr.in_avals) == len(to_move)
   new_invars = _move_to_front(closed_jaxpr.jaxpr.invars, to_move)
   new_jaxpr = Jaxpr(closed_jaxpr.jaxpr.constvars, new_invars,
@@ -1289,6 +1301,10 @@ def _move_to_front(lst: Sequence, to_move: Sequence[bool]) -> Sequence:
   return ([elt for elt, move in zip(lst, to_move) if move] +
           [elt for elt, move in zip(lst, to_move) if not move])
 
+def move_binders_to_back(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
+                         ) -> ClosedJaxpr:
+  """Reorder `invars` by moving those indicated in `to_move` to the back."""
+  return move_binders_to_front(closed_jaxpr, map(op.not_, to_move))
 
 class DynamicJaxprTracer(core.Tracer):
   __slots__ = ['aval']


### PR DESCRIPTION
Scan's partial evaluation rule is tricky!

Units are a bookkeping mechanism for partial evaluation. Even though they're only needed for partial evaluation, they currently exist in JAX tracing and jaxprs, meaning that while they may make partial evaluation bookkeeping marginally simpler (only in some cases!) everything else has to deal with units. As we added more consumers of e.g. jaxprs, dealing with units everywhere started to outweigh any benefits.

Do units really make partial evaluation bookkeeping simpler? Well, look no further than this PR for an example: because `scan` has special 'slots' for inputs and outputs (hence `num_consts`, `num_carry` etc), inserting units as placeholders meant that when performing partial evaluation these values didn't really need to change. But once we prune units, we need to keep track of how many of each kind of input and output is being pruned.

It wasn't so bad though. And I think this is the last control flow primitive to use them. We might be home free to clear out any last simple places units are introduced, at which point we can delete them...