### PR TITLE
Pin to numpy==1.22.4 until we figure out what's causing the failures …

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -6,3 +6,4 @@ pillow>=8.3.1,<9.1.0
 pytest-benchmark
 pytest-xdist
 wheel
+numpy==1.22.4


### PR DESCRIPTION
…on 1.23.0