### PR TITLE
Enable AD rules for `debug_print`

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -78,15 +78,16 @@ batching.primitive_batchers[debug_callback_p] = debug_callback_batching_rule
 def debug_callback_jvp_rule(*flat_args, callback: Callable[..., Any],
     effect: DebugEffect, in_tree: tree_util.PyTreeDef):
   del flat_args, callback, effect, in_tree
-  # TODO(sharadmv): implement jvp rule
-  raise NotImplementedError('JVP not supported for `debug_callback`.')
+  # TODO(sharadmv): link to relevant documentation when it exists
+  raise ValueError(
+      "JVP doesn't support debugging callbacks. "
+      "Instead, you can use them with `jax.custom_jvp` or `jax.custom_vjp`.")
 ad.primitive_jvps[debug_callback_p] = debug_callback_jvp_rule
 
 def debug_callback_transpose_rule(*flat_args, callback: Callable[..., Any],
     effect: DebugEffect, in_tree: tree_util.PyTreeDef):
   del flat_args, callback, effect, in_tree
-  # TODO(sharadmv): implement transpose rule
-  raise NotImplementedError('Transpose not supported for `debug_callback`.')
+  raise ValueError("Transpose doesn't support debugging callbacks.")
 ad.primitive_transposes[debug_callback_p] = debug_callback_transpose_rule
 
 def _ordered_effect_lowering(ctx, token, *args, **params):


### PR DESCRIPTION
The AD rules for `debug_print` are just errors.