### PR TITLE
Sytrd solver and SytrdDescriptor should NOT be CUDA only

### DIFF
--- a/jaxlib/gpu/solver_kernels.h
+++ b/jaxlib/gpu/solver_kernels.h
@@ -160,6 +160,7 @@ struct GesvdjDescriptor {
 
 void Gesvdj(gpuStream_t stream, void** buffers, const char* opaque,
             size_t opaque_len, XlaCustomCallStatus* status);
+#endif  // JAX_GPU_CUDA
 
 // sytrd/hetrd: Reduction of a symmetric (Hermitian) matrix to tridiagonal form.
 struct SytrdDescriptor {
@@ -171,7 +172,6 @@ struct SytrdDescriptor {
 void Sytrd(gpuStream_t stream, void** buffers, const char* opaque,
            size_t opaque_len, XlaCustomCallStatus* status);
 
-#endif  // JAX_GPU_CUDA
 
 }  // namespace JAX_GPU_NAMESPACE
 }  // namespace jax


### PR DESCRIPTION
With the addition of GPU implementation of symmetric (Hermitian) tridiagonal reduction in this commit https://github.com/google/jax/commit/352b042fe9371cca84fc4e1f47b10a4c51b3ae9c, JAX build for ROCm is broken. 