### PR TITLE
Avoid loading scipy eagerly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ PLEASE REMEMBER TO CHANGE THE '..main' WITH AN ACTUAL TAG in GITHUB LINK.
 -->
 
 ## jax 0.3.24
+  * JAX should be faster to import. We now import scipy lazily, which accounted
+    for a significant fraction of JAX's import time.
 
 ## jaxlib 0.3.24
 

--- a/jax/__init__.py
+++ b/jax/__init__.py
@@ -149,6 +149,7 @@ from jax import numpy as numpy
 from jax import ops as ops
 from jax import profiler as profiler
 from jax import random as random
+from jax import scipy as scipy
 from jax import sharding as sharding
 from jax import stages as stages
 from jax import tree_util as tree_util

--- a/jax/_src/lazy_loader.py
+++ b/jax/_src/lazy_loader.py
@@ -1,0 +1,39 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A LazyLoader class."""
+
+import importlib
+
+
+def attach(package_name, submodules):
+  """Lazily loads submodules of a package.
+
+  Example use:
+  ```
+  __getattr__, __dir__, __all__ = lazy_loader.attach(__name__, ["sub1", "sub2"])
+  ```
+  """
+
+  __all__ = list(submodules)
+
+  def __getattr__(name):
+    if name in submodules:
+      return importlib.import_module(f"{package_name}.{name}")
+    raise AttributeError(f"module '{package_name}' has no attribute '{name}")
+
+  def __dir__():
+    return __all__
+
+  return __getattr__, __dir__, __all__

--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -21,19 +21,6 @@ import os
 import warnings
 from typing import Optional, Tuple
 
-# This apparently-unused import is to work around
-# https://github.com/google/jax/issues/9218#issuecomment-1016949739
-# If the user is using Conda, we want to ensure that Conda's libstdc++ is chosen
-# by the dynamic linker in preference to the system libstdc++. Before importing
-# jaxlib, we first must import a library that:
-# a) is likely to be provided by Conda and not hand-installed by the user, and
-# b) uses C++ and links to libstdc++.
-# Some submodules of scipy (e.g., scipy.signal) satisfy this criterion.
-# If the user isn't using Conda, this code merely wastes a bit of time, but
-# we're likely to import scipy anyway later.
-import scipy.signal as _signal
-del _signal
-
 try:
   import jaxlib as jaxlib
 except ModuleNotFoundError as err:

--- a/jax/_src/nn/functions.py
+++ b/jax/_src/nn/functions.py
@@ -27,8 +27,7 @@ from jax import lax
 from jax import core
 from jax.core import AxisName
 from jax._src import util
-from jax.scipy.special import expit
-from jax.scipy.special import logsumexp as _logsumexp
+from jax._src.ops.special import logsumexp as _logsumexp
 import jax.numpy as jnp
 
 Array = Any

--- a/jax/_src/ops/special.py
+++ b/jax/_src/ops/special.py
@@ -1,0 +1,86 @@
+# Copyright 2018 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+from jax import lax
+from jax import numpy as jnp
+from jax._src.numpy.lax_numpy import _reduction_dims, _promote_args_inexact
+
+# The definition of logsumexp is shared between jax.nn and jax.scipy, and
+# although it matches scipy's definition, we put it here to avoid having
+# unnecessary scipy dependencies.
+
+def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
+  r"""Log-sum-exp reduction.
+
+  Computes
+
+  .. math::
+    \mathrm{logsumexp}(a) = \mathrm{log} \sum_j b \cdot \mathrm{exp}(a_{ij})
+
+  where the :math:`j` indices range over one or more dimensions to be reduced.
+
+  Args:
+    a: the input array
+    axis: the axis or axes over which to reduce. May be either ``None``, an
+      int, or a tuple of ints.
+    b: scaling factors for :math:`\mathrm{exp}(a)`. Must be broadcastable to the
+      shape of `a`.
+    keepdims: If ``True``, the axes that are reduced are left in the output as
+      dimensions of size 1.
+    return_sign: If ``True``, the output will be a ``(result, sign)`` pair,
+      where ``sign`` is the sign of the sums and ``result`` contains the
+      logarithms of their absolute values. If ``False`` only ``result`` is
+      returned and it will contain NaN values if the sums are negative.
+
+  Returns:
+    Either an array ``result`` or a pair of arrays ``(result, sign)``, depending
+    on the value of the ``return_sign`` argument.
+  """
+  if b is not None:
+    a, b = _promote_args_inexact("logsumexp", a, b)
+    a = jnp.where(b != 0, a, -jnp.inf)
+  else:
+    a, = _promote_args_inexact("logsumexp", a)
+  pos_dims, dims = _reduction_dims(a, axis)
+  amax = jnp.max(a, axis=dims, keepdims=keepdims)
+  amax = lax.stop_gradient(lax.select(jnp.isfinite(amax), amax, lax.full_like(amax, 0)))
+  amax_with_dims = amax if keepdims else lax.expand_dims(amax, pos_dims)
+  # fast path if the result cannot be negative.
+  if b is None and not jnp.issubdtype(a.dtype, jnp.complexfloating):
+    out = lax.add(lax.log(jnp.sum(lax.exp(lax.sub(a, amax_with_dims)),
+                                  axis=dims, keepdims=keepdims)),
+                  amax)
+    sign = jnp.where(jnp.isnan(out), out, 1.0)
+    sign = jnp.where(jnp.isneginf(out), 0.0, sign).astype(out.dtype)
+  else:
+    expsub = lax.exp(lax.sub(a, amax_with_dims))
+    if b is not None:
+      expsub = lax.mul(expsub, b)
+    sumexp = jnp.sum(expsub, axis=dims, keepdims=keepdims)
+
+    sign = lax.stop_gradient(jnp.sign(sumexp))
+    if jnp.issubdtype(sumexp.dtype, jnp.complexfloating):
+      if return_sign:
+        sumexp = sign*sumexp
+      out = lax.add(lax.log(sumexp), amax)
+    else:
+      out = lax.add(lax.log(lax.abs(sumexp)), amax)
+  if return_sign:
+    return (out, sign)
+  if b is not None:
+    if not jnp.issubdtype(out.dtype, jnp.complexfloating):
+      with jax.debug_nans(False):
+        out = jnp.where(sign < 0, jnp.array(jnp.nan, dtype=out.dtype), out)
+  return out

--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -27,7 +27,7 @@ import jax.numpy as jnp
 from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.lax_numpy import _reduction_dims, _promote_args_inexact
 from jax._src.numpy.util import _wraps
-
+from jax._src.ops import special as ops_special
 
 @_wraps(osp_special.gammaln, module='scipy.special')
 def gammaln(x):
@@ -104,42 +104,7 @@ def expit(x):
 
 @_wraps(osp_special.logsumexp, module='scipy.special')
 def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
-  if b is not None:
-    a, b = _promote_args_inexact("logsumexp", a, b)
-    a = jnp.where(b != 0, a, -jnp.inf)
-  else:
-    a, = _promote_args_inexact("logsumexp", a)
-  pos_dims, dims = _reduction_dims(a, axis)
-  amax = jnp.max(a, axis=dims, keepdims=keepdims)
-  amax = lax.stop_gradient(lax.select(jnp.isfinite(amax), amax, lax.full_like(amax, 0)))
-  amax_with_dims = amax if keepdims else lax.expand_dims(amax, pos_dims)
-  # fast path if the result cannot be negative.
-  if b is None and not np.issubdtype(a.dtype, np.complexfloating):
-    out = lax.add(lax.log(jnp.sum(lax.exp(lax.sub(a, amax_with_dims)),
-                                  axis=dims, keepdims=keepdims)),
-                  amax)
-    sign = jnp.where(jnp.isnan(out), out, 1.0)
-    sign = jnp.where(jnp.isneginf(out), 0.0, sign).astype(out.dtype)
-  else:
-    expsub = lax.exp(lax.sub(a, amax_with_dims))
-    if b is not None:
-      expsub = lax.mul(expsub, b)
-    sumexp = jnp.sum(expsub, axis=dims, keepdims=keepdims)
-
-    sign = lax.stop_gradient(jnp.sign(sumexp))
-    if np.issubdtype(sumexp.dtype, np.complexfloating):
-      if return_sign:
-        sumexp = sign*sumexp
-      out = lax.add(lax.log(sumexp), amax)
-    else:
-      out = lax.add(lax.log(lax.abs(sumexp)), amax)
-  if return_sign:
-    return (out, sign)
-  if b is not None:
-    if not np.issubdtype(out.dtype, np.complexfloating):
-      with jax.debug_nans(False):
-        out = jnp.where(sign < 0, jnp.array(np.nan, dtype=out.dtype), out)
-  return out
+  return ops_special.logsumexp(a, axis, b, keepdims, return_sign)
 
 
 @_wraps(osp_special.xlogy, module='scipy.special')

--- a/jax/scipy/__init__.py
+++ b/jax/scipy/__init__.py
@@ -12,12 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jax.scipy import interpolate as interpolate
-from jax.scipy import linalg as linalg
-from jax.scipy import ndimage as ndimage
-from jax.scipy import signal as signal
-from jax.scipy import sparse as sparse
-from jax.scipy import special as special
-from jax.scipy import stats as stats
-from jax.scipy import fft as fft
-from jax.scipy import cluster as cluster
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  from jax.scipy import interpolate as interpolate
+  from jax.scipy import linalg as linalg
+  from jax.scipy import ndimage as ndimage
+  from jax.scipy import signal as signal
+  from jax.scipy import sparse as sparse
+  from jax.scipy import special as special
+  from jax.scipy import stats as stats
+  from jax.scipy import fft as fft
+  from jax.scipy import cluster as cluster
+else:
+  import jax._src.lazy_loader as _lazy
+  __getattr__, __dir__, __all__ = _lazy.attach(__name__, [
+    "interpolate",
+    "linalg",
+    "ndimage",
+    "signal",
+    "sparse",
+    "special",
+    "stats",
+    "fft",
+    "cluster",
+  ])
+  del _lazy
+
+del TYPE_CHECKING

--- a/jaxlib/lapack.py
+++ b/jaxlib/lapack.py
@@ -27,6 +27,10 @@ from . import _lapack
 for _name, _value in _lapack.registrations().items():
   xla_client.register_custom_call_target(_name, _value, platform="cpu")
 
+# Function that lazily initializes the LAPACK kernels in the runtime on first
+# use.
+_initialize = _lapack.initialize
+
 
 def _mhlo_u8(x):
   return mhlo.ConstantOp(
@@ -46,6 +50,7 @@ def _mhlo_s32(x):
 # triangular solve
 def trsm_mhlo(dtype, alpha, a, b, left_side=False, lower=False, trans_a=False,
                conj_a=False, diag=False):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   b_type = ir.RankedTensorType(b.type)
 
@@ -95,6 +100,7 @@ def trsm_mhlo(dtype, alpha, a, b, left_side=False, lower=False, trans_a=False,
 # # ?getrf: LU decomposition
 
 def getrf_mhlo(dtype, a):
+  _initialize()
   dims = ir.RankedTensorType(a.type).shape
   assert len(dims) >= 2
   m, n = dims[-2:]
@@ -139,6 +145,7 @@ def getrf_mhlo(dtype, a):
 # # ?geqrf: QR decomposition
 
 def geqrf_mhlo(dtype, a):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   dims = a_type.shape
   assert len(dims) >= 2
@@ -191,6 +198,7 @@ def geqrf_mhlo(dtype, a):
 # # ?orgqr: product of elementary Householder reflectors:
 
 def orgqr_mhlo(dtype, a, tau):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   dims = a_type.shape
   assert len(dims) >= 2
@@ -249,6 +257,7 @@ def orgqr_mhlo(dtype, a, tau):
 # ?potrf: Cholesky decomposition
 
 def potrf_mhlo(dtype, a, lower=False):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   dims = a_type.shape
   m, n = dims[-2:]
@@ -289,6 +298,7 @@ def potrf_mhlo(dtype, a, lower=False):
 # # ?gesdd: Singular value decomposition
 
 def gesdd_mhlo(dtype, a, full_matrices=True, compute_uv=True):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   dims = a_type.shape
   assert len(dims) >= 2
@@ -378,6 +388,7 @@ def gesdd_mhlo(dtype, a, full_matrices=True, compute_uv=True):
 # # syevd: Symmetric eigendecomposition
 
 def syevd_mhlo(dtype, a, lower=False):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   dims = a_type.shape
   assert len(dims) >= 2
@@ -456,6 +467,7 @@ def syevd_mhlo(dtype, a, lower=False):
 # # geev: Nonsymmetric eigendecomposition
 
 def geev_mhlo(dtype, a, jobvl=True, jobvr=True):
+  _initialize()
   dims = ir.RankedTensorType(a.type).shape
   assert len(dims) >= 2
   m, n = dims[-2:]
@@ -540,6 +552,7 @@ def geev_mhlo(dtype, a, jobvl=True, jobvr=True):
 # # gees : Schur factorization
 
 def gees_mhlo(dtype, a, jobvs=True, sort=False, select=None):
+  _initialize()
   a_type = ir.RankedTensorType(a.type)
   etype = a_type.element_type
   dims = a_type.shape

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -458,6 +458,18 @@ jax_test(
     deps = [":lax_test_lib"],
 )
 
+py_test(
+    name = "lazy_loader_test",
+    srcs = [
+        "lazy_loader_module/__init__.py",
+        "lazy_loader_module/lazy_test_submodule.py",
+        "lazy_loader_test.py",
+    ],
+    deps = [
+        "//jax:test_util",
+    ],
+)
+
 jax_test(
     name = "linalg_test",
     srcs = ["linalg_test.py"],

--- a/tests/lazy_loader_module/__init__.py
+++ b/tests/lazy_loader_module/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax._src.lazy_loader as _lazy
+
+__getattr__, __dir__, __all__ = _lazy.attach(
+    __name__, ["lazy_test_submodule"])

--- a/tests/lazy_loader_module/lazy_test_submodule.py
+++ b/tests/lazy_loader_module/lazy_test_submodule.py
@@ -1,0 +1,15 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def a_function(): return 42

--- a/tests/lazy_loader_test.py
+++ b/tests/lazy_loader_test.py
@@ -1,0 +1,46 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+from absl.testing import absltest
+from jax._src import test_util as jtu
+
+
+class LazyLoaderTest(absltest.TestCase):
+
+  def testLazyLoader(self):
+    self.assertEmpty([m for m in sys.modules if "lazy_test_submodule" in m])
+
+    # This manipulation of sys.path exists to make this test work in Google's
+    # Hermetic Python environment: it ensures the module is resolvable.
+    saved_path = sys.path[0]
+    try:
+      sys.path[0] = os.path.dirname(__file__)
+      import lazy_loader_module as l
+    finally:
+      sys.path[0] = saved_path
+
+    self.assertEqual(["lazy_test_submodule"], l.__all__)
+    self.assertEqual(["lazy_test_submodule"], dir(l))
+
+    # The submodule should be imported only after it is accessed.
+    self.assertEmpty([m for m in sys.modules if "lazy_test_submodule" in m])
+    self.assertEqual(42, l.lazy_test_submodule.a_function())
+    self.assertLen([m for m in sys.modules if "lazy_test_submodule" in m], 1)
+
+
+if __name__ == "__main__":
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -19,6 +19,7 @@ import unittest
 
 import numpy as np
 import scipy
+import scipy.linalg
 import scipy as osp
 
 from absl.testing import absltest


### PR DESCRIPTION
scipy accounts for around 400ms of the 900ms of JAX's import time. By loading scipy lazily, we can improve the timing of `import jax` down to about 500ms.