### PR TITLE
CI: add absl-py to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+absl-py
 sphinx >=3
 sphinx-autodoc-typehints
 sphinx-book-theme>=0.3.3


### PR DESCRIPTION
Fixes the Documentation CI build. This was broken by jaxlib 0.3.24 due to absl-py becoming a soft requirement in https://github.com/google/jax/pull/12806