### PR TITLE
BUG: avoid warning when specifying dtype=complex in X32 mode

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4535,7 +4535,7 @@ def _abstractify(x):
 
 def _check_user_dtype_supported(dtype, fun_name=None):
   # Avoid using `dtype in [...]` because of numpy dtype equality overloading.
-  if isinstance(dtype, type) and dtype in {bool, int, float, complex}:
+  if isinstance(dtype, type) and dtype in {bool, int, float, builtins.complex}:
     return
   np_dtype = np.dtype(dtype)
   if np_dtype.kind not in "biufc" and np_dtype.type != dtypes.bfloat16:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -2461,6 +2461,13 @@ class APITest(jtu.JaxTestCase):
     for x, y in zip(xs, ys):
       self.assertAllClose(x, y)
 
+  def test_dtype_from_builtin_types(self):
+    for dtype in [bool, int, float, complex]:
+      with warnings.catch_warnings(record=True) as caught_warnings:
+        x = jnp.array(0, dtype=dtype)
+      self.assertEmpty(caught_warnings)
+      assert x.dtype == dtypes.canonicalize_dtype(dtype)
+
   def test_dtype_warning(self):
     # cf. issue #1230
     if config.x64_enabled:


### PR DESCRIPTION
Because of a bug in `lax.py`, currently the following produces a warning when it shouldn't:
```python
>>> import jax.numpy as jnp
>>> jnp.array(1, dtype=complex)
/github/google/jax/jax/_src/numpy/lax_numpy.py:1832: UserWarning: Explicitly requested dtype <class 'complex'> requested in array is not available, and will be truncated to dtype complex64. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
  lax_internal._check_user_dtype_supported(dtype, "array")
DeviceArray(1.+0.j, dtype=complex64)
```
This PR fixes the issue and adds a test.