### PR TITLE
Add `jax.print_environment_info()` utility

### DIFF
--- a/docs/jax.rst
+++ b/docs/jax.rst
@@ -109,3 +109,11 @@ Callbacks
 
     pure_callback
     debug.callback
+
+Miscellaneous
+-------------
+
+.. autosummary::
+  :toctree: _autosummary
+
+    print_environment_info

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -57,6 +57,7 @@ from jax._src.config import (
   transfer_guard_device_to_host as transfer_guard_device_to_host,
 )
 from .core import eval_context as ensure_compile_time_eval
+from jax._src.environment_info import print_environment_info as print_environment_info
 from jax._src.api import (
   ad,  # TODO(phawkins): update users to avoid this.
   effects_barrier,

--- a/jax/_src/environment_info.py
+++ b/jax/_src/environment_info.py
@@ -1,0 +1,56 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+from jax._src import lib
+import numpy as np
+
+import subprocess
+import sys
+import textwrap
+from typing import Optional, Union
+
+def try_nvidia_smi() -> Optional[str]:
+  try:
+    return subprocess.check_output(['nvidia-smi']).decode()
+  except Exception:
+    return None
+
+
+def print_environment_info(return_string: bool = False) -> Union[None, str]:
+  """Returns a string containing local environment & JAX installation information.
+
+  This is useful information to include when asking a question or filing a bug.
+
+  Args:
+    return_string (bool) : if True, return the string rather than printing to stdout.
+  """
+  # TODO(jakevdp): should we include other info, e.g. jax.config.values?
+  python_version = sys.version.replace('\n', ' ')
+  with np.printoptions(threshold=4, edgeitems=2):
+    devices_short = str(np.array(jax.devices())).replace('\n', '')
+  info = textwrap.dedent(f"""\
+  jax:    {jax.__version__}
+  jaxlib: {lib.version_str}
+  numpy:  {np.__version__}
+  python: {python_version}
+  jax.devices ({jax.device_count()} total, {jax.local_device_count()} local): {devices_short}
+  process_count: {jax.process_count()}""")
+  nvidia_smi = try_nvidia_smi()
+  if nvidia_smi:
+    info += "\n\n$ nvidia-smi\n" + nvidia_smi
+  if return_string:
+    return info
+  else:
+    return print(info)

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -14,12 +14,13 @@
 
 from contextlib import contextmanager
 import inspect
+import io
 import functools
 from functools import partial
 import re
 import os
 import textwrap
-from typing import Dict, List, Generator, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Generator, Sequence, Tuple, Union
 import unittest
 import warnings
 import zlib
@@ -151,6 +152,14 @@ def join_tolerance(tol1, tol2):
 def check_eq(xs, ys, err_msg=''):
   assert_close = partial(_assert_numpy_allclose, err_msg=err_msg)
   tree_all(tree_map(assert_close, xs, ys))
+
+
+@contextmanager
+def capture_stdout() -> Generator[Callable[[], str], None, None]:
+  with unittest.mock.patch('sys.stdout', new_callable=io.StringIO) as fp:
+    def _read() -> str:
+      return fp.getvalue()
+    yield _read
 
 
 @contextmanager

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -45,7 +45,7 @@ import jax.numpy as jnp
 from jax import float0, jit, grad, device_put, jacfwd, jacrev, hessian
 from jax import core, lax
 from jax import custom_batching
-from jax._src import api, dtypes, dispatch
+from jax._src import api, dtypes, dispatch, lib
 from jax.core import Primitive
 from jax.errors import UnexpectedTracerError
 from jax.interpreters import ad
@@ -8997,6 +8997,20 @@ class CleanupTest(jtu.JaxTestCase):
       assert core.trace_state_clean()  # this is the hard one
     assert core.trace_state_clean()
 
+
+class EnvironmentInfoTest(jtu.JaxTestCase):
+  @parameterized.parameters([True, False])
+  def test_print_environment_info(self, return_string):
+    with jtu.capture_stdout() as stdout:
+      result = jax.print_environment_info(return_string=return_string)
+    if return_string:
+      self.assertEmpty(stdout())
+    else:
+      self.assertIsNone(result)
+      result = stdout()
+    assert f"jax:    {jax.__version__}" in result
+    assert f"jaxlib: {lib.version_str}" in result
+    assert f"numpy:  {np.__version__}" in result
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import contextlib
 import functools
-import io
 import textwrap
 import unittest
-from unittest import mock
 
-from typing import Any, Callable, Generator, Sequence
+from typing import Any, Callable, Sequence
 
 from absl.testing import absltest
 import jax
@@ -40,16 +37,6 @@ import numpy as np
 config.parse_flags_with_absl()
 
 debug_print = debugging.debug_print
-
-
-@contextlib.contextmanager
-def capture_stdout() -> Generator[Callable[[], str], None, None]:
-  with mock.patch("sys.stdout", new_callable=io.StringIO) as fp:
-
-    def _read() -> str:
-      return fp.getvalue()
-
-    yield _read
 
 
 def _format_multiline(text):


### PR DESCRIPTION
The idea here is that this gives a single API call that we can ask users to run when opening a bug or asking a question.

Example on Colab CPU:
```python
>>> import jax; jax.print_environment_info()
jax:    0.3.17
jaxlib: 0.3.15
numpy:  1.21.6
python: 3.7.13 (default, Apr 24 2022, 01:04:09)  [GCC 7.5.0]
jax.devices (1 total, 1 local): [CpuDevice(id=0)]
process_count: 1
```
Example on Colab GPU:
```python
>>> import jax; jax.print_environment_info()
jax:    0.3.17
jaxlib: 0.3.15
numpy:  1.21.6
python: 3.7.13 (default, Apr 24 2022, 01:04:09)  [GCC 7.5.0]
jax.devices (1 total, 1 local): [GpuDevice(id=0, process_index=0)]
process_count: 1

$ nvidia-smi
Fri Sep  2 21:26:17 2022       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 460.32.03    Driver Version: 460.32.03    CUDA Version: 11.2     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla T4            Off  | 00000000:00:04.0 Off |                    0 |
| N/A   38C    P0    27W /  70W |    104MiB / 15109MiB |      4%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
+-----------------------------------------------------------------------------+
```
And if you have lots of hosts:
```python
$ XLA_FLAGS=--xla_force_host_platform_device_count=256 python -c "import jax; jax.print_environment_info()"
jax:    0.3.18
jaxlib: 0.3.15
numpy:  1.23.2
python: 3.8.2 (v3.8.2:7b3ab5921f, Feb 24 2020, 17:52:18)  [Clang 6.0 (clang-600.0.57)]
jax.devices (256 total, 256 local): [CpuDevice(id=0) CpuDevice(id=1) ... CpuDevice(id=254) CpuDevice(id=255)]
process_count: 1
```