### PR TITLE
[sparse] implement iter() of BCOO

### DIFF
--- a/jax/experimental/sparse/transform.py
+++ b/jax/experimental/sparse/transform.py
@@ -768,6 +768,9 @@ def _sparse_rewriting_take(arr, idx, indices_are_sorted=False, unique_indices=Fa
     result = BCOO.fromdense(result)
   return result
 
+def _sparse_iter(arr):
+  return iter(arr[i] for i in range(arr.shape[0]))
+
 _swap_args = lambda f: lambda a, b: f(b, a)
 
 _bcoo_methods = {
@@ -785,6 +788,7 @@ _bcoo_methods = {
   "__sub__": sparsify(jnp.subtract),
   "__rsub__": sparsify(_swap_args(jnp.subtract)),
   "__getitem__": _sparse_rewriting_take,
+  "__iter__": _sparse_iter,
 }
 
 for method, impl in _bcoo_methods.items():

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -1050,6 +1050,20 @@ class BCOOTest(jtu.JaxTestCase):
 
   @jtu.sample_product(
     [dict(shape=shape, n_batch=n_batch, n_dense=n_dense)
+     for shape in [(2,), (3, 4), (5, 6, 2)]
+     for n_batch in range(len(shape) + 1)
+     for n_dense in [0]  # TODO(jakevdp): add tests with n_dense
+    ],
+    dtype=jtu.dtypes.numeric,
+  )
+  def test_bcoo_iter(self, shape, dtype, n_batch, n_dense):
+    sprng = rand_sparse(self.rng())
+    M = sprng(shape, dtype)
+    Msp = sparse.BCOO.fromdense(M, n_batch=n_batch, n_dense=n_dense)
+    self.assertAllClose(list(M), [row.todense() for row in Msp])
+
+  @jtu.sample_product(
+    [dict(shape=shape, n_batch=n_batch, n_dense=n_dense)
       for shape in [(5,), (5, 8), (8, 5), (3, 4, 5), (3, 4, 3, 2)]
       for n_batch in range(len(shape) + 1)
       for n_dense in range(len(shape) + 1 - n_batch)


### PR DESCRIPTION
This is important because Python's default implementation of `__iter__` in this case is an infinite loop 😱 