### PR TITLE
Fix bug with integer-typed Gelu

### DIFF
--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -252,6 +252,10 @@ def gelu(x: Array, approximate: bool = True) -> Array:
     x : input array
     approximate: whether to use the approximate or exact formulation.
   """
+
+  # Promote to nearest float-like dtype.
+  x = x.astype(dtypes._to_inexact_dtype(x.dtype))
+
   if approximate:
     sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype)
     cdf = 0.5 * (1.0 + jnp.tanh(sqrt_2_over_pi * (x + 0.044715 * (x ** 3))))

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -84,9 +84,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
     val = nn.glu(jnp.array([1.0, 0.0]), axis=0)
     self.assertAllClose(val, jnp.array([0.5]))
 
-  def testGeluIntType(self):
-    val_float = nn.gelu(jnp.array(-1.0))
-    val_int = nn.gelu(jnp.array(-1))
+  @parameterized.parameters(False, True)
+  def testGeluIntType(self, approximate):
+    val_float = nn.gelu(jnp.array(-1.0), approximate=approximate)
+    val_int = nn.gelu(jnp.array(-1), approximate=approximate)
     self.assertAllClose(val_float, val_int)
 
   @parameterized.parameters(False, True)

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -84,6 +84,11 @@ class NNFunctionsTest(jtu.JaxTestCase):
     val = nn.glu(jnp.array([1.0, 0.0]), axis=0)
     self.assertAllClose(val, jnp.array([0.5]))
 
+  def testGeluIntType(self):
+    val_float = nn.gelu(jnp.array(-1.0))
+    val_int = nn.gelu(jnp.array(-1))
+    self.assertAllClose(val_float, val_int)
+
   @parameterized.parameters(False, True)
   def testGelu(self, approximate):
     def gelu_reference(x):


### PR DESCRIPTION
Certain lines in gelu()  currently round down constants if called with integer types (sqrt_2_over_pi = np.sqrt(2 / np.pi).astype(x.dtype))

Cast the input array to the nearest float-like type to avoid this, as done for trigonometic functions.