### PR TITLE
[dynamic-shapes] tweak jnp.canonicalize_shape logic

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -90,7 +90,8 @@ newaxis = None
 # Like core.canonicalize_shape, but also accept int-like (non-sequence)
 # arguments for `shape`.
 def canonicalize_shape(shape: Any, context: str="") -> core.Shape:
-  if getattr(shape, 'ndim', None) == 0 or ndim(shape) == 0:
+  if (not isinstance(shape, (tuple, list)) and
+      (getattr(shape, 'ndim', None) == 0 or ndim(shape) == 0)):
     return core.canonicalize_shape((shape,), context)  # type: ignore
   else:
     return core.canonicalize_shape(shape, context)  # type: ignore

--- a/tests/dynamic_api_test.py
+++ b/tests/dynamic_api_test.py
@@ -1427,6 +1427,16 @@ class DynamicShapeTest(jtu.JaxTestCase):
     self.assertEqual(y.shape, (sz, 4))
     self.assertAllClose(y._data, x)
 
+  def test_shape_tuple_argument_to_zeros(self):
+    @partial(jax.jit, abstracted_axes=(('n',), ('n',)))
+    def f(x, y):
+      zero =  jnp.zeros(jnp.shape(x))
+      return zero * y
+
+    x = jnp.arange(3.0)
+    y = jnp.arange(3.0) + 1
+    jax.make_jaxpr(f)(x, y)  # doesn't crash
+
 
 if __name__ == '__main__':
   absltest.main(testLoader=jtu.JaxTestLoader())


### PR DESCRIPTION
The idea with jnp.canonicalize_shape is that it handles non-tuple shapes, i.e. intended to be scalar-like arguments like Python builtin ints or numpy scalar types or 0D arrays. To do that, it checks numpy.ndim(shape) == 0. But numpy.ndim might attempt to convert its argument to a numpy.ndarray, which breaks when the argument is a tuple with Tracers inside!

Instead, let's just check if the argument is one of the canonical sequence types (list or tuple) and if so then not even call numpy.ndim.