### PR TITLE
lax.conv_general_dilated: validate padding in shape rule

### DIFF
--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -812,6 +812,9 @@ def conv_shape_tuple(lhs_shape, rhs_shape, strides, pads, batch_group_count=1):
 
   lhs_padded = np.add(lhs_shape[2:], np.sum(np.array(pads).reshape(-1, 2),
                                               axis=1))
+  if np.any(lhs_padded < 0):
+    raise ValueError("Negative padding is larger than the size of the corresponding dimension: "
+                     f"got padding={pads} for lhs_shape[2:]={lhs_shape[2:]}")
   out_space = core.stride_shape(lhs_padded, rhs_shape[2:], strides)
   out_space = np.maximum(0, out_space)
   if batch_group_count > 1:


### PR DESCRIPTION
Fixes #11517

The code from that issue now gives this result:
```python
In [1]: import jax 
   ...: def fn(lhs, rhs): 
   ...:     window_strides = [1, 1] 
   ...:     padding = [[5, 16], [-5, 1]] 
   ...:     return jax.lax.conv_general_dilated(lhs, rhs, window_strides, padding) 
   ...:  
   ...: mykey = jax.random.PRNGKey(83725540) 
   ...:  
   ...: lhs = jax.numpy.array([[[[-7.0950737, 20.612083, 53.864067], [-12.116554, -16.742317, -7.050851 ]]]]) 
   ...: rhs = jax.numpy.array([[[[29.074692, 40.518192], [21.685156, 41.867775]]]]) 
   ...:  
   ...: fn(lhs, rhs)
---------------------------------------------------------------------------
ValueError
.
.
.
~/github/google/jax/jax/_src/lax/convolution.py in conv_shape_tuple(lhs_shape, rhs_shape, strides, pads, batch_group_count)
    814                                               axis=1))
    815   if np.any(lhs_padded < 0):
--> 816     raise ValueError("Negative padding is larger than the size of the corresponding dimension: "
    817                      f"got padding={pads} for lhs_shape[2:]={lhs_shape[2:]}")
    818   out_space = core.stride_shape(lhs_padded, rhs_shape[2:], strides)

ValueError: Negative padding is larger than the size of the corresponding dimension: got padding=((5, 16), (-5, 1)) for lhs_shape[2:]=(2, 3)
```