### PR TITLE
Add support for the hermitian option on jnp.linalg.pinv.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Remember to align the itemized text with the first line of an item within a list
 -->
 
 ## jax 0.3.25
+* Changes
+  * {func}`jax.numpy.linalg.pinv` now supports the `hermitian` option.
 
 ## jaxlib 0.3.25
 


### PR DESCRIPTION
In addition:
* Improve the `pinv` implementation to avoid computing an unnecessary reduction: `svd` sorts its singular values so we don't need to use `amax()` to find the largest one.
* Avoid explicitly forming the identity matrix in the `pinv` JVP.