### PR TITLE
[x64] linspace/logspace/geomspace: avoid problematic type promotions

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2118,9 +2118,9 @@ def _linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None,
   _check_arraylike("linspace", start, stop)
 
   if dtype is None:
-    dtype = result_type(start, stop, dtypes.canonicalize_dtype(float_))
+    dtype = dtypes._to_inexact_dtype(result_type(start, stop))
   dtype = _jnp_dtype(dtype)
-  computation_dtype = promote_types(dtype, dtypes.canonicalize_dtype(float_))
+  computation_dtype = dtypes._to_inexact_dtype(dtype)
   start = asarray(start, dtype=computation_dtype)
   stop = asarray(stop, dtype=computation_dtype)
 
@@ -2176,9 +2176,9 @@ def _logspace(start, stop, num=50, endpoint=True, base=10.0, dtype=None,
   """Implementation of logspace differentiable in start and stop args."""
   lax_internal._check_user_dtype_supported(dtype, "logspace")
   if dtype is None:
-    dtype = result_type(start, stop, dtypes.canonicalize_dtype(float_))
+    dtype = dtypes._to_inexact_dtype(result_type(start, stop))
   dtype = _jnp_dtype(dtype)
-  computation_dtype = promote_types(dtype, dtypes.canonicalize_dtype(float_))
+  computation_dtype = dtypes._to_inexact_dtype(dtype)
   _check_arraylike("logspace", start, stop)
   start = asarray(start, dtype=computation_dtype)
   stop = asarray(stop, dtype=computation_dtype)
@@ -2198,9 +2198,9 @@ def _geomspace(start, stop, num=50, endpoint=True, dtype=None, axis: int = 0):
   """Implementation of geomspace differentiable in start and stop args."""
   lax_internal._check_user_dtype_supported(dtype, "geomspace")
   if dtype is None:
-    dtype = result_type(start, stop, dtypes.canonicalize_dtype(float_))
+    dtype = dtypes._to_inexact_dtype(result_type(start, stop))
   dtype = _jnp_dtype(dtype)
-  computation_dtype = promote_types(dtype, dtypes.canonicalize_dtype(float_))
+  computation_dtype = dtypes._to_inexact_dtype(dtype)
   _check_arraylike("geomspace", start, stop)
   start = asarray(start, dtype=computation_dtype)
   stop = asarray(stop, dtype=computation_dtype)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -5602,7 +5602,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         for num in [0, 1, 2, 5, 20]
         for endpoint in [True, False]
         for base in [10.0, 2, np.e]
-        for dtype in inexact_dtypes + [None,]))
+        # skip 16-bit floats due to insufficient precision for the test.
+        for dtype in jtu.dtypes.inexact + [None,]))
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLogspace(self, start_shape, stop_shape, num,
                    endpoint, base, dtype):
@@ -5613,8 +5614,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                               " doesn't exactly match other platforms.")
     rng = jtu.rand_default(self.rng())
     # relax default tolerances slightly
-    tol = {np.float16: 2e-2, np.float32: 1e-2, np.float64: 1e-6,
-           np.complex64: 1e-3, np.complex128: 1e-6}
+    tol = {np.float32: 1e-2, np.float64: 1e-6, np.complex64: 1e-3, np.complex128: 1e-6}
     args_maker = self._GetArgsMaker(rng,
                                     [start_shape, stop_shape],
                                     [dtype, dtype])


### PR DESCRIPTION
Addresses part of #10840

The issue is that with strict promotion, we can't promote to float via the normal `result_type` mechanism; we need to use the `to_inexact_dtype` mechanism to avoid errors when `jax_numpy_type_promotion=strict`.

As an added benefit, this will now avoid generating  `float64` operations when 32-bit values are passed to `linspace`, `logspace`, or `geomspace` in X64 mode.