### PR TITLE
remove 'BUG:' title prefix from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,7 @@
 name: Bug report
 description: >-
   Report a bug or unexpected behavior to help us improve the package
-title: 'BUG: '
+title: ''
 labels:
 - bug
 


### PR DESCRIPTION
We already auto-label with "bug" to this end.