### PR TITLE
[ROCM] Add TENSORFLOW_ROCM_COMMIT parameter to ROCM ci build

### DIFF
--- a/build/rocm/build_rocm.sh
+++ b/build/rocm/build_rocm.sh
@@ -19,6 +19,15 @@ ROCM_TF_FORK_REPO="https://github.com/ROCmSoftwarePlatform/tensorflow-upstream"
 ROCM_TF_FORK_BRANCH="develop-upstream"
 rm -rf /tmp/tensorflow-upstream || true
 git clone -b ${ROCM_TF_FORK_BRANCH} ${ROCM_TF_FORK_REPO} /tmp/tensorflow-upstream
+if [ ! -v TENSORFLOW_ROCM_COMMIT ]; then
+    echo "The TENSORFLOW_ROCM_COMMIT environment variable is not set, using top of branch"
+elif [ ! -z "$TENSORFLOW_ROCM_COMMIT" ]
+then
+      echo "Using tensorflow-rocm at commit: $TENSORFLOW_ROCM_COMMIT"
+      cd /tmp/tensorflow-upstream
+      git checkout $TENSORFLOW_ROCM_COMMIT
+      cd -
+fi
 
 python3 ./build/build.py --enable_rocm --rocm_path=${ROCM_PATH} --bazel_options=--override_repository=org_tensorflow=/tmp/tensorflow-upstream
 pip3 install --use-feature=2020-resolver --force-reinstall dist/*.whl  # installs jaxlib (includes XLA)

--- a/build/rocm/ci_build.sh
+++ b/build/rocm/ci_build.sh
@@ -105,6 +105,7 @@ echo "Running '${POSITIONAL_ARGS[*]}' inside ${DOCKER_IMG_NAME}..."
 docker run ${KEEP_IMAGE} --name ${DOCKER_IMG_NAME} --pid=host \
   -v ${WORKSPACE}:/workspace \
   -w /workspace \
+  -e TENSORFLOW_ROCM_COMMIT=${TENSORFLOW_ROCM_COMMIT} \
   ${ROCM_EXTRA_PARAMS} \
   "${DOCKER_IMG_NAME}" \
   ${POSITIONAL_ARGS[@]}


### PR DESCRIPTION
For ROCM builds in CI we override the org_tensorflow repo with a local checkout of tensorflow-rocm. This works well enough when building nightly.

We'd like to start adding a "release" job, to make the rocm build of jaxlib readily available and currently there is no way in the CI scripts to control the tensorflow-rocm commit to the JAX tag we happen to be building.

This commit adds an environment variable TENSORFLOW_ROCM_COMMIT to the rocm ci scripts. We'll use this in our jenkins jobs for building releases.