### PR TITLE
Disabled dlpack bfloat16 test for JAX<->cupy.

### DIFF
--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -238,6 +238,8 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
      for dtype in dlpack_dtypes))
   @unittest.skipIf(not cupy, "Test requires CuPy")
   def testJaxToCuPy(self, shape, dtype):
+    if dtype == jnp.bfloat16:
+      raise unittest.SkipTest("cupy does not support bfloat16")
     rng = jtu.rand_default(self.rng())
     x = rng(shape, dtype)
     y = jnp.array(x)


### PR DESCRIPTION
cupy does not appear to support bfloat16.