### PR TITLE
[x64] deprecate unsafe type casting in scatter-update operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
     traces as an alternative to the Tensorboard UI.
   * Added a `jax.named_scope` context manager that adds profiler metadata to
     Python programs (similar to `jax.named_call`).
+  * In scatter-update operations (i.e. :attr:`jax.numpy.ndarray.at`), unsafe implicit
+    dtype casts are deprecated, and now result in a `FutureWarning`.
+    In a future release, this will become an error. An example of an unsafe implicit
+    cast is `jnp.zeros(4, dtype=int).at[0].set(1.5)`, in which `1.5` previously was
+    silently truncated to `1`.
 
 ## jaxlib 0.3.11 (Unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jaxlib-v0.3.10...main).

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -16,6 +16,7 @@
 
 import sys
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
+import warnings
 
 import numpy as np
 
@@ -80,6 +81,13 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
                   normalize_indices):
   dtype = lax.dtype(x)
   weak_type = dtypes.is_weakly_typed(x)
+
+  if dtype != dtypes.result_type(x, y):
+    # TODO(jakevdp): change this to an error after the deprecation period.
+    warnings.warn("scatter inputs have incompatible types: cannot safely cast "
+                  f"value from dtype={lax.dtype(y)} to dtype={lax.dtype(x)}. "
+                  "In future JAX releases this will result in an error.",
+                  FutureWarning)
 
   idx = jnp._merge_static_and_dynamic_indices(treedef, static_idx, dynamic_idx)
   indexer = jnp._index_to_gather(jnp.shape(x), idx,

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -350,9 +350,10 @@ def _iterative_classical_gram_schmidt(Q, x, xnorm, max_iterations=2):
 
   # This assumes that Q's leaves all have the same dimension in the last
   # axis.
-  r = jnp.zeros(tree_leaves(Q)[0].shape[-1])
+  Q0 = tree_leaves(Q)[0]
+  r = jnp.zeros(Q0.shape[-1], dtype=Q0.dtype)
   q = x
-  xnorm_scaled = xnorm / jnp.sqrt(2)
+  xnorm_scaled = xnorm / jnp.sqrt(2.0)
 
   def body_function(carry):
     k, q, r, qnorm_scaled = carry
@@ -368,7 +369,7 @@ def _iterative_classical_gram_schmidt(Q, x, xnorm, max_iterations=2):
     def qnorm(carry):
       k, _, q, qnorm_scaled = carry
       _, qnorm = _safe_normalize(q)
-      qnorm_scaled = qnorm / jnp.sqrt(2)
+      qnorm_scaled = qnorm / jnp.sqrt(2.0)
       return (k, False, q, qnorm_scaled)
 
     init = (k, True, q, qnorm_scaled)

--- a/jax/experimental/sparse/csr.py
+++ b/jax/experimental/sparse/csr.py
@@ -93,7 +93,7 @@ class CSR(JAXSparse):
     # TODO(jakevdp): this can be done more efficiently.
     row = lax.sub(idx, lax.cond(k >= 0, lambda: zero, lambda: k))
     indptr = jnp.zeros(N + 1, dtype=index_dtype).at[1:].set(
-        jnp.cumsum(jnp.bincount(row, length=N)))
+        jnp.cumsum(jnp.bincount(row, length=N).astype(index_dtype)))
     return cls((data, indices, indptr), shape=(N, M))
 
   def todense(self):
@@ -296,7 +296,7 @@ def _csr_fromdense_impl(mat, *, nse, index_dtype):
   row = jnp.where(true_nonzeros, row, m)
   indices = col.astype(index_dtype)
   indptr = jnp.zeros(m + 1, dtype=index_dtype).at[1:].set(
-      jnp.cumsum(jnp.bincount(row, length=m)))
+      jnp.cumsum(jnp.bincount(row, length=m).astype(index_dtype)))
   return data, indices, indptr
 
 @csr_fromdense_p.def_abstract_eval

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -77,7 +77,7 @@ class CheckifyTransformTests(jtu.JaxTestCase):
                         "max", "get"])
   def test_jit_oob_update(self, update_fn):
     def f(x, i):
-      return getattr(x.at[i], update_fn)(1.)
+      return getattr(x.at[i], update_fn)(1)
 
     f = jax.jit(f)
     checked_f = checkify.checkify(f, errors=checkify.index_checks)


### PR DESCRIPTION
Fixes #10892

This is a breaking change – at the very least, we'll need to fix some internal tests and some downstream users. Also, perhaps this should involve a deprecation cycle?