### PR TITLE
Add scipy stats distributions missing cdf and ppf

### DIFF
--- a/jax/_src/scipy/stats/cauchy.py
+++ b/jax/_src/scipy/stats/cauchy.py
@@ -34,3 +34,18 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 @_wraps(osp_stats.cauchy.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.exp(logpdf(x, loc, scale))
+
+@_wraps(osp_stats.cauchy.cdf, update_doc=False)
+def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  x, loc, scale = _promote_args_inexact("cauchy.cdf", x, loc, scale)
+  half =  _lax_const(x, 0.5)
+  pi = _lax_const(x, np.pi)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  return lax.add(half, lax.div(lax.atan(scaled_x), pi))
+
+@_wraps(osp_stats.cauchy.ppf, update_doc=False)
+def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  q, loc, scale = _promote_args_inexact("cauchy.ppf", q, loc, scale)
+  pi = _lax_const(q, np.pi)
+  half = _lax_const(q, 0.5)
+  return lax.add(loc, lax.mul(scale, lax.tan(lax.mul(pi, lax.sub(q, half)))))

--- a/jax/_src/scipy/stats/chi2.py
+++ b/jax/_src/scipy/stats/chi2.py
@@ -40,3 +40,12 @@ def logpdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1
 @_wraps(osp_stats.chi2.pdf, update_doc=False)
 def pdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
     return lax.exp(logpdf(x, df, loc, scale))
+
+@_wraps(osp_stats.chi2.cdf, update_doc=False)
+def cdf(x: ArrayLike, df: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+    x, df, loc, scale = _promote_args_inexact("chi2.cdf", x, df, loc, scale)
+    y = lax.div(lax.sub(x, loc), scale)
+    two = _lax_const(x, 2)
+    # cdf_val = lax.div(lax.igamma(lax.div(df,two), lax.div(y,two)), lax.exp(lax.lgamma(lax.div(df,two))))
+    cdf_val = lax.igamma(lax.div(df, two), lax.div(y, two))
+    return where(lax.lt(x, loc), -inf, cdf_val)

--- a/jax/_src/scipy/stats/expon.py
+++ b/jax/_src/scipy/stats/expon.py
@@ -16,6 +16,7 @@ import scipy.stats as osp_stats
 
 from jax import lax
 from jax._src.numpy.util import _wraps
+from jax._src.lax.lax import _const as _lax_const
 from jax._src.numpy.lax_numpy import _promote_args_inexact, where, inf
 from jax._src.typing import Array, ArrayLike
 
@@ -31,3 +32,17 @@ def logpdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
 @_wraps(osp_stats.expon.pdf, update_doc=False)
 def pdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.exp(logpdf(x, loc, scale))
+
+@_wraps(osp_stats.expon.cdf, update_doc=False)
+def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  x, loc, scale = _promote_args_inexact("expon.cdf", x, loc, scale)
+  linear_term = lax.div(lax.sub(x, loc), scale)
+  zero = _lax_const(x, 0)
+  return where(lax.lt(x, loc), zero, lax.neg(lax.expm1(lax.neg(linear_term))))
+
+@_wraps(osp_stats.expon.ppf, update_doc=False)
+def ppf(q: ArrayLike, loc : ArrayLike = 0, scale : ArrayLike = 1) -> Array:
+  q, loc, scale = _promote_args_inexact("expon.ppf", q, loc, scale)
+  linear_term = lax.div(lax.sub(q, loc), scale)
+  zero = _lax_const(q, 0)
+  return where(lax.lt(q, loc), zero, lax.neg(lax.log1p(lax.neg(linear_term))))

--- a/jax/_src/scipy/stats/gamma.py
+++ b/jax/_src/scipy/stats/gamma.py
@@ -35,3 +35,10 @@ def logpdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1)
 @_wraps(osp_stats.gamma.pdf, update_doc=False)
 def pdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.exp(logpdf(x, a, loc, scale))
+
+# Add c from scipy.stats.gamma
+@_wraps(osp_stats.gamma.cdf, update_doc=False)
+def cdf(x: ArrayLike, a: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  x, a, loc, scale = _promote_args_inexact("gamma.cdf", x, a, loc, scale)
+  y = lax.div(lax.sub(x, loc), scale)
+  return lax.igamma(a, y)

--- a/jax/_src/scipy/stats/geom.py
+++ b/jax/_src/scipy/stats/geom.py
@@ -34,4 +34,19 @@ def logpmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
 
 @_wraps(osp_stats.geom.pmf, update_doc=False)
 def pmf(k: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
-  return jnp.exp(logpmf(k, p, loc))
+    return jnp.exp(logpmf(k, p, loc))
+
+@_wraps(osp_stats.geom.cdf, update_doc=False)
+def cdf(x: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
+    if isinstance(x, int):
+        x = float(x)
+    k = lax.floor(x)
+    return lax.neg(lax.expm1(lax.mul(lax.log1p(lax.neg(p)),k)))
+
+@_wraps(osp_stats.geom.ppf, update_doc=False)
+def ppf(q: ArrayLike, p: ArrayLike, loc: ArrayLike = 0) -> Array:
+    vals = lax.ceil(lax.log1p(lax.neg(q)) / lax.log1p(lax.neg(p)))
+    one = _lax_const(vals, 1)
+    zero = _lax_const(vals, 0)
+    temp = cdf(lax.sub(vals,one), p)
+    return jnp.where(lax.bitwise_and(lax.ge(temp, q), lax.gt(vals, zero)), lax.sub(vals, one), vals)

--- a/jax/_src/scipy/stats/laplace.py
+++ b/jax/_src/scipy/stats/laplace.py
@@ -41,6 +41,12 @@ def cdf(x: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   one = _lax_const(x, 1)
   zero = _lax_const(x, 0)
   diff = lax.div(lax.sub(x, loc), scale)
-  return lax.select(lax.le(diff, zero),
-                    lax.mul(half, lax.exp(diff)),
-                    lax.sub(one, lax.mul(half, lax.exp(lax.neg(diff)))))
+  return lax.select(lax.le(diff, zero),lax.mul(half, lax.exp(diff)),lax.sub(one, lax.mul(half, lax.exp(lax.neg(diff)))))
+
+@_wraps(osp_stats.laplace.ppf, update_doc=False)
+def ppf(q: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  q, loc, scale = _promote_args_inexact("laplace.ppf", q, loc, scale)
+  half = _lax_const(q, 0.5)
+  two = _lax_const(q, 2)
+  one = _lax_const(q, 1)
+  return lax.select(lax.lt(q, half),lax.add(loc, lax.mul(scale, lax.log(lax.div(lax.mul(q, two), one)))),lax.sub(loc, lax.mul(scale, lax.log(lax.div(lax.mul(lax.sub(one, q), two), one)))))

--- a/jax/_src/scipy/stats/pareto.py
+++ b/jax/_src/scipy/stats/pareto.py
@@ -34,3 +34,17 @@ def logpdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1)
 @_wraps(osp_stats.pareto.pdf, update_doc=False)
 def pdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
   return lax.exp(logpdf(x, b, loc, scale))
+
+@_wraps(osp_stats.pareto.cdf, update_doc=False)
+def cdf(x: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  x, b, loc, scale = _promote_args_inexact("pareto.cdf", x, b, loc, scale)
+  one = _lax_const(x, 1)
+  zero = _lax_const(x, 0)
+  scaled_x = lax.div(lax.sub(x, loc), scale)
+  return where(lax.lt(x, lax.add(loc, scale)), zero, lax.sub(one, lax.pow(lax.div(one, scaled_x), b)))
+
+@_wraps(osp_stats.pareto.ppf, update_doc=False)
+def ppf(q: ArrayLike, b: ArrayLike, loc: ArrayLike = 0, scale: ArrayLike = 1) -> Array:
+  q, b, loc, scale = _promote_args_inexact("pareto.ppf", q, b, loc, scale)
+  one = _lax_const(q, 1)
+  return lax.add(loc, lax.div(scale, lax.pow(lax.sub(one, q), lax.div(one, b))))


### PR DESCRIPTION
Regarding #13291
Contains the following missing functions -
cauchy: cdf, ppf
chi2: cdf
expon: cdf, ppf
gamma: cdf
geom: cdf, ppf
laplace: ppf
pareto: cdf, ppf
uniform: cdf, ppf