### PR TITLE
Fix zero-length array bug in scan.

### DIFF
--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -220,6 +220,9 @@ def scan(f: Callable[[Carry, X], Tuple[Carry, Y]],
     else:
       length, = unique_lengths
 
+  if length == 0:
+    return init, xs
+
   if config.jax_disable_jit:
     if length == 0:
       raise ValueError("zero-length scan is not supported in disable_jit() mode because the output type is unknown.")


### PR DESCRIPTION
When using `scan` over an array of length zero with a function `f` that expects a specific input shape (as below), the compilation of `f` leads to an error. Here is a minimal example:
```Python
def f(carry, y):
    y1, y2 = y
    return carry + y1 * y2, None
ys = jnp.array([])
jax.lax.scan(f, 0, ys)  # raises: TypeError: iteration over a 0-d array
```
This happens because `scan` infers the abstract value of the arguments of `f` (specifically right [here](https://github.com/google/jax/blob/main/jax/_src/lax/control_flow/loops.py#L238)), which in the example above returns `ShapedArray(float32[])` which is the shape of `ys` when stripped of its first dimension, but obviously is not a valid argument shape for `f`.

The fix I implemented here seems very primitive to me, specifically because `f` won't be compiled in this case. I am not sure if this leads to any unexpected problems, but for my purposes it solves the problem.