### PR TITLE
Fix autodiff of pad() of scalar inputs.

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2893,7 +2893,7 @@ def _pad_transpose(t, operand, padding_value, *, padding_config):
     t_operand = ad_util.Zero(operand.aval) if ad.is_undefined_primal(operand) else None
     t_padv = ad_util.Zero(padding_value.aval) if ad.is_undefined_primal(padding_value) else None
   else:
-    lo, hi, interior = zip(*padding_config)
+    lo, hi, interior = util.unzip3(padding_config)
     total = lambda x: _reduce_sum(x, list(range(t.ndim)))
 
     def t_op():

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -418,7 +418,7 @@ def reduce_window_shape_tuple(operand_shape, window_dimensions, window_strides,
     operand_shape = lax._dilate_shape(operand_shape, base_dilation)
   if window_dilation is not None:
     window_dimensions = lax._dilate_shape(window_dimensions, window_dilation)
-  pads_lo, pads_hi = [(), ()] if len(padding) == 0 else zip(*padding)
+  pads_lo, pads_hi = util.unzip2(padding)
   operand_padded = core.sum_shapes(operand_shape, pads_lo, pads_hi)
   return core.stride_shape(operand_padded, window_dimensions, window_strides)
 

--- a/tests/lax_autodiff_test.py
+++ b/tests/lax_autodiff_test.py
@@ -502,9 +502,12 @@ class LaxAutodiffTest(jtu.JaxTestCase):
       {"testcase_name": "_inshape={}_pads={}"
        .format(jtu.format_shape_dtype_string(shape, dtype), pads),
        "shape": shape, "dtype": dtype, "pads": pads}
-      for shape in [(2, 3)]
       for dtype in float_dtypes
-      for pads in [[(1, 2, 1), (0, 1, 0)], [(-1, 0, 0), (-1, 0, 2)]]))
+      for shape, paddings in [
+        [(), [()]],
+        ((2, 3), [[(1, 2, 1), (0, 1, 0)], [(-1, 0, 0), (-1, 0, 2)]]),
+      ]
+      for pads in paddings))
   def testPadGrad(self, shape, dtype, pads):
     rng = jtu.rand_small(self.rng())
     operand = rng(shape, dtype)


### PR DESCRIPTION
Fixes #10927