### PR TITLE
Enable ordered effects in the `cond` of a while loop

### DIFF
--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -654,6 +654,16 @@ class ControlFlowEffectsTest(jtu.JaxTestCase):
       return lax.while_loop(cond_fun, body_fun, x)
     f(2)
 
+  def test_allowed_effect_in_cond_body(self):
+    def f(x):
+      def cond_fun(x):
+        effect_p.bind(effect='while')
+        return False
+      def body_fun(x):
+        return x
+      return lax.while_loop(cond_fun, body_fun, x)
+    f(2)
+
   def test_allowed_ordered_effect_in_while_body(self):
     def f(x):
       def cond_fun(x):


### PR DESCRIPTION
For a while loop with ordered effects in the cond, we need a special lowering. Fundamentally, we'd like to rewrite a while loop that looks like this:
```python
while cond(x):
  x = body(x)
```
into something that looks like this:
```python
while True:
  token, pred = cond(token, x)
  if not pred:
    break
  token, x = body(token, x)
```
Unfortunately, with an MHLO while we can't (1) return multiple values from a `cond` and (2) can't break a while loop. We thus adopt the following rewrite strategy:
```python
def new_cond(pred, token, x):
  return pred
token, pred = cond(token, x)
while new_cond(pred, token, x):
  token, x = body(token, x)
  token, pred = cond(token, x)
```
Note that this is also the approach taken by host callback.

Stacked on: #10569 