### PR TITLE
simplify slicing jaxprs a little

### DIFF
--- a/benchmarks/api_benchmark.py
+++ b/benchmarks/api_benchmark.py
@@ -539,5 +539,13 @@ def bench_remat_eager_retracing_overheads_static_argnums(state):
   y.block_until_ready()
 
 
+@google_benchmark.register
+@google_benchmark.option.unit(google_benchmark.kMillisecond)
+def bench_slicing_compilation(state):
+  x = jnp.arange(3)
+  while state:
+    jax.jit(lambda x: (x[0], x[1], x[2])).lower(x).compile()
+
+
 if __name__ == "__main__":
   google_benchmark.main()

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3485,10 +3485,10 @@ def _normalize_index(index, axis_size):
   else:
     axis_size_val = lax.convert_element_type(core.dimension_as_value(axis_size),
                                              _dtype(index))
-  return lax.select(
-    lax.lt(index, _lax_const(index, 0)),
-    lax.add(index, axis_size_val),
-    index)
+  if isinstance(index, (int, np.integer)):
+    return lax.add(index, axis_size_val) if index < 0 else index
+  else:
+    return lax.select(index < 0, lax.add(index, axis_size_val), index)
 
 
 TAKE_ALONG_AXIS_DOC = """


### PR DESCRIPTION
**Before:**
<img width="784" alt="image" src="https://user-images.githubusercontent.com/1458824/184275181-0069f694-4a99-448a-9593-cfa4102feea0.png">

**After:**
<img width="782" alt="image" src="https://user-images.githubusercontent.com/1458824/184275089-9fa644e2-6127-4290-969f-e046d5bcafe7.png">

No more `lt`, `add`, `select`, or `convert_element_type`!

This might actually improve compilation time a bit; on CPU, **the tiny benchmark added went from ~15.5ms to 13ms on my machine.**