### PR TITLE
Ignore protobuf's DeprecationWarning during test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,7 @@ filterwarnings =
     # numpy uses distutils which is deprecated
     ignore:The distutils.* is deprecated.*:DeprecationWarning
     ignore:`sharded_jit` is deprecated. Please use `pjit` instead.*:DeprecationWarning
+    # protobuf
+    ignore:Call to deprecated create function .*Descriptor:DeprecationWarning
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"


### PR DESCRIPTION
During import of tensorflow (via jax2tf), a bunch of DeprecationWarnings
from google.protobuf (<4.0, e.g. 3.19.x) would be raised:

    DeprecationWarning: Call to deprecated create function FileDescriptor().
    DeprecationWarning: Call to deprecated create function FieldDescriptor().

Pytest should not fail due to this DeprecationWarning, so we can
explicitly ignore such protobuf-related warnings.
