### PR TITLE
Add JAX debugger tool

### DIFF
--- a/jax/_src/debugger/__init__.py
+++ b/jax/_src/debugger/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from jax._src.debugger.cli_debugger import breakpoint

--- a/jax/_src/debugger/cli_debugger.py
+++ b/jax/_src/debugger/cli_debugger.py
@@ -1,0 +1,202 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import cmd
+import dataclasses
+import inspect
+import sys
+import threading
+import traceback
+
+from typing import Any, Callable, Dict, IO, List, Optional
+
+import numpy as np
+from jax import core
+from jax import tree_util
+from jax._src import debugging
+from jax._src import traceback_util
+from jax._src import util
+import jax.numpy as jnp
+
+
+@tree_util.register_pytree_node_class
+@dataclasses.dataclass(frozen=True)
+class DebuggerFrame:
+  """Encapsulates Python frame information."""
+  filename: str
+  locals: Dict[str, Any]
+  code_context: str
+  source: List[str]
+  lineno: int
+  offset: Optional[int]
+
+  def tree_flatten(self):
+    flat_locals, locals_tree = tree_util.tree_flatten(self.locals)
+    is_valid = [
+        isinstance(l, (core.Tracer, jnp.ndarray, np.ndarray))
+        for l in flat_locals
+    ]
+    invalid_locals, valid_locals = util.partition_list(is_valid, flat_locals)
+    return valid_locals, (is_valid, invalid_locals, locals_tree, self.filename,
+                          self.code_context, self.source, self.lineno,
+                          self.offset)
+
+  @classmethod
+  def tree_unflatten(cls, info, valid_locals):
+    (is_valid, invalid_locals, locals_tree, filename, code_context, source,
+     lineno, offset) = info
+    flat_locals = util.merge_lists(is_valid, invalid_locals, valid_locals)
+    locals_ = tree_util.tree_unflatten(locals_tree, flat_locals)
+    return DebuggerFrame(filename, locals_, code_context, source, lineno,
+                         offset)
+
+  @classmethod
+  def from_frameinfo(cls, frame_info) -> DebuggerFrame:
+    try:
+      _, start = inspect.getsourcelines(frame_info.frame)
+      source = inspect.getsource(frame_info.frame).split('\n')
+      offset = frame_info.lineno - start
+    except OSError:
+      source = []
+      offset = None
+    return DebuggerFrame(
+        filename=frame_info.filename,
+        locals=frame_info.frame.f_locals,
+        code_context=frame_info.code_context,
+        source=source,
+        lineno=frame_info.lineno,
+        offset=offset)
+
+
+debug_lock = threading.Lock()
+
+
+def breakpoint(*, ordered: bool = False, **kwargs):  # pylint: disable=redefined-builtin
+  """Enters a breakpoint at a point in a program."""
+  frame_infos = inspect.stack()
+  # Filter out internal frames
+  frame_infos = [
+      frame_info for frame_info in frame_infos
+      if traceback_util.include_frame(frame_info.frame)
+  ]
+  frames = [
+      DebuggerFrame.from_frameinfo(frame_info) for frame_info in frame_infos
+  ]
+  # Throw out first frame corresponding to this function
+  frames = frames[1:]
+  flat_args, frames_tree = tree_util.tree_flatten(frames)
+
+  def _breakpoint_callback(*flat_args):
+    frames = tree_util.tree_unflatten(frames_tree, flat_args)
+    thread_id = None
+    if threading.current_thread() is not threading.main_thread():
+      thread_id = threading.get_ident()
+    with debug_lock:
+      TextDebugger(frames, thread_id, **kwargs).run()
+
+  if ordered:
+    effect = debugging.DebugEffect.ORDERED_PRINT
+  else:
+    effect = debugging.DebugEffect.PRINT
+  debugging.debug_callback(_breakpoint_callback, effect, *flat_args)
+
+
+class TextDebugger(cmd.Cmd):
+  """A text-based debugger."""
+  prompt = '(jaxdb) '
+  use_rawinput: bool = False
+
+  def __init__(self, frames: List[DebuggerFrame], thread_id,
+      stdin: Optional[IO[str]] = None, stdout: Optional[IO[str]] = None,
+      completekey: str = "tab"):
+    super().__init__(stdin=stdin, stdout=stdout, completekey=completekey)
+    self.frames = frames
+    self.frame_index = 0
+    self.thread_id = thread_id
+    self.intro = 'Entering jaxdb:'
+
+  def current_frame(self):
+    return self.frames[self.frame_index]
+
+  def evaluate(self, expr):
+    env = {}
+    curr_frame = self.frames[self.frame_index]
+    env.update(curr_frame.locals)
+    return eval(expr, {}, env)
+
+  def print_backtrace(self):
+    self.stdout.write('Traceback:\n')
+    for frame in self.frames[::-1]:
+      self.stdout.write(f'  File "{frame.filename}", line {frame.lineno}\n')
+      if frame.offset is None:
+        self.stdout.write('    <no source>\n')
+      else:
+        line = frame.source[frame.offset]
+        self.stdout.write(f'    {line}\n')
+
+  def print_context(self, num_lines=2):
+    curr_frame = self.frames[self.frame_index]
+    self.stdout.write(f'> {curr_frame.filename}({curr_frame.lineno})\n')
+    for i, line in enumerate(curr_frame.source):
+      assert curr_frame.offset is not None
+      if (curr_frame.offset - 1 - num_lines <= i <=
+          curr_frame.offset + num_lines):
+        if i == curr_frame.offset:
+          self.stdout.write(f'->  {line}\n')
+        else:
+          self.stdout.write(f'    {line}\n')
+
+  def do_p(self, arg):
+    try:
+      self.stdout.write(repr(self.evaluate(arg)) + "\n")
+    except Exception:
+      traceback.print_exc(limit=1)
+
+  def do_u(self, arg):
+    if self.frame_index == len(self.frames) - 1:
+      self.stdout.write('At topmost frame.\n')
+    else:
+      self.frame_index += 1
+    self.print_context()
+
+  def do_d(self, arg):
+    if self.frame_index == 0:
+      self.stdout.write('At bottommost frame.\n')
+    else:
+      self.frame_index -= 1
+    self.print_context()
+
+  def do_l(self, arg):
+    self.print_context(num_lines=5)
+
+  def do_ll(self, arg):
+    self.print_context(num_lines=5)
+
+  def do_c(self, arg):
+    return True
+
+  def do_EOF(self, arg):
+    sys.exit(0)
+
+  def do_bt(self, arg):
+    self.print_backtrace()
+
+  def run(self):
+    while True:
+      try:
+        self.cmdloop()
+        break
+      except KeyboardInterrupt:
+        self.stdout.write('--KeyboardInterrupt--\n')

--- a/tests/debugger_test.py
+++ b/tests/debugger_test.py
@@ -1,0 +1,280 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+import textwrap
+import unittest
+
+from typing import IO, Sequence, Tuple
+
+from absl.testing import absltest
+import jax
+from jax.config import config
+from jax._src import debugger
+from jax._src import lib as jaxlib
+from jax._src import test_util as jtu
+import jax.numpy as jnp
+
+config.parse_flags_with_absl()
+
+def make_fake_stdin_stdout(commands: Sequence[str]) -> Tuple[IO[str], io.StringIO]:
+  fake_stdin = io.StringIO()
+  fake_stdin.truncate(0)
+  for command in commands:
+    fake_stdin.write(command + "\n")
+  fake_stdin.seek(0)
+  return fake_stdin, io.StringIO()
+
+def _format_multiline(text):
+  return textwrap.dedent(text).lstrip()
+
+prev_xla_flags = None
+
+def setUpModule():
+  global prev_xla_flags
+  # This will control the CPU devices. On TPU we always have 2 devices
+  prev_xla_flags = jtu.set_host_platform_device_count(2)
+
+# Reset to previous configuration in case other test modules will be run.
+def tearDownModule():
+  prev_xla_flags()
+
+# TODO(sharadmv): remove jaxlib guards for GPU tests when jaxlib minimum
+#                 version is >= 0.3.11
+disabled_backends = ["tpu"]
+if jaxlib.version < (0, 3, 11):
+  disabled_backends.append("gpu")
+
+class CliDebuggerTest(jtu.JaxTestCase):
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_eof(self):
+    stdin, stdout = make_fake_stdin_stdout([])
+
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    with self.assertRaises(SystemExit):
+      f(2.)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_continue(self):
+    stdin, stdout = make_fake_stdin_stdout(["c"])
+
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    f(2.)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) """)
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_print_value(self):
+    stdin, stdout = make_fake_stdin_stdout(["p x", "c"])
+
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) DeviceArray(2., dtype=float32)
+    (jaxdb) """)
+    f(jnp.array(2., jnp.float32))
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_print_value_in_jit(self):
+    stdin, stdout = make_fake_stdin_stdout(["p x", "c"])
+
+    @jax.jit
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) array(2., dtype=float32)
+    (jaxdb) """)
+    f(jnp.array(2., jnp.float32))
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_print_multiple_values(self):
+    stdin, stdout = make_fake_stdin_stdout(["p x, y", "c"])
+
+    @jax.jit
+    def f(x):
+      y = x + 1.
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) (array(2., dtype=float32), array(3., dtype=float32))
+    (jaxdb) """)
+    f(jnp.array(2., jnp.float32))
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_print_context(self):
+    stdin, stdout = make_fake_stdin_stdout(["l", "c"])
+
+    @jax.jit
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    f(2.)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    \(jaxdb\) > .*debugger_test\.py\([0-9]+\)
+            @jax\.jit
+            def f\(x\):
+              y = jnp\.sin\(x\)
+    ->        debugger\.breakpoint\(stdin=stdin, stdout=stdout\)
+              return y
+    .*
+    \(jaxdb\) """)
+    self.assertRegex(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_print_backtrace(self):
+    stdin, stdout = make_fake_stdin_stdout(["bt", "c"])
+
+    @jax.jit
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+    expected = _format_multiline(r"""
+    Entering jaxdb:.*
+    \(jaxdb\) Traceback:.*
+    """)
+    f(2.)
+    self.assertRegex(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_can_work_with_multiple_stack_frames(self):
+    stdin, stdout = make_fake_stdin_stdout(["l", "u", "p x", "d", "c"])
+
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+
+    @jax.jit
+    def g(x):
+      y = f(x)
+      return jnp.exp(y)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    \(jaxdb\) > .*debugger_test\.py\([0-9]+\)
+            def f\(x\):
+              y = jnp\.sin\(x\)
+    ->        debugger\.breakpoint\(stdin=stdin, stdout=stdout\)
+              return y
+    .*
+    \(jaxdb\) > .*debugger_test\.py\([0-9]+\).*
+            @jax\.jit
+            def g\(x\):
+    ->        y = f\(x\)
+              return jnp\.exp\(y\)
+    .*
+    \(jaxdb\) array\(2\., dtype=float32\)
+    \(jaxdb\) > .*debugger_test\.py\([0-9]+\)
+            def f\(x\):
+              y = jnp\.sin\(x\)
+    ->        debugger\.breakpoint\(stdin=stdin, stdout=stdout\)
+              return y
+    .*
+    \(jaxdb\) """)
+    g(jnp.array(2., jnp.float32))
+    self.assertRegex(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_can_use_multiple_breakpoints(self):
+    stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
+
+    def f(x):
+      y = x + 1.
+      debugger.breakpoint(stdin=stdin, stdout=stdout, ordered=True)
+      return y
+
+    @jax.jit
+    def g(x):
+      y = f(x) * 2.
+      debugger.breakpoint(stdin=stdin, stdout=stdout, ordered=True)
+      return jnp.exp(y)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) array(3., dtype=float32)
+    (jaxdb) Entering jaxdb:
+    (jaxdb) array(6., dtype=float32)
+    (jaxdb) """)
+    g(jnp.array(2., jnp.float32))
+    jax.effects_barrier()
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_works_with_vmap(self):
+    stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
+
+    def f(x):
+      y = x + 1.
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return 2. * y
+
+    @jax.jit
+    @jax.vmap
+    def g(x):
+      y = f(x)
+      return jnp.exp(y)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    (jaxdb) array(1., dtype=float32)
+    (jaxdb) Entering jaxdb:
+    (jaxdb) array(2., dtype=float32)
+    (jaxdb) """)
+    g(jnp.arange(2., dtype=jnp.float32))
+    self.assertEqual(stdout.getvalue(), expected)
+
+  @jtu.skip_on_devices(*disabled_backends)
+  def test_debugger_works_with_pmap(self):
+    if jax.local_device_count() < 2:
+      raise unittest.SkipTest("Test requires >= 2 devices.")
+    stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
+
+    def f(x):
+      y = jnp.sin(x)
+      debugger.breakpoint(stdin=stdin, stdout=stdout)
+      return y
+
+    @jax.pmap
+    def g(x):
+      y = f(x)
+      return jnp.exp(y)
+    expected = _format_multiline(r"""
+    Entering jaxdb:
+    \(jaxdb\) array\(.*, dtype=float32\)
+    \(jaxdb\) Entering jaxdb:
+    \(jaxdb\) array\(.*, dtype=float32\)
+    \(jaxdb\) """)
+    g(jnp.arange(2., dtype=jnp.float32))
+    self.assertRegex(stdout.getvalue(), expected)
+
+if __name__ == '__main__':
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Adds a JAX debugging tool (internal-only for now)

Example usage:
![JAX Debugger Demo](https://user-images.githubusercontent.com/1142926/176307732-2ee4f4de-84e1-45ce-9c46-6475c4be6079.gif)
