### PR TITLE
Bump test tolerance for eigenvalue test.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -299,7 +299,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     a, = args_maker()
     w1, _ = jnp.linalg.eig(a)
     w2 = jnp.linalg.eigvals(a)
-    self.assertAllClose(w1, w2, rtol={np.complex128: 1e-14})
+    self.assertAllClose(w1, w2, rtol={np.complex64: 1e-5, np.complex128: 1e-14})
 
   @jtu.skip_on_devices("gpu", "tpu")
   def testEigvalsInf(self):


### PR DESCRIPTION
This test fails by a small amount on Linux aarch64.