### PR TITLE
DOC: explicitly enable dollarmath extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,6 +184,7 @@ html_static_path = ['_static']
 
 # -- Options for myst ----------------------------------------------
 myst_heading_anchors = 3  # auto-generate 3 levels of heading anchors
+myst_enable_extensions = ['dollarmath']
 nb_execution_mode = "force"
 nb_execution_allow_errors = False
 


### PR DESCRIPTION
Fixes #10661

This was previously enabled by default; that changed in https://github.com/executablebooks/MyST-Parser/pull/505

Problematic rendering is fixed in this PR: https://jax--10679.org.readthedocs.build/en/10679/notebooks/Common_Gotchas_in_JAX.html#summary