### PR TITLE
Allow passing empty path to compile cache

### DIFF
--- a/jax/experimental/compilation_cache/compilation_cache.py
+++ b/jax/experimental/compilation_cache/compilation_cache.py
@@ -40,6 +40,9 @@ def initialize_cache(path):
 
   """
   global _cache
+  if not path:
+    return
+
   if _cache is not None and _cache._path == pathlib.Path(path):
     logger.warning("Cache already previously initialized at %s", _cache._path)
     return


### PR DESCRIPTION
Quite a few codebases which use the compile cache currently follow this pattern:

```
if cache_path:
  compile_cache.initialize_cache(cache_path)
```

In these situations, it would be nicer to allow just the one-liner call without the `if`.