### PR TITLE
add `key_data` to `jax.random` for key array unwrapping

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -754,7 +754,8 @@ batching.primitive_batchers[random_wrap_p] = random_wrap_batch_rule
 
 
 def random_unwrap(keys):
-  assert isinstance(keys, PRNGKeyArray)
+  if not isinstance(keys, PRNGKeyArray):
+    raise TypeError(f'random_unwrap takes key array operand, got {type(keys)}')
   return random_unwrap_p.bind(keys)
 
 random_unwrap_p = core.Primitive('random_unwrap')

--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -199,6 +199,14 @@ def split(key: KeyArray, num: int = 2) -> KeyArray:
   key, wrapped = _check_prng_key(key)
   return _return_prng_keys(wrapped, _split(key, num))
 
+def _key_data(keys: KeyArray) -> jnp.ndarray:
+  assert isinstance(keys, prng.PRNGKeyArray)
+  return prng.random_unwrap(keys)
+
+def key_data(keys: KeyArray) -> jnp.ndarray:
+  keys, _ = _check_prng_key(keys)
+  return _key_data(keys)
+
 
 ### random samplers
 

--- a/jax/random.py
+++ b/jax/random.py
@@ -155,6 +155,7 @@ from jax._src.random import (
   gamma as gamma,
   generalized_normal as generalized_normal,
   gumbel as gumbel,
+  key_data as key_data,
   laplace as laplace,
   logistic as logistic,
   loggamma as loggamma,


### PR DESCRIPTION
This is often useful in testing and debugging. Its more dangerous inverse, wrapping, remains internal only.

cc #9263 