### PR TITLE
add more info to pytree prefix key errors

### DIFF
--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -2603,9 +2603,7 @@ class PJitErrorTest(jtu.JaxTestCase):
         "    pjit out_axis_resources tree root\n"
         "At that key path, the prefix pytree pjit out_axis_resources has a "
         "subtree of type\n"
-        "    <class 'list'>\n"
-        "with 2 children, but at the same key path the full pytree has a "
-        "subtree of the same type but with 3 children.")
+        "    <class 'list'>\n")
     with self.assertRaisesRegex(ValueError, error):
       pjit(lambda x: x, (p,), [p, None])([x, x, x])  # Error, we raise a generic tree mismatch message
 

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -505,6 +505,13 @@ class TreePrefixErrorsTest(jtu.JaxTestCase):
     with self.assertRaisesRegex(ValueError, expected):
       raise e2('in_axes')
 
+  def test_different_num_children_print_key_diff(self):
+    e, = prefix_errors({'a': 1}, {'a': 2, 'b': 3})
+    expected = ("so the symmetric difference on key sets is\n"
+                "    b")
+    with self.assertRaisesRegex(ValueError, expected):
+      raise e('in_axes')
+
   def test_different_metadata(self):
     e, = prefix_errors({1: 2}, {3: 4})
     expected = ("pytree structure error: different pytree metadata "


### PR DESCRIPTION
fixes #12643, so that now we get a message which reports the key sets and their symmetric difference.