### PR TITLE
Fix ConcretizationError in nested calls/subjaxprs.

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -503,7 +503,7 @@ def escaped_tracer_error(tracer, detail=None):
          f'with shape {tracer.shape} and dtype {tracer.dtype} to escape.\n'
          'JAX transformations require that functions explicitly return their '
          'outputs, and disallow saving intermediate values to global state.')
-  dbg = getattr(tracer._trace.main, 'debug_info', None)
+  dbg = getattr(tracer, '_debug_info', None)
   if dbg is not None:
     msg += ('\nThe function being traced when the value leaked was '
             f'{dbg.func_src_info} traced for {dbg.traced_for}.')

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3233,6 +3233,20 @@ class APITest(jtu.JaxTestCase):
     with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
       f()
 
+  def test_concrete_error_with_nested_call(self):
+    @jax.jit
+    def f(x, y):
+      if y:
+        return x
+
+    @jax.jit
+    def g(x):
+      return f(x, True)
+
+    msg = r"on the value of the argument 'y'"
+    with self.assertRaisesRegex(core.ConcretizationTypeError, msg):
+      g(1)
+
   def test_xla_computation_zeros_doesnt_device_put(self):
     with jtu.count_device_put() as count:
       api.xla_computation(lambda: jnp.zeros(3))()


### PR DESCRIPTION
```
@jax.jit
def f(x, y):
  if y:
    return x

@jax.jit
def g(x):
  return f(x, True)

g()
```

Before:
```
[jax/interpreters/partial_eval.py] in arg_info_pytree(fn, in_tree, has_kwargs, flat_pos)
   1840                     flat_pos: List[int]) -> str:
   1841   dummy_args = [False] * in_tree.num_leaves
-> 1842   for i in flat_pos: dummy_args[i] = True
   1843   if has_kwargs:
   1844     args, kwargs = tree_unflatten(in_tree, dummy_args)

IndexError: list assignment index out of range
```

After:
```
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected:
Traced<ShapedArray(bool[])>with<DynamicJaxprTrace(level=0/2)> 
The problem arose with the `bool` function. 
This concrete value was not available in Python because it depends on the value of the argument 'y'. 
```