### PR TITLE
improve error when f_vjp gets more than one argument

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4095,6 +4095,14 @@ class APITest(jtu.JaxTestCase):
 
     b(8)  # don't crash
 
+  def test_vjp_multiple_arguments_error_message(self):
+    # https://github.com/google/jax/issues/13099
+    def foo(x):
+      return (x, x)
+    _, f_vjp = jax.vjp(foo, 1.0)
+    with self.assertRaisesRegex(TypeError, "applied to foo"):
+      f_vjp(1.0, 1.0)
+
 
 @jtu.with_config(jax_experimental_subjaxpr_lowering_cache=True)
 class SubcallTraceCacheTest(jtu.JaxTestCase):


### PR DESCRIPTION
fixes #13099

Before:
TypeError: _vjp_pullback_wrapper() takes 5 positional arguments but 6 were given

After:
<img width="568" alt="image" src="https://user-images.githubusercontent.com/1458824/199844751-1638d223-73af-4bed-a6f8-2f31edd73804.png">
