### PR TITLE
Point to the conda-forge jaxlib wheels in the JAX readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Some standouts:
 
 JAX is written in pure Python, but it depends on XLA, which needs to be
 installed as the `jaxlib` package. Use the following instructions to install a
-binary package with `pip`, or to [build JAX from
+binary package with `pip` or `conda`, or to [build JAX from
 source](https://jax.readthedocs.io/en/latest/developer.html#building-from-source).
 
 We support installing or building `jaxlib` on Linux (Ubuntu 16.04 or later) and
@@ -511,6 +511,31 @@ jax.tools.colab_tpu.setup_tpu()
 ```
 Colab TPU runtimes use an older TPU architecture than Cloud TPU VMs, so installing `jax[tpu]` should be avoided on Colab.
 If for any reason you would like to update the jax & jaxlib libraries on a Colab TPU runtime, follow the CPU instructions above (i.e. install `jax[cpu]`).
+
+### Conda installation
+
+There is a community-supported Conda build of `jax`. To install using `conda`,
+simply run
+
+```bash
+conda install -c conda-forge jax
+```
+
+If run on a machine with NVidia GPUs, this will automatically install a
+GPU-enabled `jaxlib`. The conda-forge project redistributes CUDA and CuDNN; as
+such, there is no need to install CuDNN beforehand. However, the `cudatoolkit`
+distributed by `conda-forge` is missing `ptxas`, which JAX requires. You must
+therefore install CUDA on your machine yourself so that `ptxas` is in your path.
+
+If you would like to override which release of CUDA is used by JAX, or to
+install the CUDA build on a machine without GPUs, follow the instructions in the
+[Tips & tricks](https://conda-forge.org/docs/user/tipsandtricks.html#installing-cuda-enabled-packages-like-tensorflow-and-pytorch) section of
+the conda-forge website.
+
+See the `conda-forge`
+[jaxlib](https://github.com/conda-forge/jaxlib-feedstock#installing-jaxlib) and
+[jax](https://github.com/conda-forge/jax-feedstock#installing-jax) repositories
+for more details.
 
 ### Building JAX from source
 See [Building JAX from


### PR DESCRIPTION
Fixes https://github.com/google/jax/issues/189