### PR TITLE
Add a new scatter_reduce primitive and implement segment_reduce for a custom reduction

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -611,6 +611,66 @@ def scatter(
       indices_are_sorted=indices_are_sorted, unique_indices=unique_indices,
       mode=GatherScatterMode.from_any(mode))
 
+
+def scatter_reduce(
+    operand: Array,
+    scatter_indices: Array,
+    updates: Array,
+    computation: Callable[[Array, Array], Array],
+    dimension_numbers: ScatterDimensionNumbers,
+    *,
+    indices_are_sorted: bool = False,
+    unique_indices: bool = False,
+    mode: Optional[Union[str, GatherScatterMode]] = None) -> Array:
+  """Scatter-reduce operator.
+
+  Wraps `XLA's Scatter operator
+  <https://www.tensorflow.org/xla/operation_semantics#scatter>`_, where the
+  custom `computation` function is used to combine updates and values from
+  `operand`.
+
+  The semantics of scatter are complicated, and its API might change in the
+  future. For most use cases, you should prefer the
+  :attr:`jax.numpy.ndarray.at` property on JAX arrays which uses
+  the familiar NumPy indexing syntax.
+
+  Args:
+    operand: an array to which the scatter should be applied
+    scatter_indices: an array that gives the indices in `operand` to which each
+      update in `updates` should be applied.
+    updates: the updates that should be scattered onto `operand`.
+    computation: the reduction function for computing a new value given a
+      current value from `operand` and a corresponding update value from
+      `updates`.
+    dimension_numbers: a `lax.ScatterDimensionNumbers` object that describes how
+      dimensions of `operand`, `start_indices`, `updates` and the output relate.
+    indices_are_sorted: whether `scatter_indices` is known to be sorted. If
+      true, may improve performance on some backends.
+    unique_indices: whether the indices to be updated in ``operand`` are
+      guaranteed to not overlap with each other. If true, may improve
+      performance on some backends.
+    mode: how to handle indices that are out of bounds: when set to 'clip',
+      indices are clamped so that the slice is within bounds, and when set to
+      'fill' or 'drop' out-of-bounds updates are dropped. The behavior for
+      out-of-bounds indices when set to 'promise_in_bounds' is
+      implementation-defined.
+
+  Returns:
+    An array containing the sum of `operand` and the scattered updates.
+  """
+  jaxpr, consts = lax._reduction_jaxpr(computation,
+                                       lax._abstractify(lax._const(operand, 0)))
+  return scatter_reduce_p.bind(
+      operand,
+      scatter_indices,
+      updates,
+      update_jaxpr=jaxpr,
+      update_consts=consts,
+      dimension_numbers=dimension_numbers,
+      indices_are_sorted=indices_are_sorted,
+      unique_indices=unique_indices,
+      mode=GatherScatterMode.from_any(mode))
+
 def index_take(src: Array, idxs: Array, axes: Sequence[int]) -> Array:
   indices = lax.concatenate([lax.expand_dims(i, (1,)) for i in idxs], 1)
   indices = indices % np.array([src.shape[ax] for ax in axes])
@@ -1932,6 +1992,43 @@ batching.primitive_batchers[scatter_p] = (
   partial(_scatter_batching_rule, scatter))
 
 
+# TODO(wuke): Implement _scatter_reduce_jvp_rule.
+def _scatter_reduce_batching_rule(batched_args, batch_dims, *, update_jaxpr,
+                                  update_consts, dimension_numbers,
+                                  indices_are_sorted, unique_indices, mode):
+
+  def scatter_op(operand, scatter_indices, updates, dimension_numbers, *,
+                 indices_are_sorted, unique_indices, mode):
+    return scatter_reduce_p.bind(
+        operand,
+        scatter_indices,
+        updates,
+        update_jaxpr=update_jaxpr,
+        update_consts=update_consts,
+        dimension_numbers=dimension_numbers,
+        indices_are_sorted=indices_are_sorted,
+        unique_indices=unique_indices,
+        mode=GatherScatterMode.from_any(mode))
+
+  return _scatter_batching_rule(
+      scatter_op,
+      batched_args,
+      batch_dims,
+      update_jaxpr=update_jaxpr,
+      update_consts=update_consts,
+      dimension_numbers=dimension_numbers,
+      indices_are_sorted=indices_are_sorted,
+      unique_indices=unique_indices,
+      mode=mode)
+
+
+scatter_reduce_p = standard_primitive(
+    _scatter_shape_rule,
+    _scatter_dtype_rule,
+    "scatter-reduce",
+    weak_type_rule=_argnum_weak_type(0))
+batching.primitive_batchers[scatter_reduce_p] = _scatter_reduce_batching_rule
+
 
 def _scatter_lower(ctx, operand, indices, updates, *,
                    update_jaxpr, update_consts, dimension_numbers,
@@ -1976,6 +2073,7 @@ mlir.register_lowering(scatter_add_p, _scatter_lower)
 mlir.register_lowering(scatter_mul_p, _scatter_lower)
 mlir.register_lowering(scatter_min_p, _scatter_lower)
 mlir.register_lowering(scatter_max_p, _scatter_lower)
+mlir.register_lowering(scatter_reduce_p, _scatter_lower)
 
 
 def _real_dtype(dtype): return np.finfo(dtype).dtype

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -269,6 +269,8 @@ from jax._src.lax.slicing import (
   scatter_mul as scatter_mul,
   scatter_mul_p as scatter_mul_p,
   scatter_p as scatter_p,
+  scatter_reduce as scatter_reduce,
+  scatter_reduce_p as scatter_reduce_p,
   slice as slice,
   slice_in_dim as slice_in_dim,
   slice_p as slice_p,

--- a/jax/ops/__init__.py
+++ b/jax/ops/__init__.py
@@ -17,4 +17,5 @@ from jax._src.ops.scatter import (
   segment_prod as segment_prod,
   segment_min as segment_min,
   segment_max as segment_max,
+  segment_reduce as segment_reduce,
 )

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1119,6 +1119,10 @@ def _update_tol(op):
     tol = {np.complex128: 1e-14}
   return tol
 
+# For use with testSegmentReduction.
+_segment_reduce_add = partial(
+    ops.segment_reduce, init_value=0, computation=jnp.add, reducer=jnp.sum)
+_segment_reduce_add.__name__ = 'segment_reduce_add'
 
 class IndexedUpdateTest(jtu.JaxTestCase):
 
@@ -1359,7 +1363,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       (ops.segment_min, np.minimum, True),
       (ops.segment_max, np.maximum, False),
     ]))
-  def testSegmentReduceBoolean(self, shape, dtype, reducer, op, identity, num_segments, bucket_size):
+  def testSegmentReductionBoolean(self, shape, dtype, reducer, op, identity, num_segments, bucket_size):
     rng = jtu.rand_default(self.rng())
     idx_rng = jtu.rand_int(self.rng(), low=-2, high=3)
     args_maker = lambda: [rng(shape, dtype), idx_rng(shape[:1], jnp.int32)]
@@ -1403,8 +1407,9 @@ class IndexedUpdateTest(jtu.JaxTestCase):
       (ops.segment_prod, np.multiply, 1),
       (ops.segment_min, np.minimum, float('inf')),
       (ops.segment_max, np.maximum, -float('inf')),
+      (_segment_reduce_add, np.add, 0),
     ]))
-  def testSegmentReduce(self, shape, dtype, reducer, op, identity, num_segments, bucket_size):
+  def testSegmentReduction(self, shape, dtype, reducer, op, identity, num_segments, bucket_size):
     rng = jtu.rand_default(self.rng())
     idx_rng = jtu.rand_int(self.rng(), low=-2, high=3)
     args_maker = lambda: [rng(shape, dtype), idx_rng(shape[:1], jnp.int32)]

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2436,6 +2436,55 @@ class LaxTest(jtu.JaxTestCase):
     fun = partial(lax.scatter, dimension_numbers=dnums)
     self._CompileAndCheck(fun, args_maker)
 
+  @parameterized.named_parameters(
+      jtu.cases_from_list({
+          "testcase_name":
+              "_shape={}_idxs={}_update={}_dnums={}".format(
+                  jtu.format_shape_dtype_string(arg_shape, dtype), idxs,
+                  update_shape, dnums),
+          "arg_shape":
+              arg_shape,
+          "dtype":
+              dtype,
+          "idxs":
+              idxs,
+          "update_shape":
+              update_shape,
+          "dnums":
+              dnums
+      } for dtype in float_dtypes for arg_shape, idxs, update_shape, dnums in [
+          ((5,), np.array([[0], [2]]), (2,),
+           lax.ScatterDimensionNumbers(
+               update_window_dims=(),
+               inserted_window_dims=(0,),
+               scatter_dims_to_operand_dims=(0,))),
+          ((10,), np.array([[0], [0], [0]]), (3, 2),
+           lax.ScatterDimensionNumbers(
+               update_window_dims=(1,),
+               inserted_window_dims=(),
+               scatter_dims_to_operand_dims=(0,))),
+          ((
+              10,
+              5,
+          ), np.array([[0], [2], [1]]), (3, 3),
+           lax.ScatterDimensionNumbers(
+               update_window_dims=(1,),
+               inserted_window_dims=(0,),
+               scatter_dims_to_operand_dims=(0,))),
+      ]))
+  def testScatterReduce(self, arg_shape, dtype, idxs, update_shape, dnums):
+    rng = jtu.rand_default(self.rng())
+    rng_idx = jtu.rand_int(self.rng(), high=max(arg_shape))
+    rand_idxs = lambda: rng_idx(idxs.shape, idxs.dtype)
+    args_maker = lambda: [
+        rng(arg_shape, dtype),
+        rand_idxs(),
+        rng(update_shape, dtype)
+    ]
+    fun = partial(
+        lax.scatter_reduce, computation=jnp.logaddexp, dimension_numbers=dnums)
+    self._CompileAndCheck(fun, args_maker)
+
   # These tests are adapted from the corresponding tests in
   # tensorflow/compiler/xla/service/shape_inference_test.cc with slight
   # variations to account for the implicit setting of index_vector_dim in JAX.


### PR DESCRIPTION
I took a stab at implementing #6265 since I actually need `segment_logsumexp` now (although I created `segment_reduce` instead so that I can use different reductions).

Currently the jvp rule hasn't been implemented, it's fine for my use cases to leave it unimplemented for now, but I also want to run my idea about jvp by you guys:

I think an efficient general jvp implementation will require knowing the following function `f(x, z)`: let `z = computation(x, y)` for some `y`, `f(x, z)` is the derivative of `z` w.r.t. `x` computed knowing `x` and `z` but not `y`. For example `f_add(x, z) = 1`, `f_logaddexp(x, z) = exp(x-z)`, and `f_mul(x, z)` doesn't exist because we can't define it for x=0. If we have `f`, we can implement jvp for `scatter_reduce` using `scatter_add` and `mul`.

For the cases where `f` does exist, I wonder if we can allow the user to supply this function, and the jvp rule works when `f` is supplied. It'd be nice if there can be a way of automatically deriving `f` given `computation`, but I am not very optimistic about that.