### PR TITLE
add api_boundary, fix flax failure with new-remat-by-default

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -96,6 +96,7 @@ checkpoint_policies = types.SimpleNamespace(
 
 ### Main API
 
+@api_boundary
 def checkpoint(fun: Callable, *, prevent_cse: bool = True,
                policy: Optional[Callable[..., bool]] = None,
                static_argnums: Union[int, Tuple[int, ...]] = (),


### PR DESCRIPTION
Without this, when new-remat-by-default was enabled Flax's TracebackTest.test_dynamic_exclusion (and a few others) failed with 
```
AssertionError:
'jax/_src/ad_checkpoint.py' not found in ('flax/tests/traceback_util_test.py', '<stdlib>/contextlib.py')
Failed
```