### PR TITLE
Store profiler server as a global variable and add a `stop_server` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * Add a `create_perfetto_link` option to {func}`jax.profiler.start_trace` and
     {func}`jax.profiler.start_trace`. When used, the profiler will generate a
     link to the Perfetto UI to view the trace.
+  * Changed the semantics of {func}`jax.profiler.start_server(...)` to store the
+    keepalive globally, rather than requiring the user to keep a reference to
+    it.
 
 ## jaxlib 0.3.11 (Unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jaxlib-v0.3.10...main).

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -154,13 +154,12 @@ from a running program.
 
    ```python
    import jax.profiler
-   server = jax.profiler.start_server(9999)
+   jax.profiler.start_server(9999)
    ```
 
     This starts the profiler server that TensorBoard connects to. The profiler
-    server must be running before you move on to the next step. It will remain
-    alive and listening until the object returned by `start_server()` is
-    destroyed.
+    server must be running before you move on to the next step. When you're done
+    using the server, you can call `jax.profiler.stop_server()` to shut it down.
 
     If you'd like to profile a snippet of a long-running program (e.g. a long
     training loop), you can put this at the beginning of the program and start

--- a/jax/profiler.py
+++ b/jax/profiler.py
@@ -20,6 +20,7 @@ from jax._src.profiler import (
   device_memory_profile as device_memory_profile,
   save_device_memory_profile as save_device_memory_profile,
   start_server as start_server,
+  stop_server as stop_server,
   start_trace as start_trace,
   stop_trace as stop_trace,
   trace as trace,


### PR DESCRIPTION
Currently, the user needs to store around the return value of `jax.profiler.start_server` or the server will immediately be destroyed. This change stores the server in a global variable and exposes a way of destroying it via `stop_server`.