### PR TITLE
jax._src.typing: add basic types and use them in lax.py

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -66,6 +66,7 @@ from jax._src.lax.utils import (
   standard_translate,
 )
 from jax._src.lax import slicing
+from jax._src.typing import Array, ArrayLike, DtypeLike, Shape
 
 xb = xla_bridge
 xc = xla_client
@@ -75,10 +76,6 @@ xe = xla_client._xla
 _max = builtins.max
 _min = builtins.min
 _reduce = functools.reduce
-
-Array = Any
-DType = Any
-Shape = core.Shape
 
 T = TypeVar("T")
 
@@ -205,11 +202,11 @@ def _dyn_shape_staging_rule(trace, prim, out_aval, *args, **params):
 
 ### traceables
 
-def neg(x: Array) -> Array:
+def neg(x: ArrayLike) -> Array:
   r"""Elementwise negation: :math:`-x`."""
   return neg_p.bind(x)
 
-def sign(x: Array) -> Array:
+def sign(x: ArrayLike) -> Array:
   r"""Elementwise sign.
 
   For floating-point inputs, returns
@@ -233,7 +230,7 @@ def sign(x: Array) -> Array:
   """
   return sign_p.bind(x)
 
-def nextafter(x1: Array, x2: Array) -> Array:
+def nextafter(x1: ArrayLike, x2: ArrayLike) -> Array:
   r"""Returns the next representable value after `x1` in the direction of `x2`.
 
   Note that in some environments flush-denormal-to-zero semantics is used.
@@ -249,11 +246,11 @@ def nextafter(x1: Array, x2: Array) -> Array:
   """
   return nextafter_p.bind(x1, x2)
 
-def floor(x: Array) -> Array:
+def floor(x: ArrayLike) -> Array:
   r"""Elementwise floor: :math:`\left\lfloor x \right\rfloor`."""
   return floor_p.bind(x)
 
-def ceil(x: Array) -> Array:
+def ceil(x: ArrayLike) -> Array:
   r"""Elementwise ceiling: :math:`\left\lceil x \right\rceil`."""
   return ceil_p.bind(x)
 
@@ -261,7 +258,7 @@ class RoundingMethod(enum.IntEnum):
   AWAY_FROM_ZERO = 0
   TO_NEAREST_EVEN = 1
 
-def round(x: Array,
+def round(x: ArrayLike,
           rounding_method: RoundingMethod = RoundingMethod.AWAY_FROM_ZERO
           ) -> Array:
   r"""Elementwise round.
@@ -280,7 +277,7 @@ def round(x: Array,
   rounding_method = RoundingMethod(rounding_method)
   return round_p.bind(x, rounding_method=rounding_method)
 
-def is_finite(x: Array) -> Array:
+def is_finite(x: ArrayLike) -> Array:
   r"""Elementwise :math:`\mathrm{isfinite}`.
 
   For each element x returns `True` if and only if x is not :math:`\pm\infty` or
@@ -288,182 +285,182 @@ def is_finite(x: Array) -> Array:
   """
   return is_finite_p.bind(x)
 
-def exp(x: Array) -> Array:
+def exp(x: ArrayLike) -> Array:
   r"""Elementwise exponential: :math:`e^x`."""
   return exp_p.bind(x)
 
-def expm1(x: Array) -> Array:
+def expm1(x: ArrayLike) -> Array:
   r"""Elementwise :math:`e^{x} - 1`."""
   return expm1_p.bind(x)
 
-def log(x: Array) -> Array:
+def log(x: ArrayLike) -> Array:
   r"""Elementwise natural logarithm: :math:`\mathrm{log}(x)`."""
   return log_p.bind(x)
 
-def log1p(x: Array) -> Array:
+def log1p(x: ArrayLike) -> Array:
   r"""Elementwise :math:`\mathrm{log}(1 + x)`."""
   return log1p_p.bind(x)
 
-def tanh(x: Array) -> Array:
+def tanh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic tangent: :math:`\mathrm{tanh}(x)`."""
   return tanh_p.bind(x)
 
-def logistic(x: Array) -> Array:
+def logistic(x: ArrayLike) -> Array:
   r"""Elementwise logistic (sigmoid) function: :math:`\frac{1}{1 + e^{-x}}`."""
   return logistic_p.bind(x)
 
-def sin(x: Array) -> Array:
+def sin(x: ArrayLike) -> Array:
   r"""Elementwise sine: :math:`\mathrm{sin}(x)`."""
   return sin_p.bind(x)
 
-def cos(x: Array) -> Array:
+def cos(x: ArrayLike) -> Array:
   r"""Elementwise cosine: :math:`\mathrm{cos}(x)`."""
   return cos_p.bind(x)
 
-def atan2(x: Array, y: Array) -> Array:
+def atan2(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arc tangent of two variables:
     :math:`\mathrm{atan}({x \over y})`."""
   return atan2_p.bind(x, y)
 
-def betainc(a: Array, b: Array, x: Array) -> Array:
+def betainc(a: ArrayLike, b: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete beta integral."""
   return regularized_incomplete_beta_p.bind(a, b, x)
 
-def lgamma(x: Array) -> Array:
+def lgamma(x: ArrayLike) -> Array:
   r"""Elementwise log gamma: :math:`\mathrm{log}(\Gamma(x))`."""
   return lgamma_p.bind(x)
 
-def digamma(x: Array) -> Array:
+def digamma(x: ArrayLike) -> Array:
   r"""Elementwise digamma: :math:`\psi(x)`."""
   return digamma_p.bind(x)
 
-def igamma(a: Array, x: Array) -> Array:
+def igamma(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise regularized incomplete gamma function."""
   return igamma_p.bind(a, x)
 
-def igammac(a: Array, x: Array) -> Array:
+def igammac(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise complementary regularized incomplete gamma function."""
   return igammac_p.bind(a, x)
 
-def igamma_grad_a(a: Array, x: Array) -> Array:
+def igamma_grad_a(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise derivative of the regularized incomplete gamma function."""
   return igamma_grad_a_p.bind(a, x)
 
-def random_gamma_grad(a: Array, x: Array) -> Array:
+def random_gamma_grad(a: ArrayLike, x: ArrayLike) -> Array:
   r"""Elementwise derivative of samples from `Gamma(a, 1)`."""
   return random_gamma_grad_p.bind(a, x)
 
-def bessel_i0e(x: Array) -> Array:
+def bessel_i0e(x: ArrayLike) -> Array:
   r"""Exponentially scaled modified Bessel function of order 0:
   :math:`\mathrm{i0e}(x) = e^{-|x|} \mathrm{i0}(x)`
   """
   return bessel_i0e_p.bind(x)
 
-def bessel_i1e(x: Array) -> Array:
+def bessel_i1e(x: ArrayLike) -> Array:
   r"""Exponentially scaled modified Bessel function of order 1:
   :math:`\mathrm{i1e}(x) = e^{-|x|} \mathrm{i1}(x)`
   """
   return bessel_i1e_p.bind(x)
 
-def erf(x: Array) -> Array:
+def erf(x: ArrayLike) -> Array:
   r"""Elementwise error function: :math:`\mathrm{erf}(x)`."""
   return erf_p.bind(x)
 
-def erfc(x: Array) -> Array:
+def erfc(x: ArrayLike) -> Array:
   r"""Elementwise complementary error function:
     :math:`\mathrm{erfc}(x) = 1 - \mathrm{erf}(x)`."""
   return erfc_p.bind(x)
 
-def erf_inv(x: Array) -> Array:
+def erf_inv(x: ArrayLike) -> Array:
   r"""Elementwise inverse error function: :math:`\mathrm{erf}^{-1}(x)`."""
   return erf_inv_p.bind(x)
 
-def real(x: Array) -> Array:
+def real(x: ArrayLike) -> Array:
   r"""Elementwise extract real part: :math:`\mathrm{Re}(x)`.
 
   Returns the real part of a complex number.
   """
   return real_p.bind(x)
 
-def imag(x: Array) -> Array:
+def imag(x: ArrayLike) -> Array:
   r"""Elementwise extract imaginary part: :math:`\mathrm{Im}(x)`.
 
   Returns the imaginary part of a complex number.
   """
   return imag_p.bind(x)
 
-def complex(x: Array, y: Array) -> Array:
+def complex(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise make complex number: :math:`x + jy`.
 
   Builds a complex number from real and imaginary parts.
   """
   return complex_p.bind(x, y)
 
-def conj(x: Array) -> Array:
+def conj(x: ArrayLike) -> Array:
   r"""Elementwise complex conjugate function: :math:`\overline{x}`."""
   return conj_p.bind(x, input_dtype=_dtype(x))
 
-def abs(x: Array) -> Array:
+def abs(x: ArrayLike) -> Array:
   r"""Elementwise absolute value: :math:`|x|`."""
   return abs_p.bind(x)
 
-def pow(x: Array, y: Array) -> Array:
+def pow(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise power: :math:`x^y`."""
   return pow_p.bind(x, y)
 
-def integer_pow(x: Array, y: int) -> Array:
+def integer_pow(x: ArrayLike, y: int) -> Array:
   r"""Elementwise power: :math:`x^y`, where :math:`y` is a fixed integer."""
   return integer_pow_p.bind(x, y=y)
 
-def sqrt(x: Array) -> Array:
+def sqrt(x: ArrayLike) -> Array:
   r"""Elementwise square root: :math:`\sqrt{x}`."""
   return sqrt_p.bind(x)
 
-def rsqrt(x: Array) -> Array:
+def rsqrt(x: ArrayLike) -> Array:
   r"""Elementwise reciprocal square root:  :math:`1 \over \sqrt{x}`."""
   return rsqrt_p.bind(x)
 
-def cbrt(x: Array) -> Array:
+def cbrt(x: ArrayLike) -> Array:
   r"""Elementwise cube root: :math:`\sqrt[3]{x}`."""
   return cbrt_p.bind(x)
 
-def bitwise_not(x: Array) -> Array:
+def bitwise_not(x: ArrayLike) -> Array:
   r"""Elementwise NOT: :math:`\neg x`."""
   return not_p.bind(x)
 
-def bitwise_and(x: Array, y: Array) -> Array:
+def bitwise_and(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise AND: :math:`x \wedge y`."""
   return and_p.bind(x, y)
 
-def bitwise_or(x: Array, y: Array) -> Array:
+def bitwise_or(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise OR: :math:`x \vee y`."""
   return or_p.bind(x, y)
 
-def bitwise_xor(x: Array, y: Array) -> Array:
+def bitwise_xor(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise exclusive OR: :math:`x \oplus y`."""
   return xor_p.bind(x, y)
 
-def population_count(x: Array) -> Array:
+def population_count(x: ArrayLike) -> Array:
   r"""Elementwise popcount, count the number of set bits in each element."""
   return population_count_p.bind(x)
 
-def clz(x: Array) -> Array:
+def clz(x: ArrayLike) -> Array:
   r"""Elementwise count-leading-zeros."""
   return clz_p.bind(x)
 
-def add(x: Array, y: Array) -> Array:
+def add(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise addition: :math:`x + y`."""
   return add_p.bind(x, y)
 
-def sub(x: Array, y: Array) -> Array:
+def sub(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise subtraction: :math:`x - y`."""
   return sub_p.bind(x, y)
 
-def mul(x: Array, y: Array) -> Array:
+def mul(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise multiplication: :math:`x \times y`."""
   return mul_p.bind(x, y)
 
-def div(x: Array, y: Array) -> Array:
+def div(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise division: :math:`x \over y`.
 
   Integer division overflow
@@ -472,7 +469,7 @@ def div(x: Array, y: Array) -> Array:
   """
   return div_p.bind(x, y)
 
-def rem(x: Array, y: Array) -> Array:
+def rem(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise remainder: :math:`x \bmod y`.
 
   The sign of the result is taken from the dividend,
@@ -485,57 +482,57 @@ def rem(x: Array, y: Array) -> Array:
   """
   return rem_p.bind(x, y)
 
-def max(x: Array, y: Array) -> Array:
+def max(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise maximum: :math:`\mathrm{max}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return max_p.bind(x, y)
 
-def min(x: Array, y: Array) -> Array:
+def min(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise minimum:  :math:`\mathrm{min}(x, y)`
 
   For complex numbers, uses a lexicographic comparison on the
   `(real, imaginary)` pairs."""
   return min_p.bind(x, y)
 
-def shift_left(x: Array, y: Array) -> Array:
+def shift_left(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise left shift: :math:`x \ll y`."""
   return shift_left_p.bind(x, y)
 
-def shift_right_arithmetic(x: Array, y: Array) -> Array:
+def shift_right_arithmetic(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise arithmetic right shift: :math:`x \gg y`."""
   return shift_right_arithmetic_p.bind(x, y)
 
-def shift_right_logical(x: Array, y: Array) -> Array:
+def shift_right_logical(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise logical right shift: :math:`x \gg y`."""
   return shift_right_logical_p.bind(x, y)
 
-def eq(x: Array, y: Array) -> Array:
+def eq(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise equals: :math:`x = y`."""
   return eq_p.bind(x, y)
 
-def ne(x: Array, y: Array) -> Array:
+def ne(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise not-equals: :math:`x \neq y`."""
   return ne_p.bind(x, y)
 
-def ge(x: Array, y: Array) -> Array:
+def ge(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise greater-than-or-equals: :math:`x \geq y`."""
   return ge_p.bind(x, y)
 
-def gt(x: Array, y: Array) -> Array:
+def gt(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise greater-than: :math:`x > y`."""
   return gt_p.bind(x, y)
 
-def le(x: Array, y: Array) -> Array:
+def le(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise less-than-or-equals: :math:`x \leq y`."""
   return le_p.bind(x, y)
 
-def lt(x: Array, y: Array) -> Array:
+def lt(x: ArrayLike, y: ArrayLike) -> Array:
   r"""Elementwise less-than: :math:`x < y`."""
   return lt_p.bind(x, y)
 
-def convert_element_type(operand: Array, new_dtype: DType) -> Array:
+def convert_element_type(operand: ArrayLike, new_dtype: DtypeLike) -> Array:
   """Elementwise cast.
 
   Wraps XLA's `ConvertElementType
@@ -551,10 +548,10 @@ def convert_element_type(operand: Array, new_dtype: DType) -> Array:
     An array with the same shape as `operand`, cast elementwise to `new_dtype`.
   """
   if hasattr(operand, '__jax_array__'):
-    operand = operand.__jax_array__()
+    operand = operand.__jax_array__()  # type: ignore
   return _convert_element_type(operand, new_dtype, weak_type=False)
 
-def _convert_element_type(operand: Array, new_dtype: Optional[DType] = None,
+def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DtypeLike] = None,
                           weak_type: bool = False):
   # Don't canonicalize old_dtype because x64 context might cause
   # un-canonicalized operands to be passed in.
@@ -583,12 +580,12 @@ def _convert_element_type(operand: Array, new_dtype: Optional[DType] = None,
     old_weak_type = False
 
   if (old_dtype, old_weak_type) == (new_dtype, new_weak_type) and _is_array_or_tracer(operand):
-    return operand
+    return type_cast(Array, operand)
   else:
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
                                        weak_type=new_weak_type)
 
-def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
+def bitcast_convert_type(operand: ArrayLike, new_dtype: DtypeLike) -> Array:
   """Elementwise bitcast.
 
   Wraps XLA's `BitcastConvertType
@@ -607,7 +604,7 @@ def bitcast_convert_type(operand: Array, new_dtype: DType) -> Array:
   new_dtype = dtypes.canonicalize_dtype(new_dtype)
   return bitcast_convert_type_p.bind(operand, new_dtype=new_dtype)
 
-def clamp(min: Array, x: Array, max: Array) -> Array:
+def clamp(min: ArrayLike, x: ArrayLike, max: ArrayLike) -> Array:
   r"""Elementwise clamp.
 
   Returns :math:`\mathrm{clamp}(x) = \begin{cases}
@@ -618,7 +615,7 @@ def clamp(min: Array, x: Array, max: Array) -> Array:
   """
   return clamp_p.bind(min, x, max)
 
-def concatenate(operands: Sequence[Array], dimension: int) -> Array:
+def concatenate(operands: Union[Array, Sequence[ArrayLike]], dimension: int) -> Array:
   """Concatenates a sequence of arrays along `dimension`.
 
   Wraps XLA's `Concatenate
@@ -638,7 +635,7 @@ def concatenate(operands: Sequence[Array], dimension: int) -> Array:
   if len(operands) == 1:
     op, = operands
     if _is_array_or_tracer(op):
-      return op
+      return type_cast(Array, op)
   return concatenate_p.bind(*operands, dimension=dimension)
 
 
@@ -696,7 +693,7 @@ PrecisionLike = Union[None, str, PrecisionType, Tuple[str, str],
                       Tuple[PrecisionType, PrecisionType]]
 
 def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
-        preferred_element_type: Optional[DType] = None) -> Array:
+        preferred_element_type: Optional[DtypeLike] = None) -> Array:
   """Vector/vector, matrix/vector, and matrix/matrix multiplication.
 
   Wraps XLA's `Dot
@@ -731,9 +728,9 @@ def dot(lhs: Array, rhs: Array, precision: PrecisionLike = None,
 DotDimensionNumbers = Tuple[Tuple[Sequence[int], Sequence[int]],
                             Tuple[Sequence[int], Sequence[int]]]
 
-def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
+def dot_general(lhs: ArrayLike, rhs: ArrayLike, dimension_numbers: DotDimensionNumbers,
                 precision: PrecisionLike = None,
-                preferred_element_type: Optional[DType] = None) -> Array:
+                preferred_element_type: Optional[DtypeLike] = None) -> Array:
   """More general contraction operator.
 
   Wraps XLA's `DotGeneral
@@ -770,7 +767,7 @@ def dot_general(lhs: Array, rhs: Array, dimension_numbers: DotDimensionNumbers,
                             precision=canonicalize_precision(precision),
                             preferred_element_type=preferred_element_type)
 
-def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
+def broadcast(operand: ArrayLike, sizes: Sequence[int]) -> Array:
   """Broadcasts an array, adding new leading dimensions
 
   Args:
@@ -787,7 +784,7 @@ def broadcast(operand: Array, sizes: Sequence[int]) -> Array:
   dims = tuple(range(len(sizes), len(sizes) + np.ndim(operand)))
   return broadcast_in_dim(operand, tuple(sizes) + np.shape(operand), dims)
 
-def broadcast_in_dim(operand: Array, shape: Shape,
+def broadcast_in_dim(operand: ArrayLike, shape: Shape,
                      broadcast_dimensions: Sequence[int]) -> Array:
   """Wraps XLA's `BroadcastInDim
   <https://www.tensorflow.org/xla/operation_semantics#broadcastindim>`_
@@ -806,7 +803,7 @@ def broadcast_in_dim(operand: Array, shape: Shape,
     jax.lax.broadcast : simpler interface to add new leading dimensions.
   """
   if np.ndim(operand) == len(shape) and not len(broadcast_dimensions) and _is_array_or_tracer(operand):
-    return operand
+    return type_cast(Array, operand)
   if config.jax_dynamic_shapes:
     # We must gate this behavior under a flag because otherwise the errors
     # raised are different (and have worse source provenance information).
@@ -821,7 +818,7 @@ def broadcast_to_rank(x: Array, rank: int) -> Array:
   """Adds leading dimensions of ``1`` to give ``x`` rank ``rank``."""
   return broadcast(x, (1,) * (rank - x.ndim))
 
-def reshape(operand: Array, new_sizes: Shape,
+def reshape(operand: ArrayLike, new_sizes: Shape,
             dimensions: Optional[Sequence[int]] = None) -> Array:
   """Wraps XLA's `Reshape
   <https://www.tensorflow.org/xla/operation_semantics#reshape>`_
@@ -870,7 +867,7 @@ def reshape(operand: Array, new_sizes: Shape,
     dims = api_util._ensure_index_tuple(dimensions)
     same_dims = tuple(dims) == tuple(range(np.ndim(operand)))
   if np.shape(operand) and same_shape and same_dims and _is_array_or_tracer(operand):
-    return operand
+    return type_cast(Array, operand)
   else:
     dyn_shape, static_new_sizes = _extract_tracers_dyn_shape(new_sizes)
 
@@ -878,7 +875,7 @@ def reshape(operand: Array, new_sizes: Shape,
       operand, *dyn_shape, new_sizes=tuple(static_new_sizes),
       dimensions=None if dims is None or same_dims else dims)
 
-def pad(operand: Array, padding_value: Array,
+def pad(operand: ArrayLike, padding_value: ArrayLike,
         padding_config: Sequence[Tuple[int, int, int]]) -> Array:
   """Applies low, high, and/or interior padding to an array.
 
@@ -900,14 +897,14 @@ def pad(operand: Array, padding_value: Array,
   """
   return pad_p.bind(operand, padding_value, padding_config=tuple(padding_config))
 
-def rev(operand: Array, dimensions: Sequence[int]) -> Array:
+def rev(operand: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Wraps XLA's `Rev
   <https://www.tensorflow.org/xla/operation_semantics#rev_reverse>`_
   operator.
   """
   return rev_p.bind(operand, dimensions=tuple(dimensions))
 
-def select(pred: Array, on_true: Array, on_false: Array) -> Array:
+def select(pred: ArrayLike, on_true: ArrayLike, on_false: ArrayLike) -> Array:
   """Wraps XLA's `Select
   <https://www.tensorflow.org/xla/operation_semantics#select>`_
   operator.
@@ -916,7 +913,7 @@ def select(pred: Array, on_true: Array, on_false: Array) -> Array:
   # select(). This is because it implements `select_n`.
   return select_n_p.bind(pred, on_false, on_true)
 
-def select_n(which: Array, *cases: Array) -> Array:
+def select_n(which: ArrayLike, *cases: ArrayLike) -> Array:
   """Selects array values from multiple cases.
 
   Generalizes XLA's `Select
@@ -942,25 +939,27 @@ def select_n(which: Array, *cases: Array) -> Array:
   return select_n_p.bind(which, *cases)
 
 
-def transpose(operand: Array, permutation: Sequence[int]) -> Array:
+def transpose(operand: ArrayLike, permutation: Sequence[int]) -> Array:
   """Wraps XLA's `Transpose
   <https://www.tensorflow.org/xla/operation_semantics#transpose>`_
   operator.
   """
+  from jax.experimental import array
+
   permutation = tuple(operator.index(d) for d in permutation)
   if permutation == tuple(range(np.ndim(operand))) and _is_array_or_tracer(operand):
-    return operand
+    return type_cast(Array, operand)
   else:
     return transpose_p.bind(operand, permutation=permutation)
 
-def argmin(operand: Array, axis: int,
-           index_dtype: DType) -> Tuple[Array, Array]:
+def argmin(operand: ArrayLike, axis: int,
+           index_dtype: DtypeLike) -> Tuple[Array, Array]:
   """Computes the index of the minimum element along ``axis``."""
   return argmin_p.bind(operand, axes=(axis,),
                        index_dtype=dtypes.canonicalize_dtype(index_dtype))
 
-def argmax(operand: Array, axis: int,
-           index_dtype: DType) -> Tuple[Array, Array]:
+def argmax(operand: ArrayLike, axis: int,
+           index_dtype: DtypeLike) -> Tuple[Array, Array]:
   """Computes the index of the maximum element along ``axis``."""
   return argmax_p.bind(operand, axes=(axis,),
                        index_dtype=dtypes.canonicalize_dtype(index_dtype))
@@ -1059,47 +1058,51 @@ def _get_monoid_reducer(monoid_op: Callable,
       return _reduce_min if np.equal(aval.val, _get_min_identity(dtype)) else None
   return None
 
-def _get_bitwise_and_identity(dtype: DType) -> Array:
+def _get_bitwise_and_identity(dtype: DtypeLike) -> np.ndarray:
   return np.array(-1, dtype)
 
-def _get_bitwise_or_identity(dtype: DType) -> Array:
+def _get_bitwise_or_identity(dtype: DtypeLike) -> np.ndarray:
   return np.array(0, dtype)
 
-def _get_max_identity(dtype: DType) -> Array:
+def _get_max_identity(dtype: DtypeLike) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(-np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
     return np.array(dtypes.iinfo(dtype).min, dtype)
   elif dtypes.issubdtype(dtype, np.bool_):
     return np.array(False, np.bool_)
+  else:
+    raise ValueError(f"Unsupported dtype for max: {dtype}")
 
-def _get_min_identity(dtype: DType) -> Array:
+def _get_min_identity(dtype: DtypeLike) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
     return np.array(np.inf, dtype)
   elif dtypes.issubdtype(dtype, np.integer):
     return np.array(dtypes.iinfo(dtype).max, dtype)
   elif dtypes.issubdtype(dtype, np.bool_):
     return np.array(True, np.bool_)
+  else:
+    raise ValueError(f"Unsupported dtype for min: {dtype}")
 
-def _reduce_sum(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_sum(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_sum_p.bind(operand, axes=tuple(axes))
 
-def _reduce_prod(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_prod(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_prod_p.bind(operand, axes=tuple(axes))
 
-def _reduce_max(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_max(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_max_p.bind(operand, axes=tuple(axes))
 
-def _reduce_min(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_min(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_min_p.bind(operand, axes=tuple(axes))
 
-def _reduce_or(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_or(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_or_p.bind(operand, axes=tuple(axes))
 
-def _reduce_and(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_and(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_and_p.bind(operand, axes=tuple(axes))
 
-def _reduce_xor(operand: Array, axes: Sequence[int]) -> Array:
+def _reduce_xor(operand: ArrayLike, axes: Sequence[int]) -> Array:
   return reduce_xor_p.bind(operand, axes=tuple(axes))
 
 def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
@@ -1138,25 +1141,25 @@ def sort(operand: Union[Array, Sequence[Array]], dimension: int = -1,
     dimension = canonicalize_axis(dimension, len(operand.shape))
     return sort_p.bind(operand, dimension=dimension, is_stable=is_stable, num_keys=1)[0]
 
-def sort_key_val(keys: Array, values: Array, dimension: int = -1,
+def sort_key_val(keys: Array, values: ArrayLike, dimension: int = -1,
                  is_stable: bool = True) -> Tuple[Array, Array]:
   """Sorts ``keys`` along ``dimension`` and applies the same permutation to ``values``."""
   dimension = canonicalize_axis(dimension, len(keys.shape))
   k, v = sort_p.bind(keys, values, dimension=dimension, is_stable=is_stable, num_keys=1)
   return k, v
 
-def top_k(operand: Array, k: int) -> Tuple[Array, Array]:
+def top_k(operand: ArrayLike, k: int) -> Tuple[Array, Array]:
   """Returns top ``k`` values and their indices along the last axis of ``operand``."""
   k = int(k)
   if k < 0:
     raise ValueError(f"k argument to top_k must be nonnegative, got {k}")
   return top_k_p.bind(operand, k=k)
 
-def tie_in(x: Array, y: Array) -> Array:
+def tie_in(x: Any, y: T) -> T:
   """Deprecated. Ignores ``x`` and returns ``y``."""
   return y
 
-def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Array:
+def full(shape: Shape, fill_value: ArrayLike, dtype: Optional[DtypeLike] = None) -> Array:
   """Returns an array of `shape` filled with `fill_value`.
 
   Args:
@@ -1174,7 +1177,7 @@ def full(shape: Shape, fill_value: Array, dtype: Optional[DType] = None) -> Arra
   fill_value = _convert_element_type(fill_value, dtype, weak_type)
   return broadcast(fill_value, shape)
 
-def zeros_like_shaped_array(aval: Array) -> Array:
+def zeros_like_shaped_array(aval: ArrayLike) -> Array:
   assert isinstance(aval, ShapedArray)
   if aval.dtype == dtypes.float0:
     scalar_zero = np.zeros((), dtype=aval.dtype)
@@ -1184,14 +1187,14 @@ def zeros_like_shaped_array(aval: Array) -> Array:
 
 ad_util.aval_zeros_likers[ShapedArray] = zeros_like_shaped_array
 
-def iota(dtype: DType, size: int) -> Array:
+def iota(dtype: DtypeLike, size: int) -> Array:
   """Wraps XLA's `Iota
   <https://www.tensorflow.org/xla/operation_semantics#iota>`_
   operator.
   """
   return broadcasted_iota(dtype, (size,), 0)
 
-def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
+def broadcasted_iota(dtype: DtypeLike, shape: Shape, dimension: int) -> Array:
   """Convenience wrapper around ``iota``."""
   dtype = dtypes.canonicalize_dtype(dtype)
   shape = canonicalize_shape(shape)
@@ -1202,7 +1205,7 @@ def broadcasted_iota(dtype: DType, shape: Shape, dimension: int) -> Array:
   return iota_p.bind(*dynamic_shape, dtype=dtype, shape=tuple(static_shape),
                      dimension=dimension)
 
-def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
+def _eye(dtype: DtypeLike, shape: Shape, offset: int) -> Array:
   """Like numpy.eye, create a 2D array with ones on a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1210,7 +1213,7 @@ def _eye(dtype: DType, shape: Shape, offset: int) -> Array:
                 broadcasted_iota(np.int32, shape, 1))
   return convert_element_type_p.bind(bool_eye, new_dtype=dtype, weak_type=False)
 
-def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
+def _delta(dtype: DtypeLike, shape: Shape, axes: Sequence[int]) -> Array:
   """This utility function exists for creating Kronecker delta arrays."""
   axes = map(int, axes)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1222,7 +1225,7 @@ def _delta(dtype: DType, shape: Shape, axes: Sequence[int]) -> Array:
                                        new_dtype=dtype, weak_type=False)
   return broadcast_in_dim(result, shape, axes)
 
-def _tri(dtype: DType, shape: Shape, offset: int) -> Array:
+def _tri(dtype: DtypeLike, shape: Shape, offset: int) -> Array:
   """Like numpy.tri, create a 2D array with ones below a diagonal."""
   offset = int(offset)
   dtype = dtypes.canonicalize_dtype(dtype)
@@ -1261,7 +1264,7 @@ def stop_gradient(x: T) -> T:
       return x
   return tree_map(stop, x)
 
-def reduce_precision(operand: Union[float, Array],
+def reduce_precision(operand: Union[float, ArrayLike],
                      exponent_bits: int,
                      mantissa_bits: int) -> Array:
   """Wraps XLA's `ReducePrecision
@@ -1274,15 +1277,15 @@ def reduce_precision(operand: Union[float, Array],
     operator.index, mantissa_bits, "mantissa_bits argument of lax.reduce_precision")
   return reduce_precision_p.bind(operand, exponent_bits=exponent_bits, mantissa_bits=mantissa_bits)
 
-def squeeze(array: Array, dimensions: Sequence[int]) -> Array:
+def squeeze(array: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Squeeze any number of size 1 dimensions from an array."""
   ndim = np.ndim(array)
   dimensions = tuple(sorted(canonicalize_axis(i, ndim) for i in dimensions))
   if not dimensions and _is_array_or_tracer(array):
-    return array
+    return type_cast(Array, array)
   return squeeze_p.bind(array, dimensions=dimensions)
 
-def expand_dims(array: Array, dimensions: Sequence[int]) -> Array:
+def expand_dims(array: ArrayLike, dimensions: Sequence[int]) -> Array:
   """Insert any number of size 1 dimensions into an array."""
   if len(set(dimensions)) != len(dimensions):
     raise ValueError(f'repeated axis in lax.expand_dims: {dimensions}')
@@ -1300,7 +1303,7 @@ def expand_dims(array: Array, dimensions: Sequence[int]) -> Array:
 
 ### convenience wrappers around traceables
 
-def full_like(x: Array, fill_value: Array, dtype: Optional[DType] = None,
+def full_like(x: Array, fill_value: ArrayLike, dtype: Optional[DtypeLike] = None,
               shape: Optional[Shape] = None) -> Array:
   """Create a full array like np.full based on the example array `x`.
 
@@ -1377,11 +1380,11 @@ def batch_matmul(lhs: Array, rhs: Array,
 # These functions also exist in the XLA client library, but we treat them
 # as non-primitive to maintain a smaller set of autodiff primitives.
 
-def square(x: Array) -> Array:
+def square(x: ArrayLike) -> Array:
   r"""Elementwise square: :math:`x^2`."""
   return integer_pow(x, 2)
 
-def reciprocal(x: Array) -> Array:
+def reciprocal(x: ArrayLike) -> Array:
   r"""Elementwise reciprocal: :math:`1 \over x`."""
   return integer_pow(x, -1)
 
@@ -1396,39 +1399,39 @@ def _upcast_fp16_for_computation(f):
 
   return f_wrapped
 
-def tan(x: Array) -> Array:
+def tan(x: ArrayLike) -> Array:
   r"""Elementwise tangent: :math:`\mathrm{tan}(x)`."""
   return tan_p.bind(x)
 
-def asin(x: Array) -> Array:
+def asin(x: ArrayLike) -> Array:
   r"""Elementwise arc sine: :math:`\mathrm{asin}(x)`."""
   return asin_p.bind(x)
 
-def acos(x: Array) -> Array:
+def acos(x: ArrayLike) -> Array:
   r"""Elementwise arc cosine: :math:`\mathrm{acos}(x)`."""
   return acos_p.bind(x)
 
-def atan(x: Array) -> Array:
+def atan(x: ArrayLike) -> Array:
   r"""Elementwise arc tangent: :math:`\mathrm{atan}(x)`."""
   return atan_p.bind(x)
 
-def sinh(x: Array) -> Array:
+def sinh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic sine: :math:`\mathrm{sinh}(x)`."""
   return sinh_p.bind(x)
 
-def cosh(x: Array) -> Array:
+def cosh(x: ArrayLike) -> Array:
   r"""Elementwise hyperbolic cosine: :math:`\mathrm{cosh}(x)`."""
   return cosh_p.bind(x)
 
-def asinh(x: Array) -> Array:
+def asinh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic sine: :math:`\mathrm{asinh}(x)`."""
   return asinh_p.bind(x)
 
-def acosh(x: Array) -> Array:
+def acosh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic cosine: :math:`\mathrm{acosh}(x)`."""
   return acosh_p.bind(x)
 
-def atanh(x: Array) -> Array:
+def atanh(x: ArrayLike) -> Array:
   r"""Elementwise inverse hyperbolic tangent: :math:`\mathrm{atanh}(x)`."""
   return atanh_p.bind(x)
 
@@ -1451,7 +1454,7 @@ ShapedArray._iter = staticmethod(_iter)
 
 # Add some ad handlers that use (or could use) lax primitives
 
-def zeros_like_array(x: Array) -> Array:
+def zeros_like_array(x: ArrayLike) -> Array:
   return full_like(x, 0)
 
 for t in itertools.chain(
@@ -2463,7 +2466,7 @@ def _masked(padded_value, logical_shape, dimensions, value=0):
 
 
 def _dot_general_shape_rule(lhs, rhs, *, dimension_numbers, precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   (lhs_contracting, rhs_contracting), (lhs_batch, rhs_batch) = dimension_numbers
   if not all(np.all(np.greater_equal(d, 0)) and np.all(np.less(d, lhs.ndim))
              for d in (lhs_contracting, lhs_batch)):
@@ -2539,7 +2542,7 @@ def tuple_delete(tup, idx):
 
 
 def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   input_dtype = naryop_dtype_rule(_input_dtype, [_any, _any], 'dot_general', lhs, rhs)
   if preferred_element_type is None:
     return input_dtype
@@ -2547,7 +2550,7 @@ def _dot_general_dtype_rule(lhs, rhs, *, dimension_numbers, precision,
   return preferred_element_type
 
 def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
-                               preferred_element_type: Optional[DType],
+                               preferred_element_type: Optional[DtypeLike],
                                swap_ans=False):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   x_ndim = g.ndim - y.ndim + len(x_batch) + 2 * len(x_contract)
@@ -2564,7 +2567,7 @@ def _dot_general_transpose_lhs(g, y, *, dimension_numbers, precision,
                    tuple(out_axes))
 
 def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision,
-                               preferred_element_type: Optional[DType]):
+                               preferred_element_type: Optional[DtypeLike]):
   (x_contract, y_contract), (x_batch, y_batch) = dimension_numbers
   swapped_dimension_numbers = ((y_contract, x_contract), (y_batch, x_batch))
   return _dot_general_transpose_lhs(
@@ -2575,7 +2578,7 @@ def _dot_general_transpose_rhs(g, x, *, dimension_numbers, precision,
 
 def _dot_general_batch_rule(batched_args, batch_dims, *, dimension_numbers,
                             precision,
-                            preferred_element_type: Optional[DType]):
+                            preferred_element_type: Optional[DtypeLike]):
   lhs, rhs = batched_args
   new_dimension_numbers, result_batch_dim = _dot_general_batch_dim_nums(
       (lhs.ndim, rhs.ndim), batch_dims, dimension_numbers)
@@ -4646,7 +4649,7 @@ _two: Callable = partial(full_like, shape=(), fill_value=2)
 dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 _dtype: Callable = partial(dtypes.dtype, canonicalize=True)
 
-def _isnan(x) -> bool:
+def _isnan(x: ArrayLike) -> Array:
   return ne(x, x)
 
 def _iscomplex(x) -> bool:

--- a/jax/_src/typing.py
+++ b/jax/_src/typing.py
@@ -1,0 +1,63 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+`jax._src.typing`: JAX type annotations
+---------------------------------------
+
+This submodule is a work in progress; when we finalize the contents here, it will be
+exported at `jax.typing`. Until then, the contents here should be considered unstable
+and may change without notice.
+
+To see the proposal that led to the development of these tools, see
+https://github.com/google/jax/pull/11859/.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, Union
+from typing_extensions import Protocol
+import numpy as np
+
+class HasDtypeAttribute(Protocol):
+  dtype: Dtype
+
+Dtype = np.dtype
+
+# Any is here to allow scalar types like np.int32.
+# TODO(jakevdp) figure out how to specify these more strictly.
+DtypeLike = Union[Any, str, np.dtype, HasDtypeAttribute]
+
+# Shapes are tuples of dimension sizes, which are normally integers. We allow
+# modules to extend the set of dimension sizes to contain other types, e.g.,
+# symbolic dimensions in jax2tf.shape_poly.DimVar and masking.Poly.
+DimSize = Union[int, Any]  # extensible
+Shape = Sequence[DimSize]
+
+# Array is a type annotation for standard JAX arrays and tracers produced by
+# core functions in jax.lax and jax.numpy; it is not meant to include
+# future non-standard array types like KeyArray and BInt.
+# For now we set it to Any; in the future this will be more restrictive
+# (see https://github.com/google/jax/pull/11859)
+# TODO(jakevdp): make this conform to the JEP 12049 plan.
+Array = Any
+
+# ArrayLike is a Union of all objects that can be implicitly converted to a standard
+# JAX array (i.e. not including future non-standard array types like KeyArray and BInt).
+ArrayLike = Union[
+  Array,  # JAX array type
+  np.ndarray,  # NumPy array type
+  np.bool_, np.number,  # NumPy scalar types
+  bool, int, float, complex,  # Python scalar types
+]

--- a/jax/core.py
+++ b/jax/core.py
@@ -49,6 +49,7 @@ import jax._src.pretty_printer as pp
 from jax._src import lib
 from jax._src.lib import jax_jit
 from jax._src import traceback_util
+from jax._src.typing import DimSize, Shape
 traceback_util.register_exclusion(__file__)
 
 zip, unsafe_zip = safe_zip, zip
@@ -1599,13 +1600,6 @@ raise_to_shaped_mappings : Dict[type, Callable] = {
 }
 
 ### Operations on shapes and dimension sizes.
-
-# Shapes are tuples of dimension sizes, which are normally integers. We allow
-# modules to extend the set of dimension sizes to contain other types, e.g.,
-# symbolic dimensions in jax2tf.shape_poly.DimVar and masking.Poly.
-DimSize = Union[int, Any]  # extensible
-Shape = Sequence[DimSize]
-
 
 class InconclusiveDimensionOperation(Exception):
   """Raised when we cannot conclusively compute with symbolic dimensions."""

--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -42,14 +42,13 @@ import jax
 from jax._src.numpy import lax_numpy
 from jax._src import dtypes
 from jax._src.lax import lax
+from jax._src.typing import DimSize, Shape
 import opt_einsum
 from jax import config
 from jax import core
 
 import numpy as np
 
-DimSize = core.DimSize
-Shape = core.Shape
 TfVal = Any
 # A dimension environment maps dimension variables to expressions that
 # compute the value of the dimension. These expressions refer to the


### PR DESCRIPTION
Part of #12049; this implements some of the simpler types discussed in #11859

The question of what to do with `Array` is yet to be resolved, but this PR creates the skeleton into which we can insert the eventual solution.

For now, I'm keeping these as private APIs, in `jax._src.typing`. Once we're certain we're happy with them, we can plan to export them in `jax.typing`.