### PR TITLE
add more scan dce rule tests, fix issues

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -734,6 +734,12 @@ config.define_bool_state(
     default=(lib.version >= (0, 3, 6)),
     help=('Enables using optimization-barrier op for lowering remat.'))
 
+# TODO(mattjj): remove after May 19 2022, NeurIPS submission deadline
+config.define_bool_state(
+    name='after_neurips',
+    default=False,
+    help='Gate changes until after NeurIPS 2022 deadline.')
+
 @contextlib.contextmanager
 def explicit_device_put_scope() -> Iterator[None]:
   """Indicates that the current context is an explicit device_put*() call."""

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2037,6 +2037,8 @@ def _scan_padding_rule(in_avals, out_avals, *args, jaxpr, **params):
 
 def _scan_dce_rule(used_outputs: List[bool], eqn: core.JaxprEqn
                    ) -> Tuple[List[bool], core.JaxprEqn]:
+  if not config.after_neurips:
+    return [True] * len(eqn.params['jaxpr'].in_avals), eqn
   jaxpr = eqn.params['jaxpr']
   num_consts, num_carry = eqn.params['num_consts'], eqn.params['num_carry']
   num_xs = len(jaxpr.in_avals) - num_consts - num_carry

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2037,30 +2037,36 @@ def _scan_padding_rule(in_avals, out_avals, *args, jaxpr, **params):
 
 def _scan_dce_rule(used_outputs: List[bool], eqn: core.JaxprEqn
                    ) -> Tuple[List[bool], core.JaxprEqn]:
+  jaxpr = eqn.params['jaxpr']
   num_consts, num_carry = eqn.params['num_consts'], eqn.params['num_carry']
+  num_xs = len(jaxpr.in_avals) - num_consts - num_carry
   used_carry_out, used_extensive_out = split_list(used_outputs, [num_carry])
   for i in range(1 + num_carry):
     used_outputs = used_carry_out + used_extensive_out
-    jaxpr, used_inputs = pe.dce_jaxpr(eqn.params['jaxpr'].jaxpr, used_outputs)
+    jaxpr_dce, used_inputs = pe.dce_jaxpr(
+        jaxpr.jaxpr, used_outputs,
+        instantiate=[False] * num_consts + used_carry_out + [False] * num_xs)
     used_consts, used_carry_in, used_extensive_in = \
         split_list(used_inputs, [num_consts, num_carry])
-    if used_carry_in == used_carry_out:
+    if list(used_carry_in) == list(used_carry_out):
       break
     else:
       used_carry_out = _map(operator.or_, used_carry_out, used_carry_in)
   else:
     assert False, "Fixpoint not reached"
+  core.check_jaxpr(jaxpr.jaxpr)
 
   new_linear = [l for l, u in zip(eqn.params['linear'], used_inputs) if u]
   new_params = dict(eqn.params, num_consts=sum(used_consts),
                     num_carry=sum(used_carry_in), linear=tuple(new_linear),
-                    jaxpr=core.ClosedJaxpr(jaxpr, eqn.params['jaxpr'].consts))
+                    jaxpr=core.ClosedJaxpr(jaxpr_dce, jaxpr.consts))
   new_eqn = pe.new_jaxpr_eqn([v for v, used in zip(eqn.invars, used_inputs)
                               if used],
                              [v for v, used in zip(eqn.outvars, used_outputs)
                               if used],
                              eqn.primitive, new_params, eqn.effects,
                              eqn.source_info)
+  assert len(new_eqn.invars ) == len(new_params['jaxpr'].in_avals )
   assert len(new_eqn.outvars) == len(new_params['jaxpr'].out_avals)
   return used_inputs, new_eqn
 
@@ -2133,8 +2139,7 @@ core.custom_typechecks[scan_p] = partial(_scan_typecheck, False)
 pe.partial_eval_jaxpr_custom_rules[scan_p] = \
     partial(pe.partial_eval_jaxpr_custom_rule_not_implemented, 'scan')
 pe.padding_rules[scan_p] = _scan_padding_rule
-# TODO(mattjj): re-enable
-# pe.dce_rules[scan_p] = _scan_dce_rule
+pe.dce_rules[scan_p] = _scan_dce_rule
 
 
 @api_boundary

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4519,6 +4519,7 @@ class JaxprTest(jtu.JaxTestCase):
     self.assertLen(jaxpr.eqns, 0)
 
 
+@unittest.skipIf(not config.after_neurips, "skip until neurips deadline")
 class DCETest(jtu.JaxTestCase):
 
   def assert_dce_result(self, jaxpr: core.Jaxpr, used_outputs: List[bool],


### PR DESCRIPTION
* add an `instantiate` argument to `pe.dce_jaxpr`, needed for fixpoint in scan DCE rule (o/w can hit "fixpoint not reached")
* add more scan DCE testing, including checkin the jaxpr integrity and checking input/output behavior

~TODO: let's brainstorm more tests~