### PR TITLE
DOC: fix scipy intersphinx link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy-1.8.0/html-scipyorg/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy-1.8.1/', None),
 }
 
 suppress_warnings = [


### PR DESCRIPTION
This should fix the broken readthedocs build