### PR TITLE
Be more selective about which MLIR pieces we build.

### DIFF
--- a/build/build_wheel.py
+++ b/build/build_wheel.py
@@ -232,8 +232,8 @@ def prepare_wheel(sources_path):
   copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_mlir.{pyext}", dst_dir=mlir_libs_dir)
   copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_mlirHlo.{pyext}", dst_dir=mlir_libs_dir)
   copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_mlirDialectsSparseTensor.{pyext}", dst_dir=mlir_libs_dir)
-  copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_mlirRegisterEverything.{pyext}", dst_dir=mlir_libs_dir)
   copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_mlirSparseTensorPasses.{pyext}", dst_dir=mlir_libs_dir)
+  copy_file(f"__main__/jaxlib/mlir/_mlir_libs/_site_initialize_0.{pyext}", dst_dir=mlir_libs_dir)
   if _is_windows():
     copy_file("__main__/jaxlib/mlir/_mlir_libs/jaxlib_mlir_capi.dll", dst_dir=mlir_libs_dir)
   elif _is_mac():

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -71,23 +71,6 @@ py_extension(
     ],
 )
 
-py_extension(
-    name = "_mlirRegisterEverything",
-    srcs = [
-        "@llvm-project//mlir:include/mlir-c/Bindings/Python/Interop.h",
-        "@llvm-project//mlir:include/mlir/Bindings/Python/PybindAdaptors.h",
-        "@llvm-project//mlir:lib/Bindings/Python/RegisterEverything.cpp",
-    ],
-    copts = COPTS,
-    deps = [
-        ":jaxlib_mlir_capi_shared_library",
-        "@llvm-project//mlir:CAPIConversionHeaders",
-        "@llvm-project//mlir:CAPIRegisterEverythingHeaders",
-        "@llvm-project//mlir:CAPITransformsHeaders",
-        "@pybind11",
-    ],
-)
-
 symlink_inputs(
     name = "_mlir_libs",
     rule = py_library,
@@ -98,7 +81,21 @@ symlink_inputs(
     }},
     deps = [
         ":_mlir",
-        ":_mlirRegisterEverything",
+        ":_site_initialize_0",
+    ],
+)
+
+# JAX-specific registrations.
+py_extension(
+    name = "_site_initialize_0",
+    srcs = ["_site_initialize_0.cc"],
+    copts = COPTS,
+    deps = [
+        ":jaxlib_mlir_capi_shared_library",
+        "@llvm-project//mlir:CAPIIRHeaders",
+        "@llvm-project//mlir:MLIRBindingsPythonHeaders",
+        "@local_config_python//:headers",
+        "@pybind11",
     ],
 )
 
@@ -138,8 +135,6 @@ cc_library(
 cc_library(
     name = "jaxlib_mlir_capi_objects",
     deps = [
-        "@llvm-project//mlir:CAPIConversionObjects",
-        "@llvm-project//mlir:CAPIRegisterEverythingObjects",
         "@llvm-project//mlir:CAPISparseTensorObjects",
         "@llvm-project//mlir:CAPITransformsObjects",
         "@llvm-project//mlir:MLIRBindingsPythonCAPIObjects",

--- a/jaxlib/mlir/_mlir_libs/_site_initialize_0.cc
+++ b/jaxlib/mlir/_mlir_libs/_site_initialize_0.cc
@@ -1,0 +1,14 @@
+// Registers MLIR dialects used by JAX.
+// This module is called by mlir/__init__.py during initialization.
+
+#include "mlir-c/Dialect/Func.h"
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+PYBIND11_MODULE(_site_initialize_0, m) {
+  m.doc() = "Registers MLIR dialects used by JAX.";
+
+  m.def("register_dialects", [](MlirDialectRegistry registry) {
+    MlirDialectHandle func_dialect = mlirGetDialectHandle__func__();
+    mlirDialectHandleInsertDialect(func_dialect, registry);
+  });
+}


### PR DESCRIPTION
Reduces the size of the installed jaxlib by around 20MB on Linux x86-64.

Issue https://github.com/google/jax/issues/11225