### PR TITLE
Fix macOS builds by updating the minimum OSX version target

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
-build --macos_minimum_os=10.9
+build --macos_minimum_os=10.12
 
 # Make Bazel print out all options from rc files.
 build --announce_rc

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -278,7 +278,7 @@ def build_wheel(sources_path, output_path, cpu):
     ("Linux", "x86_64"): ("manylinux2014", "x86_64"),
     ("Linux", "aarch64"): ("manylinux2014", "aarch64"),
     ("Linux", "ppc64le"): ("manylinux2014", "ppc64le"),
-    ("Darwin", "x86_64"): ("macosx_10_9", "x86_64"),
+    ("Darwin", "x86_64"): ("macosx_10_12", "x86_64"),
     ("Darwin", "arm64"): ("macosx_11_0", "arm64"),
     ("Windows", "AMD64"): ("win", "amd64"),
   }[(platform.system(), cpu)]


### PR DESCRIPTION
Fixes #10884.

This commit bumps the minimum macOS version target to 10.12, from 10.9
previously. The reason is that a newer LLVM version, which the XLA
compiler depended on, used `std::shared_mutex`, which is only available
starting at macOS 10.12.

The fix here consists of setting the minimum version target flag that
bazel consumes for the build to 10.12.