### PR TITLE
api_util: make shaped_abstractify respect raise_to_shaped

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -318,7 +318,8 @@ def _dtype(x):
 
 def shaped_abstractify(x):
   try:
-    return core.raise_to_shaped(core.get_aval(x))
+    return core.raise_to_shaped(
+      x if isinstance(x, core.AbstractValue) else core.get_aval(x))
   except TypeError:
     pass
 

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -27,6 +27,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax._src import test_util as jtu
+from jax import dtypes
 from jax import stages
 from jax.errors import JAXTypeError
 from jax import lax
@@ -827,7 +828,7 @@ class PJitTest(jtu.BufferDonationTestCase):
       return x @ y
 
     shape = (8, 8)
-    aval = jax.ShapedArray(shape, jnp.int64)
+    aval = jax.ShapedArray(shape, dtypes.canonicalize_dtype(jnp.int64))
     x = jnp.arange(np.prod(shape)).reshape(shape)
     exe = f.lower(aval, x, _global_avals=True).compile()
     self.assertIsInstance(exe, stages.Compiled)


### PR DESCRIPTION
This issue came up when tracing functions with sparse-aware avals for testing enhancements to `jax.experimental.sparse`.

The test change is necessary because the new code path will not canonicalize the dtype of the aval; I don't think this is necessary in practice, but the pjit test with an explicitly constructed aval was falling afoul of this.