### PR TITLE
ensure_index: raise better error for traced inputs

### DIFF
--- a/jax/_src/api_util.py
+++ b/jax/_src/api_util.py
@@ -37,6 +37,7 @@ map = safe_map
 
 def _ensure_index(x: Any) -> Union[int, Tuple[int, ...]]:
   """Ensure x is either an index or a tuple of indices."""
+  x = core.concrete_or_error(None, x, "expected a static index or sequence of indices.")
   try:
     return operator.index(x)
   except TypeError:
@@ -44,6 +45,7 @@ def _ensure_index(x: Any) -> Union[int, Tuple[int, ...]]:
 
 def _ensure_index_tuple(x: Any) -> Tuple[int, ...]:
   """Convert x to a tuple of indices."""
+  x = core.concrete_or_error(None, x, "expected a static index or sequence of indices.")
   try:
     return (operator.index(x),)
   except TypeError:


### PR DESCRIPTION
Fixes #12331

Quick test:
```python
import jax

def f(x):
  return jax.numpy.squeeze(x, jax.numpy.array(1))

jax.jit(f)(jax.numpy.arange(5))
```
Previous error:
```
TypeError: iteration over a 0-d array
```
Error after this PR:
```
jax._src.errors.ConcretizationTypeError: Abstract tracer value encountered where concrete value is expected: Traced<ShapedArray(int32[], weak_type=True)>with<DynamicJaxprTrace(level=0/1)>
expected a static index or sequence of indices.
The error occurred while tracing the function f at tmp.py:3 for jit. 
```