### PR TITLE
support key array pickling

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -470,7 +470,7 @@ class KeyTy:
     return self.name
 
   def __eq__(self, other):
-    return type(other) is KeyTy and self.impl is other.impl
+    return type(other) is KeyTy and self.impl == other.impl
 
   def __hash__(self) -> int:
     return hash((self.__class__, self.impl))
@@ -1009,9 +1009,12 @@ def _threefry_fold_in(key, data):
   return threefry_2x32(key, threefry_seed(data))
 
 
-@partial(jit, static_argnums=(1, 2), inline=True)
 def threefry_random_bits(key: jnp.ndarray, bit_width, shape):
   """Sample uniform random bits of given width and shape using PRNG key."""
+  return _threefry_random_bits(key, bit_width, shape)
+
+@partial(jit, static_argnums=(1, 2), inline=True)
+def _threefry_random_bits(key: jnp.ndarray, bit_width, shape):
   if not _is_threefry_prng_key(key):
     raise TypeError("threefry_random_bits got invalid prng key.")
   if bit_width not in (8, 16, 32, 64):

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -94,6 +94,18 @@ class PickleTest(jtu.JaxTestCase):
     self.assertIsInstance(y, type(x))
     self.assertEqual(x.aval, y.aval)
 
+  @parameterized.named_parameters(jtu.cases_from_list(
+      {'testcase_name': '_' + name, 'prng_name': name}
+      for name in ['threefry2x32', 'rbg', 'unsafe_rbg']))
+  def testPickleOfKeyArray(self, prng_name):
+    with jax.default_prng_impl(prng_name):
+      k1 = jax.random.PRNGKey(72)
+      s  = pickle.dumps(k1)
+      k2 = pickle.loads(s)
+      self.assertEqual(k1.dtype, k2.dtype)
+      self.assertArraysEqual(jax.random.key_data(k1),
+                             jax.random.key_data(k2))
+
   @parameterized.parameters(
       (pxla.PartitionSpec(),),
       (pxla.PartitionSpec(None),),


### PR DESCRIPTION
Involves a weaker notion of equality on key element types and avoiding jitted functions as PRNG impl fields.

cc #9263