### PR TITLE
Enable CustomCall implementation on GPU

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -537,6 +537,8 @@ def _inline_host_callback() -> bool:
 
 
 def _use_outfeed(platform: str) -> bool:
+  if jaxlib.version >= (0, 3, 15):
+    return platform == "tpu" or FLAGS.jax_host_callback_outfeed
   return (platform in ("tpu", "gpu", "cuda", "rocm") or FLAGS.jax_host_callback_outfeed)
 
 xops = xla_client._xla.ops
@@ -1198,6 +1200,8 @@ def _outside_call_lowering(
   return results + [next_token, next_itoken]
 
 mlir.register_lowering(outside_call_p, _outside_call_lowering, platform="cpu")
+if jaxlib.version >= (0, 3, 15):
+  mlir.register_lowering(outside_call_p, _outside_call_lowering, platform="gpu")
 
 def _outside_call_run_callback(
     arrays, device, *,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -776,7 +776,6 @@ jax_test(
     srcs = ["host_callback_test.py"],
     args = ["--jax_host_callback_outfeed=false"],
     disable_backends = [
-        "gpu",
         "tpu",  # On TPU we always use outfeed
     ],
     main = "host_callback_test.py",

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -2456,6 +2456,8 @@ class HostCallbackCallTest(jtu.JaxTestCase):
                                    expected_exc_txt: str):
     """Calls thunk() and checks for expected exceptions.
     """
+    if not FLAGS.jax_host_callback_outfeed:
+      raise SkipTest("TODO: implement error handling for customcall")
     if jtu.device_under_test() == "cpu":
       # On CPU the runtime crashes, and the tests are all aborted
       raise SkipTest("TODO: CPU runtime crashes on unexpected infeed")


### PR DESCRIPTION
https://github.com/google/jax/commit/b93706638f2a6c5f3a0270fcacf3ee80e117ad2f said HCB are waiting for the GPU implementation.
According to
https://github.com/google/jax/commit/b80d7195f695b728a91f63ab2d2b6b09692f2064 and https://github.com/google/jax/pull/10970 GPU implementation seems available after jaxlib-0.3.11
