### PR TITLE
Ignore UserWarning as a WAR ...

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,6 @@ filterwarnings =
     # numpy uses distutils which is deprecated
     ignore:The distutils.* is deprecated.*:DeprecationWarning
     ignore:`sharded_jit` is deprecated. Please use `pjit` instead.*:DeprecationWarning
+    ignore:Running operations on `Array`s that are not fully addressable by this process.*:UserWarning
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"


### PR DESCRIPTION
Ignore UserWarning as a WAR to run multiprocess GPU tests, otherwise pytest treats the warning as an error and the tests don't pass