### PR TITLE
[dynamic-shapes] Add support for concatenate

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -1635,7 +1635,7 @@ def _clamp(minval, operand, maxval, *, _in_avals, _out_aval):
 tf_impl_with_avals[lax.clamp_p] = _clamp
 
 
-def _concatenate(*operands, dimension):
+def _concatenate(*operands, dimension, **_):
   return tf.concat(operands, axis=dimension)
 
 

--- a/jax/experimental/jax2tf/tests/primitive_harness.py
+++ b/jax/experimental/jax2tf/tests/primitive_harness.py
@@ -2767,7 +2767,7 @@ def _make_concatenate_harness(name,
   define(
       lax.concatenate_p,
       f"{name}_shapes={shapes_str}_dimension={dimension}",
-      lambda *args: lax.concatenate_p.bind(*args, dimension=dimension),
+      lambda *args: lax.concatenate(args, dimension=dimension),
       [RandArg(shape, dtype) for shape in shapes],
       shapes=shapes,
       dtype=dtype,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -612,7 +612,7 @@ def _broadcast_in_dim_sparse(spenv, *spvalues, shape, broadcast_dimensions):
 
 sparse_rules[lax.broadcast_in_dim_p] = _broadcast_in_dim_sparse
 
-def _concatenate_sparse(spenv, *spvalues, dimension):
+def _concatenate_sparse(spenv, *spvalues, dimension, **_):
   operands = spvalues_to_arrays(spenv, spvalues)
   result = sparse.bcoo_concatenate(operands, dimension=dimension)
   return arrays_to_spvalues(spenv, (result,))

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -620,7 +620,7 @@ class DynamicShapeTest(jtu.JaxTestCase):
     self.assertAllClose(f(4), np.ones(4, dtype='float32'), check_dtypes=True)
     self.assertEqual(count, 1)
 
-  @unittest.skip('TODO: need typechecking rule for concatenate')
+  @unittest.skipIf(jtu.device_under_test() != 'iree', "iree test")
   def test_concatenate(self):
     @partial(jax.jit, abstracted_axes=({0: 'n'},))
     def f(x):  # x: f32[n, 4]


### PR DESCRIPTION
In order to add support for concatenating dynamic shapes I add
a new parameter shape to the concatenate primitive to store the output shape.

We pass the shape as a parameter so that it can be computed once,
while lowering lax.concatenate to primitives. At that time we are
in a context where we can stage computations with shapes. This allows
us to keep the staging and typechecking rules free of shape computations.
