### PR TITLE
[ROCm] Revert unit test enablement for ROCm (from 8d9f17df19a647577357398c7a…

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1069,6 +1069,7 @@ class BCOOTest(jtu.JaxTestCase):
           [(5, 3), (5, 2), [0], [0]],
       ]
       for dtype in jtu.dtypes.floating + jtu.dtypes.complex))
+  @jtu.skip_on_devices("rocm")
   def test_bcoo_dot_general_cusparse(
     self, lhs_shape, rhs_shape, dtype, lhs_contracting, rhs_contracting):
     rng = jtu.rand_small(self.rng())


### PR DESCRIPTION
…57ceb6eb6b9f04).

/cc @hawkinsp 