### PR TITLE
Use asarray rather than array in ScalarMeta

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -156,7 +156,7 @@ class _ScalarMeta(type):
     return not (self == other)
 
   def __call__(self, x):
-    return array(x, dtype=self.dtype)
+    return asarray(x, dtype=self.dtype)
 
   def __instancecheck__(self, instance):
     return isinstance(instance, self.dtype.type)


### PR DESCRIPTION
Why? This will make it so that `jnp.int32(x)` and friends no longer insert a gratuitous `copy_p` operation in the jaxpr.

Note: when this was initially implemented, `copy_p` was not a thing, and so using `array` here did not generate a copy. Somewhere along the line we added `copy_p`, and used it in `array` (which defaults to `copy=True`). We don't actually need a copy here, because `convert_element_type` will generate a copy if needed. The only thing this *might* break is if someone is using buffer donation in conjunction with a call to a `jnp` dtype, but I suspect that's rare, and any such use-case should probably rely on an explicit copy instead.