### PR TITLE
remove dead code: jax._src.util.taggedtuple

### DIFF
--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -441,18 +441,6 @@ def tuple_delete(t, idx):
   assert 0 <= idx < len(t), (idx, len(t))
   return t[:idx] + t[idx + 1:]
 
-# TODO(mattjj): replace with dataclass when Python 2 support is removed
-def taggedtuple(name, fields) -> Callable[..., Any]:
-  """Lightweight version of namedtuple where equality depends on the type."""
-  def __new__(cls, *xs):
-    return tuple.__new__(cls, (cls,) + xs)
-  def __repr__(self):
-    return f'{name}{tuple.__str__(self[1:])}'
-  class_namespace = {'__new__' : __new__, '__repr__': __repr__}
-  for i, f in enumerate(fields):
-    class_namespace[f] = property(operator.itemgetter(i+1))  # type: ignore
-  return type(name, (tuple,), class_namespace)
-
 class HashableFunction:
   """Decouples function equality and hash from its identity.
 


### PR DESCRIPTION
This utility is unused in the jax package, and is not exported as a public API.