### PR TITLE
Don't create `DeviceArrays` for `onp.ndarray` indices

### DIFF
--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -878,8 +878,13 @@ class IndexingTest(jtu.JaxTestCase):
         ("int", int), ("np.array", np.array), ("jnp.array", jnp.array),
         ("slice_up_to", slice), ("slice_from", lambda s: slice(s, None))))
   def testConstantIndexing(self, idx, idx_type):
+    self._testConstantIndexing(idx_type(idx))
+
+  def testConstantNumpyArrayIndexing(self):
+    self._testConstantIndexing(np.array([1, 2, 3]))
+
+  def _testConstantIndexing(self, idx):
     x = jnp.arange(10)
-    idx = idx_type(idx)
     jaxpr = jax.make_jaxpr(lambda: x[idx])()
     self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
     self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.gather_p)


### PR DESCRIPTION
This PR is a follow up to #10393 and prevents the creation of `DeviceArrays` when indexing with `onp.ndarray`. This prevents index computations to happen on accelerators if the index is an `onp.ndarray`.

```python
import numpy as np
from jax import make_jaxpr, numpy as jnp

x = jnp.arange(10)
idx = np.array([1, 2, 3])
print(make_jaxpr(lambda: x[idx])())
```
would previously generate:
```
{ lambda a:i32[3] b:i32[10]; . let
    c:bool[3] = lt a 0
    d:i32[3] = add a 10
    e:i32[3] = select_n c a d
    f:i32[3,1] = broadcast_in_dim[broadcast_dimensions=(0,) shape=(3, 1)] e
    g:i32[3] = gather[
      dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))
      fill_value=None
      indices_are_sorted=False
      mode=GatherScatterMode.PROMISE_IN_BOUNDS
      slice_sizes=(1,)
      unique_indices=False
    ] b f
  in (g,) }
```
With this PR index normalisations happens in native Numpy so the Jaxpr becomes:
```
{ lambda a:i32[10] b:i32[3,1]; . let
    c:i32[3] = gather[
      dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))
      fill_value=None
      indices_are_sorted=False
      mode=GatherScatterMode.PROMISE_IN_BOUNDS
      slice_sizes=(1,)
      unique_indices=False
    ] a b
  in (c,) }
```

If I haven't missed anything this should fix #2878.