### PR TITLE
docs: pin myst-nb to 0.13.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,8 @@ sphinx-remove-toctrees
 sphinx-autodoc-typehints==1.11.1
 sphinx-copybutton>=0.5.0
 jupyter-sphinx>=0.3.2
-myst-nb
+# Newer versions cause build failures; see https://github.com/google/jax/pull/10502
+myst-nb==0.13.2
 
 # Need to pin docutils to 0.16 to make bulleted lists appear correctly on
 # ReadTheDocs: https://stackoverflow.com/a/68008428


### PR DESCRIPTION
I spent a while attempting to make our build compatible with v0.14, but couldn't get it working for a couple reasons:

- myst-nb now errors if lexers are not specified; `08-pjit.md` does not specify a lexer and if I add this metadata it is stripped by `jupytext` because there is no associated notebook. If I add an associated notebook, then there are strange diffs in the pre-commit hook (it removes the capitalization of `maps.Mesh` within markdown blocks) that I can't reproduce outside the pre-commit hook, even with identical versions of the dependencies.
- myst-nb now tries to track hash links within notebooks, and this causes warnings if it breaks. Colab uses ID-based hash links that are not recognized by myst-nb, and so we'd need to remove these in order to update.

After some back and forth, I decided to just pin the old version.