### PR TITLE
[x64] better type safety for host_callback

### DIFF
--- a/jax/experimental/host_callback.py
+++ b/jax/experimental/host_callback.py
@@ -751,7 +751,7 @@ def _call(callback_func: Callable, arg, *,
     # Turn abstract values into ShapesDtypeStruct
     flat_results_shape, result_treedef = pytree.flatten(result_shape)
     try:
-      flat_results_aval = [core.ShapedArray(np.shape(r), dtypes.result_type(r))
+      flat_results_aval = [core.ShapedArray(np.shape(r), dtypes.dtype(r, canonicalize=True))
                            for r in flat_results_shape]
     except Exception:
       msg = ("result_shape should be a pytree of values with structure "

--- a/tests/host_callback_test.py
+++ b/tests/host_callback_test.py
@@ -742,7 +742,7 @@ class HostCallbackTapTest(jtu.JaxTestCase):
     if with_jit:
       func = jax.jit(func)
     res = func(1)
-    self.assertAllClose(jnp.array([1, 2, 3]), res)
+    self.assertAllClose(jnp.arange(1, 4), res)
     hcb.barrier_wait()
     assertMultiLineStrippedEqual(self, """
         where: 1


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/host_callback_test.py
```