### PR TITLE
[x64] make checkify compatible with strict dtype promotion

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -498,7 +498,7 @@ def gather_error_check(error, enabled_errors, operand, start_indices, *,
   upper_bound = operand_dims[np.array(dnums.start_index_map)]
   upper_bound -= np.array(slice_sizes)[np.array(dnums.start_index_map)]
   upper_bound = jnp.expand_dims(upper_bound, axis=tuple(range(num_batch_dims)))
-  in_bounds = (start_indices >= 0) & (start_indices <= upper_bound)
+  in_bounds = (start_indices >= 0) & (start_indices <= upper_bound.astype(start_indices.dtype))
 
   # Get first OOB index, axis and axis size so it can be added to the error msg.
   flat_idx = jnp.argmin(in_bounds)
@@ -544,7 +544,7 @@ def scatter_in_bounds(operand, indices, updates, dnums):
                                      (len(indices.shape) - 1,))
 
   lower_in_bounds = jnp.all(jnp.greater_equal(indices, 0))
-  upper_in_bounds = jnp.all(jnp.less_equal(indices, upper_bound))
+  upper_in_bounds = jnp.all(jnp.less_equal(indices, upper_bound.astype(indices.dtype)))
   return jnp.logical_and(lower_in_bounds, upper_in_bounds)
 
 def scatter_error_check(prim, error, enabled_errors, operand, indices, updates,

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -94,7 +94,7 @@ class CheckifyTransformTests(jtu.JaxTestCase):
       for jit in [False, True]))
   def test_jit_div_errors(self, jit):
     def f(x, y):
-      return x/y
+      return x / y
 
     f = jax.jit(f) if jit else f
     checked_f = checkify.checkify(f, errors=checkify.float_checks)
@@ -102,7 +102,7 @@ class CheckifyTransformTests(jtu.JaxTestCase):
     err, _ = checked_f(jnp.ones((3,)), jnp.ones((3,)))
     self.assertIs(err.get(), None)
 
-    err, _ = checked_f(jnp.ones((3,)), jnp.array([1, 0, 1]))
+    err, _ = checked_f(jnp.ones((3,)), jnp.array([1., 0., 1.]))
     self.assertIsNotNone(err.get())
     self.assertStartsWith(err.get(), "divided by zero")
 


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10840.