### PR TITLE
[x64] make scipy_optimize_test compatible with strict dtype promotion

### DIFF
--- a/jax/_src/scipy/optimize/line_search.py
+++ b/jax/_src/scipy/optimize/line_search.py
@@ -15,6 +15,7 @@
 from typing import NamedTuple, Union
 from functools import partial
 
+from jax._src.numpy.util import _promote_dtypes_inexact
 import jax.numpy as jnp
 import jax
 from jax import lax
@@ -269,13 +270,15 @@ def line_search(f, xk, pk, old_fval=None, old_old_fval=None, gfk=None, c1=1e-4,
 
   Returns: LineSearchResults
   """
+  xk, pk = _promote_dtypes_inexact(xk, pk)
   def restricted_func_and_grad(t):
+    t = jnp.array(t, dtype=pk.dtype)
     phi, g = jax.value_and_grad(f)(xk + t * pk)
     dphi = jnp.real(_dot(g, pk))
     return phi, dphi, g
 
   if old_fval is None or gfk is None:
-    phi_0, dphi_0, gfk = restricted_func_and_grad(0.)
+    phi_0, dphi_0, gfk = restricted_func_and_grad(0)
   else:
     phi_0 = old_fval
     dphi_0 = jnp.real(_dot(gfk, pk))

--- a/tests/scipy_optimize_test.py
+++ b/tests/scipy_optimize_test.py
@@ -104,7 +104,7 @@ class TestBFGS(jtu.JaxTestCase):
   @jtu.skip_on_flag('jax_enable_x64', False)
   def test_zakharov(self):
     def zakharov_fn(x):
-      ii = jnp.arange(1, len(x) + 1, step=1)
+      ii = jnp.arange(1, len(x) + 1, step=1, dtype=x.dtype)
       answer = zakharovFromIndices(x=x, ii=ii)
       return answer
 
@@ -208,8 +208,8 @@ class TestLBFGS(jtu.JaxTestCase):
     complex_dim = 5
 
     f_re = rosenbrock(jnp)
-    init_re = jnp.zeros((2 * complex_dim,))
-    expect_re = jnp.ones((2 * complex_dim,))
+    init_re = jnp.zeros((2 * complex_dim,), dtype=complex)
+    expect_re = jnp.ones((2 * complex_dim,), dtype=complex)
 
     def f(z):
       x_re = jnp.concatenate([jnp.real(z), jnp.imag(z)])

--- a/tests/third_party/scipy/line_search_test.py
+++ b/tests/third_party/scipy/line_search_test.py
@@ -130,7 +130,7 @@ class TestLineSearch(jtu.JaxTestCase):
     # |x + s| <= c2 * |x|
     f = lambda x: jnp.dot(x, x)
     fp = lambda x: 2 * x
-    p = jnp.array([1, 0])
+    p = jnp.array([1.0, 0.0])
 
     # Smallest s satisfying strong Wolfe conditions for these arguments is 30
     x = -60 * p


### PR DESCRIPTION
Part of https://github.com/google/jax/pull/10840. Depends on #11137