### PR TITLE
Add color support to sharding visualization

### DIFF
--- a/jax/_src/debugging.py
+++ b/jax/_src/debugging.py
@@ -18,7 +18,7 @@ import string
 import sys
 import weakref
 
-from typing import Any, Dict, Callable, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Callable, Optional, Sequence, Set, Tuple, Union
 
 from jax import core
 from jax import tree_util
@@ -42,6 +42,7 @@ from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import mhlo
 import jax.numpy as jnp
 
+import numpy as np
 # pytype: disable=import-error
 try:
   import rich
@@ -49,6 +50,7 @@ try:
   import rich.box
   import rich.console
   import rich.padding
+  import rich.style
   import rich.table
   RICH_ENABLED = True
 except:
@@ -398,18 +400,47 @@ def _raise_to_slice(slc: Union[slice, int]):
     return slice(slc, slc + 1)
   return slc
 
+Color = Union[Tuple[float, float, float], str]
+ColorMap = Callable[[float], Tuple[float, float, float, float]]
+
+def _canonicalize_color(color: Color) -> str:
+  if isinstance(color, str):
+    return color
+  r, g, b = (int(a * 255) for a in color)
+  return f"#{r:02X}{g:02X}{b:02X}"
+
+def _get_text_color(color: str) -> str:
+  r, g, b = map(lambda x: int(x, 16), (color[1:3], color[3:5], color[5:7]))
+  if (r * 0.299 + g * 0.587 + b * 0.114) > 186:
+    return "#000000"
+  return "#ffffff"
+
+def make_color_iter(color_map, num_rows, num_cols):
+  num_colors = num_rows * num_cols
+  color_values = np.linspace(0, 1, num_colors)
+  idx = 0
+  for _ in range(num_colors):
+    yield color_map(color_values[idx])
+    idx = (idx + num_colors // 2 + bool(num_colors % 2 == 0)) % num_colors
+
 def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
-                       use_color: bool = False, scale: float = 1.,
-                       min_width: int = 9, max_width: int = 80):
+                       use_color: bool = True, scale: float = 1.,
+                       min_width: int = 9, max_width: int = 80,
+                       color_map: Optional[ColorMap] = None):
   """Visualizes a ``Sharding`` using ``rich``."""
   if not RICH_ENABLED:
     raise ValueError("`visualize_sharding` requires `rich` to be installed.")
-  if use_color:
-    # TODO(sharadmv): Implement color in the visualizer
-    raise NotImplementedError
   if len(shape) > 2 or len(shape) < 1:
     raise ValueError(
         "`visualize_sharding` only works for shapes with 1 and 2 dimensions.")
+  console = rich.console.Console(width=max_width)
+  use_color = use_color and console.color_system is not None
+  if use_color and not color_map:
+    try:
+      import matplotlib as mpl  # pytype: disable=import-error
+      color_map = mpl.colormaps["tab20b"]
+    except ModuleNotFoundError:
+      use_color = False
 
   base_height = int(10 * scale)
   aspect_ratio = (shape[1] if len(shape) == 2 else 1) / shape[0]
@@ -421,9 +452,10 @@ def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
 
   device_indices_map = sharding.devices_indices_map(tuple(shape))
   slices: Dict[Tuple[int, ...], Set[int]] = {}
-  heights: Dict[Tuple[int, ...], int] = {}
-  widths: Dict[Tuple[int, ...], int] = {}
-  for dev, slcs in device_indices_map.items():
+  heights: Dict[Tuple[int, ...], Optional[float]] = {}
+  widths: Dict[Tuple[int, ...], float] = {}
+
+  for i, (dev, slcs) in enumerate(device_indices_map.items()):
     assert slcs is not None
     slcs = tuple(map(_raise_to_slice, slcs))
     chunk_idxs = tuple(map(_slice_to_chunk_idx, shape, slcs))
@@ -435,47 +467,63 @@ def visualize_sharding(shape: Sequence[int], sharding: Sharding, *,
                     else shape[0])
       horiz_size = ((horiz.stop - horiz.start) if horiz.stop is not None
                     else shape[1])
-      chunk_height = vert_size / shape[0] * base_height
-      chunk_width = (
-          horiz_size / shape[1] * base_width *
-          height_to_width_ratio)
-      heights[chunk_idxs] = int(chunk_height)
-      widths[chunk_idxs] = int(chunk_width)
-      slices.setdefault(chunk_idxs, set()).add(dev.id)
+      chunk_height = vert_size / shape[0]
+      chunk_width = horiz_size / shape[1]
+      heights[chunk_idxs] = chunk_height
+      widths[chunk_idxs] = chunk_width
     else:
       # In the 1D case, we set the height to 1.
       horiz, = slcs
       vert = slice(0, 1, None)
       horiz_size = (
           (horiz.stop - horiz.start) if horiz.stop is not None else shape[0])
-      heights[(0, *chunk_idxs)] = 1
-      widths[(0, *chunk_idxs)]  = int(horiz_size / shape[0] * base_width)
-      slices.setdefault((0, *chunk_idxs), set()).add(dev.id)
+      chunk_idxs = (0, *chunk_idxs)
+      heights[chunk_idxs] = None
+      widths[chunk_idxs]  = horiz_size / shape[0]
+    slices.setdefault(chunk_idxs, set()).add(dev.id)
   num_rows = max([a[0] for a in slices.keys()]) + 1
   if len(list(slices.keys())[0]) == 1:
     num_cols = 1
   else:
     num_cols = max([a[1] for a in slices.keys()]) + 1
 
-  table = rich.table.Table(show_header=False, show_lines=True, padding=0,
-                           highlight=True, pad_edge=False,
-                           box=rich.box.SQUARE)
-  console = rich.console.Console(width=max_width)
+  color_iter = make_color_iter(color_map, num_rows, num_cols)
+  table = rich.table.Table(show_header=False, show_lines=not use_color,
+                           padding=0,
+                           highlight=not use_color, pad_edge=False,
+                           box=rich.box.SQUARE if not use_color else None)
   for i in range(num_rows):
     col = []
     for j in range(num_cols):
       entry = f"{device_kind} "+",".join([str(s) for s in sorted(slices[i, j])])
-      width, height = widths[i, j], heights[i, j]
+      width, maybe_height = widths[i, j], heights[i, j]
+      width = int(width * base_width * height_to_width_ratio)
+      if maybe_height is None:
+        height = 1
+      else:
+        height = int(maybe_height * base_height)
       width = min(max(width, min_width), max_width)
       left_padding, remainder = divmod(width - len(entry) - 2, 2)
       right_padding = left_padding + remainder
       top_padding, remainder = divmod(height - 2, 2)
       bottom_padding = top_padding + remainder
+      if use_color:
+        color = _canonicalize_color(next(color_iter)[:3])
+        text_color = _get_text_color(color)
+        top_padding += 1
+        bottom_padding += 1
+        left_padding += 1
+        right_padding += 1
+      else:
+        color = None
+        text_color = None
       padding = (top_padding, right_padding, bottom_padding, left_padding)
       padding = tuple(max(x, 0) for x in padding)  # type: ignore
       col.append(
           rich.padding.Padding(
-            rich.align.Align(entry, "center", vertical="middle"), padding))
+            rich.align.Align(entry, "center", vertical="middle"), padding,
+            style=rich.style.Style(bgcolor=color,
+              color=text_color)))
     table.add_row(*col)
   console.print(table, end='\n\n')
 

--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -1003,9 +1003,9 @@ class VisualizeShardingTest(jtu.JaxTestCase):
     with jtu.capture_stdout() as output:
       debugging.visualize_sharding(shape, sd, scale=8.)
     self.assertEqual(output(), _format_multiline("""
-    ┌──────────────┐
-    │    CPU 0     │
-    └──────────────┘
+    ┌──────────────────────────────────────┐
+    │                CPU 0                 │
+    └──────────────────────────────────────┘
     """))
 
   def test_full_sharding(self):


### PR DESCRIPTION
Allows you to pass in `use_color=True` into `jax.debug.visualize_array_sharding` and also provide a color map via the `color_map` kwarg.