### PR TITLE
CI: update flake8 pre-commit URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@
 # 'pre-commit run --all'
 
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: '5.0.4'
   hooks:
   - id: flake8


### PR DESCRIPTION
It looks like this has changed its hosting from gitlab to github.