### PR TITLE
Fix a false-positive typing warning on jax.default_device

### DIFF
--- a/jax/_src/config.py
+++ b/jax/_src/config.py
@@ -487,7 +487,7 @@ class _StateContextManager:
     self._default_value = default_value
 
   @contextlib.contextmanager
-  def __call__(self, new_val=no_default):
+  def __call__(self, new_val: Any = no_default):
     if new_val is no_default:
       if self._default_value is not no_default:
         new_val = self._default_value  # default_value provided to constructor


### PR DESCRIPTION
Consider the following code where static type checkers can report an
error:

```python
CPU = jax.devices('cpu')[0]
with jax.default_device(CPU):
  ...                 # ^^^
```

```
Pyright: Argument of type "Device" cannot be assigned to parameter "new_val" of type "NoDefault"
  "Device" is incompatible with "NoDefault" (reportGeneralTypeIssues)
```

This is because `_StateContextManager.__call__` does not have a proper
type annotation on the parameter, unlike the attribute `_default_value`
which has a type annotation. Adding a `Any` to the parameter would
make the error disappear.
