### PR TITLE
[remove-units] remove units from partial_eval.py

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1512,7 +1512,7 @@ def _mapped_axis_size(tree, vals, dims, name, *, kws=False):
       tree, leaf = treedef_children(tree)
       assert treedef_is_leaf(leaf)
     # TODO(mattjj,phawkins): add a way to inspect pytree kind more directly
-    if tree == tree_flatten((core.unit,) * tree.num_leaves)[1]:
+    if tree == tree_flatten((0,) * tree.num_leaves)[1]:
       lines1 = [f"arg {i} has shape {np.shape(x)} and axis {d} is to be mapped"
                 for i, (x, d) in enumerate(zip(vals, dims))]
       sizes = collections.defaultdict(list)

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1106,25 +1106,6 @@ def out_local_named_shapes(local_axes, *args, **kwargs):
   ans_axes = [frozenset(a.aval.named_shape) & local_axes for a in ans]
   yield ans, ans_axes
 
-@lu.transformation_with_aux
-def hide_units(unit_args, *args, **kwargs):
-  ans = yield restore_units(unit_args, args), kwargs
-  yield filter_units(ans)
-
-def filter_units(vals):
-  vals_no_units = [v for v in vals if v is not core.unit]
-  vals_is_unit = [v is core.unit for v in vals]
-  return vals_no_units, vals_is_unit
-
-def restore_units(is_unit, vals):
-  vals_it = iter(vals)
-  vals_with_units = [core.unit if u else next(vals_it) for u in is_unit]
-  try:
-    next(vals_it)
-    raise RuntimeError("Expected the iterator to be exhausted")
-  except StopIteration:
-    return vals_with_units
-
 
 def _jaxpr_trace_process_xmap(self, primitive, f: lu.WrappedFun, tracers, params):
   assert primitive is xmap_p


### PR DESCRIPTION
After last week's changes, units are no longer traced or introduced into jaxprs in any way, so we don't need to use them in partial evaluation.

(Also there are some unrelated removals of dead code in maps.py.)