### PR TITLE
[dynamic-shapes] basic linearize and grad working

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -232,7 +232,7 @@ def saved_residuals(f, *args, **kwargs) -> List[Tuple[core.AbstractValue, str]]:
     return f(*args, **kwargs)
 
   jaxpr = jax.make_jaxpr(lambda *args: jax.linearize(f_, *args)[1])(*args).jaxpr
-  res_lits = [x for x in jaxpr.outvars if isinstance(x, core.Literal)]
+  res_lits = [x for x in jaxpr.outvars if     isinstance(x, core.Literal)]
   res_vars = {x for x in jaxpr.outvars if not isinstance(x, core.Literal)}
 
   results = []

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -283,8 +283,25 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
     in_type = tuple(unsafe_zip(abstract_args, itertools.repeat(True)))
     fun = lu.annotate(fun, in_type)
   else:
-    assert all(map(core.typematch, abstract_args,
-                   [a for a, k in fun.in_type if k]))
+    # Check that the provided abstract_args are consistent with in_type by first
+    # collecting values of axis size arguments, then substituting them in for
+    # DBIdx occurrences.
+    axis_sizes: Dict[core.DBIdx, int] = {}
+    abstract_args_iter = iter(abstract_args)
+    for expected_type, explicit in fun.in_type:
+      if explicit:
+        aval = next(abstract_args_iter)
+        if isinstance(expected_type, core.DShapedArray):
+          # Check the value for any DBIdx variables is consistent.
+          assert all(axis_sizes.setdefault(d1, d2) == d2
+                     for d1, d2 in zip(expected_type.shape, aval.shape)
+                     if type(d1) is core.DBIdx)
+          # Check the type matches after substitution.
+          expected_shape = [axis_sizes.get(d, d) for d in expected_type.shape]  # type: ignore
+          expected_aval = core.ShapedArray(
+              shape=tuple(expected_shape), dtype=expected_type.dtype,
+              weak_type=expected_type.weak_type)
+          assert core.typematch(expected_aval, aval)
   with log_elapsed_time(f"Finished tracing + transforming {fun.__name__} "
                         "for jit in {elapsed_time} sec"):
     jaxpr, out_type, consts = pe.trace_to_jaxpr_final2(
@@ -295,7 +312,9 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
 
   if config.jax_dynamic_shapes:
     keep_unused = True
+    has_outfeed = False
   else:
+    has_outfeed = core.jaxpr_uses_outfeed(jaxpr)
     jaxpr = apply_outfeed_rewriter(jaxpr)
 
   if not keep_unused:
@@ -322,7 +341,8 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
   # Computations that only produce constants and/or only rearrange their inputs,
   # which are often produced from partial evaluation, don't need compilation,
   # and don't need to evaluate their arguments.
-  if not jaxpr.eqns and not always_lower and all(kept_outputs):
+  if (not always_lower and not (jaxpr.effects or has_outfeed) and
+      (not jaxpr.eqns and all(kept_outputs) or not jaxpr.outvars)):
     return XlaComputation(
         name, None, True, None, None, None, jaxpr=jaxpr, consts=consts,
         device=device, in_avals=abstract_args, out_avals=out_avals,

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -36,7 +36,7 @@ from jax._src.lax.utils import (
 )
 from jax._src.lax import lax
 from jax._src import util
-from jax._src.util import safe_zip
+from jax._src.util import safe_map, safe_zip
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.lib import xla_bridge
@@ -47,6 +47,9 @@ xc = xla_client
 
 Array = Any
 Shape = core.Shape
+
+map, unsafe_map = safe_map, map
+zip, unsafe_zip = safe_zip, zip
 
 
 def slice(operand: Array, start_indices: Sequence[int],
@@ -764,8 +767,8 @@ def _slice_transpose_rule(t, operand, *, start_indices, limit_indices, strides):
       start_indices,
       np.where(np.array(t.shape) == 0, 0,
                np.add(1, np.multiply(np.subtract(t.shape, 1), strides))))
-    pads = safe_zip(start_indices, np.subtract(operand_shape, real_limits),
-                    np.subtract(strides, 1))
+    pads = zip(start_indices, np.subtract(operand_shape, real_limits),
+               np.subtract(strides, 1))
   result = lax.pad(t, lax._const(t, 0), pads)
   assert result.shape == operand_shape, (
     f"result.shape={result.shape} operand_shape={operand_shape}")

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -167,9 +167,10 @@ def toposort(end_nodes):
         childless_nodes.append(parent)
       else:
         child_counts[id(parent)] -= 1
+  sorted_nodes = sorted_nodes[::-1]
 
-  check_toposort(sorted_nodes[::-1])
-  return sorted_nodes[::-1]
+  check_toposort(sorted_nodes)
+  return sorted_nodes
 
 def check_toposort(nodes):
   visited = set()

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -244,7 +244,16 @@ def annotate(f: WrappedFun,
     return f
   assert (type(in_type) is tuple and all(type(e) is tuple for e in in_type) and
           all(isinstance(a, core.AbstractValue) and type(b) is bool
-              for a, b in in_type))
+              and not isinstance(a, core.ConcreteArray) for a, b in in_type) and
+          all(isinstance(d, (int, core.DBIdx)) for a, _ in in_type
+              if type(a) is core.DShapedArray for d in a.shape))
+  provided = [e for _, e in in_type]
+  for aval, _ in in_type:
+    if type(aval) is core.DShapedArray:
+      for d in aval.shape:
+        if isinstance(d, core.DBIdx):
+          provided[d.val] = True
+  assert all(provided)
   return WrappedFun(f.f, f.transforms, f.stores, f.params, in_type)
 
 


### PR DESCRIPTION
Summary of changes:
* Added a `_broadcast_in_dim_partial_eval` rule. We can't use the standard partial eval rule for broadcasting when dynamic shapes are involved, because we need to instantiate any dynamic axis sizes in the trace (i.e. add them as inputs to the staged-out/unknown jaxpr and indicate that they should be saved as residuals) and produce an output Tracer with (lifted) Tracers in its aval's shape.
* Add a `core.get_referent` function, which is an identity function on non-Tracers and on Tracers calls a method on the Tracer instance. The purpose is to use this to decide when two values are symbolically equal even if they are not identical Python objects; such cases can arise in partial evaluation (hence why it's in an AD PR) because we might need to e.g. compare lifted JaxprTracers (representing a dynamic axis size in the jaxpr being staged out, so it's got a ConstVar recipe) to non-JaxprTracer objects (e.g. a DynamicJaxprTracer representing the same axis size but not wrapped the same way).
* Fixed some bugs around lu.WrappedFun type annotation updating. The one in partial_eval.py called `_update_annotation_known` was the only tricky one, just because extracting just the 'known part' of the type annotation requires re-indexing all the DBIdx. Relatedly, added more checks to `lu.annotate` to catch any malformed type annotations early.
* Adapt JaxprTrace, the mechanism for building jaxprs for linearize and vjp: (1) to handle Tracers in avals' shapes, e.g. in `new_arg` and `new_instantiated_const`, mainly by lifting such Tracers into the JaxprTrace (with ConstVar recipes), (2) in `JaxprTrace.process_call` to handle application of dynamic shape jaxprs, particularly using the helper `trace_to_subjaxpr_nounits_dyn` which is a bit long.
* Adapt `tracers_to_jaxpr` to handle substituting in Vars for Tracers in shapes, also improved clarity in general.
* Added some basic djax+AD tests.

Probably the most complex thing is `trace_to_subjaxpr_nounits_dyn`, but it's just bookkeeping.