### PR TITLE
fix broken notebook link

### DIFF
--- a/docs/notebooks/Parallelism_with_JAX.ipynb
+++ b/docs/notebooks/Parallelism_with_JAX.ipynb
@@ -1,0 +1,23 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "047cf630",
+   "metadata": {},
+   "source": [
+    "## Notebook moved!\n",
+    "It moved to [Distributed arrays and automatic\n",
+    "parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html)."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "formats": "ipynb,md:myst",
+   "main_language": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/Parallelism_with_JAX.md
+++ b/docs/notebooks/Parallelism_with_JAX.md
@@ -1,0 +1,15 @@
+---
+jupytext:
+  cell_metadata_filter: -all
+  formats: ipynb,md:myst
+  main_language: python
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+---
+
+## Notebook moved!
+It moved to [Distributed arrays and automatic
+parallelization](https://jax.readthedocs.io/en/latest/notebooks/Distributed_arrays_and_automatic_parallelization.html).

--- a/docs/notebooks/external_callbacks.ipynb
+++ b/docs/notebooks/external_callbacks.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "36878c74",
    "metadata": {
     "id": "7XNMxdTwURqI"
    },
@@ -11,6 +12,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7dc1a390",
    "metadata": {
     "id": "h6lXo6bSUYGq"
    },
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c0e1ac17",
    "metadata": {
     "id": "dF7hoWGQUneJ"
    },
@@ -40,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bf4024f0",
    "metadata": {
     "id": "Ge4fNPZdVSJY"
    },
@@ -74,6 +78,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "af45e3ef",
    "metadata": {
     "id": "vyjQj-0QVuoN"
    },
@@ -98,6 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ea271ea4",
    "metadata": {
     "id": "6svImqFHWBwj",
     "outputId": "bc8c778a-6c10-443b-9be2-c0f28e2ac1a9"
@@ -135,6 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5a24f1fe",
    "metadata": {
     "id": "txvRqR9DWGdC",
     "outputId": "d25f3476-23b1-48e4-dda1-3c06d32c3b87"
@@ -165,6 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7ac5ce3a",
    "metadata": {
     "id": "BS-Ve5u_WU0C",
     "outputId": "08cecd1f-6953-4853-e9db-25a03eb5b000"
@@ -184,6 +192,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8ff2ef41",
    "metadata": {
     "id": "SCH2ii_dWXP6"
    },
@@ -194,6 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "351a81d4",
    "metadata": {
     "id": "q3qh_4DrWxdQ",
     "outputId": "c46b0bfa-96f3-4629-b9af-a4d4f3ccb870",
@@ -244,6 +254,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "58888fb5",
    "metadata": {
     "id": "PtYeJ_xUW09v"
    },
@@ -266,6 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c0d6740e",
    "metadata": {
     "id": "BOVQnt05XvLs"
    },
@@ -284,6 +296,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "52a09836",
    "metadata": {
     "id": "W1SxcvQSX44c"
    },
@@ -294,6 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9b8e5b45",
    "metadata": {
     "id": "sCGceBs-X8nL",
     "outputId": "71c5589f-f996-44a0-f09a-ca8bb40c167a"
@@ -314,6 +328,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9df8bf45",
    "metadata": {
     "id": "gWQ4phN5YB26"
    },
@@ -324,6 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cdf9d6f1",
    "metadata": {
     "id": "QTe5mRAvYQBh",
     "outputId": "d58ecff3-9419-422a-fd0e-14a7d9cf2cc3"
@@ -346,6 +362,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fcbde755",
    "metadata": {
     "id": "QEXGxU4uYZii"
    },
@@ -369,5 +386,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
For the jax.Array notebook, some folks (e.g. on Twitter) linked to the old URL (from the old notebook name). But #13602 broke the link! This attempts to keep some version of the link alive.