### PR TITLE
[jax2tf] Improves TF.js quickdraw example

### DIFF
--- a/jax/experimental/jax2tf/examples/tf_js/README.md
+++ b/jax/experimental/jax2tf/examples/tf_js/README.md
@@ -1,3 +1,7 @@
-This directory contains examples of using the jax2tf converter to produce
-models that can be used with TensorFlow.js. Note that this is still highly
-experimental.
+This directory contains a simple example of using the jax2tf converter to
+produce models that can be used with TensorFlow.js. This example uses
+[tfjs.converters.jax_conversion.convert_jax() API](https://github.com/tensorflow/tfjs/tree/master/tfjs-converter#calling-a-converter-function-in-python-flaxjax),
+which is part of TensorFlow.JS, and uses jax2tf under the hood.
+
+See the following blog post for more details:
+[JAX on the Web with TensorFlow.js](https://blog.tensorflow.org/2022/08/jax-on-web-with-tensorflowjs.html).

--- a/jax/experimental/jax2tf/examples/tf_js/quickdraw/input_pipeline.py
+++ b/jax/experimental/jax2tf/examples/tf_js/quickdraw/input_pipeline.py
@@ -46,7 +46,7 @@ def download_dataset(dir_path, nb_classes):
         print(f'Failed to fetch {cls_filename}')
   return classes
 
-def load_classes(dir_path, classes, batch_size=256, test_ratio=0.1,
+def get_datasets(dir_path, classes, batch_size=256, test_ratio=0.1,
                  max_items_per_class=4096):
   x, y = np.empty([0, 784]), np.empty([0])
   for idx, cls in enumerate(classes):

--- a/jax/experimental/jax2tf/examples/tf_js/quickdraw/quickdraw.py
+++ b/jax/experimental/jax2tf/examples/tf_js/quickdraw/quickdraw.py
@@ -11,35 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from absl import app # type: ignore
+from absl import app
 from absl import flags
 
-import os # type: ignore
+import os
 import time
-from typing import Callable
 
-import flax # type: ignore
 from flax import linen as nn
-from flax.training import common_utils # type: ignore
+from flax.training import train_state
 
-import jax # type: ignore
+import jax
 from jax import lax
 from jax import numpy as jnp
 
-from jax.experimental.jax2tf.examples import saved_model_lib # type: ignore
+import optax
 
-import numpy as np # type: ignore
-import tensorflow as tf # type: ignore
-from tensorflowjs.converters import convert_tf_saved_model # type: ignore
+import numpy as np
+import tensorflow as tf
+import tensorflowjs as tfjs
 
-from jax.config import config # type: ignore
-config.config_with_absl()
+import input_pipeline
 
-import utils
 
-flags.DEFINE_boolean("run_eval_on_train", False,
-                     ("Also run eval on the train set after each epoch. This "
-                      "slows down training considerably."))
 flags.DEFINE_integer("num_epochs", 5,
                      ("Number of epochs to train for."))
 flags.DEFINE_integer("num_classes", 100, "Number of classification classes.")
@@ -53,7 +46,7 @@ FLAGS = flags.FLAGS
 # The code below is an adaptation for Flax from the work published here:
 # https://blog.tensorflow.org/2018/07/train-model-in-tfkeras-with-colab-and-run-in-browser-tensorflowjs.html
 
-class QuickDrawModule(nn.Module):
+class QuickDraw(nn.Module):
   @nn.compact
   def __call__(self, x):
     x = nn.Conv(features=16, kernel_size=(3, 3), padding='SAME')(x)
@@ -73,92 +66,91 @@ class QuickDrawModule(nn.Module):
     x = nn.relu(x)
 
     x = nn.Dense(features=FLAGS.num_classes)(x)
-    x = nn.softmax(x)
 
     return x
 
-def predict(params, inputs):
-  """A functional interface to the trained Module."""
-  return QuickDrawModule().apply({'params': params}, inputs)
 
-def categorical_cross_entropy_loss(logits, labels):
-  onehot_labels = common_utils.onehot(labels, logits.shape[-1])
-  return jnp.mean(-jnp.sum(onehot_labels * jnp.log(logits), axis=1))
-
-def update(optimizer, inputs, labels):
+@jax.jit
+def apply_model(state, inputs, labels):
+  """Computes gradients, loss and accuracy for a single batch."""
   def loss_fn(params):
-    logits = predict(params, inputs)
-    return categorical_cross_entropy_loss(logits, labels)
-  grad = jax.grad(loss_fn)(optimizer.target)
-  optimizer = optimizer.apply_gradient(grad)
-  return optimizer
+    logits = state.apply_fn({'params': params}, inputs)
+    one_hot = jax.nn.one_hot(labels, FLAGS.num_classes)
+    loss = jnp.mean(optax.softmax_cross_entropy(logits=logits, labels=one_hot))
+    return loss, logits
+  grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
+  (loss, logits), grads = grad_fn(state.params)
+  accuracy = jnp.mean(jnp.argmax(logits, -1) == labels)
+  return grads, loss, accuracy
 
-def accuracy(predict: Callable, params, dataset):
-  def top_k_classes(x, k):
-    bcast_idxs = jnp.broadcast_to(np.arange(x.shape[-1]), x.shape)
-    sorted_vals, sorted_idxs = lax.sort_key_val(x, bcast_idxs)
-    topk_idxs = (
-        lax.slice_in_dim(sorted_idxs, -k, sorted_idxs.shape[-1], axis=-1))
-    return topk_idxs
-  def _per_batch(inputs, labels):
-    logits = predict(params, inputs)
-    predicted_classes = top_k_classes(logits, 1)
-    predicted_classes = predicted_classes.reshape((predicted_classes.shape[0],))
-    return jnp.mean(predicted_classes == labels)
-  batched = [_per_batch(inputs, labels) for inputs, labels in dataset]
-  return jnp.mean(jnp.stack(batched))
 
-def train_one_epoch(optimizer, train_ds):
-  for inputs, labels in train_ds:
-    optimizer = jax.jit(update)(optimizer, inputs, labels)
-  return optimizer
+@jax.jit
+def update_model(state, grads):
+  return state.apply_gradients(grads=grads)
 
-def init_model():
-  rng = jax.random.PRNGKey(0)
-  init_shape = jnp.ones((1, 28, 28, 1), jnp.float32)
-  initial_params = QuickDrawModule().init(rng, init_shape)["params"]
-  optimizer = flax.optim.Adam(
-      learning_rate=0.001, beta1=0.9, beta2=0.999).create(initial_params)
-  return optimizer, initial_params
 
-def train(train_ds, test_ds, classes):
-  optimizer, params = init_model()
+def run_epoch(state, dataset, train=True):
+  epoch_loss = []
+  epoch_accuracy = []
+
+  for inputs, labels in dataset:
+    grads, loss, accuracy = apply_model(state, inputs, labels)
+    if train:
+      state = update_model(state, grads)
+    epoch_loss.append(loss)
+    epoch_accuracy.append(accuracy)
+  loss = np.mean(epoch_loss)
+  accuracy = np.mean(epoch_accuracy)
+  return state, loss, accuracy
+
+
+def create_train_state(rng):
+  quick_draw = QuickDraw()
+  params = quick_draw.init(rng, jnp.ones((1, 28, 28, 1)))['params']
+  tx = optax.adam(learning_rate=0.001, b1=0.9, b2=0.999)
+  return train_state.TrainState.create(
+    apply_fn=quick_draw.apply, params=params, tx=tx)
+
+
+def train(state, train_ds, test_ds):
   for epoch in range(1, FLAGS.num_epochs+1):
     start_time = time.time()
-    optimizer = train_one_epoch(optimizer, train_ds)
 
-    if FLAGS.run_eval_on_train:
-      train_acc = accuracy(predict, optimizer.target, train_ds)
-      print(f"Training set accuracy {train_acc}")
+    state, train_loss, train_accuracy = run_epoch(state, train_ds)
+    _, test_loss, test_accuracy = run_epoch(state, test_ds, train=False)
 
-    test_acc = accuracy(predict, optimizer.target, test_ds)
-    print(f"Test set accuracy {test_acc}")
+    print(f"Training set accuracy {train_accuracy}")
+    print(f"Training set loss {train_loss}")
+    print(f"Test set accuracy {test_accuracy}")
+    print(f"Test set loss {test_loss}")
+
     epoch_time = time.time() - start_time
     print(f"Epoch {epoch} in {epoch_time:0.2f} sec")
 
-  return optimizer.target
+  return state
 
-def main(*args):
+
+def main(argv):
+  if len(argv) > 1:
+    raise app.UsageError('Too many command-line arguments.')
+
   base_model_path = "/tmp/jax2tf/tf_js_quickdraw"
   dataset_path = os.path.join(base_model_path, "data")
-  num_classes = FLAGS.num_classes
-  classes = utils.download_dataset(dataset_path, num_classes)
-  assert len(classes) == num_classes, classes
+  classes = input_pipeline.download_dataset(dataset_path, FLAGS.num_classes)
+  assert len(classes) == FLAGS.num_classes, "Incorrect number of classes"
   print(f"Classes are: {classes}")
   print("Loading dataset into memory...")
-  train_ds, test_ds = utils.load_classes(dataset_path, classes)
+  train_ds, test_ds = input_pipeline.get_datasets(dataset_path, classes)
   print(f"Starting training for {FLAGS.num_epochs} epochs...")
-  flax_params = train(train_ds, test_ds, classes)
 
-  model_dir = os.path.join(base_model_path, "saved_models")
-  # the model must be converted with with_gradient set to True to be able to
-  # convert the saved model to TF.js, as "PreventGradient" is not supported
-  saved_model_lib.convert_and_save_model(predict, flax_params, model_dir,
-                             input_signatures=[tf.TensorSpec([1, 28, 28, 1])],
-                             with_gradient=True, compile_model=False,
-                             enable_xla=False)
-  conversion_dir = os.path.join(base_model_path, 'tfjs_models')
-  convert_tf_saved_model(model_dir, conversion_dir)
+  state = create_train_state(jax.random.PRNGKey(0))
+  state = train(state, train_ds, test_ds)
+
+  tfjs.converters.convert_jax(
+    apply_fn=state.apply_fn,
+    params={'params': state.params},
+    input_signatures=[tf.TensorSpec([1, 28, 28, 1])],
+    model_dir=os.path.join(base_model_path, 'tfjs_models'))
 
 if __name__ == "__main__":
   app.run(main)


### PR DESCRIPTION
Improves the quickdraw example in the following ways:

* Uses the TF.js API for converting JAX to TF.js
* Uses optax for optimizers (`flax.optim` does not exist anymore)
* Removes overly complex logic for computing accuracy
* Compute cross entropy loss using optax rather than a custom implementation. Note that this requires unnormalized logits, so I had to remove the final `softmax` in the model to get it working.
* Use Flax's `train_state` abstraction to hide some further complexity.

It verified this works by training the model locally and inserting it into the web demo, which worked.