### PR TITLE
[x64] make random_test more type-safe

### DIFF
--- a/jax/_src/random.py
+++ b/jax/_src/random.py
@@ -586,7 +586,7 @@ def multivariate_normal(key: KeyArray,
                         mean: RealArray,
                         cov: RealArray,
                         shape: Optional[Shape] = None,
-                        dtype: DTypeLikeFloat = dtypes.float_,
+                        dtype: DTypeLikeFloat = None,
                         method: str = 'cholesky') -> Array:
   """Sample multivariate normal random values with given mean and covariance.
 
@@ -610,12 +610,14 @@ def multivariate_normal(key: KeyArray,
     ``broadcast_shapes(mean.shape[:-1], cov.shape[:-2]) + mean.shape[-1:]``.
   """
   key, _ = _check_prng_key(key)
+  mean, cov = _promote_dtypes_inexact(mean, cov)
   if method not in {'svd', 'eigh', 'cholesky'}:
     raise ValueError("method must be one of {'svd', 'eigh', 'cholesky'}")
+  if dtype is None:
+    dtype = mean.dtype
   if not dtypes.issubdtype(dtype, np.floating):
     raise ValueError(f"dtype argument to `multivariate_normal` must be a float "
                      f"dtype, got {dtype}")
-  dtype = dtypes.canonicalize_dtype(dtype)
   if shape is not None:
     shape = core.canonicalize_shape(shape)
   return _multivariate_normal(key, mean, cov, shape, dtype, method)  # type: ignore

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -1019,7 +1019,7 @@ class LaxRandomTest(jtu.JaxTestCase):
     key = self.seed_prng(0)
     lam = jnp.array([-1, 0, jnp.nan])
     samples = random.poisson(key, lam, shape=(3,))
-    self.assertArraysEqual(samples, jnp.array([-1, 0, -1]))
+    self.assertArraysEqual(samples, jnp.array([-1, 0, -1]), check_dtypes=False)
 
   @jtu.sample_product(dtype=jtu.dtypes.floating)
   def testGumbel(self, dtype):
@@ -1201,11 +1201,11 @@ class LaxRandomTest(jtu.JaxTestCase):
   def testMultivariateNormalCovariance(self):
     # test code based on https://github.com/google/jax/issues/1869
     N = 100000
-    cov = jnp.array([[ 0.19,  0.00, -0.13,  0.00],
-                   [  0.00,  0.29,  0.00, -0.23],
-                   [ -0.13,  0.00,  0.39,  0.00],
-                   [  0.00, -0.23,  0.00,  0.49]])
     mean = jnp.zeros(4)
+    cov = jnp.array([[  0.19,  0.00, -0.13,  0.00],
+                     [  0.00,  0.29,  0.00, -0.23],
+                     [ -0.13,  0.00,  0.39,  0.00],
+                     [  0.00, -0.23,  0.00,  0.49]], dtype=mean.dtype)
 
     out_np = self.rng().multivariate_normal(mean, cov, N)
 


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/random_test.py
```