### PR TITLE
Add `jax.logging` module

### DIFF
--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -144,6 +144,7 @@ from jax import dtypes as dtypes
 from jax import errors as errors
 from jax import image as image
 from jax import lax as lax
+from jax import logging as logging
 from jax import nn as nn
 from jax import numpy as numpy
 from jax import ops as ops

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -18,13 +18,12 @@
 import contextlib
 import functools
 import itertools
+import logging
 import os
 import sys
 import threading
 from typing import Any, List, Callable, Hashable, NamedTuple, Iterator, Optional
 import warnings
-
-from absl import logging
 
 from jax._src import lib
 from jax._src.lib import jax_jit
@@ -522,6 +521,13 @@ def update_thread_local_jit_state(**kw):
   tls.extra_jit_context = _thread_local_state_cache.canonicalize(tmp)
 
 
+def _reload_logging_module(val):
+  # Update hook for the jax_use_absl_logging flag.
+  # Reloads JAX's logging module using importlib.
+  from importlib import reload, import_module
+  jax_logging = import_module("jax.logging")
+  jax_logging = reload(jax_logging)
+
 flags.DEFINE_integer(
     'jax_tracer_error_num_traceback_frames',
     int_env('JAX_TRACER_ERROR_NUM_TRACEBACK_FRAMES', 5),
@@ -532,6 +538,13 @@ flags.DEFINE_bool(
     'jax_pprint_use_color',
     bool_env('JAX_PPRINT_USE_COLOR', True),
     help='Enable jaxpr pretty-printing with colorful syntax highlighting.'
+)
+
+flags.DEFINE_bool(
+    'jax_use_absl_logging',
+    bool_env('JAX_USE_ABSL_LOGGING', False),
+    help='Use absl logging in JAX instead of Python builtin logging.',
+    update_hook=_reload_logging_module,
 )
 
 flags.DEFINE_bool(

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -30,12 +30,12 @@ import re
 import threading
 import warnings
 
-from absl import logging
 import numpy as np
 
 import jax
 from jax import core
 from jax import linear_util as lu
+from jax import logging
 from jax.errors import UnexpectedTracerError
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -18,8 +18,9 @@ import functools
 
 from typing import Any, Optional, Union, Sequence
 
-from absl import logging
 from jax._src.clusters import ClusterEnv
+from jax import logging
+from jax._src import cloud_tpu_init
 from jax._src.config import config
 from jax._src.lib import xla_extension
 

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -26,9 +26,9 @@ import threading
 from typing import Any, Dict, List, Optional, Union
 import warnings
 
-from absl import logging
+from jax import logging
 # Disable "WARNING: Logging before flag parsing goes to stderr." message
-logging._warn_preinit_stderr = 0
+logging.set_warn_preinit_stderr(False)
 
 import jax._src.lib as lib
 from jax._src.config import flags, bool_env, int_env
@@ -127,7 +127,7 @@ def get_compile_options(
     build_options.auto_spmd_partitioning_mesh_ids = auto_spmd_partitioning_mesh_ids
   if device_assignment is not None:
     logging.vlog(
-        2,
+        logging.CPP_ERROR,
         'get_compile_options: num_replicas=%s num_partitions=%s device_assignment=%s',
         num_replicas, num_partitions, device_assignment)
     device_assignment = np.array(device_assignment)
@@ -384,7 +384,7 @@ def _init_backend(platform):
   if factory is None:
     raise RuntimeError(f"Unknown backend '{platform}'")
 
-  logging.vlog(1, "Initializing backend '%s'" % platform)
+  logging.vlog(logging.CPP_WARNING, "Initializing backend '%s'" % platform)
   backend = factory()
   # TODO(skye): consider raising more descriptive errors directly from backend
   # factories instead of returning None.
@@ -396,7 +396,7 @@ def _init_backend(platform):
                              ("process_index", backend.process_index()),
                              ("device_count", backend.device_count()),
                              ("local_devices", backend.local_devices()))
-  logging.vlog(1, "Backend '%s' initialized" % platform)
+  logging.vlog(logging.CPP_WARNING, "Backend '%s' initialized" % platform)
   return backend
 
 

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -25,7 +25,7 @@ import warnings
 
 from typing import Callable, Optional
 
-from absl import logging
+from jax import logging
 from jax._src import traceback_util
 traceback_util.register_exclusion(__file__)
 

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -24,11 +24,11 @@ from typing import (Any, Callable, Dict, Iterable, List, Tuple, Generic,
                     TypeVar, Set, Iterator, Sequence, Optional)
 import weakref
 
-from absl import logging
 import numpy as np
 
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension_version
+from jax import logging
 from jax.config import config
 
 Seq = Sequence

--- a/jax/experimental/compilation_cache/compilation_cache.py
+++ b/jax/experimental/compilation_cache/compilation_cache.py
@@ -19,10 +19,10 @@ import sys
 from typing import List, Optional
 
 import jax
+from jax import logging
 from jax.experimental.compilation_cache.gfile_cache import GFileCache
 from jax._src.lib import version_str as jaxlib_version_str
 from jax._src.lib import xla_client
-from absl import logging
 
 _cache = None
 
@@ -57,14 +57,17 @@ def put_executable(module_name, xla_computation, compile_options,
   _cache.put(cache_key, serialized_executable)
 
 def _log_cache_key_hash(hash_obj, last_serialized: str, hashfn):
-  if logging.vlog_is_on(1):
+  if logging.vlog_is_on(logging.CPP_WARNING):
     # Log the hash of just this entry
     fresh_hash_obj = hashlib.sha256()
     hashfn(fresh_hash_obj)
-    logging.vlog(1, "get_cache_key hash of serialized %s: %s", last_serialized,
+    logging.vlog(logging.CPP_WARNING,
+                 "get_cache_key hash of serialized %s: %s",
+                 last_serialized,
                  fresh_hash_obj.digest().hex())
     # Log the cumulative hash
-    logging.vlog(1, "get_cache_key hash after serializing %s: %s",
+    logging.vlog(logging.CPP_WARNING,
+                 "get_cache_key hash after serializing %s: %s",
                  last_serialized, hash_obj.digest().hex())
 
 def get_cache_key(xla_computation, compile_options, backend) -> str:
@@ -212,9 +215,13 @@ def _hash_xla_flags(hash_obj):
   # (e.g. --xla_force_host_platform_device_count=8) (I think).
   for flag in xla_flags:
     if flag.split('=')[0] in _xla_flags_to_exclude_from_cache_key:
-      logging.vlog(1, "Not including XLA flag in cache key: %s", flag)
+      logging.vlog(logging.CPP_WARNING,
+                   "Not including XLA flag in cache key: %s",
+                   flag)
       continue
-    logging.vlog(1, "Including XLA flag in cache key: %s", flag)
+    logging.vlog(logging.CPP_WARNING,
+                 "Including XLA flag in cache key: %s",
+                 flag)
     _hash_string(hash_obj, flag)
 
 def _hash_int(hash_obj, int_var):

--- a/jax/experimental/gda_serialization/serialization.py
+++ b/jax/experimental/gda_serialization/serialization.py
@@ -20,9 +20,9 @@ from functools import partial
 import re
 import threading
 from typing import Callable, Sequence, Optional
-from absl import logging
 
 import jax
+from jax import logging
 from jax._src import distributed
 from jax._src.config import config
 from jax.experimental import global_device_array as gda

--- a/jax/experimental/mesh_utils.py
+++ b/jax/experimental/mesh_utils.py
@@ -17,8 +17,8 @@
 import itertools
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from absl import logging
 import jax
+from jax import logging
 import numpy as np
 
 _TPU_V2 = 'TPU v2'

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -44,13 +44,12 @@ from typing import (Any, Callable, Dict, List, NamedTuple, Optional, FrozenSet,
                     Sequence, Set, Tuple, Type, Union, Iterable, Mapping, cast,
                     TYPE_CHECKING)
 
-from absl import logging
-
 import numpy as np
 
 import jax
 from jax import core
 from jax import linear_util as lu
+from jax import logging
 from jax.core import ConcreteArray, ShapedArray
 from jax.errors import JAXTypeError
 from jax.interpreters import ad
@@ -1363,19 +1362,19 @@ def lower_parallel_callable(
   jaxpr, consts, replicas, parts, shards = stage_parallel_callable(
       pci, fun, global_arg_shapes)
 
-  if logging.vlog_is_on(2):
-    logging.vlog(2, "sharded_avals: %s", shards.sharded_avals)
-    logging.vlog(2, "global_sharded_avals: %s", shards.global_sharded_avals)
-    logging.vlog(2, "num_replicas: %d  num_local_replicas: %d",
+  if logging.vlog_is_on(logging.CPP_ERROR):
+    logging.vlog(logging.CPP_ERROR, "sharded_avals: %s", shards.sharded_avals)
+    logging.vlog(logging.CPP_ERROR, "global_sharded_avals: %s", shards.global_sharded_avals)
+    logging.vlog(logging.CPP_ERROR, "num_replicas: %d  num_local_replicas: %d",
                  replicas.num_global_replicas, replicas.num_local_replicas)
-    logging.vlog(2, "num_partitions: %d  local_num_partitions: %d",
+    logging.vlog(logging.CPP_ERROR, "num_partitions: %d  local_num_partitions: %d",
                  parts.num_partitions, parts.local_num_partitions)
-    logging.vlog(2, "arg_parts: %s", parts.arg_parts)
-    logging.vlog(2, "local_arg_parts: %s", parts.local_arg_parts)
-    logging.vlog(2, "out_parts: %s", parts.out_parts)
-    logging.vlog(2, "local_out_parts: %s", parts.local_out_parts)
-    logging.vlog(2, "devices: %s", devices)
-    logging.vlog(2, "local_devices: %s", pci.local_devices)
+    logging.vlog(logging.CPP_ERROR, "arg_parts: %s", parts.arg_parts)
+    logging.vlog(logging.CPP_ERROR, "local_arg_parts: %s", parts.local_arg_parts)
+    logging.vlog(logging.CPP_ERROR, "out_parts: %s", parts.out_parts)
+    logging.vlog(logging.CPP_ERROR, "local_out_parts: %s", parts.local_out_parts)
+    logging.vlog(logging.CPP_ERROR, "devices: %s", devices)
+    logging.vlog(logging.CPP_ERROR, "local_devices: %s", pci.local_devices)
 
   if (xb.process_count(backend) > 1 and must_run_on_all_devices and
       shards.num_local_shards != xb.local_device_count(backend)):

--- a/jax/logging.py
+++ b/jax/logging.py
@@ -1,0 +1,153 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A module for interoperable logging between ABSL and Python in JAX."""
+import importlib
+from typing import Optional
+
+from jax._src.config import FLAGS
+
+# flag indicating whether or not to use absl instead of standard logging.
+use_absl: bool = FLAGS.jax_use_absl_logging
+
+# Step 0: Import standard Python logging APIs that have no counterpart
+# in absl.logging, and can be used regardless of the chosen logging setup.
+from logging import (
+  addLevelName,
+  captureWarnings,
+  FileHandler,
+  Filter,
+  Filterer,
+  Formatter,
+  Handler,
+  Logger,
+  LogRecord,
+  makeLogRecord,
+  StreamHandler,
+)
+
+# Step 1: Conditionally import APIs and attributes that are
+# _effectively_ identical in absl and standard logging.
+# The exact values of the logging verbosity enum differ between
+# absl and standard logging, but the approach below ensures that
+# absl and standard APIs are never mixed, so this should be fine.
+if use_absl:
+  from absl.logging import (
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL,
+    debug,
+    info,
+    warning,
+    error,
+    fatal,
+    log,
+  )
+  # ABSL C++ vlog levels.
+  CPP_DEBUG = 0
+  CPP_INFO = 0
+  CPP_WARNING = 1
+  CPP_ERROR = 2
+  CPP_CRITICAL = 3
+  CPP_FATAL = 3
+
+else:
+  from logging import (
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL,
+    debug,
+    info,
+    warning,
+    error,
+    fatal,
+    log,
+  )
+  # standard values of C++ vlog levels. This representation
+  # is not as rich, because C++ warning calls are aliased
+  # to absl.DEBUG level when using logging.vlog.
+  CPP_DEBUG = 10
+  CPP_INFO = 10
+  CPP_WARNING = 10
+  CPP_ERROR = 9
+  CPP_CRITICAL = 8
+  CPP_FATAL = 8
+
+# set additional names in standard logging for the last two
+# C++ log levels to improve display, namely
+# error (vlog level 2) and critical/fatal (vlog level 3).
+# These level values _need_ to be in standard logging, since absl's
+# `vlog` translates all C++ log levels to standard logging internally.
+addLevelName(9, "CPP_ERROR")
+addLevelName(8, "CPP_CRITICAL")
+
+
+# Step 2: Implement APIs with differences between absl and standard
+# logging in a unified, as lightweight as possible interface.
+def set_warn_preinit_stderr(val: bool):
+  """
+  Toggle the `_warn_preinit_stderr` state variable in ABSL logging.
+  Can be used to suppress the
+  'WARNING: Logging before flag parsing goes to stderr.' message.
+  """
+  if use_absl:
+    absl_logging = importlib.import_module("absl.logging")
+    setattr(absl_logging, "_warn_preinit_stderr", val)
+
+
+def getLogger(name: Optional[str] = None):
+  if use_absl:
+    del name
+    # logger is a module-wide singleton with name `absl`.
+    from absl.logging import get_absl_logger
+    return get_absl_logger()
+  else:
+    from logging import getLogger
+    return getLogger(name=name)
+
+
+def vlog_is_on(level: int, name: Optional[str] = None):
+  """
+  Check whether a specific logger is enabled for a given C++ log level.
+
+  Input level should be a sensible integer input given the current
+  logging facility's level hierarchy.
+
+  When using absl C++ logging, the level should be an integer between
+  0 (debug/info) and 3 (critical/fatal), while for builtin Python logging,
+  it should be between 10 (debug) and 50 (critical/fatal).
+
+  The name argument is used to acquire the logger whose enabled level
+  should be checked. If unspecified, the level of the absl logger
+  (when using absl) or the builtin root logger (when using builtin logging)
+  will be checked.
+  """
+  if use_absl:
+    from absl.logging import vlog_is_on
+    return vlog_is_on(level=level)
+  else:
+    logger = getLogger(name=name)
+    return logger.isEnabledFor(level=level)
+
+
+def vlog(level, msg, *args, **kwargs):
+  """Log a message at C++ log level `level`."""
+  if use_absl:
+    from absl.logging import vlog
+    vlog(level, msg, *args, **kwargs)
+  else:
+    log(level, msg, *args, **kwargs)


### PR DESCRIPTION
Fixes #6308.

This commit adds the top-level `jax.logging` module to JAX. In it, the most important routines for logging are imported, enabling their use across the codebase.

The choice which module these routines are imported from (choices are absl or Python's builtin logging) can be made through the newly added `jax_use_absl_logging` config flag.

The `jax.logging` module is intended as a drop-in replacement for `from absl import logging` imports, allowing for more flexible logging setups within JAX.

EDIT: The first approach was not dynamic enough (or, at all), but using a config value update hook that hot-reloads the logging module and reimports conditionally based on the flag value, the following works now:

```python
>>> from jax import logging
>>> from jax.config import config
>>> logging.warning("hello")
>>> WARNING:root:hello  #       <-- this is the Python builtin root logger
>>> config.update("jax_use_absl_logging", True)
>>> logging.warning("hello")
>>> WARNING:absl:hello  #       <-- this is the absl logger
```