### PR TITLE
[remove-units] remove units

### DIFF
--- a/jax/_src/ad_util.py
+++ b/jax/_src/ad_util.py
@@ -28,13 +28,9 @@ Array = Any
 map = safe_map
 
 jaxval_adders: Dict[type, Callable] = {}
-jaxval_adders[core.Unit] = lambda _, __: core.unit
 
 def add_jaxvals(x, y):
-  if core.get_aval(x) is core.abstract_unit is core.get_aval(y):
-    return core.unit
-  else:
-    return add_jaxvals_p.bind(x, y)
+  return add_jaxvals_p.bind(x, y)
 
 add_jaxvals_p: Primitive = Primitive('add_any')
 add_any_p = add_jaxvals_p
@@ -53,7 +49,6 @@ def zeros_like_aval(aval):
   return aval_zeros_likers[type(aval)](aval)
 
 aval_zeros_likers: Dict[Type[core.AbstractValue], Array] = {}
-aval_zeros_likers[core.AbstractUnit] = lambda _: core.unit
 
 def zeros_like_jaxval(val):
   return zeros_like_p.bind(val)

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -104,8 +104,6 @@ def check_vmap_rule_trees(rule, original_out_tree, out_tree, out_batched_tree):
 
 # Like batching.bdim_at_front, but doesn't broadcast if not mapped
 def maybe_bdim_at_front(x, bdim):
-  if core.get_aval(x) is core.abstract_unit:
-    return core.unit
   if bdim is not_mapped:
     return x
   else:

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -955,7 +955,7 @@ def _maybe_perturbed(x: Any) -> bool:
     # If x is a DynamicJaxprTracer then we're staging out; differentiation could
     # happen later, but some types always have trivial tangents.
     vspace = x.aval.at_least_vspace()
-    return not (vspace is core.abstract_unit or vspace is core.abstract_token or
+    return not (vspace is core.abstract_token or
                 getattr(vspace, 'dtype', None) is dtypes.float0)
   elif not isinstance(x, ad.JVPTracer):
     # If x is not a JVPTracer, recursively check its contents.

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1351,7 +1351,6 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
                                    tokens_in=ctx.tokens_in,
                                    tokens_out=ctx.tokens_out),
           in_node)[0]
-    if v.aval is not core.abstract_unit else in_node
     for v, aval, in_node, arg_in_axes
     in zip(call_jaxpr.invars, ctx.avals_in, in_nodes, mesh_in_axes))
 
@@ -1378,7 +1377,6 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
                                        avals_out=None,
                                        tokens_in=ctx.tokens_in,
                                        tokens_out=ctx.tokens_out), tiled_out)[0]
-      if v.aval is not core.abstract_unit else tiled_out
       for v, vectorized_outvar, tiled_out, ans_out_axes
       in zip(call_jaxpr.outvars, vectorized_jaxpr.outvars, tiled_outs,
              mesh_out_axes)]

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -202,8 +202,6 @@ def arrays_to_spvalues(
   def array_to_spvalue(arg):
     if isinstance(arg, BCOO):
       return spenv.sparse(arg.shape, arg.data, arg.indices)
-    elif core.get_aval(arg) is core.abstract_unit:
-      return spenv.unit()
     else:
       return spenv.dense(arg)
   return tree_map(array_to_spvalue, args, is_leaf=_is_bcoo)
@@ -231,11 +229,8 @@ def spvalues_to_avals(
     ) -> Any:
   """Convert a pytree of spvalues to an equivalent pytree of abstract values."""
   def spvalue_to_aval(spvalue):
-    if spvalue.is_unit():
-      return core.abstract_unit
-    else:
-      data = spenv.data(spvalue)
-      return core.ShapedArray(spvalue.shape, data.dtype, data.aval.weak_type)
+    data = spenv.data(spvalue)
+    return core.ShapedArray(spvalue.shape, data.dtype, data.aval.weak_type)
   return tree_map(spvalue_to_aval, spvalues, is_leaf=_is_spvalue)
 
 
@@ -372,8 +367,6 @@ def eval_sparse(
     assert a is not None
     env[var] = a
 
-  # TODO: handle unitvar at all?
-  #write_buffer(core.unitvar, core.unit)
   safe_map(write_buffer, jaxpr.constvars, consts)
   safe_map(write, jaxpr.invars, spvalues)
 

--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -207,7 +207,6 @@ def backward_pass(jaxpr: core.Jaxpr, reduce_axes, transform_stack,
       primal_env[v] = val
 
   primal_env: Dict[Any, Any] = {}
-  write_primal(core.unitvar, core.unit)
   map(write_primal, jaxpr.constvars, consts)
   # FIXME: invars can contain both primal and tangent values, and this line
   #        forces primal_in to contain UndefinedPrimals for tangent values!
@@ -574,7 +573,7 @@ def instantiate_zeros(tangent):
 # to instantiate zero abstract units with a different aval
 def instantiate_zeros_aval(aval, tangent):
   if type(tangent) is Zero:
-    assert type(tangent.aval) is core.AbstractUnit or tangent.aval == aval
+    assert tangent.aval == aval
     return zeros_like_aval(aval)
   else:
     return tangent

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -128,8 +128,7 @@ class BatchTracer(Tracer):
       assert type(batch_dim) in (int, NotMapped)
       if type(batch_dim) is int:
         aval = raise_to_shaped(core.get_aval(val))
-        assert aval is core.abstract_unit or 0 <= batch_dim < len(aval.shape)  # type: ignore
-        assert aval is not core.abstract_unit or batch_dim is not_mapped
+        assert batch_dim is not_mapped or 0 <= batch_dim < len(aval.shape)  # type: ignore
     self._trace = trace
     self.val = val
     self.batch_dim = batch_dim
@@ -138,10 +137,7 @@ class BatchTracer(Tracer):
   @property
   def aval(self):
     aval = raise_to_shaped(core.get_aval(self.val))
-    if self.batch_dim is not_mapped or aval is core.abstract_unit:
-      return aval
-    else:
-      return core.mapped_aval(aval.shape[self.batch_dim], self.batch_dim, aval)
+    return core.mapped_aval(aval.shape[self.batch_dim], self.batch_dim, aval)
 
   def full_lower(self):
     if self.batch_dim is not_mapped:
@@ -514,7 +510,6 @@ def _batch_jaxpr_outer(axis_name, axis_size, in_dims, main_type, *in_vals):
     axis_size, = {x.shape[d] for x, d in zip(in_vals, in_dims) if d is not not_mapped}
   in_dims = in_dims() if callable(in_dims) else in_dims
   in_dims = [canonicalize_axis(ax, np.ndim(x)) if isinstance(ax, int)
-             and not isinstance(core.get_aval(x), core.AbstractUnit)
              else ax for x, ax in zip(in_vals, in_dims)]
   with core.new_main(main_type, axis_name=axis_name) as main:
     with core.extend_axis_env(axis_name, axis_size, main):
@@ -649,8 +644,6 @@ def reducer_batcher(prim, batched_args, batch_dims, axes, **params):
 ### general utilities for manipulating axes on jaxpr types (not vmappables)
 
 def broadcast(x, sz, axis):
-  if core.get_aval(x) is core.abstract_unit:
-    return core.unit
   shape = list(np.shape(x))
   shape.insert(axis, sz)
   broadcast_dims = tuple(np.delete(np.arange(len(shape)), axis))
@@ -658,12 +651,10 @@ def broadcast(x, sz, axis):
 
 def matchaxis(axis_name, sz, src, dst, x, sum_match=False):
   try:
-    aval = core.get_aval(x)
+    _ = core.get_aval(x)
   except TypeError as e:
     raise TypeError(f"Output from batched function {repr(x)} with type "
                     f"{type(x)} is not a valid JAX type") from e
-  if aval is core.abstract_unit:
-    return core.unit
   if src == dst:
     return x
   elif type(src) == type(dst) == int:
@@ -681,8 +672,6 @@ def matchaxis(axis_name, sz, src, dst, x, sum_match=False):
       raise ValueError(f'vmap has mapped output but out_axes is {dst}')
 
 def bdim_at_front(x, bdim, size):
-  if core.get_aval(x) is core.abstract_unit:
-    return core.unit
   if bdim is not_mapped:
     return broadcast(x, size, 0)
   else:
@@ -693,7 +682,7 @@ def bdim_at_front(x, bdim, size):
 def add_batched(batched_args, batch_dims):
   bdx, bdy = batch_dims
   x, y = batched_args
-  if bdx == bdy or core.get_aval(x) == core.abstract_unit:
+  if bdx == bdy:
     return add_jaxvals(x, y), bdx
   elif bdx is not_mapped:
     x = broadcast(x, y.shape[bdy], bdy)

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -58,11 +58,8 @@ def _avals_to_results_handler(nrep, npart, partitions, out_avals):
   return handler
 
 def _aval_to_result_handler(npart, parts, aval):
-  if aval is not core.abstract_unit:
-    spec = pxla.partitioned_sharding_spec(npart, parts, aval)
-    indices = pxla.spec_to_indices(aval.shape, spec)
-  else:
-    spec = indices = None
+  spec = pxla.partitioned_sharding_spec(npart, parts, aval)
+  indices = pxla.spec_to_indices(aval.shape, spec)
   return pxla.local_aval_to_result_handler(aval, spec, indices)
 
 

--- a/jax/jaxpr_util.py
+++ b/jax/jaxpr_util.py
@@ -75,13 +75,12 @@ def var_defs_and_refs(jaxpr: core.Jaxpr):
   refs: Dict[core.Var, List[MaybeEqn]] = {}
 
   def read(a: core.Atom, eqn: MaybeEqn):
-    if a is not core.unitvar and not isinstance(a, core.Literal):
+    if not isinstance(a, core.Literal):
       assert a in defs, a
       assert a in refs, a
       refs[a].append(eqn)
 
   def write(v: core.Var, eqn: MaybeEqn):
-    assert v is not core.unitvar
     assert v not in defs, v
     assert v not in refs, v
     if not isinstance(v, core.DropVar):

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -301,40 +301,35 @@ class CoreTest(jtu.JaxTestCase):
 
   def test_comparing_var(self):
     newsym = core.gensym()
-    a = newsym(core.abstract_unit)
-    b = newsym(core.abstract_unit)
-    c = newsym(core.abstract_unit)
+    a = newsym(core.ShapedArray((), np.dtype('int32')))
+    b = newsym(core.ShapedArray((), np.dtype('int32')))
+    c = newsym(core.ShapedArray((), np.dtype('int32')))
     assert a < b < c
     assert c > b > a
     assert a != b and b != c and a != c
 
   def test_var_ordering(self):
     newsym = core.gensym()
-    a = newsym(core.abstract_unit)
-    b = newsym(core.abstract_unit)
-    c = newsym(core.abstract_unit)
+    a = newsym(core.ShapedArray((), np.dtype('int32')))
+    b = newsym(core.ShapedArray((), np.dtype('int32')))
+    c = newsym(core.ShapedArray((), np.dtype('int32')))
     for ordering in it.permutations([a, b, c]):
       assert sorted(list(ordering)) == [a, b, c]
 
   def test_var_compared_by_identity(self):
-    a1 = core.gensym()(core.abstract_unit)
-    a2 = core.gensym()(core.abstract_unit)
+    a1 = core.gensym()(core.ShapedArray((), np.dtype('int32')))
+    a2 = core.gensym()(core.ShapedArray((), np.dtype('int32')))
     assert str(a1) == str(a2)
     assert a1 != a2
 
   def test_var_tree_flatten(self):
     newsym = core.gensym()
+    aval = core.ShapedArray((), np.dtype('int32'))
     a, b, c, d = (
-        newsym(core.abstract_unit), newsym(core.abstract_unit),
-        newsym(core.abstract_unit), newsym(core.abstract_unit))
+        newsym(aval), newsym(aval),
+        newsym(aval), newsym(aval))
     syms = {c: d, a: b}
     assert 'bd' == ''.join(map(str, tree_leaves(syms)))
-
-  def test_device_put_unit(self):
-    def f(x, y):
-      return x, 2 * y
-    args_maker = lambda: (core.unit, 1)
-    self._CompileAndCheck(f, args_maker)
 
   def test_concrete_array_string_representation(self):
     # https://github.com/google/jax/issues/5364

--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -20,7 +20,7 @@ from absl.testing import parameterized
 
 import numpy as np
 
-from jax import config, core, jit, lax
+from jax import config, jit, lax
 import jax.numpy as jnp
 import jax._src.test_util as jtu
 from jax.experimental.sparse import BCOO, sparsify, todense, SparseTracer
@@ -90,12 +90,6 @@ class SparsifyTest(jtu.JaxTestCase):
     self.assertArraysEqual(args[0], args_out[0])
     self.assertBcooIdentical(args[1], args_out[1])
     self.assertBcooIdentical(args[2], args_out[2])
-
-  def testUnitHandling(self):
-    x = BCOO.fromdense(jnp.arange(5))
-    f = jit(lambda x, y: x)
-    result = self.sparsify(jit(f))(x, core.unit)
-    self.assertBcooIdentical(result, x)
 
   def testDropvar(self):
     def inner(x):


### PR DESCRIPTION
The changes here are actually trivial! Previous PRs revised all places where units are introduced, but left places where they were handled. This PR removes where they're handled, just deleting code.

Follow-up to:
* #10431
* #10432
* #10433
* #10448
* #10453
* #10455
* #10459
* #10468
* #10469
* #10483
* #10489
* #10501
* #10505
* #10506
* #10507
* #10508
*  #10509
* #10522