### PR TITLE
BUG: fix internal _jax_type for weak bfloat16

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -269,7 +269,13 @@ _jax_dtype_set = {float0, *_bool_types, *_int_types, *_float_types, *_complex_ty
 
 def _jax_type(dtype, weak_type):
   """Return the jax type for a dtype and weak type."""
-  return type(dtype.type(0).item()) if (weak_type and dtype != bool) else dtype
+  if weak_type:
+    if dtype == bool:
+      return dtype
+    if dtype == _bfloat16_dtype:
+      return float
+    return type(dtype.type(0).item())
+  return dtype
 
 def _dtype_and_weaktype(value):
   """Return a (dtype, weak_type) tuple for the given input."""

--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -289,22 +289,34 @@ class DtypesTest(jtu.JaxTestCase):
 class TestPromotionTables(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
-    {"testcase_name": f"_jaxtype={jaxtype}",
-     "jaxtype": jaxtype}
-     for jaxtype in dtypes._jax_types)
+      {"testcase_name": f"_jaxtype={jaxtype}", "jaxtype": jaxtype}
+      for jaxtype in dtypes._jax_types + dtypes._weak_types)
   def testJaxTypeFromType(self, jaxtype):
     self.assertIs(dtypes._jax_type(*dtypes._dtype_and_weaktype(jaxtype)), jaxtype)
 
   @parameterized.named_parameters(
-    {"testcase_name": f"_jaxtype={jaxtype}",
-     "jaxtype": jaxtype}
-     for jaxtype in dtypes._jax_types)
+      {"testcase_name": f"_jaxtype={jaxtype}", "jaxtype": jaxtype}
+      for jaxtype in dtypes._jax_types + dtypes._weak_types)
   def testJaxTypeFromVal(self, jaxtype):
     try:
       val = jaxtype(0)
     except TypeError:
       val = jaxtype.type(0)
     self.assertIs(dtypes._jax_type(*dtypes._dtype_and_weaktype(val)), jaxtype)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_dtype={dtype}", "dtype": dtype}
+      for dtype in dtypes._jax_types)
+  def testJaxTypeWeak(self, dtype):
+    jax_type = dtypes._jax_type(dtype, weak_type=True)
+    if dtypes.issubdtype(jax_type, np.complexfloating):
+      self.assertIs(jax_type, complex)
+    elif dtypes.issubdtype(jax_type, np.floating):
+      self.assertIs(jax_type, float)
+    elif dtypes.issubdtype(jax_type, np.integer):
+      self.assertIs(jax_type, int)
+    else:
+      self.assertIs(jax_type, np.dtype(bool))
 
   def testResultTypeNone(self):
     # This matches the behavior of np.result_type(None) => np.float_


### PR DESCRIPTION
This is a long-standing bug in a very rare corner case, brought to light when testing #10840