### PR TITLE
Update Github Actions workflows using Ratchet

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,13 @@
+# Github Actions workflows
+
+See the Github documentation for more information on Github Actions in general.
+
+## Notes
+
+* <https://opensource.google/documentation/reference/github/services#actions>
+  mandates using a specific commit for non-Google actions. We use
+  [Ratchet](https://github.com/sethvargo/ratchet) to pin specific versions.  If
+  you'd like to update an action, you can write something like `uses:
+  'actions/checkout@v3'`, and then run `./ratchet pin workflow.yml` to convert
+  to a commit hash. See the Ratchet README for installation and more detailed
+  instructions.

--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -1,29 +1,27 @@
 name: Cloud TPU nightly
-
 on:
   schedule:
-    - cron: "0 14 * * *"  # daily at 7am PST
-  workflow_dispatch:  # allows triggering the workflow run manually
-
+    - cron: "0 14 * * *" # daily at 7am PST
+  workflow_dispatch: # allows triggering the workflow run manually
 # This should also be set to read-only in the project settings, but it's nice to
 # document and enforce the permissions here.
 permissions:
   contents: read
-
 jobs:
   cloud-tpu-test:
     runs-on: [self-hosted, tpu, v4-8]
     strategy:
-      fail-fast: false  # don't cancel all jobs on failure
+      fail-fast: false # don't cancel all jobs on failure
       matrix:
-        python-version: ["3.10"]  # TODO(jakevdp): update to 3.11 when available.
+        python-version: ["3.10"] # TODO(jakevdp): update to 3.11 when available.
         jaxlib-version: [latest, nightly]
     steps:
       # https://opensource.google/documentation/reference/github/services#actions
-      # mandates using a specific commit for non-Google actions.
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+      # mandates using a specific commit for non-Google actions. We use
+      # https://github.com/sethvargo/ratchet to pin specific versions.
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # ratchet:actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # ratchet:actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install JAX test requirements
@@ -52,7 +50,6 @@ jobs:
           python3 -c 'import jaxlib; print("jaxlib version:", jaxlib.__version__)'
           python3 -c 'import jax; print("libtpu version:",
             jax.lib.xla_bridge.get_backend().platform_version)'
-
       - name: Run tests
         env:
           JAX_PLATFORMS: tpu,cpu
@@ -60,8 +57,8 @@ jobs:
       - name: Send chat on failure
         if: failure()
         run: |
-            curl --location --request POST '${{ secrets.BUILD_CHAT_WEBHOOK }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw "{
-            'text': '\"$GITHUB_WORKFLOW\" job failed: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'
-            }"
+          curl --location --request POST '${{ secrets.BUILD_CHAT_WEBHOOK }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw "{
+          'text': '\"$GITHUB_WORKFLOW\" job failed: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'
+          }"

--- a/.github/workflows/nightly-ci-multiprocess-gpu.yml
+++ b/.github/workflows/nightly-ci-multiprocess-gpu.yml
@@ -8,18 +8,16 @@ on:
   schedule:
     - cron: "0 12 * * *" # Daily at 12:00 UTC
   workflow_dispatch: # allows triggering the workflow run manually
-  pull_request:  # Automatically trigger on pull requests affecting this file
+  pull_request: # Automatically trigger on pull requests affecting this file
     branches:
       - main
     paths:
       - '**workflows/nightly-ci-multiprocess-gpu.yml'
-
 jobs:
   jaxlib-nightly:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # ratchet:actions/checkout@v3
       - name: Launch slurm job and hook output to this shell
         run: |
           export JOBSCRIPTSDIR=${GITHUB_WORKSPACE}/.github/workflows/slurm_job_scripts
@@ -39,26 +37,22 @@ jobs:
           export SLURM_EXITCODE=$(job_exit_code "${SLURM_JOBID}" || echo $?); echo "SLURM_EXITCODE='${SLURM_EXITCODE}'"
           if [ "${SLURM_EXITCODE}" != "0" ];      then exit ${SLURM_EXITCODE:-999}; fi
           if [ "${SLURM_STATE}" != "COMPLETED" ]; then exit 1; fi
-
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@46ab8d49369d898e381a607119161771bc65c2a6 # ratchet:EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           junit_files: "outputs/*.xml"
-
       - name: Upload run results from all nodes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # ratchet:actions/upload-artifact@v3
         if: always()
         with:
           name: output-from-nodes
           path: "outputs/*.txt"
-
   jaxlib-release:
     runs-on: self-hosted
     needs: jaxlib-nightly
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # ratchet:actions/checkout@v3
       - name: Launch slurm job and hook output to this shell
         run: |
           export JOBSCRIPTSDIR=${GITHUB_WORKSPACE}/.github/workflows/slurm_job_scripts
@@ -78,20 +72,17 @@ jobs:
           export SLURM_EXITCODE=$(job_exit_code "${SLURM_JOBID}" || echo $?); echo "SLURM_EXITCODE='${SLURM_EXITCODE}'"
           if [ "${SLURM_EXITCODE}" != "0" ];      then exit ${SLURM_EXITCODE:-999}; fi
           if [ "${SLURM_STATE}" != "COMPLETED" ]; then exit 1; fi
-
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@46ab8d49369d898e381a607119161771bc65c2a6 # ratchet:EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           junit_files: "outputs/*.xml"
-
       - name: Upload run results from all nodes
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # ratchet:actions/upload-artifact@v3
         if: always()
         with:
           name: output-from-nodes
           path: "outputs/*.txt"
-
   report:
     name: report
     needs: [jaxlib-nightly, jaxlib-release]
@@ -103,11 +94,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # ratchet:actions/checkout@v3
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # ratchet:actions/setup-python@v4
         with:
           python-version: "3.x"
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7 # ratchet:actions/download-artifact@v3
         with:
           path: /tmp/workspace/logs
       - name: Parse log output
@@ -115,7 +106,7 @@ jobs:
           ls /tmp/workspace/logs/output-from-nodes/
           python .github/workflows/cat_slurm_logs.py /tmp/workspace/logs/output-from-nodes/*.txt --outfile=parsed-logs.txt
       - name: Report failures
-        uses: actions/github-script@v6
+        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # ratchet:actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-notification.yml
+++ b/.github/workflows/release-notification.yml
@@ -2,16 +2,14 @@ name: Google Chat Release Notification
 on:
   release:
     types: [published]
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Google Chat Notification
         run: |
-            curl --location --request POST '${{ secrets.RELEASES_WEBHOOK }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "text": "Release ${{github.event.release.name}} at ${{github.event.release.published_at}} by ${{github.event.release.author.login}}. <${{github.event.release.url}}|[github]>"
-            }'
+          curl --location --request POST '${{ secrets.RELEASES_WEBHOOK }}' \
+          --header 'Content-Type: application/json' \
+          --data-raw '{
+              "text": "Release ${{github.event.release.name}} at ${{github.event.release.published_at}} by ${{github.event.release.author.login}}. <${{github.event.release.url}}|[github]>"
+          }'


### PR DESCRIPTION
https://opensource.google/documentation/reference/github/services#actions mandates using a specific commit for non-Google actions in workflow files. I used https://github.com/sethvargo/ratchet to update all our workflow files. Example command: `ratchet pin cloud-tpu-ci-nightly.yml`

Ratchet appears to also auto-format the YAML files. It makes the diff confusing but I'm ok with the final result.