### PR TITLE
jnp.nonzero: require array-like input

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -1212,8 +1212,9 @@ fill_value : array_like, optional
 
 @_wraps(np.nonzero, lax_description=_NONZERO_DOC, extra_params=_NONZERO_EXTRA_PARAMS)
 def nonzero(a, *, size=None, fill_value=None):
+  _check_arraylike("nonzero", a)
   a = atleast_1d(a)
-  mask = a != 0
+  mask = a if a.dtype == bool else (a != 0)
   if size is None:
     size = mask.sum()
   size = core.concrete_or_error(operator.index, size,


### PR DESCRIPTION
Two small changes to the function to address #7737 and #10840