### PR TITLE
Fix issue #13429

### DIFF
--- a/jax/_src/ad_checkpoint.py
+++ b/jax/_src/ad_checkpoint.py
@@ -611,7 +611,7 @@ def _dummy_like(aval: core.AbstractValue) -> Any:
   if aval is core.abstract_token:
     return jax.lax.create_token()
   elif isinstance(aval, (core.ShapedArray, core.DShapedArray)):
-    return jax.lax.broadcast(jax.lax.empty(aval.dtype), aval.shape)  # type: ignore
+    return jax.lax.broadcast(lax_internal.empty(aval.dtype), aval.shape)  # type: ignore
   else:
     raise ValueError(aval)
 


### PR DESCRIPTION
Fixes the issue `AttributeError: module 'jax.lax' has no attribute 'empty'` error when using `jax_remat_opt_barrier=False`
