### PR TITLE
MAINT: unpin autodoc-typehints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinx >=3
-sphinx-autodoc-typehints==1.11.1  # Unpin after jaxlib 0.3.15 is released (#11455)
+sphinx-autodoc-typehints
 sphinx-book-theme
 sphinx-copybutton>=0.5.0
 sphinx-remove-toctrees


### PR DESCRIPTION
This had been waiting on jaxlib 0.3.15 (see https://github.com/google/jax/pull/11453#issuecomment-1180795678)