### PR TITLE
un-skip polar decomp tests skipped on gpu in ad6ce74

### DIFF
--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -506,7 +506,6 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
       for nonzero_condition_number in nonzero_condition_numbers
       for dtype in jtu.dtypes.inexact
       for seed in seeds))
-  @jtu.skip_on_devices("gpu")  # Fails on A100.
   def testPolar(
     self, n_zero_sv, degeneracy, geometric_spectrum, max_sv, shape, method,
       side, nonzero_condition_number, dtype, seed):

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -93,8 +93,6 @@ class QdwhTest(jtu.JaxTestCase):
           'm': m, 'n': n, 'log_cond': log_cond}
       for m, n in zip([8, 10, 20], [6, 10, 18])
       for log_cond in np.linspace(1, _MAX_LOG_CONDITION_NUM, 4)))
-  # TODO(tianjianlu): Fails on A100 GPU.
-  @jtu.skip_on_devices("gpu")
   def testQdwhWithUpperTriangularInputAllOnes(self, m, n, log_cond):
     """Tests qdwh with upper triangular input of all ones."""
     a = jnp.triu(jnp.ones((m, n))).astype(_QDWH_TEST_DTYPE)
@@ -181,8 +179,6 @@ class QdwhTest(jtu.JaxTestCase):
           'm': m, 'n': n, 'log_cond': log_cond}
       for m, n in zip([10, 8], [10, 8])
       for log_cond in np.linspace(1, 4, 4)))
-  # TODO(tianjianlu): Fails on A100 GPU.
-  @jtu.skip_on_devices("gpu")
   def testQdwhWithOnRankDeficientInput(self, m, n, log_cond):
     """Tests qdwh with rank-deficient input."""
     a = jnp.triu(jnp.ones((m, n))).astype(_QDWH_TEST_DTYPE)


### PR DESCRIPTION
On an A100 machine, these tests seem to run fine now. See https://github.com/google/jax/issues/8628#issuecomment-1215651697. cf. #8628 

![image](https://user-images.githubusercontent.com/1458824/184704426-d5a6cb7b-0d66-4e00-b1ca-4dfd4e3e1420.png)
