### PR TITLE
bug-report.yml: fix markdown formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,15 +10,16 @@ body:
 - type: markdown
   attributes:
     value: >
-      **Thank you for helping us improve JAX!**
+      ## Thank you for helping us improve JAX!
 
-      Please first verify that your issue is not already reported using the
+      * Please first verify that your issue is not already reported using the
       [Issue search][issue search].
 
-      If you are asking a question or seeking support, please
+      * If you are asking a question or seeking support, please
       consider [starting a discussion][Discussions].
 
-      If you prefer a non-templated issue report, click [here][Raw report].
+      * If you prefer a non-templated issue report, click [here][Raw report].
+
 
       [Discussions]: https://github.com/google/jax/discussions
 
@@ -52,4 +53,4 @@ body:
 - type: input
   attributes:
     label: Additional System Info
-    placeholder: Linux, Mac, Windows; Python version; etc.
+    placeholder: Python version, OS (Linux/Mac/Windows/WSL), etc.


### PR DESCRIPTION
Formatting of the top block is now fixed: https://github.com/google/jax/blob/03e5f9a24e94ebd4cba0db1f075d7a1b155ee440/.github/ISSUE_TEMPLATE/bug-report.yml