### PR TITLE
Add jet rules for `scatter_mul` and `copy`, and fix typos in `scatter*` docstrings.

### DIFF
--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -395,7 +395,7 @@ def scatter_mul(
       implementation-defined.
 
   Returns:
-    An array containing the sum of `operand` and the scattered updates.
+    An array containing the product of `operand` and the scattered updates.
   """
   jaxpr, consts = lax._reduction_jaxpr(lax.mul,
                                        lax._abstractify(lax._const(operand, 1)))
@@ -441,7 +441,7 @@ def scatter_min(
       implementation-defined.
 
   Returns:
-    An array containing the sum of `operand` and the scattered updates.
+    An array containing the min of `operand` and the scattered updates.
   """
   jaxpr, consts = lax._reduction_jaxpr(lax.min,
                                        lax._abstractify(lax._const(operand, 0)))
@@ -487,7 +487,7 @@ def scatter_max(
       implementation-defined.
 
   Returns:
-    An array containing the sum of `operand` and the scattered updates.
+    An array containing the max of `operand` and the scattered updates.
   """
   jaxpr, consts = lax._reduction_jaxpr(lax.max,
                                        lax._abstractify(lax._const(operand, 0)))
@@ -600,7 +600,7 @@ def scatter(
       implementation-defined.
 
   Returns:
-    An array containing the sum of `operand` and the scattered updates.
+    An array containing the replacement of `operand` with the scattered updates.
   """
   jaxpr, consts = lax._reduction_jaxpr(_scatter_reduction_computation,
                                        lax._abstractify(lax._const(operand, 0)))

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -312,6 +312,8 @@ class JetTest(jtu.JaxTestCase):
   def test_cummin(self):     self.unary_check(partial(lax.cummin, axis=0))
   @jtu.skip_on_devices("tpu")
   def test_dynamic_slice(self):     self.unary_check(partial(lax.dynamic_slice, start_indices=(0,0), slice_sizes=(1,1)))
+  @jtu.skip_on_devices("tpu")
+  def test_copy(self):       self.unary_check(jnp.copy)
 
 
   @jtu.skip_on_devices("tpu")
@@ -415,15 +417,21 @@ class JetTest(jtu.JaxTestCase):
       from jax import jacfwd, grad
 
       x = jnp.array([1., 1.])
-      μ = eps * x
+      mu = eps * x
 
       def F(t):
-        return f(x + t * μ)
+        return f(x + t * mu)
 
       return grad(jacfwd(F))(0.)
 
     self.check_jet(h, (0.,), ([1., 2., 3.],), rtol=1e-3)
 
+
+  @jtu.skip_on_devices("tpu")
+  def test_scatter_mul(self):
+    def f(z):
+      return z.at[0].multiply(-1.)
+    self.unary_check(f)
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
Add jet rules and tests for `scatter_mul` and `copy`, and fix typos in `scatter*` docstrings.

The jet rule for `scatter_mul` takes inspiration from its `jvp` rule.