### PR TITLE
Populate long_description for jax & jaxlib

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -41,6 +41,7 @@ py_binary(
     data = [
         "LICENSE.txt",
         "//jaxlib",
+        "//jaxlib:README.md",
         "//jaxlib:setup.py",
         "//jaxlib:setup.cfg",
         "@org_tensorflow//tensorflow/compiler/xla/python:xla_client",

--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -163,6 +163,7 @@ def prepare_wheel(sources_path):
 
   verify_mac_libraries_dont_reference_chkstack()
   copy_file("__main__/build/LICENSE.txt", dst_dir=sources_path)
+  copy_file("__main__/jaxlib/README.md", dst_dir=sources_path)
   copy_file("__main__/jaxlib/setup.py", dst_dir=sources_path)
   copy_file("__main__/jaxlib/setup.cfg", dst_dir=sources_path)
   copy_to_jaxlib("__main__/jaxlib/init.py", dst_filename="__init__.py")

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -82,6 +82,7 @@ symlink_files(
 )
 
 exports_files([
+    "README.md",
     "setup.py",
     "setup.cfg",
 ])

--- a/jaxlib/README.md
+++ b/jaxlib/README.md
@@ -1,0 +1,7 @@
+# jaxlib: support library for JAX
+
+jaxlib is the support library for JAX. While JAX itself is a pure Python package,
+jaxlib contains the binary (C/C++) parts of the library, including Python bindings,
+the XLA compiler, the PJRT runtime, and a handful of handwritten kernels.
+For more information, including installation and build instructions, refer to main
+JAX README: https://github.com/google/jax/.

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -21,6 +21,9 @@ project_name = 'jaxlib'
 with open('jaxlib/version.py') as f:
   exec(f.read(), globals())
 
+with open('README.md') as f:
+  _long_description = f.read()
+
 cuda_version = os.environ.get("JAX_CUDA_VERSION")
 cudnn_version = os.environ.get("JAX_CUDNN_VERSION")
 if cuda_version and cudnn_version:
@@ -34,6 +37,8 @@ setup(
     name=project_name,
     version=__version__,
     description='XLA library for JAX',
+    long_description=_long_description,
+    long_description_content_type='text/markdown',
     author='JAX team',
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension'],

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,15 @@ with open('jax/version.py') as f:
 __version__ = _dct['__version__']
 _minimum_jaxlib_version = _dct['_minimum_jaxlib_version']
 
+with open('README.md') as f:
+  _long_description = f.read()
+
 setup(
     name='jax',
     version=__version__,
     description='Differentiate, compile, and transform Numpy code.',
+    long_description=_long_description,
+    long_description_content_type='text/markdown',
     author='JAX team',
     author_email='jax-dev@google.com',
     packages=find_packages(exclude=["examples"]),


### PR DESCRIPTION
I noticed that the PyPI pages for [jax](https://pypi.org/project/jax/) and [jaxlib](https://pypi.org/project/jaxlib/) do not contain any project descriptions. This update to the `setup.py` files should result in the README contents being propagated to those pages on the next release.

For JAX, I tested this by using the approach mentioned in the [Python docs](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup):
```
$ python setup.py sdist
$ twine check sdist/*
```
I confirmed that this is doing the correct check by removing `long_description_content_type`, and observing that the `twine check` returns an appropriate error.

I did not do such a check for jaxlib, because I'm not set up to easily build it locally.
