### PR TITLE
Add dlpack support to device_array and jax.numpy

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -180,6 +180,7 @@ namespace; they are listed below.
     fromfunction
     fromiter
     fromstring
+    from_dlpack
     full
     full_like
     gcd

--- a/jax/_src/device_array.py
+++ b/jax/_src/device_array.py
@@ -266,6 +266,12 @@ for device_array in [DeviceArray]:
 
   setattr(device_array, "__array__", __array__)
 
+  def __dlpack__(self):
+    from jax.dlpack import to_dlpack  # pylint: disable=g-import-not-at-top
+    return to_dlpack(self)
+
+  setattr(device_array, "__dlpack__", __dlpack__)
+
   def __reduce__(self):
     fun, args, arr_state = self._value.__reduce__()
     aval_state = {'weak_type': self.aval.weak_type,

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -2064,6 +2064,10 @@ def fromiter(*args, **kwargs):
     "because of its potential side-effect of consuming the iterable object; for more information see "
     "https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#pure-functions")
 
+@_wraps(getattr(np, "from_dlpack", None))
+def from_dlpack(x):
+  from jax.dlpack import from_dlpack  # pylint: disable=g-import-not-at-top
+  return from_dlpack(x.__dlpack__())
 
 @_wraps(np.fromfunction)
 def fromfunction(function, shape, *, dtype=float, **kwargs):

--- a/jax/_src/numpy/ndarray.py
+++ b/jax/_src/numpy/ndarray.py
@@ -275,6 +275,8 @@ class ndarray(metaclass=ArrayMeta):
   # implement the NumPy ArrayLike protocol.
   def __array__(self) -> Any: ...
 
+  def __dlpack__(self) -> Any: ...
+
   # JAX extensions
   @property
   @abc.abstractmethod

--- a/jax/core.py
+++ b/jax/core.py
@@ -533,6 +533,10 @@ class Tracer:
   def __array__(self, *args, **kw):
     raise TracerArrayConversionError(self)
 
+  def __dlpack__(self, *args, **kw):
+    raise ConcretizationTypeError(self,
+      f"The __dlpack__() method was called on the JAX Tracer object {self}")
+
   def __index__(self):
     raise TracerIntegerConversionError(self)
 

--- a/jax/numpy/__init__.py
+++ b/jax/numpy/__init__.py
@@ -116,6 +116,7 @@ from jax._src.numpy.lax_numpy import (
     fromfunction as fromfunction,
     fromiter as fromiter,
     fromstring as fromstring,
+    from_dlpack as from_dlpack,
     full as full,
     full_like as full_like,
     gcd as gcd,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6389,7 +6389,7 @@ class NumpySignaturesTest(jtu.JaxTestCase):
     """Test that jax.numpy function signatures match numpy."""
     jnp_funcs = {name: getattr(jnp, name) for name in dir(jnp)}
     func_pairs = {name: (fun, fun.__np_wrapped__) for name, fun in jnp_funcs.items()
-                  if hasattr(fun, '__np_wrapped__')}
+                  if getattr(fun, '__np_wrapped__', None) is not None}
     assert len(func_pairs) > 0
 
     # TODO(jakevdp): fix some of the following signatures. Some are due to wrong argument names.


### PR DESCRIPTION
This adds the `__dlpack__` interface to `DeviceArray`, as well as a new `jax.numpy.from_dlpack` function with the same API as [`numpy.from_dlpack`](https://numpy.org/devdocs/reference/generated/numpy.from_dlpack.html), which was added to numpy in version 1.22.0.

With this interface defined, the following is possible:
```python
In [1]: import numpy as np

In [2]: import jax.numpy as jnp

In [3]: jnp.from_dlpack(np.arange(5))
Out[3]: DeviceArray([0, 1, 2, 3, 4], dtype=int64)

In [4]: np.from_dlpack(jnp.arange(5))
Out[4]: array([0, 1, 2, 3, 4], dtype=int32)
```
The cool thing is this dlpack interface is already supported by other libraries like pytorch, so this allows interop with that package as well:
```python
In [5]: import torch

In [6]: jnp.from_dlpack(torch.arange(5))
Out[6]: DeviceArray([0, 1, 2, 3, 4], dtype=int64)
```

Fixes #11496