### PR TITLE
lax.broadcast_shapes: clearer error for incompatible shapes

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -149,8 +149,7 @@ def _broadcast_shapes_uncached(*shapes):
   shape_list = [(1,) * (ndim - len(shape)) + shape for shape in shapes]
   result_shape = _try_broadcast_shapes(shape_list)
   if result_shape is None:
-    raise ValueError("Incompatible shapes for broadcasting: {}"
-                     .format(tuple(shape_list)))
+    raise ValueError(f"Incompatible shapes for broadcasting: shapes={list(shapes)}")
   return result_shape
 
 def _broadcast_ranks(s1, s2):


### PR DESCRIPTION
Fixes #12305

Before:
```python
>>> lax.broadcast_shapes((2, 4), (2,))
...
ValueError: Incompatible shapes for broadcasting: ((2, 4), (1, 2))
```
After:
```python
>>> lax.broadcast_shapes((2, 4), (2,))
...
ValueError: Incompatible shapes for broadcasting: shapes=[(2, 4), (2,)]
```