### PR TITLE
Migrate JAX internals to builtin Python logging

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -1,3 +1,4 @@
+absl-py
 cloudpickle
 colorama>=0.4.4
 matplotlib

--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -18,7 +18,6 @@ from typing import (Callable, Optional, List, Tuple, Sequence, Set, Union, Any,
                     FrozenSet)
 import types
 
-from absl import logging
 import numpy as np
 
 import jax

--- a/jax/_src/clusters/cluster.py
+++ b/jax/_src/clusters/cluster.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import List, Optional, Type, Sequence, Tuple
-from absl import logging
 from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
 
+logger = logging.getLogger(__name__)
 
 class ClusterEnv:
   """Interface for defining a cluster environment.
@@ -48,7 +49,7 @@ class ClusterEnv:
               local_device_ids)
     env = next((env for env in cls._cluster_types if env.is_env_present()), None)
     if env:
-      logging.vlog(1, 'Initializing distributed JAX environment via %s', env.__name__)
+      logger.debug('Initializing distributed JAX environment via %s', env.__name__)
       if coordinator_address is None:
         coordinator_address = env.get_coordinator_address()
       if num_processes is None:
@@ -64,7 +65,7 @@ class ClusterEnv:
           env.get_local_process_id() is not None):
         local_device_ids = [env.get_local_process_id()] # type: ignore[list-item]
     else:
-      logging.vlog(1, 'Could not find a known environment for initializing distributed JAX. '
+      logger.debug('Could not find a known environment for initializing distributed JAX. '
         'Known environments: %s', ', '.join(e.__name__ for e in cls._cluster_types))
     return (coordinator_address, num_processes, process_id, local_device_ids)
   # pytype: enable=bad-return-type

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -18,18 +18,19 @@
 import contextlib
 import functools
 import itertools
+import logging
 import os
 import sys
 import threading
 from typing import Any, List, Callable, Hashable, NamedTuple, Iterator, Optional
-import warnings
-
-from absl import logging
 
 from jax._src import lib
 from jax._src.lib import jax_jit
 from jax._src.lib import transfer_guard_lib
 from jax._src.lib import xla_client
+
+logger = logging.getLogger(__name__)
+
 
 def bool_env(varname: str, default: bool) -> bool:
   """Read an environment variable and interpret it as a boolean.
@@ -643,7 +644,7 @@ log_compiles = config.define_bool_state(
     name='jax_log_compiles',
     default=False,
     help=('Log a message each time every time `jit` or `pmap` compiles an XLA '
-          'computation. Logging is performed with `absl.logging`. When this '
+          'computation. Logging is performed with `logging`. When this '
           'option is set, the log level is WARNING; otherwise the level is '
           'DEBUG.'))
 
@@ -674,7 +675,7 @@ distributed_debug = config.define_bool_state(
     name='jax_distributed_debug',
     default=False,
     help=('Enable logging useful for debugging multi-process distributed '
-          'computations. Logging is performed with `absl.logging` at WARNING '
+          'computations. Logging is performed with `logging` at WARNING '
           'level.'))
 
 
@@ -772,7 +773,7 @@ def _validate_default_device(val):
     # TODO(skyewm): this is a workaround for non-PJRT Device types. Remove when
     # all JAX backends use a single C++ device interface.
     if 'Device' in str(type(val)):
-      logging.info(
+      logger.info(
           'Allowing non-`xla_client.Device` default device: %s, type: %s',
           repr(val), type(val))
       return

--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -22,14 +22,14 @@ import itertools
 import time
 from typing import (
     Any, Callable, Dict, Optional, Sequence, Set, Tuple, List, Type, Union,
-    TYPE_CHECKING, Iterator)
+    Iterator)
 from typing_extensions import Protocol
+import logging
 import os
 import re
 import threading
 import warnings
 
-from absl import logging
 import numpy as np
 
 import jax
@@ -81,6 +81,8 @@ CompileOptions = xc.CompileOptions
 
 map, unsafe_map = util.safe_map, map
 zip, unsafe_zip = util.safe_zip, zip
+
+logger = logging.getLogger(__name__)
 
 # This flag is set on exit; no logging should be attempted
 _on_exit = False
@@ -360,7 +362,7 @@ def log_elapsed_time(fmt: str):
     start_time = time.time()
     yield
     elapsed_time = time.time() - start_time
-    logging.log(log_priority, fmt.format(elapsed_time=elapsed_time))
+    logger.log(log_priority, fmt.format(elapsed_time=elapsed_time))
 
 
 def should_tuple_args(num_args: int, platform: str):
@@ -476,7 +478,7 @@ def lower_xla_callable(
       msg = f"Compiling {fun.__name__} ({id(fun)}) for {len(abstract_args)} args."
     else:
       msg = f"Compiling {fun.__name__} ({id(fun)} for args {abstract_args}."
-    logging.log(log_priority, msg)
+    logger.log(log_priority, msg)
 
   raise_warnings_or_errors_for_jit_of_pmap(nreps, backend, name, jaxpr)
 
@@ -1041,7 +1043,7 @@ def compile_or_get_cached(backend, computation: ir.Module, compile_options,
     cached_executable = _cache_read(serialized_computation, module_name,
                                     compile_options, backend)
     if cached_executable is not None:
-      logging.info("Persistent compilation cache hit for '%s'", module_name)
+      logger.info("Persistent compilation cache hit for '%s'", module_name)
       return cached_executable
     else:
       compiled = backend_compile(backend, serialized_computation,

--- a/jax/_src/distributed.py
+++ b/jax/_src/distributed.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import atexit
+import logging
 import os
-import functools
 
 from typing import Any, Optional, Union, Sequence
 
-from absl import logging
 from jax._src.clusters import ClusterEnv
 from jax._src.config import config
 from jax._src.lib import xla_extension
+
+logger = logging.getLogger(__name__)
 
 
 class State:
@@ -55,7 +56,7 @@ class State:
 
     if local_device_ids:
       visible_devices = ','.join(str(x) for x in local_device_ids) # type: ignore[union-attr]
-      logging.info('JAX distributed initialized with visible devices: %s', visible_devices)
+      logger.info('JAX distributed initialized with visible devices: %s', visible_devices)
       config.update("jax_cuda_visible_devices", visible_devices)
       config.update("jax_rocm_visible_devices", visible_devices)
 
@@ -64,7 +65,7 @@ class State:
     if process_id == 0:
       if self.service is not None:
         raise RuntimeError('distributed.initialize should only be called once.')
-      logging.info('Starting JAX distributed service on %s', coordinator_address)
+      logger.info('Starting JAX distributed service on %s', coordinator_address)
       self.service = xla_extension.get_distributed_runtime_service(
           coordinator_address, num_processes, config.jax_coordination_service)
 
@@ -75,7 +76,7 @@ class State:
     self.client = xla_extension.get_distributed_runtime_client(
         coordinator_address, process_id, config.jax_coordination_service,
         init_timeout=300)
-    logging.info('Connecting to JAX distributed service on %s', coordinator_address)
+    logger.info('Connecting to JAX distributed service on %s', coordinator_address)
     self.client.connect()
 
     if config.jax_coordination_service:

--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -18,14 +18,13 @@ import glob
 import gzip
 import http.server
 import json
+import logging
 import os
 import socketserver
 import threading
-import warnings
 
 from typing import Callable, Optional
 
-from absl import logging
 from jax._src import traceback_util
 traceback_util.register_exclusion(__file__)
 
@@ -33,6 +32,8 @@ from jax._src.lib import xla_bridge
 from jax._src.lib import xla_client
 
 _profiler_server: Optional[xla_client.profiler.ProfilerServer] = None
+
+logger = logging.getLogger(__name__)
 
 
 def start_server(port: int):
@@ -134,7 +135,7 @@ def _write_perfetto_trace_file(log_dir):
     raise ValueError(f"Invalid trace folder: {latest_folder}")
   trace_json, = trace_jsons
 
-  logging.info("Loading trace.json.gz and removing its metadata...")
+  logger.info("Loading trace.json.gz and removing its metadata...")
   # Perfetto doesn't like the `metadata` field in `trace.json` so we remove
   # it.
   # TODO(sharadmv): speed this up by updating the generated `trace.json`
@@ -144,7 +145,7 @@ def _write_perfetto_trace_file(log_dir):
     del trace["metadata"]
   filename = "perfetto_trace.json.gz"
   perfetto_trace = os.path.join(latest_folder, filename)
-  logging.info("Writing perfetto_trace.json.gz...")
+  logger.info("Writing perfetto_trace.json.gz...")
   with gzip.open(perfetto_trace, "w") as fp:
     fp.write(json.dumps(trace).encode("utf-8"))
   return perfetto_trace

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from collections import namedtuple
 import functools
 from functools import partial
 import itertools as it
-from collections import namedtuple
+import logging
 import operator
 import types
 import threading
@@ -24,12 +24,13 @@ from typing import (Any, Callable, Dict, Iterable, List, Tuple, Generic,
                     TypeVar, Set, Iterator, Sequence, Optional)
 import weakref
 
-from absl import logging
 import numpy as np
 
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension_version
 from jax.config import config
+
+logger = logging.getLogger(__name__)
 
 Seq = Sequence
 
@@ -510,7 +511,7 @@ def distributed_debug_log(*pairs):
       lines.append("DISTRIBUTED_DEBUG logging failed!")
       lines.append(f"{e}")
     lines.append("DISTRIBUTED_DEBUG_END")
-    logging.warning("\n".join(lines))
+    logger.warning("\n".join(lines))
 
 
 class OrderedSet(Generic[T]):

--- a/jax/experimental/mesh_utils.py
+++ b/jax/experimental/mesh_utils.py
@@ -15,11 +15,13 @@
 """Utils for building a device mesh."""
 
 import itertools
+import logging
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from absl import logging
 import jax
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 _TPU_V2 = 'TPU v2'
 _TPU_V3 = 'TPU v3'
@@ -248,14 +250,14 @@ def create_device_mesh(
   device_kind = devices[-1].device_kind
   if device_kind in (_TPU_V2, _TPU_V3):
     if len(devices) == 8:
-      logging.info('Reordering mesh to physical ring order on single-tray TPU v2/v3.')
+      logger.info('Reordering mesh to physical ring order on single-tray TPU v2/v3.')
       device_mesh = np.asarray(devices)
       device_mesh = device_mesh[np.array(_TRAY_RING_ORDER)]
       device_mesh = device_mesh.reshape(mesh_shape)
       return device_mesh
     elif mesh_shape[-1] == 8:
       device_mesh = np.asarray(devices).reshape(mesh_shape)
-      logging.info('Reordering mesh to physical ring order on each TPU v2/v3 tray.')
+      logger.info('Reordering mesh to physical ring order on each TPU v2/v3 tray.')
       perm = np.array(_TRAY_RING_ORDER)
       device_mesh = device_mesh[..., perm]
       return device_mesh
@@ -270,7 +272,7 @@ def create_device_mesh(
       physical_mesh = _transpose_trick(physical_mesh, mesh_shape)
     device_mesh, assignment = _create_device_mesh_for_nd_torus(
         physical_mesh, mesh_shape)
-    logging.info('_create_device_mesh_for_nd_torus assignment: %s', assignment)
+    logger.info('_create_device_mesh_for_nd_torus assignment: %s', assignment)
     return device_mesh
   else:
     device_mesh = np.asarray(devices).reshape(mesh_shape)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     package_data={'jax': ['py.typed', "*.pyi", "**/*.pyi"]},
     python_requires='>=3.7',
     install_requires=[
-        'absl-py',
         'numpy>=1.20',
         'opt_einsum',
         'scipy>=1.5',


### PR DESCRIPTION
This commit changes the JAX codebase to use Python's builtin logging instead of ABSL logging. With the latter being used in JAX code as of now, the change to Python builtin logging is advised for the following reasons (among others):

- `absl-py` can be removed as an external dependency of JAX.
- Builtin logging brings the option of adding more log handlers, for example file handlers for log dumps or writers to different IO streams.

Logging in JAX is ported over to take place at the module level. While previously, some Python namespaces within JAX already used module-scoped logging via `absl.vlog`, the following idiom was adopted to provide the same functionality in Python builtin logging:

```
logger = get_logger(__name__)
logger.debug(...)
logger.info(...)
```

This way, all log messages emitted from JAX contain their origin information directly within the logger name. Furthermore, the builtin root logger is left untouched, which is beneficial for downstream users planning to customize the Python root logger.

The package `absl-py` was removed from JAX's install requirements, and added into its test requirements. Tests are not yet migrated in this change.

Fixes #6308.