### PR TITLE
Remove type: ignore in sharding.py

### DIFF
--- a/jax/experimental/sharding.py
+++ b/jax/experimental/sharding.py
@@ -181,7 +181,7 @@ class PmapSharding(XLACompatibleSharding):
   def devices_indices_map(
       self, global_shape: Shape) -> Mapping[Device, Optional[Index]]:
     indices = pxla.spec_to_indices(global_shape, self.sharding_spec)
-    return {d: i for d, i in safe_zip(self.devices.flat, indices)}  # type: ignore
+    return {d: i for d, i in safe_zip(self.devices.flat, indices)}
 
   def _hashed_index(self, x) -> int:
     return hash(


### PR DESCRIPTION
It actually seems to be a place that's a genuine type error. Let's see
if mypy can catch it.