### PR TITLE
Relax test tolerance for spectral divide and conquer eigh test.

### DIFF
--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -583,7 +583,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     atol = jnp.linalg.norm(H) * eps
     self.assertAllClose(ev_exp, jnp.sort(evs), atol=20 * atol)
     self.assertAllClose(
-        HV, vV, atol=atol * (70 if jnp.issubdtype(dtype, jnp.complexfloating)
+        HV, vV, atol=atol * (80 if jnp.issubdtype(dtype, jnp.complexfloating)
                              else 30))
 
   @parameterized.named_parameters(jtu.cases_from_list(


### PR DESCRIPTION
Fixes test failures due to an overly tight tolerance.