### PR TITLE
[sparse] bcoo_dynamic_slice: remove unnecessary padding from output

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -993,6 +993,17 @@ class BCOOTest(jtu.JaxTestCase):
     sparse_result = sparse.bcoo_dynamic_slice(Msp, **kwds)
     sparse_result_jit = partial(sparse.bcoo_dynamic_slice, slice_sizes=slice_sizes)(Msp, start_indices)
 
+    # Array layout is the same
+    self.assertEqual(sparse_result.n_batch, Msp.n_batch)
+    self.assertEqual(sparse_result.n_sparse, Msp.n_sparse)
+    self.assertEqual(sparse_result.n_dense, Msp.n_dense)
+
+    # Unnecessary padding eliminated
+    max_nse = np.prod(sparse_result.shape[Msp.n_batch: Msp.n_batch + Msp.n_sparse])
+    self.assertLessEqual(sparse_result.nse, max_nse)
+    self.assertLessEqual(sparse_result_jit.nse, max_nse)
+
+    # Result matches dense computation
     self.assertArraysEqual(dense_result, sparse_result.todense())
     self.assertArraysEqual(dense_result, sparse_result_jit.todense())
 


### PR DESCRIPTION
Previously the output of indexing would have the same number of specified elements as the input:
```python
In [1]: import jax.numpy as jnp
In [2]: from jax.experimental import sparse
In [3]: x = sparse.BCOO.fromdense(jnp.arange(10))
In [4]: x.nse, x[:2].nse
Out[4]: (9, 9)
```
The values not appearing in the sliced array are simply padded-out in the representation.

With this change, unnecessary padding is removed if possible to do based on statically-known quantities:
```python                                 
In [4]: x.nse, x[:2].nse                                                                                      
Out[4]: (9, 2)
```