### PR TITLE
Extend Common-Gotchas docs: speed of jnp.array

### DIFF
--- a/docs/notebooks/Common_Gotchas_in_JAX.ipynb
+++ b/docs/notebooks/Common_Gotchas_in_JAX.ipynb
@@ -353,7 +353,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exception '<class 'jaxlib.xla_extension.DeviceArray'>' object does not support item assignment. JAX arrays are immutable. Instead of ``x[idx] = y``, use ``x = x.at[idx].set(y)`` or another .at[] method: https://jax.readthedocs.io/en/latest/jax.ops.html\n"
+      "Exception '<class 'jaxlib.xla_extension.DeviceArray'>' object does not support item assignment. JAX arrays are immutable. Instead of ``x[idx] = y``, use ``x = x.at[idx].set(y)`` or another .at[] method: https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html\n"
      ]
     }
    ],
@@ -772,32 +772,31 @@
     {
      "data": {
       "text/plain": [
-       "{ lambda  ; a b c d e f g h i j.\n",
-       "  let k = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] a\n",
-       "      l = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] b\n",
-       "      m = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] c\n",
-       "      n = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] d\n",
-       "      o = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] e\n",
-       "      p = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] f\n",
-       "      q = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] g\n",
-       "      r = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] h\n",
-       "      s = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] i\n",
-       "      t = broadcast_in_dim[ broadcast_dimensions=(  )\n",
-       "                            shape=(1,) ] j\n",
-       "      u = concatenate[ dimension=0 ] k l m n o p q r s t\n",
-       "      v = convert_element_type[ new_dtype=int32\n",
-       "                                weak_type=False ] u\n",
-       "      w = reduce_sum[ axes=(0,) ] v\n",
-       "  in (w,) }"
+       "{ \u001b[34m\u001b[22m\u001b[1mlambda \u001b[39m\u001b[22m\u001b[22m; a\u001b[35m:i32[]\u001b[39m b\u001b[35m:i32[]\u001b[39m c\u001b[35m:i32[]\u001b[39m d\u001b[35m:i32[]\u001b[39m e\u001b[35m:i32[]\u001b[39m f\u001b[35m:i32[]\u001b[39m g\u001b[35m:i32[]\u001b[39m h\u001b[35m:i32[]\u001b[39m i\u001b[35m:i32[]\u001b[39m\n",
+       "    j\u001b[35m:i32[]\u001b[39m. \u001b[34m\u001b[22m\u001b[1mlet\n",
+       "    \u001b[39m\u001b[22m\u001b[22mk\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] a\n",
+       "    l\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] b\n",
+       "    m\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] c\n",
+       "    n\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] d\n",
+       "    o\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] e\n",
+       "    p\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] f\n",
+       "    q\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] g\n",
+       "    r\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] h\n",
+       "    s\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] i\n",
+       "    t\u001b[35m:i32[]\u001b[39m = convert_element_type[new_dtype=int32 weak_type=False] j\n",
+       "    u\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] k\n",
+       "    v\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] l\n",
+       "    w\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] m\n",
+       "    x\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] n\n",
+       "    y\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] o\n",
+       "    z\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] p\n",
+       "    ba\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] q\n",
+       "    bb\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] r\n",
+       "    bc\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] s\n",
+       "    bd\u001b[35m:i32[1]\u001b[39m = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] t\n",
+       "    be\u001b[35m:i32[10]\u001b[39m = concatenate[dimension=0] u v w x y z ba bb bc bd\n",
+       "    bf\u001b[35m:i32[]\u001b[39m = reduce_sum[axes=(0,)] be\n",
+       "  \u001b[34m\u001b[22m\u001b[1min \u001b[39m\u001b[22m\u001b[22m(bf,) }"
       ]
      },
      "execution_count": 17,
@@ -848,6 +847,92 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course, writing the conversion explicitly does not make it any faster. Consider the following example of converting a nested list of integers to a JAX array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.21 s ± 147 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = [list(range(1000)) for i in range(1000)]    # A simple nested list\n",
+    "%timeit jnp.array(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This conversion can be sped up immensely by first converting the list to a NumPy array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "78.5 ms ± 3.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit jnp.array(np.array(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So in places where performance matters and the dtype of the input data is known, it can often be a good idea to first convert to NumPy, before initializing the JAX array.\n",
+    "\n",
+    "However, there are situations where `jnp.array(...)` and `jnp.array(np.array(...))` behave differently. Firstly, inside jit-compiled functions, `np.array` cannot be used on non-static inputs, because it would be presented with a tracer object and throw an error. Secondly, and this is related to why `jnp.array` is slower in the first place, they handle mixed dtypes differently:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "float16\n",
+      "float32\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = np.float16(0)\n",
+    "\n",
+    "print(jnp.array([x, 1]).dtype)\n",
+    "print(jnp.array(np.array([x, 1])).dtype)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "JAX treats unspecified Python scalars as \"weakly-typed\", in that they conform to the types of other \"strongly-typed\" values they interact with, so in this example JAX converts the `1` to a `float16` dtype. In contrast, NumPy treats Python scalars as 64-bit, and tends to promote things to 64-bit indiscriminately (more on this below)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "MUycRNh6e50W"
    },
@@ -878,7 +963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -891,9 +976,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.07022903604194575\n",
-      "0.11575983097278075\n",
-      "0.15620432311959775\n"
+      "0.7342569735638732\n",
+      "0.790786391922849\n",
+      "0.615476279866955\n"
      ]
     }
    ],
@@ -914,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {
     "id": "7Pyp2ajzfPO2"
    },
@@ -939,7 +1024,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {
     "id": "GAHaDCYafpAF"
    },
@@ -1000,7 +1085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1015,7 +1100,7 @@
        "DeviceArray([0, 0], dtype=uint32)"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1039,7 +1124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1078,7 +1163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1116,7 +1201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1154,7 +1239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1201,7 +1286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1245,7 +1330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1283,7 +1368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1322,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1337,7 +1422,7 @@
      "text": [
       "Exception Abstract tracer value encountered where concrete value is expected: Traced<ShapedArray(bool[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>\n",
       "The problem arose with the `bool` function. \n",
-      "While tracing the function f at <ipython-input-30-b42e45c0293f>:1 for jit, this concrete value was not available in Python because it depends on the value of the argument 'x'.\n",
+      "While tracing the function f at /var/folders/b_/mrq467b11bv_32fb0lz46bgm0000gp/T/ipykernel_41326/2259617891.py:1 for jit, this concrete value was not available in Python because it depends on the value of the argument 'x'.\n",
       "\n",
       "See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError\n"
      ]
@@ -1381,7 +1466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1421,7 +1506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1436,7 +1521,7 @@
        "DeviceArray(5., dtype=float32)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1475,7 +1560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1489,8 +1574,9 @@
      "output_type": "stream",
      "text": [
       "[4. 4. 4. 4. 4.]\n",
-      "Exception Shapes must be 1D sequences of concrete values of integer type, got (Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>,).\n",
-      "If using `jit`, try using `static_argnums` or applying `jit` to smaller subfunctions.\n",
+      "Exception The numpy.ndarray conversion method __array__() was called on the JAX Tracer object Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>\n",
+      "While tracing the function example_fun at /var/folders/b_/mrq467b11bv_32fb0lz46bgm0000gp/T/ipykernel_41326/1262266785.py:1 for jit, this concrete value was not available in Python because it depends on the value of the argument 'length'.\n",
+      "See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerArrayConversionError\n",
       "[4. 4. 4. 4. 4. 4. 4. 4. 4. 4.]\n",
       "[4. 4. 4. 4. 4.]\n"
      ]
@@ -1529,7 +1615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1552,7 +1638,7 @@
        "DeviceArray(4, dtype=int32, weak_type=True)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1603,7 +1689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1618,7 +1704,7 @@
        "DeviceArray([-1.], dtype=float32)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1653,7 +1739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1668,7 +1754,7 @@
        "DeviceArray(10, dtype=int32, weak_type=True)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1700,7 +1786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1715,7 +1801,7 @@
        "DeviceArray(45, dtype=int32, weak_type=True)"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1940,7 +2026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1955,7 +2041,7 @@
        "dtype('float32')"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2008,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -2023,7 +2109,7 @@
        "dtype('float32')"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2084,11 +2170,14 @@
    "provenance": [],
    "toc_visible": true
   },
+  "interpreter": {
+   "hash": "d3bf4fb4f9656a45b16060793b51495e1c58482f0f5b6f2fc66c6aaa1dd2c734"
+  },
   "jupytext": {
    "formats": "ipynb,md:myst"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.12 ('.venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -2102,7 +2191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #10662 
I extended "JAX - The Sharp Bits" a bit by a few cells to show where `jnp.array(...)` and `jnp.array(np.array(...))` differ and when it is appropriate to use the latter.