### PR TITLE
DOC: fix docs generator to group notebook code output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,6 +187,7 @@ myst_heading_anchors = 3  # auto-generate 3 levels of heading anchors
 myst_enable_extensions = ['dollarmath']
 nb_execution_mode = "force"
 nb_execution_allow_errors = False
+nb_merge_streams = True
 
 # Notebook cell execution timeout; defaults to 30.
 nb_execution_timeout = 100


### PR DESCRIPTION
Fixes the output formatting issue reported by #10633

[MyST-NB doc for the `nb_merge_streams` flag](https://github.com/executablebooks/MyST-NB/blob/master/docs/render/format_code_cells.md#group-into-single-streams)

Current formatting:
![image](https://user-images.githubusercontent.com/140952/169616134-1a3f6dc7-5409-4843-86e6-5752abd882d8.png)

becomes:

![image](https://user-images.githubusercontent.com/140952/169616088-e7badd48-f6bb-4fc2-bbb6-6896fbfd5daf.png)
