### PR TITLE
initial commit of DevicesSharding (fka SimpleSharding)

### DIFF
--- a/jax/sharding.py
+++ b/jax/sharding.py
@@ -19,4 +19,5 @@ from jax._src.sharding import (
     SingleDeviceSharding as SingleDeviceSharding,
     PmapSharding as PmapSharding,
     OpShardingSharding as OpShardingSharding,
+    DevicesSharding as DevicesSharding,
 )


### PR DESCRIPTION
This PR adds a new `Sharding` implementation, provisionally called `DevicesSharding` because when using it you think about reshaping, transposing, and reducing over an array of (sets of) devices, and lining that up against your data array. This `Sharding` subclass was formerly called `SimpleSharding`. Also `SharadSharding`.

We're working on a tutorial which will cover the basics of `Sharding` together with `DevicesSharding` and `MeshPSpecSharding` in detail.