### PR TITLE
upstream-dev: add failure information to CI issues

### DIFF
--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script used in the upstream-dev workflow in order to parse pytest logs."""
+
+
+import argparse
+import json
+
+from pytest import TestReport
+
+
+MSG_FORMAT = """\
+<details><summary>Summary of Failures</summary>
+
+```
+{summary}
+```
+
+</details>
+"""
+
+
+def main(logfile, outfile):
+  failures = []
+
+  with open(logfile, 'r') as f:
+    for line in f:
+      parsed = json.loads(line)
+      report_type = parsed['$report_type']
+      if report_type == "TestReport":
+        parsed = TestReport._from_json(parsed)
+        if parsed.outcome == "failed":
+          failures.append(parsed)
+
+  summary = "\n".join(f"{f.nodeid}: {f.longrepr.chain[0][1].message}"
+                      for f in failures)
+  print(f"writing to {outfile}")
+  with open(outfile, 'w') as f:
+    f.write(MSG_FORMAT.format(summary=summary))
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument("logfile", help="The path to the input logfile")
+  parser.add_argument("--outfile", help="The path to the parsed output file to be created.",
+                      default="parsed_logs.txt")
+  args = parser.parse_args()
+  main(logfile=args.logfile, outfile=args.outfile)

--- a/.github/workflows/upstream-nightly.yaml
+++ b/.github/workflows/upstream-nightly.yaml
@@ -97,21 +97,25 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: /tmp/workspace/logs
+      - name: install requirements
+        run: |
+          python -m pip install pytest
       - name: Move all log files into a single directory
         run: |
           rsync -a /tmp/workspace/logs/output-*/ ./logs
           ls -R ./logs
           cat logs/*.jsonl > pytest-logs.txt
+          python .github/workflows/parse_logs.py pytest-logs.txt --outfile=parsed-logs.txt
       - name: Report failures
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
+            const parsed_logs = fs.readFileSync('parsed-logs.txt', 'utf8');
             const title = "⚠️ Nightly upstream-dev CI failed ⚠️"
             const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-            const issue_body = `[Workflow Run URL](${workflow_url})`
+            const issue_body = `[Workflow Run URL](${workflow_url})\n${parsed_logs}`
             // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
             const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
               repository(owner: $owner, name: $name) {


### PR DESCRIPTION
The purpose of this change is to add summary information to the automated issue created when the nightly upstream-dev CI fails.

Opened from a non-fork due to github actions permissions & tested by changing `'schedule'` to `'pull_request'` in the report job, and confirming that the parsed logs end up in the relevant issue description, as seen in the latest edit to https://github.com/google/jax/issues/11480.