### PR TITLE
Bump EnricoMi/publish-unit-test-result-action from 1 to 2

### DIFF
--- a/.github/workflows/nightly-ci-multiprocess-gpu.yml
+++ b/.github/workflows/nightly-ci-multiprocess-gpu.yml
@@ -41,10 +41,10 @@ jobs:
           if [ "${SLURM_STATE}" != "COMPLETED" ]; then exit 1; fi
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: "outputs/*.xml"
+          junit_files: "outputs/*.xml"
 
       - name: Upload run results from all nodes
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This fixes a dependency issue that Dependabot raised as a PR(#11794) (but the action failed because it needed this extra fix).
