### PR TITLE
Fill in jax.distributed.initialize() arguments from environment variables

### DIFF
--- a/docs/multi_process.md
+++ b/docs/multi_process.md
@@ -61,10 +61,14 @@ The API {func}`jax.distributed.initialize` takes several arguments, namely:
   * `coordinator_address`: the IP address of process 0 in your cluster, together
     with a port available on that process. Process 0 will start a JAX service
     exposed via that IP address and port, to which the other processes in the
-    cluster will connect.
-  * `num_processes`: the number of processes in the cluster
+    cluster will connect. You can set its default value by setting the
+    `JAX_COORDINATOR_ADDRESS` environment variable, in which case
+    you can pass in `None` for it.
+  * `num_processes`: the number of processes in the cluster. You can set its
+    default value by setting the `JAX_NUM_PROCESSES` environment variable.
   * `process_id`: the ID number of this process, in the range `[0 ..
-  num_processes)`.
+    num_processes)`. You can set its default value by setting the `JAX_PROCESS_ID`
+    environment variable.
 
 For example on GPU, a typical usage is:
 
@@ -76,15 +80,21 @@ jax.distributed.initialize(coordinator_address="192.168.0.1:1234",
                            process_id=0)
 ```
 
-On Cloud TPU, you can simply call {func}`jax.distributed.initialize()` with no
-arguments. Default values for the arguments will be chosen automatically using
-the TPU pod metadata:
+On Cloud TPU, or if you have set all three of the `JAX_COORDINATOR_ADDRESS`,
+`JAX_NUM_PROCESSES`, and `JAX_PROCESS_ID` environment variables, you can simply
+call {func}`jax.distributed.initialize()` with no arguments. On TPU, default
+values for the arguments will be chosen automatically using the TPU pod
+metadata:
 
 ```python
 import jax
 
 jax.distributed.initialize()
 ```
+
+If you call {func}`jax.distributed.initialize()` with some or all arguments
+omitted and the remaining arguments cannot be filled in from the environment
+or the Cloud TPU metadata, it will raise {class}`ValueError`.
 
 On TPU at present calling {func}`jax.distributed.initialize` is optional, but
 recommanded since it enables additional checkpointing and health checking features.

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -114,6 +114,40 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
       self.assertEqual(proc.returncode, 0)
       self.assertEqual(out, f'{num_gpus_per_task},{num_gpus}')
 
+  def test_gpu_distributed_initialize_from_environment(self):
+    if jax.devices()[0].platform != 'gpu':
+      raise unittest.SkipTest('Tests only for GPU.')
+
+    port = portpicker.pick_unused_port()
+    num_gpus = 2
+    num_gpus_per_task = 1
+    num_tasks = num_gpus // num_gpus_per_task
+
+    os.environ["JAX_COORDINATOR_ADDRESS"] = "localhost:" + str(port)
+    os.environ["JAX_NUM_PROCESSES"] = str(num_tasks)
+
+    subprocesses = []
+    for task in range(num_tasks):
+      env = os.environ.copy()
+      env["JAX_PROCESS_ID"] = str(task)
+      env["CUDA_VISIBLE_DEVICES"] = ",".join(
+          str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))
+      args = [
+          sys.executable,
+          "-c",
+          ('import jax, os; '
+           'jax.distributed.initialize(); '
+           'print(f\'{jax.local_device_count()},{jax.device_count()}\', end="")'
+          )
+      ]
+      subprocesses.append(subprocess.Popen(args, env=env, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, universal_newlines=True))
+
+    for proc in subprocesses:
+      out, _ = proc.communicate()
+      self.assertEqual(proc.returncode, 0)
+      self.assertEqual(out, f'{num_gpus_per_task},{num_gpus}')
+
   @unittest.skipIf(xla_extension_version < 91,
                    "Test requires jaxlib 0.3.17 or newer")
   def test_distributed_jax_cuda_visible_devices(self):


### PR DESCRIPTION
This PR changes `jax.distributed.initialize()` to, if passed `None` arguments, fill them in from environment variables. The three environment variables are `JAX_COORDINATOR_ADDRESS` (this one was already there but undocumented and I followed its example), `JAX_NUM_PROCESSES`, and `JAX_PROCESS_ID`. This will allow us to, on GPU clusters, fill in the environment variables using some cluster specific script (I have one I am using for SLURM), and then just call `jax.distributed.initialize()` without arguments in our actual code like on TPUs, without having to worry, in our main Python script, what sort of distributed environment we are running in or how to get the arguments we need.

For instance, I have the following cluster specific `jax_env.sh`:

```sh
#!/bin/sh

echo export JAX_COORDINATOR_ADDRESS="$SLURM_LAUNCH_NODE_IPADDR":29400
echo export JAX_NUM_PROCESSES="$SLURM_NPROCS"
echo export JAX_PROCESS_ID="$SLURM_PROCID"
```

and then I can use `srun --task-prolog /path/to/jax_env.sh ./my_actual_jax_script.py` to set the environment up.

Also, I have documented the behavior where `jax.distributed.initialize()` raises `ValueError` if not all of its arguments can be filled in from Cloud TPU metadata and now the environment, we can detect if we're running in a properly set up distributed environment using this behavior.

