### PR TITLE
[dynamic-shapes] fix minor bint bugs

### DIFF
--- a/jax/core.py
+++ b/jax/core.py
@@ -1561,7 +1561,9 @@ raise_to_shaped_mappings : Dict[type, Callable] = {
   Bot: lambda aval, _: aval,
   UnshapedArray: lambda aval, _: aval,
   ShapedArray: lambda aval, weak_type: ShapedArray(
-      aval.shape, aval.dtype, weak_type, aval.named_shape)
+      aval.shape, aval.dtype, weak_type, aval.named_shape),
+  DConcreteArray: lambda aval, weak_type: DShapedArray(
+      aval.shape, aval.dtype, weak_type),
 }
 
 ### Operations on shapes and dimension sizes.

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -245,7 +245,7 @@ def annotate(f: WrappedFun,
   assert (type(in_type) is tuple and all(type(e) is tuple for e in in_type) and
           all(isinstance(a, core.AbstractValue) and type(b) is bool
               and not isinstance(a, core.ConcreteArray) for a, b in in_type) and
-          all(isinstance(d, (int, core.DBIdx)) for a, _ in in_type
+          all(isinstance(d, (int, core.BInt, core.DBIdx)) for a, _ in in_type
               if type(a) is core.DShapedArray for d in a.shape))
   provided = [e for _, e in in_type]
   for aval, _ in in_type:

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1213,6 +1213,16 @@ class DynamicShapeTest(jtu.JaxTestCase):
     self.assertEqual(y, 6)
     self.assertEqual(count, 2)
 
+  def test_bint_add(self):
+    d = lax.make_bint(4, 6)
+    x = jnp.arange(d)
+
+    @jax.jit
+    def f(x):
+      return x + x
+
+    f(x)  # doesn't crash
+
   def test_lower_abstracted_axes(self):
     @partial(jax.jit, abstracted_axes=('n',))
     def f(x):


### PR DESCRIPTION
* add a `core.raise_to_shaped` handler to map` DConcreteArray` -> `DShapedArray` (previously it was surprisingly falling back based on `__mro__`)
* update an assertion in `lu.annotate` to allow `core.BInt`s in the axis sizes in input type signatures
* add a basic test which fails without these changes