### PR TITLE
Add initial LOBPCG top-k eigenvalue solver (#3112)

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -259,3 +259,5 @@ from jax.experimental.sparse.transform import (
     sparsify as sparsify,
     SparseTracer as SparseTracer,
 )
+
+from jax.experimental.sparse import linalg

--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -1,0 +1,504 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sparse linear algebra routines."""
+
+from typing import Union, Callable
+import functools
+
+import jax
+import jax.numpy as jnp
+
+import numpy as np
+
+def lobpcg_standard(
+    A: Union[jnp.ndarray, Callable[[jnp.ndarray], jnp.ndarray]],
+    X: jnp.ndarray,
+    m: int = 100,
+    tol: Union[jnp.ndarray, float, None] = None):
+  """Compute the top-k standard eigenvalues using the LOBPCG routine.
+
+  LOBPCG [1] stands for Locally Optimal Block Preconditioned Conjugate Gradient.
+  The method enables finding top-k eigenvectors in an accelerator-friendly
+  manner.
+
+  This initial experimental version has several caveats.
+
+    - Only the standard eigenvalue problem `A U = lambda U` is supported,
+      general eigenvalues are not.
+    - Gradient code is not available.
+    - f64 will only work where jnp.linalg.eigh is supported for that type.
+    - Finding the smallest eigenvectors is not yet supported. As a result,
+      we don't yet support preconditioning, which is mostly needed for this
+      case.
+
+  The implementation is based on [2] and [3]; however, we deviate from these
+  sources in several ways to improve robustness or facilitate implementation:
+
+    - Despite increased iteration cost, we always maintain an orthonormal basis
+      for the block search directions.
+    - We change the convergence criterion; see the `tol` argument.
+    - Soft locking [4] is intentionally not implemented; it relies on
+      choosing an appropriate problem-specific tolerance to prevent
+      blow-up near convergence from catastrophic cancellation of
+      near-0 residuals. Instead, the approach implemented favors
+      truncating the iteration basis.
+
+  [1]: http://ccm.ucdenver.edu/reports/rep149.pdf
+  [2]: https://arxiv.org/abs/1704.07458
+  [3]: https://arxiv.org/abs/0705.2626
+  [4]: DOI 10.13140/RG.2.2.11794.48327
+
+  Args:
+    A : An `(n, n)` array representing a square Hermitian matrix or a
+        callable with its action.
+    X : An `(n, k)` array representing the initial search directions for the `k`
+        desired top eigenvectors. This need not be orthogonal, but must be
+        numerically linearly independent (`X` will be orthonormalized).
+        Note that we must have `0 < k * 5 < n`.
+    m : Maximum integer iteration count; LOBPCG will only ever explore (a
+        subspace of) the Krylov basis `{X, A X, A^2 X, ..., A^m X}`.
+    tol : A float convergence tolerance; an eigenpair `(lambda, v)` is converged
+          when its residual L2 norm `r = |A v - lambda v|` is below
+          `tol * 10 * n * (lambda + |A v|)`, which
+          roughly estimates the worst-case floating point error for an ideal
+          eigenvector. If all `k` eigenvectors satisfy the tolerance
+          comparison, then LOBPCG exits early. If left as None, then this is set
+          to the float epsilon of `A.dtype`.
+
+  Returns:
+    `theta, U, i [, diagnostics]`, where `theta` is a `(k,)` array
+    of eigenvalues, `U` is a `(n, k)` array of eigenvectors, `i` is the
+    number of iterations performed, and `diagnostics` is a dictionary with debug
+    information, which is only returned if `debug` is set to true.
+
+  Raises:
+    ValueError : if `A,X` dtypes or `n` dimensions do not match, or `k` is too
+                 large (only `k * 5 < n` supported), or `k == 0`.
+  """
+  # Jit-compile once per matrix shape if possible.
+  if isinstance(A, (jnp.ndarray, np.ndarray)):
+    return _lobpcg_standard_matrix(A, X, m, tol, debug=False)
+  return _lobpcg_standard_callable(A, X, m, tol, debug=False)
+
+@functools.partial(jax.jit, static_argnames=['m', 'debug'])
+def _lobpcg_standard_matrix(
+    A: jnp.ndarray,
+    X: jnp.ndarray,
+    m: int,
+    tol: Union[jnp.ndarray, float, None],
+    debug: bool = False):
+  """Computes lobpcg_standard(), possibly with debug diagnostics."""
+  return _lobpcg_standard_callable(
+      functools.partial(_mm, A), X, m, tol, debug)
+
+@functools.partial(jax.jit, static_argnames=['A', 'm', 'debug'])
+def _lobpcg_standard_callable(
+    A: Callable[[jnp.ndarray], jnp.ndarray],
+    X: jnp.ndarray,
+    m: int,
+    tol: Union[jnp.ndarray, float, None],
+    debug: bool = False):
+  """Supports generic lobpcg_standard() callable interface."""
+
+  # TODO(vladf): support mixed_precision flag, which allows f64 Rayleigh-Ritz
+  # with f32 inputs.
+
+  n, k = X.shape
+  dt = X.dtype
+
+  _check_inputs(A, X)
+
+  if tol is None:
+    tol = jnp.finfo(dt).eps
+
+  X = _orthonormalize(X)
+  P = _extend_basis(X, X.shape[1])
+
+  # We maintain X, our current list of best eigenvectors,
+  # P, our search direction, and
+  # R, our residuals, in a large joint array XPR, column-stacked, so (n, 3*k).
+
+  AX = A(X)
+  theta = jnp.sum(X * AX, axis=0, keepdims=True)
+  R = AX - theta * X
+
+  def cond(state):
+    i, _X, _P, _R, converged, _ = state
+    return jnp.logical_and(i < m, converged < k)
+
+  def body(state):
+    i, X, P, R, _, theta = state
+    # Invariants: X, P, R kept orthonormal
+    # Some R, P columns may be 0 (due to basis truncation, as decided
+    # by orthogonalization routines), but not X.
+
+    # TODO(vladf): support preconditioning for bottom-k eigenvectors
+    # if M is not None:
+    #   R = M(R)
+
+    # Residual basis selection.
+    R = _project_out(jnp.concatenate((X, P), axis=1), R)
+    XPR = jnp.concatenate((X, P, R), axis=1)
+
+    # Projected eigensolve.
+    theta, Q = _rayleigh_ritz_orth(A, XPR)
+
+    # Eigenvector X extraction
+    B = Q[:, :k]
+    normB = jnp.linalg.norm(B, ord=2, axis=0, keepdims=True)
+    B /= normB
+    X = _mm(XPR, B)
+    normX = jnp.linalg.norm(X, ord=2, axis=0, keepdims=True)
+    X /= normX
+
+    # Difference terms P extraction
+    #
+    # In next step of LOBPCG, naively, we'd set
+    # P = S[:, k:] @ Q[k:, :k] to achieve span(X, P) == span(X, previous X)
+    # (this is not obvious, see section 4 of [1]).
+    #
+    # Instead we orthogonalize concat(0, Q[k:, :k]) against Q[:, :k]
+    # in the standard basis before mapping with XPR. Since XPR is itself
+    # orthonormal, the resulting directions are themselves orthonormalized.
+    #
+    # [2] leverages Q's existing orthogonality to derive
+    # an analytic expression for this value based on the quadrant Q[:k,k:]
+    # (see section 4.2 of [2]).
+    q, _ = jnp.linalg.qr(Q[:k, k:].T)
+    diff_rayleigh_ortho = _mm(Q[:, k:], q)
+    P = _mm(XPR, diff_rayleigh_ortho)
+    normP = jnp.linalg.norm(P, ord=2, axis=0, keepdims=True)
+    P /= jnp.where(normP == 0, 1.0, normP)
+
+    # Compute new residuals.
+    AX = A(X)
+    R = AX - theta[jnp.newaxis, :k] * X
+    resid_norms = jnp.linalg.norm(R, ord=2, axis=0)
+
+    # I tried many variants of hard and soft locking [3]. All of them seemed
+    # to worsen performance relative to no locking.
+    #
+    # Further, I found a more expermental convergence formula compared to what
+    # is suggested in the literature, loosely based on floating-point
+    # expectations.
+    #
+    # [2] discusses various strategies for this in Sec 5.3. The solution
+    # they end up with, which estimates operator norm |A| via Gaussian
+    # products, was too crude in practice (and overly-lax). The Gaussian
+    # approximation seems like an estimate of the average eigenvalue.
+    #
+    # Instead, we test convergence via self-consistency of the eigenpair
+    # i.e., the residual norm |r| should be small, relative to the floating
+    # point error we'd expect from computing just the residuals given
+    # candidate vectors.
+    reltol = jnp.linalg.norm(AX, ord=2, axis=0) + theta[:k]
+    reltol *= n
+    # Allow some margin for a few element-wise operations.
+    reltol *= 10
+    res_converged = resid_norms < tol * reltol
+    converged = jnp.sum(res_converged)
+
+    new_state = i + 1, X, P, R, converged, theta[jnp.newaxis, :k]
+    if debug:
+      diagnostics = _generate_diagnostics(
+          XPR, X, P, R, theta, converged, resid_norms / reltol)
+      new_state = (new_state, diagnostics)
+    return new_state
+
+  converged = 0
+  state = (0, X, P, R, converged, theta)
+  if debug:
+    state, diagnostics = jax.lax.scan(
+        lambda state, _: body(state), state, xs=None, length=m)
+  else:
+    state = jax.lax.while_loop(cond, body, state)
+  i, X, _P, _R, _converged, theta = state
+
+  if debug:
+    return theta[0, :], X, i, diagnostics
+  return theta[0, :], X, i
+
+
+def _check_inputs(A, X):
+  n, k = X.shape
+  dt = X.dtype
+
+  if k == 0:
+    raise ValueError(f'must have search dim > 0, got {k}')
+
+  if k * 5 >= n:
+    raise ValueError(f'expected search dim * 5 < matrix dim (got {k * 5}, {n})')
+
+  test_output = A(jnp.zeros((n, 1), dtype=X.dtype))
+
+  if test_output.dtype != dt:
+    raise ValueError(
+        f'A, X must have same dtypes (were {test_output.dtype}, {dt})')
+
+  if test_output.shape != (n, 1):
+    s = test_output.shape
+    raise ValueError(f'A must be ({n}, {n}) matrix A, got output {s}')
+
+
+def _mm(a, b, precision=jax.lax.Precision.HIGHEST):
+  return jax.lax.dot(a, b, (precision, precision))
+
+def _generate_diagnostics(prev_XPR, X, P, R, theta, converged, adj_resid):
+  k = X.shape[1]
+  assert X.shape == P.shape
+
+  diagdiag = lambda x: jnp.diag(jnp.diag(x))
+  abserr = lambda x: jnp.abs(x).sum() / (k ** 2)
+
+  XTX = _mm(X.T, X)
+  DX = diagdiag(XTX)
+  orthX = abserr(XTX - DX)
+
+  PTP = _mm(P.T, P)
+  DP = diagdiag(PTP)
+  orthP = abserr(PTP - DP)
+
+  PX = abserr(X.T @ P)
+
+  prev_basis = prev_XPR.shape[1] - jnp.sum(jnp.all(prev_XPR == 0.0, axis=0))
+
+  return {
+      'basis rank': prev_basis,
+      'X zeros': jnp.sum(jnp.all(X == 0.0, axis=0)),
+      'P zeros': jnp.sum(jnp.all(P == 0.0, axis=0)),
+      'lambda history': theta[:k],
+      'residual history': jnp.linalg.norm(R, axis=0, ord=2),
+      'converged': converged,
+      'adjusted residual max': jnp.max(adj_resid),
+      'adjusted residual p50': jnp.median(adj_resid),
+      'adjusted residual min': jnp.min(adj_resid),
+      'X orth': orthX,
+      'P orth': orthP,
+      'P.X': PX}
+
+def _eigh_ascending(A):
+  w, V = jnp.linalg.eigh(A)
+  return w[::-1], V[:, ::-1]
+
+
+def _svqb(X):
+  """Derives a truncated orthonormal basis for `X`.
+
+  SVQB [1] is an accelerator-friendly orthonormalization procedure, which
+  squares the matrix `C = X.T @ X` and computes an eigenbasis for a smaller
+  `(k, k)` system; this offloads most of the work in orthonormalization
+  to the first multiply when `n` is large.
+
+  Importantly, if diagonalizing the squared matrix `C` reveals rank deficiency
+  of X (which would be evidenced by near-0 then), eigenvalues corresponding
+  columns are zeroed out.
+
+  [1]: https://sdm.lbl.gov/~kewu/ps/45577.html
+
+  Args:
+    X : An `(n, k)` array which describes a linear subspace of R^n, possibly
+        numerically degenerate with some rank less than `k`.
+
+  Returns:
+    An orthonormal space `V` described by a `(n, k)` array, with trailing
+    columns possibly zeroed out if `X` is of low rank.
+  """
+
+  # In [1] diagonal conditioning is explicit, but by normalizing first
+  # we can simplify the formulas a bit, since then diagonal conditioning
+  # becomes a no-op.
+  norms = jnp.linalg.norm(X, ord=2, axis=0, keepdims=True)
+  X /= jnp.where(norms == 0, 1.0, norms)
+
+  inner = _mm(X.T, X)
+
+  w, V = _eigh_ascending(inner)
+
+  # All mask logic is used to avoid divide-by-zeros when input columns
+  # may have been zero or new zero columns introduced from truncation.
+  #
+  # If an eigenvalue is less than max eigvalue * eps, then consider
+  # that direction "degenerate".
+  tau = jnp.finfo(X.dtype).eps * w[0]
+  padded = jnp.maximum(w, tau)
+
+  # Note the the tau == 0 edge case where X was all zeros.
+  sqrted = jnp.where(tau > 0, padded, 1.0) ** (-0.5)
+
+  # X^T X = V diag(w) V^T, so
+  # W = X V diag(w)^(-1/2) will yield W^T W = I (excerpting zeros).
+  scaledV = V * sqrted[jnp.newaxis, :]
+  orthoX = _mm(X, scaledV)
+
+  keep = ((w > tau) * (jnp.diag(inner) > 0.0))[jnp.newaxis, :]
+  orthoX *= keep.astype(orthoX.dtype)
+  norms = jnp.linalg.norm(orthoX, ord=2, axis=0, keepdims=True)
+  keep *= norms > 0.0
+  orthoX /= jnp.where(keep, norms, 1.0)
+  return orthoX
+
+
+def _project_out(basis, U):
+  """Derives component of U in the orthogonal complement of basis.
+
+  This method iteratively subtracts out the basis component and orthonormalizes
+  the remainder. To an extent, these two operations can oppose each other
+  when the remainder norm is near-zero (since normalization enlarges a vector
+  which may possibly lie in the subspace `basis` to be subtracted).
+
+  We make sure to prioritize orthogonality between `basis` and `U`, favoring
+  to return a lower-rank space thank `rank(U)`, in this tradeoff.
+
+  Args:
+    basis : An `(n, m)` array which describes a linear subspace of R^n, this
+        is assumed to be orthonormal but zero columns are allowed.
+    U : An `(n, k)` array representing another subspace of R^n, whose `basis`
+        component is to be projected out.
+
+  Returns:
+    An `(n, k)` array, with some columns possibly zeroed out, representing
+    the component of `U` in the complement of `basis`. The nonzero columns
+    are mutually orthonormal.
+  """
+
+  # See Sec. 6.9 of The Symmetric Eigenvalue Problem by Beresford Parlett [1]
+  # which motivates two loop iterations for basis subtraction. This
+  # "twice is enough" approach is due to Kahan. See also a practical note
+  # by SLEPc developers [2].
+  #
+  # Interspersing with orthonormalization isn't directly grounded in the
+  # original analysis, but taken from Algorithm 5 of [3]. In practice, due to
+  # normalization, I have noticed that that the orthonormalized basis
+  # does not always end up as a subspace of the starting basis in practice.
+  # There may be room to refine this procedure further, but the adjustment
+  # in the subsequent block handles this edge case well enough for now.
+  #
+  # [1]: https://epubs.siam.org/doi/abs/10.1137/1.9781611971163
+  # [2]: http://slepc.upv.es/documentation/reports/str1.pdf
+  # [3]: https://arxiv.org/abs/1704.07458
+  for _ in range(2):
+    U -= _mm(basis, _mm(basis.T, U))
+    U = _orthonormalize(U)
+
+  # It's crucial to end on a subtraction of the original basis.
+  # This seems to be a detail not present in [2], possibly because of
+  # of reliance on soft locking.
+  #
+  # Near convergence, if the residuals R are 0 and our last
+  # operation when projecting (X, P) out from R is the orthonormalization
+  # done above, then due to catastrophic cancellation we may re-introduce
+  # (X, P) subspace components into U, which can ruin the Rayleigh-Ritz
+  # conditioning.
+  #
+  # We zero out any columns that are even remotely suspicious, so the invariant
+  # that [basis, U] is zero-or-orthogonal is ensured.
+  for _ in range(2):
+    U -= _mm(basis, _mm(basis.T, U))
+  normU = jnp.linalg.norm(U, ord=2, axis=0, keepdims=True)
+  U *= (normU >= 0.99).astype(U.dtype)
+
+  return U
+
+def _orthonormalize(basis):
+  # Twice is enough, again.
+  for _ in range(2):
+    basis = _svqb(basis)
+  return basis
+
+
+def _rayleigh_ritz_orth(A, S):
+  """Solve the Rayleigh-Ritz problem for `A` projected to `S`.
+
+  Solves the local eigenproblem for `A` within the subspace `S`, which is
+  assumed to be orthonormal (with zero columns allowed), identifying `w, V`
+  satisfying
+
+  (1) `S.T A S V ~= diag(w) V`
+  (2) `V` is standard orthonormal
+
+  Note that (2) is simplified to be standard orthonormal because `S` is.
+
+  Args:
+    A: An operator representing the action of an `n`-sized square matrix.
+    S: An orthonormal subspace of R^n represented by an `(n, k)` array, with
+       zero columns allowed.
+
+  Returns:
+    Eigenvectors `V` and eigenvalues `w` satisfying the size-`k` system
+    described in this method doc. Note `V` will be full rank, even if `S` isn't.
+  """
+
+  SAS = _mm(S.T, A(S))
+
+  # Solve the projected subsytem.
+  # If we could tell to eigh to stop after first k, we would.
+  return _eigh_ascending(SAS)
+
+
+def _extend_basis(X, m):
+  """Extend the basis of `X` with `m` addition dimensions.
+
+  Given an orthonormal `X` of dimension `k`, a typical strategy for deriving
+  an extended basis is to generate a random one and project it out.
+
+  We instead generate a basis using block householder reflectors [1] [2] to
+  leverage the favorable properties of determinism and avoiding the chance that
+  the generated random basis has overlap with the starting basis, which may
+  happen with non-negligible probability in low-dimensional cases.
+
+  [1]: https://epubs.siam.org/doi/abs/10.1137/0725014
+  [2]: https://www.jstage.jst.go.jp/article/ipsjdc/2/0/2_0_298/_article
+
+  Args:
+    X : An `(n, k)` array representing a `k`-rank orthonormal basis for a linear
+        subspace of R^n.
+    m : A nonnegative integer such that `k + m <= n` telling us how much to
+        extend the basis by.
+
+  Returns:
+    An `(n, m)` array representing an extension to the basis of `X` such that
+    their union is orthonormal.
+  """
+  n, k = X.shape
+  # X = vstack(Xupper, Xlower), where Xupper is (k, k)
+  Xupper, Xlower = jnp.split(X, [k], axis=0)
+  u, s, vt = jnp.linalg.svd(Xupper)
+
+  # Adding U V^T to Xupper won't change its row or column space, but notice
+  # its singular values are all lifted by 1; we could write its upper k rows
+  # as u diag(1 + s) vt.
+  y = jnp.concatenate([Xupper + _mm(u, vt), Xlower], axis=0)
+
+  # Suppose we found a full-rank (n, k) matrix w which defines the
+  # perpendicular to a space we'd like to reflect over. The block householder
+  # reflector H(w) would have the usual involution property.
+  #
+  # Consider the two definitions below:
+  # H(w) = I - 2 w w^T
+  # 2 w w^T = y (v diag(1+s)^(-1) vt) y^T
+  #
+  # After some algebra, we see H(w) X = vstack(-u vt, 0)
+  # Applying H(w) to both sides since H(w)^2 = I we have
+  # X = H(w) vstack(-u vt, 0). But since H(w) is unitary its action must
+  # preserve rank. Thus H(w) vstack(0, eye(n - k)) must be orthogonal to
+  # X; taking just the first m columns H(w) vstack(0, eye(m), 0) yields
+  # an orthogonal extension to X.
+  other = jnp.concatenate(
+      [jnp.eye(m, dtype=X.dtype),
+       jnp.zeros((n - k - m, m), dtype=X.dtype)], axis=0)
+  w = _mm(y, vt.T * ((2 * (1 + s)) ** (-1/2))[jnp.newaxis, :])
+  h = -2 * jnp.linalg.multi_dot(
+      [w, w[k:, :].T, other], precision=jax.lax.Precision.HIGHEST)
+  return h.at[k:].add(other)

--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -1,0 +1,397 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for lobpcg routine.
+
+If LOBPCG_DEBUG_PLOT_DIR is set, exports debug visuals to that directory.
+Requires matplotlib.
+"""
+
+import functools
+import re
+import os
+
+from absl.testing import parameterized
+import numpy as np
+import scipy.linalg as sla
+import scipy.sparse as sps
+
+import jax
+from jax._src import test_util as jtu
+from jax._src.config import flags
+from jax.experimental.sparse import linalg, bcoo
+import jax.numpy as jnp
+
+def _clean_matrix_name(name):
+  return re.sub('[^0-9a-zA-Z]+', '_', name)
+
+def _make_concrete_cases(f64):
+  dtype = np.float64 if f64 else np.float32
+  example_names = list(_concrete_generators(dtype))
+  cases = []
+  for name in example_names:
+    nkm = [(100, 10, 20)]
+    if not flags.FLAGS.jax_skip_slow_tests:
+      nkm.append((1000, 100, 200))
+    for n, k, m in nkm:
+      if name == 'ring laplacian':
+        m *= 3
+      if name.startswith('linear'):
+        m *= 2
+      if f64:
+        m *= 2
+      case = [('matrix_name', name), ('n', n), ('k', k), ('m', m)]
+      clean_matrix_name = _clean_matrix_name(name)
+      case.append(('testcase_name', f'{clean_matrix_name}_n{n}'))
+      cases.append(dict(case))
+
+  assert len({c['testcase_name'] for c in cases}) == len(cases)
+  return cases
+
+def _make_callable_cases(f64):
+  dtype = np.float64 if f64 else np.float32
+  example_names = list(_callable_generators(dtype))
+  return [{'testcase_name': _clean_matrix_name(n), 'matrix_name': n}
+          for n in example_names]
+
+def _make_ring(n):
+  # from lobpcg scipy tests
+  col = np.zeros(n)
+  col[1] = 1
+  A = sla.toeplitz(col)
+  D = np.diag(A.sum(axis=1))
+  L = D - A
+  # Compute the full eigendecomposition using tricks, e.g.
+  # http://www.cs.yale.edu/homes/spielman/561/2009/lect02-09.pdf
+  tmp = np.pi * np.arange(n) / n
+  analytic_w = 2 * (1 - np.cos(tmp))
+  analytic_w.sort()
+  analytic_w = analytic_w[::-1]
+
+  return L, analytic_w
+
+def _make_diag(diag):
+  diag.sort()
+  diag = diag[::-1]
+  return np.diag(diag), diag
+
+def _make_cluster(to_cluster, n):
+  return _make_diag(
+      np.array([1000] * to_cluster + [1] * (n - to_cluster)))
+
+def _concrete_generators(dtype):
+  d = {
+      'id': lambda n, _k: _make_diag(np.ones(n)),
+      'linear cond=1k': lambda n, _k: _make_diag(np.linspace(1, 1000, n)),
+      'linear cond=100k':
+          lambda n, _k: _make_diag(np.linspace(1, 100 * 1000, n)),
+      'geom cond=1k': lambda n, _k: _make_diag(np.logspace(0, 3, n)),
+      'geom cond=100k': lambda n, _k: _make_diag(np.logspace(0, 5, n)),
+      'ring laplacian': lambda n, _k: _make_ring(n),
+      'cluster(k/2)': lambda n, k: _make_cluster(k // 2, n),
+      'cluster(k-1)': lambda n, k: _make_cluster(k - 1, n),
+      'cluster(k)': lambda n, k: _make_cluster(k, n)}
+  def cast_fn(fn):
+    def casted_fn(n, k):
+      result = fn(n, k)
+      cast = functools.partial(np.array, dtype=dtype)
+      return tuple(map(cast, result))
+    return casted_fn
+  return {k: cast_fn(v) for k, v in d.items()}
+
+def _make_id_fn(n):
+  return lambda x: x, np.ones(n), 5
+
+def _make_diag_fn(diagonal, m):
+  return lambda x: diagonal.astype(x.dtype) * x, diagonal, m
+
+def _make_ring_fn(n, m):
+  _, eigs = _make_ring(n)
+  def ring_action(x):
+    degree = 2 * x
+    lnbr = jnp.roll(x, 1)
+    rnbr = jnp.roll(x, -1)
+    return degree - lnbr - rnbr
+  return ring_action, eigs, m
+
+def _make_randn_fn(n, k, m):
+  rng = np.random.default_rng(1234)
+  tall_skinny = rng.standard_normal((n, k))
+  def randn_action(x):
+    ts = jnp.array(tall_skinny, dtype=x.dtype)
+    p = jax.lax.Precision.HIGHEST
+    return ts.dot(ts.T.dot(x, precision=p), precision=p)
+  _, s, _ = np.linalg.svd(tall_skinny, full_matrices=False)
+  return randn_action, s ** 2, m
+
+def _make_sparse_fn(n, fill):
+  rng = np.random.default_rng(1234)
+  slots = n ** 2
+  filled = max(int(slots * fill), 1)
+  pos = rng.choice(slots, size=filled, replace=False)
+  posx, posy = divmod(pos, n)
+  data = rng.standard_normal(len(pos))
+  coo = sps.coo_matrix((data, (posx, posy)), shape=(n, n))
+
+  def sparse_action(x):
+    coo_typed = coo.astype(np.dtype(x.dtype))
+    sps_mat = bcoo.BCOO.from_scipy_sparse(coo_typed)
+    dn = (((1,), (0,)), ((), ()))  # Good old fashioned matmul.
+    x = bcoo.bcoo_dot_general(sps_mat, x, dimension_numbers=dn)
+    sps_mat_T = sps_mat.transpose()
+    return bcoo.bcoo_dot_general(sps_mat_T, x, dimension_numbers=dn)
+
+  dense = coo.todense()
+  _, s, _ = np.linalg.svd(dense, full_matrices=False)
+  return sparse_action, s ** 2, 20
+
+
+def _callable_generators(dtype):
+  n = 100
+  topk = 10
+  d = {'id': _make_id_fn(n),
+       'linear cond=1k': _make_diag_fn(np.linspace(1, 1000, n), 40),
+       'linear cond=100k':_make_diag_fn(np.linspace(1, 100 * 1000, n), 40),
+       'geom cond=1k': _make_diag_fn(np.logspace(0, 3, n), 20),
+       'geom cond=100k': _make_diag_fn(np.logspace(0, 5, n), 20),
+       'ring laplacian': _make_ring_fn(n, 40),
+       'randn': _make_randn_fn(n, topk, 40),
+       'sparse 1%': _make_sparse_fn(n, 0.01),
+       'sparse 10%': _make_sparse_fn(n, 0.10),
+       }
+
+  ret = {}
+  for k, (vec_mul_fn, eigs, m) in d.items():
+    if jtu.num_float_bits(dtype) > 32:
+       m *= 3
+    eigs.sort()
+
+    # Note we must lift the vector multiply into matmul
+    fn = jax.vmap(vec_mul_fn, in_axes=1, out_axes=1)
+
+    ret[k] = (fn, eigs[::-1][:topk].astype(dtype), n, m)
+  return ret
+
+@jtu.with_config(
+    jax_enable_checks=True,
+    jax_debug_nans=True,
+    jax_numpy_rank_promotion='raise',
+    jax_traceback_filtering='off')
+class LobpcgTest(jtu.JaxTestCase):
+
+  def checkLobpcgConsistency(self, matrix_name, n, k, m, dtype):
+    A, eigs = _concrete_generators(dtype)[matrix_name](n, k)
+    X = self.rng().standard_normal(size=(n, k)).astype(dtype)
+
+    A, X = (jnp.array(i, dtype=dtype) for i in (A, X))
+    theta, U, i = linalg.lobpcg_standard(A, X, m)
+
+    self.assertDtypesMatch(theta, A)
+    self.assertDtypesMatch(U, A)
+
+    self.assertLess(
+        i, m, msg=f'expected early convergence iters {int(i)} < max {m}')
+
+    issorted = theta[:-1] >= theta[1:]
+    all_true = np.ones_like(issorted).astype(bool)
+    self.assertArraysEqual(issorted, all_true)
+
+    k = X.shape[1]
+    relerr = np.abs(theta - eigs[:k]) / eigs[:k]
+    for i in range(k):
+      # The self-consistency property should be ensured.
+      u = np.asarray(U[:, i], dtype=A.dtype)
+      t = float(theta[i])
+      Au = A.dot(u)
+      resid = Au - t * u
+      resid_norm = np.linalg.norm(resid)
+      vector_norm = np.linalg.norm(Au)
+      adjusted_error = resid_norm / n / (t + vector_norm) / 10
+
+      eps = float(jnp.finfo(dtype).eps)
+      self.assertLessEqual(
+          adjusted_error,
+          eps,
+          msg=f'convergence criterion for eigenvalue {i} not satisfied, '
+          f'floating point error {adjusted_error} not <= {eps}')
+
+      # There's no real guarantee we can be within x% of the true eigenvalue.
+      # However, for these simple unit test examples this should be met.
+      tol = float(np.sqrt(eps)) * 10
+      self.assertLessEqual(
+          relerr[i],
+          tol,
+          msg=f'expected relative error within {tol}, was {float(relerr[i])}'
+          f' for eigenvalue {i} (actual {float(theta[i])}, '
+          f'expected {float(eigs[i])})')
+
+  def checkLobpcgMonotonicity(self, matrix_name, n, k, m, dtype):
+    A, eigs = _concrete_generators(dtype)[matrix_name](n, k)
+    X = self.rng().standard_normal(size=(n, k)).astype(dtype)
+
+    _theta, _U, _i, info = linalg._lobpcg_standard_matrix(
+        A, X, m, tol=0, debug=True)
+    self.assertArraysEqual(info['X zeros'], jnp.zeros_like(info['X zeros']))
+
+    # To check for any divergence, make sure that the last 20% of
+    # steps have lower worst-case relerr than first 20% of steps,
+    # at least up to an order of magnitude.
+    #
+    # This is non-trivial, as many implementations have catastrophic
+    # cancellations at convergence for residual terms, and rely on
+    # brittle locking tolerance to avoid divergence.
+    eigs = eigs[:k]
+    relerrs = np.abs(np.array(info['lambda history']) - eigs) / eigs
+    few_steps = max(m // 5, 1)
+    self.assertLess(
+        relerrs[-few_steps:].max(axis=1).mean(),
+        10 * relerrs[:few_steps].max(axis=1).mean())
+
+    self._possibly_plot(A, eigs, X, m, matrix_name)
+
+  def _possibly_plot(self, A, eigs, X, m, matrix_name):
+    plot_dir = os.getenv('LOBPCG_DEBUG_PLOT_DIR')
+    if plot_dir is not None:
+      if isinstance(A, (np.ndarray, jnp.ndarray)):
+        lobpcg = linalg._lobpcg_standard_matrix
+      else:
+        lobpcg = linalg._lobpcg_standard_callable
+      _theta, _U, _i, info = lobpcg(A, X, m, tol=0, debug=True)
+      self._debug_plots(
+          X, eigs, info, matrix_name, plot_dir)
+
+  def _debug_plots(self, X, eigs, info, matrix_name, lobpcg_debug_plot_dir):
+    os.makedirs(lobpcg_debug_plot_dir, exist_ok=True)
+    clean_matrix_name = _clean_matrix_name(matrix_name)
+    n, k = X.shape
+    dt = 'f32' if X.dtype == np.float32 else 'f64'
+    figpath = os.path.join(
+        lobpcg_debug_plot_dir,
+        f'{clean_matrix_name}_n{n}_k{k}_{dt}.png')
+
+    from matplotlib import pyplot as plt
+    plt.switch_backend('Agg')
+
+    fig, (ax0, ax1, ax2, ax3) = plt.subplots(1, 4, figsize=(24, 4))
+    fig.suptitle(fr'{matrix_name} $n={n},k={k}$, {dt}')
+    line_styles = [':', '--', '-.', '-']
+
+    for key, ls in zip(['X orth', 'P orth', 'P.X'], line_styles):
+      ax0.semilogy(info[key], ls=ls, label=key)
+    ax0.set_title('basis average orthogonality')
+    ax0.legend()
+
+    relerrs = np.abs(np.array(info['lambda history']) - eigs) / eigs
+    keys = ['max', 'p50', 'min']
+    fns = [np.max, np.median, np.min]
+    for key, fn, ls in zip(keys, fns, line_styles):
+      ax1.semilogy(fn(relerrs, axis=1), ls=ls, label=key)
+    ax1.set_title('eigval relerr')
+    ax1.legend()
+
+    for key, ls in zip(['basis rank', 'converged', 'P zeros'], line_styles):
+      ax2.plot(info[key], ls=ls, label=key)
+    ax2.set_title('basis dimension counts')
+    ax2.legend()
+
+    prefix = 'adjusted residual'
+    for key, ls in zip(keys, line_styles):
+      ax3.semilogy(info[prefix + ' ' + key], ls=ls, label=key)
+    ax3.axhline(np.finfo(X.dtype).eps, label='eps', c='k')
+    ax3.legend()
+    ax3.set_title(prefix + rf' $\lambda_{{\max}}=\ ${eigs[0]:.1e}')
+
+    fig.savefig(figpath, bbox_inches='tight')
+
+  def checkApproxEigs(self, example_name, dtype):
+    fn, eigs, n, m = _callable_generators(dtype)[example_name]
+
+    k = len(eigs)
+    X = self.rng().standard_normal(size=(n, k)).astype(dtype)
+
+    theta, U, iters = linalg.lobpcg_standard(fn, X, m, tol=0.0)
+
+    # Given tolerance is zero all iters should be used.
+    self.assertEqual(iters, m)
+
+    # Evaluate in f64.
+    as64 = functools.partial(np.array, dtype=np.float64)
+    theta, eigs, U = (as64(x) for x in (theta, eigs, U))
+
+    relerr = np.abs(theta - eigs) / eigs
+    UTU = U.T.dot(U)
+
+    tol = np.sqrt(jnp.finfo(dtype).eps) * 100
+    if example_name == 'ring laplacian':
+      tol = 1e-2
+
+    for i in range(k):
+      self.assertLessEqual(
+          relerr[i], tol,
+          msg=f'eigenvalue {i} (actual {theta[i]} expected {eigs[i]})')
+      self.assertAllClose(UTU[i, i], 1.0, rtol=tol)
+      UTU[i, i] = 0
+      self.assertArraysAllClose(UTU[i], np.zeros_like(UTU[i]), atol=tol)
+
+    self._possibly_plot(fn, eigs, X, m, 'callable_' + example_name)
+
+class F32LobpcgTest(LobpcgTest):
+
+  def testLobpcgValidatesArguments(self):
+    A, _ = _concrete_generators(np.float32)['id'](100, 10)
+    X = self.rng().standard_normal(size=(100, 10)).astype(np.float32)
+
+    with self.assertRaisesRegex(ValueError, 'search dim > 0'):
+      linalg.lobpcg_standard(A, X[:,:0])
+
+    with self.assertRaisesRegex(ValueError, 'A, X must have same dtypes'):
+      linalg.lobpcg_standard(
+          lambda x: jnp.array(A).dot(x).astype(jnp.float16), X)
+
+    with self.assertRaisesRegex(ValueError, r'A must be \(100, 100\)'):
+      linalg.lobpcg_standard(A[:60, :], X)
+
+    with self.assertRaisesRegex(ValueError, r'search dim \* 5 < matrix dim'):
+      linalg.lobpcg_standard(A[:50, :50], X[:50])
+
+  @parameterized.named_parameters(_make_concrete_cases(f64=False))
+  def testLobpcgConsistencyF32(self, matrix_name, n, k, m):
+    self.checkLobpcgConsistency(matrix_name, n, k, m, jnp.float32)
+
+  @parameterized.named_parameters(_make_concrete_cases(f64=False))
+  def testLobpcgMonotonicityF32(self, matrix_name, n, k, m):
+    self.checkLobpcgMonotonicity(matrix_name, n, k, m, jnp.float32)
+
+  @parameterized.named_parameters(_make_callable_cases(f64=False))
+  def testCallableMatricesF32(self, matrix_name):
+    self.checkApproxEigs(matrix_name, jnp.float32)
+
+
+@jtu.with_config(jax_enable_x64=True)
+class F64LobpcgTest(LobpcgTest):
+
+  @parameterized.named_parameters(_make_concrete_cases(f64=True))
+  @jtu.skip_on_devices("tpu", "iree")
+  def testLobpcgConsistencyF64(self, matrix_name, n, k, m):
+    self.checkLobpcgConsistency(matrix_name, n, k, m, jnp.float64)
+
+  @parameterized.named_parameters(_make_concrete_cases(f64=True))
+  @jtu.skip_on_devices("tpu", "iree")
+  def testLobpcgMonotonicityF64(self, matrix_name, n, k, m):
+    self.checkLobpcgMonotonicity(matrix_name, n, k, m, jnp.float64)
+
+  @parameterized.named_parameters(_make_callable_cases(f64=True))
+  @jtu.skip_on_devices("tpu", "iree")
+  def testCallableMatricesF64(self, matrix_name):
+    self.checkApproxEigs(matrix_name, jnp.float64)


### PR DESCRIPTION
This initial version is f32-only for accelerators, since it relies on an eigh call (which itself is f32 at most) in its inner loop.

For details, see jax.experimental.linalg.standard_lobpcg documentation.