### PR TITLE
[dynamic-shapes] initial support for dynamic shape typechecks

### DIFF
--- a/jax/_src/custom_transpose.py
+++ b/jax/_src/custom_transpose.py
@@ -179,8 +179,9 @@ class CustomTransposePrimitive(core.Primitive):
 
 
 # TODO(frostig,mattjj): reinstate checks
-def custom_transpose_typecheck(*avals, **params):
-  return None, core.no_effects
+def custom_transpose_typecheck(*in_atoms, out_types, **params):
+  del in_atoms, params
+  return out_types, core.no_effects
 
 
 def custom_transpose_transpose_rule(

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -734,8 +734,6 @@ def broadcast_in_dim(operand: Array, shape: Shape,
   See Also:
     jax.lax.broadcast : simpler interface to add new leading dimensions.
   """
-  shape = _broadcast_in_dim_shape_rule(
-    operand, shape=shape, broadcast_dimensions=broadcast_dimensions)
   if (np.ndim(operand) == len(shape) and not len(broadcast_dimensions)
       and isinstance(operand, (device_array.DeviceArray, core.Tracer))):
     return operand
@@ -2638,6 +2636,22 @@ def _broadcast_in_dim_shape_rule(operand, *, shape, broadcast_dimensions):
 
   return shape
 
+def _broadcast_in_dim_typecheck_rule(
+    operand, *dyn_shape, shape, broadcast_dimensions):
+  if not dyn_shape:
+    out_aval, effects = broadcast_in_dim_p.abstract_eval(
+        operand.aval, shape=shape, broadcast_dimensions=broadcast_dimensions)
+    return [out_aval], effects
+  else:
+    # TODO(mattjj): perform more checks like _broadcast_in_dim_shape_rule
+    dyn_shape_ = iter(dyn_shape)
+    out_shape = [next(dyn_shape_) if d is None else d for d in shape]
+    assert next(dyn_shape_, None) is None
+    out_shape = [x.val if type(x) is core.Literal else x for x in out_shape]
+    out_aval = core.DShapedArray(tuple(out_shape), operand.aval.dtype,
+                                 operand.aval.weak_type)
+    return [out_aval], core.no_effects
+
 def _broadcast_in_dim_transpose_rule(ct, operand, *, shape, broadcast_dimensions):
   shape_in = operand.aval.shape
   unit_dimensions = tuple(i for i, s in enumerate(shape_in) if core.symbolic_equal_dim(s,  1))
@@ -2706,6 +2720,7 @@ batching.primitive_batchers[broadcast_in_dim_p] = _broadcast_in_dim_batch_rule
 pe.forwarding_rules[broadcast_in_dim_p] = _broadcast_in_dim_fwd_rule
 pe.custom_staging_rules[broadcast_in_dim_p] = _broadcast_in_dim_staging_rule
 pe.padding_rules[broadcast_in_dim_p] = _broadcast_in_dim_padding_rule
+core.custom_typechecks[broadcast_in_dim_p] = _broadcast_in_dim_typecheck_rule
 
 def _broadcast_in_dim_lower(ctx, x, *dyn_shape, shape, broadcast_dimensions):
   aval_out, = ctx.avals_out

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -2060,6 +2060,7 @@ def _dynamic_slice_indices(operand, start_indices: Any):
           for i, d in zip(start_indices, operand.shape)]
 
 
+# TODO(mattjj): getslice is a prototype for dynamic shapes, revise or remove it
 def _getslice(x, lo, hi):
   return getslice_p.bind(x, lo, hi)
 

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -929,10 +929,11 @@ ad.primitive_transposes[xmap_p] = _xmap_transpose
 
 
 def _typecheck_xmap(
-    *in_avals, call_jaxpr, name, in_axes, out_axes, donated_invars,
+    *in_atoms, call_jaxpr, name, in_axes, out_axes, donated_invars,
     global_axis_sizes, axis_resources, resource_env, backend,
     spmd_in_axes, spmd_out_axes, in_positional_semantics,
     out_positional_semantics):
+  in_avals = [x.aval for x in in_atoms]
   axis_resource_count = _get_axis_resource_count(
       axis_resources, resource_env, in_positional_semantics)
   local_axis_sizes = {
@@ -946,11 +947,8 @@ def _typecheck_xmap(
       raise core.JaxprTypeError(
         f"xmap passes operand {in_aval} to jaxpr expecting {binder_in_aval}")
 
-  mapped_in_avals = [_delete_aval_axes(a, a_in_axes, global_axis_sizes)
-                     for a, a_in_axes in zip(in_avals, in_axes)]
   with core.extend_axis_env_nd(global_axis_sizes.items()):
-    core._check_jaxpr(lambda: core.JaxprPpContext(), call_jaxpr,
-                      mapped_in_avals)
+    core._check_jaxpr(lambda: core.JaxprPpContext(), call_jaxpr)
 
   mapped_out_avals = [v.aval for v in call_jaxpr.outvars]
   out_avals = [_insert_aval_axes(a, a_out_axes, local_axis_sizes)

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -29,7 +29,7 @@ from jax import lax
 from jax import numpy as jnp
 from jax import linear_util as lu
 from jax import jvp, linearize, vjp, jit, make_jaxpr
-from jax.core import UnshapedArray, ShapedArray
+from jax.core import UnshapedArray, ShapedArray, DBIdx
 from jax.tree_util import (tree_flatten, tree_unflatten, tree_map, tree_reduce,
                            tree_leaves)
 from jax.api_util import flatten_fun_nokwargs
@@ -374,6 +374,7 @@ class CoreTest(jtu.JaxTestCase):
     self.assertEqual(dropvar.aval, aval)
 
 
+@jtu.with_config(jax_pprint_use_color=False)
 class JaxprTypeChecks(jtu.JaxTestCase):
 
   def setUp(self):
@@ -462,8 +463,8 @@ class JaxprTypeChecks(jtu.JaxTestCase):
     jaxpr.eqns[0].outvars[0].aval = make_shaped_array(jnp.int32(2))
     self.assertRaisesRegex(
         core.JaxprTypeError,
-        r"Variable 'b' inconsistently typed as f32\[\], "
-        r"bound as i32\[\]\n\nin equation:\n\nb:i32\[\] = sin a",
+        r"Value for variable 'b' inconsistently typed as f32\[\] "
+        r"for let-binder of type i32\[\]\n\nin equation:\n\nb:i32\[\] = sin a",
         lambda: core.check_jaxpr(jaxpr))
 
     jaxpr = new_jaxpr()
@@ -471,8 +472,8 @@ class JaxprTypeChecks(jtu.JaxTestCase):
       np.ones((2, 3), dtype=jnp.float32))
     self.assertRaisesRegex(
         core.JaxprTypeError,
-        r"Variable 'b' inconsistently typed as f32\[\], "
-        r"bound as f32\[2,3\]\n\nin equation:\n\nb:f32\[2,3\] = sin a",
+        r"Value for variable 'b' inconsistently typed as f32\[\] "
+        r"for let-binder of type f32\[2,3\]\n\nin equation:\n\nb:f32\[2,3\] = sin a",
         lambda: core.check_jaxpr(jaxpr))
 
   def test_jaxpr_dropvar_from_jit_call(self):
@@ -560,8 +561,8 @@ class DynamicShapesTest(jtu.JaxTestCase):
 
   def test_staging_basic(self):
     n = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
-    a = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
-    b = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    a = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    b = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
 
     @lu.wrap_init
     def f(x, y):
@@ -579,9 +580,9 @@ class DynamicShapesTest(jtu.JaxTestCase):
     self.assertEqual((jaxpr.invars[0],), jaxpr.outvars[1].aval.shape)
 
   def test_staging_nested(self):
-    n = core.DShapedArray((), jnp.dtype('int32'), weak_type=False)
-    a = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
-    b = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    n = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
+    a = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    b = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
 
     @lu.wrap_init
     def f(x, y):
@@ -614,9 +615,9 @@ class DynamicShapesTest(jtu.JaxTestCase):
     self.assertEqual((inner_jaxpr.invars[0],), inner_jaxpr.invars[4].aval.shape)
 
   def test_staging_nested_including_shape_arg(self):
-    n = core.DShapedArray((), jnp.dtype('int32'), weak_type=False)
-    a = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
-    b = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    n = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
+    a = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    b = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
 
     @lu.wrap_init
     def f(x, y):
@@ -627,7 +628,6 @@ class DynamicShapesTest(jtu.JaxTestCase):
 
     jaxpr, _, _ = pe.trace_to_jaxpr_dynamic(
       f, [n, a, b], keep_inputs=[False, True, True])
-    print(jaxpr)
 
     # { lambda ; a:i32[] b:f32[a] c:f32[a]. let
     #     d:f32[a] e:f32[a] = xla_call[
@@ -651,9 +651,9 @@ class DynamicShapesTest(jtu.JaxTestCase):
     self.assertEqual((inner_jaxpr.invars[0],), inner_jaxpr.invars[4].aval.shape)
 
   def test_staging_primitive_applications(self):
-    n = core.DShapedArray((), jnp.dtype('int32'), weak_type=False)
-    a = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
-    b = core.DShapedArray((pe.DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    n = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
+    a = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    b = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
 
     @lu.wrap_init
     def f(x, y):
@@ -673,6 +673,57 @@ class DynamicShapesTest(jtu.JaxTestCase):
 
     self.assertLen(jaxpr.outvars, 1)
     self.assertEqual(jaxpr.outvars[0].aval.shape, ())
+
+  def test_typecheck_staging_nested(self):
+    n = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
+    m = core.ShapedArray((), jnp.dtype('int32'), weak_type=False)
+    a = core.DShapedArray((DBIdx(0),), jnp.dtype('float32'), weak_type=False)
+    b = core.DShapedArray((DBIdx(1),), jnp.dtype('float32'), weak_type=False)
+
+    @lu.wrap_init
+    def f(a, b):
+      @jax.jit
+      def g(x): return x
+      return g(a),
+
+    jaxpr, _, _ = pe.trace_to_jaxpr_dynamic(
+      f, [n, m, a, b], keep_inputs=[False, False, True, True])
+    # { lambda ; a:i32[] b:i32[] c:f32[a] d:f32[b]. let
+    #     e:f32[a] = xla_call[
+    #       call_jaxpr={ lambda ; f:i32[] g:f32[f]. let  in (g,) }
+    #       name=g
+    #     ] a c
+    #   in (e,) }
+    core.check_jaxpr(jaxpr)  # no problems here...
+
+    # Let's introduce a type error by applying the called jaxpr to arguments
+    # with types which aren't consistent with its input binders:
+    _, _, c, d = jaxpr.invars
+    jaxpr.eqns[0].invars[1] = d
+    # { lambda ; a:i32[] b:i32[] c:f32[a] d:f32[b]. let
+    #     e:f32[a] = xla_call[
+    #       call_jaxpr={ lambda ; f:i32[] g:f32[f]. let  in (g,) }
+    #       name=g
+    #     ] a d   !!! type error here !!!
+    #   in (e,) }
+    with self.assertRaisesRegex(TypeError, "passes operand"):
+      core.check_jaxpr(jaxpr)
+
+    # Restore the original jaxpr:
+    jaxpr.eqns[0].invars[1] = c
+    core.check_jaxpr(jaxpr)  # no problems here...
+
+    # Let's introduce another type error by setting the call result let binders
+    # to have the wrong type:
+    jaxpr.eqns[0].outvars[0] = core.Var(0, '', d.aval)
+    # { lambda ; a:i32[] b:i32[] c:f32[a] d:f32[b]. let
+    #     e:f32[b] = xla_call[   !!! type error here !!!
+    #       call_jaxpr={ lambda ; f:i32[] g:f32[f]. let  in (g,) }
+    #       name=g
+    #     ] a c
+    #   in (h,) }
+    with self.assertRaisesRegex(TypeError, "inconsistently typed as"):
+      core.check_jaxpr(jaxpr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After this PR, jaxpr typechecking works with all existing dynamic shape tests. I was working on dynamic shape AD and realized I could make faster progress with some reliable jaxpr checks!

Summary of changes:
* Changed the logic in `_check_jaxpr` so as to check that type annotations are well-formed via the new `check_type` function (e.g. variable occurrences in types are in scope).
* Changed the logic in `_check_jaxpr` to handle dynamic shapes in inputs and outputs of primitive applications. For the input side, we change the signature of some primitive application typecheck rules to take input atoms rather than just types (see also last bullet in this list). That way we can check things like e.g. an `xla_call` application with a `call_jaxpr` with lambda binders like `n:i32[] x:f32[n]` against arguments like `3:i32[] y:f32[3]` (correct!) or `3:i32[] y:f32[4]` (error!) or `m:i32[] y:f32[k]` (error!). For the output side, we handle primitive application typechecks returning lists of abstract values in which the shapes may contain `InDBIdx` / `OutDBIdx` axis sizes (representing e.g. dependent tuples), in which case to check against the corresponding let-binder types (which have variables in them) we perform a substitution using `substitute_vars_in_output_ty`.
* Changed the signature of `_check_jaxpr` not to take as argument avals to which the jaxpr is to be applied; we check the called jaxpr's lambda-binder types are consistent with the arguments in the rule `_check_call` rather than in the recursive call to `_check_jaxpr`, which itself now just checks a jaxpr for internal consistency.
* Changed the type signature of custom typechecks to support checking calls and broadcasts, basically to something like `Primitive -> [Atom] -> Params -> OutType` where 
```
OutType = [AvalsWithInOutDBIdx]
AvalsWithInOutDBIdx = ShapedArray [AxisSizeOrDBIdx] DType
AxisSizeOrDBIdx = Lit Int | InDBIdx Int | OutDBIdx Int
```

Minor stuff:
* Moved `DBIdx`, `InDBIdx`, and `OutDBIdx` from partial_eval.py to core.py.
* Some typecheck rules returned `None` as the output type, in which case checking the type of the primitive application against the corresponding let-binders would just be skipped. This PR removes that, and adapts the typecheck rules which were returning `None` to return their correct output types.