### PR TITLE
defer to custom eltype for `slice` lowering rule

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -800,6 +800,10 @@ batching.primitive_batchers[slice_p] = _slice_batching_rule
 
 def _slice_lower(ctx, x, *, start_indices, limit_indices, strides):
   strides = strides or [1] * len(start_indices)
+  aval_out, = ctx.avals_out
+  if type(aval_out.dtype) in core.custom_eltypes:
+    return aval_out.dtype.slice_mlir(ctx, x, start_indices, limit_indices,
+                                     strides)
   return mhlo.SliceOp(x,
                       mlir.dense_int_elements(start_indices),
                       mlir.dense_int_elements(limit_indices),


### PR DESCRIPTION
We already handled dynamic slice in #11768 (among others), but plain slice is eltype-polymorphic too.