### PR TITLE
[jax2tf] An alternative support for shape polymorphism for native lowering

### DIFF
--- a/jax/_src/custom_derivatives.py
+++ b/jax/_src/custom_derivatives.py
@@ -411,7 +411,8 @@ def _custom_jvp_call_mlir_translation(ctx, *args, call_jaxpr, jvp_jaxpr_thunk,
   args_ = map(mlir.wrap_singleton_ir_values, args)
   consts = mlir._ir_consts(call_jaxpr.consts)
   out, tokens = mlir.jaxpr_subcomp(ctx.module_context, call_jaxpr.jaxpr,
-                                   ctx.tokens_in, consts, *args_)
+                                   ctx.tokens_in, consts, *args_,
+                                   dim_var_values=ctx.dim_var_values)
   ctx.set_tokens_out(tokens)
   return out
 mlir.register_lowering(custom_jvp_call_p, _custom_jvp_call_mlir_translation)

--- a/jax/_src/lax/control_flow/conditionals.py
+++ b/jax/_src/lax/control_flow/conditionals.py
@@ -820,7 +820,8 @@ def _cond_lowering(ctx, index, *args, branches, linear):
       out_vals, tokens_out = mlir.jaxpr_subcomp(
           sub_ctx, jaxpr.jaxpr, tokens_in,
           map(mlir.ir_constants, jaxpr.consts),
-          *map(mlir.wrap_singleton_ir_values, args))
+          *map(mlir.wrap_singleton_ir_values, args),
+          dim_var_values=ctx.dim_var_values)
       out_tokens = [tokens_out.get(eff) for eff in ordered_effects]
       out_vals = [*out_tokens, *out_vals]
       mhlo.ReturnOp(util.flatten(out_vals))

--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -950,12 +950,11 @@ def _threefry2x32_gpu_lowering(threefry2x32_lowering, ctx, k1, k2, x1, x2):
   k1_aval, k2_aval, x1_aval, x2_aval = ctx.avals_in
   rank = len(aval_out.shape)
   if 0 in aval_out.shape:
-    zeros = mlir.full_like_aval(0, aval_out)
+    zeros = mlir.full_like_aval(ctx, 0, aval_out)
     return [zeros, zeros]
   def _broadcast(x, aval):
-    return mhlo.BroadcastInDimOp(
-        mlir.aval_to_ir_type(aval_out), x,
-        mlir.dense_int_elements(range(rank - len(aval.shape), rank))).result
+    return mlir.broadcast_in_dim(ctx, x, aval_out,
+                                 broadcast_dimensions=range(rank - len(aval.shape), rank))
   return threefry2x32_lowering(
           (_broadcast(k1, k1_aval), _broadcast(k2, k2_aval)),
           (_broadcast(x1, x1_aval), _broadcast(x2, x2_aval)))

--- a/jax/core.py
+++ b/jax/core.py
@@ -1794,8 +1794,16 @@ def is_special_dim_size(v: Any) -> bool:
   return (handler is not None)
 
 def is_constant_dim(d: DimSize) -> bool:
-  handler, ds = _dim_handler_and_canonical(d)
-  return handler.is_constant(*ds)
+  # Whether the dimension is a static constant.
+  try:
+    int(d)
+    return True
+  except:
+    return False
+
+def is_constant_shape(s: Shape) -> bool:
+  # Whether the shape is a static constant.
+  return all(is_constant_dim(d) for d in s)
 
 def symbolic_equal_dim(d1: DimSize, d2: DimSize) -> bool:
   if d1 is d2 or get_referent(d1) is get_referent(d2): return True

--- a/jax/experimental/maps.py
+++ b/jax/experimental/maps.py
@@ -1393,7 +1393,8 @@ def _xmap_lowering_rule_replica(ctx, *in_nodes,
   if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   tiled_outs, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr, mlir.TokenSet(),
-                                     const_nodes, *tiled_ins)
+                                     const_nodes, *tiled_ins,
+                                     dim_var_values=ctx.dim_var_values)
 
   outs = [
       mlir.lower_fun(
@@ -1459,7 +1460,8 @@ def _xmap_lowering_rule_spmd(ctx, *global_in_nodes,
   if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   global_out_nodes, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr,
-      mlir.TokenSet(), const_nodes, *sharded_global_in_nodes)
+      mlir.TokenSet(), const_nodes, *sharded_global_in_nodes,
+      dim_var_values=ctx.dim_var_values)
 
   sharded_global_out_nodes = [
     mlir.wrap_with_sharding_op(node, global_sharding_spec(aval, aval_axes).sharding_proto())
@@ -1510,7 +1512,8 @@ def _xmap_lowering_rule_spmd_manual(ctx, *global_in_nodes,
   if any(eff in core.ordered_effects for eff in vectorized_jaxpr.effects):
     raise NotImplementedError('Cannot lower `xmap` with ordered effects.')
   global_out_nodes, _ = mlir.jaxpr_subcomp(sub_ctx, vectorized_jaxpr,
-      mlir.TokenSet(), const_nodes, *([n] for n in global_in_nodes))
+      mlir.TokenSet(), const_nodes, *([n] for n in global_in_nodes),
+      dim_var_values=ctx.dim_var_values)
 
   return global_out_nodes
 

--- a/jax/experimental/sparse/bcoo.py
+++ b/jax/experimental/sparse/bcoo.py
@@ -778,7 +778,7 @@ def _bcoo_dot_general_cuda_lowering(
       # Converts lhs to a row vector.
       col = _collapse_mhlo(lhs_indices, start=0, end=1)
       row = mlir.full_like_aval(
-          0, core.ShapedArray(ir.RankedTensorType(col.type).shape,
+          ctx, 0, core.ShapedArray(ir.RankedTensorType(col.type).shape,
                               np.dtype(np.int32)))
       lhs_shape = (1, lhs_spinfo.shape[0])
       dot_product = bcoo_dot_general_fn(


### PR DESCRIPTION
[jax2tf] An alternative support for shape polymorphism for native serialization.

jax2tf already supports many cases of shape polymorphism, e.g., those where the shapes of all intermediates can be expressed as polynomials in the dimension variables appearing in input shapes. We would like to achieve the same coverage while using StableHLO as the lowering format, rather than tf.Graph.

For native serialization we will support two forms of lowering:

  * one is using the growing support in JAX for dynamic shapes, of which shape polymorphism is a special case. This implementation is enabled with the `--jax_dynamic_shapes` flag. At the moment, the JAX dynamic shapes support is still incomplete and over 500 of the 1000 jax2tf shape polymorphism tests are failing.

  * a new one (added) here in which we form a `Jaxpr` using abstract values that express dimension sizes as dimension polynomials (as for the standard jax2tf) which we then lower to StableHLO. This implementation is enabled when `--jax_dynamic_shapes` is off. With this implementation only 80 jax2tf tests fail, but they seem to fail in StableHLO shape inference.

The key contribution here is to enable lowering a Jaxpr that contains dimension polynomials in some of the shapes. Many lowering rules already have some partial support for Jaxprs where the shapes contain
`Var`s. To the extent possible, we try to write lowering rules that should cover both cases of dynamic shapes: `Var` or polynomials in shapes.

The lowering convention is that at top level we collect the sorted list of dimension variable names occurring in the input shapes, and we store it in `ModuleContext.dim_vars`. All IR functions will take `N` additional prefix arguments of int32 type containing the values of the `N` dimension variables. When generating the body of the IR function the current values of the dimension variables will be a list of `ir.Value` stored in `LoweringRuleContext.dim_var_values`.

Note that the Jaxprs are not changed to have extra `Var`s for the dimension variable values. An alternative implementation could work by transforming the Jaxpr to replace dimension polynomials into Vars.

The key code pattern used in the lowering rules is::

        if not core.is_constant_shape(shape):   # Handles both Var, and polynomials
           shape = mlir.eval_dynamic_shape(ctx, shape)
           return mhlo.DynamicXxxOp(..., shape)
        else:
           return mhlo.XxxOp(..., shape)

with `mlir.eval_dynamic_shape` handling both cases of `Var` and polynomials::

        def eval_dynamic_shape(ctx, shape):
           if config.jax_dynamic_shapes:
              # Using Var
              return ... subst using ctx.axis_size_env ...
           else:
              # Using polynomials
              return ... subst using ctx.module_context.dim_vars and ctx.dim_var_values

In order to support the above some lowering functions need to take a LoweringContext parameter, e.g., `mlir.full_like_aval`.

I expect that the changes here will improve the --jax_dynamic_shapes coverage as well.
