### PR TITLE
fix scan dce rule

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2079,7 +2079,8 @@ core.custom_typechecks[scan_p] = partial(_scan_typecheck, False)
 pe.partial_eval_jaxpr_custom_rules[scan_p] = \
     partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'scan')
 pe.padding_rules[scan_p] = _scan_padding_rule
-pe.dce_rules[scan_p] = _scan_dce_rule
+# TODO(mattjj): re-enable
+# pe.dce_rules[scan_p] = _scan_dce_rule
 
 
 @api_boundary

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4503,6 +4503,7 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertNotIn('in (a,)', str(jaxpr))
 
   def test_dce_jaxpr_scan(self):
+    raise unittest.SkipTest()  # TODO(mattjj)
     @api.remat
     def scanned_f(c, x):
       out = jnp.tanh(c * x)
@@ -4518,6 +4519,7 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.eqns[-1].params['jaxpr'].jaxpr.eqns, 2)
 
   def test_dce_jaxpr_scan_nontrivial_fixedpoint(self):
+    raise unittest.SkipTest()  # TODO(mattjj)
     def f(lst):
       def body(c, _):
         return [c[0]] + [c1 + c2 for c1, c2 in zip(c[:-1], c[1:])], None
@@ -4549,6 +4551,7 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertEqual(used_inputs, [True, True, True, True])
 
   def test_dce_jaxpr_scan_const_in_jvp(self):
+    raise unittest.SkipTest()  # TODO(mattjj)
     @api.custom_jvp
     def f(x):
       return x * np.arange(3.)


### PR DESCRIPTION
This fixes the scan DCE rule (there was a dumb bug!), but we disabled it anyway until we can write more tests.

We're not sure how we missed it, but to trigger it we just needed remat-of-scan possibly combined with higher-order AD.