### PR TITLE
Fix a test on V100.

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1208,7 +1208,7 @@ class BCOOTest(jtu.JaxTestCase):
       # TODO(tianjianlu): In some cases, this fails python_should_be_executing.
       # self._CompileAndCheck(f_sparse, args_maker)
       self._CheckAgainstNumpy(f_dense, f_sparse, args_maker)
-      if dtype == np.complex128:
+      if dtype in [np.complex128, np.complex64]:
         atol = 1E-1
       else:
         atol = 1E-2


### PR DESCRIPTION
Mismatched elements: 2 / 40 (5%)
Max absolute difference: 0.01554482
Max relative difference: 1.1495375e-07

Rtol very low, so it make sense to increase atol.

complex128 shouldn't have a lower tolerance then complex64. It should be the same or the opposite.