### PR TITLE
make threefry `split` and `fold_in` symmetric

### DIFF
--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -375,6 +375,16 @@ class PrngTest(jtu.JaxTestCase):
       splits = random.split(key, 8)
       self.assertArraysEqual(folds, splits)
 
+  @skipIf(not config.jax_threefry_partitionable, 'enable after upgrade')
+  def test_threefry_split_vmapped_fold_in_symmetry(self):
+    # See https://github.com/google/jax/issues/7708
+    with jax.default_prng_impl('threefry2x32'):
+      key = random.PRNGKey(72)
+      folds = vmap(lambda k, _: random.fold_in(k, lax.axis_index('batch')),
+                   in_axes=(None, 0), axis_name='batch')(key, jnp.ones(8))
+      splits = random.split(key, 8)
+      self.assertArraysEqual(folds, splits)
+
   @jtu.sample_product([
       {"seed": 0, "type": int, "jit": True, "key": [0, 0]},
       {"seed": 0, "type": int, "jit": False, "key": [0, 0]},

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -367,6 +367,14 @@ class PrngTest(jtu.JaxTestCase):
         _prng_key_as_array(random.fold_in(k, 4)),
         np.array([2285895361,  433833334], dtype='uint32'))
 
+  @skipIf(not config.jax_threefry_partitionable, 'enable after upgrade')
+  def test_threefry_split_fold_in_symmetry(self):
+    with jax.default_prng_impl('threefry2x32'):
+      key = random.PRNGKey(72)
+      folds = jnp.array([random.fold_in(key, i) for i in range(8)])
+      splits = random.split(key, 8)
+      self.assertArraysEqual(folds, splits)
+
   @jtu.sample_product([
       {"seed": 0, "type": int, "jit": True, "key": [0, 0]},
       {"seed": 0, "type": int, "jit": False, "key": [0, 0]},


### PR DESCRIPTION
Namely, make it so that `split(key, n)[i]` equals `fold_in(key, i)` for any key and for `0 <= i < n`.

This change affects the observed random bits for a fixed key (indirectly through splits and folds), so here we guard it behind `jax.config.jax_threefry_partitionable`. It's not described very well by the flag name, but it makes for a simple way to bundle together several random-bit-altering changes as part of the same upgrade cycle.

Fixes #7708, up to the `jax_threefry_partitionable` upgrade, with a test to confirm.