### PR TITLE
Fix future numpy warning

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -195,7 +195,8 @@ class PrngTest(jtu.JaxTestCase):
     self.assertEqual(expected, result_to_hex(result))
 
     expected = ("0x1cb996fc", "0xbb002be7")
-    result = prng.threefry_2x32(np.uint32([-1, -1]), np.uint32([-1, -1]))
+    u32_max = np.iinfo(np.uint32).max
+    result = prng.threefry_2x32(np.uint32([u32_max, u32_max]), np.uint32([u32_max, u32_max]))
     self.assertEqual(expected, result_to_hex(result))
 
     expected = ("0xc4923a9c", "0x483df7a0")


### PR DESCRIPTION
Future numpy versions will raise a warning on `np.uint32(-1)`, which leads to an error in our test suite.

Fixes #12790