### PR TITLE
[jax2tf] Update jax2tf limitations.

### DIFF
--- a/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
+++ b/jax/experimental/jax2tf/g3doc/primitives_with_limited_support.md
@@ -76,13 +76,11 @@ More detailed information can be found in the
 | eig | TF error: function not compilable | all | cpu | compiled |
 | eigh | TF test skipped: Not implemented in JAX: unimplemented | bfloat16, float16 | cpu, gpu | compiled, eager, graph |
 | eigh | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
-| erf | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | erf_inv | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
-| erfc | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
-| fft | TF error: TF function not compileable | complex128, float64 | cpu, gpu | compiled |
+| fft | TF error: TF function not compileable | float64 | cpu, gpu | compiled |
+| fft | TF error: TF function not compileable for IFFT and IRFFT | complex128 | cpu, gpu | compiled |
 | igamma | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
 | igammac | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu | eager, graph |
-| integer_pow | TF error: op not defined for dtype | int16, int8, unsigned | cpu, gpu | graph |
 | lgamma | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | lu | TF test skipped: Not implemented in JAX: unimplemented | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
 | nextafter | TF error: op not defined for dtype | bfloat16, float16 | cpu, gpu, tpu | compiled, eager, graph |
@@ -103,7 +101,7 @@ More detailed information can be found in the
 | svd | TF error: op not defined for dtype | bfloat16 | tpu | compiled, eager, graph |
 | svd | TF error: op not defined for dtype | complex | tpu | compiled, graph |
 | triangular_solve | TF test skipped: Not implemented in JAX: unimplemented | float16 | gpu | compiled, eager, graph |
-| triangular_solve | TF error: op not defined for dtype | bfloat16 | cpu, gpu, tpu | compiled, eager, graph |
+| triangular_solve | TF error: op not defined for dtype | bfloat16 | cpu, gpu | eager, graph |
 | triangular_solve | TF error: op not defined for dtype | float16 | cpu, gpu | eager, graph |
 
 ## Generated summary of primitives with known numerical discrepancies in Tensorflow

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -558,21 +558,11 @@ class Jax2TfLimitation(primitive_harness.Limitation):
 
   @classmethod
   def erf(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(
-            dtypes=[dtypes.bfloat16],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph"))
-    ]
+    return []
 
   @classmethod
   def erfc(cls, harness: primitive_harness.Harness):
-    return [
-        missing_tf_kernel(
-            dtypes=[dtypes.bfloat16],
-            devices=("cpu", "gpu"),
-            modes=("eager", "graph"))
-    ]
+    return []
 
   @classmethod
   def erf_inv(cls, harness: primitive_harness.Harness):
@@ -615,8 +605,15 @@ class Jax2TfLimitation(primitive_harness.Limitation):
         Jax2TfLimitation(
             "TF function not compileable",
             devices=("cpu", "gpu"),
-            dtypes=[np.float64, np.complex128],
+            dtypes=[np.float64],
             modes="compiled"),
+        Jax2TfLimitation(
+            "TF function not compileable for IFFT and IRFFT",
+            devices=("cpu", "gpu"),
+            dtypes=[np.complex128],
+            modes="compiled",
+            enabled=(str(harness.params["fft_type"]) in ["FftType.IFFT",
+                                                         "FftType.IRFFT"])),
         # TODO: very high tolerance
         custom_numeric(tol=1e-3, modes=("eager", "graph", "compiled")),
     ]
@@ -732,13 +729,6 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   def integer_pow(cls, harness: primitive_harness.Harness):
     y = harness.params["y"]
     return [
-        missing_tf_kernel(
-            dtypes=[
-                np.int8, np.int16, np.uint8, np.uint16, np.uint32, np.uint64
-            ],
-            modes="graph",
-            enabled=(y not in [0, 1]),  # These are special-cased
-            devices=("cpu", "gpu")),
         # TODO: on TPU, for f16, we get different results with eager mode
         # than with compiled mode.
         Jax2TfLimitation(
@@ -1211,7 +1201,10 @@ class Jax2TfLimitation(primitive_harness.Limitation):
   @classmethod
   def triangular_solve(cls, harness: primitive_harness.Harness):
     return [
-        missing_tf_kernel(dtypes=[dtypes.bfloat16]),
+        missing_tf_kernel(
+            dtypes=[dtypes.bfloat16],
+            devices=("gpu", "cpu"),
+            modes=("eager", "graph")),
         missing_tf_kernel(
             dtypes=[np.float16],
             devices=("gpu", "cpu"),


### PR DESCRIPTION
It seems that TF has made progress and more JAX primitives can now
be converted correctly to TF. This PR updates the limitations.