### PR TITLE
Add an undocumented method on jit() functions to clear the function c…

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -193,15 +193,15 @@ def _xla_call_impl(fun: lu.WrappedFun, *args, device, backend, name,
                    donated_invars, inline, keep_unused: bool):
   del inline  # Only used at tracing time
   arg_specs = unsafe_map(arg_spec, args)
-  compiled_fun = _xla_callable(fun, device, backend, name, donated_invars,
-                               keep_unused, *arg_specs)
+  compiled_fun = xla_callable(fun, device, backend, name, donated_invars,
+                              keep_unused, *arg_specs)
   try:
     return compiled_fun(*args)
   except FloatingPointError:
     assert config.jax_debug_nans or config.jax_debug_infs  # compiled_fun can only raise in this case
     print("Invalid value encountered in the output of a jit-decorated function. "
           "Calling the de-optimized version.")
-    # We want to run the wrapped function again (after _xla_callable already ran
+    # We want to run the wrapped function again (after xla_callable already ran
     # it), but linear_util.WrappedFun instances are meant to be run only once.
     # In addition to re-executing the Python code, which is usually undesirable
     # but which config.jax_debug_nans is meant to opt into, we'll be
@@ -245,7 +245,7 @@ def _xla_callable_uncached(fun: lu.WrappedFun, device, backend, name,
   return lower_xla_callable(fun, device, backend, name, donated_invars, False,
                             keep_unused, *arg_specs).compile().unsafe_call
 
-_xla_callable = lu.cache(_xla_callable_uncached)
+xla_callable = lu.cache(_xla_callable_uncached)
 
 
 @contextlib.contextmanager

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -296,8 +296,12 @@ def cache(call: Callable):
       thread_local.most_recent_entry = None
       return result
 
+  def _evict_function(f):
+    fun_caches.pop(f, None)
+
   memoized_fun.most_recent_entry = _most_recent_entry  # type: ignore
   memoized_fun.cache_clear = fun_caches.clear  # type: ignore
+  memoized_fun.evict_function = _evict_function  # type: ignore
 
   return memoized_fun
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -457,6 +457,19 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     python_should_be_executing = False
     self.jit(f)(3)
 
+  def test_jit_cache_clear(self):
+    @self.jit
+    def f(x, y): return x + y
+
+    client = jax.devices()[0].client
+    num_live_initial = len(client.live_executables())
+    f(1, 2).block_until_ready()
+    num_live = len(client.live_executables())
+    self.assertEqual(num_live_initial + 1, num_live)
+    f.clear_cache()
+    num_live = len(client.live_executables())
+    self.assertEqual(num_live_initial, num_live)
+
   def test_jit_shallow_copy(self):
     def f(x):
       return copy.copy(x)


### PR DESCRIPTION
…ache.

Some users were trying to use the internal method `f._cache_clear()` to clear the function cache associated with a `jit`. Unfortunately that method only clears the C++ cache, whereas to actually evict functions one must clear a Python-level cache as well. Add a new `f.clear_cache()` method that clears both caches.

Fixes https://github.com/google/jax/issues/10878

Somewhat related to issue https://github.com/google/jax/issues/10828 as well.
