### PR TITLE
add `-W default` to pytest

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Run tests
         env:
           JAX_PLATFORMS: tpu,cpu
-        run: python -m pytest --tb=short tests examples
+        run: python -m pytest --tb=short -W default tests examples


### PR DESCRIPTION
DETAILS:

without the flag '-W default', tests/compilation_cache_test.py appears to be failed due to warning messages.