### PR TITLE
Add support for using pip-installed CUDA wheels.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,6 +70,7 @@ build:cuda --action_env TF_CUDA_COMPUTE_CAPABILITIES="sm_52,sm_60,sm_70,compute_
 build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 build:cuda --@local_config_cuda//:enable_cuda
 build:cuda --@xla//xla/python:enable_gpu=true
+build:cuda --@xla//xla/python:jax_cuda_pip_rpaths=true
 build:cuda --define=xla_python_enable_gpu=true
 
 build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain

--- a/README.md
+++ b/README.md
@@ -439,18 +439,17 @@ source](https://jax.readthedocs.io/en/latest/developer.html#building-from-source
   * cuDNN 8.6 or newer. We recommend using the cuDNN 8.6 wheel if your cuDNN
     installation is new enough, since it supports additional functionality.
   * cuDNN 8.2 or newer.
-* You *must* use an NVidia driver version that is at least as new as your
+* You *must* use an NVIDIA driver version that is at least as new as your
   [CUDA toolkit's corresponding driver version](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-major-component-versions__table-cuda-toolkit-driver-versions).
-  For example, if you have CUDA 11.4 update 4 installed, you must use NVidia
+  For example, if you have CUDA 11.4 update 4 installed, you must use NVIDIA
   driver 470.82.01 or newer if on Linux. This is a strict requirement that
   exists because JAX relies on JIT-compiling code; older drivers may lead to
   failures.
   * If you need to use an newer CUDA toolkit with an older driver, for example
-    on a cluster where you cannot update the NVidia driver easily, you may be
+    on a cluster where you cannot update the NVIDIA driver easily, you may be
     able to use the
     [CUDA forward compatibility packages](https://docs.nvidia.com/deploy/cuda-compatibility/)
-    that NVidia provides for this purpose.
-
+    that NVIDIA provides for this purpose.
 
 Next, run
 
@@ -527,7 +526,7 @@ simply run
 conda install jax -c conda-forge
 ```
 
-To install on a machine with an NVidia GPU, run
+To install on a machine with an NVIDIA GPU, run
 ```bash
 conda install jaxlib=*=*cuda* jax cuda-nvcc -c conda-forge -c nvidia
 ```

--- a/jaxlib/cuda/BUILD
+++ b/jaxlib/cuda/BUILD
@@ -97,6 +97,13 @@ pybind_extension(
         "-fno-strict-aliasing",
     ],
     features = ["-use_header_modules"],
+    linkopts = select({
+        "@xla//xla/python:use_jax_cuda_pip_rpaths": [
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cuda_runtime/lib",
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cublas/lib",
+        ],
+        "//conditions:default": [],
+    }),
     module_name = "_blas",
     deps = [
         ":cublas_kernels",
@@ -174,6 +181,13 @@ pybind_extension(
         "-fno-strict-aliasing",
     ],
     features = ["-use_header_modules"],
+    linkopts = select({
+        "@xla//xla/python:use_jax_cuda_pip_rpaths": [
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cuda_runtime/lib",
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cusolver/lib",
+        ],
+        "//conditions:default": [],
+    }),
     module_name = "_solver",
     deps = [
         ":cuda_gpu_kernel_helpers",
@@ -216,6 +230,13 @@ pybind_extension(
         "-fno-strict-aliasing",
     ],
     features = ["-use_header_modules"],
+    linkopts = select({
+        "@xla//xla/python:use_jax_cuda_pip_rpaths": [
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cuda_runtime/lib",
+            "-Wl,-rpath,$$ORIGIN/../../nvidia/cusparse/lib",
+        ],
+        "//conditions:default": [],
+    }),
     module_name = "_sparse",
     deps = [
         ":cuda_gpu_kernel_helpers",

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,9 @@ from setuptools import setup, find_packages
 _current_jaxlib_version = '0.4.6'
 # The following should be updated with each new jaxlib release.
 _latest_jaxlib_version_on_pypi = '0.4.6'
-_available_cuda_versions = ['11']
-_default_cuda_version = '11'
-_available_cudnn_versions = ['82', '86']
-_default_cudnn_version = '86'
+_available_cuda11_cudnn_versions = ['82', '86']
+_default_cuda11_cudnn_version = '86'
+_default_cuda12_cudnn_version = '88'
 _libtpu_version = '0.1.dev20230309'
 
 _dct = {}
@@ -90,16 +89,52 @@ setup(
         # $ pip install jax[australis]
         'australis': ['protobuf>=3.13,<4'],
 
-        # CUDA installations require adding jax releases URL; e.g.
+        # CUDA installations require adding the JAX CUDA releases URL.
+        # $ pip install jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+        'cuda': [
+          f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{_default_cuda11_cudnn_version}",
+        ],
+
         # Cuda installation defaulting to a CUDA and Cudnn version defined above.
         # $ pip install jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-        'cuda': [f"jaxlib=={_current_jaxlib_version}+cuda{_default_cuda_version}.cudnn{_default_cudnn_version}"],
+        'cuda': [f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{_default_cuda11_cudnn_version}"],
+
+        'cuda11_pip': [
+          f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{_default_cuda11_cudnn_version}",
+          "nvidia-cublas-cu11",
+          "nvidia-cuda-nvcc-cu11",
+          "nvidia-cuda-runtime-cu11",
+          "nvidia-cudnn-cu11",
+          "nvidia-cufft-cu11",
+          "nvidia-cusolver-cu11",
+          "nvidia-cusparse-cu11",
+        ],
+
+        'cuda12_pip': [
+          f"jaxlib=={_current_jaxlib_version}+cuda12.cudnn{_default_cuda12_cudnn_version}",
+          "nvidia-cublas-cu12",
+          "nvidia-cuda-nvcc-cu12",
+          "nvidia-cuda-runtime-cu12",
+          "nvidia-cudnn-cu12",
+          "nvidia-cufft-cu12",
+          "nvidia-cusolver-cu12",
+          "nvidia-cusparse-cu12",
+        ],
+
+        # Target that does not depend on the CUDA pip wheels, for those who want
+        # to use a preinstalled CUDA.
+        'cuda11_local': [
+          f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{_default_cuda11_cudnn_version}",
+        ],
+        'cuda12_local': [
+          f"jaxlib=={_current_jaxlib_version}+cuda12.cudnn{_default_cuda12_cudnn_version}",
+        ],
 
         # CUDA installations require adding jax releases URL; e.g.
         # $ pip install jax[cuda11_cudnn82] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
         # $ pip install jax[cuda11_cudnn86] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-        **{f'cuda{cuda_version}_cudnn{cudnn_version}': f"jaxlib=={_current_jaxlib_version}+cuda{cuda_version}.cudnn{cudnn_version}"
-           for cuda_version in _available_cuda_versions for cudnn_version in _available_cudnn_versions}
+        **{f'cuda11_cudnn{cudnn_version}': f"jaxlib=={_current_jaxlib_version}+cuda11.cudnn{cudnn_version}"
+           for cudnn_version in _available_cuda11_cudnn_versions}
     },
     url='https://github.com/google/jax',
     license='Apache-2.0',


### PR DESCRIPTION
Change `jax[cuda]` to depend on the pip CUDA wheels. Recommend this path.
Add a `jax[cuda_using_existing_cuda_installation]` to use the system CUDA instead.