### PR TITLE
lax_numpy_test: make compatible with upstream numpy

### DIFF
--- a/.github/workflows/upstream-nightly.yaml
+++ b/.github/workflows/upstream-nightly.yaml
@@ -48,7 +48,7 @@ jobs:
             scipy
       - name: Install JAX
         run: |
-          pip install .[cpu]
+          pip install .[minimum-jaxlib]
       - name: Run tests
         if: success()
         id: status

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6404,7 +6404,10 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'einsum': ['kwargs'],
       'einsum_path': ['einsum_call'],
       'eye': ['order', 'like'],
+      'hstack': ['dtype', 'casting'],
       'identity': ['like'],
+      'in1d': ['kind'],
+      'isin': ['kind'],
       'full': ['order', 'like'],
       'full_like': ['subok', 'order'],
       'fromfunction': ['like'],
@@ -6413,8 +6416,11 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'histogramdd': ['normed'],
       'ones': ['order', 'like'],
       'ones_like': ['subok', 'order'],
+      'row_stack': ['dtype', 'casting'],
+      'stack': ['dtype', 'casting'],
       'tri': ['like'],
       'unique': ['equal_nan'],
+      'vstack': ['dtype', 'casting'],
       'zeros_like': ['subok', 'order']
     }
 
@@ -6436,6 +6442,10 @@ class NumpySignaturesTest(jtu.JaxTestCase):
         continue
       if numpy_version < (1, 22) and name in ['quantile', 'nanquantile',
                                               'percentile', 'nanpercentile']:
+        continue
+      if numpy_version >= (1, 24) and name in ['histogram', 'histogram2d', 'histogramdd']:
+        # numpy 1.24 re-orders the density and weights arguments.
+        # TODO(jakevdp): migrate histogram APIs to match newer numpy versions.
         continue
       # Note: can't use inspect.getfullargspec due to numpy issue
       # https://github.com/numpy/numpy/issues/12225


### PR DESCRIPTION
This fixes the upstream-dev build breakage in #11480 (see https://github.com/google/jax/runs/7326196684?check_suite_focus=true)

~The reason for the changes to the `histogram*` APIs is that numpy has changed the order of the keyword arguments to these functions when removing the deprecated `normed` argument (see https://github.com/numpy/numpy/pull/21645).~

~Our numpy API tests check that argument order matches between JAX and numpy. While we could choose to diverge from numpy on this and keep JAX's current argument order (making an exception in the test for these APIs), in my judgment it's better to try to maintain compatibility with numpy's positional argument API as numpy evolves. What do you think?~

Opted instead to leave the APIs alone for now, and just fix the tests (with a TODO to update the APIs later)