### PR TITLE
Update jax.numpy.lcm function to match with np.lcm in case of overflow

### DIFF
--- a/jax/_src/numpy/lax_numpy.py
+++ b/jax/_src/numpy/lax_numpy.py
@@ -4367,11 +4367,12 @@ def gcd(x1: ArrayLike, x2: ArrayLike) -> Array:
 def lcm(x1: ArrayLike, x2: ArrayLike) -> Array:
   _check_arraylike("lcm", x1, x2)
   x1, x2 = _promote_dtypes(x1, x2)
+  x1, x2 = abs(x1), abs(x2)
   if not issubdtype(_dtype(x1), integer):
     raise ValueError("Arguments to jax.numpy.lcm must be integers.")
   d = gcd(x1, x2)
   return where(d == 0, _lax_const(d, 0),
-               abs(multiply(x1, floor_divide(x2, d))))
+               multiply(x1, floor_divide(x2, d)))
 
 
 @_wraps(np.extract)

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -282,6 +282,7 @@ JAX_COMPOUND_OP_RECORDS = [
               all_shapes, jtu.rand_small_positive, []),
     op_record("gcd", 2, int_dtypes_no_uint64, all_shapes, jtu.rand_default, []),
     op_record("lcm", 2, int_dtypes_no_uint64, all_shapes, jtu.rand_default, []),
+    op_record("lcm", 2, [np.int8], all_shapes, jtu.rand_not_small, [])
 ]
 
 JAX_BITWISE_OP_RECORDS = [


### PR DESCRIPTION
Close #12728 
The details are in the issue linked.
The change produces result matching with np and passing tests locally.
CLA signed.