### PR TITLE
[x64] make host_callback_test compatible with strict dtype promotion

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -3409,7 +3409,7 @@ def _reducer_masking_rule(prim, identity, padded_vals, logical_shapes,
                           axes, input_shape=None, **reduce_kwargs):
   (padded_val,), (logical_shape,) = padded_vals, logical_shapes
   padded_shape = masking.padded_shape_as_value(padded_val.shape)
-  masks = [broadcasted_iota(np.int32, padded_shape, i) < d
+  masks = [broadcasted_iota(_dtype(d), padded_shape, i) < d
            for i, d in enumerate(logical_shape) if i in axes]
   mask = _reduce(operator.and_, masks)
   masked_val = select(mask, padded_val, identity(padded_shape, padded_val.dtype))

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -828,7 +828,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
   def test_tap_jit_several_together(self):
     arg = jnp.arange(50, dtype=jnp.int32).reshape((10, 5))
-    jax.jit(lambda x, y: hcb.id_print((x, y, x * 2.)))(arg, jnp.ones(100, dtype=jnp.int32))
+    jax.jit(lambda x, y: hcb.id_print((x, y, x * 2)))(arg, jnp.ones(100, dtype=jnp.int32))
 
   def test_tap_jit_interleaving(self):
     # Several jit's without data dependencies; they may interfere
@@ -1075,7 +1075,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
   def test_tap_grad_float0(self):
     def func(x, yint):
       x, yint = hcb.id_print((x, yint), what="pair", output_stream=testing_stream)
-      return x * yint
+      return x * yint.astype(x.dtype)
 
     grad_func = jax.grad(func)
 
@@ -2104,7 +2104,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
 
       return lax.scan(step, init, np.arange(2))
 
-    self.assertAllClose(tap_scalar(3., do_print=False), tap_scalar(3., do_print=True))
+    self.assertAllClose(tap_scalar(3, do_print=False), tap_scalar(3, do_print=True))
     hcb.barrier_wait()
     expected = """
       what: step_nr


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10840.