### PR TITLE
Drop support for Python 3.7 in jax v0.4.0

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 # We test all supported Python versions as follows:
-# - 3.7  : Documentation build
+# - 3.8  : Documentation build
 # - 3.8  : Part of Matrix
 # - 3.9  : Part of Matrix with NumPy dispatch
 # - 3.10 : Part of Matrix
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - name: Cancel previous
       uses: styfle/cancel-workflow-action@0.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jax 0.4.0
 * Changes
+  * Support for Python 3.7 has been dropped, in accordance with JAX's
+    {ref}`version-support-policy`.
   * We introduce `jax.Array` which is a unified array type that subsumes
     `DeviceArray`, `ShardedDeviceArray`, and `GlobalDeviceArray` types in JAX.
     The `jax.Array` type helps make parallelism a core feature of JAX,
@@ -22,6 +24,8 @@ Remember to align the itemized text with the first line of an item within a list
 
 ## jaxlib 0.4.0
 * Changes
+  * Support for Python 3.7 has been dropped, in accordance with JAX's
+    {ref}`version-support-policy`.
   * The behavior of `XLA_PYTHON_CLIENT_MEM_FRACTION=.XX` has been changed to allocate XX% of
     the total GPU memory instead of the previous behavior of using currently available GPU memory
     to calculate preallocation. Please refer to

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -1,3 +1,4 @@
+(version-support-policy)=
 # Python and NumPy version support policy
 
 

--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -45,12 +45,11 @@ setup(
     author='JAX team',
     author_email='jax-dev@google.com',
     packages=['jaxlib', 'jaxlib.xla_extension'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=['scipy>=1.5', 'numpy>=1.20'],
     url='https://github.com/google/jax',
     license='Apache-2.0',
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     author_email='jax-dev@google.com',
     packages=find_packages(exclude=["examples"]),
     package_data={'jax': ['py.typed', "*.pyi", "**/*.pyi"]},
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=[
         'numpy>=1.20',
         'opt_einsum',
@@ -104,7 +104,6 @@ setup(
     url='https://github.com/google/jax',
     license='Apache-2.0',
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
In accordance with the [Python and NumPy version support policy](https://jax.readthedocs.io/en/latest/deprecation.html)

Also see #13444