### PR TITLE
CI: update jupytext version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     additional_dependencies: [types-requests==2.28.11, jaxlib==0.3.24]
 
 - repo: https://github.com/mwouts/jupytext
-  rev: v1.14.1
+  rev: v1.14.4
   hooks:
   - id: jupytext
     args: [--sync]

--- a/docs/autodidax.ipynb
+++ b/docs/autodidax.ipynb
@@ -3875,7 +3875,6 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
    "version": "3.7.6"
   }
  },

--- a/docs/autodidax.md
+++ b/docs/autodidax.md
@@ -6,7 +6,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3
@@ -82,7 +82,7 @@ We can implement stacks of interpreters and even have them all discharge on
 the fly as we execute the Python function to be transformed. To start, let's
 define these primitives so that we can intercept their application:
 
-```{code-cell} ipython3
+```{code-cell}
 from typing import NamedTuple
 
 class Primitive(NamedTuple):
@@ -143,7 +143,7 @@ to the element's height in the stack), an interpreter type (which we'll call a
 needs. We call each element a `MainTrace`, though maybe "Interpreter" would be
 more descriptive.
 
-```{code-cell} ipython3
+```{code-cell}
 from contextlib import contextmanager
 from typing import Type, List, Tuple, Sequence, Optional, Any
 
@@ -184,7 +184,7 @@ and `Tracer` base classes. A `Tracer` represents a boxed-up value, perhaps
 carrying some extra context data used by the interpreter. A `Trace` handles
 boxing up values into `Tracers` and also handles primitive application.
 
-```{code-cell} ipython3
+```{code-cell}
 class Trace:
   main: MainTrace
 
@@ -214,7 +214,7 @@ relationship between `Tracer`s and `AbstractValue`s is that there's one
 `Tracer` per transformation, and at least one `AbstractValue` per base type,
 like arrays.)
 
-```{code-cell} ipython3
+```{code-cell}
 import numpy as np
 
 class Tracer:
@@ -248,7 +248,7 @@ class Tracer:
 def swap(f): return lambda x, y: f(y, x)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 class ShapedArray:
   array_abstraction_level = 1
   shape: Tuple[int, ...]
@@ -328,7 +328,7 @@ singleton set consisting of a single array value.
 Now that we've set up the interpreter stack, the Trace/Tracer API for
 interpreters, and abstract values, we can come back to implement `bind`:
 
-```{code-cell} ipython3
+```{code-cell}
 def bind(prim, *args, **params):
   top_trace = find_top_trace(args)
   tracers = [full_raise(top_trace, arg) for arg in args]
@@ -343,7 +343,7 @@ rule. The calls to `full_raise` just ensure that the inputs are boxed in the
 top trace's `Tracer` instances, and the call to `full_lower` is an optional
 optimization so that we unbox values out of `Tracer`s as much as possible.
 
-```{code-cell} ipython3
+```{code-cell}
 import operator as op
 
 def find_top_trace(xs) -> Trace:
@@ -372,7 +372,7 @@ operation. That's worth exploring! JAX is designed around data dependence in
 large part because that's so natural for automatic differentiation, and JAX's
 roots are in autodiff. But it may be over-fit.
 
-```{code-cell} ipython3
+```{code-cell}
 def full_lower(val: Any):
   if isinstance(val, Tracer):
     return val.full_lower()
@@ -410,7 +410,7 @@ That's it for the JAX core! Now we can start adding interpreters.
 We'll start with the simplest interpreter: the evaluation interpreter that
 will sit at the bottom of the interpreter stack.
 
-```{code-cell} ipython3
+```{code-cell}
 class EvalTrace(Trace):
   pure = lift = lambda self, x: x  # no boxing in Tracers needed
 
@@ -441,7 +441,7 @@ impl_rules[broadcast_p] = broadcast_impl
 
 With this interpreter, we can evaluate user functions:
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   y = sin(x) * 2.
   z = - y + x
@@ -459,7 +459,7 @@ that now we can add some real transformations.
 
 First, a few helper functions:
 
-```{code-cell} ipython3
+```{code-cell}
 def zeros_like(val):
   aval = get_aval(val)
   return np.zeros(aval.shape, aval.dtype)
@@ -487,7 +487,7 @@ def zip(*args):
 The `Tracer` for forward-mode autodiff carries a primal-tangent pair. The
 `Trace` applies JVP rules.
 
-```{code-cell} ipython3
+```{code-cell}
 class JVPTracer(Tracer):
   def __init__(self, trace, primal, tangent):
     self._trace = trace
@@ -515,7 +515,7 @@ minimal amount of context, which is a zero tangent value.
 
 Let's add some JVP rules for primitives:
 
-```{code-cell} ipython3
+```{code-cell}
 def add_jvp(primals, tangents):
   (x, y), (x_dot, y_dot) = primals, tangents
   return [x + y], [x_dot + y_dot]
@@ -561,7 +561,7 @@ jvp_rules[less_p] = less_jvp
 
 Finally, we add a transformation API to kick off the trace:
 
-```{code-cell} ipython3
+```{code-cell}
 def jvp_v1(f, primals, tangents):
   with new_main(JVPTrace) as main:
     trace = JVPTrace(main)
@@ -574,14 +574,14 @@ def jvp_v1(f, primals, tangents):
 
 And with that, we can differentiate!
 
-```{code-cell} ipython3
+```{code-cell}
 x = 3.0
 y, sin_deriv_at_3 = jvp_v1(sin, (x,), (1.0,))
 print(sin_deriv_at_3)
 print(cos(3.0))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   y = sin(x) * 2.
   z = - y + x
@@ -593,7 +593,7 @@ print(y)
 print(ydot)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def deriv(f):
   return lambda x: jvp_v1(f, (x,), (1.,))[1]
 
@@ -603,7 +603,7 @@ print(deriv(deriv(deriv(sin)))(3.))
 print(deriv(deriv(deriv(deriv(sin))))(3.))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   if x > 0.:  # Python control flow
     return 2. * x
@@ -631,7 +631,7 @@ Here's how we'd like to write `jvp`, assuming the user always gives us
 functions that take arrays as inputs and produces a flat list of arrays as
 outputs:
 
-```{code-cell} ipython3
+```{code-cell}
 def jvp_flat(f, primals, tangents):
   with new_main(JVPTrace) as main:
     trace = JVPTrace(main)
@@ -645,7 +645,7 @@ def jvp_flat(f, primals, tangents):
 To support user functions that have arbitrary containers in the inputs and
 outputs, here's how we'd write the user-facing `jvp` wrapper:
 
-```{code-cell} ipython3
+```{code-cell}
 def jvp(f, primals, tangents):
   primals_flat, in_tree = tree_flatten(primals)
   tangents_flat, in_tree2 = tree_flatten(tangents)
@@ -668,7 +668,7 @@ types](https://en.wikipedia.org/wiki/Substructural_type_system).)
 All that remains is to write `tree_flatten`, `tree_unflatten`, and
 `flatten_fun`.
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 def flatten_fun(f, in_tree):
@@ -697,7 +697,7 @@ class Store:
     return self.val
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 import itertools as it
@@ -756,7 +756,7 @@ With this pytree-handling `jvp` implementation, we can now handle arbitrary
 input and output containers. That'll come in handy with future transformations
 too!
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   y = sin(x) * 2.
   z = - y + x
@@ -774,7 +774,7 @@ First, a couple helper functions, one for producing mapped abstract values
 from unmapped ones (by removing an axis), and one for moving batch dimensions
 around:
 
-```{code-cell} ipython3
+```{code-cell}
 def mapped_aval(batch_dim, aval):
   shape = list(aval.shape)
   del shape[batch_dim]
@@ -799,7 +799,7 @@ def moveaxis(x, src: int, dst: int):
 The `Tracer` for vectorized batching carries a batched value and an optional
 integer indicating which axis (if any) is the batch axis.
 
-```{code-cell} ipython3
+```{code-cell}
 from typing import Union
 
 class NotMapped: pass
@@ -854,7 +854,7 @@ size.
 
 Next we can define batching interpreter rules for each primitive:
 
-```{code-cell} ipython3
+```{code-cell}
 from functools import partial
 
 def binop_batching_rule(op, axis_size, vals_in, dims_in):
@@ -886,7 +886,7 @@ vmap_rules[reduce_sum_p] = reduce_sum_batching_rule
 
 Finally, we add a transformation API to kick off the trace:
 
-```{code-cell} ipython3
+```{code-cell}
 def vmap_flat(f, in_axes, *args):
   axis_size, = {x.shape[ax] for x, ax in zip(args, in_axes)
                 if ax is not not_mapped}
@@ -912,7 +912,7 @@ def vmap(f, in_axes):
   return batched_f
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def add_one_to_a_scalar(scalar):
   assert np.ndim(scalar) == 0
   return 1 + scalar
@@ -924,7 +924,7 @@ print(vector_in)
 print(vector_out)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def jacfwd(f, x):
   pushfwd = lambda v: jvp(f, (x,), (v,))[1]
   vecs_in = np.eye(np.size(x)).reshape(np.shape(x) * 2)
@@ -997,7 +997,7 @@ How do we represent these as Python data structures? We reuse ShapedArrays to
 represent types, and we can represent the term syntax with a few Python
 structs:
 
-```{code-cell} ipython3
+```{code-cell}
 from typing import Set
 
 class Var:
@@ -1036,7 +1036,7 @@ Type-checking a jaxpr involves checking that there are no unbound variables,
 that variables are only bound once, and that for each equation the type of
 the primitive application matches the type of the output binders.
 
-```{code-cell} ipython3
+```{code-cell}
 class JaxprType(NamedTuple):
   in_types:  List[ShapedArray]
   out_types: List[ShapedArray]
@@ -1079,7 +1079,7 @@ def typecheck_atom(env: Set[Var], x: Atom) -> ShapedArray:
 We can apply the function represented by a jaxpr to arguments with a simple
 interpreter.
 
-```{code-cell} ipython3
+```{code-cell}
 def eval_jaxpr(jaxpr: Jaxpr, args: List[Any]) -> List[Any]:
   env: Dict[Var, Any] = {}
 
@@ -1113,7 +1113,7 @@ a jaxpr; `jit` uses one and `vjp` uses the other. We'll start with the one
 used by `jit`, which is also used by control flow primitives like `lax.cond`,
 `lax.while_loop`, and `lax.scan`.
 
-```{code-cell} ipython3
+```{code-cell}
 def split_list(lst: List[Any], n: int) -> Tuple[List[Any], List[Any]]:
   assert 0 <= n <= len(lst)
   return lst[:n], lst[n:]
@@ -1126,7 +1126,7 @@ def partition_list(bs: List[bool], l: List[Any]) -> Tuple[List[Any], List[Any]]:
   return lst1, lst2
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 # NB: the analogous class in JAX is called 'DynamicJaxprTracer'
 class JaxprTracer(Tracer):
   __slots__ = ['aval']
@@ -1172,7 +1172,7 @@ abstract_eval_rules = {}
 Notice that we keep as interpreter-global data a builder object, which keeps
 track of variables, constants, and eqns as we build up the jaxpr.
 
-```{code-cell} ipython3
+```{code-cell}
 class JaxprBuilder:
   eqns: List[JaxprEqn]
   tracer_to_var: Dict[int, Var]
@@ -1223,7 +1223,7 @@ class JaxprBuilder:
     return jaxpr, constvals
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def _inline_literals(jaxpr: Jaxpr, consts: List[Any]) -> Tuple[Jaxpr, List[Any]]:
   const_binders, other_binders = split_list(jaxpr.in_binders, len(consts))
   scalars = [type(x) in jax_types and not get_aval(x).shape for x in consts]
@@ -1249,7 +1249,7 @@ produce ConcreteArray outputs as well). We'll reuse these abstract evaluation
 rules for the other jaxpr-producing trace machinery, where the potential extra
 generality is useful.
 
-```{code-cell} ipython3
+```{code-cell}
 def binop_abstract_eval(x: ShapedArray, y: ShapedArray) -> List[ShapedArray]:
   if not isinstance(x, ShapedArray) or not isinstance(y, ShapedArray):
     raise TypeError
@@ -1290,7 +1290,7 @@ abstract_eval_rules[broadcast_p] = broadcast_abstract_eval
 To check our implementation of jaxprs, we can add a `make_jaxpr`
 transformation and a pretty-printer:
 
-```{code-cell} ipython3
+```{code-cell}
 from functools import lru_cache
 
 @lru_cache()  # ShapedArrays are hashable
@@ -1308,7 +1308,7 @@ def make_jaxpr_v1(f, *avals_in):
   return jaxpr, consts, out_tree()
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 from typing import DefaultDict
@@ -1382,7 +1382,7 @@ Jaxpr.__repr__ = lambda self: str(pp_jaxpr(self))
 pp_rules: Dict[Primitive, Callable[..., PPrint]] = {}
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 jaxpr, consts, _ = make_jaxpr_v1(lambda x: 2. * x, raise_to_shaped(get_aval(3.)))
 print(jaxpr)
 print(typecheck_jaxpr(jaxpr))
@@ -1392,7 +1392,7 @@ But there's a limitation here: because of how `find_top_trace` operates by
 data dependence, `make_jaxpr_v1` can't stage out all the primitive operations
 performed by the Python callable it's given. For example:
 
-```{code-cell} ipython3
+```{code-cell}
 jaxpr, consts, _ = make_jaxpr_v1(lambda: mul(2., 2.))
 print(jaxpr)
 ```
@@ -1404,7 +1404,7 @@ applied, regardless of whether any inputs to `bind` are boxed in corresponding
 `JaxprTracer` instances. We can achieve this by employing the `dynamic_trace`
 global defined in Part 1:
 
-```{code-cell} ipython3
+```{code-cell}
 @contextmanager
 def new_dynamic(main: MainTrace):
   global dynamic_trace
@@ -1511,7 +1511,7 @@ But it's just imprecise yet sticky jargon.
 
 With the initial-style approach, here's the user-facing `jit` wrapper:
 
-```{code-cell} ipython3
+```{code-cell}
 def jit(f):
   def f_jitted(*args):
     avals_in = [raise_to_shaped(get_aval(x)) for x in args]
@@ -1534,7 +1534,7 @@ signature.
 
 First, some utilities.
 
-```{code-cell} ipython3
+```{code-cell}
 class IDHashable:
   val: Any
 
@@ -1550,7 +1550,7 @@ class IDHashable:
 
 Next, we'll define the evaluation rule for `xla_call`:
 
-```{code-cell} ipython3
+```{code-cell}
 from jax._src.lib import xla_bridge as xb
 from jax._src.lib import xla_client as xc
 xe = xc._xla
@@ -1595,7 +1595,7 @@ The main action is in `xla_callable`, which compiles a jaxpr into an XLA HLO
 program using `jaxpr_subcomp`, then returns a callable which executes the
 compiled program:
 
-```{code-cell} ipython3
+```{code-cell}
 def jaxpr_subcomp(c: xe.XlaBuilder, jaxpr: Jaxpr, args: List[xe.XlaOp]
                   ) -> xe.XlaOp:
   env: Dict[Var, xe.XlaOp] = {}
@@ -1636,7 +1636,7 @@ a common pattern: the way we process jaxprs is usually with an interpreter.
 And as with any interpreter, we need an interpretation rule for each
 primitive:
 
-```{code-cell} ipython3
+```{code-cell}
 def direct_translation(op, c, in_avals, in_vals):
   del c, in_avals
   return [op(*in_vals)]
@@ -1668,24 +1668,24 @@ xla_translations[broadcast_p] = broadcast_translation
 With that, we can now use `jit` to stage out, compile, and execute programs
 with XLA!
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x, y):
   print('tracing!')
   return sin(x) * cos(y)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 z = f(3., 4.)  # 'tracing!' prints the first time
 print(z)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 z = f(4., 5.)  # 'tracing!' doesn't print, compilation cache hit!
 print(z)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   return reduce_sum(x, axis=0)
@@ -1693,7 +1693,7 @@ def f(x):
 print(f(np.array([1., 2., 3.])))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   y = sin(x) * 2.
   z = - y + x
@@ -1721,7 +1721,7 @@ its evaluation rule. That is, we can't yet do `vmap`-of-`jit` or
 `jvp`-of-`jit` or even `jit`-of`-jit`. Instead `jit` has to be at the "top
 level." Let's fix that!
 
-```{code-cell} ipython3
+```{code-cell}
 def xla_call_jvp_rule(primals, tangents, *, jaxpr, num_consts):
   del num_consts  # Unused
   new_jaxpr, new_consts = jvp_jaxpr(jaxpr)
@@ -1744,7 +1744,7 @@ def jvp_jaxpr(jaxpr: Jaxpr) -> Tuple[Jaxpr, List[Any]]:
   return new_jaxpr, new_consts
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def xla_call_vmap_rule(axis_size, vals_in, dims_in, *, jaxpr, num_consts):
   del num_consts  # Unused
   new_jaxpr, new_consts = vmap_jaxpr(jaxpr, axis_size, tuple(dims_in))
@@ -1772,7 +1772,7 @@ def unmapped_aval(axis_size: int, batch_dim: BatchAxis, aval: ShapedArray
     return ShapedArray(tuple(shape), aval.dtype)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def xla_call_abstract_eval_rule(*in_types, jaxpr, num_consts):
   del num_consts  # Unused
   jaxpr_type = typecheck_jaxpr(jaxpr)
@@ -1796,7 +1796,7 @@ def destructure_tuple(c, tup):
   return [xops.GetTupleElement(tup, i) for i in range(num_elements)]
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   print('tracing!')
@@ -1810,11 +1810,11 @@ print(y)
 print(ydot)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 y, ydot = jvp(f, (x,), (xdot,))  # 'tracing!' not printed
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 ys = vmap(f, (0,))(np.arange(3.))
 print(ys)
 ```
@@ -1826,7 +1826,7 @@ transfer them back for the next operation. We can do that by introducing a
 `DeviceArray` class, which can wrap XLA buffers and otherwise duck-type
 `numpy.ndarray`s:
 
-```{code-cell} ipython3
+```{code-cell}
 def handle_result(aval: ShapedArray, buf):  # noqa: F811
   return DeviceArray(aval, buf)
 
@@ -1858,7 +1858,7 @@ input_handlers[DeviceArray] = lambda x: x.buf
 jax_types.add(DeviceArray)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   y = sin(x) * 2.
@@ -1871,7 +1871,7 @@ print(y)
 print(ydot)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 def pprint_xla_call(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:
@@ -1937,7 +1937,7 @@ primitive binds with a data dependence on tangent inputs.
 
 First, some utilities:
 
-```{code-cell} ipython3
+```{code-cell}
 def split_half(lst: List[Any]) -> Tuple[List[Any], List[Any]]:
   assert not len(lst) % 2
   return split_list(lst, len(lst) // 2)
@@ -1952,7 +1952,7 @@ def merge_lists(which: List[bool], l1: List[Any], l2: List[Any]) -> List[Any]:
 Next, we'll write `linearize` by combining `jvp` together with a general
 partial evaluation transformation, to be added next:
 
-```{code-cell} ipython3
+```{code-cell}
 def linearize_flat(f, *primals_in):
   pvals_in = ([PartialVal.known(x) for x in primals_in] +
               [PartialVal.unknown(vspace(get_aval(x))) for x in primals_in])
@@ -2060,7 +2060,7 @@ sort out what can be evaluated and what must be staged out into a jaxpr.
 First, we start with a `PartialVal` class, which represents a value that can
 be either known or unknown:
 
-```{code-cell} ipython3
+```{code-cell}
 class PartialVal(NamedTuple):
   aval: ShapedArray
   const: Optional[Any]
@@ -2081,7 +2081,7 @@ Partial evaluation will take a list of `PartialVal`s representing inputs, and
 return a list of `PartialVal` outputs along with a jaxpr representing the
 delayed computation:
 
-```{code-cell} ipython3
+```{code-cell}
 def partial_eval_flat(f: Callable, pvals_in: List[PartialVal]
                       ) -> Tuple[Jaxpr, List[PartialVal], List[Any]]:
   with new_main(PartialEvalTrace) as main:
@@ -2105,7 +2105,7 @@ kind of recipe is a `JaxprEqnRecipe`, corresponding to a `JaxprEqn`'s
 primitive application, but we also have recipe types for constants and lambda
 binders:
 
-```{code-cell} ipython3
+```{code-cell}
 from weakref import ref, ReferenceType
 
 class LambdaBindingRecipe(NamedTuple):
@@ -2124,7 +2124,7 @@ class JaxprEqnRecipe(NamedTuple):
 JaxprRecipe = Union[LambdaBindingRecipe, ConstRecipe, JaxprEqnRecipe]
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 class PartialEvalTracer(Tracer):
   pval: PartialVal
   recipe: Optional[JaxprRecipe]
@@ -2162,7 +2162,7 @@ That `process_primitive` logic applies to most primitives, but `xla_call_p`
 requires recursive treatment. So we special-case its rule in a
 `partial_eval_rules` dict.
 
-```{code-cell} ipython3
+```{code-cell}
 class PartialEvalTrace(Trace):
   def new_arg(self, pval: PartialVal) -> Any:
     return PartialEvalTracer(self, pval, LambdaBindingRecipe())
@@ -2200,7 +2200,7 @@ Now that we can build graph representations of jaxprs with `PartialEvalTrace`,
 we need a mechanism to convert the graph representation to a standard jaxpr.
 The jaxpr corresponds to a topological sort of the graph.
 
-```{code-cell} ipython3
+```{code-cell}
 def tracers_to_jaxpr(tracers_in: List[PartialEvalTracer],
                      tracers_out: List[PartialEvalTracer]):
   tracer_to_var: Dict[int, Var] = {id(t): Var(raise_to_shaped(t.aval))
@@ -2246,7 +2246,7 @@ def tracer_parents(t: PartialEvalTracer) -> List[PartialEvalTracer]:
   return t.recipe.tracers_in if isinstance(t.recipe, JaxprEqnRecipe) else []
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 def toposort(out_nodes: List[Any], parents: Callable[[Any], List[Any]]):
@@ -2293,7 +2293,7 @@ def check_toposort(nodes: List[Any], parents: Callable[[Any], List[Any]]):
 
 Now we can linearize!
 
-```{code-cell} ipython3
+```{code-cell}
 y, sin_lin = linearize(sin, 3.)
 print(y, sin(3.))
 print(sin_lin(1.), cos(3.))
@@ -2307,7 +2307,7 @@ There are actually two rules to write: one for trace-time partial evaluation,
 which we'll call `xla_call_partial_eval`, and one for partial evaluation of
 jaxprs, which we'll call `xla_call_peval_eqn`.
 
-```{code-cell} ipython3
+```{code-cell}
 def xla_call_partial_eval(trace, tracers, *, jaxpr, num_consts):
   del num_consts  # Unused
   in_unknowns = [not t.pval.is_known for t in tracers]
@@ -2413,7 +2413,7 @@ partial_eval_jaxpr_rules[xla_call_p] = xla_call_peval_eqn
 
 With that, we can compose `linearize` and `jit` however we like:
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   y = sin(x) * 2.
@@ -2425,7 +2425,7 @@ y_dot = f_lin(1.)
 print(y, y_dot)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   y = sin(x) * 2.
@@ -2465,7 +2465,7 @@ def vjp(f, x):
 Since we have the linear computation as a jaxpr, not just a Python callable,
 we can implement the transpose transformation as a jaxpr interpreter.
 
-```{code-cell} ipython3
+```{code-cell}
 def vjp_flat(f, *primals_in):
   pvals_in = ([PartialVal.known(x) for x in primals_in] +
               [PartialVal.unknown(vspace(get_aval(x))) for x in primals_in])
@@ -2514,7 +2514,7 @@ a handy way to prune these placeholders out of argument lists.
 Next, we can write `eval_jaxpr_transposed`, along with transpose rules for
 all primitives which can be linear in at least one argument:
 
-```{code-cell} ipython3
+```{code-cell}
 # NB: the analogous function in JAX is called 'backward_pass'
 def eval_jaxpr_transposed(jaxpr: Jaxpr, args: List[Any], cotangents: List[Any]
                           ) -> List[Any]:
@@ -2550,7 +2550,7 @@ def eval_jaxpr_transposed(jaxpr: Jaxpr, args: List[Any], cotangents: List[Any]
 transpose_rules = {}
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def mul_transpose_rule(cts, x, y):
   z_bar, = cts
   assert (type(x) is UndefPrimal) ^ (type(y) is UndefPrimal)
@@ -2597,7 +2597,7 @@ def transpose_jaxpr(jaxpr: Jaxpr, undef_primals: Tuple[bool, ...]
 
 Now that we can linearize and transpose, we can finally write `grad`:
 
-```{code-cell} ipython3
+```{code-cell}
 def grad(f):
   def gradfun(x, *xs):
     y, f_vjp = vjp(f, x, *xs)
@@ -2607,12 +2607,12 @@ def grad(f):
   return gradfun
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 y, f_vjp = vjp(sin, 3.)
 print(f_vjp(1.), cos(3.))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def f(x):
   y = sin(x) * 2.
   z = - y + x
@@ -2621,7 +2621,7 @@ def f(x):
 print(grad(f)(3.))
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 @jit
 def f(x):
   y = x * 2.
@@ -2637,7 +2637,7 @@ print(grad(f)(3.))
 
 Here's something of a compositionality stress test:
 
-```{code-cell} ipython3
+```{code-cell}
 # from core_test.py fun_with_nested_calls_2
 def foo(x):
   @jit
@@ -2700,7 +2700,7 @@ In Python, we represent it as a function which itself takes two functions as
 arguments. As with `jit`, the first step is to call `make_jaxpr` on its
 callable arguments to turn them into jaxprs:
 
-```{code-cell} ipython3
+```{code-cell}
 def cond(pred, true_fn, false_fn, *operands):
   avals_in = [raise_to_shaped(get_aval(x)) for x in operands]
   true_jaxpr, true_consts, out_tree = make_jaxpr(true_fn, *avals_in)
@@ -2741,7 +2741,7 @@ just concatenate the lists of constants.)
 Next we can turn to adding interpreter rules for `cond`. Its evaluation rule
 is simple:
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_impl(pred, *operands, true_jaxpr, false_jaxpr):
   if pred:
     return eval_jaxpr(true_jaxpr, operands)
@@ -2750,7 +2750,7 @@ def cond_impl(pred, *operands, true_jaxpr, false_jaxpr):
 impl_rules[cond_p] = cond_impl
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 out = cond(True, lambda: 3, lambda: 4)
 print(out)
 ```
@@ -2759,7 +2759,7 @@ For its JVP and vmap rules, we only need to call the same `jvp_jaxpr` and
 `vmap_jaxpr` utilities we created for `jit`, followed by another pass of
 `_join_jaxpr_consts`:
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_jvp_rule(primals, tangents, *, true_jaxpr, false_jaxpr):
   pred, *primals = primals
   _   , *tangents = tangents
@@ -2775,12 +2775,12 @@ def cond_jvp_rule(primals, tangents, *, true_jaxpr, false_jaxpr):
 jvp_rules[cond_p] = cond_jvp_rule
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 out, out_tan = jvp(lambda x: cond(True, lambda: x * x, lambda: 0.), (1.,), (1.,))
 print(out_tan)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_vmap_rule(axis_size, vals_in, dims_in, *, true_jaxpr, false_jaxpr):
   pred    , *vals_in = vals_in
   pred_dim, *dims_in = dims_in
@@ -2796,7 +2796,7 @@ def cond_vmap_rule(axis_size, vals_in, dims_in, *, true_jaxpr, false_jaxpr):
 vmap_rules[cond_p] = cond_vmap_rule
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 xs = np.array([1., 2., 3])
 out = vmap(lambda x: cond(True, lambda: x + 1., lambda: 0.), (0,))(xs)
 print(out)
@@ -2840,7 +2840,7 @@ over the leading axis.
 
 Next we can turn to abstract evaluation and XLA lowering rules:
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_abstract_eval(pred_type, *in_types, true_jaxpr, false_jaxpr):
   if pred_type != ShapedArray((), np.dtype('bool')): raise TypeError
   jaxpr_type = typecheck_jaxpr(true_jaxpr)
@@ -2875,7 +2875,7 @@ def cond_translation(c, in_avals, in_vals, *, true_jaxpr, false_jaxpr):
 xla_translations[cond_p] = cond_translation
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 out = jit(lambda: cond(False, lambda: 1, lambda: 2))()
 print(out)
 ```
@@ -2888,7 +2888,7 @@ result in distinct residuals. We use `_join_jaxpr_res` to make the output
 types of the transformed jaxprs consistent (while `_join_jaxpr_consts` dealt
 with input types).
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_partial_eval(trace, tracers, *, true_jaxpr, false_jaxpr):
   pred_tracer, *tracers = tracers
   assert pred_tracer.pval.is_known
@@ -2946,13 +2946,13 @@ def _join_jaxpr_res(jaxpr1: Jaxpr, jaxpr2: Jaxpr, n1: int, n2: int
   return new_jaxpr1, new_jaxpr2
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 _, f_lin = linearize(lambda x: cond(True, lambda: x, lambda: 0.), 1.)
 out = f_lin(3.14)
 print(out)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_peval_eqn(unks_in: List[bool], eqn: JaxprEqn,
                    ) -> Tuple[JaxprEqn, JaxprEqn, List[bool], List[Atom]]:
   pred_unk, *unks_in = unks_in
@@ -2974,7 +2974,7 @@ def cond_peval_eqn(unks_in: List[bool], eqn: JaxprEqn,
 partial_eval_jaxpr_rules[cond_p] = cond_peval_eqn
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 _, f_lin = linearize(jit(lambda x: cond(True, lambda: x, lambda: 0.)), 1.)
 out = f_lin(3.14)
 print(out)
@@ -2982,7 +2982,7 @@ print(out)
 
 Transposition is a fairly straightforward application of `transpose_jaxpr`:
 
-```{code-cell} ipython3
+```{code-cell}
 def cond_transpose_rule(cts, pred, *invals, true_jaxpr, false_jaxpr):
   undef_primals = tuple(type(x) is UndefPrimal for x in invals)
   true_jaxpr, true_consts = transpose_jaxpr(true_jaxpr, undef_primals)
@@ -2997,12 +2997,12 @@ def cond_transpose_rule(cts, pred, *invals, true_jaxpr, false_jaxpr):
 transpose_rules[cond_p] = cond_transpose_rule
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 out = grad(lambda x: cond(True, lambda: x * x, lambda: 0.))(1.)
 print(out)
 ```
 
-```{code-cell} ipython3
+```{code-cell}
 :tags: [hide-input]
 
 def pprint_cond(names: DefaultDict[Var, str], eqn: JaxprEqn) -> PPrint:

--- a/docs/autodidax.py
+++ b/docs/autodidax.py
@@ -20,7 +20,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.14.1
+#       jupytext_version: 1.14.4
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -380,7 +380,7 @@ using [jupytext](https://jupytext.readthedocs.io/) by running `jupytext --sync` 
 notebooks; for example:
 
 ```
-pip install jupytext==1.13.8
+pip install jupytext==1.14.4
 jupytext --sync docs/notebooks/quickstart.ipynb
 ```
 

--- a/docs/jax-101/01-jax-basics.md
+++ b/docs/jax-101/01-jax-basics.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/02-jitting.md
+++ b/docs/jax-101/02-jitting.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/03-vectorization.md
+++ b/docs/jax-101/03-vectorization.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/04-advanced-autodiff.md
+++ b/docs/jax-101/04-advanced-autodiff.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/05-random-numbers.md
+++ b/docs/jax-101/05-random-numbers.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/05.1-pytrees.md
+++ b/docs/jax-101/05.1-pytrees.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/06-parallelism.md
+++ b/docs/jax-101/06-parallelism.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jax-101/07-state.md
+++ b/docs/jax-101/07-state.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/jep/9407-type-promotion.md
+++ b/docs/jep/9407-type-promotion.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/Common_Gotchas_in_JAX.md
+++ b/docs/notebooks/Common_Gotchas_in_JAX.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/Custom_derivative_rules_for_Python_code.md
+++ b/docs/notebooks/Custom_derivative_rules_for_Python_code.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
+++ b/docs/notebooks/Distributed_arrays_and_automatic_parallelization.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/notebooks/How_JAX_primitives_work.md
+++ b/docs/notebooks/How_JAX_primitives_work.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/notebooks/Neural_Network_and_Data_Loading.md
+++ b/docs/notebooks/Neural_Network_and_Data_Loading.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/Writing_custom_interpreters_in_Jax.md
+++ b/docs/notebooks/Writing_custom_interpreters_in_Jax.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/autodiff_cookbook.md
+++ b/docs/notebooks/autodiff_cookbook.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/convolutions.md
+++ b/docs/notebooks/convolutions.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/external_callbacks.md
+++ b/docs/notebooks/external_callbacks.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/notebooks/neural_network_with_tfds_data.md
+++ b/docs/notebooks/neural_network_with_tfds_data.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/quickstart.md
+++ b/docs/notebooks/quickstart.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/thinking_in_jax.md
+++ b/docs/notebooks/thinking_in_jax.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/notebooks/vmapped_log_probs.md
+++ b/docs/notebooks/vmapped_log_probs.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python

--- a/docs/notebooks/xmap_tutorial.md
+++ b/docs/notebooks/xmap_tutorial.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   name: python3

--- a/docs/transformations.md
+++ b/docs/transformations.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.1
+    jupytext_version: 1.14.4
 kernelspec:
   display_name: Python 3
   language: python


### PR DESCRIPTION
Also remove the `ipython3` lexer markup in `autodidax`, because it was causing problems in the conversions.