### PR TITLE
[x64] Add to_complex_dtype utility function

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -75,6 +75,13 @@ def _to_inexact_dtype(dtype):
   return _dtype_to_inexact.get(dtype, dtype)
 
 
+def _to_complex_dtype(dtype):
+  ftype = _to_inexact_dtype(dtype)
+  if ftype in [np.dtype('float64'), np.dtype('complex128')]:
+    return np.dtype('complex128')
+  return np.dtype('complex64')
+
+
 @functools.lru_cache(maxsize=None)
 def _canonicalize_dtype(x64_enabled, dtype):
   """Convert from a dtype to a canonical dtype based on config.x64_enabled."""

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3212,7 +3212,7 @@ def sort(a, axis: Optional[int] = -1, kind='quicksort', order=None):
 def sort_complex(a):
   _check_arraylike("sort_complex", a)
   a = lax.sort(a, dimension=0)
-  return lax.convert_element_type(a, result_type(a, dtypes.canonicalize_dtype(complex_)))
+  return lax.convert_element_type(a, dtypes._to_complex_dtype(a.dtype))
 
 @_wraps(np.lexsort)
 @partial(jit, static_argnames=('axis',))


### PR DESCRIPTION
Why? Similar to to_inexact_dtype, with the new strict promotion option
we need a way to cast inputs to complex that does not depend on the
promotion lattice.

Part of landing https://github.com/google/jax/pull/10840