### PR TITLE
Make CUDA install instructions copy-pasteablee

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,8 @@ Next, run
 ```bash
 pip install --upgrade pip
 # Installs the wheel compatible with CUDA 11 and cuDNN 8.2 or newer.
-pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html  # Note: wheels only available on linux.
+# Note: wheels only available on linux.
+pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html
 ```
 
 


### PR DESCRIPTION
The command after the pip command always annoys me because (at least on zsh) leads to an error if I copy-paste that line...

```
➜ pip install --upgrade "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_releases.html # ciao
ERROR: Invalid requirement: '#'
```

This PR simply moves the comment on the line above.