### PR TITLE
[x64] make jax.numpy reductions respect input dtypes

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -274,10 +274,7 @@ def _mean(a, axis: Optional[Union[int, Tuple[int, ...]]] = None, dtype=None,
     normalizer = sum(_broadcast_to(where, np.shape(a)), axis, dtype=dtype, keepdims=keepdims)
 
   if dtype is None:
-    if dtypes.issubdtype(dtypes.dtype(a), np.bool_) or dtypes.issubdtype(dtypes.dtype(a), np.integer):
-      dtype = dtypes.float_
-    else:
-      dtype = dtypes.dtype(a)
+    dtype = dtypes._to_inexact_dtype(dtypes.dtype(a))
   dtype = dtypes.canonicalize_dtype(dtype)
 
   return lax.div(
@@ -381,15 +378,15 @@ def _var_promote_types(a_dtype, dtype):
              "on https://github.com/google/jax/issues/2283 if this behavior is "
              "important to you.")
       raise ValueError(msg)
-    computation_dtype = dtypes.promote_types(a_dtype, dtype)
+    computation_dtype = dtype
   else:
     if not dtypes.issubdtype(a_dtype, np.inexact):
-      dtype = dtypes.canonicalize_dtype(dtypes.float_)
+      dtype = dtypes._to_inexact_dtype(a_dtype)
       computation_dtype = dtype
     else:
       dtype = _complex_elem_type(a_dtype)
-      computation_dtype = _upcast_f16(a_dtype)
-  return computation_dtype, dtype
+      computation_dtype = a_dtype
+  return _upcast_f16(computation_dtype), dtype
 
 
 @_wraps(np.std, skip_params=['out'])

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -786,6 +786,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     @jtu.ignore_warning(category=RuntimeWarning,
                         message="overflow encountered.*")
     def np_fun(x):
+      x = np.asarray(x)
+      if inexact:
+        x = x.astype(dtypes._to_inexact_dtype(x.dtype))
       x_cast = x if dtype != jnp.bfloat16 else x.astype(np.float32)
       t = out_dtype if out_dtype != jnp.bfloat16 else np.float32
       return np_op(x_cast, axis, dtype=t, keepdims=keepdims)
@@ -824,6 +827,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     @jtu.ignore_warning(category=RuntimeWarning,
                         message="All-NaN (slice|axis) encountered.*")
     def np_fun(x):
+      x = np.asarray(x)
+      if inexact:
+        x = x.astype(dtypes._to_inexact_dtype(x.dtype))
       x_cast = x if not is_bf16_nan_test else x.astype(np.float32)
       res = np_op(x_cast, axis, keepdims=keepdims)
       res = res if not is_bf16_nan_test else res.astype(jnp.bfloat16)
@@ -855,6 +861,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         message="Degrees of freedom <= 0 for slice.*")
     @jtu.ignore_warning(category=np.ComplexWarning)
     def np_fun(x):
+      x = np.asarray(x)
+      if inexact:
+        x = x.astype(dtypes._to_inexact_dtype(x.dtype))
       x_cast = x if not is_bf16_nan_test else x.astype(np.float32)
       res = np_op(x_cast, axis, keepdims=keepdims, initial=initial)
       res = res if not is_bf16_nan_test else res.astype(jnp.bfloat16)
@@ -895,6 +904,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         message="Degrees of freedom <= 0 for slice.*")
     @jtu.ignore_warning(category=np.ComplexWarning)
     def np_fun(x):
+      x = np.asarray(x)
+      if inexact:
+        x = x.astype(dtypes._to_inexact_dtype(x.dtype))
       x_cast = x if not is_bf16_nan_test else x.astype(np.float32)
       res = np_op(x_cast, axis, keepdims=keepdims, initial=initial, where=where)
       res = res if not is_bf16_nan_test else res.astype(jnp.bfloat16)
@@ -935,6 +947,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         message="invalid value encountered.*")
     @jtu.ignore_warning(category=np.ComplexWarning)
     def np_fun(x):
+      x = np.asarray(x)
+      if inexact:
+        x = x.astype(dtypes._to_inexact_dtype(x.dtype))
       x_cast = x if not is_bf16_nan_test else x.astype(np.float32)
       res = np_op(x_cast, axis, keepdims=keepdims, where=where)
       res = res if not is_bf16_nan_test else res.astype(jnp.bfloat16)


### PR DESCRIPTION
Also make then compatible with strict dtype promotion mode.

Part of https://github.com/google/jax/pull/10865 and https://github.com/google/jax/pull/10840.