### PR TITLE
[sparse] fix bcoo_reshape under jit

### DIFF
--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -1860,10 +1860,10 @@ def bcoo_reshape(mat, *, new_sizes, dimensions):
     sparse_shape = tuple(mat.shape[mat.n_batch + i] for i in sparse_perm)
     flat_indices = jnp.ravel_multi_index(index_cols, dims=sparse_shape, mode='clip')
     with jax.numpy_rank_promotion('allow'):
-      oob_indices = (indices >= jnp.array(mat.shape[mat.n_batch:], dtype=indices.dtype)).any(-1)
+      oob_indices = (indices >= jnp.array(mat.shape[mat.n_batch:], dtype=indices.dtype)).any(-1, keepdims=True)
     new_index_cols = jnp.unravel_index(flat_indices, sparse_sizes)
     indices = jnp.concatenate([col[..., None] for col in new_index_cols], axis=-1)
-    indices = indices.at[oob_indices].set(jnp.array(sparse_sizes, dtype=indices.dtype))
+    indices = jnp.where(oob_indices, jnp.array(sparse_sizes, dtype=indices.dtype), indices)
 
   return BCOO((data, indices), shape=new_sizes)
 

--- a/tests/sparsify_test.py
+++ b/tests/sparsify_test.py
@@ -358,8 +358,10 @@ class SparsifyTest(jtu.JaxTestCase):
 
     arr2 = arr.reshape(new_shape)
     arr2_sparse = arr_sparse.reshape(new_shape)
+    arr2_sparse_jit = jax.jit(lambda x: x.reshape(new_shape))(arr_sparse)
 
     self.assertArraysEqual(arr2, arr2_sparse.todense())
+    self.assertArraysEqual(arr2, arr2_sparse_jit.todense())
 
   @jtu.sample_product(
     [dict(shape=shape, new_shape=new_shape, n_batch=n_batch, n_dense=n_dense,


### PR DESCRIPTION
I noticed while developing #13155 that `bcoo_reshape` currently fails within JIT or another traced context. This should fix the issue.