### PR TITLE
Fix jax 0.3.11 GPU breakge when used with jaxlib 0.3.10.

### DIFF
--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -183,7 +183,7 @@ except ImportError:
   hip_linalg = None
 
 try:
-  import jaxlib.cuda_linalg as gpu_linalg  # pytype: disable=import-error
+  import jaxlib.gpu_linalg as gpu_linalg  # pytype: disable=import-error
 except ImportError:
   gpu_linalg = None
 


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/10717