### PR TITLE
Better `argnums`/`argnames` inference

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -55,7 +55,7 @@ from jax._src import source_info_util
 from jax._src import traceback_util
 from jax._src.api_util import (
     flatten_fun, apply_flat_fun, flatten_fun_nokwargs, flatten_fun_nokwargs2,
-    argnums_partial, argnums_partial_except, flatten_axes, donation_vector,
+    argnums_partial, argnums_partial_except, flatten_axes, donation_vector, infer_argnums_and_argnames,
     rebase_donate_argnums, _ensure_index, _ensure_index_tuple,
     shaped_abstractify, _ensure_str_tuple, argnames_partial_except)
 from jax._src.lax import lax as lax_internal
@@ -185,45 +185,6 @@ def _isgeneratorfunction(fun):
   while isinstance(fun, functools.partial):
     fun = fun.func
   return inspect.isfunction(fun) and bool(fun.__code__.co_flags & inspect.CO_GENERATOR)
-
-_POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
-
-def _infer_argnums_and_argnames(
-    fun: Callable,
-    argnums: Union[int, Iterable[int], None],
-    argnames: Union[str, Iterable[str], None],
-  ) -> Tuple[Tuple[int, ...], Tuple[str, ...]]:
-  """Infer missing argnums and argnames for a function with inspect."""
-  if argnums is None and argnames is None:
-    argnums = ()
-    argnames = ()
-  elif argnums is not None and argnames is not None:
-    argnums = _ensure_index_tuple(argnums)
-    argnames = _ensure_str_tuple(argnames)
-  else:
-    try:
-      signature = inspect.signature(fun)
-    except ValueError:
-      # In rare cases, inspect can fail, e.g., on some builtin Python functions.
-      # In these cases, don't infer any parameters.
-      parameters: Mapping[str, inspect.Parameter] = {}
-    else:
-      parameters = signature.parameters
-    if argnums is None:
-      assert argnames is not None
-      argnames = _ensure_str_tuple(argnames)
-      argnums = tuple(
-          i for i, (k, param) in enumerate(parameters.items())
-          if param.kind == _POSITIONAL_OR_KEYWORD and k in argnames
-      )
-    else:
-      assert argnames is None
-      argnums = _ensure_index_tuple(argnums)
-      argnames = tuple(
-          k for i, (k, param) in enumerate(parameters.items())
-          if param.kind == _POSITIONAL_OR_KEYWORD and i in argnums
-      )
-  return argnums, argnames
 
 
 def jit(
@@ -373,7 +334,7 @@ def _python_jit(
     abstracted_axes: Optional[PytreeOfAbstractedAxesSpec] = None,
   ) -> stages.Wrapped:
   _check_callable(fun)
-  static_argnums, static_argnames = _infer_argnums_and_argnames(
+  static_argnums, static_argnames = infer_argnums_and_argnames(
       fun, static_argnums, static_argnames)
   static_argnums = _ensure_index_tuple(static_argnums)
   donate_argnums = _ensure_index_tuple(donate_argnums)
@@ -446,7 +407,7 @@ def _cpp_jit(
   # the C++ code will fallback to `_python_jit` when it faces some unsupported
   # feature.
   _check_callable(fun)
-  static_argnums, static_argnames = _infer_argnums_and_argnames(
+  static_argnums, static_argnames = infer_argnums_and_argnames(
       fun, static_argnums, static_argnames)
   static_argnums = _ensure_index_tuple(static_argnums)
   donate_argnums = _ensure_index_tuple(donate_argnums)


### PR DESCRIPTION
This PR adds additional tests for `infer_argnums_and_argnames` which has been moved from `api.py` to `api_utils.py`.

This is still a WIP and notably it changes the inference logic.

The previous logic is described in detail in [the documentation](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html#jax.jit), but seems to be needlessly restrictive, since I cannot foresee a use-case where you would want:
> if both static_argnums and static_argnames are provided, inspect.signature is not used, and only actual parameters listed in either static_argnums or static_argnames will be treated as static.

Particularly since this gives somewhat unexpected/counter-intuitive behaviour when switching from a positional argument to a keyword argument:

```python
def f(a): ...

# We expect f(1) == f(a=1) always, but this is not the case with previous logic
```

Similarly there doesn't seem to be a reason to only look up `POSITIONAL_OR_KEYWORD` type parameters, which is what leads to the bug described in #10618.

TODO if this PR is deemed viable:
- [ ] change docstring of `jax.jit` to reflect new logic - will do this after first review

# Description of new logic
`infer_argnums_and_argnames` always fills `argnums` with parameters listed in `argnames` AND vice-versa. Only in the exceedingly rare event that signature inspection is not possible is this behaviour not true, in which case we return `argnums` and `argnames` unaltered as expected.

I am curious if there is a reason why one would prefer the old behaviour over the new?

# Other
Similarly to #10603, two cases of invalid use of `argnames`/`argnums` was found. They are also fixed by this PR in order to make tests pass.

This ties in with #10614

Fix: #10618

