### PR TITLE
jax.Array: add issubclass test corresponding to existing DeviceArray test

### DIFF
--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -516,6 +516,11 @@ class ShardingTest(jtu.JaxTestCase):
         "valid for values of rank at least 4, but was applied to a value of rank 2"):
       new_mps.is_compatible_aval(shape)
 
+  def test_is_subclass(self):
+    # array version of api_test.py::APITest::test_is_subclass
+    self.assertTrue(issubclass(array.Array, jnp.ndarray))
+    self.assertFalse(issubclass(array.Array, np.ndarray))
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
This is the analog of the test for other Array types here: https://github.com/google/jax/blob/fa760bf1b9c4460e13f93499f0851bdd7839c6dc/tests/api_test.py#L1426-L1435