### PR TITLE
[ROCm] Unit tests are fixed in ROCm

### DIFF
--- a/tests/custom_linear_solve_test.py
+++ b/tests/custom_linear_solve_test.py
@@ -227,7 +227,6 @@ class CustomLinearSolveTest(jtu.JaxTestCase):
         order=2,
         rtol={jnp.float32: 6e-2, jnp.float64: 2e-3})
 
-  @jtu.skip_on_devices("rocm")  # rtol and atol needs to be adjusted for ROCm
   def test_custom_linear_solve_cholesky(self):
 
     def positive_definite_solve(a, b):

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -409,7 +409,6 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
 
     self.assertAllClose(actual, expected, rtol=1.1e-7, atol=3e-8)
 
-  @jtu.skip_on_devices("rocm")  # rtol and atol needs to be adjusted for ROCm
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises dtype promotion
   def testSphHarmOrderZeroDegreeOne(self):
     """Tests the spherical harmonics of order one and degree zero."""


### PR DESCRIPTION
two unit tests ( testSphHarmOrderZeroDegreeOne and test_custom_linear_solve_cholesky) have already been fixed in ROCm 5.2, no need to skip in the unit test.


@hawkinsp 