### PR TITLE
[sparse] add trivial sparse rule for lax.copy_p

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -78,6 +78,7 @@ _zero_preserving_unary_primitives = [
   lax.atan_p,
   lax.atanh_p,
   lax.bessel_i1e_p,
+  lax.copy_p,
   lax.expm1_p,
   lax.log1p_p,
   lax.neg_p,


### PR DESCRIPTION
Came across this missing registration while experimenting in #12018

Need to rebase after #12019 is merged.