### PR TITLE
Enable effect lowering for while/for/scan

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -23,12 +23,15 @@ from jax import tree_util
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
+from jax._src.lax import control_flow as lcf
 
 DebugEffect = enum.Enum('DebugEffect', ['PRINT', 'ORDERED_PRINT'])
 
 core.ordered_effects.add(DebugEffect.ORDERED_PRINT)
 mlir.lowerable_effects.add(DebugEffect.PRINT)
 mlir.lowerable_effects.add(DebugEffect.ORDERED_PRINT)
+lcf.allowed_effects.add(DebugEffect.PRINT)
+lcf.allowed_effects.add(DebugEffect.ORDERED_PRINT)
 
 # `debug_callback_p` is the main primitive for staging out Python callbacks.
 debug_callback_p = core.Primitive('debug_callback')

--- a/jax/core.py
+++ b/jax/core.py
@@ -2285,10 +2285,13 @@ def _check_jaxpr(
       else:
         out_avals, effects = check_eqn(prim, in_avals, eqn.params)
       if eqn.effects != effects:
-        raise JaxprTypeError("Inferred effects do not match equation effects.")
+        raise JaxprTypeError("Inferred effects do not match equation effects. "
+                             f"Equation effects: {eqn.effects}. "
+                             f"Jaxpr effects: {effects}")
       if not eqn.effects.issubset(jaxpr.effects):
         raise JaxprTypeError("Equation effects are not subset of Jaxpr effects. "
-                             f"Equation effects: {eqn.effects}. Jaxpr effects: {jaxpr.effects}")
+                             f"Equation effects: {eqn.effects}. "
+                             f"Jaxpr effects: {jaxpr.effects}")
       map(write, eqn.outvars, out_avals)
     except JaxprTypeError as e:
       ctx, settings = ctx_factory()


### PR DESCRIPTION
This change adds a global `allowed_effects` allowlist to `lax._src.control_flow.py`. Scan and while check that the jaxpr effects are in the allowlist (TODO for cond). In the lowering, ordered effects have tokens threaded in and out of the HOP bodies.

Note that this doesn't allow effects in the `cond` of a while loop, which is a trickier case and will be implemented in a subsequent PR.

cc: @LenaMartens 