### PR TITLE
Officially support Python 3.10

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,5 +1,11 @@
 name: CI
 
+# We test all supported Python versions as follows:
+# - 3.7  : Documentation build
+# - 3.8  : Part of Matrix
+# - 3.9  : Part of Matrix with NumPy dispatch
+# - 3.10 : Part of Matrix
+
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch
@@ -35,18 +41,25 @@ jobs:
       matrix:
         include:
           - name-prefix: "with 3.8"
-            python-version: 3.8
+            python-version: "3.8"
             os: ubuntu-latest
             enable-x64: 0
             package-overrides: "none"
             num_generated_cases: 1
             use-latest-jaxlib: false
           - name-prefix: "with numpy-dispatch"
-            python-version: 3.9
+            python-version: "3.9"
             os: ubuntu-latest
             enable-x64: 1
             # Test experimental NumPy dispatch
             package-overrides: "git+https://github.com/seberg/numpy-dispatch.git"
+            num_generated_cases: 1
+            use-latest-jaxlib: false
+          - name-prefix: "with 3.10"
+            python-version: "3.10"
+            os: ubuntu-latest
+            enable-x64: 0
+            package-overrides: "none"
             num_generated_cases: 1
             use-latest-jaxlib: false
     steps:

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -36,6 +36,12 @@ setup(
     install_requires=['scipy', 'numpy>=1.19', 'absl-py', 'flatbuffers >= 1.12, < 3.0'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
     package_data={
         'jaxlib': [
             '*.so',

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
This adds the appropriate classifiers to the `setup.py` package.

Additionally it adds Python 3.10 to the CI build matrix. This will use more build minutes. If this is not desirable, it would probably be better to drop Python 3.8 from the matrix since incompatibility is most likely to occur at oldest supported version (3.7) or latest supported version (3.10)

I have been using JAX with Python 3.10 for a while without any issues, but it would be nice to make the support 'official.