### PR TITLE
jax.lax: ensure GatherDimensionNumbers contains tuples for hashability

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2287,9 +2287,8 @@ class LaxTest(jtu.JaxTestCase):
           [(3, 4, 5), (np.array([0, 2, 1]),), (0,)],
           [(3, 4, 5), (np.array([-1, -2]),), (0,)],
           [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 1)],
-          [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), (0, 2)],
+          [(3, 4, 5), (np.array([0, 2]), np.array([1, 3])), [0, 2]],
       ]))
-  @jax.numpy_rank_promotion('allow')  # Test explicitly exercises implicit rank promotion.
   def testIndexTake(self, shape, dtype, idxs, axes):
     rng = jtu.rand_default(self.rng())
     rand_idxs = lambda: tuple(rng(e.shape, e.dtype) for e in idxs)


### PR DESCRIPTION
Fixes #12321

As part of this, I also make `lax.index_take` compatible with `jax_rank_promotion='raise'`