### PR TITLE
Fix mlir capi dll is missing chlo and stablehlo symbols

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,7 +96,7 @@ build:windows --linkopt=/OPT:REF
 build:windows --host_linkopt=/OPT:REF
 build:windows --linkopt=/OPT:ICF
 build:windows --host_linkopt=/OPT:ICF
-build:windows --experimental_strict_action_env=true
+build:windows --incompatible_strict_action_env=true
 
 build:linux --config=posix
 build:linux --copt=-Wno-unknown-warning-option

--- a/jaxlib/jax.bzl
+++ b/jaxlib/jax.bzl
@@ -53,7 +53,7 @@ def py_library_providing_imports_info(*, name, lib_rule = native.py_library, **k
 def py_extension(name, srcs, copts, deps):
     pybind_extension(name, srcs = srcs, copts = copts, deps = deps, module_name = name)
 
-def windows_cc_shared_mlir_library(name, out, deps = [], srcs = []):
+def windows_cc_shared_mlir_library(name, out, deps = [], srcs = [], exported_symbol_prefixes = []):
     """Workaround DLL building issue.
 
     1. cc_binary with linkshared enabled cannot produce DLL with symbol
@@ -87,6 +87,10 @@ def windows_cc_shared_mlir_library(name, out, deps = [], srcs = []):
         target_compatible_with = ["@platforms//os:windows"],
     )
 
+    # say filtered_symbol_prefixes == ["mlir", "chlo"], then construct the regex
+    # pattern as "^\\s*(mlir|clho)" to use grep
+    pattern = "^\\s*(" + "|".join(exported_symbol_prefixes) + ")"
+
     # filtered def_file, only the needed symbols are included
     filtered_def_name = name + ".filtered.def"
     filtered_def_file = out + ".def"
@@ -94,7 +98,7 @@ def windows_cc_shared_mlir_library(name, out, deps = [], srcs = []):
         name = filtered_def_name,
         srcs = [full_def_name],
         outs = [filtered_def_file],
-        cmd = """echo 'LIBRARY {}\nEXPORTS ' > $@ && grep '^\\W*mlir' $(location :{}) >> $@""".format(out, full_def_name),
+        cmd = """echo 'LIBRARY {}\nEXPORTS ' > $@ && grep -E '{}' $(location :{}) >> $@""".format(out, pattern, full_def_name),
         target_compatible_with = ["@platforms//os:windows"],
     )
 

--- a/jaxlib/mlir/_mlir_libs/BUILD.bazel
+++ b/jaxlib/mlir/_mlir_libs/BUILD.bazel
@@ -203,5 +203,10 @@ cc_binary(
 windows_cc_shared_mlir_library(
     name = "jaxlib_mlir_capi_dll",
     out = "jaxlib_mlir_capi.dll",
+    exported_symbol_prefixes = [
+        "mlir",
+        "chlo",
+        "stablehlo",
+    ],
     deps = [":jaxlib_mlir_capi_objects"],
 )


### PR DESCRIPTION
In the past, only `mlir*` symbols are needed, but now, `chlo*` and `stablehlo*` are also needed now. Otherwise, there will be linker errors for targets `_chlo` and `_stablehlo` defined  [here](https://github.com/google/jax/blob/6183727acc64b0a35fc3d5842fa05cb9dee47346/jaxlib/mlir/_mlir_libs/BUILD.bazel).