### PR TITLE
[dynamic-shapes] implement bint arrays (opaque dtypes), add padding rules

### DIFF
--- a/jax/_src/lax/lax.py
+++ b/jax/_src/lax/lax.py
@@ -559,17 +559,20 @@ def convert_element_type(operand: ArrayLike, new_dtype: DTypeLike) -> Array:
 
 def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DTypeLike] = None,
                           weak_type: bool = False):
+  if (core.is_opaque_dtype(new_dtype) or
+      core.is_opaque_dtype(getattr(operand, 'dtype', None))):
+    return convert_element_type_p.bind(operand, new_dtype=new_dtype,
+                                       weak_type=bool(weak_type))
+
   # Don't canonicalize old_dtype because x64 context might cause
   # un-canonicalized operands to be passed in.
   old_dtype = dtypes.dtype(operand, canonicalize=False)
   old_weak_type = dtypes.is_weakly_typed(operand)
-
   if new_dtype is None:
     new_dtype = old_dtype
   else:
     new_dtype = np.dtype(new_dtype)
   new_dtype = dtypes.dtype(new_dtype, canonicalize=True)
-  new_weak_type = bool(weak_type)
 
   if (dtypes.issubdtype(old_dtype, np.complexfloating) and
       not dtypes.issubdtype(new_dtype, np.complexfloating)):
@@ -585,11 +588,11 @@ def _convert_element_type(operand: ArrayLike, new_dtype: Optional[DTypeLike] = N
     operand = np.asarray(operand, new_dtype)
     old_weak_type = False
 
-  if (old_dtype, old_weak_type) == (new_dtype, new_weak_type) and _is_array_or_tracer(operand):
+  if (old_dtype, old_weak_type) == (new_dtype, weak_type) and _is_array_or_tracer(operand):
     return type_cast(Array, operand)
   else:
     return convert_element_type_p.bind(operand, new_dtype=new_dtype,
-                                       weak_type=new_weak_type)
+                                       weak_type=bool(weak_type))
 
 def bitcast_convert_type(operand: ArrayLike, new_dtype: DTypeLike) -> Array:
   """Elementwise bitcast.
@@ -1067,6 +1070,12 @@ def _get_bitwise_and_identity(dtype: DTypeLike) -> np.ndarray:
 
 def _get_bitwise_or_identity(dtype: DTypeLike) -> np.ndarray:
   return np.array(0, dtype)
+
+def _get_sum_identity(dtype: DTypeLike) -> np.ndarray:
+  return np.array(0, dtype)
+
+def _get_prod_identity(dtype: DTypeLike) -> np.ndarray:
+  return np.array(1, dtype)
 
 def _get_max_identity(dtype: DTypeLike) -> np.ndarray:
   if dtypes.issubdtype(dtype, np.inexact):
@@ -2352,7 +2361,8 @@ def _convert_elt_type_folding_rule(consts, eqn):
   c, = consts
   o, = eqn.outvars
   if (type(c) in {np.ndarray, *dtypes.python_scalar_dtypes} and
-      isinstance(o.aval, core.UnshapedArray) and not np.shape(c)):
+      isinstance(o.aval, core.UnshapedArray) and not np.shape(c) and
+      not core.is_opaque_dtype(eqn.params['new_dtype'])):
     out = np.array(c, eqn.params['new_dtype'])
     if not o.aval.weak_type:
       return [out], None
@@ -2363,7 +2373,9 @@ def _convert_elt_type_folding_rule(consts, eqn):
 
 def _convert_elt_type_fwd_rule(eqn):
   v, = eqn.invars
-  if (v.aval.dtype == eqn.params['new_dtype'] and
+  if (not core.is_opaque_dtype(eqn.params['new_dtype']) and
+      not core.is_opaque_dtype(v.aval.dtype) and
+      v.aval.dtype == eqn.params['new_dtype'] and
       v.aval.weak_type == eqn.params['weak_type']):
     return [v], None
   else:
@@ -2382,7 +2394,6 @@ def _convert_elt_type_pp_rule(eqn, context, settings):
   annotation = (source_info_util.summarize(eqn.source_info)
                 if settings.source_info else None)
   return [lhs, pp.text(" = ", annotation=annotation), *rhs]
-
 
 convert_element_type_p = Primitive('convert_element_type')
 convert_element_type_p.def_impl(partial(xla.apply_primitive, convert_element_type_p))
@@ -2895,7 +2906,8 @@ def _broadcast_in_dim_pp_rule(eqn, context, settings):
 def _broadcast_in_dim_abstract_eval(x, *dyn_shape, shape, broadcast_dimensions):
   if dyn_shape: raise NotImplementedError
   del dyn_shape
-  if not any(isinstance(d, core.BInt) for d in shape):
+  if not any(isinstance(d, core.DArray) and
+             type(core.get_aval(d).dtype) is core.bint for d in shape):
     shape = _broadcast_in_dim_shape_rule(  # error checking
         x, shape=shape, broadcast_dimensions=broadcast_dimensions)
     return core.ShapedArray(shape, x.dtype, x.weak_type, x.named_shape)
@@ -3049,11 +3061,19 @@ def _concatenate_batch_rule(batched_args, batch_dims, *, dimension):
               for op, bdim in zip(batched_args, batch_dims)]
   return concatenate(operands, dimension + 1), 0
 
+def _concatenate_pad_rule(in_avals, out_avals, *operands, dimension):
+  if all(isinstance(a.shape[dimension], (int, np.integer))
+         for a in in_avals):
+    return [concatenate(operands, dimension)]
+  else:
+    raise NotImplementedError  # TODO(mattjj)
+
 concatenate_p = standard_primitive(
     _concatenate_shape_rule, _concatenate_dtype_rule, 'concatenate')
 ad.deflinear2(concatenate_p, _concatenate_transpose_rule)
 ad.primitive_transposes[concatenate_p] = _concatenate_transpose_rule
 batching.primitive_batchers[concatenate_p] = _concatenate_batch_rule
+pe.padding_rules[concatenate_p] = _concatenate_pad_rule
 
 def _concatenate_lower(ctx, *xs, dimension):
   return mhlo.ConcatenateOp(xs, mlir.i64_attr(dimension)).results
@@ -3182,6 +3202,7 @@ squeeze_p = standard_primitive(_squeeze_shape_rule, _squeeze_dtype_rule,
                                'squeeze')
 ad.deflinear2(squeeze_p, _squeeze_transpose_rule)
 batching.primitive_batchers[squeeze_p] = _squeeze_batch_rule
+pe.def_trivial_padding(squeeze_p)
 
 def _squeeze_lower(ctx, operand, *, dimensions):
   del dimensions  # Implied by the output aval.
@@ -3641,13 +3662,13 @@ def _reduce_sum_transpose_rule(cotangent, operand, *, axes):
   assert result.shape == input_shape
   return [result]
 
-def _reduce_sum_padding_rule(in_avals, out_avals, operand, *, axes):
+def _reducer_padding(traceable, ident, in_avals, out_avals, operand, *, axes):
   del out_avals
   aval, = in_avals
   padded_axes = [(i, d.val) for i, d in enumerate(aval.shape)
                  if isinstance(d, pe.BoundedAxisSize)]
-  masked_operand = _replace_masked_values(operand, 0, padded_axes)
-  return [_reduce_sum(masked_operand, axes)]
+  operand_ = _replace_masked_values(operand, ident(aval.dtype), padded_axes)
+  return [traceable(operand_, axes)]
 
 def _replace_masked_values(x, val, padded_axes):
   if not padded_axes: return x
@@ -3661,7 +3682,8 @@ reduce_sum_p = standard_primitive(
   'reduce_sum')
 ad.deflinear2(reduce_sum_p, _reduce_sum_transpose_rule)
 batching.defreducer(reduce_sum_p)
-pe.padding_rules[reduce_sum_p] = _reduce_sum_padding_rule
+pe.padding_rules[reduce_sum_p] = partial(_reducer_padding, _reduce_sum,
+                                         _get_sum_identity)
 
 
 def _reduce_op_shape_rule(operand, *, axes, input_shape=None):
@@ -3684,6 +3706,8 @@ reduce_prod_p = standard_primitive(
   'reduce_prod')
 ad.primitive_jvps[reduce_prod_p] = _reduce_prod_jvp_rule
 batching.defreducer(reduce_prod_p)
+pe.padding_rules[reduce_prod_p] = partial(_reducer_padding, _reduce_prod,
+                                          _get_prod_identity)
 
 
 def _reduce_chooser_shape_rule(operand, *, axes):
@@ -3699,15 +3723,21 @@ def _reduce_chooser_jvp_rule(g, ans, operand, *, axes):
   counts = _reduce_sum(location_indicators, axes)
   return div(_reduce_sum(mul(g, location_indicators), axes), counts)
 
+
 reduce_max_p = standard_primitive(_reduce_op_shape_rule, _input_dtype,
                                   'reduce_max')
 ad.defjvp2(reduce_max_p, _reduce_chooser_jvp_rule)
 batching.defreducer(reduce_max_p)
+pe.padding_rules[reduce_max_p] = partial(_reducer_padding, _reduce_max,
+                                         _get_max_identity)
+
 
 reduce_min_p = standard_primitive(_reduce_op_shape_rule, _input_dtype,
                                   'reduce_min')
 ad.defjvp2(reduce_min_p, _reduce_chooser_jvp_rule)
 batching.defreducer(reduce_min_p)
+pe.padding_rules[reduce_min_p] = partial(_reducer_padding, _reduce_min,
+                                         _get_min_identity)
 
 
 def _argminmax_shape_rule(operand, *, axes, index_dtype):
@@ -3805,19 +3835,19 @@ def _unary_reduce_lower(reducer, unit_factory, ctx, x, *, axes):
   return op.results
 
 mlir.register_lowering(reduce_sum_p, partial(_unary_reduce_lower, mhlo.AddOp,
-                                         lambda dtype: np.array(0, dtype)))
+                                             _get_sum_identity))
 mlir.register_lowering(reduce_prod_p, partial(_unary_reduce_lower, mhlo.MulOp,
-                                          lambda dtype: np.array(1, dtype)))
+                                              _get_prod_identity))
 mlir.register_lowering(reduce_or_p, partial(_unary_reduce_lower, mhlo.OrOp,
-                                          _get_bitwise_or_identity))
+                                            _get_bitwise_or_identity))
 mlir.register_lowering(reduce_and_p, partial(_unary_reduce_lower, mhlo.AndOp,
-                                          _get_bitwise_and_identity))
+                                             _get_bitwise_and_identity))
 mlir.register_lowering(reduce_xor_p, partial(_unary_reduce_lower, mhlo.XorOp,
-                                          _get_bitwise_or_identity))
+                                             _get_bitwise_or_identity))
 mlir.register_lowering(reduce_min_p, partial(_unary_reduce_lower, mlir.min_mhlo,
-                                         _get_min_identity))
+                                             _get_min_identity))
 mlir.register_lowering(reduce_max_p, partial(_unary_reduce_lower, mlir.max_mhlo,
-                                         _get_max_identity))
+                                             _get_max_identity))
 
 
 
@@ -4091,6 +4121,7 @@ def _stop_gradient_batch_rule(batched_args, batch_dims):
 
 ad.primitive_jvps[ad_util.stop_gradient_p] = _stop_gradient_jvp_rule
 batching.primitive_batchers[ad_util.stop_gradient_p] = _stop_gradient_batch_rule
+pe.def_trivial_padding(ad_util.stop_gradient_p)
 
 
 def create_token(_=None):
@@ -4411,7 +4442,8 @@ def _iota_abstract_eval(*, dtype, shape, dimension):
   if not 0 <= dimension < len(shape):
     raise ValueError("iota dimension must be between 0 and len(shape), got "
                      f"dimension={dimension} for shape {shape}")
-  if not any(isinstance(d, core.BInt) for d in shape):
+  if not any(isinstance(d, core.DArray) and
+             type(core.get_aval(d).dtype) is core.bint for d in shape):
     return ShapedArray(shape, dtype)
   # TODO(mattjj): unify DShapedArray with ShapedArray, and remove this code
   return core.DShapedArray(shape, dtype, False)
@@ -4484,23 +4516,6 @@ def _iota_padding_rule(in_avals, out_avals, *dyn_shape, dtype, shape, dimension)
   return [iota_p.bind(*new_dyn_shape, shape=tuple(new_shape),
                       dtype=dtype, dimension=dimension)]
 pe.padding_rules[iota_p] = _iota_padding_rule
-
-
-def make_bint(i, bd: int):
-  return bint_p.bind(i, bd=bd)
-
-bint_p = core.Primitive('bint')
-
-@bint_p.def_impl
-def _bint_impl(i, *, bd):
-  return core.BInt(i, bd)
-
-@bint_p.def_abstract_eval
-def bint_abstract_eval(_, *, bd: int):
-  return core.AbstractBInt(bound=bd)
-
-pe.padding_rules[bint_p] = lambda _, __, i, bd: [i]
-mlir.register_lowering(bint_p, lambda ctx, x, bd: [x])
 
 
 ### util
@@ -4632,7 +4647,7 @@ def _check_shapelike(fun_name, arg_name, obj, non_zero_shape=False):
   if not len(obj):  # pylint: disable=g-explicit-length-test
     return
   if (config.jax_dynamic_shapes and isinstance(obj, (tuple, list)) and
-      any(isinstance(d, (core.Tracer, core.BInt)) for d in obj)):
+      any(isinstance(d, (core.Tracer, core.DArray)) for d in obj)):
     return  # TODO(mattjj): handle more checks in the dynamic shape case
   obj_arr = np.array(obj)
   if obj_arr.ndim != 1:
@@ -4775,3 +4790,19 @@ def _empty_lower(ctx, *, dtype):
     return dtype._rules.empty_mlir(ctx)
   return mlir.ir_constants(np.zeros((), np.dtype(dtype)))
 mlir.register_lowering(empty_p, _empty_lower)
+
+
+class BIntRules:
+  @staticmethod
+  def aval_to_ir_types(aval):
+    dtype = dtypes._scalar_type_to_dtype(int)
+    return (ir.RankedTensorType.get(aval.shape, mlir.dtype_to_ir_type(dtype)),)
+
+  @staticmethod
+  def result_handler(sticky_device, aval):
+    def handler(_, buf):
+      buf.aval = core.ShapedArray(buf.shape, buf.dtype)
+      return core.DArray(aval, buf)
+    return handler
+
+core.bint._rules = BIntRules

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -934,6 +934,15 @@ def _dynamic_slice_typecheck_rule(x, *starts_and_dyn_sizes, slice_sizes):
                                  x.aval.weak_type)
     return [out_aval], core.no_effects
 
+def _dynamic_slice_padding_rule(in_avals, out_avals, x, *starts_and_dyn,
+                                slice_sizes):
+  x_aval, start_indices_avals, dyn_avals = util.split_list(in_avals, [1, x.ndim])
+  start_indices, dyn = util.split_list(starts_and_dyn, [x.ndim])
+  dyn_ = [a.dtype.bound if type(a.dtype) is core.bint else d
+          for a, d in zip(dyn_avals, dyn)]
+  slice_sizes_ = lax._merge_dyn_shape(slice_sizes, dyn_)
+  start_idx = [d.val if type(d) is core.DArray else d for d in start_indices]
+  return [dynamic_slice(x, start_idx, slice_sizes_)]
 
 dynamic_slice_p = standard_primitive(
     _dynamic_slice_shape_rule, _dynamic_slice_dtype_rule, 'dynamic_slice',
@@ -943,6 +952,7 @@ ad.primitive_transposes[dynamic_slice_p] = _dynamic_slice_transpose_rule
 batching.primitive_batchers[dynamic_slice_p] = _dynamic_slice_batching_rule
 pe.custom_staging_rules[dynamic_slice_p] = _dynamic_slice_staging_rule
 core.custom_typechecks[dynamic_slice_p] = _dynamic_slice_typecheck_rule
+pe.padding_rules[dynamic_slice_p] = _dynamic_slice_padding_rule
 
 def _dynamic_slice_lower(ctx, x, *starts_and_dyn_sizes, slice_sizes):
   x_aval, *_ = ctx.avals_in
@@ -1365,12 +1375,25 @@ def _gather_batching_rule(batched_args, batch_dims, *, dimension_numbers,
                   indices_are_sorted=indices_are_sorted, mode=mode,
                   fill_value=fill_value), 0
 
+def _gather_pad_rule(in_avals, out_avals, operand, indices, *,
+                     dimension_numbers, slice_sizes, unique_indices,
+                     indices_are_sorted, mode, fill_value):
+  operand_aval, indices_aval = in_avals
+  if any(isinstance(d, pe.BoundedAxisSize) for d in operand_aval.shape):
+    raise NotImplementedError
+  if mode != GatherScatterMode.PROMISE_IN_BOUNDS:
+    # with fill, jnp.where on operand; with clip, jnp.where on indices
+    raise NotImplementedError
+  return [gather(operand, indices, dimension_numbers=dimension_numbers,
+                 slice_sizes=slice_sizes, mode=mode, fill_value=fill_value)]
+
 gather_p = standard_primitive(
     _gather_shape_rule, _gather_dtype_rule, 'gather',
     weak_type_rule=_argnum_weak_type(0))
 ad.defjvp(gather_p, _gather_jvp_rule, None)
 ad.primitive_transposes[gather_p] = _gather_transpose_rule
 batching.primitive_batchers[gather_p] = _gather_batching_rule
+pe.padding_rules[gather_p] = _gather_pad_rule
 
 
 def _gather_lower(ctx, operand, indices, *,
@@ -2113,6 +2136,7 @@ def _dynamic_slice_indices(operand, start_indices: Any):
       continue
     d = core.dimension_as_value(d)
     if isinstance(i, (int, np.integer)):
+      # TODO(mattjj,sharadmv): handle np.ndarray w/ ndim == 0
       result.append(i + lax.convert_element_type(d, _dtype(i)) if i < 0 else i)
       continue
     d = lax.convert_element_type(d, _dtype(i))

--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -88,10 +88,17 @@ newaxis = None
 # arguments for `shape`.
 def canonicalize_shape(
     shape: Union[core.Shape, int, core.Tracer], context: str="") -> core.Shape:
-  if isinstance(shape, core.Tracer) or ndim(shape) == 0:
+  if isinstance(shape, (list, tuple)):
+    return core.canonicalize_shape(shape, context)  # type: ignore
+  elif isinstance(shape, np.ndarray):
+    if shape.ndim == 0:
+      return core.canonicalize_shape((shape,), context)
+    else:
+      return core.canonicalize_shape(shape, context)
+  elif isinstance(shape, core.Tracer) or ndim(shape) == 0:
     return core.canonicalize_shape((shape,), context)
   else:
-    return core.canonicalize_shape(shape, context)  # type: ignore
+    raise TypeError(f"expected shape-like, got {shape}")
 
 # Common docstring additions:
 
@@ -2128,23 +2135,21 @@ def arange(start: core.DimSize, stop: Optional[core.DimSize]=None,
   if _any(core.is_special_dim_size(d) for d in (start, stop, step)):
     if stop is not None or step is not None:
       raise ValueError(
-          "jax.numpy.arange supports non-constant arguments only in single-argument form. "
-          f"Found jax.numpy.arange(start={start}, stop={stop}, step={step})")
+          "jax.numpy.arange supports non-constant arguments only in "
+          "single-argument form. Found "
+          f"jax.numpy.arange(start={start}, stop={stop}, step={step})")
     return lax.iota(dtype or int_, start)
   if dtype is None:
     dtype = result_type(start, *(x for x in [stop, step] if x is not None))
   dtype = _jnp_dtype(dtype)
   if stop is None and step is None:
-    if (jax.config.jax_dynamic_shapes and
-        not isinstance(core.get_aval(start), core.AbstractBInt) and
-        not isinstance(core.get_aval(start), core.ConcreteArray)):
-      start = ceil(start).astype(int)  # note using jnp here
-    elif (isinstance(start, core.BInt) or isinstance(start, core.Tracer) and
-          isinstance(core.get_aval(start), core.AbstractBInt)):
-      pass
-    else:
+    start_dtype = _dtype(start)
+    if not jax.config.jax_dynamic_shapes:
       start = require(start, msg("stop"))
-      start = np.ceil(start).astype(int)
+    if (not dtypes.issubdtype(start_dtype, np.integer) and
+        not core.is_opaque_dtype(start_dtype)):
+      ceil_ = ceil if isinstance(start, core.Tracer) else np.ceil
+      start = ceil_(start).astype(int)
     return lax.iota(dtype, start)
   else:
     start = require(start, msg("start"))

--- a/jax/core.py
+++ b/jax/core.py
@@ -1203,7 +1203,6 @@ def concrete_or_error(force: Any, val: Any, context=""):
 
 
 # TODO(frostig,mattjj): achieve this w/ a protocol instead of registry?
-
 opaque_dtypes: Set[Any] = set()
 
 # TODO(frostig): update inliners of the four functions below to call them
@@ -1443,12 +1442,11 @@ def primal_dtype_to_tangent_dtype(primal_dtype):
 # We have a convention of reusing AbsractValues as types, even though we could
 # make a distinction and use abstract values during tracing only. This reuse
 # becomes a bit more extreme with DShapedArrays. A DShapedArray's shape
-# attribute is a tuple which can contain several different types: int, BInt,
-# Tracer (while tracing), Var (when used as jaxpr type annotations), or
-# DBIdx/InDBIdx/OutDBIdx (when used in InputType or OutputType). We could reduce
-# this polymorphism if it seems cleaner, though it's kind of convenient!
-AxisSize = Union[int, 'BInt', Tracer, Var, DBIdx, InDBIdx, OutDBIdx]
-
+# attribute is a tuple which can contain several different types: int, DArray
+# (scalar and with dtype of bint type), Tracer (while tracing), Var (when used
+# as jaxpr type annotations), or DBIdx/InDBIdx/OutDBIdx (when used in InputType
+# or OutputType). We could reduce this polymorphism if it seems cleaner, though
+# it's kind of convenient!
 class DShapedArray(UnshapedArray):
   __slots__ = ['shape']
   shape: Tuple[AxisSize, ...]  # noqa: F821
@@ -1511,64 +1509,55 @@ class DConcreteArray(DShapedArray):
 pytype_aval_mappings: Dict[type, Callable[[Any], AbstractValue]] = {}
 
 
-# TODO(mattjj): remove this, replace with arrays of bints
-class AbstractBInt(AbstractValue):
-  __slots__ = ['bound']
-  bound: int
-  def __init__(self, bound):
-    self.bound = bound
-  def str_short(self, short_dtypes=False) -> str:
-    return f'bint{{≤{self.bound}}}[]'
-  __repr__ = str_short
-  def __eq__(self, other):
-    return type(other) is AbstractBInt and self.bound == other.bound
-  def __hash__(self) -> int:
-    return hash((type(self), self.bound))
-  def at_least_vspace(self):
-    return self  # should return float0 array
-  def join(self, other):
-    return self
 
-class BInt:
-  val: Any  # Union[int, Array]
-  bound: int
-  def __init__(self, val, bound):
-    assert 0 <= val <= bound
-    self.val = val
-    self.bound = bound
-  def __repr__(self) -> str:
-    return f'{self.val}{{≤{self.bound}}}'
-  def __int__(self) -> int:
-    return self.val
-  def __eq__(self, other) -> bool:
-    return (isinstance(other, BInt) and
-            (self.val, self.bound) == (other.val, other.bound))
-  def __hash__(self):
-    return hash((self.val, self.bound))
-pytype_aval_mappings[BInt] = lambda x: AbstractBInt(x.bound)
-
-
-# DShapedArray w/ BInt in shapes => PaddedArray runtime representation
-class PaddedArray:
+class DArray:
   _aval: DShapedArray
   _data: Any  # standard array type
   def __init__(self, aval, data):
-    padded_shape = tuple(d.bound if type(d) is BInt else d for d in aval.shape)
-    assert data.shape == padded_shape
+    pad_shape = tuple(d.dtype.bound if type(d) is DArray and
+                      type(d.dtype) is bint else d for d in aval.shape)
+    assert data.shape == pad_shape
     self._aval = aval
     self._data = data
   shape = property(lambda self: self._aval.shape)
   dtype = property(lambda self: self._aval.dtype)
   def __repr__(self) -> str:
+    if not self.shape and type(self.dtype) is bint:
+      # special-case scalar bints
+      return f'{int(self._data)}{{≤{self.dtype.bound}}}'
+
     dtypestr = _short_dtype_name(self._aval.dtype)
     shapestr = ','.join(map(str, self.shape))
-    slices = tuple(slice(d.val) if type(d) is BInt else slice(None)
-                   for d in self.shape)
+    slices = tuple(slice(int(d._data)) if type(d) is DArray and
+                   type(d.dtype) is bint else slice(None) for d in self.shape)
     data = self._data[slices]
     return f'{dtypestr}[{shapestr}] with value:\n{data}'
-pytype_aval_mappings[PaddedArray] = \
+  def __hash__(self) -> int:
+    if not self.shape:
+      return hash((self._aval, int(self._data)))
+    raise TypeError("unhashable type: DArray")
+  def __eq__(self, other):
+    if isinstance(other, DArray) and self._aval == other._aval:
+      return self._data == other._data
+    return False
+
+pytype_aval_mappings[DArray] = \
     lambda x: DConcreteArray(x._aval.shape, x._aval.dtype, x._aval.weak_type,
                              x._data)
+
+@dataclass(frozen=True, eq=True)
+class bint:
+  bound: int
+
+  @property
+  def name(self) -> str:
+    return f'bint{{≤{self.bound}}}'
+
+  def __str__(self) -> str:
+    return self.name
+opaque_dtypes.add(bint)
+
+AxisSize = Union[int, DArray, Tracer, Var, DBIdx, InDBIdx, OutDBIdx]
 
 
 class AbstractToken(AbstractValue):
@@ -1599,7 +1588,6 @@ def raise_to_shaped(aval: AbstractValue, weak_type=None):
   raise TypeError(type(aval))
 
 raise_to_shaped_mappings : Dict[type, Callable] = {
-  AbstractBInt: lambda aval, _: aval,
   AbstractToken: lambda aval, _: aval,
   Bot: lambda aval, _: aval,
   UnshapedArray: lambda aval, _: aval,
@@ -1692,10 +1680,13 @@ class DimensionHandler:
 
 _dimension_handler_int = DimensionHandler()
 _SPECIAL_DIMENSION_HANDLERS: Dict[type, DimensionHandler] = {}
+DArrayDimHandler = type('DArrayDimHandler', (DimensionHandler,), {})()
 
 def _get_special_dim_handler(dim: DimSize) -> Optional[DimensionHandler]:
   if isinstance(dim, Tracer) and not config.jax_dynamic_shapes:
     return None
+  if isinstance(dim, DArray) and not dim.shape and type(dim.dtype) is bint:
+    return DArrayDimHandler
   return _SPECIAL_DIMENSION_HANDLERS.get(type(dim))
 
 def _dim_handler_and_canonical(*dlist: DimSize) -> Tuple[DimensionHandler, Tuple[DimSize, ...]]:
@@ -1806,6 +1797,9 @@ def dimension_as_value(d: DimSize):
 def _canonicalize_dimension(dim: DimSize) -> DimSize:
   if isinstance(dim, Tracer) and config.jax_dynamic_shapes:
     return dim
+  elif (config.jax_dynamic_shapes and isinstance(dim, DArray) and
+        type(dim._aval.dtype) is bint and not dim._aval.shape):
+    return dim
   elif is_special_dim_size(dim):
     return dim
   else:
@@ -1847,20 +1841,6 @@ def _invalid_shape_error(shape: Shape, context: str=""):
     msg += ("\nIf using `jit`, try using `static_argnums` or applying `jit` to "
             "smaller subfunctions.")
   return TypeError(msg)
-
-class BIntDimensionHandler(DimensionHandler):
-  def symbolic_equal(self, d1, d2) -> bool:
-    return isinstance(d2, BInt) and d1.val == d2.val and d1.bound == d2.bound
-  def sum(self, *ds) -> BInt:
-    if not all(isinstance(d, BInt) for d in ds):
-      raise InconclusiveDimensionOperation
-    if len({d.bound for d in ds}) != 1:
-      raise InconclusiveDimensionOperation
-    return BInt(sum(d.val for d in ds), ds[0].bound)
-  def fail(self, *_): raise InconclusiveDimensionOperation
-  great_equal = diff = divide_shape_sizes = stride = dilate = as_value = fail
-_SPECIAL_DIMENSION_HANDLERS[BInt] = BIntDimensionHandler()
-
 
 
 # ------------------- Named shapes -------------------
@@ -2543,13 +2523,14 @@ def check_type(
   if isinstance(ty, DShapedArray):
     # Check all elements in the shape tuple are well-typed.
     for d in ty.shape:
-      if isinstance(d, (int, BInt)):
+      if (isinstance(d, int) or
+          isinstance(d, DArray) and not d.shape and type(d.dtype) == bint):
         continue
       elif isinstance(d, Var):
         if d not in env:
           ctx, _ = ctx_factory()
           raise JaxprTypeError(f"unbound axis size: '{pp_var(d, ctx)}'")
-        if not isinstance(d.aval, (ShapedArray, AbstractBInt)):
+        if not isinstance(d.aval, (ShapedArray, DShapedArray)):
           raise JaxprTypeError(f"axis size with unexpected type annotation: "
                                f"{d.aval} of type {type(d.aval)}")
         if isinstance(d.aval, ShapedArray):
@@ -2557,6 +2538,13 @@ def check_type(
           if shape: raise JaxprTypeError(f"axis size nonscalar: {d.aval}")
           if not dtypes.issubdtype(dtype, np.integer):
             raise JaxprTypeError(f"axis size with non-integer dtype: {d.aval}")
+        else:
+          assert isinstance(d.aval, DShapedArray)
+          shape, dtype = d.aval.shape, d.aval.dtype
+          if shape: raise JaxprTypeError(f"axis size nonscalar: {d.aval}")
+          if type(dtype) is not bint:
+            raise JaxprTypeError(
+                f"DArray axis size with non-bint dtype: {d.aval}")
       else:
         raise JaxprTypeError(f"unexpected type in shape: {type(d)}")
   else:

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -145,13 +145,8 @@ def _array_ir_types(aval: Union[core.ShapedArray, core.DShapedArray]
 
 def _dynamic_array_ir_types(aval: core.ShapedArray) -> Sequence[ir.Type]:
   # in the MHLO builder, -1 indicates a '?' axis size
-  shape = [d if type(d) is int else d.bound if type(d) is core.BInt else -1
-           for d in aval.shape]
+  shape = [d if type(d) is int else -1 for d in aval.shape]
   return (ir.RankedTensorType.get(shape, dtype_to_ir_type(aval.dtype)),)
-
-def _bint_ir_types(aval: core.AbstractBInt) -> Sequence[ir.Type]:
-  dtype = dtypes._scalar_type_to_dtype(int)
-  return (ir.RankedTensorType.get((), dtype_to_ir_type(dtype)),)
 
 ir_type_handlers: Dict[Type[core.AbstractValue],
                         Callable[[Any], Sequence[ir.Type]]] = {}
@@ -166,7 +161,6 @@ def aval_to_ir_types(aval: core.AbstractValue) -> Sequence[ir.Type]:
   except KeyError as err:
     raise TypeError(f"No ir_type_handler for aval type: {type(aval)}") from err
 
-ir_type_handlers[core.AbstractBInt] = _bint_ir_types
 ir_type_handlers[core.ShapedArray] = _array_ir_types
 ir_type_handlers[core.ConcreteArray] = _array_ir_types
 ir_type_handlers[core.AbstractToken] = lambda _: [mhlo.TokenType.get()]

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -41,9 +41,8 @@ from jax._src.util import (unzip2, safe_zip, safe_map, toposort, split_list,
 from jax.core import (Trace, Tracer, Jaxpr, Literal, get_aval, AbstractValue,
                       ClosedJaxpr, new_jaxpr_eqn, ConcreteArray, Var, DropVar,
                       raise_to_shaped, Atom, JaxprEqn, Primitive, ShapedArray,
-                      DShapedArray, AbstractBInt, mapped_aval, unmapped_aval,
-                      DBIdx, InDBIdx, OutDBIdx, InputType, OutputType,
-                      get_referent)
+                      DShapedArray, mapped_aval, unmapped_aval, DBIdx, InDBIdx,
+                      OutDBIdx, InputType, OutputType, get_referent)
 from jax._src import source_info_util
 from jax.config import config
 
@@ -2340,12 +2339,14 @@ Val = Any
 
 def pad_jaxpr(jaxpr: Jaxpr, consts: Sequence[Const]
               ) -> Tuple[Jaxpr, List[Const]]:
-  bounds = {v: v.aval.bound for v in jaxpr.invars
-            if type(v.aval) is AbstractBInt}
+  bounds = {v: v.aval.dtype.bound for v in jaxpr.invars
+            if isinstance(v.aval, core.UnshapedArray) and
+            type(v.aval.dtype) is core.bint and not v.aval.shape}
   idxs = {v: DBIdx(i) for i, v in enumerate(jaxpr.invars)}
 
   def substitute(aval: AbstractValue) -> AbstractValue:
-    if isinstance(aval, AbstractBInt):
+    if (isinstance(aval, core.UnshapedArray) and type(aval.dtype) is core.bint
+        and not aval.shape):
       return ShapedArray((), dtypes._scalar_type_to_dtype(int))
     elif isinstance(aval, DShapedArray):
       shape = [bounds.get(d, idxs.get(d, d)) for d in aval.shape]  # type: ignore
@@ -2377,20 +2378,39 @@ def _eval_jaxpr_padded(
   map(write, jaxpr.constvars, consts)
   map(write, jaxpr.invars, args)
   for eqn in jaxpr.eqns:
-    rule = padding_rules[eqn.primitive]
     in_avals  = [_substitute_axis_sizes(env, v.aval) for v in eqn.invars]
     out_avals = [_substitute_axis_sizes(env, v.aval) for v in eqn.outvars]
+    rule = padding_rules[eqn.primitive]
     outs = rule(in_avals, out_avals, *map(read, eqn.invars), **eqn.params)
     map(write, eqn.outvars, outs)
   return map(read, jaxpr.outvars)
 
 def _substitute_axis_sizes(env: Dict, aval: AbstractValue) -> AbstractValue:
   if isinstance(aval, DShapedArray):
-    shp = [BoundedAxisSize(env[d], d.aval.bound) if type(d) is Var and
-           type(d.aval) is AbstractBInt else env.get(d, d) for d in aval.shape]
+    shp = []
+    for d in aval.shape:
+      if isinstance(d, core.DArray):
+        assert not d.shape and type(d.dtype) is core.bint
+        shp.append(BoundedAxisSize(int(d._data), int(d.dtype.bound)))
+      elif (type(d) is core.Var and isinstance(d.aval, core.DShapedArray) and
+            type(d.aval.dtype) is core.bint):
+        assert not d.aval.shape
+        shp.append(BoundedAxisSize(env[d], d.aval.dtype.bound))
+      else:
+        shp.append(env.get(d, d))
     return DShapedArray(tuple(shp), aval.dtype, aval.weak_type)
   else:
     return aval
+
+def _is_bint_axis_size(d: Union[int, core.DArray, core.Var]) -> bool:
+  if isinstance(d, core.DArray):
+    assert not d.shape
+    return type(d.dtype) is core.bint
+  elif isinstance(d, core.Var):
+    return (isinstance(d.aval, core.DShapedArray) and
+            type(d.aval.dtype) is core.bint)
+  return False
+
 
 padding_rules: Dict[Primitive, Callable] = {}
 

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -2751,7 +2751,7 @@ def lower_sharding_computation(
     out_shardings = (_UNSPECIFIED,) * len(global_out_avals)
 
   # mypy doesn't understand that out_sharding here is always a sequence.
-  assert len(out_shardings) == len(global_out_avals), (
+  assert len(out_shardings) == len(global_out_avals), (  # type: ignore
       len(out_shardings), len(global_out_avals))  # type: ignore
 
   if keep_unused:

--- a/jax/interpreters/xla.py
+++ b/jax/interpreters/xla.py
@@ -265,9 +265,7 @@ canonicalize_dtype_handlers.update(
 canonicalize_dtype_handlers.update(
     (t, partial(_canonicalize_python_scalar_dtype, t)) for t in _scalar_types)
 canonicalize_dtype_handlers[core.Token] = identity
-canonicalize_dtype_handlers[core.PaddedArray] = identity
-canonicalize_dtype_handlers[core.BInt] = \
-    lambda x: core.BInt(_canonicalize_python_scalar_dtype(int, x.val), x.bound)
+canonicalize_dtype_handlers[core.DArray] = identity
 
 def abstractify(x) -> core.AbstractValue:
   typ = type(x)
@@ -289,8 +287,7 @@ def _make_abstract_python_scalar(typ, val):
 pytype_aval_mappings: Dict[Any, Callable[[Any], core.AbstractValue]] = {}
 for t in device_array.device_array_types:
   pytype_aval_mappings[t] = operator.attrgetter('aval')
-pytype_aval_mappings[core.BInt] = lambda x: core.AbstractBInt(x.bound)
-pytype_aval_mappings[core.PaddedArray] = operator.attrgetter('_aval')
+pytype_aval_mappings[core.DArray] = operator.attrgetter('_aval')
 pytype_aval_mappings[core.Token] = lambda _: core.abstract_token
 pytype_aval_mappings.update((t, make_shaped_array) for t in array_types)
 pytype_aval_mappings.update(

--- a/jax/lax/__init__.py
+++ b/jax/lax/__init__.py
@@ -143,7 +143,6 @@ from jax._src.lax.lax import (
   logistic_p as logistic_p,
   lt as lt,
   lt_p as lt_p,
-  make_bint as make_bint,
   max as max,
   max_p as max_p,
   min as min,

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -249,8 +249,11 @@ def _check_input_type(in_type: core.InputType) -> None:
   assert (type(in_type) is tuple and all(type(e) is tuple for e in in_type) and
           all(isinstance(a, core.AbstractValue) and type(b) is bool
               and not isinstance(a, core.ConcreteArray) for a, b in in_type) and
-          all(isinstance(d, (int, core.BInt, core.DBIdx)) for a, _ in in_type
-              if type(a) is core.DShapedArray for d in a.shape))
+          all(isinstance(d, (int, core.DBIdx, core.DArray))
+              and (not isinstance(d, core.DArray) or
+                   type(d.dtype) is core.bint and not d.shape)
+              for a, _ in in_type if type(a) is core.DShapedArray
+              for d in a.shape))
 
   # Check that all DBIdx point to positions to the left of the input on which
   # they appear.


### PR DESCRIPTION
This was the last bit we needed to run a batch-shape-polymorphic transformer on XLA.

Co-authored-by: Sharad Vikram <sharad.vikram@gmail.com>