### PR TITLE
[dynamic-shapes] start basic vmap compatibility

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1575,58 +1575,60 @@ def _mapped_axis_size(tree, vals, dims, name, *, kws=False):
         f"containing an array, got empty *args={args} and **kwargs={kwargs}"
     )
 
-  def _get_axis_size(name: str, shape: Tuple[int, ...], axis: int):
+  def _get_axis_size(name: str, shape: Tuple[core.AxisSize, ...], axis: int
+                     ) -> core.AxisSize:
     try:
       return shape[axis]
     except (IndexError, TypeError) as e:
       min_rank = axis + 1 if axis >= 0 else -axis
-      raise ValueError(f"{name} was requested to map its argument along axis {axis}, "
-                       f"which implies that its rank should be at least {min_rank}, "
-                       f"but is only {len(shape)} (its shape is {shape})") from e
+      raise ValueError(
+          f"{name} was requested to map its argument along axis {axis}, "
+          f"which implies that its rank should be at least {min_rank}, "
+          f"but is only {len(shape)} (its shape is {shape})") from e
 
-  mapped_axis_sizes = {_get_axis_size(name, np.shape(x), d)
-                       for x, d in zip(vals, dims)
-                       if d is not None}
-  try:
-    size, = mapped_axis_sizes
-    return size
-  except ValueError as e:
-    if not mapped_axis_sizes:
-      raise ValueError(f"{name} must have at least one non-None value in in_axes") from e
-    msg = f"{name} got inconsistent sizes for array axes to be mapped:\n" + "{}"
-    # we switch the error message based on whether args is a tuple of arrays,
-    # in which case we can produce an error message based on argument indices,
-    # or if it has nested containers.
-    if kws:
-      position_only_tree, leaf = treedef_children(tree)
-      if not treedef_is_leaf(leaf):
-        sizes = [x.shape[d] if d is not None else None for x, d in zip(vals, dims)]
-        sizes = tree_unflatten(tree, sizes)
-        raise ValueError(msg.format(f"the tree of axis sizes is:\n{sizes}")) from None
-      # if keyword arguments are included in the tree, we adapt the error
-      # message only to be about the positional arguments
-      tree = position_only_tree
-
-    # TODO(mattjj,phawkins): add a way to inspect pytree kind more directly
-    if tree == tree_flatten((0,) * tree.num_leaves)[1]:
-      lines1 = [f"arg {i} has shape {np.shape(x)} and axis {d} is to be mapped"
-                for i, (x, d) in enumerate(zip(vals, dims))]
-      sizes = collections.defaultdict(list)
-      for i, (x, d) in enumerate(zip(vals, dims)):
-        if d is not None:
-          sizes[x.shape[d]].append(i)
-      lines2 = ["{} {} {} {} to be mapped of size {}".format(
-                  "args" if len(idxs) > 1 else "arg",
-                  ", ".join(map(str, idxs)),
-                  "have" if len(idxs) > 1 else "has",
-                  "axes" if len(idxs) > 1 else "an axis",
-                  size)
-                for size, idxs in sizes.items()]
-      raise ValueError(msg.format("\n".join(lines1 + ["so"] + lines2))) from None
-    else:
+  axis_sizes = core.dedup_referents(
+      _get_axis_size(name, np.shape(x), d) for x, d in zip(vals, dims)
+      if d is not None)
+  if len(axis_sizes) == 1:
+    return axis_sizes[0]
+  if not axis_sizes:
+    msg = f"{name} must have at least one non-None value in in_axes"
+    raise ValueError(msg)
+  msg = f"{name} got inconsistent sizes for array axes to be mapped:\n" + "{}"
+  # we switch the error message based on whether args is a tuple of arrays,
+  # in which case we can produce an error message based on argument indices,
+  # or if it has nested containers.
+  if kws:
+    position_only_tree, leaf = treedef_children(tree)
+    if not treedef_is_leaf(leaf):
       sizes = [x.shape[d] if d is not None else None for x, d in zip(vals, dims)]
       sizes = tree_unflatten(tree, sizes)
       raise ValueError(msg.format(f"the tree of axis sizes is:\n{sizes}")) from None
+    # if keyword arguments are included in the tree, we adapt the error
+    # message only to be about the positional arguments
+    tree = position_only_tree
+
+  # TODO(mattjj,phawkins): add a way to inspect pytree kind more directly
+  if tree == tree_flatten((0,) * tree.num_leaves)[1]:
+    lines1 = [f"arg {i} has shape {np.shape(x)} and axis {d} is to be mapped"
+              for i, (x, d) in enumerate(zip(vals, dims))]
+    sizes = collections.defaultdict(list)
+    for i, (x, d) in enumerate(zip(vals, dims)):
+      if d is not None:
+        sizes[x.shape[d]].append(i)
+    lines2 = ["{} {} {} {} to be mapped of size {}".format(
+                "args" if len(idxs) > 1 else "arg",
+                ", ".join(map(str, idxs)),
+                "have" if len(idxs) > 1 else "has",
+                "axes" if len(idxs) > 1 else "an axis",
+                size)
+              for size, idxs in sizes.items()]
+    raise ValueError(msg.format("\n".join(lines1 + ["so"] + lines2))) from None
+  else:
+    sizes = [x.shape[d] if d is not None else None for x, d in zip(vals, dims)]
+    sizes = tree_unflatten(tree, sizes)
+    raise ValueError(msg.format(f"the tree of axis sizes is:\n{sizes}")) from None
+
 
 def pmap(
     fun: Callable,

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -21,7 +21,7 @@ import operator
 import types
 import threading
 from typing import (Any, Callable, Dict, Iterable, List, Tuple, Generic,
-                    TypeVar, Set, Iterator, Sequence)
+                    TypeVar, Set, Iterator, Sequence, Optional)
 import weakref
 
 from absl import logging
@@ -546,3 +546,18 @@ class OrderedSet(Generic[T]):
 
   def __contains__(self, elt: T) -> bool:
     return elt in self.elts_set
+
+
+class HashableWrapper:
+  x: Any
+  hash: Optional[int]
+  def __init__(self, x):
+    self.x = x
+    try: self.hash = hash(x)
+    except: self.hash = None
+  def __hash__(self):
+    return self.hash if self.hash is not None else id(self.x)
+  def __eq__(self, other):
+    if not isinstance(other, HashableWrapper):
+      return False
+    return self.x == other.x if self.hash is not None else self.x is other.x

--- a/jax/core.py
+++ b/jax/core.py
@@ -43,7 +43,7 @@ from jax import linear_util as lu
 from jax._src import source_info_util
 from jax._src.util import (safe_zip, safe_map, curry, prod, tuple_insert,
                         tuple_delete, as_hashable_function,
-                        HashableFunction, weakref_lru_cache)
+                        HashableFunction, HashableWrapper, weakref_lru_cache)
 import jax._src.pretty_printer as pp
 from jax._src import lib
 from jax._src.lib import jax_jit
@@ -1039,6 +1039,9 @@ def get_referent(x: Any) -> Any:
 def same_referent(x: Any, y: Any) -> bool:
   return get_referent(x) is get_referent(y)
 
+def dedup_referents(itr: Iterable[Any]) -> List[Any]:
+  return list({HashableWrapper(get_referent(x)):x for x in itr}.values())
+
 
 # -------------------- abstract values --------------------
 
@@ -1405,7 +1408,7 @@ def primal_dtype_to_tangent_dtype(primal_dtype):
 # Tracer (while tracing), Var (when used as jaxpr type annotations), or
 # DBIdx/InDBIdx/OutDBIdx (when used in InputType or OutputType). We could reduce
 # this polymorphism if it seems cleaner, though it's kind of convenient!
-AxisSize = Any
+AxisSize = Union[int, 'BInt', Tracer, Var, DBIdx, InDBIdx, OutDBIdx]
 
 class DShapedArray(UnshapedArray):
   __slots__ = ['shape']
@@ -2070,16 +2073,16 @@ def process_env_traces_map(primitive: MapPrimitive, level: int,
   yield outs, (tuple(todo), tuple(out_axes_transforms))
 
 
-def mapped_aval(size: int, axis: Optional[int], aval: AbstractValue
-                ) -> AbstractValue:
+def mapped_aval(size: AxisSize, axis: Optional[int],
+                aval: AbstractValue) -> AbstractValue:
   handler, _ = aval_mapping_handlers.get(type(aval), (None, None))
   if handler is not None:
     return handler(size, axis, aval)
   else:
     raise TypeError(f"no mapping handler for {aval} of type {type(aval)}")
 
-def unmapped_aval(size: int, axis_name, axis: Optional[int], aval: AbstractValue
-                  ) -> AbstractValue:
+def unmapped_aval(size: AxisSize, axis_name, axis: Optional[int],
+                  aval: AbstractValue) -> AbstractValue:
   _, handler = aval_mapping_handlers.get(type(aval), (None, None))
   if handler is not None:
     return handler(size, axis_name, axis, aval)
@@ -2103,19 +2106,18 @@ def _unmap_shaped_array(size: int, axis_name, axis: Optional[int],
   return ShapedArray(tuple_insert(aval.shape, axis, size), aval.dtype,
                      named_shape=named_shape, weak_type=aval.weak_type)
 
-def _map_dshaped_array(size: Union[int, Tracer], axis: Optional[int],
-                       aval: ShapedArray) -> ShapedArray:
-  assert False  # TODO(mattjj, dougalm)
+def _map_dshaped_array(size: AxisSize, axis: Optional[int],
+                       aval: DShapedArray) -> DShapedArray:
+  if axis is None: return aval
+  return DShapedArray(tuple_delete(aval.shape, axis), aval.dtype,
+                      aval.weak_type)
 
 def _unmap_dshaped_array(
-    size: Union[int, Tracer], axis_name, axis: Optional[int],
+    size: AxisSize, axis_name, axis: Optional[int],
     aval: DShapedArray) -> DShapedArray:
-  if isinstance(size, int):
-    if axis is None: return aval
-    return DShapedArray(tuple_insert(aval.shape, axis, size), aval.dtype,
-                        weak_type=aval.weak_type)
-  else:
-    assert False  # TODO(mattjj, dougalm)
+  if axis is None: return aval
+  return DShapedArray(tuple_insert(aval.shape, axis, size), aval.dtype,
+                      weak_type=aval.weak_type)
 
 AvalMapHandlerPair = Tuple[Callable, Callable]
 aval_mapping_handlers: Dict[Type, AvalMapHandlerPair] = {


### PR DESCRIPTION
The purpose of this PR is to make some basic parts of `vmap` work with vmapping over an axis with a dynamic size.

A dynamically-sized axis has, during tracing, a `Tracer` rather than an `int` representing its size. Yet some parts of the `vmap` code were written assuming that axis sizes are hashable. For example, we used idioms like `axis_size, = {x.shape[d] for x, d in zip(args, batch_dims) if d is not not_mapped}`. But `Tracer`s are not hashable!

To ensure that axis sizes agree, even ones represented by `Tracer`s, it's sufficient but not necessary for the `Tracer`s to be the same objects. Instead they just need to refer to equal objects (or identical when necessary). That is, we need them to have the same `core.get_referent` result. The `core.dedup_referents` function basically achieves the same thing as the previous set-based logic, but using this `core.get_referent` logic.

So the heart of this change is just:
1. adding `core.dedup_referents`;
2. calling it in a few places in batching.py and api.py where we used to rely on hashability to form singleton sets; and
3. fixing `_update_annotation` in batching.py, since it was just buggy and untested.

This PR is just a first step! More to follow.