### PR TITLE
[ROCm] Fix ROCm dockerfile to remove 2020-resolver opt in.

### DIFF
--- a/build/rocm/build_rocm.sh
+++ b/build/rocm/build_rocm.sh
@@ -30,5 +30,5 @@ then
 fi
 
 python3 ./build/build.py --enable_rocm --rocm_path=${ROCM_PATH} --bazel_options=--override_repository=org_tensorflow=/tmp/tensorflow-upstream
-pip3 install --use-feature=2020-resolver --force-reinstall dist/*.whl  # installs jaxlib (includes XLA)
-pip3 install --use-feature=2020-resolver --force-reinstall .  # installs jax
+pip3 install --force-reinstall dist/*.whl  # installs jaxlib (includes XLA)
+pip3 install --force-reinstall .  # installs jax


### PR DESCRIPTION
The 2020-resolver opt in has been removed in pip 22.3 since it has now become the default.

/cc @hawkinsp 