### PR TITLE
pretty_printing: handle case where stdout is patched by a logger

### DIFF
--- a/jax/_src/pretty_printer.py
+++ b/jax/_src/pretty_printer.py
@@ -51,7 +51,7 @@ def _can_use_color() -> bool:
   except NameError:
     pass
   # Otherwise check if we're in a terminal
-  return sys.stdout.isatty()
+  return hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
 
 CAN_USE_COLOR = _can_use_color()
 


### PR DESCRIPTION
Fixes issue introduced by https://github.com/google/jax/pull/10688 in which users who patch `sys.stdout` get an error in the recent JAX release. Example reports:

- https://github.com/google/jax/issues/11508
- https://github.com/googlecolab/colabtools/issues/2926

Technically, I think we should expect the user to provide the full interface when patching stdout, but this is a small enough change that if it saves folks some trouble, I think it's worth doing.