### PR TITLE
[dynamic shapes] revive djax+iree from bitrot

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -71,9 +71,10 @@ from jax._src.numpy.ufuncs import (  # noqa: F401
   reciprocal, remainder, right_shift, rint, sign, signbit, sin, sinc, sinh, sqrt,
   square, subtract, tan, tanh, true_divide)
 from jax._src.numpy.util import (  # noqa: F401
-  _arraylike, _broadcast_arrays, _broadcast_to, _check_arraylike, _complex_elem_type, _promote_args,
-  _promote_args_inexact, _promote_dtypes, _promote_dtypes_inexact, _promote_shapes, _register_stackable,
-  _stackable, _where, _wraps)
+  _arraylike, _broadcast_arrays, _broadcast_to, _check_arraylike,
+  _complex_elem_type, _promote_args, _promote_args_inexact, _promote_dtypes,
+  _promote_dtypes_inexact, _promote_shapes, _register_stackable, _stackable,
+  _where, _wraps)
 from jax._src.numpy.vectorize import vectorize
 from jax._src.ops import scatter
 from jax._src.util import (unzip2, prod as _prod, subvals, safe_zip, ceil_of_ratio,
@@ -2099,8 +2100,12 @@ def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
     dtype = result_type(start, *(x for x in [stop, step] if x is not None))
   dtype = _jnp_dtype(dtype)
   if stop is None and step is None:
-    start = require(start, msg("stop"))
-    start = np.ceil(start).astype(int)
+    if (jax.config.jax_dynamic_shapes and
+        not isinstance(core.get_aval(start), core.ConcreteArray)):
+      start = ceil(start).astype(int)  # note using jnp here
+    else:
+      start = require(start, msg("stop"))
+      start = np.ceil(start).astype(int)
     return lax.iota(dtype, start)
   else:
     start = require(start, msg("start"))

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -667,7 +667,7 @@ def trace_to_subjaxpr_nounits_dyn(
   out_type = [(a.update(shape=tuple(idx_map.get(d, d) for d in a.shape))  # type: ignore
                if type(a) is DShapedArray else a, True) for a in out_avals]
 
-  # Which residuals  are just forwarded inputs? Check obj id, then prune.
+  # Which residuals are just forwarded inputs? Check obj id, then prune.
   id_map = {id(c.recipe.val): i for i, c in enumerate(in_consts_full)  # type: ignore
             if c is not None}
   fwds: List[Optional[int]] = [id_map.get(id(c)) for c in res]


### PR DESCRIPTION
~#11268 is the diffbase.~

Because we hadn't released a jaxlib wheel in a while, the jaxlib and iree wheels got out of sync and so we couldn't run JAX+IREE tests in OSS for a while. (I run them manually because they're not yet covered by CI.) That led to some bit rot as we made changes to the JAX dynamic shapes stuff without updating the (untested) dispatch path.

This PR revives JAX+IREE! It also makes a batch-size-polymorphic MLP execute (i.e. compute numbers), including with autodiff, and adds basic `jnp.arange` / `lax.iota` dynamic shape support (drawn from #9426).

To run JAX+IREE tests, use `JAX_PLATFORMS=iree pytest -n auto tests/api_test.py` or similar.