### PR TITLE
Tests: remove obsolete dtype_promotion decorators

### DIFF
--- a/tests/dtypes_test.py
+++ b/tests/dtypes_test.py
@@ -75,7 +75,6 @@ def identity(x):
   return x
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class DtypesTest(jtu.JaxTestCase):
 
   def test_canonicalize_type(self):
@@ -296,7 +295,6 @@ class DtypesTest(jtu.JaxTestCase):
     self.assertEqual(dtypes.complex_, np.complex64 if precision == '32' else np.complex128)
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class TestPromotionTables(jtu.JaxTestCase):
 
   @parameterized.named_parameters(

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -522,7 +522,6 @@ def _promote_like_jnp(fun, inexact=False):
   return wrapper
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class LaxBackedNumpyTests(jtu.JaxTestCase):
   """Tests for LAX-backed Numpy implementation."""
 
@@ -6262,7 +6261,6 @@ GRAD_SPECIAL_VALUE_TEST_RECORDS = [
 ]
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class NumpyGradTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(itertools.chain.from_iterable(
@@ -6369,7 +6367,6 @@ class NumpyGradTests(jtu.JaxTestCase):
     check_grads(jnp.logaddexp2, args, 1, ["fwd", "rev"], tol, tol)
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class NumpySignaturesTest(jtu.JaxTestCase):
 
   def testWrappedSignaturesMatch(self):
@@ -6492,7 +6489,6 @@ def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:
       yield arg_dtypes
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class NumpyUfuncTests(jtu.JaxTestCase):
 
   @parameterized.named_parameters(
@@ -6525,7 +6521,6 @@ class NumpyUfuncTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_op, jnp_op, args_maker, check_dtypes=False, tol=1E-2)
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class NumpyDocTests(jtu.JaxTestCase):
 
   def test_lax_numpy_docstrings(self):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -147,7 +147,6 @@ JAX_SPECIAL_FUNCTION_RECORDS = [
 ]
 
 
-@jtu.with_config(jax_numpy_dtype_promotion='strict')
 class LaxBackedScipyTests(jtu.JaxTestCase):
   """Tests for LAX-backed Scipy implementation."""
 


### PR DESCRIPTION
`JaxTestCase` now sets this to strict by default, so these annotations are no longer necessary: https://github.com/google/jax/blob/af18235ea30799ed2fc50e557ebba869e2bdbd41/jax/_src/test_util.py#L706-L713