### PR TITLE
Make the etils[epath] dependency of JAX optional.

### DIFF
--- a/jax/_src/dispatch.py
+++ b/jax/_src/dispatch.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import atexit
-import collections
 import contextlib
 from functools import partial
 import itertools
@@ -55,7 +54,7 @@ from jax._src.lib import xla_bridge as xb
 from jax._src.lib import xla_client as xc
 import jax._src.util as util
 from jax._src.util import flatten, unflatten
-from etils import epath
+from jax._src import path
 
 
 FLAGS = flags.FLAGS
@@ -1004,7 +1003,7 @@ def _make_string_safe_for_filename(s: str) -> str:
 def _dump_ir_to_file(name: str, ir: str):
   id = next(_ir_dump_counter)
   name = f"jax_ir{id}_{_make_string_safe_for_filename(name)}.mlir"
-  name = epath.Path(FLAGS.jax_dump_ir_to) / name
+  name = path.Path(FLAGS.jax_dump_ir_to) / name
   name.write_text(ir)
 
 

--- a/jax/_src/path.py
+++ b/jax/_src/path.py
@@ -1,0 +1,33 @@
+# Copyright 2022 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import pathlib
+
+logger = logging.getLogger(__name__)
+
+try:
+  import etils.epath as epath
+except:
+  epath = None
+
+# If etils.epath (aka etils[epath] to pip) is present, we prefer it because it
+# can read and write to, e.g., GCS buckets. Otherwise we use the builtin
+# pathlib and can only read/write to the local filesystem.
+if epath:
+  logger.debug("etils.epath found. Using etils.epath for file I/O.")
+  Path = epath.Path
+else:
+  logger.debug("etils.epath was not found. Using pathlib for file I/O.")
+  Path = pathlib.Path

--- a/jax/experimental/compilation_cache/gfile_cache.py
+++ b/jax/experimental/compilation_cache/gfile_cache.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 import os
-import pathlib
 
 from jax.experimental.compilation_cache.cache_interface import CacheInterface
-from etils import epath
-from absl import logging
+from jax._src import path as pathlib
 
 class GFileCache(CacheInterface):
 
   def __init__(self, path: str):
     """Sets up a cache at 'path'. Cached values may already be present."""
-    self._path = epath.Path(path)
+    self._path = pathlib.Path(path)
     self._path.mkdir(parents=True, exist_ok=True)
 
   def get(self, key: str):

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'opt_einsum',
         'scipy>=1.5',
         'typing_extensions',
-        'etils[epath]',
     ],
     extras_require={
         # Minimum jaxlib version; used in testing.


### PR DESCRIPTION
If epath is installed then we will use it for file I/O. If it is not, we will fall back to pathlib from the standard library.