### PR TITLE
jnp.ndarray: raise error for binary operations with lists and tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * `JaxTestCase` and `JaxTestLoader` have been removed from `jax.test_util`. These
     classes have been deprecated since v0.3.1 ({jax-issue}`#11248`).
   * Added {class}`jax.scipy.gaussian_kde` ({jax-issue}`#11237`).
+  * Binary operations between JAX arrays and built-in collections (`dict`, `list`, `set`, `tuple`)
+    now raise a `TypeError` in all cases. Previously some cases (particularly equality and inequality)
+    would return boolean scalars inconsistent with similar operations in NumPy ({jax-issue}`#11234`).
 
 ## jaxlib 0.3.15 (Unreleased)
 

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -941,8 +941,8 @@ class HostCallbackTapTest(jtu.JaxTestCase):
               identity=True
               transforms=()
             ] b
-            _:f32[] = mul c 2.00
-            d:f32[] = mul 1.00 2.00
+            _:f32[] = mul 2.00 c
+            d:f32[] = mul 2.00 1.00
             e:f32[] = outside_call[
               arg_treedef={treedef}
               callback=...
@@ -960,8 +960,8 @@ class HostCallbackTapTest(jtu.JaxTestCase):
               callback=...
               identity=True
             ] b
-            _:f32[] = mul c 2.00
-            d:f32[] = mul 1.00 2.00
+            _:f32[] = mul 2.00 c
+            d:f32[] = mul 2.00 1.00
             e:f32[] = mul d 3.00
           in (e,) }}""", jaxpr)
     assertMultiLineStrippedEqual(self, "", testing_stream.output)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -642,6 +642,36 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck( fun, args_maker, atol=tol, rtol=tol)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": f"{rec.test_name}_{othertype}", "name": rec.name, "othertype": othertype}
+    for rec in JAX_OPERATOR_OVERLOADS if rec.nargs == 2
+    for othertype in [dict, list, tuple, set]))
+  def testOperatorOverloadErrors(self, name, othertype):
+    # Test that binary operators with builtin collections raise a TypeError
+    # and report the types in the correct order.
+    data = [(1, 2), (2, 3)]
+    arr = jnp.array(data)
+    other = othertype(data)
+
+    msg = f"unsupported operand type.* 'DeviceArray' and '{othertype.__name__}'"
+    with self.assertRaisesRegex(TypeError, msg):
+      getattr(arr, name)(other)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
+    {"testcase_name": f"{rec.test_name}_{othertype}", "name": rec.name, "othertype": othertype}
+    for rec in JAX_RIGHT_OPERATOR_OVERLOADS if rec.nargs == 2
+    for othertype in [dict, list, tuple, set]))
+  def testRightOperatorOverloadErrors(self, name, othertype):
+    # Test that binary operators with builtin collections raise a TypeError
+    # and report the types in the correct order.
+    data = [(1, 2), (2, 3)]
+    arr = jnp.array(data)
+    other = othertype(data)
+
+    msg = f"unsupported operand type.* '{othertype.__name__}' and 'DeviceArray'"
+    with self.assertRaisesRegex(TypeError, msg):
+      getattr(arr, name)(other)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": rec.test_name + f"_{dtype}",
        "rng_factory": rec.rng_factory,
        "op_name": rec.name, "dtype": dtype}


### PR DESCRIPTION
This fixes a potentially confusing issue when JAX arrays are compared to python sequences.

When numpy encounters a list or tuple, it implicitly casts it to an array:
```python
In [1]: import numpy as np 
   ...: print(np.array([1, 1]) == [1, 2])                                                                                                                                                                                                                                                                         
[ True False]
```
In JAX, we tend not to do this for performance reasons, and because explicit is better than implicit in this case (see e.g. the discussion in #7737). Unfortunately, this case is not explicitly handled currently in binary operators, which makes the current behavior somewhat surprising:
```python
In [2]: import jax.numpy as jnp 
   ...: print(jnp.array([1, 1]) == [1, 2])                                                                                                                                                                                                                                                                        
False
```
This comes from `list.__req__`, and is a surprising result.

With this PR, this kind of comparison becomes an explicit `TypeError`:
```python
In [1]: import numpy as np 
   ...: print(np.array([1, 1]) == [1, 2])                                                                                                                                                                                                                                                                         
[ True False]

In [2]: import jax.numpy as jnp 
   ...: print(jnp.array([1, 1]) == [1, 2])                                                                                                                                                                                                                                                                        
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-5af3cb7a0607> in <module>
      1 import jax.numpy as jnp
----> 2 print(jnp.array([1, 1]) == [1, 2])

~/github/google/jax/jax/_src/numpy/lax_numpy.py in deferring_binary_op(self, other)
   4583       other = other.__jax_array__()
   4584     if isinstance(other, _rejected_binop_types):
-> 4585       raise TypeError(f"unsupported operand type(s) for {opchar}: "
   4586                       f"{type(self).__name__!r} and {type(other).__name__!r}")
   4587     if not isinstance(other, _accepted_binop_types):

TypeError: unsupported operand type(s) for ==: 'DeviceArray' and 'list'
```
~This is a draft, mainly to see if the issue catches any tests. Still todo if we choose to make this change:~

- [x] add `set` and `dict`
- [x] ensure arguments are in correct order in error message
- [x] regression tests for this behavior
- [x] CHANGELOG entry

Closes #2406