### PR TITLE
[ROCm] Fix hip_lu_pivots_to_permutation.

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -981,7 +981,7 @@ if gpu_linalg:
   mlir.register_lowering(
       lu_pivots_to_permutation_p,
       partial(_lu_pivots_to_permutation_gpu_lowering,
-              gpu_linalg.rocm_lu_pivots_to_permutation),
+              gpu_linalg.hip_lu_pivots_to_permutation),
       platform='rocm')
 
 

--- a/jaxlib/gpu_linalg.py
+++ b/jaxlib/gpu_linalg.py
@@ -67,5 +67,5 @@ def _lu_pivots_to_permutation_mhlo(platform, gpu_linalg, pivots, *, permutation_
 
 cuda_lu_pivots_to_permutation = partial(
     _lu_pivots_to_permutation_mhlo, "cuda", _cuda_linalg)
-rocm_lu_pivots_to_permutation = partial(
-    _lu_pivots_to_permutation_mhlo, "rocm", _hip_linalg)
+hip_lu_pivots_to_permutation = partial(
+    _lu_pivots_to_permutation_mhlo, "hip", _hip_linalg)


### PR DESCRIPTION
/cc @hawkinsp 

Sorry, I realized that this needed to be fixed also.

In addition, It looked like cuda_kernels.cc was a vestigial artifact, so I removed it.