### PR TITLE
Use --no-implicit-optional for type checking

### DIFF
--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -136,7 +136,7 @@ class IreeClient:
 
   def __init__(self,
                *,
-               iree_backend: str = None):
+               iree_backend: Optional[str] = None):
     self.platform = "iree"
     self.platform_version = "0.0.1"
     self.runtime_type = "iree"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 show_error_codes = True
 disable_error_code = attr-defined
+no_implicit_optional = True
 
 [mypy-absl.*]
 ignore_missing_imports = True


### PR DESCRIPTION
This makes type checking PEP 484 compliant (as of 2018).
mypy will change its defaults soon.

See:
https://github.com/python/mypy/issues/9091
https://github.com/python/mypy/pull/13401