### PR TITLE
Increase the minimum jaxlib version to 0.3.22.

### DIFF
--- a/jax/_src/callback.py
+++ b/jax/_src/callback.py
@@ -21,7 +21,6 @@ from typing import Any, Callable, Sequence
 from jax import core
 from jax import tree_util
 from jax._src import dtypes
-from jax._src import lib as jaxlib
 from jax._src import util
 from jax._src import dispatch
 from jax.interpreters import ad
@@ -100,10 +99,6 @@ batching.primitive_batchers[pure_callback_p] = pure_callback_batching_rule
 
 
 def pure_callback_lowering(ctx, *args, callback, **params):
-
-  if ctx.module_context.platform == "TPU" and jaxlib.version < (0, 3, 15):
-    raise NotImplementedError("Pure callbacks on TPU not supported. "
-                              "Please upgrade to a jaxlib >= 0.3.15.")
 
   def _callback(*flat_args):
     return tuple(pure_callback_impl(*flat_args, callback=callback, **params))

--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -695,12 +695,10 @@ parallel_functions_output_gda = config.define_bool_state(
     help='If True, pjit will output GDAs.')
 
 def _update_jax_array_global(val):
-  if lib.xla_extension_version >= 92:
-    lib.jax_jit.global_state().jax_array = val
+  lib.jax_jit.global_state().jax_array = val
 
 def _update_jax_array_thread_local(val):
-  if lib.xla_extension_version >= 92:
-    lib.jax_jit.thread_local_state().jax_array = val
+  lib.jax_jit.thread_local_state().jax_array = val
 
 jax_array = config.define_bool_state(
     name='jax_array',
@@ -946,7 +944,7 @@ config.define_bool_state(
 # TODO(b/205307544): Remove flag once coordination service has rolled out.
 config.define_bool_state(
     name='jax_coordination_service',
-    default=(lib.xla_extension_version >= 80),
+    default=True,
     help=(
          'Use coordination service (experimental) instead of the default PjRT '
          'distributed runtime.'

--- a/jax/_src/lib/__init__.py
+++ b/jax/_src/lib/__init__.py
@@ -87,16 +87,7 @@ cpu_feature_guard.check_cpu_features()
 import jaxlib.xla_client as xla_client
 import jaxlib.lapack as lapack
 
-# TODO(phawkins): remove pocketfft references when the minimum jaxlib version
-# is 0.3.17 or newer.
-try:
-  import jaxlib.pocketfft as pocketfft  # pytype: disable=import-error
-except ImportError:
-  pocketfft = None  # type: ignore
-try:
-  import jaxlib.ducc_fft as ducc_fft  # pytype: disable=import-error
-except ImportError:
-  ducc_fft = None  # type: ignore
+import jaxlib.ducc_fft as ducc_fft
 
 xla_extension = xla_client._xla
 pytree = xla_client._xla.pytree

--- a/jax/_src/lib/xla_bridge.py
+++ b/jax/_src/lib/xla_bridge.py
@@ -48,9 +48,8 @@ traceback_util.register_exclusion(__file__)
 
 XlaBackend = xla_client._xla.Client
 
-use_sharded_buffer = xla_client._version >= 90
-# TODO(chky): Change ShardedBuffer to xla_client.ShardedBuffer when the minimum
-# jaxlib version is updated.
+# TODO(phawkins): replace with xla_client.ShardedBuffer after fixing type
+# errors.
 ShardedBuffer = Any
 
 FLAGS = flags.FLAGS
@@ -224,15 +223,14 @@ register_backend_factory('tpu_driver', _make_tpu_driver_client,
 
 def make_gpu_client(*, platform_name, visible_devices_flag):
   visible_devices = getattr(FLAGS, visible_devices_flag, "all")
-  # Pass allowed_devices unconditionally when jaxlib 0.3.15 is the minimum.
-  kwargs = {}
+  allowed_devices = None
   if visible_devices != "all":
-    kwargs["allowed_devices"] = {int(x) for x in visible_devices.split(",")}
+    allowed_devices = {int(x) for x in visible_devices.split(",")}
   return xla_client.make_gpu_client(
     distributed_client=distributed.global_state.client,
     node_id=distributed.global_state.process_id,
     platform_name=platform_name,
-    **kwargs)
+    allowed_devices=allowed_devices)
 
 if hasattr(xla_client, "make_gpu_client"):
   register_backend_factory(

--- a/jax/experimental/compilation_cache/compilation_cache.py
+++ b/jax/experimental/compilation_cache/compilation_cache.py
@@ -129,8 +129,7 @@ def _hash_computation(hash_obj, xla_computation):
   hash_obj.update(scrubbed_hlo)
 
 def _hash_compile_options(hash_obj, compile_options_obj):
-  # TODO(phawkins): simplify this code when jaxlib >= 0.3.16 is the minimum.
-  expected_num_compile_options = 33 if xla_client._version >= 84 else 32
+  expected_num_compile_options = 33
   assert len(dir(compile_options_obj)) == expected_num_compile_options, (
       f"Unexpected number of CompileOption fields: "
       f"{len(dir(compile_options_obj))}. This likely: means that an extra "
@@ -147,9 +146,7 @@ def _hash_compile_options(hash_obj, compile_options_obj):
   _hash_int(hash_obj, compile_options_obj.profile_version)
   if compile_options_obj.device_assignment is not None:
     hash_obj.update(compile_options_obj.device_assignment.serialize())
-  # TODO(phawkins): simplify this code when jaxlib >= 0.3.16 is the minimum.
-  if xla_client._version >= 84:
-    _hash_bool(hash_obj, compile_options_obj.compile_portable_executable)
+  _hash_bool(hash_obj, compile_options_obj.compile_portable_executable)
 
 def _hash_executable_build_options(hash_obj, executable_obj):
   expected_options = 34

--- a/jax/experimental/custom_partitioning.py
+++ b/jax/experimental/custom_partitioning.py
@@ -28,7 +28,6 @@ from jax.interpreters import xla
 from jax.interpreters import partial_eval as pe
 from jax._src import custom_api_util
 from jax._src.lib import xla_client as xc
-from jax._src import lib as jaxlib
 from jax._src.api_util import flatten_fun_nokwargs
 
 import weakref
@@ -268,9 +267,8 @@ def _custom_partitioning_lowering_rule(ctx: mlir.LoweringRuleContext, *values,
 mlir.register_lowering(custom_partitioning_p,
                        _custom_partitioning_lowering_rule)
 
-if jaxlib.xla_extension_version >= 95:
-  xc.register_custom_call_partitioner(  # pytype: disable=module-attr
-      _CUSTOM_PARTITIONING_CALL_NAME,
-      _custom_partitioning_propagate_user_sharding,
-      _custom_partitioning_partition,
-      _custom_partitioning_infer_sharding_from_operands, True)
+xc.register_custom_call_partitioner(  # pytype: disable=module-attr
+    _CUSTOM_PARTITIONING_CALL_NAME,
+    _custom_partitioning_propagate_user_sharding,
+    _custom_partitioning_partition,
+    _custom_partitioning_infer_sharding_from_operands, True)

--- a/jax/experimental/jax2tf/tests/jax2tf_test.py
+++ b/jax/experimental/jax2tf/tests/jax2tf_test.py
@@ -27,7 +27,6 @@ from jax import ad_checkpoint
 from jax import dtypes
 from jax import lax
 from jax import numpy as jnp
-from jax._src import lib as jaxlib
 from jax._src import source_info_util
 from jax._src import test_util as jtu
 import jax._src.lib.xla_bridge
@@ -1239,8 +1238,6 @@ def get_serialized_computation(
     lowered = jax.jit(f_jax, abstracted_axes=abstracted_axes).lower(*args)
   mhlo_module = lowered.compiler_ir(dialect='mhlo')
   mhlo_module_text = mlir.module_to_string(mhlo_module)
-  if jaxlib.version <= (0, 3, 14):
-    mhlo_module_text = jax2tf.jax2tf._fixup_mhlo_module_text(mhlo_module_text)
   logging.info(f'Serialized ir.Module = {mhlo_module_text}')
   return mhlo_module_text
 

--- a/jax/experimental/pjit.py
+++ b/jax/experimental/pjit.py
@@ -1154,7 +1154,7 @@ pxla.spmd_primitive_batchers[pjit_p] = partial(_pjit_batcher, True, None)
 
 def _pjit_batcher_for_sharding(
     s: OpShardingSharding, dim: int, val: Tuple[str, ...], mesh, ndim: int):
-  if not val and xla_extension_version >= 83:
+  if not val:
     new_op = s._op_sharding.clone()
     tad = list(new_op.tile_assignment_dimensions)
     tad.insert(dim, 1)

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -42,7 +42,6 @@ from jax._src.lax.lax import (
   DotDimensionNumbers)
 from jax._src.lib.mlir import ir
 from jax._src.lib import xla_bridge
-from jax._src.lib import version as jaxlib_version
 from jax._src.lib.mlir.dialects import mhlo
 from jax._src.numpy.setops import _unique
 
@@ -922,7 +921,7 @@ def _bcoo_dot_general_gpu_lowering(
           n_sparse == 2 and rhs_aval.ndim == 2 and
           len(lhs_contract) == 1 and lhs_contract[0] in [1, 2] and
           len(rhs_contract) == 1 and rhs_contract[0] in [0, 1] and
-          cuda_version >= 11061 and jaxlib_version >= (0, 3, 18))
+          cuda_version >= 11061)
       if not cuda_supported_batch_mode:
         warnings.warn("bcoo_dot_general GPU lowering currently does not "
                       "support this batch-mode computation. Falling back to "

--- a/jax/experimental/sparse/linalg.py
+++ b/jax/experimental/sparse/linalg.py
@@ -24,7 +24,7 @@ from jax import core
 from jax.interpreters import mlir
 from jax.interpreters import xla
 
-from jax._src.lib import gpu_solver, xla_extension_version
+from jax._src.lib import gpu_solver
 
 import numpy as np
 
@@ -550,6 +550,4 @@ def spsolve(data, indices, indptr, b, tol=1e-6, reorder=1):
     An array with the same dtype and size as b representing the solution to
     the sparse linear system.
   """
-  if xla_extension_version < 86:
-    raise ValueError('spsolve requires jaxlib version 86 or above.')
   return spsolve_p.bind(data, indices, indptr, b, tol=tol, reorder=reorder)

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -35,7 +35,6 @@ from jax._src import ad_util
 from jax._src import device_array
 from jax._src import dtypes
 from jax._src.lib import mlir_api_version, xla_extension_version
-from jax._src.lib import version as jaxlib_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import chlo
 from jax._src.lib.mlir.dialects import mhlo
@@ -335,10 +334,7 @@ def make_ir_context() -> ir.Context:
   """Creates an MLIR context suitable for JAX IR."""
   context = ir.Context()
   mhlo.register_mhlo_dialect(context)
-  if mlir_api_version < 33:
-    chlo.register_chlo_dialect(context)
-  else:
-    chlo.register_dialect(context)
+  chlo.register_dialect(context)
   return context
 
 
@@ -1554,9 +1550,6 @@ def emit_python_callback(
     ) -> Tuple[List[ir.Value], Any, Any]:
   """Emits MHLO that calls back to a provided Python function."""
   platform = ctx.module_context.platform
-  if platform in {"tpu"} and jaxlib_version < (0, 3, 15):
-    raise ValueError(
-        "`EmitPythonCallback` on TPU only supported on jaxlib >= 0.3.15")
   if platform not in {"cpu", "cuda", "rocm", "tpu"}:
     raise ValueError(
         f"`EmitPythonCallback` not supported on {platform} backend.")

--- a/jax/version.py
+++ b/jax/version.py
@@ -16,7 +16,7 @@
 # eval()-ed by setup.py, so it should not have any dependencies.
 
 __version__ = "0.3.24"
-_minimum_jaxlib_version = "0.3.15"
+_minimum_jaxlib_version = "0.3.22"
 
 def _version_as_tuple(version_str):
   return tuple(int(i) for i in version_str.split(".") if i.isdigit())

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -24,7 +24,6 @@ from jax._src import dispatch
 from jax._src import test_util as jtu
 from jax._src.lib import xla_client as xc
 from jax._src.lib import xla_bridge as xb
-from jax._src.lib import xla_extension_version
 from jax._src.util import prod, safe_zip
 from jax.interpreters import pxla
 from jax.experimental.pjit import pjit
@@ -696,8 +695,6 @@ class ShardingTest(jtu.JaxTestCase):
     self.assertFalse(issubclass(array.ArrayImpl, np.ndarray))
 
   def test_op_sharding_sharding_repr(self):
-    if xla_extension_version < 96:
-      self.skipTest('This test only works with the latest HloSharding repr.')
     op = xc.OpSharding()
     op.type = xc.OpSharding.Type.OTHER
     op.tile_assignment_dimensions = [4, 1, 2]

--- a/tests/debugger_test.py
+++ b/tests/debugger_test.py
@@ -24,7 +24,6 @@ from jax.config import config
 from jax.experimental import maps
 from jax.experimental import pjit
 from jax._src import debugger
-from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
 from jax._src.lib import xla_bridge
 import jax.numpy as jnp
@@ -54,17 +53,10 @@ def setUpModule():
 def tearDownModule():
   prev_xla_flags()
 
-# TODO(sharadmv): remove jaxlib guards for TPU tests when jaxlib minimum
-#                 version is >= 0.3.15
-disabled_backends = []
-if jaxlib.version < (0, 3, 15):
-  disabled_backends.append("tpu")
-
 foo = 2
 
 class CliDebuggerTest(jtu.JaxTestCase):
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_eof(self):
     stdin, stdout = make_fake_stdin_stdout([])
 
@@ -76,7 +68,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
       f(2.)
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_continue(self):
     stdin, stdout = make_fake_stdin_stdout(["c"])
 
@@ -91,7 +82,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     (jdb) """)
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_value(self):
     stdin, stdout = make_fake_stdin_stdout(["p x", "c"])
 
@@ -111,7 +101,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_value_in_jit(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -131,7 +120,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_multiple_values(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -151,7 +139,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_context(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -177,7 +164,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     \(jdb\) """)
     self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_print_backtrace(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -197,7 +183,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_can_work_with_multiple_stack_frames(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -239,7 +224,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_use_multiple_breakpoints(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -268,7 +252,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_vmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -301,7 +284,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_pmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -330,7 +312,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_works_with_pjit(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -360,7 +341,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
       jax.effects_barrier()
       self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_uses_local_before_global_scope(self):
     stdin, stdout = make_fake_stdin_stdout(["p foo", "c"])
 
@@ -382,7 +362,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     self.assertRegex(stdout.getvalue(), expected)
 
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debugger_accesses_globals(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -401,7 +380,6 @@ class CliDebuggerTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertRegex(stdout.getvalue(), expected)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_limit_num_frames(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -27,7 +27,6 @@ from jax._src import sharding
 from jax._src import ad_checkpoint
 from jax._src import debugging
 from jax._src import dispatch
-from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
 from jax._src.lib import xla_bridge
 import jax.numpy as jnp
@@ -56,12 +55,6 @@ def setUpModule():
 def tearDownModule():
   prev_xla_flags()
 
-# TODO(sharadmv): remove jaxlib guards for TPU tests when jaxlib minimum
-#                 version is >= 0.3.15
-disabled_backends = []
-if jaxlib.version < (0, 3, 15):
-  disabled_backends.append("tpu")
-
 class DummyDevice:
   def __init__(self, platform, id):
     self.platform = platform
@@ -73,7 +66,6 @@ class DebugPrintTest(jtu.JaxTestCase):
     super().tearDown()
     dispatch.runtime_tokens.clear()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_simple_debug_print_works_in_eager_mode(self):
     def f(x):
       debug_print('x: {}', x)
@@ -82,7 +74,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debug_print_works_with_named_format_strings(self):
     def f(x):
       debug_print('x: {x}', x=x)
@@ -91,7 +82,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_multiple_debug_prints_should_print_multiple_values(self):
     def f(x):
       debug_print('x: {x}', x=x)
@@ -101,7 +91,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\ny: 3\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_debug_print(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -114,7 +103,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_debug_print_with_donate_argnums(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -131,7 +119,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -144,7 +131,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print_with_donate_argnums(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -161,7 +147,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_prints_with_donate_argnums(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -179,7 +164,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\nx: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_double_stage_out_ordered_print(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -193,7 +177,6 @@ class DebugPrintTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "x: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_stage_out_ordered_print_with_pytree(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -423,7 +406,6 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
     # print.
     self.assertEqual(output(), "y: 3.0, z: 6.0\n" * 2)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debug_print_in_staged_out_custom_jvp(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -451,7 +433,6 @@ class DebugPrintTransformationTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self.assertEqual(output(), "goodbye: 2.0 3.0\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_debug_print_in_staged_out_custom_vjp(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -496,7 +477,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
     self.assertDictEqual(_count(text1.split("\n")), _count(text2.split("\n")))
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_scan(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -517,7 +497,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       """))
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_for_loop(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -549,7 +528,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       self._assertLinesEqual(output(), expected)
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_while_loop_body(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -573,7 +551,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       """))
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_while_loop_cond(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -606,7 +583,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       """))
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_in_batched_while_cond(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -667,7 +643,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       self._assertLinesEqual(output(), expected)
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_cond(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -694,7 +669,6 @@ class DebugPrintControlFlowTest(jtu.JaxTestCase):
       """))
 
   @jtu.sample_product(ordered=[False, True])
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_print_inside_switch(self, ordered):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -738,7 +712,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
 
     self.assertDictEqual(_count(text1.split("\n")), _count(text2.split("\n")))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_ordered_print_not_supported_in_pmap(self):
 
     @jax.pmap
@@ -748,7 +721,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
         ValueError, "Ordered effects not supported in `pmap`."):
       f(jnp.arange(jax.local_device_count()))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_works_in_pmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -774,13 +746,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
       jax.effects_barrier()
     self._assertLinesEqual(output(), "hello: 0\nhello: 1\nhello: 2\nhello: 3\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_with_pjit(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
-
-    if jax.default_backend() in {"cpu", "gpu"} and jaxlib.version < (0, 3, 16):
-      raise unittest.SkipTest("`pjit` of callback not supported.")
 
     def f(x):
       debug_print("{}", x, ordered=False)
@@ -810,14 +778,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
         jax.effects_barrier()
       self.assertEqual(output(), "140\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_of_pjit_of_while(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
-
-    if (jax.default_backend() in {"cpu", "gpu"}
-        and jaxlib.xla_extension_version < 81):
-      raise unittest.SkipTest("`pjit` of callback not supported.")
 
     def f(x):
       def cond(carry):
@@ -847,14 +810,9 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
           "[ 3  4  5  6  7  8  9 10]\n"
           "[ 4  5  6  7  8  9 10 11]\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_of_pjit_of_xmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
-
-    if (jax.default_backend() in {"cpu", "gpu"}
-        and jaxlib.xla_extension_version < 81):
-      raise unittest.SkipTest("`pjit` of callback not supported.")
 
     def f(x):
       def foo(x):
@@ -880,7 +838,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
         jax.effects_barrier()
         self._assertLinesEqual(output(), "\n".join(lines))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_with_xmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -896,7 +853,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
       lines = [f"{i}\n" for i in range(40)]
       self._assertLinesEqual(output(), "".join(lines))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_unordered_print_works_in_pmap_of_while(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -921,7 +877,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
         output(), "hello: 0\nhello: 1\nhello: 2\n"
         "hello: 1\nhello: 2\n")
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_incorrectly_formatted_string(self):
 
     @jax.jit
@@ -942,7 +897,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
       f(jnp.arange(2))
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_format_string_errors_with_unused_args(self):
 
     @jax.jit
@@ -963,7 +917,6 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
       g(jnp.arange(2))
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_accidental_fstring(self):
 
     @jax.jit
@@ -1161,9 +1114,6 @@ class InspectShardingTest(jtu.JaxTestCase):
 
   def test_inspect_sharding_is_called_in_pjit(self):
 
-    if jaxlib.xla_extension_version < 94:
-      raise unittest.SkipTest("Inspect sharding not supported.")
-
     if jtu.is_cloud_tpu():
       raise unittest.SkipTest("Inspect sharding is not supported on libtpu.")
 
@@ -1191,9 +1141,6 @@ class InspectShardingTest(jtu.JaxTestCase):
     self.assertTrue(is_called)
 
   def test_inspect_sharding_is_called_in_jit(self):
-
-    if jaxlib.xla_extension_version < 94:
-      raise unittest.SkipTest("Inspect sharding not supported.")
 
     if not config.jax_array:
       raise unittest.SkipTest("jax_array to work inside of `jit`.")

--- a/tests/jaxpr_effects_test.py
+++ b/tests/jaxpr_effects_test.py
@@ -29,7 +29,6 @@ from jax.experimental import pjit
 from jax._src import sharding
 from jax.interpreters import mlir
 from jax._src import ad_checkpoint
-from jax._src import lib as jaxlib
 from jax._src import dispatch
 from jax._src import test_util as jtu
 from jax._src import util
@@ -67,12 +66,6 @@ lcf.allowed_effects.add('while1')
 lcf.allowed_effects.add('while2')
 
 ad_checkpoint.remat_allowed_effects.add('remat')
-
-# TODO(sharadmv): remove jaxlib guards for TPU tests when jaxlib minimum
-#                 version is >= 0.3.15
-disabled_backends = []
-if jaxlib.version < (0, 3, 15):
-  disabled_backends.append('tpu')
 
 
 def trivial_effect_lowering(ctx, *, effect):
@@ -591,7 +584,6 @@ class EffectfulJaxprLoweringTest(jtu.JaxTestCase):
 
 class EffectOrderingTest(jtu.JaxTestCase):
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_execute_python_callback(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported
@@ -614,7 +606,6 @@ class EffectOrderingTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertListEqual(log, [2., 3.])
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_ordered_effect_remains_ordered_across_multiple_devices(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported
@@ -652,7 +643,6 @@ class EffectOrderingTest(jtu.JaxTestCase):
     self.assertListEqual(log, expected_log)
 
   @jtu.skip_on_devices("tpu")
-  @jtu.skip_on_devices(*disabled_backends)
   def test_different_threads_get_different_tokens(self):
     if jax.device_count() < 2:
       raise unittest.SkipTest("Test requires >= 2 devices.")
@@ -704,7 +694,6 @@ class ParallelEffectsTest(jtu.JaxTestCase):
       return x
     jax.pmap(f)(jnp.arange(jax.local_device_count()))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_pmap_unordered_callback(self):
     # TODO(sharadmv): enable this test on GPU and TPU when backends are
     # supported

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -29,7 +29,6 @@ from jax import experimental
 from jax.config import config
 from jax._src import distributed
 import jax.numpy as jnp
-from jax._src.lib import xla_extension_version
 from jax._src import test_util as jtu
 from jax._src import util
 from jax.experimental import global_device_array
@@ -130,8 +129,6 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
         for proc in subprocesses:
           proc.kill()
 
-  @unittest.skipIf(xla_extension_version < 91,
-                   "Test requires jaxlib 0.3.17 or newer")
   @jtu.skip_on_devices("rocm")
   def test_distributed_jax_cuda_visible_devices(self):
     """Test jax_cuda_visible_devices works in distributed settings."""

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -49,7 +49,6 @@ from jax.experimental.pjit import (pjit, pjit_p, with_sharding_constraint,
 from jax.interpreters import pxla
 from jax.interpreters import mlir
 from jax._src.lib import xla_client as xc, xla_bridge
-from jax._src.lib import xla_extension_version
 from jax._src.util import prod, curry, unzip2, safe_zip
 
 from jax.config import config
@@ -1093,9 +1092,6 @@ class PJitTest(jtu.BufferDonationTestCase):
   @jtu.skip_on_devices('cpu')  # Collectives don't seem to work on CPU.
   @jtu.with_mesh([('x', 4), ('y', 2)])
   def test_custom_partitioner(self):
-    if xla_extension_version < 95:
-      raise unittest.SkipTest('Must support custom partitioning.')
-
     if jtu.is_cloud_tpu():
       raise unittest.SkipTest("Custom partitioning is not supported on libtpu.")
 
@@ -2925,14 +2921,13 @@ class UtilTest(jtu.JaxTestCase):
     self.assertFalse(pxla.are_op_shardings_equal(op1, op3))
     self.assertFalse(pxla.are_op_shardings_equal(op2, op3))
 
-    if xla_extension_version >= 81:
-      hs1 = xc.HloSharding.from_proto(op1)
-      hs2 = xc.HloSharding.from_proto(op2)
-      hs3 = xc.HloSharding.from_proto(op3)
+    hs1 = xc.HloSharding.from_proto(op1)
+    hs2 = xc.HloSharding.from_proto(op2)
+    hs3 = xc.HloSharding.from_proto(op3)
 
-      self.assertEqual(hash(hs1), hash(hs2))
-      self.assertNotEqual(hash(hs1), hash(hs3))
-      self.assertNotEqual(hash(hs2), hash(hs3))
+    self.assertEqual(hash(hs1), hash(hs2))
+    self.assertNotEqual(hash(hs1), hash(hs3))
+    self.assertNotEqual(hash(hs2), hash(hs3))
 
   def test_op_sharding_partial_sharding(self):
     op1 = xc.OpSharding()
@@ -2949,10 +2944,9 @@ class UtilTest(jtu.JaxTestCase):
 
     self.assertTrue(pxla.are_op_shardings_equal(op1, op2))
 
-    if xla_extension_version >= 81:
-      hs1 = xc.HloSharding.from_proto(op1)
-      hs2 = xc.HloSharding.from_proto(op2)
-      self.assertEqual(hash(hs1), hash(hs2))
+    hs1 = xc.HloSharding.from_proto(op1)
+    hs2 = xc.HloSharding.from_proto(op2)
+    self.assertEqual(hash(hs1), hash(hs2))
 
   def test_op_sharding_tuple_shardings(self):
     top1 = xc.OpSharding()
@@ -2977,16 +2971,11 @@ class UtilTest(jtu.JaxTestCase):
 
     self.assertFalse(pxla.are_op_shardings_equal(op1, op2))
 
-    if xla_extension_version >= 81:
-      hs1 = xc.HloSharding.from_proto(op1)
-      hs2 = xc.HloSharding.from_proto(op2)
-      self.assertNotEqual(hash(hs1), hash(hs2))
+    hs1 = xc.HloSharding.from_proto(op1)
+    hs2 = xc.HloSharding.from_proto(op2)
+    self.assertNotEqual(hash(hs1), hash(hs2))
 
   def test_device_indices_cache(self):
-    if xla_extension_version < 81:
-      raise unittest.SkipTest('HloSharding is available after '
-                              'xla_extension_version >= 81')
-
     op1 = xc.OpSharding()
     op1.type = xc.OpSharding.Type.OTHER
     op1.tile_assignment_dimensions = [1, 1, 2, 1]
@@ -3018,10 +3007,6 @@ class UtilTest(jtu.JaxTestCase):
 
 
   def test_op_sharding_semantically_replicated(self):
-    if xla_extension_version < 81:
-      raise unittest.SkipTest(
-          'HloSharding is not available for this test so it cannot be tested.')
-
     op1 = xc.OpSharding()
     op1.type = xc.OpSharding.Type.OTHER
     op1.tile_assignment_dimensions = [1, 1, 2]
@@ -3051,10 +3036,6 @@ class UtilTest(jtu.JaxTestCase):
     self.assertTrue(pxla.are_op_shardings_equal(op3, op4))
 
   def test_op_sharding_manual_replicated(self):
-    if xla_extension_version < 81:
-      raise unittest.SkipTest(
-          'HloSharding is not available for this test so it cannot be tested.')
-
     op1 = xc.OpSharding()
     op1.type = xc.OpSharding.Type.OTHER
     op1.tile_assignment_dimensions = [1, 1, 2, 1]

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -24,7 +24,6 @@ from jax import lax
 from jax import tree_util
 from jax._src import debugging
 from jax._src import dispatch
-from jax._src import lib as jaxlib
 from jax._src import test_util as jtu
 from jax._src import util
 from jax._src.lib import xla_bridge
@@ -57,12 +56,6 @@ def setUpModule():
 def tearDownModule():
   prev_xla_flags()
 
-
-# TODO(sharadmv): remove jaxlib guards for TPU tests when jaxlib minimum
-#                 version is >= 0.3.15
-disabled_backends = []
-if jaxlib.version < (0, 3, 15):
-  disabled_backends.append("tpu")
 
 callback_p = core.Primitive("callback")
 callback_p.multiple_results = True
@@ -126,8 +119,7 @@ def callback_lowering(ctx, *args, effect, callback, **params):
 
 mlir.register_lowering(callback_p, callback_lowering, platform="cpu")
 mlir.register_lowering(callback_p, callback_lowering, platform="gpu")
-if jaxlib.version >= (0, 3, 15):
-  mlir.register_lowering(callback_p, callback_lowering, platform="tpu")
+mlir.register_lowering(callback_p, callback_lowering, platform="tpu")
 
 
 class PythonCallbackTest(jtu.JaxTestCase):
@@ -136,7 +128,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     super().tearDown()
     dispatch.runtime_tokens.clear()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_scalar_values(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -150,7 +141,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     self.assertEqual(out, 1.)
 
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_number_of_args(self):
 
     @jax.jit
@@ -163,7 +153,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_number_of_returned_values(self):
 
     @jax.jit
@@ -185,7 +174,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
       g()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_shape_outputs(self):
 
     @jax.jit
@@ -198,7 +186,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_dtype_outputs(self):
 
     def _cb():
@@ -213,7 +200,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_single_return_value(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -227,7 +213,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     np.testing.assert_allclose(out, np.ones(4, np.float32))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_multiple_return_values(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -243,7 +228,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(x, np.ones(4, np.float32))
     np.testing.assert_allclose(y, np.ones(5, np.int32))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_multiple_arguments_and_return_values(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -260,7 +244,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(x, np.ones(3))
     np.testing.assert_allclose(y, np.array([1., 3., 5]))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_send_recv_zero_dim_arrays(self):
 
     def _callback(x):
@@ -280,7 +263,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
       np.testing.assert_allclose(
           f(jnp.zeros(0, jnp.float32)), np.zeros(0, np.float32))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_pytree_arguments_and_return_values(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -297,7 +279,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(out, dict(y=[2.]))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop_of_scalars(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -317,7 +298,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(out, 10.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -340,7 +320,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     np.testing.assert_allclose(out, jnp.arange(10., 15.))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond_of_scalars(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -369,7 +348,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(out, 0.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -398,7 +376,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     np.testing.assert_allclose(out, jnp.zeros(2))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan_of_scalars(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -419,7 +396,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     self.assertEqual(out, 10.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -440,7 +416,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     jax.effects_barrier()
     np.testing.assert_allclose(out, jnp.arange(2.) + 10.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap_of_scalars(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -457,7 +432,6 @@ class PythonCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(
         out, np.arange(jax.local_device_count(), dtype=np.float32) + 1.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -483,7 +457,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     super().tearDown()
     dispatch.runtime_tokens.clear()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_pure_callback_passes_ndarrays_without_jit(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -496,7 +469,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       return jax.pure_callback(cb, x, x)
     f(jnp.array(2.))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_simple_pure_callback(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -506,7 +478,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       return jax.pure_callback(lambda x: (x * 2.).astype(x.dtype), x, x)
     self.assertEqual(f(2.), 4.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_can_dce_pure_callback(self):
 
     if jax.default_backend() == "tpu":
@@ -525,7 +496,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     _ = f(2.)
     self.assertEmpty(log)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_number_of_args(self):
 
     @jax.jit
@@ -538,7 +508,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_number_of_returned_values(self):
 
     @jax.jit
@@ -559,7 +528,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       g()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_shape_outputs(self):
 
     @jax.jit
@@ -572,7 +540,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrong_dtype_outputs(self):
 
     def _cb():
@@ -587,7 +554,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       f()
       jax.effects_barrier()
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_with_wrongly_specified_64_bit_dtype(self):
     if config.jax_enable_x64:
       raise unittest.SkipTest("Test only needed when 64-bit mode disabled.")
@@ -725,7 +691,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     out = f(2.)
     np.testing.assert_allclose(out, jnp.cos(2.))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_cond(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -752,7 +717,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     out = f(False, jnp.ones(2))
     np.testing.assert_allclose(out, jnp.zeros(2))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_scan(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -772,7 +736,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     out = f(jnp.arange(2.))
     np.testing.assert_allclose(out, jnp.arange(2.) + 10.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_while_loop(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -798,7 +761,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
     out = f(jnp.arange(5.))
     np.testing.assert_allclose(out, jnp.arange(10., 15.))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_of_pmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -817,7 +779,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
         out,
         np.arange(2 * jax.local_device_count()).reshape([-1, 2]) + 1.)
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_callback_inside_xmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')
@@ -834,7 +795,6 @@ class PurePythonCallbackTest(jtu.JaxTestCase):
       out = f(np.arange(40.))
     np.testing.assert_allclose(out, jnp.arange(1., 41.))
 
-  @jtu.skip_on_devices(*disabled_backends)
   def test_vectorized_callback_inside_xmap(self):
     if xla_bridge.get_backend().runtime_type == 'stream_executor':
       raise unittest.SkipTest('Host callback not supported for runtime type: stream_executor.')

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -34,10 +34,8 @@ from jax.experimental.sparse import bcsr as sparse_bcsr
 from jax.experimental.sparse.bcoo import BCOOInfo
 from jax.experimental.sparse.util import _csr_to_coo
 from jax import lax
-from jax._src.lib import xla_extension_version
 from jax._src.lib import gpu_sparse
 from jax._src.lib import xla_bridge
-from jax._src.lib import version as jaxlib_version
 from jax._src.util import unzip2
 from jax import jit
 from jax import tree_util
@@ -1206,8 +1204,7 @@ class BCOOTest(jtu.JaxTestCase):
 
     cuda_version_11061_and_beyond = _is_required_cuda_version_satisfied(
         cuda_version=11061)
-    jaxlib_version_0318_and_beyond = jaxlib_version >= (0, 3, 18)
-    if cuda_version_11061_and_beyond and jaxlib_version_0318_and_beyond:
+    if cuda_version_11061_and_beyond:
       # TODO(tianjianlu): In some cases, this fails python_should_be_executing.
       # self._CompileAndCheck(f_sparse, args_maker)
       self._CheckAgainstNumpy(f_dense, f_sparse, args_maker)
@@ -2609,7 +2606,6 @@ class SparseSolverTest(jtu.JaxTestCase):
   )
   @unittest.skipIf(not GPU_LOWERING_ENABLED, "test requires cusparse/cusolver")
   @unittest.skipIf(jtu.device_under_test() != "gpu", "test requires GPU")
-  @unittest.skipIf(xla_extension_version < 86, "test requires jaxlib version 86")
   @jtu.skip_on_devices("rocm")
   def test_sparse_qr_linear_solver(self, size, reorder, dtype):
     rng = rand_sparse(self.rng())

--- a/tests/tree_util_test.py
+++ b/tests/tree_util_test.py
@@ -16,7 +16,6 @@ import collections
 import functools
 import pickle
 import re
-import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -25,12 +24,9 @@ import jax
 from jax import tree_util
 from jax import flatten_util
 from jax._src import test_util as jtu
-from jax._src.lib import pytree as pytree
 from jax._src.tree_util import prefix_errors
 import jax.numpy as jnp
 
-
-pytree_version = getattr(pytree, "version", 0)
 
 def _dummy_func(*args, **kwargs):
   return
@@ -361,7 +357,6 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(expected, actual)
 
   @parameterized.parameters([(*t, s) for t, s in zip(TREES, TREE_STRINGS)])
-  @unittest.skipIf(pytree_version < 2, "Requires jaxlib 0.3.15")
   def testStringRepresentation(self, tree, correct_string):
     """Checks that the string representation of a tree works."""
     treedef = tree_util.tree_structure(tree)
@@ -371,7 +366,6 @@ class TreeTest(jtu.JaxTestCase):
     self.assertEqual(str(tree_util.tree_structure({})), "PyTreeDef({})")
 
   @parameterized.parameters(*TREES)
-  @unittest.skipIf(pytree_version < 3, "Requires jaxlib 0.3.16")
   def testPickleRoundTrip(self, tree):
     treedef = tree_util.tree_structure(tree)
     treedef_restored = pickle.loads(pickle.dumps(treedef))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -16,11 +16,9 @@ from absl.testing import absltest
 
 from jax import linear_util as lu
 from jax._src import test_util as jtu
-import unittest
 
 from jax.config import config
 from jax._src.util import weakref_lru_cache
-from jax._src.lib import xla_extension_version
 config.parse_flags_with_absl()
 FLAGS = config.FLAGS
 
@@ -81,8 +79,6 @@ class UtilTest(jtu.JaxTestCase):
       example_cached_fn(stable_keys[i % len(stable_keys)])
       example_cached_fn(Key())
 
-  @unittest.skipIf(xla_extension_version < 95,
-                   "Test requires jaxlib 0.3.19 or newer")
   def test_weakref_lru_cache_asan_problem(self):
 
     @weakref_lru_cache

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -46,7 +46,6 @@ from jax._src.nn import initializers as nn_initializers
 from jax._src.lib import xla_bridge
 from jax._src.lib import xla_client
 from jax._src.lib import mlir_api_version
-from jax._src.lib import xla_extension_version
 from jax._src.util import unzip2, prod, safe_zip
 from jax._src.lax import parallel as lax_parallel
 from jax._src.lax.parallel import pgather
@@ -857,8 +856,6 @@ class XMapTestManualSPMD(ManualSPMDTestMixin, XMapTestCase):
     ))
   @jtu.with_mesh_from_kwargs
   def testCollective(self, mesh):
-    if xla_extension_version < 85:
-      raise SkipTest("Need use_global_device_ids in AllReduceOp")
     all_axes = tuple(axis[0] for axis in mesh)
     f = xmap(lambda x: lax.psum(x, 'i'), in_axes=['i', 'j'], out_axes=['j'],
              axis_resources=dict(zip('ij', all_axes)))


### PR DESCRIPTION
The minimum xla_extension_version is now 98 and the minimum mlir_api_version is now 32.