### PR TITLE
Avoid generating trivial gathers when reversing array

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3775,11 +3775,16 @@ def _index_to_gather(x_shape, idx, normalize_indices=True):
           if stop is None or (not isinstance(stop, core.Tracer) and
               core.greater_equal_dim(stop, x_shape[x_axis])):
             stop = None
+        elif core.symbolic_equal_dim(step, -1):
+          step = -1
       except (TypeError, core.InconclusiveDimensionOperation):
         pass
 
-      # Handle slice(None)
-      if start is None and stop is None and step is None:
+      # Handle slice(None) and slice(None, None, -1)
+      if start is None and stop is None and (
+          step is None or isinstance(step, int) and step == -1):
+        if step == -1:
+          reversed_y_dims.append(collapsed_y_axis)
         slice_shape.append(x_shape[x_axis])
         gather_slice_shape.append(x_shape[x_axis])
         offset_dims.append(collapsed_y_axis)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -871,6 +871,10 @@ class IndexingTest(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(lambda x: x[:4])(np.arange(4))
     self.assertEqual(len(jaxpr.jaxpr.eqns), 0)
 
+    jaxpr = jax.make_jaxpr(lambda x: x[::-1])(np.arange(4))
+    self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
+    self.assertEqual(jaxpr.jaxpr.eqns[0].primitive, lax.rev_p)
+
   def testIndexingEmptyDimension(self):
     # Issue 2671: XLA error when indexing into dimension of size 0
     x = jnp.ones((2, 0))


### PR DESCRIPTION
This PR avoids generating trivial gathers when reversing arrays via numpy indexing.
XLA will already remove the trivial gather. However, this change improves performance outside of a jit without hurting readability much.

```python
from jax import make_jaxpr, numpy as jnp

make_jaxpr(lambda x: x[::-1])(jnp.arange(10))
```
**before:**
```
{ lambda a:i32[1]; b:i32[10]. let
    c:i32[10] = gather[
      dimension_numbers=GatherDimensionNumbers(offset_dims=(0,), collapsed_slice_dims=(), start_index_map=(0,))
      fill_value=None
      indices_are_sorted=True
      mode=GatherScatterMode.PROMISE_IN_BOUNDS
      slice_sizes=(10,)
      unique_indices=True
    ] b a
    d:i32[10] = rev[dimensions=(0,)] c
  in (d,) }
```
**after:**
```
{ lambda ; a:i32[10]. let b:i32[10] = rev[dimensions=(0,)] a in (b,) }
```