### PR TITLE
Pin default jax.tools.colab_tpu.setup_tpu driver version.

### DIFF
--- a/jax/tools/colab_tpu.py
+++ b/jax/tools/colab_tpu.py
@@ -22,7 +22,7 @@ from jax.config import config
 TPU_DRIVER_MODE = 0
 
 
-def setup_tpu(tpu_driver_version='tpu_driver_nightly'):
+def setup_tpu(tpu_driver_version='tpu_driver-0.2'):
   """Sets up Colab to run on TPU.
 
   Note: make sure the Colab Runtime is set to Accelerator: TPU.
@@ -30,9 +30,8 @@ def setup_tpu(tpu_driver_version='tpu_driver_nightly'):
   Args
   ----
   tpu_driver_version : (str) specify the version identifier for the tpu driver.
-    Defaults to "tpu_driver_nightly". Occasionally the nightly release contains bugs,
-    in which case a workaround is to use a known working version from a previous date,
-    for example "tpu_driver-0.1dev20211031".
+    Defaults to "tpu_driver-0.2", which can be used with jaxlib 0.3.20. Set to
+    "tpu_driver_nightly" to use the nightly tpu driver build.
   """
   global TPU_DRIVER_MODE
 


### PR DESCRIPTION
Prior to this change, we were defaulting to the TPU nightly driver version. We should instead pin to the version associated with the default jaxlib version that Colab uses.