### PR TITLE
[sparse] remove deprecated bcoo_add_batch_dim utility

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -188,7 +188,6 @@ from jax.experimental.sparse.ad import (
     value_and_grad as value_and_grad,
 )
 from jax.experimental.sparse.bcoo import (
-    bcoo_add_batch_dim,  # TODO(jakevdp) remove this function
     bcoo_broadcast_in_dim as bcoo_broadcast_in_dim,
     bcoo_concatenate as bcoo_concatenate,
     bcoo_dot_general as bcoo_dot_general,

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1612,24 +1612,6 @@ def bcoo_update_layout(mat, *, n_batch=None, n_dense=None, on_inefficient='error
   return BCOO((new_data, new_indices), shape=shape)
 
 
-def bcoo_add_batch_dim(M):
-  """Convert a sparse dimension to a batch dimension
-
-  Please note that this function may result in a far less efficient storage scheme
-  for the matrix (storage required will increase by a factor of `M.shape[0] * M.nse`).
-  This utility is provided for convenience, e.g. to allow vmapping over non-batched
-  matrices.
-
-  Args:
-    M: BCOO matrix
-
-  Returns:
-    M2: BCOO matrix with n_batch = M.n_batch + 1 and n_sparse = M.n_sparse - 1
-  """
-  warnings.warn("bcoo_add_batch_dim is deprecated; use bcoo_update_layout instead", DeprecationWarning)
-  return bcoo_update_layout(M, n_batch=M.n_batch + 1, on_inefficient=None)
-
-
 def bcoo_broadcast_in_dim(mat, *, shape, broadcast_dimensions):
   """Expand the size and rank of a BCOO array by duplicating the data.
 

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1991,26 +1991,6 @@ class BCOOTest(jtu.JaxTestCase):
       self.assertArraysEqual(Msp_dense, M)
 
   @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_nbatch={}_ndense={}".format(
-        jtu.format_shape_dtype_string(shape, dtype), n_batch, n_dense),
-       "shape": shape, "dtype": dtype, "n_batch": n_batch, "n_dense": n_dense}
-      for shape in [(5,), (5, 8), (8, 5), (3, 4, 5), (3, 4, 3, 2)]
-      for dtype in jtu.dtypes.floating + jtu.dtypes.complex
-      for n_batch in range(len(shape))
-      for n_dense in range(len(shape) - n_batch)))
-  def test_bcoo_add_batch_dim(self, shape, dtype, n_batch, n_dense):
-    # TODO(jakevdp): remove this test in favor of bcoo_update_layout
-    rng_sparse = rand_sparse(self.rng())
-    M1 = sparse.BCOO.fromdense(rng_sparse(shape, dtype), n_batch=n_batch, n_dense=n_dense)
-    with jtu.ignore_warning(category=DeprecationWarning):
-      M2 = sparse.bcoo_add_batch_dim(M1)
-    self.assertEqual(M2.n_batch, M1.n_batch + 1)
-    self.assertEqual(M1.n_dense, M2.n_dense)
-    self.assertEqual(M1.shape, M2.shape)
-    self.assertEqual(M1.dtype, M2.dtype)
-    self.assertArraysEqual(M1.todense(), M2.todense())
-
-  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_{}_nbatch={}->{}_ndense={}->{}".format(
         jtu.format_shape_dtype_string(shape, dtype),
         n_batch, n_batch_out, n_dense, n_dense_out),


### PR DESCRIPTION
This was deprecated two months ago in #10566; since `jax.experimental` is not covered by the API deprecation policy, I think this is a sufficient amount of time.