### PR TITLE
Increase jax.distributed timeout to 5 min

### DIFF
--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -72,8 +72,10 @@ class State:
     if self.client is not None:
       raise RuntimeError('distributed.initialize should only be called once.')
 
+    # Set init_timeout to 5 min to leave time for all the processes to connect
     self.client = xla_extension.get_distributed_runtime_client(
-        coordinator_address, process_id, config.jax_coordination_service)
+        coordinator_address, process_id, config.jax_coordination_service,
+        init_timeout=300)
     logging.info('Connecting to JAX distributed service on %s', coordinator_address)
     self.client.connect()
 


### PR DESCRIPTION
Fix issue where XLA distributed runtime times out in larger jobs.