### PR TITLE
[jax2tf] Refactor top-level jax2tf.convert

### DIFF
--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -270,7 +270,7 @@ def convert(fun_jax: Callable,
 
   Returns:
     A version of `fun_jax` that expects TfVals as arguments (or
-    tuple/lists/dicts) thereof, and returns TfVals as outputs, and uses
+    tuple/lists/dicts thereof), and returns TfVals as outputs, and uses
     only TensorFlow ops.
   """
   if experimental_native_lowering == "default":

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -741,30 +741,20 @@ def get_shape_evaluator(dim_vars: Sequence[str], shape: Sequence[DimSize]) ->\
   return (eval_shape,
           tuple(core.ShapedArray((), np.int32) for _ in dim_vars))
 
-def args_avals(
-    arg_shapes: Sequence[Sequence[Optional[int]]],
-    arg_jax_dtypes: Sequence[DType],
-    polymorphic_shapes: Sequence[Optional[Union[str, PolyShape]]]) -> \
-  Sequence[core.ShapedArray]:
+def arg_aval(
+    arg_shape: Sequence[Optional[int]],
+    arg_jax_dtype: DType,
+    polymorphic_shape: Optional[Union[str, PolyShape]]) -> core.ShapedArray:
   """Computes abstract values.
 
   Args:
-    arg_shapes: the shapes for the arguments, possibly having None dimensions.
-    arg_dtypes: the inferred JAX dtypes for the args.
-    polymorphic_shapes: the polymorphic specifications for the arguments.
-  Returns: a sequence of abstract values corresponding to the arguments.
+    arg_shape: the shape for the argument, possibly having None dimensions.
+    arg_dtype: the inferred JAX dtype for the arg.
+    polymorphic_shape: the polymorphic specifications for the argument.
+  Returns: the JAX abstract value for the argument.
   """
-
-  def input_aval(arg_shape: Sequence[Optional[int]],
-                 arg_jax_dtype: DType,
-                 polymorphic_shape: Optional[str]) -> core.ShapedArray:
-    """The abstract value for an input."""
-    aval_shape = _parse_spec(polymorphic_shape, arg_shape)
-    return core.ShapedArray(aval_shape, arg_jax_dtype)
-
-  avals = tuple(map(input_aval, arg_shapes, arg_jax_dtypes, polymorphic_shapes))  # type: ignore
-  return avals
-
+  aval_shape = _parse_spec(polymorphic_shape, arg_shape)
+  return core.ShapedArray(aval_shape, arg_jax_dtype)
 
 def prepare_dim_var_env(args_avals: Sequence[core.AbstractValue]) -> \
     Tuple[Sequence[str], Callable]:

--- a/jax/experimental/jax2tf/tests/shape_poly_test.py
+++ b/jax/experimental/jax2tf/tests/shape_poly_test.py
@@ -436,12 +436,11 @@ class ShapePolyTest(tf_test_util.JaxToTfTestCase):
       # Use eager mode only for when all arg_shapes are known, in order to
       # check expected_shapeenv.
       arg_dtypes = (_f32,) * len(arg_shapes)
-      def f_tf(*tf_args):
-        avals = shape_poly.args_avals(
-            arg_shapes, arg_dtypes, polymorphic_shapes)  # The function under test
-        dim_vars, get_dim_values = shape_poly.prepare_dim_var_env(avals)
-        dim_values, _ = util.unzip2(jax2tf.jax2tf._interpret_fun(lu.wrap_init(get_dim_values),
-                                                                 tf_args, avals, ""))
+      def f_tf(*args_tf):
+        avals = tuple(map(shape_poly.arg_aval, arg_shapes, arg_dtypes, polymorphic_shapes))
+        dim_vars, get_dim_values_jax = shape_poly.prepare_dim_var_env(avals)
+        dim_values, _ = jax2tf.jax2tf._interpret_fun_jax(get_dim_values_jax,
+                                                         args_tf, avals, "")
         if expected_avals is not None:
           self.assertEqual(expected_avals, avals)
         return dict(zip(dim_vars, dim_values))


### PR DESCRIPTION
There are several goals for this refactoring:
  * improve the readability of the code: more helper functions, move big
    nested functions to top-level make make it obvious what are the
    data dependencies
  * try to be more systematic about naming: JAX entities end with _jax
    and TF entities with _tf. This is helpful because in several cases
    one function has to operate with both kinds of entities.
  * the main goal is to enable fixing the experimental_native_lowering
    for pjit. For that (future) work, we want to pass JAX callables
    to _interpret_fun_jax, rather than linear_util.WrappedFun. This will
    allow us to use fewer JAX core internals, and rely more on AOT APIs.