### PR TITLE
Point to the right download for jaxlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,10 @@ version for jaxlib explicitly:
 pip install --upgrade pip
 
 # Installs the wheel compatible with Cuda >= 11.4 and cudnn >= 8.2
-pip install "jax[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install "jaxlib[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # Installs the wheel compatible with Cuda >= 11.1 and cudnn >= 8.0.5
-pip install "jax[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install "jaxlib[cuda11_cudnn805]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 You can find your CUDA version with the command:


### PR DESCRIPTION
The download right now instructs to express the download as 

```bash
pip install "jax[cuda11_cudnn84]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
```

in the code-block for jaxlib. This only downloads jax itself. Instead pointing to jaxlib as in 

```bash
pip install --upgrade "jaxlib[cuda11_cudnn84]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
```

Downloads the right jaxlib.