### PR TITLE
make device_put(prngkeyarray, sharding) for Array

### DIFF
--- a/jax/_src/array.py
+++ b/jax/_src/array.py
@@ -116,6 +116,8 @@ class ArrayImpl(basearray.Array):
                arrays: Union[Sequence[DeviceArray], Sequence[ArrayImpl]],
                committed: bool, _skip_checks: bool = False):
     # NOTE: the actual implementation of the constructor is moved to C++.
+    assert all(isinstance(a, DeviceArray) or hasattr(a, '_arrays')
+               for a in arrays)
 
     self.aval = aval
     self._sharding = sharding
@@ -545,39 +547,17 @@ def _array_pmap_shard_arg(x, devices, indices, mode):
     return pxla._shard_sharded_device_array_slow_path(x, devices, indices, mode)
 
 
-def _array_rest_shard_arg(x, devices, indices, mode):
-  if not x._committed:
-    if dispatch.is_single_device_sharding(x.sharding):
-      # This condition is to break the recursion that happens when only
-      # `pxla._shard_device_array` is used since it has `_multi_slice` in the
-      # implementation which is jitted. Eventually it calls back here and the
-      # recursion happens.
-      x_indices = tuple(x.sharding.addressable_devices_indices_map(x.shape).values())
-      if x_indices == indices:
-        return [buf if buf.device() == d else buf.copy_to_device(d)
-                for buf, d in safe_zip(x._arrays, devices)]
-      return pxla._shard_device_array(x, devices, indices, mode)
-    else:
-      raise NotImplementedError('Resharding uncommitted arrays sharded over '
-                                'multiple devices is not supported.')
-  # TODO(yashkatariya): Remove the special case here and don't move to another
-  # device if its already committed. There is a TODO in dispatch.py already
-  # for this.
-  if dispatch.is_single_device_sharding(x.sharding):
+def _array_rest_shard_arg(x: ArrayImpl, devices, indices, mode):
+  x_indices = x.sharding.addressable_devices_indices_map(x.shape).values()
+  if tuple(indices) == tuple(x_indices):
     return [buf if buf.device() == d else buf.copy_to_device(d)
             for buf, d in safe_zip(x._arrays, devices)]
-  # If PmapSharding exists, then do a round trip via host. This will happen
-  # if the input Array containing PmapSharding takes the jit path
-  # i.e. `apply_primitive` or `xla_callable_uncached`. `jit(pmap)` is the most
-  # common case where this will happen.
-  # TODO(yashkatariya): Remove the special case here and don't move to another
-  # device if its already committed. There is a TODO in dispatch.py already
-  # for this.
   elif isinstance(x.sharding, PmapSharding):
     return pxla.device_put(x._value, devices, replicate=True)
+  elif x.is_fully_addressable():
+    return pxla._shard_device_array(x, devices, indices, mode)
   else:
-    return x._arrays
-
+    raise NotImplementedError("foo")
 
 def _array_shard_arg(x, devices, indices, mode):
   if mode == pxla.InputsHandlerMode.pmap:

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -1295,16 +1295,28 @@ def _copy_array_to_device(x: jax.Array, device: Optional[xc.Device]) -> jax.Arra
 def _device_put_impl(
     x, device: Optional[Union[Device, jax.sharding.Sharding]] = None):
   from jax._src import array, sharding
+  from jax.interpreters import pxla
+
+  try:
+    a = xla.abstractify(x)
+  except TypeError as err:
+    raise TypeError(
+        f"Argument '{x}' of type {type(x)} is not a valid JAX type") from err
 
   if isinstance(device, sharding.Sharding):
-    if not device.is_fully_addressable():  # type: ignore
+    s = device
+    if not s.is_fully_addressable():  # type: ignore
       raise ValueError(
           "device_put's second argument must be a Device or a Sharding which "
           f"represents addressable devices, but got {sharding}")
-    if getattr(x, 'sharding', None) == device:
+    if getattr(x, 'sharding', None) == s:
       return x
-    # TODO(mattjj,yashkatariya,phawkins): runtime fast resharding here?
-    return array.make_array_from_callback(x.shape, device, lambda idx: x[idx])
+    # TODO(mattjj,yashkatariya,phawkins): more runtime fast resharding here?
+    arg_handler = pxla.shard_arg_handlers[type(x)]
+    result_handler = array._array_global_result_handler(a, s, True, False)
+    map_ = s.devices_indices_map(x.shape)
+    return result_handler(arg_handler(x, list(map_), list(map_.values()),
+                                      pxla.InputsHandlerMode.pjit_or_xmap))
 
   # Only `Device` exists below. `Sharding` instance is handled above.
   if isinstance(x, array.ArrayImpl):
@@ -1320,11 +1332,6 @@ def _device_put_impl(
   if device_array.type_is_device_array(x):
     return _copy_device_array_to_device(x, device)
 
-  try:
-    a = xla.abstractify(x)
-  except TypeError as err:
-    raise TypeError(
-        f"Argument '{x}' of type {type(x)} is not a valid JAX type") from err
   return aval_to_result_handler(device, a)(None, *device_put(x, device))
 
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1491,6 +1491,7 @@ class APITest(jtu.JaxTestCase):
     mesh = maps.Mesh(jax.devices(), ('x',))
     s = sharding.MeshPspecSharding(mesh, P('x'))
     x = jnp.arange(len(jax.devices()))
+
     y = jax.device_put(x, s)
     self.assertEqual(y.sharding, s)
     self.assertArraysAllClose(y, x)
@@ -1507,11 +1508,6 @@ class APITest(jtu.JaxTestCase):
     u = jax.device_put(y, jax.devices()[0])
     self.assertArraysAllClose(u, y)
     self.assertEqual(u.device(), jax.devices()[0])
-
-    # TODO(frostig): make this pass with JAX_ENABLE_CUSTOM_PRNG=1
-    # # this can cover opaque dtypes
-    # x = jax.random.split(jax.random.PRNGKey(0), len(jax.devices()))
-    # jax.device_put(x, s)  # doesn't crash
 
   def test_device_get_scalar(self):
     x = np.arange(12.).reshape((3, 4)).astype("float32")


### PR DESCRIPTION
Actually we're changing the contract of shard_arg_handlers to be more analogous to the arg handlers for jit (confusingly called device_put_handlers).

We want to use one set of handlers for both the `jax.device_put` API and for handling arguments to a pjit computation. With one set of handlers, it's easier to override their behavior (e.g. an opaque dtype, like for PRNG `KeyArray`s, can register one handler and then work both as arguments for pjit computations and in a `jax.device_put` call). The two callers, pjit computation dispatch and `jax.device_put`, have different assumptions: in particular, `jax.device_put` doesn't care about whether its array-valued argument is committed (it just wants to place/reshard its argument), whereas pjit will look at the committed bit and check agreement with other committed inputs to the computation (and with_sharding_constraint calls). So the callee, i.e. the shard arg handlers, shouldn't actually look at the committed bit, so that it can be used by both callers.