### PR TITLE
Make persistent compilation cache warn instead of raise an error on cache read/write failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
 ## jax 0.3.21
+* Changes
+  * The persistent compilation cache will now warn instead of raising an
+    exception on error ({jax-issue}`#12582`), so program execution can continue
+    if something goes wrong with the cache. Set
+    `JAX_RAISE_PERSISTENT_CACHE_ERRORS=true` to revert this behavior.
 
 ## jaxlib 0.3.21
 

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -699,6 +699,16 @@ enable_custom_vjp_by_custom_transpose = config.define_bool_state(
     help=('Enables an internal upgrade that implements `jax.custom_vjp` by '
           'reduction to `jax.custom_jvp` and `jax.custom_transpose`.'))
 
+raise_persistent_cache_errors = config.define_bool_state(
+    name='jax_raise_persistent_cache_errors',
+    default=False,
+    help=('If true, exceptions raised when reading or writing to the '
+          'persistent compilation cache will be allowed through, halting '
+          'program execution if not manually caught. If false, exceptions are '
+          'caught and raised as warnings, allowing program execution to '
+          'continue. Defaults to false so cache bugs or intermittent issues '
+          'are non-fatal.'))
+
 hlo_source_file_canonicalization_regex = config.define_string_state(
     name='jax_hlo_source_file_canonicalization_regex',
     default=None,

--- a/tests/compilation_cache_test.py
+++ b/tests/compilation_cache_test.py
@@ -19,7 +19,8 @@ import random
 import sys
 import tempfile
 import unittest
-from unittest import SkipTest
+from unittest import mock, SkipTest
+import warnings
 
 from absl.testing import absltest
 from jax.experimental import PartitionSpec as P
@@ -35,9 +36,12 @@ from jax._src.lib import xla_client
 import numpy as np
 
 from jax.config import config
+from jax._src.config import raise_persistent_cache_errors
+
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
+@jtu.with_config(jax_raise_persistent_cache_errors=True)
 class CompilationCacheTest(jtu.JaxTestCase):
 
   def setUp(self):
@@ -294,6 +298,38 @@ class CompilationCacheTest(jtu.JaxTestCase):
          axis_resources={'a': 'x'})(x)
       files_in_directory = len(os.listdir(tmpdir))
       self.assertEqual(files_in_directory, 2)
+
+  def test_cache_write_warning(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      cc.initialize_cache(tmpdir)
+      f = jit(lambda x: x*x)
+
+      with raise_persistent_cache_errors(False), \
+           mock.patch.object(cc._cache.__class__, 'put') as mock_put, \
+           warnings.catch_warnings(record=True) as w:
+        mock_put.side_effect = RuntimeError("test error")
+        self.assertEqual(f(2), 4)
+        self.assertLen(w, 1)
+        self.assertIn(
+            "Error writing persistent compilation cache entry "
+            "for 'jit__lambda_': RuntimeError: test error",
+            str(w[0].message))
+
+  def test_cache_read_warning(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      cc.initialize_cache(tmpdir)
+      f = jit(lambda x: x*x)
+
+      with raise_persistent_cache_errors(False), \
+           mock.patch.object(cc._cache.__class__, 'get') as mock_get, \
+           warnings.catch_warnings(record=True) as w:
+        mock_get.side_effect = RuntimeError("test error")
+        self.assertEqual(f(2), 4)
+        self.assertLen(w, 1)
+        self.assertIn(
+            "Error reading persistent compilation cache entry "
+            "for 'jit__lambda_': RuntimeError: test error",
+            str(w[0].message))
 
   def create_new_debug_options(self, debug_options_obj):
     debug_options_obj.xla_cpu_enable_fast_math = False


### PR DESCRIPTION
Fixes #12582. Setting the env var `JAX_RAISE_PERSISTENT_CACHE_ERRORS=true` will revert to the original behavior of raising exception instead of warning.

Also makes JAX_DUMP_IR_TO work when the persistent cache is enabled.