### PR TITLE
[x64] make tests more type-safe

### DIFF
--- a/jax/_src/scipy/optimize/_lbfgs.py
+++ b/jax/_src/scipy/optimize/_lbfgs.py
@@ -187,7 +187,7 @@ def _minimize_lbfgs(
       s_history=_update_history_vectors(history=state.s_history, new=s_k),
       y_history=_update_history_vectors(history=state.y_history, new=y_k),
       rho_history=_update_history_scalars(history=state.rho_history, new=rho_k),
-      gamma=gamma,
+      gamma=gamma.astype(state.g_k.dtype),
       status=jnp.where(converged, 0, status),
       ls_status=ls_results.status,
     )

--- a/jax/_src/scipy/sparse/linalg.py
+++ b/jax/_src/scipy/sparse/linalg.py
@@ -400,7 +400,8 @@ def _kth_arnoldi_iteration(k, A, M, V, H):
   subspace is declared to have been found, in which case in which case the new
   vector is taken to be the zero vector.
   """
-  dtype = jnp.result_type(*tree_leaves(V))
+  dtype, _ = dtypes._lattice_result_type(*tree_leaves(V))
+  dtype = dtypes.canonicalize_dtype(dtype)
   eps = jnp.finfo(dtype).eps
 
   v = tree_map(lambda x: x[..., k], V)  # Gets V[:, k]

--- a/jax/example_libraries/optimizers.py
+++ b/jax/example_libraries/optimizers.py
@@ -538,8 +538,8 @@ def polynomial_decay(step_size, decay_steps, final_step_size, power=1.0):
   return schedule
 
 def piecewise_constant(boundaries: Any, values: Any):
-  boundaries = jnp.array(boundaries)
-  values = jnp.array(values)
+  boundaries = jnp.array(boundaries, dtype=jnp.result_type(*boundaries))
+  values = jnp.array(values, dtype=jnp.result_type(*values))
   if not boundaries.ndim == values.ndim == 1:
     raise ValueError("boundaries and values must be sequences")
   if not boundaries.shape[0] == values.shape[0] - 1:

--- a/tests/batching_test.py
+++ b/tests/batching_test.py
@@ -567,7 +567,7 @@ class BatchingTest(jtu.JaxTestCase):
   def testCumProd(self):
    x = jnp.arange(9).reshape(3, 3) + 1
    y = vmap(lambda x: jnp.cumprod(x, axis=-1))(x)
-   self.assertAllClose(jnp.cumprod(x, axis=1, dtype=int), y)
+   self.assertAllClose(jnp.cumprod(x, axis=1), y)
 
   def testSelect(self):
     pred = np.array([True, False])

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -27,6 +27,7 @@ import numpy as np
 
 import jax
 from jax import core
+from jax import dtypes
 from jax.errors import UnexpectedTracerError
 from jax import lax
 from jax import random
@@ -368,7 +369,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       def body_fun(state):
         arr, num, i, total = state
         arr_i = lax.dynamic_index_in_dim(arr, i, 0, False)
-        return (arr, num, lax.add(i, 1), lax.add(total, arr_i))
+        return (arr, num, i + 1, total + arr_i)
 
       init_val = (arr, num, 0, 0.)
       _, _, _, total = lax.while_loop(cond_fun, body_fun, init_val)
@@ -552,7 +553,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         arr_i = lax.dynamic_index_in_dim(arr, i, 0, False)
         return (arr, lax.add(total, arr_i))
 
-      init_val = (arr, 0.)
+      init_val = (arr, arr.dtype.type(0))
       _, total = lax.fori_loop(0, lax.min(arr.shape[0], num), body_fun,
                                init_val)
       return total
@@ -573,7 +574,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         arr_i = lax.dynamic_index_in_dim(arr, i, 0, False)
         return {'arr': arr, 'total': lax.add(total, arr_i)}
 
-      init_val = {'arr': arr, 'total': 0.}
+      init_val = {'arr': arr, 'total': arr.dtype.type(0)}
       out_val = lax.fori_loop(0, lax.min(arr.shape[0], num), body_fun, init_val)
       return out_val['total']
 
@@ -593,7 +594,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
         arr_i = lax.dynamic_index_in_dim(arr, i, 0, False)
         return (arr, lax.add(total, arr_i), ())
 
-      init_val = (arr, 0., ())
+      init_val = (arr, arr.dtype.type(0), ())
       _, tot, _ = lax.fori_loop(0, lax.min(arr.shape[0], num), body_fun, init_val)
       return tot
 
@@ -1181,7 +1182,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       jtu.check_grads(f, (x,), order=2, modes=["fwd", "rev"])
 
   def testSwitchGradWithWeakTypeMismatch(self):  # issue #4696, PR #4896
-    dtype = jnp.ones(1).dtype
+    dtype = dtypes.canonicalize_dtype(np.float64)
     dtype = jnp.float32 if dtype == jnp.float32 else jnp.float64
 
     branches = [
@@ -1206,13 +1207,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       for cond, name in COND_IMPLS)
   def testCondGrad2(self, cond):
     def f_ref(x):
-      z = jnp.array([1., 2.]) * x if x[0] < 2 else jnp.sin(x)
+      z = jnp.array([1., 2.], x.dtype) * x if x[0] < 2 else jnp.sin(x)
       return z.sum()
 
     def _f(x):
       return cond(
           x[0] < 2,
-          lambda x: jnp.array([1., 2.]) * x,
+          lambda x: jnp.array([1., 2.], x.dtype) * x,
           lambda x: jnp.sin(x),
           x)
 
@@ -1332,13 +1333,13 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       for cond, name in COND_IMPLS)
   def testCondLinearize2(self, cond):
     def f_ref(x):
-      z = jnp.array([1., 2.]) * x if x[0] < 2 else jnp.cos(jnp.sin(x))
+      z = jnp.array([1., 2.], x.dtype) * x if x[0] < 2 else jnp.cos(jnp.sin(x))
       return z.sum()
 
     def f(x):
       return cond(
           x[0] < 2,
-          lambda x: jnp.array([1., 2.]) * x,
+          lambda x: jnp.array([1., 2.], x.dtype) * x,
           lambda x: jnp.cos(jnp.sin(x)),
           x).sum()
 
@@ -1799,7 +1800,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
       return c, b
 
     as_ = jnp.arange(6.).reshape((3, 2))
-    c = 1.
+    c = jnp.array(1, dtype=as_.dtype)
 
     jtu.check_grads(lambda c, as_: scan(f, c, as_), (c, as_),
                     modes=["rev"], order=2, rtol={np.float32: 6e-3})
@@ -2469,7 +2470,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     scan_v = jax.vmap(scan, in_axes=0, out_axes=0, axis_name='i')
     self.assertAllClose(
       scan_v(jnp.ones([1]), jnp.arange(5.).reshape((1, 5))),
-      (jnp.array([1.]), jnp.array([[0., 1., 2., 3., 4.]])))
+      (jnp.array([1.]), jnp.array([[0., 1., 2., 3., 4.]])), check_dtypes=False)
 
   def test_xla_cpu_gpu_loop_cond_bug(self):
     # https://github.com/google/jax/issues/5900

--- a/tests/lax_scipy_test.py
+++ b/tests/lax_scipy_test.py
@@ -492,8 +492,8 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     def args_maker():
       m = rng(shape, dtype)
       n = abs(m)
-      theta = jnp.linspace(-4.0, 5.0, num_z)
-      phi = jnp.linspace(-2.0, 1.0, num_z)
+      theta = np.linspace(-4.0, 5.0, num_z)
+      phi = np.linspace(-2.0, 1.0, num_z)
       return m, n, theta, phi
 
     with self.subTest('Test JIT compatibility'):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -996,14 +996,14 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       (1,),
       (7, -2),
       (3, 4, 5),
-      (np.ones((3, 4), dtype=jnp.float_), 5,
-       np.random.randn(5, 2).astype(jnp.float_)),
+      (np.ones((3, 4), dtype=float), 5,
+       np.random.randn(5, 2).astype(float)),
     ]
   )
   def testBlockDiag(self, args):
     args_maker = lambda: args
     self._CheckAgainstNumpy(osp.linalg.block_diag, jsp.linalg.block_diag,
-                            args_maker)
+                            args_maker, check_dtypes=False)
     self._CompileAndCheck(jsp.linalg.block_diag, args_maker)
 
 

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -2306,9 +2306,8 @@ class BCSRTest(sptu.SparseTestCase):
       row, col = jnp.where(x != 0, size=3)
       val = x[row, col]
       indices = col
-      indptr = jnp.zeros(x.shape[0] + 1, dtype=int)
-      indptr = indptr.at[1:].set(jnp.cumsum(
-          jnp.bincount(row, length=x.shape[0]).astype(int)))
+      indptr = jnp.zeros(x.shape[0] + 1, dtype=int).at[1:].set(
+        jnp.cumsum(jnp.bincount(row, length=x.shape[0])))
       return sparse.BCSR((val, indices, indptr), shape=x.shape)
 
     with self.subTest('_bcsr_from_elt'):
@@ -2803,7 +2802,7 @@ class SparseUtilTest(sptu.SparseTestCase):
                      [[0, 0, 0, 1], [0, 0, 2, 0], [3, 0, 0, 4]]]], dtype=dtype)
     actual_nse = sparse.util._count_stored_elements_per_batch(
         mat, n_batch=n_batch, n_dense=n_dense)
-    self.assertArraysEqual(expected_nse, actual_nse)
+    self.assertArraysEqual(expected_nse, actual_nse, check_dtypes=False)
 
 
 if __name__ == "__main__":

--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -124,7 +124,7 @@ class SvdTest(jtu.JaxTestCase):
       u, s, v = jnp.linalg.svd(a, full_matrices=False)
       cond = 10**log_cond
       s = jnp.linspace(cond, 1, m)
-      s = s.at[r:m].set(jnp.zeros((m-r,)))
+      s = s.at[r:m].set(0)
       a = (u * s) @ v
 
       with jax.default_matmul_precision('float32'):


### PR DESCRIPTION
This ensures the test passes with `jax_default_dtype_bits=32`. Tested with
```
$ JAX_DEFAULT_DTYPE_BITS=32 JAX_ENABLE_X64=1 pytest -n auto tests/$TESTNAME
```