### PR TITLE
Fix JIT cache context defaults

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -488,7 +488,7 @@ class _ThreadLocalExtraJitContext(NamedTuple):
   `_update_thread_local_jit_state` in core.py to prevent circular imports.
   """
   dynamic_trace_state: Optional[Any] = None
-  axis_env_state: Optional[Hashable] = None
+  axis_env_state: Hashable = ()
   numpy_rank_promotion: Optional[str] = None
   numpy_dtype_promotion: Optional[str] = None
   default_matmul_precision: Optional[Any] = None

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1155,6 +1155,17 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     self.assertEqual(count[0], 0)  # no compiles
     self.assertArraysAllClose(ans, expected, check_dtypes=True)
 
+  def test_cache_key_defaults(self):
+    # https://github.com/google/jax/discussions/11875
+    if not self.use_cpp_jit:
+      raise unittest.SkipTest("this test only applies to _cpp_jit")
+    f = self.jit(lambda x: (x ** 2).sum())
+    self.assertEqual(f._cache_size(), 0)
+    x = jnp.arange(5.0)
+    for _ in range(3):
+      _ = f(x)
+    self.assertEqual(f._cache_size(), 1)
+
 
 class PythonJitTest(CPPJitTest):
 


### PR DESCRIPTION
This fixes redundant cacheing due to two different default values existing for the `axis_env_state` cache key.

I'm not entirely sure that this is the right fix (it may be better to ensure that the cache key is always set to an empty tuple at the call-site) But this change is one way to fix the issue introduced in #11298 and reported in  #11875.