### PR TITLE
[x64] minor fixes for lax_numpy_test type safety

### DIFF
--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -82,7 +82,7 @@ def _scatter_impl(x, y, scatter_op, treedef, static_idx, dynamic_idx,
   dtype = lax.dtype(x)
   weak_type = dtypes.is_weakly_typed(x)
 
-  if dtype != dtypes.result_type(x, y):
+  if dtype != lax.dtype(y) and dtype != dtypes.result_type(x, y):
     # TODO(jakevdp): change this to an error after the deprecation period.
     warnings.warn("scatter inputs have incompatible types: cannot safely cast "
                   f"value from dtype={lax.dtype(y)} to dtype={lax.dtype(x)}. "


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/lax_numpy_test.py
```