### PR TITLE
Add markers to run multi node gpu tests separately

### DIFF
--- a/.github/workflows/slurm_job_scripts/multinode_pytest.sub
+++ b/.github/workflows/slurm_job_scripts/multinode_pytest.sub
@@ -40,7 +40,7 @@ EOF
 read -r -d '' cmd <<EOF
 date \
 && python3.8 -m pip  list | grep jax \
-&& python3.8 -m pytest --forked -v -s --continue-on-collection-errors \
+&& python3.8 -m pytest -m SlurmMultiNodeGpuTest --forked -v -s --continue-on-collection-errors \
     --junit-xml=/workspace/outputs/junit_output_\${SLURM_PROCID}.xml \
     /workspace/tests/multiprocess_gpu_test.py
 EOF

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+markers =
+    SlurmMultiNodeGpuTest: mark a test for Slurm multinode GPU nightly CI
 filterwarnings =
     error
     ignore:No GPU/TPU found, falling back to CPU.:UserWarning

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -33,6 +33,11 @@ try:
 except ImportError:
   portpicker = None
 
+try:
+  import pytest
+except ImportError:
+  pytest = None
+
 config.parse_flags_with_absl()
 
 
@@ -151,7 +156,11 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
 @unittest.skipIf(
     os.environ.get("SLURM_JOB_NUM_NODES", None) != "2",
     "Slurm environment with at least two nodes needed!")
+@unittest.skipIf(not pytest, "Test requires pytest markers")
 class SlurmMultiNodeGpuTest(jtu.JaxTestCase):
+
+  if pytest is not None:
+    pytestmark = pytest.mark.SlurmMultiNodeGpuTest
 
   def test_gpu_multi_node_initialize_and_psum(self):
 


### PR DESCRIPTION
Slurm launches separate processes that doesn't play well with other tests that themselves launch multiple processes (using subprocess). So, marking multi-node test to run it separately. For future multi-node tests, will be able to add this marker to run multi-node tests separately while they co-exist with other tests. 