### PR TITLE
[new-remat] add scan rule for new remat

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -589,7 +589,11 @@ def traceable(num_primals, in_tree_def, *primals_and_tangents):
 
 
 def call_transpose(primitive, params, call_jaxpr, args, ct, _, reduce_axes):
-  all_args, in_tree_def = tree_flatten(((), args, ct))  # empty consts
+  if isinstance(call_jaxpr, core.ClosedJaxpr):
+    call_jaxpr, consts = call_jaxpr.jaxpr, call_jaxpr.consts
+  else:
+    consts = ()
+  all_args, in_tree_def = tree_flatten((consts, args, ct))
   fun = lu.hashable_partial(lu.wrap_init(backward_pass), call_jaxpr,
                             reduce_axes, False)
   fun, out_tree = flatten_fun_nokwargs(fun, in_tree_def)

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -997,7 +997,6 @@ def lower_fun(fun: Callable, multiple_results: bool = True) -> Callable:
   return f_lowered
 
 
-
 def _call_lowering(fn_name, stack_name, call_jaxpr, backend, ctx, avals_in,
                    avals_out, tokens_in, *args):
   if isinstance(call_jaxpr, core.Jaxpr):
@@ -1038,6 +1037,9 @@ def _named_call_lowering(ctx, *args, name, backend=None,
 
 register_lowering(core.named_call_p, _named_call_lowering)
 register_lowering(core.call_p, partial(_named_call_lowering, name="core_call"))
+register_lowering(core.closed_call_p,
+                  partial(_named_call_lowering, name="core_closed_call"))
+
 register_lowering(core.closed_call_p,
                   partial(_named_call_lowering, name="core_closed_call"))
 


### PR DESCRIPTION
TODO:
* [x] extensive-to-intensive residuals optimization
* [x] ~forwarding optimization~ turns out it's not needed with new remat, b/c new remat doesn't pass inputs through jaxpr_known as residuals!
* [x] make sure we don't forward numpy.ndarrays though (i.e. make the fix analogous to #4526) **NOTE:** I only half-finished this, see [this TODO](https://github.com/google/jax/pull/10576/files#diff-c3f68aab0e05d9d2de62fd88802c96c19d9060f6d2500a7eb4266ee4139e717cR2374).
* [x] get lots of coverage by adapting existing tests
* [x] merge #10536 (this PR includes changes from that PR)
* [x] merge #10595 (this PR includes changes from that PR)
* [x] merge #10616 (this PR includes changes from that PR)
* [x] merge #10711 (this PR includes changes from that PR)
* [x] write new tests
* [ ] [eventually, probably not this PR] de-duplicate with `_scan_partial_eval` (the policy-less tracers-in-tracers-out analogue of the new `_scan_partial_eval_custom` function)

The main idea is that `_scan_partial_eval_custom` generalizes partial evaluation so that what gets staged out doesn't necessarily correspond to what is unknown. That is, in standard partial evaluation, we unzip into known and unknown parts, and the unknown parts get staged into a jaxpr. But with more general partial evaluation, parameterized by a policy, what gets staged out can in general be different from what's unknown: known things can get staged out too. The rule signature, accordingly, has distinct list-of-bool inputs and outputs to indicate known-ness and staged-ness.