### PR TITLE
[x64] preserve weak types in promote_dtypes_inexact

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -191,9 +191,9 @@ def nextafter(x1: Array, x2: Array) -> Array:
   values which appear as zero in any operations. Consider this example::
 
     >>> jnp.nextafter(0, 1)  # denormal numbers are representable
-    DeviceArray(1.e-45, dtype=float32)
+    DeviceArray(1.e-45, dtype=float32, weak_type=True)
     >>> jnp.nextafter(0, 1) * 1  # but are flushed to zero
-    DeviceArray(0., dtype=float32)
+    DeviceArray(0., dtype=float32, weak_type=True)
 
   For the smallest usable (i.e. normal) float, use ``tiny`` of ``jnp.finfo``.
   """

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -271,7 +271,6 @@ def _promote_dtypes_inexact(*args):
   to_dtype, weak_type = dtypes._lattice_result_type(*args)
   to_dtype = dtypes.canonicalize_dtype(to_dtype)
   to_dtype_inexact = dtypes._to_inexact_dtype(to_dtype)
-  weak_type = (weak_type and to_dtype == to_dtype_inexact)
   return [lax_internal._convert_element_type(x, to_dtype_inexact, weak_type)
           for x in args]
 


### PR DESCRIPTION
Why? Currently `jnp.sqrt(2.0)` returns a weakly-typed value, but `jnp.sqrt(2)` does not. This seems strange. ~I'm trying this change to see how many things it breaks.~ Edit: TGP is clean, I think this is good to go in!