### PR TITLE
Disable lobpcg F32 consistency test on GPU.

### DIFF
--- a/tests/lobpcg_test.py
+++ b/tests/lobpcg_test.py
@@ -366,6 +366,7 @@ class F32LobpcgTest(LobpcgTest):
       linalg.lobpcg_standard(A[:50, :50], X[:50])
 
   @parameterized.named_parameters(_make_concrete_cases(f64=False))
+  @jtu.skip_on_devices("gpu")
   def testLobpcgConsistencyF32(self, matrix_name, n, k, m):
     self.checkLobpcgConsistency(matrix_name, n, k, m, jnp.float32)
 


### PR DESCRIPTION
The test appears to be failing at least some of the time

Typical failure:

=================================== FAILURES ===================================
___________ F32LobpcgTest.testLobpcgConsistencyF32cluster_k_2__n100 ____________
[gw12] linux -- Python 3.9.12 /usr/local/bin/python3.9
tests/lobpcg_test.py:370: in testLobpcgConsistencyF32
    self.checkLobpcgConsistency(matrix_name, n, k, m, jnp.float32)
tests/lobpcg_test.py:203: in checkLobpcgConsistency
    self.assertLess(
E   AssertionError: DeviceArray(20, dtype=int32, weak_type=True) not less than 20 : expected early convergence iters 20 < max 20