### PR TITLE
tests: fix is_valid_shape() function

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -335,6 +335,7 @@ PYTHON_SCALAR_SHAPE = _PythonScalar()
 def is_valid_shape(shape, dtype):
   if shape == PYTHON_SCALAR_SHAPE:
     return dtype == np.dtype(type(np.array(0, dtype=dtype).item()))
+  return True
 
 
 def _dims_of_shape(shape):


### PR DESCRIPTION
This re-enables a number of reduction tests that were disabled by an inadvertent omission in #11006.