### PR TITLE
Fix issue in `check_tree`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docs/notebooks/.ipynb_checkpoints/
 docs/_autosummary
 .idea
 .vscode
+.envrc
 jax.iml
 
 # virtualenv/venv directories

--- a/jax/_src/lax/control_flow/common.py
+++ b/jax/_src/lax/control_flow/common.py
@@ -25,7 +25,7 @@ from jax._src.lax import lax
 from jax._src import ad_util
 from jax._src import util
 from jax._src.util import cache, weakref_lru_cache, safe_map, unzip3
-from jax.tree_util import tree_map, tree_unflatten, tree_structure
+from jax.tree_util import tree_map, tree_unflatten
 
 map, unsafe_map = safe_map, map
 
@@ -114,7 +114,7 @@ def _check_tree(func_name, expected_name, actual_tree, expected_tree, has_aux=Fa
 
     if len(actual_tree_children) == 2:
       # select first child as result tree
-      actual_tree = tree_structure(actual_tree_children[0])
+      actual_tree = actual_tree_children[0]
     else:
       raise ValueError(
         f"{func_name}() produced a pytree with structure "

--- a/tests/custom_linear_solve_test.py
+++ b/tests/custom_linear_solve_test.py
@@ -393,6 +393,33 @@ class CustomLinearSolveTest(jtu.JaxTestCase):
             out_axes=[0, 0, 0, 0, 0, None, None]), (mat, b),
         order=2)
 
+
+
+  def test_custom_linear_solve_pytree_with_aux(self):
+    # Check that lax.custom_linear_solve handles
+    # pytree inputs + has_aux=True
+    # https://github.com/google/jax/pull/13093
+
+    aux_orig = {'a': 1, 'b': 2}
+    b = {'c': jnp.ones(2), 'd': jnp.ones(3)}
+
+    def solve_with_aux(matvec, b):
+      return b, aux_orig
+
+    sol, aux = lax.custom_linear_solve(
+          lambda x:x,
+          b,
+          solve_with_aux,
+          solve_with_aux,
+          has_aux=True)
+
+    assert len(aux.keys()) == 2
+    assert 'a' in aux
+    assert 'b' in aux
+    self.assertAllClose(aux['a'], aux_orig['a'], check_dtypes=False)
+    self.assertAllClose(aux['b'], aux_orig['b'], check_dtypes=False)
+
+
   def test_custom_linear_solve_errors(self):
 
     solve = lambda f, x: x


### PR DESCRIPTION
I think this is an untested issue in jax, which arises if you use sparse solvers with `has_aux=True`.

See https://github.com/google/jax/issues/13092 for more info .

I am adding here the following MWE that shows that without this PR it is impossible to implement solvers using `lax.custom_linear_solve` that use `has_aux=True`.

The MWE simply redefines `_isolve` and `cg` to return a dumb auxiliary structure.

```python 
from jax._src.scipy.sparse.linalg import (_identity, _normalize_matvec, _shapes, _cg_solve)

from functools import partial

import numpy as np
import jax.numpy as jnp
from jax import device_put
from jax import lax
from jax.tree_util import (tree_leaves, tree_map, tree_structure)

from jax._src.util import safe_map as map

def _isolve(_isolve_solve, A, b, x0=None, *, tol=1e-5, atol=0.0,
            maxiter=None, M=None, check_symmetric=False, has_aux=False):
  if x0 is None:
    x0 = tree_map(jnp.zeros_like, b)

  b, x0 = device_put((b, x0))

  if maxiter is None:
    size = sum(bi.size for bi in tree_leaves(b))
    maxiter = 10 * size  # copied from scipy

  if M is None:
    M = _identity
  A = _normalize_matvec(A)
  M = _normalize_matvec(M)

  if tree_structure(x0) != tree_structure(b):
    raise ValueError(
        'x0 and b must have matching tree structure: '
        f'{tree_structure(x0)} vs {tree_structure(b)}')

  if _shapes(x0) != _shapes(b):
    raise ValueError(
        'arrays in x0 and b must have matching shapes: '
        f'{_shapes(x0)} vs {_shapes(b)}')

  isolve_solve = partial(
      _isolve_solve, x0=x0, tol=tol, atol=atol, maxiter=maxiter, M=M)

  # real-valued positive-definite linear operators are symmetric
  def real_valued(x):
    return not issubclass(x.dtype.type, np.complexfloating)
  symmetric = all(map(real_valued, tree_leaves(b))) \
    if check_symmetric else False
  return lax.custom_linear_solve(
      A, b, solve=isolve_solve, transpose_solve=isolve_solve,
      symmetric=symmetric, has_aux=has_aux)


def _cg_solve_with_aux(*args, **kwargs):
  x_final = _cg_solve(*args, **kwargs)
  # additional info output structure
  info = {'error': 0.03, 'niter': 1}
  return x_final, info

def cg_with_aux(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
  return _isolve(_cg_solve_with_aux,
                 A=A, b=b, x0=x0, tol=tol, atol=atol,
                 maxiter=maxiter, M=M, check_symmetric=True, has_aux=True)



import jax
fun = lambda x: jax.tree_map(lambda y: y*y, x)
pt = {'a': 1, 'b':jnp.ones(3)+1}
cg_with_aux(fun, pt)
```

on master it gives the following error:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [1], in <cell line: 68>()
     66 fun = lambda x: jax.tree_map(lambda y: y*y, x)
     67 pt = {'a': 1, 'b':jnp.ones(3)+1}
---> 68 cg_with_aux(fun, pt)

Input In [1], in cg_with_aux(A, b, x0, tol, atol, maxiter, M)
     58 def cg_with_aux(A, b, x0=None, *, tol=1e-5, atol=0.0, maxiter=None, M=None):
---> 59   return _isolve(_cg_solve_with_aux,
     60                  A=A, b=b, x0=x0, tol=tol, atol=atol,
     61                  maxiter=maxiter, M=M, check_symmetric=True, has_aux=True)

Input In [1], in _isolve(_isolve_solve, A, b, x0, tol, atol, maxiter, M, check_symmetric, has_aux)
     44   return not issubclass(x.dtype.type, np.complexfloating)
     45 symmetric = all(map(real_valued, tree_leaves(b))) \
     46   if check_symmetric else False
---> 47 return lax.custom_linear_solve(
     48     A, b, solve=isolve_solve, transpose_solve=isolve_solve,
     49     symmetric=symmetric, has_aux=has_aux)

    [... skipping hidden 2 frame]

File ~/Documents/pythonenvs/netket/python-3.10.6/lib/python3.10/site-packages/jax/_src/lax/control_flow/common.py:125, in _check_tree(func_name, expected_name, actual_tree, expected_tree, has_aux)
    119     raise ValueError(
    120       f"{func_name}() produced a pytree with structure "
    121       f"{actual_tree}, but a pytree tuple with auxiliary "
    122       f"output was expected because has_aux was set to True.")
    124 if actual_tree != expected_tree:
--> 125   raise TypeError(
    126       f"{func_name}() output pytree structure must match {expected_name}, "
    127       f"got {actual_tree} and {expected_tree}.")

TypeError: solve() output pytree structure must match b, got PyTreeDef(*) and PyTreeDef({'a': *, 'b': *}).
```

with the changes in this PR the snippet above runs fine:
```python
Out[1]:
({'a': DeviceArray(3.5198984, dtype=float32),
  'b': DeviceArray([4.0182953, 4.0182953, 4.0182953], dtype=float32)},
 {'error': 0.03, 'niter': 1})
```