### PR TITLE
dtypes.result_type: add optional return_weak_type_flag argument

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -375,11 +375,20 @@ def _lattice_result_type(*args):
     result_type = _least_upper_bound(*{_jax_type(d, w) for d, w in zip(dtypes, weak_types)})
     return dtype(result_type), any(result_type is t for t in _weak_types)
 
-def result_type(*args):
-  """Convenience function to apply JAX argument dtype promotion."""
+def result_type(*args, return_weak_type_flag=False):
+  """Convenience function to apply JAX argument dtype promotion.
+
+  Args:
+    return_weak_type_flag : if True, then return a ``(dtype, weak_type)`` tuple.
+      If False, just return `dtype`
+
+  Returns:
+    dtype or (dtype, weak_type) depending on the value of the ``return_weak_type`` argument.
+  """
   if len(args) == 0:
     raise ValueError("at least one array or dtype is required")
   dtype, weak_type = _lattice_result_type(*(float_ if arg is None else arg for arg in args))
   if weak_type:
     dtype = _default_types['f' if dtype == _bfloat16_dtype else dtype.kind]
-  return canonicalize_dtype(dtype)
+  dtype = canonicalize_dtype(dtype)
+  return (dtype, weak_type) if return_weak_type_flag else dtype

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -265,6 +265,15 @@ class TestPromotionTables(jtu.JaxTestCase):
     # This matches the behavior of np.result_type(None) => np.float_
     self.assertEqual(dtypes.result_type(None), dtypes.canonicalize_dtype(dtypes.float_))
 
+  def testResultTypeWeakFlag(self):
+    float_ = dtypes.canonicalize_dtype(dtypes.float_)
+    x_weak = jnp.array(1.)
+    x_strong = x_weak.astype(float_)
+    self.assertEqual(dtypes.result_type(x_weak), float_)
+    self.assertEqual(dtypes.result_type(x_weak, return_weak_type_flag=True), (float_, True))
+    self.assertEqual(dtypes.result_type(x_strong), float_)
+    self.assertEqual(dtypes.result_type(x_strong, return_weak_type_flag=True), (float_, False))
+
   @jtu.ignore_warning(category=UserWarning,
                       message="Explicitly requested dtype.*")
   def testObservedPromotionTable(self):


### PR DESCRIPTION
Fixes #10491

Note that this is deliberately added only to `jax.dtypes.result_type`, not `jax.numpy.result_type`. I don't think we need to extend the `jax.numpy` version of this API.

For the specific use-case in #10491, we should now be able to do something like this:
```python

In [1]: import numpy as np 
   ...: from jax import core, dtypes 
   ...:  
   ...: class Test: 
   ...:   def __init__(self, dtype, weak): 
   ...:     self.dtype = dtype 
   ...:     self.aval = core.ShapedArray((), dtype=dtype, weak_type=weak) 
   ...:  
   ...: t = Test(np.float64, True) 
   ...: dtypes.result_type(t, return_weak_type_flag=True)                                                                                                                                                                                             
Out[1]: (dtype('float32'), True)
```