### PR TITLE
Add `spmd_axis_name` to vmap to allow constraining mapped PartitionSpecs.

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1441,9 +1441,7 @@ def vmap(fun: F,
     axis_name: Optional, a hashable Python object used to identify the mapped
       axis so that parallel collectives can be applied.
     axis_size: Optional, an integer indicating the size of the axis to be
-      mapped. If not provided, the mapped axis size is inferred from arguments.
-    spmd_axis_name: Optional, a hashable Python object to insert into any
-      mapped PartitionSpecs.
+      mapped. If not provided, the mapped axis size is inferred from arguments..
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1396,7 +1396,8 @@ def vmap(fun: F,
          in_axes: Union[int, Sequence[Any]] = 0,
          out_axes: Any = 0,
          axis_name: Optional[Hashable] = None,
-         axis_size: Optional[int] = None) -> F:
+         axis_size: Optional[int] = None,
+         spmd_axis_name: Optional[Hashable] = None) -> F:
   """Vectorizing map. Creates a function which maps ``fun`` over argument axes.
 
   Args:
@@ -1441,6 +1442,8 @@ def vmap(fun: F,
       axis so that parallel collectives can be applied.
     axis_size: Optional, an integer indicating the size of the axis to be
       mapped. If not provided, the mapped axis size is inferred from arguments.
+    spmd_axis_name: Optional, a hashable Python object to insert into any
+      mapped PartitionSpecs.
 
   Returns:
     Batched/vectorized version of ``fun`` with arguments that correspond to
@@ -1564,7 +1567,8 @@ def vmap(fun: F,
                                     kws=True))
     out_flat = batching.batch(
         flat_fun, axis_name, axis_size_, in_axes_flat,
-        lambda: flatten_axes("vmap out_axes", out_tree(), out_axes)
+        lambda: flatten_axes("vmap out_axes", out_tree(), out_axes),
+        spmd_axis_name=spmd_axis_name
     ).call_wrapped(*args_flat)
     return tree_unflatten(out_tree(), out_flat)
 

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -115,7 +115,7 @@ def maybe_bdim_at_front(x, bdim):
 def vmap_unrestricted(f: lu.WrappedFun, *args, in_axes, axis_name, axis_size):
   f, out_axes = batching.batch_subtrace(f)
   f = batching._batch_outer(f, axis_name, axis_size, in_axes,
-                            batching.BatchTrace)
+                            batching.BatchTrace, None)
   outs = f.call_wrapped(*args)
   return outs, out_axes()
 


### PR DESCRIPTION
This is added to allow `vmap(lambda x: with_sharding_constraint(x, None), spmd_axis_name = 'x')(x)` to lower to `with_sharding_constraint(x, P('x'))`. Previously, there was no way to specify explicitly what axis to apply to the `with_sharding_constraint`. This patch adds `spmd_axis_name` to BatchTrace so that the `with_sharding_constraint` batching rule can optionally constrain based on the provided axis.