### PR TITLE
jax.Array: support duck-typed isinstance checks

### DIFF
--- a/jax/experimental/array.py
+++ b/jax/experimental/array.py
@@ -105,7 +105,12 @@ def _reconstruct_array(fun, args, arr_state, aval_state):
   return jnp_value
 
 
-class Array:
+class ArrayMeta(type):
+  def __instancecheck__(cls, val):
+    return super().__instancecheck__(val) or isinstance(val, core.Tracer)
+
+
+class Array(metaclass=ArrayMeta):
   # TODO(yashkatariya): Add __slots__ here.
 
   def __init__(self, aval: core.ShapedArray, sharding: Sharding,

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -486,6 +486,22 @@ class ShardingTest(jtu.JaxTestCase):
     self.assertGreater(cache_info2.hits, cache_info1.hits + 1)
     self.assertEqual(cache_info2.misses, cache_info1.misses)
 
+  def test_array_isinstance(self):
+    with jax_config.jax_array(True):
+      x = jnp.arange(5)
+
+      # Check type identity
+      assert type(x) is array.Array
+
+      # Check isinstance() for Arrays and tracers
+      is_array = lambda x: isinstance(x, array.Array)
+      jit_is_array = jax.jit(is_array)
+      vmap_is_array = jax.vmap(is_array)
+
+      self.assertTrue(is_array(x))
+      self.assertTrue(jit_is_array(x))
+      self.assertTrue(vmap_is_array(x).all())
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Why? As part of the type promotion discussion in JAX (#11859 & #12049), @patrick-kidger and I have been discussing what API jax should support for both annotations and `isinstance` checks; we think the best approach would be to eventually make `jax.Array` unify all these purposes.

This is a simple enhancement to `jax.Array` that allows it to be used in `isinstance` checks in traced functions, similar to how `isinstance(obj, jnp.ndarray)` works currently.

@yashk2810, I'm curious whether you see any issues with adding a mechanism like this to the `Array` class? Do you think this idea of unifying type checking and instance checks around the eventual `jax.Array` object has merit? Do you have any hesitations here?