### PR TITLE
jax.numpy: implement window functions in terms of lax ops

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4273,8 +4273,8 @@ def blackman(M: int) -> Array:
   dtype = dtypes.canonicalize_dtype(float_)
   if M <= 1:
     return ones(M, dtype)
-  n = (1 - M) + 2 * lax.iota(dtype, M)
-  return 0.42 + 0.5 * cos(pi * n / (M - 1)) + 0.08 * cos(2 * pi * n / (M - 1))
+  n = lax.iota(dtype, M)
+  return 0.42 - 0.5 * cos(2 * pi * n / (M - 1)) + 0.08 * cos(4 * pi * n / (M - 1))
 
 
 @_wraps(np.bartlett)
@@ -4283,8 +4283,8 @@ def bartlett(M: int) -> Array:
   dtype = dtypes.canonicalize_dtype(float_)
   if M <= 1:
     return ones(M, dtype)
-  n = (1 - M) + 2 * lax.iota(dtype, M)
-  return 1 - abs(n) / (M - 1)
+  n = lax.iota(dtype, M)
+  return 1 - abs(2 * n + 1 - M) / (M - 1)
 
 
 @_wraps(np.hamming)
@@ -4293,8 +4293,8 @@ def hamming(M: int) -> Array:
   dtype = dtypes.canonicalize_dtype(float_)
   if M <= 1:
     return ones(M, dtype)
-  n = (1 - M) + 2 * lax.iota(dtype, M)
-  return 0.54 + 0.46 * cos(pi * n / (M - 1))
+  n = lax.iota(dtype, M)
+  return 0.54 - 0.46 * cos(2 * pi * n / (M - 1))
 
 
 @_wraps(np.hanning)
@@ -4303,8 +4303,8 @@ def hanning(M: int) -> Array:
   dtype = dtypes.canonicalize_dtype(float_)
   if M <= 1:
     return ones(M, dtype)
-  n = (1 - M) + 2 * lax.iota(dtype, M)
-  return 0.5 * (1 + cos(pi * n / (M - 1)))
+  n = lax.iota(dtype, M)
+  return 0.5 * (1 - cos(2 * pi * n / (M - 1)))
 
 
 @_wraps(np.kaiser)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2441,6 +2441,21 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
       self._CompileAndCheck(jnp_fun, args_maker)
 
   @jtu.sample_product(
+    [dict(name=name, **kwds)
+      for name in ['blackman', 'bartlett', 'hamming', 'hanning', 'kaiser']
+      for kwds in ([dict(beta=1), dict(beta=0.5)] if name == 'kaiser' else [{}])
+    ],
+    size = [0, 1, 5, 10],
+  )
+  def testWindowFunction(self, name, size, **kwds):
+    print(name, size)
+    jnp_fun = partial(getattr(jnp, name), size, **kwds)
+    np_fun = partial(getattr(np, name), size, **kwds)
+    args_maker = lambda: []
+    self._CheckAgainstNumpy(jnp_fun, np_fun, args_maker)
+    self._CompileAndCheck(jnp_fun, args_maker)
+
+  @jtu.sample_product(
     [dict(shape=shape, fill_value_shape=fill_value_shape)
       for shape in array_shapes + [3, np.array(7, dtype=np.int32)]
       for fill_value_shape in _compatible_shapes(shape)],

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2448,7 +2448,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     size = [0, 1, 5, 10],
   )
   def testWindowFunction(self, name, size, **kwds):
-    print(name, size)
     jnp_fun = partial(getattr(jnp, name), size, **kwds)
     np_fun = partial(getattr(np, name), size, **kwds)
     args_maker = lambda: []


### PR DESCRIPTION
Including blackman, bartlett, hamming, hanning, kaiser.

Why? Previously these were implemented by computing the output on host at trace-time and embedding the result as a large constant array. Computing the results via `lax` operations is more in the spirit of `jax.numpy`.

Fixes #13014