### PR TITLE
[djax] add support for dynamic-shape outputs

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -529,7 +529,9 @@ def _cpp_jit(
         # Not supported: ShardedDeviceArray
         all(device_array.type_is_device_array(x) for x in out_flat) and
         # Not supported: dynamic shapes
-        not jax.config.jax_dynamic_shapes)
+        not jax.config.jax_dynamic_shapes and
+        execute.args[4] is dispatch.SimpleResultHandler
+    )
     ### If we can use the fastpath, we return required info to the caller.
     if use_fastpath:
       (_, xla_executable,
@@ -2663,14 +2665,16 @@ def make_jaxpr(fun: Callable,
       dyn_argnums = [i for i in range(len(args)) if i not in static_argnums]
       f, args = argnums_partial(f, dyn_argnums, args)
     in_avals, in_tree, keep_inputs = abstractify(args, kwargs)
+    in_type = tuple(zip(in_avals, keep_inputs))
     f, out_tree = flatten_fun(f, in_tree)
+    f = lu.annotate(f, in_type)
     with ExitStack() as stack:
       for axis_name, size in axis_env or []:
         stack.enter_context(core.extend_axis_env(axis_name, size, None))
-      jaxpr, out_avals, consts = pe.trace_to_jaxpr_dynamic(
-          f, in_avals, keep_inputs=keep_inputs)
+      jaxpr, out_type, consts = pe.trace_to_jaxpr_dynamic2(f)
     closed_jaxpr = core.ClosedJaxpr(jaxpr, consts)
     if return_shape:
+      out_avals, _ = unzip2(out_type)
       out_shapes_flat = [
           ShapeDtypeStruct(a.shape, a.dtype, a.named_shape) for a in out_avals]
       return closed_jaxpr, tree_unflatten(out_tree(), out_shapes_flat)

--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -80,6 +80,10 @@ class IreeBuffer(xla_client.DeviceArrayBase):
   def block_until_ready(self) -> IreeBuffer:
     return self  # no async
 
+  # overrides repr on base class which expects _value and aval attributes
+  def __repr__(self):
+    return f'IreeBuffer({self._npy_value})'
+
 class IreeExecutable:
 
   def __init__(self, client, devices, module_object, function_name):

--- a/jax/core.py
+++ b/jax/core.py
@@ -56,10 +56,9 @@ map, unsafe_map = safe_map, map
 
 Effect = Hashable
 Effects = Set[Effect]
-
 no_effects: Effects = set()
-
 ordered_effects: Set[Effect] = set()
+
 
 class Jaxpr:
   constvars: List[Var]

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -70,6 +70,7 @@ FLAGS = config.FLAGS
 
 python_version = (sys.version_info[0], sys.version_info[1])
 numpy_version = tuple(map(int, np.__version__.split('.')[:3]))
+jaxlib_version = jax._src.lib.version
 
 
 class CPPJitTest(jtu.BufferDonationTestCase):
@@ -8632,6 +8633,18 @@ class DynamicShapeTest(jtu.JaxTestCase):
       ans = cumsum(x)
     expected = jnp.cumsum(x)
     self.assertAllClose(ans, expected, check_dtypes=False)
+
+  @unittest.skipIf(jtu.device_under_test() != 'iree', "iree test")
+  @unittest.skipIf(jaxlib_version < (0, 3, 11), "test requires jaxlib>=0.3.11")
+  def test_jit_of_broadcast(self):
+    x = jax.jit(jnp.ones)(3)
+    self.assertAllClose(x, jnp.ones(3))
+
+  @unittest.skipIf(jtu.device_under_test() != 'iree', "iree test")
+  @unittest.skipIf(jaxlib_version < (0, 3, 11), "test requires jaxlib>=0.3.11")
+  def test_jit_of_broadcast2(self):
+    x = jax.jit(lambda n: jnp.ones(2 * n))(3)
+    self.assertAllClose(x, jnp.ones(2 * 3))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
To support dynamic shape outputs, i.e. jaxprs outputs where some array types in the output type of a jaxpr have axis sizes which depend either on lambda-bound or on let-bound values, we update our jaxpr building machinery (in partial_eval.py) and dispatch logic (in dispatch.py).

For jaxprs, an `OutputType` is a `Tuple[Tuple[bool, AbstractValue], ...]` where the `AbstractValue`s may be `DShapedArrays` which contain in their shape tuples (reverse) de Bruijn index objects `InDBIdx` or `OutDBIdx` representing indices in the argument list or in the output list, respectively, so as to encode the type's dependence on a lambda- or let-bound value. The booleans indicate whether a value is _explicit_ in the sense of being returned by the corresponding (flattened) Python function, analogous to the boolean values we have on `InputType` to indicate which arguments are explicit to the corresponding Python function (see #8955). **We're not sure if we like this "implicit outputs" approach** and we may change it in the future to make all outputs explicit. Output types are currently entirely inferred from output `Tracer`s, where `Tracer`s occurring in (trace-time) `DShapedArray` abstract values give rise to `OutputType`s with `InDBIdx`/`OutDBIdx` instances in them. **We're not sure if we like this "infer output type" approach"** and we may change it in the future to require explicit user annotation in some form.

Summary of code changes, in order of how they appear in the github diff:
* in api.py, adapt the C++ jit `use_fastpath` logic in `cache_miss` to skip the fast path if the result handlers involve dynamic shape outputs
* in dispatch.py, adapt the dispatch logic to handle dynamic shape outputs, mainly by generalizing result handlers to take as an argument an environment of values for variables occurring in output types
* in iree.py, fix a trivial printing bug
* in partial_eval.py, add new variants of `trace_to_subjaxpr_dynamic` and friends which can produce jaxprs with dynamic shape output types, keeping old versions just to avoid breakages (to be deleted soon)


TODO:
* [ ] attach output type to `core.Jaxpr`, rather than having it as a separate object which travels with jaxprs (maybe in follow-up PR)
* [ ] maybe update all jax-internal callers to use `trace_to_subjaxpr_dynamic2` and friends