### PR TITLE
normalize/rearrange (kw)args by signature in jit

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -347,6 +347,9 @@ def _prepare_jit(fun, static_argnums, static_argnames, donate_argnums,
         f"jitted function has donate_argnums={donate_argnums} but "
         f"was called with only {len(args)} positional arguments.")
 
+  sig = inspect.signature(fun)
+  ba = sig.bind(*args, **kwargs)
+  args, kwargs = ba.args, ba.kwargs
   f = lu.wrap_init(fun)
   f, args = argnums_partial_except(f, static_argnums, args, allow_invalid=True)
   f, kwargs = argnames_partial_except(f, static_argnames, kwargs)


### PR DESCRIPTION
Normalize/Rearrange positional arguments and keyword arguments according to function signature.
Thus the static arguments and donate arguments behavior will not depend on the way arguments passed.
This is a breaking change, deprecation cycle might be needed.
Cache behavior is changed as well, cause `test_jit_kwargs` failure.
Since the type of argument is determined by signature, `test_jit_with_mismatched_static_argnames` fail and need some modifications.