### PR TITLE
[sparse] implement sparse rule for lax.concatenate_p

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -189,6 +189,7 @@ from jax.experimental.sparse.ad import (
 from jax.experimental.sparse.bcoo import (
     bcoo_add_batch_dim as bcoo_add_batch_dim,
     bcoo_broadcast_in_dim as bcoo_broadcast_in_dim,
+    bcoo_concatenate as bcoo_concatenate,
     bcoo_dot_general as bcoo_dot_general,
     bcoo_dot_general_p as bcoo_dot_general_p,
     bcoo_dot_general_sampled as bcoo_dot_general_sampled,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -586,6 +586,13 @@ def _broadcast_in_dim_sparse(spenv, *spvalues, shape, broadcast_dimensions):
 
 sparse_rules[lax.broadcast_in_dim_p] = _broadcast_in_dim_sparse
 
+def _concatenate_sparse(spenv, *spvalues, dimension):
+  operands = spvalues_to_arrays(spenv, spvalues)
+  result = sparse.bcoo_concatenate(operands, dimension=dimension)
+  return arrays_to_spvalues(spenv, (result,))
+
+sparse_rules[lax.concatenate_p] = _concatenate_sparse
+
 def _squeeze_sparse(spenv, *spvalues, dimensions):
   arr, = spvalues
   dimensions = tuple(canonicalize_axis(dim, arr.ndim) for dim in dimensions)


### PR DESCRIPTION
The cool thing is that because we've already implemented `broadcast_in_dim`, this makes the sparsify transform able to handle a number of numpy APIs, e.g. `jnp.concatenate`, `jnp.stack`, `jnp.vstack`, `jnp.dstack`, `jnp.hstack`, etc.