### PR TITLE
fix ad_checkpoint.checkpoint caching issue

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -875,12 +875,12 @@ config.define_bool_state(
     default=(lib.version >= (0, 3, 6)),
     help=('Enables using optimization-barrier op for lowering remat.'))
 
-# TODO(mattjj): remove after May 19 2022, NeurIPS submission deadline
+# TODO(mattjj): set default to True, then remove
 config.define_bool_state(
-    name='after_neurips',
-    default=True,
+    name='jax_new_checkpoint',
+    default=False,
     upgrade=True,
-    help='Gate changes until after NeurIPS 2022 deadline.')
+    help='Whether to use the new jax.checkpoint implementation.')
 
 # TODO(b/205307544): Remove flag once coordination service has rolled out.
 config.define_bool_state(

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -593,8 +593,6 @@ def _ordered_unique(xs):
 
 def _cond_dce_rule(used_outputs: List[bool], eqn: core.JaxprEqn,
                    ) -> Tuple[List[bool], core.JaxprEqn]:
-  if not config.after_neurips:
-    return [True] * len(eqn.params['jaxpr'].in_avals), eqn
   closed_branches = eqn.params['branches']
   branches = [closed_jaxpr.jaxpr for closed_jaxpr in closed_branches]
 

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -781,8 +781,6 @@ def _scan_padding_rule(in_avals, out_avals, *args, jaxpr, **params):
 
 def _scan_dce_rule(used_outputs: List[bool], eqn: core.JaxprEqn
                    ) -> Tuple[List[bool], core.JaxprEqn]:
-  if not config.after_neurips:
-    return [True] * len(eqn.params['jaxpr'].in_avals), eqn
   jaxpr = eqn.params['jaxpr']
   num_consts, num_carry = eqn.params['num_consts'], eqn.params['num_carry']
   num_xs = len(jaxpr.in_avals) - num_consts - num_carry

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1509,6 +1509,10 @@ def dce_jaxpr_closed_call_rule(used_outputs: List[bool], eqn: JaxprEqn
   return used_inputs, new_eqn
 dce_rules[core.closed_call_p] = dce_jaxpr_closed_call_rule
 
+@weakref_lru_cache
+def close_jaxpr(jaxpr: Jaxpr) -> ClosedJaxpr:
+  return ClosedJaxpr(jaxpr, ())
+
 def move_binders_to_front(closed_jaxpr: ClosedJaxpr, to_move: Sequence[bool]
                           ) -> ClosedJaxpr:
   """Reorder `invars` by moving those indicated in `to_move` to the front."""

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -1979,6 +1979,8 @@ class HostCallbackTapTest(jtu.JaxTestCase):
           for grad_func in ["grad", "value_and_grad"]
           for use_remat in ["old", "new", "none"]))
   def test_tap_remat(self, use_result=False, grad_func="grad", use_remat="new"):
+    if config.jax_new_checkpoint and use_remat == "old": raise SkipTest()
+
     def f(x):
       id_print_result = hcb.id_print(x, output_stream=testing_stream)
       if use_result:


### PR DESCRIPTION
The main action here is in ad_checkpoint.py, where I refactored the transpose rule for the new remat implementation so as to get cache hits. Without this change, the test api_test.py RematTest.test_vjp_caching was failing.

I also added a config option to switch to the new checkpoint implementation globally (default False for now), as the first step in replacing and then deleting old remat. And deleted the after_neurips flag.