### PR TITLE
[x64] make jnp.unravel_index safe under strict promotion

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -814,8 +814,13 @@ and out-of-bounds indices are clipped into the valid range.
 @_wraps(np.unravel_index, lax_description=_UNRAVEL_INDEX_DOC)
 def unravel_index(indices, shape):
   _check_arraylike("unravel_index", indices)
-  shape = atleast_1d(shape)
-  if shape.ndim != 1:
+  # Note: we do not convert shape to an array, because it may be passed as a
+  # tuple of weakly-typed values, and asarray() would strip these weak types.
+  try:
+    shape = list(shape)
+  except TypeError:
+    shape = [shape]
+  if _any(ndim(s) != 0 for s in shape):
     raise ValueError("unravel_index: shape should be a scalar or 1D sequence.")
   out_indices = [None] * len(shape)
   for i, s in reversed(list(enumerate(shape))):

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -4232,10 +4232,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     rng = jtu.rand_int(self.rng(), low=-((2 * size) // 3), high=(2 * size) // 3)
 
     def np_fun(index, shape):
+      # JAX's version outputs the same dtype as the input in the typical case
+      # where shape is weakly-typed.
+      out_dtype = index.dtype
       # Adjust out-of-bounds behavior to match jax's documented behavior.
       index = np.clip(index, -size, size - 1)
       index = np.where(index < 0, index + size, index)
-      return np.unravel_index(index, shape)
+      return [i.astype(out_dtype) for i in np.unravel_index(index, shape)]
+
     jnp_fun = jnp.unravel_index
     args_maker = lambda: [rng(idx_shape, dtype), shape]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)


### PR DESCRIPTION
Part of #10840.

Additionally, this change ensures that `unravel_index` returns the same type as the input index. Previously, it would return `int32` or `int64` depending on the X64 flag mode, regardless of the type of the input.