### PR TITLE
Attach callback keepalive to JIT executable

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -815,7 +815,7 @@ def xla_computation(fun: Callable,
         out_parts_flat = tuple(flatten_axes(
             "xla_computation out_parts", out_tree(), out_parts))
       effects = list(jaxpr.effects)
-      m = mlir.lower_jaxpr_to_module(
+      m, _ = mlir.lower_jaxpr_to_module(
           f"xla_computation_{fun_name}",
           core.ClosedJaxpr(jaxpr, consts),
           effects=effects,

--- a/jax/interpreters/sharded_jit.py
+++ b/jax/interpreters/sharded_jit.py
@@ -141,7 +141,7 @@ def _sharded_callable(
 
   axis_env = xla.AxisEnv(nrep, (), ())
   effects = list(jaxpr.effects)
-  module = mlir.lower_jaxpr_to_module(
+  module, _ = mlir.lower_jaxpr_to_module(
       "spjit_{}".format(fun.__name__),
       core.ClosedJaxpr(jaxpr, consts),
       effects,

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -88,9 +88,6 @@ def _(*avals, callback, out_avals, effect):
   del avals, callback
   return out_avals, {effect}
 
-
-# TODO(sharadmv): Attach keep alive to executable
-leak = [].append
 def callback_effect_lowering(ctx: mlir.LoweringRuleContext, *args, callback, out_avals, effect):
   del out_avals
   def _token_callback(token, *args):
@@ -102,7 +99,7 @@ def callback_effect_lowering(ctx: mlir.LoweringRuleContext, *args, callback, out
       ctx.module_context.platform, _token_callback,
       [token_in, *args], [core.abstract_token, *ctx.avals_in],
       [core.abstract_token, *ctx.avals_out], True)
-  leak(keep_alive)
+  ctx.module_context.add_keepalive(keep_alive)
   ctx.set_tokens_out(ctx.tokens_in.update_tokens(mlir.TokenSet({effect:
     token_out})))
   return out_op


### PR DESCRIPTION
When staging out Python callbacks, we need to keep a reference to the Python callback alive to avoid it being garbage collected. Currently, we leak the callback into global list (this is also the approach of `host_callback`) but we can do a bit better by attaching a reference to the callback to the executable XLA computation. When the computation is gone, we no longer need the callback and it will be freed along with the executable.

This PR attaches callbacks to JIT executables and leaves a TODO for pmap executables.