### PR TITLE
Add `jax.scipy.linalg.toeplitz`.

### DIFF
--- a/docs/jax.scipy.rst
+++ b/docs/jax.scipy.rst
@@ -45,6 +45,7 @@ jax.scipy.linalg
    solve_triangular
    sqrtm
    svd
+   toeplitz
    tril
    triu
 

--- a/jax/scipy/linalg.py
+++ b/jax/scipy/linalg.py
@@ -36,6 +36,7 @@ from jax._src.scipy.linalg import (
   solve as solve,
   solve_triangular as solve_triangular,
   svd as svd,
+  toeplitz as toeplitz,
   tril as tril,
   triu as triu,
 )


### PR DESCRIPTION
A counterpart for "scipy.linalg.toeplitz" is added in "jax.scipy.linalg".

We recently have a case that requires a Jax counterpart of `tf.linalg.LinearOperatorToeplitz`, and this functionality is in fact a part of SciPy, implemented as `scipy.linalg.toeplitz`.
This also relates to the request in https://github.com/google/jax/issues/10144.

