### PR TITLE
[shape_poly] Add special-case handling for operations with polynomials

### DIFF
--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -2414,10 +2414,14 @@ class DimensionHandlerTracer(core.DimensionHandler):
     return d1 is d2
 
   def greater_equal(self, d1: core.DimSize, d2: core.DimSize):
+    if d1 is d2:
+      return True
+    if core.symbolic_equal_dim(d2, 0):
+      return True
     raise core.InconclusiveDimensionOperation("TODO")
 
   def divide_shape_sizes(self, s1: core.Shape, s2: core.Shape) -> core.DimSize:
-    """Computes integer "i" such that i  * size(s2) == size(s1).
+    """Computes dimension "d" such that size(s1) = d * size(s2).
 
     Raise InconclusiveDimensionOperation if there is no such integer for all
     contexts.


### PR DESCRIPTION
jax2tf shape-poly works with polynomials representing the dimension sizes. We want to know how often we truly
need the power of polynomials. We know that we need to do often shape equality checking, e.g., that the reshape of
`(a, b, 4, 3)` into `(12, b, a)` is a valid one. Polynomials help here, because we can normalize easily the shape sizes as `12 * a * b`. 

I wanted to know how far we can get if we disable the use of polynomials. Can we still pass all the tests that check that `vmap(f)` is batch polymorphic? Fortunately, we have a large suite of 560 such tests for practically all the JAX primitives.

The first step was to add an internal constant `shape_poly.EXPERIMENTAL_STRICT_EQ` that makes equality be defined only for identical polynomials. With this change alone, 366 tests fail.

Then I looked at all the failures and I tried to add changes to JAX that make it unnecessary to do more powerful equality checking. I needed the following changes:

 * ensure that we create the same identical polynomial from two separate occurrences of a dimension variable (use caching)
 * add special casing for `d + 0` and `d * 1` to ensure we preserve dimension identity
 * add special casing for `dilate(d, 1) == d`
 * add special casing for `stride(d, window_size=1, window_stride=1) == d`
 
With these changes now only 21 tests fail, mostly for reshape and for `random` primitives (which use reshape internally). A typical error message is `Cannot divide evenly the sizes of shapes (b0, 3, 4, 5) and (b0, 4, 15)`. Another similar error message arises for `reshape` when one dimension is `-1`: `Cannot divide evenly the sizes of shapes (b0, 3, 4, 5) and (b0, 2, -1)`.

To handle these, I added a more elaborate implementation of `core.divide_shape_sizes` (which is used to check that
`reshape` is well-formed and to compute the missing dimension size of `reshape(-1)`) to detect the special case when all the non-constant dimensions in the divisor appear in the dividend. 

This code is somewhat ugly, because it tries to handle the cases when there are multiple occurrences of a dimension, and also to handle the case for `reshape(-1)`.

With these changes ``a single`` test fails, for `random_gamma`, which does some fancy `reshape` in its [impl rule](https://github.com/google/jax/blob/0719f986aaeda3ba216416b6b1243d9f815fefda/jax/_src/random.py#L990). The error message is `Cannot divide evenly the sizes of shapes (b0, 3, 2) and (3*b0, 2)`

