### PR TITLE
Tests: re-enable some ufunc input tests

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6502,8 +6502,7 @@ class NumpyUfuncTests(jtu.JaxTestCase):
     for arg_dtypes in jtu.cases_from_list(_dtypes_for_ufunc(name)))
   def testUfuncInputTypes(self, name, arg_dtypes):
     # TODO(jakevdp): fix following failures and remove from this exception list.
-    if (name in ['divmod', 'floor_divide', 'fmod', 'gcd', 'left_shift', 'mod',
-                 'power', 'remainder', 'right_shift', 'rint', 'square']
+    if (name in ['gcd', 'left_shift', 'power', 'remainder', 'right_shift', 'rint', 'square']
         and 'bool_' in arg_dtypes):
       self.skipTest(f"jax.numpy does not support {name}{tuple(arg_dtypes)}")
     if name == 'arctanh' and jnp.issubdtype(arg_dtypes[0], jnp.complexfloating):


### PR DESCRIPTION
I noticed boolean inputs are now supported; not sure exactly when that changed.