### PR TITLE
BUG: fix incorrect order of operations in line search

### DIFF
--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -201,7 +201,7 @@ def _zoom(restricted_func_and_grad, wolfe_one, wolfe_two, a_lo, phi_lo,
     state = state._replace(j=state.j + 1)
     # Choose higher cutoff for maxiter than Scipy as Jax takes longer to find
     # the same value - possibly floating point issues?
-    state = state._replace(failed= state.failed | state.j >= 30)
+    state = state._replace(failed= state.failed | (state.j >= 30))
     return state
 
   state = lax.while_loop(lambda state: (~state.done) & (~pass_through) & (~state.failed),

--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -71,7 +71,7 @@ class TestBFGS(jtu.JaxTestCase):
      "maxiter": maxiter, "func_and_init": func_and_init}
     for maxiter in [None]
     for func_and_init in [(rosenbrock, np.zeros(2)),
-                          (himmelblau, np.zeros(2)),
+                          (himmelblau, np.ones(2)),
                           (matyas, np.ones(2) * 6.),
                           (eggholder, np.ones(2) * 100.)]))
   def test_minimize(self, maxiter, func_and_init):


### PR DESCRIPTION
Problem was introduced in #6785

I'm not sure the effect of this on outputs; I discovered it in the process of fixing tests for https://github.com/google/jax/pull/10840.