### PR TITLE
[dynamic-shapes] fix nested vmap callable annotation logic

### DIFF
--- a/jax/interpreters/ad.py
+++ b/jax/interpreters/ad.py
@@ -42,15 +42,17 @@ def identity(x): return x
 def _update_annotation(
     f: lu.WrappedFun,
     orig_type: Optional[Tuple[Tuple[core.AbstractValue, bool], ...]],
-    nonzeros: List[bool]
+    explicit_nonzeros: List[bool]
   ) -> lu.WrappedFun:
   if orig_type is None:
     return f
+  # By convention, `explicit_nonzeros` only accounts for explicit arguments.
+  assert len(explicit_nonzeros) == sum(explicit for _, explicit in orig_type)
   # Implicit arguments never have tangents, so generate the tangent part of the
   # type annotation from explicit arguments only.
-  orig_avals = [aval for aval, explicit in orig_type if explicit]
+  explicit_avals = [aval for aval, explicit in orig_type if explicit]
   tan_types = [(aval.at_least_vspace(), True)
-               for nz, aval in zip(nonzeros, orig_avals) if nz]
+               for nz, aval in zip(explicit_nonzeros, explicit_avals) if nz]
   return lu.annotate(f, (*orig_type, *tan_types))
 
 def jvp(fun: lu.WrappedFun, has_aux=False, instantiate=True,

--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -295,10 +295,10 @@ class BatchTrace(Trace):
                      for out_axis, d in zip(out_axes_thunk(), dims_out()))
       new_params = dict(params, in_axes=new_in_axes, out_axes_thunk=new_out_axes_thunk)
       vals_out = map_primitive.bind(f, *vals, **new_params)
-      dims_out = [d + 1 if both_mapped(out_axis, d) and out_axis <= d else d
-                  for d, out_axis in zip(dims_out(), out_axes_thunk())]
+      dims_out_ = [d + 1 if both_mapped(out_axis, d) and out_axis <= d else d
+                   for d, out_axis in zip(dims_out(), out_axes_thunk())]
       src = source_info_util.current()
-      return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out)]
+      return [BatchTracer(self, v, d, src) for v, d in zip(vals_out, dims_out_)]
 
   def post_process_map(self, call_primitive, out_tracers, params):
     vals, dims, srcs = unzip3((t.val, t.batch_dim, t.source_info)


### PR DESCRIPTION
The `_update_annotation` logic in batching.py was just busted before.

Also I put `map = safe_map` and `zip = safe_zip` in batching.py, which revealed a couple barely-working things.