### PR TITLE
Change JAX_PLATFORMS to raise an exception when platform initialization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 * Breaking changes
   * {func}`jax.experimental.compilation_cache.initialize_cache` does not support
     `max_cache_size_  bytes` anymore and will not get that as an input.
+  * `JAX_PLATFORMS` now raises an exception when platform initialization fails.
 * Changes
   * {func}`jax.numpy.linalg.slogdet` now accepts an optional `method` argument
     that allows selection between an LU-decomposition based implementation and

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -602,6 +602,22 @@ jax2tf_associative_scan_reductions = config.define_bool_state(
     )
 )
 
+jax_platforms = config.define_string_state(
+    name='jax_platforms',
+    default=None,
+    help=(
+        'Comma-separated list of platform names specifying which platforms jax '
+        'should initialize. If any of the platforms in this list are not successfully '
+        'initialized, an exception will be raised and the program will be aborted. '
+        'The first platform in the list will be the default platform. '
+        'For example, config.jax_platforms=cpu,tpu means that CPU and TPU backends '
+        'will be initialized, and the CPU backend will be used unless otherwise '
+        'specified. If TPU initialization fails, it will raise an exception. '
+        'By default, jax will try to initialize all available '
+        'platforms and will default to GPU or TPU if available, and fallback to CPU '
+        'otherwise.'
+        ))
+
 enable_checks = config.define_bool_state(
     name='jax_enable_checks',
     default=False,


### PR DESCRIPTION
Repurposing --jax_platforms, to not only setting the priorities of which platforms to initialize, but also abort the program if the specified platforms are not initialized correctly. This will let the user make sure what platform the program is running on, without getting confused in between. If not set, still the default behavior is that we switch to CPU if other platforms are not successfully initialized. 

[TESTING] To test this flag, there are two ways to set it. 1) set it in the terminal with `export JAX_PLATFORMS=tpu,cpu` or in a written program like test.py that has this line in it: `config.update('jax_platforms', 'tpu,cpu')`. 

The test.py script could be this: 
```
import jax
from jax._src.config import config

config.update('jax_platforms', 'tpu,cpu')
print(jax.device_count())
```

If the flag is set, we expect the program to end when TPU is already in use. So I made two terminals, in one of them using `ipython` I run these two lines to get TPU running: 
```
import jax
jax.device_count()
```
and I keep ipython running. Then in the other terminal, I run the file test.py, it will raise the exception with this error: 
```
WARNING: Logging before InitGoogle() is written to STDERR
I0000 00:00:1656090003.394494 1333717 tpu_initializer_helper.cc:116] libtpu.so is already in use by process with pid 1332169. Not attempting to load libtpu.so in this process.
Traceback (most recent call last):
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 305, in backends
    backend = _init_backend(platform)
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 349, in _init_backend
    backend = factory()
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 181, in tpu_client_timer_callback
    client = xla_client.make_tpu_client()
  File "/home/shahrokhi/.local/lib/python3.8/site-packages/jaxlib/xla_client.py", line 108, in make_tpu_client
    return _xla.get_tpu_client(
jaxlib.xla_extension.XlaRuntimeError: ABORTED: libtpu.so is already in use by process with pid 1332169. Not attempting to load libtpu.so in this process.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 5, in <module>
    print(jax.device_count())
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 416, in device_count
    return int(get_backend(backend).device_count())
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 389, in get_backend
    return _get_backend_uncached(platform)
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 373, in _get_backend_uncached
    bs = backends()
  File "/home/shahrokhi/jax/jax/_src/lib/xla_bridge.py", line 330, in backends
    raise RuntimeError(f"Unable to initialize backend '{platform}': {err}")
RuntimeError: Unable to initialize backend 'tpu': ABORTED: libtpu.so is already in use by process with pid 1332169. Not attempting to load libtpu.so in this process.
```

If the flag is not set, I get this output: 
```
WARNING: Logging before InitGoogle() is written to STDERR
I0000 00:00:1656089625.706280 1313830 tpu_initializer_helper.cc:116] libtpu.so is already in use by process with pid 1298889. Not attempting to load libtpu.so in this process.
WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
1
```

