### PR TITLE
Avoid import-time dependency on jax.experimental

### DIFF
--- a/jax/_src/dlpack.py
+++ b/jax/_src/dlpack.py
@@ -16,7 +16,6 @@ from jax import core
 from jax import numpy as jnp
 from jax._src import device_array
 from jax._src import dispatch
-from jax.experimental import array
 from jax._src.lib import xla_client
 from jax._src.lib import xla_bridge
 
@@ -40,6 +39,7 @@ def to_dlpack(x: device_array.DeviceArrayProtocol, take_ownership: bool = False)
       undefined behavior if the DLPack consumer writes to a buffer that JAX
       owns.
   """
+  from jax.experimental import array
   if not isinstance(x, (device_array.DeviceArray, array.Array)):
     raise TypeError("Argument to to_dlpack must be a DeviceArray or Array, got {}"
                     .format(type(x)))

--- a/jax/_src/numpy/ndarray.py
+++ b/jax/_src/numpy/ndarray.py
@@ -18,7 +18,6 @@ from typing import Any, Tuple, Optional, Union
 from jax import core
 from jax.interpreters import pxla
 from jax._src import device_array
-from jax.experimental import array
 import numpy as np
 
 
@@ -293,4 +292,3 @@ ndarray.register(device_array.DeviceArray)
 for t in device_array.device_array_types:
   ndarray.register(t)
 ndarray.register(pxla._SDA_BASE_CLASS)
-ndarray.register(array.Array)

--- a/jax/experimental/array.py
+++ b/jax/experimental/array.py
@@ -29,6 +29,7 @@ from jax._src.config import config
 from jax._src.util import prod, safe_zip
 from jax._src.lib import xla_client as xc
 from jax._src.api import device_put
+from jax._src.numpy.ndarray import ndarray
 from jax.interpreters import pxla, xla, mlir
 from jax.experimental.sharding import (Sharding, SingleDeviceSharding,
                                        XLACompatibleSharding)
@@ -354,6 +355,7 @@ xla.canonicalize_dtype_handlers[Array] = pxla.identity
 api_util._shaped_abstractify_handlers[Array] = op.attrgetter('aval')
 ad_util.jaxval_adders[Array] = lax_internal.add
 ad_util.jaxval_zeros_likers[Array] = lax_internal.zeros_like_array
+ndarray.register(Array)
 
 
 def _array_mlir_constant_handler(val, canonicalize_types=True):


### PR DESCRIPTION
This was causing circular imports in my static typing explorations.