### PR TITLE
Maintain invariance to JIT and other transform when the function behavior depends on `__class__` of inputs, e.g. `functools.singledispatch`

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -549,6 +549,14 @@ class Tracer:
   def aval(self):
     raise NotImplementedError("must override")
 
+  @property
+  def __class__(self):
+    return self.aval.__class__
+
+  @__class__.setter
+  def __class__(self, _): # noqa: F811
+    raise NotImplementedError()
+
   def _assert_live(self) -> None:
     pass  # Override for liveness checking
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -9606,6 +9606,13 @@ class DynamicShapeTest(jtu.JaxTestCase):
     mhlo = f_lowered.compiler_ir('mhlo')
     self.assertIn('tensor<?xi32>', str(mhlo))
 
+  def test_functools_singledispatch(self):
+    @functools.singledispatch
+    def foo(_):
+      raise NotImplementedError()
+    foo.register(jnp.ndarray, lambda x: x)
+    jax.make_jaxpr(foo)(0)
+
   def test_vmap_abstracted_axis(self):
     def foo(x, y):
       z = jax.vmap(jnp.sin)(x) * y


### PR DESCRIPTION
Solve #11075 
We override `Tracer.__class__` to return `aval.__class__` to allow tracer instances with `avals` that are instances of `UnshapedArray`
This is better than overriding ndarray isinstance checks, which can not support `functools.singledispatch` based on `x.__class__`.
Theoretically, well written code should use `x.__class__` rather than type(x) except for capturing proxy type(e.g. Tracer). Unfortunately, many users prefer `type(x)`.