### PR TITLE
Checkify: support discharging checks from control-flow through effects.

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -993,6 +993,7 @@ tf_not_yet_impl = [
     # Not high priority?
     "after_all",
     "all_to_all",
+    "assert",
     "create_token",
     "custom_transpose_call",
     "custom_vmap_call",


### PR DESCRIPTION
Currently supports scan and while-loop.

Two questions (@sharadmv):
  - Currently the `test_assert_primitive_staging_but_no_translation` test fails: you're able to abstractly evaluate an effectful `check` through `eval_shape` without an error (because no lowering happens). Do you see a way around this? Because I'm now allowing abstract_eval but disallowing lowering, I'm missing this error case (maybe that's fine?)
  - I can't seem to discharge from the `cond` in the `while_loop`, is this expected? If not, it might be a bug in my  while_loop_rule.