### PR TITLE
[x64] more type safety for lax_numpy-related tests

### DIFF
--- a/jax/_src/numpy/reductions.py
+++ b/jax/_src/numpy/reductions.py
@@ -612,7 +612,7 @@ def nanvar(a: ArrayLike, axis: Axis = None, dtype: DTypeLike = None, out: None =
   normalizer = sum(lax_internal.bitwise_not(lax_internal._isnan(a)),
                    axis=axis, keepdims=keepdims, where=where)
   normalizer = normalizer - ddof
-  normalizer_mask = lax.le(normalizer, 0)
+  normalizer_mask = lax.le(normalizer, lax_internal._zero(normalizer))
   result = sum(centered, axis, keepdims=keepdims, where=where)
   result = _where(normalizer_mask, np.nan, result)
   divisor = _where(normalizer_mask, 1, normalizer)

--- a/jax/_src/ops/scatter.py
+++ b/jax/_src/ops/scatter.py
@@ -180,7 +180,7 @@ def _segment_update(name: str,
   out = jnp.full((num_buckets, num_segments) + data.shape[1:],
                  _get_identity(scatter_op, dtype), dtype=dtype)
   out = _scatter_update(
-    out, np.index_exp[lax.div(jnp.arange(segment_ids.shape[0]), bucket_size),
+    out, np.index_exp[jnp.arange(segment_ids.shape[0]) // bucket_size,
                       segment_ids[None, :]],
     data, scatter_op, indices_are_sorted,
     unique_indices, normalize_indices=False, mode=mode)

--- a/tests/lax_numpy_indexing_test.py
+++ b/tests/lax_numpy_indexing_test.py
@@ -1282,7 +1282,7 @@ class IndexedUpdateTest(jtu.JaxTestCase):
     data = np.array([5, 1, 7, 2, 3, 4, 1, 3], dtype=float)
     segment_ids = np.array([0, 0, 0, 1, 2, 2, 3, 3])
 
-    ans = jnp.zeros(np.max(segment_ids) + 1).at[segment_ids].add(data)
+    ans = jnp.zeros_like(data, shape=np.max(segment_ids) + 1).at[segment_ids].add(data)
     expected = np.array([13, 2, 7, 4])
     self.assertAllClose(ans, expected, check_dtypes=False)
 


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/lax_numpy_*_test.py
```