### PR TITLE
[jax2tf] Fix native lowering for modules that don't use some inputs.

### DIFF
--- a/jax/experimental/jax2tf/shape_poly.py
+++ b/jax/experimental/jax2tf/shape_poly.py
@@ -886,5 +886,7 @@ def _solve_dim_equations(eqns: List[DimEquation]) -> ShapeEnv:
   err_msg = (
       f"Cannot solve for values of dimension variables {unsolved_vars} from "
       f"the remaining dimension polynomials\n  {eqns_str}.{_shapeenv_to_str()} "
-      "Dimension variables can be solved only from linear polynomials.")
+      "Dimension variables can be solved only from linear polynomials.\n"
+      "\n"
+      "Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#dimension-variables-must-be-solvable-from-the-input-shapes for more details.")
   raise ValueError(err_msg)


### PR DESCRIPTION
We must drop the corresponding actual arguments when invoking the function and we must also be careful to compute the dim_args_specs based only on the kept inputs.

As a side benefit, we now allow dimension variables that occur in more complex polynomials, as long as they also occur as trivial monomials somewhere in the input shapes for the kept arguments.