### PR TITLE
CI: set explicit permissions for ci-build action

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -16,6 +16,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read  # to fetch code
+  actions: write  # to cancel previous workflows
+
 jobs:
   lint_and_typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Why? This is a security best practice, because by default the workflow runs with the widest available permissions (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions). Narrowing permissions limits the damage that a compromised workflow might do.