### PR TITLE
update pytest.ini to print warning message for compilation_cache_test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,5 +19,8 @@ filterwarnings =
     # numpy uses distutils which is deprecated
     ignore:The distutils.* is deprecated.*:DeprecationWarning
     ignore:`sharded_jit` is deprecated. Please use `pjit` instead.*:DeprecationWarning
+    # Print message for compilation_cache_test.py::CompilationCacheTest::test_cache_read/write_warning 
+    default:Error reading persistent compilation cache entry for 'jit__lambda_'
+    default:Error writing persistent compilation cache entry for 'jit__lambda_'
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE
 addopts = --doctest-glob="*.rst"


### PR DESCRIPTION
use default filter to avoid pytest treat the two messages in `compilation_cache_test` as errors, which causes the test fails.