### PR TITLE
[ROCM] Add default setting for TENSORFLOW_ROCM_COMMIT

### DIFF
--- a/build/rocm/ci_build.sh
+++ b/build/rocm/ci_build.sh
@@ -101,6 +101,7 @@ fi
 # Run the command inside the container.
 echo "Running '${POSITIONAL_ARGS[*]}' inside ${DOCKER_IMG_NAME}..."
 
+export TENSORFLOW_ROCM_COMMIT="${TENSORFLOW_ROCM_COMMIT:-}"
 
 docker run ${KEEP_IMAGE} --name ${DOCKER_IMG_NAME} --pid=host \
   -v ${WORKSPACE}:/workspace \


### PR DESCRIPTION
A recent PR added an env var for TENSORFLOW_ROCM_COMMIT to the ROCM build CI scripts. (https://github.com/google/jax/pull/12573)

This PR adds a default setting (blank) for the env var to keep docker run happy in case you don't have this env var set at all.