### PR TITLE
Enable one gpu per process for multinode GPU tests

### DIFF
--- a/.github/workflows/slurm_job_scripts/multinode_pytest.sub
+++ b/.github/workflows/slurm_job_scripts/multinode_pytest.sub
@@ -6,8 +6,7 @@
 #SBATCH -J "ci-jax-gpu"         # job name
 #SBATCH --exclusive             # exclusive node access
 #SBATCH --mem=0                 # all mem avail
-#SBATCH --mail-type=FAIL        # only send email on failure
-#SBATCH --ntasks-per-node=1     # 1 tasks per machine for now
+#SBATCH --mail-type=FAIL        # only send email on failures
 #SBATCH --overcommit            # Needed for pytorch
 
 set -x
@@ -57,6 +56,7 @@ OUTFILE="${OUTPUT_DIR}/output-%j-%n.txt"
 # that the processes are launched together
 echo $setup_cmd
 srun -o $OUTFILE -e $OUTFILE \
+    --ntasks-per-node=1 \
     --container-writable \
     --container-image="$CONTAINER" \
     --container-name=$CONTAINER_NAME \
@@ -70,6 +70,7 @@ wait
 # Run the actual pytest command
 echo $cmd
 srun -o $OUTFILE -e $OUTFILE \
+    --ntasks-per-node=8 \
     --open-mode=append \
     --container-writable \
     --container-image="$CONTAINER" \


### PR DESCRIPTION
1. Use one process per GPU
2. Try `jax.config.update("jax_cuda_visible_devices", visible_devices)` to check multinode CI job against the fix for https://github.com/google/jax/issues/12119