### PR TITLE
[remove-units] don't use abstract_unit for dropvar avals

### DIFF
--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -343,6 +343,19 @@ class CoreTest(jtu.JaxTestCase):
                                np.array([1], dtype=np.int32))),
         'ConcreteArray([1], dtype=int32)')
 
+  def test_dropvar_avals(self):
+    def f(x):
+      def body(c, _):
+        return c, None
+      (x1, x2), _ = jax.lax.scan(body, (x, x), None, length=1)
+      return [x2]
+
+    aval = core.ShapedArray((), jnp.dtype('int32'))
+    pval = pe.PartialVal.unknown(aval)
+    jaxpr, _, _ = pe.trace_to_jaxpr_nounits(lu.wrap_init(f), [pval], False)
+    dropvar, b = jaxpr.eqns[0].outvars
+    self.assertEqual(dropvar.aval, aval)
+
 
 class JaxprTypeChecks(jtu.JaxTestCase):
 


### PR DESCRIPTION
Partial evaluation using `JaxprTrace` constructs a jaxpr by first, during tracing, building a kind of bipartite graph between `JaxprTracer`s and [`Recipe`s](https://github.com/google/jax/blob/cdd11670959b930e01d23199fadb32b183f03ca5/jax/interpreters/partial_eval.py#L530). The `JaxprTracer`s have references to the `Recipe` which constructs them, and the common `JaxprEqnRecipe`s in turn have references to the `JaxprTracer`s corresponding to both their inputs and outputs. More precisely, to avoid strong reference cycles, the `JaxprEqnRecipe`s hold weak references to their output `JaxprTracer`s. That provides a memory optimization: when user code drops a reference to a `JaxprTracer`, e.g. by a variable going out of scope, its memory can be reclaimed just like a user may expect from Python's usual reference counting operational semantics, as if there were no AD going on.

Before this PR, that led to a funny typing issue: while unused `JaxprTracer`s could go out of scope before the trace completed, we still might have variables in the jaxpr being formed which correspond to those `JaxprTracer`s, and yet since we relied on the `JaxprTracer` instance to get the aval for use as a type annotation in the jaxpr, we wouldn't be able to annotate the variable's type! We used a catch-all fallback: we used a special variable `DropVar` (pretty-printed like `_`) and, since we didn't have a type available, used an `AbstractUnit` type, pretty-printed like `*`. So the jaxpr would get let-binders which pretty-printed as `_:*`.

This had a funny downstream effect on autodiff: transpose rules could get `ad_util.Zero(core.abstract_unit)` instances passed in as their cotangent arguments, despite that not matching the type of the tangent output!

Here we fixed the issue simply by tracking the output type separately on the `JaxprEqnRecipe`, rather than relying on reading it from the weakly referenced `JaxprTracer` instances.