### PR TITLE
Migrate api_test, lax_numpy_test, and lax_vmap_test to

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -599,13 +599,15 @@ def rand_some_zero(rng):
 def rand_int(rng, low=0, high=None):
   def fn(shape, dtype):
     nonlocal high
+    gen_dtype = dtype if np.issubdtype(dtype, np.integer) else np.int64
     if low == 0 and high is None:
       if np.issubdtype(dtype, np.integer):
         high = np.iinfo(dtype).max
       else:
         raise ValueError("rand_int requires an explicit `high` value for "
                          "non-integer types.")
-    return rng.randint(low, high=high, size=shape, dtype=dtype)
+    return rng.randint(low, high=high, size=shape,
+                       dtype=gen_dtype).astype(dtype)
   return fn
 
 def rand_unique_int(rng, high=None):

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -303,10 +303,7 @@ class CPPJitTest(jtu.BufferDonationTestCase):
     self.assertEqual(self.jit(lambda x: x + 1)(1 + 1j), 2 + 1j)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": f"_{argnum_type}",
-     "argnum_type": argnum_type}
-    for argnum_type in ("static_argnums", "donate_argnums")))
+  @parameterized.parameters("static_argnums", "donate_argnums")
   def test_jit_argnums_overflow_error(self, argnum_type: str):
     def f(a, b, c):
       ...
@@ -902,10 +899,7 @@ class CPPJitTest(jtu.BufferDonationTestCase):
 
   # TODO(zhangqiaorjc): Test pruning constants after DCE pass prunes primitive
   # applications.
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": f"_num_args={num_args}",
-     "num_args": num_args}
-    for num_args in [2, 3, 4]))
+  @parameterized.parameters(2, 3, 4)
   def test_jit_with_pruned_args(self, num_args):
     def f(*args):
       used = np.array(2)
@@ -9122,12 +9116,13 @@ class NamedCallTest(jtu.JaxTestCase):
     out = f(5)
     self.assertEqual(out, 5)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_jit={jit._name}_func={func}",
-       "jit": jit, "func": func}
+  @jtu.sample_product(
+    [dict(func=func, jit=jit)
       for func in ['identity', 'asarray', 'device_put']
       for jit in jtu.JIT_IMPLEMENTATION
-      if not (jit._name == "noop" and func == 'identity')))
+      if not (jit._name == "noop" and func == 'identity')
+    ],
+  )
   def test_integer_overflow(self, jit, func):
     funcdict = {
       'identity': lambda x: x,

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -173,13 +173,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       with self.assertRaises(NotImplementedError):
         func()
 
-  @parameterized.named_parameters(
-    {"testcase_name": f"_{dtype.__name__}", "dtype": dtype}
-    for dtype in [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32, jnp.uint64,
-                  jnp.int8, jnp.int16, jnp.int32, jnp.int64,
-                  jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64,
-                  jnp.complex64, jnp.complex128]
-    if dtype == dtypes.canonicalize_dtype(dtype))
+  @parameterized.parameters(
+    [dtype for dtype in [jnp.bool_, jnp.uint8, jnp.uint16, jnp.uint32,
+                         jnp.uint64, jnp.int8, jnp.int16, jnp.int32, jnp.int64,
+                         jnp.bfloat16, jnp.float16, jnp.float32, jnp.float64,
+                         jnp.complex64, jnp.complex128]
+     if dtype == dtypes.canonicalize_dtype(dtype)])
   def testDtypeWrappers(self, dtype):
     arr = dtype(0)
     self.assertIsInstance(arr, jnp.ndarray)
@@ -191,11 +190,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     prims = [eqn.primitive for eqn in jaxpr.eqns]
     self.assertEqual(prims, [lax.convert_element_type_p])  # No copy generated.
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_{dtype}_allow_picke={allow_pickle}",
-       "dtype": dtype, "allow_pickle": allow_pickle}
-      for dtype in float_dtypes + [object]
-      for allow_pickle in [True, False]))
+  @jtu.sample_product(
+      dtype=float_dtypes + [object],
+      allow_pickle=[True, False],
+  )
   def testLoad(self, dtype, allow_pickle):
     if dtype == object and not allow_pickle:
       self.skipTest("dtype=object requires allow_pickle=True")
@@ -254,14 +252,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jax.grad(f)(jnp_array)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}_discont={}_period={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, discont, period),
-       "shape": shape, "dtype": dtype, "axis": axis, "discont": discont, "period": period}
-      for shape in all_shapes for dtype in default_dtypes
-      for discont in [None, "pi", 2]
-      for period in ["2pi", "pi"]
-      for axis in list(range(-len(shape), len(shape)))))
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
+      for shape in all_shapes
+      for axis in list(range(-len(shape), len(shape)))],
+    discont=[None, "pi", 2],
+    period=["2pi", "pi"],
+    dtype=default_dtypes,
+  )
   def testUnwrap(self, shape, dtype, axis, discont, period):
     if numpy_version < (1, 21) and period != "2pi":
       self.skipTest("numpy < 1.21 does not support the period argument to unwrap()")
@@ -291,12 +289,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             atol={dtypes.bfloat16: 1e-1, np.float16: 1e-2})
     self._CompileAndCheck(jnp_fun, args_maker, atol={dtypes.bfloat16: 1e-1})
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
-      for shape in all_shapes for dtype in all_dtypes
-      for axis in list(range(-len(shape), len(shape))) + [None]))
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
+      for shape in all_shapes
+      for axis in list(range(-len(shape), len(shape))) + [None]],
+    dtype=all_dtypes,
+  )
   def testCountNonzero(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda x: np.count_nonzero(x, axis)
@@ -305,11 +303,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+  @jtu.sample_product(shape=all_shapes, dtype=all_dtypes)
   def testNonzero(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda x: np.nonzero(x)
@@ -320,14 +314,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_size={}_fill_value={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), size, fill_value),
-       "shape": shape, "dtype": dtype, "size": size, "fill_value": fill_value}
+  @jtu.sample_product(
+    [dict(shape=shape, fill_value=fill_value)
       for shape in nonempty_array_shapes
-      for dtype in all_dtypes
       for fill_value in [None, -1, shape or (1,)]
-      for size in [1, 5, 10]))
+     ],
+    dtype=all_dtypes,
+    size=[1, 5, 10],
+  )
   def testNonzeroSize(self, shape, dtype, size, fill_value):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -344,11 +338,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+  @jtu.sample_product(shape=all_shapes, dtype=all_dtypes)
   def testFlatNonzero(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = jtu.ignore_warning(
@@ -362,14 +352,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda x: jnp.flatnonzero(x, size=np.size(x) // 2)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_size={}_fill_value={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), size, fill_value),
-       "shape": shape, "dtype": dtype, "size": size, "fill_value": fill_value}
-      for shape in nonempty_array_shapes
-      for dtype in all_dtypes
-      for fill_value in [None, -1, 10, (-1,), (10,)]
-      for size in [1, 5, 10]))
+  @jtu.sample_product(
+    shape=nonempty_array_shapes,
+    dtype=all_dtypes,
+    fill_value=[None, -1, 10, (-1,), (10,)],
+    size=[1, 5, 10],
+  )
   def testFlatNonzeroSize(self, shape, dtype, size, fill_value):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -385,11 +373,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+  @jtu.sample_product(shape=all_shapes, dtype=all_dtypes)
   def testArgWhere(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = jtu.ignore_warning(
@@ -404,14 +388,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda x: jnp.argwhere(x, size=np.size(x) // 2)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_size={}_fill_value={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), size, fill_value),
-       "shape": shape, "dtype": dtype, "size": size, "fill_value": fill_value}
+  @jtu.sample_product(
+    [dict(shape=shape, fill_value=fill_value)
       for shape in nonempty_array_shapes
-      for dtype in all_dtypes
       for fill_value in [None, -1, shape or (1,)]
-      for size in [1, 5, 10]))
+     ],
+    dtype=all_dtypes,
+    size=[1, 5, 10],
+  )
   def testArgWhereSize(self, shape, dtype, size, fill_value):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -428,17 +412,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "{}_inshape={}_axis={}_keepdims={}".format(
-          rec.test_name.capitalize(),
-          jtu.format_shape_dtype_string(shape, dtype), axis, keepdims),
-       "rng_factory": rec.rng_factory, "shape": shape, "dtype": dtype,
-       "np_op": getattr(np, rec.name), "jnp_op": getattr(jnp, rec.name),
-       "axis": axis, "keepdims": keepdims}
+  @jtu.sample_product(
+    [dict(np_op=getattr(np, rec.name), jnp_op=getattr(jnp, rec.name),
+          shape=shape, dtype=dtype, axis=axis, rng_factory=rec.rng_factory)
       for rec in JAX_ARGMINMAX_RECORDS
       for shape, dtype in _shape_and_dtypes(rec.shapes, rec.dtypes)
-      for axis in range(-len(shape), len(shape))
-      for keepdims in [True, False]))
+      for axis in range(-len(shape), len(shape))],
+    keepdims=[False, True],
+  )
   def testArgMinMax(self, np_op, jnp_op, rng_factory, shape, dtype, axis, keepdims):
     rng = rng_factory(self.rng())
     if dtype == np.complex128 and jtu.device_under_test() == "gpu":
@@ -462,10 +443,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         raise
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": rec.test_name.capitalize(), "name": rec.name,
-       "np_op": getattr(np, rec.name), "jnp_op": getattr(jnp, rec.name)}
-      for rec in JAX_ARGMINMAX_RECORDS))
+  @jtu.sample_product(
+    [dict(name=rec.name, np_op=getattr(np, rec.name),
+          jnp_op=getattr(jnp, rec.name))
+      for rec in JAX_ARGMINMAX_RECORDS],
+  )
   def testArgMinMaxEmpty(self, name, np_op, jnp_op):
     name = name[3:] if name.startswith("nan") else name
     msg = f"attempt to get {name} of an empty sequence"
@@ -479,14 +461,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_{}".format(
-          jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
-          jtu.format_shape_dtype_string(rhs_shape, rhs_dtype),
-          axes),
-       "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes}
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape, axes=axes)
       for lhs_shape, rhs_shape, axes in [
           [(2,), (2,), (-1, -1, -1, None)], # scalar output
           [(2, 4), (2, 4), (-1, -1, -1, 0)], # 2D vectors
@@ -498,8 +474,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(10, 5, 2, 8), (1, 5, 1, 3), (-2, -1, -3, None)], # axes/broadcasting
           [(4, 5, 2), (4, 5, 2), (-1, -1, 0, None)], # axisc should do nothing
           [(4, 5, 2), (4, 5, 2), (-1, -1, -1, None)] # same as before
-      ]
-      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
+      ]],
+    lhs_dtype=number_dtypes,
+    rhs_dtype=number_dtypes,
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testCross(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes):
     rng = jtu.rand_default(self.rng())
@@ -518,13 +496,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, tol=tol)
       self._CompileAndCheck(jnp_fun, args_maker, atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_{}".format(
-          name,
-          jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
-          jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
-       "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
+  @jtu.sample_product(
+    [dict(name=name, lhs_shape=lhs_shape, rhs_shape=rhs_shape)
       for name, lhs_shape, rhs_shape in [
           ("matrix-scalar", (3, 3), ()),
           ("scalar-matrix", (), (3, 3)),
@@ -535,9 +508,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("vector-tensor", (2,), (3, 2, 4)),
           ("tensor-matrix", (4, 3, 2), (2, 5)),
           ("matrix-tensor", (5, 2), (3, 2, 4)),
-          ("tensor-tensor", (2, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testDot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+          ("tensor-tensor", (2, 3, 4), (5, 4, 1))]],
+    lhs_dtype=number_dtypes,
+    rhs_dtype=number_dtypes,
+  )
+  def testDot(self, name, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
     tol = {np.float16: 1e-2, np.float32: 1e-5, np.float64: 1e-14,
@@ -552,13 +527,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_dot, jnp.dot, args_maker, tol=tol)
       self._CompileAndCheck(jnp.dot, args_maker, atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_{}".format(
-          name,
-          jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
-          jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
-       "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
+  @jtu.sample_product(
+    [dict(name=name, lhs_shape=lhs_shape, rhs_shape=rhs_shape)
       for name, lhs_shape, rhs_shape in [
           ("vector-vector", (3,), (3,)),
           ("matrix-vector", (3, 3), (3,)),
@@ -569,9 +539,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ("matrix-tensor", (5, 2), (3, 2, 4)),
           ("tensor-matrix", (5, 2, 3), (3, 2)),
           ("tensor-tensor", (5, 3, 4), (5, 4, 1)),
-          ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]
-      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
-  def testMatmul(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
+          ("tensor-tensor-broadcast", (3, 1, 3, 4), (5, 4, 1))]],
+    lhs_dtype=number_dtypes,
+    rhs_dtype=number_dtypes,
+  )
+  def testMatmul(self, name, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
     rng = jtu.rand_default(self.rng())
     def np_fun(x, y):
       dtype = jnp.promote_types(lhs_dtype, rhs_dtype)
@@ -586,14 +558,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp.matmul, args_maker, tol=tol)
       self._CompileAndCheck(jnp.matmul, args_maker, atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_{}".format(
-          jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
-          jtu.format_shape_dtype_string(rhs_shape, rhs_dtype),
-          axes),
-       "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype,
-       "axes": axes}
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape, axes=axes)
       for lhs_shape, rhs_shape, axes in [
           [(3,), (), 0],
           [(2, 3, 4), (5, 6, 7), 0],  # from issue #740
@@ -601,8 +567,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           [(2, 3, 4), (5, 4, 3, 6), [1, 2]],
           [(2, 3, 4), (5, 4, 3, 6), [[1, 2], [2, 1]]],
           [(1, 2, 3, 4), (4, 5, 3, 6), [[2, 3], [2, 0]]],
-      ]
-      for lhs_dtype, rhs_dtype in itertools.combinations_with_replacement(number_dtypes, 2)))
+      ]],
+    lhs_dtype=number_dtypes,
+    rhs_dtype=number_dtypes,
+  )
   def testTensordot(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype, axes):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -641,16 +609,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       lambda: jnp.tensordot(a, b, axes='badaxes'))
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_invert={}".format(
-          jtu.format_shape_dtype_string(element_shape, dtype),
-          jtu.format_shape_dtype_string(test_shape, dtype), invert),
-       "element_shape": element_shape, "test_shape": test_shape,
-       "dtype": dtype, "invert": invert}
-      for element_shape in all_shapes
-      for test_shape in all_shapes
-      for dtype in default_dtypes
-      for invert in [True, False]))
+  @jtu.sample_product(
+    element_shape=all_shapes,
+    test_shape=all_shapes,
+    dtype=default_dtypes,
+    invert=[False, True],
+  )
   def testIsin(self, element_shape, test_shape, dtype, invert):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(element_shape, dtype), rng(test_shape, dtype)]
@@ -660,16 +624,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_invert={}".format(
-          jtu.format_shape_dtype_string(element_shape, dtype),
-          jtu.format_shape_dtype_string(test_shape, dtype), invert),
-       "element_shape": element_shape, "test_shape": test_shape,
-       "dtype": dtype, "invert": invert}
-      for element_shape in all_shapes
-      for test_shape in all_shapes
-      for dtype in default_dtypes
-      for invert in [True, False]))
+  @jtu.sample_product(
+    element_shape=all_shapes,
+    test_shape=all_shapes,
+    dtype=default_dtypes,
+    invert=[False, True],
+  )
   def testIn1d(self, element_shape, test_shape, dtype, invert):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(element_shape, dtype), rng(test_shape, dtype)]
@@ -678,15 +638,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2)),
-       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in all_shapes
-      for shape2 in all_shapes))
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=all_shapes,
+    shape2=all_shapes,
+  )
   def testSetdiff1d(self, shape1, shape2, dtype1, dtype2):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
@@ -694,19 +651,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with jtu.strict_promotion_if_dtypes_match([dtype1, dtype2]):
       self._CheckAgainstNumpy(np.setdiff1d, jnp.setdiff1d, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_size={}_fill_value={}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2),
-       size, fill_value),
-       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2,
-       "size": size, "fill_value": fill_value}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in all_shapes
-      for shape2 in all_shapes
-      for size in [1, 5, 10]
-      for fill_value in [None, -1]))
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=all_shapes,
+    shape2=all_shapes,
+    size=[1, 5, 10],
+    fill_value=[None, -1],
+  )
   def testSetdiff1dSize(self, shape1, shape2, dtype1, dtype2, size, fill_value):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
@@ -722,15 +674,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2)),
-       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in nonempty_nonscalar_array_shapes
-      for shape2 in nonempty_nonscalar_array_shapes))
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=nonempty_nonscalar_array_shapes,
+    shape2=nonempty_nonscalar_array_shapes,
+  )
   def testUnion1d(self, shape1, shape2, dtype1, dtype2):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
@@ -740,18 +689,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with jtu.strict_promotion_if_dtypes_match([dtype1, dtype2]):
       self._CheckAgainstNumpy(np_fun, jnp.union1d, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_size={}_fill_value={}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2), size, fill_value),
-       "shape1": shape1, "shape2": shape2, "dtype1": dtype1, "dtype2": dtype2,
-       "size": size, "fill_value": fill_value}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in nonempty_nonscalar_array_shapes
-      for shape2 in nonempty_nonscalar_array_shapes
-      for size in [1, 5, 10]
-      for fill_value in [None, -1]))
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=nonempty_nonscalar_array_shapes,
+    shape2=nonempty_nonscalar_array_shapes,
+    size=[1, 5, 10],
+    fill_value=[None, -1],
+  )
   def testUnion1dSize(self, shape1, shape2, dtype1, dtype2, size, fill_value):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
@@ -769,18 +714,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_assume_unique={}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2),
-       assume_unique),
-       "shape1": shape1, "dtype1": dtype1, "shape2": shape2, "dtype2": dtype2,
-       "assume_unique": assume_unique}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in all_shapes
-      for shape2 in all_shapes
-      for assume_unique in [False, True]))
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=all_shapes,
+    shape2=all_shapes,
+    assume_unique=[False, True],
+  )
   def testSetxor1d(self, shape1, dtype1, shape2, dtype2, assume_unique):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
@@ -794,21 +734,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with jtu.strict_promotion_if_dtypes_match([dtype1, dtype2]):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_assume_unique={}_return_indices={}".format(
-       jtu.format_shape_dtype_string(shape1, dtype1),
-       jtu.format_shape_dtype_string(shape2, dtype2),
-       assume_unique,
-       return_indices),
-       "shape1": shape1, "dtype1": dtype1, "shape2": shape2, "dtype2": dtype2,
-       "assume_unique": assume_unique, "return_indices": return_indices}
-      for dtype1 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for dtype2 in [s for s in default_dtypes if s != jnp.bfloat16]
-      for shape1 in all_shapes
-      for shape2 in all_shapes
-      for assume_unique in [False, True]
-      for return_indices in [False, True]))
-  def testIntersect1d(self, shape1, dtype1, shape2, dtype2, assume_unique, return_indices):
+  @jtu.sample_product(
+    dtype1=[s for s in default_dtypes if s != jnp.bfloat16],
+    dtype2=[s for s in default_dtypes if s != jnp.bfloat16],
+    shape1=all_shapes,
+    shape2=all_shapes,
+    assume_unique=[False, True],
+    return_indices=[False, True],
+  )
+  def testIntersect1d(self, shape1, dtype1, shape2, dtype2, assume_unique,
+                      return_indices):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape1, dtype1), rng(shape2, dtype2)]
     jnp_fun = lambda ar1, ar2: jnp.intersect1d(ar1, ar2, assume_unique=assume_unique, return_indices=return_indices)
@@ -817,18 +752,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}".format(
-          jtu.format_shape_dtype_string(lhs_shape, lhs_dtype),
-          jtu.format_shape_dtype_string(rhs_shape, rhs_dtype)),
-       "lhs_shape": lhs_shape, "lhs_dtype": lhs_dtype,
-       "rhs_shape": rhs_shape, "rhs_dtype": rhs_dtype}
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, lhs_dtype=lhs_dtype,
+          rhs_shape=rhs_shape, rhs_dtype=rhs_dtype)
       # TODO(phawkins): support integer dtypes too.
       for lhs_shape, lhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
       for rhs_shape, rhs_dtype in _shape_and_dtypes(all_shapes, inexact_dtypes)
       if len(jtu._dims_of_shape(lhs_shape)) == 0
       or len(jtu._dims_of_shape(rhs_shape)) == 0
-      or lhs_shape[-1] == rhs_shape[-1]))
+      or lhs_shape[-1] == rhs_shape[-1]],
+  )
   def testInner(self, lhs_shape, lhs_dtype, rhs_shape, rhs_dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(lhs_shape, lhs_dtype), rng(rhs_shape, rhs_dtype)]
@@ -850,23 +783,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=False, atol=tol, rtol=tol)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_deg={}_rcond={}_full={}_w={}_cov={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          deg,
-          rcond,
-          full,
-          w,
-          cov),
-      "shape": shape, "dtype": dtype, "deg": deg,
-      "rcond": rcond, "full": full, "w": w, "cov": cov}
-      for dtype in [dt for dt in float_dtypes if dt not in [jnp.float16, jnp.bfloat16]]
-      for shape in [shape for shape in one_dim_array_shapes if shape != (1,)]
-      for deg in [1, 2, 3]
-      for rcond in [None, -1, 10e-3, 10e-5, 10e-10]
-      for full in [False, True]
-      for w in [False, True]
-      for cov in [False, True, "unscaled"]))
+  @jtu.sample_product(
+    dtype=[dt for dt in float_dtypes if dt not in [jnp.float16, jnp.bfloat16]],
+    shape=[shape for shape in one_dim_array_shapes if shape != (1,)],
+    deg=[1, 2, 3],
+    rcond=[None, -1, 10e-3, 10e-5, 10e-10],
+    full=[False, True],
+    w=[False, True],
+    cov=[False, True, "unscaled"],
+  )
   def testPolyfit(self, shape, dtype, deg, rcond, full, w, cov):
     rng = jtu.rand_default(self.rng())
     tol_spec = {np.float32: 1e-3, np.float64: 1e-13, np.complex64: 1e-5}
@@ -878,19 +803,40 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda x, y, a: jnp.polyfit(x, y, deg=deg, rcond=rcond, full=full, w=_w(a), cov=cov)
     np_fun = jtu.ignore_warning(
       message="Polyfit may be poorly conditioned*")(lambda x, y, a: np.polyfit(x, y, deg=deg, rcond=rcond, full=full, w=_w(a), cov=cov))
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False, tol=tol)
+
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=False, atol=tol, rtol=tol)
 
+    args = args_maker()
+    if not full:
+      args = args_maker()
+      try:
+        np_out = np_fun(*args)
+      except ValueError:
+        return  # https://github.com/numpy/numpy/issues/22380
+      jnp_out = jnp_fun(*args)
+      self.assertAllClose(np_out, jnp_out, atol=tol, rtol=tol,
+                          check_dtypes=False)
+    else:
+      # Don't compare the residuals because jnp.linalg.lstsq acts slightly
+      # differently to remain `jit`-compatible.
+      np_p, _, nrank, nsingular_values, nrcond = np_fun(*args)
+      jp_p, _, jrank, jsingular_values, jrcond = jnp_fun(*args)
+      self.assertAllClose(
+        (np_p, nrank, nsingular_values, nrcond),
+        (jp_p, jrank, jsingular_values, jrcond),
+        atol=tol, rtol=tol, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_amin={}_amax={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), a_min, a_max),
-       "shape": shape, "dtype": dtype, "a_min": a_min, "a_max": a_max}
-      for shape in all_shapes for dtype in number_dtypes
+
+  @jtu.sample_product(
+    [dict(a_min=a_min, a_max=a_max)
       for a_min, a_max in [(-1, None), (None, 1), (-0.9, 1),
                            (-np.ones(1), None),
                            (None, np.ones(1)),
-                           (np.full(1, -0.9), np.ones(1))]))
+                           (np.full(1, -0.9), np.ones(1))]
+    ],
+    shape=all_shapes,
+    dtype=number_dtypes,
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises mixed type promotion
   def testClipStaticBounds(self, shape, dtype, a_min, a_max):
@@ -908,12 +854,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, "At most one of a_min and a_max.*"):
       jnp.clip(jnp.zeros((3,)))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_decimals={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), decimals),
-       "shape": shape, "dtype": dtype, "decimals": decimals}
-      for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)
-      for decimals in [0, 1, -2]))
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype)
+      for shape, dtype in _shape_and_dtypes(all_shapes, number_dtypes)],
+    decimals=[0, 1, -2],
+  )
   def testRoundStaticDecimals(self, shape, dtype, decimals):
     rng = jtu.rand_default(self.rng())
     if jnp.issubdtype(dtype, np.integer) and decimals < 0:
@@ -928,8 +873,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=check_dtypes,
                           atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(
-    {"testcase_name": f"_jit={jit}", "jit": jit} for jit in [True, False])
+  @jtu.sample_product(jit=[False, True])
   def testOperatorRound(self, jit):
     jround = jax.jit(round, static_argnums=1) if jit else round
     self.assertAllClose(round(np.float32(7.532), 1),
@@ -946,9 +890,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                         jround(jnp.array(1.234, jnp.float32)),
                         check_dtypes=False)
 
-  @parameterized.named_parameters(
-    {"testcase_name": f"_shape={shape}", "shape": shape}
-    for shape in [(5,), (5, 2)])
+  @jtu.sample_product(shape=[(5,), (5, 2)])
   def testOperatorReversed(self, shape):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, 'float32')]
@@ -958,12 +900,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_mode={}_padwidth={}_constantvalues={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), mode, pad_width,
-          constant_values),
-       "shape": shape, "dtype": dtype, "mode": mode,
-       "pad_width": pad_width, "constant_values": constant_values}
+  @jtu.sample_product(
+    [dict(mode=mode, shape=shape, dtype=dtype,
+          pad_width=pad_width, constant_values=constant_values)
       for mode, shapes in [
           ('constant', all_shapes),
           ('wrap', nonempty_shapes),
@@ -996,7 +935,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       ]
       if (pad_width != () and constant_values != () and
           ((mode == 'constant' and constant_values is not None) or
-           (mode != 'constant' and constant_values is None)))))
+           (mode != 'constant' and constant_values is None)))],
+  )
   def testPad(self, shape, dtype, mode, pad_width, constant_values):
     if np.issubdtype(dtype, np.unsignedinteger):
       constant_values = tree_util.tree_map(abs, constant_values)
@@ -1015,11 +955,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             check_dtypes=shape is not jtu.PYTHON_SCALAR_SHAPE)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_mode={}_pad_width={}_stat_length={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), mode, pad_width, stat_length),
-       "shape": shape, "dtype": dtype, "mode": mode, "pad_width": pad_width,
-       "stat_length": stat_length}
+  @jtu.sample_product(
+    [dict(mode=mode, shape=shape, dtype=dtype,
+          pad_width=pad_width, stat_length=stat_length)
       for mode in ['maximum', 'minimum', 'mean', 'median']
       for shape, dtype in _shape_and_dtypes(nonempty_shapes, all_dtypes)
       for pad_width in [
@@ -1048,7 +986,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           1, 2
       ]
       if (pad_width != () and stat_length != () and
-          not (dtype in bool_dtypes and mode == 'mean'))))
+          not (dtype in bool_dtypes and mode == 'mean'))],
+  )
   def testPadStatValues(self, shape, dtype, mode, pad_width, stat_length):
     if mode == 'median' and np.issubdtype(dtype, np.complexfloating):
       self.skipTest("median statistic is not supported for dtype=complex.")
@@ -1062,12 +1001,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             check_dtypes=shape is not jtu.PYTHON_SCALAR_SHAPE)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_mode={}_pad_width={}_reflect_type={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), mode, pad_width, reflect_type),
-       "shape": shape, "dtype": dtype, "mode": mode, "pad_width": pad_width,
-       "reflect_type": reflect_type}
-      for mode in ['symmetric', 'reflect']
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype,
+          pad_width=pad_width, reflect_type=reflect_type)
       for shape, dtype in _shape_and_dtypes(nonempty_shapes, all_dtypes)
       for pad_width in [
           # ((before_1, after_1), ..., (before_N, after_N))
@@ -1084,7 +1020,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       for reflect_type in ['even', 'odd']
       if (pad_width != () and
           # following types lack precision when calculating odd values
-          (reflect_type != 'odd' or dtype not in [np.bool_, np.float16, jnp.bfloat16]))))
+          (reflect_type != 'odd' or dtype not in [np.bool_, np.float16, jnp.bfloat16]))],
+    mode=['symmetric', 'reflect']
+  )
   def testPadSymmetricAndReflect(self, shape, dtype, mode, pad_width, reflect_type):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1097,11 +1035,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol={np.float32: 1e-3, np.complex64: 1e-3})
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_mode={}_pad_width={}_end_values={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), "linear_ramp", pad_width, end_values),
-       "shape": shape, "dtype": dtype, "pad_width": pad_width,
-       "end_values": end_values}
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype, pad_width=pad_width, end_values=end_values)
       for shape, dtype in _shape_and_dtypes(nonempty_shapes, default_dtypes + complex_dtypes)
       for pad_width in [
         # ((before_1, after_1), ..., (before_N, after_N))
@@ -1129,7 +1064,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       ]
       if (pad_width != () and end_values != () and
           # following types lack precision
-          dtype not in [np.int8, np.int16, np.float16, jnp.bfloat16])))
+          dtype not in [np.int8, np.int16, np.float16, jnp.bfloat16])],
+  )
   def testPadLinearRamp(self, shape, dtype, pad_width, end_values):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1245,13 +1181,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       y = jnp.pad(x, 0, mode=mode)
       self.assertTrue(dtypes.is_weakly_typed(y))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape=[{}]_reps={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), reps),
-       "shape": shape, "dtype": dtype, "reps": reps}
-      for reps in [(), (2,), (3, 4), (2, 3, 4), (1, 0, 2)]
-      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
-      ))
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype)
+      for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)],
+    reps=[(), (2,), (3, 4), (2, 3, 4), (1, 0, 2)],
+  )
   def testTile(self, shape, dtype, reps):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.tile(arg, reps)
@@ -1263,26 +1197,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             check_dtypes=shape is not jtu.PYTHON_SCALAR_SHAPE)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in all_shapes
-      for dtype in all_dtypes))
+  @jtu.sample_product(shape=all_shapes, dtype=all_dtypes)
   def testExtract(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, jnp.float32), rng(shape, dtype)]
     self._CheckAgainstNumpy(np.extract, jnp.extract, args_maker)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_ncond={}_nfunc={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), ncond, nfunc),
-       "shape": shape, "dtype": dtype, "ncond": ncond, "nfunc": nfunc}
+  @jtu.sample_product(
+    [dict(ncond=ncond, nfunc=nfunc)
       for ncond in [1, 2, 3]
       for nfunc in [ncond, ncond + 1]
-      for shape in all_shapes
-      for dtype in all_dtypes))
+    ],
+    shape=all_shapes,
+    dtype=all_dtypes)
   def testPiecewise(self, shape, dtype, ncond, nfunc):
     rng = jtu.rand_default(self.rng())
     rng_bool = jtu.rand_int(self.rng(), 0, 2)
@@ -1309,15 +1237,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       jnp.piecewise(x, [x < 0], [g, 0.])
     self.assertEqual(g.num_traces, 1)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "{}_perm={}_{}".format(
-      jtu.format_shape_dtype_string(shape, dtype), perm, arg_type),
-     "dtype": dtype, "shape": shape, "perm": perm, "arg_type": arg_type}
-    for dtype in default_dtypes
-    for shape in array_shapes
-    for arg_type in ["splat", "value"]
-    for perm in [None, tuple(np.random.RandomState(0).permutation(np.zeros(shape).ndim)),
-                 tuple(np.random.RandomState(0).permutation(np.zeros(shape).ndim) - np.zeros(shape).ndim)]))
+  @jtu.sample_product(
+    [dict(shape=shape, perm=perm)
+      for shape in array_shapes
+      for perm in [
+        None,
+        tuple(np.random.RandomState(0).permutation(np.zeros(shape).ndim)),
+        tuple(np.random.RandomState(0).permutation(
+          np.zeros(shape).ndim) - np.zeros(shape).ndim)
+      ]
+    ],
+    dtype=default_dtypes,
+    arg_type=["splat", "value"],
+  )
   def testTransposeTuple(self, shape, dtype, perm, arg_type):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1332,13 +1264,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "{}_trim={}".format(
-      jtu.format_shape_dtype_string(a_shape, dtype), trim),
-     "dtype": dtype, "a_shape": a_shape, "trim": trim}
-    for dtype in default_dtypes
-    for a_shape in one_dim_array_shapes
-    for trim in ["f", "b", "fb"]))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+    trim=["f", "b", "fb"],
+  )
   def testTrimZeros(self, a_shape, dtype, trim):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(a_shape, dtype)]
@@ -1347,13 +1277,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_rank{}".format(
-        jtu.format_shape_dtype_string(a_shape, dtype), rank),
-       "dtype": dtype, "a_shape": a_shape, "rank": rank}
-      for rank in (1, 2)
-      for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes))
+  @jtu.sample_product(
+    rank=(1, 2),
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+  )
+  @jax.default_matmul_precision("float32")
   def testPoly(self, a_shape, dtype, rank):
     if dtype in (np.float16, jnp.bfloat16, np.int16):
       self.skipTest(f"{dtype} gets promoted to {np.float16}, which is not supported.")
@@ -1368,14 +1297,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.poly, jnp.poly, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp.poly, args_maker, check_dtypes=True, rtol=tol, atol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "a_shape={} , b_shape={}".format(
-          jtu.format_shape_dtype_string(a_shape, dtype),
-          jtu.format_shape_dtype_string(b_shape, dtype)),
-       "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
-      for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes
-      for b_shape in one_dim_array_shapes))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+    b_shape=one_dim_array_shapes,
+  )
   def testPolyAdd(self, a_shape, b_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polyadd(arg1, arg2)
@@ -1385,14 +1311,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "a_shape={} , b_shape={}".format(
-          jtu.format_shape_dtype_string(a_shape, dtype),
-          jtu.format_shape_dtype_string(b_shape, dtype)),
-       "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
-      for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes
-      for b_shape in one_dim_array_shapes))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+    b_shape=one_dim_array_shapes,
+  )
   def testPolySub(self, a_shape, b_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polysub(arg1, arg2)
@@ -1402,15 +1325,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_order={}_k={}".format(
-          jtu.format_shape_dtype_string(a_shape, dtype),
-          order, k),
-       "dtype": dtype, "a_shape": a_shape, "order" : order, "k": k}
+  @jtu.sample_product(
+    [dict(order=order, k=k, dtype=dtype)
       for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes
       for order in range(5)
-      for k in [np.arange(order, dtype=dtype), np.ones(1, dtype), None]))
+      for k in [np.arange(order, dtype=dtype), np.ones(1, dtype), None]],
+    a_shape=one_dim_array_shapes,
+  )
   def testPolyInt(self, a_shape, order, k, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1: np.polyint(arg1, m=order, k=k)
@@ -1420,14 +1341,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_order={}".format(
-          jtu.format_shape_dtype_string(a_shape, dtype),
-          order),
-       "dtype": dtype, "a_shape": a_shape, "order" : order}
-      for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes
-      for order in range(5)))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+    order=list(range(5)),
+  )
   def testPolyDer(self, a_shape, order, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1: np.polyder(arg1, m=order)
@@ -1436,9 +1354,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_ptype={ptype}", "ptype": ptype}
-      for ptype in ['int', 'np.int', 'jnp.int']))
+  @parameterized.parameters(['int', 'np.int', 'jnp.int'])
   def testIntegerPower(self, ptype):
     p = {'int': 2, 'np.int': np.int32(2), 'jnp.int': jnp.int32(2)}[ptype]
     jaxpr = jax.make_jaxpr(partial(jnp.power, x2=p))(1)
@@ -1446,23 +1362,23 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertLen(eqns, 1)
     self.assertEqual(eqns[0].primitive, lax.integer_pow_p)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_x={x}_y={y}", "x": x, "y": y}
-      for x in [-1, 0, 1]
-      for y in [0, 32, 64, 128]))
+  @jtu.sample_product(
+    x=[-1, 0, 1],
+    y=[0, 32, 64, 128],
+  )
   def testIntegerPowerOverflow(self, x, y):
     # Regression test for https://github.com/google/jax/issues/5987
     args_maker = lambda: [x, y]
     self._CheckAgainstNumpy(np.power, jnp.power, args_maker)
     self._CompileAndCheck(jnp.power, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in all_shapes
-      for dtype in all_dtypes
-      for axis in [None] + list(range(len(shape)))))
+      for axis in [None] + list(range(len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testCompress(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
     if shape in scalar_shapes or len(shape) == 0:
@@ -1478,15 +1394,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = partial(jnp.compress, axis=axis)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_condition=array[{}]_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), len(condition), axis),
-       "shape": shape, "dtype": dtype, "condition": condition, "axis": axis}
-      for shape in [(2, 3)]
-      for dtype in int_dtypes
-      # condition entries beyond axis size must be zero.
-      for condition in [[1], [1, 0, 0, 0, 0, 0, 0]]
-      for axis in [None, 0, 1]))
+  @jtu.sample_product(
+    shape=[(2, 3)],
+    dtype=int_dtypes,
+    # condition entries beyond axis size must be zero.
+    condition=[[1], [1, 0, 0, 0, 0, 0, 0]],
+    axis=[None, 0, 1],
+  )
   def testCompressMismatchedShapes(self, shape, dtype, condition, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [np.array(condition), rng(shape, dtype)]
@@ -1494,13 +1408,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = partial(jnp.compress, axis=axis)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in array_shapes
-      for dtype in all_dtypes
-      for axis in [None] + list(range(len(shape)))))
+      for axis in [None] + list(range(len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testCompressMethod(self, shape, dtype, axis):
     rng = jtu.rand_some_zero(self.rng())
     if shape in scalar_shapes or len(shape) == 0:
@@ -1516,16 +1430,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda condition, x: x.compress(condition, axis=axis)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_axis={}_dtype={}_baseshape=[{}]_argdtypes=[{}]".format(
-          axis, dtype and np.dtype(dtype).name, ",".join(str(d) for d in base_shape),
-          ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
-       "axis": axis, "dtype": dtype, "base_shape": base_shape, "arg_dtypes": arg_dtypes}
+  @jtu.sample_product(
+    [dict(base_shape=base_shape, axis=axis)
+      for base_shape in [(4,), (3, 4), (2, 3, 4)]
+      for axis in range(-len(base_shape)+1, len(base_shape))
+    ],
+    arg_dtypes=[
+      arg_dtypes
       for num_arrs in [3]
       for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, num_arrs)
-      for base_shape in [(4,), (3, 4), (2, 3, 4)]
-      for dtype in [None] + default_dtypes
-      for axis in range(-len(base_shape)+1, len(base_shape))))
+    ],
+    dtype=[None] + default_dtypes,
+  )
   def testConcatenate(self, axis, dtype, base_shape, arg_dtypes):
     rng = jtu.rand_default(self.rng())
     wrapped_axis = axis % len(base_shape)
@@ -1541,16 +1457,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       return [rng(shape, dtype) for shape, dtype in zip(shapes, arg_dtypes)]
 
     with jtu.strict_promotion_if_dtypes_match(arg_dtypes):
-      self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+      # TODO: tests fail with bfloat16/float16 inputs mixed with integers.
+      if np.float16 not in arg_dtypes and dtypes.bfloat16 not in arg_dtypes:
+        self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-        "shape": shape, "dtype": dtype, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in [(4, 1), (4, 3), (4, 5, 6)]
-      for dtype in all_dtypes
-      for axis in [None] + list(range(1 - len(shape), len(shape) - 1))))
+      for axis in [None] + list(range(1 - len(shape), len(shape) - 1))
+    ],
+    dtype=all_dtypes,
+  )
   def testConcatenateArray(self, shape, dtype, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1565,14 +1483,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     b = jnp.array([[5]])
     jnp.concatenate((a, b), axis=None)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_axis={}_baseshape=[{}]_dtypes=[{}]".format(
-          axis, ",".join(str(d) for d in base_shape),
-          ",".join(np.dtype(dtype).name for dtype in arg_dtypes)),
-       "axis": axis, "base_shape": base_shape, "arg_dtypes": arg_dtypes}
-      for arg_dtypes in itertools.combinations_with_replacement(default_dtypes, 2)
+  @jtu.sample_product(
+    [dict(base_shape=base_shape, axis=axis)
       for base_shape in [(4,), (3, 4), (2, 3, 4)]
-      for axis in range(-len(base_shape)+1, len(base_shape))))
+      for axis in range(-len(base_shape)+1, len(base_shape))],
+    arg_dtypes=itertools.combinations_with_replacement(default_dtypes, 2)
+  )
   def testAppend(self, axis, base_shape, arg_dtypes):
     rng = jtu.rand_default(self.rng())
     wrapped_axis = axis % len(base_shape)
@@ -1594,16 +1510,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck(jnp_fun, args_maker)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_idx={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, idx),
-       "dtype": dtype, "shape": shape, "axis": axis, "idx": idx}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis, idx=idx)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
       for axis in [None] + list(range(-len(shape), len(shape)))
       for idx in (range(-prod(shape), prod(shape))
                   if axis is None else
-                  range(-shape[axis], shape[axis]))))
+                  range(-shape[axis], shape[axis]))],
+    dtype=all_dtypes,
+  )
   def testDeleteInteger(self, shape, dtype, idx, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1612,14 +1527,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_slc={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, slc),
-       "dtype": dtype, "shape": shape, "axis": axis, "slc": slc}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
       for axis in [None] + list(range(-len(shape), len(shape)))
-      for slc in [slice(None), slice(1, 3), slice(1, 5, 2)]))
+     ],
+    dtype=all_dtypes,
+    slc=[slice(None), slice(1, 3), slice(1, 5, 2)],
+  )
   def testDeleteSlice(self, shape, dtype, axis, slc):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1628,15 +1543,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_idx={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis,
-          jtu.format_shape_dtype_string(idx_shape, int)),
-       "dtype": dtype, "shape": shape, "axis": axis, "idx_shape": idx_shape}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
       for axis in [None] + list(range(-len(shape), len(shape)))
-      for idx_shape in all_shapes))
+    ],
+    dtype=all_dtypes,
+    idx_shape=all_shapes,
+  )
   def testDeleteIndexArray(self, shape, dtype, axis, idx_shape):
     rng = jtu.rand_default(self.rng())
     max_idx = np.zeros(shape).size if axis is None else np.zeros(shape).shape[axis]
@@ -1647,13 +1561,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "dtype": dtype, "shape": shape, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
-      for axis in [None] + list(range(-len(shape), len(shape)))))
+      for axis in [None] + list(range(-len(shape), len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testDeleteMaskArray(self, shape, dtype, axis):
     rng = jtu.rand_default(self.rng())
     mask_size = np.zeros(shape).size if axis is None else np.zeros(shape).shape[axis]
@@ -1667,13 +1581,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "dtype": dtype, "shape": shape, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
-      for axis in [None] + list(range(-len(shape), len(shape)))))
+      for axis in [None] + list(range(-len(shape), len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testInsertInteger(self, shape, dtype, axis):
     x = jnp.empty(shape)
     max_ind = x.size if axis is None else x.shape[axis]
@@ -1685,13 +1599,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "dtype": dtype, "shape": shape, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for dtype in all_dtypes
-      for axis in [None] + list(range(-len(shape), len(shape)))))
+      for axis in [None] + list(range(-len(shape), len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testInsertSlice(self, shape, dtype, axis):
     x = jnp.empty(shape)
     max_ind = x.size if axis is None else x.shape[axis]
@@ -1721,15 +1635,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       np.asarray(values), axis)
     self._CheckAgainstNumpy(np.insert, jnp.insert, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_out_dims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          axis, out_dims),
-        "shape": shape, "dtype": dtype, "axis": axis, "out_dims": out_dims}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_array_shapes
-      for dtype in default_dtypes
       for axis in range(-len(shape), len(shape))
-      for out_dims in [0, 1, 2]))
+    ],
+    dtype=default_dtypes,
+    out_dims=[0, 1, 2],
+  )
   def testApplyAlongAxis(self, shape, dtype, axis, out_dims):
     def func(x, out_dims):
       if out_dims == 0:
@@ -1744,20 +1657,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype)]
     np_fun = lambda arr: np.apply_along_axis(func, axis, arr, out_dims=out_dims)
     jnp_fun = lambda arr: jnp.apply_along_axis(func, axis, arr, out_dims=out_dims)
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker,
+                            atol={dtypes.bfloat16: 2e-2})
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_func={}_keepdims={}_axes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          func, keepdims, axes),
-        "shape": shape, "dtype": dtype, "func": func, "keepdims": keepdims, "axes": axes}
+  @jtu.sample_product(
+    [dict(shape=shape, axes=axes)
       for shape in nonempty_shapes
-      for func in ["sum"]
-      for keepdims in [True, False]
       for axes in itertools.combinations(range(len(shape)), 2)
-      # Avoid low-precision types in sum()
-      for dtype in default_dtypes if dtype not in [np.float16, jnp.bfloat16]))
+    ],
+    func=["sum"],
+    keepdims=[True, False],
+    # Avoid low-precision types in sum()
+    dtype=[dtype for dtype in default_dtypes
+           if dtype not in [np.float16, jnp.bfloat16]],
+  )
   def testApplyOverAxes(self, shape, dtype, func, keepdims, axes):
     f = lambda x, axis: getattr(x, func)(axis=axis, keepdims=keepdims)
     rng = jtu.rand_default(self.rng())
@@ -1767,16 +1681,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape=[{}]_axis={}_repeats={}_fixed_size={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          axis, repeats, fixed_size),
-       "axis": axis, "shape": shape, "dtype": dtype, "repeats": repeats,
-       'fixed_size': fixed_size}
-      for repeats in [0, 1, 2]
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype, axis=axis)
       for shape, dtype in _shape_and_dtypes(all_shapes, default_dtypes)
       for axis in [None] + list(range(-len(shape), max(1, len(shape))))
-      for fixed_size in [True, False]))
+    ],
+    repeats=[0, 1, 2],
+    fixed_size=[False, True],
+  )
   def testRepeat(self, axis, shape, dtype, repeats, fixed_size):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.repeat(arg, repeats=repeats, axis=axis)
@@ -1804,19 +1716,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jaxpr = jax.make_jaxpr(f)(a)
     self.assertLessEqual(len(jaxpr.jaxpr.eqns), 6)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_ind={}_inv={}_count={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis,
-          return_index, return_inverse, return_counts),
-       "shape": shape, "dtype": dtype, "axis": axis,
-       "return_index": return_index, "return_inverse": return_inverse,
-       "return_counts": return_counts}
-      for dtype in number_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in all_shapes
-      for axis in [None] + list(range(len(shape)))
-      for return_index in [False, True]
-      for return_inverse in [False, True]
-      for return_counts in [False, True]))
+      for axis in [None] + list(range(len(shape)))],
+    dtype=number_dtypes,
+    return_index=[False, True],
+    return_inverse=[False, True],
+    return_counts=[False, True],
+  )
   def testUnique(self, shape, dtype, axis, return_index, return_inverse, return_counts):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1826,16 +1734,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda x: jnp.unique(x, *extra_args, axis=axis)
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_size={}_fill_value={}".format(
-         jtu.format_shape_dtype_string(shape, dtype), axis, size, fill_value),
-       "shape": shape, "dtype": dtype, "axis": axis,
-       "size": size, "fill_value": fill_value}
-      for dtype in number_dtypes
-      for size in [1, 5, 10]
-      for fill_value in [None, -1.0, "slice"]
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_array_shapes
-      for axis in [None] + list(range(len(shape)))))
+      for axis in [None] + list(range(len(shape)))],
+    dtype=number_dtypes,
+    size=[1, 5, 10],
+    fill_value=[None, -1.0, "slice"],
+  )
   def testUniqueSize(self, shape, dtype, axis, size, fill_value):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -1882,9 +1788,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker)
 
   @unittest.skipIf(numpy_version < (1, 21), "Numpy < 1.21 does not properly handle NaN values in unique.")
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_{dtype.__name__}", "dtype": dtype}
-      for dtype in inexact_dtypes))
+  @jtu.sample_product(dtype=inexact_dtypes)
   def testUniqueNans(self, dtype):
     if numpy_version == (1, 23, 0) and dtype == np.float16:
       # https://github.com/numpy/numpy/issues/21838
@@ -1907,10 +1811,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_fixed_size={fixed_size}",
-      "fixed_size": fixed_size}
-      for fixed_size in [True, False]))
+  @jtu.sample_product(fixed_size=[False, True])
   def testNonScalarRepeats(self, fixed_size):
     '''
     Following numpy test suite from `test_repeat` at
@@ -1982,21 +1883,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertAllClose(np_input, expected_np_input_after_call)
     self.assertAllClose(jnp_input, expected_jnp_input_after_call)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "op={}_xshape=[{}]_yshape=[{}]_mode={}".format(
-          op,
-          jtu.format_shape_dtype_string(xshape, dtype),
-          jtu.format_shape_dtype_string(yshape, dtype),
-          mode),
-       "xshape": xshape, "yshape": yshape, "dtype": dtype, "mode": mode,
-       "jnp_op": getattr(jnp, op),
-       "np_op": getattr(np, op)}
-      for mode in ['full', 'same', 'valid']
-      for op in ['convolve', 'correlate']
-      for dtype in number_dtypes
-      for xshape in one_dim_array_shapes
-      for yshape in one_dim_array_shapes))
-  def testConvolutions(self, xshape, yshape, dtype, mode, jnp_op, np_op):
+  @jtu.sample_product(
+    mode=['full', 'same', 'valid'],
+    op=['convolve', 'correlate'],
+    dtype=number_dtypes,
+    xshape=one_dim_array_shapes,
+    yshape=one_dim_array_shapes,
+  )
+  def testConvolutions(self, xshape, yshape, dtype, mode, op):
+    jnp_op = getattr(jnp, op)
+    np_op = getattr(np, op)
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(xshape, dtype), rng(yshape, dtype)]
     precision = lax.Precision.HIGHEST if jtu.device_under_test() == "tpu" else None
@@ -2008,21 +1904,22 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
-          op, jtu.format_shape_dtype_string(shape, dtype), axis,
-          out_dtype.__name__),
-       "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
-       "jnp_op": getattr(jnp, op), "np_op": getattr(np, op)}
-      for op in ["cumsum", "cumprod"]
-      for dtype in all_dtypes
-      for out_dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in all_shapes
-      for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op):
+      for axis in [None] + list(range(-len(shape), len(shape)))],
+    op=["cumsum", "cumprod"],
+    dtype=all_dtypes,
+    out_dtype=default_dtypes,
+  )
+  def testCumSumProd(self, axis, shape, dtype, out_dtype, op):
+    jnp_op = getattr(jnp, op)
+    np_op = getattr(np, op)
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np_op(arg, axis=axis, dtype=out_dtype)
     np_fun = jtu.ignore_warning(category=np.ComplexWarning)(np_fun)
+    np_fun = jtu.ignore_warning(category=RuntimeWarning,
+                                message="overflow encountered.*")(np_fun)
     jnp_fun = lambda arg: jnp_op(arg, axis=axis, dtype=out_dtype)
     jnp_fun = jtu.ignore_warning(category=jnp.ComplexWarning)(jnp_fun)
 
@@ -2035,27 +1932,28 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "op={}_shape=[{}]_axis={}_out_dtype={}".format(
-          op, jtu.format_shape_dtype_string(shape, dtype), axis,
-          out_dtype.__name__),
-       "axis": axis, "shape": shape, "dtype": dtype, "out_dtype": out_dtype,
-       "jnp_op": getattr(jnp, op), "np_op": getattr(np, op)}
-      for op in ["nancumsum", "nancumprod"]
-      for dtype in all_dtypes
-      for out_dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in all_shapes
-      for axis in [None] + list(range(-len(shape), len(shape)))))
-  def testNanCumSumProd(self, axis, shape, dtype, out_dtype, np_op, jnp_op):
+      for axis in [None] + list(range(-len(shape), len(shape)))],
+    op=["nancumsum", "nancumprod"],
+    dtype=all_dtypes,
+    out_dtype=default_dtypes,
+  )
+  def testNanCumSumProd(self, axis, shape, dtype, out_dtype, op):
+    jnp_op = getattr(jnp, op)
+    np_op = getattr(np, op)
     rng = jtu.rand_some_nan(self.rng())
     np_fun = partial(np_op, axis=axis, dtype=out_dtype)
     np_fun = jtu.ignore_warning(category=np.ComplexWarning)(np_fun)
+    np_fun = jtu.ignore_warning(category=RuntimeWarning,
+                                message="overflow encountered.*")(np_fun)
     jnp_fun = partial(jnp_op, axis=axis, dtype=out_dtype)
     jnp_fun = jtu.ignore_warning(category=jnp.ComplexWarning)(jnp_fun)
 
     args_maker = lambda: [rng(shape, dtype)]
 
-    tol_thresholds = {dtypes.bfloat16: 4e-2}
+    tol_thresholds = {dtypes.bfloat16: 4e-2, np.float16: 3e-3}
     tol = max(jtu.tolerance(dtype, tol_thresholds),
               jtu.tolerance(out_dtype, tol_thresholds))
     if dtype != jnp.bfloat16:
@@ -2064,23 +1962,20 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                               tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_yshape={}_xshape={}_dx={}_axis={}".format(
-        jtu.format_shape_dtype_string(yshape, dtype),
-        jtu.format_shape_dtype_string(xshape, dtype) if xshape is not None else None,
-        dx, axis),
-        "yshape": yshape, "xshape": xshape, "dtype": dtype, "dx": dx, "axis": axis}
-        for dtype in default_dtypes
-        for yshape, xshape, dx, axis in [
-          ((10,), None, 1.0, -1),
-          ((3, 10), None, 2.0, -1),
-          ((3, 10), None, 3.0, -0),
-          ((10, 3), (10,), 1.0, -2),
-          ((3, 10), (10,), 1.0, -1),
-          ((3, 10), (3, 10), 1.0, -1),
-          ((2, 3, 10), (3, 10), 1.0, -2),
-        ]))
+  @jtu.sample_product(
+    [dict(yshape=yshape, xshape=xshape, dx=dx, axis=axis)
+      for yshape, xshape, dx, axis in [
+        ((10,), None, 1.0, -1),
+        ((3, 10), None, 2.0, -1),
+        ((3, 10), None, 3.0, -0),
+        ((10, 3), (10,), 1.0, -2),
+        ((3, 10), (10,), 1.0, -1),
+        ((3, 10), (3, 10), 1.0, -1),
+        ((2, 3, 10), (3, 10), 1.0, -2),
+      ]
+    ],
+    dtype=default_dtypes,
+  )
   @jtu.skip_on_devices("tpu")  # TODO(jakevdp): fix and reenable this test.
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testTrapz(self, yshape, xshape, dtype, dx, axis):
@@ -2095,14 +1990,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, atol=tol, rtol=tol,
                           check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dtype={}_m={}_n={}_k={}".format(
-          np.dtype(dtype).name, m, n, k),
-       "m": m, "n": n, "k": k, "dtype": dtype}
-      for dtype in default_dtypes
-      for n in [0, 4]
-      for m in [None, 0, 1, 3, 4]
-      for k in list(range(-4, 4))))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    n=[0, 4],
+    m=[None, 0, 1, 3, 4],
+    k=list(range(-4, 4)),
+  )
   def testTri(self, m, n, k, dtype):
     np_fun = lambda: np.tri(n, M=m, k=k, dtype=dtype)
     jnp_fun = lambda: jnp.tri(n, M=m, k=k, dtype=dtype)
@@ -2110,14 +2003,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_shape={}_k={}".format(
-          op, jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "op": op, "k": k}
-      for dtype in default_dtypes
-      for shape in [shape for shape in all_shapes if len(shape) >= 2]
-      for op in ["tril", "triu"]
-      for k in list(range(-3, 3))))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=[shape for shape in all_shapes if len(shape) >= 2],
+    op=["tril", "triu"],
+    k=list(range(-3, 3)),
+  )
   def testTriLU(self, dtype, shape, op, k):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: getattr(np, op)(arg, k=k)
@@ -2126,37 +2017,33 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": f"n={n}_k={k}_m={m}",
-      "n": n, "k": k, "m": m}
-    for n in range(1, 5)
-    for k in [-1, 0, 1]
-    for m in range(1, 5)))
+  @jtu.sample_product(
+    n=range(1, 5),
+    k=[-1, 0, 1],
+    m=range(1, 5),
+  )
   def testTrilIndices(self, n, k, m):
     np_fun = lambda n, k, m: np.tril_indices(n, k=k, m=m)
     jnp_fun = lambda n, k, m: jnp.tril_indices(n, k=k, m=m)
     args_maker = lambda: [n, k, m]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": f"n={n}_k={k}_m={m}",
-      "n": n, "k": k, "m": m}
-    for n in range(1, 5)
-    for k in [-1, 0, 1]
-    for m in range(1, 5)))
+  @jtu.sample_product(
+    n=range(1, 5),
+    k=[-1, 0, 1],
+    m=range(1, 5),
+  )
   def testTriuIndices(self, n, k, m):
     np_fun = lambda n, k, m: np.triu_indices(n, k=k, m=m)
     jnp_fun = lambda n, k, m: jnp.triu_indices(n, k=k, m=m)
     args_maker = lambda: [n, k, m]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_shape={}_k={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), k),
-      "dtype": dtype, "shape": shape, "k": k}
-    for dtype in default_dtypes
-    for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
-    for k in [-1, 0, 1]))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=[(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)],
+    k=[-1, 0, 1],
+  )
   def testTriuIndicesFrom(self, shape, dtype, k):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arr, k: np.triu_indices_from(arr, k=k)
@@ -2164,13 +2051,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype), k]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_shape={}_k={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), k),
-      "dtype": dtype, "shape": shape, "k": k}
-    for dtype in default_dtypes
-    for shape in [(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)]
-    for k in [-1, 0, 1]))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=[(1,1), (1,2), (2,2), (2,3), (3,2), (3,3), (4,4)],
+    k=[-1, 0, 1],
+  )
   def testTrilIndicesFrom(self, shape, dtype, k):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arr, k: np.tril_indices_from(arr, k=k)
@@ -2178,22 +2063,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng(shape, dtype), k]
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_ndim={ndim}_n={n}",
-       "ndim": ndim, "n": n}
-      for ndim in [0, 1, 4]
-      for n in [0, 1, 7]))
+  @jtu.sample_product(
+    ndim=[0, 1, 4],
+    n=[0, 1, 7],
+  )
   def testDiagIndices(self, ndim, n):
     np.testing.assert_equal(jtu.with_jax_dtype_defaults(np.diag_indices)(n, ndim),
                             jnp.diag_indices(n, ndim))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "arr_shape={}".format(
-        jtu.format_shape_dtype_string(shape, dtype)
-      ),
-       "dtype": dtype, "shape": shape}
-      for dtype in default_dtypes
-      for shape in [(1,1), (2,2), (3,3), (4,4), (5,5)]))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=[(1,1), (2,2), (3,3), (4,4), (5,5)],
+  )
   def testDiagIndicesFrom(self, dtype, shape):
     rng = jtu.rand_default(self.rng())
     np_fun = jtu.with_jax_dtype_defaults(np.diag_indices_from)
@@ -2202,13 +2083,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_k={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "k": k}
-      for dtype in default_dtypes
-      for shape in [shape for shape in all_shapes if len(shape) in (1, 2)]
-      for k in list(range(-4, 4))))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=[shape for shape in all_shapes if len(shape) in (1, 2)],
+    k=list(range(-4, 4)),
+  )
   def testDiag(self, shape, dtype, k):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.diag(arg, k)
@@ -2217,13 +2096,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_k={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), k),
-       "dtype": dtype, "shape": shape, "k": k}
-      for dtype in default_dtypes
-      for shape in all_shapes
-      for k in range(-4, 4)))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    shape=all_shapes,
+    k=list(range(-4, 4)),
+  )
   def testDiagFlat(self, shape, dtype, k):
     rng = jtu.rand_default(self.rng())
     # numpy has inconsistencies for scalar values
@@ -2235,14 +2112,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=True)
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=True)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_a1_shape={}_a2_shape2={}".format(
-          jtu.format_shape_dtype_string(a1_shape, dtype),
-          jtu.format_shape_dtype_string(a2_shape, dtype)),
-       "dtype": dtype, "a1_shape": a1_shape, "a2_shape": a2_shape}
-      for dtype in default_dtypes
-      for a1_shape in one_dim_array_shapes
-      for a2_shape in one_dim_array_shapes))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a1_shape=one_dim_array_shapes,
+    a2_shape=one_dim_array_shapes,
+  )
   def testPolyMul(self, a1_shape, a2_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polymul(arg1, arg2)
@@ -2253,19 +2127,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun_np, args_maker, check_dtypes=False, tol=tol)
     self._CompileAndCheck(jnp_fun_co, args_maker, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "a_shape={} , b_shape={}".format(
-          jtu.format_shape_dtype_string(a_shape, dtype),
-          jtu.format_shape_dtype_string(b_shape, dtype)),
-       "dtype": dtype, "a_shape": a_shape, "b_shape" : b_shape}
-      for dtype in default_dtypes
-      for a_shape in one_dim_array_shapes
-      for b_shape in one_dim_array_shapes))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    a_shape=one_dim_array_shapes,
+    b_shape=one_dim_array_shapes,
+  )
   def testPolyDiv(self, a_shape, b_shape, dtype):
     rng = jtu.rand_default(self.rng())
 
     @jtu.ignore_warning(category=RuntimeWarning, message="divide by zero.*")
     @jtu.ignore_warning(category=RuntimeWarning, message="invalid value.*")
+    @jtu.ignore_warning(category=RuntimeWarning, message="overflow encountered.*")
     def np_fun(arg1, arg2):
       q, r = np.polydiv(arg1, arg2)
       while r.size < max(arg1.size, arg2.size): # Pad residual to same size
@@ -2291,17 +2163,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_compile, args_maker, check_dtypes=True, atol=tol, rtol=tol)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_offset={}_axis1={}_axis2={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), offset, axis1, axis2),
-       "dtype": dtype, "shape": shape, "offset": offset, "axis1": axis1,
-       "axis2": axis2}
-      for dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis1=axis1, axis2=axis2)
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in [a for a in range(-len(shape), len(shape))
                     if a % len(shape) != axis1 % len(shape)]
-      for offset in list(range(-4, 4))))
+    ],
+    dtype=default_dtypes,
+    offset=list(range(-4, 4)),
+  )
   def testDiagonal(self, shape, dtype, offset, axis1, axis2):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg: np.diagonal(arg, offset, axis1, axis2)
@@ -2310,11 +2181,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_shape={np.dtype(dtype).name}_n={n}",
-       "dtype": dtype, "n": n}
-      for dtype in default_dtypes
-      for n in list(range(4))))
+  @jtu.sample_product(
+    dtype=default_dtypes,
+    n=list(range(4)),
+  )
   def testIdentity(self, n, dtype):
     np_fun = lambda: np.identity(n, dtype)
     jnp_fun = lambda: jnp.identity(n, dtype)
@@ -2322,46 +2192,35 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_period={}_left={}_right={}_target_dtype={}".format(
-         jtu.format_shape_dtype_string(shape, dtype), period, left, right,
-         target_dtype.__name__),
-       "shape": shape, "dtype": dtype, "target_dtype": target_dtype,
-       "period": period, "left": left, "right": right}
-      for shape in nonempty_shapes
-      for period in [None, 0.59]
-      for left in [None, 0]
-      for right in [None, 1]
-      # Note: skip 8-bit and 16-bit types due to insufficient precision.
-      for dtype in jtu.dtypes.integer + jtu.dtypes.floating
-      for target_dtype in jtu.dtypes.inexact
-  ))
+  @jtu.sample_product(
+    shape=nonempty_shapes,
+    period=[None, 0.59],
+    left=[None, 0],
+    right=[None, 1],
+    # Note: skip 8-bit and 16-bit types due to insufficient precision.
+    dtype=jtu.dtypes.integer + jtu.dtypes.floating,
+    target_dtype=jtu.dtypes.inexact,
+  )
   def testInterp(self, shape, dtype, period, left, right, target_dtype):
     rng = jtu.rand_default(self.rng(), scale=10)
     kwds = dict(period=period, left=left, right=right)
     np_fun = partial(np.interp, **kwds)
     jnp_fun = partial(jnp.interp, **kwds)
 
-    args_maker = lambda: [rng(shape, dtype), np.sort(rng((20,), dtype)),
+    args_maker = lambda: [rng(shape, dtype), np.unique(rng((100,), dtype))[:20],
                           rng((20,), target_dtype)]
 
     with jtu.strict_promotion_if_dtypes_match([dtype, target_dtype]):
-      # skip numpy comparison for integer types with period specified, because numpy
-      # uses an unstable sort and so results differ for duplicate values.
-      if not (period and np.issubdtype(dtype, np.integer)):
-        self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False,
-                                rtol=1E-3)
+      self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False,
+                              rtol=3e-3, atol=1e-3)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dtype={}_period={}_left={}_right={}".format(
-         dtype, period, left, right),
-       "dtype": dtype, "period": period, "left": left, "right": right}
-      for period in [None, 0.59]
-      for left in [None, 0]
-      for right in [None, 1]
-      for dtype in jtu.dtypes.floating
-  ))
+  @jtu.sample_product(
+    period=[None, 0.59],
+    left=[None, 0],
+    right=[None, 1],
+    dtype=jtu.dtypes.floating,
+  )
   def testInterpGradNan(self, dtype, period, left, right):
     kwds = dict(period=period, left=left, right=right)
     jnp_fun = partial(jnp.interp, **kwds)
@@ -2370,20 +2229,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     g = jax.grad(lambda z: jnp.sum(jnp_fun(z, z, jnp.ones_like(z))))(x)
     np.testing.assert_equal(np.all(np.isfinite(g)), True)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_x1={}_x2={}_x1_rng={}".format(
-          jtu.format_shape_dtype_string(x1_shape, x1_dtype),
-          jtu.format_shape_dtype_string(x2_shape, np.int32),
-          x1_rng_factory_id),
-       "x1_shape": x1_shape, "x1_dtype": x1_dtype,
-       "x2_shape": x2_shape, "x1_rng_factory": x1_rng_factory,
-       "x2_rng_factory": x2_rng_factory}
-      for x1_rng_factory_id, x1_rng_factory in
-        enumerate([jtu.rand_some_inf_and_nan, jtu.rand_some_zero])
-      for x2_rng_factory in [partial(jtu.rand_int, low=-1075, high=1024)]
-      for x1_shape, x2_shape in filter(_shapes_are_broadcast_compatible,
-                                       itertools.combinations_with_replacement(array_shapes, 2))
-      for x1_dtype in default_dtypes))
+  @jtu.sample_product(
+    [dict(x1_shape=x1_shape, x2_shape=x2_shape)
+     for x1_shape, x2_shape in filter(_shapes_are_broadcast_compatible,
+                                      itertools.combinations_with_replacement(array_shapes, 2))
+    ],
+    x1_rng_factory=[jtu.rand_some_inf_and_nan, jtu.rand_some_zero],
+    x2_rng_factory=[partial(jtu.rand_int, low=-1075, high=1024)],
+    x1_dtype=default_dtypes,
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLdexp(self, x1_shape, x1_dtype, x2_shape, x1_rng_factory, x2_rng_factory):
     x1_rng = x1_rng_factory(self.rng())
@@ -2400,17 +2254,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_x={}_rng_factory={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), rng_factory_id),
-       "shape": shape, "dtype": dtype, "rng_factory": rng_factory}
-      for rng_factory_id, rng_factory in enumerate([
+  @jtu.sample_product(
+      rng_factory=[
           jtu.rand_some_inf_and_nan,
           jtu.rand_some_zero,
           partial(jtu.rand_not_small, offset=1e8),
-      ])
-      for shape in all_shapes
-      for dtype in default_dtypes))
+      ],
+      shape=all_shapes,
+      dtype=default_dtypes,
+  )
   def testFrexp(self, shape, dtype, rng_factory):
     # integer types are converted to float64 in numpy's implementation
     if (dtype not in [jnp.bfloat16, np.float16, np.float32]
@@ -2424,20 +2276,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             check_dtypes=np.issubdtype(dtype, np.inexact))
     self._CompileAndCheck(jnp_fun, args_maker)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_dtype_{}_offset={}_axis1={}_axis2={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          out_dtype, offset, axis1, axis2),
-       "dtype": dtype, "out_dtype": out_dtype, "shape": shape, "offset": offset,
-       "axis1": axis1, "axis2": axis2}
-      for dtype in default_dtypes
-      for out_dtype in [None] + number_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis1=axis1, axis2=axis2)
       for shape in [shape for shape in all_shapes if len(shape) >= 2]
       for axis1 in range(-len(shape), len(shape))
       for axis2 in range(-len(shape), len(shape))
       if (axis1 % len(shape)) != (axis2 % len(shape))
-      for offset in list(range(-4, 4))))
+    ],
+    dtype=default_dtypes,
+    out_dtype=[None] + number_dtypes,
+    offset=list(range(-4, 4)),
+  )
   def testTrace(self, shape, dtype, out_dtype, offset, axis1, axis2):
     rng = jtu.rand_default(self.rng())
     def np_fun(arg):
@@ -2447,21 +2296,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         return np.trace(arg, offset, axis1, axis2, out_dtype)
     jnp_fun = lambda arg: jnp.trace(arg, offset, axis1, axis2, out_dtype)
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
+    # TODO: Fails with uint8/uint16 output dtypes (integer overflow?)
+    if out_dtype not in (np.uint8, np.uint16, np.uint32):
+      self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_a={}_v={}_side={}_method={}".format(
-      jtu.format_shape_dtype_string(ashape, dtype),
-      jtu.format_shape_dtype_string(vshape, dtype),
-      side, method), "ashape": ashape, "vshape": vshape, "side": side,
-     "dtype": dtype, "method": method}
-    for ashape in [(15,), (16,), (17,)]
-    for vshape in [(), (5,), (5, 5)]
-    for side in ['left', 'right']
-    for dtype in number_dtypes
-    for method in ['sort', 'scan']
-  ))
+  @jtu.sample_product(
+    ashape=[(15,), (16,), (17,)],
+    vshape=[(), (5,), (5, 5)],
+    side=['left', 'right'],
+    dtype=number_dtypes,
+    method=['sort', 'scan'],
+  )
   def testSearchsorted(self, ashape, vshape, side, dtype, method):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [np.sort(rng(ashape, dtype)), rng(vshape, dtype)]
@@ -2488,12 +2334,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       with self.assertWarnsRegex(UserWarning, "Explicitly requested dtype int64"):
         out_int64 = jax.eval_shape(jnp.searchsorted, a_int64, v)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": f"_dtype={dtype.__name__}_side={side}_method={method}",
-     "dtype": dtype, "side": side, "method": method}
-    for dtype in inexact_dtypes
-    for side in ['left', 'right']
-    for method in ['sort', 'scan']))
+  @jtu.sample_product(
+    dtype=inexact_dtypes,
+    side=['left', 'right'],
+    method=['sort', 'scan'],
+  )
   def testSearchsortedNans(self, dtype, side, method):
     if np.issubdtype(dtype, np.complexfloating):
       raise SkipTest("Known failure for complex inputs; see #9107")
@@ -2510,18 +2355,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertArraysEqual(fun(x, x), fun(x_equiv, x_equiv))
     self.assertArraysEqual(jax.jit(fun)(x, x), fun(x_equiv, x_equiv))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_x={}_bins={}_right={}_reverse={}".format(
-      jtu.format_shape_dtype_string(xshape, dtype),
-      jtu.format_shape_dtype_string(binshape, dtype),
-      right, reverse), "xshape": xshape, "binshape": binshape,
-      "right": right, "reverse": reverse, "dtype": dtype}
-    for xshape in [(20,), (5, 4)]
-    for binshape in [(1,), (5,)]
-    for right in [True, False]
-    for reverse in [True, False]
-    for dtype in default_dtypes
-  ))
+  @jtu.sample_product(
+    xshape=[(20,), (5, 4)],
+    binshape=[(1,), (5,)],
+    right=[True, False],
+    reverse=[True, False],
+    dtype=default_dtypes,
+  )
   def testDigitize(self, xshape, binshape, right, reverse, dtype):
     order = jnp.index_exp[::-1] if reverse else jnp.index_exp[:]
     rng = jtu.rand_default(self.rng())
@@ -2531,19 +2371,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_array={}".format(
-          jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), array_input),
-       "shape": shape, "dtypes": dtypes, "array_input": array_input}
-      for dtypes in [
-        [np.float32],
-        [np.float32, np.float32],
-        [np.float32, np.int32, np.float32],
-        [np.float32, np.int64, np.float32],
-        [np.float32, np.int32, np.float64],
-      ]
-      for shape in [(), (2,), (3, 4), (1, 5)]
-      for array_input in [True, False]))
+  @jtu.sample_product(
+    dtypes=[
+      [np.float32],
+      [np.float32, np.float32],
+      [np.float32, np.int32, np.float32],
+      [np.float32, np.int64, np.float32],
+      [np.float32, np.int32, np.float64],
+    ],
+    shape=[(), (2,), (3, 4), (1, 5)],
+    array_input=[True, False],
+  )
   def testColumnStack(self, shape, dtypes, array_input):
     rng = jtu.rand_default(self.rng())
     if array_input:
@@ -2556,23 +2394,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "{}_axis={}_array={}_out={}".format(
-          jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), axis, array_input,
-          np.dtype(out_dtype).name),
-       "shape": shape, "axis": axis, "dtypes": dtypes, "array_input": array_input,
-       "out_dtype": out_dtype}
-      for dtypes in [
-        [np.float32],
-        [np.float32, np.float32],
-        [np.float32, np.int32, np.float32],
-        [np.float32, np.int64, np.float32],
-        [np.float32, np.int32, np.float64],
-      ]
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in [(), (2,), (3, 4), (1, 100)]
       for axis in range(-len(shape), len(shape) + 1)
-      for array_input in [True, False]
-      for out_dtype in [np.float32, np.int32]))
+    ],
+    dtypes=[
+      [np.float32],
+      [np.float32, np.float32],
+      [np.float32, np.int32, np.float32],
+      [np.float32, np.int64, np.float32],
+      [np.float32, np.int32, np.float64],
+    ],
+    array_input=[True, False],
+    out_dtype=[np.float32, np.int32],
+  )
   def testStack(self, shape, axis, dtypes, array_input, out_dtype):
     rng = jtu.rand_default(self.rng())
     if array_input:
@@ -2590,22 +2426,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_{}_array={}_out={}".format(
-          op, jtu.format_test_name_suffix("", [shape] * len(dtypes), dtypes), array_input,
-          np.dtype(out_dtype).name),
-       "shape": shape, "op": op, "dtypes": dtypes, "array_input": array_input, "out_dtype": out_dtype}
-      for op in ["hstack", "vstack", "dstack"]
-      for dtypes in [
-        [np.float32],
-        [np.float32, np.float32],
-        [np.float32, np.int32, np.float32],
-        [np.float32, np.int64, np.float32],
-        [np.float32, np.int32, np.float64],
-      ]
-      for shape in [(), (2,), (3, 4), (1, 100), (2, 3, 4)]
-      for array_input in [True, False]
-      for out_dtype in [np.float32, np.int32]))
+  @jtu.sample_product(
+    op=["hstack", "vstack", "dstack"],
+    dtypes=[
+      [np.float32],
+      [np.float32, np.float32],
+      [np.float32, np.int32, np.float32],
+      [np.float32, np.int64, np.float32],
+      [np.float32, np.int32, np.float64],
+    ],
+    shape=[(), (2,), (3, 4), (1, 100), (2, 3, 4)],
+    array_input=[True, False],
+    out_dtype=[np.float32, np.int32],
+  )
   def testHVDStack(self, shape, op, dtypes, array_input, out_dtype):
     rng = jtu.rand_default(self.rng())
     if array_input:
@@ -2623,17 +2456,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outdtype={}_fillshape={}".format(
-          jtu.format_shape_dtype_string(shape, fill_value_dtype),
-          np.dtype(out_dtype).name if out_dtype else "None",
-          fill_value_shape),
-       "fill_value_dtype": fill_value_dtype, "fill_value_shape": fill_value_shape,
-       "shape": shape, "out_dtype": out_dtype}
+  @jtu.sample_product(
+    [dict(shape=shape, fill_value_shape=fill_value_shape)
       for shape in array_shapes + [3, np.array(7, dtype=np.int32)]
-      for fill_value_dtype in default_dtypes
-      for fill_value_shape in _compatible_shapes(shape)
-      for out_dtype in [None] + default_dtypes))
+      for fill_value_shape in _compatible_shapes(shape)],
+    fill_value_dtype=default_dtypes,
+    out_dtype=[None] + default_dtypes,
+  )
   def testFull(self, shape, fill_value_dtype, fill_value_shape, out_dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda fill_value: np.full(shape, fill_value, dtype=out_dtype)
@@ -2642,19 +2471,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
-      "testcase_name": "_shape={}_n={}_axis={}_prepend={}_append={}".format(
-           jtu.format_shape_dtype_string(shape, dtype),
-           n, axis, prepend, append),
-        "shape": shape, "dtype": dtype, "n": n, "axis": axis,
-        "prepend": prepend, "append": append
-    } for shape, dtype in s(_shape_and_dtypes(nonempty_nonscalar_array_shapes, default_dtypes))
-      for n in s([0, 1, 2])
-      for axis in s(list(range(-len(shape), max(1, len(shape)))))
-      for prepend in s([None, 1, np.zeros(shape, dtype=dtype)])
-      for append in s([None, 1, np.zeros(shape, dtype=dtype)])
-      )))
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype, axis=axis)
+      for shape, dtype in _shape_and_dtypes(nonempty_nonscalar_array_shapes, default_dtypes)
+      for axis in list(range(-len(shape), max(1, len(shape))))
+    ],
+    prepend=[None, 1, 0],
+    append=[None, 1, 0],
+    n=[0, 1, 2],
+  )
   def testDiff(self, shape, dtype, n, axis, prepend, append):
+    prepend = np.zeros(shape, dtype=dtype) if prepend == 0 else prepend
+    append = np.zeros(shape, dtype=dtype) if append == 0 else append
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
 
@@ -2678,16 +2506,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker, check_dtypes=False)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(
-    jtu.cases_from_list(
-      {"testcase_name": ("_op={}_shape={}_dtype={}").format(op, shape, dtype),
-       "np_op": getattr(np, op), "jnp_op": getattr(jnp, op),
-       "shape": shape, "dtype": dtype}
-      for op in ["zeros", "ones"]
-      for shape in [2, (), (2,), (3, 0), np.array((4, 5, 6), dtype=np.int32),
-                    np.array(4, dtype=np.int32)]
-      for dtype in all_dtypes))
-  def testZerosOnes(self, np_op, jnp_op, shape, dtype):
+  @jtu.sample_product(
+    op=["zeros", "ones"],
+    shape=[2, (), (2,), (3, 0), np.array((4, 5, 6), dtype=np.int32),
+           np.array(4, dtype=np.int32)],
+    dtype=all_dtypes,
+  )
+  def testZerosOnes(self, op, shape, dtype):
+    np_op = getattr(np, op)
+    jnp_op = getattr(jnp, op)
     args_maker = lambda: []
     np_op = partial(np_op, shape, dtype)
     jnp_op = partial(jnp_op, shape, dtype)
@@ -2698,20 +2525,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaises(TypeError):
       jnp.ones((-1, 1))
 
-  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
-       "testcase_name": "_inshape={}_filldtype={}_fillshape={}_outdtype={}_outshape={}".format(
-          jtu.format_shape_dtype_string(shape, in_dtype),
-          np.dtype(fill_value_dtype).name, fill_value_shape,
-          np.dtype(out_dtype).name, out_shape),
-       "shape": shape, "in_dtype": in_dtype,
-       "fill_value_dtype": fill_value_dtype, "fill_value_shape": fill_value_shape,
-       "out_dtype": out_dtype, "out_shape": out_shape
-    } for shape in s(array_shapes)
-      for out_shape in s([None] + array_shapes)
-      for in_dtype in s(default_dtypes)
-      for fill_value_dtype in s(default_dtypes)
-      for fill_value_shape in s(_compatible_shapes(shape if out_shape is None else out_shape))
-      for out_dtype in s(default_dtypes))))
+  @jtu.sample_product(
+    [dict(shape=shape, out_shape=out_shape, fill_value_shape=fill_value_shape)
+      for shape in array_shapes
+      for out_shape in [None] + array_shapes
+      for fill_value_shape in _compatible_shapes(shape if out_shape is None else out_shape)
+    ],
+    in_dtype=default_dtypes,
+    fill_value_dtype=default_dtypes,
+    out_dtype=default_dtypes,
+  )
   def testFullLike(self, shape, in_dtype, fill_value_dtype, fill_value_shape, out_dtype, out_shape):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x, fill_value: np.full_like(
@@ -2722,17 +2545,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_func={}_inshape={}_outshape={}_outdtype={}".format(
-          func, jtu.format_shape_dtype_string(shape, in_dtype),
-          out_shape, out_dtype),
-       "func": func, "shape": shape, "in_dtype": in_dtype,
-       "out_shape": out_shape, "out_dtype": out_dtype}
-      for shape in array_shapes
-      for out_shape in [None] + array_shapes
-      for in_dtype in default_dtypes
-      for func in ["ones_like", "zeros_like"]
-      for out_dtype in default_dtypes))
+  @jtu.sample_product(
+    shape=array_shapes,
+    out_shape=[None] + array_shapes,
+    in_dtype=default_dtypes,
+    func=["ones_like", "zeros_like"],
+    out_dtype=default_dtypes,
+  )
   def testZerosOnesLike(self, func, shape, in_dtype, out_shape, out_dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: getattr(np, func)(x, dtype=out_dtype, shape=out_shape)
@@ -2741,20 +2560,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_func={}_inshape={}_weak_type={}_outshape={}_outdtype={}".format(
-          func, jtu.format_shape_dtype_string(shape, in_dtype),
-          weak_type, out_shape, out_dtype),
-       "func": func, "args": args,
-       "shape": shape, "in_dtype": in_dtype, "weak_type": weak_type,
-       "out_shape": out_shape, "out_dtype": out_dtype}
-      for shape in array_shapes
-      for in_dtype in [np.int32, np.float32, np.complex64]
-      for weak_type in [True, False]
-      for out_shape in [None, (), (10,)]
-      for func, args in [("full_like", (-100,)), ("ones_like", ()), ("zeros_like", ())]
-      for out_dtype in [None, float]))
+  @jtu.sample_product(
+    [dict(func=func, args=args)
+     for func, args in [("full_like", (-100,)), ("ones_like", ()), ("zeros_like", ())]
+    ],
+    shape=array_shapes,
+    in_dtype=[np.int32, np.float32, np.complex64],
+    weak_type=[True, False],
+    out_shape=[None, (), (10,)],
+    out_dtype=[None, float],
+  )
   def testZerosOnesFullLikeWeakType(self, func, args, shape, in_dtype, weak_type, out_shape, out_dtype):
     rng = jtu.rand_default(self.rng())
     x = lax_internal._convert_element_type(rng(shape, in_dtype),
@@ -2764,14 +2579,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(dtypes.is_weakly_typed(fun(x)), expected_weak_type)
     self.assertEqual(dtypes.is_weakly_typed(jax.jit(fun)(x)), expected_weak_type)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_funcname={}_input_type={}_val={}_dtype={}".format(
-          funcname, input_type, val, dtype),
-       "funcname": funcname, "input_type": input_type, "val": val, "dtype": dtype}
-      for funcname in ["array", "asarray"]
-      for dtype in [int, float, None]
-      for val in [0, 1]
-      for input_type in [int, float, np.int32, np.float32]))
+  @jtu.sample_product(
+    funcname=["array", "asarray"],
+    dtype=[int, float, None],
+    val=[0, 1],
+    input_type=[int, float, np.int32, np.float32],
+  )
   def testArrayWeakType(self, funcname, input_type, val, dtype):
     func = lambda x: getattr(jnp, funcname)(x, dtype=dtype)
     fjit = jax.jit(func)
@@ -2780,14 +2593,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(dtypes.is_weakly_typed(func(val)), expected_weak_type)
     self.assertEqual(dtypes.is_weakly_typed(fjit(val)), expected_weak_type)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_weak_type={}_slc={}".format(
-        jtu.format_shape_dtype_string(shape, dtype), weak_type, slc),
-       "shape": shape, "dtype": dtype, "weak_type": weak_type, "slc": slc}
-      for shape in nonempty_nonscalar_array_shapes
-      for dtype in [int, float, complex]
-      for weak_type in [True, False]
-      for slc in [slice(None), slice(0), slice(3), 0, ...]))
+  @jtu.sample_product(
+    shape=nonempty_nonscalar_array_shapes,
+    dtype=[int, float, complex],
+    weak_type=[True, False],
+    slc=[slice(None), slice(0), slice(3), 0, ...],
+  )
   def testSliceWeakTypes(self, shape, dtype, weak_type, slc):
     rng = jtu.rand_default(self.rng())
     x = lax_internal._convert_element_type(rng(shape, dtype),
@@ -2796,15 +2607,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self.assertEqual(op(x).aval.weak_type, weak_type)
     self.assertEqual(jax.jit(op)(x).aval.weak_type, weak_type)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_{}sections".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
-       "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis, num_sections=num_sections)
       for shape, axis, num_sections in [
           ((3,), 0, 3), ((12,), 0, 3), ((12, 4), 0, 4), ((12, 4), 1, 2),
           ((2, 3, 4), -1, 2), ((2, 3, 4), -2, 3)]
-      for dtype in default_dtypes))
+    ],
+    dtype=default_dtypes,
+  )
   def testSplitStaticInt(self, shape, num_sections, axis, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.split(x, num_sections, axis=axis)
@@ -2813,15 +2623,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_{}sections".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
-       "shape": shape, "num_sections": num_sections, "axis": axis, "dtype": dtype}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis, num_sections=num_sections)
       # All testcases split the specified axis unequally
       for shape, axis, num_sections in [
           ((3,), 0, 2), ((12,), 0, 5), ((12, 4), 0, 7), ((12, 4), 1, 3),
           ((2, 3, 5), -1, 2), ((2, 4, 4), -2, 3), ((7, 2, 2), 0, 3)]
-      for dtype in default_dtypes))
+    ],
+    dtype=default_dtypes,
+  )
   def testArraySplitStaticInt(self, shape, num_sections, axis, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.array_split(x, num_sections, axis=axis)
@@ -2849,21 +2659,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jax.jvp(lambda idx: jnp.split(jnp.zeros((12, 2)), (1, idx)),
             (2.,), (1.,))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_{}_bins={}_range={}_weights={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), bins, range, weights),
-      "shape": shape,
-      "dtype": dtype,
-      "bins": bins,
-      "range": range,
-      "weights": weights,
-    }
-    for shape in [(5,), (5, 5)]
-    for dtype in number_dtypes
-    for bins in [10, np.arange(-5, 6), np.array([-5, 0, 3])]
-    for range in [None, (0, 0), (0, 10)]
-    for weights in [True, False]
-  ))
+  @jtu.sample_product(
+    shape=[(5,), (5, 5)],
+    dtype=number_dtypes,
+    bins=[10, np.arange(-5, 6), np.array([-5, 0, 3])],
+    range=[None, (0, 0), (0, 10)],
+    weights=[True, False],
+  )
   def testHistogramBinEdges(self, shape, dtype, bins, range, weights):
     rng = jtu.rand_default(self.rng())
     _weights = lambda w: abs(w) if weights else None
@@ -2879,23 +2681,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker,
                           atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_{}_bins={}_density={}_weights={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), bins, density, weights),
-      "shape": shape,
-      "dtype": dtype,
-      "bins": bins,
-      "density": density,
-      "weights": weights,
-    }
-    for shape in [(5,), (5, 5)]
-    for dtype in default_dtypes
+  @jtu.sample_product(
+    shape=[(5,), (5, 5)],
+    dtype=default_dtypes,
     # We only test explicit integer-valued bin edges because in other cases
     # rounding errors lead to flaky tests.
-    for bins in [np.arange(-5, 6), np.array([-5, 0, 3])]
-    for density in [True, False]
-    for weights in [True, False]
-  ))
+    bins=[np.arange(-5, 6), np.array([-5, 0, 3])],
+    density=[True, False],
+    weights=[True, False],
+  )
   def testHistogram(self, shape, dtype, bins, density, weights):
     rng = jtu.rand_default(self.rng())
     _weights = lambda w: abs(w) if weights else None
@@ -2912,18 +2706,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                               tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_{}_bins={}_weights={}_density={}_range={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), bins, weights, density, range),
-      "shape": shape, "dtype": dtype, "bins": bins, "weights": weights, "density": density, "range": range,
-    }
-    for shape in [(5,), (12,)]
-    for dtype in int_dtypes
-    for bins in [2, [2, 2], [np.array([0, 1, 3, 5]), np.array([0, 2, 3, 4, 6])]]
-    for weights in [False, True]
-    for density in [False, True]
-    for range in [None, [(-1, 1), None], [(-1, 1), (-2, 2)]]
-  ))
+  @jtu.sample_product(
+    shape=[(5,), (12,)],
+    dtype=int_dtypes,
+    bins=[2, [2, 2], [np.array([0, 1, 3, 5]), np.array([0, 2, 3, 4, 6])]],
+    weights=[False, True],
+    density=[False, True],
+    range=[None, [(-1, 1), None], [(-1, 1), (-2, 2)]],
+  )
   def testHistogram2d(self, shape, dtype, bins, weights, density, range):
     rng = jtu.rand_default(self.rng())
     _weights = lambda w: abs(w) if weights else None
@@ -2940,18 +2730,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                           tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": "_{}_bins={}_weights={}_density={}_range={}".format(
-      jtu.format_shape_dtype_string(shape, dtype), bins, weights, density, range),
-      "shape": shape, "dtype": dtype, "bins": bins, "weights": weights, "density": density, "range": range,
-    }
-    for shape in [(5, 3), (10, 3)]
-    for dtype in int_dtypes
-    for bins in [(2, 2, 2), [np.array([-5, 0, 4]), np.array([-4, -1, 2]), np.array([-6, -1, 4])]]
-    for weights in [False, True]
-    for density in [False, True]
-    for range in [None, [(-1, 1), None, None], [(-1, 1), (-2, 2), (-3, 3)]]
-  ))
+  @jtu.sample_product(
+    shape=[(5, 3), (10, 3)],
+    dtype=int_dtypes,
+    bins=[(2, 2, 2), [np.array([-5, 0, 4]), np.array([-4, -1, 2]), np.array([-6, -1, 4])]],
+    weights=[False, True],
+    density=[False, True],
+    range=[None, [(-1, 1), None, None], [(-1, 1), (-2, 2), (-3, 3)]],
+  )
   def testHistogramdd(self, shape, dtype, bins, weights, density, range):
     rng = jtu.rand_default(self.rng())
     _weights = lambda w: abs(w) if weights else None
@@ -2967,15 +2753,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_{}sections".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, num_sections),
-       "shape": shape, "num_sections": num_sections, "axis": axis,
-       "dtype": dtype}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis, num_sections=num_sections)
       for shape, axis, num_sections in [
           ((12, 4), 0, 4), ((12, 4), 1, 2),
-          ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]
-      for dtype in default_dtypes))
+          ((2, 3, 4), 2, 2), ((4, 3, 4), 0, 2)]],
+    dtype=default_dtypes,
+  )
   def testHVDSplit(self, shape, num_sections, axis, dtype):
     rng = jtu.rand_default(self.rng())
     def fn(module, axis):
@@ -2993,15 +2777,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}_order={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype),
-          order),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "order": order}
-      for dtype in default_dtypes
-      for order in ["C", "F"]
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, out_shape=out_shape)
       for arg_shape, out_shape in [
           (jtu.NUMPY_SCALAR_SHAPE, (1, 1, 1)),
           ((), (1, 1, 1)),
@@ -3011,7 +2788,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((3, 4), -1),
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
-      ]))
+      ]
+    ],
+    dtype=default_dtypes,
+    order=["C", "F"],
+  )
   def testReshape(self, arg_shape, out_shape, dtype, order):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.reshape(x, out_shape, order=order)
@@ -3020,17 +2801,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype)),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype}
-      for dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, out_shape=out_shape)
       for arg_shape, out_shape in [
           ((7, 0), (0, 42, 101)),
           ((2, 1, 4), (-1,)),
           ((2, 2, 4), (2, 8))
-      ]))
+      ]
+    ],
+    dtype=default_dtypes,
+  )
   def testReshapeMethod(self, arg_shape, out_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.reshape(x, out_shape)
@@ -3039,13 +2819,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype)),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype}
-      for dtype in default_dtypes
-      for arg_shape, out_shape in itertools.product(all_shapes, array_shapes)))
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, out_shape=out_shape)
+      for arg_shape, out_shape in itertools.product(all_shapes, array_shapes)],
+    dtype=default_dtypes,
+  )
   def testResize(self, arg_shape, out_shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.resize(x, out_shape)
@@ -3054,15 +2832,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_expanddim={!r}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype), dim),
-       "arg_shape": arg_shape, "dtype": dtype, "dim": dim}
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, dim=dim)
       for arg_shape in [(), (3,), (3, 4)]
-      for dtype in default_dtypes
       for dim in (list(range(-len(arg_shape)+1, len(arg_shape)))
                   + [np.array(0), np.array(-1), (0,), [np.array(0)],
-                     (len(arg_shape), len(arg_shape) + 1)])))
+                     (len(arg_shape), len(arg_shape) + 1)])
+    ],
+    dtype=default_dtypes,
+  )
   def testExpandDimsStaticDim(self, arg_shape, dtype, dim):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.expand_dims(x, dim)
@@ -3089,14 +2867,14 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ValueError, 'repeated axis.*',
         lambda: np.expand_dims(x, [3, -1]))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_axes=({},{})".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype), ax1, ax2),
-       "arg_shape": arg_shape, "dtype": dtype, "ax1": ax1, "ax2": ax2}
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, ax1=ax1, ax2=ax2)
       for arg_shape, ax1, ax2 in [
           ((3, 4), 0, 1), ((3, 4), 1, 0), ((3, 4, 5), 1, 2),
           ((3, 4, 5), -1, -2), ((3, 4, 5), 0, 1)]
-      for dtype in default_dtypes))
+    ],
+    dtype=default_dtypes,
+  )
   def testSwapAxesStaticAxes(self, arg_shape, dtype, ax1, ax2):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.swapaxes(x, ax1, ax2)
@@ -3105,10 +2883,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_axis={!r}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype), ax),
-       "arg_shape": arg_shape, "dtype": dtype, "ax": ax}
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, ax=ax)
       for arg_shape, ax in [
           ((3, 1), None),
           ((3, 1), 1),
@@ -3117,7 +2893,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ((1, 3, 1), (0, 2)),
           ((1, 3, 1), (0,)),
           ((1, 4, 1), (np.array(0),))]
-      for dtype in default_dtypes))
+    ],
+    dtype=default_dtypes,
+  )
   def testSqueeze(self, arg_shape, dtype, ax):
     rng = jtu.rand_default(self.rng())
     np_fun = lambda x: np.squeeze(x, ax)
@@ -3126,22 +2904,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_axis={}_weights={}_returned={}_keepdims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          axis,
-          (None if weights_shape is None else jtu.format_shape_dtype_string(weights_shape, dtype)),
-          returned, keepdims),
-       "shape": shape, "dtype": dtype, "axis": axis,
-       "weights_shape": weights_shape, "returned": returned, "keepdims": keepdims}
+  @jtu.sample_product(
+    [dict(shape=shape, dtype=dtype, axis=axis, weights_shape=weights_shape)
       for shape, dtype in _shape_and_dtypes(nonempty_shapes, number_dtypes)
       for axis in list(range(-len(shape), len(shape))) + [None]
       # `weights_shape` is either `None`, same as the averaged axis, or same as
       # that of the input
       for weights_shape in ([None, shape] if axis is None or len(shape) == 1
                             else [None, (shape[axis],), shape])
-      for keepdims in ([False, True] if numpy_version >= (1, 23) else [None])
-      for returned in [False, True]))
+    ],
+    keepdims=([False, True] if numpy_version >= (1, 23) else [None]),
+    returned=[False, True],
+  )
   def testAverage(self, shape, dtype, axis, weights_shape, returned, keepdims):
     rng = jtu.rand_default(self.rng())
     kwds = dict(returned=returned)
@@ -3171,11 +2945,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=check_dtypes,
                           rtol=tol, atol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       f"_arg{i}_ndmin={ndmin}_dtype={np.dtype(dtype) if dtype else None}",
-       "arg": arg, "ndmin": ndmin, "dtype": dtype}
-      for i, (arg, dtypes) in enumerate([
+  @jtu.sample_product(
+    [dict(arg=arg, dtype=dtype, ndmin=ndmin)
+      for arg, dtypes in [
           ([True, False, True], all_dtypes),
           (3., all_dtypes),
           ([1, 2, 3], all_dtypes),
@@ -3186,9 +2958,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
           ([[1., 2j], [3., 4.], [5., 6.]], complex_dtypes),
           ([[3, np.array(2, dtype=jnp.float_), 1],
            np.arange(3., dtype=jnp.float_)], all_dtypes),
-      ])
+      ]
       for dtype in [None] + dtypes
-      for ndmin in [None, np.ndim(arg), np.ndim(arg) + 1, np.ndim(arg) + 2]))
+      for ndmin in [None, np.ndim(arg), np.ndim(arg) + 1, np.ndim(arg) + 2]
+    ],
+  )
   def testArray(self, arg, ndmin, dtype):
     args_maker = lambda: [arg]
     canonical_dtype = dtypes.canonicalize_dtype(dtype or np.array(arg).dtype)
@@ -3243,11 +3017,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     _check([0, np.int16(1)], np.int16, False)
     _check([0.0, np.float16(1)], np.float16, False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_dtype={np.dtype(dtype)}_func={func}",
-       "dtype": dtype, "func": func}
-      for dtype in all_dtypes
-      for func in ["array", "copy", "copy.copy", "copy.deepcopy"]))
+  @jtu.sample_product(
+    dtype=all_dtypes,
+    func=["array", "copy", "copy.copy", "copy.deepcopy"],
+  )
   def testArrayCopy(self, dtype, func):
     x = jnp.ones(10, dtype=dtype)
     if func == "copy.deepcopy":
@@ -3388,9 +3161,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         np.array(bytearray(b'\x2a\xf3'), ndmin=2)
     )
 
-  @parameterized.named_parameters(
-    {'testcase_name': f"_val={val}", 'val': val}
-    for val in [1+1j, [1+1j], jnp.pi, np.arange(2)])
+  @jtu.sample_product(val=[1+1j, [1+1j], jnp.pi, np.arange(2)])
   def testIsComplexObj(self, val):
     args_maker = lambda: [val]
     self._CheckAgainstNumpy(np.iscomplexobj, jnp.iscomplexobj, args_maker)
@@ -3421,12 +3192,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         self.assertTrue(jnp.all(jnp.equal(result_np, result_jax)))
         self.assertTrue(jnp.all(jnp.equal(result_np, result_jit)))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_x={x}_y={y}_equal_nan={equal_nan}",
-       "x": x, "y": y, "equal_nan": equal_nan}
-      for x, y in itertools.product([
-         1, [1], [1, 1 + 1E-4], [1, np.nan]], repeat=2)
-      for equal_nan in [True, False]))
+  @jtu.sample_product(
+    x=[1, [1], [1, 1 + 1E-4], [1, np.nan]],
+    y=[1, [1], [1, 1 + 1E-4], [1, np.nan]],
+    equal_nan=[True, False],
+  )
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises mixed type promotion
   def testAllClose(self, x, y, equal_nan):
     jnp_fun = partial(jnp.allclose, equal_nan=equal_nan, rtol=1E-3)
@@ -3501,14 +3271,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     cfoo = jax.jit(foo)
     self.assertRaises(NotImplementedError, lambda: cfoo(np.arange(3)))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in [(3,), (2, 3)]
-      for dtype in default_dtypes
       for axis in list(range(-len(shape), len(shape))) + [None] + [tuple(range(len(shape)))]  # Test negative axes and tuples
-    ))
+    ],
+    dtype=default_dtypes,
+  )
   def testFlip(self, shape, dtype, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
@@ -3517,12 +3286,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in [(3,), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes))
+  @jtu.sample_product(
+    shape=[(3,), (2, 3), (3, 2, 4)],
+    dtype=default_dtypes,
+  )
   def testFlipud(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
@@ -3531,13 +3298,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in [(3, 2), (2, 3), (3, 2, 4)]
-      for dtype in default_dtypes))
+  @jtu.sample_product(
+    shape=[(3, 2), (2, 3), (3, 2, 4)],
+    dtype=default_dtypes,
+  )
   def testFliplr(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
@@ -3546,19 +3310,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_k={}_axes={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), k, axes),
-       "shape": shape, "dtype": dtype, "k": k, "axes": axes}
+  @jtu.sample_product(
+    [dict(shape=shape, axes=axes)
       for shape, axes in [
           [(2, 3), (0, 1)],
           [(2, 3), (1, 0)],
           [(4, 3, 2), (0, 2)],
           [(4, 3, 2), (2, 1)],
       ]
-      for k in range(-3, 4)
-      for dtype in default_dtypes))
+    ],
+    k=range(-3, 4),
+    dtype=default_dtypes,
+  )
   def testRot90(self, shape, dtype, k, axes):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
@@ -3574,13 +3337,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     args_maker = lambda: [rng.randn(3, 4).astype("float32")]
     self._CompileAndCheck(lambda x: x.ravel(), args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_order={}_mode={}".format(
-          shape, order, mode),
-        "shape": shape, "order": order, "mode": mode}
-      for shape in nonempty_nonscalar_array_shapes
-      for order in ['C', 'F']
-      for mode in ['wrap', 'clip', 'raise']))
+  @jtu.sample_product(
+    shape=nonempty_nonscalar_array_shapes,
+    order=['C', 'F'],
+    mode=['wrap', 'clip', 'raise'],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testRavelMultiIndex(self, shape, order, mode):
     # generate indices in each dimension with a few out of bounds.
@@ -3616,18 +3377,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_ashape={}{}_cshapes={}{}_mode={}".format(
-          adtype.__name__, ashape, cdtype.__name__, cshapes, mode),
-        "ashape": ashape, "adtype": adtype, "cshapes": cshapes, "cdtype": cdtype, "mode": mode}
-      for ashape in ((), (4,), (3, 4))
-      for cshapes in [
-        [(), (4,)],
-        [(3, 4), (4,), (3, 1)]
-      ]
-      for adtype in int_dtypes
-      for cdtype in default_dtypes
-      for mode in ['wrap', 'clip', 'raise']))
+  @jtu.sample_product(
+    ashape=((), (4,), (3, 4)),
+    cshapes=[
+      [(), (4,)],
+      [(3, 4), (4,), (3, 1)]
+    ],
+    adtype=int_dtypes,
+    cdtype=default_dtypes,
+    mode=['wrap', 'clip', 'raise'],
+  )
   def testChoose(self, ashape, adtype, cshapes, cdtype, mode):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(ashape, adtype), [rng(s, cdtype) for s in cshapes]]
@@ -3656,13 +3415,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     else:
       self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idx={}".format(shape,
-        jtu.format_shape_dtype_string(idx_shape, dtype)),
-       "shape": shape, "idx_shape": idx_shape, "dtype": dtype}
-      for shape in nonempty_nonscalar_array_shapes
-      for dtype in int_dtypes
-      for idx_shape in all_shapes))
+  @jtu.sample_product(
+    shape=nonempty_nonscalar_array_shapes,
+    dtype=int_dtypes,
+    idx_shape=all_shapes,
+  )
   def testUnravelIndex(self, shape, idx_shape, dtype):
     size = prod(shape)
     rng = jtu.rand_int(self.rng(), low=-((2 * size) // 3), high=(2 * size) // 3)
@@ -3697,12 +3454,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-      "shape": shape, "dtype": dtype}
-      for shape in array_shapes
-      for dtype in all_dtypes))
+  @jtu.sample_product(
+    shape=array_shapes,
+    dtype=all_dtypes,
+  )
   def testNbytes(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_op = lambda x: np.asarray(x).nbytes
@@ -3711,12 +3466,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-      "shape": shape, "dtype": dtype}
-      for shape in array_shapes
-      for dtype in all_dtypes))
+  @jtu.sample_product(
+    shape=array_shapes,
+    dtype=all_dtypes,
+  )
   def testItemsize(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     np_op = lambda x: np.asarray(x).itemsize
@@ -3725,13 +3478,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_dtype={}".format(
-          jtu.format_shape_dtype_string(shape, a_dtype), dtype),
-      "shape": shape, "a_dtype": a_dtype, "dtype": dtype}
-      for shape in [(8,), (3, 8)]  # last dim = 8 to ensure shape compatibility
-      for a_dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)
-      for dtype in (default_dtypes + unsigned_dtypes + bool_dtypes)))
+  @jtu.sample_product(
+    shape=[(8,), (3, 8)],  # last dim = 8 to ensure shape compatibility
+    a_dtype=default_dtypes + unsigned_dtypes + bool_dtypes,
+    dtype=default_dtypes + unsigned_dtypes + bool_dtypes,
+  )
   def testView(self, shape, a_dtype, dtype):
     if jtu.device_under_test() == 'tpu':
       if jnp.dtype(a_dtype).itemsize in [1, 2] or jnp.dtype(dtype).itemsize in [1, 2]:
@@ -3803,13 +3554,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self.assertEqual(jnp.arange(0., 10, 1).dtype, float_)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonzerodim_shapes
-      for axis in (None, *range(len(shape)))))
+      for axis in (None, *range(len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testSort(self, dtype, shape, axis):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -3821,28 +3572,28 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-        "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in one_dim_array_shapes
-      for axis in [None]))
+      for axis in [None]
+    ],
+    dtype=all_dtypes,
+  )
   def testSortComplex(self, dtype, shape, axis):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
-    self._CheckAgainstNumpy(np.sort_complex, jnp.sort_complex, args_maker, check_dtypes=False)
+    self._CheckAgainstNumpy(np.sort_complex, jnp.sort_complex, args_maker,
+                            check_dtypes=False)
     self._CompileAndCheck(jnp.sort_complex, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_input_type={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          input_type.__name__, axis),
-       "shape": shape, "dtype": dtype, "input_type": input_type, "axis": axis}
-      for dtype in all_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonempty_nonscalar_array_shapes
-      for input_type in [np.array, tuple]
-      for axis in (-1, *range(len(shape) - 1))))
+      for axis in (-1, *range(len(shape) - 1))
+    ],
+    dtype=all_dtypes,
+    input_type=[np.array, tuple],
+  )
   def testLexsort(self, dtype, shape, input_type, axis):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [input_type(rng(shape, dtype))]
@@ -3851,13 +3602,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis),
-       "shape": shape, "dtype": dtype, "axis": axis}
-      for dtype in all_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in nonzerodim_shapes
-      for axis in (None, *range(len(shape)))))
+      for axis in (None, *range(len(shape)))
+    ],
+    dtype=all_dtypes,
+  )
   def testArgsort(self, dtype, shape, axis):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -3869,25 +3620,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for dtype in all_dtypes
-      for shape in nonzerodim_shapes))
+  @jtu.sample_product(
+    dtype=all_dtypes,
+    shape=nonzerodim_shapes,
+  )
   def testMsort(self, dtype, shape):
     rng = jtu.rand_some_equal(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
     self._CheckAgainstNumpy(np.msort, jnp.msort, args_maker)
     self._CompileAndCheck(jnp.msort, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_shifts={}_axis={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          shifts, axis),
-       "shape": shape, "dtype": dtype, "shifts": shifts, "axis": axis}
-      for dtype in all_dtypes
-      for shape in [(3, 4), (3, 4, 5), (7, 4, 0)]
+  @jtu.sample_product(
+    [dict(shifts=shifts, axis=axis)
       for shifts, axis in [
         (3, None),
         (1, 1),
@@ -3896,7 +3640,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         ((1, 2), (0, -1)),
         ((4, 2, 5, 5, 2, 4), None),
         (100, None),
-      ]))
+      ]
+    ],
+    dtype=all_dtypes,
+    shape=[(3, 4), (3, 4, 5), (7, 4, 0)],
+  )
   def testRoll(self, shape, dtype, shifts, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype), np.array(shifts)]
@@ -3905,16 +3653,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_start={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          axis, start),
-       "shape": shape, "dtype": dtype, "axis": axis,
-       "start": start}
-      for dtype in all_dtypes
-      for shape in [(1, 2, 3, 4)]
-      for axis in [-3, 0, 2, 3]
-      for start in [-4, -1, 2, 4]))
+  @jtu.sample_product(
+    dtype=all_dtypes,
+    shape=[(1, 2, 3, 4)],
+    axis=[-3, 0, 2, 3],
+    start=[-4, -1, 2, 4],
+  )
   def testRollaxis(self, shape, dtype, start, axis):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -3923,15 +3667,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_bitorder={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, bitorder),
-       "shape": shape, "dtype": dtype, "axis": axis,
-       "bitorder": bitorder}
-      for dtype in [np.uint8, np.bool_]
-      for bitorder in ['big', 'little']
-      for shape in [(1, 2, 3, 4)]
-      for axis in [None, 0, 1, -2, -1]))
+  @jtu.sample_product(
+    dtype=[np.uint8, np.bool_],
+    bitorder=['big', 'little'],
+    shape=[(1, 2, 3, 4)],
+    axis=[None, 0, 1, -2, -1],
+  )
   def testPackbits(self, shape, dtype, axis, bitorder):
     rng = jtu.rand_some_zero(self.rng())
     args_maker = lambda: [rng(shape, dtype)]
@@ -3940,16 +3681,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_axis={}_bitorder={}_count={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), axis, bitorder, count),
-      "shape": shape, "dtype": dtype, "axis": axis, "bitorder": bitorder,
-      "count": count}
-      for dtype in [np.uint8]
-      for bitorder in ['big', 'little']
-      for shape in [(1, 2, 3, 4)]
-      for axis in [None, 0, 1, -2, -1]
-      for count in [None, 20]))
+  @jtu.sample_product(
+    dtype=[np.uint8],
+    bitorder=['big', 'little'],
+    shape=[(1, 2, 3, 4)],
+    axis=[None, 0, 1, -2, -1],
+    count=[None, 20],
+  )
   def testUnpackbits(self, shape, dtype, axis, bitorder, count):
     rng = jtu.rand_int(self.rng(), 0, 256)
     args_maker = lambda: [rng(shape, dtype)]
@@ -3958,20 +3696,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_index={}_axis={}_mode={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          jtu.format_shape_dtype_string(index_shape, index_dtype),
-          axis, mode),
-       "shape": shape, "index_shape": index_shape, "dtype": dtype,
-       "index_dtype": index_dtype, "axis": axis, "mode": mode}
+  @jtu.sample_product(
+    [dict(shape=shape, axis=axis)
       for shape in [(3,), (3, 4), (3, 4, 5)]
-      for index_shape in scalar_shapes + [(3,), (2, 1, 3)]
       for axis in itertools.chain(range(-len(shape), len(shape)),
                                   [cast(Optional[int], None)])
-      for dtype in all_dtypes
-      for index_dtype in int_dtypes
-      for mode in [None, 'wrap', 'clip']))
+    ],
+    index_shape=scalar_shapes + [(3,), (2, 1, 3)],
+    dtype=all_dtypes,
+    index_dtype=int_dtypes,
+    mode=[None, 'wrap', 'clip'],
+  )
   def testTake(self, shape, dtype, index_shape, index_dtype, axis, mode):
     def args_maker():
       x = rng(shape, dtype)
@@ -4010,20 +3745,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                       indices_are_sorted=True, fill_value=10.0)
     self.assertArraysEqual(expected, actual)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_index={}_axis={}".format(
-          jtu.format_shape_dtype_string(x_shape, dtype),
-          jtu.format_shape_dtype_string(i_shape, index_dtype), axis),
-       "x_shape": x_shape, "i_shape": i_shape, "dtype": dtype,
-       "index_dtype": index_dtype, "axis": axis}
+  @jtu.sample_product(
+    [dict(x_shape=x_shape, i_shape=i_shape, axis=axis)
       for x_shape, i_shape in filter(
         _shapes_are_equal_length,
         filter(_shapes_are_broadcast_compatible,
                itertools.combinations_with_replacement(nonempty_nonscalar_array_shapes, 2)))
       for axis in itertools.chain(range(len(x_shape)), [-1],
                                   [cast(Optional[int], None)])
-      for dtype in default_dtypes
-      for index_dtype in int_dtypes))
+    ],
+    dtype=default_dtypes,
+    index_dtype=int_dtypes,
+  )
   def testTakeAlongAxis(self, x_shape, i_shape, dtype, index_dtype, axis):
     rng = jtu.rand_default(self.rng())
 
@@ -4081,15 +3814,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         "take_along_axis indices must be of integer type, got float32"):
       jnp.take_along_axis(x, idx, axis=0)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_n={}_increasing={}".format(
-          jtu.format_shape_dtype_string([shape], dtype),
-          n, increasing),
-       "dtype": dtype, "shape": shape, "n": n, "increasing": increasing}
-      for dtype in inexact_dtypes
-      for shape in [0, 5]
-      for n in [2, 4]
-      for increasing in [False, True]))
+  @jtu.sample_product(
+    dtype=inexact_dtypes,
+    shape=[0, 5],
+    n=[2, 4],
+    increasing=[False, True],
+  )
   def testVander(self, shape, dtype, n, increasing):
     rng = jtu.rand_default(self.rng())
     def np_fun(arg):
@@ -4103,12 +3833,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                             tol={np.float32: 1e-3})
     self._CompileAndCheck(jnp_fun, args_maker, check_dtypes=False)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix(
-            "nan_to_num", [shape], [dtype]),
-         "shape": shape, "dtype": dtype}
-        for shape in array_shapes
-        for dtype in inexact_dtypes))
+  @jtu.sample_product(
+    shape=array_shapes,
+    dtype=inexact_dtypes,
+  )
   def testNanToNum(self, shape, dtype):
     rng = jtu.rand_some_inf_and_nan(self.rng())
     dtype = np.dtype(dtypes.canonicalize_dtype(dtype)).type
@@ -4128,15 +3856,16 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp.nan_to_num, args_maker,
                           check_dtypes=check_dtypes)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix("ix_", shapes, dtypes),
-         "shapes": shapes, "dtypes": dtypes}
+  @jtu.sample_product(
+    [dict(shapes=shapes, dtypes=dtypes)
         for shapes, dtypes in (
           ((), ()),
           (((7,),), (np.int32,)),
           (((3,), (4,)), (np.int32, np.int32)),
           (((3,), (1,), (4,)), (np.int32, np.int32, np.int32)),
-        )))
+        )
+    ],
+  )
   def testIx_(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype)
@@ -4144,14 +3873,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.ix_, jnp.ix_, args_maker)
     self._CompileAndCheck(jnp.ix_, args_maker)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": "_dimensions={}_dtype={}_sparse={}".format(
-            dimensions, dtype, sparse),
-         "dimensions": dimensions, "dtype": dtype, "sparse": sparse}
-        for dimensions in [(), (2,), (3, 0), (4, 5, 6)]
-        for dtype in number_dtypes
-        for sparse in [True, False]))
+  @jtu.sample_product(
+    dimensions=[(), (2,), (3, 0), (4, 5, 6)],
+    dtype=number_dtypes,
+    sparse=[True, False],
+  )
   def testIndices(self, dimensions, dtype, sparse):
     def args_maker(): return []
     np_fun = partial(np.indices, dimensions=dimensions,
@@ -4161,48 +3887,43 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name":
-           "_op={}_a_shape={}_q_shape={}_axis={}_keepdims={}_method={}".format(
-             op,
-             jtu.format_shape_dtype_string(a_shape, a_dtype),
-             jtu.format_shape_dtype_string(q_shape, q_dtype),
-             axis, keepdims, method),
-         "a_rng": jtu.rand_some_nan,
-         "q_rng": q_rng, "op": op,
-         "a_shape": a_shape, "a_dtype": a_dtype,
-         "q_shape": q_shape, "q_dtype": q_dtype, "axis": axis,
-         "keepdims": keepdims,
-         "method": method}
-        for (op, q_rng) in (
-          ("percentile", partial(jtu.rand_uniform, low=0., high=100.)),
-          ("quantile", partial(jtu.rand_uniform, low=0., high=1.)),
-          ("nanpercentile", partial(jtu.rand_uniform, low=0., high=100.)),
-          ("nanquantile", partial(jtu.rand_uniform, low=0., high=1.)),
-        )
-        for a_dtype in default_dtypes
-        for a_shape, axis in (
-          ((7,), None),
-          ((47, 7), 0),
-          ((47, 7), ()),
-          ((4, 101), 1),
-          ((4, 47, 7), (1, 2)),
-          ((4, 47, 7), (0, 2)),
-          ((4, 47, 7), (1, 0, 2)),
-        )
-        for q_dtype in [np.float32]
-        for q_shape in scalar_shapes + [(1,), (4,)]
-        for keepdims in [False, True]
-        for method in ['linear', 'lower', 'higher', 'nearest', 'midpoint']))
-  def testQuantile(self, op, a_rng, q_rng, a_shape, a_dtype, q_shape, q_dtype,
+  @jtu.sample_product(
+    [dict(op=op, q_rng=q_rng)
+      for (op, q_rng) in (
+        ("percentile", partial(jtu.rand_uniform, low=0., high=100.)),
+        ("quantile", partial(jtu.rand_uniform, low=0., high=1.)),
+        ("nanpercentile", partial(jtu.rand_uniform, low=0., high=100.)),
+        ("nanquantile", partial(jtu.rand_uniform, low=0., high=1.)),
+      )
+    ],
+    [dict(a_shape=a_shape, axis=axis)
+      for a_shape, axis in (
+        ((7,), None),
+        ((47, 7), 0),
+        ((47, 7), ()),
+        ((4, 101), 1),
+        ((4, 47, 7), (1, 2)),
+        ((4, 47, 7), (0, 2)),
+        ((4, 47, 7), (1, 0, 2)),
+      )
+    ],
+    a_dtype=default_dtypes,
+    q_dtype=[np.float32],
+    q_shape=scalar_shapes + [(1,), (4,)],
+    keepdims=[False, True],
+    method=['linear', 'lower', 'higher', 'nearest', 'midpoint'],
+  )
+  def testQuantile(self, op, q_rng, a_shape, a_dtype, q_shape, q_dtype,
                    axis, keepdims, method):
-    a_rng = a_rng(self.rng())
+    a_rng = jtu.rand_some_nan(self.rng())
     q_rng = q_rng(self.rng())
     if "median" in op:
       args_maker = lambda: [a_rng(a_shape, a_dtype)]
     else:
       args_maker = lambda: [a_rng(a_shape, a_dtype), q_rng(q_shape, q_dtype)]
 
+    @jtu.ignore_warning(category=RuntimeWarning,
+                        message="All-NaN slice encountered")
     def np_fun(*args):
       args = [x if jnp.result_type(x) != jnp.bfloat16 else
               np.asarray(x, np.float32) for x in args]
@@ -4232,22 +3953,18 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     x = jnp.float64([1, 2, 3, 4, 7, 10])
     self.assertEqual(jnp.percentile(x, 50), 3.5)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-        {"testcase_name":
-           "_{}_a_shape={}_axis={}_keepdims={}".format(
-             op, jtu.format_shape_dtype_string(a_shape, a_dtype),
-             axis, keepdims),
-         "op": op, "a_shape": a_shape, "a_dtype": a_dtype,
-         "axis": axis,
-         "keepdims": keepdims}
-        for a_dtype in default_dtypes
-        for a_shape, axis in (
-          ((7,), None),
-          ((47, 7), 0),
-          ((4, 101), 1),
-        )
-        for keepdims in [False, True]
-        for op in ["median", "nanmedian"]))
+  @jtu.sample_product(
+    [dict(a_shape=a_shape, axis=axis)
+      for a_shape, axis in (
+        ((7,), None),
+        ((47, 7), 0),
+        ((4, 101), 1),
+      )
+    ],
+    a_dtype=default_dtypes,
+    keepdims=[False, True],
+    op=["median", "nanmedian"],
+  )
   def testMedian(self, op, a_shape, a_dtype, axis, keepdims):
     if op == "median":
       a_rng = jtu.rand_default(self.rng())
@@ -4269,11 +3986,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CompileAndCheck(jnp_fun, args_maker, rtol=tol)
 
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}".format(
-          jtu.format_shape_dtype_string(shape, dtype)),
-       "shape": shape, "dtype": dtype}
-      for shape in all_shapes for dtype in all_dtypes))
+  @jtu.sample_product(
+    shape=all_shapes,
+    dtype=all_dtypes,
+  )
   def testWhereOneArgument(self, shape, dtype):
     rng = jtu.rand_some_zero(self.rng())
     np_fun = lambda x: np.where(x)
@@ -4289,14 +4005,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_fun = lambda x: jnp.where(x, size=np.size(x) // 2)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
-      "testcase_name": "_{}".format("_".join(
-        jtu.format_shape_dtype_string(shape, dtype)
-        for shape, dtype in zip(shapes, dtypes))),
-      "shapes": shapes, "dtypes": dtypes
-    } for shapes in s(filter(_shapes_are_broadcast_compatible,
-                         itertools.combinations_with_replacement(all_shapes, 3)))
-      for dtypes in s(itertools.combinations_with_replacement(all_dtypes, 3)))))
+  @jtu.sample_product(
+    shapes=filter(_shapes_are_broadcast_compatible,
+                  itertools.combinations_with_replacement(all_shapes, 3)),
+    dtypes=itertools.combinations_with_replacement(all_dtypes, 3),
+  )
   def testWhereThreeArgument(self, shapes, dtypes):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, shapes, dtypes)
@@ -4311,15 +4024,19 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
                   jnp.ones((2,), dtype=jnp.float32))
     self.assertEqual(x.dtype, np.dtype(np.float32))
 
-  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
-      "testcase_name": jtu.format_test_name_suffix("", shapes, (np.bool_,) * n + dtypes),
-      "shapes": shapes, "dtypes": dtypes
-    } for n in s(range(1, 3))
-      for shapes in s(filter(
+  @jtu.sample_product(
+    [dict(n=n, shapes=shapes)
+      for n in range(1, 3)
+      for shapes in filter(
           _shapes_are_broadcast_compatible,
-          itertools.combinations_with_replacement(all_shapes, 2 * n + 1)))
-      for dtypes in s(itertools.combinations_with_replacement(all_dtypes, n + 1)))))
-  def testSelect(self, shapes, dtypes):
+          itertools.combinations_with_replacement(all_shapes, 2 * n + 1))
+    ],
+    # To avoid forming the full product of shapes and dtypes we always sample
+    # maximal set of dtypes.
+    dtypes=itertools.combinations_with_replacement(all_dtypes, 3),
+  )
+  def testSelect(self, n, shapes, dtypes):
+    dtypes = dtypes[:n+1]
     rng = jtu.rand_default(self.rng())
     n = len(dtypes) - 1
     def args_maker():
@@ -4329,6 +4046,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       default = rng(shapes[-1], dtypes[-1])
       return condlist, choicelist, default
     # TODO(phawkins): float32/float64 type mismatches
+    @jax.numpy_dtype_promotion('standard')
     def np_fun(condlist, choicelist, default):
       choicelist = [x if jnp.result_type(x) != jnp.bfloat16
                     else x.astype(np.float32) for x in choicelist]
@@ -4382,11 +4100,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     expected = np.reshape(a, (3, 2), order='F')
     self.assertAllClose(ans, expected)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_op={op}_dtype={dtype.__name__}",
-       "dtype": dtype, "op": op}
-      for dtype in [int, float, bool, complex]
-      for op in ["atleast_1d", "atleast_2d", "atleast_3d"]))
+  @jtu.sample_product(
+    dtype=[int, float, bool, complex],
+    op=["atleast_1d", "atleast_2d", "atleast_3d"],
+  )
   def testAtLeastNdLiterals(self, dtype, op):
     # Fixes: https://github.com/google/jax/issues/634
     np_fun = lambda arg: getattr(np, op)(arg).astype(dtypes.python_scalar_dtypes[dtype])
@@ -4395,22 +4112,13 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {
-      "testcase_name": "_shape={}_dtype={}_weights={}_minlength={}_length={}".format(
-        shape, dtype, weights, minlength, length
-      ),
-      "shape": shape,
-      "dtype": dtype,
-      "weights": weights,
-      "minlength": minlength,
-      "length": length}
-    for shape in [(0,), (5,), (10,)]
-    for dtype in int_dtypes
-    for weights in [True, False]
-    for minlength in [0, 20]
-    for length in [None, 8]
-  ))
+  @jtu.sample_product(
+    shape=[(0,), (5,), (10,)],
+    dtype=int_dtypes,
+    weights=[True, False],
+    minlength=[0, 20],
+    length=[None, 8],
+  )
   def testBincount(self, shape, dtype, weights, minlength, length):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype), (rng(shape, 'float32') if weights else None))
@@ -4442,26 +4150,24 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     jnp_result = jnp.bincount(x, w)
     self.assertAllClose(np_result, jnp_result, check_dtypes=False)
 
-
-  @parameterized.named_parameters(*jtu.cases_from_list(
-      {"testcase_name": f"_case={i}",
-       "input": input}
-       for i, input in enumerate([
-         3,
-         [3],
-         [np.array(3)],
-         [np.array([3])],
-         [[np.array(3)]],
-         [[np.array([3])]],
-         [3, 4, 5],
-         [
-           [np.eye(2, dtype=np.int32) * 2, np.zeros((2, 3), dtype=np.int32)],
-           [np.ones((3, 2), dtype=np.int32), np.eye(3, dtype=np.int32) * 3],
-         ],
-         [np.array([1, 2, 3]), np.array([2, 3, 4]), 10],
-         [np.ones((2, 2), dtype=np.int32), np.zeros((2, 2), dtype=np.int32)],
-         [[np.array([1, 2, 3])], [np.array([2, 3, 4])]],
-       ])))
+  @jtu.sample_product(
+    input=[
+      3,
+      [3],
+      [np.array(3)],
+      [np.array([3])],
+      [[np.array(3)]],
+      [[np.array([3])]],
+      [3, 4, 5],
+      [
+        [np.eye(2, dtype=np.int32) * 2, np.zeros((2, 3), dtype=np.int32)],
+        [np.ones((3, 2), dtype=np.int32), np.eye(3, dtype=np.int32) * 3],
+      ],
+      [np.array([1, 2, 3]), np.array([2, 3, 4]), 10],
+      [np.ones((2, 2), dtype=np.int32), np.zeros((2, 2), dtype=np.int32)],
+      [[np.array([1, 2, 3])], [np.array([2, 3, 4])]],
+    ],
+  )
   def testBlock(self, input):
     args_maker = lambda: [input]
     self._CheckAgainstNumpy(np.block, jnp.block, args_maker)
@@ -4509,8 +4215,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     expected = jtu.with_jax_dtype_defaults(np.arange)(5)
     self.assertAllClose(ans, expected)
 
-  @parameterized.named_parameters(
-    {"testcase_name": f"_{args}", "args": args} for args in [(5,), (0, 5)])
+  @jtu.sample_product(args=[(5,), (0, 5)])
   def testArangeJaxpr(self, args):
     jaxpr = jax.make_jaxpr(lambda: jnp.arange(*args))()
     self.assertEqual(len(jaxpr.jaxpr.eqns), 1)
@@ -4553,14 +4258,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   #   f = jax.grad(lambda x: jnp.sum(1 / (1 + jnp.exp(-x))))
   #   self.assertAllClose(f(x), np.array([0., 0., 0., 0.25], dtype=np.float32))
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix(op, [()], [dtype]),
-         "dtype": dtype, "op": op}
-      for dtype in float_dtypes
-      for op in ("sqrt", "arccos", "arcsin", "arctan", "sin", "cos", "tan",
-                 "sinh", "cosh", "tanh", "arccosh", "arcsinh", "arctanh", "exp",
-                 "log", "expm1", "log1p")))
+  @jtu.sample_product(
+    dtype=float_dtypes,
+    op=("sqrt", "arccos", "arcsin", "arctan", "sin", "cos", "tan",
+        "sinh", "cosh", "tanh", "arccosh", "arcsinh", "arctanh", "exp",
+        "log", "expm1", "log1p"),
+  )
   def testMathSpecialFloatValues(self, op, dtype):
     np_op = getattr(np, op)
     np_op = jtu.ignore_warning(category=RuntimeWarning,
@@ -4591,14 +4294,11 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testIssue967(self):
     self.assertRaises(TypeError, lambda: jnp.zeros(1.5))
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": "_shape={}_dtype={}_rowvar={}".format(
-            shape, dtype.__name__, rowvar),
-         "shape": shape, "dtype": dtype, "rowvar": rowvar}
-        for shape in [(5,), (10, 5), (4, 10)]
-        for dtype in number_dtypes
-        for rowvar in [True, False]))
+  @jtu.sample_product(
+    shape=[(5,), (10, 5), (4, 10)],
+    dtype=number_dtypes,
+    rowvar=[True, False],
+  )
   def testCorrCoef(self, shape, dtype, rowvar):
     rng = jtu.rand_default(self.rng())
     def args_maker():
@@ -4617,13 +4317,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         tol=tol)
     self._CompileAndCheck(jnp_fun, args_maker, atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_{}_{}".format(jtu.format_shape_dtype_string(shape, dtype),
-       "None" if end_dtype is None else jtu.format_shape_dtype_string(end_shape, end_dtype),
-       "None" if begin_dtype is None else jtu.format_shape_dtype_string(begin_shape, begin_dtype)),
-       "shape": shape, "dtype": dtype, "end_shape": end_shape,
-       "end_dtype": end_dtype, "begin_shape": begin_shape,
-       "begin_dtype": begin_dtype}
+  @jtu.sample_product(
+    [dict(dtype=dtype, end_dtype=end_dtype, begin_dtype=begin_dtype,
+          shape=shape, begin_shape=begin_shape, end_shape=end_shape)
       for dtype in number_dtypes
       for end_dtype in [None] + [dtype]
       for begin_dtype in [None] + [dtype]
@@ -4633,7 +4329,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         else [s for s in all_shapes if s != jtu.PYTHON_SCALAR_SHAPE])
       for end_shape in (
         [None] if end_dtype is None
-        else [s for s in all_shapes if s != jtu.PYTHON_SCALAR_SHAPE])))
+        else [s for s in all_shapes if s != jtu.PYTHON_SCALAR_SHAPE])
+    ],
+  )
   def testEDiff1d(self, shape, dtype, end_shape, end_dtype, begin_shape,
                   begin_dtype):
     rng = jtu.rand_default(self.rng())
@@ -4656,16 +4354,12 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_fun, jnp_fun, args_maker)
     self._CompileAndCheck(jnp_fun, args_maker)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": "_shapes={}_dtype={}_indexing={}_sparse={}".format(
-            shapes, dtype, indexing, sparse),
-         "shapes": shapes, "dtype": dtype, "indexing": indexing,
-         "sparse": sparse}
-        for shapes in [(), (5,), (5, 3)]
-        for dtype in number_dtypes
-        for indexing in ['xy', 'ij']
-        for sparse in [True, False]))
+  @jtu.sample_product(
+    shapes=[(), (5,), (5, 3)],
+    dtype=number_dtypes,
+    indexing=['xy', 'ij'],
+    sparse=[True, False],
+  )
   def testMeshGrid(self, shapes, dtype, indexing, sparse):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [(x,) for x in shapes],
@@ -4858,23 +4552,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testIndex_exp(self):
     self.assertEqual(np.index_exp[5:3:2j],jnp.index_exp[5:3:2j])
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": f"_start_shape={start_shape}_stop_shape={stop_shape}"
-                          f"_num={num}_endpoint={endpoint}_retstep={retstep}"
-                          f"_dtype={dtype.__name__ if dtype else 'None'}",
-         "start_shape": start_shape, "stop_shape": stop_shape,
-         "num": num, "endpoint": endpoint, "retstep": retstep,
-         "dtype": dtype}
-        for start_shape in [(), (2,), (2, 2)]
-        for stop_shape in [(), (2,), (2, 2)]
-        for num in [0, 1, 2, 5, 20]
-        for endpoint in [True, False]
-        for retstep in [True, False]
-        # floating-point compute between jitted platforms and non-jit + rounding
-        # cause unavoidable variation in integer truncation for some inputs, so
-        # we currently only test inexact 'dtype' arguments.
-        for dtype in inexact_dtypes + [None,]))
+  @jtu.sample_product(
+    start_shape=[(), (2,), (2, 2)],
+    stop_shape=[(), (2,), (2, 2)],
+    num=[0, 1, 2, 5, 20],
+    endpoint=[True, False],
+    retstep=[True, False],
+    # floating-point compute between jitted platforms and non-jit + rounding
+    # cause unavoidable variation in integer truncation for some inputs, so
+    # we currently only test inexact 'dtype' arguments.
+    dtype=inexact_dtypes + [None,],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLinspace(self, start_shape, stop_shape, num, endpoint, retstep, dtype):
     rng = jtu.rand_default(self.rng())
@@ -4898,10 +4586,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck(jnp_op, args_maker,
                             check_dtypes=False, atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": f"_dtype={dtype.__name__}", "dtype": dtype}
-        for dtype in number_dtypes))
+  @jtu.sample_product(dtype=number_dtypes)
   def testLinspaceEndpoints(self, dtype):
     """Regression test for Issue #3014."""
     rng = jtu.rand_default(self.rng())
@@ -4909,23 +4594,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     out = jnp.linspace(*endpoints, 10, dtype=dtype)
     self.assertAllClose(out[np.array([0, -1])], endpoints, rtol=0, atol=0)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": ("_start_shape={}_stop_shape={}_num={}_endpoint={}"
-                           "_base={}_dtype={}").format(
-            start_shape, stop_shape, num, endpoint, base,
-            dtype.__name__ if dtype else "None"),
-         "start_shape": start_shape,
-         "stop_shape": stop_shape,
-         "num": num, "endpoint": endpoint, "base": base,
-         "dtype": dtype}
-        for start_shape in [(), (2,), (2, 2)]
-        for stop_shape in [(), (2,), (2, 2)]
-        for num in [0, 1, 2, 5, 20]
-        for endpoint in [True, False]
-        for base in [10.0, 2, np.e]
-        # skip 16-bit floats due to insufficient precision for the test.
-        for dtype in jtu.dtypes.inexact + [None,]))
+  @jtu.sample_product(
+    start_shape=[(), (2,), (2, 2)],
+    stop_shape=[(), (2,), (2, 2)],
+    num=[0, 1, 2, 5, 20],
+    endpoint=[True, False],
+    base=[10.0, 2, np.e],
+    # skip 16-bit floats due to insufficient precision for the test.
+    dtype=jtu.dtypes.inexact + [None,],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLogspace(self, start_shape, stop_shape, num,
                    endpoint, base, dtype):
@@ -4959,31 +4636,25 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         self._CompileAndCheck(jnp_op, args_maker,
                               check_dtypes=False, atol=atol, rtol=tol)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": ("_start_shape={}_stop_shape={}_num={}_endpoint={}"
-                           "_dtype={}_axis={}").format(
-            start_shape, stop_shape, num, endpoint,
-            dtype.__name__ if dtype else "None", axis),
-         "start_shape": start_shape,
-         "stop_shape": stop_shape,
-         "num": num, "endpoint": endpoint,
-         "dtype": dtype, "axis": axis}
-        for start_shape in [(), (2,), (2, 2)]
-        for stop_shape in [(), (2,), (2, 2)]
-        for num in [0, 1, 2, 5, 20]
-        for endpoint in [True, False]
-        # NB: numpy's geomspace gives nonsense results on integer types
-        for dtype in inexact_dtypes + [None,]
-        for axis in range(-max(len(start_shape), len(stop_shape)),
-                          max(len(start_shape), len(stop_shape)))))
+  @jtu.sample_product(
+    [dict(start_shape=start_shape, stop_shape=stop_shape, axis=axis)
+      for start_shape in [(), (2,), (2, 2)]
+      for stop_shape in [(), (2,), (2, 2)]
+      for axis in range(-max(len(start_shape), len(stop_shape)),
+                         max(len(start_shape), len(stop_shape)))
+    ],
+    num=[0, 1, 2, 5, 20],
+    endpoint=[True, False],
+    # NB: numpy's geomspace gives nonsense results on integer types
+    dtype=inexact_dtypes + [None,],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testGeomspace(self, start_shape, stop_shape, num,
                     endpoint, dtype, axis):
     rng = jtu.rand_default(self.rng())
     # relax default tolerances slightly
-    tol = {np.float16: 4e-3, np.float32: 2e-3, np.float64: 1e-14,
-           np.complex128: 1e-14}
+    tol = {dtypes.bfloat16: 2e-2, np.float16: 4e-3, np.float32: 2e-3,
+           np.float64: 1e-14, np.complex128: 1e-14}
     def args_maker():
       """Test the set of inputs np.geomspace is well-defined on."""
       start, stop = self._GetArgsMaker(rng,
@@ -5082,16 +4753,17 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       any(np.array_equal(x, np.full((3, 4), 2., dtype=np.float32))
           for x in jaxpr.consts))
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"_from={from_shape}_to={to_shape}",
-       "from_shape": from_shape, "to_shape": to_shape}
+  @jtu.sample_product(
+    [dict(from_shape=from_shape, to_shape=to_shape)
       for from_shape, to_shape in [
           [(1, 3), (4, 3)],
           [(3,), (2, 1, 3)],
           [(3,), (3, 3)],
           [(1,), (3,)],
           [(1,), 3],
-      ])
+      ]
+    ],
+  )
   def testBroadcastTo(self, from_shape, to_shape):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [from_shape], [np.float32])
@@ -5100,8 +4772,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np_op, jnp_op, args_maker)
     self._CompileAndCheck(jnp_op, args_maker)
 
-  @parameterized.named_parameters(
-      {"testcase_name": f"_{shapes}", "shapes": shapes, "broadcasted_shape": broadcasted_shape}
+  @jtu.sample_product(
+    [dict(shapes=shapes, broadcasted_shape=broadcasted_shape)
       for shapes, broadcasted_shape in [
         [[], ()],
         [[()], ()],
@@ -5113,7 +4785,9 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         [[(6, 7), (5, 6, 1), (7,), (5, 1, 7)], (5, 6, 7)],
         [[[1], [0, 1]], (0, 1)],
         [[(1,), np.array([0, 1])], (0, 1)],
-    ])
+      ]
+    ],
+  )
   def testBroadcastShapes(self, shapes, broadcasted_shape):
     # Test against np.broadcast_shapes once numpy 1.20 is minimum required version
     np.testing.assert_equal(jnp.broadcast_shapes(*shapes), broadcasted_shape)
@@ -5180,16 +4854,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
         partial(jnp.inner, precision=HIGHEST),
         ones_1d, ones_1d)
 
-  @parameterized.named_parameters(
-      jtu.cases_from_list(
-        {"testcase_name": "_shape={}_varargs={} axis={}_dtype={}".format(
-            shape, varargs, axis, dtype),
-         "shape": shape, "varargs": varargs, "axis": axis, "dtype": dtype}
+  @jtu.sample_product(
+    [dict(shape=shape, varargs=varargs, axis=axis)
         for shape in [(10,), (10, 15), (10, 15, 20)]
         for _num_axes in range(len(shape))
         for varargs in itertools.combinations(range(1, len(shape) + 1), _num_axes)
         for axis in itertools.combinations(range(len(shape)), _num_axes)
-        for dtype in inexact_dtypes))
+    ],
+    dtype=inexact_dtypes,
+  )
   def testGradient(self, shape, varargs, axis, dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = self._GetArgsMaker(rng, [shape], [dtype])
@@ -5254,9 +4927,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     with self.assertRaisesRegex(jax.core.ConcretizationTypeError, msg('stop')):
       jax.jit(lambda stop: jnp.arange(0, stop))(3)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": str(dtype), "dtype": dtype}
-    for dtype in [None] + float_dtypes))
+  @jtu.sample_product(dtype=[None] + float_dtypes)
   def testArange64Bit(self, dtype):
     # Test that jnp.arange uses 64-bit arithmetic to define its range, even if the
     # output has another dtype. The issue here is that if python scalar inputs to
@@ -5284,14 +4955,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     np_object_list = np.array(object_list)
     self.assertRaises(TypeError, jnp.array, np_object_list)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
-     "shapes": shapes, "dtypes": dtypes}
-    for shapes in filter(
-      _shapes_are_broadcast_compatible,
-      itertools.combinations_with_replacement(all_shapes, 2))
-    for dtypes in itertools.product(
-      *(_valid_dtypes_for_shape(s, complex_dtypes) for s in shapes))))
+  @jtu.sample_product(
+    [dict(shapes=shapes, dtypes=dtypes)
+      for shapes in filter(
+        _shapes_are_broadcast_compatible,
+        itertools.combinations_with_replacement(all_shapes, 2))
+      for dtypes in itertools.product(
+        *(_valid_dtypes_for_shape(s, complex_dtypes) for s in shapes))
+    ],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLogaddexpComplex(self, shapes, dtypes):
     @jtu.ignore_warning(category=RuntimeWarning, message="invalid value.*")
@@ -5309,14 +4981,15 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CheckAgainstNumpy(_promote_like_jnp(np_op), jnp.logaddexp, args_maker, tol=tol)
       self._CompileAndCheck(jnp.logaddexp, args_maker, rtol=tol, atol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": jtu.format_test_name_suffix("", shapes, dtypes),
-     "shapes": shapes, "dtypes": dtypes}
-    for shapes in filter(
-      _shapes_are_broadcast_compatible,
-      itertools.combinations_with_replacement(all_shapes, 2))
-    for dtypes in itertools.product(
-      *(_valid_dtypes_for_shape(s, complex_dtypes) for s in shapes))))
+  @jtu.sample_product(
+    [dict(shapes=shapes, dtypes=dtypes)
+      for shapes in filter(
+        _shapes_are_broadcast_compatible,
+        itertools.combinations_with_replacement(all_shapes, 2))
+      for dtypes in itertools.product(
+        *(_valid_dtypes_for_shape(s, complex_dtypes) for s in shapes))
+    ],
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testLogaddexp2Complex(self, shapes, dtypes):
     @jtu.ignore_warning(category=RuntimeWarning, message="invalid value.*")
@@ -5379,7 +5052,7 @@ GRAD_TEST_RECORDS = [
                    rng_factory=jtu.rand_positive,
                    dtypes=[np.float64, np.complex64],
                    tol={np.complex64: 2e-2}),
-    grad_test_spec(jnp.arccosh, nargs=1, order=2,
+    grad_test_spec(jnp.arccosh, nargs=1, order=1,
                    rng_factory=jtu.rand_positive,
                    dtypes=[np.float64, np.complex64],
                    tol={np.complex64: 2e-2}),
@@ -5408,15 +5081,13 @@ GRAD_SPECIAL_VALUE_TEST_RECORDS = [
 
 class NumpyGradTests(jtu.JaxTestCase):
 
-  @parameterized.named_parameters(itertools.chain.from_iterable(
-      jtu.cases_from_list(
-        {"testcase_name": jtu.format_test_name_suffix(
-            rec.name, shapes, itertools.repeat(dtype)),
-         "op": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes, "dtype": dtype,
-         "order": rec.order, "tol": rec.tol}
-        for shapes in itertools.combinations_with_replacement(nonempty_shapes, rec.nargs)
-        for dtype in rec.dtypes)
-      for rec in GRAD_TEST_RECORDS))
+  @parameterized.parameters(itertools.chain.from_iterable(
+    jtu.sample_product_testcases(
+      [dict(op=rec.op, rng_factory=rec.rng_factory, tol=rec.tol,
+            order=rec.order)],
+      shapes=itertools.combinations_with_replacement(nonempty_shapes, rec.nargs),
+      dtype=rec.dtypes)
+    for rec in GRAD_TEST_RECORDS))
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   @jax.numpy_dtype_promotion('standard')  # This test explicitly exercises mixed type promotion
   def testOpGrad(self, op, rng_factory, shapes, dtype, order, tol):
@@ -5426,11 +5097,11 @@ class NumpyGradTests(jtu.JaxTestCase):
     args = tuple(rng(shape, dtype) for shape in shapes)
     check_grads(op, args, order, ["fwd", "rev"], tol, tol)
 
-  @parameterized.named_parameters(itertools.chain.from_iterable(
-      jtu.cases_from_list(
-          {"testcase_name": f"_{rec.op.__name__}_{special_value}",
-           "op": rec.op, "special_value": special_value, "order": rec.order}
-          for special_value in rec.values)
+  @parameterized.parameters(itertools.chain.from_iterable(
+      jtu.sample_product_testcases(
+        [dict(op=rec.op, order=rec.order)],
+        special_value=rec.values
+      )
       for rec in GRAD_SPECIAL_VALUE_TEST_RECORDS))
   def testOpGradSpecialValue(self, op, special_value, order):
     check_grads(op, (special_value,), order, ["fwd", "rev"],
@@ -5477,13 +5148,11 @@ class NumpyGradTests(jtu.JaxTestCase):
 
     check_grads(f, (1.,), order=1)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": jtu.format_test_name_suffix("", shapes, itertools.repeat(dtype)),
-     "shapes": shapes, "dtype": dtype}
-    for shapes in filter(
-      _shapes_are_broadcast_compatible,
-      itertools.combinations_with_replacement(nonempty_shapes, 2))
-    for dtype in (np.complex128, )))
+  @jtu.sample_product(
+    shapes=filter(_shapes_are_broadcast_compatible,
+                  itertools.combinations_with_replacement(nonempty_shapes, 2)),
+    dtype=(np.complex128,),
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testGradLogaddexpComplex(self, shapes, dtype):
     rng = jtu.rand_default(self.rng())
@@ -5494,13 +5163,11 @@ class NumpyGradTests(jtu.JaxTestCase):
       tol = 3e-2
     check_grads(jnp.logaddexp, args, 1, ["fwd", "rev"], tol, tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-    {"testcase_name": jtu.format_test_name_suffix("", shapes, itertools.repeat(dtype)),
-     "shapes": shapes, "dtype": dtype}
-    for shapes in filter(
-      _shapes_are_broadcast_compatible,
-      itertools.combinations_with_replacement(nonempty_shapes, 2))
-    for dtype in (np.complex128, )))
+  @jtu.sample_product(
+    shapes=filter(_shapes_are_broadcast_compatible,
+                  itertools.combinations_with_replacement(nonempty_shapes, 2)),
+    dtype=(np.complex128,),
+  )
   @jax.numpy_rank_promotion('allow')  # This test explicitly exercises implicit rank promotion.
   def testGradLogaddexp2Complex(self, shapes, dtype):
     rng = jtu.rand_default(self.rng())
@@ -5636,11 +5303,11 @@ def _dtypes_for_ufunc(name: str) -> Iterator[Tuple[str, ...]]:
 
 class NumpyUfuncTests(jtu.JaxTestCase):
 
-  @parameterized.named_parameters(
-    {"testcase_name": f"_{name}_{','.join(arg_dtypes)}",
-     "name": name, "arg_dtypes": arg_dtypes}
+  @parameterized.parameters(itertools.chain.from_iterable(
+    jtu.sample_product_testcases([dict(name=name)],
+                                 arg_dtypes=_dtypes_for_ufunc(name))
     for name in _all_numpy_ufuncs()
-    for arg_dtypes in jtu.cases_from_list(_dtypes_for_ufunc(name)))
+  ))
   def testUfuncInputTypes(self, name, arg_dtypes):
     if name == 'arctanh' and jnp.issubdtype(arg_dtypes[0], jnp.complexfloating):
       self.skipTest("np.arctanh & jnp.arctanh have mismatched NaNs for complex input.")

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -31,7 +31,7 @@ from jax import lax
 from jax._src import test_util as jtu
 from jax._src.lax import windowed_reductions as lax_windowed_reductions
 from jax._src.lib import xla_client
-from jax._src.util import safe_map, safe_zip
+from jax._src.util import prod, safe_map, safe_zip
 
 from lax_test import LAX_OPS
 
@@ -92,67 +92,48 @@ class LaxVmapTest(jtu.JaxTestCase):
         expected = [np.stack(xs) for xs in zip(*outs)]
     self.assertAllClose(ans, expected, rtol=rtol, atol=atol)
 
-  @parameterized.named_parameters(itertools.chain.from_iterable(
-      jtu.cases_from_list(
-        {"testcase_name": "{}_bdims={}".format(
-            jtu.format_test_name_suffix(rec.op, shapes,
-                                        itertools.repeat(dtype)), bdims),
-         "op_name": rec.op, "rng_factory": rec.rng_factory, "shapes": shapes,
-         "dtype": dtype, "bdims": bdims, "tol": rec.tol}
+  @parameterized.parameters(itertools.chain.from_iterable(
+    jtu.sample_product_testcases(
+      [dict(op_name=rec.op, rng_factory=rec.rng_factory, tol=rec.tol)],
+      [dict(shapes=shapes, bdims=bdims)
         for shape_group in compatible_shapes
         for shapes in itertools.combinations_with_replacement(shape_group, rec.nargs)
-        for bdims in all_bdims(*shapes)
-        for dtype in rec.dtypes)
-      for rec in LAX_OPS))
+        for bdims in all_bdims(*shapes)],
+      dtype=rec.dtypes,
+    ) for rec in LAX_OPS))
   def testOp(self, op_name, rng_factory, shapes, dtype, bdims, tol):
     rng = rng_factory(self.rng())
     op = getattr(lax, op_name)
     self._CheckBatching(op, 10, bdims, shapes, [dtype] * len(shapes), rng,
                         atol=tol, rtol=tol)
 
-  @parameterized.named_parameters(jtu.named_cases_from_sampler(lambda s: ({
-       "testcase_name":
-       "_lhs_shape={}_rhs_shape={}_strides={}_padding={}_lhs_dilation={}_"
-       "rhs_dilation={}_dims={}_feature_group_count={}_batch_group_count={}"
-       "_lhs_bdim={}_rhs_bdim={}_bdim_size={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               strides, padding, lhs_dil, rhs_dil, ",".join(dim_nums),
-               feature_group_count, batch_group_count, lhs_bdim, rhs_bdim,
-               bdim_size),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "strides": strides, "padding": padding, "lhs_dil": lhs_dil,
-       "rhs_dil": rhs_dil, "dimension_numbers": dim_nums,
-       "perms": perms, "lhs_bdim": lhs_bdim, "rhs_bdim": rhs_bdim,
-       "feature_group_count": feature_group_count,
-       "batch_group_count": batch_group_count, "bdim_size": bdim_size,
-     } for batch_group_count, feature_group_count in s([(1, 1), (2, 1), (1, 2)])
-       for lhs_shape, rhs_shape, all_strides, all_pads, lhs_dils, rhs_dils in s([
-           ((b * batch_group_count, i * feature_group_count, 6, 7),  # lhs_shape
-            (j * batch_group_count * feature_group_count, i, 1, 2),  # rhs_shape
-            [(1, 1), (1, 2), (2, 1)],  # strides
-            [((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],  # pads
-            [(1, 1), (2, 1)],  # lhs_dils
-            [(1, 1), (2, 2)])  # rhs_dils
-           for b, i, j in itertools.product([1, 2], repeat=3)])
-       for strides in s(all_strides)
-       for rhs_dil in s(rhs_dils)
-       for lhs_dil in s(lhs_dils)
-       for dtype in s([np.float32])
-       for padding in s(all_pads)
-       for dim_nums, perms in s([
-           (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
-           (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
-           (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3])),
-           (("HWCN", "HWIO", "HWCN"), ([2, 3, 1, 0], [2, 3, 1, 0])),
-       ])
-       for bdim_size in s([0, 5])
-       for lhs_bdim in s(itertools.chain([cast(Optional[int], None)],
-                                         range(len(lhs_shape) + 1)))
-       for rhs_bdim in s(itertools.chain([cast(Optional[int], None)],
-                                         range(len(rhs_shape) + 1)))
-       if (lhs_bdim, rhs_bdim) != (None, None)
-       )))
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape,
+          batch_group_count=batch_group_count,
+          feature_group_count=feature_group_count)
+     for batch_group_count, feature_group_count in [(1, 1), (2, 1), (1, 2)]
+     for b, i, j in itertools.product([1, 2], repeat=3)
+     for lhs_shape in [(b * batch_group_count, i * feature_group_count, 6, 7)]
+     for rhs_shape in [(j * batch_group_count * feature_group_count, i, 1, 2)]],
+    [dict(lhs_bdim=lhs_bdim, rhs_bdim=rhs_bdim)
+        for lhs_bdim in itertools.chain([cast(Optional[int], None)], range(5))
+        for rhs_bdim in itertools.chain([cast(Optional[int], None)], range(5))
+        if (lhs_bdim, rhs_bdim) != (None, None)
+    ],
+    [dict(dimension_numbers=dim_nums, perms=perms)
+     for dim_nums, perms in [
+       (("NCHW", "OIHW", "NCHW"), ([0, 1, 2, 3], [0, 1, 2, 3])),
+       (("NHWC", "HWIO", "NHWC"), ([0, 2, 3, 1], [2, 3, 1, 0])),
+       (("NHWC", "OIHW", "NCHW"), ([0, 2, 3, 1], [0, 1, 2, 3])),
+       (("HWCN", "HWIO", "HWCN"), ([2, 3, 1, 0], [2, 3, 1, 0])),
+    ]],
+    strides=[(1, 1), (1, 2), (2, 1)],
+    padding=[((0, 0), (0, 0)), ((1, 0), (0, 1)), ((0, -1), (0, 0))],
+    lhs_dil=[(1, 1), (2, 1)],
+    rhs_dil=[(1, 1), (2, 2)],
+    bdim_size=list(range(5)),
+    dtype=[np.float32],
+  )
   def testConvGeneralDilatedBatching(
       self, lhs_shape, rhs_shape, dtype, strides, padding, lhs_dil, rhs_dil,
       dimension_numbers, perms, feature_group_count, batch_group_count,
@@ -175,94 +156,77 @@ class LaxVmapTest(jtu.JaxTestCase):
                         (lhs_shape, rhs_shape), (dtype, dtype), rng, rtol=tol,
                         atol=tol)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_from_dtype={}_to_dtype={}_bdims={}".format(
-          shape, from_dtype, to_dtype, bdims),
-       "shape": shape, "from_dtype": from_dtype, "to_dtype": to_dtype,
-       "bdims": bdims}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for shape in [(2, 3)]
-      for bdims in all_bdims(shape)))
+  @jtu.sample_product(
+    [dict(from_dtype=f, to_dtype=t)
+      for f, t in itertools.product([np.float32, np.int32, "float32", "int32"],
+                                    repeat=2)
+    ],
+    [dict(shape=shape, bdims=bdims)
+     for shape in [(2, 3)] for bdims in all_bdims(shape)]
+  )
   def testConvertElementType(self, shape, from_dtype, to_dtype, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.convert_element_type(x, to_dtype)
     self._CheckBatching(op, 10, bdims, (shape,), (from_dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_{}_nmant={}_nexp={}_bdims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), nmant, nexp, bdims),
-       "shape": shape, "dtype": dtype, "nmant": nmant, "nexp": nexp, "bdims": bdims}
-      for dtype in float_dtypes
-      for shape in [(2, 4)]
-      for nexp in [1, 3, 5]
-      for nmant in [0, 2, 4]
-      for bdims in all_bdims(shape)))
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims)
+     for shape in [(2, 4)] for bdims in all_bdims(shape)],
+    dtype=float_dtypes,
+    nexp=[1, 3, 5],
+    nmant=[0, 2, 4],
+  )
   def testReducePrecision(self, shape, dtype, nmant, nexp, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.reduce_precision(x, exponent_bits=nexp, mantissa_bits=nmant)
     self._CheckBatching(op, 10, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_from_dtype={}_to_dtype={}_bdims={}".format(
-          shape, from_dtype, to_dtype, bdims),
-       "shape": shape, "from_dtype": from_dtype, "to_dtype": to_dtype,
-       "bdims": bdims}
-      for from_dtype, to_dtype in itertools.product(
-          [np.float32, np.int32, "float32", "int32"], repeat=2)
-      for shape in [(2, 3)]
-      for bdims in all_bdims(shape)))
+  @jtu.sample_product(
+    [dict(from_dtype=f, to_dtype=t)
+      for f, t in itertools.product([np.float32, np.int32, "float32", "int32"],
+                                    repeat=2)
+    ],
+    [dict(shape=shape, bdims=bdims)
+     for shape in [(2, 3)] for bdims in all_bdims(shape)]
+  )
   def testBitcastElementType(self, shape, from_dtype, to_dtype, bdims,):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.bitcast_convert_type(x, to_dtype)
     self._CheckBatching(op, 10, bdims, (shape,), (from_dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_min_shape={}_operand_shape={}_max_shape={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(min_shape, dtype),
-               jtu.format_shape_dtype_string(operand_shape, dtype),
-               jtu.format_shape_dtype_string(max_shape, dtype),
-               bdims),
-       "min_shape": min_shape, "operand_shape": operand_shape,
-       "max_shape": max_shape, "dtype": dtype, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(min_shape=min_shape, operand_shape=operand_shape, max_shape=max_shape,
+          bdims=bdims)
       for min_shape, operand_shape, max_shape in [
           [(), (2, 3), ()],
           [(2, 3), (2, 3), ()],
           [(), (2, 3), (2, 3)],
           [(2, 3), (2, 3), (2, 3)],
       ]
-      for dtype in default_dtypes
-      for bdims in all_bdims(min_shape, operand_shape, max_shape)))
+      for bdims in all_bdims(min_shape, operand_shape, max_shape)
+    ],
+    dtype=default_dtypes,
+  )
   def testClamp(self, min_shape, operand_shape, max_shape, dtype, bdims):
     rng = jtu.rand_default(self.rng())
     shapes = [min_shape, operand_shape, max_shape]
     self._CheckBatching(lax.clamp, 10, bdims, shapes, [dtype] * 3, rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_lhs_shape={}_rhs_shape={}_bdims={}".format(
-          jtu.format_shape_dtype_string(lhs_shape, dtype),
-          jtu.format_shape_dtype_string(rhs_shape, dtype),
-          bdims),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "bdims": bdims}
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape, bdims=bdims)
       for lhs_shape in [(3,), (4, 3)] for rhs_shape in [(3,), (3, 6)]
-      for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes))
+      for bdims in all_bdims(lhs_shape, rhs_shape)],
+    dtype=default_dtypes,
+  )
   def testDot(self, lhs_shape, rhs_shape, dtype, bdims):
     rng = jtu.rand_default(self.rng())
     op = partial(lax.dot, precision=lax.Precision.HIGHEST)
     self._CheckBatching(op, 5, bdims, (lhs_shape, rhs_shape), (dtype, dtype),
                         rng, rtol={np.float16: 5e-2, np.float64: 5e-14})
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_lhs_contracting={}_rhs_contracting={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               lhs_contracting, rhs_contracting, bdims),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "lhs_contracting": lhs_contracting, "rhs_contracting": rhs_contracting,
-       "bdims": bdims}
+  @jtu.sample_product(
+    [dict(bdims=bdims, lhs_shape=lhs_shape, rhs_shape=rhs_shape,
+          lhs_contracting=lhs_contracting, rhs_contracting=rhs_contracting)
       for lhs_shape, rhs_shape, lhs_contracting, rhs_contracting in [
           [(5,), (5,), [0], [0]],
           [(5, 7), (5,), [0], [0]],
@@ -275,8 +239,9 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(1, 2, 2, 3), (1, 2, 3, 1), [1], [1]],
           [(3, 2), (2, 4), [1], [0]],
       ]
-      for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes))
+      for bdims in all_bdims(lhs_shape, rhs_shape)],
+    dtype=default_dtypes,
+  )
   def testDotGeneralContractOnly(self, lhs_shape, rhs_shape, dtype,
                                  lhs_contracting, rhs_contracting, bdims):
     rng = jtu.rand_small(self.rng())
@@ -285,21 +250,16 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(dot, 5, bdims, (lhs_shape, rhs_shape), (dtype, dtype),
                         rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       "_lhs_shape={}_rhs_shape={}_dimension_numbers={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(lhs_shape, dtype),
-               jtu.format_shape_dtype_string(rhs_shape, dtype),
-               dimension_numbers, bdims),
-       "lhs_shape": lhs_shape, "rhs_shape": rhs_shape, "dtype": dtype,
-       "dimension_numbers": dimension_numbers, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(lhs_shape=lhs_shape, rhs_shape=rhs_shape,
+          dimension_numbers=dimension_numbers, bdims=bdims)
       for lhs_shape, rhs_shape, dimension_numbers in [
           ((3, 3, 2), (3, 2, 4), (([2], [1]), ([0], [0]))),
           ((3, 3, 2), (2, 3, 4), (([2], [0]), ([0], [1]))),
           ((3, 4, 2, 4), (3, 4, 3, 2), (([2], [3]), ([0, 1], [0, 1]))),
       ]
-      for bdims in all_bdims(lhs_shape, rhs_shape)
-      for dtype in default_dtypes))
+      for bdims in all_bdims(lhs_shape, rhs_shape)],
+    dtype=default_dtypes)
   def testDotGeneralContractAndBatch(self, lhs_shape, rhs_shape, dtype,
                                      dimension_numbers, bdims):
     rng = jtu.rand_small(self.rng())
@@ -313,45 +273,37 @@ class LaxVmapTest(jtu.JaxTestCase):
     for eqn in jtu.iter_eqns(jaxpr.jaxpr):
       self.assertFalse(eqn.primitive in ["transpose", "broadcast"])
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_dtype={}_broadcast_sizes={}_bdims={}".format(
-          shape, np.dtype(dtype).name, broadcast_sizes, bdims),
-       "shape": shape, "dtype": dtype, "broadcast_sizes": broadcast_sizes,
-       "bdims": bdims}
-      for shape in [(), (2, 3)]
-      for dtype in default_dtypes
-      for broadcast_sizes in [(), (2,), (1, 2)]
-      for bdims in all_bdims(shape)))
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims)
+     for shape in [(), (2, 3)] for bdims in all_bdims(shape)],
+    dtype=default_dtypes,
+    broadcast_sizes=[(), (2,), (1, 2)],
+  )
   def testBroadcast(self, shape, dtype, broadcast_sizes, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.broadcast(x, broadcast_sizes)
     self._CheckBatching(op, 5, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}_bcdims={}_bdims={}".format(
-          jtu.format_shape_dtype_string(inshape, dtype),
-          outshape, broadcast_dimensions, bdims),
-       "inshape": inshape, "dtype": dtype, "outshape": outshape,
-       "dimensions": broadcast_dimensions, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(inshape=inshape, outshape=outshape,
+          broadcast_dimensions=broadcast_dimensions, bdims=bdims)
       for inshape, outshape, broadcast_dimensions in [
           ([2], [2, 2], [0]),
           ([2], [2, 2], [1]),
           ([2], [2, 3], [0]),
           ([], [2, 3], []),
       ]
-      for dtype in default_dtypes
-      for bdims in all_bdims(inshape)))
+      for bdims in all_bdims(inshape)],
+    dtype=default_dtypes,
+  )
   @unittest.skip("this test has failures in some cases")  # TODO(mattjj)
   def testBroadcastInDim(self, inshape, dtype, outshape, dimensions, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.broadcast_in_dim(x, outshape, dimensions)
     self._CheckBatching(op, 5, bdims, (inshape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_dimensions={}_bdims={}".format(
-          jtu.format_shape_dtype_string(arg_shape, np.float32),
-          dimensions, bdims),
-       "arg_shape": arg_shape, "dimensions": dimensions, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, dimensions=dimensions, bdims=bdims)
       for arg_shape, dimensions in [
           [(1,), (0,)],
           [(1,), (-1,)],
@@ -362,21 +314,17 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(2, 1, 3, 1), (3,)],
           [(2, 1, 3, 1), (1, -1)],
       ]
-      for bdims in all_bdims(arg_shape)))
+      for bdims in all_bdims(arg_shape)],
+  )
   def testSqueeze(self, arg_shape, dimensions, bdims):
     dtype = np.float32
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.squeeze(x, dimensions)
     self._CheckBatching(op, 10, bdims, (arg_shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_outshape={}_dims={}_bdims={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          jtu.format_shape_dtype_string(out_shape, dtype),
-          dimensions, bdims),
-       "arg_shape": arg_shape, "out_shape": out_shape, "dtype": dtype,
-       "dimensions": dimensions, "bdims": bdims}
-      for dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, out_shape=out_shape, dimensions=dimensions,
+          bdims=bdims)
       for arg_shape, dimensions, out_shape in [
           [(3, 4), None, (12,)],
           [(2, 1, 4), None, (8,)],
@@ -385,49 +333,41 @@ class LaxVmapTest(jtu.JaxTestCase):
           [(2, 2, 4), (1, 0, 2), (8, 2)],
           [(2, 2, 4), (2, 1, 0), (4, 2, 2)]
       ]
-      for bdims in all_bdims(arg_shape)))
+      for bdims in all_bdims(arg_shape)],
+    dtype=default_dtypes,
+  )
   def testReshape(self, arg_shape, out_shape, dtype, dimensions, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.reshape(x, out_shape, dimensions=dimensions)
     self._CheckBatching(op, 10, bdims, (arg_shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_pads={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(shape, dtype), pads, bdims),
-       "shape": shape, "dtype": dtype, "pads": pads, "bdims": bdims}
-      for shape in [(2, 3)]
-      for bdims in all_bdims(shape, ())
-      for dtype in default_dtypes
-      for pads in [[(1, 2, 1), (0, 1, 0)]]))
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims)
+     for shape in [(2, 3)] for bdims in all_bdims(shape, ())],
+    dtype=default_dtypes,
+    pads=[[(1, 2, 1), (0, 1, 0)]],
+  )
   def testPad(self, shape, dtype, pads, bdims):
     rng = jtu.rand_small(self.rng())
     fun = lambda operand, padding: lax.pad(operand, padding, pads)
     self._CheckBatching(fun, 5, bdims, (shape, ()), (dtype, dtype), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_predshape={}_argshapes={}_bdims={}".format(
-          jtu.format_shape_dtype_string(pred_shape, np.bool_),
-          jtu.format_shape_dtype_string(arg_shape, arg_dtype),
-          bdims),
-       "pred_shape": pred_shape, "arg_shape": arg_shape, "arg_dtype": arg_dtype,
-       "bdims": bdims}
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, pred_shape=pred_shape, bdims=bdims)
       for arg_shape in [(), (3,), (2, 3)]
       for pred_shape in ([(), arg_shape] if arg_shape else [()])
-      for bdims in all_bdims(pred_shape, arg_shape, arg_shape)
-      for arg_dtype in default_dtypes))
+      for bdims in all_bdims(pred_shape, arg_shape, arg_shape)],
+    arg_dtype=default_dtypes,
+  )
   def testSelect(self, pred_shape, arg_shape, arg_dtype, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda c, x, y: lax.select(c < 0, x, y)
     self._CheckBatching(op, 5, bdims, (pred_shape, arg_shape, arg_shape,),
                         (arg_dtype, arg_dtype, arg_dtype), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name":
-       "_shape={}_start_indices={}_limit_indices={}_strides={}_bdims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype),
-          start_indices, limit_indices, strides, bdims),
-       "shape": shape, "dtype": dtype, "starts": start_indices,
-       "limits": limit_indices, "strides": strides, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(shape=shape, starts=start_indices, limits=limit_indices,
+          strides=strides, bdims=bdims)
       for shape, start_indices, limit_indices, strides in [
         [(3,), (1,), (2,), None],
         [(7,), (4,), (7,), None],
@@ -440,16 +380,16 @@ class LaxVmapTest(jtu.JaxTestCase):
         [(5, 3), (1, 1), (5, 3), (2, 1)],
       ]
       for bdims in all_bdims(shape)
-      for dtype in default_dtypes))
+    ],
+    dtype=default_dtypes,
+  )
   def testSlice(self, shape, dtype, starts, limits, strides, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.slice(x, starts, limits, strides)
     self._CheckBatching(op, 5, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_perm={}_bdims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), perm, bdims),
-       "shape": shape, "dtype": dtype, "perm": perm, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(shape=shape, perm=perm, bdims=bdims)
       for shape, perm in [
         [(3, 4), (1, 0)],
         [(3, 4), (0, 1)],
@@ -457,18 +397,16 @@ class LaxVmapTest(jtu.JaxTestCase):
         [(3, 4, 5), (1, 0, 2)],
       ]
       for bdims in all_bdims(shape)
-      for dtype in default_dtypes))
+     ],
+    dtype=default_dtypes,
+  )
   def testTranspose(self, shape, dtype, perm, bdims):
     rng = jtu.rand_default(self.rng())
     op = lambda x: lax.transpose(x, perm)
     self._CheckBatching(op, 5, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_inshape={}_reducedims={}_initval={}_bdims={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dims,
-               init_val, bdims),
-       "op": op, "init_val": init_val, "shape": shape, "dtype": dtype,
-       "dims": dims, "bdims": bdims}
+  @jtu.sample_product(
+    [dict(init_val=init_val, op=op, dtype=dtype)
       for init_val, op, dtypes in [
           (0, lax.add, default_dtypes),
           (1, lax.mul, default_dtypes),
@@ -483,28 +421,29 @@ class LaxVmapTest(jtu.JaxTestCase):
           (dtypes.iinfo(np.uint32).max, lax.min, [np.uint32]),
           (dtypes.iinfo(np.uint64).max, lax.min, [np.uint64]),
       ]
-      for dtype in dtypes
+      for dtype in dtypes],
+    [dict(shape=shape, dims=dims, bdims=bdims)
       for shape, dims in [
           [(3, 4, 5), (0,)], [(3, 4, 5), (1, 2)],
           [(3, 4, 5), (0, 2)], [(3, 4, 5), (0, 1, 2)]
       ]
-      for bdims in all_bdims(shape)))
+      for bdims in all_bdims(shape)],
+  )
   def testReduce(self, op, init_val, shape, dtype, dims, bdims):
     rng = jtu.rand_small(self.rng())
     init_val = np.asarray(init_val, dtype=dtype)
     fun = lambda operand: lax.reduce(operand, init_val, op, dims)
     self._CheckBatching(fun, 5, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_inshape={}_reducedims={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(shape, dtype), dims, bdims),
-       "shape": shape, "dtype": dtype, "dims": dims, "bdims": bdims}
-      for dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, dims=dims, bdims=bdims)
       for shape, dims in [
           [(3, 4, 5), (0,)], [(3, 4, 5), (1, 2)],
           [(3, 4, 5), (0, 2)], [(3, 4, 5), (0, 1, 2)]
       ]
-      for bdims in all_bdims(shape, shape)))
+      for bdims in all_bdims(shape, shape)],
+    dtype=default_dtypes,
+  )
   def testVariadicReduce(self, shape, dtype, dims, bdims):
     def op(a, b):
       x1, y1 = a
@@ -516,35 +455,29 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(fun, 5, bdims, (shape, shape), (dtype, dtype), rng,
                         multiple_results=True)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_inshape={}_reducedims={}_bdims={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), dim,
-               bdims),
-       "op": op, "shape": shape, "dtype": dtype,
-       "dim": dim, "bdims": bdims}
-      for op in [lax.argmin, lax.argmax]
-      for dtype in default_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims, dim=dim)
       for shape in [(3, 4, 5)]
-      for dim in range(len(shape))
-      for bdims in all_bdims(shape)))
+      for bdims in all_bdims(shape)
+      for dim in range(len(shape))],
+    op=[lax.argmin, lax.argmax],
+    dtype=default_dtypes,
+  )
   def testArgminmax(self, op, shape, dtype, dim, bdims):
     rng = jtu.rand_default(self.rng())
     fun = lambda operand: op(operand, dim, np.int32)
     self._CheckBatching(fun, 5, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": ("_op={}_shape={}_dims={}_strides={}_padding={}"
-                         "_basedilation={}_windowdilation={}")
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype),
-               dims, strides, padding, base_dilation, window_dilation),
-       "op": op, "init_val": init_val, "dtype": dtype, "shape": shape,
-       "dims": dims, "strides": strides, "padding": padding,
-       "base_dilation": base_dilation, "window_dilation": window_dilation}
-      for init_val, op, dtypes in [
-          (0, lax.add, [np.float32]),
-          (-np.inf, lax.max, [np.float32]),
-          (np.inf, lax.min, [np.float32]),
-      ]
+  @jtu.sample_product(
+    [dict(init_val=init_val, op=op, dtype=dtype)
+     for init_val, op, dtypes in [
+        (0, lax.add, [np.float32]),
+        (-np.inf, lax.max, [np.float32]),
+        (np.inf, lax.min, [np.float32]),
+     ]
+     for dtype in dtypes],
+    [dict(shape=shape, dims=dims, strides=strides, padding=padding,
+          base_dilation=base_dilation, window_dilation=window_dilation)
       for shape, dims, strides, padding, base_dilation, window_dilation in (
         itertools.chain(
           itertools.product(
@@ -560,7 +493,8 @@ class LaxVmapTest(jtu.JaxTestCase):
             ["VALID", "SAME", [(0, 1), (1, 0), (2, 3), (0, 2)]],
             [(1, 1, 1, 1), (2, 1, 3, 2)],
             [(1, 1, 1, 1), (1, 2, 2, 1)])))
-      for dtype in dtypes))
+    ],
+  )
   def testReduceWindow(self, op, init_val, dtype, shape, dims, strides, padding,
                        base_dilation, window_dilation):
     rng = jtu.rand_small(self.rng())
@@ -573,21 +507,19 @@ class LaxVmapTest(jtu.JaxTestCase):
     for bdims in all_bdims(shape):
       self._CheckBatching(fun, 3, bdims, (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_op={}_shape={}_axis={}_bdims={}_reverse={}"
-       .format(op.__name__, jtu.format_shape_dtype_string(shape, dtype), axis,
-               bdims, reverse),
-       "op": op, "shape": shape, "dtype": dtype, "bdims": bdims,
-       "axis": axis, "reverse": reverse}
+  @jtu.sample_product(
+    [dict(op=op, dtype=dtype)
       for op, types in [
           (lax.cumsum, [np.float32, np.float64]),
           (lax.cumprod, [np.float32, np.float64]),
       ]
-      for dtype in types
+      for dtype in types],
+    [dict(shape=shape, bdims=bdims, axis=axis)
       for shape in [[10], [3, 4, 5]]
       for axis in range(len(shape))
-      for bdims in all_bdims(shape)
-      for reverse in [False, True]))
+      for bdims in all_bdims(shape)],
+    reverse=[False, True],
+  )
   def testCumulativeReduce(self, op, shape, dtype, axis, bdims, reverse):
     rng_factory = (jtu.rand_default if dtypes.issubdtype(dtype, np.integer)
                    else jtu.rand_small)
@@ -595,17 +527,9 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(partial(op, axis=axis, reverse=reverse), 7, bdims,
                         (shape,), (dtype,), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_dtype={}_padding={}".format(np.dtype(dtype).name,
-                                                      padding),
-       "dtype": dtype, "padding": padding}
-      for dtype in float_dtypes
-      for padding in ["VALID", "SAME"]))
-  @jtu.skip_on_flag("jax_skip_slow_tests", True)
-  @jtu.ignore_warning(message="Using reduced precision for gradient.*")
-  def testSelectAndGatherAdd(self, dtype, padding):
-    rng = jtu.rand_small(self.rng())
-    all_configs = itertools.chain(
+  @jtu.sample_product(
+    [dict(shape=shape, dims=dims, strides=strides, bdims=bdims)
+     for shape, dims, strides in itertools.chain(
         itertools.product(
             [(4, 6)],
             [(2, 1), (1, 2)],
@@ -613,27 +537,29 @@ class LaxVmapTest(jtu.JaxTestCase):
         itertools.product(
             [(3, 2, 4, 6)], [(1, 1, 2, 1), (2, 1, 2, 1)],
             [(1, 2, 2, 1), (1, 1, 1, 1)]))
-
+     for bdims in all_bdims(shape, shape)
+    ],
+    dtype=float_dtypes,
+    padding=["VALID", "SAME"]
+  )
+  @jtu.ignore_warning(message="Using reduced precision for gradient.*")
+  def testSelectAndGatherAdd(self, dtype, padding, shape, dims, strides, bdims):
+    rng = jtu.rand_small(self.rng())
     def fun(operand, tangents):
       pads = lax.padtype_to_pads(operand.shape, dims, strides, padding)
       ones = (1,) * len(operand.shape)
       return lax_windowed_reductions._select_and_gather_add(
           operand, tangents, lax.ge_p, dims, strides, pads, ones, ones)
 
-    for shape, dims, strides in all_configs:
-      for bdims in all_bdims(shape, shape):
-        self._CheckBatching(fun, 3, bdims, (shape, shape), (dtype, dtype), rng)
+    self._CheckBatching(fun, 3, bdims, (shape, shape), (dtype, dtype), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": f"_dtype={jtu.format_shape_dtype_string(shape, dtype)}"
-      f"_padding={padding}_dims={dims}_strides={strides}",
-       "dtype": dtype, "padding": padding, "shape": shape,
-       "dims": dims, "strides": strides}
-      for dtype in float_dtypes
-      for padding in ["VALID", "SAME"]
-      for shape in [(3, 2, 4, 6)]
-      for dims in [(1, 1, 2, 1)]
-      for strides in [(1, 2, 2, 1), (1, 1, 1, 1)]))
+  @jtu.sample_product(
+    dtype=float_dtypes,
+    padding=["VALID", "SAME"],
+    shape=[(3, 2, 4, 6)],
+    dims=[(1, 1, 2, 1)],
+    strides=[(1, 2, 2, 1), (1, 1, 1, 1)],
+  )
   def testSelectAndScatterAdd(self, dtype, padding, shape, dims, strides):
     rng = jtu.rand_small(self.rng())
 
@@ -652,13 +578,12 @@ class LaxVmapTest(jtu.JaxTestCase):
       self._CheckBatching(fun, 3, bdims, (cotangent_shape, shape),
                           (dtype, dtype), rng)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_bdims={}_fft_ndims={}"
-       .format(shape, bdims, fft_ndims),
-       "shape": shape, "bdims": bdims, "fft_ndims": fft_ndims}
-      for shape in [(5,), (3, 4, 5), (2, 3, 4, 5)]
-      for bdims in all_bdims(shape)
-      for fft_ndims in range(0, min(3, len(shape)) + 1)))
+  @jtu.sample_product(
+    [dict(shape=shape, fft_ndims=fft_ndims, bdims=bdims)
+    for shape in [(5,), (3, 4, 5), (2, 3, 4, 5)]
+    for bdims in all_bdims(shape)
+    for fft_ndims in range(0, min(3, len(shape)) + 1)],
+  )
   def testFft(self, fft_ndims, shape, bdims):
     rng = jtu.rand_default(self.rng())
     ndims = len(shape)
@@ -668,13 +593,9 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(op, 5, bdims, [shape], [np.complex64], rng,
                         rtol=1e-5)
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_dnums={}_slice_sizes={}_bdims={}"
-       .format(jtu.format_shape_dtype_string(shape, dtype), idxs, dnums,
-               slice_sizes, bdims),
-       "shape": shape, "dtype": dtype, "idxs": idxs, "dnums": dnums,
-       "slice_sizes": slice_sizes, "bdims": bdims}
-      for dtype in all_dtypes
+  @jtu.sample_product(
+    [dict(shape=shape, idxs=idxs, dnums=dnums, slice_sizes=slice_sizes,
+          bdims=bdims)
       for shape, idxs, dnums, slice_sizes in [
           ((5,), np.array([[0], [2]]), lax.GatherDimensionNumbers(
             offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,)),
@@ -689,7 +610,9 @@ class LaxVmapTest(jtu.JaxTestCase):
             offset_dims=(1,), collapsed_slice_dims=(0,), start_index_map=(0, 1)),
             (1, 3)),
       ]
-      for bdims in all_bdims(shape, idxs.shape)))
+      for bdims in all_bdims(shape, idxs.shape)],
+    dtype=all_dtypes
+  )
   def testGather(self, shape, dtype, idxs, dnums, slice_sizes, bdims):
     fun = partial(lax.gather, dimension_numbers=dnums, slice_sizes=slice_sizes)
     self._CheckBatching(fun, 0, bdims, [shape, idxs.shape], [dtype, idxs.dtype],
@@ -697,13 +620,10 @@ class LaxVmapTest(jtu.JaxTestCase):
     self._CheckBatching(fun, 5, bdims, [shape, idxs.shape], [dtype, idxs.dtype],
                         jtu.rand_default(self.rng()))
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_idxs={}_update={}_dnums={}_bdims={}".format(
-          jtu.format_shape_dtype_string(arg_shape, dtype),
-          idxs, update_shape, dnums, bdims),
-       "arg_shape": arg_shape, "dtype": dtype, "idxs": idxs,
-       "update_shape": update_shape, "dnums": dnums, "bdims": bdims}
-      for dtype in float_dtypes
+
+  @jtu.sample_product(
+    [dict(arg_shape=arg_shape, idxs=idxs, update_shape=update_shape,
+          dnums=dnums, bdims=bdims)
       for arg_shape, idxs, update_shape, dnums in [
           ((5,), np.array([[0], [2]]), (2,), lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,),
@@ -715,7 +635,9 @@ class LaxVmapTest(jtu.JaxTestCase):
             update_window_dims=(1,), inserted_window_dims=(0,),
             scatter_dims_to_operand_dims=(0,))),
       ]
-      for bdims in all_bdims(arg_shape, idxs.shape, update_shape)))
+      for bdims in all_bdims(arg_shape, idxs.shape, update_shape)],
+    dtype=float_dtypes
+  )
   def testScatterAdd(self, arg_shape, dtype, idxs, update_shape, dnums, bdims):
     fun = partial(lax.scatter_add, dimension_numbers=dnums)
     self._CheckBatching(fun, 5, bdims, [arg_shape, idxs.shape, update_shape],
@@ -740,40 +662,34 @@ class LaxVmapTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(TypeError, "Shapes must be 1D sequences.*"):
       lax.broadcast_shapes(err_shape2)  # pytype: disable=wrong-arg-types
 
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_k={}_bdims={}".format(
-          jtu.format_shape_dtype_string(shape, dtype), k, bdims),
-       "shape": shape, "dtype": dtype, "k": k, "bdims": bdims, "rng_factory": rng_factory}
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims)
       for shape in [(4,), (3, 5, 3)]
-      for k in [1, 3]
-      for bdims in all_bdims(shape)
-      # TODO(b/155170120): test with repeats once the XLA:CPU stable top_k bug is fixed:
-      # The top_k indices for integer arrays with identical entries won't match between
-      # vmap'd version and manual reference, so only test unique integer arrays for int_dtypes.
-      # Note also that we chose 3 * 5 * 3 * 5 such that it fits in the range of
-      # values a bfloat16 can represent exactly to avoid ties.
-      for dtype, rng_factory in itertools.chain(
-        unsafe_zip(default_dtypes, itertools.repeat(jtu.rand_unique_int)))))
-  def testTopK(self, shape, dtype, k, bdims, rng_factory):
-    rng = rng_factory(self.rng())
+      for bdims in all_bdims(shape)],
+    k=[1, 3],
+    dtype=default_dtypes,
+  )
+  # The top_k indices for integer arrays with identical entries won't match between
+  # vmap'd version and manual reference, so only test unique integer arrays for int_dtypes.
+  # Note also that we chose 3 * 5 * 3 * 5 such that it fits in the range of
+  # values a bfloat16 can represent exactly to avoid ties.
+  def testTopK(self, shape, dtype, k, bdims):
+    rng = jtu.rand_int(self.rng(), high=prod(shape))
     # _CheckBatching doesn't work with tuple outputs, so test outputs separately.
     op1 = lambda x: lax.top_k(x, k=k)[0]
     self._CheckBatching(op1, 5, bdims, (shape,), (dtype,), rng)
     op2 = lambda x: lax.top_k(x, k=k)[1]
     self._CheckBatching(op2, 5, bdims, (shape,), (dtype,), rng)
 
-
-  @parameterized.named_parameters(jtu.cases_from_list(
-      {"testcase_name": "_shape={}_dimension={}_arity={}_bdims={}_isstable={}"
-       .format(jtu.format_shape_dtype_string(shape, np.float32), dimension,
-               arity, bdims, is_stable),
-       "shape": shape, "dimension": dimension, "arity": arity, "bdims": bdims,
-       "is_stable": is_stable}
+  @jtu.sample_product(
+    [dict(shape=shape, bdims=bdims, dimension=dimension, arity=arity)
       for shape in [(2, 3)]
       for dimension in [0, 1]
       for arity in range(3)
       for bdims in all_bdims(*((shape,) * arity))
-      for is_stable in [False, True]))
+     ],
+    is_stable=[False, True]
+  )
   def testSort(self, shape, dimension, arity, bdims, is_stable):
     rng = jtu.rand_default(self.rng())
     if arity == 1:


### PR DESCRIPTION
jtu.sample_product.

Gives a ~2x improvement in pytest --collect-only timing for lax_numpy_test.