### PR TITLE
add while_loop custom-policy partial eval rule

### DIFF
--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -446,7 +446,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   unks_out: List[bool] = [False] * len(eqn.outvars)
   for jaxpr in branches:
     _, _, unks_out_, _, _ = pe.partial_eval_jaxpr_custom(
-        jaxpr.jaxpr, in_unknowns=ops_uk, in_inst=[True] * len(ops_uk),
+        jaxpr.jaxpr, in_unknowns=ops_uk, in_inst=True,
         ensure_out_unknowns=False, ensure_out_inst=True, saveable=saveable)
     unks_out = map(operator.or_, unks_out, unks_out_)
 
@@ -458,7 +458,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   for jaxpr in branches:
     jaxpr_known, jaxpr_staged, _, inst_out, num_res = \
         pe.partial_eval_jaxpr_custom(
-            jaxpr.jaxpr, in_unknowns=ops_uk, in_inst=[True] * len(ops_uk),
+            jaxpr.jaxpr, in_unknowns=ops_uk, in_inst=True,
             ensure_out_unknowns=unks_out, ensure_out_inst=True,
             saveable=saveable)
     branches_known_.append( core.ClosedJaxpr(jaxpr_known,  jaxpr.consts))
@@ -481,7 +481,7 @@ def _cond_partial_eval_custom(saveable, unks_in, inst_in, eqn):
   # passing in_inst argument to partial_eval_jaxpr_custom above).
   new_inst = [x for x, inst in zip(eqn.invars, inst_in)
               if type(x) is core.Var and not inst]
-  inst_in = [True] * len(inst_in)
+  del inst_in
 
   # Create residual variables.
   newvar = core.gensym()

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1241,11 +1241,13 @@ call_partial_eval_rules[remat_call_p] = _remat_partial_eval
 def partial_eval_jaxpr_custom(
     jaxpr: Jaxpr,
     in_unknowns: Sequence[bool],
-    in_inst: Sequence[bool],
+    in_inst: Union[bool, Sequence[bool]],
     ensure_out_unknowns: Union[bool, Sequence[bool]],
     ensure_out_inst: Union[bool, Sequence[bool]],
     saveable: Callable[..., bool],
   ) -> Tuple[Jaxpr, Jaxpr, List[bool], List[bool], int]:
+  if type(in_inst) is bool:
+    in_inst = (in_inst,) * len(jaxpr.invars)
   if type(ensure_out_unknowns) is bool:
     ensure_out_unknowns = (ensure_out_unknowns,) * len(jaxpr.outvars)
   if type(ensure_out_inst) is bool:


### PR DESCRIPTION
This is the `while_loop` analogue of the new partial evaluation rule for `scan` landed in #10576, and for `cond` landed in #11651.

The custom-remat-policy partial evaluation rule for `while_loop` is actually just the same as the previous (policy-less) partial eval rule, written in a jaxpr-to-jaxpr (rather than trace-time) way. That's because we can't save residuals from `while_loop` anyway, at least not without dynamic shapes. Indeed:
* `while_loop` only supports `jax.linearize`, not `jax.vjp`, and
* with `jax.linearize` we always have to do "full rematerialization", running a full copy of the primal computation along with the linear part in the linearized body.

So the partial evaluation rule just needs to:
1. hoist out the known part of the body and cond functions, and
2. otherwise stage out a full copy of the loop.

As a result, the `_while_partial_eval_custom` function this PR adds is very close to the existing `_while_partial_eval` (except that it accepts/returns `JaxprEqn`s).

I chose to use the `partial_eval_jaxpr_custom` machinery (rather than just using the `partial_eval_jaxpr_nounits` stuff) just for consistency across the custom partial eval rules. I expect we'll do a consolidation pass across the standard- and custom-policy partial evaluation rules at some point, though for landing these I think keeping parallel implementations is good.