### PR TITLE
[x64] clean up internal uses of result_type()

### DIFF
--- a/jax/_src/abstract_arrays.py
+++ b/jax/_src/abstract_arrays.py
@@ -33,12 +33,10 @@ raise_to_shaped = core.raise_to_shaped
 
 
 def make_shaped_array(x):
-  dtype = dtypes.canonicalize_dtype(dtypes.result_type(x))
-  return ShapedArray(np.shape(x), dtype)
+  return ShapedArray(np.shape(x), dtypes.result_type(x))
 
 def zeros_like_array(x):
-  dtype, weak_type = dtypes._lattice_result_type(x)
-  dtype = dtypes.canonicalize_dtype(dtype)
+  dtype, weak_type = dtypes.result_type(x, return_weak_type_flag=True)
   aval = ShapedArray(np.shape(x), dtype, weak_type=weak_type)
   return ad_util.zeros_like_aval(aval)
 

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -221,7 +221,7 @@ def _asarray(arr):
   Note this will not correctly handle lists or tuples.
   """
   _check_arraylike("_asarray", arr)
-  dtype, weak_type = dtypes._lattice_result_type(arr)
+  dtype, weak_type = dtypes.result_type(arr, return_weak_type_flag=True)
   return lax_internal._convert_element_type(arr, dtype, weak_type)
 
 def _promote_shapes(fun_name, *args):
@@ -271,8 +271,7 @@ def _promote_dtypes(*args):
   if len(args) < 2:
     return args
   else:
-    to_dtype, weak_type = dtypes._lattice_result_type(*args)
-    to_dtype = dtypes.canonicalize_dtype(to_dtype)
+    to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
     return [lax_internal._convert_element_type(x, to_dtype, weak_type) for x in args]
 
 
@@ -280,8 +279,7 @@ def _promote_dtypes_inexact(*args):
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to an inexact type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
   to_dtype_inexact = dtypes.to_inexact_dtype(to_dtype)
   return [lax_internal._convert_element_type(x, to_dtype_inexact, weak_type)
           for x in args]
@@ -291,8 +289,7 @@ def _promote_dtypes_numeric(*args):
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to a numeric (non-bool) type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
   to_dtype_numeric = dtypes.to_numeric_dtype(to_dtype)
   return [lax_internal._convert_element_type(x, to_dtype_numeric, weak_type)
           for x in args]
@@ -302,8 +299,7 @@ def _promote_dtypes_complex(*args):
   """Convenience function to apply Numpy argument dtype promotion.
 
   Promotes arguments to a complex type."""
-  to_dtype, weak_type = dtypes._lattice_result_type(*args)
-  to_dtype = dtypes.canonicalize_dtype(to_dtype)
+  to_dtype, weak_type = dtypes.result_type(*args, return_weak_type_flag=True)
   to_dtype_complex = dtypes.to_complex_dtype(to_dtype)
   return [lax_internal._convert_element_type(x, to_dtype_complex, weak_type)
           for x in args]

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -179,7 +179,7 @@ def _bicgstab_solve(A, b, x0=None, *, maxiter, tol=1e-5, atol=0.0, M=_identity):
 
   r0 = _sub(b, A(x0))
   rho0 = alpha0 = omega0 = lax_internal._convert_element_type(
-      1, *dtypes._lattice_result_type(*tree_leaves(b)))
+      1, *dtypes.result_type(*tree_leaves(b), return_weak_type_flag=True))
   initial_value = (x0, r0, r0, alpha0, omega0, rho0, r0, r0, 0)
 
   x_final, *_ = lax.while_loop(cond_fun, body_fun, initial_value)
@@ -298,8 +298,7 @@ def _safe_normalize(x, thresh=None):
   taken to be 0, and the normalized x to be the zero vector.
   """
   norm = _norm(x)
-  dtype, weak_type = dtypes._lattice_result_type(*tree_leaves(x))
-  dtype = dtypes.canonicalize_dtype(dtype)
+  dtype, weak_type = dtypes.result_type(*tree_leaves(x), return_weak_type_flag=True)
   if thresh is None:
     thresh = jnp.finfo(norm.dtype).eps
   thresh = thresh.astype(dtype).real
@@ -531,8 +530,7 @@ def _gmres_batched(A, b, x0, unit_residual, residual_norm, ptol, restart, M):
       lambda x: jnp.pad(x[..., None], ((0, 0),) * x.ndim + ((0, restart),)),
       unit_residual,
   )
-  dtype, weak_type = dtypes._lattice_result_type(*tree_leaves(b))
-  dtype = dtypes.canonicalize_dtype(dtype)
+  dtype, weak_type = dtypes.result_type(*tree_leaves(b), return_weak_type_flag=True)
   H = lax_internal._convert_element_type(
       jnp.eye(restart, restart + 1, dtype=dtype), weak_type=weak_type)
 

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -245,7 +245,7 @@ def canonicalize_dtype(x):
   raise TypeError(f"No canonicalize_dtype handler for type: {type(x)}")
 
 def _canonicalize_ndarray_dtype(x):
-  return np.asarray(x, dtypes.canonicalize_dtype(dtypes.result_type(x)))
+  return np.asarray(x, dtypes.result_type(x))
 
 def _canonicalize_python_scalar_dtype(typ, x):
   return np.asarray(


### PR DESCRIPTION
Why? For X64 deprecation (#8178) I am working on some guardrails around dtype canonicalization, so we want to avoid extra calls to `canonicalize_dtype` that will generate noise.

This change is intended to be a pure refactoring, with no user-visible impact. It relies on two facts:

- `dtypes.result_type` canonicalizes the output, so there is no need to call `canonicalize_dtype` again
- `dtypes.result_type(*args, return_weak_type_flag)` is essentially equivalent to `dtypes._lattice_result_type(*args)` followed by `dtypes.canonicalize_dtype` on the output, so we can replace this common pattern with a single `dtypes.result_type` call.