### PR TITLE
Update scipy version in jax.scipy.fft

### DIFF
--- a/jax/_src/scipy/fft.py
+++ b/jax/_src/scipy/fft.py
@@ -14,7 +14,7 @@
 
 from functools import partial
 
-import scipy.fftpack as osp_fft  # TODO use scipy.fft once scipy>=1.4.0 is used
+import scipy.fft as osp_fft
 from jax import lax, numpy as jnp
 from jax._src.util import canonicalize_axis
 from jax._src.numpy.util import _wraps, _promote_dtypes_complex

--- a/tests/scipy_fft_test.py
+++ b/tests/scipy_fft_test.py
@@ -17,7 +17,7 @@ from absl.testing import absltest, parameterized
 
 from jax._src import test_util as jtu
 import jax.scipy.fft as jsp_fft
-import scipy.fftpack as osp_fft  # TODO use scipy.fft once scipy>=1.4.0 is used
+import scipy.fft as osp_fft
 
 from jax.config import config
 
@@ -75,7 +75,7 @@ class LaxBackedScipyFftTests(jtu.JaxTestCase):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: (rng(shape, dtype),)
     jnp_fn = lambda a: jsp_fft.dctn(a, s=s, axes=axes, norm=norm)
-    np_fn = lambda a: osp_fft.dctn(a, shape=s, axes=axes, norm=norm)
+    np_fn = lambda a: osp_fft.dctn(a, s=s, axes=axes, norm=norm)
     self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=False,
                             tol=1e-4)
     self._CompileAndCheck(jnp_fn, args_maker, atol=1e-4)


### PR DESCRIPTION
This is safe because we now require scipy 1.8 or newer.