### PR TITLE
[sparse] make sparse objects compatible with jax.jit.lower()

### DIFF
--- a/jax/experimental/sparse/util.py
+++ b/jax/experimental/sparse/util.py
@@ -18,6 +18,7 @@ import numpy as np
 import jax
 from jax import core
 from jax._src import dtypes
+from jax._src import stages
 import jax.numpy as jnp
 
 class SparseEfficiencyError(ValueError):
@@ -54,12 +55,15 @@ def _is_pytree_placeholder(*args):
 def _is_aval(*args):
   return all(isinstance(arg, core.AbstractValue) for arg in args)
 
+def _is_arginfo(*args):
+  return all(isinstance(arg, stages.ArgInfo) for arg in args)
+
 def _asarray_or_float0(arg):
   if isinstance(arg, np.ndarray) and arg.dtype == dtypes.float0:
     return arg
   return jnp.asarray(arg)
 
 def _safe_asarray(args):
-  if _is_pytree_placeholder(*args) or _is_aval(*args):
+  if _is_pytree_placeholder(*args) or _is_aval(*args) or _is_arginfo(*args):
     return args
   return map(_asarray_or_float0, args)

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -2074,6 +2074,15 @@ class SparseGradTest(jtu.JaxTestCase):
 class SparseObjectTest(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
+    {"testcase_name": f"_{cls.__name__}", "cls": cls}
+    for cls in [sparse.CSR, sparse.CSC, sparse.COO, sparse.BCOO])
+  def test_jit_lower(self, cls):
+    sparse_format = cls.__name__.lower()
+    M = sparse.empty((2, 4), sparse_format=sparse_format)
+    self.assertIsInstance(M, cls)
+    jax.jit(lambda x: x).lower(M)  # doesn't crash
+
+  @parameterized.named_parameters(
     {"testcase_name": f"_{cls.__name__}{shape}", "cls": cls, "shape": shape}
     for cls in [sparse.CSR, sparse.CSC, sparse.COO, sparse.BCOO]
     for shape in ([2, 5], [5, 3]))


### PR DESCRIPTION
The isse is that when lowering, a pytree of `stages.ArgInfo` objects is constructed, and this was leading to an error on sparse object validation.