### PR TITLE
remove count attribute and total_ordering from core.Var

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -618,7 +618,7 @@ def ignore_errors_jaxpr(jaxpr, error):
   payload_aval = core.raise_to_shaped(core.get_aval(error.payload))
   consts = jaxpr.consts
   jaxpr = jaxpr.jaxpr
-  new_vars = core.gensym([jaxpr])
+  new_vars = core.gensym()
   new_invars = (new_vars(err_aval), new_vars(code_aval),
                 new_vars(payload_aval), *jaxpr.invars)
   new_jaxpr = jaxpr.replace(invars=new_invars)

--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -98,7 +98,7 @@ def _initial_style_jaxprs_with_common_consts(
       unzip3(_initial_style_open_jaxpr(fun, in_tree, in_avals, primitive_name)
              for fun in funs)
 
-  newvar = core.gensym(jaxprs, suffix='_')
+  newvar = core.gensym(suffix='_')
   all_const_avals = [[raise_to_shaped(core.get_aval(c)) for c in consts]
                      for consts in all_consts]
   unused_const_vars = [[newvar(aval) for aval in const_avals]
@@ -451,7 +451,7 @@ def _while_loop_jvp(primals, tangents, cond_nconsts, cond_jaxpr, body_nconsts,
       [body_nconsts, num_carry], [len(bconst_dot), len(init_dot)],
       [num_carry], [len(init_dot)])
 
-  newvar = core.gensym([cond_jaxpr.jaxpr])
+  newvar = core.gensym()
   invars_aug = (
       cond_jaxpr.jaxpr.invars + [newvar(core.get_aval(x)) for x in init_dot])
   cond_jaxpr_augmented = core.Jaxpr(cond_jaxpr.jaxpr.constvars,
@@ -1147,7 +1147,7 @@ def _join_cond_outputs(jaxprs, all_res_avals, res_aval_indices_per_jaxpr,
 # that it does not read.
 def _join_cond_pe_staged_jaxpr_inputs(jaxprs, all_res_avals,
                                       res_aval_indices_per_jaxpr):
-  newvar = core.gensym([j.jaxpr for j in jaxprs], suffix='_')
+  newvar = core.gensym(suffix='_')
   all_res_vars = _map(newvar, all_res_avals)
 
   def augment_jaxpr(jaxpr, res_indices):

--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -1500,7 +1500,7 @@ def _rewrite_jaxpr(jaxpr: core.Jaxpr, has_input_token: bool,
   if not has_input_token and not core.jaxpr_uses_outfeed(jaxpr):
     return jaxpr
 
-  mk_new_var = core.gensym([jaxpr])
+  mk_new_var = core.gensym()
 
   eqns: List[core.JaxprEqn] = []
   # store the incoming tokens

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1833,7 +1833,7 @@ def _fix_inferred_spmd_sharding(jaxpr, resource_env, gen_fresh_name = None):
     return jaxpr.map_jaxpr(rec)
   assert isinstance(jaxpr, core.Jaxpr)
   if gen_fresh_name is None:
-    gen_fresh_name = core.gensym([jaxpr])
+    gen_fresh_name = core.gensym()
   new_eqns = []
   for eqn in jaxpr.eqns:
     new_jaxpr_params = core.traverse_jaxpr_params(rec, eqn.params)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1119,7 +1119,7 @@ def call_partial_eval_custom_rule(
   out_binders_known, _ = partition_list(unks_out, eqn.outvars)
   _, out_binders_staged = partition_list(inst_out, eqn.outvars)
   kept_outs_staged = inst_out
-  newvar = core.gensym([jaxpr_known, jaxpr_staged])
+  newvar = core.gensym()
   residuals = [newvar(v.aval) for v in jaxpr_staged.invars[:num_res]]
   params_known = {**eqn.params, jaxpr_param_name: jaxpr_known}
   params_staged = {**eqn.params, jaxpr_param_name: jaxpr_staged}

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -16,7 +16,6 @@
 from collections import namedtuple
 from functools import partial
 import gc
-import itertools as it
 import operator
 
 import numpy as np
@@ -30,8 +29,7 @@ from jax import numpy as jnp
 from jax import linear_util as lu
 from jax import jvp, linearize, vjp, jit, make_jaxpr
 from jax.core import UnshapedArray, ShapedArray
-from jax.tree_util import (tree_flatten, tree_unflatten, tree_map, tree_reduce,
-                           tree_leaves)
+from jax.tree_util import tree_flatten, tree_unflatten, tree_map, tree_reduce
 from jax.interpreters import partial_eval as pe
 
 from jax._src import test_util as jtu
@@ -299,38 +297,6 @@ class CoreTest(jtu.JaxTestCase):
     finally:
       gc.set_debug(debug)
 
-  def test_comparing_var(self):
-    newsym = core.gensym()
-    a = newsym(core.ShapedArray((), np.dtype('int32')))
-    b = newsym(core.ShapedArray((), np.dtype('int32')))
-    c = newsym(core.ShapedArray((), np.dtype('int32')))
-    assert a < b < c
-    assert c > b > a
-    assert a != b and b != c and a != c
-
-  def test_var_ordering(self):
-    newsym = core.gensym()
-    a = newsym(core.ShapedArray((), np.dtype('int32')))
-    b = newsym(core.ShapedArray((), np.dtype('int32')))
-    c = newsym(core.ShapedArray((), np.dtype('int32')))
-    for ordering in it.permutations([a, b, c]):
-      assert sorted(list(ordering)) == [a, b, c]
-
-  def test_var_compared_by_identity(self):
-    a1 = core.gensym()(core.ShapedArray((), np.dtype('int32')))
-    a2 = core.gensym()(core.ShapedArray((), np.dtype('int32')))
-    assert str(a1) == str(a2)
-    assert a1 != a2
-
-  def test_var_tree_flatten(self):
-    newsym = core.gensym()
-    aval = core.ShapedArray((), np.dtype('int32'))
-    a, b, c, d = (
-        newsym(aval), newsym(aval),
-        newsym(aval), newsym(aval))
-    syms = {c: d, a: b}
-    assert 'bd' == ''.join(map(str, tree_leaves(syms)))
-
   def test_concrete_array_string_representation(self):
     # https://github.com/google/jax/issues/5364
     self.assertEqual(
@@ -491,7 +457,7 @@ class JaxprTypeChecks(jtu.JaxTestCase):
   def test_jaxpr_undefined_eqn_invar(self):
     jaxpr = make_jaxpr(lambda x: jnp.sin(x) + jnp.cos(x))(1.).jaxpr
     cos = next(eqn for eqn in jaxpr.eqns if eqn.primitive.name == 'cos')
-    cos.invars[0] = core.gensym([jaxpr], suffix='_test')(cos.invars[0].aval)
+    cos.invars[0] = core.gensym(suffix='_test')(cos.invars[0].aval)
     self.assertRaisesRegex(
         core.JaxprTypeError,
         r"Variable '.+_test' not defined\n\nin equation:",


### PR DESCRIPTION
Originally we used the `Var.count` attribute to ensure Var instances were printed consistently regardless of context, even though only their object id was load-bearing. That is, `Var.count` was only used for pretty printing. (#1949 added a total_ordering on `Var` for reasons out of scope of JAX's core code. I'm going to figure out if that's still needed... Haiku tests all seem to pass without it.)

But #8019 revised our pretty-printing so as not to use `Var.count`. Instead it chose how to pretty-print `Var` instances based on their order of appearance in a jaxpr. That meant `Var.count` really wasn't useful anymore.

So this PR removes `Var.count`. Since we no longer have `Var.count`, we also don't need `core.gensym` to take an optional sequence of jaxprs, since that was just used to set the starting count index for new `Var`s.

In fact, `Var.__repr__` and `JaxprEqn.__repr__` were made confusing after #8019, since they could print variable names totally different from the names that would appear when the same `JaxprEqn` or `Var` objects were printed as part of a jaxpr. That is, before this PR we might have a jaxpr which printed like:

```python
import jax

def f(x):
  for _ in range(3):
    x = jax.numpy.sin(x)
  return x

jaxpr = jax.make_jaxpr(f)(3.)
print(jaxpr)
# { lambda ; a:f32[]. let
#     b:f32[] = sin a
#     c:f32[] = sin b
#     d:f32[] = sin c
#   in (d,) }

_, eqn, _ = jaxpr.jaxpr.eqns
print(eqn)
# a:f32[] = sin b
```

Notice the variable names in the equation pretty-print don't correspond to any in the jaxpr pretty-print!

So this PR changes `JaxprEqn.__repr__` and `Var.__repr__` to show `Var` object ids, and in general just do less formatting (which seems consistent with the spirit of `__repr__`):
```
JaxprEqn(invars=[Var(id=140202705341552):float32[]], outvars=[Var(id=140202705339584):float32[]], primitive=sin, params={}, effects=set(), source_info=SourceInfo(traceback=<jaxlib.xla_extension.Traceback object at 0x7f837c73d770>, name_stack=NameStack(stack=())))
```