### PR TITLE
Set JAX_PLATFORMS=tpu,cpu on TPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Remember to align the itemized text with the first line of an item within a list
 PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
-## jax 0.3.22
+## jax 0.3.22 (Oct 5, 2022)
+* Changes
+  * Add `JAX_PLATFORMS=tpu,cpu` as default setting in TPU initialization, 
+  so JAX will raise an error if TPU cannot be initialized instead of falling 
+  back to CPU. Users are able to override this behavior to automatically choose 
+  an available backend by setting `JAX_PLATFORMS=''`.
 
 ## jaxlib 0.3.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ Remember to align the itemized text with the first line of an item within a list
 PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
-## jax 0.3.22 (Oct 5, 2022)
+## jax 0.3.22
 * Changes
-  * Add `JAX_PLATFORMS=tpu,cpu` as default setting in TPU initialization, 
-  so JAX will raise an error if TPU cannot be initialized instead of falling 
-  back to CPU. Users are able to override this behavior to automatically choose 
-  an available backend by setting `JAX_PLATFORMS=''`.
+  * Add `JAX_PLATFORMS=tpu,cpu` as default setting in TPU initialization,
+  so JAX will raise an error if TPU cannot be initialized instead of falling
+  back to CPU. Set `JAX_PLATFORMS=''` to override this behavior and automatically
+  choose an available backend (the original default), or set `JAX_PLATFORMS=cpu`
+  to always use CPU regardless of if the TPU is available.
 
 ## jaxlib 0.3.22
 

--- a/jax/_src/cloud_tpu_init.py
+++ b/jax/_src/cloud_tpu_init.py
@@ -48,6 +48,7 @@ def cloud_tpu_init():
 
   libtpu.configure_library_path()
   os.environ.setdefault('GRPC_VERBOSITY', 'ERROR')
+  os.environ.setdefault('JAX_PLATFORMS', 'tpu,cpu')
   os.environ['TPU_ML_PLATFORM'] = 'JAX'
 
   # If the user has set any topology-related env vars, don't set any

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -350,8 +350,8 @@ def backends():
           # we expect a RuntimeError.
           err_msg = f"Unable to initialize backend '{platform}': {err}"
           if config.jax_platforms:
-            setup_msg = f" (set JAX_PLATFORMS='' to choose backend automatically)"
-            raise RuntimeError(err_msg + setup_msg)
+            err_msg += " (set JAX_PLATFORMS='' to automatically choose an available backend)"
+            raise RuntimeError(err_msg)
           else:
             _backends_errors[platform] = str(err)
             logging.info(err_msg)

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -350,7 +350,7 @@ def backends():
           # we expect a RuntimeError.
           err_msg = f"Unable to initialize backend '{platform}': {err}"
           if config.jax_platforms:
-            setup_msg = f"(Set JAX_PLATFORMS='' to auto fallback to CPU or JAX_PLATFORMS=cpu to always use CPU)"
+            setup_msg = f" (set JAX_PLATFORMS='' to choose backend automatically)"
             raise RuntimeError(err_msg + setup_msg)
           else:
             _backends_errors[platform] = str(err)

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -350,7 +350,8 @@ def backends():
           # we expect a RuntimeError.
           err_msg = f"Unable to initialize backend '{platform}': {err}"
           if config.jax_platforms:
-            raise RuntimeError(err_msg)
+            setup_msg = f"(Set JAX_PLATFORMS='' to auto fallback to CPU or JAX_PLATFORMS=cpu to always use CPU)"
+            raise RuntimeError(err_msg + setup_msg)
           else:
             _backends_errors[platform] = str(err)
             logging.info(err_msg)


### PR DESCRIPTION
* Set `JAX_PLATFORMS=tpu,cpu` automatically if libtpu is installed.
* It would make JAX raise an error if TPU cannot be initialized instead of falling back to CPU.
* Tests:
  * Run test file below on a non-TPU platform, it throws `Unable to initialize backend 'tpu': NOT_FOUND` error
  * Run test file below on a non-TPU platform with `export JAX_PLATFORMS=cpu`, and it runs with CPU (`No GPU/TPU found, falling back to CPU`).
  * Run test file on a non-TPU platform with both `export JAX_PLATFORMS=''` and `export JAX_PLATFORMS=` separately, and it executes with CPU (`No GPU/TPU found, falling back to CPU`).
  * Run test file on both non-TPU and TPU platforms with `export JAX_PLATFORMS=ccc`, and get error message below.

**test file**:
```
import jax
import os
import time

for i in range(5):
    print("checking...")
    print(os.environ.get('JAX_PLATFORMS'))
    print(jax.devices())
    time.sleep(10)
```

**error message**:
```
Traceback (most recent call last):
  File "/usr/local/google/home/ranran/jax/jax_test.py", line 8, in <module>
    print(jax.devices())
  File "/usr/local/google/home/ranran/jax/jax/_src/lib/xla_bridge.py", line 487, in devices
    return get_backend(backend).devices()
  File "/usr/local/google/home/ranran/jax/jax/_src/lib/xla_bridge.py", line 429, in get_backend
    return _get_backend_uncached(platform)
  File "/usr/local/google/home/ranran/jax/jax/_src/lib/xla_bridge.py", line 413, in _get_backend_uncached
    bs = backends()
  File "/usr/local/google/home/ranran/jax/jax/_src/lib/xla_bridge.py", line 354, in backends
    raise RuntimeError(err_msg + setup_msg)
RuntimeError: Unable to initialize backend 'ccc': Unknown backend 'ccc' (set JAX_PLATFORMS='' to automatically choose an available backend)
```