### PR TITLE
[x64] make jaxpr_effects_test pass with strict dtype promotion

### DIFF
--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -532,7 +532,7 @@ class EffectfulJaxprLoweringTest(jtu.JaxTestCase):
     @jax.pmap
     def f(x):
       effect_p.bind(effect='foo')
-      return x + 1.
+      return x + 1
     with self.assertRaisesRegex(
         ValueError,
         "Ordered effects not supported for map primitives: {'foo'}"):


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10840.