### PR TITLE
lax.fori_loop: allow scalar limits

### DIFF
--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -489,10 +489,21 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     vmap_test(arr, arr)
 
   def testForiLoopErrors(self):
-    """Test typing error messages for while."""
+    """Test typing error messages for fori_loop."""
     with self.assertRaisesRegex(
       TypeError, "arguments to fori_loop must have equal types"):
       lax.fori_loop(np.int16(0), jnp.int32(10), (lambda i, c: c), jnp.float32(7))
+
+  def testForiLoopScalarLimits(self):
+    """Test that scalar limits passed to fori_loop do not cause typing errors."""
+    body = lambda i, c: c + 1
+    init = jnp.float32(10)
+
+    result = lax.fori_loop(np.int16(0), 10, body, init)
+    self.assertEqual(result, init + 10)
+
+    result = lax.fori_loop(0, np.int16(10), body, init)
+    self.assertEqual(result, init + 10)
 
   def testForiLoopBatched(self):
     def body_fun(i, loop_carry):


### PR DESCRIPTION
Previously, writing something like this would lead to a type  mismatch error:
```python 
stop = np.int16(10)
lax.fori_loop(0, stop, body, init)
```
This relaxes the type match requirement when one of the limits is expressed as a Python scalar (i.e. a weakly-typed value when traced).