### PR TITLE
Change documentation to state the correct usage of XLA_PYTHON_CLIENT_MEM_FRACTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Remember to align the itemized text with the first line of an item within a list
 
 
 ## jaxlib 0.4.0
+* Changes
+  * The behavior of `XLA_PYTHON_CLIENT_MEM_FRACTION=.XX` has been changed to allocate XX% of
+    the total GPU memory instead of the previous behavior of using currently available GPU memory
+    to calculate preallocation. Please refer to
+    [GPU memory allocation](https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html) for
+    more details.
+
 
 ## jax 0.3.25 (Nov 15, 2022)
 * Changes

--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -1,7 +1,7 @@
 GPU memory allocation
 =====================
 
-**JAX will preallocate 90% of currently-available GPU memory when the first JAX
+**JAX will preallocate 90% of the total GPU memory when the first JAX
 operation is run.** Preallocating minimizes allocation overhead and memory
 fragmentation, but can sometimes cause out-of-memory (OOM) errors. If your JAX
 process fails with OOM, the following environment variables can be used to
@@ -16,7 +16,7 @@ override the default behavior:
 
 ``XLA_PYTHON_CLIENT_MEM_FRACTION=.XX``
   If preallocation is enabled, this makes JAX preallocate XX% of
-  the total GPU memory, instead of the default 90% of currently-available memory. Lowering the
+  the total GPU memory, instead of the default 90%. Lowering the
   amount preallocated can fix OOMs that occur when the JAX program starts.
 
 ``XLA_PYTHON_CLIENT_ALLOCATOR=platform``

--- a/docs/gpu_memory_allocation.rst
+++ b/docs/gpu_memory_allocation.rst
@@ -16,7 +16,7 @@ override the default behavior:
 
 ``XLA_PYTHON_CLIENT_MEM_FRACTION=.XX``
   If preallocation is enabled, this makes JAX preallocate XX% of
-  currently-available GPU memory, instead of the default 90%. Lowering the
+  the total GPU memory, instead of the default 90% of currently-available memory. Lowering the
   amount preallocated can fix OOMs that occur when the JAX program starts.
 
 ``XLA_PYTHON_CLIENT_ALLOCATOR=platform``


### PR DESCRIPTION
This pr is a follow-up fix to Jax' documentation following [this](https://github.com/tensorflow/tensorflow/pull/58638) change on XLA side.
The `XLA_PYTHON_CLIENT_MEM_FRACTION` control knob is changed on XLA side to use the total memory to calculate pre-allocation amount.
