### PR TITLE
Skip unittest for stream_executor runtime 

### DIFF
--- a/tests/debugger_test.py
+++ b/tests/debugger_test.py
@@ -26,6 +26,7 @@ from jax.experimental import pjit
 from jax._src import debugger
 from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
+from jax._src.lib import xla_bridge
 import jax.numpy as jnp
 import numpy as np
 
@@ -112,6 +113,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_value_in_jit(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p x", "c"])
 
     @jax.jit
@@ -129,6 +133,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_multiple_values(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p x, y", "c"])
 
     @jax.jit
@@ -146,6 +153,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_context(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["l", "c"])
 
     @jax.jit
@@ -169,6 +179,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_backtrace(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["bt", "c"])
 
     @jax.jit
@@ -186,6 +199,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_work_with_multiple_stack_frames(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["l", "u", "p x", "d", "c"])
 
     def f(x):
@@ -225,6 +241,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_use_multiple_breakpoints(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
 
     def f(x):
@@ -251,7 +270,11 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_vmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
+
     # On TPU, the breakpoints can be reordered inside of vmap but can be fixed
     # by ordering sends.
     # TODO(sharadmv): change back to ordered = False when sends are ordered
@@ -280,8 +303,12 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_pmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.local_device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")
+
     stdin, stdout = make_fake_stdin_stdout(["p y", "c", "p y", "c"])
 
     def f(x):
@@ -305,8 +332,12 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_pjit(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.default_backend() != "tpu":
       raise unittest.SkipTest("`pjit` doesn't work with CustomCall.")
+
     stdin, stdout = make_fake_stdin_stdout(["p y", "c"])
 
     def f(x):
@@ -353,6 +384,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_accesses_globals(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p foo", "c"])
 
     @jax.jit
@@ -369,6 +403,8 @@ class CliDebuggerTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_limit_num_frames(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
     stdin, stdout = make_fake_stdin_stdout(["u", "p x", "c"])
 
     def g():
@@ -413,6 +449,9 @@ class CliDebuggerTest(jtu.JaxTestCase):
     self.assertRegex(stdout.getvalue(), expected)
 
   def test_can_handle_dictionaries_with_unsortable_keys(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     stdin, stdout = make_fake_stdin_stdout(["p x", "p weird_dict",
                                             "p weirder_dict", "c"])
 

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -22,13 +22,14 @@ from jax import lax
 from jax.config import config
 from jax.experimental import maps
 from jax.experimental import pjit
-from jax._src import sharding
 from jax.interpreters import pxla
+from jax._src import sharding
 from jax._src import ad_checkpoint
 from jax._src import debugging
 from jax._src import dispatch
 from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
+from jax._src.lib import xla_bridge
 import jax.numpy as jnp
 import numpy as np
 
@@ -102,6 +103,9 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_debug_print(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     @jax.jit
     def f(x):
       debug_print('x: {x}', x=x)
@@ -112,8 +116,12 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_debug_print_with_donate_argnums(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.default_backend() not in {"gpu", "tpu"}:
       raise unittest.SkipTest("Donate argnums not supported.")
+
     def f(x, y):
       debug_print('x: {x}', x=x)
       return x + y
@@ -125,6 +133,9 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     @jax.jit
     def f(x):
       debug_print('x: {x}', x=x, ordered=True)
@@ -135,8 +146,12 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print_with_donate_argnums(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.default_backend() not in {"gpu", "tpu"}:
       raise unittest.SkipTest("Donate argnums not supported.")
+
     def f(x, y):
       debug_print('x: {x}', x=x, ordered=True)
       return x + y
@@ -148,8 +163,12 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_prints_with_donate_argnums(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.default_backend() not in {"gpu", "tpu"}:
       raise unittest.SkipTest("Donate argnums not supported.")
+
     def f(x, y):
       debug_print('x: {x}', x=x, ordered=True)
       debug_print('x: {x}', x=x)
@@ -162,6 +181,9 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_double_stage_out_ordered_print(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     @jax.jit
     @jax.jit
     def f(x):
@@ -173,6 +195,9 @@ class DebugPrintTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print_with_pytree(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     @jax.jit
     def f(x):
       struct = dict(foo=x)
@@ -400,6 +425,8 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debug_print_in_staged_out_custom_jvp(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f(x):
@@ -426,6 +453,8 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_debug_print_in_staged_out_custom_vjp(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f(x):
@@ -469,6 +498,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_scan(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(xs):
       def _body(carry, x):
         debug_print("carry: {carry}, x: {x}", carry=carry, x=x, ordered=ordered)
@@ -487,6 +519,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_for_loop(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def _body(i, x):
         debug_print("i: {i}", i=i, ordered=ordered)
@@ -516,6 +551,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_while_loop_body(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def _cond(x):
         return x < 10
@@ -537,6 +575,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_while_loop_cond(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def _cond(x):
         debug_print("x: {x}", x=x, ordered=ordered)
@@ -567,6 +608,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_in_batched_while_cond(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def _cond(x):
         debug_print("x: {x}", x=x, ordered=ordered)
@@ -625,6 +669,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_cond(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def true_fun(x):
         debug_print("true: {}", x, ordered=ordered)
@@ -649,6 +696,9 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
   @jtu.sample_product(ordered=[False, True])
   @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_switch(self, ordered):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       def b1(x):
         debug_print("b1: {}", x, ordered=ordered)
@@ -700,6 +750,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_works_in_pmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")
 
@@ -723,6 +776,8 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_with_pjit(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     if jax.default_backend() in {"cpu", "gpu"} and jaxlib.version < (0, 3, 16):
       raise unittest.SkipTest("`pjit` of callback not supported.")
@@ -757,6 +812,8 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_of_pjit_of_while(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     if (jax.default_backend() in {"cpu", "gpu"}
         and jaxlib.xla_extension_version < 81):
@@ -792,6 +849,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_of_pjit_of_xmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if (jax.default_backend() in {"cpu", "gpu"}
         and jaxlib.xla_extension_version < 81):
       raise unittest.SkipTest("`pjit` of callback not supported.")
@@ -822,6 +882,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_with_xmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     def f(x):
       debug_print("{}", x, ordered=False)
     f = maps.xmap(f, in_axes=['a'], out_axes=None, backend='cpu',
@@ -835,6 +898,8 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_works_in_pmap_of_while(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -35,6 +35,7 @@ from jax._src import test_util as jtu
 from jax._src import util
 from jax._src.lax import control_flow as lcf
 from jax._src.lib import can_execute_with_token
+from jax._src.lib import xla_bridge
 import numpy as np
 
 config.parse_flags_with_absl()
@@ -594,6 +595,9 @@ class EffectOrderingTest(jtu.JaxTestCase):
   def test_can_execute_python_callback(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     log = []
     def log_value(x):
       log.append(x)
@@ -614,8 +618,12 @@ class EffectOrderingTest(jtu.JaxTestCase):
   def test_ordered_effect_remains_ordered_across_multiple_devices(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")
+
     log = []
     def log_value(x):
       log.append(x)
@@ -700,8 +708,12 @@ class ParallelEffectsTest(jtu.JaxTestCase):
   def test_can_pmap_unordered_callback(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
+
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")
+
     log = set()
     def log_value(x):
       log.add(int(x))

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -27,6 +27,7 @@ from jax._src import dispatch
 from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
 from jax._src import util
+from jax._src.lib import xla_bridge
 from jax.config import config
 from jax.experimental import maps
 from jax.interpreters import mlir
@@ -137,6 +138,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_scalar_values(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f(x):
@@ -212,6 +215,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_single_return_value(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f():
@@ -224,6 +229,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_multiple_return_values(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f():
@@ -238,6 +245,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_multiple_arguments_and_return_values(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x, y, z):
       return (x, y + z)
@@ -273,6 +282,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_pytree_arguments_and_return_values(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return dict(y=[x])
@@ -288,6 +299,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop_of_scalars(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -306,6 +319,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -327,6 +342,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond_of_scalars(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback1(x):
       return (x + 1.).astype(x.dtype)
@@ -354,6 +371,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback1(x):
       return x + 1.
@@ -381,6 +400,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan_of_scalars(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -400,6 +421,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return x + 1.
@@ -419,6 +442,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap_of_scalars(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -434,6 +459,8 @@ class PythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return x + 1.
@@ -458,6 +485,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_pure_callback_passes_ndarrays_without_jit(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def cb(x):
       self.assertIs(type(x), np.ndarray)
@@ -469,6 +498,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_simple_pure_callback(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     def f(x):
@@ -571,6 +602,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       jax.effects_barrier()
 
   def test_can_vmap_pure_callback(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.jit
     @jax.vmap
@@ -600,6 +633,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(out, np.sin(np.arange(4.)) + jnp.arange(10., 14.))
 
   def test_vmap_vectorized_callback(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def cb(x):
       self.assertTupleEqual(x.shape, ())
@@ -648,6 +683,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       jax.effects_barrier()
 
   def test_can_pmap_pure_callback(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.pmap
     def f(x):
@@ -669,6 +706,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       f(2.)
 
   def test_can_take_grad_of_pure_callback_with_custom_jvp(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     @jax.custom_jvp
     def sin(x):
@@ -688,6 +727,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback1(x):
       return x + 1.
@@ -713,6 +754,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return x + 1.
@@ -731,6 +774,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _cond_callback(x):
       return np.any(x < 10)
@@ -755,6 +800,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return x + 1.
@@ -772,6 +819,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_xmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -787,6 +836,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
 
   @jtu.skip_on_devices(*disabled_backends)
   def test_vectorized_callback_inside_xmap(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def _callback(x):
       return (x + 1.).astype(x.dtype)
@@ -801,6 +852,8 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(out, jnp.arange(1., 41.))
 
   def test_array_layout_is_preserved(self):
+    if xla_bridge.get_backend().runtime_type == 'stream_executor':
+      raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
 
     def g(x):
       return jax.pure_callback(lambda x: x, x, x)


### PR DESCRIPTION
Run unit tests on CloudTPU V2-8 and found a bunch of tests fails due to call back is not supported for stream_executor runtime , disable all those tests if runtime is stream_executor .