### PR TITLE
Enable `remat(for_loop)`

### DIFF
--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -328,10 +328,10 @@ def _state_partial_eval_custom(prim, saveable, unks_in, inst_in, eqn):
   if any(unks_in):
     res = [v for v, inst in zip(eqn.invars, inst_in) if not inst]
     return None, eqn, [True] * len(eqn.outvars), [True] * len(eqn.outvars), res
-  elif saveable(get_p, *[var.aval for var in eqn.invars], **eqn.params):
+  elif saveable(prim, *[var.aval for var in eqn.invars], **eqn.params):
     return eqn, None, [False] * len(eqn.outvars), [False] * len(eqn.outvars), []
   res = [v for v, inst in zip(eqn.invars, inst_in) if not inst]
-  return eqn, eqn, [False] * len(eqn.outvars), [True] * len(eqn.outvars), []
+  return eqn, eqn, [False] * len(eqn.outvars), [True] * len(eqn.outvars), res
 
 pe.partial_eval_jaxpr_custom_rules[get_p] = partial(_state_partial_eval_custom,
                                                     get_p)


### PR DESCRIPTION
This change adds a `partial_eval_custom` rule for both `for` and for `closed_call`.

Tracker: #10982 