### PR TITLE
[x64] make scipy_stats_test.py compatible with strict dtype promotion

### DIFF
--- a/jax/_src/scipy/stats/multivariate_normal.py
+++ b/jax/_src/scipy/stats/multivariate_normal.py
@@ -32,13 +32,13 @@ def logpdf(x, mean, cov, allow_singular=None):
   x, mean, cov = _promote_dtypes_inexact(x, mean, cov)
   if not mean.shape:
     return (-1/2 * jnp.square(x - mean) / cov
-            - 1/2 * (np.log(2*np.pi) + jnp.log(cov)))
+            - 1/2 * (jnp.log(2*np.pi) + jnp.log(cov)))
   else:
     n = mean.shape[-1]
     if not np.shape(cov):
       y = x - mean
       return (-1/2 * jnp.einsum('...i,...i->...', y, y) / cov
-              - n/2 * (np.log(2*np.pi) + jnp.log(cov)))
+              - n/2 * (jnp.log(2*np.pi) + jnp.log(cov)))
     else:
       if cov.ndim < 2 or cov.shape[-2:] != (n, n):
         raise ValueError("multivariate_normal.logpdf got incompatible shapes")
@@ -47,7 +47,7 @@ def logpdf(x, mean, cov, allow_singular=None):
         partial(lax.linalg.triangular_solve, lower=True, transpose_a=True),
         signature="(n,n),(n)->(n)"
       )(L, x - mean)
-      return (-1/2 * jnp.einsum('...i,...i->...', y, y) - n/2*np.log(2*np.pi)
+      return (-1/2 * jnp.einsum('...i,...i->...', y, y) - n/2 * jnp.log(2*np.pi)
               - jnp.log(L.diagonal(axis1=-1, axis2=-2)).sum(-1))
 
 @_wraps(osp_stats.multivariate_normal.pdf, update_doc=False)


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10840.