### PR TITLE
CI: bump timeout for pre-commit

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   lint_and_typecheck:
     runs-on: ubuntu-20.04-16core
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.11.0


### PR DESCRIPTION
This has been timing out periodically at 5 minutes.