### PR TITLE
Fix stacklevel for _check_user_dtype_supported

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -4738,4 +4738,4 @@ def _check_user_dtype_supported(dtype, fun_name=None):
            "See https://github.com/google/jax#current-gotchas for more.")
     fun_name = f"requested in {fun_name}" if fun_name else ""
     truncated_dtype = dtypes.canonicalize_dtype(dtype).name
-    warnings.warn(msg.format(dtype, fun_name , truncated_dtype), stacklevel=2)
+    warnings.warn(msg.format(dtype, fun_name , truncated_dtype), stacklevel=3)


### PR DESCRIPTION
Before this change, JAX generates warnings referring to the _internal_
line inside JAX where `_check_user_dtype_supported` is called:

    In [1]: import jax.numpy as jnp

    In [2]: jnp.zeros(2, jnp.float64)
    /Users/shoyer/dev/jax/jax/_src/numpy/lax_numpy.py:1976: UserWarning: Explicitly requested dtype <class 'jax.numpy.float64'> requested in zeros is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
    lax_internal._check_user_dtype_supported(dtype, "zeros")
    Out[2]: DeviceArray([0., 0.], dtype=float32)

Now it generates warnings referring to user code:

    In [1]: import jax.numpy as jnp

    In [2]: jnp.zeros(2, jnp.float64)
    <ipython-input-2-dc38008f18e8>:1: UserWarning: Explicitly requested dtype <class 'jax.numpy.float64'> requested in zeros is not available, and will be truncated to dtype float32. To enable more dtypes, set the jax_enable_x64 configuration option or the JAX_ENABLE_X64 shell environment variable. See https://github.com/google/jax#current-gotchas for more.
    jnp.zeros(2, jnp.float64)
    Out[2]: DeviceArray([0., 0.], dtype=float32)