### PR TITLE
maintain an alias to `tree_util.tree_map` in the top level `jax` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
   * Binary operations between JAX arrays and built-in collections (`dict`, `list`, `set`, `tuple`)
     now raise a `TypeError` in all cases. Previously some cases (particularly equality and inequality)
     would return boolean scalars inconsistent with similar operations in NumPy ({jax-issue}`#11234`).
-  * {mod}`jax.tree_util` routines accessed as top-level JAX package imports are now deprecated, and
-    will be removed in a future JAX release in accordance with the {ref}`api-compatibility` policy:
+  * Several {mod}`jax.tree_util` routines accessed as top-level JAX package imports are now
+    deprecated, and will be removed in a future JAX release in accordance with the
+    {ref}`api-compatibility` policy:
     * {func}`jax.treedef_is_leaf` is deprecated in favor of {func}`jax.tree_util.treedef_is_leaf`
     * {func}`jax.tree_flatten` is deprecated in favor of {func}`jax.tree_util.tree_flatten`
     * {func}`jax.tree_leaves` is deprecated in favor of {func}`jax.tree_util.tree_leaves`
-    * {func}`jax.tree_map` is deprecated in favor of {func}`jax.tree_util.tree_map`
     * {func}`jax.tree_structure` is deprecated in favor of {func}`jax.tree_util.tree_structure`
     * {func}`jax.tree_transpose` is deprecated in favor of {func}`jax.tree_util.tree_transpose`
     * {func}`jax.tree_unflatten` is deprecated in favor of {func}`jax.tree_util.tree_unflatten`

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -115,12 +115,12 @@ from jax.experimental.maps import soft_pmap as soft_pmap
 from jax.version import __version__ as __version__
 from jax.version import __version_info__ as __version_info__
 
-# TODO(jakevdp): remove these deprecated routines after October 2022
 from jax._src.tree_util import (
+  tree_map as tree_map,
+  # TODO(jakevdp): remove these deprecated routines after October 2022
   _deprecated_treedef_is_leaf as treedef_is_leaf,
   _deprecated_tree_flatten as tree_flatten,
   _deprecated_tree_leaves as tree_leaves,
-  _deprecated_tree_map as tree_map,
   _deprecated_tree_multimap as tree_multimap,
   _deprecated_tree_structure as tree_structure,
   _deprecated_tree_transpose as tree_transpose,


### PR DESCRIPTION
Keeping this one since it is very commonly invoked by user code, and doing so was requested several times (offline).

related: #11400