### PR TITLE
experiment: add `jax.typing` module and use it in `jax.lax`

### DIFF
--- a/jax/_src/checkify.py
+++ b/jax/_src/checkify.py
@@ -61,8 +61,8 @@ def setnewattr(obj, name, val):
 
 ## Error value data type and functional assert.
 
-Bool = Union[bool, core.Tracer]
-Int = Union[int, core.Tracer]
+Bool = Union[bool, jnp.ndarray, core.Tracer]
+Int = Union[int, jnp.ndarray, core.Tracer]
 Payload = Union[np.ndarray, jnp.ndarray, core.Tracer]
 
 # For now, the payload needs to be a fixed-size array: 3 int32s, used for the

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -44,6 +44,7 @@ from jax.interpreters import xla
 from jax.interpreters import pxla
 from jax.interpreters import ad
 from jax.interpreters import batching
+from jax.typing import ArrayLike, NDArray, Shape
 import jax._src.pretty_printer as pp
 from jax._src import util
 from jax._src.util import (cache, prod, safe_zip, safe_map, canonicalize_axis,
@@ -74,10 +75,6 @@ xe = xla_client._xla
 _max = builtins.max
 _min = builtins.min
 _reduce = functools.reduce
-
-Array = Any
-DType = Any
-Shape = core.Shape
 
 T = TypeVar("T")
 
@@ -196,12 +193,14 @@ def _dyn_shape_staging_rule(trace, prim, out_aval, *args, **params):
 
 
 ### traceables
+Array = Any
+DType = Any
 
-def neg(x: Array) -> Array:
+def neg(x: ArrayLike) -> NDArray:
   r"""Elementwise negation: :math:`-x`."""
   return neg_p.bind(x)
 
-def sign(x: Array) -> Array:
+def sign(x: ArrayLike) -> NDArray:
   r"""Elementwise sign.
 
   For floating-point inputs, returns
@@ -225,7 +224,7 @@ def sign(x: Array) -> Array:
   """
   return sign_p.bind(x)
 
-def nextafter(x1: Array, x2: Array) -> Array:
+def nextafter(x1: ArrayLike, x2: ArrayLike) -> NDArray:
   r"""Returns the next representable value after `x1` in the direction of `x2`.
 
   Note that in some environments flush-denormal-to-zero semantics is used.
@@ -241,11 +240,11 @@ def nextafter(x1: Array, x2: Array) -> Array:
   """
   return nextafter_p.bind(x1, x2)
 
-def floor(x: Array) -> Array:
+def floor(x: ArrayLike) -> NDArray:
   r"""Elementwise floor: :math:`\left\lfloor x \right\rfloor`."""
   return floor_p.bind(x)
 
-def ceil(x: Array) -> Array:
+def ceil(x: ArrayLike) -> NDArray:
   r"""Elementwise ceiling: :math:`\left\lceil x \right\rceil`."""
   return ceil_p.bind(x)
 
@@ -253,9 +252,9 @@ class RoundingMethod(enum.IntEnum):
   AWAY_FROM_ZERO = 0
   TO_NEAREST_EVEN = 1
 
-def round(x: Array,
+def round(x: ArrayLike,
           rounding_method: RoundingMethod = RoundingMethod.AWAY_FROM_ZERO
-          ) -> Array:
+          ) -> NDArray:
   r"""Elementwise round.
 
   Rounds values to the nearest integer.
@@ -272,7 +271,7 @@ def round(x: Array,
   rounding_method = RoundingMethod(rounding_method)
   return round_p.bind(x, rounding_method=rounding_method)
 
-def is_finite(x: Array) -> Array:
+def is_finite(x: ArrayLike) -> NDArray:
   r"""Elementwise :math:`\mathrm{isfinite}`.
 
   For each element x returns `True` if and only if x is not :math:`\pm\infty` or
@@ -280,178 +279,178 @@ def is_finite(x: Array) -> Array:
   """
   return is_finite_p.bind(x)
 
-def exp(x: Array) -> Array:
+def exp(x: ArrayLike) -> NDArray:
   r"""Elementwise exponential: :math:`e^x`."""
   return exp_p.bind(x)
 
-def expm1(x: Array) -> Array:
+def expm1(x: ArrayLike) -> NDArray:
   r"""Elementwise :math:`e^{x} - 1`."""
   return expm1_p.bind(x)
 
-def log(x: Array) -> Array:
+def log(x: ArrayLike) -> NDArray:
   r"""Elementwise natural logarithm: :math:`\mathrm{log}(x)`."""
   return log_p.bind(x)
 
-def log1p(x: Array) -> Array:
+def log1p(x: ArrayLike) -> NDArray:
   r"""Elementwise :math:`\mathrm{log}(1 + x)`."""
   return log1p_p.bind(x)
 
-def tanh(x: Array) -> Array:
+def tanh(x: ArrayLike) -> NDArray:
   r"""Elementwise hyperbolic tangent: :math:`\mathrm{tanh}(x)`."""
   return tanh_p.bind(x)
 
-def sin(x: Array) -> Array:
+def sin(x: ArrayLike) -> NDArray:
   r"""Elementwise sine: :math:`\mathrm{sin}(x)`."""
   return sin_p.bind(x)
 
-def cos(x: Array) -> Array:
+def cos(x: ArrayLike) -> NDArray:
   r"""Elementwise cosine: :math:`\mathrm{cos}(x)`."""
   return cos_p.bind(x)
 
-def atan2(x: Array, y: Array) -> Array:
+def atan2(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise arc tangent of two variables:
     :math:`\mathrm{atan}({x \over y})`."""
   return atan2_p.bind(x, y)
 
-def betainc(a: Array, b: Array, x: Array) -> Array:
+def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> NDArray:
   r"""Elementwise regularized incomplete beta integral."""
   return regularized_incomplete_beta_p.bind(a, b, x)
 
-def lgamma(x: Array) -> Array:
+def lgamma(x: ArrayLike) -> NDArray:
   r"""Elementwise log gamma: :math:`\mathrm{log}(\Gamma(x))`."""
   return lgamma_p.bind(x)
 
-def digamma(x: Array) -> Array:
+def digamma(x: ArrayLike) -> NDArray:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)
 
-def igamma(a: Array, x: Array) -> Array:
+def igamma(a: ArrayLike, x: ArrayLike) -> NDArray:
   r"""Elementwise regularized incomplete gamma function."""
   return igamma_p.bind(a, x)
 
-def igammac(a: Array, x: Array) -> Array:
+def igammac(a: ArrayLike, x: ArrayLike) -> NDArray:
   r"""Elementwise complementary regularized incomplete gamma function."""
   return igammac_p.bind(a, x)
 
-def igamma_grad_a(a: Array, x: Array) -> Array:
+def igamma_grad_a(a: ArrayLike, x: ArrayLike) -> NDArray:
   r"""Elementwise derivative of the regularized incomplete gamma function."""
   return igamma_grad_a_p.bind(a, x)
 
-def random_gamma_grad(a: Array, x: Array) -> Array:
+def random_gamma_grad(a: ArrayLike, x: ArrayLike) -> NDArray:
   r"""Elementwise derivative of samples from `Gamma(a, 1)`."""
   return random_gamma_grad_p.bind(a, x)
 
-def bessel_i0e(x: Array) -> Array:
+def bessel_i0e(x: ArrayLike) -> NDArray:
   r"""Exponentially scaled modified Bessel function of order 0:
   :math:`\mathrm{i0e}(x) = e^{-|x|} \mathrm{i0}(x)`
   """
   return bessel_i0e_p.bind(x)
 
-def bessel_i1e(x: Array) -> Array:
+def bessel_i1e(x: ArrayLike) -> NDArray:
   r"""Exponentially scaled modified Bessel function of order 1:
   :math:`\mathrm{i1e}(x) = e^{-|x|} \mathrm{i1}(x)`
   """
   return bessel_i1e_p.bind(x)
 
-def erf(x: Array) -> Array:
+def erf(x: ArrayLike) -> NDArray:
   r"""Elementwise error function: :math:`\mathrm{erf}(x)`."""
   return erf_p.bind(x)
 
-def erfc(x: Array) -> Array:
+def erfc(x: ArrayLike) -> NDArray:
   r"""Elementwise complementary error function:
     :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
   return erfc_p.bind(x)
 
-def erf_inv(x: Array) -> Array:
+def erf_inv(x: ArrayLike) -> NDArray:
   r"""Elementwise inverse error function: :math:`\mathrm{erf}^{-1}(x)`."""
   return erf_inv_p.bind(x)
 
-def real(x: Array) -> Array:
+def real(x: ArrayLike) -> NDArray:
   r"""Elementwise extract real part: :math:`\mathrm{Re}(x)`.
 
   Returns the real part of a complex number.
   """
   return real_p.bind(x)
 
-def imag(x: Array) -> Array:
+def imag(x: ArrayLike) -> NDArray:
   r"""Elementwise extract imaginary part: :math:`\mathrm{Im}(x)`.
 
   Returns the imaginary part of a complex number.
   """
   return imag_p.bind(x)
 
-def complex(x: Array, y: Array) -> Array:
+def complex(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise make complex number: :math:`x + jy`.
 
   Builds a complex number from real and imaginary parts.
   """
   return complex_p.bind(x, y)
 
-def conj(x: Array) -> Array:
+def conj(x: ArrayLike) -> NDArray:
   r"""Elementwise complex conjugate function: :math:`\overline{x}`."""
   return conj_p.bind(x, input_dtype=_dtype(x))
 
-def abs(x: Array) -> Array:
+def abs(x: ArrayLike) -> NDArray:
   r"""Elementwise absolute value: :math:`|x|`."""
   return abs_p.bind(x)
 
-def pow(x: Array, y: Array) -> Array:
+def pow(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise power: :math:`x^y`."""
   return pow_p.bind(x, y)
 
-def integer_pow(x: Array, y: int) -> Array:
+def integer_pow(x: ArrayLike, y: int) -> NDArray:
   r"""Elementwise power: :math:`x^y`, where :math:`y` is a fixed integer."""
   return integer_pow_p.bind(x, y=y)
 
-def sqrt(x: Array) -> Array:
+def sqrt(x: ArrayLike) -> NDArray:
   r"""Elementwise square root: :math:`\sqrt{x}`."""
   return sqrt_p.bind(x)
 
-def rsqrt(x: Array) -> Array:
+def rsqrt(x: ArrayLike) -> NDArray:
   r"""Elementwise reciprocal square root:  :math:`1 \over \sqrt{x}`."""
   return rsqrt_p.bind(x)
 
-def cbrt(x: Array) -> Array:
+def cbrt(x: ArrayLike) -> NDArray:
   r"""Elementwise cube root: :math:`\sqrt[3]{x}`."""
   return cbrt_p.bind(x)
 
-def bitwise_not(x: Array) -> Array:
+def bitwise_not(x: ArrayLike) -> NDArray:
   r"""Elementwise NOT: :math:`\neg x`."""
   return not_p.bind(x)
 
-def bitwise_and(x: Array, y: Array) -> Array:
+def bitwise_and(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise AND: :math:`x \wedge y`."""
   return and_p.bind(x, y)
 
-def bitwise_or(x: Array, y: Array) -> Array:
+def bitwise_or(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise OR: :math:`x \vee y`."""
   return or_p.bind(x, y)
 
-def bitwise_xor(x: Array, y: Array) -> Array:
+def bitwise_xor(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise exclusive OR: :math:`x \oplus y`."""
   return xor_p.bind(x, y)
 
-def population_count(x: Array) -> Array:
+def population_count(x: ArrayLike) -> NDArray:
   r"""Elementwise popcount, count the number of set bits in each element."""
   return population_count_p.bind(x)
 
-def clz(x: Array) -> Array:
+def clz(x: ArrayLike) -> NDArray:
   r"""Elementwise count-leading-zeros."""
   return clz_p.bind(x)
 
-def add(x: Array, y: Array) -> Array:
+def add(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise addition: :math:`x + y`."""
   return add_p.bind(x, y)
 
-def sub(x: Array, y: Array) -> Array:
+def sub(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise subtraction: :math:`x - y`."""
   return sub_p.bind(x, y)
 
-def mul(x: Array, y: Array) -> Array:
+def mul(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise multiplication: :math:`x \times y`."""
   return mul_p.bind(x, y)
 
-def div(x: Array, y: Array) -> Array:
+def div(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise division: :math:`x \over y`.
 
   Integer division overflow
@@ -460,7 +459,7 @@ def div(x: Array, y: Array) -> Array:
   """
   return div_p.bind(x, y)
 
-def rem(x: Array, y: Array) -> Array:
+def rem(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise remainder: :math:`x \bmod y`.
 
   The sign of the result is taken from the dividend,
@@ -473,57 +472,57 @@ def rem(x: Array, y: Array) -> Array:
   """
   return rem_p.bind(x, y)
 
-def max(x: Array, y: Array) -> Array:
+def max(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise maximum: :math:`\mathrm{max}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return max_p.bind(x, y)
 
-def min(x: Array, y: Array) -> Array:
+def min(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise minimum:  :math:`\mathrm{min}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return min_p.bind(x, y)
 
-def shift_left(x: Array, y: Array) -> Array:
+def shift_left(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise left shift: :math:`x \ll y`."""
   return shift_left_p.bind(x, y)
 
-def shift_right_arithmetic(x: Array, y: Array) -> Array:
+def shift_right_arithmetic(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise arithmetic right shift: :math:`x \gg y`."""
   return shift_right_arithmetic_p.bind(x, y)
 
-def shift_right_logical(x: Array, y: Array) -> Array:
+def shift_right_logical(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise logical right shift: :math:`x \gg y`."""
   return shift_right_logical_p.bind(x, y)
 
-def eq(x: Array, y: Array) -> Array:
+def eq(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise equals: :math:`x = y`."""
   return eq_p.bind(x, y)
 
-def ne(x: Array, y: Array) -> Array:
+def ne(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise not-equals: :math:`x \neq y`."""
   return ne_p.bind(x, y)
 
-def ge(x: Array, y: Array) -> Array:
+def ge(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise greater-than-or-equals: :math:`x \geq y`."""
   return ge_p.bind(x, y)
 
-def gt(x: Array, y: Array) -> Array:
+def gt(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise greater-than: :math:`x > y`."""
   return gt_p.bind(x, y)
 
-def le(x: Array, y: Array) -> Array:
+def le(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise less-than-or-equals: :math:`x \leq y`."""
   return le_p.bind(x, y)
 
-def lt(x: Array, y: Array) -> Array:
+def lt(x: ArrayLike, y: ArrayLike) -> NDArray:
   r"""Elementwise less-than: :math:`x < y`."""
   return lt_p.bind(x, y)
 
-def convert_element_type(operand: Array, new_dtype: DType) -> Array:
+def convert_element_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
   """Elementwise cast.
 
   Wraps XLA's `ConvertElementType
@@ -539,10 +538,10 @@ def convert_element_type(operand: Array, new_dtype: DType) -> Array:
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
   if hasattr(operand, '__jax_array__'):
-    operand = operand.__jax_array__()
+    operand = operand.__jax_array__()  # type: ignore
   return _convert_element_type(operand, new_dtype, weak_type=False)
 
-def _convert_element_type(operand: Array, new_dtype: Optional[DType] = None,
+def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DType] = None,
                           weak_type: bool = False):
   from jax.experimental import array
 
@@ -579,7 +578,7 @@ def _convert_element_type(operand: Array, new_dtype: Optional[DType] = None,
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
                                        weak_type=new_weak_type)
 
-def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
+def bitcast_convert_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
   """Elementwise bitcast.
 
   Wraps XLA's `BitcastConvertType
@@ -598,7 +597,7 @@ def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
   return bitcast_convert_type_p.bind(operand, new_dtype=new_dtype)
 
-def clamp(min: Array, x: Array, max: Array) -> Array:
+def clamp(min: ArrayLike, x: ArrayLike, max: ArrayLike) -> NDArray:
   r"""Elementwise clamp.
 
   Returns :math:`\mathrm{clamp}(x) = \begin{cases}
@@ -609,7 +608,7 @@ def clamp(min: Array, x: Array, max: Array) -> Array:
   """
   return clamp_p.bind(min, x, max)
 
-def concatenate(operands: Sequence[Array], dimension: int) -> Array:
+def concatenate(operands: Union[NDArray, Sequence[ArrayLike]], dimension: int) -> NDArray:
   """Concatenates a sequence of arrays along `dimension`.
 
   Wraps XLA's `Concatenate
@@ -682,8 +681,8 @@ PrecisionType = Precision
 PrecisionLike = Union[None, str, PrecisionType, Tuple[str, str],
                       Tuple[PrecisionType, PrecisionType]]
 
-def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
-        preferred_element_type: Optional[DType] = None) -> Array:
+def dot(lhs: NDArray, rhs: NDArray, precision: PrecisionLike = None,
+        preferred_element_type: Optional[DType] = None) -> NDArray:
   """Vector/vector, matrix/vector, and matrix/matrix multiplication.
 
   Wraps XLA's `Dot
@@ -718,9 +717,9 @@ def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
 DotDimensionNumbers = Tuple[Tuple[Sequence[int], Sequence[int]],
                             Tuple[Sequence[int], Sequence[int]]]
 
-def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
+def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionNumbers,
                 precision: PrecisionLike = None,
-                preferred_element_type: Optional[DType] = None) -> Array:
+                preferred_element_type: Optional[DType] = None) -> NDArray:
   """More general contraction operator.
 
   Wraps XLA's `DotGeneral
@@ -757,7 +756,7 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
                             precision=canonicalize_precision(precision),
                             preferred_element_type=preferred_element_type)
 
-def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
+def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> NDArray:
   """Broadcasts an array, adding new leading dimensions
 
   Args:
@@ -774,8 +773,8 @@ def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
   dims = tuple(range(len(sizes), len(sizes) + np.ndim(operand)))
   return broadcast_in_dim(operand, tuple(sizes) + np.shape(operand), dims)
 
-def broadcast_in_dim(operand: Array, shape: Shape,
-                     broadcast_dimensions: Sequence[int]) -> Array:
+def broadcast_in_dim(operand: ArrayLike, shape: Shape,
+                     broadcast_dimensions: Sequence[int]) -> NDArray:
   """Wraps XLA's `BroadcastInDim
   <https://www.tensorflow.org/xla/operation_semantics#broadcastindim>`_
   operator.
@@ -807,12 +806,12 @@ def broadcast_in_dim(operand: Array, shape: Shape,
       operand, *dyn_shape, shape=tuple(static_shape),
       broadcast_dimensions=tuple(broadcast_dimensions))
 
-def broadcast_to_rank(x: Array, rank: int) -> Array:
+def broadcast_to_rank(x: NDArray, rank: int) -> NDArray:
   """Adds leading dimensions of ``1`` to give ``x`` rank ``rank``."""
   return broadcast(x, (1,) * (rank - x.ndim))
 
-def reshape(operand: Array, new_sizes: Shape,
-            dimensions: Optional[Sequence[int]] = None) -> Array:
+def reshape(operand: ArrayLike, new_sizes: Shape,
+            dimensions: Optional[Sequence[int]] = None) -> NDArray:
   """Wraps XLA's `Reshape
   <https://www.tensorflow.org/xla/operation_semantics#reshape>`_
   operator.
@@ -871,8 +870,8 @@ def reshape(operand: Array, new_sizes: Shape,
       operand, *dyn_shape, new_sizes=tuple(static_new_sizes),
       dimensions=None if dims is None or same_dims else dims)
 
-def pad(operand: Array, padding_value: Array,
-        padding_config: Sequence[Tuple[int, int, int]]) -> Array:
+def pad(operand: ArrayLike, padding_value: ArrayLike,
+        padding_config: Sequence[Tuple[int, int, int]]) -> NDArray:
   """Applies low, high, and/or interior padding to an array.
 
   Wraps XLA's `Pad
@@ -893,14 +892,14 @@ def pad(operand: Array, padding_value: Array,
   """
   return pad_p.bind(operand, padding_value, padding_config=tuple(padding_config))
 
-def rev(operand: Array, dimensions: Sequence[int]) -> Array:
+def rev(operand: ArrayLike, dimensions: Sequence[int]) -> NDArray:
   """Wraps XLA's `Rev
   <https://www.tensorflow.org/xla/operation_semantics#rev_reverse>`_
   operator.
   """
   return rev_p.bind(operand, dimensions=tuple(dimensions))
 
-def select(pred: Array, on_true: Array, on_false: Array) -> Array:
+def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> NDArray:
   """Wraps XLA's `Select
   <https://www.tensorflow.org/xla/operation_semantics#select>`_
   operator.
@@ -909,7 +908,7 @@ def select(pred: Array, on_true: Array, on_false: Array) -> Array:
   # select(). This is because it implements `select_n`.
   return select_n_p.bind(pred, on_false, on_true)
 
-def select_n(which: Array, *cases: Array) -> Array:
+def select_n(which: ArrayLike, *cases: ArrayLike) -> NDArray:
   """Selects array values from multiple cases.
 
   Generalizes XLA's `Select
@@ -935,7 +934,7 @@ def select_n(which: Array, *cases: Array) -> Array:
   return select_n_p.bind(which, *cases)
 
 
-def transpose(operand: Array, permutation: Sequence[int]) -> Array:
+def transpose(operand: ArrayLike, permutation: Sequence[int]) -> NDArray:
   """Wraps XLA's `Transpose
   <https://www.tensorflow.org/xla/operation_semantics#transpose>`_
   operator.
@@ -947,13 +946,13 @@ def transpose(operand: Array, permutation: Sequence[int]) -> Array:
   else:
     return transpose_p.bind(operand, permutation=permutation)
 
-def argmin(operand: Array, axis: int,
+def argmin(operand: ArrayLike, axis: int,
            index_dtype: DType) -> Tuple[Array, Array]:
   """Computes the index of the minimum element along ``axis``."""
   return argmin_p.bind(operand, axes=(axis,),
                        index_dtype=dtypes.canonicalize_dtype(index_dtype))
 
-def argmax(operand: Array, axis: int,
+def argmax(operand: ArrayLike, axis: int,
            index_dtype: DType) -> Tuple[Array, Array]:
   """Computes the index of the maximum element along ``axis``."""
   return argmax_p.bind(operand, axes=(axis,),
@@ -1053,47 +1052,51 @@ def _get_monoid_reducer(monoid_op: Callable,
       return _reduce_min if np.equal(aval.val, _get_min_identity(dtype)) else None
   return None
 
-def _get_bitwise_and_identity(dtype: DType) -> Array:
+def _get_bitwise_and_identity(dtype: DType) -> np.ndarray:
   return np.array(-1, dtype)
 
-def _get_bitwise_or_identity(dtype: DType) -> Array:
+def _get_bitwise_or_identity(dtype: DType) -> np.ndarray:
   return np.array(0, dtype)
 
-def _get_max_identity(dtype: DType) -> Array:
+def _get_max_identity(dtype: DType) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(-np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
     return np.array(dtypes.iinfo(dtype).min, dtype)
   elif dtypes.issubdtype(dtype, np.bool_):
     return np.array(False, np.bool_)
+  else:
+    raise ValueError(f"Unsupported dtype for max: {dtype}")
 
-def _get_min_identity(dtype: DType) -> Array:
+def _get_min_identity(dtype: DType) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
     return np.array(dtypes.iinfo(dtype).max, dtype)
   elif dtypes.issubdtype(dtype, np.bool_):
     return np.array(True, np.bool_)
+  else:
+    raise ValueError(f"Unsupported dtype for min: {dtype}")
 
-def _reduce_sum(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_sum(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_sum_p.bind(operand, axes=tuple(axes))
 
-def _reduce_prod(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_prod(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_prod_p.bind(operand, axes=tuple(axes))
 
-def _reduce_max(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_max(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_max_p.bind(operand, axes=tuple(axes))
 
-def _reduce_min(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_min(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_min_p.bind(operand, axes=tuple(axes))
 
-def _reduce_or(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_or(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_or_p.bind(operand, axes=tuple(axes))
 
-def _reduce_and(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_and(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_and_p.bind(operand, axes=tuple(axes))
 
-def _reduce_xor(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_xor(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
   return reduce_xor_p.bind(operand, axes=tuple(axes))
 
 def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
@@ -1132,25 +1135,25 @@ def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
     dimension = canonicalize_axis(dimension, len(operand.shape))
     return sort_p.bind(operand, dimension=dimension, is_stable=is_stable, num_keys=1)[0]
 
-def sort_key_val(keys: Array, values: Array, dimension: int = -1,
-                 is_stable: bool = True) -> Tuple[Array, Array]:
+def sort_key_val(keys: NDArray, values: ArrayLike, dimension: int = -1,
+                 is_stable: bool = True) -> Tuple[NDArray, NDArray]:
   """Sorts ``keys`` along ``dimension`` and applies the same permutation to ``values``."""
   dimension = canonicalize_axis(dimension, len(keys.shape))
   k, v = sort_p.bind(keys, values, dimension=dimension, is_stable=is_stable, num_keys=1)
   return k, v
 
-def top_k(operand: Array, k: int) -> Tuple[Array, Array]:
+def top_k(operand: ArrayLike, k: int) -> Tuple[NDArray, NDArray]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``."""
   k = int(k)
   if k < 0:
     raise ValueError(f"k argument to top_k must be nonnegative, got {k}")
   return top_k_p.bind(operand, k=k)
 
-def tie_in(x: Array, y: Array) -> Array:
+def tie_in(x: Any, y: T) -> T:
   """Deprecated. Ignores ``x`` and returns ``y``."""
   return y
 
-def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Array:
+def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DType] = None) -> NDArray:
   """Returns an array of `shape` filled with `fill_value`.
 
   Args:
@@ -1168,7 +1171,7 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
   fill_value = _convert_element_type(fill_value, dtype, weak_type)
   return broadcast(fill_value, shape)
 
-def zeros_like_shaped_array(aval: Array) -> Array:
+def zeros_like_shaped_array(aval: ArrayLike) -> NDArray:
   assert isinstance(aval, ShapedArray)
   if aval.dtype == dtypes.float0:
     scalar_zero = np.zeros((), dtype=aval.dtype)
@@ -1178,14 +1181,14 @@ def zeros_like_shaped_array(aval: Array) -> Array:
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
-def iota(dtype: DType, size: int) -> Array:
+def iota(dtype: DType, size: int) -> NDArray:
   """Wraps XLA's `Iota
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
   operator.
   """
   return broadcasted_iota(dtype, (size,), 0)
 
-def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
+def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> NDArray:
   """Convenience wrapper around ``iota``."""
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = canonicalize_shape(shape)
@@ -1196,7 +1199,7 @@ def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
   return iota_p.bind(*dynamic_shape, dtype=dtype, shape=tuple(static_shape),
                      dimension=dimension)
 
-def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
+def _eye(dtype: DType, shape: Shape, offset: int) -> NDArray:
   """Like numpy.eye, create a 2D array with ones on a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1204,7 +1207,7 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
                 broadcasted_iota(np.int32, shape, 1))
   return convert_element_type_p.bind(bool_eye, new_dtype=dtype, weak_type=False)
 
-def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
+def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> NDArray:
   """This utility function exists for creating Kronecker delta arrays."""
   axes = map(int, axes)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1216,7 +1219,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
                                        new_dtype=dtype, weak_type=False)
   return broadcast_in_dim(result, shape, axes)
 
-def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
+def _tri(dtype: DType, shape: Shape, offset: int) -> NDArray:
   """Like numpy.tri, create a 2D array with ones below a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1257,7 +1260,7 @@ def stop_gradient(x: T) -> T:
 
 def reduce_precision(operand: Union[float, Array],
                      exponent_bits: int,
-                     mantissa_bits: int) -> Array:
+                     mantissa_bits: int) -> NDArray:
   """Wraps XLA's `ReducePrecision
   <https://www.tensorflow.org/xla/operation_semantics#reduceprecision>`_
   operator.
@@ -1268,7 +1271,7 @@ def reduce_precision(operand: Union[float, Array],
     operator.index, mantissa_bits, "mantissa_bits argument of lax.reduce_precision")
   return reduce_precision_p.bind(operand, exponent_bits=exponent_bits, mantissa_bits=mantissa_bits)
 
-def squeeze(array: Array, dimensions: Sequence[int]) -> Array:
+def squeeze(array: ArrayLike, dimensions: Sequence[int]) -> NDArray:
   """Squeeze any number of size 1 dimensions from an array."""
   ndim = np.ndim(array)
   dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
@@ -1276,7 +1279,7 @@ def squeeze(array: Array, dimensions: Sequence[int]) -> Array:
     return array
   return squeeze_p.bind(array, dimensions=dimensions)
 
-def expand_dims(array: Array, dimensions: Sequence[int]) -> Array:
+def expand_dims(array: ArrayLike, dimensions: Sequence[int]) -> NDArray:
   """Insert any number of size 1 dimensions into an array."""
   if len(set(dimensions)) != len(dimensions):
     raise ValueError(f'repeated axis in lax.expand_dims: {dimensions}')
@@ -1294,8 +1297,8 @@ def expand_dims(array: Array, dimensions: Sequence[int]) -> Array:
 
 ### convenience wrappers around traceables
 
-def full_like(x: Array, fill_value: Array, dtype: Optional[DType] = None,
-              shape: Optional[Shape] = None) -> Array:
+def full_like(x: ArrayLike, fill_value: ArrayLike, dtype: Optional[DType] = None,
+              shape: Optional[Shape] = None) -> NDArray:
   """Create a full array like np.full based on the example array `x`.
 
   Args:
@@ -1321,15 +1324,15 @@ def full_like(x: Array, fill_value: Array, dtype: Optional[DType] = None,
   # probably in the form of a primitive like `val = match_sharding_p.bind(x, val)`
   # (so it works in staged-out code as well as 'eager' code). Related to
   # equi-sharding.
-  if (config.jax_array and hasattr(x, 'sharding') and
-      not isinstance(x.sharding, sharding.SingleDeviceSharding)):
-    return array.make_array_from_callback(
-        fill_shape, x.sharding, lambda idx: val[idx])  # type: ignore[arg-type]
+  if config.jax_array and hasattr(x, 'sharding'):
+    if not isinstance(x.sharding, sharding.SingleDeviceSharding):  # type: ignore
+      return array.make_array_from_callback(
+          fill_shape, x.sharding, lambda idx: val[idx])  # type: ignore
   return val
 
 
-def collapse(operand: Array, start_dimension: int,
-             stop_dimension: int) -> Array:
+def collapse(operand: NDArray, start_dimension: int,
+             stop_dimension: int) -> NDArray:
   """Collapses dimensions of an array into a single dimension.
 
   For example, if ``operand`` is an array with shape ``[2, 3, 4]``,
@@ -1352,8 +1355,8 @@ def collapse(operand: Array, start_dimension: int,
   return reshape(operand, new_shape)
 
 
-def batch_matmul(lhs: Array, rhs: Array,
-                 precision: PrecisionLike = None) -> Array:
+def batch_matmul(lhs: NDArray, rhs: NDArray,
+                 precision: PrecisionLike = None) -> NDArray:
   """Batch matrix multiplication."""
   if _min(lhs.ndim, rhs.ndim) < 2:
     raise ValueError('Arguments to batch_matmul must be at least 2D, got {}, {}'
@@ -1371,11 +1374,11 @@ def batch_matmul(lhs: Array, rhs: Array,
 # These functions also exist in the XLA client library, but we treat them
 # as non-primitive to maintain a smaller set of autodiff primitives.
 
-def square(x: Array) -> Array:
+def square(x: ArrayLike) -> NDArray:
   r"""Elementwise square: :math:`x^2`."""
   return integer_pow(x, 2)
 
-def reciprocal(x: Array) -> Array:
+def reciprocal(x: ArrayLike) -> NDArray:
   r"""Elementwise reciprocal: :math:`1 \over x`."""
   return integer_pow(x, -1)
 
@@ -1390,39 +1393,39 @@ def _upcast_fp16_for_computation(f):
 
   return f_wrapped
 
-def tan(x: Array) -> Array:
+def tan(x: ArrayLike) -> NDArray:
   r"""Elementwise tangent: :math:`\mathrm{tan}(x)`."""
   return tan_p.bind(x)
 
-def asin(x: Array) -> Array:
+def asin(x: ArrayLike) -> NDArray:
   r"""Elementwise arc sine: :math:`\mathrm{asin}(x)`."""
   return asin_p.bind(x)
 
-def acos(x: Array) -> Array:
+def acos(x: ArrayLike) -> NDArray:
   r"""Elementwise arc cosine: :math:`\mathrm{acos}(x)`."""
   return acos_p.bind(x)
 
-def atan(x: Array) -> Array:
+def atan(x: ArrayLike) -> NDArray:
   r"""Elementwise arc tangent: :math:`\mathrm{atan}(x)`."""
   return atan_p.bind(x)
 
-def sinh(x: Array) -> Array:
+def sinh(x: ArrayLike) -> NDArray:
   r"""Elementwise hyperbolic sine: :math:`\mathrm{sinh}(x)`."""
   return sinh_p.bind(x)
 
-def cosh(x: Array) -> Array:
+def cosh(x: ArrayLike) -> NDArray:
   r"""Elementwise hyperbolic cosine: :math:`\mathrm{cosh}(x)`."""
   return cosh_p.bind(x)
 
-def asinh(x: Array) -> Array:
+def asinh(x: ArrayLike) -> NDArray:
   r"""Elementwise inverse hyperbolic sine: :math:`\mathrm{asinh}(x)`."""
   return asinh_p.bind(x)
 
-def acosh(x: Array) -> Array:
+def acosh(x: ArrayLike) -> NDArray:
   r"""Elementwise inverse hyperbolic cosine: :math:`\mathrm{acosh}(x)`."""
   return acosh_p.bind(x)
 
-def atanh(x: Array) -> Array:
+def atanh(x: ArrayLike) -> NDArray:
   r"""Elementwise inverse hyperbolic tangent: :math:`\mathrm{atanh}(x)`."""
   return atanh_p.bind(x)
 
@@ -1445,7 +1448,7 @@ ShapedArray._iter = staticmethod(_iter)
 
 # Add some ad handlers that use (or could use) lax primitives
 
-def zeros_like_array(x: Array) -> Array:
+def zeros_like_array(x: ArrayLike) -> NDArray:
   return full_like(x, 0)
 
 for t in itertools.chain(
@@ -4621,7 +4624,7 @@ _two: Callable = partial(full_like, shape=(), fill_value=2)
 dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 _dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 
-def _isnan(x) -> bool:
+def _isnan(x: ArrayLike) -> NDArray:
   return ne(x, x)
 
 def _iscomplex(x) -> bool:

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -44,7 +44,6 @@ from jax.interpreters import xla
 from jax.interpreters import pxla
 from jax.interpreters import ad
 from jax.interpreters import batching
-from jax.typing import ArrayLike, NDArray, Shape
 import jax._src.pretty_printer as pp
 from jax._src import util
 from jax._src.util import (cache, prod, safe_zip, safe_map, canonicalize_axis,
@@ -66,6 +65,11 @@ from jax._src.lax.utils import (
   standard_translate,
 )
 from jax._src.lax import slicing
+from jax._src.typing import Shape
+from jax._src.typing.ndarray import ArrayLike, Array
+
+# TODO(jakevdp): switch to typing.DtypeLike
+DtypeLike = Any
 
 xb = xla_bridge
 xc = xla_client
@@ -193,14 +197,12 @@ def _dyn_shape_staging_rule(trace, prim, out_aval, *args, **params):
 
 
 ### traceables
-Array = Any
-DType = Any
 
-def neg(x: ArrayLike) -> NDArray:
+def neg(x: ArrayLike) -> Array:
   r"""Elementwise negation: :math:`-x`."""
   return neg_p.bind(x)
 
-def sign(x: ArrayLike) -> NDArray:
+def sign(x: ArrayLike) -> Array:
   r"""Elementwise sign.
 
   For floating-point inputs, returns
@@ -224,7 +226,7 @@ def sign(x: ArrayLike) -> NDArray:
   """
   return sign_p.bind(x)
 
-def nextafter(x1: ArrayLike, x2: ArrayLike) -> NDArray:
+def nextafter(x1: ArrayLike, x2: ArrayLike) -> Array:
   r"""Returns the next representable value after `x1` in the direction of `x2`.
 
   Note that in some environments flush-denormal-to-zero semantics is used.
@@ -240,11 +242,11 @@ def nextafter(x1: ArrayLike, x2: ArrayLike) -> NDArray:
   """
   return nextafter_p.bind(x1, x2)
 
-def floor(x: ArrayLike) -> NDArray:
+def floor(x: ArrayLike) -> Array:
   r"""Elementwise floor: :math:`\left\lfloor x \right\rfloor`."""
   return floor_p.bind(x)
 
-def ceil(x: ArrayLike) -> NDArray:
+def ceil(x: ArrayLike) -> Array:
   r"""Elementwise ceiling: :math:`\left\lceil x \right\rceil`."""
   return ceil_p.bind(x)
 
@@ -254,7 +256,7 @@ class RoundingMethod(enum.IntEnum):
 
 def round(x: ArrayLike,
           rounding_method: RoundingMethod = RoundingMethod.AWAY_FROM_ZERO
-          ) -> NDArray:
+          ) -> Array:
   r"""Elementwise round.
 
   Rounds values to the nearest integer.
@@ -271,7 +273,7 @@ def round(x: ArrayLike,
   rounding_method = RoundingMethod(rounding_method)
   return round_p.bind(x, rounding_method=rounding_method)
 
-def is_finite(x: ArrayLike) -> NDArray:
+def is_finite(x: ArrayLike) -> Array:
   r"""Elementwise :math:`\mathrm{isfinite}`.
 
   For each element x returns `True` if and only if x is not :math:`\pm\infty` or
@@ -279,178 +281,178 @@ def is_finite(x: ArrayLike) -> NDArray:
   """
   return is_finite_p.bind(x)
 
-def exp(x: ArrayLike) -> NDArray:
+def exp(x: ArrayLike) -> Array:
   r"""Elementwise exponential: :math:`e^x`."""
   return exp_p.bind(x)
 
-def expm1(x: ArrayLike) -> NDArray:
+def expm1(x: ArrayLike) -> Array:
   r"""Elementwise :math:`e^{x} - 1`."""
   return expm1_p.bind(x)
 
-def log(x: ArrayLike) -> NDArray:
+def log(x: ArrayLike) -> Array:
   r"""Elementwise natural logarithm: :math:`\mathrm{log}(x)`."""
   return log_p.bind(x)
 
-def log1p(x: ArrayLike) -> NDArray:
+def log1p(x: ArrayLike) -> Array:
   r"""Elementwise :math:`\mathrm{log}(1 + x)`."""
   return log1p_p.bind(x)
 
-def tanh(x: ArrayLike) -> NDArray:
+def tanh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic tangent: :math:`\mathrm{tanh}(x)`."""
   return tanh_p.bind(x)
 
-def sin(x: ArrayLike) -> NDArray:
+def sin(x: ArrayLike) -> Array:
   r"""Elementwise sine: :math:`\mathrm{sin}(x)`."""
   return sin_p.bind(x)
 
-def cos(x: ArrayLike) -> NDArray:
+def cos(x: ArrayLike) -> Array:
   r"""Elementwise cosine: :math:`\mathrm{cos}(x)`."""
   return cos_p.bind(x)
 
-def atan2(x: ArrayLike, y: ArrayLike) -> NDArray:
+def atan2(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arc tangent of two variables:
     :math:`\mathrm{atan}({x \over y})`."""
   return atan2_p.bind(x, y)
 
-def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> NDArray:
+def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete beta integral."""
   return regularized_incomplete_beta_p.bind(a, b, x)
 
-def lgamma(x: ArrayLike) -> NDArray:
+def lgamma(x: ArrayLike) -> Array:
   r"""Elementwise log gamma: :math:`\mathrm{log}(\Gamma(x))`."""
   return lgamma_p.bind(x)
 
-def digamma(x: ArrayLike) -> NDArray:
+def digamma(x: ArrayLike) -> Array:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)
 
-def igamma(a: ArrayLike, x: ArrayLike) -> NDArray:
+def igamma(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete gamma function."""
   return igamma_p.bind(a, x)
 
-def igammac(a: ArrayLike, x: ArrayLike) -> NDArray:
+def igammac(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise complementary regularized incomplete gamma function."""
   return igammac_p.bind(a, x)
 
-def igamma_grad_a(a: ArrayLike, x: ArrayLike) -> NDArray:
+def igamma_grad_a(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise derivative of the regularized incomplete gamma function."""
   return igamma_grad_a_p.bind(a, x)
 
-def random_gamma_grad(a: ArrayLike, x: ArrayLike) -> NDArray:
+def random_gamma_grad(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise derivative of samples from `Gamma(a, 1)`."""
   return random_gamma_grad_p.bind(a, x)
 
-def bessel_i0e(x: ArrayLike) -> NDArray:
+def bessel_i0e(x: ArrayLike) -> Array:
   r"""Exponentially scaled modified Bessel function of order 0:
   :math:`\mathrm{i0e}(x) = e^{-|x|} \mathrm{i0}(x)`
   """
   return bessel_i0e_p.bind(x)
 
-def bessel_i1e(x: ArrayLike) -> NDArray:
+def bessel_i1e(x: ArrayLike) -> Array:
   r"""Exponentially scaled modified Bessel function of order 1:
   :math:`\mathrm{i1e}(x) = e^{-|x|} \mathrm{i1}(x)`
   """
   return bessel_i1e_p.bind(x)
 
-def erf(x: ArrayLike) -> NDArray:
+def erf(x: ArrayLike) -> Array:
   r"""Elementwise error function: :math:`\mathrm{erf}(x)`."""
   return erf_p.bind(x)
 
-def erfc(x: ArrayLike) -> NDArray:
+def erfc(x: ArrayLike) -> Array:
   r"""Elementwise complementary error function:
     :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
   return erfc_p.bind(x)
 
-def erf_inv(x: ArrayLike) -> NDArray:
+def erf_inv(x: ArrayLike) -> Array:
   r"""Elementwise inverse error function: :math:`\mathrm{erf}^{-1}(x)`."""
   return erf_inv_p.bind(x)
 
-def real(x: ArrayLike) -> NDArray:
+def real(x: ArrayLike) -> Array:
   r"""Elementwise extract real part: :math:`\mathrm{Re}(x)`.
 
   Returns the real part of a complex number.
   """
   return real_p.bind(x)
 
-def imag(x: ArrayLike) -> NDArray:
+def imag(x: ArrayLike) -> Array:
   r"""Elementwise extract imaginary part: :math:`\mathrm{Im}(x)`.
 
   Returns the imaginary part of a complex number.
   """
   return imag_p.bind(x)
 
-def complex(x: ArrayLike, y: ArrayLike) -> NDArray:
+def complex(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise make complex number: :math:`x + jy`.
 
   Builds a complex number from real and imaginary parts.
   """
   return complex_p.bind(x, y)
 
-def conj(x: ArrayLike) -> NDArray:
+def conj(x: ArrayLike) -> Array:
   r"""Elementwise complex conjugate function: :math:`\overline{x}`."""
   return conj_p.bind(x, input_dtype=_dtype(x))
 
-def abs(x: ArrayLike) -> NDArray:
+def abs(x: ArrayLike) -> Array:
   r"""Elementwise absolute value: :math:`|x|`."""
   return abs_p.bind(x)
 
-def pow(x: ArrayLike, y: ArrayLike) -> NDArray:
+def pow(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise power: :math:`x^y`."""
   return pow_p.bind(x, y)
 
-def integer_pow(x: ArrayLike, y: int) -> NDArray:
+def integer_pow(x: ArrayLike, y: int) -> Array:
   r"""Elementwise power: :math:`x^y`, where :math:`y` is a fixed integer."""
   return integer_pow_p.bind(x, y=y)
 
-def sqrt(x: ArrayLike) -> NDArray:
+def sqrt(x: ArrayLike) -> Array:
   r"""Elementwise square root: :math:`\sqrt{x}`."""
   return sqrt_p.bind(x)
 
-def rsqrt(x: ArrayLike) -> NDArray:
+def rsqrt(x: ArrayLike) -> Array:
   r"""Elementwise reciprocal square root:  :math:`1 \over \sqrt{x}`."""
   return rsqrt_p.bind(x)
 
-def cbrt(x: ArrayLike) -> NDArray:
+def cbrt(x: ArrayLike) -> Array:
   r"""Elementwise cube root: :math:`\sqrt[3]{x}`."""
   return cbrt_p.bind(x)
 
-def bitwise_not(x: ArrayLike) -> NDArray:
+def bitwise_not(x: ArrayLike) -> Array:
   r"""Elementwise NOT: :math:`\neg x`."""
   return not_p.bind(x)
 
-def bitwise_and(x: ArrayLike, y: ArrayLike) -> NDArray:
+def bitwise_and(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise AND: :math:`x \wedge y`."""
   return and_p.bind(x, y)
 
-def bitwise_or(x: ArrayLike, y: ArrayLike) -> NDArray:
+def bitwise_or(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise OR: :math:`x \vee y`."""
   return or_p.bind(x, y)
 
-def bitwise_xor(x: ArrayLike, y: ArrayLike) -> NDArray:
+def bitwise_xor(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise exclusive OR: :math:`x \oplus y`."""
   return xor_p.bind(x, y)
 
-def population_count(x: ArrayLike) -> NDArray:
+def population_count(x: ArrayLike) -> Array:
   r"""Elementwise popcount, count the number of set bits in each element."""
   return population_count_p.bind(x)
 
-def clz(x: ArrayLike) -> NDArray:
+def clz(x: ArrayLike) -> Array:
   r"""Elementwise count-leading-zeros."""
   return clz_p.bind(x)
 
-def add(x: ArrayLike, y: ArrayLike) -> NDArray:
+def add(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise addition: :math:`x + y`."""
   return add_p.bind(x, y)
 
-def sub(x: ArrayLike, y: ArrayLike) -> NDArray:
+def sub(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise subtraction: :math:`x - y`."""
   return sub_p.bind(x, y)
 
-def mul(x: ArrayLike, y: ArrayLike) -> NDArray:
+def mul(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise multiplication: :math:`x \times y`."""
   return mul_p.bind(x, y)
 
-def div(x: ArrayLike, y: ArrayLike) -> NDArray:
+def div(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise division: :math:`x \over y`.
 
   Integer division overflow
@@ -459,7 +461,7 @@ def div(x: ArrayLike, y: ArrayLike) -> NDArray:
   """
   return div_p.bind(x, y)
 
-def rem(x: ArrayLike, y: ArrayLike) -> NDArray:
+def rem(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise remainder: :math:`x \bmod y`.
 
   The sign of the result is taken from the dividend,
@@ -472,57 +474,57 @@ def rem(x: ArrayLike, y: ArrayLike) -> NDArray:
   """
   return rem_p.bind(x, y)
 
-def max(x: ArrayLike, y: ArrayLike) -> NDArray:
+def max(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise maximum: :math:`\mathrm{max}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return max_p.bind(x, y)
 
-def min(x: ArrayLike, y: ArrayLike) -> NDArray:
+def min(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise minimum:  :math:`\mathrm{min}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return min_p.bind(x, y)
 
-def shift_left(x: ArrayLike, y: ArrayLike) -> NDArray:
+def shift_left(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise left shift: :math:`x \ll y`."""
   return shift_left_p.bind(x, y)
 
-def shift_right_arithmetic(x: ArrayLike, y: ArrayLike) -> NDArray:
+def shift_right_arithmetic(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arithmetic right shift: :math:`x \gg y`."""
   return shift_right_arithmetic_p.bind(x, y)
 
-def shift_right_logical(x: ArrayLike, y: ArrayLike) -> NDArray:
+def shift_right_logical(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise logical right shift: :math:`x \gg y`."""
   return shift_right_logical_p.bind(x, y)
 
-def eq(x: ArrayLike, y: ArrayLike) -> NDArray:
+def eq(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise equals: :math:`x = y`."""
   return eq_p.bind(x, y)
 
-def ne(x: ArrayLike, y: ArrayLike) -> NDArray:
+def ne(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise not-equals: :math:`x \neq y`."""
   return ne_p.bind(x, y)
 
-def ge(x: ArrayLike, y: ArrayLike) -> NDArray:
+def ge(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise greater-than-or-equals: :math:`x \geq y`."""
   return ge_p.bind(x, y)
 
-def gt(x: ArrayLike, y: ArrayLike) -> NDArray:
+def gt(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise greater-than: :math:`x > y`."""
   return gt_p.bind(x, y)
 
-def le(x: ArrayLike, y: ArrayLike) -> NDArray:
+def le(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise less-than-or-equals: :math:`x \leq y`."""
   return le_p.bind(x, y)
 
-def lt(x: ArrayLike, y: ArrayLike) -> NDArray:
+def lt(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise less-than: :math:`x < y`."""
   return lt_p.bind(x, y)
 
-def convert_element_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
+def convert_element_type(operand: ArrayLike, new_dtype: DtypeLike) -> Array:
   """Elementwise cast.
 
   Wraps XLA's `ConvertElementType
@@ -541,7 +543,7 @@ def convert_element_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
     operand = operand.__jax_array__()  # type: ignore
   return _convert_element_type(operand, new_dtype, weak_type=False)
 
-def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DType] = None,
+def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DtypeLike] = None,
                           weak_type: bool = False):
   from jax.experimental import array
 
@@ -573,12 +575,12 @@ def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DType] = None,
 
   if ((old_dtype, old_weak_type) == (new_dtype, new_weak_type)
       and isinstance(operand, (core.Tracer, device_array.DeviceArray, array.Array))):
-    return operand
+    return type_cast(Array, operand)
   else:
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
                                        weak_type=new_weak_type)
 
-def bitcast_convert_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
+def bitcast_convert_type(operand: ArrayLike, new_dtype: DtypeLike) -> Array:
   """Elementwise bitcast.
 
   Wraps XLA's `BitcastConvertType
@@ -597,7 +599,7 @@ def bitcast_convert_type(operand: ArrayLike, new_dtype: DType) -> NDArray:
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
   return bitcast_convert_type_p.bind(operand, new_dtype=new_dtype)
 
-def clamp(min: ArrayLike, x: ArrayLike, max: ArrayLike) -> NDArray:
+def clamp(min: ArrayLike, x: ArrayLike, max: ArrayLike) -> Array:
   r"""Elementwise clamp.
 
   Returns :math:`\mathrm{clamp}(x) = \begin{cases}
@@ -608,7 +610,7 @@ def clamp(min: ArrayLike, x: ArrayLike, max: ArrayLike) -> NDArray:
   """
   return clamp_p.bind(min, x, max)
 
-def concatenate(operands: Union[NDArray, Sequence[ArrayLike]], dimension: int) -> NDArray:
+def concatenate(operands: Union[Array, Sequence[ArrayLike]], dimension: int) -> Array:
   """Concatenates a sequence of arrays along `dimension`.
 
   Wraps XLA's `Concatenate
@@ -681,8 +683,8 @@ PrecisionType = Precision
 PrecisionLike = Union[None, str, PrecisionType, Tuple[str, str],
                       Tuple[PrecisionType, PrecisionType]]
 
-def dot(lhs: NDArray, rhs: NDArray, precision: PrecisionLike = None,
-        preferred_element_type: Optional[DType] = None) -> NDArray:
+def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
+        preferred_element_type: Optional[DtypeLike] = None) -> Array:
   """Vector/vector, matrix/vector, and matrix/matrix multiplication.
 
   Wraps XLA's `Dot
@@ -719,7 +721,7 @@ DotDimensionNumbers = Tuple[Tuple[Sequence[int], Sequence[int]],
 
 def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionNumbers,
                 precision: PrecisionLike = None,
-                preferred_element_type: Optional[DType] = None) -> NDArray:
+                preferred_element_type: Optional[DtypeLike] = None) -> Array:
   """More general contraction operator.
 
   Wraps XLA's `DotGeneral
@@ -756,7 +758,7 @@ def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionN
                             precision=canonicalize_precision(precision),
                             preferred_element_type=preferred_element_type)
 
-def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> NDArray:
+def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> Array:
   """Broadcasts an array, adding new leading dimensions
 
   Args:
@@ -774,7 +776,7 @@ def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> NDArray:
   return broadcast_in_dim(operand, tuple(sizes) + np.shape(operand), dims)
 
 def broadcast_in_dim(operand: ArrayLike, shape: Shape,
-                     broadcast_dimensions: Sequence[int]) -> NDArray:
+                     broadcast_dimensions: Sequence[int]) -> Array:
   """Wraps XLA's `BroadcastInDim
   <https://www.tensorflow.org/xla/operation_semantics#broadcastindim>`_
   operator.
@@ -795,7 +797,7 @@ def broadcast_in_dim(operand: ArrayLike, shape: Shape,
 
   if (np.ndim(operand) == len(shape) and not len(broadcast_dimensions)
       and isinstance(operand, (device_array.DeviceArray, core.Tracer, array.Array))):
-    return operand
+    return type_cast(Array, operand)
   if config.jax_dynamic_shapes:
     # We must gate this behavior under a flag because otherwise the errors
     # raised are different (and have worse source provenance information).
@@ -806,12 +808,12 @@ def broadcast_in_dim(operand: ArrayLike, shape: Shape,
       operand, *dyn_shape, shape=tuple(static_shape),
       broadcast_dimensions=tuple(broadcast_dimensions))
 
-def broadcast_to_rank(x: NDArray, rank: int) -> NDArray:
+def broadcast_to_rank(x: Array, rank: int) -> Array:
   """Adds leading dimensions of ``1`` to give ``x`` rank ``rank``."""
   return broadcast(x, (1,) * (rank - x.ndim))
 
 def reshape(operand: ArrayLike, new_sizes: Shape,
-            dimensions: Optional[Sequence[int]] = None) -> NDArray:
+            dimensions: Optional[Sequence[int]] = None) -> Array:
   """Wraps XLA's `Reshape
   <https://www.tensorflow.org/xla/operation_semantics#reshape>`_
   operator.
@@ -862,7 +864,7 @@ def reshape(operand: ArrayLike, new_sizes: Shape,
     same_dims = tuple(dims) == tuple(range(np.ndim(operand)))
   if (np.shape(operand) and same_shape and same_dims
       and isinstance(operand, (core.Tracer, device_array.DeviceArray, array.Array))):
-    return operand
+    return type_cast(Array, operand)
   else:
     dyn_shape, static_new_sizes = _extract_tracers_dyn_shape(new_sizes)
 
@@ -871,7 +873,7 @@ def reshape(operand: ArrayLike, new_sizes: Shape,
       dimensions=None if dims is None or same_dims else dims)
 
 def pad(operand: ArrayLike, padding_value: ArrayLike,
-        padding_config: Sequence[Tuple[int, int, int]]) -> NDArray:
+        padding_config: Sequence[Tuple[int, int, int]]) -> Array:
   """Applies low, high, and/or interior padding to an array.
 
   Wraps XLA's `Pad
@@ -892,14 +894,14 @@ def pad(operand: ArrayLike, padding_value: ArrayLike,
   """
   return pad_p.bind(operand, padding_value, padding_config=tuple(padding_config))
 
-def rev(operand: ArrayLike, dimensions: Sequence[int]) -> NDArray:
+def rev(operand: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Wraps XLA's `Rev
   <https://www.tensorflow.org/xla/operation_semantics#rev_reverse>`_
   operator.
   """
   return rev_p.bind(operand, dimensions=tuple(dimensions))
 
-def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> NDArray:
+def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> Array:
   """Wraps XLA's `Select
   <https://www.tensorflow.org/xla/operation_semantics#select>`_
   operator.
@@ -908,7 +910,7 @@ def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> NDArray:
   # select(). This is because it implements `select_n`.
   return select_n_p.bind(pred, on_false, on_true)
 
-def select_n(which: ArrayLike, *cases: ArrayLike) -> NDArray:
+def select_n(which: ArrayLike, *cases: ArrayLike) -> Array:
   """Selects array values from multiple cases.
 
   Generalizes XLA's `Select
@@ -934,26 +936,28 @@ def select_n(which: ArrayLike, *cases: ArrayLike) -> NDArray:
   return select_n_p.bind(which, *cases)
 
 
-def transpose(operand: ArrayLike, permutation: Sequence[int]) -> NDArray:
+def transpose(operand: ArrayLike, permutation: Sequence[int]) -> Array:
   """Wraps XLA's `Transpose
   <https://www.tensorflow.org/xla/operation_semantics#transpose>`_
   operator.
   """
+  from jax.experimental import array
+
   permutation = tuple(operator.index(d) for d in permutation)
   if (permutation == tuple(range(np.ndim(operand)))
-      and isinstance(operand, (core.Tracer, device_array.DeviceArray))):
-    return operand
+      and isinstance(operand, (core.Tracer, device_array.DeviceArray, array.Array))):
+    return type_cast(Array, operand)
   else:
     return transpose_p.bind(operand, permutation=permutation)
 
 def argmin(operand: ArrayLike, axis: int,
-           index_dtype: DType) -> Tuple[Array, Array]:
+           index_dtype: DtypeLike) -> Tuple[Array, Array]:
   """Computes the index of the minimum element along ``axis``."""
   return argmin_p.bind(operand, axes=(axis,),
                        index_dtype=dtypes.canonicalize_dtype(index_dtype))
 
 def argmax(operand: ArrayLike, axis: int,
-           index_dtype: DType) -> Tuple[Array, Array]:
+           index_dtype: DtypeLike) -> Tuple[Array, Array]:
   """Computes the index of the maximum element along ``axis``."""
   return argmax_p.bind(operand, axes=(axis,),
                        index_dtype=dtypes.canonicalize_dtype(index_dtype))
@@ -1052,13 +1056,13 @@ def _get_monoid_reducer(monoid_op: Callable,
       return _reduce_min if np.equal(aval.val, _get_min_identity(dtype)) else None
   return None
 
-def _get_bitwise_and_identity(dtype: DType) -> np.ndarray:
+def _get_bitwise_and_identity(dtype: DtypeLike) -> np.ndarray:
   return np.array(-1, dtype)
 
-def _get_bitwise_or_identity(dtype: DType) -> np.ndarray:
+def _get_bitwise_or_identity(dtype: DtypeLike) -> np.ndarray:
   return np.array(0, dtype)
 
-def _get_max_identity(dtype: DType) -> np.ndarray:
+def _get_max_identity(dtype: DtypeLike) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(-np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
@@ -1068,7 +1072,7 @@ def _get_max_identity(dtype: DType) -> np.ndarray:
   else:
     raise ValueError(f"Unsupported dtype for max: {dtype}")
 
-def _get_min_identity(dtype: DType) -> np.ndarray:
+def _get_min_identity(dtype: DtypeLike) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
@@ -1078,25 +1082,25 @@ def _get_min_identity(dtype: DType) -> np.ndarray:
   else:
     raise ValueError(f"Unsupported dtype for min: {dtype}")
 
-def _reduce_sum(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_sum(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_sum_p.bind(operand, axes=tuple(axes))
 
-def _reduce_prod(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_prod(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_prod_p.bind(operand, axes=tuple(axes))
 
-def _reduce_max(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_max(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_max_p.bind(operand, axes=tuple(axes))
 
-def _reduce_min(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_min(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_min_p.bind(operand, axes=tuple(axes))
 
-def _reduce_or(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_or(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_or_p.bind(operand, axes=tuple(axes))
 
-def _reduce_and(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_and(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_and_p.bind(operand, axes=tuple(axes))
 
-def _reduce_xor(operand: ArrayLike, axes: Sequence[int]) -> NDArray:
+def _reduce_xor(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_xor_p.bind(operand, axes=tuple(axes))
 
 def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
@@ -1135,14 +1139,14 @@ def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
     dimension = canonicalize_axis(dimension, len(operand.shape))
     return sort_p.bind(operand, dimension=dimension, is_stable=is_stable, num_keys=1)[0]
 
-def sort_key_val(keys: NDArray, values: ArrayLike, dimension: int = -1,
-                 is_stable: bool = True) -> Tuple[NDArray, NDArray]:
+def sort_key_val(keys: Array, values: ArrayLike, dimension: int = -1,
+                 is_stable: bool = True) -> Tuple[Array, Array]:
   """Sorts ``keys`` along ``dimension`` and applies the same permutation to ``values``."""
   dimension = canonicalize_axis(dimension, len(keys.shape))
   k, v = sort_p.bind(keys, values, dimension=dimension, is_stable=is_stable, num_keys=1)
   return k, v
 
-def top_k(operand: ArrayLike, k: int) -> Tuple[NDArray, NDArray]:
+def top_k(operand: ArrayLike, k: int) -> Tuple[Array, Array]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``."""
   k = int(k)
   if k < 0:
@@ -1153,7 +1157,7 @@ def tie_in(x: Any, y: T) -> T:
   """Deprecated. Ignores ``x`` and returns ``y``."""
   return y
 
-def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DType] = None) -> NDArray:
+def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DtypeLike] = None) -> Array:
   """Returns an array of `shape` filled with `fill_value`.
 
   Args:
@@ -1171,7 +1175,7 @@ def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DType] = None) -> 
   fill_value = _convert_element_type(fill_value, dtype, weak_type)
   return broadcast(fill_value, shape)
 
-def zeros_like_shaped_array(aval: ArrayLike) -> NDArray:
+def zeros_like_shaped_array(aval: ArrayLike) -> Array:
   assert isinstance(aval, ShapedArray)
   if aval.dtype == dtypes.float0:
     scalar_zero = np.zeros((), dtype=aval.dtype)
@@ -1181,14 +1185,14 @@ def zeros_like_shaped_array(aval: ArrayLike) -> NDArray:
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
-def iota(dtype: DType, size: int) -> NDArray:
+def iota(dtype: DtypeLike, size: int) -> Array:
   """Wraps XLA's `Iota
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
   operator.
   """
   return broadcasted_iota(dtype, (size,), 0)
 
-def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> NDArray:
+def broadcasted_iota(dtype: DtypeLike, shape: Shape, dimension: int) -> Array:
   """Convenience wrapper around ``iota``."""
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = canonicalize_shape(shape)
@@ -1199,7 +1203,7 @@ def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> NDArray:
   return iota_p.bind(*dynamic_shape, dtype=dtype, shape=tuple(static_shape),
                      dimension=dimension)
 
-def _eye(dtype: DType, shape: Shape, offset: int) -> NDArray:
+def _eye(dtype: DtypeLike, shape: Shape, offset: int) -> Array:
   """Like numpy.eye, create a 2D array with ones on a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1207,7 +1211,7 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> NDArray:
                 broadcasted_iota(np.int32, shape, 1))
   return convert_element_type_p.bind(bool_eye, new_dtype=dtype, weak_type=False)
 
-def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> NDArray:
+def _delta(dtype: DtypeLike, shape: Shape, axes: Sequence[int]) -> Array:
   """This utility function exists for creating Kronecker delta arrays."""
   axes = map(int, axes)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1219,7 +1223,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> NDArray:
                                        new_dtype=dtype, weak_type=False)
   return broadcast_in_dim(result, shape, axes)
 
-def _tri(dtype: DType, shape: Shape, offset: int) -> NDArray:
+def _tri(dtype: DtypeLike, shape: Shape, offset: int) -> Array:
   """Like numpy.tri, create a 2D array with ones below a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1260,7 +1264,7 @@ def stop_gradient(x: T) -> T:
 
 def reduce_precision(operand: Union[float, Array],
                      exponent_bits: int,
-                     mantissa_bits: int) -> NDArray:
+                     mantissa_bits: int) -> Array:
   """Wraps XLA's `ReducePrecision
   <https://www.tensorflow.org/xla/operation_semantics#reduceprecision>`_
   operator.
@@ -1271,15 +1275,17 @@ def reduce_precision(operand: Union[float, Array],
     operator.index, mantissa_bits, "mantissa_bits argument of lax.reduce_precision")
   return reduce_precision_p.bind(operand, exponent_bits=exponent_bits, mantissa_bits=mantissa_bits)
 
-def squeeze(array: ArrayLike, dimensions: Sequence[int]) -> NDArray:
+def squeeze(operand: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Squeeze any number of size 1 dimensions from an array."""
-  ndim = np.ndim(array)
-  dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
-  if not dimensions and isinstance(array, (core.Tracer, device_array.DeviceArray)):
-    return array
-  return squeeze_p.bind(array, dimensions=dimensions)
+  from jax.experimental import array
 
-def expand_dims(array: ArrayLike, dimensions: Sequence[int]) -> NDArray:
+  ndim = np.ndim(operand)
+  dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
+  if not dimensions and isinstance(operand, (core.Tracer, device_array.DeviceArray, array.Array)):
+    return type_cast(Array, operand)
+  return squeeze_p.bind(operand, dimensions=dimensions)
+
+def expand_dims(array: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Insert any number of size 1 dimensions into an array."""
   if len(set(dimensions)) != len(dimensions):
     raise ValueError(f'repeated axis in lax.expand_dims: {dimensions}')
@@ -1297,8 +1303,8 @@ def expand_dims(array: ArrayLike, dimensions: Sequence[int]) -> NDArray:
 
 ### convenience wrappers around traceables
 
-def full_like(x: ArrayLike, fill_value: ArrayLike, dtype: Optional[DType] = None,
-              shape: Optional[Shape] = None) -> NDArray:
+def full_like(x: ArrayLike, fill_value: ArrayLike, dtype: Optional[DtypeLike] = None,
+              shape: Optional[Shape] = None) -> Array:
   """Create a full array like np.full based on the example array `x`.
 
   Args:
@@ -1331,8 +1337,8 @@ def full_like(x: ArrayLike, fill_value: ArrayLike, dtype: Optional[DType] = None
   return val
 
 
-def collapse(operand: NDArray, start_dimension: int,
-             stop_dimension: int) -> NDArray:
+def collapse(operand: Array, start_dimension: int,
+             stop_dimension: int) -> Array:
   """Collapses dimensions of an array into a single dimension.
 
   For example, if ``operand`` is an array with shape ``[2, 3, 4]``,
@@ -1355,8 +1361,8 @@ def collapse(operand: NDArray, start_dimension: int,
   return reshape(operand, new_shape)
 
 
-def batch_matmul(lhs: NDArray, rhs: NDArray,
-                 precision: PrecisionLike = None) -> NDArray:
+def batch_matmul(lhs: Array, rhs: Array,
+                 precision: PrecisionLike = None) -> Array:
   """Batch matrix multiplication."""
   if _min(lhs.ndim, rhs.ndim) < 2:
     raise ValueError('Arguments to batch_matmul must be at least 2D, got {}, {}'
@@ -1374,11 +1380,11 @@ def batch_matmul(lhs: NDArray, rhs: NDArray,
 # These functions also exist in the XLA client library, but we treat them
 # as non-primitive to maintain a smaller set of autodiff primitives.
 
-def square(x: ArrayLike) -> NDArray:
+def square(x: ArrayLike) -> Array:
   r"""Elementwise square: :math:`x^2`."""
   return integer_pow(x, 2)
 
-def reciprocal(x: ArrayLike) -> NDArray:
+def reciprocal(x: ArrayLike) -> Array:
   r"""Elementwise reciprocal: :math:`1 \over x`."""
   return integer_pow(x, -1)
 
@@ -1393,39 +1399,39 @@ def _upcast_fp16_for_computation(f):
 
   return f_wrapped
 
-def tan(x: ArrayLike) -> NDArray:
+def tan(x: ArrayLike) -> Array:
   r"""Elementwise tangent: :math:`\mathrm{tan}(x)`."""
   return tan_p.bind(x)
 
-def asin(x: ArrayLike) -> NDArray:
+def asin(x: ArrayLike) -> Array:
   r"""Elementwise arc sine: :math:`\mathrm{asin}(x)`."""
   return asin_p.bind(x)
 
-def acos(x: ArrayLike) -> NDArray:
+def acos(x: ArrayLike) -> Array:
   r"""Elementwise arc cosine: :math:`\mathrm{acos}(x)`."""
   return acos_p.bind(x)
 
-def atan(x: ArrayLike) -> NDArray:
+def atan(x: ArrayLike) -> Array:
   r"""Elementwise arc tangent: :math:`\mathrm{atan}(x)`."""
   return atan_p.bind(x)
 
-def sinh(x: ArrayLike) -> NDArray:
+def sinh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic sine: :math:`\mathrm{sinh}(x)`."""
   return sinh_p.bind(x)
 
-def cosh(x: ArrayLike) -> NDArray:
+def cosh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic cosine: :math:`\mathrm{cosh}(x)`."""
   return cosh_p.bind(x)
 
-def asinh(x: ArrayLike) -> NDArray:
+def asinh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic sine: :math:`\mathrm{asinh}(x)`."""
   return asinh_p.bind(x)
 
-def acosh(x: ArrayLike) -> NDArray:
+def acosh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic cosine: :math:`\mathrm{acosh}(x)`."""
   return acosh_p.bind(x)
 
-def atanh(x: ArrayLike) -> NDArray:
+def atanh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic tangent: :math:`\mathrm{atanh}(x)`."""
   return atanh_p.bind(x)
 
@@ -1448,7 +1454,7 @@ ShapedArray._iter = staticmethod(_iter)
 
 # Add some ad handlers that use (or could use) lax primitives
 
-def zeros_like_array(x: ArrayLike) -> NDArray:
+def zeros_like_array(x: ArrayLike) -> Array:
   return full_like(x, 0)
 
 for t in itertools.chain(
@@ -2453,7 +2459,7 @@ def _masked(padded_value, logical_shape, dimensions, value=0):
 
 
 def _dot_general_shape_rule(lhs, rhs, *, dimension_numbers, precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   if not all(np.all(np.greater_equal(d, 0)) and np.all(np.less(d, lhs.ndim))
              for d in (lhs_contracting, lhs_batch)):
@@ -2529,7 +2535,7 @@ def tuple_delete(tup, idx):
 
 
 def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   input_dtype = naryop_dtype_rule(_input_dtype, [_any, _any], 'dot_general', lhs, rhs)
   if preferred_element_type is None:
     return input_dtype
@@ -2537,7 +2543,7 @@ def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
   return preferred_element_type
 
 def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
-                               preferred_element_type: Optional[DType],
+                               preferred_element_type: Optional[DtypeLike],
                                swap_ans=False):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   x_ndim = g.ndim - y.ndim + len(x_batch) + 2 * len(x_contract)
@@ -2554,7 +2560,7 @@ def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
                    tuple(out_axes))
 
 def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision,
-                               preferred_element_type: Optional[DType]):
+                               preferred_element_type: Optional[DtypeLike]):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   swapped_dimension_numbers = ((y_contract, x_contract), (y_batch, x_batch))
   return _dot_general_transpose_lhs(
@@ -2565,7 +2571,7 @@ def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision,
 
 def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
                             precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   lhs, rhs = batched_args
   new_dimension_numbers, result_batch_dim = _dot_general_batch_dim_nums(
       (lhs.ndim, rhs.ndim), batch_dims, dimension_numbers)
@@ -4624,7 +4630,7 @@ _two: Callable = partial(full_like, shape=(), fill_value=2)
 dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 _dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 
-def _isnan(x: ArrayLike) -> NDArray:
+def _isnan(x: ArrayLike) -> Array:
   return ne(x, x)
 
 def _iscomplex(x) -> bool:

--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -14,8 +14,8 @@
 
 
 from typing import Any, Optional, Sequence, Tuple, Union, cast as type_cast
-from jax.typing import NDArray
 from jax._src.numpy import lax_numpy as jnp
+from jax._src.typing.ndarray import Array
 from jax._src.util import prod
 from jax._src.lax import lax
 from jax._src.lax import convolution
@@ -127,7 +127,7 @@ def conv_general_dilated_local(
     rhs_dilation: Optional[Sequence[int]] = None,
     dimension_numbers: Optional[convolution.ConvGeneralDilatedDimensionNumbers] = None,
     precision: lax.PrecisionLike = None
-) -> NDArray:
+) -> Array:
   """General n-dimensional unshared convolution operator with optional dilation.
 
   Also known as locally connected layer, the operation is equivalent to

--- a/jax/_src/lax/other.py
+++ b/jax/_src/lax/other.py
@@ -14,6 +14,7 @@
 
 
 from typing import Any, Optional, Sequence, Tuple, Union, cast as type_cast
+from jax.typing import NDArray
 from jax._src.numpy import lax_numpy as jnp
 from jax._src.util import prod
 from jax._src.lax import lax
@@ -126,7 +127,7 @@ def conv_general_dilated_local(
     rhs_dilation: Optional[Sequence[int]] = None,
     dimension_numbers: Optional[convolution.ConvGeneralDilatedDimensionNumbers] = None,
     precision: lax.PrecisionLike = None
-) -> jnp.ndarray:
+) -> NDArray:
   """General n-dimensional unshared convolution operator with optional dilation.
 
   Also known as locally connected layer, the operation is equivalent to

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -40,12 +40,12 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.lib import xla_bridge
 from jax._src.lib import xla_client
+from jax._src.typing.simple import Shape
 
 xb = xla_bridge
 xc = xla_client
 
 Array = Any
-Shape = core.Shape
 
 map, unsafe_map = safe_map, map
 zip, unsafe_zip = safe_zip, zip

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -44,6 +44,7 @@ from jax import lax
 from jax.core import ShapedArray, DShapedArray, ConcreteArray
 from jax.interpreters import pxla
 from jax.tree_util import tree_leaves, tree_flatten, tree_map
+from jax.typing import ndarray
 
 from jax._src import device_array
 from jax._src import dtypes
@@ -52,7 +53,6 @@ from jax._src.lax.lax import (_array_copy, _sort_lt_comparator,
                               _sort_le_comparator)
 from jax._src.lax import lax as lax_internal
 from jax._src.lax.slicing import _getslice
-from jax._src.numpy.ndarray import ndarray
 from jax._src.numpy.reductions import (  # noqa: F401
   _ensure_optional_axes, _reduction_dims,
   alltrue, amin, amax, any, all, average, count_nonzero, cumsum, cumprod, cumproduct,
@@ -3586,12 +3586,12 @@ def take_along_axis(arr, indices, axis: Optional[int],
       j += 1
 
 
-  gather_indices = lax.concatenate(gather_indices, dimension=j)
+  gather_indices_arr = lax.concatenate(gather_indices, dimension=j)
   dnums = lax.GatherDimensionNumbers(
     offset_dims=tuple(offset_dims),
     collapsed_slice_dims=tuple(collapsed_slice_dims),
     start_index_map=tuple(start_index_map))
-  return lax.gather(arr, gather_indices, dnums, tuple(slice_sizes),
+  return lax.gather(arr, gather_indices_arr, dnums, tuple(slice_sizes),
                     mode="fill" if mode is None else mode)
 
 ### Indexing

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -44,7 +44,6 @@ from jax import lax
 from jax.core import ShapedArray, DShapedArray, ConcreteArray
 from jax.interpreters import pxla
 from jax.tree_util import tree_leaves, tree_flatten, tree_map
-from jax.typing import ndarray
 
 from jax._src import device_array
 from jax._src import dtypes
@@ -77,6 +76,7 @@ from jax._src.numpy.util import (  # noqa: F401
   _register_stackable, _stackable, _where, _wraps)
 from jax._src.numpy.vectorize import vectorize
 from jax._src.ops import scatter
+from jax._src.typing.ndarray import ndarray
 from jax._src.util import (unzip2, prod as _prod, subvals, safe_zip, ceil_of_ratio,
                            canonicalize_axis as _canonicalize_axis)
 from jax.experimental.array import Array

--- a/jax/_src/numpy/linalg.py
+++ b/jax/_src/numpy/linalg.py
@@ -64,7 +64,7 @@ def svd(a, full_matrices: bool = True, compute_uv: bool = True,
       vh = _H(u * sign[..., None, :].astype(u.dtype))
       return u, s, vh
     else:
-      return lax.rev(lax.sort(s, dimension=-1), dimensions=[s.ndim-1])
+      return lax.rev(lax.sort(s, dimension=-1), dimensions=[s.ndim-1])  # type: ignore
 
   return lax_linalg.svd(a, full_matrices=full_matrices, compute_uv=compute_uv)
 

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -23,11 +23,11 @@ import numpy as np
 import jax
 from jax import core
 from jax import lax
-from jax.typing import ndarray
 from jax._src import api
 from jax._src import dtypes
 from jax._src.numpy.util import _broadcast_to, _check_arraylike, _complex_elem_type, _promote_dtypes_inexact, _where, _wraps
 from jax._src.lax import lax as lax_internal
+from jax._src.typing.ndarray import ndarray
 from jax._src.util import canonicalize_axis as _canonicalize_axis, maybe_named_axis
 
 

--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -23,9 +23,9 @@ import numpy as np
 import jax
 from jax import core
 from jax import lax
+from jax.typing import ndarray
 from jax._src import api
 from jax._src import dtypes
-from jax._src.numpy.ndarray import ndarray
 from jax._src.numpy.util import _broadcast_to, _check_arraylike, _complex_elem_type, _promote_dtypes_inexact, _where, _wraps
 from jax._src.lax import lax as lax_internal
 from jax._src.util import canonicalize_axis as _canonicalize_axis, maybe_named_axis

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -20,10 +20,10 @@ from typing import (
 )
 import warnings
 
+from jax.typing import ndarray
 from jax._src.config import config
 from jax._src import dtypes
 from jax._src.lax import lax as lax_internal
-from jax._src.numpy.ndarray import ndarray
 from jax._src.util import safe_zip, safe_map
 from jax._src import api
 from jax import core

--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -20,10 +20,10 @@ from typing import (
 )
 import warnings
 
-from jax.typing import ndarray
 from jax._src.config import config
 from jax._src import dtypes
 from jax._src.lax import lax as lax_internal
+from jax._src.typing.ndarray import ndarray
 from jax._src.util import safe_zip, safe_map
 from jax._src import api
 from jax import core

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -166,10 +166,7 @@ def _segment_update(name: str,
   if num_segments is not None and num_segments < 0:
     raise ValueError("num_segments must be non-negative.")
 
-
-  num_buckets = 1 if bucket_size is None \
-                  else util.ceil_of_ratio(segment_ids.size, bucket_size)
-  if num_buckets == 1:
+  if bucket_size is None:
     out = jnp.full((num_segments,) + data.shape[1:],
                    _get_identity(scatter_op, dtype), dtype=dtype)
     return _scatter_update(
@@ -179,6 +176,7 @@ def _segment_update(name: str,
   # Bucketize indices and perform segment_update on each bucket to improve
   # numerical stability for operations like product and sum.
   assert reducer is not None
+  num_buckets = util.ceil_of_ratio(segment_ids.size, bucket_size)
   out = jnp.full((num_buckets, num_segments) + data.shape[1:],
                  _get_identity(scatter_op, dtype), dtype=dtype)
   out = _scatter_update(

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -35,7 +35,7 @@ from jax.experimental.sharding import (
 
 from jax._src import dispatch
 from jax._src import dtypes
-from jax.typing import NDArray
+from jax._src.typing.ndarray import Array
 from jax._src.api import jit, vmap
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import utils as lax_utils
@@ -94,7 +94,7 @@ class PRNGImpl(NamedTuple):
 
 # -- PRNG key arrays
 
-def _check_prng_key_data(impl, key_data: NDArray):
+def _check_prng_key_data(impl, key_data: Array):
   ndim = len(impl.key_shape)
   if not all(hasattr(key_data, attr) for attr in ['ndim', 'shape', 'dtype']):
     raise TypeError("JAX encountered invalid PRNG key data: expected key_data "
@@ -137,9 +137,9 @@ class PRNGKeyArray(metaclass=PRNGKeyArrayMeta):
   """
 
   impl: PRNGImpl
-  _base_array: NDArray
+  _base_array: Array
 
-  def __init__(self, impl, key_data: NDArray):
+  def __init__(self, impl, key_data: Array):
     assert not isinstance(key_data, core.Tracer)
     _check_prng_key_data(impl, key_data)
     self.impl = impl
@@ -807,7 +807,7 @@ def _is_threefry_prng_key(key: jnp.ndarray) -> bool:
     return False
 
 
-def threefry_seed(seed: NDArray) -> NDArray:
+def threefry_seed(seed: Array) -> Array:
   """Create a single raw threefry PRNG key given an integer seed.
 
   Args:
@@ -1016,7 +1016,7 @@ def threefry_split(key: jnp.ndarray, num: int) -> jnp.ndarray:
   return _threefry_split(key, int(num))  # type: ignore
 
 @partial(jit, static_argnums=(1,), inline=True)
-def _threefry_split(key, num) -> NDArray:
+def _threefry_split(key, num) -> Array:
   counts = lax.iota(np.uint32, num * 2)
   return lax.reshape(threefry_2x32(key, counts), (num, 2))
 

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -15,7 +15,7 @@
 
 import abc
 from functools import partial
-from typing import Any, Callable, Hashable, Iterator, NamedTuple, Sequence
+from typing import Callable, Hashable, Iterator, NamedTuple, Sequence
 
 import numpy as np
 
@@ -35,6 +35,7 @@ from jax.experimental.sharding import (
 
 from jax._src import dispatch
 from jax._src import dtypes
+from jax.typing import NDArray
 from jax._src.api import jit, vmap
 from jax._src.lax import lax as lax_internal
 from jax._src.lax import utils as lax_utils
@@ -93,7 +94,7 @@ class PRNGImpl(NamedTuple):
 
 # -- PRNG key arrays
 
-def _check_prng_key_data(impl, key_data: jnp.ndarray):
+def _check_prng_key_data(impl, key_data: NDArray):
   ndim = len(impl.key_shape)
   if not all(hasattr(key_data, attr) for attr in ['ndim', 'shape', 'dtype']):
     raise TypeError("JAX encountered invalid PRNG key data: expected key_data "
@@ -136,9 +137,9 @@ class PRNGKeyArray(metaclass=PRNGKeyArrayMeta):
   """
 
   impl: PRNGImpl
-  _base_array: jnp.ndarray
+  _base_array: NDArray
 
-  def __init__(self, impl, key_data: Any):
+  def __init__(self, impl, key_data: NDArray):
     assert not isinstance(key_data, core.Tracer)
     _check_prng_key_data(impl, key_data)
     self.impl = impl
@@ -806,8 +807,8 @@ def _is_threefry_prng_key(key: jnp.ndarray) -> bool:
     return False
 
 
-def threefry_seed(seed: jnp.ndarray) -> jnp.ndarray:
-  """Create a single raw threefry PRNG key from an integer seed.
+def threefry_seed(seed: NDArray) -> NDArray:
+  """Create a single raw threefry PRNG key given an integer seed.
 
   Args:
     seed: a 64- or 32-bit integer used as the value of the key.
@@ -1015,7 +1016,7 @@ def threefry_split(key: jnp.ndarray, num: int) -> jnp.ndarray:
   return _threefry_split(key, int(num))  # type: ignore
 
 @partial(jit, static_argnums=(1,), inline=True)
-def _threefry_split(key, num) -> jnp.ndarray:
+def _threefry_split(key, num) -> NDArray:
   counts = lax.iota(np.uint32, num * 2)
   return lax.reshape(threefry_2x32(key, counts), (num, 2))
 

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -35,7 +35,7 @@ from jax.numpy.linalg import cholesky, svd, eigh
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
-from jax.typing import NDArray
+from jax._src.typing import ndarray as typing
 from jax._src.util import prod, canonicalize_axis
 
 
@@ -85,7 +85,7 @@ def _return_prng_keys(was_wrapped, key):
     return prng.random_unwrap(key) if was_wrapped else key
 
 
-def _random_bits(key: prng.PRNGKeyArray, bit_width, shape) -> NDArray:
+def _random_bits(key: prng.PRNGKeyArray, bit_width, shape) -> typing.Array:
   assert isinstance(key, prng.PRNGKeyArray)
   return prng.random_bits(key, bit_width=bit_width, shape=shape)
 
@@ -240,7 +240,7 @@ def uniform(key: KeyArray,
             shape: Union[Sequence[int], NamedShape] = (),
             dtype: DTypeLikeFloat = dtypes.float_,
             minval: RealArray = 0.,
-            maxval: RealArray = 1.) -> NDArray:
+            maxval: RealArray = 1.) -> typing.Array:
   """Sample uniform random values in [minval, maxval) with given shape/dtype.
 
   Args:
@@ -264,7 +264,7 @@ def uniform(key: KeyArray,
   return _uniform(key, shape, dtype, minval, maxval)  # type: ignore
 
 @partial(jit, static_argnums=(1, 2), inline=True)
-def _uniform(key, shape, dtype, minval, maxval) -> NDArray:
+def _uniform(key, shape, dtype, minval, maxval) -> typing.Array:
   _check_shape("uniform", shape)
   if not jnp.issubdtype(dtype, np.floating):
     raise TypeError("uniform only accepts floating point dtypes.")
@@ -383,7 +383,7 @@ def _randint(key, shape, minval, maxval, dtype):
   return lax.add(minval, lax.convert_element_type(random_offset, dtype))
 
 
-def shuffle(key: KeyArray, x: Array, axis: int = 0) -> NDArray:
+def shuffle(key: KeyArray, x: Array, axis: int = 0) -> typing.Array:
   """Shuffle the elements of an array uniformly at random along an axis.
 
   Args:
@@ -404,7 +404,7 @@ def shuffle(key: KeyArray, x: Array, axis: int = 0) -> NDArray:
 def permutation(key: KeyArray,
                 x: Union[int, Array],
                 axis: int = 0,
-                independent: bool = False) -> NDArray:
+                independent: bool = False) -> typing.Array:
   """Returns a randomly permuted array or range.
 
   Args:
@@ -433,7 +433,7 @@ def permutation(key: KeyArray,
 
 
 @partial(jit, static_argnums=(2,), inline=True)
-def _shuffle(key, x, axis) -> NDArray:
+def _shuffle(key, x, axis) -> typing.Array:
   # On parallel architectures, Fisher-Yates is more expensive than doing
   # multiple sorts. This algorithm is based on one developed and analyzed by
   # tjablin@. We sort according to randomly-generated 32bit keys, but those keys
@@ -465,7 +465,7 @@ def choice(key: KeyArray,
            shape: Sequence[int] = (),
            replace: bool = True,
            p: Optional[RealArray] = None,
-           axis: int = 0) -> NDArray:
+           axis: int = 0) -> typing.Array:
   """Generates a random sample from a given array.
 
   .. warning::
@@ -539,7 +539,7 @@ def choice(key: KeyArray,
 
 def normal(key: KeyArray,
            shape: Union[Sequence[int], NamedShape] = (),
-           dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+           dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample standard normal random values with given shape and float dtype.
 
   Args:
@@ -561,7 +561,7 @@ def normal(key: KeyArray,
   return _normal(key, shape, dtype)  # type: ignore
 
 @partial(jit, static_argnums=(1, 2), inline=True)
-def _normal(key, shape, dtype) -> NDArray:
+def _normal(key, shape, dtype) -> typing.Array:
   if dtypes.issubdtype(dtype, np.complexfloating):
     sqrt2 = np.array(np.sqrt(2), dtype)
 
@@ -574,7 +574,7 @@ def _normal(key, shape, dtype) -> NDArray:
     return _normal_real(key, shape, dtype) # type: ignore
 
 @partial(jit, static_argnums=(1, 2), inline=True)
-def _normal_real(key, shape, dtype) -> NDArray:
+def _normal_real(key, shape, dtype) -> typing.Array:
   _check_shape("normal", shape)
   lo = np.nextafter(np.array(-1., dtype), np.array(0., dtype), dtype=dtype)
   hi = np.array(1., dtype)
@@ -587,7 +587,7 @@ def multivariate_normal(key: KeyArray,
                         cov: RealArray,
                         shape: Optional[Sequence[int]] = None,
                         dtype: DTypeLikeFloat = dtypes.float_,
-                        method: str = 'cholesky') -> NDArray:
+                        method: str = 'cholesky') -> typing.Array:
   """Sample multivariate normal random values with given mean and covariance.
 
   Args:
@@ -621,7 +621,7 @@ def multivariate_normal(key: KeyArray,
   return _multivariate_normal(key, mean, cov, shape, dtype, method)  # type: ignore
 
 @partial(jit, static_argnums=(3, 4, 5), inline=True)
-def _multivariate_normal(key, mean, cov, shape, dtype, method) -> NDArray:
+def _multivariate_normal(key, mean, cov, shape, dtype, method) -> typing.Array:
   if not np.ndim(mean) >= 1:
     msg = "multivariate_normal requires mean.ndim >= 1, got mean.ndim == {}"
     raise ValueError(msg.format(np.ndim(mean)))
@@ -655,7 +655,7 @@ def truncated_normal(key: KeyArray,
                      lower: RealArray,
                      upper: RealArray,
                      shape: Optional[Union[Sequence[int], NamedShape]] = None,
-                     dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+                     dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample truncated standard normal random values with given shape and dtype.
 
   Args:
@@ -686,7 +686,7 @@ def truncated_normal(key: KeyArray,
   return _truncated_normal(key, lower, upper, shape, dtype)  # type: ignore
 
 @partial(jit, static_argnums=(3, 4), inline=True)
-def _truncated_normal(key, lower, upper, shape, dtype) -> NDArray:
+def _truncated_normal(key, lower, upper, shape, dtype) -> typing.Array:
   if shape is None:
     shape = lax.broadcast_shapes(np.shape(lower), np.shape(upper))
   else:
@@ -711,7 +711,7 @@ def _truncated_normal(key, lower, upper, shape, dtype) -> NDArray:
 
 def bernoulli(key: KeyArray,
               p: RealArray = np.float32(0.5),
-              shape: Optional[Union[Sequence[int], NamedShape]] = None) -> NDArray:
+              shape: Optional[Union[Sequence[int], NamedShape]] = None) -> typing.Array:
   """Sample Bernoulli random values with given shape and mean.
 
   Args:
@@ -737,7 +737,7 @@ def bernoulli(key: KeyArray,
   return _bernoulli(key, p, shape)  # type: ignore
 
 @partial(jit, static_argnums=(2,), inline=True)
-def _bernoulli(key, p, shape) -> NDArray:
+def _bernoulli(key, p, shape) -> typing.Array:
   if shape is None:
     # TODO: Use the named part of `p` as well
     shape = np.shape(p)
@@ -751,7 +751,7 @@ def beta(key: KeyArray,
          a: RealArray,
          b: RealArray,
          shape: Optional[Sequence[int]] = None,
-         dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+         dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Beta random values with given shape and float dtype.
 
   Args:
@@ -802,7 +802,7 @@ def _beta(key, a, b, shape, dtype):
 
 def cauchy(key: KeyArray,
            shape: Sequence[int] = (),
-           dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+           dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Cauchy random values with given shape and float dtype.
 
   Args:
@@ -834,7 +834,7 @@ def _cauchy(key, shape, dtype):
 def dirichlet(key: KeyArray,
               alpha: RealArray,
               shape: Optional[Sequence[int]] = None,
-              dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+              dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Dirichlet random values with given shape and float dtype.
 
   Args:
@@ -892,7 +892,7 @@ def _softmax(x, axis):
 
 def exponential(key: KeyArray,
                 shape: Sequence[int] = (),
-                dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+                dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Exponential random values with given shape and float dtype.
 
   Args:
@@ -1056,7 +1056,7 @@ batching.primitive_batchers[random_gamma_p] = _gamma_batching_rule
 def gamma(key: KeyArray,
           a: RealArray,
           shape: Optional[Sequence[int]] = None,
-          dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+          dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Gamma random values with given shape and float dtype.
 
   Args:
@@ -1090,7 +1090,7 @@ def gamma(key: KeyArray,
 def loggamma(key: KeyArray,
              a: RealArray,
              shape: Optional[Sequence[int]] = None,
-             dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+             dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample log-gamma random values with given shape and float dtype.
 
   This function is implemented such that the following will hold for a
@@ -1231,7 +1231,7 @@ def _poisson(key, lam, shape, dtype):
 def poisson(key: KeyArray,
             lam: RealArray,
             shape: Optional[Sequence[int]] = None,
-            dtype: DTypeLikeInt = dtypes.int_) -> NDArray:
+            dtype: DTypeLikeInt = dtypes.int_) -> typing.Array:
   """Sample Poisson random values with given shape and integer dtype.
 
   Args:
@@ -1266,7 +1266,7 @@ def poisson(key: KeyArray,
 
 def gumbel(key: KeyArray,
            shape: Sequence[int] = (),
-           dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+           dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Gumbel random values with given shape and float dtype.
 
   Args:
@@ -1297,7 +1297,7 @@ def _gumbel(key, shape, dtype):
 def categorical(key: KeyArray,
                 logits: RealArray,
                 axis: int = -1,
-                shape: Optional[Sequence[int]] = None) -> NDArray:
+                shape: Optional[Sequence[int]] = None) -> typing.Array:
   """Sample random values from categorical distributions.
 
   Args:
@@ -1334,7 +1334,7 @@ def categorical(key: KeyArray,
 
 def laplace(key: KeyArray,
             shape: Sequence[int] = (),
-            dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+            dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Laplace random values with given shape and float dtype.
 
   Args:
@@ -1365,7 +1365,7 @@ def _laplace(key, shape, dtype):
 
 def logistic(key: KeyArray,
              shape: Sequence[int] = (),
-             dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+             dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample logistic random values with given shape and float dtype.
 
   Args:
@@ -1396,7 +1396,7 @@ def _logistic(key, shape, dtype):
 def pareto(key: KeyArray,
            b: RealArray,
            shape: Optional[Sequence[int]] = None,
-           dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+           dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Pareto random values with given shape and float dtype.
 
   Args:
@@ -1437,7 +1437,7 @@ def _pareto(key, b, shape, dtype):
 def t(key: KeyArray,
       df: RealArray,
       shape: Sequence[int] = (),
-      dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+      dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample Student's t random values with given shape and float dtype.
 
   Args:
@@ -1480,7 +1480,7 @@ def _t(key, df, shape, dtype):
 
 def rademacher(key: KeyArray,
                shape: Sequence[int],
-               dtype: DTypeLikeInt = dtypes.int_) -> NDArray:
+               dtype: DTypeLikeInt = dtypes.int_) -> typing.Array:
   """Sample from a Rademacher distribution.
 
   Args:
@@ -1507,7 +1507,7 @@ def _rademacher(key, shape, dtype):
 
 def maxwell(key: KeyArray,
             shape: Sequence[int] = (),
-            dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+            dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample from a one sided Maxwell distribution.
 
   The scipy counterpart is `scipy.stats.maxwell`.
@@ -1543,7 +1543,7 @@ def double_sided_maxwell(key: KeyArray,
                          loc: RealArray,
                          scale: RealArray,
                          shape: Sequence[int] = (),
-                         dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+                         dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample from a double sided Maxwell distribution.
 
   Samples using:
@@ -1589,7 +1589,7 @@ def weibull_min(key: KeyArray,
                 scale: RealArray,
                 concentration: RealArray,
                 shape: Sequence[int] = (),
-                dtype: DTypeLikeFloat = dtypes.float_) -> NDArray:
+                dtype: DTypeLikeFloat = dtypes.float_) -> typing.Array:
   """Sample from a Weibull distribution.
 
   The scipy counterpart is `scipy.stats.weibull_min`.
@@ -1637,7 +1637,7 @@ def orthogonal(
   n: int,
   shape: Sequence[int] = (),
   dtype: DTypeLikeFloat = dtypes.float_
-) -> NDArray:
+) -> typing.Array:
   """Sample uniformly from the orthogonal group O(n).
 
   If the dtype is complex, sample uniformly from the unitary group U(n).
@@ -1665,7 +1665,7 @@ def generalized_normal(
   p: float,
   shape: Sequence[int] = (),
   dtype: DTypeLikeFloat = dtypes.float_
-) -> NDArray:
+) -> typing.Array:
   """Sample from the generalized normal distribution.
 
   Args:

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -24,7 +24,7 @@ from jax import jit
 from jax import lax, core
 from jax.interpreters import ad
 import jax.numpy as jnp
-from jax.typing import ArrayLike, NDArray
+from jax._src.typing.ndarray import Array
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.lax_numpy import _reduction_dims, _promote_args_inexact
 from jax._src.numpy.util import _wraps
@@ -1028,11 +1028,11 @@ def lpmn_values(m: int, n: int, z: jnp.ndarray, is_normalized: bool) -> jnp.ndar
 
 
 @partial(jit, static_argnums=(4,))
-def _sph_harm(m: NDArray,
-              n: NDArray,
-              theta: NDArray,
-              phi: NDArray,
-              n_max: int) -> NDArray:
+def _sph_harm(m: Array,
+              n: Array,
+              theta: Array,
+              phi: Array,
+              n_max: int) -> Array:
   """Computes the spherical harmonics."""
 
   cos_colatitude = jnp.cos(phi)

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -24,6 +24,7 @@ from jax import jit
 from jax import lax, core
 from jax.interpreters import ad
 import jax.numpy as jnp
+from jax.typing import ArrayLike, NDArray
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.lax_numpy import _reduction_dims, _promote_args_inexact
 from jax._src.numpy.util import _wraps
@@ -1027,11 +1028,11 @@ def lpmn_values(m: int, n: int, z: jnp.ndarray, is_normalized: bool) -> jnp.ndar
 
 
 @partial(jit, static_argnums=(4,))
-def _sph_harm(m: jnp.ndarray,
-              n: jnp.ndarray,
-              theta: jnp.ndarray,
-              phi: jnp.ndarray,
-              n_max: int) -> jnp.ndarray:
+def _sph_harm(m: NDArray,
+              n: NDArray,
+              theta: NDArray,
+              phi: NDArray,
+              n_max: int) -> NDArray:
   """Computes the spherical harmonics."""
 
   cos_colatitude = jnp.cos(phi)

--- a/jax/_src/typing/__init__.py
+++ b/jax/_src/typing/__init__.py
@@ -11,17 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-from jax._src.typing.ndarray import (
-    ndarray as ndarray,
-    NDArray as NDArray,
-    ArrayLike as ArrayLike,
-)
-
-from jax._src.typing.simple import (
-    DimSize as DimSize,
-    Dtype as Dtype,
-    DtypeLike as DtypeLike,
-    Shape as Shape,
-)
+from jax._src.typing.simple import DimSize, Dtype, DtypeLike, Shape

--- a/jax/_src/typing/ndarray.py
+++ b/jax/_src/typing/ndarray.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import abc
-from typing import Any, Tuple, Optional, Union
+from typing import Any, Optional, Tuple, Union
+from typing_extensions import Protocol
 
 from jax import core
 from jax.interpreters import pxla
@@ -42,6 +44,7 @@ class ndarray(metaclass=ArrayMeta):
   ndim: int
   shape: Tuple[int, ...]
   size: int
+  sharding: Any
 
   def __init__(self, shape, dtype=None, buffer=None, offset=0, strides=None,
                order=None):
@@ -292,3 +295,12 @@ ndarray.register(device_array.DeviceArray)
 for t in device_array.device_array_types:
   ndarray.register(t)
 ndarray.register(pxla._SDA_BASE_CLASS)
+
+
+
+class HasArrayMethod(Protocol):
+  def __array__(self) -> np.ndarray:
+    ...
+
+NDArray = Union[ndarray, core.Tracer]
+ArrayLike = Union[bool, int, float, complex, NDArray, np.ndarray, HasArrayMethod]

--- a/jax/_src/typing/ndarray.py
+++ b/jax/_src/typing/ndarray.py
@@ -297,10 +297,12 @@ for t in device_array.device_array_types:
 ndarray.register(pxla._SDA_BASE_CLASS)
 
 
-
 class HasArrayMethod(Protocol):
   def __array__(self) -> np.ndarray:
     ...
 
-NDArray = Union[ndarray, core.Tracer]
-ArrayLike = Union[bool, int, float, complex, NDArray, np.ndarray, HasArrayMethod]
+
+ArrayLike = Union[bool, int, float, complex, ndarray, core.Tracer, np.ndarray, HasArrayMethod]
+
+# TODO(jakevdp): make this an alias of jax._src.array.Array when available (#12049)
+Array = Union[ndarray, core.Tracer]

--- a/jax/_src/typing/simple.py
+++ b/jax/_src/typing/simple.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simple type definitions, not """
+
+# This file should avoid importing from jax in order to avoid circular imports.
+from __future__ import annotations
+
+from typing import Any, Sequence, Union
+from typing_extensions import Protocol
+import numpy as np
+
+class HasDtypeAttribute(Protocol):
+  dtype: Dtype
+
+Dtype = np.dtype
+DtypeLike = Union[str, np.dtype, HasDtypeAttribute]
+
+# Shapes are tuples of dimension sizes, which are normally integers. We allow
+# modules to extend the set of dimension sizes to contain other types, e.g.,
+# symbolic dimensions in jax2tf.shape_poly.DimVar and masking.Poly.
+DimSize = Union[int, Any]  # extensible
+Shape = Sequence[DimSize]

--- a/jax/core.py
+++ b/jax/core.py
@@ -37,6 +37,7 @@ import numpy as np
 from jax._src import dtypes
 from jax._src import config as jax_config
 from jax._src.config import FLAGS, config
+from jax._src.typing.simple import DimSize, Shape
 from jax.errors import (ConcretizationTypeError, TracerArrayConversionError,
                         TracerIntegerConversionError, UnexpectedTracerError)
 from jax import linear_util as lu
@@ -1598,13 +1599,6 @@ raise_to_shaped_mappings : Dict[type, Callable] = {
 }
 
 ### Operations on shapes and dimension sizes.
-
-# Shapes are tuples of dimension sizes, which are normally integers. We allow
-# modules to extend the set of dimension sizes to contain other types, e.g.,
-# symbolic dimensions in jax2tf.shape_poly.DimVar and masking.Poly.
-DimSize = Union[int, Any]  # extensible
-Shape = Sequence[DimSize]
-
 
 class InconclusiveDimensionOperation(Exception):
   """Raised when we cannot conclusively compute with symbolic dimensions."""

--- a/jax/experimental/array.py
+++ b/jax/experimental/array.py
@@ -30,11 +30,11 @@ from jax._src.config import config
 from jax._src.util import prod, safe_zip
 from jax._src.lib import xla_client as xc
 from jax._src.api import device_put
+from jax._src.typing.ndarray import ndarray
 from jax.interpreters import pxla, xla, mlir
 from jax.experimental.sharding import (
     Sharding, SingleDeviceSharding, XLACompatibleSharding, PmapSharding,
     device_replica_id_map)
-from jax.typing import ndarray
 
 Shape = Tuple[int, ...]
 Device = xc.Device

--- a/jax/experimental/array.py
+++ b/jax/experimental/array.py
@@ -30,11 +30,11 @@ from jax._src.config import config
 from jax._src.util import prod, safe_zip
 from jax._src.lib import xla_client as xc
 from jax._src.api import device_put
-from jax._src.numpy.ndarray import ndarray
 from jax.interpreters import pxla, xla, mlir
 from jax.experimental.sharding import (
     Sharding, SingleDeviceSharding, XLACompatibleSharding, PmapSharding,
     device_replica_id_map)
+from jax.typing import ndarray
 
 Shape = Tuple[int, ...]
 Device = xc.Device

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -42,14 +42,13 @@ import jax
 from jax._src.numpy import lax_numpy
 from jax._src import dtypes
 from jax._src.lax import lax
+from jax._src.typing.simple import DimSize, Shape
 import opt_einsum
 from jax import config
 from jax import core
 
 import numpy as np
 
-DimSize = core.DimSize
-Shape = core.Shape
 TfVal = Any
 # A dimension environment maps dimension variables to expressions that
 # compute the value of the dimension. These expressions refer to the

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -64,6 +64,7 @@ from jax.tree_util import tree_flatten, tree_map, tree_unflatten
 from jax.util import safe_map, safe_zip, split_list
 from jax._src.config import config
 from jax._src.lax.control_flow import _check_tree_and_avals
+from jax._src.lax import lax as _lax
 from jax._src.numpy import lax_numpy
 from jax._src.util import canonicalize_axis
 from jax.experimental import sparse

--- a/jax/typing.py
+++ b/jax/typing.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from jax._src.typing.ndarray import (
+    ndarray as ndarray,
+    NDArray as NDArray,
+    ArrayLike as ArrayLike,
+)
+
+from jax._src.typing.simple import (
+    DimSize as DimSize,
+    Dtype as Dtype,
+    DtypeLike as DtypeLike,
+    Shape as Shape,
+)


### PR DESCRIPTION
Part of #12049

Changes:

- created `jax.typing` module, following roadmap in #11859
- moved `core.Shape` definition into `jax.typing`
- moved `jax.numpy.ndarray` definition into `jax.typing`
- applied these new types throughout `jax.lax`, following the style recommended in #11859
- fixed annotations in other files that were broken by the new `jax.lax` types (what a tangled web we weave...)

Some observations:
- When implementing annotations in `jax.lax`, I used `ArrayLike` for inputs and `NDArray` for outputs. Originally I had `NDArray` aliased to the `ndarray` metaclass, but because `jax.lax` has several functions that explicitly return `Tracer` types, it seemed necessary to make `NDArray = Union[ndarray, Tracer]`.
- This change had wide-ranging ripple effects: any function annotated with `-> jnp.ndarray` and returning the result of a lax operation caused a typecheck failure (because `Tracer` is inompatible), so it meant that in many places I had to change `-> jnp.ndarray` to `-> NDarray`, which caused even more ripples.
- An alternative would be to use `-> jnp.ndarray` by convention (with the understanding that it implies compatiblity with tracers) and use `#type: ignore` statements where tracers are explicitly returned.

Happy to hear any thoughts/opinions on this.