### PR TITLE
Cleanup: remove unused imports in private modules

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from functools import partial
-import operator as op
 from typing import (Callable, Optional, List, Tuple, Sequence, Set, Union, Any,
                     FrozenSet)
 import types
@@ -30,7 +29,6 @@ from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 from jax.tree_util import tree_flatten, tree_unflatten
 from jax._src import ad_util
-from jax._src import lax
 from jax._src import util
 from jax._src import source_info_util
 from jax._src import traceback_util

--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -14,7 +14,6 @@
 
 from functools import update_wrapper, reduce, partial
 import inspect
-import operator as op
 from typing import (Callable, Generic, Optional, Sequence, Tuple, TypeVar, Set,
                     Any)
 

--- a/jax/_src/debugger/colab_debugger.py
+++ b/jax/_src/debugger/colab_debugger.py
@@ -18,7 +18,7 @@ import html
 import inspect
 import traceback
 
-from typing import IO, List
+from typing import List
 
 import uuid
 

--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -32,11 +32,9 @@ from jax.interpreters import batching
 from jax.interpreters import mlir
 from jax.interpreters import partial_eval as pe
 from jax.interpreters import pxla
-from jax.interpreters import xla
 from jax._src import ad_checkpoint
 from jax._src import custom_derivatives
 from jax._src import lib as jaxlib
-from jax._src import source_info_util
 from jax._src import util
 from jax._src.lax import control_flow as lcf
 from jax._src.lib import xla_client as xc

--- a/jax/_src/lax/control_flow/for_loop.py
+++ b/jax/_src/lax/control_flow/for_loop.py
@@ -35,7 +35,6 @@ from jax._src import state
 from jax._src.util import (partition_list, merge_lists, safe_map, safe_zip,
                            split_list, split_dict)
 import jax.numpy as jnp
-import numpy as np
 
 from jax._src.lax.control_flow import loops
 from jax._src.lax.control_flow.common import _abstractify, _initial_style_jaxpr

--- a/jax/_src/lax/control_flow/loops.py
+++ b/jax/_src/lax/control_flow/loops.py
@@ -35,7 +35,6 @@ from jax.tree_util import (tree_flatten, tree_unflatten, treedef_is_leaf,
 from jax._src import ad_checkpoint
 from jax._src import ad_util
 from jax._src import api
-from jax._src import api_util
 from jax._src import dtypes
 from jax._src import source_info_util
 from jax._src import util
@@ -46,7 +45,6 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.traceback_util import api_boundary
 from jax._src.util import (
-    cache,
     extend_name_stack,
     partition_list,
     safe_map,

--- a/jax/_src/lax/control_flow/solves.py
+++ b/jax/_src/lax/control_flow/solves.py
@@ -24,7 +24,6 @@ from jax.core import raise_to_shaped
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
-from jax.interpreters import partial_eval as pe
 from jax.interpreters import xla
 from jax.tree_util import (tree_flatten, treedef_children, tree_leaves,
                            tree_unflatten, treedef_tuple)

--- a/jax/_src/lax/convolution.py
+++ b/jax/_src/lax/convolution.py
@@ -26,7 +26,6 @@ from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir
 from jax._src import util
-import jax._src.lib
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.lib import xla_client
 

--- a/jax/_src/lax/eigh.py
+++ b/jax/_src/lax/eigh.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import NamedTuple, Tuple
+from typing import NamedTuple
 
 import jax
 import jax._src.numpy.lax_numpy as jnp

--- a/jax/_src/lax/fft.py
+++ b/jax/_src/lax/fft.py
@@ -18,13 +18,11 @@ from typing import Union, Sequence
 
 import numpy as np
 
-import jax
 from jax._src.api import jit, linear_transpose, ShapeDtypeStruct
 from jax.core import Primitive
 from jax.interpreters import mlir
 from jax.interpreters import xla
 from jax._src.util import prod
-from jax._src import dtypes
 from jax import lax
 from jax.interpreters import ad
 from jax.interpreters import batching

--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -23,7 +23,6 @@ import warnings
 
 import numpy as np
 
-import jax
 from jax import core
 from jax import tree_util
 from jax.core import ShapedArray, AxisName, raise_to_shaped

--- a/jax/_src/lax/slicing.py
+++ b/jax/_src/lax/slicing.py
@@ -23,7 +23,6 @@ import jax
 from jax import core
 from jax._src import ad_util
 from jax._src import dtypes
-from jax._src import source_info_util
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir

--- a/jax/_src/lax/windowed_reductions.py
+++ b/jax/_src/lax/windowed_reductions.py
@@ -18,7 +18,6 @@ import warnings
 
 import numpy as np
 
-import jax._src.lib
 from jax.interpreters import ad
 from jax.interpreters import batching
 from jax.interpreters import mlir

--- a/jax/_src/scipy/signal.py
+++ b/jax/_src/scipy/signal.py
@@ -14,7 +14,7 @@
 
 from functools import partial
 import operator
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 import warnings
 
 import numpy as np

--- a/jax/_src/scipy/stats/betabinom.py
+++ b/jax/_src/scipy/stats/betabinom.py
@@ -13,7 +13,6 @@
 # limitations under the License
 
 
-import scipy
 import scipy.stats as osp_stats
 
 from jax import lax

--- a/jax/_src/sharding.py
+++ b/jax/_src/sharding.py
@@ -20,8 +20,7 @@ import operator as op
 from typing import (Sequence, List, Tuple, Optional, Mapping, Dict, Set,
                     FrozenSet, Union, cast)
 
-import jax
-from jax._src.util import safe_map, safe_zip, unzip2, prod
+from jax._src.util import safe_map, safe_zip
 from jax._src.lib import xla_bridge as xb
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_extension_version

--- a/jax/_src/state/discharge.py
+++ b/jax/_src/state/discharge.py
@@ -27,8 +27,7 @@ from jax import linear_util as lu
 from jax.interpreters import partial_eval as pe
 from jax._src.util import safe_map, safe_zip, split_list
 
-from jax._src.state.types import (ShapedArrayRef, ReadEffect, WriteEffect,
-                                  AccumEffect)
+from jax._src.state.types import ShapedArrayRef
 from jax._src.state.primitives import get_p, swap_p, addupdate_p
 
 ## JAX utilities

--- a/jax/_src/state/types.py
+++ b/jax/_src/state/types.py
@@ -13,27 +13,12 @@
 # limitations under the License.
 """Module for state types."""
 from __future__ import annotations
-from functools import partial
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Optional,  Union
 
-from jax import api_util
 from jax import core
-from jax import linear_util as lu
-from jax import tree_util
-from jax._src import ad_util
-from jax._src import device_array
-from jax._src import dispatch
-from jax._src import pretty_printer as pp
 from jax._src.lib import xla_bridge, xla_client
-from jax._src.util import (safe_map, safe_zip, split_list, tuple_insert,
-                           tuple_delete, prod)
-from jax.interpreters import ad
-from jax.interpreters import batching
-from jax.interpreters import mlir
-from jax.interpreters import partial_eval as pe
-from jax.interpreters import xla
-import numpy as np
+from jax._src.util import safe_map, safe_zip, tuple_insert, tuple_delete, prod
 
 xc = xla_client
 xb = xla_bridge

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -20,7 +20,7 @@ from functools import partial
 import re
 import os
 import textwrap
-from typing import Callable, Dict, List, Generator, Sequence, Tuple, Union
+from typing import Callable, List, Generator, Sequence, Tuple, Union
 import unittest
 import warnings
 import zlib

--- a/jax/_src/tree_util.py
+++ b/jax/_src/tree_util.py
@@ -17,8 +17,8 @@ import difflib
 import functools
 from functools import partial
 import operator as op
-from typing import (Any, Callable, Hashable, Iterable, Optional, Tuple, List,
-                    Dict, Type, TypeVar, overload, TYPE_CHECKING, NamedTuple)
+from typing import (Any, Callable, Dict, Hashable, Iterable, List, NamedTuple,
+                    Optional, Tuple, Type, TypeVar, overload)
 import textwrap
 import warnings
 

--- a/jax/collect_profile.py
+++ b/jax/collect_profile.py
@@ -20,7 +20,6 @@ import tempfile
 from typing import Optional
 
 # pytype: disable=import-error
-import jax
 from jax._src import profiler as jax_profiler
 try:
   from tensorflow.python.profiler import profiler_v2 as profiler

--- a/jax/config.py
+++ b/jax/config.py
@@ -14,4 +14,4 @@
 
 # TODO(phawkins): fix users of this alias and delete this file.
 
-from jax._src.config import config
+from jax._src.config import config  # noqa: F401

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -29,7 +29,6 @@ from typing import (Any, Callable, Dict, Iterator, List, NamedTuple, Optional,
 from typing_extensions import Protocol
 import warnings
 
-import jax
 from jax import core
 from jax import linear_util as lu
 from jax._src import ad_util

--- a/jax/interpreters/pxla.py
+++ b/jax/interpreters/pxla.py
@@ -83,7 +83,7 @@ from jax._src.lib.mlir.dialects import mhlo
 from jax._src.util import (unzip3, prod, safe_map, safe_zip, partition_list,
                            new_name_stack, wrap_name, assert_unreachable,
                            tuple_insert, tuple_delete, distributed_debug_log,
-                           split_dict, unzip2)
+                           unzip2)
 
 if TYPE_CHECKING:
   from jax._src.sharding import MeshPspecSharding, XLACompatibleSharding

--- a/jax/linear_util.py
+++ b/jax/linear_util.py
@@ -65,7 +65,7 @@ from __future__ import annotations
 
 import threading
 from functools import partial
-from typing import Any, Tuple, Callable, Optional
+from typing import Any, Tuple, Callable
 import weakref
 
 from jax import core

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,37 @@ exclude =
   build,
   __pycache__
 per-file-ignores =
+  # F811: redefinition of unused name
   docs/autodidax.py:F811
-  jax/*.py:F401
-  jax/**/__init__.py:F401
+  # F401: unused imports
+  # Note: we don't use jax/*.py because this matches contents of jax/_src
+  __init__.py:F401
+  jax/abstract_arrays.py:F401
+  jax/ad_checkpoint.py:F401
+  jax/api_util.py:F401
+  jax/cloud_tpu_init.py:F401
+  jax/core.py:F401
+  jax/custom_batching.py:F401
+  jax/custom_derivatives.py:F401
+  jax/custom_transpose.py:F401
+  jax/debug.py:F401
+  jax/distributed.py:F401
+  jax/dlpack.py:F401
+  jax/dtypes.py:F401
+  jax/errors.py:F401
+  jax/flatten_util.py:F401
+  jax/prng.py:F401
+  jax/profiler.py:F401
+  jax/random.py:F401
+  jax/sharding.py:F401
+  jax/stages.py:F401
+  jax/test_util.py:F401
+  jax/tree_util.py:F401
+  jax/util.py:F401
+  jax/_src/api.py:F401
+  jax/_src/numpy/lax_numpy.py:F401
   jax/experimental/*.py:F401
   jax/lax/*.py:F401
   jax/nn/*.py:F401
   jax/numpy/*.py:F401
-  jax/scipy/**/*.py:F401
+  jax/scipy/*.py:F401


### PR DESCRIPTION
Also improve our flake8 filter rules to avoid ignoring these.