### PR TITLE
test the RNG key upgrade in one of our github CI runs

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,6 +44,7 @@ jobs:
             python-version: "3.8"
             os: ubuntu-latest
             enable-x64: 0
+            prng-upgrade: 0
             package-overrides: "none"
             num_generated_cases: 1
             use-latest-jaxlib: false
@@ -51,6 +52,7 @@ jobs:
             python-version: "3.9"
             os: ubuntu-latest
             enable-x64: 1
+            prng-upgrade: 1
             # Test experimental NumPy dispatch
             package-overrides: "git+https://github.com/seberg/numpy-dispatch.git"
             num_generated_cases: 1
@@ -59,6 +61,7 @@ jobs:
             python-version: "3.10"
             os: ubuntu-latest
             enable-x64: 0
+            prng-upgrade: 0
             package-overrides: "none"
             num_generated_cases: 1
             use-latest-jaxlib: false
@@ -101,12 +104,14 @@ jobs:
       env:
         JAX_NUM_GENERATED_CASES: ${{ matrix.num_generated_cases }}
         JAX_ENABLE_X64: ${{ matrix.enable-x64 }}
+        JAX_ENABLE_CUSTOM_PRNG: ${{ matrix.prng-upgrade }}
         JAX_ENABLE_CHECKS: true
         JAX_SKIP_SLOW_TESTS: true
       run: |
         pip install -e .
         echo "JAX_NUM_GENERATED_CASES=$JAX_NUM_GENERATED_CASES"
         echo "JAX_ENABLE_X64=$JAX_ENABLE_X64"
+        echo "JAX_ENABLE_CUSTOM_PRNG=$JAX_ENABLE_CUSTOM_PRNG"
         echo "JAX_ENABLE_CHECKS=$JAX_ENABLE_CHECKS"
         pytest -n auto --tb=short tests examples
 


### PR DESCRIPTION
I went with the "numpy-dispatch" configuration since, as @jakevdp pointed out, it seems to be our frequent choice for future-proofing.

cc #9263