### PR TITLE
Additional input validation for transformations

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import operator
 from functools import partial
-from typing import Any, Dict, Iterable, Tuple, Sequence, Union, Optional
+from typing import Any, Dict, Iterable, Sequence, Set, Tuple, Union, Optional
+import warnings
 
 import numpy as np
 
@@ -132,6 +134,94 @@ class _HashableWithStrictTypeEquality:
   def __eq__(self, other):
     return type(self.val) is type(other.val) and self.val == other.val
 
+_POSITIONAL_ARGUMENTS = (
+  inspect.Parameter.POSITIONAL_ONLY,
+  inspect.Parameter.POSITIONAL_OR_KEYWORD
+)
+
+def validate_argnums(sig: inspect.Signature, argnums: Tuple[int, ...], argnums_name: str) -> None:
+  """
+  Validate that the argnums are sensible for a given function.
+
+  For functions that accept a variable number of positions arguments
+  (`f(..., *args)`) all positive argnums are considered valid.
+  """
+  n_pos_args = 0
+  for param in sig.parameters.values():
+    if param.kind in _POSITIONAL_ARGUMENTS:
+      n_pos_args += 1
+
+    elif param.kind is inspect.Parameter.VAR_POSITIONAL:
+      # We can have any number of positional arguments
+      return
+
+  if argnums and (-min(argnums) > n_pos_args or max(argnums) >= n_pos_args):
+    # raise ValueError(f"Jitted function has {argnums_name}={argnums}, "
+    #                  f"but only accepts {n_pos_args} positional arguments.")
+    # TODO: 2022-08-20 or later: replace with error
+    warnings.warn(f"Jitted function has {argnums_name}={argnums}, "
+                  f"but only accepts {n_pos_args} positional arguments. "
+                  "This warning will be replaced by an error after 2022-08-20 "
+                  "at the earliest.", SyntaxWarning)
+
+_INVALID_KEYWORD_ARGUMENTS = (
+  inspect.Parameter.POSITIONAL_ONLY,
+  inspect.Parameter.VAR_POSITIONAL
+)
+
+_KEYWORD_ARGUMENTS = (
+  inspect.Parameter.POSITIONAL_OR_KEYWORD,
+  inspect.Parameter.KEYWORD_ONLY,
+)
+def validate_argnames(sig: inspect.Signature, argnames: Tuple[str, ...], argnames_name: str) -> None:
+  """
+  Validate that the argnames are sensible for a given function.
+
+  For functions that accept a variable keyword arguments
+  (`f(..., **kwargs)`) all argnames are considered valid except those
+  marked as position-only (`f(pos_only, /, ...)`).
+  """
+  var_kwargs = False
+  valid_kwargs: Set[str] = set()
+  invalid_kwargs: Set[str] = set()
+  for param_name, param in sig.parameters.items():
+    if param.kind in _KEYWORD_ARGUMENTS:
+      valid_kwargs.add(param_name)
+
+    elif param.kind is inspect.Parameter.VAR_KEYWORD:
+      var_kwargs = True
+
+    elif param.kind in _INVALID_KEYWORD_ARGUMENTS:
+      invalid_kwargs.add(param_name)
+
+
+  # Check whether any kwargs are invalid due to position only
+  invalid_argnames = invalid_kwargs & set(argnames)
+  if invalid_argnames:
+    # raise ValueError(f"Jitted function has invalid argnames {invalid_argnames} "
+    #                  f"in {argnames_name}. These are positional-only")
+    # TODO: 2022-08-20 or later: replace with error
+    warnings.warn(f"Jitted function has invalid argnames {invalid_argnames} "
+                  f"in {argnames_name}. These are positional-only. "
+                  "This warning will be replaced by an error after 2022-08-20 "
+                  "at the earliest.", SyntaxWarning)
+
+  # Takes any kwargs
+  if var_kwargs:
+    return
+
+  # Check that all argnames exist on function
+  invalid_argnames = set(argnames) - valid_kwargs
+  if invalid_argnames:
+    # TODO: 2022-08-20 or later: replace with error
+    # raise ValueError(f"Jitted function has invalid argnames {invalid_argnames} "
+    #                  f"in {argnames_name}. Function does not take these args.")
+    warnings.warn(f"Jitted function has invalid argnames {invalid_argnames} "
+                  f"in {argnames_name}. Function does not take these args."
+                  "This warning will be replaced by an error after 2022-08-20 "
+                  "at the earliest.", SyntaxWarning)
+
+
 
 def argnums_partial(f, dyn_argnums, args, require_static_args_hashable=True):
   dyn_argnums = _ensure_index_tuple(dyn_argnums)
@@ -154,6 +244,11 @@ def argnums_partial(f, dyn_argnums, args, require_static_args_hashable=True):
 
 def _ensure_inbounds(allow_invalid: bool, num_args: int, argnums: Sequence[int]
                      ) -> Tuple[int, ...]:
+  """
+  Ensure argnum is within bounds.
+
+  Also resolves negative argnums
+  """
   result = []
   for i in argnums:
     if i >= num_args and allow_invalid: continue
@@ -162,8 +257,9 @@ def _ensure_inbounds(allow_invalid: bool, num_args: int, argnums: Sequence[int]
           "Positional argument indices, e.g. for `static_argnums`, must have "
           "value greater than or equal to -len(args) and less than len(args), "
           f"but got value {i} for len(args) == {num_args}.")
-    result.append(i % num_args)
+    result.append(i % num_args)  # Resolve negative
   return tuple(result)
+
 
 def argnums_partial_except(f: lu.WrappedFun, static_argnums: Tuple[int, ...],
                            args: Tuple[Any], *, allow_invalid: bool):
@@ -180,9 +276,7 @@ def argnums_partial_except(f: lu.WrappedFun, static_argnums: Tuple[int, ...],
     if allow_invalid and i >= len(args):
       continue
     static_arg = args[i]
-    try:
-      hash(static_arg)
-    except TypeError:
+    if not is_hashable(static_arg):
       raise ValueError(
           "Non-hashable static arguments are not supported, as this can lead "
           f"to unexpected cache-misses. Static argument (index {i}) of type "

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -148,7 +148,7 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
 
 @_wraps(scipy.linalg.lu_solve,
         lax_description=_no_overwrite_and_chkfinite_doc, skip_params=('overwrite_b', 'check_finite'))
-@partial(jit, static_argnames=('trans', 'overwrite_a', 'check_finite'))
+@partial(jit, static_argnames=('trans', 'overwrite_b', 'check_finite'))
 def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
   del overwrite_b, check_finite
   lu, pivots = lu_and_piv

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -844,6 +844,18 @@ class JaxTestCase(parameterized.TestCase):
                         atol=atol or tol, rtol=rtol or tol,
                         canonicalize_dtypes=canonicalize_dtypes)
 
+_CPP_JIT_IMPLEMENTATION = functools.partial(api._jit, True)
+_CPP_JIT_IMPLEMENTATION._name = "cpp"
+_PYTHON_JIT_IMPLEMENTATION = functools.partial(api._jit, False)
+_PYTHON_JIT_IMPLEMENTATION._name = "python"
+_NOOP_JIT_IMPLEMENTATION = lambda x, *args, **kwargs: x
+_NOOP_JIT_IMPLEMENTATION._name = "noop"
+
+JIT_IMPLEMENTATION = (
+  _CPP_JIT_IMPLEMENTATION,
+  _PYTHON_JIT_IMPLEMENTATION,
+  _NOOP_JIT_IMPLEMENTATION,
+)
 
 class BufferDonationTestCase(JaxTestCase):
   assertDeleted = lambda self, x: self._assertDeleted(x, True)

--- a/tests/jax_jit_test.py
+++ b/tests/jax_jit_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 import inspect
 
 from absl.testing import absltest
@@ -199,10 +200,11 @@ class JaxJitTest(jtu.JaxTestCase):
     self.assertTrue(signature.weak_type)
 
   def test_signature_support(self):
+    jit = partial(api._jit, True)
     def f(a, b, c):
       return a + b + c
 
-    jitted_f = api._cpp_jit(f)
+    jitted_f = jit(f)
     self.assertEqual(inspect.signature(f), inspect.signature(jitted_f))
 
 

--- a/tests/x64_context_test.py
+++ b/tests/x64_context_test.py
@@ -23,7 +23,6 @@ from absl.testing import parameterized
 import numpy as np
 
 import jax
-from jax._src import api
 from jax import lax
 from jax import random
 from jax.config import config
@@ -34,23 +33,12 @@ import jax._src.test_util as jtu
 config.parse_flags_with_absl()
 
 
-def _maybe_jit(jit_type, func, *args, **kwargs):
-  if jit_type == "python":
-    return api._python_jit(func, *args, **kwargs)
-  elif jit_type == "cpp":
-    return api._cpp_jit(func, *args, **kwargs)
-  elif jit_type is None:
-    return func
-  else:
-    raise ValueError(f"Unrecognized jit_type={jit_type!r}")
-
-
 class X64ContextTests(jtu.JaxTestCase):
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_jit={jit}", "jit": jit}
-      for jit in ["python", "cpp", None]))
+      {"testcase_name": f"_jit={jit._name}", "jit": jit}
+      for jit in jtu.JIT_IMPLEMENTATION))
   def test_make_array(self, jit):
-    func = _maybe_jit(jit, lambda: jnp.array(np.float64(0)))
+    func = jit(lambda: jnp.array(np.float64(0)))
     dtype_start = func().dtype
     with enable_x64():
       self.assertEqual(func().dtype, "float64")
@@ -60,15 +48,15 @@ class X64ContextTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
       jtu.cases_from_list({
-          "testcase_name": f"_jit={jit}_f_{f.__name__}",
+          "testcase_name": f"_jit={jit._name}_f_{f.__name__}",
           "jit": jit,
           "enable_or_disable": f
-      } for jit in ["python", "cpp", None] for f in [enable_x64, disable_x64]))
+      } for jit in jtu.JIT_IMPLEMENTATION for f in [enable_x64, disable_x64]))
   def test_correctly_capture_default(self, jit, enable_or_disable):
     # The fact we defined a jitted function with a block with a different value
     # of `config.enable_x64` has no impact on the output.
     with enable_or_disable():
-      func = _maybe_jit(jit, lambda: jnp.array(np.float64(0)))
+      func = jit(lambda: jnp.array(np.float64(0)))
       func()
 
     expected_dtype = "float64" if config._read("jax_enable_x64") else "float32"
@@ -81,12 +69,12 @@ class X64ContextTests(jtu.JaxTestCase):
 
   @unittest.skipIf(jtu.device_under_test() != "cpu", "Test presumes CPU precision")
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_jit={jit}", "jit": jit}
-      for jit in ["python", "cpp", None]))
+      {"testcase_name": f"_jit={jit._name}", "jit": jit}
+      for jit in jtu.JIT_IMPLEMENTATION))
   def test_near_singular_inverse(self, jit):
     rng = jtu.rand_default(self.rng())
 
-    @partial(_maybe_jit, jit, static_argnums=1)
+    @partial(jit, static_argnums=1)
     def near_singular_inverse(N=5, eps=1E-40):
       X = rng((N, N), dtype='float64')
       X = jnp.asarray(X)
@@ -102,10 +90,10 @@ class X64ContextTests(jtu.JaxTestCase):
       self.assertTrue(jnp.all(~jnp.isfinite(result_32)))
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_jit={jit}", "jit": jit}
-      for jit in ["python", "cpp", None]))
+      {"testcase_name": f"_jit={jit._name}", "jit": jit}
+      for jit in jtu.JIT_IMPLEMENTATION))
   def test_while_loop(self, jit):
-    @partial(_maybe_jit, jit)
+    @jit
     def count_to(N):
       return lax.while_loop(lambda x: x < N, lambda x: x + 1.0, 0.0)
 


### PR DESCRIPTION
Adds additional input validation for `*_argnames` and `*_argnums` arguments to `jax.jit`.

Previously `static_argnums` and `static_argnames` could easily lead to silently dynamic arguments. In fact, two such cases were found in the `jax` source code using the new test coverage (c477ce3).

Additional test coverage has been added.

Includes a small refactoring in `api.py` which introduces `_jit` to reduce code duplication (this leads to a number of small changes in various tests). The refactoring has the additional benefit of making experimentation with #10476 easier.

For discussion see issue: #10601

Other places that could use additional validation (just add plumbing to validation logic introduced by this PR)
- `jax.experiment.pjit`
- `jax.pmap`
- `jax.value_and_grad`
- `jax.custom_vjp`
- `jax.custom_jvp`
- `jax.hessian`
- `jax.jacrev`
- `jax.jacfwd`
- `jax.grad`

I will add validation for the functions mentioned above in a separate PR once/if this one has been merged.

# Handling of `*args` and `**kwargs`

In cases where variable positional and/or keyword arguments are used, we (rightly) assume that the function will know how to deal with these and thus it is safe to assume that for `*args` any `argnum` is valid. Similarly for `**kwargs` any `argname` is valid.

Importantly we still do some validation where possible. As an example, consider:
```python
def f(a, /, b, *, c): ...

jit(f, static_argnames=("a",))   # This will fail since we know that `a` must be positional

jit(f, static_argnums=(2,))  # This will fail since `c` must be keyword
```

# Additional improvements

`argnums` could be patched to contain positional-only arguments given as `static_argnames` using `inspect`.

Currently:
```python
def f(a, /, b, *, c):
    print(a, b, c)

ff = jit(f, static_argnames=("a", "b", "c"))  # with validation disabled
ff(1, 2, c=3)
> Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)> 2 3
# Expected: 1 2 3

ff2 = jit(f, static_argnames=("b", "c"), static_argnums=(0,))
ff2(1, 2, c=3)
> 1 Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)> 3
# Expected 1 2 3
```

This is due to the way `_infer_argnums_and_argnames` works, which might be worthwhile to change in a separate PR. See further discussion in #10614

Fix: #10601
Fix: #10046