### PR TITLE
target_total_secs has type `int` but used as type `None`

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -83,7 +83,7 @@ def benchmark(f: Callable[[], Any], iters: Optional[int] = None,
 
 
 def benchmark_suite(prepare: Callable[..., Callable], params_list: List[Dict],
-                    name: str, target_total_secs: int = None):
+                    name: str, target_total_secs: Optional[int] = None):
   """Benchmarks a function for several combinations of parameters.
 
   Prints the summarized results in a table..


### PR DESCRIPTION
**"filename"**: "benchmarks/benchmark.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " target_total_secs is declared to have type `int` but is used as type `None`."
**"warning_line"**: 86
**"fix"**: int to Optional[int]