### PR TITLE
Skip two unit tests about custom sharding on libtpu

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -255,6 +255,9 @@ def is_device_rocm():
 def is_device_cuda():
   return xla_bridge.get_backend().platform_version.startswith('cuda')
 
+def is_cloud_tpu():
+  return 'libtpu' in xla_bridge.get_backend().platform_version
+
 def is_device_tpu_v4():
   return jax.devices()[0].device_kind == "TPU v4"
 

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -1164,6 +1164,9 @@ class InspectShardingTest(jtu.JaxTestCase):
     if jaxlib.xla_extension_version < 94:
       raise unittest.SkipTest("Inspect sharding not supported.")
 
+    if jtu.is_cloud_tpu():
+      raise unittest.SkipTest("Inspect sharding is not supported on libtpu.")
+
     is_called = False
     def _cb(sd):
       nonlocal is_called

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -1098,6 +1098,9 @@ class PJitTest(jtu.BufferDonationTestCase):
     if xla_extension_version < 95:
       raise unittest.SkipTest('Must support custom partitioning.')
 
+    if jtu.is_cloud_tpu():
+      raise unittest.SkipTest("Custom partitioning is not supported on libtpu.")
+
     def partition(arg_shapes, arg_shardings, result_shape, result_sharding):
       self.assertEqual(arg_shardings[0], result_sharding)
       self.assertEqual(P(('x',)), result_sharding.spec)


### PR DESCRIPTION
DETAILS:
Due to xc.register_custom_call_partitioner is not supported on libtpu, the following two tests are skipped: tests/pjit_test.py::PJitTest::test_custom_partitioner tests/debugging_primitives_test.py::InspectShardingTest::test_inspect_sharding_is_called_in_pjit