### PR TITLE
lax_numpy_test: test bitwise ops on full input range

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -396,9 +396,12 @@ def rand_fullrange(rng, standardize_nans=False):
   """Random numbers that span the full range of available bits."""
   def gen(shape, dtype, post=lambda x: x):
     dtype = np.dtype(dtype)
-    size = dtype.itemsize * np.prod(_dims_of_shape(shape))
+    size = dtype.itemsize * np.prod(_dims_of_shape(shape), dtype=int)
     vals = rng.randint(0, np.iinfo(np.uint8).max, size=size, dtype=np.uint8)
-    vals = post(vals).view(dtype).reshape(shape)
+    vals = post(vals).view(dtype)
+    if shape is PYTHON_SCALAR_SHAPE and dtype == np.uint64:
+      vals = vals.astype(np.int64)  # prevent overflows
+    vals = vals.reshape(shape)
     # Non-standard NaNs cause errors in numpy equality assertions.
     if standardize_nans and np.issubdtype(dtype, np.floating):
       vals[np.isnan(vals)] = np.nan

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -331,15 +331,15 @@ JAX_COMPOUND_OP_RECORDS = [
 
 JAX_BITWISE_OP_RECORDS = [
     op_record("bitwise_and", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool, []),
+              jtu.rand_fullrange, []),
     op_record("bitwise_not", 1, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool, []),
+              jtu.rand_fullrange, []),
     op_record("invert", 1, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool, []),
+              jtu.rand_fullrange, []),
     op_record("bitwise_or", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool, []),
+              jtu.rand_fullrange, []),
     op_record("bitwise_xor", 2, int_dtypes + unsigned_dtypes, all_shapes,
-              jtu.rand_bool, []),
+              jtu.rand_fullrange, []),
 ]
 
 JAX_REDUCER_RECORDS = [
@@ -725,9 +725,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testBitwiseOp(self, np_op, jnp_op, rng_factory, shapes, dtypes):
     rng = rng_factory(self.rng())
-    if not config.x64_enabled and any(
-        jnp.iinfo(dtype).bits == 64 for dtype in dtypes):
-      self.skipTest("x64 types are disabled by jax_enable_x64")
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker,
                             check_dtypes=jtu.PYTHON_SCALAR_SHAPE not in shapes)


### PR DESCRIPTION
I think that using `rand_bool` was inadvertent, because it means we only test the values `0` and `1`. With this change, we test the full range of integer inputs to the function.