### PR TITLE
Fix jax numpy norm bug where passing `ord="inf"` always returns one

### DIFF
--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -469,6 +469,13 @@ def norm(x, ord=None, axis : Union[None, Tuple[int, ...], int] = None,
       # code has slightly different type promotion semantics, so we need a
       # special case too.
       return jnp.sum(jnp.abs(x), axis=axis, keepdims=keepdims)
+    elif isinstance(ord, str):
+      msg = f"Invalid order '{ord}' for vector norm."
+      if ord == "inf":
+        msg += "Use 'jax.numpy.inf' instead."
+      if ord == "-inf":
+        msg += "Use '-jax.numpy.inf' instead."
+      raise ValueError(msg)
     else:
       abs_x = jnp.abs(x)
       ord = lax_internal._const(abs_x, ord)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -539,6 +539,11 @@ class NumpyLinalgTest(jtu.JaxTestCase):
                             tol=1e-3)
     self._CompileAndCheck(jnp_fn, args_maker)
 
+  def testStringInfNorm(self):
+    err, msg = ValueError, r"Invalid order 'inf' for vector norm."
+    with self.assertRaisesRegex(err, msg):
+      jnp.linalg.norm(jnp.array([1.0, 2.0, 3.0]), ord="inf")
+
   @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_n={}_full_matrices={}_compute_uv={}_hermitian={}".format(
           jtu.format_shape_dtype_string(b + (m, n), dtype), full_matrices,


### PR DESCRIPTION
This fixes a silent bug where passing in `ord="inf"` always returns one. Calculating this norm requires passing `jnp.inf` instead.
```py
>>> import jax.numpy as jnp
>>> jnp.linalg.norm(jnp.array([10, 20]), ord=jnp.inf)
DeviceArray(20., dtype=float32)
>>> jnp.linalg.norm(jnp.array([10, 20]), ord="inf")
DeviceArray(1., dtype=float32)
```

Either it should calculate the infinity norm or raise an exception. With this change, we match numpy behavior and raise an exception.
```py
>>> import numpy as np
>>> np.linalg.norm(np.array([10, 20]), ord=np.inf)
20.0
>>> np.linalg.norm(np.array([10, 20]), ord="inf")
Traceback (most recent call last):
...
ValueError: Invalid norm order 'inf' for vectors
>>> jnp.linalg.norm(jnp.array([10, 20]), ord="inf") # (With this PR)
Traceback (most recent call last):
...
ValueError: Invalid order 'inf' for vector norm. Use 'jax.numpy.inf' instead.
```

This might break existing usage of `norm` that pass `"inf"`. I tried to search for instances of `jnp.linalg.norm(..., ord="inf", ...)` on GitHub and Google Search but couldn't find any matches.