### PR TITLE
[x64] Make TPU svd compatible with strict type promotion

### DIFF
--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -121,7 +121,7 @@ def _qdwh(x, m, n, is_hermitian, max_iterations, eps):
   # norm(x, 2) such that `alpha >= norm(x, 2)` and `beta` is a lower bound for
   # the smallest singular value of x.
   if eps is None:
-    eps = jnp.finfo(x.dtype).eps
+    eps = float(jnp.finfo(x.dtype).eps)
   alpha = (jnp.sqrt(jnp.linalg.norm(x, ord=1)) *
            jnp.sqrt(jnp.linalg.norm(x, ord=jnp.inf)))
   l = eps

--- a/jax/_src/lax/svd.py
+++ b/jax/_src/lax/svd.py
@@ -108,7 +108,7 @@ def _svd_tall_and_square_input(
     u_out = u_out @ jnp.diag(lax.sign(jnp.diag(r)))
     return u_out
 
-  eps = jnp.finfo(a.dtype).eps
+  eps = float(jnp.finfo(a.dtype).eps)
   u_out = lax.cond(s[0] < a.shape[1] * eps * s_out[0],
                    correct_rank_deficiency,
                    lambda u_out: u_out,


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10865 and https://github.com/google/jax/pull/10840.

Explanation: `finfo(dtype).eps` returns a strongly-typed `np.float32`, and this promotes to `np.float64` when combined with Python scalars via standard arithmetic operators. This causes `float64` values to come into the program, which triggers the strict promotion error when `JAX_NUMPY_DTYPE_PROMOTION=strict`. By casting to `float` here, we get weakly-typed values that promote correctly with strongly-typed inputs, and the operations are valid under strict promotion.