### PR TITLE
Add max step size argument to odeint

### DIFF
--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -157,7 +157,7 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf, dtmax=j
     rtol: float, relative local error tolerance for solver (optional).
     atol: float, absolute local error tolerance for solver (optional).
     mxstep: int, maximum number of steps to take for each timepoint (optional).
-    dtmax: float, upper bound solver step size (optional).
+    dtmax: float, upper bound on solver step size (optional).
 
   Returns:
     Values of the solution `y` (i.e. integrated system values) at each time

--- a/jax/experimental/ode.py
+++ b/jax/experimental/ode.py
@@ -142,7 +142,7 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0,
                       jnp.maximum(mean_error_ratio**(-1.0 / order) * safety, dfactor))
   return jnp.where(mean_error_ratio == 0, last_step * ifactor, last_step * factor)
 
-def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
+def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf, dtmax=jnp.inf):
   """Adaptive stepsize (Dormand-Prince) Runge-Kutta odeint implementation.
 
   Args:
@@ -157,6 +157,7 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
     rtol: float, relative local error tolerance for solver (optional).
     atol: float, absolute local error tolerance for solver (optional).
     mxstep: int, maximum number of steps to take for each timepoint (optional).
+    dtmax: float, upper bound solver step size (optional).
 
   Returns:
     Values of the solution `y` (i.e. integrated system values) at each time
@@ -171,17 +172,17 @@ def odeint(func, y0, t, *args, rtol=1.4e-8, atol=1.4e-8, mxstep=jnp.inf):
     raise TypeError(f"t must be an array of floats, but got {t}.")
 
   converted, consts = custom_derivatives.closure_convert(func, y0, t[0], *args)
-  return _odeint_wrapper(converted, rtol, atol, mxstep, y0, t, *args, *consts)
+  return _odeint_wrapper(converted, rtol, atol, mxstep, dtmax, y0, t, *args, *consts)
 
 @partial(jax.jit, static_argnums=(0, 1, 2, 3))
-def _odeint_wrapper(func, rtol, atol, mxstep, y0, ts, *args):
+def _odeint_wrapper(func, rtol, atol, mxstep, dtmax, y0, ts, *args):
   y0, unravel = ravel_pytree(y0)
   func = ravel_first_arg(func, unravel)
-  out = _odeint(func, rtol, atol, mxstep, y0, ts, *args)
+  out = _odeint(func, rtol, atol, mxstep, dtmax, y0, ts, *args)
   return jax.vmap(unravel)(out)
 
 @partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3))
-def _odeint(func, rtol, atol, mxstep, y0, ts, *args):
+def _odeint(func, rtol, atol, mxstep, dtmax, y0, ts, *args):
   func_ = lambda y, t: func(y, t, *args)
 
   def scan_fun(carry, target_t):
@@ -196,7 +197,7 @@ def _odeint(func, rtol, atol, mxstep, y0, ts, *args):
       next_t = t + dt
       error_ratio = mean_error_ratio(next_y_error, rtol, atol, y, next_y)
       new_interp_coeff = interp_fit_dopri(y, next_y, k, dt)
-      dt = optimal_step_size(dt, error_ratio)
+      dt = jnp.clip(optimal_step_size(dt, error_ratio), a_min=0., a_max=dtmax)
 
       new = [i + 1, next_y, next_f, next_t, dt,      t, new_interp_coeff]
       old = [i + 1,      y,      f,      t, dt, last_t,     interp_coeff]
@@ -209,7 +210,7 @@ def _odeint(func, rtol, atol, mxstep, y0, ts, *args):
     return carry, y_target
 
   f0 = func_(y0, ts[0])
-  dt = initial_step_size(func_, ts[0], y0, 4, rtol, atol, f0)
+  dt = jnp.clip(initial_step_size(func_, ts[0], y0, 4, rtol, atol, f0), a_min=0., a_max=dtmax)
   interp_coeff = jnp.array([y0] * 5)
   init_carry = [y0, f0, ts[0], dt, ts[0], interp_coeff]
   _, ys = lax.scan(scan_fun, init_carry, ts[1:])

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -251,7 +251,7 @@ class ODETest(jtu.JaxTestCase):
     jtu.check_grads(f, (y0, ts, alpha), modes=["rev"], order=2, atol=tol, rtol=tol)
 
   @jtu.skip_on_devices("tpu", "gpu")
-  def test_dtmax(self):
+  def test_hmax(self):
     """Test max step size control."""
 
     def rhs(y, t):
@@ -260,7 +260,7 @@ class ODETest(jtu.JaxTestCase):
         [t <= 2., (t >= 5.) & (t <= 7.)],
         [lambda s: jnp.array(1.), lambda s: jnp.array(-1.), lambda s: jnp.array(0.)]
       )
-    ys = odeint(func=rhs, y0=jnp.array(0.), t=jnp.array([0., 5., 10.]), dtmax=1.)
+    ys = odeint(func=rhs, y0=jnp.array(0.), t=jnp.array([0., 5., 10.]), hmax=1.)
 
     self.assertTrue(jnp.abs(ys[1] - 2.) < 1e-4)
     self.assertTrue(jnp.abs(ys[2]) < 1e-4)

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -250,6 +250,20 @@ class ODETest(jtu.JaxTestCase):
 
     jtu.check_grads(f, (y0, ts, alpha), modes=["rev"], order=2, atol=tol, rtol=tol)
 
+  @jtu.skip_on_devices("tpu", "gpu")
+  def test_max_dt(self):
+    """Test max step size control."""
+
+    def rhs(y, t):
+      return jnp.piecewise(
+        t,
+        [t <= 2., (t >= 5.) & (t <= 7.)],
+        [lambda s: jnp.array(1.), lambda s: jnp.array(-1.), lambda s: jnp.array(0.)]
+      )
+    ys = odeint(func=rhs, y0=jnp.array(0.), t=jnp.array([0., 5., 10.]), dtmax=1.)
+
+    self.assertTrue(jnp.abs(ys[-1]) < 1e-4)
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/ode_test.py
+++ b/tests/ode_test.py
@@ -251,7 +251,7 @@ class ODETest(jtu.JaxTestCase):
     jtu.check_grads(f, (y0, ts, alpha), modes=["rev"], order=2, atol=tol, rtol=tol)
 
   @jtu.skip_on_devices("tpu", "gpu")
-  def test_max_dt(self):
+  def test_dtmax(self):
     """Test max step size control."""
 
     def rhs(y, t):
@@ -262,7 +262,8 @@ class ODETest(jtu.JaxTestCase):
       )
     ys = odeint(func=rhs, y0=jnp.array(0.), t=jnp.array([0., 5., 10.]), dtmax=1.)
 
-    self.assertTrue(jnp.abs(ys[-1]) < 1e-4)
+    self.assertTrue(jnp.abs(ys[1] - 2.) < 1e-4)
+    self.assertTrue(jnp.abs(ys[2]) < 1e-4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #10922

Adds argument `hmax` to `odeint` allowing the user to control the maximum step size that the solver takes. Implemented by calling `jnp.clip(x, a_min=0., a_max=hmax)` at each point where a step size `x` is computed. Argument defaults to `jnp.inf`. This argument is set as `static` and `nondiff` argnums in appropriate places.

Also adds a test case that fails if `hmax=jnp.inf` (i.e. under existing behaviour), but passes if `hmax=1.`. The test case is explained in #10922 : it is set up so that the `rhs` is `0.` for long enough that the step size grows so large that it "steps over" a period of time in which the `rhs != 0`. Setting `hmax = 1.` (chosen based on the details of the ODE) prevents the solver step size from growing arbitrarily large, allowing the user to avoid this problematic behaviour.

The argument name choice `hmax` is taken from the corresponding argument of [odeint in scipy](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.odeint.html). If the reviewer thinks it makes sense, we could also implement `h0` (initial step size) and `hmin` (forced minimum step size) in this PR, which would be very similar changes.