### PR TITLE
defer to custom eltype for `gather` lowering rule

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -1315,6 +1315,12 @@ def _gather_lower(ctx, operand, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
                   indices_are_sorted, mode, fill_value):
   aval_out, = ctx.avals_out
+  if type(aval_out.dtype) in core.custom_eltypes:
+    return aval_out.dtype.gather_mlir(
+        ctx, operand, indices, dimension_numbers=dimension_numbers,
+        slice_sizes=slice_sizes, unique_indices=unique_indices,
+        indices_are_sorted=indices_are_sorted, mode=mode, fill_value=fill_value)
+
   if mode == GatherScatterMode.FILL_OR_DROP:
     gather_fill_fn = mlir.lower_fun(_gather_fill, multiple_results=False)
     return gather_fill_fn(

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -95,6 +95,14 @@ def shape_tensor(sizes: Sequence[Union[int, ir.RankedTensorType]]
     return mhlo.ConcatenateOp([d, *ds], i64_attr(0)).result
 
 
+def delegate_lowering(ctx, lowering_fun, *args, **ctx_override_kwargs):
+  """Side-effects on `ctx`"""
+  ctx_new = ctx.replace(**ctx_override_kwargs)
+  out = lowering_fun(ctx_new, *args)
+  ctx.set_tokens_out(ctx_new.tokens_out)
+  return out
+
+
 # IR Types
 
 # Non-canonicalized dtype to IR type mapping.


### PR DESCRIPTION
Follow-up to #11768

This also adds an `mlir.delegate_lowering` helper that takes optional replacements to the MLIR lowering context and restores/updates it on return. This is used to define a gather lowering rule in tests here, by calling out to the base gather lowering rule. I picked it off of a working branch that uses it as well (for key-eltyped lowering rules).