### PR TITLE
Bump minimum Mac OS version to 10.14 (Mojave).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,7 @@
 
 # Sets the default Apple platform to macOS.
 build --apple_platform_type=macos
-build --macos_minimum_os=10.12
+build --macos_minimum_os=10.14
 
 # Make Bazel print out all options from rc files.
 build --announce_rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 
 ## jaxlib 0.3.11 (Unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jaxlib-v0.3.10...main).
-  * x86-64 Mac wheels now require Mac OS 10.12 (Sierra) or newer. Mac OS 10.12
-    was released in 2016, so this should not be an onerous requirement.
+  * x86-64 Mac wheels now require Mac OS 10.14 (Mojave) or newer. Mac OS 10.14
+    was released in 2018, so this should not be a very onerous requirement.
 
 ## jax 0.3.13 (May 16, 2022)
 * [GitHub commits](https://github.com/google/jax/compare/jax-v0.3.12...jax-v0.3.13).

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -278,7 +278,7 @@ def build_wheel(sources_path, output_path, cpu):
     ("Linux", "x86_64"): ("manylinux2014", "x86_64"),
     ("Linux", "aarch64"): ("manylinux2014", "aarch64"),
     ("Linux", "ppc64le"): ("manylinux2014", "ppc64le"),
-    ("Darwin", "x86_64"): ("macosx_10_12", "x86_64"),
+    ("Darwin", "x86_64"): ("macosx_10_14", "x86_64"),
     ("Darwin", "arm64"): ("macosx_11_0", "arm64"),
     ("Windows", "AMD64"): ("win", "amd64"),
   }[(platform.system(), cpu)]


### PR DESCRIPTION
It turns out that the support for C++17 is partial in 10.12, and in particular absl::optional and std::optional are not the same thing under 10.12. Increment to 10.14 which is the lowest version that builds successfully with absl::optional == std::optional.

See: https://github.com/abseil/abseil-cpp/blob/89cdaed6557dbfb8cc8fba53a9dc8baf332df8b0/absl/base/config.h#L528
Strictly speaking, we could allow 10.13, but not without updating ABSL in the TF repository to incorporate https://github.com/abseil/abseil-cpp/commit/c86347d4cec43074e64e225a8753728f4bfc5ed6 which fixes the version detection test to permit 10.13 as well.