### PR TITLE
Fix definition of treedef_is_leaf.

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -90,6 +90,9 @@ def treedef_children(treedef):
 def treedef_is_leaf(treedef):
   return treedef.num_nodes == 1
 
+def treedef_is_strict_leaf(treedef):
+  return treedef.num_nodes == 1 and treedef.num_leaves == 1
+
 def all_leaves(iterable, is_leaf: Optional[Callable[[Any], bool]] = None):
   """Tests whether all elements in the given iterable are all leaves.
 
@@ -433,7 +436,7 @@ class FlattenedKeyPathEntry(KeyPathEntry):  # fallback
     return f'[<flat index {self.key}>]'
 
 def _child_keys(pytree: Any) -> List[KeyPathEntry]:
-  assert not treedef_is_leaf(tree_structure(pytree))
+  assert not treedef_is_strict_leaf(tree_structure(pytree))
   handler = _keypath_registry.get(type(pytree))
   if handler:
     return handler(pytree)
@@ -461,7 +464,7 @@ def _prefix_error(key_path: KeyPath, prefix_tree: Any, full_tree: Any,
                   is_leaf: Optional[Callable[[Any], bool]] = None,
                   ) -> Iterable[Callable[[str], ValueError]]:
   # A leaf is a valid prefix of any tree:
-  if treedef_is_leaf(tree_structure(prefix_tree, is_leaf=is_leaf)): return
+  if treedef_is_strict_leaf(tree_structure(prefix_tree, is_leaf=is_leaf)): return
 
   # The subtrees may disagree because their roots are of different types:
   if type(prefix_tree) != type(full_tree):

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -528,6 +528,14 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
   def test_no_errors(self):
     () = prefix_errors((1, 2), ((11, 12, 13), 2))
 
+  def test_different_structure_no_children(self):
+    e, = prefix_errors({}, {'a': []})
+    expected = ("pytree structure error: different numbers of pytree children "
+                "at key path\n"
+                "    in_axes tree root")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Empty nodes like [] and {} have 1 node and 0 leaves. This does not make
them a leaf treedef.

Reproducer:
```
pjit.pjit(lambda x: x, None, (None, {}))((3, {'a': []}))
```