### PR TITLE
[x64] minor test-only updates for better type safety

### DIFF
--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -293,7 +293,7 @@ class JaxArrayTest(jtu.JaxTestCase):
     a, input_data = create_array(
         input_shape, sharding.NamedSharding(global_mesh, P('x', 'y')))
     out = jnp.zeros_like(a)
-    expected = jnp.zeros(input_data.shape, dtype=int)
+    expected = jnp.zeros(input_data.shape, dtype=a.dtype)
     self.assertArraysEqual(out, expected)
     self.assertLen(out.addressable_shards, 8)
     for i in out.addressable_shards:

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -567,7 +567,7 @@ class BatchingTest(jtu.JaxTestCase):
   def testCumProd(self):
    x = jnp.arange(9).reshape(3, 3) + 1
    y = vmap(lambda x: jnp.cumprod(x, axis=-1))(x)
-   self.assertAllClose(np.cumprod(x, axis=1, dtype=int), y)
+   self.assertAllClose(jnp.cumprod(x, axis=1, dtype=int), y)
 
   def testSelect(self):
     pred = np.array([True, False])

--- a/tests/checkify_test.py
+++ b/tests/checkify_test.py
@@ -91,6 +91,7 @@ class CheckifyTransformTests(jtu.JaxTestCase):
     self.assertStartsWith(err.get(), "out-of-bounds indexing")
 
   @jtu.sample_product(jit=[False, True])
+  @jax.numpy_dtype_promotion('standard')
   def test_jit_div_errors(self, jit):
     def f(x, y):
       return x / y

--- a/tests/for_loop_test.py
+++ b/tests/for_loop_test.py
@@ -315,7 +315,7 @@ class ForLoopTransformationTest(jtu.JaxTestCase):
       _, b, c = for_impl(5, body, (a, b, c))
       return b, c
     a = jnp.arange(5.) + 1.
-    b = 1.
+    b = jnp.ones_like(a[0])
     _, f_lin = jax.linearize(f, a, b)
     expected_tangents = f_lin(a, b)
     _, actual_tangents = jax.jvp(f, (a, b), (a, b))
@@ -338,7 +338,7 @@ class ForLoopTransformationTest(jtu.JaxTestCase):
       _, b, c, _ = for_impl(5, body2, (a, b, c, 0))
       return b, c
     a = jnp.arange(5.) + 1.
-    b = 1.
+    b = jnp.ones_like(a[0])
     _, g_lin = jax.linearize(f, a, b)
     expected_tangents = g_lin(a, b)
     _, actual_tangents = jax.jvp(g, (a, b), (a, b))

--- a/tests/jet_test.py
+++ b/tests/jet_test.py
@@ -118,12 +118,12 @@ class JetTest(jtu.JaxTestCase):
 
     rng = self.rng()
 
-    x = rng.randn(*input_shape)
+    x = rng.randn(*input_shape).astype(W.dtype)
     primals = (W, b, x)
 
-    series_in1 = [rng.randn(*W.shape) for _ in range(order)]
-    series_in2 = [rng.randn(*b.shape) for _ in range(order)]
-    series_in3 = [rng.randn(*x.shape) for _ in range(order)]
+    series_in1 = [rng.randn(*W.shape).astype(W.dtype) for _ in range(order)]
+    series_in2 = [rng.randn(*b.shape).astype(W.dtype) for _ in range(order)]
+    series_in3 = [rng.randn(*x.shape).astype(W.dtype) for _ in range(order)]
 
     series_in = (series_in1, series_in2, series_in3)
 
@@ -313,7 +313,7 @@ class JetTest(jtu.JaxTestCase):
   @jtu.skip_on_devices("tpu")
   def test_dynamic_slice(self): self.unary_check(partial(lax.dynamic_slice, start_indices=(1,2), slice_sizes=(1,1)))
   @jtu.skip_on_devices("tpu")
-  def test_dynamic_update_slice(self): self.unary_check(partial(lax.dynamic_update_slice, start_indices=(1,2), update=jnp.arange(6.0).reshape(2, 3)))
+  def test_dynamic_update_slice(self): self.unary_check(partial(lax.dynamic_update_slice, start_indices=(1,2), update=np.arange(6.0).reshape(2, 3)))
 
 
   @jtu.skip_on_devices("tpu")
@@ -385,7 +385,7 @@ class JetTest(jtu.JaxTestCase):
 
   def test_inst_zero(self):
     def f(x):
-      return 2.
+      return jnp.full_like(x, 2.)
     def g(x):
       return 2. + 0 * x
     x = jnp.ones(1)
@@ -395,8 +395,8 @@ class JetTest(jtu.JaxTestCase):
 
     g_out_primals, g_out_series = jet(g, (x, ), ([jnp.ones_like(x) for _ in range(order)], ))
 
-    assert g_out_primals == f_out_primals
-    assert g_out_series == f_out_series
+    self.assertArraysEqual(g_out_primals, f_out_primals)
+    self.assertArraysEqual(g_out_series, f_out_series)
 
   def test_add_any(self):
     # https://github.com/google/jax/issues/5217

--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -729,7 +729,9 @@ class LaxVmapTest(jtu.JaxTestCase):
         which = an >= bn
         return (jnp.where(which, an, bn), jnp.where(which, ai, bi))
 
-      _, idxs = lax.reduce_window((norms, idxs), (-np.inf, -1), g,
+      inf = jnp.array(np.inf, dtype=norms.dtype)
+      one = jnp.array(1, dtype=idxs.dtype)
+      _, idxs = lax.reduce_window((norms, idxs), (-inf, -one), g,
                         window_dimensions=(2,), window_strides=(2,),
                         padding=((0, 0),))
       return x[idxs]

--- a/tests/name_stack_test.py
+++ b/tests/name_stack_test.py
@@ -511,8 +511,8 @@ class NameStackControlFlowTest(jtu.JaxTestCase):
       @jax.named_scope('scan_body')
       def body(carry, x):
         return carry + x, carry + x
-      return lax.scan(body, x, jnp.arange(5.))
-    jaxpr = jax.make_jaxpr(f)(1.)
+      return lax.scan(body, x, jnp.arange(5, dtype='float32'))
+    jaxpr = jax.make_jaxpr(f)(jnp.float32(1))
     self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'foo')
     self.assertEqual(str(
       jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
@@ -546,9 +546,9 @@ class NameStackControlFlowTest(jtu.JaxTestCase):
       @jax.named_scope('scan_body')
       def body(carry, x):
         return carry + x, carry + x
-      return lax.scan(body, x, jnp.arange(8.))
+      return lax.scan(body, x, jnp.arange(8, dtype='float32'))
     g = lambda x, t: jax.jvp(f, (x,), (t,))
-    jaxpr = jax.make_jaxpr(g)(1., 1.)
+    jaxpr = jax.make_jaxpr(g)(jnp.float32(1), jnp.float32(1))
     self.assertEqual(str(jaxpr.eqns[0].source_info.name_stack), 'jvp(foo)')
     self.assertEqual(str(
       jaxpr.eqns[1].params['jaxpr'].eqns[0].source_info.name_stack),
@@ -565,8 +565,8 @@ class NameStackControlFlowTest(jtu.JaxTestCase):
       @jax.named_scope('scan_body')
       def body(carry, x):
         return 2 * carry * x, carry + x
-      return lax.scan(body, x, jnp.arange(8.))[0]
-    jaxpr = jax.make_jaxpr(f)(1.)
+      return lax.scan(body, x, jnp.arange(8., dtype='float32'))[0]
+    jaxpr = jax.make_jaxpr(f)(jnp.float32(2))
     self.assertEqual(str(jaxpr.eqns[1].source_info.name_stack), 'jvp(foo)')
     self.assertEqual(str(jaxpr.eqns[3].source_info.name_stack),
         'transpose(jvp(foo))')

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -145,34 +145,34 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testOneHot(self):
     actual = nn.one_hot(jnp.array([0, 1, 2]), 3)
     expected = jnp.array([[1., 0., 0.],
-                         [0., 1., 0.],
-                         [0., 0., 1.]])
-    self.assertAllClose(actual, expected)
+                          [0., 1., 0.],
+                          [0., 0., 1.]])
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
     actual = nn.one_hot(jnp.array([1, 2, 0]), 3)
     expected = jnp.array([[0., 1., 0.],
-                         [0., 0., 1.],
-                         [1., 0., 0.]])
-    self.assertAllClose(actual, expected)
+                          [0., 0., 1.],
+                          [1., 0., 0.]])
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
   def testOneHotOutOfBound(self):
     actual = nn.one_hot(jnp.array([-1, 3]), 3)
     expected = jnp.array([[0., 0., 0.],
-                         [0., 0., 0.]])
-    self.assertAllClose(actual, expected)
+                          [0., 0., 0.]])
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
   def testOneHotNonArrayInput(self):
     actual = nn.one_hot([0, 1, 2], 3)
     expected = jnp.array([[1., 0., 0.],
-                         [0., 1., 0.],
-                         [0., 0., 1.]])
-    self.assertAllClose(actual, expected)
+                          [0., 1., 0.],
+                          [0., 0., 1.]])
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
   def testOneHotCustomDtype(self):
     actual = nn.one_hot(jnp.array([0, 1, 2]), 3, dtype=jnp.bool_)
     expected = jnp.array([[True, False, False],
-                         [False, True, False],
-                         [False, False, True]])
+                          [False, True, False],
+                          [False, False, True]])
     self.assertAllClose(actual, expected)
 
   def testOneHotConcretizationError(self):
@@ -183,14 +183,14 @@ class NNFunctionsTest(jtu.JaxTestCase):
 
   def testOneHotAxis(self):
     expected = jnp.array([[0., 1., 0.],
-                         [0., 0., 1.],
-                         [1., 0., 0.]]).T
+                          [0., 0., 1.],
+                          [1., 0., 0.]]).T
 
     actual = nn.one_hot(jnp.array([1, 2, 0]), 3, axis=0)
-    self.assertAllClose(actual, expected)
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
     actual = nn.one_hot(jnp.array([1, 2, 0]), 3, axis=-2)
-    self.assertAllClose(actual, expected)
+    self.assertAllClose(actual, expected, check_dtypes=False)
 
   def testTanhExists(self):
     nn.tanh  # doesn't crash

--- a/tests/qdwh_test.py
+++ b/tests/qdwh_test.py
@@ -71,7 +71,8 @@ class QdwhTest(jtu.JaxTestCase):
     u, s, v = jnp.linalg.svd(a, full_matrices=False)
     cond = 10**log_cond
     s = jnp.expand_dims(jnp.linspace(cond, 1, min(m, n)), range(u.ndim - 1))
-    a = (u * s) @ v
+    with jax.numpy_dtype_promotion('standard'):
+      a = (u * s) @ v
     is_hermitian = _check_symmetry(a)
     max_iterations = 2
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -81,7 +81,7 @@ class TypingTest(jtu.JaxTestCase):
     self.assertArraysEqual(out2, jnp.arange(4))
 
     out3: typing.Array = arraylike_to_array(np.arange(4))
-    self.assertArraysEqual(out3, jnp.arange(4))
+    self.assertArraysEqual(out3, jnp.arange(4), check_dtypes=False)
 
     out4: typing.Array = arraylike_to_array(True)
     self.assertArraysEqual(out4, jnp.array(True))


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests
```