### PR TITLE
Make pytest-xdist work on TPU and update Cloud TPU CI.

### DIFF
--- a/.github/workflows/cloud-tpu-ci-nightly.yml
+++ b/.github/workflows/cloud-tpu-ci-nightly.yml
@@ -53,7 +53,12 @@ jobs:
       - name: Run tests
         env:
           JAX_PLATFORMS: tpu,cpu
-        run: python -m pytest --tb=short tests examples
+        run: |
+          # Run single-accelerator tests in parallel
+          JAX_ENABLE_TPU_XDIST=true python -m pytest -n=4 --tb=short \
+            -m "not multiaccelerator" tests examples
+          # Run multi-accelerator across all chips
+          python -m pytest -m "multiaccelerator" --tb=short tests
       - name: Send chat on failure
         # Don't notify when testing the workflow from a branch.
         if: ${{ failure() && github.ref_name == 'main' }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    multiaccelerator: indicates that a test can make use of and possibly requires multiple accelerators
     SlurmMultiNodeGpuTest: mark a test for Slurm multinode GPU nightly CI
 filterwarnings =
     error
@@ -19,7 +20,7 @@ filterwarnings =
     # numpy uses distutils which is deprecated
     ignore:The distutils.* is deprecated.*:DeprecationWarning
     ignore:`sharded_jit` is deprecated. Please use `pjit` instead.*:DeprecationWarning
-    # Print message for compilation_cache_test.py::CompilationCacheTest::test_cache_read/write_warning 
+    # Print message for compilation_cache_test.py::CompilationCacheTest::test_cache_read/write_warning
     default:Error reading persistent compilation cache entry for 'jit__lambda_'
     default:Error writing persistent compilation cache entry for 'jit__lambda_'
 doctest_optionflags = NUMBER NORMALIZE_WHITESPACE

--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for GlobalDeviceArray."""
 
+import contextlib
 import os
 import unittest
 from absl.testing import absltest
@@ -42,6 +43,11 @@ config.parse_flags_with_absl()
 
 
 prev_xla_flags = None
+
+with contextlib.suppress(ImportError):
+  import pytest
+  pytestmark = pytest.mark.multiaccelerator
+
 
 # Run all tests with 8 CPU devices.
 def setUpModule():

--- a/tests/pjit_test.py
+++ b/tests/pjit_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import os
 import re
 from functools import partial, lru_cache
@@ -56,6 +57,11 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 prev_xla_flags = None
+
+with contextlib.suppress(ImportError):
+  import pytest
+  pytestmark = pytest.mark.multiaccelerator
+
 
 def setUpModule():
   global prev_xla_flags

--- a/tests/pmap_test.py
+++ b/tests/pmap_test.py
@@ -14,6 +14,7 @@
 
 
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 from functools import partial
 import itertools as it
 import gc
@@ -54,6 +55,11 @@ from jax.config import config
 config.parse_flags_with_absl()
 
 prev_xla_flags = None
+
+
+with contextlib.suppress(ImportError):
+  import pytest
+  pytestmark = pytest.mark.multiaccelerator
 
 compatible_shapes = [[(3,)], [(3, 4), (3, 1), (1, 4)], [(2, 3, 4), (2, 1, 4)]]
 

--- a/tests/remote_transfer_test.py
+++ b/tests/remote_transfer_test.py
@@ -14,6 +14,7 @@
 """Tests for cross host device transfer."""
 
 from absl.testing import absltest
+import contextlib
 import unittest
 import numpy as np
 
@@ -23,6 +24,10 @@ from jax._src import test_util as jtu
 from jax.config import config
 
 config.parse_flags_with_absl()
+
+with contextlib.suppress(ImportError):
+  import pytest
+  pytestmark = pytest.mark.multiaccelerator
 
 
 class RemoteTransferTest(jtu.JaxTestCase):

--- a/tests/xmap_test.py
+++ b/tests/xmap_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import functools
 import itertools as it
 import os
@@ -54,6 +55,11 @@ from jax.ad_checkpoint import checkpoint
 
 from jax.config import config
 config.parse_flags_with_absl()
+
+with contextlib.suppress(ImportError):
+  import pytest
+  pytestmark = pytest.mark.multiaccelerator
+
 
 # TODO(mattjj): de-duplicate setUpModule and tearDownModule with pmap_test.py
 # Run all tests with 8 CPU devices.


### PR DESCRIPTION
This change also marks multiaccelerator test files in a way pytest can understand (if pytest is installed).

By running single-device tests on a single TPU chip, running the test suite goes from 1hr 45m to 35m (both timings are running slow tests).

Sample run: https://github.com/google/jax/actions/runs/3499689262

I tried using bazel at first, which already supported parallel execution across TPU cores, but somehow it still takes 2h 20m! I'm not sure why it's so slow. It appears that bazel creates many new test processes over time, vs. pytest reuses the number of processes initially specified, and starting and stopping the TPU runtime takes a few seconds so that may be adding up. It also appears that single-process bazel is slower than single-process pytest, which I haven't looked into yet.