### PR TITLE
when i is int-like, make x.at[i].set(u) generate a DUS

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -3750,13 +3750,16 @@ def _rewriting_take(arr, idx, indices_are_sorted=False, unique_indices=False,
   # followed by an optional reverse and broadcast_in_dim.
 
   # Handle some special cases, falling back if error messages might differ.
-  if (arr.ndim > 0 and isinstance(idx, (int, np.integer)) and
-      not isinstance(idx, (bool, np.bool_)) and isinstance(arr.shape[0], int)):
-    if 0 <= idx < arr.shape[0]:
-      if _any(isinstance(d, core.Tracer) for d in arr.shape[1:]):
-        return lax.dynamic_index_in_dim(arr, idx, keepdims=False)
-      else:
-        return lax.index_in_dim(arr, idx, keepdims=False)
+  try: idx_aval = core.get_aval(idx)
+  except: idx_aval = None
+  if (idx_aval is not None and arr.ndim > 0 and not idx_aval.shape and
+      dtypes.issubdtype(idx_aval.dtype, np.integer) and
+      not dtypes.issubdtype(idx_aval.dtype, np.bool_) and
+      isinstance(arr.shape[0], int)):
+    if not isinstance(idx, core.Tracer) and 0 <= idx < arr.shape[0]:
+      return lax.index_in_dim(arr, idx, keepdims=False)
+    else:
+      return lax.dynamic_index_in_dim(arr, idx, keepdims=False)
   if (arr.ndim > 0 and isinstance(arr.shape[0], int) and
       isinstance(idx, slice) and
       (type(idx.start) is int or idx.start is None) and
@@ -5107,6 +5110,18 @@ class _IndexUpdateRef:
 
     See :mod:`jax.ops` for details.
     """
+    try: idx_aval = core.get_aval(self.index)
+    except: idx_aval = None
+    if (idx_aval is not None and not idx_aval.shape and self.array.ndim > 0 and
+        dtypes.issubdtype(idx_aval.dtype, np.integer) and
+        not dtypes.issubdtype(idx_aval.dtype, np.bool_) and
+        _dtype(self.array) == _dtype(values) and
+        shape(values) == self.array.shape[1:]):
+      out = lax.dynamic_update_index_in_dim(self.array, values, self.index, 0)
+      if dtypes.is_weakly_typed(self.array) and dtypes.is_weakly_typed(self.index):
+        out = lax_internal._convert_element_type(out, out.dtype, weak_type=True)
+      return out
+    # TODO(mattjj): when self.index is a slice, also use a DUS
     return scatter._scatter_update(self.array, self.index, values, lax.scatter,
                                    indices_are_sorted=indices_are_sorted,
                                    unique_indices=unique_indices, mode=mode)


### PR DESCRIPTION
also make x[i] generate a DS

TODO:
* [ ] make out-of-bounds behavior consistent

Context is I was looking at things like this:
```python
def gather(xs, idxs):
  def body(carry, _):
    i, xs, idxs, ys = carry
    y = xs[idxs[i]]
    ys = ys.at[i].set(y)
    new_carry = (i + 1, xs, idxs, ys)
    return new_carry, None
  ys = jnp.zeros(len(idxs), xs.dtype)
  (*_, ys), _ = jax.lax.scan(body, (0, xs, idxs, ys), None, length=len(idxs))
  return ys

xs = jnp.array([3., 1., 4.])
idxs = jnp.array([0, 2])
print(jax.make_jaxpr(jax.grad(lambda xs: gather(xs, idxs).sum()))(xs))
```

On main we get a backward pass `scan` like:
```
    bg:f32[3] _:f32[2] = scan[
      jaxpr={ lambda ; bh:f32[3] bi:f32[2] bj:i32[1] bk:i32[1]. let
          bl:bool[2] = broadcast_in_dim[broadcast_dimensions=() shape=(2,)] True
          bm:bool[2] = scatter[
            dimension_numbers=ScatterDimensionNumbers(update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,))
            indices_are_sorted=True
            mode=GatherScatterMode.FILL_OR_DROP
            unique_indices=True
            update_consts=()
            update_jaxpr={ lambda ; bn:bool[] bo:bool[]. let  in (bo,) }
          ] bl bj False
          bp:f32[2] = broadcast_in_dim[broadcast_dimensions=() shape=(2,)] 0.0
          bq:f32[2] = select_n bm bp bi
          br:f32[] = gather[
            dimension_numbers=GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))
            fill_value=0
            indices_are_sorted=False
            mode=GatherScatterMode.FILL_OR_DROP
            slice_sizes=(1,)
            unique_indices=False
          ] bi bj
          bs:f32[3] = broadcast_in_dim[broadcast_dimensions=() shape=(3,)] 0.0
          bt:f32[3] = scatter-add[
            dimension_numbers=ScatterDimensionNumbers(update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,))
            indices_are_sorted=True
            mode=GatherScatterMode.PROMISE_IN_BOUNDS
            unique_indices=True
            update_consts=()
            update_jaxpr={ lambda ; bu:f32[] bv:f32[]. let
                bw:f32[] = add bu bv
              in (bw,) }
          ] bs bk br
          bx:f32[3] = add_any bh bt
        in (bx, bq) }
      length=2
      linear=(True, True, False, False)
      num_carry=2
      num_consts=0
      reverse=True
      unroll=1
    ] bf be e f
  in (bg,) }
```

while on this branch we get:
```
    be:f32[3] _:f32[2] = scan[
      jaxpr={ lambda ; bf:f32[3] bg:f32[2] bh:i32[] bi:i32[]. let
          bj:f32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] 0.0
          bk:f32[2] = dynamic_update_slice bg bj bi
          bl:f32[1] = dynamic_slice[slice_sizes=(1,)] bg bi
          bm:f32[] = reduce_sum[axes=(0,)] bl
          bn:f32[1] = broadcast_in_dim[broadcast_dimensions=() shape=(1,)] bm
          bo:f32[3] = broadcast_in_dim[broadcast_dimensions=() shape=(3,)] 0.0
          bp:f32[3] = dynamic_update_slice bo bn bh
          bq:f32[3] = add_any bf bp
        in (bq, bk) }
      length=2
      linear=(True, True, False, False)
      num_carry=2
      num_consts=0
      reverse=True
      unroll=1
    ] bd bc e f
```