### PR TITLE
[c++ jit] only set use_fastpath in cache_miss if all args are DeviceArrays

### DIFF
--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -537,6 +537,8 @@ def _device_array_use_fast_path(execute, out_pytree_def, args_flat, out_flat):
       not execute.args[5] and not execute.args[6] and
       # Has no host callbacks
       not execute.args[8] and
+      # impl rule must have been called, i.e. top trace is an EvalTrace
+      isinstance(core.find_top_trace(args_flat), core.EvalTrace) and
       # Not supported: ShardedDeviceArray
       all(device_array.type_is_device_array(x) for x in out_flat) and
       # Not supported: dynamic shapes


### PR DESCRIPTION
fixes #12542

The fundamental issue was that in the `jit` `cache_miss` logic the `use_fastpath` boolean could be true even if the `xla_call` impl rule was not called. But the `most_recent_entry` logic, guarded by `if use_fastpath`, assumes the impl rule was just called.

For example, as per Peter's repro in #12542, we might not call the `xla_call` impl rule because we're staging out an inner jit, with an outer `jit`'s `Tracer` present in the input arguments. But because `use_fastpath` didn't check whether the input arguments were `Tracer`s, we might set `use_fastpath=True` and then evaluate the code under `if use_fastpath` _even though_ in that case the C++ dispatch code could never get a hit given `Tracer` inputs. The test `test_fastpath_cache_confusion` basically copied over this repro case.

We actually we can't just adapt `use_fastpath` to check for `Tracer` inputs, because we might be staging out an inner jitted nullary function! (Thanks, omnistaging!) The test `test_fastpath_cache_confusion2` covers this case. We just need to directly check that the `impl` rule must have been run for this particular jitted function application. We can do that by checking that `core.find_top_trace` returns an `EvalTrace` (because `find_top_trace` checks both argument `Tracer`s and the global dynamic trace to know what interpreter to dispatch to, and `EvalTrace` is exactly the interpreter which calls impl rules).

We could revise this logic not to depend on the impl rule having just been called, i.e. not to use a `most_recent_entry` mechanism. Instead we could probably form the correct cache key and just check for it in the cache. But before attempting such revisions I wanted to send this fix first because IIUC it's a bad breakage at HEAD.

I added Peter as a coauthor because he wrote the test, and Kuangyuan as a coauthor because we actually spotted the issue and potential fix together in our 1:1 on Monday (but then didn't know for sure it was the issue until Peter's repro).

Co-authored-by: Peter Hawkins <phawkins@google.com>
Co-authored-by: Kuangyuan Chen <chky@google.com>