### PR TITLE
prepare to switch to new remat

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -329,6 +329,8 @@ def _trace_to_jaxpr(fun, in_tree, in_avals):
     jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(flat_fun, in_avals, debug)
   except core.ConcretizationTypeError as e:
     msg, = e.args
+    if 'for checkpoint' not in msg:
+      raise
     new_msg = msg + "\n\n" + (
         "Consider using the `static_argnums` parameter for `jax.remat` or "
         "`jax.checkpoint`. See the `jax.checkpoint` docstring and its example "

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -206,8 +206,8 @@ def checkpoint(fun: Callable, *, prevent_cse: bool = True,
   ...     return lambda x: f1(jax.checkpoint(f2)(x))
   ...
 
-  If ``fun`` involves Python control flow which depends on argument values,
-  it may be necessary to use the ``static_argums`` parameter. For example,
+  If ``fun`` involves Python control flow that depends on argument values,
+  it may be necessary to use the ``static_argnums`` parameter. For example,
   consider a boolean flag argument:
 
     from functools import partial

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -219,11 +219,12 @@ def checkpoint(fun: Callable, *, prevent_cse: bool = True,
       else:
         ...
 
-  Here, the use of ``static_argnums`` is necessary because the ``if`` statement
-  depends on the value of ``is_training``. The only cost to using
-  ``static_argnums`` is more retracing overheads: in the example, ``foo`` must
-  be retraced for every new value of ``is_training``. In some cases it may
-  additionally be necessary to use ``jax.ensure_compile_time_eval``:
+  Here, the use of ``static_argnums`` allows the ``if`` statement's condition
+  to depends on the value of ``is_training``. The cost to using
+  ``static_argnums`` is that it introduces re-tracing overheads across calls:
+  in the example, ``foo`` is re-traced every time it is called with a new value
+  of ``is_training``. In some situations, ``jax.ensure_compile_time_eval``
+  is needed as well:
 
     @partial(jax.checkpoint, static_argnums=(1,))
     def foo(x, y):

--- a/jax/_src/errors.py
+++ b/jax/_src/errors.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from jax import core
 
@@ -145,7 +146,7 @@ class ConcretizationTypeError(JAXTypeError):
   and concrete vs. abstract values, you may want to read
   :ref:`faq-different-kinds-of-jax-values`.
   """
-  def __init__(self, tracer: "core.Tracer", context: str = ""):
+  def __init__(self, tracer: core.Tracer, context: str = ""):
     super().__init__(
         "Abstract tracer value encountered where concrete value is expected: "
         f"{tracer}\n{context}{tracer._origin_msg()}\n")
@@ -237,7 +238,7 @@ class NonConcreteBooleanIndexError(JAXIndexError):
       >>> manual_clip(jnp.arange(-2, 2))
       DeviceArray([0, 0, 0, 1], dtype=int32)
   """
-  def __init__(self, tracer: "core.Tracer"):
+  def __init__(self, tracer: core.Tracer):
     super().__init__(
         f"Array boolean indices must be concrete; got {tracer}\n")
 
@@ -316,7 +317,7 @@ class TracerArrayConversionError(JAXTypeError):
   and concrete vs. abstract values, you may want to read
   :ref:`faq-different-kinds-of-jax-values`.
   """
-  def __init__(self, tracer: "core.Tracer"):
+  def __init__(self, tracer: core.Tracer):
     super().__init__(
         "The numpy.ndarray conversion method __array__() was called on "
         f"the JAX Tracer object {tracer}{tracer._origin_msg()}")
@@ -409,7 +410,7 @@ class TracerIntegerConversionError(JAXTypeError):
   and concrete vs. abstract values, you may want to read
   :ref:`faq-different-kinds-of-jax-values`.
   """
-  def __init__(self, tracer: "core.Tracer"):
+  def __init__(self, tracer: core.Tracer):
     super().__init__(
         f"The __index__() method was called on the JAX Tracer object {tracer}")
 

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -908,7 +908,7 @@ def with_mesh(named_shape: MeshSpec) -> Generator[None, None, None]:
   local_devices = list(api.local_devices())
   if len(local_devices) < size:
     raise unittest.SkipTest(f"Test requires {size} local devices")
-  mesh_devices = np.array(local_devices[:size]).reshape(shape)
+  mesh_devices = np.array(local_devices[:size]).reshape(shape)  # type: ignore
   with Mesh(mesh_devices, axis_names):
     yield
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -3981,6 +3981,18 @@ class RematTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(core.ConcretizationTypeError, "static_argnums"):
       g(jnp.array(3.))
 
+    # But don't raise an error mentioning static_argnums here:
+    @api.remat
+    def g(x):
+      jax.jit(lambda: 0 if jnp.add(1, 1) else 0)()
+      return lax.sin(x)
+
+    try:
+      g(jnp.array(3.))
+    except core.ConcretizationTypeError as e:
+      msg = str(e)
+    self.assertNotIn('static_argnums', msg)
+
   def test_remat_grad_python_control_flow_static_argnums(self):
     @partial(api.remat, static_argnums=(0,))
     def g(x):


### PR DESCRIPTION
This commit involves a few things, which are all united in being about landing the new remat (aka new checkpoint) implementation:
  * add benchmarks for new remat eager performance, and some caching to make those benchmarks fast
  * warn when the old-remat-exclusive `concrete` feature is used, with an actionable message pointing to the new recommended approach involving static_argnums
  * add the static_argnums parameter to both new and old remat
  * update docstrings (and de-duplicate them too)
  * add new tests, especially around caching and errors/warnings