### PR TITLE
Remove experimental warning from xmap

### DIFF
--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -457,7 +457,6 @@ def xmap(fun: Callable,
     specified. This is in line with the current multi-host :py:func:`pmap`
     programming model.
   """
-  warn("xmap is an experimental feature and probably has bugs!")
   _check_callable(fun)
 
   if isinstance(in_axes, list) and not _is_axes_leaf(in_axes):


### PR DESCRIPTION
It doesn't have bugs, or at least not noticeably more than the rest of our code :)