### PR TITLE
snapshot the threefry PRNG implementation

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -651,9 +651,12 @@ enable_custom_prng = config.define_bool_state(
     help=('Enables an internal upgrade that allows one to define custom '
           'pseudo-random number generator implementations.'))
 
+prng_impl_names = [
+    'threefry2x32', 'rbg', 'unsafe_rbg', 'threefry2x32@v0.3.13']
+
 default_prng_impl = config.define_enum_state(
     name='jax_default_prng_impl',
-    enum_values=['threefry2x32', 'rbg', 'unsafe_rbg'],
+    enum_values=prng_impl_names,
     default='threefry2x32',
     help=('Select the default PRNG implementation, used when one is not '
           'explicitly provided at seeding time.'))

--- a/jax/_src/prng_snapshots/__init__.py
+++ b/jax/_src/prng_snapshots/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Upcoming changes to the threefry RNG will affect the bits generated by a given key. We might consider this a breaking change, so snapshot the current RNG implementation and add a flag for using it.

Along the way, generalize the reference test for generated bits.