### PR TITLE
[remove-units] prevent remat's partial eval from introducing units

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -2317,7 +2317,7 @@ def check_call(ctx_factory, prim, in_avals, params):
 
   # These checks also happen in recursive call, but give better errors here.
   if len(in_avals) != len(call_jaxpr.invars):
-    raise JaxprTypeError(f"Call primitive {prim} with {len(call_jaxpr.invars)} "
+    raise JaxprTypeError(f"Call primitive {prim} with {len(in_avals)} "
                          f"operands cannot call jaxpr with {len(call_jaxpr.invars)} "
                          f"inputs")
   binder_avals = [v.aval for v in call_jaxpr.invars]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4341,7 +4341,7 @@ class RematTest(jtu.JaxTestCase):
     with jtu.count_jit_and_pmap_compiles() as count:  # noqa: F841
       for _ in range(20):
         f_vjp(1.)[0].block_until_ready()
-    self.assertEqual(count[0], 2)  # eval_jaxpr on fwd, backward_pass on bwd
+    self.assertEqual(count[0], 1)  # fwd execute_trivial, backward_pass on bwd
 
 
 class JaxprTest(jtu.JaxTestCase):


### PR DESCRIPTION
Even though 'old' remat will someday soon be replaced by 'new' remat in ad_checkpoint.py, we want to get rid of units first so we need to update the old thing. (Almost paradoxically, one of the main reasons to get rid of units is to make upgrading to 'new' remat easier...)

Nothing surprising here: we just had to update remat's partial eval rule from using trace_to_jaxpr to use trace_to_jaxpr_nounits, and then follow up on all the consequences.