### PR TITLE
[x64] make jnp.modf() compatible with strict dtype promotion

### DIFF
--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -591,6 +591,7 @@ def real(val):
 @jit
 def modf(x, out=None):
   _check_arraylike("modf", x)
+  x, = _promote_dtypes_inexact(x)
   if out is not None:
     raise NotImplementedError("The 'out' argument to jnp.modf is not supported.")
   whole = _where(lax.ge(x, lax_internal._zero(x)), floor(x), ceil(x))


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10865 and https://github.com/google/jax/pull/10840.