### PR TITLE
[dynamic-shapes] add basic vmap-of-indexing support

### DIFF
--- a/jax/_src/iree.py
+++ b/jax/_src/iree.py
@@ -110,6 +110,9 @@ class IreeBuffer(xla_client.DeviceArrayBase):
   def _value(self):
     return np.asarray(self)
 
+  def copy_to_host_async(self):
+    return self
+
 class IreeExecutable:
 
   def __init__(self, client, devices, module_object, function_name):

--- a/jax/core.py
+++ b/jax/core.py
@@ -1692,7 +1692,6 @@ _SPECIAL_DIMENSION_HANDLERS: Dict[type, DimensionHandler] = {}
 def _get_special_dim_handler(dim: DimSize) -> Optional[DimensionHandler]:
   if isinstance(dim, Tracer) and not config.jax_dynamic_shapes:
     return None
-  # TODO: look up DynamicJaxprTracer
   return _SPECIAL_DIMENSION_HANDLERS.get(type(dim))
 
 def _dim_handler_and_canonical(*dlist: DimSize) -> Tuple[DimensionHandler, Tuple[DimSize, ...]]:
@@ -1801,7 +1800,9 @@ def dimension_as_value(d: DimSize):
   return handler.as_value(*ds)
 
 def _canonicalize_dimension(dim: DimSize) -> DimSize:
-  if is_special_dim_size(dim):
+  if isinstance(dim, Tracer) and config.jax_dynamic_shapes:
+    return dim
+  elif is_special_dim_size(dim):
     return dim
   else:
     return operator.index(dim)


### PR DESCRIPTION
The main changes here are only indirectly related to gather: we just had to update some other rules (e.g. for comparison, and squeeze) for a simple dynamic-batch-shape gather to work.

I also skipped two tests and deleted some old dynamic shape slicing logic because we want to handle that differently. We didn't have to do that removal in this PR, but it's just convenient given I'm looking at indexing again.