### PR TITLE
[jax2tf] add rudimentary scatter support for enable_xla=False

### DIFF
--- a/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
+++ b/jax/experimental/jax2tf/g3doc/no_xla_limitations.md
@@ -33,7 +33,7 @@ For a detailed description of these XLA ops, please see the
 | XlaConv | `lax.conv_general_dilated` | [Partial](#xlaconv) |
 | XlaGather | `lax.gather` | [Partial](#xlagather) |
 | XlaReduceWindow | `lax.reduce_window_sum_p`, `lax.reduce_window_min_p`, `lax.reduce_window_max_p`, and `lax.reduce_window_p` | [Partial](#xlareducewindow) |
-| XlaScatter | `lax.scatter_p`, `lax.scatter_min_p`, `lax.scatter_max_p`, `lax.scatter_mul_p`, `lax.scatter_add_p` | Unsupported |
+| XlaScatter | `lax.scatter_p`, `lax.scatter_min_p`, `lax.scatter_max_p`, `lax.scatter_mul_p`, `lax.scatter_add_p` | [Partial](#xlascatter) |
 | XlaSelectAndScatter | `lax.select_and_scatter_add_p` | Unsupported |
 | XlaReduce | `lax.reduce`, `lax.argmin`, `lax.argmax` | Unsupported |
 | XlaVariadicSort | `lax.sort` | Unsupported |
@@ -153,3 +153,15 @@ We support these ops with the following limitations:
 * `padding` should either be `VALID` or `SAME`.
 
 `lax.reduce_window_min_p` and `lax.reduce_window` are currently not supported.
+
+### XlaScatter
+
+This op is called by `lax.scatter`, `lax.scatter_min`, `lax.scatter_max`, 
+`lax.scatter_mul` and `lax.scatter_add`. 
+
+We support all these ops for unique indices. For non-unique indices we 
+support (min,max,mul,add) for single depth scatters.
+
+There are a few more limitations:
+* the GatherScatterMode must be PROMISE_IN_BOUNDS.
+* dtypes `np.bool` and `jnp.complex*` are not supported.

--- a/jax/experimental/jax2tf/tests/jax2tf_limitations.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_limitations.py
@@ -950,6 +950,10 @@ class Jax2TfLimitation(primitive_harness.Limitation):
     return []
 
   @classmethod
+  def scatter(cls, harness):
+    return []
+
+  @classmethod
   def select_and_gather_add(cls, harness):
     return [
         # This JAX primitives is not not exposed directly in the JAX API

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -1272,7 +1272,7 @@ def _make_scatter_harness(name,
 # Validate dtypes
 for dtype in jtu.dtypes.all:
   for f_lax in [
-      lax.scatter_add, lax.scatter_mul, lax.scatter_max, lax.scatter_min
+      lax.scatter, lax.scatter_add, lax.scatter_mul, lax.scatter_max, lax.scatter_min
   ]:
     _make_scatter_harness("dtypes", dtype=dtype, f_lax=f_lax)
 


### PR DESCRIPTION
I think this solves #9659.

Just checking now. It should work for simple indices where you index in only 1 dimension with your update. I've added quite a few guarding asserts. It still needs unit tests to be sure.

Checking #9659 test case now.