### PR TITLE
Increase minimum NumPy version to 1.20.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 
 ## jax 0.3.16 (Unreleased)
 * [GitHub commits](https://github.com/google/jax/compare/jax-v0.3.15...main).
+* Breaking changes
+  * Support for NumPy 1.19 has been dropped, per the
+    [deprecation policy](https://jax.readthedocs.io/en/latest/deprecation.html).
+    Please upgrade to NumPy 1.20 or newer.
 * Changes
   * Added {mod}`jax.debug` that includes utilities for runtime value debugging such at {func}`jax.debug.print` and {func}`jax.debug.breakpoint`.
   * Added new documentation for [runtime value debugging](debugging/index)

--- a/build/build.py
+++ b/build/build.py
@@ -83,8 +83,8 @@ def check_numpy_version(python_bin_path):
   version = shell(
       [python_bin_path, "-c", "import numpy as np; print(np.__version__)"])
   numpy_version = tuple(map(int, version.split(".")[:2]))
-  if numpy_version < (1, 19):
-    print("ERROR: JAX requires NumPy 1.19 or newer, found " + version + ".")
+  if numpy_version < (1, 20):
+    print("ERROR: JAX requires NumPy 1.20 or newer, found " + version + ".")
     sys.exit(-1)
   return version
 

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -43,7 +43,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension'],
     python_requires='>=3.7',
-    install_requires=['scipy>=1.5', 'numpy>=1.19', 'absl-py'],
+    install_requires=['scipy>=1.5', 'numpy>=1.20', 'absl-py'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     python_requires='>=3.7',
     install_requires=[
         'absl-py',
-        'numpy>=1.19',
+        'numpy>=1.20',
         'opt_einsum',
         'scipy>=1.5',
         'typing_extensions',

--- a/tests/fft_test.py
+++ b/tests/fft_test.py
@@ -30,11 +30,7 @@ from jax._src.numpy.util import _promote_dtypes_complex
 from jax.config import config
 config.parse_flags_with_absl()
 
-numpy_version = tuple(map(int, np.__version__.split('.')[:3]))
-if numpy_version < (1, 20):
-  FFT_NORMS = [None, "ortho"]
-else:
-  FFT_NORMS = [None, "ortho", "forward", "backward"]
+FFT_NORMS = [None, "ortho", "forward", "backward"]
 
 
 float_dtypes = jtu.dtypes.floating


### PR DESCRIPTION
Per NEP 29, support for 1.19 ended on Jun 21, 2022.