### PR TITLE
custom transpose: nearly rewrite `custom_vjp`

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -1220,7 +1220,7 @@ def custom_vjp_by_custom_transpose(fun, fwd, bwd, nondiff_argnums):
     *nondiff_args, primals, tangents = args
 
     outs, residuals = fwd(*nondiff_args, *primals)
-    tan_fn = custom_transpose(disallow_jvp)
+    tan_fn = custom_transpose(disallow_jvp, with_outs=True)
 
     @tan_fn.def_transpose
     def bwd_with_outs(res_and_outs, g):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -6830,8 +6830,10 @@ class _custom_transpose:
 # an option of inferring output types.
 def custom_transpose(example_out):
   if isinstance(example_out, Callable):
+    return api.custom_transpose(example_out)
     out_type = core.get_aval(0.).at_least_vspace()
     return _custom_transpose(out_type, example_out)
+  return api.custom_transpose
   return partial(
       _custom_transpose,
       tree_util.tree_map(


### PR DESCRIPTION
This change nearly supports a reimplementation of `custom_vjp` on top of `custom_transpose` and `custom_jvp`, with the former still in an intermediate state. All `custom_vjp` tests pass except for those that exercise "old" remat, and this upgrade continues to be guarded by a flag that is off by default.

part of #9129