### PR TITLE
[sparse] bcoo_broadcast_in_dim: default to adding leading batch dimensions

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1501,7 +1501,9 @@ def _bcoo_broadcast_in_dim(data, indices, *, spinfo, shape, broadcast_dimensions
   if max(sparse_dims, default=0) > min(dense_dims, default=len(shape)):
     raise ValueError("Cannot mix sparse and dense dimensions during broadcast_in_dim")
 
-  new_n_batch = props.n_batch and 1 + max(broadcast_dimensions[:props.n_batch])
+  # All new dimensions preceding a sparse or dense dimension are batch dimensions:
+  new_n_batch = min(broadcast_dimensions[props.n_batch:], default=len(shape))
+  # TODO(jakevdp): Should new trailing dimensions be dense by default?
   new_n_dense = props.n_dense and len(shape) - min(broadcast_dimensions[-props.n_dense:])
   new_n_sparse = len(shape) - new_n_batch - new_n_dense
 

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1866,11 +1866,15 @@ class BCOOTest(jtu.JaxTestCase):
     x = jnp.array(rng(shape, dtype))
     xsp = sparse.BCOO.fromdense(x, n_batch=n_batch, n_dense=n_dense)
 
+    self.assertEqual(xsp[None].n_batch, xsp.n_batch + 1)
     self.assertArraysEqual(xsp[None].todense(), x[None])
+
     if len(shape) >= 1:
+      self.assertEqual(xsp[:, None].n_batch, xsp.n_batch if xsp.n_batch < 1 else xsp.n_batch + 1)
       self.assertArraysEqual(xsp[:, None].todense(), x[:, None])
       self.assertArraysEqual(xsp[:, None, None].todense(), x[:, None, None])
     if len(shape) >= 2:
+      self.assertEqual(xsp[:, :, None].n_batch, xsp.n_batch if xsp.n_batch < 2 else xsp.n_batch + 1)
       self.assertArraysEqual(xsp[:, :, None].todense(), x[:, :, None])
       self.assertArraysEqual(xsp[:, None, :, None].todense(), x[:, None, :, None])
 


### PR DESCRIPTION
Why? Because in this situation batch dimensions always yield a more compact representation, and converting from batch to sparse dimensions is far cheaper than converting from sparse to batch dimensions.

This, along with a sparse lowering rule for `lax.concatenate_p`, will allow us to support clean concatenation & stacking of sparse arrays.

I'm a bit concerned that this might break an existing use-case, so I need to run some extra tests before merging.