### PR TITLE
Updated jax.tree_leaves --> jax.tree_util.tree_leaves to remove depre…

### DIFF
--- a/docs/jax-101/05.1-pytrees.ipynb
+++ b/docs/jax-101/05.1-pytrees.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "# Let's see how many leaves they have:\n",
     "for pytree in example_trees:\n",
-    "  leaves = jax.tree_leaves(pytree)\n",
+    "  leaves = jax.tree_util.tree_leaves(pytree)\n",
     "  print(f\"{repr(pytree):<45} has {len(leaves)} leaves: {leaves}\")"
    ]
   },
@@ -380,7 +380,7 @@
     }
    ],
    "source": [
-    "jax.tree_leaves([\n",
+    "jax.tree_util.tree_leaves([\n",
     "    MyContainer('Alice', 1, 2, 3),\n",
     "    MyContainer('Bob', 4, 5, 6)\n",
     "])"
@@ -478,7 +478,7 @@
     "jax.tree_util.register_pytree_node(\n",
     "    MyContainer, flatten_MyContainer, unflatten_MyContainer)\n",
     "\n",
-    "jax.tree_leaves([\n",
+    "jax.tree_util.tree_leaves([\n",
     "    MyContainer('Alice', 1, 2, 3),\n",
     "    MyContainer('Bob', 4, 5, 6)\n",
     "])"
@@ -525,7 +525,7 @@
     "\n",
     "# Since `tuple` is already registered with JAX, and NamedTuple is a subclass,\n",
     "# this will work out-of-the-box:\n",
-    "jax.tree_leaves([\n",
+    "jax.tree_util.tree_leaves([\n",
     "    MyOtherContainer('Alice', 1, 2, 3),\n",
     "    MyOtherContainer('Bob', 4, 5, 6)\n",
     "])"
@@ -638,7 +638,7 @@
     }
    ],
    "source": [
-    "jax.tree_leaves([None, None, None])"
+    "jax.tree_util.tree_leaves([None, None, None])"
    ]
   },
   {

--- a/docs/jax-101/05.1-pytrees.md
+++ b/docs/jax-101/05.1-pytrees.md
@@ -50,7 +50,7 @@ example_trees = [
 
 # Let's see how many leaves they have:
 for pytree in example_trees:
-  leaves = jax.tree_leaves(pytree)
+  leaves = jax.tree_util.tree_leaves(pytree)
   print(f"{repr(pytree):<45} has {len(leaves)} leaves: {leaves}")
 ```
 
@@ -210,7 +210,7 @@ class MyContainer:
 :id: OPGe2R7ZOXCT
 :outputId: 40db1f41-9df8-4dea-972a-6a7bc44a49c6
 
-jax.tree_leaves([
+jax.tree_util.tree_leaves([
     MyContainer('Alice', 1, 2, 3),
     MyContainer('Bob', 4, 5, 6)
 ])
@@ -258,7 +258,7 @@ def unflatten_MyContainer(
 jax.tree_util.register_pytree_node(
     MyContainer, flatten_MyContainer, unflatten_MyContainer)
 
-jax.tree_leaves([
+jax.tree_util.tree_leaves([
     MyContainer('Alice', 1, 2, 3),
     MyContainer('Bob', 4, 5, 6)
 ])
@@ -282,7 +282,7 @@ class MyOtherContainer(NamedTuple):
 
 # Since `tuple` is already registered with JAX, and NamedTuple is a subclass,
 # this will work out-of-the-box:
-jax.tree_leaves([
+jax.tree_util.tree_leaves([
     MyOtherContainer('Alice', 1, 2, 3),
     MyOtherContainer('Bob', 4, 5, 6)
 ])
@@ -331,7 +331,7 @@ sequence a leaf.
 :id: gIwlwo2MJcEC
 :outputId: 1e59f323-a7b7-42be-8603-afa4693c00cc
 
-jax.tree_leaves([None, None, None])
+jax.tree_util.tree_leaves([None, None, None])
 ```
 
 +++ {"id": "pwNz-rp1JvW4"}


### PR DESCRIPTION
Updated jax.tree_leaves --> jax.tree_util.tree_leaves to remove deprecation notice in jax101-pytrees tutorial

This removes the below warning every time `jax.tree_leaves` was used:
```
<ipython-input-21-6a8c2b9a82ae>:14: FutureWarning: jax.tree_leaves is deprecated, and will be removed in a future release. Use jax.tree_util.tree_leaves instead.
  leaves = jax.tree_leaves(pytree)
```

Signed-off-by: Simon Butt <simonbutt123@gmail.com>