### PR TITLE
[x64] make lax_scipy_test.py compatible with strict dtype promotion

### DIFF
--- a/jax/_src/lax/qdwh.py
+++ b/jax/_src/lax/qdwh.py
@@ -123,7 +123,7 @@ def _qdwh(x, m, n, is_hermitian, max_iterations, eps):
   if eps is None:
     eps = float(jnp.finfo(x.dtype).eps)
   alpha = (jnp.sqrt(jnp.linalg.norm(x, ord=1)) *
-           jnp.sqrt(jnp.linalg.norm(x, ord=jnp.inf)))
+           jnp.sqrt(jnp.linalg.norm(x, ord=jnp.inf))).astype(x.dtype)
   l = eps
 
   u = x / alpha

--- a/jax/_src/scipy/linalg.py
+++ b/jax/_src/scipy/linalg.py
@@ -699,6 +699,7 @@ def polar(a, side='right', *, method='qdwh', eps=None, max_iterations=None):
                                 f"side='left', got {a.shape} with side={side}")
   elif method == "svd":
     u_svd, s_svd, vh_svd = lax_linalg.svd(a, full_matrices=False)
+    s_svd = s_svd.astype(u_svd.dtype)
     unitary = u_svd @ vh_svd
     if side == "right":
       # a = u * p


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10865 and https://github.com/google/jax/pull/10840.