### PR TITLE
lax.squeeze: ensure DeviceArray is returned

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -1266,7 +1266,7 @@ def squeeze(array: Array, dimensions: Sequence[int]) -> Array:
   """Squeeze any number of size 1 dimensions from an array."""
   ndim = np.ndim(array)
   dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
-  if not dimensions:
+  if not dimensions and isinstance(array, (core.Tracer, device_array.DeviceArray)):
     return array
   return squeeze_p.bind(array, dimensions=dimensions)
 

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1388,6 +1388,30 @@ class LaxTest(jtu.JaxTestCase):
     check_grads(op, args_maker(), 2, ["fwd", "rev"], eps=1.)
 
   @parameterized.named_parameters(jtu.cases_from_list(
+      {"testcase_name": f"_input_type={input_type}_jit={jit}",
+       "input_type": input_type, "jit": jit}
+      for input_type in ["np.array", "jnp.array", "float", "np.float32"]
+      for jit in [True, False]))
+  def testEmptySqueezeReturnType(self, input_type, jit):
+    if input_type == "np.array":
+      operand = np.arange(5)
+    elif input_type == "jnp.array":
+      operand = jnp.arange(5)
+    elif input_type == "float":
+      operand = 2.0
+    elif input_type == "np.float32":
+      operand = np.float32(2.0)
+    else:
+      raise ValueError(f"Unrecognized input_type={input_type}")
+
+    op = lambda x: lax.squeeze(x, dimensions=())
+    if jit:
+      op = jax.jit(op)
+    result = op(operand)
+    expected_type = array.Array if config.jax_array else jnp.DeviceArray
+    self.assertIsInstance(result, expected_type)
+
+  @parameterized.named_parameters(jtu.cases_from_list(
       {"testcase_name": "_inshape={}_outshape={}".format(
           jtu.format_shape_dtype_string(arg_shape, dtype),
           jtu.format_shape_dtype_string(out_shape, dtype)),


### PR DESCRIPTION
Why? Our convention is that `lax` functions return device arrays or tracers. See for example similar logic in `convert_element_type`: https://github.com/google/jax/blob/fd799742e2b48392329d3a8187d2d0d564c431ef/jax/_src/lax/lax.py#L573-L575

Discovered in the course of experimenting with stricter type annotations in #12018