### PR TITLE
Fix sample code block formatting in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -700,7 +700,7 @@ If you define a function that processes the input using operations that depend o
 the relative ordering of inputs (e.g. ``max``, ``greater``, ``argsort``, etc.) then
 you may be surprised to find that the gradient is everywhere zero.
 Here is an example, where we define `f(x)` to be a step function that returns
-`0` when `x` is negative, and `1` when `x` is positive:
+`0` when `x` is negative, and `1` when `x` is positive::
 
   import jax
   import numpy as np


### PR DESCRIPTION
Add missing colon to format sample code as a code block rather than a quote.

-----

### Current rendering on ([live](https://jax.readthedocs.io/en/latest/faq.html#why-are-gradients-zero-for-functions-based-on-sort-order), broken):

![image](https://user-images.githubusercontent.com/4074659/183469659-5eefb44c-9e23-4a23-90d7-b6024f77a782.png)

-----

### Preview of the docs in GitHub with the change (fixed):

![Screen Shot 2022-08-08 at 12 39 19 PM](https://user-images.githubusercontent.com/4074659/183469902-e95efef7-f89c-4f7b-bc10-8d69e60736dc.png)
