### PR TITLE
Add `discharge_state` to convert stateful jaxprs into pure jaxprs

### DIFF
--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -14,13 +14,21 @@
 """Module for the `for_loop` primitive."""
 from functools import partial
 
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 from jax import core
+from jax import lax
+from jax import linear_util as lu
 from jax.interpreters import ad
+from jax.interpreters import partial_eval as pe
 from jax._src import ad_util
 from jax._src import pretty_printer as pp
+from jax._src import util
 
+## JAX utilities
+
+map, unsafe_map = util.safe_map, map
+zip, unsafe_zip = util.safe_zip, zip
 
 ## Helpful type aliases
 Ref = Any
@@ -204,11 +212,11 @@ def _swap_pp_rule(eqn, context, settings):
     # In the case of a set (ignored return value),
     # pretty print `_ = swap x v i` as `x[i] <- v`
     del y
-    return pp.concat([
+    return [
       pp_ref(pp.concat([
         pp.text(core.pp_var(x, context)),
         pp.text('['), pp.text(idx), pp.text(']')
-      ])), pp.text(' <- '), pp.text(core.pp_var(v, context))])
+      ])), pp.text(' <- '), pp.text(core.pp_var(v, context))]
   else:
     # pretty-print `y:T = swap x v i` as `y:T, x[i] <- x[i], v`
     x_i = pp.concat([pp.text(core.pp_var(x, context)),
@@ -273,3 +281,95 @@ def _swap_transpose(g, ref, x, *idx):
   x_bar = ref_swap(ref, idx, ad_util.instantiate(g))
   return [None, x_bar] + [None] * len(idx)
 ad.primitive_transposes[swap_p] = _swap_transpose
+
+
+## Discharging state
+
+# Let's say we have a jaxpr that takes in `Ref`s and outputs regular JAX values
+# (`Ref`s should never be outputs from jaxprs). We'd like to convert that jaxpr
+# into a "pure" jaxpr that takes in and outputs values and no longer has the
+# `State` effect.
+
+def discharge_state(jaxpr: core.Jaxpr, consts: Sequence[Any]) -> Tuple[core.Jaxpr, List[Any]]:
+  """Converts a jaxpr that takes in `Ref`s into one that doesn't."""
+  in_avals = [core.ShapedArray(v.aval.shape, v.aval.dtype)
+              if type(v.aval) is ShapedArrayRef
+              else v.aval for v in jaxpr.invars]
+  eval_jaxpr = lu.wrap_init(partial(_eval_jaxpr_discharge_state, jaxpr, consts))
+  new_jaxpr, _ , new_consts = pe.trace_to_jaxpr_dynamic(eval_jaxpr, in_avals)
+  return new_jaxpr, new_consts
+
+def _dynamic_index(x, idx):
+  if not idx: return x
+  ndim = len(x.shape)
+  starts = [*idx] + [lax.full_like(idx[0], 0, shape=())] * (ndim - len(idx))
+  sizes = (1,) * len(idx) + x.shape[len(idx):]
+  out = lax.dynamic_slice(x, starts, sizes)
+  return out.reshape(x.shape[len(idx):])
+
+def _dynamic_update_index(x, idx, val):
+  if not idx: return val
+  ndim = len(x.shape)
+  starts = [*idx] + [lax.full_like(idx[0], 0, shape=())] * (ndim - len(idx))
+  update = val.reshape((1,) * len(idx) + x.shape[len(idx):])
+  return lax.dynamic_update_slice(x, update, starts)
+
+def _eval_jaxpr_discharge_state(jaxpr: core.Jaxpr, consts: Sequence[Any],
+                                *args: Any):
+  env: Dict[core.Var, Any] = {}
+
+  def read(v: core.Atom) -> Any:
+    if type(v) is core.Literal:
+      return v.val
+    assert isinstance(v, core.Var)
+    return env[v]
+
+  def write(v: core.Var, val: Any) -> None:
+    env[v] = val
+
+  map(write, jaxpr.constvars, consts)
+  # Here some args may correspond to `Ref` avals but they'll be treated like
+  # regular values in this interpreter.
+  map(write, jaxpr.invars, args)
+
+  for eqn in jaxpr.eqns:
+    in_vals = map(read, eqn.invars)
+    if eqn.primitive is get_p:
+       # `y <- x[i]` becomes `y = ds x i`
+      x, *idx = in_vals
+      write(eqn.outvars[0], _dynamic_index(x, idx))
+    elif eqn.primitive is swap_p:
+      # `z, x[i] <- x[i], val` becomes:
+      #    z = ds x i
+      #    x = dus x i val
+      x, val, *idx = in_vals
+      write(eqn.outvars[0], _dynamic_index(x, idx))
+      assert isinstance(eqn.invars[0], core.Var)
+      write(eqn.invars[0], _dynamic_update_index(x, idx, val))
+    elif eqn.primitive is addupdate_p:
+      # `x[i] += val` becomes:
+      #    y = ds x ii
+      #    z = y + val
+      #    x = dus x i z
+      x, val, *idx = in_vals
+      ans = _dynamic_update_index(x, idx, val + _dynamic_index(x, idx))
+      assert isinstance(eqn.invars[0], core.Var)
+      write(eqn.invars[0], ans)
+    else:
+      # Default primitive rule, similar to `core.eval_jaxpr`. Note that here
+      # we assume any higher-order primitives inside of the jaxpr are *not*
+      # stateful.
+      # TODO(sharadmv): enable discharging state in higher order primitives
+      subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
+      ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
+      if eqn.primitive.multiple_results:
+        map(write, eqn.outvars, ans)
+      else:
+        write(eqn.outvars[0], ans)
+  # By convention, we return the outputs of the jaxpr first and then the final
+  # values of the `Ref`s. Callers to this function should be able to split
+  # them up by looking at `len(jaxpr.outvars)`.
+  out_vals = map(read, jaxpr.outvars)
+  ref_vals = map(
+      read, [v for v in jaxpr.invars if type(v.aval) is ShapedArrayRef])
+  return out_vals + ref_vals

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -359,7 +359,6 @@ def _eval_jaxpr_discharge_state(jaxpr: core.Jaxpr, consts: Sequence[Any],
       # Default primitive rule, similar to `core.eval_jaxpr`. Note that here
       # we assume any higher-order primitives inside of the jaxpr are *not*
       # stateful.
-      # TODO(sharadmv): enable discharging state in higher order primitives
       subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
       ans = eqn.primitive.bind(*subfuns, *map(read, eqn.invars), **bind_params)
       if eqn.primitive.multiple_results:

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -348,7 +348,7 @@ def _eval_jaxpr_discharge_state(jaxpr: core.Jaxpr, consts: Sequence[Any],
       write(eqn.invars[0], _dynamic_update_index(x, idx, val))
     elif eqn.primitive is addupdate_p:
       # `x[i] += val` becomes:
-      #    y = ds x ii
+      #    y = ds x i
       #    z = y + val
       #    x = dus x i z
       x, val, *idx = in_vals

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2448,17 +2448,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
 
 class ForLoopTest(jtu.JaxTestCase):
-  
-  def setUp(self):
-    super().setUp()
-    from jax.config import config
-    config.update('jax_enable_x64', True)
-
-  def tearDown(self):
-    super().tearDown()
-    from jax.config import config
-    config.update('jax_enable_x64', False)
-
+ 
   def test_cant_eval_get_primitive(self):
     with self.assertRaises(ValueError):
       for_loop.get_p.bind(jnp.ones(5))

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2448,7 +2448,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
 
 
 class ForLoopTest(jtu.JaxTestCase):
- 
+
   def test_cant_eval_get_primitive(self):
     with self.assertRaises(ValueError):
       for_loop.get_p.bind(jnp.ones(5))


### PR DESCRIPTION
Adds a method that discharges state from jaxprs.

Tracker: #10982 