### PR TITLE
add `dtype` property to concrete key arrays

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -731,7 +731,7 @@ def array_result_handler(sticky_device: Optional[Device],
     return lambda _, __: np.zeros(aval.shape, dtypes.float0)
   aval = core.raise_to_shaped(aval)
   if type(aval.dtype) in core.custom_eltypes:
-    return aval.dtype.result_handler(sticky_device, aval)
+    return aval.dtype._rules.result_handler(sticky_device, aval)
   handler = lambda _, b: maybe_create_array_from_da(b, aval, sticky_device)
   handler.args = aval, sticky_device  # for C++ dispatch path in api.py
   return handler

--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -2835,7 +2835,7 @@ def _broadcast_in_dim_partial_eval(
 def _broadcast_in_dim_lower(ctx, x, *dyn_shape, shape, broadcast_dimensions):
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.broadcast_in_dim_mlir(
+    return aval_out.dtype._rules.broadcast_in_dim_mlir(
         ctx, x, *dyn_shape, shape=shape,
         broadcast_dimensions=broadcast_dimensions)
   if dyn_shape:
@@ -3319,7 +3319,7 @@ def _transpose_batch_rule(batched_args, batch_dims, *, permutation):
 def _transpose_lower(ctx, x, *, permutation):
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.transpose_mlir(ctx, x, permutation=permutation)
+    return aval_out.dtype._rules.transpose_mlir(ctx, x, permutation=permutation)
   return mhlo.TransposeOp(x, mlir.dense_int_elements(permutation)).results
 
 transpose_p = standard_primitive(_transpose_shape_rule, _input_dtype,
@@ -4734,6 +4734,6 @@ empty_p = core.Primitive('empty')
 empty_p.def_abstract_eval(lambda *, eltype: core.ShapedArray((), eltype))
 def _empty_lower(ctx, *, eltype):
   if type(eltype) in core.custom_eltypes:
-    return eltype.empty_mlir(ctx)
+    return eltype._rules.empty_mlir(ctx)
   return mlir.ir_constants(np.zeros((), np.dtype(eltype)))
 mlir.register_lowering(empty_p, _empty_lower)

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -804,8 +804,8 @@ def _slice_lower(ctx, x, *, start_indices, limit_indices, strides):
   strides = strides or [1] * len(start_indices)
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.slice_mlir(ctx, x, start_indices, limit_indices,
-                                     strides)
+    return aval_out.dtype._rules.slice_mlir(
+        ctx, x, start_indices, limit_indices, strides)
   return mhlo.SliceOp(x,
                       mlir.dense_int_elements(start_indices),
                       mlir.dense_int_elements(limit_indices),
@@ -905,7 +905,8 @@ batching.primitive_batchers[dynamic_slice_p] = _dynamic_slice_batching_rule
 def _dynamic_slice_lower(ctx, x, *start_indices, slice_sizes):
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.dynamic_slice_mlir(ctx, x, start_indices, slice_sizes)
+    return aval_out.dtype._rules.dynamic_slice_mlir(
+        ctx, x, start_indices, slice_sizes)
   return mhlo.DynamicSliceOp(x, start_indices,
                              mlir.dense_int_elements(slice_sizes)).results
 
@@ -1003,7 +1004,7 @@ batching.primitive_batchers[dynamic_update_slice_p] = \
 def _dynamic_update_slice_lower(ctx, x, update, *start_indices):
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.dynamic_update_slice_mlir(
+    return aval_out.dtype._rules.dynamic_update_slice_mlir(
         ctx, x, update, *start_indices)
   return mhlo.DynamicUpdateSliceOp(mlir.aval_to_ir_type(aval_out), x, update,
                                    start_indices).results
@@ -1318,7 +1319,7 @@ def _gather_lower(ctx, operand, indices, *,
                   indices_are_sorted, mode, fill_value):
   aval_out, = ctx.avals_out
   if type(aval_out.dtype) in core.custom_eltypes:
-    return aval_out.dtype.gather_mlir(
+    return aval_out.dtype._rules.gather_mlir(
         ctx, operand, indices, dimension_numbers=dimension_numbers,
         slice_sizes=slice_sizes, unique_indices=unique_indices,
         indices_are_sorted=indices_are_sorted, mode=mode, fill_value=fill_value)

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -165,6 +165,10 @@ class PRNGKeyArray(metaclass=PRNGKeyArrayMeta):
   def ndim(self):
     return len(self.shape)
 
+  @property
+  def dtype(self):
+    return KeyTy(self.impl)
+
   def _is_scalar(self):
     base_ndim = len(self.impl.key_shape)
     return self._base_array.ndim == base_ndim

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -270,21 +270,7 @@ def base_arr_shape_to_keys_shape(impl, base_arr_shape):
   return base_arr_shape[:-base_ndim]
 
 
-class KeyTy:
-  impl: Hashable  # prng.PRNGImpl. TODO(mattjj,frostig): protocol really
-  def __init__(self, impl):
-    self.impl = impl
-  @property
-  def name(self) -> str:
-    return f'key<{self.impl.tag}>'
-  def __repr__(self) -> str:
-    return self.name
-  def __eq__(self, other):
-    return type(other) is KeyTy and self.impl is other.impl
-  def __hash__(self) -> int:
-    return hash((self.__class__, self.impl))
-
-  # handlers
+class KeyTyRules:
 
   @staticmethod
   def physical_avals(aval):  # TODO(frostig): rename to `grounded_avals`
@@ -294,7 +280,7 @@ class KeyTy:
 
   @staticmethod
   def aval_to_ir_types(aval):
-    phys_aval, = KeyTy.physical_avals(aval)
+    phys_aval, = KeyTyRules.physical_avals(aval)
     return mlir.aval_to_ir_types(phys_aval)
 
   @staticmethod
@@ -306,7 +292,7 @@ class KeyTy:
 
   @staticmethod
   def local_sharded_result_handler(aval, sharding, indices):
-    phys_aval, = KeyTy.physical_avals(aval)
+    phys_aval, = KeyTyRules.physical_avals(aval)
     key_shape = aval.dtype.impl.key_shape
 
     # TODO(yashkatariya,frostig): remove this conditional and inline it when
@@ -349,7 +335,7 @@ class KeyTy:
 
   @staticmethod
   def global_sharded_result_handler(aval, out_sharding, committed):
-    phys_aval, = KeyTy.physical_avals(aval)
+    phys_aval, = KeyTyRules.physical_avals(aval)
     key_shape = aval.dtype.impl.key_shape
 
     # TODO(yashkatariya,frostig): remove this conditional and inline it when
@@ -463,6 +449,28 @@ class KeyTy:
         ctx, gather_lower, x, indices,
         avals_in=[keys_aval_to_base_arr_aval(aval_x), aval_indices],
         avals_out=[keys_aval_to_base_arr_aval(aval_y)])
+
+
+class KeyTy:
+  impl: Hashable  # prng.PRNGImpl. TODO(mattjj,frostig): protocol really
+  _rules = KeyTyRules
+
+  def __init__(self, impl):
+    self.impl = impl
+
+  @property
+  def name(self) -> str:
+    return f'key<{self.impl.tag}>'
+
+  def __repr__(self) -> str:
+    return self.name
+
+  def __eq__(self, other):
+    return type(other) is KeyTy and self.impl is other.impl
+
+  def __hash__(self) -> int:
+    return hash((self.__class__, self.impl))
+
 
 core.custom_eltypes.add(KeyTy)
 

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -1227,8 +1227,8 @@ def poisson(key: KeyArray,
   """
   key, _ = _check_prng_key(key)
   # TODO(frostig): generalize underlying poisson implementation and
-  # remove this check (and use of core.get_aval)
-  key_impl = core.get_aval(key).dtype.impl
+  # remove this check
+  key_impl = key.dtype.impl
   if key_impl is not prng.threefry_prng_impl:
     raise NotImplementedError(
         '`poisson` is only implemented for the threefry2x32 RNG, '

--- a/jax/core.py
+++ b/jax/core.py
@@ -25,9 +25,10 @@ import operator
 from operator import attrgetter
 import threading
 import types
-from typing import (Any, Callable, ClassVar, DefaultDict, Dict, Generator,
-                    Iterator, List, NamedTuple, Optional, Sequence, Set, Tuple,
-                    Type, Union, cast, Iterable, Hashable)
+from typing import (Any, Callable, ClassVar, DefaultDict, Dict,
+                    Generator, Hashable, Iterable, Iterator, List,
+                    NamedTuple, Optional, Sequence, Set, Tuple, Type,
+                    Union, cast)
 import warnings
 from weakref import ref
 

--- a/jax/experimental/array.py
+++ b/jax/experimental/array.py
@@ -462,7 +462,7 @@ def _array_global_result_handler(global_aval, out_sharding, committed):
   if global_aval.dtype == dtypes.float0:
     return lambda _: np.zeros(global_aval.shape, dtypes.float0)  # type: ignore
   if core.aval_has_custom_eltype(global_aval):
-    return global_aval.dtype.global_sharded_result_handler(
+    return global_aval.dtype._rules.global_sharded_result_handler(
         global_aval, out_sharding, committed)
   return lambda bufs: Array(global_aval, out_sharding, bufs,
                             committed=committed, _skip_checks=True)
@@ -473,7 +473,8 @@ pxla.global_result_handlers[(core.AbstractToken, pxla.OutputType.Array)] = lambd
 
 def _array_local_result_handler(aval, sharding, indices):
   if core.aval_has_custom_eltype(aval):
-    return aval.dtype.local_sharded_result_handler(aval, sharding, indices)
+    return aval.dtype._rules.local_sharded_result_handler(
+        aval, sharding, indices)
   else:
     return lambda bufs: Array(aval, sharding, bufs, committed=True,
                               _skip_checks=True)

--- a/jax/experimental/global_device_array.py
+++ b/jax/experimental/global_device_array.py
@@ -620,7 +620,7 @@ pxla.shard_arg_handlers[GlobalDeviceArray] = _gda_shard_arg
 
 def _gda_array_result_handler(global_aval, out_sharding, committed):
   if core.aval_has_custom_eltype(global_aval):
-    return global_aval.dtype.global_sharded_result_handler(
+    return global_aval.dtype._rules.global_sharded_result_handler(
         global_aval, out_sharding, committed)
   global_mesh, out_axis_resources = out_sharding.mesh, out_sharding.spec
   global_idx_rid = get_shard_indices_replica_ids(global_aval.shape, global_mesh,

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -779,7 +779,7 @@ def _jax_physical_aval(aval: core.ShapedArray) -> core.ShapedArray:
   there is only one and return it.
   """
   if type(aval.dtype) in core.custom_eltypes:
-    aval, = aval.dtype.physical_avals(aval)
+    aval, = aval.dtype._rules.physical_avals(aval)
     return aval
   return aval
 

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -139,7 +139,7 @@ def dtype_to_ir_type(dtype: Union[np.dtype, np.generic]) -> ir.Type:
 def _array_ir_types(aval: Union[core.ShapedArray, core.DShapedArray]
                     ) -> Sequence[ir.Type]:
   if type(aval.dtype) in core.custom_eltypes:
-    return aval.dtype.aval_to_ir_types(aval)
+    return aval.dtype._rules.aval_to_ir_types(aval)
   return (ir.RankedTensorType.get(aval.shape, dtype_to_ir_type(aval.dtype)),)
 
 def _dynamic_array_ir_types(aval: core.ShapedArray) -> Sequence[ir.Type]:

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -579,7 +579,8 @@ local_result_handlers: Dict[Tuple[Type[core.AbstractValue], OutputType], PxlaRes
 def sda_array_result_handler(aval: ShapedArray, sharding, indices):
   sharding_spec = _get_sharding_specs([sharding], [aval])[0]
   if core.aval_has_custom_eltype(aval):
-    return aval.dtype.local_sharded_result_handler(aval, sharding, indices)
+    return aval.dtype._rules.local_sharded_result_handler(
+        aval, sharding, indices)
   else:
     return lambda bufs: make_sharded_device_array(aval, sharding_spec, bufs,
                                                   indices)

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -3018,17 +3018,7 @@ class LaxNamedShapeTest(jtu.JaxTestCase):
       (out,), _ = lax.psum_p.abstract_eval(aval1, axes=('i',), axis_index_groups=None)
       self.assertEqual(out, expected)
 
-
-class FooTy:
-  name = 'foo'
-  def __hash__(self) -> int:
-    return hash(FooTy)
-  def __eq__(self, other) -> bool:
-    return type(other) is FooTy
-  def __repr__(self) -> str:
-    return self.name
-  __str__ = __repr__
-
+class FooTyRules:
   # handlers
 
   @staticmethod
@@ -3114,6 +3104,19 @@ class FooTy:
     return mlir.delegate_lowering(ctx, gather_lower, x, indices,
                                   avals_in=[aval_x_raw, aval_indices],
                                   avals_out=[aval_y_raw])
+
+
+class FooTy:
+  name = 'foo'
+  _rules = FooTyRules
+
+  def __hash__(self) -> int:
+    return hash(FooTy)
+  def __eq__(self, other) -> bool:
+    return type(other) is FooTy
+  def __repr__(self) -> str:
+    return self.name
+  __str__ = __repr__
 
 # primitives
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1515,6 +1515,23 @@ class KeyArrayTest(jtu.JaxTestCase):
     make_key = partial(prng.seed_with_impl, prng.threefry_prng_impl)
     return jnp.reshape(jax.vmap(make_key)(seeds), shape)
 
+  def test_dtype_property(self):
+    k1, k2 = self.make_keys(), self.make_keys()
+    self.assertEqual(k1.dtype, k2.dtype)
+
+    k3, k4 = jax.random.split(k1, 2)
+    self.assertEqual(k1.dtype, k3.dtype)
+    self.assertEqual(k3.dtype, k4.dtype)
+
+    g = []
+    def f(k):
+      g.append(k.dtype)
+      return jax.random.split(k)
+    _ = jax.jit(f)(k1)
+    self.assertEqual(g[0], k1.dtype)
+    self.assertEqual(g[0], k2.dtype)
+
+
   # -- prng primitives
 
   def test_random_wrap_vmap(self):


### PR DESCRIPTION
Since this returns an instance of the opaque key element type to public callers, this PR also collects all of the internal element-type-specific rules (handlers, lowering rules, etc.) into a single `_rules` attribute.