### PR TITLE
Add a public facing `named_scope` function

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -96,6 +96,7 @@ from jax._src.api import (
   make_jaxpr as make_jaxpr,
   mask as mask,
   named_call as named_call,
+  named_scope as named_scope,
   pmap as pmap,
   process_count as process_count,
   process_index as process_index,


### PR DESCRIPTION
Adds `jax.named_scope`, a context-manager that adds annotations into XLA metadata for the purposes of profiling/debugging.

Example usage:
```python
@jax.jit
def layer(w, x):
  with jax.named_scope("dot_product"):
    logits = w.dot(x)
  with jax.named_scope("activation"):
    return jax.nn.relu(logits)
```

Note that the metadata from this contextmanager will only be used when the `'jax_experimental_name_stack'` flag is set to `True`.

For more examples, see `tests/name_stack_test.py`.