### PR TITLE
Add bitwise XOR reducer to `lax.reduce`

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -981,6 +981,7 @@ tf_not_yet_impl = [
     "igamma_grad_a",
     "random_gamma_grad",
     "reduce_precision",
+    "reduce_xor",
     "schur",
     "closed_call",
     "unreachable",

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -182,6 +182,7 @@ from jax._src.lax.lax import (
   reduce_precision_p as reduce_precision_p,
   reduce_prod_p as reduce_prod_p,
   reduce_sum_p as reduce_sum_p,
+  reduce_xor_p as reduce_xor_p,
   regularized_incomplete_beta_p as regularized_incomplete_beta_p,
   rem as rem,
   rem_p as rem_p,


### PR DESCRIPTION
Fixes #11005.

This commit adds handling for the `lax.bitwise_xor` operation to `lax.reduce`. It also includes a new standard reduce primitive, modeled after the existing `and`/ `or` reducer primitives.

TODO: Add testing. (The example by @jakevdp given in the issue works now, though:)

```python
>>> from jax import lax
>>> import jax.numpy as jnp
>>> lax.reduce(jnp.arange(10), 0, lax.bitwise_xor, (0,))
>>> DeviceArray(1, dtype=int32)
```