### PR TITLE
CI: upgrade doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,16 +1,10 @@
 sphinx >=3
-sphinx_rtd_theme
+sphinx-autodoc-typehints==1.11.1  # Unpin after jaxlib 0.3.15 is released (#11455)
 sphinx-book-theme
-sphinx-remove-toctrees
-# Newer versions cause issues; see https://github.com/google/jax/pull/6449
-sphinx-autodoc-typehints==1.11.1
 sphinx-copybutton>=0.5.0
+sphinx-remove-toctrees
 jupyter-sphinx>=0.3.2
 myst-nb
-
-# Need to pin docutils to 0.16 to make bulleted lists appear correctly on
-# ReadTheDocs: https://stackoverflow.com/a/68008428
-docutils==0.16.0
 
 # Packages used for CI tests.
 pytest


### PR DESCRIPTION
The reasons for pinning these requirements are now stale:

- We no longer use `sphinx-rtd-theme`, so we can remove the requirement
- The `docutils` pinning was due to a poor interaction with `sphinx-rtd-theme`
- The `sphinx-autodoc-typehints` issue has been fixed in [v1.15.0](https://github.com/tox-dev/sphinx-autodoc-typehints/blob/main/CHANGELOG.md#1150), although ~newer versions require setting the `set_type_checking_flag` config to avoid warnings about how we define `PyTreeDef`~ the issue fixed by #11455 causes unrelated issues for newer versions of the extension