### PR TITLE
CI: avoid raising error when wrapped function is None

### DIFF
--- a/jax/_src/numpy/util.py
+++ b/jax/_src/numpy/util.py
@@ -154,6 +154,10 @@ def _wraps(
       be determined from the wrapped function itself.
   """
   def wrap(op):
+    op.__np_wrapped__ = fun
+    # Allows this pattern: @wraps(getattr(np, 'new_function', None))
+    if fun is None:
+      return op
     docstr = getattr(fun, "__doc__", None)
     name = getattr(fun, "__name__", getattr(op, "__name__", str(op)))
     try:
@@ -203,7 +207,6 @@ def _wraps(
         docstr = fun.__doc__
 
     op.__doc__ = docstr
-    op.__np_wrapped__ = fun
     for attr in ['__name__', '__qualname__']:
       try:
         value = getattr(fun, attr)


### PR DESCRIPTION
Fixes current CI failures.

We often use `@wraps(getattr(np, 'funcname', None))` to wrap functions that only exist in newer numpy versions. When `JAX_ENABLE_CHECKS=true` this leads to a ValueError; since we set this flag in our CI, the CI will fail if it is run on older numpy versions. This fixes the issue and future-proofs us.