### PR TITLE
PRNGKeyArray is now a virtual subclass of ndarray

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -31,6 +31,7 @@ from jax.interpreters import batching
 from jax.interpreters import mlir
 from jax.interpreters import pxla
 from jax.interpreters import xla
+from jax._src import basearray
 from jax._src.sharding import (
     MeshPspecSharding, PmapSharding, OpShardingSharding)
 
@@ -258,6 +259,7 @@ lax_numpy._set_device_array_base_attributes(PRNGKeyArray, include=[
     '__getitem__', 'ravel', 'squeeze', 'swapaxes', 'take', 'reshape',
     'transpose', 'flatten', 'T'])
 lax_numpy._register_stackable(PRNGKeyArray)
+basearray.Array.register(PRNGKeyArray)
 
 
 # TODO(frostig): remove, rerouting callers directly to random_seed

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -476,6 +476,12 @@ class PrngTest(jtu.JaxTestCase):
     self.assertRaisesRegex(IndexError, 'Too many indices.*',
                            lambda: keys[0, 1, None, 2])
 
+  def test_isinstance(self):
+    if not config.jax_enable_custom_prng:
+      self.skipTest("test requires config.jax_enable_custom_prng")
+    key = random.PRNGKey(0)
+    self.assertIsInstance(key, jnp.ndarray)
+
 
 class LaxRandomTest(jtu.JaxTestCase):
 


### PR DESCRIPTION
Right now:
```python
import jax
jax.config.update("jax_enable_custom_prng", True)
x = jax.random.PRNGKey(0)
assert isinstance(x, jax.numpy.ndarray)  # :(
```
And I'm assuming this isn't intended.