### PR TITLE
Fix zoom state for next iteration in line search

### DIFF
--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -141,8 +141,8 @@ def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
 
     hi_to_j = wolfe_one(a_j, phi_j) | (phi_j >= state.phi_lo)
     star_to_j = wolfe_two(dphi_j) & (~hi_to_j)
-    hi_to_lo = (dphi_j * (state.a_hi - state.a_lo) >= 0.) & (~hi_to_j) & (~star_to_j)
     lo_to_j = (~hi_to_j) & (~star_to_j)
+    hi_to_old_lo = lo_to_j & (dphi_j * (state.a_hi - state.a_lo) >= 0.)
 
     state = state._replace(
         **_binary_replace(
@@ -172,19 +172,9 @@ def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
             )
         ),
     )
-    state = state._replace(
-        **_binary_replace(
-            hi_to_lo,
-            state._asdict(),
-            dict(
-                a_hi=state.a_lo,
-                phi_hi=state.phi_lo,
-                dphi_hi=state.dphi_lo,
-                a_rec=state.a_hi,
-                phi_rec=state.phi_hi,
-            ),
-        ),
-    )
+    old_a_lo = state.a_lo
+    old_phi_lo = state.phi_lo
+    old_dphi_lo = state.dphi_lo
     state = state._replace(
         **_binary_replace(
             lo_to_j,
@@ -195,6 +185,19 @@ def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
                 dphi_lo=dphi_j,
                 a_rec=state.a_lo,
                 phi_rec=state.phi_lo,
+            ),
+        ),
+    )
+    state = state._replace(
+        **_binary_replace(
+            hi_to_old_lo,
+            state._asdict(),
+            dict(
+                a_hi=old_a_lo,
+                phi_hi=old_phi_lo,
+                dphi_hi=old_dphi_lo,
+                a_rec=state.a_hi,
+                phi_rec=state.phi_hi,
             ),
         ),
     )


### PR DESCRIPTION
If both variables _lo_to_j_ and _hi_to_lo_ are _True_, the state variables ending in __hi_ and __rec_ each have the same values (_a_hi=a_rec_, _phi_hi=phi_rec_) after the state is updated. Also, the information is lost at the old point _hi_ (_a_hi, phi_hi, dphi_hi)_. Since two points are identical, this causes issues with a possible cubic approximation in the next iteration (to few different conditions).

Changes have been made to correctly update the state for the next zoom iteration and to store all available information for quadratic and cubic minimization.