### PR TITLE
Improves handling of opaque types for dynamic shapes

### DIFF
--- a/jax/_src/prng.py
+++ b/jax/_src/prng.py
@@ -282,13 +282,13 @@ def base_arr_shape_to_keys_shape(impl, base_arr_shape):
 class KeyTyRules:
 
   @staticmethod
-  def physical_avals(aval):  # TODO(frostig): rename to `grounded_avals`
+  def physical_avals(aval) -> Sequence[core.AbstractValue]:  # TODO(frostig): rename to `grounded_avals`
     # TODO(frostig): dedup with `keys_aval_to_base_arr_aval``
-    return [core.ShapedArray((*aval.shape, *aval.dtype.impl.key_shape),
+    return [core.ShapedArray((*aval.shape, *aval.dtype.impl.key_shape),  # type: ignore
                              jnp.dtype('uint32'))]
 
   @staticmethod
-  def aval_to_ir_types(aval):
+  def aval_to_ir_types(aval: core.AbstractValue) -> Sequence[mlir.ir.Type]:
     phys_aval, = KeyTyRules.physical_avals(aval)
     return mlir.aval_to_ir_types(phys_aval)
 
@@ -393,70 +393,64 @@ class KeyTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def empty_mlir(ctx):
-    aval_out, = ctx.avals_out
+  def empty_mlir(ctx, aval_out) -> Sequence[mlir.ir.Value]:
     return mlir.ir_constants(np.zeros(aval_out.dtype.impl.key_shape,
                                       dtype=np.dtype('uint32')))
 
   @staticmethod
-  def slice_mlir(ctx, x, start_indices, limit_indices, strides):
-    aval_out, = ctx.avals_out
+  def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides) -> mlir.ir.Value:
     key_shape = aval_out.dtype.impl.key_shape
     trailing_zeros = [0] * len(key_shape)
     trailing_ones  = [1] * len(key_shape)
     start_indices = (*start_indices, *trailing_zeros)
     limit_indices = (*limit_indices, *key_shape)
     strides = (*strides, *trailing_ones)
-    return mhlo.SliceOp(x,
-                        mlir.dense_int_elements(start_indices),
-                        mlir.dense_int_elements(limit_indices),
-                        mlir.dense_int_elements(strides)).results
+    physical_aval_out, = KeyTyRules.physical_avals(aval_out)
+    return mlir.slice_op(ctx, x, physical_aval_out,
+                         start_indices=start_indices, limit_indices=limit_indices, strides=strides)
 
   @staticmethod
-  def dynamic_slice_mlir(ctx, x, start_indices, slice_sizes):
-    aval_out, = ctx.avals_out
+  def dynamic_slice_mlir(ctx, aval_out, x, start_indices) -> mlir.ir.Value:
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
     key_shape = aval_out.dtype.impl.key_shape
     trailing_zeros = [mlir.ir_constant(np.array(0, dtype))] * len(key_shape)
     start_indices = (*start_indices, *trailing_zeros)
-    slice_sizes_ = mlir.dense_int_elements((*slice_sizes, *key_shape))
-    return mhlo.DynamicSliceOp(x, start_indices, slice_sizes_).results
+    physical_aval_out, = KeyTyRules.physical_avals(aval_out)
+    return mlir.dynamic_slice(ctx, physical_aval_out, x,
+                              start_indices=start_indices)
 
   @staticmethod
-  def dynamic_update_slice_mlir(ctx, x, update, *start_indices):
-    aval_out, = ctx.avals_out
+  def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices) -> mlir.ir.Value:
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
     key_shape = aval_out.dtype.impl.key_shape
     zeros = [mlir.ir_constant(np.array(0, dtype=dtype))] * len(key_shape)
     start_indices = (*start_indices, *zeros)
-    return mhlo.DynamicUpdateSliceOp(mlir.aval_to_ir_type(aval_out), x, update,
-                                     start_indices).results
+    physical_aval_out, = KeyTyRules.physical_avals(aval_out)
+    return mlir.dynamic_update_slice(ctx, physical_aval_out, x, update,
+                                     start_indices=start_indices)
 
   @staticmethod
-  def broadcast_in_dim_mlir(ctx, x, *dyn_shape, shape, broadcast_dimensions):
-    if dyn_shape: raise NotImplementedError
-    aval_out, = ctx.avals_out
+  def broadcast_in_dim_mlir(ctx, aval_out, x,
+                            broadcast_dimensions) -> mlir.ir.Value:
     key_shape = aval_out.dtype.impl.key_shape
     trailing_dims = [aval_out.ndim + i for i in range(len(key_shape))]
     broadcast_dimensions = [*broadcast_dimensions, *trailing_dims]
-    return mhlo.BroadcastInDimOp(
-        mlir.aval_to_ir_type(aval_out), x,
-        mlir.dense_int_elements(broadcast_dimensions)).results
+    physical_aval_out, = KeyTyRules.physical_avals(aval_out)
+    return mlir.broadcast_in_dim(ctx, x, physical_aval_out, broadcast_dimensions=broadcast_dimensions)
 
   @staticmethod
-  def transpose_mlir(ctx, x, *, permutation):
-    aval_out, = ctx.avals_out
+  def transpose_mlir(ctx, aval_out, x, *, permutation) -> mlir.ir.Value:
     key_shape = aval_out.dtype.impl.key_shape
     trailing_dims = [aval_out.ndim + i for i in range(len(key_shape))]
     perm = [*permutation, *trailing_dims]
-    return mhlo.TransposeOp(x, mlir.dense_int_elements(perm)).results
+    return mhlo.TransposeOp(x, mlir.dense_int_elements(perm)).result
 
   @staticmethod
-  def gather_mlir(ctx, x, indices, *,
+  def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
-                  indices_are_sorted, mode, fill_value):
-    aval_x, aval_indices = ctx.avals_in
-    aval_y, = ctx.avals_out
+                  indices_are_sorted, mode, fill_value) -> mlir.ir.Value:
+    aval_x, aval_indices = avals_in
+    aval_y = aval_out
     key_shape = aval_x.dtype.impl.key_shape
     trailing_offset_dims = [aval_y.ndim + i for i in range(len(key_shape))]
     dimension_numbers = dimension_numbers._replace(
@@ -466,10 +460,11 @@ class KeyTyRules:
         lax_internal.slicing._gather_lower, dimension_numbers=dimension_numbers,
         slice_sizes=slice_sizes, unique_indices=unique_indices,
         indices_are_sorted=indices_are_sorted, mode=mode, fill_value=fill_value)
-    return mlir.delegate_lowering(
+    res, = mlir.delegate_lowering(
         ctx, gather_lower, x, indices,
         avals_in=[keys_aval_to_base_arr_aval(aval_x), aval_indices],
         avals_out=[keys_aval_to_base_arr_aval(aval_y)])
+    return res
 
 
 class KeyTy:

--- a/jax/experimental/jax2tf/jax2tf.py
+++ b/jax/experimental/jax2tf/jax2tf.py
@@ -693,6 +693,7 @@ def _lower_native_and_run(fun_jax: Callable,
   if "in_shardings" in lowered.compile_args:
     args_tf = tuple(
       map(_shard_value, args_tf, args_avals, lowered.compile_args["in_shardings"]))
+
   res = tfxla.call_module(
       args_tf,
       version=xla_call_module_version,

--- a/jax/interpreters/mlir.py
+++ b/jax/interpreters/mlir.py
@@ -1253,6 +1253,10 @@ register_lowering(core.closed_call_p,
 def broadcast_in_dim(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue, *,
                      broadcast_dimensions) -> ir.Value:
   # Lower a possibly-dynamic broadcast_in_dim
+  if core.is_opaque_dtype(aval_out.dtype):  # type: ignore
+    return aval_out.dtype._rules.broadcast_in_dim_mlir(  # type: ignore
+        ctx, aval_out, op,
+        broadcast_dimensions=broadcast_dimensions)
   if not core.is_constant_shape(aval_out.shape):  # type: ignore
     shape = eval_dynamic_shape(ctx, aval_out.shape)  # type: ignore
     return mhlo.DynamicBroadcastInDimOp(
@@ -1284,18 +1288,65 @@ def multi_broadcast_in_dim(ctx: LoweringRuleContext,
   return out
 
 def reshape(ctx: LoweringRuleContext, op, aval_out: core.AbstractValue) -> ir.Value:
-  aval_out_shape = aval_out.shape  # type: ignore
-  if not core.is_constant_shape(aval_out_shape):
-    if core.is_opaque_dtype(aval_out.dtype):  # type: ignore
-      # TODO(necula)
-      raise NotImplementedError("reshaping opaque types")
-    shape = eval_dynamic_shape(ctx, aval_out_shape)
+  if core.is_opaque_dtype(aval_out.dtype):  # type: ignore
+    aval_out, = aval_out.dtype._rules.physical_avals(aval_out)  # type: ignore
+  if not core.is_constant_shape(aval_out.shape):  # type: ignore
+    shape = eval_dynamic_shape(ctx, aval_out.shape)  # type: ignore
     return mhlo.DynamicReshapeOp(
         aval_to_ir_type(aval_out), op,
         shape_tensor(shape),
     ).result
   else:
     return mhlo.ReshapeOp(aval_to_ir_type(aval_out), op).result
+
+def slice_op(ctx: LoweringRuleContext, x, aval_out, *,
+             start_indices, limit_indices, strides) -> ir.Value:
+  if core.is_opaque_dtype(aval_out.dtype):
+    return [aval_out.dtype._rules.slice_mlir(
+        ctx, aval_out, x, start_indices, limit_indices, strides)]
+
+  if any(not core.is_constant_shape(s) for s in (start_indices, limit_indices, strides)):
+    start_indices = eval_dynamic_shape(ctx, start_indices)
+    limit_indices = eval_dynamic_shape(ctx, limit_indices)
+    strides = eval_dynamic_shape(ctx, strides)
+    return mhlo.RealDynamicSliceOp(aval_to_ir_type(aval_out),
+                                   x,
+                                   shape_tensor(start_indices),
+                                   shape_tensor(limit_indices),
+                                   shape_tensor(strides)).result
+  else:
+    return mhlo.SliceOp(x,
+                        dense_int_elements(start_indices),
+                        dense_int_elements(limit_indices),
+                        dense_int_elements(strides)).result
+
+def dynamic_slice(ctx: LoweringRuleContext, aval_out, x, *,
+                  start_indices) -> ir.Value:
+  if core.is_opaque_dtype(aval_out.dtype):
+    return aval_out.dtype._rules.dynamic_slice_mlir(ctx, aval_out, x,
+                                                    start_indices)
+  slice_sizes = aval_out.shape
+  if not core.is_constant_shape(slice_sizes):
+    slice_sizes = eval_dynamic_shape(ctx, slice_sizes)
+    return mhlo.RealDynamicSliceOp(
+        aval_to_ir_type(aval_out), x,
+        shape_tensor(start_indices),
+        shape_tensor(slice_sizes),
+        shape_tensor([1] * len(slice_sizes))
+    ).result
+  else:
+    return mhlo.DynamicSliceOp(x, start_indices,
+                               dense_int_elements(slice_sizes)).result
+
+def dynamic_update_slice(ctx: LoweringRuleContext, aval_out, x, update, *,
+                         start_indices) -> ir.Value:
+  if core.is_opaque_dtype(aval_out.dtype):
+    return aval_out.dtype._rules.dynamic_update_slice_mlir(
+        ctx, aval_out, x, update, *start_indices)
+
+  # TODO(necula): handle dynamic shapes
+  return mhlo.DynamicUpdateSliceOp(aval_to_ir_type(aval_out), x, update,
+                                  start_indices).result
 
 def full_like_aval(ctx: LoweringRuleContext, value, aval: core.ShapedArray) -> ir.Value:
   """Returns an IR constant shaped full of `value` shaped like `aval`."""

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -2858,54 +2858,52 @@ class FooTyRules:
   # element-type-polymorphic primitive lowering rules
 
   @staticmethod
-  def empty_mlir(ctx):
+  def empty_mlir(ctx, aval_out):
     return mlir.ir_constants(np.zeros((2,), dtype=np.dtype('uint32')))
 
   @staticmethod
-  def slice_mlir(ctx, x, start_indices, limit_indices, strides):
+  def slice_mlir(ctx, aval_out, x, start_indices, limit_indices, strides):
     start_indices = (*start_indices, 0)
     limit_indices = (*limit_indices, 2)
     strides = (*strides, 1)
     return mhlo.SliceOp(x,
                         mlir.dense_int_elements(start_indices),
                         mlir.dense_int_elements(limit_indices),
-                        mlir.dense_int_elements(strides)).results
+                        mlir.dense_int_elements(strides)).result
 
   @staticmethod
-  def dynamic_slice_mlir(ctx, x, start_indices, slice_sizes):
+  def dynamic_slice_mlir(ctx, aval_out, x, start_indices):
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
     start_indices = (*start_indices, mlir.ir_constant(np.array(0, dtype=dtype)))
-    slice_sizes_ = mlir.dense_int_elements((*slice_sizes, 2))
-    return mhlo.DynamicSliceOp(x, start_indices, slice_sizes_).results
+    slice_sizes_ = mlir.dense_int_elements((*aval_out.shape, 2))
+    return mhlo.DynamicSliceOp(x, start_indices, slice_sizes_).result
 
   @staticmethod
-  def dynamic_update_slice_mlir(ctx, x, update, *start_indices):
+  def dynamic_update_slice_mlir(ctx, aval_out, x, update, *start_indices):
     aval_out, = ctx.avals_out
     dtype = dtypes.canonicalize_dtype(np.dtype('int64'))
     start_indices = (*start_indices, mlir.ir_constant(np.array(0, dtype=dtype)))
     return mhlo.DynamicUpdateSliceOp(mlir.aval_to_ir_type(aval_out), x, update,
-                                     start_indices).results
+                                     start_indices).result
 
   @staticmethod
-  def broadcast_in_dim_mlir(ctx, x, *dyn_shape, shape, broadcast_dimensions):
-    if dyn_shape: raise NotImplementedError
-    aval_out, = ctx.avals_out
+  def broadcast_in_dim_mlir(ctx, aval_out, x, broadcast_dimensions):
     broadcast_dimensions = [*broadcast_dimensions, aval_out.ndim]
     return mhlo.BroadcastInDimOp(
         mlir.aval_to_ir_type(aval_out), x,
-        mlir.dense_int_elements(broadcast_dimensions)).results
+        mlir.dense_int_elements(broadcast_dimensions)).result
 
   @staticmethod
-  def transpose_mlir(ctx, x, *, permutation):
+  def transpose_mlir(ctx, aval_out, x, *, permutation):
     perm = [*permutation, len(permutation)]
-    return mhlo.TransposeOp(x, mlir.dense_int_elements(perm)).results
+    return mhlo.TransposeOp(x, mlir.dense_int_elements(perm)).result
 
   @staticmethod
-  def gather_mlir(ctx, x, indices, *,
+  def gather_mlir(ctx, avals_in, aval_out, x, indices, *,
                   dimension_numbers, slice_sizes, unique_indices,
                   indices_are_sorted, mode, fill_value):
-    aval_x, aval_indices = ctx.avals_in
-    aval_y, = ctx.avals_out
+    aval_x, aval_indices = avals_in
+    aval_y = aval_out
     dimension_numbers = dimension_numbers._replace(
         offset_dims=(*dimension_numbers.offset_dims, aval_y.ndim))
     slice_sizes = (*slice_sizes, 2)
@@ -2917,7 +2915,7 @@ class FooTyRules:
     aval_y_raw = core.ShapedArray((*aval_y.shape, 2), np.dtype('uint32'))
     return mlir.delegate_lowering(ctx, gather_lower, x, indices,
                                   avals_in=[aval_x_raw, aval_indices],
-                                  avals_out=[aval_y_raw])
+                                  avals_out=[aval_y_raw])[0]
 
 
 class FooTy:


### PR DESCRIPTION
Improves handling of opaque types for dynamic shapes.

The immediate motivation for this is to support the lowering
to StableHLO for programs with polymorphic shapes. This requires
mixing of dynamic shapes with opaque types.

The general strategy is to push the actual selection of the MHLO ops
down into mlir module (e.g., mlir.slice_op, mlir.broadcast_in_dim)
so that we have one place where we pick whether we use the Dynamic
or static ops. These routines can also handle the opaque type.
This will result in a recursive
call to, e.g., mlir.slice_op, but the inner call will be using
the physical avals, which should not be opaque anymore.

While making this change I was confused by the fact that the
custom KeyTyRules in prng.py have lowerings that return multiple
MHLO ops. See https://github.com/google/jax/pull/11768#issuecomment-1342349102.
I changed the rules to return a single op.