### PR TITLE
Fix `Cmd.use_rawinput` type in debuggers

### DIFF
--- a/jax/_src/debugger/cli_debugger.py
+++ b/jax/_src/debugger/cli_debugger.py
@@ -27,7 +27,7 @@ DebuggerFrame = debugger_core.DebuggerFrame
 class CliDebugger(cmd.Cmd):
   """A text-based debugger."""
   prompt = '(jdb) '
-  use_rawinput: bool = False
+  use_rawinput = False
 
   def __init__(self, frames: List[DebuggerFrame], thread_id,
       stdin: Optional[IO[str]] = None, stdout: Optional[IO[str]] = None,

--- a/jax/_src/debugger/web_debugger.py
+++ b/jax/_src/debugger/web_debugger.py
@@ -34,7 +34,7 @@ _web_consoles: Dict[Tuple[str, int], web_pdb.WebConsole] = {}
 class WebDebugger(cli_debugger.CliDebugger):
   """A web-based debugger."""
   prompt = '(jdb) '
-  use_rawinput: bool = False
+  use_rawinput = False
 
   def __init__(self, frames: List[debugger_core.DebuggerFrame], thread_id,
                completekey: str = "tab", host: str = "", port: int = 5555):


### PR DESCRIPTION
Why is this an issue? In the example below:

```python
class Some:
   a = True
   b: bool = True
```

`a` and `b` have different semantics. Since `a` is initialized in a class body, tools like `mypy` assume it is a class attribute. Mypy also does inference its type to be `bool`, no annotation is needed.

But, `b` is different. It is annotated as an instance-level variable with a class-level default. (yeap, typing is a different world)

The same semantics `a = True` has can be specified by `a: ClassVar[bool] = True`, but I don't think it is worth it. Just removing type annotation is good enough.

Found in https://github.com/python/typeshed/pull/8692