### PR TITLE
[Docs] Update docs for div and rem

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -455,21 +455,21 @@ def mul(x: Array, y: Array) -> Array:
 def div(x: Array, y: Array) -> Array:
   r"""Elementwise division: :math:`x \over y`.
 
-  Integer division overflow 
-  (division by zero or signed division of INT_SMIN with -1) 
+  Integer division overflow
+  (division by zero or signed division of INT_SMIN with -1)
   produces an implementation defined value.
   """
   return div_p.bind(x, y)
 
 def rem(x: Array, y: Array) -> Array:
   r"""Elementwise remainder: :math:`x \bmod y`.
-  
-  The sign of the result is taken from the dividend, 
-  and the absolute value of the result is always 
+
+  The sign of the result is taken from the dividend,
+  and the absolute value of the result is always
   less than the divisor's absolute value.
 
-  Integer division overflow 
-  (remainder by zero or remainder of INT_SMIN with -1) 
+  Integer division overflow
+  (remainder by zero or remainder of INT_SMIN with -1)
   produces an implementation defined value.
   """
   return rem_p.bind(x, y)

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -453,11 +453,25 @@ def mul(x: Array, y: Array) -> Array:
   return mul_p.bind(x, y)
 
 def div(x: Array, y: Array) -> Array:
-  r"""Elementwise division: :math:`x \over y`."""
+  r"""Elementwise division: :math:`x \over y`.
+
+  Integer division overflow 
+  (division by zero or signed division of INT_SMIN with -1) 
+  produces an implementation defined value.
+  """
   return div_p.bind(x, y)
 
 def rem(x: Array, y: Array) -> Array:
-  r"""Elementwise remainder: :math:`x \bmod y`."""
+  r"""Elementwise remainder: :math:`x \bmod y`.
+  
+  The sign of the result is taken from the dividend, 
+  and the absolute value of the result is always 
+  less than the divisor's absolute value.
+
+  Integer division overflow 
+  (remainder by zero or remainder of INT_SMIN with -1) 
+  produces an implementation defined value.
+  """
   return rem_p.bind(x, y)
 
 def max(x: Array, y: Array) -> Array:


### PR DESCRIPTION
Clarify operation semantics for div and rem on overflow.

As per comments on https://github.com/google/jax/issues/11378, these semantics are inherited from [XLA](https://www.tensorflow.org/xla/operation_semantics#element-wise_binary_arithmetic_operations), hence directly copied here.
