### PR TITLE
Add tree_labels, tree_print.

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -584,7 +584,7 @@ def tree_labels(td, leaves):
     elif isinstance(node_data, dict):
       labels = node_data.keys
 
-    # TODO: (awf) Remove 'if TYPE_CHECKING' above, and use pytree.PyTreeDef? 
+    # TODO: (awf) Remove 'if TYPE_CHECKING' above, and use pytree.PyTreeDef?
     elif isinstance(node_data, xla_extension.PyTreeDef):
       if node_data.children() == [] and node_data.num_nodes == 1  and node_data.num_leaves == 1:
         # Pass through to the single leaf
@@ -619,11 +619,11 @@ def tree_labels(td, leaves):
 
 def tree_print(obj, prefix=''):
   """Print tree of OBJ, one line per leaf, with path-like labels.
-  
+
   Args:
     obj: Object to print, assumed to be jax.tree_* compatible.
     prefix: a string to print in front of each path.
-  
+
   Example:
     >>> foo = [3, ATuple(foo=(3, ATuple(foo=3, bar=None)), bar={'baz': 34})]
     >>> tree_print(foo, 'foo/')

--- a/jax/tree_util.py
+++ b/jax/tree_util.py
@@ -52,6 +52,8 @@ from jax._src.tree_util import (
   tree_structure as tree_structure,
   tree_transpose as tree_transpose,
   tree_unflatten as tree_unflatten,
+  tree_labels as tree_labels,
+  tree_print as tree_print,
   treedef_children as treedef_children,
   treedef_is_leaf as treedef_is_leaf,
   treedef_tuple as treedef_tuple,

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -555,9 +555,9 @@ class PyTreeWalkTest(jtu.JaxTestCase):
     x.x2 = {'x21': '2a', 'x22': y}
 
     obj = {'a1': 'leaf-a1',
-           'a2':{'b1': [111,2,3], 
-                 'b2': jnp.ones((2,3)), 
-                 'b3': {'c1': 33, 
+           'a2':{'b1': [111,2,3],
+                 'b2': jnp.ones((2,3)),
+                 'b3': {'c1': 33,
                         'c2': (44,55)}},
            'a3': x,
            'a4':'fred'}
@@ -568,9 +568,9 @@ class PyTreeWalkTest(jtu.JaxTestCase):
     self.assertEqual(out, len(leaves))
 
     out = td.walk(lambda n,node_data:n, lambda x:3, leaves)
-    expect = (3, 
-              ((3, 3, 3), 3, (3, (3, 3))), 
-              ((3, ((3, 3),), 3), (3, ((3, 3),))), 
+    expect = (3,
+              ((3, 3, 3), 3, (3, (3, 3))),
+              ((3, ((3, 3),), 3), (3, ((3, 3),))),
               3)
     self.assertEqual(out, expect)
 
@@ -579,7 +579,7 @@ class PyTreeWalkTest(jtu.JaxTestCase):
 
     for i,tree in enumerate(TREES):
       print(f'TREES[{i}]: ', tree[0])
-      tree_util.tree_print(tree[0], f'  foo/')
+      tree_util.tree_print(tree[0], '  foo/')
 
   @parameterized.parameters(*TREES)
   def testPrintedAllLeaves(self, obj):
@@ -591,7 +591,7 @@ class PyTreeWalkTest(jtu.JaxTestCase):
       leaves_printed = [x for x in leaves_printed if x != ()]
       # Ensure all leaves were printed, in the correct order
       assert leaves_printed == leaf_indices
-          
+
 
 
 if __name__ == "__main__":

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -16,7 +16,6 @@ import collections
 import functools
 import re
 import types
-import pprint
 
 import unittest
 
@@ -575,11 +574,11 @@ class PyTreeWalkTest(jtu.JaxTestCase):
               3)
     self.assertEqual(out, expect)
 
+    print('\nobj', obj)
     tree_util.tree_print(obj, 'obj/')
 
     for i,tree in enumerate(TREES):
-      print(f'TREES[{i}]: ', end='')
-      pprint.pp(tree[0])
+      print(f'TREES[{i}]: ', tree[0])
       tree_util.tree_print(tree[0], f'  foo/')
 
   @parameterized.parameters(*TREES)

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -15,6 +15,9 @@
 import collections
 import functools
 import re
+import types
+import pprint
+
 import unittest
 
 from absl.testing import absltest
@@ -128,8 +131,8 @@ TREES = (
                              [("foo", 34), ("baz", 101), ("something", -42)]),),
     (ANamedTupleSubclass(foo="hello", bar=3.5),),
     (FlatCache(None),),
-    (FlatCache(1),),
-    (FlatCache({"a": [1, 2]}),),
+    (FlatCache(111),),
+    (FlatCache({"a": [111, 112]}),),
 )
 
 
@@ -527,6 +530,69 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
 
   def test_no_errors(self):
     () = prefix_errors((1, 2), ((11, 12, 13), 2))
+
+class SNWrap(types.SimpleNamespace):
+  def __init__(self, **kwargs):
+    super().__init__(**kwargs)
+
+def SNWrap_tree_flatten(x : SNWrap):
+  return pytree.flatten(x.__dict__, lambda a: a is not x.__dict__)
+
+def SNWrap_tree_unflatten(aux, values):
+  return SNWrap(**pytree.unflatten(aux, values))
+
+tree_util.register_pytree_node(SNWrap, SNWrap_tree_flatten, SNWrap_tree_unflatten)
+
+@unittest.skipIf(jax._src.lib.xla_extension_version < 75,
+                 "Test requires jaxlib newer than 0.3.12") # TODO(awf): How to relate xla_extension_version to jaxlib version?
+class PyTreeWalkTest(jtu.JaxTestCase):
+
+  def testWalk(self):
+    y = SNWrap()
+    y.y1 = {'y11': 'ya', 'y12': 'yb'}
+
+    x = SNWrap()
+    x.x1 = {'x11': 'a', 'x12': y, 'x13':'b'}
+    x.x2 = {'x21': '2a', 'x22': y}
+
+    obj = {'a1': 'leaf-a1',
+           'a2':{'b1': [111,2,3], 
+                 'b2': jnp.ones((2,3)), 
+                 'b3': {'c1': 33, 
+                        'c2': (44,55)}},
+           'a3': x,
+           'a4':'fred'}
+
+    leaves,td = pytree.flatten(obj)
+
+    out = td.walk(lambda n,node_data:sum(n), lambda x:1, leaves)
+    self.assertEqual(out, len(leaves))
+
+    out = td.walk(lambda n,node_data:n, lambda x:3, leaves)
+    expect = (3, 
+              ((3, 3, 3), 3, (3, (3, 3))), 
+              ((3, ((3, 3),), 3), (3, ((3, 3),))), 
+              3)
+    self.assertEqual(out, expect)
+
+    tree_util.tree_print(obj, 'obj/')
+
+    for i,tree in enumerate(TREES):
+      print(f'TREES[{i}]: ', end='')
+      pprint.pp(tree[0])
+      tree_util.tree_print(tree[0], f'  foo/')
+
+  @parameterized.parameters(*TREES)
+  def testPrintedAllLeaves(self, obj):
+      leaves,td = pytree.flatten(obj)
+      leaf_indices = list(range(len(leaves)))
+      leaves_printed = [leaf for label,leaf in
+                        tree_util.tree_labels(td, leaf_indices)]
+      # Strip nulls, which are printed, but filtered from leaves
+      leaves_printed = [x for x in leaves_printed if x != ()]
+      # Ensure all leaves were printed, in the correct order
+      assert leaves_printed == leaf_indices
+          
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR follows from https://github.com/tensorflow/tensorflow/pull/56202, where the pytree walk function has been extended to pass node_data to walkers.  For example, this allows implementation of custom printers (see https://github.com/google/jax/issues/5047), which can e.g. print a tree with path labels like:

```
obj/a1 = leaf-a1
obj/a2/b1/0 = 111
obj/a2/b1/1 = 2
obj/a2/b1/2 = 3
obj/a2/b2 = [[11. 12. 13.]; [21. 22. 23.]]
obj/a2/b3/c1 = 33
obj/a2/b3/c2/0 = 44
obj/a2/b3/c2/1 = 55
obj/a3/x1/x11 = a
obj/a3/x1/x12/y1/y11 = ya
obj/a3/x1/x12/y1/y12 = yb
obj/a3/x1/x13 = b
obj/a3/x2/x21 = 2a
obj/a3/x2/x22/y1/y11 = ya
obj/a3/x2/x22/y1/y12 = yb
obj/a4 = fred
```