### PR TITLE
[x64] add jax_numpy_dtype_promotion flag

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -47,6 +47,7 @@ from jax._src.config import (
   log_compiles as log_compiles,
   default_matmul_precision as default_matmul_precision,
   default_prng_impl as default_prng_impl,
+  numpy_dtype_promotion as numpy_dtype_promotion,
   numpy_rank_promotion as numpy_rank_promotion,
   jax2tf_associative_scan_reductions as jax2tf_associative_scan_reductions,
   transfer_guard as transfer_guard,


### PR DESCRIPTION
This adds a `jax_numpy_dtype_promotion` flag, along with a `strict` mode that will raise an error on any implicit promotion between differing types. For example:
```python
import jax
import jax.numpy as jnp

x = jnp.float32(4)
y = jnp.int32(4)

# promotion='standard' is JAX's current default promotion scheme
with jax.numpy_dtype_promotion('standard'):
  print(x + 1)  # 5.0
  print(y + 1)  # 5
  print(y + 1.0)  # 5.0
  print(x + y)  # 8.0

# promotion='strict' disallows binary operations between differing dtypes, but still allows operations between a
# strong type and a compatible weak type.
with jax.numpy_dtype_promotion('strict'):
  print(x + 1)  # 5.0
  print(y + 1)  # 5
  print(y + 1.0)  # TypePromotionError: Input dtypes ('int32', "<class 'float'>") have no available implicit dtype promotion path
  print(x + y)  # TypePromotionError: Input dtypes ('float32', 'int32') have no available implicit dtype promotion path
```

I'm open to input on the details of the flag name & values.

After landing this, we should probably change `JaxTestCase` to run with `jax_numpy_dtype_promotion('strict')` by default, simlar to how we run with `jax_numpy_rank_promotion='raise'` currently. A quick tests shows that this will take a fair amount of work, as JAX library code relies on implicit promotion in many places.