### PR TITLE
Enable colors when we are using a terminal

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -476,7 +476,7 @@ flags.DEFINE_integer(
 
 flags.DEFINE_bool(
     'jax_pprint_use_color',
-    bool_env('JAX_PPRINT_USE_COLOR', False),
+    bool_env('JAX_PPRINT_USE_COLOR', True),
     help='Enable jaxpr pretty-printing with colorful syntax highlighting.'
 )
 

--- a/jax/_src/pretty_printer.py
+++ b/jax/_src/pretty_printer.py
@@ -27,6 +27,7 @@
 
 import abc
 import enum
+import sys
 from functools import partial
 from typing import List, NamedTuple, Optional, Sequence, Tuple, Union
 from jax.config import config
@@ -36,13 +37,31 @@ try:
 except ImportError:
   colorama = None
 
+def _can_use_color() -> bool:
+  try:
+    # Check if we're in IPython or Colab
+    ipython = get_ipython()  # type: ignore[name-defined]
+    shell = ipython.__class__.__name__
+    if shell == "ZMQInteractiveShell":
+      # Jupyter Notebook
+      return True
+    elif "colab" in str(ipython.__class__):
+      # Google Colab (external or internal)
+      return True
+  except NameError:
+    pass
+  # Otherwise check if we're in a terminal
+  return sys.stdout.isatty()
+
+CAN_USE_COLOR = _can_use_color()
 
 class Doc(abc.ABC):
   __slots__ = ()
 
-  def format(self, width: int = 80, use_color: bool = False,
+  def format(self, width: int = 80, use_color: Optional[bool] = None,
              annotation_prefix=" # ") -> str:
-    use_color = use_color or config.FLAGS.jax_pprint_use_color
+    if use_color is None:
+      use_color = CAN_USE_COLOR and config.FLAGS.jax_pprint_use_color
     return _format(self, width, use_color=use_color,
                    annotation_prefix=annotation_prefix)
 


### PR DESCRIPTION
Enables colors when pretty printing jaxprs by default.

The basic logic for determining if we should use color when pretty printing (`jaxpr.pretty_print(use_color=...)`:

* Case 1: `use_color` is not specified (the default case, i.e. `jaxpr.pretty_print()`).

  In this case, we first check the `jax_pprint_use_color` flag which is set to `True` by default. If it is `False`, we *do not* use color.

  If `jax_pprint_use_color` is `True`, we run a simple check to see if we are in an environment that supports color. If we are, we use color and if not we don't.
* Case 2: `use_color` is specified explicitly (e.g. `jaxpr.pretty_print(use_color=True/False)`
  
  We do whatever what was explicitly asked.

The heuristic we use to check if color is supported is still a bit brittle since we don't know while file we're printing to when choosing to use colors. We check if `sys.stdout` supports colors as a good heuristic but we could break it by doing something by having `sys.stdout` support colors but print to `sys.stderr`.
```python
# break_colors.py
import jax
import jax.numpy as jnp
import sys

def f(x):
  return x
print(jax.make_jaxpr(f)(2.), file=sys.stderr)
```
```bash
$ python break_colors.py 2>foo
$ cat foo
{ ESC[34mESC[22mESC[1mlambda ESC[39mESC[22mESC[22m; aESC[35m:f32[]ESC[39m. ESC[34mESC[22mESC[1mletESC[39mESC[22mESC[22m  ESC[34mESC[22mESC[1min ESC[39mESC[22mESC[22m(a,) }
```