### PR TITLE
Drop absl-py as a jaxlib dependency.

### DIFF
--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -46,7 +46,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension'],
     python_requires='>=3.7',
-    install_requires=['scipy>=1.5', 'numpy>=1.20', 'absl-py'],
+    install_requires=['scipy>=1.5', 'numpy>=1.20'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     classifiers=[


### PR DESCRIPTION
absl-py is unused.