### PR TITLE
Documentation fix: typo in jax.lax.custom_linear_solve doc

### DIFF
--- a/jax/_src/lax/control_flow.py
+++ b/jax/_src/lax/control_flow.py
@@ -2457,7 +2457,7 @@ def custom_linear_solve(
     b: constant right handle side of the equation. May be any nested structure
       of arrays.
     solve: higher level function that solves for solution to the linear
-      equation, i.e., ``solve(matvec, x) == x`` for all ``x`` of the same form
+      equation, i.e., ``solve(matvec, matvec(x)) == x`` for all ``x`` of the same form
       as ``b``. This function need not be differentiable.
     transpose_solve: higher level function for solving the transpose linear
       equation, i.e., ``transpose_solve(vecmat, x) == x``, where ``vecmat`` is


### PR DESCRIPTION
This PR is a simple documentation change. It only affects the docstring for `jax.lax.custom_linear_solve`.

I think there is a typo in the `jax.lax.custom_linear_solve` docstring. In particular, it currently says, in the parameter description of `solve` that the function solve satisfies `solve(matvec, x) == x `. I believe this should be `solve(marvel, matvec(x)) == x` and this branch makes that change.

That is the only change in this PR.