### PR TITLE
leak checker: explain why a tracer is alive by printing a reference chain

### DIFF
--- a/jax/interpreters/batching.py
+++ b/jax/interpreters/batching.py
@@ -164,8 +164,8 @@ class BatchTracer(Tracer):
   def _origin_msg(self):
     if self.source_info is None:
       return ""
-    return ("\nThis Tracer was created on line "
-            f"{source_info_util.summarize(self.source_info)}")
+    return (f"\nThis BatchTracer with object id {id(self)} was created on line:"
+            f"\n  {source_info_util.summarize(self.source_info)}")
 
   def _contents(self):
     return [('val', self.val), ('batch_dim', self.batch_dim)]

--- a/jax/interpreters/partial_eval.py
+++ b/jax/interpreters/partial_eval.py
@@ -1460,7 +1460,7 @@ class DynamicJaxprTracer(core.Tracer):
     if not self._trace.main.jaxpr_stack:  # type: ignore
       # If this Tracer has been leaked the jaxpr stack may no longer be
       # available. So we can't print as much origin information.
-      return ("\nThis Tracer was created on line "
+      return ("\nThis DynamicJaxprTracer was created on line "
               f"{source_info_util.summarize(self._line_info)}")
     else:
       invar_pos, progenitor_eqns = self._trace.frame.find_progenitors(self)


### PR DESCRIPTION
The idea here is that if you know what data structure(s) a leaked tracer is in, it might help you understand what the side-effect was that caused the problem.

With this code:

```python
import jax
jax.config.update('jax_check_tracer_leaks', True)

class A:
  def __init__(self, dct):
    self.dct = dct

a = A({})

def sketch(x):
  a.dct['hi'] = [lambda: x]
  return x

jax.vmap(sketch)(jax.numpy.arange(3))
```

instead of just this error:

```
Traced<ShapedArray(int32[])>with<BatchTrace(level=1/0)> with
  val = DeviceArray([0, 1, 2], dtype=int32)
  batch_dim = 0
This Tracer was created on line /usr/local/google/home/mattjj/packages/jax/qiao26.py:14 (<module>)

```

we now get this error:

```
Exception: Leaked trace MainTrace(1,BatchTrace). Leaked tracer(s):

Traced<ShapedArray(int32[])>with<BatchTrace(level=1/0)> with
  val = DeviceArray([0, 1, 2], dtype=int32)
  batch_dim = 0
This BatchTracer with object id 140443431328480 was created on line:
  /usr/local/google/home/mattjj/packages/jax/qiao26.py:14 (<module>)
<BatchTracer 140443431328480> is referred to by <function 140443431341072> closed-over variable x
<function 140443431341072> is referred to by <list 140443431333184>[0]
<list 140443431333184> is referred to by <dict 140445269059648>['hi']
<dict 140445269059648> is referred to by <A 140445263828256>.dct
<A 140445263828256> is referred to by __main__.a
```

That is, when the leak checker finds (via the `gc`) a `Tracer` which has outlived its trace, we attempt to walk back up the referrer chain for that `Tracer` and describe what objects we encounter (and even at which indices/names). In the example code, that might make us notice that the global object, and our update to `dct`, is a problem

We should also add info about which transformation or primitive the `Tracer` corresponded to (i.e. point to the last line of the file here). That may be in a follow-up PR though.