### PR TITLE
[WIP, Proposal] Improve argument annotations interface

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -43,6 +43,8 @@ from jax import core
 from jax import linear_util as lu
 from jax import stages
 from jax.core import eval_jaxpr
+from jax.experimental.annotations import DonateAnnotation, StaticAnnotation
+from jax._src.arg_annotations import ArgNumNamesAnnotations, ArgumentAnnotations
 from jax.tree_util import (tree_map, tree_flatten, tree_unflatten,
                            tree_structure, tree_transpose, tree_leaves,
                            tree_multimap, treedef_is_leaf, treedef_children,
@@ -227,6 +229,7 @@ def jit(
     *,
     static_argnums: Union[int, Iterable[int], None] = None,
     static_argnames: Union[str, Iterable[str], None] = None,
+    static_args: Optional[Sequence[Union[str, int]]] = None,
     device: Optional[xc.Device] = None,
     backend: Optional[str] = None,
     donate_argnums: Union[int, Iterable[int]] = (),
@@ -329,9 +332,9 @@ def jit(
     DeviceArray([   0,    1,  256, 6561], dtype=int32)
   """
   if FLAGS.experimental_cpp_jit and not config.jax_dynamic_shapes:
-    return _jit(True, fun, static_argnums, static_argnames, device, backend,
+    return _jit(True, fun, static_argnums, static_argnames, static_args, device, backend,
                     donate_argnums, inline, keep_unused)
-  return _jit(False, fun, static_argnums, static_argnames, device, backend,
+  return _jit(False, fun, static_argnums, static_argnames, static_args, device, backend,
                       donate_argnums, inline, keep_unused, abstracted_axes)
 
 def _jit(
@@ -339,6 +342,7 @@ def _jit(
     fun: Callable,
     static_argnums: Union[int, Iterable[int], None] = None,
     static_argnames: Union[str, Iterable[str], None] = None,
+    static_args: Optional[Sequence[Union[str, int]]] = None,
     device: Optional[xc.Device] = None,
     backend: Optional[str] = None,
     donate_argnums: Union[int, Iterable[int]] = (),
@@ -352,34 +356,40 @@ def _jit(
   # Coerce input
   donate_argnums = _ensure_index_tuple(donate_argnums)
 
-  try:
-    sig = inspect.signature(fun)
-  except ValueError:
-    # Some built-in functions don't support signature.
-    # See: https://github.com/python/cpython/issues/73485
-    # In this case no validation is done
+  # Validation
+  if (static_argnums or static_argnames) and static_args is not None:
+    raise ValueError("Cannot mix old-style argument annotations (argnums, argnames) "
+                     "and new-style argument annotations (args)")
+
+  if static_args is not None:
     static_argnums = () if static_argnums is None else _ensure_index_tuple(static_argnums)
     static_argnames = () if static_argnames is None else _ensure_str_tuple(static_argnames)
+
+    static_arg_annos = ArgumentAnnotations.from_(fun=fun, args=static_args, annotation=StaticAnnotation)
+
   else:
-    # Infer argnums and argnames according to docstring
-    static_argnums, static_argnames = _infer_argnums_and_argnames(
-        sig, static_argnums, static_argnames)
+    try:
+      sig = inspect.signature(fun)
+      static_argnums, static_argnames = _infer_argnums_and_argnames(sig, static_argnums, static_argnames)
+    except ValueError:
+      static_argnums = _ensure_index_tuple(static_argnums)
+      static_argnames = _ensure_str_tuple(static_argnames or ())
 
-    # Validation
-    validate_argnums(sig, static_argnums, "static_argnums")
-    validate_argnums(sig, donate_argnums, "donate_argnums")
+    static_arg_annos = ArgNumNamesAnnotations.from_(fun=fun, nums=static_argnums, names=static_argnames, annotation=StaticAnnotation)
 
-    validate_argnames(sig, static_argnames, "static_argnames")
+  donate_arg_annos = ArgNumNamesAnnotations.from_(fun=fun, nums=donate_argnums, names=(), annotation=DonateAnnotation)
 
   # Compensate for static argnums absorbing args
-  donate_argnums = rebase_donate_argnums(donate_argnums, static_argnums)
+  donate_argnums = rebase_donate_argnums(donate_arg_annos.nums, static_arg_annos.nums)
 
   if use_cpp_jit:
-    return _cpp_jit(fun, static_argnums=static_argnums, static_argnames=static_argnames,
+    # TODO(JeppeKlitgaard): Propagate change to ArgumentAnnotations from here
+    return _cpp_jit(fun, static_argnums=static_arg_annos.nums, static_argnames=static_arg_annos.names,
                     device=device, backend=backend,
                     donate_argnums=donate_argnums, inline=inline, keep_unused=keep_unused)
 
-  return _python_jit(fun, static_argnums=static_argnums, static_argnames=static_argnames,
+    # TODO(JeppeKlitgaard): Propagate change to ArgumentAnnotations from here
+  return _python_jit(fun, static_argnums=static_arg_annos.nums, static_argnames=static_arg_annos.names,
                       device=device, backend=backend, donate_argnums=donate_argnums,
                       inline=inline, keep_unused=keep_unused, abstracted_axes=abstracted_axes)
 

--- a/jax/_src/arg_annotations.py
+++ b/jax/_src/arg_annotations.py
@@ -1,0 +1,157 @@
+from abc import ABCMeta
+from typing import (
+    Callable,
+    Tuple,
+    Optional,
+    Union,
+    Sequence,
+    List,
+)
+
+from typing_extensions import get_args
+
+from dataclasses import dataclass
+import inspect
+import warnings
+
+from jax._src.api_util import validate_argnames, validate_argnums
+from jax.experimental.annotations import Annotation
+
+
+_VARIABLE_PARAMETERS = (
+    inspect.Parameter.VAR_POSITIONAL,
+    inspect.Parameter.VAR_KEYWORD,
+)
+
+
+__MSG_VARARG_ANNO_ERR = (
+    "Cannot directly annotate variable argument {arg}. "
+    "You can achieve annotated variable arguments through individual "
+    "argnums or argnames. These will be safely ignored if not present."
+)
+
+
+@dataclass
+class BaseArgumentAnnotations(metaclass=ABCMeta):
+    sig: Optional[inspect.Signature]
+    nums: Tuple[int, ...]
+    names: Tuple[str, ...]
+
+@dataclass
+class ArgumentAnnotations(BaseArgumentAnnotations):
+    @classmethod
+    def from_(
+        cls,
+        fun: Callable,
+        *,
+        args: Sequence[Union[str, int]],
+        annotation: Annotation,
+    ):
+        nums_given: List[int] = []
+        names_given: List[str] = []
+
+        for arg in args:
+            if isinstance(arg, int):
+                nums_given.append(arg)
+            elif isinstance(arg, str):
+                names_given.append(arg)
+            else:
+                raise ValueError(
+                    "Argument must be integer or string. "
+                    f"Was {arg} (type={type(arg)})"
+                )
+
+        try:
+            sig = inspect.signature(fun)
+        except ValueError:
+            # In rare cases, inspect can fail, e.g., on some builtin Python functions.
+            # In these cases, don't infer any parameters.
+            return cls(sig=None, nums=tuple(nums_given), names=tuple(names_given))
+
+
+        nums_derived: List[int] = []
+        names_derived: List[str] = []
+        var_args: Optional[str] = None
+        var_kwargs: Optional[str] = None
+        for num, (name, param) in enumerate(sig.parameters.items()):
+            if param.kind is inspect.Parameter.VAR_POSITIONAL:
+                var_args = name
+            elif param.kind is inspect.Parameter.VAR_KEYWORD:
+                var_kwargs = name
+
+            if param.kind not in _VARIABLE_PARAMETERS:  # Skip *args, **kwargs
+                # Resolve names from nums
+                if (
+                    num in nums_given
+                    and param.kind is not inspect.Parameter.POSITIONAL_ONLY
+                ):
+                    names_derived.append(name)
+                    continue
+
+                # Resolve nums from names
+                if (
+                    name in names_given
+                    and param.kind is not inspect.Parameter.KEYWORD_ONLY
+                ):
+                    nums_derived.append(num)
+                    continue
+
+            # Resolve type hint annotations
+            if annotation in get_args(param.annotation):
+                if param.kind in _VARIABLE_PARAMETERS:
+                    raise ValueError(__MSG_VARARG_ANNO_ERR.format(arg=name))
+
+                nums_derived.append(num)
+                names_derived.append(name)
+                continue
+
+        # We cannot mark *args-like or **kwargs-like as static, only individual args
+        for var_arg in (var_args, var_kwargs):
+            if var_arg in names_given:
+                raise ValueError(__MSG_VARARG_ANNO_ERR.format(arg=var_arg))
+
+        nums = tuple(set(nums_given + nums_derived))
+        names = tuple(set(names_given + names_derived))
+
+        validate_argnums(sig, nums, annotation.NAME + "_argnums")
+        validate_argnames(sig, names, annotation.NAME + "_argnames")
+
+        return cls(sig=sig, nums=nums, names=names)
+
+    def __bool__(self):
+        return self.nums or self.names
+
+
+@dataclass
+class ArgNumNamesAnnotations(BaseArgumentAnnotations):
+    @classmethod
+    def from_(
+        cls,
+        fun: Callable,
+        *,
+        nums: Tuple[int, ...],
+        names: Tuple[str, ...],
+        annotation: Annotation,
+    ):
+        # TODO(JeppeKlitgaard): Enable warning below. Current doctests fail
+        # TODO(JeppeKlitgaard): Insert documentation URL
+        # warnings.warn(
+        #     (
+        #         "Use of argnums and argnames is deprecated. "
+        #         "Please switch to the newer args interface, which carries many additional "
+        #         "benefits. It is documented at TODO"
+        #     ),
+        #     DeprecationWarning,
+        # )
+
+        try:
+            sig = inspect.signature(fun)
+        except ValueError:
+            # In rare cases, inspect can fail, e.g., on some builtin Python functions.
+            # In these cases, don't infer any parameters.
+            return cls(sig=None, nums=nums, names=names)
+
+        validate_argnums(sig, nums, annotation.NAME + "_argnums")
+        validate_argnames(sig, names, annotation.NAME + "_argnames")
+
+        return cls(sig=sig, nums=nums, names=names)

--- a/jax/experimental/annotations.py
+++ b/jax/experimental/annotations.py
@@ -1,0 +1,45 @@
+from typing import (
+    TypeVar,
+    Union,
+)
+
+from typing_extensions import Annotated
+
+
+T = TypeVar("T")
+
+# Sentinels
+# TODO: Change when we get https://peps.python.org/pep-0661/
+class _StaticAnnotationType:
+    NAME = "static"
+
+
+class _DonateAnnotationType:
+    NAME = "donate"
+
+
+class _DiffAnnotationType:
+    NAME = "diff"
+
+
+class _NoDiffAnnotationType:
+    NAME = "nodiff"
+
+
+StaticAnnotation = _StaticAnnotationType()
+DonateAnnotation = _DonateAnnotationType()
+DiffAnnotation = _DiffAnnotationType()
+NoDiffAnnotation = _NoDiffAnnotationType()
+
+# Pass-through annotations. See: https://peps.python.org/pep-0593/
+Static = Annotated[T, StaticAnnotation]
+Donate = Annotated[T, DonateAnnotation]
+Diff = Annotated[T, DiffAnnotation]
+NoDiff = Annotated[T, NoDiffAnnotation]
+
+Annotation = Union[
+    _StaticAnnotationType,
+    _DonateAnnotationType,
+    _DiffAnnotationType,
+    _NoDiffAnnotationType,
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ filterwarnings =
     error
     ignore:No GPU/TPU found, falling back to CPU.:UserWarning
     ignore:outfeed_receiver is unnecessary and deprecated:DeprecationWarning
+    # Argument annotation deprecation
+    ignore:"Use of argnums and argnames is deprecated.*:DeprecationWarning
     # xmap
     ignore:xmap is an experimental feature and probably has bugs!
     # The rest are for experimental/jax_to_tf


### PR DESCRIPTION
This PR introduces a container class with a bit of additional logic sprinkled on top in order to consistently handle _argument annotations_.

I propose argument annotations are parsed into an `ArgumentAnnotation` object as part of the input validation of all transformations (`jit`, `grad`, ...). These are then the objects that are passed around instead of tuples of `argnums` and `argnames`. These tuples can be accessed when needed by lower level functions.

This enables an easy and idiomatic way of ensuring arguments are validated while simultaneously providing an easy way to implement backwards compatibility through a subclass (not yet done).