### PR TITLE
Add support to test gpu jaxlib nightly in CI instead of prebuilt jax/jaxlib

### DIFF
--- a/.github/workflows/slurm_job_scripts/multinode_pytest.sub
+++ b/.github/workflows/slurm_job_scripts/multinode_pytest.sub
@@ -1,38 +1,46 @@
 #!/bin/bash
-#SBATCH -A arbitrary
+#SBATCH -A ci-jax-gpu
 #SBATCH -p compute
 #SBATCH -N 2                    # number of nodes
-#SBATCH -t 01:00:00              # wall time
-#SBATCH -J "arbitrary"     # job name (<< CHANGE ! >>)
+#SBATCH -t 00:15:00             # wall time
+#SBATCH -J "ci-jax-gpu"         # job name
 #SBATCH --exclusive             # exclusive node access
 #SBATCH --mem=0                 # all mem avail
 #SBATCH --mail-type=FAIL        # only send email on failure
-#SBATCH --ntasks-per-node=1     # n tasks per machine
+#SBATCH --ntasks-per-node=1     # 1 tasks per machine for now
 #SBATCH --overcommit            # Needed for pytorch
 
 set -x
 
 # File system and volume glue code
 #-------------------------------------------------------------------------------
-CONTAINER="nvcr.io/nvidian/jax_t5x:jax_0.3.14"
+CONTAINER="nvcr.io/nvidian/jax_t5x:cuda11.4-cudnn8.2-ubuntu20.04-manylinux2014-multipython"
 CONTAINER_NAME="multinode_ci_test_container"
 
 BASE_WORKSPACE_DIR=$GITHUB_WORKSPACE
 WORKSPACE_DIR=/workspace
 
 MOUNTS="--container-mounts=$BASE_WORKSPACE_DIR:/$WORKSPACE_DIR"
+
+# Since the docker container doesn't contain MLX drivers for IB, following flags
+# are needed to make NCCL work with an ethernet setup
+# Note:@sudhakarsingh27 This is very specific, need to abstract this out
+EXPORTS="--export=ALL,NCCL_SOCKET_IFNAME=enp45s0f0,NCCL_SOCKET_NTHREADS=2,NCCL_NSOCKS_PERTHREAD=2"
 #-------------------------------------------------------------------------------
 
 # Setup command to be run before the actual pytest command
 read -r -d '' setup_cmd <<EOF
-pip install pytest \
+python3.8 -m pip install --pre jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_cuda_releases.html \
+&& python3.8 -m pip install git+https://github.com/google/jax \
+&& python3.8 -m pip install pytest \
 && mkdir -p /workspace/outputs/
 EOF
 
 # Main pytest command that runs the tests
 read -r -d '' cmd <<EOF
 date \
-&& pytest -v  -s --continue-on-collection-errors \
+&& python3.8 -m pip  list | grep jax \
+&& python3.8 -m pytest -v  -s --continue-on-collection-errors \
     --junit-xml=/workspace/outputs/junit_output_\${SLURM_PROCID}.xml \
     /workspace/tests/distributed_multinode_test.py
 EOF
@@ -52,6 +60,7 @@ srun -o $OUTFILE -e $OUTFILE \
     --container-image="$CONTAINER" \
     --container-name=$CONTAINER_NAME \
     $MOUNTS  \
+    $EXPORTS \
     bash -c "${setup_cmd}"
 
 # Barrier command
@@ -60,9 +69,11 @@ wait
 # Run the actual pytest command
 echo $cmd
 srun -o $OUTFILE -e $OUTFILE \
+    --open-mode=append \
     --container-writable \
     --container-image="$CONTAINER" \
     --container-name=$CONTAINER_NAME \
     $MOUNTS  \
+    $EXPORTS \
     bash -c "${cmd}"
 set +x

--- a/tests/distributed_multinode_test.py
+++ b/tests/distributed_multinode_test.py
@@ -15,6 +15,8 @@
 import os
 import unittest
 
+from absl.testing import absltest
+
 import jax
 import jax._src.lib
 from jax._src import test_util as jtu
@@ -60,3 +62,6 @@ class MultiNodeGpuTest(jtu.JaxTestCase):
     y = jax.pmap(lambda x: jax.lax.psum(x, "i"), axis_name="i")(x)
     self.assertEqual(y[0], jax.device_count())
     print(y)
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
1. Replace the prebuilt jax/jaxlib container with a container built with 
    an OSS dockerfile [cuda 11.4/cudnn 8.2.4](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/ci_build/Dockerfile.rbe.cuda11.4-cudnn8.2-ubuntu20.04-manylinux2014-multipython)
2. Add additional flags to make NCCL work with bare ethernet and 
   pass them to `srun` command
4. Modify job name, deadline to make it more appropriate to run on
    the cluster