### PR TITLE
Ensure boolean scalar weak types are treated consistently

### DIFF
--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -275,7 +275,10 @@ def abstractify(x) -> core.AbstractValue:
   raise TypeError(f"Argument '{x}' of type '{type(x)}' is not a valid JAX type")
 
 def _make_abstract_python_scalar(typ, val):
-  return ShapedArray((), dtypes._scalar_type_to_dtype(typ, val), weak_type=True)
+  # Note: all python scalar types are weak except bool, because bool only
+  # comes in a single width.
+  return ShapedArray((), dtypes._scalar_type_to_dtype(typ, val),
+                     weak_type=typ is not bool)
 
 pytype_aval_mappings: Dict[Any, Callable[[Any], core.AbstractValue]] = {}
 for t in device_array.device_array_types:


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/11377#issuecomment-1176781291

Confirmed that the examples in that issue work as expected with the change. Also the core issue is that these outputs now match:
```python
In [1]: import jax

In [2]: import jax.numpy as jnp

In [3]: jnp.array(True)
Out[3]: DeviceArray(True, dtype=bool)

In [4]: jax.jit(jnp.array)(True)
Out[4]: DeviceArray(True, dtype=bool)
```
I think the reason we went this long without noticing the issue is because it only really comes into play with functions that do type promotion between boolean scalar inputs and other weakly-typed scalar values, which I suspect is fairly rare.