### PR TITLE
adding/testing Google Chat notification workflows.

### DIFF
--- a/.github/workflows/broken-main-notify.yml
+++ b/.github/workflows/broken-main-notify.yml
@@ -1,0 +1,22 @@
+name: Google Chat Broken Main Notification
+on:
+  check_suite:
+    types: 
+      - completed
+    branches:
+      - main
+    conclusion:
+      - failure
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Google Chat Notification
+      run: |
+          curl --location --request POST '${{ secrets.RELEASES_WEBHOOK }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "text": "Main is broken @ {github.event.check_suite.created_at} see <{github.event.check_suite.url}|[github]>"
+          }'

--- a/.github/workflows/pull-request-notify.yml
+++ b/.github/workflows/pull-request-notify.yml
@@ -1,0 +1,19 @@
+# Testing out a google chat notification workflow.
+name: Google Chat Pull Request Notifier
+on:
+  pull_request:
+    types: 
+      - opened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Google Chat Notification
+        run: |
+          curl --location --request POST '${{ secrets.RELEASES_WEBHOOK }}' \
+        --header 'Content-Type: application/json' \
+          --data-raw '{
+            "text": "Pull Requst {github.event.pull_request.title} by {github.event.pull_request.user.login}: {github.event.pull_request.body} <{github.event.pull_request.html_url}|[github]>"
+        }'

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -1,0 +1,17 @@
+name: Google Chat Release Notification
+on:
+  release:
+    types: [published]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Google Chat Notification
+      run: |
+          curl --location --request POST '${{ secrets.RELEASES_WEBHOOK }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "text": "Release {github.event.release.name} at {github.event.release.published_at} by {github.event.release.author.login}. Changes: {github.event.release.body} <{github.event.release.url}|[github]>"
+          }'


### PR DESCRIPTION
Trying to test out some Google chat notification workflows.

Three workflows here, one that should notify on a new cut release `release-notification.yml`, one that should trigger on any pull request (this isn't meant to persist but to be used to test on a more active trigger, eventually should be removed) as well as one that attempts to trigger any time a main branch check suite fails.