### PR TITLE
remove cotangent negation in custom VJP example

### DIFF
--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.ipynb
@@ -1752,7 +1752,7 @@
     "\n",
     "def f_bwd(res, g):\n",
     "  cos_x, sin_x, y = res\n",
-    "  return (cos_x * g * y, -sin_x * g)\n",
+    "  return (cos_x * g * y, sin_x * g)\n",
     "\n",
     "f.defvjp(f_fwd, f_bwd)"
    ]

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -906,7 +906,7 @@ def f_fwd(x, y):
 
 def f_bwd(res, g):
   cos_x, sin_x, y = res
-  return (cos_x * g * y, -sin_x * g)
+  return (cos_x * g * y, sin_x * g)
 
 f.defvjp(f_fwd, f_bwd)
 ```


### PR DESCRIPTION
This was originally intended to show that we can change the VJP by customizing it, but the algebraic incorrectness is confusing.

Fixes #13048