### PR TITLE
Fix less-nice type annotations for e.g. `List[jax.Array]`

### DIFF
--- a/jax/_src/basearray.py
+++ b/jax/_src/basearray.py
@@ -51,3 +51,6 @@ class Array(abc.ABC):
   @property
   def at(self):
     raise NotImplementedError("property must be defined in subclasses")
+
+
+Array.__module__ = "jax"


### PR DESCRIPTION
```python
from typing import List
from jax import Array
print(List[Array])
# Before: List[jax._src.basearray.Array]
# After: List[jax.Array]
```

Reassigning `__module__` is a pretty standard thing to do for this kind of thing. (See e.g. [functools.wraps](https://github.com/python/cpython/blob/f4cb8285ba7c6c71fdb459fba53e877c1678e1ab/Lib/functools.py#L32), which reassigns `__module__` along with `__name__`, `__qualname__` etc.)