### PR TITLE
docs: replace all `git.io` links with their actual URLs

### DIFF
--- a/docs/_static/device_memory_profile.svg
+++ b/docs/_static/device_memory_profile.svg
@@ -20,7 +20,7 @@
 <text text-anchor="start" x="24.5" y="-915.2" font-family="Times,serif" font-size="16.00">Type: space</text>
 <text text-anchor="start" x="24.5" y="-897.2" font-family="Times,serif" font-size="16.00">Showing nodes accounting for 80.11MB, 100% of 80.13MB total</text>
 <text text-anchor="start" x="24.5" y="-879.2" font-family="Times,serif" font-size="16.00">Dropped 26 nodes (cum &lt;= 0.40MB)</text>
-<text text-anchor="start" x="24.5" y="-842.2" font-family="Times,serif" font-size="16.00">See https://git.io/JfYMW for how to read the graph</text>
+<text text-anchor="start" x="24.5" y="-842.2" font-family="Times,serif" font-size="16.00">See https://github.com/google/pprof/blob/master/doc/README.md#interpreting-the-callgraph for how to read the graph</text>
 </g>
 <!-- N1 -->
 <g id="node1" class="node">

--- a/docs/_static/device_memory_profile_leak1.svg
+++ b/docs/_static/device_memory_profile_leak1.svg
@@ -20,7 +20,7 @@
 <text text-anchor="start" x="24.5" y="-810.2" font-family="Times,serif" font-size="16.00">Type: space</text>
 <text text-anchor="start" x="24.5" y="-792.2" font-family="Times,serif" font-size="16.00">Showing nodes accounting for 5806.95kB, 99.79% of 5819.22kB total</text>
 <text text-anchor="start" x="24.5" y="-774.2" font-family="Times,serif" font-size="16.00">Dropped 25 nodes (cum &lt;= 29.10kB)</text>
-<text text-anchor="start" x="24.5" y="-737.2" font-family="Times,serif" font-size="16.00">See https://git.io/JfYMW for how to read the graph</text>
+<text text-anchor="start" x="24.5" y="-737.2" font-family="Times,serif" font-size="16.00">See https://github.com/google/pprof/blob/master/doc/README.md#interpreting-the-callgraph for how to read the graph</text>
 </g>
 <!-- N1 -->
 <g id="node1" class="node">

--- a/docs/_static/device_memory_profile_leak2.svg
+++ b/docs/_static/device_memory_profile_leak2.svg
@@ -20,7 +20,7 @@
 <text text-anchor="start" x="24.5" y="-816.2" font-family="Times,serif" font-size="16.00">Type: space</text>
 <text text-anchor="start" x="24.5" y="-798.2" font-family="Times,serif" font-size="16.00">Showing nodes accounting for 1832.09kB, 46.05% of 3978.91kB total</text>
 <text text-anchor="start" x="24.5" y="-780.2" font-family="Times,serif" font-size="16.00">Dropped 13 nodes (cum &lt;= 19.89kB)</text>
-<text text-anchor="start" x="24.5" y="-743.2" font-family="Times,serif" font-size="16.00">See https://git.io/JfYMW for how to read the graph</text>
+<text text-anchor="start" x="24.5" y="-743.2" font-family="Times,serif" font-size="16.00">See https://github.com/google/pprof/blob/master/doc/README.md#interpreting-the-callgraph for how to read the graph</text>
 </g>
 <!-- N1 -->
 <g id="node1" class="node">

--- a/jax/experimental/jax2tf/examples/README.md
+++ b/jax/experimental/jax2tf/examples/README.md
@@ -13,7 +13,7 @@ This directory contains a number of examples of using the
 
 You can also find usage examples in other projects:
 
-  * [Vision Transformer models converted to TensorFlow](https://git.io/Jz8pj) and integrated with TensorFlow Hub.
+  * [Vision Transformer models converted to TensorFlow](https://github.com/sayakpaul/ViT-jax2tf) and integrated with TensorFlow Hub.
 
 # Generating TensorFlow SavedModel
 


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

> We will be removing all existing link redirection from git.io on April 29, 2022.

Replace all git.io links with their actual URLs.