### PR TITLE
[dynamic-shapes] revive basic bounded int machinery, add tests

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -299,6 +299,7 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
   if config.jax_dynamic_shapes:
     keep_unused = True
     has_outfeed = False
+    donated_invars = [False] * len(fun.in_type)
   else:
     has_outfeed = core.jaxpr_uses_outfeed(jaxpr)
     jaxpr = apply_outfeed_rewriter(jaxpr)
@@ -318,8 +319,7 @@ def lower_xla_callable(fun: lu.WrappedFun, device, backend, name,
   device = _xla_callable_device(nreps, backend, device, arg_devices)
   backend = xb.get_device_backend(device) if device else xb.get_backend(backend)
 
-  if (config.jax_dynamic_shapes and jaxpr_has_bints(jaxpr) and
-      not _backend_supports_unbounded_dynamic_shapes(backend)):
+  if config.jax_dynamic_shapes and jaxpr_has_bints(jaxpr):
     jaxpr, consts = pe.pad_jaxpr(jaxpr, consts)
 
   map(prefetch, itertools.chain(consts, jaxpr_literals(jaxpr)))
@@ -517,6 +517,7 @@ num_buffers_handlers[core.AbstractToken] = lambda _: 1
 num_buffers_handlers[core.ShapedArray] = lambda _: 1
 num_buffers_handlers[core.DShapedArray] = lambda _: 1
 num_buffers_handlers[core.ConcreteArray] = lambda _: 1
+num_buffers_handlers[core.AbstractBInt] = lambda _: 1
 
 
 def _input_handler(backend: Backend,
@@ -649,17 +650,22 @@ def dynamic_array_result_handler(sticky_device: Optional[Device],
     return partial(_dynamic_array_result_handler, sticky_device, aval)
 
 def _dynamic_array_result_handler(sticky_device, aval, env, buf):
-  if all(type(d) is int for d in aval.shape):
-    del env
-    return _maybe_create_array_from_da(buf, aval, sticky_device)
-  else:
-    assert env is not None
-    in_env, out_env = env
-    shape = [in_env[d.val] if type(d) is core.InDBIdx else
-             out_env[d.val] if type(d) is core.OutDBIdx else d
-             for d in aval.shape]
+  in_env, out_env = env or (None, None)
+  shape = [in_env[d.val] if type(d) is core.InDBIdx else
+           out_env[d.val] if type(d) is core.OutDBIdx else d
+           for d in aval.shape]
+  if all(type(d) is int for d in shape):
     aval = core.ShapedArray(tuple(shape), aval.dtype)
     return _maybe_create_array_from_da(buf, aval, sticky_device)
+  elif any(type(d) is core.BInt for d in shape):
+    padded_shape = [d.bound if type(d) is core.BInt else d for d in shape]
+    buf_aval = core.ShapedArray(tuple(padded_shape), aval.dtype, aval.weak_type)
+    data = _maybe_create_array_from_da(buf, buf_aval, sticky_device)
+    return core.PaddedArray(aval.update(shape=tuple(shape)), data)
+  else:
+    aval = core.ShapedArray(tuple(shape), aval.dtype)
+    return _maybe_create_array_from_da(buf, aval, sticky_device)
+
 
 
 result_handlers: Dict[
@@ -669,6 +675,8 @@ result_handlers[core.AbstractToken] = lambda _, __: lambda _, __: core.token
 result_handlers[core.ShapedArray] = array_result_handler
 result_handlers[core.DShapedArray] = dynamic_array_result_handler
 result_handlers[core.ConcreteArray] = array_result_handler
+result_handlers[core.AbstractBInt] = \
+    lambda _, a: lambda _, b: core.BInt(int(b), a.bound)
 
 
 def needs_check_special():
@@ -1005,6 +1013,7 @@ device_put_handlers: Dict[Any, Callable[[Any, Optional[Device]], Tuple[Any]]] = 
 device_put_handlers.update((t, _device_put_array) for t in array_types)
 device_put_handlers.update((t, _device_put_scalar) for t in _scalar_types)
 device_put_handlers[core.Token] = _device_put_token
+device_put_handlers[core.BInt] = lambda x, d: _device_put_scalar(x.val, d)
 
 
 def _device_put_device_array(x: Union[device_array.DeviceArrayProtocol, device_array._DeviceArray], device: Optional[Device]):
@@ -1012,6 +1021,7 @@ def _device_put_device_array(x: Union[device_array.DeviceArrayProtocol, device_a
   return (x.device_buffer,)
 for t in device_array.device_array_types:
   device_put_handlers[t] = _device_put_device_array
+device_put_handlers[core.PaddedArray] = lambda x, d: device_put(x._data, d)
 
 def _copy_device_array_to_device(
     x: Union[device_array.DeviceArrayProtocol, device_array._DeviceArray],

--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -104,8 +104,8 @@ class IreeBuffer(xla_client.DeviceArrayBase):
     return self  # no async
 
   # overrides repr on base class which expects _value and aval attributes
-  def __repr__(self):
-    return f'IreeBuffer({self.to_py()})'
+  def __repr__(self): return f'IreeBuffer({self.to_py()})'
+  _value = property(to_py)
 
 class IreeExecutable:
 

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -903,7 +903,7 @@ def _dynamic_slice_batching_rule(batched_args, batch_dims, *, slice_sizes):
 dynamic_slice_p = standard_primitive(
     _dynamic_slice_shape_rule, _dynamic_slice_dtype_rule, 'dynamic_slice',
     weak_type_rule=_argnum_weak_type(0))
-ad.primitive_jvps[dynamic_slice_p] = _dynamic_slice_jvp  # TODO
+ad.primitive_jvps[dynamic_slice_p] = _dynamic_slice_jvp
 ad.primitive_transposes[dynamic_slice_p] = _dynamic_slice_transpose_rule
 batching.primitive_batchers[dynamic_slice_p] = _dynamic_slice_batching_rule
 

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2101,8 +2101,12 @@ def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
   dtype = _jnp_dtype(dtype)
   if stop is None and step is None:
     if (jax.config.jax_dynamic_shapes and
+        not isinstance(core.get_aval(start), core.AbstractBInt) and
         not isinstance(core.get_aval(start), core.ConcreteArray)):
       start = ceil(start).astype(int)  # note using jnp here
+    elif (isinstance(start, core.BInt) or isinstance(start, core.Tracer) and
+          isinstance(core.get_aval(start), core.AbstractBInt)):
+      pass
     else:
       start = require(start, msg("stop"))
       start = np.ceil(start).astype(int)

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -2414,7 +2414,7 @@ def pad_jaxpr(jaxpr: Jaxpr, consts: Sequence[Const]
 
   def substitute(aval: AbstractValue) -> AbstractValue:
     if isinstance(aval, AbstractBInt):
-      return ShapedArray((), np.dtype('int32'))
+      return ShapedArray((), dtypes._scalar_type_to_dtype(int))
     elif isinstance(aval, DShapedArray):
       shape = [bounds.get(d, idxs.get(d, d)) for d in aval.shape]  # type: ignore
       typ = ShapedArray if all(type(d) is int for d in shape) else DShapedArray


### PR DESCRIPTION
Bounded integer types are useful for lowering dynamic shape computations to XLA (though they also work with IREE). They're also necessary for the padded-and-masked raggedness representations we need when dynamic shape computations are transformed with vmap.

This PR is a first step in reviving some bounded int machinery. The next steps are to add some tests for end-to-end examples, and then to add the raggedness features.

In addition to revival, we're also making some minor changes to past BInt experiments: most importantly, we're going to maintain the invariant that _the physical representation of an array is a function only of its type_. In particular, when an array has a BInt axis size, that means the physical buffer representation is effectively padded out along that axis to the size of the BInt's bound.

There's a new `PaddedArray` type here (to be extended later to handle raggedness, and arrays with BInt element type), which is basically the runtime data representation of an array with BInts as axis sizes.