### PR TITLE
[x64] make jnp.corrcoef compatible with strict dtype promotion

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4180,9 +4180,8 @@ def corrcoef(x, y=None, rowvar=True):
     # scalar - this should yield nan for values (nan/nan, inf/inf, 0/0), 1 otherwise
     return divide(c, c)
   d = diag(c)
-  stddev = sqrt(real(d))
-  c = divide(c, stddev[:,None])
-  c = divide(c, stddev[None,:])
+  stddev = sqrt(real(d)).astype(c.dtype)
+  c = c / stddev[:, None] / stddev[None, :]
 
   real_part = clip(real(c), -1, 1)
   if iscomplexobj(c):


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10865 and https://github.com/google/jax/pull/10840.