### PR TITLE
MAINT: remove codepath for outdated jaxlib version

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -1965,18 +1965,10 @@ def _schur_cpu_lowering(ctx, operand, *, compute_schur_vectors, sort_eig_vals,
                         select_callable):
   operand_aval, = ctx.avals_in
   batch_dims = operand_aval.shape[:-2]
-
-  # TODO(jakevdp): remove this try/except when minimum jaxlib >= 0.3.8
-  try:
-    gees_result = lapack.gees_mhlo(operand_aval.dtype, operand,
-                                   jobvs=compute_schur_vectors,
-                                   sort=sort_eig_vals,
-                                   select=select_callable)
-  except TypeError:  # API for jaxlib <= 0.3.7
-    gees_result = lapack.gees_mhlo(operand,  # pytype: disable=missing-parameter
-                                   jobvs=compute_schur_vectors,
-                                   sort=sort_eig_vals,
-                                   select=select_callable)
+  gees_result = lapack.gees_mhlo(operand_aval.dtype, operand,
+                                 jobvs=compute_schur_vectors,
+                                 sort=sort_eig_vals,
+                                 select=select_callable)
   # Number of return values depends on value of sort_eig_vals.
   T, vs, *_, info = gees_result
 


### PR DESCRIPTION
minimum jaxlib version is now 3.10, so this code is no longer relevant: https://github.com/google/jax/blob/7da733f94bc76bcc8ba8aeecec6f0651d5982763/jax/version.py#L19