### PR TITLE
Add caching to `trace_to_subjaxpr_dynamic`.

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -883,6 +883,11 @@ config.define_bool_state(
     )
 )
 
+config.define_bool_state(
+    name='jax_experimental_subjaxpr_lowering_cache',
+    default=False,
+    help='Enable using a cache for lowering subjaxprs.')
+
 @contextlib.contextmanager
 def explicit_device_put_scope() -> Iterator[None]:
   """Indicates that the current context is an explicit device_put*() call."""


### PR DESCRIPTION
This allows the MLIR lowering code to cache call lowerings.

example output:
```
module @jit_fun.0 {
  func.func public @main(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
    %0 = call @square(%arg0) : (tensor<4x8xf32>) -> tensor<4x8xf32>
    %1 = call @square(%0) : (tensor<4x8xf32>) -> tensor<4x8xf32>
    return %1 : tensor<4x8xf32>
  }
  func.func private @square(%arg0: tensor<4x8xf32>) -> tensor<4x8xf32> {
    %0 = mhlo.multiply %arg0, %arg0 : tensor<4x8xf32>
    return %0 : tensor<4x8xf32>
  }
}
```

If / when jaxprs support recursion, this approach will still work because the mlir lowering cache operates on Jaxpr object identity.