### PR TITLE
[sparse] add bcoo_gather & support for sparse indexing

### DIFF
--- a/jax/experimental/sparse/__init__.py
+++ b/jax/experimental/sparse/__init__.py
@@ -199,6 +199,7 @@ from jax.experimental.sparse.bcoo import (
     bcoo_extract_p as bcoo_extract_p,
     bcoo_fromdense as bcoo_fromdense,
     bcoo_fromdense_p as bcoo_fromdense_p,
+    bcoo_gather as bcoo_gather,
     bcoo_multiply_dense as bcoo_multiply_dense,
     bcoo_multiply_sparse as bcoo_multiply_sparse,
     bcoo_update_layout as bcoo_update_layout,

--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -634,6 +634,18 @@ def _reshape_sparse(spenv, *spvalues, new_sizes, dimensions):
 
 sparse_rules[lax.reshape_p] = _reshape_sparse
 
+
+def _gather_sparse_rule(spenv, *args, dimension_numbers, slice_sizes, unique_indices,
+                        indices_are_sorted, mode, fill_value):
+  operand, start_indices = spvalues_to_arrays(spenv, args)
+  result = sparse.bcoo_gather(operand, start_indices, dimension_numbers=dimension_numbers,
+                              slice_sizes=slice_sizes, unique_indices=unique_indices,
+                              indices_are_sorted=indices_are_sorted,
+                              mode=mode, fill_value=fill_value)
+  return arrays_to_spvalues(spenv, (result,))
+
+sparse_rules[lax.gather_p] = _gather_sparse_rule
+
 def _sparsify_jaxpr(spenv, jaxpr, *spvalues):
   # TODO(jakevdp): currently this approach discards all information about
   #   shared data & indices when generating the sparsified jaxpr. The


### PR DESCRIPTION
This adds support for general indexing of sparse arrays.

Built on changes from #13153

Some examples:
```python
In [1]: import jax.numpy as jnp                                                                                           

In [2]: from jax.experimental import sparse                                                                               

In [3]: x = sparse.BCOO.fromdense(jnp.arange(12).reshape(3, 4))                                                           

In [4]: x[0]                                                                                                              
Out[4]: BCOO(int32[4], nse=4)

In [5]: x[:2]                                                                                                             
Out[5]: BCOO(int32[2, 4], nse=8)

In [6]: x[jnp.array([0, 2])]                                                                                              
Out[6]: BCOO(int32[2, 4], nse=4, n_batch=1)

In [7]: x[:, None]                                                                                                        
Out[7]: BCOO(int32[3, 1, 4], nse=11)

In [8]: x[jnp.array([True, False, True])]                                                                                 
Out[8]: BCOO(int32[2, 4], nse=4, n_batch=1)
```