### PR TITLE
Removed repeated `nan_to_num` function name in docs

### DIFF
--- a/docs/jax.numpy.rst
+++ b/docs/jax.numpy.rst
@@ -285,7 +285,6 @@ namespace; they are listed below.
     nanquantile
     nanstd
     nansum
-    nan_to_num
     nanvar
     ndarray
     ndim


### PR DESCRIPTION
Close #12406 
The function's name appeared twice in the docs but referenced the same link and function
[jax.numpy.nan_to_num](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.nan_to_num.html#jax.numpy.nan_to_num)