### PR TITLE
DOC: fix pytrees example cross-reference

### DIFF
--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -125,7 +125,7 @@ def register_pytree_node(nodetype: Type[T],
                          unflatten_func: Callable[[_AuxData, _Children], T]):
   """Extends the set of types that are considered internal nodes in pytrees.
 
-  See `example usage <pytrees.html>`_.
+  See :ref:`example usage <pytrees>`.
 
   Args:
     nodetype: a Python type to treat as an internal pytree node.


### PR DESCRIPTION
Fixes broken "example usage" link on this page: https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.register_pytree_node.html