### PR TITLE
jnp.roots: better support for computation under JIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
 ## jax 0.3.15 (Unreleased)
+* [GitHub commits](https://github.com/google/jax/compare/jax-v0.3.14...main).
+* Changes
+  * {func}`jax.numpy.roots` is now better behaved when `strip_zeros=False` when
+    coefficients have leading zeros ({jax-issue}`#11215`).
 
 ## jaxlib 0.3.15 (Unreleased)
 
 ## jax 0.3.14 (June 21, 2022)
-* [GitHub commits](https://github.com/google/jax/compare/jax-v0.3.13...main).
+* [GitHub commits](https://github.com/google/jax/compare/jax-v0.3.13...jax-v0.3.14).
 * Breaking changes
   * {func}`jax.experimental.compilation_cache.initialize_cache` does not support
     `max_cache_size_  bytes` anymore and will not get that as an input.

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 from functools import partial
+
 import numpy as np
-import unittest
+from scipy.sparse import csgraph, csr_matrix
 
 from absl.testing import absltest
 from absl.testing import parameterized
 
-from jax import jit
+from jax._src import dtypes
 from jax import numpy as jnp
 from jax._src import test_util as jtu
 
@@ -35,114 +36,98 @@ all_dtypes = jtu.dtypes.floating + jtu.dtypes.integer + jtu.dtypes.complex
 
 class TestPolynomial(jtu.JaxTestCase):
 
+  def assertSetsAllClose(self, x, y, rtol=None, atol=None, check_dtypes=True):
+    """Assert that x and y contain permutations of the same approximate set of values.
+
+    For non-complex inputs, this is accomplished by comparing the sorted inputs.
+    For complex, such an approach can be confounded by numerical errors. In this case,
+    we compute the structural rank of the pairwise comparison matrix: if the structural
+    rank is full, it implies that the matrix can be permuted so that the diagonal is
+    non-zero, which implies a one-to-one approximate match between the permuted sets.
+    """
+    x = np.asarray(x).ravel()
+    y = np.asarray(y).ravel()
+
+    atol = max(jtu.tolerance(x.dtype, atol), jtu.tolerance(y.dtype, atol))
+    rtol = max(jtu.tolerance(x.dtype, rtol), jtu.tolerance(y.dtype, rtol))
+
+    if not (np.issubdtype(x.dtype, np.complexfloating) or
+            np.issubdtype(y.dtype, np.complexfloating)):
+      return self.assertAllClose(np.sort(x), np.sort(y), atol=atol, rtol=rtol,
+                                 check_dtypes=check_dtypes)
+
+    if check_dtypes:
+      self.assertEqual(x.dtype, y.dtype)
+    self.assertEqual(x.size, y.size)
+
+    pairwise = np.isclose(x[:, None], x[None, :],
+                          atol=atol, rtol=rtol, equal_nan=True)
+    rank = csgraph.structural_rank(csr_matrix(pairwise))
+    self.assertEqual(rank, x.size)
+
+
   @parameterized.named_parameters(jtu.cases_from_list(
     {"testcase_name": "_dtype={}_leading={}_trailing={}".format(
        jtu.format_shape_dtype_string((length+leading+trailing,), dtype),
        leading, trailing),
      "dtype": dtype, "length": length, "leading": leading, "trailing": trailing}
     for dtype in all_dtypes
-    for length in [0, 3, 9, 10, 17]
-    for leading in [0, 1, 2, 3, 5, 7, 10]
-    for trailing in [0, 1, 2, 3, 5, 7, 10]))
+    for length in [0, 3, 5]
+    for leading in [0, 2]
+    for trailing in [0, 2]))
   # TODO(phawkins): no nonsymmetric eigendecomposition implementation on GPU.
   @jtu.skip_on_devices("gpu", "tpu")
   def testRoots(self, dtype, length, leading, trailing):
-    # rng = jtu.rand_default(self.rng())
-    # This test is very fragile and breaks unless a "good" random seed is chosen.
-    rng = jtu.rand_default(self.rng())
+    rng = jtu.rand_some_zero(self.rng())
 
     def args_maker():
       p = rng((length,), dtype)
-      return jnp.concatenate(
-        [jnp.zeros(leading, p.dtype), p, jnp.zeros(trailing, p.dtype)]),
+      return [jnp.concatenate(
+        [jnp.zeros(leading, p.dtype), p, jnp.zeros(trailing, p.dtype)])]
 
-    jnp_fn = lambda arg: jnp.sort(jnp.roots(arg))
-    np_fn = lambda arg: np.sort(np.roots(arg))
-    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=False,
-                            tol=3e-6)
+    jnp_fun = jnp.roots
+    def np_fun(arg):
+      return np.roots(arg).astype(dtypes._to_complex_dtype(arg.dtype))
+
+    # Note: outputs have no defined order, so we need to use a special comparator.
+    args = args_maker()
+    np_roots = np_fun(*args)
+    jnp_roots = jnp_fun(*args)
+    self.assertSetsAllClose(np_roots, jnp_roots)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_dtype={}_trailing={}".format(
-        jtu.format_shape_dtype_string((length+trailing,), dtype), trailing),
-     "dtype": dtype, "length": length, "trailing": trailing}
+    {"testcase_name": "_dtype={}_leading={}_trailing={}".format(
+       jtu.format_shape_dtype_string((length+leading+trailing,), dtype),
+       leading, trailing),
+     "dtype": dtype, "length": length, "leading": leading, "trailing": trailing}
     for dtype in all_dtypes
-    for length in [0, 1, 3, 10]
-    for trailing in [0, 1, 3, 7]))
+    for length in [0, 3, 5]
+    for leading in [0, 2]
+    for trailing in [0, 2]))
   # TODO(phawkins): no nonsymmetric eigendecomposition implementation on GPU.
   @jtu.skip_on_devices("gpu", "tpu")
-  def testRootsNostrip(self, length, dtype, trailing):
-    # rng = jtu.rand_default(self.rng())
-    # This test is very fragile and breaks unless a "good" random seed is chosen.
-    rng = jtu.rand_default(np.random.RandomState(0))
+  def testRootsNoStrip(self, dtype, length, leading, trailing):
+    rng = jtu.rand_some_zero(self.rng())
 
     def args_maker():
       p = rng((length,), dtype)
-      if length != 0:
-        return jnp.concatenate([p, jnp.zeros(trailing, p.dtype)]),
-      else:
-        # adding trailing would make input invalid (start with zeros)
-        return p,
+      return [jnp.concatenate(
+        [jnp.zeros(leading, p.dtype), p, jnp.zeros(trailing, p.dtype)])]
 
-    jnp_fn = lambda arg: jnp.sort(jnp.roots(arg, strip_zeros=False))
-    np_fn = lambda arg: np.sort(np.roots(arg))
-    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker,
-                            check_dtypes=False, tol=1e-6)
+    jnp_fun = partial(jnp.roots, strip_zeros=False)
+    def np_fun(arg):
+      roots = np.roots(arg).astype(dtypes._to_complex_dtype(arg.dtype))
+      if len(roots) < len(arg) - 1:
+        roots = np.pad(roots, (0, len(arg) - len(roots) - 1),
+                       constant_values=complex(np.nan, np.nan))
+      return roots
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_dtype={}_trailing={}".format(
-      jtu.format_shape_dtype_string((length + trailing,), dtype), trailing),
-      "dtype": dtype, "length": length, "trailing": trailing}
-    for dtype in all_dtypes
-    for length in [0, 1, 3, 10]
-    for trailing in [0, 1, 3, 7]))
-  # TODO: enable when there is an eigendecomposition implementation
-  # for GPU/TPU.
-  @jtu.skip_on_devices("gpu", "tpu")
-  def testRootsJit(self, length, dtype, trailing):
-    # rng = jtu.rand_default(self.rng())
-    # This test is very fragile and breaks unless a "good" random seed is chosen.
-    rng = jtu.rand_default(np.random.RandomState(0))
-
-    def args_maker():
-      p = rng((length,), dtype)
-      if length != 0:
-        return jnp.concatenate([p, jnp.zeros(trailing, p.dtype)]),
-      else:
-        # adding trailing would make input invalid (start with zeros)
-        return p,
-
-    roots_compiled = jit(partial(jnp.roots, strip_zeros=False))
-    jnp_fn = lambda arg: jnp.sort(roots_compiled(arg))
-    np_fn = lambda arg: np.sort(np.roots(arg))
-    # Using strip_zeros=False makes the algorithm less efficient
-    # and leads to slightly different values compared ot numpy
-    self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker,
-                            check_dtypes=False, tol=1e-6)
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_dtype={}_zeros={}_nonzeros={}".format(
-        jtu.format_shape_dtype_string((zeros+nonzeros,), dtype),
-        zeros, nonzeros),
-     "zeros": zeros, "nonzeros": nonzeros, "dtype": dtype}
-    for dtype in all_dtypes
-    for zeros in [1, 2, 5]
-    for nonzeros in [0, 3]))
-  @jtu.skip_on_devices("gpu")
-  @unittest.skip("getting segfaults on MKL")  # TODO(#3711)
-  def testRootsInvalid(self, zeros, nonzeros, dtype):
-    rng = jtu.rand_default(self.rng())
-
-    # The polynomial coefficients here start with zero and would have to
-    # be stripped before computing eigenvalues of the companion matrix.
-    # Setting strip_zeros=False skips this check,
-    # allowing jit transformation but yielding nan's for these inputs.
-    p = jnp.concatenate([jnp.zeros(zeros, dtype), rng((nonzeros,), dtype)])
-
-    if p.size == 1:
-      # polynomial = const has no roots
-      self.assertTrue(jnp.roots(p, strip_zeros=False).size == 0)
-    else:
-      self.assertTrue(jnp.any(jnp.isnan(jnp.roots(p, strip_zeros=False))))
+    # Note: outputs have no defined order, so we need to use a special comparator.
+    args = args_maker()
+    np_roots = np_fun(*args)
+    jnp_roots = jnp_fun(*args)
+    self.assertSetsAllClose(np_roots, jnp_roots)
+    self._CompileAndCheck(jnp_fun, args_maker)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With this PR:
```python
In [1]: import jax.numpy as jnp 
   ...: from jax import jit 
   ...: from functools import partial 
   ...:  
   ...: coeffs = jnp.array([0, 0, 2, 3, 4]) 
   ...: jit(partial(jnp.roots, strip_zeros=False))(coeffs)                                                                                                           
Out[1]: DeviceArray([-0.75+1.1989578j, -0.75-1.1989578j, nan+nanj, nan+nanj], dtype=complex64)

In [2]: jnp.roots(coeffs)                                                                                                                                            
Out[2]: DeviceArray([-0.75+1.1989578j, -0.75-1.1989578j], dtype=complex64)

In [3]: import numpy as np 
   ...: np.roots(coeffs)                                                                                                                                             
Out[3]: array([-0.75+1.19895788j, -0.75-1.19895788j])
```
On the main branch:
```python

In [1]: import jax.numpy as jnp 
   ...: from jax import jit 
   ...: from functools import partial 
   ...:  
   ...: coeffs = jnp.array([0, 0, 2, 3, 4]) 
   ...: jit(partial(jnp.roots, strip_zeros=False))(coeffs)                                                                                                           
 ** On entry to SGEBAL parameter number  3 had an illegal value
 ** On entry to SGEHRD  parameter number  2 had an illegal value
 ** On entry to SHSEQR parameter number  4 had an illegal value
Out[1]: DeviceArray([nan+nanj, nan+nanj, nan+nanj, nan+nanj], dtype=complex64)
```
Also fixes #11164