### PR TITLE
WIP: [x64] set jax_numpy_dtype_promotion='strict' in tests

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -703,6 +703,7 @@ class JaxTestCase(parameterized.TestCase):
   """Base class for JAX tests including numerical checks and boilerplate."""
   _default_config = {
     'jax_enable_checks': True,
+    'jax_numpy_dtype_promotion': 'strict',
     'jax_numpy_rank_promotion': 'raise',
     'jax_traceback_filtering': 'off',
   }

--- a/jax/experimental/jax2tf/tests/tf_test_util.py
+++ b/jax/experimental/jax2tf/tests/tf_test_util.py
@@ -150,7 +150,8 @@ def ComputeTfValueAndGrad(tf_f: Callable, tf_args: Sequence,
   return f1(*args1)
 
 
-@jtu.with_config(jax_numpy_rank_promotion="allow")
+@jtu.with_config(jax_numpy_rank_promotion="allow",
+                 jax_numpy_dtype_promotion='standard')
 class JaxToTfTestCase(jtu.JaxTestCase):
 
   def setUp(self):


### PR DESCRIPTION
Follow-up to #10824

This is a draft PR meant to reveal what test failures we need to address.