### PR TITLE
DOC: switch order of custom_jvp and _wraps

### DIFF
--- a/jax/_src/scipy/special.py
+++ b/jax/_src/scipy/special.py
@@ -1304,9 +1304,9 @@ def _expi_pos(x):
   )
 
 
-@_wraps(osp_special.expi, module='scipy.special')
 @api.custom_jvp
 @jit
+@_wraps(osp_special.expi, module='scipy.special')
 def expi(x):
   (x,) = _promote_args_inexact("expi", x)
   ret = jnp.piecewise(x, [x < 0], [lambda x: -exp1(-x), _expi_pos])
@@ -1423,9 +1423,9 @@ def _expn3(n, x):
   return (ans + one) * jnp.exp(-x) / xk
 
 
-@_wraps(osp_special.expn, module='scipy.special')
 @partial(api.custom_jvp, nondiff_argnums=(0,))
 @jnp.vectorize
+@_wraps(osp_special.expn, module='scipy.special')
 @jit
 def expn(n, x):
   n, x = _promote_args_inexact("expn", n, x)


### PR DESCRIPTION
This was causing issues with the documentation build, because the signature was not being propagated: https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.special.expn.html#jax.scipy.special.expn