### PR TITLE
[typing] add type annotations to the first several lax_numpy functions

### DIFF
--- a/jax/_src/state/primitives.py
+++ b/jax/_src/state/primitives.py
@@ -68,7 +68,7 @@ get_p.def_impl(_get_impl)
 Indexer = Tuple[Union[int, slice, jnp.ndarray], ...]
 
 def _unpack_idx(idx: Indexer, ndim: int
-               ) -> Tuple[Tuple[int, ...], Tuple[bool, ...]]:
+               ) -> Tuple[Tuple[Array, ...], Tuple[bool, ...]]:
   indexed_dims_ = [type(i) != slice for i in idx]
   _, non_slice_idx = partition_list(indexed_dims_, idx)
   indexed_dims = indexed_dims_ + [False] * (ndim - len(indexed_dims_))

--- a/jax/experimental/jax2tf/tests/flax_models/bilstm_classifier.py
+++ b/jax/experimental/jax2tf/tests/flax_models/bilstm_classifier.py
@@ -124,7 +124,7 @@ class Embedder(nn.Module):
   word_dropout_rate: float = 0.
   unk_idx: Optional[int] = None
   deterministic: Optional[bool] = None
-  dtype: jnp.dtype = jnp.float32
+  dtype: jnp.dtype = jnp.dtype('float32')
 
   def setup(self):
     self.embedding = self.param(


### PR DESCRIPTION
Part of #12049

`lax_numpy.py` is a huge file, so I decided to add annotations gradually rather than all at once.